### PR TITLE
resolver: publish Entry.abs_path through the per-entry mutex

### DIFF
--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -1179,7 +1179,7 @@ where
                                                     core::sync::atomic::Ordering::Release,
                                                 );
                                             }
-                                            path_string = ent.abs_path;
+                                            path_string = ent.abs_path();
                                             file_hash = Watcher::get_hash(path_string.as_bytes());
                                             for (entry_id, hash) in hashes.iter().enumerate() {
                                                 if *hash == file_hash {

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -144,7 +144,15 @@ pub struct Entry {
     pub mutex: Mutex,
     pub need_stat: AtomicBool,
 
-    pub abs_path: Interned,
+    // Filled lazily by whichever thread first needs the absolute path (the
+    // resolver on a bundler thread, `Route::parse` on the JS thread). The fill
+    // happens under `mutex`; `has_abs_path` is the Release/Acquire publish
+    // flag that lets `abs_path()` stay lock-free, the same way `need_stat`
+    // publishes `cache`. A plain field was a data race: `Interned` is a
+    // two-word `(ptr, len)`, and a reader that saw the new `len` with the
+    // `EMPTY` pointer faulted inside `strings::last_index_of`.
+    abs_path: core::cell::Cell<Interned>,
+    has_abs_path: AtomicBool,
 }
 
 impl Entry {
@@ -188,15 +196,47 @@ impl Entry {
         self.dir
     }
 
-    /// `Interned` is `Copy`.
+    /// The cached absolute path, or `Interned::EMPTY` until a fill has been
+    /// published. Lock-free: the Acquire load pairs with the Release store in
+    /// [`set_abs_path`](Self::set_abs_path), so a reader either sees `EMPTY` or
+    /// the complete `(ptr, len)` pair, never a torn one.
     #[inline]
     pub fn abs_path(&self) -> Interned {
-        self.abs_path
+        if self.has_abs_path.load(Ordering::Acquire) {
+            self.abs_path.get()
+        } else {
+            Interned::EMPTY
+        }
     }
 
+    /// Publish the absolute path. Caller must hold `self.mutex` and must have
+    /// checked [`abs_path`](Self::abs_path) is still `EMPTY` under that lock:
+    /// a published value is never rewritten, which is what keeps the
+    /// lock-free reads in `abs_path()` sound.
     #[inline]
-    pub fn set_abs_path(&mut self, p: Interned) {
-        self.abs_path = p;
+    pub fn set_abs_path(&self, p: Interned) {
+        debug_assert!(!self.has_abs_path.load(Ordering::Relaxed));
+        self.abs_path.set(p);
+        self.has_abs_path.store(true, Ordering::Release);
+    }
+
+    /// Return the cached absolute path, computing and publishing it with
+    /// `fill` on first use. Double-checked on `self.mutex`, like
+    /// [`kind`](Self::kind): the fast path is the lock-free `abs_path()` read,
+    /// and when two threads race to fill the same entry only one `fill` runs.
+    /// `fill` must not touch this entry's `mutex`.
+    pub fn abs_path_or_fill(&self, fill: impl FnOnce() -> Interned) -> Interned {
+        if self.has_abs_path.load(Ordering::Acquire) {
+            return self.abs_path.get();
+        }
+        let _guard = self.mutex.lock_guard();
+        // Relaxed: every write happens under `mutex`, which we hold.
+        if self.has_abs_path.load(Ordering::Relaxed) {
+            return self.abs_path.get();
+        }
+        let p = fill();
+        self.set_abs_path(p);
+        p
     }
 
     /// Stat-on-first-use.
@@ -548,7 +588,8 @@ impl DirEntry {
                     kind: found_kind.unwrap_or(EntryKind::File),
                     fd: Fd::INVALID,
                 }));
-                addr_of_mut!((*p).abs_path).write(Interned::EMPTY);
+                addr_of_mut!((*p).abs_path).write(core::cell::Cell::new(Interned::EMPTY));
+                addr_of_mut!((*p).has_abs_path).write(AtomicBool::new(false));
                 p
             }
         };

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -144,13 +144,9 @@ pub struct Entry {
     pub mutex: Mutex,
     pub need_stat: AtomicBool,
 
-    // Filled lazily by whichever thread first needs the absolute path (the
-    // resolver on a bundler thread, `Route::parse` on the JS thread). The fill
-    // happens under `mutex`; `has_abs_path` is the Release/Acquire publish
-    // flag that lets `abs_path()` stay lock-free, the same way `need_stat`
-    // publishes `cache`. A plain field was a data race: `Interned` is a
-    // two-word `(ptr, len)`, and a reader that saw the new `len` with the
-    // `EMPTY` pointer faulted inside `strings::last_index_of`.
+    // Lazily filled under `mutex` and published through `has_abs_path`
+    // (Release/Acquire), so `abs_path()` is lock-free and never sees a torn
+    // two-word `Interned`. Same scheme as `need_stat` / `cache`.
     abs_path: core::cell::Cell<Interned>,
     has_abs_path: AtomicBool,
 }
