### PR TITLE
worker_threads: use the intrinsic MessagePort and MessageChannel, not the mutable globals

### DIFF
--- a/src/js/internal/worker/messaging.ts
+++ b/src/js/internal/worker/messaging.ts
@@ -22,6 +22,9 @@ const messageTypes = {
 // Set once via initThreadInfo() when worker_threads.ts loads.
 let currentThreadId = 0;
 let isMainThread = true;
+// The intrinsic constructor from worker_threads' native binding, not
+// globalThis.MessageChannel, which user code can replace (#40268).
+let MessageChannel: typeof globalThis.MessageChannel;
 
 // Only populated on the main thread (the hub); always empty elsewhere.
 // SafeMap: its prototype is a frozen null-proto snapshot taken at bootstrap, so the
@@ -42,9 +45,10 @@ const WORKER_MESSAGING_RESULT_DELIVERED = 0;
 const WORKER_MESSAGING_RESULT_NO_LISTENERS = 1;
 const WORKER_MESSAGING_RESULT_LISTENER_ERROR = 2;
 
-function initThreadInfo(threadId: number, mainThread: boolean) {
+function initThreadInfo(threadId: number, mainThread: boolean, MessageChannelCtor: typeof globalThis.MessageChannel) {
   currentThreadId = threadId;
   isMainThread = mainThread;
+  MessageChannel = MessageChannelCtor;
 }
 
 // This event handler is always executed on the main thread only.
@@ -159,7 +163,7 @@ function receiveMessageFromWorker(source, value, memory) {
 // Bun half of Node's createMainThreadPort: create the channel linking a (future)
 // thread to the main thread. Called before `new Worker`.
 function createMessagingChannel() {
-  const { port1, port2 } = new globalThis.MessageChannel();
+  const { port1, port2 } = new MessageChannel();
   // port1 (portToMain) stays with the hub; port2 (portToWorker) is transferred to
   // the new thread where it becomes that thread's mainThreadPort.
   return { portToMain: port1, portToWorker: port2 };

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -52,16 +52,6 @@ function validateWorkerFilename(filename) {
   throw $ERR_WORKER_PATH(message);
 }
 
-const {
-  MessageChannel,
-  BroadcastChannel,
-  Worker: WebWorker,
-} = globalThis as typeof globalThis & {
-  // The Worker constructor secretly takes an extra parameter to provide the node:worker_threads
-  // instance. This is so that it can emit the `worker` event on the process with the
-  // node:worker_threads instance instead of the Web Worker instance.
-  Worker: new (...args: [...ConstructorParameters<typeof globalThis.Worker>, nodeWorker: Worker]) => WebWorker;
-};
 const SHARE_ENV = Symbol.for("nodejs.worker_threads.SHARE_ENV");
 
 const isMainThread = Bun.isMainThread;
@@ -79,6 +69,13 @@ const {
   10: _isNodeWorker,
   11: _setParentPort,
   12: _setStdioPorts,
+  // The intrinsic web constructors, captured natively so user code replacing the
+  // globals (e.g. happy-dom's registrator) before this module loads cannot break
+  // worker_threads (#40268).
+  13: _MessagePort,
+  14: MessageChannel,
+  15: BroadcastChannel,
+  16: WebWorker,
 } = $cpp("Worker.cpp", "createNodeWorkerThreadsBinding") as [
   unknown,
   number,
@@ -93,6 +90,13 @@ const {
   boolean,
   (port: MessagePort) => void,
   (ports: object) => void,
+  typeof globalThis.MessagePort,
+  typeof globalThis.MessageChannel,
+  typeof globalThis.BroadcastChannel,
+  // The Worker constructor secretly takes an extra parameter to provide the node:worker_threads
+  // instance. This is so that it can emit the `worker` event on the process with the
+  // node:worker_threads instance instead of the Web Worker instance.
+  new (...args: [...ConstructorParameters<typeof globalThis.Worker>, nodeWorker: Worker]) => WebWorker,
 ];
 
 type NodeWorkerOptions = import("node:worker_threads").WorkerOptions;
@@ -281,7 +285,6 @@ function injectFakeEmitter(Class) {
   Object.setPrototypeOf(proto, inherited);
 }
 
-const _MessagePort = globalThis.MessagePort;
 injectFakeEmitter(_MessagePort);
 
 const MessagePort = _MessagePort;
@@ -591,7 +594,7 @@ let parentPort: MessagePort | null = null;
 // postMessageToThread (Node 22+): the Worker ctor always smuggles a control
 // MessagePort to the worker by wrapping workerData; unwrap it here.
 const messaging = require("internal/worker/messaging");
-messaging.initThreadInfo(threadId, isMainThread);
+messaging.initThreadInfo(threadId, isMainThread, MessageChannel);
 // Captured stdio + the messaging control port ride inside workerData (wrapped;
 // ports transferred). Unwrap and bind the worker's stdio / messaging hub.
 // Gate on _isNodeWorker so a raw `new globalThis.Worker` that loads this module

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -47,6 +47,8 @@
 #include "JSDOMConvertObject.h"
 #include "JSDOMConvertSequences.h"
 #include "JSMessagePort.h"
+#include "JSMessageChannel.h"
+#include "JSWorker.h"
 #include "MessagePortPipe.h"
 #include "JSBroadcastChannel.h"
 #include "JSStructuredSerializeOptions.h"
@@ -335,7 +337,7 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
 
     bool isNodeWorker = proxy && proxy->options().kind == WorkerOptions::Kind::Node;
 
-    JSObject* array = constructEmptyArray(globalObject, nullptr, 13);
+    JSObject* array = constructEmptyArray(globalObject, nullptr, 17);
     RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 0, workerData);
     array->putDirectIndex(globalObject, 1, threadId);
@@ -350,6 +352,12 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
     array->putDirectIndex(globalObject, 10, jsBoolean(isNodeWorker));
     array->putDirectIndex(globalObject, 11, JSFunction::create(vm, globalObject, 1, "setParentPort"_s, jsFunctionSetParentPort, ImplementationVisibility::Public, NoIntrinsic));
     array->putDirectIndex(globalObject, 12, JSFunction::create(vm, globalObject, 1, "setStdioPorts"_s, jsFunctionSetNodeWorkerStdioPorts, ImplementationVisibility::Public, NoIntrinsic));
+    // The intrinsic constructors, so worker_threads keeps working when user code
+    // replaces globalThis.MessagePort etc. before the module loads (#40268).
+    array->putDirectIndex(globalObject, 13, JSMessagePort::getConstructor(vm, globalObject));
+    array->putDirectIndex(globalObject, 14, JSMessageChannel::getConstructor(vm, globalObject));
+    array->putDirectIndex(globalObject, 15, JSBroadcastChannel::getConstructor(vm, globalObject));
+    array->putDirectIndex(globalObject, 16, JSWorker::getConstructor(vm, globalObject));
     return array;
 }
 

--- a/test/regression/issue/40268.test.ts
+++ b/test/regression/issue/40268.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// https://github.com/oven-sh/bun/issues/40268
+// node:worker_threads read MessagePort / MessageChannel / BroadcastChannel /
+// Worker from the mutable globals at module load. User code that replaces them
+// before the module loads (happy-dom's global registrator does) broke
+// `new Worker()` with "port.on is not a function".
+test("new Worker works after user code replaces the web globals", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `class FakePort extends EventTarget {}
+      class FakeChannel {}
+      class FakeBroadcastChannel {}
+      class FakeWorker {}
+      globalThis.MessagePort = FakePort;
+      globalThis.MessageChannel = FakeChannel;
+      globalThis.BroadcastChannel = FakeBroadcastChannel;
+      globalThis.Worker = FakeWorker;
+
+      const wt = await import("node:worker_threads");
+
+      // The module exports are the intrinsics, not the replaced globals.
+      if (wt.MessagePort === FakePort) throw new Error("MessagePort export is the replaced global");
+      if (wt.MessageChannel === FakeChannel) throw new Error("MessageChannel export is the replaced global");
+      if (wt.BroadcastChannel === FakeBroadcastChannel) throw new Error("BroadcastChannel export is the replaced global");
+      // The node-style emitter methods landed on the intrinsic prototype.
+      if (typeof wt.MessagePort.prototype.on !== "function") throw new Error("MessagePort.prototype.on missing");
+
+      const { port1, port2 } = new wt.MessageChannel();
+      if (!(port1 instanceof wt.MessagePort)) throw new Error("MessageChannel made a non-intrinsic port");
+      port1.close();
+      port2.close();
+
+      const w = new wt.Worker("", { eval: true });
+      await w.terminate();
+      console.log("ok");`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `new Worker()` from `node:worker_threads` throws `TypeError: port.on is not a function` (in `registerMainThreadPort`, `internal:worker/messaging`) on 1.4.0 when user code replaced `globalThis.MessagePort` before the module loads. happy-dom's global registrator does this, so every suite that preloads it and constructs a worker (pino transports through thread-stream) broke. Worked on 1.3.14.
- The cause: `src/js/node/worker_threads.ts` captured `globalThis.MessagePort` (line 284) and `globalThis.MessageChannel` at module load, and `src/js/internal/worker/messaging.ts:162` called `new globalThis.MessageChannel()`. With a replaced global, the node-style emitter methods land on the replacement's prototype and the native `MessagePort.prototype` never gets `.on`. The 1.4.0 `postMessageToThread` hub made `new Worker` call `.on` on a native port, which exposed the latent bug.

### Fix
- `createNodeWorkerThreadsBinding` (`src/jsc/bindings/webcore/Worker.cpp`) now appends the intrinsic `MessagePort`, `MessageChannel`, `BroadcastChannel`, and `Worker` constructors (via `JS*::getConstructor`, which returns the cached per-global constructor) to the binding array.
- `worker_threads.ts` takes all four from the binding instead of `globalThis`, and passes the intrinsic `MessageChannel` into `messaging.ts` through `initThreadInfo`.
- Correct because the module now behaves like Node's: its internals and exports never depend on the mutable globals, and a replaced global cannot reach them.
- Verified: `test/regression/issue/40268.test.ts` (fails on stock bun, passes with the fix). Also `test/js/node/worker_threads/` (137 pass), the worker transfer/dispose/TLA suites, and the node parallel message-port tests.

### Background
- `node:worker_threads` wraps the web `Worker`/`MessagePort`. At module load it grafts Node's `EventEmitter`-style methods (`on`, `off`, `once`, ...) onto `MessagePort.prototype` (`injectFakeEmitter`).
- `postMessageToThread` (Node 22+) makes the main thread a message hub: `new Worker` creates a control `MessageChannel` and registers the hub-side port with `port.on("message", ...)`. That registration is the call that threw.
- `getConstructor` returns the same constructor object the global property was initialized with, so `instanceof` and prototype identity are unchanged for untouched globals.

<details><summary>Notes</summary>

- Repro (no dependencies): replace `globalThis.MessagePort` with a class extending `EventTarget`, then `new Worker("", { eval: true })`. Prints `ok` on 1.3.14 and with this fix, throws on 1.4.0.
- `test/js/web/workers/worker.test.ts` has two failures on a debug build ("message flood" and "preload with an un-awaited import()"). Both fail identically on main without this diff (verified with the diff stashed) and pass on the release build, so they are pre-existing debug-build timing failures.
- The fix also covers `BroadcastChannel` and `Worker`: the same mutable-global read, so `worker_threads.BroadcastChannel` no longer becomes the replacement class, and a replaced `globalThis.Worker` cannot hijack `new Worker` internals.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/40268.test.ts"
bun test v1.4.1 (4448a2e21)

test/regression/issue/40268.test.ts:
40 |     ],
41 |     env: bunEnv,
42 |     stderr: "pipe",
43 |   });
44 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
45 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ " 8 |       globalThis.Worker = FakeWorker;
+  9 | 
+ 10 |       const wt = await import("node:worker_threads");
+ 11 | 
+ 12 |       // The module exports are the intrinsics, not the replaced globals.
+ 13 |       if (wt.MessagePort === FakePort) throw new Error("MessagePort export is the replaced global");
+                                                       ^
+ error: MessagePort export is the replaced global
+       at /workspace/bun/[eval]:13:50
+ 
+ Bun v1.4.1-debug+4448a2e21 (Linux x64)
+ "

- Expected  - 1
+ Received  + 12

      at <anonymous> (/workspace/bun/test/regression/issue/40268.test.ts:45:18)
(fail) new Worker works after user co
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/regression/issue/40268.test.ts:
40 |     ],
41 |     env: bunEnv,
42 |     stderr: "pipe",
43 |   });
44 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
45 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ " 8 |       globalThis.Worker = FakeWorker;
+  9 | 
+ 10 |       const wt = await import("node:worker_threads");
+ 11 | 
+ 12 |       // The module exports are the intrinsics, not the replaced globals.
+ 13 |       if (wt.MessagePort === FakePort) throw new Error("MessagePort export is the replaced global");
+                                                       ^
+ error: MessagePort export is the replaced global
+       at /workspace/bun/[eval]:13:50
+ 
+ Bun v1.4.0-canary.1+4448a2e21 (Linux x64)
+ "

