### PR TITLE
node: stop after a JS throw in HTTPParser callbacks, X509 getters, Buffer.from(BigInt64Array), structured-clone deserialize

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2113,7 +2113,7 @@ function generateRust(
     thunk(
       symbolName(typeName, "onStructuredCloneDeserialize"),
       `(global: &JSGlobalObject, ptr: *mut *mut u8, end: *const u8) -> JSValue`,
-      `    host_fn::host_fn_result(global, || ${T}::on_structured_clone_deserialize(global, ptr, end))`,
+      `    host_fn::structured_clone_deserialize_result(global, || ${T}::on_structured_clone_deserialize(global, ptr, end))`,
     );
   }
 

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2113,7 +2113,12 @@ function generateRust(
     thunk(
       symbolName(typeName, "onStructuredCloneDeserialize"),
       `(global: &JSGlobalObject, ptr: *mut *mut u8, end: *const u8) -> JSValue`,
-      `    host_fn::structured_clone_deserialize_result(global, || ${T}::on_structured_clone_deserialize(global, ptr, end))`,
+      `    // Empty with nothing pending: the record was malformed (CloneDeserializer::readTerminal → fail()).
+    match ${T}::on_structured_clone_deserialize(global, ptr, end) {
+        Ok(Some(value)) => value,
+        Ok(None) => JSValue::ZERO,
+        Err(err) => host_fn::host_call_error_value(global, err),
+    }`,
     );
   }
 

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -3985,9 +3985,9 @@ static JSC::EncodedJSValue createJSBufferFromJS(JSC::JSGlobalObject* lexicalGlob
             RETURN_IF_EXCEPTION(throwScope, {});
             if (byteLength) {
                 uint8Array->setFromTypedArray(lexicalGlobalObject, 0, view, 0, byteLength, CopyType::LeftToRight);
+                RETURN_IF_EXCEPTION(throwScope, {});
             }
-            RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(uint8Array));
-            break;
+            return JSC::JSValue::encode(uint8Array);
         }
         case DataViewType:
         case Uint8ArrayType:

--- a/src/jsc/bindings/JSX509Certificate.cpp
+++ b/src/jsc/bindings/JSX509Certificate.cpp
@@ -19,7 +19,6 @@
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 
-#include <JavaScriptCore/LazyPropertyInlines.h>
 #include "openssl/evp.h"
 #include "JavaScriptCore/ObjectPrototype.h"
 #include "BunString.h"

--- a/src/jsc/bindings/JSX509Certificate.cpp
+++ b/src/jsc/bindings/JSX509Certificate.cpp
@@ -592,19 +592,6 @@ bool JSX509Certificate::checkIssued(JSGlobalObject* globalObject, JSX509Certific
     return view().isIssuedBy(issuer->view());
 }
 
