### PR TITLE
Propagate the thrown value from toSatisfy / websocket handlers; check the scope after module resolution

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1456,14 +1456,16 @@ unsafe extern "C" fn Zig__GlobalObject__resolve(
     let (global, specifier, source) = unsafe { (&*global, *specifier, *source) };
     // SAFETY: C++ passes valid non-null pointers.
     let (res, query) = unsafe { (&mut *res, &mut *query) };
-    if let Err(_) = VirtualMachine::resolve(
+    if VirtualMachine::resolve(
         res,
         global,
         specifier,
         source,
         Some(query),
         crate::virtual_machine::ResolveMode::Esm,
-    ) {
+    )
+    .is_err()
+    {
         debug_assert!(global.has_exception());
     }
 }

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1456,7 +1456,7 @@ unsafe extern "C" fn Zig__GlobalObject__resolve(
     let (global, specifier, source) = unsafe { (&*global, *specifier, *source) };
     // SAFETY: C++ passes valid non-null pointers.
     let (res, query) = unsafe { (&mut *res, &mut *query) };
-    match VirtualMachine::resolve(
+    if let Err(_) = VirtualMachine::resolve(
         res,
         global,
         specifier,
@@ -1464,10 +1464,7 @@ unsafe extern "C" fn Zig__GlobalObject__resolve(
         Some(query),
         crate::virtual_machine::ResolveMode::Esm,
     ) {
-        Ok(()) => {}
-        Err(_) => {
-            debug_assert!(!res.success);
-        }
+        debug_assert!(global.has_exception());
     }
 }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3364,13 +3364,17 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
 
     WTF::String keyString;
     if (key.isString()) {
-        keyString = uncheckedDowncast<JSString>(key)->value(globalObject);
+        auto moduleName = uncheckedDowncast<JSString>(key)->value(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
-        if (keyString.startsWith("file://"_s)) {
-            auto url = WTF::URL(keyString);
+        if (moduleName->startsWith("file://"_s)) {
+            auto url = WTF::URL(moduleName);
             if (url.isValid() && !url.isEmpty()) {
                 keyString = url.fileSystemPath();
+            } else {
+                keyString = moduleName;
             }
+        } else {
+            keyString = moduleName;
         }
     } else {
         keyString = key.toWTFString(globalObject);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -228,7 +228,6 @@
 #endif
 
 #include <wtf/NumberOfCores.h>
-#include <wtf/Scope.h>
 
 using namespace Bun;
 
@@ -3363,40 +3362,28 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    ErrorableString res;
-    res.success = false;
-
-    BunString keyZ = BunStringEmpty;
-    BunString referrerZ = BunStringEmpty;
-    auto derefStrings = WTF::makeScopeExit([&] {
-        keyZ.deref();
-        referrerZ.deref();
-    });
+    WTF::String keyString;
     if (key.isString()) {
-        auto moduleName = uncheckedDowncast<JSString>(key)->value(globalObject);
+        keyString = uncheckedDowncast<JSString>(key)->value(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
-        if (moduleName->startsWith("file://"_s)) {
-            auto url = WTF::URL(moduleName);
+        if (keyString.startsWith("file://"_s)) {
+            auto url = WTF::URL(keyString);
             if (url.isValid() && !url.isEmpty()) {
-                keyZ = Bun::toStringRef(url.fileSystemPath());
-            } else {
-                keyZ = Bun::toStringRef(moduleName);
+                keyString = url.fileSystemPath();
             }
-        } else {
-            keyZ = Bun::toStringRef(moduleName);
         }
-
     } else {
-        keyZ = Bun::toStringRef(globalObject, key);
+        keyString = key.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
     }
+    WTF::String referrerString;
     if (referrer && referrer.isString()) {
-        referrerZ = Bun::toStringRef(globalObject, referrer);
+        referrerString = referrer.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
     }
 
     if (globalObject->onLoadPlugins.hasVirtualModules()) {
-        if (auto resolvedString = globalObject->onLoadPlugins.resolveVirtualModule(keyZ.toWTFString(), referrerZ.toWTFString())) {
+        if (auto resolvedString = globalObject->onLoadPlugins.resolveVirtualModule(keyString, referrerString)) {
             return Identifier::fromString(vm, resolvedString.value());
         }
     } else {
@@ -3414,36 +3401,36 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
     // as "ns:..." in source. The proper fix is for moduleLoaderImportModule
     // to mark keys it already resolved so we can skip only those.
     if (!globalObject->onLoadPlugins.namespaces.isEmpty()) {
-        auto keyStr = keyZ.toWTFString();
-        if (auto colon = keyStr.find(':'); colon != WTF::notFound && !(colon == 1 && isASCIIAlpha(keyStr[0]))) {
+        if (auto colon = keyString.find(':'); colon != WTF::notFound && !(colon == 1 && isASCIIAlpha(keyString[0]))) {
             // colon == 1 with a leading ASCII letter is a Windows drive
             // ("C:\\..."), never a plugin namespace.
-            auto ns = keyStr.left(colon);
+            auto ns = keyString.left(colon);
             for (const auto& registered : globalObject->onLoadPlugins.namespaces) {
                 if (registered == ns) {
-                    return Identifier::fromString(vm, keyStr);
+                    return Identifier::fromString(vm, keyString);
                 }
             }
         }
     }
 
-    BunString queryString = BunStringEmpty;
-    Zig__GlobalObject__resolve(&res, globalObject, &keyZ, &referrerZ, &queryString);
+    ErrorableString res;
+    res.success = false;
+    BunString keyZ = Bun::toString(keyString);
+    BunString referrerZ = Bun::toString(referrerString);
+    BunString queryZ = BunStringEmpty;
+    Zig__GlobalObject__resolve(&res, globalObject, &keyZ, &referrerZ, &queryZ);
     RETURN_IF_EXCEPTION(scope, {});
-
     if (!res.success) {
         throwException(scope, res.result.err, globalObject);
         return {};
     }
-    auto derefResult = WTF::makeScopeExit([&] {
-        res.result.value.deref();
-        queryString.deref();
-    });
+    auto resolved = res.result.value.transferToWTFString();
+    auto query = queryZ.transferToWTFString();
 
-    if (!queryString.isEmpty()) {
-        return JSC::Identifier::fromString(vm, makeString(res.result.value.toWTFString(BunString::ZeroCopy), queryString.toWTFString(BunString::ZeroCopy)));
+    if (!query.isEmpty()) {
+        return Identifier::fromString(vm, makeString(resolved, query));
     }
-    return Identifier::fromString(vm, res.result.value.toWTFString(BunString::ZeroCopy));
+    return Identifier::fromString(vm, resolved);
 }
 
 JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalObject,
@@ -3505,46 +3492,31 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     }
 
     {
-        ErrorableString resolved;
-        memset(&resolved, 0, sizeof(resolved));
-
-        BunString moduleNameZ = BunStringEmpty;
-        BunString sourceOriginZ = BunStringEmpty;
-        auto derefStrings = WTF::makeScopeExit([&] {
-            moduleNameZ.deref();
-            sourceOriginZ.deref();
-        });
-        String moduleStringHolder;
         if (moduleName.startsWith("file://"_s)) {
             auto url = WTF::URL(moduleName);
             if (url.isValid() && !url.isEmpty()) {
-                moduleStringHolder = url.fileSystemPath();
-                moduleNameZ = Bun::toStringRef(moduleStringHolder);
-            } else {
-                moduleNameZ = Bun::toStringRef(moduleName);
+                moduleName = url.fileSystemPath();
             }
-        } else {
-            moduleNameZ = Bun::toStringRef(moduleName);
         }
 
-        BunString queryString = BunStringEmpty;
-        sourceOriginZ = Bun::toStringRef(sourceOriginStringHolder);
-
-        Zig__GlobalObject__resolve(&resolved, globalObject, &moduleNameZ, &sourceOriginZ, &queryString);
+        ErrorableString res;
+        res.success = false;
+        BunString moduleNameZ = Bun::toString(moduleName);
+        BunString sourceOriginZ = Bun::toString(sourceOriginStringHolder);
+        BunString queryZ = BunStringEmpty;
+        Zig__GlobalObject__resolve(&res, globalObject, &moduleNameZ, &sourceOriginZ, &queryZ);
         RETURN_IF_EXCEPTION(scope, JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope));
-        if (!resolved.success) [[unlikely]] {
-            throwException(scope, resolved.result.err, globalObject);
+        if (!res.success) [[unlikely]] {
+            throwException(scope, res.result.err, globalObject);
             return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
         }
-        auto derefResult = WTF::makeScopeExit([&] {
-            resolved.result.value.deref();
-            queryString.deref();
-        });
+        auto resolved = res.result.value.transferToWTFString();
+        auto query = queryZ.transferToWTFString();
 
-        if (queryString.isEmpty()) {
-            resolvedIdentifier = JSC::Identifier::fromString(vm, resolved.result.value.toWTFString());
+        if (query.isEmpty()) {
+            resolvedIdentifier = JSC::Identifier::fromString(vm, resolved);
         } else {
-            resolvedIdentifier = JSC::Identifier::fromString(vm, makeString(resolved.result.value.toWTFString(BunString::ZeroCopy), queryString.toWTFString(BunString::ZeroCopy)));
+            resolvedIdentifier = JSC::Identifier::fromString(vm, makeString(resolved, query));
         }
     }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3435,17 +3435,15 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
         throwException(scope, res.result.err, globalObject);
         return {};
     }
-
-    if (!queryString.isEmpty()) {
-        auto result = JSC::Identifier::fromString(vm, makeString(res.result.value.toWTFString(BunString::ZeroCopy), queryString.toWTFString(BunString::ZeroCopy)));
+    auto derefResult = WTF::makeScopeExit([&] {
         res.result.value.deref();
         queryString.deref();
-        return result;
-    }
+    });
 
-    auto result = Identifier::fromString(vm, res.result.value.toWTFString(BunString::ZeroCopy));
-    res.result.value.deref();
-    return result;
+    if (!queryString.isEmpty()) {
+        return JSC::Identifier::fromString(vm, makeString(res.result.value.toWTFString(BunString::ZeroCopy), queryString.toWTFString(BunString::ZeroCopy)));
+    }
+    return Identifier::fromString(vm, res.result.value.toWTFString(BunString::ZeroCopy));
 }
 
 JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalObject,
@@ -3538,15 +3536,16 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
             throwException(scope, resolved.result.err, globalObject);
             return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
         }
+        auto derefResult = WTF::makeScopeExit([&] {
+            resolved.result.value.deref();
+            queryString.deref();
+        });
 
         if (queryString.isEmpty()) {
             resolvedIdentifier = JSC::Identifier::fromString(vm, resolved.result.value.toWTFString());
         } else {
             resolvedIdentifier = JSC::Identifier::fromString(vm, makeString(resolved.result.value.toWTFString(BunString::ZeroCopy), queryString.toWTFString(BunString::ZeroCopy)));
-            queryString.deref();
         }
-
-        resolved.result.value.deref();
     }
 
     // The C++ module loader now extracts `with.type` into a

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -228,6 +228,7 @@
 #endif
 
 #include <wtf/NumberOfCores.h>
+#include <wtf/Scope.h>
 
 using namespace Bun;
 
@@ -3359,13 +3360,21 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
     JSValue referrer, RefPtr<JSC::ScriptFetcher>, bool)
 {
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(jsGlobalObject);
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     ErrorableString res;
     res.success = false;
 
-    BunString keyZ;
+    BunString keyZ = BunStringEmpty;
+    BunString referrerZ = BunStringEmpty;
+    auto derefStrings = WTF::makeScopeExit([&] {
+        keyZ.deref();
+        referrerZ.deref();
+    });
     if (key.isString()) {
         auto moduleName = uncheckedDowncast<JSString>(key)->value(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
         if (moduleName->startsWith("file://"_s)) {
             auto url = WTF::URL(moduleName);
             if (url.isValid() && !url.isEmpty()) {
@@ -3379,12 +3388,16 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
 
     } else {
         keyZ = Bun::toStringRef(globalObject, key);
+        RETURN_IF_EXCEPTION(scope, {});
     }
-    BunString referrerZ = referrer && !referrer.isUndefinedOrNull() && referrer.isString() ? Bun::toStringRef(globalObject, referrer) : BunStringEmpty;
+    if (referrer && referrer.isString()) {
+        referrerZ = Bun::toStringRef(globalObject, referrer);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
 
     if (globalObject->onLoadPlugins.hasVirtualModules()) {
         if (auto resolvedString = globalObject->onLoadPlugins.resolveVirtualModule(keyZ.toWTFString(), referrerZ.toWTFString())) {
-            return Identifier::fromString(globalObject->vm(), resolvedString.value());
+            return Identifier::fromString(vm, resolvedString.value());
         }
     } else {
         ASSERT(!globalObject->onLoadPlugins.mustDoExpensiveRelativeLookup);
@@ -3408,35 +3421,31 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
             auto ns = keyStr.left(colon);
             for (const auto& registered : globalObject->onLoadPlugins.namespaces) {
                 if (registered == ns) {
-                    keyZ.deref();
-                    referrerZ.deref();
-                    return Identifier::fromString(globalObject->vm(), keyStr);
+                    return Identifier::fromString(vm, keyStr);
                 }
             }
         }
     }
 
-    BunString queryString = { BunStringTag::Empty, nullptr };
+    BunString queryString = BunStringEmpty;
     Zig__GlobalObject__resolve(&res, globalObject, &keyZ, &referrerZ, &queryString);
-    keyZ.deref();
-    referrerZ.deref();
+    RETURN_IF_EXCEPTION(scope, {});
 
-    if (res.success) {
-        if (!queryString.isEmpty()) {
-            auto result = JSC::Identifier::fromString(globalObject->vm(), makeString(res.result.value.toWTFString(BunString::ZeroCopy), queryString.toWTFString(BunString::ZeroCopy)));
-            res.result.value.deref();
-            queryString.deref();
-            return result;
-        }
-
-        auto result = Identifier::fromString(globalObject->vm(), res.result.value.toWTFString(BunString::ZeroCopy));
-        res.result.value.deref();
-        return result;
-    } else {
-        auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    if (!res.success) {
         throwException(scope, res.result.err, globalObject);
-        return globalObject->vm().propertyNames->emptyIdentifier;
+        return {};
     }
+
+    if (!queryString.isEmpty()) {
+        auto result = JSC::Identifier::fromString(vm, makeString(res.result.value.toWTFString(BunString::ZeroCopy), queryString.toWTFString(BunString::ZeroCopy)));
+        res.result.value.deref();
+        queryString.deref();
+        return result;
+    }
+
+    auto result = Identifier::fromString(vm, res.result.value.toWTFString(BunString::ZeroCopy));
+    res.result.value.deref();
+    return result;
 }
 
 JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalObject,
@@ -3501,7 +3510,12 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         ErrorableString resolved;
         memset(&resolved, 0, sizeof(resolved));
 
-        BunString moduleNameZ;
+        BunString moduleNameZ = BunStringEmpty;
+        BunString sourceOriginZ = BunStringEmpty;
+        auto derefStrings = WTF::makeScopeExit([&] {
+            moduleNameZ.deref();
+            sourceOriginZ.deref();
+        });
         String moduleStringHolder;
         if (moduleName.startsWith("file://"_s)) {
             auto url = WTF::URL(moduleName);
@@ -3515,21 +3529,13 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
             moduleNameZ = Bun::toStringRef(moduleName);
         }
 
-        BunString queryString = { BunStringTag::Empty, nullptr };
-        auto sourceOriginZ = Bun::toStringRef(sourceOriginStringHolder);
+        BunString queryString = BunStringEmpty;
+        sourceOriginZ = Bun::toStringRef(sourceOriginStringHolder);
 
         Zig__GlobalObject__resolve(&resolved, globalObject, &moduleNameZ, &sourceOriginZ, &queryString);
-
-        // If resolution failed, make sure it becomes a pending exception
-        if (!resolved.success && !scope.exception()) [[unlikely]] {
+        RETURN_IF_EXCEPTION(scope, JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope));
+        if (!resolved.success) [[unlikely]] {
             throwException(scope, resolved.result.err, globalObject);
-        }
-
-        // And convert that pending exception into a rejected promise.
-        if (scope.exception()) [[unlikely]] {
-            moduleNameZ.deref();
-            sourceOriginZ.deref();
-
             return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
         }
 
@@ -3541,8 +3547,6 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         }
 
         resolved.result.value.deref();
-        moduleNameZ.deref();
-        sourceOriginZ.deref();
     }
 
     // The C++ module loader now extracts `with.type` into a

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -63,13 +63,14 @@ JSC::Identifier bakeModuleLoaderResolve(JSC::JSGlobalObject* jsGlobal,
 
     if (auto string = dynamicDowncast<JSC::JSString>(referrer)) {
         WTF::String refererString = string->getString(global);
+        RETURN_IF_EXCEPTION(scope, {});
 
         WTF::String keyString = key.toWTFString(global);
-        RETURN_IF_EXCEPTION(scope, vm.propertyNames->emptyIdentifier);
+        RETURN_IF_EXCEPTION(scope, {});
 
         if (refererString.startsWith("bake:/"_s) || (refererString == "."_s && keyString.startsWith("bake:/"_s))) {
-            BunString result = BakeProdResolve(global, Bun::toString(referrer.getString(global)), Bun::toString(keyString));
-            RETURN_IF_EXCEPTION(scope, vm.propertyNames->emptyIdentifier);
+            BunString result = BakeProdResolve(global, Bun::toString(refererString), Bun::toString(keyString));
+            RETURN_IF_EXCEPTION(scope, {});
 
             return JSC::Identifier::fromString(vm, result.toWTFString(BunString::ZeroCopy));
         }
@@ -77,11 +78,11 @@ JSC::Identifier bakeModuleLoaderResolve(JSC::JSGlobalObject* jsGlobal,
 
     if (auto string = dynamicDowncast<JSC::JSString>(key)) {
         auto keyView = string->getString(global);
-        RETURN_IF_EXCEPTION(scope, vm.propertyNames->emptyIdentifier);
+        RETURN_IF_EXCEPTION(scope, {});
 
         if (keyView.startsWith("bake:/"_s)) {
             BunString result = BakeProdResolve(global, Bun::toString("bake:/"_s), Bun::toString(keyView.substringSharingImpl("bake:"_s.length())));
-            RETURN_IF_EXCEPTION(scope, vm.propertyNames->emptyIdentifier);
+            RETURN_IF_EXCEPTION(scope, {});
 
             return JSC::Identifier::fromString(vm, result.transferToWTFString());
         }

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -452,10 +452,8 @@ impl ServerWebSocket {
             result: Ok(JSValue::ZERO),
         };
         ws.cork(&mut corker, Corker::run);
-        let result = corker
-            .result
-            .unwrap_or_else(|e| global_object.take_exception(e));
-        if let Some(err_value) = result.to_error() {
+        if let Err(e) = corker.result {
+            let err_value = global_object.take_error(e);
             bun_output::scoped_log!(WebSocketServer, "onOpen exception");
 
             let mut closed_here = false;
@@ -532,19 +530,15 @@ impl ServerWebSocket {
         };
 
         ws.cork(&mut corker, Corker::run);
-        let result = corker
-            .result
-            .unwrap_or_else(|e| global_object.take_exception(e));
-
-        if result.is_empty_or_undefined_or_null() {
-            return Ok(());
-        }
-
-        if let Some(err_value) = result.to_error() {
-            return self
-                .handler()
-                .run_error_callback(on_error, global_object, err_value);
-        }
+        let result = match corker.result {
+            Ok(result) => result,
+            Err(e) => {
+                let err_value = global_object.take_error(e);
+                return self
+                    .handler()
+                    .run_error_callback(on_error, global_object, err_value);
+            }
+        };
 
         if let Some(promise) = result.as_any_promise() {
             match promise.status() {
@@ -595,11 +589,8 @@ impl ServerWebSocket {
             };
             let _loop_guard = vm.enter_event_loop_scope();
             self.websocket().cork(&mut corker, Corker::run);
-            let result = corker
-                .result
-                .unwrap_or_else(|e| global_object.take_exception(e));
-
-            if let Some(err_value) = result.to_error() {
+            if let Err(e) = corker.result {
+                let err_value = global_object.take_error(e);
                 handler.run_error_callback(on_error, global_object, err_value)?;
             }
         }

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -648,7 +648,7 @@ impl ServerWebSocket {
             data,
         ];
         if let Err(e) = cb.call(global_this, JSValue::UNDEFINED, &args) {
-            let err = global_this.take_exception(e);
+            let err = global_this.take_error(e);
             bun_output::scoped_log!(WebSocketServer, "onPing error");
             handler.run_error_callback(on_error, global_this, err)?;
         }
@@ -680,7 +680,7 @@ impl ServerWebSocket {
             data,
         ];
         if let Err(e) = cb.call(global_this, JSValue::UNDEFINED, &args) {
-            let err = global_this.take_exception(e);
+            let err = global_this.take_error(e);
             bun_output::scoped_log!(WebSocketServer, "onPong error");
             handler.run_error_callback(on_error, global_this, err)?;
         }
@@ -771,7 +771,7 @@ impl ServerWebSocket {
             let message_js = match jsc::bun_string_jsc::create_utf8_for_js(global_object, message) {
                 Ok(v) => v,
                 Err(e) => {
-                    let err = global_object.take_exception(e);
+                    let err = global_object.take_error(e);
                     bun_output::scoped_log!(
                         WebSocketServer,
                         "onClose error (message) {}",
@@ -783,7 +783,7 @@ impl ServerWebSocket {
 
             let call_args = [cached_this, JSValue::js_number(code as f64), message_js];
             if let Err(e) = on_close_handler.call(global_object, JSValue::UNDEFINED, &call_args) {
-                let err = global_object.take_exception(e);
+                let err = global_object.take_error(e);
                 bun_output::scoped_log!(WebSocketServer, "onClose error {}", was_not_empty);
                 return handler.run_error_callback(on_error, global_object, err);
             }

--- a/src/runtime/test_runner/expect/toSatisfy.rs
+++ b/src/runtime/test_runner/expect/toSatisfy.rs
@@ -1,5 +1,4 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
-use bun_core::ZigString;
 
 use super::Expect;
 use super::get_signature;
@@ -33,14 +32,7 @@ pub(crate) fn to_satisfy(this: &Expect, global: &JSGlobalObject, frame: &CallFra
     };
     value.ensure_still_alive();
 
-    let result = match predicate.call(global, JSValue::UNDEFINED, &[value]) {
-        Ok(r) => r,
-        Err(e) => {
-            let err = global.take_exception(e);
-            let fmt = ZigString::init(b"toSatisfy() predicate threw an exception");
-            return Err(global.throw_value(global.create_aggregate_error(&[err], &fmt)?));
-        }
-    };
+    let result = predicate.call(global, JSValue::UNDEFINED, &[value])?;
 
     let not = this.flags.get().not();
     let pass = (result.is_boolean() && result.to_boolean()) != not;

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -920,6 +920,34 @@ describe.concurrent("Bun.plugin.clearAll()", () => {
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "result=1", stderr: "", exitCode: 0 });
   });
 
+  it("an onResolve error propagates out of a static import in a later-loaded module", async () => {
+    using dir = tempDir("onresolve-throws-static", {
+      "entry.mjs": `import "./dep.custom"; export default 1;`,
+      "main.mjs": `
+        Bun.plugin({ name: "throws", setup(b) { b.onResolve({ filter: /\.custom$/ }, () => { throw new Error("resolve boom"); }); } });
+        try {
+          await import("./entry.mjs");
+          console.log("resolved");
+        } catch (e) {
+          console.log("caught=" + e.message);
+        }
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
+      stdout: "caught=resolve boom",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   it("re-registering a namespaced onResolve plugin after clearAll() drops the old callback", async () => {
     const { stdout, stderr, exitCode } = await run(`
       Bun.plugin({

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -924,7 +924,7 @@ describe.concurrent("Bun.plugin.clearAll()", () => {
     using dir = tempDir("onresolve-throws-static", {
       "entry.mjs": `import "./dep.custom"; export default 1;`,
       "main.mjs": `
-        Bun.plugin({ name: "throws", setup(b) { b.onResolve({ filter: /\.custom$/ }, () => { throw new Error("resolve boom"); }); } });
+        Bun.plugin({ name: "throws", setup(b) { b.onResolve({ filter: /\\.custom$/ }, () => { throw new Error("resolve boom"); }); } });
         try {
           await import("./entry.mjs");
           console.log("resolved");

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -175,19 +175,26 @@ describe("jest-extended", () => {
     expect({ foo: "bun" }).not.toSatisfy(fooIsBar);
     expect({ bar: "foo" }).not.toSatisfy(fooIsBar);
 
-    // Test errors
-    // @ts-expect-error
-    expect(() =>
+    // A throwing predicate propagates its own error (same as jest-extended).
+    const err = new Error("Bun!");
+    let caught;
+    try {
       expect(1).toSatisfy(() => {
-        throw new Error("Bun!");
-      }),
-    ).toThrow("predicate threw an exception");
-    // @ts-expect-error
-    expect(() =>
+        throw err;
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBe(err);
+    caught = undefined;
+    try {
       expect(1).not.toSatisfy(() => {
-        throw new Error("Bun!");
-      }),
-    ).toThrow("predicate threw an exception");
+        throw err;
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBe(err);
   });
 
   // Array

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -175,26 +175,19 @@ describe("jest-extended", () => {
     expect({ foo: "bun" }).not.toSatisfy(fooIsBar);
     expect({ bar: "foo" }).not.toSatisfy(fooIsBar);
 
-    // A throwing predicate propagates its own error (same as jest-extended).
-    const err = new Error("Bun!");
-    let caught;
-    try {
+    // Test errors
+    // @ts-expect-error
+    expect(() =>
       expect(1).toSatisfy(() => {
-        throw err;
-      });
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBe(err);
-    caught = undefined;
-    try {
+        throw new Error("Bun!");
+      }),
+    ).toThrow("Bun!");
+    // @ts-expect-error
+    expect(() =>
       expect(1).not.toSatisfy(() => {
-        throw err;
-      });
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBe(err);
+        throw new Error("Bun!");
+      }),
+    ).toThrow("Bun!");
   });
 
   // Array

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -671,6 +671,29 @@ describe("Server", () => {
         done();
       },
     }));
+    for (const hook of ["ping", "pong", "close"] as const) {
+      test(`${hook} handler that throws passes its error to error()`, done => {
+        const thrown = new Error(`${hook} threw`);
+        return {
+          open(ws) {
+            if (hook === "ping") ws.ping();
+            else if (hook === "pong") ws.pong();
+            else ws.close();
+          },
+          [hook]() {
+            throw thrown;
+          },
+          error(error) {
+            try {
+              expect(error).toBe(thrown);
+              done();
+            } catch (e) {
+              done(e);
+            }
+          },
+        };
+      });
+    }
     test("maxPayloadLength", done => ({
       maxPayloadLength: 4,
       open(ws) {

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -671,6 +671,18 @@ describe("Server", () => {
         done();
       },
     }));
+    test("returning an Error from message() is not treated as a throw", (done, connect) => ({
+      open(ws) {
+        ws.send("trigger");
+      },
+      message(ws) {
+        queueMicrotask(() => done());
+        return new Error("returned, not thrown");
+      },
+      error(error) {
+        done(error);
+      },
+    }));
     for (const hook of ["ping", "pong", "close"] as const) {
       test(`${hook} handler that throws passes its error to error()`, done => {
         const thrown = new Error(`${hook} threw`);


### PR DESCRIPTION
### What does this PR do?

Three places handed on something other than the exception that was actually thrown.

- **`expect(x).toSatisfy(predicate)`** — when `predicate` throws, the matcher took the pending exception and wrapped JSC's internal `Exception` cell (not its value) in an `AggregateError`. `e.errors[0]` was then a non-object cell; `Object.prototype.toString.call(e.errors[0])` / `console.log(e)` crashed. The predicate's error now simply propagates, which is also what jest-extended does.
- **`Bun.serve` websocket handlers** — a throw from `ping` / `pong` / `close` was passed to the `error` handler as that same internal cell (`error.message === undefined`); they now pass the thrown value. `open` / `message` / `drain` got there by folding the throw into the call's *return value* and testing `result.to_error()`, which also meant a handler that merely `return`ed an `Error` was treated as having thrown; all six now use one shape — only `Err` from the call is an error, the `Ok` value is just a return value.
- **`moduleLoaderResolve` / `moduleLoaderImportModule`** — `Zig__GlobalObject__resolve` either fills in its out-param or throws. When it threw (a `Bun.plugin` `onResolve` hook throwing while a *static* import is resolved, or building the `ResolveMessage` failing), `moduleLoaderResolve` still read the never-written error slot of the out-param and threw that over the pending exception. Both callers now declare their scope up front and `RETURN_IF_EXCEPTION` directly after the call. The key/referrer are kept as `WTF::String` and lent to the resolver as non-owning `BunString`s, and the two strings it returns are adopted with `transferToWTFString()` straight after the success check, so no return path has anything to release by hand; the `JSString::value()` / `toWTFString` conversions before the call are checked too. This is allocation- and copy-neutral against main (same conversions per `BunString` tag, same `URL`/`startsWith`/`find` work) and drops a few ref/deref pairs per resolve: the inputs are no longer ref'd into owned `BunString`s and back, and the virtual-module / namespace checks use the locals instead of materialising temporary `String`s from them. `bakeModuleLoaderResolve` (the `bun build --app` global's override, same shape) gets the same treatment: `{}` rather than `emptyIdentifier` on exception, and a check after each `getString`.

### How did you verify your code works?

New tests: `jest-extended.test.js` (`toSatisfy` rethrows the predicate's own error), `websocket-server.test.ts` (`ping`/`pong`/`close` handler that throws → `error(err)` receives that error; `message()` returning an `Error` is not routed to `error()`), `plugins.test.ts` (an `onResolve` throw surfaces from a static import in a later-loaded module). The first two fail on current release (`Received: [native code: Exception]`); the third exercises the resolve path under the ASAN validator lane. `plugins.test.ts` 47/47, `jest-extended.test.js` 58/58, `websocket-server.test.ts` 132/132 on a debug build.



