### PR TITLE
bake: link ESM modules in two phases so that an import cycle sees a live namespace

### DIFF
--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -357,9 +357,8 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
                     bun_ast::StmtData::SLocal(mut st) if st.is_export => {
                         // convertStmt: strip `export`, then visitBindingToExport
                         // for each decl. AstBuilder only emits `B.Identifier`
-                        // bindings with `kind != .import` and
-                        // `has_been_assigned_to == false`, so the simple
-                        // `'abc,'` arm of visitRefToExport applies.
+                        // bindings, and every export of an HMR module is a
+                        // getter, as in `ConvertESMExportsForHmr`.
                         st.is_export = false;
                         for i in 0..st.decls.len_u32() as usize {
                             let binding = st.decls.slice()[i].binding;
@@ -369,14 +368,12 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
                                     self.symbols[ref_.inner_index() as usize].original_name;
                                 // ImportScanner.recordExportedBinding → recordExport
                                 self.record_export(binding.loc, original_name.slice(), ref_)?;
-                                export_props.push(G::Property {
-                                    key: Some(Expr::init(
-                                        E::String::init(original_name.slice()),
-                                        binding.loc,
-                                    )),
-                                    value: Some(Expr::init_identifier(ref_, binding.loc)),
-                                    ..Default::default()
-                                });
+                                let property = self.hmr_export_getter(
+                                    original_name.slice(),
+                                    ref_,
+                                    binding.loc,
+                                );
+                                export_props.push(property);
                             }
                         }
                         hmr_stmts.push(*stmt);
@@ -401,11 +398,8 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
                             .symbol_uses
                             .put(temp_id, symbol::Use { count_estimate: 1 })?;
                         VecExt::append(&mut self.current_scope_mut().generated, temp_id);
