### PR TITLE
Resolve react for fast refresh from HTML entry directories

### DIFF
--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -570,11 +570,9 @@ impl Framework {
     /// - If any file system router types are provided, configure using
     ///   the above react configuration.
     ///
-    /// Packages are resolved from the top-level directory and from each
-    /// directory in `extra_resolve_dirs` (the directories of the HTML entry
-    /// points). The extra directories matter in a workspace: the isolated
-    /// install linker puts `react` in the workspace package's `node_modules`,
-    /// where a resolution from the top-level directory cannot see it.
+    /// Packages resolve from the top-level directory and from each directory
+    /// in `extra_resolve_dirs` (the HTML entry directories, where the
+    /// isolated install linker puts a workspace package's dependencies).
     /// The provided allocator is not stored.
     pub fn auto(
         arena: &Arena,

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -569,11 +569,18 @@ impl Framework {
     ///     react-refresh so that it still works.
     /// - If any file system router types are provided, configure using
     ///   the above react configuration.
+    ///
+    /// Packages are resolved from the top-level directory and from each
+    /// directory in `extra_resolve_dirs` (the directories of the HTML entry
+    /// points). The extra directories matter in a workspace: the isolated
+    /// install linker puts `react` in the workspace package's `node_modules`,
+    /// where a resolution from the top-level directory cannot see it.
     /// The provided allocator is not stored.
     pub fn auto(
         arena: &Arena,
         resolver: &mut bun_resolver::Resolver,
         file_system_router_types: Vec<FileSystemRouterType>,
+        extra_resolve_dirs: &[&[u8]],
     ) -> crate::Result<Framework> {
         let mut fw: Framework = Framework::none();
 
@@ -582,9 +589,9 @@ impl Framework {
             fw.file_system_router_types = file_system_router_types;
         }
 
-        if let Some(rfr) = resolve_or_null(resolver, b"react-refresh/runtime") {
+        if let Some(rfr) = resolve_or_null(resolver, extra_resolve_dirs, b"react-refresh/runtime") {
             fw.react_fast_refresh = Some(ReactFastRefresh { import_source: rfr });
-        } else if resolve_or_null(resolver, b"react").is_some() {
+        } else if resolve_or_null(resolver, extra_resolve_dirs, b"react").is_some() {
             fw.react_fast_refresh = Some(ReactFastRefresh {
                 import_source: b"react-refresh/runtime/index.js",
             });
@@ -1352,17 +1359,25 @@ impl Default for ReactFastRefresh {
 }
 
 #[inline]
-fn resolve_or_null(r: &mut bun_resolver::Resolver, path: &[u8]) -> Option<&'static [u8]> {
+fn resolve_or_null(
+    r: &mut bun_resolver::Resolver,
+    extra_dirs: &[&[u8]],
+    path: &[u8],
+) -> Option<&'static [u8]> {
     let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-    match r.resolve(top_level_dir, path, bun_ast::ImportKind::Stmt) {
-        // `path_const().text` is `&'static [u8]` already (`FilenameStore`-
-        // backed; see note in `resolve_helper` above and `bun_ptr::Interned`).
-        Ok(res) => Some(res.path_const().unwrap().text),
-        Err(_) => {
-            r.log_mut().reset();
-            None
-        }
-    }
+    core::iter::once(top_level_dir)
+        .chain(extra_dirs.iter().copied())
+        .find_map(
+            |dir| match r.resolve(dir, path, bun_ast::ImportKind::Stmt) {
+                // `path_const().text` is `&'static [u8]` already (`FilenameStore`-
+                // backed; see note in `resolve_helper` above and `bun_ptr::Interned`).
+                Ok(res) => Some(res.path_const().unwrap().text),
+                Err(_) => {
+                    r.log_mut().reset();
+                    None
+                }
+            },
+        )
 }
 
 /// Thin forwarding shim — the real impl lives on

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -934,11 +934,9 @@ impl ServerConfig {
                             .map(|t| convert_file_system_router_type(&arena, t))
                             .collect();
 
-                    // Directories of the HTML entry points. `Framework::auto`
-                    // resolves `react` / `react-refresh` from these in addition
-                    // to the top-level directory, so detection works when the
-                    // packages live in a workspace package's `node_modules`
-                    // (the isolated linker layout).
+                    // HTML entry directories. `Framework::auto` resolves react
+                    // from these too: the isolated install linker puts a
+                    // workspace package's react outside the top-level dir.
                     let mut html_entry_dirs: Vec<&[u8]> = Vec::new();
                     for &bundle in init_ctx.dedupe_html_bundle_map.keys() {
                         // SAFETY: the map's value holds a Route that refs the

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -943,14 +943,14 @@ impl ServerConfig {
                         // bundle, so it stays alive for this scope.
                         let path = unsafe { &(*bundle).path };
                         if let Some(dir) = bun_paths::dirname(path) {
-                            if !html_entry_dirs
-                                .iter()
-                                .any(|d| bun_core::strings::eql(d, dir))
-                            {
+                            if !html_entry_dirs.iter().any(|d| strings::eql(d, dir)) {
                                 html_entry_dirs.push(dir);
                             }
                         }
                     }
+                    // Sort for determinism: map iteration order follows
+                    // pointer addresses, which vary across runs.
+                    html_entry_dirs.sort_unstable_by(|a, b| strings::order(a, b));
 
                     // SAFETY: `bun_vm()` returns the live VM for this global;
                     // we need `&mut Resolver` for `Framework::auto`.

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -945,7 +945,10 @@ impl ServerConfig {
                         // bundle, so it stays alive for this scope.
                         let path = unsafe { &(*bundle).path };
                         if let Some(dir) = bun_paths::dirname(path) {
-                            if !html_entry_dirs.iter().any(|d| bun_core::strings::eql(d, dir)) {
+                            if !html_entry_dirs
+                                .iter()
+                                .any(|d| bun_core::strings::eql(d, dir))
+                            {
                                 html_entry_dirs.push(dir);
                             }
                         }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -939,8 +939,10 @@ impl ServerConfig {
                     // workspace package's react outside the top-level dir.
                     let mut html_entry_dirs: Vec<&[u8]> = Vec::new();
                     for &bundle in init_ctx.dedupe_html_bundle_map.keys() {
-                        // SAFETY: the map's value holds a Route that refs the
-                        // bundle, so it stays alive for this scope.
+                        // SAFETY: each key's bundle is kept alive by an
+                        // `AnyRoute::Html(RefPtr<Route>)` in `args.static_routes`
+                        // (`Route.bundle` is a `RefPtr<HTMLBundle>`), and
+                        // `static_routes` is not mutated before this loop.
                         let path = unsafe { &(*bundle).path };
                         if let Some(dir) = bun_paths::dirname(path) {
                             if !html_entry_dirs.iter().any(|d| strings::eql(d, dir)) {

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -934,11 +934,29 @@ impl ServerConfig {
                             .map(|t| convert_file_system_router_type(&arena, t))
                             .collect();
 
+                    // Directories of the HTML entry points. `Framework::auto`
+                    // resolves `react` / `react-refresh` from these in addition
+                    // to the top-level directory, so detection works when the
+                    // packages live in a workspace package's `node_modules`
+                    // (the isolated linker layout).
+                    let mut html_entry_dirs: Vec<&[u8]> = Vec::new();
+                    for &bundle in init_ctx.dedupe_html_bundle_map.keys() {
+                        // SAFETY: the map's value holds a Route that refs the
+                        // bundle, so it stays alive for this scope.
+                        let path = unsafe { &(*bundle).path };
+                        if let Some(dir) = bun_paths::dirname(path) {
+                            if !html_entry_dirs.iter().any(|d| bun_core::strings::eql(d, dir)) {
+                                html_entry_dirs.push(dir);
+                            }
+                        }
+                    }
+
                     // SAFETY: `bun_vm()` returns the live VM for this global;
                     // we need `&mut Resolver` for `Framework::auto`.
                     let resolver = &mut global.bun_vm().as_mut().transpiler.resolver;
-                    let framework = bb::Framework::auto(&arena, resolver, router_types)
-                        .map_err(|e| global.throw_error(e, "Framework::auto"))?;
+                    let framework =
+                        bb::Framework::auto(&arena, resolver, router_types, &html_entry_dirs)
+                            .map_err(|e| global.throw_error(e, "Framework::auto"))?;
 
                     let mut user_options = crate::bake::UserOptions {
                         arena,

--- a/test/bake/dev/react-spa.test.ts
+++ b/test/bake/dev/react-spa.test.ts
@@ -748,3 +748,98 @@ devTest("react component with hooks and mutual recursion renders without error",
     );
   },
 });
+
+// https://github.com/oven-sh/bun/issues/40245
+// In a workspace, the isolated install linker puts react in the workspace
+// package's node_modules, not the root. Fast refresh detection must resolve
+// react from the HTML entry point's directory, not only the root.
+devTest("react refresh is detected when react is only in a workspace package's node_modules", {
+  files: {
+    "package.json": `{ "name": "repro", "private": true, "workspaces": ["app"] }`,
+    "app/node_modules/react/index.js": `exports.useState = (y) => [y, x => {}];`,
+    "app/node_modules/react/jsx-dev-runtime.js": /* js */ `
+      export const $$typeof = Symbol.for("react.element");
+      export const jsxDEV = (tag, props, key) => ({
+        $$typeof,
+        props,
+        key,
+        ref: null,
+        type: tag,
+      });
+    `,
+    "app/index.html": emptyHtmlFile({
+      scripts: ["index.tsx"],
+      body: `<div id="root"></div>`,
+    }),
+    "app/index.tsx": `
+      import { App } from "./App";
+      console.log(App);
+    `,
+    "app/App.tsx": `
+      import { useState } from "react";
+      export function App() {
+        const [n] = useState(0);
+        return <div>{n}</div>;
+      }
+    `,
+  },
+  async test(dev) {
+    const html = await dev.fetch("/").text();
+    const bundleUrl = html.match(/\/_bun\/client\/[^"]+/)?.[0];
+    expect(bundleUrl).toBeDefined();
+    const bundle = await dev.fetch(bundleUrl!).text();
+    // React is installed but react-refresh is not: the bundled copy of the
+    // react-refresh runtime is used.
+    expect(bundle).toContain("hmr.reactRefreshAccept()");
+    expect(bundle).toContain('refresh: "react-refresh/runtime/index.js"');
+  },
+});
+
+// Same layout, but react-refresh itself is installed in the workspace package.
+devTest("react refresh package is detected from a workspace package's node_modules", {
+  files: {
+    "package.json": `{ "name": "repro", "private": true, "workspaces": ["app"] }`,
+    "app/node_modules/react/index.js": `exports.useState = (y) => [y, x => {}];`,
+    "app/node_modules/react/jsx-dev-runtime.js": /* js */ `
+      export const $$typeof = Symbol.for("react.element");
+      export const jsxDEV = (tag, props, key) => ({
+        $$typeof,
+        props,
+        key,
+        ref: null,
+        type: tag,
+      });
+    `,
+    "app/node_modules/react-refresh/runtime.js": /* js */ `
+      exports.performReactRefresh = () => {};
+      exports.injectIntoGlobalHook = () => {};
+      exports.isLikelyComponentType = () => true;
+      exports.register = () => {};
+      exports.createSignatureFunctionForTransform = () => fn => fn;
+    `,
+    "app/index.html": emptyHtmlFile({
+      scripts: ["index.tsx"],
+      body: `<div id="root"></div>`,
+    }),
+    "app/index.tsx": `
+      import { App } from "./App";
+      console.log(App);
+    `,
+    "app/App.tsx": `
+      import { useState } from "react";
+      export function App() {
+        const [n] = useState(0);
+        return <div>{n}</div>;
+      }
+    `,
+  },
+  async test(dev) {
+    const html = await dev.fetch("/").text();
+    const bundleUrl = html.match(/\/_bun\/client\/[^"]+/)?.[0];
+    expect(bundleUrl).toBeDefined();
+    const bundle = await dev.fetch(bundleUrl!).text();
+    expect(bundle).toContain("hmr.reactRefreshAccept()");
+    // The installed react-refresh runtime is used, not the bundled fallback.
+    expect(bundle).toContain("react-refresh/runtime.js");
+  },
+});


### PR DESCRIPTION
### Problem
- In a workspace, the dev server silently turns React Fast Refresh off. Every edit is a full page reload with `Hot update was not accepted because it or its importers do not call import.meta.hot.accept`.
- `Framework::auto` resolves `react-refresh/runtime` and `react` only from the top-level directory (`resolve_or_null`, `src/runtime/bake/bake_body.rs:1355`). The isolated install linker, the default with workspaces, puts react in the workspace package's `node_modules`. Both resolutions fail and `react_fast_refresh` stays `None`.

### Fix
- `Bun.serve` collects the directory of each HTML entry point and passes them to `Framework::auto`. `resolve_or_null` tries the top-level directory first, then each entry directory.
- The HTML entry's scripts are what import react. A package that resolves from the entry's directory is the copy the bundle uses, so detection from that directory matches the bundle.
- Verified: two new tests in `test/bake/dev/react-spa.test.ts` (react only in `app/node_modules`, with and without react-refresh installed). Both fail on current bun. Also ran all of `test/bake/dev/react-spa.test.ts`, `test/bake/dev-and-prod.test.ts`, and `test/bake/framework-router.test.ts`.

### Background
- `Framework::auto` is the zero-config detection for `Bun.serve` with HTML routes. If `react-refresh` resolves, use it. Otherwise, if `react` resolves, use a bundled copy of the react-refresh runtime. If neither resolves, no refresh registration is emitted.
- The isolated linker installs each workspace package's dependencies under that package's own `node_modules`. A resolution from the repo root cannot see them.

Fixes #40245

<details><summary>Notes</summary>

Manual verification with the issue's six-file reproduction (root `package.json` with `workspaces: ["app"]`, react 19.2.8 in `app/`):

- Unfixed bun 1.4.1: client bundle has 0 `hmr.reactRefreshAccept()` calls and 0 `refresh:` module entries.
- Fixed debug build: 1 `hmr.reactRefreshAccept()` call and `refresh: "react-refresh/runtime/index.js"` in the module map.

`Framework::resolve` re-resolves `react_fast_refresh.import_source` later. In the fallback branch the source is the built-in module key, which `resolve_helper` matches before resolving. In the installed branch the source is the already resolved absolute path, which resolves from any base directory. The second test covers that branch.

Entry directories are deduplicated with a linear scan since a config has few HTML entries. Related: #40179 asks for an explicit flag for `bun --hot`, which is the runtime, not the dev server, and is not changed here.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/react-spa.test.ts
bun test v1.4.1 (4448a2e21)

test/bake/dev/react-spa.test.ts:
Dev server testing directory: /tmp/bun-dev-test-XoQLuo
bun install v1.4.1 (4448a2e21)

+ react@19.2.4
+ react-dom@19.2.4

3 packages installed [114.00ms]
[0;30mdev|[0m Started development server: http://localhost:33111
[0;30mdev|[0m [32mBundled page in 1277ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 44ms[0m[2m:[0m App.tsx
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:react-spa-1: react in html [4129.16ms]
[0;30mdev|[0m Started development server: http://localhost:36337
[0;30mdev|[0m [32mBundled page in 173ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 44ms[0m[2m:[0m App.tsx
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 70ms[0m[2m:[0m App.tsx
(pass)  DEV:react-spa-2: rea
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (ef6ddcc12)

test/bake/dev/react-spa.test.ts:
Dev server testing directory: /tmp/bun-dev-test-IxqBTT
bun install v1.4.1-canary.1 (ef6ddcc12)

+ react@19.2.4
+ react-dom@19.2.4

3 packages installed [2.00ms]
[0;30mdev|[0m Started development server: http://localhost:42039
[0;30mdev|[0m [32mBundled page in 43ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 1ms[0m[2m:[0m App.tsx
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:react-spa-1: react in html [723.09ms]
[0;30mdev|[0m Started development server: http://localhost:36411
[0;30mdev|[0m [32mBundled page in 5ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 2ms[0m[2m:[0m App.tsx
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 4ms[0m[2m:[0m App.tsx
(pass)  DEV:react-spa-2: react refresh should register and track hook state [545.70ms]
[0;30mdev|[0m Started development server: http://localhost:40851
[0;30mdev|[0m [32mBundled pa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/react-spa.test.ts
bun test v1.4.1 (4448a2e21)

test/bake/dev/react-spa.test.ts:
Dev server testing directory: /tmp/bun-dev-test-tCwxkW
bun install v1.4.1 (4448a2e21)

+ react@19.2.4
+ react-dom@19.2.4

3 packages installed [175.00ms]
[0;30mdev|[0m Started development server: http://localhost:38527
[0;30mdev|[0m [32mBundled page in 1525ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 37ms[0m[2m:[0m App.tsx
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:react-spa-1: react in html [4650.70ms]
[0;30mdev|[0m Started development server: http://localhost:34259
[0;30mdev|[0m [32mBundled page in 225ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 60ms[0m[2m:[0m App.tsx
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 50ms[0m[2m:[0m App.tsx
(pass)  DEV:react-spa-2: rea
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 702ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m  
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/bake_body.rs      | 37 ++++++++++-----
 src/runtime/server/ServerConfig.rs | 25 +++++++++-
 test/bake/dev/react-spa.test.ts    | 95 ++++++++++++++++++++++++++++++++++++++
 3 files changed, 143 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/runtime/bake/bake_body.rs           4      2      0
src/runtime/server/ServerConfig.rs      3      4      0
test/bake/dev/react-spa.test.ts         0      0      0
```

</details>

**root cause** · written by the author bot

The dev server's framework autodetection resolved react and react-refresh only from the project's top-level directory, so in workspaces using the isolated linker, where these packages live in a nested package's node_modules, resolution failed and React Fast Refresh was silently disabled. The fix collects the parent directories of each HTML bundle entry and passes them as additional resolution directories to the framework detection logic, which now tries the top-level directory and then each entry directory in order. With resolution succeeding from the app's own node_modules, Fast Refresh bo…

<!-- robobun:evidence:end -->