### PR TITLE
bun:test: remove unsafe from the test runner

### DIFF
--- a/src/bun_core/atomic_cell.rs
+++ b/src/bun_core/atomic_cell.rs
@@ -582,6 +582,85 @@ impl<T: Default> Default for ThreadCell<T> {
     }
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// ThreadBound<T>
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A `static`-friendly slot for a `Copy` value that only the thread which
+/// stored it can read back. [`get`](Self::get) on any other thread returns
+/// `None`, and the owner check is a release-mode branch (one TLS load of a
+/// never-reused per-thread token) — that check, not a comment, is what makes
+/// the `Sync` impl sound for `!Sync` payloads such as a `&'static` to
+/// thread-affine state.
+pub struct ThreadBound<T: Copy> {
+    owner: AtomicU64,
+    value: UnsafeCell<Option<T>>,
+}
+
+// SAFETY: `value` is only ever read or written by the thread recorded in
+// `owner` (checked on every access, in all build modes); every other thread
+// observes only the atomic `owner` word.
+unsafe impl<T: Copy> Sync for ThreadBound<T> {}
+
+impl<T: Copy> Default for ThreadBound<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Copy> ThreadBound<T> {
+    pub const fn new() -> Self {
+        Self {
+            owner: AtomicU64::new(0),
+            value: UnsafeCell::new(None),
+        }
+    }
+
+    /// A process-unique token for the calling thread (never 0, never reused
+    /// by a later thread, unlike OS thread ids).
+    #[inline]
+    fn current() -> u64 {
+        static NEXT: AtomicU64 = AtomicU64::new(1);
+        #[thread_local]
+        static TOKEN: core::cell::Cell<u64> = core::cell::Cell::new(0);
+        let t = TOKEN.get();
+        if t != 0 {
+            return t;
+        }
+        let t = NEXT.fetch_add(1, Ordering::Relaxed);
+        TOKEN.set(t);
+        t
+    }
+
+    /// The stored value, if the calling thread is the one that stored it.
+    #[inline]
+    pub fn get(&self) -> Option<T> {
+        if self.owner.load(Ordering::Acquire) != Self::current() {
+            return None;
+        }
+        // SAFETY: this thread is the owner; no other thread touches `value`.
+        unsafe { *self.value.get() }
+    }
+
+    /// Store `value`, binding the slot to the calling thread on first use.
+    /// Panics if a different thread already owns the slot.
+    pub fn set(&self, value: Option<T>) {
+        let me = Self::current();
+        match self
+            .owner
+            .compare_exchange(0, me, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => {}
+            Err(prev) if prev == me => {}
+            Err(prev) => {
+                panic!("ThreadBound: thread {me} tried to set a slot owned by thread {prev}")
+            }
+        }
+        // SAFETY: this thread is (now) the owner; no other thread touches `value`.
+        unsafe { *self.value.get() = value };
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -23,7 +23,7 @@ pub mod result;
 pub mod thread_id;
 pub mod tty;
 pub mod util;
-pub use atomic_cell::{Atom, AtomicCell, ThreadCell};
+pub use atomic_cell::{Atom, AtomicCell, ThreadBound, ThreadCell};
 
 /// Shared state-machine tag for the streaming (de)compressors in
 /// `bun_brotli` / `bun_zlib` / `bun_zstd`.

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -36,6 +36,14 @@ pub unsafe fn bytes_as_slice_mut<T>(bytes: &mut [u8]) -> &mut [T] {
 #[derive(Copy, Clone)]
 pub struct Unaligned<T: Copy>(T);
 
+// SAFETY: `#[repr(C, packed)]` around a single `T: Zeroable` — same bytes, no
+// padding; the all-zero pattern is valid because it is for `T`.
+unsafe impl<T: bytemuck::Zeroable + Copy> bytemuck::Zeroable for Unaligned<T> {}
+// SAFETY: `#[repr(C, packed)]` around a single `T: Pod` — same size, align 1,
+// no padding, every bit pattern valid, `Copy + 'static`; so any byte slice whose
+// length is a multiple of `size_of::<T>()` casts to `&[Unaligned<T>]`.
+unsafe impl<T: bytemuck::Pod> bytemuck::Pod for Unaligned<T> {}
+
 impl<T: Copy> Unaligned<T> {
     #[inline(always)]
     pub fn get(self) -> T {

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -77,15 +77,15 @@ impl ManagedTask {
         fn run<T: RunOnce>(p: *mut c_void) -> JsResult<()> {
             // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`; `run`
             // passes it back exactly once.
-            T::run(*unsafe { Box::from_raw(p.cast::<T>()) })
+            T::run(*unsafe { bun_core::heap::take(p.cast::<T>()) })
         }
         fn drop_ctx<T: RunOnce>(p: *mut c_void) {
             // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`.
-            T::cancelled(*unsafe { Box::from_raw(p.cast::<T>()) });
+            T::cancelled(*unsafe { bun_core::heap::take(p.cast::<T>()) });
         }
         let managed = bun_core::heap::into_raw(Box::new(ManagedTask {
             callback: run::<T>,
-            ctx: NonNull::new(Box::into_raw(ctx).cast::<c_void>()),
+            ctx: NonNull::new(bun_core::heap::into_raw(ctx).cast::<c_void>()),
             cleanup: Some(drop_ctx::<T>),
         }));
         ManagedTask::task(managed)

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -6,6 +6,14 @@ use core::ptr::NonNull;
 
 use crate::{JsResult, Task};
 
+/// The context of a [`ManagedTask::new_boxed`] task.
+pub trait RunOnce: Sized {
+    fn run(self) -> JsResult<()>;
+    /// The task was released unrun (its VM is tearing down: script is
+    /// forbidden, the JSC heap is still alive). Default: just drop.
+    fn cancelled(self) {}
+}
+
 pub struct ManagedTask {
     // Opaque userdata pointer round-tripped through `new`/`run`; raw by design.
     pub ctx: Option<NonNull<c_void>>,
@@ -21,10 +29,10 @@ impl ManagedTask {
 
     /// # Safety
     /// `this` must be the live `*mut ManagedTask` embedded in a `Task` returned
-    /// by `new()`/`new_owned()`; ownership transfers — `this` is freed (via
+    /// by `new()`/`new_boxed()`; ownership transfers — `this` is freed (via
     /// `heap::take`) before return on both Ok and Err paths.
     pub unsafe fn run(this: *mut ManagedTask) -> JsResult<()> {
-        // SAFETY: `this` was produced by `heap::into_raw` in `new`/`new_owned`
+        // SAFETY: `this` was produced by `heap::into_raw` in `new`/`new_boxed`
         // (caller contract). Reconstituting the Box here frees it at scope
         // exit on both the Ok and Err paths.
         let this = unsafe { bun_core::heap::take(this) };
@@ -33,7 +41,7 @@ impl ManagedTask {
         callback(ctx.unwrap().as_ptr())
     }
 
-    /// Free without running: the owned context (if `new_owned`) is dropped.
+    /// Free without running: the owned context (if `new_boxed`) is dropped.
     ///
     /// # Safety
     /// As [`run`](Self::run); the task is not queued anywhere.
@@ -63,19 +71,21 @@ impl ManagedTask {
         ManagedTask::task(managed)
     }
 
-    pub fn new_owned<T>(ctx: *mut T, callback: fn(*mut T) -> JsResult<()>) -> Task {
-        fn drop_ctx<T>(p: *mut c_void) {
-            // SAFETY: `p` is the `heap::into_raw(Box<T>)` stored in `ctx` by `new_owned`.
-            unsafe { bun_core::heap::destroy(p.cast::<T>()) };
+    /// A task that owns `ctx` and [`run`](RunOnce::run)s it (or drops it if
+    /// the queue is released unrun).
+    pub fn new_boxed<T: RunOnce>(ctx: Box<T>) -> Task {
+        fn run<T: RunOnce>(p: *mut c_void) -> JsResult<()> {
+            // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`; `run`
+            // passes it back exactly once.
+            T::run(*unsafe { Box::from_raw(p.cast::<T>()) })
+        }
+        fn drop_ctx<T: RunOnce>(p: *mut c_void) {
+            // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`.
+            T::cancelled(*unsafe { Box::from_raw(p.cast::<T>()) });
         }
         let managed = bun_core::heap::into_raw(Box::new(ManagedTask {
-            // SAFETY: same fn-pointer ABI cast as `new`.
-            callback: unsafe {
-                bun_ptr::cast_fn_ptr::<fn(*mut T) -> JsResult<()>, fn(*mut c_void) -> JsResult<()>>(
-                    callback,
-                )
-            },
-            ctx: NonNull::new(ctx.cast::<c_void>()),
+            callback: run::<T>,
+            ctx: NonNull::new(Box::into_raw(ctx).cast::<c_void>()),
             cleanup: Some(drop_ctx::<T>),
         }));
         ManagedTask::task(managed)

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -19,6 +19,10 @@ pub struct ManagedTask {
     pub ctx: Option<NonNull<c_void>>,
     pub(crate) callback: fn(*mut c_void) -> JsResult<()>,
     pub cleanup: Option<fn(*mut c_void)>,
+    /// Held by the thread that boxed a `new_boxed` payload (which need not be
+    /// `Send`); `run`/`release` assert they are on it. Debug-only, zero-sized
+    /// in release.
+    origin: bun_core::ThreadLock,
 }
 
 impl ManagedTask {
@@ -36,6 +40,7 @@ impl ManagedTask {
         // (caller contract). Reconstituting the Box here frees it at scope
         // exit on both the Ok and Err paths.
         let this = unsafe { bun_core::heap::take(this) };
+        this.origin.lock_or_assert();
         let callback = this.callback;
         let ctx = this.ctx;
         callback(ctx.unwrap().as_ptr())
@@ -48,6 +53,7 @@ impl ManagedTask {
     pub unsafe fn release(this: *mut ManagedTask) {
         // SAFETY: fn contract.
         let this = unsafe { bun_core::heap::take(this) };
+        this.origin.lock_or_assert();
         if let (Some(cleanup), Some(ctx)) = (this.cleanup, this.ctx) {
             cleanup(ctx.as_ptr());
         }
@@ -67,12 +73,15 @@ impl ManagedTask {
             },
             ctx: NonNull::new(ctx.cast::<c_void>()),
             cleanup: None,
+            origin: bun_core::ThreadLock::init_unlocked(),
         }));
         ManagedTask::task(managed)
     }
 
     /// A task that owns `ctx` and [`run`](RunOnce::run)s it (or drops it if
-    /// the queue is released unrun).
+    /// the queue is released unrun). `T` need not be `Send`: the `Task` is for
+    /// this thread's own queue (`enqueue_task`), never a `ConcurrentTask` /
+    /// `JsPoster` hand-off to another thread — debug builds assert that.
     pub fn new_boxed<T: RunOnce + 'static>(ctx: Box<T>) -> Task {
         fn run<T: RunOnce>(p: *mut c_void) -> JsResult<()> {
             // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`; `run`
@@ -87,6 +96,7 @@ impl ManagedTask {
             callback: run::<T>,
             ctx: NonNull::new(bun_core::heap::into_raw(ctx).cast::<c_void>()),
             cleanup: Some(drop_ctx::<T>),
+            origin: bun_core::ThreadLock::init_locked(),
         }));
         ManagedTask::task(managed)
     }

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -73,7 +73,7 @@ impl ManagedTask {
 
     /// A task that owns `ctx` and [`run`](RunOnce::run)s it (or drops it if
     /// the queue is released unrun).
-    pub fn new_boxed<T: RunOnce>(ctx: Box<T>) -> Task {
+    pub fn new_boxed<T: RunOnce + 'static>(ctx: Box<T>) -> Task {
         fn run<T: RunOnce>(p: *mut c_void) -> JsResult<()> {
             // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`; `run`
             // passes it back exactly once.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8683,6 +8683,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// it (e.g. via `assume_init`); on `Err`, `*out` is left untouched.
     /// Taking `&mut MaybeUninit<Self>` (vs the previous `*mut Self`) makes the
     /// alignment/writability precondition a type guarantee, so this fn is safe.
+    /// Heap-construct a parser over `lexer`, logging to the `Log` the lexer was
+    /// created with. For the few off-hot-path callers (e.g. inline snapshot
+    /// rewriting) that want an owned parser rather than [`init`](Self::init)'s
+    /// in-place protocol.
+    pub fn new_boxed(
+        arena: &'a Bump,
+        source: &'a bun_ast::Source,
+        define: &'a Define,
+        lexer: js_lexer::Lexer<'a>,
+        opts: ParserOptions<'a>,
+    ) -> Result<Box<Self>, crate::Error> {
+        let mut slot: Box<core::mem::MaybeUninit<Self>> = Box::new_uninit();
+        let log = lexer.log;
+        Self::init(&mut slot, arena, log, source, define, lexer, opts)?;
+        // SAFETY: `init` returned `Ok`, so `*slot` is fully initialized.
+        Ok(unsafe { slot.assume_init() })
+    }
+
     pub fn init(
         out: &mut core::mem::MaybeUninit<Self>,
         arena: &'a Bump,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -8683,24 +8683,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// it (e.g. via `assume_init`); on `Err`, `*out` is left untouched.
     /// Taking `&mut MaybeUninit<Self>` (vs the previous `*mut Self`) makes the
     /// alignment/writability precondition a type guarantee, so this fn is safe.
-    /// Heap-construct a parser over `lexer`, logging to the `Log` the lexer was
-    /// created with. For the few off-hot-path callers (e.g. inline snapshot
-    /// rewriting) that want an owned parser rather than [`init`](Self::init)'s
-    /// in-place protocol.
-    pub fn new_boxed(
-        arena: &'a Bump,
-        source: &'a bun_ast::Source,
-        define: &'a Define,
-        lexer: js_lexer::Lexer<'a>,
-        opts: ParserOptions<'a>,
-    ) -> Result<Box<Self>, crate::Error> {
-        let mut slot: Box<core::mem::MaybeUninit<Self>> = Box::new_uninit();
-        let log = lexer.log;
-        Self::init(&mut slot, arena, log, source, define, lexer, opts)?;
-        // SAFETY: `init` returned `Ok`, so `*slot` is fully initialized.
-        Ok(unsafe { slot.assume_init() })
-    }
-
     pub fn init(
         out: &mut core::mem::MaybeUninit<Self>,
         arena: &'a Bump,
@@ -8953,6 +8935,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // redundant with the literal and have been dropped).
 
         Ok(())
+    }
+
+    /// Heap-construct a parser over `lexer`, logging to the `Log` the lexer was
+    /// created with. For the few off-hot-path callers (e.g. inline snapshot
+    /// rewriting) that want an owned parser rather than [`init`](Self::init)'s
+    /// in-place protocol.
+    pub fn new_boxed(
+        arena: &'a Bump,
+        source: &'a bun_ast::Source,
+        define: &'a Define,
+        lexer: js_lexer::Lexer<'a>,
+        opts: ParserOptions<'a>,
+    ) -> Result<Box<Self>, crate::Error> {
+        let mut slot: Box<core::mem::MaybeUninit<Self>> = Box::new_uninit();
+        let log = lexer.log;
+        Self::init(&mut slot, arena, log, source, define, lexer, opts)?;
+        // SAFETY: `init` returned `Ok`, so `*slot` is fully initialized.
+        Ok(unsafe { slot.assume_init() })
     }
 }
 

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2448,6 +2448,64 @@ impl JSValue {
     ) -> JsResult<()> {
         self.for_each(global, ctx, callback)
     }
+    /// [`for_each`](Self::for_each) with a Rust closure as the per-element
+    /// callback (the closure is the context C++ round-trips).
+    pub fn for_each_iter<F>(self, global: &JSGlobalObject, mut f: F) -> JsResult<()>
+    where
+        F: FnMut(&JSGlobalObject, JSValue),
+    {
+        extern "C" fn trampoline<F: FnMut(&JSGlobalObject, JSValue)>(
+            _: *mut crate::VM,
+            global: &JSGlobalObject,
+            ctx: *mut c_void,
+            next: JSValue,
+        ) {
+            // SAFETY: `ctx` is the `&mut F` passed to `for_each` below; C++
+            // invokes this synchronously within that call, once per element.
+            let f = unsafe { &mut *ctx.cast::<F>() };
+            f(global, next);
+        }
+        self.for_each(
+            global,
+            core::ptr::from_mut(&mut f).cast::<c_void>(),
+            trampoline::<F>,
+        )
+    }
+    /// [`for_each_property`](Self::for_each_property) /
+    /// [`for_each_property_ordered`](Self::for_each_property_ordered) with a Rust
+    /// closure `(global, key, value, is_symbol, is_private_symbol)` as the
+    /// per-property callback.
+    pub fn for_each_property_iter<F>(
+        self,
+        global: &JSGlobalObject,
+        ordered: bool,
+        mut f: F,
+    ) -> JsResult<()>
+    where
+        F: FnMut(&JSGlobalObject, &bun_core::EncodedSlice, JSValue, bool, bool),
+    {
+        extern "C" fn trampoline<
+            F: FnMut(&JSGlobalObject, &bun_core::EncodedSlice, JSValue, bool, bool),
+        >(
+            global: &JSGlobalObject,
+            ctx: *mut c_void,
+            key: *mut bun_core::EncodedSlice,
+            value: JSValue,
+            is_symbol: bool,
+            is_private_symbol: bool,
+        ) {
+            // SAFETY: `ctx` is the `&mut F` passed below and `key` a live
+            // `EncodedSlice` C++ owns for the callback; both calls are synchronous.
+            let (f, key) = unsafe { (&mut *ctx.cast::<F>(), &*key) };
+            f(global, key, value, is_symbol, is_private_symbol);
+        }
+        let ctx = core::ptr::from_mut(&mut f).cast::<c_void>();
+        if ordered {
+            self.for_each_property_ordered(global, ctx, trampoline::<F>)
+        } else {
+            self.for_each_property(global, ctx, trampoline::<F>)
+        }
+    }
     /// `JSValue.forEachProperty` — enumerate own props,
     /// invoking `callback` per (key, value, is_symbol, is_private_symbol).
     ///

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1379,7 +1379,7 @@ impl VirtualMachine {
         Bun__emitHandledPromiseEvent(global_object, promise)
     }
 
-    pub(crate) fn default_on_unhandled_rejection(
+    pub fn default_on_unhandled_rejection(
         this: &mut VirtualMachine,
         _: &JSGlobalObject,
         value: JSValue,

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -292,15 +292,11 @@ pub(crate) fn spawn_sync(
         && result.is_ok()
         && !global_this.has_exception()
         && let Some(runner) = crate::test_runner::jest::Jest::runner()
-        && let Some(active_file) = runner.bun_test_root.active_file.clone()
+        && let Some(active_file) = runner.bun_test_root.clone_active_file()
     {
         let vm = global_this.bun_vm().as_mut();
         runner.remove_active_timeout(vm);
-        crate::test_runner::bun_test::BunTest::bun_test_timeout_callback(
-            &active_file,
-            &deadline,
-            vm,
-        );
+        active_file.bun_test_timeout_callback(&deadline, vm);
         if global_this.has_exception() {
             return Ok(JSValue::ZERO);
         }
@@ -1944,11 +1940,9 @@ fn spawn_maybe_sync(
                         if let Some(active_file) = crate::test_runner::jest::Jest::runner()
                             .unwrap()
                             .bun_test_root
-                            .active_file
-                            .clone()
+                            .clone_active_file()
                         {
                             active_file
-                                .get()
                                 .execution
                                 .kill_dangling_processes_on_timeout(global_this);
                         }

--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -28,7 +28,7 @@ pub struct Coordinator<'a> {
     /// Typed enum mirror of `vm.event_loop()` for the io-layer FilePoll vtable
     /// (`bun_io::EventLoopHandle` wraps `*const EventLoopHandle`).
     pub(crate) event_loop_handle: bun_jsc::EventLoopHandle,
-    pub(crate) reporter: &'a mut CommandLineReporter,
+    pub(crate) reporter: &'static CommandLineReporter,
     pub(crate) files: Vec<Interned>,
     /// `--timings`: recorded cost per `files` index; stealing then goes by remaining time and takes the victim's slowest file.
     pub(crate) costs: Option<Vec<u64>>,
@@ -357,7 +357,7 @@ impl<'a> Coordinator<'a> {
     }
 
     fn record_timing(&mut self, file_idx: u32, dispatched_at: i64) {
-        if let Some(t) = self.reporter.timings.as_mut() {
+        if let Some(t) = self.reporter.timings.borrow_mut().as_mut() {
             t.record_since(self.files[file_idx as usize].as_bytes(), dispatched_at);
         }
     }
@@ -486,7 +486,7 @@ impl<'a> Coordinator<'a> {
                 // `self.reporter.jest`) and `bail_out()` must run after the
                 // summary borrow is released.
                 {
-                    let summary = self.reporter.summary();
+                    let mut summary = self.reporter.summary();
                     summary.pass += pass;
                     summary.fail += fail;
                     summary.skip += skip;
@@ -495,7 +495,8 @@ impl<'a> Coordinator<'a> {
                     summary.skipped_because_label += skipped_label;
                     summary.files += files;
                 }
-                self.reporter.jest.unhandled_errors_between_tests += unhandled;
+                let n = &self.reporter.jest.unhandled_errors_between_tests;
+                n.set(n.get() + unhandled);
                 self.record_timing(idx, w.dispatched_at);
 
                 w.inflight = None;
@@ -517,12 +518,15 @@ impl<'a> Coordinator<'a> {
                 // explicit splitting.
                 self.reporter
                     .failures_to_repeat_buf
+                    .borrow_mut()
                     .extend_from_slice(rd.str());
                 self.reporter
                     .skips_to_repeat_buf
+                    .borrow_mut()
                     .extend_from_slice(rd.str());
                 self.reporter
                     .todos_to_repeat_buf
+                    .borrow_mut()
                     .extend_from_slice(rd.str());
             }
             frame::Kind::CoverageFile => {

--- a/src/runtime/cli/test/parallel/aggregate.rs
+++ b/src/runtime/cli/test/parallel/aggregate.rs
@@ -16,7 +16,8 @@ use crate::test_runner::execution::Result as TestResult;
 /// serial run would have written.
 pub(crate) fn replay_test_records(coord: &mut Coordinator) {
     let files = core::mem::take(&mut coord.test_records);
-    let Some(junit) = coord.reporter.reporters.junit.as_deref_mut() else {
+    let mut junit_slot = coord.reporter.reporters.junit.borrow_mut();
+    let Some(junit) = junit_slot.as_deref_mut() else {
         return;
     };
     for (idx, file) in files.iter().enumerate() {

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -36,7 +36,7 @@ const DEFAULT_SCALE_UP_AFTER_MS: i64 = 5;
 /// fell back to the sequential path (≤1 effective worker). The caller uses
 /// this to decide whether to run the serial coverage/JUnit reporters.
 pub(crate) fn run_as_coordinator(
-    reporter: &mut CommandLineReporter,
+    reporter: &'static CommandLineReporter,
     vm: *mut VirtualMachine,
     files: &[Interned],
     ctx: Command::Context,
@@ -94,7 +94,8 @@ pub(crate) fn run_as_coordinator(
     // of file count, and each chunk is dispatched slowest-first (cache hits
     // depend on which worker runs a file, not the order within the worker).
     let mut costs: Option<Vec<u64>> = None;
-    let ranges: Vec<FileRange> = match reporter.timings.as_ref() {
+    let timings = reporter.timings.borrow();
+    let ranges: Vec<FileRange> = match timings.as_ref() {
         Some(t) if !t.is_empty() && !ctx.test_options.randomize => {
             let ranges = t.partition(&sorted, k);
             for r in &ranges {
@@ -110,6 +111,7 @@ pub(crate) fn run_as_coordinator(
             })
             .collect(),
     };
+    drop(timings);
 
     let mut workers: Vec<Worker> = Vec::with_capacity(k as usize);
     // Populate fully BEFORE constructing Coordinator so it can hold
@@ -503,13 +505,13 @@ impl ChannelOwner for WorkerCommands {
 
 // Hoisted from a local struct inside run_as_worker — Rust does not
 // support method-bearing local structs that need to be named in a generic call.
-struct WorkerLoop<'a> {
-    reporter: &'a mut CommandLineReporter,
+struct WorkerLoop {
+    reporter: &'static CommandLineReporter,
     vm: *mut VirtualMachine,
     cmds: WorkerCommands,
 }
 
-impl<'a> WorkerLoop<'a> {
+impl WorkerLoop {
     fn begin(&mut self) {
         // SAFETY: vm pointer is valid for the worker's lifetime.
         let vm = unsafe { &mut *self.vm };
@@ -540,13 +542,13 @@ impl<'a> WorkerLoop<'a> {
             };
             self.cmds.pending_idx = None;
 
-            self.reporter.worker_ipc_file_idx = Some(idx);
+            self.reporter.worker_ipc_file_idx.set(Some(idx));
             wf.begin(frame::Kind::FileStart);
             wf.u32(idx);
             self.cmds.send(wf.finish());
 
             let before = *self.reporter.summary();
-            let before_unhandled = self.reporter.jest.unhandled_errors_between_tests;
+            let before_unhandled = self.reporter.jest.unhandled_errors_between_tests.get();
             let started_ns =
                 bun_core::Timespec::now(bun_core::TimespecMockMode::ForceRealTime).ns();
 
@@ -572,7 +574,7 @@ impl<'a> WorkerLoop<'a> {
             } else {
                 Global::mimalloc_cleanup(false);
             }
-            self.reporter.jest.default_timeout_override = u32::MAX;
+            self.reporter.jest.default_timeout_override.set(u32::MAX);
 
             let elapsed_ns = bun_core::Timespec::now(bun_core::TimespecMockMode::ForceRealTime)
                 .ns()
@@ -589,7 +591,7 @@ impl<'a> WorkerLoop<'a> {
                 after.expectations - before.expectations,
                 after.skipped_because_label - before.skipped_because_label,
                 after.files - before.files,
-                self.reporter.jest.unhandled_errors_between_tests - before_unhandled,
+                self.reporter.jest.unhandled_errors_between_tests.get() - before_unhandled,
             ] {
                 wf.u32(v);
             }
@@ -611,7 +613,7 @@ impl<'a> WorkerLoop<'a> {
 // would alias. The `# Safety` contract above documents the caller's obligation.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub(crate) fn run_as_worker(
-    reporter: &mut CommandLineReporter,
+    reporter: &'static CommandLineReporter,
     vm: *mut VirtualMachine,
     ctx: Command::Context,
 ) -> ! {
@@ -670,7 +672,7 @@ pub(crate) fn run_as_worker(
 }
 
 fn worker_flush_aggregates(
-    reporter: &mut CommandLineReporter,
+    reporter: &CommandLineReporter,
     vm: &mut VirtualMachine,
     ctx: &Command::ContextData,
     cmds: &mut WorkerCommands,
@@ -678,17 +680,18 @@ fn worker_flush_aggregates(
     // Snapshots flush lazily when the next file opens its snapshot file; the
     // last file each worker ran has no successor to trigger that.
     if let Some(runner) = crate::test_runner::jest::Jest::runner() {
-        let _ = runner.snapshots.write_inline_snapshots().unwrap_or(false);
-        let _ = runner.snapshots.write_snapshot_file();
+        let mut snapshots = runner.snapshots.borrow_mut();
+        let _ = snapshots.write_inline_snapshots().unwrap_or(false);
+        let _ = snapshots.write_snapshot_file();
     }
 
     // SAFETY: single-threaded worker; WORKER_FRAME is a process-global scratch buffer
     let wf = unsafe { &mut *WORKER_FRAME.get() };
 
     wf.begin(frame::Kind::RepeatBufs);
-    wf.str(reporter.failures_to_repeat_buf.as_slice());
-    wf.str(reporter.skips_to_repeat_buf.as_slice());
-    wf.str(reporter.todos_to_repeat_buf.as_slice());
+    wf.str(reporter.failures_to_repeat_buf.borrow().as_slice());
+    wf.str(reporter.skips_to_repeat_buf.borrow().as_slice());
+    wf.str(reporter.todos_to_repeat_buf.borrow().as_slice());
     cmds.send(wf.finish());
 
     if ctx.test_options.coverage.enabled {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1,4 +1,6 @@
 use bun_io::Write as _;
+use core::cell::{Cell, RefCell};
+use std::rc::Rc;
 
 use crate::cli::Command;
 use crate::cli::test::changed_files_filter as ChangedFilesFilter;
@@ -59,7 +61,7 @@ use coverage::{ByteRangeMapping, CodeCoverageReport, Fraction};
 // `crate::test_runner::*`; the façade below adapts the body's nested-path
 // usage (`bun_test::Execution::Result`, `bun_test::BasicResult`, …) without a
 // 2k-line body rewrite.
-use crate::test_runner::jest::{self, FileColumns as _, Summary, TestRunner};
+use crate::test_runner::jest::{self, Summary, TestRunner};
 use crate::test_runner::snapshot::Snapshots;
 use bun_collections::index_sort;
 
@@ -375,11 +377,10 @@ impl TestFailure {
 
     /// VirtualMachine::on_print_error_zig_exception thunk.
     pub(crate) fn record_cb(ctx: *mut core::ffi::c_void, exception: &jsc::ZigException) {
-        // SAFETY: `ctx` was set to `&mut CommandLineReporter.test_failure` by
-        // `on_uncaught_exception` for the duration of a single
-        // `run_error_handler` call; single-threaded, no other borrow live.
-        let slot = unsafe { &mut *ctx.cast::<Option<TestFailure>>() };
-        TestFailure::record(slot, exception);
+        // SAFETY: `ctx` was set to the process-lifetime `&'static CommandLineReporter`
+        // by `on_uncaught_exception` for the duration of a single `run_error_handler` call.
+        let reporter = unsafe { &*ctx.cast::<CommandLineReporter>() };
+        TestFailure::record(&mut reporter.test_failure.borrow_mut(), exception);
     }
 }
 
@@ -940,72 +941,70 @@ fn should_drain_event_loop() -> bool {
 
 /// jest and vitest never run a test file's `process.on('exit')` listeners; node's test harness asserts from them.
 pub(crate) fn skip_exit_listeners(reporter: &CommandLineReporter) -> bool {
-    !(reporter.jest.node_test_used || should_drain_event_loop())
+    !(reporter.jest.node_test_used.get() || should_drain_event_loop())
 }
 
+/// Leaked for the process lifetime by `TestCommand::exec` (which never returns
+/// before process exit) and shared with JS-reentrant test-runner callbacks, so
+/// it is `&self`-only: state written after construction is `Cell`/`RefCell`.
 pub struct CommandLineReporter {
-    // `TestRunner<'a>` borrows `TestOptions`/regex from the CLI ctx; the
-    // reporter is held in a `Box` local to `TestCommand::exec` which never
-    // returns before process exit, so `'static` is sound here. Revisit if the
-    // reporter ever becomes scoped.
+    // `TestRunner<'a>` borrows `TestOptions`/regex from the CLI ctx, which is
+    // likewise process-lifetime.
     pub(crate) jest: TestRunner<'static>,
     pub(crate) repeat_count: u32,
-    /// Interior-mut: written from `BunTestRoot::on_before_print` via `&CommandLineReporter`
-    pub(crate) last_printed_dot: core::cell::Cell<bool>,
+    pub(crate) last_printed_dot: Cell<bool>,
 
     /// When running as a `--parallel` worker, this is the coordinator-assigned
     /// index of the file currently being executed. While set, per-test output
     /// is sent over the IPC pipe instead of to stderr; the coordinator owns
     /// the terminal.
-    pub(crate) worker_ipc_file_idx: Option<u32>,
+    pub(crate) worker_ipc_file_idx: Cell<Option<u32>>,
     /// Errors thrown by the test now running, captured while a reporter
     /// that attaches them to the test case (JUnit) is on. Taken by
     /// `handle_test_completed`.
-    pub(crate) test_failure: Option<TestFailure>,
+    pub(crate) test_failure: RefCell<Option<TestFailure>>,
 
-    pub(crate) failures_to_repeat_buf: Vec<u8>,
-    pub(crate) skips_to_repeat_buf: Vec<u8>,
-    pub(crate) todos_to_repeat_buf: Vec<u8>,
+    pub(crate) failures_to_repeat_buf: RefCell<Vec<u8>>,
+    pub(crate) skips_to_repeat_buf: RefCell<Vec<u8>>,
+    pub(crate) todos_to_repeat_buf: RefCell<Vec<u8>>,
 
     pub(crate) reporters: ReportersConfig,
 
     /// `--timings`: loaded before the run, updated per file, written back under `--update-timings`.
-    pub(crate) timings: Option<Timings>,
+    pub(crate) timings: RefCell<Option<Timings>>,
 }
 
 #[derive(Default)]
 pub struct ReportersConfig {
     pub(crate) dots: bool,
     pub(crate) only_failures: bool,
-    pub(crate) junit: Option<Box<JunitReporter>>,
+    pub(crate) junit: RefCell<Option<Box<JunitReporter>>>,
 }
 
 impl CommandLineReporter {
     fn print_test_line<const DIM: bool>(
         status: bun_test::Execution::Result,
-        sequence: &mut bun_test::Execution::ExecutionSequence,
-        test_entry: &mut bun_test::ExecutionEntry,
+        sequence: &bun_test::Execution::ExecutionSequence,
+        test_entry: &bun_test::ExecutionEntry,
         elapsed_ns: u64,
         writer: &mut impl bun_io::Write,
     ) {
         let initial_retry_count = test_entry.retry_count;
-        let attempts = (initial_retry_count - sequence.remaining_retry_count) + 1;
+        let attempts = (initial_retry_count - sequence.remaining_retry_count.get()) + 1;
         let initial_repeat_count = test_entry.repeat_count;
-        let repeats = (initial_repeat_count - sequence.remaining_repeat_count) + 1;
-        let mut scopes_stack: BoundedArray<*const bun_test::DescribeScope, 64> =
+        let repeats = (initial_repeat_count - sequence.remaining_repeat_count.get()) + 1;
+        let mut scopes_stack: BoundedArray<Rc<bun_test::DescribeScope>, 64> =
             BoundedArray::default();
-        let mut parent_: Option<*const bun_test::DescribeScope> =
-            test_entry.base.parent.map(|p| p.cast_const());
+        let mut parent_: Option<Rc<bun_test::DescribeScope>> = test_entry.base.parent();
 
         while let Some(scope) = parent_ {
+            parent_ = scope.base.parent();
             if scopes_stack.push(scope).is_err() {
                 break;
             }
-            // SAFETY: scope is a live DescribeScope pointer kept alive for the test run
-            parent_ = unsafe { (*scope).base.parent.map(|p| p.cast_const()) };
         }
 
-        let scopes: &[*const bun_test::DescribeScope] = scopes_stack.as_slice();
+        let scopes: &[Rc<bun_test::DescribeScope>] = scopes_stack.as_slice();
         let display_label: &[u8] = test_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
 
         // Quieter output when claude code is in use.
@@ -1018,20 +1017,21 @@ impl CommandLineReporter {
             match status {
                 bun_test::Execution::Result::FailBecauseExpectedAssertionCount => {
                     // not sent to writer so it doesn't get printed twice
-                    let expected_count =
-                        if let bun_test::ExpectAssertions::Exact(n) = sequence.expect_assertions {
-                            n
-                        } else {
-                            12345
-                        };
+                    let expected_count = if let bun_test::ExpectAssertions::Exact(n) =
+                        sequence.expect_assertions.get()
+                    {
+                        n
+                    } else {
+                        12345
+                    };
                     Output::err(
                         crate::Error::AssertionError,
                         "expected <green>{} assertion{}<r>, but test ended with <red>{} assertion{}<r>\n",
                         (
                             expected_count,
                             if expected_count == 1 { "" } else { "s" },
-                            sequence.expect_call_count,
-                            if sequence.expect_call_count == 1 {
+                            sequence.expect_call_count.get(),
+                            if sequence.expect_call_count.get() == 1 {
                                 ""
                             } else {
                                 "s"
@@ -1067,9 +1067,8 @@ impl CommandLineReporter {
             if Output::enable_ansi_colors_stderr() {
                 for i in 0..scopes.len() {
                     let index = (scopes.len() - 1) - i;
-                    let scope = scopes[index];
-                    // SAFETY: scope is alive for duration of test run
-                    let name: &[u8] = unsafe { (*scope).base.name.as_deref() }.unwrap_or(b"");
+                    let scope = &scopes[index];
+                    let name: &[u8] = scope.base.name.as_deref().unwrap_or(b"");
                     if name.is_empty() {
                         continue;
                     }
@@ -1088,9 +1087,8 @@ impl CommandLineReporter {
             } else {
                 for i in 0..scopes.len() {
                     let index = (scopes.len() - 1) - i;
-                    let scope = scopes[index];
-                    // SAFETY: scope is alive for duration of test run
-                    let name: &[u8] = unsafe { (*scope).base.name.as_deref() }.unwrap_or(b"");
+                    let scope = &scopes[index];
+                    let name: &[u8] = scope.base.name.as_deref().unwrap_or(b"");
                     if name.is_empty() {
                         continue;
                     }
@@ -1201,6 +1199,17 @@ impl CommandLineReporter {
         }
     }
 
+    /// `test_entry`'s enclosing describe scopes, innermost first.
+    fn scope_chain(test_entry: &bun_test::ExecutionEntry) -> Vec<Rc<bun_test::DescribeScope>> {
+        let mut chain = Vec::new();
+        let mut parent = test_entry.base.parent();
+        while let Some(scope) = parent {
+            parent = scope.base.parent();
+            chain.push(scope);
+        }
+        chain
+    }
+
     /// Everything a structured reporter needs about one finished test. Built
     /// once in `handle_test_completed`; the serial runner hands it straight
     /// to `JunitReporter::record_test_case`, a `--parallel` worker encodes it
@@ -1210,13 +1219,12 @@ impl CommandLineReporter {
         buntest: &bun_test::BunTest,
         sequence: &bun_test::Execution::ExecutionSequence,
         test_entry: &'a bun_test::ExecutionEntry,
+        scope_chain: &'a [Rc<bun_test::DescribeScope>],
         elapsed_ns: u64,
         failure: Option<TestFailure>,
     ) -> TestCaseReport<'a> {
         let file: &[u8] = if let Some(runner) = jest::Jest::runner() {
-            runner.files.items_source()[buntest.file_id as usize]
-                .path
-                .text
+            runner.file_path(buntest.file_id).text
         } else {
             b""
         };
@@ -1224,19 +1232,15 @@ impl CommandLineReporter {
 
         // Innermost first while walking up; reversed below.
         let mut scopes: Vec<(&'a [u8], u32)> = Vec::new();
-        let mut parent = test_entry.base.parent.map(|p| p.cast_const());
-        while let Some(scope) = parent {
+        for scope in scope_chain {
             if scopes.len() == 64 {
                 break;
             }
-            // SAFETY: describe scopes outlive the file's test run.
-            let scope: &'a bun_test::DescribeScope = unsafe { &*scope };
             if let Some(name) = scope.base.name.as_deref()
                 && !name.is_empty()
             {
                 scopes.push((name, scope.base.line_no));
             }
-            parent = scope.base.parent.map(|p| p.cast_const());
         }
         scopes.reverse();
 
@@ -1245,7 +1249,7 @@ impl CommandLineReporter {
             scopes,
             name: test_entry.base.name.as_deref().unwrap_or(b"(unnamed)"),
             status,
-            assertions: sequence.expect_call_count,
+            assertions: sequence.expect_call_count.get(),
             elapsed_ns,
             line_number: test_entry.base.line_no,
             failure,
@@ -1253,14 +1257,14 @@ impl CommandLineReporter {
     }
 
     #[inline]
-    pub(crate) fn summary(&mut self) -> &mut Summary {
-        &mut self.jest.summary
+    pub(crate) fn summary(&self) -> core::cell::RefMut<'_, Summary> {
+        self.jest.summary.borrow_mut()
     }
 
     pub(crate) fn handle_test_completed(
-        buntest: &mut bun_test::BunTest,
-        sequence: &mut bun_test::Execution::ExecutionSequence,
-        test_entry: &mut bun_test::ExecutionEntry,
+        buntest: &bun_test::BunTest,
+        sequence: &bun_test::Execution::ExecutionSequence,
+        test_entry: &bun_test::ExecutionEntry,
         elapsed_ns: u64,
     ) {
         let mut output_buf: Vec<u8> = Vec::new();
@@ -1268,15 +1272,9 @@ impl CommandLineReporter {
         let initial_length = output_buf.len();
         let writer = &mut output_buf;
 
-        let result = sequence.result;
+        let result = sequence.result.get();
         if result != bun_test::Execution::Result::SkippedBecauseLabel {
-            // SAFETY: `BunTest.reporter` is `NonNull<CommandLineReporter>` with write
-            // provenance from `enter_file`'s `&mut`; single-threaded; reporter outlives
-            // every BunTest. Scoped to this block so the SharedReadOnly tag is dead
-            // before the `&mut` derived from the same `NonNull` below
-            // (stacked-borrows hygiene).
-            let reporter_ref: Option<&CommandLineReporter> =
-                buntest.reporter.map(|p| unsafe { &*p.as_ptr() });
+            let reporter_ref: Option<&CommandLineReporter> = buntest.reporter.get();
             let basic = result.basic_result();
             let dots_branch = reporter_ref.is_some_and(|r| r.reporters.dots)
                 && matches!(
@@ -1340,48 +1338,61 @@ impl CommandLineReporter {
         }
         let formatted_line = &output_buf[initial_length..];
 
-        let Some(this) = buntest.reporter else {
+        let Some(this) = buntest.reporter.get() else {
             let _ = Output::error_writer().write_all(formatted_line);
             return;
         };
-        // SAFETY: `BunTest.reporter` is `NonNull<CommandLineReporter>` with write
-        // provenance from `enter_file`'s `&mut`; single-threaded test runner,
-        // sole writer for the duration of this completion callback, and the
-        // shared borrow above is dead.
-        let this: &mut CommandLineReporter = unsafe { &mut *this.as_ptr() };
 
         // Under `--parallel` the flag is forwarded to workers, whose records
         // the coordinator replays into its own `JunitReporter`.
+        let scope_chain = if this.jest.test_options.reporters.junit {
+            Self::scope_chain(test_entry)
+        } else {
+            Vec::new()
+        };
         let report = this.jest.test_options.reporters.junit.then(|| {
             let failure = this.test_failure.take();
-            Self::test_case_report(result, buntest, sequence, test_entry, elapsed_ns, failure)
+            Self::test_case_report(
+                result,
+                buntest,
+                sequence,
+                test_entry,
+                &scope_chain,
+                elapsed_ns,
+                failure,
+            )
         });
-        if let Some(idx) = this.worker_ipc_file_idx {
+        if let Some(idx) = this.worker_ipc_file_idx.get() {
             ParallelRunner::worker_emit_test_done(idx, formatted_line, report.as_ref());
         } else {
             let _ = Output::error_writer().write_all(formatted_line);
-            if let (Some(junit), Some(report)) = (this.reporters.junit.as_mut(), &report) {
+            if let (Some(junit), Some(report)) =
+                (this.reporters.junit.borrow_mut().as_deref_mut(), &report)
+            {
                 junit.record_test_case(report).expect("oom");
             }
         }
 
         if !this.reporters.dots && !this.reporters.only_failures {
-            match sequence.result.basic_result() {
+            match sequence.result.get().basic_result() {
                 bun_test::BasicResult::Skip => this
                     .skips_to_repeat_buf
+                    .borrow_mut()
                     .extend_from_slice(&output_buf[initial_length..]),
                 bun_test::BasicResult::Todo => this
                     .todos_to_repeat_buf
+                    .borrow_mut()
                     .extend_from_slice(&output_buf[initial_length..]),
                 bun_test::BasicResult::Fail => this
                     .failures_to_repeat_buf
+                    .borrow_mut()
                     .extend_from_slice(&output_buf[initial_length..]),
                 bun_test::BasicResult::Pass | bun_test::BasicResult::Pending => {}
             }
         }
 
         use bun_test::Execution::Result as R;
-        match sequence.result {
+        match sequence.result.get() {
             R::Pending => {}
             R::Pass => this.summary().pass += 1,
             R::Skip => this.summary().skip += 1,
@@ -1413,14 +1424,16 @@ impl CommandLineReporter {
                 }
             }
         }
-        this.summary().expectations = this
-            .summary()
-            .expectations
-            .saturating_add(sequence.expect_call_count);
+        {
+            let mut summary = this.summary();
+            summary.expectations = summary
+                .expectations
+                .saturating_add(sequence.expect_call_count.get());
+        }
     }
 
-    pub(crate) fn print_summary(&mut self) {
-        let summary_ = self.summary();
+    pub(crate) fn print_summary(&self) {
+        let summary_ = *self.summary();
         let tests = summary_.fail + summary_.pass + summary_.skip + summary_.todo;
         let files = summary_.files;
 
@@ -1436,10 +1449,10 @@ impl CommandLineReporter {
     }
 
     /// Like the JUnit report, called before every exit path (including bail) so measured durations aren't lost.
-    pub(crate) fn write_timings_if_needed(&mut self) {
+    pub(crate) fn write_timings_if_needed(&self) {
         if self.jest.test_options.update_timings
-            && self.worker_ipc_file_idx.is_none()
-            && let Some(timings) = self.timings.as_mut()
+            && self.worker_ipc_file_idx.get().is_none()
+            && let Some(timings) = self.timings.borrow_mut().as_mut()
         {
             timings.write(self.jest.test_options.shard.is_some());
         }
@@ -1448,8 +1461,8 @@ impl CommandLineReporter {
     /// Writes the JUnit reporter output file if a JUnit reporter is active and
     /// an outfile path was configured. This must be called before any early exit
     /// (e.g. bail) so that the report is not lost.
-    pub(crate) fn write_junit_report_if_needed(&mut self) {
-        if let Some(junit) = self.reporters.junit.as_mut() {
+    pub(crate) fn write_junit_report_if_needed(&self) {
+        if let Some(junit) = self.reporters.junit.borrow_mut().as_mut() {
             if let Some(outfile) = self.jest.test_options.reporter_outfile.as_deref() {
                 let _ = junit.write_to_file(outfile);
             }
@@ -1488,7 +1501,7 @@ impl CommandLineReporter {
     }
 
     pub(crate) fn generate_code_coverage(
-        &mut self,
+        &self,
         vm: &mut VirtualMachine,
         opts: &mut CodeCoverageOptions,
     ) {
@@ -1827,10 +1840,23 @@ impl TestCommand {
             .map(|b| unsafe { bun_ptr::detach_lifetime::<u8>(b) })
             .collect();
 
-        // Keep an owned `Box` local — `exec()` never returns before process
-        // exit, so the heap allocation outlives all raw-pointer observers
-        // (e.g. `Jest::RUNNER` below).
-        let mut reporter: Box<CommandLineReporter> = Box::new(CommandLineReporter {
+        let mut reporters = ReportersConfig::default();
+        if ctx.test_options.reporters.junit && !ctx.test_options.test_worker {
+            reporters.junit = RefCell::new(Some(JunitReporter::init()));
+        }
+        if ctx.test_options.reporters.dots {
+            reporters.dots = true;
+        }
+        if ctx.test_options.reporters.only_failures {
+            reporters.only_failures = true;
+        } else if Output::is_ai_agent() {
+            reporters.only_failures = true; // only-failures defaults to true for ai agents
+        }
+
+        // Leaked: `exec()` never returns before process exit, and JS-reentrant
+        // test-runner callbacks reach this through `Jest::runner()` /
+        // `BunTest::reporter`, so it is shared (`&'static`) from here on.
+        let reporter: &'static CommandLineReporter = Box::leak(Box::new(CommandLineReporter {
             jest: TestRunner {
                 default_timeout_ms: ctx.test_options.default_timeout_ms,
                 concurrent: ctx.test_options.concurrent,
@@ -1842,7 +1868,7 @@ impl TestCommand {
                     .as_deref()
                     .map(|s| unsafe { bun_ptr::detach_lifetime(s) }),
                 run_todo: ctx.test_options.run_todo,
-                only: ctx.test_options.only,
+                only: Cell::new(ctx.test_options.only),
                 bail: ctx.test_options.bail,
                 max_concurrency: ctx.test_options.max_concurrency,
                 // `test_filter_regex` is an erased `*mut RegularExpression` (see
@@ -1853,58 +1879,39 @@ impl TestCommand {
                     .test_options
                     .test_filter_regex()
                     .map(|p| p.cast::<jsc::RegularExpression>()),
-                snapshots: Snapshots::init(ctx.test_options.update_snapshots),
+                snapshots: RefCell::new(Snapshots::init(ctx.test_options.update_snapshots)),
                 bun_test_root: bun_test::BunTestRoot::init(),
                 // `TestRunner` cannot derive `Default` because of the
                 // `&'a TestOptions` field, so spell the remaining fields out
                 // explicitly.
-                current_file: jest::CurrentFile::default(),
-                files: jest::FileList::default(),
-                index: jest::FileMap::default(),
-                default_timeout_override: u32::MAX,
+                current_file: RefCell::new(jest::CurrentFile::default()),
+                files: RefCell::new(jest::FileList::default()),
+                index: RefCell::new(jest::FileMap::default()),
+                default_timeout_override: Cell::new(u32::MAX),
                 // SAFETY: lifetime-erase to `'static`; `ctx` is the
                 // process-lifetime CLI context and `exec()` never returns.
                 test_options: unsafe { bun_ptr::detach_lifetime_ref(&ctx.test_options) },
-                unhandled_errors_between_tests: 0,
-                summary: Summary::default(),
-                node_test_used: false,
+                unhandled_errors_between_tests: Cell::new(0),
+                summary: RefCell::new(Summary::default()),
+                node_test_used: Cell::new(false),
             },
-            repeat_count: 1,
-            last_printed_dot: core::cell::Cell::new(false),
-            worker_ipc_file_idx: None,
-            test_failure: None,
-            failures_to_repeat_buf: Vec::new(),
-            skips_to_repeat_buf: Vec::new(),
-            todos_to_repeat_buf: Vec::new(),
-            reporters: ReportersConfig::default(),
-            timings: if ctx.test_options.test_worker || ctx.test_options.timings_files.is_empty() {
-                None
-            } else {
-                Some(Timings::load(&ctx.test_options.timings_files))
-            },
-        });
-        // `defer { if (reporter.reporters.junit) |fr| fr.deinit() }` — handled by Drop.
-        reporter.repeat_count = ctx.test_options.repeat_count.max(1);
-        // SAFETY: single-threaded CLI startup; `reporter` is a `Box` that lives
-        // until `exec()` exits the process, so `&mut reporter.jest` remains
-        // valid for the process lifetime.
-        unsafe {
-            jest::Jest::RUNNER.write(Some(core::ptr::NonNull::from(&mut reporter.jest)));
-        }
-        // `reporter.jest.test_options` is initialised in the struct
-        // literal above (lifetime-erased); the post-init assignment is dropped.
-
-        if ctx.test_options.reporters.junit && !ctx.test_options.test_worker {
-            reporter.reporters.junit = Some(JunitReporter::init());
-        }
-        if ctx.test_options.reporters.dots {
-            reporter.reporters.dots = true;
-        }
-        if ctx.test_options.reporters.only_failures {
-            reporter.reporters.only_failures = true;
-        } else if Output::is_ai_agent() {
-            reporter.reporters.only_failures = true; // only-failures defaults to true for ai agents
-        }
+            repeat_count: ctx.test_options.repeat_count.max(1),
+            last_printed_dot: Cell::new(false),
+            worker_ipc_file_idx: Cell::new(None),
+            test_failure: RefCell::new(None),
+            failures_to_repeat_buf: RefCell::new(Vec::new()),
+            skips_to_repeat_buf: RefCell::new(Vec::new()),
+            todos_to_repeat_buf: RefCell::new(Vec::new()),
+            reporters,
+            timings: RefCell::new(
+                if ctx.test_options.test_worker || ctx.test_options.timings_files.is_empty() {
+                    None
+                } else {
+                    Some(Timings::load(&ctx.test_options.timings_files))
+                },
+            ),
+        }));
+        jest::Jest::set_runner(Some(&reporter.jest));
 
         // The worker's environment already holds the coordinator's env file values, and `BUN_OPTIONS` in it can carry `--env-file`.
         if ctx.test_options.test_worker {
@@ -2002,7 +2009,7 @@ impl TestCommand {
             // results go out over fd 3. Never returns.
             // SAFETY: `vm` is the live per-thread VM; `reporter`/`ctx` outlive
             // this never-returning call.
-            ParallelRunner::run_as_worker(&mut reporter, vm, ctx);
+            ParallelRunner::run_as_worker(reporter, vm, ctx);
         }
 
         // Start the debugger before we scan for files
@@ -2235,7 +2242,8 @@ impl TestCommand {
         if let Some(shard) = &ctx.test_options.shard {
             if !test_files.is_empty() {
                 let mut write: usize = 0;
-                if let Some(timings) = reporter.timings.as_ref().filter(|t| !t.is_empty()) {
+                if let Some(timings) = reporter.timings.borrow().as_ref().filter(|t| !t.is_empty())
+                {
                     write = timings.select_shard(test_files, *shard);
                 } else {
                     index_sort::sort_slice_by(test_files, |a, b| {
@@ -2337,14 +2345,14 @@ impl TestCommand {
 
             if ctx.test_options.parallel > 0 {
                 ran_parallel = ParallelRunner::run_as_coordinator(
-                    &mut reporter,
+                    reporter,
                     vm,
                     test_files,
                     &mut *ctx,
                     &mut coverage_options,
                 )?;
             } else {
-                Self::run_all_tests(&mut reporter, vm, test_files);
+                Self::run_all_tests(reporter, vm, test_files);
             }
         }
 
@@ -2378,46 +2386,51 @@ impl TestCommand {
         let write_snapshots_success = jest::Jest::runner()
             .unwrap()
             .snapshots
+            .borrow_mut()
             .write_inline_snapshots()?;
         jest::Jest::runner()
             .unwrap()
             .snapshots
+            .borrow_mut()
             .write_snapshot_file()?;
-        if reporter.summary().pass > 20
-            && !Output::is_ai_agent()
-            && !reporter.reporters.dots
-            && !reporter.reporters.only_failures
         {
-            if reporter.summary().skip > 0 {
-                pretty_error!("\n<r><d>{} tests skipped:<r>\n", reporter.summary().skip);
-                Output::flush();
+            let summary: Summary = *reporter.summary();
+            if summary.pass > 20
+                && !Output::is_ai_agent()
+                && !reporter.reporters.dots
+                && !reporter.reporters.only_failures
+            {
+                if summary.skip > 0 {
+                    pretty_error!("\n<r><d>{} tests skipped:<r>\n", summary.skip);
+                    Output::flush();
 
-                let error_writer = Output::error_writer();
-                let _ = error_writer.write_all(&reporter.skips_to_repeat_buf);
-            }
-
-            if reporter.summary().todo > 0 {
-                if reporter.summary().skip > 0 {
-                    pretty_error!("\n");
+                    let error_writer = Output::error_writer();
+                    let _ = error_writer.write_all(&reporter.skips_to_repeat_buf.borrow());
                 }
 
-                pretty_error!("\n<r><d>{} tests todo:<r>\n", reporter.summary().todo);
-                Output::flush();
+                if summary.todo > 0 {
+                    if summary.skip > 0 {
+                        pretty_error!("\n");
+                    }
 
-                let error_writer = Output::error_writer();
-                let _ = error_writer.write_all(&reporter.todos_to_repeat_buf);
-            }
+                    pretty_error!("\n<r><d>{} tests todo:<r>\n", summary.todo);
+                    Output::flush();
 
-            if reporter.summary().fail > 0 {
-                if reporter.summary().skip > 0 || reporter.summary().todo > 0 {
-                    pretty_error!("\n");
+                    let error_writer = Output::error_writer();
+                    let _ = error_writer.write_all(&reporter.todos_to_repeat_buf.borrow());
                 }
 
-                pretty_error!("\n<r><d>{} tests failed:<r>\n", reporter.summary().fail);
-                Output::flush();
+                if summary.fail > 0 {
+                    if summary.skip > 0 || summary.todo > 0 {
+                        pretty_error!("\n");
+                    }
 
-                let error_writer = Output::error_writer();
-                let _ = error_writer.write_all(&reporter.failures_to_repeat_buf);
+                    pretty_error!("\n<r><d>{} tests failed:<r>\n", summary.fail);
+                    Output::flush();
+
+                    let error_writer = Output::error_writer();
+                    let _ = error_writer.write_all(&reporter.failures_to_repeat_buf.borrow());
+                }
             }
         }
 
@@ -2501,12 +2514,10 @@ impl TestCommand {
                 reporter.generate_code_coverage(vm, &mut coverage_options);
             }
 
-            // `Summary` is `Copy`; take a value snapshot so the `&mut` from
-            // `reporter.summary()` doesn't span the whole printing block and
-            // conflict with the `reporter.jest.*` reads below.
             let summary: Summary = *reporter.summary();
-            let did_label_filter_out_all_tests = summary.did_label_filter_out_all_tests()
-                && reporter.jest.unhandled_errors_between_tests == 0;
+            let unhandled_errors_between_tests = reporter.jest.unhandled_errors_between_tests.get();
+            let did_label_filter_out_all_tests =
+                summary.did_label_filter_out_all_tests() && unhandled_errors_between_tests == 0;
 
             if !did_label_filter_out_all_tests {
                 struct DotIndenter {
@@ -2561,12 +2572,12 @@ impl TestCommand {
                 }
 
                 pretty_error!("{}{:5>} fail<r>\n", &indenter, summary.fail);
-                if reporter.jest.unhandled_errors_between_tests > 0 {
+                if unhandled_errors_between_tests > 0 {
                     pretty_error!(
                         "{}<r><red>{:5>} error{}<r>\n",
                         &indenter,
-                        reporter.jest.unhandled_errors_between_tests,
-                        if reporter.jest.unhandled_errors_between_tests > 1 {
+                        unhandled_errors_between_tests,
+                        if unhandled_errors_between_tests > 1 {
                             "s"
                         } else {
                             ""
@@ -2575,10 +2586,11 @@ impl TestCommand {
                 }
 
                 let mut print_expect_calls = summary.expectations > 0;
-                if reporter.jest.snapshots.total > 0 {
-                    let passed = reporter.jest.snapshots.passed;
-                    let failed = reporter.jest.snapshots.failed;
-                    let added = reporter.jest.snapshots.added;
+                let snapshots = reporter.jest.snapshots.borrow();
+                if snapshots.total > 0 {
+                    let passed = snapshots.passed;
+                    let failed = snapshots.failed;
+                    let added = snapshots.added;
 
                     let mut first = true;
                     if print_expect_calls && added == 0 && failed == 0 {
@@ -2586,7 +2598,7 @@ impl TestCommand {
                         pretty_error!(
                             "{}{:5>} snapshots, {:5>} expect() calls",
                             &indenter,
-                            reporter.jest.snapshots.total,
+                            snapshots.total,
                             summary.expectations
                         );
                     } else {
@@ -2617,6 +2629,7 @@ impl TestCommand {
 
                     pretty_error!("\n");
                 }
+                drop(snapshots);
 
                 if print_expect_calls {
                     pretty_error!("{}{:5>} expect() calls\n", &indenter, summary.expectations);
@@ -2655,7 +2668,7 @@ impl TestCommand {
             // unique mutable access on this single-threaded path.
             vm.run_with_api_lock(|| Self::run_event_loop_for_watch(unsafe { &mut *vm_ptr }));
         }
-        let summary = reporter.summary();
+        let summary: Summary = *reporter.summary();
 
         let should_fail_on_no_tests = !ctx.test_options.pass_with_no_tests
             && (failed_to_find_any_tests || summary.did_label_filter_out_all_tests());
@@ -2665,11 +2678,11 @@ impl TestCommand {
                 && coverage_options.fractions.failing
                 && coverage_options.fail_on_low_coverage)
             || !write_snapshots_success
-            || reporter.jest.unhandled_errors_between_tests > 0
+            || reporter.jest.unhandled_errors_between_tests.get() > 0
         {
             vm.exit_handler.exit_code = 1;
         }
-        vm.exit_handler.skip_exit_listeners = skip_exit_listeners(&reporter);
+        vm.exit_handler.skip_exit_listeners = skip_exit_listeners(reporter);
         // Must precede the GC-root release below: exit listeners are user JS and may touch still-live state.
         {
             let vm_ptr: *mut VirtualMachine = vm;
@@ -2681,16 +2694,11 @@ impl TestCommand {
         // on_exit() already set is_shutting_down; global_exit() asserts it.
         // Release `bun:test` GC roots before `global_exit()` so
         // `Zig__GlobalObject__destructOnExit()`'s `collectNow()` can reach the closures they pin
-        // (preload hooks, per-file describe/test callbacks). Clear `RUNNER`
-        // before dropping `reporter` so finalizers running inside the GC can't
-        // observe a dangling `TestRunner`.
+        // (preload hooks, per-file describe/test callbacks). Clear the runner
+        // registration so finalizers running inside the GC can't observe a
+        // torn-down `TestRunner`.
         reporter.jest.bun_test_root.deinit_for_exit();
-        // SAFETY: `RUNNER` is a `RacyCell` touched only from the single JS thread;
-        // no concurrent reader exists on this shutdown path.
-        unsafe {
-            jest::Jest::RUNNER.write(None);
-        }
-        drop(reporter);
+        jest::Jest::set_runner(None);
         {
             let vm_ptr: *mut VirtualMachine = vm;
             // SAFETY: `vm_ptr` reborrows the live `&mut VirtualMachine`;
@@ -2715,18 +2723,18 @@ impl TestCommand {
     }
 
     pub(crate) fn run_all_tests(
-        reporter_: &mut CommandLineReporter,
+        reporter_: &'static CommandLineReporter,
         vm_: &mut VirtualMachine,
         files_: &[Interned],
     ) {
         struct Context<'a> {
-            reporter: &'a mut CommandLineReporter,
+            reporter: &'static CommandLineReporter,
             vm: &'a mut VirtualMachine,
             files: &'a [Interned],
         }
         impl<'a> Context<'a> {
             fn begin(&mut self) {
-                let reporter = &mut *self.reporter;
+                let reporter = self.reporter;
                 let vm = &mut *self.vm;
                 let files = self.files;
                 debug_assert!(!files.is_empty());
@@ -2747,10 +2755,10 @@ impl TestCommand {
                         ) {
                             handle_top_level_test_error_before_javascript_start(&err);
                         }
-                        if let Some(t) = reporter.timings.as_mut() {
+                        if let Some(t) = reporter.timings.borrow_mut().as_mut() {
                             t.record_since(file_name.as_bytes(), started);
                         }
-                        reporter.jest.default_timeout_override = u32::MAX;
+                        reporter.jest.default_timeout_override.set(u32::MAX);
                         Global::mimalloc_cleanup(false);
                         if isolate {
                             crate::jsc_hooks::stop_active_handles_for_test_isolation(vm);
@@ -2776,7 +2784,7 @@ impl TestCommand {
                 ) {
                     handle_top_level_test_error_before_javascript_start(&err);
                 }
-                if let Some(t) = reporter.timings.as_mut() {
+                if let Some(t) = reporter.timings.borrow_mut().as_mut() {
                     t.record_since(last.as_bytes(), started);
                 }
             }
@@ -2800,7 +2808,7 @@ impl TestCommand {
     }
 
     pub(crate) fn run(
-        reporter: &mut CommandLineReporter,
+        reporter: &'static CommandLineReporter,
         vm: &mut VirtualMachine,
         file_name: &[u8],
         first_last: bun_test::FirstLast,
@@ -2825,12 +2833,8 @@ impl TestCommand {
         }
 
         // Restore test.only state after each module.
-        let prev_only = reporter.jest.only;
-        let reporter_ptr: *mut CommandLineReporter = reporter;
-        // SAFETY: `reporter` is caller-owned and outlives this guard; raw-ptr
-        // escape so the closure does not hold a borrowck
-        // lock on `reporter` for the entire function body.
-        scopeguard::defer! { unsafe { (*reporter_ptr).jest.only = prev_only; } }
+        let prev_only = reporter.jest.only.get();
+        scopeguard::defer! { reporter.jest.only.set(prev_only); }
 
         let resolution = vm.transpiler.resolve_entry_point(file_name)?;
         vm.clear_entry_point()?;
@@ -2869,33 +2873,22 @@ impl TestCommand {
                 vm.global().delete_module_registry_entry(&entry)?;
                 // Reset per-test snapshot counters so rerun N matches the same
                 // snapshot keys as run 1 instead of looking for "test name 2", etc.
-                reporter.jest.snapshots.reset_counts();
+                reporter.jest.snapshots.borrow_mut().reset_counts();
             }
 
-            let bun_test_root = &mut jest::Jest::runner().unwrap().bun_test_root;
+            let bun_test_root = &reporter.jest.bun_test_root;
             // Determine if this file should run tests concurrently based on glob pattern
             let should_run_concurrent = reporter.jest.should_file_run_concurrently(file_id);
             bun_test_root.enter_file(file_id, reporter, should_run_concurrent, first_last);
-            let bun_test_root_ptr: *mut bun_test::BunTestRoot = bun_test_root;
-            // SAFETY: `bun_test_root` is `&'static mut` from `Jest::runner()`;
-            // raw-ptr escape so the closure does not hold a borrowck lock on
-            // it for the loop body.
-            scopeguard::defer! { unsafe { (*bun_test_root_ptr).exit_file(); } }
+            scopeguard::defer! { bun_test_root.exit_file(); }
 
-            // SAFETY: `set()` reads only `reporter.{worker_ipc_file_idx, reporters}`
-            // and writes only `current_file` — disjoint fields. Fresh raw-ptr
-            // split (not the defer-captured `reporter_ptr`) keeps the borrows
-            // disjoint without tripping borrowck.
-            unsafe {
-                let rp: *mut CommandLineReporter = reporter;
-                (*rp).jest.current_file.set(
-                    file_title,
-                    file_prefix,
-                    repeat_count,
-                    repeat_index,
-                    &mut *rp,
-                );
-            }
+            reporter.jest.current_file.borrow_mut().set(
+                file_title,
+                file_prefix,
+                repeat_count,
+                repeat_index,
+                reporter,
+            );
 
             bun_output::scoped_log!(
                 bun_test,
@@ -2904,7 +2897,7 @@ impl TestCommand {
             );
             // Bun.jsc.Jest.bun_test.debug.group.log → local declare_scope!(bun_test).
 
-            if let Some(junit) = reporter.reporters.junit.as_mut() {
+            if let Some(junit) = reporter.reporters.junit.borrow_mut().as_mut() {
                 junit.file_start_ns = bun::Timespec::now(bun::TimespecMockMode::ForceRealTime).ns();
             }
             // need to wake up so autoTick() doesn't wait for 16-100ms after loading the entrypoint
@@ -2926,7 +2919,8 @@ impl TestCommand {
                     vm.unhandled_rejection(global, result, promise_js);
                     reporter.summary().fail += 1;
 
-                    if reporter.jest.bail == reporter.summary().fail {
+                    let fail_now = reporter.summary().fail;
+                    if reporter.jest.bail == fail_now {
                         reporter.print_summary();
                         pretty_error!(
                             "\nBailed out after {} failure{}<r>\n",
@@ -2942,14 +2936,10 @@ impl TestCommand {
                         // above never fires. Release the active file's
                         // `Strong`s and the preload-hook scope here so
                         // `Zig__GlobalObject__destructOnExit()`'s `collectNow()` can reclaim them,
-                        // then clear `RUNNER` so finalizers can't observe a
-                        // partially-torn-down `TestRunner`.
-                        // SAFETY: single-threaded; raw-ptr reborrow mirrors the
-                        // defer's escape.
-                        unsafe {
-                            (*bun_test_root_ptr).deinit_for_exit();
-                            jest::Jest::RUNNER.write(None);
-                        }
+                        // then clear the runner registration so finalizers
+                        // can't observe a partially-torn-down `TestRunner`.
+                        bun_test_root.deinit_for_exit();
+                        jest::Jest::set_runner(None);
                         let vm_ptr = std::ptr::from_mut::<VirtualMachine>(vm);
                         // SAFETY: global_exit diverges; `vm_ptr` is a fresh
                         // raw-ptr reborrow of the exclusive `vm` borrow.
@@ -2969,28 +2959,25 @@ impl TestCommand {
                     debug_assert!(false);
                     break 'blk;
                 };
-                let buntest = buntest_strong.get();
+                let buntest: &bun_test::BunTest = &buntest_strong;
 
                 // Automatically execute bun_test tests
-                if buntest.result_queue.readable_length() == 0 {
+                if buntest.readable_results() == 0 {
                     buntest.add_result(bun_test::ResultMsg::Start);
                 }
-                // `BunTestPtr` is `Rc<BunTestCell>`; clone (refcount++) so the
-                // local `buntest_strong` survives for the post-run drain loop and
-                // the explicit `drop` below.
-                bun_test::BunTest::run(&buntest_strong, vm.global())?;
+                buntest.run(vm.global())?;
 
                 // Process event loop while bun_test tests are running
                 vm.event_loop_ref().tick();
 
                 let mut prev_unhandled_count = vm.unhandled_error_counter;
-                while buntest.phase != bun_test::Phase::Done {
-                    if buntest.wants_wakeup {
-                        buntest.wants_wakeup = false;
+                while buntest.phase.get() != bun_test::Phase::Done {
+                    if buntest.wants_wakeup.get() {
+                        buntest.wants_wakeup.set(false);
                         vm.wakeup();
                     }
                     vm.event_loop_ref().auto_tick();
-                    if buntest.phase == bun_test::Phase::Done {
+                    if buntest.phase.get() == bun_test::Phase::Done {
                         break;
                     }
                     vm.event_loop_ref().tick();
@@ -3017,7 +3004,7 @@ impl TestCommand {
 
             let _ = vm.global().handle_rejected_promises();
 
-            if Output::is_github_action() && reporter.worker_ipc_file_idx.is_none() {
+            if Output::is_github_action() && reporter.worker_ipc_file_idx.get().is_none() {
                 pretty_errorln!("<r>\n::endgroup::\n");
                 Output::flush();
             }
@@ -3032,7 +3019,7 @@ impl TestCommand {
 
             repeat_index += 1;
         }
-        if let Some(junit) = reporter.reporters.junit.as_mut() {
+        if let Some(junit) = reporter.reporters.junit.borrow_mut().as_mut() {
             let _ = junit.end_file(None);
         }
         Ok(())

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1100,20 +1100,10 @@ pub(crate) unsafe fn __bun_fire_timer(
         }
         EventLoopTimerTag::BunTest => {
             let container = owner!(BunTest, timer);
-            // SAFETY: container is the payload of a live `Rc<BunTestCell>`; the
-            // strong count is ≥1 (held by `Jest.active_file`).
-            // `BunTestCell` is a `UnsafeCell<BunTest>` newtype — same
-            // layout as `BunTest`, so the raw `*mut BunTest` recovered above is
-            // also the `Rc` payload pointer.
-            let strong: BunTestPtr = unsafe {
-                let rc = std::rc::Rc::from_raw(
-                    container as *const crate::test_runner::bun_test::BunTestCell,
-                );
-                let cloned = std::rc::Rc::clone(&rc);
-                // Don't drop the original ref — it's borrowed, not owned here.
-                let _ = std::rc::Rc::into_raw(rc);
-                cloned
-            };
+            // SAFETY: container is the payload of a live `Rc<BunTest>` (an armed
+            // timer is unlinked in `Drop for BunTest`); take our own strong ref
+            // for the callback, which may drop `Jest.active_file`'s.
+            let strong: BunTestPtr = unsafe { (*container).strong() };
             // SAFETY: per fn contract. `bun_test_timeout_callback` takes a
             // `&bun_core::Timespec`; the low-tier `EventLoopTimer::Timespec` is
             // a layout-identical local stub.
@@ -1123,7 +1113,7 @@ pub(crate) unsafe fn __bun_fire_timer(
                     nsec: (*now).nsec,
                 }
             };
-            BunTest::bun_test_timeout_callback(&strong, &now_core, VirtualMachine::get());
+            strong.bun_test_timeout_callback(&now_core, VirtualMachine::get());
             Ok(())
         }
         EventLoopTimerTag::CronJob => {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1854,24 +1854,19 @@ unsafe fn retroactively_report_discovered_tests(
     let Some(runner) = Jest::runner() else {
         return next_test_id;
     };
-    let Some(active_file) = runner.bun_test_root.active_file.as_ref() else {
+    let Some(active_file) = runner.bun_test_root.clone_active_file() else {
         return next_test_id;
     };
-    // SAFETY: single-threaded; `active_file` keeps the cell alive for this call.
-    let active_file = unsafe { &mut *active_file.as_ptr() };
 
     // Only report if we're in collection or execution phase (tests have been
     // discovered).
-    match active_file.phase {
+    match active_file.phase.get() {
         Phase::Collection | Phase::Execution => {}
         Phase::Done => return next_test_id,
     }
 
     // Get the file path for source location info.
-    use crate::test_runner::jest::FileColumns as _;
-    let file_path = runner.files.items_source()[active_file.file_id as usize]
-        .path
-        .text();
+    let file_path = runner.file_path(active_file.file_id).text;
     let source_url = bun_core::String::from_bytes(file_path);
 
     let mut max_id: i32 = next_test_id;
@@ -1879,7 +1874,7 @@ unsafe fn retroactively_report_discovered_tests(
     // Recursively report all discovered tests starting from root scope.
     retroactively_report_scope(
         agent,
-        &mut active_file.collection.root_scope,
+        &active_file.collection.root_scope,
         -1,
         &mut max_id,
         &source_url,
@@ -1889,20 +1884,20 @@ unsafe fn retroactively_report_discovered_tests(
 
     fn retroactively_report_scope(
         agent: *mut TestReporterHandle,
-        scope: &mut DescribeScope,
+        scope: &DescribeScope,
         parent_id: i32,
         max_id: &mut i32,
         source_url: &bun_core::String,
     ) {
-        for entry in scope.entries.iter_mut() {
+        for entry in scope.entries.borrow().iter() {
             match entry {
                 TestScheduleEntry::Describe(describe) => {
-                    if describe.base.test_id_for_debugger == 0 {
+                    if describe.base.test_id_for_debugger.get() == 0 {
                         *max_id += 1;
                         let test_id = *max_id;
                         // Assign the ID so start/end events will fire during
                         // execution.
-                        describe.base.test_id_for_debugger = test_id;
+                        describe.base.test_id_for_debugger.set(test_id);
                         let name = bun_core::String::from_bytes(
                             describe.base.name.as_deref().unwrap_or(b"(unnamed)"),
                         );
@@ -1921,15 +1916,15 @@ unsafe fn retroactively_report_discovered_tests(
                     } else {
                         // Already has ID, just recurse with existing ID as
                         // parent.
-                        let existing = describe.base.test_id_for_debugger;
+                        let existing = describe.base.test_id_for_debugger.get();
                         retroactively_report_scope(agent, describe, existing, max_id, source_url);
                     }
                 }
                 TestScheduleEntry::TestCallback(test_entry) => {
-                    if test_entry.base.test_id_for_debugger == 0 {
+                    if test_entry.base.test_id_for_debugger.get() == 0 {
                         *max_id += 1;
                         let test_id = *max_id;
-                        test_entry.base.test_id_for_debugger = test_id;
+                        test_entry.base.test_id_for_debugger.set(test_id);
                         let name = bun_core::String::from_bytes(
                             test_entry.base.name.as_deref().unwrap_or(b"(unnamed)"),
                         );

--- a/src/runtime/test_runner/Collection.rs
+++ b/src/runtime/test_runner/Collection.rs
@@ -1,155 +1,112 @@
 //! for the collection phase of test execution where we discover all the test() calls
 
-use core::ptr::NonNull;
+use core::cell::{Cell, RefCell};
+use std::rc::Rc;
+
 use crate::test_runner::expect::make_formatter;
 
-use bun_jsc::{DeprecatedStrong, JSGlobalObject, JSValue, JsResult};
 use bun_core::Timespec;
+use bun_jsc::{DeprecatedStrong, JSGlobalObject, JSValue, JsResult};
 
-use crate::test_runner::bun_test::{
-    self, BunTest, BunTestPtr, BunTestRoot, DescribeScope, HandleUncaughtExceptionResult,
-    RefDataValue, StepResult,
-};
 use crate::test_runner::bun_test::debug::group;
+use crate::test_runner::bun_test::{
+    self, BunTestPtr, DescribeScope, HandleUncaughtExceptionResult, RefDataValue, StepResult,
+};
 use crate::test_runner::jest::Jest;
 
 pub struct Collection {
     /// set to true after collection phase ends
-    pub(crate) locked: bool,
-    pub(crate) describe_callback_queue: Vec<QueuedDescribe>,
-    pub(crate) current_scope_callback_queue: Vec<QueuedDescribe>,
-    // The two queues above are self-referential — their `NonNull<DescribeScope>` fields point
-    // into the tree rooted at `root_scope`. They are stored as raw `NonNull` (not `&`) so that
-    // `active_scope_mut()` may hand out `&mut DescribeScope` to the same nodes without
-    // invalidating any live shared-reference tags under Stacked Borrows.
+    pub(crate) locked: Cell<bool>,
+    pub(crate) describe_callback_queue: RefCell<Vec<QueuedDescribe>>,
+    pub(crate) current_scope_callback_queue: RefCell<Vec<QueuedDescribe>>,
 
-    pub(crate) root_scope: Box<DescribeScope>,
-    pub(crate) active_scope: NonNull<DescribeScope>,
+    pub(crate) root_scope: Rc<DescribeScope>,
+    active_scope: RefCell<Rc<DescribeScope>>,
 
-    pub(crate) filter_buffer: Vec<u8>,
+    pub(crate) filter_buffer: RefCell<Vec<u8>>,
 }
 
 pub struct QueuedDescribe {
     callback: DeprecatedStrong, // jsc.Strong.Deprecated
-    /// Raw cursor into `Collection.root_scope`'s tree. Stored as `NonNull` (not `&DescribeScope`)
-    /// because `Collection::active_scope_mut()` hands out `&mut` to the same node while these
-    /// queue entries are live; a `&` here would be invalidated by that `&mut` (Stacked Borrows).
-    /// The pointee is a `Box<DescribeScope>` inside `TestScheduleEntry::Describe`, so its address
-    /// is stable for the lifetime of the owning `Collection`.
-    active_scope: NonNull<DescribeScope>,
-    /// See `active_scope` — same invariants. Derived from the `&mut DescribeScope` returned by
-    /// `append_describe`, so it carries write-capable provenance (later assigned to
-    /// `Collection.active_scope` and mutated through).
-    new_scope: NonNull<DescribeScope>,
+    active_scope: Rc<DescribeScope>,
+    new_scope: Rc<DescribeScope>,
 }
-// `Strong: Drop` covers cleanup — no explicit Drop needed.
 
 impl Collection {
-    /// # Safety
-    /// `bun_test_root` must be a valid, exclusive pointer to a live `BunTestRoot` for the
-    /// duration of this call. The caller (`BunTest::init`) passes a pointer to its own
-    /// `bun_test_root` field.
-    // The `# Safety` contract above documents the deref precondition; the only caller is
-    // `BunTest::init`, which passes a pointer to its own field. Changing the signature to
-    // `&mut BunTestRoot` would require editing the caller in `bun_test.rs`.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn init(bun_test_root: *mut BunTestRoot) -> Collection {
+    pub(crate) fn init(hook_scope: &Rc<DescribeScope>) -> Collection {
         let _g = group::begin();
-        // SAFETY: see fn-level Safety doc.
-        let bun_test_root = unsafe { &mut *bun_test_root };
 
         let only = if let Some(runner) = Jest::runner() {
-            if runner.only { bun_test::Only::Contains } else { bun_test::Only::No }
+            if runner.only.get() {
+                bun_test::Only::Contains
+            } else {
+                bun_test::Only::No
+            }
         } else {
             bun_test::Only::No
         };
 
-        let mut root_scope = DescribeScope::create(bun_test::BaseScope {
-            parent: Some(&raw mut *bun_test_root.hook_scope),
+        let root_scope = DescribeScope::create(bun_test::BaseScope {
+            parent: Some(Rc::downgrade(hook_scope)),
             name: None,
             concurrent: false,
             mode: bun_test::ScopeMode::Normal,
-            only,
-            has_callback: false,
-            test_id_for_debugger: 0,
+            only: Cell::new(only),
+            has_callback: Cell::new(false),
+            test_id_for_debugger: Cell::new(0),
             line_no: 0,
         });
 
-        let active_scope = NonNull::from(&mut *root_scope);
-
         Collection {
-            locked: false,
-            describe_callback_queue: Vec::new(),
-            current_scope_callback_queue: Vec::new(),
+            locked: Cell::new(false),
+            describe_callback_queue: RefCell::new(Vec::new()),
+            current_scope_callback_queue: RefCell::new(Vec::new()),
+            active_scope: RefCell::new(Rc::clone(&root_scope)),
             root_scope,
-            active_scope,
-            filter_buffer: Vec::new(),
+            filter_buffer: RefCell::new(Vec::new()),
         }
     }
 
-    // Cleanup is covered by field Drop (Box, Vec<QueuedDescribe>, Vec<u8>).
-    // No explicit `impl Drop for Collection` needed.
-
-    /// Immutable view of the currently-active describe scope.
-    ///
-    /// SAFETY: `active_scope` is initialized to `root_scope` in `init()` and is only ever
-    /// reassigned to nodes inside `root_scope`'s tree (via `append_describe` children or
-    /// restored from a `RefDataValue::Collection` snapshot). The tree is owned by
-    /// `self.root_scope: Box<_>` and nodes are never freed for the lifetime of `Collection`,
-    /// so the pointer is always valid while `self` is.
+    /// The currently-active describe scope.
     #[inline]
-    pub(crate) fn active_scope(&self) -> &DescribeScope {
-        // SAFETY: `active_scope` always points into `self.root_scope`'s owned tree; see doc comment above.
-        unsafe { self.active_scope.as_ref() }
+    pub(crate) fn active_scope(&self) -> Rc<DescribeScope> {
+        Rc::clone(&self.active_scope.borrow())
     }
 
-    /// Mutable view of the currently-active describe scope.
-    ///
-    /// SAFETY: see `active_scope()` for validity. The returned `&mut` reborrows from `&mut self`,
-    /// so borrowck prevents simultaneous access to `self.root_scope` while it is live. The
-    /// self-referential queues (`describe_callback_queue` / `current_scope_callback_queue`) hold
-    /// only raw `NonNull<DescribeScope>` to the same nodes, never `&DescribeScope`, so creating
-    /// this `&mut` does not invalidate any outstanding shared-reference tags. `active_scope` is
-    /// always assigned from a `&mut`-derived `NonNull` (root in `init()`, `new_scope` in
-    /// `step()`), so it carries write-capable provenance.
-    #[inline]
-    pub(crate) fn active_scope_mut(&mut self) -> &mut DescribeScope {
-        // SAFETY: `active_scope` always points into `self.root_scope`'s owned tree with write provenance; see doc comment above.
-        unsafe { self.active_scope.as_mut() }
+    fn set_active_scope(&self, scope: Rc<DescribeScope>) {
+        *self.active_scope.borrow_mut() = scope;
     }
 
     pub(crate) fn enqueue_describe_callback(
-        &mut self,
-        new_scope: &mut DescribeScope,
+        &self,
+        new_scope: Rc<DescribeScope>,
         callback: Option<JSValue>,
     ) -> JsResult<()> {
         let _g = group::begin();
 
-        debug_assert!(!self.locked);
+        debug_assert!(!self.locked.get());
 
         if let Some(cb) = callback {
+            let active_scope = self.active_scope();
             group::log(format_args!(
                 "enqueueDescribeCallback / {} / in scope: {}",
                 bstr::BStr::new(new_scope.base.name.as_deref().unwrap_or(b"(unnamed)")),
-                bstr::BStr::new(self.active_scope().base.name.as_deref().unwrap_or(b"(unnamed)")),
+                bstr::BStr::new(active_scope.base.name.as_deref().unwrap_or(b"(unnamed)")),
             ));
 
-            // Store raw NonNull cursors (not `&`) so later `active_scope_mut()` calls on the same
-            // node do not invalidate them. Both pointees live in `root_scope`'s Box-allocated tree
-            // and outlive every QueuedDescribe stored in `self`. `new_scope` is `&mut`, so the
-            // resulting NonNull carries write-capable provenance (later assigned to
-            // `self.active_scope` in `step()` and mutated through).
-            self.current_scope_callback_queue.push(QueuedDescribe {
-                active_scope: self.active_scope,
-                callback: DeprecatedStrong::init(cb),
-                new_scope: NonNull::from(new_scope),
-            });
+            self.current_scope_callback_queue
+                .borrow_mut()
+                .push(QueuedDescribe {
+                    active_scope,
+                    callback: DeprecatedStrong::init(cb),
+                    new_scope,
+                });
         }
         Ok(())
     }
 
     pub(crate) fn run_one_completed(
-        &mut self,
+        &self,
         global_this: &JSGlobalObject,
         _: Option<JSValue>,
         data: &RefDataValue,
@@ -158,22 +115,37 @@ impl Collection {
 
         let _formatter = make_formatter(global_this);
 
-        let prev_scope: NonNull<DescribeScope> = match data {
-            RefDataValue::Collection { active_scope } => *active_scope,
-            _ => {
-                debug_assert!(false); // this probably can't happen
-                self.active_scope
-            }
-        };
+        // The named scope is part of `self.root_scope`'s tree, which lives as
+        // long as `self`.
+        let prev_scope: Rc<DescribeScope> = match data {
+            RefDataValue::Collection { active_scope } => active_scope.upgrade(),
+            _ => None,
+        }
+        .unwrap_or_else(|| {
+            debug_assert!(false); // this probably can't happen
+            self.active_scope()
+        });
 
         group::log(format_args!(
             "collection:runOneCompleted reset scope back from {}",
-            bstr::BStr::new(self.active_scope().base.name.as_deref().unwrap_or(b"undefined")),
+            bstr::BStr::new(
+                self.active_scope()
+                    .base
+                    .name
+                    .as_deref()
+                    .unwrap_or(b"undefined")
+            ),
         ));
-        self.active_scope = prev_scope;
+        self.set_active_scope(prev_scope);
         group::log(format_args!(
             "collection:runOneCompleted reset scope back to {}",
-            bstr::BStr::new(self.active_scope().base.name.as_deref().unwrap_or(b"undefined")),
+            bstr::BStr::new(
+                self.active_scope()
+                    .base
+                    .name
+                    .as_deref()
+                    .unwrap_or(b"undefined")
+            ),
         ));
         Ok(())
     }
@@ -184,8 +156,8 @@ impl Collection {
         data: &RefDataValue,
     ) -> JsResult<StepResult> {
         let _g = group::begin();
-        let buntest = buntest_strong.get();
-        let this = &mut buntest.collection;
+        let buntest = &**buntest_strong;
+        let this = &buntest.collection;
 
         if !matches!(data, RefDataValue::Start) {
             this.run_one_completed(global_this, None, data)?;
@@ -194,71 +166,84 @@ impl Collection {
         let _formatter = make_formatter(global_this);
 
         // append queued callbacks, in reverse order because items will be pop()ed from the end
-        // drain(..).rev() moves each item out exactly once and leaves capacity intact.
-        for item in this.current_scope_callback_queue.drain(..).rev() {
-            // SAFETY: `new_scope` points into `root_scope`'s Box-allocated tree, which outlives
-            // every queued item; short-lived read, no aliasing `&mut` is live here.
-            if unsafe { item.new_scope.as_ref() }.failed {
+        let queued: Vec<QueuedDescribe> = this
+            .current_scope_callback_queue
+            .borrow_mut()
+            .drain(..)
+            .collect();
+        for item in queued.into_iter().rev() {
+            if item.new_scope.failed.get() {
                 // if there was an error in the describe callback, don't run any describe callbacks in this scope
                 drop(item); // Strong released here
             } else {
-                this.describe_callback_queue.push(item);
+                this.describe_callback_queue.borrow_mut().push(item);
             }
         }
-        // `drain(..)` retains the queue's capacity.
 
-        while !this.describe_callback_queue.is_empty() {
+        loop {
+            let Some(first) = this.describe_callback_queue.borrow_mut().pop() else {
+                break;
+            };
             group::log(format_args!("runOne -> call next"));
-            let first = this.describe_callback_queue.pop().unwrap();
             // `first` cleanup handled by Drop at end of loop body / continue.
 
-            // SAFETY: `active_scope` points into `root_scope`'s Box-allocated tree, which outlives
-            // every queued item; short-lived read, no aliasing `&mut` is live here.
-            if unsafe { first.active_scope.as_ref() }.failed {
+            if first.active_scope.failed.get() {
                 continue; // do not execute callbacks that came from a failed describe scope
             }
 
             let callback = &first.callback;
-            let previous_scope = first.active_scope;
-            let new_scope = first.new_scope;
+            let previous_scope = Rc::clone(&first.active_scope);
+            let new_scope = Rc::clone(&first.new_scope);
 
             group::log(format_args!(
                 "collection:runOne set scope from {}",
-                bstr::BStr::new(this.active_scope().base.name.as_deref().unwrap_or(b"undefined")),
+                bstr::BStr::new(
+                    this.active_scope()
+                        .base
+                        .name
+                        .as_deref()
+                        .unwrap_or(b"undefined")
+                ),
             ));
-            // `new_scope` was constructed from the `&mut DescribeScope` returned by
-            // `append_describe`, so it carries write-capable provenance for `active_scope_mut()`.
-            this.active_scope = new_scope;
+            this.set_active_scope(new_scope);
             group::log(format_args!(
                 "collection:runOne set scope to {}",
-                bstr::BStr::new(this.active_scope().base.name.as_deref().unwrap_or(b"undefined")),
+                bstr::BStr::new(
+                    this.active_scope()
+                        .base
+                        .name
+                        .as_deref()
+                        .unwrap_or(b"undefined")
+                ),
             ));
 
-            if let Some(cfg_data) = BunTest::run_test_callback(
-                buntest_strong,
+            if let Some(cfg_data) = buntest.run_test_callback(
                 global_this,
                 callback.get(),
                 false,
-                RefDataValue::Collection { active_scope: previous_scope },
+                RefDataValue::Collection {
+                    active_scope: Rc::downgrade(&previous_scope),
+                },
                 &Timespec::EPOCH,
             ) {
                 // the result is available immediately; queue
-                // Re-derive after re-entrant call per BunTestCell::get aliasing contract.
-                buntest_strong.get().add_result(cfg_data);
+                buntest.add_result(cfg_data);
             }
 
-            return Ok(StepResult::Waiting { timeout: Timespec::EPOCH });
+            return Ok(StepResult::Waiting {
+                timeout: Timespec::EPOCH,
+            });
         }
         Ok(StepResult::Complete)
     }
 
     pub(crate) fn handle_uncaught_exception(
-        &mut self,
+        &self,
         _: &RefDataValue,
     ) -> HandleUncaughtExceptionResult {
         let _g = group::begin();
 
-        self.active_scope_mut().failed = true;
+        self.active_scope().failed.set(true);
 
         HandleUncaughtExceptionResult::ShowUnhandledErrorInDescribe // unhandled because it needs to exit with code 1
     }

--- a/src/runtime/test_runner/DoneCallback.rs
+++ b/src/runtime/test_runner/DoneCallback.rs
@@ -1,14 +1,18 @@
-use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSValue, JsClass as _, JsResult};
+use core::cell::Cell;
+
 use bun_core::String as BunString;
-use bun_ptr::RefPtr;
+use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSValue, JsClass as _, JsResult};
 
-use crate::test_runner::bun_test::{group_begin, BunTest, RefData};
+use crate::test_runner::bun_test::{BunTest, RefDataPtr, group_begin};
 
+// R-2 (host-fn re-entrancy): reached through `&self` from JS; both fields are
+// `Cell`s so the `done()` host fn and `run_test_callback` can update them
+// through the shared borrow `as_class_ref` hands out.
 #[bun_jsc::JsClass(no_construct, no_constructor)] // codegen wires to_js / from_js
 pub struct DoneCallback {
     /// Some = not called yet. None = done already called, no-op.
-    pub(crate) r#ref: Option<RefPtr<RefData>>,
-    pub(crate) called: bool, // = false
+    pub(crate) r#ref: Cell<Option<RefDataPtr>>,
+    pub(crate) called: Cell<bool>, // = false
 }
 
 impl DoneCallback {
@@ -16,8 +20,8 @@ impl DoneCallback {
         let _g = group_begin!();
 
         let done_callback = DoneCallback {
-            r#ref: None,
-            called: false,
+            r#ref: Cell::new(None),
+            called: Cell::new(false),
         };
 
         // `JsClass::to_js` boxes `self` and hands the raw pointer to the JS
@@ -31,7 +35,7 @@ impl DoneCallback {
         let call_fn = JSFunction::create(
             global,
             "done",
-            __jsc_host_bun_test_done_callback,
+            __jsc_host_call_done_callback,
             1,
             Default::default(),
         );
@@ -39,17 +43,10 @@ impl DoneCallback {
     }
 }
 
-// Raw C-ABI shim for [`BunTest::bun_test_done_callback`] so it can be passed
-// as a `JSHostFn` pointer to `JSFunction::create` (the thunk routes the result through
-// `to_js_host_fn_result` for `JsResult` → `JSValue` mapping + debug exception
-// assertions).
-bun_jsc::jsc_host_abi! {
-    unsafe fn __jsc_host_bun_test_done_callback(
-        g: *mut JSGlobalObject,
-        f: *mut CallFrame,
-    ) -> JSValue {
-        // SAFETY: JSC guarantees both pointers are live for the duration of the host call.
-        let (global, callframe) = unsafe { (&*g, &*f) };
-        bun_jsc::to_js_host_fn_result(global, BunTest::bun_test_done_callback(global, callframe))
-    }
+#[bun_jsc::host_fn]
+fn call_done_callback(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+    let Some(this) = callframe.this().as_class_ref::<DoneCallback>() else {
+        return Err(global.throw(format_args!("Expected callee to be DoneCallback")));
+    };
+    BunTest::bun_test_done_callback(this, global, callframe)
 }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -35,19 +35,20 @@
 //! ]
 //! ```
 
-use core::ptr::NonNull;
+use core::cell::{Cell, OnceCell, RefCell};
+use std::rc::Rc;
 
 use bun_core::{Timespec, TimespecMockMode};
 use bun_jsc::{JSGlobalObject, JsResult};
 // `bun_jsc::VirtualMachine` is the *module* re-export; the struct lives one level deeper.
-use bun_jsc::virtual_machine::VirtualMachine;
 use bun_core::scoped_log;
+use bun_jsc::virtual_machine::VirtualMachine;
 
-use super::debug::group as group_log; // bun_test.debug.group
 use super::bun_test::{
-    group_begin, AddedInPhase, BunTest, BunTestPtr, EntryData, ExecutionEntry,
-    HandleUncaughtExceptionResult, Order, RefDataValue, ScopeMode, StepResult,
+    AddedInPhase, BunTest, BunTestPtr, EntryData, ExecutionEntry, HandleUncaughtExceptionResult,
+    Order, RefDataValue, ScopeMode, StepResult, group_begin,
 };
+use super::debug::group as group_log; // bun_test.debug.group
 use crate::cli::test_command;
 
 // ── local shims for upstream Timespec methods not yet ported ───────────────
@@ -73,75 +74,112 @@ impl TimespecExt for Timespec {
     }
 }
 
-/// Convert the `Option<*mut ExecutionEntry>` linked-list field shape used by
-/// [`ExecutionEntry`] into the `Option<NonNull<_>>` shape this module uses.
-#[inline]
-fn nn(p: Option<*mut ExecutionEntry>) -> Option<NonNull<ExecutionEntry>> {
-    p.and_then(NonNull::new)
-}
-
 bun_core::declare_scope!(jest, visible);
 
+/// Index of an [`EntryNode`] in [`Execution::nodes`] (or, while the order is
+/// being built, in `Order::nodes`).
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct EntryId(u32);
+
+impl EntryId {
+    #[inline]
+    pub(crate) fn index(self) -> usize {
+        self.0 as usize
+    }
+    #[inline]
+    pub(crate) fn from_index(i: usize) -> Self {
+        EntryId(u32::try_from(i).expect("too many execution entries"))
+    }
+}
+
+/// One scheduled occurrence of an [`ExecutionEntry`] in the execution order.
+/// A hook shared by several tests gets one node per test; the entry itself is
+/// shared.
+pub struct EntryNode {
+    pub(crate) entry: Rc<ExecutionEntry>,
+    pub(crate) next: Cell<Option<EntryId>>,
+    /// if this entry fails, go to the entry 'failure_skip_past.next'
+    pub(crate) failure_skip_past: Cell<Option<EntryId>>,
+    /// '.epoch' = not set
+    /// when this entry begins executing, the timespec will be set to the current time plus the timeout(ms).
+    pub(crate) timespec: Cell<Timespec>,
+}
+
+impl EntryNode {
+    pub(crate) fn new(entry: Rc<ExecutionEntry>) -> Self {
+        EntryNode {
+            entry,
+            next: Cell::new(None),
+            failure_skip_past: Cell::new(None),
+            timespec: Cell::new(Timespec::EPOCH),
+        }
+    }
+}
+
 pub struct Execution {
-    pub(crate) groups: Box<[ConcurrentGroup]>,
-    // was `pub(self)`; widened so `RefDataValue::sequence` can
-    // split-borrow `groups`/`sequences` without re-entering `sequences_mut`.
-    /// the entries themselves are owned by BunTest, which owns Execution.
-    pub(crate) sequences: Box<[ExecutionSequence]>,
-    pub(crate) group_index: usize,
+    groups: OnceCell<Box<[ConcurrentGroup]>>,
+    sequences: OnceCell<Box<[ExecutionSequence]>>,
+    /// Every scheduled entry occurrence; grows during execution when a hook is
+    /// registered from inside a test. Borrows never leave the accessor they
+    /// are taken in.
+    nodes: RefCell<Vec<EntryNode>>,
+    pub(crate) group_index: Cell<usize>,
     /// The entry whose callback is synchronously on the stack right now. Set
     /// around `run_test_callback` so code re-entered from a test body (e.g.
     /// spawnSync's wait loop) can read the calling entry's own deadline.
-    pub(crate) on_stack_entry: core::cell::Cell<Option<NonNull<ExecutionEntry>>>,
+    pub(crate) on_stack_entry: Cell<Option<EntryId>>,
     /// The (group_index, sequence_index, entry, repeat) for `on_stack_entry`,
     /// set/restored alongside it. `get_current_state_data()` can't name a
     /// sequence inside a concurrent group; this can, for code re-entered from
     /// the microtask drain inside `run_test_callback` (node:test's runtime
     /// `t.skip()`/`t.todo()` mark lands there before the DoneCallback is
     /// stamped).
-    pub(crate) on_stack_entry_data: core::cell::Cell<Option<super::bun_test::EntryData>>,
+    pub(crate) on_stack_entry_data: Cell<Option<super::bun_test::EntryData>>,
 }
 
 pub struct ConcurrentGroup {
     pub(crate) sequence_start: usize,
     pub(crate) sequence_end: usize,
     /// Index of the next sequence that has not been started yet
-    pub(crate) next_sequence_index: usize,
-    pub(crate) executing: bool,
-    pub(crate) remaining_incomplete_entries: usize,
+    pub(crate) next_sequence_index: Cell<usize>,
+    pub(crate) executing: Cell<bool>,
+    pub(crate) remaining_incomplete_entries: Cell<usize>,
     /// used by beforeAll to skip directly to afterAll if it fails
     pub(crate) failure_skip_to: usize,
 }
 
 impl ConcurrentGroup {
-    pub(crate) fn init(sequence_start: usize, sequence_end: usize, next_index: usize) -> ConcurrentGroup {
+    pub(crate) fn init(
+        sequence_start: usize,
+        sequence_end: usize,
+        next_index: usize,
+    ) -> ConcurrentGroup {
         ConcurrentGroup {
             sequence_start,
             sequence_end,
-            executing: false,
-            remaining_incomplete_entries: sequence_end - sequence_start,
+            executing: Cell::new(false),
+            remaining_incomplete_entries: Cell::new(sequence_end - sequence_start),
             failure_skip_to: next_index,
-            next_sequence_index: 0,
+            next_sequence_index: Cell::new(0),
         }
     }
 
-    pub(crate) fn try_extend(&mut self, next_sequence_start: usize, next_sequence_end: usize) -> bool {
+    pub(crate) fn try_extend(
+        &mut self,
+        next_sequence_start: usize,
+        next_sequence_end: usize,
+    ) -> bool {
         if self.sequence_end != next_sequence_start {
             return false;
         }
         self.sequence_end = next_sequence_end;
-        self.remaining_incomplete_entries = self.sequence_end - self.sequence_start;
+        self.remaining_incomplete_entries
+            .set(self.sequence_end - self.sequence_start);
         true
     }
 
     pub(crate) fn sequences<'a>(&self, execution: &'a Execution) -> &'a [ExecutionSequence] {
-        &execution.sequences[self.sequence_start..self.sequence_end]
-    }
-
-
-    /// Immutable view of [`Self::sequences`] for read-only callers (e.g. debug dumps).
-    pub(crate) fn sequences_const<'a>(&self, execution: &'a Execution) -> &'a [ExecutionSequence] {
-        &execution.sequences[self.sequence_start..self.sequence_end]
+        &execution.sequences()[self.sequence_start..self.sequence_end]
     }
 }
 
@@ -153,51 +191,68 @@ pub enum ExpectAssertions {
 }
 
 pub struct ExecutionSequence {
-    pub(crate) first_entry: Option<NonNull<ExecutionEntry>>,
+    pub(crate) first_entry: Option<EntryId>,
     /// Index into ExecutionSequence.entries() for the entry that is not started or currently running
-    pub(crate) active_entry: Option<NonNull<ExecutionEntry>>,
-    pub(crate) test_entry: Option<NonNull<ExecutionEntry>>,
-    pub(crate) remaining_repeat_count: u32,
-    pub(crate) remaining_retry_count: u32,
-    pub(crate) result: Result,
-    pub(crate) executing: bool,
-    pub(crate) started_at: Timespec,
+    pub(crate) active_entry: Cell<Option<EntryId>>,
+    pub(crate) test_entry: Option<EntryId>,
+    pub(crate) remaining_repeat_count: Cell<u32>,
+    pub(crate) remaining_retry_count: Cell<u32>,
+    pub(crate) result: Cell<Result>,
+    pub(crate) executing: Cell<bool>,
+    pub(crate) started_at: Cell<Timespec>,
     /// Number of expect() calls observed in this sequence.
-    pub(crate) expect_call_count: u32,
+    pub(crate) expect_call_count: Cell<u32>,
     /// Expectation set by expect.hasAssertions() or expect.assertions(n).
-    pub(crate) expect_assertions: ExpectAssertions,
-    pub(crate) maybe_skip: bool,
+    pub(crate) expect_assertions: Cell<ExpectAssertions>,
+    pub(crate) maybe_skip: Cell<bool>,
 }
 
 impl ExecutionSequence {
     pub(crate) fn init(
-        first_entry: Option<NonNull<ExecutionEntry>>,
-        test_entry: Option<NonNull<ExecutionEntry>>,
+        first_entry: Option<EntryId>,
+        test_entry: Option<EntryId>,
         retry_count: u32,
         repeat_count: u32,
     ) -> ExecutionSequence {
         ExecutionSequence {
             first_entry,
-            active_entry: first_entry,
+            active_entry: Cell::new(first_entry),
             test_entry,
-            remaining_repeat_count: repeat_count,
-            remaining_retry_count: retry_count,
+            remaining_repeat_count: Cell::new(repeat_count),
+            remaining_retry_count: Cell::new(retry_count),
             // defaults:
-            result: Result::Pending,
-            executing: false,
-            started_at: Timespec::EPOCH,
-            expect_call_count: 0,
-            expect_assertions: ExpectAssertions::NotSet,
-            maybe_skip: false,
+            result: Cell::new(Result::Pending),
+            executing: Cell::new(false),
+            started_at: Cell::new(Timespec::EPOCH),
+            expect_call_count: Cell::new(0),
+            expect_assertions: Cell::new(ExpectAssertions::NotSet),
+            maybe_skip: Cell::new(false),
         }
     }
 
-    fn entry_mode(&self) -> ScopeMode {
+    /// Back to the not-started state, preserving retry/repeat counts.
+    fn reset(&self) {
+        self.active_entry.set(self.first_entry);
+        self.result.set(Result::Pending);
+        self.executing.set(false);
+        self.started_at.set(Timespec::EPOCH);
+        self.expect_call_count.set(0);
+        self.expect_assertions.set(ExpectAssertions::NotSet);
+        self.maybe_skip.set(false);
+    }
+
+    fn entry_mode(&self, execution: &Execution) -> ScopeMode {
         if let Some(entry) = self.test_entry {
-            // SAFETY: arena-owned entry, alive for the lifetime of BunTest which owns Execution
-            return unsafe { entry.as_ref() }.base.mode;
+            return execution.entry(entry).base.mode;
         }
         ScopeMode::Normal
+    }
+
+    #[inline]
+    fn set_result_if_pending(&self, result: Result) {
+        if self.result.get() == Result::Pending {
+            self.result.set(result);
+        }
     }
 }
 
@@ -268,59 +323,95 @@ impl Result {
     }
 }
 
-// Recover the parent `BunTest` from `&mut self`. Returns `*mut BunTest` (not
-// `&mut BunTest`) because `self` *is* `BunTest.execution`, so materializing a
-// `&mut BunTest` while `&mut self` is live would be aliased-`&mut` UB. Callers
-// must dereference at point-of-use into disjoint fields only.
-bun_core::impl_field_parent! { Execution => BunTest.execution; fn mut bun_test; }
-
 impl Execution {
     pub(crate) fn init() -> Execution {
         Execution {
-            groups: Box::default(),
-            sequences: Box::default(),
-            group_index: 0,
-            on_stack_entry: core::cell::Cell::new(None),
-            on_stack_entry_data: core::cell::Cell::new(None),
+            groups: OnceCell::new(),
+            sequences: OnceCell::new(),
+            nodes: RefCell::new(Vec::new()),
+            group_index: Cell::new(0),
+            on_stack_entry: Cell::new(None),
+            on_stack_entry_data: Cell::new(None),
         }
     }
 
-    // `groups` / `sequences` are `Box<[T]>` and drop automatically — no explicit Drop impl needed.
-
-    /// Infallible: the `Vec` → `Box<[T]>` conversion cannot fail.
-    pub(crate) fn load_from_order(&mut self, order: &mut Order::Order) {
-        debug_assert!(self.groups.is_empty());
-        debug_assert!(self.sequences.is_empty());
-        self.groups = core::mem::take(&mut order.groups).into_boxed_slice();
-        self.sequences = core::mem::take(&mut order.sequences).into_boxed_slice();
+    #[inline]
+    pub(crate) fn groups(&self) -> &[ConcurrentGroup] {
+        self.groups.get().map_or(&[], |g| &g[..])
     }
 
-    pub(crate) fn handle_timeout(&mut self, global_this: &JSGlobalObject) -> JsResult<()> {
+    #[inline]
+    pub(crate) fn sequences(&self) -> &[ExecutionSequence] {
+        self.sequences.get().map_or(&[], |s| &s[..])
+    }
+
+    pub(crate) fn entry(&self, id: EntryId) -> Rc<ExecutionEntry> {
+        Rc::clone(&self.nodes.borrow()[id.index()].entry)
+    }
+
+    pub(crate) fn next_of(&self, id: EntryId) -> Option<EntryId> {
+        self.nodes.borrow()[id.index()].next.get()
+    }
+
+    pub(crate) fn set_next(&self, id: EntryId, next: Option<EntryId>) {
+        self.nodes.borrow()[id.index()].next.set(next);
+    }
+
+    fn failure_skip_past_of(&self, id: EntryId) -> Option<EntryId> {
+        self.nodes.borrow()[id.index()].failure_skip_past.get()
+    }
+
+    pub(crate) fn timespec_of(&self, id: EntryId) -> Timespec {
+        self.nodes.borrow()[id.index()].timespec.get()
+    }
+
+    fn set_timespec(&self, id: EntryId, timespec: Timespec) {
+        self.nodes.borrow()[id.index()].timespec.set(timespec);
+    }
+
+    pub(crate) fn push_node(&self, node: EntryNode) -> EntryId {
+        let mut nodes = self.nodes.borrow_mut();
+        let id = EntryId::from_index(nodes.len());
+        nodes.push(node);
+        id
+    }
+
+    pub(crate) fn load_from_order(&self, order: &mut Order::Order) {
+        debug_assert!(self.groups().is_empty());
+        debug_assert!(self.sequences().is_empty());
+        debug_assert!(self.nodes.borrow().is_empty());
+        let _ = self
+            .groups
+            .set(core::mem::take(&mut order.groups).into_boxed_slice());
+        let _ = self
+            .sequences
+            .set(core::mem::take(&mut order.sequences).into_boxed_slice());
+        *self.nodes.borrow_mut() = core::mem::take(&mut order.nodes);
+    }
+
+    pub(crate) fn handle_timeout(
+        &self,
+        buntest: &BunTest,
+        global_this: &JSGlobalObject,
+    ) -> JsResult<()> {
         let _g = group_begin!();
         self.kill_dangling_processes_on_timeout(global_this);
-        let buntest = self.bun_test();
-        // SAFETY: deref parent at point-of-use; `self` is not accessed while this `&mut BunTest` is live.
-        unsafe { (*buntest).add_result(RefDataValue::Start) };
+        buntest.add_result(RefDataValue::Start);
         Ok(())
     }
 
     /// The kill-only half of [`handle_timeout`]: reaps a timed-out test's spawned processes without touching the runner's queue, so it may run from inside `spawnSync`'s isolated loop.
-    pub(crate) fn kill_dangling_processes_on_timeout(&mut self, global_this: &JSGlobalObject) {
+    pub(crate) fn kill_dangling_processes_on_timeout(&self, global_this: &JSGlobalObject) {
         // if the concurrent group has one sequence and the sequence has an active entry that has timed out,
         //   kill any dangling processes
         // when using test.concurrent(), we can't do this because it could kill multiple tests at once.
         if let Some(current_group) = self.active_group() {
-            // reshaped for borrowck — capture range, drop &mut group, re-borrow sequences
-            let (start, end) = (current_group.sequence_start, current_group.sequence_end);
-            let sequences = &self.sequences[start..end];
+            let sequences = current_group.sequences(self);
             if sequences.len() == 1 {
                 let sequence = &sequences[0];
-                if let Some(entry) = sequence.active_entry {
-                    // SAFETY: arena-owned entry, alive for lifetime of BunTest
-                    let entry = unsafe { entry.as_ref() };
+                if let Some(entry) = sequence.active_entry.get() {
                     let now = Timespec::now_force_real_time();
-                    if entry.timespec.order(&now) == core::cmp::Ordering::Less {
-                        // SAFETY: bun_vm() returns the live per-thread VM.
+                    if self.timespec_of(entry).order(&now) == core::cmp::Ordering::Less {
                         let kill_count = global_this.bun_vm().as_mut().auto_killer.kill();
                         if kill_count.processes > 0 {
                             bun_core::pretty_errorln!(
@@ -342,41 +433,41 @@ impl Execution {
         data: &RefDataValue,
     ) -> JsResult<StepResult> {
         let _g = group_begin!();
-        let buntest = buntest_strong.get();
-        let buntest_ptr = NonNull::from(&mut *buntest);
-        let this = &mut buntest.execution;
+        let buntest: &BunTest = buntest_strong;
+        let this = &buntest.execution;
         let mut now = Timespec::now_force_real_time();
 
         match data {
-            RefDataValue::Start => {
-                return step_group(buntest_strong, global_this, &mut now);
-            }
+            RefDataValue::Start => step_group(buntest, global_this, &mut now),
             _ => {
                 // determine the active sequence,group
                 // advance the sequence
                 // step the sequence
                 // if the group is complete, step the group
 
-                let Some((sequence_ptr, group_ptr)) =
-                    this.get_current_and_valid_execution_sequence(data)
+                let Some((sequence, group)) = this.get_current_and_valid_execution_sequence(data)
                 else {
                     group_log::log(format_args!(
                         "runOneCompleted: the data is outdated, invalid, or did not know the sequence",
                     ));
-                    return Ok(StepResult::Waiting { timeout: Timespec::EPOCH });
+                    return Ok(StepResult::Waiting {
+                        timeout: Timespec::EPOCH,
+                    });
                 };
                 let sequence_index = match data {
-                    RefDataValue::Execution { entry_data: Some(ed), .. } => ed.sequence_index,
+                    RefDataValue::Execution {
+                        entry_data: Some(ed),
+                        ..
+                    } => ed.sequence_index,
                     // get_current_and_valid_execution_sequence returned Some ⇒ data is Execution with entry_data
                     _ => unreachable!(),
                 };
 
-                // SAFETY: sequence_ptr points into this.sequences; valid while BunTest is alive.
-                debug_assert!(unsafe { sequence_ptr.as_ref() }.active_entry.is_some());
-                Execution::advance_sequence(buntest_ptr, sequence_ptr, group_ptr);
+                debug_assert!(sequence.active_entry.get().is_some());
+                this.advance_sequence(buntest, sequence, group);
 
                 let sequence_result =
-                    step_sequence(buntest_strong, global_this, group_ptr, sequence_index, &mut now)?;
+                    step_sequence(buntest, global_this, group, sequence_index, &mut now)?;
                 match sequence_result {
                     AdvanceSequenceStatus::Done => {}
                     AdvanceSequenceStatus::Execute { timeout } => {
@@ -384,27 +475,20 @@ impl Execution {
                     }
                 }
                 // this sequence is complete; execute the next sequence
-                // re-slice from `this` each iteration via the group's range; carry
-                // `group` as NonNull so no `&mut ConcurrentGroup` aliases `&mut Execution`.
-                loop {
-                    // SAFETY: group_ptr points into this.groups (disjoint from this.sequences).
-                    let group = unsafe { &mut *group_ptr.as_ptr() };
-                    let seq_len = group.sequence_end - group.sequence_start;
-                    if group.next_sequence_index >= seq_len {
-                        break;
-                    }
-                    let next_idx = group.next_sequence_index;
-                    let abs_idx = group.sequence_start + next_idx;
-                    if this.sequences[abs_idx].executing {
-                        group.next_sequence_index += 1;
+                let sequences = group.sequences(this);
+                while group.next_sequence_index.get() < sequences.len() {
+                    let next_idx = group.next_sequence_index.get();
+                    if sequences[next_idx].executing.get() {
+                        group.next_sequence_index.set(next_idx + 1);
                         continue;
                     }
                     let sequence_status =
-                        step_sequence(buntest_strong, global_this, group_ptr, next_idx, &mut now)?;
+                        step_sequence(buntest, global_this, group, next_idx, &mut now)?;
                     match sequence_status {
                         AdvanceSequenceStatus::Done => {
-                            // SAFETY: see above
-                            unsafe { &mut *group_ptr.as_ptr() }.next_sequence_index += 1;
+                            group
+                                .next_sequence_index
+                                .set(group.next_sequence_index.get() + 1);
                             continue;
                         }
                         AdvanceSequenceStatus::Execute { timeout } => {
@@ -413,43 +497,33 @@ impl Execution {
                     }
                 }
                 // all sequences have started
-                // SAFETY: see above
-                if unsafe { group_ptr.as_ref() }.remaining_incomplete_entries == 0 {
-                    return step_group(buntest_strong, global_this, &mut now);
+                if group.remaining_incomplete_entries.get() == 0 {
+                    return step_group(buntest, global_this, &mut now);
                 }
-                return Ok(StepResult::Waiting { timeout: Timespec::EPOCH });
+                Ok(StepResult::Waiting {
+                    timeout: Timespec::EPOCH,
+                })
             }
         }
     }
 
-    pub(crate) fn active_group(&mut self) -> Option<&mut ConcurrentGroup> {
-        if self.group_index >= self.groups.len() {
-            return None;
-        }
-        Some(&mut self.groups[self.group_index])
+    pub(crate) fn active_group(&self) -> Option<&ConcurrentGroup> {
+        self.groups().get(self.group_index.get())
     }
 
-    /// Shared-borrow variant of [`active_group`] for read-only inspection
-    /// (e.g. `BunTest::get_current_state_data`, which only reads).
-    pub(crate) fn active_group_ref(&self) -> Option<&ConcurrentGroup> {
-        if self.group_index >= self.groups.len() {
-            return None;
-        }
-        Some(&self.groups[self.group_index])
-    }
-
-    /// Returns `NonNull` pointers (not `&mut`) into `self.sequences` / `self.groups` so the
-    /// caller can hold both alongside other borrows of `self` without aliased-`&mut` UB.
-    /// Dereference at point-of-use only.
     pub(crate) fn get_current_and_valid_execution_sequence(
-        &mut self,
+        &self,
         data: &RefDataValue,
-    ) -> Option<(NonNull<ExecutionSequence>, NonNull<ConcurrentGroup>)> {
+    ) -> Option<(&ExecutionSequence, &ConcurrentGroup)> {
         let _g = group_begin!();
 
         group_log::log(format_args!("runOneCompleted: data: {}", data));
 
-        let RefDataValue::Execution { group_index, entry_data } = data else {
+        let RefDataValue::Execution {
+            group_index,
+            entry_data,
+        } = data
+        else {
             group_log::log(format_args!("runOneCompleted: the data is not execution"));
             return None;
         };
@@ -460,119 +534,116 @@ impl Execution {
             return None;
         };
         // Spec compares `this.activeGroup() != data.group(buntest)` by pointer; both index into
-        // `self.groups`, so equality is exactly `group_index == self.group_index`. Comparing the
-        // index avoids materializing a `&mut BunTest` that would alias `&mut self`.
-        if self.group_index >= self.groups.len() || *group_index != self.group_index {
-            group_log::log(format_args!("runOneCompleted: the data is for a different group"));
+        // `self.groups`, so equality is exactly `group_index == self.group_index`.
+        let groups = self.groups();
+        if self.group_index.get() >= groups.len() || *group_index != self.group_index.get() {
+            group_log::log(format_args!(
+                "runOneCompleted: the data is for a different group"
+            ));
             return None;
         }
-        if *group_index >= self.groups.len() {
-            group_log::log(format_args!("runOneCompleted: the data did not know the group"));
+        if *group_index >= groups.len() {
+            group_log::log(format_args!(
+                "runOneCompleted: the data did not know the group"
+            ));
             return None;
         }
-        // Disjoint split-borrow of `self.groups` and `self.sequences`.
-        let group = &mut self.groups[*group_index];
+        let group = &groups[*group_index];
         let seq_abs = group.sequence_start + entry_data.sequence_index;
         if seq_abs >= group.sequence_end {
-            group_log::log(format_args!("runOneCompleted: the data did not know the sequence"));
+            group_log::log(format_args!(
+                "runOneCompleted: the data did not know the sequence"
+            ));
             return None;
         }
-        let sequence = &mut self.sequences[seq_abs];
-        if i64::from(sequence.remaining_repeat_count) != entry_data.remaining_repeat_count {
+        let sequence = &self.sequences()[seq_abs];
+        if i64::from(sequence.remaining_repeat_count.get()) != entry_data.remaining_repeat_count {
             group_log::log(format_args!(
                 "runOneCompleted: the data is for a previous repeat count (outdated)",
             ));
             return None;
         }
-        if sequence
-            .active_entry
-            .map_or(core::ptr::null(), |p| p.as_ptr() as *const ())
-            != entry_data.entry
-        {
+        if sequence.active_entry.get() != Some(entry_data.entry) {
             group_log::log(format_args!(
                 "runOneCompleted: the data is for a different sequence index (outdated)",
             ));
             return None;
         }
-        group_log::log(format_args!("runOneCompleted: the data is valid and current"));
-        Some((NonNull::from(sequence), NonNull::from(group)))
+        group_log::log(format_args!(
+            "runOneCompleted: the data is valid and current"
+        ));
+        Some((sequence, group))
     }
 
-    /// `sequence` / `group` are carried as `NonNull` (raw-pointer semantics) because they point into
-    /// `buntest.execution.{sequences,groups}` and would otherwise alias any live `&mut Execution`.
     fn advance_sequence(
-        buntest: NonNull<BunTest>,
-        sequence_ptr: NonNull<ExecutionSequence>,
-        group_ptr: NonNull<ConcurrentGroup>,
+        &self,
+        buntest: &BunTest,
+        sequence: &ExecutionSequence,
+        group: &ConcurrentGroup,
     ) {
         let _g = group_begin!();
 
-        // SAFETY: sequence_ptr / group_ptr point into disjoint fields of `buntest.execution`
-        // (`sequences` vs `groups`); no `&mut Execution` is live in this scope.
-        let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
-
-        debug_assert!(sequence.executing);
-        if let Some(entry_ptr) = sequence.active_entry {
-            // SAFETY: arena-owned entry, alive for lifetime of BunTest
-            let entry = unsafe { entry_ptr.as_ref() };
-
-            sequence.executing = false;
-            if sequence.maybe_skip {
-                sequence.maybe_skip = false;
-                sequence.active_entry = match entry.failure_skip_past {
-                    // SAFETY: arena-owned entry
-                    Some(failure_skip_past) => nn(unsafe { (*failure_skip_past).next }),
-                    None => None,
-                };
+        debug_assert!(sequence.executing.get());
+        if let Some(entry) = sequence.active_entry.get() {
+            sequence.executing.set(false);
+            if sequence.maybe_skip.get() {
+                sequence.maybe_skip.set(false);
+                sequence
+                    .active_entry
+                    .set(match self.failure_skip_past_of(entry) {
+                        Some(failure_skip_past) => self.next_of(failure_skip_past),
+                        None => None,
+                    });
             } else {
-                sequence.active_entry = nn(entry.next);
+                sequence.active_entry.set(self.next_of(entry));
             }
         } else {
             debug_assert!(false, "can't call advanceSequence on a completed sequence");
         }
 
-        if sequence.active_entry.is_none() {
+        if sequence.active_entry.get().is_none() {
             // just completed the sequence
-            let test_failed = sequence.result.is_fail();
-            let test_passed = sequence.result.is_pass(PendingIs::PendingIsPass);
+            let test_failed = sequence.result.get().is_fail();
+            let test_passed = sequence.result.get().is_pass(PendingIs::PendingIsPass);
 
             // Handle retry logic: if test failed and we have retries remaining, retry it
-            if test_failed && sequence.remaining_retry_count > 0 {
-                sequence.remaining_retry_count -= 1;
+            if test_failed && sequence.remaining_retry_count.get() > 0 {
+                sequence
+                    .remaining_retry_count
+                    .set(sequence.remaining_retry_count.get() - 1);
                 Execution::discard_junit_failure(buntest);
-                Execution::reset_sequence(sequence);
+                self.reset_sequence(sequence);
                 return;
             }
 
             // Handle repeat logic: if test passed and we have repeats remaining, repeat it
-            if test_passed && sequence.remaining_repeat_count > 0 {
-                sequence.remaining_repeat_count -= 1;
+            if test_passed && sequence.remaining_repeat_count.get() > 0 {
+                sequence
+                    .remaining_repeat_count
+                    .set(sequence.remaining_repeat_count.get() - 1);
                 Execution::discard_junit_failure(buntest);
-                Execution::reset_sequence(sequence);
+                self.reset_sequence(sequence);
                 return;
             }
 
             // Only report the final result after all retries/repeats are done
-            Execution::on_sequence_completed(buntest, sequence);
+            self.on_sequence_completed(buntest, sequence);
 
             // No more retries or repeats; mark sequence as complete
-            // SAFETY: group_ptr points into `buntest.execution.groups`, disjoint from `sequence`.
-            let group = unsafe { &mut *group_ptr.as_ptr() };
-            if group.remaining_incomplete_entries == 0 {
+            let remaining = group.remaining_incomplete_entries.get();
+            if remaining == 0 {
                 debug_assert!(false); // remaining_incomplete_entries should never go below 0
                 return;
             }
-            group.remaining_incomplete_entries -= 1;
+            group.remaining_incomplete_entries.set(remaining - 1);
         }
     }
 
     fn on_group_started(global_this: &JSGlobalObject) {
-        // SAFETY: bun_vm() returns the live per-thread VM.
         global_this.bun_vm().as_mut().auto_killer.enable();
     }
 
     fn on_group_completed(global_this: &JSGlobalObject) {
-        // SAFETY: bun_vm() returns the live per-thread VM.
         let vm = global_this.bun_vm().as_mut();
         // Under --isolate the swap between files kills and clears the tracked set.
         if !vm.test_isolation_enabled {
@@ -580,19 +651,17 @@ impl Execution {
         }
     }
 
-    fn on_sequence_started(sequence: &mut ExecutionSequence) {
-        if let Some(entry) = sequence.test_entry {
-            // SAFETY: arena-owned entry
-            if unsafe { entry.as_ref() }.callback.is_none() {
+    fn on_sequence_started(&self, sequence: &ExecutionSequence) {
+        let test_entry = sequence.test_entry.map(|id| self.entry(id));
+        if let Some(entry) = &test_entry {
+            if entry.callback.is_none() {
                 return;
             }
         }
 
-        sequence.started_at = Timespec::now_force_real_time();
+        sequence.started_at.set(Timespec::now_force_real_time());
 
-        if let Some(entry_ptr) = sequence.test_entry {
-            // SAFETY: arena-owned entry
-            let entry = unsafe { entry_ptr.as_ref() };
+        if let Some(entry) = &test_entry {
             scoped_log!(
                 jest,
                 "Running test: {:?}",
@@ -600,20 +669,19 @@ impl Execution {
                 bstr::BStr::new(entry.base.name.as_deref().unwrap_or(b"(unnamed)"))
             );
 
-            if entry.base.test_id_for_debugger != 0 {
-                // SAFETY: VirtualMachine::get() returns the live singleton.
+            if entry.base.test_id_for_debugger.get() != 0 {
                 if let Some(debugger) = VirtualMachine::get().as_mut().debugger.as_mut() {
                     if debugger.test_reporter_agent.is_enabled() {
                         debugger
                             .test_reporter_agent
-                            .report_test_start(entry.base.test_id_for_debugger);
+                            .report_test_start(entry.base.test_id_for_debugger.get());
                     }
                 }
             }
         }
     }
 
-    fn on_entry_started(entry: &mut ExecutionEntry) {
+    fn on_entry_started(&self, id: EntryId, entry: &ExecutionEntry) {
         if entry.callback.is_none() {
             return;
         }
@@ -621,69 +689,68 @@ impl Execution {
         let _g = group_begin!();
         if entry.timeout != 0 {
             group_log::log(format_args!("-> entry.timeout: {}", entry.timeout));
-            entry.timespec = Timespec::ms_from_now_force_real_time(entry.timeout as i64);
+            self.set_timespec(
+                id,
+                Timespec::ms_from_now_force_real_time(entry.timeout as i64),
+            );
         } else {
             group_log::log(format_args!("-> entry.timeout: 0"));
-            entry.timespec = Timespec::EPOCH;
+            self.set_timespec(id, Timespec::EPOCH);
         }
     }
 
-    fn on_sequence_completed(buntest: NonNull<BunTest>, sequence: &mut ExecutionSequence) {
-        let elapsed_ns: u64 = if sequence.started_at.eql(&Timespec::EPOCH) {
+    fn on_sequence_completed(&self, buntest: &BunTest, sequence: &ExecutionSequence) {
+        let elapsed_ns: u64 = if sequence.started_at.get().eql(&Timespec::EPOCH) {
             0
         } else {
-            sequence.started_at.since_now_force_real_time()
+            sequence.started_at.get().since_now_force_real_time()
         };
-        match sequence.expect_assertions {
+        match sequence.expect_assertions.get() {
             ExpectAssertions::NotSet => {}
             ExpectAssertions::AtLeastOne => {
-                if sequence.expect_call_count == 0
-                    && sequence.result.is_pass(PendingIs::PendingIsPass)
+                if sequence.expect_call_count.get() == 0
+                    && sequence.result.get().is_pass(PendingIs::PendingIsPass)
                 {
-                    sequence.result = Result::FailBecauseExpectedHasAssertions;
+                    sequence
+                        .result
+                        .set(Result::FailBecauseExpectedHasAssertions);
                 }
             }
             ExpectAssertions::Exact(expected) => {
-                if sequence.expect_call_count != expected
-                    && sequence.result.is_pass(PendingIs::PendingIsPass)
+                if sequence.expect_call_count.get() != expected
+                    && sequence.result.get().is_pass(PendingIs::PendingIsPass)
                 {
-                    sequence.result = Result::FailBecauseExpectedAssertionCount;
+                    sequence
+                        .result
+                        .set(Result::FailBecauseExpectedAssertionCount);
                 }
             }
         }
-        if sequence.result == Result::Pending {
-            sequence.result = match sequence.entry_mode() {
+        if sequence.result.get() == Result::Pending {
+            sequence.result.set(match sequence.entry_mode(self) {
                 ScopeMode::Failing => Result::FailBecauseFailingTestPassed,
                 ScopeMode::Todo => Result::FailBecauseTodoPassed,
                 _ => Result::Pass,
-            };
+            });
         }
         if let Some(first_entry) = sequence.first_entry {
-            if sequence.test_entry.is_some() || sequence.result != Result::Pass {
-                // SAFETY: deref parent BunTest at point-of-use. `sequence` aliases
-                // `buntest.execution.sequences[i]`; `handle_test_completed`'s signature still takes
-                // both `&mut BunTest` and `&mut ExecutionSequence` (callee could be reshaped to avoid this).
+            if sequence.test_entry.is_some() || sequence.result.get() != Result::Pass {
+                let reported = self.entry(sequence.test_entry.unwrap_or(first_entry));
                 test_command::CommandLineReporter::handle_test_completed(
-                    unsafe { &mut *buntest.as_ptr() },
-                    sequence,
-                    // SAFETY: arena-owned entry, alive for lifetime of BunTest
-                    unsafe { &mut *sequence.test_entry.unwrap_or(first_entry).as_ptr() },
-                    elapsed_ns,
+                    buntest, sequence, &reported, elapsed_ns,
                 );
             }
         }
 
-        if let Some(entry_ptr) = sequence.test_entry {
-            // SAFETY: arena-owned entry
-            let entry = unsafe { entry_ptr.as_ref() };
-            if entry.base.test_id_for_debugger != 0 {
-                // SAFETY: VirtualMachine::get() returns the live singleton.
+        if let Some(entry) = sequence.test_entry {
+            let entry = self.entry(entry);
+            if entry.base.test_id_for_debugger.get() != 0 {
                 if let Some(debugger) = VirtualMachine::get().as_mut().debugger.as_mut() {
                     if debugger.test_reporter_agent.is_enabled() {
                         use bun_jsc::Debugger::TestStatus as S;
                         debugger.test_reporter_agent.report_test_end(
-                            entry.base.test_id_for_debugger,
-                            match sequence.result {
+                            entry.base.test_id_for_debugger.get(),
+                            match sequence.result.get() {
                                 Result::Pass => S::Pass,
                                 Result::Fail => S::Fail,
                                 Result::Skip => S::Skip,
@@ -711,46 +778,33 @@ impl Execution {
     /// Kept out of `reset_sequence` so within-attempt errors (e.g. a throwing
     /// afterEach after the test body already threw) accumulate instead of
     /// clobbering the primary failure.
-    fn discard_junit_failure(buntest: NonNull<BunTest>) {
-        // SAFETY: `buntest` points at the live per-file BunTest; single-threaded
-        // test runner, no other borrow live here.
-        if let Some(reporter) = unsafe { (*buntest.as_ptr()).reporter } {
-            // SAFETY: `reporter` is a `NonNull<CommandLineReporter>` with write
-            // provenance (see BunTest docs); single-threaded, no other borrow.
-            unsafe { (*reporter.as_ptr()).test_failure = None };
+    fn discard_junit_failure(buntest: &BunTest) {
+        if let Some(reporter) = buntest.reporter.get() {
+            *reporter.test_failure.borrow_mut() = None;
         }
     }
 
-    pub(crate) fn reset_sequence(sequence: &mut ExecutionSequence) {
-        debug_assert!(!sequence.executing);
+    pub(crate) fn reset_sequence(&self, sequence: &ExecutionSequence) {
+        debug_assert!(!sequence.executing.get());
         {
             // reset the entries
             let mut current_entry = sequence.first_entry;
-            while let Some(entry_ptr) = current_entry {
-                // SAFETY: arena-owned entry, alive for lifetime of BunTest
-                let entry = unsafe { &mut *entry_ptr.as_ptr() };
+            while let Some(entry) = current_entry {
                 // remove entries that were added in the execution phase
-                while let Some(next) = entry.next {
-                    // SAFETY: arena-owned entry
-                    if unsafe { (*next).added_in_phase } != AddedInPhase::Execution {
+                while let Some(next) = self.next_of(entry) {
+                    if self.entry(next).added_in_phase != AddedInPhase::Execution {
                         break;
                     }
-                    // SAFETY: arena-owned entry, alive for lifetime of BunTest
-                    entry.next = unsafe { (*next).next };
-                    // can't deinit the removed entry because it may still be referenced in a RefDataValue
+                    self.set_next(entry, self.next_of(next));
+                    // can't drop the removed entry because it may still be referenced in a RefDataValue
                 }
-                entry.timespec = Timespec::EPOCH;
-                current_entry = nn(entry.next);
+                self.set_timespec(entry, Timespec::EPOCH);
+                current_entry = self.next_of(entry);
             }
         }
 
         // Preserve retry/repeat counts across reset
-        *sequence = ExecutionSequence::init(
-            sequence.first_entry,
-            sequence.test_entry,
-            sequence.remaining_retry_count,
-            sequence.remaining_repeat_count,
-        );
+        sequence.reset();
 
         // Snapshot counters are keyed by full test name and incremented on every
         // toMatchSnapshot() call. Without this reset, retries / repeats would
@@ -760,51 +814,68 @@ impl Execution {
         // jestjs/jest#7493). Concurrent tests never touch the counts map — see
         // SnapshotInConcurrentGroup in expect.rs.
         if let Some(runner) = super::jest::Jest::runner() {
-            runner.snapshots.reset_counts();
+            runner.snapshots.borrow_mut().reset_counts();
         }
     }
 
+    /// Mark `sequence` as timed out if the running entry's deadline passed.
+    fn evaluate_timeout(
+        &self,
+        active_entry: EntryId,
+        sequence: &ExecutionSequence,
+        now: &Timespec,
+    ) -> bool {
+        let timespec = self.timespec_of(active_entry);
+        if !timespec.eql(&Timespec::EPOCH) && timespec.order(now) == core::cmp::Ordering::Less {
+            // timed out
+            let is_test_entry = sequence.test_entry == Some(active_entry);
+            let has_done_parameter = self.entry(active_entry).has_done_parameter;
+            sequence.result.set(if is_test_entry {
+                if has_done_parameter {
+                    Result::FailBecauseTimeoutWithDoneCallback
+                } else {
+                    Result::FailBecauseTimeout
+                }
+            } else if has_done_parameter {
+                Result::FailBecauseHookTimeoutWithDoneCallback
+            } else {
+                Result::FailBecauseHookTimeout
+            });
+            sequence.maybe_skip.set(true);
+            return true;
+        }
+        false
+    }
+
     pub(crate) fn handle_uncaught_exception(
-        &mut self,
+        &self,
         user_data: &RefDataValue,
     ) -> HandleUncaughtExceptionResult {
         let _g = group_begin!();
 
-        let Some((sequence_ptr, _group_ptr)) =
-            self.get_current_and_valid_execution_sequence(user_data)
+        let Some((sequence, _group)) = self.get_current_and_valid_execution_sequence(user_data)
         else {
             return HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests;
         };
-        // SAFETY: sequence_ptr points into self.sequences; `self` is not accessed for the
-        // remainder of this function, so this is the unique live `&mut` to that element.
-        let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
 
-        sequence.maybe_skip = true;
-        if sequence.active_entry != sequence.test_entry {
+        sequence.maybe_skip.set(true);
+        if sequence.active_entry.get() != sequence.test_entry {
             // executing hook
-            if sequence.result == Result::Pending {
-                sequence.result = Result::Fail;
-            }
+            sequence.set_result_if_pending(Result::Fail);
             return HandleUncaughtExceptionResult::ShowHandledError;
         }
 
-        match sequence.entry_mode() {
+        match sequence.entry_mode(self) {
             ScopeMode::Failing => {
-                if sequence.result == Result::Pending {
-                    sequence.result = Result::Pass; // executing test() callback
-                }
+                sequence.set_result_if_pending(Result::Pass); // executing test() callback
                 HandleUncaughtExceptionResult::HideError // failing tests prevent the error from being displayed
             }
             ScopeMode::Todo => {
-                if sequence.result == Result::Pending {
-                    sequence.result = Result::Todo; // executing test() callback
-                }
+                sequence.set_result_if_pending(Result::Todo); // executing test() callback
                 HandleUncaughtExceptionResult::ShowHandledError // todo tests with --todo will still display the error
             }
             _ => {
-                if sequence.result == Result::Pending {
-                    sequence.result = Result::Fail;
-                }
+                sequence.set_result_if_pending(Result::Fail);
                 HandleUncaughtExceptionResult::ShowHandledError
             }
         }
@@ -812,33 +883,25 @@ impl Execution {
 }
 
 fn step_group(
-    buntest_strong: &BunTestPtr,
+    buntest: &BunTest,
     global_this: &JSGlobalObject,
     now: &mut Timespec,
 ) -> JsResult<StepResult> {
     let _g = group_begin!();
-    let buntest = buntest_strong.get();
-    let this = &mut buntest.execution;
+    let this = &buntest.execution;
 
     loop {
-        // Carry the active group as NonNull so it does not alias `&mut Execution` re-derived
-        // inside step_group_one.
-        let group_ptr: NonNull<ConcurrentGroup> = match this.active_group() {
-            Some(g) => NonNull::from(g),
-            None => return Ok(StepResult::Complete),
+        let Some(group) = this.active_group() else {
+            return Ok(StepResult::Complete);
         };
-        {
-            // SAFETY: group_ptr points into this.groups; only this scope holds a `&mut` to it.
-            let group = unsafe { &mut *group_ptr.as_ptr() };
-            if !group.executing {
-                Execution::on_group_started(global_this);
-                group.executing = true;
-            }
+        if !group.executing.get() {
+            Execution::on_group_started(global_this);
+            group.executing.set(true);
         }
 
         // loop over items in the group and advance their execution
 
-        let status = step_group_one(buntest_strong, global_this, group_ptr, now)?;
+        let status = step_group_one(buntest, global_this, group, now)?;
         match status {
             AdvanceStatus::Execute { timeout } => {
                 return Ok(StepResult::Waiting { timeout });
@@ -846,17 +909,13 @@ fn step_group(
             AdvanceStatus::Done => {}
         }
 
-        // SAFETY: re-deref after step_group_one; disjoint from this.sequences read below.
-        let group = unsafe { &mut *group_ptr.as_ptr() };
-        group.executing = false;
+        group.executing.set(false);
         Execution::on_group_completed(global_this);
 
         // if there is one sequence and it failed, skip to the next group
-        let (start, end, failure_skip_to) =
-            (group.sequence_start, group.sequence_end, group.failure_skip_to);
         let all_failed = 'blk: {
-            for sequence in this.sequences[start..end].iter() {
-                if !sequence.result.is_fail() {
+            for sequence in group.sequences(this).iter() {
+                if !sequence.result.get().is_fail() {
                     break 'blk false;
                 }
             }
@@ -867,10 +926,12 @@ fn step_group(
             group_log::log(format_args!(
                 "stepGroup: all sequences failed, skipping to failure_skip_to group",
             ));
-            this.group_index = failure_skip_to;
+            this.group_index.set(group.failure_skip_to);
         } else {
-            group_log::log(format_args!("stepGroup: not all sequences failed, advancing to next group"));
-            this.group_index += 1;
+            group_log::log(format_args!(
+                "stepGroup: not all sequences failed, advancing to next group"
+            ));
+            this.group_index.set(this.group_index.get() + 1);
         }
     }
 }
@@ -881,29 +942,22 @@ enum AdvanceStatus {
 }
 
 fn step_group_one(
-    buntest_strong: &BunTestPtr,
+    buntest: &BunTest,
     global_this: &JSGlobalObject,
-    group: NonNull<ConcurrentGroup>,
+    group: &ConcurrentGroup,
     now: &mut Timespec,
 ) -> JsResult<AdvanceStatus> {
-    let buntest = buntest_strong.get();
     let mut final_status = AdvanceStatus::Done;
-    let concurrent_limit: usize = if let Some(reporter) = buntest.reporter {
-        // SAFETY: reporter outlives every BunTest (owned by test_command::exec).
-        unsafe { reporter.as_ref() }.jest.max_concurrency as usize
+    let concurrent_limit: usize = if let Some(reporter) = buntest.reporter.get() {
+        reporter.jest.max_concurrency as usize
     } else {
         debug_assert!(false); // probably can't get here because reporter is only set null when the file is exited
         20
     };
     let mut active_count: usize = 0;
-    let len = {
-        // SAFETY: group points into buntest.execution.groups; read-only here.
-        let g = unsafe { group.as_ref() };
-        g.sequence_end - g.sequence_start
-    };
+    let len = group.sequence_end - group.sequence_start;
     for sequence_index in 0..len {
-        let sequence_status =
-            step_sequence(buntest_strong, global_this, group, sequence_index, now)?;
+        let sequence_status = step_sequence(buntest, global_this, group, sequence_index, now)?;
         match sequence_status {
             AdvanceSequenceStatus::Done => {}
             AdvanceSequenceStatus::Execute { timeout } => {
@@ -933,16 +987,14 @@ enum AdvanceSequenceStatus {
 }
 
 fn step_sequence(
-    buntest_strong: &BunTestPtr,
+    buntest: &BunTest,
     global_this: &JSGlobalObject,
-    group: NonNull<ConcurrentGroup>,
+    group: &ConcurrentGroup,
     sequence_index: usize,
     now: &mut Timespec,
 ) -> JsResult<AdvanceSequenceStatus> {
     loop {
-        if let Some(r) =
-            step_sequence_one(buntest_strong, global_this, group, sequence_index, now)?
-        {
+        if let Some(r) = step_sequence_one(buntest, global_this, group, sequence_index, now)? {
             return Ok(r);
         }
     }
@@ -950,136 +1002,107 @@ fn step_sequence(
 
 /// returns None if the while loop should continue
 fn step_sequence_one(
-    buntest_strong: &BunTestPtr,
+    buntest: &BunTest,
     global_this: &JSGlobalObject,
-    group: NonNull<ConcurrentGroup>,
+    group: &ConcurrentGroup,
     sequence_index: usize,
     now: &mut Timespec,
 ) -> JsResult<Option<AdvanceSequenceStatus>> {
     let _g = group_begin!();
-    let buntest = buntest_strong.get();
-    let buntest_ptr = NonNull::from(&mut *buntest);
-    let this = &mut buntest.execution;
+    let this = &buntest.execution;
 
-    // Locate the sequence by absolute index, then carry it as NonNull so it can coexist with
-    // `group` (disjoint field) and with later re-borrows through `buntest_ptr` in advance_sequence.
-    // SAFETY: group points into this.groups; read-only.
-    let seq_abs = unsafe { group.as_ref() }.sequence_start + sequence_index;
-    let sequence_ptr: NonNull<ExecutionSequence> = NonNull::from(&mut this.sequences[seq_abs]);
-    // SAFETY: sequence_ptr points into this.sequences; this is the unique live `&mut` to that
-    // element until we hand it off to advance_sequence (which takes the NonNull, not the &mut).
-    let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
-    if sequence.executing {
-        let Some(active_entry_ptr) = sequence.active_entry else {
+    let sequence = &group.sequences(this)[sequence_index];
+    if sequence.executing.get() {
+        let Some(active_entry) = sequence.active_entry.get() else {
             debug_assert!(false); // sequence is executing with no active entry
             return Ok(Some(AdvanceSequenceStatus::Execute {
                 timeout: Timespec::EPOCH,
             }));
         };
-        // SAFETY: arena-owned entry
-        let active_entry = unsafe { &mut *active_entry_ptr.as_ptr() };
-        if active_entry.evaluate_timeout(sequence, now) {
-            Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
+        if this.evaluate_timeout(active_entry, sequence, now) {
+            this.advance_sequence(buntest, sequence, group);
             return Ok(None); // run again
         }
         group_log::log(format_args!("runOne: can't advance; already executing"));
         return Ok(Some(AdvanceSequenceStatus::Execute {
-            timeout: active_entry.timespec,
+            timeout: this.timespec_of(active_entry),
         }));
     }
 
-    let Some(next_item_ptr) = sequence.active_entry else {
+    let Some(next_item_id) = sequence.active_entry.get() else {
         // Sequence is complete - either because:
         // 1. It ran out of entries (normal completion)
         // 2. All retry/repeat attempts have been exhausted
         group_log::log(format_args!("runOne: no more entries; sequence complete."));
         return Ok(Some(AdvanceSequenceStatus::Done));
     };
-    // SAFETY: arena-owned entry
-    let next_item = unsafe { &mut *next_item_ptr.as_ptr() };
-    sequence.executing = true;
-    if Some(next_item_ptr) == sequence.first_entry {
-        Execution::on_sequence_started(sequence);
+    let next_item = this.entry(next_item_id);
+    sequence.executing.set(true);
+    if Some(next_item_id) == sequence.first_entry {
+        this.on_sequence_started(sequence);
     }
-    Execution::on_entry_started(next_item);
+    this.on_entry_started(next_item_id, &next_item);
 
     if let Some(cb) = next_item.callback.as_ref() {
         group_log::log(format_args!("runSequence queued callback"));
 
         let entry_data = EntryData {
             sequence_index,
-            entry: next_item_ptr.as_ptr() as *const (),
-            remaining_repeat_count: sequence.remaining_repeat_count as i64,
+            entry: next_item_id,
+            remaining_repeat_count: sequence.remaining_repeat_count.get() as i64,
         };
         let callback_data = RefDataValue::Execution {
-            group_index: this.group_index,
+            group_index: this.group_index.get(),
             entry_data: Some(entry_data),
         };
-        group_log::log(format_args!("runSequence queued callback: {}", callback_data));
+        group_log::log(format_args!(
+            "runSequence queued callback: {}",
+            callback_data
+        ));
 
-        let prev_on_stack = this.on_stack_entry.replace(Some(next_item_ptr));
+        let prev_on_stack = this.on_stack_entry.replace(Some(next_item_id));
         let prev_on_stack_data = this.on_stack_entry_data.replace(Some(entry_data));
-        let on_stack_cell = &raw const this.on_stack_entry;
-        let on_stack_data_cell = &raw const this.on_stack_entry_data;
-        // SAFETY: both cells point into `buntest.execution`, which is
-        // never moved during execution (arena-owned BunTest behind an Rc).
-        let _restore = scopeguard::guard((), move |()| unsafe {
-            (*on_stack_cell).set(prev_on_stack);
-            (*on_stack_data_cell).set(prev_on_stack_data);
+        let _restore = scopeguard::guard((), move |()| {
+            this.on_stack_entry.set(prev_on_stack);
+            this.on_stack_entry_data.set(prev_on_stack_data);
         });
 
-        if BunTest::run_test_callback(
-            buntest_strong,
-            global_this,
-            cb.get(),
-            next_item.has_done_parameter,
-            callback_data,
-            &next_item.timespec,
-        )
-        .is_some()
+        let timeout = this.timespec_of(next_item_id);
+        if buntest
+            .run_test_callback(
+                global_this,
+                cb.get(),
+                next_item.has_done_parameter,
+                callback_data,
+                &timeout,
+            )
+            .is_some()
         {
             *now = Timespec::now_force_real_time();
-            // SAFETY: re-deref after run_test_callback; sequence_ptr still valid (sequences is a
-            // Box<[ExecutionSequence]>, never reallocated during execution).
-            let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
-            let _ = next_item.evaluate_timeout(sequence, now);
+            let _ = this.evaluate_timeout(next_item_id, sequence, now);
 
             // the result is available immediately; advance the sequence and run again.
-            Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
+            this.advance_sequence(buntest, sequence, group);
             return Ok(None); // run again
         }
-        return Ok(Some(AdvanceSequenceStatus::Execute {
-            timeout: next_item.timespec,
-        }));
+        Ok(Some(AdvanceSequenceStatus::Execute {
+            timeout: this.timespec_of(next_item_id),
+        }))
     } else {
         match next_item.base.mode {
-            ScopeMode::Skip => {
-                if sequence.result == Result::Pending {
-                    sequence.result = Result::Skip;
-                }
-            }
-            ScopeMode::Todo => {
-                if sequence.result == Result::Pending {
-                    sequence.result = Result::Todo;
-                }
-            }
-            ScopeMode::FilteredOut => {
-                if sequence.result == Result::Pending {
-                    sequence.result = Result::SkippedBecauseLabel;
-                }
-            }
+            ScopeMode::Skip => sequence.set_result_if_pending(Result::Skip),
+            ScopeMode::Todo => sequence.set_result_if_pending(Result::Todo),
+            ScopeMode::FilteredOut => sequence.set_result_if_pending(Result::SkippedBecauseLabel),
             _ => {
                 group_log::log(format_args!(
                     "runSequence: no callback for sequence_index {} (entry_index {:x})",
                     sequence_index,
-                    sequence
-                        .active_entry
-                        .map_or(0, |p| p.as_ptr() as usize)
+                    next_item_id.index()
                 ));
                 debug_assert!(false);
             }
         }
-        Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
-        return Ok(None); // run again
+        this.advance_sequence(buntest, sequence, group);
+        Ok(None) // run again
     }
 }

--- a/src/runtime/test_runner/Order.rs
+++ b/src/runtime/test_runner/Order.rs
@@ -1,19 +1,16 @@
 //! take Collection phase output and convert to Execution phase input
 
-use core::ptr::NonNull;
+use std::rc::Rc;
 
 use bun_jsc::JsResult;
 
-use super::bun_test::{AddedInPhase, DescribeScope, ExecutionEntry, Only, TestScheduleEntry};
-use super::execution::{ConcurrentGroup, ExecutionSequence};
+use super::bun_test::{DescribeScope, ExecutionEntry, Only, TestScheduleEntry};
+use super::execution::{ConcurrentGroup, EntryId, EntryNode, ExecutionSequence};
 
 pub(crate) struct Order {
     pub(crate) groups: Vec<ConcurrentGroup>,
     pub(crate) sequences: Vec<ExecutionSequence>,
-    // The ExecutionEntry clones below are allocated via `heap::into_raw(Box::new(...))`;
-    // `BunTest` collects them into
-    // `cloned_hook_entries` after `generate_order_describe` and reclaims the Box
-    // headers (without running `Drop`) in `Drop for BunTest`.
+    pub(crate) nodes: Vec<EntryNode>,
     pub(crate) previous_group_was_concurrent: bool,
     pub(crate) cfg: Config,
 }
@@ -23,87 +20,80 @@ impl Order {
         Order {
             groups: Vec::new(),
             sequences: Vec::new(),
+            nodes: Vec::new(),
             cfg,
             previous_group_was_concurrent: false,
         }
     }
-    // `deinit` only freed `groups` / `sequences` — handled by Drop on Vec; no impl Drop needed.
 
-    pub(crate) fn generate_order_sub(&mut self, current: &mut TestScheduleEntry) -> JsResult<()> {
+    fn push_node(&mut self, entry: &Rc<ExecutionEntry>) -> EntryId {
+        let id = EntryId::from_index(self.nodes.len());
+        self.nodes.push(EntryNode::new(Rc::clone(entry)));
+        id
+    }
+
+    fn node(&self, id: EntryId) -> &EntryNode {
+        &self.nodes[id.index()]
+    }
+
+    pub(crate) fn generate_order_sub(&mut self, current: &TestScheduleEntry) -> JsResult<()> {
         match current {
             TestScheduleEntry::Describe(describe) => self.generate_order_describe(describe)?,
             TestScheduleEntry::TestCallback(test_callback) => {
-                self.generate_order_test(NonNull::from(&mut **test_callback))?
+                self.generate_order_test(test_callback)?
             }
         }
         Ok(())
     }
 
-    pub(crate) fn generate_all_order(&mut self, entries: &[Box<ExecutionEntry>]) -> JsResult<AllOrderResult> {
+    pub(crate) fn generate_all_order(
+        &mut self,
+        entries: &[Rc<ExecutionEntry>],
+    ) -> JsResult<AllOrderResult> {
         let start = self.groups.len();
-        for entry_box in entries.iter() {
-            // Callers (e.g. BunTestRoot.hook_scope) only hold `&` access to the Vec, so we accept
-            // `&[Box<_>]` and recover each Box's heap pointer as *mut to mutate through the
-            // pointer, not the slice. SAFETY: each Box<ExecutionEntry> is live and
-            // uniquely owned by the DescribeScope tree, and no other reference into it is live
-            // while we write, so the raw-pointer writes are sound. The pointer is obtained via `box_inner_mut`
-            // (see below) so rustc's `invalid_reference_casting` lint does not see a local
-            // `&T as *const T as *mut T` chain; field writes use raw deref to avoid materializing
-            // a long-lived `&mut`.
-            let entry: *mut ExecutionEntry = box_inner_mut(&**entry_box);
-            // SAFETY: `entry` is the heap address of a live `Box<ExecutionEntry>` uniquely owned by
-            // the DescribeScope tree (see paragraph above); raw-ptr field writes avoid
-            // materializing a long-lived `&mut`.
-            unsafe {
-                if bun_core::Environment::CI_ASSERT && (*entry).added_in_phase != AddedInPhase::Preload {
-                    debug_assert!((*entry).next.is_none());
-                }
-                (*entry).next = None;
-                (*entry).failure_skip_past = None;
-            }
+        for entry in entries {
+            let node = self.push_node(entry);
             let sequences_start = self.sequences.len();
-            self.sequences.push(ExecutionSequence::init(
-                NonNull::new(entry),
-                None,
-                0,
-                0,
-            )); // add sequence to concurrentgroup
+            self.sequences
+                .push(ExecutionSequence::init(Some(node), None, 0, 0)); // add sequence to concurrentgroup
             let sequences_end = self.sequences.len();
             let failure_skip_to = self.groups.len() + 1;
-            self.groups
-                .push(ConcurrentGroup::init(sequences_start, sequences_end, failure_skip_to)); // add a new concurrentgroup to order
+            self.groups.push(ConcurrentGroup::init(
+                sequences_start,
+                sequences_end,
+                failure_skip_to,
+            )); // add a new concurrentgroup to order
             self.previous_group_was_concurrent = false;
         }
         let end = self.groups.len();
         Ok(AllOrderResult { start, end })
     }
 
-    pub(crate) fn generate_order_describe(&mut self, current: &mut DescribeScope) -> JsResult<()> {
-        if current.failed {
+    pub(crate) fn generate_order_describe(&mut self, current: &DescribeScope) -> JsResult<()> {
+        if current.failed.get() {
             return Ok(()); // do not schedule any tests in a failed describe scope
         }
-        let use_hooks = self.cfg.always_use_hooks || current.base.has_callback;
+        let use_hooks = self.cfg.always_use_hooks || current.base.has_callback.get();
 
         // gather beforeAll
         let beforeall_order: AllOrderResult = if use_hooks {
-            self.generate_all_order(&current.before_all)?
+            self.generate_all_order(&current.before_all.borrow())?
         } else {
             AllOrderResult::EMPTY
         };
 
         // shuffle entries if randomize flag is set
         if let Some(random) = self.cfg.randomize.as_mut() {
-            shuffle_with_index(random, &mut current.entries);
+            shuffle_with_index(random, &mut current.entries.borrow_mut());
         }
 
         // gather children
-        // reshaped for borrowck — iterate by index since generate_order_sub borrows &mut self.
-        let scope_only = current.base.only;
-        for i in 0..current.entries.len() {
-            if scope_only == Only::Contains && current.entries[i].base().only == Only::No {
+        let scope_only = current.base.only.get();
+        for entry in current.entries.borrow().iter() {
+            if scope_only == Only::Contains && entry.base().only.get() == Only::No {
                 continue;
             }
-            self.generate_order_sub(&mut current.entries[i])?;
+            self.generate_order_sub(entry)?;
         }
 
         // update skip_to values for beforeAll to skip to the first afterAll
@@ -111,7 +101,7 @@ impl Order {
 
         // gather afterAll
         let afterall_order: AllOrderResult = if use_hooks {
-            self.generate_all_order(&current.after_all)?
+            self.generate_all_order(&current.after_all.borrow())?
         } else {
             AllOrderResult::EMPTY
         };
@@ -122,97 +112,68 @@ impl Order {
         Ok(())
     }
 
-    /// # Safety
-    /// `current` must point to a live, uniquely-owned `ExecutionEntry` (Box-owned in
-    /// `DescribeScope.entries`) with mutable provenance for the duration of this call. The
-    /// `base.parent` chain reachable from `*current` must consist of live `DescribeScope` nodes.
-    pub(crate) fn generate_order_test(&mut self, current: NonNull<ExecutionEntry>) -> JsResult<()> {
-        // Stacked Borrows: `current` is reborrowed as `&mut` inside `list.append` and the skip-past
-        // loop below, so we never hold a long-lived `&mut` to it across those calls — each access
-        // dereferences the pointer locally.
-        // SAFETY: caller-guaranteed live `ExecutionEntry` (see safety doc above); read-only field access.
-        debug_assert!(unsafe { current.as_ref().base.has_callback == current.as_ref().callback.is_some() });
-        // SAFETY: caller-guaranteed live `ExecutionEntry` (see above); read-only field access.
-        let use_each_hooks = unsafe { current.as_ref().base.has_callback };
-        // SAFETY: caller-guaranteed live `ExecutionEntry` (see above); read-only field access.
-        let first_parent: Option<*mut DescribeScope> = unsafe { current.as_ref().base.parent };
+    pub(crate) fn generate_order_test(&mut self, current: &Rc<ExecutionEntry>) -> JsResult<()> {
+        debug_assert!(current.base.has_callback.get() == current.callback.is_some());
+        let use_each_hooks = current.base.has_callback.get();
+        let first_parent: Option<Rc<DescribeScope>> = current.base.parent();
 
         let mut list = EntryList::default();
 
         // gather beforeEach (alternatively, this could be implemented recursively to make it less complicated)
         if use_each_hooks {
-            let mut parent: Option<*mut DescribeScope> = first_parent;
-            while let Some(p_ptr) = parent {
-                // SAFETY: parent chain consists of live DescribeScope nodes.
-                let p = unsafe { &*p_ptr };
+            let mut parent = first_parent.clone();
+            while let Some(p) = parent {
                 // prepend in reverse so they end up in forwards order
-                let mut i: usize = p.before_each.len();
-                while i > 0 {
-                    let src: *const ExecutionEntry = &raw const *p.before_each[i - 1];
-                    // Ownership: `BunTest` collects these clones into `cloned_hook_entries`
-                    // (the post-`generate_order_describe` walk) and frees only the Box
-                    // headers in `Drop for BunTest` — `Drop` must not run on the bitwise
-                    // copy or the originals' Strong/Box fields would be freed twice.
-                    // SAFETY: `src` is valid for reads; `Drop` never runs on the bitwise copy
-                    // (see ownership note above), so duplicated owning fields are not double-freed.
-                    let cloned = bun_core::heap::into_raw(Box::new(unsafe { core::ptr::read(src) }));
-                    list.prepend(cloned);
-                    i -= 1;
+                for entry in p.before_each.borrow().iter().rev() {
+                    let node = self.push_node(entry);
+                    list.prepend(self, node);
                 }
-                parent = p.base.parent;
+                parent = p.base.parent();
             }
         }
 
         // append test
-        list.append(current.as_ptr()); // add entry to sequence
+        let current_node = self.push_node(current);
+        list.append(self, current_node); // add entry to sequence
 
         // gather afterEach
         if use_each_hooks {
-            let mut parent: Option<*mut DescribeScope> = first_parent;
-            while let Some(p_ptr) = parent {
-                // SAFETY: parent chain consists of live DescribeScope nodes.
-                let p = unsafe { &*p_ptr };
-                for entry in p.after_each.iter() {
-                    let src: *const ExecutionEntry = &raw const **entry;
-                    // SAFETY: `src` is valid for reads; `Drop` never runs on the bitwise copy
-                    // (see ownership note above), so duplicated owning fields are not double-freed.
-                    let cloned = bun_core::heap::into_raw(Box::new(unsafe { core::ptr::read(src) }));
-                    list.append(cloned);
+            let mut parent = first_parent;
+            while let Some(p) = parent {
+                for entry in p.after_each.borrow().iter() {
+                    let node = self.push_node(entry);
+                    list.append(self, node);
                 }
-                parent = p.base.parent;
+                parent = p.base.parent();
             }
         }
 
         // set skip_to values
         let mut index = list.first;
-        let mut failure_skip_past: Option<*mut ExecutionEntry> = Some(current.as_ptr());
-        while let Some(entry_ptr) = index {
-            // SAFETY: list contains valid ExecutionEntry nodes linked via `next`.
-            unsafe {
-                (*entry_ptr).failure_skip_past = failure_skip_past; // we could consider matching skip_to in beforeAll to skip directly to the first afterAll from its own scope rather than skipping to the first afterAll from any scope
-                if Some(entry_ptr) == failure_skip_past {
-                    failure_skip_past = None;
-                }
-                index = (*entry_ptr).next;
+        let mut failure_skip_past: Option<EntryId> = Some(current_node);
+        while let Some(entry) = index {
+            let node = self.node(entry);
+            node.failure_skip_past.set(failure_skip_past); // we could consider matching skip_to in beforeAll to skip directly to the first afterAll from its own scope rather than skipping to the first afterAll from any scope
+            if Some(entry) == failure_skip_past {
+                failure_skip_past = None;
             }
+            index = node.next.get();
         }
 
         // add these as a single sequence
-        // SAFETY: `current` still valid; re-derive fields locally so no `&mut` outlives the
-        // competing reborrows performed by `list.append` / the skip-past loop above.
-        let (retry_count, repeat_count, concurrent) = unsafe {
-            let cur = current.as_ref();
-            (cur.retry_count, cur.repeat_count, cur.base.concurrent)
-        };
         let sequences_start = self.sequences.len();
         self.sequences.push(ExecutionSequence::init(
-            list.first.and_then(NonNull::new),
-            Some(current),
-            retry_count,
-            repeat_count,
+            list.first,
+            Some(current_node),
+            current.retry_count,
+            current.repeat_count,
         )); // add sequence to concurrentgroup
         let sequences_end = self.sequences.len();
-        self.append_or_extend_concurrent_group(concurrent, sequences_start, sequences_end)?; // add or extend the concurrent group
+        self.append_or_extend_concurrent_group(
+            current.base.concurrent,
+            sequences_start,
+            sequences_end,
+        )?; // add or extend the concurrent group
         Ok(())
     }
 
@@ -236,8 +197,11 @@ impl Order {
             }
         }
         let failure_skip_to = self.groups.len() + 1;
-        self.groups
-            .push(ConcurrentGroup::init(sequences_start, sequences_end, failure_skip_to)); // otherwise, add a new concurrentgroup to order
+        self.groups.push(ConcurrentGroup::init(
+            sequences_start,
+            sequences_end,
+            failure_skip_to,
+        )); // otherwise, add a new concurrentgroup to order
         Ok(())
     }
 }
@@ -312,48 +276,29 @@ fn uint_less_than(r: &mut bun_core::rand::DefaultPrng, less_than: u64) -> u64 {
     (m >> 64) as u64
 }
 
-/// Recover the heap pointer behind a `Box<T>` as `*mut T` given the inner `&T`.
-///
-/// Callers hand us `&[Box<T>]`, but we still need to mutate through each element.
-/// Going through this helper breaks the intraprocedural dataflow that the
-/// `invalid_reference_casting` deny-by-default lint tracks (it would otherwise flag the
-/// `&T -> *const T -> *mut T -> &mut T` chain at the call site). The provenance caveat is
-/// real — see the SAFETY note at the call site in `generate_all_order`.
-#[inline(always)]
-fn box_inner_mut<T>(b: &T) -> *mut T {
-    core::ptr::from_ref(b).cast_mut()
-}
-
 #[derive(Default)]
 struct EntryList {
-    first: Option<*mut ExecutionEntry>,
-    last: Option<*mut ExecutionEntry>,
+    first: Option<EntryId>,
+    last: Option<EntryId>,
 }
 
 impl EntryList {
-    fn prepend(&mut self, current: *mut ExecutionEntry) {
-        // SAFETY: `current` points to a live ExecutionEntry owned by the test scheduler.
-        unsafe { (*current).next = self.first };
+    fn prepend(&mut self, order: &Order, current: EntryId) {
+        order.node(current).next.set(self.first);
         self.first = Some(current);
         if self.last.is_none() {
             self.last = Some(current);
         }
     }
 
-    fn append(&mut self, current: *mut ExecutionEntry) {
-        // SAFETY: `current` points to a live ExecutionEntry owned by the test scheduler.
-        let cur = unsafe { &mut *current };
-        if bun_core::Environment::CI_ASSERT && cur.added_in_phase != AddedInPhase::Preload {
-            debug_assert!(cur.next.is_none());
-        }
-        cur.next = None;
+    fn append(&mut self, order: &Order, current: EntryId) {
+        let cur = order.node(current);
+        debug_assert!(cur.next.get().is_none());
+        cur.next.set(None);
         if let Some(last) = self.last {
-            // SAFETY: `last` was stored by a prior prepend/append and is still live.
-            let last_ref = unsafe { &mut *last };
-            if bun_core::Environment::CI_ASSERT && last_ref.added_in_phase != AddedInPhase::Preload {
-                debug_assert!(last_ref.next.is_none());
-            }
-            last_ref.next = Some(current);
+            let last_ref = order.node(last);
+            debug_assert!(last_ref.next.get().is_none());
+            last_ref.next.set(Some(current));
             self.last = Some(current);
         } else {
             self.first = Some(current);

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -419,7 +419,7 @@ impl ScopeFunctions {
                     bstr::BStr::new(bun_test.collection.active_scope().base.name.as_deref().unwrap_or(b"(unnamed)"))
                 ));
 
-                let _ = bun_test.collection.active_scope().append_test(
+                bun_test.collection.active_scope().append_test(
                     description,
                     if matches_filter { callback } else { None },
                     bun_test::ExecutionEntryCfg {
@@ -430,7 +430,7 @@ impl ScopeFunctions {
                     },
                     base,
                     bun_test::AddedInPhase::Collection,
-                )?;
+                );
             }
         }
         Ok(())

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use std::rc::Rc;
 use crate::test_runner::expect::JSValueTestExt;
 
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsResult};
@@ -134,19 +135,17 @@ impl ScopeFunctions {
 fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let _g = group_log::begin();
 
-    let Some(this_ptr) = ScopeFunctions::from_js(frame.this()) else {
+    // R-2: every field is read-only after `create_unbound`, and the body
+    // re-enters JS (get_length / array_iterator / bind / enqueue) which can form
+    // fresh `&ScopeFunctions` to the same object.
+    let Some(this) = frame.this().as_class_ref::<ScopeFunctions>() else {
         return Err(global.throw(format_args!("Expected callee to be ScopeFunctions")));
     };
-    // SAFETY: `from_js` returned non-null; the JS wrapper keeps the boxed
-    // ScopeFunctions alive for the duration of this call (we hold `frame.this()`).
-    // R-2: deref as shared (`&*const`) — every field is read-only after
-    // `create_unbound`, and the body re-enters JS (get_length / array_iterator /
-    // bind / enqueue) which can form fresh `&ScopeFunctions` to the same object.
-    let this: &ScopeFunctions = unsafe { &*this_ptr.cast_const() };
     let line_no = jest::capture_test_line_number(frame, global);
 
-    let buntest_strong = bun_test::js_fns::clone_active_strong(global, Signature::ScopeFunctions(this))?;
-    let bun_test_ptr = buntest_strong.get();
+    let buntest_strong =
+        bun_test::js_fns::clone_active_strong(global, Signature::ScopeFunctions(this))?;
+    let bun_test: &BunTest = &buntest_strong;
 
     let callback_mode: CallbackMode = match this.cfg.self_mode {
         SelfMode::Skip | SelfMode::Todo => CallbackMode::Allow,
@@ -210,9 +209,7 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                     None
                 };
                 this.enqueue_describe_or_test_callback(
-                    // Explicit reborrow: the closure must not move the `&mut`
-                    // (it is reused on later loop iterations).
-                    &mut *bun_test_ptr,
+                    bun_test,
                     global,
                     frame,
                     bound,
@@ -227,7 +224,7 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         }
     } else {
         this.enqueue_describe_or_test_callback(
-            bun_test_ptr,
+            bun_test,
             global,
             frame,
             args.callback,
@@ -271,15 +268,16 @@ impl<'a> WriteEnd for Write<'a> {
     }
 }
 
-fn filter_names<R: WriteEnd>(rem: &mut R, description: Option<&[u8]>, parent_in: Option<&DescribeScope>) {
+fn filter_names<R: WriteEnd>(
+    rem: &mut R,
+    description: Option<&[u8]>,
+    parent_in: Option<Rc<DescribeScope>>,
+) {
     const SEP: &[u8] = b" ";
     rem.write_end(description.unwrap_or(b""));
     let mut parent = parent_in;
     while let Some(scope) = parent {
-        // PORTING.md: `BaseScope.parent` is `Option<*const DescribeScope>` (raw backref);
-        // per-use reborrow.
-        // SAFETY: parent backrefs are stable for the lifetime of the collection tree.
-        parent = scope.base.parent.map(|p| unsafe { &*p });
+        parent = scope.base.parent();
         if scope.base.name.is_none() {
             continue;
         }
@@ -291,7 +289,7 @@ fn filter_names<R: WriteEnd>(rem: &mut R, description: Option<&[u8]>, parent_in:
 impl ScopeFunctions {
     fn enqueue_describe_or_test_callback(
         &self,
-        bun_test: &mut BunTest,
+        bun_test: &BunTest,
         global: &JSGlobalObject,
         frame: &CallFrame,
         callback: Option<JSValue>,
@@ -303,7 +301,7 @@ impl ScopeFunctions {
         let _g = group_log::begin();
 
         // only allow in collection phase
-        match bun_test.phase {
+        match bun_test.phase.get() {
             bun_test::Phase::Collection => {} // ok
             bun_test::Phase::Execution => {
                 return Err(global.throw(format_args!(
@@ -327,9 +325,9 @@ impl ScopeFunctions {
                 debugger.test_reporter_agent.next_test_id += 1;
                 let id = debugger.test_reporter_agent.next_test_id;
                 let name = BunString::from_bytes(description.unwrap_or(b"(unnamed)"));
-                let parent: &DescribeScope = bun_test.collection.active_scope();
-                let parent_id = if parent.base.test_id_for_debugger != 0 {
-                    parent.base.test_id_for_debugger
+                let parent = bun_test.collection.active_scope();
+                let parent_id = if parent.base.test_id_for_debugger.get() != 0 {
+                    parent.base.test_id_for_debugger.get()
                 } else {
                     -1
                 };
@@ -364,46 +362,49 @@ impl ScopeFunctions {
 
         match self.mode {
             Mode::Describe => {
-                // SAFETY: active_scope is a valid cursor into root_scope's tree for the lifetime of Collection.
-                let new_scope = unsafe { bun_test.collection.active_scope.as_mut() }.append_describe(description, base);
-                bun_test.collection.enqueue_describe_callback(new_scope, callback)?;
+                let new_scope = bun_test
+                    .collection
+                    .active_scope()
+                    .append_describe(description, base);
+                bun_test
+                    .collection
+                    .enqueue_describe_callback(new_scope, callback)?;
             }
             Mode::Test => {
                 // check for filter match
                 let mut matches_filter = true;
-                if let Some(reporter) = bun_test.reporter {
-                    // SAFETY: reporter outlives every BunTest (owned by test_command::exec).
-                    let reporter = unsafe { reporter.as_ref() };
+                if let Some(reporter) = bun_test.reporter.get() {
                     if let Some(filter_regex) = reporter.jest.filter_regex {
                         group_log::log(format_args!("matches_filter begin"));
-                        debug_assert!(bun_test.collection.filter_buffer.is_empty());
-                        // reshaped for borrowck — clear at end via explicit call below.
+                        let mut filter_buffer = bun_test.collection.filter_buffer.borrow_mut();
+                        debug_assert!(filter_buffer.is_empty());
 
-                        // SAFETY: active_scope is a valid cursor into root_scope's tree for the lifetime of Collection.
-                        let active_scope: &DescribeScope = unsafe { bun_test.collection.active_scope.as_ref() };
+                        let active_scope = bun_test.collection.active_scope();
 
                         let mut len = Measure { len: 0 };
-                        filter_names(&mut len, description, Some(active_scope));
+                        filter_names(&mut len, description, Some(Rc::clone(&active_scope)));
                         // Extend by `len.len` zero bytes and
                         // hand back the freshly-appended tail as `&mut [u8]`.
-                        let start = bun_test.collection.filter_buffer.len();
-                        bun_test.collection.filter_buffer.resize(start + len.len, 0);
-                        let slice: &mut [u8] = &mut bun_test.collection.filter_buffer[start..];
+                        let start = filter_buffer.len();
+                        filter_buffer.resize(start + len.len, 0);
+                        let slice: &mut [u8] = &mut filter_buffer[start..];
                         let mut rem = Write { buf: slice };
                         filter_names(&mut rem, description, Some(active_scope));
                         debug_assert!(rem.buf.is_empty());
 
-                        let str = BunString::from_bytes(bun_test.collection.filter_buffer.as_slice());
+                        let str = BunString::from_bytes(filter_buffer.as_slice());
                         group_log::log(format_args!(
                             "matches_filter \"{}\"",
-                            bstr::BStr::new(bun_test.collection.filter_buffer.as_slice())
+                            bstr::BStr::new(filter_buffer.as_slice())
                         ));
-                        // SAFETY: `filter_regex` is the FFI-allocated Yarr handle stored in
-                        // `TestRunner` for the process lifetime; single-threaded here so the
-                        // exclusive borrow is unaliased.
-                        matches_filter = unsafe { &mut *filter_regex.as_ptr() }.matches(&str);
+                        // `RegularExpression` is an `opaque_ffi!` ZST handle stored in
+                        // `TestRunner` for the process lifetime; `opaque_mut` is the
+                        // centralised non-null deref.
+                        matches_filter =
+                            bun_jsc::RegularExpression::opaque_mut(filter_regex.as_ptr())
+                                .matches(&str);
 
-                        bun_test.collection.filter_buffer.clear();
+                        filter_buffer.clear();
                     }
                 }
 
@@ -411,14 +412,14 @@ impl ScopeFunctions {
                     base.self_mode = SelfMode::FilteredOut;
                 }
 
-                debug_assert!(!bun_test.collection.locked);
+                debug_assert!(!bun_test.collection.locked.get());
                 group_log::log(format_args!(
                     "enqueueTestCallback / {} / in scope: {}",
                     bstr::BStr::new(description.unwrap_or(b"(unnamed)")),
                     bstr::BStr::new(bun_test.collection.active_scope().base.name.as_deref().unwrap_or(b"(unnamed)"))
                 ));
 
-                let _ = bun_test.collection.active_scope_mut().append_test(
+                let _ = bun_test.collection.active_scope().append_test(
                     description,
                     if matches_filter { callback } else { None },
                     bun_test::ExecutionEntryCfg {
@@ -703,7 +704,8 @@ pub(crate) fn parse_arguments(
         if runner.default_timeout_ms != 0 { Some(runner.default_timeout_ms) } else { None }
     });
     let override_timeout_ms: Option<u32> = jest::Jest::runner().and_then(|runner| {
-        if runner.default_timeout_override != u32::MAX { Some(runner.default_timeout_override) } else { None }
+        let v = runner.default_timeout_override.get();
+        if v != u32::MAX { Some(v) } else { None }
     });
     let timeout_option_ms: Option<u32> = timeout_option.map(|timeout| timeout as u32);
     result.options.timeout = timeout_option_ms.or(override_timeout_ms).or(default_timeout_ms).unwrap_or(0);

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -191,7 +191,7 @@ pub mod js_fns {
                 }
                 bun_core::scoped_log!(bun_test_group, "genericHook in preload");
 
-                let _ = bun_test_root.hook_scope().append_hook(
+                bun_test_root.hook_scope().append_hook(
                     tag.as_hook_tag().unwrap(),
                     args.callback,
                     cfg,
@@ -209,7 +209,7 @@ pub mod js_fns {
                             tag_name
                         )));
                     }
-                    let _ = bun_test.collection.active_scope().append_hook(
+                    bun_test.collection.active_scope().append_hook(
                         tag.as_hook_tag().unwrap(),
                         args.callback,
                         cfg,
@@ -1629,14 +1629,14 @@ impl DescribeScope {
         cfg: ExecutionEntryCfg,
         base: BaseScopeCfg,
         phase: AddedInPhase,
-    ) -> JsResult<Rc<ExecutionEntry>> {
+    ) -> Rc<ExecutionEntry> {
         let entry = ExecutionEntry::create(name_not_owned, callback, cfg, Some(self), base, phase);
         let has_cb = entry.callback.is_some();
         entry.base.propagate(has_cb);
         self.entries
             .borrow_mut()
             .push(TestScheduleEntry::TestCallback(Rc::clone(&entry)));
-        Ok(entry)
+        entry
     }
 
     pub(crate) fn get_hook_entries(&self, tag: HookTag) -> &RefCell<Vec<Rc<ExecutionEntry>>> {
@@ -1655,12 +1655,12 @@ impl DescribeScope {
         cfg: ExecutionEntryCfg,
         base: BaseScopeCfg,
         phase: AddedInPhase,
-    ) -> JsResult<Rc<ExecutionEntry>> {
+    ) -> Rc<ExecutionEntry> {
         let entry = ExecutionEntry::create(None, callback, cfg, Some(self), base, phase);
         self.get_hook_entries(tag)
             .borrow_mut()
             .push(Rc::clone(&entry));
-        Ok(entry)
+        entry
     }
 }
 

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1,18 +1,16 @@
+use core::cell::{Cell, RefCell};
 use core::fmt;
-use core::ptr::NonNull;
-use std::cell::UnsafeCell;
 use std::rc::{Rc, Weak};
 
-use bun_collections::LinearFifo;
-use bun_core::{Output, Timespec};
-use bun_jsc::{self as jsc, CallFrame, GlobalRef, JSGlobalObject, JSValue, JsResult, Strong, JsClass as _};
-use bun_jsc::virtual_machine::VirtualMachine;
-use bun_jsc::js_promise::Status as PromiseStatus;
-use bun_ptr::RefPtr;
-use super::jest::{Jest, FileId, FileColumns as _};
-use crate::timer::{EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, ElTimespec};
+use super::execution::{EntryId, EntryNode, TimespecExt as _};
+use super::jest::{FileId, Jest};
 use crate::cli::test_command::CommandLineReporter;
-use super::execution::TimespecExt as _;
+use crate::timer::{ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
+use bun_core::{Output, Timespec};
+use bun_jsc::js_promise::Status as PromiseStatus;
+use bun_jsc::virtual_machine::VirtualMachine;
+use bun_jsc::{self as jsc, CallFrame, GlobalRef, JSGlobalObject, JSValue, JsResult, Strong};
+use bun_ptr::{JsCell, ThisPtr};
 
 bun_core::declare_scope!(bun_test_group, hidden);
 // Callers use `group_log!` / `group_begin!` / `group_end!` below.
@@ -24,14 +22,6 @@ macro_rules! group_begin {
 }
 pub(crate) use group_begin;
 
-/// Recover this thread's `timer::All` heap (jsc/runtime crate cycle: `vm.timer` is `()` in
-/// the low-tier `VirtualMachine`; the real value lives in `RuntimeState`).
-#[inline]
-pub(super) fn vm_timer<'a>() -> &'a mut crate::timer::All {
-    // SAFETY: `runtime_state()` is non-null after `bun_runtime::init()`;
-    // single JS thread, raw-ptr-per-field re-entry pattern (jsc_hooks.rs).
-    unsafe { &mut (*crate::jsc_hooks::runtime_state()).timer }
-}
 
 /// `bun.timespec.orderIgnoreEpoch` — epoch == "no timeout", treated as +∞.
 /// Local helper so it can compare `bun_core::Timespec` against the
@@ -39,7 +29,13 @@ pub(super) fn vm_timer<'a>() -> &'a mut crate::timer::All {
 // ElTimespec dedup is a separate ticket.
 #[inline]
 fn order_ignore_epoch(a: &Timespec, b: &ElTimespec) -> core::cmp::Ordering {
-    Timespec::order_ignore_epoch(*a, Timespec { sec: b.sec, nsec: b.nsec })
+    Timespec::order_ignore_epoch(
+        *a,
+        Timespec {
+            sec: b.sec,
+            nsec: b.nsec,
+        },
+    )
 }
 
 /// `Strong::create` requires a `&JSGlobalObject`; recover it from the
@@ -47,8 +43,6 @@ fn order_ignore_epoch(a: &Timespec, b: &ElTimespec) -> core::cmp::Ordering {
 /// can box callbacks.
 #[inline]
 fn strong_create(value: JSValue) -> Strong {
-    // SAFETY: `VirtualMachine::get()` is the live per-thread VM; `global`
-    // is non-null after VM init.
     let global = VirtualMachine::get().global();
     Strong::create(value, global)
 }
@@ -82,16 +76,14 @@ pub mod js_fns {
     fn get_test_root(
         global_this: &JSGlobalObject,
         signature: Signature<'_>,
-    ) -> JsResult<&'static mut BunTestRoot> {
-        // `Jest.runner` is a process-global that outlives every caller, so the
-        // unbounded `&'static mut` is the honest model here.
+    ) -> JsResult<&'static BunTestRoot> {
         let Some(runner) = Jest::runner() else {
             return Err(global_this.throw(format_args!(
                 "Cannot use {} outside of the test runner. Run \"bun test\" to run tests.",
                 signature
             )));
         };
-        Ok(&mut runner.bun_test_root)
+        Ok(&runner.bun_test_root)
     }
 
     pub(crate) fn clone_active_strong(
@@ -100,10 +92,7 @@ pub mod js_fns {
     ) -> JsResult<BunTestPtr> {
         let bun_test_root = get_test_root(global_this, signature)?;
         if global_this.bun_vm().is_in_preload {
-            return Err(global_this.throw(format_args!(
-                "Cannot use {} during preload.",
-                signature
-            )));
+            return Err(global_this.throw(format_args!("Cannot use {} during preload.", signature)));
         }
         let Some(bun_test) = bun_test_root.clone_active_file() else {
             return Err(global_this.throw(format_args!(
@@ -165,7 +154,6 @@ pub mod js_fns {
         // Run the body in a closure so every error exit funnels through the
         // log below before the group guard closes.
         let result = (|| -> JsResult<JSValue> {
-
             let tag_name: &'static str = tag.into();
             let sig_bytes: &'static [u8] = tag.sig();
 
@@ -173,7 +161,10 @@ pub mod js_fns {
                 global_this,
                 call_frame,
                 Signature::Str(sig_bytes),
-                ScopeFunctions::ParseArgumentsCfg { callback: ScopeFunctions::CallbackMode::Require, kind: ScopeFunctions::FunctionKind::Hook },
+                ScopeFunctions::ParseArgumentsCfg {
+                    callback: ScopeFunctions::CallbackMode::Require,
+                    kind: ScopeFunctions::FunctionKind::Hook,
+                },
             )?;
 
             let has_done_parameter = if let Some(callback) = args.callback {
@@ -190,7 +181,8 @@ pub mod js_fns {
                 ..Default::default()
             };
 
-            let Some(bun_test) = bun_test_root.get_active_file_unless_in_preload(global_this.bun_vm()) else {
+            let Some(bun_test) = bun_test_root.active_file_unless_in_preload(global_this.bun_vm())
+            else {
                 if tag == GenericHookTag::OnTestFinished {
                     return Err(global_this.throw(format_args!(
                         "Cannot call {}() in preload. It can only be called inside a test.",
@@ -199,17 +191,17 @@ pub mod js_fns {
                 }
                 bun_core::scoped_log!(bun_test_group, "genericHook in preload");
 
-                let _ = bun_test_root.hook_scope.append_hook(
+                let _ = bun_test_root.hook_scope().append_hook(
                     tag.as_hook_tag().unwrap(),
                     args.callback,
                     cfg,
                     BaseScopeCfg::default(),
                     AddedInPhase::Preload,
-                )?;
+                );
                 return Ok(JSValue::UNDEFINED);
             };
 
-            match bun_test.phase {
+            match bun_test.phase.get() {
                 Phase::Collection => {
                     if tag == GenericHookTag::OnTestFinished {
                         return Err(global_this.throw(format_args!(
@@ -217,18 +209,21 @@ pub mod js_fns {
                             tag_name
                         )));
                     }
-                    let _ = bun_test.collection.active_scope_mut().append_hook(
+                    let _ = bun_test.collection.active_scope().append_hook(
                         tag.as_hook_tag().unwrap(),
                         args.callback,
                         cfg,
                         BaseScopeCfg::default(),
                         AddedInPhase::Collection,
-                    )?;
+                    );
                     Ok(JSValue::UNDEFINED)
                 }
                 Phase::Execution => {
                     let active = bun_test.get_current_state_data();
-                    let Some((sequence, _)) = bun_test.execution.get_current_and_valid_execution_sequence(&active) else {
+                    let execution = &bun_test.execution;
+                    let Some((sequence, _)) =
+                        execution.get_current_and_valid_execution_sequence(&active)
+                    else {
                         return Err(if tag == GenericHookTag::OnTestFinished {
                             global_this.throw(format_args!(
                                 "Cannot call {}() here. It cannot be called inside a concurrent test. Use test.serial or remove test.concurrent.",
@@ -242,22 +237,17 @@ pub mod js_fns {
                         });
                     };
 
-                    // SAFETY: `get_current_and_valid_execution_sequence` returns a NonNull
-                    // into `execution.sequences`; deref at point-of-use only.
-                    let sequence_ref = unsafe { sequence.as_ref() };
-                    let append_point: *mut ExecutionEntry = match tag {
+                    let append_point: EntryId = match tag {
                         GenericHookTag::AfterAll | GenericHookTag::AfterEach => 'blk: {
-                            let mut iter = sequence_ref.active_entry;
+                            let mut iter = sequence.active_entry.get();
                             while let Some(entry) = iter {
-                                // SAFETY: intrusive linked-list nodes are valid while sequence is live
-                                let entry_ref = unsafe { entry.as_ref() };
-                                if Some(entry) == sequence_ref.test_entry {
-                                    break 'blk sequence_ref.test_entry.unwrap().as_ptr();
+                                if Some(entry) == sequence.test_entry {
+                                    break 'blk sequence.test_entry.unwrap();
                                 }
-                                iter = entry_ref.next.and_then(NonNull::new);
+                                iter = execution.next_of(entry);
                             }
-                            match sequence_ref.active_entry {
-                                Some(e) => break 'blk e.as_ptr(),
+                            match sequence.active_entry.get() {
+                                Some(e) => break 'blk e,
                                 None => {
                                     return Err(global_this.throw(format_args!(
                                         "Cannot call {}() here. Call it inside describe() instead.",
@@ -268,17 +258,14 @@ pub mod js_fns {
                         }
                         GenericHookTag::OnTestFinished => 'blk: {
                             // Find the last entry in the sequence
-                            let Some(mut last_entry) = sequence_ref.active_entry.map(|p| p.as_ptr()) else {
+                            let Some(mut last_entry) = sequence.active_entry.get() else {
                                 return Err(global_this.throw(format_args!(
                                     "Cannot call {}() here. Call it inside a test instead.",
                                     tag_name
                                 )));
                             };
-                            // SAFETY: intrusive linked-list traversal
-                            unsafe {
-                                while let Some(next_entry) = (*last_entry).next {
-                                    last_entry = next_entry;
-                                }
+                            while let Some(next_entry) = execution.next_of(last_entry) {
+                                last_entry = next_entry;
                             }
                             break 'blk last_entry;
                         }
@@ -298,13 +285,9 @@ pub mod js_fns {
                         BaseScopeCfg::default(),
                         AddedInPhase::Execution,
                     );
-                    let new_item_ptr = bun_core::heap::into_raw(new_item);
-                    // SAFETY: append_point is a valid linked-list node; new_item_ptr just allocated
-                    unsafe {
-                        (*new_item_ptr).next = (*append_point).next;
-                        (*append_point).next = Some(new_item_ptr);
-                    }
-                    bun_test.extra_execution_entries.push(new_item_ptr);
+                    let new_id = execution.push_node(EntryNode::new(new_item));
+                    execution.set_next(new_id, execution.next_of(append_point));
+                    execution.set_next(append_point, Some(new_id));
 
                     Ok(JSValue::UNDEFINED)
                 }
@@ -343,251 +326,137 @@ pub mod js_fns {
     }
 }
 
-/// `Rc<BunTestCell>`: single-thread, weak-capable, interior-mutable shared handle.
-///
-/// Code mutates through this handle pervasively (re-entrantly via JS callbacks).
-/// `Rc<T>` does **not** wrap `T` in `UnsafeCell`, so the previous
-/// `Rc::as_ptr(&rc) as *mut T` + write was UB. The payload now lives in an
-/// explicit `UnsafeCell` so all writes go through interior-mutable provenance.
-pub type BunTestPtr = Rc<BunTestCell>;
-pub type BunTestPtrWeak = Weak<BunTestCell>;
-pub type BunTestPtrOptional = Option<Rc<BunTestCell>>;
-
-/// `UnsafeCell` newtype so `Rc<BunTestCell>` permits mutation of the shared
-/// `BunTest` (`UnsafeCell` is required for any write reachable through a
-/// shared/`*const` path).
-#[repr(transparent)]
-pub struct BunTestCell(UnsafeCell<BunTest>);
-
-impl BunTestCell {
-    #[inline]
-    pub(crate) fn new(bt: BunTest) -> Rc<Self> {
-        Rc::new(Self(UnsafeCell::new(bt)))
-    }
-
-    /// Returns `&mut` because every call site mutates. The borrow is derived
-    /// from `UnsafeCell::get()` so provenance is valid for writes even while
-    /// other `Rc`/`Weak` handles exist.
-    ///
-    /// **Aliasing contract:** the test runner is single-threaded. Callers must not
-    /// hold the returned `&mut` across a re-entrancy point (JS callback,
-    /// `Collection::step`, `Execution::step`, `BunTest::run`) that itself calls
-    /// `.get()` — re-derive afterwards instead. Prefer [`as_ptr`](Self::as_ptr)
-    /// for long-lived handles that span re-entrant calls.
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub fn get(&self) -> &mut BunTest {
-        // SAFETY: `UnsafeCell` interior; single-threaded JS VM. See contract above.
-        unsafe { &mut *self.0.get() }
-    }
-
-    /// Raw pointer for sites that must span re-entrant `.get()` calls without
-    /// holding a live `&mut` (Stacked-Borrows-safe: raw ptrs do not assert
-    /// uniqueness).
-    #[inline]
-    pub(crate) fn as_ptr(&self) -> *mut BunTest {
-        self.0.get()
-    }
-}
-
-impl core::ops::Deref for BunTestCell {
-    type Target = BunTest;
-    #[inline]
-    fn deref(&self) -> &BunTest {
-        // SAFETY: shared read through `UnsafeCell`; single-threaded — caller
-        // must not hold a live `&mut` from `.get()` concurrently.
-        unsafe { &*self.0.get() }
-    }
-}
-
-/// Back-compat shim for sibling modules (jest.rs) that funneled through this
-/// helper. Now routes through `UnsafeCell::get()` instead of the UB
-/// `*const T as *mut T` cast.
-///
-/// # Safety
-/// Caller must uphold the aliasing contract documented on [`BunTestCell::get`].
-#[inline]
-#[allow(clippy::mut_from_ref)] // interior mutability: routes through UnsafeCell::get()
-pub(crate) unsafe fn buntest_as_mut(ptr: &BunTestPtr) -> &mut BunTest {
-    ptr.get()
-}
+/// `Rc<BunTest>`: single-thread, weak-capable shared handle. Every JS-reachable
+/// entry point can re-enter another on the same file, so `BunTest` is
+/// `&self`-only and keeps its mutable state in `Cell`/`RefCell` fields whose
+/// borrows never span a call that can run JS.
+pub type BunTestPtr = Rc<BunTest>;
+pub type BunTestPtrWeak = Weak<BunTest>;
 
 pub struct BunTestRoot {
-    // gpa dropped — global mimalloc
-    pub(crate) active_file: BunTestPtrOptional,
-    pub(crate) hook_scope: Box<DescribeScope>,
-    /// `RefData` pointers handed to `Promise.then()`. Tracked here (process-lifetime)
-    /// so a never-settled promise's `+1` stays reachable; do not free orphans —
-    /// a queued reaction may still consume them.
-    pub(crate) pending_then_refs: std::cell::RefCell<Vec<*const RefData>>,
+    pub(crate) active_file: RefCell<Option<BunTestPtr>>,
+    pub(crate) hook_scope: RefCell<Rc<DescribeScope>>,
+    /// One `Rc<RefData>` per pending `Promise.then()` registration: the
+    /// reaction's context pointer is `Rc::as_ptr` of the entry, and the entry
+    /// is what keeps it alive until the promise settles (or the run exits).
+    pub(crate) pending_then_refs: RefCell<Vec<RefDataPtr>>,
     /// Monotonic per-`enter_file` counter. Exposed to JS so per-file module
     /// state (node:test root) resets on `--rerun-each` where `Bun.main` is
     /// unchanged across iterations.
-    pub(crate) file_generation: u32,
+    pub(crate) file_generation: Cell<u32>,
+}
+
+fn new_root_hook_scope() -> Rc<DescribeScope> {
+    DescribeScope::create(BaseScope {
+        parent: None,
+        name: None,
+        concurrent: false,
+        mode: ScopeMode::Normal,
+        only: Cell::new(Only::No),
+        has_callback: Cell::new(false),
+        test_id_for_debugger: Cell::new(0),
+        line_no: 0,
+    })
 }
 
 impl BunTestRoot {
     pub(crate) fn init() -> BunTestRoot {
-        let hook_scope = DescribeScope::create(BaseScope {
-            parent: None,
-            name: None,
-            concurrent: false,
-            mode: ScopeMode::Normal,
-            only: Only::No,
-            has_callback: false,
-            test_id_for_debugger: 0,
-            line_no: 0,
-        });
         BunTestRoot {
-            active_file: None,
-            hook_scope,
-            pending_then_refs: std::cell::RefCell::new(Vec::new()),
-            file_generation: 0,
+            active_file: RefCell::new(None),
+            hook_scope: RefCell::new(new_root_hook_scope()),
+            pending_then_refs: RefCell::new(Vec::new()),
+            file_generation: Cell::new(0),
         }
+    }
+
+    pub(crate) fn hook_scope(&self) -> Rc<DescribeScope> {
+        Rc::clone(&self.hook_scope.borrow())
     }
 
     /// Drop preload-level hooks registered in the previous global. The next
     /// file's `loadPreloads()` re-registers them against the fresh global.
-    pub(crate) fn reset_hook_scope_for_test_isolation(&mut self) {
-        debug_assert!(self.hook_scope.entries.is_empty());
+    pub(crate) fn reset_hook_scope_for_test_isolation(&self) {
+        debug_assert!(self.hook_scope.borrow().entries.borrow().is_empty());
         // drop old, create fresh
-        self.hook_scope = DescribeScope::create(BaseScope {
-            parent: None,
-            name: None,
-            concurrent: false,
-            mode: ScopeMode::Normal,
-            only: Only::No,
-            has_callback: false,
-            test_id_for_debugger: 0,
-            line_no: 0,
-        });
+        *self.hook_scope.borrow_mut() = new_root_hook_scope();
     }
 
     /// Tear down `bun:test` GC roots before `global_exit()` so
     /// `Zig__GlobalObject__destructOnExit()`'s `collectNow()` can reclaim the
     /// closures they pin. Releases the active file's per-test `Strong`s (the
     /// bail path skips its `scopeguard::defer! { exit_file() }` because
-    /// `process::exit()` does not unwind), the preload-hook `Strong`s held in
-    /// `hook_scope`, and the `pending_then_refs` Vec.
-    pub(crate) fn deinit_for_exit(&mut self) {
-        if self.active_file.is_some() {
+    /// `process::exit()` does not unwind) and the preload-hook `Strong`s held in
+    /// `hook_scope`.
+    pub(crate) fn deinit_for_exit(&self) {
+        if self.active_file.borrow().is_some() {
             self.exit_file();
         }
         self.reset_hook_scope_for_test_isolation();
-        // `pending_then_refs` holds the `+1` `RefData` ref taken at
-        // `Promise.then()` time so a never-settled promise's box stays
-        // reachable. The corresponding deref happens in
-        // `bun_test_then_or_catch` when the promise settles — which it now
-        // never will (the VM is going away). Release each orphan ourselves;
-        // any reaction that is still queued is dropped wholesale by
-        // `Zig__GlobalObject__destructOnExit`.
-        for ptr in self.pending_then_refs.borrow_mut().drain(..) {
-            // SAFETY: `ptr` was produced by `RefPtr::into_raw` in
-            // `BunTest::run_test_callback`; it is live because the promise
-            // never settled (the settle path removes the entry before
-            // releasing). Single-threaded.
-            drop(unsafe { RefPtr::from_raw(ptr.cast_mut()) });
-        }
+        // `pending_then_refs` is deliberately left populated: each entry is the
+        // context of a still-registered promise reaction, holds no GC root
+        // (only `Weak`s), and lives as long as this (leaked) root does, so a
+        // reaction can never observe a freed `RefData`.
     }
 
     pub(crate) fn enter_file(
-        &mut self,
+        &'static self,
         file_id: FileId,
-        reporter: &mut CommandLineReporter,
+        reporter: &'static CommandLineReporter,
         default_concurrent: bool,
         first_last: FirstLast,
     ) {
         let _g = group_begin!();
 
-        debug_assert!(self.active_file.is_none());
-        self.file_generation = self.file_generation.wrapping_add(1);
+        debug_assert!(self.active_file.borrow().is_none());
+        self.file_generation
+            .set(self.file_generation.get().wrapping_add(1));
 
-        // Derive the stored backref from the TestRunner's *stable* storage
-        // (the global `Jest::RUNNER` NonNull) rather than `self as *mut _`.
-        // A pointer coerced from `&mut self` carries provenance bounded by this
-        // call's reborrow; the next `Jest::runner()` hands out a fresh
-        // an exclusive `&mut TestRunner`, invalidating that tag, so later derefs at
-        // `BunTest::run`/`on_uncaught_exception` would be use-after-invalidation
-        // under Stacked Borrows.
-        // SAFETY: single-threaded; `RUNNER` outlives every BunTest. Field
-        // projection via `addr_of_mut!` creates no intermediate `&mut TestRunner`,
-        // and `addr_of_mut!` on a live struct field is never null.
-        let stable_root: NonNull<BunTestRoot> = Jest::runner_ptr()
-            .map(|p| unsafe { NonNull::new_unchecked(core::ptr::addr_of_mut!((*p.as_ptr()).bun_test_root)) })
-            .unwrap_or_else(|| NonNull::from(&mut *self));
-
-        // BunTest stores a backref to BunTestRoot, but the backref is the
-        // `stable_root` raw pointer above (not an `Rc`), so plain construction
-        // works without `Rc::new_cyclic`/two-phase init.
-        // The reporter is the global `CommandLineReporter` owned by
-        // `test_command::exec` which outlives every `BunTest`. `exit_file()`
-        // nulls this before the file is dropped.
-        let reporter_ptr = NonNull::from(&mut *reporter);
-        let bun_test = BunTestCell::new(BunTest::init(
-            stable_root,
+        let bun_test = BunTest::new(
+            self,
             file_id,
-            Some(reporter_ptr),
+            Some(reporter),
             default_concurrent,
             first_last,
-        ));
-        self.active_file = Some(bun_test);
+        );
+        *self.active_file.borrow_mut() = Some(bun_test);
     }
 
-    pub(crate) fn exit_file(&mut self) {
+    pub(crate) fn exit_file(&self) {
         let _g = group_begin!();
 
-        debug_assert!(self.active_file.is_some());
-        if let Some(active) = &self.active_file {
-            // SAFETY: single-threaded; no other `&mut BunTest` is live during
-            // teardown. Write goes through `UnsafeCell` (see `BunTestCell::get`).
-            active.get().reporter = None;
+        debug_assert!(self.active_file.borrow().is_some());
+        let active = self.active_file.borrow_mut().take();
+        if let Some(active) = &active {
+            active.reporter.set(None);
         }
-        self.active_file = None; // drops the Rc (deinit)
+        drop(active); // drops the Rc (deinit)
     }
 
-    pub(crate) fn get_active_file_unless_in_preload(&mut self, vm: &VirtualMachine) -> Option<&mut BunTest> {
+    pub(crate) fn active_file_unless_in_preload(&self, vm: &VirtualMachine) -> Option<BunTestPtr> {
         if vm.is_in_preload {
             return None;
         }
-        // SAFETY: single-threaded; caller (js_fns::generic_hook) holds the only
-        // live `&mut` for the duration of the hook-append below. Projection goes
-        // through `UnsafeCell` (see `BunTestCell::get`).
-        self.active_file.as_ref().map(|rc| rc.get())
+        self.clone_active_file()
     }
 
     pub(crate) fn clone_active_file(&self) -> Option<BunTestPtr> {
-        self.active_file.clone()
+        self.active_file.borrow().clone()
     }
 
     pub(crate) fn on_before_print(&self) {
-        if let Some(active_file) = &self.active_file {
-            // Do NOT go through `<BunTestCell as Deref>` here. Two of the three
-            // callers (`on_uncaught_exception`, test_command.rs report-status)
-            // reach this while a `&mut BunTest` to the *same* cell payload is
-            // live and reused afterward; materialising a sibling `&BunTest`
-            // would pop the caller's Unique tag under Stacked Borrows. Read the
-            // reporter field via raw ptr instead — `Option<NonNull<_>>` is `Copy`.
-            // SAFETY: single-threaded; `active_file` keeps the cell alive; raw
-            // field read creates no intermediate `&BunTest`.
-            let reporter = unsafe { *core::ptr::addr_of!((*active_file.as_ptr()).reporter) };
-            if let Some(reporter) = reporter {
-                // SAFETY: reporter outlives every BunTest (owned by test_command::exec).
-                // `last_printed_dot` is `Cell<bool>` so a `&` borrow suffices.
-                let reporter = unsafe { reporter.as_ref() };
-                if reporter.reporters.dots && reporter.last_printed_dot.get() {
-                    bun_core::pretty_error!("<r>\n");
-                    Output::flush();
-                    reporter.last_printed_dot.set(false);
-                }
-                // `Jest::runner()` would hand out an exclusive `&mut TestRunner` while
-                // `self: &BunTestRoot` — a field of that same TestRunner — is
-                // live. Project `current_file` through the raw global ptr instead.
-                if let Some(runner_ptr) = Jest::runner_ptr() {
-                    // SAFETY: single-threaded; disjoint field from `bun_test_root`.
-                    unsafe {
-                        (*core::ptr::addr_of_mut!((*runner_ptr.as_ptr()).current_file)).print_if_needed();
-                    }
-                }
+        let reporter = self
+            .active_file
+            .borrow()
+            .as_ref()
+            .and_then(|f| f.reporter.get());
+        if let Some(reporter) = reporter {
+            if reporter.reporters.dots && reporter.last_printed_dot.get() {
+                bun_core::pretty_error!("<r>\n");
+                Output::flush();
+                reporter.last_printed_dot.set(false);
+            }
+            if let Some(runner) = Jest::runner() {
+                runner.current_file.borrow_mut().print_if_needed();
             }
         }
     }
@@ -595,9 +464,8 @@ impl BunTestRoot {
 
 impl Drop for BunTestRoot {
     fn drop(&mut self) {
-        debug_assert!(self.hook_scope.entries.is_empty()); // entries must not be appended to the hook_scope
-        // hook_scope: Box dropped automatically
-        debug_assert!(self.active_file.is_none());
+        debug_assert!(self.hook_scope.borrow().entries.borrow().is_empty()); // entries must not be appended to the hook_scope
+        debug_assert!(self.active_file.borrow().is_none());
     }
 }
 
@@ -618,82 +486,91 @@ pub enum Phase {
 }
 
 pub struct BunTest {
-    pub(crate) bun_test_root: bun_ptr::BackRef<BunTestRoot>,
-    pub(crate) in_run_loop: bool,
-    // gpa / arena_allocator / arena dropped — see §Allocators (non-AST crate)
+    this: BunTestPtrWeak,
+    pub(crate) bun_test_root: &'static BunTestRoot,
+    /// The root preload-hook scope this file's `root_scope` is parented to;
+    /// held so `Order` can reach its `beforeEach`/`afterEach` hooks for the
+    /// whole run of this file.
+    pub(crate) hook_scope: Rc<DescribeScope>,
+    pub(crate) in_run_loop: Cell<bool>,
     pub(crate) file_id: FileId,
-    /// null if the runner has moved on to the next file but a strong reference to BunTest is still keeping it alive
-    ///
-    /// Stored as
-    /// `NonNull` (not `&`) so callbacks (`handle_test_completed`, junit writer,
-    /// uncaught-exception handler) can write through it without deriving `&mut`
-    /// from `&` (UB). The reporter is owned by `test_command::exec`'s stack
-    /// frame, which never returns; `exit_file()` nulls this before drop.
-    pub(crate) reporter: Option<NonNull<CommandLineReporter>>,
-    pub(crate) timer: EventLoopTimer,
-    pub(crate) result_queue: ResultQueue,
+    /// `None` once the runner has moved on to the next file while a strong
+    /// reference still keeps this `BunTest` alive. The reporter is leaked for
+    /// the process lifetime by `test_command::exec`.
+    pub(crate) reporter: Cell<Option<&'static CommandLineReporter>>,
+    pub(crate) timer: JsCell<EventLoopTimer>,
+    pub(crate) result_queue: RefCell<ResultQueue>,
     /// Whether tests in this file should default to concurrent execution
     pub(crate) default_concurrent: bool,
     pub(crate) first_last: FirstLast,
-    pub(crate) extra_execution_entries: Vec<*mut ExecutionEntry>,
-    /// Heap-boxed bitwise clones of hook entries from `Order::generate_order_test`.
-    /// Only the Box header may be freed in `Drop` — fields alias `DescribeScope` originals.
-    pub(crate) cloned_hook_entries: Vec<*mut ExecutionEntry>,
-    pub(crate) wants_wakeup: bool,
+    pub(crate) wants_wakeup: Cell<bool>,
 
-    pub(crate) phase: Phase,
-    pub(crate) collection: Collection,
+    pub(crate) phase: Cell<Phase>,
     pub(crate) execution: Execution::Execution,
+    pub(crate) collection: Collection,
 }
 
 bun_event_loop::impl_timer_owner!(BunTest; from_timer_ptr => timer);
 
 impl BunTest {
-    /// `bun_test_root` must point at the stable global `BunTestRoot` storage
-    /// that outlives the returned `BunTest`.
-    pub(crate) fn init(
-        bun_test_root: NonNull<BunTestRoot>,
+    fn new(
+        bun_test_root: &'static BunTestRoot,
         file_id: FileId,
-        reporter: Option<NonNull<CommandLineReporter>>,
+        reporter: Option<&'static CommandLineReporter>,
         default_concurrent: bool,
         first_last: FirstLast,
-    ) -> Self {
+    ) -> Rc<Self> {
         let _g = group_begin!();
 
-        BunTest {
-            bun_test_root: bun_ptr::BackRef::from(bun_test_root),
-            in_run_loop: false,
-            phase: Phase::Collection,
+        let hook_scope = bun_test_root.hook_scope();
+        Rc::new_cyclic(|this| BunTest {
+            this: Weak::clone(this),
+            bun_test_root,
+            in_run_loop: Cell::new(false),
+            phase: Cell::new(Phase::Collection),
             file_id,
-            collection: Collection::init(bun_test_root.as_ptr()),
+            collection: Collection::init(&hook_scope),
             execution: Execution::Execution::init(),
-            reporter,
-            result_queue: ResultQueue::init(),
+            hook_scope,
+            reporter: Cell::new(reporter),
+            result_queue: RefCell::new(ResultQueue::new()),
             default_concurrent,
             first_last,
-            extra_execution_entries: Vec::new(),
-            cloned_hook_entries: Vec::new(),
             // `EventLoopTimer` has no `Default`; `init_paused` sets
             // `next = EPOCH, state = PENDING`.
-            timer: EventLoopTimer::init_paused(EventLoopTimerTag::BunTest),
-            wants_wakeup: false,
-        }
+            timer: JsCell::new(EventLoopTimer::init_paused(EventLoopTimerTag::BunTest)),
+            wants_wakeup: Cell::new(false),
+        })
+    }
+
+    /// A strong handle to `self` (always live: every `&BunTest` is reached
+    /// through an `Rc`).
+    pub(crate) fn strong(&self) -> BunTestPtr {
+        self.this.upgrade().expect("BunTest reached outside its Rc")
+    }
+
+    pub(crate) fn timer_state(&self) -> EventLoopTimerState {
+        self.timer.get().state
+    }
+
+    pub(crate) fn timer_next(&self) -> ElTimespec {
+        self.timer.get().next
     }
 
     pub(crate) fn get_current_state_data(&self) -> RefDataValue {
-        match self.phase {
+        match self.phase.get() {
             Phase::Collection => RefDataValue::Collection {
-                active_scope: self.collection.active_scope,
+                active_scope: Rc::downgrade(&self.collection.active_scope()),
             },
             Phase::Execution => 'blk: {
-                let Some(active_group) = self.execution.active_group_ref() else {
+                let Some(active_group) = self.execution.active_group() else {
                     debug_assert!(false); // should have switched phase if we're calling getCurrentStateData, but it could happen with re-entry maybe
                     break 'blk RefDataValue::Done;
                 };
                 let sequences = active_group.sequences(&self.execution);
                 if sequences.len() != 1 {
                     break 'blk RefDataValue::Execution {
-                        group_index: self.execution.group_index,
+                        group_index: self.execution.group_index.get(),
                         entry_data: None, // the current execution entry is not known because we are running a concurrent test
                     };
                 }
@@ -701,19 +578,19 @@ impl BunTest {
                 let active_sequence_index = 0usize;
                 let sequence = &sequences[active_sequence_index];
 
-                let Some(active_entry) = sequence.active_entry else {
+                let Some(active_entry) = sequence.active_entry.get() else {
                     break 'blk RefDataValue::Execution {
-                        group_index: self.execution.group_index,
+                        group_index: self.execution.group_index.get(),
                         entry_data: None, // the sequence is completed.
                     };
                 };
 
                 RefDataValue::Execution {
-                    group_index: self.execution.group_index,
+                    group_index: self.execution.group_index.get(),
                     entry_data: Some(EntryData {
                         sequence_index: active_sequence_index,
-                        entry: active_entry.as_ptr().cast::<()>(),
-                        remaining_repeat_count: sequence.remaining_repeat_count as i64,
+                        entry: active_entry,
+                        remaining_repeat_count: sequence.remaining_repeat_count.get() as i64,
                     }),
                 }
             }
@@ -721,111 +598,96 @@ impl BunTest {
         }
     }
 
-    pub fn ref_(this_strong: &BunTestPtr, phase: RefDataValue) -> RefPtr<RefData> {
+    pub fn ref_(&self, phase: RefDataValue) -> RefDataPtr {
         let _g = group_begin!();
         bun_core::scoped_log!(bun_test_group, "ref: {}", phase);
 
-        RefPtr::new(RefData {
-            buntest_weak: Rc::downgrade(this_strong),
+        Rc::new(RefData {
+            buntest_weak: Weak::clone(&self.this),
             phase,
-            ref_count: bun_ptr::RefCount::init(),
         })
     }
 
     fn bun_test_then_or_catch(
+        this: ThisPtr<RefData>,
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
         is_catch: bool,
     ) -> JsResult<()> {
         let _g = group_begin!();
 
-        let [result, this_ptr] = callframe.arguments_as_array::<2>();
-        if this_ptr.is_empty_or_undefined_or_null() {
-            return Ok(());
-        }
+        let [result, _] = callframe.arguments_as_array::<2>();
 
-        let raw_ref: *mut RefData = this_ptr.as_promise_ptr::<RefData>();
-        // SAFETY: `raw_ref` was produced by `RefPtr::into_raw` in `run_test_callback`
-        // and round-tripped via `as_promise_ptr`; we adopt the +1 it carried.
-        let refdata = unsafe { RefPtr::from_raw(raw_ref) };
-        // Remove the pending_then_refs entry first so it never holds a freed `RefData`.
-        if let Some(runner) = Jest::runner() {
-            let mut pending = runner.bun_test_root.pending_then_refs.borrow_mut();
-            if let Some(pos) = pending.iter().position(|p| *p == raw_ref.cast_const()) {
-                pending.swap_remove(pos);
-            }
-        }
-        let has_one_ref = refdata.has_one_ref();
-        let Some(this_strong) = refdata.buntest_weak.upgrade() else {
-            bun_core::scoped_log!(bun_test_group, "bunTestThenOrCatch -> the BunTest is no longer active");
+        // Take back the `Rc` that `run_test_callback` parked for this reaction;
+        // it drops at scope exit so a paired done() callback observes
+        // `has_one_ref()` on its turn.
+        let Some(runner) = Jest::runner() else {
             return Ok(());
         };
-        // SAFETY: `&mut` derived via `UnsafeCell`; not held across `run_next_tick`
-        // (which itself calls `.get()` for a single field write).
-        let this = this_strong.get();
+        let refdata: RefDataPtr = {
+            let mut pending = runner.bun_test_root.pending_then_refs.borrow_mut();
+            let Some(pos) = pending
+                .iter()
+                .position(|p| core::ptr::eq(Rc::as_ptr(p), this.as_ptr()))
+            else {
+                return Ok(());
+            };
+            pending.swap_remove(pos)
+        };
+        let has_one_ref = refdata.has_one_ref();
+        let Some(this_strong) = refdata.bun_test() else {
+            bun_core::scoped_log!(
+                bun_test_group,
+                "bunTestThenOrCatch -> the BunTest is no longer active"
+            );
+            return Ok(());
+        };
 
         if is_catch {
-            this.on_uncaught_exception(global_this, Some(result), true, &refdata.phase);
+            this_strong.on_uncaught_exception(global_this, Some(result), true, &refdata.phase);
         }
         if !has_one_ref && !is_catch {
-            bun_core::scoped_log!(bun_test_group, "bunTestThenOrCatch -> refdata has multiple refs; don't add result until the last ref");
+            bun_core::scoped_log!(
+                bun_test_group,
+                "bunTestThenOrCatch -> refdata has multiple refs; don't add result until the last ref"
+            );
             return Ok(());
         }
 
-        this.add_result(refdata.phase);
-        // `this` borrow ends here (NLL); `run_next_tick` re-derives via `.get()`.
-        Self::run_next_tick(&refdata.buntest_weak, global_this, refdata.phase);
+        this_strong.add_result(refdata.phase.clone());
+        Self::run_next_tick(&refdata.buntest_weak, global_this, refdata.phase.clone());
         Ok(())
     }
 
-    // `#[bun_jsc::host_fn]` proc-macro emits a free-fn wrapper that
-    // calls the annotated item by bare name; that lookup fails for associated
-    // fns inside `impl` blocks. The extern-"C" trampoline is wired separately
-    // (see the gated `Bun__TestScope__Describe2__*` statics below), so the
-    // attribute is dropped here — these are plain JsResult fns.
-    fn bun_test_then(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        Self::bun_test_then_or_catch(global_this, callframe, false)?;
-        Ok(JSValue::UNDEFINED)
-    }
-
-    fn bun_test_catch(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        Self::bun_test_then_or_catch(global_this, callframe, true)?;
-        Ok(JSValue::UNDEFINED)
-    }
-
     pub(crate) fn bun_test_done_callback(
+        this: &DoneCallback,
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
         let _g = group_begin!();
 
-        let Some(this) = DoneCallback::from_js(callframe.this()) else {
-            return Err(global_this.throw(format_args!("Expected callee to be DoneCallback")));
-        };
-
         let [value] = callframe.arguments_as_array::<1>();
 
         let was_error = !value.is_empty_or_undefined_or_null();
-        // SAFETY: `this` is the live `*mut DoneCallback` returned by `from_js`;
-        // single-threaded JS VM, GC keeps the wrapper alive for the call frame.
-        if unsafe { (*this).called } {
+        if this.called.get() {
             // in Bun 1.2.20, this is a no-op
             // in Jest, this is "Expected done to be called once, but it was called multiple times."
             // Vitest does not support done callbacks
         } else {
             // error is only reported for the first done() call
             if was_error {
-                let _ = global_this.bun_vm().as_mut().uncaught_exception(global_this, value, false);
+                let _ = global_this
+                    .bun_vm()
+                    .as_mut()
+                    .uncaught_exception(global_this, value, false);
             }
         }
-        // SAFETY: see above — `this` is a live `*mut DoneCallback`.
-        let ref_in = unsafe {
-            (*this).called = true;
-            (*this).r#ref.take()
-        };
-        let Some(ref_in) = ref_in else {
+        this.called.set(true);
+        let Some(ref_in) = this.r#ref.take() else {
             return Ok(JSValue::UNDEFINED);
         };
+        // `ref_in` drops at scope exit so the paired promise then/catch path
+        // sees `has_one_ref()` on its turn.
 
         // dupe the ref and enqueue a task to call the done callback.
         // this makes it so if you do something else after calling done(), the next test doesn't start running until the next tick.
@@ -837,113 +699,98 @@ impl BunTest {
             return Ok(JSValue::UNDEFINED);
         }
 
-        let Some(strong): Option<BunTestPtr> = ref_in.buntest_weak.upgrade() else {
+        let Some(strong) = ref_in.bun_test() else {
             return Ok(JSValue::UNDEFINED);
         };
-        // SAFETY: `&mut` derived via `UnsafeCell`; borrow ends before
-        // `run_next_tick` re-derives.
-        strong.get().add_result(ref_in.phase);
-        Self::run_next_tick(&ref_in.buntest_weak, global_this, ref_in.phase);
+        strong.add_result(ref_in.phase.clone());
+        Self::run_next_tick(&ref_in.buntest_weak, global_this, ref_in.phase.clone());
 
         Ok(JSValue::UNDEFINED)
     }
 
-    pub(crate) fn bun_test_timeout_callback(
-        this_strong: &BunTestPtr,
-        _ts: &Timespec,
-        vm: &VirtualMachine,
-    ) {
+    pub(crate) fn bun_test_timeout_callback(&self, _ts: &Timespec, vm: &VirtualMachine) {
         let _g = group_begin!();
-        // Raw `*mut` (via `UnsafeCell`) because `Self::run` below re-enters and
-        // calls `.get()` on the same `Rc` — holding a long-lived `&mut` across
-        // that would alias. Each `(*this).x` is a fresh short-lived reborrow.
-        let this: *mut BunTest = this_strong.as_ptr();
         let global = vm.global();
-        // SAFETY: `this` derived from `UnsafeCell::get`; single-threaded; each
-        // deref is a point-use that does not span a re-entrant `.get()`.
-        unsafe {
-            (*this).timer.next = ElTimespec::EPOCH;
-            (*this).timer.state = EventLoopTimerState::PENDING;
+        self.timer.with_mut(|t| {
+            t.next = ElTimespec::EPOCH;
+            t.state = EventLoopTimerState::PENDING;
+        });
 
-            match (*this).phase {
-                Phase::Collection => {}
-                Phase::Execution => {
-                    if let Err(e) = (*this).execution.handle_timeout(global) {
-                        (*this).on_uncaught_exception(global, Some(global.take_exception(e)), false, &RefDataValue::Done);
-                    }
+        match self.phase.get() {
+            Phase::Collection => {}
+            Phase::Execution => {
+                if let Err(e) = self.execution.handle_timeout(self, global) {
+                    self.on_uncaught_exception(
+                        global,
+                        Some(global.take_exception(e)),
+                        false,
+                        &RefDataValue::Done,
+                    );
                 }
-                Phase::Done => {}
             }
+            Phase::Done => {}
         }
-        if let Err(e) = Self::run(this_strong, global) {
-            // SAFETY: re-derive after `run` returned; no `&mut` was held across it.
-            unsafe { (*this).on_uncaught_exception(global, Some(global.take_exception(e)), false, &RefDataValue::Done) };
+        if let Err(e) = self.run(global) {
+            self.on_uncaught_exception(
+                global,
+                Some(global.take_exception(e)),
+                false,
+                &RefDataValue::Done,
+            );
         }
     }
 
-    pub(crate) fn run_next_tick(weak: &BunTestPtrWeak, global_this: &JSGlobalObject, phase: RefDataValue) {
+    pub(crate) fn run_next_tick(
+        weak: &BunTestPtrWeak,
+        global_this: &JSGlobalObject,
+        phase: RefDataValue,
+    ) {
         let vm = global_this.bun_vm().as_mut();
         // Check liveness before allocating so the early return doesn't strand a Box.
         let Some(strong) = weak.upgrade() else {
             debug_assert!(false); // shouldn't be calling runNextTick after moving on to the next file
             return; // but just in case
         };
-        let done_callback_test = bun_core::heap::into_raw(Box::new(RunTestsTask {
+        // If the task never runs (VM teardown), the queue drainer drops it.
+        let task = jsc::ManagedTask::ManagedTask::new_boxed(Box::new(RunTestsTask {
             weak: Weak::clone(weak),
             global_this: GlobalRef::from(global_this),
             phase,
         }));
-        fn call_erased(this: *mut RunTestsTask) -> bun_event_loop::JsResult<()> {
-            // `this` was `heap::into_raw`'d above (always non-null) and is
-            // invoked exactly once by `ManagedTask`.
-            RunTestsTask::call(NonNull::new(this).unwrap())
-        }
-        // `new_owned`: if the task never runs (VM teardown), the queue drainer frees `done_callback_test`.
-        let task = jsc::ManagedTask::ManagedTask::new_owned::<RunTestsTask>(done_callback_test, call_erased);
-        // SAFETY: single field write through `UnsafeCell`; no other `&mut` live.
-        strong.get().wants_wakeup = true;
+        strong.wants_wakeup.set(true);
         // we need to wake up the event loop so autoTick() doesn't wait for 16-100ms because we just enqueued a task
         vm.enqueue_task(task);
     }
 
-    pub(crate) fn add_result(&mut self, result: RefDataValue) {
-        let _ = self.result_queue.write_item(result); // OOM/capacity: fire-and-forget
+    pub(crate) fn add_result(&self, result: RefDataValue) {
+        self.result_queue.borrow_mut().push_back(result);
     }
 
-    pub(crate) fn run(this_strong: &BunTestPtr, global_this: &JSGlobalObject) -> JsResult<()> {
-        let _g = group_begin!();
-        // `Collection::step` / `Execution::step` re-enter and call `.get()` on
-        // the same `Rc`, so we keep a raw `*mut` (via `UnsafeCell`) and reborrow
-        // per-use instead of holding one long-lived `&mut` that would alias.
-        let this: *mut BunTest = this_strong.as_ptr();
+    pub(crate) fn readable_results(&self) -> usize {
+        self.result_queue.borrow().len()
+    }
 
-        // SAFETY: `this` is `UnsafeCell::get()`-derived; single-threaded JS VM;
-        // each `(*this)` deref below is a short-lived reborrow that does not
-        // span a re-entrant `.get()` call.
-        unsafe {
-            if (*this).in_run_loop {
-                return Ok(());
-            }
-            (*this).in_run_loop = true;
+    fn next_result(&self) -> Option<RefDataValue> {
+        self.result_queue.borrow_mut().pop_front()
+    }
+
+    pub(crate) fn run(&self, global_this: &JSGlobalObject) -> JsResult<()> {
+        let _g = group_begin!();
+        let this = self.strong();
+
+        if self.in_run_loop.get() {
+            return Ok(());
         }
-        // The guard captures the raw ptr
-        // (not a `&mut bool`) so no `&mut` is held across the loop body.
-        let _reset = scopeguard::guard(this, |p| {
-            // SAFETY: `p` is the same `UnsafeCell`-derived ptr; `this_strong`
-            // keeps the allocation alive for the whole function.
-            unsafe { (*p).in_run_loop = false }
-        });
+        self.in_run_loop.set(true);
+        let _reset = scopeguard::guard((), |()| self.in_run_loop.set(false));
 
         let mut min_timeout = Timespec::EPOCH;
 
-        // SAFETY: see block-SAFETY above. `step()` may call `.get()` internally;
-        // no outer `&mut` overlaps because we only touch `*this` between calls.
-        while let Some(result) = unsafe { (*this).result_queue.read_item() } {
+        while let Some(result) = self.next_result() {
             global_this.clear_termination_exception();
-            // SAFETY: `UnsafeCell`-derived `*mut`; short-lived field read between re-entrant calls.
-            let step_result: StepResult = match unsafe { (*this).phase } {
-                Phase::Collection => Collection::step(this_strong, global_this, &result)?,
-                Phase::Execution => Execution::Execution::step(this_strong, global_this, &result)?,
+            let step_result: StepResult = match self.phase.get() {
+                Phase::Collection => Collection::step(&this, global_this, &result)?,
+                Phase::Execution => Execution::Execution::step(&this, global_this, &result)?,
                 Phase::Done => StepResult::Complete,
             };
             match step_result {
@@ -951,45 +798,47 @@ impl BunTest {
                     min_timeout = min_timeout.min_ignore_epoch(timeout);
                 }
                 StepResult::Complete => {
-                    // SAFETY: short-lived reborrow; `advance` does not re-enter `.get()`.
-                    if unsafe { (*this).advance(global_this)? } == Advance::Exit {
+                    if self.advance(global_this)? == Advance::Exit {
                         return Ok(());
                     }
-                    // SAFETY: `UnsafeCell`-derived `*mut`; sole `&mut` for this enqueue.
-                    unsafe { (*this).add_result(RefDataValue::Start) };
+                    self.add_result(RefDataValue::Start);
                 }
             }
         }
 
-        // SAFETY: loop done; sole `&mut` for the timer update.
-        unsafe { (*this).update_min_timeout(global_this, &min_timeout) };
+        self.update_min_timeout(global_this, &min_timeout);
         Ok(())
     }
 
-    fn update_min_timeout(&mut self, global_this: &JSGlobalObject, min_timeout: &Timespec) {
+    fn update_min_timeout(&self, global_this: &JSGlobalObject, min_timeout: &Timespec) {
         let _g = group_begin!();
         let _ = global_this;
         // only set the timer if the new timeout is sooner than the current timeout. this unfortunately means that we can't unset an unnecessary timer.
+        let next = self.timer_next();
         bun_core::scoped_log!(
             bun_test_group,
             "-> timeout: {:?} {}.{}, {:?}",
             min_timeout,
-            self.timer.next.sec,
-            self.timer.next.nsec,
-            order_ignore_epoch(min_timeout, &self.timer.next)
+            next.sec,
+            next.nsec,
+            order_ignore_epoch(min_timeout, &next)
         );
-        if order_ignore_epoch(min_timeout, &self.timer.next) == core::cmp::Ordering::Less {
+        if order_ignore_epoch(min_timeout, &next) == core::cmp::Ordering::Less {
             bun_core::scoped_log!(bun_test_group, "-> setting timer to {:?}", min_timeout);
-            if self.timer.next != ElTimespec::EPOCH {
+            if next != ElTimespec::EPOCH {
                 bun_core::scoped_log!(bun_test_group, "-> removing existing timer");
-                vm_timer().remove(&raw mut self.timer);
+                crate::jsc_hooks::timer_all_mut().remove(self.timer.as_ptr());
             }
             // `EventLoopTimer.next` uses the event-loop crate's local
             // `Timespec` (distinct from `bun_core::Timespec`); convert by field.
-            self.timer.next = ElTimespec { sec: min_timeout.sec, nsec: min_timeout.nsec };
-            if self.timer.next != ElTimespec::EPOCH {
+            let next = ElTimespec {
+                sec: min_timeout.sec,
+                nsec: min_timeout.nsec,
+            };
+            self.timer.with_mut(|t| t.next = next);
+            if next != ElTimespec::EPOCH {
                 bun_core::scoped_log!(bun_test_group, "-> inserting timer");
-                vm_timer().insert(&raw mut self.timer);
+                crate::jsc_hooks::timer_all_mut().insert(self.timer.as_ptr());
                 if debug::group::get_log_enabled() {
                     let duration = min_timeout.since_now_force_real_time();
                     bun_core::scoped_log!(bun_test_group, "-> timer duration: {}", duration);
@@ -999,25 +848,30 @@ impl BunTest {
         }
     }
 
-    fn advance(&mut self, _global_this: &JSGlobalObject) -> JsResult<Advance> {
+    /// Unlink the file-level timeout timer if it is armed.
+    pub(crate) fn remove_timer(&self) {
+        crate::jsc_hooks::timer_all_mut().remove(self.timer.as_ptr());
+    }
+
+    fn advance(&self, _global_this: &JSGlobalObject) -> JsResult<Advance> {
         let _g = group_begin!();
-        bun_core::scoped_log!(bun_test_group, "advance from {}", <&'static str>::from(self.phase));
-        // capture `self.phase` by raw ptr so the deferred log doesn't
-        // hold a `&self` borrow across the `self.phase = …` writes below.
-        let phase_ptr: *const Phase = &raw const self.phase;
+        bun_core::scoped_log!(
+            bun_test_group,
+            "advance from {}",
+            <&'static str>::from(self.phase.get())
+        );
         scopeguard::defer! {
-            // SAFETY: `self` outlives this guard (drops at end of this fn body).
-            bun_core::scoped_log!(bun_test_group, "advance -> {}", <&'static str>::from(unsafe { *phase_ptr }));
+            bun_core::scoped_log!(bun_test_group, "advance -> {}", <&'static str>::from(self.phase.get()));
         }
 
-        match self.phase {
+        match self.phase.get() {
             Phase::Collection => {
-                self.phase = Phase::Execution;
+                self.phase.set(Phase::Execution);
                 debug::dump_describe(&self.collection.root_scope)?;
 
-                let has_filter = if let Some(reporter) = self.reporter {
-                    // SAFETY: reporter outlives every BunTest (see field doc).
-                    unsafe { reporter.as_ref() }.jest.filter_regex.is_some()
+                let reporter = self.reporter.get();
+                let has_filter = if let Some(reporter) = reporter {
+                    reporter.jest.filter_regex.is_some()
                 } else {
                     false
                 };
@@ -1026,12 +880,14 @@ impl BunTest {
                 // seed — not on which worker ran it or what files preceded it
                 // on that worker. This is what makes --parallel --randomize
                 // reproducible via --seed=N.
-                let mut per_file_prng: Option<bun_core::rand::DefaultPrng> = if let Some(reporter) = self.reporter {
+                let mut per_file_prng: Option<bun_core::rand::DefaultPrng> = if let Some(reporter) =
+                    reporter
+                {
                     'blk: {
-                        // SAFETY: reporter outlives every BunTest (see field doc).
-                        let reporter = unsafe { reporter.as_ref() };
-                        let Some(seed) = reporter.jest.randomize_seed else { break 'blk None };
-                        let path = reporter.jest.files.items_source()[self.file_id as usize].path.text;
+                        let Some(seed) = reporter.jest.randomize_seed else {
+                            break 'blk None;
+                        };
+                        let path = reporter.jest.file_path(self.file_id).text;
                         // Basename only so the hash is platform-independent (path
                         // separators and absolute prefixes differ on Windows).
                         Some(bun_core::rand::DefaultPrng::init(
@@ -1046,41 +902,20 @@ impl BunTest {
                 let should_randomize = per_file_prng.take();
 
                 let mut order = Order::Order::init(Order::Config {
-                    always_use_hooks: self.collection.root_scope.base.only == Only::No && !has_filter,
+                    always_use_hooks: self.collection.root_scope.base.only.get() == Only::No
+                        && !has_filter,
                     randomize: should_randomize,
                 });
 
-                let root = self.bun_test_root.get();
                 let beforeall_order: Order::AllOrderResult = if self.first_last.first {
-                    order.generate_all_order(&root.hook_scope.before_all)?
+                    order.generate_all_order(&self.hook_scope.before_all.borrow())?
                 } else {
                     Order::AllOrderResult::EMPTY
                 };
-                let describe_seq_start = order.sequences.len();
-                order.generate_order_describe(&mut self.collection.root_scope)?;
-                let describe_seq_end = order.sequences.len();
-                // Collect hook-entry clones boxed by `generate_order_test` so `Drop` can
-                // reclaim the Box headers. Must run before `extra_execution_entries` are
-                // spliced into the same chains, or the walk would double-free `DescribeScope`
-                // entries.
-                debug_assert!(
-                    self.extra_execution_entries.is_empty(),
-                    "extra_execution_entries must be spliced after the cloned-hook walk"
-                );
-                for seq in &order.sequences[describe_seq_start..describe_seq_end] {
-                    let Some(test_entry) = seq.test_entry else { continue };
-                    let mut cur = seq.first_entry;
-                    while let Some(p) = cur {
-                        if p != test_entry {
-                            self.cloned_hook_entries.push(p.as_ptr());
-                        }
-                        // SAFETY: live linked-list nodes built by `generate_order_test`.
-                        cur = unsafe { p.as_ref() }.next.and_then(NonNull::new);
-                    }
-                }
+                order.generate_order_describe(&self.collection.root_scope)?;
                 beforeall_order.set_failure_skip_to(&mut order);
                 let afterall_order: Order::AllOrderResult = if self.first_last.last {
-                    order.generate_all_order(&root.hook_scope.after_all)?
+                    order.generate_all_order(&self.hook_scope.after_all.borrow())?
                 } else {
                     Order::AllOrderResult::EMPTY
                 };
@@ -1091,8 +926,8 @@ impl BunTest {
                 Ok(Advance::Cont)
             }
             Phase::Execution => {
-                self.in_run_loop = false;
-                self.phase = Phase::Done;
+                self.in_run_loop.set(false);
+                self.phase.set(Phase::Done);
                 Ok(Advance::Exit)
             }
             Phase::Done => Ok(Advance::Exit),
@@ -1101,7 +936,7 @@ impl BunTest {
 
     /// if sync, the result is returned. if async, None is returned.
     pub(crate) fn run_test_callback(
-        this_strong: &BunTestPtr,
+        &self,
         global_this: &JSGlobalObject,
         cfg_callback: JSValue,
         cfg_done_parameter: bool,
@@ -1109,11 +944,6 @@ impl BunTest {
         timeout: &Timespec,
     ) -> Option<RefDataValue> {
         let _g = group_begin!();
-        // Raw `*mut` (via `UnsafeCell`) — the JS event-loop call below can
-        // re-enter `bun_test_then_or_catch` / `bun_test_done_callback` /
-        // `on_unhandled_rejection`, each of which `.get()`s the same `BunTest`.
-        // Hold a raw ptr and reborrow per-use so no two `&mut` overlap.
-        let this: *mut BunTest = this_strong.as_ptr();
         let vm = global_this.bun_vm();
 
         // Don't use Option<JSValue> to make it harder for the conservative stack
@@ -1122,32 +952,49 @@ impl BunTest {
         let mut done_callback: JSValue = JSValue::ZERO;
 
         if cfg_done_parameter {
-            bun_core::scoped_log!(bun_test_group, "callTestCallback -> appending done callback param: data {}", cfg_data);
+            bun_core::scoped_log!(
+                bun_test_group,
+                "callTestCallback -> appending done callback param: data {}",
+                cfg_data
+            );
             done_callback = DoneCallback::create_unbound(global_this);
             done_arg = match DoneCallback::bind(done_callback, global_this) {
                 Ok(v) => v,
                 Err(e) => {
-                    // SAFETY: `UnsafeCell`-derived; sole `&mut` at this point.
-                    unsafe { (*this).on_uncaught_exception(global_this, Some(global_this.take_exception(e)), false, &cfg_data) };
+                    self.on_uncaught_exception(
+                        global_this,
+                        Some(global_this.take_exception(e)),
+                        false,
+                        &cfg_data,
+                    );
                     JSValue::ZERO // failed to bind done callback
                 }
             };
         }
 
-        // SAFETY: `UnsafeCell`-derived; sole `&mut` at this point (before JS re-entry).
-        unsafe { (*this).update_min_timeout(global_this, timeout) };
-        let args_slice: &[JSValue] = if !done_arg.is_empty() { core::slice::from_ref(&done_arg) } else { &[] };
-        let result: JSValue = match vm.event_loop_mut().run_callback_with_result_and_forcefully_drain_microtasks(
-            cfg_callback,
-            global_this,
-            JSValue::UNDEFINED,
-            args_slice,
-        ) {
+        self.update_min_timeout(global_this, timeout);
+        let args_slice: &[JSValue] = if !done_arg.is_empty() {
+            core::slice::from_ref(&done_arg)
+        } else {
+            &[]
+        };
+        let result: JSValue = match vm
+            .event_loop_mut()
+            .run_callback_with_result_and_forcefully_drain_microtasks(
+                cfg_callback,
+                global_this,
+                JSValue::UNDEFINED,
+                args_slice,
+            ) {
             Ok(v) => v,
             Err(_) => {
                 global_this.clear_termination_exception();
-                // SAFETY: re-derive after JS callback returned; no outer `&mut` was held across it.
-                unsafe { (*this).on_uncaught_exception(global_this, global_this.try_take_exception(), false, &cfg_data) };
+                self.on_uncaught_exception(
+                    global_this,
+                    global_this.try_take_exception(),
+                    false,
+                    &cfg_data,
+                );
                 bun_core::scoped_log!(bun_test_group, "callTestCallback -> error");
                 JSValue::ZERO
             }
@@ -1160,11 +1007,10 @@ impl BunTest {
             // Prevent the user's Promise rejection from going into the uncaught promise rejection queue.
             if !result.is_empty() {
                 if let Some(promise) = result.as_promise() {
-                    // SAFETY: `as_promise` returned a non-null GC-managed JSPromise.
-                    unsafe {
-                        if (*promise).status() == PromiseStatus::Rejected {
-                            (*promise).set_handled();
-                        }
+                    // S012: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
+                    let promise = bun_jsc::JSPromise::opaque_mut(promise);
+                    if promise.status() == PromiseStatus::Rejected {
+                        promise.set_handled();
                     }
                 }
             }
@@ -1176,27 +1022,17 @@ impl BunTest {
             }
         }
 
-        // `dcb_ref` is a raw observer alias, NOT a
-        // counted handle. The single +1 from `ref()` is owned by
-        // `dcb_data.ref`; `dcb_ref` just remembers the address so the
-        // pending-promise branch can `dupe()` it and the tail can branch on
-        // "wait for done callback". Holding a second `RefPtr<RefData>` here would
-        // over-count and the done-callback path would never observe
-        // `has_one_ref()`.
-        let mut dcb_ref: Option<NonNull<RefData>> = None;
+        // The `DoneCallback` that now holds a `RefData` for this callback, so the
+        // pending-promise branch below can hand the same one to `Promise.then()`
+        // and whichever of the two fires last sees `has_one_ref()`.
+        let mut dcb_ref: Option<&DoneCallback> = None;
         if !done_callback.is_empty() && !result.is_empty() {
-            if let Some(dcb_data) = DoneCallback::from_js(done_callback) {
-                // SAFETY: `dcb_data` is the live `*mut DoneCallback` from `from_js`;
-                // single-threaded JS VM, GC roots `done_callback` for this frame.
-                if unsafe { (*dcb_data).called } {
+            if let Some(dcb_data) = done_callback.as_class_ref::<DoneCallback>() {
+                if dcb_data.called.get() {
                     // done callback already called or the callback errored; add result immediately
                 } else {
-                    let r = Self::ref_(this_strong, cfg_data);
-                    let alias = NonNull::new(r.as_ptr())
-                        .expect("ref_() returns a freshly-boxed RefData");
-                    // SAFETY: see above. Move the sole +1 into the DoneCallback.
-                    unsafe { (*dcb_data).r#ref = Some(r) };
-                    dcb_ref = Some(alias);
+                    dcb_data.r#ref.set(Some(self.ref_(cfg_data.clone())));
+                    dcb_ref = Some(dcb_data);
                 }
             } else {
                 debug_assert!(false); // this should be unreachable, we create DoneCallback above
@@ -1207,34 +1043,37 @@ impl BunTest {
             if let Some(promise) = result.as_promise() {
                 let _keep = bun_jsc::EnsureStillAlive(result); // because sometimes we use promise without result
 
-                bun_core::scoped_log!(bun_test_group, "callTestCallback -> promise: data {}", cfg_data);
+                bun_core::scoped_log!(
+                    bun_test_group,
+                    "callTestCallback -> promise: data {}",
+                    cfg_data
+                );
 
                 // S012: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
                 match bun_jsc::JSPromise::opaque_mut(promise).status() {
                     PromiseStatus::Pending => {
                         // not immediately resolved; register 'then' to handle the result when it becomes available
-                        let this_ref: RefPtr<RefData> = if let Some(dcb_ref_value) = dcb_ref {
-                            // SAFETY: `dcb_ref_value` aliases the live RefData
-                            // owned by `dcb_data.r#ref` (set just above; GC
-                            // roots `done_callback` for this frame). Bump the
-                            // refcount 1→2.
-                            unsafe { RefPtr::init_ref(dcb_ref_value.as_ptr()) }
-                        } else {
-                            Self::ref_(this_strong, cfg_data)
+                        let this_ref: RefDataPtr = match dcb_ref {
+                            Some(dcb) => {
+                                let r = dcb.r#ref.take();
+                                let shared = r.clone();
+                                dcb.r#ref.set(r);
+                                shared.unwrap_or_else(|| self.ref_(cfg_data))
+                            }
+                            None => self.ref_(cfg_data),
                         };
-                        // Track the `+1` handed to `Promise.then()` in case the promise never settles.
-                        let raw_ref: *mut RefData = RefPtr::into_raw(this_ref);
-                        this_strong
-                            .bun_test_root
-                            .get()
+                        // `pending_then_refs` owns this `Rc` until the promise settles
+                        // (or forever, if it never does).
+                        let raw_ref = Rc::as_ptr(&this_ref).cast_mut();
+                        self.bun_test_root
                             .pending_then_refs
                             .borrow_mut()
-                            .push(raw_ref.cast_const());
-                        let _ = result.then(
+                            .push(this_ref);
+                        result.then(
                             global_this,
                             raw_ref,
-                            Bun__TestScope__Describe2__bunTestThen,
-                            Bun__TestScope__Describe2__bunTestCatch,
+                            crate::generated_host_exports::Bun__TestScope__Describe2__bunTestThen,
+                            crate::generated_host_exports::Bun__TestScope__Describe2__bunTestCatch,
                         );
                         // TODO: properly propagate exception upwards
                         return None;
@@ -1244,10 +1083,9 @@ impl BunTest {
                         return Some(cfg_data);
                     }
                     PromiseStatus::Rejected => {
-                        let value = bun_jsc::JSPromise::opaque_mut(promise).result(global_this.vm());
-                        // SAFETY: re-derive via `UnsafeCell` after the JS/microtask
-                        // drain above; sole `&mut` at this point.
-                        unsafe { (*this).on_uncaught_exception(global_this, Some(value), true, &cfg_data) };
+                        let value =
+                            bun_jsc::JSPromise::opaque_mut(promise).result(global_this.vm());
+                        self.on_uncaught_exception(global_this, Some(value), true, &cfg_data);
 
                         // We previously marked it as handled above.
 
@@ -1269,7 +1107,7 @@ impl BunTest {
 
     /// called from the uncaught exception handler, or if a test callback rejects or throws an error
     pub(crate) fn on_uncaught_exception(
-        &mut self,
+        &self,
         global_this: &JSGlobalObject,
         exception: Option<JSValue>,
         is_rejection: bool,
@@ -1279,13 +1117,17 @@ impl BunTest {
 
         let _ = is_rejection;
 
-        let handle_status: HandleUncaughtExceptionResult = match self.phase {
+        let handle_status: HandleUncaughtExceptionResult = match self.phase.get() {
             Phase::Collection => self.collection.handle_uncaught_exception(user_data),
             Phase::Done => HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests,
             Phase::Execution => self.execution.handle_uncaught_exception(user_data),
         };
 
-        bun_core::scoped_log!(bun_test_group, "onUncaughtException -> {}", <&'static str>::from(handle_status));
+        bun_core::scoped_log!(
+            bun_test_group,
+            "onUncaughtException -> {}",
+            <&'static str>::from(handle_status)
+        );
 
         if handle_status == HandleUncaughtExceptionResult::HideError {
             return; // do not print error, it was already consumed
@@ -1294,21 +1136,17 @@ impl BunTest {
             return; // the exception should not be visible (eg m_terminationException)
         };
 
-        let failure_ctx: *mut core::ffi::c_void = 'ctx: {
+        let failure_reporter: Option<&'static CommandLineReporter> = 'ctx: {
             if handle_status != HandleUncaughtExceptionResult::ShowHandledError {
-                break 'ctx core::ptr::null_mut();
+                break 'ctx None;
             }
-            let Some(reporter) = self.reporter else {
-                break 'ctx core::ptr::null_mut();
+            let Some(reporter) = self.reporter.get() else {
+                break 'ctx None;
             };
-            // SAFETY: `BunTest.reporter` carries write provenance from `enter_file`'s
-            // `&mut`; single-threaded test runner, no other borrow live here.
-            let reporter = unsafe { &mut *reporter.as_ptr() };
-            if reporter.jest.test_options.reporters.junit {
-                core::ptr::from_mut(&mut reporter.test_failure).cast()
-            } else {
-                core::ptr::null_mut()
+            if !reporter.jest.test_options.reporters.junit {
+                break 'ctx None;
             }
+            Some(reporter)
         };
 
         self.bun_test_root.on_before_print();
@@ -1317,11 +1155,10 @@ impl BunTest {
             HandleUncaughtExceptionResult::ShowUnhandledErrorBetweenTests
                 | HandleUncaughtExceptionResult::ShowUnhandledErrorInDescribe
         ) {
-            // SAFETY: reporter is Some (asserted by call sites that reach here);
-            // `NonNull<CommandLineReporter>` carries write provenance from
-            // `enter_file`'s `&mut`; single-threaded, no other borrow live.
-            unsafe {
-                (*self.reporter.unwrap().as_ptr()).jest.unhandled_errors_between_tests += 1;
+            debug_assert!(self.reporter.get().is_some());
+            if let Some(reporter) = self.reporter.get() {
+                let n = &reporter.jest.unhandled_errors_between_tests;
+                n.set(n.get() + 1);
             }
             bun_core::pretty_errorln!(
                 "<r>\n<b><d>#<r> <red><b>Unhandled error<r><d> between tests<r>\n<d>-------------------------------<r>\n",
@@ -1330,13 +1167,16 @@ impl BunTest {
         }
 
         let vm = global_this.bun_vm().as_mut();
-        if !failure_ctx.is_null() {
+        if let Some(reporter) = failure_reporter {
             vm.on_print_error_zig_exception =
                 Some(crate::cli::test_command::TestFailure::record_cb);
-            vm.on_print_error_zig_exception_ctx = failure_ctx;
+            vm.on_print_error_zig_exception_ctx =
+                core::ptr::from_ref::<CommandLineReporter>(reporter)
+                    .cast_mut()
+                    .cast();
         }
         vm.run_error_handler(exception, None);
-        if !failure_ctx.is_null() {
+        if failure_reporter.is_some() {
             vm.on_print_error_zig_exception = None;
             vm.on_print_error_zig_exception_ctx = core::ptr::null_mut();
         }
@@ -1357,19 +1197,9 @@ impl Drop for BunTest {
     fn drop(&mut self) {
         let _g = group_begin!();
 
-        if self.timer.state == EventLoopTimerState::ACTIVE {
+        if self.timer_state() == EventLoopTimerState::ACTIVE {
             // must remove an active timer to prevent UAF (if the timer were to trigger after BunTest deinit)
-            vm_timer().remove(&raw mut self.timer);
-        }
-
-        for entry in self.extra_execution_entries.drain(..) {
-            // SAFETY: entries were heap-allocated in generic_hook; we own them
-            unsafe { drop(bun_core::heap::take(entry)); }
-        }
-        for entry in self.cloned_hook_entries.drain(..) {
-            // Reclaim only the Box header — fields alias the `DescribeScope` originals.
-            // SAFETY: heap-boxed by `Order::generate_order_test`; same layout as `ManuallyDrop`.
-            let _ = unsafe { Box::from_raw(entry.cast::<core::mem::ManuallyDrop<ExecutionEntry>>()) };
+            self.remove_timer();
         }
         // execution, collection, result_queue: dropped automatically
     }
@@ -1377,54 +1207,44 @@ impl Drop for BunTest {
 
 // `ZigGlobalObject::promiseHandlerID` (C++) compares the fn-ptr passed to
 // `JSValue::then` against `&Bun__TestScope__Describe2__bunTestThen` by
-// identity, so the Rust thunk MUST be the symbol itself — exporting a
-// `static JSHostFn = thunk` puts the name in `.data` (nm `d`), and the address
-// C++ sees never matches the local thunk we hand to `.then()`, tripping the
-// `RELEASE_ASSERT_NOT_REACHED` at the bottom of `promiseHandlerID`.
-bun_jsc::jsc_host_abi! {
-    #[unsafe(no_mangle)]
-    pub unsafe fn Bun__TestScope__Describe2__bunTestThen(
-        global: *mut JSGlobalObject,
-        frame: *mut CallFrame,
-    ) -> JSValue {
-        // SAFETY: JSC passes non-null live pointers for both.
-        let (global, frame) = unsafe { (&*global, &*frame) };
-        jsc::host_fn::to_js_host_fn_result(global, BunTest::bun_test_then(global, frame))
-    }
-}
-bun_jsc::jsc_host_abi! {
-    #[unsafe(no_mangle)]
-    pub unsafe fn Bun__TestScope__Describe2__bunTestCatch(
-        global: *mut JSGlobalObject,
-        frame: *mut CallFrame,
-    ) -> JSValue {
-        // SAFETY: JSC passes non-null live pointers for both.
-        let (global, frame) = unsafe { (&*global, &*frame) };
-        jsc::host_fn::to_js_host_fn_result(global, BunTest::bun_test_catch(global, frame))
-    }
+// identity, so these must stay function exports.
+// HOST_EXPORT(Bun__TestScope__Describe2__bunTestThen, jsc)
+pub fn bun_test_then(
+    this: ThisPtr<RefData>,
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    BunTest::bun_test_then_or_catch(this, global, frame, false)?;
+    Ok(JSValue::UNDEFINED)
 }
 
-// Clone/Copy: bitwise OK — `entry` is a non-owning erased borrow of an
-// `ExecutionEntry` owned by `BunTest::execution`.
+// HOST_EXPORT(Bun__TestScope__Describe2__bunTestCatch, jsc)
+pub fn bun_test_catch(
+    this: ThisPtr<RefData>,
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    BunTest::bun_test_then_or_catch(this, global, frame, true)?;
+    Ok(JSValue::UNDEFINED)
+}
+
 #[derive(Copy, Clone)]
 pub struct EntryData {
     pub(crate) sequence_index: usize,
-    pub(crate) entry: *const (),
+    pub(crate) entry: EntryId,
     pub(crate) remaining_repeat_count: i64,
 }
 
-// Clone/Copy: bitwise OK — `active_scope` is a non-owning borrow of a
-// `DescribeScope` whose lifetime spans the async boundary (see field note);
-// `EntryData.entry` likewise borrows.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub enum RefDataValue {
     Start,
     Collection {
-        // A borrowed `&'a DescribeScope` cannot work here: the pointer is stored
-        // across async boundaries (promise .then), so no thread-able lifetime
-        // exists. The scope is kept alive by the collection tree (Box-ed entries
-        // under root_scope, owned by BunTest) until Phase::Done.
-        active_scope: core::ptr::NonNull<DescribeScope>,
+        // Names the scope to restore when the describe callback settles
+        // (across the promise .then boundary). `Weak`: the tree is owned by
+        // `BunTest.collection`, and an `expect()` created in a describe body
+        // holds one of these — an owning edge would cycle through the JS
+        // callbacks the tree's `Strong`s root.
+        active_scope: Weak<DescribeScope>,
     },
     Execution {
         group_index: usize,
@@ -1434,30 +1254,37 @@ pub enum RefDataValue {
 }
 
 impl RefDataValue {
-    pub(crate) fn sequence<'a>(&self, buntest: &'a mut BunTest) -> Option<&'a mut Execution::ExecutionSequence> {
-        let RefDataValue::Execution { group_index, entry_data } = self else { return None };
+    pub(crate) fn sequence<'a>(
+        &self,
+        buntest: &'a BunTest,
+    ) -> Option<&'a Execution::ExecutionSequence> {
+        let RefDataValue::Execution {
+            group_index,
+            entry_data,
+        } = self
+        else {
+            return None;
+        };
         let entry_data = (*entry_data)?;
-        // reshaped for borrowck — `ConcurrentGroup::sequences_mut`
-        // borrows `&mut Execution` while `group()` already holds a borrow into
-        // `execution.groups`. Read `(sequence_start, sequence_end)` first, then
-        // index `execution.sequences` directly.
-        let group = buntest.execution.groups.get(*group_index)?;
+        let group = buntest.execution.groups().get(*group_index)?;
         let (start, end) = (group.sequence_start, group.sequence_end);
-        Some(&mut buntest.execution.sequences[start..end][entry_data.sequence_index])
+        buntest.execution.sequences()[start..end].get(entry_data.sequence_index)
     }
 
-    pub(crate) fn entry<'a>(&self, buntest: &'a mut BunTest) -> Option<&'a mut ExecutionEntry> {
+    pub(crate) fn entry(&self, buntest: &BunTest) -> Option<Rc<ExecutionEntry>> {
         if !matches!(self, RefDataValue::Execution { .. }) {
             return None;
         }
-        if buntest.phase != Phase::Execution {
+        if buntest.phase.get() != Phase::Execution {
             return None;
         }
-        let (the_sequence, _) = buntest.execution.get_current_and_valid_execution_sequence(self)?;
-        // SAFETY: `the_sequence` is a NonNull into `execution.sequences`; deref
-        // at point-of-use only. `active_entry` is a valid intrusive node while
-        // the sequence is live.
-        unsafe { the_sequence.as_ref().active_entry.map(|p| &mut *p.as_ptr()) }
+        let (the_sequence, _) = buntest
+            .execution
+            .get_current_and_valid_execution_sequence(self)?;
+        the_sequence
+            .active_entry
+            .get()
+            .map(|id| buntest.execution.entry(id))
     }
 }
 
@@ -1466,19 +1293,27 @@ impl fmt::Display for RefDataValue {
         match self {
             RefDataValue::Start => write!(f, "start"),
             RefDataValue::Collection { active_scope } => {
-                // SAFETY: active_scope is valid for the duration of collection phase
-                let name = unsafe { &active_scope.as_ref().base.name };
-                match name {
-                    Some(n) => write!(f, "collection: active_scope={}", bstr::BStr::new(n.as_ref())),
+                match active_scope.upgrade().and_then(|s| s.base.name.clone()) {
+                    Some(n) => write!(
+                        f,
+                        "collection: active_scope={}",
+                        bstr::BStr::new(n.as_ref())
+                    ),
                     None => write!(f, "collection: active_scope=null"),
                 }
             }
-            RefDataValue::Execution { group_index, entry_data } => {
+            RefDataValue::Execution {
+                group_index,
+                entry_data,
+            } => {
                 if let Some(ed) = entry_data {
                     write!(
                         f,
                         "execution: group_index={},sequence_index={},entry_index={:x},remaining_repeat_count={}",
-                        group_index, ed.sequence_index, ed.entry as usize, ed.remaining_repeat_count
+                        group_index,
+                        ed.sequence_index,
+                        ed.entry.index(),
+                        ed.remaining_repeat_count
                     )
                 } else {
                     write!(f, "execution: group_index={}", group_index)
@@ -1489,25 +1324,33 @@ impl fmt::Display for RefDataValue {
     }
 }
 
-// Intrusive single-thread refcount.
-#[derive(bun_ptr::RefCounted)]
+/// Completion context for one test-callback invocation. Shared (`Rc`) between
+/// the `done()` callback, a pending `Promise.then()` registration
+/// (`BunTestRoot::pending_then_refs`) and `expect()` instances created while it
+/// ran; whichever completion signal drops the second-to-last handle sees
+/// `has_one_ref()` and advances the runner.
 pub struct RefData {
     pub(crate) buntest_weak: BunTestPtrWeak,
     pub(crate) phase: RefDataValue,
-    pub(crate) ref_count: bun_ptr::RefCount<RefData>,
+}
+pub type RefDataPtr = Rc<RefData>;
+impl RefData {
+    pub(crate) fn bun_test(&self) -> Option<BunTestPtr> {
+        self.buntest_weak.upgrade()
+    }
+}
+pub(crate) trait RefDataRc {
+    fn has_one_ref(&self) -> bool;
+}
+impl RefDataRc for Rc<RefData> {
+    fn has_one_ref(&self) -> bool {
+        Rc::strong_count(self) == 1
+    }
 }
 impl Drop for RefData {
     fn drop(&mut self) {
         let _g = group_begin!();
         bun_core::scoped_log!(bun_test_group, "refData: {}", self.phase);
-    }
-}
-impl RefData {
-    pub(crate) fn has_one_ref(&self) -> bool {
-        self.ref_count.has_one_ref()
-    }
-    pub(crate) fn bun_test(&self) -> Option<BunTestPtr> {
-        self.buntest_weak.upgrade()
     }
 }
 
@@ -1518,31 +1361,21 @@ pub struct RunTestsTask {
     pub global_this: GlobalRef,
     pub(crate) phase: RefDataValue,
 }
-impl RunTestsTask {
-    /// `ManagedTask` callback ABI: `fn(*mut T) -> JsResult<()>`. The pointer
-    /// was `heap::alloc`'d in `run_next_tick`; reconstitute and drop here.
-    ///
-    /// `this` must be the pointer produced by `heap::into_raw` in
-    /// `run_next_tick`; ownership is consumed (the box is dropped on return).
-    pub fn call(this: NonNull<RunTestsTask>) -> JsResult<()> {
-        // SAFETY: `this` was produced by `heap::into_raw` in `run_next_tick` and
-        // is invoked exactly once by `ManagedTask`; ownership is reclaimed here.
-        let this = unsafe { bun_core::heap::take(this.as_ptr()) };
-        // Box drops at end of scope; the Weak drops with it.
-        let Some(strong) = this.weak.upgrade() else { return Ok(()) };
-        if let Err(e) = BunTest::run(&strong, &this.global_this) {
+impl bun_event_loop::ManagedTask::RunOnce for RunTestsTask {
+    fn run(self) -> JsResult<()> {
+        let Some(strong) = self.weak.upgrade() else {
+            return Ok(());
+        };
+        if let Err(e) = strong.run(&self.global_this) {
             // A termination is the tick's to fold, not a test failure.
-            if this.global_this.has_pending_termination_exception() {
+            if self.global_this.has_pending_termination_exception() {
                 return Err(e);
             }
-            // SAFETY: `&mut` derived via `UnsafeCell` after `run` returned; sole
-            // borrow at this point.
-            let bt = strong.get();
-            bt.on_uncaught_exception(
-                &this.global_this,
-                Some(this.global_this.take_exception(e)),
+            strong.on_uncaught_exception(
+                &self.global_this,
+                Some(self.global_this.take_exception(e)),
                 false,
-                &this.phase,
+                &self.phase,
             );
         }
         Ok(())
@@ -1561,8 +1394,7 @@ pub enum HandleUncaughtExceptionResult {
     ShowUnhandledErrorInDescribe,
 }
 
-pub type ResultQueue = LinearFifo<RefDataValue, bun_collections::linear_fifo::DynamicBuffer<RefDataValue>>;
-// bun.LinearFifo(.Dynamic) → second generic is the buffer strategy.
+pub type ResultQueue = std::collections::VecDeque<RefDataValue>;
 
 pub enum StepResult {
     Waiting { timeout: Timespec },
@@ -1570,7 +1402,9 @@ pub enum StepResult {
 }
 impl Default for StepResult {
     fn default() -> Self {
-        StepResult::Waiting { timeout: Timespec::EPOCH }
+        StepResult::Waiting {
+            timeout: Timespec::EPOCH,
+        }
     }
 }
 
@@ -1666,14 +1500,14 @@ impl Only {
 }
 
 pub struct BaseScope {
-    pub(crate) parent: Option<*mut DescribeScope>,
+    pub(crate) parent: Option<Weak<DescribeScope>>,
     pub name: Option<Box<[u8]>>,
     pub(crate) concurrent: bool,
     pub(crate) mode: ScopeMode,
-    pub(crate) only: Only,
-    pub(crate) has_callback: bool,
+    pub(crate) only: Cell<Only>,
+    pub(crate) has_callback: Cell<bool>,
     /// this value is 0 unless the debugger is active and the scope has a debugger id
-    pub(crate) test_id_for_debugger: i32,
+    pub(crate) test_id_for_debugger: Cell<i32>,
     /// only available if using junit reporter, otherwise 0
     pub(crate) line_no: u32,
 }
@@ -1681,14 +1515,12 @@ impl BaseScope {
     pub(crate) fn init(
         cfg: BaseScopeCfg,
         name_not_owned: Option<&[u8]>,
-        parent: Option<*mut DescribeScope>,
+        parent: Option<&Rc<DescribeScope>>,
         has_callback: bool,
     ) -> BaseScope {
-        // SAFETY: `parent` is a live backref into the describe tree; single-threaded,
-        // and the parent outlives this child during construction.
-        let parent_base = parent.map(|p| unsafe { &(*p).base });
+        let parent_base = parent.map(|p| &p.base);
         BaseScope {
-            parent,
+            parent: parent.map(Rc::downgrade),
             name: name_not_owned.map(Box::<[u8]>::from),
             concurrent: match cfg.self_concurrent {
                 ConcurrentMode::Yes => true,
@@ -1696,151 +1528,139 @@ impl BaseScope {
                 ConcurrentMode::Inherit => parent_base.is_some_and(|p| p.concurrent),
             },
             mode: if let Some(p) = parent_base {
-                if p.mode != ScopeMode::Normal { p.mode } else { cfg.self_mode }
+                if p.mode != ScopeMode::Normal {
+                    p.mode
+                } else {
+                    cfg.self_mode
+                }
             } else {
                 cfg.self_mode
             },
-            only: if cfg.self_only { Only::Yes } else { Only::No },
-            has_callback,
-            test_id_for_debugger: cfg.test_id_for_debugger,
+            only: Cell::new(if cfg.self_only { Only::Yes } else { Only::No }),
+            has_callback: Cell::new(has_callback),
+            test_id_for_debugger: Cell::new(cfg.test_id_for_debugger),
             line_no: cfg.line_no,
         }
     }
 
-    pub(crate) fn propagate(&mut self, has_callback: bool) {
-        self.has_callback = has_callback;
-        if let Some(parent) = self.parent {
-            // SAFETY: parent backref valid; tree is single-threaded and parent
-            // outlives child. Borrows are scoped to each call.
-            unsafe {
-                if self.only != Only::No {
-                    (*parent).mark_contains_only();
-                }
-                if self.has_callback {
-                    (*parent).mark_has_callback();
-                }
+    pub(crate) fn parent(&self) -> Option<Rc<DescribeScope>> {
+        self.parent.as_ref().and_then(Weak::upgrade)
+    }
+
+    pub(crate) fn propagate(&self, has_callback: bool) {
+        self.has_callback.set(has_callback);
+        if let Some(parent) = self.parent() {
+            if self.only.get() != Only::No {
+                parent.mark_contains_only();
+            }
+            if self.has_callback.get() {
+                parent.mark_has_callback();
             }
         }
     }
 }
-// deinit: only frees `name` → Box<[u8]> drops automatically; no explicit Drop needed.
 
 pub struct DescribeScope {
     pub(crate) base: BaseScope,
-    pub(crate) entries: Vec<TestScheduleEntry>,
-    // The `Box` is load-bearing: `Order.rs` derives `*mut ExecutionEntry` from
-    // box interiors and stores them in the intrusive `next`/`failure_skip_past`
-    // chains; unboxing would dangle those pointers on `Vec` realloc.
-    #[expect(clippy::vec_box)]
-    pub(crate) before_all: Vec<Box<ExecutionEntry>>,
-    #[expect(clippy::vec_box)]
-    pub(crate) before_each: Vec<Box<ExecutionEntry>>,
-    #[expect(clippy::vec_box)]
-    pub(crate) after_each: Vec<Box<ExecutionEntry>>,
-    #[expect(clippy::vec_box)]
-    pub(crate) after_all: Vec<Box<ExecutionEntry>>,
+    pub(crate) entries: RefCell<Vec<TestScheduleEntry>>,
+    pub(crate) before_all: RefCell<Vec<Rc<ExecutionEntry>>>,
+    pub(crate) before_each: RefCell<Vec<Rc<ExecutionEntry>>>,
+    pub(crate) after_each: RefCell<Vec<Rc<ExecutionEntry>>>,
+    pub(crate) after_all: RefCell<Vec<Rc<ExecutionEntry>>>,
 
     /// if true, the describe callback threw an error. do not run any tests declared in this scope.
-    pub(crate) failed: bool,
+    pub(crate) failed: Cell<bool>,
 }
 
 impl DescribeScope {
-    pub(crate) fn create(base: BaseScope) -> Box<DescribeScope> {
-        Box::new(DescribeScope {
+    pub(crate) fn create(base: BaseScope) -> Rc<DescribeScope> {
+        Rc::new(DescribeScope {
             base,
-            entries: Vec::new(),
-            before_each: Vec::new(),
-            before_all: Vec::new(),
-            after_all: Vec::new(),
-            after_each: Vec::new(),
-            failed: false,
+            entries: RefCell::new(Vec::new()),
+            before_each: RefCell::new(Vec::new()),
+            before_all: RefCell::new(Vec::new()),
+            after_all: RefCell::new(Vec::new()),
+            after_each: RefCell::new(Vec::new()),
+            failed: Cell::new(false),
         })
     }
-    // destroy → Drop on Box<DescribeScope>; all fields own their contents.
 
-    fn mark_contains_only(&mut self) {
-        let mut target: Option<*mut DescribeScope> = Some(std::ptr::from_mut(self));
-        while let Some(scope_ptr) = target {
-            // SAFETY: walking parent backrefs; tree is single-threaded
-            let scope = unsafe { &mut *scope_ptr };
-            if scope.base.only == Only::Contains {
+    fn mark_contains_only(self: &Rc<Self>) {
+        let mut target: Option<Rc<DescribeScope>> = Some(Rc::clone(self));
+        while let Some(scope) = target {
+            if scope.base.only.get() == Only::Contains {
                 return; // already marked
             }
             // note that we overwrite '.yes' with '.contains' to support only-inside-only
-            scope.base.only = Only::Contains;
-            target = scope.base.parent;
+            scope.base.only.set(Only::Contains);
+            target = scope.base.parent();
         }
     }
 
-    fn mark_has_callback(&mut self) {
-        let mut target: Option<*mut DescribeScope> = Some(std::ptr::from_mut(self));
-        while let Some(scope_ptr) = target {
-            // SAFETY: walking parent backrefs; tree is single-threaded
-            let scope = unsafe { &mut *scope_ptr };
-            if scope.base.has_callback {
+    fn mark_has_callback(self: &Rc<Self>) {
+        let mut target: Option<Rc<DescribeScope>> = Some(Rc::clone(self));
+        while let Some(scope) = target {
+            if scope.base.has_callback.get() {
                 return; // already marked
             }
-            scope.base.has_callback = true;
-            target = scope.base.parent;
+            scope.base.has_callback.set(true);
+            target = scope.base.parent();
         }
     }
 
     /// Infallible: `Vec::push` aborts on OOM.
     pub(crate) fn append_describe(
-        &mut self,
+        self: &Rc<Self>,
         name_not_owned: Option<&[u8]>,
         base: BaseScopeCfg,
-    ) -> &mut DescribeScope {
-        let mut child = Self::create(BaseScope::init(base, name_not_owned, Some(std::ptr::from_mut(self)), false));
+    ) -> Rc<DescribeScope> {
+        let child = Self::create(BaseScope::init(base, name_not_owned, Some(self), false));
         child.base.propagate(false);
-        self.entries.push(TestScheduleEntry::Describe(child));
-        match self.entries.last_mut().unwrap() {
-            TestScheduleEntry::Describe(d) => &mut **d,
-            _ => unreachable!(),
-        }
+        self.entries
+            .borrow_mut()
+            .push(TestScheduleEntry::Describe(Rc::clone(&child)));
+        child
     }
 
     pub(crate) fn append_test(
-        &mut self,
+        self: &Rc<Self>,
         name_not_owned: Option<&[u8]>,
         callback: Option<JSValue>,
         cfg: ExecutionEntryCfg,
         base: BaseScopeCfg,
         phase: AddedInPhase,
-    ) -> JsResult<&mut ExecutionEntry> {
-        let mut entry = ExecutionEntry::create(name_not_owned, callback, cfg, Some(std::ptr::from_mut(self)), base, phase);
+    ) -> JsResult<Rc<ExecutionEntry>> {
+        let entry = ExecutionEntry::create(name_not_owned, callback, cfg, Some(self), base, phase);
         let has_cb = entry.callback.is_some();
         entry.base.propagate(has_cb);
-        self.entries.push(TestScheduleEntry::TestCallback(entry));
-        match self.entries.last_mut().unwrap() {
-            TestScheduleEntry::TestCallback(e) => Ok(&mut **e),
-            _ => unreachable!(),
-        }
+        self.entries
+            .borrow_mut()
+            .push(TestScheduleEntry::TestCallback(Rc::clone(&entry)));
+        Ok(entry)
     }
 
-    // `Box` is load-bearing: see the `before_all` field comment.
-    #[expect(clippy::vec_box)]
-    pub(crate) fn get_hook_entries(&mut self, tag: HookTag) -> &mut Vec<Box<ExecutionEntry>> {
+    pub(crate) fn get_hook_entries(&self, tag: HookTag) -> &RefCell<Vec<Rc<ExecutionEntry>>> {
         match tag {
-            HookTag::BeforeAll => &mut self.before_all,
-            HookTag::BeforeEach => &mut self.before_each,
-            HookTag::AfterEach => &mut self.after_each,
-            HookTag::AfterAll => &mut self.after_all,
+            HookTag::BeforeAll => &self.before_all,
+            HookTag::BeforeEach => &self.before_each,
+            HookTag::AfterEach => &self.after_each,
+            HookTag::AfterAll => &self.after_all,
         }
     }
 
     pub(crate) fn append_hook(
-        &mut self,
+        self: &Rc<Self>,
         tag: HookTag,
         callback: Option<JSValue>,
         cfg: ExecutionEntryCfg,
         base: BaseScopeCfg,
         phase: AddedInPhase,
-    ) -> JsResult<&mut ExecutionEntry> {
-        let entry = ExecutionEntry::create(None, callback, cfg, Some(std::ptr::from_mut(self)), base, phase);
-        let list = self.get_hook_entries(tag);
-        list.push(entry);
-        Ok(&mut **list.last_mut().unwrap())
+    ) -> JsResult<Rc<ExecutionEntry>> {
+        let entry = ExecutionEntry::create(None, callback, cfg, Some(self), base, phase);
+        self.get_hook_entries(tag)
+            .borrow_mut()
+            .push(Rc::clone(&entry));
+        Ok(entry)
     }
 }
 
@@ -1870,24 +1690,20 @@ pub enum AddedInPhase {
     Execution,
 }
 
+/// A test or hook callback. Shared (`Rc`) between the collection tree and every
+/// [`EntryNode`] the execution order schedules it at; per-run state (deadline,
+/// `next` link) lives on the node.
 pub struct ExecutionEntry {
     pub(crate) base: BaseScope,
     pub callback: Option<Strong>,
     /// 0 = unlimited timeout
     pub(crate) timeout: u32,
     pub(crate) has_done_parameter: bool,
-    /// '.epoch' = not set
-    /// when this entry begins executing, the timespec will be set to the current time plus the timeout(ms).
-    pub(crate) timespec: Timespec,
     pub(crate) added_in_phase: AddedInPhase,
     /// Number of times to retry a failed test (0 = no retries)
     pub(crate) retry_count: u32,
     /// Number of times to repeat a test (0 = run once, 1 = run twice, etc.)
     pub(crate) repeat_count: u32,
-
-    pub(crate) next: Option<*mut ExecutionEntry>,
-    /// if this entry fails, go to the entry 'failure_skip_past.next'
-    pub(crate) failure_skip_past: Option<*mut ExecutionEntry>,
 }
 
 impl ExecutionEntry {
@@ -1895,84 +1711,54 @@ impl ExecutionEntry {
         name_not_owned: Option<&[u8]>,
         cb: Option<JSValue>,
         cfg: ExecutionEntryCfg,
-        parent: Option<*mut DescribeScope>,
+        parent: Option<&Rc<DescribeScope>>,
         base: BaseScopeCfg,
         phase: AddedInPhase,
-    ) -> Box<ExecutionEntry> {
-        let mut entry = Box::new(ExecutionEntry {
-            base: BaseScope::init(base, name_not_owned, parent, cb.is_some()),
-            callback: None,
+    ) -> Rc<ExecutionEntry> {
+        let base = BaseScope::init(base, name_not_owned, parent, cb.is_some());
+        let callback = match cb {
+            None => None,
+            Some(c) => match base.mode {
+                ScopeMode::Skip => None,
+                ScopeMode::Todo => {
+                    let run_todo = Jest::runner().is_some_and(|runner| runner.run_todo);
+                    if run_todo {
+                        Some(strong_create(c))
+                    } else {
+                        None
+                    }
+                }
+                _ => Some(strong_create(c)),
+            },
+        };
+        Rc::new(ExecutionEntry {
+            base,
+            callback,
             timeout: cfg.timeout,
             has_done_parameter: cfg.has_done_parameter,
             added_in_phase: phase,
             retry_count: cfg.retry_count,
             repeat_count: cfg.repeat_count,
-            timespec: Timespec::EPOCH,
-            next: None,
-            failure_skip_past: None,
-        });
-
-        if let Some(c) = cb {
-            entry.callback = match entry.base.mode {
-                ScopeMode::Skip => None,
-                ScopeMode::Todo => {
-                    let run_todo = Jest::runner().is_some_and(|runner| runner.run_todo);
-                    if run_todo { Some(strong_create(c)) } else { None }
-                }
-                _ => Some(strong_create(c)),
-            };
-        }
-        entry
-    }
-
-    pub(crate) fn evaluate_timeout(
-        &self,
-        sequence: &mut Execution::ExecutionSequence,
-        now: &Timespec,
-    ) -> bool {
-        if !self.timespec.eql(&Timespec::EPOCH) && self.timespec.order(now) == core::cmp::Ordering::Less {
-            // timed out
-            // SAFETY: pointer-identity comparison only — no deref, no provenance laundering.
-            let is_test_entry = sequence
-                .test_entry
-                .is_some_and(|p| core::ptr::eq(p.as_ptr().cast_const(), self));
-            sequence.result = if is_test_entry {
-                if self.has_done_parameter {
-                    Execution::Result::FailBecauseTimeoutWithDoneCallback
-                } else {
-                    Execution::Result::FailBecauseTimeout
-                }
-            } else if self.has_done_parameter {
-                Execution::Result::FailBecauseHookTimeoutWithDoneCallback
-            } else {
-                Execution::Result::FailBecauseHookTimeout
-            };
-            sequence.maybe_skip = true;
-            return true;
-        }
-        false
+        })
     }
 }
-// destroy → Drop: callback (Strong) and base.name (Box) drop automatically.
 
 pub enum TestScheduleEntry {
-    Describe(Box<DescribeScope>),
-    TestCallback(Box<ExecutionEntry>),
+    Describe(Rc<DescribeScope>),
+    TestCallback(Rc<ExecutionEntry>),
 }
 impl TestScheduleEntry {
-    // deinit → Drop on the Box variants; nothing to write.
-    pub(crate) fn base(&mut self) -> &mut BaseScope {
+    pub(crate) fn base(&self) -> &BaseScope {
         match self {
-            TestScheduleEntry::Describe(describe) => &mut describe.base,
-            TestScheduleEntry::TestCallback(test_callback) => &mut test_callback.base,
+            TestScheduleEntry::Describe(describe) => &describe.base,
+            TestScheduleEntry::TestCallback(test_callback) => &test_callback.base,
         }
     }
 }
 
 // Module aliases so `Execution::ConcurrentGroup` / `Order::AllOrderResult`
 // resolve as module paths without per-reference rewrites.
-pub use super::execution as Execution;
 pub use super::debug;
-pub use super::scope_functions as ScopeFunctions;
+pub use super::execution as Execution;
 pub use super::order as Order;
-
+pub use super::scope_functions as ScopeFunctions;

--- a/src/runtime/test_runner/debug.rs
+++ b/src/runtime/test_runner/debug.rs
@@ -1,12 +1,11 @@
 use core::fmt;
-use core::ptr::NonNull;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::io::Write as _;
 
 use bun_jsc::JsResult;
 
 use crate::test_runner::bun_test::{DescribeScope, ExecutionEntry, TestScheduleEntry};
-use crate::test_runner::execution::Execution;
+use crate::test_runner::execution::{EntryId, Execution};
 
 fn dump_sub(current: &TestScheduleEntry) -> JsResult<()> {
     if !group::get_log_enabled() {
@@ -29,23 +28,23 @@ pub(crate) fn dump_describe(describe: &DescribeScope) -> JsResult<()> {
         bstr::BStr::new(describe.base.name.as_deref().unwrap_or(b"(unnamed)")),
         describe.base.concurrent,
         describe.base.mode.tag_name(),
-        describe.base.only.tag_name(),
-        describe.base.has_callback,
+        describe.base.only.get().tag_name(),
+        describe.base.has_callback.get(),
     ));
 
-    for entry in describe.before_all.as_slice() {
+    for entry in describe.before_all.borrow().iter() {
         dump_test(entry, b"beforeAll")?;
     }
-    for entry in describe.before_each.as_slice() {
+    for entry in describe.before_each.borrow().iter() {
         dump_test(entry, b"beforeEach")?;
     }
-    for entry in describe.entries.as_slice() {
+    for entry in describe.entries.borrow().iter() {
         dump_sub(entry)?;
     }
-    for entry in describe.after_each.as_slice() {
+    for entry in describe.after_each.borrow().iter() {
         dump_test(entry, b"afterEach")?;
     }
-    for entry in describe.after_all.as_slice() {
+    for entry in describe.after_all.borrow().iter() {
         dump_test(entry, b"afterAll")?;
     }
     Ok(())
@@ -60,7 +59,7 @@ fn dump_test(current: &ExecutionEntry, label: &[u8]) -> JsResult<()> {
         bstr::BStr::new(label),
         bstr::BStr::new(current.base.name.as_deref().unwrap_or(b"(unnamed)")),
         current.base.concurrent,
-        current.base.only.tag_name(),
+        current.base.only.get().tag_name(),
     ));
     Ok(())
 }
@@ -71,32 +70,31 @@ pub(crate) fn dump_order(this: &Execution) -> JsResult<()> {
     }
     let _guard = group::begin_msg(format_args!("dumpOrder"));
 
-    for (group_index, group_value) in this.groups.iter().enumerate() {
+    for (group_index, group_value) in this.groups().iter().enumerate() {
         let _guard = group::begin_msg(format_args!(
             "{} ConcurrentGroup ({}-{})",
             group_index, group_value.sequence_start, group_value.sequence_end,
         ));
 
-        for (sequence_index, sequence) in group_value.sequences_const(this).iter().enumerate() {
+        for (sequence_index, sequence) in group_value.sequences(this).iter().enumerate() {
             let _guard = group::begin_msg(format_args!(
                 "{} Sequence ({}x)",
-                sequence_index, sequence.remaining_repeat_count,
+                sequence_index,
+                sequence.remaining_repeat_count.get(),
             ));
 
-            let mut current_entry: Option<NonNull<ExecutionEntry>> = sequence.first_entry;
-            while let Some(entry_ptr) = current_entry {
-                // SAFETY: linked-list nodes are owned by the Execution and remain valid for the
-                // duration of this read-only dump.
-                let entry = unsafe { entry_ptr.as_ref() };
+            let mut current_entry: Option<EntryId> = sequence.first_entry;
+            while let Some(entry_id) = current_entry {
+                let entry = this.entry(entry_id);
                 group::log(format_args!(
                     "ExecutionEntry \"{}\" (concurrent={}, mode={}, only={}, has_callback={})",
                     bstr::BStr::new(entry.base.name.as_deref().unwrap_or(b"(unnamed)")),
                     entry.base.concurrent,
                     entry.base.mode.tag_name(),
-                    entry.base.only.tag_name(),
-                    entry.base.has_callback,
+                    entry.base.only.get().tag_name(),
+                    entry.base.has_callback.get(),
                 ));
-                current_entry = entry.next.and_then(NonNull::new);
+                current_entry = this.next_of(entry_id);
             }
         }
     }

--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -94,20 +94,9 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
 /// `bun_bundler_jsc::analyze_jsc`) because `DiffFormatter` is a `bun_runtime`
 /// type and `bun_bundler_jsc` is a lower-tier crate that cannot depend on it;
 /// the `extern "C"` symbol resolves the same at link time regardless of which
-/// crate defines it.
-#[unsafe(no_mangle)]
-extern "C" fn zig__renderDiff(
-    expected_ptr: *const core::ffi::c_char,
-    expected_len: usize,
-    received_ptr: *const core::ffi::c_char,
-    received_len: usize,
-) {
-    // SAFETY: caller (BunAnalyzeTranspiledModule.cpp) passes a valid UTF-8 buffer
-    // of length `expected_len` that outlives this call.
-    let expected = unsafe { bun_core::ffi::slice(expected_ptr.cast::<u8>(), expected_len) };
-    // SAFETY: caller (BunAnalyzeTranspiledModule.cpp) passes a valid UTF-8 buffer
-    // of length `received_len` that outlives this call.
-    let received = unsafe { bun_core::ffi::slice(received_ptr.cast::<u8>(), received_len) };
+/// crate defines it. C++ passes `(ptr, len)` pairs for the two buffers.
+// HOST_EXPORT(zig__renderDiff, c)
+pub fn render_diff(expected: &[u8], received: &[u8]) {
     let formatter = DiffFormatter::from_strings(received, expected, false);
     let _ = bun_core::output::error_writer().print(format_args!("DIFF:\n{}\n", formatter));
 }

--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -94,7 +94,9 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
 /// `bun_bundler_jsc::analyze_jsc`) because `DiffFormatter` is a `bun_runtime`
 /// type and `bun_bundler_jsc` is a lower-tier crate that cannot depend on it;
 /// the `extern "C"` symbol resolves the same at link time regardless of which
-/// crate defines it. C++ passes `(ptr, len)` pairs for the two buffers.
+/// crate defines it. The `HOST_EXPORT` marker below makes codegen emit the
+/// `zig__renderDiff` thunk, which turns C++'s `(ptr, len)` pairs into the two
+/// slices and calls this.
 // HOST_EXPORT(zig__renderDiff, c)
 pub fn render_diff(expected: &[u8], received: &[u8]) {
     let formatter = DiffFormatter::from_strings(received, expected, false);

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1,4 +1,3 @@
-use crate::test_runner::jest::FileColumns as _;
 use core::cell::Cell;
 use core::fmt;
 
@@ -72,8 +71,8 @@ pub enum AsymmetricMatcherConstructorType {
 }
 
 unsafe extern "C" {
-    fn AsymmetricMatcherConstructorType__fromJS(
-        global_object: *const JSGlobalObject,
+    safe fn AsymmetricMatcherConstructorType__fromJS(
+        global_object: &JSGlobalObject,
         value: JSValue,
     ) -> i8;
 }
@@ -86,8 +85,7 @@ impl AsymmetricMatcherConstructorType {
         // (`AsymmetricMatcherConstructorType__fromJS` is `zero_is_throw`-shaped
         // with -1 as the sentinel).
         bun_jsc::validation_scope!(scope, global_object);
-        // SAFETY: FFI call with valid &JSGlobalObject; JSValue is Copy/repr(transparent)
-        let result = unsafe { AsymmetricMatcherConstructorType__fromJS(global_object, value) };
+        let result = AsymmetricMatcherConstructorType__fromJS(global_object, value);
         scope.assert_exception_presence_matches(result == -1);
         Ok(match result {
             -1 => return Err(JsError::Thrown),
@@ -185,22 +183,22 @@ impl Expect {
     }
 
     pub(crate) fn increment_expect_call_counter(&self) {
-        let Some(parent) = self.parent.as_ref() else { return }; // not in bun:test
-        let Some(buntest_strong) = parent.bun_test() else { return }; // the test file this expect() call was for is no longer
-        let buntest = buntest_strong.get();
-        if let Some(sequence) = parent.phase.sequence(buntest) {
+        let Some(parent) = self.parent.as_ref() else {
+            return;
+        }; // not in bun:test
+        let Some(buntest) = parent.bun_test() else {
+            return;
+        }; // the test file this expect() call was for is no longer
+        if let Some(sequence) = parent.phase.sequence(&buntest) {
             // found active sequence
-            sequence.expect_call_count = sequence.expect_call_count.saturating_add(1);
+            sequence
+                .expect_call_count
+                .set(sequence.expect_call_count.get().saturating_add(1));
         } else {
             // in concurrent group or otherwise failed to get the sequence; increment the expect call count in the reporter directly
-            if let Some(reporter) = buntest.reporter {
-                // SAFETY: `reporter` is `Option<NonNull<CommandLineReporter>>`,
-                // owned by `test_command` for the process lifetime, never
-                // aliased mutably elsewhere here.
-                unsafe {
-                    let s = (*reporter.as_ptr()).summary();
-                    s.expectations = s.expectations.saturating_add(1);
-                }
+            if let Some(reporter) = buntest.reporter.get() {
+                let mut s = reporter.summary();
+                s.expectations = s.expectations.saturating_add(1);
             }
         }
     }
@@ -228,18 +226,16 @@ impl Expect {
         use bun_collections::HashMap;
         use std::sync::OnceLock;
         type Key = (&'static str, &'static str, bool);
-        static CACHE: OnceLock<bun_threading::Guarded<HashMap<Key, [Box<str>; 2]>>> =
+        static CACHE: OnceLock<bun_threading::Guarded<HashMap<Key, [&'static str; 2]>>> =
             OnceLock::new();
         let cache = CACHE.get_or_init(Default::default);
         let colors = Output::enable_ansi_colors_stderr();
 
         let mut map = cache.lock();
         if let Some(pair) = map.get(&(matcher_name, args, not)) {
-            // SAFETY: `CACHE` is process-static and entries are never removed
-            // or mutated, so the `Box<str>` allocation outlives the program.
-            return unsafe { &*std::ptr::from_ref::<str>(pair[colors as usize].as_ref()) };
+            return pair[colors as usize];
         }
-        let render = |enabled: bool| -> Box<str> {
+        let render = |enabled: bool| -> &'static str {
             #[allow(clippy::disallowed_methods)] // `args` is a `'static` template literal
             let params = Output::pretty_fmt_rt(args.as_bytes(), enabled);
             if enabled {
@@ -277,13 +273,12 @@ impl Expect {
                     matcher_name, params,
                 )
             }
-            .into_boxed_str()
+            // Interned for the process lifetime (one entry per matcher signature).
+            .leak()
         };
         let pair = [render(false), render(true)];
-        let ptr = std::ptr::from_ref::<str>(pair[colors as usize].as_ref());
         map.insert((matcher_name, args, not), pair);
-        // SAFETY: just inserted into process-static `CACHE`; never removed.
-        unsafe { &*ptr }
+        pair[colors as usize]
     }
 
     pub(crate) fn throw_pretty_matcher_error(
@@ -565,54 +560,43 @@ impl Expect {
     }
 
     /// Called by C++ when matching with asymmetric matchers
-    ///
-    /// # Safety
-    /// `out_flags`, `value`, and `any_constructor_type` must be valid, properly
-    /// aligned pointers for the duration of the call.
-    #[unsafe(no_mangle)]
-    pub(crate) unsafe extern "C" fn Expect_readFlagsAndProcessPromise(
+    fn read_flags_and_process_promise(
         instance_value: JSValue,
         global_this: &JSGlobalObject,
-        out_flags: *mut FlagsCppType,
-        value: *mut JSValue,
-        any_constructor_type: *mut u8,
+        out_flags: &mut FlagsCppType,
+        value: &mut JSValue,
+        any_constructor_type: &mut u8,
     ) -> bool {
-        // SAFETY: `from_js` returns the live `m_ctx` payload owned by `instance_value`.
-        let flags: Flags = 'flags: { unsafe {
-            if let Some(instance) = ExpectCustomAsymmetricMatcher::from_js(instance_value) {
-                break 'flags (*instance).flags;
-            } else if let Some(instance) = ExpectAny::from_js(instance_value) {
-                let f = (*instance).flags.get();
-                // SAFETY: any_constructor_type is a valid out-ptr provided by C++ caller
+        let flags: Flags = 'flags: {
+            if let Some(instance) = instance_value.as_class_ref::<ExpectCustomAsymmetricMatcher>() {
+                break 'flags instance.flags;
+            } else if let Some(instance) = instance_value.as_class_ref::<ExpectAny>() {
+                let f = instance.flags.get();
                 *any_constructor_type = f.asymmetric_matcher_constructor_type() as u8;
                 break 'flags f;
-            } else if let Some(instance) = ExpectAnything::from_js(instance_value) {
-                break 'flags (*instance).flags.get();
-            } else if let Some(instance) = ExpectStringMatching::from_js(instance_value) {
-                break 'flags (*instance).flags.get();
-            } else if let Some(instance) = ExpectCloseTo::from_js(instance_value) {
-                break 'flags (*instance).flags.get();
-            } else if let Some(instance) = ExpectObjectContaining::from_js(instance_value) {
-                break 'flags (*instance).flags.get();
-            } else if let Some(instance) = ExpectStringContaining::from_js(instance_value) {
-                break 'flags (*instance).flags.get();
-            } else if let Some(instance) = ExpectArrayContaining::from_js(instance_value) {
-                break 'flags (*instance).flags.get();
+            } else if let Some(instance) = instance_value.as_class_ref::<ExpectAnything>() {
+                break 'flags instance.flags.get();
+            } else if let Some(instance) = instance_value.as_class_ref::<ExpectStringMatching>() {
+                break 'flags instance.flags.get();
+            } else if let Some(instance) = instance_value.as_class_ref::<ExpectCloseTo>() {
+                break 'flags instance.flags.get();
+            } else if let Some(instance) = instance_value.as_class_ref::<ExpectObjectContaining>() {
+                break 'flags instance.flags.get();
+            } else if let Some(instance) = instance_value.as_class_ref::<ExpectStringContaining>() {
+                break 'flags instance.flags.get();
+            } else if let Some(instance) = instance_value.as_class_ref::<ExpectArrayContaining>() {
+                break 'flags instance.flags.get();
             } else {
                 break 'flags Flags::default();
             }
-        } };
+        };
 
-        // SAFETY: out_flags is a valid out-ptr provided by C++ caller
-        unsafe { *out_flags = flags.encode() };
+        *out_flags = flags.encode();
 
         // (note that matcher_name/matcher_args are not used because silent=true)
-        // SAFETY: value is a valid in/out-ptr provided by C++ caller
-        let v = unsafe { *value };
-        match Self::process_promise(&bun_core::String::EMPTY, flags, global_this, v, "", "", true) {
+        match Self::process_promise(&bun_core::String::EMPTY, flags, global_this, *value, "", "", true) {
             Ok(new) => {
-                // SAFETY: value is a valid in/out-ptr provided by C++ caller
-                unsafe { *value = new };
+                *value = new;
                 true
             }
             Err(_) => false,
@@ -621,26 +605,23 @@ impl Expect {
 
     pub(crate) fn get_snapshot_name(&self, hint: &[u8]) -> crate::Result<Vec<u8>> {
         let parent = self.parent.as_ref().ok_or(crate::Error::NoTest)?;
-        let buntest_strong = parent.bun_test().ok_or(crate::Error::TestNotActive)?;
-        let buntest = buntest_strong.get();
+        let buntest = parent.bun_test().ok_or(crate::Error::TestNotActive)?;
         let execution_entry = parent
             .phase
-            .entry(buntest)
+            .entry(&buntest)
             .ok_or(crate::Error::SnapshotInConcurrentGroup)?;
 
         let test_name: &[u8] = execution_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
 
         let mut length: usize = 0;
-        let mut curr_scope = execution_entry.base.parent;
+        let mut curr_scope = execution_entry.base.parent();
         while let Some(scope) = curr_scope {
-            // SAFETY: `parent` is a live `*mut DescribeScope` owned by the BunTest arena.
-            let scope = unsafe { &*scope };
             if let Some(name) = scope.base.name.as_deref() {
                 if !name.is_empty() {
                     length += name.len() + 1;
                 }
             }
-            curr_scope = scope.base.parent;
+            curr_scope = scope.base.parent();
         }
         length += test_name.len();
         if !hint.is_empty() {
@@ -661,10 +642,8 @@ impl Expect {
             buf[index..].copy_from_slice(test_name);
         }
         // copy describe scopes in reverse order
-        curr_scope = execution_entry.base.parent;
+        curr_scope = execution_entry.base.parent();
         while let Some(scope) = curr_scope {
-            // SAFETY: `parent` is a live `*mut DescribeScope` owned by the BunTest arena.
-            let scope = unsafe { &*scope };
             if let Some(name) = scope.base.name.as_deref() {
                 if !name.is_empty() {
                     index -= name.len() + 1;
@@ -672,7 +651,7 @@ impl Expect {
                     buf[index + name.len()] = b' ';
                 }
             }
-            curr_scope = scope.base.parent;
+            curr_scope = scope.base.parent();
         }
 
         Ok(buf)
@@ -690,16 +669,10 @@ impl Expect {
             }
         }
 
-        let active_execution_entry_ref = if let Some(buntest_strong_) = bun_test::clone_active_strong() {
-            let buntest_strong = buntest_strong_;
-            let state = buntest_strong.get().get_current_state_data();
-            Some(bun_test::BunTest::ref_(&buntest_strong, state))
-        } else {
-            None
-        };
-        // The ref moves into `Expect` below and `to_js()` is infallible, so
-        // there is no error path between ref creation and the wrapper taking
-        // ownership.
+        let active_execution_entry_ref = bun_test::clone_active_strong().map(|buntest| {
+            let state = buntest.get_current_state_data();
+            buntest.ref_(state)
+        });
 
         let expect = Expect {
             flags: Cell::new(Flags::default()),
@@ -712,10 +685,8 @@ impl Expect {
         super::expect::js::captured_value_set_cached(expect_js_value, global_this, value);
         expect_js_value.ensure_still_alive();
 
-        if let Some(expect_ptr) = Self::from_js(expect_js_value) {
-            // SAFETY: `expect_ptr` is the live `m_ctx` payload of the just-created
-            // wrapper, kept alive by `expect_js_value.ensure_still_alive()` above.
-            unsafe { (*expect_ptr).post_match(global_this) };
+        if let Some(expect) = expect_js_value.as_class_ref::<Self>() {
+            expect.post_match(global_this);
         }
         Ok(expect_js_value)
     }
@@ -1029,7 +1000,7 @@ impl Expect {
             let signature = Self::get_signature(fn_name, "", false);
             return throw!(this, global_this, signature, "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n");
         };
-        match runner.snapshots.add_count(this, b"") {
+        match runner.snapshots.borrow_mut().add_count(this, b"") {
             Ok(_) => {}
             Err(crate::Error::Alloc(bun_alloc::AllocError)) => return Err(JsError::OutOfMemory),
             Err(crate::Error::NoTest) => {}
@@ -1038,7 +1009,7 @@ impl Expect {
             Err(_) => {}
         }
 
-        let update = runner.snapshots.update_snapshots;
+        let update = runner.snapshots.borrow().update_snapshots;
         let needs_write;
 
         let mut pretty_value: Vec<u8> = Vec::new();
@@ -1051,15 +1022,15 @@ impl Expect {
             let trim_res = Self::trim_leading_whitespace_for_inline_snapshot(saved_value, &mut buf);
 
             if strings::eql_long(&pretty_value, trim_res.trimmed, true) {
-                runner.snapshots.passed += 1;
+                runner.snapshots.borrow_mut().passed += 1;
                 return Ok(JSValue::UNDEFINED);
             } else if update {
-                runner.snapshots.passed += 1;
+                runner.snapshots.borrow_mut().passed += 1;
                 needs_write = true;
                 start_indent = trim_res.start_indent.map(Box::<[u8]>::from);
                 end_indent = trim_res.end_indent.map(Box::<[u8]>::from);
             } else {
-                runner.snapshots.failed += 1;
+                runner.snapshots.borrow_mut().failed += 1;
                 let signature = Self::get_signature(fn_name, "<green>expected<r>", false);
                 let diff_format = DiffFormatter::from_strings(&pretty_value, trim_res.trimmed, false);
                 return throw!(this, global_this, signature, "\n\n{}\n", diff_format);
@@ -1080,18 +1051,15 @@ impl Expect {
                     );
                 }
             }
-            let Some(buntest_strong) = this.bun_test() else {
+            let Some(buntest) = this.bun_test() else {
                 let signature = Self::get_signature(fn_name, "", false);
                 return throw!(this, global_this, signature, "\n\n<b>Matcher error<r>: Snapshot matchers cannot be used outside of a test\n");
             };
-            let buntest = buntest_strong.get();
 
             // 1. find the src loc of the snapshot
             let srcloc = call_frame.get_caller_src_loc(global_this);
             let file_id = buntest.file_id;
-            // MultiArrayList::get requires MultiArrayElement (derive pending);
-            // use the column accessor which already compiles in jest.rs.
-            let fget_source_path_text = runner.files.items_source()[file_id as usize].path.text;
+            let fget_source_path_text = runner.file_path(file_id).text;
 
             if !srcloc.str.eql_utf8(fget_source_path_text) {
                 let signature = Self::get_signature(fn_name, "", false);
@@ -1106,16 +1074,19 @@ impl Expect {
             }
 
             // 2. save to write later
-            runner.snapshots.add_inline_snapshot_to_write(file_id, super::snapshot::InlineSnapshotToWrite {
-                line: core::ffi::c_ulong::from(srcloc.line),
-                col: core::ffi::c_ulong::from(srcloc.column),
-                value: core::mem::take(&mut pretty_value).into_boxed_slice(),
-                has_matchers: property_matchers.is_some(),
-                is_added: result.is_none(),
-                kind: fn_name.as_bytes(),
-                start_indent,
-                end_indent,
-            })?;
+            runner.snapshots.borrow_mut().add_inline_snapshot_to_write(
+                file_id,
+                super::snapshot::InlineSnapshotToWrite {
+                    line: core::ffi::c_ulong::from(srcloc.line),
+                    col: core::ffi::c_ulong::from(srcloc.column),
+                    value: core::mem::take(&mut pretty_value).into_boxed_slice(),
+                    has_matchers: property_matchers.is_some(),
+                    is_added: result.is_none(),
+                    kind: fn_name.as_bytes(),
+                    start_indent,
+                    end_indent,
+                },
+            )?;
         }
 
         Ok(JSValue::UNDEFINED)
@@ -1165,15 +1136,27 @@ impl Expect {
         this.match_and_fmt_snapshot(global_this, value, property_matchers, &mut pretty_value, fn_name)?;
 
         let runner = Jest::runner().expect("unreachable");
-        let existing_value = match runner.snapshots.get_or_put(this, &pretty_value, hint) {
+        // Owned copy so no `snapshots` borrow is live while errors are formatted below.
+        let existing_value = {
+            let mut snapshots = runner.snapshots.borrow_mut();
+            match snapshots.get_or_put(this, &pretty_value, hint) {
+                Ok(v) => Ok(v.map(<[u8]>::to_vec)),
+                Err(crate::Error::SnapshotCreationNotAllowedInCI) => Err((
+                    crate::Error::SnapshotCreationNotAllowedInCI,
+                    snapshots.last_error_snapshot_name.take(),
+                )),
+                Err(err) => Err((err, None)),
+            }
+        };
+        let existing_value: Option<Vec<u8>> = match existing_value {
             Ok(v) => v,
-            Err(err) => {
-                let Some(buntest_strong) = this.bun_test() else {
-                    return Err(global_this.throw(format_args!("Snapshot matchers cannot be used outside of a test")));
+            Err((err, snapshot_name)) => {
+                let Some(buntest) = this.bun_test() else {
+                    return Err(global_this.throw(format_args!(
+                        "Snapshot matchers cannot be used outside of a test"
+                    )));
                 };
-                let buntest = buntest_strong.get();
-                // MultiArrayList::get requires MultiArrayElement (derive pending); use column accessor.
-                let test_file_path = runner.files.items_source()[buntest.file_id as usize].path.text;
+                let test_file_path = runner.file_path(buntest.file_id).text;
                 let test_file_path = bstr::BStr::new(test_file_path);
                 return Err(match err {
                     crate::Error::FailedToOpenSnapshotFile => {
@@ -1189,7 +1172,6 @@ impl Expect {
                         global_this.throw(format_args!("Failed to parse snapshot file for: {test_file_path}"))
                     }
                     crate::Error::SnapshotCreationNotAllowedInCI => {
-                        let snapshot_name = runner.snapshots.last_error_snapshot_name.take();
                         if let Some(name) = snapshot_name {
                             global_this.throw(format_args!(
                                 "Snapshot creation is disabled in CI environments unless --update-snapshots is used\nTo override, set the environment variable CI=false.\n\nSnapshot name: \"{}\"\nReceived: {}",
@@ -1218,15 +1200,12 @@ impl Expect {
         };
 
         if let Some(saved_value) = existing_value {
-            // clone to owned to release the &mut borrow on runner.snapshots
-            // before mutating passed/failed counters below.
-            let saved_value: Vec<u8> = saved_value.to_vec();
             if strings::eql_long(&pretty_value, &saved_value, true) {
-                runner.snapshots.passed += 1;
+                runner.snapshots.borrow_mut().passed += 1;
                 return Ok(JSValue::UNDEFINED);
             }
 
-            runner.snapshots.failed += 1;
+            runner.snapshots.borrow_mut().failed += 1;
             let signature = Self::get_signature(fn_name, "<green>expected<r>", false);
             let diff_format = DiffFormatter::from_strings(&pretty_value, &saved_value, false);
             return throw!(self, global_this, signature, "\n\n{}\n", diff_format);
@@ -1315,13 +1294,11 @@ impl Expect {
             ));
         }
 
-        // SAFETY: FFI call with valid &JSGlobalObject
-        let expect_proto = unsafe { Expect__getPrototype(global_this) };
+        let expect_proto = Expect__getPrototype(global_this);
         let expect_constructor = <Self as bun_jsc::JsClass>::get_constructor(global_this);
-        // SAFETY: FFI call with valid &JSGlobalObject
-        let expect_static_proto = unsafe { ExpectStatic__getPrototype(global_this) };
+        let expect_static_proto = ExpectStatic__getPrototype(global_this);
 
-        // SAFETY: already checked that args[0] is an object
+        // already checked that args[0] is an object
         let matchers_to_register = args[0].get_object().expect("unreachable");
         {
             let iter = JSPropertyIterator::init(
@@ -1354,31 +1331,11 @@ impl Expect {
                 // Even though they point to the same native functions for all matchers,
                 // multiple instances are created because each instance will hold the matcher_fn as a property
 
-                // `to_js_host_fn` returns an opaque closure, so emit an
-                // explicit C-ABI shim and pass its address.
-                bun_jsc::jsc_host_abi! {
-                    unsafe fn __apply_custom_matcher_shim(
-                        g: *mut bun_jsc::JSGlobalObject,
-                        f: *mut bun_jsc::CallFrame,
-                    ) -> JSValue {
-                        // SAFETY: JSC guarantees both pointers are live for the call.
-                        let (g, f) = unsafe { (&*g, &*f) };
-                        bun_jsc::to_js_host_fn_result(g, Expect::apply_custom_matcher(g, f))
-                    }
-                }
-                let host_fn_ptr: bun_jsc::JSHostFn = __apply_custom_matcher_shim;
-                // SAFETY: FFI call with valid global, &bun_core::String, host-fn ptr, and JSValue.
                 // C++ takes the function pointer **by value** (`NativeFunctionPtr`), not a
                 // pointer-to-function-pointer — `JSHostFn` already is the
                 // function-pointer type, so pass it directly.
-                let wrapper_fn = unsafe {
-                    Bun__JSWrappingFunction__create(
-                        global_this,
-                        &matcher_name,
-                        host_fn_ptr,
-                        matcher_fn,
-                    )
-                };
+                let wrapper_fn =
+                    Bun__JSWrappingFunction__create(global_this, &matcher_name, __jsc_host_apply_custom_matcher, matcher_fn);
 
                 expect_proto.put_may_be_index(global_this, &matcher_name, wrapper_fn)?;
                 expect_constructor.put_may_be_index(global_this, &matcher_name, wrapper_fn)?;
@@ -1541,15 +1498,13 @@ impl Expect {
 
         // try to retrieve the Expect instance
         let this_value: JSValue = call_frame.this();
-        let Some(expect_ptr) = Expect::from_js(this_value) else {
+        // R-2: shared borrow — `process_promise` below may re-enter JS (await on a
+        // thenable's user-defined `then`), which can call another matcher on this same
+        // `expect()` chain.
+        let Some(expect) = this_value.as_class_ref::<Expect>() else {
             // if no Expect instance, assume it is a static call (`expect.myMatcher()`), so create an ExpectCustomAsymmetricMatcher instance
             return ExpectCustomAsymmetricMatcher::create(global_this, call_frame, matcher_fn);
         };
-        // SAFETY: from_js returned a non-null live m_ctx pointer owned by the JS wrapper.
-        // R-2: deref as shared (`&*`) — `process_promise` below may re-enter JS (await on a
-        // thenable's user-defined `then`), which can call another matcher on this same
-        // `expect()` chain; aliased `&Expect` is sound, aliased `&mut Expect` is not.
-        let expect = unsafe { &*expect_ptr };
 
         // if we got an Expect instance, then it's a non-static call (`expect().myMatcher`),
         // so now execute the symmetric matching
@@ -1602,22 +1557,39 @@ impl Expect {
     pub(crate) fn add_snapshot_serializer(global_this: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue> {
         Self::not_implemented_static_fn(global_this, call_frame)
     }
+}
 
+/// `JSHostFn`-shaped entry (`__jsc_host_apply_custom_matcher`) for the
+/// `JSWrappingFunction` created per custom matcher in `Expect::extend`.
+#[bun_jsc::host_fn]
+fn apply_custom_matcher(global_this: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue> {
+    Expect::apply_custom_matcher(global_this, call_frame)
+}
+
+impl Expect {
     // extern shim emitted by `#[bun_jsc::JsClass]` codegen (TypeClass__construct/__call); bare `#[host_fn]` cannot target an associated fn without a receiver.
-    pub(crate) fn has_assertions(global_this: &JSGlobalObject, _call_frame: &CallFrame) -> JsResult<JSValue> {
-        // SAFETY: bun_vm() returns the live VM pointer for this global.
+    pub(crate) fn has_assertions(
+        global_this: &JSGlobalObject,
+        _call_frame: &CallFrame,
+    ) -> JsResult<JSValue> {
         let _gc = global_this.bun_vm().as_mut().auto_gc_on_drop();
 
-        let Some(buntest_strong) = bun_test::clone_active_strong() else {
-            return Err(global_this.throw(format_args!("expect.assertions() must be called within a test")));
+        let Some(buntest) = bun_test::clone_active_strong() else {
+            return Err(global_this.throw(format_args!(
+                "expect.assertions() must be called within a test"
+            )));
         };
-        let buntest = buntest_strong.get();
         let state_data = buntest.get_current_state_data();
-        let Some(execution) = state_data.sequence(buntest) else {
+        let Some(execution) = state_data.sequence(&buntest) else {
             return Err(global_this.throw(format_args!("expect.assertions() is not supported in the describe phase, in concurrent tests, between tests, or after test execution has completed")));
         };
-        if !matches!(execution.expect_assertions, ExpectAssertions::Exact(_)) {
-            execution.expect_assertions = ExpectAssertions::AtLeastOne;
+        if !matches!(
+            execution.expect_assertions.get(),
+            ExpectAssertions::Exact(_)
+        ) {
+            execution
+                .expect_assertions
+                .set(ExpectAssertions::AtLeastOne);
         }
 
         Ok(JSValue::UNDEFINED)
@@ -1660,15 +1632,18 @@ impl Expect {
 
         let unsigned_expected_assertions: u32 = expected_assertions as u32;
 
-        let Some(buntest_strong) = bun_test::clone_active_strong() else {
-            return Err(global_this.throw(format_args!("expect.assertions() must be called within a test")));
+        let Some(buntest) = bun_test::clone_active_strong() else {
+            return Err(global_this.throw(format_args!(
+                "expect.assertions() must be called within a test"
+            )));
         };
-        let buntest = buntest_strong.get();
         let state_data = buntest.get_current_state_data();
-        let Some(execution) = state_data.sequence(buntest) else {
+        let Some(execution) = state_data.sequence(&buntest) else {
             return Err(global_this.throw(format_args!("expect.assertions() is not supported in the describe phase, in concurrent tests, between tests, or after test execution has completed")));
         };
-        execution.expect_assertions = ExpectAssertions::Exact(unsigned_expected_assertions);
+        execution
+            .expect_assertions
+            .set(ExpectAssertions::Exact(unsigned_expected_assertions));
 
         Ok(JSValue::UNDEFINED)
     }
@@ -1868,7 +1843,9 @@ impl ExpectStatic {
         ))
     }
 
-    fn create_asymmetric_matcher_with_flags<T: AsymmetricMatcherClass + 'static>(
+    fn create_asymmetric_matcher_with_flags<
+        T: AsymmetricMatcherClass + bun_jsc::JsClass + 'static,
+    >(
         this: &Self,
         global_this: &JSGlobalObject,
         call_frame: &CallFrame,
@@ -1876,11 +1853,10 @@ impl ExpectStatic {
         //const this: *ExpectStatic = ExpectStatic.fromJS(callFrame.this());
         let instance_jsvalue = T::invoke(global_this, call_frame)?;
         if !instance_jsvalue.is_any_error() {
-            let Some(instance) = T::from_js_ptr(instance_jsvalue) else {
+            let Some(instance) = instance_jsvalue.as_class_ref::<T>() else {
                 return Err(global_this.throw_out_of_memory());
             };
-            // SAFETY: from_js_ptr returns the live m_ctx payload owned by instance_jsvalue.
-            unsafe { (*instance).flags_cell().set(this.flags) };
+            instance.flags_cell().set(this.flags);
         }
         Ok(instance_jsvalue)
     }
@@ -1927,7 +1903,6 @@ impl ExpectStatic {
 // inherent `fn call`.
 trait AsymmetricMatcherClass {
     fn invoke(global_this: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue>;
-    fn from_js_ptr(value: JSValue) -> Option<*mut Self>;
     /// R-2: each asymmetric-matcher payload exposes its `Cell<Flags>` so
     /// `ExpectStatic::create_asymmetric_matcher_with_flags` can patch it
     /// post-construction without forming `&mut Self`.
@@ -1941,10 +1916,6 @@ macro_rules! impl_asymmetric_matcher_class {
                 #[inline]
                 fn invoke(g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
                     <$t>::call(g, f)
-                }
-                #[inline]
-                fn from_js_ptr(value: JSValue) -> Option<*mut Self> {
-                    <$t as bun_jsc::JsClass>::from_js(value)
                 }
                 #[inline]
                 fn flags_cell(&self) -> &Cell<Flags> {
@@ -2515,9 +2486,8 @@ impl ExpectCustomAsymmetricMatcher {
     /// This will not run the matcher, but just capture the args etc.
     pub(crate) fn create(global_this: &JSGlobalObject, call_frame: &CallFrame, matcher_fn: JSValue) -> JsResult<JSValue> {
         // try to retrieve the ExpectStatic instance (to get the flags)
-        let flags = if let Some(expect_static) = <ExpectStatic as bun_jsc::JsClass>::from_js(call_frame.this()) {
-            // SAFETY: from_js returns the live m_ctx payload for this JSValue.
-            unsafe { (*expect_static).flags }
+        let flags = if let Some(expect_static) = call_frame.this().as_class_ref::<ExpectStatic>() {
+            expect_static.flags
         } else {
             // if it's not an ExpectStatic instance, assume it was called from the Expect constructor, so use the default flags
             Flags::default()
@@ -2583,22 +2553,6 @@ impl ExpectCustomAsymmetricMatcher {
         }
 
         Expect::execute_custom_matcher(global_this, &matcher_name, matcher_fn, &matcher_args, this.flags, true)
-    }
-
-    /// Function called by c++ function "matchAsymmetricMatcher" to execute the custom matcher against the provided leftValue
-    ///
-    /// # Safety
-    /// `this` must point to a live `Self` and `global_this` must point to a live
-    /// `JSGlobalObject` for the duration of the call.
-    #[unsafe(no_mangle)]
-    pub(crate) unsafe extern "C" fn ExpectCustomAsymmetricMatcher__execute(
-        this: *mut Self,
-        this_value: JSValue,
-        global_this: *const JSGlobalObject,
-        received: JSValue,
-    ) -> bool {
-        // SAFETY: called from C++ with valid pointers
-        unsafe { Self::execute_impl(&*this, this_value, &*global_this, received) }.unwrap_or(false)
     }
 
     #[bun_jsc::host_fn(method)]
@@ -2669,6 +2623,18 @@ impl ExpectCustomAsymmetricMatcher {
 
 }
 
+/// Function called by c++ function "matchAsymmetricMatcher" to execute the custom matcher against the provided leftValue
+// HOST_EXPORT(ExpectCustomAsymmetricMatcher__execute, c)
+pub fn expect_custom_asymmetric_matcher_execute(
+    this: &crate::test_runner::expect::ExpectCustomAsymmetricMatcher,
+    this_value: JSValue,
+    global_this: &JSGlobalObject,
+    received: JSValue,
+) -> bool {
+    ExpectCustomAsymmetricMatcher::execute_impl(this, this_value, global_this, received)
+        .unwrap_or(false)
+}
+
 /// Reference: `MatcherContext` in https://github.com/jestjs/jest/blob/main/packages/expect/src/types.ts
 #[bun_jsc::JsClass(no_construct, no_constructor)]
 pub struct ExpectMatcherContext {
@@ -2678,8 +2644,7 @@ pub struct ExpectMatcherContext {
 impl ExpectMatcherContext {
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_utils(_this: &Self, global_this: &JSGlobalObject) -> JSValue {
-        // SAFETY: FFI call with valid &JSGlobalObject
-        unsafe { ExpectMatcherUtils__getSingleton(global_this) }
+        ExpectMatcherUtils__getSingleton(global_this)
     }
 
     #[bun_jsc::host_fn(getter)]
@@ -2719,12 +2684,29 @@ impl ExpectMatcherContext {
 #[bun_jsc::JsClass(no_construct, no_constructor)]
 pub struct ExpectMatcherUtils {}
 
-impl ExpectMatcherUtils {
-    #[unsafe(no_mangle)]
-    pub(crate) extern "C" fn ExpectMatcherUtils_createSigleton(global_this: &JSGlobalObject) -> JSValue {
-        ExpectMatcherUtils {}.to_js(global_this)
-    }
+// HOST_EXPORT(ExpectMatcherUtils_createSigleton, c)
+pub fn expect_matcher_utils_create_singleton(global_this: &JSGlobalObject) -> JSValue {
+    ExpectMatcherUtils {}.to_js(global_this)
+}
 
+// HOST_EXPORT(Expect_readFlagsAndProcessPromise, c)
+pub fn expect_read_flags_and_process_promise(
+    instance_value: JSValue,
+    global_this: &JSGlobalObject,
+    out_flags: &mut u8,
+    value: &mut JSValue,
+    any_constructor_type: &mut u8,
+) -> bool {
+    Expect::read_flags_and_process_promise(
+        instance_value,
+        global_this,
+        out_flags,
+        value,
+        any_constructor_type,
+    )
+}
+
+impl ExpectMatcherUtils {
     fn print_value(
         global_this: &JSGlobalObject,
         value: JSValue,
@@ -2899,9 +2881,9 @@ pub mod mock {
     // (UBSan: null `VM&` bind in JSGlobalObject.h).
     unsafe extern "C" {
         #[link_name = "JSMockFunction__getCalls"]
-        fn JSMockFunction__getCalls_raw(global: *mut JSGlobalObject, value: JSValue) -> JSValue;
+        safe fn JSMockFunction__getCalls_raw(global: &JSGlobalObject, value: JSValue) -> JSValue;
         #[link_name = "JSMockFunction__getReturns"]
-        fn JSMockFunction__getReturns_raw(global: *mut JSGlobalObject, value: JSValue) -> JSValue;
+        safe fn JSMockFunction__getReturns_raw(global: &JSGlobalObject, value: JSValue) -> JSValue;
     }
 
     /// `bun.cpp.JSMockFunction__getCalls` — returns the `mock.calls` array for a
@@ -2912,10 +2894,7 @@ pub mod mock {
     #[track_caller]
     #[inline]
     fn JSMockFunction__getCalls(global: &JSGlobalObject, value: JSValue) -> JsResult<JSValue> {
-        // SAFETY: `global` is live; JSValue is repr(transparent) i64.
-        bun_jsc::call_zero_is_throw(global, || unsafe {
-            JSMockFunction__getCalls_raw(global.as_ptr(), value)
-        })
+        bun_jsc::call_zero_is_throw(global, || JSMockFunction__getCalls_raw(global, value))
     }
 
     /// `bun.cpp.JSMockFunction__getReturns` — see `JSMockFunction__getCalls`.
@@ -2923,10 +2902,7 @@ pub mod mock {
     #[track_caller]
     #[inline]
     fn JSMockFunction__getReturns(global: &JSGlobalObject, value: JSValue) -> JsResult<JSValue> {
-        // SAFETY: `global` is live; JSValue is repr(transparent) i64.
-        bun_jsc::call_zero_is_throw(global, || unsafe {
-            JSMockFunction__getReturns_raw(global.as_ptr(), value)
-        })
+        bun_jsc::call_zero_is_throw(global, || JSMockFunction__getReturns_raw(global, value))
     }
 
     /// Which mock-backed array a `toHave*` matcher inspects, plus which of the two
@@ -3159,30 +3135,36 @@ pub mod mock {
 // Extract the matcher_fn from a JSCustomExpectMatcherFunction instance
 #[inline]
 fn get_custom_matcher_fn(this_value: JSValue, global_this: &JSGlobalObject) -> Option<JSValue> {
-    // SAFETY: FFI call with valid JSValue and &JSGlobalObject
-    let matcher_fn = unsafe { Bun__JSWrappingFunction__getWrappedFunction(this_value, global_this) };
-    if matcher_fn.is_empty() { None } else { Some(matcher_fn) }
+    let matcher_fn = Bun__JSWrappingFunction__getWrappedFunction(this_value, global_this);
+    if matcher_fn.is_empty() {
+        None
+    } else {
+        Some(matcher_fn)
+    }
 }
 
 unsafe extern "C" {
-    fn Bun__JSWrappingFunction__create(
-        global_this: *const JSGlobalObject,
+    safe fn Bun__JSWrappingFunction__create(
+        global_this: &JSGlobalObject,
         symbol_name: &bun_core::String,
         // C++: `Bun::NativeFunctionPtr` — a bare `EncodedJSValue (*)(JSGlobalObject*, CallFrame*)`.
         // Rust's `JSHostFn` is already the pointer type, so no extra `*const`.
         function_pointer: bun_jsc::JSHostFn,
         wrapped_fn: JSValue,
     ) -> JSValue;
-    fn Bun__JSWrappingFunction__getWrappedFunction(this: JSValue, global_this: *const JSGlobalObject) -> JSValue;
+    safe fn Bun__JSWrappingFunction__getWrappedFunction(
+        this: JSValue,
+        global_this: &JSGlobalObject,
+    ) -> JSValue;
 
-    fn ExpectMatcherUtils__getSingleton(global_this: *const JSGlobalObject) -> JSValue;
+    safe fn ExpectMatcherUtils__getSingleton(global_this: &JSGlobalObject) -> JSValue;
 
-    fn Expect__getPrototype(global_this: *const JSGlobalObject) -> JSValue;
-    fn ExpectStatic__getPrototype(global_this: *const JSGlobalObject) -> JSValue;
+    safe fn Expect__getPrototype(global_this: &JSGlobalObject) -> JSValue;
+    safe fn ExpectStatic__getPrototype(global_this: &JSGlobalObject) -> JSValue;
 }
 
-// Exports: handled by #[unsafe(no_mangle)] on:
-//   ExpectMatcherUtils_createSigleton, Expect_readFlagsAndProcessPromise, ExpectCustomAsymmetricMatcher__execute
+// Exports: `HOST_EXPORT` markers on `read_flags_and_process_promise`,
+// `expect_custom_asymmetric_matcher_execute`, `expect_matcher_utils_create_singleton`.
 
 #[cfg(test)]
 mod tests {

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1575,12 +1575,12 @@ impl Expect {
 
         let Some(buntest) = bun_test::clone_active_strong() else {
             return Err(global_this.throw(format_args!(
-                "expect.assertions() must be called within a test"
+                "expect.hasAssertions() must be called within a test"
             )));
         };
         let state_data = buntest.get_current_state_data();
         let Some(execution) = state_data.sequence(&buntest) else {
-            return Err(global_this.throw(format_args!("expect.assertions() is not supported in the describe phase, in concurrent tests, between tests, or after test execution has completed")));
+            return Err(global_this.throw(format_args!("expect.hasAssertions() is not supported in the describe phase, in concurrent tests, between tests, or after test execution has completed")));
         };
         if !matches!(
             execution.expect_assertions.get(),

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -11,7 +11,6 @@ use bun_jsc::{JsClass as _, StringJsc as _};
 use bun_jsc::js_promise;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_core::strings;
-use bun_ptr::RefPtr;
 
 use super::bun_test::{self};
 use super::diff_format::DiffFormatter;
@@ -38,7 +37,7 @@ use bun_jsc::js_error_to_write_error;
 #[bun_jsc::JsClass]
 pub struct Expect {
     pub(crate) flags: Cell<Flags>,
-    pub(crate) parent: Option<RefPtr<bun_test::RefData>>,
+    pub(crate) parent: Option<bun_test::RefDataPtr>,
     pub(crate) custom_label: bun_core::String,
 }
 

--- a/src/runtime/test_runner/expect/toBeEmpty.rs
+++ b/src/runtime/test_runner/expect/toBeEmpty.rs
@@ -1,6 +1,6 @@
-use core::ffi::c_void;
-
-use bun_jsc::{CallFrame, JSGlobalObject, JSPropertyIterator, JSPropertyIteratorOptions, JSValue, JsResult, VM};
+use bun_jsc::{
+    CallFrame, JSGlobalObject, JSPropertyIterator, JSPropertyIteratorOptions, JSValue, JsResult,
+};
 
 use super::{throw, Expect};
 
@@ -22,22 +22,7 @@ pub(crate) fn to_be_empty(
         if value.js_type_loose().is_object() {
             if value.is_iterable(global)? {
                 let mut any_properties_in_iterator = false;
-
-                extern "C" fn anything_in_iterator(
-                    _: *mut VM,
-                    _: &JSGlobalObject,
-                    any_: *mut c_void,
-                    _: JSValue,
-                ) {
-                    // SAFETY: `any_` is the `&mut bool` passed to `for_each` below.
-                    unsafe { *any_.cast::<bool>() = true };
-                }
-
-                value.for_each(
-                    global,
-                    (&raw mut any_properties_in_iterator).cast::<c_void>(),
-                    anything_in_iterator,
-                )?;
+                value.for_each_iter(global, |_, _| any_properties_in_iterator = true)?;
                 pass = !any_properties_in_iterator;
             } else {
                 let Some(_cell) = value.to_cell() else {

--- a/src/runtime/test_runner/expect/toBeOneOf.rs
+++ b/src/runtime/test_runner/expect/toBeOneOf.rs
@@ -1,34 +1,8 @@
-use core::ffi::c_void;
-
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, VM};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::Expect;
 use super::get_signature;
 use super::throw;
-
-struct ExpectedEntry<'a> {
-    global_this: &'a JSGlobalObject,
-    expected: JSValue,
-    pass: &'a mut bool,
-}
-
-extern "C" fn same_value_iterator(
-    _: *mut VM,
-    _: &JSGlobalObject,
-    entry_: *mut c_void,
-    item: JSValue,
-) {
-    // SAFETY: entry_ is &mut ExpectedEntry passed through forEach's opaque ctx; non-null for the duration of the iteration.
-    let entry = unsafe { bun_ptr::callback_ctx::<ExpectedEntry<'_>>(entry_) };
-    // Confusingly, jest-extended uses `deepEqual`, instead of `toBe`
-    let Ok(eq) = item.jest_deep_equals(entry.expected, entry.global_this) else {
-        return;
-    };
-    if eq {
-        *entry.pass = true;
-        // PERF: break out of the `forEach` when a match is found
-    }
-}
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -59,16 +33,16 @@ pub(crate) fn to_be_one_of(
             }
         }
     } else if list_value.is_iterable(global_this)? {
-        let mut expected_entry = ExpectedEntry {
-            global_this,
-            expected,
-            pass: &mut pass,
-        };
-        list_value.for_each(
-            global_this,
-            (&raw mut expected_entry).cast::<c_void>(),
-            same_value_iterator,
-        )?;
+        list_value.for_each_iter(global_this, |global_this, item| {
+            // Confusingly, jest-extended uses `deepEqual`, instead of `toBe`
+            let Ok(eq) = item.jest_deep_equals(expected, global_this) else {
+                return;
+            };
+            if eq {
+                pass = true;
+                // PERF: break out of the `forEach` when a match is found
+            }
+        })?;
     } else {
         return Err(global_this.throw(format_args!(
             "Received value must be an array type, or both received and expected values must be strings."

--- a/src/runtime/test_runner/expect/toContain.rs
+++ b/src/runtime/test_runner/expect/toContain.rs
@@ -1,7 +1,5 @@
-use core::ffi::c_void;
-
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, VM};
 use bun_core::strings;
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::Expect;
 use super::get_signature;
@@ -27,14 +25,6 @@ impl Expect {
         expected.ensure_still_alive();
         let mut pass = false;
 
-        // FFI/BACKREF: erased to *mut c_void for for_each userdata; raw ptrs
-        // avoid a struct lifetime param.
-        struct ExpectedEntry {
-            global: *const JSGlobalObject,
-            expected: JSValue,
-            pass: *mut bool,
-        }
-
         // Jest's toContain uses `===` (Array.prototype.indexOf), not Object.is:
         // `[-0]` contains `0`, `[NaN]` does not contain `NaN`.
         if value.js_type_loose().is_array_like() {
@@ -59,41 +49,15 @@ impl Expect {
                 pass = true;
             }
         } else if value.is_iterable(global)? {
-            let mut expected_entry = ExpectedEntry {
-                global: std::ptr::from_ref(global),
-                expected,
-                pass: &raw mut pass,
-            };
-
-            extern "C" fn strict_equal_iterator(
-                _: *mut VM,
-                _: &JSGlobalObject,
-                entry_: *mut c_void,
-                item: JSValue,
-            ) {
-                debug_assert!(!entry_.is_null());
-                // SAFETY: entry_ is &mut ExpectedEntry on the caller's stack, threaded through
-                // for_each as opaque userdata; non-null asserted above.
-                let entry = unsafe { bun_ptr::callback_ctx::<ExpectedEntry>(entry_) };
-                // SAFETY: entry.global was set from `std::ptr::from_ref(global)` on the caller's
-                // stack frame, which outlives the synchronous for_each this callback runs inside.
-                let global = unsafe { &*entry.global };
-                let Ok(same) = item.is_strict_equal(entry.expected, global) else {
+            value.for_each_iter(global, |global, item| {
+                let Ok(same) = item.is_strict_equal(expected, global) else {
                     return;
                 };
                 if same {
-                    // SAFETY: entry.pass is `&raw mut pass` on the caller's stack, live for the
-                    // duration of for_each; this callback is the sole writer (no aliasing &mut).
-                    unsafe { *entry.pass = true };
+                    pass = true;
                     // TODO(perf): break out of the `forEach` when a match is found
                 }
-            }
-
-            value.for_each(
-                global,
-                (&raw mut expected_entry).cast::<c_void>(),
-                strict_equal_iterator,
-            )?;
+            })?;
         } else {
             return Err(global.throw(format_args!(
                 "Received value must be an array type, or both received and expected values must be strings."

--- a/src/runtime/test_runner/expect/toContainEqual.rs
+++ b/src/runtime/test_runner/expect/toContainEqual.rs
@@ -1,32 +1,7 @@
-use core::ffi::c_void;
-
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, VM};
 use bun_core::strings;
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 use super::{get_signature, throw, Expect};
-
-struct ExpectedEntry<'a> {
-    global_this: &'a JSGlobalObject,
-    expected: JSValue,
-    pass: &'a mut bool,
-}
-
-extern "C" fn deep_equals_iterator(
-    _: *mut VM,
-    _: &JSGlobalObject,
-    entry_: *mut c_void,
-    item: JSValue,
-) {
-    // SAFETY: `entry_` is `&mut ExpectedEntry` passed through `for_each` below; non-null by contract.
-    let entry = unsafe { bun_ptr::callback_ctx::<ExpectedEntry<'_>>(entry_) };
-    let Ok(eq) = item.jest_deep_equals(entry.expected, entry.global_this) else {
-        return;
-    };
-    if eq {
-        *entry.pass = true;
-        // PERF: break out of the `forEach` when a match is found
-    }
-}
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
 // `__forward_matcher!` macro in expect.rs, where the JsClass codegen host_fn shim picks it up.
@@ -80,16 +55,15 @@ pub(crate) fn to_contain_equal(
             };
         }
     } else if value.is_iterable(global)? {
-        let mut expected_entry = ExpectedEntry {
-            global_this: global,
-            expected,
-            pass: &mut pass,
-        };
-        value.for_each(
-            global,
-            (&raw mut expected_entry).cast::<c_void>(),
-            deep_equals_iterator,
-        )?;
+        value.for_each_iter(global, |global, item| {
+            let Ok(eq) = item.jest_deep_equals(expected, global) else {
+                return;
+            };
+            if eq {
+                pass = true;
+                // PERF: break out of the `forEach` when a match is found
+            }
+        })?;
     } else {
         return Err(global.throw(format_args!(
             "Received value must be an array type, or both received and expected values must be strings."

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -1,16 +1,14 @@
-use core::ptr::NonNull;
+use core::cell::{Cell, RefCell};
 use std::io::Write as _;
 
 use crate::cli::command::TestOptions;
 use crate::cli::test_command::CommandLineReporter;
+use crate::timer::ElTimespec;
 use bun_collections::{ArrayHashMap, MultiArrayList};
 use bun_core::Output;
 use bun_jsc::bun_string_jsc;
 use bun_jsc::virtual_machine::VirtualMachine;
-use bun_jsc::{
-    self as jsc, CallFrame, JSGlobalObject, JSValue, JsClass as _, JsResult, RegularExpression,
-};
-use crate::timer::ElTimespec;
+use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsResult, RegularExpression};
 
 pub use super::bun_test;
 use super::expect::{Expect, ExpectTypeOf};
@@ -41,9 +39,9 @@ impl CurrentFile {
         prefix: &[u8],
         repeat_count: u32,
         repeat_index: u32,
-        reporter: &mut CommandLineReporter,
+        reporter: &CommandLineReporter,
     ) {
-        if reporter.worker_ipc_file_idx.is_some() {
+        if reporter.worker_ipc_file_idx.get().is_some() {
             // Coordinator owns the terminal and prints its own per-test file
             // context; the worker should not emit a header to stderr.
             self.has_printed_filename = true;
@@ -84,11 +82,7 @@ impl CurrentFile {
                 );
             }
         } else {
-            bun_core::pretty_errorln!(
-                "{}{}:\n",
-                bstr::BStr::new(prefix),
-                bstr::BStr::new(title)
-            );
+            bun_core::pretty_errorln!("{}{}:\n", bstr::BStr::new(prefix), bstr::BStr::new(title));
         }
 
         Output::flush();
@@ -109,11 +103,15 @@ impl CurrentFile {
     }
 }
 
+/// Per-process `bun test` state. Leaked for the process lifetime by
+/// `test_command::exec` (as part of `CommandLineReporter`) and reached from JS
+/// host functions through [`Jest::runner`], so it is `&self`-only; everything
+/// mutated after registration is a `Cell`/`RefCell`.
 pub struct TestRunner<'a> {
-    pub(crate) current_file: CurrentFile,
-    pub(crate) files: FileList,
-    pub(crate) index: FileMap,
-    pub(crate) only: bool,
+    pub(crate) current_file: RefCell<CurrentFile>,
+    pub(crate) files: RefCell<FileList>,
+    pub(crate) index: RefCell<FileMap>,
+    pub(crate) only: Cell<bool>,
     pub(crate) run_todo: bool,
     pub(crate) concurrent: bool,
     /// The --seed value when --randomize is on. Used to derive a per-file
@@ -127,49 +125,52 @@ pub struct TestRunner<'a> {
     pub(crate) bail: u32,
     pub(crate) max_concurrency: u32,
 
-    pub(crate) snapshots: Snapshots,
+    pub(crate) snapshots: RefCell<Snapshots>,
 
     pub(crate) default_timeout_ms: u32,
 
     /// from `setDefaultTimeout() or jest.setTimeout()`. maxInt(u32) means override not set.
-    pub(crate) default_timeout_override: u32,
+    pub(crate) default_timeout_override: Cell<u32>,
 
     pub(crate) test_options: &'a TestOptions,
 
-    /// Used for --test-name-pattern to reduce allocations.
-    /// Raw `*mut` because `RegularExpression::matches` mutates its internal
-    /// cursor through C++ — storing `&'a RegularExpression` and casting back to
-    /// `*mut` at the use site would launder shared provenance into a write (UB).
+    /// Used for --test-name-pattern to reduce allocations. An `opaque_ffi!`
+    /// Yarr handle owned by the CLI context for the process lifetime.
     pub(crate) filter_regex: Option<core::ptr::NonNull<RegularExpression>>,
 
-    pub(crate) unhandled_errors_between_tests: u32,
-    pub(crate) summary: Summary,
+    pub(crate) unhandled_errors_between_tests: Cell<u32>,
+    pub(crate) summary: RefCell<Summary>,
 
     /// Set once any `node:test` registration API is called; gates `process.on('exit')` dispatch at the end of the run.
-    pub(crate) node_test_used: bool,
+    pub(crate) node_test_used: Cell<bool>,
 
     pub(crate) bun_test_root: bun_test::BunTestRoot,
 }
 
 impl<'a> TestRunner<'a> {
+    /// The registered source path for `file_id`.
+    pub(crate) fn file_path(&self, file_id: FileId) -> bun_paths::fs::Path<'static> {
+        self.files.borrow().items_source()[file_id as usize].path
+    }
+
     pub(crate) fn get_active_timeout(&self) -> bun_core::Timespec {
-        let Some(active_file) = self.bun_test_root.active_file.as_deref() else {
+        let Some(active_file) = self.bun_test_root.clone_active_file() else {
             return bun_core::Timespec::EPOCH;
         };
         // Per-entry deadline, not the (only-advances-sooner) file timer.
         // `on_stack_entry` pins the caller when still synchronously on stack;
         // else take the latest running entry so a sibling never terminates early.
         if let Some(entry) = active_file.execution.on_stack_entry.get() {
-            // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
-            return unsafe { entry.as_ref() }.timespec;
+            return active_file.execution.timespec_of(entry);
         }
-        if active_file.phase == bun_test::Phase::Execution {
-            if let Some(group) = active_file.execution.active_group_ref() {
+        if active_file.phase.get() == bun_test::Phase::Execution {
+            if let Some(group) = active_file.execution.active_group() {
                 let mut latest: Option<bun_core::Timespec> = None;
-                for seq in group.sequences_const(&active_file.execution) {
-                    let Some(entry) = seq.active_entry else { continue };
-                    // SAFETY: arena-owned entry, alive for the lifetime of BunTest.
-                    let ts = unsafe { entry.as_ref() }.timespec;
+                for seq in group.sequences(&active_file.execution) {
+                    let Some(entry) = seq.active_entry.get() else {
+                        continue;
+                    };
+                    let ts = active_file.execution.timespec_of(entry);
                     if latest.is_none_or(|l| ts.order(&l) == core::cmp::Ordering::Greater) {
                         latest = Some(ts);
                     }
@@ -179,8 +180,8 @@ impl<'a> TestRunner<'a> {
                 }
             }
         }
-        if active_file.timer.state != TimerState::ACTIVE
-            || active_file.timer.next == ElTimespec::EPOCH
+        if active_file.timer_state() != TimerState::ACTIVE
+            || active_file.timer_next() == ElTimespec::EPOCH
         {
             return bun_core::Timespec::EPOCH;
         }
@@ -188,27 +189,25 @@ impl<'a> TestRunner<'a> {
         // same `{sec, nsec}` shape as bun_core::Timespec; convert by field
         // until the lower tier unifies on bun_core::Timespec (see
         // src/runtime/timer/mod.rs ElTimespec alias).
-        bun_core::Timespec { sec: active_file.timer.next.sec, nsec: active_file.timer.next.nsec }
+        let next = active_file.timer_next();
+        bun_core::Timespec {
+            sec: next.sec,
+            nsec: next.nsec,
+        }
     }
 
-    pub(crate) fn remove_active_timeout(&mut self, vm: &mut VirtualMachine) {
-        let Some(active_file) = self.bun_test_root.active_file.as_ref() else {
+    pub(crate) fn remove_active_timeout(&self, vm: &mut VirtualMachine) {
+        let Some(active_file) = self.bun_test_root.clone_active_file() else {
             return;
         };
-        // SAFETY: single-threaded JS VM; only borrow of this BunTest for the
-        // duration of the timer-removal below. The const→mut projection is
-        // centralized in `buntest_as_mut` pending the BunTestPtr interior-mut
-        // reshape (see bun_test.rs).
-        let active_file = unsafe { bun_test::buntest_as_mut(active_file) };
-        if active_file.timer.state != TimerState::ACTIVE
-            || active_file.timer.next == ElTimespec::EPOCH
+        if active_file.timer_state() != TimerState::ACTIVE
+            || active_file.timer_next() == ElTimespec::EPOCH
         {
             return;
         }
         let _ = vm;
-        bun_test::vm_timer().remove(&raw mut active_file.timer);
+        active_file.remove_timer();
     }
-
 
     pub(crate) fn should_file_run_concurrently(&self, file_id: FileId) -> bool {
         // Check if global concurrent flag is set
@@ -222,10 +221,10 @@ impl<'a> TestRunner<'a> {
         };
 
         // Get the file path from the file_id
-        if file_id as usize >= self.files.len() {
+        if file_id as usize >= self.files.borrow().len() {
             return false;
         }
-        let file_path = self.files.items_source()[file_id as usize].path.text();
+        let file_path = self.file_path(file_id).text;
 
         // Check if the file path matches any of the glob patterns
         for pattern in glob_patterns {
@@ -236,15 +235,17 @@ impl<'a> TestRunner<'a> {
         false
     }
 
-    pub(crate) fn get_or_put_file(&mut self, file_path: &'static [u8]) -> GetOrPutFileResult {
-        let entry = self.index.get_or_put(file_path).expect("unreachable");
+    pub(crate) fn get_or_put_file(&self, file_path: &'static [u8]) -> GetOrPutFileResult {
+        let mut index = self.index.borrow_mut();
+        let entry = index.get_or_put(file_path).expect("unreachable");
         if entry.found_existing {
             return GetOrPutFileResult {
                 file_id: *entry.value_ptr,
             };
         }
-        let file_id = self.files.len() as FileId;
-        self.files
+        let mut files = self.files.borrow_mut();
+        let file_id = files.len() as FileId;
+        files
             .append(File {
                 source: bun_ast::Source::init_empty_file(file_path),
             })
@@ -296,41 +297,32 @@ bun_collections::multi_array_columns! {
 // allocation and distinct paths never alias.
 pub(crate) type FileMap = ArrayHashMap<&'static [u8], FileId>;
 
+// HOST_EXPORT(Bun__Jest__createTestModuleObject, c)
+pub fn create_test_module_object(global_object: &JSGlobalObject) -> JSValue {
+    match Jest::create_test_module(global_object) {
+        Ok(v) => v,
+        Err(_) => JSValue::ZERO,
+    }
+}
+
 #[allow(non_snake_case)]
 pub mod Jest {
     use super::*;
 
-    // JS-VM-thread-only singleton; RacyCell
-    // over `Option<NonNull<_>>` so direct `.read()` projections in
-    // `snapshot.rs` etc. keep their shape.
-    pub(crate) static RUNNER: bun_core::RacyCell<Option<NonNull<TestRunner<'static>>>> =
-        bun_core::RacyCell::new(None);
+    /// The registered runner; bound to the thread that runs `bun test`
+    /// (`test_command::exec`), so Workers and other threads see `None`.
+    static RUNNER: bun_core::ThreadBound<&'static TestRunner<'static>> =
+        bun_core::ThreadBound::new();
 
-    pub(crate) fn runner() -> Option<&'static mut TestRunner<'static>> {
-        // SAFETY: RUNNER is only ever accessed from the single JS VM thread.
-        unsafe { RUNNER.read().map(|p| &mut *p.as_ptr()) }
+    pub(crate) fn runner() -> Option<&'static TestRunner<'static>> {
+        RUNNER.get()
     }
 
-    /// Raw-pointer accessor for callers that must not materialise
-    /// an exclusive `&mut TestRunner` because a sub-borrow of it (e.g.
-    /// `&BunTestRoot`, `&mut BunTest`) is already live — see
-    /// `BunTestRoot::on_before_print` / `BunTest::enter_file`.
-    pub(crate) fn runner_ptr() -> Option<NonNull<TestRunner<'static>>> {
-        // SAFETY: RUNNER is only ever accessed from the single JS VM thread.
-        unsafe { RUNNER.read() }
+    pub(crate) fn set_runner(runner: Option<&'static TestRunner<'static>>) {
+        RUNNER.set(runner);
     }
 
-    #[unsafe(no_mangle)]
-    extern "C" fn Bun__Jest__createTestModuleObject(
-        global_object: &JSGlobalObject,
-    ) -> JSValue {
-        match create_test_module(global_object) {
-            Ok(v) => v,
-            Err(_) => JSValue::ZERO,
-        }
-    }
-
-    fn create_test_module(global_object: &JSGlobalObject) -> JsResult<JSValue> {
+    pub(super) fn create_test_module(global_object: &JSGlobalObject) -> JsResult<JSValue> {
         let module = JSValue::create_empty_object(global_object, 23);
 
         let test_scope_functions = create_bound(
@@ -376,35 +368,79 @@ pub mod Jest {
         module.put(
             global_object,
             b"beforeEach",
-            jsc::JSFunction::create(global_object, "beforeEach", generic_hook::__jsc_host_before_each, 1, Default::default()),
+            jsc::JSFunction::create(
+                global_object,
+                "beforeEach",
+                generic_hook::__jsc_host_before_each,
+                1,
+                Default::default(),
+            ),
         );
         module.put(
             global_object,
             b"beforeAll",
-            jsc::JSFunction::create(global_object, "beforeAll", generic_hook::__jsc_host_before_all, 1, Default::default()),
+            jsc::JSFunction::create(
+                global_object,
+                "beforeAll",
+                generic_hook::__jsc_host_before_all,
+                1,
+                Default::default(),
+            ),
         );
         module.put(
             global_object,
             b"afterAll",
-            jsc::JSFunction::create(global_object, "afterAll", generic_hook::__jsc_host_after_all, 1, Default::default()),
+            jsc::JSFunction::create(
+                global_object,
+                "afterAll",
+                generic_hook::__jsc_host_after_all,
+                1,
+                Default::default(),
+            ),
         );
         module.put(
             global_object,
             b"afterEach",
-            jsc::JSFunction::create(global_object, "afterEach", generic_hook::__jsc_host_after_each, 1, Default::default()),
+            jsc::JSFunction::create(
+                global_object,
+                "afterEach",
+                generic_hook::__jsc_host_after_each,
+                1,
+                Default::default(),
+            ),
         );
         module.put(
             global_object,
             b"onTestFinished",
-            jsc::JSFunction::create(global_object, "onTestFinished", generic_hook::__jsc_host_on_test_finished, 1, Default::default()),
+            jsc::JSFunction::create(
+                global_object,
+                "onTestFinished",
+                generic_hook::__jsc_host_on_test_finished,
+                1,
+                Default::default(),
+            ),
         );
         module.put(
             global_object,
             b"setDefaultTimeout",
-            jsc::JSFunction::create(global_object, "setDefaultTimeout", __jsc_host_js_set_default_timeout, 1, Default::default()),
+            jsc::JSFunction::create(
+                global_object,
+                "setDefaultTimeout",
+                __jsc_host_js_set_default_timeout,
+                1,
+                Default::default(),
+            ),
         );
-        module.put(global_object, b"expect", jsc::codegen::js::get_constructor::<Expect>(global_object));
-        module.put(global_object, b"expectTypeOf", jsc::codegen::js::get_constructor::<ExpectTypeOf>(global_object));
+        module.put(
+            global_object,
+            b"expect",
+            jsc::codegen::js::get_constructor::<Expect>(global_object),
+        );
+        module.put(
+            global_object,
+            b"expectTypeOf",
+            jsc::codegen::js::get_constructor::<ExpectTypeOf>(global_object),
+        );
 
         // will add more 9 properties in the module here so we need to allocate 23 properties
         create_mock_objects(global_object, module);
@@ -413,15 +449,52 @@ pub mod Jest {
     }
 
     fn create_mock_objects(global_object: &JSGlobalObject, module: JSValue) {
-        let set_system_time = jsc::JSFunction::create(global_object, "setSystemTime", JSMock__jsSetSystemTime, 0, Default::default());
+        let set_system_time = jsc::JSFunction::create(
+            global_object,
+            "setSystemTime",
+            JSMock__jsSetSystemTime,
+            0,
+            Default::default(),
+        );
         module.put(global_object, b"setSystemTime", set_system_time);
 
-        let mock_fn = jsc::JSFunction::create(global_object, "fn", JSMock__jsMockFn, 1, Default::default());
-        let spy_on = jsc::JSFunction::create(global_object, "spyOn", JSMock__jsSpyOn, 2, Default::default());
-        let restore_all_mocks = jsc::JSFunction::create(global_object, "restoreAllMocks", JSMock__jsRestoreAllMocks, 2, Default::default());
-        let clear_all_mocks = jsc::JSFunction::create(global_object, "clearAllMocks", JSMock__jsClearAllMocks, 2, Default::default());
-        let reset_all_mocks = jsc::JSFunction::create(global_object, "resetAllMocks", JSMock__jsResetAllMocks, 2, Default::default());
-        let mock_module_fn = jsc::JSFunction::create(global_object, "module", JSMock__jsModuleMock, 2, Default::default());
+        let mock_fn =
+            jsc::JSFunction::create(global_object, "fn", JSMock__jsMockFn, 1, Default::default());
+        let spy_on = jsc::JSFunction::create(
+            global_object,
+            "spyOn",
+            JSMock__jsSpyOn,
+            2,
+            Default::default(),
+        );
+        let restore_all_mocks = jsc::JSFunction::create(
+            global_object,
+            "restoreAllMocks",
+            JSMock__jsRestoreAllMocks,
+            2,
+            Default::default(),
+        );
+        let clear_all_mocks = jsc::JSFunction::create(
+            global_object,
+            "clearAllMocks",
+            JSMock__jsClearAllMocks,
+            2,
+            Default::default(),
+        );
+        let reset_all_mocks = jsc::JSFunction::create(
+            global_object,
+            "resetAllMocks",
+            JSMock__jsResetAllMocks,
+            2,
+            Default::default(),
+        );
+        let mock_module_fn = jsc::JSFunction::create(
+            global_object,
+            "module",
+            JSMock__jsModuleMock,
+            2,
+            Default::default(),
+        );
         module.put(global_object, b"mock", mock_fn);
         mock_fn.put(global_object, b"module", mock_module_fn);
         mock_fn.put(global_object, b"restore", restore_all_mocks);
@@ -435,12 +508,30 @@ pub mod Jest {
         jest.put(global_object, b"clearAllMocks", clear_all_mocks);
         jest.put(global_object, b"resetAllMocks", reset_all_mocks);
         jest.put(global_object, b"setSystemTime", set_system_time);
-        jest.put(global_object, b"now", jsc::JSFunction::create(global_object, "now", JSMock__jsNow, 0, Default::default()));
-        jest.put(global_object, b"setTimeout", jsc::JSFunction::create(global_object, "setTimeout", __jsc_host_js_set_default_timeout, 1, Default::default()));
+        jest.put(
+            global_object,
+            b"now",
+            jsc::JSFunction::create(global_object, "now", JSMock__jsNow, 0, Default::default()),
+        );
+        jest.put(
+            global_object,
+            b"setTimeout",
+            jsc::JSFunction::create(
+                global_object,
+                "setTimeout",
+                __jsc_host_js_set_default_timeout,
+                1,
+                Default::default(),
+            ),
+        );
 
         module.put(global_object, b"jest", jest);
         module.put(global_object, b"spyOn", spy_on);
-        module.put(global_object, b"expect", jsc::codegen::js::get_constructor::<Expect>(global_object));
+        module.put(
+            global_object,
+            b"expect",
+            jsc::codegen::js::get_constructor::<Expect>(global_object),
+        );
 
         let vi = JSValue::create_empty_object(global_object, 6 + fake_timers::TIMER_FNS_COUNT);
         vi.put(global_object, b"fn", mock_fn);
@@ -478,7 +569,9 @@ pub mod Jest {
             let arguments = callframe.arguments();
 
             if arguments.len() < 1 || !arguments[0].is_string() {
-                return Err(global_object.throw(format_args!("Bun.jest() expects a string filename")));
+                return Err(
+                    global_object.throw(format_args!("Bun.jest() expects a string filename"))
+                );
             }
             let str = arguments[0].to_utf8(global_object)?;
             let slice = str.slice();
@@ -501,14 +594,16 @@ pub mod Jest {
     ) -> JsResult<JSValue> {
         let arguments = callframe.arguments();
         if arguments.len() < 1 || !arguments[0].is_number() {
-            return Err(global_object.throw(format_args!("setTimeout() expects a number (milliseconds)")));
+            return Err(
+                global_object.throw(format_args!("setTimeout() expects a number (milliseconds)"))
+            );
         }
 
         let timeout_ms: u32 =
             u32::try_from(arguments[0].coerce::<i32>(global_object)?.max(0)).unwrap();
 
         if let Some(test_runner) = runner() {
-            test_runner.default_timeout_override = timeout_ms;
+            test_runner.default_timeout_override.set(timeout_ms);
         }
 
         Ok(JSValue::UNDEFINED)
@@ -521,15 +616,11 @@ pub(crate) fn js_file_generation(
     global: &JSGlobalObject,
     _callframe: &CallFrame,
 ) -> JsResult<JSValue> {
-    // `runner_ptr()` rather than `runner()`: node:test calls this on every test
-    // registration, and an exclusive `&mut TestRunner` would invalidate the
-    // `bun_test_root` pointer `test_command.rs` keeps live across the file run.
-    // SAFETY: same invariant as `runner()` — RUNNER is only read on the JS thread.
-    let generation = Jest::runner_ptr().map_or(0, |p| unsafe {
+    let generation = Jest::runner().map_or(0, |runner| {
         if global.bun_vm().worker_ref().is_none() {
-            (*p.as_ptr()).node_test_used = true;
+            runner.node_test_used.set(true);
         }
-        (*p.as_ptr()).bun_test_root.file_generation
+        runner.bun_test_root.file_generation.get()
     });
     Ok(JSValue::from(generation))
 }
@@ -547,27 +638,34 @@ pub(crate) fn js_node_test_mark_result(
     let Some(buntest_strong) = bun_test::clone_active_strong() else {
         return Ok(JSValue::UNDEFINED);
     };
-    // SAFETY: single-threaded JS VM; the strong is dropped before any re-borrow.
-    let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
+    let buntest: &bun_test::BunTest = &buntest_strong;
     // `done` is a JSBoundFunction whose bound-this is the DoneCallback wrapper.
     let wrapper = bun_jsc::cpp::Bun__JSBoundFunction__boundThis(done);
-    let Some(dcb) = bun_test::DoneCallback::from_js(wrapper) else {
+    let Some(dcb) = wrapper.as_class_ref::<bun_test::DoneCallback>() else {
         return Ok(JSValue::UNDEFINED);
     };
-    // SAFETY: `dcb` is the live `*mut DoneCallback` from `from_js`; single-
-    // threaded JS VM, GC roots `done` (and its bound-this) for this frame.
-    let (dcb_ref, dcb_called) = unsafe { ((*dcb).r#ref.as_deref(), (*dcb).called) };
-    let bound = match dcb_ref {
-        Some(refdata) => refdata.phase,
+    let dcb_ref = dcb.r#ref.take();
+    let dcb_phase = dcb_ref.as_ref().map(|r| r.phase.clone());
+    // A DoneCallback minted by an earlier file / `--rerun-each` iteration names
+    // indices into that file's execution, not this one's.
+    let stale = dcb_ref
+        .as_ref()
+        .is_some_and(|r| !r.bun_test().is_some_and(|b| std::rc::Rc::ptr_eq(&b, &buntest_strong)));
+    dcb.r#ref.set(dcb_ref);
+    if stale {
+        return Ok(JSValue::UNDEFINED);
+    }
+    let bound = match dcb_phase {
+        Some(phase) => phase,
         // `r#ref` unset: `.then()` fired inside run_test_callback's microtask
         // drain before it stamps the DoneCallback. `get_current_state_data()`
         // can't name a sequence inside a concurrent group, but
         // `on_stack_entry_data` holds exactly the `cfg_data` that
         // `run_test_callback` was invoked with (set/restored around it), so
         // the mark lands on the right sequence under --concurrent too.
-        None if !dcb_called => match buntest.execution.on_stack_entry_data.get() {
+        None if !dcb.called.get() => match buntest.execution.on_stack_entry_data.get() {
             Some(entry_data) => bun_test::RefDataValue::Execution {
-                group_index: buntest.execution.group_index,
+                group_index: buntest.execution.group_index.get(),
                 entry_data: Some(entry_data),
             },
             None => buntest.get_current_state_data(),
@@ -575,15 +673,18 @@ pub(crate) fn js_node_test_mark_result(
         // done() already ran and reported — nothing left to mark.
         None => return Ok(JSValue::UNDEFINED),
     };
-    let Some((sequence_ptr, _)) =
-        buntest.execution.get_current_and_valid_execution_sequence(&bound)
+    let Some((sequence, _)) = buntest
+        .execution
+        .get_current_and_valid_execution_sequence(&bound)
     else {
         return Ok(JSValue::UNDEFINED);
     };
-    // SAFETY: NonNull into `execution.sequences`; deref at point-of-use only.
-    let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
-    if sequence.result == ExecResult::Pending {
-        sequence.result = if mode.to_boolean() { ExecResult::Todo } else { ExecResult::Skip };
+    if sequence.result.get() == ExecResult::Pending {
+        sequence.result.set(if mode.to_boolean() {
+            ExecResult::Todo
+        } else {
+            ExecResult::Skip
+        });
     }
     Ok(JSValue::UNDEFINED)
 }
@@ -597,21 +698,15 @@ pub(crate) mod on_unhandled_rejection {
         rejection: JSValue,
     ) {
         if let Some(buntest_strong) = bun_test::clone_active_strong() {
-            // `buntest_strong` released by Rc drop.
-            // SAFETY: single-threaded JS VM; `buntest_strong` is the only handle
-            // dereferenced for this scope and is dropped before `BunTest::run`
-            // re-borrows. Const→mut projection is centralized in `buntest_as_mut`
-            // pending the BunTestPtr interior-mut reshape (see bun_test.rs).
-            let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
+            let buntest: &bun_test::BunTest = &buntest_strong;
             // mark unhandled errors as belonging to the currently active test. note that this can be misleading.
             let mut current_state_data = buntest.get_current_state_data();
-            // split entry()/sequence() borrows via raw-ptr capture (per-use reborrow).
-            let entry_ptr: Option<*mut bun_test::ExecutionEntry> = current_state_data
-                .entry(buntest)
-                .map(std::ptr::from_mut::<bun_test::ExecutionEntry>);
-            if let Some(entry) = entry_ptr {
+            if let Some(entry) = current_state_data.entry(buntest) {
                 if let Some(sequence) = current_state_data.sequence(buntest) {
-                    if sequence.test_entry.map(|p| p.as_ptr()) != Some(entry) {
+                    let is_test_entry = sequence
+                        .test_entry
+                        .is_some_and(|t| std::rc::Rc::ptr_eq(&buntest.execution.entry(t), &entry));
+                    if !is_test_entry {
                         // mark errors in hooks as 'unhandled error between tests'
                         current_state_data = RefDataValue::Start;
                     }
@@ -624,13 +719,11 @@ pub(crate) mod on_unhandled_rejection {
                 &current_state_data,
             );
             buntest.add_result(current_state_data);
-            if let Err(e) = bun_test::BunTest::run(&buntest_strong, global_object) {
-                // As `RunTestsTask::call`: what advancing the runner threw is
+            if let Err(e) = buntest.run(global_object) {
+                // As `RunTestsTask::run`: what advancing the runner threw is
                 // recorded against wherever the runner now is; a termination is
                 // left where it is.
                 if !global_object.has_pending_termination_exception() {
-                    // SAFETY: as above; `run` has returned, this is the only handle.
-                    let buntest = unsafe { bun_test::buntest_as_mut(&buntest_strong) };
                     let phase = buntest.get_current_state_data();
                     buntest.on_uncaught_exception(
                         global_object,
@@ -643,13 +736,7 @@ pub(crate) mod on_unhandled_rejection {
             return;
         }
 
-        // SAFETY: `on_unhandled_rejection_exception_list` is either None or a
-        // live `NonNull<ExceptionList>` owned by the VM; reborrow as `&mut`
-        // for the duration of `run_error_handler` (single-threaded JS thread).
-        let exception_list = jsc_vm
-            .on_unhandled_rejection_exception_list
-            .map(|p| unsafe { &mut *p.as_ptr() });
-        jsc_vm.run_error_handler(rejection, exception_list);
+        VirtualMachine::default_on_unhandled_rejection(jsc_vm, global_object, rejection);
     }
 }
 
@@ -702,7 +789,9 @@ pub(crate) fn format_label(
                     let c = label[var_end];
                     if c == b'.' {
                         if var_end + 1 < label.len()
-                            && bun_js_parser::js_lexer::is_identifier_continue(label[var_end + 1] as i32)
+                            && bun_js_parser::js_lexer::is_identifier_continue(
+                                label[var_end + 1] as i32,
+                            )
                         {
                             var_end += 1;
                         } else {
@@ -833,13 +922,12 @@ pub(crate) fn capture_test_line_number(callframe: &CallFrame, global_this: &JSGl
     if let Some(runner) = Jest::runner() {
         if runner.test_options.reporters.junit {
             unsafe extern "C" {
-                fn Bun__CallFrame__getLineNumber(
-                    callframe: *const CallFrame,
-                    global: *const JSGlobalObject,
+                safe fn Bun__CallFrame__getLineNumber(
+                    callframe: &CallFrame,
+                    global: &JSGlobalObject,
                 ) -> u32;
             }
-            // SAFETY: callframe and global_this are valid live references.
-            return unsafe { Bun__CallFrame__getLineNumber(callframe, global_this) };
+            return Bun__CallFrame__getLineNumber(callframe, global_this);
         }
     }
     0

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -158,9 +158,7 @@ cfg_jsc! {
 }
 
 cfg_jsc! {
-    pub mod timers {
-        #[path = "FakeTimers.rs"] pub mod fake_timers;
-    }
+    pub mod timers;
 }
 
 cfg_jsc! {

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1,11 +1,10 @@
 use crate::test_runner::expect::JSValueTestExt;
-use core::ffi::c_void;
 
 use bun_collections::HashMap;
 use bun_core::fmt as bun_fmt;
 use bun_jsc::{
     self as jsc, ComptimeStringMapExt as _, JSGlobalObject, JSObject,
-    JSPropertyIterator, JSType, JSValue, JsError, JsResult, VM,
+    JSPropertyIterator, JSType, JSValue, JsError, JsResult,
 };
 use bun_core::{strings, EncodedSlice, Utf8Bytes};
 
@@ -304,14 +303,15 @@ pub mod visited {
     // storage; without it `ObjectPool<Map, true, 16>` defaults to
     // `UnwiredStorage` which panics on first `get_node()`.
     bun_collections::object_pool!(pub Pool: Map, threadsafe, 16);
-    pub type PoolNode = bun_collections::pool::Node<Map>;
+    pub type PoolGuard = bun_collections::PoolGuard<'static, Map>;
 }
 
 pub struct Formatter<'a> {
     pub(crate) remaining_values: &'a [JSValue],
     pub(crate) map: visited::Map,
-    /// Lazily acquired from `visited::Pool`; released back in `Drop`.
-    pub(crate) map_node: Option<core::ptr::NonNull<visited::PoolNode>>,
+    /// Lazily acquired from `visited::Pool`; its map is moved into `map` while
+    /// held and moved back (cleared) in `Drop`, which returns it to the pool.
+    pub(crate) map_node: Option<visited::PoolGuard>,
     pub global_this: &'a JSGlobalObject,
     pub(crate) indent: u32,
     pub(crate) quote_strings: bool,
@@ -359,16 +359,8 @@ impl<'a> Formatter<'a> {
 impl Drop for Formatter<'_> {
     fn drop(&mut self) {
         if let Some(mut node) = self.map_node.take() {
-            // SAFETY: `node` came from `visited::Pool::get_node()` and is
-            // exclusively owned for this `Formatter`'s lifetime; its `data` was
-            // initialized by `Map::INIT`, so `assume_init_mut` observes a valid
-            // `Map`.
-            unsafe {
-                let data = node.as_mut().data.assume_init_mut();
-                *data = core::mem::take(&mut self.map);
-                data.clear();
-                visited::Pool::release(node.as_ptr());
-            }
+            *node = core::mem::take(&mut self.map);
+            node.clear();
         }
     }
 }
@@ -761,14 +753,8 @@ pub(crate) struct MapIterator<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS
 impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
     MapIterator<'a, 'f, W, ENABLE_ANSI_COLORS>
 {
-    pub(crate) extern "C" fn for_each(
-        _: *mut VM,
-        global_object: &JSGlobalObject,
-        ctx: *mut c_void,
-        next_value: JSValue,
-    ) {
-        // SAFETY: ctx was passed as `&mut Self as *mut c_void` by the caller of for_each.
-        let Some(ctx) = (unsafe { ctx.cast::<Self>().as_mut() }) else { return };
+    pub(crate) fn visit(&mut self, global_object: &JSGlobalObject, next_value: JSValue) {
+        let ctx = self;
         if ctx.formatter.failed {
             return;
         }
@@ -812,14 +798,8 @@ pub(crate) struct SetIterator<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS
 impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
     SetIterator<'a, 'f, W, ENABLE_ANSI_COLORS>
 {
-    pub(crate) extern "C" fn for_each(
-        _: *mut VM,
-        global_object: &JSGlobalObject,
-        ctx: *mut c_void,
-        next_value: JSValue,
-    ) {
-        // SAFETY: ctx was passed as `&mut Self as *mut c_void` by the caller of for_each.
-        let Some(ctx) = (unsafe { ctx.cast::<Self>().as_mut() }) else { return };
+    pub(crate) fn visit(&mut self, global_object: &JSGlobalObject, next_value: JSValue) {
+        let ctx = self;
         if ctx.formatter.failed {
             return;
         }
@@ -894,10 +874,10 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
         Ok(())
     }
 
-    extern "C" fn for_each(
+    fn visit(
+        &mut self,
         global_this: &JSGlobalObject,
-        ctx_ptr: *mut c_void,
-        key_: *mut EncodedSlice,
+        key: &EncodedSlice,
         value: JSValue,
         is_symbol: bool,
         is_private_symbol: bool,
@@ -906,14 +886,12 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
             return;
         }
 
-        // SAFETY: key_ is non-null per JSC contract for property iteration.
-        let key = unsafe { *key_ };
+        let key = *key;
         if key.eq_ascii(b"constructor") {
             return;
         }
 
-        // SAFETY: ctx_ptr was passed as `&mut Self as *mut c_void` by the caller of for_each.
-        let Some(ctx) = (unsafe { ctx_ptr.cast::<Self>().as_mut() }) else { return };
+        let ctx = self;
         if ctx.formatter.failed {
             return;
         }
@@ -1049,23 +1027,12 @@ impl<'a> Formatter<'a> {
 
         if FORMAT.can_have_circular_references() {
             if self.map_node.is_none() {
-                // `visited::Pool::get()` returns an RAII `PoolGuard` that
-                // would release on scope exit; instead the raw node is stashed on
-                // `self` and released from `JestPrettyFormat::format`'s tail, so
-                // take the raw node directly. `data` is initialized by
-                // `Map::INIT` (see `visited::Map: ObjectPoolType`).
-                let node = core::ptr::NonNull::new(visited::Pool::get_node())
-                    .expect("ObjectPool::get_node never returns null");
+                // Take the pooled map here and swap it back into the node in
+                // `Drop`, so the pooled allocation is retained across uses.
+                let mut node = visited::Pool::get();
+                node.clear();
+                self.map = core::mem::take(&mut *node);
                 self.map_node = Some(node);
-                // Take the map here and swap it back into
-                // `node.data` at release time (see JestPrettyFormat::format tail),
-                // so the pooled allocation is retained across uses.
-                // SAFETY: see above.
-                unsafe {
-                    let data = (*node.as_ptr()).data.assume_init_mut();
-                    data.clear();
-                    self.map = core::mem::take(data);
-                }
             }
 
             let entry = self.map.get_or_put(value).expect("unreachable");
@@ -1495,11 +1462,7 @@ impl<'a> Formatter<'a> {
                     // bodies re-enter this formatter through the `ConsoleFormatter` impl
                     // below for nested values, so the byte sink is wrapped in `AsFmt` (a
                     // `core::fmt::Write` view of the same writer).
-                    if let Some(response) = value.as_::<crate::webcore::Response>() {
-                        // SAFETY: `as_` returned non-null; the GC keeps the cell alive while
-                        // `value` is on the stack (conservative scan). `write_format` does not
-                        // re-enter `as_` for the same cell, so the `&mut` is unique here.
-                        let response = unsafe { &mut *response };
+                    if let Some(response) = value.as_class_ref::<crate::webcore::Response>() {
                         let mut bridge = AsFmt::new(&mut *writer.ctx);
                         if response
                             .write_format::<_, _, ENABLE_ANSI_COLORS>(self, &mut bridge)
@@ -1515,9 +1478,7 @@ impl<'a> Formatter<'a> {
                             }
                             return Err(JsError::Thrown);
                         }
-                    } else if let Some(request) = value.as_::<crate::webcore::Request>() {
-                        // SAFETY: see Response branch above.
-                        let request = unsafe { &mut *request };
+                    } else if let Some(request) = value.as_class_ref::<crate::webcore::Request>() {
                         let mut bridge = AsFmt::new(&mut *writer.ctx);
                         if request
                             .write_format::<_, _, ENABLE_ANSI_COLORS>(value, self, &mut bridge)
@@ -1534,10 +1495,7 @@ impl<'a> Formatter<'a> {
                             return Err(JsError::Thrown);
                         }
                         return Ok(());
-                    } else if let Some(build) = value.as_::<crate::api::BuildArtifact>() {
-                        // SAFETY: see Response branch above. `write_format` is
-                        // `&self` post-R-2, so a shared borrow is sufficient.
-                        let build = unsafe { &*build };
+                    } else if let Some(build) = value.as_class_ref::<crate::api::BuildArtifact>() {
                         let mut bridge = AsFmt::new(&mut *writer.ctx);
                         if build
                             .write_format::<_, _, ENABLE_ANSI_COLORS>(value, self, &mut bridge)
@@ -1553,9 +1511,7 @@ impl<'a> Formatter<'a> {
                             }
                             return Err(JsError::Thrown);
                         }
-                    } else if let Some(blob) = value.as_::<crate::webcore::Blob>() {
-                        // SAFETY: see Response branch above.
-                        let blob = unsafe { &mut *blob };
+                    } else if let Some(blob) = value.as_class_ref::<crate::webcore::Blob>() {
                         let mut bridge = AsFmt::new(&mut *writer.ctx);
                         if blob
                             .write_format::<_, _, ENABLE_ANSI_COLORS>(self, &mut bridge)
@@ -1743,11 +1699,7 @@ impl<'a> Formatter<'a> {
                             formatter: self,
                             writer: writer.ctx,
                         };
-                        let result = value.for_each(
-                            global,
-                            (&raw mut iter).cast::<c_void>(),
-                            MapIterator::<W, ENABLE_ANSI_COLORS>::for_each,
-                        );
+                        let result = value.for_each_iter(global, |g, v| iter.visit(g, v));
                         // `indent` / `quote_strings` must be restored on every exit,
                         // including thrown exceptions — restore before propagating.
                         self.indent = self.indent.saturating_sub(1);
@@ -1786,11 +1738,7 @@ impl<'a> Formatter<'a> {
                             formatter: self,
                             writer: writer.ctx,
                         };
-                        let result = value.for_each(
-                            global,
-                            (&raw mut iter).cast::<c_void>(),
-                            SetIterator::<W, ENABLE_ANSI_COLORS>::for_each,
-                        );
+                        let result = value.for_each_iter(global, |g, v| iter.visit(g, v));
                         // `indent` / `quote_strings` must be restored on every exit,
                         // including thrown exceptions — restore before propagating.
                         self.indent = self.indent.saturating_sub(1);
@@ -2316,11 +2264,10 @@ impl<'a> Formatter<'a> {
                         parent: value,
                     };
 
-                    let result = value.for_each_property_ordered(
-                        global,
-                        (&raw mut iter).cast::<c_void>(),
-                        PropertyIterator::<W, ENABLE_ANSI_COLORS>::for_each,
-                    );
+                    let result =
+                        value.for_each_property_iter(global, true, |g, k, v, sym, private| {
+                            iter.visit(g, k, v, sym, private)
+                        });
 
                     let iter_i = iter.i;
                     let iter_always_newline = iter.always_newline;
@@ -2417,15 +2364,11 @@ impl<'a> Formatter<'a> {
 
                     macro_rules! print_typed_slice {
                         ($t:ty) => {{
-                            // SAFETY: `Unaligned<$t>` has align 1 and the same size as `$t`, so any
-                            // `*const u8` is a valid `*const Unaligned<$t>`; `slice` is the live
-                            // backing store of a JSC typed array whose elements are valid `$t`.
-                            let slice_with_type: &[bun_core::Unaligned<$t>] = unsafe {
-                                core::slice::from_raw_parts(
-                                    slice.as_ptr().cast::<bun_core::Unaligned<$t>>(),
-                                    slice.len() / core::mem::size_of::<$t>(),
-                                )
-                            };
+                            // `Unaligned<$t>` has align 1, so this holds for any backing
+                            // store (external ArrayBuffers need not be `$t`-aligned).
+                            let whole = slice.len() - slice.len() % core::mem::size_of::<$t>();
+                            let slice_with_type: &[bun_core::Unaligned<$t>] =
+                                bytemuck::cast_slice(&slice[..whole]);
                             self.indent += 1;
                             for el in slice_with_type {
                                 writer.write_all(b"\n");

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -15,7 +15,7 @@ use bun_wyhash::hash;
 
 use super::diff_format::DiffFormatter;
 use super::expect::Expect;
-use super::jest::{FileColumns as _, Jest};
+use super::jest::Jest;
 use bun_collections::index_sort;
 
 // TestRunner.File.ID — concrete alias from jest.rs (`pub type FileId = u32`).
@@ -142,10 +142,7 @@ impl Snapshots {
         target_value: &[u8],
         hint: &[u8],
     ) -> Result<Option<&[u8]>, Error> {
-        let buntest_strong = expect
-            .bun_test()
-            .ok_or(crate::Error::SnapshotFailed)?;
-        let bun_test = buntest_strong.get();
+        let bun_test = expect.bun_test().ok_or(crate::Error::SnapshotFailed)?;
         match self.get_snapshot_file(bun_test.file_id)? {
             bun_sys::Result::Ok(()) => {}
             bun_sys::Result::Err(err) => {
@@ -238,18 +235,10 @@ impl Snapshots {
         let arena = bun_alloc::Arena::new();
         let mut temp_log = bun_ast::Log::init();
 
-        // do NOT call `Jest::runner()` here — it hands out an exclusive ref to the global TestRunner,
-        // and `self: &mut Snapshots` is a live borrow of that same TestRunner's `.snapshots`
-        // field. Retagging the whole TestRunner would invalidate `self` under Stacked Borrows.
-        // Project the disjoint `.files` sibling through the raw `RUNNER` pointer instead.
-        // SAFETY: single-threaded JS VM; RUNNER is set before any Snapshots method runs
-        // (Snapshots is a field of TestRunner). Raw-pointer place projection touches only
-        // `.files` bytes, disjoint from `&mut self`.
-        let test_file_source = unsafe {
-            let p = Jest::RUNNER.read().expect("Jest runner not set").as_ptr();
-            &(*p).files.items_source()[file.id as usize]
-        };
-        let name = test_file_source.path.name();
+        let test_file_path = Jest::runner()
+            .expect("Jest runner not set")
+            .file_path(file.id);
+        let name = test_file_path.name();
         let test_filename = name.filename;
         let dir_path = name.dir_with_trailing_slash();
 
@@ -416,15 +405,11 @@ impl Snapshots {
             });
 
             // 2. load file text
-            // avoid `Jest::runner()` (would alias `&mut TestRunner` over the live
-            // `&mut self` / `ils_info` borrow of `runner.snapshots`). See comment in `parse_file`.
-            // SAFETY: see `parse_file` — raw-pointer projection to disjoint `.files` field.
-            let test_file_source = unsafe {
-                let p = Jest::RUNNER.read().expect("Jest runner not set").as_ptr();
-                &(*p).files.items_source()[file_id as usize]
-            };
+            let test_file_path = Jest::runner()
+                .expect("Jest runner not set")
+                .file_path(file_id);
             let test_filename: Box<[u8]> = {
-                let mut v = test_file_source.path.text.to_vec();
+                let mut v = test_file_path.text.to_vec();
                 v.push(0);
                 v.into_boxed_slice()
             };
@@ -531,24 +516,11 @@ impl Snapshots {
                     }
                     next_start += fn_name.len();
 
-                    // `Lexer.initWithoutReading` and `TSXParser.init` both need the same
-                    // `Log`, but Rust forbids two live `&'a mut Log`;
-                    // derive a raw pointer so borrowck doesn't track the lexer/parser borrow,
-                    // matching the pattern in `js_parser::Parser::init`. The unique `&mut`
-                    // logically lives inside `parser.lexer`; `log.add_error_fmt` calls below
-                    // reborrow via the scopeguard between parser uses.
-                    // SAFETY: `log` outlives the `'blk` block; lexer/parser are dropped at
-                    // block exit (or `continue 'ils`). See Parser.rs:214 for the provenance
-                    // discussion.
-                    let log_ptr: *mut bun_ast::Log = &raw mut *log;
-                    let mut lexer = js_lexer::Lexer::init_without_reading(
-                        // SAFETY: `log_ptr` derived from `&raw mut *log` just above; `log`
-                        // outlives `'blk` and no other `&mut Log` is live until `lexer` is
-                        // moved into `parser` below.
-                        unsafe { &mut *log_ptr },
-                        &source,
-                        &arena,
-                    );
+                    // The lexer (and the parser built over it) log to `log`; the
+                    // `log.add_error_fmt` calls below are each followed by
+                    // `continue 'ils`, which drops the parser.
+                    let mut lexer =
+                        js_lexer::Lexer::init_without_reading(&mut log, &source, &arena);
                     if next_start > 0 {
                         // equivalent to lexer.consumeRemainderBytes(next_start)
                         lexer.current += next_start - (lexer.current - lexer.end);
@@ -560,32 +532,13 @@ impl Snapshots {
                         vm.transpiler.options.jsx.clone(),
                         bun_ast::Loader::Js,
                     );
-                    // `P::init` takes an out-param
-                    // since 9a98701c980c — `P` is ~5 KiB and the previous
-                    // `let p = P::init(..)?` shape forced 2-3 by-value moves.
-                    // Mirror `init_p!` from `js_parser/parse/parse_entry.rs` here
-                    // (that macro is crate-local).
-                    let mut __parser_slot =
-                        core::mem::MaybeUninit::<js_parser::TSXParser<'_>>::uninit();
-                    // `P::init` writes a fully-initialized value on `Ok`. On `Err` we
-                    // `?`-return before arming the drop guard, so the slot stays
-                    // uninitialized and untouched.
-                    js_parser::TSXParser::init(
-                        &mut __parser_slot,
+                    let mut parser = js_parser::TSXParser::new_boxed(
                         &arena,
-                        core::ptr::NonNull::new(log_ptr).expect("log_ptr derived from &mut *log"),
                         &source,
                         &vm.transpiler.options.define,
                         lexer,
                         opts,
                     )?;
-                    // SAFETY: `init` returned `Ok`, so `*__parser_slot` is initialized;
-                    // the guard's drop closure is the sole owner of the slot from here.
-                    let mut __parser_guard =
-                        scopeguard::guard(__parser_slot, |mut s| unsafe { s.assume_init_drop() });
-                    // SAFETY: guard armed only after `init` succeeded.
-                    let parser: &mut js_parser::TSXParser<'_> =
-                        unsafe { __parser_guard.assume_init_mut() };
 
                     parser.lexer.expect(js_lexer::T::TOpenParen)?;
                     let after_open_paren_loc = parser.lexer.loc().start;
@@ -784,8 +737,7 @@ impl Snapshots {
                 result_text.extend_from_slice(b"`");
 
                 if ils.is_added {
-                    // `runner.snapshots` *is* `*self`: going back through `Jest::runner()` would
-                    // create a second `&mut Snapshots` aliasing `self` (UB) and invalidate `ils_info`.
+                    // `runner.snapshots` *is* `*self` (the caller holds its `RefCell` borrow).
                     self.added += 1;
                 }
             }
@@ -835,13 +787,10 @@ impl Snapshots {
         if self._current_file.is_none() || self._current_file.as_ref().unwrap().id != file_id {
             self.write_snapshot_file()?;
 
-            // avoid `Jest::runner()` (aliases `&mut TestRunner` over live `&mut self`).
-            // SAFETY: see `parse_file` — raw-pointer projection to disjoint `.files` field.
-            let test_file_source = unsafe {
-                let p = Jest::RUNNER.read().expect("Jest runner not set").as_ptr();
-                &(*p).files.items_source()[file_id as usize]
-            };
-            let name = test_file_source.path.name();
+            let test_file_path = Jest::runner()
+                .expect("Jest runner not set")
+                .file_path(file_id);
+            let name = test_file_path.name();
             let test_filename = name.filename;
             let dir_path = name.dir_with_trailing_slash();
 

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -236,7 +236,7 @@ impl Snapshots {
         let mut temp_log = bun_ast::Log::init();
 
         let test_file_path = Jest::runner()
-            .expect("Jest runner not set")
+            .ok_or(Error::SnapshotFailed)?
             .file_path(file.id);
         let name = test_file_path.name();
         let test_filename = name.filename;
@@ -405,9 +405,11 @@ impl Snapshots {
             });
 
             // 2. load file text
-            let test_file_path = Jest::runner()
-                .expect("Jest runner not set")
-                .file_path(file_id);
+            let Some(runner) = Jest::runner() else {
+                success.set(false);
+                continue;
+            };
+            let test_file_path = runner.file_path(file_id);
             let test_filename: Box<[u8]> = {
                 let mut v = test_file_path.text.to_vec();
                 v.push(0);
@@ -788,7 +790,7 @@ impl Snapshots {
             self.write_snapshot_file()?;
 
             let test_file_path = Jest::runner()
-                .expect("Jest runner not set")
+                .ok_or(Error::SnapshotFailed)?
                 .file_path(file_id);
             let name = test_file_path.name();
             let test_filename = name.filename;

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -101,8 +101,8 @@ impl CurrentTime {
 /// fake timers are inactive. A NaN `ms` is the "clear override" sentinel:
 /// `Date.now()` is real again until the next tick, so the mocked wall clock
 /// and `performance.timeOrigin` go back to real as well.
-#[unsafe(no_mangle)]
-extern "C" fn Bun__FakeTimers__setSystemTime(global: &JSGlobalObject, ms: f64) {
+// HOST_EXPORT(Bun__FakeTimers__setSystemTime, c)
+pub fn set_system_time(global: &JSGlobalObject, ms: f64) {
     let Some(current) = CURRENT_TIME.get_timespec_now() else {
         return;
     };
@@ -499,8 +499,7 @@ fn is_fake_timers(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSVa
 }
 
 // `#[bun_jsc::host_fn]` emits a `__jsc_host_{name}` shim with the raw
-// `JSHostFn` ABI (`unsafe extern "C" fn(*mut JSGlobalObject, *mut CallFrame) -> JSValue`),
-// which is what `JSFunction::create` expects.
+// `JSHostFn` ABI, which is what `JSFunction::create` expects.
 const FAKE_TIMERS_FNS: &[(&str, u32, JSHostFn)] = &[
     ("useFakeTimers", 0, __jsc_host_use_fake_timers),
     ("useRealTimers", 0, __jsc_host_use_real_timers),

--- a/src/runtime/test_runner/timers/mod.rs
+++ b/src/runtime/test_runner/timers/mod.rs
@@ -1,0 +1,2 @@
+#[path = "FakeTimers.rs"]
+pub mod fake_timers;

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -107,7 +107,7 @@ extern "C" fn Bun__Chrome__retire() {
     chrome.retired = true;
     #[cfg(windows)]
     {
-        // Queued events from this Chrome carry its generation; `QueuedEvent::deliver` drops them.
+        // Queued events from this Chrome carry its generation; `QueuedEvent::run` drops them.
         GENERATION.fetch_add(1, Ordering::Relaxed);
         chrome.pipes.close();
     }
@@ -931,36 +931,31 @@ struct QueuedEvent {
 #[cfg(windows)]
 impl PipeEvent {
     fn post(self, generation: u32) {
-        let queued = bun_core::heap::into_raw(Box::new(QueuedEvent {
+        let queued = Box::new(QueuedEvent {
             generation,
             event: self,
-        }));
+        });
         // Not dispatched from the read callback: C++ runs JS that may spin a nested event loop (bun:test does), and libuv re-arms the read only after the callback returns.
         VirtualMachine::get()
             .as_mut()
-            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new_owned(
-                queued,
-                QueuedEvent::deliver,
-            ));
+            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new_boxed(queued));
     }
 }
 
 #[cfg(windows)]
-impl QueuedEvent {
-    fn deliver(this: *mut QueuedEvent) -> bun_jsc::JsResult<()> {
-        // SAFETY: the box leaked by `post`; ManagedTask hands it over once.
-        let queued = unsafe { bun_core::heap::take(this) };
-        if queued.generation != GENERATION.load(Ordering::Relaxed) {
+impl bun_event_loop::ManagedTask::RunOnce for QueuedEvent {
+    fn run(self) -> bun_jsc::JsResult<()> {
+        if self.generation != GENERATION.load(Ordering::Relaxed) {
             scoped_log!(
                 Chrome,
                 "dropping event from replaced chrome (generation {})",
-                queued.generation
+                self.generation
             );
             return Ok(());
         }
         // SAFETY: plain FFI; onData copies `bytes` before returning.
         unsafe {
-            match queued.event {
+            match self.event {
                 PipeEvent::Data(bytes) => Bun__Chrome__onPipeData(bytes.as_ptr(), bytes.len()),
                 PipeEvent::Closed => Bun__Chrome__onPipeClosed(),
                 PipeEvent::Exited { signo } => Bun__Chrome__died(signo),


### PR DESCRIPTION
### What

Same programme as #40055 … #40228, applied to `src/runtime/test_runner/`: `bun_test.rs` 56 → **0**, `Execution.rs` 32 → 0, `Order.rs` 13 → 0, `Collection.rs` 5 → 0, `ScopeFunctions.rs` 6 → 0, `snapshot.rs` 6 → 0, `pretty_format.rs` 11 → 0, `diff_format.rs` 3 → 0, `DoneCallback.rs` 2 → 0, `expect/to{Contain,BeOneOf,BeEmpty,ContainEqual}.rs` → 0; `expect.rs` 33 → 3 and `jest.rs` 16 → 2 (each residual is an `unsafe extern "C" {` block of `safe fn`s). `timers/FakeTimers.rs` keeps the timer-heap accesses that #40187 rewrites (`TimerRef`); not duplicated here. Collateral: `cli/test_command.rs` 44 → 26.

- **`BunTest`** is `Rc<BunTest>` (`new_cyclic`, holds its own `Weak`), all state `Cell`/`RefCell`, every method `&self` — `BunTestCell`/`UnsafeCell`/`buntest_as_mut` are gone. The describe tree is `Rc<DescribeScope>` with `Weak` parents; `ExecutionEntry` is an immutable `Rc`, and per-occurrence state (`next`, `failure_skip_past`, `timespec`) lives in an index arena (`EntryNode`/`EntryId`) built by `Order`, replacing the intrusive raw-pointer lists and the bitwise-cloned hook entries. `RefDataValue` carries `EntryId`/`Weak<DescribeScope>`.
- **`RefData`** is `Rc<RefData>`; the `.then()` ref is owned by `BunTestRoot::pending_then_refs` and recovered by identity in `HOST_EXPORT`ed `ThisPtr<RefData>` promise reactions; `has_one_ref` ≡ `Rc::strong_count == 1` (verified equal to the old protocol at every decision point). `DoneCallback`/`Expect` hold `Rc<RefData>` and use `as_class_ref`.
- **`TestRunner`/`CommandLineReporter`** are `Box::leak`ed `&'static`, `&self`-only; `Jest::runner() -> Option<&'static TestRunner>` goes through a new `bun_core::ThreadBound<T: Copy>` (static slot readable only by the storing thread, keyed on a never-reused per-thread token) — so a Worker spawned by a test file no longer reads/mutates the main thread's runner state (previously an unsynchronised race; affected worker-side paths listed below). `RunTestsTask` uses `ManagedTask::new_boxed` + `RunOnce` (same hunk as #40190).
- Small primitives: `bun_core::Unaligned<T>: Pod` (typed-array pretty-printing via `bytemuck::cast_slice::<u8, Unaligned<T>>`, correct on unaligned external buffers), `JSValue::for_each_iter`/`for_each_property_iter` closure trampolines, `js_parser::P::new_boxed`, `VirtualMachine::default_on_unhandled_rejection` pub. (`bun_core::ThreadBound` here and `bun_ptr::ThreadBound` in #40200 are different shapes with the same name; I'll converge them when one lands.)

Intentional behaviour note: on a Worker thread `Jest::runner()` is `None`, so worker-side coverage skip-test-files check, `Bun.jest()` path validation, node:test file generation, snapshot matchers and the console before-print hook no longer touch the main runner.

### Testing

Debug+ASAN, outputs diffed byte-for-byte (modulo timings) against a main debug build: a hand-driven fixture (pass/fail/skip/todo, async, done-callback, timeout, `describe.each`, `expect.extend`, snapshots write/match/`-u`, mock/spyOn, fake timers, `onTestFinished`, retry, failing, resolves/rejects, unhandled error between tests) identical plain and with `--bail=1`, `--rerun-each 3`, `--isolate`, `--only-failures`, `--dots`, `-t`, `--randomize --seed`, `-u`, `--bail=2 --isolate`, `--preload` hooks, junit XML. `test/js/bun/test/**` 1159 pass / 9 fail (all 9 identical on the main baseline: agent/colour detection, cwd), `test/cli/test/*` 267 pass (1 env failure identical on baseline), 24 regression files + js/node/path + js/web/url as smoke. No ASAN/panic output. clippy clean on bun_runtime/bun_jsc/bun_core/bun_js_parser/bun_event_loop; `rust-check-all` windows-msvc pass.