### PR TITLE
mock.module: reject a factory promise that resolves to a non-object instead of crashing

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -236,18 +236,23 @@ OnLoadResult handleOnLoadResultNotPromise(Zig::GlobalObject* globalObject, JSC::
         return result;
     }
 
-    if (wasModuleMock) {
-        result.type = OnLoadResultTypeObject;
-        result.value.object = objectValue;
-        return result;
-    }
-
     JSC::JSObject* object = objectValue.getObject();
     if (!object) [[unlikely]] {
-        scope.throwException(globalObject, JSC::createError(globalObject, "Expected module mock to return an object"_s));
+        // A mock factory that returns a promise gets here with the promise's
+        // resolution, which JSModuleMock::executeOnce could not check.
+        if (wasModuleMock)
+            scope.throwException(globalObject, JSC::createTypeError(globalObject, "mock(module, fn) requires a function that returns an object"_s));
+        else
+            scope.throwException(globalObject, JSC::createError(globalObject, "Expected module mock to return an object"_s));
         result.value.error = scope.exception();
         (void)scope.tryClearException();
         result.type = OnLoadResultTypeError;
+        return result;
+    }
+
+    if (wasModuleMock) {
+        result.type = OnLoadResultTypeObject;
+        result.value.object = objectValue;
         return result;
     }
 

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -8,6 +8,7 @@
 // - Write test for import {foo} from "./foo"; export {foo}
 
 import { expect, mock, spyOn, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { default as defaultValue, fn, iCallFn, rexported, rexportedAs, variable } from "./mock-module-fixture";
 import * as spyFixture from "./spymodule-fixture";
 
@@ -165,6 +166,38 @@ test("mocking a builtin", async () => {
 
   const { readFile } = await import("node:fs/promises");
   expect(await readFile("hello.txt", "utf8")).toBe("hello world");
+});
+
+test("a factory that resolves to a non-object rejects the import, sync or async", async () => {
+  // The async shape used to reach the object-module generator with a null object and segfault while the
+  // import's fetch settled, so run it in a child process.
+  using dir = tempDir("mock-module-non-object", {
+    "main.test.ts": `
+      import { expect, mock, test } from "bun:test";
+      mock.module("mock-sync-non-object", () => 42 as any);
+      mock.module("mock-async-non-object", async () => {
+        await 1;
+        // no return
+      });
+      test("sync", async () => {
+        await expect(import("mock-sync-non-object")).rejects.toThrow("mock(module, fn) requires a function that returns an object");
+      });
+      test("async", async () => {
+        await expect(import("mock-async-non-object")).rejects.toThrow("mock(module, fn) requires a function that returns an object");
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "main.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain(" 2 pass");
+  expect(stderr).toContain(" 0 fail");
+  expect(exitCode).toBe(0);
 });
 
 test("a factory export getter that throws fails the import", async () => {


### PR DESCRIPTION
### Problem
- `mock.module("x", async () => { ... })` with a factory whose promise resolves to a non-object (for example a factory without a `return`) crashes the process on `import("x")`: `panic(main thread): Segmentation fault at address 0x0` in the object-module generator (`src/jsc/modules/ObjectModule.cpp:20`), called from `JSModuleLoader::makeModule` under `moduleRegistryFetchSettled`. Sentry BUN-4QGA (1.4.0, `bun test`).
- Cause: `JSModuleMock::executeOnce` (`src/jsc/bindings/BunPlugin.cpp:489`) rejects a non-object only for a sync factory. A promise is an object, so it passes. Its resolution reaches `handleOnLoadResultNotPromise` (`src/jsc/bindings/ModuleLoader.cpp:239`), which for a mock returned `OnLoadResultTypeObject` before its own object check. `handleVirtualModuleResult` then called `generateObjectModuleSourceCode` with a null `JSObject*`, and `gcProtectNullTolerant` let it through.

### Fix
- Run the object check before the mock branch. For a mock the import now rejects with the TypeError the sync path throws: `mock(module, fn) requires a function that returns an object`. Plugin virtual modules keep their existing error.
- Correct because the generator and `getIfPropertyExists` both dereference the object, so a non-object can never be a valid module result on this path.
- Verified: new test in `test/js/bun/test/mock/mock-module.test.ts`. On 1.4.0 the child process segfaults, with the fix both the sync and the async shape reject with the TypeError. `test/js/bun/test/mock/` and `test/js/bun/plugin/plugins.test.ts` pass.

### Background
- A `mock.module()` factory runs when the loader fetches the mocked key. Its object becomes a `SyntheticModuleRecord` whose generator reads the object's properties when the record is created.
- A factory that returns a promise goes through `PendingVirtualModuleResult`: the promise's resolution is handed back to the same result handling in `jsFunctionOnLoadObjectResultResolve`, on the microtask queue.

<details><summary>Notes</summary>

Found while investigating BUN-4QBM (#40170). That issue is the module loader's synchronous replay in oven-sh/WebKit and is unrelated to this crash. BUN-4QGA's stack (`moduleRegistryFetchSettled` -> `makeModule` -> `generate` -> `ObjectModule.cpp:20`, fault address 0) is exactly the async factory shape: the fetch promise settles on the normal microtask queue, and the first thing the generator does with the null object is `object->methodTable()`.

Repro on 1.4.0:

```ts
import { mock, test } from "bun:test";
mock.module("virt", async () => { await 1; /* no return */ });
test("x", async () => { await import("virt"); });
```

</details>