@@ -196,10 +192,7 @@ impl Entry {
         self.dir
     }
 
-    /// The cached absolute path, or `Interned::EMPTY` until a fill has been
-    /// published. Lock-free: the Acquire load pairs with the Release store in
-    /// [`set_abs_path`](Self::set_abs_path), so a reader either sees `EMPTY` or
-    /// the complete `(ptr, len)` pair, never a torn one.
+    /// Lock-free. `Interned::EMPTY` until a fill has been published.
     #[inline]
     pub fn abs_path(&self) -> Interned {
         if self.has_abs_path.load(Ordering::Acquire) {
@@ -209,10 +202,8 @@ impl Entry {
         }
     }
 
-    /// Publish the absolute path. Caller must hold `self.mutex` and must have
-    /// checked [`abs_path`](Self::abs_path) is still `EMPTY` under that lock:
-    /// a published value is never rewritten, which is what keeps the
-    /// lock-free reads in `abs_path()` sound.
+    /// Caller holds `self.mutex` and has seen `abs_path()` empty under it.
+    /// A published value is never rewritten.
     #[inline]
     pub fn set_abs_path(&self, p: Interned) {
         debug_assert!(!self.has_abs_path.load(Ordering::Relaxed));
@@ -220,11 +211,8 @@ impl Entry {
         self.has_abs_path.store(true, Ordering::Release);
     }
 
-    /// Return the cached absolute path, computing and publishing it with
-    /// `fill` on first use. Double-checked on `self.mutex`, like
-    /// [`kind`](Self::kind): the fast path is the lock-free `abs_path()` read,
-    /// and when two threads race to fill the same entry only one `fill` runs.
-    /// `fill` must not touch this entry's `mutex`.
+    /// Double-checked lazy fill under `self.mutex`, like [`kind`](Self::kind).
+    /// `fill` must not lock this entry's `mutex`.
     pub fn abs_path_or_fill(&self, fill: impl FnOnce() -> Interned) -> Interned {
         if self.has_abs_path.load(Ordering::Acquire) {
             return self.abs_path.get();

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3778,19 +3778,17 @@ impl<'a> Resolver<'a> {
                     return MatchStatus::NotFound;
                 }
 
-                let absolute_out_path: &[u8] = {
-                    if entry_query.entry().abs_path.is_empty() {
-                        // SAFETY: EntryStore-owned slot; resolver mutex held. RHS fully
-                        // evaluated before LHS `&mut Entry` is materialized.
-                        unsafe { &mut *entry_query.entry }.abs_path = Interned::from_static(
+                let absolute_out_path: &[u8] = entry_query
+                    .entry()
+                    .abs_path_or_fill(|| {
+                        Interned::from_static(
                             self.fs_ref()
                                 .dirname_store
                                 .append_slice(abs_esm_path)
                                 .expect("unreachable"),
-                        );
-                    }
-                    entry_query.entry().abs_path.as_bytes()
-                };
+                        )
+                    })
+                    .as_bytes();
                 let module_type = if let Some(pkg) = resolved_dir_info.package_json() {
                     pkg.module_type
                 } else {
@@ -3952,21 +3950,19 @@ impl<'a> Resolver<'a> {
         query: &crate::fs::EntryLookup<'static>,
         out: &mut MatchResult,
     ) {
-        let abs_path: &[u8] = {
-            if query.entry().abs_path.is_empty() {
+        let abs_path: &[u8] = query
+            .entry()
+            .abs_path_or_fill(|| {
                 let parts = [query.entry().dir, query.entry().base()];
                 let abs = self.fs_ref().abs_buf(&parts, bufs!(remap_path));
-                // SAFETY: EntryStore-owned slot; resolver mutex held. RHS fully
-                // evaluated before LHS `&mut Entry` is materialized.
-                unsafe { &mut *query.entry }.abs_path = Interned::from_static(
+                Interned::from_static(
                     self.fs_ref()
                         .dirname_store
                         .append_slice(abs)
                         .expect("unreachable"),
-                );
-            }
-            query.entry().abs_path.as_bytes()
-        };
+                )
+            })
+            .as_bytes();
         let module_type = if let Some(pkg) = resolved_dir_info.package_json() {
             pkg.module_type
         } else {
@@ -5363,21 +5359,19 @@ impl<'a> Resolver<'a> {
             if unsafe { lookup.entry().kind(rfs, self.store_fd) }
                 == Fs::file_system::EntryKind::File
             {
-                let out_buf: &[u8] = {
-                    if lookup.entry().abs_path.is_empty() {
+                let out_buf: &[u8] = lookup
+                    .entry()
+                    .abs_path_or_fill(|| {
                         let parts = [dir_info.abs_path, &base[..]];
                         let out_buf_ = self.fs_ref().abs_buf(&parts, bufs!(index));
-                        // SAFETY: EntryStore-owned slot; resolver mutex held. RHS fully
-                        // evaluated before LHS `&mut Entry` is materialized.
-                        unsafe { &mut *lookup.entry }.abs_path = Interned::from_static(
+                        Interned::from_static(
                             self.fs_ref()
                                 .dirname_store
                                 .append_slice(out_buf_)
                                 .expect("unreachable"),
-                        );
-                    }
-                    lookup.entry().abs_path.as_bytes()
-                };
+                        )
+                    })
+                    .as_bytes();
 
                 if let Some(debug) = self.debug_logs.as_mut() {
                     debug
@@ -5853,21 +5847,19 @@ impl<'a> Resolver<'a> {
                     debug.add_note_fmt(format_args!("Found file \"{}\" ", bstr::BStr::new(base)));
                 }
 
-                let abs_path: &'static [u8] = {
-                    if query.entry().abs_path.is_empty() {
+                let abs_path: &'static [u8] = query
+                    .entry()
+                    .abs_path_or_fill(|| {
                         let abs_path_parts = [query.entry().dir, query.entry().base()];
                         let joined = self.fs_ref().abs_buf(&abs_path_parts, bufs!(load_as_file));
-                        // SAFETY: EntryStore-owned slot; resolver mutex held. RHS fully
-                        // evaluated before LHS `&mut Entry` is materialized.
-                        unsafe { &mut *query.entry }.abs_path = Interned::from_static(
+                        Interned::from_static(
                             self.fs_ref()
                                 .dirname_store
                                 .append_slice(joined)
                                 .expect("unreachable"),
-                        );
-                    }
-                    query.entry().abs_path.as_bytes()
-                };
+                        )
+                    })
+                    .as_bytes();
 
                 dec_ret!(Some(LoadResult {
                     path: abs_path,
@@ -5959,13 +5951,12 @@ impl<'a> Resolver<'a> {
                             }
 
                             dec_ret!(Some(LoadResult {
-                                path: {
-                                    if query.entry().abs_path.is_empty() {
-                                        // SAFETY: `dir` is `&'static [u8]` (DirnameStore-interned),
-                                        // copied out so no `&Entry` borrow survives into the
-                                        // `&mut Entry` write below.
+                                path: query
+                                    .entry()
+                                    .abs_path_or_fill(|| {
                                         let entry_dir = query.entry().dir;
-                                        let new_abs = if !entry_dir.is_empty()
+                                        // the trailing separator CAN be missing here
+                                        if !entry_dir.is_empty()
                                             && entry_dir[entry_dir.len() - 1] == SEP
                                         {
                                             let parts: [&[u8]; 2] = [entry_dir, &buffer[..]];
@@ -5975,7 +5966,6 @@ impl<'a> Resolver<'a> {
                                                     .append_parts(&parts)
                                                     .expect("unreachable"),
                                             )
-                                            // the trailing path CAN be missing here
                                         } else {
                                             let parts: [&[u8]; 3] =
                                                 [entry_dir, SEP_STR.as_bytes(), &buffer[..]];
@@ -5985,13 +5975,9 @@ impl<'a> Resolver<'a> {
                                                     .append_parts(&parts)
                                                     .expect("unreachable"),
                                             )
-                                        };
-                                        // SAFETY: EntryStore-owned slot; resolver mutex held. RHS
-                                        // fully evaluated above — sole `&mut Entry` for this write.
-                                        unsafe { &mut *query.entry }.abs_path = new_abs;
-                                    }
-                                    query.entry().abs_path.as_bytes()
-                                },
+                                        }
+                                    })
+                                    .as_bytes(),
                                 dirname_fd: ts_dirname_fd,
                                 file_fd: query.entry().cache().fd,
                             }));
@@ -6063,23 +6049,17 @@ impl<'a> Resolver<'a> {
 
                 // now that we've found it, we allocate it.
                 return Some(LoadResult {
-                    path: {
-                        // SAFETY: EntryStore-owned slot; resolver mutex held. RHS is fully
-                        // evaluated (shared reads) before the LHS `&mut Entry` is
-                        // materialized for the write — no overlapping unique borrow.
-                        unsafe { &mut *query.entry }.abs_path = if query.entry().abs_path.is_empty()
-                        {
+                    path: query
+                        .entry()
+                        .abs_path_or_fill(|| {
                             Interned::from_static(
                                 self.fs_ref()
                                     .dirname_store
                                     .append_slice(&buffer[..])
                                     .expect("unreachable"),
                             )
-                        } else {
-                            query.entry().abs_path
-                        };
-                        query.entry().abs_path.as_bytes()
-                    },
+                        })
+                        .as_bytes(),
                     dirname_fd,
                     file_fd: query.entry().cache().fd,
                 });

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -730,8 +730,8 @@ impl Route {
         // because `base_`/`extname` may borrow `(*entry).base_` (tiny inline
         // string) and a `&mut Entry` parameter would alias them.
         // Reads go through `unsafe { &*entry }`; the single mutation
-        // (`set_abs_path`) goes through `unsafe { &mut *entry }` after
-        // `base_`/`extname` are no longer used.
+        // (`set_abs_path`) is interior (`Cell` + publish flag) and happens
+        // under the per-entry mutex.
         // SAFETY: caller passes an EntryStore-owned pointer valid for the
         // process lifetime; no other live `&mut` to it during this call.
         let entry_abs_path = unsafe { &*entry }.abs_path().as_bytes();
@@ -847,12 +847,24 @@ impl Route {
                 (Route::INDEX_ROUTE_NAME, Route::INDEX_ROUTE_NAME)
             };
 
-            if abs_path_str.is_empty() {
-                // The reads of `cache().fd` and the `set_abs_path` write below
-                // rewrite the cached `Entry`; serialize them on the per-entry
-                // mutex (the same lock every other `Entry` rewrite path takes).
+            // The reads of `cache().fd` and the `set_abs_path` write below
+            // rewrite the cached `Entry`; serialize them on the per-entry
+            // mutex (the same lock every other `Entry` rewrite path takes).
+            let entry_guard = if abs_path_str.is_empty() {
                 // SAFETY: see fn-level NOTE — read-only reborrow.
-                let _entry_guard = unsafe { &*entry }.mutex.lock_guard();
+                Some(unsafe { &*entry }.mutex.lock_guard())
+            } else {
+                None
+            };
+            // A resolver on a bundler thread may have published the path between
+            // the unlocked read above and taking the lock; a published value is
+            // never rewritten, so re-check under the lock before filling.
+            if abs_path_str.is_empty() {
+                // SAFETY: see fn-level NOTE — read-only reborrow.
+                abs_path_str = unsafe { &*entry }.abs_path().as_bytes();
+            }
+
+            if abs_path_str.is_empty() {
                 // NOTE: reshaped for borrowck — `defer if (needs_close) file.close()`
                 // becomes a scopeguard owning the Option<File>; `needs_close` is a
                 // Cell so the drop closure can read it while the body still mutates.
@@ -930,10 +942,11 @@ impl Route {
                     .append(_abs)
                     .expect("unreachable");
 
-                // SAFETY: sole mutation; `base_`/`extname` (which may borrow
-                // `(*entry).base_.remainder_buf`) are not used after this.
-                unsafe { &mut *entry }.set_abs_path(Interned::from_static(abs_path_str));
+                // SAFETY: see fn-level NOTE — read-only reborrow; the write is
+                // interior and `entry_guard` is held.
+                unsafe { &*entry }.set_abs_path(Interned::from_static(abs_path_str));
             }
+            drop(entry_guard);
 
             #[cfg(windows)]
             let abs_path: AbsPath = {

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -726,12 +726,8 @@ impl Route {
         public_dir_: &[u8],
         routes_dirname_len: u16,
     ) -> Option<Route> {
-        // NOTE: `entry` is a raw `*mut Entry`
-        // because `base_`/`extname` may borrow `(*entry).base_` (tiny inline
-        // string) and a `&mut Entry` parameter would alias them.
-        // Reads go through `unsafe { &*entry }`; the single mutation
-        // (`set_abs_path`) is interior (`Cell` + publish flag) and happens
-        // under the per-entry mutex.
+        // NOTE: `entry` is a raw `*mut Entry` because `base_`/`extname` may
+        // borrow `(*entry).base_` and a `&mut Entry` parameter would alias them.
         // SAFETY: caller passes an EntryStore-owned pointer valid for the
         // process lifetime; no other live `&mut` to it during this call.
         let entry_abs_path = unsafe { &*entry }.abs_path().as_bytes();
@@ -847,18 +843,14 @@ impl Route {
                 (Route::INDEX_ROUTE_NAME, Route::INDEX_ROUTE_NAME)
             };
 
-            // The reads of `cache().fd` and the `set_abs_path` write below
-            // rewrite the cached `Entry`; serialize them on the per-entry
-            // mutex (the same lock every other `Entry` rewrite path takes).
+            // Every cached-`Entry` rewrite takes the per-entry mutex.
             let entry_guard = if abs_path_str.is_empty() {
                 // SAFETY: see fn-level NOTE — read-only reborrow.
                 Some(unsafe { &*entry }.mutex.lock_guard())
             } else {
                 None
             };
-            // A resolver on a bundler thread may have published the path between
-            // the unlocked read above and taking the lock; a published value is
-            // never rewritten, so re-check under the lock before filling.
+            // Re-check under the lock: a bundler thread may have published it.
             if abs_path_str.is_empty() {
                 // SAFETY: see fn-level NOTE — read-only reborrow.
                 abs_path_str = unsafe { &*entry }.abs_path().as_bytes();
@@ -942,8 +934,7 @@ impl Route {
                     .append(_abs)
                     .expect("unreachable");
 
-                // SAFETY: see fn-level NOTE — read-only reborrow; the write is
-                // interior and `entry_guard` is held.
+                // SAFETY: see fn-level NOTE — read-only reborrow, `entry_guard` held.
                 unsafe { &*entry }.set_abs_path(Interned::from_static(abs_path_str));
             }
             drop(entry_guard);

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -416,11 +416,7 @@ impl<'a> Scanner<'a> {
                     Ok(s) => s,
                     Err(_) => bun_core::out_of_memory(),
                 };
-                let abs_path = Interned::from_static(stored);
-                {
-                    let _entry_guard = entry.mutex.lock_guard();
-                    entry.set_abs_path(abs_path);
-                }
+                let abs_path = entry.abs_path_or_fill(|| Interned::from_static(stored));
                 self.test_files.push(abs_path);
             }
         }

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -380,7 +380,7 @@ impl<'a> Scanner<'a> {
             }
             fs::EntryKind::File => {
                 // already seen it!
-                if !entry.abs_path.is_empty() {
+                if !entry.abs_path().is_empty() {
                     return;
                 }
 
@@ -416,8 +416,12 @@ impl<'a> Scanner<'a> {
                     Ok(s) => s,
                     Err(_) => bun_core::out_of_memory(),
                 };
-                entry.abs_path = Interned::from_static(stored);
-                self.test_files.push(entry.abs_path);
+                let abs_path = Interned::from_static(stored);
+                {
+                    let _entry_guard = entry.mutex.lock_guard();
+                    entry.set_abs_path(abs_path);
+                }
+                self.test_files.push(abs_path);
             }
         }
     }

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -821,6 +821,11 @@ it("match() returns null when the path string does not start with '/'", () => {
 it("reload() while Bun.build() resolves the same directory", async () => {
   // The router's route-load loop and Bun.build's entry-point resolution (which
   // runs on the bundler thread) share the process-global directory-entry cache.
+  // Both lazily fill the cached entry's absolute path: the router in
+  // Route::parse, the resolver in load_as_file (the entrypoints), load_extension
+  // (the extensionless imports), the index lookup (the directory import) and
+  // the .js to .tsx rewrite. Every page imports through each of those so the
+  // bundler's threads fill the same entries reload() fills on the main thread.
   // Run in a subprocess so a crash is observable as a signal instead of taking
   // down the test runner.
   const files: Record<string, string> = {
@@ -859,9 +864,15 @@ it("reload() while Bun.build() resolves the same directory", async () => {
       console.log("matches", matches, "builds-ok", buildsOk);
     `,
   };
+  files["pages/sub/index.tsx"] = "export default 0;\n";
   for (let i = 1; i <= 40; i++) {
-    files[`pages/p${i}.tsx`] = `export default ${i};\n`;
+    files[`pages/p${i}.tsx`] =
+      `import s from "./sub/s${i}";\n` +
+      `import sub from "./sub";\n` +
+      `import t from "./sub/t${i}.js";\n` +
+      `export default ${i} + s + sub + t;\n`;
     files[`pages/sub/s${i}.tsx`] = `export default ${i};\n`;
+    files[`pages/sub/t${i}.tsx`] = `export default ${i};\n`;
   }
   using dir = tempDir("fsr-reload-build-race", files);
 


### PR DESCRIPTION
### Problem
- `test/js/bun/util/filesystem_router.test.ts` > `reload() while Bun.build() resolves the same directory` dies with `panic: Segmentation fault at address 0x2D` (also `0x25`, `0x31`) on the Linux aarch64 lanes. Five builds in the last day (104328, 104299, 104177, 104102, 103853), plus 74037 and 90948 earlier. The symbolized frame is `strings::last_index_of` called from `Resolver::load_as_file_or_directory` (`src/resolver/resolver.rs`) on the bundle thread.
- `Entry.abs_path` (`src/resolver/fs.rs`) was a plain `Interned`, a two-word `(ptr, len)`. Six resolver sites filled it with `if abs_path.is_empty() { abs_path = ... }` and no lock, while `Route::parse` (`src/router/lib.rs`) filled the same field on the JS thread. Every `reload()` re-reads the directory, so the bundler thread and the router race to fill the same fresh `Entry`. A reader can observe the new `len` with the `EMPTY` pointer, which is `0x1` (`b""` is a dangling zero-sized literal), and `memrchr` then reads at `0x1 + len - 16`: exactly the fault addresses above.

### Fix
- `abs_path` becomes a `Cell<Interned>` written under the per-entry `mutex`, published through a new `has_abs_path: AtomicBool` with Release/Acquire. This is the pattern `Entry` already uses for `cache` and `need_stat`.
- `abs_path()` stays lock-free and returns `EMPTY` until the flag is set, so it yields either nothing or the complete pair. A published value is never rewritten.
- The six resolver sites use `abs_path_or_fill`, a double-checked fill under the mutex. `Route::parse` re-checks under the lock before it fills. `load_extension` stopped rewriting an already-set path on every hit. The hot reloader and the test scanner use the accessors.
- Verified: `bun bd test test/js/bun/util/filesystem_router.test.ts` (33 pass). The race test now also imports through `load_extension`, the index lookup and the `.js` to `.tsx` rewrite, so the bundler fills the cached entries at every resolver site that writes `abs_path`. Also `test/bundler/resolver/`, `test/js/bun/resolve/`, `test/cli/test/bun-test.test.ts`, `test/cli/hot/hot.test.ts`, `test/cli/hot/watch.test.ts`. `cargo clippy -p bun_resolver -p bun_router -p bun_runtime` is clean.

### Background
- `Entry` is one cached directory listing item in the process-global `EntryStore`. `Route::parse` (FileSystemRouter, JS thread) and the resolver (bundler threads in `Bun.build()`) share these entries through `RealFS`.
- `Interned` (`src/ptr/lib.rs`) is a `repr(transparent)` `&'static [u8]`: two machine words. A concurrent unsynchronized store and load of it is a data race, and aarch64 can make the two words visible in either order.
- `Entry.mutex` serializes every rewrite of a cached entry. `need_stat` is the existing Release/Acquire flag that lets `kind()` read `cache` without the lock once it is published. `has_abs_path` plays the same role for `abs_path`.
- #34411 proposed the same fix in July. It no longer applies (conflicting) and this supersedes it.

<details><summary>Notes</summary>

Why the fault addresses fit: `Interned::EMPTY` is `Interned(b"")`, and rustc lowers the zero-sized literal to a dangling `0x1` pointer (checked with a small program: `EMPTY ptr = 0x1`). The CI temp path of a route is about 52 to 64 bytes. A torn read gives `(0x1, len)`, and the SIMD `memrchr` behind `last_index_of(path, "node_modules/")` loads 16 bytes from the end first, at `0x1 + len - 16`: `0x25`, `0x2D`, `0x31`.

Reproduction attempts against the unfixed binary: the fixture from the test (4 concurrent `Bun.build()` calls against 80 entrypoints while `reload()` runs 50 times per round, 40 rounds) ran 200 times on Linux x64 (Bun 1.4.0 canary) and 300 times on a macOS arm64 M2 (Bun 1.4.1 profile build) with zero failures. The window is two instructions wide and only the Linux aarch64 CI machines have hit it, at roughly 2 to 3 percent of runs of this test in the last 24 hours of builds. The existing test is the regression test for this race. It is extended (not replaced) so the fixture covers every fill site; a separate timing test would not fail more reliably. On x64 the gate cannot observe a fail-before for this change: the fixture passes against the unfixed binary there.

Other readers of `Entry.abs_path`: `src/jsc/hot_reloader.rs` reads it on the watcher thread after resetting the entry's fd (read only, now via `abs_path()`), and `src/runtime/cli/test/Scanner.rs` fills it single-threaded (now `set_abs_path` under the mutex, after its existing empty check).

Not changed here: `Entry.dir` is also a two-word slice rewritten under the entry mutex on re-read (`existing.dir = self.dir` in `fs.rs`) while the resolver reads it lock-free. Both spellings of the same directory are process-lifetime interned bytes, so a tear there cannot fault, but it could produce a wrong path if the two spellings differ in length (trailing separator). That is a separate change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/filesystem_router.test.ts

<!-- robobun:evidence:end -->