### PR TITLE
install: keep the dependency closure of a trusted package out of the global store

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1231,6 +1231,31 @@ pub(crate) fn install_isolated_packages(
                         let dep_id = node_dep_ids[node_id.get() as usize];
                         let pkg_res = &pkg_resolutions[pkg_id as usize];
 
+                        // Intentionally *not* gated on `do.run_scripts`
+                        // (a later install without `--ignore-scripts`
+                        // would run the postinstall through the project
+                        // symlink and mutate the shared directory) *or*
+                        // on `meta.hasInstallScript()` (that flag is not
+                        // serialised in `bun.lock`, so it reads `false`
+                        // on every install after the first; a trusted
+                        // scripted package would flip from project-local
+                        // on the cold install to global on the warm one).
+                        // Over-excludes the rare "trusted but actually no
+                        // scripts" case in exchange for not needing a
+                        // lockfile-format change.
+                        let is_trusted = {
+                            let dep_name = if dep_id != invalid_dependency_id {
+                                dependencies[dep_id as usize].name.slice(string_buf)
+                            } else {
+                                pkg_names[pkg_id as usize].slice(string_buf)
+                            };
+                            lockfile.has_trusted_dependency(
+                                dep_name,
+                                pkg_names[pkg_id as usize].slice(string_buf),
+                                pkg_res,
+                            ) || trusted_from_update.contains(&pkg_id)
+                        };
+
                         let eligible = match pkg_res.tag {
                             ResolutionTag::Npm
                             | ResolutionTag::Git
@@ -1241,30 +1266,7 @@ pub(crate) fn install_isolated_packages(
                                 // mutate (or may mutate) their install directory, so a
                                 // shared global copy would either diverge from the
                                 // patch or be mutated underneath other projects.
-                                //
-                                // Intentionally *not* gated on `do.run_scripts`
-                                // (a later install without `--ignore-scripts`
-                                // would run the postinstall through the project
-                                // symlink and mutate the shared directory) *or*
-                                // on `meta.hasInstallScript()` (that flag is not
-                                // serialised in `bun.lock`, so it reads `false`
-                                // on every install after the first; a trusted
-                                // scripted package would flip from project-local
-                                // on the cold install to global on the warm one).
-                                // Over-excludes the rare "trusted but actually no
-                                // scripts" case in exchange for not needing a
-                                // lockfile-format change.
-                                let dep_name = if dep_id != invalid_dependency_id {
-                                    dependencies[dep_id as usize].name.slice(string_buf)
-                                } else {
-                                    pkg_names[pkg_id as usize].slice(string_buf)
-                                };
-                                if lockfile.has_trusted_dependency(
-                                    dep_name,
-                                    pkg_names[pkg_id as usize].slice(string_buf),
-                                    pkg_res,
-                                ) || trusted_from_update.contains(&pkg_id)
-                                {
+                                if is_trusted {
                                     trusted_entries.push(entry_idx);
                                     break 'eligible false;
                                 }
@@ -1306,17 +1308,7 @@ pub(crate) fn install_isolated_packages(
                                 // scripts also run, but poisoning their
                                 // closures would force most of the graph out
                                 // of the global store.
-                                let dep_name = if dep_id != invalid_dependency_id {
-                                    dependencies[dep_id as usize].name.slice(string_buf)
-                                } else {
-                                    pkg_names[pkg_id as usize].slice(string_buf)
-                                };
-                                if lockfile.has_trusted_dependency(
-                                    dep_name,
-                                    pkg_names[pkg_id as usize].slice(string_buf),
-                                    pkg_res,
-                                ) || trusted_from_update.contains(&pkg_id)
-                                {
+                                if is_trusted {
                                     trusted_entries.push(entry_idx);
                                 }
                                 false

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1193,6 +1193,11 @@ pub(crate) fn install_isolated_packages(
 
             let mut states = vec![State::Unvisited; store.entries.len()].into_boxed_slice();
 
+            // Entries whose lifecycle scripts are allowed to run; their
+            // transitive dependency closure is forced project-local after the
+            // DFS below.
+            let mut trusted_entries: Vec<usize> = Vec::new();
+
             // Iterative DFS so dependency cycles (which the isolated graph permits)
             // can't overflow the stack and are handled deterministically: a back-edge
             // contributes the dependency *name* to the parent's hash but not the
@@ -1237,6 +1242,33 @@ pub(crate) fn install_isolated_packages(
                                 // mutate (or may mutate) their install directory, so a
                                 // shared global copy would either diverge from the
                                 // patch or be mutated underneath other projects.
+                                //
+                                // Intentionally *not* gated on `do.run_scripts`
+                                // (a later install without `--ignore-scripts`
+                                // would run the postinstall through the project
+                                // symlink and mutate the shared directory) *or*
+                                // on `meta.hasInstallScript()` (that flag is not
+                                // serialised in `bun.lock`, so it reads `false`
+                                // on every install after the first; a trusted
+                                // scripted package would flip from project-local
+                                // on the cold install to global on the warm one).
+                                // Over-excludes the rare "trusted but actually no
+                                // scripts" case in exchange for not needing a
+                                // lockfile-format change.
+                                let dep_name = if dep_id != invalid_dependency_id {
+                                    dependencies[dep_id as usize].name.slice(string_buf)
+                                } else {
+                                    pkg_names[pkg_id as usize].slice(string_buf)
+                                };
+                                if lockfile.has_trusted_dependency(
+                                    dep_name,
+                                    pkg_names[pkg_id as usize].slice(string_buf),
+                                    pkg_res,
+                                ) || trusted_from_update.contains(&pkg_id)
+                                {
+                                    trusted_entries.push(entry_idx);
+                                    break 'eligible false;
+                                }
                                 if lockfile.patched_dependencies.count() > 0 {
                                     let mut name_version_buf = PathBuffer::uninit();
                                     let mut cursor =
@@ -1265,31 +1297,6 @@ pub(crate) fn install_isolated_packages(
                                     ) {
                                         break 'eligible false;
                                     }
-                                }
-                                // Intentionally *not* gated on `do.run_scripts`
-                                // (a later install without `--ignore-scripts`
-                                // would run the postinstall through the project
-                                // symlink and mutate the shared directory) *or*
-                                // on `meta.hasInstallScript()` (that flag is not
-                                // serialised in `bun.lock`, so it reads `false`
-                                // on every install after the first; a trusted
-                                // scripted package would flip from project-local
-                                // on the cold install to global on the warm one).
-                                // Over-excludes the rare "trusted but actually no
-                                // scripts" case in exchange for not needing a
-                                // lockfile-format change.
-                                let dep_name = if dep_id != invalid_dependency_id {
-                                    dependencies[dep_id as usize].name.slice(string_buf)
-                                } else {
-                                    pkg_names[pkg_id as usize].slice(string_buf)
-                                };
-                                if lockfile.has_trusted_dependency(
-                                    dep_name,
-                                    pkg_names[pkg_id as usize].slice(string_buf),
-                                    pkg_res,
-                                ) || trusted_from_update.contains(&pkg_id)
-                                {
-                                    break 'eligible false;
                                 }
                                 break 'eligible true;
                             }
@@ -1397,6 +1404,37 @@ pub(crate) fn install_isolated_packages(
                         states[entry_idx] = State::Done;
                     }
                     stack.pop();
+                }
+            }
+
+            // A trusted entry's lifecycle scripts run with its dep symlinks in
+            // place, so they can write through `node_modules/<dep>` into
+            // whatever those symlinks target. The trusted entry itself is
+            // already project-local (eligibility check above), but that is not
+            // enough: the npm `bun` wrapper's postinstall, for example, renames
+            // the platform binary out of `@oven/bun-<platform>`, which would
+            // empty the shared store entry underneath every other project (or
+            // fail outright with the store on another filesystem). Force the
+            // trusted entry's transitive dependency closure project-local too.
+            // The walk crosses entries that are already ineligible for other
+            // reasons (patched, workspace) because *their* deps are still
+            // reachable from the script. Dependents of the newly poisoned
+            // entries are handled by the fixed-point pass below.
+            {
+                let mut visited = vec![false; store.entries.len()].into_boxed_slice();
+                let mut queue = trusted_entries;
+                for &entry_idx in &queue {
+                    visited[entry_idx] = true;
+                }
+                while let Some(entry_idx) = queue.pop() {
+                    for dep in entry_dependencies[entry_idx].slice() {
+                        let dep_entry_idx = dep.entry_id.get() as usize;
+                        if !visited[dep_entry_idx] {
+                            visited[dep_entry_idx] = true;
+                            entry_hashes[dep_entry_idx] = 0;
+                            queue.push(dep_entry_idx);
+                        }
+                    }
                 }
             }
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1299,6 +1299,28 @@ pub(crate) fn install_isolated_packages(
                                 }
                                 break 'eligible true;
                             }
+                            ResolutionTag::Folder => {
+                                // Always project-local, but a trusted folder
+                                // dep's scripts run, so record it for the
+                                // closure poisoning below. Workspace and root
+                                // scripts also run, but poisoning their
+                                // closures would force most of the graph out
+                                // of the global store.
+                                let dep_name = if dep_id != invalid_dependency_id {
+                                    dependencies[dep_id as usize].name.slice(string_buf)
+                                } else {
+                                    pkg_names[pkg_id as usize].slice(string_buf)
+                                };
+                                if lockfile.has_trusted_dependency(
+                                    dep_name,
+                                    pkg_names[pkg_id as usize].slice(string_buf),
+                                    pkg_res,
+                                ) || trusted_from_update.contains(&pkg_id)
+                                {
+                                    trusted_entries.push(entry_idx);
+                                }
+                                false
+                            }
                             _ => false,
                         };
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1193,9 +1193,8 @@ pub(crate) fn install_isolated_packages(
 
             let mut states = vec![State::Unvisited; store.entries.len()].into_boxed_slice();
 
-            // Entries whose lifecycle scripts are allowed to run; their
-            // transitive dependency closure is forced project-local after the
-            // DFS below.
+            // Trusted entries; their transitive dependency closure is forced
+            // project-local after the DFS.
             let mut trusted_entries: Vec<usize> = Vec::new();
 
             // Iterative DFS so dependency cycles (which the isolated graph permits)
@@ -1407,18 +1406,13 @@ pub(crate) fn install_isolated_packages(
                 }
             }
 
-            // A trusted entry's lifecycle scripts run with its dep symlinks in
-            // place, so they can write through `node_modules/<dep>` into
-            // whatever those symlinks target. The trusted entry itself is
-            // already project-local (eligibility check above), but that is not
-            // enough: the npm `bun` wrapper's postinstall, for example, renames
-            // the platform binary out of `@oven/bun-<platform>`, which would
-            // empty the shared store entry underneath every other project (or
-            // fail outright with the store on another filesystem). Force the
-            // trusted entry's transitive dependency closure project-local too.
-            // The walk crosses entries that are already ineligible for other
-            // reasons (patched, workspace) because *their* deps are still
-            // reachable from the script. Dependents of the newly poisoned
+            // A trusted entry's lifecycle scripts can write through its
+            // `node_modules/<dep>` symlinks into whatever they target, so its
+            // transitive dependency closure must be project-local too (the npm
+            // `bun` wrapper's postinstall renames the platform binary out of
+            // the shared `@oven/bun-<platform>` entry). The walk crosses
+            // entries that are already ineligible because *their* deps are
+            // still reachable from the script. Dependents of newly poisoned
             // entries are handled by the fixed-point pass below.
             {
                 let mut visited = vec![false; store.entries.len()].into_boxed_slice();

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -3086,6 +3086,41 @@ describe("global virtual store", () => {
     assertLayout();
   });
 
+  test("the dependency closure of a trusted file: folder dep stays project-local", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
+
+    await write(
+      join(packageDir, "local-pkg", "package.json"),
+      JSON.stringify({
+        name: "local-pkg",
+        version: "1.0.0",
+        dependencies: { "no-deps": "1.0.0" },
+      }),
+    );
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-trusted-folder",
+        dependencies: { "local-pkg": "file:./local-pkg", "a-dep": "1.0.1" },
+        trustedDependencies: ["local-pkg"],
+      }),
+    );
+
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") };
+    await runBunInstall(env, packageDir);
+
+    // A trusted folder dep's scripts run, so its deps must not be shared
+    // store symlinks the script could write through.
+    const noDepsEntry = join(packageDir, "node_modules", ".bun", "no-deps@1.0.0");
+    expect(lstatSync(noDepsEntry).isSymbolicLink()).toBe(false);
+    expect(lstatSync(noDepsEntry).isDirectory()).toBe(true);
+
+    // A dependency outside the trusted closure still shares the global store.
+    const aDepEntry = join(packageDir, "node_modules", ".bun", "a-dep@1.0.1");
+    expect(lstatSync(aDepEntry).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(aDepEntry)).toMatch(/links[\/\\]a-dep@1\.0\.1-[0-9a-f]{16}$/);
+  });
+
   test("concurrent installs into a cold global store both succeed", async () => {
     // Two `bun install` processes may race to create the same content-addressed
     // global entry; the loser sees EEXIST from clonefile/symlink/bin-link and

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -3031,6 +3031,58 @@ describe("global virtual store", () => {
     expect(lstatSync(noDepsEntry).isSymbolicLink()).toBe(true);
   });
 
+  test("the dependency closure of a trusted package stays project-local", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-trusted-closure",
+        // depend-on-debug-1 -> debug-1 -> ms-1 pins *transitive* exclusion.
+        dependencies: { "depend-on-debug-1": "1.0.0", "a-dep": "1.0.1" },
+        trustedDependencies: ["depend-on-debug-1"],
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    // A trusted package's lifecycle script can write through the package's
+    // dep symlinks (the npm `bun` wrapper's postinstall renames the platform
+    // binary out of `@oven/bun-<platform>`), so the trusted package's whole
+    // dependency closure must be project-local; otherwise the script mutates
+    // the shared store entry underneath every other project.
+    const closure = ["depend-on-debug-1@1.0.0", "debug-1@4.4.0", "ms-1@2.1.3"];
+    const assertLayout = () => {
+      for (const entry of closure) {
+        const entryPath = join(packageDir, "node_modules", ".bun", entry);
+        expect({ entry, symlink: lstatSync(entryPath).isSymbolicLink() }).toEqual({ entry, symlink: false });
+        expect(lstatSync(entryPath).isDirectory()).toBe(true);
+      }
+      // A dependency outside the trusted closure still shares the global store.
+      const aDepEntry = join(packageDir, "node_modules", ".bun", "a-dep@1.0.1");
+      expect(lstatSync(aDepEntry).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(aDepEntry)).toMatch(/links[\/\\]a-dep@1\.0\.1-[0-9a-f]{16}$/);
+    };
+    assertLayout();
+
+    // Nothing from the closure was materialised in the shared store.
+    const linkEntries = await readdirSorted(join(packageDir, ".bun-cache", "links"));
+    expect(linkEntries.filter(e => !e.startsWith("a-dep@"))).toEqual([]);
+
+    // The transitive dep still resolves through the project-local chain.
+    expect(
+      await file(
+        join(packageDir, "node_modules", ".bun", "debug-1@4.4.0", "node_modules", "ms-1", "package.json"),
+      ).json(),
+    ).toMatchObject({ name: "ms-1", version: "2.1.3" });
+
+    // `meta.hasInstallScript` isn't serialised in `bun.lock`, so a warm
+    // install must reach the same layout from trustedDependencies alone.
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+    assertLayout();
+  });
+
   test("concurrent installs into a cold global store both succeed", async () => {
     // Two `bun install` processes may race to create the same content-addressed
     // global entry; the loser sees EEXIST from clonefile/symlink/bin-link and

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -3044,7 +3044,10 @@ describe("global virtual store", () => {
       }),
     );
 
-    await runBunInstall(bunEnv, packageDir);
+    // CI exports BUN_INSTALL_CACHE_DIR, which overrides bunfig's `cache`. Pin
+    // it so the `links/` assertions below look at this test's own store.
+    const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") };
+    await runBunInstall(env, packageDir);
 
     // A trusted package's lifecycle script can write through the package's
     // dep symlinks (the npm `bun` wrapper's postinstall renames the platform
@@ -3079,7 +3082,7 @@ describe("global virtual store", () => {
     // `meta.hasInstallScript` isn't serialised in `bun.lock`, so a warm
     // install must reach the same layout from trustedDependencies alone.
     await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
-    await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+    await runBunInstall(env, packageDir, { savesLockfile: false });
     assertLayout();
   });
 


### PR DESCRIPTION
### Problem

- With `install.globalStore = true`, a trusted package's postinstall can mutate the shared store. The npm `bun` wrapper resolves `@oven/bun-linux-x64` through its dep symlink and calls `renameSync()` on the binary. The shared entry loses `bin/bun`, so the next project that shares the cache fails with `error: Your package manager doesn't seem to support bun`. With the cache on another filesystem, the rename fails and the first install exits 1 (#40237).
- The cause is the eligibility pass in `src/install/isolated_install.rs`. It makes a trusted entry itself project-local, but the entry's dependencies stay in the global store. The trusted package's script writes through its `node_modules/<dep>` symlinks into the shared directories.

### Fix

- Record trusted entries during the eligibility DFS. After the DFS, walk each trusted entry's transitive dependency closure and mark it ineligible for the global store, so it is materialized project-local.
- The walk crosses entries that are already ineligible for other reasons, because their deps are still reachable from the script. The existing fixed-point pass then poisons dependents of the newly ineligible entries.
- This extends the trade the code already documents for the trusted entry itself: over-exclude to protect the shared store, with no lockfile-format change.
- Verified: `test/cli/install/isolated-install.test.ts` (two new tests, both fail on the unfixed build). Also the full isolated-install and bun-prune suites, and the issue's two-project repro end to end.

### Background

- The isolated linker gives each package an entry under `node_modules/.bun/<name@version>/node_modules/`, with sibling symlinks for its deps. Scripts run inside the entry, so `../<dep>` resolves through those symlinks.
- With the global store, an eligible entry is a symlink to `<cache>/links/<storepath>-<hash>/`, a directory shared by every project that uses the same cache. Nothing protects it from writes through the symlink.
- Eligibility is computed per entry. An entry whose scripts may run (trusted, or default-trusted) is project-local. A dep of an ineligible entry poisons its dependents, since a shared entry cannot symlink to a project-local path.

<details><summary>Notes</summary>

- Repro (issue): a project that depends on `bun@1.4.0` with `trustedDependencies: ["bun"]`, `globalStore = true`, `linker = "isolated"`. Cold install moves `bin/bun` out of `<cache>/links/@oven+bun-linux-x64@1.4.0-<hash>/...`. A second project sharing the cache then fails its postinstall. With the fix, both installs succeed and `<cache>/links/` has no `@oven/bun-*` entries at all.
- The trusted check now runs before the patched check in the eligibility match. The outcome is the same (both break ineligible), but a package that is both patched and trusted must still be recorded so its closure is poisoned.
- `has_trusted_dependency` includes bun's default trusted list when the project declares no `trustedDependencies`. Those packages (esbuild, sharp, ...) were already project-local. Their closures now are too. In practice the closures are mostly platform binary packages, which are exactly the dirs those scripts mutate.
- The new test pins transitivity with a depth-2 chain (`depend-on-debug-1` -> `debug-1` -> `ms-1`), checks a package outside the closure still uses the store, checks `<cache>/links/` contains nothing from the closure, and repeats the layout assertions on a warm install (the `hasInstallScript` flag is not serialized in `bun.lock`, so the warm install must reach the same layout from the trusted list alone).
- A review pass found the same gap for trusted `file:` folder deps: their scripts also run, but only the registry resolutions recorded trusted entries. A `Folder` arm now records them too, with its own test. Workspace and root stay excluded on purpose: their scripts always run, and poisoning their closures would force most of the graph out of the global store.
- Suites run: `test/cli/install/isolated-install.test.ts` (84 pass), `test/cli/install/bun-prune.test.ts` (110 pass).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->