### PR TITLE
console: format DOMException as an error, not a plain object

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2212,10 +2212,8 @@ pub mod formatter {
             use jsc::JSType as T;
             let tag = match js_type {
                 T::ErrorInstance => TagPayload::Error,
-                // DOMException is a wrapper object, not an ErrorInstance
-                // cell. The object formatter would dump the 25 enumerable
-                // legacy constants from its prototype, so format it as an
-                // error like Node does (#40224).
+                // DOMException is an Object cell; the object formatter would
+                // dump its 25 enumerable prototype constants (#40224).
                 T::Object if value.is_dom_exception() => TagPayload::Error,
                 T::NumberObject => TagPayload::Double,
                 T::DerivedArray

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2212,6 +2212,11 @@ pub mod formatter {
             use jsc::JSType as T;
             let tag = match js_type {
                 T::ErrorInstance => TagPayload::Error,
+                // DOMException is a wrapper object, not an ErrorInstance
+                // cell. The object formatter would dump the 25 enumerable
+                // legacy constants from its prototype, so format it as an
+                // error like Node does (#40224).
+                T::Object if value.is_dom_exception() => TagPayload::Error,
                 T::NumberObject => TagPayload::Double,
                 T::DerivedArray
                 | T::Array

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -367,6 +367,16 @@ impl JSValue {
         }
         host_fn::from_js_host_call_generic(global, || JSC__JSValue__isJSXElement(self, global))
     }
+    /// `JSValue.isDOMException()` — true iff this is a `DOMException`
+    /// wrapper. `DOMException` is not an `ErrorInstance` cell; its
+    /// `js_type()` is `Object`.
+    #[inline]
+    pub fn is_dom_exception(self) -> bool {
+        unsafe extern "C" {
+            safe fn JSC__JSValue__isDOMException(this: JSValue) -> bool;
+        }
+        JSC__JSValue__isDOMException(self)
+    }
     /// `JSValue.isAggregateError(globalObject)`.
     #[inline]
     pub fn is_aggregate_error(self, global: &JSGlobalObject) -> bool {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -368,8 +368,7 @@ impl JSValue {
         host_fn::from_js_host_call_generic(global, || JSC__JSValue__isJSXElement(self, global))
     }
     /// `JSValue.isDOMException()` — true iff this is a `DOMException`
-    /// wrapper. `DOMException` is not an `ErrorInstance` cell; its
-    /// `js_type()` is `Object`.
+    /// wrapper (an `Object` cell, not an `ErrorInstance`).
     #[inline]
     pub fn is_dom_exception(self) -> bool {
         unsafe extern "C" {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6114,7 +6114,8 @@ impl VirtualMachine {
 
         let is_error_instance = error_instance != JSValue::ZERO
             && error_instance.is_cell()
-            && error_instance.js_type() == JSType::ErrorInstance;
+            && (error_instance.js_type() == JSType::ErrorInstance
+                || error_instance.is_dom_exception());
         // NOTE: cannot use `self.global()` — `global_ref` outlives a
         // `&mut self` recursion (`print_error_instance_js`) and is passed to
         // `Formatter<'2>::format`, which requires an unbounded (VM-lifetime)

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6413,7 +6413,9 @@ impl VirtualMachine {
             if !saw_cause {
                 let key = bun_core::String::static_("cause");
                 if let Some(cause) = error_instance.get_own(global_ref, &key)? {
-                    if cause.is_cell() && cause.js_type() == JSType::ErrorInstance {
+                    if cause.is_cell()
+                        && (cause.js_type() == JSType::ErrorInstance || cause.is_dom_exception())
+                    {
                         cause.protect();
                         errors_to_append.push(cause);
                     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6315,13 +6315,16 @@ impl VirtualMachine {
                     continue;
                 }
 
+                // The fallback below is only for a cause the iterator did not
+                // visit, or the inline-formatted cause prints a second time.
+                if field.eq_ascii(b"cause") {
+                    saw_cause = true;
+                }
+
                 let kind = value.js_type();
                 // Only the errors_to_append path guards against circular
                 // references, so a DOMException takes the ErrorInstance route.
                 if (kind == JSType::ErrorInstance || value.is_dom_exception()) && !prev_had_errors {
-                    if field.eq_ascii(b"cause") {
-                        saw_cause = true;
-                    }
                     value.protect();
                     errors_to_append.push(value);
                 } else if kind.is_object()

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6316,7 +6316,9 @@ impl VirtualMachine {
                 }
 
                 let kind = value.js_type();
-                if kind == JSType::ErrorInstance && !prev_had_errors {
+                // Only the errors_to_append path guards against circular
+                // references, so a DOMException takes the ErrorInstance route.
+                if (kind == JSType::ErrorInstance || value.is_dom_exception()) && !prev_had_errors {
                     if field.eq_ascii(b"cause") {
                         saw_cause = true;
                     }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -149,6 +149,7 @@
 #include "JSDOMConvertSequences.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMConvertUnion.h"
+#include "JSDOMException.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMGlobalObjectInlines.h"
 #include "JSDOMIterator.h"
@@ -4244,6 +4245,11 @@ bool JSC__JSValue__isError(JSC::EncodedJSValue JSValue0)
 {
     JSC::JSObject* obj = JSC::JSValue::decode(JSValue0).getObject();
     return obj != nullptr && obj->isErrorInstance();
+}
+
+bool JSC__JSValue__isDOMException(JSC::EncodedJSValue JSValue0)
+{
+    return JSC::JSValue::decode(JSValue0).inherits<WebCore::JSDOMException>();
 }
 
 bool JSC__JSValue__isAggregateError(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* global)

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -227,6 +227,7 @@ CPP_DECL bool JSC__JSValue__isCallable(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isClass(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL bool JSC__JSValue__isConstructor(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isCustomGetterSetter(JSC::EncodedJSValue JSValue0);
+CPP_DECL bool JSC__JSValue__isDOMException(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isError(JSC::EncodedJSValue JSValue0);
 CPP_DECL bool JSC__JSValue__isException(JSC::EncodedJSValue JSValue0, JSC::VM* arg1);
 CPP_DECL bool JSC__JSValue__isGetterSetter(JSC::EncodedJSValue JSValue0);

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -173,6 +173,8 @@ describe.concurrent("DOMException formats as an error", () => {
     expect(stdout).toBe("");
     expect(stderr).toContain("AbortError");
     expect(stderr).toContain("aborted");
+    // The abort reason carries a .stack, and the frame must print.
+    expect(stderr).toMatch(/at .*\[eval\]/);
     expect(stderr).not.toContain("INDEX_SIZE_ERR");
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -255,8 +255,9 @@ describe.concurrent("DOMException formats as an error", () => {
     const inspected = Bun.inspect(err);
     expect(inspected).toContain("[Circular]");
     expect(inspected).not.toContain("INDEX_SIZE_ERR");
-    // The header must not repeat once per recursion level.
-    expect(inspected.split("AbortError: x").length - 1).toBeLessThanOrEqual(3);
+    // Once for the error, once for the appended self reference. Not once
+    // per recursion level.
+    expect(inspected.split("AbortError: x").length - 1).toBe(2);
   });
 });
 

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -173,8 +173,9 @@ describe.concurrent("DOMException formats as an error", () => {
     expect(stdout).toBe("");
     expect(stderr).toContain("AbortError");
     expect(stderr).toContain("aborted");
-    // The abort reason carries a .stack, and the frame must print.
-    expect(stderr).toMatch(/at .*\[eval\]/);
+    // The abort reason carries a .stack, and its frame must print after
+    // the header.
+    expect(stderr).toMatch(/AbortError: The operation was aborted\.[\s\S]*^\s+at .*\[eval\]/m);
     expect(stderr).not.toContain("INDEX_SIZE_ERR");
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -212,7 +212,11 @@ describe.concurrent("DOMException formats as an error", () => {
 
   test("DOMException as an enumerable error cause prints once", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", 'const e = new Error("outer"); e.cause = new DOMException("inner", "AbortError"); throw e;'],
+      cmd: [
+        bunExe(),
+        "-e",
+        'const e = new Error("outer"); e.cause = new DOMException("inner", "AbortError"); throw e;',
+      ],
       env: bunEnv,
       stderr: "pipe",
     });

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -152,6 +152,53 @@ test("Inserted originalLine and originalColumn do not appear in node:util.inspec
 `);
 });
 
+// https://github.com/oven-sh/bun/issues/40224
+describe.concurrent("DOMException formats as an error", () => {
+  test("Bun.inspect does not dump the legacy constant table", () => {
+    const err = new DOMException("The operation was aborted.", "AbortError");
+    const inspected = Bun.inspect(err);
+    expect(inspected).toContain("AbortError");
+    expect(inspected).toContain("The operation was aborted.");
+    expect(inspected).not.toContain("INDEX_SIZE_ERR");
+    expect(inspected).not.toContain("DATA_CLONE_ERR");
+  });
+
+  test("console.error(abort reason) prints an error", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        "const ac = new AbortController(); ac.abort(); console.error(ac.signal.reason);",
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("AbortError");
+    expect(stderr).toContain("aborted");
+    expect(stderr).not.toContain("INDEX_SIZE_ERR");
+    expect(exitCode).toBe(0);
+  });
+
+  test("uncaught DOMException does not dump the legacy constant table", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'throw new DOMException("boom", "AbortError");'],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("AbortError: boom");
+    expect(stderr).not.toContain("INDEX_SIZE_ERR");
+    expect(exitCode).toBe(1);
+  });
+
+  test("DOMException nested in an object formats as an error", () => {
+    const inspected = Bun.inspect({ reason: new DOMException("nested", "DataError") });
+    expect(inspected).toContain("DataError");
+    expect(inspected).not.toContain("INDEX_SIZE_ERR");
+  });
+});
+
 describe("observable properties", () => {
   for (let property of ["sourceURL", "line", "column"]) {
     test(`${property} is observable`, () => {

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -165,11 +165,7 @@ describe.concurrent("DOMException formats as an error", () => {
 
   test("console.error(abort reason) prints an error", async () => {
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        "const ac = new AbortController(); ac.abort(); console.error(ac.signal.reason);",
-      ],
+      cmd: [bunExe(), "-e", "const ac = new AbortController(); ac.abort(); console.error(ac.signal.reason);"],
       env: bunEnv,
       stderr: "pipe",
     });

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -228,6 +228,25 @@ describe.concurrent("DOMException formats as an error", () => {
     expect(exitCode).toBe(1);
   });
 
+  test("DOMException cause of a nested error prints once", async () => {
+    const code =
+      'const deep = new DOMException("deep", "AbortError");' +
+      'const mid = new Error("mid"); mid.cause = deep;' +
+      'throw new Error("outer", { cause: mid });';
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("error: outer");
+    expect(stderr).toContain("error: mid");
+    expect(stderr.split("AbortError: deep").length - 1).toBe(1);
+    expect(stderr).not.toContain("INDEX_SIZE_ERR");
+    expect(exitCode).toBe(1);
+  });
+
   test("self-referencing DOMException prints [Circular] instead of recursing", () => {
     const err = new DOMException("x", "AbortError");
     err.self = err;

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -169,7 +169,8 @@ describe.concurrent("DOMException formats as an error", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
     expect(stderr).toContain("AbortError");
     expect(stderr).toContain("aborted");
     expect(stderr).not.toContain("INDEX_SIZE_ERR");
@@ -182,7 +183,8 @@ describe.concurrent("DOMException formats as an error", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
     expect(stderr).toContain("AbortError: boom");
     expect(stderr).not.toContain("INDEX_SIZE_ERR");
     expect(exitCode).toBe(1);
@@ -200,11 +202,22 @@ describe.concurrent("DOMException formats as an error", () => {
       env: bunEnv,
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
     expect(stderr).toContain("error: outer");
     expect(stderr).toContain("AbortError: inner");
     expect(stderr).not.toContain("INDEX_SIZE_ERR");
     expect(exitCode).toBe(1);
+  });
+
+  test("self-referencing DOMException prints [Circular] instead of recursing", () => {
+    const err = new DOMException("x", "AbortError");
+    err.self = err;
+    const inspected = Bun.inspect(err);
+    expect(inspected).toContain("[Circular]");
+    expect(inspected).not.toContain("INDEX_SIZE_ERR");
+    // The header must not repeat once per recursion level.
+    expect(inspected.split("AbortError: x").length - 1).toBeLessThanOrEqual(3);
   });
 });
 

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -210,6 +210,20 @@ describe.concurrent("DOMException formats as an error", () => {
     expect(exitCode).toBe(1);
   });
 
+  test("DOMException as an enumerable error cause prints once", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'const e = new Error("outer"); e.cause = new DOMException("inner", "AbortError"); throw e;'],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("error: outer");
+    expect(stderr.split("AbortError: inner").length - 1).toBe(1);
+    expect(stderr).not.toContain("INDEX_SIZE_ERR");
+    expect(exitCode).toBe(1);
+  });
+
   test("self-referencing DOMException prints [Circular] instead of recursing", () => {
     const err = new DOMException("x", "AbortError");
     err.self = err;

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -193,6 +193,19 @@ describe.concurrent("DOMException formats as an error", () => {
     expect(inspected).toContain("DataError");
     expect(inspected).not.toContain("INDEX_SIZE_ERR");
   });
+
+  test("DOMException as a non-enumerable error cause is printed", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'throw new Error("outer", { cause: new DOMException("inner", "AbortError") });'],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("error: outer");
+    expect(stderr).toContain("AbortError: inner");
+    expect(stderr).not.toContain("INDEX_SIZE_ERR");
+    expect(exitCode).toBe(1);
+  });
 });
 
 describe("observable properties", () => {


### PR DESCRIPTION
### Problem

- `console.error(new DOMException(...))` prints a 35-line object dump. 25 of those lines are the legacy constants (`INDEX_SIZE_ERR: 1` ... `DATA_CLONE_ERR: 25`) from `DOMException.prototype`. Every `AbortController.abort()` reason hits this, so server logs fill with the same constant table. Node prints the error header and stack (#40224).
- `Tag::get` in `src/jsc/ConsoleObject.rs:2241` only routes `JSType::ErrorInstance` cells to the error formatter. A `DOMException` is a wrapper cell with `JSType::Object`, so it falls through to the object formatter, which picks up the enumerable prototype constants.
- The uncaught-throw path has the same gap: `print_error_instance_body` (`src/jsc/VirtualMachine.rs:6164`) re-dumps the full object after the `AbortError: message` header.

### Fix

- Add `JSC__JSValue__isDOMException` (a `inherits<JSDOMException>` brand check, the same test the inspector uses in `BunInjectedScriptHost.cpp`) and expose it as `JSValue::is_dom_exception()`.
- `Tag::get`: route a `DOMException` with `JSType::Object` to the error formatter.
- `print_error_instance_body`: treat a `DOMException` as an error instance, so it prints own properties only instead of the full object dump. A `DOMException` in an error property or a non-enumerable `cause` now takes the same guarded append path as an `Error`, so cycles print `[Circular]` and a `DOMException` cause is no longer dropped.
- Verified: eight new tests in `test/js/bun/util/inspect-error.test.js` (all fail on the unfixed build). Also ran the rest of that file, `inspect.test.js`, `test/js/bun/console/`, `test/js/web/abort/`, and `domexception-node.test.js`.

### Background

- The WebIDL spec requires the 25 legacy constants on `DOMException.prototype` as enumerable properties. This change does not touch their enumerability, only how the console formats the instance.
- `console.*`, `Bun.inspect`, and the uncaught-error printer share this formatter. The output for an abort reason is now `AbortError: The operation was aborted.` plus the stack, 5 lines instead of 35.
- Related open PRs: #32898 makes `DOMException` inherit from `JSC::ErrorInstance` (a larger structural change that would subsume the `Tag::get` guard), and #35723 extends error formatting to all `instanceof Error` objects. This change is the minimal fix for the `DOMException` case and conflicts with neither approach.

<details><summary>Notes</summary>

Output before, for `console.error(AbortSignal.abort().reason)`: 35 lines, of which 25 are the constant table plus `toString: [Function: toString]`.

Output after:

```
AbortError: The operation was aborted.
      line: 2,
    column: 9,
 sourceURL: "/tmp/repro.js",

      at /tmp/repro.js:2
```

The remaining `line`/`column`/`sourceURL` lines are enumerable own properties that Bun adds to internally created DOMExceptions. PR #39311 proposes making them non-enumerable, which would remove them from this output too.

The test-runner diff formatter (`src/runtime/test_runner/pretty_format.rs`) has the same `ErrorInstance`-only dispatch. PR #35723 covers that surface, so this change leaves it alone.

Known limitation, shared with plain `Error`: a self-referencing error reached at depth 2 or more in a cause chain takes the inline format path, which removes the value from the visited map (`print_error`), so the header repeats until the stack check bounds it. Measured on this branch: 371 headers with an `Error` cause (pre-existing), 315 with a `DOMException` cause. The fix is a change to the shared `print_error` visited-map contract and belongs in a follow-up.

`test/js/bun/util/inspect-error-leak.test.js` fails on unmodified main in this environment (RSS threshold under the debug ASAN build), with and without this diff.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.1 (861e9ae04)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [8.11ms]
(pass) Error [4.81ms]
(pass) BuildMessage [14.46ms]
(pass) Error inside minified file (no color)  [91.63ms]
(pass) Error inside minified file (color)  [53.04ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [149.60ms]
157 |   test("Bun.inspect does not dump the legacy constant table", () => {
158 |     const err = new DOMException("The operation was aborted.", "AbortError");
159 |     const inspected = Bun.inspect(err);
160 |     expect(inspected).toContain("AbortError");
161 |     expect(inspected).toContain("The operation was aborted.");
162 |     expect(inspected).not.toContain("INDEX_SIZE_ERR");
                                ^
error: expect(received).not.toContain(expected)

Expected to not contain: "INDEX_SIZE_ERR"
Received: "DOMException {\n  code: 20,\n  name: \"AbortError\",\n  message: \"The operation was aborted.\",\n  INDEX_SIZE_ERR: 1,\n  DOMSTRING_SIZ
... (truncated)

release without fix: 24 FAILED
bun test v1.4.0 (34cbb9a40)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [3.87ms]
(pass) Error [0.29ms]
(pass) BuildMessage [0.79ms]
(pass) Error inside minified file (no color)  [1.97ms]
(pass) Error inside minified file (color)  [1.90ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [3.42ms]
157 |   test("Bun.inspect does not dump the legacy constant table", () => {
158 |     const err = new DOMException("The operation was aborted.", "AbortError");
159 |     const inspected = Bun.inspect(err);
160 |     expect(inspected).toContain("AbortError");
161 |     expect(inspected).toContain("The operation was aborted.");
162 |     expect(inspected).not.toContain("INDEX_SIZE_ERR");
                                ^
error: expect(received).not.toContain(expected)

Expected to not contain: "INDEX_SIZE_ERR"
Received: "DOMException {\n  code: 20,\n  name: \"AbortError\",\n  message: \"The operation was aborted.\",\n  INDEX_SIZE_ERR: 1,\n  DOMSTRING_SIZE_ERR: 2,\n  HIERARCHY_REQUEST_ERR: 3,\n  WRONG_DOCUMENT_ERR: 4,\n  INVALID_CHARACTER_ERR: 5,\n  NO_DATA_ALLOWED_ERR: 6,\n  NO_MODIFICATION_ALLOWED_ERR: 7,\n  NOT_FOUND_ERR: 8,\
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.1 (861e9ae04)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [9.11ms]
(pass) Error [3.90ms]
(pass) BuildMessage [12.57ms]
(pass) Error inside minified file (no color)  [87.97ms]
(pass) Error inside minified file (color)  [49.78ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [143.26ms]
(pass) DOMException formats as an error > Bun.inspect does not dump the legacy constant table [4.31ms]
(pass) DOMException formats as an error > DOMException nested in an object formats as an error [3.25ms]
(pass) DOMException formats as an error > uncaught DOMException does not dump the legacy constant table [282.88ms]
(pass) DOMException formats as an error > self-referencing DOMException prints [Circular] instead of recursing [3.89ms]
(pass) DOMException formats as an error > DOMException as a non-enumerable error cause is printed [293.49ms]
(pass) DOMException formats as an error > DOMException as an enumerable error cause prints once [288.31ms]
(p
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     1f879f4494
  features     baseline

23 deps, 129 codegen, 1172 objects in 770ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] mkdir stamps
[2/1248] mkdir codegen
[3/1248] mkdir obj
[4/1248] mkdir pch
[5/1248] install /workspace/bun
bun install v1.4.0 (34cbb9a40)

Checked 26 installs across 63 packages (no changes) [26.00ms]
[6/1248] install /workspace/bun/packages/bun-error
bun install v1.4.0 (34cbb9a40)

Checked 1 install across 2 packages (no changes) [1.00ms]
[7/1248] gen ErrorCode+*.h
[8/1248] install /workspace/bun/src/node-fallbacks
bun install v1.4.0 (34cbb9a40)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[9/1248] gen node-fallbacks/react-refresh.js
Bundled 1 module in 16ms

  react-refresh.js  4.81 KB  (entry point)

[10/1248] fetch tinycc
[tinycc] up to date
[11/1248] fetch zlib
[zlib] up to date
[12/1248] fetch picohttpparser
[picohttpparser] up to date
[13/1248] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[14/1248] gen bindgenv2
[15
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/ConsoleObject.rs               |   3 +
 src/jsc/JSValue.rs                     |   9 +++
 src/jsc/VirtualMachine.rs              |  20 ++++--
 src/jsc/bindings/bindings.cpp          |   6 ++
 src/jsc/bindings/headers.h             |   1 +
 test/js/bun/util/inspect-error.test.js | 110 +++++++++++++++++++++++++++++++++
 6 files changed, 143 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/jsc/ConsoleObject.rs                    2      4      0
src/jsc/JSValue.rs                          2      3      0
src/jsc/VirtualMachine.rs                   9      9      0
src/jsc/bindings/bindings.cpp               1      2      0
src/jsc/bindings/headers.h                  1      1      0
test/js/bun/util/inspect-error.test.js      4      9      0
```

</details>

**root cause** · written by the author bot

The root cause was that DOMException was not recognized as an error-like value by the console formatter's type dispatch, so it fell through to the plain object path, which enumerates all own properties including the 25 legacy spec constants present on every instance. The fix adds a DOMException brand check predicate exposed from the JSC bindings and routes values matching it through the same error-instance formatting path used for Error, so only the name, message, and stack are printed, matching Node's output.

<!-- robobun:evidence:end -->