### PR TITLE
Remove redundant exception checks that follow already-checked calls

### DIFF
--- a/src/css_jsc/color_js.rs
+++ b/src/css_jsc/color_js.rs
@@ -312,9 +312,6 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
             } else {
                 None
             };
-            if global.has_exception() {
-                return Ok(JSValue::ZERO);
-            }
 
             break 'brk Ok(CssColor::Rgba(RGBA {
                 alpha: a.unwrap_or(255),

--- a/src/install_jsc/npm_jsc.rs
+++ b/src/install_jsc/npm_jsc.rs
@@ -11,12 +11,6 @@ pub fn operating_system_is_match(global: &JSGlobalObject, frame: &CallFrame) -> 
     while let Some(item) = iter.next()? {
         let slice = item.to_slice(global)?;
         operating_system.apply(slice.slice());
-        if global.has_exception() {
-            return Ok(JSValue::ZERO);
-        }
-    }
-    if global.has_exception() {
-        return Ok(JSValue::ZERO);
     }
     Ok(JSValue::js_boolean(
         operating_system
@@ -33,12 +27,6 @@ pub fn architecture_is_match(global: &JSGlobalObject, frame: &CallFrame) -> JsRe
     while let Some(item) = iter.next()? {
         let slice = item.to_slice(global)?;
         architecture.apply(slice.slice());
-        if global.has_exception() {
-            return Ok(JSValue::ZERO);
-        }
-    }
-    if global.has_exception() {
-        return Ok(JSValue::ZERO);
     }
     Ok(JSValue::js_boolean(
         architecture.combine().is_match(npm::Architecture::CURRENT),

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -601,7 +601,10 @@ impl JSGlobalObject {
         let actual_type = if value.js_type().is_array() {
             bun_core::ZigString::static_(b"array")
         } else {
-            value.js_type_string(self).get_zig_string(self)
+            match value.js_type_string(self).get_zig_string(self) {
+                Ok(s) => s,
+                Err(e) => return e,
+            }
         };
         self.err(
             JscError::INVALID_ARG_TYPE,
@@ -646,7 +649,10 @@ impl JSGlobalObject {
     ) -> JsError {
         // `ZigStringSlice` is RAII: `Owned` frees
         // its `Vec<u8>`, `WTF` derefs the backing `WTFStringImpl` in `Drop`.
-        let ty_str = value.js_type_string(self).to_slice(self);
+        let ty_str = match value.js_type_string(self).to_slice(self) {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(

--- a/src/jsc/JSString.rs
+++ b/src/jsc/JSString.rs
@@ -28,7 +28,11 @@ impl JSString {
         JSValue::from_cell(self)
     }
 
-    pub(crate) fn to_zig_string(&self, global: &JSGlobalObject, zig_str: &mut ZigString) -> JsResult<()> {
+    pub(crate) fn to_zig_string(
+        &self,
+        global: &JSGlobalObject,
+        zig_str: &mut ZigString,
+    ) -> JsResult<()> {
         // SAFETY: `zig_str` is a live out-parameter for the duration of the call.
         unsafe { crate::cpp::JSC__JSString__toZigString(self, global, zig_str) }
     }

--- a/src/jsc/JSString.rs
+++ b/src/jsc/JSString.rs
@@ -18,11 +18,6 @@ bun_opaque::opaque_ffi! {
 // covers zero bytes and C++ mutating the underlying GC cell does not violate
 // Rust's aliasing rules.
 unsafe extern "C" {
-    safe fn JSC__JSString__toZigString(
-        this: &JSString,
-        global: &JSGlobalObject,
-        zig_str: &mut ZigString,
-    );
     fn JSC__JSString__iterator(this: &JSString, global_object: &JSGlobalObject, iter: *mut c_void);
     safe fn JSC__JSString__length(this: &JSString) -> usize;
     safe fn JSC__JSString__is8Bit(this: &JSString) -> bool;
@@ -33,8 +28,9 @@ impl JSString {
         JSValue::from_cell(self)
     }
 
-    pub(crate) fn to_zig_string(&self, global: &JSGlobalObject, zig_str: &mut ZigString) {
-        JSC__JSString__toZigString(self, global, zig_str)
+    pub(crate) fn to_zig_string(&self, global: &JSGlobalObject, zig_str: &mut ZigString) -> JsResult<()> {
+        // SAFETY: `zig_str` is a live out-parameter for the duration of the call.
+        unsafe { crate::cpp::JSC__JSString__toZigString(self, global, zig_str) }
     }
 
     pub fn ensure_still_alive(&self) {
@@ -42,22 +38,22 @@ impl JSString {
         core::hint::black_box(std::ptr::from_ref::<Self>(self));
     }
 
-    pub fn get_zig_string(&self, global: &JSGlobalObject) -> ZigString {
+    pub fn get_zig_string(&self, global: &JSGlobalObject) -> JsResult<ZigString> {
         let mut out = ZigString::init(b"");
-        self.to_zig_string(global, &mut out);
-        out
+        self.to_zig_string(global, &mut out)?;
+        Ok(out)
     }
 
     #[inline]
-    pub fn view(&self, global: &JSGlobalObject) -> ZigString {
+    pub fn view(&self, global: &JSGlobalObject) -> JsResult<ZigString> {
         self.get_zig_string(global)
     }
 
     /// doesn't always allocate
-    pub fn to_slice(&self, global: &JSGlobalObject) -> ZigStringSlice {
+    pub fn to_slice(&self, global: &JSGlobalObject) -> JsResult<ZigStringSlice> {
         let mut str = ZigString::init(b"");
-        self.to_zig_string(global, &mut str);
-        str.to_slice()
+        self.to_zig_string(global, &mut str)?;
+        Ok(str.to_slice())
     }
 
     // `to_slice_clone` always allocates
@@ -67,7 +63,7 @@ impl JSString {
 
     pub fn to_slice_clone(&self, global: &JSGlobalObject) -> JsResult<ZigStringSlice> {
         let mut str = ZigString::init(b"");
-        self.to_zig_string(global, &mut str);
+        self.to_zig_string(global, &mut str)?;
         Ok(str.to_slice_clone())
     }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6850,7 +6850,9 @@ fn wrap_unhandled_rejection_error_for_uncaught_exception(
     if reason_str.is_string() {
         // SAFETY: `as_string()` returns a non-null `*mut JSString` when
         // `is_string()` is true; `view()` borrows it for the `write!` below.
-        let view = unsafe { (*reason_str.as_string()).view(global_object) };
+        let Ok(view) = (unsafe { (*reason_str.as_string()).view(global_object) }) else {
+            return JSValue::ZERO;
+        };
         return global_object
             .err(
                 crate::ErrorCode::ERR_UNHANDLED_REJECTION,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6850,15 +6850,19 @@ fn wrap_unhandled_rejection_error_for_uncaught_exception(
     if reason_str.is_string() {
         // SAFETY: `as_string()` returns a non-null `*mut JSString` when
         // `is_string()` is true; `view()` borrows it for the `write!` below.
-        let Ok(view) = (unsafe { (*reason_str.as_string()).view(global_object) }) else {
-            return JSValue::ZERO;
-        };
-        return global_object
-            .err(
-                crate::ErrorCode::ERR_UNHANDLED_REJECTION,
-                format_args!("{MSG_1}{view}\"."),
-            )
-            .to_js();
+        match unsafe { (*reason_str.as_string()).view(global_object) } {
+            Ok(view) => {
+                return global_object
+                    .err(
+                        crate::ErrorCode::ERR_UNHANDLED_REJECTION,
+                        format_args!("{MSG_1}{view}\"."),
+                    )
+                    .to_js();
+            }
+            // As with the stringification above: this is already the error-reporting path, so a reason that
+            // cannot be printed degrades to the generic message.
+            Err(_) => global_object.clear_exception(),
+        }
     }
     global_object
         .err(

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3736,8 +3736,10 @@ impl VirtualMachine {
                 return;
             }
             Mode::Strict => {
+                // If describing the rejection throws, that is the error reported instead.
                 let wrapped =
-                    wrap_unhandled_rejection_error_for_uncaught_exception(global_object, reason);
+                    wrap_unhandled_rejection_error_for_uncaught_exception(global_object, reason)
+                        .unwrap_or_else(|e| global_object.take_exception(e));
                 let _ = self.uncaught_exception(global_object, wrapped, true);
                 let handled = handle_unhandled();
                 if !handled {
@@ -3752,7 +3754,8 @@ impl VirtualMachine {
                     return;
                 }
                 let wrapped =
-                    wrap_unhandled_rejection_error_for_uncaught_exception(global_object, reason);
+                    wrap_unhandled_rejection_error_for_uncaught_exception(global_object, reason)
+                        .unwrap_or_else(|e| global_object.take_exception(e));
                 if self.uncaught_exception(global_object, wrapped, true) {
                     drain(self);
                     return;
@@ -6823,53 +6826,33 @@ fn is_error_like(global_object: &JSGlobalObject, reason: JSValue) -> JsResult<bo
 fn wrap_unhandled_rejection_error_for_uncaught_exception(
     global_object: &JSGlobalObject,
     reason: JSValue,
-) -> JSValue {
-    let like = is_error_like(global_object, reason).unwrap_or_else(|_| {
-        global_object.clear_exception();
-        false
-    });
-    if like {
-        return reason;
+) -> JsResult<JSValue> {
+    if is_error_like(global_object, reason)? {
+        return Ok(reason);
     }
-    // Open an explicit `TopExceptionScope`
-    // around the call and clear any exception via the scope; the C++ side has a
-    // `DECLARE_THROW_SCOPE`, so under `BUN_JSC_validateExceptionChecks=1` a
-    // post-call `clear_exception()` (whose own scope ctor asserts) would be
-    // wrong without a Rust-side scope live across the call.
-    let reason_str = {
-        crate::top_scope!(scope, global_object);
-        let r = Bun__noSideEffectsToString(global_object.vm(), global_object, reason);
-        if scope.exception().is_some() {
-            scope.clear_exception();
-        }
-        r
-    };
+    let reason_str = jsc::from_js_host_call_generic(global_object, || {
+        Bun__noSideEffectsToString(global_object.vm(), global_object, reason)
+    })?;
     const MSG_1: &str = "This error originated either by throwing inside of an async function \
         without a catch block, or by rejecting a promise which was not handled with .catch(). \
         The promise rejected with the reason \"";
     if reason_str.is_string() {
         // SAFETY: `as_string()` returns a non-null `*mut JSString` when
         // `is_string()` is true; `view()` borrows it for the `write!` below.
-        match unsafe { (*reason_str.as_string()).view(global_object) } {
-            Ok(view) => {
-                return global_object
-                    .err(
-                        crate::ErrorCode::ERR_UNHANDLED_REJECTION,
-                        format_args!("{MSG_1}{view}\"."),
-                    )
-                    .to_js();
-            }
-            // As with the stringification above: this is already the error-reporting path, so a reason that
-            // cannot be printed degrades to the generic message.
-            Err(_) => global_object.clear_exception(),
-        }
+        let view = unsafe { (*reason_str.as_string()).view(global_object) }?;
+        return Ok(global_object
+            .err(
+                crate::ErrorCode::ERR_UNHANDLED_REJECTION,
+                format_args!("{MSG_1}{view}\"."),
+            )
+            .to_js());
     }
-    global_object
+    Ok(global_object
         .err(
             crate::ErrorCode::ERR_UNHANDLED_REJECTION,
             format_args!("{MSG_1}undefined\"."),
         )
-        .to_js()
+        .to_js())
 }
 
 /// `None` when no `Bun.plugin()` `onResolve` callback claimed the specifier.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3736,10 +3736,7 @@ impl VirtualMachine {
                 return;
             }
             Mode::Strict => {
-                // If describing the rejection throws, that is the error reported instead.
-                let wrapped =
-                    wrap_unhandled_rejection_error_for_uncaught_exception(global_object, reason)
-                        .unwrap_or_else(|e| global_object.take_exception(e));
+                let wrapped = unhandled_rejection_as_uncaught_error(global_object, reason);
                 let _ = self.uncaught_exception(global_object, wrapped, true);
                 let handled = handle_unhandled();
                 if !handled {
@@ -3753,9 +3750,7 @@ impl VirtualMachine {
                     drain(self);
                     return;
                 }
-                let wrapped =
-                    wrap_unhandled_rejection_error_for_uncaught_exception(global_object, reason)
-                        .unwrap_or_else(|e| global_object.take_exception(e));
+                let wrapped = unhandled_rejection_as_uncaught_error(global_object, reason);
                 if self.uncaught_exception(global_object, wrapped, true) {
                     drain(self);
                     return;
@@ -6821,6 +6816,27 @@ fn is_error_like(global_object: &JSGlobalObject, reason: JSValue) -> JsResult<bo
     jsc::from_js_host_call_generic(global_object, || {
         Bun__promises__isErrorLike(global_object, reason)
     })
+}
+
+/// What `--unhandled-rejections=strict|throw` hand to the uncaught-exception path for `reason`. If describing the
+/// rejection itself throws (a hostile Proxy under isErrorLike, an OOM resolving a rope), that failure does not
+/// replace the thing being reported: the rejection is the user's bug, so it is reported as-is — unless what was
+/// thrown is a termination, which has to win.
+fn unhandled_rejection_as_uncaught_error(
+    global_object: &JSGlobalObject,
+    reason: JSValue,
+) -> JSValue {
+    match wrap_unhandled_rejection_error_for_uncaught_exception(global_object, reason) {
+        Ok(wrapped) => wrapped,
+        Err(e) => {
+            let secondary = global_object.take_exception(e);
+            if secondary.is_termination_exception() {
+                secondary
+            } else {
+                reason
+            }
+        }
+    }
 }
 
 fn wrap_unhandled_rejection_error_for_uncaught_exception(

--- a/src/jsc/bindings/BakeAdditionsToGlobalObject.cpp
+++ b/src/jsc/bindings/BakeAdditionsToGlobalObject.cpp
@@ -31,15 +31,10 @@ extern "C" SYSV_ABI EncodedJSValue Bake__createDevServerFrameworkRequestArgsObje
     RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(jsUndefined()));
 
     object->putDirectOffset(vm, 0, JSValue::decode(routerTypeMain));
-    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(jsUndefined()));
     object->putDirectOffset(vm, 1, JSValue::decode(routeModules));
-    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(jsUndefined()));
     object->putDirectOffset(vm, 2, JSValue::decode(clientEntryUrl));
-    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(jsUndefined()));
     object->putDirectOffset(vm, 3, JSValue::decode(styles));
-    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(jsUndefined()));
     object->putDirectOffset(vm, 4, JSValue::decode(params));
-    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(jsUndefined()));
 
     return JSValue::encode(object);
 }

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -88,7 +88,6 @@ static JSC::EncodedJSValue jsFunctionAppendOnLoadPluginBody(JSC::JSGlobalObject*
     }
 
     auto func = callframe->uncheckedArgument(1);
-    RETURN_IF_EXCEPTION(scope, {});
 
     if (!func.isCell() || !func.isCallable()) {
         throwException(globalObject, scope, createError(globalObject, "onLoad() expects second argument to be a function"_s));
@@ -185,7 +184,6 @@ static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginBody(JSC::JSGlobalObje
     auto filterValue = filterObject->getIfPropertyExists(globalObject, Identifier::fromString(vm, "filter"_s));
     RETURN_IF_EXCEPTION(scope, {});
     if (filterValue) {
-        RETURN_IF_EXCEPTION(scope, {});
         if (filterValue.isCell() && filterValue.asCell()->inherits<JSC::RegExpObject>())
             filter = uncheckedDowncast<JSC::RegExpObject>(filterValue);
     }
@@ -207,18 +205,15 @@ static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginBody(JSC::JSGlobalObje
                 return {};
             }
         }
-        RETURN_IF_EXCEPTION(scope, {});
     }
 
     auto func = callframe->uncheckedArgument(1);
-    RETURN_IF_EXCEPTION(scope, {});
 
     if (!func.isCell() || !func.isCallable()) {
         throwException(globalObject, scope, createError(globalObject, "onResolve() expects second argument to be a function"_s));
         return {};
     }
 
-    RETURN_IF_EXCEPTION(scope, {});
     plugin.append(vm, filter->regExp(), uncheckedDowncast<JSObject>(func), namespaceString);
     callback(ctx, globalObject);
 
@@ -293,7 +288,6 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
         JSC::throwTypeError(globalObject, throwScope, "plugin needs an object as first argument"_s);
         return {};
     }
-    RETURN_IF_EXCEPTION(throwScope, {});
 
     JSC::JSValue setupFunctionValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "setup"_s));
     RETURN_IF_EXCEPTION(throwScope, {});

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -450,12 +450,12 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
     Strong<JSC::JSObject> strongModule = { vm, moduleObject };
 
     WTF::String filename = callFrame->uncheckedArgument(1).toWTFString(globalObject);
-
-    if (filename.isEmpty() && !scope.exception()) {
-        JSC::throwTypeError(globalObject, scope, "dlopen requires a non-empty string as the second argument"_s);
-    }
-
     RETURN_IF_EXCEPTION(scope, {});
+
+    if (filename.isEmpty()) {
+        JSC::throwTypeError(globalObject, scope, "dlopen requires a non-empty string as the second argument"_s);
+        return {};
+    }
 
     if (filename.startsWith("file://"_s)) {
         WTF::URL fileURL = WTF::URL(filename);
@@ -4107,9 +4107,6 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage, (JSC::JSGlobalObject * glo
     }
 
     JSC::JSObject* result = JSC::constructEmptyObject(vm, process->memoryUsageStructure());
-    if (throwScope.exception()) [[unlikely]] {
-        return {};
-    }
 
     // Node.js:
     // {
@@ -4785,11 +4782,12 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionLoadBuiltinModule, (JSGlobalObject * gl
     BunString idStr = Bun::toString(idWtfStr);
 
     JSValue fetchResult = Bun::resolveAndFetchBuiltinModule(zigGlobalObject, &idStr);
+    RETURN_IF_EXCEPTION(scope, {});
     if (fetchResult) {
-        RELEASE_AND_RETURN(scope, JSC::JSValue::encode(fetchResult));
+        return JSC::JSValue::encode(fetchResult);
     }
 
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsUndefined()));
+    return JSValue::encode(jsUndefined());
 }
 
 JSC_DEFINE_HOST_FUNCTION(Process_functionEmitHelper, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -827,7 +827,6 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__upsertBunStringArray(
         scope.throwException(global, createTypeError(global, "Target must be an object"_s));
         return {};
     }
-    RETURN_IF_EXCEPTION(scope, {});
     JSC::JSValue newValue = JSC::JSValue::decode(encodedValue);
     auto& vm = global->vm();
     WTF::String str = key->tag == BunStringTag::Empty ? WTF::emptyString() : key->toWTFString();

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -14,12 +14,9 @@ namespace WebCore {
 template<typename Res>
 static void CookieMap__writeFetchHeadersToUWSResponse(CookieMap* cookie_map, JSC::JSGlobalObject* global_this, Res* res)
 {
-    auto& vm = JSC::getVM(global_this);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     // Loop over modified cookies and write Set-Cookie headers to the response
     for (auto& cookie : cookie_map->getAllChanges()) {
         auto utf8 = cookie->toString(global_this->vm()).utf8();
-        RETURN_IF_EXCEPTION(scope, );
         res->writeHeader("Set-Cookie", utf8.data());
     }
 }

--- a/src/jsc/bindings/EncodeURIComponent.cpp
+++ b/src/jsc/bindings/EncodeURIComponent.cpp
@@ -5,10 +5,8 @@
 namespace JSC {
 
 template<typename CharacterType>
-static WebCore::ExceptionOr<void> encode(VM& vm, const WTF::BitSet<256>& doNotEscape, std::span<const CharacterType> characters, StringBuilder& builder)
+static WebCore::ExceptionOr<void> encode(const WTF::BitSet<256>& doNotEscape, std::span<const CharacterType> characters, StringBuilder& builder)
 {
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
     // 18.2.6.1.1 Runtime Semantics: Encode ( string, unescapedSet )
     // https://tc39.github.io/ecma262/#sec-encode
 
@@ -81,21 +79,21 @@ static WebCore::ExceptionOr<void> encode(VM& vm, const WTF::BitSet<256>& doNotEs
     return {};
 }
 
-static WebCore::ExceptionOr<void> encode(VM& vm, WTF::StringView view, const WTF::BitSet<256>& doNotEscape, StringBuilder& builder)
+static WebCore::ExceptionOr<void> encode(WTF::StringView view, const WTF::BitSet<256>& doNotEscape, StringBuilder& builder)
 {
     if (view.is8Bit())
-        return encode(vm, doNotEscape, view.span8(), builder);
-    return encode(vm, doNotEscape, view.span16(), builder);
+        return encode(doNotEscape, view.span8(), builder);
+    return encode(doNotEscape, view.span16(), builder);
 }
 
-WebCore::ExceptionOr<void> encodeURIComponent(VM& vm, WTF::StringView source, StringBuilder& builder)
+WebCore::ExceptionOr<void> encodeURIComponent(VM&, WTF::StringView source, StringBuilder& builder)
 {
     static constexpr auto doNotEscapeWhenEncodingURIComponent = makeLatin1CharacterBitSet(
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz"
         "0123456789"
         "!'()*-._~");
-    return encode(vm, source, doNotEscapeWhenEncodingURIComponent, builder);
+    return encode(source, doNotEscapeWhenEncodingURIComponent, builder);
 }
 
 }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -535,7 +535,7 @@ extern "C" BunString Bun__ErrorCode__determineSpecificType(JSC::JSGlobalObject* 
 // C++ INVALID_ARG_VALUE overloads use so Rust-side error paths match exactly.
 extern "C" BunString Bun__ErrorCode__inspectForErrorMessage(JSC::JSGlobalObject* globalObject, EncodedJSValue value)
 {
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(JSC::getVM(globalObject));
+    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
     WTF::StringBuilder builder;
     JSValueToStringSafe(globalObject, builder, JSValue::decode(value), true);
     RETURN_IF_EXCEPTION(scope, Zig::BunStringEmpty);
@@ -1673,8 +1673,6 @@ static JSValue ERR_INVALID_ARG_VALUE(JSC::ThrowScope& throwScope, JSC::JSGlobalO
     ASCIILiteral type = nameView->contains('.') ? "property"_s : "argument"_s;
     WTF::StringBuilder builder;
 
-    RETURN_IF_EXCEPTION(throwScope, {});
-
     ASSERT(reason.isUndefined() || reason.isString());
 
     builder.append("The "_s);
@@ -1898,7 +1896,6 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Bun::jsFunctionMakeErrorWithCode, __att
     EXPECT_ARG_COUNT(1);
 
     JSC::JSValue codeValue = callFrame->argument(0);
-    RETURN_IF_EXCEPTION(scope, {});
 
 #if ASSERT_ENABLED
     if (!codeValue.isNumber()) {
@@ -2229,9 +2226,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Bun::jsFunctionMakeErrorWithCode, __att
         RETURN_IF_EXCEPTION(scope, {});
         auto cause = callFrame->argument(2);
         JSObject* error = createError(globalObject, ErrorCode::ERR_VM_MODULE_LINK_FAILURE, message);
-        RETURN_IF_EXCEPTION(scope, {});
         Bun::putDirectNamed(vm, error, "cause"_s, cause);
-        RETURN_IF_EXCEPTION(scope, {});
         return JSC::JSValue::encode(error);
     }
 

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -212,8 +212,6 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
     JSValue parentModule = callFrame->argument(5);
     JSValue resolveFilenameOptions = callFrame->argument(6);
 
-    RETURN_IF_EXCEPTION(scope, {});
-
     if (globalObject->onLoadPlugins.hasVirtualModules()) {
         if (moduleName.isString()) {
             auto moduleString = moduleName.toWTFString(globalObject);

--- a/src/jsc/bindings/JSBakeResponse.cpp
+++ b/src/jsc/bindings/JSBakeResponse.cpp
@@ -233,8 +233,6 @@ public:
 
         instance->m_ctx = ptr;
 
-        RETURN_IF_EXCEPTION(scope, {});
-
         auto size = Response__estimatedSize(ptr);
         vm.heap.reportExtraMemoryAllocated(instance, size);
 

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -818,13 +818,12 @@ static JSC::EncodedJSValue jsBufferByteLengthFromStringAndEncoding(JSC::JSGlobal
         return {};
     }
 
-    if (auto length = Bun::byteLength(str, lexicalGlobalObject, encoding)) {
+    auto length = Bun::byteLength(str, lexicalGlobalObject, encoding);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (length) {
         return JSValue::encode(jsNumber(*length));
     }
-    if (!scope.exception()) {
-        throwOutOfMemoryError(lexicalGlobalObject, scope);
-    }
-
+    throwOutOfMemoryError(lexicalGlobalObject, scope);
     return {};
 }
 
@@ -1163,7 +1162,6 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
             Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceEndValue, "sourceEnd"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &sourceEnd);
             RETURN_IF_EXCEPTION(throwScope, {});
         }
-        RETURN_IF_EXCEPTION(throwScope, {});
         [[fallthrough]];
     case 4:
         sourceStartValue = callFrame->uncheckedArgument(3);
@@ -1171,7 +1169,6 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
             Bun::V::validateInteger(throwScope, lexicalGlobalObject, sourceStartValue, "sourceStart"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &sourceStart);
             RETURN_IF_EXCEPTION(throwScope, {});
         }
-        RETURN_IF_EXCEPTION(throwScope, {});
         [[fallthrough]];
     case 3:
         targetEndValue = callFrame->uncheckedArgument(2);
@@ -1179,7 +1176,6 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
             Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetEndValue, "targetEnd"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &targetEnd);
             RETURN_IF_EXCEPTION(throwScope, {});
         }
-        RETURN_IF_EXCEPTION(throwScope, {});
         [[fallthrough]];
     case 2:
         targetStartValue = callFrame->uncheckedArgument(1);
@@ -1187,7 +1183,6 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
             Bun::V::validateInteger(throwScope, lexicalGlobalObject, targetStartValue, "targetStart"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &targetStart);
             RETURN_IF_EXCEPTION(throwScope, {});
         }
-        RETURN_IF_EXCEPTION(throwScope, {});
         break;
     case 1:
     case 0:

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -326,8 +326,6 @@ JSC_DEFINE_HOST_FUNCTION(requireResolvePathsFunction, (JSGlobalObject * globalOb
         }
     }
 
-    RETURN_IF_EXCEPTION(scope, {});
-
     // This function is not bound with the module object. This is because nearly
     // no one uses this and it is not worth creating an extra bound function for
     // every single module. Instead, we can unwrap the bound function that we

--- a/src/jsc/bindings/JSSecrets.cpp
+++ b/src/jsc/bindings/JSSecrets.cpp
@@ -295,7 +295,6 @@ void Bun__SecretsJobOptions__runFromJS(SecretsJobOptions* opts, JSGlobalObject* 
             if (opts->resultPassword.has_value()) {
                 auto resultPassword = WTF::move(opts->resultPassword.value());
                 result = jsString(vm, String::fromUTF8(resultPassword.span()));
-                RETURN_IF_EXCEPTION(scope, );
                 memsetSpan(resultPassword.mutableSpan(), 0);
             } else {
                 result = jsNull();
@@ -310,7 +309,6 @@ void Bun__SecretsJobOptions__runFromJS(SecretsJobOptions* opts, JSGlobalObject* 
             result = jsBoolean(opts->deleted);
             break;
         }
-        RETURN_IF_EXCEPTION(scope, );
         RELEASE_AND_RETURN(scope, promise->resolve(global, vm, result));
     }
 }

--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -110,7 +110,6 @@ JSC_DEFINE_HOST_FUNCTION(jsX509CertificateProtoFuncToString, (JSGlobalObject * g
 
     // Convert the certificate to PEM format and return it
     String pemString = thisObject->toPEMString();
-    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsString(vm, pemString));
 }
 

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -225,7 +225,6 @@ extern "C" EncodedJSValue Bun__NodeHTTP__buildRawHeadersArray(JSC::JSGlobalObjec
                 array->initializeIndex(initializationScope, i, JSValue::decode(argValues[i]));
             }
         } else {
-            RETURN_IF_EXCEPTION(scope, {});
             array = constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), arrayValues);
             RETURN_IF_EXCEPTION(scope, {});
         }
@@ -308,7 +307,6 @@ static EncodedJSValue NodeHTTPServer__onRequest(
     // capacity keeps the capture heap-allocation-free for the common case.
     WTF::Vector<uint8_t, 1024> flatHeaders;
     assignHeadersFromUWebSocketsForCall(request, methodString, args, flatHeaders, globalObject, vm);
-    RETURN_IF_EXCEPTION(scope, {});
 
     bool hasBody = false;
     WebCore::JSNodeHTTPResponse* nodeHTTPResponseObject = uncheckedDowncast<WebCore::JSNodeHTTPResponse>(JSValue::decode(NodeHTTPResponse__createForJS(any_server, globalObject, &hasBody, request, isSSL, response, upgrade_ctx, nodeHttpResponsePtr)));

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -743,8 +743,7 @@ void getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::Thr
                 return;
             }
 
-            outOptions.allowStrings = allowStringsValue.toBoolean(globalObject);
-            RETURN_IF_EXCEPTION(scope, );
+            outOptions.allowStrings = allowStringsValue.asBoolean();
         }
 
         auto allowWasmValue = codeGenerationObject->getIfPropertyExists(globalObject, Identifier::fromString(vm, "wasm"_s));
@@ -755,8 +754,7 @@ void getNodeVMContextOptions(JSGlobalObject* globalObject, JSC::VM& vm, JSC::Thr
                 return;
             }
 
-            outOptions.allowWasm = allowWasmValue.toBoolean(globalObject);
-            RETURN_IF_EXCEPTION(scope, );
+            outOptions.allowWasm = allowWasmValue.asBoolean();
         }
     }
 }
@@ -1642,7 +1640,7 @@ static JSPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject
 
     if (sourceOrigin.fetcher() == nullptr && sourceOrigin.url().isEmpty()) {
         if (globalObject->dynamicImportCallback().isCallable()) {
-            return NodeVM::importModuleInner(globalObject, moduleName, WTF::move(parameters), sourceOrigin, globalObject->dynamicImportCallback(), JSValue {});
+            RELEASE_AND_RETURN(scope, NodeVM::importModuleInner(globalObject, moduleName, WTF::move(parameters), sourceOrigin, globalObject->dynamicImportCallback(), JSValue {}));
         }
 
         promise->reject(vm, createError(globalObject, ErrorCode::ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING, "A dynamic import callback was not specified."_s));

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -37,7 +37,6 @@ JSArray* NodeVMModuleRequest::toJS(JSGlobalObject* globalObject) const
     for (const auto& [key, value] : m_importAttributes) {
         attributes->putDirect(globalObject->vm(), JSC::Identifier::fromString(globalObject->vm(), key), JSC::jsString(globalObject->vm(), value),
             PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete);
-        RETURN_IF_EXCEPTION(scope, {});
     }
     array->putDirectIndex(globalObject, 1, attributes);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -137,7 +137,6 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
     RefPtr fetcher(NodeVMScriptFetcher::create(vm, importer, jsUndefined()));
 
     SourceCode source = makeSource(sourceString, JSC::SourceOrigin(WTF::URL::fileURLWithFileSystemPath(options.filename), *fetcher), JSC::SourceTaintedOrigin::Untainted, options.filename, TextPosition(options.lineOffset, options.columnOffset));
-    RETURN_IF_EXCEPTION(scope, {});
 
     NodeVMScript* script = NodeVMScript::create(vm, globalObject, structure, WTF::move(source), WTF::move(options));
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -89,7 +89,6 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     RefPtr fetcher(NodeVMScriptFetcher::create(vm, dynamicImportCallback, moduleWrapper));
-    RETURN_IF_EXCEPTION(scope, nullptr);
 
     SourceOrigin sourceOrigin { {}, *fetcher };
 
@@ -111,7 +110,6 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
     NodeVMSourceTextModule* ptr = new (NotNull, allocateCell<NodeVMSourceTextModule>(vm)) NodeVMSourceTextModule(
         vm, zigGlobalObject->NodeVMSourceTextModuleStructure(), WTF::move(identifier), contextValue,
         WTF::move(sourceCode), moduleWrapper, initializeImportMeta);
-    RETURN_IF_EXCEPTION(scope, nullptr);
     ptr->finishCreation(vm);
 
     if (cachedData.isEmpty()) {
@@ -129,9 +127,7 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
     LexicallyScopedFeatures lexicallyScopedFeatures = globalObject->globalScopeExtension() ? TaintedByWithScopeLexicallyScopedFeature : NoLexicallyScopedFeatures;
     SourceCodeKey key(ptr->sourceCode(), {}, SourceCodeType::ProgramType, lexicallyScopedFeatures, JSParserScriptMode::Classic, DerivedContextType::None, EvalContextType::None, false, {}, std::nullopt);
     Ref<CachedBytecode> cachedBytecode = CachedBytecode::create(std::span(cachedData), nullptr, {});
-    RETURN_IF_EXCEPTION(scope, nullptr);
     UnlinkedModuleProgramCodeBlock* unlinkedBlock = decodeCodeBlock<UnlinkedModuleProgramCodeBlock>(vm, key, WTF::move(cachedBytecode));
-    RETURN_IF_EXCEPTION(scope, nullptr);
 
     if (unlinkedBlock) {
         JSScope* jsScope = globalObject->globalScope();
@@ -551,8 +547,8 @@ void NodeVMSourceTextModule::initializeImportMeta(JSGlobalObject* globalObject)
     args.append(metaValue);
     args.append(m_moduleWrapper.get());
 
-    JSC::call(globalObject, m_initializeImportMeta.get(), callData, jsUndefined(), args);
     scope.release();
+    JSC::call(globalObject, m_initializeImportMeta.get(), callData, jsUndefined(), args);
 }
 
 JSObject* NodeVMSourceTextModule::createPrototype(VM& vm, JSGlobalObject* globalObject)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1726,7 +1726,7 @@ JSC_DEFINE_HOST_FUNCTION(makeGetterTypeErrorForBuiltins, (JSGlobalObject * globa
     ASSERT(callFrame->argumentCount() == 2);
     VM& vm = globalObject->vm();
     DeferTermination deferScope(vm);
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto interfaceName = callFrame->uncheckedArgument(0).getString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
@@ -1745,7 +1745,7 @@ JSC_DEFINE_HOST_FUNCTION(makeDOMExceptionForBuiltins, (JSGlobalObject * globalOb
 
     auto& vm = JSC::getVM(globalObject);
     DeferTermination deferScope(vm);
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto codeValue = callFrame->uncheckedArgument(0).getString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
@@ -2721,10 +2721,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionToClass, (JSC::JSGlobalObject * globalObject,
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto target = callFrame->argument(0).toObject(globalObject);
+    RETURN_IF_EXCEPTION(scope, encodedJSValue());
     auto name = callFrame->argument(1);
     JSObject* base = callFrame->argument(2).getObject();
     JSObject* prototypeBase = nullptr;
-    RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
     if (!base) {
         base = globalObject->functionPrototype();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -949,8 +949,6 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             if (!eql) return false;
         }
 
-        RETURN_IF_EXCEPTION(scope, false);
-
         return true;
     }
 
@@ -1865,7 +1863,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
         }
 
         auto iter1 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set1, IterationKind::Keys);
-        RETURN_IF_EXCEPTION(scope, {});
         JSValue key1;
         while (iter1->next(globalObject, key1)) {
             bool has = set2->has(globalObject, key1);
@@ -1877,7 +1874,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             // We couldn't find the key in the second set. This may be a false positive due to how
             // JSValues are represented in JSC, so we need to fall back to a linear search to be sure.
             auto iter2 = JSSetIterator::create(vm, globalObject->setIteratorStructure(), set2, IterationKind::Keys);
-            RETURN_IF_EXCEPTION(scope, {});
             JSValue key2;
             bool foundMatchingKey = false;
             while (iter2->next(globalObject, key2)) {
@@ -1914,7 +1910,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
         }
 
         auto iter1 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map1, IterationKind::Entries);
-        RETURN_IF_EXCEPTION(scope, {});
         JSValue key1, value1;
         while (iter1->nextKeyValue(globalObject, key1, value1)) {
             JSValue value2 = map2->get(globalObject, key1);
@@ -1924,7 +1919,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
                 // how JSValues are represented in JSC, so we need to fall back to a linear search
                 // to be sure.
                 auto iter2 = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map2, IterationKind::Entries);
-                RETURN_IF_EXCEPTION(scope, {});
                 JSValue key2;
                 bool foundMatchingKey = false;
                 while (iter2->nextKeyValue(globalObject, key2, value2)) {
@@ -3449,19 +3443,18 @@ JSC::EncodedJSValue JSC__JSValue__fromEntries(JSC::JSGlobalObject* globalObject,
     }
 
     JSC::JSObject* object = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), std::min(static_cast<unsigned int>(initialCapacity), JSFinalObject::maxInlineCapacity));
+    RETURN_IF_EXCEPTION(scope, {});
 
     if (!clone) {
         for (size_t i = 0; i < initialCapacity; ++i) {
             object->putDirect(
                 vm, JSC::PropertyName(JSC::Identifier::fromString(vm, Zig::toString(keys[i]))),
                 Zig::toJSStringGC(values[i], globalObject), 0);
-            RETURN_IF_EXCEPTION(scope, {});
         }
     } else {
         for (size_t i = 0; i < initialCapacity; ++i) {
             object->putDirect(vm, JSC::PropertyName(Zig::toIdentifier(keys[i], globalObject)),
                 Zig::toJSStringGC(values[i], globalObject), 0);
-            RETURN_IF_EXCEPTION(scope, {});
         }
     }
 
@@ -4984,7 +4977,7 @@ JSC::JSObject* JSC__JSValue__toObject(JSC::EncodedJSValue JSValue0, JSC::JSGloba
 bool JSC__JSValue__stringIncludes(JSC::EncodedJSValue value, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue other)
 {
     VM& vm = globalObject->vm();
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     WTF::String stringToSearchIn = JSC::JSValue::decode(value).toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
@@ -5936,7 +5929,7 @@ bool JSC__JSValue__isInstanceOf(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObjec
 {
     VM& vm = globalObject->vm();
 
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSValue jsValue = JSValue::decode(JSValue0);
     JSValue jsValue1 = JSValue::decode(JSValue1);
@@ -5947,7 +5940,6 @@ bool JSC__JSValue__isInstanceOf(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObjec
     if (!jsConstructor->structure()->typeInfo().implementsHasInstance()) [[unlikely]]
         return false;
     bool result = jsConstructor->hasInstance(globalObject, jsValue);
-
     RETURN_IF_EXCEPTION(scope, {});
 
     return result;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3333,12 +3333,15 @@ JSC::JSObject* JSC__JSCell__toObject(JSC::JSCell* cell, JSC::JSGlobalObject* glo
 
 #pragma mark - JSC::JSString
 
-void JSC__JSString__toZigString(JSC::JSString* arg0, JSC::JSGlobalObject* arg1, ZigString* arg2)
+// Throws (and leaves *arg2 empty) when resolving a rope runs out of memory.
+[[ZIG_EXPORT(check_slow)]] void JSC__JSString__toZigString(JSC::JSString* arg0, JSC::JSGlobalObject* arg1, ZigString* arg2)
 {
+    auto& vm = JSC::getVM(arg1);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto value = arg0->value(arg1);
+    RETURN_IF_EXCEPTION(scope, void());
+    // ->value returns a reference to the same string as the one owned by the JSString.
     *arg2 = Zig::toZigString(value.data.impl());
-
-    // We don't need to assert here because ->value returns a reference to the same string as the one owned by the JSString.
 }
 
 bool JSC__JSString__is8Bit(const JSC::JSString* arg0) { return arg0->is8Bit(); };

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -653,7 +653,6 @@ extern "C" napi_status napi_create_arraybuffer(napi_env env,
     }
 
     auto* jsArrayBuffer = JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(), WTF::move(arrayBuffer));
-    NAPI_RETURN_IF_EXCEPTION(env);
 
     if (data && jsArrayBuffer->impl()) [[likely]] {
         *data = jsArrayBuffer->impl()->data();
@@ -806,7 +805,7 @@ void Napi::executePendingNapiModule(Zig::GlobalObject* globalObject)
 
     // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/src/node_api.cc#L734-L742
     // https://github.com/oven-sh/bun/issues/1288
-    if (!scope.exception() && strongExportsObject && strongExportsObject.get() != resultValue) {
+    if (strongExportsObject && strongExportsObject.get() != resultValue) {
         PutPropertySlot slot(strongObject.get(), false);
         strongObject->put(strongObject.get(), globalObject, WebCore::builtinNames(vm).exportsPublicName(), resultValue, slot);
         RETURN_IF_EXCEPTION(scope, void());
@@ -1723,7 +1722,6 @@ extern "C" JS_EXPORT napi_status node_api_create_sharedarraybuffer(napi_env env,
     arrayBuffer->makeShared();
 
     auto* jsArrayBuffer = JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(ArrayBufferSharingMode::Shared), WTF::move(arrayBuffer));
-    NAPI_RETURN_IF_EXCEPTION(env);
 
     if (data && jsArrayBuffer->impl()) [[likely]] {
         *data = jsArrayBuffer->impl()->data();

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -872,8 +872,6 @@ extern "C" JSC::EncodedJSValue Bun__getOrCreateNodeHTTPServerSocket(bool isSSL, 
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    RETURN_IF_EXCEPTION(scope, {});
-
     if (isSSL) {
         uWS::HttpResponse<true>* response = reinterpret_cast<uWS::HttpResponse<true>*>(us_socket);
         auto* currentSocketDataPtr = reinterpret_cast<JSC::JSCell*>(response->getHttpResponseData()->socketData);
@@ -900,7 +898,6 @@ extern "C" JSC::EncodedJSValue Bun__getOrCreateNodeHTTPServerSocket(bool isSSL, 
         uWS::HttpResponse<false>* response = reinterpret_cast<uWS::HttpResponse<false>*>(us_socket);
         response->getHttpResponseData()->socketData = socket;
     }
-    RETURN_IF_EXCEPTION(scope, {});
     if (socket) {
         socket->strongThis.set(vm, socket);
         return JSValue::encode(socket);

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -870,7 +870,6 @@ extern "C" JSC::EncodedJSValue Bun__getNodeHTTPServerSocketThisValue(bool is_ssl
 extern "C" JSC::EncodedJSValue Bun__getOrCreateNodeHTTPServerSocket(bool isSSL, us_socket_t* us_socket, Zig::GlobalObject* globalObject)
 {
     auto& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (isSSL) {
         uWS::HttpResponse<true>* response = reinterpret_cast<uWS::HttpResponse<true>*>(us_socket);

--- a/src/jsc/bindings/node/NodeTimers.cpp
+++ b/src/jsc/bindings/node/NodeTimers.cpp
@@ -63,7 +63,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeout,
     }
 #endif
 
-    return Bun__Timer__setTimeout(globalObject, JSC::JSValue::encode(job), JSC::JSValue::encode(arguments), JSValue::encode(num));
+    RELEASE_AND_RETURN(scope, Bun__Timer__setTimeout(globalObject, JSC::JSValue::encode(job), JSC::JSValue::encode(arguments), JSValue::encode(num)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionSetInterval,
@@ -120,7 +120,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetInterval,
     }
 #endif
 
-    return Bun__Timer__setInterval(globalObject, JSC::JSValue::encode(job), JSC::JSValue::encode(arguments), JSValue::encode(num));
+    RELEASE_AND_RETURN(scope, Bun__Timer__setInterval(globalObject, JSC::JSValue::encode(job), JSC::JSValue::encode(arguments), JSValue::encode(num)));
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate
@@ -166,7 +166,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSetImmediate,
     }
     }
 
-    return Bun__Timer__setImmediate(globalObject, JSC::JSValue::encode(job), JSValue::encode(arguments));
+    RELEASE_AND_RETURN(scope, Bun__Timer__setImmediate(globalObject, JSC::JSValue::encode(job), JSValue::encode(arguments)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionClearImmediate,

--- a/src/jsc/bindings/node/crypto/CryptoKeygen.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoKeygen.cpp
@@ -54,7 +54,6 @@ JSCallbackArgs SecretKeyJobCtx::runFromJS(JSGlobalObject* lexicalGlobalObject)
     KeyObject keyObject = KeyObject::create(WTF::move(*m_result));
 
     Structure* structure = globalObject->m_JSSecretKeyObjectClassStructure.get(lexicalGlobalObject);
-    RETURN_IF_EXCEPTION(scope, {});
     JSSecretKeyObject* secretKey = JSSecretKeyObject::create(vm, structure, lexicalGlobalObject, WTF::move(keyObject));
     RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/jsc/bindings/node/crypto/CryptoUtil.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoUtil.cpp
@@ -380,11 +380,9 @@ JSValue createCryptoError(JSC::JSGlobalObject* globalObject, ThrowScope& scope, 
     }
 
     WTF::String errorMessage = WTF::String::fromUTF8(message);
-    RETURN_IF_EXCEPTION(scope, {});
 
     // Create error object with the message
     JSC::JSObject* errorObject = createError(globalObject, errorMessage);
-    RETURN_IF_EXCEPTION(scope, {});
 
     PutPropertySlot messageSlot(errorObject, false);
     errorObject->put(errorObject, globalObject, Identifier::fromString(vm, "message"_s), jsString(vm, errorMessage), messageSlot);
@@ -695,7 +693,6 @@ GCOwnedDataScope<std::span<const uint8_t>> getArrayBufferOrView2(JSGlobalObject*
 
             if (encodingView != "buffer"_s) {
                 encoding = parseEnumerationFromView<BufferEncodingType>(encodingView).value_or(BufferEncodingType::utf8);
-                RETURN_IF_EXCEPTION(scope, Return(nullptr, {}));
             }
         }
 

--- a/src/jsc/bindings/node/crypto/JSCipherConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSCipherConstructor.cpp
@@ -91,8 +91,7 @@ JSC_DEFINE_HOST_FUNCTION(constructCipher, (JSC::JSGlobalObject * globalObject, J
 
     JSValue isDecipherValue = callFrame->argument(0);
     ASSERT(isDecipherValue.isBoolean());
-    CipherKind cipherKind = isDecipherValue.toBoolean(globalObject) ? CipherKind::Decipher : CipherKind::Cipher;
-    RETURN_IF_EXCEPTION(scope, {});
+    CipherKind cipherKind = isDecipherValue.asBoolean() ? CipherKind::Decipher : CipherKind::Cipher;
 
     JSValue cipherValue = callFrame->argument(1);
     JSValue keyValue = callFrame->argument(2);

--- a/src/jsc/bindings/node/crypto/JSHash.cpp
+++ b/src/jsc/bindings/node/crypto/JSHash.cpp
@@ -244,7 +244,6 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
         WTF::String encodingString = encodingValue.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
         encoding = parseEnumerationFromString<BufferEncodingType>(encodingString).value_or(BufferEncodingType::buffer);
-        RETURN_IF_EXCEPTION(scope, {});
     }
 
     bool finalized = true;

--- a/src/jsc/bindings/node/crypto/JSHmac.cpp
+++ b/src/jsc/bindings/node/crypto/JSHmac.cpp
@@ -217,7 +217,6 @@ JSC_DEFINE_HOST_FUNCTION(jsHmacProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
         WTF::String encodingString = encodingValue.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
         encoding = parseEnumerationFromString<BufferEncodingType>(encodingString).value_or(BufferEncodingType::buffer);
-        RETURN_IF_EXCEPTION(scope, {});
     }
 
     unsigned char mdValue[EVP_MAX_MD_SIZE];

--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -1997,7 +1997,6 @@ KeyObject::PrepareAsymmetricKeyResult KeyObject::prepareAsymmetricKey(JSC::JSGlo
 
                 if (encodingView != "buffer"_s) {
                     encoding = parseEnumerationFromView<BufferEncodingType>(encodingView).value_or(BufferEncodingType::utf8);
-                    RETURN_IF_EXCEPTION(scope, {});
                 }
             }
 

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1758,10 +1758,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementOpenStatementFunction, (JSC::JSGlobalObje
 #endif
     Bun__initializeSQLite();
 
-    auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     String path = pathValue.toWTFString(lexicalGlobalObject);
-    RETURN_IF_EXCEPTION(topExceptionScope, JSValue::encode(jsUndefined()));
-    (void)topExceptionScope.tryClearException();
+    RETURN_IF_EXCEPTION(scope, {});
     int openFlags = DEFAULT_SQLITE_FLAGS;
     if (callFrame->argumentCount() > 1) {
         JSValue flags = callFrame->argument(1);
@@ -2143,7 +2141,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementSetPrototypeFunction, (JSGlobalObject * l
 
         JSValue prototype = classObject->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->prototype);
         RETURN_IF_EXCEPTION(scope, {});
-        if (!prototype && !scope.exception()) [[unlikely]] {
+        if (!prototype) [[unlikely]] {
             throwTypeError(lexicalGlobalObject, scope, "Expected constructor to have a prototype"_s);
             return {};
         }
@@ -2810,13 +2808,13 @@ JSC_DEFINE_CUSTOM_GETTER(jsSqlStatementGetColumnDeclaredTypes, (JSGlobalObject *
             // declared type (e.g. CREATE TABLE t (a "X")) is valid.
             String typeStr = WTF::String::fromUTF8ReplacingInvalidSequences({ reinterpret_cast<const unsigned char*>(declType), strlen(declType) });
             typeValue = JSC::jsString(vm, typeStr);
-            RETURN_IF_EXCEPTION(scope, {});
         } else {
             // If no declared type (e.g., for expressions or results of functions)
             typeValue = JSC::jsNull();
         }
 
         array->putDirectIndex(lexicalGlobalObject, i, typeValue);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     RELEASE_AND_RETURN(scope, JSC::JSValue::encode(array));

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -483,13 +483,10 @@ static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_deleteBody(JSC::J
     }
 
     if (nameValue && nameValue.isString()) {
-        RETURN_IF_EXCEPTION(throwScope, {});
-
         if (!nameValue.isUndefined() && !nameValue.isNull()) {
             deleteOptions.name = convert<IDLUSVString>(*lexicalGlobalObject, nameValue);
+            RETURN_IF_EXCEPTION(throwScope, {});
         }
-
-        RETURN_IF_EXCEPTION(throwScope, {});
     } else {
         return throwVMError(lexicalGlobalObject, throwScope, createTypeError(lexicalGlobalObject, "Cookie name is required"_s));
     }

--- a/src/jsc/bindings/webcore/JSDOMConstructorBase.cpp
+++ b/src/jsc/bindings/webcore/JSDOMConstructorBase.cpp
@@ -38,7 +38,6 @@ JSC_DEFINE_HOST_FUNCTION(callThrowTypeErrorForJSDOMConstructor, (JSGlobalObject 
     auto* callee = callframe->jsCallee();
     auto* constructor = dynamicDowncast<JSDOMConstructorBase>(callee);
     const auto& name = constructor->name();
-    RETURN_IF_EXCEPTION(scope, {});
     Bun::throwError(globalObject, scope, constructor->errorCode(), makeString("Use `new "_s, name, "(...)` instead of `"_s, name, "(...)`"_s));
     return {};
 }

--- a/src/jsc/bindings/webcore/JSEventTargetNode.cpp
+++ b/src/jsc/bindings/webcore/JSEventTargetNode.cpp
@@ -26,7 +26,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeEventsGetEventListeners, (JSGlobalObject 
 
     JSValue thisValue = callFrame->argument(0);
     auto* thisObject = dynamicDowncast<JSEventTarget>(thisValue);
-    RETURN_IF_EXCEPTION(throwScope, {});
     auto eventType = callFrame->argument(1).toWTFString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
 

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -350,10 +350,14 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
     auto* valueToTransfer = constructEmptyArray(globalObject, nullptr, 2);
     RETURN_IF_EXCEPTION(throwScope, {});
     valueToTransfer->putDirectIndex(globalObject, 0, workerData);
+    RETURN_IF_EXCEPTION(throwScope, {});
     auto* environmentData = globalObject->nodeWorkerEnvironmentData();
     // If node:worker_threads has not been imported, environment data will not be set up yet.
     valueToTransfer->putDirectIndex(globalObject, 1, environmentData ? environmentData : jsUndefined());
+    RETURN_IF_EXCEPTION(throwScope, {});
 
+    // Reports a DataCloneError through ExceptionOr, but a getter or toJSON that throws during serialization
+    // leaves that exception on the VM and returns normally.
     ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*lexicalGlobalObject, valueToTransfer, WTF::move(transferList), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
     if (serialized.hasException()) {
         WebCore::propagateException(*lexicalGlobalObject, throwScope, serialized.releaseException());

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -359,6 +359,7 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
         WebCore::propagateException(*lexicalGlobalObject, throwScope, serialized.releaseException());
         RELEASE_AND_RETURN(throwScope, {});
     }
+    RETURN_IF_EXCEPTION(throwScope, {});
 
     Vector<TransferredMessagePort> transferredPorts;
 
@@ -374,7 +375,6 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
     options.workerDataAndEnvironmentData = serialized.releaseReturnValue();
     options.dataMessagePorts = WTF::move(transferredPorts);
 
-    RETURN_IF_EXCEPTION(throwScope, {});
     auto object = Worker::create(*context, WTF::move(scriptUrl), WTF::move(options));
     if constexpr (IsExceptionOr<decltype(object)>)
         RETURN_IF_EXCEPTION(throwScope, {});
@@ -627,7 +627,6 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_postMessage2Body(JSC
         }
     }
 
-    RETURN_IF_EXCEPTION(throwScope, {});
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.postMessage(*uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), WTF::move(message), WTF::move(options)); })));
 }
 

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -277,7 +277,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeModuleCreateRequire,
         }
     }
 
-    RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(
         scope, JSValue::encode(Bun::JSCommonJSModule::createBoundRequireFunction(vm, globalObject, val)));
 }

--- a/src/jsc/modules/NodeTTYModule.cpp
+++ b/src/jsc/modules/NodeTTYModule.cpp
@@ -13,7 +13,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionTty_isatty, (JSGlobalObject * globalObject, C
         return JSValue::encode(jsBoolean(false));
     }
 
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     int fd = callFrame->argument(0).toInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -634,6 +634,10 @@ fn inspect_table(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResul
     } else {
         table_printer.print_table::<false>(&mut array)?;
     }
+    // print_table() swallows JS throws from nested formatting and returns Ok; see ConsoleObject::Formatter::format
+    if global_this.has_exception() {
+        return Err(jsc::JsError::Thrown);
+    }
 
     // writer.flush(): Vec<u8> writer is unbuffered; nothing to flush.
 
@@ -691,6 +695,10 @@ fn inspect(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
         &mut array,
         format_options,
     )?;
+    // format2() swallows JS throws from nested formatting and returns Ok; see ConsoleObject::Formatter::format
+    if global_this.has_exception() {
+        return Err(jsc::JsError::Thrown);
+    }
     // writer.flush(): Vec<u8> is unbuffered.
 
     // we are going to always clone to keep things simple for now

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -402,9 +402,6 @@ fn shell_escape(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult
     }
 
     let bunstr = jsval.to_bun_string(global_this)?;
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
     let bunstr = scopeguard::guard(bunstr, |s| s.deref());
 
     let mut outbuf: Vec<u8> = Vec::new();
@@ -540,9 +537,6 @@ fn which(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValu
     }
 
     let bin_str = path_arg.to_slice(global_this)?;
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
 
     if bin_str.slice().len() >= MAX_PATH_BYTES {
         return Err(global_this.throw(format_args!("bin path is too long")));
@@ -635,16 +629,10 @@ fn inspect_table(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResul
     table_printer.value_formatter.ordered_properties = format_options.ordered_properties;
     table_printer.value_formatter.single_line = format_options.single_line;
 
-    let print_result = if format_options.enable_colors {
-        table_printer.print_table::<true>(&mut array)
+    if format_options.enable_colors {
+        table_printer.print_table::<true>(&mut array)?;
     } else {
-        table_printer.print_table::<false>(&mut array)
-    };
-    if print_result.is_err() {
-        if !global_this.has_exception() {
-            return Err(global_this.throw_out_of_memory());
-        }
-        return Ok(JSValue::ZERO);
+        table_printer.print_table::<false>(&mut array)?;
     }
 
     // writer.flush(): Vec<u8> writer is unbuffered; nothing to flush.
@@ -703,9 +691,6 @@ fn inspect(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
         &mut array,
         format_options,
     )?;
-    if global_this.has_exception() {
-        return Err(jsc::JsError::Thrown);
-    }
     // writer.flush(): Vec<u8> is unbuffered.
 
     // we are going to always clone to keep things simple for now
@@ -1474,11 +1459,6 @@ fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVa
                 previous_routes: false,
             },
         )?;
-
-        if global_object.has_exception() {
-            drop(config);
-            return Ok(JSValue::ZERO);
-        }
 
         break 'brk config;
     };
@@ -2434,10 +2414,6 @@ pub mod JSZlib {
             }
         }
 
-        if global_this.has_exception() {
-            return Ok(JSValue::ZERO);
-        }
-
         let buffer = coerce_compress_buffer(global_this, buffer_value)?;
         let compressed = buffer.slice();
 
@@ -2598,14 +2574,7 @@ pub mod JSZlib {
 
             if let Some(level_value) = options_val.get(global_this, "level")? {
                 level = Some(level_value.coerce::<i32>(global_this)?);
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
-                }
             }
-        }
-
-        if global_this.has_exception() {
-            return Ok(JSValue::ZERO);
         }
 
         let buffer = coerce_compress_buffer(global_this, buffer_value)?;
@@ -2716,9 +2685,6 @@ pub mod JSZstd {
         if let Some(option_obj) = options_val {
             if let Some(level_val) = option_obj.get(global_this, "level")? {
                 let value = level_val.coerce::<i32>(global_this)?;
-                if global_this.has_exception() {
-                    return Err(jsc::JsError::Thrown);
-                }
 
                 if value < 1 || value > 22 {
                     return Err(global_this.throw_invalid_arguments(format_args!(

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -571,8 +571,6 @@ pub mod js_bundler {
 
                     if let Some(err) = plugin_result.to_error() {
                         return Err(global_this.throw_value(err));
-                    } else if global_this.has_exception() {
-                        return Err(JsError::Thrown);
                     }
 
                     onstart_promise_array = plugin_result;

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -980,10 +980,6 @@ impl JSTranspiler {
 
         config.from_js(global, config_arg, arena_ref)?;
 
-        if global.has_exception() {
-            return Err(bun_jsc::JsError::Thrown);
-        }
-
         if (config.log.warnings + config.log.errors) > 0 {
             return Err(
                 global.throw_value(config.log.to_js(global, "Failed to create transpiler")?)
@@ -1306,10 +1302,6 @@ impl JSTranspiler {
             }
             break 'brk None;
         };
-
-        if global.has_exception() {
-            return Ok(JSValue::ZERO);
-        }
 
         let arena = Arena::new();
         let mut log = bun_ast::Log::init();
@@ -1656,18 +1648,12 @@ impl JSTranspiler {
             ));
         };
 
-        let code_holder = match StringOrBuffer::from_js(global, code_arg)? {
-            Some(h) => h,
-            None => {
-                if !global.has_exception() {
-                    return Err(global.throw_invalid_argument_type(
-                        "scanImports",
-                        "code",
-                        "string or Uint8Array",
-                    ));
-                }
-                return Ok(JSValue::ZERO);
-            }
+        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
+            return Err(global.throw_invalid_argument_type(
+                "scanImports",
+                "code",
+                "string or Uint8Array",
+            ));
         };
         args.eat();
         let code = code_holder.slice();

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5772,7 +5772,7 @@ impl H2FrameParser {
                         }
                     };
 
-                    let value_slice = value_str.to_slice(global_object);
+                    let value_slice = value_str.to_slice(global_object)?;
                     let value = value_slice.slice();
 
                     if let Some(ret) = handle_encode(this, value, never_index)? {
@@ -5806,7 +5806,7 @@ impl H2FrameParser {
                     }
                 };
 
-                let value_slice = value_str.to_slice(global_object);
+                let value_slice = value_str.to_slice(global_object)?;
                 let value = value_slice.slice();
                 bun_output::scoped_log!(
                     H2FrameParser,
@@ -6172,7 +6172,7 @@ impl H2FrameParser {
                 };
                 let mut encode_value = |item: JSValue| -> JsResult<Option<JSValue>> {
                     let value_str = item.to_js_string(global_object)?;
-                    let value_slice = value_str.to_slice(global_object);
+                    let value_slice = value_str.to_slice(global_object)?;
                     let value = value_slice.slice();
                     if !is_valid_header_value(value) {
                         return Err(global_object
@@ -6577,7 +6577,7 @@ impl H2FrameParser {
                     }
 
                     let name_str = name_js.to_js_string(global_object)?;
-                    let name_slice = name_str.to_slice(global_object);
+                    let name_slice = name_str.to_slice(global_object)?;
                     let name = name_slice.slice();
                     if name.is_empty() {
                         continue;
@@ -6647,7 +6647,7 @@ impl H2FrameParser {
                         }
                     };
 
-                    let value_slice = value_str.to_slice(global_object);
+                    let value_slice = value_str.to_slice(global_object)?;
                     let value = value_slice.slice();
                     if !is_valid_header_value(value) {
                         return Err(global_object
@@ -6818,7 +6818,7 @@ impl H2FrameParser {
                             }
                         };
 
-                        let value_slice = value_str.to_slice(global_object);
+                        let value_slice = value_str.to_slice(global_object)?;
                         let value = value_slice.slice();
                         if !is_valid_header_value(value) {
                             return Err(global_object
@@ -6888,7 +6888,7 @@ impl H2FrameParser {
                         }
                     };
 
-                    let value_slice = value_str.to_slice(global_object);
+                    let value_slice = value_str.to_slice(global_object)?;
                     let value = value_slice.slice();
                     if !is_valid_header_value(value) {
                         return Err(global_object

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -6143,18 +6143,15 @@ impl H2FrameParser {
                         continue;
                     }
                     if !is_valid_request_pseudo_header(validated_name) {
-                        if !global_object.has_exception() {
-                            return Err(global_object
-                                .err(
-                                    JscErrorCode::HTTP2_INVALID_PSEUDOHEADER,
-                                    format_args!(
-                                        "\"{}\" is an invalid pseudoheader or is used incorrectly",
-                                        BStr::new(name)
-                                    ),
-                                )
-                                .throw());
-                        }
-                        return Ok(JSValue::ZERO);
+                        return Err(global_object
+                            .err(
+                                JscErrorCode::HTTP2_INVALID_PSEUDOHEADER,
+                                format_args!(
+                                    "\"{}\" is an invalid pseudoheader or is used incorrectly",
+                                    BStr::new(name)
+                                ),
+                            )
+                            .throw());
                     }
                 } else if ignore_pseudo_headers == 0 {
                     continue;
@@ -6608,16 +6605,18 @@ impl H2FrameParser {
 
                         if this.is_server.get() {
                             if !is_valid_response_pseudo_header(validated_name) {
-                                if !global_object.has_exception() {
-                                    return Err(global_object.err(JscErrorCode::HTTP2_INVALID_PSEUDOHEADER, format_args!("\"{}\" is an invalid pseudoheader or is used incorrectly", BStr::new(name))).throw());
-                                }
-                                return Ok(JSValue::ZERO);
-                            }
-                        } else if !is_valid_request_pseudo_header(validated_name) {
-                            if !global_object.has_exception() {
                                 return Err(global_object.err(JscErrorCode::HTTP2_INVALID_PSEUDOHEADER, format_args!("\"{}\" is an invalid pseudoheader or is used incorrectly", BStr::new(name))).throw());
                             }
-                            return Ok(JSValue::ZERO);
+                        } else if !is_valid_request_pseudo_header(validated_name) {
+                            return Err(global_object
+                                .err(
+                                    JscErrorCode::HTTP2_INVALID_PSEUDOHEADER,
+                                    format_args!(
+                                        "\"{}\" is an invalid pseudoheader or is used incorrectly",
+                                        BStr::new(name)
+                                    ),
+                                )
+                                .throw());
                         }
                     } else if ignore_pseudo_headers == 0 {
                         continue;
@@ -6741,17 +6740,27 @@ impl H2FrameParser {
 
                     if this.is_server.get() {
                         if !is_valid_response_pseudo_header(validated_name) {
-                            if !global_object.has_exception() {
-                                return Err(global_object.err(JscErrorCode::HTTP2_INVALID_PSEUDOHEADER, format_args!("\"{}\" is an invalid pseudoheader or is used incorrectly", BStr::new(name))).throw());
-                            }
-                            return Ok(JSValue::ZERO);
+                            return Err(global_object
+                                .err(
+                                    JscErrorCode::HTTP2_INVALID_PSEUDOHEADER,
+                                    format_args!(
+                                        "\"{}\" is an invalid pseudoheader or is used incorrectly",
+                                        BStr::new(name)
+                                    ),
+                                )
+                                .throw());
                         }
                     } else {
                         if !is_valid_request_pseudo_header(validated_name) {
-                            if !global_object.has_exception() {
-                                return Err(global_object.err(JscErrorCode::HTTP2_INVALID_PSEUDOHEADER, format_args!("\"{}\" is an invalid pseudoheader or is used incorrectly", BStr::new(name))).throw());
-                            }
-                            return Ok(JSValue::ZERO);
+                            return Err(global_object
+                                .err(
+                                    JscErrorCode::HTTP2_INVALID_PSEUDOHEADER,
+                                    format_args!(
+                                        "\"{}\" is an invalid pseudoheader or is used incorrectly",
+                                        BStr::new(name)
+                                    ),
+                                )
+                                .throw());
                         }
                     }
                 } else if ignore_pseudo_headers == 0 {
@@ -6773,35 +6782,29 @@ impl H2FrameParser {
 
                     if let Some(idx) = this.single_value_index_checked(validated_name) {
                         if value_iter.len > 1 || single_value_headers[idx] {
-                            if !global_object.has_exception() {
-                                let exception = global_object.to_type_error(
-                                    bun_jsc::ErrorCode::HTTP2_HEADER_SINGLE_VALUE,
-                                    format_args!(
-                                        "Header field \"{}\" must only have a single value",
-                                        BStr::new(validated_name)
-                                    ),
-                                );
-                                return Err(global_object.throw_value(exception));
-                            }
-                            return Ok(JSValue::ZERO);
+                            let exception = global_object.to_type_error(
+                                bun_jsc::ErrorCode::HTTP2_HEADER_SINGLE_VALUE,
+                                format_args!(
+                                    "Header field \"{}\" must only have a single value",
+                                    BStr::new(validated_name)
+                                ),
+                            );
+                            return Err(global_object.throw_value(exception));
                         }
                         single_value_headers[idx] = true;
                     }
 
                     while let Some(item) = value_iter.next()? {
                         if item.is_empty_or_undefined_or_null() {
-                            if !global_object.has_exception() {
-                                return Err(global_object
-                                    .err(
-                                        JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                                        format_args!(
-                                            "Invalid value for header \"{}\"",
-                                            BStr::new(validated_name)
-                                        ),
-                                    )
-                                    .throw());
-                            }
-                            return Ok(JSValue::ZERO);
+                            return Err(global_object
+                                .err(
+                                    JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
+                                    format_args!(
+                                        "Invalid value for header \"{}\"",
+                                        BStr::new(validated_name)
+                                    ),
+                                )
+                                .throw());
                         }
 
                         let value_str = item.to_js_string(global_object)?;

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -520,14 +520,11 @@ fn spawn_maybe_sync(
                                         }
                                     };
                                 } else {
-                                    if !global_this.has_exception() {
-                                        return Err(global_this.throw_invalid_argument_type(
-                                            "spawn",
-                                            "serialization",
-                                            "string",
-                                        ));
-                                    }
-                                    return Ok(JSValue::ZERO);
+                                    return Err(global_this.throw_invalid_argument_type(
+                                        "spawn",
+                                        "serialization",
+                                        "string",
+                                    ));
                                 }
                             }
                             break 'ipc_mode IPC::Mode::Advanced;
@@ -1001,8 +998,7 @@ fn spawn_maybe_sync(
             //
             // When Bun.spawn() is given an `.ipc` callback, it enables IPC as follows:
             if let Err(_err) = env_array.try_reserve(3) {
-                let _ = global_this.throw_out_of_memory();
-                return Ok(JSValue::ZERO);
+                return Err(global_this.throw_out_of_memory());
             }
             let ipc_fd: i32 = 'brk: {
                 if ipc_channel == -1 {
@@ -1244,8 +1240,9 @@ fn spawn_maybe_sync(
         Err(err) => {
             // See EMFILE arm above.
             spawn_options.deinit();
-            let _ = global_this.throw_error(crate::Error::from(err), ": failed to spawn process");
-            return Ok(JSValue::ZERO);
+            return Err(
+                global_this.throw_error(crate::Error::from(err), ": failed to spawn process")
+            );
         }
         Ok(maybe) => match maybe {
             sys::Result::Err(err) => {
@@ -1792,8 +1789,7 @@ fn spawn_maybe_sync(
     if let Writable::Buffer(buffer) = subprocess.stdin.get() {
         if let Err(err) = Writable::buffer_writer_mut(buffer).start() {
             let _ = subprocess.try_kill(subprocess.kill_signal);
-            let _ = global_this.throw_value(err.to_js(global_this));
-            return Err(JsError::Thrown);
+            return Err(global_this.throw_value(err.to_js(global_this)));
         }
     }
 

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1452,7 +1452,11 @@ impl Subprocess<'_> {
         JSValue::NULL
     }
 
-    pub(crate) fn handle_ipc_message(&self, message: &IPC::DecodedIPCMessage, handle: JSValue) {
+    pub(crate) fn handle_ipc_message(
+        &self,
+        message: &IPC::DecodedIPCMessage,
+        handle: JSValue,
+    ) -> JsResult<()> {
         bun_output::scoped_log!(IPC, "Subprocess#handleIPCMessage");
         match message {
             // In future versions we can read this in order to detect version mismatches,
@@ -1484,13 +1488,14 @@ impl Subprocess<'_> {
             IPC::DecodedIPCMessage::Internal(data) => {
                 bun_output::scoped_log!(IPC, "Received IPC internal message from child");
                 let global_this = self.global_this;
-                let _ = node_cluster_binding::handle_internal_message_primary(
+                node_cluster_binding::handle_internal_message_primary(
                     global_this.get(),
                     self,
                     *data,
-                );
+                )?;
             }
         }
+        Ok(())
     }
 
     pub(crate) fn handle_ipc_close(&self) {

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -742,10 +742,6 @@ impl Subprocess<'_> {
         // is still performed.
         let sig: SignalCode = bun_sys_jsc::signal_code_jsc::from_js(signal_arg, global_this)?;
 
-        if global_this.has_exception() {
-            return Ok(JSValue::ZERO);
-        }
-
         match this.try_kill(sig) {
             bun_sys::Result::Ok(()) => {}
             bun_sys::Result::Err(err) => {

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -524,19 +524,15 @@ impl CryptoHasher {
                     match HMAC::init(chosen_algorithm, key.slice()) {
                         Some(h) => h,
                         None => {
-                            if !global.has_exception() {
-                                let err = boring_ssl::ERR_get_error();
-                                if err != 0 {
-                                    let instance = create_crypto_error(global, err);
-                                    boring_ssl::ERR_clear_error();
-                                    return Err(global.throw_value(instance));
-                                } else {
-                                    return Err(global.throw_todo(
-                                        b"HMAC is not supported for this algorithm yet",
-                                    ));
-                                }
+                            let err = boring_ssl::ERR_get_error();
+                            if err != 0 {
+                                let instance = create_crypto_error(global, err);
+                                boring_ssl::ERR_clear_error();
+                                return Err(global.throw_value(instance));
+                            } else {
+                                return Err(global
+                                    .throw_todo(b"HMAC is not supported for this algorithm yet"));
                             }
-                            return Err(JsError::Thrown);
                         }
                     },
                 )));
@@ -599,15 +595,11 @@ impl CryptoHasher {
                     .throw());
             }
         }
-        let buffer = match BlobOrStringOrBuffer::from_js_with_encoding(global, input, encoding)? {
-            Some(b) => b,
-            None => {
-                if !global.has_exception() {
-                    return Err(global
-                        .throw_invalid_arguments(format_args!("expected blob, string or buffer")));
-                }
-                return Err(JsError::Thrown);
-            }
+        let Some(buffer) = BlobOrStringOrBuffer::from_js_with_encoding(global, input, encoding)?
+        else {
+            return Err(
+                global.throw_invalid_arguments(format_args!("expected blob, string or buffer"))
+            );
         };
         // `defer buffer.deinit()` — handled by Drop.
         if is_bun_file_blob(&buffer) {
@@ -739,13 +731,7 @@ impl CryptoHasher {
             output_digest_slice = &mut output_digest_buf;
         }
 
-        let result = match self.final_(global, output_digest_slice) {
-            Ok(r) => r,
-            Err(_) => return Ok(JSValue::ZERO),
-        };
-        if global.has_exception() {
-            return Err(JsError::Thrown);
-        }
+        let result = self.final_(global, output_digest_slice)?;
 
         if let Some(output_buf) = output {
             Ok(output_buf.value)
@@ -758,13 +744,7 @@ impl CryptoHasher {
     fn digest_to_encoding(&self, global: &JSGlobalObject, encoding: Encoding) -> JsResult<JSValue> {
         let mut output_digest_buf: evp::Digest = [0u8; EVP_MAX_MD_SIZE_USIZE];
         let output_digest_slice: &mut [u8] = &mut output_digest_buf;
-        let out = match self.final_(global, output_digest_slice) {
-            Ok(r) => r,
-            Err(_) => return Ok(JSValue::ZERO),
-        };
-        if global.has_exception() {
-            return Err(JsError::Thrown);
-        }
+        let out = self.final_(global, output_digest_slice)?;
         encoding.encode_with_max_size(global, EVP_MAX_MD_SIZE_USIZE, out)
     }
 

--- a/src/runtime/crypto/PBKDF2.rs
+++ b/src/runtime/crypto/PBKDF2.rs
@@ -164,18 +164,14 @@ impl PBKDF2 {
                 }
             }
 
-            if !global_this.has_exception() {
-                let slice = arg4.to_slice(global_this)?;
-                let name = slice.slice();
-                return Err(global_this
-                    .err(
-                        bun_jsc::ErrorCode::CRYPTO_INVALID_DIGEST,
-                        format_args!("Invalid digest: {}", bstr::BStr::new(name)),
-                    )
-                    .throw());
-                // `slice` drops here.
-            }
-            return Err(bun_jsc::JsError::Thrown);
+            let slice = arg4.to_slice(global_this)?;
+            let name = slice.slice();
+            return Err(global_this
+                .err(
+                    bun_jsc::ErrorCode::CRYPTO_INVALID_DIGEST,
+                    format_args!("Invalid digest: {}", bstr::BStr::new(name)),
+                )
+                .throw());
         };
 
         let mut out = PBKDF2 {
@@ -185,9 +181,10 @@ impl PBKDF2 {
             length: keylen,
             algorithm,
         };
+        // Armed only on the error returns below (defused via `into_inner` on success).
         // Non-async path: `StringOrBuffer` fields drop with `out` on early return — no explicit call needed.
         let mut guard = scopeguard::guard(&mut out, |out| {
-            if global_this.has_exception() && flavor == Flavor::Async {
+            if flavor == Flavor::Async {
                 bun_jsc::Unprotect::unprotect(out);
             }
         });

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -3,7 +3,7 @@ use core::fmt::Write as _;
 use std::io::Write as _;
 
 use bun_core::ZigString;
-use bun_jsc::{ArrayBuffer, CallFrame, JSFunction, JSGlobalObject, JSValue, JsError, JsResult};
+use bun_jsc::{ArrayBuffer, CallFrame, JSFunction, JSGlobalObject, JSValue, JsResult};
 // JSC-side ZigString carries `to_js` (the `bun_core::ZigString` repr-twin
 // lives in `bun_jsc::zig_string`); used for ASCII→JS conversions only.
 use bun_jsc::ZigStringJsc as _;
@@ -754,19 +754,14 @@ fn js_password_object_verify(
 
         let algorithm_string = arguments[2].get_zig_string(global_object)?;
 
-        algorithm = match algorithm_from_zig_string(&algorithm_string) {
-            Some(a) => Some(a),
-            None => {
-                if !global_object.has_exception() {
-                    return Err(global_object.throw_invalid_argument_type(
-                        "verify",
-                        "algorithm",
-                        UNKNOWN_PASSWORD_ALGORITHM_MESSAGE,
-                    ));
-                }
-                return Err(JsError::Thrown);
-            }
+        let Some(a) = algorithm_from_zig_string(&algorithm_string) else {
+            return Err(global_object.throw_invalid_argument_type(
+                "verify",
+                "algorithm",
+                UNKNOWN_PASSWORD_ALGORITHM_MESSAGE,
+            ));
         };
+        algorithm = Some(a);
     }
 
     // TODO: this most likely should error like `verifySync` instead of stringifying.
@@ -834,19 +829,14 @@ fn js_password_object_verify_sync(
 
         let algorithm_string = arguments[2].get_zig_string(global_object)?;
 
-        algorithm = match algorithm_from_zig_string(&algorithm_string) {
-            Some(a) => Some(a),
-            None => {
-                if !global_object.has_exception() {
-                    return Err(global_object.throw_invalid_argument_type(
-                        "verify",
-                        "algorithm",
-                        UNKNOWN_PASSWORD_ALGORITHM_MESSAGE,
-                    ));
-                }
-                return Ok(JSValue::ZERO);
-            }
+        let Some(a) = algorithm_from_zig_string(&algorithm_string) else {
+            return Err(global_object.throw_invalid_argument_type(
+                "verify",
+                "algorithm",
+                UNKNOWN_PASSWORD_ALGORITHM_MESSAGE,
+            ));
         };
+        algorithm = Some(a);
     }
 
     let Some(mut password) = StringOrBuffer::from_js(global_object, arguments[0])? else {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4946,7 +4946,7 @@ impl Resolver {
                 if record_type_str.length() == 0 {
                     break 'brk RecordType::DEFAULT;
                 }
-                match RECORD_TYPE_MAP.get(record_type_str.to_slice(global_this).slice()) {
+                match RECORD_TYPE_MAP.get(record_type_str.to_slice(global_this)?.slice()) {
                     Some(r) => *r,
                     None => {
                         return Err(global_this.throw_invalid_argument_property_value(
@@ -5139,7 +5139,7 @@ impl Resolver {
             };
         }
 
-        let name = name_str.to_slice(global_this);
+        let name = name_str.to_slice(global_this)?;
         let resolver = global_resolver(global_this);
 
         resolver.do_lookup(name.slice(), port, options, global_this)
@@ -5918,7 +5918,7 @@ impl Resolver {
                 "non-empty string",
             ));
         }
-        let addr_slice = addr_str.to_slice(global_this);
+        let addr_slice = addr_str.to_slice(global_this)?;
         let addr_s = addr_slice.slice();
 
         let port_value = arguments[1];

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -829,9 +829,7 @@ impl CompileC {
             if !self.deferred_errors.is_empty() {
                 return Err(crate::Error::DeferredErrors);
             } else {
-                if !global_this.has_exception() {
-                    global_this.throw(format_args!("TinyCC failed to compile"));
-                }
+                global_this.throw(format_args!("TinyCC failed to compile"));
                 return Err(crate::Error::JSError);
             }
         }
@@ -1009,9 +1007,7 @@ impl FFI {
         let symbols_object: JSValue = object
             .get_own(global_this, &bun_core::String::borrow_utf8(b"symbols"))?
             .unwrap_or(JSValue::UNDEFINED);
-        if !global_this.has_exception()
-            && (symbols_object.is_empty() || !symbols_object.is_object())
-        {
+        if symbols_object.is_empty() || !symbols_object.is_object() {
             return Err(global_this.throw_invalid_argument_type_value(
                 b"symbols",
                 b"object",
@@ -1019,18 +1015,11 @@ impl FFI {
             ));
         }
 
-        if global_this.has_exception() {
-            return Err(JsError::Thrown);
-        }
-
         // SAFETY: already checked that symbols_object is an object
         if let Some(val) = generate_symbols(global_this, &mut compile_c.symbols.map, unsafe {
             &*symbols_object.get_object().unwrap()
         })? {
-            if !val.is_empty() && !global_this.has_exception() {
-                return Err(global_this.throw_value(val));
-            }
-            return Err(JsError::Thrown);
+            return Err(global_this.throw_value(val));
         }
 
         for func in compile_c.symbols.map.values() {
@@ -1047,10 +1036,6 @@ impl FFI {
             object.get_own(global_this, &bun_core::String::borrow_utf8(b"library"))?
         {
             compile_c.libraries = StringArray::from_js(global_this, library_value, "library")?;
-        }
-
-        if global_this.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         if let Some(flags_value) = object.get_truthy(global_this, "flags")? {
@@ -1093,10 +1078,6 @@ impl FFI {
             }
         }
 
-        if global_this.has_exception() {
-            return Err(JsError::Thrown);
-        }
-
         if let Some(define_value) = object.get_truthy(global_this, "define")? {
             if let Some(define_obj) = define_value.get_object() {
                 let mut iter = JSPropertyIterator::init(
@@ -1118,25 +1099,14 @@ impl FFI {
                             }
                         }
                     }
-                    if global_this.has_exception() {
-                        return Err(JsError::Thrown);
-                    }
 
                     compile_c.define.push([key, owned_value]);
                 }
             }
         }
 
-        if global_this.has_exception() {
-            return Err(JsError::Thrown);
-        }
-
         if let Some(include_value) = object.get_truthy(global_this, "include")? {
             compile_c.include_dirs = StringArray::from_js(global_this, include_value, "include")?;
-        }
-
-        if global_this.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         if let Some(source_value) =
@@ -1167,10 +1137,6 @@ impl FFI {
                 let source_path = source_value.get_zig_string(global_this)?.to_owned_slice_z();
                 compile_c.source = Source::File(source_path);
             }
-        }
-
-        if global_this.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         // Now we compile the code with tinycc.
@@ -1220,15 +1186,12 @@ impl FFI {
             let function_name = function.base_name.clone();
 
             if let Err(err) = function.compile(napi_env) {
-                if !global_this.has_exception() {
-                    let ret = global_this.to_invalid_arguments(format_args!(
-                        "{} when translating symbol \"{}\"",
-                        err.name(),
-                        BStr::new(function_name.as_bytes())
-                    ));
-                    return Err(global_this.throw_value(ret));
-                }
-                return Err(JsError::Thrown);
+                let ret = global_this.to_invalid_arguments(format_args!(
+                    "{} when translating symbol \"{}\"",
+                    err.name(),
+                    BStr::new(function_name.as_bytes())
+                ));
+                return Err(global_this.throw_value(ret));
             }
             match &function.step {
                 Step::Failed { msg, .. } => {

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -2009,7 +2009,10 @@ fn import_windows_socket_payload(global: &JSGlobalObject, msg_data: JSValue) -> 
             return None;
         }
     };
-    let hex = jsc::JSString::opaque_ref(info_value.as_string()).to_slice(global);
+    let Ok(hex) = jsc::JSString::opaque_ref(info_value.as_string()).to_slice(global) else {
+        global.clear_exception();
+        return None;
+    };
     let expected = bun_uws::socket_transfer::bsd_socket_export_size() as usize;
     let mut info = vec![0u8; expected];
     let decoded = strings::decode_hex_to_bytes_truncate(&mut info, hex.slice());

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -2192,38 +2192,35 @@ fn handle_ipc_message(
                 if let Some(marker) = msg_data.get(global_this, "$hasHandle")?
                     && marker.to_boolean()
                 {
-                    {
-                        #[cfg(windows)]
-                        let imported = import_windows_socket_payload(global_this, msg_data)?;
-                        #[cfg(windows)]
-                        let ack = imported.is_some();
-                        #[cfg(not(windows))]
-                        let ack = send_queue.incoming_fd.get().is_some();
-                        let packet = if ack {
-                            get_ack_packet(send_queue.mode)
-                        } else {
-                            get_nack_packet(send_queue.mode)
-                        };
-                        let mut reply = SendHandle {
-                            data: StreamBuffer::default(),
-                            handle: None,
-                            callbacks: CallbackList::AckNack,
-                        };
-                        handle_oom(reply.data.write(packet));
-                        send_queue.insert_message(reply);
-                        log!("IPC call continueSend() from internal $hasHandle ack");
-                        send_queue
-                            .continue_send(global_this, ContinueSendReason::NewMessageAppended);
-                        if !ack {
-                            return Ok(());
-                        }
-                        #[cfg(windows)]
-                        let fd = imported.unwrap();
-                        #[cfg(not(windows))]
-                        let fd = send_queue.incoming_fd.take().unwrap();
-                        received_fd = Some(fd);
-                        handle_js = received_fd_to_js(fd);
+                    #[cfg(windows)]
+                    let imported = import_windows_socket_payload(global_this, msg_data)?;
+                    #[cfg(windows)]
+                    let ack = imported.is_some();
+                    #[cfg(not(windows))]
+                    let ack = send_queue.incoming_fd.get().is_some();
+                    let packet = if ack {
+                        get_ack_packet(send_queue.mode)
+                    } else {
+                        get_nack_packet(send_queue.mode)
+                    };
+                    let mut reply = SendHandle {
+                        data: StreamBuffer::default(),
+                        handle: None,
+                        callbacks: CallbackList::AckNack,
+                    };
+                    handle_oom(reply.data.write(packet));
+                    send_queue.insert_message(reply);
+                    log!("IPC call continueSend() from internal $hasHandle ack");
+                    send_queue.continue_send(global_this, ContinueSendReason::NewMessageAppended);
+                    if !ack {
+                        return Ok(());
                     }
+                    #[cfg(windows)]
+                    let fd = imported.unwrap();
+                    #[cfg(not(windows))]
+                    let fd = send_queue.incoming_fd.take().unwrap();
+                    received_fd = Some(fd);
+                    handle_js = received_fd_to_js(fd);
                 }
             }
         }

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -970,7 +970,7 @@ impl SendQueueOwner {
         }
     }
 
-    fn handle_ipc_message(self, msg: &DecodedIPCMessage, handle: JSValue) {
+    fn handle_ipc_message(self, msg: &DecodedIPCMessage, handle: JSValue) -> JsResult<()> {
         match self {
             // SAFETY: an attached owner is live (it holds a ref on the SendQueue).
             SendQueueOwner::Subprocess(p) => unsafe { p.as_ref() }.handle_ipc_message(msg, handle),
@@ -2000,19 +2000,17 @@ pub fn windows_export_socket_hex(fd: Fd, peer_pid: u32) -> Option<Box<[u8]>> {
 pub const WIN_SOCKET_INFO_KEY: &[u8] = b"$winSocketInfo";
 
 #[cfg(windows)]
-fn import_windows_socket_payload(global: &JSGlobalObject, msg_data: JSValue) -> Option<Fd> {
-    let info_value = match msg_data.get(global, WIN_SOCKET_INFO_KEY) {
-        Ok(Some(v)) if v.is_string() => v,
-        Ok(_) => return None,
-        Err(_) => {
-            global.clear_exception();
-            return None;
-        }
+fn import_windows_socket_payload(
+    global: &JSGlobalObject,
+    msg_data: JSValue,
+) -> JsResult<Option<Fd>> {
+    let Some(info_value) = msg_data
+        .get(global, WIN_SOCKET_INFO_KEY)?
+        .filter(|v| v.is_string())
+    else {
+        return Ok(None);
     };
-    let Ok(hex) = jsc::JSString::opaque_ref(info_value.as_string()).to_slice(global) else {
-        global.clear_exception();
-        return None;
-    };
+    let hex = jsc::JSString::opaque_ref(info_value.as_string()).to_slice(global)?;
     let expected = bun_uws::socket_transfer::bsd_socket_export_size() as usize;
     let mut info = vec![0u8; expected];
     let decoded = strings::decode_hex_to_bytes_truncate(&mut info, hex.slice());
@@ -2022,7 +2020,7 @@ fn import_windows_socket_payload(global: &JSGlobalObject, msg_data: JSValue) -> 
             decoded,
             expected
         );
-        return None;
+        return Ok(None);
     }
     let mut err: c_int = 0;
     // SAFETY: `info` is a live buffer of export_size() bytes holding the
@@ -2031,10 +2029,10 @@ fn import_windows_socket_payload(global: &JSGlobalObject, msg_data: JSValue) -> 
     };
     if sock == bun_uws::LIBUS_SOCKET_DESCRIPTOR::MAX {
         log!("importWindowsSocketPayload: WSASocketW failed: {}", err);
-        return None;
+        return Ok(None);
     }
     msg_data.delete_property(global, WIN_SOCKET_INFO_KEY);
-    Some(Fd::from_system(sock as *mut c_void))
+    Ok(Some(Fd::from_system(sock as *mut c_void)))
 }
 
 fn received_fd_to_js(fd: Fd) -> JSValue {
@@ -2059,11 +2057,13 @@ enum IPCCommand {
     Nack,
 }
 
+/// One decoded message's delivery. A JS exception raised while inspecting or delivering it is this message's
+/// failure; the on-data callers fold it (reported as uncaught) and go on to the next message.
 fn handle_ipc_message(
     send_queue: &SendQueue,
     message: DecodedIPCMessage,
     global_this: &JSGlobalObject,
-) {
+) -> JsResult<()> {
     #[cfg(debug_assertions)]
     {
         // The `Formatter` runs its deinit in `Drop`.
@@ -2088,25 +2088,14 @@ fn handle_ipc_message(
         if let DecodedIPCMessage::Data(msg_data) = &message {
             let msg_data = *msg_data;
             if msg_data.is_object() {
-                let cmd = match msg_data.fast_get(global_this, jsc::BuiltinName::cmd) {
-                    Err(_) => {
-                        global_this.clear_exception();
-                        break 'handle_message;
-                    }
-                    Ok(None) => break 'handle_message,
-                    Ok(Some(v)) => v,
+                let Some(cmd) = msg_data.fast_get(global_this, jsc::BuiltinName::cmd)? else {
+                    break 'handle_message;
                 };
                 if cmd.is_string() {
                     if !cmd.is_cell() {
                         break 'handle_message;
                     }
-                    let cmd_str = match bun_jsc::bun_string_jsc::from_js(cmd, global_this) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            let _ = global_this.take_exception(e);
-                            break 'handle_message;
-                        }
-                    };
+                    let cmd_str = bun_jsc::bun_string_jsc::from_js(cmd, global_this)?;
                     if cmd_str.eql_comptime(b"NODE_HANDLE") {
                         internal_command = Some(IPCCommand::Handle(msg_data));
                     } else if cmd_str.eql_comptime(b"NODE_HANDLE_ACK") {
@@ -2123,7 +2112,7 @@ fn handle_ipc_message(
         match icmd {
             IPCCommand::Handle(msg_data) => {
                 #[cfg(windows)]
-                let imported = import_windows_socket_payload(global_this, msg_data);
+                let imported = import_windows_socket_payload(global_this, msg_data)?;
                 #[cfg(windows)]
                 let ack = imported.is_some();
                 #[cfg(not(windows))]
@@ -2149,7 +2138,7 @@ fn handle_ipc_message(
                 send_queue.continue_send(global_this, ContinueSendReason::NewMessageAppended);
 
                 if !ack {
-                    return;
+                    return Ok(());
                 }
 
                 // Get file descriptor and clear it
@@ -2160,7 +2149,7 @@ fn handle_ipc_message(
 
                 let Some(owner) = send_queue.owner_ref() else {
                     let _ = fd.close_allowing_standard_io(None);
-                    return;
+                    return Ok(());
                 };
                 let target: JSValue = match owner.kind() {
                     SendQueueOwnerKind::Subprocess => owner.this_jsvalue(),
@@ -2171,12 +2160,10 @@ fn handle_ipc_message(
                 // early-error return and the fall-through.
                 let _scope = global_this.bun_vm().enter_event_loop_scope();
                 let fd_js = received_fd_to_js(fd);
-                let res = ipc_parse(global_this, target, msg_data, fd_js);
-                if let Err(e) = res {
+                if let Err(e) = ipc_parse(global_this, target, msg_data, fd_js) {
                     // ack written already, that's okay.
                     let _ = fd.close_allowing_standard_io(None);
-                    crate::dispatch::fold(Err(e));
-                    return;
+                    return Err(e);
                 }
                 drop(_scope);
 
@@ -2184,15 +2171,15 @@ fn handle_ipc_message(
                 // we have sent the ack already so the next message could arrive at any time. maybe even before
                 // parseHandle calls emit(). however, node does this too and its messages don't end up out of order.
                 // so hopefully ours won't either.
-                return;
+                return Ok(());
             }
             IPCCommand::Ack => {
                 send_queue.on_ack_nack(global_this, AckNack::Ack);
-                return;
+                return Ok(());
             }
             IPCCommand::Nack => {
                 send_queue.on_ack_nack(global_this, AckNack::Nack);
-                return;
+                return Ok(());
             }
         }
     } else {
@@ -2202,10 +2189,12 @@ fn handle_ipc_message(
         if let DecodedIPCMessage::Internal(msg_data) = &message {
             let msg_data = *msg_data;
             if msg_data.is_object() {
-                match msg_data.get(global_this, "$hasHandle") {
-                    Ok(Some(marker)) if marker.to_boolean() => {
+                if let Some(marker) = msg_data.get(global_this, "$hasHandle")?
+                    && marker.to_boolean()
+                {
+                    {
                         #[cfg(windows)]
-                        let imported = import_windows_socket_payload(global_this, msg_data);
+                        let imported = import_windows_socket_payload(global_this, msg_data)?;
                         #[cfg(windows)]
                         let ack = imported.is_some();
                         #[cfg(not(windows))]
@@ -2226,7 +2215,7 @@ fn handle_ipc_message(
                         send_queue
                             .continue_send(global_this, ContinueSendReason::NewMessageAppended);
                         if !ack {
-                            return;
+                            return Ok(());
                         }
                         #[cfg(windows)]
                         let fd = imported.unwrap();
@@ -2235,15 +2224,11 @@ fn handle_ipc_message(
                         received_fd = Some(fd);
                         handle_js = received_fd_to_js(fd);
                     }
-                    Ok(_) => {}
-                    Err(_) => {
-                        global_this.clear_exception();
-                    }
                 }
             }
         }
         match send_queue.owner.get() {
-            Some(owner) => owner.handle_ipc_message(&message, handle_js),
+            Some(owner) => owner.handle_ipc_message(&message, handle_js)?,
             // Owner already torn down: nobody will adopt the descriptor we just acked.
             None => {
                 if let Some(fd) = received_fd {
@@ -2252,6 +2237,7 @@ fn handle_ipc_message(
             }
         }
     }
+    Ok(())
 }
 
 enum DecodeStep {
@@ -2356,7 +2342,11 @@ fn on_data2(send_queue: &SendQueue, all_data: &[u8]) {
             loop {
                 match decode_next_json(&send_queue.incoming, &global_this) {
                     DecodeStep::Message(result) => {
-                        handle_ipc_message(send_queue, result.message, &global_this);
+                        crate::dispatch::fold(handle_ipc_message(
+                            send_queue,
+                            result.message,
+                            &global_this,
+                        ));
                     }
                     step => return finish_decode(send_queue, &step),
                 }
@@ -2376,7 +2366,11 @@ fn on_data2(send_queue: &SendQueue, all_data: &[u8]) {
                     match decode_ipc_message(Mode::Advanced, data, &global_this, None) {
                         Ok(result) => {
                             let consumed = result.bytes_consumed as usize;
-                            handle_ipc_message(send_queue, result.message, &global_this);
+                            crate::dispatch::fold(handle_ipc_message(
+                                send_queue,
+                                result.message,
+                                &global_this,
+                            ));
                             if consumed < data.len() {
                                 data = &data[consumed..];
                             } else {
@@ -2409,7 +2403,11 @@ fn on_data2(send_queue: &SendQueue, all_data: &[u8]) {
             loop {
                 match decode_next_advanced(&send_queue.incoming, &global_this, &mut slice_start) {
                     DecodeStep::Message(result) => {
-                        handle_ipc_message(send_queue, result.message, &global_this);
+                        crate::dispatch::fold(handle_ipc_message(
+                            send_queue,
+                            result.message,
+                            &global_this,
+                        ));
                     }
                     step => return finish_decode(send_queue, &step),
                 }
@@ -2535,7 +2533,11 @@ pub mod IPCHandlers {
                     loop {
                         match decode_next_json(&send_queue.incoming, &global_this) {
                             DecodeStep::Message(result) => {
-                                handle_ipc_message(send_queue, result.message, &global_this);
+                                crate::dispatch::fold(handle_ipc_message(
+                                    send_queue,
+                                    result.message,
+                                    &global_this,
+                                ));
                             }
                             step => return finish_decode(send_queue, &step),
                         }
@@ -2557,7 +2559,11 @@ pub mod IPCHandlers {
                             &mut slice_start,
                         ) {
                             DecodeStep::Message(result) => {
-                                handle_ipc_message(send_queue, result.message, &global_this);
+                                crate::dispatch::fold(handle_ipc_message(
+                                    send_queue,
+                                    result.message,
+                                    &global_this,
+                                ));
                             }
                             step => return finish_decode(send_queue, &step),
                         }

--- a/src/runtime/ipc_host.rs
+++ b/src/runtime/ipc_host.rs
@@ -332,7 +332,7 @@ pub(crate) fn emit_handle_ipc_message(
             return Ok(JSValue::UNDEFINED);
         };
         // SAFETY: `get_ipc_instance` returns the live boxed IPCInstance.
-        unsafe { (*ipc).handle_ipc_message(&DecodedIPCMessage::Data(message), handle) };
+        unsafe { (*ipc).handle_ipc_message(&DecodedIPCMessage::Data(message), handle) }?;
     } else {
         if !target.is_cell() {
             return Ok(JSValue::UNDEFINED);
@@ -342,7 +342,7 @@ pub(crate) fn emit_handle_ipc_message(
         };
         // SAFETY: `from_js_direct` returned a non-null `*mut Subprocess`; the JS
         // wrapper holds it alive for the call.
-        unsafe { (*subprocess).handle_ipc_message(&DecodedIPCMessage::Data(message), handle) };
+        unsafe { (*subprocess).handle_ipc_message(&DecodedIPCMessage::Data(message), handle) }?;
     }
     Ok(JSValue::UNDEFINED)
 }
@@ -423,7 +423,7 @@ impl IPCInstance {
     }
 
     /// Dispatches a decoded IPC message (and optional handle) to the JS `process` listeners.
-    pub fn handle_ipc_message(&self, message: &DecodedIPCMessage, handle: JSValue) {
+    pub fn handle_ipc_message(&self, message: &DecodedIPCMessage, handle: JSValue) -> JsResult<()> {
         // SAFETY: VM singleton + its event loop are process-lifetime.
         let vm = bun_jsc::virtual_machine::VirtualMachine::get().as_mut();
         let global_this = vm.global();
@@ -441,18 +441,15 @@ impl IPCInstance {
             }
             DecodedIPCMessage::Internal(data) => {
                 bun_core::scoped_log!(IPC, "Received IPC internal message from parent");
-                event_loop.enter();
-                // SAFETY: `global_this` is the live VM global; JS thread.
-                unsafe {
-                    crate::jsc_hooks::handle_ipc_internal_child(
-                        core::ptr::from_ref(global_this).cast_mut(),
-                        data,
-                        handle,
-                    )
-                };
-                event_loop.exit();
+                let _entered = vm.enter_event_loop_scope();
+                crate::node::node_cluster_binding::handle_internal_message_child(
+                    global_this,
+                    data,
+                    handle,
+                )?;
             }
         }
+        Ok(())
     }
 
     /// Tears down the IPC channel and emits the disconnect events on `process`.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1411,26 +1411,6 @@ fn load_standalone_sourcemap(
     unsafe { (*graph).find(path)?.sourcemap.load() }
 }
 
-/// `node_cluster_binding.handleInternalMessageChild(global, data)` — the
-/// `IPCInstance.handleIPCMessage` `.internal` arm.
-///
-/// # Safety
-/// `global` is the live VM global; called on the JS thread inside an
-/// `event_loop.enter()` scope.
-pub(crate) unsafe fn handle_ipc_internal_child(
-    global: *mut JSGlobalObject,
-    data: JSValue,
-    handle: JSValue,
-) {
-    // SAFETY: per fn contract.
-    let global = unsafe { &*global };
-    // Spec discards a JS exception here (`catch |err| switch (err) {
-    // error.JSError => {} }`); the low tier already wrapped this call in
-    // `event_loop.enter()/exit()` which clears any pending exception, so
-    // dropping the `Err` is correct.
-    let _ = crate::node::node_cluster_binding::handle_internal_message_child(global, data, handle);
-}
-
 /// `node_cluster_binding.child_singleton.deinit()` —
 /// `IPCInstance.handleIPCClose`.
 ///

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -335,7 +335,7 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
         let atype = address_type.to_int32();
 
         let host_owned: Vec<u8> = if address.is_string() {
-            let s = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global);
+            let s = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global)?;
             let mut v = s.slice().to_vec();
             v.push(0);
             v

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -423,7 +423,7 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
         let mut is_udp = false;
         let atype: i32;
         if address_type.is_string() {
-            let s = bun_jsc::JSString::opaque_ref(address_type.as_string()).to_slice(global);
+            let s = bun_jsc::JSString::opaque_ref(address_type.as_string()).to_slice(global)?;
             is_udp = true;
             atype = if s.slice() == b"udp6" { 6 } else { 4 };
         } else {
@@ -448,7 +448,7 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
             if !address.is_string() {
                 return Err(global.throw_invalid_argument_type_value("address", "string", address));
             }
-            let path_slice = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global);
+            let path_slice = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global)?;
             let path_bytes = path_slice.slice();
             // SAFETY: sockaddr_un is plain C data; all-zero is a valid value.
             let mut sun: libc::sockaddr_un = unsafe { bun_core::ffi::zeroed_unchecked() };
@@ -600,7 +600,7 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
         let fd: c_int;
         let bound_family: c_int;
         if address.is_string() {
-            let addr_slice = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global);
+            let addr_slice = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global)?;
             let addr_bytes = addr_slice.slice();
             let mut addr_z: [u8; 256] = [0; 256];
             if addr_bytes.len() >= addr_z.len() {

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -42,10 +42,6 @@ where
     // releases its own resources; the wrapper structs need no manual hook).
     let args = <A as FsArgument>::from_js(global, &mut slice)?;
 
-    if global.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
-
     // R-2: `JsCell::with_mut` scopes the `&mut NodeFS` to the blocking
     // syscall; `dispatch` never re-enters JS, and `Maybe<R>` is fully owned
     // (`sys::Error.path` is `Box<[u8]>`, not a borrow into `sync_error_buf`).
@@ -91,14 +87,6 @@ fn run_async<A: FsArgument>(
             return Err(err);
         }
     };
-
-    if global.has_exception() {
-        args.unprotect();
-        drop(args);
-        // SAFETY: not yet dropped; only drop site for this path.
-        unsafe { ManuallyDrop::drop(&mut slice) };
-        return Ok(JSValue::ZERO);
-    }
 
     if A::HAVE_ABORT_SIGNAL {
         if let Some(signal) = args.signal() {
@@ -198,13 +186,6 @@ impl Binding {
             }
         };
 
-        if global.has_exception() {
-            drop(cp_args);
-            // SAFETY: not yet dropped; only drop site for this path.
-            unsafe { ManuallyDrop::drop(&mut slice) };
-            return Ok(JSValue::ZERO);
-        }
-
         // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
         Ok(AsyncCpTask::create(global, this, cp_args, vm))
@@ -222,10 +203,6 @@ impl Binding {
 
         // `defer args.deinit()` → `Drop` on `cp_args` (its `PathLike` fields).
         let cp_args = args::Cp::from_js(global, &mut slice)?;
-
-        if global.has_exception() {
-            return Ok(JSValue::ZERO);
-        }
 
         // R-2: blocking syscall — `&mut NodeFS` scoped to the call, no JS re-entry.
         match this.node_fs.with_mut(|nfs| nfs.cp(&cp_args, Flavor::Sync)) {
@@ -255,13 +232,6 @@ impl Binding {
             }
         };
 
-        if global.has_exception() {
-            drop(rd_args);
-            // SAFETY: not yet dropped; only drop site for this path.
-            unsafe { ManuallyDrop::drop(&mut slice) };
-            return Ok(JSValue::ZERO);
-        }
-
         // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
         // /$bunfs/ is in-memory; readdir_inner handles it (recursive included).
@@ -286,10 +256,6 @@ impl Binding {
 
         let watch_args = fs::Watcher::Arguments::from_js(global, &mut slice)?;
 
-        if global.has_exception() {
-            return Ok(JSValue::ZERO);
-        }
-
         // R-2: `NodeFS::watch` only reads `self.vm` (no scratch-buffer write);
         // scoped via `with_mut` so the borrow cannot outlive the call.
         match this
@@ -312,10 +278,6 @@ impl Binding {
         let mut slice = ArgumentsSlice::init(vm, frame.arguments());
 
         let wf_args = fs::StatWatcher::Arguments::from_js(global, &mut slice)?;
-
-        if global.has_exception() {
-            return Ok(JSValue::ZERO);
-        }
 
         match this
             .node_fs

--- a/src/runtime/node/node_util_binding.rs
+++ b/src/runtime/node/node_util_binding.rs
@@ -237,7 +237,7 @@ pub(crate) fn parse_env(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<
 
     // `validate_string` accepts StringObject, so coerce to a primitive JSString
     // before slicing.
-    let str = content.to_js_string(global)?.to_slice(global);
+    let str = content.to_js_string(global)?.to_slice(global)?;
 
     let mut p = envloader::Loader::init();
     p.load_from_string::<true, false>(str.slice())?;

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -115,10 +115,10 @@ pub(crate) fn crc32(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsRe
             // `is_string_literal()` guarantees `as_string()` is non-null and points to a
             // live JSString cell on the JSC heap. `JSString` is an `opaque_ffi!`
             // ZST handle; `opaque_ref` is the centralised deref proof.
-            break 'blk bun_jsc::JSString::opaque_ref(data.as_string()).to_slice(global_this);
+            break 'blk bun_jsc::JSString::opaque_ref(data.as_string()).to_slice(global_this)?;
         }
         let Some(buffer) = data.as_array_buffer(global_this) else {
-            let ty_str = data.js_type_string(global_this).to_slice(global_this);
+            let ty_str = data.js_type_string(global_this).to_slice(global_this)?;
             // ty_str drops at end of scope
             return Err(global_this
                 .err(

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -3,10 +3,10 @@ use core::fmt;
 use bun_core::ZigString;
 use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsError, JsResult};
 
-fn get_type_name(global_object: &JSGlobalObject, value: JSValue) -> ZigString {
+fn get_type_name(global_object: &JSGlobalObject, value: JSValue) -> JsResult<ZigString> {
     let js_type = value.js_type();
     if js_type.is_array() {
-        return ZigString::static_("array");
+        return Ok(ZigString::static_("array"));
     }
     value
         .js_type_string(global_object)
@@ -43,7 +43,10 @@ pub(crate) fn throw_err_invalid_arg_type(
     expected_type: &str,
     value: JSValue,
 ) -> JsError {
-    let actual_type = get_type_name(global_this, value);
+    let actual_type = match get_type_name(global_this, value) {
+        Ok(t) => t,
+        Err(e) => return e,
+    };
     throw_err_invalid_arg_type_with_message(
         global_this,
         format_args!(
@@ -395,7 +398,7 @@ pub(crate) fn validate_array(
     min_length: Option<i32>,
 ) -> JsResult<()> {
     if !value.js_type().is_array() {
-        let actual_type = get_type_name(global_this, value);
+        let actual_type = get_type_name(global_this, value)?;
         return Err(throw_err_invalid_arg_type_with_message(
             global_this,
             format_args!(

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -970,10 +970,6 @@ impl NodeHTTPResponse {
             &[]
         };
 
-        if global_object.has_exception() {
-            return Err(jsc::JsError::Thrown);
-        }
-
         if state.is_http_status_called() {
             return err_throw(
                 global_object,
@@ -1996,10 +1992,6 @@ impl NodeHTTPResponse {
             }
         }
         // string_or_buffer drops at scope exit.
-
-        if global_object.has_exception() {
-            return Err(jsc::JsError::Thrown);
-        }
 
         let bytes = string_or_buffer.slice();
 

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -15,7 +15,7 @@ pub use http_method::{Method, Optional as MethodOptional};
 use super::server_body::ServerInitContext;
 use super::web_socket_server_context::WebSocketServerContext;
 use super::{AnyRoute, AnyServer};
-use crate::server::jsc::{JSGlobalObject, JSPropertyIterator, JSValue, JsError, JsResult, Strong};
+use crate::server::jsc::{JSGlobalObject, JSPropertyIterator, JSValue, JsResult, Strong};
 use bun_core::fmt as bun_fmt;
 
 pub use crate::socket::ssl_config::SSLConfig;
@@ -690,9 +690,6 @@ impl ServerConfig {
             }
             args.reuse_port = args.development == DevelopmentOption::Production;
         }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
-        }
 
         if let Some(static_) = get_routes_object(global, arg)? {
             let Some(static_obj) = static_.get_object() else {
@@ -991,10 +988,6 @@ impl ServerConfig {
             }
         }
 
-        if global.has_exception() {
-            return Err(JsError::Thrown);
-        }
-
         if let Some(value) = arg.get(global, "idleTimeout")? {
             if !value.is_undefined_or_null() {
                 if !value.is_any_int() {
@@ -1033,9 +1026,6 @@ impl ServerConfig {
                 websocket_object,
             )?);
         }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
-        }
 
         if let Some(port_) = arg.get_truthy(global, "port")? {
             let number = port_.to_number(global)?;
@@ -1066,9 +1056,6 @@ impl ServerConfig {
             }
             port = p;
         }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
-        }
 
         if let Some(base_uri) = arg.get_truthy(global, "baseURI")? {
             let sliced = base_uri.to_slice(global)?;
@@ -1077,9 +1064,6 @@ impl ServerConfig {
                 // sliced drops at scope end
                 args.base_uri = Box::<[u8]>::from(sliced.slice());
             }
-        }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         let host = if let Some(h) = arg.get_stringish(global, "hostname")? {
@@ -1101,9 +1085,6 @@ impl ServerConfig {
                 has_hostname = true;
             }
         }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
-        }
 
         if let Some(unix) = arg.get_stringish(global, "unix")? {
             let unix_str = unix.to_utf8();
@@ -1117,9 +1098,6 @@ impl ServerConfig {
                 args.address = Address::Unix(bun_core::ZBox::from_bytes(unix_str.slice()));
             }
         }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
-        }
 
         if let Some(id) = arg.get(global, "id")? {
             if id.is_undefined_or_null() {
@@ -1132,9 +1110,6 @@ impl ServerConfig {
                     args.allow_hot = false;
                 }
             }
-        }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         if opts.allow_bake_config {
@@ -1164,29 +1139,17 @@ impl ServerConfig {
         if let Some(dev) = arg.get(global, "reusePort")? {
             args.reuse_port = dev.to_boolean();
         }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
-        }
 
         if let Some(dev) = arg.get(global, "ipv6Only")? {
             args.ipv6_only = dev.to_boolean();
-        }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         if let Some(v) = arg.get(global, "http3")? {
             args.http3 = v.to_boolean();
         }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
-        }
 
         if let Some(v) = arg.get(global, "http1")? {
             args.http1 = v.to_boolean();
-        }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         if let Some(max_request_body_size) = arg.get_truthy(global, "maxRequestBodySize")? {
@@ -1194,9 +1157,6 @@ impl ServerConfig {
                 args.max_request_body_size = u64::try_from(max_request_body_size.to_int64().max(0))
                     .expect("int cast") as usize;
             }
-        }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         if let Some(on_error) = arg.get_truthy(global, "error")? {
@@ -1209,9 +1169,6 @@ impl ServerConfig {
             // site (`serve_with!` / `on_reload_from_zig`) so the wrapped fn is
             // rooted by the wrapper's WriteBarrier slot the moment it exists.
             args.on_error = on_error;
-        }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         if let Some(on_request_) = arg.get_truthy(global, "onNodeHTTPRequest")? {
@@ -1237,9 +1194,6 @@ impl ServerConfig {
             && !(opts.previous_routes && !args.had_routes_object)
             && opts.is_fetch_required
         {
-            if global.has_exception() {
-                return Err(JsError::Thrown);
-            }
             return Err(global.throw_invalid_arguments(format_args!(
                 "Bun.serve() needs either:\n\n\
                  \x20 - A routes object:\n\
@@ -1254,10 +1208,6 @@ impl ServerConfig {
                  \x20    }}\n\n\
                  Learn more at https://bun.com/docs/api/http",
             )));
-        } else {
-            if global.has_exception() {
-                return Err(JsError::Thrown);
-            }
         }
 
         if let Some(tls) = arg.get_truthy(global, "tls")? {
@@ -1269,15 +1219,9 @@ impl ServerConfig {
                     // Empty TLS array means no TLS - this is valid
                 } else {
                     while let Some(item) = value_iter.next()? {
-                        let ssl_config = match SSLConfig::from_js(vm, global, item)? {
-                            Some(c) => c,
-                            None => {
-                                if global.has_exception() {
-                                    return Err(JsError::Thrown);
-                                }
-                                // Backwards-compatibility; we ignored empty tls objects.
-                                continue;
-                            }
+                        let Some(ssl_config) = SSLConfig::from_js(vm, global, item)? else {
+                            // Backwards-compatibility; we ignored empty tls objects.
+                            continue;
                         };
 
                         if args.ssl_config.is_none() {
@@ -1301,13 +1245,7 @@ impl ServerConfig {
                 if let Some(ssl_config) = SSLConfig::from_js(vm, global, tls)? {
                     args.ssl_config = Some(ssl_config);
                 }
-                if global.has_exception() {
-                    return Err(JsError::Thrown);
-                }
             }
-        }
-        if global.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         // @compatibility Bun v0.x - v0.2.1
@@ -1315,9 +1253,6 @@ impl ServerConfig {
         if args.ssl_config.is_none() {
             if let Some(ssl_config) = SSLConfig::from_js(vm, global, arg)? {
                 args.ssl_config = Some(ssl_config);
-            }
-            if global.has_exception() {
-                return Err(JsError::Thrown);
             }
         }
 

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -849,7 +849,7 @@ impl ServerWebSocket {
         // triggers GC, so both are converted (and their JSStrings held) before
         // the handler state is read.
         let topic_string = topic_value.to_js_string(global_this)?;
-        let topic_slice = topic_string.view(global_this).to_slice();
+        let topic_slice = topic_string.view(global_this)?.to_slice();
         if topic_slice.slice().is_empty() {
             return Err(global_this.throw(format_args!("publish requires a non-empty topic")));
         }
@@ -874,7 +874,7 @@ impl ServerWebSocket {
             (slice, Opcode::Binary)
         } else {
             let string = message_value.to_js_string(global_this)?;
-            message_slice = string.view(global_this).to_slice();
+            message_slice = string.view(global_this)?.to_slice();
             message_string = Some(string);
             (message_slice.slice(), Opcode::Text)
         };
@@ -912,7 +912,7 @@ impl ServerWebSocket {
         }
 
         let topic_string = topic_value.to_js_string(global_this)?;
-        let topic_slice = topic_string.view(global_this).to_slice();
+        let topic_slice = topic_string.view(global_this)?.to_slice();
 
         let compress = Self::parse_compress_arg(
             global_this,
@@ -926,7 +926,7 @@ impl ServerWebSocket {
         }
 
         let message_string = message_value.to_js_string(global_this)?;
-        let message_slice = message_string.view(global_this).to_slice();
+        let message_slice = message_string.view(global_this)?.to_slice();
 
         let Some(ctx) = self.publish_ctx() else {
             bun_output::scoped_log!(WebSocketServer, "publish() closed");
@@ -966,7 +966,7 @@ impl ServerWebSocket {
         }
 
         let topic_string = topic_value.to_js_string(global_this)?;
-        let topic_slice = topic_string.view(global_this).to_slice();
+        let topic_slice = topic_string.view(global_this)?.to_slice();
         if topic_slice.slice().is_empty() {
             return Err(global_this.throw(format_args!("publishBinary requires a non-empty topic")));
         }
@@ -1097,7 +1097,7 @@ impl ServerWebSocket {
 
         {
             let js_string = message_value.to_js_string(global_this)?;
-            let view = js_string.view(global_this);
+            let view = js_string.view(global_this)?;
             let slice = view.to_slice();
 
             let buffer = slice.slice();
@@ -1142,7 +1142,7 @@ impl ServerWebSocket {
         }
 
         let js_string = message_value.to_js_string(global_this)?;
-        let view = js_string.view(global_this);
+        let view = js_string.view(global_this)?;
         let slice = view.to_slice();
 
         let buffer = slice.slice();
@@ -1263,7 +1263,7 @@ impl ServerWebSocket {
                     return Ok(ret);
                 } else if value.is_string() {
                     // SAFETY: to_js_string returns a non-null *mut JSString on the Ok path.
-                    let string_value = value.to_js_string(global_this)?.to_slice(global_this);
+                    let string_value = value.to_js_string(global_this)?.to_slice(global_this)?;
                     let buffer = string_value.slice();
                     if buffer.len() > MAX_CONTROL_FRAME_PAYLOAD {
                         return Err(throw_control_frame_too_large(global_this, buffer.len()));

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1500,7 +1500,7 @@ where
         // Converting `message_value` can run user JS / GC; the JSString keeps the
         // topic bytes alive across it.
         let topic_string = topic_value.to_js_string(global)?;
-        let topic = topic_string.view(global).to_slice();
+        let topic = topic_string.view(global)?.to_slice();
         // jsc.JSValue
         let message_value = iter
             .next_eat()
@@ -1649,7 +1649,7 @@ where
         } else {
             let js_str = message_value.to_js_string(global)?;
             js_string = Some(js_str);
-            string_slice = js_str.view(global).to_slice();
+            string_slice = js_str.view(global)?.to_slice();
             (string_slice.slice(), uws_sys::Opcode::Text)
         };
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -594,9 +594,6 @@ impl AnyRoute {
                 bun_opaque::opaque_deref_mut(h.as_ptr()).deref();
             }
         });
-        if init_ctx.global.has_exception() {
-            return Err(JsError::Thrown);
-        }
 
         // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
         let headers_ref = fetch_headers.map(|p| bun_opaque::opaque_deref(p.as_ptr().cast_const()));
@@ -1766,10 +1763,6 @@ where
                         data_value = headers_value;
                     }
 
-                    if global.has_exception() {
-                        return Err(JsError::Thrown);
-                    }
-
                     if let Some(headers_value) = opts.fast_get(global, jsc::BuiltinName::headers)? {
                         if headers_value.is_empty_or_undefined_or_null() {
                             break 'getter;
@@ -1788,21 +1781,14 @@ where
                                             break 'brk fetch_headers.as_ptr();
                                         }
                                     }
-                                    if !global.has_exception() {
-                                        return Err(global.throw_invalid_arguments(format_args!(
-                                            "upgrade options.headers must be a Headers or an object"
-                                        )));
-                                    }
-                                    return Err(JsError::Thrown);
+                                    return Err(global.throw_invalid_arguments(format_args!(
+                                        "upgrade options.headers must be a Headers or an object"
+                                    )));
                                 }
                             };
                         // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
                         let fetch_headers_to_use =
                             bun_opaque::opaque_deref_mut(fetch_headers_to_use);
-
-                        if global.has_exception() {
-                            return Err(JsError::Thrown);
-                        }
 
                         if let Some(protocol) =
                             fetch_headers_to_use.fast_get(HTTPHeaderName::SecWebSocketProtocol)
@@ -1834,10 +1820,6 @@ where
                                 raw_response.socket().cast::<c_void>(),
                             );
                         }
-                    }
-
-                    if global.has_exception() {
-                        return Err(JsError::Thrown);
                     }
                 }
             }
@@ -2021,9 +2003,6 @@ where
                 if let Some(v) = opts.fast_get(global, jsc::BuiltinName::Data)? {
                     data_value = v;
                 }
-                if global.has_exception() {
-                    return Err(JsError::Thrown);
-                }
 
                 if let Some(headers_value) = opts.fast_get(global, jsc::BuiltinName::Headers)? {
                     if headers_value.is_empty_or_undefined_or_null() {
@@ -2032,33 +2011,21 @@ where
                     use jsc::HTTPHeaderName;
                     let fh: *mut FetchHeaders = match fetch_headers_from_js(headers_value, global) {
                         Some(h) => h,
-                        None => {
+                        None => 'brk: {
                             if headers_value.is_object() {
                                 if let Some(created) =
                                     FetchHeaders::create_from_js(global, headers_value)?
                                 {
                                     *fetch_headers_to_deref = Some(created.as_ptr());
-                                    created.as_ptr()
-                                } else if !global.has_exception() {
-                                    return Err(global.throw_invalid_arguments(format_args!(
-                                        "upgrade options.headers must be a Headers or an object"
-                                    )));
-                                } else {
-                                    return Err(JsError::Thrown);
+                                    break 'brk created.as_ptr();
                                 }
-                            } else if !global.has_exception() {
-                                return Err(global.throw_invalid_arguments(format_args!(
-                                    "upgrade options.headers must be a Headers or an object"
-                                )));
-                            } else {
-                                return Err(JsError::Thrown);
                             }
+                            return Err(global.throw_invalid_arguments(format_args!(
+                                "upgrade options.headers must be a Headers or an object"
+                            )));
                         }
                     };
                     fetch_headers_to_use = Some(fh);
-                    if global.has_exception() {
-                        return Err(JsError::Thrown);
-                    }
 
                     // S008: `FetchHeaders` is an `opaque_ffi!` ZST — safe deref.
                     let fh = bun_opaque::opaque_deref_mut(fh);
@@ -2074,9 +2041,6 @@ where
                             ZigString::init(_sec_websocket_extensions_owned.slice());
                         fh.fast_remove(HTTPHeaderName::SecWebSocketExtensions);
                     }
-                }
-                if global.has_exception() {
-                    return Err(JsError::Thrown);
                 }
             }
         }
@@ -2334,10 +2298,6 @@ where
                 previous_routes: !self.user_routes.is_empty(),
             },
         )?;
-        if global.has_exception() {
-            drop(new_config);
-            return Err(JsError::Thrown);
-        }
 
         // `on_reload_from_zig` moves `new_config.websocket` into the unscanned
         // `self.config` heap box before `write_ws_handler_slots` roots the 7

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2916,14 +2916,6 @@ pub(crate) fn create_shell_interpreter(
         }
     };
 
-    if global.has_exception() {
-        // `deinit_from_finalizer` derefs root_io and closes `root_shell.cwd_fd`.
-        // Neither `Interpreter` nor `ShellExecEnv` implements `Drop`, so a plain
-        // box drop would leak the raw `cwd_fd`; run the explicit teardown.
-        interpreter.deinit_from_exec();
-        return Err(crate::jsc::JsError::Thrown);
-    }
-
     let interpreter = bun_core::heap::into_raw(interpreter);
     // SAFETY: `interpreter` is a fresh heap allocation; the C++ wrapper takes
     // ownership of the raw pointer and `interpreter` outlives this call.

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3428,9 +3428,6 @@ impl<const SSL: bool> NewSocket<SSL> {
         let socket_obj = opts
             .get(global, "socket")?
             .ok_or_else(|| global.throw(format_args!("Expected \"socket\" option")))?;
-        if global.has_exception() {
-            return Ok(JSValue::ZERO);
-        }
         // Bytes already consumed from the wire before the upgrade (e.g. the
         // ClientHello sitting in the readable buffer of the socket being
         // wrapped); fed into the TLS engine once the upgrade is wired up.
@@ -3445,9 +3442,6 @@ impl<const SSL: bool> NewSocket<SSL> {
         // server-ness lives in the SSL accept state (adopt_tls
         // is_client=!is_server) + the ServerHandlers JS table, not here.
         let handlers = Handlers::from_js(global, socket_obj, super::SocketMode::Client)?;
-        if global.has_exception() {
-            return Ok(JSValue::ZERO);
-        }
         // Nothing holds the callback cell until the TLS wrapper below does.
         let _cell_root = handlers.root_cell(global);
 
@@ -3549,9 +3543,6 @@ impl<const SSL: bool> NewSocket<SSL> {
         } else {
             return Err(global.throw(format_args!("Expected \"tls\" option")));
         }
-        if global.has_exception() {
-            return Err(jsc::JsError::Thrown);
-        }
 
         let mut default_data = JSValue::ZERO;
         if let Some(v) = opts.fast_get(global, jsc::BuiltinName::Data)? {
@@ -3630,15 +3621,12 @@ impl<const SSL: bool> NewSocket<SSL> {
                 // `deref` runs `deinit_and_destroy`, which drops the owned_ctx
                 // ref and the handlers `Rc`. Sole owner of the fresh allocation.
                 tls.get().deref();
-                if err != 0 && !global.has_exception() {
+                if err != 0 {
                     return Err(global.throw_value(boringssl_err_to_js(global, err)));
                 }
-                if !global.has_exception() {
-                    return Err(global.throw(format_args!(
-                        "Failed to upgrade socket from TCP -> TLS. Is the TLS config correct?",
-                    )));
-                }
-                return Ok(JSValue::UNDEFINED);
+                return Err(global.throw(format_args!(
+                    "Failed to upgrade socket from TCP -> TLS. Is the TLS config correct?",
+                )));
             }
         };
 

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -1432,7 +1432,7 @@ impl UDPSocket {
                 // plain cast (no `toPrimitive`, no user JS). `JSString` is an
                 // `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
                 string_slices
-                    .push(bun_jsc::JSString::opaque_ref(val.as_string()).to_slice(global_this));
+                    .push(bun_jsc::JSString::opaque_ref(val.as_string()).to_slice(global_this)?);
                 break 'brk string_slices.last().unwrap().slice();
             };
             payloads[slice_idx] = slice.as_ptr();
@@ -1529,7 +1529,7 @@ impl UDPSocket {
                 // and `this.socket orelse throw` below handles a
                 // close-during-`toPrimitive`.
                 // SAFETY: to_js_string returned non-null on success path.
-                payload_str = payload_arg.to_js_string(global_this)?.to_slice(global_this);
+                payload_str = payload_arg.to_js_string(global_this)?.to_slice(global_this)?;
                 break 'brk payload_str.slice();
             } else {
                 return Err(global_this.throw_invalid_arguments(format_args!(

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -1529,7 +1529,9 @@ impl UDPSocket {
                 // and `this.socket orelse throw` below handles a
                 // close-during-`toPrimitive`.
                 // SAFETY: to_js_string returned non-null on success path.
-                payload_str = payload_arg.to_js_string(global_this)?.to_slice(global_this)?;
+                payload_str = payload_arg
+                    .to_js_string(global_this)?
+                    .to_slice(global_this)?;
                 break 'brk payload_str.slice();
             } else {
                 return Err(global_this.throw_invalid_arguments(format_args!(

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1388,7 +1388,7 @@ impl Expect {
                     let type_name = if matcher_fn.is_null() {
                         bun_core::String::static_("null")
                     } else {
-                        bun_core::String::init(matcher_fn.js_type_string(global_this).get_zig_string(global_this))
+                        bun_core::String::init(matcher_fn.js_type_string(global_this).get_zig_string(global_this)?)
                     };
                     return Err(global_this.throw_invalid_arguments(format_args!(
                         "expect.extend: `{}` is not a valid matcher. Must be a function, is \"{}\"",

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -699,11 +699,7 @@ impl Expect {
         let mut custom_label = bun_core::String::empty();
         if arguments.len() > 1 {
             if arguments[1].is_string() || arguments[1].implements_to_string(global_this)? {
-                let label = arguments[1].to_bun_string(global_this)?;
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
-                }
-                custom_label = label;
+                custom_label = arguments[1].to_bun_string(global_this)?;
             }
         }
 
@@ -1927,7 +1923,7 @@ impl ExpectStatic {
     ) -> JsResult<JSValue> {
         //const this: *ExpectStatic = ExpectStatic.fromJS(callFrame.this());
         let instance_jsvalue = T::invoke(global_this, call_frame)?;
-        if !instance_jsvalue.is_empty() && !instance_jsvalue.is_any_error() {
+        if !instance_jsvalue.is_any_error() {
             let Some(instance) = T::from_js_ptr(instance_jsvalue) else {
                 return Err(global_this.throw_out_of_memory());
             };
@@ -2503,11 +2499,6 @@ impl ExpectAny {
         }
 
         let asymmetric_matcher_constructor_type = AsymmetricMatcherConstructorType::from_js(global_this, constructor)?;
-
-        // I don't think this case is possible, but just in case!
-        if global_this.has_exception() {
-            return Err(JsError::Thrown);
-        }
 
         let mut flags = Flags::default();
         flags.set_asymmetric_matcher_constructor_type(asymmetric_matcher_constructor_type);

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -113,9 +113,6 @@ pub(crate) fn to_throw(
                 Some(JSValue::from_cell(result.to_js_string(global)?))
             })
             .unwrap_or(JSValue::UNDEFINED);
-            if global.has_exception() {
-                return Ok(JSValue::ZERO);
-            }
 
             // TODO: remove this allocation
             // partial match
@@ -146,9 +143,6 @@ pub(crate) fn to_throw(
             })
             .unwrap_or(JSValue::UNDEFINED);
 
-            if global.has_exception() {
-                return Ok(JSValue::ZERO);
-            }
             // TODO: REMOVE THIS GETTER! Expose a binding to call .test on the RegExp object directly.
             if let Some(test_fn) = expected_value.get(global, "test")? {
                 let matches = test_fn.call(global, expected_value, &[received_message])?;
@@ -175,9 +169,6 @@ pub(crate) fn to_throw(
                 Some(JSValue::from_cell(result.to_js_string(global)?))
             })
             .unwrap_or(JSValue::UNDEFINED);
-            if global.has_exception() {
-                return Ok(JSValue::ZERO);
-            }
 
             // no partial match for this case
             if !expected_message.is_same_value(received_message, global)? {
@@ -308,10 +299,6 @@ pub(crate) fn to_throw(
         if Expect::is_asymmetric_matcher(expected_value) {
             let signature: &'static str = get_signature("toThrow", "<green>expected<r>", false);
             let is_equal = result.jest_strict_deep_equals(expected_value, global)?;
-
-            if global.has_exception() {
-                return Ok(JSValue::ZERO);
-            }
 
             if is_equal {
                 return Ok(JSValue::UNDEFINED);

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -253,7 +253,7 @@ impl JSValkeyClient {
                 // `JSString` is an `opaque_ffi!` ZST — `opaque_ref` is the safe
                 // deref (`as_string()` returns a live cell for string values).
                 bun_jsc::JSString::opaque_ref(channel_name.as_string())
-                    .get_zig_string(global_object)
+                    .get_zig_string(global_object)?
             );
             return Ok(());
         };

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3473,10 +3473,6 @@ impl BlobExt for Blob {
 
                 _ => {
                     let sliced = current.to_slice(global)?;
-                    if global.has_exception() {
-                        let _end_result = joiner.done();
-                        return Err(jsc::JsError::Thrown);
-                    }
                     could_have_non_ascii = could_have_non_ascii || !sliced.is_wtf_backed();
                     joiner.push_cloned(sliced.slice());
                 }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1026,22 +1026,7 @@ impl Value {
             ));
         }
 
-        let blob = match Blob::get::<true, false>(global_this, value) {
-            Ok(b) => b,
-            Err(_err) => {
-                if !global_this.has_exception() {
-                    // With `REQUIRE_ARRAY = false` an "Expected an Array" branch is
-                    // unreachable (the only `error.InvalidArguments` producer is gated
-                    // on `require_array`), and every other failure path throws first
-                    // (sets the exception).
-                    return Err(
-                        global_this.throw_invalid_arguments(format_args!("Invalid Body object"))
-                    );
-                }
-                return Err(bun_jsc::JsError::Thrown);
-            }
-        };
-        Ok(Value::Blob(blob))
+        Ok(Value::Blob(Blob::get::<true, false>(global_this, value)?))
     }
 
     pub(crate) fn from_readable_stream_without_lock_check(

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -182,10 +182,6 @@ fn js_function_resolve_object_url(
     // path (exception, non-blob prefix, success) releases it.
     let str = bun_core::OwnedString::new(url_arg.to_bun_string(global_object)?);
 
-    if global_object.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
-
     if !str.has_prefix_comptime(b"blob:") || str.length() < SPECIFIER_LEN {
         return Ok(JSValue::UNDEFINED);
     }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1131,10 +1131,6 @@ impl Request {
                             Ok(None) => {}
                             Err(e) => bail!(Err(e)),
                         }
-
-                        if global_this.has_exception() {
-                            bail!(Err(JsError::Thrown));
-                        }
                     }
 
                     if !fields.contains(Fields::Body) {
@@ -1203,10 +1199,6 @@ impl Request {
                             }
                         }
                     }
-
-                    if global_this.has_exception() {
-                        bail!(Err(JsError::Thrown));
-                    }
                 }
             }
 
@@ -1236,10 +1228,6 @@ impl Request {
                     }
                     Ok(None) => {}
                     Err(e) => bail!(Err(e)),
-                }
-
-                if global_this.has_exception() {
-                    bail!(Err(JsError::Thrown));
                 }
             }
 
@@ -1282,10 +1270,6 @@ impl Request {
                     }
                     Err(e) => bail!(Err(e)),
                 }
-
-                if global_this.has_exception() {
-                    bail!(Err(JsError::Thrown));
-                }
             }
 
             if !fields.contains(Fields::Signal) {
@@ -1303,27 +1287,17 @@ impl Request {
                             // `ref_from_js` already ref'd.
                             req.signal.set(Some(signal));
                         } else {
-                            if !global_this.has_exception() {
-                                bail!(Err(global_this.throw_type_error(format_args!(
-                                    "Failed to construct 'Request': signal is not of type AbortSignal."
-                                ))));
-                            }
-                            bail!(Err(JsError::Thrown));
+                            bail!(Err(global_this.throw_type_error(format_args!(
+                                "Failed to construct 'Request': signal is not of type AbortSignal."
+                            ))));
                         }
                     }
                     Ok(None) => {}
                     Err(e) => bail!(Err(e)),
                 }
-
-                if global_this.has_exception() {
-                    bail!(Err(JsError::Thrown));
-                }
             }
 
             if !fields.contains(Fields::Method) || !fields.contains(Fields::Headers) {
-                if global_this.has_exception() {
-                    bail!(Err(JsError::Thrown));
-                }
                 match crate::webcore::response::Init::init(global_this, value) {
                     Ok(Some(response_init)) => {
                         let header_check = !explicit_check
@@ -1344,10 +1318,6 @@ impl Request {
                             }
                         }
 
-                        if global_this.has_exception() {
-                            bail!(Err(JsError::Thrown));
-                        }
-
                         let method_check = !explicit_check
                             || (explicit_check
                                 && match value.fast_get(global_this, bun_jsc::BuiltinName::Method) {
@@ -1360,16 +1330,9 @@ impl Request {
                                 fields.insert(Fields::Method);
                             }
                         }
-                        if global_this.has_exception() {
-                            bail!(Err(JsError::Thrown));
-                        }
                     }
                     Ok(None) => {}
                     Err(e) => bail!(Err(e)),
-                }
-
-                if global_this.has_exception() {
-                    bail!(Err(JsError::Thrown));
                 }
             }
 
@@ -1410,10 +1373,6 @@ impl Request {
             }
         }
 
-        if global_this.has_exception() {
-            bail!(Err(JsError::Thrown));
-        }
-
         if req.url.get().is_empty() {
             bail!(Err(global_this.throw(format_args!(
                 "Failed to construct 'Request': url is required."
@@ -1422,16 +1381,13 @@ impl Request {
 
         let href = bun_url::href_from_string(&req.url.get());
         if href.is_empty() {
-            if !global_this.has_exception() {
-                // globalThis.throw can cause GC, which could cause the above string to be freed.
-                // so we must increment the reference count before calling it.
-                let err = global_this.err_invalid_url(format_args!(
-                    "Failed to construct 'Request': Invalid URL \"{}\"",
-                    req.url.get()
-                ));
-                bail!(Err(global_this.throw_value(err)));
-            }
-            bail!(Err(JsError::Thrown));
+            // globalThis.throw can cause GC, which could cause the above string to be freed.
+            // so we must increment the reference count before calling it.
+            let err = global_this.err_invalid_url(format_args!(
+                "Failed to construct 'Request': Invalid URL \"{}\"",
+                req.url.get()
+            ));
+            bail!(Err(global_this.throw_value(err)));
         }
 
         // hrefFromString increments the reference count if they end up being

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1229,6 +1229,11 @@ impl Request {
                     Ok(None) => {}
                     Err(e) => bail!(Err(e)),
                 }
+
+                // BodyValue::from_js() throws without returning Err; see Blob::from_dom_form_data
+                if global_this.has_exception() {
+                    bail!(Err(JsError::Thrown));
+                }
             }
 
             if !fields.contains(Fields::Url) {

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1219,6 +1219,11 @@ impl Response {
         // error returns below release the extracted body payload.
         let body = scopeguard::guard(body, |b| b.reset());
 
+        // extract() throws without returning Err; see Blob::from_dom_form_data
+        if global_this.has_exception() {
+            return Err(bun_jsc::JsError::Thrown);
+        }
+
         // Perform the only remaining fallible op BEFORE heap-allocating:
         // doing it on stack locals lets `?` trigger the scopeguard and
         // `init`'s drop glue and avoids leaking the heap allocation entirely.

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -951,10 +951,6 @@ impl Response {
             // than jsonStringify which passes 0 for space and uses the slower Stringifier.
             json_value.json_stringify_fast(global_this, &mut str)?;
 
-            if global_this.has_exception() {
-                return Ok(JSValue::ZERO);
-            }
-
             if !str.is_empty() {
                 // `bun_core::String.value` is private; use
                 // `leak_wtf_impl()` to take ownership of the +1 ref as a raw
@@ -993,11 +989,8 @@ impl Response {
                         u16::try_from(0.max(arg_init.to_int32()).min(i32::from(u16::MAX))).unwrap();
                 });
             } else {
-                match Init::init(global_this, arg_init) {
-                    Ok(Some(init)) => response.init.set(init),
-                    Ok(None) => {}
-                    Err(bun_jsc::JsError::Thrown) => return Ok(JSValue::ZERO),
-                    Err(_) => {}
+                if let Some(init) = Init::init(global_this, arg_init)? {
+                    response.init.set(init);
                 }
             }
         }
@@ -1092,9 +1085,6 @@ impl Response {
                 }
             }
 
-            if global_this.has_exception() {
-                return Err(bun_jsc::JsError::Thrown);
-            }
             break 'brk response;
         };
 
@@ -1211,19 +1201,12 @@ impl Response {
             if arguments[1].is_object() {
                 break 'brk Init::init(global_this, arguments[1])?.expect("unreachable");
             }
-            if !global_this.has_exception() {
-                return Err(global_this.throw_invalid_arguments(format_args!(
-                    "Failed to construct 'Response': The provided body value is not of type 'ResponseInit'",
-                )));
-            }
-            return Err(bun_jsc::JsError::Thrown);
+            return Err(global_this.throw_invalid_arguments(format_args!(
+                "Failed to construct 'Response': The provided body value is not of type 'ResponseInit'",
+            )));
         };
         // Init's field drop glue (HeadersRef + OwnedString)
         // handles cleanup on `?` below
-
-        if global_this.has_exception() {
-            return Err(bun_jsc::JsError::Thrown);
-        }
 
         let body: Body = 'brk: {
             if arguments[0].is_undefined_or_null() {
@@ -1235,10 +1218,6 @@ impl Response {
         // `Body` has NO `Drop`; arm a guard so the
         // error returns below release the extracted body payload.
         let body = scopeguard::guard(body, |b| b.reset());
-
-        if global_this.has_exception() {
-            return Err(bun_jsc::JsError::Thrown);
-        }
 
         // Perform the only remaining fallible op BEFORE heap-allocating:
         // doing it on stack locals lets `?` trigger the scopeguard and
@@ -1366,10 +1345,6 @@ impl Init {
             }
         }
 
-        if global_this.has_exception() {
-            return Err(JsError::Thrown);
-        }
-
         if let Some(headers) = response_init.fast_get(global_this, BuiltinName::headers)? {
             // `JSValue::as_::<FetchHeaders>()` requires `JsClass`;
             // FetchHeaders is a hand-bound opaque, so use its dedicated
@@ -1390,28 +1365,17 @@ impl Init {
             }
         }
 
-        if global_this.has_exception() {
-            return Err(JsError::Thrown);
-        }
-
         if let Some(status_value) = response_init.fast_get(global_this, BuiltinName::status)? {
             let number = status_value.coerce_to_int64(global_this)?;
             if (200 <= number && number < 600) || number == 101 {
                 result.status_code = (u32::try_from(number).expect("int cast")) as u16;
             } else {
-                if !global_this.has_exception() {
-                    let err = global_this.create_range_error_instance(format_args!(
-                        "The status provided ({}) must be 101 or in the range of [200, 599]",
-                        number
-                    ));
-                    return Err(global_this.throw_value(err));
-                }
-                return Err(JsError::Thrown);
+                let err = global_this.create_range_error_instance(format_args!(
+                    "The status provided ({}) must be 101 or in the range of [200, 599]",
+                    number
+                ));
+                return Err(global_this.throw_value(err));
             }
-        }
-
-        if global_this.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         if let Some(status_text) =

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -467,7 +467,7 @@ impl<T: JsSinkType> JSSink<T> {
         }
 
         let str_ = arg.to_js_string(global)?;
-        let view = str_.view(global);
+        let view = str_.view(global)?;
         if view.is_empty() {
             return Ok(JSValue::js_number(0.0));
         }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1197,6 +1197,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     }
     .unwrap_or_default();
 
+    // HTTPRequestBody::from_js() throws without returning Err; see Blob::from_dom_form_data
+    if global_this.has_exception() {
+        return Err(jsc::JsError::Thrown);
+    }
+
     // headers: Headers | undefined;
     headers = 'extract_headers: {
         // Releases the +1 from `create_from_js` on every exit path.

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -348,19 +348,19 @@ fn reject_on_exception(
     result: JsResult<JSValue>,
 ) -> JsResult<JSValue> {
     let err = match result {
-        Ok(v) if !v.is_empty() => return Ok(v),
+        Ok(v) => return Ok(v),
         Err(jsc::JsError::OutOfMemory) => global_this.create_out_of_memory_error(),
         // A terminated worker gets no rejected promise: its termination keeps unwinding.
-        Ok(_) | Err(jsc::JsError::Thrown | jsc::JsError::Terminated)
+        Err(jsc::JsError::Thrown | jsc::JsError::Terminated)
             if global_this.has_pending_termination_exception() =>
         {
             return Err(jsc::JsError::Thrown);
         }
         Err(jsc::JsError::Terminated) => return Err(jsc::JsError::Terminated),
-        Ok(_) | Err(jsc::JsError::Thrown) => match global_this.try_take_exception() {
+        Err(jsc::JsError::Thrown) => match global_this.try_take_exception() {
             Some(exc) => exc.to_error().unwrap_or(exc),
             None => {
-                // `fetch_impl` only returns Ok(ZERO)/Err(Thrown) with an exception
+                // `fetch_impl` only returns Err(Thrown) with an exception
                 // pending; reaching here means it was cleared, which is a bug.
                 debug_assert!(
                     false,
@@ -555,10 +555,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         break 'extract_url BunString::empty();
     });
 
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
-
     if url_str.is_empty() {
         let err = ctx.to_type_error(
             jsc::ErrorCode::INVALID_URL,
@@ -661,19 +657,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         break 'extract_disable_decompression decompression_value.to_int32() == 0;
                     }
                 }
-
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
-                }
             }
         }
 
         break 'extract_disable_decompression disable_decompression;
     };
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
 
     // "compress: boolean | string | { encoding, level? }"
     'extract_compress: {
@@ -690,16 +678,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         break 'extract_compress;
                     }
                 }
-
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
-                }
             }
         }
-    }
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
     }
 
     // "maxRedirects: number"
@@ -728,16 +708,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         break 'extract_max_redirects;
                     }
                 }
-
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
-                }
             }
         }
-    }
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
     }
 
     // "tls: TLSConfig"
@@ -759,10 +731,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             }
                         }
 
-                        if global_this.has_exception() {
-                            return Ok(JSValue::ZERO);
-                        }
-
                         if let Some(check_server_identity_) = tls.get(ctx, "checkServerIdentity")? {
                             if check_server_identity_.is_cell()
                                 && check_server_identity_.is_callable()
@@ -771,19 +739,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             }
                         }
 
-                        if global_this.has_exception() {
-                            return Ok(JSValue::ZERO);
-                        }
-
-                        match SSLConfig::from_js(vm, global_this, tls) {
-                            Err(_) => {
-                                return Ok(JSValue::ZERO);
-                            }
-                            Ok(Some(config)) => {
-                                // Intern via `ssl_config::global_registry` for dedup and pointer equality
-                                break 'extract_ssl_config Some(ssl_config_intern_for_http(config));
-                            }
-                            Ok(None) => {}
+                        if let Some(config) = SSLConfig::from_js(vm, global_this, tls)? {
+                            // Intern via `ssl_config::global_registry` for dedup and pointer equality
+                            break 'extract_ssl_config Some(ssl_config_intern_for_http(config));
                         }
                     }
                 }
@@ -792,10 +750,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
         break 'extract_ssl_config ssl_config;
     };
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
 
     // unix: string | undefined
     unix_socket_path = 'extract_unix_socket_path: {
@@ -811,18 +765,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         break 'extract_unix_socket_path socket_path.to_slice_clone(global_this)?;
                     }
                 }
-
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
-                }
             }
         }
         break 'extract_unix_socket_path unix_socket_path;
     };
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
 
     // protocol: "http2" | "h2" | "http1.1" | "h1" | undefined.
     'extract_protocol: {
@@ -885,19 +831,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             || timeout_value.to_int32() == 0;
                     }
                 }
-
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
-                }
             }
         }
 
         break 'extract_disable_timeout disable_timeout;
     };
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
 
     // redirect: "follow" | "error" | "manual" | undefined;
     redirect_type = 'extract_redirect_type: {
@@ -914,24 +852,16 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
         for obj in objects_to_try {
             if !obj.is_empty() {
-                match obj.get_optional_enum::<FetchRedirect>(global_this, "redirect") {
-                    Err(_) => {
-                        return Ok(JSValue::ZERO);
-                    }
-                    Ok(Some(redirect_value)) => {
-                        break 'extract_redirect_type redirect_value;
-                    }
-                    Ok(None) => {}
+                if let Some(redirect_value) =
+                    obj.get_optional_enum::<FetchRedirect>(global_this, "redirect")?
+                {
+                    break 'extract_redirect_type redirect_value;
                 }
             }
         }
 
         break 'extract_redirect_type redirect_type;
     };
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
 
     // keepalive: boolean | undefined;
     disable_keepalive = 'extract_disable_keepalive: {
@@ -949,19 +879,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         break 'extract_disable_keepalive keepalive_value.to_int32() == 0;
                     }
                 }
-
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
-                }
             }
         }
 
         break 'extract_disable_keepalive disable_keepalive;
     };
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
 
     // verbose: boolean | "curl" | undefined;
     verbose = 'extract_verbose: {
@@ -984,10 +906,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             http::HTTPVerboseLevel::None
                         };
                     }
-                }
-
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
                 }
             }
         }
@@ -1115,19 +1033,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         }
                     }
                 }
-
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
-                }
             }
         }
 
         break 'extract_proxy url_proxy_buffer;
     };
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
 
     // signal: AbortSignal | null | undefined;
     // WebIDL `AbortSignal?` member: present iff not undefined. A present `null`
@@ -1154,10 +1064,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         err,
                     ),
                 );
-            }
-
-            if global_this.has_exception() {
-                return Ok(JSValue::ZERO);
             }
         }
 
@@ -1194,10 +1100,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         break 'extract_signal None;
     };
 
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
-
     // We do this 2nd to last instead of last so that if it's a FormData
     // object, we can still insert the boundary.
     //
@@ -1216,10 +1118,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 if !body__.is_undefined() {
                     break 'extract_body Some(HTTPRequestBody::from_js(ctx, body__)?);
                 }
-            }
-
-            if global_this.has_exception() {
-                return Ok(JSValue::ZERO);
             }
         }
 
@@ -1299,14 +1197,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     }
     .unwrap_or_default();
 
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
-
     // headers: Headers | undefined;
     headers = 'extract_headers: {
-        // Releases the +1 from `create_from_js` on every exit path (including
-        // the `has_exception()` early returns below).
+        // Releases the +1 from `create_from_js` on every exit path.
         let mut fetch_headers_to_deref = FetchHeadersRef(None);
 
         let fetch_headers: Option<*mut FetchHeaders> = 'brk: {
@@ -1330,10 +1223,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
                         break 'brk None;
                     }
-                }
-
-                if global_this.has_exception() {
-                    return Ok(JSValue::ZERO);
                 }
             }
 
@@ -1367,16 +1256,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 }
             }
 
-            if global_this.has_exception() {
-                return Ok(JSValue::ZERO);
-            }
-
             break 'extract_headers headers;
         };
-
-        if global_this.has_exception() {
-            return Ok(JSValue::ZERO);
-        }
 
         let result = if let Some(headers_) = fetch_headers {
             // `headers_` points to a live FetchHeaders (either JS-owned or
@@ -1410,10 +1291,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         break 'extract_headers result;
     };
 
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
-    }
-
     if proxy.is_some() && !unix_socket_path.slice().is_empty() {
         let err = ctx.to_type_error(
             jsc::ErrorCode::INVALID_ARG_VALUE,
@@ -1425,10 +1302,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 err,
             ),
         );
-    }
-
-    if global_this.has_exception() {
-        return Ok(JSValue::ZERO);
     }
 
     // This is not 100% correct.

--- a/src/semver_jsc/SemverObject.rs
+++ b/src/semver_jsc/SemverObject.rs
@@ -28,8 +28,8 @@ fn order(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let left_string = arguments[0].to_js_string(global)?;
     let right_string = arguments[1].to_js_string(global)?;
 
-    let left = left_string.to_slice(global);
-    let right = right_string.to_slice(global);
+    let left = left_string.to_slice(global)?;
+    let right = right_string.to_slice(global)?;
 
     if !strings::is_all_ascii(left.slice()) {
         return Ok(JSValue::js_number_from_int32(0));
@@ -77,8 +77,8 @@ fn satisfies(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let left_string = arguments[0].to_js_string(global)?;
     let right_string = arguments[1].to_js_string(global)?;
 
-    let left = left_string.to_slice(global);
-    let right = right_string.to_slice(global);
+    let left = left_string.to_slice(global)?;
+    let right = right_string.to_slice(global)?;
 
     if !strings::is_all_ascii(left.slice()) {
         return Ok(JSValue::FALSE);

--- a/src/sql_jsc/mysql/MySQLValue.rs
+++ b/src/sql_jsc/mysql/MySQLValue.rs
@@ -3,7 +3,7 @@
 //! `JSValue` references.
 
 use crate::jsc::{
-    IntegerRange, JSGlobalObject, JSGlobalObjectSqlExt as _, JSType, JSValue, JsError, JsResult,
+    IntegerRange, JSGlobalObject, JSGlobalObjectSqlExt as _, JSType, JSValue, JsResult,
     MarkedArgumentBuffer, StringJsc as _, js_error_to_mysql,
 };
 use bun_core::zig_string::Slice as ZigStringSlice;
@@ -54,10 +54,6 @@ pub(crate) fn field_type_from_js(
                     u64::MAX
                 ))
                 .throw());
-        }
-
-        if global_object.has_exception() {
-            return Err(JsError::Thrown);
         }
 
         // Ban these types:

--- a/test/internal/source-lints/jsresult-swallow.inventory.json
+++ b/test/internal/source-lints/jsresult-swallow.inventory.json
@@ -9,8 +9,7 @@
     "discarded result of a call that enters script": 4
   },
   "src/runtime/ipc.rs": {
-    "discarded result of a call that enters script": 4,
-    "taken exception discarded": 1
+    "discarded result of a call that enters script": 4
   },
   "src/runtime/napi/napi_body.rs": {
     "discarded result of a call that enters script": 2

--- a/test/internal/source-lints/jsresult-swallow.inventory.json
+++ b/test/internal/source-lints/jsresult-swallow.inventory.json
@@ -1,6 +1,5 @@
 {
   "src/jsc/VirtualMachine.rs": {
-    "JsResult collapsed on the spot": 1,
     "discarded result of a call that enters script": 1
   },
   "src/jsc/web_worker.rs": {


### PR DESCRIPTION
### What does this PR do?

Removes exception checks that can never fire.

The rule in this codebase is that every call that can throw is followed on the next line by its check — `RETURN_IF_EXCEPTION(scope, …)` in C++, `?` on a `JsResult` in Rust — and nothing else checks. An audit turned up a batch of guards that break that rule in the harmless direction: `if global.has_exception() { return … }` blocks sitting right after a call that was already `?`-checked, and `RETURN_IF_EXCEPTION` lines placed after statements that cannot throw (`callFrame->argument(n)`, `jsString(vm, …)`, `putDirect(vm, …)`, `dynamicDowncast`, `JSSetIterator::create`, `JSArrayBuffer::create(vm, …)`, plain field assignments) where the preceding throwing call already has its own check. They never fire, but they make it unclear which call a check belongs to, and a few of them were `!has_exception()` conditions guarding a fresh throw that read as if the preceding infallible code could leave something pending. This deletes them so each remaining check identifies its call.

Almost all of it is mechanical deletion. The handful that are not:

- `fetch()` option parsing (`tls`, `redirect`) and `Response.json()`'s init parsing matched `Err(_)` / `Err(Thrown)` and returned `Ok(.zero)`, re-deriving the error from the pending exception and collapsing `OutOfMemory`/`Terminated` into it. They now propagate the `JsError` with `?`. `reject_on_exception` no longer needs its empty-`Ok` arms since `fetch_impl` no longer returns `.zero`.
- `Body::Value::from_js`, `CryptoHasher` digest, `Bun.inspect.table`, and `PBKDF2` re-derived an already-returned `Err` via `has_exception()`; they use `?` / key the async unprotect guard on the error path instead.
- `setTimeout`/`setInterval`/`setImmediate` and `NodeVM`'s `moduleLoaderImportModuleInner` returned the result of a throwing call from inside an unreleased `ThrowScope`; they use `RELEASE_AND_RETURN`. `NodeVMSourceTextModule::initializeImportMeta` releases before `JSC::call` rather than after.
- `JSCookieMap.delete`, `JSSQLStatement` `columnTypes` (`putDirectIndex`) / `deserialize` (`toWTFString`), `jsFunctionToClass` (`toObject`), `process.dlopen` (`toWTFString`), `process.getBuiltinModule`, `Buffer.byteLength`, `JSValue.fromEntries`, and the `Worker` constructor had their check hoisted a statement or two away from the throwing call; it now sits directly under it.
- `tty.isatty`, `makeGetterTypeErrorForBuiltins`, `makeDOMExceptionForBuiltins`, `JSValue.stringIncludes`, `JSValue.isInstanceOf`, and `Bun__ErrorCode__inspectForErrorMessage` declared a `TopExceptionScope` but only ever return-if-exception; they use a `ThrowScope` (their callers already check).
- `encodeURIComponent`'s internal `encode` declared a `ThrowScope` it never used; removed, along with the now-pointless scope in `CookieMap__writeFetchHeadersToUWSResponse`.

No behaviour change intended.

Five guards that looked redundant turned out to be the only check for a callee that throws without returning `Err` (the console formatter for `Bun.inspect` / `Bun.inspect.table`; `Blob::from_dom_form_data` under `new Response`/`new Request`/`fetch` with a FormData body). Those are kept, each with a comment naming the callee; fixing those signatures is separate work.

`JSString::to_slice` / `view` / `get_zig_string` / `to_slice_clone` now return `JsResult`: `JSC__JSString__toZigString` resolves ropes via `JSString::value()`, which throws on OOM, and neither side surfaced that — four of the removed guards (`h2_frame_parser.rs` header pairs / value arrays, `fetch.rs` unix socket path) had been the only thing catching it. With the signature fixed they are genuinely dead.

Every removed check was then re-audited by tracing each preceding call to its throwing leaves (JSC FFI / WebKit source); the per-site evidence is in the review thread.

### How did you verify your code works?

Debug build, then ran these under `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1` with no unchecked-exception reports:

- `test/js/web/fetch/fetch.test.ts`
- `test/js/web/fetch/body.test.ts`
- `test/js/bun/http/serve.test.ts`
- `test/js/bun/http/bun-serve-args.test.ts`
- `test/js/node/crypto/node-crypto.test.js`
- `test/js/bun/util/password.test.ts`
- `test/js/bun/spawn/spawn.test.ts`
- `test/js/node/fs/fs.test.ts`
- `test/js/bun/ffi/ffi.test.js`
- `test/js/bun/test/expect.test.js`
- `test/js/node/vm/vm.test.ts`
- `test/js/bun/plugin/plugins.test.ts`
- `test/js/bun/sqlite/sqlite.test.js`
- `test/js/node/http/node-http.test.ts`

plus a script driving the touched argument-validation paths (fetch/Request/Response/Bun.serve options, CryptoHasher/pbkdf2/password, process.memoryUsage/getBuiltinModule, Buffer.byteLength/copy, expect toEqual on Set/Map and toThrow, vm codeGeneration options, sqlite `as()`/`columnTypes`, timers, spawn/kill, fs arg parsing, Bun.plugin, Blob parts, Bun.color, Transpiler.scan) under the same flags.


