### PR TITLE
Propagate JS exceptions from sql() object bindings, IPC serialization, macros, and a rejected onResolve

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1156,13 +1156,12 @@ try {
 
 ### Query Errors
 
-| Query Errors                         | Description                                |
-| ------------------------------------ | ------------------------------------------ |
-| `ERR_POSTGRES_SYNTAX_ERROR`          | Invalid SQL syntax (extends `SyntaxError`) |
-| `ERR_POSTGRES_SERVER_ERROR`          | General error from PostgreSQL server       |
-| `ERR_POSTGRES_INVALID_QUERY_BINDING` | Invalid parameter binding                  |
-| `ERR_POSTGRES_QUERY_CANCELLED`       | Query was cancelled                        |
-| `ERR_POSTGRES_NOT_TAGGED_CALL`       | Query was called without a tagged call     |
+| Query Errors                   | Description                                |
+| ------------------------------ | ------------------------------------------ |
+| `ERR_POSTGRES_SYNTAX_ERROR`    | Invalid SQL syntax (extends `SyntaxError`) |
+| `ERR_POSTGRES_SERVER_ERROR`    | General error from PostgreSQL server       |
+| `ERR_POSTGRES_QUERY_CANCELLED` | Query was cancelled                        |
+| `ERR_POSTGRES_NOT_TAGGED_CALL` | Query was called without a tagged call     |
 
 ### Data Type Errors
 

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2844,6 +2844,7 @@ pub mod asan {
         safe fn __asan_describe_address(ptr: *const c_void);
         safe fn __lsan_register_root_region(ptr: *const c_void, size: usize);
         safe fn __lsan_unregister_root_region(ptr: *const c_void, size: usize);
+        safe fn __lsan_ignore_object(ptr: *const c_void);
     }
 
     #[inline]
@@ -2888,6 +2889,15 @@ pub mod asan {
         __lsan_unregister_root_region(ptr, size);
         #[cfg(not(bun_asan))]
         let _ = (ptr, size);
+    }
+    /// The heap allocation containing `ptr` is owned through a reference LeakSanitizer cannot follow (e.g. a
+    /// tagged pointer); do not report it. Its owner is still responsible for freeing it.
+    #[inline]
+    pub fn lsan_ignore_object(ptr: *const c_void) {
+        #[cfg(bun_asan)]
+        __lsan_ignore_object(ptr);
+        #[cfg(not(bun_asan))]
+        let _ = ptr;
     }
 }
 

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -559,15 +559,15 @@ impl<'a> Run<'a> {
         };
 
         let global = vm.global();
