### PR TITLE
structuredClone/postMessage: keep string constant pool JSStrings alive during deserialization

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -2295,10 +2295,13 @@ private:
             return m_identifier;
         }
 
-        JSValue jsString(JSGlobalObject* lexicalGlobalObject)
+        JSValue jsString(CloneDeserializer& deserializer)
         {
-            if (!m_jsString)
-                m_jsString = JSC::jsString(lexicalGlobalObject->vm(), m_string);
+            if (!m_jsString) {
+                m_jsString = JSC::jsString(deserializer.m_lexicalGlobalObject->vm(), m_string);
+                // m_constantPool is not scanned by the GC.
+                deserializer.m_gcBuffer.appendWithCrashOnOverflow(m_jsString);
+            }
             return m_jsString;
         }
         const String& string() { return m_string; }
@@ -3640,7 +3643,7 @@ private:
             CachedStringRef cachedString;
             if (!readStringData(cachedString))
                 return JSValue();
-            return cachedString->jsString(m_lexicalGlobalObject);
+            return cachedString->jsString(*this);
         }
         case EmptyStringTag:
             return jsEmptyString(m_lexicalGlobalObject->vm());
@@ -3648,7 +3651,7 @@ private:
             CachedStringRef cachedString;
             if (!readStringData(cachedString))
                 return JSValue();
-            StringObject* obj = constructString(m_lexicalGlobalObject->vm(), m_globalObject, cachedString->jsString(m_lexicalGlobalObject));
+            StringObject* obj = constructString(m_lexicalGlobalObject->vm(), m_globalObject, cachedString->jsString(*this));
             addToObjectPool(obj);
             return obj;
         }

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1091,3 +1091,31 @@ describe("truncated Set/Map payloads are rejected without hanging", () => {
     expect(deserialize(serialize(new Map([[1, 1]])))).toEqual(new Map([[1, 1]]));
   });
 });
+
+describe("string constant pool entries survive GC during deserialization", () => {
+  // A string that appears twice in one payload is materialized once and referenced by index the
+  // second time. If the only object holding the first JSString drops it (here: a Map key that the
+  // payload sets twice) and the heap is collected before the back-reference is read, the
+  // deserializer must still hand back the original string.
+  test("Map value re-set during serialization", () => {
+    for (let iteration = 0; iteration < 1; iteration++) {
+      const expected = "Expected result " + iteration;
+      const map = new Map();
+      map.set("free", expected);
+      map.set("tmp", {
+        get a() {
+          map.delete("free");
+          map.set("free", 0x1234);
+          for (let i = 0; i < 0x10; i++) map.set("gc1_" + i, new ArrayBuffer(1024 * 1024 * 0x10));
+          for (let i = 0; i < 0x800; i++) map.set("gc2_" + i, new Date());
+          map.set("expected", expected);
+          return 1;
+        },
+      });
+      const result = structuredClone(map);
+      expect(result.get("expected")).toBe(expected);
+      expect(result.get("free")).toBe(0x1234);
+      expect(result.get("tmp")).toEqual({ a: 1 });
+    }
+  });
+});


### PR DESCRIPTION
### What

The structured clone deserializer (`postMessage`, `structuredClone`, `bun:jsc` `deserialize`, IPC advanced serialization) materializes each distinct string once and returns the same `JSString` for later back-references to it (`StringPoolTag`). That `JSString` was cached in `CachedString::m_jsString` inside a plain `Vector`, which the GC does not scan.

If the object graph being built dropped its only reference to that string — for example a `Map` whose serialized stream sets the same key twice because a getter mutated it mid-serialization — and a collection ran before the back-reference was read, the deserializer handed a dead (possibly already reused) cell back to JS:

```js
const string = "Expected result";
const map = new Map();
map.set("free", string);
map.set("tmp", { get a() {
  map.delete("free"); map.set("free", 0x1234);
  for (let i = 0; i < 0x10; i++) map.set("gc1_" + i, new ArrayBuffer(16 * 1024 * 1024));
  for (let i = 0; i < 0x800; i++) map.set("gc2_" + i, new Date());
  map.set("expected", string);
} });
structuredClone(map).get("expected"); // 1.4.0: "gc1_3" (a recycled cell), or a GC crash later
```

This is the same bug WebKit fixed in [276167@main](https://commits.webkit.org/276167@main); our copy of `SerializedScriptValue.cpp` predates it. The fix is the same one-liner: append the cached `JSString` to the deserializer's `MarkedArgumentBuffer`.

Found while looking at #37284. The failure mode is the same family (marker/sweeper reaching a dead `JSString`), but this particular trigger needs a duplicate key in the serialized stream, so I am not claiming it closes that issue.

### Test

`test/js/web/workers/structured-clone.test.ts` — fails on 1.4.0 (`Received: "gc1_4"`), passes with this change.