-                        export_props.push(G::Property {
-                            key: Some(Expr::init(E::String::init(b"default"), stmt.loc)),
-                            value: Some(Expr::init_identifier(temp_id, stmt.loc)),
-                            ..Default::default()
-                        });
+                        let property = self.hmr_export_getter(b"default", temp_id, stmt.loc);
+                        export_props.push(property);
                         hmr_stmts.push(Stmt::alloc(
                             S::Local {
                                 kind: S::Kind::KConst,
@@ -574,6 +568,36 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
         self.new_symbol(SymbolKind::Other, name.unwrap_or(b"temp"))
             .expect("OOM")
         // Rust aborts on OOM by default; explicit expect for clarity
+    }
+
+    /// `get name() { return name }` for the namespace object of an HMR module.
+    /// A data property reads the binding when the object is built, and the dev
+    /// server builds that object while the module instantiates, which is
+    /// before the `const` declarations of the body run.
+    fn hmr_export_getter(&mut self, key_name: &[u8], ref_: Ref, loc: Loc) -> G::Property {
+        let body_stmts = self.bump.alloc_slice_copy(&[Stmt::alloc(
+            S::Return {
+                value: Some(Expr::init_identifier(ref_, loc)),
+            },
+            loc,
+        )]);
+        G::Property {
+            kind: G::PropertyKind::Get,
+            key: Some(Expr::init(E::String::init(key_name), loc)),
+            value: Some(Expr::init(
+                E::Function {
+                    func: G::Fn {
+                        body: G::FnBody {
+                            stmts: bun_ast::StoreSlice::new_mut(body_stmts),
+                            loc,
+                        },
+                        ..Default::default()
+                    },
+                },
+                loc,
+            )),
+            ..Default::default()
+        }
     }
 
     pub(crate) fn record_export(&mut self, _loc: Loc, alias: &[u8], ref_: Ref) -> Result<(), OOM> {

--- a/src/bundler/linker_context/README.md
+++ b/src/bundler/linker_context/README.md
@@ -1008,6 +1008,7 @@ This function is essential for maintaining JavaScript module semantics across di
 **Key functions**:
 
 - HMR-specific code generation
+- Emits the ESM module body as a generator: a `yield` separates the instantiation (hoisted functions, the namespace object, `updateImport`) from the evaluation, so that the HMR runtime links an import cycle the way the ECMAScript module link does
 - Development-time optimizations
 - Live reload integration
 

--- a/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
+++ b/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
@@ -17,7 +17,7 @@ use crate::linker_context_mod::{LinkerContext, StmtList, StmtListWhich};
 ///
 /// For ESM, this function populates all three lists:
 /// 1. outside_wrapper_prefix: all import statements, unmodified.
-/// 2. inside_wrapper_prefix: a var decl line and a call to `module.retrieve`
+/// 2. inside_wrapper_prefix: the import bindings, `hmr.updateImport`, `hmr.exports` and the `yield`
 /// 3. inside_wrapper_suffix: all non-import statements
 ///
 /// The imports are rewritten at print time to fit the packed array format
@@ -28,20 +28,32 @@ use crate::linker_context_mod::{LinkerContext, StmtList, StmtListWhich};
 ///   ┃   'module_1', 1, "add",
 ///   ┃   'module_2', 2, "mul", "div",
 ///   ┃   'module_3', 0, // bare or import star
-///     ], [ "default" ], [], (hmr) => {
-/// 2 ┃   var [module_1, module_2, module_3] = hmr.imports;
-///   ┃   hmr.onUpdate = [
+///     ], [ "default" ], [], function*(hmr) {
+/// 2 ┃   var module_1, module_2, module_3;
+///   ┃   hmr.updateImport = [
 ///   ┃     (module) => (module_1 = module),
 ///   ┃     (module) => (module_2 = module),
 ///   ┃     (module) => (module_3 = module),
 ///   ┃   ];
+///   ┃   hmr.exports = {
+///   ┃     get default() { return default_export },
+///   ┃   };
+///   ┃   yield;
+///   ┃   [module_1, module_2, module_3] = hmr.imports;
 ///
 /// 3 ┃   console.log("my module", module_1.add(1, module_2.mul(2, 3));
-///   ┃   module.exports = {
-///   ┃     default: module_3.something(module_2.div),
-///   ┃   };
+///   ┃   const default_export = module_3.something(module_2.div);
 ///     }, false ],
 ///        ----- "is the module async?"
+///
+/// The module body is a generator, and the `yield` in step 2 separates the two
+/// phases of the ESM link. Above the `yield` the module only instantiates: the
+/// function declarations of the body are hoisted, the namespace object becomes
+/// live and `updateImport` is registered. The HMR runtime instantiates a module
+/// before it loads the dependencies of the module, and binds the import of the
+/// importer through `updateImport` as soon as a dependency instantiates. So a
+/// module that takes part in an import cycle reads a live namespace object of
+/// a module that has not evaluated yet, not `null`.
 pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
     c: &mut LinkerContext,
     stmts: &mut StmtList,
@@ -53,6 +65,18 @@ pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
     let hmr_api_id = Expr::init_identifier(hmr_api_ref, Loc::EMPTY);
     let mut esm_decls: bun_alloc::ArenaVec<'bump, ArrayBinding> = bun_alloc::ArenaVec::new_in(bump);
     let mut esm_callbacks: Vec<Expr> = Vec::new();
+    // A module with top-level await is emitted in one phase: an `async`
+    // function has no `yield`. It keeps the layout of a module that knows no
+    // cycle, and the HMR runtime repairs the bindings of its importers after
+    // it evaluates.
+    let uses_top_level_await = !ast.top_level_await_keyword.is_empty();
+    // `hmr.exports = { ... }`, moved above the `yield` so that the namespace
+    // object is live before any module of the cycle evaluates. A module that
+    // uses `export *` keeps the assignment in its body: the object spread the
+    // star lowers to is a copy, and a copy taken during instantiation is empty.
+    let can_hoist_exports_object =
+        ast.export_star_import_records.is_empty() && !uses_top_level_await;
+    let mut hmr_exports_object_stmt: Option<Stmt> = None;
 
     let input_files = &c.parse_graph().input_files;
     let loaders = input_files.items_loader();
@@ -237,78 +261,201 @@ pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
                     stmts.append(StmtListWhich::OutsideWrapperPrefix, *stmt);
                 }
             }
-            _ => stmts.append(StmtListWhich::InsideWrapperSuffix, *stmt),
+            _ => {
+                if can_hoist_exports_object
+                    && hmr_exports_object_stmt.is_none()
+                    && is_hmr_exports_object_assignment(stmt, hmr_api_ref)
+                {
+                    hmr_exports_object_stmt = Some(*stmt);
+                } else {
+                    stmts.append(StmtListWhich::InsideWrapperSuffix, *stmt);
+                }
+            }
         }
     }
 
     if esm_decls.len() > 0 {
-        // var ...;
-        stmts
-            .inside_wrapper_prefix
-            .append_non_dependency(Stmt::alloc(
-                S::Local {
-                    kind: js_ast::LocalKind::KVar, // remove a tdz
-                    decls: G::DeclList::from_slice(&[G::Decl {
-                        binding: Binding::alloc(
-                            bump,
-                            b::Array {
-                                items: bun_ast::StoreSlice::new_mut(
-                                    esm_decls.into_bump_slice_mut(),
-                                ),
-                                has_spread: false,
-                                is_single_line: true,
-                            },
-                            Loc::EMPTY,
-                        ),
-                        value: Some(Expr::init(
+        // hmr.updateImport = [ ... ];
+        // Capture len before moving `esm_callbacks` (borrowck).
+        let callbacks_len = esm_callbacks.len();
+        let update_import_stmt = Stmt::alloc(
+            S::SExpr {
+                value: Expr::init(
+                    E::Binary {
+                        op: js_ast::OpCode::BinAssign,
+                        left: Expr::init(
                             E::Dot {
                                 target: hmr_api_id,
-                                name: b"imports".into(),
+                                name: b"updateImport".into(),
                                 name_loc: Loc::EMPTY,
                                 ..Default::default()
                             },
                             Loc::EMPTY,
-                        )),
-                    }]),
-                    ..Default::default()
-                },
-                Loc::EMPTY,
-            ))?;
-        // hmr.onUpdate = [ ... ];
-        // Capture len before moving `esm_callbacks` (borrowck).
-        let callbacks_len = esm_callbacks.len();
-        stmts
-            .inside_wrapper_prefix
-            .append_non_dependency(Stmt::alloc(
-                S::SExpr {
-                    value: Expr::init(
-                        E::Binary {
-                            op: js_ast::OpCode::BinAssign,
-                            left: Expr::init(
-                                E::Dot {
-                                    target: hmr_api_id,
-                                    name: b"updateImport".into(),
-                                    name_loc: Loc::EMPTY,
-                                    ..Default::default()
+                        ),
+                        right: Expr::init(
+                            E::Array {
+                                items: ExprNodeList::move_from_list(esm_callbacks),
+                                is_single_line: callbacks_len <= 2,
+                                ..Default::default()
+                            },
+                            Loc::EMPTY,
+                        ),
+                    },
+                    Loc::EMPTY,
+                ),
+                ..Default::default()
+            },
+            Loc::EMPTY,
+        );
+        let hmr_imports_expr = Expr::init(
+            E::Dot {
+                target: hmr_api_id,
+                name: b"imports".into(),
+                name_loc: Loc::EMPTY,
+                ..Default::default()
+            },
+            Loc::EMPTY,
+        );
+
+        if uses_top_level_await {
+            // var [module_1, module_2, module_3] = hmr.imports;
+            stmts
+                .inside_wrapper_prefix
+                .append_non_dependency(Stmt::alloc(
+                    S::Local {
+                        kind: js_ast::LocalKind::KVar, // remove a tdz
+                        decls: G::DeclList::from_slice(&[G::Decl {
+                            binding: Binding::alloc(
+                                bump,
+                                b::Array {
+                                    items: bun_ast::StoreSlice::new_mut(
+                                        esm_decls.into_bump_slice_mut(),
+                                    ),
+                                    has_spread: false,
+                                    is_single_line: true,
                                 },
                                 Loc::EMPTY,
                             ),
-                            right: Expr::init(
-                                E::Array {
-                                    items: ExprNodeList::move_from_list(esm_callbacks),
-                                    is_single_line: callbacks_len <= 2,
-                                    ..Default::default()
-                                },
-                                Loc::EMPTY,
-                            ),
+                            value: Some(hmr_imports_expr),
+                        }]),
+                        ..Default::default()
+                    },
+                    Loc::EMPTY,
+                ))?;
+            stmts
+                .inside_wrapper_prefix
+                .append_non_dependency(update_import_stmt)?;
+        } else {
+            // var module_1, module_2, module_3;
+            // The bindings are declared here and assigned after the `yield`, so
+            // that a function declared in the body can close over them while
+            // the module is only instantiated.
+            let mut import_decls: bun_alloc::ArenaVec<'bump, G::Decl> =
+                bun_alloc::ArenaVec::new_in(bump);
+            let mut import_targets: Vec<Expr> = Vec::with_capacity(esm_decls.len());
+            for item in esm_decls.iter() {
+                match item.binding.data {
+                    b::B::BIdentifier(id) => {
+                        import_decls.push(G::Decl {
+                            binding: item.binding,
+                            value: None,
+                        });
+                        import_targets.push(Expr::init_identifier(id.r#ref, item.binding.loc));
+                    }
+                    // A bare import declares no binding and leaves a hole in
+                    // the assignment.
+                    _ => import_targets.push(Expr::init(E::Missing {}, Loc::EMPTY)),
+                }
+            }
+            if import_decls.len() > 0 {
+                stmts
+                    .inside_wrapper_prefix
+                    .append_non_dependency(Stmt::alloc(
+                        S::Local {
+                            kind: js_ast::LocalKind::KVar, // remove a tdz
+                            decls: G::DeclList::from_slice(import_decls.as_slice()),
+                            ..Default::default()
                         },
                         Loc::EMPTY,
-                    ),
-                    ..Default::default()
-                },
-                Loc::EMPTY,
-            ))?;
+                    ))?;
+            }
+            stmts
+                .inside_wrapper_prefix
+                .append_non_dependency(update_import_stmt)?;
+            // hmr.exports = { ... };
+            if let Some(exports_object_stmt) = hmr_exports_object_stmt.take() {
+                stmts
+                    .inside_wrapper_prefix
+                    .append_non_dependency(exports_object_stmt)?;
+            }
+            // yield;
+            // The boundary between instantiation and evaluation. A module with
+            // no imports cannot take part in a cycle and gets no boundary; the
+            // runtime then runs it whole in the instantiation phase.
+            stmts
+                .inside_wrapper_prefix
+                .append_non_dependency(Stmt::alloc(
+                    S::SExpr {
+                        value: Expr::init(
+                            E::Yield {
+                                value: None,
+                                is_star: false,
+                            },
+                            Loc::EMPTY,
+                        ),
+                        ..Default::default()
+                    },
+                    Loc::EMPTY,
+                ))?;
+            // [module_1, module_2, module_3] = hmr.imports;
+            stmts
+                .inside_wrapper_prefix
+                .append_non_dependency(Stmt::alloc(
+                    S::SExpr {
+                        value: Expr::assign(
+                            Expr::init(
+                                E::Array {
+                                    items: ExprNodeList::move_from_list(import_targets),
+                                    is_single_line: true,
+                                    ..Default::default()
+                                },
+                                Loc::EMPTY,
+                            ),
+                            hmr_imports_expr,
+                        ),
+                        ..Default::default()
+                    },
+                    Loc::EMPTY,
+                ))?;
+        }
+    }
+
+    // A module that was left out of the hoist keeps the assignment in its body.
+    if let Some(exports_object_stmt) = hmr_exports_object_stmt {
+        stmts.append(StmtListWhich::InsideWrapperSuffix, exports_object_stmt);
     }
 
     Ok(())
+}
+
+/// Matches `hmr.exports = { ... };`, which `ConvertESMExportsForHmr::finalize`
+/// (and the equivalent transform in `bundler/AstBuilder.rs`) appends to the
+/// module body.
+fn is_hmr_exports_object_assignment(stmt: &Stmt, hmr_api_ref: bun_ast::Ref) -> bool {
+    let StmtData::SExpr(expr_stmt) = &stmt.data else {
+        return false;
+    };
+    let bun_ast::expr::Data::EBinary(assign) = expr_stmt.value.data else {
+        return false;
+    };
+    if assign.op != js_ast::OpCode::BinAssign {
+        return false;
+    }
+    let bun_ast::expr::Data::EDot(dot) = assign.left.data else {
+        return false;
+    };
+    if dot.name.slice() != b"exports" {
+        return false;
+    }
+    matches!(dot.target.data, bun_ast::expr::Data::EIdentifier(id) if id.ref_ == hmr_api_ref)
 }

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -10,9 +10,6 @@ use bun_ast::{self as js_ast, B, Binding, E, Expr, G, S, Stmt};
 
 pub(crate) struct ConvertESMExportsForHmr<'a> {
     pub last_part: &'a mut js_ast::Part,
-    /// files in node modules will not get hot updates, so the code generation
-    /// can be a bit more concise for re-exports
-    pub is_in_node_modules: bool,
     pub imports_seen: StringArrayHashMap<ImportRef>,
     pub export_star_props: Vec<G::Property>,
     pub export_props: Vec<G::Property>,
@@ -132,14 +129,27 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                         let name = p.symbols[symbol.ref_.inner_index() as usize].original_name;
                         if ReactRefresh::is_componentish_name(name.slice()) {
                             // Lower to a function statement, and reference the function in the export list.
-                            self.export_props.push(G::Property {
-                                key: Some(Expr::init(E::EString::init(b"default"), stmt.loc)),
-                                value: Some(Expr::init_identifier(symbol.ref_, stmt.loc)),
-                                ..Default::default()
-                            });
+                            self.visit_ref_to_export(
+                                p,
+                                symbol.ref_,
+                                Some(js_ast::StoreStr::new(b"default")),
+                                stmt.loc,
+                            )?;
                             break 'stmt *s;
                         }
                         // All other functions can be properly moved.
+                    }
+                }
+
+                if let js_ast::StmtOrExpr::Expr(e) = &st.value {
+                    if let js_ast::ExprData::EIdentifier(ident) = e.data {
+                        self.visit_ref_to_export(
+                            p,
+                            ident.ref_,
+                            Some(js_ast::StoreStr::new(b"default")),
+                            stmt.loc,
+                        )?;
+                        return Ok(());
                     }
                 }
 
@@ -164,10 +174,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                         }
                         _ => unreachable!(),
                     },
