### PR TITLE
shell: remove unsafe from the interpreter, state nodes, IOWriter/IOReader and Builtin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,6 +1384,7 @@ dependencies = [
  "bstr",
  "bun_alloc",
  "bun_core",
+ "bun_ptr",
  "libc",
  "smallvec",
  "strum",

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -950,6 +950,7 @@ pub unsafe trait IntrusiveField<F>: Sized {
 ///
 /// ```ignore
 /// bun_core::intrusive_field!(ShellCpTask, task: ShellTask);
+/// bun_core::intrusive_field!(ShellCpTask, task.task: WorkPoolTask); // nested field
 /// bun_core::intrusive_field!([T: Send] Wrapper<T>, inner: Mixin<Wrapper<T>>);
 /// ```
 #[macro_export]
@@ -957,14 +958,22 @@ macro_rules! intrusive_field {
     // Bracketed-generics arm MUST come first: the bare `$T:ty` arm below would
     // otherwise try to parse `['a]` as a slice type and hard-error on the
     // lifetime before backtracking to this arm.
-    ([$($gen:tt)*] $T:ty, $field:ident : $F:ty) => {
+    ([$($gen:tt)*] $T:ty, $($field:ident).+ : $F:ty) => {
         unsafe impl<$($gen)*> $crate::IntrusiveField<$F> for $T {
-            const OFFSET: usize = ::core::mem::offset_of!($T, $field);
+            const OFFSET: usize = {
+                // The named field must actually be an `$F`.
+                let _ = |s: &$T| -> *const $F { &raw const s.$($field).+ };
+                ::core::mem::offset_of!($T, $($field).+)
+            };
         }
     };
-    ($T:ty, $field:ident : $F:ty) => {
+    ($T:ty, $($field:ident).+ : $F:ty) => {
         unsafe impl $crate::IntrusiveField<$F> for $T {
-            const OFFSET: usize = ::core::mem::offset_of!($T, $field);
+            const OFFSET: usize = {
+                // The named field must actually be an `$F`.
+                let _ = |s: &$T| -> *const $F { &raw const s.$($field).+ };
+                ::core::mem::offset_of!($T, $($field).+)
+            };
         }
     };
 }

--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -252,11 +252,40 @@ pub enum EventLoopTask {
     Mini(AnyTaskWithExtraContext),
 }
 
+/// A leaked box's embedded node, armed and ready to post to its loop
+/// ([`EventLoopTask::arm_boxed`]).
+#[derive(Clone, Copy)]
+pub enum ArmedLoopTask {
+    Js(NonNull<ConcurrentTask>),
+    Mini(NonNull<AnyTaskWithExtraContext>),
+}
+
 impl EventLoopTask {
     pub fn from_event_loop(loop_: EventLoopHandle) -> EventLoopTask {
         match loop_ {
             EventLoopHandle::Js { .. } => EventLoopTask::Js(ConcurrentTask::default()),
             EventLoopHandle::Mini(_) => EventLoopTask::Mini(AnyTaskWithExtraContext::default()),
+        }
+    }
+
+    /// Leak `owner` into the node it embeds (`node(owner)`). The JS arm queues
+    /// `Task { T::TAG, owner }` for `bun_runtime::dispatch` to rebox; the mini
+    /// arm hands the box to `R::run_from_loop_thread`. No allocation.
+    pub fn arm_boxed<T, R>(owner: Box<T>, node: fn(&mut T) -> &mut EventLoopTask) -> ArmedLoopTask
+    where
+        T: crate::Taskable,
+        R: crate::AnyTaskWithExtraContext::BoxedMiniTaskRunner<T>,
+    {
+        let raw: *mut T = bun_core::heap::into_raw(owner);
+        // SAFETY: `raw` was just leaked; this thread owns it exclusively until
+        // the node is queued.
+        match node(unsafe { &mut *raw }) {
+            EventLoopTask::Js(ct) => ArmedLoopTask::Js(NonNull::from(
+                ct.from(raw, crate::ConcurrentTask::AutoDeinit::ManualDeinit),
+            )),
+            EventLoopTask::Mini(at) => {
+                ArmedLoopTask::Mini(AnyTaskWithExtraContext::arm_at::<T, R>(at, raw))
+            }
         }
     }
 }
@@ -506,6 +535,13 @@ impl EventLoopHandle {
         // (`VirtualMachine.transpiler.env`; `MiniEventLoop::env_ptr`), live
         // for the loop's lifetime; the borrow ends with `f`.
         f(unsafe { (*env).get(key) })
+    }
+
+    /// `f(loader)` on the loop's dotenv loader; the borrow ends with `f` (the
+    /// map is mutable at runtime).
+    pub fn with_env<R>(self, f: impl FnOnce(&DotEnvLoader) -> R) -> R {
+        // SAFETY: as `with_env_var`.
+        f(unsafe { &*self.env() })
     }
 
     pub fn top_level_dir(self) -> &'static [u8] {

--- a/src/event_loop/AnyTaskWithExtraContext.rs
+++ b/src/event_loop/AnyTaskWithExtraContext.rs
@@ -68,6 +68,27 @@ impl AnyTaskWithExtraContext {
         }
     }
 
+    /// Leak `owner` and arm the node it embeds (`node(owner)`) so the mini
+    /// loop hands the box to `R::run_from_loop_thread`. No allocation.
+    pub fn arm_boxed<T, R: BoxedMiniTaskRunner<T>>(
+        owner: Box<T>,
+        node: fn(&mut T) -> &mut AnyTaskWithExtraContext,
+    ) -> NonNull<AnyTaskWithExtraContext> {
+        let raw: *mut T = bun_core::heap::into_raw(owner);
+        // SAFETY: `raw` was just leaked; this thread owns it exclusively until
+        // the node is queued.
+        Self::arm_at::<T, R>(node(unsafe { &mut *raw }), raw)
+    }
+
+    /// Arm `at` (a node inside the leaked box `raw`) for `R`.
+    pub(crate) fn arm_at<T, R: BoxedMiniTaskRunner<T>>(
+        at: &mut AnyTaskWithExtraContext,
+        raw: *mut T,
+    ) -> NonNull<AnyTaskWithExtraContext> {
+        *at = New::<T, ()>::init(raw, mini_boxed_trampoline::<T, R>);
+        NonNull::from(at)
+    }
+
     /// Initializes `self` in place to call `callback(of, extra)`.
     // The unit context means the callee is effectively `fn(*T)` only; mapped
     // to `*mut ()` to keep the two-arg stored ABI uniform.
@@ -77,12 +98,43 @@ impl AnyTaskWithExtraContext {
         std::ptr::from_mut::<Self>(self)
     }
 
-    pub(crate) fn run(&mut self, extra: *mut c_void) {
-        let callback = self.callback;
-        let ctx = self.ctx;
-        // SAFETY: caller contract — `ctx` was set by `init`/`from*` to a live pointer.
-        callback(ctx.expect("ctx is non-null").as_ptr(), extra.cast::<()>());
+    /// Copy the node's two words out so running it borrows nothing from the
+    /// allocation it lives in (the callback may free that allocation).
+    ///
+    /// # Safety
+    /// `this` is a queued node, live at the time of the call.
+    pub(crate) unsafe fn load(this: *const Self) -> Runnable {
+        // SAFETY: fn contract.
+        let (callback, ctx) = unsafe { ((*this).callback, (*this).ctx) };
+        Runnable { callback, ctx }
     }
+}
+
+/// A dequeued [`AnyTaskWithExtraContext`], detached from its storage.
+pub(crate) struct Runnable {
+    callback: fn(*mut (), *mut ()),
+    ctx: Option<NonNull<()>>,
+}
+
+impl Runnable {
+    pub(crate) fn run(self, extra: *mut c_void) {
+        (self.callback)(
+            self.ctx.expect("ctx is non-null").as_ptr(),
+            extra.cast::<()>(),
+        );
+    }
+}
+
+/// Receives a boxed payload back on the mini loop's thread
+/// ([`AnyTaskWithExtraContext::arm_boxed`]).
+pub trait BoxedMiniTaskRunner<T> {
+    fn run_from_loop_thread(owner: Box<T>);
+}
+
+fn mini_boxed_trampoline<T, R: BoxedMiniTaskRunner<T>>(this: *mut T, _extra: *mut ()) {
+    // SAFETY: `this` is the box `arm_boxed` leaked into its own node; the loop
+    // copied the node out (`load`) and fires it once.
+    R::run_from_loop_thread(unsafe { bun_core::heap::take(this) });
 }
 
 /// Stable Rust cannot take a fn value as a const generic, so `Callback` moves to

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -164,6 +164,33 @@ pub trait Taskable {
     unsafe fn release_unrun(this: *mut Self);
 }
 
+/// [`Taskable`] for a type that is only ever queued as a leaked `Box<Self>`
+/// (`heap::into_raw` / `Box::into_raw` at every post site, `Box::from_raw` in
+/// its `bun_runtime::dispatch` arm). Released unrun by reclaiming the box and
+/// handing it to `|this| $release` (default: drop it).
+///
+/// ```ignore
+/// bun_event_loop::boxed_taskable!(ShellGlobTask, ShellGlobTask, |this| this.task.unref_unrun());
+/// ```
+#[macro_export]
+macro_rules! boxed_taskable {
+    ($ty:ty, $tag:ident) => {
+        $crate::boxed_taskable!($ty, $tag, |this| ());
+    };
+    ($ty:ty, $tag:ident, |$this:ident| $release:expr) => {
+        impl $crate::Taskable for $ty {
+            const TAG: $crate::TaskTag = $crate::task_tag::$tag;
+            unsafe fn release_unrun(this: *mut Self) {
+                // SAFETY: `release_unrun` contract — `this` is the queued
+                // `Task::ptr` under `TAG`, which for this type is a leaked `Box<Self>`.
+                #[allow(unused_mut)]
+                let mut $this: ::std::boxed::Box<Self> = unsafe { ::bun_core::heap::take(this) };
+                $release;
+            }
+        }
+    };
+}
+
 impl TaskTag {
     /// The tag's identifier, for diagnostics.
     pub fn name(self) -> &'static str {

--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -315,8 +315,9 @@ impl MiniEventLoop {
         }
 
         while let Some(task) = self.tasks.read_item() {
-            // SAFETY: tasks are pushed by enqueue_task* and remain valid until run() consumes them.
-            unsafe { (*task).run(context) };
+            // SAFETY: tasks are pushed by enqueue_task* and remain valid until loaded here.
+            let task = unsafe { AnyTaskWithExtraContext::load(task) };
+            task.run(context);
         }
     }
 
@@ -325,7 +326,8 @@ impl MiniEventLoop {
             let _ = self.tick_concurrent_with_count();
             while let Some(task) = self.tasks.read_item() {
                 // SAFETY: see tick_once.
-                unsafe { (*task).run(context) };
+                let task = unsafe { AnyTaskWithExtraContext::load(task) };
+                task.run(context);
             }
 
             // SAFETY: see `loop_ptr()` invariant.

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -36,7 +36,7 @@ pub use ConcurrentTask::{Task, TaskTag, Taskable, task_tag};
 pub use DeferredTaskQueue as deferred_task_queue;
 
 pub use any_event_loop::{
-    AnyEventLoop, EventLoopHandle, EventLoopTask, JsPoster, JsPosterVTable, Posted,
+    AnyEventLoop, ArmedLoopTask, EventLoopHandle, EventLoopTask, JsPoster, JsPosterVTable, Posted,
 };
 pub use bun_io::PipeReadScratch;
 

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -2595,14 +2595,18 @@ pub type StreamingWriter<P> = WindowsStreamingWriter<P>;
 //                     parents that may drop their last ref mid-callback).
 //
 // Accessor args use closure-literal syntax (`|this| expr`) purely as a binder
-// for the macro — no actual closure is created. For `mut`/`shared`/`ptr`,
-// `expr` is pasted into an `unsafe` block with `this: *mut Self` in scope;
-// for `this`, `expr` is pasted as-is with `this: ThisPtr<Self>` in scope.
+// for the macro — no actual closure is created. For `mut`/`ptr`, `expr` is
+// pasted into an `unsafe` block with `this: *mut Self` in scope; for `this`,
+// `impl_streaming_writer_parent!` pastes `expr` as-is with `this: ThisPtr<Self>`
+// in scope. `impl_buffered_writer_parent!` binds `this: &Self` (pasted as-is)
+// for its read-only accessors under `shared`/`this`, and under `this` maps
+// the writer's `ref_`/`deref` hooks to the parent's intrusive refcount.
 
 /// Re-exports for `$crate::`-qualified use inside the macro bodies so callers
 /// need no extra `use` items.
 #[doc(hidden)]
 pub mod __parent_macro {
+    pub use ::bun_ptr::AnyRefCounted;
     pub use ::bun_ptr::ThisPtr;
     pub use ::bun_sys::Error as SysError;
     #[cfg(windows)]
@@ -2758,6 +2762,41 @@ macro_rules! impl_streaming_writer_parent {
 /// `WindowsBufferedWriterParent` for a parent type. See module comment above.
 #[macro_export]
 macro_rules! impl_buffered_writer_parent {
+    // Internal: dispatch a callback off the raw-ptr backref per `borrow` mode.
+    (@call mut    $p:expr; $m:ident($($a:tt)*)) => { (&mut *$p).$m($($a)*) };
+    (@call shared $p:expr; $m:ident($($a:tt)*)) => { (&*$p).$m($($a)*) };
+    (@call ptr    $p:expr; $m:ident($($a:tt)*)) => { <Self>::$m($p, $($a)*) };
+    (@call this   $p:expr; $m:ident($($a:tt)*)) => {
+        <Self>::$m($crate::pipe_writer::__parent_macro::ThisPtr::<Self>::new($p), $($a)*)
+    };
+
+    // Internal: evaluate an accessor body with `$id` bound per `borrow` mode.
+    // `shared`/`this` bind `&Self` (accessors only read), so accessor bodies
+    // are plain safe expressions; `mut`/`ptr` keep the raw `*mut Self`.
+    (@acc mut $id:ident = $p:ident; $e:expr) => {{
+        let $id = $p;
+        #[allow(unused_unsafe)]
+        unsafe { $e }
+    }};
+    (@acc ptr $id:ident = $p:ident; $e:expr) => {
+        $crate::impl_buffered_writer_parent!(@acc mut $id = $p; $e)
+    };
+    (@acc $borrow:tt $id:ident = $p:ident; $e:expr) => {{
+        // SAFETY: `$p` is the BACKREF set via `set_parent` — the live parent
+        // for the duration of this read-only accessor.
+        let $id: &Self = unsafe { &*$p };
+        $e
+    }};
+    // Internal: refcount hooks. `this` hands the body the raw root pointer
+    // (the body may free `*$p`); other modes bind as `@acc` does.
+    (@rc this $id:ident = $p:ident; $e:expr) => {{
+        let $id: *mut Self = $p;
+        $e
+    }};
+    (@rc $borrow:tt $id:ident = $p:ident; $e:expr) => {
+        $crate::impl_buffered_writer_parent!(@acc $borrow $id = $p; $e)
+    };
+
     (@emit
         [$($gen:tt)*] $Ty:ty;
         poll_tag   = $poll_tag:expr,
@@ -2777,31 +2816,30 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {
                 // SAFETY: `this` is the BACKREF set via `set_parent`; the
-                // BufferedWriter never materializes `&mut Parent`. The handler
-                // is dispatched per the `borrow` mode (`mut`/`shared`/`ptr`/`this` —
-                // see the module comment).
-                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_write(amount, status)) };
+                // BufferedWriter never materializes `&mut Parent`, so this is
+                // the unique access path for the callback's duration.
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_write(amount, status)) };
             }
             #[inline]
             unsafe fn on_error(this: *mut Self, err: $crate::pipe_writer::__parent_macro::SysError) {
                 // SAFETY: see on_write.
-                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_error(&err)) };
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_error(&err)) };
             }
             const HAS_ON_CLOSE: bool = true;
             #[inline]
             unsafe fn on_close(this: *mut Self) {
                 // SAFETY: see on_write.
-                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_close()) };
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_close()) };
             }
             #[inline]
             unsafe fn get_buffer<'a>(this: *mut Self) -> &'a [u8] {
                 // SAFETY: see on_write. Shared-only borrow of the buffer storage.
-                $crate::impl_streaming_writer_parent!(@acc $borrow $gb_this = this; $gb)
+                $crate::impl_buffered_writer_parent!(@acc $borrow $gb_this = this; $gb)
             }
             #[inline]
             unsafe fn event_loop(this: *mut Self) -> $crate::EventLoopHandle {
                 // SAFETY: see on_write.
-                $crate::impl_streaming_writer_parent!(@acc $borrow $el_this = this; $el)
+                $crate::impl_buffered_writer_parent!(@acc $borrow $el_this = this; $el)
             }
         }
 
@@ -2810,17 +2848,17 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn loop_(this: *mut Self) -> *mut $crate::pipe_writer::__parent_macro::UvLoop {
                 // SAFETY: BACKREF set via `set_parent`; shared-only read.
-                $crate::impl_streaming_writer_parent!(@acc $borrow $uv_this = this; $uv)
+                $crate::impl_buffered_writer_parent!(@acc $borrow $uv_this = this; $uv)
             }
             #[inline]
             unsafe fn ref_(this: *mut Self) {
                 // SAFETY: see loop_. Intrusive refcount bump.
-                $crate::impl_streaming_writer_parent!(@acc $borrow $ref_this = this; $ref_)
+                $crate::impl_buffered_writer_parent!(@rc $borrow $ref_this = this; $ref_)
             }
             #[inline]
             unsafe fn deref(this: *mut Self) {
                 // SAFETY: see loop_. May free `this`.
-                $crate::impl_streaming_writer_parent!(@acc $borrow $deref_this = this; $deref)
+                $crate::impl_buffered_writer_parent!(@rc $borrow $deref_this = this; $deref)
             }
         }
 
@@ -2829,25 +2867,60 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {
                 // SAFETY: BACKREF set via `set_parent`; see borrow-mode note.
-                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_write(amount, status)) };
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_write(amount, status)) };
             }
             #[inline]
             unsafe fn on_error(this: *mut Self, err: $crate::pipe_writer::__parent_macro::SysError) {
                 // SAFETY: see on_write.
-                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_error(&err)) };
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_error(&err)) };
             }
             const HAS_ON_CLOSE: bool = true;
             #[inline]
             unsafe fn on_close(this: *mut Self) {
                 // SAFETY: see on_write.
-                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_close()) };
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_close()) };
             }
             #[inline]
             unsafe fn get_buffer<'a>(this: *mut Self) -> &'a [u8] {
                 // SAFETY: see on_write.
-                $crate::impl_streaming_writer_parent!(@acc $borrow $gb_this = this; $gb)
+                $crate::impl_buffered_writer_parent!(@acc $borrow $gb_this = this; $gb)
             }
             const HAS_ON_WRITABLE: bool = false;
+        }
+    };
+
+    // Public entry — `borrow = this`, intrusively refcounted parent: the
+    // writer's `ref_`/`deref` hooks are the parent's own refcount.
+    (
+        $Ty:ty;
+        poll_tag   = $poll_tag:expr,
+        borrow     = this,
+        on_write   = $on_write:ident,
+        on_error   = $on_error:ident,
+        on_close   = $on_close:ident,
+        get_buffer = |$gb_this:ident| $gb:expr,
+        event_loop = |$el_this:ident| $el:expr,
+        uv_loop    = |$uv_this:ident| $uv:expr,
+    ) => {
+        $crate::impl_buffered_writer_parent! {
+            @emit [] $Ty;
+            poll_tag   = $poll_tag,
+            borrow     = this,
+            on_write   = $on_write,
+            on_error   = $on_error,
+            on_close   = $on_close,
+            get_buffer = |$gb_this| $gb,
+            event_loop = |$el_this| $el,
+            uv_loop    = |$uv_this| $uv,
+            // SAFETY: `this_` is the live parent's root pointer.
+            ref_       = |this_| unsafe {
+                <$Ty as $crate::pipe_writer::__parent_macro::AnyRefCounted>::rc_ref(this_)
+            },
+            // SAFETY: releases the ref the writer took through `ref_` above;
+            // `this_` is the parent's root pointer.
+            deref      = |this_| unsafe {
+                <$Ty as $crate::pipe_writer::__parent_macro::AnyRefCounted>::rc_deref(this_)
+            },
         }
     };
 

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -817,6 +817,15 @@ impl ConcurrentPoster {
         matches!(self, ConcurrentPoster::Js(..))
     }
 
+    /// Post a node armed by `EventLoopTask::arm_boxed` to whichever loop this
+    /// poster targets.
+    pub fn post(&self, task: bun_event_loop::ArmedLoopTask) {
+        match task {
+            bun_event_loop::ArmedLoopTask::Js(t) => self.post_js(t),
+            bun_event_loop::ArmedLoopTask::Mini(t) => self.post_mini(t),
+        }
+    }
+
     /// Post a JS-loop `ConcurrentTask`. Panics (debug) if this poster is `Mini`.
     pub fn post_js(&self, task: NonNull<ConcurrentTaskItem>) {
         match self {

--- a/src/ptr/js_cell.rs
+++ b/src/ptr/js_cell.rs
@@ -144,3 +144,187 @@ impl<T: core::fmt::Debug> core::fmt::Debug for JsCell<T> {
         self.get().fmt(f)
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// JsRefCell<T> — `JsCell` with `RefCell`-shaped guards, checked in debug.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// [`JsCell`]'s contract (one owning thread; the hazard is same-thread
+/// re-entrancy) with `core::cell::RefCell`'s API: [`borrow`](Self::borrow) /
+/// [`borrow_mut`](Self::borrow_mut) hand out guards, and in debug builds an
+/// overlapping exclusive borrow panics exactly like `RefCell`. Release builds
+/// compile the flag away, so a guard costs what the reference costs.
+pub struct JsRefCell<T> {
+    value: core::cell::UnsafeCell<T>,
+    #[cfg(debug_assertions)]
+    flag: core::cell::Cell<isize>,
+}
+
+/// Shared borrow of a [`JsRefCell`]; see `core::cell::Ref`.
+pub struct JsCellRef<'b, T: ?Sized> {
+    value: core::ptr::NonNull<T>,
+    #[cfg(debug_assertions)]
+    flag: &'b core::cell::Cell<isize>,
+    _marker: core::marker::PhantomData<&'b T>,
+}
+
+/// Exclusive borrow of a [`JsRefCell`]; see `core::cell::RefMut`.
+pub struct JsCellRefMut<'b, T: ?Sized> {
+    value: core::ptr::NonNull<T>,
+    #[cfg(debug_assertions)]
+    flag: &'b core::cell::Cell<isize>,
+    _marker: core::marker::PhantomData<&'b mut T>,
+}
+
+impl<T> JsRefCell<T> {
+    #[inline(always)]
+    pub const fn new(value: T) -> Self {
+        Self {
+            value: core::cell::UnsafeCell::new(value),
+            #[cfg(debug_assertions)]
+            flag: core::cell::Cell::new(0),
+        }
+    }
+
+    #[inline(always)]
+    #[track_caller]
+    pub fn borrow(&self) -> JsCellRef<'_, T> {
+        #[cfg(debug_assertions)]
+        {
+            let f = self.flag.get();
+            assert!(f >= 0, "JsRefCell already mutably borrowed");
+            self.flag.set(f + 1);
+        }
+        JsCellRef {
+            // SAFETY: `UnsafeCell::get` is never null.
+            value: unsafe { core::ptr::NonNull::new_unchecked(self.value.get()) },
+            #[cfg(debug_assertions)]
+            flag: &self.flag,
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    #[inline(always)]
+    #[track_caller]
+    pub fn borrow_mut(&self) -> JsCellRefMut<'_, T> {
+        #[cfg(debug_assertions)]
+        {
+            let f = self.flag.get();
+            assert!(f == 0, "JsRefCell already borrowed");
+            self.flag.set(-1);
+        }
+        JsCellRefMut {
+            // SAFETY: `UnsafeCell::get` is never null.
+            value: unsafe { core::ptr::NonNull::new_unchecked(self.value.get()) },
+            #[cfg(debug_assertions)]
+            flag: &self.flag,
+            _marker: core::marker::PhantomData,
+        }
+    }
+
+    #[inline(always)]
+    pub fn get_mut(&mut self) -> &mut T {
+        self.value.get_mut()
+    }
+
+    /// Overwrite the value (dropping the old one) with no borrow outstanding.
+    #[inline(always)]
+    #[track_caller]
+    pub fn set(&self, value: T) {
+        #[cfg(debug_assertions)]
+        {
+            assert!(self.flag.get() == 0, "JsRefCell already borrowed");
+            // Held across the old value's drop, like `*cell.borrow_mut() = v`.
+            self.flag.set(-1);
+        }
+        // SAFETY: no `JsCellRef`/`JsCellRefMut` is live (checked in debug; the
+        // type's single-thread no-overlap contract in release), so this is the
+        // only access to the value for the duration of the write.
+        unsafe { *self.value.get() = value };
+        #[cfg(debug_assertions)]
+        self.flag.set(0);
+    }
+}
+
+impl<'b, T: ?Sized> JsCellRef<'b, T> {
+    #[inline(always)]
+    pub fn map<U: ?Sized>(orig: JsCellRef<'b, T>, f: impl FnOnce(&T) -> &U) -> JsCellRef<'b, U> {
+        let value = core::ptr::NonNull::from(f(&*orig));
+        let orig = core::mem::ManuallyDrop::new(orig);
+        #[cfg(not(debug_assertions))]
+        let _ = &orig;
+        JsCellRef {
+            value,
+            #[cfg(debug_assertions)]
+            flag: orig.flag,
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<'b, T: ?Sized> JsCellRefMut<'b, T> {
+    #[inline(always)]
+    pub fn map<U: ?Sized>(
+        orig: JsCellRefMut<'b, T>,
+        f: impl FnOnce(&mut T) -> &mut U,
+    ) -> JsCellRefMut<'b, U> {
+        let mut orig = core::mem::ManuallyDrop::new(orig);
+        let value = core::ptr::NonNull::from(f(&mut **orig));
+        JsCellRefMut {
+            value,
+            #[cfg(debug_assertions)]
+            flag: orig.flag,
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<T: ?Sized> core::ops::Deref for JsCellRef<'_, T> {
+    type Target = T;
+    #[inline(always)]
+    fn deref(&self) -> &T {
+        // SAFETY: a live `JsCellRef` is a counted shared borrow of the cell (debug)
+        // / the cell's single-thread no-overlap contract (release).
+        unsafe { self.value.as_ref() }
+    }
+}
+
+impl<T: ?Sized> core::ops::Deref for JsCellRefMut<'_, T> {
+    type Target = T;
+    #[inline(always)]
+    fn deref(&self) -> &T {
+        // SAFETY: a live `JsCellRefMut` is the cell's only borrow (see `Deref` for `JsCellRef`).
+        unsafe { self.value.as_ref() }
+    }
+}
+
+impl<T: ?Sized> core::ops::DerefMut for JsCellRefMut<'_, T> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: a live `JsCellRefMut` is the cell's only borrow (see `Deref` for `JsCellRef`).
+        unsafe { self.value.as_mut() }
+    }
+}
+
+#[cfg(debug_assertions)]
+impl<T: ?Sized> Drop for JsCellRef<'_, T> {
+    #[inline(always)]
+    fn drop(&mut self) {
+        self.flag.set(self.flag.get() - 1);
+    }
+}
+
+#[cfg(debug_assertions)]
+impl<T: ?Sized> Drop for JsCellRefMut<'_, T> {
+    #[inline(always)]
+    fn drop(&mut self) {
+        self.flag.set(0);
+    }
+}
+
+impl<T: Default> Default for JsRefCell<T> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -162,6 +162,35 @@ impl<T: ?Sized> BackRef<T, Mut> {
     }
 }
 
+/// The root pointer of a value built by [`RefPtr::new_cyclic`], stored inside
+/// that value. It has no accessors of its own: the only way to use it is
+/// [`SelfRoot::this_ptr`], which takes the enclosing `&T` — so it cannot be
+/// followed before the value exists or after it is gone.
+#[repr(transparent)]
+pub struct SelfRoot<T>(pub(crate) core::ptr::NonNull<T>);
+
+impl<T> SelfRoot<T> {
+    /// The enclosing value as a [`ThisPtr`]. `owner` must be the value this
+    /// token is stored in (checked in debug builds).
+    #[inline]
+    pub fn this_ptr(&self, owner: &T) -> ThisPtr<T> {
+        debug_assert!(
+            core::ptr::eq(self.0.as_ptr().cast_const(), owner),
+            "SelfRoot used from a value it does not belong to"
+        );
+        let _ = owner;
+        // SAFETY: `owner: &T` proves the value is constructed and live; `self.0`
+        // is its allocation root (minted by `new_cyclic`).
+        unsafe { ThisPtr::new(self.0.as_ptr()) }
+    }
+
+    /// The enclosing value as a root back-reference.
+    #[inline]
+    pub fn backref(&self, owner: &T) -> BackRef<T, Root> {
+        self.this_ptr(owner).into()
+    }
+}
+
 impl<T, P> BackRef<T, P> {
     #[inline]
     pub const fn dangling() -> Self {

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -23,7 +23,7 @@
 #[path = "CowSlice.rs"]
 pub mod cow_slice;
 mod js_cell;
-pub use js_cell::JsCell;
+pub use js_cell::{JsCell, JsCellRef, JsCellRefMut, JsRefCell};
 
 // FFI-crossing externally-ref-counted pointer (e.g., WTFStringImpl). Canonical
 // impl moved down to `bun_core::external_shared` (cycle-break for the

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -555,6 +555,21 @@ impl<T: AnyRefCounted> RefPtr<T> {
         }
     }
 
+    /// [`new`](Self::new) for a `T` that stores its own root pointer (to hand
+    /// out [`ThisPtr`](crate::ThisPtr)s from `&self` entry points). `init`
+    /// receives a [`SelfRoot`](crate::SelfRoot) to store in the value; the
+    /// token cannot be dereferenced on its own, only through the `&T` that
+    /// exists once construction is done.
+    pub fn new_cyclic(init: impl FnOnce(crate::SelfRoot<T>) -> T) -> Self {
+        let raw: NonNull<T> = bun_core::heap::into_raw_nn(Box::<T>::new_uninit()).cast::<T>();
+        let value = init(crate::SelfRoot(raw));
+        // SAFETY: `raw` is a live, uninitialized, properly aligned `T` slot.
+        unsafe { raw.as_ptr().write(value) };
+        // SAFETY: freshly written, so live.
+        debug_assert!(unsafe { T::rc_has_one_ref(raw.as_ptr()) });
+        Self(raw)
+    }
+
     /// Take a new ref on the pointee of a [`ThisPtr`](crate::ThisPtr). Safe:
     /// the `ThisPtr` invariant is that its pointee is live. This is the guard
     /// to hold across a re-entrant call that may otherwise drop the last ref.

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -1,5 +1,3 @@
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use bun_collections::VecExt;
 use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult};
 #[cfg(windows)]
 use bun_sys::windows::libuv as uv;
@@ -30,16 +28,6 @@ use sys::Stdio as FdStdio;
 // `const log = bun.sys.syslog;`
 bun_output::define_scoped_log!(log, SYS, visible);
 
-/// Payload of `Stdio::Capture`.
-#[derive(Clone, Copy)]
-pub struct Capture {
-    // BACKREF: raw pointer to a capture buffer owned by the shell interpreter.
-    // The shell keeps the buffer alive for the lifetime
-    // of the spawned process; this struct never frees it.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    pub(crate) buf: *mut Vec<u8>,
-}
-
 /// Payload of `Stdio::Dup2`.
 #[derive(Clone, Copy)]
 pub struct Dup2 {
@@ -52,7 +40,9 @@ pub struct Dup2 {
 #[allow(clippy::large_enum_variant)]
 pub enum Stdio {
     Inherit,
-    Capture(Capture),
+    /// The shell tees the child's output into its own buffer through the
+    /// `PipeReader`.
+    Capture,
     Ignore,
     Fd(Fd),
     Dup2(Dup2),
@@ -104,10 +94,7 @@ impl Stdio {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub(crate) fn byte_slice(&self) -> &[u8] {
         match self {
-            // SAFETY: `buf` is a live backref owned by the caller (shell); the
-            // returned slice borrows `self` and the caller guarantees the
-            // Vec<u8> outlives this Stdio.
-            Self::Capture(c) => unsafe { (*c.buf).slice() },
+            Self::Capture => &[],
             Self::Blob(blob) => blob.slice(),
             _ => &[],
         }
@@ -284,7 +271,7 @@ impl Stdio {
                 out: d.out,
                 to: d.to,
             }),
-            Self::Capture(_) | Self::Pipe | Self::ReadableStream(_) => buffer(),
+            Self::Capture | Self::Pipe | Self::ReadableStream(_) => buffer(),
             #[cfg(not(windows))]
             Self::SocketFd => SpawnOptionsStdio::SocketFd,
             // Windows extra-stdio is a libuv pipe handle (no raw-fd ownership
@@ -308,7 +295,7 @@ impl Stdio {
 
     pub(crate) fn is_piped(&self) -> bool {
         match self {
-            Self::Capture(_) | Self::Blob(_) | Self::Pipe | Self::ReadableStream(_) => true,
+            Self::Capture | Self::Blob(_) | Self::Pipe | Self::ReadableStream(_) => true,
             Self::Ipc => cfg!(windows),
             _ => false,
         }

--- a/src/runtime/api/bun/subprocess/Readable.rs
+++ b/src/runtime/api/bun/subprocess/Readable.rs
@@ -144,7 +144,7 @@ impl Readable {
                 Readable::Pipe(PipeReader::create(event_loop, process, result, max_size))
             }
             Stdio::Blob(..) => panic!("TODO: implement Blob support in Stdio readable"),
-            Stdio::Capture(..) => panic!("TODO: implement capture support in Stdio readable"),
+            Stdio::Capture => panic!("TODO: implement capture support in Stdio readable"),
             // ReadableStream is handled separately
             Stdio::ReadableStream(..) => Readable::Ignore,
             // Rejected at i < 3 in Stdio::extract(); stdout/stderr never see this.

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -195,7 +195,7 @@ impl<'a> Writable<'a> {
                 Stdio::Memfd(_) | Stdio::Path(_) | Stdio::Ignore => {
                     return Ok(Writable::Ignore);
                 }
-                Stdio::Ipc | Stdio::Capture(_) => {
+                Stdio::Ipc | Stdio::Capture => {
                     return Ok(Writable::Ignore);
                 }
                 // Rejected at i < 3 in Stdio::extract(); stdin never sees this.
@@ -296,7 +296,7 @@ impl<'a> Writable<'a> {
             Stdio::Fd(_) => Ok(Writable::Fd(result.unwrap())),
             Stdio::Inherit => Ok(Writable::Inherit),
             Stdio::Path(_) | Stdio::Ignore => Ok(Writable::Ignore),
-            Stdio::Ipc | Stdio::Capture(_) => Ok(Writable::Ignore),
+            Stdio::Ipc | Stdio::Capture => Ok(Writable::Ignore),
             // Rejected at i < 3 in Stdio::extract(); stdin never sees this.
             Stdio::SocketFd => unreachable!("SocketFd at stdin"),
         }

--- a/src/runtime/cli/exec_command.rs
+++ b/src/runtime/cli/exec_command.rs
@@ -73,7 +73,7 @@ impl ExecCommand {
         // other live `&mut` to the same `MiniEventLoop` on this thread).
         let mini_ref = unsafe { &mut *mini };
         let code = match Interpreter::init_and_run_from_source(
-            ctx,
+            &*ctx,
             mini_ref,
             script_path,
             &script,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -333,7 +333,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             // no aliasing `&mut` exists across this call.
             let mini = unsafe { &mut *mini };
             let code = match crate::shell::Interpreter::init_and_run_from_source(
-                ctx,
+                &*ctx,
                 mini,
                 name,
                 &copy_script,
@@ -918,7 +918,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         let path_z = ZStr::from_buf(&path_buf[..], entry_path.len());
         let src = sys::File::read_from(Fd::cwd(), path_z)?;
 
-        crate::shell::Interpreter::init_and_run_from_file(ctx, mini, entry_path, &src)
+        crate::shell::Interpreter::init_and_run_from_file(&*ctx, mini, entry_path, &src)
     }
 
     /// `VirtualMachine::init`,

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -78,7 +78,6 @@ use crate::shell::dispatch_tasks::{ShellCondExprStatTask, ShellGlobTask, ShellRm
 use crate::shell::interpreter::ShellTask;
 #[cfg(not(windows))]
 use crate::shell::io_writer::Poll as ShellBufferedWriterPoll;
-use crate::shell::states::r#async::Async as ShellAsync;
 
 use crate::webcore::fetch::fetch_tasklet::FetchTasklet;
 use crate::webcore::file_sink::FlushPendingTask as FlushPendingFileSinkTask;
@@ -509,47 +508,30 @@ fn run_task_cold(task: Task) {
             task.ptr.cast::<$ty>()
         };
     }
-    /// Shell builtin tasks: route through `ShellTask::run_from_main_thread`
-    /// so the keep-alive ref taken in `ShellTask::schedule` is unref'd before
-    /// the per-builtin body runs.
-    /// The wrapper recovers `&mut Interpreter` from the embedded
-    /// `ShellTask.interp` back-ref.
+    /// Shell builtin tasks: `ShellTask::on_finish` posts a leaked `Box<$ty>`;
+    /// rebox it and route through `ShellTask::run_from_main_thread` so the
+    /// keep-alive ref taken in `ShellTask::schedule` is unref'd before the
+    /// per-builtin body runs.
     macro_rules! shell_dispatch {
         ($ty:ty) => {{
-            // SAFETY: §Dispatch — `t` is a live heap-allocated shell task;
-            // `interp` was set at schedule time and outlives the task.
-            unsafe { ShellTask::run_from_main_thread::<$ty>(cast_ptr!($ty)) };
-        }};
-        // Cond-expr wraps an inner `task: ShellTask`-embedding struct one
-        // level deeper. The type *does* implement `ShellTaskCtx`
-        // (with a two-hop `TASK_OFFSET`, needed for `ShellTask::schedule`),
-        // so this arm is behaviorally identical to the plain arm; the unref +
-        // interp-recovery are inlined here only to keep the `.task.task`
-        // shape explicit at the dispatch site.
-        (nested $ty:ty) => {{
-            let t = cast_ptr!($ty);
-            // SAFETY: see above; `task.task` is the embedded ShellTask.
-            unsafe {
-                let st = &raw mut (*t).task.task;
-                (*st).keep_alive.unref((*st).event_loop.as_event_loop_ctx());
-                let interp = &*(*st).interp;
-                <$ty>::run_from_main_thread(t, interp);
-            }
+            // SAFETY: §Dispatch — tag identifies pointee: the `Box<$ty>`
+            // `ShellTask::on_finish` leaked when posting.
+            let t = unsafe { bun_core::heap::take(cast_ptr!($ty)) };
+            ShellTask::run_from_main_thread::<$ty>(t);
         }};
     }
 
     match task.tag {
         // ── shell interpreter ────────────────────────────────────────────
         task_tag::ShellAsync => {
-            // SAFETY: §Dispatch — tag identifies pointee.
-            let t = unsafe { &mut *cast_ptr!(crate::shell::dispatch_tasks::ShellAsyncTask) };
-            // SAFETY: `interp` set at enqueue; outlives task.
-            let interp = unsafe { &*t.interp };
-            ShellAsync::run_from_main_thread(interp, t.node);
+            // SAFETY: §Dispatch — tag identifies pointee: the box
+            // `Async::enqueue_self` leaked when posting.
+            let t = unsafe {
+                bun_core::heap::take(cast_ptr!(crate::shell::dispatch_tasks::ShellAsyncTask))
+            };
+            t.run();
         }
-        task_tag::ShellCondExprStatTask => {
-            shell_dispatch!(nested ShellCondExprStatTask);
-        }
+        task_tag::ShellCondExprStatTask => shell_dispatch!(ShellCondExprStatTask),
         task_tag::ShellCpTask => shell_dispatch!(ShellCpTask),
         task_tag::ShellTouchTask => shell_dispatch!(ShellTouchTask),
         task_tag::ShellMkdirTask => shell_dispatch!(ShellMkdirTask),

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1686,7 +1686,7 @@ mod _async_tasks {
                 let dest = core::mem::take(&mut self.args.dest);
                 let shelltask = self.shelltask.expect("IS_SHELL ⇒ shelltask").as_mut_ptr();
                 // SAFETY: shelltask is non-null in the IS_SHELL specialization and
-                // outlives this task; `cp_on_finish` enqueues it concurrently.
+                // outlives this task; `cp_on_finish` reclaims it.
                 unsafe { ShellCpTask::cp_on_finish(shelltask, src, dest, result) };
                 // SAFETY: self was Box::leak'd in create*(); destroyed exactly once here
                 unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -3,7 +3,7 @@
 
 use bun_collections::VecExt;
 use bun_jsc::PinnedArrayBuffer;
-use core::cell::{Ref, RefMut};
+use bun_ptr::{JsCellRef, JsCellRefMut};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -59,13 +59,13 @@ pub(crate) trait BuiltinState: Sized {
     /// Project `&mut Impl` → `&mut Self`. `unreachable!` on variant mismatch.
     fn extract(impl_: &mut Impl) -> &mut Self;
 
-    /// Borrow this builtin's state out of the Cmd node. A `RefMut` into the
-    /// node: keep it short and never hold it across a call that touches the
-    /// same Cmd (`Builtin::of*`, `write_no_io`, `done`, ...).
-    #[inline]
+    /// Borrow this builtin's state out of the Cmd node. An exclusive borrow
+    /// of the node: keep it short and never hold it across a call that
+    /// touches the same Cmd (`Builtin::of*`, `write_no_io`, `done`, ...).
+    #[inline(always)]
     #[track_caller]
-    fn state_mut(interp: &Interpreter, cmd: NodeId) -> RefMut<'_, Self> {
-        RefMut::map(Builtin::of_mut(interp, cmd), |b| {
+    fn state_mut(interp: &Interpreter, cmd: NodeId) -> JsCellRefMut<'_, Self> {
+        JsCellRefMut::map(Builtin::of_mut(interp, cmd), |b| {
             Self::extract(&mut b.impl_)
         })
     }
@@ -156,13 +156,30 @@ macro_rules! shell_builtins {
                 }
             }
 
-            /// Hoisted dispatch for the `onIOWriterChunk` callback.
+            /// Hoisted dispatch for the `onIOWriterChunk` callback. `seq != 0`
+            /// names a parked [`OutputTask`](crate::shell::interpreter::OutputTask)
+            /// chunk of an ls/mkdir/touch/cp.
             pub fn on_io_writer_chunk(
                 interp: &Interpreter,
                 cmd: NodeId,
+                seq: u32,
                 written: usize,
                 err: Option<bun_sys::SystemError>,
             ) -> Yield {
+                use crate::shell::interpreter::OutputTask;
+                use crate::shell::builtins::{cp::Cp, ls::Ls, mkdir::Mkdir, touch::Touch};
+                if seq != 0 {
+                    return match Self::kind_of(interp, cmd) {
+                        Kind::Ls => OutputTask::<Ls>::on_chunk(interp, cmd, seq, written, err),
+                        Kind::Mkdir => OutputTask::<Mkdir>::on_chunk(interp, cmd, seq, written, err),
+                        Kind::Touch => OutputTask::<Touch>::on_chunk(interp, cmd, seq, written, err),
+                        Kind::Cp => OutputTask::<Cp>::on_chunk(interp, cmd, seq, written, err),
+                        // rm numbers its verbose chunks only so that each is
+                        // called back.
+                        Kind::Rm => crate::shell::builtins::rm::Rm::on_io_writer_chunk(interp, cmd, written, err),
+                        other => unreachable!("{} queues no numbered chunks", other.as_str()),
+                    };
+                }
                 match Self::kind_of(interp, cmd) {
                     $( Kind::$UV => crate::shell::builtins::$u_mod::$UT::on_io_writer_chunk(interp, cmd, written, err), )*
                     $( Kind::$IV => crate::shell::builtins::$i_mod::$IT::on_io_writer_chunk(interp, cmd, written, err), )*
@@ -869,22 +886,22 @@ impl Builtin {
         Cmd::on_exec_done(interp, cmd, exit_code)
     }
 
-    /// Look up the Builtin inside a Cmd's `exec` slot. A `Ref` into the Cmd
-    /// node: it must be released before anything borrows that node mutably.
-    #[inline]
+    /// Look up the Builtin inside a Cmd's `exec` slot. A shared borrow of the
+    /// Cmd node: release it before anything borrows that node exclusively.
+    #[inline(always)]
     #[track_caller]
-    pub(crate) fn of(interp: &Interpreter, cmd: NodeId) -> Ref<'_, Builtin> {
-        Ref::map(interp.as_cmd(cmd), |c| match &c.exec {
+    pub(crate) fn of(interp: &Interpreter, cmd: NodeId) -> JsCellRef<'_, Builtin> {
+        JsCellRef::map(interp.as_cmd(cmd), |c| match &c.exec {
             crate::shell::states::cmd::Exec::Builtin(b) => &**b,
             _ => panic!("Cmd {} is not running a builtin", cmd),
         })
     }
 
     /// [`of`](Self::of), mutably.
-    #[inline]
+    #[inline(always)]
     #[track_caller]
-    pub(crate) fn of_mut(interp: &Interpreter, cmd: NodeId) -> RefMut<'_, Builtin> {
-        RefMut::map(interp.as_cmd_mut(cmd), |c| match &mut c.exec {
+    pub(crate) fn of_mut(interp: &Interpreter, cmd: NodeId) -> JsCellRefMut<'_, Builtin> {
+        JsCellRefMut::map(interp.as_cmd_mut(cmd), |c| match &mut c.exec {
             crate::shell::states::cmd::Exec::Builtin(b) => &mut **b,
             _ => panic!("Cmd {} is not running a builtin", cmd),
         })

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -3,30 +3,30 @@
 
 use bun_collections::VecExt;
 use bun_jsc::PinnedArrayBuffer;
-use core::ffi::c_char;
+use core::cell::{Ref, RefMut};
+use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::shell::ExitCode;
 use crate::shell::ast;
 use crate::shell::interpreter::{
-    Interpreter, NodeId, OutputNeedsIOSafeGuard, ParseError, is_pollable_from_mode, shell_openat,
+    CapturedBuf, Interpreter, NodeId, OutputNeedsIOSafeGuard, ParseError, is_pollable_from_mode,
+    shell_openat,
 };
 use crate::shell::io::{InKind, OutFd, OutKind};
-use crate::shell::io_reader::IOReader;
-use crate::shell::io_writer::{self, IOWriter};
+use crate::shell::io_reader::{IOReader, IOReaderRef};
+use crate::shell::io_writer::{self, IOWriter, IOWriterRef};
 use crate::shell::states::cmd::{Cmd, CmdState};
 use crate::shell::yield_::Yield;
 
 pub struct Builtin {
     pub(crate) kind: Kind,
-    /// argv[1..] as NUL-terminated strings (argv[0] is the builtin name).
-    /// Points into the Cmd's `args` storage.
-    pub args: Vec<*const c_char>,
+    /// argv[1..], each NUL-terminated (argv[0], the builtin name, stays on
+    /// the Cmd). Moved out of the Cmd's `args` by `init`.
+    pub args: Vec<Vec<u8>>,
     pub(crate) stdin: BuiltinInput,
     pub(crate) stdout: BuiltinIO,
     pub(crate) stderr: BuiltinIO,
-    /// Scratch for `fmt_error_arena`. One outstanding error string at a time.
-    pub(crate) err_buf: Vec<u8>,
     pub(crate) impl_: Impl,
 }
 
@@ -59,10 +59,15 @@ pub(crate) trait BuiltinState: Sized {
     /// Project `&mut Impl` → `&mut Self`. `unreachable!` on variant mismatch.
     fn extract(impl_: &mut Impl) -> &mut Self;
 
+    /// Borrow this builtin's state out of the Cmd node. A `RefMut` into the
+    /// node: keep it short and never hold it across a call that touches the
+    /// same Cmd (`Builtin::of*`, `write_no_io`, `done`, ...).
     #[inline]
     #[track_caller]
-    fn state_mut(interp: &Interpreter, cmd: NodeId) -> &mut Self {
-        Self::extract(&mut Builtin::of_mut(interp, cmd).impl_)
+    fn state_mut(interp: &Interpreter, cmd: NodeId) -> RefMut<'_, Self> {
+        RefMut::map(Builtin::of_mut(interp, cmd), |b| {
+            Self::extract(&mut b.impl_)
+        })
     }
 }
 
@@ -256,7 +261,7 @@ pub enum BuiltinIO {
 
 /// Input stream of a builtin.
 pub enum BuiltinInput {
-    Fd(Arc<IOReader>),
+    Fd(IOReaderRef),
     ArrayBuf { buf: PinnedArrayBuffer, i: u32 },
     Blob(Arc<BuiltinBlob>),
     Ignore,
@@ -268,14 +273,14 @@ pub struct BuiltinBlob {
     pub(crate) blob: crate::webcore::Blob,
 }
 // `BuiltinBlob` is auto-`Send + Sync`: its sole field is `webcore::Blob`,
-// which already asserts `Send + Sync`. No `unsafe impl` needed.
+// which already asserts `Send + Sync`.
 const _: fn() = || {
     fn assert<T: Send + Sync>() {}
     assert::<BuiltinBlob>();
 };
 
 impl BuiltinIO {
-    /// From the Cmd's IO::OutKind. `Arc::clone` (via `OutFd: Clone`) bumps
+    /// From the Cmd's IO::OutKind. `Rc::clone` (via `OutFd: Clone`) bumps
     /// the `IOWriter` refcount; `Drop` decrements it symmetrically. `target`
     /// is the shell-env bytelist this stream flushes to (Stdout or Stderr).
     fn from_out_kind(ok: &OutKind, target: IoKind) -> BuiltinIO {
@@ -314,15 +319,11 @@ impl BuiltinIO {
     /// Body of [`Builtin::write_no_io`] with the Cmd split-borrow already
     /// performed by the caller. Exists so builtins whose payload lives in
     /// `Builtin.impl_` (disjoint from `stdout`/`stderr`) can write a borrowed
-    /// slice without an intermediate heap clone.
-    ///
-    /// # Safety
-    /// `shell` must point to the live `ShellExecEnv` owning this builtin
-    /// (i.e. `cmd.base.shell`); only dereferenced for the [`BuiltinIO::Buf`]
-    /// arm.
-    pub(crate) unsafe fn write_no_io_to(
+    /// slice without an intermediate heap clone. `shell` is the Cmd's env
+    /// (`cmd.base.shell`); only used for the [`BuiltinIO::Buf`] arm.
+    pub(crate) fn write_no_io_to(
         &mut self,
-        shell: *mut crate::shell::interpreter::ShellExecEnv,
+        shell: &crate::shell::interpreter::ShellExecEnv,
         buf: &[u8],
     ) -> bun_sys::Result<usize> {
         if buf.is_empty() {
@@ -337,16 +338,7 @@ impl BuiltinIO {
                 // `target` is the destination identity, fixed at construction
                 // and preserved across `dup_ref` so `2>&1` lands in stdout's
                 // bytelist.
-                // SAFETY: caller contract — shell env outlives the Cmd node
-                // (single-threaded); `captured` points into a live
-                // `ShellExecEnv` Bufio.
-                unsafe {
-                    let captured = match *target {
-                        IoKind::Stdout => (*shell).buffered_stdout(),
-                        IoKind::Stderr => (*shell).buffered_stderr(),
-                    };
-                    (*captured).append_slice(buf)
-                };
+                let _ = shell.captured(*target).borrow_mut().append_slice(buf);
                 Ok(buf.len())
             }
             BuiltinIO::ArrayBuf { buf: arraybuf, i } => {
@@ -371,44 +363,81 @@ impl BuiltinIO {
         }
     }
 
-    /// Queue `buf` on this stream's IOWriter and arrange for `child`'s
-    /// `on_io_writer_chunk` to fire when the chunk completes. Delegates to
-    /// `fd.writer.enqueue` passing `fd.captured` as the tee bytelist.
-    ///
-    /// `_safeguard` proves the caller checked `needs_io()`.
-    pub(crate) fn enqueue(
-        &mut self,
-        child: io_writer::ChildPtr,
-        buf: &[u8],
-        _safeguard: OutputNeedsIOSafeGuard,
-    ) -> Yield {
+    /// The writer and tee buffer, for callers holding the
+    /// [`OutputNeedsIOSafeGuard`] that proves this is `Fd`.
+    fn out_fd(&self, _safeguard: OutputNeedsIOSafeGuard) -> (IOWriterRef, Option<CapturedBuf>) {
         match self {
-            BuiltinIO::Fd(fd) => fd.writer.enqueue(child, fd.captured, buf),
-            _ => unreachable!("enqueue() on non-fd output; caller must check needs_io()"),
+            BuiltinIO::Fd(fd) => (fd.writer.clone(), fd.captured.clone()),
+            _ => unreachable!("non-fd output; caller must check needs_io()"),
+        }
+    }
+}
+
+impl Builtin {
+    fn out_fd(
+        interp: &Interpreter,
+        cmd: NodeId,
+        to: IoKind,
+        safeguard: OutputNeedsIOSafeGuard,
+    ) -> (IOWriterRef, Option<CapturedBuf>) {
+        let me = Self::of(interp, cmd);
+        match to {
+            IoKind::Stdout => me.stdout.out_fd(safeguard),
+            IoKind::Stderr => me.stderr.out_fd(safeguard),
         }
     }
 
-    /// Format with the optional `"{kind}: "` prefix and enqueue on the
-    /// underlying IOWriter.
-    pub(crate) fn enqueue_fmt(
-        &mut self,
+    /// Queue `buf` on `to`'s IOWriter; `child`'s `on_io_writer_chunk` fires
+    /// when the chunk completes. The Cmd node is not borrowed while the writer
+    /// runs (it may call other children back, or this one on a synchronous
+    /// failure).
+    pub(crate) fn write_out(
+        interp: &Interpreter,
+        cmd: NodeId,
+        to: IoKind,
+        child: io_writer::ChildPtr,
+        buf: &[u8],
+        safeguard: OutputNeedsIOSafeGuard,
+    ) -> Yield {
+        let (writer, captured) = Self::out_fd(interp, cmd, to, safeguard);
+        writer.enqueue(child, captured, buf)
+    }
+
+    /// [`write_out`](Self::write_out) with the bytes appended by `fill` (which
+    /// may borrow the node; the borrow ends before the writer runs).
+    pub(crate) fn write_out_with(
+        interp: &Interpreter,
+        cmd: NodeId,
+        to: IoKind,
+        child: io_writer::ChildPtr,
+        safeguard: OutputNeedsIOSafeGuard,
+        fill: impl FnOnce(&mut Vec<u8>),
+    ) -> Yield {
+        let (writer, captured) = Self::out_fd(interp, cmd, to, safeguard);
+        writer.enqueue_with(child, captured, fill)
+    }
+
+    /// [`write_out`](Self::write_out), formatted with the optional
+    /// `"{kind}: "` prefix.
+    pub(crate) fn write_out_fmt(
+        interp: &Interpreter,
+        cmd: NodeId,
+        to: IoKind,
         child: io_writer::ChildPtr,
         kind: Option<Kind>,
         args: core::fmt::Arguments<'_>,
-        _safeguard: OutputNeedsIOSafeGuard,
+        safeguard: OutputNeedsIOSafeGuard,
     ) -> Yield {
-        match self {
-            BuiltinIO::Fd(fd) => fd.writer.enqueue_fmt_bltn(child, fd.captured, kind, args),
-            _ => unreachable!("enqueue_fmt() on non-fd output; caller must check needs_io()"),
-        }
+        let (writer, captured) = Self::out_fd(interp, cmd, to, safeguard);
+        writer.enqueue_fmt_bltn(child, captured, kind, args)
     }
 }
 
 impl BuiltinInput {
     fn from_in_kind(ik: &InKind) -> BuiltinInput {
         match ik {
-            // `Arc::clone` bumps the IOReader refcount.
-            InKind::Fd(r) => BuiltinInput::Fd(Arc::clone(r)),
+            // `Rc::clone` bumps the IOReader refcount.
+            InKind::Fd(r) => BuiltinInput::Fd(r.clone()),
             InKind::Ignore => BuiltinInput::Ignore,
         }
     }
@@ -421,8 +450,28 @@ impl BuiltinInput {
 
 impl Builtin {
     #[inline]
-    pub(crate) fn args_slice(&self) -> &[*const c_char] {
+    pub(crate) fn args_slice(&self) -> &[Vec<u8>] {
         &self.args
+    }
+
+    /// [`parse_flags`](crate::shell::interpreter::parse_flags) over this
+    /// builtin's argv. Returns the index of the first non-flag argument
+    /// (`None`: there were no arguments at all).
+    pub(crate) fn parse_flags<O: crate::shell::interpreter::FlagParser>(
+        interp: &Interpreter,
+        cmd: NodeId,
+        opts: &mut O,
+    ) -> Result<Option<usize>, ParseError> {
+        let me = Self::of(interp, cmd);
+        let args = me.args_slice();
+        crate::shell::interpreter::parse_flags(opts, args)
+            .map(|rest| rest.map(|rest| args.len() - rest.len()))
+    }
+
+    /// `argv[1..].len()`.
+    #[inline]
+    pub(crate) fn argc(interp: &Interpreter, cmd: NodeId) -> usize {
+        Self::of(interp, cmd).args.len()
     }
 
     /// `PinnedArrayBuffer::drop`'s unpin would write to a `JSC::ArrayBuffer`
@@ -442,40 +491,27 @@ impl Builtin {
         }
     }
 
-    /// Borrow `argv[1..][idx]` as `&[u8]` (NUL excluded).
-    ///
-    /// Every entry in `self.args` borrows into the owning `Cmd`'s
-    /// `args: Vec<Vec<u8>>`, NUL-terminated by `Cmd::transition_to_exec` and
-    /// outliving this `Builtin` (the `Cmd` slot is freed only after
-    /// `Builtin::done`). Localises the per-callsite
-    /// `unsafe { CStr::from_ptr(...) }` that previously appeared at every
-    /// builtin's flag/operand parser.
-    ///
-    /// The returned slice's lifetime is intentionally **decoupled from
-    /// `&self`**: the raw `*const c_char` is copied out of `self.args` first,
-    /// so the borrow of `self` ends before `CStr::from_ptr`. This lets callers
-    /// hold the result across an `interp.as_cmd_mut(...)` reborrow (cat/ls/mv
-    /// flag loops). Soundness rests on the architectural invariant above —
-    /// argv storage is a separate heap allocation that is not freed or
-    /// reallocated while the `Builtin` is live — not on `'a`.
+    /// `arg` (a NUL-terminated argv entry) up to its first NUL — what
+    /// `execve` would see.
     #[inline]
-    pub(crate) fn arg_bytes<'a>(&self, idx: usize) -> &'a [u8] {
-        let p: *const c_char = self.args[idx];
-        // SAFETY: see doc comment — `p` is a valid NUL-terminated pointer
-        // into the Cmd's argv storage, live for the Builtin's lifetime.
-        unsafe { core::ffi::CStr::from_ptr(p) }.to_bytes()
+    pub(crate) fn arg_bytes_of(arg: &[u8]) -> &[u8] {
+        bun_core::slice_to_nul(arg)
     }
 
-    /// Borrow `argv[1..][idx]` as `&ZStr` (NUL-terminated view).
-    ///
-    /// Same invariant and lifetime decoupling as [`arg_bytes`]; for callers
-    /// that need to pass the argument to a `&ZStr`-taking syscall wrapper
-    /// without re-copying.
+    /// Borrow `argv[1..][idx]` as `&[u8]` (NUL excluded).
     #[inline]
-    pub(crate) fn arg_zstr<'a>(&self, idx: usize) -> &'a bun_core::ZStr {
-        let p: *const c_char = self.args[idx];
-        // SAFETY: see `arg_bytes` — valid NUL-terminated argv pointer.
-        bun_core::ZStr::from_cstr(unsafe { core::ffi::CStr::from_ptr(p) })
+    pub(crate) fn arg_bytes(&self, idx: usize) -> &[u8] {
+        Self::arg_bytes_of(&self.args[idx])
+    }
+
+    /// Borrow `argv[1..][idx]` as `&ZStr` (NUL-terminated view), for callers
+    /// that pass the argument to a `&ZStr`-taking syscall wrapper without
+    /// re-copying.
+    #[inline]
+    pub(crate) fn arg_zstr(&self, idx: usize) -> &bun_core::ZStr {
+        let arg = &self.args[idx];
+        debug_assert_eq!(arg.last(), Some(&0));
+        bun_core::ZStr::from_buf(arg, arg.len() - 1)
     }
 
     /// Construct a `Builtin` for `kind`, install it into the owning Cmd's
@@ -486,35 +522,28 @@ impl Builtin {
     pub(crate) fn init(interp: &Interpreter, cmd: NodeId, kind: Kind) -> Option<Yield> {
         use crate::shell::states::cmd::Exec;
 
-        // Borrow argv[1..] as `*const c_char` into the Cmd's `args` storage.
-        // The Cmd's `args: Vec<Vec<u8>>` are NUL-terminated by
-        // `Cmd::transition_to_exec` before this is called.
-        let (args, stdin, stdout, stderr) = {
-            let me = interp.as_cmd(cmd);
-            let mut argv: Vec<*const c_char> = Vec::with_capacity(me.args.len().saturating_sub(1));
-            for a in me.args.iter().skip(1) {
-                argv.push(a.as_ptr().cast::<c_char>());
-            }
-            // `Arc::clone` (inside `OutFd: Clone` / `InKind: Clone`) bumps
+        // Take argv[1..] from the Cmd's `args` (NUL-terminated by
+        // `Cmd::transition_to_exec` before this is called); argv[0] stays.
+        {
+            let mut me = interp.as_cmd_mut(cmd);
+            let args = me.args.split_off(1);
+            // `Rc::clone` (inside `OutFd: Clone` / `InKind: Clone`) bumps
             // the `IOWriter`/`IOReader` refcount; the builtin's `Drop`
             // decrements it symmetrically. No double-deref.
-            (
-                argv,
+            let (stdin, stdout, stderr) = (
                 BuiltinInput::from_in_kind(&me.io.stdin),
                 BuiltinIO::from_out_kind(&me.io.stdout, IoKind::Stdout),
                 BuiltinIO::from_out_kind(&me.io.stderr, IoKind::Stderr),
-            )
-        };
-
-        interp.as_cmd_mut(cmd).exec = Exec::Builtin(Box::new(Builtin {
-            kind,
-            args,
-            stdin,
-            stdout,
-            stderr,
-            err_buf: Vec::new(),
-            impl_: Self::make_impl(kind),
-        }));
+            );
+            me.exec = Exec::Builtin(Box::new(Builtin {
+                kind,
+                args,
+                stdin,
+                stdout,
+                stderr,
+                impl_: Self::make_impl(kind),
+            }));
+        }
 
         Self::init_redirections(interp, cmd, kind)
     }
@@ -523,7 +552,8 @@ impl Builtin {
     /// `2>&1` (`duplicate_out`).
     fn init_redirections(interp: &Interpreter, cmd: NodeId, kind: Kind) -> Option<Yield> {
         // `node` points into the AST arena which outlives every state node (see Cmd::next).
-        let node: &ast::Cmd = &*interp.as_cmd(cmd).node;
+        let node = interp.as_cmd(cmd).node;
+        let node: &ast::Cmd = node.get();
         let redirect = node.redirect;
 
         match &node.redirect_file {
@@ -543,7 +573,8 @@ impl Builtin {
                 // `&mut interp` open call below doesn't overlap a borrow into
                 // the Cmd node.
                 let path_buf: Vec<u8> = {
-                    let raw = &interp.as_cmd(cmd).redirection_file;
+                    let me = interp.as_cmd(cmd);
+                    let raw = &me.redirection_file;
                     let len = raw.len().saturating_sub(1);
                     let mut v = raw[..len].to_vec();
                     v.push(0);
@@ -634,10 +665,9 @@ impl Builtin {
                     }
                 };
 
-                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
                 if redirect.stdin() {
                     let r = IOReader::init(redirfd, evtloop);
-                    r.set_interp(interp_ptr);
+                    r.set_interp(interp);
                     Self::of_mut(interp, cmd).stdin = BuiltinInput::Fd(r);
                 }
 
@@ -658,17 +688,17 @@ impl Builtin {
                     },
                     evtloop,
                 );
-                redirect_writer.set_interp(interp_ptr);
+                redirect_writer.set_interp(interp);
 
                 if redirect.stdout() {
-                    let me = Self::of_mut(interp, cmd);
+                    let mut me = Self::of_mut(interp, cmd);
                     me.stdout = BuiltinIO::Fd(OutFd {
-                        writer: Arc::clone(&redirect_writer),
+                        writer: redirect_writer.clone(),
                         captured: None,
                     });
                 }
                 if redirect.stderr() {
-                    let me = Self::of_mut(interp, cmd);
+                    let mut me = Self::of_mut(interp, cmd);
                     me.stderr = BuiltinIO::Fd(OutFd {
                         writer: redirect_writer,
                         captured: None,
@@ -678,8 +708,6 @@ impl Builtin {
             Some(ast::Redirect::JsBuf(jsbuf)) => {
                 // ── JS object redirect (`> ${arraybuf}` / `> ${blob}`).
                 let idx = jsbuf.idx as usize;
-                // Safe accessor — single `unsafe` deref lives in
-                // `Interpreter::global_this_ref`.
                 let Some(global) = interp
                     .global_this_ref()
                     .filter(|_| idx < interp.jsobjs.len())
@@ -702,7 +730,7 @@ impl Builtin {
                         }
                         buf
                     };
-                    let me = Self::of_mut(interp, cmd);
+                    let mut me = Self::of_mut(interp, cmd);
                     if redirect.stdin() {
                         let Some(buf) = root() else {
                             return Some(Yield::failed());
@@ -721,21 +749,22 @@ impl Builtin {
                         };
                         me.stderr = BuiltinIO::ArrayBuf { buf, i: 0 };
                     }
-                } else if let Some(body) =
-                    crate::webcore::body::Value::from_request_or_response(jsval)
+                } else if let Some(taken) =
+                    crate::webcore::body::Value::with_request_or_response(jsval, |body| {
+                        let is_file_blob = matches!(body, crate::webcore::body::Value::Blob(b)
+                            if !b.needs_to_read_file());
+                        if (redirect.stdout() || redirect.stderr()) && !is_file_blob {
+                            return None;
+                        }
+                        Some(body.use_())
+                    })
                 {
-                    // SAFETY: returned a live JSC-owned `*mut Value` borrowed
-                    // from a Response/Request wrapper.
-                    let body = unsafe { &mut *body };
-                    let is_file_blob = matches!(body, crate::webcore::body::Value::Blob(b)
-                        if !b.needs_to_read_file());
-                    if (redirect.stdout() || redirect.stderr()) && !is_file_blob {
+                    let Some(original_blob) = taken else {
                         let _ = global.throw(format_args!(
                             "Cannot redirect stdout/stderr to an immutable blob. Expected a file"
                         ));
                         return Some(Yield::failed());
-                    }
-                    let original_blob = body.use_();
+                    };
                     if !redirect.stdin() && !redirect.stdout() && !redirect.stderr() {
                         drop(original_blob);
                         return None;
@@ -744,7 +773,7 @@ impl Builtin {
                         blob: original_blob.dupe(),
                     });
                     drop(original_blob);
-                    let me = Self::of_mut(interp, cmd);
+                    let mut me = Self::of_mut(interp, cmd);
                     if redirect.stdin() {
                         me.stdin = BuiltinInput::Blob(Arc::clone(&blob));
                     }
@@ -764,7 +793,7 @@ impl Builtin {
                     let theblob = Arc::new(BuiltinBlob {
                         blob: blob_ref.dupe(),
                     });
-                    let me = Self::of_mut(interp, cmd);
+                    let mut me = Self::of_mut(interp, cmd);
                     if redirect.stdin() {
                         me.stdin = BuiltinInput::Blob(theblob);
                     } else if redirect.stdout() {
@@ -783,7 +812,8 @@ impl Builtin {
             None if redirect.duplicate_out() => {
                 // `2>&1` (stderr=true,dup_out=true) → stderr := stdout
                 // `1>&2` (stdout=true,dup_out=true) → stdout := stderr
-                let me = Self::of_mut(interp, cmd);
+                let mut me = Self::of_mut(interp, cmd);
+                let me = &mut *me;
                 if redirect.stdout() {
                     me.stderr = me.stdout.dup_ref();
                 }
@@ -810,29 +840,23 @@ impl Builtin {
         use std::io::Write as _;
         let mut buf = Vec::new();
         let _ = buf.write_fmt(args);
-        if let Some(_safeguard) = interp.as_cmd(cmd).io.stderr.needs_io() {
+        let stderr = interp.as_cmd(cmd).io.stderr.clone();
+        if let OutKind::Fd(fd) = stderr {
             // Only the `Fd` arm transitions state.
             interp.as_cmd_mut(cmd).state = CmdState::WaitingWriteErr;
             let child = io_writer::ChildPtr::new(cmd, io_writer::WriterTag::Cmd);
-            // SAFETY: `OutKind::Fd` guaranteed by `needs_io()`.
-            if let OutKind::Fd(fd) = &interp.as_cmd(cmd).io.stderr {
-                return fd.writer.enqueue(child, fd.captured, &buf);
-            }
-            unreachable!()
+            return fd.writer.enqueue(child, fd.captured, &buf);
         }
         // No-IO path: append to the shell env's captured stderr and finish
         // synchronously with exit 1 (Cmd::on_io_writer_chunk's behaviour).
-        if let OutKind::Pipe = &interp.as_cmd(cmd).io.stderr {
-            // SAFETY: single trampoline frame; no other borrow of the env's
-            // (or its parent's) stderr buffer is live.
-            let stderr = unsafe {
-                interp
-                    .as_cmd_mut(cmd)
-                    .base
-                    .shell_mut()
-                    .buffered_stderr_mut()
-            };
-            stderr.append_slice(&buf);
+        if let OutKind::Pipe = stderr {
+            let _ = interp
+                .as_cmd(cmd)
+                .base
+                .shell()
+                .buffered_stderr
+                .borrow_mut()
+                .append_slice(&buf);
         }
         let parent = interp.as_cmd(cmd).base.parent;
         interp.child_done(parent, cmd, 1)
@@ -845,23 +869,25 @@ impl Builtin {
         Cmd::on_exec_done(interp, cmd, exit_code)
     }
 
-    /// Look up the Builtin inside a Cmd's `exec` slot.
+    /// Look up the Builtin inside a Cmd's `exec` slot. A `Ref` into the Cmd
+    /// node: it must be released before anything borrows that node mutably.
     #[inline]
     #[track_caller]
-    pub(crate) fn of<'a>(interp: &'a Interpreter, cmd: NodeId) -> &'a Builtin {
-        match &interp.as_cmd(cmd).exec {
-            crate::shell::states::cmd::Exec::Builtin(b) => b,
+    pub(crate) fn of(interp: &Interpreter, cmd: NodeId) -> Ref<'_, Builtin> {
+        Ref::map(interp.as_cmd(cmd), |c| match &c.exec {
+            crate::shell::states::cmd::Exec::Builtin(b) => &**b,
             _ => panic!("Cmd {} is not running a builtin", cmd),
-        }
+        })
     }
 
+    /// [`of`](Self::of), mutably.
     #[inline]
     #[track_caller]
-    pub(crate) fn of_mut<'a>(interp: &'a Interpreter, cmd: NodeId) -> &'a mut Builtin {
-        match &mut interp.as_cmd_mut(cmd).exec {
-            crate::shell::states::cmd::Exec::Builtin(b) => b,
+    pub(crate) fn of_mut(interp: &Interpreter, cmd: NodeId) -> RefMut<'_, Builtin> {
+        RefMut::map(interp.as_cmd_mut(cmd), |c| match &mut c.exec {
+            crate::shell::states::cmd::Exec::Builtin(b) => &mut **b,
             _ => panic!("Cmd {} is not running a builtin", cmd),
-        }
+        })
     }
 
     #[inline]
@@ -871,8 +897,8 @@ impl Builtin {
 
     /// Returns the bytes available on stdin when it is *not* an async fd
     /// (arraybuf / piped buf / blob).
-    pub(crate) fn read_stdin_no_io<'a>(interp: &'a Interpreter, cmd: NodeId) -> &'a [u8] {
-        match &Self::of(interp, cmd).stdin {
+    pub(crate) fn read_stdin_no_io(&self) -> &[u8] {
+        match &self.stdin {
             BuiltinInput::ArrayBuf { buf, .. } => buf.slice(),
             BuiltinInput::Blob(b) => b.blob.shared_view(),
             BuiltinInput::Fd(_) | BuiltinInput::Ignore => b"",
@@ -895,8 +921,9 @@ impl Builtin {
         }
         // Split-borrow the Cmd so `shell`
         // and the builtin's stdout/stderr are accessible simultaneously.
-        let cmd_node = interp.as_cmd_mut(cmd);
-        let shell = cmd_node.base.shell;
+        let mut cmd_node = interp.as_cmd_mut(cmd);
+        let cmd_node = &mut *cmd_node;
+        let shell = cmd_node.base.shell.borrow();
         let crate::shell::states::cmd::Exec::Builtin(me) = &mut cmd_node.exec else {
             panic!("Cmd {} is not running a builtin", cmd);
         };
@@ -904,17 +931,14 @@ impl Builtin {
             IoKind::Stdout => &mut me.stdout,
             IoKind::Stderr => &mut me.stderr,
         };
-        // SAFETY: `shell` is `cmd_node.base.shell`, live for the Cmd's lifetime.
-        unsafe { out.write_no_io_to(shell, buf) }
+        out.write_no_io_to(&shell, buf)
     }
 
-    /// Shell exec env of the owning Cmd.
+    /// Shell exec env of the owning Cmd (a clone of the handle, so the Cmd
+    /// node is not borrowed while it is used).
     #[inline]
-    pub fn shell<'a>(
-        interp: &'a Interpreter,
-        cmd: NodeId,
-    ) -> &'a crate::shell::interpreter::ShellExecEnv {
-        interp.as_cmd(cmd).base.shell()
+    pub fn shell(interp: &Interpreter, cmd: NodeId) -> crate::shell::interpreter::EnvRc {
+        Rc::clone(&interp.as_cmd(cmd).base.shell)
     }
 
     /// Event loop handle (forwarded from the interpreter).
@@ -929,53 +953,34 @@ impl Builtin {
     /// Cwd fd of the owning Cmd's shell env.
     #[inline]
     pub(crate) fn cwd(interp: &Interpreter, cmd: NodeId) -> bun_sys::Fd {
-        Self::shell(interp, cmd).cwd_fd
+        interp.as_cmd(cmd).base.shell().cwd_fd
     }
 
     /// Format `"{kind}: {fmt}"` into a fresh heap buffer.
-    ///
-    /// Stored on the `Builtin` so the returned `&[u8]` borrow stays valid
-    /// across the immediate `write_no_io` / `enqueue` call.
-    pub(crate) fn fmt_error_arena<'a>(
-        interp: &'a Interpreter,
-        cmd: NodeId,
-        kind: Option<Kind>,
-        args: core::fmt::Arguments<'_>,
-    ) -> &'a [u8] {
+    pub(crate) fn fmt_error_arena(kind: Option<Kind>, args: core::fmt::Arguments<'_>) -> Vec<u8> {
         use std::io::Write as _;
         let mut buf = Vec::new();
         if let Some(k) = kind {
             let _ = write!(&mut buf, "{}: ", k.as_str());
         }
         let _ = buf.write_fmt(args);
-        let me = Self::of_mut(interp, cmd);
-        me.err_buf = buf;
-        &me.err_buf
+        buf
     }
 
     /// Error messages formatted to match bash. Dispatches on the variant;
     /// `Sys` recurses into the system-error formatter.
-    pub(crate) fn shell_err_to_string<'a>(
-        interp: &'a Interpreter,
-        cmd: NodeId,
-        kind: Kind,
-        err: &crate::shell::ShellErr,
-    ) -> &'a [u8] {
+    pub(crate) fn shell_err_to_string(kind: Kind, err: &crate::shell::ShellErr) -> Vec<u8> {
         use crate::shell::ShellErr;
         match err {
             ShellErr::Sys(sys) => {
                 // `"{message}\n"` or `"{message}: {path}\n"`.
                 if sys.path.is_empty() {
                     Self::fmt_error_arena(
-                        interp,
-                        cmd,
                         Some(kind),
                         format_args!("{}\n", bstr::BStr::new(sys.message.byte_slice())),
                     )
                 } else {
                     Self::fmt_error_arena(
-                        interp,
-                        cmd,
                         Some(kind),
                         format_args!(
                             "{}: {}\n",
@@ -985,12 +990,9 @@ impl Builtin {
                     )
                 }
             }
-            ShellErr::Custom(s) => Self::fmt_error_arena(
-                interp,
-                cmd,
-                Some(kind),
-                format_args!("{}\n", bstr::BStr::new(s)),
-            ),
+            ShellErr::Custom(s) => {
+                Self::fmt_error_arena(Some(kind), format_args!("{}\n", bstr::BStr::new(s)))
+            }
         }
     }
 
@@ -998,36 +1000,19 @@ impl Builtin {
     /// `bun_sys::coreutils_error_map` so output matches GNU coreutils
     /// (e.g. `ENOENT` → "No such file or directory"); falls back to
     /// `"unknown error {errno}"` when unmapped.
-    pub(crate) fn task_error_to_string<'a>(
-        interp: &'a Interpreter,
-        cmd: NodeId,
-        kind: Kind,
-        err: &bun_sys::Error,
-    ) -> &'a [u8] {
+    pub(crate) fn task_error_to_string(kind: Kind, err: &bun_sys::Error) -> Vec<u8> {
         if let Some((_code, sys_errno)) = err.get_error_code_tag_name() {
             if let Some(message) = bun_sys::coreutils_error_map::get(sys_errno) {
                 if !err.path.is_empty() {
                     return Self::fmt_error_arena(
-                        interp,
-                        cmd,
                         Some(kind),
                         format_args!("{}: {}\n", bstr::BStr::new(&err.path[..]), message),
                     );
                 }
-                return Self::fmt_error_arena(
-                    interp,
-                    cmd,
-                    Some(kind),
-                    format_args!("{}\n", message),
-                );
+                return Self::fmt_error_arena(Some(kind), format_args!("{}\n", message));
             }
         }
-        Self::fmt_error_arena(
-            interp,
-            cmd,
-            Some(kind),
-            format_args!("unknown error {}\n", err.errno),
-        )
+        Self::fmt_error_arena(Some(kind), format_args!("unknown error {}\n", err.errno))
     }
 
     /// Shared failure path for builtins whose option parser returns
@@ -1044,23 +1029,17 @@ impl Builtin {
     ) -> Yield {
         let buf: Vec<u8> = match e {
             ParseError::IllegalOption(_) => Self::fmt_error_arena(
-                interp,
-                cmd,
                 Some(kind),
                 format_args!("illegal option -- {}\n", bstr::BStr::new(e.opt())),
-            )
-            .to_vec(),
+            ),
             ParseError::ShowUsage => kind.usage_string().to_vec(),
             ParseError::Unsupported(_) => Self::fmt_error_arena(
-                interp,
-                cmd,
                 Some(kind),
                 format_args!(
                     "unsupported option, please open a GitHub issue -- {}\n",
                     bstr::BStr::new(e.opt())
                 ),
-            )
-            .to_vec(),
+            ),
         };
         set_wait_err();
         Self::write_failing_error(interp, cmd, &buf, 1)
@@ -1075,14 +1054,10 @@ impl Builtin {
         buf: &[u8],
         exit_code: crate::shell::ExitCode,
     ) -> Yield {
-        if let Some(safeguard) = Self::of(interp, cmd).stderr.needs_io() {
+        let needs_io = Self::of(interp, cmd).stderr.needs_io();
+        if let Some(safeguard) = needs_io {
             let child = io_writer::ChildPtr::new(cmd, io_writer::WriterTag::Builtin);
-            // Clone buf so the &mut on
-            // `stderr` doesn't overlap a borrow into `err_buf`.
-            let owned = buf.to_vec();
-            return Self::of_mut(interp, cmd)
-                .stderr
-                .enqueue(child, &owned, safeguard);
+            return Self::write_out(interp, cmd, IoKind::Stderr, child, buf, safeguard);
         }
         let _ = Self::write_no_io(interp, cmd, IoKind::Stderr, buf);
         Self::done(interp, cmd, exit_code)
@@ -1090,7 +1065,7 @@ impl Builtin {
 }
 
 // Cleanup: every `Impl` variant owns its state via `Box`/`Vec`/`Arc`, and
-// `BuiltinIO`/`BuiltinInput` hold `Arc<IOWriter>` / `Arc<IOReader>` /
+// `BuiltinIO`/`BuiltinInput` hold `Rc<IOWriter>` / `Rc<IOReader>` /
 // `PinnedArrayBuffer` / `Arc<BuiltinBlob>` whose `Drop` already decrements
 // the refcount. So cleanup is fully covered by `Drop` on `Box<Builtin>`
 // (called from `Cmd::deinit`). No explicit deinit needed.

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -3,7 +3,7 @@
 
 use bun_collections::VecExt;
 use bun_jsc::PinnedArrayBuffer;
-use bun_ptr::{JsCellRef, JsCellRefMut};
+use bun_ptr::{JsCellRef, JsCellRefMut, RefPtr};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -14,8 +14,8 @@ use crate::shell::interpreter::{
     shell_openat,
 };
 use crate::shell::io::{InKind, OutFd, OutKind};
-use crate::shell::io_reader::{IOReader, IOReaderRef};
-use crate::shell::io_writer::{self, IOWriter, IOWriterRef};
+use crate::shell::io_reader::IOReader;
+use crate::shell::io_writer::{self, IOWriter};
 use crate::shell::states::cmd::{Cmd, CmdState};
 use crate::shell::yield_::Yield;
 
@@ -278,7 +278,7 @@ pub enum BuiltinIO {
 
 /// Input stream of a builtin.
 pub enum BuiltinInput {
-    Fd(IOReaderRef),
+    Fd(RefPtr<IOReader>),
     ArrayBuf { buf: PinnedArrayBuffer, i: u32 },
     Blob(Arc<BuiltinBlob>),
     Ignore,
@@ -382,7 +382,10 @@ impl BuiltinIO {
 
     /// The writer and tee buffer, for callers holding the
     /// [`OutputNeedsIOSafeGuard`] that proves this is `Fd`.
-    fn out_fd(&self, _safeguard: OutputNeedsIOSafeGuard) -> (IOWriterRef, Option<CapturedBuf>) {
+    fn out_fd(
+        &self,
+        _safeguard: OutputNeedsIOSafeGuard,
+    ) -> (RefPtr<IOWriter>, Option<CapturedBuf>) {
         match self {
             BuiltinIO::Fd(fd) => (fd.writer.clone(), fd.captured.clone()),
             _ => unreachable!("non-fd output; caller must check needs_io()"),
@@ -396,7 +399,7 @@ impl Builtin {
         cmd: NodeId,
         to: IoKind,
         safeguard: OutputNeedsIOSafeGuard,
-    ) -> (IOWriterRef, Option<CapturedBuf>) {
+    ) -> (RefPtr<IOWriter>, Option<CapturedBuf>) {
         let me = Self::of(interp, cmd);
         match to {
             IoKind::Stdout => me.stdout.out_fd(safeguard),

--- a/src/runtime/shell/IO.rs
+++ b/src/runtime/shell/IO.rs
@@ -1,13 +1,13 @@
 //! Carries stdin/stdout/stderr for a state node.
 //!
-//! `IO` is a plain `Clone` value; `IOReader`/`IOWriter` are `Arc`-refcounted.
+//! `IO` is a plain `Clone` value; `IOReader`/`IOWriter` are `Rc`-refcounted.
 
 use bun_collections::VecExt;
 
-use crate::api::bun_spawn::stdio::{Capture, Stdio};
-use crate::shell::interpreter::OutputNeedsIOSafeGuard;
-use crate::shell::io_reader::IOReader;
-use crate::shell::io_writer::IOWriter;
+use crate::api::bun_spawn::stdio::Stdio;
+use crate::shell::interpreter::{CapturedBuf, OutputNeedsIOSafeGuard};
+use crate::shell::io_reader::IOReaderRef;
+use crate::shell::io_writer::IOWriterRef;
 use crate::shell::shell_body::subproc::ShellIO;
 
 #[derive(Clone, Default)]
@@ -29,7 +29,7 @@ impl IO {
 
     /// Maps the state-node IO triple onto
     /// `subproc::Stdio` for [`ShellSubprocess::spawn_async`], and stashes the
-    /// owning `IOWriter` Arcs on `shellio` so [`PipeReader`]'s captured-writer
+    /// owning `IOWriter` `Rc`s on `shellio` so [`PipeReader`]'s captured-writer
     /// path can tee subprocess output back into the JS-side buffers.
     pub(crate) fn to_subproc_stdio(&self, stdio: &mut [Stdio; 3], shellio: &mut ShellIO) {
         stdio[0] = self.stdin.to_subproc_stdio();
@@ -40,7 +40,7 @@ impl IO {
 
 #[derive(Clone, Default)]
 pub enum InKind {
-    Fd(std::sync::Arc<IOReader>),
+    Fd(IOReaderRef),
     #[default]
     Ignore,
 }
@@ -55,36 +55,12 @@ pub enum OutKind {
     Ignore,
 }
 
-// Clone: bitwise OK for `captured` — it is a non-owning backref into
-// `ShellExecEnv::_buffered_{stdout,stderr}`; the env owns the Vec. `writer`
-// is `Arc` so it ref-counts on clone.
 #[derive(Clone)]
 pub struct OutFd {
-    pub(crate) writer: std::sync::Arc<IOWriter>,
+    pub(crate) writer: IOWriterRef,
     /// If set, also append every chunk to this buffer (the JS-side captured
-    /// stdout/stderr). Points into `ShellExecEnv::_buffered_{stdout,stderr}`.
-    pub(crate) captured: Option<*mut Vec<u8>>,
-}
-
-impl OutFd {
-    /// Mutably borrow the JS-side captured stdout/stderr buffer if configured.
-    ///
-    /// `captured` is a non-owning backref into `ShellExecEnv::_buffered_*`
-    /// (see field doc); the owning `ShellExecEnv` outlives every `Cmd`/builtin
-    /// that holds an `OutFd`. Localises the per-callsite raw deref so callers
-    /// can `if let Some(buf) = fd.captured_mut() { buf.extend_from_slice(...) }`.
-    ///
-    /// # Safety
-    /// Caller must ensure no other `&`/`&mut` to the target `Vec<u8>` is live
-    /// (including via the parent `ShellExecEnv`) for the returned borrow's
-    /// lifetime. The `(&self) -> &mut T` shape cannot encode this, hence
-    /// `unsafe fn`.
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub(crate) unsafe fn captured_mut(&self) -> Option<&mut Vec<u8>> {
-        // SAFETY: caller contract — single-threaded shell, env outlives `self`.
-        self.captured.map(|p| unsafe { &mut *p })
-    }
+    /// stdout/stderr, shared with `ShellExecEnv::buffered_{stdout,stderr}`).
+    pub(crate) captured: Option<CapturedBuf>,
 }
 
 impl InKind {
@@ -106,10 +82,8 @@ impl InKind {
 impl OutFd {
     fn memory_cost(&self) -> usize {
         let mut cost = self.writer.memory_cost();
-        if let Some(captured) = self.captured {
-            // SAFETY: `captured` points into a live `ShellExecEnv` buffer;
-            // the env outlives the IO that borrows it.
-            cost += unsafe { (*captured).memory_cost() };
+        if let Some(captured) = &self.captured {
+            cost += captured.borrow().memory_cost();
         }
         cost
     }
@@ -133,20 +107,15 @@ impl OutKind {
         }
     }
 
-    /// Retains the `IOWriter` Arc on
+    /// Retains the `IOWriter` on
     /// `shellio` so the subprocess's `PipeReader::captured_writer` can drain
     /// captured bytes into it after the spawn returns.
-    fn to_subproc_stdio(&self, shellio: &mut Option<std::sync::Arc<IOWriter>>) -> Stdio {
+    fn to_subproc_stdio(&self, shellio: &mut Option<IOWriterRef>) -> Stdio {
         match self {
             OutKind::Fd(val) => {
-                *shellio = Some(std::sync::Arc::clone(&val.writer));
-                if let Some(cap) = val.captured {
-                    #[cfg(not(any(target_os = "linux", target_os = "android")))]
-                    let _ = cap;
-                    Stdio::Capture(Capture {
-                        #[cfg(any(target_os = "linux", target_os = "android"))]
-                        buf: cap,
-                    })
+                *shellio = Some(val.writer.clone());
+                if val.captured.is_some() {
+                    Stdio::Capture
                 } else {
                     // `IOWriter::fd()` (IOWriter.rs) returns `Fd::INVALID`
                     // once the fd has been handed off to libuv, so the

--- a/src/runtime/shell/IO.rs
+++ b/src/runtime/shell/IO.rs
@@ -3,11 +3,12 @@
 //! `IO` is a plain `Clone` value; `IOReader`/`IOWriter` are `Rc`-refcounted.
 
 use bun_collections::VecExt;
+use bun_ptr::RefPtr;
 
 use crate::api::bun_spawn::stdio::Stdio;
 use crate::shell::interpreter::{CapturedBuf, OutputNeedsIOSafeGuard};
-use crate::shell::io_reader::IOReaderRef;
-use crate::shell::io_writer::IOWriterRef;
+use crate::shell::io_reader::IOReader;
+use crate::shell::io_writer::IOWriter;
 use crate::shell::shell_body::subproc::ShellIO;
 
 #[derive(Clone, Default)]
@@ -40,7 +41,7 @@ impl IO {
 
 #[derive(Clone, Default)]
 pub enum InKind {
-    Fd(IOReaderRef),
+    Fd(RefPtr<IOReader>),
     #[default]
     Ignore,
 }
@@ -57,7 +58,7 @@ pub enum OutKind {
 
 #[derive(Clone)]
 pub struct OutFd {
-    pub(crate) writer: IOWriterRef,
+    pub(crate) writer: RefPtr<IOWriter>,
     /// If set, also append every chunk to this buffer (the JS-side captured
     /// stdout/stderr, shared with `ShellExecEnv::buffered_{stdout,stderr}`).
     pub(crate) captured: Option<CapturedBuf>,
@@ -110,7 +111,7 @@ impl OutKind {
     /// Retains the `IOWriter` on
     /// `shellio` so the subprocess's `PipeReader::captured_writer` can drain
     /// captured bytes into it after the spawn returns.
-    fn to_subproc_stdio(&self, shellio: &mut Option<IOWriterRef>) -> Stdio {
+    fn to_subproc_stdio(&self, shellio: &mut Option<RefPtr<IOWriter>>) -> Stdio {
         match self {
             OutKind::Fd(val) => {
                 *shellio = Some(val.writer.clone());

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -1,8 +1,10 @@
 //! Similar to `IOWriter` but for reading.
 //!
-//! *NOTE* This type is reference counted via `Arc`; see the `Drop` impl note.
+//! *NOTE* This type is reference counted via `Rc`; see the `Drop` impl note.
 
-use core::cell::UnsafeCell;
+use bun_jsc::JsCell;
+use bun_ptr::{CellRefCounted as _, RefPtr, ThisPtr};
+use core::cell::{Cell, RefCell};
 #[cfg(not(windows))]
 use core::ffi::c_void;
 
@@ -39,87 +41,39 @@ type Readers = Vec<ChildPtr>;
 
 pub(crate) type ReaderImpl = bun_io::BufferedReader;
 
-struct State {
+/// Read callbacks re-enter the reader (`add_reader`/`remove_reader` from a
+/// child's chunk handler), so every field is interior-mutable behind `&self`
+/// and no borrow is held across a callback.
+#[derive(bun_ptr::CellRefCounted)]
+pub struct IOReader {
+    ref_count: Cell<u32>,
+    self_root: bun_ptr::SelfRoot<IOReader>,
+    /// The io-layer reader. Its callbacks arrive while the read loop holds a
+    /// `&mut` to it (see the `BufferedReaderParent` aliasing contract), so it
+    /// sits in its own cell that the callbacks never touch.
+    reader: JsCell<ReaderImpl>,
     fd: Fd,
-    buf: Vec<u8>,
-    readers: Readers,
+    buf: RefCell<Vec<u8>>,
+    readers: RefCell<Readers>,
     /// The raw `sys::Error`. `SystemError` is not `Clone`
     /// in the Rust port yet, so we keep the source error to re-derive a fresh
     /// `SystemError` per callee in `on_reader_done_cb`.
-    raw_err: Option<sys::Error>,
+    raw_err: RefCell<Option<sys::Error>>,
     evtloop: EventLoopHandle,
     #[cfg(windows)]
-    is_reading: bool,
-    /// Weak self-ref so `keepalive()` can bump the strong count from `&self`
-    /// without unsafe Arc-pointer reconstruction. Set via `Arc::new_cyclic` in
-    /// `init()` (the sole constructor).
-    self_weak: std::sync::Weak<IOReader>,
-    read_guards: Vec<std::sync::Arc<IOReader>>,
+    is_reading: Cell<bool>,
     /// Backref so async read callbacks can drive `Yield::run`. See
     /// `IOWriter::interp`.
-    interp: Option<bun_ptr::ParentRef<Interpreter>>,
+    interp: Cell<Option<bun_ptr::ParentRef<Interpreter>>>,
 }
-
-pub struct IOReader {
-    /// Split out of `State` so `state()`'s `&mut State` never overlaps the
-    /// `&mut ReaderImpl` the read-loop caller holds while invoking vtable
-    /// callbacks (see `BufferedReaderParent` aliasing contract). Both cells
-    /// root at SharedReadWrite; callbacks touch only `state` fields.
-    reader: UnsafeCell<ReaderImpl>,
-    state: UnsafeCell<State>,
-}
-
-// SAFETY: shell is single-threaded; `Arc` is used purely for refcounting.
-unsafe impl Send for IOReader {}
-// SAFETY: shell is single-threaded; `Arc` is used purely for refcounting.
-unsafe impl Sync for IOReader {}
 
 impl IOReader {
     #[inline]
-    #[allow(clippy::mut_from_ref)] // interior mutability via UnsafeCell; single-threaded
-    fn state(&self) -> &mut State {
-        // SAFETY: shell is single-threaded; no overlapping borrow of `state`
-        // escapes a callback (see struct doc comment).
-        unsafe { &mut *self.state.get() }
+    fn this_ptr(&self) -> ThisPtr<IOReader> {
+        self.self_root.this_ptr(self)
     }
 
-    #[inline]
-    #[allow(clippy::mut_from_ref)] // interior mutability via UnsafeCell; single-threaded
-    fn reader(&self) -> &mut ReaderImpl {
-        // SAFETY: single-threaded. Split into its own cell so a `&mut ReaderImpl`
-        // held by the bun_io read loop never overlaps a `&mut State` derived in a
-        // vtable callback (see struct doc comment).
-        //
-        // MUST NOT be invoked from within a `BufferedReaderParent` vtable
-        // callback (`on_read_chunk_cb`/`on_reader_done_cb`/`on_reader_error`):
-        // the read loop already holds a live `&mut ReaderImpl` on its stack
-        // while the callback runs (PipeReader.rs aliasing contract), so
-        // re-deriving here would create two simultaneous `&mut` to the same
-        // BufferedReader = Stacked-Borrows UB.
-        unsafe { &mut *self.reader.get() }
-    }
-
-    /// Bump our own Arc strong count. Held across re-entrant `run_yield` calls
-    /// whose child callback may drop the last external ref and free us
-    /// mid-method.
-    #[inline]
-    fn keepalive(&self) -> std::sync::Arc<IOReader> {
-        self.state()
-            .self_weak
-            .upgrade()
-            .expect("IOReader::keepalive after last Arc dropped")
-    }
-
-    fn push_read_guard(&self) {
-        let guard = self.keepalive();
-        self.state().read_guards.push(guard);
-    }
-
-    fn pop_read_guard(&self) -> Option<std::sync::Arc<IOReader>> {
-        self.state().read_guards.pop()
-    }
-
-    pub(crate) fn init(fd: Fd, evtloop: EventLoopHandle) -> std::sync::Arc<IOReader> {
+    pub(crate) fn init(fd: Fd, evtloop: EventLoopHandle) -> IOReaderRef {
         let mut reader = ReaderImpl::init::<IOReader>();
         #[cfg(not(windows))]
         {
@@ -131,56 +85,42 @@ impl IOReader {
         {
             reader.set_source(bun_io::Source::File(bun_io::Source::open_file(fd)));
         }
-        let this = std::sync::Arc::new_cyclic(|w| IOReader {
-            reader: UnsafeCell::new(reader),
-            state: UnsafeCell::new(State {
-                fd,
-                buf: Vec::new(),
-                readers: Readers::new(),
-                raw_err: None,
-                evtloop,
-                #[cfg(windows)]
-                is_reading: false,
-                self_weak: std::sync::Weak::clone(w),
-                read_guards: Vec::new(),
-                interp: None,
-            }),
+        let this = RefPtr::new_cyclic(|self_root| IOReader {
+            ref_count: Cell::new(1),
+            self_root,
+            reader: JsCell::new(reader),
+            fd,
+            buf: RefCell::new(Vec::new()),
+            readers: RefCell::new(Readers::new()),
+            raw_err: RefCell::new(None),
+            evtloop,
+            #[cfg(windows)]
+            is_reading: Cell::new(false),
+            interp: Cell::new(None),
         });
-        // NOTE: set the parent backref after Arc allocation so the
-        // address is stable.
-        let parent: *const IOReader = std::sync::Arc::as_ptr(&this);
-        // SAFETY: `Arc::as_ptr` yields `*const IOReader`, but every field of
-        // `IOReader` is `UnsafeCell`, so all mutation flows through interior
-        // mutability (SharedReadWrite). The `*mut` cast exists solely to satisfy
-        // `set_parent`'s `*mut` signature for the vtable backref; the
-        // `BufferedReaderParent` callbacks only ever reborrow it as `&Self` to
-        // call `&self` methods — no `&mut IOReader` is materialized from it.
-        unsafe { (*this.reader.get()).set_parent(parent.cast_mut().cast()) };
+        let parent: *mut IOReader = this.as_ptr();
+        this.reader.with_mut(|r| r.set_parent(parent.cast()));
         crate::shell_log!("IOReader(0x{:x}, fd={}) create", parent as usize, fd);
-        this
+        IOReaderRef(this)
     }
 
-    /// # Safety
-    /// `interp` must be null or point to the live owning `Interpreter` (it
-    /// owns the IO struct that holds this `Arc`) for the lifetime of this
-    /// reader; single-threaded.
+    /// Stash the interpreter backref so async read callbacks can drive
+    /// `Yield::run`. `interp` owns (through its IO structs) every handle to
+    /// this reader.
     #[inline]
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn set_interp(&self, interp: *mut Interpreter) {
-        // SAFETY: precondition above.
-        self.state().interp = unsafe { bun_ptr::ParentRef::from_nullable(interp) };
+    pub(crate) fn set_interp(&self, interp: &Interpreter) {
+        self.interp.set(Some(bun_ptr::ParentRef::new(interp)));
     }
 
     #[inline]
     pub(crate) fn fd(&self) -> Fd {
-        self.state().fd
+        self.fd
     }
 
     pub(crate) fn memory_cost(&self) -> usize {
-        let s = self.state();
         core::mem::size_of::<IOReader>()
-            + s.buf.capacity()
-            + s.readers.capacity() * core::mem::size_of::<ChildPtr>()
+            + self.buf.borrow().capacity()
+            + self.readers.borrow().capacity() * core::mem::size_of::<ChildPtr>()
     }
 
     /// `bun_io::EventLoopHandle` is an opaque `*mut c_void` that the io-layer
@@ -189,9 +129,7 @@ impl IOReader {
     /// vtable can recover it.
     #[inline]
     fn io_evtloop(&self) -> bun_io::EventLoopHandle {
-        // SAFETY: `bun_io::EventLoopHandle` stores `*mut c_void` purely for
-        // type-erasure; vtable consumers treat the pointee as read-only
-        self.state().evtloop.as_event_loop_ctx()
+        self.evtloop.as_event_loop_ctx()
     }
 
     /// Only does things on windows.
@@ -199,37 +137,43 @@ impl IOReader {
     fn set_reading(&self, reading: bool) {
         #[cfg(windows)]
         {
-            self.state().is_reading = reading;
+            self.is_reading.set(reading);
         }
         let _ = reading;
     }
 
     /// Idempotent function to start the reading.
+    ///
+    /// Not called from within a `BufferedReaderParent` callback: the read
+    /// loop already holds the reader mutably there.
     pub(crate) fn start(&self) -> Yield {
         #[cfg(not(windows))]
         {
-            let r = self.reader();
-            let need_start = match &r.handle {
-                bun_io::pipes::PollOrFd::Closed => true,
-                bun_io::pipes::PollOrFd::Poll(p) => !p.is_registered(),
-                bun_io::pipes::PollOrFd::Fd(_) => true,
-            };
-            if need_start {
-                let fd = self.state().fd;
-                if let Err(e) = r.start(fd, true) {
-                    self.on_reader_error(&e);
+            let fd = self.fd;
+            let res = self.reader.with_mut(|r| {
+                let need_start = match &r.handle {
+                    bun_io::pipes::PollOrFd::Closed => true,
+                    bun_io::pipes::PollOrFd::Poll(p) => !p.is_registered(),
+                    bun_io::pipes::PollOrFd::Fd(_) => true,
+                };
+                if need_start {
+                    r.start(fd, true)
+                } else {
+                    Ok(())
                 }
+            });
+            if let Err(e) = res {
+                self.on_reader_error(&e);
             }
             return Yield::suspended();
         }
         #[cfg(windows)]
         {
-            let s = self.state();
-            if s.is_reading {
+            if self.is_reading.get() {
                 return Yield::suspended();
             }
-            s.is_reading = true;
-            if let Err(e) = self.reader().start_with_current_pipe() {
+            self.is_reading.set(true);
+            if let Err(e) = self.reader.with_mut(|r| r.start_with_current_pipe()) {
                 self.on_reader_error(&e);
                 return Yield::failed();
             }
@@ -239,54 +183,52 @@ impl IOReader {
 
     /// Only adds if not already present.
     pub(crate) fn add_reader(&self, reader: ChildPtr) {
-        let s = self.state();
-        if !s.readers.contains(&reader) {
-            s.readers.push(reader);
+        let mut readers = self.readers.borrow_mut();
+        if !readers.contains(&reader) {
+            readers.push(reader);
         }
     }
 
     /// Unregister a listener; no-op if it was never added.
     pub(crate) fn remove_reader(&self, reader: ChildPtr) {
-        let s = self.state();
-        if let Some(idx) = s.readers.iter().position(|r| *r == reader) {
-            s.readers.swap_remove(idx);
+        let mut readers = self.readers.borrow_mut();
+        if let Some(idx) = readers.iter().position(|r| *r == reader) {
+            readers.swap_remove(idx);
         }
     }
 
     /// The `BufferedReader.onReadChunk` hook.
     fn on_read_chunk_cb(&self, chunk: &[u8], has_more: bun_io::ReadState) -> bool {
         // `dispatch_read_chunk` → `Cat::on_io_reader_chunk` may drop the last
-        // external Arc; hold one across the whole body so the trailing
-        // `state()` accesses (and `run_yield`'s re-read of `interp`) see live
-        // memory.
-        let _keepalive = self.keepalive();
+        // external ref; hold one across the whole body so the trailing field
+        // accesses (and `run_yield`'s re-read of `interp`) see live memory.
+        let _keepalive = self.this_ptr().ref_guard();
         self.set_reading(false);
-        // NOTE: reshaped for borrowck — `dispatch_read_chunk`/`run_yield`
-        // both re-derive `state()` (and the interpreter callback may re-enter
-        // `add_reader`/`remove_reader`), so we must NOT hold a long-lived
-        // `&mut State` across the dispatch. Re-derive `state()` per access
-        // instead.
+        // The interpreter callback may re-enter `add_reader`/`remove_reader`,
+        // so `readers` is re-borrowed per access rather than held across the
+        // dispatch.
         let mut i = 0usize;
-        while i < self.state().readers.len() {
-            let r = self.state().readers[i];
-            let interp = self.state().interp;
+        loop {
+            let Some(r) = self.readers.borrow().get(i).copied() else {
+                break;
+            };
+            let interp = self.interp.get();
             let mut remove = false;
             self.run_yield(dispatch_read_chunk(r, chunk, &mut remove, interp));
             if remove {
-                self.state().readers.swap_remove(i);
+                self.readers.borrow_mut().swap_remove(i);
             } else {
                 i += 1;
             }
         }
 
         let should_continue = has_more != bun_io::ReadState::Eof;
-        if should_continue && !self.state().readers.is_empty() {
+        if should_continue && !self.readers.borrow().is_empty() {
             self.set_reading(true);
             // NOTE: no explicit re-arm (`registerPoll()` on posix /
-            // `startWithCurrentPipe()` on windows) here: that would re-derive
-            // a second `&mut ReaderImpl` while the bun_io read loop still
-            // holds one on its stack (PipeReader.rs aliasing contract) —
-            // Stacked-Borrows UB.
+            // `startWithCurrentPipe()` on windows) here: that would touch the
+            // reader while the bun_io read loop still holds it mutably on its
+            // stack (PipeReader.rs aliasing contract).
             // On posix the re-arm is redundant: the read loop re-registers
             // itself after the callback returns based on the `bool` we return
             // (PipeReader.rs:731/755/846/920/986). On Windows the re-arm is
@@ -302,15 +244,14 @@ impl IOReader {
     }
 
     fn on_reader_error(&self, err: &sys::Error) {
-        // `dispatch_reader_done` may drop the last external Arc; keep `self`
+        // `dispatch_reader_done` may drop the last external ref; keep `self`
         // alive across the loop.
-        let _keepalive = self.keepalive();
+        let _keepalive = self.this_ptr().ref_guard();
         self.set_reading(false);
-        let s = self.state();
-        s.raw_err = Some(err.clone());
-        // NOTE: reshaped for borrowck — copy out before dispatching.
-        let readers: Vec<ChildPtr> = s.readers.clone();
-        let interp = s.interp;
+        *self.raw_err.borrow_mut() = Some(err.clone());
+        // Copy out before dispatching (callbacks may re-enter `remove_reader`).
+        let readers: Vec<ChildPtr> = self.readers.borrow().clone();
+        let interp = self.interp.get();
         for r in readers {
             // Re-derive a fresh SystemError per callee (see
             // IOWriter.on_error note).
@@ -321,18 +262,16 @@ impl IOReader {
 
     fn on_reader_done_cb(&self) {
         // `dispatch_reader_done` → `Cat::on_io_reader_done` drops Cat's
-        // `Arc<IOReader>`; if that was the last external ref, `self` is freed
-        // mid-loop and `run_yield`'s `state().interp` reads 0xdfdf poison.
-        // Hold a strong ref across the body.
-        let _keepalive = self.keepalive();
+        // `Rc<IOReader>`; if that was the last external ref, `self` would be
+        // freed mid-loop. Hold a strong ref across the body.
+        let _keepalive = self.this_ptr().ref_guard();
         self.set_reading(false);
-        let s = self.state();
-        let readers: Vec<ChildPtr> = s.readers.clone();
-        let interp = s.interp;
+        let readers: Vec<ChildPtr> = self.readers.borrow().clone();
+        let interp = self.interp.get();
         // `SystemError` isn't `Clone` yet, so we keep the source `sys::Error`
         // (which IS `Clone`) and re-derive a fresh `SystemError` per callee —
         // same approach as `on_reader_error`.
-        let raw_err = s.raw_err.clone();
+        let raw_err = self.raw_err.borrow().clone();
         for r in readers {
             let ee = raw_err.as_ref().map(|e| e.to_shell_system_error());
             self.run_yield(dispatch_reader_done(r, ee, interp));
@@ -340,7 +279,7 @@ impl IOReader {
     }
 
     fn run_yield(&self, y: Yield) {
-        let Some(interp) = self.state().interp else {
+        let Some(interp) = self.interp.get() else {
             debug_assert!(
                 matches!(y, Yield::Done | Yield::Suspended),
                 "IOReader async callback fired without interp backref"
@@ -348,7 +287,7 @@ impl IOReader {
             return;
         };
         // `ParentRef: Deref<Target=Interpreter>` — the interpreter owns the IO
-        // struct holding this Arc and outlives every IOReader. Single-threaded.
+        // struct holding this reader and outlives every IOReader. Single-threaded.
         y.run(&interp);
     }
 }
@@ -357,21 +296,43 @@ impl IOReader {
 // BufferedReaderParent — wires the bun_io BufferedReader vtable
 // ──────────────────────────────────────────────────────────────────────────
 
-// Derefs `this` only to call `&self` inherent methods (autoref → `&*this`);
-// no `&mut IOReader` is materialized, satisfying the init() *const→*mut
-// invariant. Aliasing with the caller's live `&mut ReaderImpl` is handled by
-// the state/reader UnsafeCell split — callbacks touch only `state`, never
-// `reader()`.
+// Every hook views `this` as `&Self` (via `ThisPtr`); no `&mut IOReader` is
+// materialized. Aliasing with the caller's live `&mut ReaderImpl` is handled
+// by the `reader` cell split — callbacks touch only the other fields.
 bun_io::impl_buffered_reader_parent! {
     ShellIoReader for IOReader;
+    borrow = this;
     has_on_read_chunk = true;
-    on_read_chunk   = |this, chunk, has_more| (*this).on_read_chunk_cb(&chunk, has_more);
-    on_reader_done  = |this| (*this).on_reader_done_cb();
-    on_reader_error = |this, err| (*this).on_reader_error(&err);
-    loop_           = |this| (*this).io_evtloop().native_loop();
-    event_loop      = |this| (*this).io_evtloop();
-    ref_            = |this| (*this).push_read_guard();
-    deref           = |this| drop((*this).pop_read_guard());
+    on_read_chunk   = |this, chunk, has_more| this.on_read_chunk_cb(&chunk, has_more);
+    on_reader_done  = |this| this.on_reader_done_cb();
+    on_reader_error = |this, err| this.on_reader_error(&err);
+    loop_           = |this| this.io_evtloop().native_loop();
+    event_loop      = |this| this.io_evtloop();
+    ref_            = |this| this.ref_();
+    deref           = |this| IOReader::deref_nn(this.into());
+}
+
+/// One owned ref on an [`IOReader`]; clone takes another, drop releases it.
+pub struct IOReaderRef(RefPtr<IOReader>);
+
+impl Clone for IOReaderRef {
+    fn clone(&self) -> Self {
+        IOReaderRef(self.0.dupe_ref())
+    }
+}
+
+impl Drop for IOReaderRef {
+    fn drop(&mut self) {
+        self.0.deref();
+    }
+}
+
+impl core::ops::Deref for IOReaderRef {
+    type Target = IOReader;
+    #[inline]
+    fn deref(&self) -> &IOReader {
+        self.0.data()
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -381,30 +342,31 @@ bun_io::impl_buffered_reader_parent! {
 impl Drop for IOReader {
     fn drop(&mut self) {
         // The bun_io read loop brackets every event-loop entry with the
-        // parent `ref_`/`deref` hooks (`read_guards`), so the last ref never
+        // parent `ref_`/`deref` hooks (our refcount), so the last ref never
         // drops while BufferedReader is still iterating.
-        let s = self.state.get_mut();
-        let r = self.reader.get_mut();
-        if s.fd != Fd::INVALID {
-            #[cfg(windows)]
-            {
-                // windows reader closes the file descriptor
-                if r.source.is_some() && !r.source.as_ref().is_some_and(|src| src.is_closed()) {
-                    r.close_impl::<false>();
+        let fd = self.fd;
+        self.reader.with_mut(|r| {
+            if fd != Fd::INVALID {
+                #[cfg(windows)]
+                {
+                    // windows reader closes the file descriptor
+                    if r.source.is_some() && !r.source.as_ref().is_some_and(|src| src.is_closed()) {
+                        r.close_impl::<false>();
+                    }
+                }
+                #[cfg(not(windows))]
+                {
+                    // We cleared CLOSE_HANDLE in init(), so reader Drop will not
+                    // return the FilePoll to its pool. Do it explicitly (without
+                    // closing the fd — we own that and close it ourselves below).
+                    if matches!(r.handle, bun_io::pipes::PollOrFd::Poll(_)) {
+                        r.handle.close_impl(None, None::<fn(*mut c_void)>, false);
+                    }
+                    let _ = sys::close(fd);
                 }
             }
-            #[cfg(not(windows))]
-            {
-                // We cleared CLOSE_HANDLE in init(), so reader Drop will not
-                // return the FilePoll to its pool. Do it explicitly (without
-                // closing the fd — we own that and close it ourselves below).
-                if matches!(r.handle, bun_io::pipes::PollOrFd::Poll(_)) {
-                    r.handle.close_impl(None, None::<fn(*mut c_void)>, false);
-                }
-                let _ = sys::close(s.fd);
-            }
-        }
-        r.disable_keeping_process_alive(());
+            r.disable_keeping_process_alive(());
+        });
         // `reader` Drop handles its own deinit.
     }
 }

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -3,8 +3,9 @@
 //! *NOTE* This type is reference counted via `Rc`; see the `Drop` impl note.
 
 use bun_jsc::JsCell;
+use bun_ptr::JsRefCell;
 use bun_ptr::{CellRefCounted as _, RefPtr, ThisPtr};
-use core::cell::{Cell, RefCell};
+use core::cell::Cell;
 #[cfg(not(windows))]
 use core::ffi::c_void;
 
@@ -53,12 +54,12 @@ pub struct IOReader {
     /// sits in its own cell that the callbacks never touch.
     reader: JsCell<ReaderImpl>,
     fd: Fd,
-    buf: RefCell<Vec<u8>>,
-    readers: RefCell<Readers>,
+    buf: JsRefCell<Vec<u8>>,
+    readers: JsRefCell<Readers>,
     /// The raw `sys::Error`. `SystemError` is not `Clone`
     /// in the Rust port yet, so we keep the source error to re-derive a fresh
     /// `SystemError` per callee in `on_reader_done_cb`.
-    raw_err: RefCell<Option<sys::Error>>,
+    raw_err: JsRefCell<Option<sys::Error>>,
     evtloop: EventLoopHandle,
     #[cfg(windows)]
     is_reading: Cell<bool>,
@@ -90,9 +91,9 @@ impl IOReader {
             self_root,
             reader: JsCell::new(reader),
             fd,
-            buf: RefCell::new(Vec::new()),
-            readers: RefCell::new(Readers::new()),
-            raw_err: RefCell::new(None),
+            buf: JsRefCell::new(Vec::new()),
+            readers: JsRefCell::new(Readers::new()),
+            raw_err: JsRefCell::new(None),
             evtloop,
             #[cfg(windows)]
             is_reading: Cell::new(false),

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -74,7 +74,7 @@ impl IOReader {
         self.self_root.this_ptr(self)
     }
 
-    pub(crate) fn init(fd: Fd, evtloop: EventLoopHandle) -> IOReaderRef {
+    pub(crate) fn init(fd: Fd, evtloop: EventLoopHandle) -> RefPtr<IOReader> {
         let mut reader = ReaderImpl::init::<IOReader>();
         #[cfg(not(windows))]
         {
@@ -102,7 +102,7 @@ impl IOReader {
         let parent: *mut IOReader = this.as_ptr();
         this.reader.with_mut(|r| r.set_parent(parent.cast()));
         crate::shell_log!("IOReader(0x{:x}, fd={}) create", parent as usize, fd);
-        IOReaderRef(this)
+        this
     }
 
     /// Stash the interpreter backref so async read callbacks can drive
@@ -203,7 +203,7 @@ impl IOReader {
         // `dispatch_read_chunk` → `Cat::on_io_reader_chunk` may drop the last
         // external ref; hold one across the whole body so the trailing field
         // accesses (and `run_yield`'s re-read of `interp`) see live memory.
-        let _keepalive = self.this_ptr().ref_guard();
+        let _keepalive = RefPtr::from_this(self.this_ptr());
         self.set_reading(false);
         // The interpreter callback may re-enter `add_reader`/`remove_reader`,
         // so `readers` is re-borrowed per access rather than held across the
@@ -247,7 +247,7 @@ impl IOReader {
     fn on_reader_error(&self, err: &sys::Error) {
         // `dispatch_reader_done` may drop the last external ref; keep `self`
         // alive across the loop.
-        let _keepalive = self.this_ptr().ref_guard();
+        let _keepalive = RefPtr::from_this(self.this_ptr());
         self.set_reading(false);
         *self.raw_err.borrow_mut() = Some(err.clone());
         // Copy out before dispatching (callbacks may re-enter `remove_reader`).
@@ -265,7 +265,7 @@ impl IOReader {
         // `dispatch_reader_done` → `Cat::on_io_reader_done` drops Cat's
         // `Rc<IOReader>`; if that was the last external ref, `self` would be
         // freed mid-loop. Hold a strong ref across the body.
-        let _keepalive = self.this_ptr().ref_guard();
+        let _keepalive = RefPtr::from_this(self.this_ptr());
         self.set_reading(false);
         let readers: Vec<ChildPtr> = self.readers.borrow().clone();
         let interp = self.interp.get();
@@ -311,29 +311,6 @@ bun_io::impl_buffered_reader_parent! {
     event_loop      = |this| this.io_evtloop();
     ref_            = |this| this.ref_();
     deref           = |this| IOReader::deref_nn(this.into());
-}
-
-/// One owned ref on an [`IOReader`]; clone takes another, drop releases it.
-pub struct IOReaderRef(RefPtr<IOReader>);
-
-impl Clone for IOReaderRef {
-    fn clone(&self) -> Self {
-        IOReaderRef(self.0.dupe_ref())
-    }
-}
-
-impl Drop for IOReaderRef {
-    fn drop(&mut self) {
-        self.0.deref();
-    }
-}
-
-impl core::ops::Deref for IOReaderRef {
-    type Target = IOReader;
-    #[inline]
-    fn deref(&self) -> &IOReader {
-        self.0.data()
-    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -14,8 +14,9 @@
 
 use bun_collections::VecExt;
 use bun_jsc::JsCell;
+use bun_ptr::JsRefCell;
 use bun_ptr::{RefPtr, ThisPtr};
-use core::cell::{Cell, RefCell};
+use core::cell::Cell;
 #[cfg(not(windows))]
 use core::ffi::c_void;
 
@@ -47,6 +48,10 @@ pub struct ChildPtr {
     /// `Readable::Pipe` ref on its `ShellSubprocess` until every chunk it
     /// queued has completed or been `cancel_chunks`ed.
     pub(crate) subproc: Option<bun_ptr::BackRef<PipeReader, bun_ptr::Root>>,
+    /// `tag == Builtin`: which of the builtin's queued chunks this is (0 = the
+    /// builtin itself). Chunks with different `seq` are distinct children, so
+    /// each gets its own completion.
+    pub(crate) seq: u32,
 }
 
 impl ChildPtr {
@@ -54,6 +59,7 @@ impl ChildPtr {
         node: NodeId::NONE,
         tag: WriterTag::Cmd,
         subproc: None,
+        seq: 0,
     };
 
     #[inline]
@@ -62,6 +68,19 @@ impl ChildPtr {
             node,
             tag,
             subproc: None,
+            seq: 0,
+        }
+    }
+
+    /// The `seq`th chunk queued by the builtin at `node` (see
+    /// [`OutputQueue`](crate::shell::interpreter::OutputQueue)).
+    #[inline]
+    pub(crate) const fn builtin_task(node: NodeId, seq: u32) -> ChildPtr {
+        ChildPtr {
+            node,
+            tag: WriterTag::Builtin,
+            subproc: None,
+            seq,
         }
     }
 
@@ -73,6 +92,7 @@ impl ChildPtr {
             node: NodeId::NONE,
             tag: WriterTag::Subproc,
             subproc: Some(pipe.into()),
+            seq: 0,
         }
     }
 
@@ -190,7 +210,7 @@ pub struct IOWriter {
     /// short `with_mut` scopes.
     writer: JsCell<WriterImpl>,
     fd: Cell<Fd>,
-    writers: RefCell<Writers>,
+    writers: JsRefCell<Writers>,
     /// The bytes being written. In its own cell because the io layer borrows
     /// it (`get_buffer`) for the duration of a write syscall.
     buf: JsCell<Vec<u8>>,
@@ -205,7 +225,7 @@ pub struct IOWriter {
     /// `handle_dead_writer`). The syscall error is kept (not the derived
     /// `SystemError`) so each rejected chunk gets its own freshly-derived
     /// `SystemError`.
-    err: RefCell<Option<sys::Error>>,
+    err: JsRefCell<Option<sys::Error>>,
     evtloop: EventLoopHandle,
     is_writing: Cell<bool>,
     started: Cell<bool>,
@@ -252,13 +272,13 @@ impl IOWriter {
             self_root,
             writer: JsCell::new(writer),
             fd: Cell::new(fd),
-            writers: RefCell::new(Writers::new()),
+            writers: JsRefCell::new(Writers::new()),
             buf: JsCell::new(Vec::new()),
             #[cfg(windows)]
             winbuf: JsCell::new(Vec::new()),
             writer_idx: Cell::new(0),
             total_bytes_written: Cell::new(0),
-            err: RefCell::new(None),
+            err: JsRefCell::new(None),
             evtloop,
             is_writing: Cell::new(false),
             started: Cell::new(false),
@@ -1219,7 +1239,9 @@ pub(crate) fn on_io_writer_chunk(
     use crate::shell::builtin::Builtin;
     use crate::shell::states::{cmd, cond_expr, pipeline};
     match child.tag {
-        WriterTag::Builtin => Builtin::on_io_writer_chunk(interp, child.node, written, err),
+        WriterTag::Builtin => {
+            Builtin::on_io_writer_chunk(interp, child.node, child.seq, written, err)
+        }
         WriterTag::Cmd => cmd::Cmd::on_io_writer_chunk(interp, child.node, written, err),
         WriterTag::CondExpr => {
             cond_expr::CondExpr::on_io_writer_chunk(interp, child.node, written, err)

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -190,14 +190,14 @@ pub(crate) fn on_poll(writer: &mut Poll, size_hint: isize, hup: bool) {
     let parent = writer.parent.expect("IOWriter writer.parent unset");
     // `parent` is the backref stashed via `set_parent` in `IOWriter::init`;
     // `writer` is a field of `*parent`, so the pointee is live.
-    let _keepalive = parent.this_ptr().ref_guard();
+    let _keepalive = RefPtr::from_this(parent.this_ptr());
     writer.on_poll(size_hint, hup);
 }
 
 /// Multiple state nodes share one writer and its chunk callbacks re-enter it
 /// (`enqueue` from inside `on_io_writer_chunk`), so every field is
 /// interior-mutable behind `&self` and no borrow is held across a callback.
-/// Intrusively refcounted: holders own an [`IOWriterRef`]; the io layer's
+/// Intrusively refcounted: holders own a `RefPtr<IOWriter>`; the io layer's
 /// per-write `ref_`/`deref` hooks and the keep-alive brackets below use the
 /// same count.
 #[derive(bun_ptr::CellRefCounted)]
@@ -256,7 +256,7 @@ impl IOWriter {
         self.flags.get().is_socket
     }
 
-    pub(crate) fn init(fd: Fd, flags: Flags, evtloop: EventLoopHandle) -> IOWriterRef {
+    pub(crate) fn init(fd: Fd, flags: Flags, evtloop: EventLoopHandle) -> RefPtr<IOWriter> {
         let mut writer = WriterImpl::default();
         // Tell the PipeWriter impl to *not* close the file descriptor.
         #[cfg(not(windows))]
@@ -288,7 +288,7 @@ impl IOWriter {
         let parent: *mut IOWriter = this.as_ptr();
         this.writer.with_mut(|w| w.set_parent(parent));
         crate::shell_log!("IOWriter(0x{:x}, fd={}) init", parent as usize, fd);
-        IOWriterRef(this)
+        this
     }
 
     /// Stash the interpreter backref so async poll callbacks can drive
@@ -718,7 +718,7 @@ impl IOWriter {
     /// The `BufferedWriter.onWrite` hook. Runs on the event loop when the fd
     /// is writable.
     fn on_write_pollable(this: ThisPtr<Self>, amount: usize, status: bun_io::WriteStatus) {
-        let _keepalive = this.ref_guard();
+        let _keepalive = RefPtr::from_this(this);
         let me: &Self = &this;
         me.on_write_pollable_impl(amount, status);
     }
@@ -846,7 +846,7 @@ impl IOWriter {
     /// the enqueuing child may be called back from inside its own `enqueue`;
     /// callers therefore hold no node borrow across `enqueue`.
     fn on_error(this: ThisPtr<Self>, err: &sys::Error) {
-        let _keepalive = this.ref_guard();
+        let _keepalive = RefPtr::from_this(this);
         let me: &Self = &this;
         me.on_error_impl(err);
     }
@@ -875,7 +875,7 @@ impl IOWriter {
     /// re-registration fails while other children are still queued, those are
     /// dispatched the way the async path dispatches them.
     fn on_sync_error(&self, child: ChildPtr, err: &sys::Error) -> Yield {
-        let _keepalive = self.this_ptr().ref_guard();
+        let _keepalive = RefPtr::from_this(self.this_ptr());
         let mut completion = None;
         for ptr in self.fail_pending_writers(err) {
             // `SystemError` owns `bun_core::String`s by value (no shared
@@ -1095,29 +1095,6 @@ bun_io::impl_buffered_writer_parent! {
     get_buffer = |this| this.get_buffer(),
     event_loop = |this| this.io_evtloop(),
     uv_loop    = |this| this.evtloop().uv_loop(),
-}
-
-/// One owned ref on an [`IOWriter`]; clone takes another, drop releases it.
-pub struct IOWriterRef(RefPtr<IOWriter>);
-
-impl Clone for IOWriterRef {
-    fn clone(&self) -> Self {
-        IOWriterRef(self.0.dupe_ref())
-    }
-}
-
-impl Drop for IOWriterRef {
-    fn drop(&mut self) {
-        self.0.deref();
-    }
-}
-
-impl core::ops::Deref for IOWriterRef {
-    type Target = IOWriter;
-    #[inline]
-    fn deref(&self) -> &IOWriter {
-        self.0.data()
-    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -9,11 +9,13 @@
 //!
 //! So `IOWriter` is essentially a writer queue to a file descriptor.
 //!
-//! We also make `IOWriter` reference counted (via `Arc` in the Rust port),
+//! We also make `IOWriter` reference counted (via `Rc` in the Rust port),
 //! this simplifies management of the file descriptor.
 
 use bun_collections::VecExt;
-use core::cell::UnsafeCell;
+use bun_jsc::JsCell;
+use bun_ptr::{RefPtr, ThisPtr};
+use core::cell::{Cell, RefCell};
 #[cfg(not(windows))]
 use core::ffi::c_void;
 
@@ -21,7 +23,8 @@ use core::ffi::c_void;
 use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
 use bun_sys::{self as sys, E, Fd};
 
-use crate::shell::interpreter::{EventLoopHandle, Interpreter, NodeId};
+use crate::shell::interpreter::{CapturedBuf, EventLoopHandle, Interpreter, NodeId};
+use crate::shell::subproc::PipeReader;
 use crate::shell::yield_::Yield;
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -33,24 +36,24 @@ use crate::shell::yield_::Yield;
 /// impl to dispatch to.
 ///
 /// The one tag that does **not** live in the NodeId arena is
-/// `WriterTag::Subproc` (the `subproc::CapturedWriter` embedded inside a
-/// heap-allocated `PipeReader`); for that variant the dispatch target is
-/// carried in `raw` instead of `node`.
+/// `WriterTag::Subproc` (the captured-output tee of a subprocess
+/// [`PipeReader`]); for that variant the dispatch target is carried in
+/// `subproc` instead of `node`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ChildPtr {
     pub node: NodeId,
     pub(crate) tag: WriterTag,
-    /// Only meaningful when `tag == Subproc` — `*mut subproc::PipeReader`.
-    /// `core::ptr::null_mut()` otherwise. Stored untyped to keep this header
-    /// free of a `subproc` dependency.
-    pub(crate) raw: *mut core::ffi::c_void,
+    /// Only set when `tag == Subproc`. The reader is kept alive by the
+    /// `Readable::Pipe` ref on its `ShellSubprocess` until every chunk it
+    /// queued has completed or been `cancel_chunks`ed.
+    pub(crate) subproc: Option<bun_ptr::BackRef<PipeReader, bun_ptr::Root>>,
 }
 
 impl ChildPtr {
     const NULL: ChildPtr = ChildPtr {
         node: NodeId::NONE,
         tag: WriterTag::Cmd,
-        raw: core::ptr::null_mut(),
+        subproc: None,
     };
 
     #[inline]
@@ -58,24 +61,24 @@ impl ChildPtr {
         ChildPtr {
             node,
             tag,
-            raw: core::ptr::null_mut(),
+            subproc: None,
         }
     }
 
     /// Construct a `ChildPtr` targeting a `subproc::PipeReader`'s captured
     /// writer (lives outside the NodeId arena).
     #[inline]
-    pub(crate) fn subproc_capture(cw: *mut core::ffi::c_void) -> ChildPtr {
+    pub(crate) fn subproc_capture(pipe: bun_ptr::ThisPtr<PipeReader>) -> ChildPtr {
         ChildPtr {
             node: NodeId::NONE,
             tag: WriterTag::Subproc,
-            raw: cw,
+            subproc: Some(pipe.into()),
         }
     }
 
     #[inline]
     fn is_null(&self) -> bool {
-        self.node == NodeId::NONE && self.raw.is_null()
+        self.node == NodeId::NONE && self.subproc.is_none()
     }
 }
 
@@ -87,8 +90,8 @@ pub enum WriterTag {
     Cmd,
     CondExpr,
     Pipeline,
-    /// `subproc::PipeReader::CapturedWriter` — heap-allocated, addressed via
-    /// `ChildPtr::raw` rather than `node`.
+    /// `subproc::PipeReader`'s captured-output tee — heap-allocated, addressed via
+    /// `ChildPtr::subproc` rather than `node`.
     Subproc,
 }
 
@@ -105,13 +108,13 @@ pub struct Flags {
 }
 
 /// One queued chunk: which child enqueued it, how many bytes (in `buf`), how
-/// many of those have been written so far, and an optional `Vec<u8>` to tee
+/// many of those have been written so far, and an optional buffer to tee
 /// into.
 struct Writer {
     ptr: ChildPtr,
     len: usize,
     written: usize,
-    bytelist: Option<*mut Vec<u8>>,
+    bytelist: Option<CapturedBuf>,
 }
 
 impl Writer {
@@ -129,16 +132,10 @@ impl Writer {
         self.ptr = ChildPtr::NULL;
     }
     /// Tee `chunk` into the optional capture buffer.
-    ///
-    /// `bytelist` (when set) points into a live `ShellExecEnv` `Bufio`
-    /// (`OutFd::captured` — see its doc); the env outlives every queued
-    /// `Writer`. Localises the per-callsite raw deref in
-    /// `do_file_write` / `on_write_pollable`.
     #[inline]
     fn tee(&self, chunk: &[u8]) {
-        if let Some(bl) = self.bytelist {
-            // SAFETY: see doc comment.
-            let _ = unsafe { (*bl).append_slice(chunk) };
+        if let Some(bl) = &self.bytelist {
+            let _ = bl.borrow_mut().append_slice(chunk);
         }
     }
 }
@@ -163,7 +160,7 @@ pub(crate) type WriterImpl = bun_io::pipe_writer::WindowsBufferedWriter<IOWriter
 #[cfg(not(windows))]
 pub(crate) type Poll = WriterImpl;
 
-/// Poll-dispatch entry for `SHELL_BUFFERED_WRITER`. Holds an extra Arc strong
+/// Poll-dispatch entry for `SHELL_BUFFERED_WRITER`. Holds an extra strong
 /// ref across `on_poll` so child `onIOWriterChunk` callbacks (via `bump()`)
 /// can drop the last external ref without freeing `self` while PipeWriter is
 /// still on the stack.
@@ -172,77 +169,63 @@ pub(crate) fn on_poll(writer: &mut Poll, size_hint: isize, hup: bool) {
     use bun_io::pipe_writer::PosixPipeWriter;
     let parent = writer.parent.expect("IOWriter writer.parent unset");
     // `parent` is the backref stashed via `set_parent` in `IOWriter::init`;
-    // `writer` is a field of `*parent`, so the pointee is live. Re-enter via
-    // `&self` (UnsafeCell aliasing model). `ParentRef::Deref → &IOWriter`.
-    let _keepalive = parent.keepalive();
+    // `writer` is a field of `*parent`, so the pointee is live.
+    let _keepalive = parent.this_ptr().ref_guard();
     writer.on_poll(size_hint, hup);
 }
 
-/// Mutable state. Wrapped in `UnsafeCell` so `Arc<IOWriter>`-shared callers can
-/// mutate via `&self` (single-threaded shell).
-struct State {
-    writer: WriterImpl,
-    fd: Fd,
-    writers: Writers,
-    buf: Vec<u8>,
+/// Multiple state nodes share one writer and its chunk callbacks re-enter it
+/// (`enqueue` from inside `on_io_writer_chunk`), so every field is
+/// interior-mutable behind `&self` and no borrow is held across a callback.
+/// Intrusively refcounted: holders own an [`IOWriterRef`]; the io layer's
+/// per-write `ref_`/`deref` hooks and the keep-alive brackets below use the
+/// same count.
+#[derive(bun_ptr::CellRefCounted)]
+pub struct IOWriter {
+    ref_count: Cell<u32>,
+    self_root: bun_ptr::SelfRoot<IOWriter>,
+    /// The io-layer writer. Its poll callbacks arrive while a `&mut` to it is
+    /// live on the io layer's stack (see the `BufferedWriterParent` aliasing
+    /// contract), so it sits in its own cell and is only touched through
+    /// short `with_mut` scopes.
+    writer: JsCell<WriterImpl>,
+    fd: Cell<Fd>,
+    writers: RefCell<Writers>,
+    /// The bytes being written. In its own cell because the io layer borrows
+    /// it (`get_buffer`) for the duration of a write syscall.
+    buf: JsCell<Vec<u8>>,
     /// quick hack to get windows working; ideally this should be removed.
     #[cfg(windows)]
-    winbuf: Vec<u8>,
-    writer_idx: usize,
-    total_bytes_written: usize,
+    winbuf: JsCell<Vec<u8>>,
+    writer_idx: Cell<usize>,
+    total_bytes_written: Cell<usize>,
     /// Set (and never cleared) by `fail_pending_writers`. A writer with a
     /// stored error is dead: `enqueue`/`enqueue_fmt_bltn` must reject new
     /// chunks with this error instead of queueing them (see
     /// `handle_dead_writer`). The syscall error is kept (not the derived
     /// `SystemError`) so each rejected chunk gets its own freshly-derived
     /// `SystemError`.
-    err: Option<sys::Error>,
+    err: RefCell<Option<sys::Error>>,
     evtloop: EventLoopHandle,
-    is_writing: bool,
-    started: bool,
-    flags: Flags,
-    /// Weak self-ref so `keepalive()` can bump the strong count from `&self`
-    /// without unsafe Arc-pointer reconstruction. Set via `Arc::new_cyclic` in
-    /// `init()` (the sole constructor).
-    self_weak: std::sync::Weak<IOWriter>,
+    is_writing: Cell<bool>,
+    started: Cell<bool>,
+    flags: Cell<Flags>,
     /// Backref to the owning interpreter for async-poll callbacks (which must
-    /// drive `Yield::run`). Set by the first `enqueue`/`set_interp`; `None`
-    /// until then.
-    interp: Option<bun_ptr::ParentRef<Interpreter>>,
+    /// drive `Yield::run`). Set by `set_interp`; `None` until then.
+    interp: Cell<Option<bun_ptr::ParentRef<Interpreter>>>,
 }
-
-pub struct IOWriter {
-    state: UnsafeCell<State>,
-}
-
-// SAFETY: shell is single-threaded; `Arc` is used purely for refcounting.
-// No cross-thread access.
-unsafe impl Send for IOWriter {}
-// SAFETY: see `Send` — single-threaded, `Arc` is used only for refcounting; no
-// concurrent `&IOWriter` access occurs.
-unsafe impl Sync for IOWriter {}
 
 impl IOWriter {
-    /// SAFETY: single-threaded; no overlapping `&mut State` may be live across
-    /// a re-entrant `enqueue` from a child callback (the `Yield` trampoline
-    /// runs child callbacks after the borrow is dropped).
     #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn state(&self) -> &mut State {
-        // SAFETY: single-threaded; callers uphold the no-overlapping-`&mut State`
-        // invariant documented on this fn (re-derive across re-entrant calls).
-        unsafe { &mut *self.state.get() }
+    fn this_ptr(&self) -> ThisPtr<IOWriter> {
+        self.self_root.this_ptr(self)
     }
 
-    /// Bump our own Arc strong count. Held across re-entrant `run_yield` calls
-    /// whose child callback may drop the last external ref and free us
-    /// mid-method; the stack-held strong ref prevents that.
     #[inline]
-    fn keepalive(&self) -> std::sync::Arc<IOWriter> {
-        self.state()
-            .self_weak
-            .upgrade()
-            .expect("IOWriter::keepalive after last Arc dropped")
+    fn update_flags(&self, f: impl FnOnce(&mut Flags)) {
+        let mut v = self.flags.get();
+        f(&mut v);
+        self.flags.set(v);
     }
 
     /// Read-only accessor for the `is_socket` flag (used by
@@ -250,10 +233,10 @@ impl IOWriter {
     #[inline]
     #[cfg(not(windows))]
     pub(crate) fn is_socket(&self) -> bool {
-        self.state().flags.is_socket
+        self.flags.get().is_socket
     }
 
-    pub(crate) fn init(fd: Fd, flags: Flags, evtloop: EventLoopHandle) -> std::sync::Arc<IOWriter> {
+    pub(crate) fn init(fd: Fd, flags: Flags, evtloop: EventLoopHandle) -> IOWriterRef {
         let mut writer = WriterImpl::default();
         // Tell the PipeWriter impl to *not* close the file descriptor.
         #[cfg(not(windows))]
@@ -264,75 +247,58 @@ impl IOWriter {
         {
             writer.owns_fd = false;
         }
-        let this = std::sync::Arc::new_cyclic(|w| IOWriter {
-            state: UnsafeCell::new(State {
-                writer,
-                fd,
-                writers: Writers::new(),
-                buf: Vec::new(),
-                #[cfg(windows)]
-                winbuf: Vec::new(),
-                writer_idx: 0,
-                total_bytes_written: 0,
-                err: None,
-                evtloop,
-                is_writing: false,
-                started: false,
-                flags,
-                self_weak: std::sync::Weak::clone(w),
-                interp: None,
-            }),
+        let this = RefPtr::new_cyclic(|self_root| IOWriter {
+            ref_count: Cell::new(1),
+            self_root,
+            writer: JsCell::new(writer),
+            fd: Cell::new(fd),
+            writers: RefCell::new(Writers::new()),
+            buf: JsCell::new(Vec::new()),
+            #[cfg(windows)]
+            winbuf: JsCell::new(Vec::new()),
+            writer_idx: Cell::new(0),
+            total_bytes_written: Cell::new(0),
+            err: RefCell::new(None),
+            evtloop,
+            is_writing: Cell::new(false),
+            started: Cell::new(false),
+            flags: Cell::new(flags),
+            interp: Cell::new(None),
         });
-        // Set the parent backref after Arc allocation so the address is stable.
-        // SAFETY: `Arc::as_ptr` yields `*const IOWriter`; cast to `*mut` only
-        // because the `BufferedWriterParent` callback ABI is `*mut Self`. The
-        // pointer is never used to materialize `&mut IOWriter` — every callback
-        // (`on_write`/`on_error`/`get_buffer`/…) re-enters via `&*this` and
-        // mutates solely through `UnsafeCell<State>` (`state()`), which carries
-        // its own write provenance. No const→mut UB.
-        let parent: *mut IOWriter = std::sync::Arc::as_ptr(&this).cast_mut();
-        this.state().writer.set_parent(parent);
+        let parent: *mut IOWriter = this.as_ptr();
+        this.writer.with_mut(|w| w.set_parent(parent));
         crate::shell_log!("IOWriter(0x{:x}, fd={}) init", parent as usize, fd);
-        this
+        IOWriterRef(this)
     }
 
     /// Stash the interpreter backref so async poll callbacks can drive
-    /// `Yield::run`. Idempotent.
-    ///
-    /// # Safety
-    /// `interp` must be null or point to the live owning `Interpreter` (which
-    /// owns the IO struct holding this `Arc`) and outlive it; single-threaded.
-    // Forwards `interp` to `ParentRef::from_nullable` (shared provenance)
-    // without dereferencing it here; not_unsafe_ptr_arg_deref is a false
-    // positive on opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    /// `Yield::run`. `interp` owns (through its IO structs) every handle to
+    /// this writer. Idempotent.
     #[inline]
-    pub(crate) fn set_interp(&self, interp: *mut Interpreter) {
-        // SAFETY: caller contract above.
-        self.state().interp = unsafe { bun_ptr::ParentRef::from_nullable(interp) };
+    pub(crate) fn set_interp(&self, interp: &Interpreter) {
+        self.interp.set(Some(bun_ptr::ParentRef::new(interp)));
     }
 
     #[inline]
     pub(crate) fn fd(&self) -> Fd {
-        self.state().fd
+        self.fd.get()
     }
 
     #[inline]
     #[cfg(windows)]
     pub(crate) fn evtloop(&self) -> EventLoopHandle {
-        self.state().evtloop
+        self.evtloop
     }
 
     pub(crate) fn memory_cost(&self) -> usize {
-        let s = self.state();
         let mut cost = core::mem::size_of::<IOWriter>();
-        cost += s.buf.capacity();
+        cost += self.buf.get().capacity();
         #[cfg(windows)]
         {
-            cost += s.winbuf.capacity();
+            cost += self.winbuf.get().capacity();
         }
-        cost += s.writers.capacity() * core::mem::size_of::<Writer>();
-        cost += s.writer.memory_cost();
+        cost += self.writers.borrow().capacity() * core::mem::size_of::<Writer>();
+        cost += self.writer.get().memory_cost();
         cost
     }
 
@@ -343,17 +309,16 @@ impl IOWriter {
     #[cfg(not(windows))]
     #[inline]
     fn io_evtloop(&self) -> bun_io::EventLoopHandle {
-        // SAFETY: `bun_io::EventLoopHandle` stores `*mut c_void` purely for
-        // type-erasure; vtable consumers treat the pointee as read-only
-        self.state().evtloop.as_event_loop_ctx()
+        self.evtloop.as_event_loop_ctx()
     }
 
     // ── start ────────────────────────────────────────────────────────────
 
     fn __start(&self) -> sys::Result<()> {
-        let s = self.state();
-        crate::shell_log!("IOWriter(fd={}) __start()", s.fd);
-        if let Err(e) = s.writer.start(s.fd, s.flags.pollable) {
+        let fd = self.fd.get();
+        crate::shell_log!("IOWriter(fd={}) __start()", fd);
+        let pollable = self.flags.get().pollable;
+        if let Err(e) = self.writer.with_mut(|w| w.start(fd, pollable)) {
             #[cfg(not(windows))]
             {
                 // We get this if we pass in a file descriptor that is not
@@ -365,10 +330,8 @@ impl IOWriter {
                 // same file descriptor. The shell code here makes sure to
                 // _not_ run into that case, but it is possible.
                 if e.get_errno() == E::EINVAL {
-                    crate::shell_log!("IOWriter(fd={}) got EINVAL", s.fd);
-                    s.flags.pollable = false;
-                    s.flags.nonblock = false;
-                    s.flags.is_socket = false;
+                    crate::shell_log!("IOWriter(fd={}) got EINVAL", fd);
+                    self.disable_polling();
                     return self.__start();
                 }
                 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -376,9 +339,7 @@ impl IOWriter {
                     // On linux regular files are not pollable and return EPERM,
                     // so restart if that's the case with polling disabled.
                     if e.get_errno() == E::EPERM {
-                        s.flags.pollable = false;
-                        s.flags.nonblock = false;
-                        s.flags.is_socket = false;
+                        self.disable_polling();
                         return self.__start();
                     }
                 }
@@ -391,10 +352,12 @@ impl IOWriter {
                 // uv_tty_init, but this returns EBADF. As a workaround,
                 // we'll try opening the file descriptor as a file.
                 if e.get_errno() == E::EBADF {
-                    s.flags.pollable = false;
-                    s.flags.nonblock = false;
-                    s.flags.is_socket = false;
-                    return s.writer.start_with_file(s.fd);
+                    self.update_flags(|f| {
+                        f.pollable = false;
+                        f.nonblock = false;
+                        f.is_socket = false;
+                    });
+                    return self.writer.with_mut(|w| w.start_with_file(fd));
                 }
             }
             return Err(e);
@@ -404,42 +367,52 @@ impl IOWriter {
             // When `Source::open` produced a uv pipe/tty, libuv has TAKEN
             // OWNERSHIP of the underlying HANDLE
             // (`uv_pipe_open`/`uv_tty_init`) and `uv_close` (issued by
-            // `s.writer.close()` in Drop) will close it.
+            // `writer.close()` in Drop) will close it.
             // `BaseWindowsPipeWriter::start` does not invalidate the stored
             // fd (TODO at PipeWriter.rs:1277), so disarm the Drop close here
             // instead. The `Source::File`/`SyncFile` case (incl. the
             // EBADF→`start_with_file` fallback above, which `return`s early)
-            // keeps `s.fd` valid: with `owns_fd=false` PipeWriter does NOT
+            // keeps `fd` valid: with `owns_fd=false` PipeWriter does NOT
             // close it there, so Drop must.
             if matches!(
-                s.writer.source,
+                self.writer.get().source,
                 Some(bun_io::Source::Pipe(_) | bun_io::Source::Tty(_))
             ) {
-                s.fd = Fd::INVALID;
+                self.fd.set(Fd::INVALID);
             }
         }
         #[cfg(not(windows))]
         {
             use bun_io::FilePollFlag;
-            // NOTE: re-derive `state()` — the EINVAL/EPERM fallback paths
-            // above re-enter `__start()` and mutate `writer.handle`, which
-            // invalidates `s` under Stacked Borrows.
-            let s = self.state();
-            if let Some(poll) = s.writer.get_poll() {
-                if s.flags.nonblock {
-                    poll.set_flag(FilePollFlag::Nonblocking);
+            let flags = self.flags.get();
+            self.writer.with_mut(|w| {
+                if let Some(poll) = w.get_poll() {
+                    if flags.nonblock {
+                        poll.set_flag(FilePollFlag::Nonblocking);
+                    }
+                    // On macOS `sendto` with MSG_DONTWAIT can still block, so
+                    // only mark as socket there if the fd is already O_NONBLOCK.
+                    let sendto_msg_nowait_blocks = cfg!(target_os = "macos");
+                    if flags.is_socket && (!sendto_msg_nowait_blocks || flags.nonblock) {
+                        poll.set_flag(FilePollFlag::Socket);
+                    } else if flags.pollable {
+                        poll.set_flag(FilePollFlag::Fifo);
+                    }
                 }
-                // On macOS `sendto` with MSG_DONTWAIT can still block, so
-                // only mark as socket there if the fd is already O_NONBLOCK.
-                let sendto_msg_nowait_blocks = cfg!(target_os = "macos");
-                if s.flags.is_socket && (!sendto_msg_nowait_blocks || s.flags.nonblock) {
-                    poll.set_flag(FilePollFlag::Socket);
-                } else if s.flags.pollable {
-                    poll.set_flag(FilePollFlag::Fifo);
-                }
-            }
+            });
         }
         Ok(())
+    }
+
+    /// EINVAL/EPERM fallback: this fd cannot be polled, so drop the poll (if
+    /// one was registered) and continue on the synchronous file path.
+    #[cfg(not(windows))]
+    fn disable_polling(&self) {
+        self.update_flags(|f| {
+            f.pollable = false;
+            f.nonblock = false;
+            f.is_socket = false;
+        });
     }
 
     /// Idempotent write call.
@@ -449,28 +422,23 @@ impl IOWriter {
     /// error completion has to bounce off it (`on_sync_error`) instead of
     /// re-entering `Yield::run` (see `DbgDepthGuard`).
     fn write(&self) -> WriteOutcome {
-        let s = self.state();
         #[cfg(not(windows))]
-        debug_assert!(s.flags.pollable);
+        debug_assert!(self.flags.get().pollable);
 
-        if !s.started {
-            crate::shell_log!("IOWriter(fd={}) starting", s.fd);
+        if !self.started.get() {
+            crate::shell_log!("IOWriter(fd={}) starting", self.fd.get());
             // Set before the fallible `__start` so a later enqueue does not
             // retry it.
-            s.started = true;
+            self.started.set(true);
             if let Err(e) = self.__start() {
                 return WriteOutcome::Failed(e);
             }
             #[cfg(not(windows))]
             {
-                // NOTE: `__start()` re-derives `state()` (and may mutate
-                // `writer.handle` on the EINVAL/EPERM fallback paths), which
-                // invalidates the `s` borrow under Stacked Borrows. Re-derive.
-                let s = self.state();
                 // if `handle == .fd` it means it's a file which does not
                 // support polling for writeability and we should just write to it
-                if matches!(s.writer.handle, bun_io::pipes::PollOrFd::Fd(_)) {
-                    debug_assert!(!s.flags.pollable);
+                if matches!(self.writer.get().handle, bun_io::pipes::PollOrFd::Fd(_)) {
+                    debug_assert!(!self.flags.get().pollable);
                     return WriteOutcome::IsActuallyFile;
                 }
                 return WriteOutcome::Suspended;
@@ -481,12 +449,16 @@ impl IOWriter {
 
         #[cfg(windows)]
         {
-            crate::shell_log!("IOWriter(fd={}) write() is_writing={}", s.fd, s.is_writing);
-            if s.is_writing {
+            crate::shell_log!(
+                "IOWriter(fd={}) write() is_writing={}",
+                self.fd.get(),
+                self.is_writing.get()
+            );
+            if self.is_writing.get() {
                 return WriteOutcome::Suspended;
             }
-            s.is_writing = true;
-            if let Err(e) = s.writer.start_with_current_pipe() {
+            self.is_writing.set(true);
+            if let Err(e) = self.writer.with_mut(|w| w.start_with_current_pipe()) {
                 return WriteOutcome::Failed(e);
             }
             return WriteOutcome::Suspended;
@@ -494,18 +466,23 @@ impl IOWriter {
 
         #[cfg(not(windows))]
         {
-            debug_assert!(matches!(s.writer.handle, bun_io::pipes::PollOrFd::Poll(_)));
-            if let Some(poll) = s.writer.get_poll() {
-                // `is_watching()` = `is_registered() && !needs_rearm`.
-                // NOT `is_registered()`: after a one-shot fire that drains
-                // everything (no `register_poll()`), `PollWritable` stays set
-                // but `NeedsRearm` is set → `is_registered()` would return
-                // Suspended without re-arming and stall the queue forever.
-                if poll.is_watching() {
-                    return WriteOutcome::Suspended;
-                }
+            debug_assert!(matches!(
+                self.writer.get().handle,
+                bun_io::pipes::PollOrFd::Poll(_)
+            ));
+            // `is_watching()` = `is_registered() && !needs_rearm`.
+            // NOT `is_registered()`: after a one-shot fire that drains
+            // everything (no `register_poll()`), `PollWritable` stays set
+            // but `NeedsRearm` is set → `is_registered()` would return
+            // Suspended without re-arming and stall the queue forever.
+            let watching = self
+                .writer
+                .with_mut(|w| w.get_poll().is_some_and(|poll| poll.is_watching()));
+            if watching {
+                return WriteOutcome::Suspended;
             }
-            if let Err(e) = s.writer.start(s.fd, s.flags.pollable) {
+            let (fd, pollable) = (self.fd.get(), self.flags.get().pollable);
+            if let Err(e) = self.writer.with_mut(|w| w.start(fd, pollable)) {
                 return WriteOutcome::Failed(e);
             }
             WriteOutcome::Suspended
@@ -516,15 +493,15 @@ impl IOWriter {
 
     /// Cancel the chunks enqueued by the given child by marking them as dead.
     pub(crate) fn cancel_chunks(&self, ptr: ChildPtr) {
-        let s = self.state();
-        if s.writers.is_empty() {
+        let mut writers = self.writers.borrow_mut();
+        if writers.is_empty() {
             return;
         }
-        let idx = s.writer_idx;
-        if idx >= s.writers.len() {
+        let idx = self.writer_idx.get();
+        if idx >= writers.len() {
             return;
         }
-        for w in &mut s.writers[idx..] {
+        for w in &mut writers[idx..] {
             if w.ptr == ptr {
                 w.set_dead();
             }
@@ -534,12 +511,13 @@ impl IOWriter {
     /// Skips over dead children and increments `total_bytes_written` by the
     /// amount they would have written so the buf is skipped as well.
     fn skip_dead(&self) {
-        let s = self.state();
-        while s.writer_idx < s.writers.len() {
-            let w = &s.writers[s.writer_idx];
+        let writers = self.writers.borrow();
+        while self.writer_idx.get() < writers.len() {
+            let w = &writers[self.writer_idx.get()];
             if w.is_dead() {
-                s.total_bytes_written += w.len - w.written;
-                s.writer_idx += 1;
+                self.total_bytes_written
+                    .set(self.total_bytes_written.get() + (w.len - w.written));
+                self.writer_idx.set(self.writer_idx.get() + 1);
                 continue;
             }
             return;
@@ -547,8 +525,7 @@ impl IOWriter {
     }
 
     fn wrote_everything(&self) -> bool {
-        let s = self.state();
-        s.total_bytes_written >= s.buf.len()
+        self.total_bytes_written.get() >= self.buf.get().len()
     }
 
     /// Only does things on windows.
@@ -556,7 +533,7 @@ impl IOWriter {
     fn set_writing(&self, writing: bool) {
         #[cfg(windows)]
         {
-            self.state().is_writing = writing;
+            self.is_writing.set(writing);
         }
         let _ = writing;
     }
@@ -569,44 +546,41 @@ impl IOWriter {
         let result = self.get_buffer_impl();
         #[cfg(windows)]
         {
-            let s = self.state();
-            s.winbuf.clear();
-            s.winbuf.extend_from_slice(result);
-            // `state()` ties `s` to `&self`, so the slice borrow already has
-            // the `'self` lifetime the signature wants — no raw-parts needed.
-            return s.winbuf.as_slice();
+            self.winbuf.with_mut(|winbuf| {
+                winbuf.clear();
+                winbuf.extend_from_slice(result);
+            });
+            return self.winbuf.get().as_slice();
         }
         #[cfg(not(windows))]
         result
     }
 
     fn get_buffer_impl(&self) -> &[u8] {
-        // NOTE: reshaped for borrowck — re-derive `state()` after
-        // `skip_dead()` instead of holding one `&mut State` across it.
-        {
-            let s = self.state();
-            if s.writer_idx >= s.writers.len() {
-                return &[];
+        let current_is_dead = {
+            let writers = self.writers.borrow();
+            match writers.get(self.writer_idx.get()) {
+                None => return &[],
+                Some(w) => w.is_dead(),
             }
-            if s.writers[s.writer_idx].is_dead() {
-                let _ = s;
-                self.skip_dead();
-            }
+        };
+        if current_is_dead {
+            self.skip_dead();
         }
-        let s = self.state();
-        if s.writer_idx >= s.writers.len() {
+        let writers = self.writers.borrow();
+        let idx = self.writer_idx.get();
+        if idx >= writers.len() {
             return &[];
         }
         let remaining = {
-            let writer = &s.writers[s.writer_idx];
+            let writer = &writers[idx];
             debug_assert!(writer.len != writer.written);
             writer.len - writer.written
         };
-        // `state()` already ties `s` to `&self`, so a plain slice borrow has
-        // the right lifetime. `buf` is not reallocated until after the
-        // caller's write syscall completes.
-        let start = s.total_bytes_written;
-        &s.buf[start..start + remaining]
+        // `buf` is not reallocated until after the caller's write syscall
+        // completes.
+        let start = self.total_bytes_written.get();
+        &self.buf.get()[start..start + remaining]
     }
 
     // ── bump (chunk completed) ──────────────────────────────────────────
@@ -614,37 +588,36 @@ impl IOWriter {
     /// Advance past `current_writer`, shrinking `buf` if appropriate, and
     /// return the `Yield` for the child's `on_io_writer_chunk` callback.
     fn bump(&self, current_idx: usize) -> Yield {
-        // NOTE: reshaped for borrowck — `skip_dead()` re-derives `state()`,
-        // so we must drop `s` before calling it and re-derive after, otherwise
-        // two `&mut State` are live simultaneously (UB under Stacked Borrows).
-        let (is_dead, written, child_ptr) = {
-            let s = self.state();
-            let w = &s.writers[current_idx];
-            (w.is_dead(), w.written, w.ptr)
+        let (is_dead, written, len, child_ptr) = {
+            let writers = self.writers.borrow();
+            let w = &writers[current_idx];
+            (w.is_dead(), w.written, w.len, w.ptr)
         };
 
         if is_dead {
             self.skip_dead();
         } else {
-            let s = self.state();
-            debug_assert!(s.writers[current_idx].written == s.writers[current_idx].len);
-            s.writer_idx += 1;
+            debug_assert!(written == len);
+            self.writer_idx.set(self.writer_idx.get() + 1);
         }
 
-        let s = self.state();
-        if s.writer_idx >= s.writers.len() {
-            s.buf.clear();
-            s.writer_idx = 0;
-            s.writers.clear();
-            s.total_bytes_written = 0;
-        } else if s.total_bytes_written >= SHRINK_THRESHOLD {
-            s.buf.drain_front(s.total_bytes_written);
-            s.total_bytes_written = 0;
-            // Drop the *prefix* of the writers queue: Vec::drain(..idx).
-            s.writers.drain(..s.writer_idx);
-            s.writer_idx = 0;
-            if cfg!(debug_assertions) && !s.writers.is_empty() {
-                debug_assert!(s.buf.len() >= s.writers[0].len);
+        {
+            let mut writers = self.writers.borrow_mut();
+            if self.writer_idx.get() >= writers.len() {
+                self.buf.with_mut(|b| b.clear());
+                self.writer_idx.set(0);
+                writers.clear();
+                self.total_bytes_written.set(0);
+            } else if self.total_bytes_written.get() >= SHRINK_THRESHOLD {
+                let total = self.total_bytes_written.get();
+                self.buf.with_mut(|b| b.drain_front(total));
+                self.total_bytes_written.set(0);
+                // Drop the *prefix* of the writers queue: Vec::drain(..idx).
+                writers.drain(..self.writer_idx.get());
+                self.writer_idx.set(0);
+                if cfg!(debug_assertions) && !writers.is_empty() {
+                    debug_assert!(self.buf.get().len() >= writers[0].len);
+                }
             }
         }
 
@@ -662,36 +635,30 @@ impl IOWriter {
 
     /// Tee `amt` bytes from the current buffer position into `writers[idx]`'s
     /// capture and advance its `written` / `total_bytes_written` counters.
-    #[cfg(not(windows))]
     fn record_write_progress(&self, idx: usize, amt: usize) {
-        let s = self.state();
-        let lo = s.total_bytes_written;
-        s.writers[idx].tee(&s.buf[lo..lo + amt]);
-        s.total_bytes_written += amt;
-        s.writers[idx].written += amt;
+        let mut writers = self.writers.borrow_mut();
+        let lo = self.total_bytes_written.get();
+        writers[idx].tee(&self.buf.get()[lo..lo + amt]);
+        self.total_bytes_written.set(lo + amt);
+        writers[idx].written += amt;
     }
 
     /// POSIX-only. `child` is the writer being enqueued (see `on_sync_error`).
     #[cfg(not(windows))]
     fn do_file_write(&self, child: ChildPtr) -> Yield {
-        {
-            let s = self.state();
-            debug_assert!(!s.flags.pollable);
-            debug_assert!(s.writer_idx < s.writers.len());
-        }
+        debug_assert!(!self.flags.get().pollable);
+        debug_assert!(self.writer_idx.get() < self.writers.borrow().len());
 
         scopeguard::defer! { self.set_writing(false); }
         self.skip_dead();
 
-        let idx = self.state().writer_idx;
-        debug_assert!(!self.state().writers[idx].is_dead());
+        let idx = self.writer_idx.get();
+        debug_assert!(!self.writers.borrow()[idx].is_dead());
 
         let buf = self.get_buffer();
         debug_assert!(!buf.is_empty());
 
         let result = drain_buffered_data(self, buf, u32::MAX as usize);
-        // NOTE: re-derive `state()` after `drain_buffered_data` instead of
-        // holding a stale `&mut`.
         let amt = match result {
             bun_io::WriteResult::Done(amt) | bun_io::WriteResult::Wrote(amt) => amt,
             bun_io::WriteResult::Pending(amt) => {
@@ -699,10 +666,11 @@ impl IOWriter {
                 // FIFO or chardev opened by path with O_NONBLOCK). Record the
                 // partial write and restart this writer on the pollable path.
                 self.record_write_progress(idx, amt);
-                let s = self.state();
-                s.flags.pollable = true;
-                s.flags.nonblock = true;
-                s.started = false;
+                self.update_flags(|f| {
+                    f.pollable = true;
+                    f.nonblock = true;
+                });
+                self.started.set(false);
                 return match self.write() {
                     WriteOutcome::Suspended => Yield::suspended(),
                     WriteOutcome::IsActuallyFile => self
@@ -715,7 +683,7 @@ impl IOWriter {
             bun_io::WriteResult::Err(e) => return self.on_sync_error(child, &e),
         };
         self.record_write_progress(idx, amt);
-        if !self.state().writers[idx].wrote_everything() {
+        if !self.writers.borrow()[idx].wrote_everything() {
             // The only case where we get partial writes is when an error is
             // encountered, which returns above.
             unreachable!(
@@ -729,78 +697,75 @@ impl IOWriter {
 
     /// The `BufferedWriter.onWrite` hook. Runs on the event loop when the fd
     /// is writable.
-    fn on_write_pollable(&self, amount: usize, status: bun_io::WriteStatus) {
-        // NOTE: `set_writing` re-derives `state()` on Windows, which would
-        // invalidate `s` under Stacked Borrows; do it before binding `s`
-        // (matches the ordering in `on_error`).
-        self.set_writing(false);
-        let s = self.state();
-        #[cfg(not(windows))]
-        debug_assert!(s.flags.pollable);
+    fn on_write_pollable(this: ThisPtr<Self>, amount: usize, status: bun_io::WriteStatus) {
+        let _keepalive = this.ref_guard();
+        let me: &Self = &this;
+        me.on_write_pollable_impl(amount, status);
+    }
 
-        if s.writer_idx >= s.writers.len() {
-            return;
-        }
-        let idx = s.writer_idx;
-        if s.writers[idx].is_dead() {
+    fn on_write_pollable_impl(&self, amount: usize, status: bun_io::WriteStatus) {
+        self.set_writing(false);
+        #[cfg(not(windows))]
+        debug_assert!(self.flags.get().pollable);
+
+        let idx = self.writer_idx.get();
+        let (is_dead, queue_len) = {
+            let writers = self.writers.borrow();
+            if idx >= writers.len() {
+                return;
+            }
+            (writers[idx].is_dead(), writers.len())
+        };
+        if is_dead {
             self.run_yield(self.bump(idx));
         } else {
-            let lo = s.total_bytes_written;
-            s.writers[idx].tee(&s.buf[lo..lo + amount]);
-            s.total_bytes_written += amount;
-            s.writers[idx].written += amount;
+            self.record_write_progress(idx, amount);
+            let (written, len) = {
+                let writers = self.writers.borrow();
+                (writers[idx].written, writers[idx].len)
+            };
             if status == bun_io::WriteStatus::EndOfFile {
-                // NOTE: inline `is_last_idx` instead of calling
-                // `self.is_last_idx(idx)` — that re-derives `state()` while `s`
-                // is still live, which is two simultaneous `&mut State` (UB).
-                let last = idx == s.writers.len().saturating_sub(1);
-                let not_fully_written = if last {
-                    true
-                } else {
-                    s.writers[idx].written < s.writers[idx].len
-                };
+                let last = idx == queue_len.saturating_sub(1);
+                let not_fully_written = if last { true } else { written < len };
                 if !not_fully_written {
                     return;
                 }
                 // Other end of the socket/pipe closed and we got EPIPE
                 // (e.g. `ls | echo`). Quick hack: have all writers see an
                 // error.
-                s.flags.broken_pipe = true;
+                self.update_flags(|f| f.broken_pipe = true);
                 self.broken_pipe_for_writers();
                 return;
             }
-            if s.writers[idx].written >= s.writers[idx].len {
+            if written >= len {
                 self.run_yield(self.bump(idx));
             }
         }
 
         let wrote_everything = self.wrote_everything();
-        let s = self.state();
-        if !wrote_everything && s.writer_idx < s.writers.len() {
+        if !wrote_everything && self.writer_idx.get() < self.writers.borrow().len() {
             #[cfg(windows)]
             {
-                // NOTE: inline `set_writing(true)` instead of calling the
-                // helper — the helper re-derives `state()` while `s` is live,
-                // which is two simultaneous `&mut State` (UB under Stacked
-                // Borrows). Same discipline as the top of this fn.
-                s.is_writing = true;
-                s.writer.write();
+                self.is_writing.set(true);
+                self.writer.with_mut(|w| w.write());
             }
             #[cfg(not(windows))]
             {
-                debug_assert!(matches!(s.writer.handle, bun_io::pipes::PollOrFd::Poll(_)));
-                s.writer.register_poll();
+                debug_assert!(matches!(
+                    self.writer.get().handle,
+                    bun_io::pipes::PollOrFd::Poll(_)
+                ));
+                self.writer.with_mut(|w| w.register_poll());
             }
         }
     }
 
     fn broken_pipe_for_writers(&self) {
-        let s = self.state();
-        debug_assert!(s.flags.broken_pipe);
-        // NOTE: reshaped for borrowck — collect targets first so we don't
-        // hold `&mut s.writers` across `cancel_chunks`/`run_yield`.
+        debug_assert!(self.flags.get().broken_pipe);
+        // Collect targets first so `writers` is not borrowed across
+        // `cancel_chunks`/`run_yield`.
         let mut targets: Vec<ChildPtr> = Vec::new();
-        for w in &s.writers[s.writer_idx..] {
+        for w in &self.writers.borrow()[self.writer_idx.get()..] {
             if w.is_dead() {
                 continue;
             }
@@ -817,11 +782,10 @@ impl IOWriter {
             });
             self.cancel_chunks(ptr);
         }
-        let s = self.state();
-        s.total_bytes_written = 0;
-        s.writers.clear();
-        s.buf.clear();
-        s.writer_idx = 0;
+        self.total_bytes_written.set(0);
+        self.writers.borrow_mut().clear();
+        self.buf.with_mut(|b| b.clear());
+        self.writer_idx.set(0);
     }
 
     /// Shared failure bookkeeping: mark broken pipes, reset the queue, and
@@ -830,39 +794,44 @@ impl IOWriter {
     /// re-enqueueing from its callback is not wiped afterwards.
     fn fail_pending_writers(&self, err: &sys::Error) -> Vec<ChildPtr> {
         self.set_writing(false);
-        let s = self.state();
         if err.get_errno() == E::EPIPE {
-            s.flags.broken_pipe = true;
+            self.update_flags(|f| f.broken_pipe = true);
         }
         // Mark the writer dead before any completion below runs: a child that
         // enqueues from its callback (the next statement, the RHS of `&&`, ...)
         // must be rejected by `handle_dead_writer`, not queued onto a writer
         // whose handle the error path is tearing down.
-        s.err = Some(err.clone());
+        *self.err.borrow_mut() = Some(err.clone());
         // Writers before writer_idx have already had their callback fired and
         // may have been freed; only notify the still-pending ones, dedup'd.
         let mut pending: Vec<ChildPtr> = Vec::new();
-        for w in &s.writers[s.writer_idx..] {
+        let mut writers = self.writers.borrow_mut();
+        for w in &writers[self.writer_idx.get()..] {
             if !w.is_dead() && !pending.contains(&w.ptr) {
                 pending.push(w.ptr);
             }
         }
-        s.total_bytes_written = 0;
-        s.writer_idx = 0;
-        s.buf.clear();
-        s.writers.clear();
+        self.total_bytes_written.set(0);
+        self.writer_idx.set(0);
+        self.buf.with_mut(|b| b.clear());
+        writers.clear();
         pending
     }
 
     /// Write failure reported by the `bun_io` writer callbacks. Each pending
     /// child's error completion is driven through its own `Yield::run`; on
     /// POSIX these callbacks only fire from the event loop, with no trampoline
-    /// on the stack. On Windows uv can also deliver a synchronous submission
-    /// failure from under `write()` (`start_with_current_pipe` returns `Ok`
-    /// unconditionally), a re-entry `write()` cannot turn into a
-    /// `WriteOutcome::Failed`.
-    fn on_error(&self, err: &sys::Error) {
-        let _keepalive = self.keepalive();
+    /// on the stack. On Windows uv can also report one from under the
+    /// submitting call (`start_with_current_pipe` returns `Ok` regardless), so
+    /// the enqueuing child may be called back from inside its own `enqueue`;
+    /// callers therefore hold no node borrow across `enqueue`.
+    fn on_error(this: ThisPtr<Self>, err: &sys::Error) {
+        let _keepalive = this.ref_guard();
+        let me: &Self = &this;
+        me.on_error_impl(err);
+    }
+
+    fn on_error_impl(&self, err: &sys::Error) {
         for ptr in self.fail_pending_writers(err) {
             // `SystemError` owns `bun_core::String`s by value (no shared
             // refcount yet), so re-derive a fresh one per callee instead of
@@ -886,7 +855,7 @@ impl IOWriter {
     /// re-registration fails while other children are still queued, those are
     /// dispatched the way the async path dispatches them.
     fn on_sync_error(&self, child: ChildPtr, err: &sys::Error) -> Yield {
-        let _keepalive = self.keepalive();
+        let _keepalive = self.this_ptr().ref_guard();
         let mut completion = None;
         for ptr in self.fail_pending_writers(err) {
             // `SystemError` owns `bun_core::String`s by value (no shared
@@ -908,24 +877,22 @@ impl IOWriter {
         completion.unwrap_or_else(Yield::done)
     }
 
-    fn on_close(&self) {
-        self.set_writing(false);
+    fn on_close(this: ThisPtr<Self>) {
+        this.set_writing(false);
     }
 
     /// Drive a `Yield` from inside an async poll callback. Requires `interp`
     /// to have been set; if not, the chunk-complete is dropped (debug-asserts).
     fn run_yield(&self, y: Yield) {
-        let Some(interp) = self.state().interp else {
+        let Some(interp) = self.interp.get() else {
             debug_assert!(
                 matches!(y, Yield::Done),
                 "IOWriter async callback fired without interp backref"
             );
             return;
         };
-        // SAFETY: interp outlives every IOWriter (it owns the IO struct that
-        // holds the Arc). Single-threaded; R-2: `Interpreter::run` takes
-        // `&self` now — `ParentRef: Deref<Target=Interpreter>` yields the
-        // shared borrow without `assume_mut()`.
+        // The interpreter owns the IO structs that hold this writer and
+        // outlives it. Single-threaded.
         y.run(&interp);
     }
 
@@ -940,8 +907,7 @@ impl IOWriter {
     /// flavor of the same thing. Report the error to the child instead of
     /// queueing the chunk.
     fn handle_dead_writer(&self, ptr: ChildPtr) -> Option<Yield> {
-        let s = self.state();
-        if s.flags.broken_pipe {
+        if self.flags.get().broken_pipe {
             let err = sys::Error::from_code(E::EPIPE, sys::Tag::write).to_system_error();
             return Some(Yield::OnIoWriterChunk {
                 child: ptr,
@@ -949,7 +915,7 @@ impl IOWriter {
                 err: Some(err),
             });
         }
-        if let Some(err) = &s.err {
+        if let Some(err) = &*self.err.borrow() {
             return Some(Yield::OnIoWriterChunk {
                 child: ptr,
                 written: 0,
@@ -963,13 +929,12 @@ impl IOWriter {
 
     #[cfg(not(windows))]
     fn enqueue_file(&self, child: ChildPtr) -> Yield {
-        let s = self.state();
-        if s.is_writing {
+        if self.is_writing.get() {
             return Yield::suspended();
         }
         // The pollable path sets `started` in write(); the non-pollable file
         // path bypasses write() entirely, so set it here.
-        s.started = true;
+        self.started.set(true);
         self.set_writing(true);
         self.do_file_write(child)
     }
@@ -977,10 +942,10 @@ impl IOWriter {
     /// You MUST have already added the data to `self.buf`!
     /// `child` is the writer that was just pushed (see `on_sync_error`).
     fn enqueue_internal(&self, child: ChildPtr) -> Yield {
-        debug_assert!(!self.state().flags.broken_pipe);
-        debug_assert!(self.state().err.is_none());
+        debug_assert!(!self.flags.get().broken_pipe);
+        debug_assert!(self.err.borrow().is_none());
         #[cfg(not(windows))]
-        if !self.state().flags.pollable {
+        if !self.flags.get().pollable {
             return self.enqueue_file(child);
         }
         match self.write() {
@@ -996,7 +961,7 @@ impl IOWriter {
     pub(crate) fn enqueue(
         &self,
         child: ChildPtr,
-        bytelist: Option<*mut Vec<u8>>,
+        bytelist: Option<CapturedBuf>,
         buf: &[u8],
     ) -> Yield {
         if let Some(y) = self.handle_dead_writer(child) {
@@ -1009,11 +974,43 @@ impl IOWriter {
                 err: None,
             };
         }
-        let s = self.state();
-        s.buf.extend_from_slice(buf);
-        s.writers.push(Writer {
+        self.buf.with_mut(|b| b.extend_from_slice(buf));
+        self.writers.borrow_mut().push(Writer {
             ptr: child,
             len: buf.len(),
+            written: 0,
+            bytelist,
+        });
+        self.enqueue_internal(child)
+    }
+
+    /// [`enqueue`](Self::enqueue) with the bytes produced by `fill`, which
+    /// appends them straight into the write buffer (any borrow it needs ends
+    /// with it, before the writer can call anyone back).
+    pub(crate) fn enqueue_with(
+        &self,
+        child: ChildPtr,
+        bytelist: Option<CapturedBuf>,
+        fill: impl FnOnce(&mut Vec<u8>),
+    ) -> Yield {
+        if let Some(y) = self.handle_dead_writer(child) {
+            return y;
+        }
+        let len = self.buf.with_mut(|b| {
+            let start = b.len();
+            fill(b);
+            b.len() - start
+        });
+        if len == 0 {
+            return Yield::OnIoWriterChunk {
+                child,
+                written: 0,
+                err: None,
+            };
+        }
+        self.writers.borrow_mut().push(Writer {
+            ptr: child,
+            len,
             written: 0,
             bytelist,
         });
@@ -1024,40 +1021,26 @@ impl IOWriter {
     pub(crate) fn enqueue_fmt_bltn(
         &self,
         child: ChildPtr,
-        bytelist: Option<*mut Vec<u8>>,
+        bytelist: Option<CapturedBuf>,
         kind: Option<crate::shell::builtin::Kind>,
         args: core::fmt::Arguments<'_>,
     ) -> Yield {
         use std::io::Write as _;
-        let s = self.state();
-        let start = s.buf.len();
-        if let Some(k) = kind {
-            let _ = write!(&mut s.buf, "{}: ", k.as_str());
-        }
-        let _ = s.buf.write_fmt(args);
+        let (start, end) = self.buf.with_mut(|buf| {
+            let start = buf.len();
+            if let Some(k) = kind {
+                let _ = write!(buf, "{}: ", k.as_str());
+            }
+            let _ = buf.write_fmt(args);
+            (start, buf.len())
+        });
         // `buf` is written *before* the dead-writer checks (the bytes are dead
         // on the error path but no `Writer` references them, and an errored
         // writer never drains again).
-        // NOTE: inline `handle_dead_writer` instead of calling the helper —
-        // the helper re-derives `state()` while `s` is still live, which is two
-        // simultaneous `&mut State` (UB under Stacked Borrows).
-        if s.flags.broken_pipe {
-            let err = sys::Error::from_code(E::EPIPE, sys::Tag::write).to_system_error();
-            return Yield::OnIoWriterChunk {
-                child,
-                written: 0,
-                err: Some(err),
-            };
+        if let Some(y) = self.handle_dead_writer(child) {
+            return y;
         }
-        if let Some(err) = &s.err {
-            return Yield::OnIoWriterChunk {
-                child,
-                written: 0,
-                err: Some(err.to_shell_system_error()),
-            };
-        }
-        let end = s.buf.len();
-        s.writers.push(Writer {
+        self.writers.borrow_mut().push(Writer {
             ptr: child,
             len: end - start,
             written: 0,
@@ -1083,18 +1066,38 @@ enum WriteOutcome {
 bun_io::impl_buffered_writer_parent! {
     IOWriter;
     poll_tag   = bun_io::posix_event_loop::poll_tag::SHELL_BUFFERED_WRITER,
-    // UnsafeCell aliasing model — child callbacks may re-enter `enqueue(&self)`.
-    borrow     = shared,
+    // Child callbacks may re-enter `enqueue(&self)` and drop holder refs, so
+    // every hook gets a `ThisPtr` and takes a ref guard first.
+    borrow     = this,
     on_write   = on_write_pollable,
     on_error   = on_error,
     on_close   = on_close,
-    get_buffer = |this| (*this).get_buffer(),
-    event_loop = |this| (*this).io_evtloop(),
-    uv_loop    = |this| (*(*this).evtloop().loop_()).uv_loop,
-    // INVARIANT: `this` is `Arc::as_ptr` stashed via `writer.set_parent` in
-    // `IOWriter::init` (sole constructor); passing a non-Arc ptr is UB.
-    ref_       = |this| std::sync::Arc::increment_strong_count(this as *const Self),
-    deref      = |this| std::sync::Arc::decrement_strong_count(this as *const Self),
+    get_buffer = |this| this.get_buffer(),
+    event_loop = |this| this.io_evtloop(),
+    uv_loop    = |this| this.evtloop().uv_loop(),
+}
+
+/// One owned ref on an [`IOWriter`]; clone takes another, drop releases it.
+pub struct IOWriterRef(RefPtr<IOWriter>);
+
+impl Clone for IOWriterRef {
+    fn clone(&self) -> Self {
+        IOWriterRef(self.0.dupe_ref())
+    }
+}
+
+impl Drop for IOWriterRef {
+    fn drop(&mut self) {
+        self.0.deref();
+    }
+}
+
+impl core::ops::Deref for IOWriterRef {
+    type Target = IOWriter;
+    #[inline]
+    fn deref(&self) -> &IOWriter {
+        self.0.data()
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1143,7 +1146,7 @@ fn drain_buffered_data(
     };
     let mut drained: usize = 0;
     while drained < trimmed.len() {
-        match try_write_with_write_fn(parent.state().fd, buf, sys::write) {
+        match try_write_with_write_fn(parent.fd(), buf, sys::write) {
             bun_io::WriteResult::Pending(pending) => {
                 drained += pending;
                 return bun_io::WriteResult::Pending(drained);
@@ -1172,31 +1175,31 @@ fn drain_buffered_data(
 
 impl Drop for IOWriter {
     fn drop(&mut self) {
-        // With `Arc` the last ref drops *after* the callback returns, so the
+        // With `Rc` the last ref drops *after* the callback returns, so the
         // synchronous path is safe (PipeWriter cannot touch us after free).
         // TODO: if a PipeWriter callback is on the stack when the last
-        // Arc drops (possible via re-entrant child deinit), we need the async
+        // ref drops (possible via re-entrant child deinit), we need the async
         // hop. Revisit once `bun_event_loop::EventLoopTask` is wired to the
         // shell's `EventLoopHandle` shim.
-        let s = self.state.get_mut();
-        crate::shell_log!("IOWriter(fd={}) deinit", s.fd);
-        #[cfg(not(windows))]
-        {
-            if matches!(s.writer.handle, bun_io::pipes::PollOrFd::Poll(_)) {
-                s.writer
-                    .handle
-                    .close_impl(None, None::<fn(*mut c_void)>, false);
+        let fd = self.fd.get();
+        crate::shell_log!("IOWriter(fd={}) deinit", fd);
+        let evtloop = self.evtloop;
+        self.writer.with_mut(|w| {
+            #[cfg(not(windows))]
+            {
+                if matches!(w.handle, bun_io::pipes::PollOrFd::Poll(_)) {
+                    w.handle.close_impl(None, None::<fn(*mut c_void)>, false);
+                }
             }
-        }
-        #[cfg(windows)]
-        {
-            s.writer.close();
-        }
-        if s.fd != Fd::INVALID {
-            let _ = sys::close(s.fd);
-        }
-        s.writer
-            .disable_keeping_process_alive(s.evtloop.as_event_loop_ctx());
+            #[cfg(windows)]
+            {
+                w.close();
+            }
+            if fd != Fd::INVALID {
+                let _ = sys::close(fd);
+            }
+            w.disable_keeping_process_alive(evtloop.as_event_loop_ctx());
+        });
     }
 }
 
@@ -1224,21 +1227,15 @@ pub(crate) fn on_io_writer_chunk(
         WriterTag::Pipeline => {
             pipeline::Pipeline::on_io_writer_chunk(interp, child.node, written, err)
         }
-        // The target is the subprocess PipeReader's `CapturedWriter`; it
+        // The target is the subprocess PipeReader's captured-output tee; it
         // lives outside the NodeId arena (heap-allocated PipeReader), so it
-        // is carried in `child.raw` instead of `child.node`.
+        // is carried in `child.subproc` instead of `child.node`.
         WriterTag::Subproc => {
             let _ = interp;
-            debug_assert!(!child.raw.is_null());
-            // SAFETY: `raw` is the `PipeReader` root set in
-            // `PipeReader::captured_child_ptr`; the reader is kept alive by
-            // the `Readable::Pipe` ref on the owning ShellSubprocess until
-            // `on_close_io` runs, which only happens after the writer has
-            // finished draining (or `cancel_chunks` removed this entry).
-            let pipe = unsafe {
-                bun_ptr::ThisPtr::new(child.raw.cast::<crate::shell::subproc::PipeReader>())
-            };
-            crate::shell::subproc::PipeReader::on_captured_iowriter_chunk(pipe, written, err)
+            let pipe = child
+                .subproc
+                .expect("WriterTag::Subproc carries its PipeReader");
+            PipeReader::on_captured_iowriter_chunk(pipe.this_ptr(), written, err)
         }
     }
 }

--- a/src/runtime/shell/ParsedShellScript.rs
+++ b/src/runtime/shell/ParsedShellScript.rs
@@ -8,10 +8,10 @@ use bun_jsc::{
     JsRef, JsResult, MarkedArgumentBuffer, StringJsc as _,
 };
 
+use super::EnvStr;
 use super::env_map::EnvMap;
 use super::interpreter::ShellArgs;
 use super::shell_body::shell_cmd_from_js;
-use super::{EnvStr, Interpreter};
 
 // NOTE: `pub const js = jsc.Codegen.JSParsedShellScript;` and the
 // `toJS`/`fromJS`/`fromJSDirect` re-exports are provided by the
@@ -233,48 +233,20 @@ fn create_parsed_shell_script_impl(
         marked_argument_buffer,
     )?;
 
-    // Reshaped for borrowck — `out_parser`/`out_lex_result` borrow
-    // `shargs.__arena`, so they're scoped to a block that ends before
-    // `shargs.script_ast = script` below. The arena reference is taken via raw
-    // pointer so the `&shargs` borrow doesn't outlive the call (the returned
-    // `ast::Script` is lifetime-erased).
-    let arena_ptr: *const bun_alloc::Arena = shargs.arena();
-    let script_ast = {
-        // SAFETY: `shargs` lives on this stack frame for the whole block; arena
-        // is not moved/dropped while `out_parser`/`out_lex_result` borrow it.
-        let arena = unsafe { &*arena_ptr };
-        let mut out_parser: Option<bun_shell_parser::Parser<'_>> = None;
-        let mut out_lex_result: Option<bun_shell_parser::LexResult<'_>> = None;
-        match Interpreter::parse(
-            arena,
-            &script[..],
-            &mut jsobjs[..],
-            &jsstrings[..],
-            &mut out_parser,
-            &mut out_lex_result,
-        ) {
-            Ok(ast) => ast,
-            Err(err) => {
-                // `out_lex_result.is_some()` ⇔ `err == ParseError::Lex` — `Interpreter::parse`
-                // only populates `out_lex_result` on the Lex error path.
-                if let Some(lex) = out_lex_result.as_ref() {
-                    debug_assert!(!lex.errors.is_empty());
-                    let str = lex.combine_errors(arena);
-                    return Err(global.throw(format_args!("{}", bstr::BStr::new(str))));
-                }
-
-                if let Some(p) = out_parser.as_mut() {
-                    debug_assert!(!p.errors.is_empty());
-                    let errstr = p.combine_errors();
-                    return Err(global.throw(format_args!("{}", bstr::BStr::new(errstr))));
-                }
-
-                return Err(global.throw_error(err, "failed to lex/parse shell"));
+    if let Err(err) = shargs.parse(&script[..], &jsstrings[..], jsobjs.len() as u32) {
+        use bun_shell_parser::ParseFailure;
+        return Err(match err {
+            ParseFailure::Diagnostic(msg) => {
+                global.throw(format_args!("{}", bstr::BStr::new(&msg)))
             }
-        }
-    };
-
-    shargs.set_script_ast(script_ast);
+            ParseFailure::Lexer(e) => {
+                global.throw_error(crate::Error::from(e), "failed to lex/parse shell")
+            }
+            ParseFailure::Other(e) => {
+                global.throw_error(crate::Error::from(e), "failed to lex/parse shell")
+            }
+        });
+    }
 
     let mut parsed_shell_script = Box::new(ParsedShellScript {
         args: JsCell::new(Some(shargs)),

--- a/src/runtime/shell/Yield.rs
+++ b/src/runtime/shell/Yield.rs
@@ -3,7 +3,7 @@
 //! See the doc comment on `Yield` for the design. The Rust port carries
 //! `NodeId`s (indices into `Interpreter::nodes`) instead of `&mut State`
 //! borrows; state is reached through the `&Interpreter` threaded through
-//! `run` (per-node `RefCell`s).
+//! `run` (per-node cells).
 
 use core::cell::Cell;
 

--- a/src/runtime/shell/Yield.rs
+++ b/src/runtime/shell/Yield.rs
@@ -2,8 +2,8 @@
 //!
 //! See the doc comment on `Yield` for the design. The Rust port carries
 //! `NodeId`s (indices into `Interpreter::nodes`) instead of `&mut State`
-//! borrows — the only `&mut` is the `&Interpreter` threaded through
-//! `run`.
+//! borrows; state is reached through the `&Interpreter` threaded through
+//! `run` (per-node `RefCell`s).
 
 use core::cell::Cell;
 

--- a/src/runtime/shell/builtin/basename.rs
+++ b/src/runtime/shell/builtin/basename.rs
@@ -9,7 +9,7 @@ pub struct Basename {
     buf: Vec<u8>,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 enum State {
     #[default]
     Idle,
@@ -19,12 +19,12 @@ enum State {
 
 impl Basename {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
+        if Builtin::argc(interp, cmd) == 0 {
+            return Self::fail(interp, cmd, Kind::Basename.usage_string());
+        }
         let buf = {
             let bltn = Builtin::of(interp, cmd);
             let argc = bltn.args_slice().len();
-            if argc == 0 {
-                return Self::fail(interp, cmd, Kind::Basename.usage_string());
-            }
             let mut buf = Vec::new();
             for i in 0..argc {
                 buf.extend_from_slice(bun_paths::resolve_path::basename(bltn.arg_bytes(i)));
@@ -34,13 +34,12 @@ impl Basename {
         };
 
         Self::state_mut(interp, cmd).state = State::Done;
-        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+        if let Some(safeguard) = stdout_needs_io {
             Self::state_mut(interp, cmd).buf = buf;
             let owned = Self::state_mut(interp, cmd).buf.clone();
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd)
-                .stdout
-                .enqueue(child, &owned, safeguard);
+            return Builtin::write_out(interp, cmd, IoKind::Stdout, child, &owned, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
         Builtin::done(interp, cmd, 0)
@@ -61,7 +60,8 @@ impl Basename {
             Self::state_mut(interp, cmd).state = State::Err;
             return Builtin::done(interp, cmd, 1);
         }
-        match Self::state_mut(interp, cmd).state {
+        let state = Self::state_mut(interp, cmd).state;
+        match state {
             State::Done => Builtin::done(interp, cmd, 0),
             State::Err => Builtin::done(interp, cmd, 1),
             State::Idle => unreachable!("Basename.onIOWriterChunk: idle"),

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -1,9 +1,11 @@
+use bun_ptr::RefPtr;
+
 use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinIO, BuiltinInput, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     FlagParser, Interpreter, NodeId, ParseFlagResult, shell_openat, unsupported_flag,
 };
-use crate::shell::io_reader::{ChildPtr as ReaderChildPtr, IOReader, IOReaderRef, ReaderTag};
+use crate::shell::io_reader::{ChildPtr as ReaderChildPtr, IOReader, ReaderTag};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
 
@@ -28,7 +30,7 @@ pub enum CatState {
         /// Current index into the filepath args.
         idx: usize,
         /// Per-file reader.
-        reader: Option<IOReaderRef>,
+        reader: Option<RefPtr<IOReader>>,
         chunks_queued: usize,
         chunks_done: usize,
         out_done: bool,

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
 use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinIO, BuiltinInput, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
-    FlagParser, Interpreter, NodeId, ParseFlagResult, parse_flags, shell_openat, unsupported_flag,
+    FlagParser, Interpreter, NodeId, ParseFlagResult, shell_openat, unsupported_flag,
 };
-use crate::shell::io_reader::{ChildPtr as ReaderChildPtr, IOReader, ReaderTag};
+use crate::shell::io_reader::{ChildPtr as ReaderChildPtr, IOReader, IOReaderRef, ReaderTag};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
 
@@ -30,7 +28,7 @@ pub enum CatState {
         /// Current index into the filepath args.
         idx: usize,
         /// Per-file reader.
-        reader: Option<Arc<IOReader>>,
+        reader: Option<IOReaderRef>,
         chunks_queued: usize,
         chunks_done: usize,
         out_done: bool,
@@ -59,16 +57,12 @@ impl Step {
 impl Cat {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
         let mut opts = Opts::default();
-        let filepath_start = {
-            let args = Builtin::of(interp, cmd).args_slice();
-            match parse_flags(&mut opts, args) {
-                Ok(Some(rest)) => Some(args.len() - rest.len()),
-                Ok(None) => None,
-                Err(e) => {
-                    return Builtin::fail_parse(interp, cmd, Kind::Cat, &e, || {
-                        Self::state_mut(interp, cmd).state = CatState::WaitingWriteErr
-                    });
-                }
+        let filepath_start = match Builtin::parse_flags(interp, cmd, &mut opts) {
+            Ok(start) => start,
+            Err(e) => {
+                return Builtin::fail_parse(interp, cmd, Kind::Cat, &e, || {
+                    Self::state_mut(interp, cmd).state = CatState::WaitingWriteErr
+                });
             }
         };
 
@@ -103,12 +97,11 @@ impl Cat {
         buf: &[u8],
         exit_code: ExitCode,
     ) -> Yield {
-        if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
+        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
+        if let Some(safeguard) = stderr_needs_io {
             Self::state_mut(interp, cmd).state = CatState::WaitingWriteErr;
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd)
-                .stderr
-                .enqueue(child, buf, safeguard);
+            return Builtin::write_out(interp, cmd, IoKind::Stderr, child, buf, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, buf);
         Builtin::done(interp, cmd, exit_code)
@@ -145,25 +138,30 @@ impl Cat {
                     }
                     // Copy stdin bytes so the &mut on `stdout`/`write_no_io`
                     // doesn't overlap a borrow of `stdin`.
-                    let buf = Builtin::read_stdin_no_io(interp, cmd).to_vec();
-                    if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+                    let buf = Builtin::of(interp, cmd).read_stdin_no_io().to_vec();
+                    let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+                    if let Some(safeguard) = stdout_needs_io {
                         let child = ChildPtr::new(cmd, WriterTag::Builtin);
-                        return Builtin::of_mut(interp, cmd)
-                            .stdout
-                            .enqueue(child, &buf, safeguard);
+                        return Builtin::write_out(
+                            interp,
+                            cmd,
+                            IoKind::Stdout,
+                            child,
+                            &buf,
+                            safeguard,
+                        );
                     }
                     let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
                     return Builtin::done(interp, cmd, 0);
                 }
-                // Clone the `Arc<IOReader>`
+                // Clone the `Rc<IOReader>`
                 // out of `stdin` so we hold no borrow of `interp` across
-                // `start()` (which may re-enter via the raw interp backref).
-                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+                // `start()` (which may re-enter via the interp backref).
                 let reader = match &Builtin::of(interp, cmd).stdin {
-                    BuiltinInput::Fd(r) => Arc::clone(r),
+                    BuiltinInput::Fd(r) => r.clone(),
                     _ => unreachable!("needs_io() returned true"),
                 };
-                reader.set_interp(interp_ptr);
+                reader.set_interp(interp);
                 reader.add_reader(ReaderChildPtr {
                     node: cmd,
                     tag: ReaderTag::Cat,
@@ -188,8 +186,6 @@ impl Cat {
                     *reader = None;
                 }
 
-                let path = Builtin::of(interp, cmd).arg_zstr(args_start + idx);
-
                 if let CatState::ExecFilepathArgs { idx: i, .. } =
                     &mut Self::state_mut(interp, cmd).state
                 {
@@ -197,20 +193,23 @@ impl Cat {
                 }
 
                 let dir = Builtin::cwd(interp, cmd);
-                let fd = match shell_openat(dir, path, bun_sys::O::RDONLY, 0) {
+                let opened = {
+                    let bltn = Builtin::of(interp, cmd);
+                    let path = bltn.arg_zstr(args_start + idx);
+                    shell_openat(dir, path, bun_sys::O::RDONLY, 0)
+                };
+                let fd = match opened {
                     Ok(fd) => fd,
                     Err(e) => {
-                        let buf =
-                            Builtin::task_error_to_string(interp, cmd, Kind::Cat, &e).to_vec();
+                        let buf = Builtin::task_error_to_string(Kind::Cat, &e);
                         // The reader was already taken to `None` above.
                         return Self::write_failing_error(interp, cmd, &buf, 1);
                     }
                 };
 
                 let evtloop = Builtin::event_loop(interp, cmd);
-                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
                 let reader = IOReader::init(fd, evtloop);
-                reader.set_interp(interp_ptr);
+                reader.set_interp(interp);
                 if let CatState::ExecFilepathArgs {
                     reader: slot,
                     chunks_done,
@@ -224,7 +223,7 @@ impl Cat {
                     *chunks_queued = 0;
                     *in_done = false;
                     *out_done = false;
-                    *slot = Some(Arc::clone(&reader));
+                    *slot = Some(reader.clone());
                 }
                 reader.add_reader(ReaderChildPtr {
                     node: cmd,
@@ -249,29 +248,34 @@ impl Cat {
                 tag: ReaderTag::Cat,
             };
             // Writing to stdout errored: cancel everything and finish.
-            // Pull the reader `Arc` out of
+            // Pull the reader out of
             // state before calling `remove_reader`, then drop it.
-            match &mut Self::state_mut(interp, cmd).state {
-                CatState::ExecStdin {
-                    in_done,
-                    errno: st_errno,
-                    ..
-                } => {
-                    *st_errno = errno;
-                    let was_done = core::mem::replace(in_done, true);
-                    if !was_done {
-                        if let BuiltinInput::Fd(r) = &Builtin::of(interp, cmd).stdin {
+            {
+                let mut bltn = Builtin::of_mut(interp, cmd);
+                let bltn = &mut *bltn;
+                let stdin = &bltn.stdin;
+                match &mut Self::extract(&mut bltn.impl_).state {
+                    CatState::ExecStdin {
+                        in_done,
+                        errno: st_errno,
+                        ..
+                    } => {
+                        *st_errno = errno;
+                        let was_done = core::mem::replace(in_done, true);
+                        if !was_done {
+                            if let BuiltinInput::Fd(r) = stdin {
+                                r.remove_reader(rchild);
+                            }
+                        }
+                    }
+                    CatState::ExecFilepathArgs { reader, .. } => {
+                        if let Some(r) = reader.take() {
                             r.remove_reader(rchild);
                         }
                     }
+                    CatState::WaitingWriteErr => {}
+                    _ => panic!("Invalid state"),
                 }
-                CatState::ExecFilepathArgs { reader, .. } => {
-                    if let Some(r) = reader.take() {
-                        r.remove_reader(rchild);
-                    }
-                }
-                CatState::WaitingWriteErr => {}
-                _ => panic!("Invalid state"),
             }
             return Builtin::done(interp, cmd, errno);
         }
@@ -321,18 +325,20 @@ impl Cat {
     ) -> Yield {
         *remove = false;
         let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
-        match &mut Self::state_mut(interp, cmd).state {
-            CatState::ExecStdin { chunks_queued, .. }
-            | CatState::ExecFilepathArgs { chunks_queued, .. } => {
-                if let Some(safeguard) = stdout_needs_io {
-                    *chunks_queued += 1;
-                    let child = ChildPtr::new(cmd, WriterTag::Builtin);
-                    return Builtin::of_mut(interp, cmd)
-                        .stdout
-                        .enqueue(child, chunk, safeguard);
-                }
+        if let Some(safeguard) = stdout_needs_io {
+            match &mut Self::state_mut(interp, cmd).state {
+                CatState::ExecStdin { chunks_queued, .. }
+                | CatState::ExecFilepathArgs { chunks_queued, .. } => *chunks_queued += 1,
+                _ => panic!("Invalid state"),
             }
-            _ => panic!("Invalid state"),
+            let child = ChildPtr::new(cmd, WriterTag::Builtin);
+            return Builtin::write_out(interp, cmd, IoKind::Stdout, child, chunk, safeguard);
+        }
+        if !matches!(
+            Self::state_mut(interp, cmd).state,
+            CatState::ExecStdin { .. } | CatState::ExecFilepathArgs { .. }
+        ) {
+            panic!("Invalid state");
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, chunk);
         Yield::done()
@@ -421,9 +427,7 @@ impl FlagParser for Opts {
             b't' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-t"))),
             b'u' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-u"))),
             b'v' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-v"))),
-            _ => Some(ParseFlagResult::IllegalOption(
-                &raw const smallflags[1 + i..],
-            )),
+            _ => Some(ParseFlagResult::IllegalOption(smallflags[1 + i..].into())),
         }
     }
 }

--- a/src/runtime/shell/builtin/cd.rs
+++ b/src/runtime/shell/builtin/cd.rs
@@ -22,8 +22,8 @@ enum State {
 
 impl Cd {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
-        let args = Builtin::of(interp, cmd).args_slice();
-        if args.len() > 1 {
+        let argc = Builtin::of(interp, cmd).args_slice().len();
+        if argc > 1 {
             return Self::write_stderr_non_blocking(
                 interp,
                 cmd,
@@ -31,8 +31,9 @@ impl Cd {
             );
         }
 
-        if args.is_empty() {
-            let home_str = Builtin::shell(interp, cmd).get_homedir();
+        let shell = Builtin::shell(interp, cmd);
+        if argc == 0 {
+            let home_str = shell.borrow().get_homedir();
             let home = home_str.slice().to_vec();
             home_str.deref();
             if home.is_empty() {
@@ -42,21 +43,24 @@ impl Cd {
                     format_args!("HOME not set\n"),
                 );
             }
-            if let Err(err) = interp.as_cmd_mut(cmd).base.shell_mut().change_cwd(&home) {
+            let res = shell.borrow_mut().change_cwd(&home);
+            if let Err(err) = res {
                 return Self::handle_change_cwd_err(interp, cmd, &err, &home);
             }
             return Builtin::done(interp, cmd, 0);
         }
 
-        let first_arg = Builtin::of(interp, cmd).arg_bytes(0);
+        let first_arg = Builtin::of(interp, cmd).arg_bytes(0).to_vec();
         if first_arg == b"-" {
-            let prev = Builtin::shell(interp, cmd).prev_cwd().to_vec();
-            if let Err(err) = interp.as_cmd_mut(cmd).base.shell_mut().change_prev_cwd() {
+            let prev = shell.borrow().prev_cwd().to_vec();
+            let res = shell.borrow_mut().change_prev_cwd();
+            if let Err(err) = res {
                 return Self::handle_change_cwd_err(interp, cmd, &err, &prev);
             }
         } else {
-            let target = first_arg.to_vec();
-            if let Err(err) = interp.as_cmd_mut(cmd).base.shell_mut().change_cwd(&target) {
+            let target = first_arg;
+            let res = shell.borrow_mut().change_cwd(&target);
+            if let Err(err) = res {
                 return Self::handle_change_cwd_err(interp, cmd, &err, &target);
             }
         }
@@ -102,16 +106,20 @@ impl Cd {
         args: core::fmt::Arguments<'_>,
     ) -> Yield {
         Self::state_mut(interp, cmd).state = State::WaitingIo;
-        if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
+        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
+        if let Some(safeguard) = stderr_needs_io {
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd).stderr.enqueue_fmt(
+            return Builtin::write_out_fmt(
+                interp,
+                cmd,
+                IoKind::Stderr,
                 child,
                 Some(Kind::Cd),
                 args,
                 safeguard,
             );
         }
-        let buf = Builtin::fmt_error_arena(interp, cmd, Some(Kind::Cd), args).to_vec();
+        let buf = Builtin::fmt_error_arena(Some(Kind::Cd), args);
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, &buf);
         Self::state_mut(interp, cmd).state = State::Done;
         Builtin::done(interp, cmd, 1)

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -3,8 +3,8 @@ use bun_paths::resolve_path;
 use crate::node::PathLike;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
-    EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable, OutputWrite,
+    ParseFlagResult, ShellTask, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -14,12 +14,11 @@ use crate::shell::{ExitCode, ShellErr};
 pub struct Cp {
     pub(crate) opts: Opts,
     pub(crate) state: State,
-    /// FIFO of in-flight OutputTask pointers awaiting an IOWriter chunk
-    /// completion. Stopgap until `WriterTag` can carry the `*mut OutputTask`
-    /// directly (see mkdir.rs `Exec::output_queue`). Lives on `Cp` (not
-    /// `ExecState`) because `print_shell_cp_task` is also driven from
-    /// `State::Ebusy` on Windows; both states must be able to stash/pop.
-    pub(crate) output_queue: std::collections::VecDeque<*mut OutputTask<Cp>>,
+    /// FIFO of in-flight OutputTasks awaiting an IOWriter chunk completion
+    /// (see mkdir.rs `Exec::output_queue`). Lives on `Cp` (not `ExecState`)
+    /// because `print_shell_cp_task` is also driven from `State::Ebusy` on
+    /// Windows; both states must be able to park/pop.
+    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Cp>>>,
 }
 
 #[derive(Default)]
@@ -55,7 +54,9 @@ pub struct ExecState {
 #[cfg(windows)]
 #[derive(Default)]
 pub struct EbusyState {
-    pub(crate) tasks: Vec<*mut ShellCpTask>,
+    /// Deferred EBUSY tasks; `None` once `ignore_ebusy_error_if_possible` has
+    /// consumed the slot.
+    pub(crate) tasks: Vec<Option<Box<ShellCpTask>>>,
     pub(crate) idx: usize,
     pub(crate) main_exit_code: ExitCode,
     /// Absolute target paths that some task copied successfully — used to
@@ -68,12 +69,9 @@ impl Cp {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
         let mut opts = Opts::default();
         let (sources_start, target_idx) = {
-            let args = Builtin::of(interp, cmd).args_slice();
-            match parse_flags(&mut opts, args) {
-                Ok(Some(rest)) if rest.len() > 1 => {
-                    let start = args.len() - rest.len();
-                    (start, args.len() - 1)
-                }
+            let argc = Builtin::argc(interp, cmd);
+            match Builtin::parse_flags(interp, cmd, &mut opts) {
+                Ok(Some(start)) if argc - start > 1 => (start, argc - 1),
                 Ok(_) => {
                     Self::state_mut(interp, cmd).state = State::WaitingWriteErr;
                     return Builtin::write_failing_error(interp, cmd, Kind::Cp.usage_string(), 1);
@@ -109,6 +107,11 @@ impl Cp {
             },
             #[cfg(windows)]
             Ebusy(ExitCode),
+            #[cfg(windows)]
+            IgnoreEbusy,
+            Suspend,
+            Failed,
+            AlreadyDone,
         }
         let action = match &mut Self::state_mut(interp, cmd).state {
             State::Idle => panic!(
@@ -130,7 +133,7 @@ impl Cp {
                         let act = Action::Done(exit_code);
                         act
                     } else {
-                        return Yield::suspended();
+                        Action::Suspend
                     }
                 } else {
                     exec.started = true;
@@ -143,47 +146,51 @@ impl Cp {
                 }
             }
             #[cfg(windows)]
-            State::Ebusy(_) => return Self::ignore_ebusy_error_if_possible(interp, cmd),
-            State::WaitingWriteErr => return Yield::failed(),
-            State::Done => return Builtin::done(interp, cmd, 0),
+            State::Ebusy(_) => Action::IgnoreEbusy,
+            State::WaitingWriteErr => Action::Failed,
+            State::Done => Action::AlreadyDone,
         };
         match action {
+            Action::Suspend => Yield::suspended(),
+            Action::Failed => Yield::failed(),
+            Action::AlreadyDone => Builtin::done(interp, cmd, 0),
+            #[cfg(windows)]
+            Action::IgnoreEbusy => Self::ignore_ebusy_error_if_possible(interp, cmd),
             Action::Done(code) => {
                 Self::state_mut(interp, cmd).state = State::Done;
                 Builtin::done(interp, cmd, code)
             }
             #[cfg(windows)]
             Action::Ebusy(exit_code) => {
-                let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state else {
-                    unreachable!()
-                };
-                let mut ebusy = core::mem::take(&mut exec.ebusy);
-                ebusy.idx = 0;
-                ebusy.main_exit_code = exit_code;
-                Self::state_mut(interp, cmd).state = State::Ebusy(ebusy);
+                {
+                    let mut me = Self::state_mut(interp, cmd);
+                    let State::Exec(exec) = &mut me.state else {
+                        unreachable!()
+                    };
+                    let mut ebusy = core::mem::take(&mut exec.ebusy);
+                    ebusy.idx = 0;
+                    ebusy.main_exit_code = exit_code;
+                    me.state = State::Ebusy(ebusy);
+                }
                 Self::ignore_ebusy_error_if_possible(interp, cmd)
             }
             Action::Schedule { start, target } => {
-                let cwd = Builtin::shell(interp, cmd).cwd().to_vec();
+                let cwd = Builtin::shell(interp, cmd).borrow().cwd().to_vec();
                 let opts = Self::state_mut(interp, cmd).opts;
-                let evtloop = Builtin::event_loop(interp, cmd);
                 let tgt = Builtin::of(interp, cmd).arg_bytes(target).to_vec();
                 let operands = 1 + (target - start);
-                let interp_ptr = interp.as_ctx_ptr();
                 for i in start..target {
                     let src = Builtin::of(interp, cmd).arg_bytes(i).to_vec();
                     let task = ShellCpTask::create(
                         cmd,
-                        evtloop,
                         opts,
                         operands,
                         src,
                         tgt.clone(),
                         cwd.clone(),
-                        interp_ptr,
+                        interp,
                     );
-                    // SAFETY: freshly heap-allocated.
-                    unsafe { ShellCpTask::schedule(task) };
+                    ShellTask::schedule(task);
                 }
                 Yield::suspended()
             }
@@ -199,10 +206,9 @@ impl Cp {
         if matches!(Self::state_mut(interp, cmd).state, State::WaitingWriteErr) {
             return Builtin::done(interp, cmd, 1);
         }
-        if let Some(task) = Self::state_mut(interp, cmd).output_queue.pop_front() {
-            // SAFETY: `task` was heap-allocated in `OutputTask::new` and
-            // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Cp>::on_io_writer_chunk(task, interp, written, e) };
+        let pending = Self::state_mut(interp, cmd).output_queue.pop_front();
+        if let Some(task) = pending {
+            return OutputTask::<Cp>::on_io_writer_chunk(task, interp, written, e);
         }
         Self::next(interp, cmd)
     }
@@ -221,17 +227,13 @@ impl Cp {
                     unreachable!()
                 };
                 if eb.idx < eb.tasks.len() {
-                    let t = eb.tasks[eb.idx];
+                    let t = eb.tasks[eb.idx].take().expect("ebusy task consumed once");
                     eb.idx += 1;
-                    // SAFETY: `t` is a live heap-allocated task stashed in
-                    // `on_shell_cp_task_done`; not yet freed.
-                    let tref = unsafe { &*t };
-                    let ignorable = tref
+                    let ignorable = t
                         .tgt_absolute
                         .as_ref()
                         .map_or(false, |p| eb.absolute_targets.contains(p))
-                        || tref
-                            .src_absolute
+                        || t.src_absolute
                             .as_ref()
                             .map_or(false, |p| eb.absolute_srcs.contains(p));
                     Some((t, ignorable))
@@ -240,40 +242,35 @@ impl Cp {
                 }
             };
             match next {
-                Some((t, true)) => {
-                    // SAFETY: paired with `heap::alloc` in `create()`.
-                    drop(unsafe { bun_core::heap::take(t) });
-                }
-                // SAFETY: `t` is a live heap task stashed in
-                // `on_shell_cp_task_done`; reclaim ownership.
-                Some((t, false)) => {
-                    return Self::print_shell_cp_task(interp, cmd, unsafe {
-                        bun_core::heap::take(t)
-                    });
-                }
+                Some((t, true)) => drop(t),
+                Some((t, false)) => return Self::print_shell_cp_task(interp, cmd, t),
                 None => break,
             }
         }
-        let State::Ebusy(eb) = &mut Self::state_mut(interp, cmd).state else {
-            unreachable!()
+        let exit_code = {
+            let me = Self::state_mut(interp, cmd);
+            let State::Ebusy(eb) = &me.state else {
+                unreachable!()
+            };
+            eb.main_exit_code
         };
-        let exit_code = eb.main_exit_code;
         // `Drop` frees the ebusy sets/vec here.
         Self::state_mut(interp, cmd).state = State::Done;
         Builtin::done(interp, cmd, exit_code)
     }
 
-    fn on_shell_cp_task_done(interp: &Interpreter, cmd: NodeId, task: *mut ShellCpTask) {
+    fn on_shell_cp_task_done(
+        interp: &Interpreter,
+        cmd: NodeId,
+        #[cfg_attr(not(windows), allow(unused_mut))] mut task: Box<ShellCpTask>,
+    ) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.tasks_count -= 1;
         }
-        // SAFETY: `task` was heap-allocated in `create()`; ownership transfers
-        // to this completion callback. Re-leaked below only on the EBUSY-defer path.
-        #[cfg_attr(not(windows), allow(unused_mut))]
-        let mut task = unsafe { bun_core::heap::take(task) };
         #[cfg(windows)]
         {
-            if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
+            let mut me = Self::state_mut(interp, cmd);
+            if let State::Exec(exec) = &mut me.state {
                 if let Some(err) = &task.err {
                     // Defer the task to the ebusy phase. Note the precedence:
                     //   `(is_sys && errno==EBUSY && tgt_match) || src_match`
@@ -287,7 +284,8 @@ impl Cp {
                             || task.src_absolute.as_deref()
                                     .map_or(false, |p| sys.path.eql_utf8(p)));
                     if is_ebusy {
-                        exec.ebusy.tasks.push(bun_core::heap::into_raw(task));
+                        exec.ebusy.tasks.push(Some(task));
+                        drop(me);
                         return Self::next(interp, cmd).run(interp);
                     }
                 } else {
@@ -301,6 +299,7 @@ impl Cp {
                     }
                 }
             }
+            drop(me);
         }
         Self::print_shell_cp_task(interp, cmd, task).run(interp);
     }
@@ -316,7 +315,7 @@ impl Cp {
         let output_task = OutputTask::<Cp>::new(cmd, OutputSrc::Arrlist(output));
 
         let errstr: Option<Vec<u8>> = task.err.take().map(|e| {
-            let s = Builtin::shell_err_to_string(interp, cmd, Kind::Cp, &e).to_vec();
+            let s = Builtin::shell_err_to_string(Kind::Cp, &e);
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                 exec.err = Some(e);
             }
@@ -331,25 +330,29 @@ impl OutputTaskVTable for Cp {
     fn write_err(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
+        child: Box<OutputTask<Self>>,
         errbuf: &[u8],
-    ) -> Option<Yield> {
+    ) -> OutputWrite<Self> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
-        if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
-            // Stash so on_io_writer_chunk can route to the OutputTask state
-            // machine and reclaim the box (stopgap for missing WriterTag).
+        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
+        if let Some(safeguard) = stderr_needs_io {
+            // Park it so on_io_writer_chunk can route the completion back to
+            // the OutputTask state machine (there is no WriterTag for it).
             Self::state_mut(interp, cmd).output_queue.push_back(child);
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Some(
-                Builtin::of_mut(interp, cmd)
-                    .stderr
-                    .enqueue(childptr, errbuf, safeguard),
-            );
+            return OutputWrite::Enqueued(Builtin::write_out(
+                interp,
+                cmd,
+                IoKind::Stderr,
+                childptr,
+                errbuf,
+                safeguard,
+            ));
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        None
+        OutputWrite::Done(child)
     }
     fn on_write_err(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
@@ -359,25 +362,28 @@ impl OutputTaskVTable for Cp {
     fn write_out(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
-        output: &mut OutputSrc,
-    ) -> Option<Yield> {
+        child: Box<OutputTask<Self>>,
+    ) -> OutputWrite<Self> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
-        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-            Self::state_mut(interp, cmd).output_queue.push_back(child);
+        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+        if let Some(safeguard) = stdout_needs_io {
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            let buf = output.slice().to_vec();
-            return Some(
-                Builtin::of_mut(interp, cmd)
-                    .stdout
-                    .enqueue(childptr, &buf, safeguard),
-            );
+            return OutputWrite::Enqueued(Builtin::write_out_with(
+                interp,
+                cmd,
+                IoKind::Stdout,
+                childptr,
+                safeguard,
+                |buf| {
+                    buf.extend_from_slice(child.output.slice());
+                    Self::state_mut(interp, cmd).output_queue.push_back(child);
+                },
+            ));
         }
-        let buf = output.slice().to_vec();
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-        None
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, child.output.slice());
+        OutputWrite::Done(child)
     }
     fn on_write_out(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
@@ -411,18 +417,23 @@ pub struct ShellCpTask {
     pub task: ShellTask,
 }
 
+// The pool-side body is `run_on_pool`, not `ShellTask::run_owned`: on the
+// success path the copy is handed to a `ShellAsyncCpTask` that posts the
+// bounce-back itself (`cp_on_finish`), so an unconditional post would
+// double-enqueue.
+crate::shell_task!(ShellCpTask, run = ShellCpTask::run_on_pool);
+
 impl ShellCpTask {
     fn create(
         cmd: NodeId,
-        evtloop: EventLoopHandle,
         opts: Opts,
         operands: usize,
         src: Vec<u8>,
         tgt: Vec<u8>,
         cwd_path: Vec<u8>,
-        interp: *mut Interpreter,
-    ) -> *mut ShellCpTask {
-        let mut task = Box::new(ShellCpTask {
+        interp: &Interpreter,
+    ) -> Box<ShellCpTask> {
+        Box::new(ShellCpTask {
             cmd,
             opts,
             operands,
@@ -433,12 +444,8 @@ impl ShellCpTask {
             cwd_path,
             verbose_output: bun_threading::Guarded::new(Vec::new()),
             err: None,
-            task: ShellTask::new(evtloop),
-        });
-        // Back-ref so `ShellTask::run_from_main_thread::<ShellCpTask>` (the
-        // dispatch.rs bounce-back) can recover `&Interpreter`.
-        task.task.interp = interp;
-        bun_core::heap::into_raw(task)
+            task: ShellTask::new(interp),
+        })
     }
 
     /// Appends `"{src} -> {dest}\n"` to the verbose
@@ -476,15 +483,13 @@ impl ShellCpTask {
         }
     }
 
-    /// Called when the node:fs
-    /// async cp completes (success or first error). Records the error (if any)
-    /// and re-queues this `ShellCpTask` onto the JS thread so the interpreter
-    /// can drain `verbose_output` / surface the error.
+    /// Called on the JS thread when the node:fs async cp completes (success or
+    /// first error). Records the error (if any) and finishes this `ShellCpTask`
+    /// in place so the interpreter can drain `verbose_output` / surface it.
     ///
     /// # Safety
-    /// `this` is the live `heap::alloc`'d task originally passed to
-    /// [`schedule`](Self::schedule); not touched again on this thread after
-    /// return.
+    /// `this` is the live task `run_on_pool` released to the
+    /// `ShellAsyncCpTask`; reclaimed here, not touched by the caller after.
     pub(crate) unsafe fn cp_on_finish(
         this: *mut ShellCpTask,
         src: PathLike<'static>,
@@ -492,58 +497,30 @@ impl ShellCpTask {
         result: bun_sys::Maybe<()>,
     ) {
         // SAFETY: caller contract — JS thread, from the `ShellAsyncCpTask`'s
-        // completion; `this` is live and ours. The pool side finished (and
-        // dropped its poster) when it handed the copy to that task, so continue
-        // in place rather than bouncing through the concurrent queue again.
-        unsafe {
-            (*this).src_absolute = Some(src.into_vec());
-            (*this).tgt_absolute = Some(dest.into_vec());
-            if let Err(e) = result {
-                (*this).err = Some(ShellErr::new_sys(&e));
-            }
-            ShellTask::run_from_main_thread::<ShellCpTask>(this);
+        // completion; `this` is live and ours (the box `run_on_pool` released
+        // to it). The pool side finished (and dropped its poster) when it
+        // handed the copy to that task, so continue in place rather than
+        // bouncing through the concurrent queue again.
+        let mut this = unsafe { bun_core::heap::take(this) };
+        this.src_absolute = Some(src.into_vec());
+        this.tgt_absolute = Some(dest.into_vec());
+        if let Err(e) = result {
+            this.err = Some(ShellErr::new_sys(&e));
         }
+        ShellTask::run_from_main_thread::<ShellCpTask>(this);
     }
 
-    /// Unlike most shell builtins this does NOT use the generic
-    /// [`ShellTask::schedule`] trampoline (which auto-enqueues back to main
-    /// on return): on the
-    /// success path the [`ShellAsyncCpTask`](crate::node::fs::ShellAsyncCpTask)
-    /// owns the bounce-back via `cp_on_finish`, so an unconditional post would
-    /// double-enqueue. The embedded [`ShellTask`] is reused for its
-    /// `WorkPoolTask` / `concurrent_task` / `keep_alive` storage.
-    ///
-    /// # Safety
-    /// `this` must be a fresh `heap::alloc`'d task (see [`create`]).
-    unsafe fn schedule(this: *mut ShellCpTask) {
-        use bun_threading::work_pool::WorkPool;
-        // SAFETY: `this` is live; `task` is the embedded `ShellTask`. Stay on
-        // raw pointers — once `WorkPool::schedule` returns the worker thread
-        // may already be running.
+    /// Pool-side body: run the impl, and on error post back immediately;
+    /// the success path hands the allocation to a `ShellAsyncCpTask`, whose
+    /// completion (`cp_on_finish`) reclaims it.
+    fn run_on_pool(this: Box<ShellCpTask>) {
+        let this = bun_core::heap::into_raw(this);
+        // SAFETY: `this` is the box just released; the worker thread has
+        // exclusive access until it is handed off. Raw because on success the
+        // `ShellAsyncCpTask` it now belongs to may free it from another thread
+        // at once.
         unsafe {
-            let st = &raw mut (*this).task;
-            (*st).task.callback = Self::work_pool_callback;
-            (*st).keep_alive.ref_((*st).event_loop.as_event_loop_ctx());
-            (*st).arm();
-            WorkPool::schedule(&raw mut (*st).task);
-        }
-    }
-
-    /// Recover `*ShellCpTask` from the
-    /// intrusive `*WorkPoolTask`, run the impl, and on error post back
-    /// immediately (success path defers the post to `cp_on_finish`).
-    unsafe fn work_pool_callback(task: *mut crate::shell::interpreter::WorkPoolTask) {
-        // SAFETY: `task` is the first `#[repr(C)]` field of `ShellTask`, which
-        // is embedded in `ShellCpTask` at `TASK_OFFSET`. `this` is a live
-        // heap-allocated task; the worker thread has exclusive access until
-        // the bounce-back is posted.
-        unsafe {
-            let this = bun_ptr::container_of::<ShellCpTask, _>(
-                task,
-                <Self as crate::shell::interpreter::ShellTaskCtx>::TASK_OFFSET,
-            );
-            // Moved out first: on success the copy is handed to a
-            // `ShellAsyncCpTask` whose completion may free `*this` at once.
+            // Moved out first: see above.
             let poster = (*this)
                 .task
                 .poster
@@ -552,7 +529,7 @@ impl ShellCpTask {
             if let Some(e) = (*this).run_from_thread_pool_impl(&poster) {
                 (*this).err = Some(e);
                 (*this).task.poster = Some(poster);
-                Self::enqueue_to_event_loop(this);
+                ShellTask::on_finish::<ShellCpTask>(bun_core::heap::take(this));
             } else {
                 // The copy now belongs to a `ShellAsyncCpTask` (holding its
                 // own poster, completing on the JS thread via `cp_on_finish`);
@@ -560,18 +537,6 @@ impl ShellCpTask {
                 drop(poster);
             }
         }
-    }
-
-    /// Post this task to the main-thread
-    /// concurrent queue; routed by `dispatch.rs` → [`run_from_main_thread`].
-    ///
-    /// # Safety
-    /// `this` is the live `heap::alloc`'d task; not touched again on this
-    /// thread after return.
-    unsafe fn enqueue_to_event_loop(this: *mut ShellCpTask) {
-        // Reuse the generic `ShellTask` post-back.
-        // SAFETY: caller contract.
-        unsafe { ShellTask::on_finish::<ShellCpTask>(this) };
     }
 
     fn has_trailing_sep(path: &[u8]) -> bool {
@@ -737,46 +702,27 @@ impl ShellCpTask {
 
         None
     }
-
-    /// # Safety
-    /// `this` must be a live `heap::alloc`'d task (see [`create`](Self::create));
-    /// ownership is consumed via [`Cp::on_shell_cp_task_done`].
-    fn run_from_main_thread(this: *mut ShellCpTask, interp: &Interpreter) {
-        // SAFETY: `this` is a live heap-allocated task per the caller's contract.
-        let cmd = unsafe { (*this).cmd };
-        Cp::on_shell_cp_task_done(interp, cmd, this);
-    }
 }
 
-impl bun_event_loop::Taskable for ShellCpTask {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellCpTask;
-    /// A pool completion that will not run: drop the keep-alive and the box
-    /// (nothing else frees an unrun one).
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — the box the builtin scheduled.
-        unsafe {
-            (*this).task.unref_unrun();
-            drop(bun_core::heap::take(this));
-        }
-    }
-}
+// `runtime::dispatch::run_task`'s `task_tag::ShellCpTask` arm reboxes the
+// pointer `ShellTask::on_finish` posted; a completion that will not run drops
+// the keep-alive and the box.
 
 impl crate::shell::interpreter::ShellTaskCtx for ShellCpTask {
-    const TASK_OFFSET: usize = core::mem::offset_of!(Self, task);
-    fn run_from_thread_pool(_this: &mut Self) {
-        // Not reached: `ShellCpTask::schedule` installs `work_pool_callback`
-        // directly (the generic trampoline auto-posts back, which would
-        // double-enqueue when the `ShellAsyncCpTask` later calls
-        // `cp_on_finish`).
-        debug_assert!(
-            false,
-            "ShellCpTask scheduled via ShellTask::schedule; use ShellCpTask::schedule"
-        );
+    fn shell_task(&self) -> &ShellTask {
+        &self.task
     }
-    fn run_from_main_thread(this: *mut Self, interp: &Interpreter) {
-        // SAFETY: `ShellTask::run_from_main_thread` dispatch contract — `this`
-        // is the live heap-allocated task posted via `ShellTask::schedule`.
-        Self::run_from_main_thread(this, interp)
+    fn shell_task_mut(&mut self) -> &mut ShellTask {
+        &mut self.task
+    }
+    fn run_from_thread_pool(&mut self) {
+        // Not reached: the pool-side entry is `run_on_pool` (see the
+        // `owned_task!` above), never `ShellTask::run_owned`.
+        debug_assert!(false, "ShellCpTask runs run_on_pool on the pool");
+    }
+    fn run_from_main_thread(self: Box<Self>, interp: &Interpreter) {
+        let cmd = self.cmd;
+        Cp::on_shell_cp_task_done(interp, cmd, self);
     }
 }
 
@@ -810,7 +756,7 @@ impl FlagParser for Opts {
                 Some(ParseFlagResult::ContinueParsing)
             }
             b'n' => Some(ParseFlagResult::ContinueParsing),
-            _ => Some(ParseFlagResult::IllegalOption(&raw const smallflags[i..])),
+            _ => Some(ParseFlagResult::IllegalOption(smallflags[i..].into())),
         }
     }
 }

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -1,24 +1,22 @@
 use bun_paths::resolve_path;
 
 use crate::node::PathLike;
-use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
+use crate::shell::builtin::{Builtin, BuiltinState, Kind};
 use crate::shell::interpreter::{
-    FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable, OutputWrite,
+    FlagParser, Interpreter, NodeId, OutputQueue, OutputSrc, OutputTask, OutputTaskVTable,
     ParseFlagResult, ShellTask, unsupported_flag,
 };
-use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
 use crate::shell::{ExitCode, ShellErr};
+use bun_ptr::JsCellRefMut;
 
 #[derive(Default)]
 pub struct Cp {
     pub(crate) opts: Opts,
     pub(crate) state: State,
-    /// FIFO of in-flight OutputTasks awaiting an IOWriter chunk completion
-    /// (see mkdir.rs `Exec::output_queue`). Lives on `Cp` (not `ExecState`)
-    /// because `print_shell_cp_task` is also driven from `State::Ebusy` on
-    /// Windows; both states must be able to park/pop.
-    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Cp>>>,
+    /// Lives on `Cp` (not `ExecState`) because `print_shell_cp_task` is also
+    /// driven from `State::Ebusy` on Windows; both states park tasks.
+    pub(crate) output: OutputQueue<Cp>,
 }
 
 #[derive(Default)]
@@ -41,8 +39,6 @@ pub struct ExecState {
     pub(crate) target_idx: usize,
     pub(crate) started: bool,
     pub(crate) tasks_count: u32,
-    pub(crate) output_waiting: u32,
-    pub(crate) output_done: u32,
     pub(crate) err: Option<ShellErr>,
     #[cfg(windows)]
     pub(crate) ebusy: EbusyState,
@@ -89,8 +85,6 @@ impl Cp {
             target_idx,
             started: false,
             tasks_count: 0,
-            output_waiting: 0,
-            output_done: 0,
             err: None,
             #[cfg(windows)]
             ebusy: EbusyState::default(),
@@ -113,13 +107,14 @@ impl Cp {
             Failed,
             AlreadyDone,
         }
+        let output_drained = Self::state_mut(interp, cmd).output.drained();
         let action = match &mut Self::state_mut(interp, cmd).state {
             State::Idle => panic!(
                 "Invalid state for \"Cp\": idle, this indicates a bug in Bun. Please file a GitHub issue"
             ),
             State::Exec(exec) => {
                 if exec.started {
-                    if exec.tasks_count == 0 && exec.output_done >= exec.output_waiting {
+                    if exec.tasks_count == 0 && output_drained {
                         let exit_code: ExitCode = if exec.err.is_some() { 1 } else { 0 };
                         exec.err = None;
                         #[cfg(windows)]
@@ -203,14 +198,14 @@ impl Cp {
         written: usize,
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
-        if matches!(Self::state_mut(interp, cmd).state, State::WaitingWriteErr) {
-            return Builtin::done(interp, cmd, 1);
-        }
-        let pending = Self::state_mut(interp, cmd).output_queue.pop_front();
-        if let Some(task) = pending {
-            return OutputTask::<Cp>::on_io_writer_chunk(task, interp, written, e);
-        }
-        Self::next(interp, cmd)
+        // Only the usage error is written directly; task output goes through
+        // `OutputTask::on_chunk`.
+        let _ = (written, e);
+        debug_assert!(matches!(
+            Self::state_mut(interp, cmd).state,
+            State::WaitingWriteErr
+        ));
+        Builtin::done(interp, cmd, 1)
     }
 
     /// Windows-only post-processing of tasks that failed with EBUSY: if some
@@ -327,69 +322,10 @@ impl Cp {
 }
 
 impl OutputTaskVTable for Cp {
-    fn write_err(
-        interp: &Interpreter,
-        cmd: NodeId,
-        child: Box<OutputTask<Self>>,
-        errbuf: &[u8],
-    ) -> OutputWrite<Self> {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_waiting += 1;
-        }
-        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
-        if let Some(safeguard) = stderr_needs_io {
-            // Park it so on_io_writer_chunk can route the completion back to
-            // the OutputTask state machine (there is no WriterTag for it).
-            Self::state_mut(interp, cmd).output_queue.push_back(child);
-            let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return OutputWrite::Enqueued(Builtin::write_out(
-                interp,
-                cmd,
-                IoKind::Stderr,
-                childptr,
-                errbuf,
-                safeguard,
-            ));
-        }
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        OutputWrite::Done(child)
+    fn output_queue(interp: &Interpreter, cmd: NodeId) -> JsCellRefMut<'_, OutputQueue<Self>> {
+        JsCellRefMut::map(Self::state_mut(interp, cmd), |me| &mut me.output)
     }
-    fn on_write_err(interp: &Interpreter, cmd: NodeId) {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_done += 1;
-        }
-    }
-    fn write_out(
-        interp: &Interpreter,
-        cmd: NodeId,
-        child: Box<OutputTask<Self>>,
-    ) -> OutputWrite<Self> {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_waiting += 1;
-        }
-        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
-        if let Some(safeguard) = stdout_needs_io {
-            let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return OutputWrite::Enqueued(Builtin::write_out_with(
-                interp,
-                cmd,
-                IoKind::Stdout,
-                childptr,
-                safeguard,
-                |buf| {
-                    buf.extend_from_slice(child.output.slice());
-                    Self::state_mut(interp, cmd).output_queue.push_back(child);
-                },
-            ));
-        }
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, child.output.slice());
-        OutputWrite::Done(child)
-    }
-    fn on_write_out(interp: &Interpreter, cmd: NodeId) {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_done += 1;
-        }
-    }
+
     fn on_done(interp: &Interpreter, cmd: NodeId) -> Yield {
         Self::next(interp, cmd)
     }

--- a/src/runtime/shell/builtin/dirname.rs
+++ b/src/runtime/shell/builtin/dirname.rs
@@ -19,12 +19,12 @@ enum State {
 
 impl Dirname {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
-        let bltn = Builtin::of(interp, cmd);
-        let argc = bltn.args_slice().len();
+        let argc = Builtin::argc(interp, cmd);
         if argc == 0 {
             return Self::fail(interp, cmd, b"usage: dirname string\n");
         }
 
+        let bltn = Builtin::of(interp, cmd);
         let stdout_needs_io = bltn.stdout.needs_io();
         let mut buf = Vec::new();
         for i in 0..argc {
@@ -34,15 +34,14 @@ impl Dirname {
             buf.extend_from_slice(dir);
             buf.push(b'\n');
         }
+        drop(bltn);
 
         Self::state_mut(interp, cmd).state = State::Done;
         if let Some(safeguard) = stdout_needs_io {
             Self::state_mut(interp, cmd).buf = buf;
             let owned = Self::state_mut(interp, cmd).buf.clone();
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd)
-                .stdout
-                .enqueue(child, &owned, safeguard);
+            return Builtin::write_out(interp, cmd, IoKind::Stdout, child, &owned, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
         Builtin::done(interp, cmd, 0)

--- a/src/runtime/shell/builtin/echo.rs
+++ b/src/runtime/shell/builtin/echo.rs
@@ -89,13 +89,13 @@ impl Echo {
         };
         Self::state_mut(interp, cmd).output = output;
 
-        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+
+        if let Some(safeguard) = stdout_needs_io {
             Self::state_mut(interp, cmd).state = State::WaitingIo;
             let buf = Self::state_mut(interp, cmd).output.clone();
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd)
-                .stdout
-                .enqueue(child, &buf, safeguard);
+            return Builtin::write_out(interp, cmd, IoKind::Stdout, child, &buf, safeguard);
         }
         let buf = Self::state_mut(interp, cmd).output.clone();
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);

--- a/src/runtime/shell/builtin/exit.rs
+++ b/src/runtime/shell/builtin/exit.rs
@@ -17,21 +17,18 @@ enum State {
 
 impl Exit {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
-        let bltn = Builtin::of(interp, cmd);
-        let code: crate::shell::ExitCode = match bltn.args_slice().len() {
-            0 => 0,
-            1 => {
-                let s = bltn.arg_bytes(0);
-                match parse_exit_code(s) {
-                    Some(c) => c,
-                    None => {
-                        return Self::fail(interp, cmd, b"exit: numeric argument required\n");
-                    }
-                }
+        let code: Result<crate::shell::ExitCode, &'static [u8]> = {
+            let bltn = Builtin::of(interp, cmd);
+            match bltn.args_slice().len() {
+                0 => Ok(0),
+                1 => parse_exit_code(bltn.arg_bytes(0))
+                    .ok_or(b"exit: numeric argument required\n".as_slice()),
+                _ => Err(b"exit: too many arguments\n".as_slice()),
             }
-            _ => {
-                return Self::fail(interp, cmd, b"exit: too many arguments\n");
-            }
+        };
+        let code = match code {
+            Ok(c) => c,
+            Err(msg) => return Self::fail(interp, cmd, msg),
         };
         // Intentional divergence from bash: this completes only the current
         // Cmd rather than unwinding the whole script.

--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -25,8 +25,10 @@ impl Export {
             // No args: print all exported vars.
             return Self::print_all(interp, cmd);
         }
+        let shell = Builtin::shell(interp, cmd);
         for i in 0..argc {
-            let s = Builtin::of(interp, cmd).arg_bytes(i);
+            let bltn = Builtin::of(interp, cmd);
+            let s = bltn.arg_bytes(i);
             if s.is_empty() {
                 continue;
             }
@@ -39,9 +41,8 @@ impl Export {
             // `init_slice` here would leave dangling EnvStr in `export_env`.
             let label = EnvStr::dupe_ref_counted(name);
             let val = EnvStr::dupe_ref_counted(value);
-            let shell = interp.as_cmd(cmd).base.shell;
-            // SAFETY: shell env outlives the Cmd node.
-            unsafe { (*shell).export_env.insert(label, val) };
+            drop(bltn);
+            shell.borrow_mut().export_env.insert(label, val);
             label.deref();
             val.deref();
         }
@@ -50,6 +51,7 @@ impl Export {
 
     fn print_all(interp: &Interpreter, cmd: NodeId) -> Yield {
         let mut entries: Vec<(EnvStr, EnvStr)> = Builtin::shell(interp, cmd)
+            .borrow()
             .export_env
             .iter()
             .map(|(k, v)| (*k, *v))
@@ -64,12 +66,12 @@ impl Export {
             buf.push(b'\n');
         }
 
-        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+
+        if let Some(safeguard) = stdout_needs_io {
             Self::state_mut(interp, cmd).state = State::WaitingIo;
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd)
-                .stdout
-                .enqueue(child, &buf, safeguard);
+            return Builtin::write_out(interp, cmd, IoKind::Stdout, child, &buf, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
         Builtin::done(interp, cmd, 0)

--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -1,4 +1,4 @@
-use core::cell::RefMut;
+use bun_ptr::JsCellRefMut;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::io::Write as _;
 
@@ -6,12 +6,11 @@ use bun_core::ZBox;
 use bun_sys::{E, FdExt, O, S, dir_iterator};
 
 use crate::shell::ExitCode;
-use crate::shell::builtin::{Builtin, IoKind, Kind};
+use crate::shell::builtin::{Builtin, Kind};
 use crate::shell::interpreter::{
-    EventLoopHandle, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable, OutputWrite,
+    EventLoopHandle, Interpreter, NodeId, OutputQueue, OutputSrc, OutputTask, OutputTaskVTable,
     ShellTask, shell_lstatat, shell_openat, shell_statat,
 };
-use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
 
 #[derive(Default)]
@@ -33,11 +32,7 @@ pub struct ExecState {
     pub(crate) err: Option<bun_sys::Error>,
     pub(crate) task_count: AtomicUsize,
     pub(crate) tasks_done: usize,
-    pub(crate) output_waiting: usize,
-    pub(crate) output_done: usize,
-    /// FIFO of in-flight OutputTasks awaiting an IOWriter chunk completion —
-    /// see mkdir.rs `Exec::output_queue` for rationale.
-    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Ls>>>,
+    pub(crate) output: OutputQueue<Ls>,
 }
 
 enum ParseFlag {
@@ -90,9 +85,7 @@ impl Ls {
                     err: None,
                     task_count: AtomicUsize::new(task_count),
                     tasks_done: 0,
-                    output_waiting: 0,
-                    output_done: 0,
-                    output_queue: std::collections::VecDeque::new(),
+                    output: OutputQueue::default(),
                 });
 
                 // Stable address: `Ls` lives in `Box<Ls>` (Builtin::Impl::Ls),
@@ -144,7 +137,7 @@ impl Ls {
                         unreachable!()
                     };
                     exec.tasks_done >= exec.task_count.load(Ordering::Relaxed)
-                        && exec.output_done >= exec.output_waiting
+                        && exec.output.drained()
                 };
                 if done {
                     let exit_code: ExitCode = {
@@ -171,18 +164,14 @@ impl Ls {
         written: usize,
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
-        if matches!(Self::state_mut(interp, cmd).state, State::WaitingWriteErr) {
-            return Builtin::done(interp, cmd, 1);
-        }
-        let pending = if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_queue.pop_front()
-        } else {
-            None
-        };
-        if let Some(task) = pending {
-            return OutputTask::<Ls>::on_io_writer_chunk(task, interp, written, e);
-        }
-        Self::next(interp, cmd)
+        // Only the usage error is written directly; task output goes through
+        // `OutputTask::on_chunk`.
+        let _ = (written, e);
+        debug_assert!(matches!(
+            Self::state_mut(interp, cmd).state,
+            State::WaitingWriteErr
+        ));
+        Builtin::done(interp, cmd, 1)
     }
 
     fn on_shell_ls_task_done(interp: &Interpreter, cmd: NodeId, mut task: ShellLsTask) {
@@ -254,8 +243,8 @@ impl Ls {
     }
 
     #[inline]
-    fn state_mut(interp: &Interpreter, cmd: NodeId) -> RefMut<'_, Ls> {
-        RefMut::map(Builtin::of_mut(interp, cmd), |b| match &mut b.impl_ {
+    fn state_mut(interp: &Interpreter, cmd: NodeId) -> JsCellRefMut<'_, Ls> {
+        JsCellRefMut::map(Builtin::of_mut(interp, cmd), |b| match &mut b.impl_ {
             crate::shell::builtin::Impl::Ls(l) => &mut **l,
             _ => unreachable!(),
         })
@@ -263,73 +252,13 @@ impl Ls {
 }
 
 impl OutputTaskVTable for Ls {
-    fn write_err(
-        interp: &Interpreter,
-        cmd: NodeId,
-        child: Box<OutputTask<Self>>,
-        errbuf: &[u8],
-    ) -> OutputWrite<Self> {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_waiting += 1;
-        }
-        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
-        if let Some(safeguard) = stderr_needs_io {
-            // Park it so on_io_writer_chunk can route the completion back to
-            // the OutputTask state machine (there is no WriterTag for it).
-            if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
-            }
-            let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return OutputWrite::Enqueued(Builtin::write_out(
-                interp,
-                cmd,
-                IoKind::Stderr,
-                childptr,
-                errbuf,
-                safeguard,
-            ));
-        }
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        OutputWrite::Done(child)
+    fn output_queue(interp: &Interpreter, cmd: NodeId) -> JsCellRefMut<'_, OutputQueue<Self>> {
+        JsCellRefMut::map(Self::state_mut(interp, cmd), |me| match &mut me.state {
+            State::Exec(exec) => &mut exec.output,
+            _ => unreachable!("ls output outside Exec"),
+        })
     }
-    fn on_write_err(interp: &Interpreter, cmd: NodeId) {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_done += 1;
-        }
-    }
-    fn write_out(
-        interp: &Interpreter,
-        cmd: NodeId,
-        child: Box<OutputTask<Self>>,
-    ) -> OutputWrite<Self> {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_waiting += 1;
-        }
-        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
-        if let Some(safeguard) = stdout_needs_io {
-            let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return OutputWrite::Enqueued(Builtin::write_out_with(
-                interp,
-                cmd,
-                IoKind::Stdout,
-                childptr,
-                safeguard,
-                |buf| {
-                    buf.extend_from_slice(child.output.slice());
-                    if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                        exec.output_queue.push_back(child);
-                    }
-                },
-            ));
-        }
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, child.output.slice());
-        OutputWrite::Done(child)
-    }
-    fn on_write_out(interp: &Interpreter, cmd: NodeId) {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_done += 1;
-        }
-    }
+
     fn on_done(interp: &Interpreter, cmd: NodeId) -> Yield {
         Self::next(interp, cmd)
     }

--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -1,4 +1,4 @@
-use core::ptr::NonNull;
+use core::cell::RefMut;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::io::Write as _;
 
@@ -8,8 +8,8 @@ use bun_sys::{E, FdExt, O, S, dir_iterator};
 use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, IoKind, Kind};
 use crate::shell::interpreter::{
-    EventLoopHandle, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable, ShellTask,
-    shell_lstatat, shell_openat, shell_statat,
+    EventLoopHandle, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable, OutputWrite,
+    ShellTask, shell_lstatat, shell_openat, shell_statat,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -35,10 +35,9 @@ pub struct ExecState {
     pub(crate) tasks_done: usize,
     pub(crate) output_waiting: usize,
     pub(crate) output_done: usize,
-    /// FIFO of in-flight OutputTask pointers awaiting an IOWriter chunk
-    /// completion. Stopgap until `WriterTag` can carry the `*mut OutputTask`
-    /// directly — see mkdir.rs `Exec::output_queue` for rationale.
-    pub(crate) output_queue: std::collections::VecDeque<*mut OutputTask<Ls>>,
+    /// FIFO of in-flight OutputTasks awaiting an IOWriter chunk completion —
+    /// see mkdir.rs `Exec::output_queue` for rationale.
+    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Ls>>>,
 }
 
 enum ParseFlag {
@@ -74,18 +73,15 @@ impl Ls {
                     Ok(p) => p,
                     Err(opt) => {
                         let buf: Vec<u8> = Builtin::fmt_error_arena(
-                            interp,
-                            cmd,
                             Some(Kind::Ls),
                             format_args!("illegal option -- {}\n", bstr::BStr::new(&opt[..])),
-                        )
-                        .to_vec();
+                        );
                         Self::state_mut(interp, cmd).state = State::WaitingWriteErr;
                         return Builtin::write_failing_error(interp, cmd, &buf, 1);
                     }
                 };
 
-                let argc = Builtin::of(interp, cmd).args_slice().len();
+                let argc = Builtin::argc(interp, cmd);
                 let task_count = match paths_start {
                     Some(start) => argc - start,
                     None => 1,
@@ -101,35 +97,32 @@ impl Ls {
 
                 // Stable address: `Ls` lives in `Box<Ls>` (Builtin::Impl::Ls),
                 // and the `Exec` variant is held until all tasks finish.
-                let task_count_ptr: *const AtomicUsize = {
-                    let State::Exec(exec) = &Self::state_mut(interp, cmd).state else {
+                let task_count_ptr: bun_ptr::BackRef<AtomicUsize> = {
+                    let me = Self::state_mut(interp, cmd);
+                    let State::Exec(exec) = &me.state else {
                         unreachable!()
                     };
-                    &raw const exec.task_count
+                    bun_ptr::BackRef::new(&exec.task_count)
                 };
 
                 let cwd = Builtin::cwd(interp, cmd);
                 let opts = Self::state_mut(interp, cmd).opts;
                 let evtloop = Builtin::event_loop(interp, cmd);
-                let interp_ptr = interp.as_ctx_ptr();
                 if let Some(start) = paths_start {
                     let print_directory = task_count > 1;
                     for i in start..argc {
-                        let path = Builtin::of(interp, cmd).arg_bytes(i);
-                        let task = ShellLsTask::create(
+                        let path = ZBox::from_bytes(Builtin::of(interp, cmd).arg_bytes(i));
+                        let mut task = ShellLsTask::create(
                             cmd,
                             opts,
                             task_count_ptr,
                             cwd,
-                            ZBox::from_bytes(path),
+                            path,
                             evtloop,
-                            interp_ptr,
+                            interp,
                         );
-                        // SAFETY: freshly heap-allocated.
-                        unsafe {
-                            (*task).print_directory = print_directory;
-                            ShellTask::schedule_no_ref::<ShellLsTask>(task);
-                        }
+                        task.print_directory = print_directory;
+                        ShellTask::schedule_no_ref(task);
                     }
                 } else {
                     let task = ShellLsTask::create(
@@ -139,10 +132,9 @@ impl Ls {
                         cwd,
                         ZBox::from_bytes(b"."),
                         evtloop,
-                        interp_ptr,
+                        interp,
                     );
-                    // SAFETY: freshly heap-allocated.
-                    unsafe { ShellTask::schedule_no_ref::<ShellLsTask>(task) };
+                    ShellTask::schedule_no_ref(task);
                 }
                 Yield::suspended()
             }
@@ -188,19 +180,12 @@ impl Ls {
             None
         };
         if let Some(task) = pending {
-            // SAFETY: `task` was heap-allocated in `OutputTask::new` and
-            // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Ls>::on_io_writer_chunk(task, interp, written, e) };
+            return OutputTask::<Ls>::on_io_writer_chunk(task, interp, written, e);
         }
         Self::next(interp, cmd)
     }
 
-    /// # Safety
-    /// `task` must be a live heap allocation produced by
-    /// [`ShellLsTask::create`]; ownership is reclaimed here.
-    fn on_shell_ls_task_done(interp: &Interpreter, cmd: NodeId, task: NonNull<ShellLsTask>) {
-        // SAFETY: precondition.
-        let mut task = unsafe { bun_core::heap::take(task.as_ptr()) };
+    fn on_shell_ls_task_done(interp: &Interpreter, cmd: NodeId, mut task: ShellLsTask) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.tasks_done += 1;
         }
@@ -208,7 +193,7 @@ impl Ls {
         let output_task = OutputTask::<Ls>::new(cmd, OutputSrc::Arrlist(output));
 
         let errstr: Option<Vec<u8>> = task.err.take().map(|e| {
-            let s = Builtin::task_error_to_string(interp, cmd, Kind::Ls, &e).to_vec();
+            let s = Builtin::task_error_to_string(Kind::Ls, &e);
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                 if exec.err.is_none() {
                     exec.err = Some(e);
@@ -222,21 +207,24 @@ impl Ls {
     /// Returns the index of the first non-flag arg, or `None` if there are no
     /// positional args. `Err` carries the offending flag byte.
     fn parse_opts(interp: &Interpreter, cmd: NodeId) -> Result<Option<usize>, Box<[u8]>> {
-        let argc = Builtin::of(interp, cmd).args_slice().len();
+        let argc = Builtin::argc(interp, cmd);
         if argc == 0 {
             return Ok(None);
         }
-        let mut idx = 0usize;
-        while idx < argc {
-            let flag = Builtin::of(interp, cmd).arg_bytes(idx);
-            match Self::parse_flag(&mut Self::state_mut(interp, cmd).opts, flag) {
-                ParseFlag::Done => return Ok(Some(idx)),
-                ParseFlag::ContinueParsing => {}
-                ParseFlag::IllegalOption(s) => return Err(s),
+        let mut opts = Self::state_mut(interp, cmd).opts;
+        let result = 'parsed: {
+            let bltn = Builtin::of(interp, cmd);
+            for idx in 0..argc {
+                match Self::parse_flag(&mut opts, bltn.arg_bytes(idx)) {
+                    ParseFlag::Done => break 'parsed Ok(Some(idx)),
+                    ParseFlag::ContinueParsing => {}
+                    ParseFlag::IllegalOption(s) => break 'parsed Err(s),
+                }
             }
-            idx += 1;
-        }
-        Ok(None)
+            Ok(None)
+        };
+        Self::state_mut(interp, cmd).opts = opts;
+        result
     }
 
     fn parse_flag(opts: &mut Opts, flag: &[u8]) -> ParseFlag {
@@ -266,11 +254,11 @@ impl Ls {
     }
 
     #[inline]
-    fn state_mut(interp: &Interpreter, cmd: NodeId) -> &mut Ls {
-        match &mut Builtin::of_mut(interp, cmd).impl_ {
+    fn state_mut(interp: &Interpreter, cmd: NodeId) -> RefMut<'_, Ls> {
+        RefMut::map(Builtin::of_mut(interp, cmd), |b| match &mut b.impl_ {
             crate::shell::builtin::Impl::Ls(l) => &mut **l,
             _ => unreachable!(),
-        }
+        })
     }
 }
 
@@ -278,27 +266,31 @@ impl OutputTaskVTable for Ls {
     fn write_err(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
+        child: Box<OutputTask<Self>>,
         errbuf: &[u8],
-    ) -> Option<Yield> {
+    ) -> OutputWrite<Self> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
-        if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
-            // Stash so on_io_writer_chunk can route to the OutputTask state
-            // machine and reclaim the box (stopgap for missing WriterTag).
+        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
+        if let Some(safeguard) = stderr_needs_io {
+            // Park it so on_io_writer_chunk can route the completion back to
+            // the OutputTask state machine (there is no WriterTag for it).
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                 exec.output_queue.push_back(child);
             }
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Some(
-                Builtin::of_mut(interp, cmd)
-                    .stderr
-                    .enqueue(childptr, errbuf, safeguard),
-            );
+            return OutputWrite::Enqueued(Builtin::write_out(
+                interp,
+                cmd,
+                IoKind::Stderr,
+                childptr,
+                errbuf,
+                safeguard,
+            ));
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        None
+        OutputWrite::Done(child)
     }
     fn on_write_err(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
@@ -308,27 +300,30 @@ impl OutputTaskVTable for Ls {
     fn write_out(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
-        output: &mut OutputSrc,
-    ) -> Option<Yield> {
+        child: Box<OutputTask<Self>>,
+    ) -> OutputWrite<Self> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
-        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-            if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
-            }
+        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+        if let Some(safeguard) = stdout_needs_io {
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            let buf = output.slice().to_vec();
-            return Some(
-                Builtin::of_mut(interp, cmd)
-                    .stdout
-                    .enqueue(childptr, &buf, safeguard),
-            );
+            return OutputWrite::Enqueued(Builtin::write_out_with(
+                interp,
+                cmd,
+                IoKind::Stdout,
+                childptr,
+                safeguard,
+                |buf| {
+                    buf.extend_from_slice(child.output.slice());
+                    if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
+                        exec.output_queue.push_back(child);
+                    }
+                },
+            ));
         }
-        let buf = output.slice().to_vec();
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-        None
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, child.output.slice());
+        OutputWrite::Done(child)
     }
     fn on_write_out(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
@@ -347,8 +342,9 @@ pub(crate) struct ShellLsTask {
     pub opts: Opts,
     pub print_directory: bool,
     /// Shared atomic counter (lives in `ExecState` inside `Box<Ls>`; address
-    /// is stable for the lifetime of the Exec state).
-    pub task_count: *const AtomicUsize,
+    /// is stable for the lifetime of the Exec state, which outlives every
+    /// in-flight task).
+    pub task_count: bun_ptr::BackRef<AtomicUsize>,
     pub cwd: bun_sys::Fd,
     pub path: ZBox,
     pub output: Vec<u8>,
@@ -358,23 +354,22 @@ pub(crate) struct ShellLsTask {
     /// Cached once per task to avoid repeated syscalls.
     now_secs: u64,
     pub event_loop: EventLoopHandle,
-    /// Back-ref so recursive `enqueue` can populate the subtask's
-    /// `task.interp` (needed by [`ShellTask::run_from_main_thread`]).
-    pub interp: *mut Interpreter,
     pub task: ShellTask,
 }
+
+crate::shell_task!(ShellLsTask);
 
 impl ShellLsTask {
     fn create(
         cmd: NodeId,
         opts: Opts,
-        task_count: *const AtomicUsize,
+        task_count: bun_ptr::BackRef<AtomicUsize>,
         cwd: bun_sys::Fd,
         path: ZBox,
         event_loop: EventLoopHandle,
-        interp: *mut Interpreter,
-    ) -> *mut ShellLsTask {
-        let mut task = Box::new(ShellLsTask {
+        interp: &Interpreter,
+    ) -> Box<ShellLsTask> {
+        Box::new(ShellLsTask {
             cmd,
             opts,
             print_directory: false,
@@ -386,11 +381,8 @@ impl ShellLsTask {
             err: None,
             now_secs: 0,
             event_loop,
-            interp,
-            task: ShellTask::new(event_loop),
-        });
-        task.task.interp = interp;
-        bun_core::heap::into_raw(task)
+            task: ShellTask::new(interp),
+        })
     }
 
     /// Spawns a subtask for a recursively
@@ -398,11 +390,13 @@ impl ShellLsTask {
     fn enqueue(&mut self, name: &[u8]) {
         let new_path = self.join(name);
         // Pool thread: the subtask inherits our poster rather than deriving
-        // one from the VM (`ShellTask::new` is JS-thread only).
-        let subtask = bun_core::heap::into_raw(Box::new(ShellLsTask {
+        // one from the VM (`ShellTask::new` is JS-thread only). No
+        // keep-alive ref — it runs on a worker thread with no JS-VM
+        // thread-local.
+        let subtask = Box::new(ShellLsTask {
             cmd: self.cmd,
             opts: self.opts,
-            print_directory: false,
+            print_directory: true,
             task_count: self.task_count,
             cwd: self.cwd,
             path: new_path,
@@ -411,21 +405,10 @@ impl ShellLsTask {
             err: None,
             now_secs: 0,
             event_loop: self.event_loop,
-            interp: self.interp,
             task: ShellTask::new_child(&self.task),
-        }));
-        // SAFETY: freshly allocated above.
-        unsafe { (*subtask).task.interp = self.interp };
-        // SAFETY: `task_count` points into the `Box<Ls>` ExecState which
-        // outlives every in-flight task (see `next`). `subtask` is freshly
-        // heap-allocated and scheduled via raw `WorkPool::schedule` (no
-        // keep-alive ref) — it runs on a worker thread with no JS-VM
-        // thread-local.
-        unsafe {
-            (*self.task_count).fetch_add(1, Ordering::Relaxed);
-            (*subtask).print_directory = true;
-            ShellTask::schedule_no_ref::<ShellLsTask>(subtask);
-        }
+        });
+        self.task_count.fetch_add(1, Ordering::Relaxed);
+        ShellTask::schedule_no_ref(subtask);
     }
 
     fn join(&self, child: &[u8]) -> ZBox {
@@ -622,16 +605,6 @@ impl ShellLsTask {
     fn error_with_path(&self, err: &bun_sys::Error) -> bun_sys::Error {
         err.with_path(self.path.as_bytes())
     }
-
-    /// # Safety
-    /// `this` must be a live heap allocation produced by
-    /// [`ShellLsTask::create`]; ownership is reclaimed via
-    /// [`Ls::on_shell_ls_task_done`].
-    fn run_from_main_thread(this: NonNull<ShellLsTask>, interp: &Interpreter) {
-        // SAFETY: precondition.
-        let cmd = unsafe { this.as_ref() }.cmd;
-        Ls::on_shell_ls_task_done(interp, cmd, this);
-    }
 }
 
 fn get_file_type_char(mode: u32) -> u8 {
@@ -769,28 +742,23 @@ fn civil_from_days(z: i64) -> (i32, u8, u8) {
     ((y + (m <= 2) as i64) as i32, m, d)
 }
 
-impl bun_event_loop::Taskable for ShellLsTask {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellLsTask;
-    /// A pool completion that will not run: drop the keep-alive and the box
-    /// (nothing else frees an unrun one).
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — the box the builtin scheduled.
-        unsafe {
-            (*this).task.unref_unrun();
-            drop(bun_core::heap::take(this));
-        }
-    }
-}
+// `runtime::dispatch::run_task`'s `task_tag::ShellLsTask` arm reboxes the
+// pointer `ShellTask::on_finish` posted; a completion that will not run drops
+// the keep-alive and the box.
 
 impl crate::shell::interpreter::ShellTaskCtx for ShellLsTask {
-    const TASK_OFFSET: usize = core::mem::offset_of!(Self, task);
-    fn run_from_thread_pool(this: &mut Self) {
-        Self::run_from_thread_pool(this)
+    fn shell_task(&self) -> &ShellTask {
+        &self.task
     }
-    fn run_from_main_thread(this: *mut Self, interp: &Interpreter) {
-        // The `ShellTask` trampoline hands back the live, non-null heap
-        // allocation produced by `ShellLsTask::create`.
-        Self::run_from_main_thread(NonNull::new(this).unwrap(), interp)
+    fn shell_task_mut(&mut self) -> &mut ShellTask {
+        &mut self.task
+    }
+    fn run_from_thread_pool(&mut self) {
+        Self::run_from_thread_pool(self)
+    }
+    fn run_from_main_thread(self: Box<Self>, interp: &Interpreter) {
+        let cmd = self.cmd;
+        Ls::on_shell_ls_task_done(interp, cmd, *self);
     }
 }
 

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -3,12 +3,11 @@ use crate::node::types::PathLike;
 use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
-    EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable, OutputWrite,
+    ParseFlagResult, ShellTask, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
-use core::ptr::NonNull;
 
 #[derive(Default)]
 pub struct Mkdir {
@@ -36,25 +35,20 @@ pub struct Exec {
     /// self-reference).
     pub(crate) args_start: usize,
     pub(crate) err: Option<bun_sys::Error>,
-    /// FIFO of in-flight OutputTask pointers awaiting an IOWriter chunk
-    /// completion. Stopgap until `WriterTag` can carry the `*mut OutputTask`
-    /// directly (IOWriter.rs is out of scope here): `write_err`/`write_out`
+    /// FIFO of in-flight OutputTasks awaiting an IOWriter chunk completion
+    /// (`WriterTag` cannot name an OutputTask): `write_err`/`write_out`
     /// push, `on_io_writer_chunk` pops and forwards to
-    /// `OutputTask::on_io_writer_chunk` so the box is reclaimed and the
-    /// writeErr→writeOut→onDone state machine runs.
-    pub(crate) output_queue: std::collections::VecDeque<*mut OutputTask<Mkdir>>,
+    /// `OutputTask::on_io_writer_chunk` so the writeErr→writeOut→onDone
+    /// state machine runs.
+    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Mkdir>>>,
 }
 
 impl Mkdir {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
         let (args_start, mut opts) = {
             let mut opts = Opts::default();
-            let args = Builtin::of(interp, cmd).args_slice();
-            match parse_flags(&mut opts, args) {
-                Ok(Some(rest)) => {
-                    let start = args.len() - rest.len();
-                    (start, opts)
-                }
+            match Builtin::parse_flags(interp, cmd, &mut opts) {
+                Ok(Some(start)) => (start, opts),
                 Ok(None) => {
                     return Self::fail_usage(interp, cmd);
                 }
@@ -87,8 +81,7 @@ impl Mkdir {
     }
 
     fn next(interp: &Interpreter, cmd: NodeId) -> Yield {
-        // NOTE: reshaped for borrowck — read scalars, drop the borrow,
-        // then act.
+        // Read scalars, drop the borrow, then act.
         let action = match &mut Self::state_mut(interp, cmd).state {
             State::Idle => panic!("Invalid state"),
             State::Exec(exec) => {
@@ -100,37 +93,36 @@ impl Mkdir {
                         exec.err = None;
                         NextAction::Done(exit_code)
                     } else {
-                        return Yield::suspended();
+                        NextAction::Suspend
                     }
                 } else {
                     exec.started = true;
                     NextAction::Schedule(exec.args_start)
                 }
             }
-            State::WaitingWriteErr => return Yield::failed(),
-            State::Done => return Builtin::done(interp, cmd, 0),
+            State::WaitingWriteErr => NextAction::Failed,
+            State::Done => NextAction::AlreadyDone,
         };
         match action {
+            NextAction::Suspend => Yield::suspended(),
+            NextAction::Failed => Yield::failed(),
+            NextAction::AlreadyDone => Builtin::done(interp, cmd, 0),
             NextAction::Done(code) => {
                 Self::state_mut(interp, cmd).state = State::Done;
                 Builtin::done(interp, cmd, code)
             }
             NextAction::Schedule(args_start) => {
-                let argc = Builtin::of(interp, cmd).args_slice().len();
+                let argc = Builtin::argc(interp, cmd);
                 let task_count = argc - args_start;
                 if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                     exec.tasks_count = task_count;
                 }
                 let opts = Self::state_mut(interp, cmd).opts;
-                let cwd = Builtin::shell(interp, cmd).cwd().to_vec();
-                let evtloop = Builtin::event_loop(interp, cmd);
-                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+                let cwd = Builtin::shell(interp, cmd).borrow().cwd().to_vec();
                 for i in args_start..argc {
                     let path = Builtin::of(interp, cmd).arg_bytes(i).to_vec();
-                    let task =
-                        ShellMkdirTask::create(cmd, opts, path, cwd.clone(), evtloop, interp_ptr);
-                    // SAFETY: freshly heap-allocated.
-                    unsafe { ShellTask::schedule(task) };
+                    let task = ShellMkdirTask::create(cmd, opts, path, cwd.clone(), interp);
+                    ShellTask::schedule(task);
                 }
                 Yield::suspended()
             }
@@ -144,14 +136,15 @@ impl Mkdir {
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
         let pending = match &mut Self::state_mut(interp, cmd).state {
-            State::WaitingWriteErr => return Builtin::done(interp, cmd, 1),
-            State::Exec(exec) => exec.output_queue.pop_front(),
+            State::WaitingWriteErr => Err(()),
+            State::Exec(exec) => Ok(exec.output_queue.pop_front()),
             State::Idle | State::Done => panic!("Invalid state"),
         };
+        let Ok(pending) = pending else {
+            return Builtin::done(interp, cmd, 1);
+        };
         if let Some(task) = pending {
-            // SAFETY: `task` was heap-allocated in `OutputTask::new` and
-            // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Mkdir>::on_io_writer_chunk(task, interp, written, e) };
+            return OutputTask::<Mkdir>::on_io_writer_chunk(task, interp, written, e);
         }
         Self::next(interp, cmd)
     }
@@ -167,7 +160,7 @@ impl Mkdir {
 
         let output_task = OutputTask::<Mkdir>::new(cmd, OutputSrc::Arrlist(output));
         let errstr: Option<Vec<u8>> = err.map(|e| {
-            let s = Builtin::task_error_to_string(interp, cmd, Kind::Mkdir, &e).to_vec();
+            let s = Builtin::task_error_to_string(Kind::Mkdir, &e);
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                 exec.err = Some(e);
             }
@@ -180,36 +173,43 @@ impl Mkdir {
 enum NextAction {
     Done(ExitCode),
     Schedule(usize),
+    Suspend,
+    Failed,
+    AlreadyDone,
 }
 
 impl OutputTaskVTable for Mkdir {
     fn write_err(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
+        child: Box<OutputTask<Self>>,
         errbuf: &[u8],
-    ) -> Option<Yield> {
+    ) -> OutputWrite<Self> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
-        if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
+        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
+        if let Some(safeguard) = stderr_needs_io {
             // OutputTask has no `WriterTag` of its own (it is not directly
             // dispatchable as an IOWriter child), so the enqueue is tagged
-            // `WriterTag::Builtin` and `child` is stashed on `output_queue`;
+            // `WriterTag::Builtin` and `child` is parked on `output_queue`;
             // `on_io_writer_chunk` pops it to route the completion back to
-            // the OutputTask state machine and reclaim the box.
+            // the OutputTask state machine.
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                 exec.output_queue.push_back(child);
             }
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Some(
-                Builtin::of_mut(interp, cmd)
-                    .stderr
-                    .enqueue(childptr, errbuf, safeguard),
-            );
+            return OutputWrite::Enqueued(Builtin::write_out(
+                interp,
+                cmd,
+                IoKind::Stderr,
+                childptr,
+                errbuf,
+                safeguard,
+            ));
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        None
+        OutputWrite::Done(child)
     }
 
     fn on_write_err(interp: &Interpreter, cmd: NodeId) {
@@ -221,29 +221,32 @@ impl OutputTaskVTable for Mkdir {
     fn write_out(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
-        output: &mut OutputSrc,
-    ) -> Option<Yield> {
+        child: Box<OutputTask<Self>>,
+    ) -> OutputWrite<Self> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
-        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-            // See write_err — stash `child` so the chunk callback routes to
+        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+        if let Some(safeguard) = stdout_needs_io {
+            // See write_err — park `child` so the chunk callback routes to
             // OutputTask::on_io_writer_chunk.
-            if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
-            }
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            let buf = output.slice().to_vec();
-            return Some(
-                Builtin::of_mut(interp, cmd)
-                    .stdout
-                    .enqueue(childptr, &buf, safeguard),
-            );
+            return OutputWrite::Enqueued(Builtin::write_out_with(
+                interp,
+                cmd,
+                IoKind::Stdout,
+                childptr,
+                safeguard,
+                |buf| {
+                    buf.extend_from_slice(child.output.slice());
+                    if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
+                        exec.output_queue.push_back(child);
+                    }
+                },
+            ));
         }
-        let buf = output.slice().to_vec();
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-        None
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, child.output.slice());
+        OutputWrite::Done(child)
     }
 
     fn on_write_out(interp: &Interpreter, cmd: NodeId) {
@@ -272,26 +275,25 @@ pub(crate) struct ShellMkdirTask {
     pub task: ShellTask,
 }
 
+crate::shell_task!(ShellMkdirTask);
+
 impl ShellMkdirTask {
     fn create(
         cmd: NodeId,
         opts: Opts,
         filepath: Vec<u8>,
         cwd_path: Vec<u8>,
-        evtloop: EventLoopHandle,
-        interp: *mut Interpreter,
-    ) -> *mut ShellMkdirTask {
-        let mut task = Box::new(ShellMkdirTask {
+        interp: &Interpreter,
+    ) -> Box<ShellMkdirTask> {
+        Box::new(ShellMkdirTask {
             cmd,
             opts,
             filepath,
             cwd_path,
             created_directories: Vec::new(),
             err: None,
-            task: ShellTask::new(evtloop),
-        });
-        task.task.interp = interp;
-        bun_core::heap::into_raw(task)
+            task: ShellTask::new(interp),
+        })
     }
 
     fn run_from_thread_pool(this: &mut ShellMkdirTask) {
@@ -354,34 +356,14 @@ impl ShellMkdirTask {
                 }
             }
         }
-        // Bounce-back to the main thread is posted by `shell_task_trampoline`
-        // via `ShellTask::on_finish::<Self>` (handles both JS and mini event
-        // loops).
-    }
-
-    /// Reclaims ownership of the heap allocation produced by [`Self::create`]
-    /// and forwards it to [`Mkdir::on_shell_mkdir_task_done`].
-    fn run_from_main_thread(this: NonNull<ShellMkdirTask>, interp: &Interpreter) {
-        // SAFETY: `this` is a live heap allocation produced by `Self::create`;
-        // the dispatch contract guarantees it is not yet freed.
-        let mut task = unsafe { bun_core::heap::take(this.as_ptr()) };
-        let cmd = task.cmd;
-        Mkdir::on_shell_mkdir_task_done(interp, cmd, &mut task);
+        // Bounce-back to the main thread is posted by `ShellTask::run_owned`
+        // via `ShellTask::on_finish` (handles both JS and mini event loops).
     }
 }
 
-impl bun_event_loop::Taskable for ShellMkdirTask {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellMkdirTask;
-    /// A pool completion that will not run: drop the keep-alive and the box
-    /// (nothing else frees an unrun one).
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — the box the builtin scheduled.
-        unsafe {
-            (*this).task.unref_unrun();
-            drop(bun_core::heap::take(this));
-        }
-    }
-}
+// `runtime::dispatch::run_task`'s `task_tag::ShellMkdirTask` arm reboxes the
+// pointer `ShellTask::on_finish` posted; a completion that will not run drops
+// the keep-alive and the box.
 
 /// Collects each created directory into
 /// `created_directories` (newline-separated) when `-v` is set. Passed by value
@@ -417,14 +399,19 @@ impl MkdirCtx for MkdirVerboseVTable {
 }
 
 impl crate::shell::interpreter::ShellTaskCtx for ShellMkdirTask {
-    const TASK_OFFSET: usize = core::mem::offset_of!(Self, task);
-    fn run_from_thread_pool(this: &mut Self) {
-        Self::run_from_thread_pool(this)
+    fn shell_task(&self) -> &ShellTask {
+        &self.task
     }
-    fn run_from_main_thread(this: *mut Self, interp: &Interpreter) {
-        // `ShellTaskCtx` callers guarantee `this` is the live, non-null
-        // heap-allocated task posted via `ShellTask::schedule`.
-        Self::run_from_main_thread(NonNull::new(this).unwrap(), interp)
+    fn shell_task_mut(&mut self) -> &mut ShellTask {
+        &mut self.task
+    }
+    fn run_from_thread_pool(&mut self) {
+        Self::run_from_thread_pool(self)
+    }
+    /// The task drops after `on_shell_mkdir_task_done` has taken what it needs.
+    fn run_from_main_thread(mut self: Box<Self>, interp: &Interpreter) {
+        let cmd = self.cmd;
+        Mkdir::on_shell_mkdir_task_done(interp, cmd, &mut self);
     }
 }
 
@@ -465,9 +452,7 @@ impl FlagParser for Opts {
                 self.verbose = true;
                 None
             }
-            _ => Some(ParseFlagResult::IllegalOption(
-                &raw const smallflags[1 + i..],
-            )),
+            _ => Some(ParseFlagResult::IllegalOption(smallflags[1 + i..].into())),
         }
     }
 }

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -1,13 +1,13 @@
 use crate::node::fs::{MkdirCtx, NodeFS, args as fs_args};
 use crate::node::types::PathLike;
 use crate::shell::ExitCode;
-use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
+use crate::shell::builtin::{Builtin, BuiltinState, Kind};
 use crate::shell::interpreter::{
-    FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable, OutputWrite,
+    FlagParser, Interpreter, NodeId, OutputQueue, OutputSrc, OutputTask, OutputTaskVTable,
     ParseFlagResult, ShellTask, unsupported_flag,
 };
-use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
+use bun_ptr::JsCellRefMut;
 
 #[derive(Default)]
 pub struct Mkdir {
@@ -28,19 +28,12 @@ pub struct Exec {
     pub(crate) started: bool,
     pub(crate) tasks_count: usize,
     pub(crate) tasks_done: usize,
-    pub(crate) output_waiting: u16,
-    pub(crate) output_done: u16,
     /// Index into `Builtin::args` where filepath args start (storing the
     /// index keeps the lifetime tied to the Cmd's argv without a
     /// self-reference).
     pub(crate) args_start: usize,
     pub(crate) err: Option<bun_sys::Error>,
-    /// FIFO of in-flight OutputTasks awaiting an IOWriter chunk completion
-    /// (`WriterTag` cannot name an OutputTask): `write_err`/`write_out`
-    /// push, `on_io_writer_chunk` pops and forwards to
-    /// `OutputTask::on_io_writer_chunk` so the writeErr→writeOut→onDone
-    /// state machine runs.
-    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Mkdir>>>,
+    pub(crate) output: OutputQueue<Mkdir>,
 }
 
 impl Mkdir {
@@ -66,11 +59,9 @@ impl Mkdir {
             started: false,
             tasks_count: 0,
             tasks_done: 0,
-            output_waiting: 0,
-            output_done: 0,
             args_start,
             err: None,
-            output_queue: std::collections::VecDeque::new(),
+            output: OutputQueue::default(),
         });
         Self::next(interp, cmd)
     }
@@ -86,9 +77,7 @@ impl Mkdir {
             State::Idle => panic!("Invalid state"),
             State::Exec(exec) => {
                 if exec.started {
-                    if exec.tasks_done >= exec.tasks_count
-                        && exec.output_done >= exec.output_waiting
-                    {
+                    if exec.tasks_done >= exec.tasks_count && exec.output.drained() {
                         let exit_code: ExitCode = if exec.err.is_some() { 1 } else { 0 };
                         exec.err = None;
                         NextAction::Done(exit_code)
@@ -135,18 +124,14 @@ impl Mkdir {
         written: usize,
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
-        let pending = match &mut Self::state_mut(interp, cmd).state {
-            State::WaitingWriteErr => Err(()),
-            State::Exec(exec) => Ok(exec.output_queue.pop_front()),
-            State::Idle | State::Done => panic!("Invalid state"),
-        };
-        let Ok(pending) = pending else {
-            return Builtin::done(interp, cmd, 1);
-        };
-        if let Some(task) = pending {
-            return OutputTask::<Mkdir>::on_io_writer_chunk(task, interp, written, e);
+        // Only the usage error is written directly; task output goes through
+        // `OutputTask::on_chunk`.
+        let _ = (written, e);
+        match Self::state_mut(interp, cmd).state {
+            State::WaitingWriteErr => {}
+            State::Exec(_) | State::Idle | State::Done => panic!("Invalid state"),
         }
-        Self::next(interp, cmd)
+        Builtin::done(interp, cmd, 1)
     }
 
     /// The caller ([`ShellMkdirTask::run_from_main_thread`]) owns the heap
@@ -179,80 +164,11 @@ enum NextAction {
 }
 
 impl OutputTaskVTable for Mkdir {
-    fn write_err(
-        interp: &Interpreter,
-        cmd: NodeId,
-        child: Box<OutputTask<Self>>,
-        errbuf: &[u8],
-    ) -> OutputWrite<Self> {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_waiting += 1;
-        }
-        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
-        if let Some(safeguard) = stderr_needs_io {
-            // OutputTask has no `WriterTag` of its own (it is not directly
-            // dispatchable as an IOWriter child), so the enqueue is tagged
-            // `WriterTag::Builtin` and `child` is parked on `output_queue`;
-            // `on_io_writer_chunk` pops it to route the completion back to
-            // the OutputTask state machine.
-            if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
-            }
-            let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return OutputWrite::Enqueued(Builtin::write_out(
-                interp,
-                cmd,
-                IoKind::Stderr,
-                childptr,
-                errbuf,
-                safeguard,
-            ));
-        }
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        OutputWrite::Done(child)
-    }
-
-    fn on_write_err(interp: &Interpreter, cmd: NodeId) {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_done += 1;
-        }
-    }
-
-    fn write_out(
-        interp: &Interpreter,
-        cmd: NodeId,
-        child: Box<OutputTask<Self>>,
-    ) -> OutputWrite<Self> {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_waiting += 1;
-        }
-        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
-        if let Some(safeguard) = stdout_needs_io {
-            // See write_err — park `child` so the chunk callback routes to
-            // OutputTask::on_io_writer_chunk.
-            let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return OutputWrite::Enqueued(Builtin::write_out_with(
-                interp,
-                cmd,
-                IoKind::Stdout,
-                childptr,
-                safeguard,
-                |buf| {
-                    buf.extend_from_slice(child.output.slice());
-                    if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                        exec.output_queue.push_back(child);
-                    }
-                },
-            ));
-        }
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, child.output.slice());
-        OutputWrite::Done(child)
-    }
-
-    fn on_write_out(interp: &Interpreter, cmd: NodeId) {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_done += 1;
-        }
+    fn output_queue(interp: &Interpreter, cmd: NodeId) -> JsCellRefMut<'_, OutputQueue<Self>> {
+        JsCellRefMut::map(Self::state_mut(interp, cmd), |me| match &mut me.state {
+            State::Exec(exec) => &mut exec.output,
+            _ => unreachable!("mkdir output outside Exec"),
+        })
     }
 
     fn on_done(interp: &Interpreter, cmd: NodeId) -> Yield {

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -29,12 +29,12 @@ pub struct MvArgs {
 pub enum MvState {
     #[default]
     Idle,
-    CheckTarget(Box<ShellMvCheckTargetTask>),
+    /// `None` while the task is out on the pool; put back once it is done.
+    CheckTarget(Option<Box<ShellMvCheckTargetTask>>),
     Executing {
         task_count: usize,
         tasks_done: usize,
         error_signal: AtomicBool,
-        tasks: Vec<ShellMvBatchedTask>,
         err: Option<bun_sys::Error>,
     },
     Done,
@@ -61,12 +61,11 @@ impl Mv {
         buf: &[u8],
         exit_code: ExitCode,
     ) -> Yield {
-        if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
+        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
+        if let Some(safeguard) = stderr_needs_io {
             Self::state_mut(interp, cmd).state = MvState::WaitingWriteErr { exit_code };
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd)
-                .stderr
-                .enqueue(child, buf, safeguard);
+            return Builtin::write_out(interp, cmd, IoKind::Stderr, child, buf, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, buf);
         Builtin::done(interp, cmd, exit_code)
@@ -95,12 +94,9 @@ impl Mv {
                 if let Err(e) = Self::parse_opts(interp, cmd) {
                     let buf: Vec<u8> = match e {
                         MvParseError::IllegalOption(s) => Builtin::fmt_error_arena(
-                            interp,
-                            cmd,
                             Some(Kind::Mv),
                             format_args!("illegal option -- {}\n", bstr::BStr::new(s)),
-                        )
-                        .to_vec(),
+                        ),
                         MvParseError::ShowUsage => Kind::Mv.usage_string().to_vec(),
                     };
                     return Self::write_failing_error(interp, cmd, &buf, 1);
@@ -108,32 +104,27 @@ impl Mv {
                 let cwd = Builtin::cwd(interp, cmd);
                 let target_idx = Self::state_mut(interp, cmd).args.target_idx;
                 let target = ZBox::from_bytes(Builtin::of(interp, cmd).arg_bytes(target_idx));
-                let evtloop = Builtin::event_loop(interp, cmd);
-                let mut task = Box::new(ShellMvCheckTargetTask {
+                let task = Box::new(ShellMvCheckTargetTask {
                     cmd,
                     cwd,
                     target,
                     result: None,
-                    done: false,
-                    task: ShellTask::new(evtloop),
+                    task: ShellTask::new(interp),
                 });
-                task.task.interp = interp.as_ctx_ptr();
-                // SAFETY: `task` is heap-allocated and outlives the worker
-                // call (held in `MvState::CheckTarget` below).
-                unsafe { ShellTask::schedule(&raw mut *task) };
-                Self::state_mut(interp, cmd).state = MvState::CheckTarget(task);
+                Self::state_mut(interp, cmd).state = MvState::CheckTarget(None);
+                ShellTask::schedule(task);
                 Yield::suspended()
             }
             Tag::CheckTarget => {
-                let done = match &Self::state_mut(interp, cmd).state {
-                    MvState::CheckTarget(t) => t.done,
-                    _ => unreachable!(),
-                };
+                let done = matches!(
+                    Self::state_mut(interp, cmd).state,
+                    MvState::CheckTarget(Some(_))
+                );
                 if !done {
                     return Yield::suspended();
                 }
                 let result = match &mut Self::state_mut(interp, cmd).state {
-                    MvState::CheckTarget(t) => t.result.take(),
+                    MvState::CheckTarget(Some(t)) => t.result.take(),
                     _ => unreachable!(),
                 };
                 debug_assert!(result.is_some());
@@ -145,7 +136,7 @@ impl Mv {
                         // one source. Any other errno (EACCES, ELOOP, …)
                         // is reported and fails regardless of source count.
                         let target = match &Self::state_mut(interp, cmd).state {
-                            MvState::CheckTarget(t) => t.target.as_bytes().to_vec(),
+                            MvState::CheckTarget(Some(t)) => t.target.as_bytes().to_vec(),
                             _ => unreachable!(),
                         };
                         if e.get_errno() == bun_sys::E::ENOENT {
@@ -157,113 +148,96 @@ impl Mv {
                                 None
                             } else {
                                 let buf = Builtin::fmt_error_arena(
-                                    interp,
-                                    cmd,
                                     Some(Kind::Mv),
                                     format_args!(
                                         "{}: No such file or directory\n",
                                         bstr::BStr::new(&target)
                                     ),
-                                )
-                                .to_vec();
+                                );
                                 return Self::write_failing_error(interp, cmd, &buf, 1);
                             }
                         } else {
                             let msg = e.msg().unwrap_or(b"unknown error");
                             let buf = Builtin::fmt_error_arena(
-                                interp,
-                                cmd,
                                 Some(Kind::Mv),
                                 format_args!(
                                     "{}: {}\n",
                                     bstr::BStr::new(&target),
                                     bstr::BStr::new(msg)
                                 ),
-                            )
-                            .to_vec();
+                            );
                             return Self::write_failing_error(interp, cmd, &buf, 1);
                         }
                     }
                 };
 
                 let n_sources = {
-                    let me = Self::state_mut(interp, cmd);
+                    let mut me = Self::state_mut(interp, cmd);
                     me.args.target_fd = maybe_fd;
                     me.args.target_idx - me.args.sources_start
                 };
                 // Trying to move multiple files into a non-directory.
                 if maybe_fd.is_none() && n_sources > 1 {
                     let target = match &Self::state_mut(interp, cmd).state {
-                        MvState::CheckTarget(t) => t.target.as_bytes().to_vec(),
+                        MvState::CheckTarget(Some(t)) => t.target.as_bytes().to_vec(),
                         _ => unreachable!(),
                     };
                     let buf = Builtin::fmt_error_arena(
-                        interp,
-                        cmd,
                         Some(Kind::Mv),
                         format_args!("{} is not a directory\n", bstr::BStr::new(&target)),
-                    )
-                    .to_vec();
+                    );
                     return Self::write_failing_error(interp, cmd, &buf, 1);
                 }
 
                 const BATCH: usize = ShellMvBatchedTask::BATCH_SIZE;
                 let task_count = n_sources.div_ceil(BATCH);
                 let cwd = Builtin::cwd(interp, cmd);
-                let evtloop = Builtin::event_loop(interp, cmd);
                 let (sources_start, target_idx) = {
                     let me = Self::state_mut(interp, cmd);
                     (me.args.sources_start, me.args.target_idx)
                 };
-                let target = Builtin::of(interp, cmd).arg_bytes(target_idx);
-
-                let mut tasks: Vec<ShellMvBatchedTask> = Vec::with_capacity(task_count);
-                for i in 0..task_count {
-                    let start = sources_start + i * BATCH;
-                    let end = (start + BATCH).min(target_idx);
-                    let mut srcs = Vec::with_capacity(end - start);
-                    for j in start..end {
-                        srcs.push(ZBox::from_bytes(Builtin::of(interp, cmd).arg_bytes(j)));
+                let mut tasks: Vec<Box<ShellMvBatchedTask>> = Vec::with_capacity(task_count);
+                {
+                    let bltn = Builtin::of(interp, cmd);
+                    let target = bltn.arg_bytes(target_idx);
+                    for i in 0..task_count {
+                        let start = sources_start + i * BATCH;
+                        let end = (start + BATCH).min(target_idx);
+                        let mut srcs = Vec::with_capacity(end - start);
+                        for j in start..end {
+                            srcs.push(ZBox::from_bytes(bltn.arg_bytes(j)));
+                        }
+                        tasks.push(Box::new(ShellMvBatchedTask {
+                            cmd,
+                            sources: srcs,
+                            target: ZBox::from_bytes(target),
+                            target_fd: maybe_fd,
+                            cwd,
+                            error_signal: None,
+                            err: None,
+                            task: ShellTask::new(interp),
+                        }));
                     }
-                    tasks.push(ShellMvBatchedTask {
-                        cmd,
-                        idx: i,
-                        sources: srcs,
-                        target: ZBox::from_bytes(target),
-                        target_fd: maybe_fd,
-                        cwd,
-                        error_signal: None,
-                        err: None,
-                        task: ShellTask::new(evtloop),
-                    });
                 }
 
                 Self::state_mut(interp, cmd).state = MvState::Executing {
                     task_count,
                     tasks_done: 0,
                     error_signal: AtomicBool::new(false),
-                    tasks,
                     err: None,
                 };
                 // Now that the AtomicBool has its final address, point
                 // every task at it and schedule.
-                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
-                if let MvState::Executing {
-                    error_signal,
-                    tasks,
-                    ..
-                } = &mut Self::state_mut(interp, cmd).state
-                {
-                    let sig = BackRef::new(&*error_signal);
-                    for t in tasks.iter_mut() {
-                        t.error_signal = Some(sig);
-                        t.task.interp = interp_ptr;
-                        // SAFETY: `t` lives in `MvState::Executing::tasks`,
-                        // which is fully populated before any task is scheduled
-                        // and never grown afterward, so its address is stable
-                        // for the worker call's lifetime.
-                        unsafe { ShellTask::schedule(&raw mut *t) };
-                    }
+                let sig = {
+                    let me = Self::state_mut(interp, cmd);
+                    let MvState::Executing { error_signal, .. } = &me.state else {
+                        unreachable!()
+                    };
+                    BackRef::new(error_signal)
+                };
+                for mut t in tasks {
+                    t.error_signal = Some(sig);
+                    ShellTask::schedule(t);
                 }
                 Yield::suspended()
             }
@@ -283,38 +257,44 @@ impl Mv {
         _: usize,
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
-        match Self::state_mut(interp, cmd).state {
-            MvState::WaitingWriteErr { exit_code } => {
-                if let Some(_err) = e {
-                    Self::state_mut(interp, cmd).state = MvState::Err;
-                    return Self::next(interp, cmd);
-                }
-                Builtin::done(interp, cmd, exit_code)
-            }
+        let exit_code = match Self::state_mut(interp, cmd).state {
+            MvState::WaitingWriteErr { exit_code } => exit_code,
             _ => panic!("Invalid state"),
+        };
+        if let Some(_err) = e {
+            Self::state_mut(interp, cmd).state = MvState::Err;
+            return Self::next(interp, cmd);
         }
+        Builtin::done(interp, cmd, exit_code)
     }
 
-    fn check_target_task_done(interp: &Interpreter, cmd: NodeId) {
-        if let MvState::CheckTarget(t) = &mut Self::state_mut(interp, cmd).state {
-            t.done = true;
+    fn check_target_task_done(
+        interp: &Interpreter,
+        cmd: NodeId,
+        task: Box<ShellMvCheckTargetTask>,
+    ) {
+        {
+            let mut me = Self::state_mut(interp, cmd);
+            if let MvState::CheckTarget(slot) = &mut me.state {
+                *slot = Some(task);
+            }
         }
         Self::next(interp, cmd).run(interp);
     }
 
-    fn batched_move_task_done(interp: &Interpreter, cmd: NodeId, task_idx: usize) {
+    fn batched_move_task_done(interp: &Interpreter, cmd: NodeId, mut task: ShellMvBatchedTask) {
         let (all_done, had_err) = {
+            let mut me = Self::state_mut(interp, cmd);
             let MvState::Executing {
                 task_count,
                 tasks_done,
                 error_signal,
-                tasks,
                 err,
-            } = &mut Self::state_mut(interp, cmd).state
+            } = &mut me.state
             else {
                 unreachable!()
             };
-            if let Some(e) = tasks[task_idx].err.take() {
+            if let Some(e) = task.err.take() {
                 error_signal.store(true, Ordering::SeqCst);
                 if err.is_none() {
                     *err = Some(e);
@@ -331,7 +311,7 @@ impl Mv {
                 };
                 // The failing rename's errno becomes the shell exit code.
                 let exit_code = e.errno as ExitCode;
-                let buf = Builtin::task_error_to_string(interp, cmd, Kind::Mv, &e).to_vec();
+                let buf = Builtin::task_error_to_string(Kind::Mv, &e);
                 Self::write_failing_error(interp, cmd, &buf, exit_code).run(interp);
                 return;
             }
@@ -347,14 +327,14 @@ impl Mv {
         }
         let mut idx = 0usize;
         while idx < argc {
-            let flag = Builtin::of(interp, cmd).arg_bytes(idx);
-            match Self::parse_flag(flag) {
+            let parsed = Self::parse_flag(Builtin::of(interp, cmd).arg_bytes(idx));
+            match parsed {
                 MvFlag::Done => {
                     let filepath_args = argc - idx;
                     if filepath_args < 2 {
                         return Err(MvParseError::ShowUsage);
                     }
-                    let me = Self::state_mut(interp, cmd);
+                    let mut me = Self::state_mut(interp, cmd);
                     me.args.sources_start = idx;
                     me.args.target_idx = argc - 1;
                     return Ok(());
@@ -408,9 +388,19 @@ pub struct ShellMvCheckTargetTask {
     /// `Ok(Some(fd))` → directory; `Ok(None)` → not a directory; `Err(e)` →
     /// open error (e.g. ENOENT).
     pub(crate) result: Option<Result<Option<bun_sys::Fd>, bun_sys::Error>>,
-    pub(crate) done: bool,
     pub task: ShellTask,
 }
+
+impl Drop for ShellMvCheckTargetTask {
+    fn drop(&mut self) {
+        if let Some(Ok(Some(fd))) = self.result.take() {
+            closefd(fd);
+        }
+    }
+}
+
+crate::shell_task!(ShellMvCheckTargetTask);
+crate::shell_task!(ShellMvBatchedTask);
 
 impl ShellMvCheckTargetTask {
     fn run_from_thread_pool(this: &mut ShellMvCheckTargetTask) {
@@ -420,16 +410,13 @@ impl ShellMvCheckTargetTask {
             Err(e) if e.get_errno() == bun_sys::E::ENOTDIR => Ok(None),
             Err(e) => Err(e),
         });
-        // Bounce-back is posted by `shell_task_trampoline`.
+        // Bounce-back is posted by `ShellTask::run_owned`.
     }
 }
 
 /// renameat() each source into the target.
 pub struct ShellMvBatchedTask {
     pub(crate) cmd: NodeId,
-    /// Index into `MvState::Executing::tasks` so the main-thread completion
-    /// can route to `Mv::batched_move_task_done`.
-    pub(crate) idx: usize,
     pub(crate) sources: Vec<ZBox>,
     pub(crate) target: ZBox,
     pub(crate) target_fd: Option<bun_sys::Fd>,
@@ -474,7 +461,7 @@ impl ShellMvBatchedTask {
                 e
             });
         }
-        // Bounce-back is posted by `shell_task_trampoline`.
+        // Bounce-back is posted by `ShellTask::run_owned`.
     }
 
     /// `renameat()`, falling through to [`Self::move_across_devices`] on EXDEV.
@@ -679,52 +666,37 @@ impl ShellMvBatchedTask {
     }
 }
 
-impl bun_event_loop::Taskable for ShellMvCheckTargetTask {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellMvCheckTargetTask;
-    /// Owned by the builtin's `MvState`, which frees it with the interpreter;
-    /// only the keep-alive is this hop's to drop.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract; the Mv state outlives the queue entry.
-        unsafe { (*this).task.unref_unrun() }
-    }
-}
-impl bun_event_loop::Taskable for ShellMvBatchedTask {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellMvBatchedTask;
-    /// An element of `MvState::Executing.tasks`; as `ShellMvCheckTargetTask`.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: as above.
-        unsafe { (*this).task.unref_unrun() }
-    }
-}
+// `runtime::dispatch::run_task`'s arms rebox the pointer `ShellTask::on_finish`
+// posted; a completion that will not run drops the keep-alive and the box.
 
-// `*mut Self` sig is forced by the `ShellTaskCtx` trait contract; the body's
-// internal deref is SAFETY-commented.
 impl crate::shell::interpreter::ShellTaskCtx for ShellMvCheckTargetTask {
-    const TASK_OFFSET: usize = core::mem::offset_of!(Self, task);
-    fn run_from_thread_pool(this: &mut Self) {
-        Self::run_from_thread_pool(this)
+    fn shell_task(&self) -> &ShellTask {
+        &self.task
     }
-    // `*mut Self` sig forced by `ShellTaskCtx` trait contract; the body's internal deref is SAFETY-commented.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn run_from_main_thread(this: *mut Self, interp: &Interpreter) {
-        // SAFETY: `ShellTask::run_from_main_thread` dispatch contract — `this`
-        // is a live `ShellMvCheckTargetTask` held in `MvState::CheckTarget`.
-        let this = unsafe { this.as_ref() }.unwrap();
-        Mv::check_target_task_done(interp, this.cmd);
+    fn shell_task_mut(&mut self) -> &mut ShellTask {
+        &mut self.task
+    }
+    fn run_from_thread_pool(&mut self) {
+        Self::run_from_thread_pool(self)
+    }
+    fn run_from_main_thread(self: Box<Self>, interp: &Interpreter) {
+        let cmd = self.cmd;
+        Mv::check_target_task_done(interp, cmd, self);
     }
 }
 
 impl crate::shell::interpreter::ShellTaskCtx for ShellMvBatchedTask {
-    const TASK_OFFSET: usize = core::mem::offset_of!(Self, task);
-    fn run_from_thread_pool(this: &mut Self) {
-        Self::run_from_thread_pool(this)
+    fn shell_task(&self) -> &ShellTask {
+        &self.task
     }
-    // `*mut Self` sig forced by `ShellTaskCtx` trait contract; the body's internal deref is SAFETY-commented.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn run_from_main_thread(this: *mut Self, interp: &Interpreter) {
-        // SAFETY: `ShellTask::run_from_main_thread` dispatch contract — `this`
-        // is a live `ShellMvBatchedTask` held in `MvState::Executing::tasks`.
-        let this = unsafe { this.as_ref() }.unwrap();
-        Mv::batched_move_task_done(interp, this.cmd, this.idx);
+    fn shell_task_mut(&mut self) -> &mut ShellTask {
+        &mut self.task
+    }
+    fn run_from_thread_pool(&mut self) {
+        Self::run_from_thread_pool(self)
+    }
+    fn run_from_main_thread(self: Box<Self>, interp: &Interpreter) {
+        let cmd = self.cmd;
+        Mv::batched_move_task_done(interp, cmd, *self);
     }
 }

--- a/src/runtime/shell/builtin/pwd.rs
+++ b/src/runtime/shell/builtin/pwd.rs
@@ -29,32 +29,30 @@ impl Pwd {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
         if !Builtin::of(interp, cmd).args_slice().is_empty() {
             let msg: &[u8] = b"pwd: too many arguments\n";
-            if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
+            let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
+            if let Some(safeguard) = stderr_needs_io {
                 Self::state_mut(interp, cmd).state = State::WaitingIo {
                     kind: WaitKind::Stderr,
                 };
                 let child = ChildPtr::new(cmd, WriterTag::Builtin);
-                return Builtin::of_mut(interp, cmd)
-                    .stderr
-                    .enqueue(child, msg, safeguard);
+                return Builtin::write_out(interp, cmd, IoKind::Stderr, child, msg, safeguard);
             }
             let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, msg);
             return Builtin::done(interp, cmd, 1);
         }
 
         let cwd: Vec<u8> = {
-            let mut v = Builtin::shell(interp, cmd).cwd().to_vec();
+            let mut v = Builtin::shell(interp, cmd).borrow().cwd().to_vec();
             v.push(b'\n');
             v
         };
-        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+        if let Some(safeguard) = stdout_needs_io {
             Self::state_mut(interp, cmd).state = State::WaitingIo {
                 kind: WaitKind::Stdout,
             };
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd)
-                .stdout
-                .enqueue(child, &cwd, safeguard);
+            return Builtin::write_out(interp, cmd, IoKind::Stdout, child, &cwd, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &cwd);
         Self::state_mut(interp, cmd).state = State::Done;
@@ -72,8 +70,11 @@ impl Pwd {
             return Builtin::done(interp, cmd, 1);
         }
         let kind = match &Self::state_mut(interp, cmd).state {
-            State::WaitingIo { kind } => *kind,
-            _ => return Builtin::done(interp, cmd, 0),
+            State::WaitingIo { kind } => Some(*kind),
+            _ => None,
+        };
+        let Some(kind) = kind else {
+            return Builtin::done(interp, cmd, 0);
         };
         Self::state_mut(interp, cmd).state = State::Done;
         Builtin::done(interp, cmd, if kind == WaitKind::Stderr { 1 } else { 0 })

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -417,10 +417,15 @@ impl Rm {
         if let Some(s) = errstr {
             let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
             if let Some(safeguard) = stderr_needs_io {
-                if let RmState::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                    exec.output_count.fetch_add(1, Ordering::SeqCst);
-                }
-                let child = ChildPtr::new(cmd, WriterTag::Builtin);
+                let seq = match &mut Self::state_mut(interp, cmd).state {
+                    RmState::Exec(exec) => {
+                        exec.output_count.fetch_add(1, Ordering::SeqCst);
+                        exec.verbose_seq += 1;
+                        exec.verbose_seq
+                    }
+                    _ => 1,
+                };
+                let child = ChildPtr::builtin_task(cmd, seq);
                 Builtin::write_out(interp, cmd, IoKind::Stderr, child, &s, safeguard).run(interp);
                 return;
             }

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -41,6 +41,7 @@ pub struct ExecState {
     pub(crate) error_signal: AtomicBool,
     pub(crate) output_done: AtomicUsize,
     pub(crate) output_count: AtomicUsize,
+    pub(crate) verbose_seq: u32,
     pub(crate) tasks_done: usize,
     pub(crate) started: bool,
 }
@@ -250,6 +251,7 @@ impl Rm {
                                 error_signal: AtomicBool::new(false),
                                 output_done: AtomicUsize::new(0),
                                 output_count: AtomicUsize::new(0),
+                                verbose_seq: 0,
                                 tasks_done: 0,
                                 started: false,
                             });
@@ -473,7 +475,16 @@ impl Rm {
         let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
 
         if let Some(safeguard) = stdout_needs_io {
-            let child = ChildPtr::new(cmd, WriterTag::Builtin);
+            // One chunk per DirTask can be in flight; number them so each is
+            // called back (a failed writer calls equal children back once).
+            let seq = match &mut Self::state_mut(interp, cmd).state {
+                RmState::Exec(exec) => {
+                    exec.verbose_seq += 1;
+                    exec.verbose_seq
+                }
+                _ => 1,
+            };
+            let child = ChildPtr::builtin_task(cmd, seq);
             return Builtin::write_out(interp, cmd, IoKind::Stdout, child, &buf, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
@@ -552,8 +563,8 @@ impl Rm {
     }
 
     #[inline]
-    fn state_mut(interp: &Interpreter, cmd: NodeId) -> core::cell::RefMut<'_, Rm> {
-        core::cell::RefMut::map(Builtin::of_mut(interp, cmd), |b| match &mut b.impl_ {
+    fn state_mut(interp: &Interpreter, cmd: NodeId) -> bun_ptr::JsCellRefMut<'_, Rm> {
+        bun_ptr::JsCellRefMut::map(Builtin::of_mut(interp, cmd), |b| match &mut b.impl_ {
             crate::shell::builtin::Impl::Rm(r) => &mut **r,
             _ => unreachable!(),
         })

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -141,7 +141,8 @@ impl Rm {
                     }
 
                     let arg = Builtin::of(interp, cmd).arg_bytes(idx as usize).to_vec();
-                    match Self::parse_flag(&mut Self::state_mut(interp, cmd).opts, &arg) {
+                    let parsed = Self::parse_flag(&mut Self::state_mut(interp, cmd).opts, &arg);
+                    match parsed {
                         RmParseFlag::ContinueParsing => {
                             if let RmState::ParseOpts { idx: i, .. } =
                                 &mut Self::state_mut(interp, cmd).state
@@ -170,7 +171,7 @@ impl Rm {
 
                             // Check that none of the paths will delete the root.
                             {
-                                let cwd = Builtin::shell(interp, cmd).cwd().to_vec();
+                                let cwd = Builtin::shell(interp, cmd).borrow().cwd().to_vec();
                                 // Operands are unbounded user input, so neither
                                 // step may use the fixed-size thread-local
                                 // buffers behind `join` / `normalize_string`.
@@ -180,13 +181,13 @@ impl Rm {
                                 let mut normalize_buf = Vec::new();
 
                                 for i in args_start..argc {
-                                    let path = Builtin::of(interp, cmd).arg_bytes(i);
-                                    let resolved: &[u8] = if Platform::AUTO.is_absolute(path) {
-                                        path
+                                    let path = Builtin::of(interp, cmd).arg_bytes(i).to_vec();
+                                    let resolved: &[u8] = if Platform::AUTO.is_absolute(&path) {
+                                        &path
                                     } else {
                                         resolve_path::join_spill::<platform::Auto>(
                                             &mut join_spill,
-                                            &[&cwd, path],
+                                            &[&cwd, &path],
                                         )
                                     };
                                     if normalize_buf.len() <= resolved.len() {
@@ -205,37 +206,35 @@ impl Rm {
                                         // Copy resolved before
                                         // re-borrowing `interp` mutably.
                                         let resolved_owned = resolved.to_vec();
-                                        if let Some(safeguard) =
-                                            Builtin::of(interp, cmd).stderr.needs_io()
-                                        {
+                                        let stderr_needs_io =
+                                            Builtin::of(interp, cmd).stderr.needs_io();
+                                        if let Some(safeguard) = stderr_needs_io {
                                             Self::state_mut(interp, cmd).state =
                                                 RmState::ParseOpts {
                                                     idx,
                                                     wait_write_err: true,
                                                 };
                                             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-                                            return Builtin::of_mut(interp, cmd)
-                                                .stderr
-                                                .enqueue_fmt(
-                                                    child,
-                                                    Some(Kind::Rm),
-                                                    format_args!(
-                                                        "\"{}\" may not be removed\n",
-                                                        bstr::BStr::new(&resolved_owned)
-                                                    ),
-                                                    safeguard,
-                                                );
+                                            return Builtin::write_out_fmt(
+                                                interp,
+                                                cmd,
+                                                IoKind::Stderr,
+                                                child,
+                                                Some(Kind::Rm),
+                                                format_args!(
+                                                    "\"{}\" may not be removed\n",
+                                                    bstr::BStr::new(&resolved_owned)
+                                                ),
+                                                safeguard,
+                                            );
                                         }
                                         let buf = Builtin::fmt_error_arena(
-                                            interp,
-                                            cmd,
                                             Some(Kind::Rm),
                                             format_args!(
                                                 "\"{}\" may not be removed\n",
                                                 bstr::BStr::new(&resolved_owned)
                                             ),
-                                        )
-                                        .to_vec();
+                                        );
                                         let _ =
                                             Builtin::write_no_io(interp, cmd, IoKind::Stderr, &buf);
                                         return Builtin::done(interp, cmd, 1);
@@ -265,13 +264,17 @@ impl Rm {
                             );
                         }
                         RmParseFlag::IllegalOptionWithFlag => {
-                            if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
+                            let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
+                            if let Some(safeguard) = stderr_needs_io {
                                 Self::state_mut(interp, cmd).state = RmState::ParseOpts {
                                     idx,
                                     wait_write_err: true,
                                 };
                                 let child = ChildPtr::new(cmd, WriterTag::Builtin);
-                                return Builtin::of_mut(interp, cmd).stderr.enqueue_fmt(
+                                return Builtin::write_out_fmt(
+                                    interp,
+                                    cmd,
+                                    IoKind::Stderr,
                                     child,
                                     Some(Kind::Rm),
                                     format_args!(
@@ -282,12 +285,9 @@ impl Rm {
                                 );
                             }
                             let buf = Builtin::fmt_error_arena(
-                                interp,
-                                cmd,
                                 Some(Kind::Rm),
                                 format_args!("illegal option -- {}\n", bstr::BStr::new(&arg[1..])),
-                            )
-                            .to_vec();
+                            );
                             let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, &buf);
                             return Builtin::done(interp, cmd, 1);
                         }
@@ -300,29 +300,29 @@ impl Rm {
                     };
                     if !started {
                         let cwd = Builtin::cwd(interp, cmd);
-                        let evtloop = Builtin::event_loop(interp, cmd);
                         let opts = Self::state_mut(interp, cmd).opts;
-                        let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
                         let (args_start, argc) = {
-                            let me = Self::state_mut(interp, cmd);
+                            let mut me = Self::state_mut(interp, cmd);
                             let RmState::Exec(e) = &mut me.state else {
                                 unreachable!()
                             };
                             e.started = true;
                             (e.args_start, e.args_start + e.total_tasks)
                         };
-                        let (sig, out_count) = match &Self::state_mut(interp, cmd).state {
-                            RmState::Exec(e) => (
+                        let (sig, out_count) = {
+                            let me = Self::state_mut(interp, cmd);
+                            let RmState::Exec(e) = &me.state else {
+                                unreachable!()
+                            };
+                            (
                                 bun_ptr::BackRef::new(&e.error_signal),
                                 bun_ptr::BackRef::new(&e.output_count),
-                            ),
-                            _ => unreachable!(),
+                            )
                         };
                         for i in args_start..argc {
-                            let root = Builtin::of(interp, cmd).arg_bytes(i);
-                            let task = ShellRmTask::create(
-                                cmd, opts, root, cwd, sig, out_count, evtloop, interp_ptr,
-                            );
+                            let root = Builtin::of(interp, cmd).arg_bytes(i).to_vec();
+                            let task =
+                                ShellRmTask::create(cmd, opts, &root, cwd, sig, out_count, interp);
                             // SAFETY: freshly heap-allocated.
                             unsafe { ShellRmTask::schedule(task) };
                         }
@@ -336,15 +336,14 @@ impl Rm {
     }
 
     fn write_err_literal(interp: &Interpreter, cmd: NodeId, idx: u32, buf: &[u8]) -> Yield {
-        if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
+        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
+        if let Some(safeguard) = stderr_needs_io {
             Self::state_mut(interp, cmd).state = RmState::ParseOpts {
                 idx,
                 wait_write_err: true,
             };
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd)
-                .stderr
-                .enqueue(child, buf, safeguard);
+            return Builtin::write_out(interp, cmd, IoKind::Stderr, child, buf, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, buf);
         Builtin::done(interp, cmd, 1)
@@ -397,7 +396,7 @@ impl Rm {
         // stashing the error on `exec` (formatting needs &mut interp).
         let errstr: Option<Vec<u8>> = task_err
             .as_ref()
-            .map(|e| Builtin::task_error_to_string(interp, cmd, Kind::Rm, e).to_vec());
+            .map(|e| Builtin::task_error_to_string(Kind::Rm, e));
         let (tasks_done, total) = {
             let RmState::Exec(exec) = &mut Self::state_mut(interp, cmd).state else {
                 panic!("Invalid state")
@@ -414,15 +413,13 @@ impl Rm {
         };
 
         if let Some(s) = errstr {
-            if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
+            let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
+            if let Some(safeguard) = stderr_needs_io {
                 if let RmState::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                     exec.output_count.fetch_add(1, Ordering::SeqCst);
                 }
                 let child = ChildPtr::new(cmd, WriterTag::Builtin);
-                Builtin::of_mut(interp, cmd)
-                    .stderr
-                    .enqueue(child, &s, safeguard)
-                    .run(interp);
+                Builtin::write_out(interp, cmd, IoKind::Stderr, child, &s, safeguard).run(interp);
                 return;
             }
             let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, &s);
@@ -473,11 +470,11 @@ impl Rm {
             }
         });
 
-        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+
+        if let Some(safeguard) = stdout_needs_io {
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd)
-                .stdout
-                .enqueue(child, &buf, safeguard);
+            return Builtin::write_out(interp, cmd, IoKind::Stdout, child, &buf, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
         let done = match &mut Self::state_mut(interp, cmd).state {
@@ -555,11 +552,11 @@ impl Rm {
     }
 
     #[inline]
-    fn state_mut(interp: &Interpreter, cmd: NodeId) -> &mut Rm {
-        match &mut Builtin::of_mut(interp, cmd).impl_ {
+    fn state_mut(interp: &Interpreter, cmd: NodeId) -> core::cell::RefMut<'_, Rm> {
+        core::cell::RefMut::map(Builtin::of_mut(interp, cmd), |b| match &mut b.impl_ {
             crate::shell::builtin::Impl::Rm(r) => &mut **r,
             _ => unreachable!(),
-        }
+        })
     }
 }
 
@@ -668,9 +665,9 @@ impl ShellRmTask {
         cwd: bun_sys::Fd,
         error_signal: bun_ptr::BackRef<AtomicBool>,
         output_count: bun_ptr::BackRef<AtomicUsize>,
-        evtloop: EventLoopHandle,
-        interp: *mut Interpreter,
+        interp: &Interpreter,
     ) -> *mut ShellRmTask {
+        let evtloop = interp.event_loop;
         let join_style = JoinStyle::from_path(root_path);
         // Separate allocation — see the comment on `root_task`.
         let root_task = bun_core::heap::into_raw(Box::new(DirTask {
@@ -690,7 +687,7 @@ impl ShellRmTask {
                 callback: DirTask::work_pool_callback,
             },
         }));
-        let mut boxed = Box::new(ShellRmTask {
+        let boxed = Box::new(ShellRmTask {
             cmd,
             opts,
             cwd,
@@ -701,9 +698,8 @@ impl ShellRmTask {
             err: bun_threading::Guarded::new(None),
             join_style,
             event_loop: evtloop,
-            task: ShellTask::new(evtloop),
+            task: ShellTask::new(interp),
         });
-        boxed.task.interp = interp;
         let raw = bun_core::heap::into_raw(boxed);
         // SAFETY: both freshly leaked; exclusive.
         unsafe { (*root_task).task_manager = raw };
@@ -734,12 +730,12 @@ impl ShellRmTask {
     /// Recover `*ShellRmTask` from the intrusive `*WorkPoolTask` and run the
     /// root DirTask.
     unsafe fn work_pool_callback(task: *mut WorkPoolTask) {
-        // SAFETY: `task` is the first `#[repr(C)]` field of `ShellTask`, which
-        // is embedded in `ShellRmTask` at `TASK_OFFSET`. `this` is a live
-        // heap-allocated task; the worker thread has exclusive access to
+        // SAFETY: `task` is `self.task.task`, embedded in a live heap-allocated
+        // `ShellRmTask`; the worker thread has exclusive access to
         // `root_task` until it spawns subtasks.
         unsafe {
-            let this = <Self as crate::shell::interpreter::ShellTaskCtx>::from_work_task(task);
+            let this =
+                bun_ptr::container_of::<Self, _>(task, core::mem::offset_of!(Self, task.task));
             DirTask::run_from_thread_pool_impl((*this).root_task);
         }
     }
@@ -751,18 +747,29 @@ impl ShellRmTask {
     /// `this` is the live `heap::alloc`'d task; not touched again on this
     /// thread after return (unless a verbose pending-count keeps it alive).
     unsafe fn finish_concurrently(this: *mut ShellRmTask) {
-        // SAFETY: caller contract.
-        unsafe { ShellTask::on_finish::<ShellRmTask>(this) };
-    }
-
-    /// # Safety
-    /// `this` must be a live `heap::alloc`'d [`ShellRmTask`] posted via
-    /// [`finish_concurrently`]; main thread.
-    fn run_from_main_thread(this: *mut ShellRmTask, interp: &Interpreter) {
-        // SAFETY: caller contract.
+        use bun_event_loop::{ArmedLoopTask, ConcurrentTask::AutoDeinit, EventLoopTask};
+        use core::ptr::NonNull;
+        // SAFETY: caller contract. Raw place access only: queued verbose hops
+        // may read `*this` on the main thread concurrently, so no `Box`/`&mut`
+        // may cover it here; `poster` is moved out before the post, after
+        // which the main thread may free `*this`.
         unsafe {
-            let cmd = (*this).cmd;
-            Rm::on_shell_rm_task_done(interp, cmd, this);
+            let poster = (*this)
+                .task
+                .poster
+                .take()
+                .expect("shell task on the pool is armed");
+            let armed = match &mut (*this).task.concurrent_task {
+                EventLoopTask::Js(ct) => {
+                    ArmedLoopTask::Js(NonNull::from(ct.from(this, AutoDeinit::ManualDeinit)))
+                }
+                EventLoopTask::Mini(at) => ArmedLoopTask::Mini(
+                    NonNull::new(at.from(this, shell_rm_task_run_from_main_thread_mini))
+                        .expect("intrusive task"),
+                ),
+            };
+            poster.post(armed);
+            drop(poster);
         }
     }
 
@@ -1548,8 +1555,9 @@ impl DirTask {
         // SAFETY: caller contract — `interp` set at create.
         let (interp, cmd) = unsafe {
             let tm = (*this).task_manager;
-            (&*(*tm).task.interp, (*tm).cmd)
+            ((*tm).task.interp, (*tm).cmd)
         };
+        let interp = interp.get();
         Rm::write_verbose(interp, cmd, this).run(interp);
     }
 
@@ -1751,9 +1759,21 @@ impl bun_event_loop::Taskable for DirTask {
     }
 }
 
+/// Mini-loop trampoline for [`ShellRmTask::finish_concurrently`].
+fn shell_rm_task_run_from_main_thread_mini(this: *mut ShellRmTask, _: *mut ()) {
+    // SAFETY: `this` is the live heap task `finish_concurrently` posted; the
+    // mini loop fires it once on the main thread.
+    ShellTask::run_from_main_thread::<ShellRmTask>(unsafe { bun_core::heap::take(this) });
+}
+
 impl crate::shell::interpreter::ShellTaskCtx for ShellRmTask {
-    const TASK_OFFSET: usize = core::mem::offset_of!(Self, task);
-    fn run_from_thread_pool(_this: &mut Self) {
+    fn shell_task(&self) -> &ShellTask {
+        &self.task
+    }
+    fn shell_task_mut(&mut self) -> &mut ShellTask {
+        &mut self.task
+    }
+    fn run_from_thread_pool(&mut self) {
         // Not reached: `ShellRmTask::schedule` installs `work_pool_callback`
         // directly (the generic trampoline auto-posts back, which would race
         // the recursive DirTask tree's own `finish_concurrently`).
@@ -1762,8 +1782,10 @@ impl crate::shell::interpreter::ShellTaskCtx for ShellRmTask {
             "ShellRmTask scheduled via ShellTask::schedule; use ShellRmTask::schedule"
         );
     }
-    fn run_from_main_thread(this: *mut Self, interp: &Interpreter) {
-        // SAFETY: `ShellTask::run_from_main_thread` dispatch contract.
-        Self::run_from_main_thread(this, interp)
+    /// Released back to the raw pending-callback protocol
+    /// (`decr_pending_and_maybe_deinit` frees it).
+    fn run_from_main_thread(self: Box<Self>, interp: &Interpreter) {
+        let cmd = self.cmd;
+        Rm::on_shell_rm_task_done(interp, cmd, bun_core::heap::into_raw(self));
     }
 }

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -18,10 +18,8 @@ pub struct Seq {
     start: f32,
     end: f32,
     increment: f32,
-    /// Borrowed from argv (NUL-terminated arena strings) or `'static` literals;
-    /// argv outlives the builtin — `RawSlice` invariant.
-    separator: bun_ptr::RawSlice<u8>,
-    terminator: bun_ptr::RawSlice<u8>,
+    separator: Vec<u8>,
+    terminator: Vec<u8>,
 }
 
 impl Default for Seq {
@@ -31,8 +29,8 @@ impl Default for Seq {
             start: 1.0,
             end: 1.0,
             increment: 1.0,
-            separator: bun_ptr::RawSlice::new(b"\n"),
-            terminator: bun_ptr::RawSlice::EMPTY,
+            separator: b"\n".to_vec(),
+            terminator: Vec::new(),
         }
     }
 }
@@ -44,24 +42,23 @@ impl Seq {
             return Self::fail(interp, cmd, Kind::Seq.usage_string());
         }
 
+        let arg_at = |i: usize| -> Vec<u8> { Builtin::of(interp, cmd).arg_bytes(i).to_vec() };
         let mut idx = 0usize;
-        // Flag parsing — operates on raw argv pointers so we can stash
-        // borrowed slices into separator/terminator.
         while idx < argc {
-            let arg = Builtin::of(interp, cmd).arg_bytes(idx);
+            let arg = arg_at(idx);
 
             if arg == b"-s" || arg == b"--separator" {
                 idx += 1;
                 if idx >= argc {
                     return Self::fail(interp, cmd, b"seq: option requires an argument -- s\n");
                 }
-                let bytes = Builtin::of(interp, cmd).arg_bytes(idx);
-                Self::state_mut(interp, cmd).separator = bun_ptr::RawSlice::new(bytes);
+                let bytes = arg_at(idx);
+                Self::state_mut(interp, cmd).separator = bytes;
                 idx += 1;
                 continue;
             }
             if arg.starts_with(b"-s") && arg.len() > 2 {
-                Self::state_mut(interp, cmd).separator = bun_ptr::RawSlice::new(&arg[2..]);
+                Self::state_mut(interp, cmd).separator = arg[2..].to_vec();
                 idx += 1;
                 continue;
             }
@@ -70,13 +67,13 @@ impl Seq {
                 if idx >= argc {
                     return Self::fail(interp, cmd, b"seq: option requires an argument -- t\n");
                 }
-                let bytes = Builtin::of(interp, cmd).arg_bytes(idx);
-                Self::state_mut(interp, cmd).terminator = bun_ptr::RawSlice::new(bytes);
+                let bytes = arg_at(idx);
+                Self::state_mut(interp, cmd).terminator = bytes;
                 idx += 1;
                 continue;
             }
             if arg.starts_with(b"-t") && arg.len() > 2 {
-                Self::state_mut(interp, cmd).terminator = bun_ptr::RawSlice::new(&arg[2..]);
+                Self::state_mut(interp, cmd).terminator = arg[2..].to_vec();
                 idx += 1;
                 continue;
             }
@@ -90,8 +87,8 @@ impl Seq {
         // Positional args.
         macro_rules! parse_num {
             ($i:expr) => {{
-                let s = Builtin::of(interp, cmd).arg_bytes($i);
-                match parse_f32(s) {
+                let s = arg_at($i);
+                match parse_f32(&s) {
                     Some(n) if n.is_finite() => n,
                     _ => return Self::fail(interp, cmd, b"seq: invalid argument\n"),
                 }
@@ -104,7 +101,7 @@ impl Seq {
         let int1 = parse_num!(idx);
         idx += 1;
         {
-            let me = Self::state_mut(interp, cmd);
+            let mut me = Self::state_mut(interp, cmd);
             me.end = int1;
             if me.start > me.end {
                 me.increment = -1.0;
@@ -115,7 +112,8 @@ impl Seq {
             let int2 = parse_num!(idx);
             idx += 1;
             {
-                let me = Self::state_mut(interp, cmd);
+                let mut me = Self::state_mut(interp, cmd);
+                let me = &mut *me;
                 me.start = int1;
                 me.end = int2;
                 me.increment = if me.start < me.end {
@@ -129,19 +127,22 @@ impl Seq {
             if idx < argc {
                 let int3 = parse_num!(idx);
                 {
-                    let me = Self::state_mut(interp, cmd);
+                    let mut me = Self::state_mut(interp, cmd);
                     me.start = int1;
                     me.increment = int2;
                     me.end = int3;
                 }
-                let me = Self::state_mut(interp, cmd);
-                if me.increment == 0.0 {
+                let (start, end, increment) = {
+                    let me = Self::state_mut(interp, cmd);
+                    (me.start, me.end, me.increment)
+                };
+                if increment == 0.0 {
                     return Self::fail(interp, cmd, b"seq: zero increment\n");
                 }
-                if me.start > me.end && me.increment > 0.0 {
+                if start > end && increment > 0.0 {
                     return Self::fail(interp, cmd, b"seq: needs negative decrement\n");
                 }
-                if me.start < me.end && me.increment < 0.0 {
+                if start < end && increment < 0.0 {
                     return Self::fail(interp, cmd, b"seq: needs positive increment\n");
                 }
             }
@@ -160,8 +161,14 @@ impl Seq {
         // Render entirely into a local Vec, then either enqueue it or
         // write_no_io it; we buffer once for simplicity.
         let (start, end, incr, sep, term) = {
-            let me = Self::state_mut(interp, cmd);
-            (me.start, me.end, me.increment, me.separator, me.terminator)
+            let mut me = Self::state_mut(interp, cmd);
+            (
+                me.start,
+                me.end,
+                me.increment,
+                core::mem::take(&mut me.separator),
+                core::mem::take(&mut me.terminator),
+            )
         };
         let mut out = Vec::new();
         let mut current = start;
@@ -173,7 +180,7 @@ impl Seq {
             // Rust `{}` for f32 prints the shortest decimal that round-trips
             // (no exponent, no trailing ".0").
             let _ = write!(&mut out, "{}", current);
-            out.extend_from_slice(sep.slice());
+            out.extend_from_slice(&sep);
             let next = current + incr;
             if next == current {
                 // f32 rounding can make `current + incr` equal `current`
@@ -184,15 +191,13 @@ impl Seq {
             }
             current = next;
         }
-        out.extend_from_slice(term.slice());
+        out.extend_from_slice(&term);
 
         Self::state_mut(interp, cmd).state = State::Done;
         if needs_io {
             let safeguard = Builtin::of(interp, cmd).stdout.needs_io().unwrap();
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd)
-                .stdout
-                .enqueue(child, &out, safeguard);
+            return Builtin::write_out(interp, cmd, IoKind::Stdout, child, &out, safeguard);
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &out);
         Builtin::done(interp, cmd, 0)
@@ -208,7 +213,8 @@ impl Seq {
             Self::state_mut(interp, cmd).state = State::Err;
             return Builtin::done(interp, cmd, 1);
         }
-        match Self::state_mut(interp, cmd).state {
+        let state = Self::state_mut(interp, cmd).state;
+        match state {
             State::Done => Builtin::done(interp, cmd, 0),
             State::Err => Builtin::done(interp, cmd, 1),
             State::Idle => {

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -1,11 +1,11 @@
 use crate::shell::ExitCode;
-use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
+use crate::shell::builtin::{Builtin, BuiltinState, Kind};
 use crate::shell::interpreter::{
-    FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable, OutputWrite,
+    FlagParser, Interpreter, NodeId, OutputQueue, OutputSrc, OutputTask, OutputTaskVTable,
     ParseFlagResult, ShellTask, unsupported_flag,
 };
-use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
+use bun_ptr::JsCellRefMut;
 
 #[derive(Default)]
 pub struct Touch {
@@ -25,14 +25,10 @@ pub struct ExecState {
     pub(crate) started: bool,
     pub(crate) tasks_count: usize,
     pub(crate) tasks_done: usize,
-    pub(crate) output_done: usize,
-    pub(crate) output_waiting: usize,
     /// Index into argv where filepath args start.
     pub(crate) args_start: usize,
     pub(crate) err: Option<bun_sys::Error>,
-    /// FIFO of in-flight OutputTasks awaiting an IOWriter chunk completion —
-    /// see mkdir.rs `Exec::output_queue` for rationale.
-    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Touch>>>,
+    pub(crate) output: OutputQueue<Touch>,
 }
 
 impl Touch {
@@ -61,11 +57,9 @@ impl Touch {
             started: false,
             tasks_count: 0,
             tasks_done: 0,
-            output_done: 0,
-            output_waiting: 0,
             args_start,
             err: None,
-            output_queue: std::collections::VecDeque::new(),
+            output: OutputQueue::default(),
         });
         Self::next(interp, cmd)
     }
@@ -82,9 +76,7 @@ impl Touch {
             State::Idle => panic!("Invalid state"),
             State::Exec(exec) => {
                 if exec.started {
-                    if exec.tasks_done >= exec.tasks_count
-                        && exec.output_done >= exec.output_waiting
-                    {
+                    if exec.tasks_done >= exec.tasks_count && exec.output.drained() {
                         let code: ExitCode = if exec.err.is_some() { 1 } else { 0 };
                         exec.err = None;
                         Action::Done(code)
@@ -129,18 +121,14 @@ impl Touch {
         written: usize,
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
-        if matches!(Self::state_mut(interp, cmd).state, State::WaitingWriteErr) {
-            return Builtin::done(interp, cmd, 1);
-        }
-        let pending = if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_queue.pop_front()
-        } else {
-            None
-        };
-        if let Some(task) = pending {
-            return OutputTask::<Touch>::on_io_writer_chunk(task, interp, written, e);
-        }
-        Self::next(interp, cmd)
+        // Only the usage error is written directly; task output goes through
+        // `OutputTask::on_chunk`.
+        let _ = (written, e);
+        debug_assert!(matches!(
+            Self::state_mut(interp, cmd).state,
+            State::WaitingWriteErr
+        ));
+        Builtin::done(interp, cmd, 1)
     }
 
     fn on_shell_touch_task_done(interp: &Interpreter, cmd: NodeId, mut task: ShellTouchTask) {
@@ -161,73 +149,13 @@ impl Touch {
 }
 
 impl OutputTaskVTable for Touch {
-    fn write_err(
-        interp: &Interpreter,
-        cmd: NodeId,
-        child: Box<OutputTask<Self>>,
-        errbuf: &[u8],
-    ) -> OutputWrite<Self> {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_waiting += 1;
-        }
-        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
-        if let Some(safeguard) = stderr_needs_io {
-            // Park it so on_io_writer_chunk can route the completion back to
-            // the OutputTask state machine (there is no WriterTag for it).
-            if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
-            }
-            let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return OutputWrite::Enqueued(Builtin::write_out(
-                interp,
-                cmd,
-                IoKind::Stderr,
-                childptr,
-                errbuf,
-                safeguard,
-            ));
-        }
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        OutputWrite::Done(child)
+    fn output_queue(interp: &Interpreter, cmd: NodeId) -> JsCellRefMut<'_, OutputQueue<Self>> {
+        JsCellRefMut::map(Self::state_mut(interp, cmd), |me| match &mut me.state {
+            State::Exec(exec) => &mut exec.output,
+            _ => unreachable!("touch output outside Exec"),
+        })
     }
-    fn on_write_err(interp: &Interpreter, cmd: NodeId) {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_done += 1;
-        }
-    }
-    fn write_out(
-        interp: &Interpreter,
-        cmd: NodeId,
-        child: Box<OutputTask<Self>>,
-    ) -> OutputWrite<Self> {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_waiting += 1;
-        }
-        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
-        if let Some(safeguard) = stdout_needs_io {
-            let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return OutputWrite::Enqueued(Builtin::write_out_with(
-                interp,
-                cmd,
-                IoKind::Stdout,
-                childptr,
-                safeguard,
-                |buf| {
-                    buf.extend_from_slice(child.output.slice());
-                    if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                        exec.output_queue.push_back(child);
-                    }
-                },
-            ));
-        }
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, child.output.slice());
-        OutputWrite::Done(child)
-    }
-    fn on_write_out(interp: &Interpreter, cmd: NodeId) {
-        if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-            exec.output_done += 1;
-        }
-    }
+
     fn on_done(interp: &Interpreter, cmd: NodeId) -> Yield {
         Self::next(interp, cmd)
     }

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -1,8 +1,8 @@
 use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
-    EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable, OutputWrite,
+    ParseFlagResult, ShellTask, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -30,19 +30,17 @@ pub struct ExecState {
     /// Index into argv where filepath args start.
     pub(crate) args_start: usize,
     pub(crate) err: Option<bun_sys::Error>,
-    /// FIFO of in-flight OutputTask pointers awaiting an IOWriter chunk
-    /// completion. Stopgap until `WriterTag` can carry the `*mut OutputTask`
-    /// directly — see mkdir.rs `Exec::output_queue` for rationale.
-    pub(crate) output_queue: std::collections::VecDeque<*mut OutputTask<Touch>>,
+    /// FIFO of in-flight OutputTasks awaiting an IOWriter chunk completion —
+    /// see mkdir.rs `Exec::output_queue` for rationale.
+    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Touch>>>,
 }
 
 impl Touch {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
         let mut opts = Opts::default();
         let args_start = {
-            let args = Builtin::of(interp, cmd).args_slice();
-            match parse_flags(&mut opts, args) {
-                Ok(Some(rest)) => args.len() - rest.len(),
+            match Builtin::parse_flags(interp, cmd, &mut opts) {
+                Ok(Some(start)) => start,
                 Ok(None) => {
                     Self::state_mut(interp, cmd).state = State::WaitingWriteErr;
                     return Builtin::write_failing_error(
@@ -76,6 +74,9 @@ impl Touch {
         enum Action {
             Done(ExitCode),
             Schedule(usize),
+            Suspend,
+            Failed,
+            AlreadyDone,
         }
         let action = match &mut Self::state_mut(interp, cmd).state {
             State::Idle => panic!("Invalid state"),
@@ -88,34 +89,34 @@ impl Touch {
                         exec.err = None;
                         Action::Done(code)
                     } else {
-                        return Yield::suspended();
+                        Action::Suspend
                     }
                 } else {
                     exec.started = true;
                     Action::Schedule(exec.args_start)
                 }
             }
-            State::WaitingWriteErr => return Yield::failed(),
-            State::Done => return Builtin::done(interp, cmd, 0),
+            State::WaitingWriteErr => Action::Failed,
+            State::Done => Action::AlreadyDone,
         };
         match action {
+            Action::Suspend => Yield::suspended(),
+            Action::Failed => Yield::failed(),
+            Action::AlreadyDone => Builtin::done(interp, cmd, 0),
             Action::Done(code) => {
                 Self::state_mut(interp, cmd).state = State::Done;
                 Builtin::done(interp, cmd, code)
             }
             Action::Schedule(args_start) => {
-                let argc = Builtin::of(interp, cmd).args_slice().len();
+                let argc = Builtin::argc(interp, cmd);
                 if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                     exec.tasks_count = argc - args_start;
                 }
-                let cwd = Builtin::shell(interp, cmd).cwd().to_vec();
-                let evtloop = Builtin::event_loop(interp, cmd);
-                let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+                let cwd = Builtin::shell(interp, cmd).borrow().cwd().to_vec();
                 for i in args_start..argc {
                     let path = Builtin::of(interp, cmd).arg_bytes(i).to_vec();
-                    let task = ShellTouchTask::create(cmd, path, cwd.clone(), evtloop, interp_ptr);
-                    // SAFETY: freshly heap-allocated.
-                    unsafe { ShellTask::schedule(task) };
+                    let task = ShellTouchTask::create(cmd, path, cwd.clone(), interp);
+                    ShellTask::schedule(task);
                 }
                 Yield::suspended()
             }
@@ -137,25 +138,18 @@ impl Touch {
             None
         };
         if let Some(task) = pending {
-            // SAFETY: `task` was heap-allocated in `OutputTask::new` and
-            // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Touch>::on_io_writer_chunk(task, interp, written, e) };
+            return OutputTask::<Touch>::on_io_writer_chunk(task, interp, written, e);
         }
         Self::next(interp, cmd)
     }
 
-    /// # Safety
-    /// `task` must be a live heap allocation produced by
-    /// [`ShellTouchTask::create`]; ownership is reclaimed here.
-    fn on_shell_touch_task_done(interp: &Interpreter, cmd: NodeId, task: *mut ShellTouchTask) {
-        // SAFETY: task was heap-allocated in create(); reclaim.
-        let mut task = unsafe { bun_core::heap::take(task) };
+    fn on_shell_touch_task_done(interp: &Interpreter, cmd: NodeId, mut task: ShellTouchTask) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.tasks_done += 1;
         }
         if let Some(e) = task.err.take() {
             let output_task = OutputTask::<Touch>::new(cmd, OutputSrc::Arrlist(Vec::new()));
-            let errstr = Builtin::task_error_to_string(interp, cmd, Kind::Touch, &e).to_vec();
+            let errstr = Builtin::task_error_to_string(Kind::Touch, &e);
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                 exec.err = Some(e);
             }
@@ -170,27 +164,31 @@ impl OutputTaskVTable for Touch {
     fn write_err(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
+        child: Box<OutputTask<Self>>,
         errbuf: &[u8],
-    ) -> Option<Yield> {
+    ) -> OutputWrite<Self> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
-        if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
-            // Stash so on_io_writer_chunk can route to the OutputTask state
-            // machine and reclaim the box (stopgap for missing WriterTag).
+        let stderr_needs_io = Builtin::of(interp, cmd).stderr.needs_io();
+        if let Some(safeguard) = stderr_needs_io {
+            // Park it so on_io_writer_chunk can route the completion back to
+            // the OutputTask state machine (there is no WriterTag for it).
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                 exec.output_queue.push_back(child);
             }
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Some(
-                Builtin::of_mut(interp, cmd)
-                    .stderr
-                    .enqueue(childptr, errbuf, safeguard),
-            );
+            return OutputWrite::Enqueued(Builtin::write_out(
+                interp,
+                cmd,
+                IoKind::Stderr,
+                childptr,
+                errbuf,
+                safeguard,
+            ));
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        None
+        OutputWrite::Done(child)
     }
     fn on_write_err(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
@@ -200,27 +198,30 @@ impl OutputTaskVTable for Touch {
     fn write_out(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
-        output: &mut OutputSrc,
-    ) -> Option<Yield> {
+        child: Box<OutputTask<Self>>,
+    ) -> OutputWrite<Self> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
-        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-            if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
-            }
+        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+        if let Some(safeguard) = stdout_needs_io {
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            let buf = output.slice().to_vec();
-            return Some(
-                Builtin::of_mut(interp, cmd)
-                    .stdout
-                    .enqueue(childptr, &buf, safeguard),
-            );
+            return OutputWrite::Enqueued(Builtin::write_out_with(
+                interp,
+                cmd,
+                IoKind::Stdout,
+                childptr,
+                safeguard,
+                |buf| {
+                    buf.extend_from_slice(child.output.slice());
+                    if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
+                        exec.output_queue.push_back(child);
+                    }
+                },
+            ));
         }
-        let buf = output.slice().to_vec();
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-        None
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, child.output.slice());
+        OutputWrite::Done(child)
     }
     fn on_write_out(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
@@ -241,23 +242,22 @@ pub struct ShellTouchTask {
     pub task: ShellTask,
 }
 
+crate::shell_task!(ShellTouchTask);
+
 impl ShellTouchTask {
     pub(crate) fn create(
         cmd: NodeId,
         filepath: Vec<u8>,
         cwd_path: Vec<u8>,
-        evtloop: EventLoopHandle,
-        interp: *mut Interpreter,
-    ) -> *mut ShellTouchTask {
-        let mut task = Box::new(ShellTouchTask {
+        interp: &Interpreter,
+    ) -> Box<ShellTouchTask> {
+        Box::new(ShellTouchTask {
             cmd,
             filepath,
             cwd_path,
             err: None,
-            task: ShellTask::new(evtloop),
-        });
-        task.task.interp = interp;
-        bun_core::heap::into_raw(task)
+            task: ShellTask::new(interp),
+        })
     }
 
     /// utimes() the path; on ENOENT
@@ -306,43 +306,28 @@ impl ShellTouchTask {
                 this.err = Some(err.with_path(filepath.as_bytes()));
             }
         }
-        // Worker→main bounce-back is posted by `shell_task_trampoline` after
+        // Worker→main bounce-back is posted by `ShellTask::run_owned` after
         // this returns.
     }
-
-    /// # Safety
-    /// `this` must be a live heap allocation produced by [`Self::create`];
-    /// ownership is consumed via [`Touch::on_shell_touch_task_done`].
-    fn run_from_main_thread(this: *mut ShellTouchTask, interp: &Interpreter) {
-        // SAFETY: `this` is a live heap-allocated task.
-        let cmd = unsafe { (*this).cmd };
-        // SAFETY: forwarded from caller's contract.
-        Touch::on_shell_touch_task_done(interp, cmd, this);
-    }
 }
 
-impl bun_event_loop::Taskable for ShellTouchTask {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellTouchTask;
-    /// A pool completion that will not run: drop the keep-alive and the box
-    /// (nothing else frees an unrun one).
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — the box the builtin scheduled.
-        unsafe {
-            (*this).task.unref_unrun();
-            drop(bun_core::heap::take(this));
-        }
-    }
-}
+// `runtime::dispatch::run_task`'s `task_tag::ShellTouchTask` arm reboxes the
+// pointer `ShellTask::on_finish` posted; a completion that will not run drops
+// the keep-alive and the box.
 
 impl crate::shell::interpreter::ShellTaskCtx for ShellTouchTask {
-    const TASK_OFFSET: usize = core::mem::offset_of!(Self, task);
-    fn run_from_thread_pool(this: &mut Self) {
-        Self::run_from_thread_pool(this)
+    fn shell_task(&self) -> &ShellTask {
+        &self.task
     }
-    fn run_from_main_thread(this: *mut Self, interp: &Interpreter) {
-        // SAFETY: `ShellTaskCtx` callers guarantee `this` is the live
-        // heap-allocated task posted via `ShellTask::schedule`.
-        Self::run_from_main_thread(this, interp)
+    fn shell_task_mut(&mut self) -> &mut ShellTask {
+        &mut self.task
+    }
+    fn run_from_thread_pool(&mut self) {
+        Self::run_from_thread_pool(self)
+    }
+    fn run_from_main_thread(self: Box<Self>, interp: &Interpreter) {
+        let cmd = self.cmd;
+        Touch::on_shell_touch_task_done(interp, cmd, *self);
     }
 }
 
@@ -375,9 +360,7 @@ impl FlagParser for Opts {
             b'm' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-m"))),
             b'r' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-r"))),
             b't' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-t"))),
-            _ => Some(ParseFlagResult::IllegalOption(
-                &raw const smallflags[1 + i..],
-            )),
+            _ => Some(ParseFlagResult::IllegalOption(smallflags[1 + i..].into())),
         }
     }
 }

--- a/src/runtime/shell/builtin/which.rs
+++ b/src/runtime/shell/builtin/which.rs
@@ -32,12 +32,11 @@ impl Which {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
         let argc = Builtin::of(interp, cmd).args_slice().len();
         if argc == 0 {
-            if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+            let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+            if let Some(safeguard) = stdout_needs_io {
                 Self::state_mut(interp, cmd).state = State::OneArg;
                 let child = ChildPtr::new(cmd, WriterTag::Builtin);
-                return Builtin::of_mut(interp, cmd)
-                    .stdout
-                    .enqueue(child, b"\n", safeguard);
+                return Builtin::write_out(interp, cmd, IoKind::Stdout, child, b"\n", safeguard);
             }
             let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, b"\n");
             return Builtin::done(interp, cmd, 1);
@@ -53,23 +52,17 @@ impl Which {
                 match search.resolve(&arg) {
                     Some(resolved) => {
                         let buf = Builtin::fmt_error_arena(
-                            interp,
-                            cmd,
                             None,
                             format_args!("{}\n", bstr::BStr::new(&resolved)),
-                        )
-                        .to_vec();
+                        );
                         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
                     }
                     None => {
                         had_not_found = true;
                         let buf = Builtin::fmt_error_arena(
-                            interp,
-                            cmd,
                             Some(Kind::Which),
                             format_args!("{} not found\n", bstr::BStr::new(&arg)),
-                        )
-                        .to_vec();
+                        );
                         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
                     }
                 }
@@ -114,8 +107,12 @@ impl Which {
                     *had_not_found = true;
                     *waiting_write = true;
                 }
-                if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-                    return Builtin::of_mut(interp, cmd).stdout.enqueue_fmt(
+                let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+                if let Some(safeguard) = stdout_needs_io {
+                    return Builtin::write_out_fmt(
+                        interp,
+                        cmd,
+                        IoKind::Stdout,
                         child,
                         None,
                         format_args!("{} not found\n", bstr::BStr::new(&arg)),
@@ -123,12 +120,9 @@ impl Which {
                     );
                 }
                 let buf = Builtin::fmt_error_arena(
-                    interp,
-                    cmd,
                     None,
                     format_args!("{} not found\n", bstr::BStr::new(&arg)),
-                )
-                .to_vec();
+                );
                 let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
                 Self::arg_complete(interp, cmd)
             }
@@ -138,8 +132,12 @@ impl Which {
                 {
                     *waiting_write = true;
                 }
-                if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-                    return Builtin::of_mut(interp, cmd).stdout.enqueue_fmt(
+                let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+                if let Some(safeguard) = stdout_needs_io {
+                    return Builtin::write_out_fmt(
+                        interp,
+                        cmd,
+                        IoKind::Stdout,
                         child,
                         None,
                         format_args!("{}\n", bstr::BStr::new(&resolved)),
@@ -147,12 +145,9 @@ impl Which {
                     );
                 }
                 let buf = Builtin::fmt_error_arena(
-                    interp,
-                    cmd,
                     None,
                     format_args!("{}\n", bstr::BStr::new(&resolved)),
-                )
-                .to_vec();
+                );
                 let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
                 Self::arg_complete(interp, cmd)
             }
@@ -181,10 +176,18 @@ impl Which {
         if let Some(err) = e {
             return Builtin::done(interp, cmd, err.errno as crate::shell::ExitCode);
         }
-        match Self::state_mut(interp, cmd).state {
-            State::OneArg => Builtin::done(interp, cmd, 1),
-            State::MultiArgs { .. } => Self::arg_complete(interp, cmd),
-            _ => Builtin::done(interp, cmd, 0),
+        enum Then {
+            Done(crate::shell::ExitCode),
+            ArgComplete,
+        }
+        let then = match Self::state_mut(interp, cmd).state {
+            State::OneArg => Then::Done(1),
+            State::MultiArgs { .. } => Then::ArgComplete,
+            _ => Then::Done(0),
+        };
+        match then {
+            Then::Done(code) => Builtin::done(interp, cmd, code),
+            Then::ArgComplete => Self::arg_complete(interp, cmd),
         }
     }
 
@@ -203,6 +206,7 @@ struct SearchEnv {
 impl SearchEnv {
     fn load(interp: &Interpreter, cmd: NodeId) -> Self {
         let shell = Builtin::shell(interp, cmd);
+        let shell = shell.borrow();
         // `EnvMap::get` refs the returned string; balance it.
         let path_env = shell
             .export_env

--- a/src/runtime/shell/builtin/yes.rs
+++ b/src/runtime/shell/builtin/yes.rs
@@ -1,5 +1,5 @@
 use crate::shell::ExitCode;
-use crate::shell::builtin::{Builtin, BuiltinIO, BuiltinState, Impl, Kind};
+use crate::shell::builtin::{Builtin, BuiltinIO, BuiltinState, Impl, IoKind, Kind};
 use crate::shell::interpreter::{EventLoopHandle, Interpreter, NodeId, OutputNeedsIOSafeGuard};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::states::cmd::Exec;
@@ -64,20 +64,21 @@ impl Yes {
         }
 
         let evtloop = Builtin::event_loop(interp, cmd);
-        let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
         {
-            let me = Self::state_mut(interp, cmd);
+            let mut me = Self::state_mut(interp, cmd);
             me.buffer = buf;
             me.buffer_used = filled;
             me.task = Some(YesTask {
-                interp: interp_ptr,
+                interp: bun_ptr::ParentRef::new(interp),
                 cmd,
                 evtloop,
                 concurrent_task: EventLoopTask::from_event_loop(evtloop),
             });
         }
 
-        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io();
+
+        if let Some(safeguard) = stdout_needs_io {
             Self::state_mut(interp, cmd).state = State::WaitingIo;
             return Self::enqueue_chunk(interp, cmd, safeguard);
         }
@@ -92,8 +93,9 @@ impl Yes {
         // are accessible simultaneously — the buffer is written zero-copy,
         // which matters for `yes` throughput.
         let err = {
-            let cmd_node = interp.as_cmd_mut(cmd);
-            let shell = cmd_node.base.shell;
+            let mut cmd_node = interp.as_cmd_mut(cmd);
+            let cmd_node = &mut *cmd_node;
+            let shell = cmd_node.base.shell.borrow();
             let Exec::Builtin(me) = &mut cmd_node.exec else {
                 unreachable!()
             };
@@ -101,8 +103,7 @@ impl Yes {
             let chunk = &yes.buffer[..yes.buffer_used];
             let mut err = None;
             for _ in 0..4 {
-                // SAFETY: `shell` is `cmd_node.base.shell`, live for the Cmd.
-                if let Err(e) = unsafe { stdout.write_no_io_to(shell, chunk) } {
+                if let Err(e) = stdout.write_no_io_to(&shell, chunk) {
                     err = Some(e);
                     break;
                 }
@@ -111,12 +112,9 @@ impl Yes {
         };
         if let Some(e) = err {
             let buf = Builtin::fmt_error_arena(
-                interp,
-                cmd,
                 Some(Kind::Yes),
                 format_args!("{}\n", bstr::BStr::new(e.name())),
-            )
-            .to_vec();
+            );
             return Self::write_failing_error(interp, cmd, &buf, 1);
         }
         // Bounce back via the event loop so we don't block the main thread.
@@ -139,10 +137,10 @@ impl Yes {
         safeguard: OutputNeedsIOSafeGuard,
     ) -> Yield {
         let child = ChildPtr::new(cmd, WriterTag::Builtin);
-        // `stdout` and `impl_` are disjoint fields of `Builtin` — split-borrow
-        // so the tiled buffer is enqueued zero-copy.
-        let (stdout, yes) = Self::split_stdout_state(Builtin::of_mut(interp, cmd));
-        stdout.enqueue(child, &yes.buffer[..yes.buffer_used], safeguard)
+        Builtin::write_out_with(interp, cmd, IoKind::Stdout, child, safeguard, |buf| {
+            let yes = Self::state_mut(interp, cmd);
+            buf.extend_from_slice(&yes.buffer[..yes.buffer_used]);
+        })
     }
 
     fn write_failing_error(
@@ -191,7 +189,7 @@ impl Yes {
 #[repr(C)]
 pub struct YesTask {
     /// Back-ref to the owning [`Interpreter`].
-    pub(crate) interp: *mut Interpreter,
+    pub(crate) interp: bun_ptr::ParentRef<Interpreter>,
     pub(crate) cmd: NodeId,
     pub(crate) evtloop: EventLoopHandle,
     pub(crate) concurrent_task: EventLoopTask,
@@ -240,8 +238,7 @@ impl YesTask {
     /// [`Yes::start`]. Reached only via the concurrent-task dispatch installed
     /// in [`enqueue`](Self::enqueue).
     pub(crate) fn run_from_main_thread(this: &Self) {
-        // SAFETY: `interp` was set in `Yes::start` and outlives the task.
-        let (interp, cmd) = unsafe { (&*this.interp, this.cmd) };
+        let (interp, cmd) = (&*this.interp, this.cmd);
         Yes::write_no_io_loop(interp, cmd).run(interp);
     }
 

--- a/src/runtime/shell/dispatch_tasks.rs
+++ b/src/runtime/shell/dispatch_tasks.rs
@@ -1,32 +1,43 @@
-//! Forward-decl shell task types referenced by `runtime::dispatch::run_task`.
+//! Shell task types referenced by `runtime::dispatch::run_task`.
 //!
 //! Several shell task types collapsed into the NodeId-arena state machine
-//! (`interpreter.rs`); the rest are gated behind `interpreter_body_gated.rs`.
-//! The high-tier dispatcher must still cast the erased `Task.ptr` to a
-//! concrete type and call the per-type entry point, so the shapes are
-//! declared here. Bodies that already exist elsewhere re-export through this
-//! module; the rest carry the body inline (mostly `run_from_main_thread()` →
-//! resume the parent state via NodeId).
+//! (`interpreter.rs`). The high-tier dispatcher must still rebox the erased
+//! `Task.ptr` as a concrete type and call the per-type entry point, so the
+//! shapes are declared here. Bodies that already exist elsewhere re-export
+//! through this module; the rest carry the body inline (mostly
+//! `run_from_main_thread()` → resume the parent state via NodeId).
 
-use crate::shell::interpreter::{Interpreter, NodeId, ShellTask};
+use bun_ptr::ParentRef;
+
+use crate::shell::interpreter::{Interpreter, NodeId, ShellTask, ShellTaskCtx};
+
 /// Task payload for [`ShellAsync`](crate::shell::states::r#async::Async)'s
 /// bounce back to the main thread. The state lives in `interp.nodes`, so
-/// the enqueued payload is `(interp, node)`.
-#[repr(C)]
+/// the enqueued payload is `(interp, node)`; one is boxed per `Async` node
+/// and reused for each bounce.
 pub(crate) struct ShellAsyncTask {
-    pub interp: *mut Interpreter,
+    pub interp: ParentRef<Interpreter>,
     pub node: NodeId,
+    /// Intrusive node for the mini-loop post (the JS loop queues a `Task`).
+    pub concurrent_task: bun_event_loop::AnyTaskWithExtraContext::AnyTaskWithExtraContext,
 }
 
-/// Stat task backing shell conditional expressions (`[ -f x ]` etc.). Wraps an
-/// inner [`ShellTask`].
-#[repr(C)]
+impl ShellAsyncTask {
+    pub(crate) fn run(self: Box<Self>) {
+        crate::shell::states::r#async::Async::run_from_main_thread(self);
+    }
+}
+
+impl bun_event_loop::AnyTaskWithExtraContext::BoxedMiniTaskRunner<ShellAsyncTask>
+    for ShellAsyncTask
+{
+    fn run_from_loop_thread(owner: Box<ShellAsyncTask>) {
+        owner.run();
+    }
+}
+
+/// Stat task backing shell conditional expressions (`[ -f x ]` etc.).
 pub(crate) struct ShellCondExprStatTask {
-    pub task: CondExprStatInner,
-}
-
-#[repr(C)]
-pub(crate) struct CondExprStatInner {
     pub task: ShellTask,
     pub cond: NodeId,
     pub stat: bun_sys::Result<bun_sys::Stat>,
@@ -37,21 +48,23 @@ pub(crate) struct CondExprStatInner {
     pub cwd_fd: bun_sys::Fd,
 }
 
-impl ShellCondExprStatTask {
-    /// # Safety
-    /// `this` must be a live `heap::alloc` payload paired with the schedule
-    /// site. Ownership of `*this` is consumed.
-    // Dispatch trampoline: `this` validity is guaranteed by the `run_task`
-    // contract; signature is fixed by `dispatch.rs`.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn run_from_main_thread(this: *mut Self, interp: &Interpreter) {
-        // SAFETY: live Box'd task; paired with `heap::alloc` at schedule time.
-        let owned = unsafe { bun_core::heap::take(this) };
+crate::shell_task!(ShellCondExprStatTask);
+
+impl ShellTaskCtx for ShellCondExprStatTask {
+    fn shell_task(&self) -> &ShellTask {
+        &self.task
+    }
+    fn shell_task_mut(&mut self) -> &mut ShellTask {
+        &mut self.task
+    }
+    fn run_from_thread_pool(&mut self) {
+        debug_assert!(self.path.last() == Some(&0));
+        let z = bun_core::ZStr::from_buf(&self.path, self.path.len() - 1);
+        self.stat = crate::shell::interpreter::shell_statat(self.cwd_fd, z);
+    }
+    fn run_from_main_thread(self: Box<Self>, interp: &Interpreter) {
         crate::shell::states::cond_expr::CondExpr::on_stat_task_done(
-            interp,
-            owned.task.cond,
-            &owned.task.stat,
-            &owned.task.path,
+            interp, self.cond, &self.stat, &self.path,
         );
     }
 }
@@ -63,7 +76,6 @@ pub enum ShellGlobErr {
 }
 
 /// Glob-expansion task run off the JS thread during word expansion.
-#[repr(C)]
 pub(crate) struct ShellGlobTask {
     pub task: ShellTask,
     pub expansion: NodeId,
@@ -72,63 +84,47 @@ pub(crate) struct ShellGlobTask {
     pub err: Option<ShellGlobErr>,
 }
 
-impl bun_event_loop::Taskable for ShellGlobTask {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellGlobTask;
-    /// A pool completion that will not run: drop the keep-alive and the box
-    /// (nothing else frees an unrun one).
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — the box the builtin scheduled.
-        unsafe {
-            (*this).task.unref_unrun();
-            drop(bun_core::heap::take(this));
-        }
-    }
-}
+crate::shell_task!(ShellGlobTask);
 
-impl crate::shell::interpreter::ShellTaskCtx for ShellGlobTask {
-    const TASK_OFFSET: usize = core::mem::offset_of!(Self, task);
-    fn run_from_thread_pool(this: &mut Self) {
-        match Self::walk_impl(&mut this.walker, &mut this.result) {
+impl ShellTaskCtx for ShellGlobTask {
+    fn shell_task(&self) -> &ShellTask {
+        &self.task
+    }
+    fn shell_task_mut(&mut self) -> &mut ShellTask {
+        &mut self.task
+    }
+    fn run_from_thread_pool(&mut self) {
+        match Self::walk_impl(&mut self.walker, &mut self.result) {
             Ok(Ok(())) => {}
-            Ok(Err(e)) => this.err = Some(ShellGlobErr::Syscall(e)),
-            Err(e) => this.err = Some(ShellGlobErr::Unknown(e)),
+            Ok(Err(e)) => self.err = Some(ShellGlobErr::Syscall(e)),
+            Err(e) => self.err = Some(ShellGlobErr::Unknown(e)),
         }
     }
-    // Dispatch trampoline: `this` validity is guaranteed by the `run_task`
-    // contract; signature is fixed by the `ShellTaskCtx` trait.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn run_from_main_thread(this: *mut Self, interp: &Interpreter) {
-        // SAFETY: paired with `heap::alloc` in `create_and_schedule`.
-        let mut me = unsafe { bun_core::heap::take(this) };
+    fn run_from_main_thread(mut self: Box<Self>, interp: &Interpreter) {
         crate::shell::states::expansion::Expansion::on_glob_walk_done(
             interp,
-            me.expansion,
-            core::mem::take(&mut me.result),
-            me.err.take(),
+            self.expansion,
+            core::mem::take(&mut self.result),
+            self.err.take(),
         );
     }
 }
 
 impl ShellGlobTask {
-    /// Heap-allocate the glob task for `expansion` and schedule it on the
-    /// work pool; the allocation is freed in `run_from_main_thread`.
+    /// Box the glob task for `expansion` and schedule it on the work pool;
+    /// it comes back through `run_from_main_thread`.
     pub(crate) fn create_and_schedule(
         interp: &Interpreter,
         expansion: NodeId,
         walker: bun_glob::BunGlobWalkerZ,
     ) {
-        let mut task = ShellTask::new(interp.event_loop);
-        task.interp = interp.as_ctx_ptr();
-        let this = bun_core::heap::alloc(ShellGlobTask {
-            task,
+        ShellTask::schedule(Box::new(ShellGlobTask {
+            task: ShellTask::new(interp),
             expansion,
             walker,
             result: Vec::new(),
             err: None,
-        });
-        // SAFETY: `this` is a fresh heap allocation embedding `ShellTask` at
-        // `TASK_OFFSET`; freed in `run_from_main_thread`.
-        unsafe { ShellTask::schedule::<ShellGlobTask>(this) };
+        }));
     }
 
     fn walk_impl(

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -22,16 +22,17 @@
 //! `match` on the parent's tag (`Interpreter::child_done`), which keeps the
 //! per-tick hot path inlined (see PORTING.md §Dispatch hot-path).
 //!
-//! Each slot is a `RefCell<Node>` in its own heap box, so a borrowed node
-//! stays put while the arena grows and overlapping borrows of one node are a
-//! checked panic rather than aliasing. State methods take
+//! Slots are `JsRefCell<Node>`s in boxed chunks, so a borrowed node stays put
+//! while the arena grows and (in debug builds) overlapping borrows of one
+//! node are a checked panic rather than aliasing. State methods take
 //! `(&Interpreter, this: NodeId)` and look their own data up via
 //! `interp.as_<kind>(this)` / `interp.as_<kind>_mut(this)`; keep those borrows
 //! short and never hold one across a call that re-enters the same node.
 
 use bun_collections::VecExt;
 use bun_jsc::JsCell;
-use core::cell::{Cell, Ref, RefCell, RefMut};
+use bun_ptr::{JsCellRef, JsCellRefMut, JsRefCell};
+use core::cell::Cell;
 use core::fmt;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -103,7 +104,16 @@ impl fmt::Display for NodeId {
 }
 
 const NODE_CHUNK: usize = 8;
-type NodeChunk = [RefCell<Node>; NODE_CHUNK];
+type NodeChunk = [JsRefCell<Node>; NODE_CHUNK];
+
+/// A chunk of free slots, built in place on the heap (an array literal would
+/// be assembled on the stack and copied over).
+fn new_node_chunk() -> Box<NodeChunk> {
+    let chunk: Box<[JsRefCell<Node>]> = core::iter::repeat_with(|| JsRefCell::new(Node::Free))
+        .take(NODE_CHUNK)
+        .collect();
+    chunk.try_into().ok().expect("exactly NODE_CHUNK slots")
+}
 
 /// One slot in the interpreter's state arena. All state structs
 /// live as enum variants so the arena is a single homogeneous vector.
@@ -177,33 +187,34 @@ impl Node {
     }
 }
 
+#[cold]
+#[inline(never)]
+#[track_caller]
+fn node_kind_mismatch(expected: &'static str, id: NodeId, got: StateKind) -> ! {
+    panic!("expected Node::{expected} at {id}, got {got:?}")
+}
+
 /// Generate `Interpreter::as_<kind>{,_mut}` typed accessors. These panic on
-/// tag mismatch, and (being `RefCell` borrows) on an overlapping borrow of
+/// tag mismatch, and (in debug builds) on an overlapping borrow of
 /// the same node.
 macro_rules! node_accessors {
     ($($variant:ident => $ty:ty, $get:ident, $get_mut:ident);* $(;)?) => {
         impl Interpreter {
             $(
-                #[inline]
+                #[inline(always)]
                 #[track_caller]
-                pub fn $get(&self, id: NodeId) -> Ref<'_, $ty> {
-                    Ref::map(self.node(id), |n| match n {
+                pub fn $get(&self, id: NodeId) -> JsCellRef<'_, $ty> {
+                    JsCellRef::map(self.node(id), |n| match n {
                         Node::$variant(v) => v,
-                        other => panic!(
-                            concat!("expected Node::", stringify!($variant), " at {}, got {:?}"),
-                            id, other.kind()
-                        ),
+                        other => node_kind_mismatch(stringify!($variant), id, other.kind()),
                     })
                 }
-                #[inline]
+                #[inline(always)]
                 #[track_caller]
-                pub fn $get_mut(&self, id: NodeId) -> RefMut<'_, $ty> {
-                    RefMut::map(self.node_mut(id), |n| match n {
+                pub fn $get_mut(&self, id: NodeId) -> JsCellRefMut<'_, $ty> {
+                    JsCellRefMut::map(self.node_mut(id), |n| match n {
                         Node::$variant(v) => v,
-                        other => panic!(
-                            concat!("expected Node::", stringify!($variant), " at {}, got {:?}"),
-                            id, other.kind()
-                        ),
+                        other => node_kind_mismatch(stringify!($variant), id, other.kind()),
                     })
                 }
             )*
@@ -273,10 +284,12 @@ pub enum OutputNeedsIOSafeGuard {
 pub struct Interpreter {
     /// State-machine node arena. Indices are `NodeId`s; freed slots are
     /// recycled via `free_list`. Slots live in fixed-size boxed chunks that
-    /// are only ever appended, so a `Ref`/`RefMut` into one stays valid while
-    /// the arena grows, and filling a slot goes through its own `RefCell`.
+    /// are only ever appended, so a `JsCellRef`/`JsCellRefMut` into one stays valid
+    /// while the arena grows; refilling a slot goes through its own cell.
+    nodes_head: Box<NodeChunk>,
+    /// Chunks after the first (most scripts never need one).
     #[allow(clippy::vec_box, reason = "chunk address stability across growth")]
-    nodes: JsCell<Vec<Box<NodeChunk>>>,
+    nodes_tail: JsCell<Vec<Box<NodeChunk>>>,
     /// Slots handed out so far (high-water mark).
     node_len: Cell<u32>,
     free_list: JsCell<Vec<u32>>,
@@ -420,7 +433,7 @@ impl Interpreter {
         debug_assert_eq!(*cwd_arr.last().unwrap(), 0);
 
         let (buffered_stdout, buffered_stderr) = CapturedBuf::new_pair();
-        let root_shell = Rc::new(RefCell::new(ShellExecEnv {
+        let root_shell = Rc::new(JsRefCell::new(ShellExecEnv {
             buffered_stdout,
             buffered_stderr,
             shell_env: EnvMap::init(),
@@ -459,7 +472,8 @@ impl Interpreter {
 
         // ── assemble ───────────────────────────────────────────────────────
         let interpreter = Box::new(Interpreter {
-            nodes: JsCell::new(Vec::new()),
+            nodes_head: new_node_chunk(),
+            nodes_tail: JsCell::new(Vec::new()),
             node_len: Cell::new(0),
             free_list: JsCell::new(Vec::new()),
             event_loop,
@@ -695,21 +709,25 @@ impl Interpreter {
 
     /// Allocate a fresh slot in the node arena and return its id. Reuses
     /// freed slots when available.
+    #[inline]
     pub(crate) fn alloc_node(&self, node: Node) -> NodeId {
-        let id = match self.free_list.with_mut(|f| f.pop()) {
-            Some(slot) => NodeId(slot),
-            None => {
-                let n = self.node_len.get();
-                if n as usize == self.nodes.get().len() * NODE_CHUNK {
-                    self.nodes.with_mut(|c| {
-                        c.push(Box::new([const { RefCell::new(Node::Free) }; NODE_CHUNK]))
-                    });
-                }
-                self.node_len.set(n + 1);
-                NodeId(n)
-            }
-        };
-        *self.node_mut(id) = node;
+        if let Some(slot) = self.free_list.with_mut(|f| f.pop()) {
+            let id = NodeId(slot);
+            self.slot(id).set(node);
+            return id;
+        }
+        self.alloc_node_slow(node)
+    }
+
+    #[inline(never)]
+    fn alloc_node_slow(&self, node: Node) -> NodeId {
+        let n = self.node_len.get();
+        if n as usize == (self.nodes_tail.get().len() + 1) * NODE_CHUNK {
+            self.nodes_tail.with_mut(|c| c.push(new_node_chunk()));
+        }
+        self.node_len.set(n + 1);
+        let id = NodeId(n);
+        self.slot(id).set(node);
         id
     }
 
@@ -724,11 +742,14 @@ impl Interpreter {
         if id == NodeId::NONE || id == NodeId::INTERPRETER {
             return;
         }
-        let old = core::mem::replace(&mut *self.node_mut(id), Node::Free);
-        debug_assert!(!matches!(old, Node::Free), "double-free of {}", id);
-        // Dropped outside the slot borrow: a node's fields (`IO`, env `Rc`s)
-        // never re-enter the arena on drop today, but keep it structural.
-        drop(old);
+        debug_assert!(
+            !matches!(self.kind(id), StateKind::Free),
+            "double-free of {}",
+            id
+        );
+        // Dropped in place: a node's fields (`IO`, env handles) never re-enter
+        // the arena on drop.
+        self.slot(id).set(Node::Free);
         self.free_list.with_mut(|f| f.push(id.0));
     }
 
@@ -808,9 +829,15 @@ impl Interpreter {
         false
     }
 
-    #[inline]
-    fn slot(&self, id: NodeId) -> &RefCell<Node> {
-        &self.nodes.get()[id.idx() / NODE_CHUNK][id.idx() % NODE_CHUNK]
+    #[inline(always)]
+    fn slot(&self, id: NodeId) -> &JsRefCell<Node> {
+        let i = id.idx();
+        if i < NODE_CHUNK {
+            &self.nodes_head[i]
+        } else {
+            let i = i - NODE_CHUNK;
+            &self.nodes_tail.get()[i / NODE_CHUNK][i % NODE_CHUNK]
+        }
     }
 
     #[cfg(not(windows))]
@@ -819,23 +846,33 @@ impl Interpreter {
         self.node_len.get() as usize
     }
 
-    #[inline]
+    #[inline(always)]
     #[track_caller]
-    pub fn node(&self, id: NodeId) -> Ref<'_, Node> {
+    pub fn node(&self, id: NodeId) -> JsCellRef<'_, Node> {
         self.slot(id).borrow()
     }
 
-    #[inline]
+    #[inline(always)]
     #[track_caller]
-    pub(crate) fn node_mut(&self, id: NodeId) -> RefMut<'_, Node> {
+    pub(crate) fn node_mut(&self, id: NodeId) -> JsCellRefMut<'_, Node> {
         self.slot(id).borrow_mut()
     }
 
     /// The state tag of node `id`.
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     pub fn kind(&self, id: NodeId) -> StateKind {
         self.node(id).kind()
+    }
+
+    /// The IO a `Stmt` under `parent` (a `Script` or `If`) hands its children.
+    #[inline]
+    pub(crate) fn io_of(&self, parent: NodeId) -> IO {
+        match &*self.node(parent) {
+            Node::Script(s) => s.io.clone(),
+            Node::If(i) => i.io.clone(),
+            other => node_kind_mismatch("Script|If", parent, other.kind()),
+        }
     }
 
     // ── hoisted dispatch (PORTING.md §Dispatch hot-path) ───────────────────
@@ -1278,10 +1315,9 @@ impl Interpreter {
         // finished); the only remaining reader is `memory_cost()`, which
         // queries the arena's size and never touches the AST.
         debug_assert!(
-            self.nodes
-                .get()
+            self.nodes_head
                 .iter()
-                .flat_map(|c| c.iter())
+                .chain(self.nodes_tail.get().iter().flat_map(|c| c.iter()))
                 .all(|slot| matches!(&*slot.borrow(), Node::Free)),
             "AST arena reset with live state nodes"
         );
@@ -1508,14 +1544,14 @@ pub(crate) fn throw_shell_err(
 /// stdout/stderr pairs that share one allocation.
 #[derive(Clone)]
 pub struct CapturedBuf {
-    pair: Rc<[RefCell<Vec<u8>>; 2]>,
+    pair: Rc<[JsRefCell<Vec<u8>>; 2]>,
     idx: u8,
 }
 
 impl CapturedBuf {
     /// A fresh `(stdout, stderr)` pair.
     pub fn new_pair() -> (CapturedBuf, CapturedBuf) {
-        let pair: Rc<[RefCell<Vec<u8>>; 2]> = Rc::default();
+        let pair: Rc<[JsRefCell<Vec<u8>>; 2]> = Rc::default();
         (
             CapturedBuf {
                 pair: Rc::clone(&pair),
@@ -1527,13 +1563,13 @@ impl CapturedBuf {
 
     #[inline]
     #[track_caller]
-    pub fn borrow(&self) -> Ref<'_, Vec<u8>> {
+    pub fn borrow(&self) -> JsCellRef<'_, Vec<u8>> {
         self.pair[self.idx as usize].borrow()
     }
 
     #[inline]
     #[track_caller]
-    pub fn borrow_mut(&self) -> RefMut<'_, Vec<u8>> {
+    pub fn borrow_mut(&self) -> JsCellRefMut<'_, Vec<u8>> {
         self.pair[self.idx as usize].borrow_mut()
     }
 }
@@ -1542,7 +1578,7 @@ impl CapturedBuf {
 /// nodes that dupe (Script for command substitution, Subshell, pipeline
 /// children) hold the only handle to the fresh env, everything else shares
 /// its parent's. The env is freed when its last holder is.
-pub type EnvRc = Rc<RefCell<ShellExecEnv>>;
+pub type EnvRc = Rc<JsRefCell<ShellExecEnv>>;
 
 /// Shell execution environment (env vars, cwd, captured stdout/stderr).
 pub struct ShellExecEnv {
@@ -1675,7 +1711,7 @@ impl ShellExecEnv {
             "[ShellExecEnv] dupe 0x{:x}",
             std::ptr::from_ref(&duped) as usize
         );
-        Ok(Rc::new(RefCell::new(duped)))
+        Ok(Rc::new(JsRefCell::new(duped)))
     }
 
     /// Early teardown for the root env (held by the `Interpreter` until it is
@@ -2279,130 +2315,172 @@ impl OutputSrc {
 pub enum OutputTaskState {
     WaitingWriteErr,
     WaitingWriteOut,
-    Done,
 }
 
-/// What a builtin did with an [`OutputTask`]'s write request.
-#[allow(clippy::large_enum_variant)]
-pub enum OutputWrite<P: OutputTaskVTable> {
-    /// Queued on an `IOWriter`; the builtin holds the task until the chunk
-    /// callback hands it back through [`OutputTask::on_io_writer_chunk`].
-    Enqueued(Yield),
-    /// Written synchronously; carry on with the task.
-    Done(Box<OutputTask<P>>),
+/// The in-flight [`OutputTask`]s of one builtin. A task whose chunk is
+/// queued on an IOWriter is parked here under the sequence number carried
+/// in that chunk's [`ChildPtr`](crate::shell::io_writer::ChildPtr), so every
+/// chunk completion (or failure) finds exactly its task.
+pub struct OutputQueue<P: OutputTaskVTable> {
+    next_seq: u32,
+    /// Chunks queued on a writer that have not called back yet.
+    waiting: u32,
+    parked: Vec<OutputTask<P>>,
 }
 
-/// Vtable trait the parent builtin implements. All hooks
-/// take `(&Interpreter, NodeId)` (NodeId style — the parent builtin lives
-/// inside the interpreter's node arena).
-///
-/// `write_*` receive the task itself so an async write can park it on the
-/// builtin until the chunk completes.
-pub trait OutputTaskVTable: Sized {
-    fn write_err(
-        interp: &Interpreter,
-        cmd: NodeId,
-        task: Box<OutputTask<Self>>,
-        errbuf: &[u8],
-    ) -> OutputWrite<Self>;
-    fn on_write_err(interp: &Interpreter, cmd: NodeId);
-    /// Write `task.output`.
-    fn write_out(
-        interp: &Interpreter,
-        cmd: NodeId,
-        task: Box<OutputTask<Self>>,
-    ) -> OutputWrite<Self>;
-    fn on_write_out(interp: &Interpreter, cmd: NodeId);
+impl<P: OutputTaskVTable> Default for OutputQueue<P> {
+    fn default() -> Self {
+        Self {
+            next_seq: 0,
+            waiting: 0,
+            parked: Vec::new(),
+        }
+    }
+}
+
+impl<P: OutputTaskVTable> OutputQueue<P> {
+    /// No chunk is still out on a writer.
+    #[inline]
+    pub(crate) fn drained(&self) -> bool {
+        self.waiting == 0
+    }
+}
+
+/// Implemented by the builtins that print through [`OutputTask`]s
+/// (ls/mkdir/touch/cp).
+pub trait OutputTaskVTable: Sized + 'static {
+    fn output_queue(interp: &Interpreter, cmd: NodeId) -> JsCellRefMut<'_, OutputQueue<Self>>;
+    /// A task finished both writes; usually re-runs the builtin's `next`.
     fn on_done(interp: &Interpreter, cmd: NodeId) -> Yield;
 }
 
-/// A task that can write to stdout and/or stderr.
+/// Writes one sub-task's error message (stderr) and then its output (stdout)
+/// for the builtin at `parent`, then reports `on_done`.
 pub struct OutputTask<P: OutputTaskVTable> {
     /// Owning Cmd node (the builtin's `cmd` id).
     pub(crate) parent: NodeId,
     pub(crate) output: OutputSrc,
     pub(crate) state: OutputTaskState,
+    /// Key in the builtin's [`OutputQueue`] while a chunk is out.
+    seq: u32,
     _marker: core::marker::PhantomData<P>,
 }
 
 impl<P: OutputTaskVTable> OutputTask<P> {
-    pub(crate) fn new(parent: NodeId, output: OutputSrc) -> Box<Self> {
-        Box::new(OutputTask {
+    pub(crate) fn new(parent: NodeId, output: OutputSrc) -> Self {
+        OutputTask {
             parent,
             output,
             state: OutputTaskState::WaitingWriteErr,
+            seq: 0,
             _marker: core::marker::PhantomData,
+        }
+    }
+
+    /// Write `errbuf` (if any) to stderr, then the output to stdout, then
+    /// `on_done`. Returns as soon as a write has to wait for a writer.
+    pub(crate) fn start(mut me: Self, interp: &Interpreter, errbuf: Option<&[u8]>) -> Yield {
+        log!(
+            "OutputTask(0x{:x}) start errbuf={:?}",
+            &raw const me as usize,
+            errbuf.map(|b| b.len())
+        );
+        if let Some(err) = errbuf {
+            me.state = OutputTaskState::WaitingWriteErr;
+            match Self::write(me, interp, crate::shell::builtin::IoKind::Stderr, Some(err)) {
+                Ok(y) => return y,
+                Err(done) => me = done,
+            }
+        }
+        Self::write_output(me, interp)
+    }
+
+    fn write_output(mut me: Self, interp: &Interpreter) -> Yield {
+        me.state = OutputTaskState::WaitingWriteOut;
+        match Self::write(me, interp, crate::shell::builtin::IoKind::Stdout, None) {
+            Ok(y) => y,
+            Err(done) => Self::finish(done, interp),
+        }
+    }
+
+    /// Write `bytes` (or, for `None`, `me.output`) to `to`. `Ok`: the chunk
+    /// is queued and `me` parked until [`on_chunk`](Self::on_chunk); `Err`:
+    /// written without IO, carry on with `me`.
+    fn write(
+        mut me: Self,
+        interp: &Interpreter,
+        to: crate::shell::builtin::IoKind,
+        bytes: Option<&[u8]>,
+    ) -> Result<Yield, Self> {
+        use crate::shell::builtin::{Builtin, IoKind};
+        use crate::shell::io_writer::ChildPtr;
+        let parent = me.parent;
+        let needs_io = {
+            let b = Builtin::of(interp, parent);
+            match to {
+                IoKind::Stdout => b.stdout.needs_io(),
+                IoKind::Stderr => b.stderr.needs_io(),
+            }
+        };
+        let Some(safeguard) = needs_io else {
+            let _ = match bytes {
+                Some(b) => Builtin::write_no_io(interp, parent, to, b),
+                None => Builtin::write_no_io(interp, parent, to, me.output.slice()),
+            };
+            return Err(me);
+        };
+        // Park first: the writer may complete (or fail) the chunk from inside
+        // `enqueue`.
+        let seq = {
+            let mut q = P::output_queue(interp, parent);
+            q.next_seq += 1;
+            q.waiting += 1;
+            me.seq = q.next_seq;
+            let seq = me.seq;
+            q.parked.push(me);
+            seq
+        };
+        let child = ChildPtr::builtin_task(parent, seq);
+        Ok(match bytes {
+            Some(b) => Builtin::write_out(interp, parent, to, child, b, safeguard),
+            None => Builtin::write_out_with(interp, parent, to, child, safeguard, |buf| {
+                let q = P::output_queue(interp, parent);
+                if let Some(t) = q.parked.iter().rev().find(|t| t.seq == seq) {
+                    buf.extend_from_slice(t.output.slice());
+                }
+            }),
         })
     }
 
-    /// Drives the first state transition: write `errbuf` (if any), then the
-    /// output, then `on_done`.
-    pub(crate) fn start(mut me: Box<Self>, interp: &Interpreter, errbuf: Option<&[u8]>) -> Yield {
-        log!(
-            "OutputTask(0x{:x}) start errbuf={:?}",
-            &raw const *me as usize,
-            errbuf.map(|b| b.len())
-        );
-        me.state = OutputTaskState::WaitingWriteErr;
-        let parent = me.parent;
-        if let Some(err) = errbuf {
-            return match P::write_err(interp, parent, me, err) {
-                OutputWrite::Enqueued(y) => y,
-                OutputWrite::Done(me) => Self::next(me, interp),
-            };
-        }
-        me.state = OutputTaskState::WaitingWriteOut;
-        match P::write_out(interp, parent, me) {
-            OutputWrite::Enqueued(y) => y,
-            OutputWrite::Done(mut me) => {
-                P::on_write_out(interp, parent);
-                me.state = OutputTaskState::Done;
-                Self::deinit(me, interp)
-            }
-        }
-    }
-
-    pub(crate) fn next(mut me: Box<Self>, interp: &Interpreter) -> Yield {
-        let parent = me.parent;
-        match me.state {
-            OutputTaskState::WaitingWriteErr => {
-                P::on_write_err(interp, parent);
-                me.state = OutputTaskState::WaitingWriteOut;
-                match P::write_out(interp, parent, me) {
-                    OutputWrite::Enqueued(y) => y,
-                    OutputWrite::Done(mut me) => {
-                        P::on_write_out(interp, parent);
-                        me.state = OutputTaskState::Done;
-                        Self::deinit(me, interp)
-                    }
-                }
-            }
-            OutputTaskState::WaitingWriteOut => {
-                P::on_write_out(interp, parent);
-                me.state = OutputTaskState::Done;
-                Self::deinit(me, interp)
-            }
-            OutputTaskState::Done => panic!("Invalid state"),
-        }
-    }
-
-    pub(crate) fn on_io_writer_chunk(
-        me: Box<Self>,
+    /// The chunk parked under `seq` completed (or its writer failed).
+    pub(crate) fn on_chunk(
         interp: &Interpreter,
+        cmd: NodeId,
+        seq: u32,
         _written: usize,
         _err: Option<bun_sys::SystemError>,
     ) -> Yield {
-        log!(
-            "OutputTask(0x{:x}) onIOWriterChunk",
-            &raw const *me as usize
-        );
-        Self::next(me, interp)
+        let me = {
+            let mut q = P::output_queue(interp, cmd);
+            let pos = q.parked.iter().position(|t| t.seq == seq);
+            pos.map(|i| {
+                q.waiting -= 1;
+                q.parked.swap_remove(i)
+            })
+        };
+        let Some(me) = me else {
+            debug_assert!(false, "OutputTask chunk {seq} of {cmd} has no parked task");
+            return P::on_done(interp, cmd);
+        };
+        log!("OutputTask(0x{:x}) onIOWriterChunk", &raw const me as usize);
+        match me.state {
+            OutputTaskState::WaitingWriteErr => Self::write_output(me, interp),
+            OutputTaskState::WaitingWriteOut => Self::finish(me, interp),
+        }
     }
 
-    /// Fires `on_done` then frees.
-    fn deinit(me: Box<Self>, interp: &Interpreter) -> Yield {
-        debug_assert!(me.state == OutputTaskState::Done);
-        log!("OutputTask(0x{:x}) deinit", &raw const *me as usize);
+    fn finish(me: Self, interp: &Interpreter) -> Yield {
+        log!("OutputTask(0x{:x}) deinit", &raw const me as usize);
         let parent = me.parent;
         drop(me);
         P::on_done(interp, parent)

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -17,18 +17,23 @@
 //!
 //! A parent/child back-pointer tree would be borrow-checker hostile
 //! (overlapping `&mut` of parent and child), so all state nodes live in a
-//! flat `Vec<Node>` owned by the `Interpreter`. Nodes refer to each other
-//! (and to their parent) by `NodeId` — a `u32` index. Dispatch is a single
-//! hoisted `match` on the parent's tag (`Interpreter::child_done`), which
-//! keeps the per-tick hot path inlined (see PORTING.md §Dispatch hot-path).
+//! flat arena owned by the `Interpreter`. Nodes refer to each other (and to
+//! their parent) by `NodeId` — a `u32` index. Dispatch is a single hoisted
+//! `match` on the parent's tag (`Interpreter::child_done`), which keeps the
+//! per-tick hot path inlined (see PORTING.md §Dispatch hot-path).
 //!
-//! State methods take `(&mut Interpreter, this: NodeId)` and look their
-//! own data up via `interp.node_mut(this)` / `interp.nodes[this]`.
+//! Each slot is a `RefCell<Node>` in its own heap box, so a borrowed node
+//! stays put while the arena grows and overlapping borrows of one node are a
+//! checked panic rather than aliasing. State methods take
+//! `(&Interpreter, this: NodeId)` and look their own data up via
+//! `interp.as_<kind>(this)` / `interp.as_<kind>_mut(this)`; keep those borrows
+//! short and never hold one across a call that re-enters the same node.
 
 use bun_collections::VecExt;
 use bun_jsc::JsCell;
-use core::cell::Cell;
+use core::cell::{Cell, Ref, RefCell, RefMut};
 use core::fmt;
+use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use bun_sys::{self, Fd};
@@ -51,7 +56,6 @@ use crate::shell::yield_::Yield;
 use crate::shell::{ShellErr, ast};
 
 bun_core::declare_scope!(SHELL, visible);
-bun_core::declare_scope!(CowFd, hidden);
 
 /// `log!("...")` — scoped debug logger for the shell interpreter. Expands to
 /// nothing in release; the `SHELL` static is referenced by absolute path so
@@ -98,9 +102,11 @@ impl fmt::Display for NodeId {
     }
 }
 
+const NODE_CHUNK: usize = 8;
+type NodeChunk = [RefCell<Node>; NODE_CHUNK];
+
 /// One slot in the interpreter's state arena. All state structs
-/// live as enum variants in a single `Vec<Node>` so the only outstanding
-/// borrow at any time is `&mut Interpreter`.
+/// live as enum variants so the arena is a single homogeneous vector.
 pub enum Node {
     /// Freed slot, available for reuse by `alloc_node`.
     Free,
@@ -135,8 +141,7 @@ impl Node {
         }
     }
 
-    /// Every state struct embeds a `Base` header at a known field; this is the
-    /// hoisted accessor.
+    /// Every state struct embeds a `Base` header; `None` for a freed slot.
     pub(crate) fn base(&self) -> Option<&Base> {
         match self {
             Node::Free => None,
@@ -173,34 +178,33 @@ impl Node {
 }
 
 /// Generate `Interpreter::as_<kind>{,_mut}` typed accessors. These panic on
-/// tag mismatch.
+/// tag mismatch, and (being `RefCell` borrows) on an overlapping borrow of
+/// the same node.
 macro_rules! node_accessors {
     ($($variant:ident => $ty:ty, $get:ident, $get_mut:ident);* $(;)?) => {
         impl Interpreter {
             $(
                 #[inline]
                 #[track_caller]
-                pub fn $get(&self, id: NodeId) -> &$ty {
-                    match &self.nodes.get()[id.idx()] {
+                pub fn $get(&self, id: NodeId) -> Ref<'_, $ty> {
+                    Ref::map(self.node(id), |n| match n {
                         Node::$variant(v) => v,
                         other => panic!(
                             concat!("expected Node::", stringify!($variant), " at {}, got {:?}"),
                             id, other.kind()
                         ),
-                    }
+                    })
                 }
                 #[inline]
                 #[track_caller]
-                #[allow(clippy::mut_from_ref)]
-                pub fn $get_mut(&self, id: NodeId) -> &mut $ty {
-                    // SAFETY: R-2 single-JS-thread invariant — see `nodes_mut`.
-                    match unsafe { &mut self.nodes.get_mut()[id.idx()] } {
+                pub fn $get_mut(&self, id: NodeId) -> RefMut<'_, $ty> {
+                    RefMut::map(self.node_mut(id), |n| match n {
                         Node::$variant(v) => v,
                         other => panic!(
                             concat!("expected Node::", stringify!($variant), " at {}, got {:?}"),
                             id, other.kind()
                         ),
-                    }
+                    })
                 }
             )*
         }
@@ -267,9 +271,14 @@ pub enum OutputNeedsIOSafeGuard {
 // interpreter entirely — see `DbgDepthGuard::MAX_DEPTH`). With every field
 // behind `UnsafeCell`, an overlapping `&Interpreter` is sound.
 pub struct Interpreter {
-    /// Flat arena of state-machine nodes. Indices are `NodeId`s; freed slots
-    /// are recycled via `free_list`.
-    pub(crate) nodes: JsCell<Vec<Node>>,
+    /// State-machine node arena. Indices are `NodeId`s; freed slots are
+    /// recycled via `free_list`. Slots live in fixed-size boxed chunks that
+    /// are only ever appended, so a `Ref`/`RefMut` into one stays valid while
+    /// the arena grows, and filling a slot goes through its own `RefCell`.
+    #[allow(clippy::vec_box, reason = "chunk address stability across growth")]
+    nodes: JsCell<Vec<Box<NodeChunk>>>,
+    /// Slots handed out so far (high-water mark).
+    node_len: Cell<u32>,
     free_list: JsCell<Vec<u32>>,
 
     pub(crate) event_loop: EventLoopHandle,
@@ -288,7 +297,7 @@ pub struct Interpreter {
     /// the mini-event-loop path always passes an empty vec.
     pub(crate) jsobjs: Vec<crate::jsc::JSValue>,
 
-    pub(crate) root_shell: JsCell<ShellExecEnv>,
+    pub(crate) root_shell: EnvRc,
     pub(crate) root_io: JsCell<IO>,
 
     pub(crate) has_pending_activity: AtomicU32,
@@ -308,12 +317,13 @@ pub struct Interpreter {
     pub(crate) estimated_size_for_gc: Cell<usize>,
 
     /// Lazily-populated UTF-8 cache for the JS-side argv (`$@`/`$N` expansion
-    /// when running under a Worker). See [`Interpreter::get_vm_args_utf8`].
+    /// when running under a Worker). See [`Interpreter::append_var_argv`].
     pub(crate) vm_args_utf8: JsCell<Vec<bun_core::Utf8Bytes<'static>>>,
 
-    /// `bun run` CLI context for `$N` expansion on the mini event loop.
-    /// Null when constructed from JS (no `ContextData` is reachable).
-    pub(crate) command_ctx: *mut bun_options_types::context::ContextData,
+    /// `bun run` CLI context for `$N` expansion on the mini event loop; the
+    /// caller of `init_and_run_*` owns it for longer than the interpreter
+    /// lives. `None` when constructed from JS.
+    command_ctx: Option<bun_ptr::BackRef<bun_options_types::context::ContextData>>,
 }
 
 #[repr(transparent)]
@@ -345,107 +355,10 @@ pub enum CleanupState {
 // Construction / standalone-exec entrypoints
 // ────────────────────────────────────────────────────────────────────────────
 
-impl ShellArgs {
-    /// Heap-allocated (returned as `Box`) because the interpreter stores
-    /// `Box<ShellArgs>` and state nodes hold `*const ast::*` into the arena;
-    /// the box must not move once `parse()` has filled `script_ast`.
-    pub(crate) fn init() -> Box<ShellArgs> {
-        Box::new(ShellArgs {
-            __arena: bun_alloc::Arena::new(),
-            // Overwritten by `parse()` before `run()`. An empty stmt list is
-            // a safe placeholder.
-            script_ast: ast::Script { stmts: &[] },
-        })
-    }
-
-    #[inline]
-    pub(crate) fn arena(&self) -> &bun_alloc::Arena {
-        &self.__arena
-    }
-
-    /// Store the parsed AST root alongside its owning arena. This is the single
-    /// self-referential lifetime-erasure point: `script` borrows `self.__arena`
-    /// for `'a`, but `ShellArgs` is heap-allocated and the arena is never moved
-    /// or dropped while the interpreter (and thus every state node holding
-    /// `*const ast::*`) is live. Widening `'a` → `'static` here is therefore
-    /// sound — every later dereference happens through raw pointers under
-    /// `unsafe`, which is where the real invariant is checked.
-    ///
-    /// `Interpreter::parse` returns the lifetime-tied `Script<'a>` so callers
-    /// that *don't* store (e.g. `TestingAPIs::shell_parse`) get the correct
-    /// borrow scope; only callers that move the arena into long-lived storage
-    /// route through this helper.
-    #[inline]
-    pub(crate) fn set_script_ast(&mut self, script: bun_shell_parser::ast::Script<'_>) {
-        // `ast::Script` is `bun_shell_parser::ast::Script<'static>` — identical
-        // type, only the lifetime parameter differs. `self.__arena` owns every
-        // node `script.stmts` references and is dropped only when this
-        // `ShellArgs` is, so the widened references remain valid for the
-        // interpreter's lifetime. Re-construct field-by-field via a slice
-        // pointer cast (`Stmt<'a>` and `Stmt<'static>` are layout-identical).
-        let stmts = script.stmts;
-        // SAFETY: lifetime-only widen; arena outlives `self` (see above).
-        let stmts: &'static [ast::Stmt] =
-            unsafe { core::slice::from_raw_parts(stmts.as_ptr().cast::<ast::Stmt>(), stmts.len()) };
-        self.script_ast = ast::Script { stmts };
-    }
-
-    /// Reports the arena's `allocated_bytes()` (a superset — tokens + strpool
-    /// + AST nodes). This is for GC `estimatedSize` reporting only, where
-    /// over-approximation is preferable to a tree walk on a lifetime-erased
-    /// AST mirror.
-    pub(crate) fn memory_cost(&self) -> usize {
-        core::mem::size_of::<ShellArgs>() + self.__arena.allocated_bytes()
-    }
-}
-
 /// Only used by the construction path (`Interpreter::init`).
 pub(crate) type ShellResult<T> = Result<T, ShellErr>;
 
 impl Interpreter {
-    /// Lex `src` (ASCII or Unicode), build a `Parser`, and return the root
-    /// `ast::Script`. Tokens and AST nodes are bump-allocated into `arena`.
-    ///
-    /// On lex error, `out_lex_err` is populated and `ParseError::Lex` returned
-    /// so the caller can `combineErrors()` for diagnostics; on parse error
-    /// `out_parse_err` is populated likewise.
-    pub(crate) fn parse<'a>(
-        arena: &'a bun_alloc::Arena,
-        src: &'a [u8],
-        jsobjs: &'a mut [crate::jsc::JSValue],
-        jsstrings_to_escape: &'a [bun_core::String],
-        out_parser: &mut Option<bun_shell_parser::Parser<'a>>,
-        out_lex_result: &mut Option<bun_shell_parser::LexResult<'a>>,
-    ) -> crate::Result<bun_shell_parser::ast::Script<'a>> {
-        use crate::shell::shell_body::{LexerAscii, LexerUnicode, ParseError, Parser};
-        let jsobjs_len = jsobjs.len() as u32;
-        let lex_result = if bun_core::is_all_ascii(src) {
-            let mut lexer = LexerAscii::new(arena, src, jsstrings_to_escape, jsobjs_len);
-            lexer.lex().map_err(crate::Error::from)?;
-            lexer.get_result()
-        } else {
-            let mut lexer = LexerUnicode::new(arena, src, jsstrings_to_escape, jsobjs_len);
-            lexer.lex().map_err(crate::Error::from)?;
-            lexer.get_result()
-        };
-        if !lex_result.errors.is_empty() {
-            *out_lex_result = Some(lex_result);
-            return Err(ParseError::Lex.into());
-        }
-        let jsobjs_raw: &'a mut [bun_shell_parser::JSValueRaw] = {
-            let len = jsobjs.len();
-            let ptr = jsobjs.as_mut_ptr().cast::<bun_shell_parser::JSValueRaw>();
-            // SAFETY: `bun_jsc::JSValue` and `bun_shell_parser::JSValueRaw` are both
-            // `#[repr(transparent)]` over `usize` — see the `JSValueRaw` doc in
-            // `shell_parser/parse.rs`. Reinterpret in place via a typed pointer cast.
-            // Compute `len` before deriving the raw mut pointer so the shared
-            // reborrow inside `len()` does not stack on top of the Unique tag.
-            unsafe { core::slice::from_raw_parts_mut(ptr, len) }
-        };
-        *out_parser = Some(Parser::new(arena, lex_result, jsobjs_raw)?);
-        Ok(out_parser.as_mut().unwrap().parse()?)
-    }
-
     /// Builds the root `ShellExecEnv` (export env from the event loop's
     /// `DotEnv::Loader`, cwd from `getcwd()`, cwd_fd from `open(O_DIRECTORY)`),
     /// dups stdin into an `IOReader`, and heap-allocates the interpreter.
@@ -454,17 +367,12 @@ impl Interpreter {
     ///
     /// On success the returned box owns `shargs`; on error `shargs` is
     /// dropped.
-    ///
-    /// Note: `allocator` parameter dropped (always global mimalloc).
-    /// `ctx` is stored for `bun run` argv access from builtins; held as a raw
-    /// pointer because the interpreter outlives any single `&mut ContextData`
-    /// borrow.
     // `ShellErr` is the shared shell-wide error type defined in `shell_body.rs`;
     // boxing it here would change `pub fn` signatures across every
     // `?`-propagating shell caller.
     #[allow(clippy::result_large_err)]
     pub(crate) fn init(
-        ctx: *mut bun_options_types::context::ContextData,
+        ctx: Option<&bun_options_types::context::ContextData>,
         event_loop: EventLoopHandle,
         shargs: Box<ShellArgs>,
         jsobjs: Vec<crate::jsc::JSValue>,
@@ -473,22 +381,19 @@ impl Interpreter {
     ) -> ShellResult<Box<Interpreter>> {
         // ── export_env ─────────────────────────────────────────────────────
         // On the `.js` event loop, take `export_env_` (or empty); on `.mini`,
-        // populate from `event_loop.env()` (the loop's `DotEnv::Loader`).
+        // populate from the loop's `DotEnv::Loader`.
         let export_env = if matches!(event_loop, EventLoopHandle::Js { .. }) {
             export_env_.unwrap_or_else(EnvMap::init)
         } else {
-            // SAFETY: `event_loop.env()` returns the `MiniEventLoop`'s
-            // `DotEnv::Loader`, which is set by `init_global()` and outlives
-            // the interpreter (thread-lifetime singleton).
-            let env_loader = unsafe { &mut *event_loop.env() };
-            let mut export_env = EnvMap::init_with_capacity(env_loader.map.map.count());
-            let mut iter = env_loader.iterator();
-            while let Some(entry) = iter.next() {
-                let key = crate::shell::EnvStr::init_slice(&entry.key_ptr[..]);
-                let value = crate::shell::EnvStr::init_slice(&entry.value_ptr.value[..]);
-                export_env.insert(key, value);
-            }
-            export_env
+            event_loop.with_env(|env_loader| {
+                let mut export_env = EnvMap::init_with_capacity(env_loader.map.map.count());
+                for (key, value) in env_loader.map.map.iter() {
+                    let key = crate::shell::EnvStr::init_slice(&key[..]);
+                    let value = crate::shell::EnvStr::init_slice(&value.value[..]);
+                    export_env.insert(key, value);
+                }
+                export_env
+            })
         };
 
         // ── cwd / cwd_fd ───────────────────────────────────────────────────
@@ -514,6 +419,18 @@ impl Interpreter {
         cwd_arr.extend_from_slice(&pathbuf[..cwd_len + 1]);
         debug_assert_eq!(*cwd_arr.last().unwrap(), 0);
 
+        let (buffered_stdout, buffered_stderr) = CapturedBuf::new_pair();
+        let root_shell = Rc::new(RefCell::new(ShellExecEnv {
+            buffered_stdout,
+            buffered_stderr,
+            shell_env: EnvMap::init(),
+            cmd_local_env: EnvMap::init(),
+            export_env,
+            __prev_cwd: cwd_arr.clone(),
+            __cwd: cwd_arr,
+            cwd_fd,
+        }));
+
         // ── stdin ──────────────────────────────────────────────────────────
         log!("Duping stdin");
         let stdin_fd_res = if bun_core::output::stdio::is_stdin_null() {
@@ -532,12 +449,10 @@ impl Interpreter {
         } else {
             shell_dup(Fd::stdin())
         };
+        // On error `root_shell` drops here, closing `cwd_fd`.
         let stdin_fd = match stdin_fd_res {
             Ok(fd) => fd,
-            Err(e) => {
-                closefd(cwd_fd);
-                return Err(ShellErr::new_sys(&e));
-            }
+            Err(e) => return Err(ShellErr::new_sys(&e)),
         };
 
         let stdin_reader = IOReader::init(stdin_fd, event_loop);
@@ -545,20 +460,12 @@ impl Interpreter {
         // ── assemble ───────────────────────────────────────────────────────
         let interpreter = Box::new(Interpreter {
             nodes: JsCell::new(Vec::new()),
+            node_len: Cell::new(0),
             free_list: JsCell::new(Vec::new()),
             event_loop,
             args: JsCell::new(shargs),
             jsobjs,
-            root_shell: JsCell::new(ShellExecEnv {
-                _buffered_stdout: Bufio::default(),
-                _buffered_stderr: Bufio::default(),
-                shell_env: EnvMap::init(),
-                cmd_local_env: EnvMap::init(),
-                export_env,
-                __prev_cwd: cwd_arr.clone(),
-                __cwd: cwd_arr,
-                cwd_fd,
-            }),
+            root_shell,
             root_io: JsCell::new(IO {
                 stdin: crate::shell::io::InKind::Fd(stdin_reader),
                 // By default stdout/stderr should be IOWriters on dup'd
@@ -581,26 +488,20 @@ impl Interpreter {
             cleanup_state: Cell::new(CleanupState::NeedsFullCleanup),
             estimated_size_for_gc: Cell::new(0),
             vm_args_utf8: JsCell::new(Vec::new()),
-            command_ctx: ctx,
+            command_ctx: ctx.map(bun_ptr::BackRef::new),
         });
         // Wire the interpreter backref into root stdin so async poll
         // callbacks can drive `Yield::run`.
-        let interp_ptr: *mut Interpreter = Interpreter::as_ctx_ptr(&interpreter);
         if let crate::shell::io::InKind::Fd(ref r) = interpreter.root_io.get().stdin {
-            // SAFETY: `interp_ptr` is the live `Interpreter` just constructed.
-            r.set_interp(interp_ptr);
+            r.set_interp(&interpreter);
         }
 
         // ── optional cwd override ───────────────────────────────────────────
         if let Some(c) = cwd_ {
-            // On failure, deref root_io + deinit root_shell + free.
-            if let Err(e) = interpreter
-                .root_shell
-                .with_mut(|rs| rs.change_cwd_impl(c, true))
-            {
+            let res = interpreter.root_shell.borrow_mut().change_cwd_impl(c, true);
+            if let Err(e) = res {
                 // `deinit_from_exec` performs the full teardown (drops
-                // `root_io` Arcs, frees env maps, closes `cwd_fd`, consumes
-                // the box).
+                // `root_io`, frees env maps, closes `cwd_fd`, consumes the box).
                 interpreter.deinit_from_exec();
                 return Err(ShellErr::new_sys(&e));
             }
@@ -611,15 +512,14 @@ impl Interpreter {
 
     /// Full teardown for the standalone (`MiniEventLoop`) path. Drops root IO
     /// refcounts, frees the root shell env, and consumes the box.
-    fn deinit_from_exec(self) {
+    #[allow(clippy::boxed_local, reason = "consumes and frees the interpreter")]
+    pub(crate) fn deinit_from_exec(self: Box<Self>) {
         log!("deinit interpreter");
         self.this_jsvalue.set(crate::jsc::JSValue::ZERO);
-        // `root_io` holds `Arc<IOReader>`/`Arc<IOWriter>`; replacing with
+        // `root_io` holds `Rc<IOReader>`/`Rc<IOWriter>`; replacing with
         // default drops the refs.
         self.root_io.set(IO::default());
-        // Free buffered IO, env
-        // maps, cwd fd; do NOT free the struct itself (it's embedded).
-        self.root_shell.with_mut(|rs| rs.deinit_embedded(true));
+        self.root_shell.borrow_mut().clear(true);
     }
 
     /// Standalone-shell entrypoint for `bun <file>.sh`: parse `src` (already
@@ -629,7 +529,7 @@ impl Interpreter {
     /// ("Failed to run <basename>" vs "Failed to run script <name>") and in
     /// not bumping `standalone_shell` analytics.
     pub(crate) fn init_and_run_from_file(
-        ctx: &mut bun_options_types::context::ContextData,
+        ctx: &bun_options_types::context::ContextData,
         mini: &'static mut bun_event_loop::MiniEventLoop::MiniEventLoop,
         path: &[u8],
         src: &[u8],
@@ -646,7 +546,7 @@ impl Interpreter {
     /// directly; the `Result` only carries lexer/parser errors that escaped
     /// without a diagnostic.
     pub(crate) fn init_and_run_from_source(
-        ctx: &mut bun_options_types::context::ContextData,
+        ctx: &bun_options_types::context::ContextData,
         mini: &'static mut bun_event_loop::MiniEventLoop::MiniEventLoop,
         path_for_errors: &[u8],
         src: &[u8],
@@ -660,72 +560,41 @@ impl Interpreter {
     /// the parse-error diagnostic — the only two behavioural deltas between
     /// the two entrypoints.
     fn init_and_run_impl(
-        ctx: &mut bun_options_types::context::ContextData,
+        ctx: &bun_options_types::context::ContextData,
         mini: &'static mut bun_event_loop::MiniEventLoop::MiniEventLoop,
         label: &[u8],
         src: &[u8],
         cwd: Option<&[u8]>,
         from_source: bool,
     ) -> crate::Result<ExitCode> {
+        use bun_shell_parser::ParseFailure;
         if from_source {
             bun_analytics::features::standalone_shell.fetch_add(1, Ordering::Relaxed);
         }
         // We are the script's shell (`bun run <script>`, `bun exec`, `bun x.sh`).
         bun_spawn::ctrl_c::install();
 
-        let mut shargs = ShellArgs::init();
-
         // ── parse ──────────────────────────────────────────────────────────
-        // `out_parser`/`out_lex_result` borrow `shargs.__arena`, so they're
-        // scoped to a block that ends before `shargs.set_script_ast` below.
-        let arena_ptr: *const bun_alloc::Arena = shargs.arena();
-        let script = {
-            // SAFETY: `shargs` lives on this stack frame for the whole block;
-            // arena is not moved/dropped while `out_parser`/`out_lex_result`
-            // borrow it.
-            let arena = unsafe { &*arena_ptr };
-            let mut out_parser: Option<bun_shell_parser::Parser<'_>> = None;
-            let mut out_lex_result: Option<bun_shell_parser::LexResult<'_>> = None;
-            match Self::parse(
-                arena,
-                src,
-                &mut [],
-                &[],
-                &mut out_parser,
-                &mut out_lex_result,
-            ) {
-                Ok(s) => s,
-                Err(err) => {
-                    let what = if from_source { "script " } else { "" };
-                    let errstr: &[u8] = if let Some(lex) = out_lex_result.as_ref() {
-                        lex.combine_errors(arena)
-                    } else if let Some(p) = out_parser.as_mut() {
-                        p.combine_errors()
-                    } else {
-                        return Err(err);
-                    };
-                    bun_core::pretty_errorln!(
-                        "<r><red>error<r>: Failed to run {}<b>{}<r> due to error <b>{}<r>",
-                        what,
-                        bstr::BStr::new(label),
-                        bstr::BStr::new(errstr),
-                    );
-                    bun_core::Global::exit(1);
-                }
-            }
-        };
-        shargs.set_script_ast(script);
+        let mut shargs = ShellArgs::init();
+        if let Err(err) = shargs.parse(src, &[], 0) {
+            let errstr = match err {
+                ParseFailure::Diagnostic(msg) => msg,
+                ParseFailure::Lexer(e) => return Err(e.into()),
+                ParseFailure::Other(e) => return Err(e.into()),
+            };
+            let what = if from_source { "script " } else { "" };
+            bun_core::pretty_errorln!(
+                "<r><red>error<r>: Failed to run {}<b>{}<r> due to error <b>{}<r>",
+                what,
+                bstr::BStr::new(label),
+                bstr::BStr::new(&errstr),
+            );
+            bun_core::Global::exit(1);
+        }
 
         // ── init ───────────────────────────────────────────────────────────
         let evtloop = EventLoopHandle::init_mini(std::ptr::from_mut(mini));
-        let interp = match Self::init(
-            std::ptr::from_mut(ctx),
-            evtloop,
-            shargs,
-            Vec::new(),
-            None,
-            cwd,
-        ) {
+        let interp = match Self::init(Some(ctx), evtloop, shargs, Vec::new(), None, cwd) {
             Ok(i) => i,
             Err(e) => e.throw_mini(),
         };
@@ -744,15 +613,7 @@ impl Interpreter {
         }
 
         // ── tick until done ────────────────────────────────────────────────
-        // The closure captures a raw pointer so borrowck doesn't see an
-        // overlap with `tick`'s `&mut self` on `mini`.
-        let interp_ptr: *const Interpreter = &raw const *interp;
-        mini.tick(core::ptr::null_mut(), |_ctx| {
-            // SAFETY: `interp` lives in this stack frame for the whole tick
-            // loop; `flags` is `Cell<InterpreterFlags>` (interior-mutable), so
-            // the read is sound even while tasks `tick` drains mutate it.
-            unsafe { (*interp_ptr).flags.get().done() }
-        });
+        mini.tick(core::ptr::null_mut(), |_ctx| interp.flags.get().done());
 
         let code = interp.exit_code.get().expect("exit_code set by finish()");
         interp.deinit_from_exec();
@@ -789,7 +650,7 @@ macro_rules! shell_state_dispatch {
             if parent == NodeId::INTERPRETER {
                 return self.on_root_child_done(child, exit_code);
             }
-            match self.nodes.get()[parent.idx()].kind() {
+            match self.kind(parent) {
                 $( StateKind::$v => $h::child_done(self, parent, child, exit_code), )+
                 StateKind::Free => unreachable!("child_done on freed {}", parent),
             }
@@ -798,7 +659,7 @@ macro_rules! shell_state_dispatch {
         /// Advance node `id` by one step. The trampoline (`Yield::run`) calls
         /// this; replaces the per-variant `&mut State` dispatch in Yield.
         pub fn next_node(&self, id: NodeId) -> Yield {
-            match self.nodes.get()[id.idx()].kind() {
+            match self.kind(id) {
                 $( StateKind::$v => $h::next(self, id), )+
                 StateKind::Free => unreachable!("next on freed {}", id),
             }
@@ -807,7 +668,7 @@ macro_rules! shell_state_dispatch {
         /// Start node `id`. Most states return `Yield::<Kind>(id)` immediately;
         /// the trampoline then calls `next_node`.
         pub fn start_node(&self, id: NodeId) -> Yield {
-            match self.nodes.get()[id.idx()].kind() {
+            match self.kind(id) {
                 $( StateKind::$v => $h::start(self, id), )+
                 StateKind::Free => unreachable!("start on freed {}", id),
             }
@@ -822,15 +683,6 @@ macro_rules! shell_state_dispatch {
 impl Interpreter {
     // ─── R-2 interior-mutability helpers ─────────────────────────────────────
 
-    /// `&self` → `*mut Self` for ctx slots. Kept inherent (NOT via the
-    /// `bun_ptr::AsCtxPtr` blanket trait) so `Box<Interpreter>` callers
-    /// auto-deref to `&Interpreter` and get `*mut Interpreter`, not
-    /// `*mut Box<Interpreter>`.
-    #[inline]
-    pub(crate) fn as_ctx_ptr(&self) -> *mut Self {
-        std::ptr::from_ref::<Self>(self).cast_mut()
-    }
-
     /// Read-modify-write the packed `Cell<InterpreterFlags>` through `&self`.
     #[inline]
     fn update_flags(&self, f: impl FnOnce(&mut InterpreterFlags)) {
@@ -839,36 +691,26 @@ impl Interpreter {
         self.flags.set(v);
     }
 
-    /// Mutable projection of the node arena from `&self`.
-    ///
-    /// # Safety
-    /// R-2 single-JS-thread invariant: the state machine never holds two
-    /// `&mut` into `nodes` simultaneously (borrowck previously enforced this
-    /// via `&mut Interpreter`; that discipline is preserved at every call
-    /// site). Do **not** hold the returned borrow across any call that may
-    /// reach `finish()`/`throw()` (the only paths that re-enter JS).
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    unsafe fn nodes_mut(&self) -> &mut Vec<Node> {
-        // SAFETY: forwarded to caller — see fn-level contract.
-        unsafe { self.nodes.get_mut() }
-    }
-
     // ── arena management ───────────────────────────────────────────────────
 
     /// Allocate a fresh slot in the node arena and return its id. Reuses
     /// freed slots when available.
     pub(crate) fn alloc_node(&self, node: Node) -> NodeId {
-        if let Some(slot) = self.free_list.with_mut(|f| f.pop()) {
-            // SAFETY: no other borrow of `nodes` is live across this store.
-            unsafe { self.nodes_mut()[slot as usize] = node };
-            return NodeId(slot);
-        }
-        self.nodes.with_mut(|n| {
-            let id = NodeId(n.len() as u32);
-            n.push(node);
-            id
-        })
+        let id = match self.free_list.with_mut(|f| f.pop()) {
+            Some(slot) => NodeId(slot),
+            None => {
+                let n = self.node_len.get();
+                if n as usize == self.nodes.get().len() * NODE_CHUNK {
+                    self.nodes.with_mut(|c| {
+                        c.push(Box::new([const { RefCell::new(Node::Free) }; NODE_CHUNK]))
+                    });
+                }
+                self.node_len.set(n + 1);
+                NodeId(n)
+            }
+        };
+        *self.node_mut(id) = node;
+        id
     }
 
     /// Free a slot. The node's own
@@ -882,10 +724,11 @@ impl Interpreter {
         if id == NodeId::NONE || id == NodeId::INTERPRETER {
             return;
         }
-        self.nodes.with_mut(|n| {
-            debug_assert!(!matches!(n[id.idx()], Node::Free), "double-free of {}", id);
-            n[id.idx()] = Node::Free;
-        });
+        let old = core::mem::replace(&mut *self.node_mut(id), Node::Free);
+        debug_assert!(!matches!(old, Node::Free), "double-free of {}", id);
+        // Dropped outside the slot borrow: a node's fields (`IO`, env `Rc`s)
+        // never re-enter the arena on drop today, but keep it structural.
+        drop(old);
         self.free_list.with_mut(|f| f.push(id.0));
     }
 
@@ -897,7 +740,7 @@ impl Interpreter {
     /// member only. Anywhere else it ends us the way it ended the child, so
     /// `a; b` and `a || b` stop at `a`.
     fn propagate_interrupt(&self, parent: NodeId, child: NodeId) {
-        if !self.node(child).base().is_some_and(|b| b.interrupted) {
+        if !self.interrupted(child) {
             if bun_spawn::ctrl_c::Child::alive() == 0 {
                 // A Ctrl+C the job handled is used up with the job (bash resets it per wait).
                 bun_spawn::ctrl_c::take_received();
@@ -907,13 +750,14 @@ impl Interpreter {
         if parent == NodeId::INTERPRETER {
             bun_spawn::ctrl_c::exit_like_child();
         }
-        if let Node::Pipeline(p) = self.node(parent) {
+        if self.kind(parent) == StateKind::Pipeline {
+            let mut p = self.as_pipeline_mut(parent);
             let rightmost = p.cmds.as_deref().is_none_or(|c| {
                 c.len() < 2
                     || matches!(c.last(), Some(crate::shell::states::pipeline::CmdOrResult::Cmd(id)) if *id == child)
             });
             if rightmost {
-                self.as_pipeline_mut(parent).base.interrupted = true;
+                p.base.interrupted = true;
             }
             return;
         }
@@ -934,17 +778,17 @@ impl Interpreter {
     /// Some ancestor is a member of a multi-command pipeline.
     fn in_pipeline(&self, mut id: NodeId) -> bool {
         while id != NodeId::INTERPRETER {
-            let Some(base) = self.node(id).base() else {
+            let Some(parent) = self.node(id).base().map(|b| b.parent) else {
                 return false;
             };
-            if base.parent != NodeId::INTERPRETER {
-                if let Node::Pipeline(p) = self.node(base.parent) {
+            if parent != NodeId::INTERPRETER {
+                if let Node::Pipeline(p) = &*self.node(parent) {
                     if p.cmds.as_deref().is_some_and(|c| c.len() >= 2) {
                         return true;
                     }
                 }
             }
-            id = base.parent;
+            id = parent;
         }
         false
     }
@@ -965,15 +809,33 @@ impl Interpreter {
     }
 
     #[inline]
-    pub fn node(&self, id: NodeId) -> &Node {
-        &self.nodes.get()[id.idx()]
+    fn slot(&self, id: NodeId) -> &RefCell<Node> {
+        &self.nodes.get()[id.idx() / NODE_CHUNK][id.idx() % NODE_CHUNK]
+    }
+
+    #[cfg(not(windows))]
+    #[inline]
+    pub(crate) fn node_count(&self) -> usize {
+        self.node_len.get() as usize
     }
 
     #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub(crate) fn node_mut(&self, id: NodeId) -> &mut Node {
-        // SAFETY: see `nodes_mut` — single-JS-thread, no overlapping borrow.
-        unsafe { &mut self.nodes_mut()[id.idx()] }
+    #[track_caller]
+    pub fn node(&self, id: NodeId) -> Ref<'_, Node> {
+        self.slot(id).borrow()
+    }
+
+    #[inline]
+    #[track_caller]
+    pub(crate) fn node_mut(&self, id: NodeId) -> RefMut<'_, Node> {
+        self.slot(id).borrow_mut()
+    }
+
+    /// The state tag of node `id`.
+    #[inline]
+    #[track_caller]
+    pub fn kind(&self, id: NodeId) -> StateKind {
+        self.node(id).kind()
     }
 
     // ── hoisted dispatch (PORTING.md §Dispatch hot-path) ───────────────────
@@ -993,32 +855,32 @@ impl Interpreter {
     }
 
     /// Init + start a child state node for an `ast::Expr`. For `.subshell`,
-    /// dupes the parent shell env first; all other variants borrow `shell`.
+    /// dupes the parent shell env first; all other variants share `shell`.
     ///
     /// Note: `Async` must NOT call this — `Async` restricts its child to
     /// pipeline/cmd/if/condexpr and inits without starting (see `Async::next`).
     pub(crate) fn spawn_expr(
         &self,
-        shell: *mut ShellExecEnv,
+        shell: &EnvRc,
         expr: &ast::Expr,
         parent: NodeId,
         io: IO,
     ) -> (Option<NodeId>, Yield) {
         let child = match expr {
-            ast::Expr::Cmd(c) => Cmd::init(self, shell, *c, parent, io),
-            ast::Expr::Binary(b) => Binary::init(self, shell, *b, parent, io),
-            ast::Expr::Pipeline(p) => Pipeline::init(self, shell, *p, parent, io),
-            ast::Expr::Assign(a) => Assigns::init(self, shell, *a, parent, AssignCtx::Shell),
-            ast::Expr::If(i) => If::init(self, shell, *i, parent, io),
-            ast::Expr::CondExpr(c) => CondExpr::init(self, shell, *c, parent, io),
+            ast::Expr::Cmd(c) => Cmd::init(self, Rc::clone(shell), c, parent, io),
+            ast::Expr::Binary(b) => Binary::init(self, Rc::clone(shell), b, parent, io),
+            ast::Expr::Pipeline(p) => Pipeline::init(self, Rc::clone(shell), p, parent, io),
+            ast::Expr::Assign(a) => {
+                Assigns::init(self, Rc::clone(shell), a, parent, AssignCtx::Shell)
+            }
+            ast::Expr::If(i) => If::init(self, Rc::clone(shell), i, parent, io),
+            ast::Expr::CondExpr(c) => CondExpr::init(self, Rc::clone(shell), c, parent, io),
             ast::Expr::Subshell(s) => {
                 // Stmt/Binary callers dupe
                 // the env here so `Subshell::start`/`next` can use `base.shell`
                 // as-is. (Pipeline dupes itself and calls `Subshell::init`
                 // directly, so it does NOT go through this path.)
-                // SAFETY: `shell` is the live parent `ShellExecEnv` borrowed for the
-                // dupe; `self` is the live interpreter.
-                match Subshell::init_dupe_shell_state(self, shell, *s, parent, io) {
+                match Subshell::init_dupe_shell_state(self, shell, s, parent, io) {
                     Ok(id) => id,
                     Err(e) => {
                         self.throw(ShellErr::new_sys(&e));
@@ -1030,7 +892,7 @@ impl Interpreter {
                     }
                 }
             }
-            ast::Expr::Async(e) => Async::init(self, shell, *e, parent, io),
+            ast::Expr::Async(e) => Async::init(self, Rc::clone(shell), e, parent, io),
         };
         let y = self.start_node(child);
         (Some(child), y)
@@ -1045,7 +907,7 @@ impl Interpreter {
             return;
         }
         // NOTE: keep in sync with shell_state_dispatch! table (irregular Async/Free arms keep this hand-rolled for v1).
-        match self.nodes.get()[id.idx()].kind() {
+        match self.kind(id) {
             StateKind::Script => Script::deinit(self, id),
             StateKind::Stmt => Stmt::deinit(self, id),
             StateKind::Binary => Binary::deinit(self, id),
@@ -1055,7 +917,7 @@ impl Interpreter {
             StateKind::Expansion => Expansion::deinit(self, id),
             StateKind::IfClause => If::deinit(self, id),
             StateKind::Condexpr => CondExpr::deinit(self, id),
-            StateKind::Async => return, // Async deinit is purposefully empty; freed later by async_cmd_done → actually_deinit.
+            StateKind::Async => return, // Async deinit is purposefully empty; freed later by async_cmd_done.
             StateKind::Subshell => Subshell::deinit(self, id),
             StateKind::Free => return,
         }
@@ -1066,7 +928,7 @@ impl Interpreter {
 
     fn on_root_child_done(&self, child: NodeId, exit_code: ExitCode) -> Yield {
         // Only `Script` can be a direct child of the interpreter.
-        debug_assert!(matches!(self.nodes.get()[child.idx()], Node::Script(_)));
+        debug_assert!(matches!(self.kind(child), StateKind::Script));
         log!("Interpreter script finish {}", exit_code);
         self.free_node(child);
         self.exit_code.set(Some(exit_code));
@@ -1077,7 +939,6 @@ impl Interpreter {
     }
 
     pub(crate) fn async_cmd_done(&self, async_id: NodeId) {
-        Async::actually_deinit(self, async_id);
         self.free_node(async_id);
         self.async_commands_executing
             .set(self.async_commands_executing.get() - 1);
@@ -1096,7 +957,7 @@ impl Interpreter {
     pub(crate) fn compute_estimated_size_for_gc(&self) -> usize {
         let mut size = core::mem::size_of::<Interpreter>();
         size += self.args.get().memory_cost();
-        size += self.root_shell.get().memory_cost();
+        size += self.root_shell.borrow().memory_cost();
         size += self.root_io.get().memory_cost();
         size += self.jsobjs.len() * core::mem::size_of::<crate::jsc::JSValue>();
         let vm_args = self.vm_args_utf8.get();
@@ -1118,9 +979,8 @@ impl Interpreter {
 
     /// Safe accessor for the set-once `global_this: Cell<*mut JSGlobalObject>`
     /// backref. `None` on the mini-event-loop path (never set); `Some` once
-    /// `create_shell_interpreter` populates it. Single `unsafe` deref site —
-    /// callers (`throw`, `finish_internal`) read through this instead of
-    /// open-coding the raw `&*self.global_this.get()` deref.
+    /// `create_shell_interpreter` populates it. Callers (`throw`,
+    /// `finish_internal`) read through this instead of open-coding the deref.
     #[inline]
     pub(crate) fn global_this_ref(&self) -> Option<&crate::jsc::JSGlobalObject> {
         let g = self.global_this.get();
@@ -1150,7 +1010,7 @@ impl Interpreter {
     /// the null device if the process was started with that stream closed),
     /// wrap each in an `IOWriter`, and install them as `root_io.stdout/stderr`
     /// so command output reaches the terminal. On the JS event loop the
-    /// `captured` slot is also wired to `_buffered_stdout/err` so
+    /// `captured` slot is also wired to `buffered_stdout/err` so
     /// `Bun.$` callers can read it back.
     fn setup_io_before_run(&self) -> bun_sys::Result<()> {
         if self.flags.get().quiet() {
@@ -1181,7 +1041,6 @@ impl Interpreter {
             }
         };
 
-        let interp_ptr: *mut Interpreter = self.as_ctx_ptr();
         let stdout_writer = IOWriter::init(
             stdout_fd,
             crate::shell::io_writer::Flags {
@@ -1190,8 +1049,7 @@ impl Interpreter {
             },
             event_loop,
         );
-        // SAFETY: `interp_ptr` is the live `Interpreter` being initialized.
-        stdout_writer.set_interp(interp_ptr);
+        stdout_writer.set_interp(self);
         let stderr_writer = IOWriter::init(
             stderr_fd,
             crate::shell::io_writer::Flags {
@@ -1200,15 +1058,17 @@ impl Interpreter {
             },
             event_loop,
         );
-        // SAFETY: `interp_ptr` is the live `Interpreter` being initialized.
-        stderr_writer.set_interp(interp_ptr);
+        stderr_writer.set_interp(self);
 
         // On the JS event loop, hook captured buffers so the JS
         // `Bun.$` API can read stdout/stderr after completion. The mini path
         // does not capture (it writes straight to the dup'd fd).
         let (cap_out, cap_err) = if matches!(event_loop, EventLoopHandle::Js { .. }) {
-            self.root_shell
-                .with_mut(|rs| (Some(rs.buffered_stdout()), Some(rs.buffered_stderr())))
+            let rs = self.root_shell.borrow();
+            (
+                Some(rs.buffered_stdout.clone()),
+                Some(rs.buffered_stderr.clone()),
+            )
         } else {
             (None, None)
         };
@@ -1231,10 +1091,15 @@ impl Interpreter {
         log!("Interpreter(0x{:x}) run", std::ptr::from_ref(self) as usize);
         self.setup_io_before_run()?;
 
-        let shell = self.root_shell.as_ptr();
-        let ast = &raw const self.args.get().script_ast;
+        let root_node = self.args.get().script_ast();
         let io = self.root_io.get().clone();
-        let root = Script::init(self, shell, ast, NodeId::INTERPRETER, io);
+        let root = Script::init(
+            self,
+            Rc::clone(&self.root_shell),
+            root_node,
+            NodeId::INTERPRETER,
+            io,
+        );
         self.started.store(true, Ordering::SeqCst);
         Script::start(self, root).run(self);
         Ok(())
@@ -1355,10 +1220,15 @@ impl Interpreter {
         }
         Self::incr_pending_activity_flag(&self.has_pending_activity);
 
-        let shell = self.root_shell.as_ptr();
-        let ast = &raw const self.args.get().script_ast;
+        let root_node = self.args.get().script_ast();
         let io = self.root_io.get().clone();
-        let root = Script::init(self, shell, ast, NodeId::INTERPRETER, io);
+        let root = Script::init(
+            self,
+            Rc::clone(&self.root_shell),
+            root_node,
+            NodeId::INTERPRETER,
+            io,
+        );
         self.started.store(true, Ordering::SeqCst);
         Script::start(self, root).run(self);
         if global_this.has_exception() {
@@ -1379,23 +1249,16 @@ impl Interpreter {
 
         if free_buffered_io {
             // Can safely be called multiple times.
-            self.root_shell.with_mut(|rs| {
-                if let Bufio::Owned(o) = &mut rs._buffered_stderr {
-                    o.clear_and_free();
-                }
-                if let Bufio::Owned(o) = &mut rs._buffered_stdout {
-                    o.clear_and_free();
-                }
-            });
+            self.root_shell.borrow().free_buffered_io();
         }
 
         // Has this already been finalized?
         if self.this_jsvalue.get() != crate::jsc::JSValue::ZERO {
             // Cannot be safely called multiple times.
-            // `root_io` holds `Arc<IOReader>`/`Arc<IOWriter>`; replacing with
+            // `root_io` holds `Rc<IOReader>`/`Rc<IOWriter>`; replacing with
             // default drops the refs.
             self.root_io.set(IO::default());
-            self.root_shell.with_mut(|rs| rs.deinit_embedded(false));
+            self.root_shell.borrow_mut().clear(false);
         }
 
         // Note: free the parse arena eagerly. `bun_alloc::Arena` is
@@ -1410,29 +1273,31 @@ impl Interpreter {
         // (`memid.initially_zero == false` → the expensive scan is skipped)
         // and memory stays flat. The new heap created by `reset()` allocates
         // no pages until first use, so the per-interpreter footprint left for
-        // the finalizer is just the bare `mi_heap_t`. `script_ast` is cleared
-        // first because every node it references lives in the arena being
-        // destroyed; nothing dereferences it after this point (the only
-        // remaining reader is `memory_cost()`, which queries
-        // `__arena.allocated_bytes()` and never touches the AST).
-        self.args.with_mut(|a| {
-            a.script_ast = ast::Script { stmts: &[] };
-            a.__arena.reset();
-        });
+        // the finalizer is just the bare `mi_heap_t`. Every state node holding
+        // a back-reference into the tree has been freed by now (the script
+        // finished); the only remaining reader is `memory_cost()`, which
+        // queries the arena's size and never touches the AST.
+        debug_assert!(
+            self.nodes
+                .get()
+                .iter()
+                .flat_map(|c| c.iter())
+                .all(|slot| matches!(&*slot.borrow(), Node::Free)),
+            "AST arena reset with live state nodes"
+        );
+        self.args.with_mut(|a| a.reset());
 
         self.this_jsvalue.set(crate::jsc::JSValue::ZERO);
         self.cleanup_state.set(CleanupState::RuntimeCleaned);
     }
 
-    /// GC finalizer body — runs
-    /// whatever teardown `finish()` didn't, then frees the box.
-    ///
-    /// # Safety
-    /// `this` must be the `heap::alloc`'d pointer stored in the JS wrapper's
-    /// `m_ctx`; called exactly once from the GC thread's finalizer.
-    pub(crate) unsafe fn deinit_from_finalizer(this: *mut Self) {
-        // SAFETY: caller contract — `this` is a live `heap::alloc` payload.
-        let this = unsafe { bun_core::heap::take(this) };
+    /// GC finalizer body — runs whatever teardown `finish()` didn't, then
+    /// frees the box. `this` is the payload the JS wrapper's `m_ctx` owned.
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "consumes and frees the m_ctx payload"
+    )]
+    pub(crate) fn deinit_from_finalizer(this: Box<Self>) {
         log!(
             "Interpreter(0x{:x}) deinitFromFinalizer (cleanup_state={})",
             &raw const *this as usize,
@@ -1442,51 +1307,23 @@ impl Interpreter {
         match this.cleanup_state.get() {
             CleanupState::NeedsFullCleanup => {
                 // The script is still in flight (e.g. `worker.terminate()`
-                // mid-command) and `Node` has no `Drop` for its raw-pointer
-                // resources: deinit every live `Cmd` (kills the child, frees
-                // the `ShellSubprocess`, readers, redirection fd). Slots stay
-                // occupied so the env walk below still sees pipeline-duped
-                // Cmd envs. Windows: leak-over-UAF, see
+                // mid-command): deinit every live `Cmd` (kills the child,
+                // frees the `ShellSubprocess`, readers, redirection fd) before
+                // the slots drop with the box. Windows: leak-over-UAF, see
                 // `ShellSubprocess::abort_after_failed_start`.
                 #[cfg(not(windows))]
                 {
-                    let node_count = this.nodes.get().len();
-                    for i in 0..node_count {
+                    for i in 0..this.node_count() {
                         let id = NodeId(i as u32);
-                        if matches!(this.nodes.get()[id.idx()].kind(), StateKind::Cmd) {
+                        if matches!(this.kind(id), StateKind::Cmd) {
                             Cmd::deinit_from_finalizer(&this, id);
                         }
                     }
                 }
-                // A node owns `base.shell` iff it was created via `dupe_for_subshell`,
-                // i.e. its `base.shell` differs from its parent's.
-                {
-                    let root_shell_ptr: *mut ShellExecEnv = this.root_shell.as_ptr();
-                    let nodes = this.nodes.get();
-                    let owned_envs: Vec<*mut ShellExecEnv> = nodes
-                        .iter()
-                        .filter_map(|n| {
-                            let base = n.base()?;
-                            if base.shell.is_null() {
-                                return None;
-                            }
-                            let parent_shell: *mut ShellExecEnv =
-                                if base.parent == NodeId::INTERPRETER {
-                                    root_shell_ptr
-                                } else {
-                                    nodes.get(base.parent.idx())?.base()?.shell
-                                };
-                            (base.shell != parent_shell).then_some(base.shell)
-                        })
-                        .collect();
-                    for env in owned_envs {
-                        // each `env` was returned by `dupe_for_subshell`
-                        // and is owned by exactly one node (filtered above).
-                        ShellExecEnv::deinit_impl(env);
-                    }
-                }
+                // Duped envs (`Base.shell`) drop with their nodes when the
+                // arena drops below; the root env is cleared here.
                 this.root_io.set(IO::default());
-                this.root_shell.with_mut(|rs| rs.deinit_embedded(true));
+                this.root_shell.borrow_mut().clear(true);
             }
             CleanupState::RuntimeCleaned => {
                 // `finish()` already cleaned up via
@@ -1495,6 +1332,8 @@ impl Interpreter {
         }
 
         this.keep_alive.with_mut(|k| k.disable());
+        // `nodes` is declared (and so dropped) before `args`, so no node's AST
+        // back-reference outlives the arena.
     }
 
     pub(crate) fn is_running(
@@ -1519,20 +1358,14 @@ impl Interpreter {
         &self,
         global_this: &crate::jsc::JSGlobalObject,
     ) -> bun_jsc::JsResult<crate::jsc::JSValue> {
-        io_to_js_value(
-            global_this,
-            self.root_shell.with_mut(|rs| rs.buffered_stdout()),
-        )
+        io_to_js_value(global_this, &self.root_shell.borrow().buffered_stdout)
     }
 
     pub(crate) fn get_buffered_stderr(
         &self,
         global_this: &crate::jsc::JSGlobalObject,
     ) -> bun_jsc::JsResult<crate::jsc::JSValue> {
-        io_to_js_value(
-            global_this,
-            self.root_shell.with_mut(|rs| rs.buffered_stderr()),
-        )
+        io_to_js_value(global_this, &self.root_shell.borrow().buffered_stderr)
     }
 
     /// GC finalizer hook — called from the
@@ -1540,10 +1373,7 @@ impl Interpreter {
     /// `host_fn::host_fn_finalize`.
     pub fn finalize(self: Box<Self>) {
         log!("Interpreter(0x{:x}) finalize", &raw const *self as usize);
-        // See [`deinit_from_finalizer`](Self::deinit_from_finalizer).
-        // SAFETY: `self` is the unique GC-owned `m_ctx` payload; round-trip via
-        // raw ptr so `deinit_from_finalizer` can `heap::take` it.
-        unsafe { Self::deinit_from_finalizer(Box::into_raw(self)) };
+        Self::deinit_from_finalizer(self);
     }
 
     /// GC `hasPendingActivity()` hook.
@@ -1567,24 +1397,10 @@ impl Interpreter {
         );
     }
 
-    /// Appends the value of `$N` to
-    /// `out`. Takes the relevant interpreter fields by-part so callers can
-    /// split-borrow alongside the node arena.
-    ///
-    /// # Safety
-    /// `command_ctx` must be null or point to a live `ContextData` that
-    /// outlives this call.
-    // `*mut T` sig forced by trait/callback contract; the body's internal deref is SAFETY-commented.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn append_var_argv(
-        out: &mut Vec<u8>,
-        original_int: u8,
-        event_loop: EventLoopHandle,
-        command_ctx: *mut bun_options_types::context::ContextData,
-        vm_args_utf8: &mut Vec<bun_core::Utf8Bytes<'static>>,
-    ) {
+    /// Appends the value of `$N` to `out`.
+    pub(crate) fn append_var_argv(&self, out: &mut Vec<u8>, original_int: u8) {
         let mut int = original_int;
-        match event_loop {
+        match self.event_loop {
             EventLoopHandle::Js { .. } => {
                 if int == 0 {
                     if let Ok(p) = bun_core::self_exe_path() {
@@ -1594,15 +1410,10 @@ impl Interpreter {
                 }
                 int -= 1;
 
-                let vm_ptr = event_loop
-                    .bun_vm()
-                    .cast::<bun_jsc::virtual_machine::VirtualMachine>();
-                if vm_ptr.is_null() {
+                let Some(global) = self.global_this_ref() else {
                     return;
-                }
-                // SAFETY: `bun_vm()` on a JS event loop returns the live
-                // `*VirtualMachine` owning that loop.
-                let vm = unsafe { &*vm_ptr };
+                };
+                let vm = global.bun_vm();
                 let main = vm.main();
                 if !main.is_empty() {
                     if int == 0 {
@@ -1612,22 +1423,22 @@ impl Interpreter {
                     int -= 1;
                 }
 
-                if let Some(worker_ptr) = vm.worker {
-                    // SAFETY: `vm.worker` is set in `VirtualMachine::init_worker`
-                    // to a live `*WebWorker` for the worker's lifetime.
-                    let worker = unsafe { &*worker_ptr.cast::<bun_jsc::web_worker::WebWorker>() };
+                if let Some(worker) = vm.worker_ref() {
                     let argv = worker.argv();
                     if int as usize >= argv.len() {
                         return;
                     }
-                    if vm_args_utf8.len() != argv.len() {
-                        vm_args_utf8.reserve(argv.len());
-                        for arg in argv {
-                            vm_args_utf8
-                                .push(crate::node::process::worker_option_string(*arg).into_utf8());
+                    self.vm_args_utf8.with_mut(|vm_args_utf8| {
+                        if vm_args_utf8.len() != argv.len() {
+                            vm_args_utf8.reserve(argv.len());
+                            for arg in argv {
+                                vm_args_utf8.push(
+                                    crate::node::process::worker_option_string(*arg).into_utf8(),
+                                );
+                            }
                         }
-                    }
-                    out.extend_from_slice(vm_args_utf8[int as usize].slice());
+                        out.extend_from_slice(vm_args_utf8[int as usize].slice());
+                    });
                     return;
                 }
 
@@ -1636,12 +1447,9 @@ impl Interpreter {
                 }
             }
             EventLoopHandle::Mini(_) => {
-                if command_ctx.is_null() {
+                let Some(ctx) = self.command_ctx else {
                     return;
-                }
-                // SAFETY: `command_ctx` is the process-global `ContextData`
-                // (see `init`); it outlives the interpreter.
-                let ctx = unsafe { &*command_ctx };
+                };
                 if int as usize > ctx.passthrough.len() {
                     return;
                 }
@@ -1662,10 +1470,9 @@ impl Interpreter {
 /// and resets the source to empty.
 fn io_to_js_value(
     global_this: &crate::jsc::JSGlobalObject,
-    buf: *mut Vec<u8>,
+    buf: &CapturedBuf,
 ) -> bun_jsc::JsResult<crate::jsc::JSValue> {
-    // SAFETY: `buf` points into a live `ShellExecEnv` (root or borrowed).
-    let bytelist = core::mem::take(unsafe { &mut *buf });
+    let bytelist = core::mem::take(&mut *buf.borrow_mut());
     // The moved-out `Vec<u8>` storage is handed to JSC directly; the
     // `Vec<u8>` value itself is `mem::forget`-ed since JSC now owns the bytes.
     let mut bytelist = core::mem::ManuallyDrop::new(bytelist);
@@ -1695,40 +1502,72 @@ pub(crate) fn throw_shell_err(
 // ShellExecEnv
 // ────────────────────────────────────────────────────────────────────────────
 
+/// A captured stdout/stderr buffer. Shared between an env and the envs of
+/// its subshell/pipeline children (whose output bubbles up), the root
+/// `IO`'s tee slot, and the `IOWriter` chunks that tee into it. Minted in
+/// stdout/stderr pairs that share one allocation.
+#[derive(Clone)]
+pub struct CapturedBuf {
+    pair: Rc<[RefCell<Vec<u8>>; 2]>,
+    idx: u8,
+}
+
+impl CapturedBuf {
+    /// A fresh `(stdout, stderr)` pair.
+    pub fn new_pair() -> (CapturedBuf, CapturedBuf) {
+        let pair: Rc<[RefCell<Vec<u8>>; 2]> = Rc::default();
+        (
+            CapturedBuf {
+                pair: Rc::clone(&pair),
+                idx: 0,
+            },
+            CapturedBuf { pair, idx: 1 },
+        )
+    }
+
+    #[inline]
+    #[track_caller]
+    pub fn borrow(&self) -> Ref<'_, Vec<u8>> {
+        self.pair[self.idx as usize].borrow()
+    }
+
+    #[inline]
+    #[track_caller]
+    pub fn borrow_mut(&self) -> RefMut<'_, Vec<u8>> {
+        self.pair[self.idx as usize].borrow_mut()
+    }
+}
+
+/// Handle to a [`ShellExecEnv`]. Every state node holds one in its `Base`:
+/// nodes that dupe (Script for command substitution, Subshell, pipeline
+/// children) hold the only handle to the fresh env, everything else shares
+/// its parent's. The env is freed when its last holder is.
+pub type EnvRc = Rc<RefCell<ShellExecEnv>>;
+
 /// Shell execution environment (env vars, cwd, captured stdout/stderr).
-/// Every state node holds a `*mut ShellExecEnv` in its `Base`; some nodes
-/// (Script, Subshell, command-substitution, pipeline children) own a duped
-/// env that they must `deinit`.
 pub struct ShellExecEnv {
-    pub(crate) _buffered_stdout: Bufio,
-    pub(crate) _buffered_stderr: Bufio,
+    pub(crate) buffered_stdout: CapturedBuf,
+    pub(crate) buffered_stderr: CapturedBuf,
     pub(crate) shell_env: EnvMap,
     pub(crate) cmd_local_env: EnvMap,
     pub(crate) export_env: EnvMap,
     pub(crate) __prev_cwd: Vec<u8>,
     pub(crate) __cwd: Vec<u8>,
+    /// `Fd::INVALID` once [`clear`](Self::clear)ed; closed on drop otherwise.
     pub(crate) cwd_fd: Fd,
 }
 
-pub enum Bufio {
-    Owned(Vec<u8>),
-    Borrowed(*mut Vec<u8>),
-}
-
-impl Default for Bufio {
-    fn default() -> Self {
-        Bufio::Owned(Vec::<u8>::default())
-    }
-}
-
-impl Bufio {
-    pub(crate) fn memory_cost(&self) -> usize {
-        match self {
-            Bufio::Owned(o) => o.memory_cost(),
-            // SAFETY: borrowed buffer points into a live parent `ShellExecEnv`
-            // (set by `dupe_for_subshell`); the parent outlives the child.
-            Bufio::Borrowed(b) => unsafe { (**b).memory_cost() },
+impl Drop for ShellExecEnv {
+    fn drop(&mut self) {
+        log!(
+            "[ShellExecEnv] deinit 0x{:x}",
+            std::ptr::from_ref(self) as usize
+        );
+        if self.cwd_fd != Fd::INVALID {
+            closefd(self.cwd_fd);
         }
+        // EnvMap/Vec drop impls free their storage; the captured buffers are
+        // shared and free with their last holder.
     }
 }
 
@@ -1749,8 +1588,8 @@ impl ShellExecEnv {
         size += self.export_env.memory_cost();
         size += self.__cwd.capacity();
         size += self.__prev_cwd.capacity();
-        size += self._buffered_stderr.memory_cost();
-        size += self._buffered_stdout.memory_cost();
+        size += self.buffered_stderr.borrow().memory_cost();
+        size += self.buffered_stdout.borrow().memory_cost();
         size
     }
 
@@ -1770,152 +1609,96 @@ impl ShellExecEnv {
         &self.__prev_cwd[..self.__prev_cwd.len().saturating_sub(1)]
     }
 
-    pub(crate) fn buffered_stdout(&mut self) -> *mut Vec<u8> {
-        // Return the raw `*mut` directly — no `&mut Vec<u8>` is materialised,
-        // so the `Bufio::Borrowed` aliasing concern (which forces
-        // [`buffered_stdout_mut`] to be `unsafe fn`) does not apply here. The
-        // dereference obligation is on whoever later writes through it.
-        match &mut self._buffered_stdout {
-            Bufio::Owned(o) => std::ptr::from_mut(o),
-            Bufio::Borrowed(b) => *b,
-        }
-    }
-
-    pub(crate) fn buffered_stderr(&mut self) -> *mut Vec<u8> {
-        match &mut self._buffered_stderr {
-            Bufio::Owned(o) => std::ptr::from_mut(o),
-            Bufio::Borrowed(b) => *b,
-        }
-    }
-
-    /// Mutably borrow the captured-stdout buffer (owned, or the parent env's
-    /// buffer for subshell/pipeline children — see `Bufio`).
-    ///
-    /// # Safety
-    /// In the `Bufio::Borrowed` arm the returned `&mut Vec<u8>` aliases the
-    /// PARENT `ShellExecEnv`'s buffer. Caller must ensure no other
-    /// `&`/`&mut` to that buffer is live (including via a `&mut` of the
-    /// parent env). The shell trampoline mutates one node at a time so this
-    /// holds in practice, but `&mut self` alone does not encode it — hence
-    /// `unsafe fn`. The parent env strictly outlives this child (parents
-    /// `deinit` after children), so the pointer is never dangling.
+    /// The captured buffer for `which` (stdout or stderr).
     #[inline]
-    pub(crate) unsafe fn buffered_stdout_mut(&mut self) -> &mut Vec<u8> {
-        match &mut self._buffered_stdout {
-            Bufio::Owned(o) => o,
-            // SAFETY: caller contract.
-            Bufio::Borrowed(b) => unsafe { &mut **b },
+    pub(crate) fn captured(&self, which: crate::shell::builtin::IoKind) -> &CapturedBuf {
+        match which {
+            crate::shell::builtin::IoKind::Stdout => &self.buffered_stdout,
+            crate::shell::builtin::IoKind::Stderr => &self.buffered_stderr,
         }
     }
 
-    /// See [`buffered_stdout_mut`].
-    ///
-    /// # Safety
-    /// See [`buffered_stdout_mut`].
-    #[inline]
-    pub(crate) unsafe fn buffered_stderr_mut(&mut self) -> &mut Vec<u8> {
-        match &mut self._buffered_stderr {
-            Bufio::Owned(o) => o,
-            // SAFETY: caller contract; see `buffered_stdout_mut`.
-            Bufio::Borrowed(b) => unsafe { &mut **b },
-        }
+    /// Release the captured stdout/stderr storage (the JS side has taken
+    /// what it wanted). Idempotent.
+    pub(crate) fn free_buffered_io(&self) {
+        self.buffered_stdout.borrow_mut().clear_and_free();
+        self.buffered_stderr.borrow_mut().clear_and_free();
     }
 
-    /// Heap-allocates a
-    /// fresh env for a subshell/pipeline child: dups `cwd_fd`, clones
+    /// A fresh env for a subshell/pipeline child: dups `cwd_fd`, clones
     /// `shell_env`/`export_env`, gives it a fresh empty `cmd_local_env`, and
-    /// borrows or owns buffered stdout/stderr per `kind` (subshell/pipeline
-    /// borrow the parent's buffers so output bubbles up; cmd-subst owns).
-    ///
-    /// Caller frees with `ShellExecEnv::deinit_impl(p)`.
+    /// shares or owns buffered stdout/stderr per `kind` (subshell/pipeline
+    /// share the parent's buffers so output bubbles up; cmd-subst owns).
     pub(crate) fn dupe_for_subshell(
-        &mut self,
+        &self,
         io: &IO,
         kind: ShellExecEnvKind,
-    ) -> bun_sys::Result<*mut ShellExecEnv> {
+    ) -> bun_sys::Result<EnvRc> {
         use crate::shell::io::OutKind;
 
         let dupedfd = bun_sys::dup(self.cwd_fd)?;
 
         // For `.fd` with a captured
-        // buffer, borrow that; for `.ignore`, own a fresh one; for `.pipe`,
-        // own when normal/cmd_subst, borrow parent's when subshell/pipeline.
-        let bufio_for = |out: &OutKind, parent_buf: *mut Vec<u8>| -> Bufio {
+        // buffer, share that; for `.ignore`, own a fresh one; for `.pipe`,
+        // own when normal/cmd_subst, share parent's when subshell/pipeline.
+        let (fresh_out, fresh_err) = CapturedBuf::new_pair();
+        let bufio_for = |out: &OutKind,
+                         parent_buf: &CapturedBuf,
+                         fresh: CapturedBuf|
+         -> CapturedBuf {
             match out {
-                OutKind::Fd(f) => match f.captured {
-                    Some(cap) => Bufio::Borrowed(cap),
-                    None => Bufio::Owned(Vec::<u8>::default()),
+                OutKind::Fd(f) => match &f.captured {
+                    Some(cap) => cap.clone(),
+                    None => fresh,
                 },
-                OutKind::Ignore => Bufio::Owned(Vec::<u8>::default()),
+                OutKind::Ignore => fresh,
                 OutKind::Pipe => match kind {
-                    ShellExecEnvKind::Normal | ShellExecEnvKind::CmdSubst => {
-                        Bufio::Owned(Vec::<u8>::default())
-                    }
-                    ShellExecEnvKind::Subshell | ShellExecEnvKind::Pipeline => {
-                        Bufio::Borrowed(parent_buf)
-                    }
+                    ShellExecEnvKind::Normal | ShellExecEnvKind::CmdSubst => fresh,
+                    ShellExecEnvKind::Subshell | ShellExecEnvKind::Pipeline => parent_buf.clone(),
                 },
             }
         };
-        let stdout = bufio_for(&io.stdout, self.buffered_stdout());
-        let stderr = bufio_for(&io.stderr, self.buffered_stderr());
+        let stdout = bufio_for(&io.stdout, &self.buffered_stdout, fresh_out);
+        let stderr = bufio_for(&io.stderr, &self.buffered_stderr, fresh_err);
 
-        let duped = Box::new(ShellExecEnv {
-            _buffered_stdout: stdout,
-            _buffered_stderr: stderr,
+        let duped = ShellExecEnv {
+            buffered_stdout: stdout,
+            buffered_stderr: stderr,
             shell_env: self.shell_env.clone(),
             cmd_local_env: EnvMap::init(),
             export_env: self.export_env.clone(),
             __prev_cwd: self.__prev_cwd.clone(),
             __cwd: self.__cwd.clone(),
             cwd_fd: dupedfd,
-        });
-        Ok(bun_core::heap::into_raw(duped))
-    }
-
-    /// Teardown for the heap-allocated subshell/pipeline-child case.
-    ///
-    /// # Safety
-    /// `this` must have been returned by `dupe_for_subshell` (or otherwise
-    /// `heap::alloc`'d) and not yet freed.
-    // `*mut T` sig forced by trait/callback contract; the body's internal deref is SAFETY-commented.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn deinit_impl(this: *mut ShellExecEnv) {
-        log!("[ShellExecEnv] deinit 0x{:x}", this as usize);
-        // SAFETY: precondition above. Reclaim the Box; `Drop` for the env
-        // maps / vecs / owned `Bufio` runs on drop. Only `cwd_fd` needs an
-        // explicit close.
-        let boxed = unsafe { bun_core::heap::take(this) };
-        closefd(boxed.cwd_fd);
-        // EnvMap/Vec/Vec<u8> drop impls free their storage; `Bufio::Borrowed`
-        // is a raw ptr so its drop is a no-op.
-        drop(boxed);
-    }
-
-    /// Teardown for the *embedded* root env (held by value in `Interpreter`).
-    /// `deinit_impl(this: *mut)` covers the heap-allocated subshell case.
-    pub(crate) fn deinit_embedded(&mut self, free_buffered_io: bool) {
+        };
         log!(
-            "[ShellExecEnv] deinit 0x{:x}",
+            "[ShellExecEnv] dupe 0x{:x}",
+            std::ptr::from_ref(&duped) as usize
+        );
+        Ok(Rc::new(RefCell::new(duped)))
+    }
+
+    /// Early teardown for the root env (held by the `Interpreter` until it is
+    /// finalized): free the env maps and cwd storage and close `cwd_fd` now,
+    /// leaving a valid empty env behind. `free_buffered_io` also releases the
+    /// captured output.
+    pub(crate) fn clear(&mut self, free_buffered_io: bool) {
+        log!(
+            "[ShellExecEnv] clear 0x{:x}",
             std::ptr::from_ref(self) as usize
         );
         if free_buffered_io {
-            if let Bufio::Owned(o) = &mut self._buffered_stdout {
-                o.clear_and_free();
-            }
-            if let Bufio::Owned(o) = &mut self._buffered_stderr {
-                o.clear_and_free();
-            }
+            self.free_buffered_io();
         }
-        // EnvMap has a Drop impl; replace with fresh to free now and leave
-        // valid state for any later `Drop` of the outer `Interpreter` box.
         self.shell_env = EnvMap::init();
         self.cmd_local_env = EnvMap::init();
         self.export_env = EnvMap::init();
         self.__cwd = Vec::new();
         self.__prev_cwd = Vec::new();
-        closefd(self.cwd_fd);
-        self.cwd_fd = bun_sys::Fd::INVALID;
+        if self.cwd_fd != Fd::INVALID {
+            closefd(self.cwd_fd);
+            self.cwd_fd = Fd::INVALID;
+        }
     }
 
     /// `cd -`.
@@ -2087,11 +1870,52 @@ impl ShellExecEnv {
 // ShellArgs (AST + arena)
 // ────────────────────────────────────────────────────────────────────────────
 
+/// The parsed script and the arena its nodes live in. State nodes hold
+/// `bun_ptr::BackRef<ast::*>` into it; they are all freed before the arena is
+/// reset (`Interpreter::deref_root_shell_and_io_if_needed`) or dropped.
 pub struct ShellArgs {
-    /// Arena owning the parsed AST nodes, tokens, and string pool.
-    pub(crate) __arena: bun_alloc::Arena,
-    /// Root AST node. State nodes hold `*const ast::*` into this arena.
-    pub(crate) script_ast: ast::Script,
+    script: bun_shell_parser::ParsedScript,
+}
+
+impl ShellArgs {
+    /// Heap-allocated (returned as `Box`) because it is handed from
+    /// `ParsedShellScript` to the interpreter as one unit.
+    pub(crate) fn init() -> Box<ShellArgs> {
+        Box::new(ShellArgs {
+            script: bun_shell_parser::ParsedScript::new(),
+        })
+    }
+
+    /// See [`bun_shell_parser::ParsedScript::parse`].
+    #[inline]
+    pub(crate) fn parse(
+        &mut self,
+        src: &[u8],
+        jsstrings_to_escape: &[bun_core::String],
+        jsobjs_len: u32,
+    ) -> Result<(), bun_shell_parser::ParseFailure> {
+        self.script.parse(src, jsstrings_to_escape, jsobjs_len)
+    }
+
+    /// The root AST node; see [`bun_shell_parser::ParsedScript`] for how long
+    /// it stays valid (until `reset`, which `deref_root_shell_and_io_if_needed`
+    /// runs only once every state node is freed).
+    #[inline]
+    pub(crate) fn script_ast(&self) -> bun_ptr::BackRef<ast::Script> {
+        self.script.root_backref()
+    }
+
+    #[inline]
+    pub(crate) fn reset(&mut self) {
+        self.script.reset();
+    }
+
+    /// Reports the arena's `allocated_bytes()` (a superset — tokens + strpool
+    /// + AST nodes). This is for GC `estimatedSize` reporting only, where
+    /// over-approximation is preferable to a tree walk.
+    pub(crate) fn memory_cost(&self) -> usize {
+        self.script.memory_cost()
+    }
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -2103,45 +1927,6 @@ pub struct ShellArgs {
 /// `bun_event_loop` and re-exported through `bun_jsc`; shell re-exports it
 /// here so `IOReader`/`IOWriter`/builtin tasks keep their existing import path.
 pub use bun_event_loop::EventLoopHandle;
-
-// ────────────────────────────────────────────────────────────────────────────
-// CowFd
-// ────────────────────────────────────────────────────────────────────────────
-
-/// Copy-on-write file descriptor: avoids multiple non-blocking writers on the
-/// same fd (which breaks epoll/kqueue).
-pub struct CowFd {
-    __fd: Fd,
-    refcount: u32,
-}
-
-impl CowFd {
-    pub(crate) fn init(fd: Fd) -> *mut CowFd {
-        let new = bun_core::heap::into_raw(Box::new(CowFd {
-            __fd: fd,
-            refcount: 1,
-        }));
-        bun_core::scoped_log!(CowFd, "init {:x} fd={}", new as usize, fd);
-        new
-    }
-
-    /// # Safety
-    /// `this` must point to a live `CowFd` (refcount ≥ 1). If this drops the
-    /// refcount to 0, `this` is freed and must not be used again.
-    // `*mut T` sig forced by trait/callback contract; the body's internal deref is SAFETY-commented.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn deref(this: *mut CowFd) {
-        // SAFETY: caller upholds the precondition above (`this` is a live `CowFd`).
-        unsafe {
-            (*this).refcount -= 1;
-            if (*this).refcount == 0 {
-                // Close the fd before freeing; `closefd` tolerates EBADF.
-                closefd((*this).__fd);
-                drop(bun_core::heap::take(this));
-            }
-        }
-    }
-}
 
 // ────────────────────────────────────────────────────────────────────────────
 // Convenience re-exports for state modules
@@ -2385,28 +2170,20 @@ pub(crate) fn shell_openat(
 // Builtin flag-parsing infra
 // ────────────────────────────────────────────────────────────────────────────
 
-/// Custom parse error for invalid options.
-///
-/// Payload slices borrow from the builtin's argv (NUL-terminated arena strings)
-/// or are `'static` literals; the builtin formats them into an error message
-/// before the next argv mutation, so a raw fat pointer is safe.
+/// Custom parse error for invalid options. The payload is the offending
+/// option name.
 pub(crate) enum ParseError {
-    IllegalOption(*const [u8]),
-    Unsupported(*const [u8]),
+    IllegalOption(Box<[u8]>),
+    Unsupported(Box<[u8]>),
     ShowUsage,
 }
 
 impl ParseError {
-    /// Borrow the option-name payload. The pointer borrows either a `'static`
-    /// literal (e.g. `b"-"`) or the owning `Builtin`'s argv storage
-    /// (NUL-terminated `Vec<u8>` in `Cmd::args`, live for the `Builtin`'s
-    /// lifetime — see [`Builtin::arg_bytes`](crate::shell::builtin::Builtin::arg_bytes)).
-    /// Builtins format the error before any argv mutation.
+    /// The option-name payload (empty for `ShowUsage`).
     #[inline]
     pub(crate) fn opt(&self) -> &[u8] {
         match self {
-            // SAFETY: see doc comment.
-            ParseError::IllegalOption(s) | ParseError::Unsupported(s) => unsafe { &**s },
+            ParseError::IllegalOption(s) | ParseError::Unsupported(s) => s,
             ParseError::ShowUsage => b"",
         }
     }
@@ -2415,15 +2192,15 @@ impl ParseError {
 pub enum ParseFlagResult {
     ContinueParsing,
     Done,
-    IllegalOption(*const [u8]),
-    Unsupported(*const [u8]),
+    IllegalOption(Box<[u8]>),
+    Unsupported(Box<[u8]>),
 }
 
 /// Returns just `name` and lets the caller's `fmt_error_arena` add the
 /// "unsupported option" prefix once.
 #[inline]
-pub(crate) const fn unsupported_flag(name: &'static [u8]) -> *const [u8] {
-    std::ptr::from_ref::<[u8]>(name)
+pub(crate) fn unsupported_flag(name: &'static [u8]) -> Box<[u8]> {
+    name.into()
 }
 
 /// Per-builtin opts type implements this to plug into `FlagParser::parse_flags`.
@@ -2434,18 +2211,19 @@ pub trait FlagParser {
     fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult>;
 }
 
-/// Returns the trailing non-flag args (`args[idx..]`) on success.
+/// Parses leading flags out of `args` (a builtin's argv, each entry
+/// NUL-terminated). Returns the trailing non-flag args (`args[idx..]`) on
+/// success.
 pub(crate) fn parse_flags<'a, O: FlagParser>(
     opts: &mut O,
-    args: &'a [*const core::ffi::c_char],
-) -> Result<Option<&'a [*const core::ffi::c_char]>, ParseError> {
+    args: &'a [Vec<u8>],
+) -> Result<Option<&'a [Vec<u8>]>, ParseError> {
     if args.is_empty() {
         return Ok(None);
     }
     let mut idx = 0usize;
     while idx < args.len() {
-        // SAFETY: argv entries are NUL-terminated C strings (see Builtin::init).
-        let flag = unsafe { bun_core::ffi::cstr(args[idx]) }.to_bytes();
+        let flag = crate::shell::builtin::Builtin::arg_bytes_of(&args[idx]);
         match parse_one_flag(opts, flag) {
             ParseFlagResult::Done => return Ok(Some(&args[idx..])),
             ParseFlagResult::ContinueParsing => {}
@@ -2462,7 +2240,7 @@ fn parse_one_flag<O: FlagParser>(opts: &mut O, flag: &[u8]) -> ParseFlagResult {
         return ParseFlagResult::Done;
     }
     if flag.len() == 1 {
-        return ParseFlagResult::IllegalOption(std::ptr::from_ref::<[u8]>(b"-"));
+        return ParseFlagResult::IllegalOption(b"-".as_slice().into());
     }
     if flag.len() > 2 && flag[1] == b'-' {
         if let Some(r) = opts.parse_long(flag) {
@@ -2504,34 +2282,41 @@ pub enum OutputTaskState {
     Done,
 }
 
+/// What a builtin did with an [`OutputTask`]'s write request.
+#[allow(clippy::large_enum_variant)]
+pub enum OutputWrite<P: OutputTaskVTable> {
+    /// Queued on an `IOWriter`; the builtin holds the task until the chunk
+    /// callback hands it back through [`OutputTask::on_io_writer_chunk`].
+    Enqueued(Yield),
+    /// Written synchronously; carry on with the task.
+    Done(Box<OutputTask<P>>),
+}
+
 /// Vtable trait the parent builtin implements. All hooks
-/// take `(&mut Interpreter, NodeId)` (NodeId style — the parent builtin lives
+/// take `(&Interpreter, NodeId)` (NodeId style — the parent builtin lives
 /// inside the interpreter's node arena).
 ///
-/// `child` is the heap-allocated `OutputTask` itself, passed so `write_*` can
-/// register it as the IOWriter callback target.
+/// `write_*` receive the task itself so an async write can park it on the
+/// builtin until the chunk completes.
 pub trait OutputTaskVTable: Sized {
     fn write_err(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
+        task: Box<OutputTask<Self>>,
         errbuf: &[u8],
-    ) -> Option<Yield>;
+    ) -> OutputWrite<Self>;
     fn on_write_err(interp: &Interpreter, cmd: NodeId);
+    /// Write `task.output`.
     fn write_out(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
-        output: &mut OutputSrc,
-    ) -> Option<Yield>;
+        task: Box<OutputTask<Self>>,
+    ) -> OutputWrite<Self>;
     fn on_write_out(interp: &Interpreter, cmd: NodeId);
     fn on_done(interp: &Interpreter, cmd: NodeId) -> Yield;
 }
 
 /// A task that can write to stdout and/or stderr.
-///
-/// Heap-allocated (`heap::alloc`) so the IOWriter can hold a raw pointer to
-/// it across async chunks; freed by `deinit`.
 pub struct OutputTask<P: OutputTaskVTable> {
     /// Owning Cmd node (the builtin's `cmd` id).
     pub(crate) parent: NodeId,
@@ -2550,84 +2335,74 @@ impl<P: OutputTaskVTable> OutputTask<P> {
         })
     }
 
-    /// Takes the freshly-constructed task by `Box` (callers always pair `new`
-    /// → `start`), leaks it to the raw `*mut Self` the IOWriter callback chain
-    /// needs, and drives the first state transition. The box is reclaimed by
-    /// [`Self::deinit`] (via `heap::take`) when the task reaches `Done`.
-    pub(crate) fn start(me: Box<Self>, interp: &Interpreter, errbuf: Option<&[u8]>) -> Yield {
-        // Leak so `P::write_*` can stash `this` as the IOWriter's `ChildPtr`;
-        // address is stable for the task's lifetime. Re-derive `&mut` per
-        // step (the `P::*` callbacks re-enter via raw `this`, not a reborrow
-        // of `me`).
-        let this = bun_core::heap::into_raw(me);
-        // SAFETY: `this` is a fresh, uniquely-owned heap allocation.
-        unsafe {
-            let me = &mut *this;
-            log!(
-                "OutputTask(0x{:x}) start errbuf={:?}",
-                this as usize,
-                errbuf.map(|b| b.len())
-            );
-            me.state = OutputTaskState::WaitingWriteErr;
-            if let Some(err) = errbuf {
-                if let Some(y) = P::write_err(interp, me.parent, this, err) {
-                    return y;
-                }
-                return Self::next(this, interp);
+    /// Drives the first state transition: write `errbuf` (if any), then the
+    /// output, then `on_done`.
+    pub(crate) fn start(mut me: Box<Self>, interp: &Interpreter, errbuf: Option<&[u8]>) -> Yield {
+        log!(
+            "OutputTask(0x{:x}) start errbuf={:?}",
+            &raw const *me as usize,
+            errbuf.map(|b| b.len())
+        );
+        me.state = OutputTaskState::WaitingWriteErr;
+        let parent = me.parent;
+        if let Some(err) = errbuf {
+            return match P::write_err(interp, parent, me, err) {
+                OutputWrite::Enqueued(y) => y,
+                OutputWrite::Done(me) => Self::next(me, interp),
+            };
+        }
+        me.state = OutputTaskState::WaitingWriteOut;
+        match P::write_out(interp, parent, me) {
+            OutputWrite::Enqueued(y) => y,
+            OutputWrite::Done(mut me) => {
+                P::on_write_out(interp, parent);
+                me.state = OutputTaskState::Done;
+                Self::deinit(me, interp)
             }
-            me.state = OutputTaskState::WaitingWriteOut;
-            if let Some(y) = P::write_out(interp, me.parent, this, &mut me.output) {
-                return y;
-            }
-            P::on_write_out(interp, me.parent);
-            me.state = OutputTaskState::Done;
-            Self::deinit(this, interp)
         }
     }
 
-    pub(crate) unsafe fn next(this: *mut Self, interp: &Interpreter) -> Yield {
-        // SAFETY: caller contract — see `start`.
-        unsafe {
-            let me = &mut *this;
-            match me.state {
-                OutputTaskState::WaitingWriteErr => {
-                    P::on_write_err(interp, me.parent);
-                    me.state = OutputTaskState::WaitingWriteOut;
-                    if let Some(y) = P::write_out(interp, me.parent, this, &mut me.output) {
-                        return y;
+    pub(crate) fn next(mut me: Box<Self>, interp: &Interpreter) -> Yield {
+        let parent = me.parent;
+        match me.state {
+            OutputTaskState::WaitingWriteErr => {
+                P::on_write_err(interp, parent);
+                me.state = OutputTaskState::WaitingWriteOut;
+                match P::write_out(interp, parent, me) {
+                    OutputWrite::Enqueued(y) => y,
+                    OutputWrite::Done(mut me) => {
+                        P::on_write_out(interp, parent);
+                        me.state = OutputTaskState::Done;
+                        Self::deinit(me, interp)
                     }
-                    P::on_write_out(interp, me.parent);
-                    me.state = OutputTaskState::Done;
-                    Self::deinit(this, interp)
                 }
-                OutputTaskState::WaitingWriteOut => {
-                    P::on_write_out(interp, me.parent);
-                    me.state = OutputTaskState::Done;
-                    Self::deinit(this, interp)
-                }
-                OutputTaskState::Done => panic!("Invalid state"),
             }
+            OutputTaskState::WaitingWriteOut => {
+                P::on_write_out(interp, parent);
+                me.state = OutputTaskState::Done;
+                Self::deinit(me, interp)
+            }
+            OutputTaskState::Done => panic!("Invalid state"),
         }
     }
 
-    pub(crate) unsafe fn on_io_writer_chunk(
-        this: *mut Self,
+    pub(crate) fn on_io_writer_chunk(
+        me: Box<Self>,
         interp: &Interpreter,
         _written: usize,
         _err: Option<bun_sys::SystemError>,
     ) -> Yield {
-        log!("OutputTask(0x{:x}) onIOWriterChunk", this as usize);
-        // SAFETY: `this` is the live heap-allocated `OutputTask` guaranteed by
-        // this fn's caller contract; forwarded unchanged to `next`.
-        unsafe { Self::next(this, interp) }
+        log!(
+            "OutputTask(0x{:x}) onIOWriterChunk",
+            &raw const *me as usize
+        );
+        Self::next(me, interp)
     }
 
     /// Fires `on_done` then frees.
-    unsafe fn deinit(this: *mut Self, interp: &Interpreter) -> Yield {
-        // SAFETY: `this` was heap-allocated in `new`; reclaim and drop.
-        let me = unsafe { bun_core::heap::take(this) };
+    fn deinit(me: Box<Self>, interp: &Interpreter) -> Yield {
         debug_assert!(me.state == OutputTaskState::Done);
-        log!("OutputTask(0x{:x}) deinit", this as usize);
+        log!("OutputTask(0x{:x}) deinit", &raw const *me as usize);
         let parent = me.parent;
         drop(me);
         P::on_done(interp, parent)
@@ -2638,56 +2413,48 @@ impl<P: OutputTaskVTable> OutputTask<P> {
 // ShellTask
 // ────────────────────────────────────────────────────────────────────────────
 
-/// Thread-pool task wrapper used by mv/rm/ls/mkdir/touch/cp builtins.
+/// Thread-pool round-trip used by mv/rm/ls/mkdir/touch/cp builtins, glob
+/// expansion and `[ -f ]`-style tests: a boxed context embedding a
+/// [`ShellTask`] is handed to the [`WorkPool`], runs its pool-side body
+/// there, and is posted back to the owning event loop where
+/// [`run_from_main_thread`](Self::run_from_main_thread) consumes it.
 ///
-/// A trait the per-builtin task struct implements. The container-of chain
-/// (WorkPoolTask → ShellTask → Ctx) is built from `core::mem::offset_of!` in
-/// [`ShellTaskCtx::TASK_OFFSET`] + the `#[repr(C)]` first-field guarantee on
-/// [`ShellTask::task`].
-///
-/// `Taskable` is a supertrait so [`ShellTask::on_finish`] can build the
-/// JS-side `ConcurrentTask`.
-pub trait ShellTaskCtx: Sized + bun_event_loop::Taskable {
-    /// Byte offset of the embedded `task: ShellTask` field within `Self`.
-    /// Implementors define this as `core::mem::offset_of!(Self, task)`.
-    const TASK_OFFSET: usize;
-    /// Worker-thread body. Takes `&mut Self`: the trampoline recovers the
-    /// heap allocation from the intrusive task node and forms the unique
-    /// borrow once; no impl re-enters or frees `self` here (that happens in
-    /// `run_from_main_thread`).
-    fn run_from_thread_pool(this: &mut Self);
-    fn run_from_main_thread(this: *mut Self, interp: &Interpreter);
+/// The pool-side entry ([`schedule`](ShellTask::schedule)) is
+/// [`bun_threading::work_pool::OwnedTask::run`]; each context declares it with
+/// `bun_threading::owned_task!(Ty, task.task, run = ...)`, normally pointing
+/// at [`ShellTask::run_owned`] (do the work, then [`ShellTask::on_finish`]).
+/// The main-thread side is delivered by tag: `bun_runtime::dispatch` reboxes
+/// the pointer and calls [`ShellTask::run_from_main_thread`], so each context
+/// is also `bun_event_loop::boxed_taskable!`.
+/// Stamp the pool/dispatch glue for a [`ShellTaskCtx`] whose [`ShellTask`]
+/// lives in a field named `task`: `OwnedTask` (pool entry), `Taskable`
+/// (dispatch tag; released unrun by dropping the keep-alive) and the two
+/// accessors. `run = path` overrides the pool-side body.
+#[macro_export]
+macro_rules! shell_task {
+    ($ty:ident) => {
+        $crate::shell_task!($ty, run = $crate::shell::interpreter::ShellTask::run_owned);
+    };
+    ($ty:ident, run = $run:path) => {
+        ::bun_threading::owned_task!($ty, task.task, run = $run);
+        ::bun_event_loop::boxed_taskable!($ty, $ty, |this| this.task.unref_unrun());
+    };
+}
 
-    /// Recover `*mut Self` from the intrusive `*mut WorkPoolTask` that the
-    /// thread pool hands the callback. `WorkPoolTask` is the first
-    /// `#[repr(C)]` field of [`ShellTask`], so the `WorkPoolTask*` and
-    /// `ShellTask*` coincide; one `byte_sub(TASK_OFFSET)` walks back to the
-    /// outer `Self`.
-    ///
-    /// Provided so the two opt-out builtins (`cp`/`rm`, which install a
-    /// custom `work_pool_callback` and bypass [`shell_task_trampoline`]) can
-    /// reuse the exact recovery the generic trampoline performs, instead of
-    /// each open-coding the `byte_sub` walk.
-    ///
-    /// # Safety
-    /// `task` must point at the [`WorkPoolTask`] node embedded in a live
-    /// `Self` allocation at `Self::TASK_OFFSET` (i.e. the `task.task` field
-    /// of the `ShellTask` field), with provenance covering the whole `Self`.
-    #[inline(always)]
-    unsafe fn from_work_task(task: *mut WorkPoolTask) -> *mut Self {
-        // SAFETY: caller contract — `task` is the first `#[repr(C)]` field of
-        // `ShellTask`, embedded in `Self` at `TASK_OFFSET`.
-        unsafe { bun_core::container_of::<Self, _>(task, Self::TASK_OFFSET) }
-    }
+pub trait ShellTaskCtx: bun_event_loop::Taskable + Sized + 'static {
+    fn shell_task(&self) -> &ShellTask;
+    fn shell_task_mut(&mut self) -> &mut ShellTask;
+    /// Worker-thread body.
+    fn run_from_thread_pool(&mut self);
+    /// Main thread, after the round-trip; consumes the task.
+    fn run_from_main_thread(self: Box<Self>, interp: &Interpreter);
 }
 
 pub type WorkPoolTask = bun_threading::work_pool::Task;
 
 #[repr(C)]
 pub struct ShellTask {
-    /// Intrusive thread-pool node. MUST be the first field so the
-    /// `*mut WorkPoolTask` → `*mut ShellTask` cast in the trampoline is a
-    /// no-op`).
+    /// Intrusive thread-pool node (`owned_task!(Ctx, task.task)`).
     pub task: WorkPoolTask,
     pub(crate) event_loop: EventLoopHandle,
     /// How the pool thread bounces the task back to its owning loop; held only
@@ -2696,15 +2463,50 @@ pub struct ShellTask {
     /// interpreter state a JS wrapper may own.
     pub(crate) poster: Option<bun_jsc::ConcurrentPoster>,
     pub(crate) keep_alive: bun_io::KeepAlive,
-    /// Back-ref to the owning [`Interpreter`]. The high-tier dispatch
-    /// (`runtime::dispatch::run_task`) recovers `&mut Interpreter` from this
-    /// field. Set at `ShellTask::new`; cleared (raw-ptr) only when the task
-    /// is freed.
-    pub(crate) interp: *mut Interpreter,
-    /// Intrusive concurrent-task node for the worker→main bounce. JS arm holds
-    /// a [`ConcurrentTask`](bun_event_loop::ConcurrentTask::ConcurrentTask),
-    /// mini arm holds an `AnyTaskWithExtraContext`.
+    /// The owning [`Interpreter`], handed to `run_from_main_thread`.
+    pub(crate) interp: InterpRef,
+    /// Intrusive node for the worker→owner bounce (`on_finish`), so the
+    /// round-trip allocates nothing.
     pub(crate) concurrent_task: bun_event_loop::EventLoopTask,
+}
+
+/// The owning interpreter as carried by payloads that visit other threads.
+/// It is opened only back on the owning thread (`ShellTask::run_from_main_thread`
+/// and the rm verbose hop); debug builds assert that.
+#[derive(Clone, Copy)]
+pub(crate) struct InterpRef {
+    ptr: bun_ptr::ParentRef<Interpreter>,
+    #[cfg(debug_assertions)]
+    owner: bun_core::thread_id::ThreadId,
+}
+
+impl InterpRef {
+    pub(crate) fn new(interp: &Interpreter) -> Self {
+        Self {
+            ptr: bun_ptr::ParentRef::new(interp),
+            #[cfg(debug_assertions)]
+            owner: bun_core::thread_id::current(),
+        }
+    }
+
+    pub(crate) fn get(&self) -> &Interpreter {
+        #[cfg(debug_assertions)]
+        debug_assert!(
+            bun_core::thread_id::current() == self.owner,
+            "shell interpreter touched off its owning thread"
+        );
+        &self.ptr
+    }
+}
+
+/// Mini-loop receiver for [`ShellTaskCtx`] payloads.
+pub(crate) struct ShellTaskRunner;
+impl<C: ShellTaskCtx> bun_event_loop::AnyTaskWithExtraContext::BoxedMiniTaskRunner<C>
+    for ShellTaskRunner
+{
+    fn run_from_loop_thread(ctx: Box<C>) {
+        ShellTask::run_from_main_thread(ctx);
+    }
 }
 
 impl ShellTask {
@@ -2732,62 +2534,43 @@ impl ShellTask {
             },
             event_loop: parent.event_loop,
             keep_alive: Default::default(),
-            interp: core::ptr::null_mut(),
+            interp: parent.interp,
             concurrent_task: bun_event_loop::EventLoopTask::from_event_loop(parent.event_loop),
         }
     }
 
-    pub(crate) fn new(event_loop: EventLoopHandle) -> Self {
+    pub(crate) fn new(interp: &Interpreter) -> Self {
         ShellTask {
             task: WorkPoolTask {
                 node: Default::default(),
-                // Real callback is installed by `schedule::<C>()`; this only
-                // fires if a caller forgets the `<C>` (debug-asserted there).
+                // Real callback is installed by `WorkPool::schedule_owned`.
                 callback: shell_task_unset_callback,
             },
             poster: None,
-            event_loop,
+            event_loop: interp.event_loop,
             keep_alive: Default::default(),
-            interp: core::ptr::null_mut(),
-            concurrent_task: bun_event_loop::EventLoopTask::from_event_loop(event_loop),
+            interp: InterpRef::new(interp),
+            concurrent_task: bun_event_loop::EventLoopTask::from_event_loop(interp.event_loop),
         }
     }
 
-    /// Installs the per-`C`
-    /// trampoline and hands the intrusive task to the global [`WorkPool`].
-    ///
-    /// SAFETY: `ctx` must be a live heap allocation that embeds this
-    /// `ShellTask` at `C::TASK_OFFSET` and outlives the worker-thread call.
-    pub(crate) unsafe fn schedule<C: ShellTaskCtx>(ctx: *mut C) {
+    /// Owning thread: take a keep-alive on the loop and hand `ctx` to the
+    /// [`WorkPool`](bun_threading::work_pool::WorkPool).
+    pub(crate) fn schedule<C: ShellTaskCtx + bun_threading::work_pool::OwnedTask>(mut ctx: Box<C>) {
         log!("ShellTask schedule");
-        // SAFETY: caller contract — `ctx` embeds `ShellTask` at `TASK_OFFSET`.
-        unsafe {
-            let this = ctx.byte_add(C::TASK_OFFSET).cast::<ShellTask>();
-            (*this)
-                .keep_alive
-                .ref_((*this).event_loop.as_event_loop_ctx());
-            Self::schedule_no_ref::<C>(ctx);
-        }
+        let this = ctx.shell_task_mut();
+        this.keep_alive.ref_(this.event_loop.as_event_loop_ctx());
+        Self::schedule_no_ref(ctx);
     }
 
-    /// Install the per-`C` trampoline and hand the intrusive task to
-    /// [`WorkPool`] WITHOUT a `keep_alive.ref` — for tasks scheduled
-    /// recursively from a worker thread where no JS-thread VM thread-local
-    /// exists (e.g. `ls`).
-    ///
-    /// SAFETY: same as [`Self::schedule`].
-    pub(crate) unsafe fn schedule_no_ref<C: ShellTaskCtx>(ctx: *mut C) {
-        use bun_threading::work_pool::WorkPool;
-        // SAFETY: caller contract — `ctx` embeds `ShellTask` at `TASK_OFFSET`.
-        // Stay on raw pointers: once `WorkPool::schedule` returns the worker
-        // thread may already be touching `*this`, so we must not hold a live
-        // `&mut ShellTask` across that call.
-        unsafe {
-            let this = ctx.byte_add(C::TASK_OFFSET).cast::<ShellTask>();
-            (*this).task.callback = shell_task_trampoline::<C>;
-            (*this).arm();
-            WorkPool::schedule(&raw mut (*this).task);
-        }
+    /// [`schedule`](Self::schedule) WITHOUT a `keep_alive.ref` — for tasks
+    /// scheduled recursively from a worker thread where no JS-thread VM
+    /// thread-local exists (e.g. `ls`).
+    pub(crate) fn schedule_no_ref<C: ShellTaskCtx + bun_threading::work_pool::OwnedTask>(
+        mut ctx: Box<C>,
+    ) {
+        ctx.shell_task_mut().arm();
+        bun_threading::work_pool::WorkPool::schedule_owned(ctx);
     }
 
     /// About to leave the owning thread: take the poster (for a JS loop, a
@@ -2802,100 +2585,53 @@ impl ShellTask {
         }
     }
 
-    /// Called from the worker
-    /// thread once `C::run_from_thread_pool` returns; enqueues the embedded
-    /// concurrent task so the main thread re-enters via
-    /// [`run_from_main_thread`](Self::run_from_main_thread) (which performs the
-    /// `keep_alive.unref` paired with [`schedule`](Self::schedule)).
-    ///
-    /// # Safety
-    /// `ctx` must be the same live heap allocation passed to
-    /// [`schedule`](Self::schedule); not touched again on the worker thread
-    /// after this returns.
-    pub(crate) unsafe fn on_finish<C: ShellTaskCtx>(ctx: *mut C) {
-        use bun_event_loop::{ConcurrentTask::AutoDeinit, EventLoopTask};
+    /// The default [`OwnedTask::run`](bun_threading::work_pool::OwnedTask::run)
+    /// body: run the pool-side work, then post back.
+    pub fn run_owned<C: ShellTaskCtx>(mut ctx: Box<C>) {
+        ctx.run_from_thread_pool();
+        Self::on_finish(ctx);
+    }
+
+    /// Worker thread: post `ctx` back to its owning loop, where
+    /// [`run_from_main_thread`](Self::run_from_main_thread) picks it up (and
+    /// performs the `keep_alive.unref` paired with [`schedule`](Self::schedule)).
+    pub(crate) fn on_finish<C: ShellTaskCtx>(mut ctx: Box<C>) {
         log!("ShellTask onFinish");
-        // SAFETY: caller contract — `ctx` embeds `ShellTask` at `TASK_OFFSET`.
-        // Stay on raw pointers: once `enqueue_task_concurrent` returns, the
-        // main thread may already be touching `*this`, so no live `&mut`
-        // into it may span that call. `this` is live and exclusively owned by
-        // this thread until the enqueue below.
-        unsafe {
-            let this = ctx.byte_add(C::TASK_OFFSET).cast::<ShellTask>();
-            // Moved out: the owning thread may free `*this` once it is queued.
-            let poster = (*this)
-                .poster
-                .take()
-                .expect("shell task on the pool is armed");
-            match &mut (*this).concurrent_task {
-                EventLoopTask::Js(ct) => {
-                    // Tag resolved via `C: Taskable`.
-                    ct.from(ctx, AutoDeinit::ManualDeinit);
-                    poster.post_js(core::ptr::NonNull::from(ct));
-                }
-                EventLoopTask::Mini(at) => {
-                    // Pass the monomorphised callback explicitly.
-                    let at = at.from(this, shell_task_run_from_main_thread_mini::<C>);
-                    poster.post_mini(core::ptr::NonNull::new(at).expect("intrusive task"));
-                }
-            }
-            drop(poster);
-        }
+        // Moved out first: the owning thread may free `ctx` once it is queued.
+        let poster = ctx
+            .shell_task_mut()
+            .poster
+            .take()
+            .expect("shell task on the pool is armed");
+        // JS arm: reboxed by the `C::TAG` arm of `bun_runtime::dispatch::run_task`.
+        poster.post(
+            bun_event_loop::EventLoopTask::arm_boxed::<C, ShellTaskRunner>(ctx, |c| {
+                &mut c.shell_task_mut().concurrent_task
+            }),
+        );
+        drop(poster);
     }
 
-    /// Unrefs the
-    /// event-loop keep-alive paired with [`schedule`], then dispatches to
-    /// `C::run_from_main_thread`. The high-tier `runtime::dispatch::run_task`
-    /// `shell_dispatch!` arm calls this so the ref/unref pairing is kept at
-    /// the seam.
-    ///
-    /// # Safety
-    /// `ctx` must be a live heap allocation that embeds a `ShellTask` at
-    /// `C::TASK_OFFSET` whose `interp` back-ref is valid; called on the main
-    /// thread after the worker bounce-back.
-    pub(crate) unsafe fn run_from_main_thread<C: ShellTaskCtx>(ctx: *mut C) {
+    /// Main thread, after the worker bounce-back: unref the keep-alive paired
+    /// with [`schedule`](Self::schedule), then hand off to
+    /// `C::run_from_main_thread`.
+    pub fn run_from_main_thread<C: ShellTaskCtx>(mut ctx: Box<C>) {
         log!("ShellTask runFromJS");
-        // SAFETY: caller contract — `ctx` embeds `ShellTask` at `TASK_OFFSET`.
-        unsafe {
-            let this = ctx.byte_add(C::TASK_OFFSET).cast::<ShellTask>();
-            (*this)
-                .keep_alive
-                .unref((*this).event_loop.as_event_loop_ctx());
-            let interp = &*(*this).interp;
-            C::run_from_main_thread(ctx, interp);
-        }
+        let this = ctx.shell_task_mut();
+        this.keep_alive.unref(this.event_loop.as_event_loop_ctx());
+        let interp = this.interp;
+        C::run_from_main_thread(ctx, interp.get());
     }
-}
-
-/// Recover `*Ctx` from the
-/// intrusive `*WorkPoolTask`, run the user body, then post back to main.
-unsafe fn shell_task_trampoline<C: ShellTaskCtx>(task: *mut WorkPoolTask) {
-    // SAFETY: `task` is the first `#[repr(C)]` field of `ShellTask`, which is
-    // embedded in `C` at `TASK_OFFSET`. `ctx`
-    // remains the live heap allocation handed to `schedule`.
-    unsafe {
-        let ctx = C::from_work_task(task);
-        // The worker thread is the sole accessor until `on_finish` publishes
-        // the task back; the `&mut` ends before that call.
-        C::run_from_thread_pool(&mut *ctx);
-        ShellTask::on_finish::<C>(ctx);
-    }
-}
-
-/// Mini-loop `AnyTaskWithExtraContext` callback shape (`fn(*mut T, *mut ())`).
-fn shell_task_run_from_main_thread_mini<C: ShellTaskCtx>(this: *mut ShellTask, _: *mut ()) {
-    // SAFETY: `this` is the `ShellTask` embedded in a live `C` at `TASK_OFFSET`;
-    // mini-loop dispatch runs on the main thread.
-    unsafe {
-        ShellTask::run_from_main_thread::<C>(bun_core::container_of::<C, _>(this, C::TASK_OFFSET))
-    };
 }
 
 // Body never dereferences the pointer; a safe `fn` item coerces to the
 // `WorkPoolTask::callback` field type at the assignment site.
 #[cold]
 fn shell_task_unset_callback(_: *mut WorkPoolTask) {
-    debug_assert!(false, "ShellTask scheduled without schedule::<C>()");
+    debug_assert!(
+        false,
+        "ShellTask scheduled without WorkPool::schedule_owned"
+    );
 }
 
 #[cold]
@@ -2914,12 +2650,11 @@ pub(crate) fn unreachable_state(context: &str, state: &str) -> ! {
 // across the boundary, layout is irrelevant. Defined `extern "C" SYSV_ABI`.
 bun_jsc::jsc_abi_extern! {
     #[allow(improper_ctypes)]
-    // PRECONDITION: `ptr` must point to a live `Interpreter` — C++ calls back
-    // into `ShellInterpreter__estimatedSize(ptr)` which dereferences it, and
-    // the JS wrapper takes ownership of the allocation (freed via `finalize`).
-    // Cannot be `safe fn`: `NonNull` alone does not encode points-to-valid-T.
-    fn Bun__createShellInterpreter(
-        global: *const crate::jsc::JSGlobalObject,
+    // `ptr` is a leaked `Box<Interpreter>` whose ownership moves to the JS
+    // wrapper (released via `ShellInterpreterClass__finalize`); the only
+    // caller is `interpreter_to_js` below.
+    safe fn Bun__createShellInterpreter(
+        global: *mut crate::jsc::JSGlobalObject,
         ptr: *mut Interpreter,
         parsed_shell_script: crate::jsc::JSValue,
         resolve: crate::jsc::JSValue,
@@ -2927,14 +2662,32 @@ bun_jsc::jsc_abi_extern! {
     ) -> crate::jsc::JSValue;
 }
 
+/// Wrap `interpreter` in its JS cell; the wrapper owns it from here on.
+fn interpreter_to_js(
+    interpreter: Box<Interpreter>,
+    global: &crate::jsc::JSGlobalObject,
+    parsed_shell_script: crate::jsc::JSValue,
+    resolve: crate::jsc::JSValue,
+    reject: crate::jsc::JSValue,
+) -> crate::jsc::JSValue {
+    Bun__createShellInterpreter(
+        global.as_mut_ptr(),
+        bun_core::heap::into_raw(interpreter),
+        parsed_shell_script,
+        resolve,
+        reject,
+    )
+}
+
+bun_jsc::impl_js_class_via_generated!(Interpreter => crate::generated_classes::js_ShellInterpreter, no_constructor);
+
 pub(crate) fn create_shell_interpreter(
     global: &crate::jsc::JSGlobalObject,
     callframe: &crate::jsc::CallFrame,
 ) -> crate::jsc::JsResult<crate::jsc::JSValue> {
-    use crate::jsc::{ArgumentsSlice, JsClass as _};
+    use crate::jsc::ArgumentsSlice;
     use crate::shell::parsed_shell_script::ParsedShellScript;
 
-    // SAFETY: bun_vm() returns the live thread-local VM for a Bun-owned global.
     let vm = global.bun_vm();
     let mut arguments = ArgumentsSlice::init(vm, callframe.arguments());
 
@@ -2948,13 +2701,9 @@ pub(crate) fn create_shell_interpreter(
         .next_eat()
         .ok_or_else(|| global.throw(format_args!("shell: expected 3 arguments, got 0")))?;
 
-    let parsed_shell_script = ParsedShellScript::from_js(parsed_shell_script_js)
+    let parsed_shell_script = parsed_shell_script_js
+        .as_class_ref::<ParsedShellScript>()
         .ok_or_else(|| global.throw(format_args!("shell: expected a ParsedShellScript")))?;
-    // SAFETY: from_js returned a live wrapper-owned heap pointer. R-2: deref as
-    // shared (`&*const`) — `ParsedShellScript`'s methods/fields are `&self` +
-    // interior-mutable, so no `&mut` is required (and forming one here would
-    // alias if JS re-enters another host fn on the same wrapper).
-    let parsed_shell_script: &ParsedShellScript = unsafe { &*parsed_shell_script };
 
     if parsed_shell_script.args.get().is_none() {
         return Err(global.throw(format_args!(
@@ -2971,7 +2720,7 @@ pub(crate) fn create_shell_interpreter(
     let event_loop = EventLoopHandle::init(global.bun_vm().as_mut().event_loop().cast::<()>());
     let interpreter: Box<Interpreter> = match Interpreter::init(
         // command_ctx — unused on the JS event-loop path.
-        core::ptr::null_mut(),
+        None,
         event_loop,
         shargs,
         jsobjs,
@@ -2986,33 +2735,21 @@ pub(crate) fn create_shell_interpreter(
         }
     };
 
-    let interpreter = bun_core::heap::into_raw(interpreter);
-    // SAFETY: `interpreter` is a fresh heap allocation; the C++ wrapper takes
-    // ownership of the raw pointer and `interpreter` outlives this call.
-    // Single-threaded.
-    let js_value = unsafe {
-        let it = &*interpreter;
-        it.update_flags(|f| f.set_quiet(quiet));
-        it.global_this
-            .set(std::ptr::from_ref::<crate::jsc::JSGlobalObject>(global).cast_mut());
-        it.estimated_size_for_gc
-            .set(it.compute_estimated_size_for_gc());
-        let js_value = Bun__createShellInterpreter(
-            global,
-            interpreter,
-            parsed_shell_script_js,
-            resolve,
-            reject,
-        );
-        it.this_jsvalue.set(js_value);
-        it.keep_alive.with_mut(|k| {
-            // `bun_vm_ptr()` is the live per-thread VM singleton.
-            k.ref_(crate::jsc::VirtualMachineRef::event_loop_ctx(
-                global.bun_vm_ptr(),
-            ))
-        });
-        js_value
-    };
+    interpreter.update_flags(|f| f.set_quiet(quiet));
+    interpreter
+        .global_this
+        .set(std::ptr::from_ref::<crate::jsc::JSGlobalObject>(global).cast_mut());
+    interpreter
+        .estimated_size_for_gc
+        .set(interpreter.compute_estimated_size_for_gc());
+    let js_value = interpreter_to_js(interpreter, global, parsed_shell_script_js, resolve, reject);
+    let interpreter = js_value
+        .as_class_ref::<Interpreter>()
+        .expect("Bun__createShellInterpreter returns a JSShellInterpreter");
+    interpreter.this_jsvalue.set(js_value);
+    interpreter
+        .keep_alive
+        .with_mut(|k| k.ref_(interpreter.event_loop.as_event_loop_ctx()));
     bun_analytics::features::shell.fetch_add(1, Ordering::Relaxed);
     Ok(js_value)
 }

--- a/src/runtime/shell/mod.rs
+++ b/src/runtime/shell/mod.rs
@@ -135,14 +135,12 @@ pub mod subproc;
 pub use bun_shell_parser::{escape_8bit, needs_escape_utf8_ascii_latin1};
 
 // ─── AST surface (lifetime-erased aliases over `bun_shell_parser::ast`) ──────
-// State nodes hold `*const ast::*` raw pointers into the bumpalo-allocated AST
-// (`ShellArgs::__arena`). The arena outlives every state node, so the `'arena`
-// lifetime on `bun_shell_parser::ast::*<'arena>` carries no information the
-// interpreter can use — threading it through `Interpreter`/`Node`/every state
-// struct would be pure noise. Instead we erase it to `'static` here and store
-// raw pointers; `ShellArgs::set_script_ast` performs the single
-// lifetime-widening slice cast (`Script<'a>` → `Script<'static>`, identical
-// layout) at the arena/state-machine boundary.
+// State nodes hold `bun_ptr::BackRef<ast::*>` into the AST owned by
+// `bun_shell_parser::ParsedScript` (`ShellArgs::script`), which the interpreter
+// resets only after every state node is freed. The `'arena` lifetime on
+// `bun_shell_parser::ast::*<'arena>` therefore carries no information the
+// interpreter can use; `ParsedScript::root_backref` erases it once, at the
+// arena/state-machine boundary, under the `BackRef` obligation.
 pub mod ast {
     pub use bun_shell_parser::parse::SmolList;
     use bun_shell_parser::parse::ast as p;

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -819,8 +819,6 @@ pub mod testing_apis {
             }
         };
 
-        let arena = Bump::new();
-
         let template_args_js: JSValue = match arguments.next_eat() {
             Some(s) => s,
             None => {
@@ -842,39 +840,25 @@ pub mod testing_apis {
             marked_argument_buffer,
         )?;
 
-        let mut out_parser: Option<bun_shell_parser::Parser<'_>> = None;
-        let mut out_lex_result: Option<bun_shell_parser::LexResult<'_>> = None;
-
-        let script_ast = match interpret::Interpreter::parse(
-            &arena,
-            &script[..],
-            &mut jsobjs[..],
-            &jsstrings[..],
-            &mut out_parser,
-            &mut out_lex_result,
-        ) {
-            Ok(a) => a,
-            Err(err) => {
-                // `out_lex_result` is populated by `parse()` only on lex errors.
-                if let Some(lex) = out_lex_result.as_ref() {
-                    let str = lex.combine_errors(&arena);
-                    return Err(global.throw(format_args!("{}", bstr::BStr::new(str))));
+        let mut parsed = bun_shell_parser::ParsedScript::new();
+        if let Err(err) = parsed.parse(&script[..], &jsstrings[..], jsobjs.len() as u32) {
+            use bun_shell_parser::ParseFailure;
+            return Err(match err {
+                ParseFailure::Diagnostic(msg) => {
+                    global.throw(format_args!("{}", bstr::BStr::new(&msg)))
                 }
-
-                if let Some(p) = out_parser.as_mut() {
-                    let errstr = p.combine_errors();
-                    return Err(global.throw(format_args!("{}", bstr::BStr::new(errstr))));
+                ParseFailure::Lexer(e) => {
+                    global.throw_error(crate::Error::from(e), "failed to lex/parse shell")
                 }
+                ParseFailure::Other(e) => {
+                    global.throw_error(crate::Error::from(e), "failed to lex/parse shell")
+                }
+            });
+        }
 
-                return Err(global.throw_error(err, "failed to lex/parse shell"));
-            }
-        };
-
-        // `crate::shell::ast::Script` is a `'static`-erased alias of
-        // `bun_shell_parser::ast::Script`, so it formats directly.
         let str = format!(
             "{}",
-            bun_shell_parser::json_fmt::script_json_fmt(&script_ast)
+            bun_shell_parser::json_fmt::script_json_fmt(parsed.root())
         );
         bun_string_jsc::create_utf8_for_js(global, str.as_bytes())
     }

--- a/src/runtime/shell/states/Assigns.rs
+++ b/src/runtime/shell/states/Assigns.rs
@@ -2,11 +2,12 @@
 //! no effect on the environment of the shell, so we can skip them.
 
 use crate::shell::ast;
-use crate::shell::interpreter::{Interpreter, Node, NodeId, ShellExecEnv, log};
+use crate::shell::interpreter::{EnvRc, Interpreter, Node, NodeId, log};
 use crate::shell::states::base::Base;
 use crate::shell::states::expansion::Expansion;
 use crate::shell::yield_::Yield;
 use crate::shell::{EnvStr, ExitCode};
+use std::rc::Rc;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum AssignCtx {
@@ -16,14 +17,13 @@ pub enum AssignCtx {
 
 pub struct Assigns {
     pub(crate) base: Base,
-    /// Points into the AST arena, which outlives every state node — `RawSlice`
-    /// invariant.
-    pub node: bun_ptr::RawSlice<ast::Assign>,
+    /// Points into the AST arena, which outlives every state node.
+    pub node: bun_ptr::BackRef<[ast::Assign]>,
     pub(crate) state: AssignsState,
     pub ctx: AssignCtx,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone, Copy)]
 pub enum AssignsState {
     #[default]
     Idle,
@@ -36,15 +36,14 @@ pub enum AssignsState {
 impl Assigns {
     pub(crate) fn init(
         interp: &Interpreter,
-        shell: *mut ShellExecEnv,
+        shell: EnvRc,
         node: &[ast::Assign],
         parent: NodeId,
         ctx: AssignCtx,
     ) -> NodeId {
         interp.alloc_node(Node::Assigns(Assigns {
             base: Base::new(parent, shell),
-            // AST arena outlives every state node — `RawSlice` invariant.
-            node: bun_ptr::RawSlice::new(node),
+            node: bun_ptr::BackRef::new(node),
             state: AssignsState::Idle,
             ctx,
         }))
@@ -58,10 +57,11 @@ impl Assigns {
         loop {
             let (shell, node) = {
                 let me = interp.as_assigns(this);
-                (me.base.shell, me.node)
+                (Rc::clone(&me.base.shell), me.node)
             };
-            let assigns = node.slice();
-            match interp.as_assigns(this).state {
+            let assigns = node.get();
+            let state = interp.as_assigns(this).state;
+            match state {
                 AssignsState::Idle => {
                     interp.as_assigns_mut(this).state = AssignsState::Expanding { idx: 0 };
                     continue;
@@ -71,7 +71,7 @@ impl Assigns {
                         interp.as_assigns_mut(this).state = AssignsState::Done;
                         continue;
                     }
-                    let atom: *const ast::Atom = &raw const assigns[idx as usize].value;
+                    let atom = bun_ptr::BackRef::new(&assigns[idx as usize].value);
                     let child = Expansion::init(interp, shell, atom, this, true);
                     return Expansion::start(interp, child);
                 }
@@ -104,12 +104,16 @@ impl Assigns {
             let me = interp.as_assigns(this);
             (me.node, me.ctx)
         };
-        let AssignsState::Expanding { idx } = &mut interp.as_assigns_mut(this).state else {
-            unreachable!("Assigns child_done outside Expanding")
+        let label = {
+            let mut me = interp.as_assigns_mut(this);
+            let AssignsState::Expanding { idx } = &mut me.state else {
+                unreachable!("Assigns child_done outside Expanding")
+            };
+            // `idx` was bounds-checked in `next` before spawning the child.
+            let label = node.get()[*idx as usize].label;
+            *idx += 1;
+            label
         };
-        // `idx` was bounds-checked in `next` before spawning the child.
-        let label = node.slice()[*idx as usize].label;
-        *idx += 1;
 
         // Join multi-word expansions with a single space. `ExpansionOut` stores all words contiguously in `buf`
         // with `bounds` marking inter-word offsets, so the merged value is
@@ -129,7 +133,7 @@ impl Assigns {
         };
 
         let value_ref = EnvStr::init_ref_counted(value.into_boxed_slice());
-        interp.as_assigns_mut(this).base.shell_mut().assign_var(
+        interp.as_assigns(this).base.shell_mut().assign_var(
             EnvStr::init_slice(label),
             value_ref,
             ctx,

--- a/src/runtime/shell/states/Async.rs
+++ b/src/runtime/shell/states/Async.rs
@@ -1,6 +1,7 @@
 use crate::shell::ExitCode;
 use crate::shell::ast;
-use crate::shell::interpreter::{EventLoopHandle, Interpreter, Node, NodeId, ShellExecEnv, log};
+use crate::shell::dispatch_tasks::ShellAsyncTask;
+use crate::shell::interpreter::{EnvRc, EventLoopHandle, Interpreter, Node, NodeId, log};
 use crate::shell::io::IO;
 use crate::shell::states::base::Base;
 use crate::shell::states::cmd::Cmd;
@@ -8,6 +9,7 @@ use crate::shell::states::cond_expr::CondExpr;
 use crate::shell::states::r#if::If;
 use crate::shell::states::pipeline::Pipeline;
 use crate::shell::yield_::Yield;
+use std::rc::Rc;
 
 pub struct Async {
     pub(crate) base: Base,
@@ -15,11 +17,9 @@ pub struct Async {
     pub(crate) io: IO,
     pub(crate) state: AsyncState,
     pub(crate) event_loop: EventLoopHandle,
-    /// Heap payload for the main-thread bounce. The node lives in the
-    /// reallocatable `Interpreter::nodes` arena, so the intrusive
-    /// concurrent-task node must live in a stable heap allocation instead.
-    /// Allocated in `init`, freed in `actually_deinit`.
-    task: *mut crate::shell::dispatch_tasks::ShellAsyncTask,
+    /// The one bounce payload for this node: taken by `enqueue_self`, handed
+    /// back by `run_from_main_thread` (at most one bounce is in flight).
+    pub(crate) task: Option<Box<ShellAsyncTask>>,
 }
 
 #[derive(Default, strum::IntoStaticStr)]
@@ -35,7 +35,7 @@ pub enum AsyncState {
 impl Async {
     pub(crate) fn init(
         interp: &Interpreter,
-        shell: *mut ShellExecEnv,
+        shell: EnvRc,
         node: &ast::Expr,
         parent: NodeId,
         io: IO,
@@ -44,21 +44,14 @@ impl Async {
             .async_commands_executing
             .set(interp.async_commands_executing.get() + 1);
         let evtloop = interp.event_loop;
-        let id = interp.alloc_node(Node::Async(Async {
+        interp.alloc_node(Node::Async(Async {
             base: Base::new(parent, shell),
             node: bun_ptr::BackRef::new(node),
             io,
             state: AsyncState::Idle,
             event_loop: evtloop,
-            task: core::ptr::null_mut(),
-        }));
-        // The payload needs the NodeId, so it's allocated after the node.
-        interp.as_async_mut(id).task =
-            bun_core::heap::alloc(crate::shell::dispatch_tasks::ShellAsyncTask {
-                interp: interp.as_ctx_ptr(),
-                node: id,
-            });
-        id
+            task: None,
+        }))
     }
 
     pub(crate) fn start(interp: &Interpreter, this: NodeId) -> Yield {
@@ -77,7 +70,7 @@ impl Async {
             <&'static str>::from(&interp.as_async(this).state)
         );
         let action = {
-            let me = interp.as_async_mut(this);
+            let mut me = interp.as_async_mut(this);
             match &mut me.state {
                 AsyncState::Idle => {
                     me.state = AsyncState::Exec { child: None };
@@ -102,17 +95,17 @@ impl Async {
             NextAction::SpawnChild => {
                 let (shell, io, node) = {
                     let me = interp.as_async(this);
-                    (me.base.shell, me.io.clone(), me.node)
+                    (Rc::clone(&me.base.shell), me.io.clone(), me.node)
                 };
                 // Init the child WITHOUT starting it, store it, enqueue self, return
                 // suspended. The child is started on the NEXT event-loop tick
                 // via the `StartChild` arm above. Restricted to
                 // pipeline/cmd/if/condexpr — other Expr variants panic.
                 let child = match node.get() {
-                    ast::Expr::Pipeline(p) => Pipeline::init(interp, shell, *p, this, io),
-                    ast::Expr::Cmd(c) => Cmd::init(interp, shell, *c, this, io),
-                    ast::Expr::If(i) => If::init(interp, shell, *i, this, io),
-                    ast::Expr::CondExpr(c) => CondExpr::init(interp, shell, *c, this, io),
+                    ast::Expr::Pipeline(p) => Pipeline::init(interp, shell, p, this, io),
+                    ast::Expr::Cmd(c) => Cmd::init(interp, shell, c, this, io),
+                    ast::Expr::If(i) => If::init(interp, shell, i, this, io),
+                    ast::Expr::CondExpr(c) => CondExpr::init(interp, shell, c, this, io),
                     ast::Expr::Assign(_)
                     | ast::Expr::Binary(_)
                     | ast::Expr::Subshell(_)
@@ -146,48 +139,46 @@ impl Async {
         Yield::suspended()
     }
 
-    /// Bounce `run_from_main_thread` through the event loop so the async body runs on subsequent ticks while the
-    /// parent proceeds.
+    /// Bounce `run_from_main_thread` through the event loop so the async body
+    /// runs on subsequent ticks while the parent proceeds.
     fn enqueue_self(interp: &Interpreter, this: NodeId) {
-        let me = interp.as_async_mut(this);
-        let task = me.task;
-        debug_assert!(!task.is_null());
-        match me.event_loop {
-            // Next loop iteration, after I/O has had a turn. `task` is the live
-            // heap payload allocated in `init` and freed only in `actually_deinit`.
+        let (event_loop, task) = {
+            let mut me = interp.as_async_mut(this);
+            (me.event_loop, me.task.take())
+        };
+        let task = task.unwrap_or_else(|| {
+            Box::new(ShellAsyncTask {
+                interp: bun_ptr::ParentRef::new(interp),
+                node: this,
+                concurrent_task: Default::default(),
+            })
+        });
+        match event_loop {
+            // Next loop iteration, after I/O has had a turn. Reboxed by the
+            // `ShellAsync` arm of `bun_runtime::dispatch::run_task`.
             EventLoopHandle::Js { owner } => {
-                owner.enqueue_task_after_yield(bun_jsc::Task::init(task))
+                owner.enqueue_task_after_yield(bun_jsc::Task::from_boxed(task))
             }
-            EventLoopHandle::Mini(mut mini) => {
-                // The payload embeds only the JS-arm `ConcurrentTask`, so the
-                // mini arm heap-allocates an auto-deinit wrapper per bounce.
-                let any = bun_jsc::AnyTaskWithExtraContext::AnyTaskWithExtraContext::from_callback_auto_deinit(
-                    task,
-                    run_from_main_thread_mini,
-                );
-                // SAFETY: the shell's own mini loop, on its thread.
-                unsafe { mini.get_mut() }
-                    .enqueue_task_concurrent(core::ptr::NonNull::new(any).expect("heap task"));
+            EventLoopHandle::Mini(_) => {
+                bun_jsc::ConcurrentPoster::from_event_loop_handle(&event_loop).post_mini(
+                    bun_jsc::AnyTaskWithExtraContext::AnyTaskWithExtraContext::arm_boxed::<
+                        _,
+                        ShellAsyncTask,
+                    >(task, |t| &mut t.concurrent_task),
+                )
             }
         }
     }
 
-    /// `deinit` is purposefully empty: an `Async` appears "done" to its parent
-    /// immediately (see `start`), so the parent must not free it. Real cleanup
-    /// happens in `actually_deinit` once the background body finishes.
-    pub(crate) fn actually_deinit(interp: &Interpreter, this: NodeId) {
-        let me = interp.as_async_mut(this);
-        if !me.task.is_null() {
-            // SAFETY: allocated in `init`; the final bounce that reached
-            // `async_cmd_done` (and thus here) has already been dequeued and
-            // dispatched, so nothing else references the payload.
-            drop(unsafe { bun_core::heap::take(me.task) });
-            me.task = core::ptr::null_mut();
-        }
-    }
+    // `deinit` is purposefully absent: an `Async` appears "done" to its parent
+    // immediately (see `start`), so the parent must not free it. The slot is
+    // freed by `Interpreter::async_cmd_done` once the background body finishes.
 
-    pub(crate) fn run_from_main_thread(interp: &Interpreter, this: NodeId) {
-        Self::next(interp, this).run(interp);
+    pub(crate) fn run_from_main_thread(task: Box<ShellAsyncTask>) {
+        let interp = task.interp;
+        let this = task.node;
+        interp.as_async_mut(this).task = Some(task);
+        Self::next(&interp, this).run(&interp);
     }
 }
 
@@ -198,29 +189,6 @@ enum NextAction {
     Finish,
 }
 
-// `runtime::dispatch::run_task`'s `task_tag::ShellAsync` arm casts the
-// enqueued pointer back to `ShellAsyncTask`; both sides MUST agree.
-impl bun_event_loop::Taskable for crate::shell::dispatch_tasks::ShellAsyncTask {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellAsync;
-    /// The `Async` node's bounce box, freed only at the end of a chain that
-    /// will not continue: free it here.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — the box `Async::init` made; nothing else frees an unrun one.
-        drop(unsafe { bun_core::heap::take(this) });
-    }
-}
-
-/// Mini-loop trampoline.
-fn run_from_main_thread_mini(
-    task: *mut crate::shell::dispatch_tasks::ShellAsyncTask,
-    _: *mut core::ffi::c_void,
-) {
-    // SAFETY: `task` is the live payload owned by the Async node; it is freed
-    // only in `actually_deinit`, which runs at the tail of this bounce chain
-    // (after the final `next()` dispatch), and `interp` outlives every node.
-    unsafe {
-        let interp = &*(*task).interp;
-        let node = (*task).node;
-        Async::run_from_main_thread(interp, node);
-    }
-}
+// `runtime::dispatch::run_task`'s `task_tag::ShellAsync` arm reboxes the
+// enqueued pointer as `ShellAsyncTask`; both sides MUST agree.
+bun_event_loop::boxed_taskable!(ShellAsyncTask, ShellAsync);

--- a/src/runtime/shell/states/Base.rs
+++ b/src/runtime/shell/states/Base.rs
@@ -1,30 +1,27 @@
 //! Base header struct embedded in every state-machine node.
 //!
 //! The interpreter is passed as `&Interpreter` to every method, so only
-//! `parent: NodeId` and the `*mut ShellExecEnv` (which may be owned or
-//! borrowed — see field doc) are stored here.
+//! `parent: NodeId` and the shell env handle are stored here.
 
-use crate::shell::interpreter::{NodeId, ShellExecEnv};
+use core::cell::{Ref, RefMut};
+
+use crate::shell::interpreter::{EnvRc, NodeId, ShellExecEnv};
 
 pub struct Base {
     /// Index of the parent node in `Interpreter::nodes`, or
     /// `NodeId::INTERPRETER` if the parent is the interpreter itself.
     pub(crate) parent: NodeId,
-    /// Borrowed or owned in specific cases — affects whether this node must
-    /// `deinit` it. Owned when created via `dupe_for_subshell` (Script,
-    /// pipeline children, subshells, command substitutions); otherwise
-    /// borrows the parent's env.
-    // Kept raw (not an Owned(Box)/Borrowed enum) because the env may outlive
-    // this node's slot (shared across multiple children) and is freed by the
-    // owning node, not by Drop on Base.
-    pub shell: *mut ShellExecEnv,
+    /// This node's env: a fresh dupe (Script for command substitution,
+    /// pipeline children, subshells) or a share of the parent's. See
+    /// [`EnvRc`].
+    pub shell: EnvRc,
     /// This node, or the part of it that decides its status, was killed by a
     /// Ctrl+C the interpreter left to it. See `Interpreter::propagate_interrupt`.
     pub(crate) interrupted: bool,
 }
 
 impl Base {
-    pub(crate) fn new(parent: NodeId, shell: *mut ShellExecEnv) -> Self {
+    pub(crate) fn new(parent: NodeId, shell: EnvRc) -> Self {
         Self {
             parent,
             shell,
@@ -33,18 +30,14 @@ impl Base {
     }
 
     #[inline]
-    pub fn shell(&self) -> &ShellExecEnv {
-        // SAFETY: `shell` is set in `new()` from a live env owned either by
-        // the interpreter (root) or by an ancestor node that outlives this
-        // node's slot (deinit order is child→parent).
-        unsafe { &*self.shell }
+    #[track_caller]
+    pub fn shell(&self) -> Ref<'_, ShellExecEnv> {
+        self.shell.borrow()
     }
 
     #[inline]
-    pub(crate) fn shell_mut(&mut self) -> &mut ShellExecEnv {
-        // SAFETY: see `shell()`. Mutation is single-threaded (interpreter
-        // runs on one thread) and the trampoline only holds one `&mut` at a
-        // time.
-        unsafe { &mut *self.shell }
+    #[track_caller]
+    pub(crate) fn shell_mut(&self) -> RefMut<'_, ShellExecEnv> {
+        self.shell.borrow_mut()
     }
 }

--- a/src/runtime/shell/states/Base.rs
+++ b/src/runtime/shell/states/Base.rs
@@ -3,7 +3,7 @@
 //! The interpreter is passed as `&Interpreter` to every method, so only
 //! `parent: NodeId` and the shell env handle are stored here.
 
-use core::cell::{Ref, RefMut};
+use bun_ptr::{JsCellRef, JsCellRefMut};
 
 use crate::shell::interpreter::{EnvRc, NodeId, ShellExecEnv};
 
@@ -31,13 +31,13 @@ impl Base {
 
     #[inline]
     #[track_caller]
-    pub fn shell(&self) -> Ref<'_, ShellExecEnv> {
+    pub fn shell(&self) -> JsCellRef<'_, ShellExecEnv> {
         self.shell.borrow()
     }
 
     #[inline]
     #[track_caller]
-    pub(crate) fn shell_mut(&self) -> RefMut<'_, ShellExecEnv> {
+    pub(crate) fn shell_mut(&self) -> JsCellRefMut<'_, ShellExecEnv> {
         self.shell.borrow_mut()
     }
 }

--- a/src/runtime/shell/states/Binary.rs
+++ b/src/runtime/shell/states/Binary.rs
@@ -1,9 +1,10 @@
 use crate::shell::ExitCode;
 use crate::shell::ast;
-use crate::shell::interpreter::{Interpreter, Node, NodeId, ShellExecEnv, log};
+use crate::shell::interpreter::{EnvRc, Interpreter, Node, NodeId, log};
 use crate::shell::io::IO;
 use crate::shell::states::base::Base;
 use crate::shell::yield_::Yield;
+use std::rc::Rc;
 
 pub struct Binary {
     pub(crate) base: Base,
@@ -18,7 +19,7 @@ pub struct Binary {
 impl Binary {
     pub(crate) fn init(
         interp: &Interpreter,
-        shell: *mut ShellExecEnv,
+        shell: EnvRc,
         node: &ast::Binary,
         parent: NodeId,
         io: IO,
@@ -41,7 +42,13 @@ impl Binary {
     pub(crate) fn next(interp: &Interpreter, this: NodeId) -> Yield {
         let (left_exit, right_exit, parent, shell, node) = {
             let me = interp.as_binary(this);
-            (me.left, me.right, me.base.parent, me.base.shell, me.node)
+            (
+                me.left,
+                me.right,
+                me.base.parent,
+                Rc::clone(&me.base.shell),
+                me.node,
+            )
         };
         let n = node.get();
 
@@ -59,13 +66,13 @@ impl Binary {
                 return interp.child_done(parent, this, left);
             }
             let io = interp.as_binary(this).io.clone();
-            let (child, y) = interp.spawn_expr(shell, &n.right, this, io);
+            let (child, y) = interp.spawn_expr(&shell, &n.right, this, io);
             interp.as_binary_mut(this).currently_executing = child;
             return y;
         }
 
         let io = interp.as_binary(this).io.clone();
-        let (child, y) = interp.spawn_expr(shell, &n.left, this, io);
+        let (child, y) = interp.spawn_expr(&shell, &n.left, this, io);
         interp.as_binary_mut(this).currently_executing = child;
         y
     }
@@ -78,7 +85,7 @@ impl Binary {
     ) -> Yield {
         interp.deinit_node(child);
         {
-            let me = interp.as_binary_mut(this);
+            let mut me = interp.as_binary_mut(this);
             me.currently_executing = None;
             if me.left.is_none() && !me.base.interrupted {
                 me.left = Some(exit_code);

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -6,7 +6,9 @@
 use crate::shell::ExitCode;
 use crate::shell::ast;
 use crate::shell::builtin::{Builtin, Kind as BuiltinKind};
-use crate::shell::interpreter::{CowFd, Interpreter, Node, NodeId, ShellExecEnv, StateKind, log};
+use crate::shell::interpreter::{
+    CapturedBuf, EnvRc, Interpreter, Node, NodeId, StateKind, closefd, log,
+};
 use crate::shell::io::{IO, OutKind as IoOutKind};
 use crate::shell::shell_body::subproc::{Readable, ShellSubprocess, StdioKind};
 use crate::shell::states::assigns::{AssignCtx, Assigns};
@@ -16,6 +18,7 @@ use crate::shell::subproc::{ShellIO, SpawnArgs};
 use crate::shell::util::{OutKind, Stdio};
 use crate::shell::yield_::Yield;
 use bun_collections::VecExt;
+use std::rc::Rc;
 
 pub struct Cmd {
     pub(crate) base: Base,
@@ -24,12 +27,14 @@ pub struct Cmd {
     pub(crate) state: CmdState,
     pub args: Vec<Vec<u8>>,
     pub(crate) redirection_file: Vec<u8>,
-    pub(crate) redirection_fd: Option<*mut CowFd>,
+    /// The fd opened for a `> file` redirect on the subprocess path; closed in
+    /// `deinit`.
+    pub(crate) redirection_fd: Option<bun_sys::Fd>,
     pub(crate) exec: Exec,
     pub(crate) exit_code: Option<ExitCode>,
 }
 
-#[derive(Default, strum::IntoStaticStr)]
+#[derive(Default, Clone, Copy, strum::IntoStaticStr)]
 pub enum CmdState {
     #[default]
     Idle,
@@ -57,8 +62,7 @@ impl Cmd {
     /// Borrow the AST node this `Cmd` was built from.
     ///
     /// `node` is a [`BackRef`](bun_ptr::BackRef) into the parsed-script arena,
-    /// which is owned by the `Interpreter` and outlives every `Cmd` slot (the
-    /// arena is dropped only in `Interpreter::deinit`).
+    /// which the `Interpreter` resets only after every state slot is freed.
     #[inline]
     pub(crate) fn ast_node(&self) -> &ast::Cmd {
         self.node.get()
@@ -69,14 +73,14 @@ pub struct SubprocExec {
     /// `None` until `spawn_async` succeeds.
     pub(crate) child: Option<bun_ptr::OwnedThis<ShellSubprocess>>,
     pub(crate) buffered_closed: BufferedIoClosed,
-    /// NodeId-arena backrefs so the legacy `&mut self` subprocess callbacks
-    /// (`buffered_output_close` / `on_exit`) can hand a [`Yield`] back to the
-    /// trampoline. The `Cmd` lives inside `interp.nodes`, so we stash the
-    /// indices and
-    /// return `Yield::Next(this_id)` for the caller (`PipeReader::run_yield`)
-    /// to drive.
-    pub(crate) interp: *mut Interpreter,
-    pub(crate) this_id: NodeId,
+    /// `false` until `start` and the `did_exit_immediately` handling have
+    /// returned. A synchronous `Cmd::on_exit` (process exit handler) or
+    /// `Cmd::buffered_output_close` (an eager `read_all` on a pipe erroring
+    /// inside the start) would otherwise drive the trampoline while
+    /// `transition_to_exec` is still mid-flight, tearing the Cmd down (and
+    /// freeing `child`) underneath it. While unset, both record
+    /// `exit_code`/`state = Done` and return; `transition_to_exec` resumes.
+    pub(crate) started: bool,
 }
 
 /// Tracks which subprocess stdio pipes are still open. Each `Option` is `None`
@@ -167,13 +171,13 @@ impl BufferedIoClosed {
     /// a pipe its buffered bytes are taken (ownership moves into
     /// `state.Closed`) and, if the shell-side IO is `.pipe` and the AST
     /// redirect didn't send this stream elsewhere, also tee'd into the
-    /// command-substitution aggregate buffer.
+    /// command-substitution aggregate buffer `shell_buf`.
     fn close_out(
         slot: &mut Option<BufferedIoState>,
         readable: &Readable,
         io_is_pipe: bool,
         redirects_elsewhere: bool,
-        shell_buf: *mut Vec<u8>,
+        shell_buf: &CapturedBuf,
     ) {
         let Some(state) = slot.as_mut() else { return };
         let Readable::Pipe(pipe) = readable else {
@@ -184,12 +188,8 @@ impl BufferedIoClosed {
         };
         // If the shell state is piped (inside a cmd substitution) aggregate
         // the output of this command.
-        if io_is_pipe && !redirects_elsewhere && !shell_buf.is_null() {
-            let the_slice = pipe.slice();
-            // SAFETY: `shell_buf` points into `ShellExecEnv::_buffered_*`,
-            // which the owning Cmd's `base.shell` keeps live for the duration
-            // of the command. Single-threaded.
-            unsafe { (*shell_buf).append_slice(the_slice) };
+        if io_is_pipe && !redirects_elsewhere {
+            let _ = shell_buf.borrow_mut().append_slice(pipe.slice());
         }
         let buffer = pipe.take_buffer();
         *state = BufferedIoState::Closed(Vec::<u8>::move_from_list(buffer));
@@ -199,7 +199,7 @@ impl BufferedIoClosed {
 impl Cmd {
     pub(crate) fn init(
         interp: &Interpreter,
-        shell: *mut ShellExecEnv,
+        shell: EnvRc,
         node: &ast::Cmd,
         parent: NodeId,
         io: IO,
@@ -223,17 +223,13 @@ impl Cmd {
 
     pub(crate) fn next(interp: &Interpreter, this: NodeId) -> Yield {
         loop {
-            let (shell, node) = {
+            let (shell, node, state) = {
                 let me = interp.as_cmd(this);
-                (me.base.shell, me.node)
+                (Rc::clone(&me.base.shell), me.node, me.state)
             };
             let n = node.get();
-            log!(
-                "Cmd {} next state={}",
-                this,
-                <&'static str>::from(&interp.as_cmd(this).state)
-            );
-            match interp.as_cmd(this).state {
+            log!("Cmd {} next state={}", this, <&'static str>::from(&state));
+            match state {
                 CmdState::Idle => {
                     if !n.assigns.is_empty() {
                         interp.as_cmd_mut(this).state = CmdState::ExpandingAssigns;
@@ -250,7 +246,7 @@ impl Cmd {
                 CmdState::ExpandingRedirect { idx } => {
                     match &n.redirect_file {
                         Some(ast::Redirect::Atom(atom)) if idx == 0 => {
-                            let atom: *const ast::Atom = atom;
+                            let atom = bun_ptr::BackRef::new(atom);
                             let child = Expansion::init(interp, shell, atom, this, false);
                             return Expansion::start(interp, child);
                         }
@@ -270,7 +266,7 @@ impl Cmd {
                     let assign_ctx = idx > 0
                         && is_declaration_utility(&args[0])
                         && is_assignment_word(&args[idx as usize]);
-                    let atom: *const ast::Atom = &raw const args[idx as usize];
+                    let atom = bun_ptr::BackRef::new(&args[idx as usize]);
                     let child = Expansion::init(interp, shell, atom, this, assign_ctx);
                     return Expansion::start(interp, child);
                 }
@@ -279,8 +275,10 @@ impl Cmd {
                 }
                 CmdState::WaitingWriteErr => return Yield::suspended(),
                 CmdState::Done => {
-                    let exit = interp.as_cmd(this).exit_code.unwrap_or(0);
-                    let parent = interp.as_cmd(this).base.parent;
+                    let (exit, parent) = {
+                        let me = interp.as_cmd(this);
+                        (me.exit_code.unwrap_or(0), me.base.parent)
+                    };
                     return interp.child_done(parent, this, exit);
                 }
             }
@@ -314,7 +312,7 @@ impl Cmd {
         child: NodeId,
         exit_code: ExitCode,
     ) -> Yield {
-        let child_kind = interp.node(child).kind();
+        let child_kind = interp.kind(child);
         // A nonzero exit from an
         // Assigns or Expansion child aborts the command — write the failing
         // error to stderr and finish with exit 1. Do NOT advance idx.
@@ -331,7 +329,7 @@ impl Cmd {
             if let Some(err) = err {
                 return Builtin::cmd_write_failing_error(interp, this, format_args!("{}\n", err));
             }
-            let me = interp.as_cmd_mut(this);
+            let mut me = interp.as_cmd_mut(this);
             me.exit_code = Some(1);
             me.state = CmdState::Done;
             return Yield::Next(this);
@@ -340,7 +338,9 @@ impl Cmd {
         // advance the state machine.
         if matches!(child_kind, StateKind::Expansion) {
             let out = Expansion::take_out(interp, child);
-            match interp.as_cmd_mut(this).state {
+            let mut me = interp.as_cmd_mut(this);
+            let me = &mut *me;
+            match me.state {
                 CmdState::ExpandingArgs { ref mut idx } => {
                     *idx += 1;
                     let new_idx = *idx;
@@ -354,7 +354,7 @@ impl Cmd {
                     // the exit status of the last command substitution
                     // performed").
                     {
-                        let n = interp.as_cmd(this).ast_node();
+                        let n = me.node.get();
                         if new_idx == 1
                             && n.name_and_args.len() == 1
                             && matches!(
@@ -362,12 +362,11 @@ impl Cmd {
                                 ast::Atom::Simple(ast::SimpleAtom::CmdSubst(_))
                             )
                         {
-                            interp.as_cmd_mut(this).exit_code = Some(out.out_exit_code);
+                            me.exit_code = Some(out.out_exit_code);
                         }
                     }
                     // `out.bounds` splits the expansion into multiple argv
                     // words (glob/IFS).
-                    let me = interp.as_cmd_mut(this);
                     if out.bounds.is_empty() {
                         // An empty
                         // expansion that did *not* see a `""` literal pushes
@@ -398,7 +397,7 @@ impl Cmd {
                     if !buf.is_empty() && buf.last() != Some(&0) {
                         buf.push(0);
                     }
-                    interp.as_cmd_mut(this).redirection_file = buf;
+                    me.redirection_file = buf;
                 }
                 _ => {}
             }
@@ -410,7 +409,7 @@ impl Cmd {
     /// Resolves argv[0] to a builtin or falls through to subprocess spawn
     /// (still gated).
     fn transition_to_exec(interp: &Interpreter, this: NodeId) -> Yield {
-        // NUL-terminate every arg so builtins can borrow them as `*const c_char`.
+        // NUL-terminate every arg so builtins can borrow them as `&ZStr`.
         for a in &mut interp.as_cmd_mut(this).args {
             if a.last() != Some(&0) {
                 a.push(0);
@@ -420,19 +419,19 @@ impl Cmd {
         // Empty/null argv[0] → exit
         // with the exit code from a sole command-substitution (stashed by
         // `child_done` from `Expansion::out_exit_code`), else 0.
-        let first_arg: Vec<u8> = {
+        let first_arg: Result<Vec<u8>, (ExitCode, NodeId)> = {
             let me = interp.as_cmd(this);
             match me.args.first() {
                 Some(a) if a.len() > 1 => {
                     // strip the trailing NUL we just added
-                    a[..a.len() - 1].to_vec()
+                    Ok(a[..a.len() - 1].to_vec())
                 }
-                _ => {
-                    let exit = me.exit_code.unwrap_or(0);
-                    let parent = me.base.parent;
-                    return interp.child_done(parent, this, exit);
-                }
+                _ => Err((me.exit_code.unwrap_or(0), me.base.parent)),
             }
+        };
+        let first_arg = match first_arg {
+            Ok(a) => a,
+            Err((exit, parent)) => return interp.child_done(parent, this, exit),
         };
 
         if let Some(kind) = BuiltinKind::from_argv0(&first_arg) {
@@ -445,28 +444,25 @@ impl Cmd {
         }
 
         // ── Subprocess path ─────────────────────────────────────────────────
-        // `SpawnArgs` borrows only the local `arena` (its
-        // `interp`/`argv` fields are raw pointers), so `interp: &mut
-        // Interpreter` is freely re-borrowable at every step before
-        // `spawn_async`. Re-enter the arena via `interp.as_cmd{,_mut}(this)`
-        // for each short-lived access instead of caching raw `*mut Cmd`.
+        // `SpawnArgs` borrows the local `arena` and `cwd_buf`; re-enter the node
+        // via `interp.as_cmd{,_mut}(this)` for each short-lived access.
         let event_loop = interp.event_loop;
 
+        let shell = Rc::clone(&interp.as_cmd(this).base.shell);
+        let mut cwd_buf = bun_paths::path_buffer_pool::get();
+        let cwd_len = {
+            let env = shell.borrow();
+            let cwd = env.cwd();
+            cwd_buf[..cwd.len()].copy_from_slice(cwd);
+            cwd.len()
+        };
         let arena = bun_alloc::Arena::new();
         let mut spawn_args = SpawnArgs::default::<false>(&arena, interp, event_loop);
-        // Cache the raw `*mut ShellExecEnv` and deref it directly so the
-        // `cwd: &[u8]` stored in `spawn_args` is decoupled from any borrow of
-        // `*interp` — `Base::shell()` would tie the slice's lifetime to
-        // `&interp`, blocking every `interp.as_cmd_mut(...)` below for the
-        // life of `spawn_args`. The env is a separate heap allocation that
-        // outlives this Cmd, so the slice remains valid across reborrows.
-        let shell_ptr: *mut ShellExecEnv = interp.as_cmd(this).base.shell;
-        // SAFETY: `shell_ptr` is the live env owned by this Cmd's scope chain.
-        spawn_args.cwd = unsafe { &*shell_ptr }.cwd();
+        spawn_args.cwd = &cwd_buf[..cwd_len];
 
         // Fill env from export_env + cmd_local_env.
         {
-            let env = interp.as_cmd_mut(this).base.shell_mut();
+            let mut env = shell.borrow_mut();
             let mut iter = env.export_env.iterator();
             spawn_args.fill_env::<false>(&mut iter);
             let mut iter = env.cmd_local_env.iterator();
@@ -555,28 +551,18 @@ impl Cmd {
         }
 
         // Stage the exec slot *before* starting the subprocess so PipeReader
-        // / process-exit callbacks (which deref `cmd_parent.exec`) see a
-        // populated `Subproc` with the correct `child`. `interp` is left null
-        // until `start` and the `did_exit_immediately` handling have returned:
-        // a synchronous `Cmd::on_exit` (process exit handler) or
-        // `Cmd::buffered_output_close` (an eager `read_all` on a pipe erroring
-        // inside the start) would otherwise drive the trampoline
-        // (`Yield::run(&*interp)`) while this frame still holds
-        // `&Interpreter`, tearing the Cmd down (and freeing `child`)
-        // underneath us. With `interp` null, both record `exit_code`/`state =
-        // Done` and return; we resume via the Yield we hand back below.
-        let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
+        // / process-exit callbacks (which reach the Cmd through `cmd_parent`)
+        // see a populated `Subproc` with the correct `child`; see
+        // `SubprocExec::started` for why they don't resume it yet.
         let buffered_closed = BufferedIoClosed::from_stdio(&spawn_args.stdio);
         interp.as_cmd_mut(this).exec = Exec::Subproc(Box::new(SubprocExec {
             child: None,
             buffered_closed,
-            interp: core::ptr::null_mut(),
-            this_id: this,
+            started: false,
         }));
 
         // `cmd_parent` is `(interp, NodeId)` rather than the spec's `*ShellCmd`
-        // — the Cmd lives inline in `interp.nodes: Vec<Node>`, and a raw
-        // `*mut Cmd` would dangle on the next `alloc_node` reallocation.
+        // — the Cmd lives inline in `interp.nodes`.
         let cmd_parent = crate::shell::subproc::CmdHandle {
             interp: bun_ptr::ParentRef::new(interp),
             id: this,
@@ -618,13 +604,12 @@ impl Cmd {
         let mut did_exit_immediately = false;
         // `start` is re-entrant: `watch()`/`read_all()` may fire
         // `on_process_exit` / `buffered_output_close` which reach back into
-        // `interp` via the backrefs on `SubprocExec`. By NLL the `interp`
-        // borrow above is dead here, so those callbacks do not alias a live
-        // `&mut`.
+        // this Cmd via `cmd_parent`. No borrow of the node is held here.
         if let Err(e) =
             ShellSubprocess::start(subproc, event_loop, &mut lazy, &mut did_exit_immediately)
         {
-            match core::mem::take(&mut interp.as_cmd_mut(this).exec) {
+            let exec = core::mem::take(&mut interp.as_cmd_mut(this).exec);
+            match exec {
                 // Windows: dropping would trip PipeReader's not-closed assert
                 // on a possibly-uninitialized uv source; leak instead
                 // (pre-existing behavior).
@@ -651,14 +636,13 @@ impl Cmd {
             }
         }
 
-        // Publish the interpreter backref now that all synchronous spawn-time
-        // callbacks have returned, so subsequent async pipe-close /
-        // process-exit notifications can drive the trampoline themselves. If a
-        // synchronous callback already finished the command (`state = Done`),
-        // resume here instead — the callback couldn't, with `interp` null.
-        let me = interp.as_cmd_mut(this);
+        // All synchronous spawn-time callbacks have returned, so subsequent
+        // async pipe-close / process-exit notifications may drive the
+        // trampoline themselves. If a synchronous callback already finished
+        // the command (`state = Done`), resume here instead — it couldn't.
+        let mut me = interp.as_cmd_mut(this);
         if let Exec::Subproc(exec) = &mut me.exec {
-            exec.interp = interp_ptr;
+            exec.started = true;
         }
         if matches!(me.state, CmdState::Done) {
             return Yield::Next(this);
@@ -681,7 +665,8 @@ impl Cmd {
         const STDOUT_NO: usize = 1;
         const STDERR_NO: usize = 2;
 
-        let node: &ast::Cmd = interp.as_cmd(this).ast_node();
+        let node = interp.as_cmd(this).node;
+        let node: &ast::Cmd = node.get();
         let flags = node.redirect;
 
         let Some(redirect) = &node.redirect_file else {
@@ -704,8 +689,6 @@ impl Cmd {
 
         match redirect {
             ast::Redirect::JsBuf(val) => {
-                // Safe accessor — single `unsafe` deref lives in
-                // `Interpreter::global_this_ref`.
                 let global = interp
                     .global_this_ref()
                     .expect("JS values not allowed in this context");
@@ -765,10 +748,7 @@ impl Cmd {
                     }
                 } else if crate::webcore::ReadableStream::from_js(jsval, global)?.is_some() {
                     panic!("TODO SHELL READABLE STREAM");
-                } else if let Some(req) = jsval.as_::<crate::webcore::Response>() {
-                    // SAFETY: `as_` returns a live JSC-owned `*mut Response`;
-                    // `get_body_value` is `&self`.
-                    let req = unsafe { &*req };
+                } else if let Some(req) = jsval.as_class_ref::<crate::webcore::Response>() {
                     req.get_body_value().to_blob_if_possible();
                     if flags.stdin() {
                         let b = req.get_body_value().use_as_any_blob();
@@ -808,7 +788,8 @@ impl Cmd {
                     )));
                 }
                 let path_buf: Vec<u8> = {
-                    let raw = &interp.as_cmd(this).redirection_file;
+                    let me = interp.as_cmd(this);
+                    let raw = &me.redirection_file;
                     let len = raw.len().saturating_sub(1);
                     let mut v = raw[..len].to_vec();
                     v.push(0);
@@ -837,7 +818,7 @@ impl Cmd {
                         )));
                     }
                 };
-                interp.as_cmd_mut(this).redirection_fd = Some(CowFd::init(redirfd));
+                interp.as_cmd_mut(this).redirection_fd = Some(redirfd);
                 set_stdio_from_redirect(stdio, flags, redirfd);
             }
         }
@@ -848,7 +829,7 @@ impl Cmd {
     pub(crate) fn on_exec_done(interp: &Interpreter, this: NodeId, exit_code: ExitCode) -> Yield {
         log!("Cmd {} execDone exit={}", this, exit_code);
         {
-            let me = interp.as_cmd_mut(this);
+            let mut me = interp.as_cmd_mut(this);
             me.exit_code = Some(exit_code);
             me.state = CmdState::Done;
         }
@@ -861,7 +842,7 @@ impl Cmd {
     #[cfg(not(windows))]
     pub(crate) fn deinit_from_finalizer(interp: &Interpreter, this: NodeId) {
         {
-            let me = interp.as_cmd_mut(this);
+            let mut me = interp.as_cmd_mut(this);
             match &mut me.exec {
                 Exec::Builtin(b) => b.defuse_array_buf_pins(),
                 Exec::Subproc(sub) => {
@@ -878,12 +859,11 @@ impl Cmd {
     pub(crate) fn deinit(interp: &Interpreter, this: NodeId) {
         log!("Cmd {} deinit", this);
         let exec = {
-            let me = interp.as_cmd_mut(this);
+            let mut me = interp.as_cmd_mut(this);
             me.args.clear();
             me.redirection_file.clear();
             if let Some(fd) = me.redirection_fd.take() {
-                // SAFETY: `fd` is the +1 ref held in `me.redirection_fd`.
-                CowFd::deref(fd);
+                closefd(fd);
             }
             core::mem::take(&mut me.exec)
         };
@@ -913,16 +893,13 @@ impl Cmd {
             }
         }
         // Argv/env are heap-owned `Vec`s; there is no spawn arena to free.
-        // `base.shell` is borrowed (or, when parent is Pipeline, freed by
-        // `Pipeline::child_done` before this runs) — never freed here.
+        // `base.shell` drops with the slot.
     }
 
-    // ── Subprocess callbacks (legacy `*Cmd` backref shape) ────────────────
-    // `ShellSubprocess` / `PipeReader` hold a `*mut Cmd` backref and call
-    // these via `&mut self`. The NodeId-arena port stashes `(interp, this_id)`
-    // on `SubprocExec` so the resulting `Yield` can be driven by the caller's
-    // `PipeReader::run_yield` without aliasing `&Interpreter` against
-    // `&mut self`.
+    // ── Subprocess callbacks ─────────────────────────────────────────────
+    // `ShellSubprocess` / `PipeReader` hold a `CmdHandle` (`(interp, NodeId)`)
+    // backref and call these; each borrows the node only for as long as it
+    // needs, so the resulting `Yield` can be driven right after.
 
     /// True once the command has both an exit code and (for subprocesses)
     /// all buffered stdio closed.
@@ -939,121 +916,121 @@ impl Cmd {
     }
 
     /// Mark the subprocess's buffered stdin as closed.
-    pub(crate) fn buffered_input_close(&mut self) -> Yield {
-        let Exec::Subproc(sub) = &mut self.exec else {
+    pub(crate) fn buffered_input_close(interp: &Interpreter, this: NodeId) -> Yield {
+        let mut me = interp.as_cmd_mut(this);
+        let Exec::Subproc(sub) = &mut me.exec else {
             return Yield::suspended();
         };
         sub.buffered_closed.close_stdin();
-        self.finish_if_done()
+        me.finish_if_done(this)
     }
 
     /// Mark the subprocess's buffered stdout/stderr as closed (flushing the
     /// captured bytes into the shell buffers).
     pub(crate) fn buffered_output_close(
-        &mut self,
+        interp: &Interpreter,
+        this: NodeId,
         kind: OutKind,
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
-        match kind {
-            OutKind::Stdout => self.buffered_output_close_stdout(err),
-            OutKind::Stderr => self.buffered_output_close_stderr(err),
-        }
-        self.finish_if_done()
+        Self::buffered_output_close_kind(interp, this, kind, err);
+        interp.as_cmd_mut(this).finish_if_done(this)
     }
 
     /// Called by `ShellSubprocess::on_process_exit`.
-    pub(crate) fn on_exit(&mut self, exit_code: ExitCode) -> Yield {
+    pub(crate) fn on_exit(interp: &Interpreter, this: NodeId, exit_code: ExitCode) -> Yield {
         log!("cmd exit code={}", exit_code);
+        let mut me = interp.as_cmd_mut(this);
         // Keep the errno a stdio error already recorded.
-        if self.exit_code.is_none() {
-            self.exit_code = Some(exit_code);
+        if me.exit_code.is_none() {
+            me.exit_code = Some(exit_code);
         }
-        self.finish_if_done()
+        me.finish_if_done(this)
     }
 
     /// `Done` once the exit code and every piped stdio are in; the caller runs
-    /// the Yield.
-    fn finish_if_done(&mut self) -> Yield {
+    /// the Yield once its node borrow has ended.
+    fn finish_if_done(&mut self, this: NodeId) -> Yield {
         if matches!(self.state, CmdState::Done) || !self.has_finished() {
             return Yield::suspended();
         }
         self.state = CmdState::Done;
-        let (interp, this_id) = match &self.exec {
-            Exec::Subproc(sub) => (sub.interp, sub.this_id),
+        let started = match &self.exec {
+            Exec::Subproc(sub) => sub.started,
             // Builtins finish through `Builtin::done`.
             _ => return Yield::suspended(),
         };
-        // Still inside the spawn; `transition_to_exec` resumes from `state`.
-        if interp.is_null() {
+        // See `SubprocExec::started`: still inside the spawn;
+        // `transition_to_exec` resumes from `state`.
+        if !started {
             return Yield::suspended();
         }
-        Yield::Next(this_id)
+        Yield::Next(this)
     }
 
-    fn buffered_output_close_stdout(&mut self, err: Option<bun_sys::SystemError>) {
-        debug_assert!(matches!(self.exec, Exec::Subproc(_)));
-        log!("cmd close buffered stdout");
-        if let Some(e) = err {
-            self.exit_code = Some(e.errno.unsigned_abs() as ExitCode);
-        }
-        let redirect = self.ast_node().redirect;
-        let Exec::Subproc(sub) = &mut self.exec else {
-            return;
+    fn buffered_output_close_kind(
+        interp: &Interpreter,
+        this: NodeId,
+        kind: OutKind,
+        err: Option<bun_sys::SystemError>,
+    ) {
+        let (io_kind, stdio_kind) = match kind {
+            OutKind::Stdout => (ast::IoKind::Stdout, StdioKind::Stdout),
+            OutKind::Stderr => (ast::IoKind::Stderr, StdioKind::Stderr),
         };
-        let child = sub.child.as_ref().expect("spawned").this_ptr();
-        // Tee into the JS-side captured buffer if stdout is an fd with a
-        // `captured` slot and the redirect didn't send stdout elsewhere.
-        if let IoOutKind::Fd(fd) = &self.io.stdout {
-            // SAFETY: single-threaded; the captured `Vec<u8>` lives in the
-            // owning `ShellExecEnv` and no other borrow of it is live here.
-            if let Some(captured) = unsafe { fd.captured_mut() } {
-                if !redirect.redirects_elsewhere(ast::IoKind::Stdout) {
-                    if let Readable::Pipe(pipe) = child.stdout.get() {
-                        captured.append_slice(pipe.slice());
+        log!(
+            "cmd close buffered {}",
+            match kind {
+                OutKind::Stdout => "stdout",
+                OutKind::Stderr => "stderr",
+            }
+        );
+        let child = {
+            let mut me = interp.as_cmd_mut(this);
+            let me = &mut *me;
+            debug_assert!(matches!(me.exec, Exec::Subproc(_)));
+            if let Some(e) = err {
+                me.exit_code = Some(e.errno.unsigned_abs() as ExitCode);
+            }
+            let redirect = me.ast_node().redirect;
+            let Exec::Subproc(sub) = &mut me.exec else {
+                return;
+            };
+            let child = sub.child.as_ref().expect("spawned").this_ptr();
+            let (io, slot) = match kind {
+                OutKind::Stdout => (&me.io.stdout, &mut sub.buffered_closed.stdout),
+                OutKind::Stderr => (&me.io.stderr, &mut sub.buffered_closed.stderr),
+            };
+            let readable = match kind {
+                OutKind::Stdout => child.stdout.get(),
+                OutKind::Stderr => child.stderr.get(),
+            };
+            // Tee into the JS-side captured buffer if this stream is an fd with
+            // a `captured` slot and the redirect didn't send it elsewhere.
+            if let IoOutKind::Fd(fd) = io {
+                if let Some(captured) = &fd.captured {
+                    if !redirect.redirects_elsewhere(io_kind) {
+                        if let Readable::Pipe(pipe) = readable {
+                            let _ = captured.borrow_mut().append_slice(pipe.slice());
+                        }
                     }
                 }
             }
-        }
-        BufferedIoClosed::close_out(
-            &mut sub.buffered_closed.stdout,
-            child.stdout.get(),
-            matches!(self.io.stdout, IoOutKind::Pipe),
-            redirect.redirects_elsewhere(ast::IoKind::Stdout),
-            self.base.shell_mut().buffered_stdout(),
-        );
-        child.close_io(StdioKind::Stdout);
-    }
-
-    fn buffered_output_close_stderr(&mut self, err: Option<bun_sys::SystemError>) {
-        debug_assert!(matches!(self.exec, Exec::Subproc(_)));
-        log!("cmd close buffered stderr");
-        if let Some(e) = err {
-            self.exit_code = Some(e.errno.unsigned_abs() as ExitCode);
-        }
-        let redirect = self.ast_node().redirect;
-        let Exec::Subproc(sub) = &mut self.exec else {
-            return;
+            let shell = me.base.shell();
+            let shell_buf = match kind {
+                OutKind::Stdout => &shell.buffered_stdout,
+                OutKind::Stderr => &shell.buffered_stderr,
+            };
+            BufferedIoClosed::close_out(
+                slot,
+                readable,
+                matches!(io, IoOutKind::Pipe),
+                redirect.redirects_elsewhere(io_kind),
+                shell_buf,
+            );
+            child
         };
-        let child = sub.child.as_ref().expect("spawned").this_ptr();
-        if let IoOutKind::Fd(fd) = &self.io.stderr {
-            // SAFETY: single-threaded; the captured `Vec<u8>` lives in the
-            // owning `ShellExecEnv` and no other borrow of it is live here.
-            if let Some(captured) = unsafe { fd.captured_mut() } {
-                if !redirect.redirects_elsewhere(ast::IoKind::Stderr) {
-                    if let Readable::Pipe(pipe) = child.stderr.get() {
-                        captured.append_slice(pipe.slice());
-                    }
-                }
-            }
-        }
-        BufferedIoClosed::close_out(
-            &mut sub.buffered_closed.stderr,
-            child.stderr.get(),
-            matches!(self.io.stderr, IoOutKind::Pipe),
-            redirect.redirects_elsewhere(ast::IoKind::Stderr),
-            self.base.shell_mut().buffered_stderr(),
-        );
-        child.close_io(StdioKind::Stderr);
+        child.close_io(stdio_kind);
     }
 }
 

--- a/src/runtime/shell/states/CondExpr.rs
+++ b/src/runtime/shell/states/CondExpr.rs
@@ -2,11 +2,12 @@
 
 use crate::shell::ExitCode;
 use crate::shell::ast;
-use crate::shell::interpreter::{Interpreter, Node, NodeId, ShellExecEnv, log};
+use crate::shell::interpreter::{EnvRc, Interpreter, Node, NodeId, log};
 use crate::shell::io::IO;
 use crate::shell::states::base::Base;
 use crate::shell::states::expansion::Expansion;
 use crate::shell::yield_::Yield;
+use std::rc::Rc;
 
 pub struct CondExpr {
     pub(crate) base: Base,
@@ -16,7 +17,7 @@ pub struct CondExpr {
     pub args: Vec<Vec<u8>>,
 }
 
-#[derive(Default, strum::IntoStaticStr)]
+#[derive(Default, Clone, Copy, strum::IntoStaticStr)]
 pub enum CondExprState {
     #[default]
     Idle,
@@ -30,7 +31,7 @@ pub enum CondExprState {
 impl CondExpr {
     pub(crate) fn init(
         interp: &Interpreter,
-        shell: *mut ShellExecEnv,
+        shell: EnvRc,
         node: &ast::CondExpr,
         parent: NodeId,
         io: IO,
@@ -51,12 +52,12 @@ impl CondExpr {
     pub(crate) fn next(interp: &Interpreter, this: NodeId) -> Yield {
         // Expand each arg via Expansion, then evaluate the operator.
         loop {
-            let (shell, node) = {
+            let (shell, node, state) = {
                 let me = interp.as_condexpr(this);
-                (me.base.shell, me.node)
+                (Rc::clone(&me.base.shell), me.node, me.state)
             };
             let n = node.get();
-            match interp.as_condexpr(this).state {
+            match state {
                 CondExprState::Idle => {
                     interp.as_condexpr_mut(this).state = CondExprState::ExpandingArgs { idx: 0 };
                     continue;
@@ -65,7 +66,7 @@ impl CondExpr {
                     if (idx as usize) >= n.args.len() {
                         return Self::command_impl_start(interp, this, n.op);
                     }
-                    let atom: *const ast::Atom = n.args.get_const(idx as usize);
+                    let atom = bun_ptr::BackRef::new(n.args.get_const(idx as usize));
                     let child = Expansion::init(interp, shell, atom, this, false);
                     return Expansion::start(interp, child);
                 }
@@ -242,7 +243,7 @@ impl CondExpr {
         let out = Expansion::take_out(interp, child);
         interp.deinit_node(child);
         {
-            let me = interp.as_condexpr_mut(this);
+            let mut me = interp.as_condexpr_mut(this);
             me.args.push(out.buf);
             if let CondExprState::ExpandingArgs { ref mut idx } = me.state {
                 *idx += 1;
@@ -257,26 +258,18 @@ impl CondExpr {
     /// `ShellCondExprStatTask::run_from_main_thread` → `on_stat_task_done`.
     /// `path` is NUL-terminated by the caller.
     fn do_stat(interp: &Interpreter, this: NodeId, cwd_fd: bun_sys::Fd, path: Vec<u8>) -> Yield {
-        use crate::shell::dispatch_tasks::{CondExprStatInner, ShellCondExprStatTask};
+        use crate::shell::dispatch_tasks::ShellCondExprStatTask;
         use crate::shell::interpreter::ShellTask;
         debug_assert!(path.last() == Some(&0));
-        let mut task = ShellTask::new(interp.event_loop);
-        task.interp = interp.as_ctx_ptr();
-        let stat_task = bun_core::heap::alloc(ShellCondExprStatTask {
-            task: CondExprStatInner {
-                task,
-                cond: this,
-                // Placeholder — always overwritten by `run_from_thread_pool`
-                // before the main thread reads it.
-                stat: Err(Default::default()),
-                path,
-                cwd_fd,
-            },
-        });
-        // SAFETY: `stat_task` is a fresh heap allocation embedding `ShellTask`
-        // at `TASK_OFFSET`; consumed (heap::take) in
-        // `ShellCondExprStatTask::run_from_main_thread`.
-        unsafe { ShellTask::schedule::<ShellCondExprStatTask>(stat_task) };
+        ShellTask::schedule(Box::new(ShellCondExprStatTask {
+            task: ShellTask::new(interp),
+            cond: this,
+            // Placeholder — always overwritten by `run_from_thread_pool`
+            // before the main thread reads it.
+            stat: Err(Default::default()),
+            path,
+            cwd_fd,
+        }));
         Yield::suspended()
     }
 
@@ -300,24 +293,21 @@ impl CondExpr {
             interp.as_condexpr_mut(this).state = CondExprState::WaitingWriteErr;
             let child = io_writer::ChildPtr::new(this, io_writer::WriterTag::CondExpr);
             // `OutKind::Fd` guaranteed by `needs_io()`.
-            if let OutKind::Fd(fd) = &interp.as_condexpr(this).io.stderr {
-                return fd.writer.enqueue(child, fd.captured, &buf);
-            }
-            unreachable!()
+            let OutKind::Fd(fd) = interp.as_condexpr(this).io.stderr.clone() else {
+                unreachable!()
+            };
+            return fd.writer.enqueue(child, fd.captured, &buf);
         }
         // No-IO path: append to the shell env's captured stderr and finish
         // synchronously with exit 1 (matches `on_io_writer_chunk`).
         if let OutKind::Pipe = &interp.as_condexpr(this).io.stderr {
-            // SAFETY: single trampoline frame; no other borrow of the env's
-            // (or its parent's) stderr buffer is live.
-            let stderr = unsafe {
-                interp
-                    .as_condexpr_mut(this)
-                    .base
-                    .shell_mut()
-                    .buffered_stderr_mut()
-            };
-            stderr.extend_from_slice(&buf);
+            interp
+                .as_condexpr(this)
+                .base
+                .shell()
+                .buffered_stderr
+                .borrow_mut()
+                .extend_from_slice(&buf);
         }
         let parent = interp.as_condexpr(this).base.parent;
         interp.child_done(parent, this, 1)
@@ -325,46 +315,6 @@ impl CondExpr {
 
     pub(crate) fn deinit(interp: &Interpreter, this: NodeId) {
         log!("CondExpr {} deinit", this);
-        let me = interp.as_condexpr_mut(this);
-        me.args.clear();
-    }
-}
-
-// `runtime::dispatch::run_task`'s `task_tag::ShellCondExprStatTask` arm casts
-// the enqueued pointer back to `ShellCondExprStatTask`; both sides MUST agree.
-impl bun_event_loop::Taskable for crate::shell::dispatch_tasks::ShellCondExprStatTask {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellCondExprStatTask;
-    /// A stat the pool finished whose result will not be applied: drop the
-    /// keep-alive and the box.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — the box `do_stat` scheduled.
-        unsafe {
-            (*this).task.task.unref_unrun();
-            drop(bun_core::heap::take(this));
-        }
-    }
-}
-
-impl crate::shell::interpreter::ShellTaskCtx
-    for crate::shell::dispatch_tasks::ShellCondExprStatTask
-{
-    // The `ShellTask` is embedded one level down (`.task.task`); the dispatch
-    // arm (`shell_dispatch!(nested ...)`) walks the same two hops.
-    const TASK_OFFSET: usize =
-        core::mem::offset_of!(crate::shell::dispatch_tasks::ShellCondExprStatTask, task)
-            + core::mem::offset_of!(crate::shell::dispatch_tasks::CondExprStatInner, task);
-
-    fn run_from_thread_pool(this: &mut Self) {
-        let inner = &mut this.task;
-        debug_assert!(inner.path.last() == Some(&0));
-        let z = bun_core::ZStr::from_buf(&inner.path, inner.path.len() - 1);
-        inner.stat = crate::shell::interpreter::shell_statat(inner.cwd_fd, z);
-    }
-
-    fn run_from_main_thread(this: *mut Self, interp: &Interpreter) {
-        // Delegates to the inherent fn in `dispatch_tasks.rs` (which consumes
-        // the heap allocation). The dispatch arm calls the inherent fn
-        // directly; this trait method exists to satisfy `ShellTaskCtx`.
-        crate::shell::dispatch_tasks::ShellCondExprStatTask::run_from_main_thread(this, interp);
+        interp.as_condexpr_mut(this).args.clear();
     }
 }

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -6,13 +6,14 @@
 
 use crate::shell::ast;
 use crate::shell::interpreter::{
-    EventLoopHandle, Interpreter, Node, NodeId, ShellExecEnv, ShellExecEnvKind, StateKind, log,
+    EnvRc, Interpreter, Node, NodeId, ShellExecEnv, ShellExecEnvKind, StateKind, log,
 };
 use crate::shell::io::{IO, OutKind};
 use crate::shell::states::base::Base;
 use crate::shell::states::script::Script;
 use crate::shell::yield_::Yield;
 use crate::shell::{ExitCode, ShellErr};
+use std::rc::Rc;
 
 pub struct Expansion {
     pub(crate) base: Base,
@@ -87,19 +88,14 @@ pub struct ExpansionOut {
 impl Expansion {
     pub(crate) fn init(
         interp: &Interpreter,
-        shell: *mut ShellExecEnv,
-        node: *const ast::Atom,
+        shell: EnvRc,
+        node: bun_ptr::BackRef<ast::Atom>,
         parent: NodeId,
         assign_ctx: bool,
     ) -> NodeId {
         interp.alloc_node(Node::Expansion(Expansion {
             base: Base::new(parent, shell),
-            // SAFETY: `node` is non-null and points into the AST arena
-            // (`ShellArgs::__arena`), which the interpreter holds for its
-            // entire lifetime — strictly outliving every state node (the
-            // BackRef invariant). Callers pass `&raw const` only to escape
-            // borrowck across the `&Interpreter` reborrow.
-            node: unsafe { bun_ptr::BackRef::from_raw(node as *mut ast::Atom) },
+            node,
             state: ExpansionState::Idle,
             word_idx: 0,
             out: ExpansionOut::default(),
@@ -123,16 +119,8 @@ impl Expansion {
     /// `child_done` advances `word_idx`.
     pub(crate) fn next(interp: &Interpreter, this: NodeId) -> Yield {
         loop {
-            // Split-borrow: `me` from `nodes`, `vm_args_utf8` from its own
-            // field, so `expand_simple_no_io` can expand `$N` without aliasing.
-            // R-2: both are `JsCell`-backed; `as_ptr()`/`node_mut()` project
-            // disjoint `&mut` from `&Interpreter`.
-            let event_loop = interp.event_loop;
-            let command_ctx = interp.command_ctx;
-            // SAFETY: single-JS-thread; `vm_args_utf8` and `nodes` are
-            // disjoint `JsCell` fields (no aliasing between the two borrows).
-            let vm_args_utf8 = unsafe { &mut *interp.vm_args_utf8.as_ptr() };
-            let me = interp.as_expansion_mut(this);
+            let mut me_ref = interp.as_expansion_mut(this);
+            let me = &mut *me_ref;
             match me.state {
                 ExpansionState::Idle => {
                     me.state = ExpansionState::Walking;
@@ -148,6 +136,7 @@ impl Expansion {
                     // variants, glob the original pattern. The normal glob path likewise calls
                     // `transition_to_glob_state` directly (see below).
                     if matches!(me.state, ExpansionState::Glob) {
+                        drop(me_ref);
                         return Self::transition_to_glob_state(interp, this);
                     }
                     continue;
@@ -169,23 +158,20 @@ impl Expansion {
                 me.word_idx = 1;
             }
 
-            let shell_ptr: *mut ShellExecEnv = me.base.shell;
+            let shell_rc = Rc::clone(&me.base.shell);
             while me.word_idx < atoms_len {
                 let simple: &ast::SimpleAtom = match atom {
                     ast::Atom::Simple(s) => s,
                     ast::Atom::Compound(c) => &c.atoms[me.word_idx as usize],
                 };
-                let shell = me.base.shell();
                 let is_cmd_subst = Self::expand_simple_no_io(
-                    shell,
+                    interp,
+                    &shell_rc.borrow(),
                     simple,
                     &mut me.current_out,
                     &mut me.meta_offsets,
                     &mut me.has_quoted_empty,
                     true,
-                    event_loop,
-                    command_ctx,
-                    vm_args_utf8,
                 );
                 if !is_cmd_subst {
                     me.word_idx += 1;
@@ -197,20 +183,20 @@ impl Expansion {
                     unreachable!()
                 };
                 let quoted = sub.quoted;
-                let script_ast: *const ast::Script = &raw const sub.script;
+                let script_ast = bun_ptr::BackRef::new(&sub.script);
                 me.state = ExpansionState::CmdSubst;
                 me.cmd_subst_quoted = quoted;
+                drop(me_ref);
 
                 let io = IO {
                     stdin: interp.root_io().stdin.clone(),
                     stdout: OutKind::Pipe,
                     stderr: interp.root_io().stderr.clone(),
                 };
-                // SAFETY: `shell_ptr` is a live env owned by the parent state
-                // node and outlives this expansion.
-                let duped = match unsafe { &mut *shell_ptr }
-                    .dupe_for_subshell(&io, ShellExecEnvKind::CmdSubst)
-                {
+                let duped = shell_rc
+                    .borrow()
+                    .dupe_for_subshell(&io, ShellExecEnvKind::CmdSubst);
+                let duped = match duped {
                     Ok(d) => d,
                     Err(e) => {
                         drop(io);
@@ -225,7 +211,7 @@ impl Expansion {
 
             // All sub-atoms expanded — post-process leading tilde then finish.
             if leading_tilde {
-                let home = me.base.shell().get_homedir();
+                let home = shell_rc.borrow().get_homedir();
                 let len_before = me.current_out.len();
                 match me.current_out.first() {
                     Some(b'/') | Some(b'\\') => {
@@ -259,16 +245,22 @@ impl Expansion {
                 continue;
             }
             if atom.has_glob_expansion() {
+                drop(me_ref);
                 return Self::transition_to_glob_state(interp, this);
             }
             Self::push_current_out(me);
             me.state = ExpansionState::Done;
         }
-        let parent = interp.as_expansion(this).base.parent;
-        let exit: ExitCode = if matches!(interp.as_expansion(this).state, ExpansionState::Err(_)) {
-            1
-        } else {
-            0
+        let (parent, exit): (NodeId, ExitCode) = {
+            let me = interp.as_expansion(this);
+            (
+                me.base.parent,
+                if matches!(me.state, ExpansionState::Err(_)) {
+                    1
+                } else {
+                    0
+                },
+            )
         };
         interp.child_done(parent, this, exit)
     }
@@ -430,7 +422,7 @@ impl Expansion {
         let pattern: Vec<u8>;
         let cwd: Vec<u8>;
         {
-            let me = interp.as_expansion_mut(this);
+            let mut me = interp.as_expansion_mut(this);
             me.state = ExpansionState::Glob;
             pattern = Self::neutralize_glob_metachars(&me.current_out, &me.meta_offsets);
             cwd = me.base.shell().cwd().to_vec();
@@ -459,15 +451,13 @@ impl Expansion {
     /// one [`ast::SimpleAtom`] to `out`. Returns `true` for `CmdSubst` so the
     /// caller spawns a `Script` for it.
     fn expand_simple_no_io(
+        interp: &Interpreter,
         shell: &ShellExecEnv,
         atom: &ast::SimpleAtom,
         out: &mut Vec<u8>,
         meta_offsets: &mut Vec<u32>,
         has_quoted_empty: &mut bool,
         expand_tilde: bool,
-        event_loop: EventLoopHandle,
-        command_ctx: *mut bun_options_types::context::ContextData,
-        vm_args_utf8: &mut Vec<bun_core::Utf8Bytes<'static>>,
     ) -> bool {
         use crate::shell::env_str::EnvStr;
         match atom {
@@ -490,10 +480,7 @@ impl Expansion {
                     v.deref();
                 }
             }
-            ast::SimpleAtom::VarArgv(int) => {
-                // SAFETY: `command_ctx` is the live VM ctx; `vm_args_utf8` borrows it.
-                Interpreter::append_var_argv(out, *int, event_loop, command_ctx, vm_args_utf8);
-            }
+            ast::SimpleAtom::VarArgv(int) => interp.append_var_argv(out, *int),
             ast::SimpleAtom::Asterisk => {
                 meta_offsets.push(out.len() as u32);
                 out.push(b'*');
@@ -599,17 +586,15 @@ impl Expansion {
     ) -> Yield {
         // Child is a Script (command substitution). Its captured stdout lives
         // in the duped `ShellExecEnv` it owns; read it before deinit.
-        debug_assert!(matches!(interp.node(child).kind(), StateKind::Script));
-        // SAFETY: single trampoline frame; the child script's env (and its
-        // parent buffer in the `Borrowed` case) has no other live borrow.
-        let stdout = unsafe {
-            interp
-                .as_script_mut(child)
+        debug_assert!(matches!(interp.kind(child), StateKind::Script));
+        let stdout = core::mem::take(
+            &mut *interp
+                .as_script(child)
                 .base
-                .shell_mut()
-                .buffered_stdout_mut()
-        }
-        .clone();
+                .shell()
+                .buffered_stdout
+                .borrow_mut(),
+        );
         // Like bash, drop NUL bytes from command-substitution output: the words
         // become NUL-terminated argv entries.
         let stdout = if bun_core::strings::contains_char(&stdout, 0) {
@@ -630,7 +615,8 @@ impl Expansion {
             me.cmd_subst_quoted || me.assign_ctx
         };
         {
-            let me = interp.as_expansion_mut(this);
+            let mut me = interp.as_expansion_mut(this);
+            let me = &mut *me;
             if exit_code != 0 && sole_cmd_subst {
                 me.out_exit_code = exit_code;
             }
@@ -676,34 +662,41 @@ impl Expansion {
             // In variable assignments a no-match glob
             // expands to the literal pattern; otherwise it's an error.
             let parent = interp.as_expansion(this).base.parent;
-            let in_assign = matches!(interp.node(parent).kind(), StateKind::Assign)
-                || matches!(
-                    interp.node(parent),
-                    Node::Cmd(c) if matches!(
-                        c.state,
-                        crate::shell::states::cmd::CmdState::ExpandingAssigns
-                    )
-                );
-            let me = interp.as_expansion_mut(this);
-            if in_assign {
-                Self::push_current_out(me);
-                me.state = ExpansionState::Done;
-            } else if let Some(err) = walk_err {
-                let shell_err = match err {
-                    ShellGlobErr::Syscall(e) => ShellErr::new_sys(&e),
-                    ShellGlobErr::Unknown(e) => ShellErr::Custom(e.to_string().into_bytes().into()),
-                };
-                me.state = ExpansionState::Err(Box::new(shell_err));
-            } else {
-                let msg = format!("no matches found: {}", bstr::BStr::new(&me.current_out));
-                me.state = ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_bytes().into())));
+            let in_assign = matches!(
+                &*interp.node(parent),
+                Node::Assigns(_)
+                    | Node::Cmd(crate::shell::states::cmd::Cmd {
+                        state: crate::shell::states::cmd::CmdState::ExpandingAssigns,
+                        ..
+                    })
+            );
+            {
+                let mut me = interp.as_expansion_mut(this);
+                let me = &mut *me;
+                if in_assign {
+                    Self::push_current_out(me);
+                    me.state = ExpansionState::Done;
+                } else if let Some(err) = walk_err {
+                    let shell_err = match err {
+                        ShellGlobErr::Syscall(e) => ShellErr::new_sys(&e),
+                        ShellGlobErr::Unknown(e) => {
+                            ShellErr::Custom(e.to_string().into_bytes().into())
+                        }
+                    };
+                    me.state = ExpansionState::Err(Box::new(shell_err));
+                } else {
+                    let msg = format!("no matches found: {}", bstr::BStr::new(&me.current_out));
+                    me.state =
+                        ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_bytes().into())));
+                }
             }
             Yield::Next(this).run(interp);
             return;
         }
 
         {
-            let me = interp.as_expansion_mut(this);
+            let mut me = interp.as_expansion_mut(this);
+            let me = &mut *me;
             // Push each match as its own argv word. The
             // walker arena owns the strings, so they were `to_vec`'d already.
             for entry in result {
@@ -720,7 +713,7 @@ impl Expansion {
     /// Take the error out of `state == Err(_)` (called by the parent on
     /// `child_done(_, 1)` to print it). Leaves `state == Done`.
     pub(crate) fn take_err(interp: &Interpreter, this: NodeId) -> Option<ShellErr> {
-        let me = interp.as_expansion_mut(this);
+        let mut me = interp.as_expansion_mut(this);
         match core::mem::replace(&mut me.state, ExpansionState::Done) {
             ExpansionState::Err(e) => Some(*e),
             other => {
@@ -736,7 +729,7 @@ impl Expansion {
         if let Some(c) = child {
             interp.deinit_node(c);
         }
-        let me = interp.as_expansion_mut(this);
+        let mut me = interp.as_expansion_mut(this);
         me.out.buf.clear();
         me.out.bounds.clear();
         me.current_out.clear();
@@ -744,7 +737,7 @@ impl Expansion {
 
     /// Take the expanded output (called by the parent after `child_done`).
     pub(crate) fn take_out(interp: &Interpreter, this: NodeId) -> ExpansionOut {
-        let me = interp.as_expansion_mut(this);
+        let mut me = interp.as_expansion_mut(this);
         let mut out = core::mem::take(&mut me.out);
         out.out_exit_code = me.out_exit_code;
         out.has_quoted_empty = me.has_quoted_empty;

--- a/src/runtime/shell/states/If.rs
+++ b/src/runtime/shell/states/If.rs
@@ -1,10 +1,11 @@
 use crate::shell::ExitCode;
 use crate::shell::ast;
-use crate::shell::interpreter::{Interpreter, Node, NodeId, ShellExecEnv, log};
+use crate::shell::interpreter::{EnvRc, Interpreter, Node, NodeId, log};
 use crate::shell::io::IO;
 use crate::shell::states::base::Base;
 use crate::shell::states::stmt::Stmt;
 use crate::shell::yield_::Yield;
+use std::rc::Rc;
 
 pub struct If {
     pub(crate) base: Base,
@@ -23,27 +24,17 @@ pub enum IfState {
 pub struct Exec {
     pub(crate) state: ExecBranch,
     /// Back-reference to the current `SmolList<ast::Stmt, 1>` being walked.
-    /// Points into the AST arena, which the interpreter holds for its entire
-    /// lifetime — it outlives every state node.
+    /// Points into the AST arena, which is reset only after every state node
+    /// is freed.
     pub(crate) stmts: bun_ptr::BackRef<ast::SmolList<ast::Stmt, 1>>,
     pub(crate) stmt_idx: u32,
     pub(crate) last_exit_code: ExitCode,
 }
 
 impl Exec {
-    /// Borrow the current `SmolList<Stmt, 1>` being walked.
-    ///
-    /// `stmts` always points into the AST arena (`ShellArgs::__arena`), which
-    /// the interpreter holds for its entire lifetime — it outlives every state
-    /// node (BackRef invariant).
-    #[inline]
-    fn stmts(&self) -> &ast::SmolList<ast::Stmt, 1> {
-        self.stmts.get()
-    }
-
     #[inline]
     fn stmts_len(&self) -> u32 {
-        self.stmts().len() as u32
+        self.stmts.len() as u32
     }
 }
 
@@ -57,7 +48,7 @@ pub enum ExecBranch {
 impl If {
     pub(crate) fn init(
         interp: &Interpreter,
-        shell: *mut ShellExecEnv,
+        shell: EnvRc,
         node: &ast::If,
         parent: NodeId,
         io: IO,
@@ -80,7 +71,7 @@ impl If {
             // Read/mutate `state` via a short-lived borrow, decide an action,
             // then drop the borrow before calling back into `interp`.
             let action = {
-                let me = interp.as_if_mut(this);
+                let mut me = interp.as_if_mut(this);
                 // Copy the BackRef out so `n` borrows a local, leaving `me`
                 // free for the disjoint `&mut me.state` borrow below.
                 let node = me.node;
@@ -158,8 +149,8 @@ impl If {
                             let i = exec.stmt_idx;
                             exec.stmt_idx += 1;
                             // `i` was bounds-checked against `stmts_len()`.
-                            let stmt_node: *const ast::Stmt = &raw const exec.stmts()[i as usize];
-                            Action::SpawnStmt(stmt_node)
+                            let stmts = exec.stmts;
+                            Action::SpawnStmt(bun_ptr::BackRef::new(&stmts.get()[i as usize]))
                         }
                     }
                 }
@@ -169,7 +160,7 @@ impl If {
                 Action::SpawnStmt(stmt_node) => {
                     let (shell, io) = {
                         let me = interp.as_if(this);
-                        (me.base.shell, me.io.clone())
+                        (Rc::clone(&me.base.shell), me.io.clone())
                     };
                     let new_stmt = Stmt::init(interp, shell, stmt_node, this, io);
                     Stmt::start(interp, new_stmt)
@@ -189,7 +180,7 @@ impl If {
             let parent = interp.as_if(this).base.parent;
             return interp.child_done(parent, this, exit_code);
         }
-        let me = interp.as_if_mut(this);
+        let mut me = interp.as_if_mut(this);
         let IfState::Exec(exec) = &mut me.state else {
             panic!(
                 "Expected `exec` state in If, this indicates a bug in Bun. Please file a GitHub issue."
@@ -206,5 +197,5 @@ impl If {
 
 pub(crate) enum Action {
     Done(ExitCode),
-    SpawnStmt(*const ast::Stmt),
+    SpawnStmt(bun_ptr::BackRef<ast::Stmt>),
 }

--- a/src/runtime/shell/states/If.rs
+++ b/src/runtime/shell/states/If.rs
@@ -158,11 +158,8 @@ impl If {
             return match action {
                 Action::Done(exit) => interp.child_done(parent, this, exit),
                 Action::SpawnStmt(stmt_node) => {
-                    let (shell, io) = {
-                        let me = interp.as_if(this);
-                        (Rc::clone(&me.base.shell), me.io.clone())
-                    };
-                    let new_stmt = Stmt::init(interp, shell, stmt_node, this, io);
+                    let shell = Rc::clone(&interp.as_if(this).base.shell);
+                    let new_stmt = Stmt::init(interp, shell, stmt_node, this);
                     Stmt::start(interp, new_stmt)
                 }
             };

--- a/src/runtime/shell/states/Pipeline.rs
+++ b/src/runtime/shell/states/Pipeline.rs
@@ -1,7 +1,7 @@
 use crate::shell::ExitCode;
 use crate::shell::ast;
 use crate::shell::interpreter::{
-    Interpreter, Node, NodeId, Pipe, ShellExecEnv, ShellExecEnvKind, StateKind, closefd, log,
+    EnvRc, Interpreter, Node, NodeId, Pipe, ShellExecEnvKind, closefd, log,
 };
 use crate::shell::io::{IO, InKind, OutKind};
 use crate::shell::io_reader::IOReader;
@@ -12,6 +12,7 @@ use crate::shell::states::cond_expr::CondExpr;
 use crate::shell::states::r#if::If;
 use crate::shell::states::subshell::Subshell;
 use crate::shell::yield_::Yield;
+use std::rc::Rc;
 
 pub struct Pipeline {
     pub(crate) base: Base,
@@ -28,6 +29,7 @@ pub enum CmdOrResult {
     Result(ExitCode),
 }
 
+#[derive(Clone, Copy)]
 pub enum PipelineState {
     /// `idx` is the next `cmds[]` slot to start.
     StartingCmds {
@@ -49,7 +51,7 @@ impl Default for PipelineState {
 impl Pipeline {
     pub(crate) fn init(
         interp: &Interpreter,
-        shell: *mut ShellExecEnv,
+        shell: EnvRc,
         node: &ast::Pipeline,
         parent: NodeId,
         io: IO,
@@ -83,7 +85,8 @@ impl Pipeline {
     }
 
     pub(crate) fn next(interp: &Interpreter, this: NodeId) -> Yield {
-        match interp.as_pipeline(this).state {
+        let state = interp.as_pipeline(this).state;
+        match state {
             PipelineState::StartingCmds { idx } => Self::next_starting(interp, this, idx),
             PipelineState::Pending | PipelineState::WaitingWriteErr => Yield::suspended(),
             PipelineState::Done { exit_code } => {
@@ -128,9 +131,9 @@ impl Pipeline {
     fn setup_commands(interp: &Interpreter, this: NodeId) -> Option<Yield> {
         let (node, parent_shell, evtloop) = {
             let me = interp.as_pipeline(this);
-            (me.node, me.base.shell, interp.event_loop)
+            (me.node, Rc::clone(&me.base.shell), interp.event_loop)
         };
-        let items: &[ast::PipelineItem] = node.items;
+        let items: &[ast::PipelineItem] = node.get().items;
         let cmd_count = items
             .iter()
             .filter(|it| !matches!(it, ast::PipelineItem::Assigns(_)))
@@ -170,7 +173,6 @@ impl Pipeline {
             }
         }
 
-        let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
         let mut cmds: Vec<CmdOrResult> = Vec::with_capacity(cmd_count);
         for item in items {
             if matches!(item, ast::PipelineItem::Assigns(_)) {
@@ -185,7 +187,7 @@ impl Pipeline {
                     me.io.stdin.clone()
                 } else {
                     let r = IOReader::init(pipes[cmd_idx - 1][0], evtloop);
-                    r.set_interp(interp_ptr);
+                    r.set_interp(interp);
                     InKind::Fd(r)
                 };
                 let stdout = if cmd_idx == cmd_count - 1 {
@@ -202,7 +204,7 @@ impl Pipeline {
                         },
                         evtloop,
                     );
-                    w.set_interp(interp_ptr);
+                    w.set_interp(interp);
                     OutKind::Fd(crate::shell::io::OutFd {
                         writer: w,
                         captured: None,
@@ -216,12 +218,12 @@ impl Pipeline {
             };
 
             // Each pipeline child gets its own duped env (var assignments
-            // inside a pipeline must not leak to siblings or the parent).
-            // SAFETY: `parent_shell` is a live env owned by this pipeline's
-            // parent state.
-            let duped = match unsafe {
-                (*parent_shell).dupe_for_subshell(&child_io, ShellExecEnvKind::Pipeline)
-            } {
+            // inside a pipeline must not leak to siblings or the parent); it
+            // is dropped with the child node.
+            let duped = parent_shell
+                .borrow()
+                .dupe_for_subshell(&child_io, ShellExecEnvKind::Pipeline);
+            let duped = match duped {
                 Ok(d) => d,
                 Err(e) => {
                     // Close the pipe ends that neither `child_io` nor an inited child owns.
@@ -276,27 +278,24 @@ impl Pipeline {
         use std::io::Write as _;
         let mut buf = Vec::new();
         let _ = buf.write_fmt(args);
-        let stderr_fd = match &interp.as_pipeline(this).io.stderr {
-            OutKind::Fd(fd) => Some((std::sync::Arc::clone(&fd.writer), fd.captured)),
-            OutKind::Pipe | OutKind::Ignore => None,
-        };
-        if let Some((writer, captured)) = stderr_fd {
+        if interp.as_pipeline(this).io.stderr.needs_io().is_some() {
             // Only the fd arm transitions state.
             interp.as_pipeline_mut(this).state = PipelineState::WaitingWriteErr;
             let child = io_writer::ChildPtr::new(this, io_writer::WriterTag::Pipeline);
-            return writer.enqueue(child, captured, &buf);
+            // `OutKind::Fd` guaranteed by `needs_io()`.
+            let OutKind::Fd(fd) = interp.as_pipeline(this).io.stderr.clone() else {
+                unreachable!()
+            };
+            return fd.writer.enqueue(child, fd.captured, &buf);
         }
         if let OutKind::Pipe = &interp.as_pipeline(this).io.stderr {
-            // SAFETY: single trampoline frame; no other borrow of the env's
-            // (or its parent's) stderr buffer is live.
-            let stderr = unsafe {
-                interp
-                    .as_pipeline_mut(this)
-                    .base
-                    .shell_mut()
-                    .buffered_stderr_mut()
-            };
-            stderr.extend_from_slice(&buf);
+            interp
+                .as_pipeline(this)
+                .base
+                .shell()
+                .buffered_stderr
+                .borrow_mut()
+                .extend_from_slice(&buf);
         }
         Self::finish(interp, this, 1)
     }
@@ -332,7 +331,7 @@ impl Pipeline {
         );
         // Find the child in `cmds` and replace with its result.
         let (all_done, n) = {
-            let me = interp.as_pipeline_mut(this);
+            let mut me = interp.as_pipeline_mut(this);
             me.exited_count += 1;
             let n = me.cmds.as_ref().map(|c| c.len() as u32).unwrap_or(0);
             if let Some(cmds) = &mut me.cmds {
@@ -345,10 +344,7 @@ impl Pipeline {
             }
             (me.exited_count >= n && n > 0, n)
         };
-        // We duped a ShellExecEnv per child in `next_starting`. Cmd/If/CondExpr
-        // do NOT free `base.shell` in their own `deinit`, so free it here.
-        // Subshell frees its own; Assigns is skipped.
-        Self::deinit_child_duped_env(interp, child);
+        // The per-child env duped in `setup_commands` drops with the child.
         interp.deinit_node(child);
         if all_done {
             // Exit code = last command's exit code (bash semantics).
@@ -371,33 +367,14 @@ impl Pipeline {
         Yield::suspended()
     }
 
-    /// Free the per-child env duped in `next_starting` for child kinds that
-    /// don't free `base.shell` themselves.
-    fn deinit_child_duped_env(interp: &Interpreter, child: NodeId) {
-        let kind = interp.node(child).kind();
-        if matches!(
-            kind,
-            StateKind::Cmd | StateKind::IfClause | StateKind::Condexpr
-        ) {
-            if let Some(base) = interp.node_mut(child).base_mut() {
-                let shell = core::mem::replace(&mut base.shell, core::ptr::null_mut());
-                if !shell.is_null() {
-                    // SAFETY: `shell` is the duped env this pipeline child owned;
-                    // null-checked above and exclusively held here.
-                    ShellExecEnv::deinit_impl(shell);
-                }
-            }
-        }
-    }
-
     pub(crate) fn deinit(interp: &Interpreter, this: NodeId) {
         log!("Pipeline {} deinit", this);
-        // Only children that never started (setup failed) are still here.
+        // Only children that never started (setup failed) are still here;
+        // their duped envs and unclaimed pipe ends drop with them.
         let cmds = interp.as_pipeline_mut(this).cmds.take();
         if let Some(cmds) = cmds {
             for c in cmds.into_vec() {
                 if let CmdOrResult::Cmd(id) = c {
-                    Self::deinit_child_duped_env(interp, id);
                     interp.deinit_node(id);
                 }
             }

--- a/src/runtime/shell/states/Script.rs
+++ b/src/runtime/shell/states/Script.rs
@@ -3,18 +3,18 @@
 
 use crate::shell::ExitCode;
 use crate::shell::ast;
-use crate::shell::interpreter::{Interpreter, Node, NodeId, ShellExecEnv, StateKind, log};
+use crate::shell::interpreter::{EnvRc, Interpreter, Node, NodeId, log};
 use crate::shell::io::IO;
 use crate::shell::states::base::Base;
 use crate::shell::states::stmt::Stmt;
 use crate::shell::yield_::Yield;
+use std::rc::Rc;
 
 pub struct Script {
     pub(crate) base: Base,
-    /// Back-reference into the bumpalo-allocated AST (`ShellArgs::__arena`).
-    /// The arena outlives every state node (it's dropped only when the
-    /// interpreter is finalized), so the BackRef invariant holds. Stored
-    /// lifetime-erased to keep `Node` lifetime-free.
+    /// Back-reference into the parsed-script arena (`ShellArgs`). The arena
+    /// outlives every state node (it's reset/dropped only after they are all
+    /// freed), so the BackRef invariant holds.
     pub node: bun_ptr::BackRef<ast::Script>,
     pub(crate) io: IO,
     pub(crate) state: ScriptState,
@@ -31,21 +31,19 @@ impl Default for ScriptState {
 }
 
 impl Script {
+    /// `shell` is this script's env: the caller's own for the root script and
+    /// subshell bodies, a fresh dupe for command substitution (dropped with
+    /// the node).
     pub(crate) fn init(
         interp: &Interpreter,
-        shell: *mut ShellExecEnv,
-        node: *const ast::Script,
+        shell: EnvRc,
+        node: bun_ptr::BackRef<ast::Script>,
         parent: NodeId,
         io: IO,
     ) -> NodeId {
         let id = interp.alloc_node(Node::Script(Script {
             base: Base::new(parent, shell),
-            // SAFETY: `node` is non-null and points into the AST arena
-            // (`ShellArgs::__arena`), which the interpreter holds for its
-            // entire lifetime — strictly outliving every state node (the
-            // BackRef invariant). Callers pass `&raw const` only to escape
-            // borrowck across the `&Interpreter` reborrow.
-            node: unsafe { bun_ptr::BackRef::from_raw(node as *mut ast::Script) },
+            node,
             io,
             state: ScriptState::default(),
         }));
@@ -61,19 +59,18 @@ impl Script {
     }
 
     pub(crate) fn next(interp: &Interpreter, this: NodeId) -> Yield {
-        let (idx, shell) = {
-            let me = interp.as_script_mut(this);
-            let len = Self::stmt_count_of(me);
+        let (idx, shell, node, io) = {
+            let mut me = interp.as_script_mut(this);
+            let len = Self::stmt_count_of(&me);
             let ScriptState::Normal { idx } = &mut me.state;
             if *idx >= len {
                 return Yield::suspended();
             }
             let i = *idx;
             *idx += 1;
-            (i, me.base.shell)
+            (i, Rc::clone(&me.base.shell), me.node, me.io.clone())
         };
-        let stmt_node = Self::stmt_at(interp, this, idx);
-        let io = interp.as_script(this).io.clone();
+        let stmt_node = bun_ptr::BackRef::new(&node.get().stmts[idx]);
         let stmt = Stmt::init(interp, shell, stmt_node, this, io);
         Stmt::start(interp, stmt)
     }
@@ -93,7 +90,7 @@ impl Script {
         let (idx, len) = {
             let me = interp.as_script(this);
             let ScriptState::Normal { idx } = me.state;
-            (idx, Self::stmt_count_of(me))
+            (idx, Self::stmt_count_of(&me))
         };
         if idx >= len || interp.interrupted(this) {
             return Self::finish(interp, this, exit_code);
@@ -101,47 +98,22 @@ impl Script {
         Self::next(interp, this)
     }
 
-    pub(crate) fn deinit(interp: &Interpreter, this: NodeId) {
+    pub(crate) fn deinit(_interp: &Interpreter, this: NodeId) {
         log!("Script {} deinit", this);
-        let parent = interp.as_script(this).base.parent;
-        let parent_kind = if parent == NodeId::INTERPRETER {
-            None
-        } else {
-            Some(interp.node(parent).kind())
-        };
-        let me = interp.as_script_mut(this);
-        // io.deref() — IO uses Arc fields; Drop on the cloned `io` handles the
-        // refcount decrement, no explicit call needed.
-        if !matches!(parent_kind, None | Some(StateKind::Subshell)) {
-            // The shell env is owned by the parent when the parent is the
-            // Interpreter or a Subshell; otherwise this Script represents a
-            // command substitution which duped from the parent and must
-            // deinitialize it.
-            if !me.base.shell.is_null() {
-                // SAFETY: `me.base.shell` is the duped env this Script owned;
-                // null-checked and exclusively held here.
-                ShellExecEnv::deinit_impl(me.base.shell);
-                me.base.shell = core::ptr::null_mut();
-            }
-        }
-        // free_node is done by the caller (Interpreter::deinit_node).
+        // `io` and the env handle drop with the slot
+        // (`Interpreter::free_node`); a command-substitution env this Script
+        // owned is freed there.
     }
 
     // ── AST helpers ────────────────────────────────────────────────────────
 
     #[inline]
     fn stmt_count(interp: &Interpreter, this: NodeId) -> usize {
-        Self::stmt_count_of(interp.as_script(this))
+        Self::stmt_count_of(&interp.as_script(this))
     }
 
     #[inline]
     fn stmt_count_of(me: &Script) -> usize {
         me.node.stmts.len()
-    }
-
-    #[inline]
-    fn stmt_at(interp: &Interpreter, this: NodeId, idx: usize) -> *const ast::Stmt {
-        let me = interp.as_script(this);
-        &raw const me.node.stmts[idx]
     }
 }

--- a/src/runtime/shell/states/Script.rs
+++ b/src/runtime/shell/states/Script.rs
@@ -59,7 +59,7 @@ impl Script {
     }
 
     pub(crate) fn next(interp: &Interpreter, this: NodeId) -> Yield {
-        let (idx, shell, node, io) = {
+        let (idx, shell, node) = {
             let mut me = interp.as_script_mut(this);
             let len = Self::stmt_count_of(&me);
             let ScriptState::Normal { idx } = &mut me.state;
@@ -68,10 +68,10 @@ impl Script {
             }
             let i = *idx;
             *idx += 1;
-            (i, Rc::clone(&me.base.shell), me.node, me.io.clone())
+            (i, Rc::clone(&me.base.shell), me.node)
         };
         let stmt_node = bun_ptr::BackRef::new(&node.get().stmts[idx]);
-        let stmt = Stmt::init(interp, shell, stmt_node, this, io);
+        let stmt = Stmt::init(interp, shell, stmt_node, this);
         Stmt::start(interp, stmt)
     }
 

--- a/src/runtime/shell/states/Stmt.rs
+++ b/src/runtime/shell/states/Stmt.rs
@@ -1,7 +1,6 @@
 use crate::shell::ExitCode;
 use crate::shell::ast;
 use crate::shell::interpreter::{EnvRc, Interpreter, Node, NodeId, StateKind, log};
-use crate::shell::io::IO;
 use crate::shell::states::base::Base;
 use crate::shell::yield_::Yield;
 use std::rc::Rc;
@@ -12,16 +11,17 @@ pub struct Stmt {
     pub(crate) idx: usize,
     pub(crate) last_exit_code: Option<ExitCode>,
     pub(crate) currently_executing: Option<NodeId>,
-    pub(crate) io: IO,
 }
 
 impl Stmt {
+    /// A statement runs its children with its parent's (`Script`/`If`) env
+    /// and IO, so it stores neither an IO of its own nor a separate env
+    /// handle beyond `base.shell`.
     pub(crate) fn init(
         interp: &Interpreter,
         shell: EnvRc,
         node: bun_ptr::BackRef<ast::Stmt>,
         parent: NodeId,
-        io: IO,
     ) -> NodeId {
         let id = interp.alloc_node(Node::Stmt(Stmt {
             base: Base::new(parent, shell),
@@ -29,7 +29,6 @@ impl Stmt {
             idx: 0,
             last_exit_code: None,
             currently_executing: None,
-            io,
         }));
         log!("Stmt {} init", id);
         id
@@ -44,21 +43,20 @@ impl Stmt {
     }
 
     pub(crate) fn next(interp: &Interpreter, this: NodeId) -> Yield {
-        let (idx, len, parent, last, shell, node, io) = {
+        let (idx, shell, node, io) = {
             let me = interp.as_stmt(this);
+            if me.idx >= Self::expr_count(&me) {
+                let (parent, last) = (me.base.parent, me.last_exit_code);
+                drop(me);
+                return interp.child_done(parent, this, last.unwrap_or(0));
+            }
             (
                 me.idx,
-                Self::expr_count(&me),
-                me.base.parent,
-                me.last_exit_code,
                 Rc::clone(&me.base.shell),
                 me.node,
-                me.io.clone(),
+                interp.io_of(me.base.parent),
             )
         };
-        if idx >= len {
-            return interp.child_done(parent, this, last.unwrap_or(0));
-        }
         let expr = &node.get().exprs[idx];
         let (child, y) = interp.spawn_expr(&shell, expr, this, io);
         interp.as_stmt_mut(this).currently_executing = child;

--- a/src/runtime/shell/states/Stmt.rs
+++ b/src/runtime/shell/states/Stmt.rs
@@ -1,9 +1,10 @@
 use crate::shell::ExitCode;
 use crate::shell::ast;
-use crate::shell::interpreter::{Interpreter, Node, NodeId, ShellExecEnv, StateKind, log};
+use crate::shell::interpreter::{EnvRc, Interpreter, Node, NodeId, StateKind, log};
 use crate::shell::io::IO;
 use crate::shell::states::base::Base;
 use crate::shell::yield_::Yield;
+use std::rc::Rc;
 
 pub struct Stmt {
     pub(crate) base: Base,
@@ -17,19 +18,14 @@ pub struct Stmt {
 impl Stmt {
     pub(crate) fn init(
         interp: &Interpreter,
-        shell: *mut ShellExecEnv,
-        node: *const ast::Stmt,
+        shell: EnvRc,
+        node: bun_ptr::BackRef<ast::Stmt>,
         parent: NodeId,
         io: IO,
     ) -> NodeId {
         let id = interp.alloc_node(Node::Stmt(Stmt {
             base: Base::new(parent, shell),
-            // SAFETY: `node` is non-null and points into the AST arena
-            // (`ShellArgs::__arena`), which the interpreter holds for its
-            // entire lifetime — strictly outliving every state node (the
-            // BackRef invariant). Callers pass `&raw const` only to escape
-            // borrowck across the `&Interpreter` reborrow.
-            node: unsafe { bun_ptr::BackRef::from_raw(node as *mut ast::Stmt) },
+            node,
             idx: 0,
             last_exit_code: None,
             currently_executing: None,
@@ -48,22 +44,23 @@ impl Stmt {
     }
 
     pub(crate) fn next(interp: &Interpreter, this: NodeId) -> Yield {
-        let (idx, len, parent, last, shell) = {
+        let (idx, len, parent, last, shell, node, io) = {
             let me = interp.as_stmt(this);
             (
                 me.idx,
-                Self::expr_count(me),
+                Self::expr_count(&me),
                 me.base.parent,
                 me.last_exit_code,
-                me.base.shell,
+                Rc::clone(&me.base.shell),
+                me.node,
+                me.io.clone(),
             )
         };
         if idx >= len {
             return interp.child_done(parent, this, last.unwrap_or(0));
         }
-        let expr: ast::Expr = interp.as_stmt(this).node.exprs[idx];
-        let io = interp.as_stmt(this).io.clone();
-        let (child, y) = interp.spawn_expr(shell, &expr, this, io);
+        let expr = &node.get().exprs[idx];
+        let (child, y) = interp.spawn_expr(&shell, expr, this, io);
         interp.as_stmt_mut(this).currently_executing = child;
         y
     }
@@ -76,19 +73,19 @@ impl Stmt {
     ) -> Yield {
         log!("Stmt {} childDone exit={}", this, exit_code);
         {
-            let me = interp.as_stmt_mut(this);
+            let mut me = interp.as_stmt_mut(this);
             me.last_exit_code = Some(exit_code);
             me.idx += 1;
             me.currently_executing = None;
         }
         // Async children are *not* freed here (they outlive their parent's
         // notion of "done"); see `Async`'s empty `deinit`.
-        if !matches!(interp.node(child).kind(), StateKind::Async) {
+        if !matches!(interp.kind(child), StateKind::Async) {
             interp.deinit_node(child);
         }
         if interp.interrupted(this) {
-            let me = interp.as_stmt_mut(this);
-            me.idx = Self::expr_count(me);
+            let mut me = interp.as_stmt_mut(this);
+            me.idx = Self::expr_count(&me);
         }
         Yield::Next(this)
     }

--- a/src/runtime/shell/states/Subshell.rs
+++ b/src/runtime/shell/states/Subshell.rs
@@ -1,10 +1,11 @@
 use crate::shell::ExitCode;
 use crate::shell::ast;
-use crate::shell::interpreter::{Interpreter, Node, NodeId, ShellExecEnv, ShellExecEnvKind, log};
+use crate::shell::interpreter::{EnvRc, Interpreter, Node, NodeId, ShellExecEnvKind, log};
 use crate::shell::io::IO;
 use crate::shell::states::base::Base;
 use crate::shell::states::script::Script;
 use crate::shell::yield_::Yield;
+use std::rc::Rc;
 
 pub struct Subshell {
     pub(crate) base: Base,
@@ -14,7 +15,7 @@ pub struct Subshell {
     pub(crate) exit_code: ExitCode,
 }
 
-#[derive(Default, strum::IntoStaticStr)]
+#[derive(Default, Clone, Copy, strum::IntoStaticStr)]
 pub enum SubshellState {
     #[default]
     Idle,
@@ -25,10 +26,10 @@ pub enum SubshellState {
 impl Subshell {
     /// `shell` must already be a duped env owned by this node (see
     /// `init_dupe_shell_state` for the Stmt/Binary path; Pipeline dupes the
-    /// env itself before calling this). `Subshell::deinit` frees it.
+    /// env itself before calling this). It is dropped with the node.
     pub(crate) fn init(
         interp: &Interpreter,
-        shell: *mut ShellExecEnv,
+        shell: EnvRc,
         node: &ast::Subshell,
         parent: NodeId,
         io: IO,
@@ -45,24 +46,16 @@ impl Subshell {
     /// Dupe the parent env and `init`.
     /// Called by Stmt/Binary via `Interpreter::spawn_expr`. Pipeline does
     /// NOT use this (it dupes per-child itself and calls `init` directly).
-    ///
-    /// # Safety
-    /// `parent_shell` must point to a live `ShellExecEnv` owned by the parent
-    /// state for the duration of this call.
-    // Caller (Interpreter::spawn_expr) holds the parent env as a raw pointer;
-    // the safety contract is documented above and at the call site.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub(crate) fn init_dupe_shell_state(
         interp: &Interpreter,
-        parent_shell: *mut ShellExecEnv,
+        parent_shell: &EnvRc,
         node: &ast::Subshell,
         parent: NodeId,
         io: IO,
     ) -> bun_sys::Result<NodeId> {
-        // SAFETY: caller guarantees `parent_shell` points to a live
-        // `ShellExecEnv` owned by the parent state for the duration of this
-        // call (see `# Safety` above).
-        let duped = unsafe { (*parent_shell).dupe_for_subshell(&io, ShellExecEnvKind::Subshell) }?;
+        let duped = parent_shell
+            .borrow()
+            .dupe_for_subshell(&io, ShellExecEnvKind::Subshell)?;
         Ok(Self::init(interp, duped, node, parent, io))
     }
 
@@ -71,12 +64,16 @@ impl Subshell {
     }
 
     pub(crate) fn next(interp: &Interpreter, this: NodeId) -> Yield {
-        let (state_tag, parent) = {
+        let (state, parent) = {
             let me = interp.as_subshell(this);
-            (<&'static str>::from(&me.state), me.base.parent)
+            (me.state, me.base.parent)
         };
-        log!("Subshell {} next state={}", this, state_tag);
-        match interp.as_subshell(this).state {
+        log!(
+            "Subshell {} next state={}",
+            this,
+            <&'static str>::from(&state)
+        );
+        match state {
             SubshellState::Idle => {
                 // Spawn Script directly with
                 // `this.base.shell`. The env was already duped at construction
@@ -84,9 +81,9 @@ impl Subshell {
                 // again here.
                 let (shell, io, node) = {
                     let me = interp.as_subshell(this);
-                    (me.base.shell, me.io.clone(), me.node)
+                    (Rc::clone(&me.base.shell), me.io.clone(), me.node)
                 };
-                let script_node: *const ast::Script = &raw const node.get().script;
+                let script_node = bun_ptr::BackRef::new(&node.get().script);
                 interp.as_subshell_mut(this).state = SubshellState::Exec;
                 // `node.redirect` is always `None` here: the parser rejects
                 // subshells with redirections ("Subshells with redirections
@@ -110,23 +107,15 @@ impl Subshell {
     ) -> Yield {
         interp.deinit_node(child);
         {
-            let me = interp.as_subshell_mut(this);
+            let mut me = interp.as_subshell_mut(this);
             me.exit_code = exit_code;
             me.state = SubshellState::Done;
         }
         Yield::Next(this)
     }
 
-    pub(crate) fn deinit(interp: &Interpreter, this: NodeId) {
+    pub(crate) fn deinit(_interp: &Interpreter, this: NodeId) {
         log!("Subshell {} deinit", this);
-        let me = interp.as_subshell_mut(this);
-        // The env was duped at construction (either by Pipeline or by
-        // `init_dupe_shell_state`) — Subshell always owns it.
-        if !me.base.shell.is_null() {
-            // SAFETY: `me.base.shell` is the duped env this Subshell owned;
-            // null-checked and exclusively held here.
-            ShellExecEnv::deinit_impl(me.base.shell);
-            me.base.shell = core::ptr::null_mut();
-        }
+        // The duped env drops with the slot (`Interpreter::free_node`).
     }
 }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1,5 +1,4 @@
 use core::cell::Cell;
-use std::sync::Arc;
 
 #[cfg(unix)]
 use crate::api::bun::process::SpawnResultExt as _;
@@ -9,8 +8,8 @@ use crate::api::bun::process::{
 #[cfg(windows)]
 use crate::api::bun::process::{WindowsOptions, WindowsStdioResult};
 use crate::api::bun::subprocess as JscSubprocess;
-use crate::shell::interpreter::{Interpreter, NodeId};
-use crate::shell::io_writer::{self, IOWriter};
+use crate::shell::interpreter::{ExitCode, Interpreter, NodeId};
+use crate::shell::io_writer::{self, IOWriterRef};
 use crate::shell::states::cmd::Cmd as ShellCmd;
 use crate::shell::{self as sh, Yield};
 use crate::webcore::{self, FileSink};
@@ -61,13 +60,13 @@ bun_output::define_scoped_log!(log, SHELL_SUBPROC, visible);
 /// Used for captured writer
 #[derive(Default)]
 pub struct ShellIO {
-    pub(crate) stdout: Option<Arc<IOWriter>>,
-    pub(crate) stderr: Option<Arc<IOWriter>>,
+    pub(crate) stdout: Option<IOWriterRef>,
+    pub(crate) stderr: Option<IOWriterRef>,
 }
 
-// Note: with `Arc<IOWriter>` the only correct way to
-// retain is to *clone the Arc and keep it*; a freestanding `ref()` that
-// discards the clone is a no-op. Callers hold their own `Arc` clones and
+// Note: with `Rc<IOWriter>` the only correct way to
+// retain is to *clone the Rc and keep it*; a freestanding `ref()` that
+// discards the clone is a no-op. Callers hold their own `Rc` clones and
 // `ShellIO`'s `Drop` releases them — no explicit ref/deref methods.
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -80,12 +79,10 @@ pub(crate) const DEFAULT_MAX_BUFFER_SIZE: u32 = 1024 * 1024 * 4;
 
 /// Backref from a heap-allocated [`ShellSubprocess`] to its owning `Cmd`.
 /// Spec stores `cmd_parent: *ShellCmd` directly. In the NodeId-arena port the
-/// `Cmd` lives **inline** in `Interpreter::nodes: Vec<Node>`, so a raw `*mut
-/// Cmd` taken at spawn time dangles the moment a later `alloc_node` grows the
-/// `Vec` (long pipelines hit this — every piped command pushes new Expansion /
-/// Cmd nodes while earlier subprocesses' PipeReaders are still registered in
-/// epoll). Store `(interp, NodeId)` instead and resolve through the arena at
-/// each use site.
+/// `Cmd` lives in `Interpreter::nodes`, so store `(interp, NodeId)` and resolve
+/// through the arena at each use site. `id` indexes a `Node::Cmd` slot for
+/// every caller: the subprocess / PipeReader callbacks fire strictly before
+/// `Cmd::deinit` recycles it.
 #[derive(Clone, Copy)]
 pub struct CmdHandle {
     pub(crate) interp: ParentRef<Interpreter>,
@@ -93,13 +90,21 @@ pub struct CmdHandle {
 }
 
 impl CmdHandle {
-    /// Resolve to the live `Cmd` slot. Single-threaded; the caller must not
-    /// hold the result across a call that re-enters the interpreter. `id`
-    /// indexes a `Node::Cmd` slot for every caller: the subprocess /
-    /// PipeReader callbacks fire strictly before `Cmd::deinit` recycles it.
     #[inline]
-    pub(crate) fn cmd_mut(&self) -> &mut ShellCmd {
-        self.interp.get().as_cmd_mut(self.id)
+    fn buffered_input_close(&self) -> Yield {
+        ShellCmd::buffered_input_close(&self.interp, self.id)
+    }
+
+    #[inline]
+    fn buffered_output_close(&self, kind: OutKind, err: Option<SystemError>) -> Yield {
+        ShellCmd::buffered_output_close(&self.interp, self.id, kind, err)
+    }
+
+    #[inline]
+    fn on_exit(&self, exit_code: ExitCode, interrupted: bool) -> Yield {
+        let interp = self.interp.get();
+        interp.as_cmd_mut(self.id).base.interrupted |= interrupted;
+        ShellCmd::on_exit(interp, self.id, exit_code)
     }
 }
 
@@ -174,10 +179,10 @@ impl ShellSubprocess {
             this.as_ptr() as usize,
             handle.id
         );
-        // No borrow of `this` is live past this point; the `&mut Cmd` ends
-        // before the Yield runs, which may free `this`.
-        let y = handle.cmd_mut().buffered_input_close();
-        y.run(handle.interp.get());
+        // No borrow of `this` or the Cmd is live here; the Yield may free `this`.
+        handle
+            .buffered_input_close()
+            .run(handle.interp.get());
     }
 
     pub(crate) fn has_exited(&self) -> bool {
@@ -678,12 +683,10 @@ impl ShellSubprocess {
 
         let Some(code) = exit_code else { return };
         let handle = this.cmd_parent;
-        // No borrow of `this` is live past this point; the `&mut Cmd` ends
-        // before the Yield runs, which may free `this`.
-        let cmd = handle.cmd_mut();
-        cmd.base.interrupted |= interrupted;
-        let y = cmd.on_exit(code.into());
-        y.run(handle.interp.get());
+        // No borrow of `this` or the Cmd is live here; the Yield may free `this`.
+        handle
+            .on_exit(code.into(), interrupted)
+            .run(handle.interp.get());
     }
 }
 
@@ -771,7 +774,7 @@ impl Writable {
                 Stdio::Memfd(_) | Stdio::Path(_) | Stdio::Ignore => {
                     return Ok(Writable::Ignore);
                 }
-                Stdio::Ipc | Stdio::Capture(_) => {
+                Stdio::Ipc | Stdio::Capture => {
                     return Ok(Writable::Ignore);
                 }
                 Stdio::SocketFd => {
@@ -813,7 +816,7 @@ impl Writable {
                 Stdio::Fd(_) => Ok(Writable::Fd(result.unwrap())),
                 Stdio::Inherit => Ok(Writable::Inherit),
                 Stdio::Path(_) | Stdio::Ignore => Ok(Writable::Ignore),
-                Stdio::Ipc | Stdio::Capture(_) => Ok(Writable::Ignore),
+                Stdio::Ipc | Stdio::Capture => Ok(Writable::Ignore),
                 Stdio::ReadableStream(_) => {
                     // The shell never uses this
                     panic!("Unimplemented stdin readable_stream");
@@ -900,7 +903,7 @@ impl Readable {
         out_type: OutKind,
         stdio: Stdio,
         redirect_buf: Option<jsc::PinnedArrayBuffer>,
-        shellio: Option<Arc<IOWriter>>,
+        shellio: Option<IOWriterRef>,
         event_loop: EventLoopHandle,
         process: ThisPtr<ShellSubprocess>,
         result: StdioResult,
@@ -910,7 +913,7 @@ impl Readable {
     ) -> Readable {
         assert_stdio_result!(result);
 
-        debug_assert!(redirect_buf.is_none() || matches!(stdio, Stdio::Pipe | Stdio::Capture(_)));
+        debug_assert!(redirect_buf.is_none() || matches!(stdio, Stdio::Pipe | Stdio::Capture));
         let buffered_output = match redirect_buf {
             Some(buf) => BufferedOutput::ArrayBuffer { buf, i: 0 },
             None => BufferedOutput::default(),
@@ -937,7 +940,7 @@ impl Readable {
                     out_type,
                     interp,
                 )),
-                Stdio::Capture(_) => Readable::Pipe(PipeReader::create(
+                Stdio::Capture => Readable::Pipe(PipeReader::create(
                     event_loop,
                     process,
                     result,
@@ -980,7 +983,7 @@ impl Readable {
                     out_type,
                     interp,
                 )),
-                Stdio::Capture(_) => Readable::Pipe(PipeReader::create(
+                Stdio::Capture => Readable::Pipe(PipeReader::create(
                     event_loop,
                     process,
                     result,
@@ -1003,7 +1006,7 @@ impl Readable {
                 fd.close();
             }
             // .fd is borrowed from the shell's IOWriter (see IO.OutKind.to_subproc_stdio) or
-            // a CowFd redirect; the owner closes it.
+            // the Cmd's redirect fd; the owner closes it.
             Readable::Fd(_) => {
                 *self = Readable::Closed;
             }
@@ -1213,7 +1216,7 @@ impl BufferedOutput {
 pub struct CapturedWriter {
     pub(crate) dead: Cell<bool>,
     /// `None` iff `dead == true`.
-    pub(crate) writer: JsCell<Option<Arc<IOWriter>>>,
+    pub(crate) writer: JsCell<Option<IOWriterRef>>,
     pub(crate) written: Cell<usize>,
     pub(crate) err: JsCell<Option<SystemError>>,
 }
@@ -1233,7 +1236,7 @@ impl PipeReader {
     /// The `IOWriter` child handle for this reader's captured-output tee.
     #[inline]
     pub(crate) fn captured_child_ptr(this: ThisPtr<Self>) -> io_writer::ChildPtr {
-        io_writer::ChildPtr::subproc_capture(this.as_ptr().cast())
+        io_writer::ChildPtr::subproc_capture(this)
     }
 
     fn captured_do_write(this: ThisPtr<Self>, chunk: &[u8]) {
@@ -1369,14 +1372,14 @@ impl PipeReader {
         event_loop: EventLoopHandle,
         process: ThisPtr<ShellSubprocess>,
         result: StdioResult,
-        capture: Option<Arc<IOWriter>>,
+        capture: Option<IOWriterRef>,
         buffered_output: BufferedOutput,
         out_type: OutKind,
         interp: Option<ParentRef<Interpreter>>,
     ) -> RefPtr<PipeReader> {
         let captured_writer = CapturedWriter::default();
         if let Some(cap) = capture {
-            captured_writer.writer.set(Some(cap)); // dupeRef → Arc clone already happened on pass-in
+            captured_writer.writer.set(Some(cap)); // dupeRef → Rc clone already happened on pass-in
             captured_writer.dead.set(false);
         }
 
@@ -1575,10 +1578,10 @@ impl PipeReader {
         if let Some(proc) = process {
             let e: Option<SystemError> = this.take_captured_error();
             // `proc` is the `ShellSubprocess` freed only by `Cmd::deinit`,
-            // which runs strictly after every PipeReader has signalled done.
-            // `cmd_mut` resolves through the node arena (see `CmdHandle`).
+            // which runs strictly after every PipeReader has signalled done
+            // (see `CmdHandle`).
             let handle = proc.cmd_parent;
-            return handle.cmd_mut().buffered_output_close(out_type, e);
+            return handle.buffered_output_close(out_type, e);
         }
         Yield::Suspended
     }
@@ -1726,7 +1729,7 @@ impl Drop for PipeReader {
 
         // PipeReaderState::Done(Box<[u8]>) drops its buffer automatically.
 
-        // CapturedWriter's fields drop the err and writer Arc.
+        // CapturedWriter's fields drop the err and writer Rc.
 
         self.state.with_mut(|s| {
             if let PipeReaderState::Err(slot) = s {

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -9,7 +9,7 @@ use crate::api::bun::process::{
 use crate::api::bun::process::{WindowsOptions, WindowsStdioResult};
 use crate::api::bun::subprocess as JscSubprocess;
 use crate::shell::interpreter::{ExitCode, Interpreter, NodeId};
-use crate::shell::io_writer::{self, IOWriterRef};
+use crate::shell::io_writer::{self, IOWriter};
 use crate::shell::states::cmd::Cmd as ShellCmd;
 use crate::shell::{self as sh, Yield};
 use crate::webcore::{self, FileSink};
@@ -60,8 +60,8 @@ bun_output::define_scoped_log!(log, SHELL_SUBPROC, visible);
 /// Used for captured writer
 #[derive(Default)]
 pub struct ShellIO {
-    pub(crate) stdout: Option<IOWriterRef>,
-    pub(crate) stderr: Option<IOWriterRef>,
+    pub(crate) stdout: Option<RefPtr<IOWriter>>,
+    pub(crate) stderr: Option<RefPtr<IOWriter>>,
 }
 
 // Note: with `Rc<IOWriter>` the only correct way to
@@ -903,7 +903,7 @@ impl Readable {
         out_type: OutKind,
         stdio: Stdio,
         redirect_buf: Option<jsc::PinnedArrayBuffer>,
-        shellio: Option<IOWriterRef>,
+        shellio: Option<RefPtr<IOWriter>>,
         event_loop: EventLoopHandle,
         process: ThisPtr<ShellSubprocess>,
         result: StdioResult,
@@ -1216,7 +1216,7 @@ impl BufferedOutput {
 pub struct CapturedWriter {
     pub(crate) dead: Cell<bool>,
     /// `None` iff `dead == true`.
-    pub(crate) writer: JsCell<Option<IOWriterRef>>,
+    pub(crate) writer: JsCell<Option<RefPtr<IOWriter>>>,
     pub(crate) written: Cell<usize>,
     pub(crate) err: JsCell<Option<SystemError>>,
 }
@@ -1372,7 +1372,7 @@ impl PipeReader {
         event_loop: EventLoopHandle,
         process: ThisPtr<ShellSubprocess>,
         result: StdioResult,
-        capture: Option<IOWriterRef>,
+        capture: Option<RefPtr<IOWriter>>,
         buffered_output: BufferedOutput,
         out_type: OutKind,
         interp: Option<ParentRef<Interpreter>>,

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -180,9 +180,7 @@ impl ShellSubprocess {
             handle.id
         );
         // No borrow of `this` or the Cmd is live here; the Yield may free `this`.
-        handle
-            .buffered_input_close()
-            .run(handle.interp.get());
+        handle.buffered_input_close().run(handle.interp.get());
     }
 
     pub(crate) fn has_exited(&self) -> bool {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -664,18 +664,20 @@ impl Value {
     /// cannot be used. Instead, try both wrapper classes and return the inner
     /// body pointer.
     ///
-    /// Returns a raw pointer; the storage is owned
-    /// by the JSC heap cell and outlives the call only as long as `value` is
-    /// kept alive by the caller.
-    pub(crate) fn from_request_or_response(value: JSValue) -> Option<*mut Value> {
+    /// The storage is owned by the JSC heap cell; `f` gets it for the call
+    /// only (see `Request::get_body_value`).
+    pub(crate) fn with_request_or_response<R>(
+        value: JSValue,
+        f: impl FnOnce(&mut Value) -> R,
+    ) -> Option<R> {
         if value.is_empty_or_undefined_or_null() {
             return None;
         }
         if let Some(req) = value.as_class_ref::<crate::webcore::Request>() {
-            return Some(std::ptr::from_mut::<Value>(req.get_body_value()));
+            return Some(f(req.get_body_value()));
         }
         if let Some(res) = value.as_class_ref::<crate::webcore::Response>() {
-            return Some(std::ptr::from_mut::<Value>(res.get_body_value()));
+            return Some(f(res.get_body_value()));
         }
         None
     }

--- a/src/shell_parser/Cargo.toml
+++ b/src/shell_parser/Cargo.toml
@@ -18,3 +18,4 @@ smallvec.workspace = true
 thiserror.workspace = true
 bun_alloc.workspace = true
 bun_core.workspace = true
+bun_ptr.workspace = true

--- a/src/shell_parser/lib.rs
+++ b/src/shell_parser/lib.rs
@@ -19,6 +19,6 @@ pub mod parse;
 pub mod json_fmt;
 
 pub use parse::{
-    JSValueRaw, LexResult, LexerError, ParseError, Parser, ast, escape_8bit, escape_bun_str,
-    needs_escape_bunstr, needs_escape_utf8_ascii_latin1,
+    LexResult, LexerError, ParseError, ParseFailure, ParsedScript, Parser, ast, escape_8bit,
+    escape_bun_str, needs_escape_bunstr, needs_escape_utf8_ascii_latin1,
 };

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -15,16 +15,6 @@ use bun_core::{String as BunString, strings};
 // `strings::Cursor` aliased as `CodepointCursor` for readability.
 type CodepointCursor = strings::Cursor;
 
-/// Opaque stand-in for `bun_jsc::JSValue` — the parser only *stores* the
-/// jsobjs slice (never inspects it), so the lower-tier crate can stay
-/// JSC-free. `bun_jsc::JSValue` is `#[repr(transparent)] usize`, so callers
-/// in `bun_runtime` may safely reinterpret `&mut [JSValue]` ↔ `&mut [JSValueRaw]`
-/// via a typed pointer cast.
-#[repr(transparent)]
-#[derive(Clone, Copy)]
-pub struct JSValueRaw(pub usize);
-type JSValue = JSValueRaw;
-
 bun_core::define_scoped_log!(log, SHELL, hidden);
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr, Clone, Copy, PartialEq, Eq)]
@@ -50,6 +40,108 @@ impl From<ParseError> for crate::Error {
             ParseError::Unknown => crate::Error::Unknown,
             ParseError::Lex => crate::Error::Lex,
         }
+    }
+}
+
+// ───────────────────────────── ParsedScript ─────────────────────────────
+
+/// Why [`ParsedScript::parse`] failed.
+pub enum ParseFailure {
+    /// The lexer or parser reported errors; the payload is their combined
+    /// message.
+    Diagnostic(Box<[u8]>),
+    Lexer(LexerError),
+    Other(crate::Error),
+}
+
+/// A parsed script together with the arena every AST node lives in.
+///
+/// The tree is stored with its arena lifetime erased (`ast::Script<'static>`)
+/// because it sits next to the arena that owns it. [`root`](Self::root) lends
+/// it for the borrow of `self`; [`root_backref`](Self::root_backref) hands out
+/// the erased form under the `bun_ptr::BackRef` obligation: every `ast::*`
+/// reached through it points into `self` and is valid until `self` is
+/// [`reset`](Self::reset), moved or dropped — the holder must not outlive that.
+pub struct ParsedScript {
+    arena: Bump,
+    root: ast::Script<'static>,
+}
+
+impl Default for ParsedScript {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ParsedScript {
+    pub fn new() -> Self {
+        Self {
+            arena: Bump::new(),
+            root: ast::Script { stmts: &[] },
+        }
+    }
+
+    /// Lex and parse `src` into this arena, replacing any previous tree.
+    /// `jsstrings_to_escape` are the interpolated JS strings the lexer
+    /// splices in; `jsobjs_len` bounds `\x08__bun_N` object references.
+    pub fn parse(
+        &mut self,
+        src: &[u8],
+        jsstrings_to_escape: &[BunString],
+        jsobjs_len: u32,
+    ) -> Result<(), ParseFailure> {
+        self.root = ast::Script { stmts: &[] };
+        let arena = &self.arena;
+        let lex_result = if bun_core::is_all_ascii(src) {
+            let mut lexer = LexerAscii::new(arena, src, jsstrings_to_escape, jsobjs_len);
+            lexer.lex().map_err(ParseFailure::Lexer)?;
+            lexer.get_result()
+        } else {
+            let mut lexer = LexerUnicode::new(arena, src, jsstrings_to_escape, jsobjs_len);
+            lexer.lex().map_err(ParseFailure::Lexer)?;
+            lexer.get_result()
+        };
+        if !lex_result.errors.is_empty() {
+            return Err(ParseFailure::Diagnostic(
+                lex_result.combine_errors(arena).into(),
+            ));
+        }
+        let mut parser = Parser::new(arena, lex_result);
+        let root = match parser.parse() {
+            Ok(root) => root,
+            Err(e) if parser.errors.is_empty() => return Err(ParseFailure::Other(e)),
+            Err(_) => return Err(ParseFailure::Diagnostic(parser.combine_errors().into())),
+        };
+        // SAFETY: lifetime-only transmute (`Script<'_>` → `Script<'static>`).
+        // Every node `root` reaches was allocated in `self.arena`, which lives
+        // exactly as long as `self.root` and is only reset together with it
+        // (`reset`/`parse` clear `root` first); see the type-level contract.
+        self.root = unsafe { core::mem::transmute::<ast::Script<'_>, ast::Script<'static>>(root) };
+        Ok(())
+    }
+
+    /// The root of the tree, for the borrow of `self`.
+    #[inline]
+    pub fn root(&self) -> &ast::Script<'_> {
+        &self.root
+    }
+
+    /// The root with the arena lifetime erased; see the type docs for the
+    /// holder's obligation.
+    #[inline]
+    pub fn root_backref(&self) -> bun_ptr::BackRef<ast::Script<'static>> {
+        bun_ptr::BackRef::new(&self.root)
+    }
+
+    /// Free every node and return the arena's pages. The tree is empty
+    /// afterwards.
+    pub fn reset(&mut self) {
+        self.root = ast::Script { stmts: &[] };
+        self.arena.reset();
+    }
+
+    pub fn memory_cost(&self) -> usize {
+        core::mem::size_of::<Self>() + self.arena.allocated_bytes()
     }
 }
 
@@ -715,7 +807,6 @@ pub struct Parser<'bump> {
     /// refs). See `Lexer::js_string_ranges`.
     pub(crate) js_string_ranges: &'bump [TextRange],
     pub(crate) alloc: &'bump Bump,
-    pub(crate) jsobjs: &'bump mut [JSValue],
     pub(crate) current: u32,
     pub errors: bun_alloc::ArenaVec<'bump, ParserError<'bump>>,
     pub(crate) inside_subshell: Option<SubshellKind>,
@@ -744,21 +835,16 @@ pub struct ParserError<'bump> {
 type ParseResult<T> = crate::Result<T>;
 
 impl<'bump> Parser<'bump> {
-    pub fn new(
-        bump: &'bump Bump,
-        lex_result: LexResult<'bump>,
-        jsobjs: &'bump mut [JSValue],
-    ) -> ParseResult<Parser<'bump>> {
-        Ok(Parser {
+    pub fn new(bump: &'bump Bump, lex_result: LexResult<'bump>) -> Parser<'bump> {
+        Parser {
             strpool: lex_result.strpool,
             tokens: lex_result.tokens,
             js_string_ranges: lex_result.js_string_ranges,
             alloc: bump,
-            jsobjs,
             current: 0,
             errors: bun_alloc::ArenaVec::new_in(bump),
             inside_subshell: None,
-        })
+        }
     }
 
     /// __WARNING__:
@@ -772,9 +858,6 @@ impl<'bump> Parser<'bump> {
             tokens: self.tokens,
             js_string_ranges: self.js_string_ranges,
             alloc: self.alloc,
-            // reshaped for borrowck — move the
-            // exclusive borrow into the subparser and restore it in continue_from_subparser.
-            jsobjs: core::mem::take(&mut self.jsobjs),
             current: self.current,
             errors: core::mem::replace(&mut self.errors, bun_alloc::ArenaVec::new_in(self.alloc)),
             inside_subshell: Some(kind),
@@ -791,7 +874,6 @@ impl<'bump> Parser<'bump> {
             &mut subparser.errors,
             bun_alloc::ArenaVec::new_in(self.alloc),
         );
-        self.jsobjs = core::mem::take(&mut subparser.jsobjs);
     }
 
     /// Main parse function

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -82,13 +82,13 @@ macro_rules! intrusive_work_task {
     // Generic/lifetime form. The leading `[..]` disambiguates from the
     // plain-type arm so the `:ty` fragment below never sees a `<const ..>`
     // and hard-errors.
-    ([$($gen:tt)*] $ty:ty, $field:ident) => {
-        ::bun_core::intrusive_field!([$($gen)*] $ty, $field: $crate::work_pool::Task);
+    ([$($gen:tt)*] $ty:ty, $($field:ident).+) => {
+        ::bun_core::intrusive_field!([$($gen)*] $ty, $($field).+: $crate::work_pool::Task);
         // SAFETY: `IntrusiveField<Task>` impl above supplies the offset/field.
         unsafe impl<$($gen)*> $crate::work_pool::IntrusiveWorkTask for $ty {}
     };
-    ($ty:ty, $field:ident) => {
-        ::bun_core::intrusive_field!($ty, $field: $crate::work_pool::Task);
+    ($ty:ty, $($field:ident).+) => {
+        ::bun_core::intrusive_field!($ty, $($field).+: $crate::work_pool::Task);
         // SAFETY: `IntrusiveField<Task>` impl above supplies the offset/field.
         unsafe impl $crate::work_pool::IntrusiveWorkTask for $ty {}
     };
@@ -106,28 +106,34 @@ macro_rules! intrusive_work_task {
 /// safety obligation
 /// ("all fields are sound to move across threads") is restated once here
 /// rather than at every `WorkPool::schedule(addr_of_mut!((*p).task))` site.
+///
+/// `run = path` names the worker-thread body explicitly (a `fn(Box<Self>)`)
+/// instead of the inherent `run_owned`; the field may be a nested path
+/// (`task.task`).
 #[macro_export]
 macro_rules! owned_task {
-    ([$($gen:tt)*] $ty:ty, $field:ident) => {
-        $crate::intrusive_work_task!([$($gen)*] $ty, $field);
+    ([$($gen:tt)*] $ty:ty, $($field:ident).+ $(, run = $run:path)?) => {
+        $crate::intrusive_work_task!([$($gen)*] $ty, $($field).+);
         // SAFETY: see macro doc — the type is moved to a worker thread by design.
         unsafe impl<$($gen)*> ::core::marker::Send for $ty {}
         // SAFETY: `run` forwards to the inherent `run_owned`.
         unsafe impl<$($gen)*> $crate::work_pool::OwnedTask for $ty {
             #[inline]
-            fn run(self: ::std::boxed::Box<Self>) { <$ty>::run_owned(self) }
+            fn run(self: ::std::boxed::Box<Self>) { $crate::owned_task!(@run self, $ty $(, $run)?) }
         }
     };
-    ($ty:ty, $field:ident) => {
-        $crate::intrusive_work_task!($ty, $field);
+    ($ty:ty, $($field:ident).+ $(, run = $run:path)?) => {
+        $crate::intrusive_work_task!($ty, $($field).+);
         // SAFETY: see macro doc — the type is moved to a worker thread by design.
         unsafe impl ::core::marker::Send for $ty {}
         // SAFETY: `run` forwards to the inherent `run_owned`.
         unsafe impl $crate::work_pool::OwnedTask for $ty {
             #[inline]
-            fn run(self: ::std::boxed::Box<Self>) { <$ty>::run_owned(self) }
+            fn run(self: ::std::boxed::Box<Self>) { $crate::owned_task!(@run self, $ty $(, $run)?) }
         }
     };
+    (@run $self:ident, $ty:ty) => { <$ty>::run_owned($self) };
+    (@run $self:ident, $ty:ty, $run:path) => { $run($self) };
 }
 
 static POOL: OnceLock<ThreadPool> = OnceLock::new();

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -183,25 +183,6 @@
       "ThreadIsolated<T>"
     ]
   },
-  "src/runtime/shell/IOReader.rs": {
-    "unsafe impl Send": [
-      "IOReader"
-    ],
-    "unsafe impl Sync": [
-      "IOReader"
-    ]
-  },
-  "src/runtime/shell/IOWriter.rs": {
-    "unsafe impl Send": [
-      "IOWriter"
-    ],
-    "unsafe impl Sync": [
-      "IOWriter"
-    ]
-  },
-  "src/runtime/shell/builtin/cp.rs": {
-    "WorkPool::schedule*": 1
-  },
   "src/runtime/shell/builtin/rm.rs": {
     "WorkPool::schedule*": 2,
     "unsafe impl Send": [
@@ -210,7 +191,7 @@
     ]
   },
   "src/runtime/shell/interpreter.rs": {
-    "WorkPool::schedule*": 1
+    "WorkPool::schedule*": 2
   },
   "src/runtime/webcore/Blob.rs": {
     "WorkPool::schedule*": 1

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -9,6 +9,19 @@ const fileExists = async (path: string): Promise<boolean> =>
 
 $.nothrow();
 
+// Each directory listing is one OutputTask; once the reader side of the pipe is
+// gone (EPIPE) the remaining tasks must still complete.
+test("ls of many directories into a closed pipe finishes", async () => {
+  const files: Record<string, string> = {};
+  for (let i = 0; i < 300; i++) files[`sub${i % 30}/file${i}.txt`] = "";
+  using dir = tempDir("ls-epipe", files);
+  const subs = Array.from({ length: 30 }, (_, i) => `sub${i}`).join(" ");
+  const r = await $`ls ${{ raw: subs }} | head -1`.cwd(String(dir)).quiet();
+  // Listings complete in any order; each starts with its `subN:` header.
+  expect(r.stdout.toString()).toMatch(/^sub\d+:\n$/);
+  expect(r.exitCode).toBe(0);
+});
+
 beforeAll(() => {
   setDefaultTimeout(1000 * 60 * 5);
 });

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -10,8 +10,9 @@ const fileExists = async (path: string): Promise<boolean> =>
 $.nothrow();
 
 // Each directory listing is one OutputTask; once the reader side of the pipe is
-// gone (EPIPE) the remaining tasks must still complete.
-test("ls of many directories into a closed pipe finishes", async () => {
+// gone (EPIPE) the remaining tasks must still complete. `head` is not a shell
+// builtin, so this needs a system `head` (POSIX only).
+test.skipIf(!isPosix)("ls of many directories into a closed pipe finishes", async () => {
   const files: Record<string, string> = {};
   for (let i = 0; i < 300; i++) files[`sub${i % 30}/file${i}.txt`] = "";
   using dir = tempDir("ls-epipe", files);

--- a/test/js/bun/shell/commands/mkdir.test.ts
+++ b/test/js/bun/shell/commands/mkdir.test.ts
@@ -79,7 +79,8 @@ test("operands longer than the path buffers are reported, not a crash", async ()
 
 // `-v` output goes through one OutputTask per operand; once the reader side of
 // the pipe is gone (EPIPE) the remaining tasks must still complete.
-test("mkdir -v into a closed pipe finishes", async () => {
+// `head` is not a shell builtin, so this needs a system `head` (not on Windows CI).
+test.skipIf(isWindows)("mkdir -v into a closed pipe finishes", async () => {
   using dir = tempDir("mkdir-epipe", {});
   const names = Array.from({ length: 40 }, (_, i) => `d${i}`).join(" ");
   await using proc = Bun.spawn({
@@ -97,7 +98,9 @@ test("mkdir -v into a closed pipe finishes", async () => {
   // `head -1` passes exactly one line through (the directories are created
   // concurrently, so which one is not fixed); the rest hit EPIPE.
   const [out, code] = JSON.parse(stdout);
-  expect(out).toMatch(new RegExp(`^${join(String(dir), "d")}\\d+\\n$`));
+  const prefix = join(String(dir), "d");
+  expect(out.startsWith(prefix)).toBe(true);
+  expect(out.slice(prefix.length)).toMatch(/^\d+\n$/);
   expect(code).toBe(0);
   expect(existsSync(join(String(dir), "d39"))).toBe(true);
   expect(exitCode).toBe(0);

--- a/test/js/bun/shell/commands/mkdir.test.ts
+++ b/test/js/bun/shell/commands/mkdir.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 // A relative operand was joined onto the cwd in a fixed 4096-byte buffer, so an
@@ -73,5 +74,31 @@ test("operands longer than the path buffers are reported, not a crash", async ()
       ? { exitCode: 0, stderr: "", created: true }
       : { ...failed(`${dir}/${dotSlashes}as-written`), created: false },
   });
+  expect(exitCode).toBe(0);
+});
+
+// `-v` output goes through one OutputTask per operand; once the reader side of
+// the pipe is gone (EPIPE) the remaining tasks must still complete.
+test("mkdir -v into a closed pipe finishes", async () => {
+  using dir = tempDir("mkdir-epipe", {});
+  const names = Array.from({ length: 40 }, (_, i) => `d${i}`).join(" ");
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const r = await Bun.$\`mkdir -v ${names} | head -1\`.quiet().nothrow(); console.log(JSON.stringify([r.stdout.toString(), r.exitCode]));`,
+    ],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  // `head -1` passes exactly one line through (the directories are created
+  // concurrently, so which one is not fixed); the rest hit EPIPE.
+  const [out, code] = JSON.parse(stdout);
+  expect(out).toMatch(new RegExp(`^${join(String(dir), "d")}\\d+\\n$`));
+  expect(code).toBe(0);
+  expect(existsSync(join(String(dir), "d39"))).toBe(true);
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -484,3 +484,25 @@ test("operands longer than the path scratch buffers are reported, not a crash", 
   });
   expect(exitCode).toBe(0);
 });
+
+// With stderr on a regular file the error write completes synchronously, from
+// inside the builtin's own step.
+test("rm error with stderr redirected to a file", async () => {
+  using dir = tempDir("rm-stderr-file", {});
+  const errPath = path.join(String(dir), "err.txt");
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "exec", "rm does_not_exist_123; echo after"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: Bun.file(errPath),
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("after\n");
+  expect(await Bun.file(errPath).text()).toBe("rm: does_not_exist_123: No such file or directory\n");
+  expect(exitCode).toBe(0);
+
+  const res = await $`rm does_not_exist_456 2> ${Bun.file(errPath)}`.cwd(String(dir)).quiet();
+  expect(await Bun.file(errPath).text()).toBe("rm: does_not_exist_456: No such file or directory\n");
+  expect(res.exitCode).toBe(1);
+});

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -506,3 +506,27 @@ test("rm error with stderr redirected to a file", async () => {
   expect(await Bun.file(errPath).text()).toBe("rm: does_not_exist_456: No such file or directory\n");
   expect(res.exitCode).toBe(1);
 });
+
+// Each failing operand queues its own error chunk on stderr; once the reader
+// side of the pipe is gone the remaining chunks must each still be called back.
+test("rm errors for several operands into a closed pipe finish", async () => {
+  using dir = tempDir("rm-epipe", {});
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const r = await Bun.$\`rm nope1 nope2 nope3 nope4 2>&1 | true\`.nothrow(); console.log(r.exitCode);`,
+    ],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "0\n",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});


### PR DESCRIPTION
### What

Same programme as #40055 … #40221. **Stacked on #40204** (base branch `claude/subprocess-zero-unsafe`; retarget to main once that lands). Every target in `src/runtime/shell/` goes to **0**: `interpreter.rs` 53 → 0, `states/{Cmd,Expansion,CondExpr,Async,Base,Pipeline,Script,Stmt,Subshell}.rs` → 0, `IOWriter.rs` 7 → 0, `IOReader.rs` 7 → 0, `Builtin.rs` 10 → 0, `IO.rs` 4 → 0, `dispatch_tasks.rs` 5 → 0; builtins touched on the way: `mv.rs` 8 → 0, `touch.rs` 6 → 0, `export.rs` 1 → 0, `mkdir.rs` 6 → 1, `ls.rs` 11 → 2, `cp.rs` 17 → 3 (`rm.rs`'s DirTask tree is its own raw-pointer design and is left for a follow-up).

- **State tree**: nodes live in an append-only chunked slab on the `Interpreter` addressed by id; parent/child links are ids, `child_done` re-enters through the interpreter, and no `Ref`/`RefMut` on a node, env, or captured buffer is held across a re-entrant call (builtins never hold their node borrowed across `IOWriter::enqueue`). `ShellExecEnv` has `Drop` + `clear()`; `Bufio::Borrowed` → `Rc<RefCell<Vec>>`.
- **Parsed script**: `bun_shell_parser::ParsedScript` owns arena + root; `root(&self) -> &Script<'_>` is covariant/safe and the erased `'static` form is only available as `root_backref() -> BackRef<Script<'static>>` (one lifetime-only transmute with SAFETY in the parser crate).
- **IOWriter / IOReader**: intrusively refcounted (`IOWriterRef`/`IOReaderRef` RAII newtypes over `RefPtr`); `impl_buffered_writer_parent!` gets a `borrow = this` entry whose `ref_`/`deref` hooks are the parent's intrusive count; pending-writer entries are typed; sync completions are deferred through `Yield::OnIoWriterChunk`.
- **Thread-pool / loop bounces**: `bun_event_loop::EventLoopTask::arm_boxed<T, R>(Box<T>, node)` (JS arm = manual-deinit `ConcurrentTask` with `T::TAG`, mini arm = trampoline to `R::run_from_loop_thread(Box<T>)`), `AnyTaskWithExtraContext::{arm_boxed, load}` (also fixes a pre-existing free-under-`&mut` in the mini loop — it now copies the node out before running), `boxed_taskable!`, `crate::shell_task!(Ty)`; `ShellTask.interp` is an `InterpRef` openable only on the owning thread. Bounces use the embedded nodes (no allocation per bounce; mini `Async` is 0 allocs vs 1 on main).
- `bun_ptr::SelfRoot`/`RefPtr::new_cyclic` cherry-picked from #40210; `owned_task!`/`intrusive_work_task!`/`intrusive_field!` accept a nested field path; `EventLoopHandle::with_env`; `Body::Value::with_request_or_response(value, |v| ..)`; `Stdio::Capture` is a unit variant.

Behaviour notes: a parser-internal error with no diagnostics surfaces as `ParseFailure::Other` (thrown/returned) instead of an empty message; a pipeline/subshell child's duped env closes when its slot is freed (after `Cmd::deinit` rather than just before). Windows: a synchronous uv submission failure still re-enters `IOWriter::on_error` from inside `write()` exactly as on main (io-layer follow-up).

**Perf** (release, `perf stat -e instructions:u`, `taskset`-pinned, interleaved, 7 runs, medians; base = #40204): `bun run --shell=bun` script of 1000× `true` −0.15 %; 500× (`[ -f ]` + `mkdir -p` + `touch` + glob) +0.15 %; JS loop 3000× `` $`true` `` +0.35 %. (Node state uses a `bun_ptr::JsRefCell` — RefCell API/panics in debug, `JsCell` cost in release; node chunks are built in place with the first chunk inline.) No allocation per thread-pool or Async bounce (embedded nodes; mini `Async` is 0 allocs vs 1 on main).

Pre-existing bug fixed in passing: `IOWriter::fail_pending_writers` called each child back once while every output chunk of a builtin shared one `ChildPtr`, so `mkdir -v a b c | head -1` / `ls dir1 dir2 … | head -1` could hang after EPIPE; each parked `OutputTask` now has its own sequence number and the four per-builtin output vtables are one generic `OutputTask::{start, write, on_chunk}` (tests added).

### Testing

Debug+ASAN: bunshell, commands/*, exec, throw, yield, lazy, leak, lex/parse/brace/glob/escape/env, file-io, epipe, pipeline_stack, worker-terminate-leak, seq-condexpr, sentinel, cmdsub-crash, blocking-pipe, read/write-fault, leak-args, shelloutput, bunshell-file/instance/default, run-shell, spawn-shell-signal, shell regression tests — 945 pass / 3 fail (root-user cases, identical on base) / 33 skip; new test `rm error with stderr redirected to a file`. Hand-driven: pipelines mixing builtins and subprocesses, `${Buffer}`/`${Response}` redirects, `&&`/`||`/subshell/cmdsubst, brace+glob, `.text/.lines/.quiet/.nothrow/.env/.cwd`, throwing interpolation, Worker terminated mid-pipeline, 2000× `echo hi` then GC (`ShellInterpreter` count back to baseline) — exit codes correct, no ASAN output. clippy clean; source lints pass; `rust-check-all` windows-msvc + apple-darwin pass.
