### PR TITLE
bake production + FrameworkRouter: remove unsafe; BundleV2 holds its transpiler as a ParentRef

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -499,13 +499,13 @@ impl<'a> LinkerContext<'a> {
         // SAFETY: field-disjoint with `self` (= `(*bundle).linker`); `parse_graph`
         // is a `*mut Graph` backref so no `&mut` is materialized.
         self.parse_graph = unsafe { core::ptr::addr_of_mut!((*bundle).graph) };
-        // SAFETY: field-disjoint scalar read; `transpiler` is itself a `*mut`.
+        // SAFETY: field-disjoint with `self` (= `(*bundle).linker`).
         let dyn_entry_points =
             unsafe { &mut *core::ptr::addr_of_mut!((*bundle).dynamic_import_entry_points) };
 
-        // SAFETY: `bundle.transpiler` is a `*mut Transpiler` backref valid for
-        // the bundle's lifetime; `resolver`/`log`/`options` are stable fields.
-        let transpiler = unsafe { &mut *(*bundle).transpiler };
+        // SAFETY: field-disjoint read of the transpiler back-reference; the
+        // pointee outlives the bundle (see `BundleV2::transpiler`).
+        let transpiler = unsafe { &*core::ptr::addr_of!((*bundle).transpiler) };
         self.graph.code_splitting = transpiler.options.code_splitting;
         // `transpiler.log` is the canonical
         // `*mut Log` (same value aliased into `linker.log` / `resolver.log`).

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -58,10 +58,12 @@ pub struct PendingImport {
 }
 
 pub struct BundleV2<'a> {
-    // `ssr_transpiler` may alias this same transpiler when the SSR graph
-    // isn't separate, so it stays `*mut`; `transpiler` is `&'a mut` for
-    // ergonomic field access throughout the bundler bodies.
-    pub transpiler: &'a mut Transpiler<'a>,
+    /// The primary (server-side under bake) transpiler. Non-exclusive
+    /// back-reference: the owner keeps using it between bundler turns (the dev
+    /// server resolves through it while a bundle is in flight) and
+    /// `ssr_transpiler` aliases it when the SSR graph isn't separate. Read via
+    /// `Deref`/[`BundleV2::transpiler`], write via [`BundleV2::transpiler_mut`].
+    pub(crate) transpiler: bun_ptr::ParentRef<Transpiler<'a>, bun_ptr::Mut>,
     /// When Server Components is enabled, this is used for the client bundles
     /// and `transpiler` is used for the server bundles.
     ///
@@ -140,6 +142,23 @@ pub struct BundleV2<'a> {
     /// dense and this is probed once per import in `on_parse_task_complete`
     /// (the main-thread parse-phase throughput limiter).
     pub(crate) requested_exports: Vec<Option<RequestedExports>>,
+
+    /// The bundle heap when this bundle owns it ([`BundleV2::init_with_owned_heap`]);
+    /// `graph.heap` and every `'a` arena borrow point into it. Declared last so
+    /// it is dropped after every field that references it.
+    owned_heap: Option<OwnedHeap>,
+}
+
+/// A heap allocation of the bundle arena, held as a raw pointer so the `'a`
+/// borrows minted from it in [`BundleV2::init_with_owned_heap`] stay valid
+/// while it moves into the bundle. Freed on drop.
+struct OwnedHeap(NonNull<bun_alloc::Arena>);
+
+impl Drop for OwnedHeap {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` came from `heap::into_raw_nn` and is dropped once, here.
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
+    }
 }
 
 bun_core::declare_scope!(Bundle, visible);
@@ -152,18 +171,32 @@ pub(crate) type ResolveQueue = StringHashMap<*mut ParseTask>;
 pub struct BakeOptions<'a> {
     pub framework: bake::Framework,
     pub client_transpiler: NonNull<Transpiler<'a>>,
-    pub ssr_transpiler: NonNull<Transpiler<'a>>,
+    /// `None` when the SSR graph is not separate: SSR then goes through the
+    /// primary (server) transpiler.
+    pub ssr_transpiler: Option<NonNull<Transpiler<'a>>>,
     pub plugins: Option<NonNull<JSBundlerPlugin>>,
 }
 
 impl<'a> BundleV2<'a> {
-    // ── raw-ptr accessors ─────────────────────────────────────────────────
-    // `ssr_transpiler` is `*mut` because it may alias `transpiler`
-    // (same pointer in both slots when no SSR graph).
-    // Callers go through these accessors so the unsafe deref is centralized.
+    // ── transpiler accessors ──────────────────────────────────────────────
+    // `transpiler` / `client_transpiler` / `ssr_transpiler` are back-references
+    // handed over at construction (`ssr_transpiler` aliases `transpiler` when
+    // there is no separate SSR graph). Callers go through these accessors so
+    // the deref is centralized.
     #[inline]
-    pub(crate) fn transpiler(&self) -> &Transpiler<'a> {
-        &*self.transpiler
+    pub fn transpiler(&self) -> &Transpiler<'a> {
+        &self.transpiler
+    }
+
+    /// Exclusive access to the primary transpiler (log, resolver caches,
+    /// option fix-ups).
+    #[inline]
+    pub fn transpiler_mut(&mut self) -> &mut Transpiler<'a> {
+        // SAFETY: the `ParentRef` handed to `init` carries its owner's
+        // guarantee that the transpiler outlives this bundle and is not
+        // borrowed elsewhere while the bundler runs; `&mut self` rules out
+        // another borrow through this bundle.
+        unsafe { self.transpiler.assume_mut() }
     }
 
     #[inline]
@@ -255,7 +288,7 @@ impl<'a> BundleV2<'a> {
                     panic!("Failed to initialize client transpiler: {}", e.name())
                 });
             }
-            return &mut *self.transpiler;
+            return self.transpiler_mut();
         }
         // SAFETY: all three pointers are live for `'a` (set in `init`); the
         // `client_transpiler` arm is only reached when bake populated it.
@@ -263,7 +296,7 @@ impl<'a> BundleV2<'a> {
             match target {
                 Target::Browser => self.client_transpiler.unwrap().assume_mut(),
                 Target::ServerComponentsSsr => &mut *self.ssr_transpiler,
-                _ => &mut *self.transpiler,
+                _ => self.transpiler.assume_mut(),
             }
         }
     }
@@ -2901,9 +2934,12 @@ pub mod bv2_impl {
             Ok(Some(source_index.get()))
         }
 