-                    js_ast::StmtOrExpr::Expr(e) => match e.data {
-                        js_ast::ExprData::EIdentifier(_) => true,
-                        _ => e.can_be_moved(),
-                    },
+                    js_ast::StmtOrExpr::Expr(e) => e.can_be_moved(),
                 };
                 if can_be_moved_to_inner_scope {
                     // Note: `StmtOrExpr` is not `Copy`; read by ptr to avoid moving
@@ -199,11 +206,12 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                         // SAFETY: `current_scope` is a live arena ptr for the parser lifetime.
                         VecExt::append(&mut p.current_scope_mut().generated, temp_id);
 
-                        self.export_props.push(G::Property {
-                            key: Some(Expr::init(E::EString::init(b"default"), stmt.loc)),
-                            value: Some(Expr::init_identifier(temp_id, stmt.loc)),
-                            ..Default::default()
-                        });
+                        self.visit_ref_to_export(
+                            p,
+                            temp_id,
+                            Some(js_ast::StoreStr::new(b"default")),
+                            stmt.loc,
+                        )?;
 
                         // SAFETY: as above — POD-shaped read out of arena.
                         let value = unsafe { core::ptr::read(&raw const st.value) }.to_expr();
@@ -229,22 +237,17 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                         );
                     }
                     js_ast::StmtOrExpr::Stmt(s) => {
-                        self.export_props.push(G::Property {
-                            key: Some(Expr::init(E::EString::init(b"default"), stmt.loc)),
-                            value: Some(Expr::init_identifier(
-                                match s.data {
-                                    js_ast::StmtData::SClass(class) => {
-                                        class.class.class_name.unwrap().ref_
-                                    }
-                                    js_ast::StmtData::SFunction(func) => {
-                                        func.func.name.unwrap().ref_
-                                    }
-                                    _ => unreachable!(),
-                                },
-                                stmt.loc,
-                            )),
-                            ..Default::default()
-                        });
+                        let name_ref = match s.data {
+                            js_ast::StmtData::SClass(class) => class.class.class_name.unwrap().ref_,
+                            js_ast::StmtData::SFunction(func) => func.func.name.unwrap().ref_,
+                            _ => unreachable!(),
+                        };
+                        self.visit_ref_to_export(
+                            p,
+                            name_ref,
+                            Some(js_ast::StoreStr::new(b"default")),
+                            stmt.loc,
+                        )?;
                         break 'stmt *s;
                     }
                 }
@@ -256,20 +259,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                 }
 
                 let class_name_ref = st.class.class_name.unwrap().ref_;
-                // Export as CommonJS
-                self.export_props.push(G::Property {
-                    key: Some(Expr::init(
-                        // SAFETY: arena-owned name slice valid for the parse.
-                        E::EString::init(
-                            p.symbols[class_name_ref.inner_index() as usize]
-                                .original_name
-                                .slice(),
-                        ),
-                        stmt.loc,
-                    )),
-                    value: Some(Expr::init_identifier(class_name_ref, stmt.loc)),
-                    ..Default::default()
-                });
+                self.visit_ref_to_export(p, class_name_ref, None, stmt.loc)?;
 
                 st.is_export = false;
 
@@ -283,14 +273,14 @@ impl<'a> ConvertESMExportsForHmr<'a> {
 
                 st.func.flags.remove(bun_ast::flags::Function::IsExport);
 
-                self.visit_ref_to_export(p, st.func.name.unwrap().ref_, None, stmt.loc, false)?;
+                self.visit_ref_to_export(p, st.func.name.unwrap().ref_, None, stmt.loc)?;
 
                 break 'stmt stmt;
             }
             js_ast::StmtData::SExportClause(st) => {
                 for item in st.items.iter() {
                     let ref_ = item.name.ref_;
-                    self.visit_ref_to_export(p, ref_, Some(item.alias), item.name.loc, false)?;
+                    self.visit_ref_to_export(p, ref_, Some(item.alias), item.name.loc)?;
                 }
 
                 return Ok(()); // do not emit a statement here
@@ -320,13 +310,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                         import_record_index: deduped.import_record_index,
                         ..Default::default()
                     }));
-                    self.visit_ref_to_export(
-                        p,
-                        ref_,
-                        Some(item.alias),
-                        item.name.loc,
-                        !self.is_in_node_modules, // live binding when this may be replaced
-                    )?;
+                    self.visit_ref_to_export(p, ref_, Some(item.alias), item.name.loc)?;
 
                     // imports and export statements have their alias +
                     // original_name swapped. this is likely a design bug in
