### PR TITLE
napi: make uv_default_loop return the driven event loop on Windows

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -804,6 +804,21 @@ impl VirtualMachine {
         if p.is_null() { None } else { Some(p) }
     }
 
+    /// The main thread VM's libuv loop, or null before the main VM's `init()`
+    /// has installed it. Callable from any thread: `MAIN_THREAD_VM` and
+    /// `event_loop_handle` are both written once during `init()`, before user
+    /// code (and so any N-API addon) can run.
+    #[cfg(windows)]
+    pub fn main_thread_uv_loop() -> *mut crate::PlatformEventLoop {
+        let Some(vm) = Self::get_main_thread_vm() else {
+            return core::ptr::null_mut();
+        };
+        // SAFETY: raw field projection so no `&VirtualMachine` is formed off
+        // the JS thread; the main VM allocation is never freed.
+        unsafe { core::ptr::addr_of!((*vm).event_loop_handle).read() }
+            .unwrap_or(core::ptr::null_mut())
+    }
+
     #[inline]
     pub fn is_loaded() -> bool {
         VM.get().is_some()

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -450,6 +450,14 @@ pub(crate) struct VMHolder;
 static MAIN_THREAD_VM: core::sync::atomic::AtomicPtr<VirtualMachine> =
     core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
 
+/// The main thread VM's permanent libuv loop, cached once in `init()` for
+/// [`VirtualMachine::main_thread_uv_loop`]. The live `event_loop_handle`
+/// field is rewritten after init (spawnSync swaps in a short-lived loop and
+/// restores it), so that field cannot be read off-thread.
+#[cfg(windows)]
+static MAIN_THREAD_UV_LOOP: core::sync::atomic::AtomicPtr<crate::PlatformEventLoop> =
+    core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
+
 // `#[thread_local]` (bare `__thread` slot) instead of `thread_local!` macro:
 // `LocalKey::__getit` adds a lazy-init check + on some targets a
 // `pthread_getspecific` round-trip per access. `get_or_null()` (which reads `VM`) is the
@@ -804,19 +812,11 @@ impl VirtualMachine {
         if p.is_null() { None } else { Some(p) }
     }
 
-    /// The main thread VM's libuv loop, or null before the main VM's `init()`
-    /// has installed it. Callable from any thread: `MAIN_THREAD_VM` and
-    /// `event_loop_handle` are both written once during `init()`, before user
-    /// code (and so any N-API addon) can run.
+    /// The main thread VM's permanent libuv loop, or null before the main
+    /// VM's `init()` has cached it. Callable from any thread.
     #[cfg(windows)]
     pub fn main_thread_uv_loop() -> *mut crate::PlatformEventLoop {
-        let Some(vm) = Self::get_main_thread_vm() else {
-            return core::ptr::null_mut();
-        };
-        // SAFETY: raw field projection so no `&VirtualMachine` is formed off
-        // the JS thread; the main VM allocation is never freed.
-        unsafe { core::ptr::addr_of!((*vm).event_loop_handle).read() }
-            .unwrap_or(core::ptr::null_mut())
+        MAIN_THREAD_UV_LOOP.load(core::sync::atomic::Ordering::Acquire)
     }
 
     #[inline]
@@ -2665,6 +2665,16 @@ impl VirtualMachine {
         if opts.is_main_thread {
             // SAFETY: `vm` is the freshly-initialised per-thread VM singleton.
             bun_io::ParentDeathWatchdog::install_on_event_loop(unsafe { Self::event_loop_ctx(vm) });
+            // Cache the permanent loop for `main_thread_uv_loop()` while
+            // `event_loop_handle` still holds what `ensure_waker()` installed.
+            #[cfg(windows)]
+            MAIN_THREAD_UV_LOOP.store(
+                // SAFETY: `vm` is the live per-thread VM; raw projection, no
+                // `&VirtualMachine` formed.
+                unsafe { core::ptr::addr_of!((*vm).event_loop_handle).read() }
+                    .unwrap_or(core::ptr::null_mut()),
+                core::sync::atomic::Ordering::Release,
+            );
         }
 
         if opts.smol {

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2307,6 +2307,25 @@ extern "C" fn napi_get_uv_event_loop(env_: napi_env, loop_: *mut napi_event_loop
     env.ok()
 }
 
+/// `uv_default_loop` as N-API addons resolve it from bun.exe (the export is
+/// aliased to this in src/symbols.def; internal callers still bind to the
+/// real libuv symbol at link time). libuv's real default loop exists in the
+/// binary but nothing ever runs it, so a NAN-era addon that posts work to it
+/// (`uv_queue_work(uv_default_loop(), ...)`, e.g. ibm_db) would wait forever
+/// for its after-work callback. As in Node, the default loop is the main
+/// thread's driven loop, from any thread (a Worker's addon gets the main
+/// loop too; `napi_get_uv_event_loop` gives the per-VM loop).
+#[cfg(windows)]
+#[unsafe(no_mangle)]
+extern "C" fn Bun__uv_default_loop() -> *mut bun_sys::windows::libuv::Loop {
+    let loop_ = VirtualMachine::main_thread_uv_loop();
+    if !loop_.is_null() {
+        return loop_;
+    }
+    // No main VM yet: the real (undriven) default loop, as before.
+    unsafe { bun_sys::windows::libuv::uv_default_loop() }
+}
+
 unsafe extern "C" {
     pub(super) fn napi_fatal_exception(env: napi_env, err: napi_value) -> napi_status;
     pub(super) fn napi_add_async_cleanup_hook(

--- a/src/symbols.def
+++ b/src/symbols.def
@@ -95,7 +95,9 @@ EXPORTS
   uv_fs_event_getpath
   uv_fs_scandir_next
   uv_loop_configure
-  uv_default_loop
+  ; Addons get the main thread's driven loop, not libuv's (never-run) real
+  ; default loop. See Bun__uv_default_loop in src/runtime/napi/napi_body.rs.
+  uv_default_loop=Bun__uv_default_loop
   uv_loop_new
   uv_loop_close
   uv_loop_delete

--- a/test/napi/uv-stub-stuff/default_loop.c
+++ b/test/napi/uv-stub-stuff/default_loop.c
@@ -1,0 +1,68 @@
+// uv_default_loop() as seen from an N-API addon. On Windows bun links real
+// libuv and addons resolve uv_* from bun.exe; the exported uv_default_loop
+// must be a loop bun actually runs, or NAN-era addons that call
+// uv_queue_work(uv_default_loop(), ...) never get their after-work callback
+// (oven-sh/bun#40225, ibm_db).
+#include <node_api.h>
+#include <stdlib.h>
+#include <uv.h>
+
+typedef struct {
+  uv_work_t req;
+  napi_env env;
+  napi_ref cb;
+  int ran_work;
+} work_data;
+
+static void work_cb(uv_work_t *req) { ((work_data *)req->data)->ran_work = 1; }
+
+static void after_work_cb(uv_work_t *req, int status) {
+  work_data *data = (work_data *)req->data;
+  napi_env env = data->env;
+  napi_handle_scope scope;
+  napi_open_handle_scope(env, &scope);
+  napi_value cb, global, arg, result;
+  napi_get_reference_value(env, data->cb, &cb);
+  napi_get_global(env, &global);
+  napi_create_int32(env, data->ran_work, &arg);
+  napi_call_function(env, global, cb, 1, &arg, &result);
+  napi_delete_reference(env, data->cb);
+  napi_close_handle_scope(env, scope);
+  free(data);
+}
+
+// queueWork(cb): uv_queue_work on uv_default_loop(); cb(ran_work) runs from
+// the after-work callback, which only fires if the runtime drives the loop.
+static napi_value queue_work(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+  work_data *data = (work_data *)calloc(1, sizeof(work_data));
+  data->env = env;
+  napi_create_reference(env, argv[0], 1, &data->cb);
+  data->req.data = data;
+  uv_queue_work(uv_default_loop(), &data->req, work_cb, after_work_cb);
+  return NULL;
+}
+
+// defaultLoopIsNapiLoop(): uv_default_loop() == the loop returned by
+// napi_get_uv_event_loop, which is the loop the runtime drives.
+static napi_value default_loop_is_napi_loop(napi_env env,
+                                            napi_callback_info info) {
+  uv_loop_t *napi_loop = NULL;
+  napi_get_uv_event_loop(env, &napi_loop);
+  napi_value result;
+  napi_get_boolean(env, uv_default_loop() == napi_loop, &result);
+  return result;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_value fn;
+  napi_create_function(env, NULL, 0, queue_work, NULL, &fn);
+  napi_set_named_property(env, exports, "queueWork", fn);
+  napi_create_function(env, NULL, 0, default_loop_is_napi_loop, NULL, &fn);
+  napi_set_named_property(env, exports, "defaultLoopIsNapiLoop", fn);
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/napi/uv.test.ts
+++ b/test/napi/uv.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, canBuildNodeAddons, isWindows, tempDirWithFiles } from "harness";
 import { existsSync, readFileSync } from "node:fs";
 import { constants } from "node:os";
 import path from "node:path";
@@ -191,7 +191,7 @@ describe.if(!isWindows)("uv stubs", () => {
 // (ibm_db) call uv_queue_work(uv_default_loop(), ...) directly, and the
 // after-work callback only fires when that loop runs (#40225). libuv's real
 // default loop exists in the binary but nothing ever runs it.
-describe.if(isWindows)("uv_default_loop", () => {
+describe.if(isWindows && canBuildNodeAddons())("uv_default_loop", () => {
   let addon: {
     queueWork: (cb: (ranWork: number) => void) => void;
     defaultLoopIsNapiLoop: () => boolean;
@@ -226,7 +226,8 @@ describe.if(isWindows)("uv_default_loop", () => {
     await Bun.$`${bunExe()} i --ignore-scripts && ${bunExe()} run build:napi`.env(bunEnv).cwd(tempdir);
     addonPath = path.join(tempdir, "build/Release/default_loop.node");
     addon = require(addonPath);
-  });
+    // The MSBuild compile of the addon overruns the default 5s hook timeout.
+  }, 300_000);
 
   test("returns the loop bun drives", () => {
     expect(addon.defaultLoopIsNapiLoop()).toBe(true);

--- a/test/napi/uv.test.ts
+++ b/test/napi/uv.test.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { constants } from "node:os";
 import path from "node:path";
 import { symbols, test_skipped } from "../../src/jsc/bindings/libuv/generate_uv_posix_stubs_constants";
+import defaultLoopSource from "./uv-stub-stuff/default_loop.c";
 import source from "./uv-stub-stuff/uv_impl.c";
 
 const symbols_to_test = symbols.filter(s => !test_skipped.includes(s));
@@ -182,5 +183,57 @@ describe.if(!isWindows)("uv stubs", () => {
       afterClose: -constants.errno.EBADF,
     });
     expect(exitCode).toBe(0);
+  });
+});
+
+// On Windows bun links real libuv and addons resolve uv_* from bun.exe. The
+// exported uv_default_loop must return the loop bun drives: NAN-era addons
+// (ibm_db) call uv_queue_work(uv_default_loop(), ...) directly, and the
+// after-work callback only fires when that loop runs (#40225). libuv's real
+// default loop exists in the binary but nothing ever runs it.
+describe.if(isWindows)("uv_default_loop", () => {
+  let addon: {
+    queueWork: (cb: (ranWork: number) => void) => void;
+    defaultLoopIsNapiLoop: () => boolean;
+  };
+  let addonPath: string = "";
+
+  beforeAll(async () => {
+    const files = {
+      "default_loop.c": await Bun.file(defaultLoopSource).text(),
+      "package.json": JSON.stringify({
+        "name": "default-loop-addon",
+        "version": "1.0.0",
+        "scripts": {
+          "build:napi": "node-gyp configure && node-gyp build",
+        },
+        "dependencies": {
+          "node-gyp": "10.2.0",
+        },
+      }),
+      "binding.gyp": `{
+        "targets": [
+          {
+            "target_name": "default_loop",
+            "sources": [ "default_loop.c" ],
+          },
+        ]
+      }`,
+    };
+    const tempdir = tempDirWithFiles("uv-default-loop", files);
+    // --ignore-scripts skips the implicit `node-gyp rebuild` bun install runs
+    // for a root binding.gyp package; build:napi is the single explicit build.
+    await Bun.$`${bunExe()} i --ignore-scripts && ${bunExe()} run build:napi`.env(bunEnv).cwd(tempdir);
+    addonPath = path.join(tempdir, "build/Release/default_loop.node");
+    addon = require(addonPath);
+  });
+
+  test("returns the loop bun drives", () => {
+    expect(addon.defaultLoopIsNapiLoop()).toBe(true);
+  });
+
+  test("uv_queue_work on it delivers the after-work callback", async () => {
+    const ranWork = await new Promise(resolve => addon.queueWork(resolve));
+    expect(ranWork).toBe(1);
   });
 });

--- a/test/napi/uv.test.ts
+++ b/test/napi/uv.test.ts
@@ -201,14 +201,18 @@ describe.if(isWindows && canBuildNodeAddons())("uv_default_loop", () => {
   beforeAll(async () => {
     const files = {
       "default_loop.c": await Bun.file(defaultLoopSource).text(),
+      // `bun --bun node-gyp` (the napi-app recipe): under node, config.gypi
+      // inherits clang=1 and lld linker flags from node's own build and MSBuild
+      // then wants the ClangCL toolset, which plain VS installs lack.
       "package.json": JSON.stringify({
         "name": "default-loop-addon",
         "version": "1.0.0",
+        "gypfile": true,
         "scripts": {
-          "build:napi": "node-gyp configure && node-gyp build",
+          "install": "bun --bun node-gyp rebuild",
         },
         "dependencies": {
-          "node-gyp": "10.2.0",
+          "node-gyp": "^11.2.0",
         },
       }),
       "binding.gyp": `{
@@ -221,9 +225,7 @@ describe.if(isWindows && canBuildNodeAddons())("uv_default_loop", () => {
       }`,
     };
     const tempdir = tempDirWithFiles("uv-default-loop", files);
-    // --ignore-scripts skips the implicit `node-gyp rebuild` bun install runs
-    // for a root binding.gyp package; build:napi is the single explicit build.
-    await Bun.$`${bunExe()} i --ignore-scripts && ${bunExe()} run build:napi`.env(bunEnv).cwd(tempdir);
+    await Bun.$`${bunExe()} i`.env(bunEnv).cwd(tempdir);
     addonPath = path.join(tempdir, "build/Release/default_loop.node");
     addon = require(addonPath);
     // The MSBuild compile of the addon overruns the default 5s hook timeout.

--- a/test/napi/uv.test.ts
+++ b/test/napi/uv.test.ts
@@ -196,7 +196,6 @@ describe.if(isWindows && canBuildNodeAddons())("uv_default_loop", () => {
     queueWork: (cb: (ranWork: number) => void) => void;
     defaultLoopIsNapiLoop: () => boolean;
   };
-  let addonPath: string = "";
 
   beforeAll(async () => {
     const files = {
@@ -226,8 +225,7 @@ describe.if(isWindows && canBuildNodeAddons())("uv_default_loop", () => {
     };
     const tempdir = tempDirWithFiles("uv-default-loop", files);
     await Bun.$`${bunExe()} i`.env(bunEnv).cwd(tempdir);
-    addonPath = path.join(tempdir, "build/Release/default_loop.node");
-    addon = require(addonPath);
+    addon = require(path.join(tempdir, "build/Release/default_loop.node"));
     // The MSBuild compile of the addon overruns the default 5s hook timeout.
   }, 300_000);
 


### PR DESCRIPTION
### Problem

- On Windows, async N-API work queued with `uv_queue_work(uv_default_loop(), ...)` never completes. The after-work callback never fires, so `ibm_db` open/query promises and callbacks hang forever (#40225).
- Addons resolve `uv_*` from bun.exe. The exported `uv_default_loop` (src/symbols.def) was libuv's real default loop, and nothing in Bun ever runs that loop. Bun drives a per-thread loop from `Loop::get()` instead (src/libuv_sys/libuv.rs:408).

### Fix

- Alias the `uv_default_loop` export to `Bun__uv_default_loop` (src/symbols.def), a wrapper that returns the main thread's permanent loop, cached once into an atomic during VM init (src/runtime/napi/napi_body.rs, src/jsc/VirtualMachine.rs). Internal callers still bind to the real libuv symbol at link time.
- As in Node, the default loop is the main thread's loop, from any thread. The posix implementation in #39652 uses the same semantics. Before the main VM exists, the wrapper falls back to the real default loop.
- Correct because the wrapper returns the loop `napi_get_uv_event_loop` already returns on Windows, so addon completions run on the path that N-API addons already use.
- Verified: test/napi/uv.test.ts, new `uv_default_loop` block. On stock bun the loop check returns false and the callback test times out. With the fix both pass, and the full file passes on Linux and Windows.

### Background

- NAN-era addons (ibm_db has about 25 such call sites) call libuv directly instead of `napi_create_async_work`. The work item runs on libuv's threadpool either way, but the completion is delivered through the owning loop's `wq_async` handle, which fires only when that loop polls.
- In Node the main thread's event loop is `uv_default_loop()`, so the pattern works there. Sync `ibm_db` APIs work in Bun because they never touch a loop.
- On Windows, bun links real libuv and exports its symbols for addons. node-gyp's delay-load hook redirects an addon's node.exe imports to the host executable, so the export table in symbols.def is what addons see.

<details><summary>Notes</summary>

- Verified against the reporter's module: `ibm_db@4.0.1` on Windows x64, with a connection string that fails fast. Before the fix, promise and callback modes hang until a watchdog kills the process. After the fix, all modes settle in about a second with the same SQL30081N error Node reports.
- A pending work request also keeps the process alive: a script that only calls `queueWork(cb)` waits for the callback and exits 0.
- The fix is Windows-only (`src/symbols.def` plus `cfg(windows)` Rust), so the new tests run on Windows lanes and skip elsewhere. Fail-before was verified on Windows x64: `USE_SYSTEM_BUN=1 bun test test/napi/uv.test.ts` fails both new tests (loop mismatch, 5s timeout), `bun bd test test/napi/uv.test.ts` passes.
- The test addon builds with `bun --bun node-gyp rebuild` (the napi-app recipe). Under node, config.gypi inherits `clang=1` and lld linker flags from node's own build, and MSBuild then requires the ClangCL toolset, which plain VS installs lack.
- Worker threads: an addon on a worker thread that calls `uv_default_loop()` gets the main thread's loop, as in Node. `uv_queue_work` cross-thread submission is mutex-protected in libuv, and the completion fires on the main thread.
- The wrapper reads a pointer cached at init instead of the live `event_loop_handle` field. spawnSync swaps that field to a short-lived loop and restores it, and the server rewrites it, so a cross-thread read of the field could race those writes or hand an addon a loop about to be destroyed (review finding, fixed in 06cdec8c).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/napi/uv.test.ts

<!-- robobun:evidence:end -->
