### PR TITLE
Blob, Bun.file: remove unsafe from Blob.rs, read_file.rs, copy_file.rs and Store.rs

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2112,27 +2112,29 @@ function generateRust(
 
   // ── structuredClone ──────────────────────────────────────────────────────
   if (structuredClone) {
+    // The impl sees a `&mut StructuredCloneWriter` / `&mut StructuredCloneReader`
+    // over C++'s serializer / byte range; the raw sink and cursor stay here.
     thunk(
       symbolName(typeName, "onStructuredCloneSerialize"),
       `(this: ${recv}, global: &JSGlobalObject, ctx: *mut c_void, write_bytes: WriteBytesFn) -> ()`,
-      `    ${T}::on_structured_clone_serialize(this, global, ctx, write_bytes)`,
+      `    // SAFETY: C++ passes its live \`CloneSerializer\` and the matching write callback for this call.\n` +
+        `        let mut writer = unsafe { host_fn::StructuredCloneWriter::new(ctx, write_bytes) };\n` +
+        `        ${T}::on_structured_clone_serialize(this, global, &mut writer)`,
     );
     if (typeof structuredClone === "object" && structuredClone.transferable) {
       thunk(
         symbolName(typeName, "onStructuredCloneTransfer"),
         `(this: ${recv}, global: &JSGlobalObject, ctx: *mut c_void, write_bytes: WriteBytesFn) -> ()`,
-        `    ${T}::on_structured_clone_transfer(this, global, ctx, write_bytes)`,
+        `    // SAFETY: as \`onStructuredCloneSerialize\`.\n` +
+          `        let mut writer = unsafe { host_fn::StructuredCloneWriter::new(ctx, write_bytes) };\n` +
+          `        ${T}::on_structured_clone_transfer(this, global, &mut writer)`,
       );
     }
     thunk(
       symbolName(typeName, "onStructuredCloneDeserialize"),
       `(global: &JSGlobalObject, ptr: *mut *mut u8, end: *const u8) -> JSValue`,
-      `    // Empty with nothing pending: the record was malformed (CloneDeserializer::readTerminal → fail()).
-    match ${T}::on_structured_clone_deserialize(global, ptr, end) {
-        Ok(Some(value)) => value,
-        Ok(None) => JSValue::ZERO,
-        Err(err) => host_fn::host_call_error_value(global, err),
-    }`,
+      `    // SAFETY: C++ passes its live cursor into the \`SerializedScriptValue\` buffer ending at \`end\`.\n` +
+        `        unsafe { host_fn::host_fn_structured_clone_deserialize(global, ptr, end, ${T}::on_structured_clone_deserialize) }`,
     );
   }
 
@@ -2257,11 +2259,7 @@ use bun_jsc::{self, host_fn, CallFrame, JSGlobalObject, JSValue, JsError, JsResu
 
 /// \`SYSV_ABI void (*)(CloneSerializer*, const uint8_t*, uint32_t)\`
 #[allow(dead_code, unreachable_pub, unused)]
-#[cfg(all(windows, target_arch = "x86_64"))]
-pub type WriteBytesFn = unsafe extern "sysv64" fn(*mut c_void, *const u8, u32);
-#[allow(dead_code, unreachable_pub, unused)]
-#[cfg(not(all(windows, target_arch = "x86_64")))]
-pub type WriteBytesFn = unsafe extern "C" fn(*mut c_void, *const u8, u32);
+pub use bun_jsc::host_fn::WriteBytesFn;
 
 /// \`JSC::PropertyName\` — opaque pointer-sized handle (UniquedStringImpl*).
 #[allow(dead_code, unreachable_pub, unused)]

--- a/src/codegen/generate-host-exports.ts
+++ b/src/codegen/generate-host-exports.ts
@@ -148,6 +148,14 @@ function ptrify(ty: string): { cTy: string; deref: (n: string) => string; extraL
   if (/^&[^\[]*\[/.test(ty) || /^&\s*str\b/.test(ty)) {
     throw new Error(`slice/str param \`${ty}\` is not FFI-safe; use \`&[T]\` (const) or (ptr, len)`);
   }
+  // `Option<&CStr>` — C passes a (possibly null) NUL-terminated `const char*`.
+  if (/^Option\s*<\s*&\s*(?:(?:::)?(?:core|std)::ffi::)?CStr\s*>$/.test(ty)) {
+    return {
+      cTy: `*const c_char`,
+      deref: n =>
+        `{\n        // SAFETY: C++ caller passes null or a NUL-terminated string live for the call.\n        if ${n}.is_null() { None } else { Some(unsafe { ::core::ffi::CStr::from_ptr(${n}) }) }\n    }`,
+    };
+  }
   // `&mut T` / `&T` — keep as a reference in the thunk signature. `&T` and
   // `*const T` (resp. `&mut T`/`*mut T`) are ABI-identical for `extern "C"`
   // when the C++ caller guarantees non-null (it does), so the thunk param can
@@ -280,13 +288,15 @@ for (const { dir, crate } of scanRoots) {
       if (abi === "rust") shape = "rust";
       else if (
         params.length === 3 &&
-        /^(?:(?:::)?bun_ptr::)?ThisPtr\s*</.test(params[0].ty) &&
+        /^(?:(?:(?:::)?bun_ptr::)?ThisPtr|Box)\s*</.test(params[0].ty) &&
         /JSGlobalObject$/.test(params[1].ty) &&
         /CallFrame$/.test(params[2].ty) &&
         isJsRet
       ) {
         // Promise reaction: `JSValue::then(global, ctx, resolve, reject)` stashes
-        // `ctx` as the trailing argument; the thunk hands it back typed.
+        // `ctx` as the trailing argument; the thunk hands it back typed — a
+        // `ThisPtr` to a refcounted registrant, or the `Box` the registrant
+        // released to the reaction pair (exactly one of which runs, once).
         shape = "reaction";
         abi ??= "jsc";
       } else if (
@@ -437,13 +447,20 @@ ${emitNoMangle(e.abi, e.symbol, "g: *mut JSGlobalObject, cf: *mut CallFrame", "J
     }
     case "reaction": {
       const wrap = retIsJsResult ? "host_fn::host_fn_static_raw" : "host_fn::host_fn_static_passthrough_raw";
+      const boxed = /^Box\s*</.test(e.params[0].ty);
+      const recover = boxed
+        ? `::bun_core::heap::take(args[args.len() - 1].as_promise_ptr())`
+        : `::bun_ptr::ThisPtr::new(args[args.len() - 1].as_promise_ptr())`;
+      const held = boxed
+        ? `the \`Box\` the registrant released to this reaction pair, reclaimed once here.`
+        : `on which the registrant holds a ref until it runs.`;
       const body = `    // SAFETY: JSC trampoline guarantees g/cf are non-null and valid; the
     // trailing argument is the \`ctx\` this reaction was registered with via
-    // \`JSValue::then\`, on which the registrant holds a ref until it runs.
+    // \`JSValue::then\`, ${held}
     unsafe {
         ${wrap}(g, cf, |g, cf| {
             let args = cf.arguments();
-            let this = ::bun_ptr::ThisPtr::new(args[args.len() - 1].as_promise_ptr());
+            let this = ${recover};
             ${impl}(this, g, cf)
         })
     }`;
@@ -467,14 +484,8 @@ ${emitNoMangle(e.abi, e.symbol, "g: &JSGlobalObject", "JSValue", body)}`;
     case "rust": {
       // `extern "Rust"` link-time hook: forward the safe signature verbatim
       // (no pointer rewriting; `extern "Rust"` ABI == native Rust ABI).
-      // Reference params/returns are rejected — `extern "Rust" fn` items need
-      // explicit lifetimes for borrowed types and the generator does not
-      // synthesise them. Use raw pointers in the impl signature instead.
-      for (const p of e.params)
-        if (p.ty.startsWith("&"))
-          throw new Error(
-            `${loc}: HOST_EXPORT(${e.symbol}, rust) param \`${p.raw}\` is a reference; use a raw pointer`,
-          );
+      // Reference params use elided lifetimes; a reference return is
+      // rejected — the generator does not synthesise the lifetime it needs.
       if (e.ret.startsWith("&"))
         throw new Error(
           `${loc}: HOST_EXPORT(${e.symbol}, rust) return type \`${e.ret}\` is a reference; use a raw pointer`,

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -1364,6 +1364,34 @@ pub const fn io_request_callback<T: IoRequestHandler + 'static>() -> RequestCall
     run::<T>
 }
 
+/// One more thing the io thread can be asked to do with a `T`'s request,
+/// besides its [`IoRequestHandler`]: the owner swaps this in with
+/// [`Request::store_callback_seq_cst`] before re-queuing the request.
+pub trait IoRequestHook<T: IntrusiveIoRequest> {
+    /// io thread: `owner`'s request was just popped (`scheduled` is already
+    /// cleared). Nothing else touches the owner while it is queued or here.
+    fn on_io_request(owner: &mut T) -> Action<'_>;
+}
+
+/// The [`RequestCallback`] that has `H` handle `T`'s request.
+pub const fn io_request_callback_with<T, H>() -> RequestCallback
+where
+    T: IntrusiveIoRequest + 'static,
+    H: IoRequestHook<T>,
+{
+    /// # Safety
+    /// [`RequestCallback`] contract: `request` is the intrusive request of a
+    /// live `T` that scheduled it, and nothing else touches that `T` now.
+    unsafe fn run<T: IntrusiveIoRequest + 'static, H: IoRequestHook<T>>(
+        request: &mut Request,
+    ) -> Action<'_> {
+        // SAFETY: fn contract — `request` is embedded in a live, unaliased `T`.
+        let owner: &mut T = unsafe { &mut *T::from_io_request(core::ptr::from_mut(request)) };
+        H::on_io_request(owner)
+    }
+    run::<T, H>
+}
+
 // ─── ParkedRequest ────────────────────────────────────────────────────────────
 
 /// The io [`Request`] of a job that may park on the io loop waiting for a

--- a/src/io/uv_fs_request.rs
+++ b/src/io/uv_fs_request.rs
@@ -5,7 +5,7 @@
 //! While libuv has the box nothing can reach the `T` — the same guarantee as
 //! a `&T` borrow held from submission to completion.
 
-use core::ffi::{CStr, c_int};
+use core::ffi::{CStr, c_int, c_void};
 
 use bun_sys::windows::libuv as uv;
 
@@ -25,20 +25,70 @@ pub trait OnFsWrite: IntrusiveUvFs + 'static {
     fn on_fs_write(this: Box<Self>, result: uv::ReturnCodeI64);
 }
 
+/// An owner that reads a file into a `Vec<u8>` it holds through its embedded
+/// request.
+pub trait OnFsRead: IntrusiveUvFs + 'static {
+    /// Loop thread: `uv_fs_read` completed with `result` (bytes read, or a
+    /// negative error code). The bytes read are already appended to the
+    /// `Vec` that [`read`] was given. The request has not been cleaned up.
+    fn on_fs_read(this: Box<Self>, result: uv::ReturnCodeI64);
+}
+
+/// An owner that `fstat`s a file through its embedded request.
+pub trait OnFsStat: IntrusiveUvFs + 'static {
+    /// Loop thread: `uv_fs_fstat` completed with `result`; on success the
+    /// request's `statbuf` is filled. The request has not been cleaned up.
+    fn on_fs_stat(this: Box<Self>, result: uv::ReturnCodeI64);
+}
+
+/// An owner that copies a file through its embedded request.
+pub trait OnFsCopyfile: IntrusiveUvFs + 'static {
+    /// Loop thread: `uv_fs_copyfile` completed with `result`; on success the
+    /// request's `statbuf` describes the source. The request has not been
+    /// cleaned up.
+    fn on_fs_copyfile(this: Box<Self>, result: uv::ReturnCodeI64);
+}
+
+/// An owner that `chmod`s a path through its embedded request.
+pub trait OnFsChmod: IntrusiveUvFs + 'static {
+    /// Loop thread: `uv_fs_chmod` completed with `result`. The request has
+    /// not been cleaned up.
+    fn on_fs_chmod(this: Box<Self>, result: uv::ReturnCodeI64);
+}
+
 /// Which of `T`'s completions a submitted request reports to.
 trait Completion<T> {
-    fn done(owner: Box<T>, result: uv::ReturnCodeI64);
+    /// `data` is the request's `data` word as [`submit`]'s `start` left it.
+    fn done(owner: Box<T>, data: *mut c_void, result: uv::ReturnCodeI64);
 }
 struct Open;
 impl<T: OnFsOpen> Completion<T> for Open {
-    fn done(owner: Box<T>, result: uv::ReturnCodeI64) {
+    fn done(owner: Box<T>, _: *mut c_void, result: uv::ReturnCodeI64) {
         T::on_fs_open(owner, result)
     }
 }
 struct Write;
 impl<T: OnFsWrite> Completion<T> for Write {
-    fn done(owner: Box<T>, result: uv::ReturnCodeI64) {
+    fn done(owner: Box<T>, _: *mut c_void, result: uv::ReturnCodeI64) {
         T::on_fs_write(owner, result)
+    }
+}
+struct Stat;
+impl<T: OnFsStat> Completion<T> for Stat {
+    fn done(owner: Box<T>, _: *mut c_void, result: uv::ReturnCodeI64) {
+        T::on_fs_stat(owner, result)
+    }
+}
+struct Copyfile;
+impl<T: OnFsCopyfile> Completion<T> for Copyfile {
+    fn done(owner: Box<T>, _: *mut c_void, result: uv::ReturnCodeI64) {
+        T::on_fs_copyfile(owner, result)
+    }
+}
+struct Chmod;
+impl<T: OnFsChmod> Completion<T> for Chmod {
+    fn done(owner: Box<T>, _: *mut c_void, result: uv::ReturnCodeI64) {
+        T::on_fs_chmod(owner, result)
     }
 }
 
@@ -52,11 +102,11 @@ fn submit<T: IntrusiveUvFs + 'static, C: Completion<T>>(
 ) -> Result<(), (Box<T>, uv::ReturnCode)> {
     extern "C" fn on_done<T: IntrusiveUvFs + 'static, C: Completion<T>>(req: *mut uv::fs_t) {
         // SAFETY: `req` is the live request libuv just completed.
-        let result = unsafe { (*req).result };
+        let (data, result) = unsafe { ((*req).data, (*req).result) };
         // SAFETY: it is embedded in the `Box<T>` that `submit` released to
         // libuv, which calls back exactly once; nothing else holds that box.
         let owner = unsafe { bun_core::heap::take(T::from_uv_fs(req)) };
-        C::done(owner, result);
+        C::done(owner, data, result);
     }
     let raw = bun_core::heap::into_raw(owner);
     let rc = start(
@@ -107,5 +157,124 @@ pub fn write<T: OnFsWrite>(
         // until `cb` reclaims the box. libuv copies the one `uv_buf_t`
         // descriptor before returning.
         unsafe { uv::uv_fs_write(uv::Loop::get(), req, fd, &buf, 1, offset, cb) }
+    })
+}
+
+struct Read<T: OnFsRead>(core::marker::PhantomData<T>);
+
+/// `req.data` while a [`read`] is in flight (the word libuv never touches):
+/// the `Vec` libuv is filling — moved out of the owner for the duration, so
+/// the buffer libuv writes to is exactly the one whose length is bumped —
+/// how much spare room it was granted, and where to put it back.
+struct ReadTarget<T> {
+    vec: Vec<u8>,
+    granted: usize,
+    put_back: fn(&mut T) -> &mut Vec<u8>,
+}
+
+impl<T: OnFsRead> Completion<T> for Read<T> {
+    fn done(mut owner: Box<T>, data: *mut c_void, result: uv::ReturnCodeI64) {
+        // SAFETY: `read` boxed this `ReadTarget<T>` into `req.data` for exactly
+        // this completion; it is reclaimed once, here.
+        let mut target = unsafe { bun_core::heap::take(data.cast::<ReadTarget<T>>()) };
+        if result.int() > 0 {
+            let filled = usize::try_from(result.int()).expect("int cast");
+            assert!(filled <= target.granted);
+            // SAFETY: libuv was handed `granted` bytes of `target.vec`'s spare
+            // capacity (untouched since) and initialized the first `filled`.
+            unsafe { target.vec.set_len(target.vec.len() + filled) };
+        }
+        *(target.put_back)(&mut owner) = target.vec;
+        T::on_fs_read(owner, result)
+    }
+}
+
+/// `uv_fs_read(fd, offset)` into the spare capacity of `buffer(&mut owner)`
+/// (at most `max_len` bytes) on this thread's loop through `owner`'s request.
+/// That `Vec` is moved out of the owner while libuv has it and stored back
+/// through `buffer`, with the bytes read appended, before
+/// [`OnFsRead::on_fs_read`] gets `owner` back; if libuv refuses the request
+/// `owner` comes straight back (its `Vec` restored) with the code.
+pub fn read<T: OnFsRead>(
+    mut owner: Box<T>,
+    fd: uv::uv_file,
+    buffer: fn(&mut T) -> &mut Vec<u8>,
+    max_len: usize,
+    offset: i64,
+) -> Result<(), (Box<T>, uv::ReturnCode)> {
+    let vec = core::mem::take(buffer(&mut owner));
+    let granted = (vec.capacity() - vec.len())
+        .min(max_len)
+        .min(uv::ULONG::MAX as usize);
+    let mut target = Box::new(ReadTarget::<T> {
+        vec,
+        granted,
+        put_back: buffer,
+    });
+    let buf = uv::uv_buf_t {
+        len: granted as uv::ULONG,
+        base: target.vec.spare_capacity_mut().as_mut_ptr().cast::<u8>(),
+    };
+    let target = bun_core::heap::into_raw(target);
+    submit::<T, Read<T>>(owner, |_, req, cb| {
+        // SAFETY: `req` (inside the heap `T` just released) and the spare
+        // capacity `buf` points at (the heap buffer of `target.vec`) stay at
+        // fixed addresses, untouched, until `cb` reclaims both boxes; libuv
+        // copies the one `uv_buf_t` descriptor before returning.
+        unsafe {
+            (*req).data = target.cast();
+            uv::uv_fs_read(uv::Loop::get(), req, fd, &buf, 1, offset, cb)
+        }
+    })
+    .map_err(|(mut owner, rc)| {
+        // SAFETY: libuv refused the request, so `Read::done` will never
+        // reclaim `target`; it is still ours.
+        let target = unsafe { bun_core::heap::take(target) };
+        *(target.put_back)(&mut owner) = target.vec;
+        (owner, rc)
+    })
+}
+
+/// `uv_fs_fstat(fd)` on this thread's loop through `owner`'s request; libuv
+/// keeps `owner` until [`OnFsStat::on_fs_stat`] gets it back, or hands it
+/// straight back with the code if it refuses the request.
+pub fn fstat<T: OnFsStat>(owner: Box<T>, fd: uv::uv_file) -> Result<(), (Box<T>, uv::ReturnCode)> {
+    submit::<T, Stat>(owner, |_, req, cb| {
+        // SAFETY: `req` is the request inside the live heap `T` just released,
+        // at a fixed address until `cb` reclaims the box.
+        unsafe { uv::uv_fs_fstat(uv::Loop::get(), req, fd, cb) }
+    })
+}
+
+/// `uv_fs_copyfile(src, dest, flags)` on this thread's loop through `owner`'s
+/// request; libuv keeps `owner` until [`OnFsCopyfile::on_fs_copyfile`] gets it
+/// back, or hands it straight back with the code if it refuses the request.
+pub fn copyfile<T: OnFsCopyfile>(
+    owner: Box<T>,
+    src: &CStr,
+    dest: &CStr,
+    flags: c_int,
+) -> Result<(), (Box<T>, uv::ReturnCode)> {
+    submit::<T, Copyfile>(owner, |_, req, cb| {
+        // SAFETY: `req` is the request inside the live heap `T` just released,
+        // at a fixed address until `cb` reclaims the box; libuv copies both
+        // paths before returning.
+        unsafe { uv::uv_fs_copyfile(uv::Loop::get(), req, src.as_ptr(), dest.as_ptr(), flags, cb) }
+    })
+}
+
+/// `uv_fs_chmod(path, mode)` on this thread's loop through `owner`'s
+/// request; libuv keeps `owner` until [`OnFsChmod::on_fs_chmod`] gets it
+/// back, or hands it straight back with the code if it refuses the request.
+pub fn chmod<T: OnFsChmod>(
+    owner: Box<T>,
+    path: &CStr,
+    mode: c_int,
+) -> Result<(), (Box<T>, uv::ReturnCode)> {
+    submit::<T, Chmod>(owner, |_, req, cb| {
+        // SAFETY: `req` is the request inside the live heap `T` just released,
+        // at a fixed address until `cb` reclaims the box; libuv copies `path`
+        // before returning.
+        unsafe { uv::uv_fs_chmod(uv::Loop::get(), req, path.as_ptr(), mode, cb) }
     })
 }

--- a/src/io/uv_fs_request.rs
+++ b/src/io/uv_fs_request.rs
@@ -43,9 +43,9 @@ pub trait OnFsStat: IntrusiveUvFs + 'static {
 
 /// An owner that copies a file through its embedded request.
 pub trait OnFsCopyfile: IntrusiveUvFs + 'static {
-    /// Loop thread: `uv_fs_copyfile` completed with `result`; on success the
-    /// request's `statbuf` describes the source. The request has not been
-    /// cleaned up.
+    /// Loop thread: `uv_fs_copyfile` completed with `result`. libuv reports no
+    /// byte count for a copy (`statbuf` is left untouched). The request has not
+    /// been cleaned up.
     fn on_fs_copyfile(this: Box<Self>, result: uv::ReturnCodeI64);
 }
 

--- a/src/jsc/DOMFormData.rs
+++ b/src/jsc/DOMFormData.rs
@@ -82,3 +82,64 @@ impl DOMFormData {
         WebCore__DOMFormData__count(self)
     }
 }
+
+/// One `FormData` entry as [`DOMFormData::for_each`] presents it. The
+/// strings and the blob belong to the `DOMFormData`'s entries.
+pub enum FormDataEntry<'a> {
+    String(EncodedSlice<'a>),
+    File {
+        blob: &'a crate::webcore_types::Blob,
+        filename: EncodedSlice<'a>,
+    },
+}
+
+impl DOMFormData {
+    /// Call `f(name, entry)` for every entry, in order. C++ walks its own
+    /// list synchronously. The names, strings and blobs are the entries' own
+    /// and live while `self` stays borrowed and unmodified: neither `f` nor
+    /// the holder of `'a` may run JS (which could mutate the `FormData`).
+    pub fn for_each<'a, F: FnMut(EncodedSlice<'a>, FormDataEntry<'a>)>(&'a mut self, mut f: F) {
+        type Thunk<'a> = extern "C" fn(
+            *mut c_void,
+            *mut EncodedSlice<'a>,
+            *mut c_void,
+            *mut EncodedSlice<'a>,
+            u8,
+        );
+        unsafe extern "C" {
+            // safe: `this` is the exclusive borrow; `ctx`/`cb` are only used
+            // for the duration of the call.
+            safe fn DOMFormData__forEach(this: &mut DOMFormData, ctx: *mut c_void, cb: Thunk<'_>);
+        }
+        extern "C" fn thunk<'a, F: FnMut(EncodedSlice<'a>, FormDataEntry<'a>)>(
+            ctx: *mut c_void,
+            name: *mut EncodedSlice<'a>,
+            value: *mut c_void,
+            filename: *mut EncodedSlice<'a>,
+            is_blob: u8,
+        ) {
+            // SAFETY: `ctx` is the `&mut F` passed below, live for this
+            // synchronous callback; `name` (and `filename` when non-null) point
+            // at stack `EncodedSlice`s in `DOMFormData__forEach`; `value` is a
+            // `EncodedSlice*` for string entries and the entry's `JSBlob::m_ctx`
+            // (`Blob*`, alive with the entry) for file entries.
+            unsafe {
+                let f = &mut *ctx.cast::<F>();
+                let entry = if is_blob == 0 {
+                    FormDataEntry::String(*value.cast::<EncodedSlice<'a>>())
+                } else {
+                    FormDataEntry::File {
+                        blob: &*value.cast::<crate::webcore_types::Blob>(),
+                        filename: if filename.is_null() {
+                            EncodedSlice::EMPTY
+                        } else {
+                            *filename
+                        },
+                    }
+                };
+                f(*name, entry);
+            }
+        }
+        DOMFormData__forEach(self, (&raw mut f).cast::<c_void>(), thunk::<'a, F>);
+    }
+}

--- a/src/jsc/LinuxMemFdAllocator.rs
+++ b/src/jsc/LinuxMemFdAllocator.rs
@@ -31,7 +31,7 @@ use bun_sys as sys;
 use bun_sys::FdExt;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
-use crate::webcore::blob::store::Bytes as BlobStoreBytes;
+use crate::webcore_types::store::Bytes as BlobStoreBytes;
 
 /// Intrusive thread-safe ref-counted memfd allocator.
 ///
@@ -106,6 +106,21 @@ impl LinuxMemFdAllocator {
         }
     }
 
+    /// The memfd allocator backing `bytes`, if [`create`](Self::create) made
+    /// them. `bytes` holds a ref on it (through its allocator) for as long as
+    /// it lives, so the borrow is tied to `bytes`.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn from_bytes(bytes: &BlobStoreBytes) -> Option<&Self> {
+        // SAFETY: `Bytes` with this vtable are only built by `alloc`, whose
+        // allocator `ptr` is the live `Self` they hold a ref on until dropped.
+        Self::from(bytes.allocator()).map(|p| unsafe { &*p })
+    }
+
+    #[inline]
+    pub fn fd(&self) -> Fd {
+        self.fd
+    }
+
     /// # Safety
     /// `this` must be a live Box-allocated `*mut Self` (see [`Self::allocator`]).
     /// On `Ok`, the returned `Bytes` borrows one ref on `*this` (via the
@@ -149,8 +164,8 @@ impl LinuxMemFdAllocator {
                 Ok(unsafe {
                     BlobStoreBytes::from_raw_parts(
                         slice_ptr,
-                        len as crate::webcore::blob::SizeType,
-                        map_len as crate::webcore::blob::SizeType,
+                        len as crate::webcore_types::SizeType,
+                        map_len as crate::webcore_types::SizeType,
                         Self::allocator(this),
                     )
                 })
@@ -160,12 +175,12 @@ impl LinuxMemFdAllocator {
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    pub(crate) fn should_use(bytes: &[u8]) -> bool {
+    pub fn should_use(bytes: &[u8]) -> bool {
         if !sys::can_use_memfd() {
             return false;
         }
 
-        if crate::jsc::VirtualMachine::is_smol_mode() {
+        if crate::virtual_machine::is_smol_mode() {
             return bytes.len() >= 1024 * 1024;
         }
 
@@ -175,7 +190,7 @@ impl LinuxMemFdAllocator {
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    pub(crate) fn create(bytes: &[u8]) -> sys::Result<BlobStoreBytes> {
+    pub fn create(bytes: &[u8]) -> sys::Result<BlobStoreBytes> {
         let mut label_buf = [0u8; 128];
         let label: &core::ffi::CStr = {
             use std::io::Write as _;

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -572,6 +572,39 @@ impl ArrayBuffer {
         }
     }
 
+    /// `store.shared_view()[range]` as a JS `typed_array_type` without
+    /// copying: the ref `store` carries keeps the bytes alive (and writable
+    /// through the returned object) until JSC collects it.
+    pub fn to_js_from_store(
+        global: &JSGlobalObject,
+        store: bun_ptr::RefPtr<crate::webcore_types::Store>,
+        range: core::ops::Range<usize>,
+        typed_array_type: JSType,
+    ) -> JsResult<JSValue> {
+        extern "C" fn release_store(_bytes: *mut c_void, ctx: *mut c_void) {
+            if let Some(store) = core::ptr::NonNull::new(ctx.cast::<crate::webcore_types::Store>())
+            {
+                // SAFETY: `ctx` is the ref `to_js_from_store` released with
+                // `into_raw`; JSC calls this once.
+                unsafe { crate::webcore_types::Store::deref(store) };
+            }
+        }
+        let bytes = match crate::webcore_types::Store::data_mut(&store) {
+            crate::webcore_types::store::Data::Bytes(bytes) => &mut bytes.as_array_list()[range],
+            _ => &mut [],
+        };
+        let buffer = Self::from_bytes(bytes, typed_array_type);
+        // SAFETY: `buffer` points into `store`'s bytes, which the ref handed
+        // over here keeps alive until `release_store` runs.
+        unsafe {
+            buffer.to_js_with_context(
+                global,
+                store.into_raw().cast::<c_void>(),
+                Some(release_store),
+            )
+        }
+    }
+
     #[inline]
     pub(crate) fn from_array_buffer(ctx: &JSGlobalObject, value: JSValue) -> ArrayBuffer {
         Self::from_typed_array(ctx, value)

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -1024,11 +1024,6 @@ impl MarkedArrayBuffer {
 // `no_mangle` dropped: 0 C++ refs (phase_c_exports.rs mention is a comment).
 pub use bun_alloc::c_thunks::mi_free_bytes as MarkedArrayBuffer_deallocator;
 
-// LAYERING: `BlobArrayBuffer_deallocator` releases a
-// `Blob::Store` ref. `Store` is a `bun_runtime` type, so the `#[no_mangle]`
-// export lives next to it at `bun_runtime::webcore::blob::Store` — `bun_jsc`
-// cannot own this symbol without a dep cycle. C++ links by name only.
-
 // ──────────────────────────────────────────────────────────────────────────
 // Free functions
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/jsc/host_fn.rs
+++ b/src/jsc/host_fn.rs
@@ -653,6 +653,73 @@ pub unsafe fn host_fn_finalize_ref_counted<T: bun_ptr::AnyRefCounted>(
     unsafe { T::rc_deref(this) };
 }
 
+/// `SYSV_ABI void (*)(CloneSerializer*, const uint8_t*, uint32_t)` — the
+/// byte sink C++ hands `onStructuredCloneSerialize`.
+#[cfg(all(windows, target_arch = "x86_64"))]
+pub type WriteBytesFn = unsafe extern "sysv64" fn(*mut c_void, *const u8, u32);
+/// `SYSV_ABI void (*)(CloneSerializer*, const uint8_t*, uint32_t)` — the
+/// byte sink C++ hands `onStructuredCloneSerialize`.
+#[cfg(not(all(windows, target_arch = "x86_64")))]
+pub type WriteBytesFn = unsafe extern "C" fn(*mut c_void, *const u8, u32);
+
+/// The `SerializedScriptValue` byte sink an `on_structured_clone_serialize`
+/// writes into. Built by the codegen thunk for the duration of that call.
+pub struct StructuredCloneWriter {
+    ctx: *mut c_void,
+    write: WriteBytesFn,
+}
+
+impl StructuredCloneWriter {
+    /// # Safety
+    /// `ctx`/`write` are the `CloneSerializer*` and callback C++ passed for
+    /// this serialize call, and the writer is dropped before it returns.
+    #[inline]
+    pub unsafe fn new(ctx: *mut c_void, write: WriteBytesFn) -> Self {
+        Self { ctx, write }
+    }
+}
+
+impl bun_io::Write for StructuredCloneWriter {
+    fn write_all(&mut self, bytes: &[u8]) -> bun_io::Result<()> {
+        // SAFETY: `new`'s contract — the serializer is live for this call.
+        unsafe { (self.write)(self.ctx, bytes.as_ptr(), bytes.len() as u32) };
+        Ok(())
+    }
+}
+
+/// The bytes an `on_structured_clone_deserialize` reads from.
+pub type StructuredCloneReader<'a> = bun_io::FixedBufferStream<&'a [u8]>;
+
+/// Codegen thunk entry for `onStructuredCloneDeserialize`: hand `f` the
+/// serialized bytes `[*ptr, end)` and advance `*ptr` past what it consumed.
+/// `f` returns `Ok(None)` for a malformed record; the thunk then returns the
+/// empty value with nothing pending (CloneDeserializer::readTerminal → fail()).
+///
+/// # Safety
+/// `ptr` is C++'s live cursor into a `SerializedScriptValue` buffer ending
+/// at `end` (`*ptr <= end`), valid for the call.
+pub unsafe fn host_fn_structured_clone_deserialize(
+    global: &JSGlobalObject,
+    ptr: *mut *mut u8,
+    end: *const u8,
+    f: impl FnOnce(&JSGlobalObject, &mut StructuredCloneReader<'_>) -> JsResult<Option<JSValue>>,
+) -> JSValue {
+    // SAFETY: fn contract.
+    let (start, bytes) = unsafe {
+        let start = *ptr;
+        (start, bun_core::ffi::slice(start, end as usize - start as usize))
+    };
+    let mut reader = bun_io::FixedBufferStream::new(bytes);
+    let result = match f(global, &mut reader) {
+        Ok(Some(value)) => value,
+        Ok(None) => JSValue::ZERO,
+        Err(err) => host_call_error_value(global, err),
+    };
+    // SAFETY: `pos <= len`, so the cursor stays inside `[start, end]`.
+    unsafe { *ptr = start.add(reader.pos.min(bytes.len())) };
+    result
+}
+
 /// Codegen thunk entry for prototype setters.
 #[track_caller]
 #[inline]

--- a/src/jsc/job.rs
+++ b/src/jsc/job.rs
@@ -117,6 +117,13 @@ unsafe impl<A: JsAffine, B: JsAffine, C: JsAffine> JsAffine for (A, B, C) {}
 unsafe impl<T: ?Sized> JsAffine for JsPtr<T> {}
 // SAFETY: see the group note above.
 unsafe impl JsAffine for Protected {}
+// SAFETY: see the group note above.
+unsafe impl<F: ?Sized> JsAffine for JsCallback<F> {}
+
+/// The JS-thread completion a job reports to (a `Box<dyn …>` receiver): the
+/// promise, wrapper or handler it captures is the callee's JS-side state,
+/// and it is run or dropped only on the owning JS thread.
+pub struct JsCallback<F: ?Sized>(pub Box<F>);
 
 /// A GC-protected value a job's completion needs (Node: a `Global<Value>` on
 /// the req_wrap). Unprotected on drop.

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1258,6 +1258,8 @@ pub use self::array_buffer::JSTypedArrayBytesDeallocator;
 // inseparable from `bun_runtime` (streams/fetch). Code that needs to downcast
 // a `JSValue` to `Request`/`Response` lives in `bun_runtime`.
 // ──────────────────────────────────────────────────────────────────────────
+#[path = "LinuxMemFdAllocator.rs"]
+pub mod linux_mem_fd_allocator;
 #[path = "node_path.rs"]
 pub mod node_path;
 #[path = "webcore_types.rs"]
@@ -1335,6 +1337,27 @@ pub mod codegen {
 }
 pub use self::codegen as Codegen;
 
+/// A JS string over `store.shared_view()[range]` without copying: the ref
+/// `store` carries keeps the bytes alive until JSC finalizes the string.
+pub fn external_string_from_store(
+    global: &JSGlobalObject,
+    store: bun_ptr::RefPtr<webcore_types::Store>,
+    range: core::ops::Range<usize>,
+) -> JsResult<JSValue> {
+    let store = bun_ptr::RefPtr::into_raw(store);
+    // SAFETY: `store` carries the ref just released by `into_raw`; it is handed
+    // to JSC below and `Store::external` releases exactly that ref, so the bytes
+    // outlive the string.
+    unsafe {
+        let bytes = &(*store).shared_view()[range];
+        EncodedSliceJsc::external(
+            &bun_core::EncodedSlice::latin1(bytes),
+            global,
+            store.cast::<core::ffi::c_void>(),
+            webcore_types::Store::external,
+        )
+    }
+}
 /// Extension trait providing JSC-aware methods on `bun_sys::Error` (`bun.sys.Error`).
 pub trait SysErrorJsc {
     fn to_system_error(&self) -> SystemError;

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -7,9 +7,9 @@
 //! Those targets live in `bun_runtime`, which depends on this crate —
 //! re-exporting them here would create a cycle. Callers reference
 //! `bun_runtime::{webcore,api,node}` directly; lower-tier consumers that
-//! constructed those types (e.g. `output_file_jsc`, `BlobArrayBuffer_deallocator`)
-//! have been moved up into `bun_runtime`, and the few that only need an opaque
-//! borrow (e.g. `DOMFormData::for_each`) are generic over the caller's `Blob`.
+//! constructed those types (e.g. `output_file_jsc`) have been moved up into
+//! `bun_runtime`, and the few that only need an opaque borrow (e.g.
+//! `DOMFormData::for_each`) are generic over the caller's `Blob`.
 
 #![allow(deprecated, non_snake_case)]
 #![allow(unexpected_cfgs)]

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -1041,6 +1041,22 @@ impl RareData {
         self.stdin_store
             .map_or(core::ptr::null_mut(), NonNull::as_ptr)
     }
+
+    /// The lazily-created store behind `Bun.stdin` / `Bun.stdout` /
+    /// `Bun.stderr`, as a counted ref of its own.
+    pub fn stdio_store(
+        &mut self,
+        which: bun_sys::Stdio,
+    ) -> bun_ptr::RefPtr<crate::webcore_types::Store> {
+        let erased = match which {
+            bun_sys::Stdio::StdIn => self.stdin(),
+            bun_sys::Stdio::StdOut => self.stdout(),
+            bun_sys::Stdio::StdErr => self.stderr(),
+        };
+        // SAFETY: `stdio_ctor` returns `Box::<Store>::into_raw`, non-null and
+        // live (RareData holds a ref) until `RareData` is torn down.
+        unsafe { bun_ptr::RefPtr::init_ref(erased.cast::<crate::webcore_types::Store>()) }
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -187,6 +187,9 @@ const _: () = {
     // (or `None`) — no precondition beyond the link succeeding.
     unsafe extern "Rust" {
         safe fn __bun_blob_from_build_artifact(value: JSValue) -> Option<*mut Blob>;
+        // safe: by-value `Blob` and a live `&JSGlobalObject`; the Rust-ABI body
+        // in `bun_runtime` heap-promotes the blob into a new JS wrapper.
+        safe fn __bun_blob_to_js(blob: Blob, global: &JSGlobalObject) -> JSValue;
     }
 
     impl JsClass for Blob {
@@ -197,12 +200,10 @@ const _: () = {
             JSBlob::from_js_direct(value)
         }
         fn to_js(self, global: &JSGlobalObject) -> JSValue {
-            // Heap-promote and hand
-            // ownership to the codegen wrapper. The S3File fast-path (different
-            // JS wrapper) is layered on by `bun_runtime`'s `BlobExt::to_js` for
-            // S3-backed blobs; lower-tier callers never construct S3 blobs.
-            let ptr = Blob::new(self);
-            JSBlob::to_js(ptr, global)
+            // Heap-promote and hand ownership to a new wrapper — `JSBlob`, or
+            // `JSS3File` for an S3-backed blob, which only `bun_runtime` can
+            // tell apart, so it resolves at link time.
+            __bun_blob_to_js(self, global)
         }
         fn get_constructor(global: &JSGlobalObject) -> JSValue {
             JSBlob::get_constructor(global)
@@ -527,6 +528,68 @@ unsafe extern "C" fn Blob__deref(this: *mut Blob) {
     }
 }
 
+/// A new heap `Blob` (for C++ to adopt as a wrapper's `m_ctx`) owning a copy
+/// of `bytes`.
+// HOST_EXPORT(Blob__fromBytes, c)
+pub fn blob_from_bytes(global: &JSGlobalObject, bytes: &[u8]) -> *mut crate::webcore_types::Blob {
+    if bytes.is_empty() {
+        return Blob::new(Blob::init_empty(global));
+    }
+    Blob::new(Blob::init_with_store(Store::init(bytes.to_vec()), global))
+}
+
+fn stamp_content_type(blob: &Blob, mime: Option<&core::ffi::CStr>) {
+    let mime = mime.map(core::ffi::CStr::to_bytes).unwrap_or_default();
+    if !mime.is_empty() {
+        blob.content_type.set(BlobContentType::Owned(mime.into()));
+        blob.content_type_was_set.set(true);
+    }
+}
+
+/// [`blob_from_bytes`] with a `type`.
+// HOST_EXPORT(Blob__fromBytesWithType, c)
+pub fn blob_from_bytes_with_type(
+    global: &JSGlobalObject,
+    bytes: &[u8],
+    mime: Option<&core::ffi::CStr>,
+) -> *mut crate::webcore_types::Blob {
+    let blob = if bytes.is_empty() {
+        Blob::init_empty(global)
+    } else {
+        Blob::init_with_store(Store::init(bytes.to_vec()), global)
+    };
+    stamp_content_type(&blob, mime);
+    Blob::new(blob)
+}
+
+/// A new heap `Blob` that adopts an `mmap`'d region — no copy; the store
+/// `munmap`s it when its last ref drops.
+///
+/// # Safety
+/// `ptr[..len]` is a live mapping nothing else uses or unmaps, handed over to
+/// the returned blob.
+// HOST_EXPORT(Blob__fromMmapWithType, c)
+pub unsafe fn blob_from_mmap_with_type(
+    global: &JSGlobalObject,
+    ptr: *mut u8,
+    len: usize,
+    mime: Option<&core::ffi::CStr>,
+) -> *mut crate::webcore_types::Blob {
+    #[cfg(not(unix))]
+    {
+        // SAFETY: fn contract — `ptr[..len]` is live for the copy.
+        return blob_from_bytes_with_type(global, unsafe { bun_core::ffi::slice(ptr, len) }, mime);
+    }
+    #[cfg(unix)]
+    {
+        // SAFETY: fn contract.
+        let store = Store::from_bytes(unsafe { store::Bytes::adopt_mmap(ptr, len) });
+        let blob = Blob::init_with_store(store, global);
+        stamp_content_type(&blob, mime);
+        Blob::new(blob)
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Store
 // ──────────────────────────────────────────────────────────────────────────
@@ -764,6 +827,71 @@ pub mod store {
                 None => &mut [],
             }
         }
+
+        /// Move the bytes out as a `Vec<u8>`, leaving `self` empty: the
+        /// allocation itself when it is the global allocator's, otherwise a
+        /// copy (and the original is freed through its own allocator).
+        pub fn take_vec(&mut self) -> Vec<u8> {
+            let bytes = match self.ptr.take() {
+                None => Vec::new(),
+                Some(ptr)
+                    if core::ptr::eq(
+                        self.allocator.vtable,
+                        bun_alloc::basic::C_ALLOCATOR.vtable,
+                    ) =>
+                {
+                    // SAFETY: a `Bytes` tagged `C_ALLOCATOR` holds the exact
+                    // `(ptr, len, cap)` of a global-allocator `Vec<u8>`/`Box<[u8]>`
+                    // (`init`/`init_owned`; the `from_raw_parts` contract otherwise).
+                    unsafe {
+                        Vec::from_raw_parts(ptr.as_ptr(), self.len as usize, self.cap as usize)
+                    }
+                }
+                Some(ptr) => {
+                    // SAFETY: `ptr[..len]` initialized, `ptr[..cap]` the
+                    // allocation (the `from_raw_parts` contract).
+                    let (init, all) = unsafe {
+                        (
+                            core::slice::from_raw_parts(ptr.as_ptr(), self.len as usize),
+                            core::slice::from_raw_parts(ptr.as_ptr(), self.cap as usize),
+                        )
+                    };
+                    let copy = init.to_vec();
+                    self.allocator.free(all);
+                    copy
+                }
+            };
+            self.len = 0;
+            self.cap = 0;
+            self.allocator = bun_alloc::basic::C_ALLOCATOR;
+            bytes
+        }
+
+        /// Adopt an `mmap`'d region; dropping the `Bytes` `munmap`s it.
+        ///
+        /// # Safety
+        /// `ptr[..len]` is a live mapping nothing else uses or unmaps, handed
+        /// over to the returned value.
+        #[cfg(unix)]
+        pub unsafe fn adopt_mmap(ptr: *mut u8, len: usize) -> Bytes {
+            fn free(_: *mut core::ffi::c_void, buf: &mut [u8], _: bun_alloc::Alignment, _: usize) {
+                if let Err(err) = bun_sys::munmap(buf.as_mut_ptr(), buf.len()) {
+                    bun_core::debug_warn!("Blob mmap-store munmap failed: {:?}", err);
+                }
+            }
+            static MMAP_FREE_VTABLE: bun_alloc::AllocatorVTable =
+                bun_alloc::AllocatorVTable::free_only(free);
+            Bytes {
+                ptr: NonNull::new(ptr),
+                len: len as SizeType,
+                cap: len as SizeType,
+                allocator: bun_alloc::StdAllocator {
+                    ptr: core::ptr::null_mut(),
+                    vtable: &MMAP_FREE_VTABLE,
+                },
+                stored_name: Box::default(),
+            }
+        }
     }
 
     impl Drop for Bytes {
@@ -898,8 +1026,13 @@ pub mod store {
         /// Takes ownership of
         /// `bytes`. Returns a +1-ref heap `Store`.
         pub fn init(bytes: Vec<u8>) -> RefPtr<Store> {
+            Store::from_bytes(Bytes::init(bytes))
+        }
+
+        /// A +1-ref heap `Store` over `bytes`.
+        pub fn from_bytes(bytes: Bytes) -> RefPtr<Store> {
             RefPtr::new(Store {
-                data: Data::Bytes(Bytes::init(bytes)),
+                data: Data::Bytes(bytes),
                 mime_type: bun_http_types::MimeType::NONE,
                 ref_count: bun_ptr::ThreadSafeRefCount::init(),
                 is_all_ascii: IsAllAscii::default(),

--- a/src/runtime/allocators/mod.rs
+++ b/src/runtime/allocators/mod.rs
@@ -3,5 +3,7 @@
 //! callers import these paths directly (no forwarding stubs in `bun_alloc`).
 #![warn(unused_must_use)]
 
-#[path = "LinuxMemFdAllocator.rs"]
-pub mod linux_mem_fd_allocator;
+/// The memfd allocator backs `Blob` byte stores, which are `bun_jsc` types.
+pub mod linux_mem_fd_allocator {
+    pub use bun_jsc::linux_mem_fd_allocator::*;
+}

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -1,5 +1,6 @@
 //! `Bun.Archive` — tar/tgz pack + extract over libarchive.
 
+use bun_jsc::JsClass as _;
 use std::ffi::CString;
 
 use crate::webcore::Blob;
@@ -832,10 +833,7 @@ impl TaskContext for BlobContext {
                 // self.result already replaced with Uncompressed above — ownership transferred
                 Ok(PromiseResult::Resolve(match self.output_type {
                     BlobOutputType::Blob => {
-                        let blob_ptr =
-                            Blob::new(Blob::create_with_bytes_and_allocator(data, global, false));
-                        // SAFETY: blob_ptr is the heap allocation just produced by Blob::new.
-                        unsafe { (*blob_ptr).to_js(global) }
+                        Blob::create_with_bytes_and_allocator(data, global, false).to_js(global)
                     }
                     BlobOutputType::Bytes => {
                         // Ownership transfers to JSC's `MarkedArrayBuffer_deallocator`.
@@ -848,9 +846,7 @@ impl TaskContext for BlobContext {
                     // The clone bumps the refcount; ownership of
                     // the new ref transfers into the Blob via init_with_store.
                     let store = self.store.clone();
-                    let blob_ptr = Blob::new(Blob::init_with_store(store, global));
-                    // SAFETY: blob_ptr is the heap allocation just produced by Blob::new.
-                    PromiseResult::Resolve(unsafe { (*blob_ptr).to_js(global) })
+                    PromiseResult::Resolve(Blob::init_with_store(store, global).to_js(global))
                 }
                 BlobOutputType::Bytes => {
                     // On allocation failure, reject the promise instead of aborting.
@@ -1128,10 +1124,8 @@ impl TaskContext for FilesContext {
 
                 for entry in entries.iter_mut() {
                     let data = core::mem::take(&mut entry.data); // Ownership transferred
-                    let blob_ptr =
-                        Blob::new(Blob::create_with_bytes_and_allocator(data, global, false));
-                    // SAFETY: blob_ptr is the heap allocation just produced by Blob::new.
-                    let blob = unsafe { &mut *blob_ptr };
+                    let blob_ptr = Blob::create_with_bytes_and_allocator(data, global, false);
+                    let blob = blob_ptr;
                     blob.is_jsdom_file.set(true);
                     blob.name.set(bun_core::String::clone_utf8(&entry.path));
                     blob.last_modified.set((entry.mtime * 1000) as f64);

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -1124,8 +1124,7 @@ impl TaskContext for FilesContext {
 
                 for entry in entries.iter_mut() {
                     let data = core::mem::take(&mut entry.data); // Ownership transferred
-                    let blob_ptr = Blob::create_with_bytes_and_allocator(data, global, false);
-                    let blob = blob_ptr;
+                    let blob = Blob::create_with_bytes_and_allocator(data, global, false);
                     blob.is_jsdom_file.set(true);
                     blob.name.set(bun_core::String::clone_utf8(&entry.path));
                     blob.last_modified.set((entry.mtime * 1000) as f64);

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -63,6 +63,7 @@ pub(crate) fn get_public_path_with_asset_prefix(
 }
 
 use bun_jsc::HostReturn as _;
+use bun_jsc::JsClass as _;
 use core::ffi::c_void;
 use std::io::Write as _;
 
@@ -1828,7 +1829,6 @@ fn get_is_standalone_executable(global_this: &JSGlobalObject, _: &JSObject) -> J
 }
 
 fn get_embedded_files(global_this: &JSGlobalObject, _: &JSObject) -> JsResult<JSValue> {
-    use crate::webcore::blob::{Blob, BlobExt as _};
     use bun_standalone_graph::{File as GraphFile, Graph as StandaloneModuleGraph};
     let Some(graph) = StandaloneModuleGraph::get_ref() else {
         return JSValue::create_empty_array(global_this, 0);
@@ -1861,12 +1861,8 @@ fn get_embedded_files(global_this: &JSGlobalObject, _: &JSObject) -> JsResult<JS
         let file: &GraphFile = &unsorted_files[*index as usize];
         // `file_blob` keeps the embedded path (minus the `/$bunfs/root/` prefix)
         // as the blob name, preserving any subdirectory from the asset template.
-        let blob = Blob::new(crate::api::standalone_graph_jsc::file_blob(
-            file,
-            global_this,
-        ));
-        // SAFETY: `blob` is heap-allocated and lives until JS owns it via to_js.
-        array.put_index(global_this, i as u32, unsafe { (*blob).to_js(global_this) })?;
+        let blob = crate::api::standalone_graph_jsc::file_blob(file, global_this);
+        array.put_index(global_this, i as u32, blob.to_js(global_this))?;
     }
 
     Ok(array)
@@ -2817,7 +2813,7 @@ mod stdio_stores {
     use super::*;
     use crate::node::types::PathOrFileDescriptor;
     use crate::webcore::blob::store::{Data, File as FileStore, IsAllAscii};
-    use crate::webcore::blob::{Blob, BlobExt as _, Store};
+    use crate::webcore::blob::{Blob, Store};
     use bun_ptr::RefPtr;
 
     thread_local! {
@@ -2861,9 +2857,7 @@ mod stdio_stores {
             // store.ref() — extra +1 for the new Blob.
             s.as_ref().unwrap().clone()
         });
-        let blob = Blob::new(Blob::init_with_store(store, global_this));
-        // SAFETY: `Blob::new` heap-allocates; the JS wrapper takes ownership.
-        unsafe { (&*blob).to_js(global_this) }
+        Blob::init_with_store(store, global_this).to_js(global_this)
     }
 
     pub(super) fn stdin(global_this: &JSGlobalObject) -> JSValue {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -831,14 +831,22 @@ unsafe fn __bun_io_pollable_on_io_error(
 /// `poll` is the `io_poll` field of a live owner of type `tag`.
 #[unsafe(no_mangle)]
 unsafe fn __bun_io_pollable_on_closed(tag: bun_io::PollableTag, poll: *mut bun_io::Poll) {
-    use crate::webcore::blob::FileCloser;
+    // The parked-io close path (and `FileCloser`) is POSIX-only.
+    #[cfg(windows)]
+    {
+        let _ = (tag, poll);
+        unreachable!("io::Poll on_closed on Windows");
+    }
+    #[cfg(not(windows))]
     match tag {
         bun_io::PollableTag::ReadFile => {
+            use crate::webcore::blob::FileCloser as _;
             // SAFETY: per fn contract.
             let this = unsafe { &mut *ReadFile::from_field_ptr(poll) };
             ReadFile::on_io_request_closed(this);
         }
         bun_io::PollableTag::WriteFile => {
+            use crate::webcore::blob::FileCloser as _;
             // SAFETY: per fn contract.
             let this = unsafe { &mut *WriteFile::from_field_ptr(poll) };
             WriteFile::on_io_request_closed(this);

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -272,10 +272,9 @@ mod sql_hooks {
     unsafe fn blob_shared_view(this: *const c_void, out_len: *mut usize) -> *const u8 {
         // SAFETY: `this` is a live `Blob`; `out_len` is a caller stack slot.
         unsafe {
-            crate::webcore::blob::Bun__Blob__sharedView(
-                this.cast::<crate::webcore::Blob>(),
-                out_len,
-            )
+            let view = (*this.cast::<crate::webcore::Blob>()).shared_view();
+            *out_len = view.len();
+            view.as_ptr()
         }
     }
 

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1239,18 +1239,18 @@ impl Image {
 /// Promise-of-promise flattens, so the caller sees one `await` for
 /// read+decode+ops+encode. After the first read, subsequent terminals on the
 /// same instance reuse the `.owned` bytes without re-reading.
-struct BlobReadChain<'a> {
+struct BlobReadChain {
     image: *const Image,
-    global: &'a JSGlobalObject,
+    global: bun_ptr::BackRef<JSGlobalObject>,
     kind: Kind,
     deliver: Deliver,
     outer: jsc::JSPromiseStrong,
 }
 
-impl<'a> BlobReadChain<'a> {
+impl BlobReadChain {
     fn start(
         image: &Image,
-        global: &'a JSGlobalObject,
+        global: &JSGlobalObject,
         this_value: JSValue,
         kind: Kind,
         deliver: Deliver,
@@ -1280,28 +1280,23 @@ impl<'a> BlobReadChain<'a> {
 
         let chain = Box::new(BlobReadChain {
             image: std::ptr::from_ref::<Image>(image),
-            global,
+            global: bun_ptr::BackRef::new(global),
             kind,
             deliver,
             outer: jsc::JSPromiseStrong::init(global),
         });
         let promise = chain.outer.value();
-        // `read_bytes_to_handler` stores the handler pointer and calls
-        // `on_read_bytes` on the JS thread (sync for in-memory, async for
-        // file/S3). Ownership of the chain transfers there; the trait impl
-        // below reconstructs the Box and frees it.
-        let raw = bun_core::heap::into_raw(chain);
-        // SAFETY: `raw` is freshly leaked and not used again here; the read
-        // dispatch hands it to `on_read_bytes` below exactly once, also when it
-        // returns `Err` (an exception left pending while delivering synchronously,
-        // i.e. after the chain has already been reclaimed).
-        unsafe { blob.read_bytes_to_handler(raw, global) }?;
+        // `read_bytes_to_handler` calls `on_read_bytes` on the JS thread (sync
+        // for in-memory, async for file/S3) exactly once, also when it returns
+        // `Err` (an exception left pending while delivering synchronously,
+        // i.e. after the chain has already been consumed).
+        blob.read_bytes_to_handler(chain, global)?;
         Ok(promise)
     }
 
     /// JS thread — `read_bytes_to_handler` guarantees this. `r.ok` is owned by us.
     fn on_read_bytes_impl(self, r: ReadBytesResult) -> JsResult<()> {
-        let global = self.global;
+        let global = self.global.get();
         // SAFETY: `image` is a BACKREF kept alive by the Strong `this_ref`
         // bump in `start()`; we are on the JS thread. R-2: shared deref —
         // mutation goes through `Cell`/`JsCell`.
@@ -1354,13 +1349,9 @@ impl<'a> BlobReadChain<'a> {
     }
 }
 
-impl<'a> ReadBytesHandler for BlobReadChain<'a> {
-    unsafe fn on_read_bytes(this: *mut Self, result: ReadBytesResult) -> JsResult<()> {
-        // SAFETY: `this` is the Box `start()` leaked into `read_bytes_to_handler`,
-        // handed back to us exactly once (trait contract); nothing else points
-        // at it, so reclaiming it here is the chain's one and only free.
-        let boxed = unsafe { bun_core::heap::take(this) };
-        boxed.on_read_bytes_impl(result)
+impl ReadBytesHandler for BlobReadChain {
+    fn on_read_bytes(self: Box<Self>, result: ReadBytesResult) -> JsResult<()> {
+        (*self).on_read_bytes_impl(result)
     }
 }
 

--- a/src/runtime/node/net/BlockList.rs
+++ b/src/runtime/node/net/BlockList.rs
@@ -1,29 +1,5 @@
 use core::ffi::c_void;
 
-// ─── non-JSC helpers (real) ───────────────────────────────────────────────
-// `Rule` and the IP-compare helpers depend on `sockaddr` from the sibling
-// `socket_address` module (lives in `crate::socket`, not `super::`), so they
-// stay gated below. Only the structured-clone byte-shuffling is JSC-free and
-// dependency-free.
-
-struct StructuredCloneWriter {
-    ctx: *mut c_void,
-    // callconv(jsc.conv) → codegen `WriteBytesFn` typedef (cfg-splits to
-    // `"sysv64"` on Windows-x64).
-    impl_: crate::generated_classes::WriteBytesFn,
-}
-
-impl bun_io::Write for StructuredCloneWriter {
-    #[inline]
-    fn write_all(&mut self, bytes: &[u8]) -> bun_io::Result<()> {
-        // SAFETY: `ctx` and `impl_` were supplied together by the C++
-        // SerializedScriptValue writer; the callback only reads `len` bytes
-        // from `ptr`, both of which we derive from a single `&[u8]`.
-        unsafe { (self.impl_)(self.ctx, bytes.as_ptr(), bytes.len() as u32) };
-        Ok(())
-    }
-}
-
 // ─── JsClass payload + host fns ───────────────────────────────────────────
 // `BlockList` is the `m_ctx` payload for a `.classes.ts` wrapper; every method
 // is a `#[bun_jsc::host_fn]` and the struct itself carries `#[bun_jsc::JsClass]`.
@@ -407,19 +383,13 @@ impl BlockList {
     pub(crate) fn on_structured_clone_serialize(
         this: &Self,
         _global: &JSGlobalObject,
-        ctx: *mut c_void,
-        // codegen `WriteBytesFn` typedef (jsc.conv).
-        write_bytes: crate::generated_classes::WriteBytesFn,
+        writer: &mut bun_jsc::host_fn::StructuredCloneWriter,
     ) {
         use bun_io::Write as _;
         let _guard = this.mutex.lock_guard();
         this.ref_();
         let addr = std::ptr::from_ref::<Self>(this) as usize;
         SERIALIZED_REFS.lock().push((this.serialize_nonce, addr));
-        let mut writer = StructuredCloneWriter {
-            ctx,
-            impl_: write_bytes,
-        };
         // The writer is infallible, so no `?` needed.
         // Only the nonce is serialized; deserialize maps it back to `*mut Self`
         // through `SERIALIZED_REFS` and never forms `&mut Self` (only `ref_()` +
@@ -427,35 +397,14 @@ impl BlockList {
         _ = writer.write_int_le(this.serialize_nonce);
     }
 
-    // C++ codegen calls this with a live `*mut *mut u8` cursor and end pointer; the
-    // signature is fixed by `generate-classes.ts`, so the deref is documented with
-    // the SAFETY comment below.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     /// `Ok(None)`: the bytes are not a valid record (the deserializer reports its usual error).
     pub(crate) fn on_structured_clone_deserialize(
         global: &JSGlobalObject,
-        ptr: *mut *mut u8,
-        end: *const u8,
+        r: &mut bun_jsc::host_fn::StructuredCloneReader<'_>,
     ) -> JsResult<Option<JSValue>> {
-        // SAFETY: `*ptr` and `end` bound a contiguous byte buffer owned by the
-        // caller (C++ SerializedScriptValue); `end >= *ptr`. `ptr` itself is a
-        // non-null out-param the caller expects us to advance.
-        let start: *mut u8 = unsafe { *ptr };
-        let total_length: usize = (end as usize) - (start as usize);
-        // SAFETY: `start` through `end` is the contiguous C++-owned deserialization
-        // buffer (see above); `total_length = end - start`, so the resulting slice
-        // is exactly that buffer and stays valid for the lifetime of `r`.
-        let mut r =
-            bun_io::FixedBufferStream::new(unsafe { bun_core::ffi::slice(start, total_length) });
-
         let Ok(nonce) = r.read_int_le::<u64>() else {
             return Ok(None);
         };
-
-        // Advance the caller's cursor by the number of bytes consumed
-        // SAFETY: `r.pos <= total_length` (`read_exact` bounds-checks via
-        // `checked_add`); `ptr` is the caller's live out-param (see above).
-        unsafe { *ptr = start.add(r.pos) };
 
         // A single SerializedScriptValue can be deserialized multiple times
         // (e.g. BroadcastChannel fan-out), so each wrapper must own its own ref

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -1,3 +1,4 @@
+use bun_jsc::JsClass as _;
 use core::cell::Cell;
 use core::ffi::c_void;
 use core::mem;
@@ -16,7 +17,7 @@ use crate::server::jsc::{
     JsError, JsRef, JsResult,
 };
 use crate::server::web_socket_server_context::HandlerFlags;
-use crate::webcore::{Blob, BlobExt};
+use crate::webcore::Blob;
 
 bun_output::declare_scope!(WebSocketServer, visible);
 
@@ -609,12 +610,7 @@ impl ServerWebSocket {
             BinaryType::ArrayBuffer => {
                 ArrayBuffer::create::<{ JSType::ArrayBuffer }>(global_this, data)
             }
-            BinaryType::Blob => {
-                let blob = Blob::new(Blob::init(data.to_vec(), global_this));
-                // SAFETY: `blob` is the live allocation `Blob::new` just made. `BlobExt::to_js`
-                // reports the payload size to the GC, which the by-value `JsClass::to_js` skips.
-                Ok(unsafe { BlobExt::to_js(&*blob, global_this) })
-            }
+            BinaryType::Blob => Ok(Blob::init(data.to_vec(), global_this).to_js(global_this)),
         }
     }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -491,7 +491,7 @@ impl BlobExt for Blob {
             // request needs out of its blob's store (a fresh +1 ref) first.
             let store = t.blob.store().expect("infallible: store present").clone();
             let s3 = store.data.as_s3();
-            let cred = std::rc::Rc::clone(s3.get_credentials());
+            let cred = s3.get_credentials().clone();
             let path = s3.path();
             let payer = s3.request_payer;
             let cb = Box::new(move |r: crate::webcore::__s3_client::S3DownloadResult<'_>| t.cb(r));

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2214,9 +2214,7 @@ impl BlobExt for Blob {
             let converted = match strings::to_utf16_alloc(buf, false, false) {
                 Ok(converted) => converted,
                 Err(_) => {
-                    return Err(bun_string_jsc::throw_utf16_transcode_failure(
-                        global, buf,
-                    ));
+                    return Err(bun_string_jsc::throw_utf16_transcode_failure(global, buf));
                 }
             };
             if let Some(external) = converted {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5,16 +5,13 @@
 //! basic file copy instead of a naive read write loop.
 
 use core::cell::Cell;
-use core::ffi::{c_char, c_void};
-use core::ptr::NonNull;
+use core::ops::Range;
 
 use bun_jsc::JsCell;
 
 use crate::webcore::jsc::{
     self as jsc, CallFrame, JSGlobalObject, JSPromise, JSValue, JsResult, VirtualMachine,
 };
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use bun_core as bun;
 use bun_core::Output;
 use bun_core::{EncodedSlice, String as BunString, Utf8Bytes, WTFStringImplExt as _, strings};
 use bun_http_types::MimeType::MimeType;
@@ -58,24 +55,22 @@ pub mod read_file;
 #[path = "blob/write_file.rs"]
 pub mod write_file;
 
-/// Deallocator for `ArrayBuffer`s backed by a `Blob::Store` ref. Passed as a C
-/// callback to `ArrayBuffer::to_js_with_context`; the `ctx` is a raw `Store*`
-/// produced by `RefPtr<Store>::into_raw()`.
-///
-/// Defined here (rather than in `bun_jsc`) because `Store` is a `bun_runtime`
-/// type and the `bun_jsc` copy is a forward-dep placeholder.
-///
-/// Body wraps its only privileged op (`Store::deref`) locally; a safe
-/// `extern "C" fn` coerces to the `JSTypedArrayBytesDeallocator` pointer
-/// expected by `to_js_with_context`.
-pub(crate) extern "C" fn blob_store_array_buffer_deallocator(
-    _bytes: *mut c_void,
-    ctx: *mut c_void,
-) {
-    if let Some(store) = NonNull::new(ctx.cast::<Store>()) {
-        // SAFETY: `ctx` is a `*mut Store` previously yielded by `RefPtr<Store>::into_raw`
-        // (one outstanding strong ref). `Store::deref` consumes that ref.
-        unsafe { Store::deref(store) };
+/// The bytes a `to_*_with_bytes` conversion consumes: a buffer it now owns (a
+/// finished file read), or a window of this blob's store bytes to clone,
+/// share or transfer per its [`Lifetime`].
+pub enum SourceBytes {
+    Temporary(Box<[u8]>),
+    Store(Range<usize>, Lifetime),
+}
+
+impl SourceBytes {
+    /// The lifetime this variant is delivered under.
+    #[inline]
+    pub fn lifetime(&self) -> Lifetime {
+        match self {
+            SourceBytes::Temporary(_) => Lifetime::Temporary,
+            SourceBytes::Store(_, lifetime) => *lifetime,
+        }
     }
 }
 
@@ -98,19 +93,10 @@ pub enum ReadBytesResult {
 /// Handler trait for `read_bytes_to_handler` — the body only requires
 /// `on_read_bytes`.
 pub trait ReadBytesHandler {
-    /// Invoked exactly once, on the JS thread, with the `ctx` given to
-    /// `read_bytes_to_handler`; ownership of `*this` comes back to the handler
-    /// here, and a heap-allocated one reclaims itself (`heap::take(this)`).
-    /// That is why the receiver is a raw pointer, as in
-    /// `read_file::ReadFileCompletion::run`: freeing the allocation behind a
-    /// `&mut self` argument is UB under the aliasing model (the argument is
-    /// protected for the whole call), even if `self` is never touched again.
-    /// It may settle promises: an exception it leaves pending is the `Err`.
-    ///
-    /// # Safety
-    /// `this` is the `ctx` passed to `read_bytes_to_handler`, still live, and
-    /// the caller does not use it afterwards.
-    unsafe fn on_read_bytes(this: *mut Self, result: ReadBytesResult) -> JsResult<()>;
+    /// Invoked exactly once, on the JS thread, with the handler given to
+    /// `read_bytes_to_handler`. It may settle promises: an exception it
+    /// leaves pending is the `Err`.
+    fn on_read_bytes(self: Box<Self>, result: ReadBytesResult) -> JsResult<()>;
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -152,39 +138,31 @@ pub trait BlobExt {
         &self,
         global: &JSGlobalObject,
     ) -> JsResult<JSValue>;
-    fn do_read_file<F: read_file::ReadFileToJs>(&self, global: &JSGlobalObject) -> JSValue;
-    /// # Safety
-    /// `ctx` must be a valid, exclusively-accessible `*mut H`. Ownership of
-    /// `*ctx` passes to the single `H::on_read_bytes(ctx, ..)` this makes
-    /// (synchronously or from the async completion), whatever this returns;
-    /// the caller must not use `ctx` afterwards.
-    unsafe fn read_bytes_to_handler<H: ReadBytesHandler>(
+    fn do_read_file<F: read_file::ReadFileToJs + 'static>(
         &self,
-        ctx: *mut H,
+        global: &JSGlobalObject,
+    ) -> JSValue;
+    fn read_bytes_to_handler<H: ReadBytesHandler + 'static>(
+        &self,
+        handler: Box<H>,
         global: &JSGlobalObject,
     ) -> JsResult<()>;
     fn do_image(_this: &Self, global: &JSGlobalObject, cf: &CallFrame) -> JsResult<JSValue>
     where
         Self: Sized;
-    fn do_read_file_internal<C, F: InternalReadFileFn<C>>(
-        &self,
-        ctx: *mut C,
-        global: &JSGlobalObject,
-    );
+    fn do_read_file_internal(&self, on_done: read_file::ReadFileOnDone, global: &JSGlobalObject);
     fn get_content_type(&self) -> Option<Utf8Bytes<'_>>;
     fn _on_structured_clone_serialize<W: bun_io::Write>(&self, writer: &mut W)
     -> crate::Result<()>;
     fn on_structured_clone_serialize(
         &self,
         _global_this: &JSGlobalObject,
-        ctx: *mut c_void,
-        write_bytes: crate::generated_classes::WriteBytesFn,
+        writer: &mut jsc::host_fn::StructuredCloneWriter,
     );
     /// `Ok(None)`: the bytes are not a valid record (the deserializer reports its usual error).
     fn on_structured_clone_deserialize(
         global_this: &JSGlobalObject,
-        ptr: *mut *mut u8,
-        end: *const u8,
+        reader: &mut jsc::host_fn::StructuredCloneReader<'_>,
     ) -> JsResult<Option<JSValue>>
     where
         Self: Sized;
@@ -288,59 +266,33 @@ pub trait BlobExt {
     where
         Self: Sized;
     fn transfer(&self);
-    fn shared_view_raw(&self) -> *mut [u8];
+    fn shared_view_range(&self) -> Range<usize>;
+    fn source_slice<'a>(&'a self, bytes: &'a SourceBytes) -> &'a [u8];
     fn set_is_ascii_flag(&self, is_all_ascii: bool);
-    /// # Safety
-    /// `raw_bytes` must be valid for reads for the duration of the call; when
-    /// `LIFETIME == Temporary` it must be a leaked default-allocator `Box<[u8]>`.
-    unsafe fn to_string_with_bytes<const LIFETIME: Lifetime>(
+    fn to_string_with_bytes(
         &self,
         global: &JSGlobalObject,
-        raw_bytes: *mut [u8],
+        bytes: SourceBytes,
     ) -> JsResult<JSValue>;
     fn to_string_transfer(&self, global: &JSGlobalObject) -> JsResult<JSValue>;
     fn to_string(&self, global: &JSGlobalObject, lifetime: Lifetime) -> JsResult<JSValue>;
     fn to_json(&self, global: &JSGlobalObject, lifetime: Lifetime) -> JsResult<JSValue>;
-    /// # Safety
-    /// `raw_bytes` must be valid for reads for the duration of the call; when
-    /// `LIFETIME == Temporary` it must be a leaked default-allocator `Box<[u8]>`.
-    unsafe fn to_json_with_bytes<const LIFETIME: Lifetime>(
+    fn to_json_with_bytes(&self, global: &JSGlobalObject, bytes: SourceBytes) -> JsResult<JSValue>;
+    fn to_form_data_with_bytes(&self, global: &JSGlobalObject, bytes: SourceBytes) -> JSValue;
+    fn to_array_buffer_with_bytes(
         &self,
         global: &JSGlobalObject,
-        raw_bytes: *mut [u8],
+        bytes: SourceBytes,
     ) -> JsResult<JSValue>;
-    /// # Safety
-    /// `buf` must be valid for reads for the duration of the call.
-    unsafe fn to_form_data_with_bytes<const _L: Lifetime>(
+    fn to_uint8_array_with_bytes(
         &self,
         global: &JSGlobalObject,
-        buf: *mut [u8],
-    ) -> JSValue;
-    /// # Safety
-    /// See [`BlobExt::to_array_buffer_view_with_bytes`].
-    unsafe fn to_array_buffer_with_bytes<const LIFETIME: Lifetime>(
-        &self,
-        global: &JSGlobalObject,
-        buf: *mut [u8],
+        bytes: SourceBytes,
     ) -> JsResult<JSValue>;
-    /// # Safety
-    /// See [`BlobExt::to_array_buffer_view_with_bytes`].
-    unsafe fn to_uint8_array_with_bytes<const LIFETIME: Lifetime>(
+    fn to_array_buffer_view_with_bytes<const TYPED_ARRAY_VIEW: jsc::JSType>(
         &self,
         global: &JSGlobalObject,
-        buf: *mut [u8],
-    ) -> JsResult<JSValue>;
-    /// # Safety
-    /// `buf` must be valid for reads (and, for `Share`/`Transfer`, owned by the
-    /// store backing this blob); when `LIFETIME == Temporary` it must be a
-    /// leaked default-allocator `Box<[u8]>` whose ownership transfers to JSC.
-    unsafe fn to_array_buffer_view_with_bytes<
-        const LIFETIME: Lifetime,
-        const TYPED_ARRAY_VIEW: jsc::JSType,
-    >(
-        &self,
-        global: &JSGlobalObject,
-        buf: *mut [u8],
+        bytes: SourceBytes,
     ) -> JsResult<JSValue>;
     fn to_array_buffer(&self, global: &JSGlobalObject, lifetime: Lifetime) -> JsResult<JSValue>;
     fn to_uint8_array(&self, global: &JSGlobalObject, lifetime: Lifetime) -> JsResult<JSValue>;
@@ -373,7 +325,6 @@ pub trait BlobExt {
         Self: Sized;
     fn calculate_estimated_byte_size(&self);
     fn estimated_size(&self) -> usize;
-    fn to_js(&self, global_object: &JSGlobalObject) -> JSValue;
     fn find_or_create_file_from_path(
         path_or_fd: &mut PathOrFileDescriptor<'static>,
         global_this: &JSGlobalObject,
@@ -382,28 +333,6 @@ pub trait BlobExt {
     where
         Self: Sized;
     fn is_all_ascii(&self) -> Option<bool>;
-}
-
-/// C-ABI trampoline for `Blob::shared_view` so C++ (`ZigGeneratedClasses`)
-/// can read blob bytes.
-///
-/// # Safety
-/// `this` must be a live `*const Blob` (the codegen `m_ctx` payload obtained
-/// via `Blob__fromJS`), valid for shared read for the duration of the call.
-/// `len` must be a writable `usize` out-param (caller stack slot). Kept as a
-/// raw-pointer ABI (not `&Blob`/`&mut usize`) because the sole Rust caller is
-/// the type-erased `SqlRuntimeHooks` vtable in `hw_exports.rs`, which forwards
-/// `*const c_void` without materialising a reference.
-#[unsafe(no_mangle)]
-pub(crate) unsafe extern "C" fn Bun__Blob__sharedView(
-    this: *const Blob,
-    len: *mut usize,
-) -> *const u8 {
-    // SAFETY: preconditions documented on the fn item above.
-    let view = unsafe { (*this).shared_view() };
-    // SAFETY: `len` is a valid writable out-param per the fn safety contract.
-    unsafe { *len = view.len() };
-    view.as_ptr()
 }
 
 #[allow(non_snake_case, clippy::too_many_arguments)]
@@ -423,75 +352,35 @@ impl BlobExt for Blob {
         global: &JSGlobalObject,
     ) -> JsResult<JSValue> {
         debug!("doReadFromS3");
-        // Adapt `(b, g, bytes)` → `(b, g, bytes, .clone)`
-        // and route through `to_js_host_call` so the exception scope is asserted.
+        // Route through `to_js_host_call` so the exception scope is asserted.
         fn wrapped<F: read_file::ReadFileToJs>(
             b: &Blob,
             g: bun_ptr::BackRef<JSGlobalObject>,
-            by: &mut [u8],
+            bytes: Range<usize>,
         ) -> JSValue {
             let g = g.get();
             jsc::host_fn::to_js_host_call(g, || {
-                F::call(b, g, std::ptr::from_mut::<[u8]>(by), Lifetime::Clone)
+                F::call(b, g, SourceBytes::Store(bytes, Lifetime::Clone))
             })
         }
         S3BlobDownloadTask::init(global, self, wrapped::<F>)
     }
 
-    fn do_read_file<F: read_file::ReadFileToJs>(&self, global: &JSGlobalObject) -> JSValue {
+    fn do_read_file<F: read_file::ReadFileToJs + 'static>(
+        &self,
+        global: &JSGlobalObject,
+    ) -> JSValue {
         debug!("doReadFile");
-
-        type Handler<'a, F> = read_file::NewReadFileHandler<'a, F>;
 
         // The callback may read context.content_type (e.g. to_form_data_with_bytes),
         // which is heap-owned by the source JS Blob and freed on finalize(). Take
         // an owning dupe so the handler outliving the source can't dangle.
-        let handler =
-            bun_core::heap::into_raw(Box::new(Handler::<'_, F>::new(self.dupe(), global)));
-
-        #[cfg(windows)]
-        {
-            // SAFETY: handler was just boxed; sole owner.
-            unsafe { (*handler).promise = jsc::JSPromiseStrong::init(global) };
-            let promise_value = unsafe { (*handler).promise.value() };
-            promise_value.ensure_still_alive();
-
-            read_file::ReadFileUV::start::<Handler<'_, F>>(
-                // `bun_vm()` returns the live VM for this global; the event
-                // loop outlives any in-flight async fs request.
-                global.bun_vm().event_loop(),
-                self.store().expect("infallible: store present").clone(),
-                self.offset.get(),
-                self.size.get(),
-                handler,
-            );
-            return promise_value;
-        }
-
-        #[cfg(not(windows))]
-        {
-            let file_read = read_file::ReadFile::create(
-                self.store().expect("infallible: store present").clone(),
-                self.offset.get(),
-                self.size.get(),
-            )
-            .unwrap_or_else(|e| bun_core::handle_oom(Err(e)));
-            // Create the Promise only after the store has been ref()'d.
-            // SAFETY: handler was just boxed; sole owner.
-            unsafe { (*handler).promise = jsc::JSPromiseStrong::init(global) };
-            // SAFETY: same `handler` as above; still solely owned here.
-            let promise_value = unsafe { (*handler).promise.value() };
-            promise_value.ensure_still_alive();
-
-            read_file::ReadFile::schedule(
-                file_read,
-                read_file::ReadFileCompletionFns::of(handler),
-                global,
-            );
-
-            debug!("doReadFile: read_file_task scheduled");
-            promise_value
-        }
+        let handler = read_file::NewReadFileHandler::<F>::new(self.dupe(), global);
+        let promise_value = handler.promise.value();
+        promise_value.ensure_still_alive();
+        self.do_read_file_internal(read_file::ReadFileOnDone::new(handler), global);
+        debug!("doReadFile: read_file_task scheduled");
+        promise_value
     }
     /// Read this Blob's bytes — file (`ReadFile`/`ReadFileUV`), S3 (`S3.download`),
     /// or in-memory — and deliver them to `Handler::on_read_bytes(ctx, result)` on the
@@ -506,42 +395,31 @@ impl BlobExt for Blob {
     /// callers that already special-case `shared_view()` can keep doing that and
     /// only call this when it's empty.
     ///
-    /// Every store kind hands `ctx` to exactly one `H::on_read_bytes` call:
+    /// Every store kind hands `handler` to exactly one `on_read_bytes` call:
     /// in-memory stores synchronously below, file stores from the read's
     /// `run`/`cancel` completion (exactly one of which fires), S3 from the
     /// download callback (which `execute_simple_s3_request` also invokes
     /// synchronously when it cannot start the request). An `Err` here is an
     /// exception a synchronous delivery left pending, so the handler has
     /// already been consumed in that case too.
-    ///
-    /// # Safety
-    /// `ctx` must be a valid, exclusively-accessible `*mut H`. Ownership of
-    /// `*ctx` passes to the single `H::on_read_bytes(ctx, ..)` this makes,
-    /// whatever this returns; the caller must not use `ctx` afterwards.
-    unsafe fn read_bytes_to_handler<H: ReadBytesHandler>(
+    fn read_bytes_to_handler<H: ReadBytesHandler + 'static>(
         &self,
-        ctx: *mut H,
+        handler: Box<H>,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
         if self.needs_to_read_file() {
-            struct Adapter<H>(core::marker::PhantomData<H>);
-            impl<H: ReadBytesHandler> InternalReadFileFn<H> for Adapter<H> {
-                fn call(c: *mut H, r: read_file::ReadFileResultType) -> JsResult<()> {
+            struct Adapter<H>(Box<H>);
+            impl<H: ReadBytesHandler> read_file::ReadFileCompletion for Adapter<H> {
+                fn run(self: Box<Self>, r: read_file::ReadFileResultType) -> JsResult<()> {
                     let result = match r {
                         read_file::ReadFileResultType::Result(b) => {
-                            // SAFETY: `buf` is `Box::<[u8]>::into_raw` from the
-                            // ReadFile finisher; reclaim ownership here.
-                            let buf = unsafe { bun_core::heap::take(b.buf) };
-                            ReadBytesResult::Ok(buf.into_vec())
+                            ReadBytesResult::Ok(b.buf.into_vec())
                         }
                         read_file::ReadFileResultType::Err(e) => ReadBytesResult::Err(Box::new(e)),
                     };
-                    // SAFETY: `c` is the `ctx` handed to `read_bytes_to_handler`,
-                    // and the read completion fires exactly once (`call` or
-                    // `cancel`), so this is its single delivery.
-                    unsafe { H::on_read_bytes(c, result) }
+                    self.0.on_read_bytes(result)
                 }
-                fn cancel(c: *mut H) {
+                fn cancel(self: Box<Self>) {
                     let err = jsc::SystemError {
                         code: BunString::static_("ECANCELED"),
                         message: BunString::static_(
@@ -552,89 +430,71 @@ impl BlobExt for Blob {
                     };
                     // The read's thread stopped; this runs at teardown (the unrun job's release,
                     // or `JobList::release_all_js`), where what the handler leaves stays pending.
-                    // SAFETY: as for `call`.
-                    let _ = unsafe { H::on_read_bytes(c, ReadBytesResult::Err(Box::new(err))) };
+                    let _ = self.0.on_read_bytes(ReadBytesResult::Err(Box::new(err)));
                 }
             }
-            self.do_read_file_internal::<H, Adapter<H>>(ctx, global);
+            self.do_read_file_internal(read_file::ReadFileOnDone::new(Adapter(handler)), global);
             return Ok(());
         }
         if self.is_s3() {
             struct Task<H> {
-                ctx: *mut H,
+                handler: Box<H>,
                 blob: Blob, // dupe for store ref + offset/size
                 poll: bun_io::KeepAlive,
             }
             impl<H: ReadBytesHandler> Task<H> {
-                fn done(mut self: Box<Self>, r: ReadBytesResult) -> JsResult<()> {
-                    self.poll.unref(bun_io::js_vm_ctx());
-                    self.blob.deinit();
-                    let ctx = self.ctx;
-                    drop(self);
-                    // SAFETY: `ctx` is the pointer handed to `read_bytes_to_handler`;
-                    // the download callback (and so `done`) runs exactly once, and
-                    // the `Task` that held the pointer is gone.
-                    unsafe { H::on_read_bytes(ctx, r) }
+                fn done(self, r: ReadBytesResult) -> JsResult<()> {
+                    let Self {
+                        handler,
+                        mut blob,
+                        mut poll,
+                    } = self;
+                    poll.unref(bun_io::js_vm_ctx());
+                    blob.deinit();
+                    handler.on_read_bytes(r)
                 }
-                fn cb(
-                    result: crate::webcore::__s3_client::S3DownloadResult,
-                    opaque_self: *mut c_void,
-                ) -> JsResult<()> {
-                    // SAFETY: `opaque_self` was heap-allocated below.
-                    let t = unsafe { bun_core::heap::take(opaque_self.cast::<Task<H>>()) };
+                fn cb(self, result: crate::webcore::__s3_client::S3DownloadResult) -> JsResult<()> {
                     match result {
                         // `body` is owned by us (simple_request.rs); take the Vec's items as-is.
                         crate::webcore::__s3_client::S3DownloadResult::Success(response) => {
-                            t.done(ReadBytesResult::Ok(response.body.list))
+                            self.done(ReadBytesResult::Ok(response.body.list))
                         }
                         // S3Error has its own JS-error builder; flatten to a
                         // SystemError so the callback has one shape to handle.
                         crate::webcore::__s3_client::S3DownloadResult::NotFound(e)
                         | crate::webcore::__s3_client::S3DownloadResult::Failure(e) => {
-                            // reshaped for borrowck — `t.done` moves
-                            // `t`, so build the SystemError (cloning the path
-                            // out of `t.blob.store`) before the call.
+                            // reshaped for borrowck — `done` moves `self`, so
+                            // build the SystemError (cloning the path out of
+                            // `self.blob.store`) before the call.
                             let err = bun_jsc::SystemError {
                                 code: BunString::clone_utf8(e.code),
                                 message: BunString::clone_utf8(e.message),
                                 path: BunString::clone_utf8(
-                                    t.blob.store().and_then(|s| s.get_path()).unwrap_or(b""),
+                                    self.blob.store().and_then(|s| s.get_path()).unwrap_or(b""),
                                 ),
                                 syscall: BunString::static_("fetch"),
                                 ..Default::default()
                             };
-                            t.done(ReadBytesResult::Err(Box::new(err)))
+                            self.done(ReadBytesResult::Err(Box::new(err)))
                         }
                     }
                 }
             }
-            let mut t = Box::new(Task::<H> {
-                ctx,
+            let mut t = Task::<H> {
+                handler,
                 blob: self.dupe(),
                 poll: bun_io::KeepAlive::default(),
-            });
+            };
             t.poll.ref_(bun_io::js_vm_ctx());
             let proxy = http_proxy_href(global);
-            // reshaped for borrowck — `heap::alloc(t)` moves `t`, so clone the
-            // credentials ref out and stash `path` as a raw `*const [u8]`
-            // whose backing store is kept alive by the same `t.blob` now
-            // owned by the heap task.
-            let (cred, path, payer);
-            {
-                let s3 = t
-                    .blob
-                    .store()
-                    .expect("infallible: store present")
-                    .data
-                    .as_s3();
-                cred = s3.get_credentials().clone();
-                path = std::ptr::from_ref::<[u8]>(s3.path());
-                payer = s3.request_payer;
-            }
-            // SAFETY: `path` borrows the store held by `t.blob` (a fresh +1 ref);
-            // it stays valid until `Task::done` deinits the blob in the callback.
-            let path = unsafe { &*path };
-            let t_ptr = bun_core::heap::into_raw(t).cast::<c_void>();
+            // The task moves into the download's completion, so read what the
+            // request needs out of its blob's store (a fresh +1 ref) first.
+            let store = t.blob.store().expect("infallible: store present").clone();
+            let s3 = store.data.as_s3();
+            let cred = std::rc::Rc::clone(s3.get_credentials());
+            let path = s3.path();
+            let payer = s3.request_payer;
+            let cb = Box::new(move |r: crate::webcore::__s3_client::S3DownloadResult<'_>| t.cb(r));
             if self.offset.get() > 0 || self.size.get() != MAX_SIZE {
                 let len: Option<usize> = if self.size.get() != MAX_SIZE {
                     Some(self.size.get() as usize)
@@ -646,29 +506,19 @@ impl BlobExt for Blob {
                     path,
                     self.offset.get() as usize,
                     len,
-                    Task::<H>::cb,
-                    t_ptr,
+                    cb,
                     proxy.as_deref(),
                     payer,
                 )?;
             } else {
-                crate::webcore::__s3_client::download(
-                    &cred,
-                    path,
-                    Task::<H>::cb,
-                    t_ptr,
-                    proxy.as_deref(),
-                    payer,
-                )?;
+                crate::webcore::__s3_client::download(&cred, path, cb, proxy.as_deref(), payer)?;
             }
             return Ok(());
         }
         // In-memory or detached.
         let view = self.shared_view();
         let owned = view.to_vec();
-        // SAFETY: `ctx` is this call's handler (fn contract) and this is its
-        // only delivery.
-        unsafe { H::on_read_bytes(ctx, ReadBytesResult::Ok(owned)) }
+        handler.on_read_bytes(ReadBytesResult::Ok(owned))
     }
 
     /// `Bun.file("…").image(opts?)` ≡ `new Bun.Image(this, opts?)`. Lives here so
@@ -679,20 +529,15 @@ impl BlobExt for Blob {
         Image::from_blob_js(global, cf.this(), cf.argument(0))
     }
 
-    fn do_read_file_internal<C, F: InternalReadFileFn<C>>(
-        &self,
-        ctx: *mut C,
-        global: &JSGlobalObject,
-    ) {
+    fn do_read_file_internal(&self, on_done: read_file::ReadFileOnDone, global: &JSGlobalObject) {
         #[cfg(windows)]
         {
-            return read_file::ReadFileUV::start_with_ctx(
-                // SAFETY: `bun_vm()` returns the live VM for this global.
-                global.bun_vm().event_loop(),
+            return read_file::ReadFileUV::start(
+                global.bun_vm().event_loop_shared(),
                 self.store().expect("infallible: store present").clone(),
                 self.offset.get(),
                 self.size.get(),
-                NewInternalReadFileHandler::<C, F>::completion(ctx),
+                on_done,
             );
         }
         #[cfg(not(windows))]
@@ -701,13 +546,8 @@ impl BlobExt for Blob {
                 self.store().expect("infallible: store present").clone(),
                 self.offset.get(),
                 self.size.get(),
-            )
-            .unwrap_or_else(|e| bun_core::handle_oom(Err(e)));
-            read_file::ReadFile::schedule(
-                file_read,
-                NewInternalReadFileHandler::<C, F>::completion(ctx),
-                global,
             );
+            read_file::ReadFile::schedule(file_read, on_done, global);
         }
     }
     fn get_content_type(&self) -> Option<Utf8Bytes<'_>> {
@@ -790,49 +630,20 @@ impl BlobExt for Blob {
     fn on_structured_clone_serialize(
         &self,
         _global_this: &JSGlobalObject,
-        ctx: *mut c_void,
-        write_bytes: crate::generated_classes::WriteBytesFn,
+        writer: &mut jsc::host_fn::StructuredCloneWriter,
     ) {
-        let mut writer = StructuredCloneWriter {
-            ctx,
-            impl_: write_bytes,
-        };
-        let _ = self._on_structured_clone_serialize(&mut writer);
+        let _ = self._on_structured_clone_serialize(writer);
     }
 
-    // C++ codegen calls this with a live `*mut *mut u8` cursor and end pointer; the
-    // trait signature is fixed, so the deref is documented with the SAFETY comment below.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn on_structured_clone_deserialize(
         global_this: &JSGlobalObject,
-        ptr: *mut *mut u8,
-        end: *const u8,
+        reader: &mut jsc::host_fn::StructuredCloneReader<'_>,
     ) -> JsResult<Option<JSValue>> {
-        // SAFETY: codegen passes a live `*mut *mut u8` cursor (C++:
-        // `(uint8_t**)&ptr`) and a one-past-the-end `*const u8`; both are
-        // non-null and `[*ptr, end)` is the serialized byte range owned by
-        // SerializedScriptValue for the duration of this call.
-        let start = unsafe { *ptr };
-        let total_length: usize = (end as usize) - (start as usize);
-        // SAFETY: `[start, end)` spans `total_length` bytes owned by the
-        // SerializedScriptValue for the duration of this call (see fn contract).
-        let mut buffer_stream =
-            bun_io::FixedBufferStream::new(unsafe { bun_core::ffi::slice(start, total_length) });
-
-        let result = match on_structured_clone_deserialize(global_this, &mut buffer_stream) {
-            Ok(v) => v,
-            Err(e) if e.name() == "OutOfMemory" => {
-                return Err(global_this.throw_out_of_memory());
-            }
-            Err(_) => return Ok(None),
-        };
-
-        // Advance the caller's cursor by the number of bytes consumed.
-        // SAFETY: `ptr` is the live cursor (fn contract); `pos <= total_length` by
-        // construction, so the advanced pointer stays within `[start, end]`.
-        unsafe { *ptr = start.add(buffer_stream.pos) };
-
-        Ok(Some(result))
+        match on_structured_clone_deserialize(global_this, reader) {
+            Ok(v) => Ok(Some(v)),
+            Err(e) if e.name() == "OutOfMemory" => Err(global_this.throw_out_of_memory()),
+            Err(_) => Ok(None),
+        }
     }
     fn from_url_search_params(
         global_this: &JSGlobalObject,
@@ -840,18 +651,19 @@ impl BlobExt for Blob {
     ) -> Blob {
         let mut converter = URLSearchParamsConverter { buf: Vec::new() };
         search_params.to_string(&mut converter, URLSearchParamsConverter::convert);
-        let store = Store::init(converter.buf);
-        // SAFETY: `store` is the sole +1 on this freshly-allocated Store.
-        unsafe {
-            (*store.as_ptr()).mime_type = bun_http_types::MimeType::Compact::from(
+        let store = RefPtr::new(Store {
+            data: store::Data::Bytes(store::Bytes::init(converter.buf)),
+            mime_type: bun_http_types::MimeType::Compact::from(
                 // The bare tag, *without* `;charset=UTF-8` (charset promotion is
                 // Compact::to_mime_type's job, applied when read).
                 bun_http_types::MimeType::Table::from_mime_literal(
                     "application/x-www-form-urlencoded",
                 ),
             )
-            .to_mime_type();
-        }
+            .to_mime_type(),
+            ref_count: bun_ptr::ThreadSafeRefCount::init(),
+            is_all_ascii: store::IsAllAscii::default(),
+        });
         let content_type = BlobContentType::from_mime(&store.mime_type);
 
         let blob = Blob::init_with_store(store, global_this);
@@ -865,7 +677,6 @@ impl BlobExt for Blob {
         const BOUNDARY_PREFIX: &[u8; 22] = b"----WebKitFormBoundary";
         let mut boundary_buf = [0u8; BOUNDARY_PREFIX.len() + 32];
         let boundary: &[u8] = {
-            // SAFETY: bun_vm() never returns null for a Bun-owned global.
             let random = global_this.bun_vm().as_mut().rare_data().next_uuid().bytes;
             boundary_buf[..BOUNDARY_PREFIX.len()].copy_from_slice(BOUNDARY_PREFIX);
             bun_core::fmt::bytes_to_hex_lower(&random, &mut boundary_buf[BOUNDARY_PREFIX.len()..]);
@@ -873,7 +684,7 @@ impl BlobExt for Blob {
         };
 
         let mut context = FormDataContext {
-            joiner: bun_core::string_joiner::StringJoiner::default(),
+            joiner: Parts::default(),
             boundary,
             failed: false,
             global_this,
@@ -882,72 +693,7 @@ impl BlobExt for Blob {
         // string entry 8, plus 3 for the closing boundary.
         context.joiner.reserve(form_data.count() * 13 + 3);
 
-        // `bun_jsc::DOMFormData::for_each` yields the
-        // lower-tier `bun_jsc::dom_form_data::FormDataEntry`, whose `blob`
-        // field is `&bun_jsc::WebCore::Blob` (the forward-decl). The native
-        // pointer the C++ hands us is the `m_ctx` `*mut Blob`; reinterpret it
-        // as the runtime `&mut Blob` here. Driving the FFI directly (rather
-        // than going through `for_each`'s immutable wrapper) avoids a
-        // `&T → &mut T` cast. Every raw deref is wrapped locally; the safe fn
-        // item coerces to the callback-pointer type at `DOMFormData__forEach`.
-        extern "C" fn for_each_thunk(
-            ctx_ptr: *mut c_void,
-            name_: *mut EncodedSlice,
-            value_ptr: *mut c_void,
-            filename: *mut EncodedSlice,
-            is_blob: u8,
-        ) {
-            // SAFETY: `ctx_ptr` is the `&mut FormDataContext` passed below; the
-            // erased lifetime is the caller's stack frame in `from_dom_form_data`.
-            let ctx = unsafe { bun_ptr::callback_ctx::<FormDataContext<'_>>(ctx_ptr) };
-            let entry = if is_blob == 0 {
-                // SAFETY: when `is_blob == 0`, `value_ptr` points to an `EncodedSlice`.
-                FormDataEntry::String(unsafe { *value_ptr.cast::<EncodedSlice>() })
-            } else {
-                FormDataEntry::File {
-                    // SAFETY: `value_ptr` is the C++ `JSBlob::m_ctx` (`*mut Blob`);
-                    // valid for the synchronous callback scope.
-                    blob: unsafe { &mut *value_ptr.cast::<Blob>() },
-                    filename: if filename.is_null() {
-                        EncodedSlice::EMPTY
-                    } else {
-                        // SAFETY: non-null `filename` is a valid `*EncodedSlice` for this call.
-                        unsafe { *filename }
-                    },
-                }
-            };
-            // SAFETY: `name_` is always a valid non-null `*EncodedSlice` for this callback.
-            ctx.on_entry(unsafe { *name_ }, entry);
-        }
-        unsafe extern "C" {
-            // `this` is the `&mut DOMFormData` param (coerced); `ctx`/`cb` are
-            // stored opaquely and only used synchronously. Module-private with
-            // one call site below — no caller-side precondition remains. Kept
-            // `*mut` (not `&mut`) to match the `bun_jsc` decl and avoid
-            // `clashing_extern_declarations`.
-            safe fn DOMFormData__forEach(
-                this: *mut jsc::DOMFormData,
-                ctx: *mut c_void,
-                // Safe fn-ptr: `for_each_thunk` is a safe `extern "C" fn` (its
-                // body localises every raw deref individually), so the callback
-                // type carries no caller-side precondition. ABI-identical to
-                // `bun_jsc`'s `ForEachFunction` alias.
-                cb: extern "C" fn(
-                    *mut c_void,
-                    *mut EncodedSlice,
-                    *mut c_void,
-                    *mut EncodedSlice,
-                    u8,
-                ),
-            );
-        }
-        // C++ invokes the callback synchronously and does not retain `ctx`/`cb`
-        // past this call.
-        DOMFormData__forEach(
-            form_data,
-            (&raw mut context).cast::<c_void>(),
-            for_each_thunk,
-        );
+        form_data.for_each(|name, entry| context.on_entry(name, entry));
         if context.failed {
             // Drop the joiner (Drop runs StringJoiner::deinit) so every
             // heap-owned slice already pushed — escaped names, non-ASCII
@@ -960,13 +706,7 @@ impl BlobExt for Blob {
         context.joiner.push_static(boundary);
         context.joiner.push_static(b"--\r\n");
 
-        let store = Store::init(
-            context
-                .joiner
-                .done()
-                .map(|b| b.into_vec())
-                .unwrap_or_else(|_| bun_core::out_of_memory()),
-        );
+        let store = Store::init(context.joiner.done());
         let blob = Blob::init_with_store(store, global_this);
         const CONTENT_TYPE_PREFIX: &[u8] = b"multipart/form-data; boundary=";
         let mut ct = Vec::with_capacity(CONTENT_TYPE_PREFIX.len() + boundary.len());
@@ -1282,7 +1022,6 @@ impl BlobExt for Blob {
         JSValue::from(bun_sys::S::ISREG(file.mode) || bun_sys::S::ISFIFO(file.mode))
     }
     fn do_write(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        // SAFETY: bun_vm() never returns null for a Bun-owned global.
         let mut args = jsc::ArgumentsSlice::init(global_this.bun_vm(), callframe.arguments());
 
         validate_writable_blob(global_this, self)?;
@@ -1337,7 +1076,6 @@ impl BlobExt for Blob {
     }
 
     fn do_unlink(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        // SAFETY: bun_vm() never returns null for a Bun-owned global.
         let mut args = jsc::ArgumentsSlice::init(global_this.bun_vm(), callframe.arguments());
 
         validate_writable_blob(global_this, self)?;
@@ -1391,12 +1129,8 @@ impl BlobExt for Blob {
             };
 
             let path = s3.path();
-            // SAFETY: bun_vm() never returns null for a Bun-owned global; `env`
-            // is a live `*mut Loader` owned by the transpiler.
-            let proxy = unsafe {
-                (*global_this.bun_vm().as_mut().transpiler.env).get_http_proxy(true, None, None)
-            };
-            let proxy_url = proxy.map(|p| p.href);
+            let proxy = http_proxy_href(global_this);
+            let proxy_url = proxy.as_deref();
 
             // When no JS overrides were supplied, hand the store's *base*
             // credentials to the upload.
@@ -1413,8 +1147,6 @@ impl BlobExt for Blob {
                 aws_options.acl,
                 aws_options.storage_class,
                 self.content_type_or_mime_type(),
-                // SAFETY: option-wrapped raw `*const [u8]` borrowed back; the
-                // backing storage is owned by `aws_options` which outlives this call.
                 aws_options.content_disposition.as_deref(),
                 aws_options.content_encoding.as_deref(),
                 proxy_url,
@@ -1478,7 +1210,7 @@ impl BlobExt for Blob {
                         // `RareData::std{out,err}_store` is `Option<NonNull<c_void>>`
                         // (type-erased `*Blob.Store`); compare on raw pointer
                         // identity exactly like the POSIX arm below.
-                        let store_ptr = store.as_ptr().cast::<c_void>();
+                        let store_ptr = store.as_ptr().cast::<core::ffi::c_void>();
                         if rare.stdout_store.map(|p| p.as_ptr()) == Some(store_ptr) {
                             break 'brk true;
                         }
@@ -1596,7 +1328,7 @@ impl BlobExt for Blob {
                         // The pump's ref: released by the reactions below, or
                         // by the controller's destructor at heap teardown.
                         sink.hold_stream_promise_ref(file_sink);
-                        let wrapper = bun_core::heap::into_raw(Box::new(FileStreamWrapper {
+                        let wrapper = Box::new(FileStreamWrapper {
                             promise: jsc::JSPromiseStrong::init(global_this),
                             readable_stream_ref:
                                 webcore::readable_stream::ReadableStreamStrong::init(
@@ -1604,14 +1336,15 @@ impl BlobExt for Blob {
                                     global_this,
                                 ),
                             sink,
-                        }));
-                        // SAFETY: wrapper was just produced by heap::alloc; sole owner here.
-                        let promise_value = unsafe { (*wrapper).promise.value() };
+                        });
+                        let promise_value = wrapper.promise.value();
+                        // Released to the reaction pair: exactly one of them
+                        // runs, once, and takes the box back.
                         assignment_result.then(
                             global_this,
-                            wrapper.cast::<c_void>(),
-                            on_file_stream_resolve_request_stream_shim,
-                            on_file_stream_reject_request_stream_shim,
+                            bun_core::heap::into_raw(wrapper),
+                            crate::generated_host_exports::Bun__FileStreamWrapper__onResolveRequestStream,
+                            crate::generated_host_exports::Bun__FileStreamWrapper__onRejectRequestStream,
                         );
                         return Ok(promise_value);
                     }
@@ -1668,15 +1401,10 @@ impl BlobExt for Blob {
             // content-type writes below don't conflict.
             let s3 = store.data.as_s3();
             let path = s3.path();
-            // SAFETY: `bun_vm()` returns the live per-global VM; `transpiler.env`
-            // is the process-singleton dotenv loader, never null once init'd.
-            let proxy_url: Option<bun_url::URL<'_>> = unsafe {
-                (*global_this.bun_vm().as_mut().transpiler.env).get_http_proxy(true, None, None)
-            };
             // Copy the href out of the env map before any reentrant JS (the
             // `get_truthy`/credential getters below) can mutate `process.env`
             // and free the backing allocation.
-            let proxy_owned: Option<Vec<u8>> = proxy_url.as_ref().map(|p| p.href.to_vec());
+            let proxy_owned: Option<Vec<u8>> = http_proxy_href(global_this);
             let proxy = proxy_owned.as_deref();
 
             if has_args && arg0.is_object() {
@@ -1749,7 +1477,6 @@ impl BlobExt for Blob {
             use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
 
             let pathlike = &store.data.as_file().pathlike;
-            // SAFETY: bun_vm() never returns null for a Bun-owned global.
             let vm = global_this.bun_vm().as_mut();
             let fd: Fd = match pathlike {
                 PathOrFileDescriptor::Fd(fd) => *fd,
@@ -1774,7 +1501,7 @@ impl BlobExt for Blob {
                     break 'brk false;
                 }
                 if let Some(rare) = vm.rare_data.as_ref() {
-                    let store_ptr = store.as_ptr().cast::<c_void>();
+                    let store_ptr = store.as_ptr().cast::<core::ffi::c_void>();
                     if rare.stdout_store.map(|p| p.as_ptr()) == Some(store_ptr) {
                         break 'brk true;
                     }
@@ -1895,12 +1622,7 @@ impl BlobExt for Blob {
         blob.content_type_was_set
             .set(self.content_type_was_set.get() || content_type_was_allocated);
 
-        let ptr = Blob::new(blob);
-        // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`. Spelled
-        // `BlobExt::to_js(&*ptr, ..)` so the `&self` impl below (which calls
-        // `calculate_estimated_byte_size` and routes S3 blobs to
-        // `s3_file::to_js_unchecked`) is chosen over the by-value `JsClass::to_js`.
-        unsafe { BlobExt::to_js(&*ptr, global_this) }
+        blob.to_js(global_this)
     }
 
     /// https://w3c.github.io/FileAPI/#slice-method-algo
@@ -1910,11 +1632,7 @@ impl BlobExt for Blob {
         let args = &mut arguments_[..];
 
         if self.size.get() == 0 {
-            let ptr = Blob::new(Blob::init_empty(global_this));
-            // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`; spelled
-            // `BlobExt::to_js(&*ptr, ..)` to pick the `&self` impl over the
-            // by-value `JsClass::to_js`.
-            return Ok(unsafe { BlobExt::to_js(&*ptr, global_this) });
+            return Ok(Blob::init_empty(global_this).to_js(global_this));
         }
 
         // If the optional start parameter is not used as a parameter, let relativeStart be 0.
@@ -2118,29 +1836,22 @@ impl BlobExt for Blob {
                     .as_file();
                 match &file.pathlike {
                     PathOrFileDescriptor::Path(path_like) => {
-                        // SAFETY: bun_vm() returns the live VM for this global.
                         let vm = global_this.bun_vm().as_mut();
-                        // SAFETY: lazily-initialised per-VM NodeFS binding; never null after init.
-                        let binding = unsafe {
-                            &*vm.node_fs().cast::<crate::node::node_fs_binding::Binding>()
-                        };
+                        // The `*Binding` arg is unused in `AsyncFSTask::create`.
+                        let binding = crate::node::fs::Binding::default();
                         Ok(crate::node::fs::async_::Stat::create(
                             global_this,
-                            binding,
+                            &binding,
                             crate::node::fs::args::Stat::owned(path_like.slice().to_vec()),
                             vm,
                         ))
                     }
                     PathOrFileDescriptor::Fd(fd) => {
-                        // SAFETY: bun_vm() returns the live VM for this global.
                         let vm = global_this.bun_vm().as_mut();
-                        // SAFETY: lazily-initialised per-VM NodeFS binding; never null after init.
-                        let binding = unsafe {
-                            &*vm.node_fs().cast::<crate::node::node_fs_binding::Binding>()
-                        };
+                        let binding = crate::node::fs::Binding::default();
                         Ok(crate::node::fs::async_::Fstat::create(
                             global_this,
-                            binding,
+                            &binding,
                             crate::node::fs::args::Fstat::for_fd(*fd),
                             vm,
                         ))
@@ -2410,52 +2121,32 @@ impl BlobExt for Blob {
 
     // dupe / dupe_with_content_type / to_js: defined once below (top-level impl); duplicates removed (E0592).
 
-    /// Raw-pointer counterpart of [`shared_view`]: returns a `*mut [u8]` into
-    /// the Store's byte buffer with **mutable provenance** (derived through
-    /// `RefPtr<Store>::as_ptr()` → the original `heap::alloc` tag), suitable for
-    /// the `*_with_bytes` paths that hand the buffer to JSC as a writable
-    /// ArrayBuffer backing, without
-    /// laundering a `&[u8]` through `as *const _ as *mut _` (which would carry
-    /// read-only provenance and make the downstream `&mut *buf` retag UB).
-    ///
-    /// Returns a dangling-empty slice when there is no byte store.
-    ///
-    /// # Aliasing
-    /// The returned pointer aliases the Store's `Vec<u8>` payload. Callers must
-    /// not hold a live `&`/`&mut` into the same Store across uses of this
-    /// pointer, and must keep a `RefPtr<Store>` alive for the pointer's lifetime.
-    fn shared_view_raw(&self) -> *mut [u8] {
-        let empty = || {
-            core::ptr::slice_from_raw_parts_mut(core::ptr::NonNull::<u8>::dangling().as_ptr(), 0)
-        };
+    /// The window of the store's byte buffer [`shared_view`](Blob::shared_view)
+    /// covers: `offset..offset+size`, clamped. Empty when there is no byte
+    /// store.
+    fn shared_view_range(&self) -> Range<usize> {
         if self.size.get() == 0 {
-            return empty();
+            return 0..0;
         }
-        let Some(store_ref) = self.store() else {
-            return empty();
+        let Some(store) = self.store() else {
+            return 0..0;
         };
-        // `Store::data_mut` derefs the original `heap::alloc` `*mut Store`
-        // (mutable provenance over the whole allocation) without materializing
-        // a `Deref`-produced `&Store`, so the brief `&mut` to the payload does
-        // not alias any outstanding borrow (other `RefPtr<Store>`s only hold raw
-        // `NonNull<Store>`, never a long-lived `&Store`; JS execution is
-        // single-threaded).
-        match Store::data_mut(store_ref) {
-            store::Data::Bytes(bytes) => {
-                let v: &mut [u8] = bytes.as_array_list_leak();
-                let len = v.len();
-                if len == 0 {
-                    return empty();
-                }
-                // Defensive: `offset` may originate from untrusted structured-clone data.
-                let off = (self.offset.get() as usize).min(len);
-                let clamped = (len - off).min(self.size.get() as usize);
-                // `v` already carries mutable provenance (derived through
-                // `Store::data_mut`); safe sub-slicing then raw-ptr coercion
-                // preserves it without `from_raw_parts_mut`/`ptr::add`.
-                core::ptr::from_mut::<[u8]>(&mut v[off..off + clamped])
-            }
-            _ => empty(),
+        let len = store.shared_view().len();
+        // Defensive: `offset` may originate from untrusted structured-clone data.
+        let off = (self.offset.get() as usize).min(len);
+        let clamped = (len - off).min(self.size.get() as usize);
+        off..off + clamped
+    }
+
+    /// The bytes `bytes` stands for: its own, or that window of this blob's
+    /// store.
+    fn source_slice<'a>(&'a self, bytes: &'a SourceBytes) -> &'a [u8] {
+        match bytes {
+            SourceBytes::Temporary(owned) => owned,
+            SourceBytes::Store(range, _) => self
+                .store()
+                .and_then(|s| s.shared_view().get(range.clone()))
+                .unwrap_or(&[]),
         }
     }
 
@@ -2472,35 +2163,27 @@ impl BlobExt for Blob {
             }
         }
     }
-    /// `raw_bytes` is a raw `*mut [u8]` (not `&[u8]`) so the
-    /// `LIFETIME == Temporary` branch can `heap::take` it with the
-    /// caller's original allocation provenance — going through `&[u8]`
-    /// would narrow to read-only and make the dealloc UB.
-    ///
-    /// # Safety
-    /// `raw_bytes` must be valid for reads for the duration of the call; when
-    /// `LIFETIME == Temporary` it must be a leaked default-allocator `Box<[u8]>`.
-    unsafe fn to_string_with_bytes<const LIFETIME: Lifetime>(
+
+    fn to_string_with_bytes(
         &self,
         global: &JSGlobalObject,
-        raw_bytes: *mut [u8],
+        bytes: SourceBytes,
     ) -> JsResult<JSValue> {
-        // SAFETY: `raw_bytes` is valid for reads for the duration of this call
-        // (either a leaked Box for `Temporary` or a store-backed view otherwise).
-        let raw_slice: &[u8] = unsafe { &*raw_bytes };
+        let lifetime = bytes.lifetime();
+        let raw_slice: &[u8] = self.source_slice(&bytes);
         let (bom, buf) = strings::BOM::detect_and_split(raw_slice);
+        // `buf`'s window of the source (a BOM is skipped).
+        let buf_range = match &bytes {
+            SourceBytes::Store(range, _) => range.start + (raw_slice.len() - buf.len())..range.end,
+            SourceBytes::Temporary(_) => raw_slice.len() - buf.len()..raw_slice.len(),
+        };
 
         if buf.is_empty() {
-            // If all it contained was the bom, we need to free the bytes
-            if LIFETIME == Lifetime::Temporary {
-                // SAFETY: temporary lifetime means raw_bytes is a leaked default-allocator buffer.
-                unsafe { drop(bun_core::heap::take(raw_bytes)) };
-            }
+            // If all it contained was the bom, `bytes` frees it on drop.
             return Ok(JSValue::js_empty_string(global));
         }
 
         if bom == Some(strings::BOM::Utf16Le) {
-            let _free = (LIFETIME == Lifetime::Temporary).then(|| TemporaryBytes(raw_bytes));
             // Reinterpret as u16: drop a trailing odd byte.
             // This branch intentionally does NOT `self.detach()` for
             // `Lifetime::Transfer`, unlike the toJSON path.
@@ -2531,88 +2214,57 @@ impl BlobExt for Blob {
             let converted = match strings::to_utf16_alloc(buf, false, false) {
                 Ok(converted) => converted,
                 Err(_) => {
-                    let err = bun_string_jsc::throw_utf16_transcode_failure(global, buf);
-                    if LIFETIME == Lifetime::Temporary {
-                        // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`; reclaim it.
-                        unsafe { drop(bun_core::heap::take(raw_bytes)) };
-                    }
-                    return Err(err);
+                    return Err(bun_string_jsc::throw_utf16_transcode_failure(
+                        global, buf,
+                    ));
                 }
             };
             if let Some(external) = converted {
-                if LIFETIME != Lifetime::Temporary {
+                if lifetime != Lifetime::Temporary {
                     self.set_is_ascii_flag(false);
                 }
-                if LIFETIME == Lifetime::Transfer {
+                if lifetime == Lifetime::Transfer {
                     self.detach();
                 }
-                if LIFETIME == Lifetime::Temporary {
-                    // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`; reclaim it.
-                    unsafe { drop(bun_core::heap::take(raw_bytes)) };
-                }
+                drop(bytes);
                 return bun_string_jsc::owned_utf16_into_js(global, external);
             }
 
-            if LIFETIME != Lifetime::Temporary {
+            if lifetime != Lifetime::Temporary {
                 self.set_is_ascii_flag(true);
             }
         }
 
-        match LIFETIME {
+        match bytes {
             // strings are immutable
             // we don't need to clone
-            Lifetime::Clone => {
+            //
+            // we don't need to worry about UTF-8 BOM in this case because the store owns the memory.
+            SourceBytes::Store(_, Lifetime::Clone | Lifetime::Share) => {
                 let store = self.store().expect("infallible: store present").clone();
-                // we don't need to worry about UTF-8 BOM in this case because the store owns the memory.
-                // SAFETY: `into_raw` hands the store's +1 ref to JSC; `Store::external`
-                // is the matching finalizer that consumes `ctx` and the buffer.
-                unsafe {
-                    EncodedSlice::latin1(buf).external(
-                        global,
-                        store.into_raw().cast::<c_void>(),
-                        Store::external,
-                    )
-                }
+                jsc::external_string_from_store(global, store, buf_range)
             }
-            Lifetime::Transfer => {
+            SourceBytes::Store(_, Lifetime::Transfer) => {
                 // Cloning the RefPtr<Store> here would bump the
                 // intrusive count by +1 *and* `transfer()` would leak the original
                 // +1, leaving an unmatched ref. Move the existing ref out instead;
-                // `into_raw` then hands that single ref to JSC.
+                // its single ref is handed to JSC.
                 let store = self.take_store().expect("transfer with null store");
                 debug_assert!(matches!(store.data, store::Data::Bytes(_)));
-                // SAFETY: `into_raw` hands the store's +1 ref to JSC; `Store::external`
-                // is the matching finalizer that consumes `ctx` and the buffer.
-                unsafe {
-                    EncodedSlice::latin1(buf).external(
-                        global,
-                        store.into_raw().cast::<c_void>(),
-                        Store::external,
-                    )
-                }
+                jsc::external_string_from_store(global, store, buf_range)
             }
-            Lifetime::Share => {
-                let store = self.store().expect("infallible: store present").clone();
-                // SAFETY: `into_raw` hands the store's +1 ref to JSC; `Store::external`
-                // is the matching finalizer that consumes `ctx` and the buffer.
-                unsafe {
-                    EncodedSlice::latin1(buf).external(
-                        global,
-                        store.into_raw().cast::<c_void>(),
-                        Store::external,
-                    )
-                }
+            SourceBytes::Store(_, Lifetime::Temporary) => {
+                unreachable!("store-owned bytes are never Temporary")
             }
-            Lifetime::Temporary => {
+            SourceBytes::Temporary(owned) => {
                 // if there was a UTF-8 BOM, we need to clone the buffer because
                 // external doesn't support this case here yet.
-                if buf.len() != raw_slice.len() {
-                    let out = BunString::clone_latin1(buf);
-                    // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`.
-                    unsafe { drop(bun_core::heap::take(raw_bytes)) };
+                if buf_range.start != 0 {
+                    let out = BunString::clone_latin1(&owned[buf_range]);
+                    drop(owned);
                     return out.into_js(global);
                 }
-                EncodedSlice::latin1(buf).to_external_value(global)
+                bun_string_jsc::owned_latin1_into_js(global, owned.into_vec())
             }
         }
     }
@@ -2629,37 +2281,15 @@ impl BlobExt for Blob {
             return self.do_read_from_s3::<ToStringWithBytesFn>(global);
         }
 
-        // `shared_view_raw` yields a `*mut [u8]` with mutable provenance (via
-        // `RefPtr<Store>::as_ptr`), avoiding a const→mut cast. `to_string_with_bytes`
-        // only ever reads through it (`&*raw_bytes`); the sole write path —
-        // `heap::take` in the `Temporary` arm — is statically unreachable
-        // below.
-        let view_ptr = self.shared_view_raw();
-        if view_ptr.len() == 0 {
+        debug_assert!(
+            lifetime != Lifetime::Temporary,
+            "store-owned bytes are never Temporary"
+        );
+        let view = self.shared_view_range();
+        if view.is_empty() {
             return Ok(JSValue::js_empty_string(global));
         }
-        match lifetime {
-            // SAFETY: `view_ptr` is the store-backed view from `shared_view_raw`;
-            // valid for reads while the store ref is held.
-            Lifetime::Clone => unsafe {
-                self.to_string_with_bytes::<{ Lifetime::Clone }>(global, view_ptr)
-            },
-            // SAFETY: same as `Clone` above.
-            Lifetime::Transfer => unsafe {
-                self.to_string_with_bytes::<{ Lifetime::Transfer }>(global, view_ptr)
-            },
-            // SAFETY: same as `Clone` above.
-            Lifetime::Share => unsafe {
-                self.to_string_with_bytes::<{ Lifetime::Share }>(global, view_ptr)
-            },
-            // UB guard: `Temporary` would `heap::take(view_ptr)`, but
-            // `view_ptr` points at a store-owned interior slice (not a leaked
-            // `Box<[u8]>`). No caller passes `Temporary` to `to_string`;
-            // the leaked-buffer path calls `to_string_with_bytes` directly.
-            Lifetime::Temporary => {
-                unreachable!("Blob::to_string: store-owned bytes are never Temporary")
-            }
-        }
+        self.to_string_with_bytes(global, SourceBytes::Store(view, lifetime))
     }
 
     fn to_json(&self, global: &JSGlobalObject, lifetime: Lifetime) -> JsResult<JSValue> {
@@ -2670,52 +2300,21 @@ impl BlobExt for Blob {
             return self.do_read_from_s3::<ToJsonWithBytesFn>(global);
         }
 
-        // `shared_view_raw` yields a `*mut [u8]` with mutable provenance (via
-        // `RefPtr<Store>::as_ptr`). `to_json_with_bytes` only reads through it for the
-        // non-`Temporary` lifetimes below.
-        let view_ptr = self.shared_view_raw();
-        match lifetime {
-            // SAFETY: `view_ptr` is the store-backed view from `shared_view_raw`;
-            // valid for reads while the store ref is held.
-            Lifetime::Clone => unsafe {
-                self.to_json_with_bytes::<{ Lifetime::Clone }>(global, view_ptr)
-            },
-            // SAFETY: same as `Clone` above.
-            Lifetime::Transfer => unsafe {
-                self.to_json_with_bytes::<{ Lifetime::Transfer }>(global, view_ptr)
-            },
-            // SAFETY: same as `Clone` above.
-            Lifetime::Share => unsafe {
-                self.to_json_with_bytes::<{ Lifetime::Share }>(global, view_ptr)
-            },
-            // UB guard: `Temporary` would `heap::take(view_ptr)`, but
-            // `view_ptr` points at a store-owned interior slice (not a leaked
-            // `Box<[u8]>`). No caller passes `Temporary` to `to_json`; the
-            // leaked-buffer path calls `to_json_with_bytes` directly.
-            Lifetime::Temporary => {
-                unreachable!("Blob::to_json: store-owned bytes are never Temporary")
-            }
-        }
+        debug_assert!(
+            lifetime != Lifetime::Temporary,
+            "store-owned bytes are never Temporary"
+        );
+        self.to_json_with_bytes(
+            global,
+            SourceBytes::Store(self.shared_view_range(), lifetime),
+        )
     }
 
-    /// See [`to_string_with_bytes`] for why `raw_bytes` is `*mut [u8]`.
-    ///
-    /// # Safety
-    /// `raw_bytes` must be valid for reads for the duration of the call; when
-    /// `LIFETIME == Temporary` it must be a leaked default-allocator `Box<[u8]>`.
-    unsafe fn to_json_with_bytes<const LIFETIME: Lifetime>(
-        &self,
-        global: &JSGlobalObject,
-        raw_bytes: *mut [u8],
-    ) -> JsResult<JSValue> {
-        // SAFETY: `raw_bytes` is valid for reads for the duration of this call
-        // (either a leaked Box for `Temporary` or a store-backed view otherwise).
-        let (bom, buf) = strings::BOM::detect_and_split(unsafe { &*raw_bytes });
+    fn to_json_with_bytes(&self, global: &JSGlobalObject, bytes: SourceBytes) -> JsResult<JSValue> {
+        let lifetime = bytes.lifetime();
+        // `bytes` (freed on every return when it owns the buffer) outlives `buf`.
+        let (bom, buf) = strings::BOM::detect_and_split(self.source_slice(&bytes));
         if buf.is_empty() {
-            if LIFETIME == Lifetime::Temporary {
-                // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`; reclaim it.
-                unsafe { drop(bun_core::heap::take(raw_bytes)) };
-            }
             return Err(global.throw_value(
                 global.create_syntax_error_instance(format_args!("Unexpected end of JSON input")),
             ));
@@ -2736,15 +2335,8 @@ impl BlobExt for Blob {
                     BunString::clone_utf16(&units)
                 }
             };
-            // Compute the
-            // result first, then perform the deferred work explicitly — capturing
-            // `&mut self` in a scopeguard closure conflicts with later uses below.
             let result = out.to_js_by_parse_json(global);
-            if LIFETIME == Lifetime::Temporary {
-                // SAFETY: `Temporary` ⇒ caller passed a leaked `Box<[u8]>`.
-                unsafe { drop(bun_core::heap::take(raw_bytes)) };
-            }
-            if LIFETIME == Lifetime::Transfer {
+            if lifetime == Lifetime::Transfer {
                 self.detach();
             }
             return result;
@@ -2754,15 +2346,12 @@ impl BlobExt for Blob {
         let could_be_all_ascii = self
             .is_all_ascii()
             .or_else(|| self.store().and_then(|s| s.is_all_ascii.get()));
-        // When a BOM is present `buf` is an interior slice of `raw_bytes`; we must
-        // free the original allocation, not the offset pointer.
-        let _free = (LIFETIME == Lifetime::Temporary).then(|| TemporaryBytes(raw_bytes));
 
         if could_be_all_ascii.is_none() || !could_be_all_ascii.unwrap() {
             if let Some(external) = strings::to_utf16_alloc(buf, false, false)
                 .map_err(|_| bun_string_jsc::throw_utf16_transcode_failure(global, buf))?
             {
-                if LIFETIME != Lifetime::Temporary {
+                if lifetime != Lifetime::Temporary {
                     self.set_is_ascii_flag(false);
                 }
                 let result = EncodedSlice::utf16(&external).to_json_object(global);
@@ -2770,7 +2359,7 @@ impl BlobExt for Blob {
                 return result;
             }
 
-            if LIFETIME != Lifetime::Temporary {
+            if lifetime != Lifetime::Temporary {
                 self.set_is_ascii_flag(true);
             }
         }
@@ -2778,25 +2367,14 @@ impl BlobExt for Blob {
         EncodedSlice::latin1(buf).to_json_object(global)
     }
 
-    /// See [`to_string_with_bytes`] for why `buf` is `*mut [u8]`.
-    ///
-    /// # Safety
-    /// `buf` must be valid for reads for the duration of the call.
-    unsafe fn to_form_data_with_bytes<const _L: Lifetime>(
-        &self,
-        global: &JSGlobalObject,
-        buf: *mut [u8],
-    ) -> JSValue {
+    fn to_form_data_with_bytes(&self, global: &JSGlobalObject, bytes: SourceBytes) -> JSValue {
         let Some(encoder) = self.get_form_data_encoding() else {
             return global.create_error_instance(format_args!("Invalid encoding"));
         };
 
         // `crate::webcore::form_data::Encoding` re-exports
         // `bun_core::form_data::Encoding` — same type, no re-tagging needed.
-        // SAFETY: `buf` is valid for reads for the duration of this call (either a
-        // leaked Box for `Temporary` or a store-backed view otherwise);
-        // `FormData::to_js` only reads it.
-        let buf = unsafe { &*buf };
+        let buf = self.source_slice(&bytes);
         match crate::webcore::form_data::FormData::to_js(global, buf, &encoder.encoding) {
             Ok(v) => v,
             Err(err) => {
@@ -2805,55 +2383,30 @@ impl BlobExt for Blob {
         }
     }
 
-    /// # Safety
-    /// See [`BlobExt::to_array_buffer_view_with_bytes`].
-    unsafe fn to_array_buffer_with_bytes<const LIFETIME: Lifetime>(
+    fn to_array_buffer_with_bytes(
         &self,
         global: &JSGlobalObject,
-        buf: *mut [u8],
+        bytes: SourceBytes,
     ) -> JsResult<JSValue> {
-        // SAFETY: forwarded from caller's contract.
-        unsafe {
-            self.to_array_buffer_view_with_bytes::<LIFETIME, { jsc::JSType::ArrayBuffer }>(
-                global, buf,
-            )
-        }
+        self.to_array_buffer_view_with_bytes::<{ jsc::JSType::ArrayBuffer }>(global, bytes)
     }
 
-    /// # Safety
-    /// See [`BlobExt::to_array_buffer_view_with_bytes`].
-    unsafe fn to_uint8_array_with_bytes<const LIFETIME: Lifetime>(
+    fn to_uint8_array_with_bytes(
         &self,
         global: &JSGlobalObject,
-        buf: *mut [u8],
+        bytes: SourceBytes,
     ) -> JsResult<JSValue> {
-        // SAFETY: forwarded from caller's contract.
-        unsafe {
-            self.to_array_buffer_view_with_bytes::<LIFETIME, { jsc::JSType::Uint8Array }>(
-                global, buf,
-            )
-        }
+        self.to_array_buffer_view_with_bytes::<{ jsc::JSType::Uint8Array }>(global, bytes)
     }
 
-    /// See [`to_string_with_bytes`] for why `buf` is `*mut [u8]`.
-    ///
-    /// # Safety
-    /// `buf` must be valid for reads (and, for `Share`/`Transfer`, owned by the
-    /// store backing this blob); when `LIFETIME == Temporary` it must be a
-    /// leaked default-allocator `Box<[u8]>` whose ownership transfers to JSC.
-    unsafe fn to_array_buffer_view_with_bytes<
-        const LIFETIME: Lifetime,
-        const TYPED_ARRAY_VIEW: jsc::JSType,
-    >(
+    fn to_array_buffer_view_with_bytes<const TYPED_ARRAY_VIEW: jsc::JSType>(
         &self,
         global: &JSGlobalObject,
-        buf: *mut [u8],
+        bytes: SourceBytes,
     ) -> JsResult<JSValue> {
-        // SAFETY: `buf` is valid for reads for the duration of this call (either a
-        // leaked Box for `Temporary` or a store-backed view otherwise).
-        let buf_len = unsafe { &*buf }.len();
-        match LIFETIME {
-            Lifetime::Clone => {
+        let buf_len = self.source_slice(&bytes).len();
+        match bytes {
+            SourceBytes::Store(range, Lifetime::Clone) => {
                 if TYPED_ARRAY_VIEW != jsc::JSType::ArrayBuffer {
                     // ArrayBuffer doesn't have this limit.
                     if buf_len > jsc::virtual_machine::synthetic_allocation_limit() {
@@ -2862,79 +2415,58 @@ impl BlobExt for Blob {
                     }
                 }
 
+                // Held across the conversion so the bytes (and a memfd behind
+                // them) stay put whatever `self` does meanwhile.
+                let Some(store) = self.store().cloned() else {
+                    return jsc::ArrayBuffer::create::<TYPED_ARRAY_VIEW>(global, b"");
+                };
                 #[cfg(any(target_os = "linux", target_os = "android"))]
                 {
                     use crate::allocators::linux_mem_fd_allocator::LinuxMemFdAllocator;
                     // If we can use a copy-on-write clone of the buffer, do so.
-                    if let Some(store) = self.store.get() {
-                        if let store::Data::Bytes(bytes) = &store.data {
-                            let allocated = bytes.allocated_slice();
-                            // SAFETY: `Clone` arm reads only; `buf` is store-backed.
-                            if bun::is_slice_in_buffer(unsafe { &*buf }, allocated) {
-                                if let Some(memfd) = LinuxMemFdAllocator::from(bytes.allocator()) {
-                                    // A ref across the FFI call so a concurrent
-                                    // store-deref cannot close the fd mid-mmap.
-                                    // SAFETY: `memfd` is the live Box-allocated ptr
-                                    // smuggled through `StdAllocator.ptr` by
-                                    // `LinuxMemFdAllocator::allocator`.
-                                    let memfd = unsafe { bun_ptr::RefPtr::init_ref(memfd) };
-                                    let byte_offset = (buf.cast::<u8>() as usize)
-                                        .saturating_sub(allocated.as_ptr() as usize);
-                                    let result =
-                                        jsc::ArrayBuffer::to_array_buffer_from_shared_memfd(
-                                            memfd.fd.native() as i64,
-                                            global,
-                                            byte_offset,
-                                            buf_len,
-                                            allocated.len(),
-                                            TYPED_ARRAY_VIEW,
-                                        );
-                                    let result = result?;
-                                    debug!(
-                                        "toArrayBuffer COW clone({}, {}) = {}",
-                                        byte_offset,
-                                        buf_len,
-                                        (result != JSValue::ZERO) as u8
-                                    );
-                                    if result != JSValue::ZERO {
-                                        return Ok(result);
-                                    }
-                                }
+                    if let store::Data::Bytes(store_bytes) = &store.data {
+                        if let Some(memfd) = LinuxMemFdAllocator::from_bytes(store_bytes) {
+                            // `shared_view()` starts at the mapping's start.
+                            let byte_offset = range.start;
+                            let result = jsc::ArrayBuffer::to_array_buffer_from_shared_memfd(
+                                memfd.fd().native() as i64,
+                                global,
+                                byte_offset,
+                                buf_len,
+                                store_bytes.allocated_slice().len(),
+                                TYPED_ARRAY_VIEW,
+                            )?;
+                            debug!(
+                                "toArrayBuffer COW clone({}, {}) = {}",
+                                byte_offset,
+                                buf_len,
+                                (result != JSValue::ZERO) as u8
+                            );
+                            if result != JSValue::ZERO {
+                                return Ok(result);
                             }
                         }
                     }
                 }
-                // SAFETY: `Clone` copies into a new JSC allocation; `buf` is only read.
-                jsc::ArrayBuffer::create::<TYPED_ARRAY_VIEW>(global, unsafe { &*buf })
+                jsc::ArrayBuffer::create::<TYPED_ARRAY_VIEW>(global, &store.shared_view()[range])
             }
-            Lifetime::Share => {
+            SourceBytes::Store(range, Lifetime::Share) => {
                 if buf_len > jsc::virtual_machine::synthetic_allocation_limit()
                     && TYPED_ARRAY_VIEW != jsc::JSType::ArrayBuffer
                 {
                     return Err(global.throw_out_of_memory());
                 }
                 let store = self.store().expect("infallible: store present").clone();
-                // SAFETY: `from_bytes` only records ptr+len into the FFI struct; the
-                // pointer is then handed to JSC as an external buffer backing whose
-                // lifetime is the cloned `store` ref above (the deallocator releases
-                // that ref exactly once at GC). No Rust-side `&` to the Store bytes
-                // is live across this reborrow.
-                unsafe {
-                    jsc::ArrayBuffer::from_bytes(&mut *buf, TYPED_ARRAY_VIEW).to_js_with_context(
-                        global,
-                        store.into_raw().cast::<c_void>(),
-                        Some(blob_store_array_buffer_deallocator),
-                    )
-                }
+                // JSC keeps the bytes alive through the store ref it is handed,
+                // released at GC.
+                jsc::ArrayBuffer::to_js_from_store(global, store, range, TYPED_ARRAY_VIEW)
             }
-            Lifetime::Transfer => {
+            SourceBytes::Store(range, Lifetime::Transfer) => {
                 if self.store().is_some_and(|s| !s.has_one_ref()) {
-                    // SAFETY: same `buf` contract as the caller; the `Clone` arm only reads it.
-                    let copied = unsafe {
-                        self.to_array_buffer_view_with_bytes::<{ Lifetime::Clone }, TYPED_ARRAY_VIEW>(
-                            global, buf,
-                        )
-                    };
+                    let copied = self.to_array_buffer_view_with_bytes::<TYPED_ARRAY_VIEW>(
+                        global,
+                        SourceBytes::Store(range, Lifetime::Clone),
+                    );
                     self.detach();
                     return copied;
                 }
@@ -2946,30 +2478,22 @@ impl BlobExt for Blob {
                 }
                 // Move the existing +1 out. Cloning then `transfer()` would leak a ref.
                 let store = self.take_store().expect("transfer with null store");
-                // SAFETY: see `Share` arm. After `take()` the store ref is moved
-                // out of `self`, so JSC becomes the sole owner via the deallocator.
-                unsafe {
-                    jsc::ArrayBuffer::from_bytes(&mut *buf, TYPED_ARRAY_VIEW).to_js_with_context(
-                        global,
-                        store.into_raw().cast::<c_void>(),
-                        Some(blob_store_array_buffer_deallocator),
-                    )
-                }
+                jsc::ArrayBuffer::to_js_from_store(global, store, range, TYPED_ARRAY_VIEW)
             }
-            Lifetime::Temporary => {
+            SourceBytes::Store(_, Lifetime::Temporary) => {
+                unreachable!("store-owned bytes are never Temporary")
+            }
+            SourceBytes::Temporary(owned) => {
                 if buf_len > jsc::virtual_machine::synthetic_allocation_limit()
                     && TYPED_ARRAY_VIEW != jsc::JSType::ArrayBuffer
                 {
-                    // SAFETY: `Temporary` ⇒ `buf` is a leaked default-allocator `Box<[u8]>`.
-                    unsafe { drop(bun_core::heap::take(buf)) };
+                    drop(owned);
                     return Err(global.throw_out_of_memory());
                 }
-                // SAFETY: `Temporary` ⇒ `buf` is a leaked `Box<[u8]>` we exclusively own;
-                // ownership is transferred to JSC.
+                // Ownership is transferred to JSC.
                 // `to_js_unchecked`: `to_js`'s heap-region probe would skip the deallocator
                 // for a non-mimalloc buffer, but `Temporary` is always default-allocator.
-                jsc::ArrayBuffer::from_bytes(unsafe { &mut *buf }, TYPED_ARRAY_VIEW)
-                    .to_js_unchecked(global)
+                jsc::ArrayBuffer::from_owned_bytes(owned, TYPED_ARRAY_VIEW).to_js_unchecked(global)
             }
         }
     }
@@ -3004,45 +2528,18 @@ impl BlobExt for Blob {
             };
         }
 
-        // `shared_view_raw` yields a `*mut [u8]` with mutable provenance (via
-        // `RefPtr<Store>::as_ptr`). The `Clone` arm only reads (`&*buf`);
-        // `Share`/`Transfer` hand the ptr to JSC as an external ArrayBuffer
-        // backing via FFI and materialize `&mut *buf` to record ptr+len, which
-        // is sound now that the provenance is writable. The `Temporary` arm
-        // (`heap::take`) is statically unreachable below.
-        let view_ptr = self.shared_view_raw();
-        if view_ptr.len() == 0 {
+        debug_assert!(
+            lifetime != Lifetime::Temporary,
+            "store-owned bytes are never Temporary"
+        );
+        let view = self.shared_view_range();
+        if view.is_empty() {
             return jsc::ArrayBuffer::create::<TYPED_ARRAY_VIEW>(global, b"");
         }
-        match lifetime {
-            // SAFETY: `view_ptr` is the store-backed view from `shared_view_raw`;
-            // valid for the store's lifetime.
-            Lifetime::Clone => unsafe {
-                self.to_array_buffer_view_with_bytes::<{ Lifetime::Clone }, TYPED_ARRAY_VIEW>(
-                    global, view_ptr,
-                )
-            },
-            // SAFETY: same as `Clone` above.
-            Lifetime::Share => unsafe {
-                self.to_array_buffer_view_with_bytes::<{ Lifetime::Share }, TYPED_ARRAY_VIEW>(
-                    global, view_ptr,
-                )
-            },
-            // SAFETY: same as `Clone` above.
-            Lifetime::Transfer => unsafe {
-                self.to_array_buffer_view_with_bytes::<{ Lifetime::Transfer }, TYPED_ARRAY_VIEW>(
-                    global, view_ptr,
-                )
-            },
-            // UB guard: `Temporary` would `heap::take(view_ptr)`, but
-            // `view_ptr` points at a store-owned interior slice (not a leaked
-            // `Box<[u8]>`). No caller passes `Temporary` to
-            // `to_array_buffer_view`; the leaked-buffer path calls
-            // `to_array_buffer_view_with_bytes` directly.
-            Lifetime::Temporary => {
-                unreachable!("Blob::to_array_buffer_view: store-owned bytes are never Temporary")
-            }
-        }
+        self.to_array_buffer_view_with_bytes::<TYPED_ARRAY_VIEW>(
+            global,
+            SourceBytes::Store(view, lifetime),
+        )
     }
 
     fn to_form_data(&self, global: &JSGlobalObject, _lifetime: Lifetime) -> JsResult<JSValue> {
@@ -3053,18 +2550,11 @@ impl BlobExt for Blob {
             return self.do_read_from_s3::<ToFormDataWithBytesFn>(global);
         }
 
-        // `shared_view_raw` yields a `*mut [u8]` with mutable provenance (via
-        // `RefPtr<Store>::as_ptr`). It is *only ever read* by
-        // `to_form_data_with_bytes` (`FormData::to_js` takes `&[u8]`). Note: the
-        // Store is intrusively shared (`ref_count: AtomicU32`); `&mut self` does
-        // NOT imply exclusive ownership of the underlying bytes.
-        let view_ptr = self.shared_view_raw();
-        if view_ptr.len() == 0 {
+        let view = self.shared_view_range();
+        if view.is_empty() {
             return Ok(jsc::DOMFormData::create(global));
         }
-        // SAFETY: `view_ptr` is the store-backed view from `shared_view_raw`;
-        // `to_form_data_with_bytes` only reads it.
-        Ok(unsafe { self.to_form_data_with_bytes::<{ Lifetime::Temporary }>(global, view_ptr) })
+        Ok(self.to_form_data_with_bytes(global, SourceBytes::Store(view, Lifetime::Temporary)))
     }
     #[inline]
     fn get<const MOVE: bool, const REQUIRE_ARRAY: bool>(
@@ -3153,10 +2643,7 @@ impl BlobExt for Blob {
 
                 jsc::JSType::DOMWrapper => {
                     if !fail_if_top_value_is_not_typed_array_like {
-                        if let Some(blob_ptr) = top_value.as_::<Blob>() {
-                            // SAFETY: live JS heap pointer; single-threaded JS execution.
-                            // Shared access only — Blob state is Cell/JsCell-based.
-                            let blob = unsafe { &*blob_ptr };
+                        if let Some(blob) = top_value.as_class_ref::<Blob>() {
                             if MOVE {
                                 // Move the store without bumping its refcount, but take
                                 // independent ownership of name/content_type so the
@@ -3225,7 +2712,7 @@ impl BlobExt for Blob {
         // JS object graph, so a heap `Vec<JSValue>` is GC-safe with
         // unbounded capacity (a prior `BoundedArray<_, 128>` panicked on overflow).
         let mut stack: Vec<JSValue> = Vec::new();
-        let mut joiner = bun_core::string_joiner::StringJoiner::default();
+        let mut joiner = Parts::default();
         let mut could_have_non_ascii = false;
 
         loop {
@@ -3296,13 +2783,11 @@ impl BlobExt for Blob {
                                         // or resizes this buffer before `done()`.
                                         joiner.push_cloned(buf.byte_slice());
                                     } else {
-                                        // SAFETY: the prescan above proved no remaining
-                                        // part can run user JS, so this buffer (rooted
-                                        // via `_keep`/`arg`) stays attached and valid
-                                        // until `joiner.done()` below.
-                                        joiner.push(unsafe {
-                                            bun_ptr::detach_lifetime(buf.byte_slice())
-                                        });
+                                        // The prescan above proved no remaining part
+                                        // can run user JS, so this buffer (rooted via
+                                        // `_keep`/`arg`) stays attached and valid until
+                                        // `joiner.done()` below reads it.
+                                        joiner.push(Part::Buffer(buf));
                                     }
                                     continue;
                                 }
@@ -3321,13 +2806,7 @@ impl BlobExt for Blob {
                                         if parts_can_run_js {
                                             joiner.push_cloned(blob.shared_view());
                                         } else {
-                                            // SAFETY: the prescan above proved no
-                                            // remaining part can run user JS, so this
-                                            // Blob (rooted via `_keep`/`arg`) keeps its
-                                            // Store alive until `joiner.done()` below.
-                                            joiner.push(unsafe {
-                                                bun_ptr::detach_lifetime(blob.shared_view())
-                                            });
+                                            joiner.push(Part::of_blob(blob));
                                         }
                                         continue;
                                     } else {
@@ -3365,11 +2844,11 @@ impl BlobExt for Blob {
 
                 t if t.is_array_buffer_like() => {
                     let buf = current.as_array_buffer(global).unwrap();
-                    // SAFETY: this arm is only reached when the typed array is the
+                    // This arm is only reached when the typed array is the
                     // top-level value (the walk stack is empty), so no user JS runs
                     // between this push and `joiner.done()` below; `_keep`/`arg` keeps
                     // the buffer alive for that span.
-                    joiner.push(unsafe { bun_ptr::detach_lifetime(buf.slice()) });
+                    joiner.push(Part::Buffer(buf));
                     could_have_non_ascii = true;
                 }
 
@@ -3385,7 +2864,7 @@ impl BlobExt for Blob {
             };
         }
 
-        let joined: Vec<u8> = joiner.done().expect("oom").into_vec();
+        let joined: Vec<u8> = joiner.done();
 
         if !could_have_non_ascii {
             return Ok(Blob::init_with_all_ascii(joined, global, true));
@@ -3426,23 +2905,6 @@ impl BlobExt for Blob {
         self.reported_estimated_size.get()
     }
 
-    fn to_js(&self, global_object: &JSGlobalObject) -> JSValue {
-        // if cfg!(debug_assertions) { debug_assert!(self.is_heap_allocated()); }
-        self.calculate_estimated_byte_size();
-
-        // R-2: `&self` receiver, but the FFI shims take `*mut Blob` (the
-        // heap-allocated `m_ctx` pointer). `self` *is* that allocation (caller
-        // contract), so the const→mut cast is the original `Blob::new` provenance.
-        let this = std::ptr::from_ref::<Blob>(self).cast_mut();
-        if self.is_s3() {
-            // SAFETY: `self` is a heap-allocated *mut Blob (see `Blob::new`); the
-            // C++ side wraps it in a JSS3File without taking a second ref.
-            return crate::webcore::s3_file::to_js_unchecked(global_object, this);
-        }
-
-        js::to_js_unchecked(global_object, this)
-    }
-
     /// `Bun.file(pathOrFd)` core: wrap a path-or-fd in a `Store::File` and
     /// return a Blob viewing it. Runtime `check_s3` matches the call shape used
     /// by `server_body.rs` / `fetch.rs` (collapsed from a const generic since
@@ -3456,7 +2918,6 @@ impl BlobExt for Blob {
         if check_s3 {
             if let PathOrFileDescriptor::Path(p) = &*path_or_fd {
                 if p.slice().starts_with(b"s3://") {
-                    // SAFETY: bun_vm() is live for the duration of a host call.
                     let vm = global_this.bun_vm().as_mut();
                     // `bun_dotenv::Loader` (T2) returns its local POD mirror by
                     // reference; lift it into the refcounted
@@ -3500,21 +2961,7 @@ impl BlobExt for Blob {
             }
             PathOrFileDescriptor::Fd(fd) => {
                 if let Some(tag) = fd.stdio_tag() {
-                    // SAFETY: bun_vm() is live for the duration of a host call.
-                    let vm = global_this.bun_vm().as_mut();
-                    // `RareData::{stdin,stdout,stderr}()` return the cached
-                    // `webcore::blob::Store` erased to `*mut c_void` (the
-                    // low-tier crate cannot name the high-tier type — see
-                    // `STDIO_BLOB_STORE_CTOR`). Cast back and take a counted ref.
-                    let erased = match tag {
-                        bun_sys::Stdio::StdIn => vm.rare_data().stdin(),
-                        bun_sys::Stdio::StdErr => vm.rare_data().stderr(),
-                        bun_sys::Stdio::StdOut => vm.rare_data().stdout(),
-                    };
-                    // SAFETY: the ctor hook (`__bun_stdio_blob_store_new`)
-                    // returns `Box::<Store>::into_raw` — non-null, live for the
-                    // process lifetime, and laid out as `Store`.
-                    let store = unsafe { RefPtr::init_ref(erased.cast::<Store>()) };
+                    let store = global_this.bun_vm().as_mut().rare_data().stdio_store(tag);
                     return Blob::init_with_store(store, global_this);
                 }
                 PathOrFileDescriptor::Fd(*fd)
@@ -3549,7 +2996,6 @@ use crate::node;
 use crate::webcore::s3::client as s3_client;
 use crate::webcore::s3::simple_request::S3UploadResult;
 use crate::webcore::s3_file as S3File;
-use bun_core::string_joiner::StringJoiner;
 use bun_jsc::SysErrorJsc as _;
 // The `write_file` module name coexists with `pub fn write_file` below (module
 // vs value namespace); alias the module so the call sites read unambiguously.
@@ -3558,49 +3004,102 @@ use self::write_file::{WriteFilePromise, WriteFileWaitFromLockedValueTask};
 use bun_bundler::options_impl::LoaderExt as _;
 use bun_jsc::JsClass as _;
 
-/// Local mirror of `jsc.DOMFormData.FormDataEntry` (`union(enum) { string, file }`).
-/// `bun_jsc::dom_form_data::FormDataEntry` carries `&Blob` (immutable) but
-/// `FormDataContext::on_entry` needs `&mut Blob` to call `resolve_size()`, so
-/// we drive the C++ `DOMFormData__forEach` directly with this mutable variant.
-pub(crate) enum FormDataEntry<'a> {
-    String(EncodedSlice<'a>),
-    File {
-        blob: &'a mut Blob,
-        filename: EncodedSlice<'a>,
-    },
+pub(crate) use bun_jsc::dom_form_data::FormDataEntry;
+
+/// Blob `to_js` for every tier (`JsClass::to_js` links here): heap-promote
+/// `blob` into a new `JSBlob` — or `JSS3File` — wrapper that owns it.
+// HOST_EXPORT(__bun_blob_to_js, rust)
+pub fn blob_to_js(blob: crate::webcore::Blob, global_object: &JSGlobalObject) -> JSValue {
+    blob.calculate_estimated_byte_size();
+    let is_s3 = blob.is_s3();
+    let this = Blob::new(blob);
+    if is_s3 {
+        return crate::webcore::s3_file::to_js_unchecked(global_object, this);
+    }
+    js::to_js_unchecked(global_object, this)
 }
 
-/// Carries `Function(ctx, bytes)` at the type level —
-/// a trait impl so `run` can be taken as a
-/// plain `fn(*mut c_void, ReadFileResultType)` thunk, monomorphized per `(C, F)`.
-pub trait InternalReadFileFn<C> {
-    fn call(ctx: *mut C, bytes: read_file::ReadFileResultType) -> JsResult<()>;
-    /// The read will never complete (its VM stopped first): do with `ctx` what its owner needs.
-    fn cancel(ctx: *mut C);
+// ──────────────────────────────────────────────────────────────────────────
+// Parts — pieces of a blob under assembly
+// ──────────────────────────────────────────────────────────────────────────
+
+/// One piece of a blob being assembled from JS values, holding whatever keeps
+/// its bytes alive until [`Parts::done`] copies them out.
+enum Part<'a> {
+    Borrowed(&'a [u8]),
+    Owned(Box<[u8]>),
+    /// A string's bytes (and the pin on them, if any).
+    Slice(Utf8Bytes<'a>),
+    /// A rooted typed array's bytes; only pushed when no user JS can run
+    /// (and detach it) before `done`.
+    Buffer(jsc::ArrayBuffer),
+    /// `range` of a blob's store bytes.
+    Store(RefPtr<Store>, Range<usize>),
+    ContentType(BlobContentType),
 }
 
-pub(crate) struct NewInternalReadFileHandler<C, F>(core::marker::PhantomData<(C, F)>);
+impl Part<'_> {
+    fn of_blob(blob: &Blob) -> Part<'static> {
+        match blob.store() {
+            Some(store) => Part::Store(store.clone(), blob.shared_view_range()),
+            None => Part::Borrowed(b""),
+        }
+    }
 
-impl<C, F> NewInternalReadFileHandler<C, F>
-where
-    F: InternalReadFileFn<C>,
-{
-    /// The erased `(ctx, run, cancel)` a `ReadFile`/`ReadFileUV` carries for this handler.
-    pub(crate) fn completion(ctx: *mut C) -> read_file::ReadFileCompletionFns {
-        fn run<C, F: InternalReadFileFn<C>>(
-            ctx: *mut c_void,
-            bytes: read_file::ReadFileResultType,
-        ) -> JsResult<()> {
-            F::call(ctx.cast::<C>(), bytes)
+    fn bytes(&self) -> &[u8] {
+        match self {
+            Part::Borrowed(s) => s,
+            Part::Owned(s) => s,
+            Part::Slice(s) => s.slice(),
+            Part::Buffer(b) => b.byte_slice(),
+            Part::Store(store, range) => &store.shared_view()[range.clone()],
+            Part::ContentType(c) => c.as_slice(),
         }
-        fn cancel<C, F: InternalReadFileFn<C>>(ctx: *mut c_void) {
-            F::cancel(ctx.cast::<C>());
+    }
+}
+
+#[derive(Default)]
+struct Parts<'a> {
+    parts: Vec<Part<'a>>,
+    len: usize,
+}
+
+impl<'a> Parts<'a> {
+    fn reserve(&mut self, additional: usize) {
+        self.parts.reserve(additional);
+    }
+
+    fn push(&mut self, part: Part<'a>) {
+        let n = part.bytes().len();
+        if n == 0 {
+            return;
         }
-        read_file::ReadFileCompletionFns {
-            ctx: ctx.cast::<c_void>(),
-            run: run::<C, F>,
-            cancel: cancel::<C, F>,
+        self.len += n;
+        self.parts.push(part);
+    }
+
+    fn push_static(&mut self, bytes: &'a [u8]) {
+        self.push(Part::Borrowed(bytes));
+    }
+
+    fn push_owned(&mut self, bytes: Box<[u8]>) {
+        self.push(Part::Owned(bytes));
+    }
+
+    fn push_cloned(&mut self, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
         }
+        self.push(Part::Owned(Box::from(bytes)));
+    }
+
+    /// Every piece, concatenated.
+    fn done(self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.len);
+        for part in &self.parts {
+            out.extend_from_slice(part.bytes());
+        }
+        out
     }
 }
 
@@ -3613,7 +3112,7 @@ where
 /// both strictly outlive this struct, so they are stored as plain references
 /// rather than raw pointers.
 struct FormDataContext<'a> {
-    joiner: StringJoiner<'a>,
+    joiner: Parts<'a>,
     boundary: &'a [u8], // borrowed; outlives the joiner
     failed: bool,
     global_this: &'a JSGlobalObject,
@@ -3678,7 +3177,7 @@ fn encode_form_data_component(bytes: &[u8], component: FormDataComponent) -> Opt
     Some(out.into_boxed_slice())
 }
 
-impl FormDataContext<'_> {
+impl<'a> FormDataContext<'a> {
     /// Append the UTF-8 view of a form-data string without copying it: the
     /// borrowed case points into a WTF string owned by the `DOMFormData` being
     /// serialized, which outlives `joiner.done()` in `from_dom_form_data`; an owned slice
@@ -3686,8 +3185,8 @@ impl FormDataContext<'_> {
     /// joiner. `component` selects the spec's newline-normalization and
     /// percent-encoding transforms, which copy when they apply.
     fn push_string_slice(
-        joiner: &mut StringJoiner<'_>,
-        slice: Utf8Bytes,
+        joiner: &mut Parts<'a>,
+        slice: Utf8Bytes<'a>,
         component: FormDataComponent,
     ) {
         if let Some(encoded) = encode_form_data_component(slice.slice(), component) {
@@ -3697,15 +3196,16 @@ impl FormDataContext<'_> {
         match slice {
             // `into_vec` moves the buffer out of an `Owned` slice without copying.
             Utf8Bytes::Owned(_) => joiner.push_owned(slice.into_vec().into_boxed_slice()),
-            // SAFETY: borrowed bytes are owned by the `DOMFormData` being serialized,
+            // Borrowed bytes are owned by the `DOMFormData` being serialized,
             // which outlives `joiner.done()` in `from_dom_form_data`.
-            Utf8Bytes::Borrowed(b) => joiner.push(unsafe { bun_ptr::detach_lifetime(b) }),
+            Utf8Bytes::Borrowed(_) => joiner.push(Part::Slice(slice)),
             // Releases its ref on drop — copy rather than borrow past it.
             Utf8Bytes::Shared(_) => joiner.push_cloned(slice.slice()),
         }
     }
 
-    fn on_entry(&mut self, name: EncodedSlice, entry: FormDataEntry<'_>) {
+    #[allow(clippy::needless_pass_by_value)] // the shape `DOMFormData::for_each` yields
+    fn on_entry(&mut self, name: EncodedSlice<'a>, entry: FormDataEntry<'a>) {
         if self.failed {
             return;
         }
@@ -3732,20 +3232,13 @@ impl FormDataContext<'_> {
                 Self::push_string_slice(joiner, filename.to_utf8(), FormDataComponent::Filename);
                 joiner.push_static(b"\"\r\n");
 
-                // Borrowed from the blob, which the `DOMFormData` keeps alive
-                // past `joiner.done()`.
                 let blob_ct = blob.content_type_slice();
-                let content_type: &[u8] =
-                    if !blob_ct.is_empty() && !strings::contains_any(blob_ct, b"\r\n") {
-                        blob_ct
-                    } else {
-                        b"application/octet-stream"
-                    };
                 joiner.push_static(b"Content-Type: ");
-                // SAFETY: either a `'static` literal or borrowed from the entry's Blob,
-                // which the `DOMFormData` keeps alive past `joiner.done()` in
-                // `from_dom_form_data`.
-                joiner.push(unsafe { bun_ptr::detach_lifetime(content_type) });
+                if !blob_ct.is_empty() && !strings::contains_any(blob_ct, b"\r\n") {
+                    joiner.push(Part::ContentType(blob.content_type.get().clone()));
+                } else {
+                    joiner.push_static(b"application/octet-stream");
+                }
                 joiner.push_static(b"\r\n\r\n");
 
                 if blob.store.get().is_some() {
@@ -3794,10 +3287,7 @@ impl FormDataContext<'_> {
                             }
                         }
                         store::Data::Bytes(_) => {
-                            // SAFETY: borrowed from the blob's store, which the
-                            // `DOMFormData` entry keeps alive until after
-                            // `joiner.done()`.
-                            joiner.push(unsafe { bun_ptr::detach_lifetime(blob.shared_view()) });
+                            joiner.push(Part::of_blob(blob));
                         }
                     }
                 }
@@ -3809,36 +3299,8 @@ impl FormDataContext<'_> {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// getContentType
-// ──────────────────────────────────────────────────────────────────────────
-
-// ──────────────────────────────────────────────────────────────────────────
 // Structured clone serialize / deserialize
 // ──────────────────────────────────────────────────────────────────────────
-
-struct StructuredCloneWriter {
-    ctx: *mut c_void,
-    // JSC host-fn calling convention: codegen `WriteBytesFn` cfg-splits to
-    // `"sysv64"` on Windows-x64, `"C"` elsewhere.
-    impl_: crate::generated_classes::WriteBytesFn,
-}
-
-impl StructuredCloneWriter {
-    fn write(&self, bytes: &[u8]) -> usize {
-        // SAFETY: ctx and impl_ are supplied by C++ SerializedScriptValue and valid
-        // for the duration of on_structured_clone_serialize.
-        unsafe { (self.impl_)(self.ctx, bytes.as_ptr(), bytes.len() as u32) };
-        bytes.len()
-    }
-}
-
-// Implement `bun_io::Write` so `write_int_le` / `write_all` work directly.
-impl bun_io::Write for StructuredCloneWriter {
-    fn write_all(&mut self, bytes: &[u8]) -> bun_io::Result<()> {
-        StructuredCloneWriter::write(self, bytes);
-        Ok(())
-    }
-}
 
 // Only ever called with f64 (Blob.last_modified). A concrete impl
 // because Rust forbids `[u8; size_of::<F>()]`
@@ -3887,16 +3349,14 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
     // Bun.file() keeps its window's end. MAX_SIZE means unknown.
     let mut file_size: Option<u64> = None;
 
-    let blob: *mut Blob = match store_tag {
+    // Until `to_js` at the end, an early return drops `blob` and with it the
+    // store (and payload bytes) it owns.
+    let blob: Blob = match store_tag {
         store::SerializeTag::Bytes => 'bytes: {
             let bytes_len = reader.read_int_le::<u32>()?;
             let bytes = read_slice(reader, bytes_len as usize)?;
 
             let blob = Blob::init(bytes, global_this);
-            // `blob` now owns `bytes` (via its Store when non-empty). If any
-            // of the remaining reads fail before we heap-promote it, Drop on
-            // `blob` releases the store so the payload bytes don't leak.
-            let guard = scopeguard::guard(blob, |mut b| b.deinit());
 
             'versions: {
                 if version == 1 {
@@ -3906,8 +3366,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                 let name_len = reader.read_int_le::<u32>()?;
                 let name = read_slice(reader, name_len as usize)?;
 
-                // ScopeGuard derefs to its inner Blob.
-                if let Some(store) = (*guard).store() {
+                if let Some(store) = blob.store() {
                     if let store::Data::Bytes(bytes_store) = &mut Store::data_mut(store) {
                         // Transfer ownership of the local `name: Vec<u8>` into
                         // `stored_name` (a `Box<[u8]>`); freed by `Bytes::Drop`.
@@ -3921,8 +3380,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                 }
             }
 
-            let blob = scopeguard::ScopeGuard::into_inner(guard);
-            break 'bytes Blob::new(blob);
+            break 'bytes blob;
         }
         store::SerializeTag::File => 'file: {
             use crate::node::types::PathOrFileDescriptorSerializeTag;
@@ -3944,11 +3402,11 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                         return Err(crate::Error::InvalidValue);
                     }
                     let mut path_or_fd = PathOrFileDescriptor::Fd(fd);
-                    break 'file Blob::new(Blob::find_or_create_file_from_path(
+                    break 'file Blob::find_or_create_file_from_path(
                         &mut path_or_fd,
                         global_this,
                         true,
-                    ));
+                    );
                 }
                 PathOrFileDescriptorSerializeTag::Path => {
                     let path_len = reader.read_int_le::<u32>()?;
@@ -3960,25 +3418,12 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                         return Err(crate::Error::InvalidValue);
                     }
                     let mut dest = PathOrFileDescriptor::Path(PathLike::owned(path));
-                    break 'file Blob::new(Blob::find_or_create_file_from_path(
-                        &mut dest,
-                        global_this,
-                        true,
-                    ));
+                    break 'file Blob::find_or_create_file_from_path(&mut dest, global_this, true);
                 }
             }
         }
-        store::SerializeTag::Empty => Blob::new(Blob::init_empty(global_this)),
+        store::SerializeTag::Empty => Blob::init_empty(global_this),
     };
-    // `blob` is heap-allocated past this point; on any remaining error
-    // (truncated trailer fields) tear down both the heap object and its
-    // store. `content_type` is handled by its own Drop above since it
-    // hasn't been attached to `blob` yet.
-    // SAFETY: blob is a freshly-allocated heap pointer from Blob::new.
-    let blob_guard = scopeguard::guard(blob, |b| unsafe { (*b).deinit() });
-    // SAFETY: `blob_guard` holds the sole pointer to the fresh heap allocation.
-    // Shared access only — Blob state is Cell/JsCell-based.
-    let blob = unsafe { &**blob_guard };
 
     'versions: {
         if version == 1 {
@@ -4003,11 +3448,6 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
             break 'versions;
         }
     }
-
-    debug_assert!(
-        blob.is_heap_allocated(),
-        "expected blob to be heap-allocated"
-    );
 
     // `offset` comes from untrusted bytes. Clamp it so a crafted payload cannot
     // make shared_view() slice past the end of the backing store (OOB heap read).
@@ -4035,11 +3475,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
         blob.content_type_was_set.set(content_type_was_set);
     }
 
-    let blob_ptr = scopeguard::ScopeGuard::into_inner(blob_guard);
-    // SAFETY: blob_ptr is valid; to_js is infallible. Spelled
-    // `BlobExt::to_js(&*blob_ptr, ..)` to pick the `&self` impl over the
-    // by-value `JsClass::to_js`.
-    Ok(unsafe { BlobExt::to_js(&*blob_ptr, global_this) })
+    Ok(blob.to_js(global_this))
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -4060,31 +3496,31 @@ impl URLSearchParamsConverter {
 // C-exported helpers
 // ──────────────────────────────────────────────────────────────────────────
 
-#[unsafe(no_mangle)]
-pub(crate) extern "C" fn Blob__dupeFromJS(value: JSValue) -> Option<NonNull<Blob>> {
-    let this = Blob::from_js(value)?;
-    // SAFETY: `from_js` returns a live heap pointer when Some.
-    Some(
-        NonNull::new(Blob__dupe(unsafe { &*this }))
-            .expect("Blob__dupe returns a fresh heap allocation"),
-    )
+/// A new heap `Blob` sharing `value`'s store, or null if `value` is not a `Blob`.
+// HOST_EXPORT(Blob__dupeFromJS, c)
+pub fn blob_dupe_from_js(value: JSValue) -> *mut crate::webcore::Blob {
+    match value.as_class_ref::<Blob>() {
+        Some(blob) => blob_dupe(blob),
+        None => core::ptr::null_mut(),
+    }
 }
 
-#[unsafe(no_mangle)]
-pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &BunString) {
+// HOST_EXPORT(Blob__setAsFile, c)
+pub fn blob_set_as_file(this: &crate::webcore::Blob, path_str: &bun_core::String) {
     this.is_jsdom_file.set(true);
     if !path_str.is_empty() && this.get_file_name().is_none() {
         this.name.set(path_str.clone());
     }
 }
 
-#[unsafe(no_mangle)]
-pub(crate) extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
+/// A new heap `Blob` (refcount 1, for C++ to adopt) sharing `this`'s store.
+// HOST_EXPORT(Blob__dupe, c)
+pub fn blob_dupe(this: &crate::webcore::Blob) -> *mut crate::webcore::Blob {
     Blob::new(this.dupe_with_content_type(true))
 }
 
-#[unsafe(no_mangle)]
-pub(crate) extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
+// HOST_EXPORT(Blob__getFileNameString, c)
+pub fn blob_get_file_name_string(this: &crate::webcore::Blob) -> BunString {
     this.get_name_string()
         .map_or(BunString::EMPTY, Clone::clone)
 }
@@ -4143,6 +3579,7 @@ pub(crate) fn mkdirp_parent(path: &[u8]) -> bun_sys::Result<()> {
 
 // TODO: move this to bun_sys?
 #[inline(never)]
+#[cfg_attr(windows, allow(dead_code))] // the Windows writers mkdirp through `AsyncMkdirp`
 pub(crate) fn mkdir_if_not_exists<T: MkdirpTarget>(
     this: &mut T,
     err: &bun_sys::Error,
@@ -4219,20 +3656,12 @@ fn write_file_with_empty_source_to_destination(
     destination_blob: &mut Blob,
     options: &WriteFileOptions,
 ) -> JsResult<JSValue> {
-    // SAFETY: null-checked by caller
     let destination_store = destination_blob
         .store()
         .expect("infallible: store present")
         .clone();
-    // `scopeguard::guard(&mut *destination_blob, …)` would hold an
-    // exclusive borrow for the entire function, blocking the immut reads below
-    // (`content_type_or_mime_type`). Capture a raw pointer instead — the
-    // `&mut Blob` parameter outlives this stack frame, and the closure runs
-    // strictly after every other use of `destination_blob` here.
-    let dest_ptr: *mut Blob = destination_blob;
-    // SAFETY: `dest_ptr` derives from the caller's `&mut Blob`; deref'd only on
-    // scope exit, after all other borrows in this function have ended.
-    let _detach = scopeguard::guard((), move |_| unsafe { (*dest_ptr).detach() });
+    let destination_blob = &*destination_blob;
+    let _detach = scopeguard::guard((), |_| destination_blob.detach());
 
     match &destination_store.data {
         store::Data::File(file) => {
@@ -4298,7 +3727,7 @@ fn write_file_with_empty_source_to_destination(
                                     break 'err;
                                 }
 
-                                // SAFETY: we check if `file.pathlike` is an fd above, returning if it is.
+                                // `file.pathlike` is a path: the fd case returned above.
                                 let mut buf = bun_paths::path_buffer_pool::get();
                                 let mode: bun_sys::Mode =
                                     options.mode.unwrap_or(node::fs::DEFAULT_PERMISSION);
@@ -4338,36 +3767,26 @@ fn write_file_with_empty_source_to_destination(
                 }
             };
 
-            struct Wrapper {
-                promise: jsc::JSPromiseStrong,
-                store: RefPtr<Store>,
-                global: bun_ptr::BackRef<JSGlobalObject>,
-            }
-            impl Wrapper {
-                fn resolve(result: S3UploadResult, opaque_this: *mut c_void) -> JsResult<()> {
-                    // SAFETY: opaque_this was heap-allocated in the caller below.
-                    let mut this = unsafe { bun_core::heap::take(opaque_this.cast::<Wrapper>()) };
-                    let global = this.global.get();
-                    match result {
-                        S3UploadResult::Success => {
-                            this.promise.resolve(global, JSValue::js_number(0.0))?
-                        }
-                        S3UploadResult::Failure(err) => {
-                            let err_js = s3_client::error_jsc::s3_error_to_js_with_async_stack(
-                                &err,
-                                global,
-                                this.store.get_path(),
-                                this.promise.get(),
-                            );
-                            this.promise.reject(global, Ok(err_js))?;
-                        }
-                    }
-                    Ok(())
-                }
-            }
-
-            let promise = jsc::JSPromiseStrong::init(ctx);
+            let mut promise = jsc::JSPromiseStrong::init(ctx);
             let promise_value = promise.value();
+            let store = destination_store.clone();
+            let global = bun_ptr::BackRef::new(ctx);
+            let resolve = move |result: S3UploadResult<'_>| -> JsResult<()> {
+                let global = global.get();
+                match result {
+                    S3UploadResult::Success => promise.resolve(global, JSValue::js_number(0.0))?,
+                    S3UploadResult::Failure(err) => {
+                        let err_js = s3_client::error_jsc::s3_error_to_js_with_async_stack(
+                            &err,
+                            global,
+                            store.get_path(),
+                            promise.get(),
+                        );
+                        promise.reject(global, Ok(err_js))?;
+                    }
+                }
+                Ok(())
+            };
             let proxy_owned = http_proxy_href(ctx);
             let proxy_url = proxy_owned.as_deref();
             s3_client::upload(
@@ -4381,13 +3800,7 @@ fn write_file_with_empty_source_to_destination(
                 proxy_url,
                 aws_options.storage_class,
                 aws_options.request_payer,
-                Wrapper::resolve,
-                bun_core::heap::into_raw(Box::new(Wrapper {
-                    promise,
-                    store: destination_store.clone(),
-                    global: bun_ptr::BackRef::new(ctx),
-                }))
-                .cast::<c_void>(),
+                Box::new(resolve),
             )?;
             return Ok(promise_value);
         }
@@ -4511,13 +3924,8 @@ pub(crate) fn write_file_with_source_destination(
         // If this is bytes <> bytes, we can just duplicate it
         // this is an edgecase
         // it will happen if someone did Bun.write(new Blob([123]), new Blob([456]))
-        let cloned = Blob::new(source_blob.dupe());
-        // SAFETY: `cloned` was just produced by heap::alloc in Blob::new;
-        // `BlobExt::to_js(&self)` (not the by-value `JsClass` one) hands
-        // ownership to the C++ wrapper.
-        return Ok(JSPromise::resolved_promise_value(ctx, unsafe {
-            BlobExt::to_js(&*cloned, ctx)
-        }));
+        let cloned = source_blob.dupe().to_js(ctx);
+        return Ok(JSPromise::resolved_promise_value(ctx, cloned));
     } else if destination_type == store::DataTag::Bytes
         && (source_type == store::DataTag::File || source_type == store::DataTag::S3)
     {
@@ -4574,43 +3982,31 @@ pub(crate) fn write_file_with_source_destination(
                         .to_js());
                     }
                 } else {
-                    struct Wrapper {
-                        store: RefPtr<Store>,
-                        promise: jsc::JSPromiseStrong,
-                        global: bun_ptr::BackRef<JSGlobalObject>,
-                    }
-                    impl Wrapper {
-                        fn resolve(
-                            result: S3UploadResult,
-                            opaque_self: *mut c_void,
-                        ) -> JsResult<()> {
-                            // SAFETY: opaque_self is the heap::alloc(Wrapper) we passed to S3::upload below.
-                            let mut this =
-                                unsafe { bun_core::heap::take(opaque_self.cast::<Wrapper>()) };
-                            let global = this.global.get();
-                            match result {
-                                S3UploadResult::Success => {
-                                    this.promise.resolve(
-                                        global,
-                                        JSValue::js_number(this.store.data.as_bytes().len() as f64),
-                                    )?;
-                                }
-                                S3UploadResult::Failure(err) => {
-                                    let err_js =
-                                        s3_client::error_jsc::s3_error_to_js_with_async_stack(
-                                            &err,
-                                            global,
-                                            this.store.get_path(),
-                                            this.promise.get(),
-                                        );
-                                    this.promise.reject(global, Ok(err_js))?;
-                                }
-                            }
-                            Ok(())
-                        }
-                    }
-                    let promise = jsc::JSPromiseStrong::init(ctx);
+                    let mut promise = jsc::JSPromiseStrong::init(ctx);
                     let promise_value = promise.value();
+                    let store = source_store.clone();
+                    let global = bun_ptr::BackRef::new(ctx);
+                    let resolve = move |result: S3UploadResult<'_>| -> JsResult<()> {
+                        let global = global.get();
+                        match result {
+                            S3UploadResult::Success => {
+                                promise.resolve(
+                                    global,
+                                    JSValue::js_number(store.data.as_bytes().len() as f64),
+                                )?;
+                            }
+                            S3UploadResult::Failure(err) => {
+                                let err_js = s3_client::error_jsc::s3_error_to_js_with_async_stack(
+                                    &err,
+                                    global,
+                                    store.get_path(),
+                                    promise.get(),
+                                );
+                                promise.reject(global, Ok(err_js))?;
+                            }
+                        }
+                        Ok(())
+                    };
                     s3_client::upload(
                         &aws_options.credentials,
                         s3.path(),
@@ -4622,13 +4018,7 @@ pub(crate) fn write_file_with_source_destination(
                         proxy_url,
                         aws_options.storage_class,
                         aws_options.request_payer,
-                        Wrapper::resolve,
-                        bun_core::heap::into_raw(Box::new(Wrapper {
-                            store: source_store.clone(),
-                            promise,
-                            global: bun_ptr::BackRef::new(ctx),
-                        }))
-                        .cast::<c_void>(),
+                        Box::new(resolve),
                     )?;
                     return Ok(promise_value);
                 }
@@ -4836,11 +4226,15 @@ pub(crate) fn write_file_internal(
     // TODO: implement a writev() fast path
     let source_blob: Blob = 'brk: {
         // `Response` and `Request` both expose `get_body_value()` /
-        // `get_body_readable_stream()`; one helper takes the
-        // body-value pointer and a `get_stream` closure.
-        let mut body_dispatch = |body_value: *mut webcore::body::Value,
-                                 get_stream: &mut dyn FnMut() -> Option<ReadableStream>|
-         -> JsResult<core::ops::ControlFlow<JSValue, Blob>> {
+        // `get_body_readable_stream()` (`BodyMixin`). Every body borrow below
+        // is re-derived and scoped so none spans the JS-running calls in the
+        // arms.
+        fn body_dispatch<B: webcore::body::BodyMixin>(
+            body: &B,
+            destination_blob: &mut Blob,
+            global_this: &JSGlobalObject,
+            options: &WriteFileOptions,
+        ) -> JsResult<core::ops::ControlFlow<JSValue, Blob>> {
             use core::ops::ControlFlow;
             use webcore::body::Value as BodyValue;
             enum BodyTag {
@@ -4848,17 +4242,13 @@ pub(crate) fn write_file_internal(
                 Error,
                 Locked,
             }
-            // `body_value` is `&mut Body::Value` from a live JS heap
-            // Response/Request `m_ctx`, held raw so every borrow below is
-            // scoped and none spans the JS-running calls in the arms.
             // A stream someone holds a reader on, or has read from, is theirs.
-            let existing = get_stream().or_else(|| {
-                // SAFETY: scoped exclusive borrow; runs no JS.
-                match unsafe { &mut *body_value } {
-                    BodyValue::Locked(locked) => locked.readable.get(),
-                    _ => None,
-                }
-            });
+            let existing =
+                body.get_body_readable_stream()
+                    .or_else(|| match body.get_body_value() {
+                        BodyValue::Locked(locked) => locked.readable.get(),
+                        _ => None,
+                    });
             if let Some(readable) = existing {
                 if readable.is_locked(global_this) || readable.is_disturbed(global_this) {
                     destination_blob.detach();
@@ -4866,10 +4256,8 @@ pub(crate) fn write_file_internal(
                 }
             }
             // A body that is all here (also behind an untouched `.body` stream) is written as a blob.
-            // SAFETY: scoped exclusive borrow; runs no JS.
-            unsafe { (*body_value).to_blob_if_possible() };
-            // SAFETY: scoped shared read of the variant tag.
-            let tag = match unsafe { &*body_value } {
+            body.get_body_value().to_blob_if_possible();
+            let tag = match body.get_body_value() {
                 BodyValue::Error(_) => BodyTag::Error,
                 BodyValue::Locked(_) => BodyTag::Locked,
                 BodyValue::Used => {
@@ -4880,21 +4268,18 @@ pub(crate) fn write_file_internal(
             };
             match tag {
                 BodyTag::Use => {
-                    // SAFETY: exclusive borrow scoped to the call; `use_()` runs no JS.
-                    Ok(ControlFlow::Continue(unsafe { (*body_value).use_() }))
+                    // `use_()` runs no JS.
+                    Ok(ControlFlow::Continue(body.get_body_value().use_()))
                 }
                 BodyTag::Error => {
                     let err_js = {
-                        // SAFETY: exclusive borrow; ends before `use_()` below.
-                        let BodyValue::Error(err_ref) = (unsafe { &mut *body_value }) else {
+                        let BodyValue::Error(err_ref) = body.get_body_value() else {
                             unreachable!()
                         };
                         err_ref.to_js(global_this)
                     };
                     destination_blob.detach();
-                    // SAFETY: exclusive borrow scoped to the call; no other
-                    // borrow of the body value is live.
-                    let _ = unsafe { (*body_value).use_() };
+                    let _ = body.get_body_value().use_();
                     Ok(ControlFlow::Break(
                         JSPromise::rejected_promise(global_this, err_js).to_js(),
                     ))
@@ -4908,11 +4293,10 @@ pub(crate) fn write_file_internal(
                         let s3 = dest_store.data.as_s3();
                         let aws_options =
                             s3.get_credentials_with_options(options.extra_options, global_this)?;
-                        // SAFETY: exclusive borrow scoped to the call (may run JS).
-                        let _ = unsafe { (*body_value).to_readable_stream(global_this) }?;
-                        let readable_opt = get_stream().or_else(|| {
-                            // SAFETY: re-borrow after `to_readable_stream`.
-                            let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
+                        // May run JS.
+                        let _ = body.get_body_value().to_readable_stream(global_this)?;
+                        let readable_opt = body.get_body_readable_stream().or_else(|| {
+                            let BodyValue::Locked(locked) = body.get_body_value() else {
                                 return None;
                             };
                             locked.readable.get()
@@ -4955,30 +4339,29 @@ pub(crate) fn write_file_internal(
                     // A body that is a stream, or that its producer can stream (fetch, the
                     // server, HTMLRewriter): pipe it into the file instead of collecting it in
                     // memory first. The stream also outlives the Response it came from.
-                    let streamable = get_stream().is_some() || {
-                        // SAFETY: scoped exclusive borrow; runs no JS.
-                        let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
+                    let streamable = body.get_body_readable_stream().is_some() || {
+                        let BodyValue::Locked(locked) = body.get_body_value() else {
                             unreachable!()
                         };
                         locked.readable.has() || locked.on_start_streaming.is_some()
                     };
                     if streamable {
-                        // SAFETY: exclusive borrow scoped to the call (may run JS).
-                        let _ = unsafe { (*body_value).to_readable_stream(global_this) }?;
-                        let readable = get_stream().or_else(|| {
-                            // SAFETY: re-borrow after `to_readable_stream`.
-                            let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
+                        // May run JS.
+                        let _ = body.get_body_value().to_readable_stream(global_this)?;
+                        let readable = body.get_body_readable_stream().or_else(|| {
+                            let BodyValue::Locked(locked) = body.get_body_value() else {
                                 return None;
                             };
                             locked.readable.get()
                         });
-                        // SAFETY: scoped; `to_readable_stream` may have replaced the value.
-                        let body = unsafe { &*body_value };
-                        if let (Some(readable), BodyValue::Locked(_)) = (readable, body) {
+                        // `to_readable_stream` may have replaced the value.
+                        if let (Some(readable), BodyValue::Locked(_)) =
+                            (readable, body.get_body_value())
+                        {
                             let promise = destination_blob.pipe_readable_stream_to_blob(
                                 global_this,
                                 readable,
-                                &options,
+                                options,
                             )?;
                             // The destination could not be opened: the stream was not touched and
                             // is still the body's.
@@ -4986,70 +4369,60 @@ pub(crate) fn write_file_internal(
                                 matches!(p.status(), jsc::js_promise::Status::Rejected)
                             });
                             if !failed {
-                                // SAFETY: scoped exclusive write; the stream now belongs to the sink.
-                                unsafe { *body_value = BodyValue::Used };
+                                // The stream now belongs to the sink.
+                                *body.get_body_value() = BodyValue::Used;
                             }
                             return Ok(ControlFlow::Break(promise));
                         }
                         // The producer settled the body while the stream was being made.
-                        // SAFETY: scoped borrows, as in the arms above.
-                        match unsafe { &mut *body_value } {
+                        match body.get_body_value() {
                             BodyValue::Locked(_) => {}
                             BodyValue::Error(err) => {
                                 let err_js = err.to_js(global_this);
                                 destination_blob.detach();
-                                // SAFETY: `err` is not used after `to_js`, so this is the only
-                                // live borrow of the value.
-                                let _ = unsafe { (*body_value).use_() };
+                                let _ = body.get_body_value().use_();
                                 return Ok(ControlFlow::Break(
                                     JSPromise::rejected_promise(global_this, err_js).to_js(),
                                 ));
                             }
-                            // SAFETY: the match borrow ended with the pattern; no other borrow is live.
-                            _ => return Ok(ControlFlow::Continue(unsafe { (*body_value).use_() })),
+                            _ => return Ok(ControlFlow::Continue(body.get_body_value().use_())),
                         }
                     }
                     let task = Box::new(WriteFileWaitFromLockedValueTask {
                         global_this: bun_ptr::BackRef::new(global_this),
                         // Move `destination_blob` by value into the task.
                         file_blob: core::mem::replace(
-                            &mut destination_blob,
+                            destination_blob,
                             Blob::init_empty(global_this),
                         ),
                         promise: jsc::JSPromiseStrong::init(global_this),
                         mkdirp_if_not_exists: options.mkdirp_if_not_exists.unwrap_or(true),
                     });
                     let promise = task.promise.value();
-                    // SAFETY: re-borrow after the early-return paths.
-                    let BodyValue::Locked(locked) = (unsafe { &mut *body_value }) else {
+                    let BodyValue::Locked(locked) = body.get_body_value() else {
                         unreachable!()
                     };
                     let producer_hook = locked.on_start_buffering.take().zip(locked.task);
                     locked.on_receive_value = Some(webcore::body::ReceiveValue::WriteFile(task));
                     // Signalled last (see `PendingValue::on_start_buffering`):
-                    // the task may run and `*body_value` be replaced inside.
+                    // the task may run and the body value be replaced inside.
                     if let Some((on_start_buffering, producer_task)) = producer_hook {
                         on_start_buffering(producer_task);
                     }
                     Ok(ControlFlow::Break(promise))
                 }
             }
-        };
+        }
 
-        // `as_class_ref` is the safe shared-borrow downcast (one audited unsafe
-        // in `JSValue`); `get_body_value` / `get_body_readable_stream` both
-        // take `&self` (interior mutability for the body cell).
         if let Some(response) = data.as_class_ref::<Response>() {
-            let bv = std::ptr::from_mut(response.get_body_value());
-            match body_dispatch(bv, &mut || response.get_body_readable_stream())? {
+            match body_dispatch(response, &mut destination_blob, global_this, &options)? {
                 core::ops::ControlFlow::Break(v) => return Ok(v),
                 core::ops::ControlFlow::Continue(b) => break 'brk b,
             }
         }
 
         if let Some(request) = data.as_class_ref::<Request>() {
-            let bv = std::ptr::from_mut(request.get_body_value());
-            match body_dispatch(bv, &mut || request.get_body_readable_stream())? {
+            match body_dispatch(request, &mut destination_blob, global_this, &options)? {
                 core::ops::ControlFlow::Break(v) => return Ok(v),
                 core::ops::ControlFlow::Continue(b) => break 'brk b,
             }
@@ -5138,7 +4511,6 @@ fn set_content_type_from_js(
 /// `Bun.write(destination, input, options?)`
 pub(crate) fn write_file(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
     let arguments = callframe.arguments();
-    // SAFETY: `bun_vm()` returns a live VM pointer for the calling JS context.
     let mut args = jsc::ArgumentsSlice::init(global_this.bun_vm(), arguments);
 
     let mut path_or_blob = write_destination_from_js(global_this, &mut args)?;
@@ -5357,12 +4729,6 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
     }
 
     if truncate {
-        #[cfg(windows)]
-        // SAFETY: fd is a valid open handle on this code path; FFI call.
-        unsafe {
-            bun_sys::windows::kernel32::SetEndOfFile(fd.native())
-        };
-        #[cfg(not(windows))]
         let _ = bun_sys::ftruncate(fd, i64::try_from(written).expect("int cast"));
     }
 
@@ -5373,25 +4739,23 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
 // JSDOMFile constructor
 // ──────────────────────────────────────────────────────────────────────────
 
-// C++ side declares `extern "C" SYSV_ABI void* JSDOMFile__construct(...)` (JSDOMFile.cpp).
-bun_jsc::jsc_host_abi! {
-    #[unsafe(no_mangle)]
-    pub unsafe fn JSDOMFile__construct(
-        global_this: &JSGlobalObject,
-        callframe: &CallFrame,
-    ) -> Option<NonNull<Blob>> {
-        match jsdom_file_construct(global_this, callframe) {
-            Ok(b) => Some(NonNull::new(b).expect("jsdom_file_construct returns Blob::new (heap::alloc)")),
-            Err(jsc::JsError::Thrown) => None,
-            Err(jsc::JsError::Terminated) => {
-                // A constructor runs beneath script: rethrow so the caller keeps unwinding.
-                let _ = bun_jsc::Stopped.throw(global_this);
-                None
-            }
-            Err(jsc::JsError::OutOfMemory) => {
-                let _ = global_this.throw_out_of_memory();
-                None
-            }
+/// C++ side declares `extern "C" SYSV_ABI void* JSDOMFile__construct(...)` (JSDOMFile.cpp).
+// HOST_EXPORT(JSDOMFile__construct, jsc)
+pub fn jsdom_file_construct_export(
+    global_this: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> *mut crate::webcore::Blob {
+    match jsdom_file_construct(global_this, callframe) {
+        Ok(b) => b,
+        Err(jsc::JsError::Thrown) => core::ptr::null_mut(),
+        Err(jsc::JsError::Terminated) => {
+            // A constructor runs beneath script: rethrow so the caller keeps unwinding.
+            let _ = bun_jsc::Stopped.throw(global_this);
+            core::ptr::null_mut()
+        }
+        Err(jsc::JsError::OutOfMemory) => {
+            let _ = global_this.throw_out_of_memory();
+            core::ptr::null_mut()
         }
     }
 }
@@ -5461,10 +4825,8 @@ pub(crate) fn jsdom_file_construct(
         blob.content_type_was_set.set(false);
     }
 
-    let blob_ = Blob::new(blob);
-    // SAFETY: ptr was just produced by heap::alloc in Blob::new.
-    unsafe { (*blob_).is_jsdom_file.set(true) };
-    Ok(blob_)
+    blob.is_jsdom_file.set(true);
+    Ok(Blob::new(blob))
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -5478,7 +4840,6 @@ pub(crate) fn construct_bun_file(
     global_object: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
-    // SAFETY: bun_vm() never returns null for a Bun-owned global.
     let vm = global_object.bun_vm();
     let arguments_slice = callframe.arguments();
     let mut args = jsc::ArgumentsSlice::init(vm, arguments_slice);
@@ -5530,11 +4891,7 @@ pub(crate) fn construct_bun_file(
         }
     }
 
-    let ptr = Blob::new(blob);
-    // SAFETY: ptr was just produced by heap::alloc in Blob::new. Spelled
-    // `BlobExt::to_js(&*ptr, ..)` to pick the `&self` impl over the by-value
-    // `JsClass::to_js`.
-    Ok(unsafe { BlobExt::to_js(&*ptr, global_object) })
+    Ok(blob.to_js(global_object))
 }
 
 // `find_or_create_file_from_path`: canonical impl lives later in this file
@@ -5562,11 +4919,13 @@ struct S3BlobDownloadTask {
     pub(crate) handler: S3ReadHandler,
 }
 
-type S3ReadHandler = fn(&Blob, bun_ptr::BackRef<JSGlobalObject>, &mut [u8]) -> JSValue;
+/// `(blob, global, bytes)`: `bytes` is the window of `blob`'s freshly
+/// installed store holding the download.
+type S3ReadHandler = fn(&Blob, bun_ptr::BackRef<JSGlobalObject>, Range<usize>) -> JSValue;
 
 impl S3BlobDownloadTask {
-    pub(crate) fn call_handler(&mut self, raw_bytes: &mut [u8]) -> JSValue {
-        (self.handler)(&self.blob, self.global_this, raw_bytes)
+    pub(crate) fn call_handler(&mut self, bytes: Range<usize>) -> JSValue {
+        (self.handler)(&self.blob, self.global_this, bytes)
     }
 
     #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
@@ -5582,19 +4941,13 @@ impl S3BlobDownloadTask {
             crate::webcore::__s3_client::S3DownloadResult::Success(response) => {
                 // Move the downloaded body into a Blob store so its lifetime is
                 // tied to the Blob/JS view and freed via the store's finalizer.
+                let len = response.body.list.len();
                 let store = Store::init(response.body.list);
-                let bytes: *mut [u8] = match Store::data_mut(&store) {
-                    store::Data::Bytes(b) => std::ptr::from_mut(b.as_array_list()),
-                    _ => unreachable!(),
-                };
                 this.blob.store.set(Some(store));
                 if this.blob.size.get() == MAX_SIZE {
-                    this.blob.size.set(bytes.len() as SizeType);
+                    this.blob.size.set(len as SizeType);
                 }
-                // SAFETY: `bytes` points into the byte store just installed on
-                // `this.blob.store`; the store outlives this call.
-                let value =
-                    JSPromise::wrap(global, |_g| Ok(this.call_handler(unsafe { &mut *bytes })))?;
+                let value = JSPromise::wrap(global, |_g| Ok(this.call_handler(0..len)))?;
                 this.promise.resolve(global, value)?;
             }
             crate::webcore::__s3_client::S3DownloadResult::NotFound(err)
@@ -5618,25 +4971,23 @@ impl S3BlobDownloadTask {
         // The callback may read this.blob.content_type, which is heap-owned by the
         // source JS Blob and freed on finalize(). Take an owning dupe so the task
         // outliving the source can't dangle.
-        let this = bun_core::heap::into_raw(Box::new(S3BlobDownloadTask {
+        let mut this = Box::new(S3BlobDownloadTask {
             global_this: bun_ptr::BackRef::new(global_this),
             blob: Blob::dupe(blob),
             promise: jsc::JSPromiseStrong::init(global_this),
             poll_ref: bun_io::KeepAlive::default(),
             handler,
-        }));
-        // SAFETY: just allocated; sole pointer until handed to the s3 callback
-        // below. Exclusive access scoped to the call.
-        unsafe { (*this).poll_ref.ref_(bun_io::js_vm_ctx()) };
-        // SAFETY: as above; shared access only from here on.
-        let this_ref = unsafe { &*this };
-        let promise = this_ref.promise.value();
-        let store::Data::S3(s3_store) = &this_ref
+        });
+        this.poll_ref.ref_(bun_io::js_vm_ctx());
+        let promise = this.promise.value();
+        // The task moves into the download's completion, so read what the
+        // request needs out of its blob's store (a fresh +1 ref) first.
+        let store = this
             .blob
             .store()
             .expect("infallible: store present")
-            .data
-        else {
+            .clone();
+        let store::Data::S3(s3_store) = &store.data else {
             unreachable!("S3BlobDownloadTask::init on non-S3 blob")
         };
         let credentials = s3_store.get_credentials();
@@ -5645,14 +4996,11 @@ impl S3BlobDownloadTask {
         let proxy_owned = http_proxy_href(global_this);
         let proxy = proxy_owned.as_deref();
 
-        fn s3_cb(
-            result: crate::webcore::__s3_client::S3DownloadResult<'_>,
-            ctx: *mut c_void,
-        ) -> JsResult<()> {
-            // SAFETY: `ctx` is the box leaked in `init()`; the download callback fires once.
-            let task = unsafe { bun_core::heap::take(ctx.cast::<S3BlobDownloadTask>()) };
-            S3BlobDownloadTask::on_s3_download_resolved(result, task)
-        }
+        let s3_cb = Box::new(
+            move |result: crate::webcore::__s3_client::S3DownloadResult<'_>| {
+                S3BlobDownloadTask::on_s3_download_resolved(result, this)
+            },
+        );
 
         if blob.offset.get() > 0 {
             let len: Option<usize> = if blob.size.get() != MAX_SIZE {
@@ -5667,7 +5015,6 @@ impl S3BlobDownloadTask {
                 offset,
                 len,
                 s3_cb,
-                this.cast::<c_void>(),
                 proxy,
                 s3_store.request_payer,
             )?;
@@ -5676,7 +5023,6 @@ impl S3BlobDownloadTask {
                 credentials,
                 path,
                 s3_cb,
-                this.cast::<c_void>(),
                 proxy,
                 s3_store.request_payer,
             )?;
@@ -5689,7 +5035,6 @@ impl S3BlobDownloadTask {
                 offset,
                 Some(len),
                 s3_cb,
-                this.cast::<c_void>(),
                 proxy,
                 s3_store.request_payer,
             )?;
@@ -5714,7 +5059,7 @@ impl Drop for S3BlobDownloadTask {
 // FileStreamWrapper / pipeReadableStreamToBlob
 // ──────────────────────────────────────────────────────────────────────────
 
-struct FileStreamWrapper {
+pub struct FileStreamWrapper {
     pub(crate) promise: jsc::JSPromiseStrong,
     pub(crate) readable_stream_ref: webcore::readable_stream::ReadableStreamStrong,
     /// Kept alive by the pump ref `pipe_readable_stream_to_blob` parked in the
@@ -5728,15 +5073,16 @@ impl Drop for FileStreamWrapper {
     }
 }
 
-pub(crate) fn on_file_stream_resolve_request_stream(
+// C++ `promiseHandlerID` compares the handler passed to `JSValue::then` against
+// these symbols by address, so they must stay function exports. The box comes
+// back from the reaction pair; dropping it releases the pump's sink ref.
+// HOST_EXPORT(Bun__FileStreamWrapper__onResolveRequestStream, jsc)
+#[allow(clippy::boxed_local)] // the reaction hands the box back; dropping it releases the sink ref
+pub fn on_file_stream_resolve_request_stream(
+    mut this: Box<crate::webcore::blob::FileStreamWrapper>,
     global_this: &JSGlobalObject,
-    callframe: &CallFrame,
+    _callframe: &CallFrame,
 ) -> JsResult<JSValue> {
-    let args = callframe.arguments();
-    // SAFETY: last arg is a promise-ptr created by FileStreamWrapper::new in pipe_readable_stream_to_blob.
-    let mut this: Box<FileStreamWrapper> = unsafe {
-        bun_core::heap::take(args[args.len() - 1].as_number() as usize as *mut FileStreamWrapper)
-    };
     let strong = core::mem::take(&mut this.readable_stream_ref);
     if let Some(stream) = strong.get() {
         stream.done();
@@ -5747,18 +5093,14 @@ pub(crate) fn on_file_stream_resolve_request_stream(
     Ok(JSValue::UNDEFINED)
 }
 
-pub(crate) fn on_file_stream_reject_request_stream(
+// HOST_EXPORT(Bun__FileStreamWrapper__onRejectRequestStream, jsc)
+#[allow(clippy::boxed_local)]
+pub fn on_file_stream_reject_request_stream(
+    mut this: Box<crate::webcore::blob::FileStreamWrapper>,
     global_this: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
     let args = callframe.arguments();
-    // Take ownership via Box so Drop releases the sink's pump ref
-    // and frees the wrapper.
-    // SAFETY: the trailing argument is the `FileStreamWrapper*` boxed and passed
-    // through `then()` from the resolve path; we are the sole consumer here.
-    let mut this: Box<FileStreamWrapper> = unsafe {
-        bun_core::heap::take(args[args.len() - 1].as_number() as usize as *mut FileStreamWrapper)
-    };
     let err = args[0];
 
     let strong = core::mem::take(&mut this.readable_stream_ref);
@@ -5771,162 +5113,34 @@ pub(crate) fn on_file_stream_reject_request_stream(
     Ok(JSValue::UNDEFINED)
 }
 
-// C-ABI shims for `JSValue::then`. The Rust-side
-// host fns above are `JSHostFnZig`; `then()` wants the raw `JSHostFn` shape.
-// Exported under the legacy symbol names so C++ (`BunPromiseInlines.h`) links
-// the same symbol it does today.
-bun_jsc::jsc_host_abi! {
-    #[unsafe(export_name = "Bun__FileStreamWrapper__onResolveRequestStream")]
-    unsafe fn on_file_stream_resolve_request_stream_shim(
-        global: *mut JSGlobalObject,
-        callframe: *mut CallFrame,
-    ) -> JSValue {
-        // S008: `JSGlobalObject`/`CallFrame` are `opaque_ffi!` ZST handles —
-        // safe `*mut → &` via `opaque_deref` (JSC guarantees non-null/live).
-        let (global, callframe) =
-            (bun_opaque::opaque_deref(global), bun_opaque::opaque_deref(callframe));
-        bun_jsc::host_fn::to_js_host_fn_result(global, on_file_stream_resolve_request_stream(global, callframe))
-    }
-}
-bun_jsc::jsc_host_abi! {
-    #[unsafe(export_name = "Bun__FileStreamWrapper__onRejectRequestStream")]
-    unsafe fn on_file_stream_reject_request_stream_shim(
-        global: *mut JSGlobalObject,
-        callframe: *mut CallFrame,
-    ) -> JSValue {
-        // S008: `JSGlobalObject`/`CallFrame` are `opaque_ffi!` ZST handles —
-        // safe `*mut → &` via `opaque_deref` (JSC guarantees non-null/live).
-        let (global, callframe) =
-            (bun_opaque::opaque_deref(global), bun_opaque::opaque_deref(callframe));
-        bun_jsc::host_fn::to_js_host_fn_result(global, on_file_stream_reject_request_stream(global, callframe))
-    }
-}
-
-// the local `AnyPromiseResultExt` shim was removed —
-// `bun_jsc::AnyPromise::result` is an inherent method (and `JSInternalPromise`
-// is a transparent alias for `JSPromise`), so the `.result(vm)` call below
-// resolves directly upstream.
-
 // ──────────────────────────────────────────────────────────────────────────
 // getSliceFrom / getSlice / type/name/lastModified/size getters
 // ──────────────────────────────────────────────────────────────────────────
 
-#[unsafe(no_mangle)]
-pub(crate) extern "C" fn Bun__Blob__getSizeForBindings(this: &mut Blob) -> u64 {
+// HOST_EXPORT(Bun__Blob__getSizeForBindings, c)
+pub fn blob_get_size_for_bindings(this: &crate::webcore::Blob) -> u64 {
     this.get_size_for_bindings()
 }
 
-#[unsafe(no_mangle)]
-pub(crate) extern "C" fn Blob__getDataPtr(value: JSValue) -> *mut c_void {
-    let Some(blob) = Blob::from_js(value) else {
-        return core::ptr::null_mut();
-    };
-    // SAFETY: `from_js` returns a non-null pointer to a live JSC-owned Blob.
-    let data = unsafe { (*blob).shared_view() };
-    if data.is_empty() {
-        return core::ptr::null_mut();
+/// The start of `value`'s in-memory bytes (null if not a `Blob` or empty);
+/// pairs with `Blob__getSize`. Valid while the blob and its store live.
+// HOST_EXPORT(Blob__getDataPtr, c)
+pub fn blob_get_data_ptr(value: JSValue) -> *const u8 {
+    match value.as_class_ref::<Blob>().map(Blob::shared_view) {
+        Some(data) if !data.is_empty() => data.as_ptr(),
+        _ => core::ptr::null(),
     }
-    data.as_ptr().cast_mut().cast::<c_void>()
 }
 
-#[unsafe(no_mangle)]
-pub(crate) extern "C" fn Blob__getSize(value: JSValue) -> usize {
-    let Some(blob) = Blob::from_js(value) else {
-        return 0;
-    };
-    // SAFETY: `from_js` returns a non-null pointer to a live JSC-owned Blob.
-    unsafe { (*blob).shared_view().len() }
+// HOST_EXPORT(Blob__getSize, c)
+pub fn blob_get_size(value: JSValue) -> usize {
+    value
+        .as_class_ref::<Blob>()
+        .map_or(0, |blob| blob.shared_view().len())
 }
 
-/// # Safety
-/// `[ptr, ptr+len)` must be a valid readable byte range (or `ptr` null / `len` 0).
-#[unsafe(no_mangle)]
-pub(crate) unsafe extern "C" fn Blob__fromBytes(
-    global_this: &JSGlobalObject,
-    ptr: *const u8,
-    len: usize,
-) -> *mut Blob {
-    if ptr.is_null() || len == 0 {
-        return Blob::new(Blob::init_empty(global_this));
-    }
-    // SAFETY: caller guarantees [ptr, ptr+len) is valid.
-    let bytes = unsafe { bun_core::ffi::slice(ptr, len) }.to_vec();
-    let store = Store::init(bytes);
-    Blob::new(Blob::init_with_store(store, global_this))
-}
-
-/// Same as Blob__fromBytes but stamps content_type. `mime` must be a
-/// string literal with process lifetime (not freed by deinit — the caller
-/// passes one of the image/* constants).
-///
-/// # Safety
-/// `[ptr, ptr+len)` must be a valid readable byte range and `mime` a
-/// NUL-terminated `'static` C string.
-#[unsafe(no_mangle)]
-pub(crate) unsafe extern "C" fn Blob__fromBytesWithType(
-    global_this: &JSGlobalObject,
-    ptr: *const u8,
-    len: usize,
-    mime: *const c_char,
-) -> *mut Blob {
-    // SAFETY: forwarded from caller's contract.
-    let blob = unsafe { Blob__fromBytes(global_this, ptr, len) };
-    // SAFETY: caller guarantees `mime` is a NUL-terminated 'static C string.
-    let mime_slice = unsafe { bun_core::ffi::cstr(mime) }.to_bytes();
-    if !mime_slice.is_empty() {
-        // SAFETY: `blob` is a fresh heap allocation returned by `Blob__fromBytes`;
-        // we are the sole owner until this function returns it.
-        unsafe {
-            (*blob)
-                .content_type
-                .set(BlobContentType::Owned(mime_slice.into()));
-            (*blob).content_type_was_set.set(true);
-        }
-    }
-    blob
-}
-
-/// Adopts an mmap'd region — no copy. The Blob's store holds the mapping;
-/// when the store's refcount drops to zero, deinit calls allocator.free
-/// which munmap's.
-///
-/// # Safety
-/// `[ptr, ptr+len)` must be a valid page-aligned mmap'd region whose ownership
-/// is transferred to the returned Blob, and `mime` a NUL-terminated `'static`
-/// C string.
-#[unsafe(no_mangle)]
-pub(crate) unsafe extern "C" fn Blob__fromMmapWithType(
-    global_this: &JSGlobalObject,
-    ptr: *mut u8,
-    len: usize,
-    mime: *const c_char,
-) -> *mut Blob {
-    #[cfg(not(unix))]
-    {
-        // Windows Chrome backend never calls this; if it ever does, fall back to copying.
-        // SAFETY: forwarded from caller's contract.
-        return unsafe { Blob__fromBytesWithType(global_this, ptr, len, mime) };
-    }
-    #[cfg(unix)]
-    {
-        // SAFETY: caller (C++ WebKit screenshot path) guarantees `[ptr, ptr+len)`
-        // is a valid page-aligned mmap'd region we now own.
-        let store = Store::init_mmap(unsafe { core::slice::from_raw_parts_mut(ptr, len) });
-        let blob = Blob::new(Blob::init_with_store(store, global_this));
-        // SAFETY: caller (C++) passes a valid NUL-terminated C string.
-        let mime_slice = unsafe { bun_core::ffi::cstr(mime) }.to_bytes();
-        if !mime_slice.is_empty() {
-            // SAFETY: `blob` was just produced by heap::alloc in Blob::new.
-            unsafe {
-                (*blob)
-                    .content_type
-                    .set(BlobContentType::Owned(mime_slice.into()));
-                (*blob).content_type_was_set.set(true);
-            }
-        }
-        blob
-    }
-}
+// `Blob__fromBytes` / `Blob__fromBytesWithType` / `Blob__fromMmapWithType`
+// live next to `Store` in `bun_jsc::webcore_types`.
 
 /// `stat.{st_mtime, st_mtime_nsec}` → JS epoch ms. `bun_sys::Stat` is
 /// `libc::stat` on POSIX (fields) and `uv_stat_t` on Windows (`mtim` timespec);
@@ -5999,22 +5213,6 @@ fn resolve_file_stat(store: &RefPtr<Store>) {
 // toStringWithBytes / toString / toJSON / toFormData / toArrayBuffer{View}
 // ──────────────────────────────────────────────────────────────────────────
 
-/// RAII owner for a leaked `Box<[u8]>` passed across the
-/// `to_*_with_bytes::<Lifetime::Temporary>` boundary as `*mut [u8]`. Stores
-/// the raw pointer and reconstructs/drops the `Box` only at scope end so
-/// interior `&[u8]` borrows of the same allocation remain valid until then
-/// (constructing the `Box` eagerly would assert uniqueness and invalidate
-/// them under Stacked Borrows).
-struct TemporaryBytes(*mut [u8]);
-impl Drop for TemporaryBytes {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: only constructed when `LIFETIME == Temporary`, where the
-        // caller passed ownership of a leaked default-allocator `Box<[u8]>`.
-        unsafe { drop(bun_core::heap::take(self.0)) };
-    }
-}
-
 // Marker types for static fn dispatch through do_read_file/do_read_from_s3.
 // Each implements `ReadFileToJs` so a plain fn-pointer monomorphizes per `*WithBytes` body.
 pub(crate) struct ToStringWithBytesFn;
@@ -6023,75 +5221,30 @@ pub(crate) struct ToArrayBufferWithBytesFn;
 pub(crate) struct ToUint8ArrayWithBytesFn;
 pub(crate) struct ToFormDataWithBytesFn;
 
-// `ReadFileToJs::call`'s `by: *mut [u8]` is fixed by the trait; each impl forwards
-// it to the matching unsafe `*_with_bytes` body, so the deref is documented there.
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
 impl read_file::ReadFileToJs for ToStringWithBytesFn {
-    fn call(b: &Blob, g: &JSGlobalObject, by: *mut [u8], l: Lifetime) -> JsResult<JSValue> {
-        // SAFETY: `by` upholds the `ReadFileToJs::call` contract — a leaked
-        // `Box<[u8]>` for `Temporary`, store-backed otherwise.
-        unsafe {
-            match l {
-                Lifetime::Clone => b.to_string_with_bytes::<{ Lifetime::Clone }>(g, by),
-                Lifetime::Temporary => b.to_string_with_bytes::<{ Lifetime::Temporary }>(g, by),
-                Lifetime::Share => b.to_string_with_bytes::<{ Lifetime::Share }>(g, by),
-                Lifetime::Transfer => b.to_string_with_bytes::<{ Lifetime::Transfer }>(g, by),
-            }
-        }
+    fn call(b: &Blob, g: &JSGlobalObject, bytes: SourceBytes) -> JsResult<JSValue> {
+        b.to_string_with_bytes(g, bytes)
     }
 }
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
 impl read_file::ReadFileToJs for ToJsonWithBytesFn {
-    fn call(b: &Blob, g: &JSGlobalObject, by: *mut [u8], l: Lifetime) -> JsResult<JSValue> {
-        // SAFETY: see `ToStringWithBytesFn::call`.
-        unsafe {
-            match l {
-                Lifetime::Clone => b.to_json_with_bytes::<{ Lifetime::Clone }>(g, by),
-                Lifetime::Temporary => b.to_json_with_bytes::<{ Lifetime::Temporary }>(g, by),
-                Lifetime::Share => b.to_json_with_bytes::<{ Lifetime::Share }>(g, by),
-                Lifetime::Transfer => b.to_json_with_bytes::<{ Lifetime::Transfer }>(g, by),
-            }
-        }
+    fn call(b: &Blob, g: &JSGlobalObject, bytes: SourceBytes) -> JsResult<JSValue> {
+        b.to_json_with_bytes(g, bytes)
     }
 }
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
 impl read_file::ReadFileToJs for ToArrayBufferWithBytesFn {
-    fn call(b: &Blob, g: &JSGlobalObject, by: *mut [u8], l: Lifetime) -> JsResult<JSValue> {
-        // SAFETY: see `ToStringWithBytesFn::call`.
-        unsafe {
-            match l {
-                Lifetime::Clone => b.to_array_buffer_with_bytes::<{ Lifetime::Clone }>(g, by),
-                Lifetime::Temporary => {
-                    b.to_array_buffer_with_bytes::<{ Lifetime::Temporary }>(g, by)
-                }
-                Lifetime::Share => b.to_array_buffer_with_bytes::<{ Lifetime::Share }>(g, by),
-                Lifetime::Transfer => b.to_array_buffer_with_bytes::<{ Lifetime::Transfer }>(g, by),
-            }
-        }
+    fn call(b: &Blob, g: &JSGlobalObject, bytes: SourceBytes) -> JsResult<JSValue> {
+        b.to_array_buffer_with_bytes(g, bytes)
     }
 }
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
 impl read_file::ReadFileToJs for ToUint8ArrayWithBytesFn {
-    fn call(b: &Blob, g: &JSGlobalObject, by: *mut [u8], l: Lifetime) -> JsResult<JSValue> {
-        // SAFETY: see `ToStringWithBytesFn::call`.
-        unsafe {
-            match l {
-                Lifetime::Clone => b.to_uint8_array_with_bytes::<{ Lifetime::Clone }>(g, by),
-                Lifetime::Temporary => {
-                    b.to_uint8_array_with_bytes::<{ Lifetime::Temporary }>(g, by)
-                }
-                Lifetime::Share => b.to_uint8_array_with_bytes::<{ Lifetime::Share }>(g, by),
-                Lifetime::Transfer => b.to_uint8_array_with_bytes::<{ Lifetime::Transfer }>(g, by),
-            }
-        }
+    fn call(b: &Blob, g: &JSGlobalObject, bytes: SourceBytes) -> JsResult<JSValue> {
+        b.to_uint8_array_with_bytes(g, bytes)
     }
 }
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
 impl read_file::ReadFileToJs for ToFormDataWithBytesFn {
-    fn call(b: &Blob, g: &JSGlobalObject, by: *mut [u8], l: Lifetime) -> JsResult<JSValue> {
-        let _ = l; // FormData ignores lifetime — bytes are read-only.
-        // SAFETY: `by` is valid for reads per the `ReadFileToJs::call` contract.
-        Ok(unsafe { b.to_form_data_with_bytes::<{ Lifetime::Temporary }>(g, by) })
+    fn call(b: &Blob, g: &JSGlobalObject, bytes: SourceBytes) -> JsResult<JSValue> {
+        // FormData ignores lifetime — bytes are read-only.
+        Ok(b.to_form_data_with_bytes(g, bytes))
     }
 }
 
@@ -6235,13 +5388,9 @@ impl Any {
                 self.to_uint8_array_transfer(global_this)
             }
             streams::BufferActionTag::Blob => {
-                let result = Blob::new(self.to_blob(global_this));
-                // SAFETY: `Blob::new` returns a fresh heap allocation we own;
-                // `BlobExt::to_js(&self)` (not the by-value `JsClass` one) consumes
-                // the pointer into a JS wrapper which takes ownership.
-                unsafe { (*result).global_this.set(global_this) };
-                // SAFETY: same fresh `result` allocation; ownership transfers to the JS wrapper.
-                Ok(BlobExt::to_js(unsafe { &*result }, global_this))
+                let result = self.to_blob(global_this);
+                result.global_this.set(global_this);
+                Ok(result.to_js(global_this))
             }
             streams::BufferActionTag::ArrayBuffer => {
                 if matches!(self, Any::Blob(_)) {
@@ -6579,18 +5728,14 @@ impl Internal {
 // JSDOMFile__hasInstance / FileOpener / FileCloser
 // ──────────────────────────────────────────────────────────────────────────
 
-// C++ side declares `extern "C" SYSV_ABI bool JSDOMFile__hasInstance(...)` (JSDOMFile.cpp).
-bun_jsc::jsc_host_abi! {
-    #[unsafe(no_mangle)]
-    pub unsafe fn JSDOMFile__hasInstance(
-        _a: JSValue,
-        _b: &JSGlobalObject,
-        value: JSValue,
-    ) -> bool {
-        jsc::mark_binding();
-        let Some(blob) = value.as_class_ref::<Blob>() else { return false };
-        blob.is_jsdom_file.get()
-    }
+/// C++ side declares `extern "C" SYSV_ABI bool JSDOMFile__hasInstance(...)` (JSDOMFile.cpp).
+// HOST_EXPORT(JSDOMFile__hasInstance, jsc)
+pub fn jsdom_file_has_instance(_a: JSValue, _b: &JSGlobalObject, value: JSValue) -> bool {
+    jsc::mark_binding();
+    let Some(blob) = value.as_class_ref::<Blob>() else {
+        return false;
+    };
+    blob.is_jsdom_file.get()
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -6598,8 +5743,10 @@ bun_jsc::jsc_host_abi! {
 // ──────────────────────────────────────────────────────────────────────────
 
 // TODO: move to bun_sys?
-/// Generic file-open helper used by ReadFile/WriteFile/CopyFile state machines,
-/// modeled as a trait the target implements.
+/// Generic (POSIX, pool-thread) file-open helper used by the ReadFile/WriteFile
+/// state machines, modeled as a trait the target implements. Windows opens go
+/// through `bun_io::uv_fs::open`.
+#[cfg(not(windows))]
 pub trait FileOpener: Sized {
     /// Override if you need different open flags; defaults to RDONLY.
     const OPEN_FLAGS: i32 = bun_sys::O::RDONLY;
@@ -6623,17 +5770,6 @@ pub trait FileOpener: Sized {
     ) -> Retry {
         Retry::No
     }
-    #[cfg(windows)]
-    fn loop_(&self) -> *mut bun_libuv_sys::uv_loop_t;
-    #[cfg(windows)]
-    fn req(&mut self) -> &mut bun_libuv_sys::uv_fs_t;
-    /// Stash/retrieve the open completion callback across the libuv async hop.
-    /// Rust can't const-generic over fn
-    /// pointers, so the implementor stores it on `self` (e.g. next to `req`).
-    #[cfg(windows)]
-    fn set_open_callback(&mut self, cb: fn(&mut Self, Fd));
-    #[cfg(windows)]
-    fn open_callback(&self) -> fn(&mut Self, Fd);
 
     fn get_fd_by_opening(&mut self, callback: fn(&mut Self, Fd)) {
         let mut buf = bun_paths::path_buffer_pool::get();
@@ -6643,124 +5779,40 @@ pub trait FileOpener: Sized {
         };
         let path = path_string.slice_z(&mut buf);
 
-        #[cfg(windows)]
-        {
-            use bun_sys::ReturnCodeExt as _;
-            // Monomorphic libuv completion thunk — recovers `*mut Self` from
-            // `req.data`.
-            extern "C" fn wrapped_callback<S: FileOpener>(req: *mut bun_libuv_sys::uv_fs_t) {
-                use bun_sys::ReturnCodeExt as _;
-                // SAFETY: `req.data` was set to `self as *mut Self` below before
-                // `uv_fs_open` was queued; libuv guarantees `req` is valid here.
-                let self_: &mut S = unsafe { bun_ptr::callback_ctx::<S>((*req).data) };
-                {
-                    // SAFETY: req points into self_.req(); cleanup before reuse.
-                    scopeguard::defer! { unsafe { bun_libuv_sys::uv_fs_req_cleanup(req); } }
-                    // SAFETY: req is the live uv_fs_t from the open request.
-                    let result = unsafe { (*req).result };
-                    if let Some(err_enum) = result.errno() {
-                        let path_string_2 = match self_.pathlike() {
-                            PathOrFileDescriptor::Path(p) => p.clone(),
-                            PathOrFileDescriptor::Fd(_) => unreachable!(),
-                        };
-                        self_.set_errno(bun_errno::from_errno(err_enum as i32).into());
-                        self_.set_system_error(
-                            bun_sys::Error::from_code(err_enum, bun_sys::Tag::open)
-                                .with_path(path_string_2.slice())
-                                .to_system_error()
-                                .into(),
-                        );
-                        self_.set_opened_fd(bun_sys::Fd::INVALID);
-                    } else {
-                        self_.set_opened_fd(Fd::from_uv(result.to_fd()));
-                    }
+        loop {
+            match bun_sys::open(
+                path,
+                Self::OPEN_FLAGS | Self::OPENER_FLAGS,
+                crate::node::fs::DEFAULT_PERMISSION,
+            ) {
+                bun_sys::Result::Ok(fd) => {
+                    self.set_opened_fd(fd);
+                    break;
                 }
-                let cb = self_.open_callback();
-                cb(self_, self_.opened_fd());
-            }
-
-            self.set_open_callback(callback);
-            let loop_ = self.loop_();
-            let self_ptr: *mut Self = core::ptr::from_mut(self);
-            // Derive `req` THROUGH `self_ptr` rather than via a fresh `self.req()`
-            // reborrow. Under Stacked Borrows, a direct `self.req()` here would
-            // create a sibling `&mut` that pops `self_ptr`'s tag, making the
-            // later deref in `wrapped_callback` (via `req.data`) UB. Going
-            // through the raw pointer keeps the reborrow as a child of
-            // `self_ptr`, so its provenance survives until the callback fires.
-            // SAFETY: `self_ptr` was just derived from a live `&mut self`.
-            let req = unsafe { (*self_ptr).req() };
-            // Stash `self` on the request BEFORE dispatch. libuv never touches
-            // `req.data`, so pre-setting is safe; doing it after `uv_fs_open`
-            // is a UAF when the call fails synchronously and `callback` frees
-            // `self` (ReadFileUV::on_finish → finalize → heap::take).
-            req.data = self_ptr.cast();
-            // SAFETY: loop_/req are live for the duration of the async open;
-            // req.data is consumed by `wrapped_callback::<Self>` above.
-            let rc = unsafe {
-                bun_libuv_sys::uv_fs_open(
-                    loop_,
-                    req,
-                    path.as_ptr(),
-                    Self::OPEN_FLAGS | Self::OPENER_FLAGS,
-                    node::fs::DEFAULT_PERMISSION as i32,
-                    Some(wrapped_callback::<Self>),
-                )
-            };
-            if let Some(errno) = rc.errno() {
-                self.set_errno(bun_errno::from_errno(errno as i32).into());
-                self.set_system_error(
-                    bun_sys::Error::from_code(errno, bun_sys::Tag::open)
-                        .with_path(path_string.slice())
-                        .to_system_error()
-                        .into(),
-                );
-                self.set_opened_fd(bun_sys::Fd::INVALID);
-                // `callback` may free `self` (see comment above) — must be the
-                // last thing we touch on this path.
-                callback(self, bun_sys::Fd::INVALID);
-                return;
-            }
-            return;
-        }
-
-        #[cfg(not(windows))]
-        {
-            loop {
-                match bun_sys::open(
-                    path,
-                    Self::OPEN_FLAGS | Self::OPENER_FLAGS,
-                    crate::node::fs::DEFAULT_PERMISSION,
-                ) {
-                    bun_sys::Result::Ok(fd) => {
-                        self.set_opened_fd(fd);
-                        break;
-                    }
-                    bun_sys::Result::Err(err) => {
-                        if err.get_errno() == bun_sys::E::ENOENT {
-                            match self.try_mkdirp(err.clone(), path, path_string.slice()) {
-                                Retry::Continue => continue,
-                                Retry::Fail => {
-                                    // `mkdir_if_not_exists` already populated
-                                    // `errno`/`system_error` on the impl.
-                                    self.set_opened_fd(Fd::INVALID);
-                                    break;
-                                }
-                                Retry::No => {}
+                bun_sys::Result::Err(err) => {
+                    if err.get_errno() == bun_sys::E::ENOENT {
+                        match self.try_mkdirp(err.clone(), path, path_string.slice()) {
+                            Retry::Continue => continue,
+                            Retry::Fail => {
+                                // `mkdir_if_not_exists` already populated
+                                // `errno`/`system_error` on the impl.
+                                self.set_opened_fd(Fd::INVALID);
+                                break;
                             }
+                            Retry::No => {}
                         }
-                        self.set_errno(bun_errno::from_errno(err.errno as i32).into());
-                        self.set_system_error(jsc::SysErrorJsc::to_system_error(
-                            &err.with_path(path_string.slice()),
-                        ));
-                        self.set_opened_fd(Fd::INVALID);
-                        break;
                     }
+                    self.set_errno(bun_errno::from_errno(err.errno as i32).into());
+                    self.set_system_error(jsc::SysErrorJsc::to_system_error(
+                        &err.with_path(path_string.slice()),
+                    ));
+                    self.set_opened_fd(Fd::INVALID);
+                    break;
                 }
             }
-
-            callback(self, self.opened_fd());
         }
+
+        callback(self, self.opened_fd());
     }
 
     fn get_fd(&mut self, callback: fn(&mut Self, Fd)) {
@@ -6781,41 +5833,31 @@ pub trait FileOpener: Sized {
 }
 
 // TODO: move to bun_sys?
-pub trait FileCloser: Sized {
+/// The close half of a POSIX parked-io job (`ReadFile`/`WriteFile`): closing
+/// the fd it opened and, when its poll is still registered with the io loop,
+/// getting it unregistered there first.
+#[cfg(not(windows))]
+pub trait FileCloser:
+    Sized + bun_io::PollOwner + bun_io::IntrusiveIoRequest + bun_threading::WorkTaskHandler + 'static
+{
     fn opened_fd(&self) -> Fd;
     fn set_opened_fd(&mut self, fd: Fd);
     fn close_after_io(&self) -> bool;
     fn set_close_after_io(&mut self, v: bool);
     fn state(&self) -> &core::sync::atomic::AtomicU8;
-    fn io_request(&mut self) -> Option<&mut bun_io::Request>;
+    fn io_request(&mut self) -> &mut bun_io::Request;
     fn task(&mut self) -> &mut bun_jsc::WorkPoolTask;
-    #[cfg(windows)]
-    fn loop_(&self) -> *mut bun_libuv_sys::uv_loop_t;
-
-    /// The [`bun_io::RequestCallback`] `do_close` installs: the impl
-    /// recovers `Self` from its intrusive request (`offset_of!` cannot name
-    /// fields on a trait `Self`) and answers [`close_action`](Self::close_action).
-    ///
-    /// # Safety
-    /// [`bun_io::RequestCallback`]'s contract.
-    unsafe fn schedule_close(request: &mut bun_io::Request) -> bun_io::Action<'_>;
 
     /// The io-thread action that unregisters this job's poll; its completion
     /// comes back as [`on_io_request_closed`](Self::on_io_request_closed).
-    fn close_action(&mut self) -> bun_io::Action<'_>
-    where
-        Self: bun_io::PollOwner,
-    {
+    fn close_action(&mut self) -> bun_io::Action<'_> {
         let fd = self.opened_fd();
         bun_io::Action::Close(bun_io::FileAction::new(self, fd))
     }
 
     /// io thread: the poll is unregistered; hand the job back to the pool
     /// (its [`WorkTaskHandler`](bun_threading::WorkTaskHandler) resumes it).
-    fn on_io_request_closed(this: &mut Self)
-    where
-        Self: bun_io::PollOwner + bun_threading::WorkTaskHandler,
-    {
+    fn on_io_request_closed(this: &mut Self) {
         bun_core::IntrusiveField::<bun_io::Poll>::field_mut(this)
             .flags
             .remove(bun_io::Flags::WasEverRegistered);
@@ -6825,38 +5867,30 @@ pub trait FileCloser: Sized {
     }
 
     fn do_close(&mut self, is_allowed_to_close_fd: bool) -> bool {
-        // Check `close_after_io()` before `io_request()` so the immutable
-        // `self` reads finish before
-        // taking the `&mut self` borrow via `io_request()`.
         if self.close_after_io() {
             self.state().store(
                 ClosingState::Closing as u8,
                 core::sync::atomic::Ordering::SeqCst,
             );
-            if let Some(io_request) = self.io_request() {
-                // The io thread reads `callback` after popping from its MPSC
-                // queue; a plain store here is a data race. `bun_io::Request::
-                // store_callback_seq_cst` lowers to a volatile write + SeqCst
-                // fence (Rust has no `AtomicFnPtr`).
-                io_request.store_callback_seq_cst(Self::schedule_close);
-                if !io_request.scheduled {
-                    bun_io::IoRequestLoop::schedule(io_request);
-                }
-                return true;
+            let io_request = self.io_request();
+            // The io thread reads `callback` after popping from its MPSC
+            // queue; a plain store here is a data race. `bun_io::Request::
+            // store_callback_seq_cst` lowers to a volatile write + SeqCst
+            // fence (Rust has no `AtomicFnPtr`).
+            io_request
+                .store_callback_seq_cst(bun_io::io_request_callback_with::<Self, CloseRequest>());
+            if !io_request.scheduled {
+                bun_io::IoRequestLoop::schedule(io_request);
             }
+            return true;
         }
 
         if is_allowed_to_close_fd
             && self.opened_fd() != Fd::INVALID
             && self.opened_fd().stdio_tag().is_none()
         {
-            #[cfg(windows)]
-            bun_io::Closer::close(self.opened_fd(), self.loop_());
-            #[cfg(not(windows))]
-            {
-                use bun_sys::FdExt as _;
-                let _ = self.opened_fd().close_allowing_bad_file_descriptor(None);
-            }
+            use bun_sys::FdExt as _;
+            let _ = self.opened_fd().close_allowing_bad_file_descriptor(None);
             self.set_opened_fd(Fd::INVALID);
         }
 
@@ -6864,13 +5898,26 @@ pub trait FileCloser: Sized {
     }
 }
 
+/// The io-thread hook `do_close` re-queues a [`FileCloser`]'s request with:
+/// answers its [`close_action`](FileCloser::close_action).
+#[cfg(not(windows))]
+pub struct CloseRequest;
+
+#[cfg(not(windows))]
+impl<T: FileCloser> bun_io::IoRequestHook<T> for CloseRequest {
+    fn on_io_request(owner: &mut T) -> bun_io::Action<'_> {
+        owner.close_action()
+    }
+}
+
 /// Implements [`FileCloser`] for a task struct with the standard field set
 /// (`opened_fd`, `close_after_io`, `state`, `io: ParkedRequest`, `io_poll`,
-/// `task`). The type must also carry `bun_io::intrusive_io_request!` (the
-/// parent-pointer recovery `schedule_close` uses), `bun_io::poll_owner!` and
-/// a `bun_threading::WorkTaskHandler` impl that resumes it.
+/// `task`). The type must also carry `bun_io::intrusive_io_request!`,
+/// `bun_io::poll_owner!` and a `bun_threading::WorkTaskHandler` impl that
+/// resumes it.
 macro_rules! impl_file_closer {
     ($T:ident) => {
+        #[cfg(not(windows))]
         impl crate::webcore::blob::FileCloser for $T {
             fn opened_fd(&self) -> ::bun_sys::Fd {
                 self.opened_fd
@@ -6887,24 +5934,11 @@ macro_rules! impl_file_closer {
             fn state(&self) -> &::core::sync::atomic::AtomicU8 {
                 &self.state
             }
-            fn io_request(&mut self) -> Option<&mut ::bun_io::Request> {
-                Some(self.io.request())
+            fn io_request(&mut self) -> &mut ::bun_io::Request {
+                self.io.request()
             }
             fn task(&mut self) -> &mut ::bun_jsc::WorkPoolTask {
                 &mut self.task
-            }
-            #[cfg(windows)]
-            fn loop_(&self) -> *mut ::bun_libuv_sys::uv_loop_t {
-                unreachable!()
-            }
-
-            unsafe fn schedule_close(request: &mut ::bun_io::Request) -> ::bun_io::Action<'_> {
-                use ::bun_io::IntrusiveIoRequest as _;
-                // SAFETY: fn contract — `request` is `self.io`'s request
-                // (intrusive), so this recovers the live parent, which nothing
-                // else touches while the io thread has its request.
-                let this = unsafe { &mut *$T::from_io_request(::core::ptr::from_mut(request)) };
-                <$T as crate::webcore::blob::FileCloser>::close_action(this)
             }
         }
     };

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2554,7 +2554,7 @@ impl BlobExt for Blob {
         if view.is_empty() {
             return Ok(jsc::DOMFormData::create(global));
         }
-        Ok(self.to_form_data_with_bytes(global, SourceBytes::Store(view, Lifetime::Temporary)))
+        Ok(self.to_form_data_with_bytes(global, SourceBytes::Store(view, Lifetime::Clone)))
     }
     #[inline]
     fn get<const MOVE: bool, const REQUIRE_ARRAY: bool>(
@@ -5742,6 +5742,118 @@ pub fn jsdom_file_has_instance(_a: JSValue, _b: &JSGlobalObject, value: JSValue)
 // FileOpener<T> / FileCloser<T>
 // ──────────────────────────────────────────────────────────────────────────
 
+/// What a pool-thread job (`ReadFile`, `CopyFile`) needs of a `store::File`,
+/// copied on the JS thread when the job is created: the JS thread may re-stat
+/// the live store (`resolve_file_stat` rewrites `mode`/`seekable`/...) while
+/// the job runs, so the job never reads the store's `File` itself.
+#[cfg_attr(windows, allow(dead_code))] // the Windows jobs run on the JS thread
+pub struct FileSnapshot {
+    pub pathlike: SnapshotPath,
+    pub mode: bun_sys::Mode,
+    pub is_atty: Option<bool>,
+}
+
+#[cfg_attr(windows, allow(dead_code))] // the Windows jobs run on the JS thread
+impl FileSnapshot {
+    pub fn new(file: &store::File) -> Self {
+        Self {
+            pathlike: match &file.pathlike {
+                PathOrFileDescriptor::Fd(fd) => SnapshotPath::Fd(*fd),
+                PathOrFileDescriptor::Path(p) => {
+                    SnapshotPath::Path(SnapshotPathBuf(p.slice().into()))
+                }
+            },
+            mode: file.mode,
+            is_atty: file.is_atty,
+        }
+    }
+}
+
+/// [`FileSnapshot`]'s owned copy of a `PathOrFileDescriptor`.
+#[cfg_attr(windows, allow(dead_code))] // the Windows jobs run on the JS thread
+pub enum SnapshotPath {
+    Fd(Fd),
+    Path(SnapshotPathBuf),
+}
+
+#[cfg_attr(windows, allow(dead_code))] // the Windows jobs run on the JS thread
+pub struct SnapshotPathBuf(Box<[u8]>);
+
+#[cfg_attr(windows, allow(dead_code))] // the Windows jobs run on the JS thread
+impl SnapshotPathBuf {
+    #[inline]
+    pub fn slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// NUL-terminated in `buf` (empty if it does not fit), as
+    /// `PathLike::slice_z` does on POSIX.
+    pub fn slice_z<'a>(&'a self, buf: &'a mut bun_paths::PathBuffer) -> &'a bun_core::ZStr {
+        let path = &self.0[..];
+        if path.len() >= buf.len() {
+            bun_core::debug_warn!(
+                "path too long: {} bytes exceeds PathBuffer capacity of {}\n",
+                path.len(),
+                buf.len()
+            );
+            return bun_core::ZStr::EMPTY;
+        }
+        buf[..path.len()].copy_from_slice(path);
+        buf[path.len()] = 0;
+        bun_core::ZStr::from_buf(&buf[..], path.len())
+    }
+}
+
+#[cfg_attr(windows, allow(dead_code))] // the Windows jobs run on the JS thread
+impl SnapshotPath {
+    #[inline]
+    pub fn is_fd(&self) -> bool {
+        matches!(self, SnapshotPath::Fd(_))
+    }
+    #[inline]
+    pub fn is_path(&self) -> bool {
+        matches!(self, SnapshotPath::Path(_))
+    }
+    #[inline]
+    pub fn fd(&self) -> Fd {
+        match self {
+            SnapshotPath::Fd(fd) => *fd,
+            SnapshotPath::Path(_) => unreachable!("SnapshotPath::fd on a path"),
+        }
+    }
+    #[inline]
+    pub fn path(&self) -> &SnapshotPathBuf {
+        match self {
+            SnapshotPath::Path(p) => p,
+            SnapshotPath::Fd(_) => unreachable!("SnapshotPath::path on an fd"),
+        }
+    }
+    #[inline]
+    pub fn as_ref(&self) -> PathOrFdRef<'_> {
+        match self {
+            SnapshotPath::Fd(fd) => PathOrFdRef::Fd(*fd),
+            SnapshotPath::Path(p) => PathOrFdRef::Path(p.slice()),
+        }
+    }
+}
+
+/// A path-or-fd borrowed from wherever a [`FileOpener`] keeps it.
+#[cfg_attr(windows, allow(dead_code))] // the Windows jobs run on the JS thread
+pub enum PathOrFdRef<'a> {
+    Fd(Fd),
+    Path(&'a [u8]),
+}
+
+#[cfg(not(windows))]
+impl<'a> From<&'a PathOrFileDescriptor<'_>> for PathOrFdRef<'a> {
+    fn from(p: &'a PathOrFileDescriptor<'_>) -> Self {
+        match p {
+            PathOrFileDescriptor::Fd(fd) => PathOrFdRef::Fd(*fd),
+            PathOrFileDescriptor::Path(p) => PathOrFdRef::Path(p.slice()),
+        }
+    }
+}
+
 // TODO: move to bun_sys?
 /// Generic (POSIX, pool-thread) file-open helper used by the ReadFile/WriteFile
 /// state machines, modeled as a trait the target implements. Windows opens go
@@ -5756,8 +5868,8 @@ pub trait FileOpener: Sized {
     fn set_opened_fd(&mut self, fd: Fd);
     fn set_errno(&mut self, e: crate::Error);
     fn set_system_error(&mut self, e: jsc::SystemError);
-    /// Either `self.file_store.pathlike` or `self.file_blob.store.data.file.pathlike`.
-    fn pathlike(&self) -> &PathOrFileDescriptor<'static>;
+    /// The file to open: the job's snapshot, or `self.file_blob.store.data.file.pathlike`.
+    fn pathlike(&self) -> PathOrFdRef<'_>;
     /// Implementors that have a `mkdirp_if_not_exists` field (`WriteFile`,
     /// `CopyFile`) override this to call [`mkdir_if_not_exists`]; everyone else
     /// (e.g. `ReadFile`) keeps the default `Retry::No`, so the open path falls
@@ -5774,8 +5886,8 @@ pub trait FileOpener: Sized {
     fn get_fd_by_opening(&mut self, callback: fn(&mut Self, Fd)) {
         let mut buf = bun_paths::path_buffer_pool::get();
         let path_string = match self.pathlike() {
-            PathOrFileDescriptor::Path(p) => p.clone(),
-            PathOrFileDescriptor::Fd(_) => unreachable!(),
+            PathOrFdRef::Path(p) => SnapshotPathBuf(p.into()),
+            PathOrFdRef::Fd(_) => unreachable!(),
         };
         let path = path_string.slice_z(&mut buf);
 
@@ -5821,8 +5933,7 @@ pub trait FileOpener: Sized {
             return;
         }
 
-        if let PathOrFileDescriptor::Fd(fd) = self.pathlike() {
-            let fd = *fd;
+        if let PathOrFdRef::Fd(fd) = self.pathlike() {
             self.set_opened_fd(fd);
             callback(self, fd);
             return;

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1,5 +1,6 @@
 //! https://developer.mozilla.org/en-US/docs/Web/API/Body
 
+use bun_jsc::JsClass as _;
 use core::ffi::c_void;
 use core::ptr::NonNull;
 
@@ -1153,9 +1154,8 @@ impl Value {
                         result?;
                     }
                     Action::None | Action::GetBlob => {
-                        let blob_ptr = Blob::new(new.use_());
-                        // SAFETY: `Blob::new` returns a freshly heap-allocated *mut Blob.
-                        let blob = unsafe { &mut *blob_ptr };
+                        let blob_owned = new.use_();
+                        let blob = &blob_owned;
                         if let Some(fetch_headers) = headers {
                             // `headers` is a live C++ FetchHeaders handle;
                             // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
@@ -1172,7 +1172,7 @@ impl Value {
                         if !blob.content_type_was_set.get() && blob.store.get().is_some() {
                             set_blob_content_type(blob, bun_http_types::MimeType::TEXT);
                         }
-                        promise.resolve(global, blob.to_js(global))?;
+                        promise.resolve(global, blob_owned.to_js(global))?;
                     }
                 }
                 promise_.unprotect();
@@ -2151,9 +2151,8 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         }
 
         let value = self.get_body_value();
-        let blob_ptr = Blob::new(value.use_());
-        // SAFETY: `Blob::new` returns a freshly heap-allocated, ref-counted Blob.
-        let blob = unsafe { &mut *blob_ptr };
+        let blob_owned = value.use_();
+        let blob = &blob_owned;
         if blob.content_type().is_empty() {
             if let Some(fetch_headers) = BodyMixin::get_fetch_headers(self) {
                 // `fetch_headers` is a live C++ FetchHeaders handle;
@@ -2171,7 +2170,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         }
         Ok(JSPromise::resolved_promise_value(
             global_object,
-            blob.to_js(global_object),
+            blob_owned.to_js(global_object),
         ))
     }
 

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -1,3 +1,4 @@
+use bun_jsc::JsClass as _;
 use std::sync::OnceLock;
 
 use bun_collections::HashMap;
@@ -7,7 +8,6 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _, UUID
 use bun_threading::Guarded;
 
 use crate::webcore::Blob;
-use crate::webcore::BlobExt as _;
 
 // The map is wrapped in a `Guarded` (mutex + value).
 //
@@ -86,9 +86,10 @@ impl ObjectURLRegistry {
         pathname: &[u8],
         global_object: &JSGlobalObject,
     ) -> Option<JSValue> {
-        let blob = Blob::new(self.resolve_and_dupe(pathname, global_object)?);
-        // SAFETY: `Blob::new` returns a freshly-boxed heap pointer.
-        Some(unsafe { (*blob).to_js(global_object) })
+        Some(
+            self.resolve_and_dupe(pathname, global_object)?
+                .to_js(global_object),
+        )
     }
 
     pub(crate) fn revoke(&self, pathname: &[u8]) {

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -1,8 +1,8 @@
 use bstr::BStr;
+use bun_jsc::JsClass as _;
 
 use crate::node::PathLike;
 use crate::node::types::PathLikeExt as _;
-use crate::webcore::blob::BlobExt as _;
 use crate::webcore::blob::store::S3Ext as _;
 use crate::webcore::s3::MultiPartUploadOptions;
 use crate::webcore::s3::client::{ACL, S3Credentials, StorageClass};
@@ -410,16 +410,10 @@ impl S3Client {
             }
         };
         let options = args.next_eat();
-        // `Blob::new` heap-promotes and marks `ref_count = 1` so
-        // the JSS3File wrapper's `finalize` knows to free the blob.
-        let blob = crate::webcore::blob::Blob::new(ptr.construct_blob(global, path, options)?);
-        // `to_js` runs `calculate_estimated_byte_size()`
-        // before wrapping the heap Blob in a JSS3File so JSC sees the correct
-        // GC pressure. Route through `BlobExt::to_js` (the `&self` impl, which
-        // hands the heap pointer to the wrapper), same as `S3File::construct_internal_js`.
-        // SAFETY: `blob` is a freshly leaked `*mut Blob` from `Blob::new`;
-        // `to_js` hands ownership of that pointer to the C++ wrapper.
-        Ok(unsafe { &mut *blob }.to_js(global))
+        // `to_js` heap-promotes (so the JSS3File wrapper's `finalize` knows to
+        // free the blob) after `calculate_estimated_byte_size()`, so JSC sees
+        // the correct GC pressure.
+        Ok(ptr.construct_blob(global, path, options)?.to_js(global))
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -342,16 +342,6 @@ fn finish_s3_blob(
     Ok(blob)
 }
 
-fn construct_s3_file_internal(
-    global: &JSGlobalObject,
-    path: PathLike<'static>,
-    options: Option<JSValue>,
-) -> JsResult<*mut Blob> {
-    Ok(Blob::new(construct_s3_file_internal_store(
-        global, path, options,
-    )?))
-}
-
 pub(crate) struct S3BlobStatTask {
     promise: bun_jsc::JSPromiseStrong,
     // LIFETIMES.tsv: JSC_BORROW (&JSGlobalObject). `BackRef` so the heap task
@@ -696,12 +686,8 @@ pub(crate) fn construct_internal_js(
     path: PathLike<'static>,
     options: Option<JSValue>,
 ) -> JsResult<JSValue> {
-    let blob = construct_s3_file_internal(global, path, options)?;
-    // SAFETY: `blob` is a freshly heap-allocated `*mut Blob` from `Blob::new`.
-    // Call the `BlobExt::to_js` `&mut self` method (not the by-value
-    // `JsClass::to_js`), which hands the existing heap pointer to the C++
-    // wrapper.
-    Ok(BlobExt::to_js(unsafe { &mut *blob }, global))
+    let blob = construct_s3_file_internal_store(global, path, options)?;
+    Ok(blob.to_js(global))
 }
 
 pub(crate) fn to_js_unchecked(global: &JSGlobalObject, this: *mut Blob) -> JSValue {

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -5,9 +5,6 @@
 //! this module re-exports them and layers the `bun_runtime`-tier behaviour
 //! (S3 I/O, async file ops, structured-clone serialize) via extension traits.
 
-use core::ffi::c_void;
-use core::ptr::NonNull;
-
 use crate::node::fs as node_fs;
 use crate::node::types::PathOrFileDescriptorSerializeTag;
 use crate::webcore::jsc::{JSGlobalObject, JSPromise, JSValue, JsResult};
@@ -15,16 +12,12 @@ use crate::webcore::node_types::{PathLike, PathOrFileDescriptor};
 use crate::webcore::s3::client as s3_client;
 use crate::webcore::s3::client::S3ErrorJsc as _;
 use crate::webcore::s3::client::{
-    S3Credentials, S3CredentialsWithOptions, S3DeleteResult, S3ListObjectsOptions,
-    S3ListObjectsResult,
+    S3Credentials, S3CredentialsWithOptions, S3DeleteResult, S3ListObjectsResult,
 };
 use bun_core::strings;
 use bun_http_types::MimeType::MimeType;
 use bun_ptr::RefPtr;
 use bun_url::URL;
-
-#[cfg(unix)]
-use super::SizeType;
 
 // ──────────────────────────────────────────────────────────────────────────
 // Re-export the canonical data types from `bun_jsc`.
@@ -55,10 +48,6 @@ pub trait StoreExt {
     ) -> Result<RefPtr<Store>, crate::Error>
     where
         Self: Sized;
-    #[cfg(unix)]
-    fn init_mmap(slice: &'static mut [u8]) -> RefPtr<Store>
-    where
-        Self: Sized;
     fn serialize(&self, writer: &mut impl bun_io::Write) -> Result<(), crate::Error>;
 }
 
@@ -68,7 +57,8 @@ pub trait S3Ext {
         options: Option<JSValue>,
         global_object: &JSGlobalObject,
     ) -> JsResult<S3CredentialsWithOptions>;
-    /// `store` is the heap `Store` that owns `self` (`self == &store.data.S3`).
+    /// `store` is the heap `Store` that owns `self` (`self == &store.data.S3`);
+    /// the request keeps its own ref on it.
     fn unlink(
         &self,
         store: &RefPtr<Store>,
@@ -90,10 +80,6 @@ pub trait FileExt {
 }
 
 pub trait BytesExt {
-    #[cfg(unix)]
-    fn init_mmap(slice: &'static mut [u8]) -> Bytes
-    where
-        Self: Sized;
     fn to_internal_blob(&mut self) -> super::Internal;
 }
 
@@ -159,18 +145,6 @@ impl StoreExt for Store {
         }))
     }
 
-    /// Adopt an mmap'd region — no copy. The store's `Bytes` payload owns the
-    /// mapping; when the refcount drops to zero, `Bytes::drop` calls `munmap`.
-    #[cfg(unix)]
-    fn init_mmap(slice: &'static mut [u8]) -> RefPtr<Store> {
-        RefPtr::new(Store {
-            data: Data::Bytes(Bytes::init_mmap(slice)),
-            mime_type: bun_http_types::MimeType::NONE,
-            ref_count: bun_ptr::ThreadSafeRefCount::init(),
-            is_all_ascii: IsAllAscii::default(),
-        })
-    }
-
     fn serialize(&self, writer: &mut impl bun_io::Write) -> Result<(), crate::Error> {
         match &self.data {
             Data::File(file) => {
@@ -224,8 +198,6 @@ impl FileExt for File {
             PathOrFileDescriptor::Path(path_like) => {
                 // The `*Binding` arg is unused in `AsyncFSTask::create`.
                 let binding = node_fs::Binding::default();
-                // SAFETY: `bun_vm()` returns the live per-global VM pointer; the
-                // task is created on the JS thread that owns it.
                 Ok(node_fs::async_::Unlink::create(
                     global_this,
                     &binding,
@@ -274,46 +246,27 @@ impl S3Ext for S3 {
         global_this: &JSGlobalObject,
         extra_options: Option<JSValue>,
     ) -> JsResult<JSValue> {
-        struct Wrapper {
-            promise: bun_jsc::JSPromiseStrong,
-            store: RefPtr<Store>,
-            // LIFETIMES.tsv: JSC_BORROW → &JSGlobalObject. `BackRef` so the heap
-            // wrapper can outlive the constructing frame while reads stay safe.
-            global: bun_ptr::BackRef<JSGlobalObject>,
-        }
-
-        impl Wrapper {
-            #[inline]
-            fn new(init: Wrapper) -> Box<Wrapper> {
-                Box::new(init)
-            }
-
-            fn resolve(result: S3DeleteResult<'_>, opaque_self: *mut c_void) -> JsResult<()> {
-                // SAFETY: opaque_self was created via heap::alloc(Wrapper::new(..)) below.
-                let mut self_ = unsafe { bun_core::heap::take(opaque_self.cast::<Wrapper>()) };
-                // `defer self.deinit()` → Box drops at scope exit.
-                let global_object = self_.global.get();
-                match result {
-                    S3DeleteResult::Success => {
-                        self_.promise.resolve(global_object, JSValue::TRUE)?;
-                    }
-                    S3DeleteResult::NotFound(err) | S3DeleteResult::Failure(err) => {
-                        // Split borrows: `reject` takes `&mut promise`, so
-                        // compute the error (which reads `promise.get()`) first.
-                        let err_val = err.to_js_with_async_stack(
-                            global_object,
-                            self_.store.get_path(),
-                            self_.promise.get(),
-                        );
-                        self_.promise.reject(global_object, err_val)?;
-                    }
-                }
-                Ok(())
-            }
-        }
-
-        let promise = bun_jsc::JSPromiseStrong::init(global_this);
+        let mut promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
+        let global = bun_ptr::BackRef::new(global_this);
+        let store = store.clone();
+        let resolve = move |result: S3DeleteResult<'_>| -> JsResult<()> {
+            let global_object = global.get();
+            match result {
+                S3DeleteResult::Success => {
+                    promise.resolve(global_object, JSValue::TRUE)?;
+                }
+                S3DeleteResult::NotFound(err) | S3DeleteResult::Failure(err) => {
+                    // Split borrows: `reject` takes `&mut promise`, so
+                    // compute the error (which reads `promise.get()`) first.
+                    let err_val =
+                        err.to_js_with_async_stack(global_object, store.get_path(), promise.get());
+                    promise.reject(global_object, err_val)?;
+                }
+            }
+            Ok(())
+        };
+
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
         // dotenv loader (never null once the VM is initialised).
         let proxy_url: Option<URL<'_>> = global_this
@@ -329,13 +282,7 @@ impl S3Ext for S3 {
         s3_client::delete(
             &aws_options.credentials,
             self.path(),
-            Wrapper::resolve,
-            bun_core::heap::into_raw(Wrapper::new(Wrapper {
-                promise,
-                store: store.clone(),
-                global: bun_ptr::BackRef::new(global_this),
-            }))
-            .cast::<c_void>(),
+            Box::new(resolve),
             proxy,
             aws_options.request_payer,
         )?;
@@ -356,50 +303,34 @@ impl S3Ext for S3 {
             )));
         }
 
-        struct Wrapper {
-            promise: bun_jsc::JSPromiseStrong,
-            store: RefPtr<Store>,
-            resolved_list_options: S3ListObjectsOptions,
-            // LIFETIMES.tsv: JSC_BORROW. `BackRef` for safe deref across the async callback.
-            global: bun_ptr::BackRef<JSGlobalObject>,
-        }
-
-        impl Wrapper {
-            fn resolve(result: S3ListObjectsResult<'_>, opaque_self: *mut c_void) -> JsResult<()> {
-                // SAFETY: opaque_self was created via heap::alloc below.
-                let mut self_ = unsafe { bun_core::heap::take(opaque_self.cast::<Wrapper>()) };
-                // `defer self.deinit()` → Box drops at scope exit.
-                let global_object = self_.global.get();
-
-                match result {
-                    S3ListObjectsResult::Success(list_result) => {
-                        // `defer list_result.deinit()` → Drop handles it.
-                        let list_result_js = match list_result.to_js(global_object) {
-                            Ok(v) => v,
-                            Err(e) => {
-                                return self_.promise.reject(global_object, Err(e));
-                            }
-                        };
-                        self_.promise.resolve(global_object, list_result_js)?;
-                    }
-
-                    S3ListObjectsResult::NotFound(err) | S3ListObjectsResult::Failure(err) => {
-                        // Split borrows: `reject` takes `&mut promise`, so
-                        // compute the error (which reads `promise.get()`) first.
-                        let err_val = err.to_js_with_async_stack(
-                            global_object,
-                            self_.store.get_path(),
-                            self_.promise.get(),
-                        );
-                        self_.promise.reject(global_object, err_val)?;
-                    }
-                }
-                Ok(())
-            }
-        }
-
-        let promise = bun_jsc::JSPromiseStrong::init(global_this);
+        let mut promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
+        let global = bun_ptr::BackRef::new(global_this);
+        let store = store.clone();
+        let resolve = move |result: S3ListObjectsResult<'_>| -> JsResult<()> {
+            let global_object = global.get();
+            match result {
+                S3ListObjectsResult::Success(list_result) => {
+                    let list_result_js = match list_result.to_js(global_object) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            return promise.reject(global_object, Err(e));
+                        }
+                    };
+                    promise.resolve(global_object, list_result_js)?;
+                }
+
+                S3ListObjectsResult::NotFound(err) | S3ListObjectsResult::Failure(err) => {
+                    // Split borrows: `reject` takes `&mut promise`, so
+                    // compute the error (which reads `promise.get()`) first.
+                    let err_val =
+                        err.to_js_with_async_stack(global_object, store.get_path(), promise.get());
+                    promise.reject(global_object, err_val)?;
+                }
+            }
+            Ok(())
+        };
+
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
         // dotenv loader (never null once the VM is initialised).
         let proxy_url: Option<URL<'_>> = global_this
@@ -412,110 +343,23 @@ impl S3Ext for S3 {
         let aws_options = self.get_credentials_with_options(extra_options, global_this)?;
         // `defer aws_options.deinit()` → Drop handles it.
 
+        // Only read synchronously, to build the search-params string.
         let options = s3_client::get_list_objects_options_from_js(global_this, list_options)?;
 
-        // Box the wrapper first so the options live on the heap, then hand a
-        // borrow to `list_objects` (which only reads them synchronously to
-        // build the search-params string). The wrapper retains ownership for
-        // `Drop` after the async callback.
-        let wrapper = bun_core::heap::into_raw(Box::new(Wrapper {
-            promise,
-            store: store.clone(),
-            resolved_list_options: options,
-            global: bun_ptr::BackRef::new(global_this),
-        }));
-
-        s3_client::list_objects(
-            &aws_options.credentials,
-            // SAFETY: `wrapper` is freshly leaked and untouched until the
-            // callback; this borrow ends before any other access.
-            unsafe { &(*wrapper).resolved_list_options },
-            Wrapper::resolve,
-            wrapper.cast::<c_void>(),
-            proxy,
-        )?;
+        s3_client::list_objects(&aws_options.credentials, &options, Box::new(resolve), proxy)?;
 
         Ok(value)
     }
 }
 
 impl BytesExt for Bytes {
-    /// Adopt an mmap'd region. `Drop` (`allocator.free`) will `munmap` it.
-    #[cfg(unix)]
-    fn init_mmap(slice: &'static mut [u8]) -> Bytes {
-        // Stateless allocator vtable whose `free` munmap's. Same pattern as
-        // `LinuxMemFdAllocator` but without the stateful fd. Body is fully
-        // safe (`bun_sys::munmap` is a safe wrapper); the safe fn item coerces
-        // into `AllocatorVTable::free_only`'s raw fn-pointer slot.
-        fn free(_: *mut core::ffi::c_void, buf: &mut [u8], _: bun_alloc::Alignment, _: usize) {
-            if let bun_sys::Result::Err(err) = bun_sys::munmap(buf.as_mut_ptr(), buf.len()) {
-                bun_core::debug_warn!("Blob mmap-store munmap failed: {:?}", err);
-            }
-        }
-        static MMAP_FREE_VTABLE: bun_alloc::AllocatorVTable =
-            bun_alloc::AllocatorVTable::free_only(free);
-        // SAFETY: caller (C++ WebKit screenshot path) guarantees `slice` is a
-        // page-aligned mmap'd region we now own. `len == cap` so `free` munmaps
-        // exactly the same range.
-        unsafe {
-            Bytes::from_raw_parts(
-                slice.as_mut_ptr(),
-                slice.len() as SizeType,
-                slice.len() as SizeType,
-                bun_alloc::StdAllocator {
-                    ptr: core::ptr::null_mut(),
-                    vtable: &MMAP_FREE_VTABLE,
-                },
-            )
-        }
-    }
-
     fn to_internal_blob(&mut self) -> super::Internal {
-        // `Internal.bytes` is `Vec<u8>` (global allocator), so
-        // round-trip only when the storage *is* the global allocator; otherwise
-        // copy + free through the original allocator (e.g. memfd → munmap).
-        let bytes = if self.ptr.is_none() {
-            Vec::new()
-        } else if core::ptr::eq(
-            std::ptr::from_ref(self.allocator.vtable),
-            std::ptr::from_ref(bun_alloc::basic::C_ALLOCATOR.vtable),
-        ) {
-            let len = self.len as usize;
-            let cap = self.cap as usize;
-            let ptr = self.ptr.take().unwrap();
-            // SAFETY: `init(Vec<u8>)` is the only path that stores
-            // `C_ALLOCATOR`, and it recorded the exact `(ptr, len, cap)`
-            // from `Vec::into_raw_parts`-equivalent decomposition.
-            unsafe { Vec::from_raw_parts(ptr.as_ptr(), len, cap) }
-        } else {
-            // Non-global allocator (e.g. memfd → munmap): copy through the
-            // safe `Bytes::slice()` accessor, then free via the owning vtable
-            // — same path `Bytes::drop` takes (`allocator.free(allocated_slice())`).
-            let copy = self.slice().to_vec();
-            self.allocator.free(self.allocated_slice());
-            self.ptr = None;
-            copy
-        };
-        self.len = 0;
-        self.cap = 0;
-        self.allocator = bun_alloc::basic::C_ALLOCATOR;
+        // `Internal.bytes` is `Vec<u8>` (global allocator): the allocation
+        // itself when the storage *is* the global allocator's, otherwise a
+        // copy (and the original is freed through its allocator, e.g. munmap).
         super::Internal {
-            bytes,
+            bytes: self.take_vec(),
             was_string: false,
         }
     }
-}
-
-/// JSC `ArrayBuffer` external
-/// deallocator callback for buffers backed by a `Blob.Store`. C++ stashes a
-/// `*mut Store` as the deallocator context; this releases that ref.
-#[unsafe(no_mangle)]
-pub(crate) extern "C" fn BlobArrayBuffer_deallocator(
-    _bytes: *mut core::ffi::c_void,
-    blob: *mut core::ffi::c_void,
-) {
-    // SAFETY: `blob` is the non-null `*mut Store` C++ stashed as deallocator
-    // context (originating from `heap::alloc` / `RefPtr<Store>::into_raw`); it
-    // owns one outstanding reference being released here.
-    unsafe { Store::deref(NonNull::new_unchecked(blob.cast::<Store>())) };
 }

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -1335,7 +1335,7 @@ impl CopyFileWindows {
     /// the read/write loop handles those.
     fn resolve_copy_path<'a>(
         pathlike: &'a PathOrFileDescriptor,
-        buf: &'a mut PathBuffer,
+        buf: &'a mut bun_paths::PathBuffer,
     ) -> bun_sys::Result<Option<&'a bun_core::ZStr>> {
         match pathlike {
             PathOrFileDescriptor::Path(_) => Ok(Some(pathlike.path().slice_z(buf))),

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -19,25 +19,19 @@ use bun_sys::windows::libuv;
 use bun_sys::{self, Fd, FdExt, Mode, SystemError};
 #[cfg(windows)]
 use bun_sys_jsc::ErrorJsc as _;
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use core::ffi::c_int;
-#[cfg(windows)]
-use core::ffi::c_void;
 use core::marker::ConstParamTy;
 
 // ───────────────────────────────────────────────────────────────────────────
 // CopyFile (POSIX, blocking off-thread)
 // ───────────────────────────────────────────────────────────────────────────
 
+#[cfg_attr(windows, allow(dead_code))] // Windows copies go through `CopyFileWindows`
 pub struct CopyFile {
-    #[cfg(not(windows))]
-    pub(crate) destination_file_store: store::File,
-    pub(crate) source_file_store: store::File,
-    // `RefPtr<Store>` is the thread-safe refcounted handle;
-    // it keeps the stores — and the path slices the `File` clones borrow — alive
-    // while this task is on the work pool.
-    pub(crate) store: Option<RefPtr<Store>>,
-    pub(crate) source_store: Option<RefPtr<Store>>,
+    /// The destination store (a `Data::File`); its `File` is
+    /// [`destination_file_store`](Self::destination_file_store). The refs keep
+    /// both stores alive while this task is on the work pool.
+    pub(crate) store: RefPtr<Store>,
+    pub(crate) source_store: RefPtr<Store>,
     pub offset: SizeType,
     #[cfg(not(windows))]
     pub(crate) max_length: SizeType,
@@ -67,9 +61,6 @@ impl MkdirpTarget for CopyFile {
     }
 }
 
-// SAFETY: file stores/paths and blob store refs (atomic counts); nothing thread-affine.
-unsafe impl Send for CopyFile {}
-
 impl jsc::JobContext for CopyFile {
     type OffThread = Self;
     type Js = jsc::JSPromiseStrong;
@@ -78,15 +69,26 @@ impl jsc::JobContext for CopyFile {
         Some(done)
     }
     fn then(
-        mut this: Self,
+        this: Self,
         mut promise: jsc::JSPromiseStrong,
         cx: &jsc::JsThread<'_>,
     ) -> jsc::JsResult<()> {
-        CopyFile::then(&mut this, promise.swap(), cx.global())
+        CopyFile::then(this, promise.swap(), cx.global())
     }
 }
 
 impl CopyFile {
+    #[cfg(not(windows))]
+    #[inline]
+    pub(crate) fn destination_file_store(&self) -> &store::File {
+        self.store.data.as_file()
+    }
+
+    #[inline]
+    pub(crate) fn source_file_store(&self) -> &store::File {
+        self.source_store.data.as_file()
+    }
+
     /// Schedule the copy on the work pool; returns its promise.
     #[cfg(not(windows))]
     pub(crate) fn create(
@@ -99,10 +101,8 @@ impl CopyFile {
         destination_mode: Option<Mode>,
     ) -> JSValue {
         let copy = CopyFile {
-            destination_file_store: store.data.as_file().clone(),
-            source_file_store: source_store.data.as_file().clone(),
-            store: Some(store),
-            source_store: Some(source_store),
+            store,
+            source_store,
             offset: off,
             max_length: max_len,
             mkdirp_if_not_exists,
@@ -121,18 +121,18 @@ impl CopyFile {
     }
 
     pub(crate) fn reject(
-        &mut self,
+        mut self,
         promise: &mut JSPromise,
         global_this: &JSGlobalObject,
     ) -> jsc::JsResult<()> {
         let mut system_error: SystemError = self.system_error.take().unwrap_or_default();
         if matches!(
-            self.source_file_store.pathlike,
+            self.source_file_store().pathlike,
             PathOrFileDescriptor::Path(_)
         ) && system_error.path.is_empty()
         {
             system_error.path =
-                bun_core::String::clone_utf8(self.source_file_store.pathlike.path().slice());
+                bun_core::String::clone_utf8(self.source_file_store().pathlike.path().slice());
         }
 
         if system_error.message.is_empty() {
@@ -141,37 +141,36 @@ impl CopyFile {
 
         let instance = jsc::SystemError::from(system_error)
             .to_error_instance_with_async_stack(global_this, promise);
-        if let Some(store) = self.store.take() {
-            drop(store); // deref()
-        }
+        // Releases both store refs before settling.
+        drop(self);
         promise.reject(global_this, Ok(instance))
     }
 
     pub(crate) fn then(
-        &mut self,
+        self,
         promise: &mut JSPromise,
         global_this: &JSGlobalObject,
     ) -> jsc::JsResult<()> {
-        drop(self.source_store.take()); // source_store.?.deref()
-
         if self.system_error.is_some() {
             return self.reject(promise, global_this);
         }
 
-        promise.resolve(
-            global_this,
-            JSValue::js_number_from_uint64(self.read_len as u64),
-        )
+        let read_len = self.read_len;
+        // Releases both store refs before settling.
+        drop(self);
+        promise.resolve(global_this, JSValue::js_number_from_uint64(read_len as u64))
     }
 
     #[cfg(not(windows))]
     pub(crate) fn do_close(&mut self) {
         let close_input = !matches!(
-            self.destination_file_store.pathlike,
+            self.destination_file_store().pathlike,
             PathOrFileDescriptor::Fd(_)
         ) && self.destination_fd != Fd::INVALID;
-        let close_output = !matches!(self.source_file_store.pathlike, PathOrFileDescriptor::Fd(_))
-            && self.source_fd != Fd::INVALID;
+        let close_output = !matches!(
+            self.source_file_store().pathlike,
+            PathOrFileDescriptor::Fd(_)
+        ) && self.source_fd != Fd::INVALID;
 
         // Apply destination mode using fchmod before closing.
         // This ensures mode is applied even when overwriting existing files, since
@@ -220,7 +219,7 @@ impl CopyFile {
         // if it fails, we don't want the extra destination file hanging out
         if matches!(WHICH, IOWhich::Both | IOWhich::Source) {
             self.source_fd = match bun_sys::open(
-                self.source_file_store
+                self.source_file_store()
                     .pathlike
                     .path()
                     .slice_z(&mut path_buf1),
@@ -251,13 +250,13 @@ impl CopyFile {
                 // detach `dest` lifetime from `self` (borrowck) — slice_z
                 // copies into path_buf1, so build the ZStr directly from the buffer.
                 let dest_len = {
-                    let s = self.destination_file_store.pathlike.path().slice();
+                    let s = self.destination_file_store().pathlike.path().slice();
                     let n = s.len().min(path_buf1.len() - 1);
                     path_buf1[..n].copy_from_slice(&s[..n]);
                     path_buf1[n] = 0;
                     n
                 };
-                // SAFETY: path_buf1[dest_len] == 0 written above.
+                // path_buf1[dest_len] == 0 written above.
                 let dest: &bun_core::ZStr = bun_core::ZStr::from_buf(&path_buf1[..], dest_len);
                 let mode = self.destination_mode.unwrap_or(node_fs::DEFAULT_PERMISSION);
                 match bun_sys::open(dest, OPEN_DESTINATION_FLAGS, mode) {
@@ -293,7 +292,7 @@ impl CopyFile {
 
                         self.system_error = Some(
                             errno
-                                .with_path(self.destination_file_store.pathlike.path().slice())
+                                .with_path(self.destination_file_store().pathlike.path().slice())
                                 .to_system_error(),
                         );
                         return Err(bun_errno::from_errno(errno.errno as i32).into());
@@ -316,7 +315,7 @@ impl CopyFile {
         total_written: &mut u64,
     ) -> Result<(), crate::Error> {
         let bun_opened_dest = matches!(
-            self.destination_file_store.pathlike,
+            self.destination_file_store().pathlike,
             PathOrFileDescriptor::Path(_)
         );
         let cap = if unknown_size {
@@ -343,8 +342,6 @@ impl CopyFile {
     pub(crate) fn do_copy_file_range<const USE: TryWith, const CLEAR_APPEND_IF_INVALID: bool>(
         &mut self,
     ) -> Result<(), crate::Error> {
-        use bun_sys::linux;
-
         let mut remain: usize = self.max_length as usize;
         let unknown_size = remain == MAX_SIZE as usize || remain == 0;
         if unknown_size {
@@ -356,65 +353,39 @@ impl CopyFile {
         }
 
         let mut total_written: u64 = 0;
+        let result = self.copy_file_range_loop::<USE, CLEAR_APPEND_IF_INVALID>(
+            remain,
+            unknown_size,
+            &mut total_written,
+        );
+        self.read_len = total_written as SizeType;
+        result
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn copy_file_range_loop<const USE: TryWith, const CLEAR_APPEND_IF_INVALID: bool>(
+        &mut self,
+        mut remain: usize,
+        unknown_size: bool,
+        total_written: &mut u64,
+    ) -> Result<(), crate::Error> {
+        use bun_sys::linux;
         let src_fd = self.source_fd;
         let dest_fd = self.destination_fd;
-
-        let read_len_slot: *mut SizeType = &raw mut self.read_len;
-        let total_written_slot: *const u64 = core::ptr::addr_of!(total_written);
-        scopeguard::defer! {
-            // SAFETY: both raw ptrs point into the enclosing stack frame which
-            // outlives this guard (dropped before fn return); disjoint fields.
-            unsafe { *read_len_slot = *total_written_slot as SizeType };
-        }
-
         let mut has_unset_append = false;
 
         // If they can't use copy_file_range, they probably also can't
         // use sendfile() or splice()
         if !bun_sys::copy_file::can_use_copy_file_range_syscall() {
-            return self.fallback_read_write(remain, unknown_size, &mut total_written);
+            return self.fallback_read_write(remain, unknown_size, total_written);
         }
 
         loop {
             // TODO: this should use non-blocking I/O.
             let written: isize = match USE {
-                TryWith::CopyFileRange => {
-                    // SAFETY: raw copy_file_range(2); both fds owned by caller, null offsets.
-                    unsafe {
-                        linux::copy_file_range(
-                            src_fd.native(),
-                            core::ptr::null_mut(),
-                            dest_fd.native(),
-                            core::ptr::null_mut(),
-                            remain,
-                            0,
-                        )
-                    }
-                }
-                TryWith::Sendfile => {
-                    // SAFETY: raw sendfile(2); both fds owned by caller, null offset.
-                    unsafe {
-                        linux::sendfile(
-                            dest_fd.native(),
-                            src_fd.native(),
-                            core::ptr::null_mut(),
-                            remain,
-                        )
-                    }
-                }
-                TryWith::Splice => {
-                    // SAFETY: raw splice(2); both fds owned by caller, null offsets.
-                    unsafe {
-                        libc::splice(
-                            src_fd.native(),
-                            core::ptr::null_mut(),
-                            dest_fd.native(),
-                            core::ptr::null_mut(),
-                            remain,
-                            0,
-                        )
-                    }
-                }
+                TryWith::CopyFileRange => linux::copy_file_range_cur(src_fd, dest_fd, remain, 0),
+                TryWith::Sendfile => linux::sendfile_cur(dest_fd, src_fd, remain),
+                TryWith::Splice => linux::splice_cur(src_fd, dest_fd, remain, 0),
             };
 
             match bun_sys::get_errno(written) {
@@ -425,7 +396,7 @@ impl CopyFile {
                 // OPNOTSUPP: filesystem doesn't support this operation
                 bun_sys::E::ENOSYS | bun_sys::E::EXDEV | bun_sys::E::ENOTSUP => {
                     // TODO: this should use non-blocking I/O.
-                    return self.fallback_read_write(remain, unknown_size, &mut total_written);
+                    return self.fallback_read_write(remain, unknown_size, total_written);
                 }
 
                 // EINVAL: eCryptfs and other filesystems may not support copy_file_range.
@@ -437,18 +408,15 @@ impl CopyFile {
                             // make() can set STDOUT / STDERR to O_APPEND
                             // this messes up sendfile()
                             has_unset_append = true;
-                            // SAFETY: dest_fd is a valid open fd; raw fcntl(2).
-                            let flags =
-                                unsafe { libc::fcntl(dest_fd.native(), libc::F_GETFL, 0 as c_int) };
+                            let flags = match bun_sys::get_fcntl_flags(dest_fd) {
+                                Ok(flags) => flags as i32,
+                                Err(_) => -1,
+                            };
                             if (flags & bun_sys::O::APPEND) != 0 {
-                                // SAFETY: dest_fd is a valid open fd; raw fcntl(2).
-                                let _ = unsafe {
-                                    libc::fcntl(
-                                        dest_fd.native(),
-                                        libc::F_SETFL,
-                                        flags ^ bun_sys::O::APPEND,
-                                    )
-                                };
+                                let _ = bun_sys::set_fcntl_flags(
+                                    dest_fd,
+                                    (flags ^ bun_sys::O::APPEND) as bun_sys::FcntlInt,
+                                );
                                 continue;
                             }
                         }
@@ -458,9 +426,9 @@ impl CopyFile {
                     // copy_file_range or the file descriptor is
                     // incompatible with the chosen syscall, fall back
                     // to a read/write loop
-                    if total_written == 0 {
+                    if *total_written == 0 {
                         // TODO: this should use non-blocking I/O.
-                        return self.fallback_read_write(remain, unknown_size, &mut total_written);
+                        return self.fallback_read_write(remain, unknown_size, total_written);
                     }
 
                     self.system_error = Some(
@@ -489,7 +457,7 @@ impl CopyFile {
             }
 
             // wrote zero bytes means EOF
-            total_written += u64::try_from(written).expect("int cast");
+            *total_written += u64::try_from(written).expect("int cast");
             if written == 0 {
                 break;
             }
@@ -581,22 +549,27 @@ impl CopyFile {
             // bytes live in `dest_buf`, so capture the length and re-borrow
             // from the buffer (not `self`) after dropping the first borrow.
             let dest_len = self
-                .destination_file_store
+                .destination_file_store()
                 .pathlike
                 .path()
                 .slice_z(&mut dest_buf)
                 .len();
-            // SAFETY: `slice_z` wrote `dest_len` bytes + NUL into `dest_buf`.
+            // `slice_z` wrote `dest_len` bytes + NUL into `dest_buf`.
             let dest = bun_core::ZStr::from_buf(&dest_buf[..], dest_len);
             match bun_sys::clonefile(
-                self.source_file_store
+                self.source_file_store()
                     .pathlike
                     .path()
                     .slice_z(&mut source_buf),
                 dest,
             ) {
                 bun_sys::Result::Err(errno) => {
-                    let err_path = self.destination_file_store.pathlike.path().slice().to_vec();
+                    let err_path = self
+                        .destination_file_store()
+                        .pathlike
+                        .path()
+                        .slice()
+                        .to_vec();
                     match blob::mkdir_if_not_exists(self, &errno, dest, &err_path) {
                         Retry::Continue => continue,
                         Retry::Fail => {}
@@ -624,11 +597,11 @@ impl CopyFile {
             #[cfg(not(target_os = "macos"))]
             let stat_: Option<Stat> = None;
 
-            if let PathOrFileDescriptor::Fd(fd) = &self.destination_file_store.pathlike {
+            if let PathOrFileDescriptor::Fd(fd) = &self.destination_file_store().pathlike {
                 self.destination_fd = *fd;
             }
 
-            if let PathOrFileDescriptor::Fd(fd) = &self.source_file_store.pathlike {
+            if let PathOrFileDescriptor::Fd(fd) = &self.source_file_store().pathlike {
                 self.source_fd = *fd;
             }
 
@@ -640,11 +613,11 @@ impl CopyFile {
                 {
                     if self.offset == 0
                         && matches!(
-                            self.source_file_store.pathlike,
+                            self.source_file_store().pathlike,
                             PathOrFileDescriptor::Path(_)
                         )
                         && matches!(
-                            self.destination_file_store.pathlike,
+                            self.destination_file_store().pathlike,
                             PathOrFileDescriptor::Path(_)
                         )
                     {
@@ -654,7 +627,7 @@ impl CopyFile {
                             // stat the output file, make sure it:
                             // 1. Exists
                             match bun_sys::stat(
-                                self.source_file_store
+                                self.source_file_store()
                                     .pathlike
                                     .path()
                                     .slice_z(&mut path_buf),
@@ -686,17 +659,13 @@ impl CopyFile {
                                             < SizeType::try_from(stat_size).expect("int cast")
                                     {
                                         // If this fails...well, there's not much we can do about it.
-                                        // SAFETY: NUL-terminated path in path_buf; libc truncate(2).
-                                        let _ = unsafe {
-                                            bun_sys::c::truncate(
-                                                self.destination_file_store
-                                                    .pathlike
-                                                    .path()
-                                                    .slice_z(&mut path_buf)
-                                                    .as_ptr(),
-                                                i64::try_from(self.max_length).expect("int cast"),
-                                            )
-                                        };
+                                        let _ = bun_sys::truncate(
+                                            self.destination_file_store()
+                                                .pathlike
+                                                .path()
+                                                .slice_z(&mut path_buf),
+                                            i64::try_from(self.max_length).expect("int cast"),
+                                        );
                                         self.read_len =
                                             SizeType::try_from(self.max_length).expect("int cast");
                                     } else {
@@ -706,7 +675,7 @@ impl CopyFile {
                                     // Apply destination mode if specified (clonefile copies source permissions)
                                     if let Some(mode) = self.destination_mode {
                                         match bun_sys::chmod(
-                                            self.destination_file_store
+                                            self.destination_file_store()
                                                 .pathlike
                                                 .path()
                                                 .slice_z(&mut path_buf),
@@ -738,14 +707,14 @@ impl CopyFile {
                 }
                 // Do we need to open only one file?
             } else if self.destination_fd == Fd::INVALID {
-                self.source_fd = self.source_file_store.pathlike.fd();
+                self.source_fd = self.source_file_store().pathlike.fd();
 
                 if self.do_open_file::<{ IOWhich::Destination }>().is_err() {
                     return;
                 }
                 // Do we need to open only one file?
             } else if self.source_fd == Fd::INVALID {
-                self.destination_fd = self.destination_file_store.pathlike.fd();
+                self.destination_fd = self.destination_file_store().pathlike.fd();
 
                 if self.do_open_file::<{ IOWhich::Source }>().is_err() {
                     return;
@@ -760,7 +729,7 @@ impl CopyFile {
             debug_assert!(self.source_fd.is_valid());
 
             if matches!(
-                self.destination_file_store.pathlike,
+                self.destination_file_store().pathlike,
                 PathOrFileDescriptor::Fd(_)
             ) {
                 // nothing to do for the Fd case
@@ -799,7 +768,7 @@ impl CopyFile {
 
                 if PREALLOCATE_SUPPORTED
                     && matches!(
-                        self.destination_file_store.pathlike,
+                        self.destination_file_store().pathlike,
                         PathOrFileDescriptor::Path(_)
                     )
                     && self.max_length > PREALLOCATE_LENGTH
@@ -817,10 +786,10 @@ impl CopyFile {
             {
                 // Bun.write(Bun.file("a"), Bun.file("b"))
                 if bun_sys::S::ISREG(stat.st_mode as _)
-                    && (bun_sys::S::ISREG(self.destination_file_store.mode as _)
-                        || self.destination_file_store.mode == 0)
+                    && (bun_sys::S::ISREG(self.destination_file_store().mode as _)
+                        || self.destination_file_store().mode == 0)
                 {
-                    if self.destination_file_store.is_atty.unwrap_or(false) {
+                    if self.destination_file_store().is_atty.unwrap_or(false) {
                         let _ = self.do_copy_file_range::<{ TryWith::CopyFileRange }, true>();
                     } else {
                         let _ = self.do_copy_file_range::<{ TryWith::CopyFileRange }, false>();
@@ -832,9 +801,9 @@ impl CopyFile {
 
                 // $ bun run foo.js | bun run bar.js
                 if bun_sys::S::ISFIFO(stat.st_mode as _)
-                    && bun_sys::S::ISFIFO(self.destination_file_store.mode as _)
+                    && bun_sys::S::ISFIFO(self.destination_file_store().mode as _)
                 {
-                    if self.destination_file_store.is_atty.unwrap_or(false) {
+                    if self.destination_file_store().is_atty.unwrap_or(false) {
                         let _ = self.do_copy_file_range::<{ TryWith::Splice }, true>();
                     } else {
                         let _ = self.do_copy_file_range::<{ TryWith::Splice }, false>();
@@ -848,7 +817,7 @@ impl CopyFile {
                     || bun_sys::S::ISCHR(stat.st_mode as _)
                     || bun_sys::S::ISSOCK(stat.st_mode as _)
                 {
-                    if self.destination_file_store.is_atty.unwrap_or(false) {
+                    if self.destination_file_store().is_atty.unwrap_or(false) {
                         let _ = self.do_copy_file_range::<{ TryWith::Sendfile }, true>();
                     } else {
                         let _ = self.do_copy_file_range::<{ TryWith::Sendfile }, false>();
@@ -868,7 +837,7 @@ impl CopyFile {
                 // fcopyfile rewrites dest from offset 0 and the slice trim is
                 // ftruncate; both are only safe for a dest Bun opened O_TRUNC.
                 if matches!(
-                    self.destination_file_store.pathlike,
+                    self.destination_file_store().pathlike,
                     PathOrFileDescriptor::Path(_)
                 ) {
                     if self.do_fcopy_file_with_read_write_loop_fallback().is_err() {
@@ -895,7 +864,7 @@ impl CopyFile {
             #[cfg(target_os = "freebsd")]
             {
                 if matches!(
-                    self.destination_file_store.pathlike,
+                    self.destination_file_store().pathlike,
                     PathOrFileDescriptor::Path(_)
                 ) {
                     let mut total_written: u64 = 0;
@@ -979,18 +948,17 @@ fn read_write_loop_capped(
     cap: SizeType,
     total: &mut u64,
 ) -> bun_sys::Result<()> {
-    let mut stack_buf = bun_core::vec::UninitBuf::<{ 64 * 1024 }>::uninit();
-    // SAFETY: `read` is the only writer of `buf`; each iteration reads back only `buf[..amt]`.
-    let buf = unsafe { stack_buf.as_bytes_mut() };
+    let mut buf = [core::mem::MaybeUninit::<u8>::uninit(); 64 * 1024];
     let mut remaining = cap;
     while remaining > 0 {
         let want = (buf.len() as SizeType).min(remaining) as usize;
-        let amt = bun_sys::read(src_fd, &mut buf[..want])?;
+        let read: &[u8] = bun_sys::read_uninit(src_fd, &mut buf[..want])?;
+        let amt = read.len();
         if amt == 0 {
             break;
         }
         remaining -= amt as SizeType;
-        let mut slice = &buf[..amt];
+        let mut slice = read;
         while !slice.is_empty() {
             match bun_sys::write(dest_fd, slice)? {
                 0 => return Ok(()),
@@ -1004,14 +972,7 @@ fn read_write_loop_capped(
     Ok(())
 }
 
-// Ownership is encoded in the types, so cleanup is all field `Drop`:
-// `source_file_store.pathlike` is a `PathLike` clone that is independently
-// droppable — `PathLike::clone` dupes owned string buffers (freed by the
-// clone's own `CowSlice` drop), bumps refs for WTF-backed slices, and only
-// shares the backing for borrowed-string/Buffer variants (whose owner is kept
-// alive by the `source_store` `RefPtr<Store>`). Each clone's field `Drop` frees
-// exactly what it owns; the `RefPtr<Store>`s release just their Store refcounts on
-// drop. No explicit `Drop` impl is needed.
+// Cleanup is all field `Drop`: the `RefPtr<Store>`s release their Store refcounts.
 
 // Kept local until bun_sys exports these; values match crate::node::fs.
 #[cfg(not(windows))]
@@ -1045,10 +1006,14 @@ impl TryWith {
 
 // ───────────────────────────────────────────────────────────────────────────
 // CopyFileWindows (libuv async)
+//
+// Owned as a `Box` by whoever drives the next step: libuv while a
+// copyfile/read/write/chmod is in flight (`bun_io::uv_fs`), the mkdirp hop, or
+// the code below. Settling the promise drops the box.
 // ───────────────────────────────────────────────────────────────────────────
 
 #[cfg(windows)]
-pub struct CopyFileWindows<'a> {
+pub struct CopyFileWindows {
     pub(crate) destination_file_store: RefPtr<Store>,
     pub(crate) source_file_store: RefPtr<Store>,
 
@@ -1056,10 +1021,7 @@ pub struct CopyFileWindows<'a> {
     pub(crate) promise: jsc::JSPromiseStrong,
     pub(crate) mkdirp_if_not_exists: bool,
     pub(crate) destination_mode: Option<Mode>,
-    // per LIFETIMES.tsv: JSC_BORROW → &jsc::EventLoop
-    // TODO(refactor): lifetime — heap-allocated and re-entered from libuv callbacks;
-    // likely should be *const jsc::EventLoop.
-    pub(crate) event_loop: &'a jsc::event_loop::EventLoop,
+    pub(crate) event_loop: bun_ptr::BackRef<jsc::event_loop::EventLoop>,
 
     pub(crate) size: SizeType,
 
@@ -1074,6 +1036,9 @@ pub struct CopyFileWindows<'a> {
 }
 
 #[cfg(windows)]
+bun_io::intrusive_uv_fs!(CopyFileWindows, io_request);
+
+#[cfg(windows)]
 pub struct ReadWriteLoop {
     pub(crate) source_fd: Fd,
     pub(crate) must_close_source_fd: bool,
@@ -1081,7 +1046,8 @@ pub struct ReadWriteLoop {
     pub(crate) must_close_destination_fd: bool,
     pub(crate) written: usize,
     pub(crate) read_buf: Vec<u8>,
-    pub(crate) uv_buf: libuv::uv_buf_t,
+    /// How much of `read_buf` the current chunk's writes have consumed.
+    pub(crate) chunk_written: usize,
 }
 
 #[cfg(windows)]
@@ -1094,62 +1060,58 @@ impl Default for ReadWriteLoop {
             must_close_destination_fd: false,
             written: 0,
             read_buf: Vec::new(),
-            uv_buf: libuv::uv_buf_t {
-                len: 0,
-                base: core::ptr::null_mut(),
-            },
+            chunk_written: 0,
         }
     }
 }
 
-// `ReadWriteLoop` is a subobject of `CopyFileWindows`, so passing both as
-// `&mut` would be aliasing UB. These are hoisted onto `CopyFileWindows` so the
-// borrow checker can see `self.read_write_loop` / `self.io_request` / `self.event_loop`
-// as disjoint field accesses through a single `&mut self`.
 #[cfg(windows)]
-impl<'a> CopyFileWindows<'a> {
-    fn read_write_loop_start(&mut self) -> bun_sys::Result<()> {
-        self.read_write_loop.read_buf.reserve_exact(64 * 1024);
-
-        self.read_write_loop_read()
+impl CopyFileWindows {
+    /// On return, libuv has `this` (until `on_fs_read`) or it has finished.
+    fn read_write_loop_start(mut this: Box<Self>) {
+        this.read_write_loop.read_buf.reserve_exact(64 * 1024);
+        Self::read_write_loop_read(this);
     }
 
-    fn read_write_loop_read(&mut self) -> bun_sys::Result<()> {
-        self.read_write_loop.read_buf.clear();
-        // reshaped for borrowck — use the full capacity slice.
-        let cap = self.read_write_loop.read_buf.capacity();
-        self.read_write_loop.uv_buf = libuv::uv_buf_t {
-            len: cap as libuv::ULONG,
-            base: self.read_write_loop.read_buf.as_mut_ptr(),
-        };
-        let source_fd = self.read_write_loop.source_fd;
-        let loop_ = self.event_loop.uv_loop();
+    /// On return, libuv has `this` (until `on_fs_read`) or it has finished.
+    fn read_write_loop_read(mut this: Box<Self>) {
+        this.read_write_loop.read_buf.clear();
+        this.read_write_loop.chunk_written = 0;
+        let source_fd = this.read_write_loop.source_fd.uv();
+        let cap = this.read_write_loop.read_buf.capacity();
 
         // This io_request is used for both reading and writing.
         // For now, we don't start reading the next chunk until
         // we've finished writing all the previous chunks.
-        self.io_request.data = core::ptr::from_mut(self).cast::<c_void>();
-
-        // SAFETY: FFI — `loop_` is the live VM uv loop, `io_request` is a zeroed/cleaned
-        // `fs_t` owned by `self`, `uv_buf` points into `read_buf`'s capacity, and
-        // `on_read` is a valid `uv_fs_cb`.
-        let rc = unsafe {
-            libuv::uv_fs_read(
-                loop_,
-                &mut self.io_request,
-                source_fd.uv(),
-                core::ptr::from_mut(&mut self.read_write_loop.uv_buf),
-                1,
-                -1,
-                Some(on_read),
-            )
-        };
-
-        if let Some(err) = rc.to_error(bun_sys::Tag::read) {
-            return bun_sys::Result::Err(err);
+        if let Err((this, rc)) = aio::uv_fs::read(
+            this,
+            source_fd,
+            |t: &mut Self| &mut t.read_write_loop.read_buf,
+            cap,
+            -1,
+        ) {
+            let err = rc.to_error(bun_sys::Tag::read).expect("negative rc");
+            Self::fail_read_write_loop(this, err);
         }
+    }
 
-        bun_sys::Result::Ok(())
+    /// The rest of the current chunk still to be written.
+    fn pending_chunk(&self) -> &[u8] {
+        &self.read_write_loop.read_buf[self.read_write_loop.chunk_written..]
+    }
+
+    /// On return, libuv has `this` (until `on_fs_write`) or it has finished.
+    fn read_write_loop_write(this: Box<Self>) {
+        let destination_fd = this.read_write_loop.destination_fd.uv();
+        if let Err((this, rc)) = aio::uv_fs::write(this, destination_fd, Self::pending_chunk, -1) {
+            let err = rc.to_error(bun_sys::Tag::write).expect("negative rc");
+            Self::fail_read_write_loop(this, err);
+        }
+    }
+
+    fn fail_read_write_loop(mut this: Box<Self>, err: bun_sys::Error) {
+        this.err = Some(err);
+        Self::on_read_write_loop_complete(this);
     }
 }
 
@@ -1187,205 +1149,117 @@ impl ReadWriteLoop {
 }
 
 #[cfg(windows)]
-extern "C" fn on_read(req: *mut libuv::fs_t) {
-    // SAFETY: `req->data` was set to `core::ptr::from_mut(self)` (whole-struct
-    // provenance) before scheduling. Recover the parent from `data` rather than
-    // `from_field_ptr!(.., io_request, req)`: the `req` pointer libuv hands back was
-    // produced from a `&mut self.io_request` reborrow whose provenance covers only the
-    // `io_request` field, so `container_of`-style subtraction would yield a
-    // `*mut CopyFileWindows` with out-of-bounds provenance (UB under Stacked/Tree
-    // Borrows). After forming `this`, access the request via `this.io_request` — never
-    // through `(*req)`, which would alias the live `&mut`.
-    let this: &mut CopyFileWindows = unsafe { &mut *(*req).data.cast::<CopyFileWindows>() };
-    debug_assert!(core::ptr::addr_of_mut!(this.io_request) == req);
+impl aio::uv_fs::OnFsRead for CopyFileWindows {
+    fn on_fs_read(mut this: Box<Self>, rc: libuv::ReturnCodeI64) {
+        let source_fd = this.read_write_loop.source_fd;
 
-    let source_fd = this.read_write_loop.source_fd;
-    let destination_fd = this.read_write_loop.destination_fd;
-    // reshaped for borrowck — `read_buf.items` is `Vec` len-slice.
-    let read_buf = &mut this.read_write_loop.read_buf;
+        bun_sys::syslog!(
+            "uv_fs_read({}, {}) = {}",
+            source_fd,
+            this.read_write_loop.read_buf.len(),
+            rc.int()
+        );
+        if let Some(err) = rc.to_error(bun_sys::Tag::read) {
+            return Self::fail_read_write_loop(this, err);
+        }
 
-    let event_loop = this.event_loop;
-
-    let rc = this.io_request.result;
-
-    bun_sys::syslog!(
-        "uv_fs_read({}, {}) = {}",
-        source_fd,
-        read_buf.len(),
-        rc.int()
-    );
-    if let Some(err) = rc.to_error(bun_sys::Tag::read) {
-        this.err = Some(err);
-        this.on_read_write_loop_complete();
-        return;
-    }
-
-    let n = usize::try_from(rc.int()).expect("int cast");
-    // SAFETY: libuv wrote `n` bytes into the buffer's capacity.
-    unsafe { read_buf.set_len(n) };
-    this.read_write_loop.uv_buf = libuv::uv_buf_t::init(read_buf.as_slice());
-
-    if rc.int() == 0 {
-        // Handle EOF. We can't read any more.
-        this.on_read_write_loop_complete();
-        return;
-    }
-
-    // Re-use the fs request.
-    this.io_request.deinit();
-    // SAFETY: FFI — `io_request` was just cleaned via `deinit()`, `uv_buf` points into
-    // `read_buf` (len set above), and `on_write` is a valid `uv_fs_cb`.
-    let rc2 = unsafe {
-        libuv::uv_fs_write(
-            event_loop.uv_loop(),
-            &mut this.io_request,
-            destination_fd.uv(),
-            core::ptr::from_mut(&mut this.read_write_loop.uv_buf),
-            1,
-            -1,
-            Some(on_write),
-        )
-    };
-    this.io_request.data = core::ptr::from_mut(this).cast::<c_void>();
-
-    if let Some(err) = rc2.to_error(bun_sys::Tag::write) {
-        this.err = Some(err);
-        this.on_read_write_loop_complete();
-        return;
-    }
-}
-
-#[cfg(windows)]
-extern "C" fn on_write(req: *mut libuv::fs_t) {
-    // SAFETY: see `on_read` — recover from `req->data` (whole-struct provenance),
-    // not `from_field_ptr!`; then access the request only via `this.io_request`.
-    let this: &mut CopyFileWindows = unsafe { &mut *(*req).data.cast::<CopyFileWindows>() };
-    debug_assert!(core::ptr::addr_of_mut!(this.io_request) == req);
-    let buf_len = this.read_write_loop.read_buf.len();
-
-    let destination_fd = this.read_write_loop.destination_fd;
-
-    let rc = this.io_request.result;
-
-    bun_sys::syslog!(
-        "uv_fs_write({}, {}) = {}",
-        destination_fd,
-        buf_len,
-        rc.int()
-    );
-
-    if let Some(err) = rc.to_error(bun_sys::Tag::write) {
-        this.err = Some(err);
-        this.on_read_write_loop_complete();
-        return;
-    }
-
-    let wrote: u32 = u32::try_from(rc.int()).expect("int cast");
-
-    this.read_write_loop.written += wrote as usize;
-
-    if (wrote as usize) < buf_len {
-        if wrote == 0 {
-            // Handle EOF. We can't write any more.
-            this.on_read_write_loop_complete();
-            return;
+        // `uv_fs::read` already appended the `rc` bytes to `read_buf`.
+        if rc.int() == 0 {
+            // Handle EOF. We can't read any more.
+            return Self::on_read_write_loop_complete(this);
         }
 
         // Re-use the fs request.
         this.io_request.deinit();
-        this.io_request.data = core::ptr::from_mut(this).cast::<c_void>();
-
-        let prev = this.read_write_loop.uv_buf.slice();
-        this.read_write_loop.uv_buf = libuv::uv_buf_t::init(&prev[wrote as usize..]);
-        // SAFETY: FFI — `io_request` was just cleaned via `deinit()`, `uv_buf` is a tail
-        // slice of the previous write buffer (still backed by `read_buf`), and
-        // `on_write` is a valid `uv_fs_cb`.
-        let rc2 = unsafe {
-            libuv::uv_fs_write(
-                this.event_loop.uv_loop(),
-                &mut this.io_request,
-                destination_fd.uv(),
-                core::ptr::from_mut(&mut this.read_write_loop.uv_buf),
-                1,
-                -1,
-                Some(on_write),
-            )
-        };
-
-        if let Some(err) = rc2.to_error(bun_sys::Tag::write) {
-            this.err = Some(err);
-            this.on_read_write_loop_complete();
-            return;
-        }
-
-        return;
-    }
-
-    this.io_request.deinit();
-    match this.read_write_loop_read() {
-        bun_sys::Result::Err(err) => {
-            this.err = Some(err);
-            this.on_read_write_loop_complete();
-        }
-        bun_sys::Result::Ok(()) => {}
+        Self::read_write_loop_write(this);
     }
 }
 
 #[cfg(windows)]
-impl<'a> CopyFileWindows<'a> {
-    pub(crate) fn on_read_write_loop_complete(&mut self) {
-        self.event_loop.unref_keep_alive();
+impl aio::uv_fs::OnFsWrite for CopyFileWindows {
+    fn on_fs_write(mut this: Box<Self>, rc: libuv::ReturnCodeI64) {
+        let buf_len = this.pending_chunk().len();
+        let destination_fd = this.read_write_loop.destination_fd;
 
-        if let Some(err) = self.err.take() {
-            self.throw(err);
-            return;
+        bun_sys::syslog!(
+            "uv_fs_write({}, {}) = {}",
+            destination_fd,
+            buf_len,
+            rc.int()
+        );
+
+        if let Some(err) = rc.to_error(bun_sys::Tag::write) {
+            return Self::fail_read_write_loop(this, err);
         }
 
-        let written = self.read_write_loop.written;
-        self.on_complete(written);
-    }
+        let wrote: u32 = u32::try_from(rc.int()).expect("int cast");
 
-    pub(crate) fn new(init: CopyFileWindows<'a>) -> Box<CopyFileWindows<'a>> {
-        Box::new(init)
+        this.read_write_loop.written += wrote as usize;
+
+        if (wrote as usize) < buf_len {
+            if wrote == 0 {
+                // Handle EOF. We can't write any more.
+                return Self::on_read_write_loop_complete(this);
+            }
+
+            // Re-use the fs request.
+            this.io_request.deinit();
+            this.read_write_loop.chunk_written += wrote as usize;
+            return Self::read_write_loop_write(this);
+        }
+
+        this.io_request.deinit();
+        Self::read_write_loop_read(this);
+    }
+}
+
+#[cfg(windows)]
+impl CopyFileWindows {
+    /// On return, `this` has settled and been dropped.
+    pub(crate) fn on_read_write_loop_complete(mut this: Box<Self>) {
+        this.event_loop.unref_keep_alive();
+
+        if let Some(err) = this.err.take() {
+            return Self::throw(this, err);
+        }
+
+        let written = this.read_write_loop.written;
+        Self::on_complete(this, written);
     }
 
     pub(crate) fn init(
         destination_file_store: RefPtr<Store>,
         source_file_store: RefPtr<Store>,
-        event_loop: &'a jsc::event_loop::EventLoop,
+        event_loop: &jsc::event_loop::EventLoop,
         mkdirp_if_not_exists: bool,
         size_: SizeType,
         destination_mode: Option<Mode>,
     ) -> JSValue {
-        // destination_file_store.ref() / source_file_store.ref() — Arc clone
+        // destination_file_store.ref() / source_file_store.ref() — the refs owned here
         let global = event_loop.global_ref();
-        let result = bun_core::heap::into_raw(CopyFileWindows::new(CopyFileWindows {
+        let this = Box::new(CopyFileWindows {
             destination_file_store,
             source_file_store,
             promise: jsc::JSPromiseStrong::init(global),
-            // SAFETY: all-zero is a valid libuv::fs_t
             io_request: bun_core::ffi::zeroed::<libuv::fs_t>(),
-            event_loop,
+            event_loop: bun_ptr::BackRef::new(event_loop),
             mkdirp_if_not_exists,
             destination_mode,
             size: size_,
             written_bytes: 0,
             err: None,
             read_write_loop: ReadWriteLoop::default(),
-        }));
-        // SAFETY: result was just allocated above
-        let result_ref = unsafe { &mut *result };
-        let promise = result_ref.promise.value();
+        });
+        let promise = this.promise.value();
 
-        // On error, this function might free the CopyFileWindows struct.
-        // So we can no longer reference it beyond this point.
-        result_ref.copyfile();
+        // On error, this settles (and frees) the CopyFileWindows.
+        Self::copyfile(this);
 
         promise
     }
 
     fn prepare_pathlike(
-        pathlike: &mut PathOrFileDescriptor,
+        pathlike: &PathOrFileDescriptor,
         must_close: &mut bool,
         is_reading: bool,
     ) -> bun_sys::Result<Fd> {
@@ -1424,296 +1298,183 @@ impl<'a> CopyFileWindows<'a> {
         }
     }
 
-    fn prepare_read_write_loop(&mut self) {
+    /// On return, `this` is with libuv, the mkdirp hop, or settled.
+    fn prepare_read_write_loop(mut this: Box<Self>) {
         // Open the destination first, so that if we need to call
         // mkdirp(), we don't spend extra time opening the file handle for
         // the source.
-        self.read_write_loop.destination_fd = match Self::prepare_pathlike(
-            &mut Store::data_mut(&self.destination_file_store)
-                .as_file_mut()
-                .pathlike,
-            &mut self.read_write_loop.must_close_destination_fd,
+        let dest_store = this.destination_file_store.clone();
+        this.read_write_loop.destination_fd = match Self::prepare_pathlike(
+            &dest_store.data.as_file().pathlike,
+            &mut this.read_write_loop.must_close_destination_fd,
             false,
         ) {
             bun_sys::Result::Ok(fd) => fd,
             bun_sys::Result::Err(err) => {
-                if self.mkdirp_if_not_exists && err.get_errno() == bun_sys::E::ENOENT {
-                    self.mkdirp();
-                    return;
+                if this.mkdirp_if_not_exists && err.get_errno() == bun_sys::E::ENOENT {
+                    return Self::mkdirp(this);
                 }
 
-                self.throw(err);
-                return;
+                return Self::throw(this, err);
             }
         };
 
-        self.read_write_loop.source_fd = match Self::prepare_pathlike(
-            &mut Store::data_mut(&self.source_file_store)
-                .as_file_mut()
-                .pathlike,
-            &mut self.read_write_loop.must_close_source_fd,
+        let src_store = this.source_file_store.clone();
+        this.read_write_loop.source_fd = match Self::prepare_pathlike(
+            &src_store.data.as_file().pathlike,
+            &mut this.read_write_loop.must_close_source_fd,
             true,
         ) {
             bun_sys::Result::Ok(fd) => fd,
             bun_sys::Result::Err(err) => {
-                self.throw(err);
-                return;
+                return Self::throw(this, err);
             }
         };
 
-        match self.read_write_loop_start() {
-            bun_sys::Result::Err(err) => {
-                self.throw(err);
-            }
-            bun_sys::Result::Ok(()) => {
-                self.event_loop.ref_keep_alive();
+        this.event_loop.ref_keep_alive();
+        Self::read_write_loop_start(this);
+    }
+
+    /// A path for `pathlike`: its own, or the fd's (into `buf`). `Ok(None)`
+    /// when the fd has no path (NUL device, pipe) or is a character device —
+    /// the read/write loop handles those.
+    fn resolve_copy_path<'a>(
+        pathlike: &'a PathOrFileDescriptor,
+        buf: &'a mut PathBuffer,
+    ) -> bun_sys::Result<Option<&'a bun_core::ZStr>> {
+        match pathlike {
+            PathOrFileDescriptor::Path(_) => Ok(Some(pathlike.path().slice_z(buf))),
+            PathOrFileDescriptor::Fd(fd) => {
+                let fd = *fd;
+                match bun_sys::File::borrow(&fd).kind()? {
+                    bun_sys::FileKind::Directory => Err(bun_sys::Error::from_code(
+                        bun_sys::E::EISDIR,
+                        bun_sys::Tag::open,
+                    )),
+                    bun_sys::FileKind::CharacterDevice => Ok(None),
+                    _ => {
+                        let len = match bun_sys::get_fd_path(fd, buf) {
+                            Ok(out) => out.len(),
+                            // This case can happen when either:
+                            // - NUL device
+                            // - Pipe. `cat foo.txt | bun bar.ts`
+                            Err(_) => return Ok(None),
+                        };
+                        buf[len] = 0;
+                        Ok(Some(bun_core::ZStr::from_buf(&buf[..], len)))
+                    }
+                }
             }
         }
     }
 
-    fn copyfile(&mut self) {
+    /// On return, `this` is with libuv, the read/write loop, or settled.
+    fn copyfile(mut this: Box<Self>) {
         // This is for making it easier for us to test this code path
         if bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_UV_FS_COPYFILE
             .get()
             .unwrap_or(false)
         {
-            self.prepare_read_write_loop();
-            return;
+            return Self::prepare_read_write_loop(this);
         }
 
         let mut pathbuf1 = bun_paths::path_buffer_pool::get();
         let mut pathbuf2 = bun_paths::path_buffer_pool::get();
-        // capture the raw `self` pointer before borrowing the file
-        // stores. `slice_z` ties the returned `&ZStr` lifetime to `&self`, so
-        // `new_path`/`old_path` keep `self.{destination,source}_file_store`
-        // borrowed across the `uv_fs_copyfile` call below; taking
-        // `core::ptr::from_mut(self)` there would require an exclusive reborrow
-        // of all of `*self` and conflict. The pointer is only stored in
-        // `io_request.data` for the libuv callback to recover `self`.
-        let this_ptr: *mut c_void = core::ptr::from_mut(self).cast::<c_void>();
-        let destination_file_store = &mut self.destination_file_store.data.as_file();
-        let source_file_store = &mut self.source_file_store.data.as_file();
+        // Cloned so the resolved paths borrow the stores, not `this`, which
+        // moves into the request below.
+        let dest_store = this.destination_file_store.clone();
+        let src_store = this.source_file_store.clone();
+        let event_loop = this.event_loop;
 
-        let new_path: &bun_core::ZStr = 'brk: {
-            match &destination_file_store.pathlike {
-                PathOrFileDescriptor::Path(_) => {
-                    break 'brk destination_file_store
-                        .pathlike
-                        .path()
-                        .slice_z(&mut pathbuf1);
-                }
-                PathOrFileDescriptor::Fd(fd) => {
-                    let fd = *fd;
-                    match bun_sys::File::borrow(&fd).kind() {
-                        bun_sys::Result::Err(err) => {
-                            self.throw(err);
-                            return;
-                        }
-                        bun_sys::Result::Ok(kind) => match kind {
-                            bun_sys::FileKind::Directory => {
-                                self.throw(bun_sys::Error::from_code(
-                                    bun_sys::E::EISDIR,
-                                    bun_sys::Tag::open,
-                                ));
-                                return;
-                            }
-                            bun_sys::FileKind::CharacterDevice => {
-                                self.prepare_read_write_loop();
-                                return;
-                            }
-                            _ => {
-                                let out = match bun_sys::get_fd_path(fd, &mut pathbuf1) {
-                                    Ok(out) => out,
-                                    Err(_) => {
-                                        // This case can happen when either:
-                                        // - NUL device
-                                        // - Pipe. `cat foo.txt | bun bar.ts`
-                                        self.prepare_read_write_loop();
-                                        return;
-                                    }
-                                };
-                                let len = out.len();
-                                pathbuf1[len] = 0;
-                                // SAFETY: pathbuf1[len] == 0 written above
-                                break 'brk bun_core::ZStr::from_buf(&pathbuf1[..], len);
-                            }
-                        },
-                    }
-                }
-            }
-        };
-        let old_path: &bun_core::ZStr = 'brk: {
-            match &source_file_store.pathlike {
-                PathOrFileDescriptor::Path(_) => {
-                    break 'brk source_file_store.pathlike.path().slice_z(&mut pathbuf2);
-                }
-                PathOrFileDescriptor::Fd(fd) => {
-                    let fd = *fd;
-                    match bun_sys::File::borrow(&fd).kind() {
-                        bun_sys::Result::Err(err) => {
-                            self.throw(err);
-                            return;
-                        }
-                        bun_sys::Result::Ok(kind) => match kind {
-                            bun_sys::FileKind::Directory => {
-                                self.throw(bun_sys::Error::from_code(
-                                    bun_sys::E::EISDIR,
-                                    bun_sys::Tag::open,
-                                ));
-                                return;
-                            }
-                            bun_sys::FileKind::CharacterDevice => {
-                                self.prepare_read_write_loop();
-                                return;
-                            }
-                            _ => {
-                                let out = match bun_sys::get_fd_path(fd, &mut pathbuf2) {
-                                    Ok(out) => out,
-                                    Err(_) => {
-                                        // This case can happen when either:
-                                        // - NUL device
-                                        // - Pipe. `cat foo.txt | bun bar.ts`
-                                        self.prepare_read_write_loop();
-                                        return;
-                                    }
-                                };
-                                let len = out.len();
-                                pathbuf2[len] = 0;
-                                // SAFETY: pathbuf2[len] == 0 written above
-                                break 'brk bun_core::ZStr::from_buf(&pathbuf2[..], len);
-                            }
-                        },
-                    }
-                }
-            }
-        };
-        let loop_ = self.event_loop.uv_loop();
-        self.io_request.data = this_ptr;
+        let new_path =
+            match Self::resolve_copy_path(&dest_store.data.as_file().pathlike, &mut pathbuf1) {
+                Ok(Some(p)) => p,
+                Ok(None) => return Self::prepare_read_write_loop(this),
+                Err(err) => return Self::throw(this, err),
+            };
+        let old_path =
+            match Self::resolve_copy_path(&src_store.data.as_file().pathlike, &mut pathbuf2) {
+                Ok(Some(p)) => p,
+                Ok(None) => return Self::prepare_read_write_loop(this),
+                Err(err) => return Self::throw(this, err),
+            };
+        this.io_request.loop_ = this.event_loop.uv_loop().cast();
 
-        // SAFETY: FFI — `loop_` is the live VM uv loop, `io_request` is owned by `self`,
-        // `old_path`/`new_path` are NUL-terminated (from `slice_z`/`ZStr`), and
-        // `on_copy_file` is a valid `uv_fs_cb`.
-        let rc = unsafe {
-            libuv::uv_fs_copyfile(
-                loop_,
-                &mut self.io_request,
-                old_path.as_ptr(),
-                new_path.as_ptr(),
-                0,
-                Some(on_copy_file),
-            )
-        };
-
-        if let Some(mut err) = rc.to_error(bun_sys::Tag::copyfile) {
+        if let Err((this, rc)) =
+            aio::uv_fs::copyfile(this, old_path.as_cstr(), new_path.as_cstr(), 0)
+        {
+            let mut err = rc.to_error(bun_sys::Tag::copyfile).expect("negative rc");
             // https://github.com/oven-sh/bun/issues/6336
             if err.get_errno() == bun_sys::E::EPERM {
                 err = bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::copyfile);
             }
-            self.throw(err.with_path(old_path.as_bytes()));
-            return;
+            return Self::throw(this, err.with_path(old_path.as_bytes()));
         }
-        self.event_loop.ref_keep_alive();
+        event_loop.ref_keep_alive();
     }
 
-    pub fn throw(&mut self, err: bun_sys::Error) {
-        let global_this = self.event_loop.global_ref();
-        // `swap()` returns a `&mut JSPromise` into a GC-owned cell (not into
-        // `self`), but its lifetime is elided to `&mut self`. Decay to a raw pointer so
-        // borrowck doesn't tie it to `self` across `destroy` below.
-        let promise = JSPromise::opaque_mut(self.promise.swap());
+    /// On return, `this` has been dropped.
+    pub fn throw(mut this: Box<Self>, err: bun_sys::Error) {
+        let global_this = this.event_loop.global_ref();
+        // `swap()` releases the Strong's root; the promise cell stays alive on
+        // the stack below.
+        let promise = JSPromise::opaque_mut(this.promise.swap());
         let err_instance = err.to_js_with_async_stack(global_this, promise);
 
-        // SAFETY: VM-owned event loop is valid for the process lifetime; `enter_scope`
-        // calls enter() now and exit() on drop.
-        let _guard = unsafe {
-            jsc::event_loop::EventLoop::enter_scope(self.event_loop as *const _ as *mut _)
-        };
-        // SAFETY: self was heap-allocated in init(); destroy reclaims and drops it. self is not accessed afterward.
-        unsafe { Self::destroy(core::ptr::from_mut(self)) };
-        // `promise` points to a GC-owned `JSPromise` cell, not into `self`; valid after `destroy`.
+        let _guard = jsc::VirtualMachine::VirtualMachine::get().enter_event_loop_scope();
+        drop(this);
         // This libuv completion is the landing frame for what settling leaves.
         crate::dispatch::fold(promise.reject(global_this, err_instance));
     }
 
-    pub(crate) fn on_complete(&mut self, written_actual: usize) {
+    /// On return, `this` is with libuv (chmod) or settled.
+    pub(crate) fn on_complete(this: Box<Self>, written_actual: usize) {
         let mut written = written_actual;
-        if written != usize::try_from(self.size).expect("int cast") && self.size != MAX_SIZE {
-            self.truncate();
-            written = usize::try_from(self.size).expect("int cast");
+        if written != usize::try_from(this.size).expect("int cast") && this.size != MAX_SIZE {
+            this.truncate();
+            written = usize::try_from(this.size).expect("int cast");
         }
 
         // Apply destination mode if specified (async)
-        if let Some(mode) = self.destination_mode {
-            if matches!(
-                self.destination_file_store.data.as_file().pathlike,
-                PathOrFileDescriptor::Path(_)
-            ) {
-                self.written_bytes = written;
+        if let Some(mode) = this.destination_mode {
+            let dest_store = this.destination_file_store.clone();
+            if let PathOrFileDescriptor::Path(p) = &dest_store.data.as_file().pathlike {
+                let mut this = this;
+                this.written_bytes = written;
+                let event_loop = this.event_loop;
                 let mut pathbuf = bun_paths::path_buffer_pool::get();
-                // Borrowck: `slice_z` ties the returned `&ZStr` to
-                // `&self.destination_file_store`, which would conflict with the
-                // `core::ptr::from_mut(self)` below. Capture the raw C pointer now —
-                // it points either into the stack-local `pathbuf` or into the
-                // Arc-held `destination_file_store` path bytes, both of which outlive
-                // the `uv_fs_chmod` call (libuv `strdup`s the path internally).
-                let path_ptr = self
-                    .destination_file_store
-                    .data
-                    .as_file()
-                    .pathlike
-                    .path()
-                    .slice_z(&mut pathbuf)
-                    .as_ptr();
-                let loop_ = self.event_loop.uv_loop();
-                self.io_request.deinit();
-                // SAFETY: all-zero is a valid libuv::fs_t
-                self.io_request = bun_core::ffi::zeroed::<libuv::fs_t>();
-                self.io_request.data = core::ptr::from_mut(self).cast::<c_void>();
+                let path = p.slice_z(&mut pathbuf);
+                this.io_request.deinit();
+                this.io_request = bun_core::ffi::zeroed::<libuv::fs_t>();
+                this.io_request.loop_ = this.event_loop.uv_loop().cast();
 
-                // SAFETY: FFI — `loop_` is the live VM uv loop, `io_request` was just zeroed,
-                // `path_ptr` is NUL-terminated (from `slice_z`) and live for this call,
-                // and `on_chmod` is a valid `uv_fs_cb`.
-                let rc = unsafe {
-                    libuv::uv_fs_chmod(
-                        loop_,
-                        &mut self.io_request,
-                        path_ptr,
-                        i32::try_from(mode).expect("int cast"),
-                        Some(on_chmod),
-                    )
-                };
-
-                // chmod failed to start - reject the promise to report the error.
-                if let Some(mut err) = rc.to_error(bun_sys::Tag::chmod) {
-                    let destination = &self.destination_file_store.data.as_file();
-                    if let PathOrFileDescriptor::Path(p) = &destination.pathlike {
-                        err = err.with_path(p.slice());
-                    }
-                    self.throw(err);
-                    return;
+                if let Err((this, rc)) =
+                    aio::uv_fs::chmod(this, path.as_cstr(), i32::try_from(mode).expect("int cast"))
+                {
+                    // chmod failed to start - reject the promise to report the error.
+                    let err = rc
+                        .to_error(bun_sys::Tag::chmod)
+                        .expect("negative rc")
+                        .with_path(p.slice());
+                    return Self::throw(this, err);
                 }
-                self.event_loop.ref_keep_alive();
+                event_loop.ref_keep_alive();
                 return;
             }
         }
 
-        self.resolve_promise(written);
+        Self::resolve_promise(this, written);
     }
 
-    fn resolve_promise(&mut self, written: usize) {
-        let global_this = self.event_loop.global_ref();
+    /// On return, `this` has been dropped.
+    fn resolve_promise(mut this: Box<Self>, written: usize) {
+        let global_this = this.event_loop.global_ref();
         // see `throw` — re-type the GC cell via the ZST opaque deref so it
-        // outlives `destroy(self)` for borrowck.
-        let promise = JSPromise::opaque_mut(self.promise.swap());
-        // SAFETY: VM-owned event loop is valid for the process lifetime; `enter_scope`
-        // calls enter() now and exit() on drop.
-        let _guard = unsafe {
-            jsc::event_loop::EventLoop::enter_scope(self.event_loop as *const _ as *mut _)
-        };
+        // outlives `this` for borrowck.
+        let promise = JSPromise::opaque_mut(this.promise.swap());
+        let _guard = jsc::VirtualMachine::VirtualMachine::get().enter_event_loop_scope();
 
-        // SAFETY: self was heap-allocated in init(); destroy reclaims and drops it. self is not accessed afterward.
-        unsafe { Self::destroy(core::ptr::from_mut(self)) };
-        // `promise` points to a GC-owned `JSPromise` cell, not into `self`; valid after `destroy`.
+        drop(this);
         // As in `throw`: folded at this libuv completion.
         crate::dispatch::fold(
             promise.resolve(global_this, JSValue::js_number_from_uint64(written as u64)),
@@ -1721,7 +1482,7 @@ impl<'a> CopyFileWindows<'a> {
     }
 
     #[cold]
-    fn truncate(&mut self) {
+    fn truncate(&self) {
         // TODO: optimize this
 
         let mut node_fs_ = node_fs::NodeFS::default();
@@ -1735,173 +1496,142 @@ impl<'a> CopyFileWindows<'a> {
         );
     }
 
-    /// SAFETY: `this` must have been produced by `heap::alloc` in `init()` and
-    /// not yet destroyed. After this call `this` is dangling.
-    pub(crate) unsafe fn destroy(this: *mut Self) {
-        // SAFETY: caller contract — `this` is a live `heap::alloc`-ed pointer.
-        unsafe {
-            (*this).read_write_loop.close();
-            // destination_file_store.deref() / source_file_store.deref() — Arc Drop on Box drop
-            // promise.deinit() — handled by JscStrong's Drop on Box drop
-            (*this).io_request.deinit();
-            drop(bun_core::heap::take(this));
-        }
-    }
-
-    fn mkdirp(&mut self) {
+    /// On return, `this` is with the mkdirp hop or settled.
+    fn mkdirp(mut this: Box<Self>) {
         bun_sys::syslog!("mkdirp");
-        self.mkdirp_if_not_exists = false;
-        // Borrowck: compute the raw path slice pointer up-front so the
-        // immutable borrow of `self.destination_file_store` ends before we take
-        // `core::ptr::from_mut(self)` for `completion_ctx` below.
-        let path: *const [u8] = {
-            let destination = &self.destination_file_store.data.as_file();
-            if !matches!(destination.pathlike, PathOrFileDescriptor::Path(_)) {
-                self.throw(bun_sys::Error {
+        this.mkdirp_if_not_exists = false;
+        let dest_store = this.destination_file_store.clone();
+        let destination = dest_store.data.as_file();
+        if !matches!(destination.pathlike, PathOrFileDescriptor::Path(_)) {
+            return Self::throw(
+                this,
+                bun_sys::Error {
                     errno: bun_sys::SystemErrno::EINVAL as u16,
                     syscall: bun_sys::Tag::mkdir,
                     ..Default::default()
-                });
-                return;
-            }
-            let path_slice = destination.pathlike.path().slice();
-            // BORROW: not owned — `destination_file_store` (and thus its path) is held in
-            // `self`, which outlives the workpool task (completion runs `copyfile`/`throw`
-            // on `self` before any `destroy`).
-            bun_paths::dirname(path_slice)
-                // this shouldn't happen
-                .unwrap_or(path_slice) as *const [u8]
-        };
+                },
+            );
+        }
+        let path_slice = destination.pathlike.path().slice();
+        // BORROW: not owned — `destination_file_store` (and thus its path) is held in
+        // `this`, which the mkdirp completion gets back before anything is freed.
+        let path = bun_paths::dirname(path_slice)
+            // this shouldn't happen
+            .unwrap_or(path_slice) as *const [u8];
 
-        self.event_loop.ref_keep_alive();
+        this.event_loop.ref_keep_alive();
         node_fs::async_::AsyncMkdirp::schedule(
-            CopyFileMkdirp(core::ptr::from_mut(self).cast()),
+            this,
             path,
             jsc::VirtualMachine::VirtualMachine::get().ticket(),
         );
     }
+}
 
-    fn on_mkdirp_complete(&mut self) {
-        self.event_loop.unref_keep_alive();
+#[cfg(windows)]
+impl aio::uv_fs::OnFsCopyfile for CopyFileWindows {
+    fn on_fs_copyfile(mut this: Box<Self>, rc: libuv::ReturnCodeI64) {
+        this.event_loop.unref_keep_alive();
 
-        if let Some(err) = self.err.take() {
-            // `bun_sys::Error.path` is an owned `Box<[u8]>` and is dropped with
-            // `err` inside `throw`.
-            self.throw(err);
-            return;
+        bun_sys::syslog!("uv_fs_copyfile() = {}", rc);
+        if let Some(errno) = rc.errno() {
+            // ENOENT from uv_fs_copyfile can mean either the source file or the
+            // destination directory is missing. Disambiguate so a missing source
+            // rejects directly instead of entering the mkdirp+retry path. Only an
+            // ENOENT from the probe counts as "missing"; any other error leaves
+            // the mkdirp+retry path available.
+            let source_missing = errno == bun_sys::E::ENOENT
+                && match &this.source_file_store.data.as_file().pathlike {
+                    PathOrFileDescriptor::Path(p) => {
+                        let mut buf = bun_paths::path_buffer_pool::get();
+                        matches!(
+                            bun_sys::access(p.slice_z(&mut buf), 0),
+                            bun_sys::Result::Err(e) if e.get_errno() == bun_sys::E::ENOENT
+                        )
+                    }
+                    PathOrFileDescriptor::Fd(_) => false,
+                };
+
+            if this.mkdirp_if_not_exists && errno == bun_sys::E::ENOENT && !source_missing {
+                this.io_request.deinit();
+                return Self::mkdirp(this);
+            }
+
+            let mut err = bun_sys::Error::from_code(
+                // #6336
+                if errno == bun_sys::E::EPERM {
+                    bun_sys::E::ENOENT
+                } else {
+                    errno
+                },
+                bun_sys::Tag::copyfile,
+            );
+            let store = if source_missing {
+                &this.source_file_store
+            } else {
+                &this.destination_file_store
+            };
+            match &store.data.as_file().pathlike {
+                PathOrFileDescriptor::Path(p) => {
+                    err = err.with_path(p.slice());
+                }
+                PathOrFileDescriptor::Fd(fd) => {
+                    err = err.with_fd(*fd);
+                }
+            }
+
+            return Self::throw(this, err);
         }
 
-        self.copyfile();
+        let size = this.io_request.statbuf.size();
+        Self::on_complete(this, size as usize);
     }
 }
 
 #[cfg(windows)]
-extern "C" fn on_copy_file(req: *mut libuv::fs_t) {
-    // SAFETY: see `on_read` — recover from `req->data` (whole-struct provenance),
-    // not `from_field_ptr!`; then access the request only via `this.io_request`.
-    let this: &mut CopyFileWindows = unsafe { &mut *(*req).data.cast::<CopyFileWindows>() };
-    debug_assert!(core::ptr::addr_of_mut!(this.io_request) == req);
+impl aio::uv_fs::OnFsChmod for CopyFileWindows {
+    fn on_fs_chmod(this: Box<Self>, rc: libuv::ReturnCodeI64) {
+        this.event_loop.unref_keep_alive();
 
-    let event_loop = this.event_loop;
-    event_loop.unref_keep_alive();
-    let rc = this.io_request.result;
-
-    bun_sys::syslog!("uv_fs_copyfile() = {}", rc);
-    if let Some(errno) = rc.errno() {
-        // ENOENT from uv_fs_copyfile can mean either the source file or the
-        // destination directory is missing. Disambiguate so a missing source
-        // rejects directly instead of entering the mkdirp+retry path. Only an
-        // ENOENT from the probe counts as "missing"; any other error leaves
-        // the mkdirp+retry path available.
-        let source_missing = errno == bun_sys::E::ENOENT
-            && match &this.source_file_store.data.as_file().pathlike {
-                PathOrFileDescriptor::Path(p) => {
-                    let mut buf = bun_paths::path_buffer_pool::get();
-                    matches!(
-                        bun_sys::access(p.slice_z(&mut buf), 0),
-                        bun_sys::Result::Err(e) if e.get_errno() == bun_sys::E::ENOENT
-                    )
-                }
-                PathOrFileDescriptor::Fd(_) => false,
-            };
-
-        if this.mkdirp_if_not_exists && errno == bun_sys::E::ENOENT && !source_missing {
-            this.io_request.deinit();
-            this.mkdirp();
-            return;
-        }
-
-        let mut err = bun_sys::Error::from_code(
-            // https://github.com/oven-sh/bun/issues/6336
-            if errno == bun_sys::E::EPERM {
-                bun_sys::E::ENOENT
-            } else {
-                errno
-            },
-            bun_sys::Tag::copyfile,
-        );
-        let store = if source_missing {
-            &this.source_file_store
-        } else {
-            &this.destination_file_store
-        };
-        match &store.data.as_file().pathlike {
-            PathOrFileDescriptor::Path(p) => {
+        if let Some(mut err) = rc.to_error(bun_sys::Tag::chmod) {
+            if let PathOrFileDescriptor::Path(p) =
+                &this.destination_file_store.data.as_file().pathlike
+            {
                 err = err.with_path(p.slice());
             }
-            PathOrFileDescriptor::Fd(fd) => {
-                err = err.with_fd(*fd);
-            }
+            return Self::throw(this, err);
         }
 
-        this.throw(err);
-        return;
+        let written = this.written_bytes;
+        Self::resolve_promise(this, written);
     }
-
-    let size = this.io_request.statbuf.size();
-    this.on_complete(size as usize);
 }
 
+/// JS thread: the mkdirp hop came back.
 #[cfg(windows)]
-extern "C" fn on_chmod(req: *mut libuv::fs_t) {
-    // SAFETY: see `on_read` — recover from `req->data` (whole-struct provenance),
-    // not `from_field_ptr!`; then access the request only via `this.io_request`.
-    let this: &mut CopyFileWindows = unsafe { &mut *(*req).data.cast::<CopyFileWindows>() };
-    debug_assert!(core::ptr::addr_of_mut!(this.io_request) == req);
-
-    let event_loop = this.event_loop;
-    event_loop.unref_keep_alive();
-
-    let rc = this.io_request.result;
-    if let Some(mut err) = rc.to_error(bun_sys::Tag::chmod) {
-        let destination = &this.destination_file_store.data.as_file();
-        if let PathOrFileDescriptor::Path(p) = &destination.pathlike {
-            err = err.with_path(p.slice());
-        }
-        this.throw(err);
-        return;
-    }
-
-    this.resolve_promise(this.written_bytes);
-}
-
-/// The `CopyFileWindows` an `AsyncMkdirp` reports back to.
-#[cfg(windows)]
-struct CopyFileMkdirp(*mut CopyFileWindows<'static>);
-
-#[cfg(windows)]
-impl node_fs::async_::MkdirpCompletion for CopyFileMkdirp {
+impl node_fs::async_::MkdirpCompletion for Box<CopyFileWindows> {
     fn on_mkdirp_done(self, result: bun_sys::Maybe<()>) {
         bun_sys::syslog!("mkdirp complete");
-        // SAFETY: `self.0` is the heap-allocated `CopyFileWindows` handed to
-        // `AsyncMkdirp` by `mkdirp` above, back on its JS thread;
-        // `on_mkdirp_complete` may free it via `throw`, so it is not touched
-        // afterward.
-        unsafe {
-            debug_assert!((*self.0).err.is_none());
-            (*self.0).err = result.err();
-            (*self.0).on_mkdirp_complete();
+        self.event_loop.unref_keep_alive();
+
+        debug_assert!(self.err.is_none());
+        if let Err(err) = result {
+            // `bun_sys::Error.path` is an owned `Box<[u8]>` and is dropped with
+            // `err` inside `throw`.
+            return CopyFileWindows::throw(self, err);
         }
+
+        CopyFileWindows::copyfile(self);
+    }
+}
+
+#[cfg(windows)]
+impl Drop for CopyFileWindows {
+    fn drop(&mut self) {
+        self.read_write_loop.close();
+        // destination_file_store.deref() / source_file_store.deref() — RefPtr<Store> Drop
+        // promise.deinit() — handled by JSPromiseStrong's Drop
+        self.io_request.deinit();
     }
 }
 

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -1578,8 +1578,27 @@ impl aio::uv_fs::OnFsCopyfile for CopyFileWindows {
             return Self::throw(this, err);
         }
 
-        let size = this.io_request.statbuf.size();
-        Self::on_complete(this, size as usize);
+        // `uv_fs_copyfile` reports no byte count, so read the size back from
+        // the destination (or, failing that, the source).
+        let size = Self::copied_size(&this.destination_file_store.data.as_file().pathlike)
+            .or_else(|| Self::copied_size(&this.source_file_store.data.as_file().pathlike))
+            .unwrap_or(0);
+        Self::on_complete(this, size);
+    }
+}
+
+#[cfg(windows)]
+impl CopyFileWindows {
+    fn copied_size(pathlike: &PathOrFileDescriptor) -> Option<usize> {
+        let stat = match pathlike {
+            PathOrFileDescriptor::Path(p) => {
+                let mut buf = bun_paths::path_buffer_pool::get();
+                bun_sys::stat(p.slice_z(&mut buf))
+            }
+            PathOrFileDescriptor::Fd(fd) => bun_sys::fstat(*fd),
+        }
+        .ok()?;
+        usize::try_from(stat.st_size).ok()
     }
 }
 

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -1,10 +1,13 @@
 //! blocking, but off the main thread
 
 use crate::node::fs as node_fs;
+#[cfg(windows)]
 use crate::node::types::PathLikeExt as _;
 #[cfg(not(windows))]
 use crate::webcore::blob::{self, Retry};
-use crate::webcore::blob::{MAX_SIZE, MkdirpTarget, SizeType, Store, store};
+use crate::webcore::blob::{FileSnapshot, SnapshotPath};
+use crate::webcore::blob::{MAX_SIZE, MkdirpTarget, SizeType, Store};
+#[cfg(windows)]
 use crate::webcore::node_types::PathOrFileDescriptor;
 #[cfg(windows)]
 use bun_io as aio;
@@ -27,11 +30,13 @@ use core::marker::ConstParamTy;
 
 #[cfg_attr(windows, allow(dead_code))] // Windows copies go through `CopyFileWindows`
 pub struct CopyFile {
-    /// The destination store (a `Data::File`); its `File` is
-    /// [`destination_file_store`](Self::destination_file_store). The refs keep
-    /// both stores alive while this task is on the work pool.
-    pub(crate) store: RefPtr<Store>,
-    pub(crate) source_store: RefPtr<Store>,
+    /// What the pool thread reads of each store's `File`, copied at creation.
+    pub(crate) destination_file_store: FileSnapshot,
+    pub(crate) source_file_store: FileSnapshot,
+    /// Held (not read) so both stores stay alive while this task is on the
+    /// work pool; released before the promise settles.
+    _store: RefPtr<Store>,
+    _source_store: RefPtr<Store>,
     pub offset: SizeType,
     #[cfg(not(windows))]
     pub(crate) max_length: SizeType,
@@ -80,13 +85,13 @@ impl jsc::JobContext for CopyFile {
 impl CopyFile {
     #[cfg(not(windows))]
     #[inline]
-    pub(crate) fn destination_file_store(&self) -> &store::File {
-        self.store.data.as_file()
+    pub(crate) fn destination_file_store(&self) -> &FileSnapshot {
+        &self.destination_file_store
     }
 
     #[inline]
-    pub(crate) fn source_file_store(&self) -> &store::File {
-        self.source_store.data.as_file()
+    pub(crate) fn source_file_store(&self) -> &FileSnapshot {
+        &self.source_file_store
     }
 
     /// Schedule the copy on the work pool; returns its promise.
@@ -101,8 +106,10 @@ impl CopyFile {
         destination_mode: Option<Mode>,
     ) -> JSValue {
         let copy = CopyFile {
-            store,
-            source_store,
+            destination_file_store: FileSnapshot::new(store.data.as_file()),
+            source_file_store: FileSnapshot::new(source_store.data.as_file()),
+            _store: store,
+            _source_store: source_store,
             offset: off,
             max_length: max_len,
             mkdirp_if_not_exists,
@@ -126,10 +133,8 @@ impl CopyFile {
         global_this: &JSGlobalObject,
     ) -> jsc::JsResult<()> {
         let mut system_error: SystemError = self.system_error.take().unwrap_or_default();
-        if matches!(
-            self.source_file_store().pathlike,
-            PathOrFileDescriptor::Path(_)
-        ) && system_error.path.is_empty()
+        if matches!(self.source_file_store().pathlike, SnapshotPath::Path(_))
+            && system_error.path.is_empty()
         {
             system_error.path =
                 bun_core::String::clone_utf8(self.source_file_store().pathlike.path().slice());
@@ -163,14 +168,10 @@ impl CopyFile {
 
     #[cfg(not(windows))]
     pub(crate) fn do_close(&mut self) {
-        let close_input = !matches!(
-            self.destination_file_store().pathlike,
-            PathOrFileDescriptor::Fd(_)
-        ) && self.destination_fd != Fd::INVALID;
-        let close_output = !matches!(
-            self.source_file_store().pathlike,
-            PathOrFileDescriptor::Fd(_)
-        ) && self.source_fd != Fd::INVALID;
+        let close_input = !matches!(self.destination_file_store().pathlike, SnapshotPath::Fd(_))
+            && self.destination_fd != Fd::INVALID;
+        let close_output = !matches!(self.source_file_store().pathlike, SnapshotPath::Fd(_))
+            && self.source_fd != Fd::INVALID;
 
         // Apply destination mode using fchmod before closing.
         // This ensures mode is applied even when overwriting existing files, since
@@ -316,7 +317,7 @@ impl CopyFile {
     ) -> Result<(), crate::Error> {
         let bun_opened_dest = matches!(
             self.destination_file_store().pathlike,
-            PathOrFileDescriptor::Path(_)
+            SnapshotPath::Path(_)
         );
         let cap = if unknown_size {
             MAX_SIZE
@@ -597,11 +598,11 @@ impl CopyFile {
             #[cfg(not(target_os = "macos"))]
             let stat_: Option<Stat> = None;
 
-            if let PathOrFileDescriptor::Fd(fd) = &self.destination_file_store().pathlike {
+            if let SnapshotPath::Fd(fd) = &self.destination_file_store().pathlike {
                 self.destination_fd = *fd;
             }
 
-            if let PathOrFileDescriptor::Fd(fd) = &self.source_file_store().pathlike {
+            if let SnapshotPath::Fd(fd) = &self.source_file_store().pathlike {
                 self.source_fd = *fd;
             }
 
@@ -612,13 +613,10 @@ impl CopyFile {
                 #[cfg(target_os = "macos")]
                 {
                     if self.offset == 0
-                        && matches!(
-                            self.source_file_store().pathlike,
-                            PathOrFileDescriptor::Path(_)
-                        )
+                        && matches!(self.source_file_store().pathlike, SnapshotPath::Path(_))
                         && matches!(
                             self.destination_file_store().pathlike,
-                            PathOrFileDescriptor::Path(_)
+                            SnapshotPath::Path(_)
                         )
                     {
                         'do_clonefile: {
@@ -728,10 +726,7 @@ impl CopyFile {
             debug_assert!(self.destination_fd.is_valid());
             debug_assert!(self.source_fd.is_valid());
 
-            if matches!(
-                self.destination_file_store().pathlike,
-                PathOrFileDescriptor::Fd(_)
-            ) {
+            if matches!(self.destination_file_store().pathlike, SnapshotPath::Fd(_)) {
                 // nothing to do for the Fd case
             }
 
@@ -769,7 +764,7 @@ impl CopyFile {
                 if PREALLOCATE_SUPPORTED
                     && matches!(
                         self.destination_file_store().pathlike,
-                        PathOrFileDescriptor::Path(_)
+                        SnapshotPath::Path(_)
                     )
                     && self.max_length > PREALLOCATE_LENGTH
                     && self.max_length != MAX_SIZE
@@ -838,7 +833,7 @@ impl CopyFile {
                 // ftruncate; both are only safe for a dest Bun opened O_TRUNC.
                 if matches!(
                     self.destination_file_store().pathlike,
-                    PathOrFileDescriptor::Path(_)
+                    SnapshotPath::Path(_)
                 ) {
                     if self.do_fcopy_file_with_read_write_loop_fallback().is_err() {
                         self.do_close();
@@ -865,7 +860,7 @@ impl CopyFile {
             {
                 if matches!(
                     self.destination_file_store().pathlike,
-                    PathOrFileDescriptor::Path(_)
+                    SnapshotPath::Path(_)
                 ) {
                     let mut total_written: u64 = 0;
                     match node_fs::NodeFS::copy_file_using_read_write_loop(

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -216,6 +216,9 @@ pub struct ReadFile {
     pub task: WorkPoolTask,
     pub(crate) system_error: Option<SystemError>,
     pub(crate) errno: Option<Error>,
+    /// The file's mtime as read off-thread / in the completion; applied to the
+    /// store on the JS thread when the read finishes.
+    pub(crate) last_modified: Option<jsc::JSTimeType>,
     #[cfg(not(windows))]
     pub(crate) io_task: Option<ReadFileTask>,
     pub(crate) io_poll: io::Poll,
@@ -314,6 +317,7 @@ impl ReadFile {
             task: bun_threading::work_task_for::<Self>(),
             system_error: None,
             errno: None,
+            last_modified: None,
             io_task: None,
             io_poll: io::Poll::default(),
             io: io::ParkedRequest::new(io::io_request_callback::<Self>()),
@@ -474,7 +478,12 @@ impl ReadFile {
         let buf = core::mem::take(&mut this.buffer);
         let system_error = this.system_error.take();
         // Held across the completion (it may inspect the store); released after.
-        let _store = this.store.clone();
+        let store = this.store.clone();
+        if let Some(last_modified) = this.last_modified {
+            if let Data::File(file) = Store::data_mut(&store) {
+                file.last_modified = last_modified;
+            }
+        }
         drop(this);
 
         if let Some(err) = system_error {
@@ -545,10 +554,8 @@ impl ReadFile {
             }
         };
 
-        if let Data::File(file) = Store::data_mut(&self.store) {
-            let mtime = bun_sys::PosixStat::init(&stat).mtime();
-            file.last_modified = jsc::to_js_time(mtime.sec as isize, mtime.nsec as isize);
-        }
+        let mtime = bun_sys::PosixStat::init(&stat).mtime();
+        self.last_modified = Some(jsc::to_js_time(mtime.sec as isize, mtime.nsec as isize));
 
         if bun_sys::S::ISDIR(stat.st_mode as _) {
             self.errno = Some(crate::Error::Sys(bun_errno::SystemErrno::EISDIR));
@@ -756,6 +763,9 @@ pub struct ReadFileUV {
     pub(crate) buffer: Vec<u8>,
     pub(crate) system_error: Option<SystemError>,
     pub(crate) errno: Option<Error>,
+    /// The file's mtime as read off-thread / in the completion; applied to the
+    /// store on the JS thread when the read finishes.
+    pub(crate) last_modified: Option<jsc::JSTimeType>,
     /// `Some` until the read completes; a `ReadFileUV` dropped before that cancels it.
     pub(crate) on_done: Option<ReadFileOnDone>,
     pub(crate) is_regular_file: bool,
@@ -790,6 +800,7 @@ impl ReadFileUV {
             buffer: Vec::new(),
             system_error: None,
             errno: None,
+            last_modified: None,
             on_done: Some(on_done),
             is_regular_file: false,
             req: bun_core::ffi::zeroed(),
@@ -811,6 +822,12 @@ impl ReadFileUV {
         let event_loop = this.event_loop;
 
         let on_done = this.on_done.take().expect("a ReadFileUV completes once");
+
+        if let Some(last_modified) = this.last_modified {
+            if let Data::File(file) = Store::data_mut(&this.store) {
+                file.last_modified = last_modified;
+            }
+        }
 
         let result = if let Some(err) = this.system_error.take() {
             ReadFileResultType::Err(err)
@@ -987,12 +1004,12 @@ impl bun_io::uv_fs::OnFsStat for ReadFileUV {
         let stat = this.req.statbuf;
 
         // keep in sync with resolveSizeAndLastModified
-        if let Data::File(file) = Store::data_mut(&this.store) {
-            // `uv_timespec_t` fields are `c_long` (i32 on Windows); widen to the
-            // platform-width `isize` `to_js_time` expects.
-            file.last_modified =
-                jsc::to_js_time(stat.mtime().sec as isize, stat.mtime().nsec as isize);
-        }
+        // `uv_timespec_t` fields are `c_long` (i32 on Windows); widen to the
+        // platform-width `isize` `to_js_time` expects.
+        this.last_modified = Some(jsc::to_js_time(
+            stat.mtime().sec as isize,
+            stat.mtime().nsec as isize,
+        ));
 
         if bun_sys::S::ISDIR(u32::try_from(stat.mode()).expect("int cast")) {
             this.errno = Some(crate::Error::Sys(bun_errno::SystemErrno::EISDIR));

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -408,66 +408,65 @@ impl ReadFile {
     ) -> Option<usize> {
         let cap = (self.max_length.saturating_sub(self.read_off)) as usize;
         let is_socket = bun_sys::S::ISSOCK(self.file_store.mode);
-        let result: bun_sys::Result<usize> = if buffer.spare_capacity_mut().len() < stack.len() {
-            let room = stack.len().min(cap);
-            let stack = &mut stack[..room];
-            let filled = if is_socket {
-                bun_sys::recv_non_block_uninit(self.opened_fd, stack)
-            } else {
-                bun_sys::read_uninit(self.opened_fd, stack)
-            };
-            // We read into the stack buffer, so we need to copy it into the heap.
-            filled.map(|read| {
-                if buffer.capacity() == 0 {
-                    // We need to allocate a new buffer
-                    // In this case, we want to use `ensureTotalCapacityPrecise` so that it's an exact amount
-                    // We want to avoid over-allocating incase it's a large amount of data sent in a single chunk followed by a 0 byte chunk.
-                    buffer.reserve_exact(read.len());
-                } else {
-                    buffer.reserve(read.len());
-                }
-                buffer.extend_from_slice(read);
-                read.len()
-            })
-        } else if is_socket {
-            bun_sys::recv_non_block_to_spare(self.opened_fd, buffer, cap)
-        } else {
-            bun_sys::read_to_spare(self.opened_fd, buffer, cap)
-        };
-
         loop {
-            match &result {
-                Ok(res) => {
-                    self.read_eof = *res == 0;
-                    return Some(*res);
-                }
-                Err(err) => {
-                    match err.get_errno() {
-                        e if e == io::RETRY => {
-                            if !self.could_block {
-                                // regular files cannot use epoll.
-                                // this is fine on kqueue, but not on epoll.
-                                continue;
-                            }
-                            *retry = true;
-                            self.read_eof = false;
-                            return Some(0);
-                        }
-                        _ => {
-                            self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
-                            self.system_error = Some(err.to_system_error().into());
-                            if self.system_error.as_ref().unwrap().path.is_empty() {
-                                let path = if self.file_store.pathlike.is_path() {
-                                    BunString::clone_utf8(self.file_store.pathlike.path().slice())
-                                } else {
-                                    BunString::EMPTY
-                                };
-                                self.system_error.as_mut().unwrap().path = path;
-                            }
-                            return None;
-                        }
+            let result: bun_sys::Result<usize> = if buffer.spare_capacity_mut().len() < stack.len()
+            {
+                let room = stack.len().min(cap);
+                let stack = &mut stack[..room];
+                let filled = if is_socket {
+                    bun_sys::recv_non_block_uninit(self.opened_fd, stack)
+                } else {
+                    bun_sys::read_uninit(self.opened_fd, stack)
+                };
+                // We read into the stack buffer, so we need to copy it into the heap.
+                filled.map(|read| {
+                    if buffer.capacity() == 0 {
+                        // We need to allocate a new buffer
+                        // In this case, we want to use `ensureTotalCapacityPrecise` so that it's an exact amount
+                        // We want to avoid over-allocating incase it's a large amount of data sent in a single chunk followed by a 0 byte chunk.
+                        buffer.reserve_exact(read.len());
+                    } else {
+                        buffer.reserve(read.len());
                     }
+                    buffer.extend_from_slice(read);
+                    read.len()
+                })
+            } else if is_socket {
+                bun_sys::recv_non_block_to_spare(self.opened_fd, buffer, cap)
+            } else {
+                bun_sys::read_to_spare(self.opened_fd, buffer, cap)
+            };
+
+            match result {
+                Ok(res) => {
+                    self.read_eof = res == 0;
+                    return Some(res);
                 }
+                Err(err) => match err.get_errno() {
+                    e if e == io::RETRY => {
+                        if !self.could_block {
+                            // regular files cannot use epoll.
+                            // this is fine on kqueue, but not on epoll.
+                            continue;
+                        }
+                        *retry = true;
+                        self.read_eof = false;
+                        return Some(0);
+                    }
+                    _ => {
+                        self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
+                        let mut system_error = err.to_system_error();
+                        if system_error.path.is_empty() {
+                            system_error.path = if self.file_store.pathlike.is_path() {
+                                BunString::clone_utf8(self.file_store.pathlike.path().slice())
+                            } else {
+                                BunString::EMPTY
+                            };
+                        }
+                        self.system_error = Some(system_error.into());
+                        return None;
+                    }
+                },
             }
         }
     }

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -8,10 +8,12 @@ use core::sync::atomic::Ordering;
 use crate::Error;
 #[cfg(not(windows))]
 use crate::webcore::blob::ClosingState;
-use crate::webcore::blob::store::{Data, File as FileStore};
+use crate::webcore::blob::store::Data;
+#[cfg(windows)]
+use crate::webcore::blob::store::File as FileStore;
 use crate::webcore::blob::{Blob, MAX_SIZE, SizeType, SourceBytes, Store};
 #[cfg(not(windows))]
-use crate::webcore::blob::{FileCloser, FileOpener};
+use crate::webcore::blob::{FileCloser, FileOpener, FileSnapshot, PathOrFdRef};
 use bun_core::String as BunString;
 use bun_io as io;
 #[cfg(windows)]
@@ -193,9 +195,11 @@ impl ReadFile {
 
 #[cfg_attr(windows, allow(dead_code))] // Windows reads go through `ReadFileUV`
 pub struct ReadFile {
-    /// The file store being read (a `Data::File`); its `File` is
-    /// [`file_store`](Self::file_store).
+    /// The file store being read (a `Data::File`).
     pub(crate) store: RefPtr<Store>,
+    /// What the pool thread reads of that store's `File`, copied at creation.
+    #[cfg(not(windows))]
+    pub(crate) file_store: FileSnapshot,
     pub offset: SizeType,
     #[cfg(not(windows))]
     pub(crate) max_length: SizeType,
@@ -267,8 +271,8 @@ impl FileOpener for ReadFile {
     fn set_system_error(&mut self, e: jsc::SystemError) {
         self.system_error = Some(e);
     }
-    fn pathlike(&self) -> &crate::webcore::node_types::PathOrFileDescriptor<'static> {
-        &self.file_store().pathlike
+    fn pathlike(&self) -> PathOrFdRef<'_> {
+        self.file_store.pathlike.as_ref()
     }
 }
 
@@ -276,12 +280,6 @@ impl FileOpener for ReadFile {
 crate::webcore::blob::impl_file_closer!(ReadFile);
 
 impl ReadFile {
-    #[cfg(not(windows))]
-    #[inline]
-    pub(crate) fn file_store(&self) -> &FileStore {
-        self.store.data.as_file()
-    }
-
     pub(crate) fn update(&mut self) {
         #[cfg(windows)]
         {
@@ -301,8 +299,10 @@ impl ReadFile {
     #[cfg(not(windows))]
     pub(crate) fn create(store: RefPtr<Store>, off: SizeType, max_len: SizeType) -> ReadFile {
         // store.ref() — `RefPtr<Store>` carries the +1; held in `self.store`.
+        let file_store = FileSnapshot::new(store.data.as_file());
         ReadFile {
             store,
+            file_store,
             offset: off,
             max_length: max_len,
             total_size: MAX_SIZE,
@@ -403,7 +403,7 @@ impl ReadFile {
         retry: &mut bool,
     ) -> Option<usize> {
         let cap = (self.max_length.saturating_sub(self.read_off)) as usize;
-        let is_socket = bun_sys::S::ISSOCK(self.file_store().mode);
+        let is_socket = bun_sys::S::ISSOCK(self.file_store.mode);
         let result: bun_sys::Result<usize> = if buffer.spare_capacity_mut().len() < stack.len() {
             let room = stack.len().min(cap);
             let stack = &mut stack[..room];
@@ -453,8 +453,8 @@ impl ReadFile {
                             self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
                             self.system_error = Some(err.to_system_error().into());
                             if self.system_error.as_ref().unwrap().path.is_empty() {
-                                let path = if self.file_store().pathlike.is_path() {
-                                    BunString::clone_utf8(self.file_store().pathlike.path().slice())
+                                let path = if self.file_store.pathlike.is_path() {
+                                    BunString::clone_utf8(self.file_store.pathlike.path().slice())
                                 } else {
                                     BunString::EMPTY
                                 };
@@ -501,8 +501,8 @@ impl ReadFile {
         {
             self.io_task = Some(task);
 
-            if self.file_store().pathlike.is_fd() {
-                self.opened_fd = self.file_store().pathlike.fd();
+            if self.file_store.pathlike.is_fd() {
+                self.opened_fd = self.file_store.pathlike.fd();
             }
 
             self.get_fd(Self::run_async_with_fd);
@@ -511,7 +511,7 @@ impl ReadFile {
 
     #[cfg(not(windows))]
     pub(crate) fn is_allowed_to_close(&self) -> bool {
-        self.file_store().pathlike.is_path()
+        self.file_store.pathlike.is_path()
     }
 
     #[cfg(not(windows))]
@@ -554,8 +554,8 @@ impl ReadFile {
             self.errno = Some(crate::Error::Sys(bun_errno::SystemErrno::EISDIR));
             self.system_error = Some(SystemError {
                 code: BunString::static_("EISDIR"),
-                path: if self.file_store().pathlike.is_path() {
-                    BunString::clone_utf8(self.file_store().pathlike.path().slice())
+                path: if self.file_store.pathlike.is_path() {
+                    BunString::clone_utf8(self.file_store.pathlike.path().slice())
                 } else {
                     BunString::EMPTY
                 },
@@ -599,7 +599,7 @@ impl ReadFile {
 
         // Special files might report a size of > 0, and be wrong.
         // so we should check specifically that its a regular file before trusting the size.
-        if self.size == 0 && bun_sys::is_regular_file(self.file_store().mode) {
+        if self.size == 0 && bun_sys::is_regular_file(self.file_store.mode) {
             self.buffer = Vec::new();
             self.on_finish();
             return;

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -1,27 +1,20 @@
-use core::ffi::c_void;
 use core::marker::PhantomData;
-#[cfg(windows)]
+#[cfg(not(windows))]
 use core::mem::MaybeUninit;
 use core::sync::atomic::AtomicU8;
 #[cfg(not(windows))]
 use core::sync::atomic::Ordering;
 
 use crate::Error;
-use crate::webcore::Lifetime;
 #[cfg(not(windows))]
 use crate::webcore::blob::ClosingState;
-#[cfg(windows)]
-use crate::webcore::blob::store::Bytes as ByteStore;
 use crate::webcore::blob::store::{Data, File as FileStore};
-use crate::webcore::blob::{Blob, FileCloser, FileOpener, MAX_SIZE, SizeType, Store};
-use crate::webcore::node_types::PathOrFileDescriptor;
-#[cfg(windows)]
-use bun_collections::ByteVecExt as _;
-use bun_core;
+use crate::webcore::blob::{Blob, MAX_SIZE, SizeType, SourceBytes, Store};
+#[cfg(not(windows))]
+use crate::webcore::blob::{FileCloser, FileOpener};
 use bun_core::String as BunString;
 use bun_io as io;
 #[cfg(windows)]
-// `bun_jsc::EventLoop` is the *module*; the struct is one level deeper.
 use bun_jsc::event_loop::EventLoop;
 use bun_jsc::{
     self as jsc, AnyPromise, JSGlobalObject, JSPromiseStrong, JSValue, JsResult, SystemError,
@@ -54,60 +47,48 @@ macro_rules! log {
 /// `F` provides the callback that converts the read bytes to a JSValue.
 /// Modelled as a trait so each instantiation monomorphizes.
 pub trait ReadFileToJs {
-    /// `by` carries the caller's allocation provenance unchanged:
-    /// `Lifetime::Temporary` ⇒ a `Box::<[u8]>::into_raw` the callee MUST take
-    /// ownership of (every `to_*_with_bytes::<Temporary>` arm reclaims it);
-    /// otherwise a borrow valid for the call.
-    fn call(b: &Blob, g: &JSGlobalObject, by: *mut [u8], lifetime: Lifetime) -> JsResult<JSValue>;
+    fn call(b: &Blob, g: &JSGlobalObject, bytes: SourceBytes) -> JsResult<JSValue>;
 }
 
-pub struct NewReadFileHandler<'a, F: ReadFileToJs> {
+/// Settles `promise` with `F(bytes)` once a file read finishes.
+pub struct NewReadFileHandler<F: ReadFileToJs> {
     pub(crate) context: Blob,
     pub(crate) promise: JSPromiseStrong,
-    pub global_this: &'a JSGlobalObject,
+    pub global_this: bun_ptr::BackRef<JSGlobalObject>,
     _f: PhantomData<F>,
 }
 
-impl<'a, F: ReadFileToJs> NewReadFileHandler<'a, F> {
-    pub(crate) fn new(context: Blob, global_this: &'a JSGlobalObject) -> Self {
+impl<F: ReadFileToJs> NewReadFileHandler<F> {
+    pub(crate) fn new(context: Blob, global_this: &JSGlobalObject) -> Self {
         Self {
             context,
-            promise: JSPromiseStrong::default(),
-            global_this,
+            promise: JSPromiseStrong::init(global_this),
+            global_this: bun_ptr::BackRef::new(global_this),
             _f: PhantomData,
         }
     }
 }
 
-/// A typed receiver for a file read's bytes. [`ReadFileCompletionFns::of`] erases it to the
-/// `(ctx, run, cancel)` a `ReadFile` job carries as its JS side (or a `ReadFileUV` as a field): the
-/// shims call `C::run` / `C::cancel` directly and `ctx` is the raw `*mut C`, no extra heap wrapper.
+/// Where a file read's bytes (or error) go, on the JS thread. Exactly one of
+/// `run`/`cancel` is called, once.
 pub trait ReadFileCompletion {
-    /// # Safety
-    /// `ctx` must be a heap-allocated `Self` whose ownership is transferred to
-    /// this call (it is reclaimed via `bun_core::heap::take`).
-    unsafe fn run(ctx: *mut Self, bytes: ReadFileResultType) -> JsResult<()>;
-    /// The read will never complete (its VM stopped before it did): release `ctx`.
-    ///
-    /// # Safety
-    /// Same ownership transfer as `run`; exactly one of the two is called.
-    unsafe fn cancel(ctx: *mut Self) {
-        // SAFETY: per the trait contract `ctx` is the heap-allocated `Self` we now own.
-        drop(unsafe { bun_core::heap::take(ctx) });
-    }
+    fn run(self: Box<Self>, bytes: ReadFileResultType) -> JsResult<()>;
+    /// The read will never complete (its VM stopped before it did).
+    fn cancel(self: Box<Self>) {}
 }
 
-impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
-    unsafe fn run(handler: *mut Self, maybe_bytes: ReadFileResultType) -> JsResult<()> {
-        // SAFETY: handler was heap-allocated by doReadFile(); we take ownership here.
-        let mut handler = unsafe { bun_core::heap::take(handler) };
-        // `Strong::swap()` ties the returned `&mut JSPromise` to
-        // `&mut self`, but the promise is GC-heap-owned and outlives `handler`.
-        // Decay to a raw pointer so `handler` can be dropped before resolution.
-        let promise: *mut jsc::JSPromise = handler.promise.swap();
-        let blob = core::mem::take(&mut handler.context);
-        let global_this = handler.global_this;
-        drop(handler);
+impl<F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<F> {
+    fn run(self: Box<Self>, maybe_bytes: ReadFileResultType) -> JsResult<()> {
+        let Self {
+            context: blob,
+            mut promise,
+            global_this,
+            ..
+        } = *self;
+        let global_this = global_this.get();
+        // `swap()` releases the Strong's root; the promise cell stays alive on
+        // the stack below.
+        let promise = promise.swap();
         match maybe_bytes {
             ReadFileResultType::Result(result) => {
                 let bytes = result.buf;
@@ -118,15 +99,10 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
                 // The `#[track_caller]` `to_js_host_call` inside `AnyPromise::wrap`
                 // provides the source-location/exception-scope behaviour.
                 AnyPromise::Normal(promise).wrap(global_this, move |g| {
-                    F::call(&blob, g, bytes, Lifetime::Temporary)
+                    F::call(&blob, g, SourceBytes::Temporary(bytes))
                 })?;
             }
             ReadFileResultType::Err(err) => {
-                // SAFETY: `promise` was just swapped out of `handler.promise`,
-                // the `JSPromiseStrong` that rooted it across the async read;
-                // from here to `reject` it is a JS-thread stack local, kept
-                // alive by JSC's conservative stack scan.
-                let promise = unsafe { &mut *promise };
                 let val = err.to_error_instance_with_async_stack(global_this, promise);
                 promise.reject(global_this, Ok(val))?;
             }
@@ -139,64 +115,34 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
 // Type aliases / result types
 // ──────────────────────────────────────────────────────────────────────────
 
-type ReadFileOnReadFileCallback = fn(ctx: *mut c_void, bytes: ReadFileResultType) -> JsResult<()>;
-/// The read never completed; do with `ctx` what its owner needs (free it, or tell it).
-type ReadFileOnCancelCallback = fn(ctx: *mut c_void);
+/// A `ReadFile`'s (or `ReadFileUV`'s) JS side: what to do with the bytes,
+/// completed by `then`, or cancelled when dropped uncompleted (the job came
+/// back to a VM that is no longer running script).
+#[derive(bun_jsc::JsAffine)]
+pub struct ReadFileOnDone(Option<jsc::job::JsCallback<dyn ReadFileCompletion>>);
 
-/// What a `ReadFile`/`ReadFileUV` does with the bytes (or the lack of them): `run` on completion,
-/// `cancel` if it is dropped before completing. Exactly one of the two is invoked, once, on the JS
-/// thread — the ctx typically owns a promise and a Blob, so this is the job's JS side.
-pub struct ReadFileCompletionFns {
-    pub(crate) ctx: *mut c_void,
-    pub(crate) run: ReadFileOnReadFileCallback,
-    pub(crate) cancel: ReadFileOnCancelCallback,
-}
-
-impl ReadFileCompletionFns {
-    /// Erase a typed `ReadFileCompletion`.
-    pub(crate) fn of<C: ReadFileCompletion>(ctx: *mut C) -> Self {
-        fn run<C: ReadFileCompletion>(ctx: *mut c_void, bytes: ReadFileResultType) -> JsResult<()> {
-            // SAFETY: `ctx` is the `*mut C` erased below; ownership transfers per the trait.
-            unsafe { C::run(ctx.cast::<C>(), bytes) }
-        }
-        fn cancel<C: ReadFileCompletion>(ctx: *mut c_void) {
-            // SAFETY: as for `run`.
-            unsafe { C::cancel(ctx.cast::<C>()) }
-        }
-        Self {
-            ctx: ctx.cast::<c_void>(),
-            run: run::<C>,
-            cancel: cancel::<C>,
-        }
+impl ReadFileOnDone {
+    pub fn new<C: ReadFileCompletion + 'static>(completion: C) -> Self {
+        Self(Some(jsc::job::JsCallback(Box::new(completion))))
     }
 
-    fn complete(self, bytes: ReadFileResultType) -> JsResult<()> {
-        let this = core::mem::ManuallyDrop::new(self);
-        (this.run)(this.ctx, bytes)
+    fn complete(mut self, bytes: ReadFileResultType) -> JsResult<()> {
+        let completion = self.0.take().expect("a read completes once");
+        completion.0.run(bytes)
     }
 }
 
-impl Drop for ReadFileCompletionFns {
+impl Drop for ReadFileOnDone {
     fn drop(&mut self) {
-        (self.cancel)(self.ctx)
+        if let Some(completion) = self.0.take() {
+            completion.0.cancel();
+        }
     }
 }
-
-// SAFETY: the ctx holds JS-thread state (promise, Blob); it is only ever completed or cancelled on
-// the JS thread — as a Job's `Js` side, or inside the JS-thread-only ReadFileUV.
-unsafe impl bun_jsc::job::JsAffine for ReadFileCompletionFns {}
 
 pub struct ReadFileRead {
-    /// Always a `Box::<[u8]>::into_raw` from the producer's read buffer
-    /// (`Vec::into_boxed_slice()` so layout is exactly `(ptr, len)`). Every
-    /// consumer reclaims via `heap::take` — there is no borrow case left
-    /// (only the two finishers below construct this type and both hand off
-    /// owned bytes).
-    /// Stored as a raw pointer rather than `Box<[u8]>` because the
-    /// `NewReadFileHandler` consumer forwards it straight into
-    /// `to_*_with_bytes::<Temporary>(*mut [u8])`, which itself decides whether
-    /// the bytes are freed locally or transferred to a JSC external string.
-    pub(crate) buf: *mut [u8],
+    /// The producer's read buffer, handed over whole.
+    pub(crate) buf: Box<[u8]>,
 }
 
 /// Result-or-error union for a completed read.
@@ -211,11 +157,6 @@ pub enum ReadFileResultType {
 /// The completion token a `ReadFile` keeps across its async I/O.
 pub type ReadFileTask = bun_jsc::Completion<ReadFile>;
 
-// SAFETY: file store / byte store / blob store ref (atomic), the read buffer and io-loop
-// registration state — nothing thread-affine. What the bytes are delivered to lives in the job's
-// JS side (`ReadFileCompletionFns`), never here.
-unsafe impl Send for ReadFile {}
-
 impl bun_jsc::JobContext for ReadFile {
     type OffThread = Self;
     /// A read parked on a pipe/tty that never becomes readable is the one
@@ -226,20 +167,14 @@ impl bun_jsc::JobContext for ReadFile {
     } else {
         Some(bun_jsc::job::ParkedRequestOffset::INLINE)
     };
-    /// Where the bytes go: completed by `then`, or cancelled (its `Drop`) when the job comes
-    /// back to a VM that is no longer running script and is released unrun.
-    type Js = ReadFileCompletionFns;
+    type Js = ReadFileOnDone;
     fn run(this: &mut Self, done: bun_jsc::Completion<Self>) -> Option<bun_jsc::Completion<Self>> {
         // Starts the read; finishes from the io loop via the token.
         this.run(done);
         None
     }
-    fn then(
-        this: Self,
-        completion: ReadFileCompletionFns,
-        cx: &bun_jsc::JsThread<'_>,
-    ) -> jsc::JsResult<()> {
-        ReadFile::then(this, completion, cx.global())
+    fn then(this: Self, on_done: ReadFileOnDone, cx: &bun_jsc::JsThread<'_>) -> jsc::JsResult<()> {
+        ReadFile::then(this, on_done, cx.global())
     }
 }
 
@@ -247,12 +182,8 @@ impl bun_jsc::JobContext for ReadFile {
 impl ReadFile {
     /// JS thread: hand a prepared `ReadFile` and what to do with its bytes to the work pool (the
     /// job is its one heap allocation).
-    pub(crate) fn schedule(
-        this: ReadFile,
-        completion: ReadFileCompletionFns,
-        global: &JSGlobalObject,
-    ) {
-        bun_jsc::Job::<ReadFile>::schedule(&global.js_thread(), this, completion);
+    pub(crate) fn schedule(this: ReadFile, on_done: ReadFileOnDone, global: &JSGlobalObject) {
+        bun_jsc::Job::<ReadFile>::schedule(&global.js_thread(), this, on_done);
     }
 }
 
@@ -260,9 +191,11 @@ impl ReadFile {
 // ReadFile
 // ──────────────────────────────────────────────────────────────────────────
 
+#[cfg_attr(windows, allow(dead_code))] // Windows reads go through `ReadFileUV`
 pub struct ReadFile {
-    pub(crate) file_store: FileStore,
-    pub(crate) store: Option<RefPtr<Store>>,
+    /// The file store being read (a `Data::File`); its `File` is
+    /// [`file_store`](Self::file_store).
+    pub(crate) store: RefPtr<Store>,
     pub offset: SizeType,
     #[cfg(not(windows))]
     pub(crate) max_length: SizeType,
@@ -320,7 +253,7 @@ impl io::IoRequestHandler for ReadFile {
     }
 }
 
-// The default methods on the FileOpener/FileCloser traits provide the bodies.
+#[cfg(not(windows))]
 impl FileOpener for ReadFile {
     fn opened_fd(&self) -> Fd {
         self.opened_fd
@@ -334,30 +267,21 @@ impl FileOpener for ReadFile {
     fn set_system_error(&mut self, e: jsc::SystemError) {
         self.system_error = Some(e);
     }
-    fn pathlike(&self) -> &PathOrFileDescriptor<'static> {
-        &self.file_store.pathlike
-    }
-    #[cfg(windows)]
-    fn loop_(&self) -> *mut bun_libuv_sys::uv_loop_t {
-        unreachable!("ReadFile is POSIX-only; see ReadFileUV")
-    }
-    #[cfg(windows)]
-    fn req(&mut self) -> &mut bun_libuv_sys::uv_fs_t {
-        unreachable!("ReadFile is POSIX-only; see ReadFileUV")
-    }
-    #[cfg(windows)]
-    fn set_open_callback(&mut self, _cb: fn(&mut Self, Fd)) {
-        unreachable!()
-    }
-    #[cfg(windows)]
-    fn open_callback(&self) -> fn(&mut Self, Fd) {
-        unreachable!()
+    fn pathlike(&self) -> &crate::webcore::node_types::PathOrFileDescriptor<'static> {
+        &self.file_store().pathlike
     }
 }
 
+#[cfg(not(windows))]
 crate::webcore::blob::impl_file_closer!(ReadFile);
 
 impl ReadFile {
+    #[cfg(not(windows))]
+    #[inline]
+    pub(crate) fn file_store(&self) -> &FileStore {
+        self.store.data.as_file()
+    }
+
     pub(crate) fn update(&mut self) {
         #[cfg(windows)]
         {
@@ -375,15 +299,10 @@ impl ReadFile {
 
     // Not for Windows; Windows callers use ReadFileUV.
     #[cfg(not(windows))]
-    pub(crate) fn create(
-        store: RefPtr<Store>,
-        off: SizeType,
-        max_len: SizeType,
-    ) -> Result<ReadFile, Error> {
-        let file_store = store.data.as_file().clone();
-        let read_file = ReadFile {
-            file_store,
-            store: Some(store),
+    pub(crate) fn create(store: RefPtr<Store>, off: SizeType, max_len: SizeType) -> ReadFile {
+        // store.ref() — `RefPtr<Store>` carries the +1; held in `self.store`.
+        ReadFile {
+            store,
             offset: off,
             max_length: max_len,
             total_size: MAX_SIZE,
@@ -401,8 +320,7 @@ impl ReadFile {
             could_block: false,
             close_after_io: false,
             state: AtomicU8::new(ClosingState::Running as u8),
-        };
-        Ok(read_file)
+        }
     }
 
     pub fn on_ready(&mut self) {
@@ -471,55 +389,53 @@ impl ReadFile {
         io::IoRequestLoop::schedule(self.io.request());
     }
 
-    /// Pick the read target: `buffer`'s spare capacity if it is at least as
-    /// large as `stack_buffer`, otherwise `stack_buffer`; capped by
-    /// `max_length - read_off`. Returns `(use_stack, target)` so the caller
-    /// keys its `extend_from_slice`/`commit_spare` decision off the same
-    /// branch taken here.
+    /// One `read()`/`recv()` into `target`: `buffer`'s spare capacity, or
+    /// `stack` when that is the roomier of the two — capped by
+    /// `max_length - read_off`. Returns the byte count (`0` with
+    /// `*retry == true` when a non-blocking source had nothing yet) or `None`
+    /// after recording the error. Never touches `self.buffer`; the caller
+    /// moves it out for the duration.
     #[cfg(not(windows))]
-    fn remaining_buffer<'a>(
-        buffer: &'a mut Vec<u8>,
-        stack_buffer: &'a mut [u8],
-        max_length: SizeType,
-        read_off: SizeType,
-    ) -> (bool, &'a mut [u8]) {
-        let cap = (max_length.saturating_sub(read_off)) as usize;
-        let spare = buffer.spare_capacity_mut();
-        if spare.len() < stack_buffer.len() {
-            let n = stack_buffer.len().min(cap);
-            (true, &mut stack_buffer[..n])
-        } else {
-            let n = spare.len().min(cap);
-            // SAFETY: `spare` is `&mut [MaybeUninit<u8>]` over the Vec's spare
-            // capacity. The bytes are only written by the `read()`/`recv()`
-            // syscall below and `commit_spare` advances `len` by exactly the
-            // kernel-reported initialized count; no uninit byte is ever read.
-            let target =
-                unsafe { core::slice::from_raw_parts_mut(spare.as_mut_ptr().cast::<u8>(), n) };
-            (false, target)
-        }
-    }
-
-    /// Never touches `self.buffer`; the caller moves it out for the duration.
-    #[cfg(not(windows))]
-    pub(crate) fn do_read(
+    fn do_read(
         &mut self,
-        buf: &mut [u8],
-        read_len: &mut usize,
+        buffer: &mut Vec<u8>,
+        stack: &mut [MaybeUninit<u8>],
         retry: &mut bool,
-    ) -> bool {
-        let result: bun_sys::Result<usize> = 'brk: {
-            if bun_sys::S::ISSOCK(self.file_store.mode) {
-                break 'brk bun_sys::recv_non_block(self.opened_fd, buf);
-            }
-            break 'brk bun_sys::read(self.opened_fd, buf);
+    ) -> Option<usize> {
+        let cap = (self.max_length.saturating_sub(self.read_off)) as usize;
+        let is_socket = bun_sys::S::ISSOCK(self.file_store().mode);
+        let result: bun_sys::Result<usize> = if buffer.spare_capacity_mut().len() < stack.len() {
+            let room = stack.len().min(cap);
+            let stack = &mut stack[..room];
+            let filled = if is_socket {
+                bun_sys::recv_non_block_uninit(self.opened_fd, stack)
+            } else {
+                bun_sys::read_uninit(self.opened_fd, stack)
+            };
+            // We read into the stack buffer, so we need to copy it into the heap.
+            filled.map(|read| {
+                if buffer.capacity() == 0 {
+                    // We need to allocate a new buffer
+                    // In this case, we want to use `ensureTotalCapacityPrecise` so that it's an exact amount
+                    // We want to avoid over-allocating incase it's a large amount of data sent in a single chunk followed by a 0 byte chunk.
+                    buffer.reserve_exact(read.len());
+                } else {
+                    buffer.reserve(read.len());
+                }
+                buffer.extend_from_slice(read);
+                read.len()
+            })
+        } else if is_socket {
+            bun_sys::recv_non_block_to_spare(self.opened_fd, buffer, cap)
+        } else {
+            bun_sys::read_to_spare(self.opened_fd, buffer, cap)
         };
 
         loop {
             match &result {
                 Ok(res) => {
-                    *read_len = *res as usize; // @truncate — usize→usize is identity here
                     self.read_eof = *res == 0;
+                    return Some(*res);
                 }
                 Err(err) => {
                     match err.get_errno() {
@@ -531,72 +447,42 @@ impl ReadFile {
                             }
                             *retry = true;
                             self.read_eof = false;
-                            return true;
+                            return Some(0);
                         }
                         _ => {
                             self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
                             self.system_error = Some(err.to_system_error().into());
                             if self.system_error.as_ref().unwrap().path.is_empty() {
-                                self.system_error.as_mut().unwrap().path =
-                                    if self.file_store.pathlike.is_path() {
-                                        BunString::clone_utf8(
-                                            self.file_store.pathlike.path().slice(),
-                                        )
-                                    } else {
-                                        BunString::EMPTY
-                                    };
+                                let path = if self.file_store().pathlike.is_path() {
+                                    BunString::clone_utf8(self.file_store().pathlike.path().slice())
+                                } else {
+                                    BunString::EMPTY
+                                };
+                                self.system_error.as_mut().unwrap().path = path;
                             }
-                            return false;
+                            return None;
                         }
                     }
                 }
             }
-            break;
         }
-
-        true
     }
 
-    pub(crate) fn then(
-        this: Self,
-        completion: ReadFileCompletionFns,
-        _: &JSGlobalObject,
-    ) -> JsResult<()> {
+    pub(crate) fn then(this: Self, on_done: ReadFileOnDone, _: &JSGlobalObject) -> JsResult<()> {
         let mut this = this;
-
-        if this.store.is_none() && this.system_error.is_some() {
-            let system_error = this.system_error.take().unwrap();
-            drop(this);
-            return completion.complete(ReadFileResultType::Err(system_error));
-        } else if this.store.is_none() {
-            drop(this);
-            if cfg!(debug_assertions) {
-                panic!("assertion failure - store should not be null");
-            }
-            return completion.complete(ReadFileResultType::Err(SystemError {
-                code: BunString::static_("INTERNAL_ERROR"),
-                message: BunString::static_("assertion failure - store should not be null"),
-                syscall: BunString::static_("read"),
-                ..Default::default()
-            }));
-        }
-
-        let _store = this.store.take().unwrap();
         // reshaped for borrowck — take buffer out so it survives `drop(this)`.
         let buf = core::mem::take(&mut this.buffer);
-
-        // `_store` is dropped at end of scope (= store.deref()).
         let system_error = this.system_error.take();
+        // Held across the completion (it may inspect the store); released after.
+        let _store = this.store.clone();
         drop(this);
 
         if let Some(err) = system_error {
-            return completion.complete(ReadFileResultType::Err(err));
+            return on_done.complete(ReadFileResultType::Err(err));
         }
 
-        // The receiver takes ownership. Normalize to `Box<[u8]>` so every
-        // consumer can reclaim via `heap::take` with a matching layout.
-        completion.complete(ReadFileResultType::Result(ReadFileRead {
-            buf: bun_core::heap::into_raw(buf.into_boxed_slice()),
+        on_done.complete(ReadFileResultType::Result(ReadFileRead {
+            buf: buf.into_boxed_slice(),
         }))
     }
 
@@ -615,8 +501,8 @@ impl ReadFile {
         {
             self.io_task = Some(task);
 
-            if self.file_store.pathlike.is_fd() {
-                self.opened_fd = self.file_store.pathlike.fd();
+            if self.file_store().pathlike.is_fd() {
+                self.opened_fd = self.file_store().pathlike.fd();
             }
 
             self.get_fd(Self::run_async_with_fd);
@@ -625,7 +511,7 @@ impl ReadFile {
 
     #[cfg(not(windows))]
     pub(crate) fn is_allowed_to_close(&self) -> bool {
-        self.file_store.pathlike.is_path()
+        self.file_store().pathlike.is_path()
     }
 
     #[cfg(not(windows))]
@@ -659,19 +545,17 @@ impl ReadFile {
             }
         };
 
-        if let Some(store) = &self.store {
-            if let Data::File(file) = Store::data_mut(store) {
-                let mtime = bun_sys::PosixStat::init(&stat).mtime();
-                file.last_modified = jsc::to_js_time(mtime.sec as isize, mtime.nsec as isize);
-            }
+        if let Data::File(file) = Store::data_mut(&self.store) {
+            let mtime = bun_sys::PosixStat::init(&stat).mtime();
+            file.last_modified = jsc::to_js_time(mtime.sec as isize, mtime.nsec as isize);
         }
 
         if bun_sys::S::ISDIR(stat.st_mode as _) {
             self.errno = Some(crate::Error::Sys(bun_errno::SystemErrno::EISDIR));
             self.system_error = Some(SystemError {
                 code: BunString::static_("EISDIR"),
-                path: if self.file_store.pathlike.is_path() {
-                    BunString::clone_utf8(self.file_store.pathlike.path().slice())
+                path: if self.file_store().pathlike.is_path() {
+                    BunString::clone_utf8(self.file_store().pathlike.path().slice())
                 } else {
                     BunString::EMPTY
                 },
@@ -715,9 +599,8 @@ impl ReadFile {
 
         // Special files might report a size of > 0, and be wrong.
         // so we should check specifically that its a regular file before trusting the size.
-        if self.size == 0 && bun_sys::is_regular_file(self.file_store.mode) {
+        if self.size == 0 && bun_sys::is_regular_file(self.file_store().mode) {
             self.buffer = Vec::new();
-
             self.on_finish();
             return;
         }
@@ -763,132 +646,104 @@ impl ReadFile {
 
     #[cfg(not(windows))]
     fn do_read_loop(&mut self) {
-        #[cfg(not(windows))]
-        {
-            // we hold a 64 KB stack buffer incase the amount of data to
-            // be read is greater than the reported amount
-            //
-            // 64 KB is large, but since this is running in a thread
-            // with it's own stack, it should have sufficient space.
-            let mut stack_storage = bun_core::vec::UninitBuf::<{ 64 * 1024 }>::uninit();
-            // SAFETY: only `do_read` writes into it and only `stack_buffer[..read_amount]` is read back.
-            let stack_buffer = unsafe { stack_storage.as_bytes_mut() };
-            // `do_read` never touches `self.buffer`; move it out so the read
-            // target slice (which may point into its spare capacity) can be
-            // held as a safe `&mut [u8]` across the `&mut self` call.
-            let mut buffer = core::mem::take(&mut self.buffer);
-            while self.state.load(Ordering::Relaxed) == ClosingState::Running as u8 {
-                let (use_stack, buf) = Self::remaining_buffer(
-                    &mut buffer,
-                    stack_buffer,
-                    self.max_length,
-                    self.read_off,
-                );
+        // we hold a 64 KB stack buffer incase the amount of data to
+        // be read is greater than the reported amount
+        //
+        // 64 KB is large, but since this is running in a thread
+        // with it's own stack, it should have sufficient space.
+        let mut stack_buffer = [MaybeUninit::<u8>::uninit(); 64 * 1024];
+        // `do_read` appends to the buffer it is handed; move ours out so it
+        // can sit beside `&mut self`.
+        let mut buffer = core::mem::take(&mut self.buffer);
+        while self.state.load(Ordering::Relaxed) == ClosingState::Running as u8 {
+            let room = (self.max_length.saturating_sub(self.read_off) as usize)
+                .min(buffer.spare_capacity_mut().len().max(stack_buffer.len()));
 
-                if !buf.is_empty() && self.errno.is_none() && !self.read_eof {
-                    let mut read_amount: usize = 0;
-                    let mut retry = false;
-                    let continue_reading = self.do_read(buf, &mut read_amount, &mut retry);
+            if room > 0 && self.errno.is_none() && !self.read_eof {
+                let mut retry = false;
+                let read = self.do_read(&mut buffer, &mut stack_buffer, &mut retry);
 
-                    // We might read into the stack buffer, so we need to copy it into the heap.
-                    if use_stack {
-                        // `do_read` initialized exactly `stack_buffer[..read_amount]` (0 on error/retry).
-                        let read = &stack_buffer[..read_amount];
-                        if buffer.capacity() == 0 {
-                            // We need to allocate a new buffer
-                            // In this case, we want to use `ensureTotalCapacityPrecise` so that it's an exact amount
-                            // We want to avoid over-allocating incase it's a large amount of data sent in a single chunk followed by a 0 byte chunk.
-                            buffer.reserve_exact(read.len());
-                        } else {
-                            buffer.reserve(read.len());
-                        }
-                        buffer.extend_from_slice(read);
-                    } else {
-                        // record the amount of data read
-                        // SAFETY: read() wrote `read_amount` initialized bytes into spare capacity.
-                        unsafe { bun_core::vec::commit_spare(&mut buffer, read_amount) };
-                    }
-                    // - If they DID set a max length, we should stop
-                    //   reading after that.
-                    //
-                    // - If they DID NOT set a max_length, then it will
-                    //   be Blob.max_size which is an impossibly large
-                    //   amount to read.
-                    if !self.read_eof && buffer.len() >= self.max_length as usize {
-                        break;
-                    }
-
-                    if !continue_reading {
-                        // Stop reading, we errored
-                        break;
-                    }
-
-                    // If it's not a regular file, it might be something
-                    // which would block on the next read. So we should
-                    // avoid immediately reading again until the next time
-                    // we're scheduled to read.
-                    //
-                    // An example of where this happens is stdin.
-                    //
-                    //    await Bun.stdin.text();
-                    //
-                    // If we immediately call read(), it will block until stdin is
-                    // readable.
-                    if retry
-                        || (self.could_block
-                        // If we received EOF, we can skip the poll() system
-                        // call. We already know it's done.
-                        && !self.read_eof)
-                    {
-                        if self.could_block
-                        // If we received EOF, we can skip the poll() system
-                        // call. We already know it's done.
-                        && !self.read_eof
-                        {
-                            match bun_core::is_readable(self.opened_fd) {
-                                bun_core::Pollable::NotReady => {}
-                                bun_core::Pollable::Ready | bun_core::Pollable::Hup => continue,
-                            }
-                        }
-                        self.read_eof = false;
-                        self.buffer = buffer;
-                        self.wait_for_readable();
-
-                        return;
-                    }
-
-                    // There can be more to read
-                    continue;
+                // - If they DID set a max length, we should stop
+                //   reading after that.
+                //
+                // - If they DID NOT set a max_length, then it will
+                //   be Blob.max_size which is an impossibly large
+                //   amount to read.
+                if !self.read_eof && buffer.len() >= self.max_length as usize {
+                    break;
                 }
 
-                // -- We are done reading.
-                break;
-            }
-            self.buffer = buffer;
+                if read.is_none() {
+                    // Stop reading, we errored
+                    break;
+                }
 
-            if self.system_error.is_some() {
-                self.buffer = Vec::new(); // clearAndFree
+                // If it's not a regular file, it might be something
+                // which would block on the next read. So we should
+                // avoid immediately reading again until the next time
+                // we're scheduled to read.
+                //
+                // An example of where this happens is stdin.
+                //
+                //    await Bun.stdin.text();
+                //
+                // If we immediately call read(), it will block until stdin is
+                // readable.
+                if retry
+                    || (self.could_block
+                    // If we received EOF, we can skip the poll() system
+                    // call. We already know it's done.
+                    && !self.read_eof)
+                {
+                    if self.could_block
+                    // If we received EOF, we can skip the poll() system
+                    // call. We already know it's done.
+                    && !self.read_eof
+                    {
+                        match bun_core::is_readable(self.opened_fd) {
+                            bun_core::Pollable::NotReady => {}
+                            bun_core::Pollable::Ready | bun_core::Pollable::Hup => continue,
+                        }
+                    }
+                    self.read_eof = false;
+                    self.buffer = buffer;
+                    self.wait_for_readable();
+
+                    return;
+                }
+
+                // There can be more to read
+                continue;
             }
 
-            // If we over-allocated by a lot, we should shrink the buffer to conserve memory.
-            if self.buffer.len() + 16_000 < self.buffer.capacity() {
-                self.buffer.shrink_to_fit();
-            }
-            self.on_finish();
+            // -- We are done reading.
+            break;
         }
+        self.buffer = buffer;
+
+        if self.system_error.is_some() {
+            self.buffer = Vec::new(); // clearAndFree
+        }
+
+        // If we over-allocated by a lot, we should shrink the buffer to conserve memory.
+        if self.buffer.len() + 16_000 < self.buffer.capacity() {
+            self.buffer.shrink_to_fit();
+        }
+        self.on_finish();
     }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
 // ReadFileUV (Windows)
+//
+// Owned as a `Box` by whoever drives the next step: libuv while an
+// open/fstat/read is in flight (`bun_io::uv_fs`), otherwise the code below.
+// Finishing drops the box.
 // ──────────────────────────────────────────────────────────────────────────
 
 #[cfg(windows)]
-pub struct ReadFileUV<'a> {
-    pub(crate) loop_: *mut libuv::uv_loop_t,
-    pub(crate) event_loop: &'a EventLoop,
-    pub(crate) file_store: FileStore,
-    pub(crate) byte_store: ByteStore,
+pub struct ReadFileUV {
+    pub(crate) event_loop: bun_ptr::BackRef<EventLoop>,
     pub(crate) store: RefPtr<Store>,
     pub offset: SizeType,
     pub(crate) max_length: SizeType,
@@ -902,123 +757,28 @@ pub struct ReadFileUV<'a> {
     pub(crate) system_error: Option<SystemError>,
     pub(crate) errno: Option<Error>,
     /// `Some` until the read completes; a `ReadFileUV` dropped before that cancels it.
-    pub(crate) completion: Option<ReadFileCompletionFns>,
+    pub(crate) on_done: Option<ReadFileOnDone>,
     pub(crate) is_regular_file: bool,
 
     pub(crate) req: libuv::fs_t,
-    /// Stash for the open completion callback across the libuv async hop.
-    open_callback: fn(&mut Self, Fd),
 }
 
 #[cfg(windows)]
-impl<'a> FileOpener for ReadFileUV<'a> {
-    fn opened_fd(&self) -> Fd {
-        self.opened_fd
-    }
-    fn set_opened_fd(&mut self, fd: Fd) {
-        self.opened_fd = fd;
-    }
-    fn set_errno(&mut self, e: crate::Error) {
-        self.errno = Some(e);
-    }
-    fn set_system_error(&mut self, e: jsc::SystemError) {
-        self.system_error = Some(e);
-    }
-    fn pathlike(&self) -> &PathOrFileDescriptor<'static> {
-        &self.file_store.pathlike
-    }
-    fn loop_(&self) -> *mut bun_libuv_sys::uv_loop_t {
-        self.loop_
-    }
-    fn req(&mut self) -> &mut bun_libuv_sys::uv_fs_t {
-        &mut self.req
-    }
-    fn set_open_callback(&mut self, cb: fn(&mut Self, Fd)) {
-        self.open_callback = cb;
-    }
-    fn open_callback(&self) -> fn(&mut Self, Fd) {
-        self.open_callback
-    }
-}
+bun_io::intrusive_uv_fs!(ReadFileUV, req);
 
 #[cfg(windows)]
-impl<'a> FileCloser for ReadFileUV<'a> {
-    fn opened_fd(&self) -> Fd {
-        self.opened_fd
-    }
-    fn set_opened_fd(&mut self, fd: Fd) {
-        self.opened_fd = fd;
-    }
-    fn loop_(&self) -> *mut bun_libuv_sys::uv_loop_t {
-        self.loop_
-    }
-
-    // `ReadFileUV` has no `io_request` field (its libuv request field is
-    // `req`), so `do_close` falls straight to the close-fd branch and
-    // none of the methods below are ever reached — these are genuinely dead
-    // code paths.
-    fn close_after_io(&self) -> bool {
-        false
-    }
-    fn set_close_after_io(&mut self, _: bool) {
-        unreachable!("@hasField(ReadFileUV, \"io_request\") == false")
-    }
-    fn state(&self) -> &AtomicU8 {
-        unreachable!("@hasField(ReadFileUV, \"io_request\") == false")
-    }
-    fn io_request(&mut self) -> Option<&mut bun_io::Request> {
-        None
-    }
-    fn task(&mut self) -> &mut bun_jsc::WorkPoolTask {
-        unreachable!("@hasField(ReadFileUV, \"io_request\") == false")
-    }
-    unsafe fn schedule_close(_: &mut bun_io::Request) -> bun_io::Action<'_> {
-        unreachable!("@hasField(ReadFileUV, \"io_request\") == false")
-    }
-}
-
-#[cfg(windows)]
-impl<'a> ReadFileUV<'a> {
-    /// Typed entry: `C` supplies run/cancel for the erased completion.
-    pub(crate) fn start<C: ReadFileCompletion>(
-        event_loop: *mut EventLoop,
+impl ReadFileUV {
+    pub(crate) fn start(
+        event_loop: &EventLoop,
         store: RefPtr<Store>,
         off: SizeType,
         max_len: SizeType,
-        handler: *mut C,
-    ) {
-        Self::start_with_ctx(
-            event_loop,
-            store,
-            off,
-            max_len,
-            ReadFileCompletionFns::of(handler),
-        )
-    }
-
-    /// Raw entry — caller already has the type-erased `(fn, *anyopaque)` pair
-    /// Shares the body with `start`.
-    pub(crate) fn start_with_ctx(
-        event_loop: *mut EventLoop,
-        store: RefPtr<Store>,
-        off: SizeType,
-        max_len: SizeType,
-        completion: ReadFileCompletionFns,
+        on_done: ReadFileOnDone,
     ) {
         log!("ReadFileUV.start");
-        // SAFETY: `event_loop` is the per-thread `EventLoop` singleton owned by
-        // the VM (`global.bun_vm().event_loop()`); it strictly outlives this
-        // async op, which additionally holds a keep-alive on it below.
-        let event_loop: &'a EventLoop = unsafe { &*event_loop };
-        let file_store = store.data.as_file().clone();
-        let this = Box::new(ReadFileUV {
-            // Projected through the helper to avoid materializing a
-            // `&VirtualMachine`.
-            loop_: event_loop.uv_loop().cast(),
-            event_loop,
-            file_store,
-            byte_store: ByteStore::default(),
-            store, // store.ref() — Arc clone owned here
+        let mut this = Box::new(ReadFileUV {
+            event_loop: bun_ptr::BackRef::new(event_loop),
+            store, // store.ref() — the +1 owned here
             offset: off,
             max_length: max_len,
             total_size: MAX_SIZE,
@@ -1030,131 +790,198 @@ impl<'a> ReadFileUV<'a> {
             buffer: Vec::new(),
             system_error: None,
             errno: None,
-            completion: Some(completion),
+            on_done: Some(on_done),
             is_regular_file: false,
             req: bun_core::ffi::zeroed(),
-            open_callback: Self::on_file_open,
         });
+        this.req.loop_ = event_loop.uv_loop().cast();
         // Keep the event loop alive while the async operation is pending
         event_loop.ref_keep_alive();
-        let this_ptr: *mut ReadFileUV = bun_core::heap::into_raw(this);
-        // SAFETY: this_ptr is freshly boxed and uniquely owned by the async op.
-        unsafe { (*this_ptr).get_fd(Self::on_file_open) };
-        // ownership now lives with the libuv request chain until finalize().
-        let _ = this_ptr;
+        Self::get_fd(this);
     }
 
-    pub fn finalize(this: *mut Self) {
+    #[inline]
+    fn file_store(&self) -> &FileStore {
+        self.store.data.as_file()
+    }
+
+    /// On return, `this` has been dropped.
+    fn finalize(mut this: Box<Self>) {
         log!("ReadFileUV.finalize");
-        // SAFETY: `this` was heap-allocated in start(); we reclaim ownership here.
-        let mut this_box = unsafe { bun_core::heap::take(this) };
-        let event_loop = this_box.event_loop;
+        let event_loop = this.event_loop;
 
-        let completion = this_box
-            .completion
-            .take()
-            .expect("a ReadFileUV completes once");
+        let on_done = this.on_done.take().expect("a ReadFileUV completes once");
 
-        let result = if let Some(err) = this_box.system_error.take() {
+        let result = if let Some(err) = this.system_error.take() {
             ReadFileResultType::Err(err)
         } else {
-            // Move byte_store out so dropping `this_box` below does not free the
-            // buffer we hand to the callback. Normalize to `Box<[u8]>` so the
-            // `is_temporary` consumer (Body.rs / Blob.rs) can soundly reclaim
-            // via `heap::take` — handing out `(ptr, len)` from a ByteStore
-            // whose `cap > len` would be a layout-mismatched dealloc.
-            let boxed = core::mem::take(&mut this_box.byte_store).into_boxed_slice();
             ReadFileResultType::Result(ReadFileRead {
-                buf: bun_core::heap::into_raw(boxed),
+                buf: core::mem::take(&mut this.buffer).into_boxed_slice(),
             })
         };
 
         // The completion must run BEFORE the cleanup below (store deref / req.deinit /
         // box drop / event_loop.unref) — it may inspect store. A libuv callback returns void: an
         // exception the JS side left pending is reported here (a termination just stands down).
-        crate::dispatch::fold(completion.complete(result));
+        crate::dispatch::fold(on_done.complete(result));
 
-        this_box.req.deinit();
-        drop(this_box);
+        // store.deref runs via RefPtr<Store>'s Drop when the Box drops.
+        this.req.deinit();
+        drop(this);
         // Release the event loop reference now that we're done
         event_loop.unref_keep_alive();
         log!("ReadFileUV.finalize destroy");
     }
 
     pub(crate) fn is_allowed_to_close(&self) -> bool {
-        self.file_store.pathlike.is_path()
+        self.file_store().pathlike.is_path()
     }
 
-    fn on_finish(&mut self) {
+    /// On return, `this` has been dropped.
+    fn on_finish(mut this: Box<Self>) {
         log!("ReadFileUV.onFinish");
-        let fd = self.opened_fd;
+        let fd = this.opened_fd;
         let needs_close = fd != Fd::INVALID;
 
-        self.size = self.read_len.max(self.size);
-        self.total_size = self.total_size.max(self.size);
+        this.size = this.read_len.max(this.size);
+        this.total_size = this.total_size.max(this.size);
 
-        if needs_close {
-            if self.do_close(self.is_allowed_to_close()) {
-                // we have to wait for the close to finish
-                return;
-            }
+        if needs_close && this.is_allowed_to_close() && fd.stdio_tag().is_none() {
+            bun_io::Closer::close(fd, this.req.loop_);
+            this.opened_fd = Fd::INVALID;
         }
 
-        Self::finalize(core::ptr::from_mut(self));
+        Self::finalize(this);
     }
 
-    pub(crate) fn on_file_open(&mut self, opened_fd: Fd) {
+    fn fail(mut this: Box<Self>, errno: bun_sys::E, syscall: bun_sys::Tag) {
+        this.errno = Some(bun_errno::from_errno(errno as i32).into());
+        this.system_error = Some(
+            bun_sys::Error::from_code(errno, syscall)
+                .to_system_error()
+                .into(),
+        );
+        Self::on_finish(this);
+    }
+
+    fn get_fd(mut this: Box<Self>) {
+        if let crate::webcore::node_types::PathOrFileDescriptor::Fd(fd) = this.file_store().pathlike
+        {
+            this.opened_fd = fd;
+            return Self::on_file_open(this);
+        }
+        use crate::node::types::PathLikeExt as _;
+        let mut buf = bun_paths::PathBuffer::uninit();
+        // Force-copied so the result lives in `buf`, not `this`.
+        let len = this
+            .file_store()
+            .pathlike
+            .path()
+            .slice_z_with_force_copy::<true>(&mut buf)
+            .len();
+        let path = bun_core::ZStr::from_buf(&buf[..], len);
+        if let Err((this, rc)) = bun_io::uv_fs::open(
+            this,
+            path.as_cstr(),
+            bun_sys::O::RDONLY | bun_sys::O::NONBLOCK | bun_sys::O::CLOEXEC,
+            crate::node::fs::DEFAULT_PERMISSION as i32,
+        ) {
+            let errno = rc.errno().expect("negative rc");
+            Self::fail_open(this, errno);
+        }
+    }
+
+    fn fail_open(mut this: Box<Self>, errno: bun_sys::E) {
+        this.errno = Some(bun_errno::from_errno(errno as i32).into());
+        this.system_error = Some(
+            bun_sys::Error::from_code(errno, bun_sys::Tag::open)
+                .with_path(this.file_store().pathlike.path().slice())
+                .to_system_error()
+                .into(),
+        );
+        this.opened_fd = Fd::INVALID;
+        Self::on_finish(this);
+    }
+
+    fn on_file_open(mut this: Box<Self>) {
         log!("ReadFileUV.onFileOpen");
-        if self.errno.is_some() {
-            self.on_finish();
-            return;
+        this.req.deinit();
+        let fd = this.opened_fd.uv();
+        if let Err((this, rc)) = bun_io::uv_fs::fstat(this, fd) {
+            let errno = rc.errno().expect("negative rc");
+            Self::fail(this, errno, bun_sys::Tag::fstat);
         }
-
-        self.req.deinit();
-        self.req.data = core::ptr::from_mut(self).cast::<c_void>();
-
-        // SAFETY: FFI — `loop_` is the live VM uv loop, `self.req` is a freshly
-        // deinit'd `fs_t` owned by `self`, `opened_fd.uv()` is the just-opened fd,
-        // and `on_file_initial_stat` is a valid `uv_fs_cb` that recovers `self`
-        // from `req.data` (set above).
-        let rc = unsafe {
-            libuv::uv_fs_fstat(
-                self.loop_,
-                &mut self.req,
-                opened_fd.uv(),
-                Some(Self::on_file_initial_stat),
-            )
-        };
-        if let Some(errno) = rc.errno() {
-            self.errno = Some(bun_errno::from_errno(errno as i32).into());
-            self.system_error = Some(
-                bun_sys::Error::from_code(errno, bun_sys::Tag::fstat)
-                    .to_system_error()
-                    .into(),
-            );
-            self.on_finish();
-            return;
-        }
-
-        self.req.data = core::ptr::from_mut(self).cast::<c_void>();
     }
 
-    extern "C" fn on_file_initial_stat(req: *mut libuv::fs_t) {
-        log!("ReadFileUV.onFileInitialStat");
-        // SAFETY: req.data was set to *mut Self in on_file_open().
-        let this: &mut ReadFileUV = unsafe { bun_ptr::callback_ctx::<ReadFileUV>((*req).data) };
+    fn spare_room(&self) -> usize {
+        (self.max_length.saturating_sub(self.read_off) as usize)
+            .min(self.buffer.capacity() - self.buffer.len())
+    }
 
-        // `req` aliases `this.req`; once `&mut ReadFileUV` exists, going through the
-        // raw `req` pointer would violate Stacked Borrows. Read via `this.req` instead.
-        if let Some(errno) = this.req.result.errno() {
-            this.errno = Some(bun_errno::from_errno(errno as i32).into());
-            this.system_error = Some(
-                bun_sys::Error::from_code(errno, bun_sys::Tag::fstat)
-                    .to_system_error()
-                    .into(),
+    pub(crate) fn queue_read(mut this: Box<Self>) {
+        // if not a regular file, buffer capacity is arbitrary, and running out doesn't mean we're
+        // at the end of the file
+        if (this.spare_room() > 0 || !this.is_regular_file)
+            && this.errno.is_none()
+            && !this.read_eof
+        {
+            log!(
+                "ReadFileUV.queueRead - this.remainingBuffer().len = {}",
+                this.spare_room()
             );
-            this.on_finish();
-            return;
+
+            if !this.is_regular_file {
+                // non-regular files have variable sizes, so we always ensure
+                // theres at least 4096 bytes of free space. there has already
+                // been an initial allocation done for us
+                if this.buffer.try_reserve(4096).is_err() {
+                    this.errno = Some(crate::Error::Alloc(bun_alloc::AllocError));
+                    this.system_error = Some(
+                        bun_sys::Error::from_code(bun_sys::E::NOMEM, bun_sys::Tag::read)
+                            .to_system_error()
+                            .into(),
+                    );
+                    return Self::on_finish(this);
+                }
+            }
+
+            this.req.assert_cleaned_up();
+            let fd = this.opened_fd.uv();
+            let max = this.max_length.saturating_sub(this.read_off) as usize;
+            let offset = i64::try_from(this.offset + this.read_off).expect("int cast");
+            if let Err((this, rc)) =
+                bun_io::uv_fs::read(this, fd, |t: &mut Self| &mut t.buffer, max, offset)
+            {
+                let errno = rc.errno().expect("negative rc");
+                Self::fail(this, errno, bun_sys::Tag::read);
+            }
+        } else {
+            log!("ReadFileUV.queueRead done");
+
+            // We are done reading.
+            Self::on_finish(this);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl bun_io::uv_fs::OnFsOpen for ReadFileUV {
+    fn on_fs_open(mut this: Box<Self>, rc: libuv::ReturnCodeI64) {
+        this.req.cleanup();
+        if let Some(errno) = rc.errno() {
+            return Self::fail_open(this, errno);
+        }
+        this.opened_fd = Fd::from_uv(rc.to_fd());
+        Self::on_file_open(this);
+    }
+}
+
+#[cfg(windows)]
+impl bun_io::uv_fs::OnFsStat for ReadFileUV {
+    fn on_fs_stat(mut this: Box<Self>, rc: libuv::ReturnCodeI64) {
+        log!("ReadFileUV.onFileInitialStat");
+        if let Some(errno) = rc.errno() {
+            return Self::fail(this, errno, bun_sys::Tag::fstat);
         }
 
         let stat = this.req.statbuf;
@@ -1171,8 +998,8 @@ impl<'a> ReadFileUV<'a> {
             this.errno = Some(crate::Error::Sys(bun_errno::SystemErrno::EISDIR));
             this.system_error = Some(SystemError {
                 code: BunString::static_("EISDIR").into(),
-                path: if this.file_store.pathlike.is_path() {
-                    BunString::clone_utf8(this.file_store.pathlike.path().slice())
+                path: if this.file_store().pathlike.is_path() {
+                    BunString::clone_utf8(this.file_store().pathlike.path().slice())
                 } else {
                     BunString::EMPTY
                 }
@@ -1181,8 +1008,7 @@ impl<'a> ReadFileUV<'a> {
                 syscall: BunString::static_("read").into(),
                 ..Default::default()
             });
-            this.on_finish();
-            return;
+            return Self::on_finish(this);
         }
         // `uv_stat_t::st_size` is `u64` (never negative); clamp to MAX_SIZE
         // without a signed detour so a hypothetical >i64::MAX value isn't
@@ -1211,22 +1037,11 @@ impl<'a> ReadFileUV<'a> {
         // Special files might report a size of > 0, and be wrong.
         // so we should check specifically that its a regular file before trusting the size.
         if this.size == 0 && this.is_regular_file {
-            // buffer is empty here,
-            // so move it (Vec<u8>) into the owning ByteStore rather than borrow.
-            this.byte_store = ByteStore::init(core::mem::take(&mut this.buffer));
-            this.on_finish();
-            return;
+            return Self::on_finish(this);
         }
         // Out of memory we can't read more than 4GB at a time (ULONG) on Windows
         if this.size as usize > bun_sys::windows::ULONG::MAX as usize {
-            this.errno = Some(bun_errno::from_errno(bun_sys::E::NOMEM as i32).into());
-            this.system_error = Some(
-                bun_sys::Error::from_code(bun_sys::E::NOMEM, bun_sys::Tag::read)
-                    .to_system_error()
-                    .into(),
-            );
-            this.on_finish();
-            return;
+            return Self::fail(this, bun_sys::E::NOMEM, bun_sys::Tag::read);
         }
         // add an extra 16 bytes to the buffer to avoid having to resize it for trailing extra data
         let want =
@@ -1238,137 +1053,33 @@ impl<'a> ReadFileUV<'a> {
                     .to_system_error()
                     .into(),
             );
-            this.on_finish();
-            return;
+            return Self::on_finish(this);
         }
         this.read_len = 0;
         this.read_off = 0;
 
         this.req.deinit();
 
-        this.queue_read();
+        Self::queue_read(this);
     }
+}
 
-    fn remaining_buffer(&mut self) -> &mut [MaybeUninit<u8>] {
-        // libuv writes into spare capacity before any read; callers only need
-        // ptr/len, so expose the spare slice directly instead of materialising
-        // a `&mut [u8]` over uninitialized bytes.
-        let limit = (self.max_length.saturating_sub(self.read_off)) as usize;
-        let spare = self.buffer.spare_capacity_mut();
-        let take = spare.len().min(limit);
-        &mut spare[..take]
-    }
-
-    pub(crate) fn queue_read(&mut self) {
-        // if not a regular file, buffer capacity is arbitrary, and running out doesn't mean we're
-        // at the end of the file
-        if (!self.remaining_buffer().is_empty() || !self.is_regular_file)
-            && self.errno.is_none()
-            && !self.read_eof
-        {
-            log!(
-                "ReadFileUV.queueRead - this.remainingBuffer().len = {}",
-                self.remaining_buffer().len()
-            );
-
-            if !self.is_regular_file {
-                // non-regular files have variable sizes, so we always ensure
-                // theres at least 4096 bytes of free space. there has already
-                // been an initial allocation done for us
-                if self.buffer.try_reserve(4096).is_err() {
-                    self.errno = Some(crate::Error::Alloc(bun_alloc::AllocError));
-                    self.system_error = Some(
-                        bun_sys::Error::from_code(bun_sys::E::NOMEM, bun_sys::Tag::read)
-                            .to_system_error()
-                            .into(),
-                    );
-                    self.on_finish();
-                    return;
-                }
-            }
-
-            let buf = self.remaining_buffer();
-            // Construct uv_buf_t directly from `as_mut_ptr()` so the stored
-            // `base` carries write provenance — `uv_buf_t::init` takes `&[u8]`
-            // and would implicitly reborrow `buf` as shared, yielding a
-            // SharedReadOnly-tagged pointer that libuv then *writes* through
-            // (uv_fs_read fills this buffer), which is UB under Stacked Borrows.
-            let mut bufs: [libuv::uv_buf_t; 1] = [libuv::uv_buf_t {
-                len: buf.len() as libuv::ULONG,
-                base: buf.as_mut_ptr().cast::<u8>(),
-            }];
-            self.req.assert_cleaned_up();
-            // SAFETY: FFI — `loop_` is the live VM uv loop, `self.req` is a
-            // cleaned-up `fs_t` owned by `self`, `bufs` points at a stack uv_buf
-            // wrapping `self.buffer`'s spare capacity (libuv copies the iovec
-            // descriptor before returning), `opened_fd.uv()` is the open fd, and
-            // `on_read` is a valid `uv_fs_cb` that recovers `self` from `req.data`.
-            let res = unsafe {
-                libuv::uv_fs_read(
-                    self.loop_,
-                    &mut self.req,
-                    self.opened_fd.uv(),
-                    bufs.as_mut_ptr(),
-                    bufs.len() as u32,
-                    i64::try_from(self.offset + self.read_off).expect("int cast"),
-                    Some(Self::on_read),
-                )
-            };
-            self.req.data = core::ptr::from_mut(self).cast::<c_void>();
-            if let Some(errno) = res.errno() {
-                self.errno = Some(bun_errno::from_errno(errno as i32).into());
-                self.system_error = Some(
-                    bun_sys::Error::from_code(errno, bun_sys::Tag::read)
-                        .to_system_error()
-                        .into(),
-                );
-                self.on_finish();
-            }
-        } else {
-            log!("ReadFileUV.queueRead done");
-
-            // We are done reading.
-            let owned = core::mem::take(&mut self.buffer).into_boxed_slice();
-            self.byte_store = ByteStore::init_owned(owned);
-            self.on_finish();
-        }
-    }
-
-    pub(crate) extern "C" fn on_read(req: *mut libuv::fs_t) {
-        // SAFETY: req.data was set to *mut Self in queue_read().
-        let this: &mut ReadFileUV = unsafe { bun_ptr::callback_ctx::<ReadFileUV>((*req).data) };
-
-        // `req` aliases `this.req`; once `&mut ReadFileUV` exists, going through the
-        // raw `req` pointer would violate Stacked Borrows. Read via `this.req` instead.
-        let result = this.req.result;
-
+#[cfg(windows)]
+impl bun_io::uv_fs::OnFsRead for ReadFileUV {
+    fn on_fs_read(mut this: Box<Self>, result: libuv::ReturnCodeI64) {
         if let Some(errno) = result.errno() {
-            this.errno = Some(bun_errno::from_errno(errno as i32).into());
-            this.system_error = Some(
-                bun_sys::Error::from_code(errno, bun_sys::Tag::read)
-                    .to_system_error()
-                    .into(),
-            );
-            this.on_finish();
-            return;
+            return Self::fail(this, errno, bun_sys::Tag::read);
         }
 
         if result.int() == 0 {
             // We are done reading.
-            let owned = core::mem::take(&mut this.buffer).into_boxed_slice();
-            this.byte_store = ByteStore::init_owned(owned);
-            this.on_finish();
-            return;
+            return Self::on_finish(this);
         }
 
+        // `uv_fs::read` already appended the bytes to `buffer`.
         this.read_off += SizeType::try_from(result.int()).expect("int cast");
-        // SAFETY: libuv wrote result.int() bytes into remaining_buffer()'s spare slice.
-        unsafe {
-            this.buffer
-                .uv_commit(usize::try_from(result.int()).expect("int cast"))
-        };
 
         this.req.deinit();
-        this.queue_read();
+        Self::queue_read(this);
     }
 }

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -887,7 +887,7 @@ impl ReadFileUV {
             return Self::on_file_open(this);
         }
         use crate::node::types::PathLikeExt as _;
-        let mut buf = bun_paths::PathBuffer::uninit();
+        let mut buf = bun_paths::path_buffer_pool::get();
         // Force-copied so the result lives in `buf`, not `this`.
         let len = this
             .file_store()

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -9,11 +9,9 @@ use bun_ptr::BackRef;
 use bun_sys::{self as sys, Fd};
 use bun_threading::{WorkPool, WorkPoolTask};
 
-use crate::webcore::blob::{
-    self, Blob, FileOpener, MkdirpTarget, Retry, SizeType, mkdir_if_not_exists,
-};
+use crate::webcore::blob::{self, Blob, MkdirpTarget, SizeType};
 #[cfg(not(windows))]
-use crate::webcore::blob::{ClosingState, FileCloser};
+use crate::webcore::blob::{ClosingState, FileCloser, FileOpener, Retry, mkdir_if_not_exists};
 use crate::webcore::body;
 
 bun_output::declare_scope!(WriteFile, hidden);
@@ -69,6 +67,7 @@ impl WriteFile {
     }
 }
 
+#[cfg_attr(windows, allow(dead_code))] // Windows writes go through `WriteFileWindows`
 pub struct WriteFile {
     pub(crate) file_blob: Blob,
     #[cfg(not(windows))]
@@ -102,6 +101,7 @@ bun_io::poll_owner!(WriteFile, io_poll, WriteFile);
 // FileOpener / FileCloser
 // ──────────────────────────────────────────────────────────────────────────
 
+#[cfg(not(windows))]
 impl FileOpener for WriteFile {
     const OPEN_FLAGS: i32 =
         bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC | bun_sys::O::NONBLOCK;
@@ -136,22 +136,6 @@ impl FileOpener for WriteFile {
         display_path: &[u8],
     ) -> Retry {
         mkdir_if_not_exists(self, &err, path, display_path)
-    }
-    #[cfg(windows)]
-    fn loop_(&self) -> *mut bun_libuv_sys::uv_loop_t {
-        unreachable!("WriteFile is POSIX-only; see WriteFileWindows")
-    }
-    #[cfg(windows)]
-    fn req(&mut self) -> &mut bun_libuv_sys::uv_fs_t {
-        unreachable!("WriteFile is POSIX-only")
-    }
-    #[cfg(windows)]
-    fn set_open_callback(&mut self, _cb: fn(&mut Self, Fd)) {
-        unreachable!()
-    }
-    #[cfg(windows)]
-    fn open_callback(&self) -> fn(&mut Self, Fd) {
-        unreachable!()
     }
 }
 

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -118,8 +118,8 @@ impl FileOpener for WriteFile {
     fn set_system_error(&mut self, e: SystemError) {
         self.system_error = Some(e);
     }
-    fn pathlike(&self) -> &jsc::node_path::PathOrFileDescriptor<'static> {
-        &self
+    fn pathlike(&self) -> blob::PathOrFdRef<'_> {
+        (&self
             .file_blob
             .store
             .get()
@@ -127,7 +127,8 @@ impl FileOpener for WriteFile {
             .unwrap()
             .data
             .as_file()
-            .pathlike
+            .pathlike)
+            .into()
     }
     fn try_mkdirp(
         &mut self,

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -76,16 +76,14 @@ pub(crate) fn stat(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Stat(callback),
-        callback_context,
+        s3_simple_request::Callback::stat(callback, callback_context),
     )
 }
 
 pub(crate) fn download(
     this: &S3Credentials,
     path: &[u8],
-    callback: fn(S3DownloadResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: s3_simple_request::DownloadCallback,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -100,7 +98,6 @@ pub(crate) fn download(
             ..Default::default()
         },
         s3_simple_request::Callback::Download(callback),
-        callback_context,
     )
 }
 
@@ -109,8 +106,7 @@ pub(crate) fn download_slice(
     path: &[u8],
     offset: usize,
     size: Option<usize>,
-    callback: fn(S3DownloadResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: s3_simple_request::DownloadCallback,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -144,15 +140,13 @@ pub(crate) fn download_slice(
             ..Default::default()
         },
         s3_simple_request::Callback::Download(callback),
-        callback_context,
     )
 }
 
 pub(crate) fn delete(
     this: &S3Credentials,
     path: &[u8],
-    callback: fn(S3DeleteResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: s3_simple_request::DeleteCallback,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -167,15 +161,14 @@ pub(crate) fn delete(
             ..Default::default()
         },
         s3_simple_request::Callback::Delete(callback),
-        callback_context,
     )
 }
 
 pub(crate) fn list_objects(
     this: &S3Credentials,
+    // Only read here, synchronously, to build the search-params string.
     list_options: &S3ListObjectsOptions,
-    callback: fn(S3ListObjectsResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: s3_simple_request::ListObjectsCallback,
     proxy_url: Option<&[u8]>,
 ) -> JsResult<()> {
     let mut search_params: Vec<u8> = Vec::<u8>::default();
@@ -272,13 +265,10 @@ pub(crate) fn list_objects(
             drop(search_params);
 
             let error_code_and_message = Error::get_sign_error_code_and_message(sign_err.into());
-            callback(
-                S3ListObjectsResult::Failure(Error::S3Error {
-                    code: error_code_and_message.code,
-                    message: error_code_and_message.message,
-                }),
-                callback_context,
-            )?;
+            callback(S3ListObjectsResult::Failure(Error::S3Error {
+                code: error_code_and_message.code,
+                message: error_code_and_message.message,
+            }))?;
 
             return Ok(());
         }
@@ -292,8 +282,7 @@ pub(crate) fn list_objects(
         // Written below via `MaybeUninit::write` before any read.
         http: core::mem::MaybeUninit::uninit(),
         sign_result: result,
-        callback_context,
-        callback: s3_simple_request::Callback::ListObjects(callback),
+        callback: Some(s3_simple_request::Callback::ListObjects(callback)),
         headers,
         http_ticket: None,
         response_buffer: MutableString::default(),
@@ -385,8 +374,7 @@ pub(crate) fn upload(
     proxy_url: Option<&[u8]>,
     storage_class: Option<StorageClass>,
     request_payer: bool,
-    callback: fn(S3UploadResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: s3_simple_request::UploadCallback,
 ) -> JsResult<()> {
     s3_simple_request::execute_simple_s3_request(
         this,
@@ -404,7 +392,6 @@ pub(crate) fn upload(
             ..Default::default()
         },
         s3_simple_request::Callback::Upload(callback),
-        callback_context,
     )
 }
 

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -346,8 +346,10 @@ impl UploadPart {
                 request_payer: ctx.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Part(Self::on_part_response),
-            std::ptr::from_ref::<Self>(self).cast_mut().cast::<c_void>(),
+            s3_simple_request::S3Callback::part(
+                Self::on_part_response,
+                std::ptr::from_ref::<Self>(self).cast_mut().cast::<c_void>(),
+            ),
         )
     }
 
@@ -430,8 +432,10 @@ impl MultiPartUpload {
                             request_payer: self_.request_payer,
                             ..Default::default()
                         },
-                        s3_simple_request::S3Callback::Upload(Self::single_send_upload_response),
-                        this.cast::<c_void>(),
+                        s3_simple_request::S3Callback::upload(
+                            Self::single_send_upload_response,
+                            this.cast::<c_void>(),
+                        ),
                     )
                 } else {
                     scoped_log!(S3MultiPartUpload, "singleSendUploadResponse failed");
@@ -814,8 +818,10 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Commit(Self::on_commit_multi_part_request),
-            self.as_ctx_ptr(),
+            s3_simple_request::S3Callback::commit(
+                Self::on_commit_multi_part_request,
+                self.as_ctx_ptr(),
+            ),
         )
     }
 
@@ -844,8 +850,10 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Upload(Self::on_rollback_multi_part_request),
-            self.as_ctx_ptr(),
+            s3_simple_request::S3Callback::upload(
+                Self::on_rollback_multi_part_request,
+                self.as_ctx_ptr(),
+            ),
         )
     }
 
@@ -879,8 +887,10 @@ impl MultiPartUpload {
                     request_payer: self.request_payer,
                     ..Default::default()
                 },
-                s3_simple_request::S3Callback::Download(Self::start_multi_part_request_result),
-                self.as_ctx_ptr(),
+                s3_simple_request::S3Callback::download(
+                    Self::start_multi_part_request_result,
+                    self.as_ctx_ptr(),
+                ),
             )?;
         } else if self.state.get() == State::MultipartCompleted {
             part.start()?;
@@ -1012,8 +1022,10 @@ impl MultiPartUpload {
                     request_payer: self.request_payer,
                     ..Default::default()
                 },
-                s3_simple_request::S3Callback::Upload(Self::single_send_upload_response),
-                self.as_ctx_ptr(),
+                s3_simple_request::S3Callback::upload(
+                    Self::single_send_upload_response,
+                    self.as_ctx_ptr(),
+                ),
             ); // TODO: properly propagate exception upwards
         } else {
             // we need to split

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -120,8 +120,8 @@ pub struct S3HttpSimpleTask {
     pub(crate) http_ticket: Option<bun_jsc::Ticket>,
     pub(crate) sign_result: SignResult,
     pub(crate) headers: Headers,
-    pub(crate) callback_context: *mut c_void,
-    pub callback: Callback,
+    /// `Some` until the response (or failure) is delivered.
+    pub callback: Option<Callback>,
     pub(crate) response_buffer: MutableString,
     pub(crate) result: HTTPClientResult<'static>,
     pub(crate) concurrent_task: ConcurrentTask,
@@ -149,48 +149,93 @@ impl Taskable for S3HttpSimpleTask {
     }
 }
 
+/// Receives an [`S3StatResult`] once, on the JS thread.
+pub type StatCallback = Box<dyn FnOnce(S3StatResult<'_>) -> bun_jsc::JsResult<()>>;
+/// Receives an [`S3DownloadResult`] once, on the JS thread.
+pub type DownloadCallback = Box<dyn FnOnce(S3DownloadResult<'_>) -> bun_jsc::JsResult<()>>;
+/// Receives an [`S3UploadResult`] once, on the JS thread.
+pub type UploadCallback = Box<dyn FnOnce(S3UploadResult<'_>) -> bun_jsc::JsResult<()>>;
+/// Receives an [`S3DeleteResult`] once, on the JS thread.
+pub type DeleteCallback = Box<dyn FnOnce(S3DeleteResult<'_>) -> bun_jsc::JsResult<()>>;
+/// Receives an [`S3ListObjectsResult`] once, on the JS thread.
+pub type ListObjectsCallback = Box<dyn FnOnce(S3ListObjectsResult<'_>) -> bun_jsc::JsResult<()>>;
+/// Receives an [`S3CommitResult`] once, on the JS thread.
+pub type CommitCallback = Box<dyn FnOnce(S3CommitResult<'_>) -> bun_jsc::JsResult<()>>;
+/// Receives an [`S3PartResult`] once, on the JS thread.
+pub type PartCallback = Box<dyn FnOnce(S3PartResult<'_>) -> bun_jsc::JsResult<()>>;
+
+/// What a simple request delivers its outcome to: one completion, called
+/// once. Whatever it captures (a promise, a store ref, a raw context a
+/// C-style receiver recovers) is the receiver's.
 pub enum Callback {
-    Stat(fn(S3StatResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    Download(fn(S3DownloadResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    Upload(fn(S3UploadResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    Delete(fn(S3DeleteResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    ListObjects(fn(S3ListObjectsResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    Commit(fn(S3CommitResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    Part(fn(S3PartResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
+    Stat(StatCallback),
+    Download(DownloadCallback),
+    Upload(UploadCallback),
+    Delete(DeleteCallback),
+    ListObjects(ListObjectsCallback),
+    Commit(CommitCallback),
+    Part(PartCallback),
 }
 
 impl Callback {
-    fn fail(&self, code: &[u8], message: &[u8], context: *mut c_void) -> bun_jsc::JsResult<()> {
+    /// Adapt a C-style `(fn, ctx)` receiver.
+    pub fn stat(
+        f: fn(S3StatResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>,
+        ctx: *mut c_void,
+    ) -> Self {
+        Callback::Stat(Box::new(move |r| f(r, ctx)))
+    }
+    /// Adapt a C-style `(fn, ctx)` receiver.
+    pub fn download(
+        f: fn(S3DownloadResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>,
+        ctx: *mut c_void,
+    ) -> Self {
+        Callback::Download(Box::new(move |r| f(r, ctx)))
+    }
+    /// Adapt a C-style `(fn, ctx)` receiver.
+    pub fn upload(
+        f: fn(S3UploadResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>,
+        ctx: *mut c_void,
+    ) -> Self {
+        Callback::Upload(Box::new(move |r| f(r, ctx)))
+    }
+    /// Adapt a C-style `(fn, ctx)` receiver.
+    pub fn commit(
+        f: fn(S3CommitResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>,
+        ctx: *mut c_void,
+    ) -> Self {
+        Callback::Commit(Box::new(move |r| f(r, ctx)))
+    }
+    /// Adapt a C-style `(fn, ctx)` receiver.
+    pub fn part(
+        f: fn(S3PartResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>,
+        ctx: *mut c_void,
+    ) -> Self {
+        Callback::Part(Box::new(move |r| f(r, ctx)))
+    }
+
+    fn fail(self, code: &[u8], message: &[u8]) -> bun_jsc::JsResult<()> {
         let err = S3Error { code, message };
         match self {
-            Callback::Upload(callback) => callback(S3UploadResult::Failure(err), context)?,
-            Callback::Download(callback) => callback(S3DownloadResult::Failure(err), context)?,
-            Callback::Stat(callback) => callback(S3StatResult::Failure(err), context)?,
-            Callback::Delete(callback) => callback(S3DeleteResult::Failure(err), context)?,
-            Callback::ListObjects(callback) => {
-                callback(S3ListObjectsResult::Failure(err), context)?
-            }
-            Callback::Commit(callback) => callback(S3CommitResult::Failure(err), context)?,
-            Callback::Part(callback) => callback(S3PartResult::Failure(err), context)?,
+            Callback::Upload(callback) => callback(S3UploadResult::Failure(err))?,
+            Callback::Download(callback) => callback(S3DownloadResult::Failure(err))?,
+            Callback::Stat(callback) => callback(S3StatResult::Failure(err))?,
+            Callback::Delete(callback) => callback(S3DeleteResult::Failure(err))?,
+            Callback::ListObjects(callback) => callback(S3ListObjectsResult::Failure(err))?,
+            Callback::Commit(callback) => callback(S3CommitResult::Failure(err))?,
+            Callback::Part(callback) => callback(S3PartResult::Failure(err))?,
         }
         Ok(())
     }
 
-    fn not_found(
-        &self,
-        code: &[u8],
-        message: &[u8],
-        context: *mut c_void,
-    ) -> bun_jsc::JsResult<()> {
+    fn not_found(self, code: &[u8], message: &[u8]) -> bun_jsc::JsResult<()> {
         let err = S3Error { code, message };
         match self {
-            Callback::Download(callback) => callback(S3DownloadResult::NotFound(err), context)?,
-            Callback::Stat(callback) => callback(S3StatResult::NotFound(err), context)?,
-            Callback::Delete(callback) => callback(S3DeleteResult::NotFound(err), context)?,
-            Callback::ListObjects(callback) => {
-                callback(S3ListObjectsResult::NotFound(err), context)?
-            }
-            _ => self.fail(code, message, context)?,
+            Callback::Download(callback) => callback(S3DownloadResult::NotFound(err))?,
+            Callback::Stat(callback) => callback(S3StatResult::NotFound(err))?,
+            Callback::Delete(callback) => callback(S3DeleteResult::NotFound(err))?,
+            Callback::ListObjects(callback) => callback(S3ListObjectsResult::NotFound(err))?,
+            other => other.fail(code, message)?,
         }
         Ok(())
     }
@@ -212,7 +257,11 @@ impl S3HttpSimpleTask {
         bun_core::heap::into_raw(Box::new(init))
     }
 
-    fn error_with_body(&self, error_type: ErrorType) -> bun_jsc::JsResult<()> {
+    fn take_callback(&mut self) -> Callback {
+        self.callback.take().expect("S3 request completes once")
+    }
+
+    fn error_with_body(&self, callback: Callback, error_type: ErrorType) -> bun_jsc::JsResult<()> {
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
         let mut has_error_code = false;
@@ -242,16 +291,20 @@ impl S3HttpSimpleTask {
                 code = b"NoSuchKey";
                 message = b"The specified key does not exist.";
             }
-            self.callback
-                .not_found(code, message, self.callback_context)?;
+            callback.not_found(code, message)?;
         } else {
-            self.callback.fail(code, message, self.callback_context)?;
+            callback.fail(code, message)?;
         }
         Ok(())
     }
 
-    /// A commit can answer 200 and still carry an `<Error>` document.
-    fn fail_if_contains_error(&mut self, status: u32) -> bun_jsc::JsResult<bool> {
+    /// A commit can answer 200 and still carry an `<Error>` document, in
+    /// which case `callback` is failed here; otherwise it comes back.
+    fn fail_if_contains_error(
+        &self,
+        status: u32,
+        callback: Callback,
+    ) -> bun_jsc::JsResult<Option<Callback>> {
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
         let parsed;
@@ -268,11 +321,11 @@ impl S3HttpSimpleTask {
                 message = error.message.as_deref().unwrap_or(message);
             }
             if (parsed.is_none() && status == 200) || status == 206 {
-                return Ok(false);
+                return Ok(Some(callback));
             }
         }
-        self.callback.fail(code, message, self.callback_context)?;
-        Ok(true)
+        callback.fail(code, message)?;
+        Ok(None)
     }
 
     /// this is the task callback from the last task result and is always in the main thread
@@ -292,37 +345,34 @@ impl S3HttpSimpleTask {
         // `this` is dropped at scope exit.
         let mut this = unsafe { bun_core::heap::take(this) };
 
+        let callback = this.take_callback();
         if !this.result.is_success() {
-            this.error_with_body(ErrorType::Failure)?;
+            this.error_with_body(callback, ErrorType::Failure)?;
             return Ok(());
         }
         debug_assert!(this.result.metadata.is_some());
-        // reshaped for borrowck — borrow response once, dispatch on a copy of `callback`.
         let response = &this.result.metadata.as_ref().unwrap().response;
-        match this.callback {
+        match callback {
             Callback::Stat(callback) => match response.status_code {
                 200 => {
-                    callback(
-                        S3StatResult::Success(S3StatSuccess {
-                            etag: response.headers.get(b"etag").unwrap_or(b""),
-                            last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
-                            content_type: response.headers.get(b"content-type").unwrap_or(b""),
-                            size: response
-                                .headers
-                                .get(b"content-length")
-                                .map(bun_http_types::parse_content_length)
-                                .unwrap_or(0),
-                        }),
-                        this.callback_context,
-                    )?;
+                    callback(S3StatResult::Success(S3StatSuccess {
+                        etag: response.headers.get(b"etag").unwrap_or(b""),
+                        last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
+                        content_type: response.headers.get(b"content-type").unwrap_or(b""),
+                        size: response
+                            .headers
+                            .get(b"content-length")
+                            .map(bun_http_types::parse_content_length)
+                            .unwrap_or(0),
+                    }))?;
                 }
-                404 => this.error_with_body(ErrorType::NotFound)?,
-                _ => this.error_with_body(ErrorType::Failure)?,
+                404 => this.error_with_body(Callback::Stat(callback), ErrorType::NotFound)?,
+                _ => this.error_with_body(Callback::Stat(callback), ErrorType::Failure)?,
             },
             Callback::Delete(callback) => match response.status_code {
-                200 | 204 => callback(S3DeleteResult::Success, this.callback_context)?,
-                404 => this.error_with_body(ErrorType::NotFound)?,
-                _ => this.error_with_body(ErrorType::Failure)?,
+                200 | 204 => callback(S3DeleteResult::Success)?,
+                404 => this.error_with_body(Callback::Delete(callback), ErrorType::NotFound)?,
+                _ => this.error_with_body(Callback::Delete(callback), ErrorType::Failure)?,
             },
             Callback::ListObjects(callback) => match response.status_code {
                 200 => {
@@ -337,44 +387,42 @@ impl S3HttpSimpleTask {
                             message: b"ListObjectsV2 response is not a well-formed <ListBucketResult> document (if keys can contain control characters, pass encodingType: \"url\")",
                         }),
                     };
-                    callback(result, this.callback_context)?;
+                    callback(result)?;
                 }
-                404 => this.error_with_body(ErrorType::NotFound)?,
-                _ => this.error_with_body(ErrorType::Failure)?,
+                404 => {
+                    this.error_with_body(Callback::ListObjects(callback), ErrorType::NotFound)?
+                }
+                _ => this.error_with_body(Callback::ListObjects(callback), ErrorType::Failure)?,
             },
             Callback::Upload(callback) => match response.status_code {
-                200 => callback(S3UploadResult::Success, this.callback_context)?,
-                _ => this.error_with_body(ErrorType::Failure)?,
+                200 => callback(S3UploadResult::Success)?,
+                _ => this.error_with_body(Callback::Upload(callback), ErrorType::Failure)?,
             },
             Callback::Download(callback) => match response.status_code {
                 200 | 204 | 206 => {
                     let body = core::mem::take(&mut this.response_buffer);
-                    callback(
-                        S3DownloadResult::Success(S3DownloadSuccess { body }),
-                        this.callback_context,
-                    )?;
+                    callback(S3DownloadResult::Success(S3DownloadSuccess { body }))?;
                 }
-                404 => this.error_with_body(ErrorType::NotFound)?,
-                _ => {
-                    // error
-                    this.error_with_body(ErrorType::Failure)?;
-                }
+                404 => this.error_with_body(Callback::Download(callback), ErrorType::NotFound)?,
+                _ => this.error_with_body(Callback::Download(callback), ErrorType::Failure)?,
             },
-            Callback::Commit(callback) => {
+            commit @ Callback::Commit(_) => {
                 // commit multipart upload can fail with status 200
-                let status = response.status_code;
-                if !this.fail_if_contains_error(status)? {
-                    callback(S3CommitResult::Success, this.callback_context)?;
+                if let Some(Callback::Commit(callback)) =
+                    this.fail_if_contains_error(response.status_code, commit)?
+                {
+                    callback(S3CommitResult::Success)?;
                 }
             }
-            Callback::Part(callback) => {
-                let status = response.status_code;
-                if !this.fail_if_contains_error(status)? {
-                    let response = &this.result.metadata.as_ref().unwrap().response;
+            part @ Callback::Part(_) => {
+                if let Some(part) = this.fail_if_contains_error(response.status_code, part)? {
                     if let Some(etag) = response.headers.get(b"etag") {
-                        callback(S3PartResult::Etag(etag), this.callback_context)?;
+                        let Callback::Part(callback) = part else {
+                            unreachable!()
+                        };
+                        callback(S3PartResult::Etag(etag))?;
                     } else {
-                        this.error_with_body(ErrorType::Failure)?;
+                        this.error_with_body(part, ErrorType::Failure)?;
                     }
                 }
             }
@@ -553,7 +601,6 @@ pub(crate) fn execute_simple_s3_request(
     this: &S3Credentials,
     options: S3SimpleRequestOptions<'_>,
     callback: Callback,
-    callback_context: *mut c_void,
 ) -> bun_jsc::JsResult<()> {
     // A multipart/retry continuation can reach here from teardown's queue
     // release; nothing new leaves a VM that is stopping.
@@ -562,7 +609,6 @@ pub(crate) fn execute_simple_s3_request(
         callback.fail(
             b"ERR_S3_VM_SHUTDOWN",
             b"The JavaScript VM that owns this request is shutting down",
-            callback_context,
         )?;
         return Ok(());
     }
@@ -587,11 +633,7 @@ pub(crate) fn execute_simple_s3_request(
             // options.range drops here automatically
             drop(options.range);
             let error_code_and_message = get_sign_error_code_and_message(sign_err.into());
-            callback.fail(
-                error_code_and_message.code,
-                error_code_and_message.message,
-                callback_context,
-            )?;
+            callback.fail(error_code_and_message.code, error_code_and_message.message)?;
             return Ok(());
         }
     };
@@ -625,8 +667,7 @@ pub(crate) fn execute_simple_s3_request(
         // written below via `MaybeUninit::write` before any read.
         http: core::mem::MaybeUninit::uninit(),
         sign_result: result,
-        callback_context,
-        callback,
+        callback: Some(callback),
         headers,
         http_ticket: None,
         response_buffer: MutableString::default(),

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -2629,6 +2629,15 @@ mod posix_impl {
         check!(safe_libc::ftruncate(fd.native(), len), Tag::ftruncate);
         Ok(())
     }
+    pub fn truncate(path: &ZStr, len: i64) -> Maybe<()> {
+        check_p!(
+            // SAFETY: `ZStr::as_ptr()` yields a valid NUL-terminated C string.
+            unsafe { libc::truncate(path.as_ptr(), len as libc::off_t) },
+            Tag::truncate,
+            path
+        );
+        Ok(())
+    }
     pub fn getcwd(buf: &mut [u8]) -> Maybe<usize> {
         // SAFETY: `buf` is a valid exclusive slice; `getcwd` writes at most
         // `buf.len()` bytes (including the NUL).
@@ -4414,6 +4423,53 @@ fn read_fill_vec(
     }
 }
 
+/// One `syscall` — a [`read`]-shaped producer that writes only the prefix it
+/// reports — into uninitialized `buf`; the prefix it filled.
+#[inline]
+fn fill_uninit<'a>(
+    buf: &'a mut [core::mem::MaybeUninit<u8>],
+    syscall: impl FnOnce(&mut [u8]) -> Maybe<usize>,
+) -> Maybe<&'a mut [u8]> {
+    let len = buf.len();
+    let ptr = buf.as_mut_ptr().cast::<u8>();
+    // SAFETY: write-only view for the producer, as `bun_core::vec::spare_bytes_mut`.
+    let n = syscall(unsafe { core::slice::from_raw_parts_mut(ptr, len) })?;
+    assert!(n <= len);
+    // SAFETY: the producer initialized `buf[..n]`.
+    Ok(unsafe { core::slice::from_raw_parts_mut(ptr, n) })
+}
+
+/// [`read`] into uninitialized memory: the bytes the kernel wrote.
+pub fn read_uninit(fd: Fd, buf: &mut [core::mem::MaybeUninit<u8>]) -> Maybe<&mut [u8]> {
+    fill_uninit(buf, |b| read(fd, b))
+}
+
+/// [`recv_non_block`] into uninitialized memory: the bytes the kernel wrote.
+pub fn recv_non_block_uninit(fd: Fd, buf: &mut [core::mem::MaybeUninit<u8>]) -> Maybe<&mut [u8]> {
+    fill_uninit(buf, |b| recv_non_block(fd, b))
+}
+
+/// [`read`] at most `max` bytes into `buf`'s spare capacity and extend its
+/// length by what the kernel wrote; that count (0 on EOF or no spare room).
+pub fn read_to_spare(fd: Fd, buf: &mut Vec<u8>, max: usize) -> Maybe<usize> {
+    let spare = buf.spare_capacity_mut();
+    let len = spare.len().min(max);
+    let n = read_uninit(fd, &mut spare[..len])?.len();
+    // SAFETY: `read_uninit` initialized `n <= spare` bytes past `len()`.
+    unsafe { buf.set_len(buf.len() + n) };
+    Ok(n)
+}
+
+/// [`read_to_spare`] with [`recv_non_block`].
+pub fn recv_non_block_to_spare(fd: Fd, buf: &mut Vec<u8>, max: usize) -> Maybe<usize> {
+    let spare = buf.spare_capacity_mut();
+    let len = spare.len().min(max);
+    let n = recv_non_block_uninit(fd, &mut spare[..len])?.len();
+    // SAFETY: `recv_non_block_uninit` initialized `n <= spare` bytes past `len()`.
+    unsafe { buf.set_len(buf.len() + n) };
+    Ok(n)
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // `bun.PlatformIOVecConst` / `bun.platformIOVecConstCreate` — POSIX
 // `iovec_const` (= `struct iovec` with the writev contract that `base` is
@@ -5465,6 +5521,48 @@ pub mod linux {
 
     // sendfile — use the existing `linux::sendfile` (libc
     // wrapper, isize return) defined above; `get_errno::<isize>` decodes it.
+
+    /// `copy_file_range(in, NULL, out, NULL, len, flags)`: both fds' own
+    /// offsets are used and advanced. Raw return; decode with `get_errno`.
+    #[inline]
+    pub fn copy_file_range_cur(in_: super::Fd, out: super::Fd, len: usize, flags: u32) -> isize {
+        // SAFETY: null offset pointers; the kernel validates the fds.
+        unsafe {
+            copy_file_range(
+                in_.native(),
+                core::ptr::null_mut(),
+                out.native(),
+                core::ptr::null_mut(),
+                len,
+                flags,
+            )
+        }
+    }
+
+    /// `sendfile(out, in, NULL, count)`: `in`'s own offset is used and
+    /// advanced. Raw return; decode with `get_errno`.
+    #[inline]
+    pub fn sendfile_cur(out: super::Fd, in_: super::Fd, count: usize) -> isize {
+        // SAFETY: null offset pointer; the kernel validates the fds.
+        unsafe { sendfile(out.native(), in_.native(), core::ptr::null_mut(), count) }
+    }
+
+    /// `splice(in, NULL, out, NULL, len, flags)`. Raw return; decode with
+    /// `get_errno`.
+    #[inline]
+    pub fn splice_cur(in_: super::Fd, out: super::Fd, len: usize, flags: u32) -> isize {
+        // SAFETY: null offset pointers; the kernel validates the fds.
+        unsafe {
+            libc::splice(
+                in_.native(),
+                core::ptr::null_mut(),
+                out.native(),
+                core::ptr::null_mut(),
+                len,
+                flags,
+            )
+        }
+    }
 
     /// `bun.linux.RWFFlagSupport` — runtime probe for `RWF_NOWAIT` (kernel ≥ 4.14).
     pub struct RWFFlagSupport;
@@ -7227,6 +7325,11 @@ pub fn get_fcntl_flags(fd: Fd) -> Maybe<FcntlInt> {
 #[cfg(windows)]
 pub fn get_fcntl_flags(_fd: Fd) -> Maybe<FcntlInt> {
     Err(Error::from_code_int(libc::ENOSYS, Tag::fcntl))
+}
+/// `fcntl(fd, F_SETFL, flags)`.
+#[cfg(unix)]
+pub fn set_fcntl_flags(fd: Fd, flags: FcntlInt) -> Maybe<()> {
+    fcntl(fd, libc::F_SETFL, flags).map(|_| ())
 }
 #[inline]
 pub fn set_nonblocking(fd: Fd) -> Maybe<()> {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -255,6 +255,8 @@ const IS_UV_FS_COPYFILE_DISABLED =
     {
       const result = await Bun.write(Bun.file(tmpbase + "fetch.js.out"), Bun.file(tmpbase + "fetch.js.in"));
       await gcTick();
+      // The copied byte count. On Windows the uv_fs_copyfile fast path used to resolve 0 here.
+      expect(result).toBe(Buffer.byteLength(exampleHtml));
       expect(await Bun.file(tmpbase + "fetch.js.out").text()).toBe(exampleHtml);
       await gcTick();
     }


### PR DESCRIPTION
### What

Same programme as #40055 … #40220. **Stacked on #40213** (base branch is `claude/filesink-zero-unsafe`; retarget to main once that lands). `src/runtime/webcore/Blob.rs` 171 → **0** (202 on main), `blob/read_file.rs` 22 → 0, `blob/copy_file.rs` 27 → 0, `blob/Store.rs` 9 → 0. No new `unsafe` under `src/runtime/**`; incidental reductions in BunObject/Archive/Body/S3File/S3Client/ServerWebSocket/ObjectURLRegistry/Image/BlockList.

- **ReadFile / ReadFileUV / CopyFile(Windows)** follow #40213's WriteFile shape exactly: `IoRequestHandler` (+ new `IoRequestHook<T>` / `io_request_callback_with::<T, H>()`), `WorkTaskHandler`, `FileCloser::{close_action, set_close_after_io}` (no `unsafe fn schedule_close`, no `unreachable!` stubs), `JobContext::PARKED_REQUEST`; Windows through `bun_io::uv_fs::{read, fstat, copyfile, chmod}` — `read` moves the target `Vec` into the request box for the flight and bumps `len` by at most the granted bytes. The JS-completion erasure (`fn(*mut c_void, ReadFileResultType)` + ctx) becomes `job::JsCallback<F: ?Sized>` / boxed `ReadBytesHandler::on_read_bytes(self: Box<Self>)`.
- **`bun_sys`**: `read_uninit` / `recv_non_block_uninit(fd, &mut [MaybeUninit<u8>]) -> &mut [u8]`, `read_to_spare` / `recv_non_block_to_spare(fd, &mut Vec<u8>, max)`, `truncate`, `set_fcntl_flags`, `linux::{copy_file_range_cur, sendfile_cur, splice_cur}`.
- **`bun_jsc`**: `external_string_utf16(Vec<u16>)` / `external_string_latin1(Box<[u8]>)` / `external_string_from_store(StoreRef, Range)`, `ArrayBuffer::to_js_from_store`, `DOMFormData::for_each`, `StructuredCloneWriter`/`StructuredCloneReader` (codegen passes typed reader/writer objects to `onStructuredCloneSerialize/Deserialize`), `RareData::stdio_store(Stdio) -> StoreRef`, `Bytes::{take_vec, adopt_mmap}`, `Store::from_bytes`, `IsAllAscii` (atomic tri-state), `LinuxMemFdAllocator::from_bytes`; `Blob__fromBytes*/fromMmapWithType/dupe/destroy/getDataPtr…` are `HOST_EXPORT`s (`fromMmapWithType` stays an `unsafe fn` wrapped by the thunk — adopting a raw mmap region from C++ is a contract). Codegen: `Option<&CStr>` params, `Box<T>` promise-reaction receivers, `&` params on `rust` hooks.
- S3 `client::{download, download_slice, delete, upload, list_objects}` take boxed callbacks (no `callback_context: *mut c_void`); `File::cached_blob: AtomicPtr`.

Pre-existing bugs fixed in passing: Windows `CopyFileWindows` read/write fallback resolved early with a short count after any partial `uv_fs_write`; `Blob::get_stat` cast a `*mut NodeFS` to `&Binding` (type confusion, harmless only because unused).

### Testing

Debug+ASAN, all pass, no ASAN output: blob.test.ts, bun-write.test.js, bun-file*.test.ts, blob-cow/array-fast-path/file-name-ownership/write/oom, structured-clone-blob-file, structured-clone-fastpath, workers/structured-clone, body/body-clone/body-stream/body-mixin-errors, bun-serve-file, spawn-stdin-readable-stream, s3.test.ts offline suite + s3-list-objects/argument-validation/insecure/storage-class/requester-pays/write-to-file-sync-close/stream-error-gc/stream-cancel-leak/connection-close, FormData/multipart-serialization/file-error-leak, URLSearchParams, blocklist-gc, test/js/bun/image, fs.test.ts `-t "Bun.file|copyFile|writeFile"`. Hand-driven: 0/1 MB/200 MB copies, non-existent target dir, slice chains, mixed-part `new Blob`, `structuredClone(File)`, Blob posted to a Worker, `Bun.file(fd)`, exists/unlink/stat, 1000 concurrent reads, Worker terminated mid-read, pipes/stdin, `Bun.write(stdout, file)`, 9 MB memfd blob — exit 0. clippy clean on bun_sys/bun_io/bun_jsc/bun_standalone_graph/bun_runtime; `rust-check-all` windows-msvc + apple-darwin pass (Windows paths compile-checked only).