@@ -350,15 +334,12 @@ impl<'a> ConvertESMExportsForHmr<'a> {
 
                 if let Some(alias) = &st.alias {
                     // 'export * as ns from' creates one named property.
-                    self.export_props.push(G::Property {
-                        // SAFETY: arena-owned name slice valid for the parse.
-                        key: Some(Expr::init(
-                            E::EString::init(alias.original_name.slice()),
-                            stmt.loc,
-                        )),
-                        value: Some(Expr::init_identifier(deduped.namespace_ref, stmt.loc)),
-                        ..Default::default()
-                    });
+                    self.visit_ref_to_export(
+                        p,
+                        deduped.namespace_ref,
+                        Some(alias.original_name),
+                        stmt.loc,
+                    )?;
                 } else {
                     // 'export * from' creates a spread, hoisted at the top.
                     self.export_star_props.push(G::Property {
@@ -520,7 +501,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
         match binding.data {
             B::B::BMissing(_) => {}
             B::B::BIdentifier(id) => {
-                self.visit_ref_to_export(p, id.r#ref, None, binding.loc, false)?;
+                self.visit_ref_to_export(p, id.r#ref, None, binding.loc)?;
             }
             B::B::BArray(array) => {
                 for item in array.items.iter() {
@@ -542,15 +523,10 @@ impl<'a> ConvertESMExportsForHmr<'a> {
         ref_: Ref,
         export_symbol_name: Option<js_ast::StoreStr>,
         loc: bun_ast::Loc,
-        is_live_binding_source: bool,
     ) -> Result<(), AllocError> {
-        let (kind, has_been_assigned_to, original_name) = {
+        let (kind, original_name) = {
             let symbol = &p.symbols[ref_.inner_index() as usize];
-            (
-                symbol.kind,
-                symbol.has_been_assigned_to(),
-                symbol.original_name,
-            )
+            (symbol.kind, symbol.original_name)
         };
         let id = if kind == js_ast::symbol::Kind::Import {
             Expr::init(
@@ -563,9 +539,13 @@ impl<'a> ConvertESMExportsForHmr<'a> {
         } else {
             Expr::init_identifier(ref_, loc)
         };
-        if is_live_binding_source
-            || (kind == js_ast::symbol::Kind::Import && !self.is_in_node_modules)
-            || has_been_assigned_to
+        // The namespace object is created while the module instantiates, which
+        // is before its body runs and before any module of its import cycle
+        // evaluates. A data property would capture the binding at that moment:
+        // `undefined` for a `var`, a temporal dead zone error for a `let` or a
+        // `class`. So a reference to a module-scope binding is always read
+        // through a getter; a data property holds only an expression that
+        // `can_be_moved`, which reads no binding when it is evaluated.
         {
             // TODO (2024-11-24) instead of requiring getters for live-bindings,
             // a callback propagation system should be considered.  mostly
@@ -580,22 +560,6 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                 E::EString::init(export_symbol_name.unwrap_or(original_name).slice()),
                 loc,
             );
-
-            // This is technically incorrect in that we've marked this as a
-            // top level symbol. but all we care about is preventing name
-            // collisions, not necessarily the best minificaiton (dev only)
-            let arg1 = p.generate_temp_ref(Some(original_name.slice()));
-            self.last_part
-                .declared_symbols
-                .append(js_ast::DeclaredSymbol {
-                    ref_: arg1,
-                    is_top_level: true,
-                })?;
-            self.last_part
-                .symbol_uses
-                .put_no_clobber(arg1, js_ast::symbol::Use { count_estimate: 1 })?;
-            // SAFETY: `current_scope` is a live arena ptr for the parser lifetime.
-            VecExt::append(&mut p.current_scope_mut().generated, arg1);
 
             // 'get abc() { return abc }'
             let body_stmts = p
@@ -619,16 +583,6 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                 ..Default::default()
             });
             // no setter is added since live bindings are read-only
-        } else {
-            // 'abc,'
-            self.export_props.push(G::Property {
-                key: Some(Expr::init(
-                    E::EString::init(export_symbol_name.unwrap_or(original_name).slice()),
-                    loc,
-                )),
-                value: Some(id),
-                ..Default::default()
-            });
         }
         Ok(())
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -7830,7 +7830,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .expect("hot_module_reloading parse always has at least one part");
             let mut hmr_transform_ctx = ConvertESMExportsForHmr {
                 last_part,
-                is_in_node_modules: self.source.path.is_node_module(),
                 imports_seen: Default::default(),
                 export_star_props: Vec::new(),
                 export_props: Vec::new(),

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -6737,9 +6737,17 @@ pub(crate) mod __gated_printer {
                 }
                 self.print(b"], ");
 
-                // Print the code
-                if !ast.top_level_await_keyword.is_empty() {
+                // Print the code. A module without top-level await is a
+                // generator: the single `yield` in its body separates the
+                // instantiation of the module from its evaluation, which lets
+                // the HMR runtime link an import cycle the way the ECMAScript
+                // module link does. A module with top-level await must be able
+                // to suspend on `await`, so it keeps the one phase arrow form.
+                let uses_top_level_await = !ast.top_level_await_keyword.is_empty();
+                if uses_top_level_await {
                     self.print(b"async");
+                } else {
+                    self.print(b"function*");
                 }
                 self.print_fn_args(
                     Some(func.open_parens_loc),
@@ -6747,7 +6755,11 @@ pub(crate) mod __gated_printer {
                     func.flags.contains(G::FnFlags::HasRestArg),
                     false,
                 );
-                self.print(b" => {\n");
+                self.print(if uses_top_level_await {
+                    b" => {\n".as_slice()
+                } else {
+                    b" {\n".as_slice()
+                });
                 self.indent();
                 self.print_block_body(slice_of(func.body.stmts));
                 self.unindent();
@@ -6755,7 +6767,7 @@ pub(crate) mod __gated_printer {
                 self.print(b"}, ");
 
                 // Print isAsync
-                self.print(if !ast.top_level_await_keyword.is_empty() {
+                self.print(if uses_top_level_await {
                     b"true".as_slice()
                 } else {
                     b"false".as_slice()

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2872,7 +2872,10 @@ impl DevServer {
         if any {
             w.extend_from_slice(b"  ");
         }
-        w.extend_from_slice(b"], [], [], () => {}, false],\n");
+        // The load function of an HTML route is a generator like every other
+        // module without top-level await: the runtime resumes it once to
+        // instantiate and once to evaluate.
+        w.extend_from_slice(b"], [], [], function* () {}, false],\n");
 
         // Avoid-recloning if it is was moved to the heap
         Ok(array.into_boxed_slice())

--- a/src/runtime/bake/bake.private.d.ts
+++ b/src/runtime/bake/bake.private.d.ts
@@ -47,9 +47,27 @@ declare type UnloadedESM = [
   deps: EncodedDependencyArray,
   exportKeys: string[],
   starImports: Id[],
-  load: (mod: import("./hmr-module").HMRModule) => Promise<void>,
+  load: EsmTwoPhaseLoad | EsmSinglePhaseLoad,
   isAsync: boolean,
 ];
+/** An ESM module links in two phases. The bundler emits the module body as a
+ * generator whose single `yield` separates them:
+ *
+ * - Before the `yield` (instantiate): the hoisted declarations, `hmr.exports`
+ *   and `hmr.updateImport`. No statement of the module body runs.
+ * - After the `yield` (evaluate): `hmr.imports` is destructured, then the rest
+ *   of the module body runs.
+ *
+ * The runtime instantiates a module before it loads the dependencies of the
+ * module, and binds the import of the importer as soon as a dependency
+ * instantiates. So a module in an import cycle observes a live namespace
+ * object for a partner that has not evaluated yet. */
+declare type EsmTwoPhaseLoad = (mod: import("./hmr-module").HMRModule) => EsmLink;
+declare type EsmLink = Generator<void, void, void>;
+/** A module with top-level await must be able to suspend on `await`, so the
+ * bundler emits its body in one phase. The `isAsync` slot of `UnloadedESM`
+ * selects this form. */
+declare type EsmSinglePhaseLoad = (mod: import("./hmr-module").HMRModule) => Promise<void>;
 declare type EncodedDependencyArray = (string | number)[];
 declare type UnloadedCommonJS = (
   hmr: import("./hmr-module").HMRModule,

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -77,7 +77,8 @@ export class HMRModule {
   /** ES Modules have different semantics for `.exports` and `.cjs` */
   esm: boolean;
   state: State = State.Pending;
-  /** The ESM namespace object. `null` if not yet initialized. */
+  /** The ESM namespace object. `null` until the module is instantiated; from
+   * then on it is a live object, even while the module still evaluates. */
   exports: any = null;
   /** For ESM, this is the converted CJS exports.
    *  For CJS, this is the `module` object. */
@@ -89,9 +90,13 @@ export class HMRModule {
    * 1. HMRModule[] - List of parsed imports. indexOf is used to go from HMRModule -> updater function
    * 2. any[] - List of module namespace objects. Read by the ESM module's load function.
    * Unused for CJS
+   *
+   * Stays `null` until the module evaluates, which is after its dependencies
+   * load.
    */
   imports: HMRModule[] | any[] | null = null;
-  /** Assignned by an ESM module's load function immediately.
+  /** Assigned by an ESM module's load function during instantiation, which is
+   * before `imports` is filled in.
    * HTML files do not emit a store to this field */
   updateImport: ((exports: any) => void)[] | null = null;
   /** When calling `import.meta.hot.dispose` */
@@ -272,13 +277,21 @@ HMRModule.prototype.indirectHot = new Proxy({}, {
 });
 
 // TODO: This function is currently recursive.
-export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModule | null): HMRModule {
+export function loadModuleSync(
+  id: Id,
+  isUserDynamic: boolean,
+  importer: HMRModule | null,
+  importIndex?: number,
+): HMRModule {
   // First, try and re-use an existing module.
   let mod = registry.get(id);
   if (mod) {
     if (mod.state === State.Error) throw mod.failure;
     if (mod.state === State.Stale) {
       mod.state = State.Pending;
+      // The bindings of the previous evaluation take no part in this one.
+      mod.imports = null;
+      mod.updateImport = null;
       isUserDynamic = false;
     } else {
       if (importer) {
@@ -346,14 +359,16 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
       mod.importers.add(importer);
     }
 
+    const link = instantiateEsmModule(mod, load, false); // `isAsync` was rejected above
+    bindImportOfImporterOnStack(importer, importIndex, mod);
     const { list: depsList } = parseEsmDependencies(mod, deps, loadModuleSync);
-    const exportsBefore = mod.exports;
     mod.imports = depsList.map(getEsmExports);
-    load(mod);
+    const shouldPatchImporters = !mod.selfAccept || mod.selfAccept === implicitAcceptFunction;
+    evaluateEsmModule(mod, link, load);
     mod.imports = depsList;
-    if (mod.exports === exportsBefore) mod.exports = {};
     mod.cjs = null;
     mod.state = State.Loaded;
+    if (shouldPatchImporters) patchImporters(mod);
   }
 
   return mod;
@@ -368,6 +383,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
   id: Id,
   isUserDynamic: IsUserDynamic,
   importer: HMRModule | null,
+  importIndex?: number,
 ): (IsUserDynamic extends true ? null : never) | Promise<HMRModule> | HMRModule {
   // First, try and re-use an existing module.
   let mod = registry.get(id)!;
@@ -376,6 +392,9 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
     if (state === State.Error) throw mod.failure;
     if (state === State.Stale) {
       mod.state = State.Pending;
+      // The bindings of the previous evaluation take no part in this one.
+      mod.imports = null;
+      mod.updateImport = null;
       isUserDynamic = false as IsUserDynamic;
     } else {
       if (importer) {
@@ -431,7 +450,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
         throw e;
       }
     }
-    const [deps /* exports */ /* stars */, , , load /* isAsync */] = loadOrEsmModule;
+    const [deps /* exports */ /* stars */, , , load, usesTopLevelAwait] = loadOrEsmModule;
 
     if (!mod) {
       mod = new HMRModule(id, false);
@@ -445,7 +464,22 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
       mod.importers.add(importer);
     }
 
-    const { list, isAsync } = parseEsmDependencies(mod, deps, loadModuleAsync<false>);
+    // Instantiate before the dependencies are visited, so that a dependency
+    // which imports this module back sees a live namespace object. A module
+    // with no imports has no `yield`, so this runs its whole body; record a
+    // throw the same way the evaluation phase does.
+    let link: EsmLink | null;
+    let list: (HMRModule | Promise<HMRModule>)[];
+    let isAsync: boolean;
+    try {
+      link = instantiateEsmModule(mod, load, usesTopLevelAwait);
+      bindImportOfImporterOnStack(importer, importIndex, mod);
+      ({ list, isAsync } = parseEsmDependencies(mod, deps, loadModuleAsync<false>));
+    } catch (e) {
+      mod.state = State.Error;
+      mod.failure = e;
+      throw e;
+    }
     DEBUG.ASSERT(
       isAsync //
         ? list.some(x => x instanceof Promise)
@@ -456,7 +490,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
     // not a performance optimization but a behavioral correctness issue.
     return isAsync
       ? Promise.all(list).then(
-          list => finishLoadModuleAsync(mod, load, list),
+          list => finishLoadModuleAsync(mod, link, load, list),
           e => {
             mod.state = State.Error;
             mod.failure = e;
@@ -465,29 +499,87 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
         )
       : finishLoadModuleAsync(
           mod,
+          link,
           load,
           list as HMRModule[], // no promises as by assert above
         );
   }
 }
 
-function finishLoadModuleAsync(mod: HMRModule, load: UnloadedESM[3], modules: HMRModule[]) {
+/** Phase one of the ESM link. Runs the module up to its `yield`, which declares
+ * the hoisted functions, installs the namespace object and registers
+ * `updateImport`. No statement of the module body runs.
+ *
+ * Returns `null` for a module with top-level await: that module is emitted in
+ * one phase, so it can only be instantiated and evaluated together. A cycle
+ * through such a module reads an empty namespace object instead of `null`, and
+ * the importer replaces it with the loaded one when its own dependencies
+ * settle. */
+function instantiateEsmModule(mod: HMRModule, load: UnloadedESM[ESMProps.load], usesTopLevelAwait: boolean) {
+  // The namespace object of the previous evaluation must not survive a hot
+  // update of a module that has no exports now.
+  mod.exports = null;
+  const link = usesTopLevelAwait ? null : (load as EsmTwoPhaseLoad)(mod);
+  link?.next();
+  // A module with no exports emits no store to `hmr.exports`. Give it an empty
+  // namespace object anyway: an importer must never see `null`.
+  mod.exports ??= {};
+  return link;
+}
+
+/** The importer is on the stack while its dependency instantiates: the body
+ * of the importer has not bound its imports yet. A function of the importer
+ * that the body of the dependency calls, as happens in an import cycle, must
+ * already see the namespace object. So the binding is made here, the way the
+ * ESM link binds every import before any module evaluates. An importer that
+ * is emitted in one phase, or a CommonJS importer, has no `updateImport` yet
+ * and binds its imports itself. */
+function bindImportOfImporterOnStack(
+  importer: HMRModule | null,
+  importIndex: number | undefined,
+  dependency: HMRModule,
+) {
+  if (importer === null || importIndex === undefined) return;
+  importer.updateImport?.[importIndex](dependency.exports);
+}
+
+/** Phase two of the ESM link. Runs the module body. Returns the promise of a
+ * module that uses top-level await.
+ *
+ * A module with no imports cannot take part in a cycle, so the bundler emits
+ * no `yield` for it and phase one already ran its body. The loop covers that
+ * case: a generator that has finished answers `done`. */
+function evaluateEsmModule(
+  mod: HMRModule,
+  link: EsmLink | null,
+  load: UnloadedESM[ESMProps.load],
+): Promise<void> | void {
+  if (!link) return (load as EsmSinglePhaseLoad)(mod);
+  let step = link.next();
+  while (!step.done) {
+    step = link.next();
+  }
+}
+
+function finishLoadModuleAsync(
+  mod: HMRModule,
+  link: EsmLink | null,
+  load: UnloadedESM[ESMProps.load],
+  modules: HMRModule[],
+) {
   try {
-    const exportsBefore = mod.exports;
     mod.imports = modules.map(getEsmExports);
     const shouldPatchImporters = !mod.selfAccept || mod.selfAccept === implicitAcceptFunction;
-    const p = load(mod);
+    const p = evaluateEsmModule(mod, link, load);
     mod.imports = modules;
     if (p) {
       return p.then(() => {
         mod.state = State.Loaded;
-        if (mod.exports === exportsBefore) mod.exports = {};
         mod.cjs = null;
         if (shouldPatchImporters) patchImporters(mod);
         return mod;
       });
     }
-    if (mod.exports === exportsBefore) mod.exports = {};
     mod.cjs = null;
     if (shouldPatchImporters) patchImporters(mod);
     mod.state = State.Loaded;
@@ -499,7 +591,7 @@ function finishLoadModuleAsync(mod: HMRModule, load: UnloadedESM[3], modules: HM
   }
 }
 
-type GenericModuleLoader<R> = (id: Id, isUserDynamic: false, importer: HMRModule) => R;
+type GenericModuleLoader<R> = (id: Id, isUserDynamic: false, importer: HMRModule, importIndex: number) => R;
 // TODO: This function is currently recursive.
 function parseEsmDependencies<T extends GenericModuleLoader<any>>(
   parent: HMRModule,
@@ -515,7 +607,7 @@ function parseEsmDependencies<T extends GenericModuleLoader<any>>(
     DEBUG.ASSERT(typeof dep === "string");
     let expectedExportKeyEnd = i + 2 + (deps[i + 1] as number);
     DEBUG.ASSERT(typeof deps[i + 1] === "number");
-    const promiseOrModule = enqueueModuleLoad(dep, false, parent);
+    const promiseOrModule = enqueueModuleLoad(dep, false, parent, list.length);
     list.push(promiseOrModule);
 
     const unloadedModule = unloadedModuleRegistry[dep];
@@ -801,8 +893,10 @@ function patchImporters(mod: HMRModule) {
   const { importers } = mod;
   const exports = getEsmExports(mod);
   for (const importer of importers) {
-    if (!importer.esm || !importer.updateImport) continue;
-    const index = importer.imports!.indexOf(mod);
+    // `updateImport` is registered during instantiation, `imports` only just
+    // before evaluation, so an importer can be instantiated but not linked yet.
+    if (!importer.esm || !importer.updateImport || !importer.imports) continue;
+    const index = importer.imports.indexOf(mod);
     if (index === -1) continue; // require or dynamic import
     importer.updateImport![index](exports);
   }
@@ -923,12 +1017,18 @@ function isReactRefreshBoundary(esmExports): boolean {
   let areAllExportsComponents = true;
   for (const key in esmExports) {
     hasExports = true;
-    const desc = Object.getOwnPropertyDescriptor(esmExports, key);
-    if (desc && desc.get) {
-      // Don't invoke getters as they may have side effects.
+    // Metro refuses a getter here, because a getter can have side effects.
+    // Every getter of a namespace object of the dev server is a read of a
+    // binding that the bundler emitted, so it has no side effect. It can still
+    // throw: a re-export reads the binding of another module, and inside an
+    // import cycle that module can be between its declarations. A module that
+    // cannot answer is not a boundary.
+    let exportValue;
+    try {
+      exportValue = esmExports[key];
+    } catch {
       return false;
     }
-    const exportValue = esmExports[key];
     if (!isLikelyComponentType(exportValue)) {
       areAllExportsComponents = false;
     }

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -280,6 +280,53 @@ devTest("deleting imported file shows error then recovers", {
 // client_graph.disconnectAndDeleteFile which frees that key. Previously the
 // Dep was left pointing at freed memory, and the next directory-watch event
 // that re-resolved that Dep read it (use-after-free, caught by ASAN).
+// A `"use client"` module is replaced on the server by a client reference
+// proxy, which the transform in `AstBuilder` generates. The dev server builds
+// the namespace object of a module while the module instantiates, which is
+// before the `const` declarations of its body run, so every property of that
+// object must be a getter. A data property reads its binding at once, and the
+// update of the proxy then throws `ReferenceError: Cannot access 'marker'
+// before initialization` inside the server runtime.
+devTest("the server reads the namespace of a client reference proxy after an update", {
+  // separateSSRGraph puts the proxy in the server graph, where an update
+  // instantiates it again.
+  framework: {
+    ...minimalFramework,
+    serverComponents: {
+      ...minimalFramework.serverComponents!,
+      separateSSRGraph: true,
+    },
+  },
+  files: {
+    "routes/index.ts": `
+      import * as Comp from '../components/Comp';
+      export default function (req, meta) {
+        return new Response(
+          'keys: ' + Object.keys(Comp).sort().join(',') +
+          ' | value: ' + typeof Comp.marker.value +
+          ' | uid: ' + Comp.marker.uid,
+        );
+      }
+    `,
+    "components/Comp.ts": `
+      "use client";
+      export const marker = "one";
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("keys: marker | value: function | uid: marker");
+    await dev.write(
+      "components/Comp.ts",
+      `
+        "use client";
+        export const marker = "two";
+      `,
+    );
+    // Without a getter the proxy throws while it instantiates, and this
+    // request answers 500.
+    await dev.fetch("/").equals("keys: marker | value: function | uid: marker");
+  },
+});
 devTest("removing 'use client' from a component with a pending resolution failure", {
   // separateSSRGraph is required so the "use client" file is parsed with the
   // browser target; otherwise the resolution failure is attributed to the

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -206,6 +206,314 @@ devTest("export { default as y }", {
     await dev.fetch("/").equals("Value: 2");
   },
 });
+// A module that takes part in an import cycle is evaluated while its partner is
+// still on the stack. Its partner's exported function declarations are already
+// initialized, the same as with `bun run` and with `bun build`.
+devTest("import cycle: a top level read of the cyclic import", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    // `index.ts` enters the cycle through `load-client.ts`, so `router.ts` is
+    // the module that evaluates inside the cycle.
+    "index.ts": `
+      import { replaceRouteChunk } from './load-client';
+      import { RouterCore } from './router';
+      if (typeof RouterCore.prototype.replaceRouteChunk !== 'function')
+        throw new Error('the cyclic import was not linked: ' + typeof RouterCore.prototype.replaceRouteChunk);
+      if (replaceRouteChunk() !== 'chunk:info') throw new Error('wrong value: ' + replaceRouteChunk());
+      console.log('PASS');
+    `,
+    "load-client.ts": `
+      import { getInfo } from './router';
+      export function replaceRouteChunk() { return 'chunk:' + getInfo(); }
+    `,
+    "router.ts": `
+      import { replaceRouteChunk } from './load-client';
+      export function getInfo() { return 'info'; }
+      export class RouterCore {}
+      RouterCore.prototype.replaceRouteChunk = replaceRouteChunk;
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage("PASS");
+  },
+});
+// The same cycle, read after both modules evaluate. `patchImporters` repairs
+// this one, and it must keep working with the two phase link.
+devTest("import cycle: a deferred read of the cyclic import", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import './load-client';
+      import { RouterCore } from './router';
+      if (new RouterCore().replaceRouteChunk() !== 'chunk:info') throw new Error('wrong value');
+      console.log('PASS');
+    `,
+    "load-client.ts": `
+      import { getInfo } from './router';
+      export function replaceRouteChunk() { return 'chunk:' + getInfo(); }
+    `,
+    "router.ts": `
+      import { replaceRouteChunk } from './load-client';
+      export function getInfo() { return 'info'; }
+      export class RouterCore {
+        replaceRouteChunk() { return replaceRouteChunk(); }
+      }
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage("PASS");
+  },
+});
+// Each export form of the module inside the cycle is read by its partner
+// while the module is still on the stack: a class, a reassigned `let`, an
+// `export * as` namespace, a default export of an object, an alias, and a
+// constant that the lowering moves into the namespace object.
+devTest("import cycle: each export form of the module inside the cycle", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    // `index.ts` enters the cycle through `reader.ts`, so `shapes.ts`
+    // evaluates inside the cycle and calls `read` while `reader.ts` is still
+    // on the stack.
+    "index.ts": `
+      import { read } from './reader';
+      import { reading } from './shapes';
+      if (reading !== 'function,2,leaf,made,renamed,moved') throw new Error('wrong value: ' + reading);
+      if (read() !== reading) throw new Error('the later read differs: ' + read());
+      console.log('PASS');
+    `,
+    "reader.ts": `
+      import made, { Shape, counter, ns, renamed, movable } from './shapes';
+      export function read() {
+        return [typeof Shape, counter, ns.leaf, made.kind, renamed, movable].join(',');
+      }
+    `,
+    "shapes.ts": `
+      import { read } from './reader';
+      export class Shape {}
+      export let counter = 1;
+      counter = 2;
+      export * as ns from './leaf';
+      export default { kind: 'made' };
+      const local = 'renamed';
+      export { local as renamed };
+      export const movable = 'moved';
+      export const reading = read();
+    `,
+    "leaf.ts": `
+      export const leaf = 'leaf';
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage("PASS");
+  },
+});
+// A read of a binding that the module inside the cycle has not declared yet
+// is a temporal dead zone error, the same as with `bun run`: not `undefined`,
+// and not a `TypeError` on a missing namespace.
+devTest("import cycle: a read of a binding before its declaration throws", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    // `index.ts` enters the cycle through `shapes.ts`, so `reader.ts`
+    // evaluates before `shapes.ts` declares `Shape`.
+    "index.ts": `
+      import { Shape } from './shapes';
+      import { seen } from './reader';
+      if (seen !== 'ReferenceError') throw new Error('expected the temporal dead zone, got: ' + seen);
+      if (typeof Shape !== 'function') throw new Error('the class is not exported');
+      console.log('PASS');
+    `,
+    "reader.ts": `
+      import { Shape } from './shapes';
+      let seen;
+      try { seen = typeof Shape; } catch (error) { seen = error.constructor.name; }
+      export { seen };
+    `,
+    "shapes.ts": `
+      import './reader';
+      export class Shape {}
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage("PASS");
+  },
+});
+// A module with top level await keeps the single phase form: its namespace
+// object exists only after its body. Its partner reads it after both evaluate.
+devTest("import cycle through a module with top level await: a deferred read", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { describe } from './partner';
+      import { waited, partnerName } from './waiter';
+      if (describe() !== 'waited:partner') throw new Error('wrong value: ' + describe());
+      if (partnerName() !== 'partner') throw new Error('wrong value: ' + partnerName());
+      console.log('PASS');
+    `,
+    "partner.ts": `
+      import { waited } from './waiter';
+      export const name = 'partner';
+      export function describe() { return waited + ':' + name; }
+    `,
+    "waiter.ts": `
+      import { name } from './partner';
+      export const waited = await Promise.resolve('waited');
+      export function partnerName() { return name; }
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage("PASS");
+  },
+});
+// A module with top level await keeps the single phase form, so its namespace
+// object stays empty until its body ends. A top level read of it from inside
+// the cycle answers `undefined`. `bun run` throws
+// `ReferenceError: Cannot access 'value' before initialization` for the same
+// files, and the dev server of 1.4.0 throws `TypeError: null is not an
+// object`. This test documents the middle state, which no longer stops the
+// page.
+devTest("import cycle through a module with top level await: a top level read", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { seen } from './waiter';
+      console.log('seen: ' + seen);
+    `,
+    "waiter.ts": `
+      import { describe } from './partner';
+      export const value = await Promise.resolve('waited');
+      export const seen = describe();
+    `,
+    "partner.ts": `
+      import { value } from './waiter';
+      export function describe() { return String(value); }
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage("seen: undefined");
+  },
+});
+// A module with `export * from` keeps the single phase form too, because the
+// spread copies the re-exported values. Its partner reads it after both
+// evaluate.
+devTest("import cycle through an export star barrel: a deferred read", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { read } from './reader';
+      import * as barrel from './barrel';
+      if (read() !== 'leaf+reader') throw new Error('wrong value: ' + read());
+      if (barrel.leaf !== 'leaf') throw new Error('wrong value: ' + barrel.leaf);
+      console.log('PASS');
+    `,
+    "reader.ts": `
+      import { leaf, own } from './barrel';
+      export const tag = 'reader';
+      export function read() { return leaf + '+' + own(); }
+    `,
+    "barrel.ts": `
+      import { tag } from './reader';
+      export * from './leaf';
+      export function own() { return tag; }
+    `,
+    "leaf.ts": `
+      export const leaf = 'leaf';
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage("PASS");
+  },
+});
+// A hot update replaces the module inside the cycle and links it again with
+// its partner, which did not change.
+devTest("import cycle: a hot update of the module inside the cycle", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import './load-client';
+      import { RouterCore } from './router';
+      console.log('value ' + new RouterCore().replaceRouteChunk());
+      import.meta.hot.accept();
+    `,
+    "load-client.ts": `
+      import { getInfo } from './router';
+      export function replaceRouteChunk() { return 'chunk:' + getInfo(); }
+    `,
+    "router.ts": `
+      import { replaceRouteChunk } from './load-client';
+      export function getInfo() { return 'info 1'; }
+      export class RouterCore {
+        replaceRouteChunk() { return replaceRouteChunk(); }
+      }
+      RouterCore.prototype.chunkAtLoad = replaceRouteChunk();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage("value chunk:info 1");
+    await dev.patch("router.ts", {
+      find: "info 1",
+      replace: "info 2",
+    });
+    await c.expectMessage("value chunk:info 2");
+  },
+});
+// A module with no imports gets no `yield`, so the instantiation phase runs
+// its whole body. A throw there must be recorded on the module, the way a
+// throw in the evaluation phase is: the next import of that id repeats the
+// error instead of handing out a module that never finished.
+devTest("a module that throws while it instantiates keeps the failure", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      async function attempt(label) {
+        try {
+          await import('./boom');
+          console.log(label + ': no error');
+        } catch (error) {
+          console.log(label + ': ' + error.message);
+        }
+      }
+      void (async () => {
+        await attempt('first');
+        await attempt('second');
+      })();
+    `,
+    // No imports, so the bundler emits no `yield` for this module.
+    "boom.ts": `
+      throw new Error('boom');
+      export const unreachable = 1;
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client({ errors: ["error: boom"] });
+    await c.expectMessage("first: boom", "second: boom");
+  },
+});
 devTest("export * as namespace", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/bake/dev/react-spa.test.ts
+++ b/test/bake/dev/react-spa.test.ts
@@ -93,6 +93,52 @@ const reactAndRefreshStub = {
     });
   `,
 };
+// `isReactRefreshBoundary` reads the value of every export. A re-export reads
+// the binding of another module, and inside an import cycle that module can be
+// between its declarations, so the read throws. A module that cannot answer is
+// not a boundary; it must not fail to load.
+devTest("a re-export inside an import cycle does not break the refresh boundary check", {
+  framework: minimalFramework,
+  files: {
+    ...reactAndRefreshStub,
+    // The shared stub answers `true` for every value, which returns from
+    // `isReactRefreshBoundary` before it reads a single export. This runtime
+    // answers the way `react-refresh` does, so the check reads the values.
+    "node_modules/react-refresh/runtime.js": /* js */ `
+      exports.performReactRefresh = () => {};
+      exports.injectIntoGlobalHook = () => {};
+      exports.isLikelyComponentType = (value) => typeof value === "function";
+      exports.register = require("bun-devserver-react-mock").register;
+      exports.createSignatureFunctionForTransform = require("bun-devserver-react-mock").createSignatureFunctionForTransform;
+    `,
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.tsx"],
+    }),
+    "index.tsx": `
+      import { Thing } from './a';
+      import { Widget } from './b';
+      console.log('loaded ' + typeof Thing + ' ' + typeof Widget);
+    `,
+    // `b.tsx` evaluates while this module is still between its `yield` and the
+    // declaration of `Thing`.
+    "a.tsx": `
+      import './b';
+      export class Thing {}
+    `,
+    // `Widget` makes this module register a component, so it calls
+    // `hmr.reactRefreshAccept()`, which reads the value of every export of
+    // this module, including the re-export of `Thing`.
+    "b.tsx": `
+      export { Thing } from './a';
+      export function Widget() { return null; }
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage("loaded function function");
+  },
+});
 devTest("react in html", {
   fixture: "react-spa-simple",
   async test(dev) {


### PR DESCRIPTION
### What does this PR do?

Fixes #40248.

#### The defect

A module in an import cycle reads its partner. The dev server gives it `null`. The read then throws:

```
TypeError: null is not an object (evaluating 'import_entry.name')
```

`@tanstack/react-router` 1.170.31 cannot load under the dev server for this reason. `@tanstack/router-core` has the cycle `router.js` ⇄ `load-client.js`, and its `router.js` reads the import at the top level.

The same 4 files work with `bun run`, with `bun build`, and with `development: { hmr: false }`.

#### The cause

The dev server links a module in one phase. The wrapper reads `hmr.imports` at the start of the body. It assigns `hmr.exports` at the end. A module in a cycle evaluates while its partner is still on the stack, so the partner has no namespace object yet. `patchImporters` cannot repair that importer, because the importer has no import list yet.

#### The change

The module body is a generator now. One `yield` separates the two phases of the ECMAScript module link.

| Phase | What the module does |
| --- | --- |
| before the `yield` | declares the hoisted functions, assigns `hmr.exports`, registers `hmr.updateImport` |
| after the `yield` | reads `[...] = hmr.imports`, then runs the body |

The runtime instantiates a module before it loads the dependencies of that module. It also binds the import of an importer that is still on the stack, as soon as a dependency instantiates. The evaluation order does not change.

Every property of the namespace object that reads a binding is a getter now. A data property reads its binding when the object is built, and the dev server builds that object during instantiation. Two transforms build this object, and both emit getters: `ConvertESMExportsForHmr` and the open-coded transform in `AstBuilder.rs`.

#### How other dev servers link a cycle

| Tool | The namespace object exists | The exports are registered |
| --- | --- | --- |
| webpack | before the factory runs: `module = __webpack_module_cache__[id] = { exports: {} }` | `__webpack_require__.d(exports, {...})`, in the earliest init fragment `STAGE_HARMONY_EXPORTS` |
| Vite | before `runInlinedModule`: `mod.exports = exports` | `__vite_ssr_exportName__("foo", () => ...)`, prepended before the first statement |
| Parcel | before the factory runs: `cache[name] = new newRequire.Module(name)` | `Object.defineProperty(m, key, { get })` |

All 3 build the object before the body, and all 3 use getters. This PR gives the dev server the same shape.

One difference is deliberate. The Vite getter answers `undefined` for a binding in its temporal dead zone. This PR lets that read throw, as `bun run` does.

#### 4 cases that needed care

| Case | What this PR does |
| --- | --- |
| top-level await | The module keeps the one-phase form, because a generator cannot suspend on `await`. See the limitation below. |
| `export *` | The module keeps its `hmr.exports` assignment in the body. The spread that the star lowers to copies the values, and a copy taken at instantiation is empty. |
| client reference proxies | `AstBuilder.rs` emitted data properties over `const` bindings that its body declares later. The proxy threw `ReferenceError`, and the route answered 500. It emits getters now. |
| React Fast Refresh | `isReactRefreshBoundary` refused an accessor. It reads the values now, or no module is a boundary and every edit reloads the page. A value that throws answers "not a boundary". |

#### A known limitation

A cycle through a module with top-level await gets better, not correct. That module keeps the one-phase form, so its namespace object stays empty until its body ends. A top level read inside such a cycle answers:

| Where | Answer |
| --- | --- |
| dev server on 1.4.0 | `TypeError: null is not an object`, and the page stops |
| dev server with this PR | `undefined`, and the page runs |
| `bun run` | `ReferenceError: Cannot access 'value' before initialization` |

A deferred read through such a module is correct, because `patchImporters` rebinds the import after the module loads. Two tests cover both reads.

webpack and Vite do not have this limitation. They register the exports with a call at the top of the body, not with one assignment at the end. An async module of theirs therefore registers its getters before its first `await`. Their module body also pulls its own dependencies, while the dev server pushes them in from the loader. That is why this PR needs a suspension point.

A module tuple with 2 entry points would remove the limitation: a synchronous `instantiate(hmr)`, and an `evaluate(hmr)` that may be async. That changes the module format, so it is out of scope here.

#### Notes for a reviewer

- Phase one records a failure the way the evaluation phase does. A module with no imports gets no `yield`, so phase one runs its whole body. Without this the module stayed `Pending` with `failure === null`, and the next import of that id returned a module that never finished.
- A function of the importer that the cycle calls sees the imports that instantiated so far. An import later in the list binds when its own module instantiates. webpack and the Vite module runner behave the same way.
- The HTML route stub in `DevServer.rs` is a generator now, like every other module without top-level await.

#### Earlier work

#25294 attempted the same defect and was closed without merge. It had no test, and it deferred every evaluation until the graph traversal ended, which changes the evaluation order.

#29747 and #29749 lose a live binding through an `export *` barrel. Here the whole namespace is lost through a cycle.

#40259 fixes the same defect and also rewrites `export *`. This PR is narrower: it covers the cycle itself with 8 tests, including 2 for top-level await, which #40259 does not test.

### How did you verify your code works?

#### Tests for the defect

`test/bake/dev/esm.test.ts` gets 8 tests under `import cycle:`. 5 of them fail on 1.4.0 and pass here:

```sh
USE_SYSTEM_BUN=1 bun test test/bake/dev/esm.test.ts -t "import cycle"   # 3 pass, 5 fail
bun bd test test/bake/dev/esm.test.ts -t "import cycle"                 # 8 pass
```

The 5 are:

- a top level read of the cyclic import;
- each export form of the module inside the cycle: a `class`, a reassigned `let`, an `export * as` namespace, a default export, an alias, and a moved constant;
- a read of a binding before its declaration, which throws `ReferenceError` as `bun run` does;
- a hot update of the module inside the cycle;
- a top level read through a module with top-level await, which answers `undefined` here and throws `TypeError` on 1.4.0.

The other 3 pass before and after this change, as guards: a deferred read of the cyclic import, a cycle through a module with top-level await, and a cycle through an `export *` barrel.

#### Tests for the change itself

3 more tests guard the parts of this PR that are not the defect. I ran each one on a build that misses only its own fix, so each test is red for a reason.

| Test | Without its fix |
| --- | --- |
| `bundle.test.ts`: the server reads the namespace of a client reference proxy after an update | 500, `ReferenceError: Cannot access 'marker' before initialization` |
| `esm.test.ts`: a module that throws while it instantiates keeps the failure | the second import answers "no error" |
| `react-spa.test.ts`: a re-export inside an import cycle does not break the refresh boundary check | `ReferenceError: Cannot access 'Thing' before initialization` |

All 3 pass on main, so they guard the change and do not encode it. The refresh test carries its own `react-refresh` runtime, because the shared stub answers `isLikelyComponentType` with `true`. That answer returns from `isReactRefreshBoundary` before it reads an export.

#### Suites and checks

`bun bd test test/bake/`: 203 pass, 1 fail. The failure is `deinitialization.test.ts`. Its first case waits on a `fetch` to a stopped server, and a `fetch` to any closed `localhost` port takes 134 s on my machine (WSL2) with the stock 1.4.0 too. It is not related to this change.

`cargo clippy -p bun_js_parser -p bun_bundler -p bun_js_printer --no-deps`: no warnings. `cargo fmt --check` and `bun run prettier --check`: clean. The branch is rebased on `acd34224`.

#### The application that found it

An editor of 516 client modules uses `@tanstack/react-router` 1.170.31. It loads with this change. It throws `TypeError: null is not an object (evaluating 'import_load_client.replaceRouteChunk')` without it. I checked both builds with the happy-dom client of `test/bake/bake-harness.ts` and in Chrome.
