### PR TITLE
test: drop 64 stale entries from no-validate-exceptions.txt

### DIFF
--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -52,7 +52,3 @@ test/integration/next-pages/test/dev-server-ssr-100.test.ts
 test/integration/next-pages/test/dev-server.test.ts
 test/integration/next-pages/test/next-build.test.ts
 test/js/third_party/next-auth/next-auth.test.ts
-
-# Not yet verified clean under validateExceptionChecks.
-test/cli/run/require-cache.test.ts
-

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -2,7 +2,6 @@
 
 # List of tests that potentially throw inside of reifyStaticProperties
 test/bake/dev/production.test.ts
-test/cli/install/bun-install-lifecycle-scripts.test.ts
 test/integration/vite-build/vite-build.test.ts
 test/js/bun/test/parallel/test-integration-rspack.ts
 test/js/bun/util/BunObject.test.ts
@@ -15,68 +14,20 @@ test/js/third_party/astro/astro-post.test.js
 test/bundler/bundler_compile.test.ts
 
 # 3rd party napi
-test/integration/sharp/sharp.test.ts
-test/js/third_party/@napi-rs/canvas/napi-rs-canvas.test.ts
 test/js/third_party/prisma/prisma.test.ts
 test/js/third_party/remix/remix.test.ts
-test/js/third_party/resvg/bbox.test.js
-test/js/third_party/rollup-v4/rollup-v4.test.ts
-test/napi/napi-finalizer-delete-ref.test.ts
-test/napi/uv.test.ts
-test/napi/uv_stub.test.ts
-test/napi/node-napi-tests/test/js-native-api/2_function_arguments/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/3_callbacks/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/4_object_factory/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/5_function_factory/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/6_object_wrap/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/7_factory_wrap/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/8_passing_wrapped/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_array/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_bigint/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_cannot_run_js/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_constructor/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_conversions/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_dataview/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_date/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_error/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_exception/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_finalizer/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_function/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_general/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_handle_scope/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_instance_data/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_new_target/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_number/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_object/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_promise/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_properties/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_reference/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_reference_double_free/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_string/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_symbol/do.test.ts
-test/napi/node-napi-tests/test/js-native-api/test_typedarray/do.test.ts
-test/napi/node-napi-tests/test/node-api/1_hello_world/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_async/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_buffer/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_callback_scope/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_cleanup_hook/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_exception/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_fatal/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_fatal_exception/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_general/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_make_callback/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_threadsafe_function/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_worker_terminate_finalization/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_worker_terminate/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_worker_buffer_callback/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_reference_by_node_api_version/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_env_teardown_gc/do.test.ts
-test/napi/node-napi-tests/test/node-api/test_general/do.test.ts
 
-# normalizeCryptoAlgorithmParameters
-test/js/deno/crypto/webcrypto.test.ts
-test/js/node/crypto/node-crypto.test.js
-test/js/third_party/pg/pg.test.ts
+# napi entry points that declare a plain ThrowScope and return a status to the
+# addon with the exception pending (napi_run_script, napi_create_bigint_words,
+# napi_create_dataview, napi_create_buffer, NapiEnv::throwPendingException) and
+# napi_get_all_property_names' unchecked get/toPropertyKey.
+test/napi/napi.test.ts
+test/napi/node-napi-tests/test/js-native-api/test_bigint/do.test.ts
+test/napi/node-napi-tests/test/js-native-api/test_dataview/do.test.ts
+test/napi/node-napi-tests/test/js-native-api/test_general/do.test.ts
+test/napi/node-napi-tests/test/js-native-api/test_object/do.test.ts
+
+# vendor/elysia
 vendor/elysia/test/aot/response.test.ts
 vendor/elysia/test/cookie/response.test.ts
 vendor/elysia/test/cookie/signature.test.ts
@@ -85,15 +36,8 @@ vendor/elysia/test/lifecycle/error.test.ts
 vendor/elysia/test/validator/body.test.ts
 vendor/elysia/test/ws/message.test.ts
 
-
 # TODO: jsc
 test/js/bun/jsonl/jsonl-parse.test.ts
-
-# Third-party SDK with unchecked exception path in JSArray pushInline
-test/js/third_party/@azure/service-bus/azure-service-bus.test.ts
-
-# `bun run build` in the react templates loads bun-plugin-tailwind's napi addon.
-test/cli/init/init.test.ts
 
 # JSC JSONP fast path (Interpreter::executeProgram doGet lambda) does an
 # unchecked getPropertySlot/getValue pair; only throwable through
@@ -109,13 +53,6 @@ test/integration/next-pages/test/dev-server.test.ts
 test/integration/next-pages/test/next-build.test.ts
 test/js/third_party/next-auth/next-auth.test.ts
 
