### PR TITLE
resolver: resolve phantom dependencies from global-store entries through the project's hoisted layer

### DIFF
--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -124,9 +124,9 @@ Bun folds resolved peer dependencies (required and optional) into each global en
 
 ### Phantom-dependency fallback
 
-When packages live under the project's `node_modules/.bun/`, Node's module resolution walks up through `node_modules/.bun/node_modules/` — the hidden hoisted layer — before reaching the project root. With the global store, packages realpath into `<cache>/links/`, so that layer is no longer on the resolution path from inside a package.
+When packages live under the project's `node_modules/.bun/`, Node's module resolution walks up through `node_modules/.bun/node_modules/` — the hidden hoisted layer — before reaching the project root. With the global store, packages realpath into `<cache>/links/`, so that layer is no longer on the filesystem walk from inside a package.
 
-In practice this only affects **true phantom dependencies**: a package doing `require('helper')` for something it never declared in `dependencies`, `peerDependencies`, or `peerDependenciesMeta`. If you hit this, add the helper to the consuming package's dependencies (the right fix) or set `globalStore = false`.
+This only matters for **true phantom dependencies**: a package doing `require('helper')` for something it never declared in `dependencies`, `peerDependencies`, or `peerDependenciesMeta`. Bun's own resolver compensates: when the walk is about to leave a store entry, it continues at the hidden hoisted layer of the project that links that entry, so `bun run` and `bun build` resolve phantom dependencies in the same order as with a project-local store. Bun finds that project from the working directory, so run bun from inside the project. External tools that walk the real filesystem — `node`, `tsc`, `eslint` — still can't see that layer from inside the store. If one of those hits a phantom dependency, add the helper to the consuming package's dependencies (the right fix) or set `globalStore = false`.
 
 [`publicHoistPattern`](/runtime/bunfig#install-publichoistpattern) and [`hoistPattern`](/runtime/bunfig#install-hoistpattern) hoist into the project's `node_modules`, which packages inside the global store can't reach. They still work for resolving hoisted packages from your own source code.
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2829,10 +2829,13 @@ impl<'a> Resolver<'a> {
                         if !tried_store_fallback
                             && is_global_store_entry_dir(dir_info.abs_path, p.abs_path)
                         {
-                            tried_store_fallback = true;
                             if let Some(fallback) =
                                 self.store_hoisted_fallback_dir_info(dir_info.abs_path)
                             {
+                                // Set only on success: a lookalike directory
+                                // with no project link must not use up the
+                                // one jump.
+                                tried_store_fallback = true;
                                 if let Some(debug) = self.debug_logs.as_mut() {
                                     debug.add_note_fmt(format_args!(
                                         "Retrying from the project's store fallback \"{}\"",

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2821,16 +2821,11 @@ impl<'a> Resolver<'a> {
 
                 match dir_info.get_parent() {
                     Some(p) => {
-                        // A module inside the isolated linker's global virtual
-                        // store realpaths into `<cache>/links/<entry>/`, so
-                        // the walk is about to leave the entry for the shared
-                        // cache and would never see the project's hidden
-                        // hoisted layer (`node_modules/.bun/node_modules`).
-                        // Jump to that layer instead, exactly where a
-                        // project-local entry's walk would reach it, so
-                        // packages the project installs stay resolvable and
-                        // the cache's own ancestors are never consulted
-                        // before the project.
+                        // Leaving a global-store entry for the shared cache:
+                        // jump to the project's hidden hoisted layer instead,
+                        // the directory a project-local entry's walk reaches
+                        // next, so packages the project installs stay
+                        // resolvable from the store.
                         if !tried_store_fallback
                             && is_global_store_entry_dir(dir_info.abs_path, p.abs_path)
                         {
@@ -3344,16 +3339,12 @@ impl<'a> Resolver<'a> {
         MatchStatus::NotFound
     }
 
-    /// The isolated linker's hidden hoisted layer for the project this
-    /// process runs in: the `node_modules/.bun` directory (it holds the
-    /// fallback at `node_modules/.bun/node_modules`) of the nearest ancestor
-    /// of `top_level_dir`, including `top_level_dir` itself, whose store
-    /// links `entry_dir`. A global-store entry is shared, so the hoisted
-    /// layer of a project that does not link it must not answer for it.
+    /// The `node_modules/.bun` directory of the nearest ancestor of
+    /// `top_level_dir` whose store links `entry_dir`. The link check keeps a
+    /// project that does not use the shared entry from answering for it.
     fn store_hoisted_fallback_dir_info(&mut self, entry_dir: &[u8]) -> Option<DirInfoRef> {
         let entry_name = bun_paths::basename(entry_dir);
-        // Strip the `-<16 hex entry hash>` suffix to get the store key, the
-        // name of the project-side `node_modules/.bun/<store key>` symlink.
+        // The project-side link is named without the `-<16 hex>` hash suffix.
         let store_key = &entry_name[..entry_name.len().checked_sub(17)?];
 
         let mut dir: &[u8] = self.fs_ref().top_level_dir;
@@ -6824,22 +6815,17 @@ fn is_dot_slash(path: &[u8]) -> bool {
     }
 }
 
-/// Whether `dir`, whose parent is `parent_dir`, is an entry of the isolated
-/// linker's global virtual store: `<cache>/links/<entry>`. The project's
-/// `node_modules/.bun/<store key>` symlinks point there, so a module's
-/// realpath escapes the project. The resolver cannot ask `bun_install` for
-/// the configured cache directory (that would be a dependency cycle), so it
-/// recognizes the layout structurally.
+/// Is `dir` (with parent `parent_dir`) a global virtual store entry,
+/// `<cache>/links/<entry>`? Recognized structurally: the resolver cannot ask
+/// `bun_install` for the cache directory (dependency cycle).
 fn is_global_store_entry_dir(dir: &[u8], parent_dir: &[u8]) -> bool {
     bun_paths::basename(parent_dir) == b"links"
         && is_global_store_entry_name(bun_paths::basename(dir))
 }
 
-/// Whether `dir` is a project root whose store links the global entry
-/// `entry_name`: `<dir>/node_modules/.bun/<store_key>` is a link whose
-/// target's last component is `entry_name`. The entry hash in the name pins
-/// the resolved dependency closure, so a matching link from another cache
-/// still names identical content.
+/// Does `<dir>/node_modules/.bun/<store_key>` link a target whose last
+/// component is `entry_name`? The hash in `entry_name` pins the dependency
+/// closure, so a match from another cache names identical content.
 fn project_store_links_entry(dir: &[u8], store_key: &[u8], entry_name: &[u8]) -> bool {
     use bun_core::ZStr;
     use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6847,7 +6847,8 @@ fn project_store_links_entry(dir: &[u8], store_key: &[u8], entry_name: &[u8]) ->
     let mut link_buf = bun_paths::path_buffer_pool::get();
     let cap = link_buf.len() - 1;
     let parts: [&[u8]; 4] = [dir, b"node_modules", b".bun", store_key];
-    let Some(joined) = join_abs_string_buf_checked::<platform::Auto>(dir, &mut link_buf[..cap], &parts)
+    let Some(joined) =
+        join_abs_string_buf_checked::<platform::Auto>(dir, &mut link_buf[..cap], &parts)
     else {
         return false;
     };

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2602,6 +2602,7 @@ impl<'a> Resolver<'a> {
 
         // Then check for the package in any enclosing "node_modules" directories
         // or in the package root directory if it's a self-reference
+        let mut tried_store_fallback = false;
         if use_node_module_resolver {
             loop {
                 // Skip directories that are themselves called "node_modules", since we
@@ -2819,7 +2820,36 @@ impl<'a> Resolver<'a> {
                 }
 
                 match dir_info.get_parent() {
-                    Some(p) => dir_info = p,
+                    Some(p) => {
+                        // A module inside the isolated linker's global virtual
+                        // store realpaths into `<cache>/links/<entry>/`, so
+                        // the walk is about to leave the entry for the shared
+                        // cache and would never see the project's hidden
+                        // hoisted layer (`node_modules/.bun/node_modules`).
+                        // Jump to that layer instead, exactly where a
+                        // project-local entry's walk would reach it, so
+                        // packages the project installs stay resolvable and
+                        // the cache's own ancestors are never consulted
+                        // before the project.
+                        if !tried_store_fallback
+                            && is_global_store_entry_dir(dir_info.abs_path, p.abs_path)
+                        {
+                            tried_store_fallback = true;
+                            if let Some(fallback) =
+                                self.store_hoisted_fallback_dir_info(dir_info.abs_path)
+                            {
+                                if let Some(debug) = self.debug_logs.as_mut() {
+                                    debug.add_note_fmt(format_args!(
+                                        "Retrying from the project's store fallback \"{}\"",
+                                        bstr::BStr::new(fallback.abs_path)
+                                    ));
+                                }
+                                dir_info = fallback;
+                                continue;
+                            }
+                        }
+                        dir_info = p;
+                    }
                     None => break,
                 }
             }
@@ -3312,6 +3342,33 @@ impl<'a> Resolver<'a> {
             d.decrease_indent();
         }
         MatchStatus::NotFound
+    }
+
+    /// The isolated linker's hidden hoisted layer for the project this
+    /// process runs in: the `node_modules/.bun` directory (it holds the
+    /// fallback at `node_modules/.bun/node_modules`) of the nearest ancestor
+    /// of `top_level_dir`, including `top_level_dir` itself, whose store
+    /// links `entry_dir`. A global-store entry is shared, so the hoisted
+    /// layer of a project that does not link it must not answer for it.
+    fn store_hoisted_fallback_dir_info(&mut self, entry_dir: &[u8]) -> Option<DirInfoRef> {
+        let entry_name = bun_paths::basename(entry_dir);
+        // Strip the `-<16 hex entry hash>` suffix to get the store key, the
+        // name of the project-side `node_modules/.bun/<store key>` symlink.
+        let store_key = &entry_name[..entry_name.len().checked_sub(17)?];
+
+        let mut dir: &[u8] = self.fs_ref().top_level_dir;
+        loop {
+            if project_store_links_entry(dir, store_key, entry_name)
+                && let Some(abs) = self
+                    .fs_ref()
+                    .abs_buf_checked(&[dir, b"node_modules", b".bun"], bufs!(node_modules_check))
+                && let Ok(Some(info)) = self.dir_info_cached(abs)
+                && info.has_node_modules()
+            {
+                return Some(info);
+            }
+            dir = bun_paths::dirname(dir)?;
+        }
     }
 
     fn dir_info_for_resolution(
@@ -6765,6 +6822,64 @@ fn is_dot_slash(path: &[u8]) -> bool {
     {
         path.len() == 2 && path[0] == b'.' && strings::char_is_any_slash(path[1])
     }
+}
+
+/// Whether `dir`, whose parent is `parent_dir`, is an entry of the isolated
+/// linker's global virtual store: `<cache>/links/<entry>`. The project's
+/// `node_modules/.bun/<store key>` symlinks point there, so a module's
+/// realpath escapes the project. The resolver cannot ask `bun_install` for
+/// the configured cache directory (that would be a dependency cycle), so it
+/// recognizes the layout structurally.
+fn is_global_store_entry_dir(dir: &[u8], parent_dir: &[u8]) -> bool {
+    bun_paths::basename(parent_dir) == b"links"
+        && is_global_store_entry_name(bun_paths::basename(dir))
+}
+
+/// Whether `dir` is a project root whose store links the global entry
+/// `entry_name`: `<dir>/node_modules/.bun/<store_key>` is a link whose
+/// target's last component is `entry_name`. The entry hash in the name pins
+/// the resolved dependency closure, so a matching link from another cache
+/// still names identical content.
+fn project_store_links_entry(dir: &[u8], store_key: &[u8], entry_name: &[u8]) -> bool {
+    use bun_core::ZStr;
+    use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
+
+    let mut link_buf = bun_paths::path_buffer_pool::get();
+    let cap = link_buf.len() - 1;
+    let parts: [&[u8]; 4] = [dir, b"node_modules", b".bun", store_key];
+    let Some(joined) = join_abs_string_buf_checked::<platform::Auto>(dir, &mut link_buf[..cap], &parts)
+    else {
+        return false;
+    };
+    let len = joined.len();
+    link_buf[len] = 0;
+    let link_path = ZStr::from_buf(&link_buf[..], len);
+
+    let mut target_buf = bun_paths::path_buffer_pool::get();
+    let Ok(n) = bun_sys::readlink(link_path, &mut target_buf[..]) else {
+        return false;
+    };
+    let mut target: &[u8] = &target_buf[..n];
+    while let Some((&last, rest)) = target.split_last() {
+        if last != b'/' && last != b'\\' {
+            break;
+        }
+        target = rest;
+    }
+    bun_paths::basename(target) == entry_name
+}
+
+/// `<name>@<resolution>[+<16 hex peer hash>]-<16 hex entry hash>`, written by
+/// `fmt_global_store_path` in `src/install/isolated_install/Store.rs`.
+fn is_global_store_entry_name(name: &[u8]) -> bool {
+    let Some(dash) = name.len().checked_sub(17) else {
+        return false;
+    };
+    name[dash] == b'-'
+        && name[dash + 1..]
+            .iter()
+            .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+        && strings::contains_char(&name[..dash], b'@')
 }
 
 bun_core::comptime_string_map! {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -3288,7 +3288,11 @@ describe("global virtual store", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [strangerErr, strangerCode] = await Promise.all([stranger.stderr.text(), stranger.exited]);
+    const [, strangerErr, strangerCode] = await Promise.all([
+      stranger.stdout.text(),
+      stranger.stderr.text(),
+      stranger.exited,
+    ]);
     expect(strangerErr).toContain("Cannot find module");
     expect(strangerCode).not.toBe(0);
   });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -3177,6 +3177,122 @@ describe("global virtual store", () => {
     expect(JSON.parse(out.trim())).toEqual({ direct: "two-range-deps", transitive: "no-deps" });
   });
 
+  test("a phantom dependency the project installs resolves from inside a global-store entry", async () => {
+    // Regression test for #40243: `a-dep` never declares `no-deps`, but the
+    // project does. A module inside `a-dep`'s global-store entry realpaths
+    // into `<cache>/links/`, so the node_modules walk runs out inside the
+    // shared cache and used to miss the project's hidden hoisted fallback
+    // (`node_modules/.bun/node_modules`). The resolver now re-enters the walk
+    // there, matching how a project-local entry resolves the same import.
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
+
+    // `createTestDir` puts the cache (and with it `<cache>/links/`) inside
+    // the project dir, where the walk out of a store entry still reaches the
+    // project's `node_modules`. Real installs keep the cache under
+    // `~/.bun/install/cache`. Move it to a sibling temp dir so the walk runs
+    // out like it does in a real install.
+    using cacheDir = tempDir("gvs-phantom-cache-", {});
+    await write(
+      join(packageDir, "bunfig.toml"),
+      Bun.TOML.stringify({
+        install: {
+          cache: join(String(cacheDir), "cache"),
+          registry: registry.registryUrl(),
+          linker: "isolated",
+          globalStore: true,
+        },
+      }),
+    );
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-phantom",
+        dependencies: { "a-dep": "1.0.1", "@types/is-number": "1.0.0", "no-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    // A decoy in an ancestor of the cache must not shadow the project's
+    // hoisted layer: the fallback jumps from the store entry straight to the
+    // project, the same order a project-local entry's walk produces.
+    const decoy = join(String(cacheDir), "node_modules", "no-deps", "package.json");
+    await write(decoy, JSON.stringify({ name: "no-deps", version: "999.999.999" }));
+
+    // Plant modules inside the shared entries that import the undeclared
+    // package, like an adapter package that expects the consumer to install
+    // the validator it wraps. The cache is private to this test dir. The
+    // scoped consumer pins the `@scope+name@version` entry-name shape the
+    // resolver's store-entry check recognizes.
+    const consumers = {
+      "a-dep": join(packageDir, "node_modules", ".bun", "a-dep@1.0.1"),
+      "@types/is-number": join(packageDir, "node_modules", ".bun", "@types+is-number@1.0.0"),
+    };
+    for (const [pkg, entry] of Object.entries(consumers)) {
+      expect(lstatSync(entry).isSymbolicLink()).toBe(true);
+      const target = readlinkSync(entry);
+      await write(
+        join(target, "node_modules", pkg, "phantom.js"),
+        `module.exports = require("no-deps/package.json").version;`,
+      );
+      await write(
+        join(target, "node_modules", pkg, "phantom.mjs"),
+        `import pkg from "no-deps/package.json";\nexport const version = pkg.version;`,
+      );
+    }
+    await write(
+      join(packageDir, "index.mjs"),
+      `import { createRequire } from "module";
+      const require = createRequire(import.meta.url);
+      console.log(JSON.stringify({
+        cjs: require("a-dep/phantom.js"),
+        esm: (await import("a-dep/phantom.mjs")).version,
+        scopedCjs: require("@types/is-number/phantom.js"),
+        scopedEsm: (await import("@types/is-number/phantom.mjs")).version,
+      }));`,
+    );
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "index.mjs"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).toBe("");
+    expect(JSON.parse(out.trim())).toEqual({
+      cjs: "1.0.0",
+      esm: "1.0.0",
+      scopedCjs: "1.0.0",
+      scopedEsm: "1.0.0",
+    });
+    expect(code).toBe(0);
+
+    // A working directory that does not link the entry must not answer for
+    // it: the fallback anchors at the project that owns the store entry, so
+    // an unrelated project's hoisted layer stays out of the resolution.
+    await rm(join(String(cacheDir), "node_modules"), { recursive: true, force: true });
+    using strangerDir = tempDir("gvs-phantom-stranger-", {
+      "node_modules/.bun/node_modules/no-deps/package.json": JSON.stringify({
+        name: "no-deps",
+        version: "6.6.6",
+      }),
+    });
+    const phantomAbs = join(readlinkSync(consumers["a-dep"]), "node_modules", "a-dep", "phantom.js");
+    const stranger = spawn({
+      cmd: [bunExe(), "-e", `require(${JSON.stringify(phantomAbs)})`],
+      cwd: String(strangerDir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [strangerErr, strangerCode] = await Promise.all([stranger.stderr.text(), stranger.exited]);
+    expect(strangerErr).toContain("Cannot find module");
+    expect(strangerCode).not.toBe(0);
+  });
+
   test("an entry that loses global-store eligibility detaches without mutating the shared entry", async () => {
     // Regression: a previously-GVS entry that becomes project-local on the
     // next install (newly patched, newly trusted, …) used to write its new


### PR DESCRIPTION
### Problem

- With `install.globalStore = true`, an import of a package the project installs but the importing package never declared fails at runtime: `error: Cannot find module 'zod/v4/core' from '<cache>/links/@hookform+resolvers@5.2.2+.../node_modules/@hookform/resolvers/zod/dist/zod.mjs'` (#40243).
- A global-store module realpaths into `<cache>/links/<entry>/`. The node_modules walk from there runs out inside the shared cache. It never reaches the project's hidden hoisted fallback at `node_modules/.bun/node_modules`, which is what makes the same import work with a project-local store.

### Fix

- In `load_node_modules` (`src/resolver/resolver.rs`), when the walk is about to leave a global-store entry for the shared cache, jump to the project's hidden hoisted layer and continue the walk from there. This reproduces the project-local order exactly: the entry's own `node_modules`, then the hoisted layer, then the project, and never the cache's own ancestors.
- The entry directory is recognized structurally (`links/<name@version...-16hex>` parent and name). The resolver cannot ask `bun_install` for the cache path without a dependency cycle.
- The project is the nearest ancestor of `top_level_dir` whose `node_modules/.bun/<store key>` link targets this entry. The check keeps an unrelated project's hoisted layer from answering for an entry it does not link. An install-side fix is not possible: a shared entry cannot hold per-project fallback links, and keying entries by the project's hoisted set would end cross-project sharing.
- Verified: `test/cli/install/isolated-install.test.ts` (new test, fails on unfixed bun; covers CJS and ESM, a scoped consumer, cache-ancestor decoy ordering, and a non-owner working directory). Also the full isolated-install, bun-prune, bun resolve, and node module suites, plus the #40243 repro from the project root and a workspace subdirectory.

### Background

- The isolated linker stores each package at `node_modules/.bun/<store key>/node_modules/<pkg>` and adds a hidden fallback dir `node_modules/.bun/node_modules` with one symlink per project package. Phantom imports resolve through it because the upward walk from a package's realpath passes `node_modules/.bun`.
- The global store (`install.globalStore`) replaces `node_modules/.bun/<store key>` with a symlink into `<cache>/links/<store key>-<entry hash>`, shared across projects. Realpaths then leave the project, so the on-disk walk loses the fallback.
- `node`, `tsc`, and `eslint` walk the real filesystem and still miss the layer. That is #39498 and stays as documented.

<details><summary>Notes</summary>

- The reporter's workaround (`trustedDependencies`) works because trust makes the entry project-local, but it also grants lifecycle-script trust. This fix needs no config.
- Resolution order with the jump matches a project-local entry. A decoy `node_modules` in an ancestor of the cache (for example `~/node_modules` above the default cache) is no longer consulted before the project. The new test pins this with a decoy that must lose to the hoisted layer.
- The ownership check compares the basename of the project's `.bun/<store key>` link target with the entry name. The 16-hex entry hash pins the resolved dependency closure, so a match from another cache names identical content. Basename comparison also avoids realpath-vs-written-path mismatches (symlinked `$HOME`, Windows `\\?\` prefixes).
- Anchoring is by working directory: run bun from inside the project (any subdirectory works, including workspace members). Running a global-store project from an unrelated cwd stays an error, as before the fix. With a cwd under a different project that does not link the entry, the ownership check keeps the fallback inert instead of resolving a wrong version.
- Known follow-up: `module.paths` / `Module._nodeModulePaths` (`node_module_paths_js_value` in src/jsc) still report Node's textual ancestor list and do not include the hoisted-layer dir the resolver now searches from inside a store entry. That is a textual-semantics mismatch only. It can be aligned in a small separate change.
- `require.resolve(request, { paths })` with a path inside the store goes through the same walk and gets the same fallback.
- Repro used for manual verification: the issue's workspace with `@hookform/resolvers@5.2.2` + `zod@4.3.6`, `bun install && bun run app/index.ts` prints `function` with the fix, fails with `Cannot find module 'zod/v4/core'` without it.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->