-template<typename T>
-static T* computeOnce(JSX509Certificate* owner, JSGlobalObject* globalObject, WriteBarrier<T>& slot, T* (*compute)(ncrypto::X509View, JSGlobalObject*))
-{
-    if (auto* cached = slot.get())
-        return cached;
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    T* value = compute(owner->view(), globalObject);
-    RETURN_IF_EXCEPTION(scope, nullptr);
-    slot.set(vm, owner, value);
-    return value;
-}
-
 static JSString* computeSubjectString(ncrypto::X509View view, JSGlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
@@ -625,39 +612,102 @@ static JSString* computeIssuerString(ncrypto::X509View view, JSGlobalObject* glo
 
 JSString* JSX509Certificate::subject(JSGlobalObject* globalObject)
 {
-    return computeOnce(this, globalObject, m_subject, computeSubjectString);
+    if (auto* cached = m_subject.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSString* value = computeSubjectString(view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    m_subject.set(vm, this, value);
+    return value;
 }
 JSString* JSX509Certificate::issuer(JSGlobalObject* globalObject)
 {
-    return computeOnce(this, globalObject, m_issuer, computeIssuerString);
+    if (auto* cached = m_issuer.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSString* value = computeIssuerString(view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    m_issuer.set(vm, this, value);
+    return value;
 }
 JSString* JSX509Certificate::validFrom(JSGlobalObject* globalObject)
 {
-    return computeOnce(this, globalObject, m_validFrom, computeValidFrom);
+    if (auto* cached = m_validFrom.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSString* value = computeValidFrom(view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    m_validFrom.set(vm, this, value);
+    return value;
 }
 JSString* JSX509Certificate::validTo(JSGlobalObject* globalObject)
 {
-    return computeOnce(this, globalObject, m_validTo, computeValidTo);
+    if (auto* cached = m_validTo.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSString* value = computeValidTo(view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    m_validTo.set(vm, this, value);
+    return value;
 }
 JSString* JSX509Certificate::serialNumber(JSGlobalObject* globalObject)
 {
-    return computeOnce(this, globalObject, m_serialNumber, computeSerialNumber);
+    if (auto* cached = m_serialNumber.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSString* value = computeSerialNumber(view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    m_serialNumber.set(vm, this, value);
+    return value;
 }
 JSString* JSX509Certificate::fingerprint(JSGlobalObject* globalObject)
 {
-    return computeOnce(this, globalObject, m_fingerprint, computeFingerprint);
+    if (auto* cached = m_fingerprint.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSString* value = computeFingerprint(view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    m_fingerprint.set(vm, this, value);
+    return value;
 }
 JSString* JSX509Certificate::fingerprint256(JSGlobalObject* globalObject)
 {
-    return computeOnce(this, globalObject, m_fingerprint256, computeFingerprint256);
+    if (auto* cached = m_fingerprint256.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSString* value = computeFingerprint256(view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    m_fingerprint256.set(vm, this, value);
+    return value;
 }
 JSString* JSX509Certificate::fingerprint512(JSGlobalObject* globalObject)
 {
-    return computeOnce(this, globalObject, m_fingerprint512, computeFingerprint512);
+    if (auto* cached = m_fingerprint512.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSString* value = computeFingerprint512(view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    m_fingerprint512.set(vm, this, value);
+    return value;
 }
 JSUint8Array* JSX509Certificate::raw(JSGlobalObject* globalObject)
 {
-    return computeOnce(this, globalObject, m_raw, computeRaw);
+    if (auto* cached = m_raw.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSUint8Array* value = computeRaw(view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    m_raw.set(vm, this, value);
+    return value;
 }
 JSValue JSX509Certificate::subjectAltName(JSGlobalObject* globalObject)
 {
@@ -673,7 +723,14 @@ JSValue JSX509Certificate::subjectAltName(JSGlobalObject* globalObject)
 }
 JSObject* JSX509Certificate::publicKey(JSGlobalObject* globalObject)
 {
-    return computeOnce(this, globalObject, m_publicKey, computePublicKey);
+    if (auto* cached = m_publicKey.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSObject* value = computePublicKey(view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    m_publicKey.set(vm, this, value);
+    return value;
 }
 
 bool JSX509Certificate::checkPrivateKey(const KeyObject& keyObject)

--- a/src/jsc/bindings/JSX509Certificate.cpp
+++ b/src/jsc/bindings/JSX509Certificate.cpp
@@ -203,58 +203,6 @@ void JSX509Certificate::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-
-    m_fingerprint.initLater([](const JSC::LazyProperty<JSX509Certificate, JSString>::Initializer& init) {
-        init.set(init.owner->computeFingerprint(init.owner->view(), init.owner->globalObject()));
-    });
-    m_subject.initLater([](const JSC::LazyProperty<JSX509Certificate, JSString>::Initializer& init) {
-        auto scope = DECLARE_THROW_SCOPE(init.vm);
-        auto value = init.owner->computeSubject(init.owner->view(), init.owner->globalObject(), false);
-        RETURN_IF_EXCEPTION(scope, init.property.setMayBeNull(init.vm, init.owner, nullptr));
-        if (!value.isString()) {
-            init.set(jsEmptyString(init.owner->vm()));
-            return;
-        }
-
-        init.set(value.toString(init.owner->globalObject()));
-    });
-    m_issuer.initLater([](const JSC::LazyProperty<JSX509Certificate, JSString>::Initializer& init) {
-        auto scope = DECLARE_THROW_SCOPE(init.vm);
-        JSValue value = init.owner->computeIssuer(init.owner->view(), init.owner->globalObject(), false);
-        RETURN_IF_EXCEPTION(scope, init.property.setMayBeNull(init.vm, init.owner, nullptr));
-        if (value.isString()) {
-            init.set(value.toString(init.owner->globalObject()));
-        } else {
-            init.property.setMayBeNull(init.owner->vm(), init.owner, nullptr);
-        }
-    });
-    m_validFrom.initLater([](const JSC::LazyProperty<JSX509Certificate, JSString>::Initializer& init) {
-        init.set(init.owner->computeValidFrom(init.owner->view(), init.owner->globalObject()));
-    });
-    m_validTo.initLater([](const JSC::LazyProperty<JSX509Certificate, JSString>::Initializer& init) {
-        init.set(init.owner->computeValidTo(init.owner->view(), init.owner->globalObject()));
-    });
-    m_serialNumber.initLater([](const JSC::LazyProperty<JSX509Certificate, JSString>::Initializer& init) {
-        init.set(init.owner->computeSerialNumber(init.owner->view(), init.owner->globalObject()));
-    });
-    m_fingerprint256.initLater([](const JSC::LazyProperty<JSX509Certificate, JSString>::Initializer& init) {
-        init.set(init.owner->computeFingerprint256(init.owner->view(), init.owner->globalObject()));
-    });
-    m_fingerprint512.initLater([](const JSC::LazyProperty<JSX509Certificate, JSString>::Initializer& init) {
-        init.set(init.owner->computeFingerprint512(init.owner->view(), init.owner->globalObject()));
-    });
-    m_raw.initLater([](const JSC::LazyProperty<JSX509Certificate, JSUint8Array>::Initializer& init) {
-        init.property.setMayBeNull(init.owner->vm(), init.owner, init.owner->computeRaw(init.owner->view(), init.owner->globalObject()));
-    });
-
-    m_subjectAltName.initLater([](const JSC::LazyProperty<JSX509Certificate, JSString>::Initializer& init) {
-        init.property.setMayBeNull(init.owner->vm(), init.owner, init.owner->computeSubjectAltName(init.owner->view(), init.owner->globalObject()));
-    });
-
-    m_publicKey.initLater([](const JSC::LazyProperty<JSX509Certificate, JSCell>::Initializer& init) {
-        JSValue value = init.owner->computePublicKey(init.owner->view(), init.owner->globalObject());
-        init.property.setMayBeNull(init.owner->vm(), init.owner, !value.isEmpty() && value.isCell() ? value.asCell() : nullptr);
-    });
 }
 
 JSX509Certificate* JSX509Certificate::create(VM& vm, Structure* structure)
@@ -314,17 +262,17 @@ void JSX509Certificate::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
-    thisObject->m_subject.visit(visitor);
-    thisObject->m_issuer.visit(visitor);
-    thisObject->m_validFrom.visit(visitor);
-    thisObject->m_validTo.visit(visitor);
-    thisObject->m_serialNumber.visit(visitor);
-    thisObject->m_fingerprint.visit(visitor);
-    thisObject->m_fingerprint256.visit(visitor);
-    thisObject->m_fingerprint512.visit(visitor);
-    thisObject->m_raw.visit(visitor);
-    thisObject->m_subjectAltName.visit(visitor);
-    thisObject->m_publicKey.visit(visitor);
+    visitor.append(thisObject->m_subject);
+    visitor.append(thisObject->m_issuer);
+    visitor.append(thisObject->m_validFrom);
+    visitor.append(thisObject->m_validTo);
+    visitor.append(thisObject->m_serialNumber);
+    visitor.append(thisObject->m_fingerprint);
+    visitor.append(thisObject->m_fingerprint256);
+    visitor.append(thisObject->m_fingerprint512);
+    visitor.append(thisObject->m_raw);
+    visitor.append(thisObject->m_subjectAltName);
+    visitor.append(thisObject->m_publicKey);
     visitor.reportExtraMemoryVisited(thisObject->m_extraMemorySizeForGC);
 }
 
@@ -484,7 +432,7 @@ JSString* JSX509Certificate::computeValidFrom(ncrypto::X509View view, JSGlobalOb
     auto bio = view.getValidFrom();
     if (!bio) {
         throwCryptoOperationFailed(globalObject, scope);
-        return jsEmptyString(vm);
+        return nullptr;
     }
 
     return jsString(vm, toWTFString(bio));
@@ -498,7 +446,7 @@ JSString* JSX509Certificate::computeValidTo(ncrypto::X509View view, JSGlobalObje
     auto bio = view.getValidTo();
     if (!bio) {
         throwCryptoOperationFailed(globalObject, scope);
-        return jsEmptyString(vm);
+        return nullptr;
     }
 
     return jsString(vm, toWTFString(bio));
@@ -512,7 +460,7 @@ JSString* JSX509Certificate::computeSerialNumber(ncrypto::X509View view, JSGloba
     auto serial = view.getSerialNumber();
     if (!serial) {
         throwCryptoOperationFailed(globalObject, scope);
-        return jsEmptyString(vm);
+        return nullptr;
     }
 
     return jsString(vm, toUppercaseASCIIWTFString(std::span(static_cast<const char*>(serial.get()), serial.size())));
@@ -526,7 +474,7 @@ JSString* JSX509Certificate::computeFingerprint(ncrypto::X509View view, JSGlobal
     auto fingerprint = view.getFingerprint(EVP_sha1());
     if (!fingerprint) {
         throwCryptoOperationFailed(globalObject, scope);
-        return jsEmptyString(vm);
+        return nullptr;
     }
 
     return jsString(vm, fingerprint.value());
@@ -540,7 +488,7 @@ JSString* JSX509Certificate::computeFingerprint256(ncrypto::X509View view, JSGlo
     auto fingerprint = view.getFingerprint(EVP_sha256());
     if (!fingerprint) {
         throwCryptoOperationFailed(globalObject, scope);
-        return jsEmptyString(vm);
+        return nullptr;
     }
 
     return jsString(vm, fingerprint.value());
@@ -554,7 +502,7 @@ JSString* JSX509Certificate::computeFingerprint512(ncrypto::X509View view, JSGlo
     auto fingerprint = view.getFingerprint(EVP_sha512());
     if (!fingerprint) {
         throwCryptoOperationFailed(globalObject, scope);
-        return jsEmptyString(vm);
+        return nullptr;
     }
 
     return jsString(vm, fingerprint.value());
@@ -645,50 +593,88 @@ bool JSX509Certificate::checkIssued(JSGlobalObject* globalObject, JSX509Certific
     return view().isIssuedBy(issuer->view());
 }
 
-JSString* JSX509Certificate::subject()
+template<typename T>
+static T* computeOnce(JSX509Certificate* owner, JSGlobalObject* globalObject, WriteBarrier<T>& slot, T* (*compute)(ncrypto::X509View, JSGlobalObject*))
 {
-    return m_subject.get(this);
-}
-JSString* JSX509Certificate::issuer()
-{
-    return m_issuer.get(this);
-}
-JSString* JSX509Certificate::validFrom()
-{
-    return m_validFrom.get(this);
-}
-JSString* JSX509Certificate::validTo()
-{
-    return m_validTo.get(this);
-}
-JSString* JSX509Certificate::serialNumber()
-{
-    return m_serialNumber.get(this);
-}
-JSString* JSX509Certificate::fingerprint()
-{
-    return m_fingerprint.get(this);
-}
-JSString* JSX509Certificate::fingerprint256()
-{
-    return m_fingerprint256.get(this);
-}
-JSString* JSX509Certificate::fingerprint512()
-{
-    return m_fingerprint512.get(this);
-}
-JSUint8Array* JSX509Certificate::raw()
-{
-    return m_raw.get(this);
-}
-JSString* JSX509Certificate::subjectAltName()
-{
-    return m_subjectAltName.get(this);
+    if (auto* cached = slot.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    T* value = compute(owner->view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    slot.set(vm, owner, value);
+    return value;
 }
 
-JSValue JSX509Certificate::publicKey()
+static JSString* computeSubjectString(ncrypto::X509View view, JSGlobalObject* globalObject)
 {
-    return m_publicKey.get(this);
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue value = JSX509Certificate::computeSubject(view, globalObject, false);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    return value.isString() ? asString(value) : jsEmptyString(vm);
+}
+
+static JSString* computeIssuerString(ncrypto::X509View view, JSGlobalObject* globalObject)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue value = JSX509Certificate::computeIssuer(view, globalObject, false);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    return value.isString() ? asString(value) : jsEmptyString(vm);
+}
+
+JSString* JSX509Certificate::subject(JSGlobalObject* globalObject)
+{
+    return computeOnce(this, globalObject, m_subject, computeSubjectString);
+}
+JSString* JSX509Certificate::issuer(JSGlobalObject* globalObject)
+{
+    return computeOnce(this, globalObject, m_issuer, computeIssuerString);
+}
+JSString* JSX509Certificate::validFrom(JSGlobalObject* globalObject)
+{
+    return computeOnce(this, globalObject, m_validFrom, computeValidFrom);
+}
+JSString* JSX509Certificate::validTo(JSGlobalObject* globalObject)
+{
+    return computeOnce(this, globalObject, m_validTo, computeValidTo);
+}
+JSString* JSX509Certificate::serialNumber(JSGlobalObject* globalObject)
+{
+    return computeOnce(this, globalObject, m_serialNumber, computeSerialNumber);
+}
+JSString* JSX509Certificate::fingerprint(JSGlobalObject* globalObject)
+{
+    return computeOnce(this, globalObject, m_fingerprint, computeFingerprint);
+}
+JSString* JSX509Certificate::fingerprint256(JSGlobalObject* globalObject)
+{
+    return computeOnce(this, globalObject, m_fingerprint256, computeFingerprint256);
+}
+JSString* JSX509Certificate::fingerprint512(JSGlobalObject* globalObject)
+{
+    return computeOnce(this, globalObject, m_fingerprint512, computeFingerprint512);
+}
+JSUint8Array* JSX509Certificate::raw(JSGlobalObject* globalObject)
+{
+    return computeOnce(this, globalObject, m_raw, computeRaw);
+}
+JSValue JSX509Certificate::subjectAltName(JSGlobalObject* globalObject)
+{
+    if (JSValue cached = m_subjectAltName.get())
+        return cached;
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSString* string = computeSubjectAltName(view(), globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSValue value = string ? JSValue(string) : jsNull();
+    m_subjectAltName.set(vm, this, value);
+    return value;
+}
+JSObject* JSX509Certificate::publicKey(JSGlobalObject* globalObject)
+{
+    return computeOnce(this, globalObject, m_publicKey, computePublicKey);
 }
 
 bool JSX509Certificate::checkPrivateKey(const KeyObject& keyObject)
@@ -725,23 +711,32 @@ __attribute__((minsize)) JSC::JSObject* JSX509Certificate::toLegacyObject(ncrypt
     };
 
     // Set subject
-    Bun::putDirectNamed(vm, object, "subject"_s, valueOrUndefined(computeSubject(view, globalObject, true)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSValue subject = computeSubject(view, globalObject, true);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "subject"_s, valueOrUndefined(subject));
+    }
 
     // Set issuer
-    Bun::putDirectNamed(vm, object, "issuer"_s, valueOrUndefined(computeIssuer(view, globalObject, true)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSValue issuer = computeIssuer(view, globalObject, true);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "issuer"_s, valueOrUndefined(issuer));
+    }
 
     // Set subjectaltname
     {
         JSString* san = computeSubjectAltName(view, globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
         Bun::putDirectNamed(vm, object, "subjectaltname"_s, san ? JSValue(san) : jsUndefined());
     }
-    RETURN_IF_EXCEPTION(scope, nullptr);
 
     // Set infoAccess
-    Bun::putDirectNamed(vm, object, "infoAccess"_s, valueOrUndefined(computeInfoAccess(view, globalObject)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSValue infoAccess = computeInfoAccess(view, globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "infoAccess"_s, valueOrUndefined(infoAccess));
+    }
 
     // Set modulus and exponent for RSA keys
     EVP_PKEY* pkey = X509_get0_pubkey(cert);
@@ -842,34 +837,58 @@ __attribute__((minsize)) JSC::JSObject* JSX509Certificate::toLegacyObject(ncrypt
     }
 
     // Set validFrom
-    Bun::putDirectNamed(vm, object, "valid_from"_s, valueOrUndefined(computeValidFrom(view, globalObject)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* validFrom = computeValidFrom(view, globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "valid_from"_s, valueOrUndefined(validFrom));
+    }
 
     // Set validTo
-    Bun::putDirectNamed(vm, object, "valid_to"_s, valueOrUndefined(computeValidTo(view, globalObject)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* validTo = computeValidTo(view, globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "valid_to"_s, valueOrUndefined(validTo));
+    }
 
     // Set fingerprints
-    Bun::putDirectNamed(vm, object, "fingerprint"_s, valueOrUndefined(computeFingerprint(view, globalObject)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* fingerprint = computeFingerprint(view, globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "fingerprint"_s, valueOrUndefined(fingerprint));
+    }
 
-    Bun::putDirectNamed(vm, object, "fingerprint256"_s, valueOrUndefined(computeFingerprint256(view, globalObject)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* fingerprint256 = computeFingerprint256(view, globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "fingerprint256"_s, valueOrUndefined(fingerprint256));
+    }
 
-    Bun::putDirectNamed(vm, object, "fingerprint512"_s, valueOrUndefined(computeFingerprint512(view, globalObject)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* fingerprint512 = computeFingerprint512(view, globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "fingerprint512"_s, valueOrUndefined(fingerprint512));
+    }
 
     // Set keyUsage
-    Bun::putDirectNamed(vm, object, "ext_key_usage"_s, getKeyUsage(view, globalObject));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSValue keyUsage = getKeyUsage(view, globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "ext_key_usage"_s, keyUsage);
+    }
 
     // Set serialNumber
-    Bun::putDirectNamed(vm, object, "serialNumber"_s, valueOrUndefined(computeSerialNumber(view, globalObject)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* serialNumber = computeSerialNumber(view, globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "serialNumber"_s, valueOrUndefined(serialNumber));
+    }
 
     // Set raw
-    Bun::putDirectNamed(vm, object, "raw"_s, computeRaw(view, globalObject));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSUint8Array* raw = computeRaw(view, globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "raw"_s, raw);
+    }
 
     // Set CA flag
     Bun::putDirectNamed(vm, object, "ca"_s, jsBoolean(computeIsCA(view, globalObject)));
@@ -902,23 +921,32 @@ JSC::JSObject* JSX509Certificate::toLegacyObject(JSGlobalObject* globalObject)
     };
 
     // Set subject
-    Bun::putDirectNamed(vm, object, "subject"_s, valueOrUndefined(computeSubject(view(), globalObject, true)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSValue subject = computeSubject(view(), globalObject, true);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "subject"_s, valueOrUndefined(subject));
+    }
 
     // Set issuer
-    Bun::putDirectNamed(vm, object, "issuer"_s, valueOrUndefined(computeIssuer(view(), globalObject, true)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSValue issuer = computeIssuer(view(), globalObject, true);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "issuer"_s, valueOrUndefined(issuer));
+    }
 
     // Set subjectaltname
     {
-        JSString* san = subjectAltName();
-        Bun::putDirectNamed(vm, object, "subjectaltname"_s, san ? JSValue(san) : jsUndefined());
+        JSValue san = subjectAltName(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "subjectaltname"_s, san.isString() ? san : jsUndefined());
     }
-    RETURN_IF_EXCEPTION(scope, nullptr);
 
     // Set infoAccess
-    Bun::putDirectNamed(vm, object, "infoAccess"_s, valueOrUndefined(computeInfoAccess(view(), globalObject)));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSValue infoAccess = computeInfoAccess(view(), globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "infoAccess"_s, valueOrUndefined(infoAccess));
+    }
 
     // Set modulus and exponent for RSA keys
     EVP_PKEY* pkey = X509_get0_pubkey(cert);
@@ -1019,34 +1047,58 @@ JSC::JSObject* JSX509Certificate::toLegacyObject(JSGlobalObject* globalObject)
     }
 
     // Set validFrom
-    Bun::putDirectNamed(vm, object, "valid_from"_s, valueOrUndefined(validFrom()));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* validFrom = this->validFrom(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "valid_from"_s, valueOrUndefined(validFrom));
+    }
 
     // Set validTo
-    Bun::putDirectNamed(vm, object, "valid_to"_s, valueOrUndefined(validTo()));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* validTo = this->validTo(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "valid_to"_s, valueOrUndefined(validTo));
+    }
 
     // Set fingerprints
-    Bun::putDirectNamed(vm, object, "fingerprint"_s, valueOrUndefined(fingerprint()));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* fingerprint = this->fingerprint(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "fingerprint"_s, valueOrUndefined(fingerprint));
+    }
 
-    Bun::putDirectNamed(vm, object, "fingerprint256"_s, valueOrUndefined(fingerprint256()));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* fingerprint256 = this->fingerprint256(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "fingerprint256"_s, valueOrUndefined(fingerprint256));
+    }
 
-    Bun::putDirectNamed(vm, object, "fingerprint512"_s, valueOrUndefined(fingerprint512()));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* fingerprint512 = this->fingerprint512(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "fingerprint512"_s, valueOrUndefined(fingerprint512));
+    }
 
     // Set keyUsage
-    Bun::putDirectNamed(vm, object, "ext_key_usage"_s, getKeyUsage(globalObject));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSValue keyUsage = getKeyUsage(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "ext_key_usage"_s, keyUsage);
+    }
 
     // Set serialNumber
-    Bun::putDirectNamed(vm, object, "serialNumber"_s, valueOrUndefined(serialNumber()));
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSString* serialNumber = this->serialNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "serialNumber"_s, valueOrUndefined(serialNumber));
+    }
 
     // Set raw
-    Bun::putDirectNamed(vm, object, "raw"_s, raw());
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    {
+        JSUint8Array* raw = this->raw(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        Bun::putDirectNamed(vm, object, "raw"_s, raw);
+    }
 
     // Set CA flag
     Bun::putDirectNamed(vm, object, "ca"_s, jsBoolean(computeIsCA(view(), globalObject)));
@@ -1055,7 +1107,7 @@ JSC::JSObject* JSX509Certificate::toLegacyObject(JSGlobalObject* globalObject)
     return object;
 }
 
-JSValue JSX509Certificate::computePublicKey(ncrypto::X509View view, JSGlobalObject* lexicalGlobalObject)
+JSObject* JSX509Certificate::computePublicKey(ncrypto::X509View view, JSGlobalObject* lexicalGlobalObject)
 {
     VM& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1064,7 +1116,7 @@ JSValue JSX509Certificate::computePublicKey(ncrypto::X509View view, JSGlobalObje
     auto result = view.getPublicKey();
     if (!result) {
         throwCryptoError(lexicalGlobalObject, scope, result.error.value_or(0));
-        return {};
+        return nullptr;
     }
 
     auto handle = KeyObject::create(CryptoKeyType::Public, WTF::move(result.value));
@@ -1107,10 +1159,12 @@ JSValue JSX509Certificate::computeInfoAccess(ncrypto::X509View view, JSGlobalObj
         if (existingValue) {
             JSArray* array = uncheckedDowncast<JSArray>(existingValue);
             array->push(globalObject, jsString(vm, value));
+            RETURN_IF_EXCEPTION(scope, {});
         } else {
             JSArray* array = constructEmptyArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), 1);
             RETURN_IF_EXCEPTION(scope, {});
             array->putDirectIndex(globalObject, 0, jsString(vm, value));
+            RETURN_IF_EXCEPTION(scope, {});
             object->putDirect(vm, identifier, array);
         }
 
@@ -1159,6 +1213,7 @@ JSValue JSX509Certificate::getKeyUsage(ncrypto::X509View view, JSGlobalObject* g
     for (int i = 0; i < count; i++) {
         if (OBJ_obj2txt(buf, sizeof(buf), sk_ASN1_OBJECT_value(keyUsage.get(), i), 1) >= 0) {
             array->putDirectIndex(globalObject, j++, jsString(vm, String::fromUTF8(buf)));
+            RETURN_IF_EXCEPTION(scope, {});
         }
     }
 

--- a/src/jsc/bindings/JSX509Certificate.h
+++ b/src/jsc/bindings/JSX509Certificate.h
@@ -9,8 +9,7 @@
 #include <JavaScriptCore/JSDestructibleObject.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSString.h>
-#include <JavaScriptCore/LazyProperty.h>
-#include <JavaScriptCore/LazyPropertyInlines.h>
+#include <JavaScriptCore/WriteBarrier.h>
 #include "KeyObject.h"
 
 namespace Zig {
@@ -37,30 +36,33 @@ public:
         return m_x509.view();
     }
 
-    // Lazily computed certificate data
-    LazyProperty<JSX509Certificate, JSString> m_subject;
-    LazyProperty<JSX509Certificate, JSString> m_issuer;
-    LazyProperty<JSX509Certificate, JSString> m_validFrom;
-    LazyProperty<JSX509Certificate, JSString> m_validTo;
-    LazyProperty<JSX509Certificate, JSString> m_serialNumber;
-    LazyProperty<JSX509Certificate, JSString> m_fingerprint;
-    LazyProperty<JSX509Certificate, JSString> m_fingerprint256;
-    LazyProperty<JSX509Certificate, JSString> m_fingerprint512;
-    LazyProperty<JSX509Certificate, JSUint8Array> m_raw;
-    LazyProperty<JSX509Certificate, JSString> m_subjectAltName;
-    LazyProperty<JSX509Certificate, JSCell> m_publicKey;
+    // Certificate data computed on first access. A getter that throws caches nothing, so the next access
+    // computes (and throws) again rather than handing out a stale placeholder. An absent subject / issuer is
+    // cached as the empty string; an absent subjectAltName as null.
+    WriteBarrier<JSString> m_subject;
+    WriteBarrier<JSString> m_issuer;
+    WriteBarrier<JSString> m_validFrom;
+    WriteBarrier<JSString> m_validTo;
+    WriteBarrier<JSString> m_serialNumber;
+    WriteBarrier<JSString> m_fingerprint;
+    WriteBarrier<JSString> m_fingerprint256;
+    WriteBarrier<JSString> m_fingerprint512;
+    WriteBarrier<JSUint8Array> m_raw;
+    WriteBarrier<Unknown> m_subjectAltName;
+    WriteBarrier<JSObject> m_publicKey;
 
-    JSString* subject();
-    JSString* issuer();
-    JSString* validFrom();
-    JSString* validTo();
-    JSString* serialNumber();
-    JSString* fingerprint();
-    JSString* fingerprint256();
-    JSString* fingerprint512();
-    JSUint8Array* raw();
-    JSString* subjectAltName();
-    JSValue publicKey();
+    JSString* subject(JSGlobalObject*);
+    JSString* issuer(JSGlobalObject*);
+    JSString* validFrom(JSGlobalObject*);
+    JSString* validTo(JSGlobalObject*);
+    JSString* serialNumber(JSGlobalObject*);
+    JSString* fingerprint(JSGlobalObject*);
+    JSString* fingerprint256(JSGlobalObject*);
+    JSString* fingerprint512(JSGlobalObject*);
+    JSUint8Array* raw(JSGlobalObject*);
+    // The string, or null when the certificate has no subjectAltName extension.
+    JSValue subjectAltName(JSGlobalObject*);
+    JSObject* publicKey(JSGlobalObject*);
 
     // Certificate validation methods
     // `peerName`, when provided, receives the subject name that matched, which
@@ -133,7 +135,7 @@ public:
     static bool computeIsCA(ncrypto::X509View view, JSGlobalObject*);
     static JSValue computeInfoAccess(ncrypto::X509View view, JSGlobalObject*);
     static JSString* computeSubjectAltName(ncrypto::X509View view, JSGlobalObject*);
-    static JSValue computePublicKey(ncrypto::X509View view, JSGlobalObject*);
+    static JSObject* computePublicKey(ncrypto::X509View view, JSGlobalObject*);
 
     JSX509Certificate(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure)

--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -456,7 +456,9 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_fingerprint, (JSGlobalObject * 
         return {};
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject->fingerprint()));
+    JSString* fingerprint = thisObject->fingerprint(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(fingerprint);
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_fingerprint256, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
@@ -470,7 +472,9 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_fingerprint256, (JSGlobalObject
         return {};
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject->fingerprint256()));
+    JSString* fingerprint256 = thisObject->fingerprint256(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(fingerprint256);
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_fingerprint512, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
@@ -484,7 +488,9 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_fingerprint512, (JSGlobalObject
         return {};
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject->fingerprint512()));
+    JSString* fingerprint512 = thisObject->fingerprint512(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(fingerprint512);
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_signatureAlgorithm, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
@@ -534,7 +540,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_subject, (JSGlobalObject * glob
         return {};
     }
 
-    JSString* subject = thisObject->subject();
+    JSString* subject = thisObject->subject(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(undefinedIfEmpty(subject));
 }
@@ -550,8 +556,9 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_subjectAltName, (JSGlobalObject
         return {};
     }
 
-    JSString* san = thisObject->subjectAltName();
-    RELEASE_AND_RETURN(scope, JSValue::encode(san ? JSValue(san) : jsUndefined()));
+    JSValue san = thisObject->subjectAltName(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(san.isString() ? san : jsUndefined());
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_infoAccess, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
@@ -600,7 +607,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_issuer, (JSGlobalObject * globa
         return {};
     }
 
-    JSString* issuer = thisObject->issuer();
+    JSString* issuer = thisObject->issuer(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(undefinedIfEmpty(issuer));
 }
@@ -633,7 +640,9 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_publicKey, (JSGlobalObject * gl
         return {};
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(thisObject->publicKey()));
+    JSObject* publicKey = thisObject->publicKey(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(publicKey);
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_raw, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
@@ -647,7 +656,9 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_raw, (JSGlobalObject * globalOb
         return {};
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(undefinedIfEmpty(thisObject->raw())));
+    JSUint8Array* raw = thisObject->raw(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(undefinedIfEmpty(raw));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_serialNumber, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
@@ -661,7 +672,9 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_serialNumber, (JSGlobalObject *
         return {};
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(undefinedIfEmpty(thisObject->serialNumber())));
+    JSString* serialNumber = thisObject->serialNumber(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(undefinedIfEmpty(serialNumber));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_validFrom, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
@@ -675,7 +688,9 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_validFrom, (JSGlobalObject * gl
         return {};
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(undefinedIfEmpty(thisObject->validFrom())));
+    JSString* validFrom = thisObject->validFrom(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(undefinedIfEmpty(validFrom));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_validTo, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
@@ -689,7 +704,9 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_validTo, (JSGlobalObject * glob
         return {};
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(undefinedIfEmpty(thisObject->validTo())));
+    JSString* validTo = thisObject->validTo(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(undefinedIfEmpty(validTo));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_validToDate, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
@@ -703,7 +720,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_validToDate, (JSGlobalObject * 
         return {};
     }
 
-    auto* validToDate = thisObject->validTo();
+    auto* validToDate = thisObject->validTo(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     auto view = validToDate->view(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
@@ -726,7 +743,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_validFromDate, (JSGlobalObject 
         return {};
     }
 
-    auto* validFromDate = thisObject->validFrom();
+    auto* validFromDate = thisObject->validFrom(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     auto view = validFromDate->view(globalObject);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/node/crypto/JSCipherConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSCipherConstructor.cpp
@@ -222,6 +222,7 @@ JSC_DEFINE_HOST_FUNCTION(constructCipher, (JSC::JSGlobalObject * globalObject, J
 
     if (!ctx.init(Cipher(), encrypt, keyData.data(), ivView ? reinterpret_cast<uint8_t*>(ivView->vector()) : nullptr)) {
         throwCryptoError(globalObject, scope, ERR_get_error(), "Failed to initialize cipher"_s);
+        return {};
     }
 
     auto* zigGlobalObject = defaultGlobalObject(globalObject);

--- a/src/jsc/bindings/node/http/NodeHTTPParser.cpp
+++ b/src/jsc/bindings/node/http/NodeHTTPParser.cpp
@@ -335,6 +335,15 @@ bool HTTPParser::lessThan(HTTPParser& other) const
     return m_lastMessageStart < other.m_lastMessageStart;
 }
 
+int HTTPParser::stopForPendingException()
+{
+    llhttp_set_error_reason(&m_parserData, "HPE_USER:JS Exception");
+    return HPE_USER;
+}
+
+// The on* callbacks run under llhttp_execute(), C frames that cannot check a ThrowScope. Each is the top of
+// its own entry: a JS exception is left pending, llhttp is stopped via the return code, and execute()
+// observes the exception on its own scope once llhttp_execute() returns.
 int HTTPParser::onMessageBegin()
 {
     JSGlobalObject* globalObject = m_globalObject;
@@ -345,9 +354,9 @@ int HTTPParser::onMessageBegin()
 
     if (JSConnectionsList* connections = m_connectionsList.get()) {
         connections->pop(globalObject, thisParser);
-        RETURN_IF_EXCEPTION(scope, {});
+        RETURN_IF_EXCEPTION(scope, stopForPendingException());
         connections->popActive(globalObject, thisParser);
-        RETURN_IF_EXCEPTION(scope, {});
+        RETURN_IF_EXCEPTION(scope, stopForPendingException());
     }
 
     m_numFields = 0;
@@ -360,18 +369,18 @@ int HTTPParser::onMessageBegin()
 
     if (JSConnectionsList* connections = m_connectionsList.get()) {
         connections->push(globalObject, thisParser);
-        RETURN_IF_EXCEPTION(scope, {});
+        RETURN_IF_EXCEPTION(scope, stopForPendingException());
         connections->pushActive(globalObject, thisParser);
-        RETURN_IF_EXCEPTION(scope, {});
+        RETURN_IF_EXCEPTION(scope, stopForPendingException());
     }
 
     JSValue onMessageBeginCallback = thisParser->get(globalObject, Identifier::from(vm, kOnMessageBegin));
-    RETURN_IF_EXCEPTION(scope, 0);
+    RETURN_IF_EXCEPTION(scope, stopForPendingException());
     if (onMessageBeginCallback.isCallable()) {
         CallData callData = getCallData(onMessageBeginCallback);
         MarkedArgumentBuffer args;
         JSC::profiledCall(globalObject, ProfilingReason::API, onMessageBeginCallback, callData, thisParser, args);
-        RETURN_IF_EXCEPTION(scope, 0);
+        RETURN_IF_EXCEPTION(scope, stopForPendingException());
     }
 
     return 0;
@@ -416,10 +425,7 @@ int HTTPParser::onHeaderField(const char* at, size_t length)
         if (m_numFields == kMaxHeaderFieldsCount) {
             // ran out of space - flush to javascript land
             flush();
-            if (scope.exception()) [[unlikely]] {
-                llhttp_set_error_reason(&m_parserData, "HPE_USER:JS Exception");
-                return HPE_USER;
-            }
+            RETURN_IF_EXCEPTION(scope, stopForPendingException());
             m_numFields = 1;
             m_numValues = 0;
         }
@@ -509,7 +515,7 @@ int HTTPParser::onHeadersComplete()
     });
 
     JSValue onHeadersCompleteCallback = thisParser->get(globalObject, Identifier::from(vm, kOnHeadersComplete));
-    RETURN_IF_EXCEPTION(scope, -1);
+    RETURN_IF_EXCEPTION(scope, stopForPendingException());
 
     if (!onHeadersCompleteCallback.isCallable()) {
         return 0;
@@ -517,10 +523,10 @@ int HTTPParser::onHeadersComplete()
 
     if (m_haveFlushed) {
         flush();
-        RETURN_IF_EXCEPTION(scope, -1);
+        RETURN_IF_EXCEPTION(scope, stopForPendingException());
     } else {
         auto headers = createHeaders(globalObject);
-        RETURN_IF_EXCEPTION(scope, -1);
+        RETURN_IF_EXCEPTION(scope, stopForPendingException());
         args.at(A_HEADERS) = headers;
         if (m_parserData.type == HTTP_REQUEST) {
             args.at(A_URL) = m_url.toString(globalObject);
@@ -550,10 +556,10 @@ int HTTPParser::onHeadersComplete()
     CallData callData = getCallData(onHeadersCompleteCallback);
 
     JSValue result = JSC::profiledCall(globalObject, ProfilingReason::API, onHeadersCompleteCallback, callData, thisParser, args);
-    RETURN_IF_EXCEPTION(scope, -1);
+    RETURN_IF_EXCEPTION(scope, stopForPendingException());
 
     int32_t ret = result.toInt32(globalObject);
-    RETURN_IF_EXCEPTION(scope, -1);
+    RETURN_IF_EXCEPTION(scope, stopForPendingException());
 
     return ret;
 }
@@ -570,13 +576,13 @@ int HTTPParser::onBody(const char* at, size_t length)
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     JSValue onBodyCallback = m_thisParser->get(lexicalGlobalObject, Identifier::from(vm, kOnBody));
-    RETURN_IF_EXCEPTION(scope, 0);
+    RETURN_IF_EXCEPTION(scope, stopForPendingException());
     if (!onBodyCallback.isCallable()) {
         return 0;
     }
 
     JSUint8Array* buffer = JSUint8Array::create(lexicalGlobalObject, globalObject->JSBufferSubclassStructure(), length);
-    RETURN_IF_EXCEPTION(scope, 0);
+    RETURN_IF_EXCEPTION(scope, stopForPendingException());
 
     memcpy(buffer->vector(), at, length);
 
@@ -585,11 +591,7 @@ int HTTPParser::onBody(const char* at, size_t length)
     args.append(buffer);
 
     JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, onBodyCallback, callData, m_thisParser, args);
-
-    if (scope.exception()) [[unlikely]] {
-        llhttp_set_error_reason(&m_parserData, "HPE_USER:JS Exception");
-        return HPE_USER;
-    }
+    RETURN_IF_EXCEPTION(scope, stopForPendingException());
 
     return 0;
 }
@@ -603,25 +605,25 @@ int HTTPParser::onMessageComplete()
 
     if (JSConnectionsList* connections = m_connectionsList.get()) {
         connections->pop(globalObject, thisParser);
-        RETURN_IF_EXCEPTION(scope, {});
+        RETURN_IF_EXCEPTION(scope, stopForPendingException());
         connections->popActive(globalObject, thisParser);
-        RETURN_IF_EXCEPTION(scope, {});
+        RETURN_IF_EXCEPTION(scope, stopForPendingException());
     }
 
     m_lastMessageStart = 0;
 
     if (JSConnectionsList* connections = m_connectionsList.get()) {
         connections->push(globalObject, thisParser);
-        RETURN_IF_EXCEPTION(scope, {});
+        RETURN_IF_EXCEPTION(scope, stopForPendingException());
     }
 
     if (m_numFields) {
         flush();
-        RETURN_IF_EXCEPTION(scope, 0);
+        RETURN_IF_EXCEPTION(scope, stopForPendingException());
     }
 
     JSValue onMessageCompleteCallback = thisParser->get(globalObject, Identifier::from(vm, kOnMessageComplete));
-    RETURN_IF_EXCEPTION(scope, 0);
+    RETURN_IF_EXCEPTION(scope, stopForPendingException());
 
     if (!onMessageCompleteCallback.isCallable()) {
         return 0;
@@ -630,8 +632,7 @@ int HTTPParser::onMessageComplete()
     CallData callData = getCallData(onMessageCompleteCallback);
     MarkedArgumentBuffer args;
     JSC::profiledCall(globalObject, ProfilingReason::API, onMessageCompleteCallback, callData, thisParser, args);
-
-    RETURN_IF_EXCEPTION(scope, -1);
+    RETURN_IF_EXCEPTION(scope, stopForPendingException());
 
     return 0;
 }

--- a/src/jsc/bindings/node/http/NodeHTTPParser.h
+++ b/src/jsc/bindings/node/http/NodeHTTPParser.h
@@ -168,6 +168,8 @@ public:
 
     int trackHeader(size_t len);
     void flush();
+    // Return value for an llhttp callback whose JS threw: stops llhttp; execute() rethrows the exception.
+    int stopForPendingException();
 
     inline bool headersCompleted() const { return m_headersCompleted; }
     inline uint64_t lastMessageStart() const { return m_lastMessageStart; }

--- a/src/jsc/bindings/webcore/BroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/BroadcastChannel.cpp
@@ -89,7 +89,7 @@ void BroadcastChannel::dispatchMessage(Ref<SerializedScriptValue>&& message)
         if (vm.hasPendingTerminationException())
             return;
         scope.clearException();
-        dispatchEvent(MessageEvent::createMessageErrorEvent());
+        dispatchEvent(MessageEvent::create(eventNames().messageerrorEvent, MessageEvent::Init { {}, jsNull() }, MessageEvent::IsTrusted::Yes));
         return;
     }
     dispatchEvent(event->event);

--- a/src/jsc/bindings/webcore/BroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/BroadcastChannel.cpp
@@ -81,13 +81,18 @@ void BroadcastChannel::dispatchMessage(Ref<SerializedScriptValue>&& message)
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
+    // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-postmessage (step 7's task,
+    // sub-step 3): if deserializing throws, catch it and fire messageerror instead.
     Vector<RefPtr<MessagePort>> dummyPorts;
     auto event = MessageEvent::create(*globalObject, WTF::move(message), {}, {}, nullptr, WTF::move(dummyPorts));
     if (scope.exception()) [[unlikely]] {
-        RELEASE_ASSERT(vm.hasPendingTerminationException());
+        if (vm.hasPendingTerminationException())
+            return;
+        scope.clearException();
+        dispatchEvent(MessageEvent::createMessageErrorEvent());
         return;
     }
-    dispatchEvent(event.event);
+    dispatchEvent(event->event);
 }
 
 void BroadcastChannel::close()

--- a/src/jsc/bindings/webcore/MessageEvent.cpp
+++ b/src/jsc/bindings/webcore/MessageEvent.cpp
@@ -88,23 +88,24 @@ auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScrip
 auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports) -> MessageEventWithStrongData
 {
     auto& vm = globalObject.vm();
-    // Locker<JSC::JSLock> locker(vm.apiLock());
-    auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    bool didFail = false;
-
-    auto deserialized = data->deserialize(globalObject, &globalObject, ports, SerializationErrorMode::NonThrowing, &didFail);
-    // A record that fails to rehydrate is delivered as a `messageerror` event, not an exception; only the VM's
-    // termination stays pending for the caller.
-    if (topExceptionScope.exception()) [[unlikely]] {
-        topExceptionScope.clearExceptionExceptTermination();
-        didFail = true;
-        deserialized = jsUndefined();
+    // https://html.spec.whatwg.org/multipage/web-messaging.html#message-port-post-message-steps (7.3):
+    // "Let deserializeRecord be StructuredDeserializeWithTransfer(serializeWithTransferResult, targetRealm).
+    //  If this throws an exception, catch it, fire an event named messageerror at finalTargetPort, using
+    //  MessageEvent, and then return." A termination is not caught; the caller sees it on its scope.
+    bool didThrow = false;
+    JSValue deserialized = data->deserialize(globalObject, &globalObject, ports, SerializationErrorMode::Throwing);
+    if (scope.exception()) [[unlikely]] {
+        if (!vm.hasPendingTerminationException())
+            scope.clearException();
+        didThrow = true;
+        deserialized = jsNull();
     }
 
     JSC::Strong<JSC::Unknown> strongData(vm, deserialized);
 
-    auto& eventType = didFail ? eventNames().messageerrorEvent : eventNames().messageEvent;
+    auto& eventType = didThrow ? eventNames().messageerrorEvent : eventNames().messageEvent;
     auto event = adoptRef(*new MessageEvent(eventType, WTF::move(data), origin, lastEventId, WTF::move(source), WTF::move(ports)));
     JSC::Strong<JSC::JSObject> strongWrapper(vm, uncheckedDowncast<JSC::JSObject>(toJS(&globalObject, uncheckedDowncast<JSDOMGlobalObject>(&globalObject), event.get())));
     // Since we've already deserialized the SerializedScriptValue, cache the result so we don't have to deserialize

--- a/src/jsc/bindings/webcore/MessageEvent.cpp
+++ b/src/jsc/bindings/webcore/MessageEvent.cpp
@@ -80,39 +80,33 @@ Ref<MessageEvent> MessageEvent::create(const AtomString& type, Init&& initialize
 
 MessageEvent::~MessageEvent() = default;
 
-auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScriptValue>&& data, RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports) -> MessageEventWithStrongData
+auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScriptValue>&& data, RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports) -> std::optional<MessageEventWithStrongData>
 {
     return create(globalObject, WTF::move(data), {}, {}, WTF::move(source), WTF::move(ports));
 }
 
-auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports) -> MessageEventWithStrongData
+auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScriptValue>&& data, const String& origin, const String& lastEventId, RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports) -> std::optional<MessageEventWithStrongData>
 {
     auto& vm = globalObject.vm();
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
-    // https://html.spec.whatwg.org/multipage/web-messaging.html#message-port-post-message-steps (7.3):
-    // "Let deserializeRecord be StructuredDeserializeWithTransfer(serializeWithTransferResult, targetRealm).
-    //  If this throws an exception, catch it, fire an event named messageerror at finalTargetPort, using
-    //  MessageEvent, and then return." A termination is not caught; the caller sees it on its scope.
-    bool didThrow = false;
     JSValue deserialized = data->deserialize(globalObject, &globalObject, ports, SerializationErrorMode::Throwing);
-    if (scope.exception()) [[unlikely]] {
-        if (!vm.hasPendingTerminationException())
-            scope.clearException();
-        didThrow = true;
-        deserialized = jsNull();
-    }
-
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
     JSC::Strong<JSC::Unknown> strongData(vm, deserialized);
 
-    auto& eventType = didThrow ? eventNames().messageerrorEvent : eventNames().messageEvent;
-    auto event = adoptRef(*new MessageEvent(eventType, WTF::move(data), origin, lastEventId, WTF::move(source), WTF::move(ports)));
+    auto event = adoptRef(*new MessageEvent(eventNames().messageEvent, WTF::move(data), origin, lastEventId, WTF::move(source), WTF::move(ports)));
     JSC::Strong<JSC::JSObject> strongWrapper(vm, uncheckedDowncast<JSC::JSObject>(toJS(&globalObject, uncheckedDowncast<JSDOMGlobalObject>(&globalObject), event.get())));
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
     // Since we've already deserialized the SerializedScriptValue, cache the result so we don't have to deserialize
     // again the next time JSMessageEvent::data() gets called by the main world.
     event->cachedData().set(vm, strongWrapper.get(), deserialized);
 
     return MessageEventWithStrongData { event, WTF::move(strongWrapper) };
+}
+
+Ref<MessageEvent> MessageEvent::createMessageErrorEvent(RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports)
+{
+    return adoptRef(*new MessageEvent(eventNames().messageerrorEvent, Init { {}, jsNull(), {}, {}, WTF::move(source), WTF::move(ports) }, IsTrusted::Yes));
 }
 
 void MessageEvent::initMessageEvent(const AtomString& type, bool canBubble, bool cancelable, JSValue data, const String& origin, const String& lastEventId, RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports)

--- a/src/jsc/bindings/webcore/MessageEvent.cpp
+++ b/src/jsc/bindings/webcore/MessageEvent.cpp
@@ -94,8 +94,13 @@ auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScrip
     bool didFail = false;
 
     auto deserialized = data->deserialize(globalObject, &globalObject, ports, SerializationErrorMode::NonThrowing, &didFail);
-    if (topExceptionScope.exception()) [[unlikely]]
+    // A record that fails to rehydrate is delivered as a `messageerror` event, not an exception; only the VM's
+    // termination stays pending for the caller.
+    if (topExceptionScope.exception()) [[unlikely]] {
+        topExceptionScope.clearExceptionExceptTermination();
+        didFail = true;
         deserialized = jsUndefined();
+    }
 
     JSC::Strong<JSC::Unknown> strongData(vm, deserialized);
 

--- a/src/jsc/bindings/webcore/MessageEvent.cpp
+++ b/src/jsc/bindings/webcore/MessageEvent.cpp
@@ -104,11 +104,6 @@ auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScrip
     return MessageEventWithStrongData { event, WTF::move(strongWrapper) };
 }
 
-Ref<MessageEvent> MessageEvent::createMessageErrorEvent(RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports)
-{
-    return adoptRef(*new MessageEvent(eventNames().messageerrorEvent, Init { {}, jsNull(), {}, {}, WTF::move(source), WTF::move(ports) }, IsTrusted::Yes));
-}
-
 void MessageEvent::initMessageEvent(const AtomString& type, bool canBubble, bool cancelable, JSValue data, const String& origin, const String& lastEventId, RefPtr<MessagePort>&& source, Vector<RefPtr<MessagePort>>&& ports)
 {
     if (isBeingDispatched())

--- a/src/jsc/bindings/webcore/MessageEvent.h
+++ b/src/jsc/bindings/webcore/MessageEvent.h
@@ -68,7 +68,6 @@ public:
     // Deserializes `data` in the target realm. Throws what deserialization throws (nullopt then); the dispatching
     // task turns that into a `messageerror` event (message port post message steps, 7.3).
     static std::optional<MessageEventWithStrongData> create(JSC::JSGlobalObject&, Ref<SerializedScriptValue>&&, const String& origin = {}, const String& lastEventId = {}, RefPtr<MessagePort>&& = nullptr, Vector<RefPtr<MessagePort>>&& = {});
-    static Ref<MessageEvent> createMessageErrorEvent(RefPtr<MessagePort>&& source = nullptr, Vector<RefPtr<MessagePort>>&& = {});
 
     static std::optional<MessageEventWithStrongData> create(JSC::JSGlobalObject&, Ref<SerializedScriptValue>&&, RefPtr<MessagePort>&& = nullptr, Vector<RefPtr<MessagePort>>&& = {});
 

--- a/src/jsc/bindings/webcore/MessageEvent.h
+++ b/src/jsc/bindings/webcore/MessageEvent.h
@@ -65,9 +65,12 @@ public:
         JSC::Strong<JSC::JSObject> strongWrapper; // Keep the wrapper alive until the event is fired, since it is what keeps `data` alive.
     };
 
-    static MessageEventWithStrongData create(JSC::JSGlobalObject&, Ref<SerializedScriptValue>&&, const String& origin = {}, const String& lastEventId = {}, RefPtr<MessagePort>&& = nullptr, Vector<RefPtr<MessagePort>>&& = {});
+    // Deserializes `data` in the target realm. Throws what deserialization throws (nullopt then); the dispatching
+    // task turns that into a `messageerror` event (message port post message steps, 7.3).
+    static std::optional<MessageEventWithStrongData> create(JSC::JSGlobalObject&, Ref<SerializedScriptValue>&&, const String& origin = {}, const String& lastEventId = {}, RefPtr<MessagePort>&& = nullptr, Vector<RefPtr<MessagePort>>&& = {});
+    static Ref<MessageEvent> createMessageErrorEvent(RefPtr<MessagePort>&& source = nullptr, Vector<RefPtr<MessagePort>>&& = {});
 
-    static MessageEventWithStrongData create(JSC::JSGlobalObject&, Ref<SerializedScriptValue>&&, RefPtr<MessagePort>&& = nullptr, Vector<RefPtr<MessagePort>>&& = {});
+    static std::optional<MessageEventWithStrongData> create(JSC::JSGlobalObject&, Ref<SerializedScriptValue>&&, RefPtr<MessagePort>&& = nullptr, Vector<RefPtr<MessagePort>>&& = {});
 
     virtual ~MessageEvent();
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -367,6 +367,10 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
     }
 
     auto event = MessageEvent::create(*context.jsGlobalObject(), message.message.releaseNonNull(), {}, {}, {}, WTF::move(ports));
+    if (scope.exception()) [[unlikely]] {
+        RELEASE_ASSERT(vm->hasPendingTerminationException());
+        return;
+    }
     dispatchEvent(event.event);
 }
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -366,12 +366,17 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
         return;
     }
 
+    // https://html.spec.whatwg.org/multipage/web-messaging.html#message-port-post-message-steps (7.3): if
+    // deserializing throws, catch it and fire messageerror instead.
     auto event = MessageEvent::create(*context.jsGlobalObject(), message.message.releaseNonNull(), {}, {}, {}, WTF::move(ports));
     if (scope.exception()) [[unlikely]] {
-        RELEASE_ASSERT(vm->hasPendingTerminationException());
+        if (vm->hasPendingTerminationException())
+            return;
+        scope.clearException();
+        dispatchEvent(MessageEvent::createMessageErrorEvent());
         return;
     }
-    dispatchEvent(event.event);
+    dispatchEvent(event->event);
 }
 
 JSValue MessagePort::tryTakeMessage(JSGlobalObject* lexicalGlobalObject, bool& hadMessage)

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -373,7 +373,7 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
         if (vm->hasPendingTerminationException())
             return;
         scope.clearException();
-        dispatchEvent(MessageEvent::createMessageErrorEvent());
+        dispatchEvent(MessageEvent::create(eventNames().messageerrorEvent, MessageEvent::Init { {}, jsNull() }, MessageEvent::IsTrusted::Yes));
         return;
     }
     dispatchEvent(event->event);

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -3564,6 +3564,7 @@ private:
         // read bun types
         if (auto value = StructuredCloneableDeserialize::fromTagDeserialize(tag, m_lexicalGlobalObject, m_ptr, m_end)) {
             JSValue deserialized = JSValue::decode(value.value());
+            // Empty: the record was malformed, or the hook threw (the caller checks its scope first).
             if (deserialized.isEmpty()) {
                 fail();
                 return JSValue();

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -4855,9 +4855,12 @@ JSC::JSValue SerializedScriptValue::fromArrayBuffer(JSC::JSGlobalObject& domGlob
     if (didFail) {
         *didFail = result.second != SerializationReturnCode::SuccessfullyCompleted;
     }
-    if (throwScope.exception() || throwExceptions == SerializationErrorMode::Throwing) [[unlikely]]
-        maybeThrowExceptionIfSerializationFailed(*globalObject, result.second);
+    // Whatever the deserializer itself threw (a Blob/File/native record that failed to rehydrate, OOM) is the error.
     RETURN_IF_EXCEPTION(throwScope, {});
+    if (throwExceptions == SerializationErrorMode::Throwing) {
+        maybeThrowExceptionIfSerializationFailed(*globalObject, result.second);
+        RETURN_IF_EXCEPTION(throwScope, {});
+    }
 
     return result.first ? result.first : jsNull();
 }
@@ -5088,13 +5091,12 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
     );
     if (didFail)
         *didFail = result.second != SerializationReturnCode::SuccessfullyCompleted;
-    // Deserialize may throw an exception. Similar to serialize (SerializedScriptValue::create),
-    // we'll catch and rethrow.
-    if (scope.exception() || throwExceptions == SerializationErrorMode::Throwing) [[unlikely]]
-        maybeThrowExceptionIfSerializationFailed(lexicalGlobalObject, result.second);
-
-    // Rethrow is a bit simpler here since we don't deal with return codes.
+    // Whatever the deserializer itself threw (a Blob/File/native record that failed to rehydrate, OOM) is the error.
     RETURN_IF_EXCEPTION(scope, {});
+    if (throwExceptions == SerializationErrorMode::Throwing) {
+        maybeThrowExceptionIfSerializationFailed(lexicalGlobalObject, result.second);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
 
     return result.first;
 }

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -321,6 +321,8 @@ static bool drainInbox(WorkerMessagingProxy::MessageInbox& inbox, Zig::GlobalObj
             auto message = batch.takeFirst();
             auto ports = MessagePort::entanglePorts(context, WTF::move(message.transferredPorts));
             auto event = MessageEvent::create(globalObject, message.message.releaseNonNull(), nullptr, WTF::move(ports));
+            if (globalObject.vm().hasPendingTerminationException()) [[unlikely]]
+                return false;
             dispatch(event.event);
             if (globalObject.drainMicrotasks())
                 return false; // termination pending

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -291,6 +291,8 @@ static constexpr size_t drainBatchLimit = 1024;
 template<typename Dispatch>
 static bool drainInbox(WorkerMessagingProxy::MessageInbox& inbox, Zig::GlobalObject& globalObject, ScriptExecutionContext& context, DrainBudget budget, Dispatch&& dispatch)
 {
+    auto& vm = globalObject.vm();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     size_t remaining = budget == DrainBudget::UntilEmpty ? std::numeric_limits<size_t>::max() : drainBatchLimit;
 
     while (true) {
@@ -320,10 +322,15 @@ static bool drainInbox(WorkerMessagingProxy::MessageInbox& inbox, Zig::GlobalObj
                 return false;
             auto message = batch.takeFirst();
             auto ports = MessagePort::entanglePorts(context, WTF::move(message.transferredPorts));
+            // message port post message steps (7.3): if deserializing throws, catch it and fire messageerror.
             auto event = MessageEvent::create(globalObject, message.message.releaseNonNull(), nullptr, WTF::move(ports));
-            if (globalObject.vm().hasPendingTerminationException()) [[unlikely]]
-                return false;
-            dispatch(event.event);
+            if (scope.exception()) [[unlikely]] {
+                if (vm.hasPendingTerminationException())
+                    return false;
+                scope.clearException();
+                dispatch(MessageEvent::createMessageErrorEvent());
+            } else
+                dispatch(event->event);
             if (globalObject.drainMicrotasks())
                 return false; // termination pending
         }

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -328,7 +328,7 @@ static bool drainInbox(WorkerMessagingProxy::MessageInbox& inbox, Zig::GlobalObj
                 if (vm.hasPendingTerminationException())
                     return false;
                 scope.clearException();
-                dispatch(MessageEvent::createMessageErrorEvent());
+                dispatch(MessageEvent::create(eventNames().messageerrorEvent, MessageEvent::Init { {}, jsNull() }, MessageEvent::IsTrusted::Yes));
             } else
                 dispatch(event->event);
             if (globalObject.drainMicrotasks())

--- a/src/jsc/host_fn.rs
+++ b/src/jsc/host_fn.rs
@@ -698,34 +698,6 @@ pub fn to_js_host_call(
     normal
 }
 
-/// The `onStructuredCloneDeserialize` hook: `Ok(None)` means the record was malformed — the C++
-/// deserializer turns an empty result with no exception pending into its `ValidationError`; `Err`
-/// leaves the exception for it to propagate.
-#[track_caller]
-pub fn structured_clone_deserialize_result(
-    global_this: &JSGlobalObject,
-    f: impl FnOnce() -> JsResult<Option<JSValue>>,
-) -> JSValue {
-    let mut scope_storage = core::mem::MaybeUninit::uninit();
-    let mut scope = jsc::ExceptionValidationScope::init_guard(&mut scope_storage, global_this);
-    match f() {
-        Ok(Some(v)) => {
-            scope.assert_no_exception();
-            debug_assert!(!v.is_empty());
-            v
-        }
-        Ok(None) => {
-            scope.assert_no_exception();
-            JSValue::ZERO
-        }
-        Err(e) => {
-            let v = host_call_error_value(global_this, e);
-            scope.assert_exception_presence_matches(v.is_empty());
-            v
-        }
-    }
-}
-
 /// Convert the return value of a function returning a maybe-empty `JSValue` into an error union.
 /// The wrapped function must return an empty `JSValue` if and only if it has thrown an exception.
 /// If your function does not follow this pattern (if it can return empty without an exception, or

--- a/src/jsc/host_fn.rs
+++ b/src/jsc/host_fn.rs
@@ -698,6 +698,34 @@ pub fn to_js_host_call(
     normal
 }
 
+/// The `onStructuredCloneDeserialize` hook: `Ok(None)` means the record was malformed — the C++
+/// deserializer turns an empty result with no exception pending into its `ValidationError`; `Err`
+/// leaves the exception for it to propagate.
+#[track_caller]
+pub fn structured_clone_deserialize_result(
+    global_this: &JSGlobalObject,
+    f: impl FnOnce() -> JsResult<Option<JSValue>>,
+) -> JSValue {
+    let mut scope_storage = core::mem::MaybeUninit::uninit();
+    let mut scope = jsc::ExceptionValidationScope::init_guard(&mut scope_storage, global_this);
+    match f() {
+        Ok(Some(v)) => {
+            scope.assert_no_exception();
+            debug_assert!(!v.is_empty());
+            v
+        }
+        Ok(None) => {
+            scope.assert_no_exception();
+            JSValue::ZERO
+        }
+        Err(e) => {
+            let v = host_call_error_value(global_this, e);
+            scope.assert_exception_presence_matches(v.is_empty());
+            v
+        }
+    }
+}
+
 /// Convert the return value of a function returning a maybe-empty `JSValue` into an error union.
 /// The wrapped function must return an empty `JSValue` if and only if it has thrown an exception.
 /// If your function does not follow this pattern (if it can return empty without an exception, or

--- a/src/runtime/node/net/BlockList.rs
+++ b/src/runtime/node/net/BlockList.rs
@@ -454,9 +454,7 @@ impl BlockList {
         let nonce = match r.read_int_le::<u64>() {
             Ok(n) => n,
             Err(_) => {
-                return Err(global.throw(format_args!(
-                    "BlockList.onStructuredCloneDeserialize failed"
-                )));
+                return Err(global.throw_type_error(format_args!("Unable to deserialize data.")));
             }
         };
 
@@ -473,9 +471,7 @@ impl BlockList {
         let this: *mut Self = {
             let refs = SERIALIZED_REFS.lock();
             let Some(addr) = refs.iter().find_map(|&(n, a)| (n == nonce).then_some(a)) else {
-                return Err(global.throw(format_args!(
-                    "BlockList.onStructuredCloneDeserialize failed"
-                )));
+                return Err(global.throw_type_error(format_args!("Unable to deserialize data.")));
             };
             let this = addr as *mut Self;
             // SAFETY: the entry was pushed by `on_structured_clone_serialize`

--- a/src/runtime/node/net/BlockList.rs
+++ b/src/runtime/node/net/BlockList.rs
@@ -435,11 +435,12 @@ impl BlockList {
     // signature is fixed by `generate-classes.ts`, so the deref is documented with
     // the SAFETY comment below.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    /// `Ok(None)`: the bytes are not a valid record (the deserializer reports its usual error).
     pub(crate) fn on_structured_clone_deserialize(
         global: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
-    ) -> JsResult<JSValue> {
+    ) -> JsResult<Option<JSValue>> {
         // SAFETY: `*ptr` and `end` bound a contiguous byte buffer owned by the
         // caller (C++ SerializedScriptValue); `end >= *ptr`. `ptr` itself is a
         // non-null out-param the caller expects us to advance.
@@ -451,11 +452,8 @@ impl BlockList {
         let mut r =
             bun_io::FixedBufferStream::new(unsafe { bun_core::ffi::slice(start, total_length) });
 
-        let nonce = match r.read_int_le::<u64>() {
-            Ok(n) => n,
-            Err(_) => {
-                return Err(global.throw_type_error(format_args!("Unable to deserialize data.")));
-            }
+        let Ok(nonce) = r.read_int_le::<u64>() else {
+            return Ok(None);
         };
 
         // Advance the caller's cursor by the number of bytes consumed
@@ -471,7 +469,7 @@ impl BlockList {
         let this: *mut Self = {
             let refs = SERIALIZED_REFS.lock();
             let Some(addr) = refs.iter().find_map(|&(n, a)| (n == nonce).then_some(a)) else {
-                return Err(global.throw_type_error(format_args!("Unable to deserialize data.")));
+                return Ok(None);
             };
             let this = addr as *mut Self;
             // SAFETY: the entry was pushed by `on_structured_clone_serialize`
@@ -485,7 +483,7 @@ impl BlockList {
         // SAFETY: ownership of the ref taken above transfers to the C++ wrapper
         // (released via `finalize` → `deref`). `to_js_ptr` is the
         // `#[bun_jsc::JsClass]`-generated `${T}__create` shim.
-        Ok(unsafe { Self::to_js_ptr(this, global) })
+        Ok(Some(unsafe { Self::to_js_ptr(this, global) }))
     }
 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -831,7 +831,9 @@ impl BlobExt for Blob {
             }
             // Same error every other malformed record produces (SerializedScriptValue's ValidationError).
             Err(_) => {
-                return Err(global_this.throw_type_error(format_args!("Unable to deserialize data.")));
+                return Err(
+                    global_this.throw_type_error(format_args!("Unable to deserialize data."))
+                );
             }
         };
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -184,11 +184,12 @@ pub trait BlobExt {
         ctx: *mut c_void,
         write_bytes: crate::generated_classes::WriteBytesFn,
     );
+    /// `Ok(None)`: the bytes are not a valid record (the deserializer reports its usual error).
     fn on_structured_clone_deserialize(
         global_this: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
-    ) -> JsResult<JSValue>
+    ) -> JsResult<Option<JSValue>>
     where
         Self: Sized;
     fn from_url_search_params(
@@ -812,7 +813,7 @@ impl BlobExt for Blob {
         global_this: &JSGlobalObject,
         ptr: *mut *mut u8,
         end: *const u8,
-    ) -> JsResult<JSValue> {
+    ) -> JsResult<Option<JSValue>> {
         // SAFETY: codegen passes a live `*mut *mut u8` cursor (C++:
         // `(uint8_t**)&ptr`) and a one-past-the-end `*const u8`; both are
         // non-null and `[*ptr, end)` is the serialized byte range owned by
@@ -829,10 +830,7 @@ impl BlobExt for Blob {
             Err(e) if e.name() == "OutOfMemory" => {
                 return Err(global_this.throw_out_of_memory());
             }
-            // Same error every other malformed record produces (SerializedScriptValue's ValidationError).
-            Err(_) => {
-                return Err(global_this.throw_type_error(format_args!("Unable to deserialize data.")));
-            }
+            Err(_) => return Ok(None),
         };
 
         // Advance the caller's cursor by the number of bytes consumed.
@@ -840,7 +838,7 @@ impl BlobExt for Blob {
         // construction, so the advanced pointer stays within `[start, end]`.
         unsafe { *ptr = start.add(buffer_stream.pos) };
 
-        Ok(result)
+        Ok(Some(result))
     }
     fn from_url_search_params(
         global_this: &JSGlobalObject,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -829,10 +829,9 @@ impl BlobExt for Blob {
             Err(e) if e.name() == "OutOfMemory" => {
                 return Err(global_this.throw_out_of_memory());
             }
+            // Same error every other malformed record produces (SerializedScriptValue's ValidationError).
             Err(_) => {
-                return Err(
-                    global_this.throw(format_args!("Blob.onStructuredCloneDeserialize failed"))
-                );
+                return Err(global_this.throw_type_error(format_args!("Unable to deserialize data.")));
             }
         };
 

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -3923,6 +3923,15 @@ it("should not trim utf-8 start bytes at end of string", () => {
   expect(buf2.toString("utf-8")).toEqual("6\uFFFD");
 });
 
+it("Buffer.from(BigInt64Array) throws instead of returning a zero-filled buffer", () => {
+  // Copying BigInt elements into a Uint8Array is a TypeError (same as `new Uint8Array(2).set(new BigInt64Array(1))`).
+  expect(() => Buffer.from(new BigInt64Array([1n]))).toThrow(TypeError);
+  expect(() => Buffer.from(new BigUint64Array([1n]))).toThrow(TypeError);
+  expect(() => new Buffer(new BigInt64Array([1n]))).toThrow(TypeError);
+  // An empty one has nothing to copy.
+  expect(Buffer.from(new BigInt64Array(0)).length).toBe(0);
+});
+
 it("Buffer.from(arrayBuffer)", () => {
   const ab = Buffer.from([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]).buffer;
   const buf = Buffer.from(ab);

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -42,6 +42,19 @@ lGNHf1nq+j8dNaMGmheHKQ==
 -----END CERTIFICATE-----
 `;
 
+// Self-signed, brainpoolP256r1 key (a curve BoringSSL does not support, so publicKey cannot be decoded).
+const brainpoolCertPem = `-----BEGIN CERTIFICATE-----
+MIIBfTCCASSgAwIBAgIUbtq88KPedDaNbLVSO/txNjRWPicwCgYIKoZIzj0EAwIw
+FDESMBAGA1UEAwwJYnJhaW5wb29sMB4XDTI2MDgyMzIwMDAyMVoXDTM2MDgyMDIw
+MDAyMVowFDESMBAGA1UEAwwJYnJhaW5wb29sMFowFAYHKoZIzj0CAQYJKyQDAwII
+AQEHA0IABG8tl/XkdDFsqeIkd03yEF82Ivy1xzmsN8/NekZJzuwDSLlCCIbX2k6z
+JUoTfqdTxRL4ccrI4cXpqDxZPPaywMOjUzBRMB0GA1UdDgQWBBRpnrKAVW6DXXNk
+BABmxqGZ3WvcPDAfBgNVHSMEGDAWgBRpnrKAVW6DXXNkBABmxqGZ3WvcPDAPBgNV
+HRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0cAMEQCIBssqQu642CLwl1dfD7WoD0D
+qGl/+1Di3abpA8YZOtoyAiAiScaiKhxu48bWQXYW5ZoQNzAfBIwL4krTuLVAKYZc
+Vg==
+-----END CERTIFICATE-----`;
+
 describe("X509Certificate.checkHost()", () => {
   const cert = new X509Certificate(wildcardSanCertPem);
   const cnOnly = new X509Certificate(cnOnlyCertPem);
@@ -102,6 +115,18 @@ describe("X509Certificate.subjectAltName", () => {
     const cert = new X509Certificate(emptySanCertPem);
     expect(cert.subjectAltName).toBe("");
     expect(cert.toLegacyObject().subjectaltname).toBe("");
+  });
+});
+
+describe("X509Certificate getters that fail", () => {
+  test("publicKey throws on every access when the key cannot be decoded (nothing stale is cached)", () => {
+    const cert = new X509Certificate(brainpoolCertPem);
+    expect(() => cert.publicKey).toThrow(expect.objectContaining({ code: "ERR_OSSL_X509_PUBLIC_KEY_DECODE_ERROR" }));
+    expect(() => cert.publicKey).toThrow(expect.objectContaining({ code: "ERR_OSSL_X509_PUBLIC_KEY_DECODE_ERROR" }));
+    // The rest of the certificate is still readable and cached.
+    expect(cert.fingerprint256).toMatch(/^([0-9A-F]{2}:){31}[0-9A-F]{2}$/);
+    expect(cert.fingerprint256).toBe(cert.fingerprint256);
+    expect(cert.toLegacyObject().fingerprint256).toBe(cert.fingerprint256);
   });
 });
 

--- a/test/js/node/http/node-http-parser.test.ts
+++ b/test/js/node/http/node-http-parser.test.ts
@@ -212,6 +212,46 @@ describe("HTTPParser.prototype.execute", () => {
   });
 });
 
+describe("a callback that throws stops the parse", () => {
+  const kOnMessageBegin = HTTPParser.kOnMessageBegin;
+  const kOnBody = HTTPParser.kOnBody;
+  const kOnMessageComplete = HTTPParser.kOnMessageComplete;
+  // Two pipelined requests so that a parser that kept going after the throw would reach the second one.
+  const input = Buffer.from(
+    "POST /a HTTP/1.1\r\nHost: x\r\nContent-Length: 1\r\n\r\nA" +
+      "POST /b HTTP/1.1\r\nHost: x\r\nContent-Length: 1\r\n\r\nB",
+  );
+  for (const throwing of ["begin", "headersComplete", "body", "complete"] as const) {
+    test(throwing, () => {
+      const parser = new HTTPParser();
+      parser.initialize(HTTPParser.REQUEST, {});
+      const calls: string[] = [];
+      const err = new Error(throwing + " threw");
+      const hook = (name: string) => () => {
+        calls.push(name);
+        if (name === throwing) throw err;
+        return 0;
+      };
+      parser[kOnMessageBegin] = hook("begin");
+      parser[kOnHeadersComplete] = hook("headersComplete");
+      parser[kOnBody] = hook("body");
+      parser[kOnMessageComplete] = hook("complete");
+      let caught;
+      try {
+        parser.execute(input);
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBe(err);
+      // Nothing ran after the callback that threw.
+      expect(calls.at(-1)).toBe(throwing);
+      expect(calls.filter(c => c === "begin").length).toBe(1);
+      // The parser is left in the errored state.
+      expect(parser.execute(Buffer.from("GET / HTTP/1.1\r\n\r\n"))).toBeInstanceOf(Error);
+    });
+  }
+});
+
 test("HTTPParser.prototype.getCurrentBuffer", async () => {
   const parser = new HTTPParser();
   parser.initialize(HTTPParser.REQUEST, {});


### PR DESCRIPTION
### What does this PR do?

Five places in the node-compat bindings that kept going after a JS exception was thrown, so the exception was either lost, thrown over, or left pending next to a bogus return value.

- **`X509Certificate`** — the lazily computed properties cached whatever the initializer produced even when it threw: `publicKey` was cached as an empty cell, so on a certificate whose key BoringSSL cannot decode (e.g. a brainpool curve) the first read throws `ERR_OSSL_X509_PUBLIC_KEY_DECODE_ERROR` and the **second read segfaults**; `fingerprint*` / `validFrom` / `validTo` / `serialNumber` were cached as `""` after throwing. They are now computed on first *successful* access; an access that throws caches nothing and the next one throws again. `computeInfoAccess` / `getKeyUsage` check the array writes inside their loops (an `X509Certificate` reached from a TLS peer certificate tripped the exception validator here), and `toLegacyObject` checks each computed value before storing it.
- **`process.binding("http_parser")`** — the `kOnMessageBegin` / `kOnBody` / `kOnMessageComplete` / connection-list paths returned `HPE_OK` after their JS hook threw, so llhttp carried on and the next callback re-entered JS with the exception pending (only `kOnHeaders` overflow and one `kOnBody` path stopped correctly). Every callback now stops llhttp on a pending exception and `execute()` rethrows it; the parser is left errored as before.
- **`Buffer.from(new BigInt64Array(n))`** (and `BigUint64Array`, `new Buffer(...)`) built the zero-filled result and returned it with the `TypeError` from the element copy still pending. It now throws it, as Node does.
- **`bun:jsc` / `node:v8` `deserialize`, advanced IPC** — when a Bun-specific record (Blob, File, BlockList) failed to rehydrate it threw, and `SerializedScriptValue::deserialize` then threw `"Unable to deserialize data."` on top of it. Those hooks now report a malformed record *without* throwing (`on_structured_clone_deserialize` returns `Ok(None)`), so the deserializer produces its one `TypeError` exactly as for any other record type, and a real exception from the hook (OOM) propagates instead of being thrown over. The observable error is unchanged. A `MessageEvent` whose data fails to rehydrate is delivered as `messageerror` rather than leaving the exception pending in the dispatch path.
- **`createCipheriv` / `createDecipheriv`** — the second `EVP_CipherInit_ex` failure threw without returning and went on to construct the object.

### How did you verify your code works?

New tests: `x509.test.ts` (brainpool certificate: `publicKey` throws on every access, other getters still work and cache — segfaults on current release), `node-http-parser.test.ts` (a throw from each of begin / headersComplete / body / complete stops the parse at that callback across two pipelined requests and leaves the parser errored), `buffer.test.js` (`Buffer.from(BigInt64Array)` throws). Ran under `BUN_JSC_validateExceptionChecks=1` on a debug build: node-http-parser 20/20, the `test-http-parser-*` / `test-http-chunk-extensions-limit` node tests, x509 21/21, x509-subclass 12/12, `test-crypto-x509.js`, `test-tls-getcertificate-x509.js`, buffer 679/679, structured-clone-blob-file 42/42, workers/structured-clone 234/234, message-channel 17/17, broadcast-channel 11/11, node-crypto 212/212.