-# Process_functionDlopen (BunProcess.cpp:397) leaves putInlineSlow's exception
-# unchecked at recursionDepth 12/13; every napi .node load trips it. Moved here
-# from expectations.txt so the 170+ tests in this file run on ASAN.
-test/napi/napi.test.ts
-
-# "does not include unevaluated modules" loads msgpackr-extract's napi .node,
-# whose NapiClass::finishCreation (NapiClass.cpp:120) leaves an exception
-# unchecked at defineOwnNonIndexProperty. Moved here from expectations.txt.
+# Not yet verified clean under validateExceptionChecks.
 test/cli/run/require-cache.test.ts
 

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -27,15 +27,6 @@ test/napi/node-napi-tests/test/js-native-api/test_dataview/do.test.ts
 test/napi/node-napi-tests/test/js-native-api/test_general/do.test.ts
 test/napi/node-napi-tests/test/js-native-api/test_object/do.test.ts
 
-# vendor/elysia
-vendor/elysia/test/aot/response.test.ts
-vendor/elysia/test/cookie/response.test.ts
-vendor/elysia/test/cookie/signature.test.ts
-vendor/elysia/test/core/dynamic.test.ts
-vendor/elysia/test/lifecycle/error.test.ts
-vendor/elysia/test/validator/body.test.ts
-vendor/elysia/test/ws/message.test.ts
-
 # TODO: jsc
 test/js/bun/jsonl/jsonl-parse.test.ts
 

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -30,6 +30,11 @@ test/napi/node-napi-tests/test/js-native-api/test_object/do.test.ts
 # TODO: jsc
 test/js/bun/jsonl/jsonl-parse.test.ts
 
+# X509Certificate toLegacyObject → computeInfoAccess pushes onto a JSArray in a
+# loop without checking (JSX509Certificate.cpp); reached from a TLS peer
+# certificate. The tests only run with service-bus credentials, so CI-only.
+test/js/third_party/@azure/service-bus/azure-service-bus.test.ts
+
 # JSC JSONP fast path (Interpreter::executeProgram doGet lambda) does an
 # unchecked getPropertySlot/getValue pair; only throwable through
 # NodeVMGlobalObject's overridden getOwnPropertySlot. Needs a WebKit-side fix.

--- a/test/regression/issue/30205.test.ts
+++ b/test/regression/issue/30205.test.ts
@@ -45,20 +45,9 @@ describe.skipIf(!canBuildNodeAddons())("#30205", () => {
     if (!install.success) throw new Error("node-gyp build failed");
   }, 120_000);
 
-  // CI's ASAN lane runs this file with BUN_JSC_validateExceptionChecks=1,
-  // which leaks into the spawned subprocesses via bunEnv → process.env.
-  // The napi layer has a known unchecked ThrowScope between
-  // napi_create_function and napi_set_named_property (see the "3rd party
-  // napi" section in test/no-validate-exceptions.txt — every napi test is
-  // excluded); under collectContinuously the simulated-throw counter lands
-  // on the addon's init path and the subprocess aborts before the fixture
-  // even runs. That's orthogonal to the GC UAF this test covers, so strip
-  // the validator from the child env only.
   const env = {
     ...bunEnv,
     BUN_JSC_collectContinuously: "1",
-    BUN_JSC_validateExceptionChecks: undefined,
-    BUN_JSC_dumpSimulatedThrows: undefined,
   };
 
   // The crash is a GC-timing race; collectContinuously + per-file


### PR DESCRIPTION
### What does this PR do?

`test/no-validate-exceptions.txt` lists test files that the ASAN lane runs *without* `BUN_JSC_validateExceptionChecks=1`. Running every entry individually under the validator on a current debug build shows 64 of them no longer trip it (the sites their comments cited — `Process_functionDlopen`, `NapiClass::finishCreation`, the webcrypto `normalizeCryptoAlgorithmParameters` path — have since been fixed), so this removes them and they get exception-check coverage in CI again:

- all `test/napi/node-napi-tests/**` suites except `test_bigint`, `test_dataview`, `test_general`, `test_object`
- `sharp`, `@napi-rs/canvas`, `resvg`, `rollup-v4`, `pg`
- `test/js/deno/crypto/webcrypto.test.ts`, `test/js/node/crypto/node-crypto.test.js`
- `test/cli/init/init.test.ts`, `bun-install-lifecycle-scripts`, `require-cache`, `napi-finalizer-delete-ref`, `uv`, `uv_stub`, all seven `vendor/elysia` files

The remaining entries are regrouped under comments describing their *current* first fault. `napi.test.ts` and the four js-native-api suites above still fail on napi entry points that declare a plain `ThrowScope` and return a status to the addon with the exception pending (`napi_run_script`, `napi_create_bigint_words`, `napi_create_dataview`, `napi_create_buffer`, `NapiEnv::throwPendingException`); that is a separate change.

### How did you verify your code works?

`BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1 bun bd test <file>` for each of the 86 listed files; the removed ones exit 0 with no "Unchecked JS exception" output. The ASAN lane on this PR is the real check.
