### PR TITLE
S3 client + Bun.WebView host: remove unsafe from webcore/s3 and webview

### DIFF
--- a/src/codegen/generate-host-exports.ts
+++ b/src/codegen/generate-host-exports.ts
@@ -144,7 +144,19 @@ function ptrify(ty: string): { cTy: string; deref: (n: string) => string; extraL
         `{\n        // SAFETY: C++ caller passes \`${n}_len\` live elements at \`${n}\` (or 0).\n        unsafe { ::bun_core::ffi::slice(${n}, ${n}_len) }\n    }`,
     };
   }
-  // Other slice shapes (`&mut [T]`, `&'a [T]`) and `&str` are NOT FFI-safe; reject.
+  // `&mut [T]` — C passes `(T* name, size_t name_len)`; the caller owns the
+  // buffer exclusively for the call.
+  const sliceMut = /^&\s*mut\s*\[\s*([^;]+?)\s*\]$/.exec(ty);
+  if (sliceMut) {
+    const elem = sliceMut[1].trim();
+    return {
+      cTy: `*mut ${elem}`,
+      extraLen: true,
+      deref: n =>
+        `{\n        // SAFETY: C++ caller passes \`${n}_len\` live, exclusively borrowed elements at \`${n}\` (or 0).\n        unsafe { ::bun_core::ffi::slice_mut(${n}, ${n}_len) }\n    }`,
+    };
+  }
+  // Other slice shapes (`&'a [T]`) and `&str` are NOT FFI-safe; reject.
   if (/^&[^\[]*\[/.test(ty) || /^&\s*str\b/.test(ty)) {
     throw new Error(`slice/str param \`${ty}\` is not FFI-safe; use \`&[T]\` (const) or (ptr, len)`);
   }

--- a/src/codegen/generate-host-exports.ts
+++ b/src/codegen/generate-host-exports.ts
@@ -158,7 +158,7 @@ function ptrify(ty: string): { cTy: string; deref: (n: string) => string; extraL
   }
   // Other slice shapes (`&'a [T]`) and `&str` are NOT FFI-safe; reject.
   if (/^&[^\[]*\[/.test(ty) || /^&\s*str\b/.test(ty)) {
-    throw new Error(`slice/str param \`${ty}\` is not FFI-safe; use \`&[T]\` (const) or (ptr, len)`);
+    throw new Error(`slice/str param \`${ty}\` is not FFI-safe; use \`&[T]\`, \`&mut [T]\`, or (ptr, len)`);
   }
   // `Option<&CStr>` — C passes a (possibly null) NUL-terminated `const char*`.
   if (/^Option\s*<\s*&\s*(?:(?:::)?(?:core|std)::ffi::)?CStr\s*>$/.test(ty)) {

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -132,20 +132,6 @@ pub struct Task {
     pub ptr: *mut (),
 }
 
-/// What it takes to be queued as a [`Task`]: a tag, and how the task is
-/// freed when it will never run. Implement on every type that can be
-/// enqueued; the impl lives in whatever crate owns the type.
-///
-/// A queued task ends one of two ways: it runs (`bun_runtime::dispatch::
-/// run_task`), or its VM stops before running it —
-/// [`release_unrun`](Self::release_unrun), required here so no type can be
-/// queued without having decided it. (A *weak* poster — `JsPoster` — can also
-/// get its task back unqueued once the VM has closed; that task never entered
-/// a queue and is the poster's own to free: [`ConcurrentTask::release_refused`].)
-///
-/// Re-exported from `bun_jsc` for ergonomics, but defined here (lowest tier on
-/// the hot-dispatch list, see PORTING.md §Dispatch) so that
-/// [`Task::init`] can use it without a dep cycle.
 /// A task whose queued pointer is a [`ThisPtr`](bun_ptr::ThisPtr) to
 /// `Target`, which keeps itself alive for the task; the dispatcher runs it or
 /// releases it through here. Implemented by a zero-sized hop type per tag so
@@ -165,6 +151,20 @@ pub trait TaskHop {
     }
 }
 
+/// What it takes to be queued as a [`Task`]: a tag, and how the task is
+/// freed when it will never run. Implement on every type that can be
+/// enqueued; the impl lives in whatever crate owns the type.
+///
+/// A queued task ends one of two ways: it runs (`bun_runtime::dispatch::
+/// run_task`), or its VM stops before running it —
+/// [`release_unrun`](Self::release_unrun), required here so no type can be
+/// queued without having decided it. (A *weak* poster — `JsPoster` — can also
+/// get its task back unqueued once the VM has closed; that task never entered
+/// a queue and is the poster's own to free: [`ConcurrentTask::release_refused`].)
+///
+/// Re-exported from `bun_jsc` for ergonomics, but defined here (lowest tier on
+/// the hot-dispatch list, see PORTING.md §Dispatch) so that
+/// [`Task::init`] can use it without a dep cycle.
 pub trait Taskable {
     /// The tag constant from [`task_tag`] for this type. Both this and the
     /// `bun_runtime::dispatch` match arms MUST agree.

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -146,6 +146,25 @@ pub struct Task {
 /// Re-exported from `bun_jsc` for ergonomics, but defined here (lowest tier on
 /// the hot-dispatch list, see PORTING.md §Dispatch) so that
 /// [`Task::init`] can use it without a dep cycle.
+/// A task whose queued pointer is a [`ThisPtr`](bun_ptr::ThisPtr) to
+/// `Target`, which keeps itself alive for the task; the dispatcher runs it or
+/// releases it through here. Implemented by a zero-sized hop type per tag so
+/// the ref protocol lives next to `Target`.
+pub trait TaskHop {
+    type Target;
+    /// The tag constant from [`task_tag`]; the `bun_runtime::dispatch` match
+    /// arms MUST agree.
+    const TAG: TaskTag;
+    fn run(this: bun_ptr::ThisPtr<Self::Target>) -> crate::JsResult<()>;
+    /// As [`Taskable::release_unrun`].
+    fn release_unrun(this: bun_ptr::ThisPtr<Self::Target>);
+
+    #[inline]
+    fn task(this: bun_ptr::ThisPtr<Self::Target>) -> Task {
+        Task::new(Self::TAG, this.as_ptr().cast::<()>())
+    }
+}
+
 pub trait Taskable {
     /// The tag constant from [`task_tag`] for this type. Both this and the
     /// `bun_runtime::dispatch` match arms MUST agree.
@@ -216,6 +235,10 @@ pub struct ConcurrentTask {
     /// dispatch. Immutable after construction; read only on the consumer thread,
     /// so it does not need to share a word with the contended `next` link.
     pub auto_delete: bool,
+    /// A [`ReusableConcurrentTask`] is armed (posted and not yet consumed).
+    /// Cleared by the consumer after its last read of the node; `false` for a
+    /// freshly built node.
+    pub queued: core::sync::atomic::AtomicBool,
 }
 
 impl Default for ConcurrentTask {
@@ -226,6 +249,52 @@ impl Default for ConcurrentTask {
             task: unsafe { bun_core::ffi::zeroed_unchecked() },
             next: Link::new(),
             auto_delete: false,
+            queued: core::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
+/// An intrusive [`ConcurrentTask`] its owner posts again and again, at most one
+/// post in flight: [`arm`](Self::arm) hands the node out only once the consumer
+/// is done with the previous post.
+pub struct ReusableConcurrentTask(core::cell::UnsafeCell<ConcurrentTask>);
+
+// SAFETY: the node is written only by the thread that wins `queued`
+// (false -> true) and read only by the consumer, which clears `queued` after
+// its last read; `queued` itself is atomic.
+unsafe impl Sync for ReusableConcurrentTask {}
+// SAFETY: as above; the payload is a tag and an address.
+unsafe impl Send for ReusableConcurrentTask {}
+
+impl Default for ReusableConcurrentTask {
+    fn default() -> Self {
+        Self(core::cell::UnsafeCell::new(ConcurrentTask::default()))
+    }
+}
+
+impl ReusableConcurrentTask {
+    /// The node loaded with `task`, ready to post; `None` while the previous
+    /// post has not been consumed yet.
+    pub fn arm(&self, task: Task) -> Option<core::ptr::NonNull<ConcurrentTask>> {
+        let node = self.0.get();
+        // SAFETY: `queued` is atomic; winning false -> true makes this thread the
+        // node's only writer until the consumer clears it (`consumed`).
+        unsafe {
+            if (*node)
+                .queued
+                .compare_exchange(
+                    false,
+                    true,
+                    core::sync::atomic::Ordering::AcqRel,
+                    core::sync::atomic::Ordering::Acquire,
+                )
+                .is_err()
+            {
+                return None;
+            }
+            (*node).task = task;
+            (*node).auto_delete = false;
+            Some(core::ptr::NonNull::new_unchecked(node))
         }
     }
 }
@@ -241,7 +310,7 @@ impl Default for ConcurrentTask {
 const _: () = assert!(
     core::mem::size_of::<ConcurrentTask>()
         == core::mem::size_of::<Task>() + 2 * core::mem::size_of::<usize>(),
-    "ConcurrentTask = Task + next ptr + auto_delete (padded)"
+    "ConcurrentTask = Task + next ptr + auto_delete/queued (padded)"
 );
 
 // SAFETY: `link()` always projects to the same embedded `next: Link<Self>`
@@ -277,6 +346,7 @@ impl ConcurrentTask {
             task,
             next: Link::new(),
             auto_delete: true,
+            queued: core::sync::atomic::AtomicBool::new(false),
         });
         // SAFETY: `new` heap-allocates via `heap::into_raw` — never null.
         unsafe { core::ptr::NonNull::new_unchecked(raw) }
@@ -307,6 +377,7 @@ impl ConcurrentTask {
             task: Task::init(of),
             next: Link::new(),
             auto_delete: auto_deinit == AutoDeinit::AutoDeinit,
+            queued: core::sync::atomic::AtomicBool::new(false),
         };
         self
     }
@@ -322,9 +393,23 @@ impl ConcurrentTask {
             let (task, auto_delete) = (this.as_ref().task, this.as_ref().auto_delete());
             if auto_delete {
                 drop(bun_core::heap::take(this.as_ptr()));
+            } else {
+                Self::consumed(this);
             }
             task
         }
+    }
+
+    /// Consuming thread: done reading an intrusive node (its `task` copied,
+    /// the batch iterator past it); a [`ReusableConcurrentTask`] may be armed again.
+    ///
+    /// # Safety
+    /// `this` is live and not read again by the consumer for this post.
+    pub unsafe fn consumed(this: core::ptr::NonNull<ConcurrentTask>) {
+        // SAFETY: fn contract.
+        unsafe { this.as_ref() }
+            .queued
+            .store(false, core::sync::atomic::Ordering::Release);
     }
 
     /// A weak poster got `task` back because the target VM has closed: free

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -29,7 +29,7 @@ pub mod any_event_loop;
 // ─── public surface ─────────────────────────────────────────────────────────
 
 pub type JsResult<T> = core::result::Result<T, bun_core::JsError>;
-pub use ConcurrentTask::{Task, TaskTag, Taskable, task_tag};
+pub use ConcurrentTask::{ReusableConcurrentTask, Task, TaskHop, TaskTag, Taskable, task_tag};
 
 // snake_case alias for the file-level-struct module so higher tiers avoid
 // the type/module namespace collision on the PascalCase form.

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -1,5 +1,5 @@
 use core::ptr::NonNull;
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use bun_ast::{Loc, Log};
 use bun_core::FeatureFlags;
@@ -51,6 +51,12 @@ pub struct AsyncHTTP<'a> {
     pub elapsed: u64,
 
     pub(crate) signals: Signals,
+
+    /// Set (release) by the HTTP thread on the caller's original right before
+    /// the terminal result callback / shutdown release
+    /// ([`HTTPClientResultCallback::hand_back`]): from then on the HTTP thread
+    /// never touches the original again ([`crate::InFlight::reclaim`]).
+    pub(crate) handed_back: AtomicBool,
 }
 
 bun_threading::intrusive_work_task!(['a] AsyncHTTP<'a>, task);
@@ -454,6 +460,7 @@ impl<'a> AsyncHTTP<'a> {
             async_http_id,
             elapsed: 0,
             signals,
+            handed_back: AtomicBool::new(false),
         };
         if let Some(val) = options.unix_socket_path {
             this.client.unix_socket_path = val;
@@ -597,7 +604,7 @@ fn send_sync_callback(
     // `read_item`.
     unsafe {
         result.body_into(&mut (*(*this).response_buffer).list);
-        (*this).write_item(result.detach_lifetime());
+        (*this).write_item(result.into_owned());
     }
 }
 
@@ -750,7 +757,7 @@ impl<'a> AsyncHTTP<'a> {
                 }
                 let elapsed = (*this).elapsed;
                 bun_core::scoped_log!(AsyncHTTP, "onAsyncHTTPCallback: {:?}", elapsed);
-                callback.run(async_http, result);
+                callback.hand_back(async_http, result);
 
                 // SAFETY: `async_http` is the `async_http` field of a
                 // `ThreadlocalAsyncHTTP` heap-allocated by HTTPThread via

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -930,11 +930,11 @@ impl HttpThread {
         let release_unstarted = |http: NonNull<AsyncHttp<'static>>| {
             // SAFETY: heap-owned by the caller, alive until its completion,
             // and never touched by us again after this.
-            let release = unsafe { (*http.as_ptr()).result_callback };
-            if let Some(f) = release.release_at_shutdown {
-                // SAFETY: paired ctx/fn from `HTTPClientResultCallback::new_with_release`.
-                unsafe { f(release.ctx) };
-            }
+            unsafe {
+                (*http.as_ptr())
+                    .result_callback
+                    .hand_back_at_shutdown(http.as_ptr())
+            };
         };
         for http in core::mem::take(&mut self.deferred_tasks) {
             release_unstarted(http);
@@ -965,9 +965,11 @@ impl HttpThread {
                 client.close_proxy_tunnel(false);
                 drop(core::mem::take(&mut client.custom_ssl_ctx));
                 drop(core::mem::take(&mut client.state));
-                if let Some(f) = release.release_at_shutdown {
-                    f(release.ctx);
-                }
+                let real = (*nn.as_ptr())
+                    .async_http
+                    .real
+                    .expect("in-flight copy has an original");
+                release.hand_back_at_shutdown(real.as_ptr());
                 std::alloc::dealloc(
                     nn.as_ptr().cast::<u8>(),
                     std::alloc::Layout::new::<crate::ThreadlocalAsyncHttp<'static>>(),

--- a/src/http/Signals.rs
+++ b/src/http/Signals.rs
@@ -107,7 +107,7 @@ impl Default for Store {
 }
 
 impl Store {
-    pub fn to(&mut self) -> Signals {
+    pub fn to(&self) -> Signals {
         Signals {
             header_progress: Some(NonNull::from(&self.header_progress)),
             response_body_streaming: Some(NonNull::from(&self.response_body_streaming)),
@@ -117,7 +117,7 @@ impl Store {
         }
     }
 
-    pub fn to_with_backpressure(&mut self) -> Signals {
+    pub fn to_with_backpressure(&self) -> Signals {
         Signals {
             body_receive_mode: Some(NonNull::from(&self.body_receive_mode)),
             ..self.to()

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -171,6 +171,7 @@ use bun_core::MutableString;
 use bun_http_types::FetchRedirect::CommonAbortReason;
 use bun_ptr::RefPtr;
 use core::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+use std::sync::Arc;
 
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
@@ -516,16 +517,10 @@ impl<'a> HTTPClientResult<'a> {
         }
     }
 
-    /// Widen the borrow to `'static` for self-referential storage.
-    ///
-    /// `body` is the only lifetime-carrying field; it borrows the HTTP
-    /// thread's `decoded_body` scratch buffer, which is cleared immediately
-    /// after the callback returns, so the stored form carries `body: &[]`.
-    ///
-    /// # Safety
-    /// Caller must not read `.body` from the returned value.
+    /// The result without its borrowed `body` view (the bytes, if any, are in
+    /// `body_owned` on the terminal callback), for keeping past the callback.
     #[inline]
-    pub unsafe fn detach_lifetime(self) -> HTTPClientResult<'static> {
+    pub fn into_owned(self) -> HTTPClientResult<'static> {
         HTTPClientResult {
             body: &[],
             body_owned: self.body_owned,
@@ -558,12 +553,47 @@ pub struct HTTPClientResultCallback {
     /// allocator); the JS thread is parked in `shutdown_for_exit` waiting
     /// for the ack. `None` ⇒ no-op (the default for callers whose `ctx`
     /// is process-lifetime or whose code path never reaches `global_exit`).
+    /// Set by `new_with_release` and `from_handler`.
     pub(crate) release_at_shutdown: Option<unsafe fn(*mut ())>,
 }
 
 impl HTTPClientResultCallback {
     pub(crate) fn run(self, async_http: *mut AsyncHTTP<'static>, result: HTTPClientResult<'_>) {
         (self.function)(self.ctx, async_http, result);
+    }
+
+    /// The terminal result for the HTTP thread's copy `clone`: nothing touches
+    /// the caller's original after this, so mark it handed back, then deliver.
+    ///
+    /// # Safety
+    /// `clone` is the HTTP thread's live `ThreadlocalAsyncHTTP` copy.
+    pub(crate) unsafe fn hand_back(
+        self,
+        clone: *mut AsyncHTTP<'static>,
+        result: HTTPClientResult<'_>,
+    ) {
+        debug_assert!(!result.has_more);
+        // SAFETY: fn contract; `real` outlives the copy.
+        if let Some(real) = unsafe { (*clone).real } {
+            // SAFETY: as above.
+            unsafe { (*real.as_ptr()).handed_back.store(true, Ordering::Release) };
+        }
+        self.run(clone, result);
+    }
+
+    /// `process.exit()` with the request still out: mark the caller's
+    /// `original` handed back and run the owner's shutdown release, if any.
+    ///
+    /// # Safety
+    /// `original` is the caller's live `AsyncHTTP`; the HTTP thread never
+    /// touches it again.
+    pub(crate) unsafe fn hand_back_at_shutdown(self, original: *mut AsyncHTTP<'static>) {
+        // SAFETY: fn contract.
+        unsafe { (*original).handed_back.store(true, Ordering::Release) };
+        if let Some(release) = self.release_at_shutdown {
+            // SAFETY: paired ctx/fn from `new_with_release` / `from_handler`.
+            unsafe { release(self.ctx) };
+        }
     }
 
     // Type-erases a typed callback behind a raw context pointer.
@@ -593,6 +623,178 @@ impl HTTPClientResultCallback {
         let mut cb = Self::new(this, callback);
         cb.release_at_shutdown = Some(release);
         cb
+    }
+}
+
+/// The receiving end of a request started through
+/// [`HTTPClientResultCallback::from_handler`], called on the HTTP thread.
+pub trait HTTPClientResultHandler: Send + Sync + 'static {
+    /// A progress (`result.has_more`) or terminal result. By the terminal one
+    /// the request has already been handed back, so nothing of it is passed.
+    fn on_result(&self, result: HTTPClientResult<'_>);
+    /// The process is exiting with the request still out: nothing more will be
+    /// delivered. HTTP thread; the JS thread is parked.
+    fn release_at_shutdown(&self) {}
+}
+
+impl HTTPClientResultCallback {
+    /// Deliver results to `handler`, which the request holds until its terminal
+    /// result (or shutdown release) has been delivered.
+    pub fn from_handler<H: HTTPClientResultHandler>(handler: Arc<H>) -> Self {
+        fn on_result<H: HTTPClientResultHandler>(
+            ctx: *mut (),
+            async_http: *mut AsyncHTTP<'static>,
+            result: HTTPClientResult<'_>,
+        ) {
+            let _ = async_http;
+            let terminal = !result.has_more;
+            // SAFETY: `ctx` is the `Arc<H>` `from_handler` leaked, released only
+            // below / in `release`.
+            unsafe { (*ctx.cast_const().cast::<H>()).on_result(result) };
+            if terminal {
+                // SAFETY: the terminal result is delivered once; this is that ref.
+                drop(unsafe { Arc::from_raw(ctx.cast_const().cast::<H>()) });
+            }
+        }
+        unsafe fn release<H: HTTPClientResultHandler>(ctx: *mut ()) {
+            // SAFETY: as in `on_result`; no result follows a shutdown release.
+            let handler = unsafe { Arc::from_raw(ctx.cast_const().cast::<H>()) };
+            handler.release_at_shutdown();
+        }
+        Self {
+            ctx: Arc::into_raw(handler).cast_mut().cast::<()>(),
+            function: on_result::<H>,
+            release_at_shutdown: Some(release::<H>),
+        }
+    }
+}
+
+/// An [`AsyncHTTP`] together with the storage its request borrows (URL, header
+/// buffer, body bytes, hostname, ...) point into, in one allocation.
+pub struct OwnedRequest<S: 'static>(Box<RequestCell<S>>);
+
+struct RequestCell<S: 'static> {
+    /// Borrows `storage`: declared first so it is dropped first. `None` only
+    /// while `OwnedRequest::new` builds it and after `into_storage`.
+    http: Option<AsyncHTTP<'static>>,
+    storage: S,
+}
+
+impl<S: 'static> OwnedRequest<S> {
+    /// Build the request from borrows of `storage`.
+    pub fn new(storage: S, build: impl for<'a> FnOnce(&'a S) -> AsyncHTTP<'a>) -> Self {
+        let mut cell = Box::new(RequestCell {
+            http: None,
+            storage,
+        });
+        let http = build(&cell.storage);
+        // SAFETY: `http` borrows only `cell.storage`, which stays in this heap
+        // cell, is never lent out `&mut` or moved while `http` is alive, and is
+        // dropped after it; every accessor re-ties the lifetime to a borrow of
+        // `self`.
+        let http = unsafe { core::mem::transmute::<AsyncHTTP<'_>, AsyncHTTP<'static>>(http) };
+        cell.http = Some(http);
+        Self(cell)
+    }
+
+    pub fn storage(&self) -> &S {
+        &self.0.storage
+    }
+
+    /// Drop the request and take the storage back.
+    pub fn into_storage(mut self) -> S {
+        self.0.http = None;
+        self.0.storage
+    }
+
+    pub fn http(&self) -> &AsyncHTTP<'_> {
+        self.0.http.as_ref().expect("built")
+    }
+
+    /// Adjust the request before it is started.
+    pub fn with_http_mut<R>(&mut self, f: impl for<'a> FnOnce(&mut AsyncHTTP<'a>) -> R) -> R {
+        let http = self.0.http.as_mut().expect("built");
+        // SAFETY: `'a` is fresh for `f` and outlives the `&mut`, so `f` can
+        // store into the request only `'static` data or what it already
+        // borrows (`self.0.storage`); see `new`.
+        f(unsafe { core::mem::transmute::<&mut AsyncHTTP<'static>, &mut AsyncHTTP<'_>>(http) })
+    }
+
+    /// Queue the request on `batch` for the HTTP thread. The request stays
+    /// allocated, untouched by this thread, until the HTTP thread hands it back.
+    pub fn start(self, batch: &mut bun_threading::thread_pool::Batch) -> InFlight<S> {
+        let id = self.http().async_http_id;
+        let ptr = NonNull::from(Box::leak(self.0));
+        // SAFETY: `ptr` is the live allocation just leaked; the HTTP thread takes
+        // it over from `schedule` until it sets `handed_back`.
+        unsafe {
+            (*ptr.as_ptr())
+                .http
+                .as_mut()
+                .expect("built")
+                .schedule(batch)
+        };
+        InFlight { ptr, id }
+    }
+}
+
+/// The caller's handle on a started [`OwnedRequest`]: its id for the
+/// `HTTPThread::schedule_*` calls, and the way to take it back once the HTTP
+/// thread is done with it. Dropping it before then leaks the request.
+pub struct InFlight<S: 'static> {
+    ptr: NonNull<RequestCell<S>>,
+    id: u32,
+}
+
+impl<S: 'static> InFlight<S> {
+    pub fn async_http_id(&self) -> u32 {
+        self.id
+    }
+
+    /// Whether the HTTP thread has handed the request back (its terminal result
+    /// or shutdown release was delivered).
+    pub fn handed_back(&self) -> bool {
+        // SAFETY: the allocation is live until `reclaim`/`drop`; `handed_back`
+        // is atomic and the HTTP thread only ever reads the bytes around it.
+        unsafe {
+            (*self.ptr.as_ptr())
+                .http
+                .as_ref()
+                .expect("built")
+                .handed_back
+                .load(Ordering::Acquire)
+        }
+    }
+
+    /// The request's storage. The HTTP thread is reading the bytes `http`
+    /// borrowed from it: `S` must not free or reallocate those through `&S`.
+    pub fn storage(&self) -> &S {
+        // SAFETY: live until `reclaim`/`drop`; never written while in flight.
+        unsafe { &(*self.ptr.as_ptr()).storage }
+    }
+
+    /// Take the request back; `Err(self)` while the HTTP thread still has it.
+    pub fn reclaim(self) -> Result<OwnedRequest<S>, Self> {
+        if !self.handed_back() {
+            return Err(self);
+        }
+        let this = core::mem::ManuallyDrop::new(self);
+        // SAFETY: `start` leaked exactly this box, and the HTTP thread is done with it.
+        Ok(OwnedRequest(unsafe { Box::from_raw(this.ptr.as_ptr()) }))
+    }
+}
+
+impl<S: 'static> Drop for InFlight<S> {
+    fn drop(&mut self) {
+        if self.handed_back() {
+            // SAFETY: as in `reclaim`.
+            drop(unsafe { Box::from_raw(self.ptr.as_ptr()) });
+        } else {
+            debug_assert!(
+                false,
+                "InFlight request dropped before the HTTP thread handed it back"
+            );
+        }
     }
 }
 

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -346,14 +346,14 @@ impl NetworkTask {
         }
         // SAFETY: the HTTP thread is the sole writer for this call; nothing
         // exclusive to `*this` outlives this block, which ends before the
-        // cross-thread push below. `detach_lifetime` erases the callback-scoped
-        // `'_` to `'static` and clears `body` to `&[]`; the body bytes were
-        // stashed into `(*this).response_buffer` above.
+        // cross-thread push below. `into_owned` drops the callback-scoped
+        // `body` view; the body bytes were stashed into `(*this).response_buffer`
+        // above.
         unsafe {
             // Preserve metadata captured on an earlier streaming callback; the
             // final `result` won't have it.
             let saved_metadata = (*this).response.metadata.take();
-            (*this).response = result.detach_lifetime();
+            (*this).response = result.into_owned();
             if (*this).response.metadata.is_none() {
                 (*this).response.metadata = saved_metadata;
             }

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -262,6 +262,28 @@ impl Ticket {
     pub fn cancelled(&self) -> bool {
         self.shared.state() >= State::Draining
     }
+
+    /// This ticket in a form that can be handed back through `&self`
+    /// ([`InFlightTicket::hand_back`]), for work whose state is shared.
+    pub fn in_flight(self) -> InFlightTicket {
+        let this = core::mem::ManuallyDrop::new(self);
+        InFlightTicket {
+            // SAFETY: `this` is never dropped; its one `shared` moves here.
+            shared: unsafe { core::ptr::read(&raw const this.shared) },
+            kind: this.kind,
+            #[cfg(debug_assertions)]
+            id: this.id,
+            returned: core::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    fn give_back(shared: &Shared, #[cfg(debug_assertions)] id: u64) {
+        #[cfg(debug_assertions)]
+        shared.debug.live.lock().at.remove(&id);
+        if shared.tickets.fetch_sub(1, Ordering::SeqCst) == 1 && shared.state() >= State::Draining {
+            shared.notify();
+        }
+    }
 }
 
 impl Clone for Ticket {
@@ -274,13 +296,54 @@ impl Clone for Ticket {
 
 impl Drop for Ticket {
     fn drop(&mut self) {
-        #[cfg(debug_assertions)]
-        self.shared.debug.live.lock().at.remove(&self.id);
-        if self.shared.tickets.fetch_sub(1, Ordering::SeqCst) == 1
-            && self.shared.state() >= State::Draining
-        {
-            self.shared.notify();
+        Ticket::give_back(
+            &self.shared,
+            #[cfg(debug_assertions)]
+            self.id,
+        );
+    }
+}
+
+/// A [`Ticket`] kept in state shared with the JS thread: the other thread
+/// posts through it and hands it back, once, through `&self` when its last
+/// touch of the VM is done. Dropping it unreturned hands it back.
+pub struct InFlightTicket {
+    shared: Arc<Shared>,
+    kind: LoopKind,
+    #[cfg(debug_assertions)]
+    id: u64,
+    returned: core::sync::atomic::AtomicBool,
+}
+
+impl InFlightTicket {
+    /// [`Ticket::post`]. Not after [`hand_back`](Self::hand_back).
+    pub fn post(&self, task: NonNull<ConcurrentTaskItem>) {
+        debug_assert!(
+            !self.returned.load(Ordering::Relaxed),
+            "post after hand_back"
+        );
+        debug_assert!(
+            self.shared.state() != State::Closed,
+            "ticket post after its VM closed (a ticket was created after the wait)"
+        );
+        self.shared.deliver(self.kind, task);
+    }
+
+    /// Give the ticket back (what dropping a [`Ticket`] does); later calls do nothing.
+    pub fn hand_back(&self) {
+        if !self.returned.swap(true, Ordering::SeqCst) {
+            Ticket::give_back(
+                &self.shared,
+                #[cfg(debug_assertions)]
+                self.id,
+            );
         }
+    }
+}
+
+impl Drop for InFlightTicket {
+    fn drop(&mut self) {
+        self.hand_back();
     }
 }
 

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -640,6 +640,10 @@ impl EventLoop {
             // LinearFifo's fields are private — `write_item` is the
             // public path (single-slot copy, same complexity).
             let _ = self.tasks.write_item(task_ref.task);
+            if to_destroy != Some(task) {
+                // SAFETY: `task` is live; this loop is done reading it.
+                unsafe { ConcurrentTask::ConcurrentTask::consumed(NonNull::new_unchecked(task)) };
+            }
         }
 
         if let Some(dest) = to_destroy {

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1196,7 +1196,7 @@ pub mod virtual_machine;
 pub mod vm_handle;
 pub use self::virtual_machine as VirtualMachine;
 pub use self::virtual_machine::InitOptions as VirtualMachineInitOptions;
-pub use self::vm_handle::{ConcurrentPoster, LoopKind, Posted, Ticket, VmHandle};
+pub use self::vm_handle::{ConcurrentPoster, InFlightTicket, LoopKind, Posted, Ticket, VmHandle};
 
 #[path = "ModuleLoader.rs"]
 pub mod module_loader;

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -1297,6 +1297,272 @@ impl Pipe {
     }
 }
 
+/// `uv_pipe()`: a connected pair of pipe ends, `[read, write]`.
+pub fn pipe_pair(read_flags: c_int, write_flags: c_int) -> Result<[uv_file; 2], ReturnCode> {
+    let mut fds: [uv_file; 2] = [0; 2];
+    // SAFETY: `fds` is the out-array `uv_pipe` fills.
+    let rc = unsafe { uv_pipe(&raw mut fds, read_flags, write_flags) };
+    if rc.is_err() { Err(rc) } else { Ok(fds) }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// OwnedPipe — a heap `uv_pipe_t` with its read state, owned from Rust.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// What [`OwnedPipe::read_start`] delivers, on the loop thread.
+pub enum PipeRead<'a> {
+    /// Bytes read into the pipe's buffer; borrowed for the call.
+    Data(&'a [u8]),
+    /// The raw negative libuv errno (e.g. `UV_EOF`); reading has been stopped.
+    Error(c_int),
+}
+
+struct PipeReadState {
+    buf: Box<[u8]>,
+    on_read: Box<dyn FnMut(PipeRead<'_>)>,
+}
+
+/// The allocation behind an [`OwnedPipe`]: the handle (first, so the pointer
+/// libuv holds is the allocation's) and the read state its callbacks use.
+/// Freed once both the [`OwnedPipe`] is gone and the close callback has run,
+/// whichever is later, so it outlives every libuv callback and the owner.
+#[repr(C)]
+struct PipeBox {
+    pipe: Pipe,
+    read: Option<PipeReadState>,
+    /// The [`OwnedPipe`] still exists.
+    owned: bool,
+    /// The close callback has run: libuv is done with the handle.
+    closed: bool,
+}
+
+impl PipeBox {
+    unsafe extern "C" fn on_close(handle: *mut Pipe) {
+        // SAFETY: `handle` is the `PipeBox` allocation (pipe first); the close
+        // callback runs once, after libuv's last use of the handle.
+        unsafe {
+            let this = handle.cast::<PipeBox>();
+            (*this).closed = true;
+            if !(*this).owned {
+                drop(Box::from_raw(this));
+            }
+        }
+    }
+
+    /// `uv_close` the handle unless that already started. Loop thread.
+    ///
+    /// # Safety
+    /// `this` is a live `PipeBox` whose handle was initialised.
+    unsafe fn close(this: *mut PipeBox) {
+        // SAFETY: fn contract.
+        unsafe {
+            if !(*this).closed && !(*this).pipe.is_closing() {
+                (*this).pipe.close(Self::on_close);
+            }
+        }
+    }
+
+    /// [`open_handles::CloseViaOwner`] for VM teardown: close, but leave the
+    /// allocation to the [`OwnedPipe`].
+    unsafe fn close_for_teardown(owner: *mut c_void) {
+        // SAFETY: registered with this `PipeBox` as owner while it is live
+        // (cleared by `uv_close` → `open_handles::remove`).
+        unsafe { Self::close(owner.cast::<PipeBox>()) }
+    }
+}
+
+/// One in-flight [`OwnedPipe::write`]: the request, the bytes it points into,
+/// and the completion. libuv owns the box until the write callback.
+#[repr(C)]
+struct PipeWrite {
+    req: uv_write_t,
+    buf: uv_buf_t,
+    _bytes: Box<[u8]>,
+    on_done: Option<Box<dyn FnOnce(ReturnCode)>>,
+}
+
+/// An initialised `uv_pipe_t` on this thread's loop that Rust owns: dropping
+/// it `uv_close`s the handle (cancelling in-flight writes, whose completions
+/// still run) and frees it from the close callback.
+pub struct OwnedPipe(core::ptr::NonNull<PipeBox>);
+
+impl OwnedPipe {
+    /// `uv_pipe_init` on this thread's loop.
+    pub fn init(ipc: bool) -> Result<OwnedPipe, ReturnCode> {
+        // SAFETY: all-zero is a valid (uninitialised) `uv_pipe_t`.
+        let pipe: Pipe = unsafe { core::mem::zeroed() };
+        let raw = Box::into_raw(Box::new(PipeBox {
+            pipe,
+            read: None,
+            owned: true,
+            closed: false,
+        }));
+        // SAFETY: `raw` is the live box just leaked; on failure the handle was
+        // never registered with the loop, so it is freed directly.
+        unsafe {
+            let rc = (*raw).pipe.init(Loop::get(), ipc);
+            if rc.is_err() {
+                drop(Box::from_raw(raw));
+                return Err(rc);
+            }
+            open_handles::set_owner(raw.cast(), raw.cast(), Some(PipeBox::close_for_teardown));
+            Ok(OwnedPipe(core::ptr::NonNull::new_unchecked(raw)))
+        }
+    }
+
+    #[inline]
+    fn pipe(&self) -> *mut Pipe {
+        // SAFETY: `PipeBox` is `repr(C)` with `pipe` first.
+        unsafe { &raw mut (*self.0.as_ptr()).pipe }
+    }
+
+    /// `uv_pipe_open`: adopt `file` as this pipe's handle.
+    pub fn open(&self, file: uv_file) -> Result<(), ReturnCode> {
+        // SAFETY: live, initialised handle (type invariant).
+        let rc = unsafe { (*self.pipe()).open(file) };
+        if rc.is_err() { Err(rc) } else { Ok(()) }
+    }
+
+    pub fn unref(&self) {
+        // SAFETY: live, initialised handle (type invariant).
+        unsafe { (*self.pipe()).unref() }
+    }
+
+    /// `uv_read_start` into a `buf_size` buffer; `on_read` gets each result
+    /// on the loop thread until [`read_stop`](Self::read_stop) or drop.
+    pub fn read_start(
+        &self,
+        buf_size: usize,
+        on_read: Box<dyn FnMut(PipeRead<'_>)>,
+    ) -> Result<(), ReturnCode> {
+        unsafe extern "C" fn alloc_cb(
+            handle: *mut uv_handle_t,
+            _suggested_size: usize,
+            buf: *mut uv_buf_t,
+        ) {
+            // SAFETY: `handle` is the `PipeBox` this was registered on, whose
+            // `read` was set before `uv_read_start`; `buf` is libuv's out-param.
+            unsafe {
+                let this = handle.cast::<PipeBox>();
+                *buf = match (*this).read.as_mut() {
+                    Some(state) => uv_buf_t {
+                        len: state.buf.len() as ULONG,
+                        base: state.buf.as_mut_ptr(),
+                    },
+                    None => uv_buf_t::init(b""), // libuv reports UV_ENOBUFS
+                };
+            }
+        }
+        unsafe extern "C" fn read_cb(
+            stream: *mut uv_stream_t,
+            nread: ReturnCodeI64,
+            buf: *const uv_buf_t,
+        ) {
+            let n = nread.int();
+            if n == 0 {
+                return; // EAGAIN / EWOULDBLOCK
+            }
+            // SAFETY: as `alloc_cb`; `buf` is the buffer `alloc_cb` handed out,
+            // filled with `n` bytes when `n > 0`. The state is moved out for the
+            // call so a re-entrant `read_start` cannot free the running closure.
+            unsafe {
+                let this = stream.cast::<PipeBox>();
+                let Some(mut state) = (*this).read.take() else {
+                    return;
+                };
+                if n < 0 {
+                    let _ = uv_read_stop(stream);
+                    (state.on_read)(PipeRead::Error(n as c_int));
+                } else {
+                    debug_assert!(core::ptr::eq((*buf).base, state.buf.as_ptr()));
+                    (state.on_read)(PipeRead::Data(&state.buf[..n as usize]));
+                }
+                if (*this).read.is_none() {
+                    (*this).read = Some(state);
+                }
+            }
+        }
+        // SAFETY: live, initialised handle (type invariant); the read state is
+        // installed before libuv can call back and lives until the close callback.
+        unsafe {
+            (*self.0.as_ptr()).read = Some(PipeReadState {
+                buf: vec![0u8; buf_size].into_boxed_slice(),
+                on_read,
+            });
+            let rc = uv_read_start(self.pipe().cast(), Some(alloc_cb), Some(read_cb));
+            if rc.is_err() { Err(rc) } else { Ok(()) }
+        }
+    }
+
+    pub fn read_stop(&self) {
+        // SAFETY: live, initialised handle (type invariant); always succeeds.
+        let _ = unsafe { uv_read_stop(self.pipe().cast()) };
+    }
+
+    /// `uv_write` a copy of `bytes`; `on_done` gets the status on the loop
+    /// thread (`UV_ECANCELED` if the pipe is closed first). On `Err` nothing
+    /// was queued and `on_done` never runs.
+    pub fn write(
+        &self,
+        bytes: Box<[u8]>,
+        on_done: Box<dyn FnOnce(ReturnCode)>,
+    ) -> Result<(), ReturnCode> {
+        unsafe extern "C" fn write_cb(req: *mut uv_write_t, status: ReturnCode) {
+            // SAFETY: `req` is the first field of the `PipeWrite` leaked in
+            // `write`; libuv calls this exactly once.
+            let mut write = unsafe { Box::from_raw(req.cast::<PipeWrite>()) };
+            if let Some(on_done) = write.on_done.take() {
+                on_done(status);
+            }
+        }
+        // SAFETY: all-zero is a valid `uv_write_t` for `uv_write` to fill.
+        let req: uv_write_t = unsafe { core::mem::zeroed() };
+        let mut write = Box::new(PipeWrite {
+            req,
+            buf: uv_buf_t::init(b""),
+            _bytes: bytes,
+            on_done: Some(on_done),
+        });
+        write.buf = uv_buf_t::init(&write._bytes);
+        let raw = Box::into_raw(write);
+        // SAFETY: live, initialised handle (type invariant); `raw` stays
+        // allocated and unmoved until `write_cb` reclaims it.
+        unsafe {
+            let rc = uv_write(
+                &raw mut (*raw).req,
+                self.pipe().cast(),
+                &raw const (*raw).buf,
+                1,
+                Some(write_cb),
+            );
+            if rc.is_err() {
+                drop(Box::from_raw(raw));
+                return Err(rc);
+            }
+        }
+        Ok(())
+    }
+}
+
+const _: () = assert!(core::mem::offset_of!(PipeBox, pipe) == 0);
+const _: () = assert!(core::mem::offset_of!(PipeWrite, req) == 0);
+
+impl Drop for OwnedPipe {
+    fn drop(&mut self) {
+        // SAFETY: live `PipeBox` (type invariant); freed here only if libuv is
+        // already done with it, else by the close callback.
+        unsafe {
+            let this = self.0.as_ptr();
+            (*this).owned = false;
+            if (*this).closed {
+                drop(Box::from_raw(this));
+            } else {
+                PipeBox::close(this);
+            }
+        }
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // `uv_tty_t`.
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/picohttp/lib.rs
+++ b/src/picohttp/lib.rs
@@ -75,6 +75,12 @@ pub struct Header {
     value_len: usize,
 }
 
+// SAFETY: a `Header` is two borrowed `&[u8]` views spelled as (ptr, len) for C
+// layout; it owns nothing and has `&[u8]`'s thread-safety.
+unsafe impl Send for Header {}
+// SAFETY: as above.
+unsafe impl Sync for Header {}
+
 impl Default for Header {
     #[inline]
     fn default() -> Self {

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -660,6 +660,14 @@ impl<T> ThisPtr<T> {
         self.0.as_ptr()
     }
 
+    /// Record this pointer as a write-capable back-reference (for handle enums
+    /// whose dispatcher forms the `&mut`). The holder takes on the `BackRef`
+    /// invariant.
+    #[inline]
+    pub fn backref_mut(self) -> BackRef<T, Mut> {
+        BackRef(self.0, core::marker::PhantomData)
+    }
+
     /// Fresh shared borrow of the pointee.
     ///
     /// Sound under the [`new`](Self::new) invariant: the pointee is live and
@@ -687,6 +695,49 @@ impl<T> core::ops::Deref for ThisPtr<T> {
     #[inline]
     fn deref(&self) -> &T {
         self.get()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OwnedThis<T> — single-owner heap allocation that hands out `ThisPtr`s.
+//
+// `Box<T>` asserts unique access on every touch, which is wrong for a callback
+// hub whose address is also held by C / JS / a task queue and re-entered while
+// a method on it is running. `OwnedThis` keeps the ownership (drop frees) but
+// only ever lends the pointee as `ThisPtr<T>` / `&T`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The unique owner of a heap-allocated `T` that is otherwise reached through
+/// [`ThisPtr`] copies. Dropping it drops and frees the `T`; every `ThisPtr`
+/// lent from it must be dead by then (the usual back-reference obligation).
+pub struct OwnedThis<T>(core::ptr::NonNull<T>);
+
+impl<T> OwnedThis<T> {
+    #[inline]
+    pub fn new(value: T) -> Self {
+        OwnedThis(core::ptr::NonNull::from(Box::leak(Box::new(value))))
+    }
+
+    /// A dispatch handle to the pointee (root provenance).
+    #[inline]
+    pub fn this_ptr(&self) -> ThisPtr<T> {
+        ThisPtr(self.0)
+    }
+}
+
+impl<T> core::ops::Deref for OwnedThis<T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: we own the live allocation.
+        unsafe { self.0.as_ref() }
+    }
+}
+
+impl<T> Drop for OwnedThis<T> {
+    fn drop(&mut self) {
+        // SAFETY: `new` leaked exactly this `Box`; we are its unique owner.
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
     }
 }
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -84,8 +84,8 @@ use crate::webcore::fetch::fetch_tasklet::FetchTasklet;
 use crate::webcore::file_sink::FileSink;
 #[cfg(not(windows))]
 use crate::webcore::file_sink::Poll as FileSinkPoll;
-use crate::webcore::s3::download_stream::S3HttpDownloadStreamingTask;
-use crate::webcore::s3::simple_request::S3HttpSimpleTask;
+use crate::webcore::s3::download_stream as s3_download;
+use crate::webcore::s3::simple_request as s3_request;
 use crate::webcore::streams::Pending as StreamPending;
 
 use crate::api::bun_subprocess::Subprocess;
@@ -188,6 +188,17 @@ pub(crate) fn run_task(
         ($ty:ty) => {
             task.ptr.cast::<$ty>()
         };
+    }
+    /// `<$hop as TaskHop>::run` on the queued `ThisPtr`, SAFETY spelled once.
+    macro_rules! hop {
+        ($hop:ty) => {{
+            // SAFETY: §Dispatch — `task.tag` is `<$hop>::TAG`, set together with
+            // `task.ptr` from a `ThisPtr` whose pointee keeps itself alive for
+            // the queued task; not touched here after the call.
+            <$hop as bun_event_loop::TaskHop>::run(unsafe {
+                bun_ptr::ThisPtr::new(cast_ptr!(<$hop as bun_event_loop::TaskHop>::Target))
+            })
+        }};
     }
     /// `CompressionStream::<T>::run_from_js_thread` takes `*mut T` (full
     /// allocation provenance — R-2) so its trailing `T::deref()` may free the box.
@@ -344,14 +355,8 @@ pub(crate) fn run_task(
                 ))
             };
         }
-        // `cast_ptr!` yields the heap-allocated S3 task; JS-thread dispatch
-        // is the sole owner here.
-        task_tag::S3HttpSimpleTask => {
-            S3HttpSimpleTask::on_response(cast_ptr!(S3HttpSimpleTask))?;
-        }
-        task_tag::S3HttpDownloadStreamingTask => {
-            S3HttpDownloadStreamingTask::on_response(cast_ptr!(S3HttpDownloadStreamingTask));
-        }
+        task_tag::S3HttpSimpleTask => hop!(s3_request::ResponseHop)?,
+        task_tag::S3HttpDownloadStreamingTask => hop!(s3_download::ProgressHop)?,
 
         // ── napi ─────────────────────────────────────────────────────────
         task_tag::NapiAsyncWork => {
@@ -1251,6 +1256,15 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
             unsafe { <$ty as Taskable>::release_unrun(task.ptr.cast::<$ty>()) }
         }};
     }
+    /// `<$hop as TaskHop>::release_unrun` on the queued `ThisPtr`, SAFETY spelled once.
+    macro_rules! release_hop {
+        ($hop:ty) => {{
+            // SAFETY: as `release!`; the tag is `<$hop>::TAG`.
+            <$hop as bun_event_loop::TaskHop>::release_unrun(unsafe {
+                bun_ptr::ThisPtr::new(task.ptr.cast::<<$hop as bun_event_loop::TaskHop>::Target>())
+            })
+        }};
+    }
     match task.tag {
         task_tag::AnyTaskJob => {
             // The one erased tag: every payload is a `Job<C>` reached through its header.
@@ -1302,8 +1316,8 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
             unsafe { bun_ptr::ThisPtr::new(task.ptr.cast::<FileSink>()) },
         ),
         task_tag::RuntimeTranspilerStore => release!(RuntimeTranspilerStore),
-        task_tag::S3HttpDownloadStreamingTask => release!(S3HttpDownloadStreamingTask),
-        task_tag::S3HttpSimpleTask => release!(S3HttpSimpleTask),
+        task_tag::S3HttpDownloadStreamingTask => release_hop!(s3_download::ProgressHop),
+        task_tag::S3HttpSimpleTask => release_hop!(s3_request::ResponseHop),
         task_tag::SendQueueDeferred => release!(crate::ipc::SendQueue),
         task_tag::ServerAllConnectionsClosedTask => release!(ServerAllConnectionsClosedTask),
         task_tag::ShellAsync => release!(crate::shell::dispatch_tasks::ShellAsyncTask),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -102,6 +102,8 @@ pub(crate) struct RuntimeState {
     /// stop; one ref per entry, released by `CronJob::remove_from_list` /
     /// `clear_all_for_vm`.
     pub(crate) cron_jobs: Vec<bun_ptr::RefPtr<crate::api::cron::CronJob>>,
+    /// The `Bun.WebView` browser host processes spawned from this thread.
+    pub(crate) webview_hosts: crate::webview::Hosts,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -214,6 +216,19 @@ pub(crate) fn active_handles() -> Option<&'static mut ActiveHandles> {
     }
     // SAFETY: live boxed per-thread `RuntimeState`.
     Some(unsafe { &mut (*state).active_handles })
+}
+
+/// This thread's `Bun.WebView` host-process registry, lent to `f`. `None`
+/// before [`init_runtime_state`] / after teardown.
+#[inline]
+pub(crate) fn with_webview_hosts<R>(f: impl FnOnce(&crate::webview::Hosts) -> R) -> Option<R> {
+    let state = runtime_state();
+    if state.is_null() {
+        return None;
+    }
+    // SAFETY: live boxed per-thread `RuntimeState`; the shared borrow ends
+    // with `f`, and nothing `f` reaches frees the state on this thread.
+    Some(f(unsafe { &(*state).webview_hosts }))
 }
 
 impl ActiveHandle {
@@ -409,6 +424,7 @@ unsafe fn init_runtime_state(
         active_handles: ActiveHandles::default(),
         wake_ctx: None,
         cron_jobs: Vec::new(),
+        webview_hosts: crate::webview::Hosts::default(),
     }));
     RUNTIME_STATE.with(|c| c.set(state));
 
@@ -1800,15 +1816,9 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
                 crate::webcore::fetch::FetchTasklet::stop_for_vm_teardown(t.as_ptr())
             },
             // SAFETY: live until they unregister in `on_response`.
-            ActiveHandle::S3Request(t) => unsafe {
-                crate::webcore::s3::simple_request::S3HttpSimpleTask::stop_for_vm_teardown(
-                    t.as_ptr(),
-                )
-            },
+            ActiveHandle::S3Request(t) => unsafe { t.as_ref() }.stop_for_vm_teardown(),
             // SAFETY: as above.
-            ActiveHandle::S3Download(t) => unsafe {
-                crate::webcore::s3::download_stream::S3HttpDownloadStreamingTask::stop_for_vm_teardown(t.as_ptr())
-            },
+            ActiveHandle::S3Download(t) => unsafe { t.as_ref() }.stop_for_vm_teardown(),
             // A live VM cannot cancel a build: hop tasks it already queued here
             // would still be dispatched against the finished pass. The build
             // runs on; its completion lands on the next file's global.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1737,6 +1737,9 @@ pub(crate) fn stop_active_handles_for_test_isolation(vm: &mut VirtualMachine) {
 }
 
 pub(crate) fn stop_active_handles_for_vm_teardown(vm: &mut VirtualMachine) -> SweepResult {
+    // The browser children were killed by `Bun__WebView__closeAllForTermination`;
+    // release their process handles while this VM's poll store is still alive.
+    with_webview_hosts(crate::webview::Hosts::release_all);
     stop_active_handles(vm, StopReason::VmTeardown)
 }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2652,11 +2652,11 @@ where
                         .get_http_proxy(true, None, None)
                         .map(|proxy| proxy.href);
 
+                    let ctx = this.as_ctx_ptr().cast::<c_void>();
                     let _ = S3::client::stat(
                         credentials,
                         path,
-                        Self::on_s3_size_resolved_thunk,
-                        this.as_ctx_ptr().cast::<c_void>(),
+                        Box::new(move |result| Self::on_s3_size_resolved_thunk(result, ctx)),
                         proxy_url,
                         s3.request_payer,
                     ); // TODO: properly propagate exception upwards

--- a/src/runtime/webcore.rs
+++ b/src/runtime/webcore.rs
@@ -356,7 +356,7 @@ pub enum SinkHandle {
     None,
     ServerResponse(crate::server::AnyRequestContext),
     FetchRequestBody(bun_ptr::BackRef<fetch::FetchRequestBodySink, bun_ptr::Mut>),
-    S3Upload(bun_ptr::BackRef<streams::NetworkSink, bun_ptr::Mut>),
+    S3Upload(bun_ptr::BackRef<streams::NetworkSink, bun_ptr::Root>),
     FileSink(bun_ptr::BackRef<file_sink::FileSink>),
     HTMLRewriter(bun_ptr::BackRef<crate::api::html_rewriter::RewriterPipe>),
     HttpResponse(bun_ptr::BackRef<streams::HTTPResponseSink, bun_ptr::Mut>),
@@ -383,8 +383,7 @@ impl SinkHandle {
             SinkHandle::ServerResponse(any) => any.write_chunk(data),
             // SAFETY: live backref; ByteStream clears sink before free.
             SinkHandle::FetchRequestBody(mut p) => unsafe { p.get_mut() }.write(data),
-            // SAFETY: live backref; ByteStream clears sink before free.
-            SinkHandle::S3Upload(mut p) => unsafe { p.get_mut() }.write(data),
+            SinkHandle::S3Upload(p) => p.write(data),
             SinkHandle::FileSink(p) => p.write(data),
             SinkHandle::HTMLRewriter(p) => p.write(data),
             // SAFETY: live backref; transform detaches before the JSSink is finalized.
@@ -405,8 +404,7 @@ impl SinkHandle {
             SinkHandle::ServerResponse(any) => any.end_chunk(err.as_ref()),
             // SAFETY: live backref; ByteStream clears sink before free.
             SinkHandle::FetchRequestBody(mut p) => unsafe { p.get_mut() }.end_from_stream(err),
-            // Raw-ptr dispatch: may re-borrow and free the sink (see its doc).
-            SinkHandle::S3Upload(p) => streams::NetworkSink::end_from_stream(p.as_ptr(), err),
+            SinkHandle::S3Upload(p) => streams::NetworkSink::end_from_stream(p.this_ptr(), err),
             SinkHandle::FileSink(p) => p.end_from_stream(err),
             SinkHandle::HTMLRewriter(p) => p.end_from_stream(err),
             SinkHandle::HttpResponse(_) => {}

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1152,7 +1152,6 @@ impl BlobExt for Blob {
                 proxy_url,
                 aws_options.request_payer,
                 None,
-                core::ptr::null_mut(),
             );
         }
 
@@ -3968,7 +3967,6 @@ pub(crate) fn write_file_with_source_destination(
                             proxy_url,
                             aws_options.request_payer,
                             None,
-                            core::ptr::null_mut(),
                         );
                     } else {
                         return Ok(JSPromise::rejected_promise(
@@ -4049,7 +4047,6 @@ pub(crate) fn write_file_with_source_destination(
                         proxy_url,
                         aws_options.request_payer,
                         None,
-                        core::ptr::null_mut(),
                     );
                 } else {
                     return Ok(JSPromise::rejected_promise(
@@ -4326,7 +4323,6 @@ pub(crate) fn write_file_internal(
                                 proxy_url,
                                 aws_options.request_payer,
                                 None,
-                                core::ptr::null_mut(),
                             )?));
                         }
                         destination_blob.detach();

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -102,13 +102,6 @@ impl ProducerHold {
         }
     }
 
-    /// [`hold`](Self::hold) for a source the caller has in hand.
-    pub fn hold_source(&self, source: &mut Source) {
-        self.release();
-        source.increment_count();
-        self.source.set(Some(core::ptr::NonNull::from(source)));
-    }
-
     pub fn is_held(&self) -> bool {
         self.source.get().is_some()
     }

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -102,6 +102,13 @@ impl ProducerHold {
         }
     }
 
+    /// [`hold`](Self::hold) for a source the caller has in hand.
+    pub fn hold_source(&self, source: &mut Source) {
+        self.release();
+        source.increment_count();
+        self.source.set(Some(core::ptr::NonNull::from(source)));
+    }
+
     pub fn is_held(&self) -> bool {
         self.source.get().is_some()
     }

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -422,13 +422,13 @@ impl S3Client {
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (mut blob, options) = ptr.blob_and_options(
+        let (blob, options) = ptr.blob_and_options(
             global,
             callframe,
             "presign",
             MissingPathError::MissingOrInvalid,
         )?;
-        S3File::get_presign_url_from(&mut blob, global, options)
+        S3File::get_presign_url_from(&blob, global, options)
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -159,8 +159,8 @@ pub(crate) fn presign(global: &JSGlobalObject, callframe: &CallFrame) -> JsResul
 
     let error_message = "Expected a S3 or path to presign";
     let path_or_blob = parse_s3_path_or_blob(global, &mut args, error_message)?;
-    let (mut blob, options) = resolve_s3_blob(global, &mut args, path_or_blob, error_message)?;
-    get_presign_url_from(&mut blob, global, options)
+    let (blob, options) = resolve_s3_blob(global, &mut args, path_or_blob, error_message)?;
+    get_presign_url_from(&blob, global, options)
 }
 
 #[bun_jsc::host_fn]
@@ -351,22 +351,21 @@ pub(crate) struct S3BlobStatTask {
 }
 
 impl S3BlobStatTask {
-    fn new(init: S3BlobStatTask) -> *mut S3BlobStatTask {
-        bun_core::heap::into_raw(Box::new(init))
+    fn new(global: &JSGlobalObject, blob: &Blob) -> S3BlobStatTask {
+        S3BlobStatTask {
+            promise: bun_jsc::JSPromiseStrong::init(global),
+            store: blob.store.get().as_ref().unwrap().clone(),
+            global: bun_ptr::BackRef::new(global),
+        }
     }
 
-    fn on_s3_exists_resolved(
-        result: s3::S3StatResult,
-        this: *mut core::ffi::c_void,
-    ) -> JsResult<()> {
-        // SAFETY: `this` was allocated via heap::alloc in `exists`; reconstructing here replaces `defer this.deinit()`
-        let mut this = unsafe { bun_core::heap::take(this.cast::<S3BlobStatTask>()) };
-        // Copy the BackRef out so `this` is not borrowed across `&mut this.promise`.
-        let global_ref = this.global;
+    fn on_s3_exists_resolved(mut self, result: s3::S3StatResult) -> JsResult<()> {
+        // Copy the BackRef out so `self` is not borrowed across `&mut self.promise`.
+        let global_ref = self.global;
         let global = global_ref.get();
         match result {
             s3::S3StatResult::NotFound(_) => {
-                this.promise.resolve(global, JSValue::FALSE)?;
+                self.promise.resolve(global, JSValue::FALSE)?;
             }
             s3::S3StatResult::Success(_) => {
                 // calling .exists() should not prevent it to download a bigger file
@@ -374,51 +373,47 @@ impl S3BlobStatTask {
                 // if (this.blob.size == Blob.max_size) {
                 //     this.blob.size = @truncate(stat.size);
                 // }
-                this.promise.resolve(global, JSValue::TRUE)?;
+                self.promise.resolve(global, JSValue::TRUE)?;
             }
             s3::S3StatResult::Failure(err) => {
                 let value = s3_error_to_js_with_async_stack(
                     &err,
                     global,
-                    Some(this.store.data.as_s3().path()),
-                    this.promise.get(),
+                    Some(self.store.data.as_s3().path()),
+                    self.promise.get(),
                 );
-                this.promise.reject(global, Ok(value))?;
+                self.promise.reject(global, Ok(value))?;
             }
         }
         Ok(())
     }
 
-    fn on_s3_size_resolved(result: s3::S3StatResult, this: *mut core::ffi::c_void) -> JsResult<()> {
-        // SAFETY: `this` was allocated via heap::alloc in `size`; reconstructing here replaces `defer this.deinit()`
-        let mut this = unsafe { bun_core::heap::take(this.cast::<S3BlobStatTask>()) };
-        // Copy the BackRef out so `this` is not borrowed across `&mut this.promise`.
-        let global_ref = this.global;
+    fn on_s3_size_resolved(mut self, result: s3::S3StatResult) -> JsResult<()> {
+        // Copy the BackRef out so `self` is not borrowed across `&mut self.promise`.
+        let global_ref = self.global;
         let global = global_ref.get();
 
         match result {
             s3::S3StatResult::Success(stat_result) => {
-                this.promise
+                self.promise
                     .resolve(global, JSValue::js_number(stat_result.size as f64))?;
             }
             s3::S3StatResult::NotFound(err) | s3::S3StatResult::Failure(err) => {
                 let value = s3_error_to_js_with_async_stack(
                     &err,
                     global,
-                    Some(this.store.data.as_s3().path()),
-                    this.promise.get(),
+                    Some(self.store.data.as_s3().path()),
+                    self.promise.get(),
                 );
-                this.promise.reject(global, Ok(value))?;
+                self.promise.reject(global, Ok(value))?;
             }
         }
         Ok(())
     }
 
-    fn on_s3_stat_resolved(result: s3::S3StatResult, this: *mut core::ffi::c_void) -> JsResult<()> {
-        // SAFETY: `this` was allocated via heap::alloc in `stat`; reconstructing here replaces `defer this.deinit()`
-        let mut this = unsafe { bun_core::heap::take(this.cast::<S3BlobStatTask>()) };
-        // Copy the BackRef out so `this` is not borrowed across `&mut this.promise`.
-        let global_ref = this.global;
+    fn on_s3_stat_resolved(mut self, result: s3::S3StatResult) -> JsResult<()> {
+        // Copy the BackRef out so `self` is not borrowed across `&mut self.promise`.
+        let global_ref = self.global;
         let global = global_ref.get();
         match result {
             s3::S3StatResult::Success(stat_result) => {
@@ -431,33 +426,32 @@ impl S3BlobStatTask {
                 ) {
                     Ok(b) => (*b).to_js(global),
                     Err(_) => {
-                        return this.promise.reject(global, Err(JsError::Thrown));
+                        return self.promise.reject(global, Err(JsError::Thrown));
                     }
                 };
-                this.promise.resolve(global, s3_stat)?;
+                self.promise.resolve(global, s3_stat)?;
             }
             s3::S3StatResult::NotFound(err) | s3::S3StatResult::Failure(err) => {
                 let value = s3_error_to_js_with_async_stack(
                     &err,
                     global,
-                    Some(this.store.data.as_s3().path()),
-                    this.promise.get(),
+                    Some(self.store.data.as_s3().path()),
+                    self.promise.get(),
                 );
-                this.promise.reject(global, Ok(value))?;
+                self.promise.reject(global, Ok(value))?;
             }
         }
         Ok(())
     }
 
-    pub(crate) fn exists(global: &JSGlobalObject, blob: &Blob) -> JsResult<JSValue> {
-        let this = S3BlobStatTask::new(S3BlobStatTask {
-            promise: bun_jsc::JSPromiseStrong::init(global),
-            store: blob.store.get().as_ref().unwrap().clone(),
-            global: bun_ptr::BackRef::new(global),
-        });
-        // SAFETY: `this` is a freshly leaked Box; sole pointer until handed to the s3
-        // callback below. Scoped shared access.
-        let promise = unsafe { (*this).promise.value() };
+    /// HEAD the blob's object and settle a new promise with `on_resolved`.
+    fn request(
+        global: &JSGlobalObject,
+        blob: &Blob,
+        on_resolved: fn(Self, s3::S3StatResult) -> JsResult<()>,
+    ) -> JsResult<JSValue> {
+        let this = S3BlobStatTask::new(global, blob);
+        let promise = this.promise.value();
         let s3_store = blob.store.get().as_ref().unwrap().data.as_s3();
         let credentials = s3_store.get_credentials();
         let path = s3_store.path();
@@ -468,69 +462,26 @@ impl S3BlobStatTask {
         s3::stat(
             credentials,
             path,
-            S3BlobStatTask::on_s3_exists_resolved,
-            this.cast::<core::ffi::c_void>(),
+            Box::new(move |result| on_resolved(this, result)),
             env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
             s3_store.request_payer,
         )?;
         Ok(promise)
+    }
+
+    pub(crate) fn exists(global: &JSGlobalObject, blob: &Blob) -> JsResult<JSValue> {
+        Self::request(global, blob, Self::on_s3_exists_resolved)
     }
 
     pub(crate) fn stat(global: &JSGlobalObject, blob: &Blob) -> JsResult<JSValue> {
-        let this = S3BlobStatTask::new(S3BlobStatTask {
-            promise: bun_jsc::JSPromiseStrong::init(global),
-            store: blob.store.get().as_ref().unwrap().clone(),
-            global: bun_ptr::BackRef::new(global),
-        });
-        // SAFETY: `this` is a freshly leaked Box; sole pointer until handed to the s3
-        // callback below. Scoped shared access.
-        let promise = unsafe { (*this).promise.value() };
-        let s3_store = blob.store.get().as_ref().unwrap().data.as_s3();
-        let credentials = s3_store.get_credentials();
-        let path = s3_store.path();
-        // `Transpiler::env_mut` is the safe accessor for the process-singleton
-        // dotenv loader (set during init).
-        let env = global.bun_vm().as_mut().transpiler.env_mut();
-
-        s3::stat(
-            credentials,
-            path,
-            S3BlobStatTask::on_s3_stat_resolved,
-            this.cast::<core::ffi::c_void>(),
-            env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
-            s3_store.request_payer,
-        )?;
-        Ok(promise)
+        Self::request(global, blob, Self::on_s3_stat_resolved)
     }
 
     pub(crate) fn size(global: &JSGlobalObject, blob: &mut Blob) -> JsResult<JSValue> {
-        let this = S3BlobStatTask::new(S3BlobStatTask {
-            promise: bun_jsc::JSPromiseStrong::init(global),
-            store: blob.store.get().as_ref().unwrap().clone(),
-            global: bun_ptr::BackRef::new(global),
-        });
-        // SAFETY: `this` is a freshly leaked Box; sole pointer until handed to the s3
-        // callback below. Scoped shared access.
-        let promise = unsafe { (*this).promise.value() };
-        let s3_store = blob.store.get().as_ref().unwrap().data.as_s3();
-        let credentials = s3_store.get_credentials();
-        let path = s3_store.path();
-        // `Transpiler::env_mut` is the safe accessor for the process-singleton
-        // dotenv loader (set during init).
-        let env = global.bun_vm().as_mut().transpiler.env_mut();
-
-        s3::stat(
-            credentials,
-            path,
-            S3BlobStatTask::on_s3_size_resolved,
-            this.cast::<core::ffi::c_void>(),
-            env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
-            s3_store.request_payer,
-        )?;
-        Ok(promise)
+        Self::request(global, blob, Self::on_s3_size_resolved)
     }
 
-    // Teardown (store deref, promise deinit, freeing the box) is handled by Box<Self> Drop.
+    // Teardown (store deref, promise deinit) is handled by the fields' Drop.
 }
 
 // `Method.fromJS` lives in `bun_http_jsc` so `bun_http_types` stays
@@ -541,7 +492,7 @@ fn method_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<Me
 }
 
 pub(crate) fn get_presign_url_from(
-    this: &mut Blob,
+    this: &Blob,
     global: &JSGlobalObject,
     extra_options: Option<JSValue>,
 ) -> JsResult<JSValue> {
@@ -654,7 +605,7 @@ fn get_bucket(this: &Blob, global: &JSGlobalObject) -> JsResult<JSValue> {
 }
 
 fn get_presign_url(
-    this: &mut Blob,
+    this: &Blob,
     global: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
@@ -696,48 +647,29 @@ pub(crate) fn to_js_unchecked(global: &JSGlobalObject, this: *mut Blob) -> JSVal
     BUN__createJSS3FileUnsafely(global, this.cast::<core::ffi::c_void>())
 }
 
-// Symbols exported with C linkage and JSC calling convention.
-// JSS3File__presign     -> raw shim wrapping get_presign_url (method-with-context)
-// JSS3File__bucket      -> get_bucket
-// JSS3File__stat        -> raw shim wrapping get_stat (method-with-context)
+// Symbols exported with C linkage and JSC calling convention (JSS3File.cpp):
+// the prototype getter/methods pass the wrapper's live `m_ctx` Blob.
+// HOST_EXPORT(JSS3File__bucket, jsc)
+pub fn s3_file_bucket(this: &crate::webcore::Blob, global: &JSGlobalObject) -> JsResult<JSValue> {
+    get_bucket(this, global)
+}
 
-pub(crate) mod exports {
-    use super::*;
+// HOST_EXPORT(JSS3File__presign, jsc)
+pub fn s3_file_presign(
+    this: &crate::webcore::Blob,
+    global: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    get_presign_url(this, global, callframe)
+}
 
-    /// Getter (JSC calling convention; takes `*Blob, *JSGlobalObject`,
-    /// returns JSValue).
-    #[unsafe(no_mangle)]
-    #[bun_jsc::host_call]
-    fn JSS3File__bucket(this: *mut Blob, global: *mut JSGlobalObject) -> JSValue {
-        // SAFETY: C++ prototype getter passes the live `m_ctx` Blob and global.
-        let (this, global) = unsafe { (&*this, &*global) };
-        bun_jsc::to_js_host_call(global, || super::get_bucket(this, global))
-    }
-
-    /// Method-with-context shim wrapping `get_presign_url`.
-    #[unsafe(no_mangle)]
-    #[bun_jsc::host_call]
-    fn JSS3File__presign(
-        this: *mut Blob,
-        global: *mut JSGlobalObject,
-        callframe: *mut CallFrame,
-    ) -> JSValue {
-        // SAFETY: JSC method shim passes live `m_ctx`/global/callframe.
-        let (this, global, callframe) = unsafe { (&mut *this, &*global, &*callframe) };
-        bun_jsc::to_js_host_call(global, || super::get_presign_url(this, global, callframe))
-    }
-
-    #[unsafe(no_mangle)]
-    #[bun_jsc::host_call]
-    fn JSS3File__stat(
-        this: *mut Blob,
-        global: *mut JSGlobalObject,
-        callframe: *mut CallFrame,
-    ) -> JSValue {
-        // SAFETY: JSC method shim passes live `m_ctx`/global/callframe.
-        let (this, global, callframe) = unsafe { (&mut *this, &*global, &*callframe) };
-        bun_jsc::to_js_host_call(global, || super::get_stat(this, global, callframe))
-    }
+// HOST_EXPORT(JSS3File__stat, jsc)
+pub fn s3_file_stat(
+    this: &crate::webcore::Blob,
+    global: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    get_stat(this, global, callframe)
 }
 
 // C++ side defines `SYSV_ABI EncodedJSValue` (JSS3File.cpp).

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -790,9 +790,10 @@ pub(crate) unsafe fn sink_handle_from_id(
         HTTPS_RESPONSE_SINK => SinkHandle::HttpsResponse(unsafe {
             bun_ptr::BackRef::from_raw_mut(raw.cast::<streams::HTTPSResponseSink>())
         }),
-        // SAFETY: caller contract — `raw` is a live `*mut NetworkSink`.
+        // SAFETY: caller contract — `raw` is a live `*mut NetworkSink` (the
+        // wrapper's `m_ctx`, its allocation root).
         NETWORK_SINK => SinkHandle::S3Upload(unsafe {
-            bun_ptr::BackRef::from_raw_mut(raw.cast::<streams::NetworkSink>())
+            bun_ptr::BackRef::from_root(raw.cast::<streams::NetworkSink>())
         }),
         // SAFETY: caller contract — `raw` is a live `*mut FetchRequestBodySink`.
         FETCH_REQUEST_BODY_SINK => SinkHandle::FetchRequestBody(unsafe {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1664,6 +1664,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 // lifetime is managed by the resolve callback itself).
                 let _ = S3StreamWrapper::resolve(result, ctx.cast::<S3StreamWrapper<'static>>());
             }
+            let s3_stream_ctx = bun_core::heap::into_raw(s3_stream).cast::<libc::c_void>();
             // `dupe()` heap-allocates a fresh intrusive-refcounted copy.
             // `upload_stream` adopts the ref by value (no extra bump) and the
             // MultiPartUpload derefs on completion.
@@ -1680,8 +1681,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 headers.as_ref().and_then(|h| h.get_content_encoding()),
                 proxy_url,
                 credentials_with_options.request_payer,
-                Some(s3_stream_wrapper_resolve),
-                bun_core::heap::into_raw(s3_stream).cast::<libc::c_void>(),
+                Some(Box::new(move |result| {
+                    s3_stream_wrapper_resolve(result, s3_stream_ctx)
+                })),
             )?;
             // url/url_proxy_buffer ownership moved into s3_stream above.
             return Ok(promise_value);

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2374,9 +2374,7 @@ impl FetchTasklet {
         // stored copy.
         let body: &[u8] = result.body;
         let body_owned: Vec<u8> = core::mem::take(&mut result.body_owned);
-        // SAFETY: lifetime erasure for non-body fields; `body` is stored as
-        // `&'static []` so no borrow escapes.
-        task_ref.result = unsafe { result.detach_lifetime() };
+        task_ref.result = result.into_owned();
         // can_stream is a one-shot signal to start the request body stream; don't let a
         // later coalesced result clobber it before the JS thread sees it.
         task_ref.result.can_stream = task_ref.result.can_stream || prev_can_stream;

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -777,8 +777,6 @@ pub(crate) fn upload_stream(
         _ => {}
     }
 
-    // `credentials` is owned-by-value and explicitly `.deref()`ed on each early
-    // return above; the ref is adopted by value — moved into the MultiPartUpload below.
     let part_size = options.part_size;
     let upload = new_upload(
         credentials,

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -440,7 +440,6 @@ pub(crate) fn writable_stream(
     storage_class: Option<StorageClass>,
     request_payer: bool,
 ) -> JsResult<JSValue> {
-    let part_size = options.part_size;
     let upload = new_upload(
         credentials,
         path,
@@ -777,7 +776,6 @@ pub(crate) fn upload_stream(
         _ => {}
     }
 
-    let part_size = options.part_size;
     let upload = new_upload(
         credentials,
         path,

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -1041,7 +1041,9 @@ pub(crate) fn readable_stream(
     reader.context.setup();
     let readable_value = reader.to_readable_stream(global_this)?;
 
-    let sink = S3DownloadStreamWrapper::new(reader, path, GlobalRef::from(global_this));
+    let sink = S3DownloadStreamWrapper::new(path, GlobalRef::from(global_this));
+    // SAFETY: `reader` is the live `Source::new_mut` allocation made above.
+    unsafe { sink.stream.hold(&raw mut reader.context) };
     // The task drops the wrapper once the download is over, and the wrapper
     // lets go of the source (clearing this handle) first (holder obligation).
     reader

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -1,14 +1,11 @@
 use core::cell::Cell;
-use core::ffi::c_void;
-use core::ptr::NonNull;
 use std::io::Write as _;
 
 use bun_collections::{ByteVecExt, VecExt};
 use bun_core::MutableString;
 use bun_http::HeadersExt as _;
-use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{GlobalRef, JSGlobalObject, JSValue, JsCell, JsResult};
-use bun_ptr::RefPtr;
+use bun_ptr::{RefPtr, ThisPtr};
 
 // Re-exports (thin aliases)
 pub(crate) use crate::webcore::s3::download_stream::S3HttpDownloadStreamingTask;
@@ -33,6 +30,7 @@ pub use bun_s3_signing::credentials::S3Credentials;
 pub use bun_s3_signing::credentials::S3CredentialsWithOptions;
 use bun_s3_signing::credentials::encode_uri_component;
 
+pub(crate) use crate::webcore::s3::download_stream::S3DownloadStreamWrapper;
 pub(crate) use crate::webcore::s3::list_objects::S3ListObjectsOptions;
 pub(crate) use crate::webcore::s3::list_objects::get_list_objects_options_from_js;
 pub(crate) use crate::webcore::s3::simple_request::S3DeleteResult;
@@ -43,12 +41,14 @@ pub(crate) use crate::webcore::s3::simple_request::S3StatResult;
 pub use crate::webcore::s3::simple_request::S3UploadResult;
 
 use crate::webcore::s3::simple_request as s3_simple_request;
+use crate::webcore::s3::simple_request::RequestStorage;
 
 use crate::webcore::ByteStream;
 use crate::webcore::ReadableStream;
 use crate::webcore::readable_stream::Source as ReadableStreamPtr;
 use crate::webcore::readable_stream::Strong as ReadableStreamStrong;
 use crate::webcore::s3::multipart::State as MultiPartUploadState;
+use crate::webcore::s3::multipart::UploadObserver;
 use crate::webcore::sink::JSSink;
 use crate::webcore::streams::{NetworkSink, NetworkSinkJSSink};
 use bun_collections::IntegerBitSet;
@@ -61,8 +61,7 @@ bun_core::declare_scope!(S3UploadStream, visible);
 pub(crate) fn stat(
     this: &S3Credentials,
     path: &[u8],
-    callback: fn(S3StatResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: s3_simple_request::StatCallback,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -76,7 +75,7 @@ pub(crate) fn stat(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::stat(callback, callback_context),
+        s3_simple_request::Callback::Stat(callback),
     )
 }
 
@@ -101,6 +100,25 @@ pub(crate) fn download(
     )
 }
 
+/// The `Range:` header value for `size` bytes from `offset`, if not the whole object.
+fn range_header(offset: usize, size: Option<usize>) -> Option<Vec<u8>> {
+    if let Some(size_) = size {
+        let mut end = offset + size_;
+        if size_ > 0 {
+            end -= 1;
+        }
+        let mut v = Vec::new();
+        write!(&mut v, "bytes={}-{}", offset, end).expect("infallible: in-memory write");
+        return Some(v);
+    }
+    if offset == 0 {
+        return None;
+    }
+    let mut v = Vec::new();
+    write!(&mut v, "bytes={}-", offset).expect("infallible: in-memory write");
+    Some(v)
+}
+
 pub(crate) fn download_slice(
     this: &S3Credentials,
     path: &[u8],
@@ -110,24 +128,6 @@ pub(crate) fn download_slice(
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
-    let range: Option<Vec<u8>> = 'brk: {
-        if let Some(size_) = size {
-            let mut end = offset + size_;
-            if size_ > 0 {
-                end -= 1;
-            }
-            let mut v = Vec::new();
-            write!(&mut v, "bytes={}-{}", offset, end).expect("infallible: in-memory write");
-            break 'brk Some(v);
-        }
-        if offset == 0 {
-            break 'brk None;
-        }
-        let mut v = Vec::new();
-        write!(&mut v, "bytes={}-", offset).expect("infallible: in-memory write");
-        Some(v)
-    };
-
     s3_simple_request::execute_simple_s3_request(
         this,
         s3_simple_request::Options {
@@ -135,7 +135,7 @@ pub(crate) fn download_slice(
             method: bun_http::Method::GET,
             proxy_url,
             body: b"",
-            range: range.map(Vec::into_boxed_slice),
+            range: range_header(offset, size).map(Vec::into_boxed_slice),
             request_payer,
             ..Default::default()
         },
@@ -278,88 +278,16 @@ pub(crate) fn list_objects(
 
     let headers = bun_http::Headers::from_pico_http_headers(result.headers());
 
-    let task_ptr = bun_core::heap::into_raw(Box::new(S3HttpSimpleTask {
-        // Written below via `MaybeUninit::write` before any read.
-        http: core::mem::MaybeUninit::uninit(),
-        sign_result: result,
-        callback: Some(s3_simple_request::Callback::ListObjects(callback)),
-        headers,
-        http_ticket: None,
-        response_buffer: MutableString::default(),
-        result: bun_http::HTTPClientResult::default(),
-        concurrent_task: Default::default(),
-        proxy_url: Box::default(),
-        body: Box::default(),
-        poll_ref: bun_io::KeepAlive::init(),
-        signal_store: Default::default(),
-    }));
-    // SAFETY: just allocated, non-null
-    let task = unsafe { &mut *task_ptr };
-
-    task.poll_ref.ref_(bun_io::js_vm_ctx());
-
-    let proxy = proxy_url.unwrap_or(b"");
-    task.proxy_url = if !proxy.is_empty() {
-        Box::<[u8]>::from(proxy)
-    } else {
-        Box::<[u8]>::default()
-    };
-
-    // SAFETY: lifetime extension — `url`, `headers_buf`, and `proxy_url` borrow from
-    // heap-allocated fields of `*task` which the task outlives. AsyncHTTP::init wants
-    // `'static` borrows because the HTTP thread reads them concurrently; they remain valid
-    // until `task` is dropped in `on_response`.
-    let url = bun_url::URL::parse(unsafe { bun_ptr::detach_lifetime_ref(&*task.sign_result.url) });
-    // SAFETY: same lifetime-extension invariant as `url` above — `task.headers.buf` is
-    // heap-owned by `*task` and outlives the AsyncHTTP request.
-    let headers_buf: &'static [u8] =
-        unsafe { bun_ptr::detach_lifetime(task.headers.buf.as_slice()) };
-    let http_proxy = if !task.proxy_url.is_empty() {
-        // SAFETY: same lifetime-extension invariant as `url` above — `task.proxy_url` is
-        // heap-owned by `*task` and outlives the AsyncHTTP request.
-        Some(bun_url::URL::parse(unsafe {
-            bun_ptr::detach_lifetime_ref(&*task.proxy_url)
-        }))
-    } else {
-        None
-    };
-    // JS thread (request setup): read options from the current VM.
-    let vm = VirtualMachine::get();
-
-    task.http.write(bun_http::AsyncHTTP::init(
+    S3HttpSimpleTask::start(
         bun_http::Method::GET,
-        url,
-        task.headers.entries.clone().expect("OOM"),
-        headers_buf,
-        b"",
-        bun_http::HTTPClientResultCallback::new_with_release::<S3HttpSimpleTask>(
-            task_ptr,
-            // SAFETY: `task_ptr` is the heap-allocated task registered above; the
-            // HTTP thread invokes this with that exact pointer.
-            S3HttpSimpleTask::http_callback,
-            S3HttpSimpleTask::release_at_shutdown,
-        ),
-        bun_http::FetchRedirect::Follow,
-        bun_http::async_http::Options {
-            http_proxy,
-            verbose: Some(vm.get_verbose_fetch()),
-            reject_unauthorized: Some(vm.get_tls_reject_unauthorized()),
-            signals: Some(task.signal_store.to()),
-            ..Default::default()
+        RequestStorage {
+            sign_result: result,
+            headers,
+            body: Box::default(),
+            proxy_url: RequestStorage::owned_proxy(proxy_url),
         },
-    ));
-
-    // queue http request
-    bun_http::http_thread::init(&Default::default());
-    let mut batch = bun_threading::thread_pool::Batch::default();
-    // SAFETY: `http` was initialised by `task.http.write(...)` immediately above.
-    unsafe { task.http.assume_init_mut() }.schedule(&mut batch);
-    // Out on the HTTP thread until its final callback: the VM aborts it at
-    // teardown (registry) and waits for it (the ticket).
-    task.http_ticket = Some(VirtualMachine::get().ticket());
-    crate::jsc_hooks::ActiveHandle::S3Request(core::ptr::NonNull::new(task_ptr).expect("task"))
-        .register();
-    bun_http::HTTPThread::schedule(batch);
+        s3_simple_request::Callback::ListObjects(callback),
+    );
     Ok(())
 }
 
@@ -395,6 +323,108 @@ pub(crate) fn upload(
     )
 }
 
+/// A new upload, holding its own lifecycle ref (see [`MultiPartUpload`]).
+/// Takes ownership of one `credentials` ref.
+fn new_upload(
+    credentials: bun_ptr::RefPtr<S3Credentials>,
+    path: &[u8],
+    global_this: &JSGlobalObject,
+    options: MultiPartUploadOptions,
+    acl: Option<ACL>,
+    storage_class: Option<StorageClass>,
+    content_type: Option<&[u8]>,
+    content_disposition: Option<&[u8]>,
+    content_encoding: Option<&[u8]>,
+    proxy: Option<&[u8]>,
+    request_payer: bool,
+    state: MultiPartUploadState,
+) -> RefPtr<MultiPartUpload> {
+    let proxy_url = proxy.unwrap_or(b"");
+    let upload = RefPtr::new_cyclic(|root| MultiPartUpload {
+        root,
+        lifecycle: Cell::new(None),
+        observer: JsCell::new(None),
+        queue: JsCell::new(None),
+        available: Cell::new(IntegerBitSet::init_full()),
+        current_part_number: Cell::new(1),
+        ref_count: Cell::new(1),
+        ended: Cell::new(false),
+        options: Cell::new(options),
+        acl,
+        storage_class,
+        request_payer,
+        credentials,
+        poll_ref: JsCell::new(KeepAlive::init()),
+        // JSC_BORROW: `global_this` outlives the upload (it owns the VM/heap
+        // that owns the JS objects which keep the upload alive).
+        global_this: GlobalRef::from(global_this),
+        buffered: JsCell::new(StreamBuffer::default()),
+        uploaded_bytes: Cell::new(0),
+        path: Box::<[u8]>::from(path),
+        proxy: if !proxy_url.is_empty() {
+            Box::<[u8]>::from(proxy_url)
+        } else {
+            Box::default()
+        },
+        content_type: content_type.map(Box::<[u8]>::from),
+        content_disposition: content_disposition.map(Box::<[u8]>::from),
+        content_encoding: content_encoding.map(Box::<[u8]>::from),
+        upload_id: JsCell::new(Box::default()),
+        multipart_etags: JsCell::new(Vec::new()),
+        multipart_upload_list: JsCell::new(Vec::new()),
+        state: Cell::new(state),
+    });
+    upload.lifecycle.set(Some(upload.clone()));
+    upload
+        .poll_ref
+        .with_mut(|poll_ref| poll_ref.ref_(bun_io::js_vm_ctx()));
+    upload
+}
+
+/// `s3file.writer()`'s upload settled: settle the sink's pending promises and
+/// detach it.
+pub(crate) fn writer_settled(
+    sink: ThisPtr<NetworkSink>,
+    upload: &MultiPartUpload,
+    result: S3UploadResult,
+) -> JsResult<()> {
+    let global = sink
+        .global_this
+        .expect("NetworkSink.global_this set at construction");
+    let global = global.get();
+    if sink.end_promise.get().has_value() || sink.flush_promise.get().has_value() {
+        let _exit_guard = global.bun_vm().enter_event_loop_scope();
+        match result {
+            S3UploadResult::Success => {
+                if sink.flush_promise.get().has_value() {
+                    sink.flush_promise
+                        .with_mut(|p| p.resolve(global, JSValue::js_number(0.0)))?;
+                }
+                if sink.end_promise.get().has_value() {
+                    let uploaded = JSValue::js_number(upload.uploaded_bytes.get() as f64);
+                    sink.end_promise.with_mut(|p| p.resolve(global, uploaded))?;
+                }
+            }
+            S3UploadResult::Failure(err) => {
+                let js_err = s3_error_to_js(&err, global, Some(&upload.path));
+                if sink.flush_promise.get().has_value() {
+                    sink.flush_promise
+                        .with_mut(|p| p.reject(global, Ok(js_err)))?;
+                }
+                if sink.end_promise.get().has_value() {
+                    sink.end_promise
+                        .with_mut(|p| p.reject(global, Ok(js_err)))?;
+                }
+                if !sink.done.get() {
+                    sink.abort();
+                }
+            }
+        }
+    }
+    sink.detach_writable();
+    Ok(())
+}
+
 /// returns a writable stream that writes to the s3 path
 ///
 /// `credentials` is moved into the `MultiPartUpload`.
@@ -410,269 +440,172 @@ pub(crate) fn writable_stream(
     storage_class: Option<StorageClass>,
     request_payer: bool,
 ) -> JsResult<JSValue> {
-    // Local callback wrapper. `uploaded` is read off the upload (see `MultiPartUpload::callback`).
-    fn wrapper_callback(
-        result: S3UploadResult,
-        uploaded: u64,
-        sink: &mut NetworkSink,
-    ) -> JsResult<()> {
-        // `global_this` is a `BackRef` set at construction; copy it so the
-        // re-borrow does not hold `&sink` across the `&mut sink` calls below.
-        let global = sink
-            .global_this
-            .expect("NetworkSink.global_this set at construction");
-        let global = global.get();
-        if sink.end_promise.has_value() || sink.flush_promise.has_value() {
-            // SAFETY: `bun_vm()` returns the live per-thread VM pointer.
-            let event_loop = global.bun_vm().as_mut().event_loop();
-            // SAFETY: event_loop is initialised for the lifetime of the VM.
-            // RAII: `enter()` now, `exit()` on drop.
-            let _exit_guard = unsafe { bun_jsc::event_loop::EventLoop::enter_scope(event_loop) };
-            match result {
-                S3UploadResult::Success => {
-                    if sink.flush_promise.has_value() {
-                        sink.flush_promise
-                            .resolve(global, JSValue::js_number(0.0))?;
-                    }
-                    if sink.end_promise.has_value() {
-                        sink.end_promise
-                            .resolve(global, JSValue::js_number(uploaded as f64))?;
-                    }
-                }
-                S3UploadResult::Failure(err) => {
-                    let js_err = s3_error_to_js(&err, global, sink.path());
-                    if sink.flush_promise.has_value() {
-                        sink.flush_promise.reject(global, Ok(js_err))?;
-                    }
-                    if sink.end_promise.has_value() {
-                        sink.end_promise.reject(global, Ok(js_err))?;
-                    }
-                    if !sink.done {
-                        sink.abort();
-                    }
-                }
-            }
-        }
-        sink.finalize();
-        Ok(())
-    }
-
-    // Thunks adapting typed callbacks to the erased `*mut c_void` signatures stored on
-    // MultiPartUpload.
-    fn wrapper_callback_thunk(
-        task: &MultiPartUpload,
-        result: S3UploadResult,
-        ctx: *mut c_void,
-    ) -> JsResult<()> {
-        let sink = ctx.cast::<NetworkSink>();
-        // SAFETY: ctx was set to `response_stream: *mut NetworkSink` below; the box is live
-        // while the upload holds it.
-        let r = wrapper_callback(result, task.uploaded_bytes.get(), unsafe { &mut *sink });
-        // SAFETY: the upload's hold on the box ends here; `sink` is not used afterwards.
-        unsafe { NetworkSink::release_writer_holder(sink) };
-        r
-    }
-    fn on_writable_thunk(task: &MultiPartUpload, ctx: *mut c_void, flushed: u64) {
-        NetworkSink::on_writable(task, ctx.cast::<NetworkSink>(), flushed);
-    }
-
-    let proxy_url = proxy.unwrap_or(b"");
-    // `credentials` ref adopted by value — moved into the MultiPartUpload below.
-    // JSC_BORROW: `global_this` outlives the task (it owns the VM/heap that owns the JS
-    // objects which keep the task alive); stored via `GlobalRef` in the heap-allocated
-    // MultiPartUpload.
-    let global_static = GlobalRef::from(global_this);
-    let task_ptr: *mut MultiPartUpload = bun_core::heap::into_raw(Box::new(MultiPartUpload {
-        root: Cell::new(None),
-        queue: JsCell::new(None),
-        available: Cell::new(IntegerBitSet::init_full()),
-        current_part_number: Cell::new(1),
-        ref_count: Cell::new(2), // +1 for the stream
-        ended: Cell::new(false),
-        options: Cell::new(options),
-        acl: None,
-        storage_class,
-        request_payer,
+    let part_size = options.part_size;
+    let upload = new_upload(
         credentials,
-        poll_ref: JsCell::new(KeepAlive::init()),
-        // SAFETY (JSC_BORROW): VirtualMachine::get() returns the live per-thread VM; it
-        // outlives every MultiPartUpload (the VM owns the heap that owns the JS objects
-        // keeping this task alive). Dereference to `&'static` for storage.
-        vm: VirtualMachine::get(),
-        global_this: global_static,
-        buffered: JsCell::new(StreamBuffer::default()),
-        uploaded_bytes: Cell::new(0),
-        path: Box::<[u8]>::from(path),
-        proxy: if !proxy_url.is_empty() {
-            Box::<[u8]>::from(proxy_url)
-        } else {
-            Box::default()
-        },
-        content_type: content_type.map(Box::<[u8]>::from),
-        content_disposition: content_disposition.map(Box::<[u8]>::from),
-        content_encoding: content_encoding.map(Box::<[u8]>::from),
-        upload_id: JsCell::new(Box::default()),
-        multipart_etags: JsCell::new(Vec::new()),
-        multipart_upload_list: JsCell::new(Vec::new()),
-        state: Cell::new(MultiPartUploadState::NotStarted),
-        callback: wrapper_callback_thunk,
-        on_writable: Some(on_writable_thunk),
-        callback_context: Cell::new(core::ptr::null_mut()), // assigned below
-    }));
-    // SAFETY: `task_ptr` is the fresh, non-null allocation root.
-    unsafe { (*task_ptr).root.set(core::ptr::NonNull::new(task_ptr)) };
-    // SAFETY: freshly heap-allocated and refcounted; only shared access from here on.
-    let task = unsafe { &*task_ptr };
-
-    task.poll_ref
-        .with_mut(|poll_ref| poll_ref.ref_(bun_io::js_vm_ctx()));
-
-    // Heap-allocate; `JSSink<NetworkSink>` is layout-
-    // compatible (`{ sink: NetworkSink }`) so the cast in `to_sink()` is just a pointer reinterpret.
-    let response_stream: *mut NetworkSink =
-        bun_core::heap::into_raw(NetworkSink::new(NetworkSink {
-            // SAFETY: adopts one of `task_ptr`'s two initial refs (released in `detach_writable`).
-            task: Some(unsafe { RefPtr::from_raw(task_ptr) }),
-            global_this: Some(bun_ptr::BackRef::new(global_this)),
-            writer_holders: Cell::new(2),
-            ..Default::default()
-        }));
-
-    task.callback_context.set(response_stream.cast::<c_void>());
-
-    // SAFETY: freshly heap-allocated; exclusive access here. Ownership transfers to the JS
-    // wrapper via `to_js()` (the C++ side stores it as m_ctx and calls `finalize` on collect).
-    let sink = unsafe { &*response_stream };
-    // `source` defaults to `SourceHandle::None`; no stream is attached on the
-    // `writer()` path, so ready/close/start are no-ops.
-    debug_assert!(sink.source.is_dead());
-    Ok(NetworkSink::to_js(
-        core::ptr::NonNull::new(response_stream).expect("heap allocation"),
+        path,
         global_this,
-    ))
+        options,
+        None,
+        storage_class,
+        content_type,
+        content_disposition,
+        content_encoding,
+        proxy,
+        request_payer,
+        MultiPartUploadState::NotStarted,
+    );
+    let observer = upload.this_ptr();
+    // The sink holds the upload's construction ref (released in `detach_writable`).
+    let sink = NetworkSink::new(upload, global_this);
+    observer
+        .observer
+        .set(Some(UploadObserver::Writer(sink.clone())));
+    // `source` stays `SourceHandle::None`; no stream is attached on the
+    // `writer()` path, so ready/close/start are no-ops.
+    debug_assert!(sink.source.get().is_dead());
+    Ok(NetworkSink::to_js(sink, global_this))
 }
 
+/// The JS side of `Bun.write(s3file, readableStream)` (and fetch PUT with a
+/// stream body): pumps the stream into a [`NetworkSink`] and settles
+/// `end_promise` with the upload's outcome. Reference-counted: the upload
+/// (its observer) and the stream pump (`pump_ref`) each hold one.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct S3UploadStreamWrapper {
-    pub(crate) ref_count: core::cell::Cell<u32>,
-
-    pub sink: Option<NonNull<NetworkSink>>,
-    pub task: RefPtr<MultiPartUpload>,
-    pub(crate) end_promise: bun_jsc::JSPromiseStrong,
-    pub callback: Option<fn(S3UploadResult, *mut c_void)>,
-    pub(crate) callback_context: *mut c_void,
-    /// this is owned by the task not by the wrapper
-    pub path: bun_ptr::RawSlice<u8>,
-    /// Roots the source ReadableStream, and the JS pump reachable only through it, until this wrapper drops.
-    pub readable_stream_ref: ReadableStreamStrong,
-    pub global: GlobalRef, // JSC_BORROW
+    ref_count: Cell<u32>,
+    /// The ref the stream pump holds: released by the `assign_to_stream`
+    /// reaction (`handle_{resolve,reject}_stream`), or on the native ByteStream
+    /// path by `NetworkSink::end_from_stream` / `resolve`.
+    pump_ref: Cell<Option<RefPtr<S3UploadStreamWrapper>>>,
+    /// Our ref on the sink, from `upload_stream` until `detach_sink`. The JS
+    /// controller created by `assign_to_stream` only borrows it (it detaches in
+    /// `controller.end()/close()`, or `controller_finalize` at heap teardown).
+    sink: JsCell<Option<RefPtr<NetworkSink>>>,
+    /// Released on drop.
+    task: RefPtr<MultiPartUpload>,
+    pub(crate) end_promise: JsCell<bun_jsc::JSPromiseStrong>,
+    /// Told the upload's outcome once it settles.
+    on_done: Cell<Option<Box<dyn FnOnce(S3UploadResult<'_>)>>>,
+    /// Roots the source ReadableStream, and the JS pump reachable only through
+    /// it, until this wrapper drops.
+    readable_stream_ref: JsCell<ReadableStreamStrong>,
+    global: GlobalRef, // JSC_BORROW
 }
 
 impl S3UploadStreamWrapper {
-    fn detach_sink(&mut self) {
-        bun_output::scoped_log!(S3UploadStream, "detachSink {}", self.sink.is_some());
-        if let Some(sink_ptr) = self.sink.take() {
-            // SAFETY: allocated via `Box::leak` in `upload_stream`; consumed once here.
-            let mut sink = unsafe { bun_core::heap::take(sink_ptr.as_ptr()) };
-            JSSink::<NetworkSink>::detach(&mut sink.source, &self.global);
-            // releases NetworkSink's counted ref on the MultiPartUpload
-            sink.finalize();
+    /// Release the stream pump's ref (see `pump_ref`).
+    pub(crate) fn release_pump_ref(this: ThisPtr<Self>) {
+        if let Some(pump_ref) = this.pump_ref.take() {
+            drop(pump_ref);
         }
     }
 
-    /// Exclusive borrow of the sink while `self.sink` is `Some` (owned
-    /// allocation from `upload_stream` until `detach_sink`). Single-threaded.
-    #[inline]
-    fn sink_mut(&mut self) -> Option<&mut NetworkSink> {
-        // SAFETY: sink is a live Box allocation owned by this wrapper.
-        self.sink.map(|p| unsafe { &mut *p.as_ptr() })
+    fn sink(&self) -> Option<ThisPtr<NetworkSink>> {
+        self.sink.get().as_ref().map(RefPtr::this_ptr)
     }
 
-    pub(crate) fn on_writable(task: &MultiPartUpload, self_: &mut Self, flushed: u64) {
+    fn detach_sink(&self) {
+        bun_output::scoped_log!(S3UploadStream, "detachSink {}", self.sink.get().is_some());
+        if let Some(sink) = self.sink.replace(None) {
+            let mut source = sink
+                .source
+                .replace(crate::webcore::streams::SourceHandle::None);
+            JSSink::<NetworkSink>::detach(&mut source, &self.global);
+            // releases NetworkSink's counted ref on the MultiPartUpload
+            sink.detach_writable();
+            drop(sink);
+        }
+    }
+
+    pub(crate) fn on_writable(&self, task: &MultiPartUpload, flushed: u64) {
         bun_output::scoped_log!(
             S3UploadStream,
             "onWritable {} {}",
-            self_.sink.is_some(),
+            self.sink.get().is_some(),
             task.ended.get()
         );
         // end was called we dont need to drain anymore
         if task.ended.get() {
             return;
         }
-        if let Some(sink) = self_.sink_mut() {
+        if let Some(sink) = self.sink() {
             // Fires `source.ready()` so the upstream pump resumes.
-            NetworkSink::on_writable(task, sink, flushed);
+            sink.on_writable(flushed);
         }
     }
 
     /// Stream pump resolved (sink.end() already wrote EOF to the task).
-    /// Balances the +1 ref taken for the pump promise in `upload_stream`.
-    pub(crate) fn handle_resolve_stream(&mut self) {
+    /// Balances the pump ref taken in `upload_stream`.
+    pub(crate) fn handle_resolve_stream(this: ThisPtr<Self>) {
         bun_output::scoped_log!(S3UploadStream, "handleResolveStream");
-        self.detach_sink();
-        // SAFETY: `self` is a live Box allocation; this adopts the pump ref.
-        drop(unsafe { RefPtr::from_raw(std::ptr::from_mut::<Self>(self)) });
+        this.detach_sink();
+        Self::release_pump_ref(this);
     }
 
     /// Stream pump rejected. Rejects the caller's end_promise, fails the upload,
-    /// and balances the +1 ref taken for the pump promise in `upload_stream`.
-    pub(crate) fn handle_reject_stream(&mut self, err: JSValue) {
+    /// and balances the pump ref taken in `upload_stream`.
+    pub(crate) fn handle_reject_stream(this: ThisPtr<Self>, err: JSValue) {
         bun_output::scoped_log!(S3UploadStream, "handleRejectStream");
-        self.detach_sink();
-        // SAFETY: adopts the pump ref; released at scope exit, after the borrows below.
-        let _pump_ref = unsafe { RefPtr::from_raw(std::ptr::from_mut::<Self>(self)) };
-        if self.end_promise.has_value() && !err.is_empty_or_undefined_or_null() {
+        this.detach_sink();
+        if this.end_promise.get().has_value() && !err.is_empty_or_undefined_or_null() {
             // if we have a explicit error, reject the promise
             // if not when calling .fail will create a S3Error instance
             // this match the previous behavior
-            let _ = self.end_promise.reject(&self.global, Ok(err));
-            self.end_promise = bun_jsc::JSPromiseStrong::empty();
+            let mut end_promise = this.end_promise.replace(bun_jsc::JSPromiseStrong::empty());
+            let _ = end_promise.reject(&this.global, Ok(err));
         }
         // idempotent (`state != Finished`); `task.ended` was set by the pump's close path
-        let _ = self.task.fail(Error::S3Error {
+        let _ = this.task.fail(Error::S3Error {
             code: b"UnknownError",
             message: b"ReadableStream ended with an error",
         });
+        Self::release_pump_ref(this);
     }
 
-    fn resolve(result: S3UploadResult, self_: &mut Self) -> JsResult<()> {
+    /// The upload settled; `this` is kept alive by the upload's observer ref,
+    /// which the caller releases right after.
+    pub(crate) fn resolve(this: ThisPtr<Self>, result: S3UploadResult) -> JsResult<()> {
         bun_output::scoped_log!(S3UploadStream, "resolve");
-        // SAFETY: adopts the upload's ref; released at scope exit, after the borrows below.
-        let _upload_ref = unsafe { RefPtr::from_raw(std::ptr::from_mut::<Self>(self_)) };
-        let global = self_.global;
+        let global = this.global;
         // The native teardown (source close, pump-ref release, completion callback)
         // runs on every path; the promise slots are settled until one settle leaves an
         // exception pending, which is what this returns (nothing settles over it).
         let mut settled: JsResult<()> = Ok(());
         match &result {
             S3UploadResult::Success => {
-                let uploaded = JSValue::js_number(self_.task.uploaded_bytes.get() as f64);
-                if let Some(sink) = self_.sink_mut() {
-                    sink.pending.run();
-                    if settled.is_ok() && sink.flush_promise.has_value() {
-                        settled = sink.flush_promise.resolve(&global, JSValue::js_number(0.0));
+                let uploaded = JSValue::js_number(this.task.uploaded_bytes.get() as f64);
+                if let Some(sink) = this.sink() {
+                    sink.run_pending();
+                    if settled.is_ok() && sink.flush_promise.get().has_value() {
+                        settled = sink
+                            .flush_promise
+                            .with_mut(|p| p.resolve(&global, JSValue::js_number(0.0)));
                     }
-                    if settled.is_ok() && sink.end_promise.has_value() {
-                        settled = sink.end_promise.resolve(&global, uploaded);
+                    if settled.is_ok() && sink.end_promise.get().has_value() {
+                        settled = sink.end_promise.with_mut(|p| p.resolve(&global, uploaded));
                     }
                 }
-                if self_.end_promise.has_value() {
+                if this.end_promise.get().has_value() {
+                    let mut end_promise =
+                        this.end_promise.replace(bun_jsc::JSPromiseStrong::empty());
                     if settled.is_ok() {
-                        settled = self_.end_promise.resolve(&global, uploaded);
+                        settled = end_promise.resolve(&global, uploaded);
                     }
-                    self_.end_promise = bun_jsc::JSPromiseStrong::empty();
                 }
             }
             S3UploadResult::Failure(err) => {
                 // If the native ByteStream source errored, prefer the original
                 // JS error it stashed on the sink (preserves `.code` /
                 // `.name`) over the generic `UnknownError` passed to `fail()`.
-                let stashed = self_.sink_mut().and_then(|s| s.upstream_error.try_swap());
-                let js_err = stashed
-                    .unwrap_or_else(|| s3_error_to_js(err, &global, Some(self_.path.slice())));
+                let stashed = this
+                    .sink()
+                    .and_then(|s| s.upstream_error.with_mut(|e| e.try_swap()));
+                let js_err =
+                    stashed.unwrap_or_else(|| s3_error_to_js(err, &global, Some(&this.task.path)));
                 js_err.ensure_still_alive();
                 let mut is_native = false;
-                if let Some(sink) = self_.sink_mut() {
+                if let Some(sink) = this.sink() {
                     // Sink pump still in-flight: fire source.close() so the JSSink
                     // controller's onClose cancels the upstream ReadableStream. The
                     // pump promise settles after, triggering the `.then` shim which
@@ -684,101 +617,75 @@ impl S3UploadStreamWrapper {
                     // `end_from_stream` cleared `source` when it drove this call,
                     // so this is only true when the S3 side failed first.
                     is_native = matches!(
-                        sink.source,
+                        sink.source.get(),
                         crate::webcore::streams::SourceHandle::ByteStream(_)
                             | crate::webcore::streams::SourceHandle::FileReader(_)
                     );
-                    sink.ended = true;
-                    sink.done = true;
-                    sink.pending.result = crate::webcore::streams::Writable::Done;
-                    sink.pending.run();
-                    if settled.is_ok() && sink.flush_promise.has_value() {
-                        settled = sink.flush_promise.reject(&global, Ok(js_err));
+                    sink.ended.set(true);
+                    sink.done.set(true);
+                    sink.pending
+                        .with_mut(|p| p.result = crate::webcore::streams::Writable::Done);
+                    sink.run_pending();
+                    if settled.is_ok() && sink.flush_promise.get().has_value() {
+                        settled = sink
+                            .flush_promise
+                            .with_mut(|p| p.reject(&global, Ok(js_err)));
                     }
-                    if settled.is_ok() && sink.end_promise.has_value() {
-                        settled = sink.end_promise.reject(&global, Ok(js_err));
+                    if settled.is_ok() && sink.end_promise.get().has_value() {
+                        settled = sink.end_promise.with_mut(|p| p.reject(&global, Ok(js_err)));
                     }
-                    sink.source.close(None);
+                    sink.close_source(None);
                 }
                 if is_native {
-                    self_.detach_sink();
-                    // SAFETY: `self_` is the live Box allocation; this balances the
-                    // pump +1 from `upload_stream` (rc 2→1). The scopeguard above
-                    // releases the remaining ref at scope exit.
-                    unsafe { Self::deref(std::ptr::from_mut::<Self>(self_)) };
+                    this.detach_sink();
+                    Self::release_pump_ref(this);
                 }
-                if self_.end_promise.has_value() {
+                if this.end_promise.get().has_value() {
+                    let mut end_promise =
+                        this.end_promise.replace(bun_jsc::JSPromiseStrong::empty());
                     if settled.is_ok() {
-                        settled = self_.end_promise.reject(&global, Ok(js_err));
+                        settled = end_promise.reject(&global, Ok(js_err));
                     }
-                    self_.end_promise = bun_jsc::JSPromiseStrong::empty();
                 }
             }
         }
 
-        if let Some(callback) = self_.callback {
-            callback(result, self_.callback_context);
+        if let Some(on_done) = this.on_done.take() {
+            on_done(result);
         }
         settled
     }
 }
 
-fn s3_upload_stream_on_resolve(
+// C++ `promiseHandlerID` compares the handler passed to `JSValue::then` against
+// these symbols by address, so they must stay function exports.
+// HOST_EXPORT(Bun__S3UploadStream__onResolveStream, jsc)
+pub fn s3_upload_stream_on_resolve(
+    this: ThisPtr<crate::webcore::s3::client::S3UploadStreamWrapper>,
     _global_this: &JSGlobalObject,
-    callframe: &CallFrame,
+    _callframe: &CallFrame,
 ) -> JsResult<JSValue> {
-    let args = callframe.arguments();
-    let this: *mut S3UploadStreamWrapper =
-        args[args.len() - 1].as_promise_ptr::<S3UploadStreamWrapper>();
-    // SAFETY: `as_promise_ptr` recovers the ctx stashed by `upload_stream`; kept
-    // alive by the ref taken there, which `handle_resolve_stream` balances.
-    unsafe { (*this).handle_resolve_stream() };
+    S3UploadStreamWrapper::handle_resolve_stream(this);
     Ok(JSValue::UNDEFINED)
 }
 
-fn s3_upload_stream_on_reject(
+// HOST_EXPORT(Bun__S3UploadStream__onRejectStream, jsc)
+pub fn s3_upload_stream_on_reject(
+    this: ThisPtr<crate::webcore::s3::client::S3UploadStreamWrapper>,
     _global_this: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
     let args = callframe.arguments();
-    let this: *mut S3UploadStreamWrapper =
-        args[args.len() - 1].as_promise_ptr::<S3UploadStreamWrapper>();
     let err = args[0];
-    // SAFETY: `as_promise_ptr` recovers the ctx stashed by `upload_stream`; kept
-    // alive by the ref taken there, which `handle_reject_stream` balances.
-    unsafe { (*this).handle_reject_stream(err) };
+    S3UploadStreamWrapper::handle_reject_stream(this, err);
     Ok(JSValue::UNDEFINED)
-}
-
-bun_jsc::jsc_host_abi! {
-    #[unsafe(export_name = "Bun__S3UploadStream__onResolveStream")]
-    unsafe fn s3_upload_stream_on_resolve_shim(
-        g: *mut JSGlobalObject,
-        cf: *mut CallFrame,
-    ) -> JSValue {
-        match s3_upload_stream_on_resolve(bun_opaque::opaque_deref(g), bun_opaque::opaque_deref(cf)) {
-            Ok(v) => v,
-            Err(_) => JSValue::ZERO,
-        }
-    }
-}
-bun_jsc::jsc_host_abi! {
-    #[unsafe(export_name = "Bun__S3UploadStream__onRejectStream")]
-    unsafe fn s3_upload_stream_on_reject_shim(
-        g: *mut JSGlobalObject,
-        cf: *mut CallFrame,
-    ) -> JSValue {
-        match s3_upload_stream_on_reject(bun_opaque::opaque_deref(g), bun_opaque::opaque_deref(cf)) {
-            Ok(v) => v,
-            Err(_) => JSValue::ZERO,
-        }
-    }
 }
 
 impl Drop for S3UploadStreamWrapper {
     fn drop(&mut self) {
-        bun_output::scoped_log!(S3UploadStream, "deinit {}", self.sink.is_some());
+        bun_output::scoped_log!(S3UploadStream, "deinit {}", self.sink.get().is_some());
         self.detach_sink();
+        // `task` is released as the field drops.
     }
 }
 
@@ -798,10 +705,8 @@ pub(crate) fn upload_stream(
     content_encoding: Option<&[u8]>,
     proxy: Option<&[u8]>,
     request_payer: bool,
-    callback: Option<fn(S3UploadResult, *mut c_void)>,
-    callback_context: *mut c_void,
+    on_done: Option<Box<dyn FnOnce(S3UploadResult<'_>)>>,
 ) -> JsResult<JSValue> {
-    let proxy_url = proxy.unwrap_or(b"");
     if readable_stream.is_disturbed(global_this) {
         return Ok(bun_jsc::JSPromise::rejected_promise(
             global_this,
@@ -872,108 +777,50 @@ pub(crate) fn upload_stream(
         _ => {}
     }
 
-    // Thunks adapting typed callbacks to the erased `*mut c_void` signatures stored on
-    // MultiPartUpload.
-    fn resolve_thunk(
-        _: &MultiPartUpload,
-        result: S3UploadResult,
-        ctx: *mut c_void,
-    ) -> JsResult<()> {
-        // SAFETY: ctx was set to `*mut S3UploadStreamWrapper` below.
-        S3UploadStreamWrapper::resolve(result, unsafe {
-            bun_ptr::callback_ctx::<S3UploadStreamWrapper>(ctx)
-        })
-    }
-    fn on_writable_thunk(task: &MultiPartUpload, ctx: *mut c_void, flushed: u64) {
-        // SAFETY: task is the live MultiPartUpload; ctx is the wrapper set as callback_context.
-        S3UploadStreamWrapper::on_writable(
-            task,
-            unsafe { bun_ptr::callback_ctx::<S3UploadStreamWrapper>(ctx) },
-            flushed,
-        );
-    }
-
-    // SAFETY (JSC_BORROW): see `writable_stream` for rationale.
-    let global_static = GlobalRef::from(global_this);
-    let task_ptr: *mut MultiPartUpload = bun_core::heap::into_raw(Box::new(MultiPartUpload {
-        root: Cell::new(None),
-        queue: JsCell::new(None),
-        available: Cell::new(IntegerBitSet::init_full()),
-        current_part_number: Cell::new(1),
-        ref_count: Cell::new(2), // +1 for the stream ctx (only deinit after task and context ended)
-        ended: Cell::new(false),
-        options: Cell::new(options),
+    // `credentials` is owned-by-value and explicitly `.deref()`ed on each early
+    // return above; the ref is adopted by value — moved into the MultiPartUpload below.
+    let part_size = options.part_size;
+    let upload = new_upload(
+        credentials,
+        path,
+        global_this,
+        options,
         acl,
         storage_class,
+        content_type,
+        content_disposition,
+        content_encoding,
+        proxy,
         request_payer,
-        credentials,
-        poll_ref: JsCell::new(KeepAlive::init()),
-        // SAFETY (JSC_BORROW): VirtualMachine::get() returns the live per-thread VM; it
-        // outlives every MultiPartUpload. Dereference to `&'static` for storage.
-        vm: VirtualMachine::get(),
-        global_this: global_static,
-        buffered: JsCell::new(StreamBuffer::default()),
-        uploaded_bytes: Cell::new(0),
-        path: Box::<[u8]>::from(path),
-        proxy: if !proxy_url.is_empty() {
-            Box::<[u8]>::from(proxy_url)
-        } else {
-            Box::default()
-        },
-        content_type: content_type.map(Box::<[u8]>::from),
-        content_disposition: content_disposition.map(Box::<[u8]>::from),
-        content_encoding: content_encoding.map(Box::<[u8]>::from),
-        upload_id: JsCell::new(Box::default()),
-        multipart_etags: JsCell::new(Vec::new()),
-        multipart_upload_list: JsCell::new(Vec::new()),
-        state: Cell::new(MultiPartUploadState::WaitStreamCheck),
-        callback: resolve_thunk,
-        on_writable: Some(on_writable_thunk),
-        callback_context: Cell::new(core::ptr::null_mut()), // assigned below
-    }));
-    // SAFETY: `task_ptr` is the fresh, non-null allocation root.
-    unsafe { (*task_ptr).root.set(core::ptr::NonNull::new(task_ptr)) };
-    // SAFETY: freshly heap-allocated and refcounted; only shared access from here on.
-    let task = unsafe { &*task_ptr };
+        MultiPartUploadState::WaitStreamCheck,
+    );
+    let task = upload.this_ptr();
 
-    task.poll_ref
-        .with_mut(|poll_ref| poll_ref.ref_(bun_io::js_vm_ctx()));
+    // The sink's ref on the upload (released in `detach_writable`); `upload`
+    // itself becomes the wrapper's (`S3UploadStreamWrapper::task`).
+    let sink = NetworkSink::new(upload.clone(), global_this);
+    let sink_ptr = sink.this_ptr();
+    let sink_handle = crate::webcore::SinkHandle::S3Upload(sink_ptr.into());
 
-    let ctx_ptr: *mut S3UploadStreamWrapper =
-        bun_core::heap::into_raw(Box::new(S3UploadStreamWrapper {
-            ref_count: Cell::new(2), // +1 for the stream pump (released by the .then shim / handle_*_stream)
-            sink: None,
-            callback,
-            callback_context,
-            path: bun_ptr::RawSlice::new(&task.path),
-            // SAFETY: adopts one of `task_ptr`'s two initial refs.
-            task: unsafe { RefPtr::from_raw(task_ptr) },
-            end_promise: bun_jsc::JSPromiseStrong::init(global_this),
-            readable_stream_ref: ReadableStreamStrong::default(),
-            global: global_static,
-        }));
-    // SAFETY: freshly heap-allocated; exclusive access here.
-    let ctx = unsafe { &mut *ctx_ptr };
-    task.callback_context.set(ctx_ptr.cast::<c_void>());
-
-    // Heap-allocate; `JSSink<NetworkSink>` is layout-
-    // compatible (`{ sink: NetworkSink }`) so the cast in `to_sink()` is just a pointer reinterpret.
-    // Ownership stays with `ctx.sink` (freed in `detach_sink`); the JS
-    // controller created by `assign_to_stream` detaches (`m_sinkPtr = null`)
-    // via `controller.end()/close()` before GC so its destructor never calls
-    // `finalize` on this allocation.
-    let sink: &mut NetworkSink = Box::leak(NetworkSink::new(NetworkSink {
-        // SAFETY: `task_ptr` is live; the sink's ref is released in `detach_writable`.
-        task: Some(unsafe { RefPtr::init_ref(task_ptr) }),
-        global_this: Some(bun_ptr::BackRef::new(global_this)),
-        ..Default::default()
-    }));
-    let sink_handle = crate::webcore::SinkHandle::S3Upload(bun_ptr::BackRef::new_mut(sink));
-    ctx.sink = Some(NonNull::from(&mut *sink));
+    let wrapper = RefPtr::new(S3UploadStreamWrapper {
+        ref_count: Cell::new(1),
+        pump_ref: Cell::new(None),
+        sink: JsCell::new(Some(sink)),
+        on_done: Cell::new(on_done),
+        task: upload,
+        end_promise: JsCell::new(bun_jsc::JSPromiseStrong::init(global_this)),
+        readable_stream_ref: JsCell::new(ReadableStreamStrong::default()),
+        global: GlobalRef::from(global_this),
+    });
+    let ctx = wrapper.this_ptr();
+    // +1 for the stream pump (released by the `.then` reaction / handle_*_stream);
+    // `wrapper` itself is the upload's, released once it settles.
+    ctx.pump_ref.set(Some(wrapper.clone()));
+    task.observer.set(Some(UploadObserver::Stream(wrapper)));
 
     // Captured before `assign_to_stream`: a synchronously-draining stream may
     // resolve + clear `ctx.end_promise` before control returns here.
-    let end_promise_value = ctx.end_promise.value();
+    let end_promise_value = ctx.end_promise.get().value();
     end_promise_value.ensure_still_alive();
 
     // Transition WaitStreamCheck → NotStarted before the pump can deliver the
@@ -981,14 +828,23 @@ pub(crate) fn upload_stream(
     // default-controller stream synchronously inside `assign_to_stream`.
     task.continue_stream();
 
-    ctx.readable_stream_ref = ReadableStreamStrong::init(readable_stream, global_this);
+    ctx.readable_stream_ref
+        .set(ReadableStreamStrong::init(readable_stream, global_this));
 
     // Native ByteStream fast-path: wire the source/sink handles directly so
     // bytes flow via `ByteStream::on_data` → `SinkHandle::write` without the JS
     // `readStreamIntoSink` pump.
     if let Some(byte_stream) = readable_stream.ptr.bytes() {
         if byte_stream.sink.get().is_none() {
-            sink.source = crate::webcore::streams::SourceHandle::ByteStream(byte_stream);
+            // A write below can fail the upload synchronously, which settles
+            // the wrapper and releases the sink; keep both for this block.
+            let _ctx_alive = RefPtr::from_this(ctx);
+            let _sink_alive = RefPtr::from_this(sink_ptr);
+            sink_ptr
+                .source
+                .set(crate::webcore::streams::SourceHandle::ByteStream(
+                    byte_stream,
+                ));
             byte_stream.sink.set(sink_handle);
             byte_stream.sink_paused.set(false);
             readable_stream.lock_native(global_this);
@@ -997,7 +853,7 @@ pub(crate) fn upload_stream(
             if let Some(err) = byte_stream.take_pending_error() {
                 let err_js = err.to_js(global_this);
                 err_js.ensure_still_alive();
-                ctx.handle_reject_stream(err_js);
+                S3UploadStreamWrapper::handle_reject_stream(ctx, err_js);
                 return Ok(end_promise_value);
             }
 
@@ -1009,18 +865,20 @@ pub(crate) fn upload_stream(
                 } else {
                     crate::webcore::streams::StreamResult::Owned(buffered)
                 };
-                match sink.write(&chunk) {
+                match sink_ptr.write(&chunk) {
                     crate::webcore::streams::Writable::Backpressure(_) => {
                         byte_stream.sink_paused.set(true);
                     }
                     crate::webcore::streams::Writable::Done
                     | crate::webcore::streams::Writable::Err(_) => {
                         byte_stream.sink.set(crate::webcore::SinkHandle::None);
-                        sink.source.clear();
-                        if !sink.ended {
-                            let _ = sink.end(None);
+                        sink_ptr
+                            .source
+                            .set(crate::webcore::streams::SourceHandle::None);
+                        if !sink_ptr.ended.get() {
+                            let _ = sink_ptr.end(None);
                         }
-                        ctx.handle_resolve_stream();
+                        S3UploadStreamWrapper::handle_resolve_stream(ctx);
                         return Ok(end_promise_value);
                     }
                     _ => {}
@@ -1028,16 +886,18 @@ pub(crate) fn upload_stream(
             }
             if had_last {
                 byte_stream.sink.set(crate::webcore::SinkHandle::None);
-                sink.source.clear();
-                if !sink.ended {
-                    let _ = sink.end(None);
+                sink_ptr
+                    .source
+                    .set(crate::webcore::streams::SourceHandle::None);
+                if !sink_ptr.ended.get() {
+                    let _ = sink_ptr.end(None);
                 }
-                ctx.handle_resolve_stream();
+                S3UploadStreamWrapper::handle_resolve_stream(ctx);
             } else if !byte_stream.sink_paused.get() {
                 // Wake the producer after the older bytes are in the sink.
                 byte_stream.signal_drained();
             }
-            // `!had_last`: the stream-pump +1 (rc=2) is released by
+            // `!had_last`: the pump ref is released by
             // `NetworkSink::end_from_stream` after the terminal write/fail so the
             // sink outlives the synchronous `resolve()` re-entry.
             return Ok(end_promise_value);
@@ -1046,15 +906,12 @@ pub(crate) fn upload_stream(
     }
 
     // The controller cell is installed into `sink.source` by `assign_to_stream`.
-    let assignment_result: JSValue = NetworkSinkJSSink::assign_to_stream(
-        global_this,
-        readable_stream.value,
-        NonNull::from(sink),
-    );
+    let assignment_result: JSValue =
+        NetworkSinkJSSink::assign_to_stream(global_this, readable_stream.value, sink_ptr.into());
     assignment_result.ensure_still_alive();
 
     if let Some(err_value) = assignment_result.to_error() {
-        ctx.handle_reject_stream(err_value);
+        S3UploadStreamWrapper::handle_reject_stream(ctx, err_value);
         return Ok(end_promise_value);
     }
 
@@ -1062,20 +919,22 @@ pub(crate) fn upload_stream(
         if let Some(promise) = assignment_result.as_any_promise() {
             match promise.status() {
                 bun_jsc::js_promise::Status::Pending => {
+                    // The pump ref rides on the reaction pair: exactly one of
+                    // them runs, once.
                     assignment_result.then(
                         global_this,
-                        ctx_ptr,
-                        s3_upload_stream_on_resolve_shim,
-                        s3_upload_stream_on_reject_shim,
+                        ctx.as_ptr(),
+                        crate::generated_host_exports::Bun__S3UploadStream__onResolveStream,
+                        crate::generated_host_exports::Bun__S3UploadStream__onRejectStream,
                     );
                 }
                 bun_jsc::js_promise::Status::Fulfilled => {
-                    ctx.handle_resolve_stream();
+                    S3UploadStreamWrapper::handle_resolve_stream(ctx);
                 }
                 bun_jsc::js_promise::Status::Rejected => {
                     promise.set_handled(global_this.vm());
                     let result = promise.result(global_this.vm());
-                    ctx.handle_reject_stream(result);
+                    S3UploadStreamWrapper::handle_reject_stream(ctx, result);
                 }
             }
             return Ok(end_promise_value);
@@ -1083,14 +942,14 @@ pub(crate) fn upload_stream(
     }
 
     // The stream drained synchronously inside `assign_to_stream` (no promise
-    // returned). `handle_resolve_stream` destroys the sink, so re-borrow from
-    // `ctx.sink` rather than the `sink` reference taken before assign_to_stream.
-    if let Some(sink) = ctx.sink_mut() {
-        if !sink.ended {
+    // returned). `handle_resolve_stream` destroys the sink, so re-read it from
+    // `ctx` rather than use the handle taken before assign_to_stream.
+    if let Some(sink) = ctx.sink() {
+        if !sink.ended.get() {
             let _ = sink.end(None);
         }
     }
-    ctx.handle_resolve_stream();
+    S3UploadStreamWrapper::handle_resolve_stream(ctx);
     Ok(end_promise_value)
 }
 
@@ -1102,31 +961,9 @@ fn download_stream(
     size: Option<usize>,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
-    callback: fn(
-        chunk: &MutableString,
-        has_more: bool,
-        err: Option<Error::S3Error>,
-        ctx: *mut c_void,
-    ),
-    callback_context: *mut c_void,
-) -> *mut S3HttpDownloadStreamingTask {
-    let range: Option<Vec<u8>> = 'brk: {
-        if let Some(size_) = size {
-            let mut end = offset + size_;
-            if size_ > 0 {
-                end -= 1;
-            }
-            let mut v = Vec::new();
-            write!(&mut v, "bytes={}-{}", offset, end).expect("infallible: in-memory write");
-            break 'brk Some(v);
-        }
-        if offset == 0 {
-            break 'brk None;
-        }
-        let mut v = Vec::new();
-        write!(&mut v, "bytes={}-", offset).expect("infallible: in-memory write");
-        Some(v)
-    };
+    sink: bun_ptr::OwnedThis<S3DownloadStreamWrapper>,
+) {
+    let range = range_header(offset, size);
 
     let result = match this.sign_request::<false>(
         &bun_s3_signing::SignOptions {
@@ -1148,16 +985,15 @@ fn download_stream(
         Err(sign_err) => {
             drop(range);
             let error_code_and_message = Error::get_sign_error_code_and_message(sign_err.into());
-            callback(
+            sink.on_chunk(
                 &MutableString::default(),
                 false,
                 Some(Error::S3Error {
                     code: error_code_and_message.code,
                     message: error_code_and_message.message,
                 }),
-                callback_context,
             );
-            return core::ptr::null_mut();
+            return;
         }
     };
 
@@ -1174,264 +1010,15 @@ fn download_stream(
             break 'brk bun_http::Headers::from_pico_http_headers(result.headers());
         }
     };
-    let proxy = proxy_url.unwrap_or(b"");
-    let owned_proxy: Box<[u8]> = if !proxy.is_empty() {
-        Box::<[u8]>::from(proxy)
-    } else {
-        Box::<[u8]>::default()
-    };
-    let task_ptr = bun_core::heap::into_raw(S3HttpDownloadStreamingTask::new(
-        S3HttpDownloadStreamingTask {
-            // `http: undefined` — fully overwritten by `task.http.write(AsyncHTTP::init(...))` below.
-            http: core::mem::MaybeUninit::uninit(),
+    S3HttpDownloadStreamingTask::start(
+        RequestStorage {
             sign_result: result,
-            proxy_url: owned_proxy,
-            callback_context: NonNull::new(callback_context.cast::<()>())
-                .expect("callers always pass a non-null Box-allocated context"),
-            callback,
             headers,
-            http_ticket: None,
-            has_schedule_callback: core::sync::atomic::AtomicBool::new(false),
-            signal_store: Default::default(),
-            signals: Default::default(),
-            poll_ref: bun_io::KeepAlive::init(),
-            mutex: Default::default(),
-            request_error: None,
-            reported_response_buffer: MutableString::default(),
-            // `State::default()` sets
-            // `has_more = true` (bit 48). Passing 0 here would start the task with
-            // `has_more == false`, tripping the `assert(state.has_more)` in
-            // `process_http_callback` on the very first HTTP-thread callback.
-            state: core::sync::atomic::AtomicU64::new(
-                crate::webcore::s3::download_stream::State::default().0,
-            ),
-            concurrent_task: Default::default(),
-            async_http_id: 0,
+            body: Box::default(),
+            proxy_url: RequestStorage::owned_proxy(proxy_url),
         },
-    ));
-    // SAFETY: just allocated via heap::alloc, non-null; lifetime owned by HTTP callback
-    // (freed via heap::take in S3HttpDownloadStreamingTask::http_callback).
-    let task = unsafe { &mut *task_ptr };
-    task.poll_ref.ref_(bun_io::js_vm_ctx());
-
-    // SAFETY: lifetime extension — `url` / `headers_buf` / `proxy_url` borrow from heap-allocated
-    // fields of `*task` which the task outlives. See `execute_simple_s3_request`.
-    let url = bun_url::URL::parse(unsafe { bun_ptr::detach_lifetime_ref(&*task.sign_result.url) });
-    // SAFETY: same lifetime-extension invariant as `url` above — `task.headers.buf` is
-    // heap-owned by `*task` and outlives the AsyncHTTP request.
-    let headers_buf: &'static [u8] =
-        unsafe { bun_ptr::detach_lifetime(task.headers.buf.as_slice()) };
-    let http_proxy = if !task.proxy_url.is_empty() {
-        // SAFETY: same lifetime-extension invariant as `url` above — `task.proxy_url` is
-        // heap-owned by `*task` and outlives the AsyncHTTP request.
-        Some(bun_url::URL::parse(unsafe {
-            bun_ptr::detach_lifetime_ref(&*task.proxy_url)
-        }))
-    } else {
-        None
-    };
-
-    task.signals = task.signal_store.to_with_backpressure();
-
-    let vm = VirtualMachine::get();
-    let verbose = vm.get_verbose_fetch();
-    let reject_unauthorized = vm.get_tls_reject_unauthorized();
-
-    task.http.write(bun_http::AsyncHTTP::init(
-        bun_http::Method::GET,
-        url,
-        task.headers.entries.clone().expect("OOM"),
-        headers_buf,
-        b"",
-        bun_http::HTTPClientResultCallback::new_with_release::<S3HttpDownloadStreamingTask>(
-            task_ptr,
-            // SAFETY: `task_ptr` is the heap-allocated task registered above; the
-            // HTTP thread invokes this with that exact pointer.
-            S3HttpDownloadStreamingTask::http_callback,
-            S3HttpDownloadStreamingTask::release_at_shutdown,
-        ),
-        bun_http::FetchRedirect::Follow,
-        bun_http::async_http::Options {
-            http_proxy,
-            verbose: Some(verbose),
-            signals: Some(task.signals),
-            reject_unauthorized: Some(reject_unauthorized),
-            ..Default::default()
-        },
-    ));
-    // SAFETY: `http` was initialised by `task.http.write(...)` immediately above.
-    let http = unsafe { task.http.assume_init_mut() };
-    task.async_http_id = http.async_http_id;
-    // enable streaming
-    http.enable_response_body_streaming();
-    // queue http request
-    bun_http::http_thread::init(&Default::default());
-    let mut batch = bun_threading::thread_pool::Batch::default();
-    http.schedule(&mut batch);
-    // Out on the HTTP thread until its final callback: the VM aborts it at
-    // teardown (registry) and waits for it (the ticket).
-    task.http_ticket = Some(VirtualMachine::get().ticket());
-    crate::jsc_hooks::ActiveHandle::S3Download(core::ptr::NonNull::new(task_ptr).expect("task"))
-        .register();
-    bun_http::HTTPThread::schedule(batch);
-    task_ptr
-}
-
-pub struct S3DownloadStreamWrapper {
-    stream: crate::webcore::byte_stream::ProducerHold,
-    pub path: Box<[u8]>,
-    pub global: GlobalRef, // JSC_BORROW
-    /// Non-owning. The task frees itself on the main thread once `has_more == false`,
-    /// which first drops this wrapper (clearing the stream's producer handle), so this
-    /// pointer is never observed dangling from `on_stream_cancelled`.
-    pub task: Cell<*mut S3HttpDownloadStreamingTask>,
-}
-
-impl S3DownloadStreamWrapper {
-    fn new(init: Self) -> *mut Self {
-        bun_core::heap::into_raw(Box::new(init))
-    }
-
-    /// `this` is the heap pointer from `new` (write and dealloc provenance): the terminal
-    /// callback frees the wrapper through it, so no reference derived from it may outlive
-    /// this call.
-    fn callback(
-        chunk: &MutableString,
-        has_more: bool,
-        request_err: Option<Error::S3Error>,
-        this: *mut Self,
-    ) {
-        let _guard = scopeguard::guard(this, move |s| {
-            if !has_more {
-                // SAFETY: `s` is the live allocation from `new`; the HTTP thread does not call
-                // back after the terminal chunk, so this is the only owner left.
-                drop(unsafe { bun_core::heap::take(s) });
-            }
-        });
-        // SAFETY: live until the guard runs, which is after the last use of this borrow.
-        let self_ = unsafe { &*this };
-
-        if let Some(err) = request_err {
-            let Some(bytes) = self_.stream.take() else {
-                return;
-            };
-            bytes.on_data(crate::webcore::streams::StreamResult::Err(
-                crate::webcore::streams::StreamError::JSValue(bun_jsc::strong::Optional::create(
-                    s3_error_to_js(&err, &self_.global, Some(&self_.path)),
-                    &self_.global,
-                )),
-            ));
-            return;
-        }
-        if has_more {
-            let Some(bytes) = self_.stream.bytes() else {
-                return;
-            };
-            bytes.on_data(crate::webcore::streams::StreamResult::Temporary(
-                // chunk.list is borrowed for the duration of on_data.
-                bun_ptr::RawSlice::new(chunk.list.as_slice()),
-            ));
-            // `on_data` can cancel us, which releases the hold.
-            if self_.stream.is_held() {
-                self_.after_chunk_delivered(&bytes);
-            }
-            return;
-        }
-        let Some(bytes) = self_.stream.take() else {
-            return;
-        };
-        bytes.on_data(crate::webcore::streams::StreamResult::TemporaryAndDone(
-            // chunk.list is borrowed for the duration of on_data.
-            bun_ptr::RawSlice::new(chunk.list.as_slice()),
-        ));
-    }
-
-    /// The other half of this rule is in `S3HttpDownloadStreamingTask::process_http_callback`
-    /// (HTTP thread).
-    fn after_chunk_delivered(&self, bytes: &ByteStream) {
-        use crate::webcore::byte_stream::{AfterDelivery, ProducerHold};
-        let task = self.task.get();
-        if task.is_null() {
-            return;
-        }
-        match ProducerHold::after_delivery(bytes) {
-            // SAFETY: see `task`.
-            AfterDelivery::Resume => unsafe { (*task).resume_receive() },
-            // SAFETY: see `task`.
-            AfterDelivery::Pause => unsafe { (*task).signal_store.pause_receive() },
-            AfterDelivery::Park => {
-                // SAFETY: see `task`.
-                unsafe { (*task).signal_store.pause_receive() };
-                if self.stream.park() {
-                    // SAFETY: see `task`; `park` touched the stream's source, not the task.
-                    unsafe { (*task).poll_ref.unref(bun_io::js_vm_ctx()) };
-                }
-            }
-        }
-    }
-
-    fn unpark(&self) {
-        let task = self.task.get();
-        if self.stream.unpark() && !task.is_null() {
-            // SAFETY: see `task`; reached from a consumer, so the task is still live.
-            unsafe { (*task).poll_ref.ref_(bun_io::js_vm_ctx()) };
-        }
-    }
-
-    pub(crate) fn on_stream_drained(&self) {
-        self.unpark();
-        let task = self.task.get();
-        if !task.is_null() {
-            // SAFETY: see `task`.
-            unsafe { (*task).resume_receive() };
-        }
-    }
-
-    pub(crate) fn on_consumer_attached(&self) {
-        self.unpark();
-    }
-
-    /// The parked stream's wrapper was collected: nothing can read the rest. Inside a GC sweep;
-    /// touches no JS cell.
-    pub(crate) fn on_stream_collected(&self) {
-        self.on_stream_cancelled();
-    }
-
-    pub(crate) fn on_stream_cancelled(&self) {
-        // The download may still be in progress, but the callback will see no stream and skip
-        // delivery. When the download finishes (has_more == false) the task frees this wrapper.
-        self.stream.release();
-        // Abort the in-flight HTTP request so the HTTP thread delivers a final
-        // callback with `has_more == false`, which frees the task and this wrapper.
-        // Without this, a server that never sends the terminal chunk would leak both.
-        let task = self.task.replace(core::ptr::null_mut());
-        if !task.is_null() {
-            // SAFETY: task is live until its own `on_response` frees it on this thread,
-            // which has not happened yet (it would have dropped this wrapper first).
-            unsafe {
-                (*task)
-                    .signal_store
-                    .aborted
-                    .store(true, core::sync::atomic::Ordering::Relaxed);
-                (*task).poll_ref.unref(bun_io::js_vm_ctx());
-                // Wake the HTTP thread so it observes the abort even when the
-                // socket is idle; otherwise the final `has_more == false`
-                // callback never fires and both the task and wrapper leak.
-                bun_http::http_thread().schedule_shutdown_by_id((*task).async_http_id);
-            }
-        }
-    }
-
-    fn opaque_callback(
-        chunk: &MutableString,
-        has_more: bool,
-        err: Option<Error::S3Error>,
-        opaque_self: *mut c_void,
-    ) {
-        // `opaque_self` is the wrapper allocated in `readable_stream`; handed on as the raw
-        // pointer so that the terminal callback can free it.
-        Self::callback(chunk, has_more, err, opaque_self.cast::<Self>());
-    }
+        sink,
+    );
 }
 
 /// returns a readable stream that reads from the s3 path
@@ -1444,57 +1031,27 @@ pub(crate) fn readable_stream(
     request_payer: bool,
     global_this: &JSGlobalObject,
 ) -> JsResult<JSValue> {
-    // SAFETY (JSC_BORROW): `global_this` outlives the wrapper (it owns the JS heap that
-    // owns the readable stream which keeps the wrapper reachable via the producer handle);
-    // store as `'static` for the heap-allocated wrapper.
-    let global_static = GlobalRef::from(global_this);
-
     // Ownership of the heap-allocated NewSource transfers to the JS wrapper (m_ctx) via
-    // `to_readable_stream()`/`to_js()`; the wrapper's finalize() reclaims it.
-    let reader: *mut crate::webcore::byte_stream::Source =
-        crate::webcore::byte_stream::Source::new(crate::webcore::readable_stream::NewSource {
+    // `to_readable_stream()`; the wrapper's finalize() reclaims it.
+    let reader =
+        crate::webcore::byte_stream::Source::new_mut(crate::webcore::readable_stream::NewSource {
             context: ByteStream::default(),
             global_this: Some(bun_ptr::BackRef::new(global_this)),
             ..Default::default()
         });
-    // SAFETY: freshly heap-allocated via TrivialNew; exclusive access until handed to JS below.
-    let reader_mut = unsafe { &mut *reader };
 
-    reader_mut.context.setup();
-    let readable_value = reader_mut.to_readable_stream(global_this)?;
+    reader.context.setup();
+    let readable_value = reader.to_readable_stream(global_this)?;
 
-    let wrapper = S3DownloadStreamWrapper::new(S3DownloadStreamWrapper {
-        stream: Default::default(),
-        path: Box::<[u8]>::from(path),
-        global: global_static,
-        task: Cell::new(core::ptr::null_mut()),
-    });
-    // SAFETY: `reader` is the live source made above; `wrapper` the live heap allocation.
-    unsafe { (*wrapper).stream.hold(&raw mut reader_mut.context) };
-
-    reader_mut
+    let sink = S3DownloadStreamWrapper::new(reader, path, GlobalRef::from(global_this));
+    // The task drops the wrapper once the download is over, and the wrapper
+    // lets go of the source (clearing this handle) first (holder obligation).
+    reader
         .producer
         .set(crate::webcore::streams::SourceHandle::S3DownloadBody(
-            // SAFETY: `wrapper` is the live heap allocation; cleared from the producer slot before
-            // it is freed (`ProducerHold::take`).
-            unsafe { bun_ptr::BackRef::from_raw(wrapper) },
+            bun_ptr::BackRef::new(&*sink),
         ));
 
-    let task = download_stream(
-        this,
-        path,
-        offset,
-        size,
-        proxy_url,
-        request_payer,
-        S3DownloadStreamWrapper::opaque_callback,
-        wrapper.cast::<c_void>(),
-    );
-    if !task.is_null() {
-        // SAFETY: on the success path `download_stream` only schedules work onto the HTTP
-        // thread; the wrapper is freed via `opaque_callback` on this (main) thread, which
-        // cannot run until we return to the event loop, so `wrapper` is still live here.
-        unsafe { (*wrapper).task.set(task) };
-    }
+    download_stream(this, path, offset, size, proxy_url, request_payer, sink);
     Ok(readable_value)
 }

--- a/src/runtime/webcore/s3/download_stream.rs
+++ b/src/runtime/webcore/s3/download_stream.rs
@@ -1,67 +1,59 @@
-use core::ffi::c_void;
-use core::ptr::NonNull;
-use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use core::cell::Cell;
+use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
+use std::sync::Arc;
 
 use bun_core::MutableString;
-use bun_event_loop::ConcurrentTask::{AutoDeinit, ConcurrentTask};
-use bun_event_loop::{TaskTag, Taskable, task_tag};
-use bun_http::{AsyncHTTP, HTTPClientResult, Headers, Signals};
+use bun_event_loop::ConcurrentTask::ConcurrentTask;
+use bun_event_loop::{ReusableConcurrentTask, Task, TaskHop, TaskTag, task_tag};
+use bun_http::{HTTPClientResult, HTTPClientResultHandler, InFlight};
 use bun_io::KeepAlive;
-use bun_s3_signing::credentials::SignResult;
+use bun_jsc::virtual_machine::VirtualMachine;
+use bun_jsc::{GlobalRef, InFlightTicket, JsCell};
+use bun_ptr::{RefPtr, ThisPtr};
 use bun_s3_signing::error::S3Error;
+use bun_threading::Guarded;
 
+use crate::webcore::byte_stream::{AfterDelivery, ByteStream, ProducerHold, Source};
+use crate::webcore::s3::client::s3_error_to_js;
+use crate::webcore::s3::simple_request::RequestStorage;
 use crate::webcore::s3::xml_response;
-use bun_threading::Mutex;
 
 bun_core::declare_scope!(S3, hidden);
 
-pub struct S3HttpDownloadStreamingTask {
-    // `MaybeUninit` because `AsyncHTTP` contains non-null references, so
-    // `mem::zeroed()` can't be used here (mirrors `S3HttpSimpleTask`).
-    pub(crate) http: core::mem::MaybeUninit<AsyncHTTP<'static>>,
-    /// Held while the download is out on the HTTP thread: how it delivers
-    /// chunks, and what makes the VM wait for it.
-    pub(crate) http_ticket: Option<bun_jsc::Ticket>,
-    pub(crate) sign_result: SignResult,
-    pub(crate) headers: Headers,
-    pub(crate) callback_context: NonNull<()>,
-    pub callback: fn(chunk: &MutableString, has_more: bool, err: Option<S3Error>, ctx: *mut c_void),
-    pub(crate) has_schedule_callback: AtomicBool,
-    pub(crate) signal_store: bun_http::signals::Store,
-    pub(crate) signals: Signals,
-    pub poll_ref: KeepAlive,
-
-    pub(crate) mutex: Mutex,
-    pub(crate) reported_response_buffer: MutableString,
-    /// The HTTP-level failure, if any. Guarded by `mutex`; the `request_error`
-    /// bit in `state` mirrors `request_error.is_some()`.
-    pub(crate) request_error: Option<bun_http::Error>,
-    pub(crate) state: AtomicU64,
-
-    pub(crate) concurrent_task: ConcurrentTask,
-    pub(crate) proxy_url: Box<[u8]>,
-    /// Captured once on the main thread before the request is queued so the cancel
-    /// path can call `schedule_shutdown_by_id` without dereferencing `http` (which
-    /// `update_state` overwrites on the HTTP thread under `mutex`).
-    pub(crate) async_http_id: u32,
+/// What the HTTP thread has buffered for the next progress report.
+#[derive(Default)]
+struct Progress {
+    buffer: MutableString,
+    /// The HTTP-level failure, if any; the `request_error` bit in
+    /// [`DownloadShared::state`] mirrors `request_error.is_some()`.
+    request_error: Option<bun_http::Error>,
 }
 
-// Hot-dispatch tag for `ConcurrentTask::from`.
-impl Taskable for S3HttpDownloadStreamingTask {
-    const TAG: TaskTag = task_tag::S3HttpDownloadStreamingTask;
-    /// As `S3HttpSimpleTask`: the completion frees the context; run it.
-    unsafe fn release_unrun(this: *mut Self) {
-        S3HttpDownloadStreamingTask::on_response(this);
-    }
+/// The part of a streaming download shared with the HTTP thread: `bun_http`
+/// holds it (as the request's result handler) until the terminal result; the
+/// task and its sink's abort handle for their whole life.
+pub(crate) struct DownloadShared {
+    progress: Guarded<Progress>,
+    state: AtomicU64,
+    /// A progress hop is queued on the JS thread and has not run yet; set by
+    /// the HTTP thread (compare-exchange, under `progress`' lock) and cleared
+    /// by `on_response` under the same lock.
+    has_schedule_callback: AtomicBool,
+    /// The HTTP client's abort flag: set by a stream cancel or the VM's stop
+    /// phase so the request fails promptly and comes back.
+    signal_store: bun_http::signals::Store,
+    /// The task's address for the JS-thread hops; set once, before the request
+    /// is scheduled. The task keeps itself alive for them (`http_ref`).
+    task: AtomicPtr<S3HttpDownloadStreamingTask>,
+    /// The progress hop's queue node (at most one is queued at a time:
+    /// `has_schedule_callback`).
+    node: ReusableConcurrentTask,
+    /// How the HTTP thread posts to the JS thread, and what makes the VM wait
+    /// for it; handed back after the terminal result.
+    ticket: InFlightTicket,
 }
 
-impl S3HttpDownloadStreamingTask {
-    const HOLDS_TICKET: &str = "S3 download on the HTTP thread holds a ticket";
-
-    pub(crate) fn new(init: Self) -> Box<Self> {
-        Box::new(init)
-    }
-
+impl DownloadShared {
     pub(crate) fn get_state(&self) -> State {
         State(self.state.load(Ordering::Acquire))
     }
@@ -70,186 +62,58 @@ impl S3HttpDownloadStreamingTask {
         self.state.store(state.0, Ordering::Relaxed);
     }
 
-    /// The chunk callback runs JS, which reaches back into this task through the stream
-    /// wrapper's pointer (`pause_receive`, `poll_ref`). No borrow of `this` may span that call,
-    /// so this takes the raw pointer and scopes every access to its statement.
-    ///
-    /// # Safety
-    /// `this` is live and exclusively accessed by this thread for the duration of the call
-    /// (`on_response`).
-    unsafe fn report_progress(this: *mut Self, state: State) {
-        let has_more = state.has_more();
-        let failed = match state.status_code() {
-            200 | 204 | 206 => state.request_error() != 0,
-            _ => true,
-        };
-        // SAFETY: fn contract; `callback` and `callback_context` are set once, before the task
-        // is queued.
-        let (callback, callback_context) =
-            unsafe { ((*this).callback, (*this).callback_context.as_ptr().cast()) };
-        bun_core::scoped_log!(
-            S3,
-            "reportProgres failed: {} has_more: {} len: {}",
-            failed,
-            has_more,
-            // SAFETY: fn contract.
-            unsafe { (*this).reported_response_buffer.list.len() }
+    fn post_progress(&self) {
+        let task = Task::new(
+            task_tag::S3HttpDownloadStreamingTask,
+            self.task.load(Ordering::Acquire).cast::<()>(),
         );
-
-        if failed {
-            if has_more {
-                return;
-            }
-            let empty = MutableString::default();
-            let mut code: &[u8] = b"UnknownError";
-            let mut message: &[u8] = b"an unexpected error has occurred";
-            let parsed;
-            // SAFETY: fn contract.
-            if let Some(req_err) = unsafe { (*this).request_error } {
-                code = req_err.name().as_bytes();
-            } else {
-                // SAFETY: fn contract; the buffer is not touched again before the callback
-                // returns, and `message` is not used after it.
-                let bytes = unsafe { (*this).reported_response_buffer.list.as_slice() };
-                if !bytes.is_empty() {
-                    message = bytes;
-                }
-                parsed = xml_response::parse_error(bytes);
-                if let Some(error) = &parsed {
-                    code = error.code.as_deref().unwrap_or(code);
-                    message = error.message.as_deref().unwrap_or(message);
-                }
-            }
-            callback(
-                &empty,
-                false,
-                Some(S3Error { code, message }),
-                callback_context,
-            );
-            return;
-        }
-
-        // dont report empty chunks if we have more data to read
-        // SAFETY: fn contract.
-        if !has_more || unsafe { (*this).reported_response_buffer.list.len() } > 0 {
-            // `core::mem::take` transfers ownership of the buffer, leaving an
-            // empty MutableString behind.
-            // SAFETY: fn contract; the borrow ends with the statement.
-            let chunk = unsafe { core::mem::take(&mut (*this).reported_response_buffer) };
-            callback(&chunk, has_more, None, callback_context);
-            // SAFETY: fn contract; the callback does not free the task, `on_response` does,
-            // after this returns.
-            unsafe { (*this).reported_response_buffer.reset() };
-        }
+        // `has_schedule_callback` was clear, so the previous hop has run and its
+        // node was consumed; the heap node is only a fallback.
+        let node = self
+            .node
+            .arm(task)
+            .unwrap_or_else(|| ConcurrentTask::create(task));
+        self.ticket.post(node);
     }
 
-    /// this is the task callback from the last task result and is always in the main thread
-    ///
-    /// # Safety
-    /// `this` must be a live heap pointer produced by `Self::new`; the event loop guarantees
-    /// exclusive main-thread access for the duration of this call. When the loaded state's
-    /// `has_more` is false this call reclaims and drops the allocation exactly once.
-    pub(crate) fn on_response(this: *mut Self) {
-        // SAFETY: `this` is a live heap allocation created via `Self::new`; the event loop
-        // guarantees exclusive access on the main thread for the duration of this callback.
-        // Each access below is scoped so no borrow spans `report_progress` (which invokes
-        // the chunk callback).
-        unsafe { (*this).mutex.lock() };
-        // the state is atomic let's load it once
-        // SAFETY: as above.
-        let state = unsafe { (*this).get_state() };
-        let has_more = state.has_more();
-        // Use a scopeguard so any future early-exit / unwind through
-        // `report_progress` still unlocks + deinits.
-        let this_ptr = this;
-        scopeguard::defer! {
-            // SAFETY: `this_ptr` was allocated via `Box::new` in `Self::new`; once
-            // `has_more == false` we are the sole owner (HTTP thread will not call back again).
-            unsafe {
-                (*this_ptr).mutex.unlock();
-                if !has_more {
-                    crate::jsc_hooks::ActiveHandle::S3Download(core::ptr::NonNull::new(this_ptr).expect("task")).unregister();
-                    drop(bun_core::heap::take(this_ptr));
-                }
-            }
-        };
-
-        // there is no reason to set has_schedule_callback to true if we dont have more data to read
-        if has_more {
-            // SAFETY: as above.
-            unsafe {
-                (*this)
-                    .has_schedule_callback
-                    .store(false, Ordering::Relaxed)
-            };
-        }
-        // SAFETY: as above.
-        unsafe { Self::report_progress(this, state) };
-    }
-
-    /// this function is only called from the http callback in the HTTPThread and returns true if we
-    /// should wait until we are done buffering the response body to report
-    /// should only be called when already locked
+    /// HTTP thread, `progress` locked: fold `result`'s status into `state`.
+    /// Returns whether reporting should wait until the body is fully buffered
+    /// (an error or non-2xx status).
     fn update_state(
-        &mut self,
-        async_http: &mut AsyncHTTP<'static>,
-        // borrowed so the caller (process_http_callback) can still read
-        // `result.body` afterward.
+        &self,
+        progress: &mut Progress,
         result: &HTTPClientResult,
         state: &mut State,
     ) -> bool {
         let is_done = !result.has_more;
-        // if we got a error or fail wait until we are done buffering the response body to report
-        let wait_until_done;
-        {
-            state.set_has_more(!is_done);
+        state.set_has_more(!is_done);
 
-            self.request_error = result.fail;
-            state.set_request_error(if result.fail.is_some() { 1 } else { 0 });
-            if state.status_code() == 0 {
-                // `certificate_info` / `metadata` free their owned buffers via `Drop`
-                // when `HTTPClientResult` is dropped by the caller after this returns.
-                if let Some(m) = &result.metadata {
-                    state.set_status_code(m.response.status_code);
-                }
+        progress.request_error = result.fail;
+        state.set_request_error(if result.fail.is_some() { 1 } else { 0 });
+        if state.status_code() == 0 {
+            if let Some(m) = &result.metadata {
+                state.set_status_code(m.response.status_code);
             }
-            match state.status_code() {
-                200 | 204 | 206 => wait_until_done = state.request_error() != 0,
-                _ => wait_until_done = true,
-            }
-            // store the new state
-            self.set_state(*state);
-            // SAFETY: `async_http` points to a live AsyncHTTP owned by the HTTP thread; a
-            // bitwise read+write copies its current state into `self.http` without running
-            // destructors (the HTTP thread retains ownership of the source until the request
-            // completes). `self.http` was previously initialised in
-            // `client::download_stream`.
-            unsafe { core::ptr::write(self.http.as_mut_ptr(), core::ptr::read(async_http)) };
         }
+        let wait_until_done = match state.status_code() {
+            200 | 204 | 206 => state.request_error() != 0,
+            _ => true,
+        };
+        self.set_state(*state);
         wait_until_done
     }
 
-    /// this functions is only called from the http callback in the HTTPThread and returns true if
-    /// we should enqueue another task
-    fn process_http_callback(
-        &mut self,
-        async_http: &mut AsyncHTTP<'static>,
-        mut result: HTTPClientResult,
-    ) -> bool {
-        // lets lock and unlock to be safe we know the state is not in the middle of a callback when locked
-        // The RAII guard unlocks on every
-        // return path. The guard holds the mutex by raw pointer (see
-        // `Mutex::lock_guard`), so `&mut self` stays freely usable while
-        // locked, and it drops before this fn returns — strictly before the
-        // task can be freed by the main thread.
-        let _guard = self.mutex.lock_guard();
+    /// HTTP thread: buffer `result` and decide whether a progress hop should
+    /// be posted for it.
+    fn process_http_callback(&self, mut result: HTTPClientResult) -> bool {
+        // Locked so the JS thread never observes the state mid-update.
+        let mut progress = self.progress.lock();
 
-        // remember the state is atomic load it once, and store it again
         let mut state = self.get_state();
         // old state should have more otherwise it's an HTTP-client bug
         debug_assert!(state.has_more());
         let is_done = !result.has_more;
-        let wait_until_done = self.update_state(async_http, &result, &mut state);
+        let wait_until_done = self.update_state(&mut progress, &result, &mut state);
         let should_enqueue = !wait_until_done || is_done;
         bun_core::scoped_log!(
             S3,
@@ -260,18 +124,18 @@ impl S3HttpDownloadStreamingTask {
             should_enqueue
         );
 
-        result.body_into(&mut self.reported_response_buffer.list);
+        result.body_into(&mut progress.buffer.list);
         // Only a body that is being delivered can be resumed: the wrapper resumes as JS takes
         // chunks. An error body is collected whole before it is reported, with no chunk
         // delivered in between, so pausing it would never be undone.
         if !is_done
             && !wait_until_done
-            && self.reported_response_buffer.list.len() >= bun_http::signals::BODY_HIGH_WATER_MARK
+            && progress.buffer.list.len() >= bun_http::signals::BODY_HIGH_WATER_MARK
         {
             self.signal_store.pause_receive();
         }
         if should_enqueue {
-            if self.reported_response_buffer.list.is_empty() && !is_done {
+            if progress.buffer.list.is_empty() && !is_done {
                 return false;
             }
             if let Err(has_schedule_callback) = self.has_schedule_callback.compare_exchange(
@@ -288,122 +152,395 @@ impl S3HttpDownloadStreamingTask {
         }
         false
     }
+}
 
-    /// this is the AsyncHTTP callback and is always called from the HTTPThread
-    ///
-    /// # Safety
-    /// `this` must be a live heap pointer produced by `Self::new`, valid for the duration of the
-    /// HTTP request; `mutex` serializes against `on_response`. `async_http` must be a valid
-    /// pointer to an initialised `AsyncHTTP` for the duration of this call.
-    pub(crate) fn http_callback(
-        this: *mut Self,
-        async_http: *mut AsyncHTTP<'static>,
-        result: HTTPClientResult,
-    ) {
-        // SAFETY: `this` is live for the duration of the HTTP request; HTTPThread holds the only
-        // concurrent reference and `mutex` serializes against `on_response`. `async_http` is the
-        // live HTTP-thread copy, non-null for the callback's duration. Borrows scoped to the call.
+impl HTTPClientResultHandler for DownloadShared {
+    fn on_result(&self, result: HTTPClientResult<'_>) {
         let is_done = !result.has_more;
-        // No refcount here: on the final callback `on_response` may free `this`
-        // as soon as the task is queued, so the ticket has to be out first.
-        let done_ticket = is_done.then(|| {
-            // SAFETY: as above; HTTP-thread field.
-            unsafe { (*this).http_ticket.take() }.expect(Self::HOLDS_TICKET)
-        });
-        // SAFETY: as above; the HTTP thread is the only one touching it here.
-        if unsafe { (*this).process_http_callback(&mut *async_http, result) } {
-            // we are always unlocked here and its safe to enqueue
-            // SAFETY: same exclusivity as above; `task` is the inline `concurrent_task` field of
-            // this heap request and the queue takes ownership of its `next` link. Not done ⇒
-            // `this` (and the ticket in it) outlives the post.
-            unsafe {
-                let task = core::ptr::NonNull::from(
-                    (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit),
-                );
-                done_ticket
-                    .as_ref()
-                    .unwrap_or_else(|| (*this).http_ticket.as_ref().expect(Self::HOLDS_TICKET))
-                    .post(task);
-            }
+        if self.process_http_callback(result) {
+            self.post_progress();
         }
-        drop(done_ticket);
+        if is_done {
+            self.ticket.hand_back();
+        }
     }
 
-    /// `HTTPClientResultCallback::release_at_shutdown`: the exiting main
-    /// thread parked the HTTP thread, which will not call back; hand the
-    /// download back as failed/finished so its VM's wait ends and the JS
-    /// thread frees it.
-    ///
-    /// # Safety
-    /// `this` is the live task registered with the callback; HTTP thread parked.
-    pub(crate) unsafe fn release_at_shutdown(this: *mut ()) {
-        let this = this.cast::<Self>();
-        // SAFETY: fn contract — nothing else touches the task now (the JS
-        // thread is waiting in the HTTP shutdown).
-        unsafe {
-            let ticket = (*this).http_ticket.take().expect(Self::HOLDS_TICKET);
-            let should_enqueue = {
-                let _guard = (*this).mutex.lock_guard();
-                let mut state = (*this).get_state();
-                state.set_has_more(false);
-                (*this).request_error = Some(bun_http::Error::Aborted);
-                state.set_request_error(1);
-                (*this).set_state(state);
-                (*this)
-                    .has_schedule_callback
-                    .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-                    .is_ok()
-            };
-            if should_enqueue {
-                let task = core::ptr::NonNull::from(
-                    (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit),
-                );
-                ticket.post(task);
+    /// The exiting main thread parked the HTTP thread, which will not call
+    /// back; hand the download back as failed/finished so its VM's wait ends
+    /// and the JS thread releases it.
+    fn release_at_shutdown(&self) {
+        let should_enqueue = {
+            let mut progress = self.progress.lock();
+            let mut state = self.get_state();
+            state.set_has_more(false);
+            progress.request_error = Some(bun_http::Error::Aborted);
+            state.set_request_error(1);
+            self.set_state(state);
+            self.has_schedule_callback
+                .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+                .is_ok()
+        };
+        if should_enqueue {
+            self.post_progress();
+        }
+        self.ticket.hand_back();
+    }
+}
+
+/// A streaming S3 download (`s3file.stream()` / `readable`). Lives on the JS
+/// thread; the HTTP thread only sees [`DownloadShared`].
+#[derive(bun_ptr::CellRefCounted)]
+pub struct S3HttpDownloadStreamingTask {
+    ref_count: Cell<u32>,
+    /// The ref the progress hops (and the teardown registry) reach this task
+    /// through; released by the hop that sees `has_more == false`.
+    http_ref: Cell<Option<RefPtr<S3HttpDownloadStreamingTask>>>,
+    shared: Arc<DownloadShared>,
+    /// The request out on (or back from) the HTTP thread; taken back on drop.
+    request: InFlight<RequestStorage>,
+    /// Where the body goes.
+    sink: bun_ptr::OwnedThis<S3DownloadStreamWrapper>,
+}
+
+/// `task_tag::S3HttpDownloadStreamingTask`: the HTTP thread has body bytes
+/// (or the end of the download) for the JS thread.
+pub struct ProgressHop;
+impl TaskHop for ProgressHop {
+    type Target = S3HttpDownloadStreamingTask;
+    const TAG: TaskTag = task_tag::S3HttpDownloadStreamingTask;
+    fn run(this: ThisPtr<S3HttpDownloadStreamingTask>) -> bun_jsc::JsResult<()> {
+        S3HttpDownloadStreamingTask::on_response(this);
+        Ok(())
+    }
+    /// As `S3HttpSimpleTask`: the completion is what releases the sink; run it.
+    fn release_unrun(this: ThisPtr<S3HttpDownloadStreamingTask>) {
+        S3HttpDownloadStreamingTask::on_response(this);
+    }
+}
+
+impl S3HttpDownloadStreamingTask {
+    fn report_progress(&self, state: State, mut progress: Progress) {
+        let has_more = state.has_more();
+        let failed = match state.status_code() {
+            200 | 204 | 206 => state.request_error() != 0,
+            _ => true,
+        };
+        bun_core::scoped_log!(
+            S3,
+            "reportProgres failed: {} has_more: {} len: {}",
+            failed,
+            has_more,
+            progress.buffer.list.len()
+        );
+
+        if failed {
+            if has_more {
+                return;
             }
-            drop(ticket);
+            let empty = MutableString::default();
+            let mut code: &[u8] = b"UnknownError";
+            let mut message: &[u8] = b"an unexpected error has occurred";
+            let parsed;
+            if let Some(req_err) = progress.request_error {
+                code = req_err.name().as_bytes();
+            } else {
+                let bytes = progress.buffer.list.as_slice();
+                if !bytes.is_empty() {
+                    message = bytes;
+                }
+                parsed = xml_response::parse_error(bytes);
+                if let Some(error) = &parsed {
+                    code = error.code.as_deref().unwrap_or(code);
+                    message = error.message.as_deref().unwrap_or(message);
+                }
+            }
+            self.sink
+                .on_chunk(&empty, false, Some(S3Error { code, message }));
+            return;
+        }
+
+        // dont report empty chunks if we have more data to read
+        if !has_more || !progress.buffer.list.is_empty() {
+            let chunk = core::mem::take(&mut progress.buffer);
+            self.sink.on_chunk(&chunk, has_more, None);
+        }
+    }
+
+    /// A progress hop (JS thread): deliver what the HTTP thread buffered, and
+    /// release the task once the download is over.
+    pub(crate) fn on_response(this: ThisPtr<Self>) {
+        // `on_chunk` re-enters JS, which may run the final hop under us.
+        let _alive = RefPtr::from_this(this);
+        let (state, progress) = {
+            let mut progress = this.shared.progress.lock();
+            // the state is atomic let's load it once
+            let state = this.shared.get_state();
+            // there is no reason to set has_schedule_callback to true if we dont have more data to read
+            if state.has_more() {
+                this.shared
+                    .has_schedule_callback
+                    .store(false, Ordering::Relaxed);
+            }
+            // A failure is only reported once the body is complete, so leave
+            // it buffered until then.
+            let failed = match state.status_code() {
+                200 | 204 | 206 => state.request_error() != 0,
+                _ => true,
+            };
+            let taken = if failed && state.has_more() {
+                Progress::default()
+            } else {
+                Progress {
+                    buffer: core::mem::take(&mut progress.buffer),
+                    request_error: progress.request_error,
+                }
+            };
+            (state, taken)
+        };
+        let http_ref = (!state.has_more()).then(|| {
+            crate::jsc_hooks::ActiveHandle::S3Download(this.into()).unregister();
+            this.http_ref
+                .take()
+                .expect("S3 download is handed back once")
+        });
+        this.report_progress(state, progress);
+        if let Some(http_ref) = http_ref {
+            drop(http_ref);
         }
     }
 
     /// VM teardown's stop phase (JS thread): abort the transport so the HTTP
     /// thread fails the request promptly and hands it back.
-    ///
-    /// # Safety
-    /// `this` is live (registered ⇒ not yet freed by `on_response`); JS thread.
-    pub(crate) unsafe fn stop_for_vm_teardown(this: *mut Self) {
-        // SAFETY: fn contract; `http` is initialised before the task is registered.
-        unsafe {
-            (*this).signal_store.aborted.store(true, Ordering::Relaxed);
-            bun_http::http_thread().schedule_shutdown((*this).http.assume_init_ref());
-        }
+    pub(crate) fn stop_for_vm_teardown(&self) {
+        self.shared
+            .signal_store
+            .aborted
+            .store(true, Ordering::Relaxed);
+        bun_http::http_thread().schedule_shutdown_by_id(self.request.async_http_id());
+    }
+
+    /// Put the request on the HTTP thread with response-body streaming on;
+    /// `sink` gets the body on this (the JS) thread.
+    pub(crate) fn start(
+        storage: RequestStorage,
+        sink: bun_ptr::OwnedThis<S3DownloadStreamWrapper>,
+    ) {
+        let shared = Arc::new(DownloadShared {
+            progress: Guarded::default(),
+            state: AtomicU64::new(State::default().0),
+            has_schedule_callback: AtomicBool::new(false),
+            signal_store: Default::default(),
+            task: AtomicPtr::new(core::ptr::null_mut()),
+            node: ReusableConcurrentTask::default(),
+            ticket: VirtualMachine::get().ticket().in_flight(),
+        });
+        let mut request = storage.request(
+            bun_http::Method::GET,
+            Arc::clone(&shared),
+            shared.signal_store.to_with_backpressure(),
+        );
+        request.with_http_mut(|http| http.enable_response_body_streaming());
+        bun_http::http_thread::init(&Default::default());
+        let mut batch = bun_threading::thread_pool::Batch::default();
+        let request = request.start(&mut batch);
+        sink.control.set(Some(DownloadControl {
+            shared: Arc::clone(&shared),
+            async_http_id: request.async_http_id(),
+        }));
+        sink.poll_ref
+            .with_mut(|poll_ref| poll_ref.ref_(bun_io::js_vm_ctx()));
+        let task = RefPtr::new(S3HttpDownloadStreamingTask {
+            ref_count: Cell::new(1),
+            http_ref: Cell::new(None),
+            shared,
+            request,
+            sink,
+        });
+        let this = task.this_ptr();
+        this.shared.task.store(this.as_ptr(), Ordering::Release);
+        // Out on the HTTP thread until its final hop: the VM aborts it at
+        // teardown (registry) and waits for it (the ticket).
+        crate::jsc_hooks::ActiveHandle::S3Download(this.into()).register();
+        this.http_ref.set(Some(task));
+        bun_http::HTTPThread::schedule(batch);
+    }
+}
+
+// Field drop order: `request` — the HTTP thread handed it back before the
+// final hop was posted, so this frees it — then `sink`, which lets go of the
+// stream and the event loop.
+
+/// The stream side's handles on the in-flight download: abort it, or pause /
+/// resume the transport's receive (the JS-thread half of the backpressure).
+pub(crate) struct DownloadControl {
+    shared: Arc<DownloadShared>,
+    async_http_id: u32,
+}
+
+impl DownloadControl {
+    fn pause_receive(&self) {
+        self.shared.signal_store.pause_receive();
     }
 
     /// A consumer took bytes: undo a pause from either side of the hop.
-    pub(crate) fn resume_receive(&self) {
-        if self.signal_store.unpause_receive() {
+    fn resume_receive(&self) {
+        if self.shared.signal_store.unpause_receive() {
             bun_http::http_thread().schedule_receive_resume(self.async_http_id);
         }
     }
 
-    fn release_portable(&mut self) {
-        // SAFETY: `http` is always initialised before the task is scheduled / dropped.
-        let http = unsafe { self.http.assume_init_mut() };
-        http.clear_data();
-        http.request_headers = Default::default();
-        http.client.header_entries = Default::default();
+    /// Make the HTTP thread fail the request promptly, so its terminal result
+    /// comes back and the task (with this wrapper) is released.
+    fn abort(&self) {
+        self.shared
+            .signal_store
+            .aborted
+            .store(true, Ordering::Relaxed);
+        // Wake the HTTP thread so it observes the abort even when the socket is
+        // idle; otherwise the final `has_more == false` result never comes.
+        bun_http::http_thread().schedule_shutdown_by_id(self.async_http_id);
     }
 }
 
-impl Drop for S3HttpDownloadStreamingTask {
-    fn drop(&mut self) {
-        // KeepAlive::unref now takes an aio EventLoopCtx; the JS-loop ctx is fetched
-        // via the global hook (registered by crate::init) — same pattern as
-        // `S3HttpSimpleTask::drop` in simple_request.rs.
-        self.poll_ref.unref(bun_io::posix_event_loop::get_vm_ctx(
-            bun_io::AllocatorType::Js,
+/// The JS side of a streaming download: feeds each chunk to the
+/// `ReadableStream`'s `ByteStream` source and applies the receive backpressure.
+/// Owned by the task; the source holds a back-reference to it
+/// (`SourceHandle::S3DownloadBody`) that [`ProducerHold`] clears.
+pub struct S3DownloadStreamWrapper {
+    stream: ProducerHold,
+    pub path: Box<[u8]>,
+    pub global: GlobalRef,
+    /// Set once the request is in flight; taken by `on_stream_cancelled`.
+    control: JsCell<Option<DownloadControl>>,
+    /// Keeps the event loop alive for the download; let go while the stream is
+    /// parked unread, once it is cancelled, and when the download is over.
+    poll_ref: JsCell<KeepAlive>,
+}
+
+impl S3DownloadStreamWrapper {
+    /// A wrapper producing into `source` (it takes the producer ref on it).
+    pub(crate) fn new(
+        source: &mut Source,
+        path: &[u8],
+        global: GlobalRef,
+    ) -> bun_ptr::OwnedThis<Self> {
+        let this = bun_ptr::OwnedThis::new(Self {
+            stream: ProducerHold::default(),
+            path: Box::<[u8]>::from(path),
+            global,
+            control: JsCell::new(None),
+            poll_ref: JsCell::new(KeepAlive::init()),
+        });
+        this.stream.hold_source(source);
+        this
+    }
+
+    pub(crate) fn on_chunk(
+        &self,
+        chunk: &MutableString,
+        has_more: bool,
+        request_err: Option<S3Error<'_>>,
+    ) {
+        if let Some(err) = request_err {
+            let Some(bytes) = self.stream.take() else {
+                return;
+            };
+            bytes.on_data(crate::webcore::streams::StreamResult::Err(
+                crate::webcore::streams::StreamError::JSValue(bun_jsc::strong::Optional::create(
+                    s3_error_to_js(&err, &self.global, Some(&self.path)),
+                    &self.global,
+                )),
+            ));
+            return;
+        }
+        if has_more {
+            let Some(bytes) = self.stream.bytes() else {
+                return;
+            };
+            bytes.on_data(crate::webcore::streams::StreamResult::Temporary(
+                // chunk.list is borrowed for the duration of on_data.
+                bun_ptr::RawSlice::new(chunk.list.as_slice()),
+            ));
+            // `on_data` can cancel us, which releases the hold.
+            if self.stream.is_held() {
+                self.after_chunk_delivered(&bytes);
+            }
+            return;
+        }
+        let Some(bytes) = self.stream.take() else {
+            return;
+        };
+        bytes.on_data(crate::webcore::streams::StreamResult::TemporaryAndDone(
+            // chunk.list is borrowed for the duration of on_data.
+            bun_ptr::RawSlice::new(chunk.list.as_slice()),
         ));
-        // reported_response_buffer, headers, sign_result, range, proxy_url:
-        // dropped automatically (Box/Vec-backed fields).
-        self.release_portable();
+    }
+
+    /// The other half of this rule is in [`DownloadShared::process_http_callback`]
+    /// (HTTP thread).
+    fn after_chunk_delivered(&self, bytes: &ByteStream) {
+        let control = self.control.get();
+        let Some(control) = control.as_ref() else {
+            return;
+        };
+        match ProducerHold::after_delivery(bytes) {
+            AfterDelivery::Resume => control.resume_receive(),
+            AfterDelivery::Pause => control.pause_receive(),
+            AfterDelivery::Park => {
+                control.pause_receive();
+                if self.stream.park() {
+                    self.poll_ref
+                        .with_mut(|poll_ref| poll_ref.unref(bun_io::js_vm_ctx()));
+                }
+            }
+        }
+    }
+
+    fn unpark(&self) {
+        if self.stream.unpark() && self.control.get().is_some() {
+            self.poll_ref
+                .with_mut(|poll_ref| poll_ref.ref_(bun_io::js_vm_ctx()));
+        }
+    }
+
+    pub(crate) fn on_stream_drained(&self) {
+        self.unpark();
+        if let Some(control) = self.control.get().as_ref() {
+            control.resume_receive();
+        }
+    }
+
+    pub(crate) fn on_consumer_attached(&self) {
+        self.unpark();
+    }
+
+    /// The parked stream's wrapper was collected: nothing can read the rest.
+    /// Inside a GC sweep; touches no JS cell.
+    pub(crate) fn on_stream_collected(&self) {
+        self.on_stream_cancelled();
+    }
+
+    pub(crate) fn on_stream_cancelled(&self) {
+        // The download may still be in progress, but `on_chunk` will see no
+        // stream and skip delivery. When the download finishes
+        // (`has_more == false`), the task drops this wrapper with itself.
+        self.stream.release();
+        // Abort the in-flight HTTP request so that terminal result does come;
+        // without this, a server that never sends the last chunk would keep
+        // both the task and this wrapper alive.
+        if let Some(control) = self.control.replace(None) {
+            control.abort();
+            self.poll_ref
+                .with_mut(|poll_ref| poll_ref.unref(bun_io::js_vm_ctx()));
+        }
+    }
+}
+
+impl Drop for S3DownloadStreamWrapper {
+    fn drop(&mut self) {
+        self.poll_ref.get_mut_unique().unref(bun_io::js_vm_ctx());
+        // `stream` drops next and lets go of the source (clearing its
+        // producer handle), so the stream never calls back into a freed wrapper.
     }
 }
 

--- a/src/runtime/webcore/s3/download_stream.rs
+++ b/src/runtime/webcore/s3/download_stream.rs
@@ -13,7 +13,7 @@ use bun_ptr::{RefPtr, ThisPtr};
 use bun_s3_signing::error::S3Error;
 use bun_threading::Guarded;
 
-use crate::webcore::byte_stream::{AfterDelivery, ByteStream, ProducerHold, Source};
+use crate::webcore::byte_stream::{AfterDelivery, ByteStream, ProducerHold};
 use crate::webcore::s3::client::s3_error_to_js;
 use crate::webcore::s3::simple_request::RequestStorage;
 use crate::webcore::s3::xml_response;
@@ -407,7 +407,8 @@ impl DownloadControl {
 /// Owned by the task; the source holds a back-reference to it
 /// (`SourceHandle::S3DownloadBody`) that [`ProducerHold`] clears.
 pub struct S3DownloadStreamWrapper {
-    stream: ProducerHold,
+    /// The stream this download produces into, from `readable_stream` on.
+    pub(crate) stream: ProducerHold,
     pub path: Box<[u8]>,
     pub global: GlobalRef,
     /// Set once the request is in flight; taken by `on_stream_cancelled`.
@@ -418,21 +419,15 @@ pub struct S3DownloadStreamWrapper {
 }
 
 impl S3DownloadStreamWrapper {
-    /// A wrapper producing into `source` (it takes the producer ref on it).
-    pub(crate) fn new(
-        source: &mut Source,
-        path: &[u8],
-        global: GlobalRef,
-    ) -> bun_ptr::OwnedThis<Self> {
-        let this = bun_ptr::OwnedThis::new(Self {
+    /// A wrapper not yet producing into a stream (see `stream`).
+    pub(crate) fn new(path: &[u8], global: GlobalRef) -> bun_ptr::OwnedThis<Self> {
+        bun_ptr::OwnedThis::new(Self {
             stream: ProducerHold::default(),
             path: Box::<[u8]>::from(path),
             global,
             control: JsCell::new(None),
             poll_ref: JsCell::new(KeepAlive::init()),
-        });
-        this.stream.hold_source(source);
-        this
+        })
     }
 
     pub(crate) fn on_chunk(

--- a/src/runtime/webcore/s3/error_jsc.rs
+++ b/src/runtime/webcore/s3/error_jsc.rs
@@ -8,12 +8,11 @@ use bun_s3_signing::error::{self as s3_error, get_sign_error_message};
 
 pub use s3_error::S3Error;
 
-// `get_sign_error_message` returns `&'static [u8]` of ASCII literals; reinterpret as
+// `get_sign_error_message` returns `&'static [u8]` of ASCII literals; view as
 // `&str` for the `format_args!`-taking `JSGlobalObject::err()` builder.
 #[inline]
 fn msg(bytes: &'static [u8]) -> &'static str {
-    // SAFETY: every value returned by `get_sign_error_message` is an ASCII string literal.
-    unsafe { core::str::from_utf8_unchecked(bytes) }
+    core::str::from_utf8(bytes).expect("S3 sign error messages are ASCII literals")
 }
 
 pub(crate) fn get_js_sign_error(err: SignError, global_this: &JSGlobalObject) -> JSValue {

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -241,7 +241,7 @@ impl MultiPartUpload {
     /// Tell the observer `flushed` bytes drained. It is kept alive across the
     /// call: draining can complete the upload, which releases the observer.
     fn emit_writable(&self, flushed: u64) {
-        let Some(observer) = self.observer.get().as_ref().map(UploadObserver::clone) else {
+        let Some(observer) = self.observer.get().clone() else {
             return;
         };
         match &observer {

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -90,7 +90,6 @@
 //                        End
 
 use core::cell::Cell;
-use core::ffi::c_void;
 use std::io::Write as _;
 
 use bstr::BStr;
@@ -100,9 +99,8 @@ use bun_collections::IntegerBitSet;
 use bun_core::{declare_scope, scoped_log};
 use bun_io::KeepAlive;
 use bun_io::StreamBuffer;
-use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{GlobalRef, JsCell};
-use bun_ptr::RefPtr;
+use bun_ptr::{BackRef, RefPtr, Root, SelfRoot, ThisPtr};
 use bun_s3_signing::acl::ACL;
 use bun_s3_signing::credentials::S3Credentials;
 use bun_s3_signing::error::S3Error;
@@ -111,19 +109,48 @@ use bun_s3_signing::storage_class::StorageClass;
 // File-level mods are declared flat in `webcore.rs` via `#[path]`, so `super`
 // here is `crate::webcore`, not the `s3` directory. Route through the `s3`
 // re-export hub instead.
+use crate::webcore::s3::client::S3UploadStreamWrapper;
 use crate::webcore::s3::multipart_options::MultiPartUploadOptions;
 use crate::webcore::s3::simple_request::{
     self as s3_simple_request, S3CommitResult, S3DownloadResult, S3PartResult, S3UploadResult,
     execute_simple_s3_request,
 };
 use crate::webcore::s3::xml_response;
+use crate::webcore::streams::NetworkSink;
 use bun_collections::index_sort;
 
 declare_scope!(S3MultiPartUpload, hidden);
 
+/// Who is fed back the upload's drain events and outcome. The upload holds one
+/// ref on it until the outcome has been delivered.
+pub(crate) enum UploadObserver {
+    /// `s3file.writer()`: the sink behind the JS `NetworkSink` wrapper.
+    Writer(RefPtr<NetworkSink>),
+    /// `Bun.write(s3file, stream)` / `fetch("s3://…", { body: stream })`.
+    Stream(RefPtr<S3UploadStreamWrapper>),
+}
+
+impl Clone for UploadObserver {
+    fn clone(&self) -> Self {
+        match self {
+            UploadObserver::Writer(sink) => UploadObserver::Writer(sink.clone()),
+            UploadObserver::Stream(wrapper) => UploadObserver::Stream(wrapper.clone()),
+        }
+    }
+}
+
+/// Reference-counted: `lifecycle` (released once the upload settles — after
+/// the commit/rollback for a multipart one), the sink feeding it
+/// (`NetworkSink::task`), the stream wrapper (`S3UploadStreamWrapper::task`)
+/// and every request in flight each hold a [`RefPtr`].
 #[derive(bun_ptr::CellRefCounted)]
 pub struct MultiPartUpload {
-    pub(crate) root: Cell<Option<core::ptr::NonNull<MultiPartUpload>>>,
+    pub(crate) root: SelfRoot<MultiPartUpload>,
+    /// The upload's own ref, released when it settles (`done` / `fail` /
+    /// commit / rollback).
+    pub(crate) lifecycle: Cell<Option<RefPtr<MultiPartUpload>>>,
+    /// Taken when the outcome is delivered.
+    pub(crate) observer: JsCell<Option<UploadObserver>>,
     pub(crate) queue: JsCell<Option<Box<[UploadPart]>>>,
     pub(crate) available: Cell<IntegerBitSet<{ Self::MAX_QUEUE_SIZE }>>,
 
@@ -137,7 +164,6 @@ pub struct MultiPartUpload {
     pub(crate) request_payer: bool,
     pub(crate) credentials: RefPtr<S3Credentials>,
     pub poll_ref: JsCell<KeepAlive>,
-    pub(crate) vm: &'static VirtualMachine,
     // JSC_BORROW per LIFETIMES.tsv row 1886 — rust_type `&JSGlobalObject` used verbatim
     pub global_this: GlobalRef,
 
@@ -157,12 +183,6 @@ pub struct MultiPartUpload {
     pub(crate) multipart_upload_list: JsCell<Vec<u8>>, // was bun.Vec<u8>
 
     pub(crate) state: Cell<State>,
-
-    /// Completion. The upload is passed so `uploaded_bytes` can be read by a callee that no
-    /// longer holds a ref to it (a `writer()` sink whose JS wrapper was collected).
-    pub callback: fn(&MultiPartUpload, S3UploadResult, *mut c_void) -> bun_jsc::JsResult<()>,
-    pub(crate) on_writable: Option<fn(&MultiPartUpload, *mut c_void, u64)>,
-    pub(crate) callback_context: Cell<*mut c_void>,
 }
 
 #[repr(u8)]
@@ -179,35 +199,58 @@ pub enum State {
 impl MultiPartUpload {
     const MAX_QUEUE_SIZE: usize = MultiPartUploadOptions::MAX_QUEUE_SIZE as usize;
     const MAX_UPLOAD_ID_LEN: usize = 2000;
-    // `const AWS = S3Credentials;` — type alias unused in this file; dropped.
 
-    // bun.ptr.RefCount(Self, "ref_count", deinit, .{}) — intrusive refcount.
-    // `ref_()`/`deref()` are provided by `#[derive(CellRefCounted)]`.
-    // Inherent associated types (`pub type Ref = ...` inside `impl`) are
-    // unstable; the alias lives at module scope as `MultiPartUploadRef`.
-    /// # Safety
-    /// `this` must be a live heap-allocated `MultiPartUpload` created via
-    /// `heap::alloc` with a non-zero intrusive refcount.
     #[inline]
-    // Forwards `this` to the derived intrusive-rc decrement without dereferencing it here;
-    // not_unsafe_ptr_arg_deref is a false positive on opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn deref_(this: *mut Self) {
-        // SAFETY: per fn contract — forwarded to the derived intrusive-rc decrement.
-        unsafe { <Self as bun_ptr::CellRefCounted>::deref(this) }
+    fn this_ptr(&self) -> ThisPtr<MultiPartUpload> {
+        self.root.this_ptr(self)
     }
 
-    #[inline]
-    fn root_ptr(&self) -> *mut MultiPartUpload {
-        self.root
-            .get()
-            .expect("MultiPartUpload root set at construction")
-            .as_ptr()
+    fn release_lifecycle(&self) {
+        let lifecycle = self.lifecycle.take();
+        debug_assert!(lifecycle.is_some(), "upload settled twice");
+        if let Some(lifecycle) = lifecycle {
+            drop(lifecycle);
+        }
     }
 
-    #[inline]
-    fn as_ctx_ptr(&self) -> *mut c_void {
-        self.root_ptr().cast::<c_void>()
+    /// The stream wrapper observing this upload, if that is who observes it.
+    pub(crate) fn stream_wrapper(&self) -> Option<ThisPtr<S3UploadStreamWrapper>> {
+        match self.observer.get().as_ref() {
+            Some(UploadObserver::Stream(wrapper)) => Some(wrapper.this_ptr()),
+            _ => None,
+        }
+    }
+
+    /// Hand the outcome to the observer (once) and release the ref held on it.
+    fn settle(&self, result: S3UploadResult) -> bun_jsc::JsResult<()> {
+        let Some(observer) = self.observer.replace(None) else {
+            return Ok(());
+        };
+        let settled = match &observer {
+            UploadObserver::Writer(sink) => {
+                crate::webcore::s3::client::writer_settled(sink.this_ptr(), self, result)
+            }
+            UploadObserver::Stream(wrapper) => {
+                S3UploadStreamWrapper::resolve(wrapper.this_ptr(), result)
+            }
+        };
+        drop(observer);
+        settled
+    }
+
+    /// Tell the observer `flushed` bytes drained. It is kept alive across the
+    /// call: draining can complete the upload, which releases the observer.
+    fn emit_writable(&self, flushed: u64) {
+        let Some(observer) = self.observer.get().as_ref().map(UploadObserver::clone) else {
+            return;
+        };
+        match &observer {
+            UploadObserver::Writer(sink) => sink.on_writable(flushed),
+            UploadObserver::Stream(wrapper) => {
+                S3UploadStreamWrapper::on_writable(wrapper, self, flushed)
+            }
+        }
+        drop(observer);
     }
 }
 
@@ -222,11 +265,10 @@ pub enum PartState {
 }
 
 pub struct UploadPart {
-    /// Raw owned slice; backing allocation length is `allocated_size` (may exceed `data.len()`).
-    /// Freed via `free_allocated_slice`. Default is a static empty slice.
-    pub(crate) data: Cell<*const [u8]>,
-    pub ctx: bun_ptr::BackRef<MultiPartUpload, bun_ptr::Mut>, // BACKREF (LIFETIMES.tsv)
-    pub(crate) allocated_size: Cell<usize>,
+    /// This part's bytes: a copy of a `part_size` window of the upload's
+    /// buffer, or the whole buffer taken over when it was exactly one part.
+    pub(crate) data: JsCell<Vec<u8>>,
+    pub ctx: BackRef<MultiPartUpload, Root>,
     pub(crate) state: Cell<PartState>,
     pub(crate) part_number: Cell<u16>, // max is 10,000
     pub(crate) retry: Cell<u8>,        // auto retry, decrement until 0 and fail after this
@@ -239,39 +281,26 @@ pub struct UploadPartResult {
 }
 
 impl UploadPart {
-    fn free_allocated_slice(&self) {
-        let allocated_size = self.allocated_size.get();
-        if allocated_size > 0 {
-            // SAFETY: `data.ptr` was allocated by the global allocator with capacity == allocated_size
-            // (either via `to_vec().into_boxed_slice()` where len==cap, or by taking ownership of
-            // StreamBuffer's backing allocation). Reconstruct and drop.
-            unsafe {
-                let ptr = (*self.data.get()).as_ptr().cast_mut();
-                drop(Vec::from_raw_parts(ptr, allocated_size, allocated_size));
-            }
-        }
-        self.data.set(std::ptr::from_ref::<[u8]>(b"" as &[u8]));
-        self.allocated_size.set(0);
+    fn free_data(&self) {
+        self.data.set(Vec::new());
     }
 
-    #[inline]
-    fn data(&self) -> &[u8] {
-        // SAFETY: data is either a static empty slice or a live heap slice owned by this part
-        unsafe { &*self.data.get() }
-    }
-
-    fn on_part_response(result: S3PartResult, this: *mut c_void) -> bun_jsc::JsResult<()> {
-        // SAFETY: callback context — `this` is the queue slot passed in `perform()`; the
-        // ref this part holds on `ctx` keeps the queue alive until the tail `deref_` below.
-        let this = unsafe { &*this.cast::<Self>() };
-        let ctx_ptr = this.ctx.as_ptr();
-        let ctx = this.ctx.get();
+    /// The response for part `index` of `upload` (which this request held a
+    /// ref on; released here unless the part is retried with it).
+    fn on_part_response(
+        upload: RefPtr<MultiPartUpload>,
+        index: usize,
+        result: S3PartResult,
+    ) -> bun_jsc::JsResult<()> {
+        let ctx = upload.this_ptr();
+        let queue = ctx.queue.get().as_deref().expect("part queue");
+        let this = &queue[index];
         let part_number = this.part_number.get();
 
         if this.state.get() == PartState::Canceled || ctx.state.get() == State::Finished {
             scoped_log!(S3MultiPartUpload, "onPartResponse {} canceled", part_number);
-            this.free_allocated_slice();
-            MultiPartUpload::deref_(ctx_ptr);
+            this.free_data();
+            drop(upload);
             return Ok(());
         }
 
@@ -284,21 +313,21 @@ impl UploadPart {
                     scoped_log!(S3MultiPartUpload, "onPartResponse {} retry", part_number);
                     this.retry.set(retry - 1);
                     // retry failed
-                    this.perform()
+                    this.perform(upload)
                 } else {
                     scoped_log!(S3MultiPartUpload, "onPartResponse {} failed", part_number);
                     this.state.set(PartState::NotAssigned);
-                    this.free_allocated_slice();
+                    this.free_data();
                     // The ctx deref must run after fail():
                     let r = ctx.fail(err);
-                    MultiPartUpload::deref_(ctx_ptr);
+                    drop(upload);
                     r
                 }
             }
             S3PartResult::Etag(etag) => {
                 scoped_log!(S3MultiPartUpload, "onPartResponse {} success", part_number);
-                let sent = this.data().len();
-                this.free_allocated_slice();
+                let sent = this.data.get().len();
+                this.free_data();
                 // we will need to order this
                 ctx.multipart_etags.with_mut(|etags| {
                     etags.push(UploadPartResult {
@@ -314,13 +343,14 @@ impl UploadPart {
                 // The ctx deref must run after drain_enqueued_parts():
                 // drain more
                 let r = ctx.drain_enqueued_parts(sent as u64);
-                MultiPartUpload::deref_(ctx_ptr);
+                drop(upload);
                 r
             }
         }
     }
 
-    fn perform(&self) -> bun_jsc::JsResult<()> {
+    /// PUT this part; `upload` is the ref the request holds on the upload.
+    fn perform(&self, upload: RefPtr<MultiPartUpload>) -> bun_jsc::JsResult<()> {
         let ctx = self.ctx.get();
         let mut params_buffer = [0u8; 2048];
         let written = {
@@ -335,21 +365,21 @@ impl UploadPart {
             2048 - w.len()
         };
         let search_params = &params_buffer[..written];
+        let index = self.index.get() as usize;
         execute_simple_s3_request(
             &ctx.credentials,
             s3_simple_request::S3RequestOptions {
                 path: &ctx.path,
                 method: bun_http::Method::PUT,
                 proxy_url: ctx.proxy_url(),
-                body: self.data(),
+                body: self.data.get(),
                 search_params: Some(search_params),
                 request_payer: ctx.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::part(
-                Self::on_part_response,
-                std::ptr::from_ref::<Self>(self).cast_mut().cast::<c_void>(),
-            ),
+            s3_simple_request::S3Callback::Part(Box::new(move |result| {
+                Self::on_part_response(upload, index, result)
+            })),
         )
     }
 
@@ -358,9 +388,9 @@ impl UploadPart {
         if self.state.get() != PartState::Pending || ctx.state.get() != State::MultipartCompleted {
             return Ok(());
         }
-        ctx.ref_();
+        let upload = RefPtr::from_this(self.ctx.this_ptr());
         self.state.set(PartState::Started);
-        self.perform()
+        self.perform(upload)
     }
 
     fn cancel(&self) {
@@ -368,7 +398,7 @@ impl UploadPart {
 
         match state {
             PartState::Pending => {
-                self.free_allocated_slice();
+                self.free_data();
             }
             // if is not pending we will free later or is already freed
             _ => {}
@@ -379,33 +409,24 @@ impl UploadPart {
 impl Drop for MultiPartUpload {
     fn drop(&mut self) {
         scoped_log!(S3MultiPartUpload, "deinit");
-        // queue: Box<[UploadPart]> — dropped automatically (parts' raw `data` already freed during lifecycle)
-        // KeepAlive::unref takes an `EventLoopCtx` (aio cycle-break vtable),
-        // not `&VirtualMachine`. Route through the global hook like simple_request does.
-        let _ = self.vm;
-        self.poll_ref.with_mut(|poll_ref| {
-            poll_ref.unref(bun_io::posix_event_loop::get_vm_ctx(
-                bun_io::AllocatorType::Js,
-            ))
-        });
+        self.poll_ref
+            .with_mut(|poll_ref| poll_ref.unref(bun_io::js_vm_ctx()));
     }
 }
 
 impl MultiPartUpload {
+    /// The response to the single PUT; `upload` is the ref that request held,
+    /// released here (or carried into the retry).
     pub(crate) fn single_send_upload_response(
+        upload: RefPtr<Self>,
         result: S3UploadResult,
-        this: *mut c_void,
     ) -> bun_jsc::JsResult<()> {
-        let this = this.cast::<Self>();
-        // SAFETY: callback context — `this` is live; this takes over the ref
-        // `process_buffered` (or the retry path) took for this request.
-        let _guard = unsafe { RefPtr::from_raw(this) };
-        // SAFETY: `this` is live for at least the guard's duration.
-        let self_ = unsafe { &*this };
+        let self_ = upload.this_ptr();
         if self_.state.get() == State::Finished {
+            drop(upload);
             return Ok(());
         }
-        match result {
+        let settled = match result {
             S3UploadResult::Failure(err) => {
                 let mut options = self_.options.get();
                 if options.retry > 0 {
@@ -416,59 +437,50 @@ impl MultiPartUpload {
                     );
                     options.retry -= 1;
                     self_.options.set(options);
-                    self_.ref_();
-                    execute_simple_s3_request(
-                        &self_.credentials,
-                        s3_simple_request::S3RequestOptions {
-                            path: &self_.path,
-                            method: bun_http::Method::PUT,
-                            proxy_url: self_.proxy_url(),
-                            body: self_.buffered.get().slice(),
-                            content_type: self_.content_type.as_deref(),
-                            content_disposition: self_.content_disposition.as_deref(),
-                            content_encoding: self_.content_encoding.as_deref(),
-                            acl: self_.acl,
-                            storage_class: self_.storage_class,
-                            request_payer: self_.request_payer,
-                            ..Default::default()
-                        },
-                        s3_simple_request::S3Callback::upload(
-                            Self::single_send_upload_response,
-                            this.cast::<c_void>(),
-                        ),
-                    )
-                } else {
-                    scoped_log!(S3MultiPartUpload, "singleSendUploadResponse failed");
-                    self_.fail(err)
+                    return self_.send_single(upload);
                 }
+                scoped_log!(S3MultiPartUpload, "singleSendUploadResponse failed");
+                self_.fail(err)
             }
             S3UploadResult::Success => {
                 scoped_log!(S3MultiPartUpload, "singleSendUploadResponse success");
-
-                if let Some(callback) = self_.on_writable {
-                    callback(
-                        self_,
-                        self_.callback_context.get(),
-                        self_.buffered.get().size() as u64,
-                    );
-                }
+                self_.emit_writable(self_.buffered.get().size() as u64);
                 self_.done()
             }
-        }
+        };
+        drop(upload);
+        settled
     }
 
-    /// This is the only place we allocate the queue or the parts, this is responsible for the flow of parts and the max allowed concurrency
-    fn get_create_part(
-        &self,
-        chunk: &[u8],
-        allocated_size: usize,
-        needs_clone: bool,
-    ) -> Option<&UploadPart> {
+    /// PUT the whole buffer as one object; `upload` is the ref the request holds.
+    fn send_single(&self, upload: RefPtr<Self>) -> bun_jsc::JsResult<()> {
+        execute_simple_s3_request(
+            &self.credentials,
+            s3_simple_request::S3RequestOptions {
+                path: &self.path,
+                method: bun_http::Method::PUT,
+                proxy_url: self.proxy_url(),
+                body: self.buffered.get().slice(),
+                content_type: self.content_type.as_deref(),
+                content_disposition: self.content_disposition.as_deref(),
+                content_encoding: self.content_encoding.as_deref(),
+                acl: self.acl,
+                storage_class: self.storage_class,
+                request_payer: self.request_payer,
+                ..Default::default()
+            },
+            s3_simple_request::S3Callback::Upload(Box::new(move |result| {
+                Self::single_send_upload_response(upload, result)
+            })),
+        )
+    }
+
+    /// Claim a free queue slot for the next part, allocating the queue on
+    /// first use. `None` when the queue (or the allowed concurrency) is full.
+    fn claim_part_slot(&self) -> Option<usize> {
         let mut available = self.available.get();
-        let Some(index) = available.find_first_set() else {
-            // this means that the queue is full and we cannot flush it
-            return None;
-        };
+        // `None` means that the queue is full and we cannot flush it
+        let index = available.find_first_set()?;
         let queue_size = self.options.get().queue_size as usize;
         if index >= queue_size {
             // ops too much concurrency wait more
@@ -477,17 +489,15 @@ impl MultiPartUpload {
         available.unset(index);
         self.available.set(available);
         if self.queue.get().is_none() {
-            // SAFETY: `root_ptr()` is this heap-stable allocation's root (write
-            // provenance); every in-flight `UploadPart` holds a ref so it
+            // Every in-flight `UploadPart` holds a ref on the upload, so it
             // outlives the part (BackRef invariant).
-            let self_ref = unsafe { bun_ptr::BackRef::from_raw_mut(self.root_ptr()) };
+            let self_ref = self.root.backref(self);
             // queueSize will never change and is small (max 255)
             let mut queue: Vec<UploadPart> = Vec::with_capacity(queue_size);
             // zero set just in case
             for _ in 0..queue_size {
                 queue.push(UploadPart {
-                    data: Cell::new(std::ptr::from_ref::<[u8]>(b"" as &[u8])),
-                    allocated_size: Cell::new(0),
+                    data: JsCell::new(Vec::new()),
                     part_number: Cell::new(0),
                     ctx: self_ref,
                     index: Cell::new(0),
@@ -497,26 +507,22 @@ impl MultiPartUpload {
             }
             self.queue.set(Some(queue.into_boxed_slice()));
         }
-        let (data, allocated_len): (*const [u8], usize) = if needs_clone {
-            let owned = Box::<[u8]>::from(chunk);
-            let len = owned.len();
-            (bun_core::heap::into_raw(owned).cast_const(), len)
-        } else {
-            (std::ptr::from_ref::<[u8]>(chunk), allocated_size)
-        };
+        Some(index)
+    }
 
+    /// This is the only place we allocate the queue or the parts, this is responsible for the flow of parts and the max allowed concurrency
+    fn create_part(&self, index: usize, data: Vec<u8>) -> &UploadPart {
         let part_number = self.current_part_number.get();
         self.current_part_number.set(part_number + 1);
 
         let queue = self.queue.get().as_deref().expect("queue allocated above");
         let queue_item = &queue[index];
         queue_item.data.set(data);
-        queue_item.allocated_size.set(allocated_len);
         queue_item.part_number.set(part_number);
         queue_item.index.set(index as u8); // @truncate
         queue_item.retry.set(self.options.get().retry);
         queue_item.state.set(PartState::Pending);
-        Some(queue_item)
+        queue_item
     }
 
     /// Drain the parts, this is responsible for starting the parts and processing the buffered data
@@ -543,18 +549,14 @@ impl MultiPartUpload {
 
         // empty queue
         if self.is_queue_empty() {
-            if let Some(callback) = self.on_writable {
-                callback(self, self.callback_context.get(), flushed);
-            }
+            self.emit_writable(flushed);
             // `on_writable` may re-enter and enqueue a final part; re-check.
             if self.ended.get() && self.is_queue_empty() {
                 self.done()?;
             }
         } else if !self.has_backpressure() && flushed > 0 {
             // we have more space in the queue, we can drain more
-            if let Some(callback) = self.on_writable {
-                callback(self, self.callback_context.get(), flushed);
-            }
+            self.emit_writable(flushed);
         }
         Ok(())
     }
@@ -576,11 +578,7 @@ impl MultiPartUpload {
         }
         if self.state.get() != State::Finished {
             let old_state = self.state.replace(State::Finished);
-            (self.callback)(
-                self,
-                S3UploadResult::Failure(err),
-                self.callback_context.get(),
-            )?;
+            self.settle(S3UploadResult::Failure(err))?;
 
             if old_state == State::MultipartCompleted {
                 // we are a multipart upload so we need to rollback
@@ -588,7 +586,7 @@ impl MultiPartUpload {
                 self.rollback_multi_part_request()?;
             } else {
                 // single file upload no need to rollback
-                MultiPartUpload::deref_(self.root_ptr());
+                self.release_lifecycle();
             }
         }
         Ok(())
@@ -627,24 +625,20 @@ impl MultiPartUpload {
             self.state.set(State::Finished);
             // single file upload no need to commit
             // The deref must run after the callback:
-            let r = (self.callback)(self, S3UploadResult::Success, self.callback_context.get());
-            MultiPartUpload::deref_(self.root_ptr());
+            let r = self.settle(S3UploadResult::Success);
+            self.release_lifecycle();
             r
         } else {
             Ok(())
         }
     }
 
-    /// Result of the Multipart request, after this we can start draining the parts
-    pub(crate) fn start_multi_part_request_result(
+    /// Result of the Multipart request, after this we can start draining the
+    /// parts. The caller holds a ref across the call.
+    fn start_multi_part_request_result(
+        self_: ThisPtr<Self>,
         result: S3DownloadResult,
-        this: *mut c_void,
     ) -> bun_jsc::JsResult<()> {
-        let this = this.cast::<Self>();
-        // SAFETY: callback context — takes over the ref taken before the request was queued.
-        let _guard = unsafe { RefPtr::from_raw(this) };
-        // SAFETY: `this` is live for at least the guard's duration.
-        let self_ = unsafe { &*this };
         if self_.state.get() == State::Finished {
             return Ok(());
         }
@@ -713,15 +707,13 @@ impl MultiPartUpload {
         }
     }
 
-    /// We do a best effort to commit the multipart upload, if it fails we will retry, if it still fails we will fail the upload
+    /// We do a best effort to commit the multipart upload, if it fails we will retry, if it still fails we will fail the upload.
+    /// `lifecycle` is the upload's own ref, released once this settles.
     pub(crate) fn on_commit_multi_part_request(
+        lifecycle: RefPtr<Self>,
         result: S3CommitResult,
-        this: *mut c_void,
     ) -> bun_jsc::JsResult<()> {
-        let this = this.cast::<Self>();
-        // SAFETY: callback context — `this` is live; the request owns the final-step ref,
-        // released as the tail statement below.
-        let self_ = unsafe { &*this };
+        let self_ = lifecycle.this_ptr();
         scoped_log!(
             S3MultiPartUpload,
             "onCommitMultiPartRequest {}",
@@ -735,39 +727,33 @@ impl MultiPartUpload {
                     options.retry -= 1;
                     self_.options.set(options);
                     // retry commit
+                    self_.lifecycle.set(Some(lifecycle));
                     self_.commit_multi_part_request()?;
                     return Ok(());
                 }
                 self_.state.set(State::Finished);
                 // The deref must run after the callback:
-                let r = (self_.callback)(
-                    self_,
-                    S3UploadResult::Failure(err),
-                    self_.callback_context.get(),
-                );
-                MultiPartUpload::deref_(this);
+                let r = self_.settle(S3UploadResult::Failure(err));
+                drop(lifecycle);
                 r
             }
             S3CommitResult::Success => {
                 self_.state.set(State::Finished);
                 // The deref must run after the callback:
-                let r =
-                    (self_.callback)(self_, S3UploadResult::Success, self_.callback_context.get());
-                MultiPartUpload::deref_(this);
+                let r = self_.settle(S3UploadResult::Success);
+                drop(lifecycle);
                 r
             }
         }
     }
 
-    /// We do a best effort to rollback the multipart upload, if it fails we will retry, if it still we just deinit the upload
+    /// We do a best effort to rollback the multipart upload, if it fails we will retry, if it still we just deinit the upload.
+    /// `lifecycle` is the upload's own ref, released once this settles.
     pub(crate) fn on_rollback_multi_part_request(
+        lifecycle: RefPtr<Self>,
         result: S3UploadResult,
-        this: *mut c_void,
     ) -> bun_jsc::JsResult<()> {
-        let this = this.cast::<Self>();
-        // SAFETY: callback context — `this` is live; the request owns the final-step ref,
-        // released as the tail statement below.
-        let self_ = unsafe { &*this };
+        let self_ = lifecycle.this_ptr();
         scoped_log!(
             S3MultiPartUpload,
             "onRollbackMultiPartRequest {}",
@@ -780,14 +766,15 @@ impl MultiPartUpload {
                     options.retry -= 1;
                     self_.options.set(options);
                     // retry rollback
+                    self_.lifecycle.set(Some(lifecycle));
                     self_.rollback_multi_part_request()?;
                     return Ok(());
                 }
-                MultiPartUpload::deref_(this);
+                drop(lifecycle);
                 Ok(())
             }
             S3UploadResult::Success => {
-                MultiPartUpload::deref_(this);
+                drop(lifecycle);
                 Ok(())
             }
         }
@@ -807,6 +794,11 @@ impl MultiPartUpload {
         };
         let search_params = &params_buffer[..written];
 
+        // Rides on the upload's own ref: the final step.
+        let lifecycle = self
+            .lifecycle
+            .take()
+            .expect("multipart commit holds the upload's lifecycle ref");
         execute_simple_s3_request(
             &self.credentials,
             s3_simple_request::S3RequestOptions {
@@ -818,10 +810,9 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::commit(
-                Self::on_commit_multi_part_request,
-                self.as_ctx_ptr(),
-            ),
+            s3_simple_request::S3Callback::Commit(Box::new(move |result| {
+                Self::on_commit_multi_part_request(lifecycle, result)
+            })),
         )
     }
 
@@ -839,6 +830,11 @@ impl MultiPartUpload {
         };
         let search_params = &params_buffer[..written];
 
+        // Rides on the upload's own ref: the final step.
+        let lifecycle = self
+            .lifecycle
+            .take()
+            .expect("multipart rollback holds the upload's lifecycle ref");
         execute_simple_s3_request(
             &self.credentials,
             s3_simple_request::S3RequestOptions {
@@ -850,27 +846,24 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::upload(
-                Self::on_rollback_multi_part_request,
-                self.as_ctx_ptr(),
-            ),
+            s3_simple_request::S3Callback::Upload(Box::new(move |result| {
+                Self::on_rollback_multi_part_request(lifecycle, result)
+            })),
         )
     }
 
-    fn enqueue_part(
-        &self,
-        chunk: &[u8],
-        allocated_size: usize,
-        needs_clone: bool,
-    ) -> bun_jsc::JsResult<bool> {
-        let Some(part) = self.get_create_part(chunk, allocated_size, needs_clone) else {
+    /// Queue `data` as the next part (if a slot is free) and start whatever
+    /// can start. `data` is only called for once a slot is claimed.
+    fn enqueue_part(&self, data: impl FnOnce() -> Vec<u8>) -> bun_jsc::JsResult<bool> {
+        let Some(index) = self.claim_part_slot() else {
             return Ok(false);
         };
+        let part = self.create_part(index, data());
 
         if self.state.get() == State::NotStarted {
             // will auto start later
             self.state.set(State::MultipartStarted);
-            self.ref_();
+            let upload = RefPtr::from_this(self.this_ptr());
             execute_simple_s3_request(
                 &self.credentials,
                 s3_simple_request::S3RequestOptions {
@@ -887,10 +880,12 @@ impl MultiPartUpload {
                     request_payer: self.request_payer,
                     ..Default::default()
                 },
-                s3_simple_request::S3Callback::download(
-                    Self::start_multi_part_request_result,
-                    self.as_ctx_ptr(),
-                ),
+                s3_simple_request::S3Callback::Download(Box::new(move |result| {
+                    // `upload` is the ref this request held.
+                    let settled = Self::start_multi_part_request_result(upload.this_ptr(), result);
+                    drop(upload);
+                    settled
+                })),
             )?;
         } else if self.state.get() == State::MultipartCompleted {
             part.start()?;
@@ -928,27 +923,16 @@ impl MultiPartUpload {
             }
             // if is one big chunk we can pass ownership and avoid dupe
             if self.buffered.get().cursor == 0 && self.buffered.get().size() == len {
-                let owned = self.buffered.replace(StreamBuffer::default());
-                // we need to know the allocated size to free the memory later
-                let allocated_size = owned.memory_cost();
-                let slice_len = owned.slice().len();
-
+                let slice_len = len;
                 // we dont care about the result because we are sending everything
-                if self.enqueue_part(owned.slice(), allocated_size, false)? {
+                if self.enqueue_part(|| self.buffered.replace(StreamBuffer::default()).list)? {
                     scoped_log!(
                         S3MultiPartUpload,
                         "processMultiPart {} {} full buffer enqueued",
                         BStr::new(&self.path),
                         slice_len
                     );
-                    let _ = core::mem::ManuallyDrop::new(owned);
                     return Ok(());
-                }
-                let appended = self.buffered.replace(owned);
-                if appended.is_not_empty() {
-                    self.buffered
-                        .with_mut(|b| b.write(appended.slice()).map(|_| ()))
-                        .unwrap_or(());
                 }
                 scoped_log!(
                     S3MultiPartUpload,
@@ -960,10 +944,8 @@ impl MultiPartUpload {
                 return Ok(());
             }
 
-            let slice_ptr = std::ptr::from_ref::<[u8]>(&self.buffered.get().slice()[..len]);
             // allocated size is the slice len because we dupe the buffer
-            // SAFETY: slice_ptr points at self.buffered's storage which is not mutated until after enqueue_part dupes it
-            if self.enqueue_part(unsafe { &*slice_ptr }, len, true)? {
+            if self.enqueue_part(|| self.buffered.get().slice()[..len].to_vec())? {
                 scoped_log!(
                     S3MultiPartUpload,
                     "processMultiPart {} {} slice enqueued",
@@ -1006,27 +988,7 @@ impl MultiPartUpload {
             );
             self.state.set(State::SinglefileStarted);
             // we can do only 1 request
-            self.ref_();
-            let _ = execute_simple_s3_request(
-                &self.credentials,
-                s3_simple_request::S3RequestOptions {
-                    path: &self.path,
-                    method: bun_http::Method::PUT,
-                    proxy_url: self.proxy_url(),
-                    body: self.buffered.get().slice(),
-                    content_type: self.content_type.as_deref(),
-                    content_disposition: self.content_disposition.as_deref(),
-                    content_encoding: self.content_encoding.as_deref(),
-                    acl: self.acl,
-                    storage_class: self.storage_class,
-                    request_payer: self.request_payer,
-                    ..Default::default()
-                },
-                s3_simple_request::S3Callback::upload(
-                    Self::single_send_upload_response,
-                    self.as_ctx_ptr(),
-                ),
-            ); // TODO: properly propagate exception upwards
+            let _ = self.send_single(RefPtr::from_this(self.this_ptr())); // TODO: properly propagate exception upwards
         } else {
             // we need to split
             let _ = self.process_multi_part(part_size); // TODO: properly propagate exception upwards
@@ -1077,7 +1039,7 @@ impl MultiPartUpload {
 
     // The encoding is a plain runtime arg — the three thin wrappers below
     // pass a constant, so the optimizer still specializes each branch.
-    fn write(
+    pub(crate) fn write_encoded(
         &self,
         encoding: WriteEncoding,
         chunk: &[u8],
@@ -1087,8 +1049,7 @@ impl MultiPartUpload {
             return Ok(UploadBackpressure::Done); // no backpressure since we are done
         }
         // we may call done inside processBuffered so we ensure that we keep a ref until we are done
-        // SAFETY: `self` is live; `root_ptr()` carries the allocation's provenance.
-        let _guard = unsafe { RefPtr::init_ref(self.root_ptr()) };
+        let _deref_guard = RefPtr::from_this(self.this_ptr());
 
         if self.state.get() == State::WaitStreamCheck && chunk.is_empty() && is_last {
             // we do this because stream will close if the file dont exists and we dont wanna to send an empty part in this case
@@ -1133,28 +1094,12 @@ impl MultiPartUpload {
         })
     }
 
-    pub(crate) fn write_latin1(
-        &self,
-        chunk: &[u8],
-        is_last: bool,
-    ) -> Result<UploadBackpressure, AllocError> {
-        self.write(WriteEncoding::Latin1, chunk, is_last)
-    }
-
-    pub(crate) fn write_utf16(
-        &self,
-        chunk: &[u8],
-        is_last: bool,
-    ) -> Result<UploadBackpressure, AllocError> {
-        self.write(WriteEncoding::Utf16, chunk, is_last)
-    }
-
     pub(crate) fn write_bytes(
         &self,
         chunk: &[u8],
         is_last: bool,
     ) -> Result<UploadBackpressure, AllocError> {
-        self.write(WriteEncoding::Bytes, chunk, is_last)
+        self.write_encoded(WriteEncoding::Bytes, chunk, is_last)
     }
 }
 
@@ -1166,7 +1111,7 @@ pub enum UploadBackpressure {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub(crate) enum WriteEncoding {
+pub enum WriteEncoding {
     Bytes,
     Latin1,
     Utf16,

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -1,22 +1,25 @@
-use core::ffi::c_void;
-use core::sync::atomic::Ordering;
+use core::cell::Cell;
+use core::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::Arc;
 
 use bun_core::MutableString;
-use bun_event_loop::ConcurrentTask::{AutoDeinit, ConcurrentTask};
-use bun_event_loop::{TaskTag, Taskable, task_tag};
+use bun_event_loop::ConcurrentTask::ConcurrentTask;
+use bun_event_loop::{ReusableConcurrentTask, Task, TaskHop, TaskTag, task_tag};
 use bun_http::async_http::Options as HttpOptions;
 use bun_http::{
-    AsyncHTTP, FetchRedirect, HTTPClientResult, HTTPClientResultCallback, Headers, HeadersExt,
-    Method,
+    AsyncHTTP, FetchRedirect, HTTPClientResult, HTTPClientResultCallback, HTTPClientResultHandler,
+    Headers, HeadersExt, InFlight, Method, OwnedRequest, Signals,
 };
 use bun_io::KeepAlive;
+use bun_jsc::InFlightTicket;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_picohttp as picohttp;
+use bun_ptr::{RefPtr, ThisPtr};
 use bun_s3_signing::acl::ACL;
 use bun_s3_signing::credentials::{S3Credentials, SignOptions, SignResult};
 use bun_s3_signing::error::{S3Error, get_sign_error_code_and_message};
 use bun_s3_signing::storage_class::StorageClass;
-use bun_threading::thread_pool;
+use bun_threading::{Guarded, thread_pool};
 use bun_url::URL;
 
 use crate::webcore::s3::{list_objects, xml_response};
@@ -105,46 +108,164 @@ pub enum S3PartResult<'a> {
     Failure(S3Error<'a>),
 }
 
-pub struct S3HttpSimpleTask {
-    // `http` is `MaybeUninit` because (a) it is initialised late —
-    // `AsyncHTTP` contains `&'static [u8]` and `fn(...)` fields, so a
-    // zeroed/default value would be instant UB; and (b) `Drop` only calls
-    // `http.clear_data()`, never a full destructor, and `http_callback` does a no-drop bitwise
-    // overwrite. Wrapping in `MaybeUninit` makes both possible: write-without-
-    // drop on assignment, and `clear_data()`-only in `Drop`. Invariant: `http` is initialised by
-    // `execute_simple_s3_request` before the task pointer escapes, so every later access (in
-    // `http_callback` / `Drop`) may `assume_init`.
-    pub(crate) http: core::mem::MaybeUninit<AsyncHTTP<'static>>,
-    /// Held while the request is out on the HTTP thread: how it delivers the
-    /// response, and what makes the VM wait for it.
-    pub(crate) http_ticket: Option<bun_jsc::Ticket>,
+/// What a request out on the HTTP thread borrows (URL, header buffer, body,
+/// proxy): kept, untouched, until the HTTP thread hands the request back.
+pub(crate) struct RequestStorage {
     pub(crate) sign_result: SignResult,
     pub(crate) headers: Headers,
-    /// `Some` until the response (or failure) is delivered.
-    pub callback: Option<Callback>,
-    pub(crate) response_buffer: MutableString,
-    pub(crate) result: HTTPClientResult<'static>,
-    pub(crate) concurrent_task: ConcurrentTask,
-    /// Owned dupe of the proxy URL. The env-derived proxy slice can be freed
-    /// by a concurrent process.env.HTTP_PROXY write while the HTTP thread is
-    /// in flight, so we must own our copy for the task's lifetime.
-    pub(crate) proxy_url: Box<[u8]>,
-    /// Owned copy of the request body. The HTTP thread reads the body slice
-    /// concurrently for the lifetime of the request, so the task owns its own
-    /// copy instead of borrowing caller memory.
+    /// Owned copy of the request body: the HTTP thread reads it for the
+    /// lifetime of the request.
     pub(crate) body: Box<[u8]>,
-    pub poll_ref: KeepAlive,
-    /// The HTTP client's abort flag: set by the VM's stop phase so a request
-    /// still queued or in flight fails promptly and comes back.
-    pub(crate) signal_store: bun_http::signals::Store,
+    /// Owned copy of the proxy URL: a concurrent `process.env.HTTP_PROXY`
+    /// write can free the env-derived slice while the request is in flight.
+    pub(crate) proxy_url: Box<[u8]>,
 }
 
-impl Taskable for S3HttpSimpleTask {
+impl RequestStorage {
+    /// The request for `sign_result.url` with these headers and body,
+    /// delivering its results to `handler` on the HTTP thread.
+    pub(crate) fn request<H: HTTPClientResultHandler>(
+        self,
+        method: Method,
+        handler: Arc<H>,
+        signals: Signals,
+    ) -> OwnedRequest<Self> {
+        let vm = VirtualMachine::get();
+        let verbose = vm.get_verbose_fetch();
+        let reject_unauthorized = vm.get_tls_reject_unauthorized();
+        OwnedRequest::new(self, |storage| {
+            AsyncHTTP::init(
+                method,
+                URL::parse(&storage.sign_result.url),
+                storage.headers.entries.clone().expect("OOM"),
+                storage.headers.buf.as_slice(),
+                &storage.body,
+                HTTPClientResultCallback::from_handler(handler),
+                FetchRedirect::Follow,
+                HttpOptions {
+                    http_proxy: (!storage.proxy_url.is_empty())
+                        .then(|| URL::parse(&storage.proxy_url)),
+                    verbose: Some(verbose),
+                    reject_unauthorized: Some(reject_unauthorized),
+                    signals: Some(signals),
+                    ..Default::default()
+                },
+            )
+        })
+    }
+
+    pub(crate) fn owned_proxy(proxy_url: Option<&[u8]>) -> Box<[u8]> {
+        match proxy_url {
+            Some(proxy) if !proxy.is_empty() => Box::<[u8]>::from(proxy),
+            _ => Box::default(),
+        }
+    }
+}
+
+/// What the HTTP thread produced, for the JS thread to consume.
+#[derive(Default)]
+struct Response {
+    buffer: MutableString,
+    result: HTTPClientResult<'static>,
+}
+
+/// The part of a simple request shared with the HTTP thread: `bun_http` holds
+/// it (as the request's result handler) until the terminal result; the task
+/// for its whole life.
+pub(crate) struct Shared {
+    response: Guarded<Response>,
+    /// The HTTP client's abort flag: set by the VM's stop phase so a request
+    /// still queued or in flight fails promptly and comes back.
+    signal_store: bun_http::signals::Store,
+    /// The task's address for the JS-thread hop; set once, before the request
+    /// is scheduled. The task keeps itself alive for the hop (`http_ref`).
+    task: AtomicPtr<S3HttpSimpleTask>,
+    /// The hop's queue node (posted once).
+    node: ReusableConcurrentTask,
+    /// How the HTTP thread posts to the JS thread, and what makes the VM wait
+    /// for it; handed back right after the hop is posted.
+    ticket: InFlightTicket,
+}
+
+impl Shared {
+    fn stage(&self, mut result: HTTPClientResult<'_>) {
+        let mut response = self.response.lock();
+        let previous_metadata = response.result.metadata.take();
+        result.body_into(&mut response.buffer.list);
+        response.result = result.into_owned();
+        if response.result.metadata.is_none() {
+            response.result.metadata = previous_metadata;
+        }
+    }
+
+    /// HTTP thread, nothing more to deliver: post the response hop and give
+    /// the ticket back.
+    fn hand_back(&self) {
+        let task = Task::new(
+            task_tag::S3HttpSimpleTask,
+            self.task.load(Ordering::Acquire).cast::<()>(),
+        );
+        let node = self
+            .node
+            .arm(task)
+            .unwrap_or_else(|| ConcurrentTask::create(task));
+        self.ticket.post(node);
+        self.ticket.hand_back();
+    }
+}
+
+impl HTTPClientResultHandler for Shared {
+    /// HTTP thread: fold `result` into the response; the terminal one posts it
+    /// to the JS thread.
+    fn on_result(&self, result: HTTPClientResult<'_>) {
+        let is_done = !result.has_more;
+        self.stage(result);
+        if is_done {
+            self.hand_back();
+        }
+    }
+
+    /// The exiting main thread parked the HTTP thread, which will not call
+    /// back; hand the request back as failed so its VM's wait ends and the JS
+    /// thread releases it.
+    fn release_at_shutdown(&self) {
+        {
+            let mut response = self.response.lock();
+            response.result.fail = Some(bun_http::Error::Aborted);
+            response.result.has_more = false;
+        }
+        self.hand_back();
+    }
+}
+
+/// One S3 request (stat / download / upload / delete / list / a multipart
+/// step). Lives on the JS thread; the HTTP thread only sees [`Shared`].
+#[derive(bun_ptr::CellRefCounted)]
+pub struct S3HttpSimpleTask {
+    ref_count: Cell<u32>,
+    /// The ref the response hop (and the teardown registry) reach this task
+    /// through; released by `on_response`.
+    http_ref: Cell<Option<RefPtr<S3HttpSimpleTask>>>,
+    shared: Arc<Shared>,
+    /// The request out on (or back from) the HTTP thread; taken back on drop.
+    request: InFlight<RequestStorage>,
+    /// `Some` until the response (or failure) is delivered.
+    callback: Cell<Option<Callback>>,
+    poll_ref: KeepAlive,
+}
+
+/// `task_tag::S3HttpSimpleTask`: the HTTP thread handed the request back.
+pub struct ResponseHop;
+impl TaskHop for ResponseHop {
+    type Target = S3HttpSimpleTask;
     const TAG: TaskTag = task_tag::S3HttpSimpleTask;
-    /// A response the HTTP thread handed back during teardown: its native
-    /// completion is what frees the caller's context (and settles a promise
-    /// nobody can observe — script is forbidden), so run it.
-    unsafe fn release_unrun(this: *mut Self) {
+    fn run(this: ThisPtr<S3HttpSimpleTask>) -> bun_jsc::JsResult<()> {
+        S3HttpSimpleTask::on_response(this)
+    }
+    /// The VM is tearing down: the native completion is what releases the
+    /// caller's state (and settles a promise nobody can observe — script is
+    /// forbidden), so run it.
+    fn release_unrun(this: ThisPtr<S3HttpSimpleTask>) {
         let _ = S3HttpSimpleTask::on_response(this);
     }
 }
@@ -165,8 +286,8 @@ pub type CommitCallback = Box<dyn FnOnce(S3CommitResult<'_>) -> bun_jsc::JsResul
 pub type PartCallback = Box<dyn FnOnce(S3PartResult<'_>) -> bun_jsc::JsResult<()>>;
 
 /// What a simple request delivers its outcome to: one completion, called
-/// once. Whatever it captures (a promise, a store ref, a raw context a
-/// C-style receiver recovers) is the receiver's.
+/// once. Whatever it captures (a promise, a store ref, an upload ref) is the
+/// receiver's.
 pub enum Callback {
     Stat(StatCallback),
     Download(DownloadCallback),
@@ -178,42 +299,6 @@ pub enum Callback {
 }
 
 impl Callback {
-    /// Adapt a C-style `(fn, ctx)` receiver.
-    pub fn stat(
-        f: fn(S3StatResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>,
-        ctx: *mut c_void,
-    ) -> Self {
-        Callback::Stat(Box::new(move |r| f(r, ctx)))
-    }
-    /// Adapt a C-style `(fn, ctx)` receiver.
-    pub fn download(
-        f: fn(S3DownloadResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>,
-        ctx: *mut c_void,
-    ) -> Self {
-        Callback::Download(Box::new(move |r| f(r, ctx)))
-    }
-    /// Adapt a C-style `(fn, ctx)` receiver.
-    pub fn upload(
-        f: fn(S3UploadResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>,
-        ctx: *mut c_void,
-    ) -> Self {
-        Callback::Upload(Box::new(move |r| f(r, ctx)))
-    }
-    /// Adapt a C-style `(fn, ctx)` receiver.
-    pub fn commit(
-        f: fn(S3CommitResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>,
-        ctx: *mut c_void,
-    ) -> Self {
-        Callback::Commit(Box::new(move |r| f(r, ctx)))
-    }
-    /// Adapt a C-style `(fn, ctx)` receiver.
-    pub fn part(
-        f: fn(S3PartResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>,
-        ctx: *mut c_void,
-    ) -> Self {
-        Callback::Part(Box::new(move |r| f(r, ctx)))
-    }
-
     fn fail(self, code: &[u8], message: &[u8]) -> bun_jsc::JsResult<()> {
         let err = S3Error { code, message };
         match self {
@@ -249,18 +334,7 @@ enum ErrorType {
     Failure,
 }
 
-impl S3HttpSimpleTask {
-    const HOLDS_TICKET: &str = "S3 request on the HTTP thread holds a ticket";
-
-    // bun.TrivialNew(@This()) — heap-allocate; pointer crosses thread boundary via http callback
-    pub(crate) fn new(init: Self) -> *mut Self {
-        bun_core::heap::into_raw(Box::new(init))
-    }
-
-    fn take_callback(&mut self) -> Callback {
-        self.callback.take().expect("S3 request completes once")
-    }
-
+impl Response {
     fn error_with_body(&self, callback: Callback, error_type: ErrorType) -> bun_jsc::JsResult<()> {
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
@@ -270,7 +344,7 @@ impl S3HttpSimpleTask {
             code = err.name().as_bytes();
             has_error_code = true;
         } else {
-            let bytes = self.response_buffer.list.as_slice();
+            let bytes = self.buffer.list.as_slice();
             if !bytes.is_empty() {
                 message = bytes;
                 parsed = xml_response::parse_error(bytes);
@@ -311,7 +385,7 @@ impl S3HttpSimpleTask {
         if let Some(err) = self.result.fail {
             code = err.name().as_bytes();
         } else {
-            let bytes = self.response_buffer.list.as_slice();
+            let bytes = self.buffer.list.as_slice();
             if !bytes.is_empty() {
                 message = bytes;
             }
@@ -328,30 +402,16 @@ impl S3HttpSimpleTask {
         Ok(None)
     }
 
-    /// this is the task callback from the last task result and is always in the main thread
-    ///
-    /// # Safety
-    /// `this` must be a live heap pointer produced by `S3HttpSimpleTask::new` whose ownership
-    /// is being transferred to this call (it is reclaimed and dropped here exactly once).
-    //
-    // ConcurrentTask dispatch entrypoint (see `runtime::dispatch`): `this` is the raw task
-    // pointer the queue hands back, non-null by the `ConcurrentTask::from` contract.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn on_response(this: *mut Self) -> bun_jsc::JsResult<()> {
-        crate::jsc_hooks::ActiveHandle::S3Request(core::ptr::NonNull::new(this).expect("task"))
-            .unregister();
-        // SAFETY: `this` was produced by `S3HttpSimpleTask::new` (heap::alloc) and ownership is
-        // reclaimed here exactly once via the ConcurrentTask `AutoDeinit::ManualDeinit` contract;
-        // `this` is dropped at scope exit.
-        let mut this = unsafe { bun_core::heap::take(this) };
-
-        let callback = this.take_callback();
-        if !this.result.is_success() {
-            this.error_with_body(callback, ErrorType::Failure)?;
+    /// Hand the outcome to `callback`. JS thread.
+    fn deliver(mut self, callback: Callback) -> bun_jsc::JsResult<()> {
+        if !self.result.is_success() {
+            self.error_with_body(callback, ErrorType::Failure)?;
             return Ok(());
         }
-        debug_assert!(this.result.metadata.is_some());
-        let response = &this.result.metadata.as_ref().unwrap().response;
+        debug_assert!(self.result.metadata.is_some());
+        // Moved out so the `Download` arm can take `buffer` while reading headers.
+        let metadata = self.result.metadata.take().unwrap();
+        let response = &metadata.response;
         match callback {
             Callback::Stat(callback) => match response.status_code {
                 200 => {
@@ -366,17 +426,17 @@ impl S3HttpSimpleTask {
                             .unwrap_or(0),
                     }))?;
                 }
-                404 => this.error_with_body(Callback::Stat(callback), ErrorType::NotFound)?,
-                _ => this.error_with_body(Callback::Stat(callback), ErrorType::Failure)?,
+                404 => self.error_with_body(Callback::Stat(callback), ErrorType::NotFound)?,
+                _ => self.error_with_body(Callback::Stat(callback), ErrorType::Failure)?,
             },
             Callback::Delete(callback) => match response.status_code {
                 200 | 204 => callback(S3DeleteResult::Success)?,
-                404 => this.error_with_body(Callback::Delete(callback), ErrorType::NotFound)?,
-                _ => this.error_with_body(Callback::Delete(callback), ErrorType::Failure)?,
+                404 => self.error_with_body(Callback::Delete(callback), ErrorType::NotFound)?,
+                _ => self.error_with_body(Callback::Delete(callback), ErrorType::Failure)?,
             },
             Callback::ListObjects(callback) => match response.status_code {
                 200 => {
-                    let body = this.response_buffer.list.as_slice();
+                    let body = self.buffer.list.as_slice();
                     let result = match list_objects::parse_s3_list_objects_result(body) {
                         Some(listing) => S3ListObjectsResult::Success(Box::new(listing)),
                         // Half a listing is worse than none: S3 emits keys
@@ -390,165 +450,112 @@ impl S3HttpSimpleTask {
                     callback(result)?;
                 }
                 404 => {
-                    this.error_with_body(Callback::ListObjects(callback), ErrorType::NotFound)?
+                    self.error_with_body(Callback::ListObjects(callback), ErrorType::NotFound)?
                 }
-                _ => this.error_with_body(Callback::ListObjects(callback), ErrorType::Failure)?,
+                _ => self.error_with_body(Callback::ListObjects(callback), ErrorType::Failure)?,
             },
             Callback::Upload(callback) => match response.status_code {
                 200 => callback(S3UploadResult::Success)?,
-                _ => this.error_with_body(Callback::Upload(callback), ErrorType::Failure)?,
+                _ => self.error_with_body(Callback::Upload(callback), ErrorType::Failure)?,
             },
             Callback::Download(callback) => match response.status_code {
                 200 | 204 | 206 => {
-                    let body = core::mem::take(&mut this.response_buffer);
+                    let body = core::mem::take(&mut self.buffer);
                     callback(S3DownloadResult::Success(S3DownloadSuccess { body }))?;
                 }
-                404 => this.error_with_body(Callback::Download(callback), ErrorType::NotFound)?,
-                _ => this.error_with_body(Callback::Download(callback), ErrorType::Failure)?,
+                404 => self.error_with_body(Callback::Download(callback), ErrorType::NotFound)?,
+                _ => self.error_with_body(Callback::Download(callback), ErrorType::Failure)?,
             },
             commit @ Callback::Commit(_) => {
                 // commit multipart upload can fail with status 200
                 if let Some(Callback::Commit(callback)) =
-                    this.fail_if_contains_error(response.status_code, commit)?
+                    self.fail_if_contains_error(response.status_code, commit)?
                 {
                     callback(S3CommitResult::Success)?;
                 }
             }
             part @ Callback::Part(_) => {
-                if let Some(part) = this.fail_if_contains_error(response.status_code, part)? {
+                if let Some(part) = self.fail_if_contains_error(response.status_code, part)? {
                     if let Some(etag) = response.headers.get(b"etag") {
                         let Callback::Part(callback) = part else {
                             unreachable!()
                         };
                         callback(S3PartResult::Etag(etag))?;
                     } else {
-                        this.error_with_body(part, ErrorType::Failure)?;
+                        self.error_with_body(part, ErrorType::Failure)?;
                     }
                 }
             }
         }
         Ok(())
     }
+}
 
-    fn stage_http_result(
-        &mut self,
-        async_http: *mut AsyncHTTP<'static>,
-        mut result: HTTPClientResult<'_>,
-    ) {
-        let previous_metadata = self.result.metadata.take();
-        result.body_into(&mut self.response_buffer.list);
-        // SAFETY: `result.body` (the only borrowed field) points at `self.response_buffer`,
-        // which lives for the task's lifetime — extending to `'static` here is sound for
-        // self-reference.
-        self.result = unsafe { result.detach_lifetime() };
-        if self.result.metadata.is_none() {
-            self.result.metadata = previous_metadata;
-        }
-        // `AsyncHTTP` transitively owns Drop types (`HTTPClient`, header
-        // `EntryList`s), so a plain `=` here would (a) drop the old `self.http`, freeing heap
-        // buffers that `*async_http` (a bitwise clone created by the HTTP thread) still
-        // aliases, and (b) leave the http-thread side to drop them again → double-free. We
-        // instead write through `MaybeUninit` to suppress the LHS drop, doing a bitwise struct
-        // overwrite with no destructor on either side. Ownership of the inner heap data
-        // conceptually transfers here; the http-thread side must free only its outer
-        // allocation (TrivialDeinit).
-        // SAFETY: `async_http` is a valid live pointer for the duration of this callback;
-        // `self.http` was previously initialised in `execute_simple_s3_request`.
-        unsafe { core::ptr::write(self.http.as_mut_ptr(), core::ptr::read(async_http)) };
-    }
-
-    /// this is the AsyncHTTP callback and is always called from the HTTPThread
-    ///
-    /// # Safety
-    /// `this` must be a live heap pointer produced by `S3HttpSimpleTask::new` and exclusively
-    /// owned by the HTTP thread for the duration of this call. `async_http` must be a valid
-    /// pointer to an initialised `AsyncHTTP` for the duration of this call.
-    //
-    // `HTTPClientResultCallback` entrypoint: invoked by the HTTP thread with the raw task and
-    // request pointers it captured at schedule time, both non-null by construction.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn http_callback(
-        this: *mut Self,
-        async_http: *mut AsyncHTTP<'static>,
-        result: HTTPClientResult<'_>,
-    ) {
-        let is_done = !result.has_more;
-        // SAFETY: `this` was produced by `S3HttpSimpleTask::new` and is exclusively owned
-        // by the HTTP thread until the handoff below; this borrow is scoped to the call.
-        unsafe { (*this).stage_http_result(async_http, result) };
-        if is_done {
-            // SAFETY: same exclusivity as above; the queue takes ownership of the inline
-            // `concurrent_task` field's `next` link. The ticket is moved out first: the
-            // JS thread may free `this` the moment it is queued.
-            unsafe {
-                let ticket = (*this).http_ticket.take().expect(Self::HOLDS_TICKET);
-                let queued = core::ptr::NonNull::from(
-                    (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit),
-                );
-                ticket.post(queued);
-            }
-        }
-    }
-
-    /// `HTTPClientResultCallback::release_at_shutdown`: the exiting main
-    /// thread parked the HTTP thread, which will not call back; hand the
-    /// request back as failed so its VM's wait ends and the JS thread frees it.
-    ///
-    /// # Safety
-    /// `this` is the live task registered with the callback; HTTP thread parked.
-    pub(crate) unsafe fn release_at_shutdown(this: *mut ()) {
-        let this = this.cast::<Self>();
-        // SAFETY: fn contract — nothing else touches the task now.
-        unsafe {
-            (*this).result.fail = Some(bun_http::Error::Aborted);
-            (*this).result.has_more = false;
-            let ticket = (*this).http_ticket.take().expect(Self::HOLDS_TICKET);
-            let queued = core::ptr::NonNull::from(
-                (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit),
-            );
-            ticket.post(queued);
-        }
+impl S3HttpSimpleTask {
+    /// The response hop (JS thread): the HTTP thread is done with the request.
+    /// Delivers the outcome, then releases the task.
+    fn on_response(this: ThisPtr<Self>) -> bun_jsc::JsResult<()> {
+        crate::jsc_hooks::ActiveHandle::S3Request(this.into()).unregister();
+        let http_ref = this
+            .http_ref
+            .take()
+            .expect("S3 request is handed back once");
+        let callback = this.callback.take().expect("S3 request completes once");
+        let response = core::mem::take(&mut *this.shared.response.lock());
+        let delivered = response.deliver(callback);
+        drop(http_ref);
+        delivered
     }
 
     /// VM teardown's stop phase (JS thread): abort the transport so the HTTP
     /// thread fails the request promptly and hands it back.
-    ///
-    /// # Safety
-    /// `this` is live (registered ⇒ its response has not run); JS thread.
-    pub(crate) unsafe fn stop_for_vm_teardown(this: *mut Self) {
-        // SAFETY: fn contract; `http` is initialised before the task is registered.
-        unsafe {
-            (*this).signal_store.aborted.store(true, Ordering::Relaxed);
-            bun_http::http_thread().schedule_shutdown((*this).http.assume_init_ref());
-        }
+    pub(crate) fn stop_for_vm_teardown(&self) {
+        self.shared
+            .signal_store
+            .aborted
+            .store(true, Ordering::Relaxed);
+        bun_http::http_thread().schedule_shutdown_by_id(self.request.async_http_id());
     }
 
-    fn release_portable(&mut self) {
-        // SAFETY: `http` is always initialised before the task pointer escapes (see
-        // `execute_simple_s3_request`).
-        let http = unsafe { self.http.assume_init_mut() };
-        http.clear_data();
-        http.request_headers = Default::default();
-        http.client.header_entries = Default::default();
+    /// Put the request on the HTTP thread; `callback` gets the outcome on this
+    /// (the JS) thread.
+    pub(crate) fn start(method: Method, storage: RequestStorage, callback: Callback) {
+        let shared = Arc::new(Shared {
+            response: Guarded::default(),
+            signal_store: Default::default(),
+            task: AtomicPtr::new(core::ptr::null_mut()),
+            node: ReusableConcurrentTask::default(),
+            ticket: VirtualMachine::get().ticket().in_flight(),
+        });
+        let request = storage.request(method, Arc::clone(&shared), shared.signal_store.to());
+        bun_http::http_thread::init(&Default::default());
+        let mut batch = thread_pool::Batch::default();
+        let request = request.start(&mut batch);
+        let mut poll_ref = KeepAlive::init();
+        poll_ref.ref_(bun_io::js_vm_ctx());
+        let task = RefPtr::new(S3HttpSimpleTask {
+            ref_count: Cell::new(1),
+            http_ref: Cell::new(None),
+            shared,
+            request,
+            callback: Cell::new(Some(callback)),
+            poll_ref,
+        });
+        let this = task.this_ptr();
+        this.shared.task.store(this.as_ptr(), Ordering::Release);
+        // Out on the HTTP thread until the response hop: the VM aborts it at
+        // teardown (registry) and waits for it (the ticket).
+        crate::jsc_hooks::ActiveHandle::S3Request(this.into()).register();
+        this.http_ref.set(Some(task));
+        bun_http::HTTPThread::schedule(batch);
     }
 }
 
 impl Drop for S3HttpSimpleTask {
     fn drop(&mut self) {
-        // Side effects beyond freeing owned fields (which Rust drops automatically):
-        // - poll_ref.unref(vm)
-        // - http.clearData()
-        // Owned-field frees (response_buffer, headers, sign_result, range,
-        // proxy_url, result.certificate_info, result.metadata) are handled by their own Drop impls.
-        // KeepAlive::unref takes an aio EventLoopCtx; the JS-loop ctx is fetched via
-        // the global hook (registered by crate::init) — same pattern as
-        // `event_loop_handle_to_ctx` in process.rs.
-        self.poll_ref.unref(bun_io::posix_event_loop::get_vm_ctx(
-            bun_io::AllocatorType::Js,
-        ));
-        // Only `http.clear_data()` runs — never a full AsyncHTTP destructor —
-        // so we intentionally do NOT `assume_init_drop`.
-        self.release_portable();
+        self.poll_ref.unref(bun_io::js_vm_ctx());
+        // `request` drops next: the HTTP thread handed it back before the
+        // response hop was posted, so this frees it.
     }
 }
 
@@ -658,96 +665,15 @@ pub(crate) fn execute_simple_s3_request(
         }
     };
 
-    let mut poll_ref = KeepAlive::init();
-    poll_ref.ref_(bun_io::posix_event_loop::get_vm_ctx(
-        bun_io::AllocatorType::Js,
-    ));
-    let proxy = options.proxy_url.unwrap_or(b"");
-    let task_ptr = S3HttpSimpleTask::new(S3HttpSimpleTask {
-        // written below via `MaybeUninit::write` before any read.
-        http: core::mem::MaybeUninit::uninit(),
-        sign_result: result,
-        callback: Some(callback),
-        headers,
-        http_ticket: None,
-        response_buffer: MutableString::default(),
-        result: HTTPClientResult::default(),
-        concurrent_task: ConcurrentTask::default(),
-        proxy_url: if !proxy.is_empty() {
-            Box::<[u8]>::from(proxy)
-        } else {
-            Box::default()
-        },
-        body: Box::<[u8]>::from(options.body),
-        poll_ref,
-        signal_store: Default::default(),
-    });
-    // SAFETY: `task_ptr` is a freshly heap-allocated pointer; shared reads only until
-    // the scoped exclusive `http` writes below.
-    let task = unsafe { &*task_ptr };
-    // SAFETY: lifetime extension — `url`, `headers_buf`, and `proxy_url` borrow from
-    // heap-allocated fields of `*task` (sign_result.url / headers.buf / proxy_url) which the task
-    // outlives. AsyncHTTP::init wants `'static` borrows because the HTTP thread reads them
-    // concurrently; they remain valid until `task` is dropped in `on_response`.
-    let url = URL::parse(unsafe { bun_ptr::detach_lifetime_ref(&*task.sign_result.url) });
-    // SAFETY: same lifetime-extension invariant as `url` above — `task.headers.buf` is heap-owned
-    // by `*task` and outlives the AsyncHTTP request.
-    let headers_buf: &'static [u8] =
-        unsafe { bun_ptr::detach_lifetime(task.headers.buf.as_slice()) };
-    // SAFETY: same lifetime-extension invariant as `url` above — `task.body` is a heap-owned
-    // `Box<[u8]>` field of `*task` (an owned copy of the caller's slice) and outlives the
-    // AsyncHTTP request; it is freed only when `task` is dropped in `on_response`.
-    let body: &'static [u8] = unsafe { bun_ptr::detach_lifetime(&*task.body) };
-    let http_proxy = if !task.proxy_url.is_empty() {
-        // SAFETY: same lifetime-extension invariant as `url` above — `task.proxy_url` is a
-        // heap-owned `Box<[u8]>` field of `*task` and outlives the AsyncHTTP request.
-        Some(URL::parse(unsafe {
-            bun_ptr::detach_lifetime_ref(&*task.proxy_url)
-        }))
-    } else {
-        None
-    };
-    let vm = VirtualMachine::get();
-    let verbose = vm.get_verbose_fetch();
-    let reject_unauthorized = vm.get_tls_reject_unauthorized();
-    let async_http = AsyncHTTP::init(
+    S3HttpSimpleTask::start(
         options.method,
-        url,
-        task.headers.entries.clone().expect("OOM"),
-        headers_buf,
-        body,
-        HTTPClientResultCallback::new_with_release::<S3HttpSimpleTask>(
-            task_ptr,
-            // SAFETY: `task_ptr` was just heap-allocated above and `async_http` is supplied by
-            // the HTTP thread as a live pointer for the duration of the callback.
-            S3HttpSimpleTask::http_callback,
-            S3HttpSimpleTask::release_at_shutdown,
-        ),
-        FetchRedirect::Follow,
-        HttpOptions {
-            http_proxy,
-            verbose: Some(verbose),
-            reject_unauthorized: Some(reject_unauthorized),
-            // SAFETY: `task_ptr` outlives the request; the store is only read
-            // through these pointers by the HTTP client.
-            signals: Some(unsafe { (*task_ptr).signal_store.to() }),
-            ..Default::default()
+        RequestStorage {
+            sign_result: result,
+            headers,
+            body: Box::<[u8]>::from(options.body),
+            proxy_url: RequestStorage::owned_proxy(options.proxy_url),
         },
+        callback,
     );
-    // SAFETY: `task_ptr` is still the sole pointer (the HTTP thread only sees it after
-    // `schedule` below); scoped exclusive write of the `http` field.
-    unsafe { (*task_ptr).http.write(async_http) };
-    // queue http request
-    bun_http::http_thread::init(&Default::default());
-    let mut batch = thread_pool::Batch::default();
-    // SAFETY: `http` was initialised immediately above; scoped exclusive access.
-    unsafe { (*task_ptr).http.assume_init_mut() }.schedule(&mut batch);
-    // Out on the HTTP thread until its final callback: the VM aborts it at
-    // teardown (registry) and waits for it (the ticket).
-    // SAFETY: as above.
-    unsafe { (*task_ptr).http_ticket = Some(VirtualMachine::get().ticket()) };
-    crate::jsc_hooks::ActiveHandle::S3Request(core::ptr::NonNull::new(task_ptr).expect("task"))
-        .register();
-    bun_http::HTTPThread::schedule(batch);
     Ok(())
 }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1,7 +1,7 @@
 use core::ffi::c_void;
 use core::ptr::NonNull;
 
-use bun_ptr::{BackRef, RawSlice, RefPtr};
+use bun_ptr::{BackRef, RawSlice};
 
 use crate::webcore::jsc::{
     self as jsc, ArrayBuffer, CommonAbortReason, CommonAbortReasonExt as _, JSGlobalObject,

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -30,7 +30,7 @@ type ByteListPoolNode = bun_collections::pool::Node<Vec<u8>>;
 // for callers that still spell it that way.
 pub mod bun_s3 {
     pub use crate::webcore::s3::MultiPartUpload;
-    pub use crate::webcore::s3::multipart::UploadBackpressure;
+    pub use crate::webcore::s3::multipart::{UploadBackpressure, WriteEncoding};
 }
 
 /// `Blob.SizeType` is `u64` (see `webcore::blob::SizeType`).
@@ -890,7 +890,7 @@ pub enum SourceHandle {
     ShellWritable(BackRef<crate::shell::subproc::Writable, bun_ptr::Mut>),
     FetchResponseBody(BackRef<crate::webcore::fetch::fetch_tasklet::FetchTasklet, bun_ptr::Mut>),
     ServerRequestBody(crate::server::AnyRequestContext),
-    S3DownloadBody(BackRef<crate::webcore::s3::client::S3DownloadStreamWrapper>),
+    S3DownloadBody(BackRef<crate::webcore::s3::download_stream::S3DownloadStreamWrapper>),
     HTMLRewriter(BackRef<crate::api::html_rewriter::RewriterPipe>),
     /// `bun:internal-for-testing` only: `ready()` re-enters the stream's
     /// `on_cancel`, making consumed-during-`signal_drained` re-entrancy
@@ -2115,10 +2115,22 @@ pub type HTTPResponseSink = HTTPServerWritable<false>;
 // NetworkSink
 // ──────────────────────────────────────────────────────────────────────────
 
+/// The sink side of an S3 upload: `s3file.writer()` (a JS `NetworkSink`
+/// wrapper owns it) or the stream pump of `Bun.write(s3file, stream)` (the
+/// `S3UploadStreamWrapper` owns it). Reference-counted: those owners, and the
+/// `MultiPartUpload` it feeds while it waits to report the upload's outcome,
+/// each hold a [`RefPtr`](bun_ptr::RefPtr).
+#[derive(bun_ptr::CellRefCounted)]
 pub struct NetworkSink {
-    /// The sink's ref on the upload, released in `detach_writable`.
-    pub task: Option<RefPtr<bun_s3::MultiPartUpload>>,
-    pub(crate) source: SourceHandle,
+    ref_count: core::cell::Cell<u32>,
+    root: bun_ptr::SelfRoot<NetworkSink>,
+    /// The ref the JS wrapper created by [`to_js`](Self::to_js) holds through
+    /// `m_ctx`; released by `finalize`.
+    js_ref: core::cell::Cell<Option<bun_ptr::RefPtr<NetworkSink>>>,
+    /// The upload this sink feeds, until it settles or the sink is finalized
+    /// (`detach_writable`).
+    pub task: bun_jsc::JsCell<Option<bun_ptr::RefPtr<bun_s3::MultiPartUpload>>>,
+    pub(crate) source: core::cell::Cell<SourceHandle>,
     // JSC_BORROW: process-lifetime VM global; safe `Deref` via `BackRef`.
     pub global_this: Option<BackRef<JSGlobalObject>>,
     /// Pending `flush()` promise. Serves both the user `s3file.writer().flush()`
@@ -2127,41 +2139,41 @@ pub struct NetworkSink {
     /// Resolved by `on_writable`. The `readStreamIntoSink` pump no longer calls
     /// `flush()` — it resumes via `source.ready()` → `m_onPull` — so no promise
     /// is allocated on that path.
-    pub(crate) flush_promise: JSPromiseStrong,
+    pub(crate) flush_promise: bun_jsc::JsCell<JSPromiseStrong>,
     /// Backpressure promise returned from `write()` to a JS controller;
     /// resolved by `on_writable` → `pending.run()`.
-    pub(crate) pending: WritablePending,
-    pub(crate) end_promise: JSPromiseStrong,
+    pub(crate) pending: bun_jsc::JsCell<WritablePending>,
+    pub(crate) end_promise: bun_jsc::JsCell<JSPromiseStrong>,
     /// Upstream ByteStream error stashed by `end_from_stream` so the upload
     /// failure callback can reject with the original JS error (e.g. S3
     /// `NoSuchKey`) instead of the generic `UnknownError` passed to `fail()`.
-    pub(crate) upstream_error: jsc::strong::Optional,
-    pub(crate) ended: bool,
-    pub(crate) done: bool,
-    /// `s3file.writer()`: the box is referenced by the JS wrapper (`finalize`) and by the upload's
-    /// completion callback; whichever lets go last frees it. 0 = owned elsewhere
-    /// (`S3UploadStreamWrapper`).
-    pub(crate) writer_holders: core::cell::Cell<u8>,
-}
-
-impl Default for NetworkSink {
-    fn default() -> Self {
-        Self {
-            task: None,
-            source: SourceHandle::default(),
-            global_this: None,
-            flush_promise: JSPromiseStrong::default(),
-            pending: WritablePending::default(),
-            end_promise: JSPromiseStrong::default(),
-            upstream_error: jsc::strong::Optional::empty(),
-            ended: false,
-            done: false,
-            writer_holders: core::cell::Cell::new(0),
-        }
-    }
+    pub(crate) upstream_error: bun_jsc::JsCell<jsc::strong::Optional>,
+    pub(crate) ended: core::cell::Cell<bool>,
+    pub(crate) done: core::cell::Cell<bool>,
 }
 
 impl NetworkSink {
+    /// A sink feeding `task` (one ref, released by `detach_writable`).
+    pub(crate) fn new(
+        task: bun_ptr::RefPtr<bun_s3::MultiPartUpload>,
+        global_this: &JSGlobalObject,
+    ) -> bun_ptr::RefPtr<NetworkSink> {
+        bun_ptr::RefPtr::new_cyclic(|root| NetworkSink {
+            ref_count: core::cell::Cell::new(1),
+            root,
+            js_ref: core::cell::Cell::new(None),
+            task: bun_jsc::JsCell::new(Some(task)),
+            source: core::cell::Cell::new(SourceHandle::None),
+            global_this: Some(BackRef::new(global_this)),
+            flush_promise: bun_jsc::JsCell::new(JSPromiseStrong::default()),
+            pending: bun_jsc::JsCell::new(WritablePending::default()),
+            end_promise: bun_jsc::JsCell::new(JSPromiseStrong::default()),
+            upstream_error: bun_jsc::JsCell::new(jsc::strong::Optional::empty()),
+            ended: core::cell::Cell::new(false),
+            done: core::cell::Cell::new(false),
+        })
+    }
+
     /// Borrow the JS global stored at construction.
     ///
     /// Invariant: `global_this` is set at construction and the VM-owned global
@@ -2174,113 +2186,74 @@ impl NetworkSink {
             .get()
     }
 
-    /// Shared borrow of the upload task, if attached.
+    /// The upload, if still attached. A dispatch handle, not a borrow: the
+    /// upload's own completion (reached from `write`/`end`) detaches it.
     #[inline]
-    fn task_ref(&self) -> Option<&bun_s3::MultiPartUpload> {
-        self.task.as_deref()
+    fn task_ref(&self) -> Option<bun_ptr::ThisPtr<bun_s3::MultiPartUpload>> {
+        self.task.get().as_ref().map(bun_ptr::RefPtr::this_ptr)
     }
 
-    pub(crate) fn new(init: NetworkSink) -> Box<NetworkSink> {
-        Box::new(init)
-    }
-
-    pub fn path(&self) -> Option<&[u8]> {
-        if let Some(task) = self.task_ref() {
-            return Some(&task.path);
-        }
-        None
-    }
-
-    pub(crate) fn start(&mut self, _stream_start: &Start) -> bun_sys::Result<()> {
-        if self.ended {
+    pub(crate) fn start(&self, _stream_start: &Start) -> bun_sys::Result<()> {
+        if self.ended.get() {
             return bun_sys::Result::Ok(());
         }
 
-        self.source.start();
+        self.source.get().start();
         bun_sys::Result::Ok(())
     }
 
-    pub fn finalize(&mut self) {
-        self.detach_writable();
-    }
-
-    /// One of the `writer_holders` is done with the box.
-    ///
-    /// # Safety
-    /// `this` is the live heap box from `writable()`; not used by the caller afterwards.
-    pub(crate) unsafe fn release_writer_holder(this: *mut NetworkSink) {
-        // SAFETY: fn contract.
-        unsafe {
-            let holders = (*this).writer_holders.get();
-            if holders == 0 {
-                return;
-            }
-            (*this).writer_holders.set(holders - 1);
-            if holders == 1 {
-                drop(bun_core::heap::take(this));
-            }
+    pub(crate) fn detach_writable(&self) {
+        if let Some(task) = self.task.replace(None) {
+            drop(task);
         }
-    }
-
-    fn detach_writable(&mut self) {
-        self.task = None;
     }
 
     /// The S3 upload drained: settle the flush/write promises (terminal, like
     /// `flush_promise`) and wake the source.
-    pub(crate) fn on_writable(
-        task: &bun_s3::MultiPartUpload,
-        this: *mut NetworkSink,
-        flushed: u64,
-    ) {
-        bun_core::scoped_log!(
-            NetworkSinkLog,
-            "onWritable flushed: {} state: {}",
-            flushed,
-            task.state.get() as u8
-        );
-        let _ = task;
-        // SAFETY: `this` is the live sink; each access is scoped and ends
-        // before the re-entrant wake below.
-        let mut source = unsafe {
-            if (*this).flush_promise.has_value() {
-                let global = (*this)
-                    .global_this
-                    .expect("global_this set at construction");
-                let flushed = (*this)
-                    .flush_promise
-                    .resolve(&global, JSValue::js_number(flushed as f64));
-                crate::dispatch::fold(flushed);
-            }
-            (*this).pending.run();
-            (*this).source
-        };
+    pub(crate) fn on_writable(&self, flushed: u64) {
+        bun_core::scoped_log!(NetworkSinkLog, "onWritable flushed: {}", flushed);
+        if self.flush_promise.get().has_value() {
+            let global = self.global_this.expect("global_this set at construction");
+            let flushed = self
+                .flush_promise
+                .with_mut(|p| p.resolve(&global, JSValue::js_number(flushed as f64)));
+            crate::dispatch::fold(flushed);
+        }
+        self.run_pending();
         // Wake the upstream source (JS controller onPull or native ByteStream
         // resume). No-op when `source` is `None` (the `writer()` path).
-        source.ready(None, None);
+        self.source.get().ready(None, None);
     }
 
-    pub fn flush(&mut self) -> bun_sys::Result<()> {
+    /// Settle the parked write; the settlement runs outside the cell borrow
+    /// because it re-enters JS.
+    pub(crate) fn run_pending(&self) {
+        if let Some(settlement) = self.pending.with_mut(WritablePending::take_settlement) {
+            settlement.run();
+        }
+    }
+
+    pub fn flush(&self) -> bun_sys::Result<()> {
         bun_sys::Result::Ok(())
     }
 
     pub(crate) fn flush_from_js(
-        &mut self,
+        &self,
         global_this: &JSGlobalObject,
         _wait: bool,
     ) -> bun_sys::Result<JSValue> {
-        if self.flush_promise.has_value() {
-            return bun_sys::Result::Ok(self.flush_promise.value());
+        if self.flush_promise.get().has_value() {
+            return bun_sys::Result::Ok(self.flush_promise.get().value());
         }
-        if self.done {
+        if self.done.get() {
             return bun_sys::Result::Ok(JSPromise::resolved_promise_value(
                 global_this,
                 JSValue::js_number(0.0),
             ));
         }
         if self.task_ref().is_some_and(|t| !t.is_queue_empty()) {
-            self.flush_promise = JSPromiseStrong::init(global_this);
-            return bun_sys::Result::Ok(self.flush_promise.value());
+            self.flush_promise.set(JSPromiseStrong::init(global_this));
+            return bun_sys::Result::Ok(self.flush_promise.get().value());
         }
         bun_sys::Result::Ok(JSPromise::resolved_promise_value(
             global_this,
@@ -2288,42 +2261,53 @@ impl NetworkSink {
         ))
     }
 
-    pub(crate) fn abort(&mut self) {
-        self.ended = true;
-        self.done = true;
-        self.pending.result = Writable::Done;
-        self.pending.run();
-        self.source.close(None);
-        self.finalize();
+    pub(crate) fn abort(&self) {
+        self.ended.set(true);
+        self.done.set(true);
+        self.pending.with_mut(|p| p.result = Writable::Done);
+        self.run_pending();
+        self.close_source(None);
+        self.detach_writable();
+    }
+
+    /// `close` never rewrites the handle itself, and a JS controller's
+    /// `onClose` may re-enter and clear `self.source`; so close a copy.
+    pub(crate) fn close_source(&self, err: Option<SysError>) {
+        let mut source = self.source.get();
+        source.close(err);
     }
 
     /// The upload queue is full. Native ByteStream/FileReader pumps match on
     /// `Backpressure` directly; a JS controller gets a pending Promise so
     /// `await controller.write()` parks until `on_writable` → `pending.run()`.
-    fn backpressure_result(&mut self, len: BlobSizeType) -> Writable {
+    fn backpressure_result(&self, len: BlobSizeType) -> Writable {
         if matches!(
-            self.source,
+            self.source.get(),
             SourceHandle::ByteStream(_) | SourceHandle::FileReader(_)
         ) {
             return Writable::Backpressure(len);
         }
-        self.pending.consumed = len;
-        self.pending.result = Writable::Owned(len);
-        Writable::Pending(core::ptr::from_mut(&mut self.pending))
+        self.pending.with_mut(|pending| {
+            pending.consumed = len;
+            pending.result = Writable::Owned(len);
+        });
+        Writable::Pending(self.pending.as_ptr())
     }
 
-    pub fn write(&mut self, data: &StreamResult) -> Writable {
-        if self.ended {
+    fn write_encoded(&self, encoding: bun_s3::WriteEncoding, data: &StreamResult) -> Writable {
+        if self.ended.get() {
             return Writable::Owned(0);
         }
+        // The write can settle the upload, whose owner then releases this sink.
+        let _alive = bun_ptr::RefPtr::from_this(self.root.this_ptr(self));
         let bytes = data.slice();
         let len = bytes.len() as BlobSizeType;
         // Direct `.writer()` (no source) exposes `write()` as `number`; only
         // the pump paths consume `Backpressure`/`Done`.
-        let has_source = !matches!(self.source, SourceHandle::None);
+        let has_source = !matches!(self.source.get(), SourceHandle::None);
 
         let result = match self.task_ref() {
-            Some(task) => task.write_bytes(bytes, false),
+            Some(task) => task.write_encoded(encoding, bytes, false),
             None => return Writable::Owned(len),
         };
         match result {
@@ -2336,97 +2320,59 @@ impl NetworkSink {
         }
     }
 
-    pub(crate) fn write_latin1(&mut self, data: &StreamResult) -> Writable {
-        if self.ended {
-            return Writable::Owned(0);
-        }
-
-        let bytes = data.slice();
-        let len = bytes.len() as BlobSizeType;
-        let has_source = !matches!(self.source, SourceHandle::None);
-
-        let result = match self.task_ref() {
-            Some(task) => task.write_latin1(bytes, false),
-            None => return Writable::Owned(len),
-        };
-        match result {
-            Ok(bun_s3::UploadBackpressure::Backpressure) if has_source => {
-                self.backpressure_result(len)
-            }
-            Ok(bun_s3::UploadBackpressure::Done) if has_source => Writable::Done,
-            Ok(_) => Writable::Owned(len),
-            Err(_) => Writable::Err(SysError::from_code(sys::E::ENOMEM, sys::Tag::write)),
-        }
+    pub fn write(&self, data: &StreamResult) -> Writable {
+        self.write_encoded(bun_s3::WriteEncoding::Bytes, data)
     }
 
-    pub(crate) fn write_utf16(&mut self, data: &StreamResult) -> Writable {
-        if self.ended {
-            return Writable::Owned(0);
-        }
-        let bytes = data.slice();
-        let len = bytes.len() as BlobSizeType;
-        let has_source = !matches!(self.source, SourceHandle::None);
+    pub(crate) fn write_latin1(&self, data: &StreamResult) -> Writable {
+        self.write_encoded(bun_s3::WriteEncoding::Latin1, data)
+    }
+
+    pub(crate) fn write_utf16(&self, data: &StreamResult) -> Writable {
         // we must always buffer UTF-16
         // we assume the case of all-ascii UTF-16 string is pretty uncommon
-        let result = match self.task_ref() {
-            Some(task) => task.write_utf16(bytes, false),
-            None => return Writable::Owned(len),
-        };
-        match result {
-            Ok(bun_s3::UploadBackpressure::Backpressure) if has_source => {
-                self.backpressure_result(len)
-            }
-            Ok(bun_s3::UploadBackpressure::Done) if has_source => Writable::Done,
-            Ok(_) => Writable::Owned(len),
-            Err(_) => Writable::Err(SysError::from_code(sys::E::ENOMEM, sys::Tag::write)),
-        }
+        self.write_encoded(bun_s3::WriteEncoding::Utf16, data)
     }
 
-    pub(crate) fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
-        if self.ended {
+    pub(crate) fn end(&self, err: Option<SysError>) -> bun_sys::Result<()> {
+        if self.ended.get() {
             return bun_sys::Result::Ok(());
         }
 
         // send EOF
-        self.ended = true;
-        self.pending.result = Writable::Done;
-        self.pending.run();
+        self.ended.set(true);
+        // The EOF write can settle the upload, whose owner then releases this sink.
+        let _alive = bun_ptr::RefPtr::from_this(self.root.this_ptr(self));
+        self.pending.with_mut(|p| p.result = Writable::Done);
+        self.run_pending();
         // flush everything and send EOF
         if let Some(task) = self.task_ref() {
             let _ = task.write_bytes(b"", true);
             // bun.handleOom → Rust aborts on OOM
         }
 
-        self.source.close(err);
+        self.close_source(err);
         bun_sys::Result::Ok(())
     }
 
     /// JS-pump terminator for a source that failed. Unlike `end()`, the upload
     /// is aborted, not committed; the stashed reason becomes the caller's
     /// rejection. The pump's reject reaction still releases the pump ref, so
-    /// no wrapper deref here.
-    ///
-    /// Raw `*mut Self`: `task.fail()` synchronously fires
-    /// `S3UploadStreamWrapper::resolve`, which re-borrows this sink.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn fail_from_js_pump(this: *mut Self, global: &JSGlobalObject, reason: JSValue) {
-        // SAFETY: `this` is the live Box<NetworkSink> the wrapper owns; the
-        // borrow ends before `fail` re-enters.
-        let task_ref = unsafe {
-            if (*this).ended {
-                return;
-            }
-            (*this).ended = true;
-            (*this).done = true;
-            (*this).pending.result = Writable::Done;
-            (*this).pending.run();
-            if !reason.is_empty_or_undefined_or_null() {
-                (*this).upstream_error.set(global, reason);
-            }
-            // Our own ref: `fail` re-enters and may clear `(*this).task`.
-            (*this).task.clone()
-        };
-        let Some(task) = task_ref else {
+    /// no wrapper release here. `task.fail()` synchronously settles the
+    /// upload, whose owner then releases this sink.
+    pub(crate) fn fail_from_js_pump(&self, global: &JSGlobalObject, reason: JSValue) {
+        if self.ended.get() {
+            return;
+        }
+        let _alive = bun_ptr::RefPtr::from_this(self.root.this_ptr(self));
+        self.ended.set(true);
+        self.done.set(true);
+        self.pending.with_mut(|p| p.result = Writable::Done);
+        self.run_pending();
+        if !reason.is_empty_or_undefined_or_null() {
+            self.upstream_error.with_mut(|e| e.set(global, reason));
+        }
+        let Some(task) = self.task_ref() else {
             return;
         };
         let _ = task.fail(bun_s3_signing::error::S3Error {
@@ -2439,56 +2385,39 @@ impl NetworkSink {
     /// (clean EOF / commit), an upstream error on the ByteStream fast-path must
     /// abort the upload and surface the original JS error to the caller.
     ///
-    /// Raw `*mut Self` because `task.fail()`/`write_bytes(EOF)` synchronously
-    /// fire `S3UploadStreamWrapper::resolve`, which re-borrows this sink, and
-    /// the terminal `deref_` may drop rc→0 and free `*this` via `detach_sink`.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn end_from_stream(this: *mut Self, err: Option<StreamError>) {
-        // SAFETY: `this` is the live Box<NetworkSink> the wrapper owns; short
-        // reborrows below do not span the re-entrant `fail`/`write_bytes` calls.
-        let (ended, is_bytestream) = unsafe {
-            (
-                (*this).ended,
-                matches!((*this).source, SourceHandle::ByteStream(_)),
-            )
-        };
-        if ended {
+    /// `task.fail()`/`write_bytes(EOF)` synchronously settle the upload, whose
+    /// stream wrapper then releases the pump ref and with it this sink; the
+    /// guard keeps it alive until this returns.
+    pub(crate) fn end_from_stream(this: bun_ptr::ThisPtr<Self>, err: Option<StreamError>) {
+        let _alive = bun_ptr::RefPtr::from_this(this);
+        if this.ended.get() {
             return;
         }
-        if !is_bytestream {
+        if !matches!(this.source.get(), SourceHandle::ByteStream(_)) {
             let sys_err = match err {
                 Some(StreamError::Error(e)) => Some(e),
                 _ => None,
             };
-            // SAFETY: `end()` does not free `*this` or re-enter the sink;
-            // exclusive borrow scoped to the call.
-            let _ = unsafe { (*this).end(sys_err) };
+            let _ = this.end(sys_err);
             return;
         }
-        // SAFETY: scoped accesses for field writes; no re-entry in this block.
-        let (task, wrapper) = unsafe {
-            (*this).ended = true;
-            (*this).source.clear();
-            // Our own ref: `fail`/`write_bytes` re-enter and may clear `(*this).task`.
-            let Some(task) = (*this).task.clone() else {
-                return;
-            };
-            let wrapper = task
-                .callback_context
-                .get()
-                .cast::<crate::webcore::s3::client::S3UploadStreamWrapper>();
-            if let Some(err) = &err {
-                (*this).done = true;
-                let global = (*this)
-                    .global_this
-                    .expect("NetworkSink.global_this set at construction");
-                let js_err = err.to_js(&global);
-                if !js_err.is_empty_or_undefined_or_null() {
-                    (*this).upstream_error.set(&global, js_err);
-                }
-            }
-            (task, wrapper)
+        this.ended.set(true);
+        this.source.set(SourceHandle::None);
+        let Some(task) = this.task_ref() else {
+            return;
         };
+        // Captured before the upload settles (which takes its observer).
+        let wrapper = task.stream_wrapper();
+        if let Some(err) = &err {
+            this.done.set(true);
+            let global = this
+                .global_this
+                .expect("NetworkSink.global_this set at construction");
+            let js_err = err.to_js(&global);
+            if !js_err.is_empty_or_undefined_or_null() {
+                this.upstream_error.with_mut(|e| e.set(&global, js_err));
+            }
+        }
         if err.is_some() {
             let _ = task.fail(bun_s3_signing::error::S3Error {
                 code: b"UnknownError",
@@ -2497,31 +2426,33 @@ impl NetworkSink {
         } else {
             let _ = task.write_bytes(b"", true);
         }
-        // SAFETY: `wrapper` live with rc ≥ 1; this may free `*this`.
-        unsafe { crate::webcore::s3::client::S3UploadStreamWrapper::deref(wrapper) };
+        if let Some(wrapper) = wrapper {
+            crate::webcore::s3::client::S3UploadStreamWrapper::release_pump_ref(wrapper);
+        }
     }
 
-    pub(crate) fn end_from_js(
-        &mut self,
-        _global_this: &JSGlobalObject,
-    ) -> bun_sys::Result<JSValue> {
+    pub(crate) fn end_from_js(&self, _global_this: &JSGlobalObject) -> bun_sys::Result<JSValue> {
         let _ = self.end(None);
-        if self.end_promise.has_value() {
+        if self.end_promise.get().has_value() {
             // we are already waiting for the end
-            return bun_sys::Result::Ok(self.end_promise.value());
+            return bun_sys::Result::Ok(self.end_promise.get().value());
         }
-        if self.task.is_some() && !self.done {
+        if self.task.get().is_some() && !self.done.get() {
             // we need to wait for the task to end
-            self.end_promise = JSPromiseStrong::init(self.global_this());
-            return bun_sys::Result::Ok(self.end_promise.value());
+            self.end_promise
+                .set(JSPromiseStrong::init(self.global_this()));
+            return bun_sys::Result::Ok(self.end_promise.get().value());
         }
         // task already detached
         bun_sys::Result::Ok(JSValue::js_number(0.0))
     }
 
-    /// `this` is the allocation root; the wrapper's `finalize` releases it.
-    pub fn to_js(this: core::ptr::NonNull<Self>, global_this: &JSGlobalObject) -> JSValue {
-        NetworkSinkJSSink::create_object(global_this, this, 0)
+    /// Wrap this sink in a JS `NetworkSink` object, which takes over `this`
+    /// ref (released by `finalize`).
+    pub fn to_js(this: bun_ptr::RefPtr<NetworkSink>, global_this: &JSGlobalObject) -> JSValue {
+        let sink = this.this_ptr();
+        sink.js_ref.set(Some(this));
+        NetworkSinkJSSink::create_object(global_this, sink.into(), 0)
     }
 
     pub(crate) fn memory_cost(&self) -> usize {
@@ -2545,26 +2476,33 @@ impl crate::webcore::sink::JsSinkType for NetworkSink {
 
     crate::impl_js_sink_forwarders!();
 
+    /// The `s3file.writer()` wrapper is done with the sink: detach the upload
+    /// and release the wrapper's ref.
     fn finalize(this: bun_ptr::ThisPtr<Self>) {
-        // SAFETY: trait contract — `this` is live and not used after this call.
-        unsafe {
-            (*this.as_ptr()).finalize();
-            Self::release_writer_holder(this.as_ptr());
+        this.detach_writable();
+        if let Some(js_ref) = this.js_ref.take() {
+            drop(js_ref);
         }
+    }
+    /// A stream-pump controller died attached (heap teardown): it holds no
+    /// ref of its own (the `S3UploadStreamWrapper` does), so only detach.
+    fn controller_finalize(this: bun_ptr::ThisPtr<Self>) {
+        this.detach_writable();
+    }
+    fn end_from_js(&mut self, global: &JSGlobalObject) -> bun_sys::Result<JSValue> {
+        Self::end_from_js(self, global)
     }
     unsafe fn close_with_error(
         this: *mut Self,
         global: &JSGlobalObject,
         reason: JSValue,
     ) -> bun_sys::Result<()> {
-        Self::fail_from_js_pump(this, global, reason);
+        // SAFETY: trait contract; `fail_from_js_pump` keeps the sink alive across the call.
+        unsafe { &*this }.fail_from_js_pump(global, reason);
         bun_sys::Result::Ok(())
     }
-    fn end_from_js(&mut self, global: &JSGlobalObject) -> bun_sys::Result<JSValue> {
-        Self::end_from_js(self, global)
-    }
     fn source(&mut self) -> Option<&mut SourceHandle> {
-        Some(&mut self.source)
+        Some(self.source.get_mut())
     }
 }
 

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -80,10 +80,10 @@ namespace CDP {
 using namespace JSC;
 
 // Implemented in ChromeProcess.rs. Returns the parent's socketpair fd (0 on Windows, which keeps the pipes), -1 on failure.
-// path overrides auto-detection; extraArgv (count entries, each NUL-
-// terminated) appends after core flags. All pointers nullable.
+// path overrides auto-detection; extraArgv (extraArgvLen bytes of
+// back-to-back NUL-terminated strings) appends after core flags. All pointers nullable.
 extern "C" int32_t Bun__Chrome__ensure(Zig::GlobalObject*, const char* userDataDir,
-    const char* path, const char* const* extraArgv, uint32_t extraArgvLen,
+    const char* path, const char* extraArgv, size_t extraArgvLen,
     bool stdoutInherit, bool stderrInherit);
 #if OS(WINDOWS)
 // Copies and queues one chunk; a failure arrives later as Bun__Chrome__onPipeClosed.
@@ -292,19 +292,20 @@ bool Transport::ensureSpawned(Zig::GlobalObject* zig, const WTF::String& userDat
     // Chrome falls back to the default profile → ProcessSingleton abort.
     WTF::CString dir = userDataDir.utf8();
     WTF::CString pathC = path.utf8();
-    // Two-level pack: CString owns the bytes, ptrVec holds data() pointers.
-    // Both live until Bun__Chrome__ensure returns (spawn copies argv).
-    WTF::Vector<WTF::CString, 8> argvC;
-    WTF::Vector<const char*, 8> argvPtrs;
+    // Packed back to back, each NUL-terminated; lives until
+    // Bun__Chrome__ensure returns (spawn copies argv).
+    WTF::Vector<char, 256> argvPacked;
     for (auto& s : extraArgv) {
-        argvC.append(s.utf8());
-        argvPtrs.append(argvC.last().data());
+        WTF::CString utf8 = s.utf8();
+        // Up to the first NUL, as an argv entry would be read.
+        argvPacked.append(std::span<const char>(utf8.data(), strlen(utf8.data())));
+        argvPacked.append('\0');
     }
     int32_t rc = Bun__Chrome__ensure(zig,
         dir.length() ? dir.data() : nullptr,
         pathC.length() ? pathC.data() : nullptr,
-        argvPtrs.isEmpty() ? nullptr : argvPtrs.span().data(),
-        static_cast<uint32_t>(argvPtrs.size()),
+        argvPacked.isEmpty() ? nullptr : argvPacked.span().data(),
+        argvPacked.size(),
         stdoutInherit, stderrInherit);
     if (rc < 0) {
         m_dead = true;
@@ -1794,10 +1795,16 @@ extern "C" void Bun__Chrome__died(int32_t signo)
 }
 
 #if OS(WINDOWS)
+/// `bun_core::ffi::FfiSlice` — a borrowed `&[u8]` passed by value.
+struct BunFfiSlice {
+    const char* ptr;
+    size_t len;
+};
+
 // cdpOnData / cdpOnEnd counterparts, called from the tasks ChromeProcess.rs posts.
-extern "C" void Bun__Chrome__onPipeData(const char* data, size_t len)
+extern "C" void Bun__Chrome__onPipeData(BunFfiSlice data)
 {
-    CDP::transport().onData(data, static_cast<int>(len));
+    CDP::transport().onData(data.ptr, static_cast<int>(data.len));
 }
 
 extern "C" void Bun__Chrome__onPipeClosed()

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -18,11 +18,10 @@
 //! and the write path can share it.
 //! Windows (no inheritable sockets): two uv_pipe()s driven here instead, see [`PipeEvent`] and `Bun__Chrome__writePipe`.
 
-use core::ffi::{CStr, c_char};
-use core::ptr;
+use core::cell::Cell;
+use core::ffi::CStr;
 #[cfg(windows)]
-use core::sync::atomic::AtomicU32;
-use core::sync::atomic::{AtomicPtr, Ordering};
+use core::sync::atomic::{AtomicU32, Ordering};
 use std::io::Write as _;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -30,16 +29,12 @@ use bun_core::ZStr;
 use bun_core::{self, ZBox, env_var, getenv_z, strings, zstr};
 use bun_jsc::JSGlobalObject;
 use bun_jsc::virtual_machine::VirtualMachine;
-#[cfg(windows)]
-use bun_libuv_sys::{UvHandle as _, UvStream as _};
 use bun_output::{declare_scope, scoped_log};
 use bun_paths::{self, path_buffer_pool, platform, resolve_path};
+use bun_ptr::{OwnedThis, ThisPtr};
 #[cfg(unix)]
 use bun_spawn::SpawnResultExt as _;
-use bun_spawn::{
-    self, EventLoopHandle, Process, ProcessExit, ProcessExitKind, ProcessHandle, SpawnOptions,
-    Status, Stdio,
-};
+use bun_spawn::{self, EventLoopHandle, ProcessHandle, SpawnEnv, SpawnOptions, Status, Stdio};
 #[cfg(windows)]
 use bun_sys::ReturnCodeExt as _;
 #[cfg(windows)]
@@ -49,33 +44,30 @@ use bun_which::which;
 
 declare_scope!(Chrome, hidden);
 
+/// The Chrome child. Owned by this thread's [`Hosts`](crate::webview::Hosts)
+/// until its exit is reaped.
 pub(crate) struct ChromeProcess {
+    /// Our ref on the process; dropping this detaches and releases it.
     process: ProcessHandle,
-    /// Set by [`Bun__Chrome__retire`]: the exit is reaped but not reported to C++.
-    retired: bool,
+    /// Set by [`chrome_retire`]: the exit is reaped but not reported to C++.
+    retired: Cell<bool>,
     #[cfg(windows)]
     pipes: WindowsPipes,
     #[cfg(windows)]
     generation: u32,
 }
 
-/// Our ends of the two pipes (boxed, null once closed) and the read scratch.
+/// Our ends of the two pipes (`None` once closed).
 #[cfg(windows)]
 struct WindowsPipes {
     /// Child reads the other end as fd 3.
-    cmd: *mut uv::Pipe,
+    cmd: bun_jsc::JsCell<Option<uv::OwnedPipe>>,
     /// Child writes the other end as fd 4.
-    reply: *mut uv::Pipe,
-    read_buf: Box<[u8]>,
+    reply: bun_jsc::JsCell<Option<uv::OwnedPipe>>,
 }
 
-// PORTING.md §Global mutable state: JS-thread-only singleton ptr → AtomicPtr.
-// Only accessed from the JS thread (exported fns are called from C++ on the
-// mutator thread; on_process_exit runs on the event loop thread which is the
-// same thread), so Relaxed ordering suffices.
-static INSTANCE: AtomicPtr<ChromeProcess> = AtomicPtr::new(ptr::null_mut());
-
-/// Generation of the Chrome in INSTANCE; stamped on every [`PipeEvent`] (same threading as INSTANCE).
+/// Generation of the published Chrome; stamped on every [`PipeEvent`]. Main
+/// (JS) thread only, like the registry.
 #[cfg(windows)]
 static GENERATION: AtomicU32 = AtomicU32::new(0);
 
@@ -85,125 +77,105 @@ static GENERATION: AtomicU32 = AtomicU32::new(0);
 /// dies. SIGKILL here takes the browser process, the zygote tree follows.
 /// The C++ side doesn't touch JS state; EVFILT_PROC → Bun__Chrome__died →
 /// rejectAllAndMarkDead handles promise rejection on the next loop tick.
-#[unsafe(no_mangle)]
-extern "C" fn Bun__Chrome__kill() {
-    // SAFETY: JS-thread-only global; see INSTANCE decl.
-    unsafe {
-        if let Some(i) = INSTANCE.load(Ordering::Relaxed).as_mut() {
-            let _ = i.process.kill(9);
+// HOST_EXPORT(Bun__Chrome__kill, c)
+pub fn chrome_kill() {
+    crate::jsc_hooks::with_webview_hosts(|hosts| {
+        if let Some(chrome) = hosts.chrome.current() {
+            let _ = chrome.process.kill(9);
         }
-    }
+    });
 }
 
 /// Transport::retireGlobal (`bun test --isolate`): unpublish and kill this Chrome so the next file can spawn its own at once.
-#[unsafe(no_mangle)]
-extern "C" fn Bun__Chrome__retire() {
-    let this = INSTANCE.swap(ptr::null_mut(), Ordering::Relaxed);
-    // SAFETY: INSTANCE held a live heap-allocated pointer; `on_exit` only
-    // frees it after it runs, and we have just taken it out of INSTANCE.
-    let Some(chrome) = (unsafe { this.as_mut() }) else {
-        return;
-    };
-    chrome.retired = true;
-    #[cfg(windows)]
-    {
-        // Queued events from this Chrome carry its generation; `QueuedEvent::deliver` drops them.
-        GENERATION.fetch_add(1, Ordering::Relaxed);
-        chrome.pipes.close();
-    }
-    let _ = chrome.process.kill(9);
+// HOST_EXPORT(Bun__Chrome__retire, c)
+pub fn chrome_retire() {
+    crate::jsc_hooks::with_webview_hosts(|hosts| {
+        let Some(chrome) = hosts.chrome.retire() else {
+            return;
+        };
+        chrome.retired.set(true);
+        #[cfg(windows)]
+        {
+            // Queued events from this Chrome carry its generation; `QueuedEvent::deliver` drops them.
+            GENERATION.fetch_add(1, Ordering::Relaxed);
+            chrome.pipes.close();
+        }
+        let _ = chrome.process.kill(9);
+    });
 }
 
 /// Returns the parent's socketpair fd (POSIX, owned by usockets from then on), 0 (Windows), or -1 on failure.
-///
-/// # Safety
-/// `user_data_dir` and `path` must each be null or point to a valid
-/// NUL-terminated string. `extra_argv` must be null or point to
-/// `extra_argv_len` valid NUL-terminated string pointers.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__Chrome__ensure(
+/// `extra_argv` is the extra switches back to back, each NUL-terminated.
+// HOST_EXPORT(Bun__Chrome__ensure, c)
+pub fn chrome_ensure(
     global: &JSGlobalObject,
-    user_data_dir: *const c_char,     // ?[*:0]const u8
-    path: *const c_char,              // ?[*:0]const u8
-    extra_argv: *const *const c_char, // ?[*]const [*:0]const u8
-    extra_argv_len: u32,
+    user_data_dir: Option<&CStr>,
+    path: Option<&CStr>,
+    extra_argv: &[u8],
     stdout_inherit: bool,
     stderr_inherit: bool,
 ) -> i32 {
-    {
-        if !INSTANCE.load(Ordering::Relaxed).is_null() {
-            return -1; // C++ already holds the transport
-        }
+    let published = crate::jsc_hooks::with_webview_hosts(|hosts| hosts.chrome.is_published());
+    if published != Some(false) {
+        return -1; // C++ already holds the transport (or no runtime state)
+    }
 
-        let extra: &[*const c_char] = if extra_argv.is_null() {
-            &[]
-        } else {
-            // SAFETY: caller guarantees extra_argv points to extra_argv_len entries.
-            unsafe { core::slice::from_raw_parts(extra_argv, extra_argv_len as usize) }
-        };
-        let vm = global.bun_vm_ptr();
-        let user_data_dir = if user_data_dir.is_null() {
-            None
-        } else {
-            // SAFETY: caller passes a valid NUL-terminated string when non-null; null is handled above.
-            Some(unsafe { bun_core::ffi::cstr(user_data_dir) })
-        };
-        let path = if path.is_null() {
-            None
-        } else {
-            // SAFETY: caller passes a valid NUL-terminated string when non-null; null is handled above.
-            Some(unsafe { bun_core::ffi::cstr(path) })
-        };
-        match spawn(
-            vm,
-            user_data_dir,
-            path,
-            extra,
-            stdout_inherit,
-            stderr_inherit,
-        ) {
-            Ok(rc) => rc,
-            Err(err) => {
-                scoped_log!(Chrome, "spawn failed: {}", err.name());
-                -1
-            }
+    let extra: Vec<&CStr> = extra_argv
+        .split_inclusive(|&b| b == 0)
+        .filter_map(|arg| CStr::from_bytes_with_nul(arg).ok())
+        .collect();
+    match spawn(
+        global.bun_vm(),
+        user_data_dir,
+        path,
+        &extra,
+        stdout_inherit,
+        stderr_inherit,
+    ) {
+        Ok(rc) => rc,
+        Err(err) => {
+            scoped_log!(Chrome, "spawn failed: {}", err.name());
+            -1
         }
     }
 }
 
 bun_spawn::link_impl_ProcessExit! {
     ChromeProcess for ChromeProcess => |this| {
-        on_process_exit(process, status, _rusage) => ChromeProcess::on_exit(this, process, &status),
+        on_process_exit(_process, status, _rusage) => ChromeProcess::on_exit(ThisPtr::new(this), &status),
     }
 }
 
 impl ChromeProcess {
-    /// Safety: `this` is the pointer published in INSTANCE (freed here); `process` is the exit callback's own argument, which carries the `&mut Process` already live in its frame (as in `SyncWindowsProcess::on_process_exit`).
-    unsafe fn on_exit(this: *mut ChromeProcess, process: *mut Process, status: &Status) {
+    /// The exit handler: `this` is the Chrome the registry owns (installed
+    /// with `set_exit_handler`), taken back and dropped here.
+    fn on_exit(this: ThisPtr<ChromeProcess>, status: &Status) {
         scoped_log!(Chrome, "chrome exited: {}", status);
-        // A retired Chrome was already unpublished by `Bun__Chrome__retire`.
-        let _ =
-            INSTANCE.compare_exchange(this, ptr::null_mut(), Ordering::Relaxed, Ordering::Relaxed);
-        // SAFETY: caller contract; nothing else references the allocation once INSTANCE is cleared.
-        let mut chrome = unsafe { bun_core::heap::take(this) };
-        debug_assert_eq!(process, chrome.process.as_ptr());
+        // A retired Chrome was already unpublished by `chrome_retire`.
+        let chrome =
+            crate::jsc_hooks::with_webview_hosts(|hosts| hosts.chrome.take(this)).flatten();
+        debug_assert!(chrome.is_some(), "chrome exit for an unknown chrome");
+        let Some(chrome) = chrome else {
+            return;
+        };
         chrome.close_transport();
-        if chrome.retired {
+        let retired = chrome.retired.get();
+        #[cfg(windows)]
+        let generation = chrome.generation;
+        // Releases our ref on the process.
+        drop(chrome);
+        if retired {
             return;
         }
         let signo: i32 = status.signal_code().map_or(0, |s| s as i32);
         #[cfg(windows)]
-        PipeEvent::Exited { signo }.post(chrome.generation);
+        PipeEvent::Exited { signo }.post(generation);
         #[cfg(not(windows))]
-        {
-            drop(chrome);
-            // SAFETY: plain FFI call; takes no pointers.
-            unsafe { Bun__Chrome__died(signo) };
-        }
+        Bun__Chrome__died(signo);
     }
 
     /// On POSIX C++ owns the socket.
-    fn close_transport(&mut self) {
+    fn close_transport(&self) {
         #[cfg(windows)]
         self.pipes.close();
     }
@@ -478,143 +450,136 @@ fn find_playwright_shell() -> Option<ZBox> {
 
 /// Returns `Bun__Chrome__ensure`'s success value.
 fn spawn(
-    vm: *mut VirtualMachine,
+    vm: &VirtualMachine,
     user_data_dir: Option<&CStr>,
     explicit_path: Option<&CStr>,
-    extra_argv: &[*const c_char],
+    extra_argv: &[&CStr],
     stdout_inherit: bool,
     stderr_inherit: bool,
 ) -> crate::Result<i32> {
-    {
-        let chrome = find_chrome(explicit_path).ok_or(crate::Error::ChromeNotFound)?;
-        scoped_log!(
-            Chrome,
-            "using chrome: {}",
-            bstr::BStr::new(chrome.as_bytes())
-        );
+    let chrome = find_chrome(explicit_path).ok_or(crate::Error::ChromeNotFound)?;
+    scoped_log!(
+        Chrome,
+        "using chrome: {}",
+        bstr::BStr::new(chrome.as_bytes())
+    );
 
-        // SAFETY: `vm` is the live thread-local VM; `event_loop()` is its
-        // per-thread `jsc::EventLoop`.
-        let event_loop = unsafe { EventLoopHandle::init((*vm).event_loop().cast()) };
-        let mut endpoints = Endpoints::create(event_loop)?;
+    let event_loop = EventLoopHandle::init(vm.as_mut().event_loop().cast::<()>());
+    let mut endpoints = Endpoints::create(event_loop)?;
 
-        // Minimal flags. --remote-debugging-pipe is the one that matters;
-        // --headless works on both full Chrome (switches to headless mode) and
-        // chrome-headless-shell (no-op, it's already headless). --headless=new
-        // breaks chrome-headless-shell (it IS the new headless mode; =new is a
-        // full-Chrome-only switch). Playwright passes plain --headless
-        // (chromium.js:293).
-        //
-        // --user-data-dir MUST precede --remote-debugging-pipe in argv. Chrome's
-        // CommandLine::Init stops at the first -- after argv[0] on some builds;
-        // order-insensitive on most, but --user-data-dir-first is the defensive
-        // layout every headless harness uses. Without it, ProcessSingleton locks
-        // the default profile (~/Library/Application Support/Google/Chrome) and
-        // aborts if a real Chrome is already running.
-        let data_dir: ZBox = if let Some(d) = user_data_dir {
-            let d = d.to_bytes();
-            let mut v = Vec::with_capacity(16 + d.len());
-            v.extend_from_slice(b"--user-data-dir=");
-            v.extend_from_slice(d);
-            ZBox::from_vec(v)
+    // Minimal flags. --remote-debugging-pipe is the one that matters;
+    // --headless works on both full Chrome (switches to headless mode) and
+    // chrome-headless-shell (no-op, it's already headless). --headless=new
+    // breaks chrome-headless-shell (it IS the new headless mode; =new is a
+    // full-Chrome-only switch). Playwright passes plain --headless
+    // (chromium.js:293).
+    //
+    // --user-data-dir MUST precede --remote-debugging-pipe in argv. Chrome's
+    // CommandLine::Init stops at the first -- after argv[0] on some builds;
+    // order-insensitive on most, but --user-data-dir-first is the defensive
+    // layout every headless harness uses. Without it, ProcessSingleton locks
+    // the default profile (~/Library/Application Support/Google/Chrome) and
+    // aborts if a real Chrome is already running.
+    let data_dir: ZBox = if let Some(d) = user_data_dir {
+        let d = d.to_bytes();
+        let mut v = Vec::with_capacity(16 + d.len());
+        v.extend_from_slice(b"--user-data-dir=");
+        v.extend_from_slice(d);
+        ZBox::from_vec(v)
+    } else {
+        let mut name_buf = [0u8; 64];
+        let name = bun_paths::fs::FileSystem::tmpname(
+            b"bun-chrome",
+            &mut name_buf,
+            bun_core::fast_random(),
+        )?;
+        let mut dir_buf = path_buffer_pool::get();
+        let dir_parts: [&[u8]; 2] = [bun_resolver::fs::RealFS::tmpdir_path(), name.as_bytes()];
+        let dir = resolve_path::join_string_buf_z::<platform::Auto>(&mut dir_buf[..], &dir_parts);
+        bun_sys::mkdir(dir, 0o700)?;
+        let mut v = Vec::with_capacity(16 + dir.len());
+        v.extend_from_slice(b"--user-data-dir=");
+        v.extend_from_slice(&dir[..]);
+        ZBox::from_vec(v)
+    };
+
+    let mut argv: Vec<&CStr> = vec![
+        chrome.as_zstr().as_cstr(),
+        data_dir.as_zstr().as_cstr(),
+        c"--remote-debugging-pipe",
+        c"--headless",
+        c"--no-first-run",
+        c"--no-default-browser-check",
+        c"--disable-gpu", // headless CI has no GPU context
+        // Enterprise policy can force-install extensions (webRequest spam on
+        // stderr). --disable-extensions is best-effort; mandatory extensions
+        // may still load. --disable-background-networking shuts up GCM/update.
+        c"--disable-extensions",
+        c"--disable-background-networking",
+        // Throttling suite (playwright's chromiumSwitches.ts subset). These
+        // gate rAF/setTimeout firing when the tab thinks it's backgrounded.
+        // A headless target is "occluded" by definition; without these Chrome
+        // throttles timers to 1 Hz and pauses rAF entirely.
+        c"--disable-background-timer-throttling",
+        c"--disable-backgrounding-occluded-windows",
+        c"--disable-renderer-backgrounding",
+        // CDP message rate limiter — a burst of evaluates/clicks in a test
+        // loop hits it otherwise. Playwright and puppeteer both ship this.
+        c"--disable-ipc-flooding-protection",
+        // No startup window — targets are Target.createTarget'd, not the
+        // default about:blank. Saves one tab and the visual-complete wait.
+        c"--no-startup-window",
+    ];
+    // User extras last so they can override built-in flags (Chrome's
+    // CommandLine last-wins for duplicate switches). Memory is the caller's
+    // buffer — lives until Bun__Chrome__ensure returns, after which
+    // posix_spawn has copied argv into the child.
+    argv.extend_from_slice(extra_argv);
+
+    let env = vm
+        .as_mut()
+        .transpiler
+        .env_mut()
+        .map
+        .create_null_delimited_env_map()?;
+    let env: Vec<&CStr> = env.iter().collect();
+
+    let opts = SpawnOptions {
+        stdin: Stdio::Ignore,
+        stdout: if stdout_inherit {
+            Stdio::Inherit
         } else {
-            let mut name_buf = [0u8; 64];
-            let name = bun_paths::fs::FileSystem::tmpname(
-                b"bun-chrome",
-                &mut name_buf,
-                bun_core::fast_random(),
-            )?;
-            let mut dir_buf = path_buffer_pool::get();
-            let dir_parts: [&[u8]; 2] = [bun_resolver::fs::RealFS::tmpdir_path(), name.as_bytes()];
-            let dir =
-                resolve_path::join_string_buf_z::<platform::Auto>(&mut dir_buf[..], &dir_parts);
-            bun_sys::mkdir(dir, 0o700)?;
-            let mut v = Vec::with_capacity(16 + dir.len());
-            v.extend_from_slice(b"--user-data-dir=");
-            v.extend_from_slice(&dir[..]);
-            ZBox::from_vec(v)
-        };
-
-        let mut argv: Vec<*const c_char> = vec![
-            chrome.as_ptr(),
-            data_dir.as_ptr(),
-            c"--remote-debugging-pipe".as_ptr(),
-            c"--headless".as_ptr(),
-            c"--no-first-run".as_ptr(),
-            c"--no-default-browser-check".as_ptr(),
-            c"--disable-gpu".as_ptr(), // headless CI has no GPU context
-            // Enterprise policy can force-install extensions (webRequest spam on
-            // stderr). --disable-extensions is best-effort; mandatory extensions
-            // may still load. --disable-background-networking shuts up GCM/update.
-            c"--disable-extensions".as_ptr(),
-            c"--disable-background-networking".as_ptr(),
-            // Throttling suite (playwright's chromiumSwitches.ts subset). These
-            // gate rAF/setTimeout firing when the tab thinks it's backgrounded.
-            // A headless target is "occluded" by definition; without these Chrome
-            // throttles timers to 1 Hz and pauses rAF entirely.
-            c"--disable-background-timer-throttling".as_ptr(),
-            c"--disable-backgrounding-occluded-windows".as_ptr(),
-            c"--disable-renderer-backgrounding".as_ptr(),
-            // CDP message rate limiter — a burst of evaluates/clicks in a test
-            // loop hits it otherwise. Playwright and puppeteer both ship this.
-            c"--disable-ipc-flooding-protection".as_ptr(),
-            // No startup window — targets are Target.createTarget'd, not the
-            // default about:blank. Saves one tab and the visual-complete wait.
-            c"--no-startup-window".as_ptr(),
-        ];
-        // User extras last so they can override built-in flags (Chrome's
-        // CommandLine last-wins for duplicate switches). Memory is the caller's
-        // CString Vector — lives until Bun__Chrome__ensure returns, after which
-        // posix_spawn has copied argv into the child.
-        for a in extra_argv {
-            argv.push(*a);
-        }
-        argv.push(core::ptr::null());
-
-        // SAFETY: vm is the per-thread VirtualMachine (valid for the call);
-        // `transpiler.env` is set during VM init and lives for VM lifetime;
-        // `.map` is its `&mut Map` slot.
-        let env = unsafe { (*(*vm).transpiler.env).map.create_null_delimited_env_map() }?;
-
-        let opts = SpawnOptions {
-            stdin: Stdio::Ignore,
-            stdout: if stdout_inherit {
-                Stdio::Inherit
-            } else {
-                Stdio::Ignore
-            },
-            stderr: if stderr_inherit {
-                Stdio::Inherit
-            } else {
-                Stdio::Ignore
-            },
-            extra_fds: endpoints.child_fds(), // dup2'd to child fd 3 and 4, in order
-            argv0: Some(chrome.as_ptr()),
-            #[cfg(windows)]
-            windows: bun_spawn::WindowsOptions {
-                loop_: event_loop,
-                ..Default::default()
-            },
-            ..SpawnOptions::default()
-        };
-
-        // SAFETY: `argv`/`env` are local null-terminated C-string arrays with
-        // argv[0] non-null; valid for this call.
-        let spawned =
-            unsafe { bun_spawn::spawn_process(&opts, argv.as_ptr(), env.as_ptr().cast()) }??;
+            Stdio::Ignore
+        },
+        stderr: if stderr_inherit {
+            Stdio::Inherit
+        } else {
+            Stdio::Ignore
+        },
+        extra_fds: endpoints.child_fds(), // dup2'd to child fd 3 and 4, in order
+        argv0: Some(chrome.as_ptr()),
         #[cfg(windows)]
-        let mut spawned = spawned;
+        windows: bun_spawn::WindowsOptions {
+            loop_: event_loop,
+            ..Default::default()
+        },
+        ..SpawnOptions::default()
+    };
 
-        // Keeping our copies of the child's ends would mask Chrome's death (no EOF).
-        endpoints.close_child_ends();
+    let spawned = bun_spawn::spawn_process_cstr(&opts, &argv, SpawnEnv::Strings(&env))??;
+    #[cfg(windows)]
+    let mut spawned = spawned;
 
-        endpoints.attach(spawned.to_process_handle(event_loop))
-    }
+    // Keeping our copies of the child's ends would mask Chrome's death (no EOF).
+    endpoints.close_child_ends();
+
+    let process = spawned.to_process_handle(event_loop);
+    endpoints.attach(process)
 }
 
 // Implemented in ChromeBackend.cpp. Rejects all pending CDP promises.
 unsafe extern "C" {
-    fn Bun__Chrome__died(signo: i32);
+    safe fn Bun__Chrome__died(signo: i32);
 }
 
 // --- POSIX transport: one socketpair --------------------------------------
@@ -671,33 +636,24 @@ impl Endpoints {
         }
     }
 
-    /// Publishes the singleton and returns our fd for C++ to adopt.
+    /// Publishes the Chrome and returns our fd for C++ to adopt.
     fn attach(mut self, process: ProcessHandle) -> crate::Result<i32> {
-        let self_ptr = bun_core::heap::into_raw(Box::new(ChromeProcess {
+        let chrome = OwnedThis::new(ChromeProcess {
             process,
-            retired: false,
-        }));
-        // SAFETY: `self_ptr` is the freshly-allocated Box that owns `process`
-        // and outlives it.
-        let process = unsafe {
-            let process = &(*self_ptr).process;
-            process
-                .process_mut()
-                .set_exit_handler(ProcessExit::new(ProcessExitKind::ChromeProcess, self_ptr));
-            process
-        };
-        if let Err(e) = process.process_mut().watch() {
+            retired: Cell::new(false),
+        });
+        chrome.process.set_exit_handler(chrome.this_ptr());
+        if let Err(e) = chrome.process.watch() {
             scoped_log!(Chrome, "watch failed: {}", e);
-            // SAFETY: reclaim the Box (drops our process ref).
-            drop(unsafe { bun_core::heap::take(self_ptr) });
+            // Dropping `chrome` detaches and releases the process.
             self.close_all();
             return Err(crate::Error::WatchFailed);
         }
         // Same weak-handle reasoning as HostProcess: parent exit → Chrome's
         // fd 3 EOFs → DevToolsPipeHandler::Shutdown → exit. dispatchOnExit
         // also SIGKILLs via Bun__Chrome__kill.
-        process.process_mut().disable_keeping_event_loop_alive();
-        INSTANCE.store(self_ptr, Ordering::Relaxed);
+        chrome.process.disable_keeping_event_loop_alive();
+        crate::jsc_hooks::with_webview_hosts(|hosts| hosts.chrome.publish(chrome));
 
         let fds = self.fds.take().expect("endpoints live");
         debug_assert!(self.child_closed);
@@ -723,70 +679,56 @@ struct Endpoints {
     /// The child's ends; `None` once closed.
     cmd_child: Option<Fd>,
     reply_child: Option<Fd>,
-    /// Our ends; null once handed over.
-    cmd: *mut uv::Pipe,
-    reply: *mut uv::Pipe,
+    /// Our ends; `None` once handed over.
+    cmd: Option<uv::OwnedPipe>,
+    reply: Option<uv::OwnedPipe>,
 }
 
 #[cfg(windows)]
 impl Endpoints {
-    fn create(event_loop: EventLoopHandle) -> crate::Result<Endpoints> {
+    fn create(_event_loop: EventLoopHandle) -> crate::Result<Endpoints> {
         // uv_pipe() returns [read end, write end]; UV_NONBLOCK_PIPE (overlapped) goes on our ends only.
-        let mut cmd_fds: [uv::uv_file; 2] = [0; 2];
-        // SAFETY: FFI; `cmd_fds` is the out-array uv_pipe fills.
-        unsafe { uv::uv_pipe(&raw mut cmd_fds, 0, uv::UV_NONBLOCK_PIPE as i32) }
-            .to_result(bun_sys::Tag::uv_pipe)?;
+        let cmd_fds = uv::pipe_pair(0, uv::UV_NONBLOCK_PIPE as i32)
+            .map_err(|rc| pipe_error(rc, bun_sys::Tag::uv_pipe))?;
         let mut endpoints = Endpoints {
             cmd_child: Some(Fd::from_uv(cmd_fds[0])),
             reply_child: None,
-            cmd: ptr::null_mut(),
-            reply: ptr::null_mut(),
+            cmd: None,
+            reply: None,
         };
         let cmd_parent = Fd::from_uv(cmd_fds[1]);
-        if let Err(err) = endpoints.wrap(event_loop, cmd_parent, |e, pipe| e.cmd = pipe) {
-            cmd_parent.close();
-            return Err(err);
+        match Self::wrap(cmd_parent) {
+            Ok(pipe) => endpoints.cmd = Some(pipe),
+            Err(err) => {
+                cmd_parent.close();
+                return Err(err);
+            }
         }
 
-        let mut reply_fds: [uv::uv_file; 2] = [0; 2];
-        // SAFETY: FFI; `reply_fds` is the out-array uv_pipe fills.
-        unsafe { uv::uv_pipe(&raw mut reply_fds, uv::UV_NONBLOCK_PIPE as i32, 0) }
-            .to_result(bun_sys::Tag::uv_pipe)?;
+        let reply_fds = uv::pipe_pair(uv::UV_NONBLOCK_PIPE as i32, 0)
+            .map_err(|rc| pipe_error(rc, bun_sys::Tag::uv_pipe))?;
         endpoints.reply_child = Some(Fd::from_uv(reply_fds[1]));
         let reply_parent = Fd::from_uv(reply_fds[0]);
-        if let Err(err) = endpoints.wrap(event_loop, reply_parent, |e, pipe| e.reply = pipe) {
-            reply_parent.close();
-            return Err(err);
+        match Self::wrap(reply_parent) {
+            Ok(pipe) => endpoints.reply = Some(pipe),
+            Err(err) => {
+                reply_parent.close();
+                return Err(err);
+            }
         }
         Ok(endpoints)
     }
 
     /// On success libuv owns `fd`; on failure the caller still does.
-    fn wrap(
-        &mut self,
-        event_loop: EventLoopHandle,
-        fd: Fd,
-        store: impl FnOnce(&mut Endpoints, *mut uv::Pipe),
-    ) -> crate::Result<()> {
-        let pipe: *mut uv::Pipe = bun_core::heap::into_raw(bun_core::boxed_zeroed::<uv::Pipe>());
-        // SAFETY: `pipe` is a live Box; `close_and_destroy` frees it in any state.
-        let result = unsafe {
-            (*pipe)
-                .init(event_loop.uv_loop(), false)
-                .to_result(bun_sys::Tag::uv_pipe)
-                .and_then(|()| (*pipe).open(fd.uv()).to_result(bun_sys::Tag::open))
-        };
-        if let Err(err) = result {
-            // SAFETY: see above.
-            unsafe { uv::Pipe::close_and_destroy(pipe) };
-            return Err(err.into());
-        }
+    fn wrap(fd: Fd) -> crate::Result<uv::OwnedPipe> {
+        let pipe =
+            uv::OwnedPipe::init(false).map_err(|rc| pipe_error(rc, bun_sys::Tag::uv_pipe))?;
+        pipe.open(fd.uv())
+            .map_err(|rc| pipe_error(rc, bun_sys::Tag::open))?;
         // Pending commands keep the loop alive (Transport::updateKeepAlive), not
         // the pipes.
-        // SAFETY: `pipe` is initialized.
-        unsafe { (*pipe).unref() };
-        store(self, pipe);
-        Ok(())
+        pipe.unref();
+        Ok(pipe)
     }
 
     fn child_fds(&self) -> Box<[Stdio]> {
@@ -808,51 +750,55 @@ impl Endpoints {
 
     /// Moves our ends into a [`ChromeProcess`], starts reading replies, and publishes it.
     fn attach(mut self, process: ProcessHandle) -> crate::Result<i32> {
-        let pipes = WindowsPipes {
-            cmd: core::mem::replace(&mut self.cmd, ptr::null_mut()),
-            reply: core::mem::replace(&mut self.reply, ptr::null_mut()),
-            read_buf: vec![0u8; READ_BUF_SIZE].into_boxed_slice(),
-        };
-        let reply = pipes.reply;
         let generation = GENERATION.load(Ordering::Relaxed).wrapping_add(1);
-        let self_ptr = bun_core::heap::into_raw(Box::new(ChromeProcess {
+        let chrome = OwnedThis::new(ChromeProcess {
             process,
-            retired: false,
-            pipes,
+            retired: Cell::new(false),
+            pipes: WindowsPipes {
+                cmd: bun_jsc::JsCell::new(self.cmd.take()),
+                reply: bun_jsc::JsCell::new(self.reply.take()),
+            },
             generation,
-        }));
-        // SAFETY: `self_ptr` is the freshly-allocated Box that owns `process`.
-        let process: *mut Process = unsafe { (*self_ptr).process.as_ptr() };
+        });
 
         // Unlike POSIX the exit can't be delivered before we return (it comes
         // through this thread's loop), so the exit handler is installed after.
-        // SAFETY: `reply` and `process` are owned by `*self_ptr`, which
-        // outlives the reads (`WindowsPipes::close` stops them first).
-        let started = unsafe {
-            (*reply)
-                .read_start_ctx::<ChromeProcess>(self_ptr)
-                .to_result(bun_sys::Tag::listen)
-                .and_then(|()| (*process).watch())
-        };
+        let started = chrome
+            .pipes
+            .reply
+            .get()
+            .as_ref()
+            .expect("just moved in")
+            .read_start(
+                READ_BUF_SIZE,
+                Box::new(move |read| match read {
+                    uv::PipeRead::Data(data) => {
+                        scoped_log!(Chrome, "read {} bytes", data.len());
+                        PipeEvent::Data(Box::from(data)).post(generation);
+                    }
+                    uv::PipeRead::Error(err) => {
+                        scoped_log!(
+                            Chrome,
+                            "reply pipe closed: {:?}",
+                            bun_sys::windows::translate_uv_error_to_e(err)
+                        );
+                        PipeEvent::Closed.post(generation);
+                    }
+                }),
+            )
+            .map_err(|rc| pipe_error(rc, bun_sys::Tag::listen))
+            .and_then(|()| chrome.process.watch().map_err(Into::into));
         if let Err(err) = started {
             scoped_log!(Chrome, "read_start/watch failed: {}", err);
-            // SAFETY: `self_ptr` is unpublished; dropping it closes the pipes,
-            // then detaches and releases the process.
-            unsafe {
-                let mut chrome = bun_core::heap::take(self_ptr);
-                chrome.pipes.close();
-                let _ = chrome.process.kill(9);
-            }
-            return Err(err.into());
+            chrome.pipes.close();
+            let _ = chrome.process.kill(9);
+            // Dropping `chrome` detaches (closing the handle) and releases the process.
+            return Err(err);
         }
 
-        // SAFETY: `self_ptr` is live until `on_exit`.
-        unsafe {
-            let p = process;
-            (*p).set_exit_handler(ProcessExit::new(ProcessExitKind::ChromeProcess, self_ptr));
-            (*p).disable_keeping_event_loop_alive();
-        }
-        INSTANCE.store(self_ptr, Ordering::Relaxed);
+        chrome.process.set_exit_handler(chrome.this_ptr());
+        chrome.process.disable_keeping_event_loop_alive();
+        crate::jsc_hooks::with_webview_hosts(|hosts| hosts.chrome.publish(chrome));
         GENERATION.store(generation, Ordering::Relaxed);
         Ok(0)
     }
@@ -862,55 +808,26 @@ impl Endpoints {
 impl Drop for Endpoints {
     fn drop(&mut self) {
         self.close_child_ends();
-        for pipe in [self.cmd, self.reply] {
-            if !pipe.is_null() {
-                // SAFETY: still ours; `attach` nulls the fields it takes over.
-                unsafe { uv::Pipe::close_and_destroy(pipe) };
-            }
-        }
+        // `cmd` / `reply` still ours (not taken by `attach`) close as they drop.
     }
+}
+
+#[cfg(windows)]
+fn pipe_error(rc: uv::ReturnCode, tag: bun_sys::Tag) -> crate::Error {
+    bun_sys::Error::from_uv_rc(rc, tag)
+        .expect("an error return code")
+        .into()
 }
 
 #[cfg(windows)]
 impl WindowsPipes {
     /// Idempotent; in-flight writes complete with UV_ECANCELED and free themselves.
-    fn close(&mut self) {
-        let reply = core::mem::replace(&mut self.reply, ptr::null_mut());
-        if !reply.is_null() {
-            // SAFETY: the live Box from `attach`; ownership ends here.
-            unsafe {
-                (*reply).read_stop();
-                uv::Pipe::close_and_destroy(reply);
-            }
+    fn close(&self) {
+        if let Some(reply) = self.reply.replace(None) {
+            reply.read_stop();
+            drop(reply);
         }
-        let cmd = core::mem::replace(&mut self.cmd, ptr::null_mut());
-        if !cmd.is_null() {
-            // SAFETY: as above.
-            unsafe { uv::Pipe::close_and_destroy(cmd) };
-        }
-    }
-}
-
-#[cfg(windows)]
-impl uv::StreamReader for ChromeProcess {
-    fn on_read_alloc(this: &mut Self, _suggested_size: usize) -> &mut [u8] {
-        &mut this.pipes.read_buf
-    }
-
-    fn on_read_error(this: &mut Self, err: core::ffi::c_int) {
-        scoped_log!(
-            Chrome,
-            "reply pipe closed: {:?}",
-            bun_sys::windows::translate_uv_error_to_e(err)
-        );
-        PipeEvent::Closed.post(this.generation);
-    }
-
-    unsafe fn on_read(this: *mut Self, data: &[u8]) {
-        scoped_log!(Chrome, "read {} bytes", data.len());
-        // SAFETY: `this` is live for the duration of the callback.
-        let generation = unsafe { (*this).generation };
-        PipeEvent::Data(Box::from(data)).post(generation);
+        drop(self.cmd.replace(None));
     }
 }
 
@@ -956,99 +873,65 @@ impl QueuedEvent {
             );
             return Ok(());
         }
-        // SAFETY: plain FFI; onData copies `bytes` before returning.
-        unsafe {
-            match queued.event {
-                PipeEvent::Data(bytes) => Bun__Chrome__onPipeData(bytes.as_ptr(), bytes.len()),
-                PipeEvent::Closed => Bun__Chrome__onPipeClosed(),
-                PipeEvent::Exited { signo } => Bun__Chrome__died(signo),
-            }
+        match queued.event {
+            PipeEvent::Data(bytes) => Bun__Chrome__onPipeData(bun_core::ffi::FfiSlice::new(&bytes)),
+            PipeEvent::Closed => Bun__Chrome__onPipeClosed(),
+            PipeEvent::Exited { signo } => Bun__Chrome__died(signo),
         }
         Ok(())
     }
 }
 
-/// One in-flight `uv_write` and the copy of the chunk `buf` points into.
-#[cfg(windows)]
-struct WriteReq {
-    req: uv::uv_write_t,
-    buf: uv::uv_buf_t,
-    bytes: Box<[u8]>,
-    generation: u32,
-}
-
-#[cfg(windows)]
-impl WriteReq {
-    /// Safety: `pipe` is the live command pipe of the Chrome with `generation`.
-    unsafe fn submit(pipe: *mut uv::Pipe, chunk: &[u8], generation: u32) -> bool {
-        let mut req = Box::new(WriteReq {
-            req: bun_core::ffi::zeroed::<uv::uv_write_t>(),
-            buf: uv::uv_buf_t::init(b""), // re-init below, once `bytes` has stopped moving
-            bytes: Box::from(chunk),
-            generation,
-        });
-        req.buf = uv::uv_buf_t::init(&req.bytes);
-        let req = bun_core::heap::into_raw(req);
-        // SAFETY: caller contract; `req` stays put until `on_write` reclaims it.
-        let rc = unsafe {
-            (*req)
-                .req
-                .write((*pipe).as_stream(), &(*req).buf, req, WriteReq::on_write)
+/// Transport::writeRaw on Windows (POSIX writes through the usockets socket
+/// C++ owns). A write that fails surfaces as a Closed event, like any other
+/// loss of the transport.
+// HOST_EXPORT(Bun__Chrome__writePipe, c)
+pub fn chrome_write_pipe(data: &[u8]) {
+    #[cfg(not(windows))]
+    let _ = data;
+    #[cfg(windows)]
+    crate::jsc_hooks::with_webview_hosts(|hosts| {
+        let Some(chrome) = hosts.chrome.current() else {
+            return; // Chrome already exited; the Exited event is on its way to C++
         };
-        if let Some(err) = rc.to_error(bun_sys::Tag::write) {
-            scoped_log!(Chrome, "uv_write failed: {}", err);
-            // SAFETY: libuv did not take `req`, so the callback will not run.
-            unsafe { bun_core::heap::destroy(req) };
-            return false;
-        }
-        true
-    }
-
-    fn on_write(this: *mut WriteReq, status: uv::ReturnCode) {
-        // SAFETY: the Box leaked by `submit`; libuv hands it back exactly once.
-        let req = unsafe { bun_core::heap::take(this) };
-        if let Some(err) = status.to_error(bun_sys::Tag::write) {
-            scoped_log!(Chrome, "command pipe write failed: {}", err);
-            // ECANCELED is `WindowsPipes::close` draining the queue; the death is already being reported.
-            if status.int() != uv::UV_ECANCELED {
-                PipeEvent::Closed.post(req.generation);
+        let generation = chrome.generation;
+        scoped_log!(Chrome, "write {} bytes", data.len());
+        let cmd = chrome.pipes.cmd.get();
+        let cmd = cmd
+            .as_ref()
+            .expect("pipes are only closed after the chrome is unpublished");
+        for chunk in data.chunks(u32::MAX as usize) {
+            let queued = cmd.write(
+                Box::from(chunk),
+                Box::new(move |status: uv::ReturnCode| {
+                    if let Some(err) = status.to_error(bun_sys::Tag::write) {
+                        scoped_log!(Chrome, "command pipe write failed: {}", err);
+                        // ECANCELED is `WindowsPipes::close` draining the queue; the death is already being reported.
+                        if status.int() != uv::UV_ECANCELED {
+                            PipeEvent::Closed.post(generation);
+                        }
+                    }
+                }),
+            );
+            if let Err(rc) = queued {
+                scoped_log!(
+                    Chrome,
+                    "uv_write failed: {:?}",
+                    rc.to_error(bun_sys::Tag::write)
+                );
+                PipeEvent::Closed.post(generation);
+                return;
             }
         }
-    }
-}
-
-/// Transport::writeRaw on Windows. A write that fails surfaces as a Closed event, like any other loss of the transport. Safety: `data` points to `len` readable bytes.
-#[cfg(windows)]
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__Chrome__writePipe(data: *const u8, len: usize) {
-    let instance = INSTANCE.load(Ordering::Relaxed);
-    if instance.is_null() {
-        return; // Chrome already exited; the Exited event is on its way to C++
-    }
-    // SAFETY: INSTANCE is live until `on_exit` clears it; raw field reads, so
-    // nothing aliases the `&mut` the read callbacks form.
-    let (pipe, generation) = unsafe { ((*instance).pipes.cmd, (*instance).generation) };
-    debug_assert!(
-        !pipe.is_null(),
-        "pipes are only closed after INSTANCE is cleared"
-    );
-    scoped_log!(Chrome, "write {} bytes", len);
-    // SAFETY: caller contract.
-    let bytes = unsafe { bun_core::ffi::slice(data, len) };
-    for chunk in bytes.chunks(u32::MAX as usize) {
-        // SAFETY: `pipe` belongs to the published instance read above.
-        if !unsafe { WriteReq::submit(pipe, chunk, generation) } {
-            PipeEvent::Closed.post(generation);
-            return;
-        }
-    }
+    });
 }
 
 // Implemented in ChromeBackend.cpp.
 #[cfg(windows)]
 unsafe extern "C" {
-    fn Bun__Chrome__onPipeData(data: *const u8, len: usize);
-    fn Bun__Chrome__onPipeClosed();
+    // `onPipeData` copies the bytes before returning.
+    safe fn Bun__Chrome__onPipeData(data: bun_core::ffi::FfiSlice<'_>);
+    safe fn Bun__Chrome__onPipeClosed();
 }
 
 // --- DevToolsActivePort discovery -------------------------------------------
@@ -1163,20 +1046,14 @@ fn read_dev_tools_active_port(out_buf: &mut Vec<u8>) -> Option<()> {
 /// fails with a close code; C++ falls back to spawn in that case
 /// (m_wasAutoDetected gate in wsOnClose). We don't pre-validate here
 /// because that'd need a network round-trip which defeats the file.
-///
-/// # Safety
-/// `out_buf` must point to at least `out_cap` writable bytes.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__Chrome__autoDetect(out_buf: *mut u8, out_cap: usize) -> usize {
+// HOST_EXPORT(Bun__Chrome__autoDetect, c)
+pub fn chrome_auto_detect(out_buf: &mut [u8]) -> usize {
     let mut buf: Vec<u8> = Vec::new();
     if read_dev_tools_active_port(&mut buf).is_some() {
-        if buf.len() > out_cap {
+        if buf.len() > out_buf.len() {
             return 0;
         }
-        // SAFETY: caller guarantees out_buf points to at least out_cap writable bytes.
-        unsafe {
-            core::ptr::copy_nonoverlapping(buf.as_ptr(), out_buf, buf.len());
-        }
+        out_buf[..buf.len()].copy_from_slice(&buf);
         return buf.len();
     }
     0

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -814,9 +814,7 @@ impl Drop for Endpoints {
 
 #[cfg(windows)]
 fn pipe_error(rc: uv::ReturnCode, tag: bun_sys::Tag) -> crate::Error {
-    bun_sys::Error::from_uv_rc(rc, tag)
-        .expect("an error return code")
-        .into()
+    rc.to_error(tag).expect("an error return code").into()
 }
 
 #[cfg(windows)]

--- a/src/runtime/webview/HostProcess.rs
+++ b/src/runtime/webview/HostProcess.rs
@@ -14,35 +14,33 @@
 //! This file owns process lifetime only. The usockets client lives in C++
 //! (WebKitBackend.cpp) — usockets is a C API and the frame protocol is C structs.
 
-use core::ptr;
+use core::cell::Cell;
 
 use bun_jsc::JSGlobalObject;
 use bun_output::{declare_scope, scoped_log};
-use bun_spawn::{self, ProcessHandle};
+use bun_ptr::ThisPtr;
+use bun_spawn::{ProcessHandle, Status};
 
 #[cfg(target_os = "macos")]
 use {
     crate::Error,
     bun_jsc::virtual_machine::VirtualMachine,
-    bun_spawn::{
-        EventLoopHandle, ProcessExit, ProcessExitKind, SpawnOptions, SpawnResultExt as _, Stdio,
-    },
+    bun_ptr::OwnedThis,
+    bun_spawn::{EventLoopHandle, SpawnEnv, SpawnOptions, SpawnResultExt as _, Stdio},
     bun_sys::{self, Fd, FdExt as _},
-    core::ffi::c_char,
+    core::ffi::CStr,
 };
 
 declare_scope!(WebViewHost, hidden);
 
+/// The WebKit host child. Owned by this thread's [`Hosts`](crate::webview::Hosts)
+/// until its exit is reaped.
 pub(crate) struct HostProcess {
+    /// Our ref on the process; dropping the host detaches and releases it.
     process: ProcessHandle,
-    /// Set by [`Bun__WebViewHost__retire`]: the exit is reaped but not reported to C++.
-    retired: bool,
+    /// Set by [`webview_host_retire`]: the exit is reaped but not reported to C++.
+    retired: Cell<bool>,
 }
-
-// PORTING.md §Global mutable state: JS-thread-only singleton ptr → AtomicPtr.
-// Only ever accessed from the JS thread (macOS WebView host is single-VM).
-static INSTANCE: core::sync::atomic::AtomicPtr<HostProcess> =
-    core::sync::atomic::AtomicPtr::new(ptr::null_mut());
 
 /// Called from WebView.closeAll() and dispatchOnExit. Socket EOF handles
 /// normal parent-death (including SIGKILL of Bun — kernel closes fds, child
@@ -50,32 +48,25 @@ static INSTANCE: core::sync::atomic::AtomicPtr<HostProcess> =
 /// hasn't yet noticed EOF before we return from main(). WKWebView's own
 /// WebContent/GPU/Network helpers are XPC-connected to the child — when the
 /// child dies they get connection-invalidated and exit.
-#[unsafe(no_mangle)]
-extern "C" fn Bun__WebViewHost__kill() {
-    // SAFETY: single-threaded access (JS thread only).
-    unsafe {
-        if let Some(i) = INSTANCE
-            .load(core::sync::atomic::Ordering::Relaxed)
-            .as_mut()
-        {
-            // SAFETY: INSTANCE is set to a live heap-allocated pointer in
-            // spawn() and cleared in on_process_exit before the box is dropped.
-            let _ = (*i.process.as_ptr()).kill(9);
+// HOST_EXPORT(Bun__WebViewHost__kill, c)
+pub fn webview_host_kill() {
+    crate::jsc_hooks::with_webview_hosts(|hosts| {
+        if let Some(host) = hosts.webkit.current() {
+            let _ = host.process.kill(9);
         }
-    }
+    });
 }
 
 /// HostClient::retireGlobal (`bun test --isolate`): unpublish and kill this host so the next file can spawn its own at once.
-#[unsafe(no_mangle)]
-extern "C" fn Bun__WebViewHost__retire() {
-    let this = INSTANCE.swap(ptr::null_mut(), core::sync::atomic::Ordering::Relaxed);
-    // SAFETY: INSTANCE held a live heap-allocated pointer; on_process_exit
-    // only frees it after it runs, and we have just taken it out of INSTANCE.
-    let Some(host) = (unsafe { this.as_mut() }) else {
-        return;
-    };
-    host.retired = true;
-    let _ = host.process.kill(9);
+// HOST_EXPORT(Bun__WebViewHost__retire, c)
+pub fn webview_host_retire() {
+    crate::jsc_hooks::with_webview_hosts(|hosts| {
+        let Some(host) = hosts.webkit.retire() else {
+            return;
+        };
+        host.retired.set(true);
+        let _ = host.process.kill(9);
+    });
 }
 
 /// Lazy: first `new Bun.WebView()` calls this via C++. Returns the parent
@@ -85,8 +76,8 @@ extern "C" fn Bun__WebViewHost__retire() {
 /// a bug" not "spawn failed". We deliberately don't store the fd — usockets
 /// owns it; re-returning a fd usockets may have already closed would be a
 /// use-after-close. Rust only owns process lifetime (watch + kill).
-#[unsafe(no_mangle)]
-extern "C" fn Bun__WebViewHost__ensure(
+// HOST_EXPORT(Bun__WebViewHost__ensure, c)
+pub fn webview_host_ensure(
     global: &JSGlobalObject,
     stdout_inherit: bool,
     stderr_inherit: bool,
@@ -94,24 +85,16 @@ extern "C" fn Bun__WebViewHost__ensure(
     #[cfg(not(target_os = "macos"))]
     {
         let _ = (global, stdout_inherit, stderr_inherit);
-        return -1;
+        -1
     }
     #[cfg(target_os = "macos")]
     {
-        if !INSTANCE
-            .load(core::sync::atomic::Ordering::Relaxed)
-            .is_null()
-        {
-            return -1; // C++ already holds the fd
+        let published = crate::jsc_hooks::with_webview_hosts(|hosts| hosts.webkit.is_published());
+        if published != Some(false) {
+            return -1; // C++ already holds the fd (or no runtime state)
         }
 
-        // `bun_vm()` returns `&'static VirtualMachine`; `spawn` takes the raw
-        // `*mut` because it threads through C ABI / event-loop dispatch.
-        let fd = match spawn(
-            std::ptr::from_ref(global.bun_vm()).cast_mut(),
-            stdout_inherit,
-            stderr_inherit,
-        ) {
+        let fd = match spawn(global.bun_vm(), stdout_inherit, stderr_inherit) {
             Ok(fd) => fd,
             Err(err) => {
                 scoped_log!(WebViewHost, "spawn failed: {}", err.name());
@@ -128,133 +111,111 @@ bun_spawn::link_impl_ProcessExit! {
         // already (clean FIN vs SIGKILL/SIGSEGV). Tell C++ to reject any
         // pending promises and mark the host dead.
         on_process_exit(_process, status, _rusage) => {
-            scoped_log!(WebViewHost, "child exited: {}", status);
-            // A retired host was already unpublished by Bun__WebViewHost__retire.
-            if !(*this).retired {
-                let signo: i32 = status.signal_code().map_or(0, |s| s as i32);
-                Bun__WebViewHost__childDied(signo);
-            }
-            // `this` was heap-allocated in spawn(); dropping it releases our
-            // ref on the process.
-            drop(bun_core::heap::take(this));
-            let _ = INSTANCE.compare_exchange(
-                this,
-                ptr::null_mut(),
-                core::sync::atomic::Ordering::Relaxed,
-                core::sync::atomic::Ordering::Relaxed,
-            );
+            HostProcess::on_exit(ThisPtr::new(this), &status)
         },
     }
 }
 
-#[cfg(target_os = "macos")]
-fn spawn(vm: *mut VirtualMachine, stdout_inherit: bool, stderr_inherit: bool) -> Result<Fd, Error> {
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = (vm, stdout_inherit, stderr_inherit);
-        return Err(crate::Error::Unsupported);
-    }
-    #[cfg(target_os = "macos")]
-    {
-        // Both ends nonblocking — parent uses usockets; child sets O_NONBLOCK
-        // again after dup2 (socketpair flags are per-fd, not per-pair).
-        let fds: [Fd; 2] = bun_sys::socketpair(
-            libc::AF_UNIX as i32,
-            libc::SOCK_STREAM as i32,
-            0,
-            true, // .nonblocking
-        )?;
-        // fd0_guard rolls back fds[0] on any error below.
-        let fd0_guard = scopeguard::guard(fds[0], |fd| fd.close());
-        // fds[1] is closed by spawnProcess after dup2 into the child.
-
-        let exe = bun_core::self_exe_path()?;
-
-        // Child sees fd 3 (first extra_fd → 3+0). The env var is the only
-        // signal; no argv changes so `ps` shows a normal `bun` invocation.
-        // Same pattern as NODE_CHANNEL_FD in js_bun_spawn_bindings.rs.
-        // SAFETY: vm is the per-thread VirtualMachine (valid for the call);
-        // `transpiler.env` is set during VM init and lives for VM lifetime.
-        let base = unsafe { (*(*vm).transpiler.env).map.create_null_delimited_env_map() }?;
-        let base_slice = base.as_slice();
-        // base_slice already has a trailing None sentinel; drop it, append our
-        // var, then re-terminate.
-        let base_entries = &base_slice[..base_slice.len().saturating_sub(1)];
-        let mut env: Vec<*const c_char> = Vec::with_capacity(base_entries.len() + 2);
-        env.extend(base_entries.iter().copied());
-        env.push(c"BUN_INTERNAL_WEBVIEW_HOST=3".as_ptr());
-        env.push(ptr::null());
-
-        let argv: [*const c_char; 2] = [exe.as_ptr(), ptr::null()];
-
-        let opts = SpawnOptions {
-            stdin: Stdio::Ignore,
-            // Default ignore — the child runs no JS or user code, so output is
-            // only panics/NSLog from WebKit. Opt-in via backend.stderr when
-            // debugging a silent host crash.
-            stdout: if stdout_inherit {
-                Stdio::Inherit
-            } else {
-                Stdio::Ignore
-            },
-            stderr: if stderr_inherit {
-                Stdio::Inherit
-            } else {
-                Stdio::Ignore
-            },
-            extra_fds: vec![Stdio::Pipe(fds[1])].into_boxed_slice(),
-            argv0: Some(exe.as_ptr()),
-            ..SpawnOptions::default()
-        };
-
-        // SAFETY: `argv`/`env` are local null-terminated C-string arrays with
-        // argv[0] non-null; valid for this call.
-        let spawned = unsafe { bun_spawn::spawn_process(&opts, argv.as_ptr(), env.as_ptr()) }??;
-
-        // SAFETY: `vm` is the live thread-local VM; `event_loop()` is its
-        // per-thread `jsc::EventLoop`.
-        let event_loop = unsafe { EventLoopHandle::init((*vm).event_loop().cast()) };
-        let self_ptr = bun_core::heap::into_raw(Box::new(HostProcess {
-            process: spawned.to_process_handle(event_loop),
-            retired: false,
-        }));
-        // SAFETY: `self_ptr` is the freshly-allocated Box that owns `process`
-        // and outlives it.
-        let process = unsafe {
-            let process = &(*self_ptr).process;
-            process
-                .process_mut()
-                .set_exit_handler(ProcessExit::new(ProcessExitKind::HostProcess, self_ptr));
-            process
-        };
-        match process.process_mut().watch() {
-            Ok(()) => {
-                // Weak handle: parent exits when no views + nothing pending,
-                // child gets socket EOF and exits, EVFILT_PROC fires into a
-                // dead process (kernel discards). If we ref'd, parent would
-                // stay alive forever waiting on a child that is waiting on us.
-                // dispatchOnExit also SIGKILLs via Bun__WebViewHost__kill.
-                process.process_mut().disable_keeping_event_loop_alive();
-            }
-            Err(e) => {
-                scoped_log!(WebViewHost, "watch failed: {}", e);
-                // SAFETY: reclaim the Box (drops our process ref).
-                drop(unsafe { bun_core::heap::take(self_ptr) });
-                // fd0_guard (declared at the top) closes fds[0]; don't double-close here.
-                return Err(crate::Error::WatchFailed);
-            }
+impl HostProcess {
+    /// The exit handler: `this` is the host the registry owns (installed with
+    /// `set_exit_handler`), taken back and dropped here.
+    fn on_exit(this: ThisPtr<HostProcess>, status: &Status) {
+        scoped_log!(WebViewHost, "child exited: {}", status);
+        let retired = this.retired.get();
+        // A retired host was already unpublished by `webview_host_retire`.
+        if !retired {
+            let signo: i32 = status.signal_code().map_or(0, |s| s as i32);
+            Bun__WebViewHost__childDied(signo);
         }
-        INSTANCE.store(self_ptr, core::sync::atomic::Ordering::Relaxed);
-        // fd handed to C++ which adopts it into usockets. Not stored here —
-        // usockets owns the socket; Rust only owns process lifetime.
-        let fd0 = scopeguard::ScopeGuard::into_inner(fd0_guard);
-        Ok(fd0)
+        let host = crate::jsc_hooks::with_webview_hosts(|hosts| hosts.webkit.take(this)).flatten();
+        debug_assert!(host.is_some(), "webview host exit for an unknown host");
+        // Dropping it releases our ref on the process.
+        drop(host);
     }
+}
+
+#[cfg(target_os = "macos")]
+fn spawn(vm: &VirtualMachine, stdout_inherit: bool, stderr_inherit: bool) -> Result<Fd, Error> {
+    // Both ends nonblocking — parent uses usockets; child sets O_NONBLOCK
+    // again after dup2 (socketpair flags are per-fd, not per-pair).
+    let fds: [Fd; 2] = bun_sys::socketpair(
+        libc::AF_UNIX as i32,
+        libc::SOCK_STREAM as i32,
+        0,
+        true, // .nonblocking
+    )?;
+    // fd0_guard rolls back fds[0] on any error below.
+    let fd0_guard = scopeguard::guard(fds[0], |fd| fd.close());
+    // fds[1] is closed by spawnProcess after dup2 into the child.
+
+    let exe = bun_core::self_exe_path()?;
+
+    // Child sees fd 3 (first extra_fd → 3+0). The env var is the only
+    // signal; no argv changes so `ps` shows a normal `bun` invocation.
+    // Same pattern as NODE_CHANNEL_FD in js_bun_spawn_bindings.rs.
+    let base = vm
+        .as_mut()
+        .transpiler
+        .env_mut()
+        .map
+        .create_null_delimited_env_map()?;
+    let mut env: Vec<&CStr> = base.iter().collect();
+    env.push(c"BUN_INTERNAL_WEBVIEW_HOST=3");
+
+    let opts = SpawnOptions {
+        stdin: Stdio::Ignore,
+        // Default ignore — the child runs no JS or user code, so output is
+        // only panics/NSLog from WebKit. Opt-in via backend.stderr when
+        // debugging a silent host crash.
+        stdout: if stdout_inherit {
+            Stdio::Inherit
+        } else {
+            Stdio::Ignore
+        },
+        stderr: if stderr_inherit {
+            Stdio::Inherit
+        } else {
+            Stdio::Ignore
+        },
+        extra_fds: vec![Stdio::Pipe(fds[1])].into_boxed_slice(),
+        argv0: Some(exe.as_ptr()),
+        ..SpawnOptions::default()
+    };
+
+    let spawned = bun_spawn::spawn_process_cstr(&opts, &[exe.as_cstr()], SpawnEnv::Strings(&env))??;
+
+    let event_loop = EventLoopHandle::init(vm.as_mut().event_loop().cast::<()>());
+    let host = OwnedThis::new(HostProcess {
+        process: spawned.to_process_handle(event_loop),
+        retired: Cell::new(false),
+    });
+    host.process.set_exit_handler(host.this_ptr());
+    match host.process.watch() {
+        Ok(()) => {
+            // Weak handle: parent exits when no views + nothing pending,
+            // child gets socket EOF and exits, EVFILT_PROC fires into a
+            // dead process (kernel discards). If we ref'd, parent would
+            // stay alive forever waiting on a child that is waiting on us.
+            // dispatchOnExit also SIGKILLs via Bun__WebViewHost__kill.
+            host.process.disable_keeping_event_loop_alive();
+        }
+        Err(e) => {
+            scoped_log!(WebViewHost, "watch failed: {}", e);
+            // Dropping `host` detaches and releases the process.
+            // fd0_guard (declared at the top) closes fds[0]; don't double-close here.
+            return Err(crate::Error::WatchFailed);
+        }
+    }
+    crate::jsc_hooks::with_webview_hosts(|hosts| hosts.webkit.publish(host));
+    // fd handed to C++ which adopts it into usockets. Not stored here —
+    // usockets owns the socket; Rust only owns process lifetime.
+    let fd0 = scopeguard::ScopeGuard::into_inner(fd0_guard);
+    Ok(fd0)
 }
 
 // Implemented in WebKitBackend.cpp. Rejects all pending promises, marks the
 // host socket dead. `signo` is the signal that killed the child (0 if it
 // exited cleanly).
 unsafe extern "C" {
-    fn Bun__WebViewHost__childDied(signo: i32);
+    safe fn Bun__WebViewHost__childDied(signo: i32);
 }

--- a/src/runtime/webview/mod.rs
+++ b/src/runtime/webview/mod.rs
@@ -22,6 +22,15 @@ pub(crate) struct Hosts {
     pub(crate) webkit: HostSlot<host_process::HostProcess>,
 }
 
+impl Hosts {
+    /// VM teardown's stop phase: drop every host (detaching its exit handler
+    /// and releasing its `Process`) while the VM's poll store is still alive.
+    pub(crate) fn release_all(&self) {
+        self.chrome.release_all();
+        self.webkit.release_all();
+    }
+}
+
 /// One kind of host: the published instance and the retired ones whose exit
 /// has not arrived yet. Owns them; their exit handlers get a `ThisPtr` back.
 pub(crate) struct HostSlot<T> {
@@ -61,6 +70,11 @@ impl<T> HostSlot<T> {
         Some(this)
     }
 
+    fn release_all(&self) {
+        drop(self.current.replace(None));
+        drop(self.retired.replace(Vec::new()));
+    }
+
     /// Hand `this` host (published or retired) back to the caller.
     pub(crate) fn take(&self, this: ThisPtr<T>) -> Option<OwnedThis<T>> {
         let is = |host: &OwnedThis<T>| core::ptr::eq(host.this_ptr().as_ptr(), this.as_ptr());
@@ -71,15 +85,5 @@ impl<T> HostSlot<T> {
             let i = retired.iter().position(is)?;
             Some(retired.swap_remove(i))
         })
-    }
-}
-
-impl<T> Drop for HostSlot<T> {
-    /// VM teardown: the children were killed by
-    /// `Bun__WebView__closeAllForTermination` and their exits can no longer be
-    /// delivered here; leave the handles to process exit, as before.
-    fn drop(&mut self) {
-        let _ = core::mem::ManuallyDrop::new(self.current.replace(None));
-        let _ = core::mem::ManuallyDrop::new(self.retired.replace(Vec::new()));
     }
 }

--- a/src/runtime/webview/mod.rs
+++ b/src/runtime/webview/mod.rs
@@ -4,7 +4,82 @@
 //! ChromeBackend.cpp) own the usockets client and frame protocol; this module
 //! only spawns/watches the child.
 
+use bun_jsc::JsCell;
+use bun_ptr::{OwnedThis, ThisPtr};
+
 #[path = "ChromeProcess.rs"]
 pub mod chrome_process;
 #[path = "HostProcess.rs"]
 pub mod host_process;
+
+/// The browser host processes this (the main) thread spawned: at most one of
+/// each kind is published to C++ at a time; a retired one (`bun test
+/// --isolate`) stays here until its exit is reaped. Lives in the thread's
+/// `RuntimeState` (`jsc_hooks::with_webview_hosts`).
+#[derive(Default)]
+pub(crate) struct Hosts {
+    pub(crate) chrome: HostSlot<chrome_process::ChromeProcess>,
+    pub(crate) webkit: HostSlot<host_process::HostProcess>,
+}
+
+/// One kind of host: the published instance and the retired ones whose exit
+/// has not arrived yet. Owns them; their exit handlers get a `ThisPtr` back.
+pub(crate) struct HostSlot<T> {
+    current: JsCell<Option<OwnedThis<T>>>,
+    retired: JsCell<Vec<OwnedThis<T>>>,
+}
+
+impl<T> Default for HostSlot<T> {
+    fn default() -> Self {
+        Self {
+            current: JsCell::new(None),
+            retired: JsCell::new(Vec::new()),
+        }
+    }
+}
+
+impl<T> HostSlot<T> {
+    pub(crate) fn is_published(&self) -> bool {
+        self.current.get().is_some()
+    }
+
+    /// The published host, if any.
+    pub(crate) fn current(&self) -> Option<ThisPtr<T>> {
+        self.current.get().as_ref().map(OwnedThis::this_ptr)
+    }
+
+    pub(crate) fn publish(&self, host: OwnedThis<T>) {
+        debug_assert!(!self.is_published(), "a host is already published");
+        self.current.set(Some(host));
+    }
+
+    /// Unpublish the current host but keep it until its exit ([`take`](Self::take)).
+    pub(crate) fn retire(&self) -> Option<ThisPtr<T>> {
+        let host = self.current.replace(None)?;
+        let this = host.this_ptr();
+        self.retired.with_mut(|retired| retired.push(host));
+        Some(this)
+    }
+
+    /// Hand `this` host (published or retired) back to the caller.
+    pub(crate) fn take(&self, this: ThisPtr<T>) -> Option<OwnedThis<T>> {
+        let is = |host: &OwnedThis<T>| core::ptr::eq(host.this_ptr().as_ptr(), this.as_ptr());
+        if self.current.get().as_ref().is_some_and(is) {
+            return self.current.replace(None);
+        }
+        self.retired.with_mut(|retired| {
+            let i = retired.iter().position(is)?;
+            Some(retired.swap_remove(i))
+        })
+    }
+}
+
+impl<T> Drop for HostSlot<T> {
+    /// VM teardown: the children were killed by
+    /// `Bun__WebView__closeAllForTermination` and their exits can no longer be
+    /// delivered here; leave the handles to process exit, as before.
+    fn drop(&mut self) {
+        let _ = core::mem::ManuallyDrop::new(self.current.replace(None));
+        let _ = core::mem::ManuallyDrop::new(self.retired.replace(Vec::new()));
+    }
+}

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -192,11 +192,8 @@ impl ProcessHandle {
         self.process_mut().on_exit(status, rusage)
     }
 
-    pub fn kill(&self, signal: u8) -> Maybe<()> {
-        self.process_mut().kill(signal)
-    }
-
-    /// The process's address, for identity checks in exit callbacks.
+    /// The process's address, for identity checks in exit callbacks and
+    /// registries keyed by it (`ProcessAutoKiller`). Valid while this handle is held.
     pub fn as_ptr(&self) -> *mut Process {
         self.0.as_ptr()
     }
@@ -243,13 +240,6 @@ impl ProcessHandle {
             Poller::Uv(uv_proc) => Some(uv_getrusage(uv_proc)),
             _ => None,
         }
-    }
-
-    /// The process's address (root provenance), for registries keyed by it
-    /// (`ProcessAutoKiller`). Valid while this handle is held.
-    #[inline]
-    pub fn as_ptr(&self) -> core::ptr::NonNull<Process> {
-        self.0.as_non_null()
     }
 }
 

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -200,6 +200,86 @@ impl ProcessHandle {
     pub fn as_ptr(&self) -> *mut Process {
         self.0.as_ptr()
     }
+
+    /// See [`Process::watch`].
+    pub fn watch(&self) -> bun_sys::Result<()> {
+        self.process_mut().watch()
+    }
+
+    /// See [`Process::wait`]; may synchronously run the exit handler.
+    pub fn wait(&self, sync_: bool) {
+        self.process_mut().wait(sync_)
+    }
+
+    /// See [`Process::kill`].
+    pub fn kill(&self, signal: u8) -> Maybe<()> {
+        self.process_mut().kill(signal)
+    }
+
+    /// See [`Process::close`].
+    pub fn close(&self) {
+        self.process_mut().close()
+    }
+
+    /// See [`Process::detach`]: closes the poller and clears the exit handler
+    /// now; the owned ref is still released on drop.
+    pub fn detach(&self) {
+        self.process_mut().detach()
+    }
+
+    pub fn enable_keeping_event_loop_alive(&self) {
+        self.process_mut().enable_keeping_event_loop_alive()
+    }
+
+    pub fn disable_keeping_event_loop_alive(&self) {
+        self.process_mut().disable_keeping_event_loop_alive()
+    }
+
+    /// `uv_getrusage` on the live `uv_process_t`, if this process is still
+    /// polled through libuv.
+    #[cfg(windows)]
+    pub fn uv_rusage(&self) -> Option<Rusage> {
+        match &mut self.process_mut().poller {
+            Poller::Uv(uv_proc) => Some(uv_getrusage(uv_proc)),
+            _ => None,
+        }
+    }
+
+    /// The process's address (root provenance), for registries keyed by it
+    /// (`ProcessAutoKiller`). Valid while this handle is held.
+    #[inline]
+    pub fn as_ptr(&self) -> core::ptr::NonNull<Process> {
+        self.0.as_non_null()
+    }
+}
+
+// Read accessors return by value: no `&Process` may be held across the
+// `&mut`-projecting calls above.
+impl ProcessHandle {
+    #[inline]
+    pub fn pid(&self) -> PidT {
+        self.0.pid
+    }
+
+    pub fn status(&self) -> Status {
+        self.0.status.clone()
+    }
+
+    pub fn has_killed(&self) -> bool {
+        self.0.has_killed()
+    }
+
+    pub fn signal_code(&self) -> Option<bun_core::SignalCode> {
+        self.0.signal_code()
+    }
+
+    pub fn has_exit_handler(&self) -> bool {
+        self.0.exit_handler.is_some()
+    }
+
+    pub fn memory_cost(&self) -> usize {
+        self.0.memory_cost()
+    }
 }
 
 impl Drop for ProcessHandle {


### PR DESCRIPTION
### What

Same programme as #40055 … #40244. **Stacked on #40221** (base branch `claude/blob-zero-unsafe` → #40213; retarget as those land). Shares `bun_http::{OwnedRequest, InFlight, HTTPClientResultHandler}` / `bun_jsc::InFlightTicket` / `bun_event_loop::{TaskHop, ReusableConcurrentTask}` with #40202 (same hunks, cherry-picked additively so main's FetchTasklet is untouched here).

`src/runtime/webcore/s3/`: `client.rs` 45 → **0**, `simple_request.rs` 20 → 0, `download_stream.rs` 15 → 0, `multipart.rs` 13 → 0, `error_jsc.rs` 1 → 0, `S3File.rs` 12 → 0. `src/runtime/webview/`: `ChromeProcess.rs` 49 → 2, `HostProcess.rs` 14 → 1 (residuals are all-`safe fn` `unsafe extern "C"` blocks). Collateral: `streams.rs` 26 → 19 (`NetworkSink` is `RefPtr`-owned with `&self` methods; `SinkHandle::S3Upload(BackRef<NetworkSink, Root>)`), `SourceHandle::S3DownloadBody(BackRef<S3DownloadStreamWrapper>)`.

- **S3 requests** own their `AsyncHTTP` through `OwnedRequest`/`InFlight` and receive results through `HTTPClientResultHandler`; `MultiPartUpload` is `CellRefCounted` with typed part callbacks (no `*mut c_void` ctx); `client::stat` / `upload_stream` take boxed callbacks; `S3DownloadStream` is a typed `ByteStream` source.
- **WebView host**: `RuntimeState.webview_hosts` + `with_webview_hosts(|hosts| ..)` replaces the process-global statics (per main thread; `WebView.closeAll()` from a Worker is a no-op where it previously read the global racily); Windows IPC goes through new `bun_libuv_sys::{pipe_pair, OwnedPipe}` (handle + read state freed only after both the owner drops and `uv_close` runs; registered with `open_handles` for VM teardown); `Bun__Chrome__ensure` takes NUL-packed extra argv (fixes an embedded-NUL bug); codegen gains `&mut [T]` → `(T*, size_t)`.

Pre-existing bugs fixed in passing: `s3file.writer()`'s `NetworkSink` was never freed; the `AsyncHTTP` originals held by S3 tasks never ran their destructor; Chrome extra-argv with an embedded NUL. Parity kept, not fixed: `signal` is ignored on `fetch("s3://…", { method: "PUT", body: stream })`. Noted residual: dropping a `ProcessHandle` inside `on_process_exit` (same shape as cron.rs) wants `bun_spawn` to pass `ThisPtr<Process>` — separate change.

### Testing

Debug+ASAN: all 14 `test/js/bun/s3/s3-*.test.ts`; `s3.test.ts` against a local MinIO 298/298 (R2 variants skipped; 2 virtual-hosted-style cases need `bucket.127.0.0.1` DNS); `s3.leak.test.ts` 5/5; bun-file*; webview-chrome-pipe 8, webview-chrome-disconnect 7, webview-chrome.test.ts 58/58 with real headless Chrome; regression sweep streams/fetch.stream/body-stream/filesink/serve-body-leak/spawn/cron/bun-serve-file all pass. Hand-driven: small upload/stat/presign, 30 MB multipart writer, 30 MB `Response(stream)` upload, native ByteStream → S3, partial stream read + cancel, erroring upload stream, list/unlink/exists, 200 concurrent GETs then GC (flat), Worker terminated mid-upload, `NoSuchKey`; WebView spawn/evaluate/closeAll/respawn — exit 0, no ASAN output. clippy clean; `rust-check-all` windows + mac pass (Windows `OwnedPipe` type-checked only).