### PR TITLE
node:os, CompressionStream, TextEncoder/TextDecoder: remove unsafe

### DIFF
--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -99,6 +99,20 @@ pub fn decode_lenient(destination: &mut [u8], source: &[u8], is_urlsafe: bool) -
     wrote
 }
 
+/// [`decode_lenient`] appended to `out` (reserving the worst case,
+/// [`decode_lenient_len`], itself); returns the number of bytes appended.
+pub fn decode_lenient_append(out: &mut Vec<u8>, source: &[u8], is_urlsafe: bool) -> usize {
+    let len = decode_lenient_len(source.len());
+    // SAFETY: the decoders behind `decode_lenient` only write the destination,
+    // and report how many leading bytes they initialized (`<= len`).
+    unsafe {
+        bun_core::vec::fill_spare(out, len, |spare| {
+            let wrote = decode_lenient(&mut spare[..len], source, is_urlsafe);
+            (wrote, wrote)
+        })
+    }
+}
+
 #[derive(thiserror::Error, strum::IntoStaticStr, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DecodeAllocError {
     #[error("DecodingFailed")]
@@ -132,6 +146,11 @@ pub fn encode_append(out: &mut Vec<u8>, source: &[u8]) -> usize {
             (written, written)
         })
     }
+}
+
+/// [`encode_url_safe`] appended to `out` (reserving the room itself); returns the number of bytes appended.
+pub fn encode_url_safe_append(out: &mut Vec<u8>, source: &[u8]) -> usize {
+    encode_append_impl(out, source, true)
 }
 
 pub fn encode_alloc(source: &[u8]) -> Vec<u8> {

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -137,11 +137,15 @@ pub use bun_core::base64::encode;
 
 /// [`encode`] appended to `out` (reserving the room itself); returns the number of bytes appended.
 pub fn encode_append(out: &mut Vec<u8>, source: &[u8]) -> usize {
-    let len = simdutf::base64::encode_len(source.len(), false);
+    encode_append_impl(out, source, false)
+}
+
+fn encode_append_impl(out: &mut Vec<u8>, source: &[u8], is_urlsafe: bool) -> usize {
+    let len = simdutf::base64::encode_len(source.len(), is_urlsafe);
     // SAFETY: `encode_raw` writes exactly `len` bytes into the `len` spare bytes reserved here.
     unsafe {
         bun_core::vec::fill_spare(out, len, |spare| {
-            let written = simdutf::base64::encode_raw(source, spare.as_mut_ptr(), false);
+            let written = simdutf::base64::encode_raw(source, spare.as_mut_ptr(), is_urlsafe);
             debug_assert_eq!(written, len);
             (written, written)
         })

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -25,7 +25,7 @@ static MIXED_DECODER: zig_base64::Base64DecoderWithIgnore = {
 /// An initialized byte buffer viewed as write slots. Sound because `u8` has no
 /// invalid bit patterns and nothing here ever stores `MaybeUninit::uninit()`.
 #[inline]
-fn as_uninit_mut(bytes: &mut [u8]) -> &mut [MaybeUninit<u8>] {
+pub(crate) fn as_uninit_mut(bytes: &mut [u8]) -> &mut [MaybeUninit<u8>] {
     // SAFETY: same layout; every slot starts (and, written only via `write`, stays) initialized.
     unsafe { &mut *(core::ptr::from_mut(bytes) as *mut [MaybeUninit<u8>]) }
 }
@@ -922,7 +922,11 @@ pub mod zig_base64 {
                 let decoded = &mut buffer[..];
                 let mut written: usize = 0;
                 decoder_ignore_nothing
-                    .decode(decoded, expected_with_ignore, &mut written)
+                    .decode(
+                        crate::as_uninit_mut(decoded),
+                        expected_with_ignore,
+                        &mut written,
+                    )
                     .unwrap();
                 assert!(written <= decoded.len());
                 assert_eq!(expected_decoded, &decoded[0..written]);
@@ -935,7 +939,7 @@ pub mod zig_base64 {
             let decoded = &mut buffer[..];
             let mut written: usize = 0;
             decoder_ignore_space
-                .decode(decoded, encoded, &mut written)
+                .decode(crate::as_uninit_mut(decoded), encoded, &mut written)
                 .unwrap();
             assert_eq!(expected_decoded, &decoded[0..written]);
         }
@@ -963,7 +967,11 @@ pub mod zig_base64 {
             }
 
             let mut written: usize = 0;
-            let result = decoder_ignore_space.decode(&mut buffer[..], encoded, &mut written);
+            let result = decoder_ignore_space.decode(
+                crate::as_uninit_mut(&mut buffer[..]),
+                encoded,
+                &mut written,
+            );
             match expected_with_ignore {
                 Some(expected) => assert_eq!(result.unwrap_err(), expected),
                 None => assert!(result.is_ok()),
@@ -976,7 +984,8 @@ pub mod zig_base64 {
             let size = codecs.decoder.calc_size_for_slice(encoded).unwrap() - 1;
             let decoded = &mut buffer[0..size];
             let mut written: usize = 0;
-            match decoder_ignore_space.decode(decoded, encoded, &mut written) {
+            match decoder_ignore_space.decode(crate::as_uninit_mut(decoded), encoded, &mut written)
+            {
                 Ok(_) => panic!("ExpectedError"),
                 Err(err) => assert_eq!(err, Error::NoSpaceLeft),
             }

--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -1,3 +1,5 @@
+use core::mem::MaybeUninit;
+
 use bun_simdutf_sys::simdutf::{self, SIMDUTFResult};
 
 // ASCII control codes used in the ignore set below.
@@ -20,8 +22,21 @@ static MIXED_DECODER: zig_base64::Base64DecoderWithIgnore = {
     decoder
 };
 
+/// An initialized byte buffer viewed as write slots. Sound because `u8` has no
+/// invalid bit patterns and nothing here ever stores `MaybeUninit::uninit()`.
+#[inline]
+fn as_uninit_mut(bytes: &mut [u8]) -> &mut [MaybeUninit<u8>] {
+    // SAFETY: same layout; every slot starts (and, written only via `write`, stays) initialized.
+    unsafe { &mut *(core::ptr::from_mut(bytes) as *mut [MaybeUninit<u8>]) }
+}
+
 pub fn decode(destination: &mut [u8], source: &[u8]) -> SIMDUTFResult {
-    let result = simdutf::base64::decode(source, destination, false);
+    decode_into_uninit(as_uninit_mut(destination), source)
+}
+
+/// [`decode`] into uninitialized storage; the leading `count` slots are initialized on return.
+fn decode_into_uninit(destination: &mut [MaybeUninit<u8>], source: &[u8]) -> SIMDUTFResult {
+    let result = simdutf::base64::decode_into_uninit(source, destination, false);
 
     if !result.is_successful() {
         // The input does not follow the WHATWG forgiving-base64 specification
@@ -65,10 +80,20 @@ pub const fn decode_lenient_len(source_len: usize) -> usize {
 ///
 /// Returns the number of bytes written to `destination`.
 pub fn decode_lenient(destination: &mut [u8], source: &[u8], is_urlsafe: bool) -> usize {
+    decode_lenient_into_uninit(as_uninit_mut(destination), source, is_urlsafe)
+}
+
+/// [`decode_lenient`] into uninitialized storage; returns how many leading
+/// slots of `destination` it initialized.
+fn decode_lenient_into_uninit(
+    destination: &mut [MaybeUninit<u8>],
+    source: &[u8],
+    is_urlsafe: bool,
+) -> usize {
     // Fast path: the common case is strictly valid base64 for the requested
     // alphabet (possibly with whitespace and padding), which simdutf decodes
     // with its fastest kernel. This is the same first attempt Node.js makes.
-    let strict = simdutf::base64::decode(source, destination, is_urlsafe);
+    let strict = simdutf::base64::decode_into_uninit(source, destination, is_urlsafe);
     if strict.is_successful() {
         return strict.count;
     }
@@ -87,7 +112,7 @@ pub fn decode_lenient(destination: &mut [u8], source: &[u8], is_urlsafe: bool) -
         source
     };
 
-    let result = simdutf::base64::decode_lenient(source, destination);
+    let result = simdutf::base64::decode_lenient_into_uninit(source, destination);
     if result.is_successful() {
         return result.count;
     }
@@ -103,11 +128,10 @@ pub fn decode_lenient(destination: &mut [u8], source: &[u8], is_urlsafe: bool) -
 /// [`decode_lenient_len`], itself); returns the number of bytes appended.
 pub fn decode_lenient_append(out: &mut Vec<u8>, source: &[u8], is_urlsafe: bool) -> usize {
     let len = decode_lenient_len(source.len());
-    // SAFETY: the decoders behind `decode_lenient` only write the destination,
-    // and report how many leading bytes they initialized (`<= len`).
+    // SAFETY: `decode_lenient_into_uninit` reports how many leading slots it initialized (`<= len`).
     unsafe {
         bun_core::vec::fill_spare(out, len, |spare| {
-            let wrote = decode_lenient(&mut spare[..len], source, is_urlsafe);
+            let wrote = decode_lenient_into_uninit(&mut spare[..len], source, is_urlsafe);
             (wrote, wrote)
         })
     }
@@ -122,14 +146,12 @@ pub enum DecodeAllocError {
 pub fn decode_alloc(input: &[u8]) -> Result<Vec<u8>, DecodeAllocError> {
     let len = decode_len(input);
     let mut dest: Vec<u8> = Vec::with_capacity(len);
-    // SAFETY: both decoders behind `decode` only write the destination, never read it.
-    let destination = unsafe { bun_core::vec::spare_bytes_mut(&mut dest) };
-    let result = decode(&mut destination[..len], input);
+    let result = decode_into_uninit(&mut dest.spare_capacity_mut()[..len], input);
     if !result.is_successful() {
         return Err(DecodeAllocError::DecodingFailed);
     }
-    // SAFETY: on success the decoder wrote the first `result.count` (<= `len`) bytes of the spare.
-    unsafe { bun_core::vec::commit_spare(&mut dest, result.count) };
+    // SAFETY: on success the decoder initialized the first `result.count` (<= `len`) spare slots.
+    unsafe { dest.set_len(result.count) };
     Ok(dest)
 }
 
@@ -142,10 +164,10 @@ pub fn encode_append(out: &mut Vec<u8>, source: &[u8]) -> usize {
 
 fn encode_append_impl(out: &mut Vec<u8>, source: &[u8], is_urlsafe: bool) -> usize {
     let len = simdutf::base64::encode_len(source.len(), is_urlsafe);
-    // SAFETY: `encode_raw` writes exactly `len` bytes into the `len` spare bytes reserved here.
+    // SAFETY: `encode_into_uninit` initializes exactly the `len` leading spare slots reserved here.
     unsafe {
         bun_core::vec::fill_spare(out, len, |spare| {
-            let written = simdutf::base64::encode_raw(source, spare.as_mut_ptr(), is_urlsafe);
+            let written = simdutf::base64::encode_into_uninit(source, spare, is_urlsafe);
             debug_assert_eq!(written, len);
             (written, written)
         })
@@ -421,6 +443,8 @@ pub mod vlq {
 }
 
 pub mod zig_base64 {
+    use core::mem::MaybeUninit;
+
     #[derive(thiserror::Error, strum::IntoStaticStr, Debug, Clone, Copy, PartialEq, Eq)]
     pub enum Error {
         #[error("InvalidCharacter")]
@@ -703,7 +727,7 @@ pub mod zig_base64 {
         /// Returns the number of bytes written to dest.
         pub(crate) fn decode(
             &self,
-            dest: &mut [u8],
+            dest: &mut [MaybeUninit<u8>],
             source: &[u8],
             wrote: &mut usize,
         ) -> Result<(), Error> {
@@ -739,7 +763,7 @@ pub mod zig_base64 {
                         return Err(Error::NoSpaceLeft);
                     }
                     acc_len -= 8;
-                    dest[*wrote] = (acc >> acc_len) as u8;
+                    dest[*wrote].write((acc >> acc_len) as u8);
                     *wrote += 1;
                 }
             }

--- a/src/boringssl/lib.rs
+++ b/src/boringssl/lib.rs
@@ -12,7 +12,7 @@ use bun_core::strings;
 
 /// BoringSSL's translated C API
 pub use boring as c;
-pub use boring::rand_bytes;
+pub use boring::{rand_bytes, rand_bytes_uninit};
 
 pub fn load() {
     // Callers are expected to invoke this on a single thread during startup

--- a/src/boringssl_sys/lib.rs
+++ b/src/boringssl_sys/lib.rs
@@ -20,6 +20,18 @@ pub fn rand_bytes(buf: &mut [u8]) {
     }
 }
 
+/// [`rand_bytes`] into uninitialized storage; every slot of `buf` is initialized on return.
+#[inline]
+pub fn rand_bytes_uninit(buf: &mut [core::mem::MaybeUninit<u8>]) {
+    if buf.is_empty() {
+        return;
+    }
+    // SAFETY: `buf` is valid for `buf.len()` writes; `RAND_bytes` stores every byte and never reads them.
+    unsafe {
+        boringssl::RAND_bytes(buf.as_mut_ptr().cast::<u8>(), buf.len());
+    }
+}
+
 /// Constant-time byte-slice equality via BoringSSL `CRYPTO_memcmp`.
 ///
 /// Returns `false` when lengths differ (the length comparison itself is NOT

--- a/src/brotli/lib.rs
+++ b/src/brotli/lib.rs
@@ -265,3 +265,179 @@ pub fn encode_append(
     unsafe { bun_core::vec::commit_spare(out, out_len) };
     Some(out_len)
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Owned streaming encoder / decoder — one codec call per `step`, output
+// into a `Vec`'s spare capacity with a caller-chosen limit.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// What one [`EncoderStream::step`] / [`DecoderStream::step`] call did.
+#[derive(Clone, Copy, Debug)]
+pub struct Step<R> {
+    /// Bytes of `input` the codec consumed.
+    pub consumed: usize,
+    /// Bytes appended to `out`.
+    pub written: usize,
+    /// Bytes of the offered output window left unused (`available_out` after the call).
+    pub avail_out: usize,
+    pub result: R,
+}
+
+/// One brotli call over `input` into `out[len..]`, offering at most `out_limit` bytes.
+#[inline]
+fn stream_step<R>(
+    input: &[u8],
+    out: &mut Vec<u8>,
+    out_limit: usize,
+    call: impl FnOnce(&mut usize, &mut *const u8, &mut usize, &mut *mut u8) -> R,
+) -> Step<R> {
+    let spare = out.spare_capacity_mut();
+    let offered = spare.len().min(out_limit);
+    let mut next_out: *mut u8 = spare.as_mut_ptr().cast::<u8>();
+    let mut avail_out = offered;
+    let mut next_in: *const u8 = input.as_ptr();
+    let mut avail_in = input.len();
+    let result = call(&mut avail_in, &mut next_in, &mut avail_out, &mut next_out);
+    let written = offered - avail_out;
+    // SAFETY: brotli wrote `written <= offered <= spare.len()` initialized
+    // bytes at the start of the spare capacity.
+    unsafe { bun_core::vec::commit_spare(out, written) };
+    Step {
+        consumed: input.len() - avail_in,
+        written,
+        avail_out,
+        result,
+    }
+}
+
+/// An owned `BrotliEncoderState` with default parameters; destroyed on drop.
+pub struct EncoderStream(ptr::NonNull<c::BrotliEncoder>);
+
+// SAFETY: the encoder state is private heap memory with no thread affinity;
+// it is only reached through `&mut self`.
+unsafe impl Send for EncoderStream {}
+
+impl EncoderStream {
+    pub fn new() -> Option<Self> {
+        // SAFETY: allocator hooks are valid `extern "C"` fns; `opaque` is unused by them.
+        ptr::NonNull::new(unsafe {
+            c::BrotliEncoderCreateInstance(
+                Some(BrotliAllocator::alloc),
+                Some(BrotliAllocator::free),
+                ptr::null_mut(),
+            )
+        })
+        .map(Self)
+    }
+
+    /// One `BrotliEncoderCompressStream(op)` call. `result` is `false` if the
+    /// encoder reported an error.
+    pub fn step(
+        &mut self,
+        op: c::BrotliEncoderOperation,
+        input: &[u8],
+        out: &mut Vec<u8>,
+        out_limit: usize,
+    ) -> Step<bool> {
+        stream_step(
+            input,
+            out,
+            out_limit,
+            |avail_in, next_in, avail_out, next_out| {
+                // SAFETY: live encoder; the four in/out params describe `input` and
+                // the spare window for this one call.
+                unsafe {
+                    c::BrotliEncoderCompressStream(
+                        self.0.as_ptr(),
+                        op,
+                        avail_in,
+                        next_in,
+                        avail_out,
+                        next_out,
+                        ptr::null_mut(),
+                    ) != 0
+                }
+            },
+        )
+    }
+}
+
+impl Drop for EncoderStream {
+    fn drop(&mut self) {
+        // SAFETY: created by `BrotliEncoderCreateInstance`, destroyed exactly once.
+        unsafe { c::BrotliEncoderDestroyInstance(self.0.as_ptr()) }
+    }
+}
+
+/// An owned `BrotliDecoderState` with default parameters; destroyed on drop.
+pub struct DecoderStream(ptr::NonNull<c::BrotliDecoder>);
+
+// SAFETY: as for `EncoderStream`.
+unsafe impl Send for DecoderStream {}
+
+impl DecoderStream {
+    pub fn new() -> Option<Self> {
+        // SAFETY: allocator hooks are valid `extern "C"` fns; `opaque` is unused by them.
+        ptr::NonNull::new(unsafe {
+            c::BrotliDecoderCreateInstance(
+                Some(BrotliAllocator::alloc),
+                Some(BrotliAllocator::free),
+                ptr::null_mut(),
+            )
+        })
+        .map(Self)
+    }
+
+    /// One `BrotliDecoderDecompressStream` call.
+    pub fn step(
+        &mut self,
+        input: &[u8],
+        out: &mut Vec<u8>,
+        out_limit: usize,
+    ) -> Step<c::BrotliDecoderResult> {
+        stream_step(
+            input,
+            out,
+            out_limit,
+            |avail_in, next_in, avail_out, next_out| {
+                // SAFETY: live decoder; the four in/out params describe `input` and
+                // the spare window for this one call.
+                unsafe {
+                    c::BrotliDecoderDecompressStream(
+                        self.0.as_ptr(),
+                        avail_in,
+                        next_in,
+                        avail_out,
+                        next_out,
+                        ptr::null_mut(),
+                    )
+                }
+            },
+        )
+    }
+
+    pub fn error_code(&self) -> c::BrotliDecoderErrorCode2 {
+        // SAFETY: live decoder.
+        c::BrotliDecoderGetErrorCode(unsafe { self.0.as_ref() })
+    }
+
+    /// Decoded bytes are still buffered in the ring buffer (brotli can report
+    /// `needs_more_input` before they are all handed out).
+    pub fn has_more_output(&self) -> bool {
+        // SAFETY: live decoder.
+        c::BrotliDecoder::has_more_output(unsafe { self.0.as_ref() })
+    }
+}
+
+impl Drop for DecoderStream {
+    fn drop(&mut self) {
+        // SAFETY: created by `BrotliDecoderCreateInstance`, destroyed exactly once.
+        unsafe { c::BrotliDecoderDestroyInstance(self.0.as_ptr()) }
+    }
+}
+
+/// `BrotliDecoderErrorString`: the `_ERROR_...` name of `code`.
+pub fn decoder_error_string(code: c::BrotliDecoderErrorCode2) -> &'static core::ffi::CStr {
+    // SAFETY: brotli returns a pointer to a static NUL-terminated string for every code.
+    unsafe { core::ffi::CStr::from_ptr(c::BrotliDecoderErrorString(code)) }
+}

--- a/src/brotli/lib.rs
+++ b/src/brotli/lib.rs
@@ -1,5 +1,7 @@
 use core::ptr;
 
+use bun_core::ffi::FfiSlice;
+
 pub mod error;
 pub use error::{Error, Result};
 
@@ -286,7 +288,7 @@ pub struct Step<R> {
 /// One brotli call over `input` into `out[len..]`, offering at most `out_limit` bytes.
 #[inline]
 fn stream_step<R>(
-    input: &[u8],
+    input: FfiSlice<'_>,
     out: &mut Vec<u8>,
     out_limit: usize,
     call: impl FnOnce(&mut usize, &mut *const u8, &mut usize, &mut *mut u8) -> R,
@@ -335,7 +337,7 @@ impl EncoderStream {
     pub fn step(
         &mut self,
         op: c::BrotliEncoderOperation,
-        input: &[u8],
+        input: FfiSlice<'_>,
         out: &mut Vec<u8>,
         out_limit: usize,
     ) -> Step<bool> {
@@ -391,7 +393,7 @@ impl DecoderStream {
     /// One `BrotliDecoderDecompressStream` call.
     pub fn step(
         &mut self,
-        input: &[u8],
+        input: FfiSlice<'_>,
         out: &mut Vec<u8>,
         out_limit: usize,
     ) -> Step<c::BrotliDecoderResult> {

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -506,36 +506,31 @@ pub mod vec {
         unsafe { v.set_len(v.len() + n) };
     }
 
-    /// One-shot "reserve → hand spare bytes to producer → commit" combinator.
+    /// One-shot "reserve → hand spare capacity to producer → commit" combinator.
     ///
     /// If `min_spare > 0`, reserves at least that many spare bytes first.
-    /// Calls `f` with the spare-capacity slice; `f` must return
+    /// Calls `f` with `v.spare_capacity_mut()`; `f` must return
     /// `(bytes_written, payload)` — `bytes_written` is committed via
     /// [`commit_spare`] and `payload` is returned to the caller. Return
     /// `(0, payload)` to commit nothing (e.g. on a producer error).
     ///
     /// # Safety
-    /// Same as [`spare_bytes_mut`]: `f` receives a slice over uninitialized
-    /// bytes and must treat it as write-only. The `bytes_written` it reports
-    /// must not exceed the slice length and must cover only bytes `f`
-    /// actually initialized.
+    /// The `bytes_written` `f` reports must not exceed the slice length and
+    /// must cover only leading slots `f` actually initialized.
     #[inline]
     pub unsafe fn fill_spare<R>(
         v: &mut Vec<u8>,
         min_spare: usize,
-        f: impl FnOnce(&mut [u8]) -> (usize, R),
+        f: impl FnOnce(&mut [core::mem::MaybeUninit<u8>]) -> (usize, R),
     ) -> R {
         if min_spare > 0 {
             v.reserve(min_spare);
         }
-        // SAFETY: caller upholds the `spare_bytes_mut` write-only contract via
-        // `f`; `n` is `f`'s reported written-byte count, which by contract is
+        let (n, r) = f(v.spare_capacity_mut());
+        // SAFETY: `n` is `f`'s reported written-byte count, which by contract is
         // ≤ the spare slice length and covers only initialized bytes.
-        unsafe {
-            let (n, r) = f(spare_bytes_mut(v));
-            commit_spare(v, n);
-            r
-        }
+        unsafe { commit_spare(v, n) };
+        r
     }
 
     /// The stack-array form of [`spare_bytes_mut`]: `N` uninitialized bytes for a producer that reports how many it wrote.
@@ -1191,11 +1186,11 @@ pub use crate::string::immutable::{
     CodePoint, DecodeHexError, LineRange, PercentEncodeError, QuoteEscapeFormatFlags,
     SplitIterator, StringOrTinyString, UNICODE_REPLACEMENT, WHITESPACE_CHARS, append, cat,
     concat_with_length, contains_char, copy, count_char, decode_hex_to_bytes,
-    decode_hex_to_bytes_truncate, encode_bytes_to_hex, ends_with_any, ends_with_char,
-    ends_with_char_or_is_zero_length, eql_any_comptime, eql_comptime, eql_comptime_utf16,
-    format_escapes, has_prefix, has_prefix_case_insensitive, has_prefix_comptime,
-    has_prefix_comptime_utf16, has_suffix_comptime, index_of, index_of_scalar, is_all_whitespace,
-    is_npm_package_name, is_npm_package_name_ignore_length, is_on_char_boundary,
+    decode_hex_to_bytes_truncate, decode_hex_to_uninit, encode_bytes_to_hex, ends_with_any,
+    ends_with_char, ends_with_char_or_is_zero_length, eql_any_comptime, eql_comptime,
+    eql_comptime_utf16, format_escapes, has_prefix, has_prefix_case_insensitive,
+    has_prefix_comptime, has_prefix_comptime_utf16, has_suffix_comptime, index_of, index_of_scalar,
+    is_all_whitespace, is_npm_package_name, is_npm_package_name_ignore_length, is_on_char_boundary,
     is_utf8_char_boundary, is_valid_utf8, last_index_of, last_index_of_t,
     length_of_leading_whitespace_ascii, memmem, order, order_t, percent_encode_write, sort_asc,
     sort_desc, split, starts_with_case_insensitive_ascii, starts_with_char, str_utf8,
@@ -1660,7 +1655,7 @@ pub(crate) mod strings_impl {
                 let r = simdutf::simdutf__convert_utf16le_to_utf8_with_errors(
                     utf16.as_ptr(),
                     utf16.len(),
-                    spare.as_mut_ptr(),
+                    spare.as_mut_ptr().cast::<u8>(),
                 );
                 (
                     if r.status == simdutf::Status::SURROGATE {
@@ -2493,9 +2488,9 @@ pub mod ffi {
         #[inline]
         pub fn copy_to(self, dst: &mut [T]) -> usize {
             let n = self.len.min(dst.len());
-            // SAFETY: `ptr[..n]` is readable (type invariant); `dst` is a distinct
-            // Rust-owned buffer of at least `n` elements.
-            unsafe { core::ptr::copy_nonoverlapping(self.ptr, dst.as_mut_ptr(), n) };
+            // SAFETY: `ptr[..n]` is readable (type invariant) and `dst` is valid for
+            // `n` writes; `from_raw` does not rule out `dst` overlapping it, so memmove.
+            unsafe { core::ptr::copy(self.ptr, dst.as_mut_ptr(), n) };
             n
         }
 

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2421,6 +2421,11 @@ pub mod ffi {
     /// borrow's lifetime, so an import taking `FfiSlice<'_, T>` can be declared
     /// `safe fn`: the callee may read `len` elements at `ptr` for the duration
     /// of the call and nothing else.
+    ///
+    /// One made with [`from_raw`](Self::from_raw) may cover memory something
+    /// else writes meanwhile (a pinned JS `ArrayBuffer`), so an `FfiSlice` is
+    /// never turned back into a `&[T]`: C code reads it, or
+    /// [`copy_to`](Self::copy_to)/[`to_vec`](Self::to_vec) take a raw copy.
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct FfiSlice<'a, T = u8> {
@@ -2437,6 +2442,79 @@ pub mod ffi {
                 len: s.len(),
                 _borrow: core::marker::PhantomData,
             }
+        }
+
+        /// # Safety
+        /// `ptr[..len]` stays allocated and readable for all of `'a` (its
+        /// contents may change, but it may not be freed, moved or shrunk).
+        #[inline]
+        pub const unsafe fn from_raw(ptr: *const T, len: usize) -> Self {
+            Self {
+                ptr,
+                len,
+                _borrow: core::marker::PhantomData,
+            }
+        }
+
+        #[inline]
+        pub const fn as_ptr(self) -> *const T {
+            self.ptr
+        }
+        #[inline]
+        pub const fn len(self) -> usize {
+            self.len
+        }
+        #[inline]
+        pub const fn is_empty(self) -> bool {
+            self.len == 0
+        }
+
+        /// `self[start..]`; panics if `start > len`.
+        #[inline]
+        #[track_caller]
+        pub fn skip(self, start: usize) -> Self {
+            assert!(start <= self.len, "FfiSlice::skip out of bounds");
+            // SAFETY: `start <= len`, so the result stays inside the same readable range.
+            unsafe { Self::from_raw(self.ptr.add(start), self.len - start) }
+        }
+
+        /// `self[..len.min(n)]`.
+        #[inline]
+        pub fn take(self, n: usize) -> Self {
+            Self {
+                len: self.len.min(n),
+                ..self
+            }
+        }
+    }
+
+    impl<'a, T: Copy> FfiSlice<'a, T> {
+        /// Copy `min(self.len, dst.len)` leading elements into `dst`; returns how many.
+        #[inline]
+        pub fn copy_to(self, dst: &mut [T]) -> usize {
+            let n = self.len.min(dst.len());
+            // SAFETY: `ptr[..n]` is readable (type invariant); `dst` is a distinct
+            // Rust-owned buffer of at least `n` elements.
+            unsafe { core::ptr::copy_nonoverlapping(self.ptr, dst.as_mut_ptr(), n) };
+            n
+        }
+
+        /// A copy of the elements as they are now.
+        pub fn to_vec(self) -> Vec<T> {
+            self.to_vec_with_prefix(&[])
+        }
+
+        /// `prefix` followed by a copy of the elements as they are now.
+        pub fn to_vec_with_prefix(self, prefix: &[T]) -> Vec<T> {
+            let mut out = Vec::<T>::with_capacity(prefix.len() + self.len);
+            out.extend_from_slice(prefix);
+            // SAFETY: `ptr[..len]` is readable (type invariant); `out` has room
+            // for `len` more elements after `prefix`, which the copy initializes.
+            unsafe {
+                core::ptr::copy_nonoverlapping(self.ptr, out.as_mut_ptr().add(out.len()), self.len);
+                out.set_len(out.len() + self.len);
+            }
+            out
         }
     }
 

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1589,6 +1589,15 @@ pub fn decode_hex_to_bytes_truncate<Char: HexChar>(
     _decode_hex_to_bytes::<Char, true>(as_uninit_mut(destination), source).unwrap_or(0)
 }
 
+/// [`decode_hex_to_bytes`] into uninitialized storage; on `Ok(n)` the leading
+/// `n` slots of `destination` are initialized.
+pub fn decode_hex_to_uninit<Char: HexChar>(
+    destination: &mut [MaybeUninit<u8>],
+    source: &[Char],
+) -> Result<usize, DecodeHexError> {
+    _decode_hex_to_bytes::<Char, false>(destination, source)
+}
+
 /// [`decode_hex_to_bytes_truncate`] appended to `out` (reserving
 /// `source.len() / 2` itself, no zero-fill); returns the number of bytes appended.
 pub fn decode_hex_append<Char: HexChar>(out: &mut Vec<u8>, source: &[Char]) -> usize {

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -36,12 +36,12 @@ pub use crate::strings_impl::{
 // Transcoding helpers from `unicode_draft` — re-exported so downstream
 // `bun_core::strings::*` callers (e.g. runtime/webcore/encoding.rs) resolve.
 pub use unicode_draft::{
-    BOM, UTF16Replacement, allocate_latin1_into_utf8, copy_cp1252_into_utf16,
-    copy_latin1_into_ascii, copy_latin1_into_utf8_stop_on_non_ascii, copy_latin1_into_utf16,
-    copy_u8_into_u16, copy_u16_into_u8, copy_utf16_into_utf8_impl,
-    element_length_cp1252_into_utf16, element_length_utf8_into_utf16, to_utf8_list_with_type_bun,
-    to_utf16_alloc_maybe_buffered, u16_is_lead, u16_is_trail, utf16_codepoint,
-    utf16_codepoint_with_fffd, wtf8_sequence,
+    BOM, UTF16Replacement, allocate_latin1_into_utf8, append_latin1_as_utf16_bytes,
+    copy_cp1252_into_utf16, copy_latin1_into_ascii, copy_latin1_into_utf8_stop_on_non_ascii,
+    copy_latin1_into_utf16, copy_u8_into_u16, copy_u16_into_u8, copy_utf16_into_utf8_impl,
+    cp1252_to_utf16_alloc, element_length_cp1252_into_utf16, element_length_utf8_into_utf16,
+    to_utf8_list_with_type_bun, to_utf16_alloc_maybe_buffered, u16_is_lead, u16_is_trail,
+    utf16_codepoint, utf16_codepoint_with_fffd, wtf8_sequence,
 };
 
 /// `bun.strings.visible` — terminal-visible-width helpers. The implementation
@@ -1578,6 +1578,20 @@ pub fn decode_hex_to_bytes_truncate<Char: HexChar>(
     source: &[Char],
 ) -> usize {
     _decode_hex_to_bytes::<Char, true>(destination, source).unwrap_or(0)
+}
+
+/// [`decode_hex_to_bytes_truncate`] appended to `out` (reserving
+/// `source.len() / 2` itself, no zero-fill); returns the number of bytes appended.
+pub fn decode_hex_append<Char: HexChar>(out: &mut Vec<u8>, source: &[Char]) -> usize {
+    let n = source.len() / 2;
+    // SAFETY: the hex decoders only write `destination` and report how many
+    // leading bytes they wrote (`<= n`), which is all that gets committed.
+    unsafe {
+        crate::vec::fill_spare(out, n, |spare| {
+            let wrote = decode_hex_to_bytes_truncate(&mut spare[..n], source);
+            (wrote, wrote)
+        })
+    }
 }
 
 #[inline]

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2,6 +2,7 @@
 //! SIMD-accelerated immutable string utilities operating on `&[u8]` (NOT `&str`).
 
 use core::cmp::Ordering;
+use core::mem::MaybeUninit;
 
 use crate::BoundedArray;
 use crate::CrateError as Error;
@@ -1538,8 +1539,8 @@ pub trait HexChar: Copy {
 
     /// Decode up to `min(src.len() / 2, dst.len())` hex pairs with SIMD,
     /// stopping at the first pair containing a non-hex character.
-    /// Returns the number of bytes written.
-    fn decode_hex_highway(src: &[Self], dst: &mut [u8]) -> usize;
+    /// Returns the number of (leading) bytes written.
+    fn decode_hex_highway(src: &[Self], dst: &mut [MaybeUninit<u8>]) -> usize;
 }
 
 impl HexChar for u8 {
@@ -1549,7 +1550,7 @@ impl HexChar for u8 {
     }
 
     #[inline(always)]
-    fn decode_hex_highway(src: &[Self], dst: &mut [u8]) -> usize {
+    fn decode_hex_highway(src: &[Self], dst: &mut [MaybeUninit<u8>]) -> usize {
         highway::decode_hex(src, dst)
     }
 }
@@ -1561,42 +1562,48 @@ impl HexChar for u16 {
     }
 
     #[inline(always)]
-    fn decode_hex_highway(src: &[Self], dst: &mut [u8]) -> usize {
+    fn decode_hex_highway(src: &[Self], dst: &mut [MaybeUninit<u8>]) -> usize {
         highway::decode_hex_u16(src, dst)
     }
+}
+
+/// An initialized byte buffer viewed as write slots. Sound because `u8` has no
+/// invalid bit patterns and nothing here ever stores `MaybeUninit::uninit()`.
+#[inline]
+fn as_uninit_mut(bytes: &mut [u8]) -> &mut [MaybeUninit<u8>] {
+    // SAFETY: same layout; every slot starts (and, written only via `write`, stays) initialized.
+    unsafe { &mut *(core::ptr::from_mut(bytes) as *mut [MaybeUninit<u8>]) }
 }
 
 pub fn decode_hex_to_bytes<Char: HexChar>(
     destination: &mut [u8],
     source: &[Char],
 ) -> Result<usize, DecodeHexError> {
-    _decode_hex_to_bytes::<Char, false>(destination, source)
+    _decode_hex_to_bytes::<Char, false>(as_uninit_mut(destination), source)
 }
 
 pub fn decode_hex_to_bytes_truncate<Char: HexChar>(
     destination: &mut [u8],
     source: &[Char],
 ) -> usize {
-    _decode_hex_to_bytes::<Char, true>(destination, source).unwrap_or(0)
+    _decode_hex_to_bytes::<Char, true>(as_uninit_mut(destination), source).unwrap_or(0)
 }
 
 /// [`decode_hex_to_bytes_truncate`] appended to `out` (reserving
 /// `source.len() / 2` itself, no zero-fill); returns the number of bytes appended.
 pub fn decode_hex_append<Char: HexChar>(out: &mut Vec<u8>, source: &[Char]) -> usize {
     let n = source.len() / 2;
-    // SAFETY: the hex decoders only write `destination` and report how many
-    // leading bytes they wrote (`<= n`), which is all that gets committed.
-    unsafe {
-        crate::vec::fill_spare(out, n, |spare| {
-            let wrote = decode_hex_to_bytes_truncate(&mut spare[..n], source);
-            (wrote, wrote)
-        })
-    }
+    out.reserve(n);
+    let wrote =
+        _decode_hex_to_bytes::<Char, true>(&mut out.spare_capacity_mut()[..n], source).unwrap_or(0);
+    // SAFETY: the decoder initialized the first `wrote <= n` spare slots.
+    unsafe { out.set_len(out.len() + wrote) };
+    wrote
 }
 
 #[inline]
 fn _decode_hex_to_bytes<Char: HexChar, const TRUNCATE: bool>(
-    destination: &mut [u8],
+    destination: &mut [MaybeUninit<u8>],
     source: &[Char],
 ) -> Result<usize, DecodeHexError> {
     // Highway fast path: decode whole pairs in bulk, stopping at the first
@@ -1635,7 +1642,7 @@ fn _decode_hex_to_bytes<Char: HexChar, const TRUNCATE: bool>(
             }
             return Err(DecodeHexError::InvalidByteSequence);
         }
-        remain[0] = (a << 4) | b;
+        remain[0].write((a << 4) | b);
         remain = &mut remain[1..];
         input = &input[2..];
     }

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -454,6 +454,37 @@ pub fn copy_latin1_into_utf16(buf_: &mut [u16], latin1_: &[u8]) -> EncodeIntoRes
     }
 }
 
+/// [`copy_cp1252_into_utf16`] into a fresh, exactly-sized `Vec<u16>` (no zero-fill).
+pub fn cp1252_to_utf16_alloc(cp1252: &[u8]) -> Vec<u16> {
+    let mut out: Vec<u16> = Vec::with_capacity(cp1252.len());
+    let spare = &mut out.spare_capacity_mut()[..cp1252.len()];
+    // SAFETY: `MaybeUninit<u16>` and `u16` have the same layout; the slice is
+    // handed write-only to `copy_cp1252_into_utf16`, which stores one unit per
+    // input byte and reads none of it, so all `cp1252.len()` units are then set.
+    unsafe {
+        let dst = &mut *(core::ptr::from_mut(spare) as *mut [u16]);
+        let r = copy_cp1252_into_utf16(dst, cp1252);
+        debug_assert_eq!(r.written as usize, cp1252.len());
+        out.set_len(r.written as usize);
+    }
+    out
+}
+
+/// Each Latin-1 byte widened to one native-endian UTF-16 code unit, appended
+/// to `out` as bytes (`2 * latin1.len()` of them, no zero-fill).
+pub fn append_latin1_as_utf16_bytes(out: &mut Vec<u8>, latin1: &[u8]) {
+    out.reserve(latin1.len() * 2);
+    let (pairs, _) = out.spare_capacity_mut().as_chunks_mut::<2>();
+    for (pair, &b) in pairs.iter_mut().zip(latin1) {
+        let [lo, hi] = u16::from(b).to_ne_bytes();
+        pair[0].write(lo);
+        pair[1].write(hi);
+    }
+    // SAFETY: the loop initialized one pair per input byte — the first
+    // `2 * latin1.len()` spare bytes, which `reserve` made room for.
+    unsafe { out.set_len(out.len() + latin1.len() * 2) };
+}
+
 pub fn element_length_cp1252_into_utf16(cp1252_: &[u8]) -> usize {
     // cp1252 is always at most 1 UTF-16 code unit long
     cp1252_.len()

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -456,18 +456,16 @@ pub fn copy_latin1_into_utf16(buf_: &mut [u16], latin1_: &[u8]) -> EncodeIntoRes
 
 /// [`copy_cp1252_into_utf16`] into a fresh, exactly-sized `Vec<u16>` (no zero-fill).
 pub fn cp1252_to_utf16_alloc(cp1252: &[u8]) -> Vec<u16> {
-    let mut out: Vec<u16> = Vec::with_capacity(cp1252.len());
-    let spare = &mut out.spare_capacity_mut()[..cp1252.len()];
-    // SAFETY: `MaybeUninit<u16>` and `u16` have the same layout; the slice is
-    // handed write-only to `copy_cp1252_into_utf16`, which stores one unit per
-    // input byte and reads none of it, so all `cp1252.len()` units are then set.
-    unsafe {
-        let dst = &mut *(core::ptr::from_mut(spare) as *mut [u16]);
-        let r = copy_cp1252_into_utf16(dst, cp1252);
-        debug_assert_eq!(r.written as usize, cp1252.len());
-        out.set_len(r.written as usize);
-    }
-    out
+    cp1252
+        .iter()
+        .map(|&b| {
+            if b < 0x80 {
+                u16::from(b)
+            } else {
+                cp1252_to_codepoint_bytes_assume_not_ascii16(u32::from(b))
+            }
+        })
+        .collect()
 }
 
 /// Each Latin-1 byte widened to one native-endian UTF-16 code unit, appended

--- a/src/codegen/generate-host-exports.ts
+++ b/src/codegen/generate-host-exports.ts
@@ -110,6 +110,8 @@ interface Param {
   callExpr: string;
   /** `&[T]` param: the C signature carries a trailing `name_len: usize` */
   extraLen?: boolean;
+  /** `SinkHandle` param: the C signature is `(name_id: u8, name: *mut c_void)` */
+  sinkId?: boolean;
 }
 
 interface Export {
@@ -130,7 +132,12 @@ const markerRe = /^\s*\/\/\s*HOST_EXPORT\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:,\s*(
 // a small balanced-paren scanner because params routinely span lines.
 const fnHeadRe = /^\s*pub\s+(unsafe\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/;
 
-function ptrify(ty: string): { cTy: string; deref: (n: string) => string; extraLen?: boolean } {
+function ptrify(ty: string): {
+  cTy: string;
+  deref: (n: string) => string;
+  extraLen?: boolean;
+  sinkId?: boolean;
+} {
   ty = ty.trim();
   // `&[T]` — C passes `(const T* name, size_t name_len)`; the thunk rebuilds
   // the slice (null/0 → empty).
@@ -144,9 +151,32 @@ function ptrify(ty: string): { cTy: string; deref: (n: string) => string; extraL
         `{\n        // SAFETY: C++ caller passes \`${n}_len\` live elements at \`${n}\` (or 0).\n        unsafe { ::bun_core::ffi::slice(${n}, ${n}_len) }\n    }`,
     };
   }
-  // Other slice shapes (`&mut [T]`, `&'a [T]`) and `&str` are NOT FFI-safe; reject.
+  // `&mut [T]` — C passes `(T* name, size_t name_len)`, a buffer nothing
+  // else reads or writes for the duration of the call (null/0 → empty).
+  const sliceMut = /^&mut\s*\[\s*([^;]+?)\s*\]$/.exec(ty);
+  if (sliceMut) {
+    const elem = sliceMut[1].trim();
+    return {
+      cTy: `*mut ${elem}`,
+      extraLen: true,
+      deref: n =>
+        `{\n        // SAFETY: C++ caller passes \`${n}_len\` live, unaliased elements at \`${n}\` (or 0).\n        unsafe { ::bun_core::ffi::slice_mut(${n}, ${n}_len) }\n    }`,
+    };
+  }
+  // Other slice shapes (`&'a [T]`) and `&str` are NOT FFI-safe; reject.
   if (/^&[^\[]*\[/.test(ty) || /^&\s*str\b/.test(ty)) {
-    throw new Error(`slice/str param \`${ty}\` is not FFI-safe; use \`&[T]\` (const) or (ptr, len)`);
+    throw new Error(`slice/str param \`${ty}\` is not FFI-safe; use \`&[T]\`/\`&mut [T]\` or (ptr, len)`);
+  }
+  // `SinkHandle` — C passes the `(uint8_t id, void* ptr)` pair a
+  // `JSTransformStream` holds for its attached native sink (`m_nativeSinkId`,
+  // `m_nativeSinkPtr`); the thunk resolves it to the typed handle.
+  if (/^(?:crate::webcore::)?SinkHandle$/.test(ty)) {
+    return {
+      cTy: `*mut c_void`,
+      sinkId: true,
+      deref: n =>
+        `match ::core::ptr::NonNull::new(${n}) {\n        // SAFETY: C++ caller passes a live JSSink of type \`${n}_id\`, valid for the call.\n        Some(p) => unsafe { crate::webcore::sink::sink_handle_from_id(${n}_id, p) },\n        None => crate::webcore::SinkHandle::None,\n    }`,
+    };
   }
   // `&mut T` / `&T` — keep as a reference in the thunk signature. `&T` and
   // `*const T` (resp. `&mut T`/`*mut T`) are ABI-identical for `extern "C"`
@@ -197,8 +227,8 @@ function parseParams(list: string, where: string): Param[] {
       // and intentionally documentary — keep it.
       if (name === "_") name = `_a${i}`;
       const ty = raw.slice(colon + 1).trim();
-      const { cTy, deref, extraLen } = ptrify(ty);
-      return { raw, name, ty, cTy, callExpr: deref(name), extraLen };
+      const { cTy, deref, extraLen, sinkId } = ptrify(ty);
+      return { raw, name, ty, cTy, callExpr: deref(name), extraLen, sinkId };
     });
 }
 
@@ -490,13 +520,21 @@ pub extern "Rust" fn ${e.symbol}(${sig}) -> ${e.ret} {
 }`;
     }
     case "generic": {
-      for (const p of e.params)
-        if (p.extraLen && e.params.some(q => q.name === `${p.name}_len`))
+      for (const p of e.params) {
+        const extra = p.extraLen ? `${p.name}_len` : p.sinkId ? `${p.name}_id` : null;
+        if (extra && e.params.some(q => q.name === extra))
           throw new Error(
-            `${loc}: slice param \`${p.name}\` needs a synthesized \`${p.name}_len\`, which collides with an existing param`,
+            `${loc}: param \`${p.name}\` needs a synthesized \`${extra}\`, which collides with an existing param`,
           );
+      }
       const sig = e.params
-        .map(p => (p.extraLen ? `${p.name}: ${p.cTy}, ${p.name}_len: usize` : `${p.name}: ${p.cTy}`))
+        .map(p =>
+          p.extraLen
+            ? `${p.name}: ${p.cTy}, ${p.name}_len: usize`
+            : p.sinkId
+              ? `${p.name}_id: u8, ${p.name}: ${p.cTy}`
+              : `${p.name}: ${p.cTy}`,
+        )
         .join(", ");
       // Bind each ref-deref once so the call site is clean (and so a
       // `JsResult` body doesn't deref `global` twice).

--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -648,15 +648,17 @@ pub fn encode_hex_lower(src: &[u8], dst: &mut [u8]) {
 /// bytes written (`min(src.len() / 2, dst.len())` when the input is fully
 /// valid). A trailing lone hex digit is ignored.
 #[inline(always)]
-pub fn decode_hex(src: &[u8], dst: &mut [u8]) -> usize {
+pub fn decode_hex(src: &[u8], dst: &mut [core::mem::MaybeUninit<u8>]) -> usize {
     let pairs = (src.len() / 2).min(dst.len());
     if pairs == 0 {
         return 0;
     }
 
     // SAFETY: `src` is readable for at least `2 * pairs` bytes and `dst` is
-    // writable for at least `pairs` bytes; the kernel reads/writes at most that.
-    let written = unsafe { highway_decode_hex8(src.as_ptr(), dst.as_mut_ptr(), pairs) };
+    // writable for at least `pairs` bytes; the kernel only writes `dst`, and
+    // initializes exactly the `written` leading bytes it reports.
+    let written =
+        unsafe { highway_decode_hex8(src.as_ptr(), dst.as_mut_ptr().cast::<u8>(), pairs) };
 
     debug_assert!(written <= pairs);
     written
@@ -666,15 +668,17 @@ pub fn decode_hex(src: &[u8], dst: &mut [u8]) -> usize {
 /// byte, as Node's `Buffer` hex decoder does: U+FF41 decodes as `'A'`, and a
 /// unit whose low byte is not a hex digit stops decoding.
 #[inline(always)]
-pub fn decode_hex_u16(src: &[u16], dst: &mut [u8]) -> usize {
+pub fn decode_hex_u16(src: &[u16], dst: &mut [core::mem::MaybeUninit<u8>]) -> usize {
     let pairs = (src.len() / 2).min(dst.len());
     if pairs == 0 {
         return 0;
     }
 
     // SAFETY: `src` is readable for at least `2 * pairs` code units and `dst`
-    // is writable for at least `pairs` bytes; the kernel reads/writes at most that.
-    let written = unsafe { highway_decode_hex16(src.as_ptr(), dst.as_mut_ptr(), pairs) };
+    // is writable for at least `pairs` bytes; the kernel only writes `dst`, and
+    // initializes exactly the `written` leading bytes it reports.
+    let written =
+        unsafe { highway_decode_hex16(src.as_ptr(), dst.as_mut_ptr().cast::<u8>(), pairs) };
 
     debug_assert!(written <= pairs);
     written

--- a/src/jsc/JSString.rs
+++ b/src/jsc/JSString.rs
@@ -43,6 +43,79 @@ impl JSString {
         unsafe { JSC__JSString__iterator(self, global_object, core::ptr::from_mut(iter).cast()) }
     }
 
+    /// Walk this string's characters without resolving it: a rope's fibers
+    /// are handed to `visitor` one at a time, until it returns `false`.
+    pub fn visit<V: StringVisitor>(&self, global_object: &JSGlobalObject, visitor: &mut V) {
+        /// One callback: hand `len` characters at `ptr` to the visitor behind
+        /// `it.data`, stopping the iteration if it says so.
+        ///
+        /// # Safety
+        /// `it` is the `Iterator` built in `visit::<V>` (so `data` is its
+        /// `&mut V`, not otherwise borrowed during `JSC__JSString__iterator`),
+        /// and `ptr[..len]` is live for the call.
+        unsafe fn deliver<V, T>(
+            it: *mut Iterator,
+            ptr: *const T,
+            len: u32,
+            f: impl FnOnce(&mut V, &[T]) -> bool,
+        ) {
+            // SAFETY: fn contract.
+            let (it, visitor, chunk) = unsafe {
+                let it = &mut *it;
+                let visitor = &mut *it.data.cast::<V>();
+                (it, visitor, bun_core::ffi::slice(ptr, len as usize))
+            };
+            if !f(visitor, chunk) {
+                it.stop = 1;
+            }
+        }
+        // SAFETY (the four below): JSC calls back synchronously with the
+        // `Iterator` passed to `JSC__JSString__iterator` and a live segment.
+        unsafe extern "C" fn append8<V: StringVisitor>(
+            it: *mut Iterator,
+            ptr: *const u8,
+            len: u32,
+        ) {
+            // SAFETY: see above.
+            unsafe { deliver::<V, u8>(it, ptr, len, |v, c| v.append8(c)) }
+        }
+        unsafe extern "C" fn append16<V: StringVisitor>(
+            it: *mut Iterator,
+            ptr: *const u16,
+            len: u32,
+        ) {
+            // SAFETY: see above.
+            unsafe { deliver::<V, u16>(it, ptr, len, |v, c| v.append16(c)) }
+        }
+        unsafe extern "C" fn write8<V: StringVisitor>(
+            it: *mut Iterator,
+            ptr: *const u8,
+            len: u32,
+            offset: u32,
+        ) {
+            // SAFETY: see above.
+            unsafe { deliver::<V, u8>(it, ptr, len, |v, c| v.write8(c, offset)) }
+        }
+        unsafe extern "C" fn write16<V: StringVisitor>(
+            it: *mut Iterator,
+            ptr: *const u16,
+            len: u32,
+            offset: u32,
+        ) {
+            // SAFETY: see above.
+            unsafe { deliver::<V, u16>(it, ptr, len, |v, c| v.write16(c, offset)) }
+        }
+        let mut iter = Iterator {
+            data: core::ptr::from_mut(visitor).cast(),
+            stop: 0,
+            append8: Some(append8::<V>),
+            append16: Some(append16::<V>),
+            write8: Some(write8::<V>),
+            write16: Some(write16::<V>),
+        };
+        self.iterator(global_object, &mut iter);
+    }
+
     pub fn length(&self) -> usize {
         JSC__JSString__length(self)
     }
@@ -90,6 +163,16 @@ impl Drop for JSStringView<'_> {
     fn drop(&mut self) {
         self.cell.ensure_still_alive();
     }
+}
+
+/// The segments of a [`JSString`] as [`JSString::visit`] finds them:
+/// `append*` in order from the start, `write*` at a given character offset.
+/// Return `false` from any of them to stop.
+pub trait StringVisitor {
+    fn append8(&mut self, chunk: &[u8]) -> bool;
+    fn append16(&mut self, chunk: &[u16]) -> bool;
+    fn write8(&mut self, chunk: &[u8], offset: u32) -> bool;
+    fn write16(&mut self, chunk: &[u16], offset: u32) -> bool;
 }
 
 pub(crate) type JStringIteratorAppend8Callback =

--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -746,14 +746,8 @@ fn read_cache_file(state: &CacheState, key: u64, entry: &mut Entry, code: Option
                 finish(line, &|| "allocation failed\n".into());
                 return;
             }
-            // SAFETY: `pread_all` only writes into the spare bytes and returns how many it filled.
-            let read = unsafe {
-                bun_core::vec::fill_spare(&mut contents, 0, |spare| {
-                    let read = file.pread_all(&mut spare[..total], 0).ok();
-                    (read.unwrap_or(0), read)
-                })
-            };
-            if read != Some(total) {
+            contents.resize(total, 0);
+            if file.pread_all(&mut contents, 0).ok() != Some(total) {
                 finish(line, &|| "reading header failed\n".into());
                 return;
             }

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -172,12 +172,16 @@ impl ArrayBuffer {
 /// an [`FfiSlice`](bun_core::ffi::FfiSlice) for C code (a codec) to read,
 /// under the job's [`Ticket`](crate::Ticket). Made on the JS thread and
 /// released there when the job comes back.
-pub struct JobPinnedArrayBuffer(PinnedArrayBuffer);
+pub struct JobPinnedArrayBuffer {
+    buffer: PinnedArrayBuffer,
+    /// The VM whose heap owns `buffer`: the only thread that may unpin/unroot it.
+    owner: *const crate::virtual_machine::VirtualMachine,
+}
 
 // SAFETY: the only off-thread operation is `ffi_slice`, which demands a
 // `Ticket` (VM alive) and lends memory that is pinned in place and rooted for
 // as long as `self` lives, never as a `&[u8]`; `Drop` releases pin/root only
-// on a JS thread (see there) and is a leak, not a race, anywhere else.
+// on the owning VM's thread (see there) and is a leak, not a race, anywhere else.
 unsafe impl Send for JobPinnedArrayBuffer {}
 
 impl JobPinnedArrayBuffer {
@@ -191,11 +195,14 @@ impl JobPinnedArrayBuffer {
         if buffer.resizable || buffer.shared || buffer.ptr.is_null() {
             return None;
         }
-        Some(Self(buffer))
+        Some(Self {
+            buffer,
+            owner: global.bun_vm_ptr().cast_const(),
+        })
     }
 
     pub fn byte_len(&self) -> usize {
-        self.0.byte_len
+        self.buffer.byte_len
     }
 
     /// The bytes, for C code to read from any thread that holds a job's
@@ -206,17 +213,20 @@ impl JobPinnedArrayBuffer {
         // while `self` lives, and the heap outlives the ticket: the `byte_len`
         // bytes at `ptr` stay allocated for `'a`. May be concurrently written
         // by JS; `FfiSlice` never forms a `&[u8]` over it.
-        unsafe { bun_core::ffi::FfiSlice::from_raw(self.0.ptr.cast_const(), self.0.byte_len) }
+        unsafe {
+            bun_core::ffi::FfiSlice::from_raw(self.buffer.ptr.cast_const(), self.buffer.byte_len)
+        }
     }
 }
 
 impl Drop for JobPinnedArrayBuffer {
     fn drop(&mut self) {
-        // Pin count and the protected-values table belong to the JS thread. A
-        // job always comes back to its VM's thread to drop this; a thread with
-        // no VM (nothing else should hold one) leaks the pin instead of racing.
-        if crate::virtual_machine::VirtualMachine::get_or_null().is_none() {
-            self.0.defuse();
+        // Pin count and the protected-values table belong to the owning VM's
+        // thread. A job always comes back there to drop this; any other thread
+        // (no VM, or another VM's) leaks the pin instead of racing.
+        let here = crate::virtual_machine::VirtualMachine::get_or_null();
+        if here.map(<*mut _>::cast_const) != Some(self.owner) {
+            self.buffer.defuse();
         }
     }
 }

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -205,14 +205,17 @@ impl JobPinnedArrayBuffer {
         self.buffer.byte_len
     }
 
-    /// The bytes, for C code to read from any thread that holds a job's
-    /// ticket. The owning JS thread may store into them concurrently; a
+    /// The bytes, for C code to read while both `self` and the job's ticket
+    /// are held. The owning JS thread may store into them concurrently; a
     /// reader sees each byte's old or new value.
-    pub fn ffi_slice<'a>(&'a self, _vm_alive: &crate::Ticket) -> bun_core::ffi::FfiSlice<'a, u8> {
+    pub fn ffi_slice<'a>(
+        &'a self,
+        _vm_alive: &'a crate::Ticket,
+    ) -> bun_core::ffi::FfiSlice<'a, u8> {
         // SAFETY: pinned (no detach/transfer, not resizable/shared) and rooted
-        // while `self` lives, and the heap outlives the ticket: the `byte_len`
-        // bytes at `ptr` stay allocated for `'a`. May be concurrently written
-        // by JS; `FfiSlice` never forms a `&[u8]` over it.
+        // while `self` lives, and the heap is alive while the ticket is borrowed:
+        // the `byte_len` bytes at `ptr` stay allocated for `'a`, which both bound.
+        // May be concurrently written by JS; `FfiSlice` never forms a `&[u8]` over it.
         unsafe {
             bun_core::ffi::FfiSlice::from_raw(self.buffer.ptr.cast_const(), self.buffer.byte_len)
         }

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -162,7 +162,57 @@ impl ArrayBuffer {
     // require('buffer').kMaxLength.
     // keep in sync with Bun::Buffer::kMaxLength
     pub const MAX_SIZE: c_uint = c_uint::MAX;
+}
 
+/// An `ArrayBuffer`'s (or view's) bytes for a pool [`Job`](crate::Job) to
+/// read: the buffer is pinned (it cannot be detached or transferred, and —
+/// being non-resizable or a growable `SharedArrayBuffer` — cannot move or
+/// shrink) and its cell GC-protected until this is dropped. Like
+/// [`ThreadSafe`](crate::node_path::ThreadSafe), it is made on the JS thread
+/// and released there when the job comes back; in between, the job reads the
+/// bytes under its [`Ticket`](crate::Ticket) (proof the heap is still alive).
+pub struct PinnedArrayBuffer(ArrayBuffer);
+
+// SAFETY: the only off-thread operation is `bytes`, which demands a `Ticket`
+// (VM alive) and reads memory that is pinned in place and protected for as
+// long as `self` lives; `Drop` releases pin/protect only on a JS thread (see
+// there) and is a leak, not a race, anywhere else.
+unsafe impl Send for PinnedArrayBuffer {}
+
+impl PinnedArrayBuffer {
+    /// Pin and protect `value` if it is an `ArrayBuffer` or view whose bytes
+    /// stay put while pinned; `None` otherwise (not a buffer, or a resizable
+    /// non-shared one, whose `resize()` can decommit pages regardless of the pin).
+    pub fn pin(global: &JSGlobalObject, value: JSValue) -> Option<Self> {
+        let buffer = value.as_pinned_arraybuffer(global)?;
+        if buffer.resizable && !buffer.shared {
+            buffer.unpin();
+            return None;
+        }
+        buffer.value.protect();
+        Some(Self(buffer))
+    }
+
+    /// The bytes, from any thread that holds a job's ticket.
+    #[inline]
+    pub fn bytes<'a>(&'a self, _vm_alive: &crate::Ticket) -> &'a [u8] {
+        self.0.byte_slice()
+    }
+}
+
+impl Drop for PinnedArrayBuffer {
+    fn drop(&mut self) {
+        // Pin count and the protected-values table belong to the JS thread. A
+        // job always comes back to its VM's thread to drop this; a thread with
+        // no VM (nothing else should hold one) leaks the pin instead of racing.
+        if crate::virtual_machine::VirtualMachine::get_or_null().is_some() {
+            self.0.unpin();
+            self.0.value.unprotect();
+        }
+    }
+}
+
+impl ArrayBuffer {
     // 4 MB or so is pretty good for mmap()
     const MMAP_THRESHOLD: usize = 1024 * 1024 * 4;
 

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -164,28 +164,29 @@ impl ArrayBuffer {
     pub const MAX_SIZE: c_uint = c_uint::MAX;
 }
 
-/// An `ArrayBuffer`'s (or view's) bytes for a pool [`Job`](crate::Job) to
-/// read: the buffer is pinned (it cannot be detached or transferred, and —
-/// being non-resizable or a growable `SharedArrayBuffer` — cannot move or
-/// shrink) and its cell GC-protected until this is dropped. Like
-/// [`ThreadSafe`](crate::node_path::ThreadSafe), it is made on the JS thread
-/// and released there when the job comes back; in between, the job reads the
-/// bytes under its [`Ticket`](crate::Ticket) (proof the heap is still alive).
+/// An `ArrayBuffer`'s (or view's) bytes handed to a pool [`Job`](crate::Job)
+/// without copying them on the JS thread: the buffer is pinned (it cannot be
+/// detached or transferred, and — being neither resizable nor shared — cannot
+/// move, shrink, or be written by another agent) and its cell GC-protected
+/// until this is dropped. JS on the owning thread can still store into it
+/// while the job runs, so the job never views it as a `&[u8]`; it takes a
+/// snapshot with [`to_vec`](Self::to_vec) under its [`Ticket`](crate::Ticket).
+/// Like [`ThreadSafe`](crate::node_path::ThreadSafe), it is made on the JS
+/// thread and released there when the job comes back.
 pub struct PinnedArrayBuffer(ArrayBuffer);
 
-// SAFETY: the only off-thread operation is `bytes`, which demands a `Ticket`
-// (VM alive) and reads memory that is pinned in place and protected for as
-// long as `self` lives; `Drop` releases pin/protect only on a JS thread (see
+// SAFETY: the only off-thread operation is `to_vec`, which demands a `Ticket`
+// (VM alive) and raw-copies memory that is pinned in place and protected for
+// as long as `self` lives; `Drop` releases pin/protect only on a JS thread (see
 // there) and is a leak, not a race, anywhere else.
 unsafe impl Send for PinnedArrayBuffer {}
 
 impl PinnedArrayBuffer {
-    /// Pin and protect `value` if it is an `ArrayBuffer` or view whose bytes
-    /// stay put while pinned; `None` otherwise (not a buffer, or a resizable
-    /// non-shared one, whose `resize()` can decommit pages regardless of the pin).
+    /// Pin and protect `value` if it is a non-shared, non-resizable
+    /// `ArrayBuffer` or view; `None` otherwise (the caller copies instead).
     pub fn pin(global: &JSGlobalObject, value: JSValue) -> Option<Self> {
         let buffer = value.as_pinned_arraybuffer(global)?;
-        if buffer.resizable && !buffer.shared {
+        if buffer.resizable || buffer.shared {
             buffer.unpin();
             return None;
         }
@@ -193,10 +194,27 @@ impl PinnedArrayBuffer {
         Some(Self(buffer))
     }
 
-    /// The bytes, from any thread that holds a job's ticket.
-    #[inline]
-    pub fn bytes<'a>(&'a self, _vm_alive: &crate::Ticket) -> &'a [u8] {
-        self.0.byte_slice()
+    pub fn byte_len(&self) -> usize {
+        self.0.byte_len
+    }
+
+    /// A copy of the bytes as they are now, from any thread that holds a
+    /// job's ticket. The owning JS thread may be storing into the buffer
+    /// concurrently; what such a racing store contributes is unspecified.
+    pub fn to_vec(&self, _vm_alive: &crate::Ticket) -> Vec<u8> {
+        let len = self.0.byte_len;
+        let mut out = Vec::<u8>::with_capacity(len);
+        if len != 0 {
+            // SAFETY: `ptr[..len]` is the pinned, protected backing store (alive
+            // while the VM is, which the ticket proves); `out` has `len` bytes of
+            // capacity and the two cannot overlap. Read through a raw pointer,
+            // never a `&[u8]`, because JS may write it meanwhile.
+            unsafe {
+                core::ptr::copy_nonoverlapping(self.0.ptr.cast_const(), out.as_mut_ptr(), len);
+                out.set_len(len);
+            }
+        }
+        out
     }
 }
 

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -165,20 +165,21 @@ impl ArrayBuffer {
 }
 
 /// An `ArrayBuffer`'s (or view's) bytes handed to a pool [`Job`](crate::Job)
-/// without copying them on the JS thread: the buffer is pinned (it cannot be
-/// detached or transferred, and — being neither resizable nor shared — cannot
-/// move, shrink, or be written by another agent) and its cell GC-protected
-/// until this is dropped. JS on the owning thread can still store into it
-/// while the job runs, so the job never views it as a `&[u8]`; it takes a
-/// snapshot with [`to_vec`](Self::to_vec) under its [`Ticket`](crate::Ticket).
-/// Like [`ThreadSafe`](crate::node_path::ThreadSafe), it is made on the JS
-/// thread and released there when the job comes back.
+/// without copying: the buffer is pinned (it cannot be detached or
+/// transferred, and — being neither resizable nor shared — cannot move,
+/// shrink, or be written by another agent) and its cell GC-protected until
+/// this is dropped. JS on the owning thread can still store into it while the
+/// job runs, so the job never views it as a `&[u8]`: [`ffi_slice`](Self::ffi_slice)
+/// lends it as an [`FfiSlice`](bun_core::ffi::FfiSlice) for C code (a codec)
+/// to read, under the job's [`Ticket`](crate::Ticket). Like
+/// [`ThreadSafe`](crate::node_path::ThreadSafe), it is made on the JS thread
+/// and released there when the job comes back.
 pub struct PinnedArrayBuffer(ArrayBuffer);
 
-// SAFETY: the only off-thread operation is `to_vec`, which demands a `Ticket`
-// (VM alive) and raw-copies memory that is pinned in place and protected for
-// as long as `self` lives; `Drop` releases pin/protect only on a JS thread (see
-// there) and is a leak, not a race, anywhere else.
+// SAFETY: the only off-thread operation is `ffi_slice`, which demands a
+// `Ticket` (VM alive) and lends memory that is pinned in place and protected
+// for as long as `self` lives, never as a `&[u8]`; `Drop` releases pin/protect
+// only on a JS thread (see there) and is a leak, not a race, anywhere else.
 unsafe impl Send for PinnedArrayBuffer {}
 
 impl PinnedArrayBuffer {
@@ -198,23 +199,15 @@ impl PinnedArrayBuffer {
         self.0.byte_len
     }
 
-    /// A copy of the bytes as they are now, from any thread that holds a
-    /// job's ticket. The owning JS thread may be storing into the buffer
-    /// concurrently; what such a racing store contributes is unspecified.
-    pub fn to_vec(&self, _vm_alive: &crate::Ticket) -> Vec<u8> {
-        let len = self.0.byte_len;
-        let mut out = Vec::<u8>::with_capacity(len);
-        if len != 0 {
-            // SAFETY: `ptr[..len]` is the pinned, protected backing store (alive
-            // while the VM is, which the ticket proves); `out` has `len` bytes of
-            // capacity and the two cannot overlap. Read through a raw pointer,
-            // never a `&[u8]`, because JS may write it meanwhile.
-            unsafe {
-                core::ptr::copy_nonoverlapping(self.0.ptr.cast_const(), out.as_mut_ptr(), len);
-                out.set_len(len);
-            }
-        }
-        out
+    /// The bytes, for C code to read from any thread that holds a job's
+    /// ticket. The owning JS thread may store into them concurrently; a
+    /// reader sees each byte's old or new value.
+    pub fn ffi_slice<'a>(&'a self, _vm_alive: &crate::Ticket) -> bun_core::ffi::FfiSlice<'a, u8> {
+        // SAFETY: pinned (no detach/transfer, not resizable/shared) and
+        // protected while `self` lives, and the heap outlives the ticket: the
+        // `byte_len` bytes at `ptr` stay allocated for `'a`. May be concurrently
+        // written by JS; `FfiSlice` never forms a `&[u8]` over it.
+        unsafe { bun_core::ffi::FfiSlice::from_raw(self.0.ptr.cast_const(), self.0.byte_len) }
     }
 }
 

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -164,34 +164,33 @@ impl ArrayBuffer {
     pub const MAX_SIZE: c_uint = c_uint::MAX;
 }
 
-/// An `ArrayBuffer`'s (or view's) bytes handed to a pool [`Job`](crate::Job)
-/// without copying: the buffer is pinned (it cannot be detached or
-/// transferred, and — being neither resizable nor shared — cannot move,
-/// shrink, or be written by another agent) and its cell GC-protected until
-/// this is dropped. JS on the owning thread can still store into it while the
-/// job runs, so the job never views it as a `&[u8]`: [`ffi_slice`](Self::ffi_slice)
-/// lends it as an [`FfiSlice`](bun_core::ffi::FfiSlice) for C code (a codec)
-/// to read, under the job's [`Ticket`](crate::Ticket). Like
-/// [`ThreadSafe`](crate::node_path::ThreadSafe), it is made on the JS thread
-/// and released there when the job comes back.
-pub struct PinnedArrayBuffer(ArrayBuffer);
+/// A [`root`](PinnedArrayBuffer::root)ed `ArrayBuffer` (or view) handed to a
+/// pool [`Job`](crate::Job) without copying: being neither resizable nor
+/// shared it cannot move, shrink, or be written by another agent while pinned.
+/// JS on the owning thread can still store into it while the job runs, so the
+/// job never views it as a `&[u8]`: [`ffi_slice`](Self::ffi_slice) lends it as
+/// an [`FfiSlice`](bun_core::ffi::FfiSlice) for C code (a codec) to read,
+/// under the job's [`Ticket`](crate::Ticket). Made on the JS thread and
+/// released there when the job comes back.
+pub struct JobPinnedArrayBuffer(PinnedArrayBuffer);
 
 // SAFETY: the only off-thread operation is `ffi_slice`, which demands a
-// `Ticket` (VM alive) and lends memory that is pinned in place and protected
-// for as long as `self` lives, never as a `&[u8]`; `Drop` releases pin/protect
-// only on a JS thread (see there) and is a leak, not a race, anywhere else.
-unsafe impl Send for PinnedArrayBuffer {}
+// `Ticket` (VM alive) and lends memory that is pinned in place and rooted for
+// as long as `self` lives, never as a `&[u8]`; `Drop` releases pin/root only
+// on a JS thread (see there) and is a leak, not a race, anywhere else.
+unsafe impl Send for JobPinnedArrayBuffer {}
 
-impl PinnedArrayBuffer {
-    /// Pin and protect `value` if it is a non-shared, non-resizable
+impl JobPinnedArrayBuffer {
+    /// Pin and root `value` if it is a non-shared, non-resizable
     /// `ArrayBuffer` or view; `None` otherwise (the caller copies instead).
-    pub fn pin(global: &JSGlobalObject, value: JSValue) -> Option<Self> {
-        let buffer = value.as_pinned_arraybuffer(global)?;
-        if buffer.resizable || buffer.shared {
-            buffer.unpin();
+    pub fn root(global: &JSGlobalObject, value: JSValue) -> Option<Self> {
+        if !value.is_cell() {
             return None;
         }
-        buffer.value.protect();
+        let buffer = PinnedArrayBuffer::root(global, value)?;
+        if buffer.resizable || buffer.shared || buffer.ptr.is_null() {
+            return None;
+        }
         Some(Self(buffer))
     }
 
@@ -203,22 +202,21 @@ impl PinnedArrayBuffer {
     /// ticket. The owning JS thread may store into them concurrently; a
     /// reader sees each byte's old or new value.
     pub fn ffi_slice<'a>(&'a self, _vm_alive: &crate::Ticket) -> bun_core::ffi::FfiSlice<'a, u8> {
-        // SAFETY: pinned (no detach/transfer, not resizable/shared) and
-        // protected while `self` lives, and the heap outlives the ticket: the
-        // `byte_len` bytes at `ptr` stay allocated for `'a`. May be concurrently
-        // written by JS; `FfiSlice` never forms a `&[u8]` over it.
+        // SAFETY: pinned (no detach/transfer, not resizable/shared) and rooted
+        // while `self` lives, and the heap outlives the ticket: the `byte_len`
+        // bytes at `ptr` stay allocated for `'a`. May be concurrently written
+        // by JS; `FfiSlice` never forms a `&[u8]` over it.
         unsafe { bun_core::ffi::FfiSlice::from_raw(self.0.ptr.cast_const(), self.0.byte_len) }
     }
 }
 
-impl Drop for PinnedArrayBuffer {
+impl Drop for JobPinnedArrayBuffer {
     fn drop(&mut self) {
         // Pin count and the protected-values table belong to the JS thread. A
         // job always comes back to its VM's thread to drop this; a thread with
         // no VM (nothing else should hold one) leaks the pin instead of racing.
-        if crate::virtual_machine::VirtualMachine::get_or_null().is_some() {
-            self.0.unpin();
-            self.0.value.unprotect();
+        if crate::virtual_machine::VirtualMachine::get_or_null().is_none() {
+            self.0.defuse();
         }
     }
 }

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -755,12 +755,6 @@ impl PinnedArrayBuffer {
         Some(this)
     }
 
-    /// [`root`](Self::root) for a job that reads the bytes itself: see [`copy_if_resizable`](Self::copy_if_resizable).
-    pub fn root_read_only(global: &JSGlobalObject, value: JSValue) -> Option<Self> {
-        let mut this = Self::root(global, value)?;
-        this.copy_if_resizable(global).then_some(this)
-    }
-
     /// A pin stops a detach but not a shrink, which unmaps pages: a resizable non-shared buffer is copied so a later read of the bytes in user space cannot fault (a syscall reader gets `EFAULT` and needs no copy). `false` if the copy cannot be allocated.
     pub fn copy_if_resizable(&mut self, global: &JSGlobalObject) -> bool {
         if !self.buffer.resizable

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -412,6 +412,7 @@ extern "C" const char* Bun__version_sha;
 
 extern "C" void EncodedSlice__freeGlobal(const unsigned char* ptr, size_t len);
 
+// `to[..other_len]` must not overlap the input characters.
 extern "C" size_t Bun__encoding__writeLatin1(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
 extern "C" size_t Bun__encoding__writeUTF16(const char16_t* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
 

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -412,7 +412,8 @@ extern "C" const char* Bun__version_sha;
 
 extern "C" void EncodedSlice__freeGlobal(const unsigned char* ptr, size_t len);
 
-// `to[..other_len]` must not overlap the input characters.
+// `to[..other_len]` (ArrayBuffer storage) never overlaps `ptr[..len]` (a JS string's characters);
+// the Rust side copies with memcpy semantics.
 extern "C" size_t Bun__encoding__writeLatin1(const unsigned char* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
 extern "C" size_t Bun__encoding__writeUTF16(const char16_t* ptr, size_t len, unsigned char* to, size_t other_len, Encoding encoding);
 

--- a/src/jsc/bindings/webcore/streams/JSCompressionStream.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStream.h
@@ -35,10 +35,11 @@ public:
     }
     static JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM&);
 
-    // the Rust CompressionStreamCoder, refcounted (ownership rules on its
-    // `ref_count` field). This cell's reference is released eagerly at
-    // ClearAlgorithms (post-flush / error / cancel); a vm.heap.addFinalizer
-    // registered in the constructor is the idempotent fallback.
+    // The Rust CompressionStreamCoder this cell owns outright. Freed eagerly
+    // (CompressionStreamCoder__destroy) at ClearAlgorithms (post-flush / error /
+    // cancel); a vm.heap.addFinalizer registered in the constructor is the
+    // idempotent fallback. An in-flight off-thread step owns the codec state
+    // and hands it back through CompressionStreamCoder__restore.
     void* m_coder { nullptr };
 
 private:

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -388,19 +388,32 @@ static CodecStepResult deliverAsyncOutput(JSGlobalObject* globalObject, JSTransf
     return step;
 }
 
-// JS-thread completion of an off-thread step. `out` borrows the coder's buffer, so it is
+// `bun_core::ffi::FfiSlice` — a borrowed `&[u8]` passed by value.
+struct FfiSlice {
+    const uint8_t* ptr;
+    size_t len;
+};
+
+// JS-thread completion of an off-thread step. The step owned the codec state (`codec`) while it
+// ran; it goes back to the stream's coder first. `out` borrows the step's buffer, so it is
 // consumed BEFORE m_asyncCodecInFlight is cleared and the coder may be released or
 // re-dispatched. Entered from the event loop with no JS above it (a TopExceptionScope, and
 // atStreamsBoundary for the delivery): a failed delivery is the pending chunk's rejection.
-extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue streamCell, const uint8_t* out, size_t outLen, bool more, JSC::EncodedJSValue error)
+extern "C" void Bun__CompressionStream__deliverAsync(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue streamCell, void* codec, FfiSlice outSlice, bool more, JSC::EncodedJSValue error)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* stream = dynamicDowncast<JSTransformStream>(JSValue::decode(streamCell));
     ASSERT(stream);
-    if (!stream) [[unlikely]]
+    if (!stream) [[unlikely]] {
+        CompressionStreamCoder__restore(nullptr, codec);
         return;
+    }
     ASSERT(stream->m_asyncCodecInFlight);
+    // Strongly held and in flight, so the stream still has its coder.
+    CompressionStreamCoder__restore(coderOf(stream), codec);
+    const uint8_t* out = outSlice.ptr;
+    size_t outLen = outSlice.len;
 
     CodecStepResult step;
     step.more = more;

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.h
@@ -8,8 +8,10 @@
 // CompressionStreamCoder.rs. Each transform call runs one bounded step; `more` means the coder
 // must be stepped again (with no input, it kept the tail) before the next chunk is fed.
 extern "C" void* CompressionStreamCoder__create(uint8_t format, bool decompress, size_t highWaterMark);
-// Releases the cell's reference (in-flight off-thread steps hold their own).
+// Frees the coder. An in-flight off-thread step owns the codec state itself and gives it back
+// through CompressionStreamCoder__restore (or drops it if the coder is gone by then).
 extern "C" void CompressionStreamCoder__destroy(void* coder);
+extern "C" void CompressionStreamCoder__restore(void* coder, void* codec);
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transform(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, bool* more);
 extern "C" JSC::EncodedJSValue CompressionStreamCoder__transformInto(void* coder, JSC::JSGlobalObject* global, const uint8_t* input, size_t input_len, bool finish, uint8_t sinkId, void* sinkPtr, bool* more);
 // Off-thread step, completed by Bun__CompressionStream__deliverAsync.

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.h
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.h
@@ -57,8 +57,8 @@ public:
     // ClearAlgorithms defers the eager free to the arm's epilogue instead.
     bool m_nativeStateInUse : 1 { false };
     bool m_nativeStateReleasePending : 1 { false };
-    // An off-thread codec step holds the coder; ClearAlgorithms / runNativeArm must defer
-    // the free until the step's JS-thread completion clears this.
+    // An off-thread codec step has the coder's state; ClearAlgorithms / runNativeArm must defer
+    // the free until the step's JS-thread completion hands it back and clears this.
     bool m_asyncCodecInFlight : 1 { false };
     // The chunk behind m_codecPromise runs its steps on the thread pool.
     bool m_codecChunkOffThread : 1 { false };

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -188,7 +188,8 @@ pub use self::js_value::{
 // and is wired into `event_loop::tick` directly at link time. No fn-pointer
 // hook is re-exported from the crate root.
 pub use self::array_buffer::{
-    ArrayBuffer, BinaryType, JSCArrayBuffer, MarkedArrayBuffer, PinnedArrayBuffer, TypedArrayType,
+    ArrayBuffer, BinaryType, JSCArrayBuffer, JobPinnedArrayBuffer, MarkedArrayBuffer,
+    PinnedArrayBuffer, TypedArrayType,
 };
 pub use self::console_object as ConsoleObject;
 pub use self::console_object::Formatter;

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -19,7 +19,6 @@ use bun_paths as path;
 use bun_paths::resolve_path::{join_abs_string_buf_z, normalize_buf, normalize_buf_z};
 use bun_resolver::fs::FileSystem;
 use bun_sha_hmac as sha;
-use bun_simdutf_sys::simdutf;
 use bun_sys::dir_iterator as DirIterator;
 use bun_sys::{self, Fd, File, FileKind};
 use bun_url::URL;
@@ -2054,16 +2053,7 @@ impl PublishCommand {
                 ),
             );
 
-            // SAFETY: `encode_raw` writes exactly `encoded_tarball_len`
-            // (= `base64::encode_len(tarball_bytes.len(), false)`) bytes into the
-            // reserved spare capacity; `fill_spare` commits exactly that count.
-            let count = unsafe {
-                bun_core::vec::fill_spare(&mut buf, encoded_tarball_len, |spare| {
-                    let n =
-                        simdutf::base64::encode_raw(&ctx.tarball_bytes, spare.as_mut_ptr(), false);
-                    (n, n)
-                })
-            };
+            let count = bun_base64::encode_append(&mut buf, &ctx.tarball_bytes);
             debug_assert!(count == encoded_tarball_len);
 
             let _ = write!(&mut buf, "\",\"length\":{}}}}}}}", ctx.tarball_bytes.len());

--- a/src/runtime/node/buffer.rs
+++ b/src/runtime/node/buffer.rs
@@ -45,17 +45,11 @@ mod _impl {
             // `ALLOW_PARTIAL_WRITE = true`: Node's `Fill` (node_buffer.cc) copies
             // `min(encodedLength, fillLength)` raw bytes of the encoding, so the
             // repeat loop below always doubles a seed equal to the full encoding.
-            // SAFETY: `s` and `buf` are valid slices derived above; the source/destination
-            // pointers and lengths passed to the encoder are exactly those slice bounds.
             let result = if str.is_16bit() {
                 let s = str.utf16_slice();
                 dispatch_encoding!(encoding, {
-                    // SAFETY: caller (`extern "C"` fill) guarantees `s`/`buf` are valid disjoint buffers per the Buffer.fill contract.
-                    Encoding::Ucs2 => unsafe { encoder::write_u16::<{ Encoding::Utf16le as u8 }, true>(
-                        s.as_ptr(), s.len(), buf.as_mut_ptr(), buf.len(),
-                    ) },
-                // SAFETY: caller (`extern "C"` fill) guarantees `s`/`buf` are valid disjoint buffers per the Buffer.fill contract.
-                }, |E| unsafe { encoder::write_u16::<E, true>(s.as_ptr(), s.len(), buf.as_mut_ptr(), buf.len()) })
+                    Encoding::Ucs2 => encoder::write_u16::<{ Encoding::Utf16le as u8 }, true>(s, buf),
+                }, |E| encoder::write_u16::<E, true>(s, buf))
             } else {
                 let s = str.slice();
                 dispatch_encoding!(encoding, {

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -243,10 +243,10 @@ pub mod random {
             match this {
                 RandomFillJob::Scratch { scratch, size, .. } => {
                     let size = *size;
-                    // SAFETY: `rand_bytes` only writes, and fills every byte of the slice it is given.
+                    // SAFETY: `rand_bytes_uninit` initializes every slot of the slice it is given.
                     unsafe {
                         bun_core::vec::fill_spare(scratch, 0, |spare| {
-                            boringssl::rand_bytes(&mut spare[..size]);
+                            boringssl::rand_bytes_uninit(&mut spare[..size]);
                             (size, ())
                         })
                     }

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -893,15 +893,16 @@ mod _impl {
 
             // mac <string> The MAC address of the network interface
             {
-                // We need to search for the link-layer interface whose name matches this one
+                // The link-layer entry for this interface; a Linux alias
+                // (`eth0:1`) takes its base interface's (`eth0`), as in libuv.
                 let maybe_ll_addr: Option<&[u8]> = interfaces
                     .iter()
                     .filter(|&ll_iface| !skip(ll_iface))
                     .filter(|ll_iface| {
                         let ll_name = ll_iface.name();
-                        strings::has_prefix(ll_name, interface_name)
-                            && (ll_name.len() <= interface_name.len()
-                                || ll_name[interface_name.len()] == b':')
+                        strings::has_prefix(interface_name, ll_name)
+                            && (interface_name.len() == ll_name.len()
+                                || interface_name[ll_name.len()] == b':')
                     })
                     .find_map(InterfaceAddress::link_layer_address);
 

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -639,14 +639,14 @@ mod _impl {
                     // (zygote/run-as), return a usable default rather than throwing.
                     #[cfg(target_os = "android")]
                     {
-                        Ok(BunString::static_("/data/local/tmp"))
+                        return Ok(BunString::static_("/data/local/tmp"));
                     }
                     // in uv__getpwuid_r, null result throws UV_ENOENT.
                     #[cfg(not(target_os = "android"))]
-                    Err(global.throw_value(
+                    return Err(global.throw_value(
                         bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::uv_os_homedir)
                             .to_js(global),
-                    ))
+                    ));
                 }
                 Ok(Some(dir)) if dir.is_empty() => Ok(BunString::EMPTY),
                 Ok(Some(dir)) => Ok(BunString::clone_utf8(&dir)),

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -1,14 +1,20 @@
 use core::ffi::c_int;
 #[cfg(not(windows))]
-use core::ffi::{c_char, c_uint, c_void};
+use core::ffi::c_uint;
 
 use bun_core;
 use bun_core::String as BunString;
 use bun_jsc::bun_string_jsc;
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 
+// c-bindings.cpp / OsBinding.cpp
 unsafe extern "C" {
     safe fn bun_sysconf__SC_NPROCESSORS_ONLN() -> i32;
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    safe fn bun_sysconf__SC_CLK_TCK() -> isize;
+    safe fn Bun__Os__getFreeMemory() -> u64;
+    safe fn get_process_priority(pid: i32) -> i32;
+    safe fn set_process_priority(pid: i32, priority: i32) -> i32;
 }
 
 #[derive(Default, Clone, Copy)]
@@ -21,10 +27,6 @@ pub(crate) struct CPUTimes {
 }
 
 pub(crate) fn freemem() -> u64 {
-    // OsBinding.cpp
-    unsafe extern "C" {
-        safe fn Bun__Os__getFreeMemory() -> u64;
-    }
     Bun__Os__getFreeMemory()
 }
 
@@ -36,14 +38,15 @@ mod _impl {
     #[cfg(not(windows))]
     use bun_core::strings;
     use bun_core::{env_var, fmt as bun_fmt};
-    use bun_jsc::{CallFrame, JSArray, StringJsc as _, SysErrorJsc as _, SystemError};
-
+    use bun_jsc::{
+        CallFrame, JSArray, StringJsc as _, SysErrorJsc as _, SystemError, ZigStringJsc as _,
+    };
     #[cfg(windows)]
     use bun_sys::ReturnCodeExt as _;
     #[cfg(not(windows))]
     use bun_sys::c;
     #[cfg(windows)]
-    use bun_sys::windows::{self, libuv};
+    use bun_sys::windows::libuv;
     use std::io::Write as _;
 
     // ─── local shims for upstream API gaps (Phase D) ──────────────────────────
@@ -151,7 +154,6 @@ mod _impl {
 
     pub(crate) fn create_node_os_binding(global: &JSGlobalObject) -> JsResult<JSValue> {
         let obj = JSValue::create_empty_object(global, 14);
-        // SAFETY: pure FFI getter
         obj.put(
             global,
             b"hostCpuCount",
@@ -257,7 +259,6 @@ mod _impl {
                         // hidepid mounts (common on Android) deny /proc/stat. lazyCpus in os.ts
                         // pre-creates hostCpuCount lazy proxies, so return that many stub
                         // entries (zeroed times / unknown model / speed 0) — matches Node.
-                        // SAFETY: pure FFI getter
                         let count: u32 =
                             u32::try_from(1i32.max(bun_sysconf__SC_NPROCESSORS_ONLN())).unwrap();
                         let stubs = JSValue::create_empty_array(global_this, count as usize)?;
@@ -407,7 +408,6 @@ mod _impl {
                 .map_err(|_| crate::Error::fmt)?;
                 let remaining = cursor.len();
                 let written = path_buf.len() - remaining;
-                // SAFETY: we wrote a NUL terminator at path_buf[written-1]
                 ZStr::from_buf(&path_buf[..], written - 1)
             };
             if let Ok(file) = bun_sys::File::open(path, bun_sys::O::RDONLY, 0) {
@@ -454,7 +454,6 @@ mod _impl {
         bun_sys::posix::sysctl_read_slice(c"kern.cp_times", &mut times_buf[..])
             .map_err(|_| OsError::Any)?;
 
-        // SAFETY: pure FFI getter
         let ticks: i64 = bun_sysconf__SC_CLK_TCK() as i64;
         let mult: u64 = if ticks > 0 {
             1000 / u64::try_from(ticks).expect("int cast")
@@ -483,39 +482,12 @@ mod _impl {
         Ok(values)
     }
 
-    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-    unsafe extern "C" {
-        safe fn bun_sysconf__SC_CLK_TCK() -> isize;
-    }
-
     #[cfg(target_os = "macos")]
     fn cpus_impl_darwin(global_this: &JSGlobalObject) -> Result<JSValue, OsError> {
         // Fetch the CPU info structure
-        let mut num_cpus: c::natural_t = 0;
-        let mut info: *mut c::processor_cpu_load_info = core::ptr::null_mut();
-        let mut info_size: c::mach_msg_type_number_t = 0;
-        // SAFETY: FFI call with valid out-pointers
-        if unsafe {
-            c::host_processor_info(
-                c::mach_host_self(),
-                c::PROCESSOR_CPU_LOAD_INFO,
-                &raw mut num_cpus,
-                (&raw mut info).cast::<c::processor_info_array_t>(),
-                &raw mut info_size,
-            )
-        } != 0
-        {
-            return Err(OsError::Any);
-        }
-        scopeguard::defer! {
-            // SAFETY: info/info_size returned by host_processor_info
-            unsafe { let _ = c::vm_deallocate(c::mach_task_self(), info as usize, info_size as usize); }
-        };
-
-        // Ensure we got the amount of data we expected to guard against buffer overruns
-        if info_size != c::PROCESSOR_CPU_LOAD_INFO_COUNT * num_cpus {
-            return Err(OsError::Any);
-        }
+        let info = bun_sys::os::ProcessorCpuLoadInfo::get().ok_or(OsError::Any)?;
+        let info_slice = info.as_slice();
+        let num_cpus = u32::try_from(info_slice.len()).expect("int cast");
 
         // Get CPU model name
         let mut model_name_buf = [0u8; 512];
@@ -548,15 +520,12 @@ mod _impl {
         }
 
         // Get the multiplier; this is the number of ms/tick
-        // SAFETY: pure FFI getter
         let ticks: i64 = bun_sysconf__SC_CLK_TCK() as i64;
         let multiplier: u64 = 1000 / u64::try_from(ticks).expect("int cast");
 
         // Set up each CPU value in the return
         let values = JSValue::create_empty_array(global_this, num_cpus as usize)?;
         let mut cpu_index: u32 = 0;
-        // SAFETY: info points to num_cpus entries per host_processor_info contract
-        let info_slice = unsafe { bun_core::ffi::slice(info, num_cpus as usize) };
         while cpu_index < num_cpus {
             let ticks = &info_slice[cpu_index as usize].cpu_ticks;
             let times = CPUTimes {
@@ -584,45 +553,30 @@ mod _impl {
 
     #[cfg(windows)]
     fn cpus_impl_windows(global_this: &JSGlobalObject) -> Result<JSValue, OsError> {
-        let mut cpu_infos: *mut libuv::uv_cpu_info_t = core::ptr::null_mut();
-        let mut count: c_int = 0;
-        // SAFETY: valid out-pointers
-        let err = unsafe { libuv::uv_cpu_info(&mut cpu_infos, &mut count) };
-        if err != 0 {
-            return Err(OsError::Any);
-        }
-        scopeguard::defer! {
-            // SAFETY: returned by uv_cpu_info
-            unsafe { libuv::uv_free_cpu_info(cpu_infos, count) };
-        };
+        let cpu_infos = bun_sys::os::CpuInfoList::get().map_err(|_| OsError::Any)?;
 
-        let values =
-            JSValue::create_empty_array(global_this, usize::try_from(count).expect("int cast"))?;
+        let values = JSValue::create_empty_array(global_this, cpu_infos.iter().count())?;
 
-        // SAFETY: cpu_infos points to `count` entries per uv_cpu_info contract
-        let infos =
-            unsafe { bun_core::ffi::slice(cpu_infos, usize::try_from(count).expect("int cast")) };
-        for (i, cpu_info) in infos.iter().enumerate() {
+        for (i, cpu_info) in cpu_infos.iter().enumerate() {
+            let t = cpu_info.times();
             let times = CPUTimes {
-                user: cpu_info.cpu_times.user,
-                nice: cpu_info.cpu_times.nice,
-                sys: cpu_info.cpu_times.sys,
-                idle: cpu_info.cpu_times.idle,
-                irq: cpu_info.cpu_times.irq,
+                user: t.user,
+                nice: t.nice,
+                sys: t.sys,
+                idle: t.idle,
+                irq: t.irq,
             };
 
             let cpu = JSValue::create_empty_object(global_this, 3);
-            // SAFETY: cpu_info.model is a NUL-terminated C string from libuv
-            let model = unsafe { bun_core::ffi::cstr(cpu_info.model) }.to_bytes();
             cpu.put(
                 global_this,
                 b"model",
-                bun_string_jsc::create_utf8_for_js(global_this, model)?,
+                bun_string_jsc::create_utf8_for_js(global_this, cpu_info.model())?,
             );
             cpu.put(
                 global_this,
                 b"speed",
-                JSValue::js_number(cpu_info.speed as f64),
+                JSValue::js_number(cpu_info.speed() as f64),
             );
             cpu.put(global_this, b"times", times.to_value(global_this));
 
@@ -630,10 +584,6 @@ mod _impl {
         }
 
         Ok(values)
-    }
-
-    unsafe extern "C" {
-        safe fn get_process_priority(pid: i32) -> i32;
     }
 
     pub(crate) fn get_priority(global: &JSGlobalObject, pid: i32) -> JsResult<i32> {
@@ -659,14 +609,13 @@ mod _impl {
         #[cfg(windows)]
         {
             let mut out = bun_paths::path_buffer_pool::get();
-            let mut size: usize = out.len();
-            // SAFETY: valid buffer + size out-param
-            if let Some(err) = unsafe { libuv::uv_os_homedir(out.as_mut_ptr(), &mut size) }
-                .to_error(bun_sys::Tag::uv_os_homedir)
-            {
-                return Err(global.throw_value(err.to_js(global)));
-            }
-            return Ok(BunString::clone_utf8(&out[0..size]));
+            return match bun_sys::os::homedir(&mut out[..]) {
+                Ok(size) => Ok(BunString::clone_utf8(&out[0..size])),
+                Err(rc) => {
+                    let err = rc.to_error(bun_sys::Tag::uv_os_homedir).expect("nonzero");
+                    Err(global.throw_value(err.to_js(global)))
+                }
+            };
         }
         #[cfg(not(windows))]
         {
@@ -678,82 +627,32 @@ mod _impl {
                 }
             }
 
-            // From libuv:
-            // > Calling sysconf(_SC_GETPW_R_SIZE_MAX) would get the suggested size, but it
-            // > is frequently 1024 or 4096, so we can just use that directly. The pwent
-            // > will not usually be large.
-            // Instead of always using an allocation, first try a stack allocation
-            // of 4096, then fallback to heap.
-            let mut stack_string_bytes = [0u8; 4096];
-            let mut heap_bytes: Vec<u8>;
-            let mut string_bytes: &mut [u8] = &mut stack_string_bytes[..];
-            let mut using_heap = false;
-
-            // SAFETY: zeroed POD
-            let mut pw: libc::passwd = bun_core::ffi::zeroed();
-            let mut result: *mut libc::passwd = core::ptr::null_mut();
-
-            let ret: c_int = loop {
-                // SAFETY: valid buffers and out-pointer
-                let ret = unsafe {
-                    libc::getpwuid_r(
-                        libc::geteuid(),
-                        &raw mut pw,
-                        string_bytes.as_mut_ptr().cast::<c_char>(),
-                        string_bytes.len(),
-                        &raw mut result,
-                    )
-                };
-
-                if ret == bun_sys::E::EINTR as c_int {
-                    continue;
-                }
-
-                // If the system call wants more memory, double it.
-                if ret == bun_sys::E::ERANGE as c_int {
-                    let len = string_bytes.len();
-                    heap_bytes = vec![0u8; len * 2];
-                    string_bytes = &mut heap_bytes[..];
-                    using_heap = true;
-                    continue;
-                }
-
-                break ret;
-            };
-            let _ = using_heap;
-
-            if ret != 0 {
-                return Err(global.throw_value(
+            return match bun_sys::os::passwd_home_dir() {
+                Err(errno) => Err(global.throw_value(
                     bun_sys::Error::from_code(
-                        // `ret` is a libc errno; a code outside the table is `EUNKNOWN`.
-                        bun_sys::E::from_raw(ret as u16),
+                        // `errno` is a libc errno; a code outside the table is `EUNKNOWN`.
+                        bun_sys::E::from_raw(errno as u16),
                         bun_sys::Tag::uv_os_homedir,
                     )
                     .to_js(global),
-                ));
-            }
-
-            if result.is_null() {
-                // bionic has no passwd entries for app uids; with HOME also unset
-                // (zygote/run-as), return a usable default rather than throwing.
-                #[cfg(target_os = "android")]
-                {
-                    return Ok(BunString::static_("/data/local/tmp"));
+                )),
+                Ok(None) => {
+                    // bionic has no passwd entries for app uids; with HOME also unset
+                    // (zygote/run-as), return a usable default rather than throwing.
+                    #[cfg(target_os = "android")]
+                    {
+                        Ok(BunString::static_("/data/local/tmp"))
+                    }
+                    // in uv__getpwuid_r, null result throws UV_ENOENT.
+                    #[cfg(not(target_os = "android"))]
+                    Err(global.throw_value(
+                        bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::uv_os_homedir)
+                            .to_js(global),
+                    ))
                 }
-                // in uv__getpwuid_r, null result throws UV_ENOENT.
-                #[cfg(not(target_os = "android"))]
-                return Err(global.throw_value(
-                    bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::uv_os_homedir)
-                        .to_js(global),
-                ));
-            }
-
-            return Ok(if !pw.pw_dir.is_null() {
-                // SAFETY: pw_dir is a NUL-terminated C string from getpwuid_r
-                BunString::clone_utf8(unsafe { bun_core::ffi::cstr(pw.pw_dir) }.to_bytes())
-            } else {
-                BunString::EMPTY
-            });
+                Ok(Some(dir)) if dir.is_empty() => Ok(BunString::EMPTY),
+                Ok(Some(dir)) => Ok(BunString::clone_utf8(&dir)),
+            };
         }
     }
 
@@ -761,11 +660,8 @@ mod _impl {
         #[cfg(windows)]
         {
             let mut name_buffer: [u16; 130] = [0; 130]; // [129:0]u16 → 130 u16s with NUL at [129]
-            // SAFETY: idempotent Winsock init (libuv defers it to first use).
-            unsafe { windows::libuv::uv__winsock_ensure() };
-            // SAFETY: valid buffer
-            if unsafe { windows::GetHostNameW(name_buffer.as_mut_ptr(), 129) } == 0 {
-                return BunString::clone_utf16(slice_to_nul_u16(&name_buffer)).into_js(global);
+            if let Some(name) = bun_sys::os::hostname_w(&mut name_buffer) {
+                return BunString::clone_utf16(name).into_js(global);
             }
 
             return Ok(global.common_strings().unknown());
@@ -821,14 +717,7 @@ mod _impl {
             [0.0, 0.0, 0.0]
         };
         #[cfg(target_os = "freebsd")]
-        let result: [f64; 3] = 'loadavg: {
-            let mut avg: [f64; 3] = [0.0, 0.0, 0.0];
-            // SAFETY: valid buffer
-            if unsafe { c::getloadavg(avg.as_mut_ptr(), 3) } != 3 {
-                break 'loadavg [0.0, 0.0, 0.0];
-            }
-            avg
-        };
+        let result: [f64; 3] = bun_sys::os::loadavg().unwrap_or([0.0, 0.0, 0.0]);
         #[cfg(windows)]
         let result: [f64; 3] = [0.0, 0.0, 0.0];
 
@@ -849,50 +738,45 @@ mod _impl {
 
     #[cfg(unix)]
     pub fn network_interfaces_posix(global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        // getifaddrs sets a pointer to a linked list
-        let mut interface_start: *mut libc::ifaddrs = core::ptr::null_mut();
-        // SAFETY: valid out-pointer
-        let rc = unsafe { libc::getifaddrs(&raw mut interface_start) };
-        if rc != 0 {
-            let _ = rc;
-            let errno = bun_sys::posix::errno();
-            // Android API 30+: SELinux denies the netlink socket getifaddrs uses.
-            // Node returns {} rather than throwing.
-            #[cfg(target_os = "android")]
-            {
-                if errno == bun_sys::posix::E::EACCES as c_int
-                    || errno == bun_sys::posix::E::EPERM as c_int
-                {
-                    return Ok(JSValue::create_empty_object(global_this, 0));
-                }
-            }
-            let err = SystemError {
-                message: BunString::static_(
-                    "A system error occurred: getifaddrs returned an error",
-                ),
-                code: BunString::static_("ERR_SYSTEM_ERROR"),
-                errno: errno as c_int,
-                syscall: BunString::static_("getifaddrs"),
-                ..Default::default()
-            };
+        use bun_sys::os::{InterfaceAddress, InterfaceAddresses};
 
-            return Err(global_this.throw_value(err.to_error_instance(global_this)));
-        }
-        scopeguard::defer! {
-            // SAFETY: returned by getifaddrs
-            unsafe { libc::freeifaddrs(interface_start) };
+        let interfaces = match InterfaceAddresses::get() {
+            Ok(list) => list,
+            Err(errno) => {
+                // Android API 30+: SELinux denies the netlink socket getifaddrs uses.
+                // Node returns {} rather than throwing.
+                #[cfg(target_os = "android")]
+                {
+                    if errno == bun_sys::posix::E::EACCES as c_int
+                        || errno == bun_sys::posix::E::EPERM as c_int
+                    {
+                        return Ok(JSValue::create_empty_object(global_this, 0));
+                    }
+                }
+                let err = SystemError {
+                    message: BunString::static_(
+                        "A system error occurred: getifaddrs returned an error",
+                    ),
+                    code: BunString::static_("ERR_SYSTEM_ERROR"),
+                    errno: errno as c_int,
+                    syscall: BunString::static_("getifaddrs"),
+                    ..Default::default()
+                };
+
+                return Err(global_this.throw_value(err.to_error_instance(global_this)));
+            }
         };
 
         // We'll skip interfaces that aren't actually available
-        fn skip(iface: &libc::ifaddrs) -> bool {
+        fn skip(iface: InterfaceAddress<'_>) -> bool {
             // Skip interfaces that aren't actually available
-            if iface.ifa_flags & libc::IFF_RUNNING as c_uint == 0 {
+            if iface.flags() & libc::IFF_RUNNING as c_uint == 0 {
                 return true;
             }
-            if iface.ifa_flags & libc::IFF_UP as c_uint == 0 {
+            if iface.flags() & libc::IFF_UP as c_uint == 0 {
                 return true;
             }
-            if iface.ifa_addr.is_null() {
+            if iface.family().is_none() {
                 return true;
             }
             false
@@ -900,59 +784,39 @@ mod _impl {
 
         // We won't actually return link-layer interfaces but we need them for
         //  extracting the MAC address
-        fn is_link_layer(iface: &libc::ifaddrs) -> bool {
-            if iface.ifa_addr.is_null() {
-                return false;
-            }
+        fn is_link_layer(iface: InterfaceAddress<'_>) -> bool {
             #[cfg(any(target_os = "linux", target_os = "android"))]
-            // SAFETY: ifa_addr is non-null per check above
-            return unsafe { (*iface.ifa_addr).sa_family } as c_int == libc::AF_PACKET;
+            return iface.family() == Some(libc::AF_PACKET);
             #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-            // SAFETY: ifa_addr is non-null per check above
-            return unsafe { (*iface.ifa_addr).sa_family } as c_int == libc::AF_LINK;
+            return iface.family() == Some(libc::AF_LINK);
         }
 
-        fn is_loopback(iface: &libc::ifaddrs) -> bool {
-            iface.ifa_flags & libc::IFF_LOOPBACK as c_uint == libc::IFF_LOOPBACK as c_uint
+        fn is_loopback(iface: InterfaceAddress<'_>) -> bool {
+            iface.flags() & libc::IFF_LOOPBACK as c_uint == libc::IFF_LOOPBACK as c_uint
         }
-
-        // The list currently contains entries for link-layer interfaces
-        //  and the IPv4, IPv6 interfaces.  We only want to return the latter two
-        //  but need the link-layer entries to determine MAC address.
-        // So, on our first pass through the linked list we'll count the number of
-        //  INET interfaces only.
-        let mut num_inet_interfaces: usize = 0;
-        let mut it = interface_start;
-        while !it.is_null() {
-            // SAFETY: it is a valid pointer in the linked list
-            let iface = unsafe { &*it };
-            if !(skip(iface) || is_link_layer(iface)) {
-                num_inet_interfaces += 1;
-            }
-            it = iface.ifa_next;
-        }
-        let _ = num_inet_interfaces;
 
         let ret = JSValue::create_empty_object(global_this, 0);
 
-        // Second pass through, populate each interface object
-        let mut it = interface_start;
-        while !it.is_null() {
-            // SAFETY: it is a valid pointer in the linked list
-            let iface = unsafe { &*it };
-            let next = iface.ifa_next;
+        // The list contains entries for link-layer interfaces and the IPv4,
+        //  IPv6 interfaces.  We only return the latter two but need the
+        //  link-layer entries to determine MAC address.
+        for iface in interfaces.iter() {
             if skip(iface) || is_link_layer(iface) {
-                it = next;
                 continue;
             }
 
-            // SAFETY: ifa_name is a NUL-terminated C string
-            let interface_name = unsafe { bun_core::ffi::cstr(iface.ifa_name) }.to_bytes();
-            // SAFETY: ifa_addr/ifa_netmask are valid sockaddr* (skip() ensures ifa_addr non-null)
-            let addr = unsafe { bun_sys::net::Address::init_posix(iface.ifa_addr.cast_const()) };
-            // SAFETY: ifa_netmask is a valid sockaddr* populated by getifaddrs for this entry
-            let netmask =
-                unsafe { bun_sys::net::Address::init_posix(iface.ifa_netmask.cast_const()) };
+            let interface_name = iface.name();
+            let addr = iface.address().expect("skip() checked ifa_addr");
+            // getifaddrs(3) leaves ifa_netmask null when the entry has none;
+            // libuv reads that as an all-zero mask.
+            let netmask = iface.netmask().unwrap_or_else(|| {
+                let zero: core::net::IpAddr = if addr.family() == libc::AF_INET6 {
+                    core::net::Ipv6Addr::UNSPECIFIED.into()
+                } else {
+                    core::net::Ipv4Addr::UNSPECIFIED.into()
+                };
+                bun_sys::net::Address::from_ip(zero, 0)
+            });
 
             let interface = JSValue::create_empty_object(global_this, 0);
 
@@ -962,18 +826,12 @@ mod _impl {
                 // Compute the CIDR suffix; returns null if the netmask cannot
                 //  be converted to a CIDR suffix
                 let maybe_suffix: Option<u8> = match addr.family() as c_int {
-                    // SAFETY: family checked; storage is sockaddr_in/sockaddr_in6-sized
-                    libc::AF_INET => netmask_to_cidr_suffix(unsafe {
-                        (*netmask.as_sockaddr().cast::<libc::sockaddr_in>())
-                            .sin_addr
-                            .s_addr
+                    libc::AF_INET => netmask
+                        .as_in4()
+                        .and_then(|m| netmask_to_cidr_suffix(m.sin_addr.s_addr)),
+                    libc::AF_INET6 => netmask.as_in6().and_then(|m| {
+                        netmask_to_cidr_suffix(u128::from_ne_bytes(m.sin6_addr.s6_addr))
                     }),
-                    // SAFETY: family checked; storage is sockaddr_in6-sized
-                    libc::AF_INET6 => netmask_to_cidr_suffix(u128::from_ne_bytes(unsafe {
-                        (*netmask.as_sockaddr().cast::<libc::sockaddr_in6>())
-                            .sin6_addr
-                            .s6_addr
-                    })),
                     _ => None,
                 };
 
@@ -1038,52 +896,18 @@ mod _impl {
             // mac <string> The MAC address of the network interface
             {
                 // We need to search for the link-layer interface whose name matches this one
-                let mut ll_it = interface_start;
-                let maybe_ll_addr: Option<*const c_void> = 'search: {
-                    while !ll_it.is_null() {
-                        // SAFETY: ll_it is a valid pointer in the linked list
-                        let ll_iface = unsafe { &*ll_it };
-                        let ll_next = ll_iface.ifa_next;
-                        if skip(ll_iface) || !is_link_layer(ll_iface) {
-                            ll_it = ll_next;
-                            continue;
-                        }
+                let maybe_ll_addr: Option<&[u8]> = interfaces
+                    .iter()
+                    .filter(|&ll_iface| !skip(ll_iface))
+                    .filter(|ll_iface| {
+                        let ll_name = ll_iface.name();
+                        strings::has_prefix(ll_name, interface_name)
+                            && (ll_name.len() <= interface_name.len()
+                                || ll_name[interface_name.len()] == b':')
+                    })
+                    .find_map(InterfaceAddress::link_layer_address);
 
-                        // SAFETY: ifa_name is a NUL-terminated C string
-                        let ll_name = unsafe { bun_core::ffi::cstr(ll_iface.ifa_name) }.to_bytes();
-                        if !strings::has_prefix(ll_name, interface_name) {
-                            ll_it = ll_next;
-                            continue;
-                        }
-                        if ll_name.len() > interface_name.len()
-                            && ll_name[interface_name.len()] != b':'
-                        {
-                            ll_it = ll_next;
-                            continue;
-                        }
-
-                        // This is the correct link-layer interface entry for the current interface,
-                        //  cast to a link-layer socket address
-                        break 'search Some(ll_iface.ifa_addr.cast::<c_void>().cast_const());
-                    }
-                    None
-                };
-
-                if let Some(ll_addr) = maybe_ll_addr {
-                    #[cfg(any(target_os = "linux", target_os = "android"))]
-                    // SAFETY: ll_addr is a sockaddr_ll* per is_link_layer check
-                    let addr_data: &[u8] =
-                        unsafe { &(*ll_addr.cast::<libc::sockaddr_ll>()).sll_addr };
-                    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-                    let addr_data: &[u8] = {
-                        // SAFETY: ll_addr is a sockaddr_dl* per is_link_layer check.
-                        // `sdl_data` is `[c_char; N]` (signedness varies by platform);
-                        // reinterpret as bytes — same width, same provenance.
-                        let dl = unsafe { &*ll_addr.cast::<c::sockaddr_dl>() };
-                        let raw = &dl.sdl_data[dl.sdl_nlen as usize..];
-                        // c_char and u8 are both Pod; bytemuck statically checks the layout.
-                        bytemuck::cast_slice::<_, u8>(raw)
-                    };
+                if let Some(addr_data) = maybe_ll_addr {
                     if addr_data.len() < 6 {
                         let mac = b"00:00:00:00:00:00";
                         interface.put(
@@ -1115,11 +939,12 @@ mod _impl {
             interface.put(global_this, b"internal", JSValue::from(is_loopback(iface)));
 
             // scopeid <number> The numeric IPv6 scope ID (only specified when family is IPv6)
-            if addr.family() as c_int == libc::AF_INET6 {
-                // SAFETY: family checked; storage is sockaddr_in6-sized
-                let scope_id =
-                    unsafe { (*addr.as_sockaddr().cast::<libc::sockaddr_in6>()).sin6_scope_id };
-                interface.put(global_this, b"scopeid", JSValue::js_number(scope_id as f64));
+            if let Some(in6) = addr.as_in6() {
+                interface.put(
+                    global_this,
+                    b"scopeid",
+                    JSValue::js_number(in6.sin6_scope_id as f64),
+                );
             }
 
             // Does this entry already exist?
@@ -1134,8 +959,6 @@ mod _impl {
                 array.put_index(global_this, 0, interface)?;
                 ret.put(global_this, interface_name, array);
             }
-
-            it = next;
         }
 
         Ok(ret)
@@ -1143,24 +966,19 @@ mod _impl {
 
     #[cfg(windows)]
     pub fn network_interfaces_windows(global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        let mut ifaces: *mut libuv::uv_interface_address_t = core::ptr::null_mut();
-        let mut count: c_int = 0;
-        // SAFETY: valid out-pointers
-        let err = unsafe { libuv::uv_interface_addresses(&mut ifaces, &mut count) };
-        if err != 0 {
-            let sys_err = SystemError {
-                message: BunString::static_("uv_interface_addresses failed").into(),
-                code: BunString::static_("ERR_SYSTEM_ERROR").into(),
-                //.info = info,
-                errno: err,
-                syscall: BunString::static_("uv_interface_addresses").into(),
-                ..Default::default()
-            };
-            return Err(global_this.throw_value(sys_err.to_error_instance(global_this)));
-        }
-        scopeguard::defer! {
-            // SAFETY: returned by uv_interface_addresses
-            unsafe { libuv::uv_free_interface_addresses(ifaces, count) };
+        let ifaces = match bun_sys::os::InterfaceAddresses::get() {
+            Ok(list) => list,
+            Err(err) => {
+                let sys_err = SystemError {
+                    message: BunString::static_("uv_interface_addresses failed"),
+                    code: BunString::static_("ERR_SYSTEM_ERROR"),
+                    //.info = info,
+                    errno: err,
+                    syscall: BunString::static_("uv_interface_addresses"),
+                    ..Default::default()
+                };
+                return Err(global_this.throw_value(sys_err.to_error_instance(global_this)));
+            }
         };
 
         let ret = JSValue::create_empty_object(global_this, 8);
@@ -1168,47 +986,32 @@ mod _impl {
         // 65 comes from: https://stackoverflow.com/questions/39443413/why-is-inet6-addrstrlen-defined-as-46-in-c
         let mut ip_buf = [0u8; 65];
 
-        // SAFETY: ifaces points to `count` entries per uv_interface_addresses contract
-        let iface_slice =
-            unsafe { bun_core::ffi::slice(ifaces, usize::try_from(count).expect("int cast")) };
-        for iface in iface_slice {
+        for iface in ifaces.iter() {
             let interface = JSValue::create_empty_object(global_this, 7);
+            let addr = iface.address();
+            let netmask = iface.netmask();
 
             // address <string> The assigned IPv4 or IPv6 address
             // cidr <string> The assigned IPv4 or IPv6 address with the routing prefix in CIDR notation. If the netmask is invalid, this property is set to null.
             let mut cidr = JSValue::NULL;
+            let family = addr.family() as c_int;
             {
                 // Compute the CIDR suffix; returns null if the netmask cannot
                 //  be converted to a CIDR suffix
-                // SAFETY: union read tagged by family
-                let family = unsafe { iface.address.address4.sin_family } as c_int;
                 let maybe_suffix: Option<u8> = match family {
-                    bun_sys::posix::AF::INET => {
-                        netmask_to_cidr_suffix(unsafe { iface.netmask.netmask4.sin_addr.s_addr })
-                    }
-                    bun_sys::posix::AF::INET6 => {
-                        netmask_to_cidr_suffix(u128::from_ne_bytes(unsafe {
-                            iface.netmask.netmask6.sin6_addr.s6_addr
-                        }))
-                    }
+                    bun_sys::posix::AF::INET => netmask
+                        .as_in4()
+                        .and_then(|m| netmask_to_cidr_suffix(m.sin_addr.s_addr)),
+                    bun_sys::posix::AF::INET6 => netmask.as_in6().and_then(|m| {
+                        netmask_to_cidr_suffix(u128::from_ne_bytes(m.sin6_addr.s6_addr))
+                    }),
                     _ => None,
                 };
 
                 // Format the address and then, if valid, the CIDR suffix; both
                 //  the address and cidr values can be slices into this same buffer
                 // e.g. addr_str = "192.168.88.254", cidr_str = "192.168.88.254/24"
-                let addr_str = bun_fmt::format_ip(
-                    // bun_sys::net::Address will do ptrCast depending on the family so this is ok
-                    // SAFETY: the address union backs a valid sockaddr_in/sockaddr_in6; pointer derived
-                    // from the whole union so provenance covers the full 28 bytes init_posix may copy.
-                    &unsafe {
-                        bun_sys::net::Address::init_posix(
-                            core::ptr::from_ref(&iface.address).cast::<bun_sys::posix::sockaddr>(),
-                        )
-                    },
-                    &mut ip_buf,
-                )
-                .expect("unreachable");
+                let addr_str = bun_fmt::format_ip(&addr, &mut ip_buf).expect("unreachable");
                 let addr_len = addr_str.len();
                 let start = addr_str.as_ptr() as usize - ip_buf.as_ptr() as usize;
                 if let Some(suffix) = maybe_suffix {
@@ -1237,18 +1040,7 @@ mod _impl {
 
             // netmask
             {
-                let str = bun_fmt::format_ip(
-                    // bun_sys::net::Address will do ptrCast depending on the family so this is ok
-                    // SAFETY: the netmask union backs a valid sockaddr_in/sockaddr_in6; pointer derived
-                    // from the whole union so provenance covers the full 28 bytes init_posix may copy.
-                    &unsafe {
-                        bun_sys::net::Address::init_posix(
-                            core::ptr::from_ref(&iface.netmask).cast::<bun_sys::posix::sockaddr>(),
-                        )
-                    },
-                    &mut ip_buf,
-                )
-                .expect("unreachable");
+                let str = bun_fmt::format_ip(&netmask, &mut ip_buf).expect("unreachable");
                 interface.put(
                     global_this,
                     b"netmask",
@@ -1256,8 +1048,6 @@ mod _impl {
                 );
             }
             // family
-            // SAFETY: union read tagged by family
-            let family = unsafe { iface.address.address4.sin_family } as c_int;
             interface.put(
                 global_this,
                 b"family",
@@ -1270,7 +1060,7 @@ mod _impl {
 
             // mac
             {
-                let mac_buf = bun_fmt::mac_address_lower(iface.phys_addr);
+                let mac_buf = bun_fmt::mac_address_lower(iface.phys_addr());
                 interface.put(
                     global_this,
                     b"mac",
@@ -1280,29 +1070,23 @@ mod _impl {
 
             // internal
             {
-                interface.put(
-                    global_this,
-                    b"internal",
-                    JSValue::from(iface.is_internal != 0),
-                );
+                interface.put(global_this, b"internal", JSValue::from(iface.is_internal()));
             }
 
             // cidr. this is here to keep ordering consistent with the node implementation
             interface.put(global_this, b"cidr", cidr);
 
             // scopeid
-            if family == bun_sys::posix::AF::INET6 {
-                // SAFETY: union read; family == INET6
+            if let Some(in6) = addr.as_in6() {
                 interface.put(
                     global_this,
                     b"scopeid",
-                    JSValue::js_number(unsafe { iface.address.address6.sin6_scope_id } as f64),
+                    JSValue::js_number(in6.sin6_scope_id as f64),
                 );
             }
 
             // Does this entry already exist?
-            // SAFETY: iface.name is a NUL-terminated C string from libuv
-            let interface_name = unsafe { bun_core::ffi::cstr(iface.name) }.to_bytes();
+            let interface_name = iface.name();
             if let Some(array) = ret.get(global_this, interface_name)? {
                 // Add this interface entry to the existing array
                 let next_index: u32 =
@@ -1339,23 +1123,15 @@ mod _impl {
         };
         #[cfg(windows)]
         let value: &[u8] = 'slice: {
-            // SAFETY: zeroed POD
-            let mut info: libuv::uv_utsname_s = unsafe { bun_core::ffi::zeroed_unchecked() };
-            // SAFETY: valid out-pointer
-            let err = unsafe { libuv::uv_os_uname(&mut info) };
-            if err != 0 {
+            let Ok(info) = bun_sys::os::uname() else {
                 break 'slice b"unknown";
-            }
+            };
             let value = bun_core::slice_to_nul(&info.release);
             name_buffer[0..value.len()].copy_from_slice(value);
             &name_buffer[0..value.len()]
         };
 
         BunString::clone_utf8(value)
-    }
-
-    unsafe extern "C" {
-        pub(crate) safe fn set_process_priority(pid: i32, priority: i32) -> i32;
     }
 
     fn set_process_priority_impl(pid: i32, priority: i32) -> bun_sys::E {
@@ -1418,28 +1194,26 @@ mod _impl {
         }
         #[cfg(windows)]
         {
-            // SAFETY: pure FFI getter
-            return unsafe { libuv::uv_get_total_memory() };
+            return bun_sys::os::total_memory();
         }
     }
 
     pub(crate) fn uptime(global: &JSGlobalObject) -> JsResult<f64> {
         #[cfg(windows)]
         {
-            let mut uptime_value: f64 = 0.0;
-            // SAFETY: valid out-pointer
-            let err = unsafe { libuv::uv_uptime(&mut uptime_value) };
-            if err != 0 {
-                let sys_err = SystemError {
-                    message: BunString::static_("failed to get system uptime").into(),
-                    code: BunString::static_("ERR_SYSTEM_ERROR").into(),
-                    errno: err,
-                    syscall: BunString::static_("uv_uptime").into(),
-                    ..Default::default()
-                };
-                return Err(global.throw_value(sys_err.to_error_instance(global)));
-            }
-            return Ok(uptime_value);
+            return match bun_sys::os::uptime() {
+                Ok(uptime_value) => Ok(uptime_value),
+                Err(err) => {
+                    let sys_err = SystemError {
+                        message: BunString::static_("failed to get system uptime"),
+                        code: BunString::static_("ERR_SYSTEM_ERROR"),
+                        errno: err,
+                        syscall: BunString::static_("uv_uptime"),
+                        ..Default::default()
+                    };
+                    Err(global.throw_value(sys_err.to_error_instance(global)))
+                }
+            };
         }
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
         {
@@ -1532,13 +1306,9 @@ mod _impl {
         };
         #[cfg(windows)]
         let slice: &[u8] = 'slice: {
-            // SAFETY: zeroed POD
-            let mut info: libuv::uv_utsname_s = unsafe { bun_core::ffi::zeroed_unchecked() };
-            // SAFETY: valid out-pointer
-            let err = unsafe { libuv::uv_os_uname(&mut info) };
-            if err != 0 {
+            let Ok(info) = bun_sys::os::uname() else {
                 break 'slice b"unknown";
-            }
+            };
             let s = bun_core::slice_to_nul(&info.version);
             name_buffer[0..s.len()].copy_from_slice(s);
             &name_buffer[0..s.len()]
@@ -1606,11 +1376,4 @@ fn parse_u64(s: &[u8]) -> crate::Result<u64> {
 #[inline]
 fn parse_u32(s: &[u8]) -> crate::Result<u32> {
     bun_core::fmt::parse_int(s, 10).map_err(|_| crate::Error::InvalidCharacter)
-}
-
-#[cfg(windows)]
-#[inline]
-fn slice_to_nul_u16(buf: &[u16]) -> &[u16] {
-    let nul = bun_core::strings::index_of_scalar(buf, 0).unwrap_or(buf.len());
-    &buf[..nul]
 }

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -38,9 +38,7 @@ mod _impl {
     #[cfg(not(windows))]
     use bun_core::strings;
     use bun_core::{env_var, fmt as bun_fmt};
-    use bun_jsc::{
-        CallFrame, JSArray, StringJsc as _, SysErrorJsc as _, SystemError, ZigStringJsc as _,
-    };
+    use bun_jsc::{CallFrame, JSArray, StringJsc as _, SysErrorJsc as _, SystemError};
     #[cfg(windows)]
     use bun_sys::ReturnCodeExt as _;
     #[cfg(not(windows))]

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -4,28 +4,29 @@
 //! `deflate-raw`, `gzip`, plus Bun's `brotli` / `zstd` extensions), each a
 //! `TransformStream` whose transform step feeds bytes into a codec and
 //! enqueues whatever comes out. The C++ `JSCompressionStream` /
-//! `JSDecompressionStream` cells own one `CompressionStreamCoder` via a
-//! `void*` and drive it through the `extern "C"` fns at the bottom of this
-//! file.
+//! `JSDecompressionStream` cells own one `CompressionStreamCoder` (a `Box`
+//! they release through `CompressionStreamCoder__destroy`) and drive it
+//! through the exports at the bottom of this file (thunks in
+//! `generated_host_exports.rs`).
 //!
 //! TransformStream backpressure only applies between chunks, and one chunk can
 //! expand without bound (a few hundred bytes of brotli decode to gigabytes), so
-//! a chunk is transformed in steps of bounded output
-//! ([`CompressionStreamCoder::step`]). The C++ arm
-//! (`JSCompressionStreamShared.cpp`) delivers each step's output and steps
-//! again once the consumer has room; in between, the coder keeps the chunk's
-//! unconsumed input ([`Pending`]).
+//! a chunk is transformed in steps of bounded output ([`Codec::step`]). The
+//! C++ arm (`JSCompressionStreamShared.cpp`) delivers each step's output and
+//! steps again once the consumer has room; in between, the codec keeps the
+//! chunk's unconsumed input ([`Pending`]).
 
 use core::ffi::c_int;
-use core::ptr::{self, NonNull};
 
 use bun_core::EncodedSlice;
+use bun_core::ffi::FfiSlice;
 use bun_jsc::EncodedSliceJsc as _;
 use bun_jsc::{ErrorCode, JSGlobalObject, JSUint8Array, JSValue, PinnedArrayBuffer, Strong};
 
 use bun_brotli::c as brotli;
 use bun_zlib as zlib;
-use bun_zstd::c as zstd;
+
+use crate::webcore::SinkHandle;
 
 /// Matches `Bun::WebStreams::CompressionFormat` in `StreamsForward.h`.
 #[repr(u8)]
@@ -63,20 +64,19 @@ impl Format {
 /// Growth granularity of a step's output buffer.
 const CHUNK: usize = 16 * 1024;
 
-/// Room for one codec call: grows `out` by up to [`CHUNK`], clamped to `cap`.
-fn spare(out: &mut Vec<u8>, cap: usize) -> Result<&mut [core::mem::MaybeUninit<u8>], CodecError> {
+/// Room for one codec call: grows `out`'s spare capacity by up to [`CHUNK`],
+/// and returns how much of it the codec may use so `out` stays within `cap`.
+fn reserve(out: &mut Vec<u8>, cap: usize) -> Result<usize, CodecError> {
     debug_assert!(out.len() < cap);
     let budget = cap - out.len();
     out.try_reserve(budget.min(CHUNK))
         .map_err(|_| CodecError::OutOfMemory)?;
-    let spare = out.spare_capacity_mut();
-    let len = spare.len().min(budget);
-    Ok(&mut spare[..len])
+    Ok(budget)
 }
 
 /// `CodecError` for a `ZSTD_isError` return value.
 fn zstd_error(rc: usize, message: &'static str) -> CodecError {
-    if zstd::ZSTD_getErrorCode(rc) == zstd::ZSTD_error_memory_allocation {
+    if bun_zstd::c::ZSTD_getErrorCode(rc) == bun_zstd::c::ZSTD_error_memory_allocation {
         CodecError::OutOfMemory
     } else {
         CodecError::Message(message)
@@ -102,30 +102,31 @@ enum Progress {
 }
 
 enum Backend {
-    Deflate(Box<zlib::z_stream>),
+    Deflate(zlib::DeflateEncoder),
     Inflate {
-        state: Box<zlib::z_stream>,
+        state: zlib::InflateDecoder,
         /// Gzip only: after the first member ends, any further bytes must be
         /// another gzip member (RFC 1952 §2.2) — the decoder resets and
         /// continues. Deflate/deflate-raw have no such concatenation, so
         /// leftover input is the spec's "trailing junk" TypeError.
         gzip: bool,
     },
-    BrotliEncode(NonNull<brotli::BrotliEncoder>),
-    BrotliDecode(NonNull<brotli::BrotliDecoder>),
-    ZstdEncode(NonNull<zstd::ZSTD_CCtx>),
-    ZstdDecode(NonNull<zstd::ZSTD_DStream>),
+    BrotliEncode(bun_brotli::EncoderStream),
+    BrotliDecode(bun_brotli::DecoderStream),
+    ZstdEncode(bun_zstd::CompressStream),
+    ZstdDecode(bun_zstd::DecompressStream),
 }
 
-#[derive(bun_ptr::ThreadSafeRefCounted)]
+/// What the C++ cell holds. The codec itself moves into an off-thread step
+/// for its duration ([`CompressionAsyncCtx`]) and back when it completes;
+/// TransformStream serializes transforms, so nothing asks for it meanwhile.
 pub struct CompressionStreamCoder {
+    codec: Option<Box<Codec>>,
+}
+
+/// The codec state and the bookkeeping a chunk's steps share.
+pub struct Codec {
     backend: Backend,
-    /// Shared-ownership count: 1 for the JS cell (released by its finalizer /
-    /// `nativeTransformReleaseState` via `CompressionStreamCoder__destroy`), plus 1 per in-flight
-    /// `CompressionAsyncCtx`. VM teardown (`lastChanceToFinalize`) runs the
-    /// cell's finalizer even while a pool thread is inside `transform` — the
-    /// ctx's reference is what keeps the coder alive through that.
-    ref_count: bun_ptr::ThreadSafeRefCount<CompressionStreamCoder>,
     /// DecompressionStream only: the codec has reported end-of-stream. Any
     /// further input is the spec's "trailing junk" TypeError.
     ended: bool,
@@ -143,37 +144,6 @@ pub struct CompressionStreamCoder {
     pending: Option<Pending>,
 }
 
-// SAFETY: the z_stream / Brotli*Instance / ZSTD_*Ctx handles are single-owner
-// heap state with no thread affinity; TransformStream serializes writes so at
-// most one chunk is ever in flight per coder.
-unsafe impl Send for CompressionStreamCoder {}
-
-impl Drop for CompressionStreamCoder {
-    fn drop(&mut self) {
-        // SAFETY: each pointer was created by the matching `*_create`/`*Init`
-        // below and has not been freed (the field is consumed exactly once,
-        // here).
-        unsafe {
-            match &mut self.backend {
-                Backend::Deflate(s) => {
-                    zlib::deflateEnd(&raw mut **s);
-                }
-                Backend::Inflate { state, .. } => {
-                    zlib::inflateEnd(&raw mut **state);
-                }
-                Backend::BrotliEncode(p) => brotli::BrotliEncoderDestroyInstance(p.as_ptr()),
-                Backend::BrotliDecode(p) => brotli::BrotliDecoderDestroyInstance(p.as_ptr()),
-                Backend::ZstdEncode(p) => {
-                    zstd::ZSTD_freeCCtx(p.as_ptr());
-                }
-                Backend::ZstdDecode(p) => {
-                    zstd::ZSTD_freeDCtx(p.as_ptr());
-                }
-            }
-        }
-    }
-}
-
 #[derive(Clone, Copy)]
 enum CodecError {
     TrailingJunk,
@@ -183,92 +153,53 @@ enum CodecError {
     /// Brotli decoder error; `BrotliDecoderErrorString` (static C string).
     /// Surfaced as TypeError with `.code = "ERR_" + <this>` for node:zlib compat.
     Brotli(&'static str),
+    /// A step was asked for while another still has the codec.
+    Busy,
 }
 
-impl CompressionStreamCoder {
-    fn new(
-        format: Format,
-        decompress: bool,
-        high_water_mark: usize,
-    ) -> Result<Box<Self>, CodecError> {
+impl Codec {
+    fn new(format: Format, decompress: bool, high_water_mark: usize) -> Result<Self, CodecError> {
         let backend = match (format, decompress) {
             (Format::Deflate | Format::DeflateRaw | Format::Gzip, false) => {
-                let mut s = Box::new(bun_core::ffi::zeroed::<zlib::z_stream>());
-                // Spec: "default compression level". Z_DEFAULT_COMPRESSION = -1.
-                // SAFETY: `s` is a zeroed, #[repr(C)] z_stream; zlibVersion() is
-                // a static C string.
-                let rc = unsafe {
-                    zlib::deflateInit2_(
-                        &raw mut *s,
-                        -1,
-                        8, // Z_DEFLATED
-                        format.window_bits(),
-                        8, // default mem_level
-                        0, // Z_DEFAULT_STRATEGY
-                        zlib::zlibVersion().cast(),
-                        core::mem::size_of::<zlib::z_stream>() as c_int,
-                    )
-                };
-                if rc != zlib::ReturnCode::Ok {
-                    return Err(CodecError::Message("failed to initialize deflate"));
-                }
+                // Spec: "default compression level" (Z_DEFAULT_COMPRESSION = -1),
+                // default mem_level 8, Z_DEFAULT_STRATEGY.
+                let s = zlib::DeflateEncoder::new(-1, format.window_bits(), 8, 0)
+                    .map_err(|_| CodecError::Message("failed to initialize deflate"))?;
                 Backend::Deflate(s)
             }
             (Format::Deflate | Format::DeflateRaw | Format::Gzip, true) => {
-                let mut s = Box::new(bun_core::ffi::zeroed::<zlib::z_stream>());
-                // SAFETY: as above.
-                let rc = unsafe {
-                    zlib::inflateInit2_(
-                        &raw mut *s,
-                        format.window_bits(),
-                        zlib::zlibVersion().cast(),
-                        core::mem::size_of::<zlib::z_stream>() as c_int,
-                    )
-                };
-                if rc != zlib::ReturnCode::Ok {
-                    return Err(CodecError::Message("failed to initialize inflate"));
-                }
+                let s = zlib::InflateDecoder::new(format.window_bits())
+                    .map_err(|_| CodecError::Message("failed to initialize inflate"))?;
                 Backend::Inflate {
                     state: s,
                     gzip: format == Format::Gzip,
                 }
             }
-            (Format::Brotli, false) => {
-                // SAFETY: FFI — the default-allocator instance (all nulls).
-                let p = NonNull::new(unsafe {
-                    brotli::BrotliEncoderCreateInstance(None, None, ptr::null_mut())
-                })
-                .ok_or(CodecError::Message("failed to initialize brotli encoder"))?;
-                Backend::BrotliEncode(p)
-            }
-            (Format::Brotli, true) => {
-                // SAFETY: FFI — the default-allocator instance (all nulls).
-                let p = NonNull::new(unsafe {
-                    brotli::BrotliDecoderCreateInstance(None, None, ptr::null_mut())
-                })
-                .ok_or(CodecError::Message("failed to initialize brotli decoder"))?;
-                Backend::BrotliDecode(p)
-            }
-            (Format::Zstd, false) => {
-                let p = NonNull::new(zstd::ZSTD_createCCtx())
-                    .ok_or(CodecError::Message("failed to initialize zstd encoder"))?;
-                Backend::ZstdEncode(p)
-            }
-            (Format::Zstd, true) => {
-                let p = NonNull::new(zstd::ZSTD_createDCtx())
-                    .ok_or(CodecError::Message("failed to initialize zstd decoder"))?;
-                Backend::ZstdDecode(p)
-            }
+            (Format::Brotli, false) => Backend::BrotliEncode(
+                bun_brotli::EncoderStream::new()
+                    .ok_or(CodecError::Message("failed to initialize brotli encoder"))?,
+            ),
+            (Format::Brotli, true) => Backend::BrotliDecode(
+                bun_brotli::DecoderStream::new()
+                    .ok_or(CodecError::Message("failed to initialize brotli decoder"))?,
+            ),
+            (Format::Zstd, false) => Backend::ZstdEncode(
+                bun_zstd::CompressStream::new()
+                    .ok_or(CodecError::Message("failed to initialize zstd encoder"))?,
+            ),
+            (Format::Zstd, true) => Backend::ZstdDecode(
+                bun_zstd::DecompressStream::new()
+                    .ok_or(CodecError::Message("failed to initialize zstd decoder"))?,
+            ),
         };
-        Ok(Box::new(Self {
+        Ok(Self {
             backend,
-            ref_count: bun_ptr::ThreadSafeRefCount::init(),
             ended: false,
             zstd_head: [0; 4],
             zstd_head_len: 0,
             high_water_mark,
             pending: None,
-        }))
+        })
     }
 
     const ZSTD_MAGIC: [u8; 4] = 0xFD2F_B528u32.to_le_bytes();
@@ -345,8 +276,8 @@ impl CompressionStreamCoder {
     ) -> Result<Progress, CodecError> {
         match &mut self.backend {
             Backend::Deflate(s) => {
-                // `avail_in` is `uInt`; clamp and refill so a ≥4 GiB chunk
-                // isn't silently truncated by the `as u32` cast.
+                // `avail_in` is `uInt`; `step_into_spare` clamps a ≥4 GiB
+                // chunk and reports what it consumed, so refill until done.
                 let mut remaining = input;
                 loop {
                     if out.len() >= cap {
@@ -354,27 +285,14 @@ impl CompressionStreamCoder {
                             consumed: input.len() - remaining.len(),
                         });
                     }
-                    let take = remaining.len().min(u32::MAX as usize);
-                    let tail = remaining.len() > take;
+                    let tail = remaining.len() > u32::MAX as usize;
                     let flush = if finish && !tail {
                         zlib::FlushValue::Finish
                     } else {
                         zlib::FlushValue::NoFlush
                     };
-                    s.next_in = remaining.as_ptr();
-                    s.avail_in = take as u32;
-                    let spare = spare(out, cap)?;
-                    s.next_out = spare.as_mut_ptr().cast();
-                    s.avail_out = spare.len().min(u32::MAX as usize) as u32;
-                    let before = s.avail_out;
-                    // SAFETY: `s` was initialized by `deflateInit2_`; next_in/
-                    // avail_in borrow `remaining`, next_out/avail_out borrow
-                    // the Vec's spare capacity for this one call.
-                    let rc = unsafe { zlib::deflate(&raw mut **s, flush) };
-                    let written = (before - s.avail_out) as usize;
-                    // SAFETY: deflate wrote exactly `written` bytes.
-                    unsafe { out.set_len(out.len() + written) };
-                    let consumed = take - s.avail_in as usize;
+                    let limit = reserve(out, cap)?;
+                    let (consumed, rc) = s.step_into_spare(remaining, out, limit, flush);
                     remaining = &remaining[consumed..];
                     match rc {
                         zlib::ReturnCode::Ok | zlib::ReturnCode::BufError => {}
@@ -382,7 +300,7 @@ impl CompressionStreamCoder {
                         zlib::ReturnCode::MemError => return Err(CodecError::OutOfMemory),
                         _ => return Err(CodecError::Message("deflate failed")),
                     }
-                    if s.avail_out != 0 && remaining.is_empty() {
+                    if s.avail_out() != 0 && remaining.is_empty() {
                         return Ok(Progress::Done);
                     }
                 }
@@ -397,8 +315,7 @@ impl CompressionStreamCoder {
                         if !gzip {
                             return Err(CodecError::TrailingJunk);
                         }
-                        // SAFETY: `s` is an initialized inflate stream.
-                        if unsafe { zlib::inflateReset(&raw mut **s) } != zlib::ReturnCode::Ok {
+                        if s.reset() != zlib::ReturnCode::Ok {
                             return Err(CodecError::Message("inflate failed"));
                         }
                         self.ended = false;
@@ -414,26 +331,14 @@ impl CompressionStreamCoder {
                             consumed: input.len() - remaining.len(),
                         });
                     }
-                    let take = remaining.len().min(u32::MAX as usize);
-                    let tail = remaining.len() > take;
+                    let tail = remaining.len() > u32::MAX as usize;
                     let flush = if finish && !tail {
                         zlib::FlushValue::Finish
                     } else {
                         zlib::FlushValue::NoFlush
                     };
-                    s.next_in = remaining.as_ptr();
-                    s.avail_in = take as u32;
-                    let spare = spare(out, cap)?;
-                    s.next_out = spare.as_mut_ptr().cast();
-                    s.avail_out = spare.len().min(u32::MAX as usize) as u32;
-                    let before = s.avail_out;
-                    // SAFETY: `s` was initialized by `inflateInit2_`; buffers
-                    // as in the deflate arm.
-                    let rc = unsafe { zlib::inflate(&raw mut **s, flush) };
-                    let written = (before - s.avail_out) as usize;
-                    // SAFETY: inflate wrote exactly `written` bytes.
-                    unsafe { out.set_len(out.len() + written) };
-                    let consumed = take - s.avail_in as usize;
+                    let limit = reserve(out, cap)?;
+                    let (consumed, rc) = s.step_into_spare(remaining, out, limit, flush);
                     remaining = &remaining[consumed..];
                     match rc {
                         zlib::ReturnCode::Ok => {}
@@ -450,8 +355,7 @@ impl CompressionStreamCoder {
                             if !gzip {
                                 return Err(CodecError::TrailingJunk);
                             }
-                            // SAFETY: `s` is an initialized inflate stream.
-                            if unsafe { zlib::inflateReset(&raw mut **s) } != zlib::ReturnCode::Ok {
+                            if s.reset() != zlib::ReturnCode::Ok {
                                 return Err(CodecError::Message("inflate failed"));
                             }
                             self.ended = false;
@@ -463,7 +367,7 @@ impl CompressionStreamCoder {
                         zlib::ReturnCode::MemError => return Err(CodecError::OutOfMemory),
                         _ => return Err(CodecError::Message("inflate failed")),
                     }
-                    if s.avail_out != 0 && remaining.is_empty() {
+                    if s.avail_out() != 0 && remaining.is_empty() {
                         if finish && !self.ended {
                             return Err(CodecError::Message("unexpected end of file"));
                         }
@@ -471,94 +375,58 @@ impl CompressionStreamCoder {
                     }
                 }
             }
-            Backend::BrotliEncode(p) => {
+            Backend::BrotliEncode(encoder) => {
                 let op = if finish {
                     brotli::BrotliEncoderOperation::finish
                 } else {
                     brotli::BrotliEncoderOperation::process
                 };
-                let mut next_in: *const u8 = input.as_ptr();
-                let mut avail_in: usize = input.len();
+                let mut remaining = input;
                 loop {
                     if out.len() >= cap {
                         return Ok(Progress::More {
-                            consumed: input.len() - avail_in,
+                            consumed: input.len() - remaining.len(),
                         });
                     }
-                    let spare = spare(out, cap)?;
-                    let mut next_out: *mut u8 = spare.as_mut_ptr().cast();
-                    let mut avail_out: usize = spare.len();
-                    let before = avail_out;
-                    // SAFETY: `p` is a live encoder; the four ptrs borrow the
-                    // locals / spare for this one call.
-                    let ok = unsafe {
-                        brotli::BrotliEncoderCompressStream(
-                            p.as_ptr(),
-                            op,
-                            &raw mut avail_in,
-                            &raw mut next_in,
-                            &raw mut avail_out,
-                            &raw mut next_out,
-                            ptr::null_mut(),
-                        )
-                    };
-                    let written = before - avail_out;
-                    // SAFETY: the encoder wrote exactly `written` bytes.
-                    unsafe { out.set_len(out.len() + written) };
-                    if ok == 0 {
+                    let limit = reserve(out, cap)?;
+                    let step = encoder.step(op, remaining, out, limit);
+                    remaining = &remaining[step.consumed..];
+                    if !step.result {
                         return Err(CodecError::Message("brotli encode failed"));
                     }
-                    if avail_in == 0 && avail_out != 0 {
+                    if remaining.is_empty() && step.avail_out != 0 {
                         return Ok(Progress::Done);
                     }
                 }
             }
-            Backend::BrotliDecode(p) => {
+            Backend::BrotliDecode(decoder) => {
                 if self.ended {
                     if !input.is_empty() {
                         return Err(CodecError::TrailingJunk);
                     }
                     return Ok(Progress::Done);
                 }
-                let mut next_in: *const u8 = input.as_ptr();
-                let mut avail_in: usize = input.len();
+                let mut remaining = input;
                 loop {
                     if out.len() >= cap {
                         return Ok(Progress::More {
-                            consumed: input.len() - avail_in,
+                            consumed: input.len() - remaining.len(),
                         });
                     }
-                    let spare = spare(out, cap)?;
-                    let mut next_out: *mut u8 = spare.as_mut_ptr().cast();
-                    let mut avail_out: usize = spare.len();
-                    let before = avail_out;
-                    // SAFETY: `p` is a live decoder; buffers as above.
-                    let result = unsafe {
-                        brotli::BrotliDecoderDecompressStream(
-                            p.as_ptr(),
-                            &raw mut avail_in,
-                            &raw mut next_in,
-                            &raw mut avail_out,
-                            &raw mut next_out,
-                            ptr::null_mut(),
-                        )
-                    };
-                    let written = before - avail_out;
-                    // SAFETY: the decoder wrote exactly `written` bytes.
-                    unsafe { out.set_len(out.len() + written) };
-                    match result {
+                    let limit = reserve(out, cap)?;
+                    let step = decoder.step(remaining, out, limit);
+                    remaining = &remaining[step.consumed..];
+                    match step.result {
                         brotli::BrotliDecoderResult::success => {
                             self.ended = true;
-                            if avail_in != 0 {
+                            if !remaining.is_empty() {
                                 return Err(CodecError::TrailingJunk);
                             }
                             return Ok(Progress::Done);
                         }
                         brotli::BrotliDecoderResult::needs_more_input => {
                             // Brotli reports `needs_more_input` even with output left in its ring buffer.
-                            // SAFETY: `p` is a live decoder.
-                            let decoder = unsafe { &*p.as_ptr() };
-                            if written > 0 && brotli::BrotliDecoder::has_more_output(decoder) {
+                            if step.written > 0 && decoder.has_more_output() {
                                 continue;
                             }
                             if finish {
@@ -568,78 +436,48 @@ impl CompressionStreamCoder {
                         }
                         brotli::BrotliDecoderResult::needs_more_output => {}
                         brotli::BrotliDecoderResult::err => {
-                            // SAFETY: `p` is a live decoder.
-                            let ec = brotli::BrotliDecoderGetErrorCode(unsafe { &*p.as_ptr() });
+                            let ec = decoder.error_code();
                             if ec.is_alloc_failure() {
                                 return Err(CodecError::OutOfMemory);
                             }
-                            // SAFETY: the error string is a static C string owned by the brotli library.
-                            let code = unsafe {
-                                core::ffi::CStr::from_ptr(brotli::BrotliDecoderErrorString(ec))
-                            };
                             return Err(CodecError::Brotli(
-                                code.to_str().unwrap_or("brotli decode failed"),
+                                bun_brotli::decoder_error_string(ec)
+                                    .to_str()
+                                    .unwrap_or("brotli decode failed"),
                             ));
                         }
                     }
                 }
             }
-            Backend::ZstdEncode(p) => {
-                // ZSTD_EndDirective: 0 = ZSTD_e_continue, 2 = ZSTD_e_end.
-                let end: core::ffi::c_uint = if finish { 2 } else { 0 };
-                let mut input_buf = zstd::ZSTD_inBuffer {
-                    src: input.as_ptr().cast(),
-                    size: input.len(),
-                    pos: 0,
-                };
+            Backend::ZstdEncode(cctx) => {
+                let mut remaining = input;
                 loop {
                     if out.len() >= cap {
                         return Ok(Progress::More {
-                            consumed: input_buf.pos,
+                            consumed: input.len() - remaining.len(),
                         });
                     }
-                    let spare = spare(out, cap)?;
-                    let mut output_buf = zstd::ZSTD_outBuffer {
-                        dst: spare.as_mut_ptr().cast(),
-                        size: spare.len(),
-                        pos: 0,
-                    };
-                    // SAFETY: `p` is a live CCtx; the buffers borrow locals /
-                    // spare for this one call.
-                    let remaining = unsafe {
-                        zstd::ZSTD_compressStream2(
-                            p.as_ptr(),
-                            &raw mut output_buf,
-                            &raw mut input_buf,
-                            end,
-                        )
-                    };
-                    // SAFETY: compressStream2 wrote exactly `output_buf.pos`
-                    // bytes.
-                    unsafe { out.set_len(out.len() + output_buf.pos) };
-                    if zstd::ZSTD_isError(remaining) != 0 {
-                        return Err(zstd_error(remaining, "zstd encode failed"));
+                    let limit = reserve(out, cap)?;
+                    let step = cctx.step(remaining, out, limit, finish);
+                    remaining = &remaining[step.consumed..];
+                    if bun_zstd::c::ZSTD_isError(step.code) != 0 {
+                        return Err(zstd_error(step.code, "zstd encode failed"));
                     }
-                    if input_buf.pos == input_buf.size && (!finish || remaining == 0) {
+                    if remaining.is_empty() && (!finish || step.code == 0) {
                         return Ok(Progress::Done);
                     }
                 }
             }
-            Backend::ZstdDecode(p) => {
+            Backend::ZstdDecode(dctx) => {
                 // After a frame completes, whatever follows must be another frame
                 // magic (see `zstd_head`); `step` has already re-attached a split one.
-                let mut input_buf = zstd::ZSTD_inBuffer {
-                    src: input.as_ptr().cast(),
-                    size: input.len(),
-                    pos: 0,
-                };
+                let mut remaining = input;
                 loop {
                     if self.ended {
-                        let rest = &input[input_buf.pos..];
-                        if rest.is_empty() {
+                        if remaining.is_empty() {
                             return Ok(Progress::Done);
                         }
-                        let head = &rest[..rest.len().min(4)];
+                        let head = &remaining[..remaining.len().min(4)];
                         if !Self::is_zstd_frame_prefix(head) {
                             return Err(CodecError::TrailingJunk);
                         }
@@ -651,46 +489,25 @@ impl CompressionStreamCoder {
                             self.zstd_head_len = head.len() as u8;
                             return Ok(Progress::Done);
                         }
-                        // SAFETY: `p` is a live DCtx.
-                        unsafe {
-                            zstd::ZSTD_DCtx_reset(
-                                p.as_ptr(),
-                                zstd::ZSTD_reset_session_and_parameters,
-                            )
-                        };
+                        dctx.reset();
                         self.ended = false;
                     }
                     if out.len() >= cap {
                         return Ok(Progress::More {
-                            consumed: input_buf.pos,
+                            consumed: input.len() - remaining.len(),
                         });
                     }
-                    let spare = spare(out, cap)?;
-                    let mut output_buf = zstd::ZSTD_outBuffer {
-                        dst: spare.as_mut_ptr().cast(),
-                        size: spare.len(),
-                        pos: 0,
-                    };
-                    // SAFETY: `p` is a live DCtx; buffers borrow locals / spare
-                    // for this one call.
-                    let remaining = unsafe {
-                        zstd::ZSTD_decompressStream(
-                            p.as_ptr(),
-                            &raw mut output_buf,
-                            &raw mut input_buf,
-                        )
-                    };
-                    // SAFETY: decompressStream wrote exactly `output_buf.pos`
-                    // bytes.
-                    unsafe { out.set_len(out.len() + output_buf.pos) };
-                    if zstd::ZSTD_isError(remaining) != 0 {
-                        return Err(zstd_error(remaining, "zstd decode failed"));
+                    let limit = reserve(out, cap)?;
+                    let step = dctx.step(remaining, out, limit);
+                    remaining = &remaining[step.consumed..];
+                    if bun_zstd::c::ZSTD_isError(step.code) != 0 {
+                        return Err(zstd_error(step.code, "zstd decode failed"));
                     }
-                    if remaining == 0 {
+                    if step.code == 0 {
                         self.ended = true;
                         continue;
                     }
-                    if input_buf.pos == input_buf.size && output_buf.pos < output_buf.size {
+                    if remaining.is_empty() && step.written < step.offered {
                         if finish {
                             return Err(CodecError::Message("unexpected end of file"));
                         }
@@ -702,107 +519,82 @@ impl CompressionStreamCoder {
     }
 }
 
-/// A chunk's bytes for the pool thread: what the paired [`PinnedArrayBuffer`] on the JS side keeps valid, or an owned copy.
+impl CompressionStreamCoder {
+    /// One JS-thread step with the codec this coder holds (the C++ side never
+    /// steps while an off-thread step has it: `m_asyncCodecInFlight`).
+    fn step(&mut self, input: &[u8], finish: bool, out: &mut Vec<u8>) -> Result<bool, CodecError> {
+        debug_assert!(self.codec.is_some(), "codec stepped while off-thread");
+        match &mut self.codec {
+            Some(codec) => codec.step(input, finish, out),
+            None => Err(CodecError::Busy),
+        }
+    }
+}
+
+/// A chunk's bytes for the pool thread: the pinned ArrayBuffer they live in,
+/// or an owned copy.
 pub(crate) enum AsyncInput {
-    Pinned { ptr: *const u8, len: usize },
+    Pinned(PinnedArrayBuffer),
     Owned(Vec<u8>),
 }
-// SAFETY: `Pinned.ptr` points at bytes the paired `PinnedArrayBuffer` keeps
-// valid for as long as the job lives; read only under the pool borrow.
-unsafe impl Send for AsyncInput {}
 
 impl AsyncInput {
     /// JS thread: pin `chunk` if it is a pinnable ArrayBuffer/view, else copy `fallback`.
-    pub(crate) fn new(
-        global: &JSGlobalObject,
-        chunk: JSValue,
-        fallback: &[u8],
-    ) -> (Self, Option<PinnedArrayBuffer>) {
-        // Continuation steps pass no chunk.
-        if !chunk.is_cell() {
-            return (Self::Owned(fallback.to_vec()), None);
+    pub(crate) fn new(global: &JSGlobalObject, chunk: JSValue, fallback: &[u8]) -> Self {
+        match PinnedArrayBuffer::pin(global, chunk) {
+            Some(pinned) => Self::Pinned(pinned),
+            None => Self::Owned(fallback.to_vec()),
         }
-        if let Some(buf) = PinnedArrayBuffer::root_read_only(global, chunk) {
-            return (
-                Self::Pinned {
-                    ptr: buf.ptr,
-                    len: buf.byte_len,
-                },
-                Some(buf),
-            );
-        }
-        (Self::Owned(fallback.to_vec()), None)
     }
 
+    /// Pool thread, under the job's ticket.
     #[inline]
-    pub(crate) fn slice(&self) -> &[u8] {
+    pub(crate) fn slice<'a>(&'a self, ticket: &bun_jsc::Ticket) -> &'a [u8] {
         match self {
-            Self::Pinned { ptr, len } => {
-                if ptr.is_null() {
-                    return &[];
-                }
-                // SAFETY: see the `Send` note.
-                unsafe { core::slice::from_raw_parts(*ptr, *len) }
-            }
+            Self::Pinned(pinned) => pinned.bytes(ticket),
             Self::Owned(v) => v.as_slice(),
         }
     }
 }
 
-// ─── extern "C" surface (called from JSCompressionStream.cpp) ──────────────
+// ─── exports (called from JSCompressionStream.cpp) ─────────────────────────
 
-#[unsafe(no_mangle)]
-pub extern "C" fn CompressionStreamCoder__create(
+// HOST_EXPORT(CompressionStreamCoder__create, c)
+pub fn create(
     format: u8,
     decompress: bool,
     high_water_mark: usize,
-) -> *mut CompressionStreamCoder {
-    let Some(format) = Format::from_u8(format) else {
-        return ptr::null_mut();
-    };
-    match CompressionStreamCoder::new(format, decompress, high_water_mark.max(1)) {
-        Ok(b) => Box::into_raw(b),
-        Err(_) => ptr::null_mut(),
-    }
+) -> Option<Box<crate::webcore::compression_stream_coder::CompressionStreamCoder>> {
+    let format = Format::from_u8(format)?;
+    let codec = Codec::new(format, decompress, high_water_mark.max(1)).ok()?;
+    Some(Box::new(CompressionStreamCoder {
+        codec: Some(Box::new(codec)),
+    }))
 }
 
-/// Releases the C++ cell's reference; see [`CompressionStreamCoder::ref_count`].
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn CompressionStreamCoder__destroy(this: *mut CompressionStreamCoder) {
-    if !this.is_null() {
-        // SAFETY: `this` was returned by `CompressionStreamCoder__create` and
-        // the cell's reference has not been released yet.
-        unsafe { bun_ptr::ThreadSafeRefCount::<CompressionStreamCoder>::deref(this) };
-    }
+/// The C++ cell (its finalizer or `nativeTransformReleaseState`) gives up the
+/// coder; a step still on the pool owns the codec and drops it itself.
+// HOST_EXPORT(CompressionStreamCoder__destroy, c)
+pub fn destroy(
+    this: Option<Box<crate::webcore::compression_stream_coder::CompressionStreamCoder>>,
+) {
+    drop(this);
 }
 
-/// One JS-thread [`step`](CompressionStreamCoder::step): returns its output as
-/// a fresh (possibly empty) `Uint8Array` and sets `more` if the coder must be
-/// stepped again (with `input` null), or throws a `TypeError` and returns zero.
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn CompressionStreamCoder__transform(
-    this: *mut CompressionStreamCoder,
+/// One JS-thread [`step`](Codec::step): returns its output as a fresh
+/// (possibly empty) `Uint8Array` and sets `more` if the coder must be stepped
+/// again (with empty `input`), or throws a `TypeError` and returns zero.
+// HOST_EXPORT(CompressionStreamCoder__transform, c)
+pub fn transform(
+    this: &mut crate::webcore::compression_stream_coder::CompressionStreamCoder,
     global: &JSGlobalObject,
-    input: *const u8,
-    input_len: usize,
+    input: &[u8],
     finish: bool,
     more: &mut bool,
 ) -> JSValue {
-    let slice = if input.is_null() {
-        &[][..]
-    } else {
-        // SAFETY: the caller passes a BufferSource's bytes; `slice` does not
-        // escape this call (`step` copies whatever it leaves unconsumed).
-        unsafe { core::slice::from_raw_parts(input, input_len) }
-    };
     let rare = global.bun_vm().as_mut().rare_data();
     let mut out = rare.take_compression_scratch();
-    // SAFETY: `this` is the live coder owned by the calling JS cell; it is
-    // only driven from the JS thread, so the call-scoped `&mut *this` has no
-    // alias.
-    let result = match unsafe { (*this).step(slice, finish, &mut out) } {
+    let result = match this.step(input, finish, &mut out) {
         Ok(has_more) => {
             *more = has_more;
             let chunk = if out.is_empty() {
@@ -842,6 +634,9 @@ fn codec_error_to_js(global: &JSGlobalObject, e: &CodecError) -> JSValue {
             err.put(global, b"cause", cause);
             err
         }
+        CodecError::Busy => global.create_type_error_instance(format_args!(
+            "compression stream is busy with another chunk"
+        )),
     }
 }
 
@@ -850,48 +645,30 @@ fn throw_codec_error(global: &JSGlobalObject, e: CodecError) {
 }
 
 /// [`CompressionStreamCoder__transform`], but the output is written to the
-/// native JSSink `sink_ptr`: returns the sink's `write` result (see
+/// stream's native `sink`: returns the sink's `write` result (see
 /// nativeSinkWriteIsBackpressure), `undefined` when there was no output.
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn CompressionStreamCoder__transformInto(
-    this: *mut CompressionStreamCoder,
+// HOST_EXPORT(CompressionStreamCoder__transformInto, c)
+pub fn transform_into(
+    this: &mut crate::webcore::compression_stream_coder::CompressionStreamCoder,
     global: &JSGlobalObject,
-    input: *const u8,
-    input_len: usize,
+    input: &[u8],
     finish: bool,
-    sink_id: u8,
-    sink_ptr: *mut core::ffi::c_void,
+    sink: SinkHandle,
     more: &mut bool,
 ) -> JSValue {
-    let slice = if input.is_null() {
-        &[][..]
-    } else {
-        // SAFETY: as in `CompressionStreamCoder__transform`.
-        unsafe { core::slice::from_raw_parts(input, input_len) }
-    };
     let rare = global.bun_vm().as_mut().rare_data();
     let mut out = rare.take_compression_scratch();
-    // SAFETY: as in `CompressionStreamCoder__transform`.
-    let result = match unsafe { (*this).step(slice, finish, &mut out) } {
+    let result = match this.step(input, finish, &mut out) {
         Ok(has_more) => {
             *more = has_more;
-            'write: {
-                let Some(sink_ptr) = NonNull::new(sink_ptr).filter(|_| !out.is_empty()) else {
-                    break 'write JSValue::UNDEFINED;
-                };
-                // SAFETY: `sink_ptr` is a live JSSink of type `sink_id`; the sink
-                // copies what it needs before returning.
-                let handle =
-                    unsafe { crate::webcore::sink::sink_handle_from_id(sink_id, sink_ptr) };
-                if handle.is_none() {
-                    break 'write JSValue::UNDEFINED;
-                }
-                handle
-                    .write(&crate::webcore::streams::Result::Temporary(
-                        bun_ptr::RawSlice::new(&out),
-                    ))
-                    .to_js(global)
+            if out.is_empty() || sink.is_none() {
+                JSValue::UNDEFINED
+            } else {
+                // The sink copies what it needs before returning.
+                sink.write(&crate::webcore::streams::Result::Temporary(
+                    bun_ptr::RawSlice::new(&out),
+                ))
+                .to_js(global)
             }
         }
         Err(e) => {
@@ -906,36 +683,46 @@ pub extern "C" fn CompressionStreamCoder__transformInto(
 
 // ─── off-thread path (chunks > kAsyncCodecThreshold) ───────────────────────
 
+#[allow(improper_ctypes)] // `Codec` is opaque to C++: handed straight back to `CompressionStreamCoder__restore`
 unsafe extern "C" {
-    /// JS-thread completion in `JSCompressionStreamShared.cpp`: consumes
-    /// `out[..out_len]` before anything may release or re-dispatch the coder.
-    fn Bun__CompressionStream__deliverAsync(
+    /// JS-thread completion in `JSCompressionStreamShared.cpp`: hands `codec`
+    /// back to the stream's coder (`CompressionStreamCoder__restore`), then
+    /// consumes `out` before anything may release or re-dispatch the coder.
+    safe fn Bun__CompressionStream__deliverAsync(
         global: &JSGlobalObject,
         stream_cell: JSValue,
-        out: *const u8,
-        out_len: usize,
+        codec: Option<Box<Codec>>,
+        out: FfiSlice<'_>,
         more: bool,
         error: JSValue,
     );
 }
 
+/// The codec an off-thread step took comes back to the coder the stream
+/// still holds (`None` if the stream has none, which drops it).
+// HOST_EXPORT(CompressionStreamCoder__restore, c)
+pub fn restore(
+    this: Option<&mut crate::webcore::compression_stream_coder::CompressionStreamCoder>,
+    codec: Option<Box<crate::webcore::compression_stream_coder::Codec>>,
+) {
+    if let Some(this) = this {
+        debug_assert!(this.codec.is_none());
+        this.codec = codec;
+    }
+}
+
 /// One step of a large `CompressionStream`/`DecompressionStream` chunk, run
-/// off the JS thread.
+/// off the JS thread. It owns the codec for its duration; TransformStream
+/// serializes writes, so nothing else asks for it meanwhile.
 pub struct CompressionAsyncCtx {
-    /// See [`CompressionStreamCoder::ref_count`]. TransformStream serializes
-    /// writes, so nothing else touches the coder while the pool has it.
-    coder: bun_ptr::RefPtr<CompressionStreamCoder>,
-    /// Empty on a continuation step: the coder holds the chunk's tail.
+    codec: Option<Box<Codec>>,
+    /// Empty on a continuation step: the codec holds the chunk's tail.
     input: AsyncInput,
     finish: bool,
     out: Vec<u8>,
     more: bool,
     error: Option<CodecError>,
 }
-
-// SAFETY: the coder is `ThreadSafeRefCounted` and only touched by whoever holds
-// the transform (pool thread, then JS thread); `AsyncInput` owns or pins its bytes.
-unsafe impl Send for CompressionAsyncCtx {}
 
 #[derive(bun_jsc::JsAffine)]
 pub struct CompressionAsyncJs {
@@ -944,7 +731,6 @@ pub struct CompressionAsyncJs {
     /// and its `m_codecPromise` WriteBarrier keeps the pending
     /// transform-algorithm promise alive.
     stream: Strong,
-    _pin: Option<PinnedArrayBuffer>,
 }
 
 impl bun_jsc::JobContext for CompressionAsyncCtx {
@@ -952,10 +738,11 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
     type Js = CompressionAsyncJs;
 
     fn run(this: &mut Self, done: bun_jsc::Completion<Self>) -> Option<bun_jsc::Completion<Self>> {
-        // SAFETY: `coder` is kept alive by the reference this ctx holds (the
-        // cell's finalizer only releases its own); see the field doc.
-        match unsafe { (*this.coder.as_ptr()).step(this.input.slice(), this.finish, &mut this.out) }
-        {
+        let result = match &mut this.codec {
+            Some(codec) => codec.step(this.input.slice(done.ticket()), this.finish, &mut this.out),
+            None => Err(CodecError::Busy),
+        };
+        match result {
             Ok(more) => this.more = more,
             Err(e) => this.error = Some(e),
         }
@@ -968,52 +755,40 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
         cx: &bun_jsc::JsThread<'_>,
     ) -> bun_jsc::JsResult<()> {
         let global = cx.global();
-        let (out, out_len, err) = match &this.error {
-            None => (this.out.as_ptr(), this.out.len(), JSValue::ZERO),
-            Some(e) => (core::ptr::null(), 0, codec_error_to_js(global, e)),
+        let (out, err) = match &this.error {
+            None => (&this.out[..], JSValue::ZERO),
+            Some(e) => (&[][..], codec_error_to_js(global, e)),
         };
-        // SAFETY: FFI into `JSCompressionStreamShared.cpp`; see above.
-        unsafe {
-            Bun__CompressionStream__deliverAsync(
-                global,
-                js.stream.get(),
-                out,
-                out_len,
-                this.more,
-                err,
-            )
-        };
+        Bun__CompressionStream__deliverAsync(
+            global,
+            js.stream.get(),
+            this.codec,
+            FfiSlice::new(out),
+            this.more,
+            err,
+        );
         Ok(())
     }
 }
 
 /// Schedules one off-thread step; a continuation step passes no chunk and no
-/// input (the coder kept the tail).
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn CompressionStreamCoder__transformAsync(
-    this: *mut CompressionStreamCoder,
+/// input (the codec kept the tail). `input` is `chunk`'s bytes: pinned in
+/// place when `chunk` allows it, else copied.
+// HOST_EXPORT(CompressionStreamCoder__transformAsync, c)
+pub fn transform_async(
+    this: &mut crate::webcore::compression_stream_coder::CompressionStreamCoder,
     global: &JSGlobalObject,
     stream_cell: JSValue,
     chunk: JSValue,
-    input: *const u8,
-    input_len: usize,
+    input: &[u8],
     finish: bool,
 ) {
-    let fallback = if input.is_null() {
-        &[][..]
-    } else {
-        // SAFETY: the caller passes a BufferSource's bytes; either pinned (and
-        // `fallback` is ignored) or copied into an owned Vec.
-        unsafe { core::slice::from_raw_parts(input, input_len) }
-    };
-    let (input, pin) = AsyncInput::new(global, chunk, fallback);
+    let input = AsyncInput::new(global, chunk, input);
     let cx = global.js_thread();
     bun_jsc::Job::<CompressionAsyncCtx>::schedule(
         &cx,
         CompressionAsyncCtx {
-            // SAFETY: `this` is the live coder owned by the calling JS cell.
-            coder: unsafe { bun_ptr::RefPtr::init_ref(this) },
+            codec: this.codec.take(),
             input,
             finish,
             out: Vec::new(),
@@ -1022,7 +797,6 @@ pub extern "C" fn CompressionStreamCoder__transformAsync(
         },
         CompressionAsyncJs {
             stream: Strong::create(stream_cell, global),
-            _pin: pin,
         },
     );
 }

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -531,8 +531,8 @@ impl CompressionStreamCoder {
     }
 }
 
-/// A chunk's bytes for the pool thread: the pinned ArrayBuffer they live in,
-/// or an owned copy.
+/// A chunk's bytes for the pool thread: the pinned ArrayBuffer they live in
+/// (copied out there, off the JS thread), or a copy made up front.
 pub(crate) enum AsyncInput {
     Pinned(PinnedArrayBuffer),
     Owned(Vec<u8>),
@@ -547,12 +547,19 @@ impl AsyncInput {
         }
     }
 
-    /// Pool thread, under the job's ticket.
-    #[inline]
-    pub(crate) fn slice<'a>(&'a self, ticket: &bun_jsc::Ticket) -> &'a [u8] {
+    /// Pool thread, under the job's ticket: the bytes to feed the codec
+    /// (`snapshot` receives the copy of a pinned chunk).
+    pub(crate) fn bytes<'a>(
+        &'a self,
+        ticket: &bun_jsc::Ticket,
+        snapshot: &'a mut Vec<u8>,
+    ) -> &'a [u8] {
         match self {
-            Self::Pinned(pinned) => pinned.bytes(ticket),
-            Self::Owned(v) => v.as_slice(),
+            Self::Pinned(pinned) => {
+                *snapshot = pinned.to_vec(ticket);
+                snapshot
+            }
+            Self::Owned(v) => v,
         }
     }
 }
@@ -738,8 +745,11 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
     type Js = CompressionAsyncJs;
 
     fn run(this: &mut Self, done: bun_jsc::Completion<Self>) -> Option<bun_jsc::Completion<Self>> {
+        // A pinned chunk is copied here, off the JS thread.
+        let mut snapshot = Vec::new();
+        let bytes = this.input.bytes(done.ticket(), &mut snapshot);
         let result = match &mut this.codec {
-            Some(codec) => codec.step(this.input.slice(done.ticket()), this.finish, &mut this.out),
+            Some(codec) => codec.step(bytes, this.finish, &mut this.out),
             None => Err(CodecError::Busy),
         };
         match result {

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -21,7 +21,7 @@ use core::ffi::c_int;
 use bun_core::EncodedSlice;
 use bun_core::ffi::FfiSlice;
 use bun_jsc::EncodedSliceJsc as _;
-use bun_jsc::{ErrorCode, JSGlobalObject, JSUint8Array, JSValue, PinnedArrayBuffer, Strong};
+use bun_jsc::{ErrorCode, JSGlobalObject, JSUint8Array, JSValue, JobPinnedArrayBuffer, Strong};
 
 use bun_brotli::c as brotli;
 use bun_zlib as zlib;
@@ -541,14 +541,14 @@ impl CompressionStreamCoder {
 /// A chunk's bytes for the pool thread: the pinned ArrayBuffer they live in
 /// (fed to the codec in place), or a copy made up front.
 pub(crate) enum AsyncInput {
-    Pinned(PinnedArrayBuffer),
+    Pinned(JobPinnedArrayBuffer),
     Owned(Vec<u8>),
 }
 
 impl AsyncInput {
     /// JS thread: pin `chunk` if it is a pinnable ArrayBuffer/view, else copy `fallback`.
     pub(crate) fn new(global: &JSGlobalObject, chunk: JSValue, fallback: &[u8]) -> Self {
-        match PinnedArrayBuffer::pin(global, chunk) {
+        match JobPinnedArrayBuffer::root(global, chunk) {
             Some(pinned) => Self::Pinned(pinned),
             None => Self::Owned(fallback.to_vec()),
         }

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -220,12 +220,17 @@ impl Codec {
     /// collects at most `max(high_water_mark, chunk length)` bytes into `out` and
     /// returns `true` if the codec stopped at that cap, in which case the caller
     /// must step again (with no input) before feeding the next chunk.
-    fn step(&mut self, input: &[u8], finish: bool, out: &mut Vec<u8>) -> Result<bool, CodecError> {
+    fn step(
+        &mut self,
+        input: FfiSlice<'_>,
+        finish: bool,
+        out: &mut Vec<u8>,
+    ) -> Result<bool, CodecError> {
         out.clear();
         if let Some(mut pending) = self.pending.take() {
             debug_assert!(input.is_empty());
             return match self.run(
-                &pending.input[pending.pos..],
+                FfiSlice::new(&pending.input[pending.pos..]),
                 pending.finish,
                 true,
                 pending.cap,
@@ -241,10 +246,10 @@ impl Codec {
         }
         // Zstd decode: re-attach the frame magic the previous chunk ended inside of.
         let joined;
-        let bytes: &[u8] = if self.zstd_head_len > 0 {
-            joined = [&self.zstd_head[..self.zstd_head_len as usize], input].concat();
+        let bytes = if self.zstd_head_len > 0 {
+            joined = input.to_vec_with_prefix(&self.zstd_head[..self.zstd_head_len as usize]);
             self.zstd_head_len = 0;
-            &joined
+            FfiSlice::new(&joined)
         } else {
             input
         };
@@ -253,7 +258,7 @@ impl Codec {
             Progress::Done => Ok(false),
             Progress::More { consumed } => {
                 self.pending = Some(Pending {
-                    input: bytes[consumed..].to_vec(),
+                    input: bytes.skip(consumed).to_vec(),
                     pos: 0,
                     finish,
                     cap,
@@ -268,7 +273,7 @@ impl Codec {
     /// input left, to drain the output it is holding.
     fn run(
         &mut self,
-        input: &[u8],
+        input: FfiSlice<'_>,
         finish: bool,
         continuing: bool,
         cap: usize,
@@ -293,7 +298,7 @@ impl Codec {
                     };
                     let limit = reserve(out, cap)?;
                     let (consumed, rc) = s.step_into_spare(remaining, out, limit, flush);
-                    remaining = &remaining[consumed..];
+                    remaining = remaining.skip(consumed);
                     match rc {
                         zlib::ReturnCode::Ok | zlib::ReturnCode::BufError => {}
                         zlib::ReturnCode::StreamEnd => return Ok(Progress::Done),
@@ -339,7 +344,7 @@ impl Codec {
                     };
                     let limit = reserve(out, cap)?;
                     let (consumed, rc) = s.step_into_spare(remaining, out, limit, flush);
-                    remaining = &remaining[consumed..];
+                    remaining = remaining.skip(consumed);
                     match rc {
                         zlib::ReturnCode::Ok => {}
                         zlib::ReturnCode::BufError => {
@@ -390,7 +395,7 @@ impl Codec {
                     }
                     let limit = reserve(out, cap)?;
                     let step = encoder.step(op, remaining, out, limit);
-                    remaining = &remaining[step.consumed..];
+                    remaining = remaining.skip(step.consumed);
                     if !step.result {
                         return Err(CodecError::Message("brotli encode failed"));
                     }
@@ -415,7 +420,7 @@ impl Codec {
                     }
                     let limit = reserve(out, cap)?;
                     let step = decoder.step(remaining, out, limit);
-                    remaining = &remaining[step.consumed..];
+                    remaining = remaining.skip(step.consumed);
                     match step.result {
                         brotli::BrotliDecoderResult::success => {
                             self.ended = true;
@@ -459,7 +464,7 @@ impl Codec {
                     }
                     let limit = reserve(out, cap)?;
                     let step = cctx.step(remaining, out, limit, finish);
-                    remaining = &remaining[step.consumed..];
+                    remaining = remaining.skip(step.consumed);
                     if bun_zstd::c::ZSTD_isError(step.code) != 0 {
                         return Err(zstd_error(step.code, "zstd encode failed"));
                     }
@@ -477,7 +482,9 @@ impl Codec {
                         if remaining.is_empty() {
                             return Ok(Progress::Done);
                         }
-                        let head = &remaining[..remaining.len().min(4)];
+                        let mut head_buf = [0u8; 4];
+                        let head_len = remaining.copy_to(&mut head_buf);
+                        let head = &head_buf[..head_len];
                         if !Self::is_zstd_frame_prefix(head) {
                             return Err(CodecError::TrailingJunk);
                         }
@@ -485,8 +492,8 @@ impl Codec {
                             if finish {
                                 return Err(CodecError::TrailingJunk);
                             }
-                            self.zstd_head[..head.len()].copy_from_slice(head);
-                            self.zstd_head_len = head.len() as u8;
+                            self.zstd_head = head_buf;
+                            self.zstd_head_len = head_len as u8;
                             return Ok(Progress::Done);
                         }
                         dctx.reset();
@@ -499,7 +506,7 @@ impl Codec {
                     }
                     let limit = reserve(out, cap)?;
                     let step = dctx.step(remaining, out, limit);
-                    remaining = &remaining[step.consumed..];
+                    remaining = remaining.skip(step.consumed);
                     if bun_zstd::c::ZSTD_isError(step.code) != 0 {
                         return Err(zstd_error(step.code, "zstd decode failed"));
                     }
@@ -525,14 +532,14 @@ impl CompressionStreamCoder {
     fn step(&mut self, input: &[u8], finish: bool, out: &mut Vec<u8>) -> Result<bool, CodecError> {
         debug_assert!(self.codec.is_some(), "codec stepped while off-thread");
         match &mut self.codec {
-            Some(codec) => codec.step(input, finish, out),
+            Some(codec) => codec.step(FfiSlice::new(input), finish, out),
             None => Err(CodecError::Busy),
         }
     }
 }
 
 /// A chunk's bytes for the pool thread: the pinned ArrayBuffer they live in
-/// (copied out there, off the JS thread), or a copy made up front.
+/// (fed to the codec in place), or a copy made up front.
 pub(crate) enum AsyncInput {
     Pinned(PinnedArrayBuffer),
     Owned(Vec<u8>),
@@ -547,19 +554,11 @@ impl AsyncInput {
         }
     }
 
-    /// Pool thread, under the job's ticket: the bytes to feed the codec
-    /// (`snapshot` receives the copy of a pinned chunk).
-    pub(crate) fn bytes<'a>(
-        &'a self,
-        ticket: &bun_jsc::Ticket,
-        snapshot: &'a mut Vec<u8>,
-    ) -> &'a [u8] {
+    /// Pool thread, under the job's ticket: the bytes to feed the codec.
+    pub(crate) fn ffi_slice<'a>(&'a self, ticket: &bun_jsc::Ticket) -> FfiSlice<'a> {
         match self {
-            Self::Pinned(pinned) => {
-                *snapshot = pinned.to_vec(ticket);
-                snapshot
-            }
-            Self::Owned(v) => v,
+            Self::Pinned(pinned) => pinned.ffi_slice(ticket),
+            Self::Owned(v) => FfiSlice::new(v),
         }
     }
 }
@@ -745,11 +744,12 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
     type Js = CompressionAsyncJs;
 
     fn run(this: &mut Self, done: bun_jsc::Completion<Self>) -> Option<bun_jsc::Completion<Self>> {
-        // A pinned chunk is copied here, off the JS thread.
-        let mut snapshot = Vec::new();
-        let bytes = this.input.bytes(done.ticket(), &mut snapshot);
         let result = match &mut this.codec {
-            Some(codec) => codec.step(bytes, this.finish, &mut this.out),
+            Some(codec) => codec.step(
+                this.input.ffi_slice(done.ticket()),
+                this.finish,
+                &mut this.out,
+            ),
             None => Err(CodecError::Busy),
         };
         match result {
@@ -782,8 +782,8 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
 }
 
 /// Schedules one off-thread step; a continuation step passes no chunk and no
-/// input (the codec kept the tail). `input` is `chunk`'s bytes: pinned in
-/// place when `chunk` allows it, else copied.
+/// input (the codec kept the tail). `input` is `chunk`'s bytes: pinned and
+/// read in place when `chunk` allows it, else copied.
 // HOST_EXPORT(CompressionStreamCoder__transformAsync, c)
 pub fn transform_async(
     this: &mut crate::webcore::compression_stream_coder::CompressionStreamCoder,

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -555,7 +555,7 @@ impl AsyncInput {
     }
 
     /// Pool thread, under the job's ticket: the bytes to feed the codec.
-    pub(crate) fn ffi_slice<'a>(&'a self, ticket: &bun_jsc::Ticket) -> FfiSlice<'a> {
+    pub(crate) fn ffi_slice<'a>(&'a self, ticket: &'a bun_jsc::Ticket) -> FfiSlice<'a> {
         match self {
             Self::Pinned(pinned) => pinned.ffi_slice(ticket),
             Self::Owned(v) => FfiSlice::new(v),

--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -345,11 +345,10 @@ impl TextDecoder {
                 // However, this is also what WebKit seems to do.
                 //
                 // => The reason we need to encode it is because TextDecoder "latin1" is actually CP1252, while WebKit latin1 is 8-bit utf-16
-                let out_length = strings::element_length_cp1252_into_utf16(buffer_slice);
-                let mut units: Vec<u16> = vec![0; out_length];
-                let out = strings::copy_cp1252_into_utf16(&mut units, buffer_slice);
-                units.truncate(out.written as usize);
-                bun_string_jsc::owned_utf16_into_js(global_this, units)
+                bun_string_jsc::owned_utf16_into_js(
+                    global_this,
+                    strings::cp1252_to_utf16_alloc(buffer_slice),
+                )
             }
             EncodingLabel::Utf8 => {
                 // Prepend the partial UTF-8 sequence carried over from the

--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -229,28 +229,23 @@ impl TextDecoder {
         decoded
             .try_reserve_exact(cap)
             .map_err(|_| strings::ToUTF16Error::OutOfMemory)?;
-        // SAFETY: `decoded` has `cap` spare units. encoding_rs only writes to
-        // its output slice (Gecko has it fill uninitialized string storage the
-        // same way), so the units need no zero-fill; `set_len` below exposes
-        // only the prefix it reports as written.
-        let dst = unsafe { core::slice::from_raw_parts_mut(decoded.as_mut_ptr(), cap) };
+        decoded.resize(cap, 0);
 
         let written = if self.fatal {
             let (result, _, written) =
-                decoder.decode_to_utf16_without_replacement(bytes, dst, FLUSH);
+                decoder.decode_to_utf16_without_replacement(bytes, &mut decoded, FLUSH);
             if let encoding_rs::DecoderResult::Malformed(..) = result {
                 return Err(strings::ToUTF16Error::InvalidByteSequence);
             }
             debug_assert!(matches!(result, encoding_rs::DecoderResult::InputEmpty));
             written
         } else {
-            let (result, _, written, _) = decoder.decode_to_utf16(bytes, dst, FLUSH);
+            let (result, _, written, _) = decoder.decode_to_utf16(bytes, &mut decoded, FLUSH);
             debug_assert!(matches!(result, encoding_rs::CoderResult::InputEmpty));
             written
         };
         debug_assert!(written <= cap);
-        // SAFETY: encoding_rs initialized `dst[..written]`, and `written <= cap`.
-        unsafe { decoded.set_len(written) };
+        decoded.truncate(written);
         // `cap` is about one code unit per input byte; two-byte CJK text fills
         // half of it, and this buffer lives as long as the JS string does.
         decoded.shrink_to_fit();
@@ -351,13 +346,9 @@ impl TextDecoder {
                 //
                 // => The reason we need to encode it is because TextDecoder "latin1" is actually CP1252, while WebKit latin1 is 8-bit utf-16
                 let out_length = strings::element_length_cp1252_into_utf16(buffer_slice);
-                let mut units: Vec<u16> = Vec::with_capacity(out_length);
-                // SAFETY: `units` has `out_length` spare units; `buf` is only ever written.
-                let buf =
-                    unsafe { core::slice::from_raw_parts_mut(units.as_mut_ptr(), out_length) };
-                let out = strings::copy_cp1252_into_utf16(buf, buffer_slice);
-                // SAFETY: the copy above initialized `out.written` (≤ `out_length`) units.
-                unsafe { units.set_len(out.written as usize) };
+                let mut units: Vec<u16> = vec![0; out_length];
+                let out = strings::copy_cp1252_into_utf16(&mut units, buffer_slice);
+                units.truncate(out.written as usize);
                 bun_string_jsc::owned_utf16_into_js(global_this, units)
             }
             EncodingLabel::Utf8 => {
@@ -648,24 +639,22 @@ impl TextDecoder {
 /// the inline `StreamingUTF8DecodeState` instead of this decoder, so no
 /// `TextDecoder` is allocated: `*out_utf8_fast_path` is set and null is
 /// returned with no exception.
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn TextDecoder__createForStream(
+// HOST_EXPORT(TextDecoder__createForStream, c)
+pub fn create_for_stream(
     global: &JSGlobalObject,
     label: JSValue,
     fatal: bool,
     ignore_bom: bool,
-    out_utf8_fast_path: *mut bool,
-    out_encoding: *mut EncodingLabel,
-) -> *mut TextDecoder {
-    // SAFETY: both out-params are stack locals on the caller's frame.
-    unsafe { *out_utf8_fast_path = false };
+    out_utf8_fast_path: &mut bool,
+    out_encoding: &mut crate::webcore::EncodingLabel,
+) -> Option<Box<crate::webcore::TextDecoder>> {
+    *out_utf8_fast_path = false;
     let encoding = if label.is_undefined() {
         EncodingLabel::Utf8
     } else {
         let converted = match bun_core::String::from_js(label, global) {
             Ok(s) => s,
-            Err(_) => return core::ptr::null_mut(),
+            Err(_) => return None,
         };
         let str = converted.to_utf8();
         match EncodingLabel::which(str.slice()) {
@@ -680,18 +669,16 @@ pub extern "C" fn TextDecoder__createForStream(
                         ),
                     )
                     .throw();
-                return core::ptr::null_mut();
+                return None;
             }
         }
     };
-    // SAFETY: as above.
-    unsafe { out_encoding.write(encoding) };
+    *out_encoding = encoding;
     if matches!(encoding, EncodingLabel::Utf8) && !fatal {
-        // SAFETY: as above.
-        unsafe { *out_utf8_fast_path = true };
-        return core::ptr::null_mut();
+        *out_utf8_fast_path = true;
+        return None;
     }
-    bun_core::heap::into_raw(TextDecoder::new(TextDecoder {
+    Some(TextDecoder::new(TextDecoder {
         fatal,
         ignore_bom,
         encoding,
@@ -700,52 +687,32 @@ pub extern "C" fn TextDecoder__createForStream(
 }
 
 /// `TextDecoderStream.prototype.encoding`.
-#[unsafe(no_mangle)]
-pub extern "C" fn TextDecoder__encodingToJS(
-    global: &JSGlobalObject,
-    encoding: EncodingLabel,
-) -> JSValue {
+// HOST_EXPORT(TextDecoder__encodingToJS, c)
+pub fn encoding_to_js(global: &JSGlobalObject, encoding: crate::webcore::EncodingLabel) -> JSValue {
     encoding.to_js(global)
 }
 
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn TextDecoder__destroyForStream(this: *mut TextDecoder) {
-    if !this.is_null() {
-        // SAFETY: `this` was returned by `TextDecoder__createForStream` and has not been
-        // freed (the C++ cell clears its pointer before calling).
-        unsafe { bun_core::heap::destroy(this) };
-    }
+/// The C++ cell cleared its pointer before calling; dropping the box frees the decoder.
+// HOST_EXPORT(TextDecoder__destroyForStream, c)
+pub fn destroy_for_stream(this: Option<Box<crate::webcore::TextDecoder>>) {
+    drop(this);
 }
 
 /// The TextDecoderStream transform/flush step. `stream = true` for a mid-
-/// stream chunk, `false` for the final flush. `input` may be null iff
-/// `input_len == 0`. Returns a JSString on success, or `JSValue::zero` with
-/// the exception pending on `global`.
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn TextDecoder__decodeForStream(
-    this: *mut TextDecoder,
+/// stream chunk, `false` for the final flush. Returns a JSString on success,
+/// or `JSValue::zero` with the exception pending on `global`.
+// HOST_EXPORT(TextDecoder__decodeForStream, c)
+pub fn decode_for_stream(
+    this: &crate::webcore::TextDecoder,
     global: &JSGlobalObject,
-    input: *const u8,
-    input_len: usize,
+    input: &[u8],
     stream: bool,
 ) -> JSValue {
-    // SAFETY: `this` is the live decoder owned by the calling JS cell; driven
-    // only from the JS thread, so `&*this` has no mutable alias.
-    let this = unsafe { &*this };
-    let slice = if input.is_null() {
-        &[][..]
-    } else {
-        // SAFETY: the caller passes a BufferSource's bytes; `slice` does not
-        // escape this call.
-        unsafe { core::slice::from_raw_parts(input, input_len) }
-    };
     this.begin_decode(stream);
     let result = if stream {
-        this.decode_slice::<false>(global, slice)
+        this.decode_slice::<false>(global, input)
     } else {
-        this.decode_slice::<true>(global, slice)
+        this.decode_slice::<true>(global, input)
     };
     result.or_pending_exception()
 }

--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -1,9 +1,7 @@
-use core::ffi::c_void;
-
 use bun_core::strings;
 use bun_jsc::HostReturn as _;
-use bun_jsc::js_string::Iterator as JSStringIterator;
-use bun_jsc::{ArrayBuffer, JSGlobalObject, JSString, JSType, JSValue, JsResult};
+use bun_jsc::js_string::StringVisitor;
+use bun_jsc::{ArrayBuffer, JSGlobalObject, JSType, JSValue, JsResult};
 
 // `const TextEncoder = @This();` — file is a namespace of exported fns; no wrapper struct needed.
 
@@ -12,17 +10,8 @@ fn create_uninitialized_uint8_array(global: &JSGlobalObject, len: usize) -> JsRe
     JSValue::create_uninitialized_uint8_array(global, len)
 }
 
-/// # Safety
-/// `ptr` must be valid for reading `len` bytes of Latin-1 data.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn TextEncoder__encode8(
-    global_this: &JSGlobalObject,
-    ptr: *const u8,
-    len: usize,
-) -> JSValue {
-    // SAFETY: caller guarantees ptr[0..len] is valid Latin-1 data
-    let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
-
+// HOST_EXPORT(TextEncoder__encode8, c)
+pub fn encode8(global_this: &JSGlobalObject, slice: &[u8]) -> JSValue {
     if strings::first_non_ascii(slice).is_none() {
         let Ok(uint8array) = create_uninitialized_uint8_array(global_this, slice.len()) else {
             return JSValue::ZERO;
@@ -61,7 +50,8 @@ fn replacement_char_uint8_array(global_this: &JSGlobalObject) -> JSValue {
     uint8array
 }
 
-fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
+// HOST_EXPORT(TextEncoder__encode16, c)
+pub fn encode16(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
     const SMALL_BUF_LEN: usize = 192;
     if slice.len() <= SMALL_BUF_LEN / 3 {
         let mut buf = [0u8; SMALL_BUF_LEN];
@@ -109,28 +99,6 @@ fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
         .or_pending_exception()
 }
 
-/// # Safety
-/// `ptr` must be valid for reading `len` UTF-16 code units.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn TextEncoder__encode16(
-    global_this: &JSGlobalObject,
-    ptr: *const u16,
-    len: usize,
-) -> JSValue {
-    // SAFETY: caller guarantees ptr[0..len] is valid UTF-16 data
-    let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
-    encode16_impl(global_this, slice)
-}
-
-/// # Safety
-/// `ptr` must be valid for reading `len` UTF-16 code units.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn c(global_this: &JSGlobalObject, ptr: *const u16, len: usize) -> JSValue {
-    // SAFETY: caller guarantees ptr[0..len] is valid UTF-16 data
-    let slice = unsafe { core::slice::from_raw_parts(ptr, len) };
-    encode16_impl(global_this, slice)
-}
-
 // This is a fast path for copying a Rope string into a Uint8Array.
 // This keeps us from an extra string temporary allocation
 struct RopeStringEncoder<'a> {
@@ -139,98 +107,50 @@ struct RopeStringEncoder<'a> {
     any_non_ascii: bool,
 }
 
-impl<'a> RopeStringEncoder<'a> {
-    /// Recover `(&mut JSStringIterator, &mut Self)` from the rope-iteration
-    /// callback's `*mut JSStringIterator`. Centralises the per-callback raw
-    /// derefs so the four `extern "C"` thunks below are safe callers (one
-    /// accessor, N safe call sites).
-    ///
-    /// # Safety (encapsulated)
-    /// Only ever invoked from the four callbacks registered in [`Self::iter`],
-    /// which JSC calls with the live stack-allocated `JSStringIterator` whose
-    /// `.data` field was set to `&mut Self` by `iter()`. The iterator and the
-    /// encoder live in disjoint stack allocations (the iterator is a local in
-    /// `TextEncoder__encodeRopeString`; the encoder is its sibling local), so
-    /// the two `&mut` borrows do not alias. JSC rope iteration is
-    /// single-threaded and re-entrancy-free, so each is the sole live `&mut`
-    /// for the callback's duration.
-    #[inline(always)]
-    fn resolve<'r>(it: *mut JSStringIterator) -> (&'r mut JSStringIterator, &'r mut Self) {
-        debug_assert!(!it.is_null());
-        // SAFETY: see fn doc — `it` is the live iterator JSC passed; `it.data`
-        // is the `&mut RopeStringEncoder` stashed in `iter()`. Disjoint
-        // allocations, single-threaded, exclusively accessed for `'r`.
-        unsafe {
-            let it = &mut *it;
-            let this = &mut *it.data_ptr().cast::<RopeStringEncoder<'a>>();
-            (it, this)
-        }
-    }
-
-    // The four rope-iteration callbacks coerce (safe → unsafe `extern "C"`) to
-    // the `JSStringIterator` callback-pointer field types at `iter()` below.
-    extern "C" fn append8(it: *mut JSStringIterator, ptr: *const u8, len: u32) {
-        let (it, this) = Self::resolve(it);
-        // SAFETY: ptr[0..len] is provided by JSC rope iteration
-        let src = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
+impl StringVisitor for RopeStringEncoder<'_> {
+    fn append8(&mut self, src: &[u8]) -> bool {
         let result = strings::copy_latin1_into_utf8_stop_on_non_ascii::<true>(
-            &mut this.buf[this.tail..],
+            &mut self.buf[self.tail..],
             src,
         );
         if result.read == u32::MAX && result.written == u32::MAX {
-            it.stop = 1;
-            this.any_non_ascii = true;
+            self.any_non_ascii = true;
+            false
         } else {
-            this.tail += result.written as usize;
+            self.tail += result.written as usize;
+            true
         }
     }
 
-    extern "C" fn append16(it: *mut JSStringIterator, _: *const u16, _: u32) {
-        let (it, this) = Self::resolve(it);
-        this.any_non_ascii = true;
-        it.stop = 1;
+    fn append16(&mut self, _: &[u16]) -> bool {
+        self.any_non_ascii = true;
+        false
     }
 
-    extern "C" fn write8(it: *mut JSStringIterator, ptr: *const u8, len: u32, offset: u32) {
-        let (it, this) = Self::resolve(it);
-        // SAFETY: ptr[0..len] is provided by JSC rope iteration
-        let src = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
+    fn write8(&mut self, src: &[u8], offset: u32) -> bool {
         let result = strings::copy_latin1_into_utf8_stop_on_non_ascii::<true>(
-            &mut this.buf[offset as usize..],
+            &mut self.buf[offset as usize..],
             src,
         );
         if result.read == u32::MAX && result.written == u32::MAX {
-            it.stop = 1;
-            this.any_non_ascii = true;
+            self.any_non_ascii = true;
+            false
+        } else {
+            true
         }
     }
 
-    extern "C" fn write16(it: *mut JSStringIterator, _: *const u16, _: u32, _: u32) {
-        let (it, this) = Self::resolve(it);
-        this.any_non_ascii = true;
-        it.stop = 1;
-    }
-
-    fn iter(&mut self) -> JSStringIterator {
-        JSStringIterator {
-            data: std::ptr::from_mut::<Self>(self).cast::<c_void>(),
-            stop: 0,
-            append8: Some(Self::append8),
-            append16: Some(Self::append16),
-            write8: Some(Self::write8),
-            write16: Some(Self::write16),
-        }
+    fn write16(&mut self, _: &[u16], _: u32) -> bool {
+        self.any_non_ascii = true;
+        false
     }
 }
 
 // This fast path is only suitable for ASCII strings
 // It's not suitable for UTF-16 strings, because getting the byteLength is unpredictable
 // It also isn't usable for latin1 strings which contain non-ascii characters
-#[unsafe(no_mangle)]
-extern "C" fn TextEncoder__encodeRopeString(
-    global_this: &JSGlobalObject,
-    rope_str: &JSString,
-) -> JSValue {
+// HOST_EXPORT(TextEncoder__encodeRopeString, c)
+pub fn encode_rope_string(global_this: &JSGlobalObject, rope_str: &bun_jsc::JSString) -> JSValue {
     debug_assert!(rope_str.is_8bit());
     let length = rope_str.length();
     let array = match create_uninitialized_uint8_array(global_this, length) {
@@ -246,9 +166,8 @@ extern "C" fn TextEncoder__encodeRopeString(
         tail: 0,
         any_non_ascii: false,
     };
-    let mut iter = encoder.iter();
     array.ensure_still_alive();
-    rope_str.iterator(global_this, &mut iter);
+    rope_str.visit(global_this, &mut encoder);
     array.ensure_still_alive();
 
     if encoder.any_non_ascii {
@@ -258,46 +177,20 @@ extern "C" fn TextEncoder__encodeRopeString(
     array
 }
 
-/// # Safety
-/// `input_ptr` must be valid for reading `input_len` UTF-16 code units and
-/// `buf_ptr` must be valid for writing `buf_len` bytes.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn TextEncoder__encodeInto16(
-    input_ptr: *const u16,
-    input_len: usize,
-    buf_ptr: *mut u8,
-    buf_len: usize,
-) -> u64 {
-    // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer
-    let output = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
-    // SAFETY: caller guarantees input_ptr[0..input_len] is valid UTF-16 data
-    let input = unsafe { core::slice::from_raw_parts(input_ptr, input_len) };
-    let result: strings::EncodeIntoResult = strings::copy_utf16_into_utf8(output, input);
-    // Pack `read` at byte offset 0 and `written` at offset 4 via native-endian bytes — no `unsafe`.
+/// `read` at byte offset 0 and `written` at offset 4, as the C++ caller unpacks them.
+fn pack_encode_into_result(result: strings::EncodeIntoResult) -> u64 {
     let mut b = [0u8; 8];
     b[..4].copy_from_slice(&result.read.to_ne_bytes());
     b[4..].copy_from_slice(&result.written.to_ne_bytes());
     u64::from_ne_bytes(b)
 }
 
-/// # Safety
-/// `input_ptr` must be valid for reading `input_len` bytes of Latin-1 data and
-/// `buf_ptr` must be valid for writing `buf_len` bytes.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn TextEncoder__encodeInto8(
-    input_ptr: *const u8,
-    input_len: usize,
-    buf_ptr: *mut u8,
-    buf_len: usize,
-) -> u64 {
-    // SAFETY: caller guarantees buf_ptr[0..buf_len] is a valid mutable buffer
-    let output = unsafe { core::slice::from_raw_parts_mut(buf_ptr, buf_len) };
-    // SAFETY: caller guarantees input_ptr[0..input_len] is valid Latin-1 data
-    let input = unsafe { core::slice::from_raw_parts(input_ptr, input_len) };
-    let result: strings::EncodeIntoResult = strings::copy_latin1_into_utf8(output, input);
-    // Pack `read` at byte offset 0 and `written` at offset 4 via native-endian bytes — no `unsafe`.
-    let mut b = [0u8; 8];
-    b[..4].copy_from_slice(&result.read.to_ne_bytes());
-    b[4..].copy_from_slice(&result.written.to_ne_bytes());
-    u64::from_ne_bytes(b)
+// HOST_EXPORT(TextEncoder__encodeInto16, c)
+pub fn encode_into16(input: &[u16], output: &mut [u8]) -> u64 {
+    pack_encode_into_result(strings::copy_utf16_into_utf8(output, input))
+}
+
+// HOST_EXPORT(TextEncoder__encodeInto8, c)
+pub fn encode_into8(input: &[u8], output: &mut [u8]) -> u64 {
+    pack_encode_into_result(strings::copy_latin1_into_utf8(output, input))
 }

--- a/src/runtime/webcore/TextEncoderStreamEncoder.rs
+++ b/src/runtime/webcore/TextEncoderStreamEncoder.rs
@@ -1,5 +1,4 @@
 use core::cell::Cell;
-use core::ptr::NonNull;
 
 use bun_alloc::AllocError;
 use bun_core::strings;
@@ -7,7 +6,7 @@ use bun_jsc::{JSGlobalObject, JSUint8Array, JSValue, JsResult};
 use bun_ptr::RawSlice;
 use bun_simdutf_sys::simdutf;
 
-use crate::webcore::sink::sink_handle_from_id;
+use crate::webcore::SinkHandle;
 use crate::webcore::streams;
 
 bun_output::declare_scope!(TextEncoderStreamEncoder, visible);
@@ -68,23 +67,22 @@ impl TextEncoderStreamEncoder {
 
         let mut remain = input;
         while !remain.is_empty() {
-            // SAFETY: copy_latin1_into_utf8 writes initialized bytes into the spare capacity and
-            // returns the number written; fill_spare commits exactly that many.
-            let result = unsafe {
-                bun_core::vec::fill_spare(buffer, 0, |spare| {
-                    let r = strings::copy_latin1_into_utf8(spare, remain);
-                    (r.written as usize, r)
-                })
+            let Some(i) = strings::first_non_ascii(remain) else {
+                buffer.try_reserve(remain.len()).map_err(|_| AllocError)?;
+                buffer.extend_from_slice(remain);
+                break;
             };
-            remain = &remain[result.read as usize..];
-
-            if result.written == 0 && result.read == 0 {
-                buffer.try_reserve(2).map_err(|_| AllocError)?;
-            } else if buffer.len() == buffer.capacity() && !remain.is_empty() {
-                buffer
-                    .try_reserve(remain.len() + 1)
-                    .map_err(|_| AllocError)?;
+            let i = i as usize;
+            buffer.try_reserve(i + 2).map_err(|_| AllocError)?;
+            buffer.extend_from_slice(&remain[..i]);
+            remain = &remain[i..];
+            // The run of non-ASCII bytes that follows: two UTF-8 bytes each.
+            let run = remain.iter().take_while(|&&c| c >= 0x80).count();
+            buffer.try_reserve(run * 2).map_err(|_| AllocError)?;
+            for &c in &remain[..run] {
+                buffer.extend_from_slice(&strings::latin1_to_codepoint_bytes_assume_not_ascii(c));
             }
+            remain = &remain[run..];
         }
         debug_assert!(
             buffer.len() == (simdutf::length::utf8::from::latin1(input) + prepend_replacement_len)
@@ -165,36 +163,15 @@ impl TextEncoderStreamEncoder {
             break 'prepend None;
         };
 
-        let length = simdutf::length::utf8::from::utf16::le(remain);
-
-        buf.try_reserve(
-            length
-                + match prepend {
-                    Some(pre) => pre.len as usize,
-                    None => 0,
-                },
-        )
-        .map_err(|_| AllocError)?;
-
         if let Some(pre) = &prepend {
+            buf.try_reserve(pre.len as usize).map_err(|_| AllocError)?;
             buf.extend_from_slice(&pre.bytes[0..pre.len as usize]);
         }
 
-        // SAFETY: simdutf writes initialized bytes into the spare capacity and returns the
-        // count; on non-SUCCESS we commit 0 and fall through to the slow path.
-        let result = unsafe {
-            bun_core::vec::fill_spare(buf, 0, |spare| {
-                let r = simdutf::convert::utf16::to::utf8::with_errors::le(remain, spare);
-                (
-                    if r.status == simdutf::Status::SUCCESS {
-                        r.count
-                    } else {
-                        0
-                    },
-                    r,
-                )
-            })
-        };
+        // Reserves the UTF-8 length of `remain`; appends nothing unless the
+        // whole of it was valid UTF-16.
+        let result = simdutf::convert::utf16::to::utf8::with_errors::le_append(remain, buf)
+            .ok_or(AllocError)?;
 
         if result.status != simdutf::Status::SUCCESS {
             // Slow path: there was invalid UTF-16, so we need to convert it without simdutf.
@@ -219,38 +196,32 @@ impl TextEncoderStreamEncoder {
 // The TextEncoderStream cell owns its encoder directly as a `void*` (no JS
 // wrapper cell, no prototype lookup) and drives it through these.
 
-#[unsafe(no_mangle)]
-pub extern "C" fn TextEncoderStreamEncoder__createForStream() -> *mut TextEncoderStreamEncoder {
-    Box::into_raw(Box::new(TextEncoderStreamEncoder::default()))
+// HOST_EXPORT(TextEncoderStreamEncoder__createForStream, c)
+pub fn create_for_stream()
+-> Option<Box<crate::webcore::text_encoder_stream_encoder::TextEncoderStreamEncoder>> {
+    Some(Box::default())
 }
 
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn TextEncoderStreamEncoder__destroyForStream(this: *mut TextEncoderStreamEncoder) {
-    if !this.is_null() {
-        // SAFETY: `this` was returned by `TextEncoderStreamEncoder__createForStream` and has not been
-        // freed (the C++ cell clears its pointer before calling).
-        drop(unsafe { Box::from_raw(this) });
-    }
+/// The C++ cell cleared its pointer before calling; dropping the box frees the encoder.
+// HOST_EXPORT(TextEncoderStreamEncoder__destroyForStream, c)
+pub fn destroy_for_stream(
+    this: Option<Box<crate::webcore::text_encoder_stream_encoder::TextEncoderStreamEncoder>>,
+) {
+    drop(this);
 }
 
 /// The TextEncoderStream transform step: WebIDL `USVString` conversion of
 /// `chunk` (user JS — may throw), then encode. Returns a fresh `Uint8Array`
 /// on success, or `JSValue::zero` with the exception pending on `global`.
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn TextEncoderStreamEncoder__encodeForStream(
-    this: *mut TextEncoderStreamEncoder,
+// HOST_EXPORT(TextEncoderStreamEncoder__encodeForStream, c)
+pub fn encode_for_stream(
+    this: &crate::webcore::text_encoder_stream_encoder::TextEncoderStreamEncoder,
     global: &JSGlobalObject,
     chunk: JSValue,
 ) -> JSValue {
     let Ok(str) = chunk.to_js_string_view(global) else {
         return JSValue::ZERO;
     };
-    // SAFETY: `this` is the live encoder owned by the calling JS cell; driven
-    // only from the JS thread, so `&*this` has no mutable alias. Taken after
-    // the coercion so no user JS runs while the borrow is live.
-    let this = unsafe { &*this };
     let encoded = if str.is_utf16() {
         this.encode_utf16(global, str.utf16())
     } else {
@@ -259,14 +230,12 @@ pub extern "C" fn TextEncoderStreamEncoder__encodeForStream(
     bun_jsc::to_js_host_fn_result(global, encoded)
 }
 
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn TextEncoderStreamEncoder__flushForStream(
-    this: *mut TextEncoderStreamEncoder,
+// HOST_EXPORT(TextEncoderStreamEncoder__flushForStream, c)
+pub fn flush_for_stream(
+    this: &crate::webcore::text_encoder_stream_encoder::TextEncoderStreamEncoder,
     global: &JSGlobalObject,
 ) -> JSValue {
-    // SAFETY: as in `TextEncoderStreamEncoder__encodeForStream`.
-    bun_jsc::to_js_host_fn_result(global, unsafe { &*this }.flush_body(global))
+    bun_jsc::to_js_host_fn_result(global, this.flush_body(global))
 }
 
 /// Cap on the reusable scratch buffer so a single huge chunk doesn't pin
@@ -280,21 +249,16 @@ const SCRATCH_CAP: usize = 64 * 1024;
 /// nativeSinkWriteIsBackpressure for the backpressure-signal shapes),
 /// `undefined` for an empty output, or `JSValue::zero` with the exception
 /// pending on `global`.
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn TextEncoderStreamEncoder__encodeIntoSink(
-    this: *mut TextEncoderStreamEncoder,
+// HOST_EXPORT(TextEncoderStreamEncoder__encodeIntoSink, c)
+pub fn encode_into_sink(
+    this: &crate::webcore::text_encoder_stream_encoder::TextEncoderStreamEncoder,
     global: &JSGlobalObject,
     chunk: JSValue,
-    sink_id: u8,
-    sink_ptr: *mut core::ffi::c_void,
+    sink: SinkHandle,
 ) -> JSValue {
     let Ok(str) = chunk.to_js_string_view(global) else {
         return JSValue::ZERO;
     };
-    // SAFETY: `this` is the live encoder owned by the calling JS cell; taken
-    // after the coercion so no user JS runs while the borrow is live.
-    let this = unsafe { &*this };
     // Move the Vec out of the RefCell for the duration of the sink write so a
     // (theoretical) re-entrant encode-into-sink call cannot BorrowMut-panic.
     let mut buf = this.scratch.take();
@@ -307,22 +271,11 @@ pub extern "C" fn TextEncoderStreamEncoder__encodeIntoSink(
     if encoded.is_err() {
         return global.throw_out_of_memory_value();
     }
-    if buf.is_empty() {
+    if buf.is_empty() || sink.is_none() {
         this.scratch.replace(buf);
         return JSValue::UNDEFINED;
     }
-    let Some(ptr) = NonNull::new(sink_ptr) else {
-        this.scratch.replace(buf);
-        return JSValue::UNDEFINED;
-    };
-    // SAFETY: `sink_ptr` is a live JSSink of type `sink_id` (the C++ caller
-    // null-checks it before attaching); the sink copies what it needs.
-    let handle = unsafe { sink_handle_from_id(sink_id, ptr) };
-    if handle.is_none() {
-        this.scratch.replace(buf);
-        return JSValue::UNDEFINED;
-    }
-    let wrote = handle
+    let wrote = sink
         .write(&streams::Result::Temporary(RawSlice::new(&buf)))
         .to_js(global);
     if buf.capacity() <= SCRATCH_CAP {
@@ -332,29 +285,19 @@ pub extern "C" fn TextEncoderStreamEncoder__encodeIntoSink(
 }
 
 /// Native-sink flush step; see `TextEncoderStreamEncoder__encodeIntoSink` for the return contract.
-#[unsafe(no_mangle)]
-#[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn TextEncoderStreamEncoder__flushIntoSink(
-    this: *mut TextEncoderStreamEncoder,
+// HOST_EXPORT(TextEncoderStreamEncoder__flushIntoSink, c)
+pub fn flush_into_sink(
+    this: &crate::webcore::text_encoder_stream_encoder::TextEncoderStreamEncoder,
     global: &JSGlobalObject,
-    sink_id: u8,
-    sink_ptr: *mut core::ffi::c_void,
+    sink: SinkHandle,
 ) -> JSValue {
-    // SAFETY: as in `TextEncoderStreamEncoder__encodeForStream`.
-    let this = unsafe { &*this };
     if this.pending_lead_surrogate.get().is_none() {
         return JSValue::UNDEFINED;
     }
     const REPLACEMENT: [u8; 3] = [0xef, 0xbf, 0xbd];
-    let Some(ptr) = NonNull::new(sink_ptr) else {
-        return JSValue::UNDEFINED;
-    };
-    // SAFETY: as in `TextEncoderStreamEncoder__encodeIntoSink`.
-    let handle = unsafe { sink_handle_from_id(sink_id, ptr) };
-    if handle.is_none() {
+    if sink.is_none() {
         return JSValue::UNDEFINED;
     }
-    handle
-        .write(&streams::Result::Temporary(RawSlice::new(&REPLACEMENT)))
+    sink.write(&streams::Result::Temporary(RawSlice::new(&REPLACEMENT)))
         .to_js(global)
 }

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -505,9 +505,12 @@ fn byte_length_u8<const ENCODING: u8>(input: &[u8]) -> usize {
     }
 }
 
-/// [`write_u8`] for a UTF-16 source. `input` is a JS string's characters and
-/// `to` an `ArrayBuffer`'s storage, which never share memory (the C++
-/// declarations say so too), so every arm is a plain copy.
+/// [`write_u8`] for a UTF-16 source. `input` and `to` never share memory, so
+/// every arm is a plain copy (as in [`write_u8`]): `input` is always a JS
+/// string's characters (`JSString::view()` in `Buffer.prototype.write` /
+/// `Buffer.fill` / `napi_get_value_string_*`), which JSC keeps immutable and
+/// never backs with `ArrayBuffer` storage, and `to` is typed-array storage or a
+/// NAPI caller's own out-buffer. The C++ declarations carry the same contract.
 pub(crate) fn write_u16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bool>(
     input: &[u16],
     to: &mut [u8],

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -6,7 +6,6 @@ use crate::webcore::jsc::{JSGlobalObject, JSValue, JsResult, StringJsc as _};
 use bun_core::String as BunString;
 use bun_core::strings;
 use bun_simdutf_sys::simdutf as bun_simdutf;
-use core::mem::MaybeUninit;
 
 // `bun_core::String` exposes safe `Vec<u8>`/`Vec<u16>` → WTF::ExternalStringImpl
 // constructors; delegate so the FFI ownership-transfer invariant is enforced
@@ -97,27 +96,11 @@ macro_rules! dispatch_encoding {
 pub(crate) use dispatch_encoding;
 
 // ────────────────────────────────────────────────────────────────────────────
-// Exported C ABI entry points
+// Exported C ABI entry points (thunks in `generated_host_exports.rs`)
 // ────────────────────────────────────────────────────────────────────────────
 
-/// # Safety
-/// Caller (C++) must guarantee `input[..len]` and `to[..to_len]` are valid for
-/// reading / writing respectively for the duration of the call.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__encoding__writeLatin1(
-    input: *const u8,
-    len: usize,
-    to: *mut u8,
-    to_len: usize,
-    encoding: u8,
-) -> usize {
-    // SAFETY: forwarded from this fn's contract.
-    let (input, to) = unsafe {
-        (
-            bun_core::ffi::slice(input, len),
-            bun_core::ffi::slice_mut(to, to_len),
-        )
-    };
+// HOST_EXPORT(Bun__encoding__writeLatin1, c)
+pub fn write_latin1(input: &[u8], to: &mut [u8], encoding: u8) -> usize {
     let r = dispatch_encoding!(encoding_from_u8(encoding), {
         Encoding::Ucs2 => write_u8::<{ enc::UTF16LE }, false>(input, to),
         Encoding::Buffer => unreachable!(),
@@ -125,57 +108,32 @@ unsafe extern "C" fn Bun__encoding__writeLatin1(
     r.unwrap_or(0)
 }
 
-/// # Safety
-/// Caller (C++) must guarantee `input[..len]` and `to[..to_len]` are valid for
-/// reading / writing respectively for the duration of the call.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__encoding__writeUTF16(
-    input: *const u16,
-    len: usize,
-    to: *mut u8,
-    to_len: usize,
-    encoding: u8,
-) -> usize {
-    // SAFETY: forwarded from this fn's contract.
-    let r = unsafe {
-        dispatch_encoding!(encoding_from_u8(encoding), {
-            Encoding::Latin1 => write_u16::<{ enc::ASCII }, false>(input, len, to, to_len),
-            Encoding::Ucs2 => write_u16::<{ enc::UTF16LE }, false>(input, len, to, to_len),
-            Encoding::Buffer => unreachable!(),
-        }, |E| write_u16::<E, false>(input, len, to, to_len))
-    };
+// HOST_EXPORT(Bun__encoding__writeUTF16, c)
+pub fn write_utf16(input: &[u16], to: &mut [u8], encoding: u8) -> usize {
+    let r = dispatch_encoding!(encoding_from_u8(encoding), {
+        Encoding::Latin1 => write_u16::<{ enc::ASCII }, false>(input, to),
+        Encoding::Ucs2 => write_u16::<{ enc::UTF16LE }, false>(input, to),
+        Encoding::Buffer => unreachable!(),
+    }, |E| write_u16::<E, false>(input, to));
     r.unwrap_or(0)
 }
 
-/// # Safety
-/// Caller (C++) must guarantee `input[..len]` is valid for reading.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__encoding__byteLengthLatin1AsUTF8(input: *const u8, len: usize) -> usize {
-    // SAFETY: forwarded from this fn's contract.
-    let input = unsafe { bun_core::ffi::slice(input, len) };
+// HOST_EXPORT(Bun__encoding__byteLengthLatin1AsUTF8, c)
+pub fn byte_length_latin1_as_utf8(input: &[u8]) -> usize {
     byte_length_u8::<{ enc::UTF8 }>(input)
 }
 
-/// # Safety
-/// Caller (C++) must guarantee `input[..len]` is valid for reading.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__encoding__byteLengthUTF16AsUTF8(input: *const u16, len: usize) -> usize {
-    // SAFETY: forwarded from this fn's contract.
-    let input = unsafe { bun_core::ffi::slice(input, len) };
+// HOST_EXPORT(Bun__encoding__byteLengthUTF16AsUTF8, c)
+pub fn byte_length_utf16_as_utf8(input: &[u16]) -> usize {
     strings::element_length_utf16_into_utf8(input)
 }
 
-/// # Safety
-/// Caller (C++) must guarantee `input[..len]` is valid for reading.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__encoding__constructFromLatin1(
+// HOST_EXPORT(Bun__encoding__constructFromLatin1, c)
+pub fn construct_from_latin1(
     global_object: &JSGlobalObject,
-    input: *const u8,
-    len: usize,
+    input: &[u8],
     encoding: u8,
 ) -> JSValue {
-    // SAFETY: forwarded from this fn's contract.
-    let input = unsafe { bun_core::ffi::slice(input, len) };
     // Ownership of the allocation transfers to JSC: `create_buffer` registers the
     // pointer with `MarkedArrayBuffer_deallocator`, which frees it on GC. Wrapping
     // in `ManuallyDrop` prevents Rust from also freeing it at scope exit (which
@@ -187,17 +145,12 @@ unsafe extern "C" fn Bun__encoding__constructFromLatin1(
     bun_jsc::HostReturn::or_pending_exception(JSValue::create_buffer(global_object, &mut slice[..]))
 }
 
-/// # Safety
-/// Caller (C++) must guarantee `input[..len]` is valid for reading.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__encoding__constructFromUTF16(
+// HOST_EXPORT(Bun__encoding__constructFromUTF16, c)
+pub fn construct_from_utf16(
     global_object: &JSGlobalObject,
-    input: *const u16,
-    len: usize,
+    input: &[u16],
     encoding: u8,
 ) -> JSValue {
-    // SAFETY: forwarded from this fn's contract.
-    let input = unsafe { bun_core::ffi::slice(input, len) };
     // Ownership of the allocation transfers to JSC: `create_buffer` registers the
     // pointer with `MarkedArrayBuffer_deallocator`, which frees it on GC. Wrapping
     // in `ManuallyDrop` prevents Rust from also freeing it at scope exit (which
@@ -210,33 +163,16 @@ unsafe extern "C" fn Bun__encoding__constructFromUTF16(
 }
 
 // for SQL statement
-/// # Safety
-/// Caller (C++) must guarantee `input[..len]` is valid for reading.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__encoding__toStringUTF8(
-    input: *const u8,
-    len: usize,
-    global_object: &JSGlobalObject,
-) -> JSValue {
-    // SAFETY: forwarded from this fn's contract.
-    let input = unsafe { bun_core::ffi::slice(input, len) };
+// HOST_EXPORT(Bun__encoding__toStringUTF8, c)
+pub fn to_string_utf8(input: &[u8], global_object: &JSGlobalObject) -> JSValue {
     match to_string_comptime::<{ enc::UTF8 }>(input, global_object) {
         Ok(v) => v,
         Err(_) => JSValue::ZERO,
     }
 }
 
-/// # Safety
-/// Caller (C++) must guarantee `input[..len]` is valid for reading.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__encoding__toString(
-    input: *const u8,
-    len: usize,
-    global_object: &JSGlobalObject,
-    encoding: u8,
-) -> JSValue {
-    // SAFETY: forwarded from this fn's contract.
-    let input = unsafe { bun_core::ffi::slice(input, len) };
+// HOST_EXPORT(Bun__encoding__toString, c)
+pub fn to_string_dyn(input: &[u8], global_object: &JSGlobalObject, encoding: u8) -> JSValue {
     match to_string(input, global_object, encoding_from_u8(encoding)) {
         Ok(v) => v,
         Err(_) => JSValue::ZERO,
@@ -454,17 +390,10 @@ fn encode_base64_to_bun_string(input: &[u8], url_safe: bool) -> BunString {
     if to.try_reserve_exact(to_len).is_err() {
         return BunString::OUT_OF_MEMORY;
     }
-    // SAFETY: the spare bytes are write-only; the encoder reports how many it
-    // initialized and only those are committed.
-    let wrote = unsafe {
-        bun_core::vec::fill_spare(&mut to, 0, |spare| {
-            let wrote = if url_safe {
-                bun_base64::encode_url_safe(&mut spare[..to_len], input)
-            } else {
-                bun_base64::encode(&mut spare[..to_len], input)
-            };
-            (wrote, wrote)
-        })
+    let wrote = if url_safe {
+        bun_base64::encode_url_safe_append(&mut to, input)
+    } else {
+        bun_base64::encode_append(&mut to, input)
     };
     debug_assert_eq!(wrote, to_len);
     create_external_globally_allocated_latin1(to)
@@ -576,105 +505,47 @@ fn byte_length_u8<const ENCODING: u8>(input: &[u8]) -> usize {
     }
 }
 
-/// # Safety
-/// `input` must be valid for reading `len` `u16`s and `to` must be valid for
-/// writing `to_len` bytes; either pointer may be null when its length is 0 (a
-/// detached `ArrayBufferView` has a null vector and a byte length of 0). For
-/// `Ucs2`/`Utf16le` the ranges may overlap (memmove semantics); for all other
-/// encodings they must not.
-pub(crate) unsafe fn write_u16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bool>(
-    input: *const u16,
-    len: usize,
-    to: *mut u8,
-    to_len: usize,
+/// [`write_u8`] for a UTF-16 source.
+pub(crate) fn write_u16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bool>(
+    input: &[u16],
+    to: &mut [u8],
 ) -> Result<usize, crate::Error> {
-    if len == 0 || to_len == 0 {
+    if input.is_empty() || to.is_empty() {
         return Ok(0);
     }
 
-    // NOTE: Do NOT eagerly materialize `&[u16]` / `&mut [u8]` slices over `input`/`to` here.
-    // The Ucs2/Utf16le arm is spec'd to accept overlapping input/output (it copies with
-    // memmove semantics). Building a `&mut [u8]` whose memory is also
-    // covered by a live `&[u16]` would violate `slice::from_raw_parts_mut`'s exclusive-access
-    // contract (aliased-&mut UB). Each arm below constructs only the slice views it needs,
-    // and the Ucs2/Utf16le arm stays raw-pointer-only.
-
     match encoding_from_u8(ENCODING) {
-        Encoding::Utf8 => {
-            // SAFETY: caller guarantees `input[..len]` and `to[..to_len]` are valid and
-            // non-overlapping for this encoding.
-            let (input_slice, to_slice) = unsafe {
-                (
-                    bun_core::ffi::slice(input, len),
-                    bun_core::ffi::slice_mut(to, to_len),
-                )
-            };
-            Ok(
-                strings::copy_utf16_into_utf8_impl::<ALLOW_PARTIAL_WRITE>(to_slice, input_slice)
-                    .written as usize,
-            )
-        }
+        Encoding::Utf8 => Ok(
+            strings::copy_utf16_into_utf8_impl::<ALLOW_PARTIAL_WRITE>(to, input).written as usize,
+        ),
         Encoding::Latin1 | Encoding::Ascii | Encoding::Buffer => {
-            let out = len.min(to_len);
-            // SAFETY: caller guarantees `input[..len]` and `to[..to_len]` are valid and
-            // non-overlapping for this encoding.
-            let (input_slice, to_slice) = unsafe {
-                (
-                    bun_core::ffi::slice(input, out),
-                    bun_core::ffi::slice_mut(to, to_len),
-                )
-            };
-            strings::copy_u16_into_u8(to_slice, input_slice);
+            let out = input.len().min(to.len());
+            strings::copy_u16_into_u8(to, &input[..out]);
             Ok(out)
         }
         // string is already encoded, just need to copy the data
         Encoding::Ucs2 | Encoding::Utf16le => {
-            if ALLOW_PARTIAL_WRITE {
-                let bytes_input_len = len * 2;
-                let written = bytes_input_len.min(to_len);
-                let input_u8 = input.cast::<u8>();
-                // SAFETY: ranges may overlap; use ptr::copy (memmove).
-                unsafe { core::ptr::copy(input_u8, to, written) };
-                Ok(written)
+            let bytes: &[u8] = bytemuck::cast_slice(input);
+            let written = bytes.len().min(to.len());
+            let written = if ALLOW_PARTIAL_WRITE {
+                written
+            } else if written < 2 {
+                return Ok(0);
             } else {
-                let bytes_input_len = len * 2;
-                let written = bytes_input_len.min(to_len);
-                if written < 2 {
-                    return Ok(0);
-                }
-
-                let fixed_len = (written / 2) * 2;
-                let input_u8 = input.cast::<u8>();
-                // SAFETY: ranges may overlap; use ptr::copy (memmove).
-                unsafe { core::ptr::copy(input_u8, to, fixed_len) };
-                Ok(fixed_len)
-            }
-        }
-
-        Encoding::Hex => {
-            // SAFETY: caller guarantees `input[..len]` and `to[..to_len]` are valid and
-            // non-overlapping for this encoding.
-            let (input_slice, to_slice) = unsafe {
-                (
-                    bun_core::ffi::slice(input, len),
-                    bun_core::ffi::slice_mut(to, to_len),
-                )
+                (written / 2) * 2
             };
-            Ok(strings::decode_hex_to_bytes_truncate(to_slice, input_slice))
+            to[..written].copy_from_slice(&bytes[..written]);
+            Ok(written)
         }
+
+        Encoding::Hex => Ok(strings::decode_hex_to_bytes_truncate(to, input)),
 
         Encoding::Base64 | Encoding::Base64url => {
             // Match Node.js: two-byte strings are decoded from the low byte of
             // each UTF-16 code unit (so e.g. U+013D behaves like '=' and
             // U+1234 like '4'), the same narrowing Node's lenient fallback
             // decoder applies.
-            // SAFETY: caller guarantees `input[..len]` is valid.
-            let input_slice = unsafe { bun_core::ffi::slice(input, len) };
-            let narrowed = narrow_u16_to_u8(input_slice);
-            // SAFETY: caller guarantees `to[..to_len]` is valid for writing; `input_slice`
-            // is dead by now, so no other view of caller memory is live.
-            let to = unsafe { bun_core::ffi::slice_mut(to, to_len) };
-            write_u8::<ENCODING, ALLOW_PARTIAL_WRITE>(&narrowed, to)
+            write_u8::<ENCODING, ALLOW_PARTIAL_WRITE>(&narrow_u16_to_u8(input), to)
         } // else => return &[_]u8{};
     }
 }
@@ -697,14 +568,11 @@ fn construct_from_u8<const ENCODING: u8>(input: &[u8]) -> Vec<u8> {
             // (`copy_latin1_into_utf16` is exactly that loop). Write the bytes
             // directly into a `Vec<u8>` so we never depend on an allocator-
             // layout-dependent `Vec<u16> → Vec<u8>` header reinterpret.
-            let out_len = input.len() * 2;
-            let mut to: Vec<u8> = Vec::with_capacity(out_len);
-            let (pairs, _) = to.spare_capacity_mut().as_chunks_mut::<2>();
+            let mut to: Vec<u8> = vec![0; input.len() * 2];
+            let (pairs, _) = to.as_chunks_mut::<2>();
             for (out, &b) in pairs.iter_mut().zip(input) {
-                *out = u16::from(b).to_ne_bytes().map(MaybeUninit::new);
+                *out = u16::from(b).to_ne_bytes();
             }
-            // SAFETY: the loop wrote one pair per input byte, i.e. all `out_len` reserved bytes.
-            unsafe { to.set_len(out_len) };
             to
         }
 
@@ -718,22 +586,12 @@ fn construct_from_u8<const ENCODING: u8>(input: &[u8]) -> Vec<u8> {
             }
 
             let is_urlsafe = matches!(encoding_from_u8(ENCODING), Encoding::Base64url);
-            let outlen = bun_base64::decode_lenient_len(slice.len());
-            // Decode into uninitialized spare capacity: the decoder only ever
-            // writes to the destination, and only the `wrote` bytes it
-            // initialized are committed below. This buffer becomes the
-            // Buffer's storage, so a zero-fill would be pure overhead for
-            // large inputs.
+            // Decoded straight into what becomes the Buffer's storage (no
+            // zero-fill, no second copy).
             let mut to: Vec<u8> = Vec::new();
-            // SAFETY: the returned spare bytes are write-only until committed.
-            let dest = unsafe { bun_core::vec::reserve_spare_bytes(&mut to, outlen) };
-            let wrote = bun_base64::decode_lenient(&mut dest[..outlen], slice, is_urlsafe);
-            if wrote == 0 {
+            if bun_base64::decode_lenient_append(&mut to, slice, is_urlsafe) == 0 {
                 return Vec::new();
             }
-            // SAFETY: the decoder initialized the first `wrote` bytes
-            // (`wrote <= outlen <= capacity`).
-            unsafe { bun_core::vec::commit_spare(&mut to, wrote) };
             to
         }
     }
@@ -769,15 +627,7 @@ fn construct_from_u16<const ENCODING: u8>(input: &[u16]) -> Vec<u8> {
 
 /// The low byte of every code unit, in a fresh exactly-sized `Vec<u8>`.
 fn narrow_u16_to_u8(input: &[u16]) -> Vec<u8> {
-    let mut out: Vec<u8> = Vec::with_capacity(input.len());
-    // SAFETY: `copy_u16_into_u8` only writes `dst`, initializing exactly `input.len()` bytes.
-    unsafe {
-        bun_core::vec::fill_spare(&mut out, 0, |dst| {
-            strings::copy_u16_into_u8(&mut dst[..input.len()], input);
-            (input.len(), ())
-        })
-    };
-    out
+    input.iter().map(|&unit| unit as u8).collect()
 }
 
 /// Decodes hex pairs up to the first invalid one (`Buffer.from("..", "hex")` semantics).
@@ -787,16 +637,13 @@ fn construct_from_hex<Char: strings::HexChar>(input: &[Char]) -> Vec<u8> {
         return Vec::new();
     }
 
-    let mut to: Vec<u8> = Vec::new();
-    // SAFETY: the returned spare bytes are write-only until committed.
-    let dest = unsafe { bun_core::vec::reserve_spare_bytes(&mut to, outlen) };
-    let wrote = strings::decode_hex_to_bytes_truncate(&mut dest[..outlen], input);
+    let mut to: Vec<u8> = vec![0; outlen];
+    let wrote = strings::decode_hex_to_bytes_truncate(&mut to, input);
     // `create_buffer` frees nothing for an empty slice, so an empty result must not own memory.
     if wrote == 0 {
         return Vec::new();
     }
-    // SAFETY: the decoder initialized the first `wrote` bytes (`wrote <= outlen <= capacity`).
-    unsafe { bun_core::vec::commit_spare(&mut to, wrote) };
+    to.truncate(wrote);
     to
 }
 

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -505,7 +505,9 @@ fn byte_length_u8<const ENCODING: u8>(input: &[u8]) -> usize {
     }
 }
 
-/// [`write_u8`] for a UTF-16 source.
+/// [`write_u8`] for a UTF-16 source. `input` is a JS string's characters and
+/// `to` an `ArrayBuffer`'s storage, which never share memory (the C++
+/// declarations say so too), so every arm is a plain copy.
 pub(crate) fn write_u16<const ENCODING: u8, const ALLOW_PARTIAL_WRITE: bool>(
     input: &[u16],
     to: &mut [u8],
@@ -568,11 +570,8 @@ fn construct_from_u8<const ENCODING: u8>(input: &[u8]) -> Vec<u8> {
             // (`copy_latin1_into_utf16` is exactly that loop). Write the bytes
             // directly into a `Vec<u8>` so we never depend on an allocator-
             // layout-dependent `Vec<u16> → Vec<u8>` header reinterpret.
-            let mut to: Vec<u8> = vec![0; input.len() * 2];
-            let (pairs, _) = to.as_chunks_mut::<2>();
-            for (out, &b) in pairs.iter_mut().zip(input) {
-                *out = u16::from(b).to_ne_bytes();
-            }
+            let mut to: Vec<u8> = Vec::new();
+            strings::append_latin1_as_utf16_bytes(&mut to, input);
             to
         }
 
@@ -637,13 +636,11 @@ fn construct_from_hex<Char: strings::HexChar>(input: &[Char]) -> Vec<u8> {
         return Vec::new();
     }
 
-    let mut to: Vec<u8> = vec![0; outlen];
-    let wrote = strings::decode_hex_to_bytes_truncate(&mut to, input);
+    let mut to: Vec<u8> = Vec::new();
     // `create_buffer` frees nothing for an empty slice, so an empty result must not own memory.
-    if wrote == 0 {
+    if strings::decode_hex_append(&mut to, input) == 0 {
         return Vec::new();
     }
-    to.truncate(wrote);
     to
 }
 

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -221,6 +221,7 @@ pub mod length {
 pub mod base64 {
     use super::SIMDUTFResult;
     use core::ffi::c_int;
+    use core::mem::MaybeUninit;
 
     unsafe extern "C" {
         fn simdutf__base64_encode(
@@ -252,6 +253,28 @@ pub mod base64 {
                 input.as_ptr(),
                 input.len(),
                 output.as_mut_ptr(),
+                is_urlsafe as c_int,
+            )
+        }
+    }
+
+    /// [`encode`] into uninitialized storage (e.g. `Vec::spare_capacity_mut`).
+    /// Initializes and returns exactly [`encode_len`]`(input.len(), is_urlsafe)`
+    /// leading slots of `output`; panics if `output` is shorter than that.
+    pub fn encode_into_uninit(
+        input: &[u8],
+        output: &mut [MaybeUninit<u8>],
+        is_urlsafe: bool,
+    ) -> usize {
+        let need = encode_len(input.len(), is_urlsafe);
+        assert!(output.len() >= need, "base64 output buffer too small");
+        // SAFETY: `output` is valid for writes of `need <= output.len()` bytes; a
+        // `&mut` slice cannot overlap the shared `input` borrow.
+        unsafe {
+            simdutf__base64_encode(
+                input.as_ptr(),
+                input.len(),
+                output.as_mut_ptr().cast::<u8>(),
                 is_urlsafe as c_int,
             )
         }
@@ -290,6 +313,25 @@ pub mod base64 {
         }
     }
 
+    /// [`decode`] into uninitialized storage. On success the leading `count`
+    /// slots of `output` are initialized.
+    pub fn decode_into_uninit(
+        input: &[u8],
+        output: &mut [MaybeUninit<u8>],
+        is_urlsafe: bool,
+    ) -> SIMDUTFResult {
+        // SAFETY: `output` is valid for writes of `output.len()` bytes; FFI honors that bound and only stores.
+        unsafe {
+            simdutf__base64_decode_from_binary(
+                input.as_ptr(),
+                input.len(),
+                output.as_mut_ptr().cast::<u8>(),
+                output.len(),
+                is_urlsafe as c_int,
+            )
+        }
+    }
+
     /// Lenient decode matching Node.js `Buffer` semantics
     /// (`simdutf::base64_default_or_url_accept_garbage` + loose last chunk):
     /// accepts both the standard and URL-safe alphabets, skips whitespace and
@@ -302,6 +344,23 @@ pub mod base64 {
                 input.as_ptr(),
                 input.len(),
                 output.as_mut_ptr(),
+                output.len(),
+            )
+        }
+    }
+
+    /// [`decode_lenient`] into uninitialized storage. On success the leading
+    /// `count` slots of `output` are initialized.
+    pub fn decode_lenient_into_uninit(
+        input: &[u8],
+        output: &mut [MaybeUninit<u8>],
+    ) -> SIMDUTFResult {
+        // SAFETY: `output` is valid for writes of `output.len()` bytes; FFI honors that bound and only stores.
+        unsafe {
+            simdutf__base64_decode_from_binary_lenient(
+                input.as_ptr(),
+                input.len(),
+                output.as_mut_ptr().cast::<u8>(),
                 output.len(),
             )
         }

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -130,6 +130,31 @@ pub mod convert {
                             )
                         }
                     }
+
+                    /// [`le`] appended to `out`, reserving the room itself (`None`
+                    /// if that allocation fails). The bytes are kept only when
+                    /// all of `input` converted (`SUCCESS`, `count` = bytes
+                    /// appended); on any other status `out` is left unchanged.
+                    pub fn le_append(input: &[u16], out: &mut Vec<u8>) -> Option<SIMDUTFResult> {
+                        out.try_reserve(crate::simdutf::length::utf8::from::utf16::le(input))
+                            .ok()?;
+                        let spare = out.spare_capacity_mut();
+                        // SAFETY: `spare` holds `utf8_length_from_utf16le(input)`
+                        // bytes, simdutf's documented bound for this conversion.
+                        let r = unsafe {
+                            simdutf__convert_utf16le_to_utf8_with_errors(
+                                input.as_ptr(),
+                                input.len(),
+                                spare.as_mut_ptr().cast::<u8>(),
+                            )
+                        };
+                        if r.status == Status::SUCCESS {
+                            debug_assert!(r.count <= spare.len());
+                            // SAFETY: on success simdutf initialized the first `count` spare bytes.
+                            unsafe { out.set_len(out.len() + r.count) };
+                        }
+                        Some(r)
+                    }
                 }
 
                 pub fn le(input: &[u16], output: &mut [u8]) -> usize {

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -280,21 +280,6 @@ pub mod base64 {
         }
     }
 
-    /// Raw-pointer variant of [`encode`] for writing into uninitialised
-    /// storage (e.g. `Vec::spare_capacity_mut`). Writes exactly
-    /// [`encode_len(input.len(), is_urlsafe)`] bytes to `output` and returns
-    /// that count.
-    ///
-    /// # Safety
-    /// `output` must be valid for writes of at least
-    /// `encode_len(input.len(), is_urlsafe)` bytes and must not overlap
-    /// `input`.
-    pub unsafe fn encode_raw(input: &[u8], output: *mut u8, is_urlsafe: bool) -> usize {
-        // SAFETY: caller contract guarantees `output` is valid for
-        // `encode_len(input.len(), is_urlsafe)` bytes and disjoint from `input`.
-        unsafe { simdutf__base64_encode(input.as_ptr(), input.len(), output, is_urlsafe as c_int) }
-    }
-
     pub fn encode_len(input: usize, is_urlsafe: bool) -> usize {
         // SAFETY: pure length computation; no pointers dereferenced.
         unsafe { simdutf__base64_length_from_binary(input, is_urlsafe as c_int) }

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -48,10 +48,10 @@ fn parse_bytea(hex: &[u8]) -> Result<SQLDataCell> {
     let mut buf: Vec<u8> = Vec::new();
     buf.try_reserve_exact(len)
         .map_err(|_| AnyPostgresError::OutOfMemory)?;
-    // SAFETY: the decoder only writes into the spare bytes and returns how many it filled.
+    // SAFETY: the decoder returns how many leading spare slots it initialized.
     let written = unsafe {
         bun_core::vec::fill_spare(&mut buf, 0, |spare| {
-            match bun_core::decode_hex_to_bytes(&mut spare[..len], hex) {
+            match bun_core::decode_hex_to_uninit(&mut spare[..len], hex) {
                 Ok(written) => (written, Ok(written)),
                 Err(_) => (0, Err(AnyPostgresError::InvalidByteSequence)),
             }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -906,6 +906,7 @@ pub mod signal_code;
 pub use signal_code::SignalCode;
 pub mod tmp;
 pub use tmp::Tmpfile;
+pub mod os;
 // `windows/mod.rs` is `#![cfg(windows)]`-gated internally; on POSIX this
 // declares an empty module so `bun_sys::windows::*` paths still resolve under
 // `#[cfg(windows)]` arms in dependents.

--- a/src/sys/os.rs
+++ b/src/sys/os.rs
@@ -83,20 +83,35 @@ impl<'a> InterfaceAddress<'a> {
         Some(unsafe { Address::init_posix(self.0.ifa_addr) })
     }
 
-    /// The netmask, tagged with the entry's family: BSD kernels can report a
-    /// mask whose own `sa_family` is `AF_UNSPEC` (libuv reads it by the
-    /// address's family too).
+    /// The netmask, read and tagged by the entry's *address* family, as libuv
+    /// does: BSD kernels report masks whose own `sa_family` is `AF_UNSPEC`
+    /// (and whose `sa_len` may be shorter than the full sockaddr, the missing
+    /// tail meaning zero bits).
     pub fn netmask(self) -> Option<Address> {
         if self.0.ifa_netmask.is_null() {
             return None;
         }
-        // SAFETY: as for `address`, for `ifa_netmask`.
-        let mut mask = unsafe { Address::init_posix(self.0.ifa_netmask) };
-        if mask.family() == libc::AF_UNSPEC {
-            if let Some(family) = self.family() {
-                mask.any.ss_family = family as _;
-            }
-        }
+        let family = self.family()?;
+        let want = match family {
+            libc::AF_INET6 => core::mem::size_of::<libc::sockaddr_in6>(),
+            libc::AF_INET => core::mem::size_of::<libc::sockaddr_in>(),
+            _ => core::mem::size_of::<libc::sockaddr>(),
+        };
+        // SAFETY: getifaddrs(3) stores each entry's netmask in the list's block
+        // with room for a sockaddr of the entry's address family (libuv copies
+        // `sizeof(sockaddr_in6)` from it for AF_INET6 entries); on the BSDs
+        // `sa_len` says how much of it the kernel filled in.
+        let mask = unsafe {
+            let src = self.0.ifa_netmask;
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            let len = want.min(usize::from((*src).sa_len));
+            #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
+            let len = want;
+            let mut any: libc::sockaddr_storage = core::mem::zeroed();
+            core::ptr::copy_nonoverlapping(src.cast::<u8>(), (&raw mut any).cast::<u8>(), len);
+            any.ss_family = family as _;
+            Address { any }
+        };
         Some(mask)
     }
 

--- a/src/sys/os.rs
+++ b/src/sys/os.rs
@@ -1,0 +1,463 @@
+//! `node:os` platform queries. Each C API that hands back a list it owns
+//! (`getifaddrs(3)`, `host_processor_info`, `uv_cpu_info`,
+//! `uv_interface_addresses`) gets an owning type that frees it on drop and
+//! lends typed entries, so callers never see the raw pointers.
+
+#[allow(unused_imports)]
+use core::ffi::{c_char, c_int, c_uint};
+
+use crate::net::Address;
+
+// ──────────────────────────────────────────────────────────────────────────
+// getifaddrs(3)
+// ──────────────────────────────────────────────────────────────────────────
+
+/// The interface list of one `getifaddrs(3)` call; `freeifaddrs` on drop.
+#[cfg(unix)]
+pub struct InterfaceAddresses {
+    head: *mut libc::ifaddrs,
+}
+
+#[cfg(unix)]
+impl InterfaceAddresses {
+    /// `Err` is the `errno` `getifaddrs` failed with.
+    pub fn get() -> Result<Self, c_int> {
+        let mut head: *mut libc::ifaddrs = core::ptr::null_mut();
+        // SAFETY: `head` is a stack out-param; on success it receives the list.
+        if unsafe { libc::getifaddrs(&raw mut head) } != 0 {
+            return Err(crate::posix::errno());
+        }
+        Ok(Self { head })
+    }
+
+    /// Every entry, in the order `getifaddrs` returned them.
+    pub fn iter(&self) -> impl Iterator<Item = InterfaceAddress<'_>> + Clone {
+        // SAFETY: `head` and each `ifa_next` are null or a node of this list,
+        // all of which live until `self` is dropped.
+        core::iter::successors(unsafe { self.head.as_ref() }, |ifa| unsafe {
+            ifa.ifa_next.as_ref()
+        })
+        .map(InterfaceAddress)
+    }
+}
+
+#[cfg(unix)]
+impl Drop for InterfaceAddresses {
+    fn drop(&mut self) {
+        if !self.head.is_null() {
+            // SAFETY: the list `getifaddrs` allocated, freed exactly once.
+            unsafe { libc::freeifaddrs(self.head) }
+        }
+    }
+}
+
+/// One node of an [`InterfaceAddresses`] list.
+#[cfg(unix)]
+#[derive(Clone, Copy)]
+pub struct InterfaceAddress<'a>(&'a libc::ifaddrs);
+
+#[cfg(unix)]
+impl<'a> InterfaceAddress<'a> {
+    pub fn name(self) -> &'a [u8] {
+        // SAFETY: getifaddrs(3) sets `ifa_name` to a NUL-terminated string owned by the list.
+        unsafe { core::ffi::CStr::from_ptr(self.0.ifa_name) }.to_bytes()
+    }
+
+    /// `IFF_*` bits.
+    pub fn flags(self) -> c_uint {
+        self.0.ifa_flags
+    }
+
+    /// The address family of `ifa_addr`, if the entry has one.
+    pub fn family(self) -> Option<c_int> {
+        // SAFETY: a non-null `ifa_addr` points at a sockaddr owned by the list.
+        unsafe { self.0.ifa_addr.as_ref() }.map(|sa| c_int::from(sa.sa_family))
+    }
+
+    pub fn address(self) -> Option<Address> {
+        if self.0.ifa_addr.is_null() {
+            return None;
+        }
+        // SAFETY: getifaddrs(3) — a non-null `ifa_addr` points into the list's
+        // block at a sockaddr for the family it declares (libuv copies it the same way).
+        Some(unsafe { Address::init_posix(self.0.ifa_addr) })
+    }
+
+    /// The netmask, tagged with the entry's family: BSD kernels can report a
+    /// mask whose own `sa_family` is `AF_UNSPEC` (libuv reads it by the
+    /// address's family too).
+    pub fn netmask(self) -> Option<Address> {
+        if self.0.ifa_netmask.is_null() {
+            return None;
+        }
+        // SAFETY: as for `address`, for `ifa_netmask`.
+        let mut mask = unsafe { Address::init_posix(self.0.ifa_netmask) };
+        if mask.family() == libc::AF_UNSPEC {
+            if let Some(family) = self.family() {
+                mask.any.ss_family = family as _;
+            }
+        }
+        Some(mask)
+    }
+
+    /// The hardware-address bytes of a link-layer (`AF_PACKET`) entry.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn link_layer_address(self) -> Option<&'a [u8]> {
+        if self.family()? != libc::AF_PACKET {
+            return None;
+        }
+        // SAFETY: an `AF_PACKET` `ifa_addr` is a `sockaddr_ll` owned by the list.
+        let ll = unsafe { &*self.0.ifa_addr.cast::<libc::sockaddr_ll>() };
+        Some(&ll.sll_addr[..])
+    }
+
+    /// The hardware-address bytes of a link-layer (`AF_LINK`) entry.
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    pub fn link_layer_address(self) -> Option<&'a [u8]> {
+        if self.family()? != libc::AF_LINK {
+            return None;
+        }
+        let dl = self.0.ifa_addr.cast::<libc::sockaddr_dl>();
+        // SAFETY: an `AF_LINK` `ifa_addr` is a `sockaddr_dl` of `sdl_len`
+        // bytes owned by the list; the address follows the name in `sdl_data`.
+        unsafe {
+            let total = usize::from((*dl).sdl_len);
+            let start = (core::mem::offset_of!(libc::sockaddr_dl, sdl_data)
+                + usize::from((*dl).sdl_nlen))
+            .min(total);
+            let len = usize::from((*dl).sdl_alen).min(total - start);
+            Some(core::slice::from_raw_parts(dl.cast::<u8>().add(start), len))
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// getpwuid_r(3), getloadavg(3)
+// ──────────────────────────────────────────────────────────────────────────
+
+/// The effective user's home directory from the passwd database
+/// (`getpwuid_r(geteuid())`). `Ok(None)`: no entry for this uid; an entry
+/// with no `pw_dir` yields an empty path. `Err` is the errno `getpwuid_r`
+/// returned.
+#[cfg(unix)]
+pub fn passwd_home_dir() -> Result<Option<Vec<u8>>, c_int> {
+    // From libuv:
+    // > Calling sysconf(_SC_GETPW_R_SIZE_MAX) would get the suggested size, but it
+    // > is frequently 1024 or 4096, so we can just use that directly. The pwent
+    // > will not usually be large.
+    let mut stack = [0u8; 4096];
+    let mut heap: Vec<u8>;
+    let mut buf: &mut [u8] = &mut stack;
+    let mut pw: libc::passwd = bun_core::ffi::zeroed();
+    let mut result: *mut libc::passwd = core::ptr::null_mut();
+    loop {
+        // SAFETY: `pw`/`result` are stack out-params; `buf` is writable for `buf.len()`.
+        let rc = unsafe {
+            libc::getpwuid_r(
+                libc::geteuid(),
+                &raw mut pw,
+                buf.as_mut_ptr().cast::<c_char>(),
+                buf.len(),
+                &raw mut result,
+            )
+        };
+        if rc == libc::EINTR {
+            continue;
+        }
+        if rc == libc::ERANGE {
+            let len = buf.len();
+            heap = vec![0u8; len * 2];
+            buf = &mut heap;
+            continue;
+        }
+        if rc != 0 {
+            return Err(rc);
+        }
+        break;
+    }
+    if result.is_null() {
+        return Ok(None);
+    }
+    if pw.pw_dir.is_null() {
+        return Ok(Some(Vec::new()));
+    }
+    // SAFETY: on success `pw_dir` is a NUL-terminated string inside `buf`.
+    Ok(Some(
+        unsafe { core::ffi::CStr::from_ptr(pw.pw_dir) }
+            .to_bytes()
+            .to_vec(),
+    ))
+}
+
+/// `getloadavg(3)`; `None` unless all three samples were returned.
+#[cfg(target_os = "freebsd")]
+pub fn loadavg() -> Option<[f64; 3]> {
+    let mut avg = [0.0f64; 3];
+    // SAFETY: `avg` has room for the 3 samples requested.
+    (unsafe { libc::getloadavg(avg.as_mut_ptr(), 3) } == 3).then_some(avg)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// host_processor_info (macOS)
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Per-CPU tick counters from `host_processor_info(PROCESSOR_CPU_LOAD_INFO)`;
+/// the Mach buffer is `vm_deallocate`d on drop.
+#[cfg(target_os = "macos")]
+pub struct ProcessorCpuLoadInfo {
+    info: *mut libc::processor_cpu_load_info,
+    count: libc::natural_t,
+    info_size: libc::mach_msg_type_number_t,
+}
+
+#[cfg(target_os = "macos")]
+impl ProcessorCpuLoadInfo {
+    /// `None` if the call fails or returns a buffer of unexpected size.
+    pub fn get() -> Option<Self> {
+        let mut count: libc::natural_t = 0;
+        let mut info: *mut libc::processor_cpu_load_info = core::ptr::null_mut();
+        let mut info_size: libc::mach_msg_type_number_t = 0;
+        // SAFETY: all three are stack out-params.
+        if unsafe {
+            libc::host_processor_info(
+                crate::c::mach_host_self(),
+                libc::PROCESSOR_CPU_LOAD_INFO,
+                &raw mut count,
+                (&raw mut info).cast::<libc::processor_info_array_t>(),
+                &raw mut info_size,
+            )
+        } != 0
+        {
+            return None;
+        }
+        let this = Self {
+            info,
+            count,
+            info_size,
+        };
+        (info_size == crate::c::PROCESSOR_CPU_LOAD_INFO_COUNT * count).then_some(this)
+    }
+
+    pub fn as_slice(&self) -> &[libc::processor_cpu_load_info] {
+        // SAFETY: `get` checked that `info` holds exactly `count` entries; they live until drop.
+        unsafe { core::slice::from_raw_parts(self.info, self.count as usize) }
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for ProcessorCpuLoadInfo {
+    fn drop(&mut self) {
+        // SAFETY: the `info_size`-word buffer `host_processor_info` mapped into this task.
+        unsafe {
+            let _ = libc::vm_deallocate(
+                crate::c::mach_task_self(),
+                self.info as usize,
+                self.info_size as usize,
+            );
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// libuv (Windows)
+// ──────────────────────────────────────────────────────────────────────────
+
+#[cfg(windows)]
+use crate::windows::libuv as uv;
+
+/// The result of `uv_cpu_info`; `uv_free_cpu_info` on drop.
+#[cfg(windows)]
+pub struct CpuInfoList {
+    ptr: *mut uv::uv_cpu_info_t,
+    count: c_int,
+}
+
+#[cfg(windows)]
+impl CpuInfoList {
+    /// `Err` is the libuv error code.
+    pub fn get() -> Result<Self, c_int> {
+        let mut ptr = core::ptr::null_mut();
+        let mut count: c_int = 0;
+        // SAFETY: both are stack out-params.
+        let rc = unsafe { uv::uv_cpu_info(&mut ptr, &mut count) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(Self { ptr, count })
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = CpuInfo<'_>> {
+        let entries: &[uv::uv_cpu_info_t] = if self.ptr.is_null() {
+            &[]
+        } else {
+            // SAFETY: `uv_cpu_info` returned `count` entries at `ptr`; they live until drop.
+            unsafe { core::slice::from_raw_parts(self.ptr, self.count.max(0) as usize) }
+        };
+        entries.iter().map(CpuInfo)
+    }
+}
+
+#[cfg(windows)]
+impl Drop for CpuInfoList {
+    fn drop(&mut self) {
+        // SAFETY: the array `uv_cpu_info` allocated, freed exactly once.
+        unsafe { uv::uv_free_cpu_info(self.ptr, self.count) }
+    }
+}
+
+/// One entry of a [`CpuInfoList`].
+#[cfg(windows)]
+#[derive(Clone, Copy)]
+pub struct CpuInfo<'a>(&'a uv::uv_cpu_info_t);
+
+#[cfg(windows)]
+impl<'a> CpuInfo<'a> {
+    pub fn model(self) -> &'a [u8] {
+        if self.0.model.is_null() {
+            return b"";
+        }
+        // SAFETY: libuv sets `model` to a NUL-terminated string owned by the list.
+        unsafe { core::ffi::CStr::from_ptr(self.0.model) }.to_bytes()
+    }
+    pub fn speed(self) -> c_int {
+        self.0.speed
+    }
+    pub fn times(self) -> &'a uv::uv_cpu_times_t {
+        &self.0.cpu_times
+    }
+}
+
+/// The result of `uv_interface_addresses`; `uv_free_interface_addresses` on drop.
+#[cfg(windows)]
+pub struct InterfaceAddresses {
+    ptr: *mut uv::uv_interface_address_t,
+    count: c_int,
+}
+
+#[cfg(windows)]
+impl InterfaceAddresses {
+    /// `Err` is the libuv error code.
+    pub fn get() -> Result<Self, c_int> {
+        let mut ptr = core::ptr::null_mut();
+        let mut count: c_int = 0;
+        // SAFETY: both are stack out-params.
+        let rc = unsafe { uv::uv_interface_addresses(&mut ptr, &mut count) };
+        if rc != 0 {
+            return Err(rc);
+        }
+        Ok(Self { ptr, count })
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = InterfaceAddress<'_>> {
+        let entries: &[uv::uv_interface_address_t] = if self.ptr.is_null() {
+            &[]
+        } else {
+            // SAFETY: `uv_interface_addresses` returned `count` entries at `ptr`; they live until drop.
+            unsafe { core::slice::from_raw_parts(self.ptr, self.count.max(0) as usize) }
+        };
+        entries.iter().map(InterfaceAddress)
+    }
+}
+
+#[cfg(windows)]
+impl Drop for InterfaceAddresses {
+    fn drop(&mut self) {
+        // SAFETY: the array `uv_interface_addresses` allocated, freed exactly once.
+        unsafe { uv::uv_free_interface_addresses(self.ptr, self.count) }
+    }
+}
+
+/// One entry of an [`InterfaceAddresses`] list.
+#[cfg(windows)]
+#[derive(Clone, Copy)]
+pub struct InterfaceAddress<'a>(&'a uv::uv_interface_address_t);
+
+#[cfg(windows)]
+impl<'a> InterfaceAddress<'a> {
+    pub fn name(self) -> &'a [u8] {
+        if self.0.name.is_null() {
+            return b"";
+        }
+        // SAFETY: libuv sets `name` to a NUL-terminated string owned by the list.
+        unsafe { core::ffi::CStr::from_ptr(self.0.name) }.to_bytes()
+    }
+    pub fn phys_addr(self) -> [u8; 6] {
+        self.0.phys_addr
+    }
+    pub fn is_internal(self) -> bool {
+        self.0.is_internal != 0
+    }
+    pub fn address(self) -> Address {
+        // SAFETY: the union holds a `sockaddr_in` or `sockaddr_in6` tagged by
+        // its family, and is as large as the larger, so `init_posix`'s
+        // family-sized copy stays inside it.
+        unsafe { Address::init_posix(core::ptr::from_ref(&self.0.address).cast()) }
+    }
+    pub fn netmask(self) -> Address {
+        // SAFETY: as for `address`.
+        unsafe { Address::init_posix(core::ptr::from_ref(&self.0.netmask).cast()) }
+    }
+}
+
+/// `uv_os_homedir` into `buf`; `Ok` is the length written.
+#[cfg(windows)]
+pub fn homedir(buf: &mut [u8]) -> Result<usize, uv::ReturnCode> {
+    let mut size = buf.len();
+    // SAFETY: `buf` is writable for `size` bytes; `size` is a stack in/out-param.
+    let rc = unsafe { uv::uv_os_homedir(buf.as_mut_ptr(), &mut size) };
+    if rc.int() != 0 {
+        return Err(rc);
+    }
+    Ok(size)
+}
+
+/// `uv_os_uname`; `Err` is the libuv error code.
+#[cfg(windows)]
+pub fn uname() -> Result<uv::uv_utsname_t, c_int> {
+    let mut info = uv::uv_utsname_t {
+        sysname: [0; 256],
+        release: [0; 256],
+        version: [0; 256],
+        machine: [0; 256],
+    };
+    // SAFETY: `info` is a stack out-param.
+    let rc = unsafe { uv::uv_os_uname(&mut info) };
+    if rc != 0 {
+        return Err(rc);
+    }
+    Ok(info)
+}
+
+/// `uv_get_total_memory`.
+#[cfg(windows)]
+pub fn total_memory() -> u64 {
+    // SAFETY: no arguments, no preconditions.
+    unsafe { uv::uv_get_total_memory() }
+}
+
+/// `uv_uptime`; `Err` is the libuv error code.
+#[cfg(windows)]
+pub fn uptime() -> Result<f64, c_int> {
+    let mut value = 0.0f64;
+    // SAFETY: `value` is a stack out-param.
+    let rc = unsafe { uv::uv_uptime(&mut value) };
+    if rc != 0 {
+        return Err(rc);
+    }
+    Ok(value)
+}
+
+/// `GetHostNameW` into `buf` (Winsock initialised first); the name up to its
+/// NUL, or `None` on failure.
+#[cfg(windows)]
+pub fn hostname_w(buf: &mut [u16]) -> Option<&[u16]> {
+    let cap = c_int::try_from(buf.len().checked_sub(1)?).ok()?;
+    // SAFETY: idempotent Winsock init (libuv defers it to first use).
+    unsafe { uv::uv__winsock_ensure() };
+    // SAFETY: `buf` has room for `cap` characters plus the terminating NUL.
+    if unsafe { crate::windows::GetHostNameW(buf.as_mut_ptr(), cap) } != 0 {
+        return None;
+    }
+    let len = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    Some(&buf[..len])
+}

--- a/src/sys/os.rs
+++ b/src/sys/os.rs
@@ -247,12 +247,13 @@ impl ProcessorCpuLoadInfo {
 #[cfg(target_os = "macos")]
 impl Drop for ProcessorCpuLoadInfo {
     fn drop(&mut self) {
-        // SAFETY: the `info_size`-word buffer `host_processor_info` mapped into this task.
+        // SAFETY: the buffer `host_processor_info` mapped into this task:
+        // `info_size` `integer_t`s starting at `info`.
         unsafe {
             let _ = libc::vm_deallocate(
                 crate::c::mach_task_self(),
                 self.info as usize,
-                self.info_size as usize,
+                self.info_size as usize * core::mem::size_of::<libc::integer_t>(),
             );
         }
     }

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -883,6 +883,11 @@ pub struct DeflateEncoder {
     strm: Box<zStream_struct>,
 }
 
+// SAFETY: the z_stream and the `deflate_state` it owns are plain heap memory
+// with no thread affinity; `next_in`/`next_out` only point at caller buffers
+// for the duration of a `step*` call.
+unsafe impl Send for DeflateEncoder {}
+
 impl DeflateEncoder {
     pub fn new(
         level: c_int,
@@ -938,7 +943,23 @@ impl DeflateEncoder {
         reserve: usize,
         flush: FlushValue,
     ) -> (usize, ReturnCode) {
-        step(&mut self.strm, input, out, reserve, flush, deflate)
+        if out.try_reserve(reserve).is_err() {
+            return (0, ReturnCode::MemError);
+        }
+        step_into_spare(&mut self.strm, input, out, usize::MAX, flush, deflate)
+    }
+
+    /// [`step`](Self::step) without reserving: writes into whatever spare
+    /// capacity `out` already has, and at most `out_limit` bytes of it. With
+    /// no room to write, zlib returns `BufError` having done nothing.
+    pub fn step_into_spare(
+        &mut self,
+        input: &[u8],
+        out: &mut Vec<u8>,
+        out_limit: usize,
+        flush: FlushValue,
+    ) -> (usize, ReturnCode) {
+        step_into_spare(&mut self.strm, input, out, out_limit, flush, deflate)
     }
 }
 
@@ -963,6 +984,10 @@ pub struct InflateDecoder {
     /// members are all decoded instead of silently dropped after the first.
     multi_member: bool,
 }
+
+// SAFETY: as for `DeflateEncoder` — the z_stream and its `inflate_state` are
+// plain heap memory with no thread affinity.
+unsafe impl Send for InflateDecoder {}
 
 impl InflateDecoder {
     pub fn new(window_bits: c_int) -> Result<Self, ZlibError> {
@@ -1012,7 +1037,23 @@ impl InflateDecoder {
         reserve: usize,
         flush: FlushValue,
     ) -> (usize, ReturnCode) {
-        step(&mut self.strm, input, out, reserve, flush, inflate)
+        if out.try_reserve(reserve).is_err() {
+            return (0, ReturnCode::MemError);
+        }
+        step_into_spare(&mut self.strm, input, out, usize::MAX, flush, inflate)
+    }
+
+    /// [`step`](Self::step) without reserving: writes into whatever spare
+    /// capacity `out` already has, and at most `out_limit` bytes of it. With
+    /// no room to write, zlib returns `BufError` having done nothing.
+    pub fn step_into_spare(
+        &mut self,
+        input: &[u8],
+        out: &mut Vec<u8>,
+        out_limit: usize,
+        flush: FlushValue,
+    ) -> (usize, ReturnCode) {
+        step_into_spare(&mut self.strm, input, out, out_limit, flush, inflate)
     }
 
     /// Consume all of `input`, appending decompressed output to `out`
@@ -1135,25 +1176,21 @@ fn new_zstream() -> zStream_struct {
     }
 }
 
-/// Shared body of [`DeflateEncoder::step`] / [`InflateDecoder::step`].
-fn step(
+/// Shared body of [`DeflateEncoder::step_into_spare`] / [`InflateDecoder::step_into_spare`].
+fn step_into_spare(
     strm: &mut zStream_struct,
     input: &[u8],
     out: &mut Vec<u8>,
-    reserve: usize,
+    out_limit: usize,
     flush: FlushValue,
     op: unsafe extern "C" fn(*mut zStream_struct, FlushValue) -> ReturnCode,
 ) -> (usize, ReturnCode) {
-    if out.try_reserve(reserve).is_err() {
-        return (0, ReturnCode::MemError);
-    }
-
     let in_len = input.len().min(u32::MAX as usize);
     strm.next_in = input.as_ptr();
     strm.avail_in = in_len as uInt;
 
     let spare = out.spare_capacity_mut();
-    let out_len = spare.len().min(u32::MAX as usize);
+    let out_len = spare.len().min(out_limit).min(u32::MAX as usize);
     strm.next_out = spare.as_mut_ptr().cast::<u8>();
     strm.avail_out = out_len as uInt;
 

--- a/src/zlib/lib.rs
+++ b/src/zlib/lib.rs
@@ -22,6 +22,7 @@ unsafe extern "C" {
     ) -> c_int;
 }
 
+use bun_core::ffi::FfiSlice;
 pub use bun_zlib_sys::shared::{Bytef, uInt, uLong, uLongf};
 
 // typedef voidpf (*alloc_func) OF((voidpf opaque, uInt items, uInt size));
@@ -946,7 +947,14 @@ impl DeflateEncoder {
         if out.try_reserve(reserve).is_err() {
             return (0, ReturnCode::MemError);
         }
-        step_into_spare(&mut self.strm, input, out, usize::MAX, flush, deflate)
+        step_into_spare(
+            &mut self.strm,
+            input.into(),
+            out,
+            usize::MAX,
+            flush,
+            deflate,
+        )
     }
 
     /// [`step`](Self::step) without reserving: writes into whatever spare
@@ -954,7 +962,7 @@ impl DeflateEncoder {
     /// no room to write, zlib returns `BufError` having done nothing.
     pub fn step_into_spare(
         &mut self,
-        input: &[u8],
+        input: FfiSlice<'_>,
         out: &mut Vec<u8>,
         out_limit: usize,
         flush: FlushValue,
@@ -1040,7 +1048,14 @@ impl InflateDecoder {
         if out.try_reserve(reserve).is_err() {
             return (0, ReturnCode::MemError);
         }
-        step_into_spare(&mut self.strm, input, out, usize::MAX, flush, inflate)
+        step_into_spare(
+            &mut self.strm,
+            input.into(),
+            out,
+            usize::MAX,
+            flush,
+            inflate,
+        )
     }
 
     /// [`step`](Self::step) without reserving: writes into whatever spare
@@ -1048,7 +1063,7 @@ impl InflateDecoder {
     /// no room to write, zlib returns `BufError` having done nothing.
     pub fn step_into_spare(
         &mut self,
-        input: &[u8],
+        input: FfiSlice<'_>,
         out: &mut Vec<u8>,
         out_limit: usize,
         flush: FlushValue,
@@ -1179,7 +1194,7 @@ fn new_zstream() -> zStream_struct {
 /// Shared body of [`DeflateEncoder::step_into_spare`] / [`InflateDecoder::step_into_spare`].
 fn step_into_spare(
     strm: &mut zStream_struct,
-    input: &[u8],
+    input: FfiSlice<'_>,
     out: &mut Vec<u8>,
     out_limit: usize,
     flush: FlushValue,
@@ -1194,8 +1209,8 @@ fn step_into_spare(
     strm.next_out = spare.as_mut_ptr().cast::<u8>();
     strm.avail_out = out_len as uInt;
 
-    // SAFETY: strm was initialized by deflateInit2_/inflateInit2_; input is
-    // valid for `in_len` bytes; spare is valid write-only storage for
+    // SAFETY: strm was initialized by deflateInit2_/inflateInit2_; `input`
+    // is readable for `in_len` bytes (FfiSlice invariant; zlib only reads it); spare is valid write-only storage for
     // `out_len` bytes. zlib writes at most `out_len - avail_out` bytes.
     let rc = unsafe { op(&raw mut *strm, flush) };
 

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -2,6 +2,7 @@
 use core::ffi::{c_ulonglong, c_void};
 
 use bun_core::ZStr;
+use bun_core::ffi::FfiSlice;
 
 // ─── FFI bindings ─────────────────────────────────────────────────────────
 // Externs stay in this crate per PORTING.md §FFI: "If your file has externs
@@ -800,7 +801,7 @@ pub struct Step {
 /// One zstd call over `input` into `out[len..]`, offering at most `out_limit` bytes.
 #[inline]
 fn stream_step(
-    input: &[u8],
+    input: FfiSlice<'_>,
     out: &mut Vec<u8>,
     out_limit: usize,
     call: impl FnOnce(&mut c::ZSTD_outBuffer, &mut c::ZSTD_inBuffer) -> usize,
@@ -842,14 +843,21 @@ impl CompressStream {
 
     /// One `ZSTD_compressStream2` call; `end` selects `ZSTD_e_end` over
     /// `ZSTD_e_continue`.
-    pub fn step(&mut self, input: &[u8], out: &mut Vec<u8>, out_limit: usize, end: bool) -> Step {
+    pub fn step(
+        &mut self,
+        input: FfiSlice<'_>,
+        out: &mut Vec<u8>,
+        out_limit: usize,
+        end: bool,
+    ) -> Step {
         let directive = if end {
             c::ZSTD_e_end
         } else {
             c::ZSTD_e_continue
         };
         stream_step(input, out, out_limit, |out_buf, in_buf| {
-            // SAFETY: live CCtx; the buffers describe `input` and the spare window for this one call.
+            // SAFETY: live CCtx; the buffers describe `input` (readable, FfiSlice
+            // invariant; zstd only reads it) and the spare window for this one call.
             unsafe { c::ZSTD_compressStream2(self.0.as_ptr(), out_buf, in_buf, directive) }
         })
     }
@@ -874,9 +882,10 @@ impl DecompressStream {
     }
 
     /// One `ZSTD_decompressStream` call.
-    pub fn step(&mut self, input: &[u8], out: &mut Vec<u8>, out_limit: usize) -> Step {
+    pub fn step(&mut self, input: FfiSlice<'_>, out: &mut Vec<u8>, out_limit: usize) -> Step {
         stream_step(input, out, out_limit, |out_buf, in_buf| {
-            // SAFETY: live DCtx; the buffers describe `input` and the spare window for this one call.
+            // SAFETY: live DCtx; the buffers describe `input` (readable, FfiSlice
+            // invariant; zstd only reads it) and the spare window for this one call.
             unsafe { c::ZSTD_decompressStream(self.0.as_ptr(), out_buf, in_buf) }
         })
     }

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -776,3 +776,117 @@ pub fn inflate_embedded_nul(compressed: &'static [u8]) -> Box<[u8]> {
     inflated.push(0);
     inflated.into_boxed_slice()
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// Owned streaming contexts — one codec call per `step`, output into a
+// `Vec`'s spare capacity with a caller-chosen limit.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// What one [`CompressStream::step`] / [`DecompressStream::step`] call did.
+#[derive(Clone, Copy, Debug)]
+pub struct Step {
+    /// Bytes of `input` the codec consumed.
+    pub consumed: usize,
+    /// Bytes appended to `out`.
+    pub written: usize,
+    /// Size of the output window that was offered (`written <= offered`).
+    pub offered: usize,
+    /// The zstd return code (check with `ZSTD_isError`; otherwise a size hint,
+    /// `0` meaning the frame/flush is complete).
+    pub code: usize,
+}
+
+/// One zstd call over `input` into `out[len..]`, offering at most `out_limit` bytes.
+#[inline]
+fn stream_step(
+    input: &[u8],
+    out: &mut Vec<u8>,
+    out_limit: usize,
+    call: impl FnOnce(&mut c::ZSTD_outBuffer, &mut c::ZSTD_inBuffer) -> usize,
+) -> Step {
+    let spare = out.spare_capacity_mut();
+    let mut out_buf = c::ZSTD_outBuffer {
+        dst: spare.as_mut_ptr().cast::<c_void>(),
+        size: spare.len().min(out_limit),
+        pos: 0,
+    };
+    let mut in_buf = c::ZSTD_inBuffer {
+        src: input.as_ptr().cast::<c_void>(),
+        size: input.len(),
+        pos: 0,
+    };
+    let code = call(&mut out_buf, &mut in_buf);
+    // SAFETY: zstd wrote `pos <= size <= spare.len()` initialized bytes at the
+    // start of the spare capacity.
+    unsafe { bun_core::vec::commit_spare(out, out_buf.pos) };
+    Step {
+        consumed: in_buf.pos,
+        written: out_buf.pos,
+        offered: out_buf.size,
+        code,
+    }
+}
+
+/// An owned `ZSTD_CCtx` with default parameters; freed on drop.
+pub struct CompressStream(core::ptr::NonNull<c::ZSTD_CCtx>);
+
+// SAFETY: the context is private heap memory with no thread affinity; it is
+// only reached through `&mut self`.
+unsafe impl Send for CompressStream {}
+
+impl CompressStream {
+    pub fn new() -> Option<Self> {
+        core::ptr::NonNull::new(c::ZSTD_createCCtx()).map(Self)
+    }
+
+    /// One `ZSTD_compressStream2` call; `end` selects `ZSTD_e_end` over
+    /// `ZSTD_e_continue`.
+    pub fn step(&mut self, input: &[u8], out: &mut Vec<u8>, out_limit: usize, end: bool) -> Step {
+        // ZSTD_EndDirective: 0 = ZSTD_e_continue, 2 = ZSTD_e_end.
+        let directive: c::ZSTD_EndDirective = if end { 2 } else { c::ZSTD_e_continue };
+        stream_step(input, out, out_limit, |out_buf, in_buf| {
+            // SAFETY: live CCtx; the buffers describe `input` and the spare window for this one call.
+            unsafe { c::ZSTD_compressStream2(self.0.as_ptr(), out_buf, in_buf, directive) }
+        })
+    }
+}
+
+impl Drop for CompressStream {
+    fn drop(&mut self) {
+        // SAFETY: created by `ZSTD_createCCtx`, freed exactly once.
+        unsafe { c::ZSTD_freeCCtx(self.0.as_ptr()) };
+    }
+}
+
+/// An owned `ZSTD_DCtx` with default parameters; freed on drop.
+pub struct DecompressStream(core::ptr::NonNull<c::ZSTD_DStream>);
+
+// SAFETY: as for `CompressStream`.
+unsafe impl Send for DecompressStream {}
+
+impl DecompressStream {
+    pub fn new() -> Option<Self> {
+        core::ptr::NonNull::new(c::ZSTD_createDCtx()).map(Self)
+    }
+
+    /// One `ZSTD_decompressStream` call.
+    pub fn step(&mut self, input: &[u8], out: &mut Vec<u8>, out_limit: usize) -> Step {
+        stream_step(input, out, out_limit, |out_buf, in_buf| {
+            // SAFETY: live DCtx; the buffers describe `input` and the spare window for this one call.
+            unsafe { c::ZSTD_decompressStream(self.0.as_ptr(), out_buf, in_buf) }
+        })
+    }
+
+    /// `ZSTD_DCtx_reset(ZSTD_reset_session_and_parameters)`: ready for a new frame.
+    pub fn reset(&mut self) {
+        // SAFETY: live DCtx.
+        unsafe { c::ZSTD_DCtx_reset(self.0.as_ptr(), c::ZSTD_reset_session_and_parameters) };
+    }
+}
+
+impl Drop for DecompressStream {
+    fn drop(&mut self) {
+        // SAFETY: created by `ZSTD_createDCtx`, freed exactly once.
+        unsafe { c::ZSTD_freeDCtx(self.0.as_ptr()) };
+    }
+}

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -33,6 +33,7 @@ pub mod c {
 
     // ZSTD_EndDirective
     pub const ZSTD_e_continue: ZSTD_EndDirective = 0;
+    pub const ZSTD_e_end: ZSTD_EndDirective = 2;
 
     pub const ZSTD_reset_session_and_parameters: ZSTD_ResetDirective = 3;
 
@@ -842,8 +843,11 @@ impl CompressStream {
     /// One `ZSTD_compressStream2` call; `end` selects `ZSTD_e_end` over
     /// `ZSTD_e_continue`.
     pub fn step(&mut self, input: &[u8], out: &mut Vec<u8>, out_limit: usize, end: bool) -> Step {
-        // ZSTD_EndDirective: 0 = ZSTD_e_continue, 2 = ZSTD_e_end.
-        let directive: c::ZSTD_EndDirective = if end { 2 } else { c::ZSTD_e_continue };
+        let directive = if end {
+            c::ZSTD_e_end
+        } else {
+            c::ZSTD_e_continue
+        };
         stream_step(input, out, out_limit, |out_buf, in_buf| {
             // SAFETY: live CCtx; the buffers describe `input` and the spare window for this one call.
             unsafe { c::ZSTD_compressStream2(self.0.as_ptr(), out_buf, in_buf, directive) }

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -397,27 +397,32 @@ describe("CompressionStream and DecompressionStream", () => {
       return out;
     }
 
-    test("2MB chunk round-trips through CompressionStream('gzip') -> DecompressionStream('gzip')", async () => {
-      const big = randomBytes(2 * 1024 * 1024);
+    // Incompressible, so the compressed output outgrows the input-sized output
+    // cap mid-chunk and the final flush still has encoder output pending.
+    test.each(["gzip", "deflate-raw", "brotli", "zstd"] as const)(
+      "2MB chunk round-trips through CompressionStream(%s) -> DecompressionStream",
+      async format => {
+        const big = randomBytes(2 * 1024 * 1024);
 
-      const cs = new CompressionStream("gzip");
-      const cw = cs.writable.getWriter();
-      const compressedP = new Response(cs.readable).arrayBuffer();
-      await cw.write(big);
-      await cw.close();
-      const compressed = new Uint8Array(await compressedP);
-      expect(compressed.byteLength).toBeGreaterThan(0);
+        const cs = new CompressionStream(format);
+        const cw = cs.writable.getWriter();
+        const compressedP = new Response(cs.readable).arrayBuffer();
+        await cw.write(big);
+        await cw.close();
+        const compressed = new Uint8Array(await compressedP);
+        expect(compressed.byteLength).toBeGreaterThan(big.byteLength);
 
-      const ds = new DecompressionStream("gzip");
-      const dw = ds.writable.getWriter();
-      const decompressedP = new Response(ds.readable).arrayBuffer();
-      await dw.write(compressed);
-      await dw.close();
-      const decompressed = Buffer.from(await decompressedP);
+        const ds = new DecompressionStream(format);
+        const dw = ds.writable.getWriter();
+        const decompressedP = new Response(ds.readable).arrayBuffer();
+        await dw.write(compressed);
+        await dw.close();
+        const decompressed = Buffer.from(await decompressedP);
 
-      expect(decompressed.byteLength).toBe(big.byteLength);
-      expect(Buffer.compare(decompressed, Buffer.from(big.buffer))).toBe(0);
-    });
+        expect(decompressed.byteLength).toBe(big.byteLength);
+        expect(Buffer.compare(decompressed, Buffer.from(big.buffer))).toBe(0);
+      },
+    );
 
     test("DecompressionStream('gzip') handles a single >128KB compressed chunk", async () => {
       const big = randomBytes(2 * 1024 * 1024);


### PR DESCRIPTION
### What

Same programme as #40055 … #40242. `src/runtime/node/node_os.rs` 52 → 1, `src/runtime/webcore/CompressionStreamCoder.rs` 44 → 1 (each residual is an all-`safe fn` `unsafe extern "C"` block for symbols defined in Bun's own C++), `encoding.rs` 39 → **0**, `TextEncoder.rs` 24 → 0, `TextDecoder.rs` 17 → 0, `TextEncoderStreamEncoder.rs` 15 → 0.

- **`bun_sys::os`** (new): `InterfaceAddresses::get()/iter()` + `InterfaceAddress { name, flags, family, address, netmask, link_layer_address }` (RAII `freeifaddrs`), `passwd_home_dir`, `loadavg` (FreeBSD), `ProcessorCpuLoadInfo` (macOS, `vm_deallocate` on drop); Windows `CpuInfoList`, `InterfaceAddresses`, `homedir`, `uname`, `total_memory`, `uptime`, `hostname_w`.
- **Compression**: `bun_zlib::{DeflateEncoder, InflateDecoder}::step_into_spare`, `bun_brotli::{EncoderStream, DecoderStream}`, `bun_zstd::{CompressStream, DecompressStream}` — RAII, `Send`, write only into `spare_capacity ∩ out_limit` and commit what the codec reports; `bun_jsc::PinnedArrayBuffer` for the off-thread input.
- **Encoding**: `bun_simdutf …::le_append` (reserve simdutf's bound, commit on success), `bun_base64::{encode_url_safe_append, decode_lenient_append}`, `bun_core::strings::{decode_hex_append, append_latin1_as_utf16_bytes, cp1252_to_utf16_alloc}` — the `Buffer.from(str, 'hex'|'ucs2'|'base64')` paths write into spare capacity with no zero-fill, as before; `JSString::visit<V: StringVisitor>`; `bun_jsc::external_string_utf16(Vec<u16>)`; `encoding::write_u16` takes `(&[u16], &mut [u8])` (source is always JS string characters, never ArrayBuffer storage — the non-overlap contract every other arm on main already assumed is now documented on the `Bun__encoding__write*` declarations). All six files' C exports are `HOST_EXPORT`s (codegen gains `&mut [T]` → `(T*, len)` and `SinkHandle` params); `CompressionStreamCoder__restore` added, C++ updated.

Pre-existing bugs fixed in passing: macOS `networkInterfaces()` MAC lookup indexed the fixed 12-byte `sdl_data` (wrong MAC for interface names > 6 chars, panic for `sdl_nlen > 12`); a null `ifa_netmask` was dereferenced (now zero mask, as libuv). Known deltas: `TextDecoder`'s encoding_rs legacy multi-byte path zero-fills its output (cold; no uninit-output API); zlib/brotli stream state now comes from the mimalloc zones.

### Testing

Debug+ASAN: os.test.js 53/53; `test/js/web/encoding` 603/603; compression / fetch-compress / fetch-gzip / body / body-stream 9731 pass; zlib.test.js + encoder/decoder streams 750 pass; buffer.test.js 678 pass; node parallel test-os-*, test-whatwg-encoding-*, test-whatwg-webstreams-compression exit 0. Hand-driven: `os.*` JSON identical to system bun; gzip/deflate/deflate-raw/brotli/zstd round-trips (empty / 1 B / 10 MB random / 3 MB compressible), truncated/corrupt/trailing-junk errors, TextDecoder split/fatal/shift_jis/latin1/utf16, `encodeInto`, atob/btoa, TextEncoderStream/TextDecoderStream, HTTP native-sink paths — byte-identical to system bun, no ASAN output. clippy clean on all touched crates; `rust-check-all` windows-msvc + apple-darwin pass.
