### PR TITLE
ci: raise the core file size limit so a crashed test process dumps core on the Debian and Ubuntu lanes

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -296,47 +296,57 @@ function getCoreFileSizeLimit() {
 }
 
 /**
- * systemd starts the agent with a soft RLIMIT_CORE of 0 and a hard limit of
- * infinity (its default for services). The glibc images inherit that, so a
- * crashed test process writes no core even though kernel.core_pattern points
- * at coresDir. Raise this process's soft limit to the hard limit; every test
- * process inherits it. Returns the limit that is in effect afterwards.
+ * Sets this process's soft RLIMIT_CORE to `soft` ("0", "unlimited", or a byte
+ * count) and leaves the hard limit alone; every test process inherits it.
+ * @param {string} soft
+ * @returns {Promise<boolean>}
+ */
+async function setSoftCoreFileSizeLimit(soft) {
+  const prlimit = await spawnSafe({
+    command: "prlimit",
+    args: ["--pid", `${process.pid}`, `--core=${soft}:`],
+    stdout: () => {},
+    stderr: () => {},
+  });
+  if (!prlimit.ok) {
+    console.warn(`Could not set the core file size limit to ${soft}: ${prlimit.error}`);
+  }
+  return prlimit.ok;
+}
+
+/**
+ * On the Debian and Ubuntu images the agent runs as a systemd service with a
+ * soft RLIMIT_CORE of 0 and a hard limit of infinity: the distro's
+ * /usr/lib/systemd/system.conf.d/10-coredump-debian.conf sets
+ * `DefaultLimitCORE=0:infinity`, and that drop-in overrides the
+ * `DefaultLimitCORE=infinity` bootstrap.sh writes into /etc/systemd/system.conf.
+ * So a crashed test process writes no core even though kernel.core_pattern
+ * points at coresDir. Raise the soft limit to the hard limit here. Returns the
+ * limit that is in effect afterwards.
  *
- * Not for an ASAN build: it prints its own report on a crash, and with
- * abort_on_error=1 it also aborts on a leak report at exit, so a core there
- * would turn a passing test file into "core dumped".
+ * An ASAN build gets a soft limit of 0 instead: it prints its own report on a
+ * crash, and with abort_on_error=1 it also aborts on a leak report at exit, so
+ * a core from it turns a passing test file into "core dumped".
  * @param {string} execPath
  * @returns {Promise<string | undefined>}
  */
 async function raiseCoreFileSizeLimit(execPath) {
-  if (basename(execPath).includes("asan")) {
-    return getCoreFileSizeLimit()?.soft;
-  }
   const before = getCoreFileSizeLimit();
-  if (!before || before.soft === "unlimited") {
-    return before?.soft;
+  if (!before) {
+    return undefined;
   }
-  if (before.hard === "0") {
-    console.warn("The hard core file size limit is 0, so crashed test processes will not dump core");
-    return before.soft;
+  const isAsan = basename(execPath).includes("asan");
+  const wanted = isAsan ? "0" : before.hard;
+  if (before.soft !== wanted) {
+    await setSoftCoreFileSizeLimit(wanted);
   }
-  if (before.soft === before.hard) {
-    return before.soft;
-  }
-  const prlimit = await spawnSafe({
-    command: "prlimit",
-    args: ["--pid", `${process.pid}`, `--core=${before.hard}:`],
-    stdout: () => {},
-    stderr: () => {},
-  });
-  const after = getCoreFileSizeLimit();
-  if (!prlimit.ok || !after || after.soft === before.soft) {
+  const after = getCoreFileSizeLimit()?.soft;
+  if (!isAsan && (after === "0" || after !== wanted)) {
     console.warn(
-      `Could not raise the core file size limit from ${before.soft} (hard limit ${before.hard}): ${prlimit.error}`,
+      `Crashed test processes will not dump core: the core file size limit is ${after} (hard limit ${before.hard})`,
     );
-    return after?.soft ?? before.soft;
   }
-  return after.soft;
+  return after;
 }
 
 if (options["coredump-upload"]) {

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -277,6 +277,60 @@ if (isBuildkite) {
 
 let coresDir;
 
+/**
+ * The soft and hard RLIMIT_CORE of this process, as `ulimit` prints them
+ * ("0", "unlimited", or a byte count).
+ * @returns {{ soft: string, hard: string } | undefined}
+ */
+function getCoreFileSizeLimit() {
+  try {
+    const line = readFileSync("/proc/self/limits", "utf-8")
+      .split("\n")
+      .find(line => line.startsWith("Max core file size"));
+    const [, soft, hard] = /^Max core file size\s+(\S+)\s+(\S+)/.exec(line ?? "") ?? [];
+    if (soft && hard) {
+      return { soft, hard };
+    }
+  } catch {}
+  return undefined;
+}
+
+/**
+ * systemd starts the agent with a soft RLIMIT_CORE of 0 and a hard limit of
+ * infinity (its default for services). The glibc images inherit that, so a
+ * crashed test process writes no core even though kernel.core_pattern points
+ * at coresDir. Raise this process's soft limit to the hard limit; every test
+ * process inherits it. Returns the limit that is in effect afterwards.
+ * @returns {Promise<string | undefined>}
+ */
+async function raiseCoreFileSizeLimit() {
+  const before = getCoreFileSizeLimit();
+  if (!before || before.soft === "unlimited") {
+    return before?.soft;
+  }
+  if (before.hard === "0") {
+    console.warn("The hard core file size limit is 0, so crashed test processes will not dump core");
+    return before.soft;
+  }
+  if (before.soft === before.hard) {
+    return before.soft;
+  }
+  const prlimit = await spawnSafe({
+    command: "prlimit",
+    args: ["--pid", `${process.pid}`, `--core=${before.hard}:`],
+    stdout: () => {},
+    stderr: () => {},
+  });
+  const after = getCoreFileSizeLimit();
+  if (!prlimit.ok || !after || after.soft === before.soft) {
+    console.warn(
+      `Could not raise the core file size limit from ${before.soft} (hard limit ${before.hard}): ${prlimit.error}`,
+    );
+    return after?.soft ?? before.soft;
+  }
+  return after.soft;
+}
+
 if (options["coredump-upload"]) {
   // this sysctl is set in bootstrap.sh to /var/bun-cores-$distro-$release-$arch
   const sysctl = await spawnSafe({ command: "sysctl", args: ["-n", "kernel.core_pattern"] });
@@ -290,6 +344,7 @@ if (options["coredump-upload"]) {
   } else {
     throw new Error(`Failed to check core_pattern: ${sysctl.error}`);
   }
+  console.log(`core file size limit: ${await raiseCoreFileSizeLimit()}`);
 }
 
 let remapPort = undefined;

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -301,9 +301,17 @@ function getCoreFileSizeLimit() {
  * crashed test process writes no core even though kernel.core_pattern points
  * at coresDir. Raise this process's soft limit to the hard limit; every test
  * process inherits it. Returns the limit that is in effect afterwards.
+ *
+ * Not for an ASAN build: it prints its own report on a crash, and with
+ * abort_on_error=1 it also aborts on a leak report at exit, so a core there
+ * would turn a passing test file into "core dumped".
+ * @param {string} execPath
  * @returns {Promise<string | undefined>}
  */
-async function raiseCoreFileSizeLimit() {
+async function raiseCoreFileSizeLimit(execPath) {
+  if (basename(execPath).includes("asan")) {
+    return getCoreFileSizeLimit()?.soft;
+  }
   const before = getCoreFileSizeLimit();
   if (!before || before.soft === "unlimited") {
     return before?.soft;
@@ -344,7 +352,6 @@ if (options["coredump-upload"]) {
   } else {
     throw new Error(`Failed to check core_pattern: ${sysctl.error}`);
   }
-  console.log(`core file size limit: ${await raiseCoreFileSizeLimit()}`);
 }
 
 let remapPort = undefined;
@@ -590,6 +597,10 @@ async function runTests() {
     execPath = getExecPath(options["exec-path"]);
   }
   !isQuiet && console.log("Bun:", execPath);
+
+  if (options["coredump-upload"]) {
+    console.log(`core file size limit: ${await raiseCoreFileSizeLimit(execPath)}`);
+  }
 
   const expectations = getTestExpectations();
   const modifiers = getTestModifiers(execPath);

--- a/test/bundler/native-plugin.test.ts
+++ b/test/bundler/native-plugin.test.ts
@@ -1,6 +1,6 @@
 import { BunFile, Loader } from "bun";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, isMusl, makeTree, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isASAN, makeTree, noCoreDump, tempDirWithFiles } from "harness";
 import path from "path";
 import bundlerPluginHeader from "../../packages/bun-native-bundler-plugin-api/bundler_plugin.h" with { type: "file" };
 import source from "./native_plugin.cc" with { type: "file" };
@@ -408,10 +408,8 @@ const many_foo = ["foo","foo","foo","foo","foo","foo","foo"]
   });
 
   // This test segfaults on purpose. Windows: never worked. ASAN: traps the SEGV
-  // and aborts before the crash handler can print the name. musl: the crash
-  // handler re-raises and the agent writes a core, which the runner counts as a
-  // failed job even though every test passed.
-  it.skipIf(process.platform === "win32" || isASAN || isMusl)("prints name when plugin crashes", async () => {
+  // and aborts before the crash handler can print the name.
+  it.skipIf(process.platform === "win32" || isASAN)("prints name when plugin crashes", async () => {
     const prelude = /* ts */ `import values from "./stuff.ts"
   const many_foo = ["foo","foo","foo","foo","foo","foo","foo"]
       `;
@@ -456,7 +454,10 @@ const many_foo = ["foo","foo","foo","foo","foo","foo","foo"]
     // BUN_CRASH_REPORT_URL="": this segfault is deliberate; uploading it to
     // CI's remap server pins a spurious "crash reported" error on the next
     // unrelated failing test (runner only drains /traces on non-zero exit).
-    const { stdout, stderr } = await Bun.$`${bunExe()} run build.ts`
+    // noCoreDump: the crash handler re-raises the signal, and a core file from
+    // it makes the CI runner count the job as failed even though every test
+    // passed.
+    const { stdout, stderr } = await Bun.$`${noCoreDump([bunExe(), "run", "build.ts"])}`
       .env({ ...bunEnv, BUN_TEST_TEMP_DIR: tempdir, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPORTING: "0" })
       .throws(false);
     const errorString = stderr.toString();

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, noCoreDump, tempDir } from "harness";
 import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import path from "path";
@@ -386,13 +386,6 @@ test("raise ignoring panic handler does not trigger the panic handler", async ()
   expect(sent).toBe(false);
 });
 
-// For children that die via SIG_DFL (rather than via a test hook that calls
-// suppress_core_dumps_if_necessary()): on the --coredump-upload CI lane the
-// runner flags leaked core files as a hard failure. ulimit -c 0 in a shell
-// wrapper is inherited by the bun child (and by anything it spawns); every
-// user is isPosix-gated so /bin/sh is available.
-const noCoreCmd = (argv: string[]) => ["/bin/sh", "-c", `ulimit -c 0 && exec "$@"`, "--", ...argv];
-
 // SIGABRT (libc abort(), mimalloc/glibc heap-corruption, std::terminate) and
 // SIGTRAP (WTF CRASH()/RELEASE_ASSERT, __builtin_trap() -> `brk` on aarch64)
 // must route through the crash handler so they are not silently lost. Outside
@@ -458,7 +451,7 @@ describe.if(isPosix)("SIGABRT/SIGTRAP are caught by the crash handler", () => {
     });
 
     await using proc = Bun.spawn({
-      cmd: noCoreCmd([bunExe(), "-e", "process.abort()"]),
+      cmd: noCoreDump([bunExe(), "-e", "process.abort()"]),
       env: mergeWindowEnvs([
         bunEnv,
         {
@@ -497,7 +490,7 @@ describe.if(isPosix)("process.kill() aimed at the process itself is not reported
   // process-group forms of kill(2) below cannot reach this test runner.
   async function run(code: string, { detached = false } = {}) {
     await using proc = Bun.spawn({
-      cmd: noCoreCmd([bunExe(), "-e", code, "--debug-crash-handler-use-trace-string"]),
+      cmd: noCoreDump([bunExe(), "-e", code, "--debug-crash-handler-use-trace-string"]),
       env: noReportEnv,
       stdio: ["ignore", "pipe", "pipe"],
       detached,

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -130,6 +130,18 @@ export function bunExe() {
   return process.execPath;
 }
 
+/**
+ * Wraps a command so the child (and anything it spawns) runs with a core file
+ * size limit of 0. For children that die via SIG_DFL on purpose, rather than
+ * through a test hook that calls `suppress_core_dumps_if_necessary()`: the CI
+ * runner (`--coredump-upload`) treats a new core file as a failed job even when
+ * every test passed. POSIX only; on Windows the command is returned unchanged.
+ */
+export function noCoreDump(argv: string[]): string[] {
+  if (isWindows) return argv;
+  return ["/bin/sh", "-c", `ulimit -c 0 && exec "$@"`, "--", ...argv];
+}
+
 export function nodeExe(): string | null {
   return which("node") || null;
 }


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-publish.test.ts` went red in build 104370 (`:debian: 13 aarch64`): the test runner died in a GC helper thread, `Segmentation fault at address 0xD0` in `JSC::SlotVisitor::drain` -> `visitChildren`. Build 103701 (`bun-update-transitive.test.ts`) died the same way. Both say `no core file found`.
- The Debian and Ubuntu lanes run the tests with a soft `RLIMIT_CORE` of 0 (`coredump(blocks) 0` in the job's Limits group): Debian's `/usr/lib/systemd/system.conf.d/10-coredump-debian.conf` sets `DefaultLimitCORE=0:infinity`, and that drop-in overrides the `DefaultLimitCORE=infinity` that `bootstrap.sh` writes into `/etc/systemd/system.conf`. Alpine (OpenRC) runs with `unlimited`, so its three hits since 08-14 came with a core.
- The crash visits a cell that an earlier collection freed. Its cause is not known. #39587 tracks the same class on alpine.

### Fix
- With `--coredump-upload`, the runner reads `/proc/self/limits` and runs `prlimit --pid <self> --core=<hard>:` when the soft core limit is below the hard one. The test processes inherit it. For an ASAN build it sets the soft limit to 0 instead: ASAN reports crashes itself, and with `abort_on_error=1` it aborts on a leak report at exit too, so a core from it turned two passing files into "core dumped" in build 104428.
- `test/bundler/native-plugin.test.ts` segfaults a child on purpose. With cores enabled it left one in every glibc build (104440). The `ulimit -c 0` wrapper from `run-crash-handler.test.ts` moves into the harness as `noCoreDump()` and wraps that child, which also lets the test run on musl.
- Correct to have: raising the soft limit up to the hard limit needs no privilege, and the only other deliberate crashes go through `suppress_core_dumps_if_necessary()`.
- Verified: the helper under `prlimit --core=0:unlimited`, `0:4096000`, `0:0`, `unlimited:unlimited` with a release and an `asan` name; both test files pass on the release build. Build 104440 printed `core file size limit: unlimited` on all 80 glibc shards.

### Background
- `scripts/runner.node.mjs` runs each test file in its own process and, with `--coredump-upload`, backtraces new files in the `kernel.core_pattern` directory with gdb. #39587 extends that to every thread.
- The kernel writes a core only if the crashing process's soft `RLIMIT_CORE` allows it. systemd drop-ins override the main `system.conf`, so the Debian one wins.
- A zapped cell is a freed JSC cell whose structure ID the sweep zeroed. 0xD0 is `methodTable.visitChildrenWithSlotVisitor` read through its null `ClassInfo`.

<details><summary>Notes</summary>

How the 0xD0 was derived: `SlotVisitor::visitChildren` dispatches on the cell's type byte and, for anything but strings, final objects and arrays, calls `cell->methodTable()->visitChildren(...)`. With this WebKit pin, `offsetof(Structure, m_classInfo)` is 0x50, `offsetof(ClassInfo, methodTable)` is 0x30, and `visitChildrenWithSlotVisitor` is entry 20 of `MethodTable`, so its address inside a null `ClassInfo` is 0x30 + 20 * 8 = 0xD0. A zapped cell has structure ID 0, which decodes to the start of the structure heap. On Linux that reservation is a readable `MAP_NORESERVE` mapping, so `m_classInfo` reads as 0 and the fault lands at 0xD0 on every platform. Sentry shows the same address for this frame on Linux x64, macOS x64 and macOS arm64 (BUN-2Y5H, 1.3.13 and 1.3.14), so the signature is not new to this cycle.

What was scanned: annotations of every failed, canceled and passed build from 2026-08-13 to 2026-08-23 (about 11,000 builds). GC marking crashes: 96675 (08-14, alpine x64, `test-http-proxy-request.mjs`, 0xD0), 97509 (08-15, alpine x64, `bun-patch.test.ts` verdaccio, dead `JSArray`), 100350 (08-18, alpine x64, `bun-audit.test.ts` verdaccio, dead `JSArray`), 103701 (08-22, debian 13 aarch64, `bun-update-transitive.test.ts` runner, 0xD0), 104370 (08-23, debian 13 aarch64, `bun-publish.test.ts` runner, 0xD0). None on a glibc x64 lane, none on darwin. Every process that crashed ran an HTTP server whose clients were other processes (`node:http` in verdaccio and the node test, `Bun.serve` in the test runners).

Local attempts to reproduce on linux x64 glibc with the 4448a2e21 and acd342244 release builds: 60 runs of `bun-publish.test.ts` plus `bun-update-transitive.test.ts` and 3 passes over all 80 install test files under `BUN_JSC_collectContinuously=1`, 400 + 420 rounds of a script that serves a mock registry from `Bun.serve`, spawns `bun install` children against it and resets raw TCP connections mid-request. No GC crash.

Limits per lane in build 104370: alpine x64 and aarch64 `core file size (blocks) (-c) unlimited`, debian 13 x64, debian 13 x64-asan, debian 13 aarch64, ubuntu 25.04 x64 `coredump(blocks) 0`.

Build 104428 (first revision, ASAN lane included): `test/cli/test/parallel.test.ts` and `test/js/bun/resolve/resolver-permission-denied-ancestor.test.ts` passed every test but were reported as "core dumped". The second core's backtrace ends in `__lsan::DoLeakCheck` -> `__sanitizer::Die` -> `abort` from `__cxa_finalize` after `handle_root_error` -> `exit`: a child process that exits with an error leaks under LSAN, and `abort_on_error=1` turns the report into a SIGABRT. That abort existed before, but without a core the test file passed.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts, test/bundler/native-plugin.test.ts

<!-- robobun:evidence:end -->