-        let result = match vm.run_with_api_lock(|| macro_callback.call(global, JSValue::ZERO, args))
-        {
+        let result = match vm.run_with_api_lock(|| macro_callback.call(global, JSValue::ZERO, args)) {
             Ok(result) => result,
-            Err(e) => {
-                // The macro threw: report it (with its stack) and fail this expansion.
-                let err = global.take_exception(e);
+            // The macro threw: report it (with its stack) and fail this expansion.
+            Err(JsError::Thrown) => {
+                let err = global.take_exception(JsError::Thrown);
                 vm.as_mut().uncaught_exception(global, err, false);
                 return Err(MacroError::MacroFailed);
             }
+            Err(e) => return Err(e.into()),
         };
 
         let mut runner = Run {
@@ -587,8 +587,8 @@ impl<'a> Run<'a> {
             // Converting the macro's return value threw (a getter, an iterator, a toString): report it the
             // way a throw from the macro function itself is reported above, rather than leaving it pending
             // under the parser.
-            Err(MacroError::Js(e)) => {
-                let err = global.take_exception(e);
+            Err(MacroError::Js(JsError::Thrown)) => {
+                let err = global.take_exception(JsError::Thrown);
                 vm.as_mut().uncaught_exception(global, err, false);
                 Err(MacroError::MacroFailed)
             }

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -559,7 +559,8 @@ impl<'a> Run<'a> {
         };
 
         let global = vm.global();
-        let result = match vm.run_with_api_lock(|| macro_callback.call(global, JSValue::ZERO, args)) {
+        let result = match vm.run_with_api_lock(|| macro_callback.call(global, JSValue::ZERO, args))
+        {
             Ok(result) => result,
             // The macro threw: report it (with its stack) and fail this expansion.
             Err(JsError::Thrown) => {

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -559,11 +559,15 @@ impl<'a> Run<'a> {
         };
 
         let global = vm.global();
-        let result = vm.run_with_api_lock(|| {
-            macro_callback
-                .call(global, JSValue::ZERO, args)
-                .unwrap_or_else(|_| global.try_take_exception().unwrap_or_default())
-        });
+        let result = match vm.run_with_api_lock(|| macro_callback.call(global, JSValue::ZERO, args)) {
+            Ok(result) => result,
+            Err(e) => {
+                // The macro threw: report it (with its stack) and fail this expansion.
+                let err = global.take_exception(e);
+                vm.as_mut().uncaught_exception(global, err, false);
+                return Err(MacroError::MacroFailed);
+            }
+        };
 
         let mut runner = Run {
             caller,
@@ -578,7 +582,17 @@ impl<'a> Run<'a> {
 
         // `runner.visited` dropped at scope exit (was `defer runner.visited.deinit(allocator)`)
 
-        runner.run(result)
+        match runner.run(result) {
+            // Converting the macro's return value threw (a getter, an iterator, a toString): report it the
+            // way a throw from the macro function itself is reported above, rather than leaving it pending
+            // under the parser.
+            Err(MacroError::Js(e)) => {
+                let err = global.take_exception(e);
+                vm.as_mut().uncaught_exception(global, err, false);
+                Err(MacroError::MacroFailed)
+            }
+            other => other,
+        }
     }
 
     pub(crate) fn run(&mut self, value: JSValue) -> Result<Expr, MacroError> {

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -559,7 +559,8 @@ impl<'a> Run<'a> {
         };
 
         let global = vm.global();
-        let result = match vm.run_with_api_lock(|| macro_callback.call(global, JSValue::ZERO, args)) {
+        let result = match vm.run_with_api_lock(|| macro_callback.call(global, JSValue::ZERO, args))
+        {
             Ok(result) => result,
             Err(e) => {
                 // The macro threw: report it (with its stack) and fail this expansion.

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1371,13 +1371,14 @@ impl JSValue {
         }
         Ok(Some(prop))
     }
+    /// The value of the own property `property_value` (running an own getter), or `undefined` when there is
+    /// no such own property. `self` must be an object.
     pub fn get_own_by_value(
         self,
         global: &JSGlobalObject,
         property_value: JSValue,
-    ) -> Option<JSValue> {
-        let v = JSC__JSValue__getOwnByValue(self, global, property_value);
-        if v.is_empty() { None } else { Some(v) }
+    ) -> JsResult<JSValue> {
+        crate::cpp::JSC__JSValue__getOwnByValue(self, global, property_value)
     }
     /// `Object.hasOwnProperty(key)`. `self` **must** be an object — the C++ side
     /// `uncheckedDowncast`s. `key.toPropertyKey()` and Proxy `ownKeys` traps
@@ -2053,11 +2054,6 @@ unsafe extern "C" {
         buf: &mut [u8; 64],
     ) -> i32;
     safe fn JSC__JSValue__isPrimitive(this: JSValue) -> bool;
-    safe fn JSC__JSValue__getOwnByValue(
-        this: JSValue,
-        global: &JSGlobalObject,
-        key: JSValue,
-    ) -> JSValue;
     safe fn JSC__JSValue__hasOwnPropertyValue(
         this: JSValue,
         global: &JSGlobalObject,

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -231,6 +231,8 @@ impl SavedSourceMap {
     pub(crate) fn put_value(&mut self, path: &[u8], value: Value) -> bun_js_printer::Result<()> {
         use bun_collections::zig_hash_map::MapEntry as Entry;
 
+        // The table owns `value`'s allocation through a tagged pointer, which LeakSanitizer cannot follow.
+        bun_core::asan::lsan_ignore_object(value.as_uintptr() as usize as *const c_void);
         self.lock();
         // Note: reshaped for borrowck — explicit unlock paired manually.
 
@@ -283,6 +285,8 @@ impl SavedSourceMap {
             // the returned `Arc`.
             let result = Arc::new(ParsedSourceMap::from_internal(ism));
             *mapping = Value::init(Arc::into_raw(Arc::clone(&result))).ptr();
+            // As in `put_value`: owned by the table through a tagged pointer.
+            bun_core::asan::lsan_ignore_object(Arc::as_ptr(&result).cast());
             self.unlock();
             return SourceMap::ParseUrl {
                 map: Some(result),

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -869,9 +869,10 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, BunS
                 return {};
             }
             case JSPromise::Status::Rejected: {
-                promise->setFlags(static_cast<uint16_t>(JSC::JSPromise::Status::Fulfilled));
-                result = promise->result();
-                return JSValue::encode(result);
+                // Resolution is synchronous here; the rejection is this resolve's error.
+                promise->markAsHandled();
+                JSC::throwException(globalObject, scope, promise->result());
+                return {};
             }
             case JSPromise::Status::Fulfilled: {
                 result = promise->result();

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -175,7 +175,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_POSTGRES_INVALID_CHARACTER", TypeError, "PostgresError"],
   ["ERR_POSTGRES_INVALID_MESSAGE_LENGTH", Error, "PostgresError"],
   ["ERR_POSTGRES_INVALID_MESSAGE", Error, "PostgresError"],
-  ["ERR_POSTGRES_INVALID_QUERY_BINDING", Error, "PostgresError"],
   ["ERR_POSTGRES_INVALID_SERVER_KEY", Error, "PostgresError"],
   ["ERR_POSTGRES_INVALID_SERVER_SIGNATURE", Error, "PostgresError"],
   ["ERR_POSTGRES_INVALID_TRANSACTION_STATE", Error, "PostgresError"],

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6157,7 +6157,9 @@ CPP_DECL double JSC__JSValue__getUnixTimestamp(JSC::EncodedJSValue timeValue)
     return number;
 }
 
-extern "C" JSC::EncodedJSValue JSC__JSValue__getOwnByValue(JSC::EncodedJSValue value, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue propertyValue)
+// The own property's value, undefined if there is no such own property (the caller treats an undefined value
+// the same way), {} on exception.
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue JSC__JSValue__getOwnByValue(JSC::EncodedJSValue value, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue propertyValue)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -6167,22 +6169,19 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__getOwnByValue(JSC::EncodedJSValue v
 
     PropertySlot slot(object, PropertySlot::InternalMethodType::GetOwnProperty);
     if (property.getUInt32(index)) {
-        if (!object->getOwnPropertySlotByIndex(object, globalObject, index, slot))
-            return {};
-
+        bool found = object->getOwnPropertySlotByIndex(object, globalObject, index, slot);
         RETURN_IF_EXCEPTION(scope, {});
-
-        return JSC::JSValue::encode(slot.getValue(globalObject, index));
-    } else {
-        auto propertyName = property.toPropertyKey(globalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-        if (!object->getOwnNonIndexPropertySlot(vm, object->structure(), propertyName, slot))
-            return {};
-
-        RETURN_IF_EXCEPTION(scope, {});
-
-        return JSC::JSValue::encode(slot.getValue(globalObject, propertyName));
+        if (!found)
+            return JSC::JSValue::encode(JSC::jsUndefined());
+        RELEASE_AND_RETURN(scope, JSC::JSValue::encode(slot.getValue(globalObject, index)));
     }
+    auto propertyName = property.toPropertyKey(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    bool found = object->getOwnNonIndexPropertySlot(vm, object->structure(), propertyName, slot);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!found)
+        return JSC::JSValue::encode(JSC::jsUndefined());
+    RELEASE_AND_RETURN(scope, JSC::JSValue::encode(slot.getValue(globalObject, propertyName)));
 }
 
 extern "C" [[ZIG_EXPORT(check_slow)]] double Bun__parseDate(JSC::JSGlobalObject* globalObject, BunString* str)

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -404,8 +404,6 @@ mod advanced {
 
         let payload_length: usize = size_of::<IPCMessageType>() + size_of::<u32>() + size as usize;
 
-        // Propagate OOM so serializeAndSend
-        // returns `.failure` instead of silently discarding the Result.
         writer
             .ensure_unused_capacity(payload_length)
             .map_err(|_| global.throw_out_of_memory())?;
@@ -569,8 +567,6 @@ mod json {
             result_len += 1;
         }
 
-        // Propagate OOM so serializeAndSend
-        // returns `.failure` instead of silently discarding the Result.
         writer
             .ensure_unused_capacity(result_len)
             .map_err(|_| global.throw_out_of_memory())?;

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -231,22 +231,17 @@ impl From<JsError> for IPCDecodeError {
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum IPCSerializationError {
-    /// Value could not be serialized.
-    #[error("SerializationFailed")]
-    SerializationFailed,
-    // —— bun.JSError variants ——
-    #[error("JSError")]
-    JSError,
-    #[error("OutOfMemory")]
-    OutOfMemory,
+    /// The value has no serialization (e.g. JSON.stringify yields undefined); nothing was thrown.
+    #[error("NotSerializable")]
+    NotSerializable,
+    /// A JS exception is pending (or the VM is terminating).
+    #[error("{0:?}")]
+    Js(JsError),
 }
 
 impl From<JsError> for IPCSerializationError {
     fn from(e: JsError) -> Self {
-        match e {
-            JsError::Thrown | JsError::Terminated => IPCSerializationError::JSError,
-            JsError::OutOfMemory => IPCSerializationError::OutOfMemory,
-        }
+        IPCSerializationError::Js(e)
     }
 }
 
@@ -413,7 +408,7 @@ mod advanced {
         // returns `.failure` instead of silently discarding the Result.
         writer
             .ensure_unused_capacity(payload_length)
-            .map_err(|_| IPCSerializationError::OutOfMemory)?;
+            .map_err(|_| global.throw_out_of_memory())?;
 
         writer.write_type_as_bytes_assume_capacity(message_type);
         writer.write_type_as_bytes_assume_capacity(size);
@@ -562,7 +557,7 @@ mod json {
         let out = bun_core::OwnedString::new(out);
 
         if out.tag() == bun_core::Tag::Dead {
-            return Err(IPCSerializationError::SerializationFailed);
+            return Err(IPCSerializationError::NotSerializable);
         }
 
         // TODO: it would be cool to have a 'toUTF8Into' which can write directly into 'ipc_data.outgoing.list'
@@ -578,7 +573,7 @@ mod json {
         // returns `.failure` instead of silently discarding the Result.
         writer
             .ensure_unused_capacity(result_len)
-            .map_err(|_| IPCSerializationError::OutOfMemory)?;
+            .map_err(|_| global.throw_out_of_memory())?;
 
         if is_internal == IsInternal::Internal {
             writer.write_assume_capacity(&[2]);
@@ -1619,6 +1614,7 @@ impl SendQueue {
         }
     }
 
+    /// `Failure`: the value has no serialization. A JS exception raised while serializing is `Err`.
     pub fn serialize_and_send(
         &self,
         global: &JSGlobalObject,
@@ -1626,29 +1622,25 @@ impl SendQueue {
         is_internal: IsInternal,
         callback: JSValue,
         handle: Option<Handle>,
-    ) -> SerializeAndSendResult {
+    ) -> JsResult<SerializeAndSendResult> {
         log!("SendQueue#serializeAndSend");
         let indicate_backoff = self.waiting_for_ack.get().is_some() && !self.queue.get().is_empty();
         let mode = self.mode;
         let mut payload = StreamBuffer::default();
         let payload_length = match serialize(mode, &mut payload, global, value, is_internal) {
             Ok(n) => n,
-            Err(_) => return SerializeAndSendResult::Failure,
+            Err(IPCSerializationError::NotSerializable) => return Ok(SerializeAndSendResult::Failure),
+            Err(IPCSerializationError::Js(e)) => return Err(e),
         };
         debug_assert!(payload.list.len() == payload_length);
-        if self
-            .start_message(global, callback, handle, payload)
-            .is_err()
-        {
-            return SerializeAndSendResult::Failure;
-        }
+        self.start_message(global, callback, handle, payload)?;
         log!("IPC call continueSend() from serializeAndSend");
         self.continue_send(global, ContinueSendReason::NewMessageAppended);
 
         if indicate_backoff {
-            return SerializeAndSendResult::Backoff;
+            return Ok(SerializeAndSendResult::Backoff);
         }
-        SerializeAndSendResult::Success
+        Ok(SerializeAndSendResult::Success)
     }
 
     fn debug_log_message_queue(&self) {

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -1629,7 +1629,9 @@ impl SendQueue {
         let mut payload = StreamBuffer::default();
         let payload_length = match serialize(mode, &mut payload, global, value, is_internal) {
             Ok(n) => n,
-            Err(IPCSerializationError::NotSerializable) => return Ok(SerializeAndSendResult::Failure),
+            Err(IPCSerializationError::NotSerializable) => {
+                return Ok(SerializeAndSendResult::Failure);
+            }
             Err(IPCSerializationError::Js(e)) => return Err(e),
         };
         debug_assert!(payload.list.len() == payload_length);

--- a/src/runtime/ipc_host.rs
+++ b/src/runtime/ipc_host.rs
@@ -274,7 +274,7 @@ pub(crate) fn do_send(
     }
 
     let status =
-        ipc_data.serialize_and_send(global_object, message, is_internal, callback, zig_handle);
+        ipc_data.serialize_and_send(global_object, message, is_internal, callback, zig_handle)?;
 
     if status != SerializeAndSendResult::Failure {
         call_handle_method(global_object, pause_target, "pause")?;

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -168,14 +168,20 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
         );
     }
 
-    let success = ipc_data.serialize_and_send(
+    let sent = ipc_data.serialize_and_send(
         global,
         message,
         IsInternal::Internal,
         JSValue::NULL,
         native_handle,
-    )?;
-    Ok(match success {
+    );
+    if !matches!(sent, Ok(SerializeAndSendResult::Success | SerializeAndSendResult::Backoff)) {
+        // Nothing was queued, so no ack/nack will ever retire the callback registered above.
+        ipc_data.internal_msg_queue.with_mut(|q| {
+            q.callbacks.swap_remove(&this_seq);
+        });
+    }
+    Ok(match sent? {
         SerializeAndSendResult::Success => JSValue::TRUE,
         SerializeAndSendResult::Backoff => JSValue::FALSE,
         SerializeAndSendResult::Failure => JSValue::NULL,

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -175,7 +175,10 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
         JSValue::NULL,
         native_handle,
     );
-    if !matches!(sent, Ok(SerializeAndSendResult::Success | SerializeAndSendResult::Backoff)) {
+    if !matches!(
+        sent,
+        Ok(SerializeAndSendResult::Success | SerializeAndSendResult::Backoff)
+    ) {
         // Nothing was queued, so no ack/nack will ever retire the callback registered above.
         ipc_data.internal_msg_queue.with_mut(|q| {
             q.callbacks.swap_remove(&this_seq);

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -174,7 +174,7 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
         IsInternal::Internal,
         JSValue::NULL,
         native_handle,
-    );
+    )?;
     Ok(match success {
         SerializeAndSendResult::Success => JSValue::TRUE,
         SerializeAndSendResult::Backoff => JSValue::FALSE,

--- a/src/sql/mysql/protocol/AnyMySQLError.rs
+++ b/src/sql/mysql/protocol/AnyMySQLError.rs
@@ -30,7 +30,6 @@ pub enum Error {
 
     InvalidLocalInfileRequest,
     InvalidAuthSwitchRequest,
-    InvalidQueryBinding,
     InvalidResultRow,
     InvalidBinaryValue,
     InvalidEncodedInteger,

--- a/src/sql/postgres/AnyPostgresError.rs
+++ b/src/sql/postgres/AnyPostgresError.rs
@@ -19,7 +19,6 @@ pub enum AnyPostgresError {
     InvalidCharacter,
     InvalidMessage,
     InvalidMessageLength,
-    InvalidQueryBinding,
     InvalidServerKey,
     InvalidServerSignature,
     JSError,

--- a/src/sql_jsc/error.rs
+++ b/src/sql_jsc/error.rs
@@ -1,7 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
-    #[error("InvalidQueryBinding")]
-    InvalidQueryBinding,
     #[error("BufferTooSmall")]
     BufferTooSmall,
     #[error("InvalidEscapeSequence")]
@@ -40,7 +38,6 @@ impl Error {
     #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn name(&self) -> &'static str {
         match self {
-            Self::InvalidQueryBinding => "InvalidQueryBinding",
             Self::BufferTooSmall => "BufferTooSmall",
             Self::InvalidEscapeSequence => "InvalidEscapeSequence",
             Self::UnknownEscapeSequence => "UnknownEscapeSequence",

--- a/src/sql_jsc/mysql/MySQLQuery.rs
+++ b/src/sql_jsc/mysql/MySQLQuery.rs
@@ -133,10 +133,6 @@ impl MySQLQuery {
             i += 1;
         }
 
-        if iter.any_failed() {
-            return Err(AnyMySQLError::InvalidQueryBinding);
-        }
-
         if i as usize != len {
             // Fewer values than the prepared statement expects; the remaining slots
             // would be uninitialized.

--- a/src/sql_jsc/mysql/protocol/Signature.rs
+++ b/src/sql_jsc/mysql/protocol/Signature.rs
@@ -71,9 +71,6 @@ impl Signature {
             });
         }
 
-        if iter.any_failed() {
-            return Err(crate::Error::InvalidQueryBinding);
-        }
 
         Ok(Signature {
             name: name.into_boxed_slice(),

--- a/src/sql_jsc/mysql/protocol/Signature.rs
+++ b/src/sql_jsc/mysql/protocol/Signature.rs
@@ -71,7 +71,6 @@ impl Signature {
             });
         }
 
-
         Ok(Signature {
             name: name.into_boxed_slice(),
             fields: fields.into_boxed_slice(),

--- a/src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs
+++ b/src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs
@@ -97,7 +97,6 @@ pub(crate) fn mysql_error_to_js(
         "UnsupportedColumnType" => b"ERR_MYSQL_UNSUPPORTED_COLUMN_TYPE",
         "InvalidLocalInfileRequest" => b"ERR_MYSQL_INVALID_LOCAL_INFILE_REQUEST",
         "InvalidAuthSwitchRequest" => b"ERR_MYSQL_INVALID_AUTH_SWITCH_REQUEST",
-        "InvalidQueryBinding" => b"ERR_MYSQL_INVALID_QUERY_BINDING",
         "InvalidResultRow" => b"ERR_MYSQL_INVALID_RESULT_ROW",
         "InvalidBinaryValue" => b"ERR_MYSQL_INVALID_BINARY_VALUE",
         "InvalidEncodedInteger" => b"ERR_MYSQL_INVALID_ENCODED_INTEGER",

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -98,9 +98,6 @@ pub(crate) fn write_bind<Context: WriterContext>(
                     if let Some(value) = iter.next().map_err(js_error_to_postgres)? {
                         break 'brk value.is_string();
                     }
-                    if iter.any_failed() {
-                        return Err(AnyPostgresError::InvalidQueryBinding);
-                    }
                     break 'brk false;
                 });
 

--- a/src/sql_jsc/postgres/Signature.rs
+++ b/src/sql_jsc/postgres/Signature.rs
@@ -19,9 +19,7 @@ impl Signature {
 
     // No explicit `Drop` impl needed: the `Box<[T]>` fields free the four owned slices automatically.
 
-    // JSError (from QueryBindingIterator /
-    // Tag::from_js), OOM, and InvalidQueryBinding are collapsed to the
-    // crate-wide `crate::Error`.
+    // JSError (from QueryBindingIterator / Tag::from_js) and OOM are collapsed to the crate-wide `crate::Error`.
     pub(crate) fn generate(
         global_object: &JSGlobalObject,
         query: &[u8],
@@ -88,9 +86,6 @@ impl Signature {
             }
         }
 
-        if iter.any_failed() {
-            return Err(crate::Error::InvalidQueryBinding);
-        }
         // max u64 length is 20, max prepared_statement_name length is 63
         let prepared_statement_name: Box<[u8]> = if unnamed {
             Box::default()

--- a/src/sql_jsc/postgres/error_jsc.rs
+++ b/src/sql_jsc/postgres/error_jsc.rs
@@ -66,7 +66,6 @@ pub(crate) fn postgres_error_to_js(
         InvalidCharacter => b"ERR_POSTGRES_INVALID_CHARACTER",
         InvalidMessage => b"ERR_POSTGRES_INVALID_MESSAGE",
         InvalidMessageLength => b"ERR_POSTGRES_INVALID_MESSAGE_LENGTH",
-        InvalidQueryBinding => b"ERR_POSTGRES_INVALID_QUERY_BINDING",
         InvalidServerKey => b"ERR_POSTGRES_INVALID_SERVER_KEY",
         InvalidServerSignature => b"ERR_POSTGRES_INVALID_SERVER_SIGNATURE",
         MultidimensionalArrayNotSupportedYet => {

--- a/src/sql_jsc/shared/ObjectIterator.rs
+++ b/src/sql_jsc/shared/ObjectIterator.rs
@@ -13,17 +13,11 @@ pub(crate) struct ObjectIterator<'a> {
     pub(crate) current_row: JSValue,
     pub(crate) columns_count: u32,
     pub(crate) array_length: u32,
-    pub(crate) any_failed: bool,
 }
 
 impl<'a> ObjectIterator<'a> {
+    /// The next cell value (row `row_i`, column `cell_i`), `Ok(None)` once every row has been visited.
     pub(crate) fn next(&mut self) -> JsResult<Option<JSValue>> {
-        if self.array.is_empty_or_undefined_or_null()
-            || self.columns.is_empty_or_undefined_or_null()
-        {
-            self.any_failed = true;
-            return Ok(None);
-        }
         if self.row_i >= self.array_length {
             return Ok(None);
         }
@@ -35,53 +29,30 @@ impl<'a> ObjectIterator<'a> {
         let global_object = self.global_object;
 
         if self.current_row.is_empty() {
-            self.current_row = match JSObject::get_index(self.array, global_object, row_i) {
-                Ok(v) => v,
-                Err(_) => {
-                    self.any_failed = true;
-                    return Ok(None);
-                }
-            };
-            if self.current_row.is_empty_or_undefined_or_null() {
+            self.current_row = JSObject::get_index(self.array, global_object, row_i)?;
+            if !self.current_row.is_object() {
                 return Err(global_object.throw(format_args!(
-                    "Expected a row to be returned at index {}",
+                    "Expected a row object at index {}",
                     row_i
                 )));
             }
         }
 
-        // The labeled block computes the result first, then the bookkeeping
-        // below runs exactly once before returning.
-        let result: JsResult<Option<JSValue>> = 'out: {
-            let property = match JSObject::get_index(self.columns, global_object, cell_i) {
-                Ok(v) => v,
-                Err(_) => {
-                    self.any_failed = true;
-                    break 'out Ok(None);
-                }
-            };
-            if property.is_undefined() {
-                break 'out Err(global_object.throw(format_args!(
-                    "Expected a column at index {} in row {}",
-                    cell_i, row_i
-                )));
-            }
-
-            // `get_own_by_value` maps the C++ empty (zero) return to `None`,
-            // so the `Some(JSValue::ZERO)` comparison below is defensively dead
-            // (an unwrapped value is never zero).
-            let value: Option<JSValue> = self.current_row.get_own_by_value(global_object, property);
-            if value == Some(JSValue::ZERO) || value.is_some_and(|v| v.is_undefined()) {
-                if !global_object.has_exception() {
-                    break 'out Err(global_object.throw(format_args!(
-                        "Expected a value at index {} in row {}",
-                        cell_i, row_i
-                    )));
-                }
-                self.any_failed = true;
-                break 'out Ok(None);
-            }
-            Ok(value)
+        let property = JSObject::get_index(self.columns, global_object, cell_i)?;
+        if property.is_undefined() {
+            return Err(global_object.throw(format_args!(
+                "Expected a column at index {} in row {}",
+                cell_i, row_i
+            )));
+        }
+        let value = self.current_row.get_own_by_value(global_object, property)?;
+        let result = if value.is_undefined() {
+            Err(global_object.throw(format_args!(
+                "Expected a value at index {} in row {}",
+                cell_i, row_i
+            )))
+        } else {
+            Ok(Some(value))
         };
 
         if self.cell_i >= self.columns_count {

--- a/src/sql_jsc/shared/ObjectIterator.rs
+++ b/src/sql_jsc/shared/ObjectIterator.rs
@@ -31,10 +31,9 @@ impl<'a> ObjectIterator<'a> {
         if self.current_row.is_empty() {
             self.current_row = JSObject::get_index(self.array, global_object, row_i)?;
             if !self.current_row.is_object() {
-                return Err(global_object.throw(format_args!(
-                    "Expected a row object at index {}",
-                    row_i
-                )));
+                return Err(
+                    global_object.throw(format_args!("Expected a row object at index {}", row_i))
+                );
             }
         }
 

--- a/src/sql_jsc/shared/QueryBindingIterator.rs
+++ b/src/sql_jsc/shared/QueryBindingIterator.rs
@@ -26,7 +26,6 @@ impl<'a> QueryBindingIterator<'a> {
             current_row: JSValue::ZERO,
             columns_count: columns.get_length(global)? as u32,
             array_length: array.get_length(global)? as u32,
-            any_failed: false,
         }))
     }
 
@@ -34,13 +33,6 @@ impl<'a> QueryBindingIterator<'a> {
         match self {
             Self::Array(iter) => iter.next(),
             Self::Objects(iter) => iter.next(),
-        }
-    }
-
-    pub(crate) fn any_failed(&self) -> bool {
-        match self {
-            Self::Array(_) => false,
-            Self::Objects(iter) => iter.any_failed,
         }
     }
 

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -181,9 +181,13 @@ describe("a macro that throws", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toContain("error: macro boom");
       expect(stdout.trim().split("\n").at(-1)).toBe("import failed: macro threw exception");
-      expect(exitCode).toBe(0);
+      // One assertion so the child's stderr is in the diff if it did not exit cleanly.
+      expect({ exitCode, signalCode: proc.signalCode, stderr }).toEqual({
+        exitCode: 0,
+        signalCode: null,
+        stderr: expect.stringContaining("error: macro boom"),
+      });
     });
   }
 });

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -159,6 +159,35 @@ test("object argument with a sparse numeric key", async () => {
   });
 });
 
+describe("a macro that throws", () => {
+  for (const [name, macro] of [
+    ["from its body", `export function m() { throw new Error("macro boom"); }`],
+    [
+      "while its return value is being converted",
+      `export function m() { return { get x() { throw new Error("macro boom"); } }; }`,
+    ],
+  ] as const) {
+    test(name + " reports that error and fails the import", async () => {
+      using dir = tempDir("macro-throws", {
+        "m.ts": macro,
+        "user.ts": `import { m } from "./m.ts" with { type: "macro" };\nconsole.log(JSON.stringify(m()));\n`,
+        "index.ts": `try { await import("./user.ts"); console.log("imported"); } catch (e) { console.log("import failed: " + String(e.message).split("\\n")[0]); }`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "index.ts"],
+        env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("error: macro boom");
+      expect(stdout.trim().split("\n").at(-1)).toBe("import failed: macro threw exception");
+      expect(exitCode).toBe(0);
+    });
+  }
+});
+
 test("object destructuring of a macro result keeps every bound property regardless of key order or repeated keys", async () => {
   using dir = tempDir("macro-destructure-object", {
     "m.ts": `export function m() {\n  return { a: 1, c: 2 };\n}\n`,

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -948,6 +948,20 @@ describe.concurrent("Bun.plugin.clearAll()", () => {
     });
   });
 
+  it("an onResolve callback that returns a rejected promise fails the import with that rejection", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const err = new Error("rejected resolve");
+      Bun.plugin({ name: "rejects", setup(b) { b.onResolve({ filter: /.*/, namespace: "rej" }, async () => { throw err; }); } });
+      try {
+        await import("rej:thing");
+        console.log("resolved");
+      } catch (e) {
+        console.log("same=" + (e === err));
+      }
+    `);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "same=true", stderr: "", exitCode: 0 });
+  });
+
   it("re-registering a namespaced onResolve plugin after clearAll() drops the old callback", async () => {
     const { stdout, stderr, exitCode } = await run(`
       Bun.plugin({

--- a/test/js/node/child_process/child_process_ipc.test.js
+++ b/test/js/node/child_process/child_process_ipc.test.js
@@ -1,5 +1,5 @@
 import { $ } from "bun";
-import { bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("child_process ipc", async () => {
   const output = await $`${bunExe()} ${import.meta.dir}/fixtures/ipc_fixture.js`.text();
@@ -12,4 +12,56 @@ test("child_process ipc", async () => {
     cb ERR_IPC_CHANNEL_CLOSED
     "
   `);
+});
+
+// A message whose serialization throws (a getter here) rejects that send with the thrown error, the channel
+// stays usable, and nothing else is delivered in its place — for process.send() and cluster's worker.send().
+test.each(["json", "advanced"])("send() with a message that throws while serializing (%s)", async serialization => {
+  const src = `
+    const cluster = require("node:cluster");
+    if (cluster.isPrimary) {
+      cluster.setupPrimary({ serialization: ${JSON.stringify(serialization)} });
+      const worker = cluster.fork();
+      const err = new Error("primary getter");
+      worker.on("message", m => {
+        if (m === "ready") {
+          let caught;
+          try { worker.send({ get x() { throw err; } }); } catch (e) { caught = e; }
+          console.log("primary caught own error:", caught === err);
+          worker.send("after");
+        } else {
+          console.log("primary got:", JSON.stringify(m));
+          if (m.done) worker.kill();
+        }
+      });
+      worker.on("exit", () => console.log("worker exited"));
+    } else {
+      const err = new Error("worker getter");
+      let caught;
+      try { process.send({ get x() { throw err; } }); } catch (e) { caught = e; }
+      process.send({ workerCaughtOwnError: caught === err });
+      process.on("message", m => { if (m === "after") process.send({ done: true }); });
+      process.send("ready");
+    }
+  `;
+  // cluster.fork() re-executes argv[1], so this needs a real file.
+  using dir = tempDir("ipc-throwing-serialize", { "main.js": src });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
+    stdout: [
+      `primary got: {"workerCaughtOwnError":true}`,
+      "primary caught own error: true",
+      `primary got: {"done":true}`,
+      "worker exited",
+    ],
+    stderr: "",
+    exitCode: 0,
+  });
 });

--- a/test/js/sql/sql-mysql.helpers.test.ts
+++ b/test/js/sql/sql-mysql.helpers.test.ts
@@ -33,6 +33,22 @@ describeWithContainer(
       expect(result[0].age).toBe(30);
     });
 
+    test("insert helper: a row getter that throws rejects the query with that error", async () => {
+      await using sql = new SQL({ ...getOptions(), max: 1 });
+      const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+      await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (id int, name text)`;
+      const boom = new Error("row getter");
+      const row = {
+        id: 1,
+        get name() {
+          throw boom;
+        },
+      };
+      expect(async () => await sql`INSERT INTO ${sql(random_name)} ${sql(row)}`).toThrow(boom);
+      expect(async () => await sql`INSERT INTO ${sql(random_name)} ${sql([row], "id", "name")}`).toThrow(boom);
+      expect(await sql`SELECT count(*) AS n FROM ${sql(random_name)}`).toEqual([{ n: 0 }]);
+    });
+
     test("insert into with select helper with IN", async () => {
       await using sql = new SQL({ ...getOptions(), max: 1 });
       const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -11681,6 +11681,23 @@ CREATE TABLE ${table_name} (
         expect(result[0].age).toBe(30);
       });
 
+      test("insert helper: a row getter that throws rejects the query with that error", async () => {
+        await using sql = postgres({ ...options, max: 1 });
+        const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+        await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (id int, name text)`;
+        const boom = new Error("row getter");
+        const row = {
+          id: 1,
+          get name() {
+            throw boom;
+          },
+        };
+        expect(async () => await sql`INSERT INTO ${sql(random_name)} ${sql(row)}`).toThrow(boom);
+        expect(async () => await sql`INSERT INTO ${sql(random_name)} ${sql([row], "id", "name")}`).toThrow(boom);
+        // and the connection is still usable
+        expect(await sql`SELECT count(*)::int AS n FROM ${sql(random_name)}`).toEqual([{ n: 0 }]);
+      });
+
       test("insert into with select helper using where IN", async () => {
         await using sql = postgres({ ...options, max: 1 });
         const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");


### PR DESCRIPTION
### What does this PR do?

Four places that noticed a JS exception and then carried on as if something else had happened.

- **`` sql`insert into t ${sql(rows)}` `` (postgres / mysql wire protocols)** — when reading a cell threw (a getter on the row object, an index accessor on the array), `ObjectIterator` recorded it on an `any_failed` side channel and returned "no value"; callers then threw `ERR_POSTGRES_INVALID_QUERY_BINDING` / the mysql equivalent *over* the pending exception, and the second bind pass in `PostgresRequest` didn't check the flag at all and wrote a short Bind message. The iterator now returns `Err` for a throw and its callers propagate it; `any_failed` is gone. `JSValue::get_own_by_value` (its only user) returns `JsResult<JSValue>` — `undefined` for "no such own property", which the iterator already treated the same as an `undefined` value.
- **`process.send()` / `cluster` `worker.send()`** — `serialize_and_send()` collapsed "the value threw while being serialized" (`toJSON` throwing, a structured-clone failure) into the same `Failure` as "this value has no serialization", so `process.send` built a `TypeError("process.send() failed")` over the pending exception and cluster's send helper returned `null` with it still pending. It now returns `JsResult<SerializeAndSendResult>`; `Failure` is only the nothing-thrown case, and the two internal buffer-growth failures throw an OOM instead of masquerading as one.
- **Macros** — a throw from the macro function came back as the engine's exception cell and was reported as `cannot coerce Exception (JSType(0)) to Bun's AST`; a throw while converting the return value (a getter, an iterator, `toString`) was logged as a generic `"Js(Thrown)" error in macro` with the exception left pending under the parser. Both are now reported with the error's own message and location and fail the expansion with `macro threw exception`.
- **`Bun.plugin` `onResolve` returning an already-rejected promise** (e.g. `async () => { throw … }`) — the promise's flags were overwritten to "fulfilled" and its reason used as the resolve result; the reason is now thrown from the resolve.

`ERR_POSTGRES_INVALID_QUERY_BINDING` / `ERR_MYSQL_INVALID_QUERY_BINDING` are removed: nothing produces them any more, and they were only ever thrown on top of another pending exception, so callers never observed them.

Also: `SavedSourceMap` now tells LeakSanitizer about the values it owns through a tagged pointer (LSan cannot follow the high-bit tag), which the new macro tests tripped on the ASAN lane — an error remapped from inside a macro followed by a clean exit left the materialized `ParsedSourceMap` looking unreferenced.

### How did you verify your code works?

New tests: `macro-test.test.ts` (macro throwing from its body / from a getter on its return value → stderr has the error, import fails with "macro threw exception"), `plugins.test.ts` (onResolve rejecting → `import()` rejects with the same error). Both fail on current release. Under `BUN_JSC_validateExceptionChecks=1` on a debug build: macro-test 24/24, `03830.test.ts` 3/3, plugins 48/48, `sql-helpers-validation` 28/28, and `process.send` / `worker.send` with a throwing `toJSON` in json and advanced modes. The postgres/mysql bind path needs the Docker-backed suites in CI.

