### PR TITLE
Add regression tests for the Yarr JIT surrogate mask

### DIFF
--- a/test/js/bun/jsc-stress/fixtures/regexp-unicode-surrogate-mask.js
+++ b/test/js/bun/jsc-stress/fixtures/regexp-unicode-surrogate-mask.js
@@ -1,0 +1,60 @@
+// Regression test for the YARR JIT surrogate mask. Surrogates occupy U+D800..U+DFFF
+// and must be isolated with the mask 0xFC00 (bits 15..10). The JIT used 0xDC00, which
+// drops bit 13, so ordinary BMP code units in U+F800..U+FFFF were misclassified as
+// surrogates and two of them were fused into a single code point. All of these are
+// plain BMP scalars, so each string below is two code points, never one.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${expected}, got ${actual}`);
+}
+
+let loop = typeof testLoopCount !== "undefined" ? testLoopCount : 200;
+let cc = String.fromCharCode;
+
+// [firstUnit, secondUnit, codePoints]: only a genuine pair (lead 0xD800..0xDBFF followed
+// by trail 0xDC00..0xDFFF) is a single code point. The "fake" variants set bit 13 and are
+// two ordinary BMP code points.
+let cases = [
+    [0xd800, 0xdc00, 1], // genuine surrogate pair -> one code point
+    [0xdbff, 0xdfff, 1], // genuine pair, top of range
+    [0xf800, 0xfc00, 2], // fake lead + fake trail (both bit 13 set)
+    [0xd800, 0xfc00, 2], // real lead + fake trail
+    [0xf800, 0xdc00, 2], // fake lead + real trail
+    [0xfbff, 0xffff, 2], // fake pair, top of range
+    [0x0041, 0x0042, 2], // plain BMP control
+];
+
+for (let i = 0; i < loop; i++) {
+    for (let [a, b, cps] of cases) {
+        let s = cc(a, b);
+        let tag = `[${a.toString(16)},${b.toString(16)}]`;
+
+        // Spread is the correct code-point segmentation reference.
+        shouldBe([...s].length, cps, `codepoints ${tag}`);
+
+        // In /u mode a dot matches exactly one code point.
+        shouldBe(/^.$/u.test(s), cps === 1, `single dot ${tag}`);
+        shouldBe(/^..$/u.test(s), cps === 2, `double dot ${tag}`);
+
+        // Greedy variable-width class match (forward advance uses the same mask).
+        let fwd = new RegExp("([^X]*)Z", "u").exec(s + "Z");
+        shouldBe(fwd !== null, true, `greedy match ${tag}`);
+        shouldBe(fwd[1], s, `greedy capture ${tag}`);
+
+        // Greedy variable-width class backtracking: the class eats everything, then must
+        // give back exactly one code point so the trailing literal (the second code unit)
+        // can match. This only works if the last matched code point is one unit wide, i.e.
+        // the two units were not fused into a bogus pair.
+        if (cps === 2) {
+            let re = new RegExp("([^X]*)" + cc(b), "u");
+            let m = re.exec(s);
+            shouldBe(m !== null, true, `backtrack match ${tag}`);
+            shouldBe(m[1], cc(a), `backtrack capture ${tag}`);
+        }
+    }
+
+    // Genuine pairs must still be treated as one code point after the fix.
+    shouldBe(/^.$/u.test("\u{10000}"), true, "astral single dot");
+    shouldBe(/^.$/u.test("\u{10ffff}"), true, "astral max single dot");
+}

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -64,6 +64,8 @@ const jsFixtures = [
   // FTL - RegExp
   "ftl-regexp-exec.js",
   "ftl-regexp-test.js",
+  // Yarr JIT
+  "regexp-unicode-surrogate-mask.js",
   // FTL - Arguments
   "ftl-getmyargumentslength.js",
   "ftl-getmyargumentslength-inline.js",

--- a/test/js/bun/jsc/regexp-unicode-surrogate-mask.test.ts
+++ b/test/js/bun/jsc/regexp-unicode-surrogate-mask.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+// The Yarr JIT reads two UTF-16 code units at once and tests them against a
+// surrogate mask. Bun 1.3.13 and 1.3.14 shipped a JSC whose mask was
+// 0xdc00dc00 instead of 0xfc00fc00, so U+F800..U+FBFF passed as a lead and
+// U+FC00..U+FFFF passed as a trail. Two ordinary BMP code units were fused into
+// one bogus code point and the second one was never matched.
+// Fixed upstream in WebKit 317399@main (bugs.webkit.org/show_bug.cgi?id=319651).
+// The interpreter (BUN_JSC_useRegExpJIT=false) was never affected.
+
+const isLead = (c: number) => c >= 0xd800 && c <= 0xdbff;
+const isTrail = (c: number) => c >= 0xdc00 && c <= 0xdfff;
+const isSurrogate = (c: number) => isLead(c) || isTrail(c);
+
+describe("RegExp /u and /v surrogate pair detection", () => {
+  test("\\p{Cs} matches a lone lead surrogate followed by U+FE0F", () => {
+    expect(/\p{Cs}/u.test("\uD87E\uFE0F")).toBe(true);
+    expect(/\p{Cs}/v.test("\uD87E\uFE0F")).toBe(true);
+  });
+
+  test("a class range matches after a U+F800..U+FBFF code unit", () => {
+    expect("\uF900\uFE01".replace(/[\uFE00-\uFE0D]/gu, "Z")).toBe("\uF900Z");
+    expect("\uF900\uFE01".replace(/[\uFE00-\uFE0D]/gv, "Z")).toBe("\uF900Z");
+    expect(/\uFE01/u.test("\uF900\uFE01")).toBe(true);
+  });
+
+  test("only D800..DBFF followed by DC00..DFFF is one code point", () => {
+    // Boundaries of the surrogate ranges, of the ranges the wrong mask also
+    // accepted (F800..FBFF as lead, FC00..FFFF as trail), and plain controls.
+    const prefixes = [
+      0x41, 0xd7ff, 0xd800, 0xd87e, 0xdbff, 0xdc00, 0xdfff, 0xe000, 0xf7ff, 0xf800, 0xf900, 0xfbff, 0xfc00, 0xffff,
+    ];
+    const targets = [
+      0x42, 0xd800, 0xdbff, 0xdc00, 0xdfff, 0xe000, 0xfbff, 0xfc00, 0xfdd0, 0xfe01, 0xfe0f, 0xfeff, 0xffff,
+    ];
+
+    const oneCodePoint = /^.$/u;
+    const twoCodePoints = /^..$/u;
+    const surrogate = /\p{Cs}/u;
+    const highBmp = /[\uFC00-\uFFFF]/u;
+
+    const failures: string[] = [];
+    for (const p of prefixes) {
+      for (const t of targets) {
+        const s = String.fromCharCode(p, t);
+        const pair = isLead(p) && isTrail(t);
+        const got = [oneCodePoint.test(s), twoCodePoints.test(s), surrogate.test(s), highBmp.test(s)];
+        // A real pair is one astral code point, and neither unit is visible on
+        // its own. Anything else is two BMP code points, each matched separately.
+        const want = [pair, !pair, !pair && (isSurrogate(p) || isSurrogate(t)), !pair && (p >= 0xfc00 || t >= 0xfc00)];
+        if (got.join() !== want.join())
+          failures.push(`U+${p.toString(16)} U+${t.toString(16)}: got ${got}, want ${want}`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Problem
- In Bun 1.3.13 and 1.3.14, a `/u` or `/v` regex misses a code point when the code unit before it is in U+D800..U+DBFF or U+F800..U+FBFF. `/\p{Cs}/u.test("\uD87E\uFE0F")` returns `false`, and `"\uF900\uFE01".replace(/[\uFE00-\uFE0D]/gu, "Z")` returns the input unchanged. Node returns `true` and `"\uF900Z"`.
- The cause is the Yarr JIT surrogate mask in `Source/JavaScriptCore/yarr/YarrJIT.cpp` (`surrogateTagMask`). It was `0xdc00dc00` instead of `0xfc00fc00`. The JIT loads two code units at once and tests `(pair & mask) == 0xdc00d800`. Without bit 13 in the mask, U+F800..U+FBFF passes as a lead and U+FC00..U+FFFF passes as a trail. The two units are fused into one bogus code point and the second one is never matched. `BUN_JSC_useRegExpJIT=false` (the interpreter) gives the correct result.

### Fix
- No code change. The fix is upstream in WebKit 317399@main (webkit.org/b/319651) and is in the WebKit pin since 01b81aa400. The 1.4.0 release passes. Only 1.3.13, 1.3.14, and a 1.4.0 canary from before 2026-07-29 are affected.
- This PR adds the upstream stress test `regexp-unicode-surrogate-mask.js` to the `jsc-stress` fixtures, and a `bun:test` file with the reported repros and a sweep over the boundaries of the surrogate ranges and of the two ranges the wrong mask accepted.
- Verified: `test/js/bun/jsc/regexp-unicode-surrogate-mask.test.ts` and `test/js/bun/jsc-stress/jsc-stress.test.ts -t regexp` pass under `bun bd test`. Both fail on the 1.3.14 release binary (linux x64) and on 1.3.13 (darwin arm64).

### Background
- Yarr is the JavaScriptCore regex engine. It has a bytecode interpreter and a JIT. `useRegExpJIT` selects the JIT when the pattern is supported.
- Under the `u` or `v` flag, a match position holds a code point. A lead surrogate (U+D800..U+DBFF) followed by a trail surrogate (U+DC00..U+DFFF) is one astral code point. A lone surrogate is a code point of its own, and `\p{Cs}` matches it.
- `tryReadUnicodeCharImpl` in `YarrJIT.cpp` reads a 32-bit word (two UTF-16 units) and tests both tags with one AND and one compare. The mask must keep bits 15..10 of each unit, so it is `0xfc00` per unit.

<details><summary>Notes</summary>

- Reproduced with `bun 1.3.13` on a darwin arm64 host and with the `bun-v1.3.14` linux x64 release binary. All three reported repros fail, plus `/\uFE01/u.test("\uF900\uFE01")` and `"\uF900\uFE01".match(/./gu).length` (1 instead of 2). With `BUN_JSC_useRegExpJIT=false` all pass.
- `BUN_JSC_dumpRegExpDisassembly=true` on 1.3.13 (arm64) shows the materialized mask: `mov w16, #0xdc00; movk w16, #0xdc00, lsl #16; ands w5, w6, w16`, then `cmp w5, #0xdc00d800`.
- The wrong constant was introduced with the two-units-at-once reader and fixed by oven-sh/WebKit 28426f7314 (2026-07-17). WebKit pins up to 5491700992 (bun 21b593cc57, 2026-07-23) still carry `0xdc00dc00`. Pin 34c01d1339 (bun 01b81aa400, 2026-07-29) has `0xfc00fc00`. The `bun-v1.4.0` tag pins 0f966e81b7, which has the fix, and the 1.4.0 release binaries (darwin arm64, linux x64) pass.
- The `package.json` version was bumped to 1.4.0 on 2026-05-17, so a canary from before 2026-07-29 reports 1.4.0 and has the bug.
- The fixture is a verbatim copy of `JSTests/stress/regexp-unicode-surrogate-mask.js` from the pinned WebKit, like the other files in `test/js/bun/jsc-stress/fixtures/`.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc-stress/jsc-stress.test.ts' 'test/js/bun/jsc/regexp-unicode-surrogate-mask.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc-stress/jsc-stress.test.ts test/js/bun/jsc/regexp-unicode-surrogate-mask.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/jsc/regexp-unicode-surrogate-mask.test.ts:
(pass) RegExp /u and /v surrogate pair detection > \p{Cs} matches a lone lead surrogate followed by U+FE0F [10.83ms]
(pass) RegExp /u and /v surrogate pair detection > a class range matches after a U+F800..U+FBFF code unit [4.34ms]
(pass) RegExp /u and /v surrogate pair detection > only D800..DBFF followed by DC00..DFFF is one code point [72.23ms]

test/js/bun/jsc-stress/jsc-stress.test.ts:
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsin.js [315.71ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithcos.js [294.22ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsqrt.js [291.89ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithtan.js [296.32ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-equality.js [299.27ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-library-substring.js [282.72ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-ident-equality.js [313.30ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-strict-equality.js [368.46ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-test.js [346.80ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-exec.js [361.62ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength.js [280.66ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength-inline.js [294.42ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val.js [319.90ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined.js [319.27ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inl
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../fixtures/regexp-unicode-surrogate-mask.js      | 60 ++++++++++++++++++++++
 test/js/bun/jsc-stress/jsc-stress.test.ts          |  2 +
 .../bun/jsc/regexp-unicode-surrogate-mask.test.ts  | 57 ++++++++++++++++++++
 3 files changed, 119 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…un/jsc-stress/fixtures/regexp-unicode-surrogate-mask.js      0      0      0
test/js/bun/jsc-stress/jsc-stress.test.ts                     1      2      0
test/js/bun/jsc/regexp-unicode-surrogate-mask.test.ts         1      2      0
```

</details>

<!-- robobun:evidence:end -->