- Expected  - 1
+ Received  + 12

      at <anonymous> (/workspace/bun/test/regression/issue/40268.test.ts:45:18)
(fail) new Worker works after user code replaces the web globals [14.53ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [162.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/40268.test.ts"
bun test v1.4.1 (4448a2e21)

test/regression/issue/40268.test.ts:
(pass) new Worker works after user code replaces the web globals [1149.09ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [3.19s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 636ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 244 extern-C blocks audited
[2/24] gen cpp.rs (cppbind)
[3/24] gen JS modules (bundle-modules)
Preprocess modules (7401ms)
Bundle modules (69ms)
Postprocesss modules (35ms)
Bundle Functions (530ms)
Generate Code (21ms)

[8.07s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/8] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_perf v0.0.0 (/workspace/bun/src/perf)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src/threading)
[1m[92m   Compiling[0m bun_which v0.0.0 (/workspace/bun/src/which)
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/workspace/bun/src/spawn_sys)
[1m[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/worker/messaging.ts |  8 +++++--
 src/js/node/worker_threads.ts       | 27 +++++++++++----------
 src/jsc/bindings/webcore/Worker.cpp | 10 +++++++-
 test/regression/issue/40268.test.ts | 48 +++++++++++++++++++++++++++++++++++++
 4 files changed, 78 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/js/internal/worker/messaging.ts      1      3      0
src/js/node/worker_threads.ts            4      5      0
src/jsc/bindings/webcore/Worker.cpp      2      4      0
test/regression/issue/40268.test.ts      0      1      0
```

</details>

**root cause** · written by the author bot

The node:worker_threads module read MessagePort and MessageChannel from the mutable global object, so when user code such as happy-dom's registrator replaced globalThis.MessagePort before the module loaded, Bun's internal messaging code received a DOM-shaped port without emitter methods and threw "port.on is not a function" during Worker construction. The fix has the native worker_threads binding supply the intrinsic MessagePort, MessageChannel, BroadcastChannel, and Worker constructors directly, and the module's internals now use those instead of the globals. As a result, Worker constructi…

<!-- robobun:evidence:end -->