### PR TITLE
Fix --bytecode cache never being used when the bundle contains non-ASCII bytes

### DIFF
--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1041,7 +1041,7 @@ impl TranspilerJob {
                 _ => (ptr::null_mut(), 0),
             };
             self.resolved_source = OwnedResolvedSource::from(ResolvedSource {
-                source_code: String::clone_latin1(&parse_result.source.contents),
+                source_code: String::clone_utf8(&parse_result.source.contents),
                 already_bundled: true,
                 bytecode_cache,
                 bytecode_cache_size,

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -183,6 +183,16 @@ extern "C" void CachedBytecode__deref(JSC::CachedBytecode* cachedBytecode)
     cachedBytecode->deref();
 }
 
+// The cache key includes the source's length and hash, so the string parsed here has to be
+// the string the runtime will build from the same bytes: Bun::toString(bytes, length)
+// (8-bit when all-ASCII, otherwise decoded as UTF-8), not the bytes reinterpreted as Latin-1.
+static WTF::String sourceStringForBytecodeCache(const Latin1Character* bytes, size_t length)
+{
+    if (!length)
+        return emptyString();
+    return Bun::toString(reinterpret_cast<const char*>(bytes), length).transferToWTFString();
+}
+
 static JSC::VM& getVMForBytecodeCache()
 {
     static thread_local JSC::VM* vmForBytecodeCache = nullptr;
@@ -198,8 +208,7 @@ static JSC::VM& getVMForBytecodeCache()
 
 extern "C" bool generateCachedModuleByteCodeFromSourceCode(BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr)
 {
-    std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
-    JSC::SourceCode sourceCode = JSC::makeSource(WTF::String(sourceCodeSpan), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
+    JSC::SourceCode sourceCode = JSC::makeSource(sourceStringForBytecodeCache(inputSourceCode, inputSourceCodeSize), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
 
     JSC::VM& vm = getVMForBytecodeCache();
 
@@ -233,9 +242,8 @@ extern "C" bool generateCachedModuleByteCodeFromSourceCode(BunString* sourceProv
 
 extern "C" bool generateCachedCommonJSProgramByteCodeFromSourceCode(BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr)
 {
-    std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
+    JSC::SourceCode sourceCode = JSC::makeSource(sourceStringForBytecodeCache(inputSourceCode, inputSourceCodeSize), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
 
-    JSC::SourceCode sourceCode = JSC::makeSource(WTF::String(sourceCodeSpan), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
     JSC::VM& vm = getVMForBytecodeCache();
 
     JSC::JSLockHolder locker(vm);

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2978,7 +2978,7 @@ fn transpile_source_code_inner(
                         _ => (core::ptr::null_mut(), 0),
                     };
                     return Ok(OwnedResolvedSource::from(ResolvedSource {
-                        source_code: bun_core::String::clone_latin1(&source.contents),
+                        source_code: bun_core::String::clone_utf8(&source.contents),
                         specifier: input_specifier.dupe_ref(),
                         source_url: create_if_different(input_specifier, path.text),
                         already_bundled: true,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -137,6 +137,32 @@ describe("bundler", () => {
       },
     },
   });
+  // A non-ASCII byte anywhere in the output (here: preserved legal comments)
+  // makes the runtime decode the chunk as UTF-8; the bytecode has to be keyed
+  // on that same string or the cache never hits.
+  for (const format of ["cjs", "esm"] as const) {
+    itBundled("compile/BytecodeNonAsciiSource+" + format, {
+      compile: true,
+      bytecode: true,
+      format,
+      files: {
+        "/entry.ts": `
+          /*! (c) Jimmy Wärting */
+          import { greet } from "./lib";
+          console.log(greet("café"));
+        `,
+        "/lib.ts": `
+          //! © üñîçødé
+          export function greet(s: string) { return "héllo " + s + " ☃"; }
+        `,
+      },
+      run: {
+        stdout: "héllo café ☃",
+        stderr: ["[Disk Cache] Cache hit for sourceCode", "[Disk Cache] Cache miss for sourceCode"].join("\n"),
+        env: { BUN_JSC_verboseDiskCache: "1" },
+      },
+    });
+  }
 
   // `import defer * as ns from "..."` must not break bytecode generation.
   // The bundler inlines the deferred module into the entry chunk (documented


### PR DESCRIPTION
### What does this PR do?

A single non-ASCII byte in a bundled chunk — e.g. a preserved `/*! (c) Jimmy Wärting */` license comment from `formdata-polyfill` — made `bun build --compile --bytecode` output that never used its bytecode. The runtime decodes such a chunk as UTF-8, but the bytecode was generated against the same bytes reinterpreted as Latin-1, so the source length and hash in JSC's cache key never matched and the executable silently fell back to parsing while still carrying the full bytecode (on an express/mongodb/pg bundle: 17.5 MB of bytecode, zero startup benefit).

The fix generates the bytecode from the string the runtime will actually build (`Bun::toString`: 8-bit when all-ASCII, UTF-8 decoded otherwise) — `sourceStringForBytecodeCache` in `ZigSourceProvider.cpp` — and decodes on-disk `.jsc`-backed sources the same way (`clone_utf8` instead of `clone_latin1` in `jsc_hooks.rs` / `RuntimeTranspilerStore.rs`) so that path keeps matching too.

### How did you verify your code works?

- New test `compile/BytecodeNonAsciiSource+{cjs,esm}` in `bundler_compile.test.ts`: expects `[Disk Cache] Cache hit` for a bundle with non-ASCII legal comments. Fails with `USE_SYSTEM_BUN=1` (1.4.0), passes on `bun bd`.
- Manually: `bun build --compile --bytecode` of an express+fastify+mongodb+pg+undici bundle goes from `Cache miss` / 131 ms startup to `Cache hit` / 70 ms; `bun build --bytecode --outdir` + `bun out/entry.js` still hits.