-        /// `heap` is not freed when `deinit`ing the BundleV2
+        /// `transpiler` (and the bake transpilers) are back-references: the
+        /// owner keeps them alive, in place and otherwise unborrowed while the
+        /// bundle uses them. `heap` is not freed when `deinit`ing the BundleV2
+        /// (see [`BundleV2::init_with_owned_heap`] for a bundle that owns it).
         pub fn init(
-            transpiler: &'a mut Transpiler<'a>,
+            transpiler: bun_ptr::ParentRef<Transpiler<'a>, bun_ptr::Mut>,
             bake_options: Option<BakeOptions<'a>>,
             _alloc: &bun_alloc::Arena,
             event_loop: EventLoop,
@@ -2915,16 +2951,18 @@ pub mod bv2_impl {
             thread_pool: Option<NonNull<ThreadPoolLib>>,
             heap: &'a ThreadLocalArena,
         ) -> Result<Box<BundleV2<'a>>, Error> {
-            // The Box is heap-owned and dropped by the caller.
-            transpiler.options.mark_builtins_as_external =
-                transpiler.options.target.is_bun() || transpiler.options.target == Target::Node;
-            transpiler.resolver.opts.mark_builtins_as_external =
-                transpiler.options.target.is_bun() || transpiler.options.target == Target::Node;
+            {
+                // SAFETY: construction contract above — live and unborrowed.
+                let transpiler = unsafe { transpiler.assume_mut() };
+                transpiler.options.mark_builtins_as_external =
+                    transpiler.options.target.is_bun() || transpiler.options.target == Target::Node;
+                transpiler.resolver.opts.mark_builtins_as_external =
+                    transpiler.options.target.is_bun() || transpiler.options.target == Target::Node;
+            }
 
-            // SAFETY: `ssr_transpiler` intentionally aliases `transpiler` via a
-            // raw `*mut` until bake installs a separate SSR transpiler; all
-            // derefs go through the centralized accessors.
-            let ssr_alias: *mut Transpiler<'a> = std::ptr::from_mut(transpiler);
+            // `ssr_transpiler` intentionally aliases `transpiler` until bake
+            // installs a separate SSR transpiler.
+            let ssr_alias: *mut Transpiler<'a> = transpiler.as_mut_ptr();
             let mut this = Box::new(BundleV2 {
                 transpiler,
                 client_transpiler: None,
@@ -2962,6 +3000,7 @@ pub mod bv2_impl {
                 asynchronous: false,
                 has_any_top_level_await_modules: false,
                 requested_exports: Vec::new(),
+                owned_heap: None,
             });
             if let Some(bo) = bake_options {
                 // SAFETY: `bo.client_transpiler` is the caller's live, write-capable
@@ -2969,7 +3008,9 @@ pub mod bv2_impl {
                 this.client_transpiler = Some(unsafe {
                     bun_ptr::ParentRef::from_raw_mut(bo.client_transpiler.as_ptr())
                 });
-                this.ssr_transpiler = bo.ssr_transpiler.as_ptr();
+                if let Some(ssr) = bo.ssr_transpiler {
+                    this.ssr_transpiler = ssr.as_ptr();
+                }
                 let separate_ssr = bo
                     .framework
                     .server_components
@@ -3004,8 +3045,8 @@ pub mod bv2_impl {
             let tree_shaking = this.transpiler.options.tree_shaking_override.unwrap_or(
                 this.transpiler.options.output_format != options::Format::InternalBakeDev,
             );
-            this.transpiler.options.tree_shaking = tree_shaking;
-            this.transpiler.resolver.opts.tree_shaking = tree_shaking;
+            this.transpiler_mut().options.tree_shaking = tree_shaking;
+            this.transpiler_mut().resolver.opts.tree_shaking = tree_shaking;
 
             // BACKREF: `LinkerContext<'a>.resolver` is `ParentRef<Resolver<'a>>`;
             // the resolver lives in `transpiler` which outlives `self` (same `'a`).
@@ -3095,6 +3136,43 @@ pub mod bv2_impl {
             // `Graph::pool` wraps the `BackRef` deref; `start()` takes `&self`.
             this.graph.pool().start();
             Ok(this)
+        }
+
+        /// [`BundleV2::init`] for an owner that cannot name the bundle's
+        /// lifetime (bake's dev server keeps the bundle across event-loop turns):
+        /// the bundle takes the heap and frees it last, after everything
+        /// allocated from it. Everything the bundle exposes with lifetime `'a`
+        /// that lives in this heap (`graph.ast`, `heap()`, ...) is valid only
+        /// while the returned box is; the owner must not retain it past that.
+        pub fn init_with_owned_heap(
+            transpiler: bun_ptr::ParentRef<Transpiler<'a>, bun_ptr::Mut>,
+            bake_options: Option<BakeOptions<'a>>,
+            heap: Box<ThreadLocalArena>,
+            event_loop: EventLoop,
+            cli_watch_flag: bool,
+            thread_pool: Option<NonNull<ThreadPoolLib>>,
+        ) -> Result<Box<BundleV2<'a>>, Error> {
+            let heap = super::OwnedHeap(bun_core::heap::into_raw_nn(heap));
+            // SAFETY: `heap` is a live allocation freed only when `OwnedHeap`
+            // drops: after `this` on the error path below, or as the bundle's
+            // last field.
+            let heap_ref: &'a ThreadLocalArena = unsafe { heap.0.as_ref() };
+            let mut this = Self::init(
+                transpiler,
+                bake_options,
+                heap_ref,
+                event_loop,
+                cli_watch_flag,
+                thread_pool,
+                heap_ref,
+            )?;
+            this.owned_heap = Some(heap);
+            Ok(this)
+        }
+
+        /// The bundle heap (`graph.heap`).
+        pub fn heap(&self) -> &ThreadLocalArena {
+            self.graph.heap
         }
 
         pub(crate) fn arena(&self) -> &'a bun_alloc::Arena {
@@ -3201,7 +3279,7 @@ pub mod bv2_impl {
                 }
 
                 // no plugins were matched
-                let mut resolved = match self.transpiler.resolve_entry_point(entry_point) {
+                let mut resolved = match self.transpiler_mut().resolve_entry_point(entry_point) {
                     Ok(r) => r,
                     Err(_) => continue,
                 };
@@ -3250,7 +3328,7 @@ pub mod bv2_impl {
                     if flags.client() && !flags.server() && !flags.ssr() {
                         std::ptr::from_mut(self.transpiler_for_target(Target::Browser))
                     } else {
-                        &raw mut *self.transpiler
+                        self.transpiler.as_mut_ptr()
                     };
                 let server_target = self.transpiler.options.target;
                 let client_loader = flags.html().then_some(Loader::Html);
@@ -3389,7 +3467,7 @@ pub mod bv2_impl {
                 }
 
                 // no plugins matched
-                let mut resolved = match self.transpiler.resolve_entry_point(abs_path) {
+                let mut resolved = match self.transpiler_mut().resolve_entry_point(abs_path) {
                     Ok(r) => r,
                     Err(_) => continue,
                 };
@@ -4019,7 +4097,7 @@ pub mod bv2_impl {
         }
 
         pub fn generate_from_cli(
-            transpiler: &'a mut Transpiler<'a>,
+            transpiler: bun_ptr::ParentRef<Transpiler<'a>, bun_ptr::Mut>,
             alloc: &'a bun_alloc::Arena,
             event_loop: EventLoop,
             enable_reloading: bool,
@@ -4169,7 +4247,7 @@ pub mod bv2_impl {
         /// worker pool is owned (created with `thread_pool: None`), so tearing
         /// it down does not touch the runtime VM's parse threads.
         pub fn scan_module_graph_from_cli(
-            transpiler: &'a mut Transpiler<'a>,
+            transpiler: bun_ptr::ParentRef<Transpiler<'a>, bun_ptr::Mut>,
             alloc: &'a bun_alloc::Arena,
             event_loop: EventLoop,
             entry_points: &[&[u8]],
@@ -4199,7 +4277,7 @@ pub mod bv2_impl {
 
         pub fn generate_from_bake_production_cli(
             entry_points: &bake_types::production::EntryPointMap,
-            server_transpiler: &'a mut Transpiler<'a>,
+            server_transpiler: bun_ptr::ParentRef<Transpiler<'a>, bun_ptr::Mut>,
             bake_options: BakeOptions<'a>,
             alloc: &'a bun_alloc::Arena,
             event_loop: EventLoop,
@@ -7647,7 +7725,7 @@ pub mod bv2_impl {
 
         /// To satisfy the interface from NewHotReloader()
         pub fn bust_dir_cache(&mut self, path: &[u8]) -> bool {
-            self.transpiler.resolver.bust_dir_cache(path)
+            self.transpiler_mut().resolver.bust_dir_cache(path)
         }
     }
 

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -823,7 +823,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
     }
 
     // Don't write to disk if compile mode is enabled - we need buffer values for compilation
-    let is_compile = bundler.transpiler.options.compile_mode.is_executable();
+    let is_compile = bundler.transpiler().options.compile_mode.is_executable();
     if root_path.len() > 0 && !is_compile {
         write_output_files_to_disk(
             c,

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -1343,7 +1343,7 @@ impl<'a> HotReloaderCtx for bun_bundler::BundleV2<'a> {
     }
 
     fn get_loaders(&self) -> &bun_ast::LoaderHashTable {
-        &self.transpiler.options.loaders
+        &self.transpiler().options.loaders
     }
 
     fn log_level_at_least_info(&self) -> bool {
@@ -1370,13 +1370,14 @@ impl<'a> HotReloaderCtx for bun_bundler::BundleV2<'a> {
         let watcher_ptr: *mut Watcher = watcher_nn.as_ptr();
         self.bun_watcher = Some(watcher_nn);
         // SAFETY: `watcher_ptr` was just installed; live for the process.
-        self.transpiler.resolver.watcher = Some(unsafe { (*watcher_ptr).get_resolve_watcher() });
+        self.transpiler_mut().resolver.watcher =
+            Some(unsafe { (*watcher_ptr).get_resolve_watcher() });
         watcher_ptr
     }
 
     fn compute_clear_screen(&self) -> bool {
         !self
-            .transpiler
+            .transpiler()
             .env()
             .has_set_no_clear_terminal_on_reload(!Output::enable_ansi_colors_stdout())
     }

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -99,7 +99,7 @@ impl strings::Appender for FilenameStoreAppender {
 /// to `RealFS::kind`.
 pub trait EntryKindResolver {
     fn resolve_kind(
-        &mut self,
+        &self,
         dir: &[u8],
         base: &[u8],
         existing_fd: Fd,
@@ -203,29 +203,26 @@ impl Entry {
     ///
     /// # Safety
     /// `fs` must point to a live `EntryKindResolver` (the process-global
-    /// `RealFS` singleton in practice). `resolve_kind` must not re-enter
-    /// this entry's `mutex` (it only performs syscalls and string interning).
+    /// `RealFS` singleton in practice); see [`Entry::kind_with`].
+    pub unsafe fn kind<R: EntryKindResolver>(&self, fs: *mut R, store_fd: bool) -> EntryKind {
+        // SAFETY: caller contract — `fs` is live.
+        self.kind_with(unsafe { &*fs }, store_fd)
+    }
+
+    /// Stat-on-first-use. `resolve_kind` must not re-enter this entry's
+    /// `mutex` (it only performs syscalls and string interning).
     // `Entry` lives in the EntryStore BSSMap singleton. The lazy-stat rewrite
     // of `need_stat` / `cache` is serialized on the per-entry `mutex` here
-    // (double-checked: the cached fast path stays lock-free). `fs` is `*mut`
-    // so the call site does not require a second exclusive `&mut RealFS`
-    // borrow while a `&mut Entry` (borrowed out of `RealFS.entries`) is live.
-    // Generic over `R: EntryKindResolver` so this block is independent of
-    // which `RealFS` copy `fs` points at (see file-top comment).
-    pub unsafe fn kind<R: EntryKindResolver>(&self, fs: *mut R, store_fd: bool) -> EntryKind {
+    // (double-checked: the cached fast path stays lock-free). Generic over
+    // `R: EntryKindResolver` so this block is independent of which `RealFS`
+    // copy `fs` points at (see file-top comment).
+    pub fn kind_with<R: EntryKindResolver>(&self, fs: &R, store_fd: bool) -> EntryKind {
         if self.need_stat.load(Ordering::Acquire) {
             let _guard = self.mutex.lock_guard();
             // Relaxed: every write happens under `mutex`, which we hold.
             if self.need_stat.load(Ordering::Relaxed) {
                 // This is technically incorrect, but we are choosing not to handle errors here
-                // SAFETY: `fs` points at the process-global RealFS singleton; `resolve_kind`
-                // only does syscalls + string interning, so the short `&mut` cannot alias.
-                match unsafe { &mut *fs }.resolve_kind(
-                    self.dir,
-                    self.base(),
-                    self.cache().fd,
-                    store_fd,
-                ) {
+                match fs.resolve_kind(self.dir, self.base(), self.cache().fd, store_fd) {
                     Ok(c) => self.cache.set(c),
                     Err(_) => {
                         self.need_stat.store(false, Ordering::Release);
@@ -388,6 +385,18 @@ pub struct DirEntry {
 }
 
 impl DirEntry {
+    /// `(lowercased basename, entry)` pairs. Iteration order is unspecified;
+    /// hold `RealFS::entries_mutex` if other threads may be re-reading this
+    /// directory.
+    pub fn iter(&self) -> impl Iterator<Item = (&[u8], &Entry)> + '_ {
+        Self::debug_assert_entries_mutex_held();
+        // SAFETY: every value in `data` is a non-null pointer into the
+        // process-lifetime, append-only `EntryStore` (see `add_entry_with_store`),
+        // the same invariant `DirEntry::get` relies on; `Entry`'s lazily
+        // written state is `Cell`/atomic under its own mutex.
+        self.data.iter().map(|(k, v)| (&**k, unsafe { &**v }))
+    }
+
     pub(crate) fn init(dir: &'static [u8], generation: Generation) -> DirEntry {
         DirEntry {
             dir,

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1363,7 +1363,7 @@ pub mod fs {
         /// (if reparse point) `CreateFileW`-follow + `GetFinalPathNameByHandle`
         /// realpath.
         pub(crate) fn kind(
-            &mut self,
+            &self,
             dir_: &[u8],
             base: &[u8],
             existing_fd: Fd,
@@ -1551,7 +1551,7 @@ pub mod fs {
     impl crate::fs_full::EntryKindResolver for RealFS {
         #[inline(always)]
         fn resolve_kind(
-            &mut self,
+            &self,
             dir: &[u8],
             base: &[u8],
             existing_fd: bun_sys::Fd,

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1245,7 +1245,15 @@ impl CompletionStruct for JSBundleCompletionTask {
         let worker_pool = NonNull::new(thread_pool);
 
         // `Graph.heap` is a borrow, so reuse the caller-owned `bump`.
-        let mut bv2 = BundleV2::init(transpiler, None, bump, event_loop, false, worker_pool, bump)?;
+        let mut bv2 = BundleV2::init(
+            bun_ptr::ParentRef::from_ref_mut(transpiler),
+            None,
+            bump,
+            event_loop,
+            false,
+            worker_pool,
+            bump,
+        )?;
 
         bv2.plugins = self.plugins();
         bv2.completion = Some(self.as_js_bundle_completion_task());

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -140,15 +140,23 @@ extern "C" JSC::EncodedJSValue BakeGetDefaultExportFromModule(
   return JSC::JSValue::encode(uncheckedDowncast<JSC::JSModuleNamespaceObject>(JSC::JSValue::decode(BakeGetModuleNamespace(global, keyValue)))->get(global, vm.propertyNames->defaultKeyword));
 }
 
-// There were issues when trying to use JSValue.get from zig
+// `bun_core::ffi::FfiSlice<u8>`.
+struct BakeModuleNamespaceKey {
+  const unsigned char* ptr;
+  size_t len;
+};
+
 extern "C" JSC::EncodedJSValue BakeGetOnModuleNamespace(
   JSC::JSGlobalObject* global,
-  JSC::JSModuleNamespaceObject* moduleNamespace,
-  const unsigned char* key,
-  size_t keyLength
+  JSC::EncodedJSValue moduleNamespaceValue,
+  BakeModuleNamespaceKey key
 ) {
+  auto* moduleNamespace = dynamicDowncast<JSC::JSModuleNamespaceObject>(JSC::JSValue::decode(moduleNamespaceValue));
+  if (!moduleNamespace) {
+    return {};
+  }
   auto& vm = JSC::getVM(global);
-  const auto propertyString = String(StringImpl::createWithoutCopying({ key, keyLength }));
+  const auto propertyString = String(StringImpl::createWithoutCopying({ key.ptr, key.len }));
   const auto identifier = JSC::Identifier::fromString(vm, propertyString);
   const auto property = JSC::PropertyName(identifier);
   return JSC::JSValue::encode(moduleNamespace->get(global, property));

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -20,7 +20,7 @@ use bun_alloc::{AllocError, Arena};
 use bun_ast::Log;
 use bun_bundler::options_impl::TargetExt as _;
 use bun_collections::{ArrayHashMap, DynamicBitSet, HashMap, StringHashMap};
-use bun_core::{self as str, String as BunString, ZStr, strings};
+use bun_core::{self as str, String as BunString, strings};
 use bun_core::{Environment, Output};
 use bun_jsc::bun_string_jsc;
 use bun_jsc::virtual_machine::VirtualMachine;
@@ -185,7 +185,7 @@ pub(crate) use map_log;
 pub struct Options<'a> {
     /// Arena must live until DevServer drops
     pub arena: &'a Arena,
-    pub root: &'a ZStr,
+    pub root: &'a [u8],
     pub vm: &'a VirtualMachine,
     /// The `Bun.serve` instance that owns the dev server.
     pub server: AnyServer,
@@ -197,8 +197,7 @@ pub struct Options<'a> {
 // Note: the fields (`arena`, `root`, `vm`, `server`, `framework`,
 // `bundler_options`, `broadcast_console_log_from_browser_to_server`) are
 // required with no sensible zero value, so `Default` is intentionally NOT
-// implemented. Callers construct `Options` via struct-literal at the call site
-// (see `bake_body.rs::UserOptions::into_dev_server_options`).
+// implemented. Callers construct `Options` via struct-literal at the call site.
 
 #[cfg(debug_assertions)]
 #[repr(u128)]
@@ -243,17 +242,9 @@ pub enum TestingBatchEvents {
 /// inevitably share state. This bundle is asynchronous, storing its state here
 /// while in-flight. All allocations held by `.bv2.graph.heap`'s arena
 pub struct CurrentBundle {
-    /// OWNED (LIFETIMES.tsv): `BundleV2.init()` → `deinitWithoutFreeingArena()`.
-    /// Note: `'static` is a stand-in for the DevServer-self lifetime —
-    /// `BundleV2<'a>` borrows the three `Transpiler<'_>` fields stored inline
-    /// in `DevServer`, so the true bound is the `Box<DevServer>` allocation
-    /// (stable address, never moved post-init). Threading a real `'dev` would
-    /// make `DevServer` self-referential; raw-ptr aliasing inside `BundleV2`
-    /// already encodes that contract.
+    /// Owns the bundle heap; holds back-references to the dev server's three
+    /// boxed `Transpiler<'static>`s, which outlive every bundle.
     pub bv2: Box<BundleV2<'static>>,
-    /// Owns the arena that `bv2.graph.heap` borrows (`'static` self-ref via the
-    /// boxed allocation's stable address; same erasure as `bv2` above).
-    pub heap: Box<bun_alloc::MimallocArena>,
     /// Backs the small `AstVec`s built during bundle setup
     /// (`start_async_bundle`'s AST scope); dropped with the bundle.
     pub ast_alloc_state: Option<Box<bun_alloc::ast_alloc::AstAllocState>>,
@@ -284,16 +275,6 @@ pub(crate) struct BundleRequest {
     pub(crate) had_reload_event: bool,
     /// When the work that led to this bundle started.
     pub(crate) timer: Instant,
-}
-
-/// A bundle set up by `start_async_bundle_setup`, before its entry points are
-/// enqueued.
-struct BundleSetup {
-    bv2: Box<BundleV2<'static>>,
-    /// Lives in `heap`; AST nodes built while the entry points are enqueued go
-    /// through it (see `start_async_bundle`).
-    ast_memory_store: &'static mut bun_ast::ASTMemoryAllocator,
-    heap: Box<bun_alloc::MimallocArena>,
 }
 
 pub struct NextBundle {
@@ -509,7 +490,7 @@ pub(crate) fn init(options: Options) -> JsResult<bun_ptr::OwnedThis<DevServerCel
     let global = options.vm.global();
 
     let generic_action = "while initializing development server";
-    let root = paths::string_paths::without_trailing_slash_windows_path(options.root.as_bytes());
+    let root = paths::string_paths::without_trailing_slash_windows_path(options.root);
     // FileSystem is a process-lifetime singleton; `init` interns the path into
     // the `DirnameStore` (process-lifetime arena) so no caller-side leak is
     // needed for the `'static` it stores.
@@ -969,7 +950,7 @@ impl Drop for DevServer {
 impl DevServer {
     fn init_server_runtime(&mut self) {
         let runtime = BunString::create_static_external(
-            crate::bake::bake_body::get_hmr_runtime(crate::bake::bake_body::Side::Server)
+            crate::bake::bake_body::get_hmr_runtime(bake::Side::Server)
                 .code
                 .as_bytes(),
             true,
@@ -2639,19 +2620,14 @@ impl DevServer {
             had_reload_event,
             timer,
         } = request;
-        // Bound in this order so that on an early return `bv2` (which borrows
-        // `*heap`) drops before `heap`.
-        let BundleSetup {
-            heap,
-            ast_memory_store,
-            mut bv2,
-        } = cell.with_mut(|dev| dev.start_async_bundle_setup(&entry_points))?;
+        // `bv2` owns its heap (dropped last), so an early return frees the
+        // bundle before the arena it points into.
+        let mut bv2 = cell.with_mut(|dev| dev.start_async_bundle_setup(&entry_points))?;
 
         // AST nodes built while the entry points are enqueued live exactly as
         // long as the bundle: the `AstAllocState` is taken into `CurrentBundle`
-        // below and released by the guard on every path.
-        let mut ast_memory_store =
-            scopeguard::guard(ast_memory_store, |store| store.release_ast_state());
+        // below (or released when the allocator drops on an error path).
+        let mut ast_memory_store = bun_ast::ASTMemoryAllocator::borrowing(bv2.heap());
         let ast_scope = ast_memory_store.enter();
 
         // LAYERING: `bun_bundler::bake_types::EntryPointList` is the TYPE_ONLY
@@ -2692,7 +2668,6 @@ impl DevServer {
         cell.with_mut(move |dev| {
             dev.current_bundle = Some(CurrentBundle {
                 bv2,
-                heap,
                 ast_alloc_state,
                 timer,
                 start_data,
@@ -2714,7 +2689,7 @@ impl DevServer {
     fn start_async_bundle_setup(
         &mut self,
         entry_points: &EntryPointList,
-    ) -> crate::Result<BundleSetup> {
+    ) -> crate::Result<Box<BundleV2<'static>>> {
         debug_assert!(self.current_bundle.is_none());
         debug_assert!(!entry_points.set.is_empty());
         self.log.clear_and_free();
@@ -2733,40 +2708,36 @@ impl DevServer {
         // Ref server to keep it from closing.
         self.server.on_pending_request();
 
-        // Owned by the `CurrentBundle` alongside `bv2`, which borrows it as
-        // `graph.heap`.
+        // Owned by `bv2` (dropped after everything allocated from it).
         let heap: Box<bun_alloc::MimallocArena> = Box::new(bun_alloc::MimallocArena::new());
-        let (server_transpiler, heap_ref) = self.bundle_borrows(&heap);
-        let client_transpiler = ::core::ptr::NonNull::from(&mut *self.client_transpiler);
-        let ssr_transpiler = match &mut self.ssr_transpiler {
-            Some(t) => ::core::ptr::NonNull::from(&mut **t),
-            None => ::core::ptr::NonNull::from(&mut *server_transpiler),
-        };
-
-        let ast_memory_store = heap_ref.alloc(bun_ast::ASTMemoryAllocator::borrowing(heap_ref));
-
         // The bundler stores `Option<NonNull<AnyEventLoop>>`; park the value
         // in `heap` so it lives exactly as long as `bv2`.
         let event_loop: bun_bundler::linker_context_mod::EventLoop =
-            Some(::core::ptr::NonNull::from(heap_ref.alloc(
+            Some(::core::ptr::NonNull::from(heap.alloc(
                 bun_event_loop::AnyEventLoop::js(self.vm().event_loop().cast()),
             )));
+        let client_transpiler = ::core::ptr::NonNull::from(&mut *self.client_transpiler);
+        let ssr_transpiler = self
+            .ssr_transpiler
+            .as_deref_mut()
+            .map(::core::ptr::NonNull::from);
 
-        let mut bv2: Box<BundleV2<'static>> = BundleV2::init(
-            server_transpiler,
+        // The three boxed transpilers outlive every bundle. The dev server
+        // keeps resolving through `server_transpiler` between bundler turns.
+        let mut bv2: Box<BundleV2<'static>> = BundleV2::init_with_owned_heap(
+            bun_ptr::ParentRef::from_ref_mut(&mut *self.server_transpiler),
             Some(bundler::bundle_v2::BakeOptions {
                 framework: self.framework.as_bundler_view(),
                 client_transpiler,
                 ssr_transpiler,
                 plugins: self.bundler_options.plugin,
             }),
-            heap_ref,
+            heap,
             event_loop,
             false, // watching is handled separately
             Some(::core::ptr::NonNull::from(
                 bun_threading::work_pool::WorkPool::get(),
             )),
-            heap_ref,
         )?;
         bv2.bun_watcher = Some(::core::ptr::NonNull::from(self.watcher()));
         bv2.asynchronous = true;
@@ -2781,39 +2752,7 @@ impl DevServer {
             self.graph_safety_lock.unlock();
         }
 
-        Ok(BundleSetup {
-            bv2,
-            ast_memory_store,
-            heap,
-        })
-    }
-
-    /// The two borrows a `BundleV2<'static>` holds for the lifetime of a
-    /// bundle: the server transpiler (`bv2.transpiler`) and the bundle's heap
-    /// (`bv2.graph.heap`). `BundleV2<'a>` ties both to one `'a`, which for the
-    /// dev server's `Transpiler<'static>` must be `'static`. Liveness: the
-    /// transpiler is boxed in `self` and the heap is boxed in the
-    /// `CurrentBundle` next to `bv2`, and `finalize_bundle_cleanup` drops `bv2`
-    /// before either. Aliasing: this is NOT exclusive — the dev server keeps
-    /// using `self.server_transpiler` (its resolver) while the bundle runs, as
-    /// the bundler's own `client_transpiler`/`ssr_transpiler` `NonNull`s
-    /// already do. Goes away when `BundleV2` takes its primary transpiler the
-    /// same way (`NonNull`/`BackRef`) and owns the dev-server bundle heap.
-    fn bundle_borrows(
-        &mut self,
-        heap: &bun_alloc::MimallocArena,
-    ) -> (
-        &'static mut Transpiler<'static>,
-        &'static bun_alloc::MimallocArena,
-    ) {
-        // SAFETY: see doc comment (liveness holds; exclusivity is the bundler's
-        // existing shared-transpiler contract, not established here).
-        unsafe {
-            (
-                bun_ptr::detach_lifetime_mut(&mut *self.server_transpiler),
-                bun_ptr::detach_lifetime_ref(heap),
-            )
-        }
+        Ok(bv2)
     }
 
     pub(crate) fn prepare_and_log_resolution_failures(&mut self) -> crate::Result<()> {
@@ -3331,7 +3270,7 @@ fn finalize_bundle_cleanup(
     if let Some(cb) = &mut dev.current_bundle {
         cb.promise.deinit_idempotently();
     }
-    // Drops `CurrentBundle.heap` (the arena `bv2.graph.heap` borrows).
+    // Drops `bv2` and, last, the bundle heap it owns.
     dev.current_bundle = None;
     dev.log.clear_and_free();
 

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -76,11 +76,7 @@ pub(crate) type DynamicRouteMap = ArrayHashMap<EncodedPattern, RouteIndex, Effec
 
 /// A logical route, for which layouts are looked up on after resolving a route.
 pub(crate) struct Route {
-    // Payload bytes borrow from the sibling `pattern_string_arena` field — a
-    // self-referential borrow Rust lifetimes cannot express, so it is detached
-    // to `'static` via `to_owned_part()` at insertion. See `to_owned_part` for
-    // the safety invariant (arena outlives every `Route`).
-    pub(crate) part: Part<'static>,
+    pub(crate) part: StoredPart,
     pub r#type: TypeIndex,
 
     pub(crate) parent: Option<RouteIndex>,
@@ -189,7 +185,7 @@ impl FrameworkRouter {
             debug_assert!(strings::has_prefix(&ty.abs_root, root));
 
             routes.push(Route {
-                part: Part::Text(b""),
+                part: StoredPart::EMPTY,
                 r#type: TypeIndex::init(u8::try_from(type_index).expect("int cast")),
                 parent: None,
                 next_sibling: None,
@@ -1071,7 +1067,7 @@ impl FrameworkRouter {
             'outer: loop {
                 let mut next = self.route_ptr(route_index).first_child;
                 while let Some(current) = next {
-                    if current_part.eql(&self.route_ptr(current).part) {
+                    if current_part.eql(&self.route_ptr(current).part.get()) {
                         match next_part(&mut static_it, &mut dynamic_it) {
                             None => break 'brk current, // found it!
                             Some(p) => current_part = p,
@@ -1087,10 +1083,7 @@ impl FrameworkRouter {
 
                 // Must add to this child
                 let mut new_route_index = self.new_route(Route {
-                    // SAFETY: `current_part` borrows from `pattern_string_arena`
-                    // (owned by `self`), which outlives every `Route` stored in
-                    // `self.routes`.
-                    part: unsafe { current_part.to_owned_part() },
+                    part: StoredPart::new(current_part),
                     r#type: ty,
                     parent: Some(route_index),
                     first_child: None,
@@ -1110,10 +1103,7 @@ impl FrameworkRouter {
                 // inserting routes simpler to implement, but could technically be avoided.
                 while let Some(next_part_val) = next_part(&mut static_it, &mut dynamic_it) {
                     let newer_route_index = self.new_route(Route {
-                        // SAFETY: `next_part_val` borrows from
-                        // `pattern_string_arena` (owned by `self`), which
-                        // outlives every `Route` stored in `self.routes`.
-                        part: unsafe { next_part_val.to_owned_part() },
+                        part: StoredPart::new(next_part_val),
                         r#type: ty,
                         parent: Some(new_route_index),
                         first_child: None,
@@ -1169,35 +1159,36 @@ impl FrameworkRouter {
     }
 }
 
-// `Part` stored in `Route` borrows from the router's own `pattern_string_arena`.
-// Rust cannot express that self-referential borrow, so `to_owned_part` detaches
-// the lifetime when storing into `Route`.
-impl<'a> Part<'a> {
-    /// Detach the borrow lifetime so this `Part` can be stored in `Route`.
-    ///
-    /// # Safety
-    /// Every payload slice must point into `FrameworkRouter::pattern_string_arena`
-    /// (or other storage that outlives the owning `FrameworkRouter`).
-    #[allow(unsafe_op_in_unsafe_fn)]
-    unsafe fn to_owned_part(self) -> Part<'static> {
-        // Variant-by-variant detach (no bitcast). `d` stays `unsafe fn` so a
-        // safe-signature wrapper does not hide the lifetime-widen.
-        #[inline(always)]
-        unsafe fn d(s: &[u8]) -> &'static [u8] {
-            // SAFETY: (`Interned::assume` — Population B, holder-backed) every
-            // payload slice points into `FrameworkRouter::pattern_string_arena`,
-            // which is owned by the `FrameworkRouter` and freed only on
-            // router drop/reset — strictly after every `Route` holding a
-            // `Part<'static>` is gone. NOT process-lifetime; a `'bump`
-            // parameter on `Part` would model this more precisely.
-            unsafe { bun_ptr::Interned::assume(s) }.as_bytes()
+/// A [`Part`] stored in a [`Route`]: the payload lives in the router's
+/// `pattern_string_arena` (both patterns handed to `insert` are backed by it),
+/// which outlives every `Route`.
+#[derive(Copy, Clone)]
+pub(crate) struct StoredPart {
+    tag: PartTag,
+    payload: bun_ptr::RawSlice<u8>,
+}
+
+impl StoredPart {
+    pub(crate) const EMPTY: StoredPart = StoredPart {
+        tag: PartTag::Text,
+        payload: bun_ptr::RawSlice::EMPTY,
+    };
+
+    fn new(part: Part<'_>) -> StoredPart {
+        StoredPart {
+            tag: part.tag(),
+            payload: bun_ptr::RawSlice::new(part.payload()),
         }
-        match self {
-            Part::Text(s) => Part::Text(d(s)),
-            Part::Param(s) => Part::Param(d(s)),
-            Part::CatchAllOptional(s) => Part::CatchAllOptional(d(s)),
-            Part::CatchAll(s) => Part::CatchAll(d(s)),
-            Part::Group(s) => Part::Group(d(s)),
+    }
+
+    pub(crate) fn get(&self) -> Part<'_> {
+        let payload = self.payload.slice();
+        match self.tag {
+            PartTag::Text => Part::Text(payload),
+            PartTag::Param => Part::Param(payload),
+            PartTag::CatchAllOptional => Part::CatchAllOptional(payload),
+            PartTag::CatchAll => Part::CatchAll(payload),
+            PartTag::Group => Part::Group(payload),
         }
     }
 }
@@ -1497,17 +1488,13 @@ impl FrameworkRouter {
         arena_state: &mut Arena,
         ctx: &mut dyn InsertionHandler,
     ) -> Result<(), AllocError> {
-        let fs = r.fs();
-        // SAFETY: BACKREF — `r.fs()` is the process-global FileSystem singleton; valid for the
-        // program lifetime. Resolver mutex serializes mutation. We hold a raw pointer (no borrow)
-        // so `r.read_dir_info_ignore_error(&mut self)` below does not conflict.
-        let fs_ref = unsafe { &*fs };
-        // SAFETY: `fs` is the non-null process-global FileSystem singleton (see above);
-        // `addr_of_mut!` only computes a field address without forming a reference.
-        let fs_impl = unsafe { core::ptr::addr_of_mut!((*fs).fs) };
+        // The process-global singleton (what `r.fs()` points at); fetched
+        // statically so `r` stays free for the `read_dir_info_ignore_error`
+        // recursion below.
+        let fs_ref = bun_resolver::fs::FileSystem::get();
 
         {
-            // Note: `entries.data` is backed by `std::collections::HashMap`,
+            // Note: `DirEntry` is backed by `std::collections::HashMap`,
             // whose iteration order is unspecified. The route-tree child order
             // is this iteration order (see `insert`), and
             // `test/bake/framework-router.test.ts` snapshots it. Rebuild into a
@@ -1517,7 +1504,7 @@ impl FrameworkRouter {
             // re-insertion order is irrelevant.
             let mut zig_order: bun_collections::zig_hash_map::HashMap<
                 Box<[u8]>,
-                *mut bun_resolver::fs::Entry,
+                &bun_resolver::fs::Entry,
                 ZigStringHashContext,
             > = Default::default();
             {
@@ -1526,24 +1513,18 @@ impl FrameworkRouter {
                 // walk so the `read_dir_info_ignore_error` recursion can re-lock.
                 let _entries_lock = fs_ref.fs.entries_mutex.lock_guard();
                 if let Some(entries) = dir_info.get_entries_const() {
-                    for (k, &v) in entries.data.iter() {
-                        let _ = zig_order.put(Box::from(&**k), v);
+                    for (k, v) in entries.iter() {
+                        let _ = zig_order.put(Box::from(k), v);
                     }
                 }
             }
             let mut it = zig_order.iter();
             'outer: while let Some(entry) = it.next() {
-                let file_ptr: *mut bun_resolver::fs::Entry = *entry.1;
-                // SAFETY: EntryMap stores `*mut Entry` into the EntryStore singleton
-                // (process lifetime); the lazy-stat rewrite in `kind()` below is
-                // serialized on the per-entry `Entry.mutex`.
-                let file = unsafe { &*file_ptr };
+                let file: &bun_resolver::fs::Entry = *entry.1;
                 let base = file.base();
-                // Note: reshaped for borrowck — fetch type fields fresh each iteration.
-                // SAFETY: `Entry::kind` mutates only the entry's lazily-cached kind; `file_ptr`
-                // is the unique live reference to this entry during the scan, and `fs_impl`
-                // points at the process-global FS implementation.
-                match unsafe { (*file_ptr).kind(&raw mut *fs_impl, false) } {
+                // The lazy-stat rewrite in `kind_with()` is serialized on the
+                // per-entry `Entry.mutex`.
+                match file.kind_with(&fs_ref.fs, false) {
                     bun_resolver::fs::EntryKind::Dir => {
                         let t = &self.types[t_index.get() as usize];
                         if t.ignore_underscores && base.starts_with(b"_") {
@@ -1913,7 +1894,11 @@ impl JSFrameworkRouter {
     fn route_to_json(&self, global: &JSGlobalObject, route_index: RouteIndex) -> JsResult<JSValue> {
         let route = self.router.route_ptr(route_index);
         let obj = JSValue::create_empty_object(global, 4);
-        obj.put(global, b"part", Self::part_to_js(global, &route.part)?);
+        obj.put(
+            global,
+            b"part",
+            Self::part_to_js(global, &route.part.get())?,
+        );
         obj.put(
             global,
             b"page",
@@ -1952,7 +1937,11 @@ impl JSFrameworkRouter {
     ) -> JsResult<JSValue> {
         let route = self.router.route_ptr(route_index);
         let obj = JSValue::create_empty_object(global, 4);
-        obj.put(global, b"part", Self::part_to_js(global, &route.part)?);
+        obj.put(
+            global,
+            b"part",
+            Self::part_to_js(global, &route.part.get())?,
+        );
         obj.put(
             global,
             b"page",

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -674,27 +674,28 @@ impl Framework {
                     .collect()
                 };
 
-                let ignore_dirs: Vec<Cow<'static, [u8]>> =
-                    if let Some(exts_js) = fsr_opts.get(global, "ignoreDirs")? {
-                        'exts: {
-                            if exts_js.is_array() {
-                                let mut it_2 = array.array_iterator(global)?;
-                                let mut dirs = Vec::with_capacity(len as usize);
-                                while let Some(array_item) = it_2.next()? {
-                                    dirs.push(Cow::Owned(
-                                        array_item.to_utf8(global)?.slice().to_vec(),
-                                    ));
-                                }
-                                break 'exts dirs;
+                let ignore_dirs: Vec<Cow<'static, [u8]>> = if let Some(exts_js) =
+                    fsr_opts.get(global, "ignoreDirs")?
+                {
+                    'exts: {
+                        if exts_js.is_array() {
+                            let mut it_2 = exts_js.array_iterator(global)?;
+                            let mut dirs = Vec::with_capacity(exts_js.get_length(global)? as usize);
+                            while let Some(array_item) = it_2.next()? {
+                                dirs.push(Cow::Owned(
+                                    array_item.to_utf8(global)?.slice().to_vec(),
+                                ));
                             }
+                            break 'exts dirs;
+                        }
 
-                            return Err(global.throw_invalid_arguments(format_args!(
+                        return Err(global.throw_invalid_arguments(format_args!(
                             "'ignoreDirs' must be an array of strings or \"*\" for all extensions"
                         )));
-                        }
-                    } else {
-                        vec![Cow::Borrowed(b".git"), Cow::Borrowed(b"node_modules")]
-                    };
+                    }
+                } else {
+                    vec![Cow::Borrowed(b".git"), Cow::Borrowed(b"node_modules")]
+                };
 
                 file_system_router_types.push(FileSystemRouterType {
                     root: Cow::Owned(root),

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -10,7 +10,6 @@ use std::borrow::Cow;
 use bun_alloc::Arena;
 use bun_collections::StringArrayHashMap;
 use bun_core::Output;
-use bun_core::Utf8Bytes;
 use bun_core::{ZStr, strings};
 use bun_jsc::{JSGlobalObject, JSValue, JsError, JsResult};
 use bun_paths::PathBuffer;
@@ -480,7 +479,9 @@ impl Framework {
                         "'framework.serverComponents.separateSSRGraph' must be a boolean"
                     )));
                 },
-                server_runtime_import: match sc.get_optional_slice(global, "serverRuntimeImportSource")? {
+                server_runtime_import: match sc
+                    .get_optional_slice(global, "serverRuntimeImportSource")?
+                {
                     Some(s) => Cow::Owned(s.slice().to_vec()),
                     None => {
                         return Err(global.throw_invalid_arguments(format_args!(

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -4,17 +4,21 @@
 //! role as a framework, Bake is tool for frameworks to build on top of.
 #![allow(unexpected_cfgs)] // `bun_codegen_embed` is set via RUSTFLAGS (scripts/build/rust.ts) for release/CI builds.
 
-use bun_alloc::ArenaVecExt as _;
 use core::ptr::NonNull;
+use std::borrow::Cow;
 
-use bun_alloc::Arena; // = bumpalo::Bump
-use bun_collections::ArrayHashMap;
+use bun_alloc::Arena;
+use bun_collections::StringArrayHashMap;
 use bun_core::Output;
-use bun_core::Utf8Bytes;
 use bun_core::{ZStr, strings};
+use bun_core::Utf8Bytes;
 use bun_jsc::{JSGlobalObject, JSValue, JsError, JsResult};
-use bun_options_types::schema as bun_schema;
-use bun_paths::{self as paths, PathBuffer};
+use bun_paths::PathBuffer;
+
+use super::{
+    BuildConfigSubset, BuiltInModule, FileSystemRouterType, Framework, ReactFastRefresh,
+    ServerComponents, SplitBundlerOptions,
+};
 
 // `jsc.API.JSBundler.Plugin` — opaque FFI handle for the C++ JSBundlerPlugin.
 // Re-exported from `crate::api::js_bundler` so `SplitBundlerOptions.plugin`
@@ -22,15 +26,7 @@ use bun_paths::{self as paths, PathBuffer};
 pub(crate) use crate::api::js_bundler::Plugin;
 use crate::api::js_bundler::js_bundler::PluginJscExt as _;
 
-// Note: parent `mod.rs` already declares `dev_server` / `framework_router`
-// as sibling modules of this file; pull them in instead of re-declaring (which
-// would duplicate the module tree and fail on `framework_router` having no
-// matching filename).
-use super::{dev_server, framework_router};
-
-// Note: `pub use dev_server as DevServer` / `framework_router as
-// FrameworkRouter` are already provided by the parent `mod.rs` (lines 349/369);
-// re-exporting here triggers E0365 because `bake_body` is a private module.
+use super::framework_router;
 
 use bun_bundler_jsc::source_map_mode_jsc::source_map_mode_from_js;
 
@@ -41,54 +37,20 @@ fn throw_core_error(global: &JSGlobalObject, e: crate::Error, ctx: &'static str)
     global.throw_error(e, ctx)
 }
 
-/// Erase the `'bump` lifetime of an arena-backed slice. Arena-erasure
-/// convention (see file-level TODO(lifetime)): `UserOptions.arena` outlives every
-/// borrower, so the bytes are valid for the program-relevant lifetime.
-#[inline(always)]
-pub(crate) fn arena_erase<T: ?Sized>(r: &T) -> &'static T {
-    // SAFETY: arena-backed; UserOptions owns the bump and is dropped last.
-    // PORTING.md sanctions this only inside the bake `from_js` self-referential
-    // pattern — do NOT generalize.
-    unsafe { bun_ptr::detach_ref(r) }
-}
-
-/// Copy `bytes` plus a trailing NUL into the bump arena.
-/// Returns `&'static ZStr` per the file-level `'static` convention
-/// (arena-backed; lifetime erased — see TODO(lifetime) at top of file).
-pub(crate) fn arena_dupe_z(arena: &Arena, bytes: &[u8]) -> &'static ZStr {
-    let buf: &mut [u8] = arena.alloc_slice_fill_default(bytes.len() + 1);
-    buf[..bytes.len()].copy_from_slice(bytes);
-    buf[bytes.len()] = 0;
-    // SAFETY: buf is NUL-terminated; arena outlives all borrowers per the
-    // self-referential UserOptions pattern. Not `from_buf`: the `'static`
-    // return type intentionally erases the arena lifetime; threading a real
-    // `'bump` would replace this with `from_buf`.
-    unsafe { ZStr::from_raw(buf.as_ptr(), bytes.len()) }
-}
-
 /// export default { app: ... };
 const API_NAME: &str = "app";
 
-// TODO(lifetime): many `&'static [u8]` fields below are actually backed
-// by `UserOptions.arena` (bumpalo::Bump) or `UserOptions.allocations`
-// (StringRefList). `&'static` is used to avoid struct lifetime params per
-// PORTING.md; could thread `'bump` or introduce `ArenaStr`.
-
 /// Rust version of the TS definition 'Bake.Options' in 'bake.d.ts'
 pub struct UserOptions {
-    /// This arena contains some miscellaneous allocations at startup
+    /// Scratch arena for the transpilers built from these options.
     pub(crate) arena: Arena,
-    pub allocations: StringRefList,
-
-    pub(crate) root: &'static ZStr, // TODO(lifetime): arena-owned, self-referential with .arena
+    pub(crate) root: Box<[u8]>,
     pub(crate) framework: Framework,
     pub(crate) bundler_options: SplitBundlerOptions,
 }
 
 impl Drop for UserOptions {
     fn drop(&mut self) {
-        // arena: dropped by Bump's Drop
-        // allocations: dropped by StringRefList's Drop
         if let Some(p) = self.bundler_options.plugin {
             // `p` is the FFI handle returned by `Plugin::create` in
             // `parse_plugin_array`; `PluginJscExt::destroy` is its paired
@@ -103,10 +65,6 @@ impl UserOptions {
     /// Currently, this function must run at the top of the event loop.
     pub fn from_js(config: JSValue, global: &JSGlobalObject) -> JsResult<UserOptions> {
         let arena = Arena::new();
-        // errdefer arena.deinit() — handled by Drop
-
-        let mut allocations = StringRefList::EMPTY;
-        // errdefer allocations.free() — handled by Drop
         let mut bundler_options = SplitBundlerOptions::default();
 
         if !config.is_object() {
@@ -116,8 +74,8 @@ impl UserOptions {
                 let utf8_string = bunstr.to_utf8();
 
                 if strings::eql(utf8_string.slice(), b"react") {
-                    let root = match bun_sys::getcwd_alloc() {
-                        Ok(z) => arena_dupe_z(&arena, z.as_bytes()),
+                    let root: Box<[u8]> = match bun_sys::getcwd_alloc() {
+                        Ok(z) => Box::from(z.as_bytes()),
                         Err(e) => {
                             return Err(global.throw_error(
                                 e.to_zig_err(),
@@ -126,15 +84,13 @@ impl UserOptions {
                         }
                     };
 
-                    let framework = Framework::react(&arena)
+                    let framework = Framework::react()
                         .map_err(|e| throw_core_error(global, e, "Framework::react"))?;
 
                     return Ok(UserOptions {
-                        // TODO(lifetime): self-referential — `root`/`framework` borrow `arena`
                         root,
                         framework,
                         bundler_options,
-                        allocations,
                         arena,
                     });
                 }
@@ -167,16 +123,14 @@ impl UserOptions {
                 }
             },
             global,
-            &mut allocations,
             &mut bundler_options,
-            &arena,
         )?;
 
-        let root: &[u8] = if let Some(slice) = config.get_optional_slice(global, "root")? {
-            allocations.track(slice)
+        let root: Box<[u8]> = if let Some(slice) = config.get_optional_slice(global, "root")? {
+            Box::from(slice.slice())
         } else {
             match bun_sys::getcwd_alloc() {
-                Ok(z) => arena_dupe_z(&arena, z.as_bytes()).as_bytes(),
+                Ok(z) => Box::from(z.as_bytes()),
                 Err(e) => {
                     return Err(global
                         .throw_error(e.to_zig_err(), "while querying current working directory"));
@@ -188,65 +142,16 @@ impl UserOptions {
             bundler_options.parse_plugin_array(plugin_array, global)?;
         }
 
-        let root_z = arena_dupe_z(&arena, root);
-
         Ok(UserOptions {
-            root: root_z,
+            root,
             framework,
             bundler_options,
-            allocations,
             arena,
         })
     }
 }
 
-/// Each string stores its allocator since some may hold reference counts to JSC
-#[derive(Default)]
-pub struct StringRefList {
-    pub(crate) strings: Vec<Utf8Bytes<'static>>,
-}
-
-impl StringRefList {
-    pub(crate) const EMPTY: StringRefList = StringRefList {
-        strings: Vec::new(),
-    };
-
-    // Note: returned slice borrows JSC-owned storage kept alive by the
-    // `Utf8Bytes` now stored in `self.strings`; it is valid only for as
-    // long as `self` is. Callers that store the result in `Framework` /
-    // `FileSystemRouterType` / `ServerComponents` fields must thread a `'bump`
-    // lifetime (or switch those fields to `Box<[u8]>` / `ArenaStr`) — see the
-    // file-level TODO(lifetime) above. Do NOT paper over this with a `'static`
-    // transmute (forbidden per PORTING.md §Forbidden — lifetime extension).
-    pub(crate) fn track(&mut self, str: Utf8Bytes<'static>) -> &'static [u8] {
-        self.strings.push(str);
-        let slice = self.strings.last().unwrap().slice();
-        // SAFETY: (`Interned::assume` — Population B, holder-backed) the
-        // `Utf8Bytes` is now owned by `self.strings` and lives exactly as
-        // long as the `StringRefList`, which is owned by `UserOptions` and
-        // dropped only when bake teardown runs (`UserOptions::deinit`). The
-        // returned slice is stored only in `Framework` / `FileSystemRouterType`
-        // / `ServerComponents` fields that are themselves owned by the same
-        // `UserOptions`, so no read outlives the holder. NOT process-lifetime
-        // — a real `'bump` lifetime should eventually be threaded here (see
-        // file-level TODO(lifetime)); `assume` makes the lie grep-able until then.
-        unsafe { bun_ptr::Interned::assume(slice) }.as_bytes()
-    }
-}
-
-#[derive(Default)]
-pub struct SplitBundlerOptions {
-    pub plugin: Option<NonNull<Plugin>>,
-    pub client: BuildConfigSubset,
-    pub server: BuildConfigSubset,
-    pub ssr: BuildConfigSubset,
-}
-
 impl SplitBundlerOptions {
-    // Note: was `pub const EMPTY` — `ArrayHashMap::new()` (inside
-    // `BuildConfigSubset`) is not `const fn`, so this is now a fn-backed
-    // default. Callers updated to `SplitBundlerOptions::default()`.
-
     fn parse_plugin_array(
         &mut self,
         plugin_array: JSValue,
@@ -329,20 +234,6 @@ impl SplitBundlerOptions {
     }
 }
 
-pub struct BuildConfigSubset {
-    pub ignore_dce_annotations: Option<bool>,
-    pub conditions: ArrayHashMap<&'static [u8], ()>,
-    pub drop: ArrayHashMap<&'static [u8], ()>,
-    pub env: bun_schema::api::DotEnvBehavior,
-    pub env_prefix: Option<&'static [u8]>,
-    pub define: bun_schema::api::StringMap,
-    pub source_map: bun_schema::api::SourceMapMode,
-
-    pub minify_syntax: Option<bool>,
-    pub minify_identifiers: Option<bool>,
-    pub minify_whitespace: Option<bool>,
-}
-
 impl BuildConfigSubset {
     pub fn from_js(global: &JSGlobalObject, js_options: JSValue) -> JsResult<BuildConfigSubset> {
         let mut options = BuildConfigSubset::default();
@@ -390,115 +281,59 @@ impl BuildConfigSubset {
     }
 }
 
-impl Default for BuildConfigSubset {
-    fn default() -> Self {
-        // Note: was `pub const DEFAULT` — `ArrayHashMap::new()` is not
-        // `const fn`, so this lives behind `Default` instead.
-        BuildConfigSubset {
-            ignore_dce_annotations: None,
-            conditions: ArrayHashMap::new(),
-            drop: ArrayHashMap::new(),
-            env: bun_schema::api::DotEnvBehavior::_none,
-            env_prefix: None,
-            define: bun_schema::api::StringMap::EMPTY,
-            source_map: bun_schema::api::SourceMapMode::External,
-
-            minify_syntax: None,
-            minify_identifiers: None,
-            minify_whitespace: None,
-        }
-    }
-}
-
-/// A "Framework" in our eyes is simply set of bundler options that a framework
-/// author would set in order to integrate the framework with the application.
-/// Since many fields have default values which may point to static memory, this
-/// structure is always arena-allocated, usually owned by the arena in `UserOptions`
-///
-/// Full documentation on these fields is located in the TypeScript definitions.
-pub struct Framework {
-    pub is_built_in_react: bool,
-    /// `resolve()` rewrites this in place. Stored as an owned `Vec` so
-    /// `#[derive(Clone)]` deep-copies (a shared `&[T]` would alias and make
-    /// `resolve()`'s mutation UB).
-    pub file_system_router_types: Vec<FileSystemRouterType>,
-    // static_routers: &'static [&'static [u8]],
-    pub server_components: Option<ServerComponents>,
-    pub react_fast_refresh: Option<ReactFastRefresh>,
-    pub built_in_modules: ArrayHashMap<&'static [u8], BuiltInModule>,
-}
-
-impl Default for Framework {
-    fn default() -> Self {
-        Self {
-            is_built_in_react: false,
-            file_system_router_types: Vec::new(),
-            server_components: None,
-            react_fast_refresh: None,
-            built_in_modules: ArrayHashMap::new(),
-        }
-    }
-}
-
 impl Framework {
     /// Bun provides built-in support for using React as a framework.
     /// Depends on externally provided React
     ///
     /// $ bun i react@experimental react-dom@experimental react-refresh@experimental react-server-dom-bun
-    pub fn react(arena: &Arena) -> crate::Result<Framework> {
+    pub fn react() -> crate::Result<Framework> {
         // Cannot use .import because resolution must happen from the user's POV
-        let built_in_values: &[BuiltInModule] = &[
-            // Browser-side source: compressed in release builds.
-            BuiltInModule::Code(bun_zstd::embed_compressed!(
-                src "runtime/bake/bun-framework-react/client.tsx"
-            )),
-            BuiltInModule::Code(
+        let built_ins: [(&'static [u8], &'static [u8]); 3] = [
+            (
+                b"bun-framework-react/client.tsx",
+                // Browser-side source: compressed in release builds.
+                bun_zstd::embed_compressed!(src "runtime/bake/bun-framework-react/client.tsx"),
+            ),
+            (
+                b"bun-framework-react/server.tsx",
                 bun_core::runtime_embed_file!(Src, "runtime/bake/bun-framework-react/server.tsx")
                     .as_bytes(),
             ),
-            BuiltInModule::Code(
+            (
+                b"bun-framework-react/ssr.tsx",
                 bun_core::runtime_embed_file!(Src, "runtime/bake/bun-framework-react/ssr.tsx")
                     .as_bytes(),
             ),
         ];
+        let mut built_in_modules = StringArrayHashMap::new();
+        built_in_modules.ensure_total_capacity(built_ins.len())?;
+        for (k, code) in built_ins {
+            built_in_modules.put(k, BuiltInModule::Code(code.into()))?;
+        }
 
         Ok(Framework {
             is_built_in_react: true,
             server_components: Some(ServerComponents {
                 separate_ssr_graph: true,
-                server_runtime_import: b"react-server-dom-bun/server",
-                ..ServerComponents::default()
+                server_runtime_import: Cow::Borrowed(b"react-server-dom-bun/server"),
+                server_register_client_reference: Cow::Borrowed(b"registerClientReference"),
+                server_register_server_reference: Cow::Borrowed(b"registerServerReference"),
+                client_register_server_reference: Cow::Borrowed(b"registerServerReference"),
             }),
             react_fast_refresh: Some(ReactFastRefresh::default()),
             file_system_router_types: vec![FileSystemRouterType {
-                root: b"pages",
-                prefix: b"/",
-                entry_client: Some(b"bun-framework-react/client.tsx"),
-                entry_server: b"bun-framework-react/server.tsx",
+                root: Cow::Borrowed(b"pages"),
+                prefix: Cow::Borrowed(b"/"),
+                entry_client: Some(Cow::Borrowed(b"bun-framework-react/client.tsx")),
+                entry_server: Cow::Borrowed(b"bun-framework-react/server.tsx"),
                 ignore_underscores: true,
-                ignore_dirs: &[b"node_modules", b".git"],
-                extensions: &[b".tsx", b".jsx"],
+                ignore_dirs: vec![Cow::Borrowed(b"node_modules"), Cow::Borrowed(b".git")],
+                extensions: vec![Cow::Borrowed(b".tsx"), Cow::Borrowed(b".jsx")],
                 style: framework_router::Style::NextjsPages,
                 allow_layouts: true,
             }],
-            // .static_routers = arena.alloc_slice_copy(&[b"public"]),
-            built_in_modules: {
-                // Note: was `ArrayHashMap::from_entries(arena, keys, vals)`;
-                // that constructor doesn't exist on the heap-backed
-                // `ArrayHashMap` — build it imperatively. `bun.handleOom`.
-                let keys: [&'static [u8]; 3] = [
-                    b"bun-framework-react/client.tsx",
-                    b"bun-framework-react/server.tsx",
-                    b"bun-framework-react/ssr.tsx",
-                ];
-                let mut m: ArrayHashMap<&'static [u8], BuiltInModule> = ArrayHashMap::new();
-                bun_core::handle_oom(m.ensure_total_capacity(keys.len()));
-                for (k, v) in keys.iter().zip(built_in_values.iter()) {
-                    m.put_assume_capacity(*k, *v);
-                }
-                let _ = arena; // arena param retained for API parity
-                m
-            },
+            // static_routers: ["public"],
+            built_in_modules,
         })
     }
 
@@ -510,187 +345,39 @@ impl Framework {
     ///   the above react configuration.
     /// The provided allocator is not stored.
     pub fn auto(
-        arena: &Arena,
         resolver: &mut bun_resolver::Resolver,
         file_system_router_types: Vec<FileSystemRouterType>,
     ) -> crate::Result<Framework> {
-        let mut fw: Framework = Framework::none();
+        let mut fw: Framework = Framework::default();
 
         if !file_system_router_types.is_empty() {
-            fw = Self::react(arena)?;
+            fw = Self::react()?;
             fw.file_system_router_types = file_system_router_types;
         }
 
         if let Some(rfr) = resolve_or_null(resolver, b"react-refresh/runtime") {
-            fw.react_fast_refresh = Some(ReactFastRefresh { import_source: rfr });
+            fw.react_fast_refresh = Some(ReactFastRefresh {
+                import_source: Cow::Borrowed(rfr),
+            });
         } else if resolve_or_null(resolver, b"react").is_some() {
             fw.react_fast_refresh = Some(ReactFastRefresh {
-                import_source: b"react-refresh/runtime/index.js",
+                import_source: Cow::Borrowed(b"react-refresh/runtime/index.js"),
             });
-            let react_refresh_code = BuiltInModule::Code(
-                bun_zstd::embed_compressed!(codegen "node-fallbacks/react-refresh.js"),
-            );
-            let _ = arena;
             fw.built_in_modules.put(
-                b"react-refresh/runtime/index.js" as &[u8],
-                react_refresh_code,
+                b"react-refresh/runtime/index.js",
+                BuiltInModule::Code(
+                    bun_zstd::embed_compressed!(codegen "node-fallbacks/react-refresh.js").into(),
+                ),
             )?;
         }
 
         Ok(fw)
     }
 
-    /// Unopinionated default. Note: was `pub const NONE` —
-    /// `ArrayHashMap::new()` is not `const fn`.
-    pub fn none() -> Framework {
-        Framework {
-            is_built_in_react: false,
-            file_system_router_types: Vec::new(),
-            server_components: None,
-            react_fast_refresh: None,
-            built_in_modules: ArrayHashMap::new(),
-        }
-    }
-
-    /// `Framework.clone()` — manual because `ArrayHashMap` exposes a
-    /// fallible inherent `clone()` rather than `impl Clone`.
-    pub fn clone(&self) -> Framework {
-        Framework {
-            is_built_in_react: self.is_built_in_react,
-            file_system_router_types: self.file_system_router_types.clone(),
-            server_components: self.server_components,
-            react_fast_refresh: self.react_fast_refresh,
-            built_in_modules: bun_core::handle_oom(self.built_in_modules.clone()),
-        }
-    }
-
-    pub fn add_react_install_command_note(log: &mut bun_ast::Log) -> crate::Result<()> {
-        let clone_line_text = log.clone_line_text;
-        log.add_msg(bun_ast::Msg {
-            kind: bun_ast::Kind::Note,
-            data: bun_ast::range_data(
-                None,
-                bun_ast::Range::NONE,
-                // `range_data` takes `impl Into<Cow<'static, [u8]>>`;
-                // `concat!` yields `&'static str` — go via `.as_bytes()`.
-                concat!(
-                    "Install the built in react integration with \"",
-                    "bun i react@experimental react-dom@experimental react-server-dom-bun react-refresh@experimental",
-                    "\""
-                )
-                .as_bytes(),
-            )
-            .clone_line_text(clone_line_text),
-            ..Default::default()
-        });
-        Ok(())
-    }
-
-    /// Given a Framework configuration, this returns another one with all paths resolved.
-    /// New memory allocated into provided arena.
-    ///
-    /// All resolution errors will happen before returning error.ModuleNotFound
-    /// Errors written into `r.log`
-    pub fn resolve(
-        &self,
-        server: &mut bun_resolver::Resolver,
-        client: &mut bun_resolver::Resolver,
-        arena: &Arena,
-    ) -> crate::Result<Framework> {
-        let mut clone = self.clone();
-        let mut had_errors: bool = false;
-
-        if let Some(react_fast_refresh) = &mut clone.react_fast_refresh {
-            self.resolve_helper(
-                client,
-                &mut react_fast_refresh.import_source,
-                &mut had_errors,
-                b"react refresh runtime",
-            );
-        }
-
-        if let Some(sc) = &mut clone.server_components {
-            self.resolve_helper(
-                server,
-                &mut sc.server_runtime_import,
-                &mut had_errors,
-                b"server components runtime",
-            );
-            // self.resolve_helper(client, &mut sc.client_runtime_import, &mut had_errors);
-        }
-
-        for fsr in clone.file_system_router_types.iter_mut() {
-            let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-            fsr.root = arena_erase(arena.alloc_slice_copy(paths::resolve_path::join_abs::<
-                paths::platform::Auto,
-            >(top_level_dir, fsr.root)));
-            if let Some(entry_client) = &mut fsr.entry_client {
-                self.resolve_helper(
-                    client,
-                    entry_client,
-                    &mut had_errors,
-                    b"client side entrypoint",
-                );
-            }
-            self.resolve_helper(
-                client,
-                &mut fsr.entry_server,
-                &mut had_errors,
-                b"server side entrypoint",
-            );
-        }
-
-        if had_errors {
-            return Err(crate::Error::ModuleNotFound);
-        }
-
-        Ok(clone)
-    }
-
-    #[inline]
-    fn resolve_helper(
-        &self,
-        r: &mut bun_resolver::Resolver,
-        path: &mut &'static [u8],
-        had_errors: &mut bool,
-        desc: &[u8],
-    ) {
-        if let Some(module) = self.built_in_modules.get(path) {
-            match module {
-                BuiltInModule::Import(p) => *path = p,
-                BuiltInModule::Code(_) => {}
-            }
-            return;
-        }
-
-        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-        let mut result = match r.resolve(top_level_dir, *path, bun_ast::ImportKind::Stmt) {
-            Ok(res) => res,
-            Err(err) => {
-                Output::err(
-                    err,
-                    "Failed to resolve '{}' for framework ({})",
-                    (bstr::BStr::new(path), bstr::BStr::new(desc)),
-                );
-                *had_errors = true;
-                return;
-            }
-        };
-        // `resolver::Result::path().text` is `&'static [u8]` already (resolver's
-        // `Path` alias is `bun_paths::fs::Path<'static>`, populated from the
-        // `FilenameStore` singleton). No widen needed; the previous
-        // `arena_erase` here laundered an already-`'static` slice and falsely
-        // implied arena ownership. See `bun_ptr::Interned` for the type that
-        // `Path::text` should eventually become.
-        *path = result.path().unwrap().text;
-    }
-
     fn from_js(
         opts: JSValue,
         global: &JSGlobalObject,
-        refs: &mut StringRefList,
         bundler_options: &mut SplitBundlerOptions,
-        arena: &Arena,
     ) -> JsResult<Framework> {
         if opts.is_string() {
             let str = opts.to_bun_string(global)?;
@@ -700,12 +387,12 @@ impl Framework {
                 bun_core::warn!(
                     "deprecation notice: 'react-server-components' will be renamed to 'react'"
                 );
-                return Framework::react(arena)
+                return Framework::react()
                     .map_err(|e| throw_core_error(global, e, "Framework::react"));
             }
 
             if str.eq_ascii(b"react") {
-                return Framework::react(arena)
+                return Framework::react()
                     .map_err(|e| throw_core_error(global, e, "Framework::react"));
             }
         }
@@ -755,7 +442,7 @@ impl Framework {
             let str = prop.to_bun_string(global)?;
 
             Some(ReactFastRefresh {
-                import_source: refs.track(str.into_utf8()),
+                import_source: Cow::Owned(str.into_utf8().slice().to_vec()),
             })
         };
         let server_components: Option<ServerComponents> = 'sc: {
@@ -793,33 +480,32 @@ impl Framework {
                         "'framework.serverComponents.separateSSRGraph' must be a boolean"
                     )));
                 },
-                server_runtime_import: refs.track(
-                    match sc.get_optional_slice(global, "serverRuntimeImportSource")? {
-                        Some(s) => s,
-                        None => {
-                            return Err(global.throw_invalid_arguments(format_args!(
-                                "Missing 'framework.serverComponents.serverRuntimeImportSource'"
-                            )));
-                        }
-                    },
-                ),
+                server_runtime_import: match sc.get_optional_slice(global, "serverRuntimeImportSource")? {
+                    Some(s) => Cow::Owned(s.slice().to_vec()),
+                    None => {
+                        return Err(global.throw_invalid_arguments(format_args!(
+                            "Missing 'framework.serverComponents.serverRuntimeImportSource'"
+                        )));
+                    }
+                },
                 server_register_client_reference: if let Some(slice) =
                     sc.get_optional_slice(global, "serverRegisterClientReferenceExport")?
                 {
-                    refs.track(slice)
+                    Cow::Owned(slice.slice().to_vec())
                 } else {
-                    b"registerClientReference"
+                    Cow::Borrowed(b"registerClientReference")
                 },
-                ..ServerComponents::default()
+                server_register_server_reference: Cow::Borrowed(b"registerServerReference"),
+                client_register_server_reference: Cow::Borrowed(b"registerServerReference"),
             })
         };
-        let built_in_modules: ArrayHashMap<&'static [u8], BuiltInModule> = 'built_in_modules: {
+        let built_in_modules: StringArrayHashMap<BuiltInModule> = 'built_in_modules: {
             let Some(array) = opts.get_array(global, "builtInModules")? else {
-                break 'built_in_modules ArrayHashMap::new();
+                break 'built_in_modules StringArrayHashMap::new();
             };
 
             let len = array.get_length(global)?;
-            let mut files: ArrayHashMap<&'static [u8], BuiltInModule> = ArrayHashMap::new();
+            let mut files: StringArrayHashMap<BuiltInModule> = StringArrayHashMap::new();
             bun_core::handle_oom(files.ensure_total_capacity(len as usize));
 
             let mut it = array.array_iterator(global)?;
@@ -832,7 +518,7 @@ impl Framework {
                     )));
                 }
 
-                let path = match get_optional_string(file, global, b"import", refs)? {
+                let path = match get_optional_string(file, global, b"import")? {
                     Some(p) => p,
                     None => {
                         return Err(global.throw_invalid_arguments(format_args!(
@@ -843,10 +529,10 @@ impl Framework {
                 };
 
                 let value: BuiltInModule =
-                    if let Some(str) = get_optional_string(file, global, b"path", refs)? {
-                        BuiltInModule::Import(str)
-                    } else if let Some(str) = get_optional_string(file, global, b"code", refs)? {
-                        BuiltInModule::Code(str)
+                    if let Some(str) = get_optional_string(file, global, b"path")? {
+                        BuiltInModule::Import(str.into())
+                    } else if let Some(str) = get_optional_string(file, global, b"code")? {
+                        BuiltInModule::Code(str.into())
                     } else {
                         return Err(global.throw_invalid_arguments(format_args!(
                             "'builtInModules[{}]' needs either 'path' or 'code'",
@@ -854,7 +540,7 @@ impl Framework {
                         )));
                     };
 
-                files.put_assume_capacity(path, value);
+                files.put_assume_capacity(&path, value);
                 i += 1;
             }
 
@@ -884,7 +570,7 @@ impl Framework {
             // releases the `Strong` held by its `JavascriptDefined` arm (the
             // only owning variant; the named styles are unit-like).
             while let Some(fsr_opts) = it.next()? {
-                let root = match get_optional_string(fsr_opts, global, b"root", refs)? {
+                let root = match get_optional_string(fsr_opts, global, b"root")? {
                     Some(r) => r,
                     None => {
                         return Err(global.throw_invalid_arguments(format_args!(
@@ -894,7 +580,7 @@ impl Framework {
                     }
                 };
                 let server_entry_point =
-                    match get_optional_string(fsr_opts, global, b"serverEntryPoint", refs)? {
+                    match get_optional_string(fsr_opts, global, b"serverEntryPoint")? {
                         Some(s) => s,
                         None => {
                             return Err(global.throw_invalid_arguments(format_args!(
@@ -904,9 +590,9 @@ impl Framework {
                         }
                     };
                 let client_entry_point =
-                    get_optional_string(fsr_opts, global, b"clientEntryPoint", refs)?;
-                let prefix =
-                    get_optional_string(fsr_opts, global, b"prefix", refs)?.unwrap_or(b"/");
+                    get_optional_string(fsr_opts, global, b"clientEntryPoint")?;
+                let prefix = get_optional_string(fsr_opts, global, b"prefix")?
+                    .map_or(Cow::Borrowed(b"/".as_slice()), Cow::Owned);
                 let ignore_underscores = fsr_opts
                     .get_boolean_strict(global, "ignoreUnderscores")?
                     .unwrap_or(false);
@@ -928,24 +614,22 @@ impl Framework {
                 )?;
                 // errdefer style.deinit() — handled by Style's Drop
 
-                let extensions: &'static [&'static [u8]] = if let Some(exts_js) =
+                let extensions: Vec<Cow<'static, [u8]>> = if let Some(exts_js) =
                     fsr_opts.get(global, "extensions")?
                 {
                     'exts: {
                         if exts_js.is_string() {
                             let str = exts_js.to_utf8(global)?;
                             if str.slice() == b"*" {
-                                break 'exts &[] as &[&[u8]];
+                                break 'exts Vec::new();
                             }
                         } else if exts_js.is_array() {
                             let mut it_2 = exts_js.array_iterator(global)?;
                             let mut extensions =
-                                bun_alloc::ArenaVec::<&'static [u8]>::with_capacity_in(
-                                    exts_js.get_length(global)? as usize,
-                                    arena,
-                                );
+                                Vec::with_capacity(exts_js.get_length(global)? as usize);
                             while let Some(array_item) = it_2.next()? {
-                                let slice = refs.track(array_item.to_utf8(global)?);
+                                let str = array_item.to_utf8(global)?;
+                                let slice = str.slice();
                                 if slice == b"*" {
                                     return Err(global.throw_invalid_arguments(format_args!(
                                             "'extensions' cannot include \"*\" as an extension. Pass \"*\" instead of the array."
@@ -958,20 +642,16 @@ impl Framework {
                                     )));
                                 }
 
-                                extensions.push(if slice[0] == b'.' {
-                                    slice
+                                extensions.push(Cow::Owned(if slice[0] == b'.' {
+                                    slice.to_vec()
                                 } else {
-                                    // Concatenate "." + slice into the arena.
-                                    let mut v = bun_alloc::ArenaVec::<u8>::with_capacity_in(
-                                        1 + slice.len(),
-                                        arena,
-                                    );
+                                    let mut v = Vec::with_capacity(1 + slice.len());
                                     v.push(b'.');
                                     v.extend_from_slice(slice);
-                                    arena_erase(v.into_bump_slice())
-                                });
+                                    v
+                                }));
                             }
-                            break 'exts arena_erase(extensions.into_bump_slice());
+                            break 'exts extensions;
                         }
 
                         return Err(global.throw_invalid_arguments(format_args!(
@@ -979,41 +659,49 @@ impl Framework {
                         )));
                     }
                 } else {
-                    &[
-                        b".jsx", b".tsx", b".js", b".ts", b".cjs", b".cts", b".mjs", b".mts",
+                    [
+                        b".jsx".as_slice(),
+                        b".tsx",
+                        b".js",
+                        b".ts",
+                        b".cjs",
+                        b".cts",
+                        b".mjs",
+                        b".mts",
                     ]
+                    .into_iter()
+                    .map(Cow::Borrowed)
+                    .collect()
                 };
 
-                let ignore_dirs: &'static [&'static [u8]] = if let Some(exts_js) =
-                    fsr_opts.get(global, "ignoreDirs")?
-                {
-                    'exts: {
-                        if exts_js.is_array() {
-                            let mut it_2 = array.array_iterator(global)?;
-                            let mut dirs = bun_alloc::ArenaVec::<&'static [u8]>::with_capacity_in(
-                                len as usize,
-                                arena,
-                            );
-                            while let Some(array_item) = it_2.next()? {
-                                dirs.push(refs.track(array_item.to_utf8(global)?));
+                let ignore_dirs: Vec<Cow<'static, [u8]>> =
+                    if let Some(exts_js) = fsr_opts.get(global, "ignoreDirs")? {
+                        'exts: {
+                            if exts_js.is_array() {
+                                let mut it_2 = array.array_iterator(global)?;
+                                let mut dirs = Vec::with_capacity(len as usize);
+                                while let Some(array_item) = it_2.next()? {
+                                    dirs.push(Cow::Owned(
+                                        array_item.to_utf8(global)?.slice().to_vec(),
+                                    ));
+                                }
+                                break 'exts dirs;
                             }
-                            break 'exts arena_erase(dirs.into_bump_slice());
-                        }
 
-                        return Err(global.throw_invalid_arguments(format_args!(
+                            return Err(global.throw_invalid_arguments(format_args!(
                             "'ignoreDirs' must be an array of strings or \"*\" for all extensions"
                         )));
-                    }
-                } else {
-                    &[b".git", b"node_modules"]
-                };
+                        }
+                    } else {
+                        vec![Cow::Borrowed(b".git"), Cow::Borrowed(b"node_modules")]
+                    };
 
                 file_system_router_types.push(FileSystemRouterType {
-                    root,
+                    root: Cow::Owned(root),
                     prefix,
                     style,
-                    entry_server: server_entry_point,
-                    entry_client: client_entry_point,
+                    entry_server: Cow::Owned(server_entry_point),
+                    entry_client: client_entry_point.map(Cow::Owned),
                     ignore_underscores,
                     extensions,
                     ignore_dirs,
@@ -1040,251 +728,6 @@ impl Framework {
         }
 
         Ok(framework)
-    }
-
-    /// Project the fields the bundler reads into the lower-tier
-    /// `bun_bundler::bake_types::Framework` view. The bundler crate cannot
-    /// name `bun_runtime::bake::Framework`, so it carries a TYPE_ONLY subset
-    /// that we populate here.
-    pub(crate) fn as_bundler_view(&self) -> bun_bundler::bake_types::Framework {
-        use bun_bundler::bake_types as bt;
-        let mut built_in_modules = bun_collections::StringArrayHashMap::new();
-        for (k, v) in self.built_in_modules.iter() {
-            let bv = match *v {
-                BuiltInModule::Import(p) => bt::BuiltInModule::Import(p.into()),
-                BuiltInModule::Code(c) => bt::BuiltInModule::Code(c.into()),
-            };
-            bun_core::handle_oom(built_in_modules.put(k, bv));
-        }
-        let server_components = self
-            .server_components
-            .as_ref()
-            .map(|sc| bt::ServerComponents {
-                separate_ssr_graph: sc.separate_ssr_graph,
-                server_runtime_import: sc.server_runtime_import.into(),
-                server_register_client_reference: sc.server_register_client_reference.into(),
-                server_register_server_reference: sc.server_register_server_reference.into(),
-                client_register_server_reference: sc.client_register_server_reference.into(),
-            });
-        let react_fast_refresh = self
-            .react_fast_refresh
-            .as_ref()
-            .map(|rfr| bt::ReactFastRefresh {
-                import_source: rfr.import_source.into(),
-            });
-        bt::Framework::new(
-            built_in_modules,
-            server_components,
-            react_fast_refresh,
-            self.is_built_in_react,
-        )
-    }
-
-    pub fn init_transpiler_with_options<'a>(
-        &mut self,
-        arena: &'a Arena,
-        log: &mut bun_ast::Log,
-        mode: Mode,
-        renderer: Graph,
-        out: &mut core::mem::MaybeUninit<bun_bundler::Transpiler<'a>>,
-        bundler_options: &BuildConfigSubset,
-        source_map: bun_bundler::options::SourceMapOption,
-        minify_whitespace: Option<bool>,
-        minify_syntax: Option<bool>,
-        minify_identifiers: Option<bool>,
-    ) -> crate::Result<()> {
-        // `ASTMemoryAllocator::enter` returns an RAII `Scope` whose `Drop`
-        // runs `exit()` at end-of-fn.
-        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(arena);
-        let _ast_scope = ast_memory_allocator.enter();
-
-        // The caller (`DevServer::init`) hands us an uninitialized slot, so
-        // use `MaybeUninit::write` (no drop of prior bytes) then reborrow as
-        // `&mut Transpiler` for the field assignments below.
-        let out: &mut bun_bundler::Transpiler = out.write(bun_bundler::Transpiler::init(
-            arena,
-            log,
-            // `TransformOptions::default()`: every `Option` is `None`, every
-            // slice empty, every scalar zero/false.
-            bun_schema::api::TransformOptions::default(),
-            None,
-        )?);
-
-        out.options.target = match renderer {
-            Graph::Client => bun_ast::Target::Browser,
-            Graph::Server | Graph::Ssr => bun_ast::Target::Bun,
-        };
-        out.options.public_path = match renderer {
-            Graph::Client => dev_server::CLIENT_PREFIX.as_bytes().into(),
-            Graph::Server | Graph::Ssr => Box::default(),
-        };
-        out.options.entry_points = Box::default();
-        out.options.log = log;
-        out.options.output_format = match mode {
-            Mode::Development => bun_bundler::options::Format::InternalBakeDev,
-            Mode::ProductionDynamic | Mode::ProductionStatic => bun_bundler::options::Format::Esm,
-        };
-        out.options.out_extensions = bun_collections::StringHashMap::new();
-        out.options.hot_module_reloading = mode == Mode::Development;
-        out.options.code_splitting = mode != Mode::Development;
-
-        // force disable filesystem output, even though bundle_v2
-        // is special cased to return before that code is reached.
-        out.options.output_dir = Box::default();
-
-        // framework configuration
-        out.options.react_fast_refresh = mode == Mode::Development
-            && renderer == Graph::Client
-            && self.react_fast_refresh.is_some();
-        out.options.server_components = self.server_components.is_some();
-
-        out.options.conditions = bun_bundler::options::ESMConditions::init(
-            out.options.target.default_conditions(),
-            out.options.target.is_server_side(),
-            bundler_options.conditions.keys(),
-        )?;
-        if renderer == Graph::Server && self.server_components.is_some() {
-            out.options.conditions.append_slice(&[b"react-server"])?;
-        }
-        if mode == Mode::Development {
-            // Support `esm-env` package using this condition.
-            out.options.conditions.append_slice(&[b"development"])?;
-        }
-        // Ensure "node" condition is included for server-side rendering
-        // This helps with package.json imports field resolution
-        if renderer == Graph::Server || renderer == Graph::Ssr {
-            out.options.conditions.append_slice(&[b"node"])?;
-        }
-
-        out.options.production = mode != Mode::Development;
-        out.options.tree_shaking = mode != Mode::Development;
-        out.options.minify_syntax = minify_syntax.unwrap_or(mode != Mode::Development);
-        out.options.minify_identifiers = minify_identifiers.unwrap_or(mode != Mode::Development);
-        out.options.minify_whitespace = minify_whitespace.unwrap_or(mode != Mode::Development);
-        out.options.css_chunking = true;
-        // The bundler crate (lower tier) carries a TYPE_ONLY projection (`bake_types::Framework`).
-        out.options.framework = Some(std::sync::Arc::new(self.as_bundler_view()));
-        out.options.inline_entrypoint_import_meta_main = true;
-        if let Some(ignore) = bundler_options.ignore_dce_annotations {
-            out.options.ignore_dce_annotations = ignore;
-        }
-
-        out.options.source_map = source_map;
-        if bundler_options.env != bun_schema::api::DotEnvBehavior::_none {
-            out.options.env.behavior = bundler_options.env;
-            out.options.env.prefix = bundler_options.env_prefix.unwrap_or(b"").into();
-        }
-        // The resolver crate carries a FORWARD_DECL subset of
-        // `BundleOptions`, so re-project via the dedicated helper rather than
-        // `Clone`.
-        out.sync_resolver_opts();
-
-        out.configure_linker();
-        out.configure_defines()?;
-
-        out.options.jsx.development = mode == Mode::Development;
-
-        add_import_meta_defines(
-            &mut out.options.define,
-            mode,
-            match renderer {
-                Graph::Client => Side::Client,
-                Graph::Server | Graph::Ssr => Side::Server,
-            },
-        )?;
-
-        if (bundler_options.define.keys.len() + bundler_options.drop.count()) > 0 {
-            debug_assert_eq!(
-                bundler_options.define.keys.len(),
-                bundler_options.define.values.len()
-            );
-            use bun_bundler::DefineDataExt;
-            for (k, v) in bundler_options
-                .define
-                .keys
-                .iter()
-                .zip(bundler_options.define.values.iter())
-            {
-                let parsed =
-                    bun_bundler::defines::DefineData::parse(k, v, false, false, log, arena)?;
-                out.options.define.insert(k, parsed)?;
-            }
-
-            for drop_item in bundler_options.drop.keys() {
-                if !drop_item.is_empty() {
-                    let parsed = bun_bundler::defines::DefineData::parse(
-                        drop_item, b"", true, true, log, arena,
-                    )?;
-                    out.options.define.insert(drop_item, parsed)?;
-                }
-            }
-        }
-
-        if mode != Mode::Development {
-            // Hide information about the source repository, at the cost of debugging quality.
-            out.options.entry_naming = b"_bun/[hash].[ext]".as_slice().into();
-            out.options.chunk_naming = b"_bun/[hash].[ext]".as_slice().into();
-            out.options.asset_naming = b"_bun/[hash].[ext]".as_slice().into();
-        }
-
-        // Re-sync after define/naming mutations so the resolver sees the
-        // final option set.
-        out.sync_resolver_opts();
-        Ok(())
-    }
-}
-
-#[derive(Clone)]
-pub struct FileSystemRouterType {
-    pub root: &'static [u8],
-    pub prefix: &'static [u8],
-    pub entry_server: &'static [u8],
-    pub entry_client: Option<&'static [u8]>,
-    pub ignore_underscores: bool,
-    pub ignore_dirs: &'static [&'static [u8]],
-    pub extensions: &'static [&'static [u8]],
-    pub style: framework_router::Style,
-    pub allow_layouts: bool,
-}
-
-#[derive(Clone, Copy)]
-pub enum BuiltInModule {
-    Import(&'static [u8]),
-    Code(&'static [u8]),
-}
-
-#[derive(Copy, Clone)]
-pub struct ServerComponents {
-    pub separate_ssr_graph: bool,
-    pub server_runtime_import: &'static [u8],
-    // pub client_runtime_import: &'static [u8],
-    pub server_register_client_reference: &'static [u8],
-    pub server_register_server_reference: &'static [u8],
-    pub client_register_server_reference: &'static [u8],
-}
-
-impl Default for ServerComponents {
-    fn default() -> Self {
-        Self {
-            separate_ssr_graph: false,
-            server_runtime_import: b"",
-            server_register_client_reference: b"registerClientReference",
-            server_register_server_reference: b"registerServerReference",
-            client_register_server_reference: b"registerServerReference",
-        }
-    }
-}
-
-#[derive(Copy, Clone)]
-pub struct ReactFastRefresh {
-    pub import_source: &'static [u8],
-}
-
-impl Default for ReactFastRefresh {
-    fn default() -> Self {
-        Self {
-            import_source: b"react-refresh/runtime",
-        }
     }
 }
 
@@ -1313,11 +756,10 @@ fn get_optional_string(
     target: JSValue,
     global: &JSGlobalObject,
     property: &[u8],
-    allocations: &mut StringRefList,
-) -> JsResult<Option<&'static [u8]>> {
+) -> JsResult<Option<Vec<u8>>> {
     Ok(target
         .get_optional_slice(global, property)?
-        .map(|slice| allocations.track(slice)))
+        .map(|slice| slice.slice().to_vec()))
 }
 
 // Note: `HmrRuntime` is defined canonically in the parent `bake/mod.rs`
@@ -1367,13 +809,8 @@ pub(crate) fn get_hmr_runtime(side: Side) -> HmrRuntime {
     })
 }
 
-// Note: `Mode`/`Side`/`Graph` are defined canonically in the parent
-// `bake/mod.rs` (which itself re-exports `Side`/`Graph` from
-// `bun_bundler::bake_types`). Re-export here so `bake_body::Mode` ≡
-// `crate::bake::Mode` and downstream callers (production.rs, build_command.rs,
-// IncrementalGraph.rs) see one nominal type.
-pub(crate) use super::Mode;
-pub(crate) use bun_bundler::bake_types::{Graph, Side};
+use super::Mode;
+use bun_bundler::bake_types::Side;
 
 pub(crate) fn add_import_meta_defines(
     define: &mut bun_bundler::options::Define,

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -10,8 +10,8 @@ use std::borrow::Cow;
 use bun_alloc::Arena;
 use bun_collections::StringArrayHashMap;
 use bun_core::Output;
-use bun_core::{ZStr, strings};
 use bun_core::Utf8Bytes;
+use bun_core::{ZStr, strings};
 use bun_jsc::{JSGlobalObject, JSValue, JsError, JsResult};
 use bun_paths::PathBuffer;
 
@@ -682,9 +682,7 @@ impl Framework {
                             let mut it_2 = exts_js.array_iterator(global)?;
                             let mut dirs = Vec::with_capacity(exts_js.get_length(global)? as usize);
                             while let Some(array_item) = it_2.next()? {
-                                dirs.push(Cow::Owned(
-                                    array_item.to_utf8(global)?.slice().to_vec(),
-                                ));
+                                dirs.push(Cow::Owned(array_item.to_utf8(global)?.slice().to_vec()));
                             }
                             break 'exts dirs;
                         }

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -693,7 +693,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
 
         // Bust the resolution cache of the dir containing this file.
         let dirname = bun_paths::dirname(abs_path).unwrap_or(abs_path);
-        let _ = bv2.transpiler.resolver.bust_dir_cache(dirname);
+        let _ = bv2.bust_dir_cache(dirname);
 
         // Clear the cached entry from the path→source-index maps.
         for map in bv2.graph.build_graphs.values_mut() {

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -27,7 +27,7 @@ pub(crate) use dev_server_body::is_allowed_host_header;
 pub(crate) mod framework_router_body;
 
 #[path = "production.rs"]
-mod production_body;
+pub mod production_body;
 
 // `Bun__add{Bake,DevServer}SourceProvider*` host exports — the Rust side of
 // `BakeSourceProvider.h` / `DevServerSourceProvider.h`. Reached only via the
@@ -90,9 +90,7 @@ pub struct ReactFastRefresh {
     pub(crate) import_source: Cow<'static, [u8]>,
 }
 
-/// `bake.Framework.FileSystemRouterType`. Full body (with `Style` enum and
-/// `from_js`) lives in the gated `bake_body.rs` draft; only the field set
-/// DevServer touches is named here.
+/// `bake.Framework.FileSystemRouterType` (`from_js` lives in `bake_body.rs`).
 // Deliberately not `Clone` — `framework_router::Style` is the
 // body enum (carries `JavascriptDefined(jsc::Strong)`, not `Clone`).
 pub struct FileSystemRouterType {
@@ -111,8 +109,7 @@ pub struct FileSystemRouterType {
 
 /// A "Framework" is simply a set of bundler options that a framework author
 /// would set in order to integrate with the application. Since many fields
-/// have default values which may point to static memory, this structure is
-/// always arena-allocated, usually owned by the arena in `UserOptions`.
+/// default to static strings, they are `Cow<'static, [u8]>`.
 pub struct Framework {
     pub(crate) is_built_in_react: bool,
     /// Owned `Vec` so `resolve()` can take `&mut` and rewrite entries in
@@ -123,13 +120,34 @@ pub struct Framework {
     pub(crate) built_in_modules: bun_collections::StringArrayHashMap<BuiltInModule>,
 }
 
+impl Default for Framework {
+    /// Unopinionated default.
+    fn default() -> Self {
+        Framework {
+            is_built_in_react: false,
+            file_system_router_types: Vec::new(),
+            server_components: None,
+            react_fast_refresh: None,
+            built_in_modules: bun_collections::StringArrayHashMap::new(),
+        }
+    }
+}
+
+impl Default for ReactFastRefresh {
+    fn default() -> Self {
+        ReactFastRefresh {
+            import_source: Cow::Borrowed(b"react-refresh/runtime"),
+        }
+    }
+}
+
 impl Framework {
     /// Project the runtime-side `bake::Framework` into the bundler crate's
     /// TYPE_ONLY view (`bun_bundler::bake_types::Framework`). The bundler is a
     /// lower-tier crate and cannot name `bun_runtime::bake::Framework`; this is
     /// the value `init_transpiler` arena-allocates and hands to
     /// `out.options.framework`.
-    fn as_bundler_view(&self) -> bun_bundler::bake_types::Framework {
+    pub(crate) fn as_bundler_view(&self) -> bun_bundler::bake_types::Framework {
         use bun_bundler::bake_types as bt;
         let mut built_in_modules = bun_collections::StringArrayHashMap::new();
         for (k, v) in self.built_in_modules.iter() {
@@ -172,12 +190,7 @@ impl Framework {
         )
     }
 
-    /// Sets up a per-graph
-    /// `Transpiler` in place. The full body lives in
-    /// `bake_body::Framework::init_transpiler_with_options`; this keystone
-    /// version operates on the keystone `BuildConfigSubset` (which omits
-    /// `conditions`/`env`/`define`/`drop` until the schema types are
-    /// const-constructible — those paths default).
+    /// Sets up a per-graph `Transpiler`.
     /// The transpiler is boxed because its linker holds pointers into it.
     pub(crate) fn init_transpiler<'a>(
         &mut self,
@@ -186,6 +199,41 @@ impl Framework {
         mode: Mode,
         renderer: Graph,
         bundler_options: &BuildConfigSubset,
+    ) -> crate::Result<Box<bun_bundler::Transpiler<'a>>> {
+        self.init_transpiler_with_options(
+            arena,
+            log,
+            mode,
+            renderer,
+            bundler_options,
+            match mode {
+                // Source maps must always be external, as DevServer special cases
+                // the linking and part of the generation of these. It also relies
+                // on source maps always being enabled.
+                Mode::Development => bun_bundler::options::SourceMapOption::External,
+                // TODO: follow user configuration
+                Mode::ProductionDynamic | Mode::ProductionStatic => {
+                    bun_bundler::options::SourceMapOption::None
+                }
+            },
+            None,
+            None,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn init_transpiler_with_options<'a>(
+        &mut self,
+        arena: &'a bun_alloc::Arena,
+        log: &mut bun_ast::Log,
+        mode: Mode,
+        renderer: Graph,
+        bundler_options: &BuildConfigSubset,
+        source_map: bun_bundler::options::SourceMapOption,
+        minify_whitespace: Option<bool>,
+        minify_syntax: Option<bool>,
+        minify_identifiers: Option<bool>,
     ) -> crate::Result<Box<bun_bundler::Transpiler<'a>>> {
         use bun_options_types::schema as bun_schema;
 
@@ -242,12 +290,9 @@ impl Framework {
 
         out.options.production = mode != Mode::Development;
         out.options.tree_shaking = mode != Mode::Development;
-        // The three minify overrides always default to `mode != Development`
-        // here regardless of `BuildConfigSubset`. User-supplied minify flags
-        // are only honored by `init_transpiler_with_options` (bake_body).
-        out.options.minify_syntax = mode != Mode::Development;
-        out.options.minify_identifiers = mode != Mode::Development;
-        out.options.minify_whitespace = mode != Mode::Development;
+        out.options.minify_syntax = minify_syntax.unwrap_or(mode != Mode::Development);
+        out.options.minify_identifiers = minify_identifiers.unwrap_or(mode != Mode::Development);
+        out.options.minify_whitespace = minify_whitespace.unwrap_or(mode != Mode::Development);
         out.options.css_chunking = true;
         // The bundler crate (lower tier) carries a TYPE_ONLY
         // projection (`bake_types::Framework`).
@@ -256,19 +301,10 @@ impl Framework {
         if let Some(ignore) = bundler_options.ignore_dce_annotations {
             out.options.ignore_dce_annotations = ignore;
         }
-        out.options.source_map = match mode {
-            // Source maps must always be external, as DevServer special cases
-            // the linking and part of the generation of these. It also relies
-            // on source maps always being enabled.
-            Mode::Development => bun_bundler::options::SourceMapOption::External,
-            // TODO: follow user configuration
-            Mode::ProductionDynamic | Mode::ProductionStatic => {
-                bun_bundler::options::SourceMapOption::None
-            }
-        };
+        out.options.source_map = source_map;
         if bundler_options.env != bun_schema::api::DotEnvBehavior::_none {
             out.options.env.behavior = bundler_options.env;
-            out.options.env.prefix = bundler_options.env_prefix.unwrap_or(b"").into();
+            out.options.env.prefix = bundler_options.env_prefix.clone().unwrap_or_default();
         }
         // The resolver crate carries a FORWARD_DECL subset of `BundleOptions`, so
         // re-project via the dedicated helper rather than `Clone`.
@@ -452,118 +488,38 @@ pub struct SplitBundlerOptions {
     pub(crate) ssr: BuildConfigSubset,
 }
 
-// ─── bake_body → keystone bridges ────────────────────────────────────────────
-// LAYERING: `UserOptions` (bake_body.rs) carries `&'static [u8]`-backed
-// duplicates of `Framework`/`SplitBundlerOptions`; `DevServer::Options`
-// (DevServer.rs) wants the keystone Cow-backed types defined above. Until the
-// two struct families unify (tracked by the `convert_file_system_router_type`
-// note in ServerConfig.rs), bridge by-value here so `server/mod.rs` can hand
-// `config.bake` straight into `DevServer::init`. All `&'static [u8]` →
-// `Cow::Borrowed` / `Box<[u8]>` projections are by-reference (no copy of the
-// underlying arena bytes).
-impl From<bake_body::FileSystemRouterType> for FileSystemRouterType {
-    fn from(src: bake_body::FileSystemRouterType) -> Self {
-        Self {
-            root: Cow::Borrowed(src.root),
-            prefix: Cow::Borrowed(src.prefix),
-            entry_client: src.entry_client.map(Cow::Borrowed),
-            entry_server: Cow::Borrowed(src.entry_server),
-            ignore_underscores: src.ignore_underscores,
-            ignore_dirs: src.ignore_dirs.iter().map(|s| Cow::Borrowed(*s)).collect(),
-            extensions: src.extensions.iter().map(|s| Cow::Borrowed(*s)).collect(),
-            style: src.style,
-            allow_layouts: src.allow_layouts,
-        }
-    }
-}
-impl From<bake_body::ServerComponents> for ServerComponents {
-    fn from(src: bake_body::ServerComponents) -> Self {
-        Self {
-            separate_ssr_graph: src.separate_ssr_graph,
-            server_runtime_import: Cow::Borrowed(src.server_runtime_import),
-            server_register_client_reference: Cow::Borrowed(src.server_register_client_reference),
-            server_register_server_reference: Cow::Borrowed(src.server_register_server_reference),
-            client_register_server_reference: Cow::Borrowed(src.client_register_server_reference),
-        }
-    }
-}
-impl From<bake_body::ReactFastRefresh> for ReactFastRefresh {
-    fn from(src: bake_body::ReactFastRefresh) -> Self {
-        Self {
-            import_source: Cow::Borrowed(src.import_source),
-        }
-    }
-}
-impl From<bake_body::BuiltInModule> for BuiltInModule {
-    fn from(src: bake_body::BuiltInModule) -> Self {
-        match src {
-            bake_body::BuiltInModule::Import(p) => BuiltInModule::Import(p.into()),
-            bake_body::BuiltInModule::Code(c) => BuiltInModule::Code(c.into()),
-        }
-    }
-}
-impl From<bake_body::Framework> for Framework {
-    fn from(src: bake_body::Framework) -> Self {
-        let mut built_in_modules = bun_collections::StringArrayHashMap::new();
-        for (k, v) in src.built_in_modules.iter() {
-            bun_core::handle_oom(built_in_modules.put(*k, BuiltInModule::from(*v)));
-        }
-        Self {
-            is_built_in_react: src.is_built_in_react,
-            file_system_router_types: src
-                .file_system_router_types
-                .into_iter()
-                .map(FileSystemRouterType::from)
-                .collect(),
-            server_components: src.server_components.map(ServerComponents::from),
-            react_fast_refresh: src.react_fast_refresh.map(ReactFastRefresh::from),
-            built_in_modules,
-        }
-    }
-}
-impl From<bake_body::BuildConfigSubset> for BuildConfigSubset {
-    fn from(src: bake_body::BuildConfigSubset) -> Self {
-        // `BuildConfigSubset` mirrors the field-set
-        // `Framework::init_transpiler` reads (everything except `source_map`,
-        // which only `init_transpiler_with_options` honours).
-        Self {
-            ignore_dce_annotations: src.ignore_dce_annotations,
-            conditions: src.conditions,
-            drop: src.drop,
-            env: src.env,
-            env_prefix: src.env_prefix,
-            define: src.define,
-        }
-    }
-}
-impl From<bake_body::SplitBundlerOptions> for SplitBundlerOptions {
-    fn from(src: bake_body::SplitBundlerOptions) -> Self {
-        Self {
-            // `bake_body::Plugin` and keystone `jsc::Plugin` both alias
-            // `crate::api::js_bundler::Plugin` — same nominal type, no cast.
-            plugin: src.plugin,
-            client: src.client.into(),
-            server: src.server.into(),
-            ssr: src.ssr.into(),
-        }
-    }
-}
-
-/// `bake.SplitBundlerOptions.BuildConfigSubset`. Full body (with `from_js`)
-/// lives in `bake_body.rs`; this keystone mirror carries every field that
-/// `Framework::init_transpiler` reads so DevServer's
-/// per-graph transpilers see bunfig `[serve.static]` define/env/conditions.
-#[derive(Default)]
+/// `bake.SplitBundlerOptions.BuildConfigSubset` (`from_js` lives in
+/// `bake_body.rs`).
 pub struct BuildConfigSubset {
     pub(crate) ignore_dce_annotations: Option<bool>,
     pub(crate) conditions: bun_collections::ArrayHashMap<&'static [u8], ()>,
     pub(crate) drop: bun_collections::ArrayHashMap<&'static [u8], ()>,
     pub(crate) env: bun_options_types::schema::api::DotEnvBehavior,
-    pub(crate) env_prefix: Option<&'static [u8]>,
+    pub(crate) env_prefix: Option<Box<[u8]>>,
     pub(crate) define: bun_options_types::schema::api::StringMap,
-    // `source_map` intentionally omitted — only
-    // `init_transpiler_with_options` (bake_body) honours it, and DevServer
-    // never calls that path.
+    /// Honoured by the production build only; the dev server forces external
+    /// source maps (see [`Framework::init_transpiler`]).
+    pub(crate) source_map: bun_options_types::schema::api::SourceMapMode,
+    pub(crate) minify_syntax: Option<bool>,
+    pub(crate) minify_identifiers: Option<bool>,
+    pub(crate) minify_whitespace: Option<bool>,
+}
+
+impl Default for BuildConfigSubset {
+    fn default() -> Self {
+        BuildConfigSubset {
+            ignore_dce_annotations: None,
+            conditions: bun_collections::ArrayHashMap::new(),
+            drop: bun_collections::ArrayHashMap::new(),
+            env: bun_options_types::schema::api::DotEnvBehavior::_none,
+            env_prefix: None,
+            define: bun_options_types::schema::api::StringMap::EMPTY,
+            source_map: bun_options_types::schema::api::SourceMapMode::External,
+            minify_syntax: None,
+            minify_identifiers: None,
+            minify_whitespace: None,
+        }
+    }
 }
 
 /// `bake.HmrRuntime` — embedded HMR runtime code + precomputed line count.
@@ -583,8 +539,6 @@ pub(crate) use bake_body::get_hmr_runtime;
 // the cross-crate hook is gone. This crate's `HmrRuntime` keeps the
 // NUL-terminated `&ZStr` form for JSC handoff; the bundler-side one is plain
 // `&[u8]`.)
-
-pub use bake_body::StringRefList;
 
 // ══════════════════════════════════════════════════════════════════════════
 // FrameworkRouter

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -1,17 +1,13 @@
 //! Implements building a Bake application to production
 
 use bun_paths::strings;
-use core::cell::UnsafeCell;
-use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 use std::io::Write as _;
-use std::sync::OnceLock;
 
 use bstr::BStr;
 
 use super::PatternBuffer;
 use crate::bake;
-use crate::bake::bake_body;
 use crate::bake::framework_router::{self, FrameworkRouter, OpaqueFileId};
 use bun_alloc::Arena;
 use bun_bundler::BundleV2;
@@ -60,16 +56,6 @@ fn side_name(s: bun_bundler::options::Side) -> &'static str {
     }
 }
 
-/// Process-lifetime backing storage for the dotenv singleton; `OnceLock` owns
-/// the allocation.
-struct DotenvSingleton {
-    loader: UnsafeCell<dotenv::Loader>,
-}
-// SAFETY: `build_command` runs single-threaded during CLI init; the singleton
-// is set exactly once before any reader exists.
-unsafe impl Sync for DotenvSingleton {}
-static DOTENV_SINGLETON: OnceLock<DotenvSingleton> = OnceLock::new();
-
 pub fn build_command(ctx: Context) -> crate::Result<()> {
     bake::print_warning();
 
@@ -102,27 +88,20 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
 
     let mut arena = Arena::new();
 
-    let vm_ptr = VirtualMachine::init_bake(jsc::virtual_machine::Options {
-        // arena: arena — dropped per §Allocators (global mimalloc)
+    // Installs the per-thread VM that `VirtualMachine::get{,_mut}` return below.
+    VirtualMachine::init_bake(jsc::virtual_machine::Options {
         log: NonNull::new(ctx.log),
         args: ctx.args.clone(),
         smol: ctx.runtime_options.smol,
         ..Default::default()
     })?;
-    // SAFETY: `init_bake` returns a freshly-allocated VM owned by this thread;
-    // unique access for the rest of this function.
-    let vm = unsafe { &mut *vm_ptr };
-    // Note: pass `vm_ptr` by value into the guard so the drop closure does
-    // not borrow the local (`defer!` would capture `&vm_ptr`, which under
-    // edition-2024 disjoint-capture rules collides with the `&mut *vm_ptr`
-    // re-borrows on the JSError path).
-    let _vm_guard = scopeguard::guard(vm_ptr, |p| {
-        // SAFETY: p is the unique live VM on this thread; its loop is alive, so
-        // queued work is released here rather than by a thread teardown.
-        unsafe {
-            (*p).release_queued_work();
-            (*p).destroy()
-        };
+    let vm = VirtualMachine::get_mut();
+    let _vm_guard = scopeguard::guard((), |()| {
+        // The loop is alive, so queued work is released here rather than by a
+        // thread teardown.
+        let vm = VirtualMachine::get_mut();
+        vm.release_queued_work();
+        vm.destroy();
     });
 
     // A special global object is used to allow registering virtual modules
@@ -196,33 +175,19 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     vm.is_main_thread = true;
     jsc::virtual_machine::IS_MAIN_THREAD_VM.set(true);
 
-    // SAFETY: vm.jsc_vm is the live JSC::VM* set in `VirtualMachine::init_bake`;
-    // raw-ptr deref yields an unbounded `&VM` so the `ApiLock<'_>` does not
-    // borrow `vm` (the VirtualMachine) and the body below can keep using it.
-    //
     // Declaration order matters: `_api_lock` is bound before `pt` so LIFO drop
     // detaches `pt` (a JSC FFI call) *while the API lock is still held*, then
-    // releases the lock.
-    let _api_lock = unsafe { (*vm.jsc_vm).get_api_lock() };
-
-    // Note: `PerThread` owns its data. Start with an empty placeholder so Drop
-    // (which detaches the C++-side per-thread pointer) runs in this frame's
-    // LIFO order — under the API lock, before the VM is destroyed.
-    let mut pt = PerThread::placeholder(vm_ptr);
+    // releases the lock — before the VM is destroyed.
+    let _api_lock = VirtualMachine::get().jsc_vm().get_api_lock();
+    let mut pt: Option<AttachedPerThread> = None;
 
     match build_with_vm(ctx, &cwd, &mut pt) {
         Ok(()) => {}
         Err(crate::Error::JSError) => {
-            // SAFETY: vm.global is live for VM lifetime.
-            let global = unsafe { &*(*vm_ptr).global };
+            let vm = VirtualMachine::get_mut();
+            let global = vm.global();
             let err_value = global.take_exception(jsc::JsError::Thrown);
-            // SAFETY: see above.
-            unsafe {
-                (*vm_ptr)
-                    .print_error_like_object_to_console(err_value.to_error().unwrap_or(err_value))
-            };
-            // SAFETY: see above.
-            let vm = unsafe { &mut *vm_ptr };
+            vm.print_error_like_object_to_console(err_value.to_error().unwrap_or(err_value));
             if vm.exit_handler.exit_code == 0 {
                 vm.exit_handler.exit_code = 1;
             }
@@ -274,12 +239,12 @@ fn write_sourcemap_to_disk(
     Ok(())
 }
 
-fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<()> {
-    // `pt.vm` is the live per-thread VM's BackRef set in `build_command`;
-    // `as_ptr()` is `Copy` and does not borrow `pt`.
-    let vm_ptr: *mut VirtualMachine = pt.vm.as_ptr();
-    // SAFETY: exclusive access on this thread for the duration of the call.
-    let vm = unsafe { &mut *vm_ptr };
+fn build_with_vm(
+    ctx: Context,
+    cwd: &[u8],
+    pt_slot: &mut Option<AttachedPerThread>,
+) -> crate::Result<()> {
+    let vm = VirtualMachine::get_mut();
     // Load and evaluate the configuration module. `global()` returns
     // `&'static`, decoupled from `vm` so later `&mut vm` reborrows are allowed.
     let global = vm.global();
@@ -391,7 +356,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                 ))));
             };
 
-            bake_body::UserOptions::from_js(app, global).map_err(js_err)?
+            bake::UserOptions::from_js(app, global).map_err(js_err)?
         }
         Unwrapped::Rejected(err) => {
             return Err(js_err(global.throw_value(err.to_error().unwrap_or(err))));
@@ -407,77 +372,57 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         .unwrap_or(false);
 
     // this is probably wrong
-    // Note: process-lifetime dotenv singleton owned via `OnceLock`
-    // (PORTING.md §Forbidden: no leaking).
-    let backing = DOTENV_SINGLETON.get_or_init(|| DotenvSingleton {
-        loader: UnsafeCell::new(dotenv::Loader::init()),
-    });
-    // SAFETY: single-threaded CLI init; `get_or_init` guarantees one-time
-    // setup and `backing` is never moved (static storage).
-    let loader = unsafe { &mut *backing.loader.get() };
+    let mut loader = Box::new(dotenv::Loader::init());
     loader.map.put(b"NODE_ENV", b"production")?;
-    dotenv::set_instance(std::ptr::from_mut::<dotenv::Loader>(loader));
+    // Process-lifetime singleton: the global `INSTANCE` becomes its owner.
+    dotenv::set_instance(bun_core::heap::into_raw(loader));
 
-    // In-place init via `MaybeUninit` (`init_transpiler_with_options`
-    // keeps the out-param shape shared with the dev-server path).
-    let mut client_transpiler = MaybeUninit::<Transpiler>::uninit();
-    let mut server_transpiler = MaybeUninit::<Transpiler>::uninit();
-    let mut ssr_transpiler = MaybeUninit::<Transpiler>::uninit();
     // `vm.log` is set from `ctx.log` (non-null, process-lifetime);
     // `log_mut()` is the safe accessor encapsulating the NonNull deref.
     let vm_log = vm.log_mut().unwrap();
-    framework.init_transpiler_with_options(
+    let mut server_transpiler = framework.init_transpiler_with_options(
         &options.arena,
         vm_log,
-        bake_body::Mode::ProductionStatic,
-        bake_body::Graph::Server,
-        &mut server_transpiler,
+        bake::Mode::ProductionStatic,
+        bake::Graph::Server,
         &options.bundler_options.server,
         SourceMapOption::from_api(Some(options.bundler_options.server.source_map)),
         options.bundler_options.server.minify_whitespace,
         options.bundler_options.server.minify_syntax,
         options.bundler_options.server.minify_identifiers,
     )?;
-    framework.init_transpiler_with_options(
+    let mut client_transpiler = framework.init_transpiler_with_options(
         &options.arena,
         vm_log,
-        bake_body::Mode::ProductionStatic,
-        bake_body::Graph::Client,
-        &mut client_transpiler,
+        bake::Mode::ProductionStatic,
+        bake::Graph::Client,
         &options.bundler_options.client,
         SourceMapOption::from_api(Some(options.bundler_options.client.source_map)),
         options.bundler_options.client.minify_whitespace,
         options.bundler_options.client.minify_syntax,
         options.bundler_options.client.minify_identifiers,
     )?;
-    if separate_ssr_graph {
-        framework.init_transpiler_with_options(
+    let mut ssr_transpiler = if separate_ssr_graph {
+        Some(framework.init_transpiler_with_options(
             &options.arena,
             vm_log,
-            bake_body::Mode::ProductionStatic,
-            bake_body::Graph::Ssr,
-            &mut ssr_transpiler,
+            bake::Mode::ProductionStatic,
+            bake::Graph::Ssr,
             &options.bundler_options.ssr,
             SourceMapOption::from_api(Some(options.bundler_options.ssr.source_map)),
             options.bundler_options.ssr.minify_whitespace,
             options.bundler_options.ssr.minify_syntax,
             options.bundler_options.ssr.minify_identifiers,
-        )?;
-    }
-    // SAFETY: written above by init_transpiler_with_options.
-    let server_transpiler = unsafe { server_transpiler.assume_init_mut() };
-    // SAFETY: written above by init_transpiler_with_options.
-    let client_transpiler = unsafe { client_transpiler.assume_init_mut() };
-    // `ssr_transpiler` stays `MaybeUninit` and is only `assume_init_mut()`'d
-    // inside `if separate_ssr_graph` blocks below — Rust forbids forming
-    // `&mut T` to uninitialized memory regardless of later use.
+        )?)
+    } else {
+        None
+    };
 
     if ctx.bundler_options.bake_debug_disable_minify {
         let mut targets: Vec<&mut Transpiler> =
             vec![&mut *client_transpiler, &mut *server_transpiler];
-        if separate_ssr_graph {
-            // SAFETY: written above by init_transpiler_with_options when separate_ssr_graph.
-            targets.push(unsafe { ssr_transpiler.assume_init_mut() });
+        if let Some(ssr) = &mut ssr_transpiler {
+            targets.push(ssr);
         }
         for transpiler in targets {
             transpiler.options.minify_syntax = false;
@@ -498,27 +443,24 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     // these share pointers right now, so setting NODE_ENV == production on one should affect all
     debug_assert!(core::ptr::eq(server_transpiler.env, client_transpiler.env));
 
-    *framework = match framework.resolve(
-        &mut server_transpiler.resolver,
-        &mut client_transpiler.resolver,
-        &options.arena,
-    ) {
-        Ok(f) => f,
-        Err(_) => {
-            if framework.is_built_in_react {
-                // SAFETY: `server_transpiler.log` is the process-lifetime ctx.log.
-                bake_body::Framework::add_react_install_command_note(unsafe {
-                    &mut *server_transpiler.log
-                })?;
-            }
-            bun_core::err_generic!("Failed to resolve all imports required by the framework");
-            Output::flush();
-            let _ = server_transpiler
-                .log()
-                .print(std::ptr::from_mut(Output::error_writer()));
-            Global::crash();
+    if framework
+        .resolve(
+            &mut server_transpiler.resolver,
+            &mut client_transpiler.resolver,
+            &options.arena,
+        )
+        .is_err()
+    {
+        if framework.is_built_in_react {
+            bake::Framework::add_react_install_command_note(server_transpiler.log_mut());
         }
-    };
+        bun_core::err_generic!("Failed to resolve all imports required by the framework");
+        Output::flush();
+        let _ = server_transpiler
+            .log()
+            .print(std::ptr::from_mut(Output::error_writer()));
+        Global::crash();
+    }
 
     bun_core::pretty_errorln!("Bundling routes");
     Output::flush();
@@ -544,7 +486,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     };
 
     for fsr in &framework.file_system_router_types {
-        let joined_root = resolve_path::join_abs::<platform::Auto>(cwd, fsr.root);
+        let joined_root = resolve_path::join_abs::<platform::Auto>(cwd, &fsr.root);
         let Some(entry) = server_transpiler
             .resolver
             .read_dir_info_ignore_error(joined_root)
@@ -552,8 +494,8 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
             continue;
         };
         let server_file =
-            entry_points.get_or_put_entry_point(fsr.entry_server, bake::Side::Server)?;
-        let client_file = if let Some(client) = fsr.entry_client {
+            entry_points.get_or_put_entry_point(&fsr.entry_server, bake::Side::Server)?;
+        let client_file = if let Some(client) = &fsr.entry_client {
             Some(entry_points.get_or_put_entry_point(client, bake::Side::Client)?)
         } else {
             None
@@ -566,12 +508,12 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
             ignore_dirs: fsr
                 .ignore_dirs
                 .iter()
-                .map(|s| Box::<[u8]>::from(*s))
+                .map(|s| Box::<[u8]>::from(&**s))
                 .collect(),
             extensions: fsr
                 .extensions
                 .iter()
-                .map(|s| Box::<[u8]>::from(*s))
+                .map(|s| Box::<[u8]>::from(&**s))
                 .collect(),
             // `Style` is `Clone` (the `JavascriptDefined` arm panics inside
             // `clone()`).
@@ -589,28 +531,16 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         framework_router::InsertionContext::wrap(&mut entry_points),
     )?;
 
-    // `bake_body::Framework` is the runtime-side superset; the bundler reads only
-    // `built_in_modules` / `server_components` / `react_fast_refresh` /
-    // `is_built_in_react` via its lower-tier `bake_types::Framework` view.
-    // Project once here via the shared helper so the field-shape (e.g.
-    // `BuiltInModule` `&'static [u8]` → `Box<[u8]>`) stays in one place.
-    // (The two Framework types could only merge if `FileSystemRouterType` /
-    // `framework_router::Style` moved down to bun_bundler.)
+    // The bundler reads only `built_in_modules` / `server_components` /
+    // `react_fast_refresh` / `is_built_in_react` via its lower-tier
+    // `bake_types::Framework` view.
     let bundler_framework = framework.as_bundler_view();
 
     let bundled_outputs_list: Vec<OutputFile> = {
-        // Transpiler pointers — reborrow via raw to sidestep the
-        // `&'a mut Transpiler<'a>` invariant lifetime on the bundler API.
-        // SAFETY: the three transpilers live in this stack frame and outlive
-        // the bundle call; `BundleV2` does not retain them past return.
-        let server_ptr: *mut Transpiler = &raw mut *server_transpiler;
-        let client_ptr: *mut Transpiler = &raw mut *client_transpiler;
-        let ssr_ptr: *mut Transpiler = if separate_ssr_graph {
-            // SAFETY: written above by init_transpiler_with_options when separate_ssr_graph.
-            core::ptr::from_mut(unsafe { ssr_transpiler.assume_init_mut() })
-        } else {
-            server_ptr
-        };
+        // The three boxed transpilers outlive the bundle call; `BundleV2`
+        // holds them as non-exclusive back-references.
+        let client_ptr = NonNull::from(&mut *client_transpiler);
+        let ssr_ptr = ssr_transpiler.as_deref_mut().map(NonNull::from);
 
         // Construct the `AnyEventLoop` enum
         // value (NOT a pointer-cast: the bundler matches on its discriminant).
@@ -623,12 +553,11 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         // (in the bundler), not a user-facing diagnostic to swallow.
         BundleV2::generate_from_bake_production_cli(
             &entry_points,
-            // SAFETY: see `server_ptr` comment above.
-            unsafe { &mut *server_ptr },
+            bun_ptr::ParentRef::from_ref_mut(&mut *server_transpiler),
             bun_bundler::bundle_v2::BakeOptions {
                 framework: bundler_framework,
-                client_transpiler: NonNull::new(client_ptr).expect("stack-owned transpiler"),
-                ssr_transpiler: NonNull::new(ssr_ptr).expect("stack-owned transpiler"),
+                client_transpiler: client_ptr,
+                ssr_transpiler: ssr_ptr,
                 plugins: options.bundler_options.plugin,
             },
             &options.arena,
@@ -807,15 +736,18 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         }
     }
 
-    *pt = PerThread::init(
-        vm_ptr,
-        entry_points,
-        bundled_outputs_list,
-        module_keys,
-        output_module_map,
-        source_maps,
-    )?;
-    pt.attach();
+    debug_assert!(pt_slot.is_none());
+    let pt: &mut PerThread = pt_slot.insert(
+        Box::new(PerThread::init(
+            vm,
+            entry_points,
+            bundled_outputs_list,
+            module_keys,
+            output_module_map,
+            source_maps,
+        )?)
+        .attach(),
+    );
 
     // Static site generator
     let server_render_funcs =
@@ -990,8 +922,8 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         let mut next: Option<framework_router::RouteIndex> = Some(route_index);
         while let Some(current_index) = next {
             let current = router.route_ptr(current_index);
-            pattern.prepend_part(current.part);
-            match current.part {
+            pattern.prepend_part(current.part.get());
+            match current.part.get() {
                 framework_router::Part::Param(name) | framework_router::Part::CatchAll(name) => {
                     params_buf.push(name);
                 }
@@ -1158,28 +1090,24 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
             .map_err(js_err)?;
     }
 
-    // SAFETY: C++ never returns null (allocates a `JSPromise` on the GC heap);
-    // `JSPromise` is an opaque `UnsafeCell`-backed handle so `&mut *` is sound.
-    let render_promise = unsafe {
-        &mut *BakeRenderRoutesForProdStatic(
-            global,
-            &BunString::from_bytes(&root_dir_path),
-            pt.all_server_files.as_ref().unwrap().get(),
-            server_render_funcs,
-            server_param_funcs,
-            client_entry_urls,
-            route_patterns,
-            route_nested_files,
-            route_type_and_flags,
-            route_source_files,
-            route_param_info,
-            route_style_references,
-        )
-    };
+    // C++ never returns null (allocates a `JSPromise` on the GC heap).
+    let render_promise = JSPromise::opaque_mut(BakeRenderRoutesForProdStatic(
+        global,
+        &BunString::from_bytes(&root_dir_path),
+        pt.all_server_files.as_ref().unwrap().get(),
+        server_render_funcs,
+        server_param_funcs,
+        client_entry_urls,
+        route_patterns,
+        route_nested_files,
+        route_type_and_flags,
+        route_source_files,
+        route_param_info,
+        route_style_references,
+    ));
     render_promise.set_handled();
-    // Rebind from the raw pointer: `PerThread::init`/`attach`/`load_bundled_module`
-    // above accessed the same allocation through `vm_ptr`, invalidating the
-    // earlier `&mut` under Stacked Borrows.
+    // Rebind: `load_bundled_module` above went through the VM singleton,
+    // invalidating the earlier `&mut` under Stacked Borrows.
     let vm = VirtualMachine::get().as_mut();
     vm.wait_for_promise(AnyPromise::Normal(render_promise))
         .map_err(|stopped| js_err(stopped.throw(vm.global())))?;
@@ -1198,13 +1126,9 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     Ok(())
 }
 
-/// unsafe function, must be run outside of the event loop
-/// quits the process on exception
-fn load_module(
-    vm: *mut VirtualMachine,
-    global: &JSGlobalObject,
-    key: JSValue,
-) -> crate::Result<JSValue> {
+/// Must be run outside of the event loop.
+/// Quits the process on exception.
+fn load_module(global: &JSGlobalObject, key: JSValue) -> crate::Result<JSValue> {
     let promise_value = BakeLoadModuleByKey(global, key);
     let promise: *mut jsc::JSInternalPromise = match promise_value.as_any_promise().unwrap() {
         AnyPromise::Internal(p) => p,
@@ -1213,11 +1137,6 @@ fn load_module(
     // S012: `JSInternalPromise` (= `JSPromise`) is an `opaque_ffi!` ZST —
     // safe `*mut → &mut` deref via the const-asserted accessor.
     jsc::JSInternalPromise::opaque_mut(promise).set_handled();
-    // Note: we take `*mut VirtualMachine` (not `&VirtualMachine`) so the provenance
-    // permits mutation — casting a `&T` to `*mut T` and writing through it is
-    // UB. The raw pointer flows from `VirtualMachine::init_bake` unchanged.
-    //
-    let _ = vm;
     let vm_ref = VirtualMachine::get();
     vm_ref
         .as_mut()
@@ -1251,19 +1170,18 @@ fn bake_get_on_module_namespace(
     property: &[u8],
 ) -> Option<JSValue> {
     unsafe extern "C" {
-        // PRECONDITION: `ptr` must be readable for `len` bytes (C++ builds an
-        // `Identifier` from the slice). Cannot be `safe fn` — raw ptr+len pair
-        // carries a caller-side validity precondition.
-        #[link_name = "BakeGetOnModuleNamespace"]
-        fn f(global: *const JSGlobalObject, module: JSValue, ptr: *const u8, len: usize)
-        -> JSValue;
+        safe fn BakeGetOnModuleNamespace(
+            global: &JSGlobalObject,
+            module: JSValue,
+            key: bun_core::ffi::FfiSlice<'_, u8>,
+        ) -> JSValue;
     }
-    // SAFETY: `global` is a live `&JSGlobalObject`, `module` is a stack-held
-    // `JSValue`, and `property.as_ptr()`/`len()` describe a valid borrowed
-    // `&[u8]` for the call duration — discharges the ptr+len precondition above.
-    let result: JSValue = unsafe { f(global, module, property.as_ptr(), property.len()) };
-    debug_assert!(!result.is_empty());
-    Some(result)
+    let result = BakeGetOnModuleNamespace(global, module, property.into());
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
 }
 
 // Renders all routes for static site generation by calling the JavaScript implementation.
@@ -1298,8 +1216,8 @@ unsafe extern "C" {
     ) -> *mut JSPromise;
 }
 
-#[unsafe(no_mangle)]
-extern "C" fn BakeToWindowsPath(input: &BunString) -> BunString {
+// HOST_EXPORT(BakeToWindowsPath, c)
+pub fn bake_to_windows_path(input: &BunString) -> BunString {
     #[cfg(unix)]
     {
         let _ = input;
@@ -1315,8 +1233,8 @@ extern "C" fn BakeToWindowsPath(input: &BunString) -> BunString {
     }
 }
 
-#[unsafe(no_mangle)]
-extern "C" fn BakeProdResolve(
+// HOST_EXPORT(BakeProdResolve, c)
+pub fn bake_prod_resolve(
     global: &JSGlobalObject,
     a_str: &BunString,
     specifier_str: &BunString,
@@ -1415,9 +1333,6 @@ impl framework_router::InsertionHandler for EntryPointMap {
 
 /// Data used on each rendering thread. Contains all information in the bundle needed to render.
 /// This is referred to as `pt` in variable/field naming, and Bake::ProductionPerThread in C++
-///
-/// Owns the backing storage so the value can outlive `build_with_vm` in the
-/// caller's frame without dangling references.
 pub struct PerThread {
     // Shared Data (owned)
     /// Owns `input_files` (keys) and `output_indexes` (values).
@@ -1430,34 +1345,49 @@ pub struct PerThread {
     pub(crate) source_maps: StringArrayHashMap<OutputFileIndex>,
 
     // Thread-local
-    pub(crate) vm: bun_ptr::BackRef<VirtualMachine, bun_ptr::Mut>,
+    pub(crate) vm: bun_ptr::BackRef<VirtualMachine>,
     /// Indexed by entry point index (OpaqueFileId)
     pub(crate) loaded_files: AutoBitSet,
     /// JSArray of JSString, indexed by entry point index (OpaqueFileId)
-    // Strong is required for JSValue struct fields. `None` is the pre-init
-    // state; `PerThread::init` fills it. Strong's Drop releases the GC root.
+    // Strong is required for JSValue struct fields. Strong's Drop releases the
+    // GC root.
     pub(crate) all_server_files: Option<bun_jsc::Strong>,
-    /// `attach()` was called and Drop should detach. The placeholder created in
-    /// `build_command` before `init` must not call into C++ on drop.
-    attached: bool,
 }
 
-// C++ treats `PerThread` as an opaque pointer (Bake::ProductionPerThread*); the Rust
-// layout is irrelevant across the FFI boundary, so silence the improper_ctypes lint.
-// C++ stores `pt` opaquely on the global (never dereferenced C++-side; null
-// detaches), so the call has no precondition beyond a live `&JSGlobalObject`
-// — declare `safe fn`.
+// C++ stores `pt` opaquely on the global and hands it back to `BakeProdLoad`
+// while attached; null detaches.
 #[allow(improper_ctypes)]
 unsafe extern "C" {
-    safe fn BakeGlobalObject__attachPerThreadData(global: &JSGlobalObject, pt: *mut PerThread);
+    safe fn BakeGlobalObject__attachPerThreadData(global: &JSGlobalObject, pt: *const PerThread);
+}
+
+/// A heap-allocated [`PerThread`] whose address is registered with the C++
+/// global (see `BakeProdLoad`); dropping it detaches before the allocation is
+/// freed.
+pub struct AttachedPerThread(Box<PerThread>);
+
+impl core::ops::Deref for AttachedPerThread {
+    type Target = PerThread;
+    fn deref(&self) -> &PerThread {
+        &self.0
+    }
+}
+
+impl core::ops::DerefMut for AttachedPerThread {
+    fn deref_mut(&mut self) -> &mut PerThread {
+        &mut self.0
+    }
+}
+
+impl Drop for AttachedPerThread {
+    fn drop(&mut self) {
+        BakeGlobalObject__attachPerThreadData(self.0.global(), core::ptr::null());
+    }
 }
 
 impl PerThread {
-    /// Safe `&VirtualMachine` accessor for the JSC_BORROW `vm` back-pointer.
     #[inline]
     pub(crate) fn vm(&self) -> &VirtualMachine {
-        // BackRef invariant: VM outlives `PerThread` (set in `init`/`placeholder`
-        // from `init_bake`).
         self.vm.get()
     }
 
@@ -1467,26 +1397,10 @@ impl PerThread {
         self.vm().global()
     }
 
-    /// Empty placeholder used in `build_command` before `build_with_vm` fills it.
-    fn placeholder(vm: *mut VirtualMachine) -> PerThread {
-        PerThread {
-            entry_points: EntryPointMap::default(),
-            bundled_outputs: Vec::new(),
-            module_keys: Vec::new(),
-            module_map: StringArrayHashMap::default(),
-            source_maps: StringArrayHashMap::default(),
-            // SAFETY: `vm` is the live per-thread VM from `init_bake` (non-null,
-            // write provenance); outlives `PerThread`.
-            vm: unsafe { bun_ptr::BackRef::from_raw_mut(vm) },
-            loaded_files: AutoBitSet::init_empty(0).expect("unreachable"),
-            all_server_files: None,
-            attached: false,
-        }
-    }
-
-    /// After initializing, call `attach`
+    /// After initializing, call `attach`. `vm` is the per-thread VM, which
+    /// outlives `PerThread`.
     pub(crate) fn init(
-        vm: *mut VirtualMachine,
+        vm: &VirtualMachine,
         entry_points: EntryPointMap,
         bundled_outputs: Vec<OutputFile>,
         module_keys: Vec<BunString>,
@@ -1495,11 +1409,8 @@ impl PerThread {
     ) -> crate::Result<PerThread> {
         let n = entry_points.files.count();
         let loaded_files = AutoBitSet::init_empty(n)?;
-        // errdefer loaded_files.deinit() — handled by Drop on error path
 
-        // SAFETY: BackRef invariant — vm is the live per-thread VM from `init_bake`
-        // (non-null, write provenance); outlives PerThread.
-        let vm = unsafe { bun_ptr::BackRef::from_raw_mut(vm) };
+        let vm = bun_ptr::BackRef::new(vm);
         let global = vm.global();
         let all_server_files = Some(bun_jsc::Strong::create(
             JSValue::create_empty_array(global, n).map_err(js_err)?,
@@ -1515,18 +1426,12 @@ impl PerThread {
             vm,
             loaded_files,
             all_server_files,
-            attached: false,
         })
     }
 
-    pub(crate) fn attach(&mut self) {
-        // `self.global()` derefs the JSC_BORROW `vm` back-pointer (live for the
-        // VM lifetime); C++ stores `pt` opaquely and hands it back via
-        // `BakeProdResolve`, so passing `from_mut(self)` is just identity —
-        // detached in Drop.
-        let global = self.global();
-        BakeGlobalObject__attachPerThreadData(global, std::ptr::from_mut::<PerThread>(self));
-        self.attached = true;
+    pub(crate) fn attach(self: Box<Self>) -> AttachedPerThread {
+        BakeGlobalObject__attachPerThreadData(self.global(), &raw const *self);
+        AttachedPerThread(self)
     }
 
     pub(crate) fn output_index(&self, id: OpaqueFileId) -> OutputFileIndex {
@@ -1545,7 +1450,6 @@ impl PerThread {
     pub(crate) fn load_bundled_module(&self, id: OpaqueFileId) -> crate::Result<JSValue> {
         let global = self.global();
         load_module(
-            self.vm.as_ptr(),
             global,
             self.module_keys[id.get() as usize]
                 .to_js(global)
@@ -1577,23 +1481,10 @@ impl PerThread {
     }
 }
 
-impl Drop for PerThread {
-    fn drop(&mut self) {
-        if self.attached {
-            // Passing null detaches the previously-attached pointer; `global()`
-            // goes through the safe `vm()` accessor (VM outlives PerThread).
-            BakeGlobalObject__attachPerThreadData(self.global(), core::ptr::null_mut());
-        }
-        // `all_server_files: Strong` is dropped automatically, releasing the GC root.
-    }
-}
-
-/// Given a key, returns the source code to load.
-#[unsafe(no_mangle)]
-extern "C" fn BakeProdLoad(pt: *mut PerThread, key: &BunString) -> BunString {
-    // SAFETY: `pt` is the non-null pointer previously attached via
-    // BakeGlobalObject__attachPerThreadData; C++ only calls this while attached.
-    let pt = unsafe { &*pt };
+/// Given a key, returns the source code to load. `pt` is the pointer
+/// attached via `PerThread::attach`; C++ only calls this while attached.
+// HOST_EXPORT(BakeProdLoad, c)
+pub fn bake_prod_load(pt: &crate::bake::production_body::PerThread, key: &BunString) -> BunString {
     let utf8 = key.to_utf8();
     log!("BakeProdLoad: {}\n", BStr::new(utf8.slice()));
     if let Some(value) = pt.module_map.get(utf8.slice()) {

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -118,11 +118,10 @@ impl BuildCommand {
         // `exec` never returns until process exit (`exit_or_watch` diverges),
         // so use the shared CLI arena instead of allocating a fresh one.
         let arena: &'static bun_alloc::Arena = crate::cli::cli_arena();
-        // Note: `generate_from_cli` takes `&'a mut Transpiler<'a>`, which
-        // borrows the transpiler for its full lifetime — dropck then rejects a
-        // stack local because the borrow would still be live in its destructor.
-        // Allocate in the process-lifetime arena (same rationale as `arena`;
-        // `exec` diverges so this is never dropped).
+        // The bundle keeps a back-reference to the transpiler (under `--watch`
+        // for the rest of the process), so allocate it in the process-lifetime
+        // arena (same rationale as `arena`; `exec` diverges so this is never
+        // dropped).
         let this_transpiler: &mut transpiler::Transpiler<'static> = arena.alloc(
             transpiler::Transpiler::init(arena, log, ctx.args.clone(), None)?,
         );
@@ -605,10 +604,9 @@ impl BuildCommand {
         let mut minify_duration: u64 = 0;
         let mut input_code_length: u64 = 0;
 
-        // Note: `BundleV2::generate_from_cli` takes `&'a mut Transpiler<'a>`,
-        // which (with `'a = 'static` from the leaked arena) borrows
-        // `this_transpiler` for the rest of its life. Snapshot every options
-        // field read after that point so the borrow checker is satisfied.
+        // `BundleV2::generate_from_cli` keeps a back-reference to
+        // `this_transpiler` (under `--watch` for the rest of the process), so
+        // snapshot the options fields read after that point up front.
         let opt_output_dir: Box<[u8]> = this_transpiler.options.output_dir.clone();
         let opt_minify_identifiers = this_transpiler.options.minify_identifiers;
         let opt_minify_whitespace = this_transpiler.options.minify_whitespace;
@@ -667,7 +665,7 @@ impl BuildCommand {
             let mut event_loop = bun_event_loop::AnyEventLoop::init();
 
             let build_result = match BundleV2::generate_from_cli(
-                this_transpiler,
+                bun_ptr::ParentRef::from_ref_mut(this_transpiler),
                 arena,
                 Some(core::ptr::NonNull::from(&mut event_loop)),
                 ctx.debug.hot_reload == HotReload::Watch,

--- a/src/runtime/cli/test/ChangedFilesFilter.rs
+++ b/src/runtime/cli/test/ChangedFilesFilter.rs
@@ -126,9 +126,8 @@ pub(crate) fn filter<'a>(
     // log, and we want the runtime transpiler left untouched for actually
     // executing tests afterward.
     //
-    // `BundleV2::scan_module_graph_from_cli` takes
-    // `&'a mut Transpiler<'a>` (invariant), so the arena, log, and transpiler
-    // are process-lifetime. Route through the shared CLI arena.
+    // The arena, log, and transpiler are process-lifetime (the bundle keeps
+    // back-references to them). Route through the shared CLI arena.
     let arena: &'static Arena = crate::cli::cli_arena();
     let log: &'static mut bun_ast::Log = arena.alloc(bun_ast::Log::new());
 
@@ -167,7 +166,7 @@ pub(crate) fn filter<'a>(
     let mut event_loop = bun_event_loop::AnyEventLoop::init();
 
     let mut bundle = match BundleV2::scan_module_graph_from_cli(
-        scan_transpiler,
+        bun_ptr::ParentRef::from_ref_mut(scan_transpiler),
         arena,
         Some(core::ptr::NonNull::from(&mut event_loop)),
         &entry_points,
@@ -300,13 +299,12 @@ pub(crate) fn filter<'a>(
     // global heap and the slab-only `MultiArrayList` drop never frees them, so
     // release the graph columns and the bundler-owned worker pool now that
     // everything needed has been copied out above. The scan transpiler itself
-    // is in the CLI arena (the `&'a mut Transpiler<'a>` invariant forces a
-    // `'static` borrow), so its Drop never runs either; free its heap-backed
-    // options through the borrow `bundle` still holds.
+    // is in the CLI arena, so its Drop never runs either; free its heap-backed
+    // options through the back-reference `bundle` still holds.
     bundle.deinit_without_freeing_arena();
-    // SAFETY: `bundle.transpiler` is the arena-backed `&'static mut` noted
-    // above — its `Drop` never runs, so `deinit` cannot lead to a double-drop.
-    unsafe { bundle.transpiler.deinit() };
+    // SAFETY: `bundle.transpiler` is the arena-backed transpiler noted above —
+    // its `Drop` never runs, so `deinit` cannot lead to a double-drop.
+    unsafe { bundle.transpiler_mut().deinit() };
 
     Ok(Result {
         test_files: &mut test_files[0..write],

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -565,46 +565,6 @@ fn get_routes_object(global: &JSGlobalObject, arg: JSValue) -> JsResult<Option<J
     Ok(None)
 }
 
-/// Bridge `crate::bake::FileSystemRouterType` (Cow-backed, populated by
-/// `server_body::AnyRoute::from_js`) into `bake_body::FileSystemRouterType`
-/// (`&'static [u8]`-backed, consumed by `Framework::auto`). The duplication is a
-/// layering wart and this conversion stands in for an arena-dupe until the two
-/// structs unify. All bytes are duped into `arena` so the resulting `&'static`
-/// slices live as long as `UserOptions.arena`.
-fn convert_file_system_router_type(
-    arena: &bun_alloc::Arena,
-    src: crate::bake::FileSystemRouterType,
-) -> crate::bake::bake_body::FileSystemRouterType {
-    use crate::bake::bake_body as bb;
-    // NOTE: `bb::arena_erase` is the single sanctioned `'bump → 'static`
-    // erasure for the `UserOptions.arena` self-referential pattern; bake_body's
-    // own `Framework::from_js` / `resolve` use it identically.
-    // TODO(refactor): thread a real `'bump` through `bb::Framework`/
-    // `bb::FileSystemRouterType` and remove this together with `arena_erase`.
-    fn dupe(arena: &bun_alloc::Arena, bytes: &[u8]) -> &'static [u8] {
-        bb::arena_erase(arena.alloc_slice_copy(bytes))
-    }
-    fn dupe_slice_of(
-        arena: &bun_alloc::Arena,
-        v: &[std::borrow::Cow<'static, [u8]>],
-    ) -> &'static [&'static [u8]] {
-        let inner: Vec<&'static [u8]> = v.iter().map(|c| dupe(arena, c.as_ref())).collect();
-        bb::arena_erase(arena.alloc_slice_copy(&inner))
-    }
-
-    bb::FileSystemRouterType {
-        root: dupe(arena, src.root.as_ref()),
-        prefix: dupe(arena, src.prefix.as_ref()),
-        entry_server: dupe(arena, src.entry_server.as_ref()),
-        entry_client: src.entry_client.as_deref().map(|b| dupe(arena, b)),
-        ignore_underscores: src.ignore_underscores,
-        ignore_dirs: dupe_slice_of(arena, &src.ignore_dirs),
-        extensions: dupe_slice_of(arena, &src.extensions),
-        style: src.style,
-        allow_layouts: src.allow_layouts,
-    }
-}
-
 impl ServerConfig {
     pub fn from_js(
         global: &JSGlobalObject,
@@ -756,7 +716,6 @@ impl ServerConfig {
                 // `UserOptions`).
                 dedupe_html_bundle_map: Default::default(),
                 framework_router_list: Vec::new(),
-                js_string_allocations: crate::bake::StringRefList::EMPTY,
                 user_routes: &mut args.static_routes,
                 global,
             };
@@ -937,57 +896,31 @@ impl ServerConfig {
                 || !init_ctx.framework_router_list.is_empty()
             {
                 if args.development.is_hmr_enabled() {
-                    use crate::bake::bake_body as bb;
                     use bun_options_types::schema::api::DotEnvBehavior;
 
-                    // NOTE: the arena is created here and moved into
-                    // `UserOptions` (lives until `args.bake` is dropped).
-                    let arena = bun_alloc::Arena::new();
-
-                    let root = bb::arena_dupe_z(
-                        &arena,
-                        bun_paths::fs::FileSystem::instance().top_level_dir(),
-                    );
-
-                    // Convert `crate::bake::FileSystemRouterType` (Cow-backed)
-                    // into `bake_body::FileSystemRouterType` (`&'static` slices)
-                    // by duping every string into the arena. Type
-                    // duplication; remove once the two structs unify.
-                    let router_types: Vec<bb::FileSystemRouterType> =
-                        core::mem::take(&mut init_ctx.framework_router_list)
-                            .into_iter()
-                            .map(|t| convert_file_system_router_type(&arena, t))
-                            .collect();
-
-                    // SAFETY: `bun_vm()` returns the live VM for this global;
-                    // we need `&mut Resolver` for `Framework::auto`.
+                    let root: Box<[u8]> =
+                        Box::from(bun_paths::fs::FileSystem::instance().top_level_dir());
+                    let router_types = core::mem::take(&mut init_ctx.framework_router_list);
                     let resolver = &mut global.bun_vm().as_mut().transpiler.resolver;
-                    let framework = bb::Framework::auto(&arena, resolver, router_types)
+                    let framework = crate::bake::Framework::auto(resolver, router_types)
                         .map_err(|e| global.throw_error(e, "Framework::auto"))?;
 
                     let mut user_options = crate::bake::UserOptions {
-                        arena,
-                        allocations: core::mem::replace(
-                            &mut init_ctx.js_string_allocations,
-                            crate::bake::StringRefList::EMPTY,
-                        ),
+                        arena: bun_alloc::Arena::new(),
                         root,
                         framework,
-                        bundler_options: bb::SplitBundlerOptions::default(),
+                        bundler_options: crate::bake::SplitBundlerOptions::default(),
                     };
 
                     let o = &vm.transpiler.options.transform_options;
 
                     match o.serve_env_behavior {
                         DotEnvBehavior::prefix => {
-                            // NOTE: `serve_env_prefix` is `Option<Box<[u8]>>`
-                            // owned by the long-lived `transform_options`; dupe
-                            // into the arena so the `&'static [u8]` field is
-                            // backed by `UserOptions.arena`.
-                            user_options.bundler_options.client.env_prefix = o
-                                .serve_env_prefix
-                                .as_deref()
-                                .map(|p| bb::arena_dupe_z(&user_options.arena, p).as_bytes());
+                            user_options
+                                .bundler_options
+                                .client
+                                .env_prefix
+                                .clone_from(&o.serve_env_prefix);
                             user_options.bundler_options.client.env = DotEnvBehavior::prefix;
                         }
                         DotEnvBehavior::load_all => {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2028,15 +2028,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             };
             crate::bake::DevServer::init(crate::bake::DevServer::Options {
                 arena: &bake_options.arena,
-                root: bake_options.root,
+                root: &bake_options.root,
                 vm: jsc::VirtualMachine::get(),
                 server: AnyServer::from(&*server),
-                // LAYERING: `UserOptions` carries the `bake_body` shapes;
-                // `DevServer::Options` consumes the keystone shapes;
-                // `From` impls in `bake/mod.rs` bridge
-                // until the duplicates are collapsed.
-                framework: core::mem::take(&mut bake_options.framework).into(),
-                bundler_options: core::mem::take(&mut bake_options.bundler_options).into(),
+                framework: core::mem::take(&mut bake_options.framework),
+                bundler_options: core::mem::take(&mut bake_options.bundler_options),
                 broadcast_console_log_from_browser_to_server: config
                     .broadcast_console_log_from_browser_to_server_for_bake,
             })

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -815,7 +815,7 @@ impl AnyRoute {
 
         if argument.is_object() {
             if let Some(dir) = argument.get_optional_slice(global, b"dir")? {
-                let relative_root = init_ctx.js_string_allocations.track(dir);
+                let relative_root = dir.slice();
 
                 if !strings::ends_with(path, b"/*") {
                     return Err(global.throw_invalid_arguments(format_args!(
@@ -921,7 +921,6 @@ impl AnyRoute {
 pub struct ServerInitContext<'a> {
     pub(crate) dedupe_html_bundle_map:
         HashMap<*const HTMLBundle, bun_ptr::BackRef<html_bundle::Route, bun_ptr::Root>>,
-    pub(crate) js_string_allocations: bake::StringRefList,
     pub global: &'a JSGlobalObject,
     pub(crate) framework_router_list: Vec<bake::FileSystemRouterType>,
     pub(crate) user_routes: &'a mut Vec<server_config::StaticRouteEntry>,

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -919,3 +919,36 @@ devTest("barrel optimization: namespace re-export cycle through a star-exported 
     await c.expectMessage("result: object Y KEEP DEEP OTHER");
   },
 });
+devTest("fileSystemRouterTypes[n].ignoreDirs skips route files under ignored directories", {
+  framework: {
+    ...minimalFramework,
+    fileSystemRouterTypes: [
+      {
+        ...minimalFramework.fileSystemRouterTypes[0],
+        ignoreDirs: ["ignored"],
+      },
+    ],
+  },
+  files: {
+    "routes/index.ts": `
+      export default function (req, meta) {
+        return new Response('index');
+      }
+    `,
+    "routes/kept/index.ts": `
+      export default function (req, meta) {
+        return new Response('kept');
+      }
+    `,
+    "routes/ignored/index.ts": `
+      export default function (req, meta) {
+        return new Response('should not be routed');
+      }
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("index");
+    await dev.fetch("/kept").equals("kept");
+    await dev.fetch("/ignored").expect404();
+  },
+});


### PR DESCRIPTION
### What

Same programme as #40055 … #40260. **Stacked on #40255** (base branch `claude/devserver-zero-unsafe` → #40214; retarget as those land).

`src/runtime/bake/production.rs` 28 → 4 (all-`safe fn` extern blocks), `FrameworkRouter.rs` 10 → **0**, `bake_body.rs` 3 → 0, and `DevServer.rs`'s last real block (`bundle_borrows`) is gone.

- **`BundleV2` holds its primary transpiler as `ParentRef<Transpiler, Mut>`**, the same non-exclusive back-reference it already used for `client_transpiler`/`ssr_transpiler`, with `transpiler()`/`transpiler_mut()` accessors; `init`/`generate_from_cli`/`scan_module_graph_from_cli`/`generate_from_bake_production_cli` take the `ParentRef` (callers write `ParentRef::from_ref_mut(..)`). `init_with_owned_heap(.., Box<Arena>, ..)` stores the arena in a private `OwnedHeap` declared as the last field, so the bundle's arena is freed after every field that points into it by construction — this is what lets the dev server build a bundle without lifetime laundering. `bundle_v2.rs` 124 → 127 (the accessors), not a target here.
- **production.rs**: `PerThread`/`AttachedPerThread` typed; `Bake__*` SSG callbacks are `HOST_EXPORT`s; `BakeGetOnModuleNamespace` takes `EncodedJSValue` + a by-value `{ptr,len}` and `dynamicDowncast`s.
- **FrameworkRouter.rs**: `InsertionContext` is a trait object; `bun_resolver::fs::DirEntry::iter()` (safe, asserts the entries mutex in debug) and `Entry::kind_with(&self, fs, fd)` replace the raw-pointer walks; `EntryKindResolver::resolve_kind`/`RealFS::kind` take `&self`.
- **bake_body.rs**: the duplicated option structs (`Framework`, `FileSystemRouterType`, `BuildConfigSubset`, `SplitBundlerOptions`, `StringRefList`, `arena_erase`/`arena_dupe_z`, …) are deleted in favour of the `bake::` ones with owned fields (`UserOptions.root: Box<[u8]>`, `env_prefix: Option<Box<[u8]>>`); `ServerInitContext.js_string_allocations` removed.

Residual contract (documented, unchanged from main): the owner keeps using its `Box<Transpiler>` while a `BundleV2` holds a `ParentRef` to it. Pre-existing bug fixed in passing (with a test): `fileSystemRouterTypes[].ignoreDirs` was parsed by iterating the outer `fileSystemRouterTypes` array, so user `ignoreDirs` never matched.

### Testing

Debug+ASAN, `--timeout 60000`, all exit 0: test/bake/{framework-router, deinitialization, dev-and-prod, serve-plugins-dev-server}, test/bake/dev/* (production, ssg-pages-router, bundle, css, esm, hot, html, plugins, react-spa, sourcemap, server-sourcemap, incremental-graph-edge-deletion, vfile, import-meta-inline ±, request-cookies, response-to-bake-response, react-response, harness, ecosystem, stress), bun-serve-html*, test/cli/hot/*, test/bundler/{bundler_edgecase, bundler_html, bundler_html_server, bundler_plugin, bundler_splitting, bun-build-api, esbuild/default}. Hand-driven: `bun build --splitting --minify --sourcemap=linked` and `--target bun` outdirs byte-identical to system bun; `Bun.build` with an onResolve/onLoad plugin; `bun build --app` on the react SSG fixture (dist tree identical to system bun); HTML dev server edit → HMR → rebundled content, clean SIGTERM — no ASAN output. clippy clean on bun_bundler/bun_resolver/bun_jsc/bun_runtime; `rust-check-all` windows-msvc + apple-darwin pass.
