### PR TITLE
Bun.sql + Bun.redis: remove unsafe from sql_jsc and valkey_jsc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,6 +1537,7 @@ dependencies = [
  "bun_collections",
  "bun_core",
  "bun_event_loop",
+ "bun_http",
  "bun_io",
  "bun_jsc",
  "bun_opaque",

--- a/src/boringssl_sys/lib.rs
+++ b/src/boringssl_sys/lib.rs
@@ -32,3 +32,41 @@ pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     // SAFETY: both pointers are valid for `a.len()` bytes; lengths verified equal above.
     unsafe { boringssl::CRYPTO_memcmp(a.as_ptr().cast(), b.as_ptr().cast(), a.len()) == 0 }
 }
+
+/// `PKCS5_PBKDF2_HMAC` with SHA-256 into `out` (the derived key length is
+/// `out.len()`). Returns whether BoringSSL succeeded.
+pub fn pbkdf2_hmac_sha256(password: &[u8], salt: &[u8], iterations: u32, out: &mut [u8]) -> bool {
+    // SAFETY: each pointer is readable/writable for the length passed with it
+    // (an empty password is passed as null/0); `EVP_sha256` is a static digest.
+    unsafe {
+        boringssl::PKCS5_PBKDF2_HMAC(
+            if password.is_empty() {
+                core::ptr::null()
+            } else {
+                password.as_ptr()
+            },
+            password.len(),
+            salt.as_ptr(),
+            salt.len(),
+            iterations,
+            boringssl::EVP_sha256(),
+            out.len(),
+            out.as_mut_ptr(),
+        ) > 0
+    }
+}
+
+/// `ERR_error_string_n`: the human-readable string for `packed_error`, written
+/// into `buf` and returned up to (not including) its NUL terminator.
+pub fn err_error_string_n(packed_error: u32, buf: &mut [u8]) -> &[u8] {
+    if buf.is_empty() {
+        return buf;
+    }
+    // SAFETY: `buf` is writable for `buf.len()` bytes; BoringSSL NUL-terminates
+    // within that length.
+    unsafe {
+        boringssl::ERR_error_string_n(packed_error, buf.as_mut_ptr().cast(), buf.len());
+    }
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    &buf[..end]
+}

--- a/src/boringssl_sys/lib.rs
+++ b/src/boringssl_sys/lib.rs
@@ -67,6 +67,6 @@ pub fn err_error_string_n(packed_error: u32, buf: &mut [u8]) -> &[u8] {
     unsafe {
         boringssl::ERR_error_string_n(packed_error, buf.as_mut_ptr().cast(), buf.len());
     }
-    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    let end = bun_core::strings::index_of_char_usize(buf, 0).unwrap_or(buf.len());
     &buf[..end]
 }

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2048,13 +2048,26 @@ function generateRust(
             `    ${T}::${fastId}(this, global${args.length ? ", " + argFwd : ""})`,
           );
         }
-        thunk(
-          names.fn,
-          `(this: ${recv}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
-          passThis
-            ? `    ${helper("host_fn_this_value")}(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v))`
-            : `    ${helper("host_fn_this")}(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c))`,
-        );
+        if (sharedThis) {
+          // `*mut T` + receiver-generic helper: the method takes `&self` or
+          // `this: ThisPtr<Self>` and inference picks (see `HostReceiver`).
+          thunk(
+            names.fn,
+            `(this: *mut ${T}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
+            `    // SAFETY: C++ passes the wrapper's live \`m_ctx\`.\n    ` +
+              (passThis
+                ? `    unsafe { host_fn::host_fn_this_value_ptr(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v)) }`
+                : `    unsafe { host_fn::host_fn_this_ptr(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c)) }`),
+          );
+        } else {
+          thunk(
+            names.fn,
+            `(this: ${recv}, global: &JSGlobalObject, callframe: &CallFrame${passThis ? ", js_this_value: JSValue" : ""}) -> JSValue`,
+            passThis
+              ? `    ${helper("host_fn_this_value")}(this, global, callframe, js_this_value, |t, g, c, v| ${T}::${id}(t, g, c, v))`
+              : `    ${helper("host_fn_this")}(this, global, callframe, |t, g, c| ${T}::${id}(t, g, c))`,
+          );
+        }
       }
     }
   }

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -119,7 +119,6 @@ pub mod task_tag {
         ShellAsyncCpTask,
         StreamPending,
         ThreadSafeFunction,
-        ValkeyDeferredClose,
         WindowsNamedPipeContext,
         Write,
         Writev,

--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -5,6 +5,10 @@
 use Timespec as timespec;
 pub use bun_core::Timespec;
 
+use core::ptr::NonNull;
+
+use bun_ptr::JsCell;
+
 // Re-export so higher tiers see the *same* type they pass to
 // `bun_io::heap::Intrusive<EventLoopTimer, _>` (a zero-sized local stub
 // would make the real pairing-heap unusable — orphan rule blocks
@@ -18,26 +22,10 @@ const NS_PER_MS: i64 = bun_core::time::NS_PER_MS as i64;
 // intrusive heap node; the `match tag { … container_of … }` dispatch lives in
 // `bun_runtime::dispatch` because it names ~20 high-tier container types.
 //
-// LAYERING: rather than a runtime-registered fn-ptr (init-order
-// hazard), the bodies are declared `extern "Rust"` and defined `#[no_mangle]`
-// in `bun_runtime`; the linker resolves them. No `AtomicPtr`, no registration.
-//
 // PERF: `__bun_js_timer_epoch` sits on the
 // heap-compare path. Consider denormalizing `epoch` into `EventLoopTimer`
 // to drop the cross-crate call if profiling shows it matters.
 unsafe extern "Rust" {
-    /// Runtime owns the tag→variant `match`; `vm` is an erased
-    /// `*mut VirtualMachine`. Defined in `bun_runtime::dispatch`.
-    ///
-    /// SAFETY (genuine FFI precondition — NOT a `safe fn` candidate): impl
-    /// derefs `t`/`now`, recovers the tier-6 container via `container_of`
-    /// keyed on `(*t).tag`, and may free that container. Caller must pass a
-    /// live timer just popped from `All.timers` and must not touch `t` after.
-    fn __bun_fire_timer(
-        t: *mut EventLoopTimer,
-        now: *const timespec,
-        vm: *mut (),
-    ) -> crate::JsResult<()>;
     /// Returns the JS-timer epoch (TimerObjectInternals.flags.epoch) for
     /// TimeoutObject/ImmediateObject/AbortSignalTimeout, else `None`.
     /// Defined in `bun_runtime::dispatch`.
@@ -53,39 +41,53 @@ pub struct EventLoopTimer {
     /// The absolute time to fire this timer next.
     pub next: timespec,
     pub state: State,
-    pub tag: Tag,
-    /// Internal heap fields.
-    pub heap: IntrusiveField<EventLoopTimer>,
-    pub in_heap: InHeap,
+    /// Fixed at construction: the dispatch `container_of` is keyed on it.
+    tag: Tag,
+    /// Internal heap links; written only by [`TimerHeap`].
+    heap: IntrusiveField<EventLoopTimer>,
+    /// Which [`TimerHeap`] this slot is linked into; written only by [`TimerHeap`].
+    in_heap: InHeap,
 }
 
-// Duck-typed `.heap` field access for `bun_io::heap::Intrusive`. Implemented
-// here (the defining crate) so higher tiers can instantiate
-// `Intrusive<EventLoopTimer, _>` without hitting the orphan rule.
 impl bun_io::heap::HeapNode for EventLoopTimer {
     #[inline]
-    fn heap(&mut self) -> &mut IntrusiveField<Self> {
-        &mut self.heap
+    fn heap(&self) -> &IntrusiveField<Self> {
+        &self.heap
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Default)]
+#[derive(Copy, Clone, Eq, PartialEq, Default, Debug)]
 pub enum InHeap {
     #[default]
     None,
     Regular,
     Fake,
+    Wtf,
 }
 
 impl EventLoopTimer {
     pub fn init_paused(tag: Tag) -> Self {
+        Self::new(tag, State::PENDING, timespec::EPOCH)
+    }
+
+    pub fn new(tag: Tag, state: State, next: timespec) -> Self {
         Self {
-            next: timespec::EPOCH,
-            state: State::PENDING,
+            next,
+            state,
             tag,
             heap: IntrusiveField::default(),
             in_heap: InHeap::None,
         }
+    }
+
+    #[inline]
+    pub fn tag(&self) -> Tag {
+        self.tag
+    }
+
+    #[inline]
+    pub fn in_heap(&self) -> InHeap {
+        self.in_heap
     }
 
     pub fn less(_: (), a: &Self, b: &Self) -> bool {
@@ -144,41 +146,235 @@ impl EventLoopTimer {
     #[inline]
     pub(crate) fn js_timer_epoch(&self) -> Option<u32> {
         // SAFETY: `self` is a live timer; the extern impl reads `tag` and
-        // recovers the container via `offset_of`.
+        // recovers the container via `offset_of` (`TimerOwner` tag contract).
         unsafe { __bun_js_timer_epoch(self.tag, self) }
     }
+}
 
-    /// Fire the timer's callback.
-    ///
-    /// The `match self.tag { … container_of … }` body is
-    /// hot-dispatch over ~20 tier-6 variant types (Subprocess, DevServer,
-    /// PostgresSQLConnection, …). That match lives in
-    /// `bun_runtime::dispatch::__bun_fire_timer` (link-time extern). `vm` is
-    /// the erased `*mut VirtualMachine`.
-    ///
-    /// Deliberately takes `this: *mut Self`, NOT
-    /// `&mut self`. `__bun_fire_timer` dispatches via container_of into a
-    /// tier-6 timer object whose JS callback can re-enter and re-derive a
-    /// `&mut EventLoopTimer` to *this same node* (e.g. `clearTimeout()` →
-    /// `vm.timer.remove()` mutates `(*this).state`/`heap`). A live `&mut self`
-    /// across that FFI call lets LLVM `noalias` dead-store the re-entrant
-    /// write. Both callers (`drain_timers`, `get_timeout`) already hold a raw
-    /// `*mut EventLoopTimer` popped from the heap — pass it directly.
-    ///
-    /// The owner returns the exception its handler left pending as `Err` and
-    /// never reports it itself; the drain loop that called `fire` folds it.
-    ///
+// ─── TimerOwner / TimerRef / TimerHeap ──────────────────────────────────────
+
+/// A type that embeds one or more [`EventLoopTimer`] slots and lends them to a
+/// [`TimerHeap`]. Emitted by [`impl_timer_owner!`]; invoking that macro is the
+/// owner's assertion of this contract.
+///
+/// # Safety
+/// The implementor guarantees, for every slot of `Self` it constructs:
+/// - the slot is created with the [`Tag`] whose `bun_runtime::dispatch` arm
+///   names `Self` and that field, so the tag→container recovery is an
+///   identity (the tag cannot change after construction);
+/// - every teardown path of a `Self` unlinks its slots before the value is
+///   dropped, freed, or moved.
+///
+/// The remaining obligation is the holder's, as for [`bun_ptr::BackRef`]: a
+/// `Self` whose slot is linked must be kept alive and in place by whoever owns
+/// it (a JS wrapper's ref, a `Box` owned by C++, a field of the per-thread
+/// timer state, …) until it is unlinked.
+pub unsafe trait TimerOwner {}
+
+/// Handle to an [`EventLoopTimer`] slot embedded in a live [`TimerOwner`]; the
+/// currency of [`TimerHeap`] and `bun_runtime::timer::All`.
+///
+/// Like [`bun_ptr::BackRef`], validity is an obligation rather than a borrow:
+/// a `TimerRef` is usable while its slot is linked, for the duration of the
+/// owner's own call that passed it (arm/disarm), or of the dispatch that
+/// popped it (fire, until the owner's handler returns). Do not retain one past
+/// those points. It exposes the slot's deadline and state but neither its tag
+/// nor its heap links, which only construction and [`TimerHeap`] write.
+#[repr(transparent)]
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct TimerRef(NonNull<JsCell<EventLoopTimer>>);
+
+impl TimerRef {
+    /// Re-derive `slot` (a field of `*owner`) from `owner`'s address so the
+    /// handle carries whole-owner provenance for the dispatch `container_of`.
+    #[inline]
+    fn project<O: ?Sized>(owner: *const O, owner_size: usize, slot: *const EventLoopTimer) -> Self {
+        let offset = (slot as usize).wrapping_sub(owner.cast::<u8>() as usize);
+        assert!(
+            offset.saturating_add(core::mem::size_of::<EventLoopTimer>()) <= owner_size,
+            "TimerRef: slot is not a field of its owner"
+        );
+        // `slot`'s own address (so already aligned), re-derived from `owner`.
+        #[allow(clippy::cast_ptr_alignment)]
+        let p = owner
+            .cast::<u8>()
+            .wrapping_add(offset)
+            .cast::<JsCell<EventLoopTimer>>()
+            .cast_mut();
+        // SAFETY: `p` addresses a field of `*owner` (checked above), so it is non-null.
+        TimerRef(unsafe { NonNull::new_unchecked(p) })
+    }
+
+    /// `owner`'s `slot` (which must be a field of `*owner`).
+    #[inline]
+    pub fn new<O: TimerOwner + ?Sized>(owner: &O, slot: fn(&O) -> &JsCell<EventLoopTimer>) -> Self {
+        let cell: *const JsCell<EventLoopTimer> = slot(owner);
+        Self::project(owner, core::mem::size_of_val(owner), cell.cast())
+    }
+
+    /// [`new`](Self::new) for owners that hold the slot as a bare field.
+    #[inline]
+    pub fn from_mut<O: TimerOwner + ?Sized>(
+        owner: &mut O,
+        slot: fn(&mut O) -> &mut EventLoopTimer,
+    ) -> Self {
+        let owner_size = core::mem::size_of_val(owner);
+        let cell: *const EventLoopTimer = slot(owner);
+        Self::project(core::ptr::from_mut(owner), owner_size, cell)
+    }
+
     /// # Safety
-    /// `this` is a live timer just popped from `All.timers`; `now` is the
-    /// snapshot taken by `All::next`; `vm` is the per-thread VM. The handler
-    /// may free the container — caller must not touch `this` after.
-    pub unsafe fn fire(
-        this: *mut Self,
-        now: &timespec,
-        vm: *mut (), /* SAFETY: erased *mut VirtualMachine */
-    ) -> crate::JsResult<()> {
-        // SAFETY: per fn contract.
-        unsafe { __bun_fire_timer(this, now, vm) }
+    /// `slot` is an [`EventLoopTimer`] slot of a live [`TimerOwner`] (or is
+    /// otherwise pinned, unlinked before it is freed, and tagged for its
+    /// container), with provenance over that container.
+    #[inline]
+    pub unsafe fn from_raw(slot: *mut EventLoopTimer) -> Self {
+        debug_assert!(!slot.is_null());
+        // SAFETY: non-null per contract; `JsCell<T>` is `repr(transparent)` over `T`.
+        TimerRef(unsafe { NonNull::new_unchecked(slot.cast()) })
+    }
+
+    /// The slot's address, for the `container_of` dispatch and identity checks.
+    #[inline]
+    pub fn as_ptr(self) -> *mut EventLoopTimer {
+        self.0.as_ptr().cast()
+    }
+
+    #[inline]
+    fn cell(&self) -> &JsCell<EventLoopTimer> {
+        // SAFETY: `TimerOwner` / holder contract — the slot's owner is alive
+        // while this handle is in use (see the type docs for when that is).
+        unsafe { self.0.as_ref() }
+    }
+
+    #[inline]
+    pub fn tag(self) -> Tag {
+        self.cell().get().tag
+    }
+    #[inline]
+    pub fn state(self) -> State {
+        self.cell().get().state
+    }
+    #[inline]
+    pub fn set_state(self, state: State) {
+        self.cell().with_mut(|t| t.state = state);
+    }
+    #[inline]
+    pub fn next(self) -> timespec {
+        self.cell().get().next
+    }
+    #[inline]
+    pub fn set_next(self, next: timespec) {
+        self.cell().with_mut(|t| t.next = next);
+    }
+    #[inline]
+    pub fn in_heap(self) -> InHeap {
+        self.cell().get().in_heap
+    }
+}
+
+#[derive(Default)]
+pub struct TimerOrder;
+
+impl bun_io::heap::HeapContext<EventLoopTimer> for TimerOrder {
+    #[inline]
+    fn less(&self, a: &EventLoopTimer, b: &EventLoopTimer) -> bool {
+        EventLoopTimer::less((), a, b)
+    }
+}
+
+/// Pairing heap of [`EventLoopTimer`] slots, ordered by deadline (then JS
+/// epoch). Holds no ownership: each linked slot is kept alive by its
+/// [`TimerOwner`]. The heap is the only writer of a slot's links and
+/// [`InHeap`] membership, so `insert`/`remove` can refuse a slot that is
+/// already linked / not linked here instead of corrupting the structure.
+pub struct TimerHeap {
+    heap: bun_io::heap::Intrusive<EventLoopTimer, TimerOrder>,
+    kind: InHeap,
+}
+
+impl TimerHeap {
+    pub fn new(kind: InHeap) -> Self {
+        debug_assert!(kind != InHeap::None);
+        Self {
+            heap: Default::default(),
+            kind,
+        }
+    }
+
+    #[inline]
+    fn wrap(t: *mut EventLoopTimer) -> Option<TimerRef> {
+        // SAFETY: every node in the heap came from a `TimerRef` (`insert`).
+        (!t.is_null()).then(|| unsafe { TimerRef::from_raw(t) })
+    }
+
+    #[inline]
+    pub fn peek(&self) -> Option<TimerRef> {
+        Self::wrap(self.heap.peek())
+    }
+
+    /// Link `t`. A slot that is already in a heap is left where it is.
+    #[inline]
+    pub fn insert(&self, t: TimerRef) {
+        let cell = t.cell();
+        if cell.get().in_heap != InHeap::None {
+            debug_assert!(
+                false,
+                "TimerHeap::insert: slot already in {:?}",
+                cell.get().in_heap
+            );
+            return;
+        }
+        cell.with_mut(|t| t.in_heap = self.kind);
+        // SAFETY: unlinked (checked above); the `TimerOwner` / holder contract
+        // keeps the slot live and in place until it is unlinked again.
+        unsafe { self.heap.insert(t.as_ptr()) }
+    }
+
+    /// Unlink `t`. A slot that is not in this heap is left alone.
+    #[inline]
+    pub fn remove(&self, t: TimerRef) {
+        let cell = t.cell();
+        if cell.get().in_heap != self.kind {
+            debug_assert!(
+                false,
+                "TimerHeap::remove: slot is in {:?}",
+                cell.get().in_heap
+            );
+            return;
+        }
+        // SAFETY: `t` is live (`TimerOwner` contract) and linked into this heap
+        // (only `insert` sets `in_heap` to `self.kind`).
+        unsafe { self.heap.remove(t.as_ptr()) };
+        cell.with_mut(|t| t.in_heap = InHeap::None);
+    }
+
+    #[inline]
+    pub fn delete_min(&self) -> Option<TimerRef> {
+        let t = Self::wrap(self.heap.delete_min())?;
+        t.cell().with_mut(|t| t.in_heap = InHeap::None);
+        Some(t)
+    }
+
+    /// O(N).
+    #[inline]
+    pub fn find_max(&self) -> Option<TimerRef> {
+        Self::wrap(self.heap.find_max())
+    }
+
+    /// O(N).
+    #[inline]
+    pub fn count(&self) -> usize {
+        self.heap.count()
+    }
+
+    /// Every linked slot, in no particular order.
+    pub fn to_vec(&self) -> Vec<TimerRef> {
+        let mut out = Vec::new();
+        // SAFETY: as `wrap` — visited nodes are linked, hence from a `TimerRef`.
+        self.heap
+            .for_each(|t| out.push(unsafe { TimerRef::from_raw(t) }));
+        out
     }
 }
 
@@ -228,10 +424,12 @@ impl Tag {
 
 /// Stamp out one `unsafe fn $method(*const EventLoopTimer) -> *mut Self` per
 /// `(method => field)` pair: each recovers the embedding owner from a pointer
-/// to the named intrusive [`EventLoopTimer`] slot (typed container_of).
+/// to the named intrusive [`EventLoopTimer`] slot (typed container_of), and
+/// marks `$Owner` as a [`TimerOwner`] — **invoking this macro asserts that
+/// trait's contract** for the named slots.
 ///
 /// The accessor layer exists only as a cross-crate visibility shim: the
-/// `__bun_fire_timer` tag-dispatch in `bun_runtime` cannot name private timer
+/// `fire_timer` tag-dispatch in `bun_runtime` cannot name private timer
 /// fields on owners defined elsewhere, so each owner exports a named thunk per
 /// slot. The input is `*const` (so `*mut` / `&mut` / `&` all coerce at the
 /// call site); the field may be a bare `EventLoopTimer` or any
@@ -247,6 +445,8 @@ impl Tag {
 #[macro_export]
 macro_rules! impl_timer_owner {
     ($Owner:ty; $($method:ident => $field:ident),+ $(,)?) => {
+        // SAFETY: asserted by the invoker — see the macro docs.
+        unsafe impl $crate::EventLoopTimer::TimerOwner for $Owner {}
         impl $Owner {
             $(
                 /// Recover `*mut Self` from a pointer to its intrusive

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -6,6 +6,14 @@ use core::ptr::NonNull;
 
 use crate::{JsResult, Task};
 
+/// The context of a [`ManagedTask::new_boxed`] task.
+pub trait RunOnce: Sized {
+    fn run(self) -> JsResult<()>;
+    /// The task was released unrun (its VM is tearing down: script is
+    /// forbidden, the JSC heap is still alive). Default: just drop.
+    fn cancelled(self) {}
+}
+
 pub struct ManagedTask {
     // Opaque userdata pointer round-tripped through `new`/`run`; raw by design.
     pub ctx: Option<NonNull<c_void>>,
@@ -59,6 +67,26 @@ impl ManagedTask {
             },
             ctx: NonNull::new(ctx.cast::<c_void>()),
             cleanup: None,
+        }));
+        ManagedTask::task(managed)
+    }
+
+    /// A task that owns `ctx` and [`run`](RunOnce::run)s it (or drops it if
+    /// the queue is released unrun).
+    pub fn new_boxed<T: RunOnce>(ctx: Box<T>) -> Task {
+        fn run<T: RunOnce>(p: *mut c_void) -> JsResult<()> {
+            // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`; `run`
+            // passes it back exactly once.
+            T::run(*unsafe { Box::from_raw(p.cast::<T>()) })
+        }
+        fn drop_ctx<T: RunOnce>(p: *mut c_void) {
+            // SAFETY: `p` is the `Box<T>` `new_boxed` leaked into `ctx`.
+            T::cancelled(*unsafe { Box::from_raw(p.cast::<T>()) });
+        }
+        let managed = bun_core::heap::into_raw(Box::new(ManagedTask {
+            callback: run::<T>,
+            ctx: NonNull::new(Box::into_raw(ctx).cast::<c_void>()),
+            cleanup: Some(drop_ctx::<T>),
         }));
         ManagedTask::task(managed)
     }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2031,13 +2031,7 @@ pub fn init(
         wr!(options, options);
         wr!(
             active_lifecycle_scripts,
-            crate::lifecycle_script_runner::List {
-                root: core::ptr::null_mut(),
-                // `lifecycle_script_runner::List`'s heap comparator never
-                // dereferences its context arg, so it is modeled as a ZST
-                // (`StartedAtCtx`) instead of threading a back-pointer.
-                context: crate::lifecycle_script_runner::StartedAtCtx,
-            }
+            crate::lifecycle_script_runner::List::default()
         );
         wr!(network_task_fifo, NetworkQueue::init());
         wr!(patch_task_fifo, PatchTaskFifo::init());
@@ -2492,10 +2486,7 @@ fn init_with_runtime_once(
         );
         wr!(
             active_lifecycle_scripts,
-            crate::lifecycle_script_runner::List {
-                root: core::ptr::null_mut(),
-                context: crate::lifecycle_script_runner::StartedAtCtx,
-            }
+            crate::lifecycle_script_runner::List::default()
         );
         wr!(network_task_fifo, NetworkQueue::init());
         wr!(log, std::ptr::from_mut(log));

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -316,21 +316,15 @@ pub type List<'a> = io_heap::Intrusive<LifecycleScriptSubprocess<'a>, StartedAtC
 
 impl<'a> io_heap::HeapNode for LifecycleScriptSubprocess<'a> {
     #[inline]
-    fn heap(&mut self) -> &mut io_heap::IntrusiveField<Self> {
-        &mut self.heap
+    fn heap(&self) -> &io_heap::IntrusiveField<Self> {
+        &self.heap
     }
 }
 
 impl<'a> io_heap::HeapContext<LifecycleScriptSubprocess<'a>> for StartedAtCtx {
     #[inline]
-    unsafe fn less(
-        &self,
-        a: *mut LifecycleScriptSubprocess<'a>,
-        b: *mut LifecycleScriptSubprocess<'a>,
-    ) -> bool {
-        // SAFETY: `a`/`b` are live heap nodes owned by the intrusive heap; the
-        // heap only calls `less` on nodes it has been handed via `insert`.
-        unsafe { (*a).started_at < (*b).started_at }
+    fn less(&self, a: &LifecycleScriptSubprocess<'a>, b: &LifecycleScriptSubprocess<'a>) -> bool {
+        a.started_at < b.started_at
     }
 }
 
@@ -437,18 +431,15 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         // SAFETY: caller contract — `this` is non-null and live.
         unsafe {
             let manager: *mut PackageManager = (*this).manager.as_ptr();
-            let heap = core::ptr::addr_of_mut!((*this).heap);
+            let heap = core::ptr::addr_of!((*this).heap);
             // SAFETY: `manager` is non-null and outlives every subprocess (see
             // `Self::manager`); the install loop is single-threaded here.
-            let active = &mut (*manager).active_lifecycle_scripts;
-            if !(*heap).child.is_null()
-                || !(*heap).next.is_null()
-                || !(*heap).prev.is_null()
-                || core::ptr::eq(active.root, this as *const _)
-            {
+            let this = this.cast::<LifecycleScriptSubprocess<'static>>();
+            let active = &(*manager).active_lifecycle_scripts;
+            if (*heap).is_linked() || active.is_root(this) {
                 // SAFETY: `this` was inserted via `insert(this)` with allocation-
                 // rooted provenance; the heap holds no other live `&mut` to it here.
-                active.remove(this.cast::<LifecycleScriptSubprocess<'static>>());
+                active.remove(this);
             }
         }
     }

--- a/src/io/heap.rs
+++ b/src/io/heap.rs
@@ -1,3 +1,4 @@
+use core::cell::Cell;
 use core::ptr;
 
 /// An intrusive heap implementation backed by a pairing heap[1] implementation.
@@ -18,30 +19,36 @@ use core::ptr;
 /// - You can easily make this a min or max heap by inverting the result of
 ///   "less" below.
 ///
+/// Invariant: every node reachable from `root` was handed to [`insert`] and has
+/// not been returned by [`delete_min`] / passed to [`remove`] since, so by
+/// `insert`'s contract it is live. All node access goes through `&T` and the
+/// `Cell` links, so the heap never forms a `&mut T`.
+///
 /// [1]: https://en.wikipedia.org/wiki/Pairing_heap
 /// [2]: https://www.boost.org/doc/libs/1_64_0/doc/html/intrusive/intrusive_vs_nontrusive.html
+///
+/// [`insert`]: Intrusive::insert
+/// [`delete_min`]: Intrusive::delete_min
+/// [`remove`]: Intrusive::remove
 //
 // The comparator is a trait on `Context` (`HeapContext<T>::less`) rather than
 // a fn-pointer parameter (fn pointers can't be const generics on stable).
 // This preserves monomorphization (no indirect call) at the cost of requiring
 // the caller to impl the trait instead of passing a free fn.
 pub struct Intrusive<T: HeapNode, Context: HeapContext<T>> {
-    pub root: *mut T,
+    root: Cell<*mut T>,
     pub context: Context,
 }
 
 /// Trait providing the ordering relation for `Intrusive`.
 /// Implement this on your `Context` type (or a ZST if no context is needed).
 pub trait HeapContext<T> {
-    /// # Safety
-    /// `a` and `b` must be non-null, aligned, and point to live nodes currently
-    /// owned by the intrusive heap. Only called from `Intrusive` internals.
-    unsafe fn less(&self, a: *mut T, b: *mut T) -> bool;
+    fn less(&self, a: &T, b: &T) -> bool;
 }
 
 /// Trait giving generic access to the embedded `IntrusiveField` on `T`.
 pub trait HeapNode: Sized {
-    fn heap(&mut self) -> &mut IntrusiveField<Self>;
+    fn heap(&self) -> &IntrusiveField<Self>;
 }
 
 impl<T: HeapNode, Context: HeapContext<T>> Default for Intrusive<T, Context>
@@ -50,119 +57,129 @@ where
 {
     fn default() -> Self {
         Self {
-            root: ptr::null_mut(),
+            root: Cell::new(ptr::null_mut()),
             context: Context::default(),
         }
     }
 }
 
 impl<T: HeapNode, Context: HeapContext<T>> Intrusive<T, Context> {
+    /// Borrow a linked node.
+    ///
+    /// # Safety
+    /// `n` is non-null and linked into this heap (struct invariant ⇒ live).
+    #[inline]
+    unsafe fn node<'a>(n: *mut T) -> &'a T {
+        // SAFETY: caller contract.
+        unsafe { &*n }
+    }
+
     /// Insert a new element v into the heap. An element v can only
     /// be a member of a single heap at any given time. When compiled
     /// with runtime-safety, assertions will help verify this property.
-    pub unsafe fn insert(&mut self, v: *mut T) {
-        // SAFETY: caller guarantees `v` is a valid, exclusively-owned node not
-        // currently in any heap; `self.root` is either null or a valid node.
-        self.root = if !self.root.is_null() {
-            let root = self.root;
-            self.meld(v, root)
+    ///
+    /// # Safety
+    /// `v` points at a live `T` that is not linked into any heap, and it stays
+    /// live at that address until it leaves this heap again (via
+    /// [`delete_min`](Self::delete_min) or [`remove`](Self::remove)).
+    pub unsafe fn insert(&self, v: *mut T) {
+        let root = self.root.get();
+        self.root.set(if !root.is_null() {
+            // SAFETY: `v` per fn contract; `root` per struct invariant.
+            unsafe { self.meld(v, root) }
         } else {
             v
-        };
+        });
     }
 
     /// Look at the next minimum value but do not remove it.
     pub fn peek(&self) -> *mut T {
-        self.root
+        self.root.get()
+    }
+
+    /// `true` if `v` is the root of this heap.
+    pub fn is_root(&self, v: *const T) -> bool {
+        ptr::eq(self.root.get(), v)
     }
 
     /// Count the number of elements in the heap. This is an O(N) operation.
-    pub unsafe fn count(&self) -> usize {
-        // SAFETY: all reachable nodes from `self.root` are valid for the heap's lifetime.
-        Self::count_internal(self.root)
+    pub fn count(&self) -> usize {
+        let mut n = 0;
+        self.for_each(|_| n += 1);
+        n
     }
 
-    unsafe fn count_internal(node: *mut T) -> usize {
-        if node.is_null() {
-            return 0;
+    /// Visit every linked node (in no particular order). `f` must not link or
+    /// unlink nodes of this heap.
+    pub fn for_each(&self, mut f: impl FnMut(*mut T)) {
+        let root = self.root.get();
+        if root.is_null() {
+            return;
         }
-        let current = node;
-        let mut result: usize = 1;
-
-        // Count children
-        // SAFETY: `current` is non-null and valid (checked above / invariant).
-        result += Self::count_internal((*current).heap().child);
-
-        // Count siblings
-        result += Self::count_internal((*current).heap().next);
-
-        result
+        let mut stack: Vec<*mut T> = vec![root];
+        while let Some(node) = stack.pop() {
+            // SAFETY: struct invariant — reachable nodes are live.
+            let links = unsafe { Self::node(node) }.heap();
+            let (child, next) = (links.child.get(), links.next.get());
+            if !child.is_null() {
+                stack.push(child);
+            }
+            if !next.is_null() {
+                stack.push(next);
+            }
+            f(node);
+        }
     }
 
     /// Look at the next maximum value but do not remove it. This is an O(N) operation.
-    pub unsafe fn find_max(&self) -> *mut T {
-        if self.root.is_null() {
-            return ptr::null_mut();
-        }
-        let root = self.root;
-        // SAFETY: `root` is non-null and valid.
-        Self::find_max_internal(&self.context, root, root)
-    }
-
-    unsafe fn find_max_internal(ctx: &Context, node: *mut T, current_max: *mut T) -> *mut T {
-        let mut max_so_far = current_max;
-
-        // Update max if current node is greater
-        if ctx.less(max_so_far, node) {
-            max_so_far = node;
-        }
-
-        // Traverse children
-        // SAFETY: `node` is a valid heap node (caller invariant).
-        let child = (*node).heap().child;
-        if !child.is_null() {
-            max_so_far = Self::find_max_internal(ctx, child, max_so_far);
-        }
-
-        // Traverse siblings
-        let next_sibling = (*node).heap().next;
-        if !next_sibling.is_null() {
-            max_so_far = Self::find_max_internal(ctx, next_sibling, max_so_far);
-        }
-
-        max_so_far
+    pub fn find_max(&self) -> *mut T {
+        let mut max = self.root.get();
+        self.for_each(|node| {
+            // SAFETY: struct invariant — both are linked, live nodes.
+            let (a, b) = unsafe { (Self::node(max), Self::node(node)) };
+            if self.context.less(a, b) {
+                max = node;
+            }
+        });
+        max
     }
 
     /// Delete the minimum value from the heap and return it.
-    pub unsafe fn delete_min(&mut self) -> *mut T {
-        if self.root.is_null() {
+    pub fn delete_min(&self) -> *mut T {
+        let root = self.root.get();
+        if root.is_null() {
             return ptr::null_mut();
         }
-        let root = self.root;
-        // SAFETY: `root` is non-null and valid.
-        let child = (*root).heap().child;
-        self.root = if !child.is_null() {
-            self.combine_siblings(child)
+        // SAFETY: struct invariant — `root` is a linked, live node.
+        let root_links = unsafe { Self::node(root) }.heap();
+        let child = root_links.child.get();
+        self.root.set(if !child.is_null() {
+            // SAFETY: `child` is linked (reachable from root).
+            unsafe { self.combine_siblings(child) }
         } else {
             ptr::null_mut()
-        };
+        });
 
         // Clear pointers with runtime safety so we can verify on
         // insert that values aren't incorrectly being set multiple times.
-        *(*root).heap() = IntrusiveField::default();
+        root_links.clear();
 
         root
     }
 
     /// Remove the value v from the heap.
-    pub unsafe fn remove(&mut self, v: *mut T) {
+    ///
+    /// # Safety
+    /// `v` points at a live `T` currently linked into this heap.
+    pub unsafe fn remove(&self, v: *mut T) {
         // If v doesn't have a previous value, this must be the root
         // element. If it is NOT the root element, v can't be in this
         // heap and we trigger an assertion failure.
-        // SAFETY: caller guarantees `v` is a valid node currently in this heap.
-        let prev = (*v).heap().prev;
+        // SAFETY: fn contract.
+        let v_links = unsafe { Self::node(v) }.heap();
+        let prev = v_links.prev.get();
         if prev.is_null() {
-            debug_assert!(self.root == v);
+            debug_assert!(self.is_root(v));
             let _ = self.delete_min();
             return;
         }
@@ -171,28 +188,33 @@ impl<T: HeapNode, Context: HeapContext<T>> Intrusive<T, Context> {
         // is as if this node never nexisted. The previous value
         // must point to the proper next value and the pointers
         // must all be cleaned up.
-        let v_next = (*v).heap().next;
+        let v_next = v_links.next.get();
         if !v_next.is_null() {
-            (*v_next).heap().prev = prev;
+            // SAFETY: linked from `v`, hence in this heap.
+            unsafe { Self::node(v_next) }.heap().prev.set(prev);
         }
-        if (*prev).heap().child == v {
-            (*prev).heap().child = v_next;
+        // SAFETY: linked from `v`, hence in this heap.
+        let prev_links = unsafe { Self::node(prev) }.heap();
+        if ptr::eq(prev_links.child.get(), v) {
+            prev_links.child.set(v_next);
         } else {
-            (*prev).heap().next = v_next;
+            prev_links.next.set(v_next);
         }
-        (*v).heap().prev = ptr::null_mut();
-        (*v).heap().next = ptr::null_mut();
+        v_links.prev.set(ptr::null_mut());
+        v_links.next.set(ptr::null_mut());
 
         // If we have children, then we need to merge them back in.
-        let child = (*v).heap().child;
+        let child = v_links.child.get();
         if child.is_null() {
             return;
         }
-        (*v).heap().child = ptr::null_mut();
-        let x = self.combine_siblings(child);
-        // SAFETY: `self.root` is non-null here — `v` had a `prev`, so it was not the
-        // root, hence the heap is non-empty.
-        self.root = self.meld(x, self.root);
+        v_links.child.set(ptr::null_mut());
+        // SAFETY: `child` was linked under `v`; `self.root` is non-null here —
+        // `v` had a `prev`, so it was not the root, hence the heap is non-empty.
+        unsafe {
+            let x = self.combine_siblings(child);
+            self.root.set(self.meld(x, self.root.get()));
+        }
     }
 
     /// Meld (union) two heaps together. This isn't a generalized
@@ -202,34 +224,41 @@ impl<T: HeapNode, Context: HeapContext<T>> Intrusive<T, Context> {
     ///
     /// For example, when melding a new value "v" with an existing
     /// root "root", "v" must always be the first param.
-    unsafe fn meld(&mut self, a: *mut T, b: *mut T) -> *mut T {
-        // SAFETY: `a` and `b` are distinct valid nodes (caller invariant).
-        debug_assert!((*a).heap().next.is_null());
+    ///
+    /// # Safety
+    /// `a` and `b` are distinct, live nodes (linked, or being linked by `insert`).
+    unsafe fn meld(&self, a: *mut T, b: *mut T) -> *mut T {
+        // SAFETY: fn contract.
+        let (a_ref, b_ref) = unsafe { (Self::node(a), Self::node(b)) };
+        let (al, bl) = (a_ref.heap(), b_ref.heap());
+        debug_assert!(al.next.get().is_null());
 
-        if self.context.less(a, b) {
+        if self.context.less(a_ref, b_ref) {
             // B points back to A
-            (*b).heap().prev = a;
+            bl.prev.set(a);
 
             // If B has siblings, then A inherits B's siblings
             // and B's immediate sibling must point back to A to
             // maintain the doubly linked list.
-            let b_next = (*b).heap().next;
+            let b_next = bl.next.get();
             if !b_next.is_null() {
-                (*a).heap().next = b_next;
-                (*b_next).heap().prev = a;
-                (*b).heap().next = ptr::null_mut();
+                al.next.set(b_next);
+                // SAFETY: linked from `b`.
+                unsafe { Self::node(b_next) }.heap().prev.set(a);
+                bl.next.set(ptr::null_mut());
             }
 
             // If A has a child, then B becomes the leftmost sibling
             // of that child.
-            let a_child = (*a).heap().child;
+            let a_child = al.child.get();
             if !a_child.is_null() {
-                (*b).heap().next = a_child;
-                (*a_child).heap().prev = b;
+                bl.next.set(a_child);
+                // SAFETY: linked from `a`.
+                unsafe { Self::node(a_child) }.heap().prev.set(b);
             }
 
             // B becomes the leftmost child of A
-            (*a).heap().child = b;
+            al.child.set(b);
 
             return a;
         }
@@ -237,67 +266,92 @@ impl<T: HeapNode, Context: HeapContext<T>> Intrusive<T, Context> {
         // Replace A with B in the tree. Any of B's children
         // become siblings of A. A becomes the leftmost child of B.
         // A points back to B
-        (*b).heap().prev = (*a).heap().prev;
-        (*a).heap().prev = b;
-        let b_child = (*b).heap().child;
+        bl.prev.set(al.prev.get());
+        al.prev.set(b);
+        let b_child = bl.child.get();
         if !b_child.is_null() {
-            (*a).heap().next = b_child;
-            (*b_child).heap().prev = a;
+            al.next.set(b_child);
+            // SAFETY: linked from `b`.
+            unsafe { Self::node(b_child) }.heap().prev.set(a);
         }
-        (*b).heap().child = a;
+        bl.child.set(a);
         b
     }
 
     /// Combine the siblings of the leftmost value "left" into a single
     /// new rooted with the minimum value.
-    unsafe fn combine_siblings(&mut self, left: *mut T) -> *mut T {
-        // SAFETY: `left` is a valid non-null node (caller invariant).
-        (*left).heap().prev = ptr::null_mut();
+    ///
+    /// # Safety
+    /// `left` is a non-null node linked into this heap.
+    unsafe fn combine_siblings(&self, left: *mut T) -> *mut T {
+        // SAFETY: (whole body) every pointer followed is a link of a node
+        // reachable from `left`, hence linked and live (struct invariant).
+        unsafe {
+            Self::node(left).heap().prev.set(ptr::null_mut());
 
-        // Merge pairs right
-        let mut root: *mut T = 'root: {
-            let mut a: *mut T = left;
+            // Merge pairs right
+            let mut root: *mut T = 'root: {
+                let mut a: *mut T = left;
+                loop {
+                    let mut b = Self::node(a).heap().next.get();
+                    if b.is_null() {
+                        break 'root a;
+                    }
+                    Self::node(a).heap().next.set(ptr::null_mut());
+                    b = self.meld(a, b);
+                    let next_a = Self::node(b).heap().next.get();
+                    if next_a.is_null() {
+                        break 'root b;
+                    }
+                    a = next_a;
+                }
+            };
+
+            // Merge pairs left
             loop {
-                let mut b = (*a).heap().next;
+                let b = Self::node(root).heap().prev.get();
                 if b.is_null() {
-                    break 'root a;
+                    return root;
                 }
-                (*a).heap().next = ptr::null_mut();
-                b = self.meld(a, b);
-                let next_a = (*b).heap().next;
-                if next_a.is_null() {
-                    break 'root b;
-                }
-                a = next_a;
+                Self::node(b).heap().next.set(ptr::null_mut());
+                root = self.meld(b, root);
             }
-        };
-
-        // Merge pairs left
-        loop {
-            let b = (*root).heap().prev;
-            if b.is_null() {
-                return root;
-            }
-            (*b).heap().next = ptr::null_mut();
-            root = self.meld(b, root);
         }
     }
 }
 
 /// The state that is required for IntrusiveHeap element types. This
 /// should be set as the "heap" field in the type T.
+/// The links are private: only [`Intrusive`] writes them, which is what lets its
+/// safe methods trust them.
 pub struct IntrusiveField<T> {
-    pub child: *mut T,
-    pub prev: *mut T,
-    pub next: *mut T,
+    child: Cell<*mut T>,
+    prev: Cell<*mut T>,
+    next: Cell<*mut T>,
+}
+
+impl<T> IntrusiveField<T> {
+    /// `true` while any link is set. A lone root has no links, so callers that
+    /// need "is in heap H" must also ask [`Intrusive::is_root`].
+    #[inline]
+    pub fn is_linked(&self) -> bool {
+        !self.child.get().is_null() || !self.prev.get().is_null() || !self.next.get().is_null()
+    }
+
+    #[inline]
+    fn clear(&self) {
+        self.child.set(ptr::null_mut());
+        self.prev.set(ptr::null_mut());
+        self.next.set(ptr::null_mut());
+    }
 }
 
 impl<T> Default for IntrusiveField<T> {
     fn default() -> Self {
         Self {
-            child: ptr::null_mut(),
-            prev: ptr::null_mut(),
-            next: ptr::null_mut(),
+            child: Cell::new(ptr::null_mut()),
+            prev: Cell::new(ptr::null_mut()),
+            next: Cell::new(ptr::null_mut()),
         }
     }
 }

--- a/src/io/heap.rs
+++ b/src/io/heap.rs
@@ -83,6 +83,8 @@ impl<T: HeapNode, Context: HeapContext<T>> Intrusive<T, Context> {
     /// live at that address until it leaves this heap again (via
     /// [`delete_min`](Self::delete_min) or [`remove`](Self::remove)).
     pub unsafe fn insert(&self, v: *mut T) {
+        // SAFETY: `v` is live per fn contract.
+        debug_assert!(!unsafe { Self::node(v) }.heap().is_linked() && !self.is_root(v));
         let root = self.root.get();
         self.root.set(if !root.is_null() {
             // SAFETY: `v` per fn contract; `root` per struct invariant.

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -4,8 +4,7 @@ use core::sync::atomic::Ordering;
 
 use crate::{CommonAbortReason, JSGlobalObject, JSValue, VirtualMachineRef as VirtualMachine};
 use bun_event_loop::EventLoopTimer::{
-    EventLoopTimer, InHeap, IntrusiveField, State as TimerState, Tag as TimerTag, TimerFlags,
-    Timespec as ElTimespec,
+    EventLoopTimer, State as TimerState, Tag as TimerTag, TimerFlags, Timespec as ElTimespec,
 };
 
 bun_opaque::opaque_ffi! {
@@ -299,16 +298,14 @@ impl Timeout {
             .add_ms(i64::try_from(milliseconds).expect("AbortSignal.timeout(ms) overflows i64"));
 
         let this: *mut Timeout = bun_core::heap::into_raw(Box::new(Timeout {
-            event_loop_timer: EventLoopTimer {
-                next: ElTimespec {
+            event_loop_timer: EventLoopTimer::new(
+                TimerTag::AbortSignalTimeout,
+                TimerState::CANCELLED,
+                ElTimespec {
                     sec: deadline.sec,
                     nsec: deadline.nsec,
                 },
-                tag: TimerTag::AbortSignalTimeout,
-                state: TimerState::CANCELLED,
-                heap: IntrusiveField::default(),
-                in_heap: InHeap::default(),
-            },
+            ),
             signal: signal_,
             flags: TimerFlags::default(),
             generation: VirtualMachine::get().test_isolation_generation,

--- a/src/jsc/JSObject.rs
+++ b/src/jsc/JSObject.rs
@@ -152,6 +152,30 @@ impl JSObject {
         unsafe { JSC__createStructure(global.as_ptr(), owner_cell, length, names) }
     }
 
+    /// [`create_structure`](Self::create_structure) over a slice. `owner` is
+    /// the cell the structure is write-barriered against, or the empty value
+    /// for none.
+    pub fn create_structure_for(
+        global: &JSGlobalObject,
+        owner: JSValue,
+        names: &mut [ExternColumnIdentifier],
+    ) -> JSValue {
+        crate::mark_binding!();
+        assert!(owner.is_empty() || owner.is_cell());
+        let owner_cell = owner.0 as *mut JSCell;
+        // SAFETY: `owner_cell` is null or a live cell (checked above; the caller
+        // holds `owner` on the stack); `names` is an initialized slice C++ reads
+        // for the duration of the call only.
+        unsafe {
+            JSC__createStructure(
+                global.as_ptr(),
+                owner_cell,
+                names.len() as u32,
+                names.as_mut_ptr(),
+            )
+        }
+    }
+
     /// The C++ side returns the object even when `creator` threw inside
     /// `initializer_call`, so the exception state is checked explicitly.
     pub fn create_with_initializer<Ctx: ObjectInitializer>(

--- a/src/jsc/MarkedArgumentBuffer.rs
+++ b/src/jsc/MarkedArgumentBuffer.rs
@@ -49,7 +49,7 @@ impl MarkedArgumentBuffer {
         ctx.r.unwrap()
     }
 
-    pub fn append(&mut self, value: JSValue) {
+    pub fn append(&self, value: JSValue) {
         MarkedArgumentBuffer__append(self, value)
     }
 

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -3,7 +3,9 @@ use core::ptr;
 
 use crate as jsc;
 use crate::SysErrorJsc;
-use crate::{ComptimeStringMapExt as _, JSGlobalObject, JSType, JSValue, JsResult};
+use crate::{
+    ComptimeStringMapExt as _, JSGlobalObject, JSType, JSValue, JsResult, MarkedArgumentBuffer,
+};
 use bun_alloc::mimalloc;
 use bun_sys::{self, Fd, FdExt};
 
@@ -138,6 +140,101 @@ unsafe extern "C" {
     safe fn JSC__ArrayBuffer__deref(self_: &JSCArrayBuffer);
     // safe: by-value `JSValue`; no-op for non-buffer values.
     safe fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
+    // safe: by-value `JSValue`; out-params are `&mut` (same ABI as `*mut`).
+    // The obligation is on the *returned* bytes (see `MarkedArgumentBuffer::pin_bytes`).
+    safe fn JSC__JSValue__borrowBytesForOffThread(
+        v: JSValue,
+        out_ptr: &mut *const u8,
+        out_len: &mut usize,
+    ) -> i32;
+}
+
+/// The bytes of an ArrayBuffer / view argument, readable until dropped even
+/// if JS that runs meanwhile tries to detach the buffer or drops its last
+/// reference: [`MarkedArgumentBuffer::pin_bytes`] roots the value in the
+/// argument buffer (so the cell outlives `'a`) and pins a detachable
+/// `ArrayBuffer` until this drops; a `FastTypedArray`'s GC-movable inline
+/// vector is copied instead.
+pub struct PinnedBytes<'a> {
+    bytes: bun_core::Utf8Bytes<'a>,
+    /// The value whose `ArrayBuffer` this pinned, unpinned on drop; `ZERO`
+    /// when nothing was pinned.
+    pinned: JSValue,
+}
+
+impl PinnedBytes<'_> {
+    pub const EMPTY: Self = Self {
+        bytes: bun_core::Utf8Bytes::EMPTY,
+        pinned: JSValue::ZERO,
+    };
+
+    #[inline]
+    pub fn slice(&self) -> &[u8] {
+        self.bytes.slice()
+    }
+}
+
+impl core::ops::Deref for PinnedBytes<'_> {
+    type Target = [u8];
+    #[inline]
+    fn deref(&self) -> &[u8] {
+        self.bytes.slice()
+    }
+}
+
+impl Drop for PinnedBytes<'_> {
+    fn drop(&mut self) {
+        if !self.pinned.is_empty() {
+            JSC__JSValue__unpinArrayBuffer(self.pinned);
+        }
+    }
+}
+
+impl MarkedArgumentBuffer {
+    /// `value`'s ArrayBuffer / view bytes, kept readable for as long as this
+    /// argument buffer is borrowed (see [`PinnedBytes`]). `None` for a
+    /// detached buffer or a value that is not a buffer/view at all.
+    pub fn pin_bytes(&self, value: JSValue) -> Option<PinnedBytes<'_>> {
+        let mut ptr: *const u8 = core::ptr::null();
+        let mut len: usize = 0;
+        let kind = JSC__JSValue__borrowBytesForOffThread(value, &mut ptr, &mut len);
+        if kind == 0 {
+            return None;
+        }
+        let bytes: &[u8] = if ptr.is_null() || len == 0 {
+            &[]
+        } else {
+            // SAFETY: for kinds 1..=3 C++ returned the live (ptr, len) of the
+            // buffer's storage; each arm below keeps it put for `'_`.
+            unsafe { core::slice::from_raw_parts(ptr, len) }
+        };
+        Some(match kind {
+            // A `FastTypedArray`'s GC-movable inline vector: copy it now.
+            1 => PinnedBytes {
+                bytes: bun_core::Utf8Bytes::Owned(bytes.to_vec()),
+                pinned: JSValue::ZERO,
+            },
+            // An `ArrayBuffer`, now pinned (non-detachable) until the unpin on
+            // drop; rooted here so the cell that owns the storage outlives it.
+            2 => {
+                self.append(value);
+                PinnedBytes {
+                    bytes: bun_core::Utf8Bytes::Borrowed(bytes),
+                    pinned: value,
+                }
+            }
+            // A bufferless oversize view: the storage is immovable for the
+            // cell's lifetime, and the cell is rooted here.
+            3 => {
+                self.append(value);
+                PinnedBytes {
+                    bytes: bun_core::Utf8Bytes::Borrowed(bytes),
+                    pinned: JSValue::ZERO,
+                }
+            }
+            _ => unreachable!("borrowBytesForOffThread kind {kind}"),
+        })
+    }
 }
 
 impl JSValue {

--- a/src/jsc/auto_flusher.rs
+++ b/src/jsc/auto_flusher.rs
@@ -1,0 +1,102 @@
+//! A refcounted object's entry in its VM's [`DeferredTaskQueue`]
+//! (`EventLoop.deferred_tasks`): the "flush my write buffer after the
+//! microtask queue drains" hook shared by the SQL and Redis clients.
+//!
+//! The queue stores an erased pointer and calls back with it, so the entry
+//! must keep the object alive. [`AutoFlusher`] is that entry as a typed slot
+//! on the object: while registered it holds one ref, released when the object
+//! unregisters itself or when its callback tells the queue to drop the entry.
+//!
+//! [`DeferredTaskQueue`]: bun_event_loop::DeferredTaskQueue::DeferredTaskQueue
+
+use core::cell::Cell;
+use core::ffi::c_void;
+
+use bun_ptr::{AnyRefCounted, RefPtr, ThisPtr};
+
+use crate::virtual_machine::VirtualMachine;
+
+/// A type with an [`AutoFlusher`] slot.
+pub trait AutoFlushTarget: AnyRefCounted + 'static {
+    fn auto_flusher(&self) -> &AutoFlusher<Self>;
+    /// Runs after the microtask queue drains while registered. Return `true`
+    /// to stay registered for the next drain, `false` to drop the entry.
+    fn on_auto_flush(this: ThisPtr<Self>) -> bool;
+}
+
+/// `T`'s deferred-task registration; see the module docs.
+pub struct AutoFlusher<T: AutoFlushTarget> {
+    held: Cell<Option<RefPtr<T>>>,
+}
+
+impl<T: AutoFlushTarget> Default for AutoFlusher<T> {
+    fn default() -> Self {
+        Self {
+            held: Cell::new(None),
+        }
+    }
+}
+
+impl<T: AutoFlushTarget> AutoFlusher<T> {
+    #[inline]
+    pub fn is_registered(&self) -> bool {
+        let held = self.held.take();
+        let registered = held.is_some();
+        self.held.set(held);
+        registered
+    }
+
+    /// Queue `this` for the next deferred-task drain if it is not queued yet.
+    pub fn register(this: ThisPtr<T>, vm: &VirtualMachine) {
+        let slot = this.auto_flusher();
+        if slot.is_registered() {
+            return;
+        }
+        slot.held.set(Some(RefPtr::from_this(this)));
+        let found_existing = vm.event_loop_mut().deferred_tasks.post_task(
+            core::ptr::NonNull::new(this.as_ptr().cast::<c_void>()),
+            run::<T>,
+        );
+        debug_assert!(!found_existing);
+    }
+
+    /// Remove the entry, if any. Releases the ref it held, which may be the
+    /// last one.
+    pub fn unregister(&self, vm: &VirtualMachine) {
+        let Some(held) = self.held.take() else {
+            return;
+        };
+        let removed = vm
+            .event_loop_mut()
+            .deferred_tasks
+            .unregister_task(core::ptr::NonNull::new(held.as_ptr().cast::<c_void>()));
+        debug_assert!(removed);
+        drop(held);
+    }
+}
+
+impl<T: AutoFlushTarget> Drop for AutoFlusher<T> {
+    fn drop(&mut self) {
+        debug_assert!(
+            self.held.get_mut().is_none(),
+            "AutoFlusher dropped while registered"
+        );
+    }
+}
+
+extern "C" fn run<T: AutoFlushTarget>(ctx: *mut c_void) -> bool {
+    // SAFETY: `ctx` is the pointer `register` posted; the queue only calls an
+    // entry that is still registered, and a registered entry holds a ref on
+    // that `T` (`held`), so it is live here.
+    let this = unsafe { ThisPtr::new(ctx.cast::<T>()) };
+    // The callback may `unregister` (releasing `held`) and then drop the last
+    // other ref from re-entrant JS; keep `this` alive until we are done with it.
+    let _alive = RefPtr::from_this(this);
+    let keep = T::on_auto_flush(this);
+    if keep {
+        return true;
+    }
+    // The queue drops the entry on `false`; release the ref it held.
+    drop(this.auto_flusher().held.take());
+    false
+}

--- a/src/jsc/host_fn.rs
+++ b/src/jsc/host_fn.rs
@@ -537,29 +537,64 @@ pub fn host_fn_construct_this<R: IntoHostConstructReturn>(
 // (Phase 3 of `R-2-design.md` deletes them and drops the `_shared` suffix).
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Prototype method (`sharedThis`): `fn(&self, &JSGlobalObject, &CallFrame) -> R`.
+/// How a `sharedThis` prototype method receives the wrapper's `m_ctx`: as a
+/// plain `&T`, or as a [`ThisPtr<T>`](bun_ptr::ThisPtr) when the method needs
+/// the allocation's root pointer (to take/release intrusive refs on itself or
+/// hand itself to a dispatch path that may). The generated thunk is generic
+/// over this, so the method's own signature picks.
+pub trait HostReceiver<'a, T: 'a>: Sized {
+    /// # Safety
+    /// `this` is the live, non-null `m_ctx` of a JS wrapper that stays rooted
+    /// for `'a`.
+    unsafe fn from_m_ctx(this: *mut T) -> Self;
+}
+impl<'a, T: 'a> HostReceiver<'a, T> for &'a T {
+    #[inline(always)]
+    unsafe fn from_m_ctx(this: *mut T) -> Self {
+        // SAFETY: trait contract.
+        unsafe { &*this }
+    }
+}
+impl<'a, T: 'a> HostReceiver<'a, T> for bun_ptr::ThisPtr<T> {
+    #[inline(always)]
+    unsafe fn from_m_ctx(this: *mut T) -> Self {
+        // SAFETY: trait contract.
+        unsafe { bun_ptr::ThisPtr::new(this) }
+    }
+}
+
+/// Prototype method (`sharedThis`) taking `&self` or `this: ThisPtr<Self>`.
+///
+/// # Safety
+/// `this` is the live `m_ctx` of the JS wrapper the call was dispatched on.
 #[track_caller]
 #[inline]
-pub fn host_fn_this_shared<T, R: IntoHostFnReturn>(
-    this: &T,
-    global: &JSGlobalObject,
-    callframe: &CallFrame,
-    f: impl FnOnce(&T, &JSGlobalObject, &CallFrame) -> R,
+pub unsafe fn host_fn_this_ptr<'a, T: 'a, Rcv: HostReceiver<'a, T>, R: IntoHostFnReturn>(
+    this: *mut T,
+    global: &'a JSGlobalObject,
+    callframe: &'a CallFrame,
+    f: impl FnOnce(Rcv, &'a JSGlobalObject, &'a CallFrame) -> R,
 ) -> JSValue {
+    // SAFETY: fn contract.
+    let this = unsafe { Rcv::from_m_ctx(this) };
     host_fn_result(global, || f(this, global, callframe))
 }
 
-/// Prototype method (`sharedThis`, passThis):
-/// `fn(&self, &JSGlobalObject, &CallFrame, JSValue) -> R`.
+/// [`host_fn_this_ptr`] with `passThis`.
+///
+/// # Safety
+/// As [`host_fn_this_ptr`].
 #[track_caller]
 #[inline]
-pub fn host_fn_this_value_shared<T, R: IntoHostFnReturn>(
-    this: &T,
-    global: &JSGlobalObject,
-    callframe: &CallFrame,
+pub unsafe fn host_fn_this_value_ptr<'a, T: 'a, Rcv: HostReceiver<'a, T>, R: IntoHostFnReturn>(
+    this: *mut T,
+    global: &'a JSGlobalObject,
+    callframe: &'a CallFrame,
     js_this: JSValue,
-    f: impl FnOnce(&T, &JSGlobalObject, &CallFrame, JSValue) -> R,
+    f: impl FnOnce(Rcv, &'a JSGlobalObject, &'a CallFrame, JSValue) -> R,
 ) -> JSValue {
+    // SAFETY: fn contract.
+    let this = unsafe { Rcv::from_m_ctx(this) };
     host_fn_result(global, || f(this, global, callframe, js_this))
 }
 

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1233,7 +1233,10 @@ pub use self::js_property_iterator::{
 #[path = "event_loop.rs"]
 pub mod event_loop;
 pub use self::event_loop as EventLoop;
+pub mod auto_flusher;
 pub mod job;
+pub use self::array_buffer::PinnedBytes;
+pub use self::auto_flusher::{AutoFlushTarget, AutoFlusher};
 pub use self::event_loop::{
     AnyEventLoop, AnyTaskWithExtraContext, ConcurrentCppTask, ConcurrentTask, CppTask,
     DeferredTaskQueue, EventLoopHandle, EventLoopTask, GarbageCollectionController, ManagedTask,

--- a/src/jsc_macros/lib.rs
+++ b/src/jsc_macros/lib.rs
@@ -136,7 +136,22 @@ fn expand_host_fn(args: &HostFnArgs, func: &ItemFn) -> syn::Result<TokenStream2>
         .inputs
         .first()
         .is_some_and(|a| matches!(a, FnArg::Receiver(r) if r.mutability.is_none()));
-    let this_reborrow = if receiver_is_shared {
+    // A typed `this: ThisPtr<Self>` first parameter gets the root pointer
+    // wrapped instead of reborrowed.
+    let first_is_this_ptr = func.sig.inputs.first().is_some_and(|a| match a {
+        FnArg::Typed(pt) => match &*pt.ty {
+            syn::Type::Path(tp) => tp
+                .path
+                .segments
+                .last()
+                .is_some_and(|seg| seg.ident == "ThisPtr"),
+            _ => false,
+        },
+        _ => false,
+    });
+    let this_reborrow = if first_is_this_ptr {
+        quote! { let __t = unsafe { ::bun_ptr::ThisPtr::new(__this) }; }
+    } else if receiver_is_shared {
         quote! { let __t = unsafe { &*__this }; }
     } else {
         quote! { let __t = unsafe { &mut *__this }; }

--- a/src/jsc_macros/lib.rs
+++ b/src/jsc_macros/lib.rs
@@ -118,11 +118,25 @@ fn expand_host_fn(args: &HostFnArgs, func: &ItemFn) -> syn::Result<TokenStream2>
     // shim is emitted *inside* the surrounding `impl` block so it can name
     // `Self`; the C-ABI signature passes `*mut Self` as the first argument
     // (the codegen'd C++ passes `m_ctx`).
-    let has_receiver = func
-        .sig
-        .inputs
-        .first()
-        .is_some_and(|a| matches!(a, FnArg::Receiver(_)));
+    // A typed `this: ThisPtr<Self>` first parameter gets the root pointer
+    // wrapped instead of reborrowed, and counts as a receiver.
+    let first_is_this_ptr = func.sig.inputs.first().is_some_and(|a| match a {
+        FnArg::Typed(pt) => match &*pt.ty {
+            syn::Type::Path(tp) => tp
+                .path
+                .segments
+                .last()
+                .is_some_and(|seg| seg.ident == "ThisPtr"),
+            _ => false,
+        },
+        _ => false,
+    });
+    let has_receiver = first_is_this_ptr
+        || func
+            .sig
+            .inputs
+            .first()
+            .is_some_and(|a| matches!(a, FnArg::Receiver(_)));
 
     // R-2 (PORT_NOTES_PLAN): for `&self` receivers, materialise `&*__this`
     // (NOT `&mut *__this`). A method that calls back into JS can be re-entered
@@ -136,19 +150,6 @@ fn expand_host_fn(args: &HostFnArgs, func: &ItemFn) -> syn::Result<TokenStream2>
         .inputs
         .first()
         .is_some_and(|a| matches!(a, FnArg::Receiver(r) if r.mutability.is_none()));
-    // A typed `this: ThisPtr<Self>` first parameter gets the root pointer
-    // wrapped instead of reborrowed.
-    let first_is_this_ptr = func.sig.inputs.first().is_some_and(|a| match a {
-        FnArg::Typed(pt) => match &*pt.ty {
-            syn::Type::Path(tp) => tp
-                .path
-                .segments
-                .last()
-                .is_some_and(|seg| seg.ident == "ThisPtr"),
-            _ => false,
-        },
-        _ => false,
-    });
     let this_reborrow = if first_is_this_ptr {
         quote! { let __t = unsafe { ::bun_ptr::ThisPtr::new(__this) }; }
     } else if receiver_is_shared {

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -1506,18 +1506,22 @@ impl Timer {
             panic!("internal error: uv_timer_stop failed");
         }
     }
-    /// Milliseconds until the timer is due (0 if overdue or stopped).
+    /// Milliseconds until the timer is due (0 if overdue, stopped, or never `init`ed).
     #[inline]
     pub fn get_due_in(&self) -> u64 {
-        debug_assert!(!self.loop_.is_null());
-        // SAFETY: timer was `init`ed (reads `self.timeout` and `loop_->time`).
+        if self.loop_.is_null() {
+            return 0;
+        }
+        // SAFETY: `loop_` is set, so the timer was `init`ed (reads `self.timeout` and `loop_->time`).
         unsafe { uv_timer_get_due_in(self) }
     }
-    /// `uv_update_time` on the loop this timer was `init`ed on.
+    /// `uv_update_time` on the loop this timer was `init`ed on; no-op before `init`.
     #[inline]
     pub fn update_loop_time(&self) {
-        debug_assert!(!self.loop_.is_null());
-        // SAFETY: timer was `init`ed, so `loop_` is the live loop it is registered on.
+        if self.loop_.is_null() {
+            return;
+        }
+        // SAFETY: `loop_` is set, so it is the live loop this timer was `init`ed on.
         unsafe { uv_update_time(self.loop_) }
     }
 }

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -1506,6 +1506,20 @@ impl Timer {
             panic!("internal error: uv_timer_stop failed");
         }
     }
+    /// Milliseconds until the timer is due (0 if overdue or stopped).
+    #[inline]
+    pub fn get_due_in(&self) -> u64 {
+        debug_assert!(!self.loop_.is_null());
+        // SAFETY: timer was `init`ed (reads `self.timeout` and `loop_->time`).
+        unsafe { uv_timer_get_due_in(self) }
+    }
+    /// `uv_update_time` on the loop this timer was `init`ed on.
+    #[inline]
+    pub fn update_loop_time(&self) {
+        debug_assert!(!self.loop_.is_null());
+        // SAFETY: timer was `init`ed, so `loop_` is the live loop it is registered on.
+        unsafe { uv_update_time(self.loop_) }
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/ptr/js_cell.rs
+++ b/src/ptr/js_cell.rs
@@ -73,6 +73,13 @@ impl<T> JsCell<T> {
         unsafe { &mut *self.0.get() }
     }
 
+    /// Mutable access through an exclusive borrow of the cell itself — no
+    /// aliasing is possible, so this is plain [`UnsafeCell::get_mut`].
+    #[inline(always)]
+    pub fn get_mut_unique(&mut self) -> &mut T {
+        self.0.get_mut()
+    }
+
     /// Closure-scoped mutable access. The `&mut T` cannot escape `f`, so the
     /// only way to violate the aliasing invariant is for `f` itself to
     /// re-enter a path that touches this same cell — which the

--- a/src/ptr/js_cell.rs
+++ b/src/ptr/js_cell.rs
@@ -41,6 +41,13 @@ impl<T> JsCell<T> {
         Self(core::cell::UnsafeCell::new(value))
     }
 
+    /// View exclusively-borrowed storage as a cell (like `Cell::from_mut`).
+    #[inline(always)]
+    pub fn from_mut(value: &mut T) -> &mut JsCell<T> {
+        // SAFETY: `JsCell<T>` is `repr(transparent)` over `UnsafeCell<T>`.
+        unsafe { &mut *core::ptr::from_mut(core::cell::UnsafeCell::from_mut(value)).cast() }
+    }
+
     /// Shared-reference read. Caller must not hold a live `get_mut()` borrow
     /// across this call (single-JS-thread reentrancy makes overlap rare but
     /// possible — keep borrows short).

--- a/src/ptr/js_cell.rs
+++ b/src/ptr/js_cell.rs
@@ -41,13 +41,6 @@ impl<T> JsCell<T> {
         Self(core::cell::UnsafeCell::new(value))
     }
 
-    /// View exclusively-borrowed storage as a cell (like `Cell::from_mut`).
-    #[inline(always)]
-    pub fn from_mut(value: &mut T) -> &mut JsCell<T> {
-        // SAFETY: `JsCell<T>` is `repr(transparent)` over `UnsafeCell<T>`.
-        unsafe { &mut *core::ptr::from_mut(core::cell::UnsafeCell::from_mut(value)).cast() }
-    }
-
     /// Shared-reference read. Caller must not hold a live `get_mut()` borrow
     /// across this call (single-JS-thread reentrancy makes overlap rare but
     /// possible — keep borrows short).

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1800,11 +1800,9 @@ fn get_valkey_default_client(global_this: &JSGlobalObject, _: &JSObject) -> JSVa
         }
     };
 
-    let as_js = JSValkeyClient::ptr_to_js(valkey, global_this);
+    let as_js = JSValkeyClient::ptr_to_js(valkey.as_ptr(), global_this);
 
-    // SAFETY: `valkey` is a fresh heap allocation owned by the JS wrapper; we
-    // hold the only reference for field init below.
-    let valkey_ref = unsafe { &*valkey };
+    let valkey_ref: &JSValkeyClient = &valkey;
     valkey_ref.this_value.set(jsc::JsRef::init_weak(as_js));
     match SubscriptionCtx::init(valkey_ref) {
         Ok(ctx) => valkey_ref._subscription_ctx.set(ctx),

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1852,7 +1852,7 @@ fn spawn_maybe_sync(
                 // comparable with `now`.
                 if abort_signal_timeout.event_loop_timer.state
                     == crate::timer::EventLoopTimerState::ACTIVE
-                    && abort_signal_timeout.event_loop_timer.in_heap
+                    && abort_signal_timeout.event_loop_timer.in_heap()
                         == crate::timer::InHeap::Regular
                 {
                     let next = &abort_signal_timeout.event_loop_timer.next;

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -626,14 +626,18 @@ impl Subprocess<'_> {
             return;
         }
         self.event_loop_timer_refd.set(refd);
-        let uws_loop = self.global_this().bun_vm().uws_loop();
         let delta: i32 = if refd { 1 } else { -1 };
-        Self::timer_all().increment_timer_ref(delta, uws_loop);
+        Self::timer_all().increment_timer_ref(delta);
     }
 
     #[inline]
-    fn timer_all() -> &'static mut crate::timer::All {
-        crate::jsc_hooks::timer_all_mut()
+    fn timer_all() -> &'static crate::timer::All {
+        crate::jsc_hooks::timer_all()
+    }
+
+    #[inline]
+    fn timer_ref(&self) -> crate::timer::TimerRef {
+        crate::timer::TimerRef::new(self, |p| &p.event_loop_timer)
     }
 
     pub(crate) fn timeout_callback(&self) {
@@ -949,7 +953,7 @@ impl Subprocess<'_> {
         // kept explicit at the tail for now (no early returns in this body).
 
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
-            Self::timer_all().remove(self.event_loop_timer.as_ptr());
+            Self::timer_all().remove(self.timer_ref());
         }
         self.set_event_loop_timer_refd(false);
 
@@ -1321,7 +1325,7 @@ impl Subprocess<'_> {
             self.deref();
         }
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
-            Self::timer_all().remove(self.event_loop_timer.as_ptr());
+            Self::timer_all().remove(self.timer_ref());
         }
         self.set_event_loop_timer_refd(false);
 

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -40,7 +40,7 @@ use crate::api::bun::process::SpawnResultExt as _;
 use crate::api::bun::process::{
     self as spawn, Process, ProcessHandle, Rusage, SpawnOptions, Status,
 };
-use crate::timer::{EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
+use crate::timer::{EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, TimerRef};
 use bun_core::ZStr;
 use bun_core::strings;
 use bun_io::pipe_reader::BufferedReaderParent;
@@ -62,7 +62,7 @@ fn vm_mut<'a>() -> &'a mut VirtualMachine {
     VirtualMachine::get_mut()
 }
 
-use crate::jsc_hooks::timer_all_mut as timer_all;
+use crate::jsc_hooks::timer_all;
 
 // ============================================================================
 // CronJobBase — shared base for CronRegisterJob and CronRemoveJob
@@ -1434,11 +1434,16 @@ impl CronJob {
         }
     }
 
+    #[inline]
+    fn timer_ref(&self) -> TimerRef {
+        TimerRef::new(self, |job| &job.event_loop_timer)
+    }
+
     /// Idempotent — every step checks its own state.
     fn stop_internal(&self, _vm: &VirtualMachine) {
         self.stopped.set(true);
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
-            timer_all().remove(self.event_loop_timer.as_ptr());
+            timer_all().remove(self.timer_ref());
         }
         self.poll_ref.with_mut(|p| p.unref(bun_io::js_vm_ctx()));
         self.maybe_downgrade();
@@ -1541,12 +1546,7 @@ impl CronJob {
         let Some(next_time) = this.compute_next_timespec() else {
             return Self::finish_deferred_stop(this, vm);
         };
-        timer_all().update(
-            this.event_loop_timer
-                .as_ptr()
-                .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>(),
-            &next_time,
-        );
+        timer_all().update(this.timer_ref(), &next_time);
     }
 
     /// The tick's callback runs here as a top-level call (what it throws
@@ -1754,12 +1754,7 @@ impl CronJob {
         );
 
         job.poll_ref.with_mut(|p| p.ref_(bun_io::js_vm_ctx()));
-        timer_all().update(
-            job.event_loop_timer
-                .as_ptr()
-                .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>(),
-            &next_time,
-        );
+        timer_all().update(job.timer_ref(), &next_time);
 
         Ok(js_value)
     }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1070,8 +1070,10 @@ impl Drop for DevServer {
         }
 
         if self.memory_visualizer_timer.state == EventLoopTimerState::ACTIVE {
-            let timer_ptr: *mut EventLoopTimer = &raw mut self.memory_visualizer_timer;
-            self.timer_heap().remove(timer_ptr);
+            let heap = self.timer_heap();
+            heap.remove(crate::timer::TimerRef::from_mut(self, |d| {
+                &mut d.memory_visualizer_timer
+            }));
         }
         self.graph_safety_lock.lock();
         // Hand ownership of the heap allocation to the watcher thread (which frees it in
@@ -1115,8 +1117,11 @@ impl Drop for DevServer {
             value.ref_count = 0;
         }
         if self.source_maps.weak_ref_sweep_timer.state == EventLoopTimerState::ACTIVE {
-            let timer_ptr: *mut EventLoopTimer = &raw mut self.source_maps.weak_ref_sweep_timer;
-            self.timer_heap().remove(timer_ptr);
+            let heap = self.timer_heap();
+            heap.remove(crate::timer::TimerRef::from_mut(
+                &mut self.source_maps,
+                |s| &mut s.weak_ref_sweep_timer,
+            ));
         }
 
         // `Watcher::shutdown` serialises with `dispatch_file_updates` on
@@ -5494,8 +5499,8 @@ impl DevServer {
     pub fn emit_visualizer_message_if_needed(&mut self) {}
 
     #[inline]
-    fn timer_heap(&self) -> &mut crate::timer::All {
-        crate::jsc_hooks::timer_all_mut()
+    fn timer_heap(&self) -> &'static crate::timer::All {
+        crate::jsc_hooks::timer_all()
     }
 
     pub fn emit_memory_visualizer_message_timer(

--- a/src/runtime/bake/dev_server/hmr_socket.rs
+++ b/src/runtime/bake/dev_server/hmr_socket.rs
@@ -127,20 +127,16 @@ impl HmrSocket {
                                         // Note (jsc/runtime crate cycle): `vm.timer` is `()` on the
                                         // low-tier `VirtualMachine`; the real `timer::All`
                                         // lives in `RuntimeState` (see jsc_hooks.rs).
-                                        let state = crate::jsc_hooks::runtime_state();
                                         let next = bun_core::Timespec::ms_from_now(
                                             bun_core::TimespecMockMode::ForceRealTime,
                                             1000,
                                         );
-                                        // SAFETY: `runtime_state()` is non-null after
-                                        // `bun_runtime::init()`; JS-thread only, sole
-                                        // `&mut` to `timer` in this scope.
-                                        unsafe {
-                                            (*state).timer.update(
-                                                &raw mut dev.memory_visualizer_timer,
-                                                &next,
-                                            );
-                                        }
+                                        crate::jsc_hooks::timer_all().update(
+                                            crate::timer::TimerRef::from_mut(dev, |d| {
+                                                &mut d.memory_visualizer_timer
+                                            }),
+                                            &next,
+                                        );
                                     }
                                 }
                                 _ => {}
@@ -310,14 +306,10 @@ impl HmrSocket {
                 if dev.emit_incremental_visualizer_events == 0
                     && dev.memory_visualizer_timer.state == EventLoopTimerState::ACTIVE
                 {
-                    // Note (jsc/runtime crate cycle): `vm.timer` is `()` on the low-tier
-                    // `VirtualMachine`; the real `timer::All` lives in `RuntimeState`.
-                    let state = crate::jsc_hooks::runtime_state();
-                    // SAFETY: `runtime_state()` is non-null after `bun_runtime::init()`;
-                    // JS-thread only, sole `&mut` to `timer` in this scope.
-                    unsafe {
-                        (*state).timer.remove(&raw mut dev.memory_visualizer_timer);
-                    }
+                    crate::jsc_hooks::timer_all()
+                        .remove(crate::timer::TimerRef::from_mut(dev, |d| {
+                            &mut d.memory_visualizer_timer
+                        }));
                 }
             }
         }

--- a/src/runtime/bake/dev_server/source_map_store.rs
+++ b/src/runtime/bake/dev_server/source_map_store.rs
@@ -452,8 +452,13 @@ impl SourceMapStore {
     }
 
     #[inline]
-    fn timer_all<'a>() -> &'a mut crate::timer::All {
-        crate::jsc_hooks::timer_all_mut()
+    fn timer_all() -> &'static crate::timer::All {
+        crate::jsc_hooks::timer_all()
+    }
+
+    #[inline]
+    fn sweep_timer_ref(&mut self) -> crate::timer::TimerRef {
+        crate::timer::TimerRef::from_mut(self, |s| &mut s.weak_ref_sweep_timer)
     }
 
     pub(crate) fn put_or_increment_ref_count(
@@ -535,7 +540,7 @@ impl SourceMapStore {
                 if self.weak_ref_sweep_timer.state == EventLoopTimerState::ACTIVE
                     && self.weak_ref_sweep_timer.next.sec == first.expire
                 {
-                    Self::timer_all().remove(core::ptr::addr_of_mut!(self.weak_ref_sweep_timer));
+                    Self::timer_all().remove(self.sweep_timer_ref());
                 }
             }
         }
@@ -550,7 +555,7 @@ impl SourceMapStore {
 
         if self.weak_ref_sweep_timer.state != EventLoopTimerState::ACTIVE {
             map_log!("arming weak ref sweep timer");
-            Self::timer_all().update(core::ptr::addr_of_mut!(self.weak_ref_sweep_timer), &expire);
+            Self::timer_all().update(self.sweep_timer_ref(), &expire);
         }
         map_log!("addWeakRef {:x}, ref_count: {}", key.get(), entry_ref_count);
     }
@@ -644,7 +649,7 @@ impl SourceMapStore {
                 store.weak_refs.unget(&[item]).expect("unreachable"); // space exists since the last item was just removed.
                 store.weak_ref_sweep_timer.state = EventLoopTimerState::FIRED;
                 Self::timer_all().update(
-                    core::ptr::addr_of_mut!(store.weak_ref_sweep_timer),
+                    store.sweep_timer_ref(),
                     &Timespec {
                         sec: item.expire + 1,
                         nsec: 0,

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -893,6 +893,18 @@ macro_rules! timer_owner_this {
     }};
 }
 
+/// Fire the `WTFTimer` whose slot `t` was just popped from `All.wtf_timers`.
+/// Does not read the slot (a GC thread may be re-arming it under the lock).
+pub(crate) fn fire_wtf_timer(t: TimerRef) {
+    use crate::timer::WTFTimer;
+    // SAFETY: only `WTFTimer`s are linked into `All.wtf_timers` (`wtf_arm`),
+    // and the C++ `TimerBase` that owns it is alive while it is scheduled. The
+    // borrow ends before `fire`, which may destroy it.
+    let timer = unsafe { &*bun_core::from_field_ptr!(WTFTimer, event_loop_timer, t.as_ptr()) };
+    let run_loop_timer = timer.take_for_fire();
+    crate::timer::wtf_timer::RunLoopTimer::fire(run_loop_timer);
+}
+
 /// The tag→`container_of` match that fires a due timer.
 ///
 /// Reached from [`crate::timer::All::drain_timers`] (every due heap timer),
@@ -907,7 +919,7 @@ macro_rules! timer_owner_this {
 /// `t` was just popped from a heap; the handler may free its owner, so `t` is
 /// dead once this returns.
 pub(crate) fn fire_timer(t: TimerRef, now: &ElTimespec, vm: &VirtualMachine) -> JsResult<()> {
-    use crate::timer::{ImmediateObject, TimeoutObject, TimerObject, WTFTimer};
+    use crate::timer::{ImmediateObject, TimeoutObject, TimerObject};
 
     /// Recover the embedding container from `t` (the popped timer slot).
     macro_rules! owner {
@@ -956,11 +968,7 @@ pub(crate) fn fire_timer(t: TimerRef, now: &ElTimespec, vm: &VirtualMachine) -> 
             Ok(())
         }
         EventLoopTimerTag::WTFTimer => {
-            let c: *mut WTFTimer = owner!(WTFTimer, event_loop_timer);
-            // SAFETY: `TimerOwner` contract — `c` is a live `WTFTimer`. The
-            // borrow ends before `fire`, which may destroy it.
-            let run_loop_timer = unsafe { &*c }.take_for_fire();
-            crate::timer::wtf_timer::RunLoopTimer::fire(run_loop_timer);
+            fire_wtf_timer(t);
             Ok(())
         }
         EventLoopTimerTag::AbortSignalTimeout => {
@@ -1083,6 +1091,7 @@ pub(crate) fn fire_timer(t: TimerRef, now: &ElTimespec, vm: &VirtualMachine) -> 
             Ok(())
         }
         EventLoopTimerTag::DevServerMemoryVisualizerTick => {
+            t.set_state(bun_event_loop::EventLoopTimer::State::FIRED);
             // SAFETY: per fn contract; `t` is the `memory_visualizer_timer`
             // field of a live DevServer.
             DevServer::emit_memory_visualizer_message_timer(unsafe { &mut *t.as_ptr() }, unsafe {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -275,13 +275,6 @@ pub(crate) fn run_task(
             // SAFETY: boxed in `on_raw_libuv_complete`; the arm consumes it.
             unsafe { bun_core::heap::take(cast_ptr!(crate::dns_jsc::LibuvCompleteHolder)) }.run();
         }
-        task_tag::ValkeyDeferredClose => {
-            // SAFETY: boxed at the enqueue site; the arm consumes it.
-            unsafe {
-                bun_core::heap::take(cast_ptr!(crate::valkey_jsc::js_valkey::ValkeyDeferredClose))
-            }
-            .run();
-        }
         task_tag::StatWatcherTimerUpdate => {
             // SAFETY: boxed in `schedule_timer_update`; the arm consumes it.
             unsafe {
@@ -589,7 +582,7 @@ fn run_task_cold(task: Task) {
 /// `release_task_unrun` track `bun_event_loop::task_tag::COUNT`. Bump when
 /// adding a variant — and give it an arm in both.
 const _: () = assert!(
-    task_tag::COUNT == 61,
+    task_tag::COUNT == 60,
     "dispatch::run_task / release_task_unrun arm count out of sync with bun_event_loop::task_tag",
 );
 
@@ -1037,44 +1030,38 @@ pub(crate) fn fire_timer(t: TimerRef, now: &ElTimespec, vm: &VirtualMachine) -> 
             }
         }
         EventLoopTimerTag::PostgresSQLConnectionTimeout => {
-            // SAFETY: §Dispatch — tag set together with the container at
-            // construction; `t` is the connection's `timer` field.
-            let container = unsafe { PostgresSQLConnection::from_timer_ptr(t.as_ptr()) };
-            // SAFETY: per fn contract.
-            unsafe { (*container).on_connection_timeout() };
+            PostgresSQLConnection::on_connection_timeout(&*timer_owner_this!(
+                PostgresSQLConnection,
+                timer,
+                t
+            ));
             Ok(())
         }
         EventLoopTimerTag::PostgresSQLConnectionMaxLifetime => {
-            // SAFETY: §Dispatch — `t` is the connection's `max_lifetime_timer`.
-            let container =
-                unsafe { PostgresSQLConnection::from_max_lifetime_timer_ptr(t.as_ptr()) };
-            // SAFETY: per fn contract.
-            unsafe { (*container).on_max_lifetime_timeout() };
+            PostgresSQLConnection::on_max_lifetime_timeout(&*timer_owner_this!(
+                PostgresSQLConnection,
+                max_lifetime_timer,
+                t
+            ));
             Ok(())
         }
         EventLoopTimerTag::MySQLConnectionTimeout => {
-            // SAFETY: §Dispatch — `t` is the connection's `timer` field.
-            let container = unsafe { MySQLConnection::from_timer_ptr(t.as_ptr()) };
-            // SAFETY: per fn contract.
-            unsafe { (*container).on_connection_timeout() };
+            MySQLConnection::on_connection_timeout(&*timer_owner_this!(MySQLConnection, timer, t));
             Ok(())
         }
         EventLoopTimerTag::MySQLConnectionMaxLifetime => {
-            // SAFETY: §Dispatch — `t` is the connection's `max_lifetime_timer`.
-            let container = unsafe { MySQLConnection::from_max_lifetime_timer_ptr(t.as_ptr()) };
-            // SAFETY: per fn contract.
-            unsafe { (*container).on_max_lifetime_timeout() };
+            MySQLConnection::on_max_lifetime_timeout(&*timer_owner_this!(
+                MySQLConnection,
+                max_lifetime_timer,
+                t
+            ));
             Ok(())
         }
         EventLoopTimerTag::ValkeyConnectionTimeout => {
-            let container = owner!(Valkey, timer);
-            // SAFETY: per fn contract.
-            unsafe { (*container).on_connection_timeout() }
+            Valkey::on_connection_timeout(timer_owner_this!(Valkey, timer, t))
         }
         EventLoopTimerTag::ValkeyConnectionReconnect => {
-            let container = owner!(Valkey, reconnect_timer);
-            // SAFETY: per fn contract.
-            unsafe { (*container).on_reconnect_timer() }
+            Valkey::on_reconnect_timer(timer_owner_this!(Valkey, reconnect_timer, t))
         }
         EventLoopTimerTag::SubprocessTimeout => {
             timer_arm!(Subprocess<'_>, event_loop_timer, |c, _now, _vm| (*c)
@@ -1396,9 +1383,6 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
         task_tag::ShellAsyncCpTask => release!(crate::node::fs::ShellAsyncCpTask),
         task_tag::StreamPending => release!(StreamPending),
         task_tag::ThreadSafeFunction => release!(ThreadSafeFunction),
-        task_tag::ValkeyDeferredClose => {
-            release!(crate::valkey_jsc::js_valkey::ValkeyDeferredClose)
-        }
         // ── Windows-only producers ───────────────────────────────────────
         task_tag::GetAddrInfoLibuvComplete => {
             #[cfg(windows)]

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -907,9 +907,9 @@ pub(crate) fn fire_wtf_timer(t: TimerRef) {
 
 /// The tag→`container_of` match that fires a due timer.
 ///
-/// Reached from [`crate::timer::All::drain_timers`] (every due heap timer),
-/// [`crate::timer::All::get_timeout`] (WTFTimer side-effect) and the fake
-/// clock (`FakeTimers::fire`).
+/// Reached from [`crate::timer::All::drain_timers`] (every due heap timer)
+/// and the fake clock (`FakeTimers::fire`); `WTFTimer`s live in their own
+/// heap and go through [`fire_wtf_timer`] instead.
 ///
 /// Each arm is the owner's timer entry with its result surfaced: an owner
 /// returns the exception it left pending and never reports it; the drain loop
@@ -967,10 +967,7 @@ pub(crate) fn fire_timer(t: TimerRef, now: &ElTimespec, vm: &VirtualMachine) -> 
             );
             Ok(())
         }
-        EventLoopTimerTag::WTFTimer => {
-            fire_wtf_timer(t);
-            Ok(())
-        }
+        EventLoopTimerTag::WTFTimer => unreachable!("WTFTimers are only in All::wtf_timers"),
         EventLoopTimerTag::AbortSignalTimeout => {
             timer_arm!(AbortSignalTimeout, event_loop_timer, |c, _now, vm| {
                 AbortSignalTimeout::run(c, vm)

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -35,7 +35,7 @@ use bun_event_loop::{Task, task_tag};
 use bun_io::posix_event_loop::{FilePoll, Flags as PollFlag, poll_tag};
 
 use bun_event_loop::EventLoopTimer::{
-    EventLoopTimer, Tag as EventLoopTimerTag, Timespec as ElTimespec,
+    EventLoopTimer, Tag as EventLoopTimerTag, TimerRef, Timespec as ElTimespec,
 };
 
 use bun_jsc::event_loop::{EventLoop, Stopped};
@@ -829,9 +829,9 @@ unsafe fn __bun_io_pollable_on_io_error(
 // `bun_jsc::event_loop` extern impls (link-time)
 // ════════════════════════════════════════════════════════════════════════════
 
-/// `__bun_run_immediate_task` body — cast the low-tier erased `*mut ()` to the
-/// real `crate::timer::ImmediateObject` and run the task (low tier stores
-/// `*mut ()`, high tier owns the cast).
+/// `__bun_run_immediate_task` body — recover the queued
+/// `crate::timer::ImmediateObject` from the low tier's erased `*mut ()` and
+/// run it.
 ///
 /// # Safety
 /// `task` was produced by `enqueue_immediate_task` from a live
@@ -841,19 +841,15 @@ unsafe fn __bun_run_immediate_task(
     task: *mut (),
     vm: *mut bun_jsc::virtual_machine::VirtualMachine,
 ) -> bool {
-    // SAFETY: per fn contract — the only producer (`TimerObjectInternals::init`)
-    // stores a `*mut crate::timer::ImmediateObject`, so the cast is the identity.
-    unsafe {
-        crate::timer::ImmediateObject::run_immediate_task(
-            task.cast::<crate::timer::ImmediateObject>(),
-            vm,
-        )
-    }
+    // SAFETY: per fn contract — the only producer (`ImmediateObject::init`)
+    // stores a `ThisPtr<ImmediateObject>` the queue holds a ref on.
+    let (this, vm) = unsafe { (bun_ptr::ThisPtr::new(task.cast()), &*vm) };
+    crate::timer::ImmediateObject::run_immediate_task(this, vm)
 }
 
 /// `__bun_cancel_pending_immediate` body — VM-teardown release of the event
-/// loop's `+1` ref on a still-queued `ImmediateObject` (low tier stores
-/// `*mut ()`, high tier owns the cast). Does not run the callback.
+/// loop's `+1` ref on a still-queued `ImmediateObject`. Does not run the
+/// callback.
 ///
 /// # Safety
 /// `task` was produced by `enqueue_immediate_task` from a live
@@ -864,115 +860,108 @@ unsafe fn __bun_cancel_pending_immediate(
     task: *mut (),
     vm: *mut bun_jsc::virtual_machine::VirtualMachine,
 ) {
-    // SAFETY: per fn contract — the only producer (`TimerObjectInternals::init`)
-    // stores a `*mut crate::timer::ImmediateObject`, so the cast is the identity.
-    unsafe {
-        crate::timer::ImmediateObject::cancel_pending(
-            task.cast::<crate::timer::ImmediateObject>(),
-            vm,
-        );
-    }
+    // SAFETY: per fn contract — see `__bun_run_immediate_task`.
+    let (this, vm) = unsafe { (bun_ptr::ThisPtr::new(task.cast()), &*vm) };
+    crate::timer::ImmediateObject::cancel_pending(this, vm);
 }
 
-/// `__bun_run_wtf_timer` body — cast the low-tier erased `*mut ()` to the real
-/// `crate::timer::WTFTimer` and fire it.
+/// `__bun_run_wtf_timer` body — recover the `crate::timer::WTFTimer` from the
+/// low tier's erased `*mut ()` and fire it.
 ///
 /// # Safety
 /// `timer` was published by `WTFTimer::update` into `imminent_gc_timer` and
 /// remains live until consumed; `vm` is the live per-thread VM.
 #[unsafe(no_mangle)]
-unsafe fn __bun_run_wtf_timer(timer: *mut (), vm: *mut bun_jsc::virtual_machine::VirtualMachine) {
+unsafe fn __bun_run_wtf_timer(timer: *mut (), _vm: *mut bun_jsc::virtual_machine::VirtualMachine) {
     // SAFETY: per fn contract — the only producer (`WTFTimer::update`) stores a
-    // `*mut crate::timer::WTFTimer`, so the cast is the identity.
-    let real = timer.cast::<crate::timer::WTFTimer>();
-    // SAFETY: per fn contract — `real` is live until consumed; `vm` is the
-    // per-thread VM. `run` may re-enter `(*runtime_state()).timer.remove()`;
-    // no `&mut` held here.
-    unsafe { crate::timer::WTFTimer::run(real, vm) }
+    // live `*mut crate::timer::WTFTimer`. The borrow ends before `fire`, which
+    // may destroy the timer.
+    let run_loop_timer = unsafe { &*timer.cast::<crate::timer::WTFTimer>() }.take_for_run();
+    crate::timer::wtf_timer::RunLoopTimer::fire(run_loop_timer);
 }
 
 // ════════════════════════════════════════════════════════════════════════════
 // EventLoopTimer dispatch
 // ════════════════════════════════════════════════════════════════════════════
 
-/// `__bun_fire_timer` body — the tag→`container_of` match for
-/// [`EventLoopTimer::fire`].
+/// Recover a JS-timer owner from its popped/linked slot as a dispatch handle.
+macro_rules! timer_owner_this {
+    ($ty:ty, $field:ident, $t:expr) => {{
+        // SAFETY: `TimerOwner` contract — the slot's tag names `$ty.$field`
+        // and its owner is alive (linked, or being fired/cancelled right now).
+        unsafe { bun_ptr::ThisPtr::<$ty>::new(bun_core::from_field_ptr!($ty, $field, $t.as_ptr())) }
+    }};
+}
+
+/// The tag→`container_of` match that fires a due timer.
 ///
-/// Reached from [`crate::timer::All::drain_timers`] (every due heap timer) and
-/// [`crate::timer::All::get_timeout`] (WTFTimer side-effect).
+/// Reached from [`crate::timer::All::drain_timers`] (every due heap timer),
+/// [`crate::timer::All::get_timeout`] (WTFTimer side-effect) and the fake
+/// clock (`FakeTimers::fire`).
 ///
 /// Each arm is the owner's timer entry with its result surfaced: an owner
 /// returns the exception it left pending and never reports it; the drain loop
 /// (`All::drain_timers`) folds every timer's result in one place. Owners whose
 /// entry cannot enter JS return `()` (`timer_arm!` makes that `Ok(())`).
 ///
-/// # Safety
-/// `t` points at a live [`EventLoopTimer`] just popped from `All.timers`;
-/// `now` is the snapshot taken by `All::next`; `vm` is the erased
-/// `*mut VirtualMachine`. The handler may free the container — do not touch
-/// `t` after the per-arm call returns.
-#[unsafe(no_mangle)]
-pub(crate) unsafe fn __bun_fire_timer(
-    t: *mut EventLoopTimer,
-    now: *const ElTimespec,
-    vm: *mut (),
-) -> bun_event_loop::JsResult<()> {
-    use crate::timer::{ImmediateObject, TimeoutObject, TimerObjectInternals, WTFTimer};
+/// `t` was just popped from a heap; the handler may free its owner, so `t` is
+/// dead once this returns.
+pub(crate) fn fire_timer(t: TimerRef, now: &ElTimespec, vm: &VirtualMachine) -> JsResult<()> {
+    use crate::timer::{ImmediateObject, TimeoutObject, TimerObject, WTFTimer};
 
     /// Recover the embedding container from `t` (the popped timer slot).
     macro_rules! owner {
         ($ty:ty, $field:ident) => {{
-            // SAFETY: §Dispatch — `t.tag` was set together with the container
-            // at construction; tag uniquely identifies the embedding type and
-            // `$field` is the `EventLoopTimer` slot `t` points into.
-            unsafe { bun_core::from_field_ptr!($ty, $field, t) }
+            // SAFETY: `TimerOwner` contract — `t.tag` was set together with the
+            // container at construction; tag uniquely identifies the embedding
+            // type and `$field` is the `EventLoopTimer` slot `t` points into.
+            unsafe { bun_core::from_field_ptr!($ty, $field, t.as_ptr()) }
         }};
     }
-    // SAFETY: per fn contract — `t` is live for the dispatch read.
-    let tag = unsafe { (*t).tag };
-    let vm = vm.cast::<VirtualMachine>();
+    let tag = t.tag();
+    let now: *const ElTimespec = now;
+    let vm_ref = vm;
+    let vm: *mut VirtualMachine = core::ptr::from_ref(vm).cast_mut();
 
     /// One match-arm body: recover the container as RAW `*mut $Ty` (never
     /// `&mut` — the handler may free it or re-enter), bind `now`/`vm`, and run
     /// `$body` under one `unsafe` covering the per-fn-contract dereferences.
     /// Defined *after* the `vm` cast so the def-site `vm` ident resolves to
-    /// the typed `*mut VirtualMachine`, not the erased `*mut ()` param.
+    /// the typed `*mut VirtualMachine`.
     // An owner that cannot enter JS: its `()` return is `Ok(())` here.
     macro_rules! timer_arm {
         ($Ty:ty, $field:ident, |$c:ident, $now:ident, $vm:ident| $body:expr) => {{
             let $c: *mut $Ty = owner!($Ty, $field);
             let ($now, $vm) = (now, vm);
-            // SAFETY: per fn contract; container derived from a live `$Ty`.
+            // SAFETY: `TimerOwner` contract; container derived from a live `$Ty`.
             let () = unsafe { $body };
             Ok(())
         }};
     }
     let fired: JsResult<()> = match tag {
-        // ── JS-exposed timers (TimerObjectInternals::fire) ───────────────
+        // ── JS-exposed timers (TimerObject::fire) ────────────────────────
         // `Bun__JSTimeout__call` reports the callback's exception itself.
         EventLoopTimerTag::TimeoutObject => {
-            let container = owner!(TimeoutObject, event_loop_timer);
-            // SAFETY: container derived from a live `TimeoutObject`; do NOT
-            // form `&mut *container` — `internals.fire` may `deref()` and free.
-            let internals = unsafe { core::ptr::addr_of_mut!((*container).internals) };
-            // SAFETY: per fn contract — `now` is the live snapshot; `vm` is the
-            // per-thread VM. `fire` may free the container; `t` is dead after.
-            // `fire` takes `*mut Self` (noalias re-entrancy — see its doc).
-            unsafe { TimerObjectInternals::fire(internals, &*now, vm) };
+            TimerObject::fire(
+                timer_owner_this!(TimeoutObject, event_loop_timer, t),
+                vm_ref,
+            );
             Ok(())
         }
         EventLoopTimerTag::ImmediateObject => {
-            let container = owner!(ImmediateObject, event_loop_timer);
-            // SAFETY: see TimeoutObject arm.
-            let internals = unsafe { core::ptr::addr_of_mut!((*container).internals) };
-            // SAFETY: see TimeoutObject arm.
-            unsafe { TimerObjectInternals::fire(internals, &*now, vm) };
+            TimerObject::fire(
+                timer_owner_this!(ImmediateObject, event_loop_timer, t),
+                vm_ref,
+            );
             Ok(())
         }
         EventLoopTimerTag::WTFTimer => {
-            timer_arm!(WTFTimer, event_loop_timer, |c, now, vm| WTFTimer::fire(
-                c, &*now, vm
-            ))
+            let c: *mut WTFTimer = owner!(WTFTimer, event_loop_timer);
+            // SAFETY: `TimerOwner` contract — `c` is a live `WTFTimer`. The
+            // borrow ends before `fire`, which may destroy it.
+            let run_loop_timer = unsafe { &*c }.take_for_fire();
+            crate::timer::wtf_timer::RunLoopTimer::fire(run_loop_timer);
+            Ok(())
         }
         EventLoopTimerTag::AbortSignalTimeout => {
             timer_arm!(AbortSignalTimeout, event_loop_timer, |c, _now, vm| {
@@ -987,12 +976,12 @@ pub(crate) unsafe fn __bun_fire_timer(
             )
         }
         EventLoopTimerTag::DateHeaderTimer => {
-            timer_arm!(DateHeaderTimer, event_loop_timer, |c, _now, vm| (*c)
-                .run(&mut *vm))
+            timer_arm!(DateHeaderTimer, event_loop_timer, |c, _now, _vm| (&*c)
+                .run(vm_ref, crate::jsc_hooks::timer_all()))
         }
         EventLoopTimerTag::EventLoopDelayMonitor => {
-            timer_arm!(EventLoopDelayMonitor, event_loop_timer, |c, now, vm| {
-                (*c).on_fire(&mut *vm, &*now)
+            timer_arm!(EventLoopDelayMonitor, event_loop_timer, |c, now, _vm| {
+                (&*c).on_fire(&*now, crate::jsc_hooks::timer_all())
             })
         }
         EventLoopTimerTag::StatWatcherScheduler => {
@@ -1045,28 +1034,29 @@ pub(crate) unsafe fn __bun_fire_timer(
         EventLoopTimerTag::PostgresSQLConnectionTimeout => {
             // SAFETY: §Dispatch — tag set together with the container at
             // construction; `t` is the connection's `timer` field.
-            let container = unsafe { PostgresSQLConnection::from_timer_ptr(t) };
+            let container = unsafe { PostgresSQLConnection::from_timer_ptr(t.as_ptr()) };
             // SAFETY: per fn contract.
             unsafe { (*container).on_connection_timeout() };
             Ok(())
         }
         EventLoopTimerTag::PostgresSQLConnectionMaxLifetime => {
             // SAFETY: §Dispatch — `t` is the connection's `max_lifetime_timer`.
-            let container = unsafe { PostgresSQLConnection::from_max_lifetime_timer_ptr(t) };
+            let container =
+                unsafe { PostgresSQLConnection::from_max_lifetime_timer_ptr(t.as_ptr()) };
             // SAFETY: per fn contract.
             unsafe { (*container).on_max_lifetime_timeout() };
             Ok(())
         }
         EventLoopTimerTag::MySQLConnectionTimeout => {
             // SAFETY: §Dispatch — `t` is the connection's `timer` field.
-            let container = unsafe { MySQLConnection::from_timer_ptr(t) };
+            let container = unsafe { MySQLConnection::from_timer_ptr(t.as_ptr()) };
             // SAFETY: per fn contract.
             unsafe { (*container).on_connection_timeout() };
             Ok(())
         }
         EventLoopTimerTag::MySQLConnectionMaxLifetime => {
             // SAFETY: §Dispatch — `t` is the connection's `max_lifetime_timer`.
-            let container = unsafe { MySQLConnection::from_max_lifetime_timer_ptr(t) };
+            let container = unsafe { MySQLConnection::from_max_lifetime_timer_ptr(t.as_ptr()) };
             // SAFETY: per fn contract.
             unsafe { (*container).on_max_lifetime_timeout() };
             Ok(())
@@ -1089,13 +1079,15 @@ pub(crate) unsafe fn __bun_fire_timer(
             // `sweep_weak_refs` takes the raw `*EventLoopTimer` and recovers
             // the store inside.
             // SAFETY: per fn contract.
-            SourceMapStore::sweep_weak_refs(t, unsafe { &*now });
+            SourceMapStore::sweep_weak_refs(t.as_ptr(), unsafe { &*now });
             Ok(())
         }
         EventLoopTimerTag::DevServerMemoryVisualizerTick => {
             // SAFETY: per fn contract; `t` is the `memory_visualizer_timer`
             // field of a live DevServer.
-            DevServer::emit_memory_visualizer_message_timer(unsafe { &mut *t }, unsafe { &*now });
+            DevServer::emit_memory_visualizer_message_timer(unsafe { &mut *t.as_ptr() }, unsafe {
+                &*now
+            });
             Ok(())
         }
         EventLoopTimerTag::BunTest => {
@@ -1123,13 +1115,13 @@ pub(crate) unsafe fn __bun_fire_timer(
                     nsec: (*now).nsec,
                 }
             };
-            BunTest::bun_test_timeout_callback(&strong, &now_core, VirtualMachine::get());
+            BunTest::bun_test_timeout_callback(&strong, &now_core, vm_ref);
             Ok(())
         }
         EventLoopTimerTag::CronJob => {
             let c: *mut CronJob = owner!(CronJob, event_loop_timer);
             // SAFETY: a scheduled job's JS wrapper keeps it alive; `t` was just popped.
-            CronJob::on_timer_fire(unsafe { bun_ptr::ThisPtr::new(c) }, VirtualMachine::get());
+            CronJob::on_timer_fire(unsafe { bun_ptr::ThisPtr::new(c) }, vm_ref);
             Ok(())
         }
         EventLoopTimerTag::QuicEndpoint => {
@@ -1161,22 +1153,127 @@ pub(crate) fn fold(result: JsResult<()>) {
 }
 
 /// `__bun_js_timer_epoch` body — the tag→`container_of` read for
-/// [`EventLoopTimer::js_timer_epoch`]. Returns `internals.flags.epoch` for
-/// the three JS-timer container types, else `None`. Sits on the heap-compare
-/// hot path
+/// [`EventLoopTimer::js_timer_epoch`]. Returns `flags.epoch` for the three
+/// JS-timer container types, else `None`. Sits on the heap-compare hot path
 /// (`EventLoopTimer::less` → `TimerHeap` meld).
 ///
 /// # Safety
-/// `t` points at a live [`EventLoopTimer`] currently linked into a `TimerHeap`.
+/// `t` points at a live [`EventLoopTimer`] slot of a `TimerOwner`.
 #[unsafe(no_mangle)]
 pub(crate) unsafe fn __bun_js_timer_epoch(
     _tag: EventLoopTimerTag,
     t: *const EventLoopTimer,
 ) -> Option<u32> {
-    // SAFETY: per fn contract — `t` is live in a `TimerHeap`. `_tag` kept for
-    // the `extern "Rust"` ABI in `bun_event_loop`; helper re-reads `(*t).tag`
-    // (same address the caller loaded it from — folds under LTO).
-    unsafe { crate::timer::js_timer_flags_ptr(t).map(|p| (*p.as_ptr()).epoch()) }
+    // SAFETY: per fn contract. `_tag` kept for the `extern "Rust"` ABI in
+    // `bun_event_loop`; `js_timer_epoch` re-reads `(*t).tag` (same address the
+    // caller loaded it from — folds under LTO).
+    js_timer_epoch(unsafe { TimerRef::from_raw(t.cast_mut()) })
+}
+
+/// `flags.epoch` of the JS timer that owns `t` (`TimeoutObject` /
+/// `ImmediateObject` / `AbortSignalTimeout`), else `None`.
+#[inline]
+pub(crate) fn js_timer_epoch(t: TimerRef) -> Option<u32> {
+    use crate::timer::{ImmediateObject, TimeoutObject};
+    match t.tag() {
+        EventLoopTimerTag::TimeoutObject => Some(
+            timer_owner_this!(TimeoutObject, event_loop_timer, t)
+                .internals
+                .flags
+                .get()
+                .epoch(),
+        ),
+        EventLoopTimerTag::ImmediateObject => Some(
+            timer_owner_this!(ImmediateObject, event_loop_timer, t)
+                .internals
+                .flags
+                .get()
+                .epoch(),
+        ),
+        EventLoopTimerTag::AbortSignalTimeout => {
+            // SAFETY: `TimerOwner` contract — `t` is the `event_loop_timer` slot
+            // of a live boxed `abort_signal::Timeout`.
+            Some(unsafe {
+                (*AbortSignalTimeout::from_timer_ptr(t.as_ptr()))
+                    .flags
+                    .epoch()
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Stamp `epoch` into the JS timer that owns `t` so equal-deadline JS timers
+/// fire in scheduling order. `false` for every other tag.
+#[inline]
+pub(crate) fn set_js_timer_epoch(t: TimerRef, epoch: u32) -> bool {
+    use crate::timer::{ImmediateObject, TimeoutObject};
+    let flags = match t.tag() {
+        EventLoopTimerTag::TimeoutObject => {
+            &timer_owner_this!(TimeoutObject, event_loop_timer, t)
+                .internals
+                .flags
+        }
+        EventLoopTimerTag::ImmediateObject => {
+            &timer_owner_this!(ImmediateObject, event_loop_timer, t)
+                .internals
+                .flags
+        }
+        EventLoopTimerTag::AbortSignalTimeout => {
+            // SAFETY: `TimerOwner` contract — `t` is the `event_loop_timer` slot
+            // of a live boxed `abort_signal::Timeout`; JS thread, no other
+            // borrow of the box is live while `All` (re)links it.
+            unsafe {
+                (*AbortSignalTimeout::from_timer_ptr(t.as_ptr()))
+                    .flags
+                    .set_epoch(epoch)
+            };
+            return true;
+        }
+        _ => return false,
+    };
+    let mut f = flags.get();
+    f.set_epoch(epoch);
+    flags.set(f);
+    true
+}
+
+/// Cancel a JS-program-scheduled timer (the
+/// [`EventLoopTimerTag::allow_fake_timers`] set plus `ImmediateObject`) on its
+/// owner's behalf — VM teardown / `--isolate` swap
+/// (`All::cancel_all_timeout_objects`) or the fake clock's `clear` — so the
+/// owner releases what the heap entry pinned. `t` may still be linked or
+/// already popped. May free the owner; `t` is dead once this returns.
+pub(crate) fn cancel_js_timer(t: TimerRef, _vm: &VirtualMachine) {
+    use crate::timer::{ImmediateObject, TimeoutObject, TimerObject};
+    match t.tag() {
+        EventLoopTimerTag::TimeoutObject => {
+            TimerObject::release_heap_entry(timer_owner_this!(TimeoutObject, event_loop_timer, t));
+        }
+        EventLoopTimerTag::ImmediateObject => {
+            TimerObject::cancel(timer_owner_this!(ImmediateObject, event_loop_timer, t));
+        }
+        // `AbortSignal.timeout()` boxes are owned by the C++ `AbortSignal`, so
+        // each one is handed back to its signal, which unlinks and frees it and
+        // clears `m_timeout`. Only unlinking the node would leave every
+        // observed signal's wrapper (under `--isolate`: the retired global its
+        // listeners close over) pinned by `isReachableFromOpaqueRoots` for the
+        // rest of the process; see `Timeout::discard`.
+        EventLoopTimerTag::AbortSignalTimeout => {
+            // SAFETY: `TimerOwner` contract — `t` is the slot of a live boxed
+            // `abort_signal::Timeout` still owned by its signal; JS thread; no
+            // borrow of `All` is held here (`discard` re-enters `All::remove`).
+            unsafe { AbortSignalTimeout::discard(AbortSignalTimeout::from_timer_ptr(t.as_ptr())) };
+        }
+        EventLoopTimerTag::CronJob => {
+            CronJob::stop_dropped_from_fake_heap(timer_owner_this!(CronJob, event_loop_timer, t));
+        }
+        tag => debug_assert!(
+            false,
+            "{} timer has no release path",
+            <&'static str>::from(tag),
+        ),
+    }
 }
 
 /// `__bun_tick_queue_with_count` body — declared `extern "Rust"` in

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3918,18 +3918,14 @@ impl Resolver {
             sec: now.sec,
             nsec: now.nsec,
         };
-        let uws_loop = vm.uws_loop();
+        let _ = vm;
         // R-2: `&self` carries no `noalias`, and every field touched below is
         // UnsafeCell-backed, so the re-entrant `ares_process_fd` callbacks
         // (`request_completed`, `drain_pending_*`) may freely re-derive
         // `&Resolver` from their stored ctx without aliasing UB.
         let deref_this = self.as_ctx_ptr();
         scopeguard::defer! {
-            // jsc/runtime crate cycle: low-tier `VirtualMachine.timer` is `()`;
-            // resolve via the high-tier `RuntimeState` hook.
-            let state = crate::jsc_hooks::runtime_state();
-            // SAFETY: `state` is the boxed per-thread `RuntimeState`; single-threaded JS heap.
-            unsafe { (*state).timer.increment_timer_ref(-1, uws_loop) };
+            crate::jsc_hooks::timer_all().increment_timer_ref(-1);
             // SAFETY: `deref_this` is the heap allocation from `init`; releases
             // `add_timer`'s ref. May be the final release; nothing touches
             // `*self` after this point.
@@ -4021,18 +4017,9 @@ impl Resolver {
                 nsec: next.nsec,
             }
         });
-        let uws_loop = self.vm().uws_loop();
-        let state = crate::jsc_hooks::runtime_state();
-        // SAFETY: `state` is the boxed per-thread `RuntimeState`; single-threaded JS heap.
-        unsafe {
-            (*state).timer.increment_timer_ref(1, uws_loop);
-            // whole-struct provenance: `from_field_ptr!` recovers the container on fire
-            (*state).timer.insert(
-                core::ptr::addr_of!(self.event_loop_timer)
-                    .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>()
-                    .cast_mut(),
-            );
-        }
+        let timers = crate::jsc_hooks::timer_all();
+        timers.increment_timer_ref(1);
+        timers.insert(crate::timer::TimerRef::new(self, |r| &r.event_loop_timer));
         true
     }
 
@@ -4050,16 +4037,13 @@ impl Resolver {
             // global-resolver permanent pin), so this
             // `deref` cannot reach 0 while `&self` is live.
             unsafe {
-                let uws_loop = (*this).vm().uws_loop();
-                let state = crate::jsc_hooks::runtime_state();
-                (*state).timer.increment_timer_ref(-1, uws_loop);
+                crate::jsc_hooks::timer_all().increment_timer_ref(-1);
                 Self::deref(this);
             }
         }
 
-        let state = crate::jsc_hooks::runtime_state();
-        // SAFETY: `state` is the boxed per-thread `RuntimeState`; single-threaded JS heap.
-        unsafe { (*state).timer.remove(self.event_loop_timer.as_ptr()) };
+        crate::jsc_hooks::timer_all()
+            .remove(crate::timer::TimerRef::new(self, |r| &r.event_loop_timer));
     }
 
     // ───────────── pending-cache helpers ─────────────

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -328,6 +328,8 @@ pub(crate) struct SharedConnection {
     early_out_armed_for: Cell<i64>,
 }
 
+bun_event_loop::impl_timer_owner!(SharedConnection; from_early_out_timer_ptr => early_out_timer);
+
 thread_local! {
     static SHARED: Cell<*mut SharedConnection> = const { Cell::new(ptr::null_mut()) };
 }
@@ -553,13 +555,10 @@ impl SharedConnection {
         }
         let now = bun::timespec::now(bun::TimespecMockMode::ForceRealTime);
         let next = now.add_ms((deadline - now.ms()).max(1));
-        let state = crate::jsc_hooks::runtime_state();
-        // SAFETY: this thread's live RuntimeState; the timer slot is valid until `destroy`.
-        unsafe {
-            (*state).timer.update(
-                core::ptr::addr_of!(self.early_out_timer)
-                    .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>()
-                    .cast_mut(),
+        // The timer slot is valid until `destroy`.
+        {
+            crate::jsc_hooks::timer_all().update(
+                crate::timer::TimerRef::new(self, |c| &c.early_out_timer),
                 &ElTimespec {
                     sec: next.sec,
                     nsec: next.nsec,
@@ -605,12 +604,8 @@ impl SharedConnection {
         if conn.early_out_timer.get().state == EventLoopTimerState::ACTIVE
             && VirtualMachine::get_or_null().is_some()
         {
-            // SAFETY: this thread's live RuntimeState owns the timer heap.
-            unsafe {
-                (*crate::jsc_hooks::runtime_state())
-                    .timer
-                    .remove(conn.early_out_timer.as_ptr())
-            };
+            crate::jsc_hooks::timer_all()
+                .remove(crate::timer::TimerRef::new(&*conn, |c| &c.early_out_timer));
         }
         // SAFETY: `file_poll` is the live hive slot; `deinit` returns it.
         unsafe { (*conn.file_poll.as_ptr()).deinit() };

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -201,20 +201,26 @@ mod sql_hooks {
         unsafe { core::ptr::addr_of_mut!((*state).sql_rare) }
     }
     unsafe fn timer_heap(_vm: *mut VirtualMachine) -> *mut c_void {
-        crate::jsc_hooks::timer_all().cast()
+        core::ptr::from_ref(crate::jsc_hooks::timer_all())
+            .cast_mut()
+            .cast()
     }
     unsafe fn timer_insert(heap: *mut c_void, timer: *mut EventLoopTimer) {
         // SAFETY: `heap` is `&runtime_state().timer` (live for the VM); `timer`
-        // is a live intrusive heap node owned by the caller. Route through
-        // `All::insert` (NOT the raw `.timers` field) so the fake-timers
-        // routing and the `(*timer).state` / `in_heap` bookkeeping happen.
-        unsafe { (*heap.cast::<crate::timer::All>()).insert(timer) };
+        // is the slot of a live `TimerOwner` (the SQL connection). Route
+        // through `All::insert` (NOT the raw `.timers` field) so the
+        // fake-timers routing and the `state` / `in_heap` bookkeeping happen.
+        unsafe {
+            (*heap.cast::<crate::timer::All>()).insert(crate::timer::TimerRef::from_raw(timer))
+        };
     }
     unsafe fn timer_remove(heap: *mut c_void, timer: *mut EventLoopTimer) {
         // SAFETY: `heap` is `&runtime_state().timer`; `timer` was previously
         // inserted via `timer_insert`. Route through `All::remove` so
         // `in_heap` is consulted and reset.
-        unsafe { (*heap.cast::<crate::timer::All>()).remove(timer) };
+        unsafe {
+            (*heap.cast::<crate::timer::All>()).remove(crate::timer::TimerRef::from_raw(timer))
+        };
     }
     unsafe fn ssl_ctx_cache(_vm: *mut VirtualMachine) -> *mut c_void {
         let state = crate::jsc_hooks::runtime_state();

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -20,8 +20,6 @@
 //!   - `Bun__Process__send`
 //!       → `bun_jsc::virtual_machine_exports`
 
-use core::ffi::c_void;
-
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
     CallFrame, JSGlobalObject, JSInternalPromise, JSValue, StringJsc as _, ZigStackFrame,
@@ -176,131 +174,40 @@ pub fn close_child_ipc(global: &JSGlobalObject) {
 
 // ─── sql_jsc bridge — `bun_sql_jsc::jsc::SqlRuntimeHooks` vtable ─────────────
 //
-// `bun_sql_jsc` cannot name `RuntimeState` / `socket::SSLConfig` /
-// `webcore::Blob` (this crate depends on it). Instead of Rust→Rust
-// `extern "C"` re-decls (which let the two sides silently disagree on pointee
-// layout), the low tier defines [`bun_sql_jsc::jsc::SqlRuntimeHooks`] and this
-// crate registers a `&'static` instance from [`crate::jsc_hooks::
-// `__BUN_SQL_RUNTIME_HOOKS`. Every fn-pointer signature is type-checked at the
-// struct-literal below.
-//
-// Opaque-pointer protocol for `SSLConfig`: `ssl_config_from_js` returns a
-// `Box<socket::SSLConfig>::into_raw`; the SQL side holds it as `*mut c_void`
-// and frees via `ssl_config_free`. Scalar accessors borrow into that box.
+// `bun_sql_jsc` cannot name `RuntimeState` / `socket::SSLConfig::from_js`
+// (this crate depends on it). Instead of Rust→Rust `extern "C"` re-decls (which let the
+// two sides silently disagree on pointee layout), the low tier defines
+// [`bun_sql_jsc::jsc::SqlRuntimeHooks`] and this crate registers a `&'static`
+// instance, `__BUN_SQL_RUNTIME_HOOKS`. Every fn-pointer signature is
+// type-checked at the struct-literal below.
 
 mod sql_hooks {
     use super::*;
-    use bun_event_loop::EventLoopTimer::EventLoopTimer;
     use bun_sql_jsc::jsc::{RareData as SqlRareData, SqlRuntimeHooks};
 
-    unsafe fn sql_rare(_vm: *mut VirtualMachine) -> *mut SqlRareData {
-        let state = crate::jsc_hooks::runtime_state();
-        debug_assert!(!state.is_null(), "RuntimeState not installed");
-        // SAFETY: `state` is the boxed per-thread `RuntimeState`; `sql_rare` is
-        // an embedded field with stable address for the VM lifetime.
-        unsafe { core::ptr::addr_of_mut!((*state).sql_rare) }
+    fn with_sql_state(f: &mut dyn FnMut(&mut SqlRareData)) {
+        crate::jsc_hooks::with_sql_state(f)
     }
-    unsafe fn timer_heap(_vm: *mut VirtualMachine) -> *mut c_void {
-        core::ptr::from_ref(crate::jsc_hooks::timer_all())
-            .cast_mut()
-            .cast()
+    fn timer_insert(timer: crate::timer::TimerRef) {
+        crate::jsc_hooks::timer_all().insert(timer);
     }
-    unsafe fn timer_insert(heap: *mut c_void, timer: *mut EventLoopTimer) {
-        // SAFETY: `heap` is `&runtime_state().timer` (live for the VM); `timer`
-        // is the slot of a live `TimerOwner` (the SQL connection). Route
-        // through `All::insert` (NOT the raw `.timers` field) so the
-        // fake-timers routing and the `state` / `in_heap` bookkeeping happen.
-        unsafe {
-            (*heap.cast::<crate::timer::All>()).insert(crate::timer::TimerRef::from_raw(timer))
-        };
+    fn timer_remove(timer: crate::timer::TimerRef) {
+        crate::jsc_hooks::timer_all().remove(timer);
     }
-    unsafe fn timer_remove(heap: *mut c_void, timer: *mut EventLoopTimer) {
-        // SAFETY: `heap` is `&runtime_state().timer`; `timer` was previously
-        // inserted via `timer_insert`. Route through `All::remove` so
-        // `in_heap` is consulted and reset.
-        unsafe {
-            (*heap.cast::<crate::timer::All>()).remove(crate::timer::TimerRef::from_raw(timer))
-        };
-    }
-    unsafe fn ssl_ctx_cache(_vm: *mut VirtualMachine) -> *mut c_void {
-        let state = crate::jsc_hooks::runtime_state();
-        debug_assert!(!state.is_null(), "RuntimeState not installed");
-        // SAFETY: `state` is the boxed per-thread `RuntimeState`; the embedded
-        // `SSLContextCache` has stable address for the VM lifetime.
-        unsafe { core::ptr::addr_of_mut!((*state).ssl_ctx_cache).cast::<c_void>() }
-    }
-    unsafe fn ssl_ctx_get_or_create(
-        cache: *mut c_void,
-        opts: &bun_uws::us_bun_socket_context_options_t,
-        err: &mut bun_uws::create_bun_socket_error_t,
-    ) -> Option<bun_boringssl_sys::OwnedSslCtx> {
-        // SAFETY: `cache` is `&runtime_state().ssl_ctx_cache`.
-        let cache = unsafe { &mut *cache.cast::<crate::api::SSLContextCache::SSLContextCache>() };
-        cache.get_or_create_opts(opts, err)
-    }
-    unsafe fn ssl_config_from_js(global: &JSGlobalObject, value: JSValue) -> *mut c_void {
+    fn ssl_config_from_js(
+        global: &JSGlobalObject,
+        value: JSValue,
+    ) -> bun_jsc::JsResult<Option<bun_http::SSLConfig>> {
         use crate::socket::SSLConfigFromJs;
-        match crate::socket::SSLConfig::from_js(global.bun_vm_ref(), global, value) {
-            Ok(Some(cfg)) => bun_core::heap::into_raw(Box::new(cfg)).cast::<c_void>(),
-            Ok(None) => core::ptr::null_mut(),
-            Err(bun_jsc::JsError::OutOfMemory) => {
-                let _ = global.throw_out_of_memory();
-                core::ptr::null_mut()
-            }
-            Err(_) => core::ptr::null_mut(),
-        }
+        crate::socket::SSLConfig::from_js(global.bun_vm_ref(), global, value)
     }
-    unsafe fn ssl_config_free(this: *mut c_void) {
-        // SAFETY: `this` was produced by `heap::alloc` in
-        // `ssl_config_from_js`; sql_jsc's `SSLConfig::drop` guards null/double.
-        drop(unsafe { bun_core::heap::take(this.cast::<crate::socket::SSLConfig>()) });
-    }
-    unsafe fn ssl_config_as_usockets_client(
-        this: *const c_void,
-    ) -> bun_uws::us_bun_socket_context_options_t {
-        // SAFETY: `this` is a live boxed `SSLConfig` from `ssl_config_from_js`.
-        unsafe { &*this.cast::<crate::socket::SSLConfig>() }.as_usockets_for_client_verification()
-    }
-    unsafe fn ssl_config_server_name(this: *const c_void) -> *const core::ffi::c_char {
-        // SAFETY: `this` is a live boxed `SSLConfig`; returned ptr borrows its
-        // heap-owned C-string field, valid until `ssl_config_free`.
-        unsafe { &*this.cast::<crate::socket::SSLConfig>() }.server_name
-    }
-    unsafe fn ssl_config_reject_unauthorized(this: *const c_void) -> i32 {
-        // SAFETY: `this` is a live boxed `SSLConfig`.
-        unsafe { (*this.cast::<crate::socket::SSLConfig>()).reject_unauthorized }
-    }
-    unsafe fn blob_needs_to_read_file(this: *const c_void) -> bool {
-        // SAFETY: `this` is a live `Blob` (codegen `m_ctx` payload from
-        // `Blob__fromJS`).
-        unsafe { (*this.cast::<crate::webcore::Blob>()).needs_to_read_file() }
-    }
-    unsafe fn blob_shared_view(this: *const c_void, out_len: *mut usize) -> *const u8 {
-        // SAFETY: `this` is a live `Blob`; `out_len` is a caller stack slot.
-        unsafe {
-            crate::webcore::blob::Bun__Blob__sharedView(
-                this.cast::<crate::webcore::Blob>(),
-                out_len,
-            )
-        }
-    }
-
     /// Declared `extern "Rust"` in `bun_sql_jsc::jsc`; link-time resolved.
     #[unsafe(no_mangle)]
     static __BUN_SQL_RUNTIME_HOOKS: SqlRuntimeHooks = SqlRuntimeHooks {
-        sql_rare,
-        timer_heap,
+        with_sql_state,
         timer_insert,
         timer_remove,
-        ssl_ctx_cache,
-        ssl_ctx_get_or_create,
         ssl_config_from_js,
-        ssl_config_free,
-        ssl_config_as_usockets_client,
-        ssl_config_server_name,
-        ssl_config_reject_unauthorized,
-        blob_needs_to_read_file,
-        blob_shared_view,
     };
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -158,41 +158,34 @@ pub(crate) fn runtime_state() -> *mut RuntimeState {
     RUNTIME_STATE.with(Cell::get)
 }
 
-/// Recover this thread's `timer::All` heap as a raw pointer.
+/// This thread's `timer::All`, or `None` before [`init_runtime_state`] has run
+/// (e.g. `bun_jsc` unit tests with no high tier, or `Bun__Timer__getNextID`
+/// racing init).
 ///
-/// Note: `bun_jsc::VirtualMachine.timer` is a `()` placeholder;
-/// the real `All` lives in [`RuntimeState::timer`] until that slot widens.
-/// Null only before [`init_runtime_state`] has run (e.g. `bun_jsc` unit tests
-/// with no high tier, or `Bun__Timer__getNextID` racing init).
-///
-/// Returns `*mut` (NOT `&mut`) so callers that are themselves fields of `All`
-/// (`DateHeaderTimer`, `EventLoopDelayMonitor`, `FakeTimers`) can dereference
-/// per-field under `// SAFETY:` without forming an aliased `&mut All` while
-/// `&mut self` is live (raw-ptr-per-field re-entry pattern, see `auto_tick`).
+/// Note: `bun_jsc::VirtualMachine.timer` is a `()` placeholder; the real `All`
+/// lives in [`RuntimeState::timer`] until that slot widens. `All` is
+/// `&self`-only (interior mutability), so the shared borrow is sound across
+/// the JS re-entry its own methods perform.
 #[inline]
-pub(crate) fn timer_all() -> *mut timer::All {
+pub(crate) fn timer_all_opt() -> Option<&'static timer::All> {
     let state = runtime_state();
     if state.is_null() {
-        return ptr::null_mut();
+        return None;
     }
     // SAFETY: `state` is the live boxed `RuntimeState` for this thread;
-    // `timer` is an embedded field at a stable address for the VM lifetime.
-    unsafe { ptr::addr_of_mut!((*state).timer) }
+    // `timer` is an embedded field at a stable address for the VM lifetime and
+    // is never borrowed `&mut`.
+    Some(unsafe { &*ptr::addr_of!((*state).timer) })
 }
 
-/// [`timer_all`] but `&'static mut` — only valid once `RuntimeState` is
-/// installed (true for every JS host-call entry point) and only for callers
-/// that are NOT themselves fields of `All` (`Subprocess`, `DevServer`,
-/// `cron`, sockets). Single JS thread + boxed-for-process-lifetime ⇒ the
-/// borrow is sound; callers must not hold it across a JS re-entry that could
-/// itself call this (every use is single-expression).
+/// [`timer_all_opt`] for callers that run only once `RuntimeState` is
+/// installed (every JS host-call entry point and event-loop tick).
 #[inline]
-pub(crate) fn timer_all_mut() -> &'static mut timer::All {
+pub(crate) fn timer_all() -> &'static timer::All {
     let state = runtime_state();
     debug_assert!(!state.is_null(), "RuntimeState not installed");
-    // SAFETY: `runtime_state()` is non-null after `bun_runtime::init()`;
-    // single JS thread so no concurrent `&mut`.
-    unsafe { &mut (*state).timer }
+    // SAFETY: see `timer_all_opt`; non-null once `init_runtime_state` has run.
+    unsafe { &*ptr::addr_of!((*state).timer) }
 }
 
 #[inline]
@@ -1003,16 +996,8 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     // ── DateHeaderTimer / imminent-GC ───────────────────────────────────
     let state = runtime_state();
     if !state.is_null() {
-        // SAFETY: `state` is the live per-thread `RuntimeState`; `loop_` is the
-        // live per-thread uws loop; `vm` per fn contract. The re-entrant
-        // `All::insert`/`update` inside `DateHeaderTimer::enable` touches only
-        // fields disjoint from `date_header_timer` (raw-ptr-per-field pattern,
-        // same as `Bun__internal_ensureDateHeaderTimerIsEnabled`).
-        unsafe {
-            (*state)
-                .timer
-                .update_date_header_timer_if_necessary(&*loop_, vm)
-        };
+        // SAFETY: `loop_` is the live per-thread uws loop; `vm` per fn contract.
+        timer_all().update_date_header_timer_if_necessary(unsafe { &*loop_ }, unsafe { &*vm });
     }
     // SAFETY: `el` is the live per-thread event loop.
     unsafe { (*el).run_imminent_gc_timer() };
@@ -1063,31 +1048,19 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
             // timer armed after the poll deadline is computed is not in that deadline.
             // SAFETY: `el` is the live per-thread event loop.
             unsafe { (*el).process_gc_timer() };
-            // Note (§Forbidden aliased-&mut): `get_timeout` may fire a
-            // `WTFTimer` JS callback.
-            // A re-entrant `setTimeout`/`clearTimeout` reaches
-            // `timer::All::insert`/`remove` via `runtime_state()` and would
-            // mint a second `&mut timer` if we held `&mut (*state).timer`
-            // across the call. Pass the raw `*mut Self` instead;
-            // `timer::All::get_timeout` forms short-lived `&mut` only around
-            // heap ops that cannot re-enter JS, releasing the borrow before
-            // invoking `fire()`.
+            // `get_timeout` may fire a `WTFTimer`.
             // `get_timeout` reads CLOCK_MONOTONIC to compare against the timer heap; hand that
             // same reading to the tick for the park hook's idle-sweep rate limit. It is lazy,
             // and so is the hook: NOW_NS_UNKNOWN means it took none.
             let mut now: Option<bun_core::Timespec> = None;
-            // SAFETY: `state` is the live per-thread `RuntimeState`; the
-            // `timer` field address is stable for the VM lifetime.
-            let have_timeout = unsafe {
-                timer::All::get_timeout(
-                    &mut (*state).timer,
-                    &mut timespec,
-                    has_pending_immediate,
-                    quic_next_tick_us,
-                    vm.cast(),
-                    &mut now,
-                )
-            };
+            let have_timeout = timer_all().get_timeout(
+                &mut timespec,
+                has_pending_immediate,
+                quic_next_tick_us,
+                // SAFETY: per fn contract.
+                unsafe { &*vm },
+                &mut now,
+            );
             let now_ns = now.map_or(bun_uws::NOW_NS_UNKNOWN, |t| t.ns());
             // SAFETY: `loop_` is the live per-thread uws loop.
             unsafe {
@@ -1100,19 +1073,9 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
         }
     }
 
+    // SAFETY: per fn contract.
     #[cfg(unix)]
-    {
-        // Note (§Forbidden aliased-&mut): `drain_timers` fires user
-        // `setTimeout` callbacks which may re-enter `timer::All::insert`/
-        // `remove` via `runtime_state()`. Pass raw `*mut Self` so no
-        // long-lived `&mut (*state).timer` is held across `fire()`;
-        // `drain_timers` forms short-lived `&mut` only around heap pop/peek.
-        // SAFETY: `state` is the live per-thread `RuntimeState`; the `timer`
-        // field address is stable for the VM lifetime.
-        unsafe { timer::All::drain_timers(&mut (*state).timer, vm.cast()) };
-    }
-    #[cfg(not(unix))]
-    let _ = state;
+    timer_all().drain_timers(unsafe { &*vm });
 
     // SAFETY: per fn contract.
     unsafe { (*vm).on_after_event_loop() };
@@ -1163,11 +1126,7 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     let state = runtime_state();
     if !state.is_null() {
         // SAFETY: see the matching call in `auto_tick` above.
-        unsafe {
-            (*state)
-                .timer
-                .update_date_header_timer_if_necessary(&*loop_, vm)
-        };
+        timer_all().update_date_header_timer_if_necessary(unsafe { &*loop_ }, unsafe { &*vm });
     }
 
     if state.is_null() {
@@ -1203,18 +1162,14 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
             // same reading to the tick for the park hook's idle-sweep rate limit. It is lazy,
             // and so is the hook: NOW_NS_UNKNOWN means it took none.
             let mut now: Option<bun_core::Timespec> = None;
-            // SAFETY: `state` is the live per-thread `RuntimeState`; see
-            // Note on `auto_tick` re: aliased-&mut across `fire()`.
-            let have_timeout = unsafe {
-                timer::All::get_timeout(
-                    &mut (*state).timer,
-                    &mut timespec,
-                    has_pending_immediate,
-                    quic_next_tick_us,
-                    vm.cast(),
-                    &mut now,
-                )
-            };
+            let have_timeout = timer_all().get_timeout(
+                &mut timespec,
+                has_pending_immediate,
+                quic_next_tick_us,
+                // SAFETY: per fn contract.
+                unsafe { &*vm },
+                &mut now,
+            );
             let now_ns = now.map_or(bun_uws::NOW_NS_UNKNOWN, |t| t.ns());
             // SAFETY: `loop_` is the live per-thread uws loop.
             unsafe {
@@ -1227,12 +1182,9 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
         }
     }
 
+    // SAFETY: per fn contract.
     #[cfg(unix)]
-    {
-        // SAFETY: `state` is the live per-thread `RuntimeState`; see Note
-        // on `auto_tick` re: aliased-&mut across `fire()`.
-        unsafe { timer::All::drain_timers(&mut (*state).timer, vm.cast()) };
-    }
+    timer_all().drain_timers(unsafe { &*vm });
     #[cfg(not(unix))]
     let _ = state;
 
@@ -1295,9 +1247,9 @@ unsafe fn timer_insert(
     // SAFETY: per fn contract.
     let state = unsafe { runtime_state_of(vm) };
     debug_assert!(!state.is_null(), "timer_insert before init_runtime_state");
-    // SAFETY: this leaf hook runs no JS, so a short-lived `&mut RuntimeState`
-    // does not alias anything. `Timer::All::insert` re-derefs `t` per-field.
-    unsafe { &mut (*state).timer }.insert(t);
+    // SAFETY: `state` is live (leaf hook, JS thread); `t` per fn contract is
+    // the slot of a live `TimerOwner`.
+    unsafe { (*state).timer.insert(timer::TimerRef::from_raw(t)) };
 }
 
 /// `vm.timer.remove(timer)` — counterpart to [`timer_insert`].
@@ -1311,8 +1263,8 @@ unsafe fn timer_remove(
     // SAFETY: per fn contract.
     let state = unsafe { runtime_state_of(vm) };
     debug_assert!(!state.is_null(), "timer_remove before init_runtime_state");
-    // SAFETY: see `timer_insert` — leaf hook, short-lived `&mut RuntimeState`.
-    unsafe { &mut (*state).timer }.remove(t);
+    // SAFETY: see `timer_insert`.
+    unsafe { (*state).timer.remove(timer::TimerRef::from_raw(t)) };
 }
 
 /// `Node.fs.NodeFS{ .vm = … }` lazy creation.
@@ -1643,11 +1595,8 @@ unsafe fn cancel_all_timers(vm: *mut VirtualMachine) {
     unsafe {
         crate::node::node_fs_stat_watcher::StatWatcherScheduler::shutdown_for_exit(vm);
     }
-    // SAFETY: `state` is the live boxed per-thread `RuntimeState`; `vm` per fn
-    // contract. `addr_of_mut!` does not materialize a `&mut RuntimeState`.
-    unsafe {
-        crate::timer::All::cancel_all_timeout_objects(ptr::addr_of_mut!((*state).timer), vm);
-    }
+    // SAFETY: `vm` per fn contract.
+    timer_all().cancel_all_timeout_objects(unsafe { &*vm });
 }
 
 /// `RuntimeHooks::close_timer_loop_handles_after_vm_destroyed`: teardown-only companion of
@@ -1657,12 +1606,7 @@ unsafe fn cancel_all_timers(vm: *mut VirtualMachine) {
 /// `runtime_state()` is installed; JS thread; the JSC VM is already destroyed.
 unsafe fn close_timer_loop_handles_after_vm_destroyed(_vm: *mut VirtualMachine) {
     #[cfg(windows)]
-    {
-        let state = runtime_state();
-        debug_assert!(!state.is_null());
-        // SAFETY: live boxed per-thread RuntimeState (fn contract).
-        unsafe { (*state).timer.close_loop_handles_for_vm_teardown() };
-    }
+    timer_all().close_loop_handles_for_vm_teardown();
 }
 
 /// `RuntimeHooks::stop_active_handles_for_vm_teardown` — see [`stop_active_handles_for_vm_teardown`].
@@ -1676,12 +1620,9 @@ unsafe fn stop_active_handles_for_vm_teardown_hook(vm: *mut VirtualMachine) -> S
 
 /// `RuntimeHooks::disarm_all_timers_for_vm_teardown`.
 unsafe fn disarm_all_timers_for_vm_teardown(_vm: *mut VirtualMachine) {
-    let all = timer_all();
-    if all.is_null() {
-        return;
+    if let Some(all) = timer_all_opt() {
+        all.disarm_all_for_vm_teardown();
     }
-    // SAFETY: live per-thread `All`; JS thread; teardown has forbidden script.
-    unsafe { crate::timer::All::disarm_all_for_vm_teardown(all) };
 }
 
 /// `RuntimeHooks::stop_dns_for_vm_teardown` — destroy the per-VM global DNS
@@ -1746,19 +1687,10 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
     // touch the outgoing signals.
     {
         let all = timer_all();
-        // SAFETY: `state` is non-null so `timer_all()` is non-null; single
-        // JS thread, no re-entry while we hold the field borrow.
-        if !all.is_null() && unsafe { (*all).fake_timers.is_active() } {
-            let global = vm.global();
-            // SAFETY: as above; only touches `fake_timers.active` and the
-            // `CURRENT_TIME` static.
-            unsafe { (*all).fake_timers.reset_for_isolation(global) };
+        if all.fake_timers.is_active() {
+            all.fake_timers.reset_for_isolation(vm.global());
         }
-        if !all.is_null() {
-            // SAFETY: as above; `disable` borrows only `event_loop_delay` and
-            // reaches the heap through `timer_all()` (disjoint-field access).
-            unsafe { (*all).event_loop_delay.disable() };
-        }
+        all.event_loop_delay.disable(all);
     }
     // Entries that stay registered across a test-isolation swap.
     let mut kept: Vec<ActiveHandle> = Vec::new();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -188,6 +188,21 @@ pub(crate) fn timer_all() -> &'static timer::All {
     unsafe { &*ptr::addr_of!((*state).timer) }
 }
 
+/// Runs `f` against this thread's SQL per-VM state (`RareData` of
+/// `bun_sql_jsc`). A callback rather than a `&'static mut`, which two callers
+/// could hold at once; `f` must not re-enter anything that reaches it.
+#[inline]
+pub(crate) fn with_sql_state<R>(f: impl FnOnce(&mut bun_sql_jsc::jsc::RareData) -> R) -> R {
+    let state = runtime_state();
+    debug_assert!(
+        !state.is_null(),
+        "runtime_state() before init_runtime_state"
+    );
+    // SAFETY: live boxed per-thread `RuntimeState`; single JS thread; the
+    // borrow ends when `f` returns.
+    f(unsafe { &mut (*state).sql_rare })
+}
+
 /// Runs `f` against this thread's in-process cron job list (`None` before the
 /// runtime state exists). A callback rather than a `&'static mut`, which two
 /// callers could hold at once; `f` must not re-enter anything that reaches the

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1057,8 +1057,6 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
                 &mut timespec,
                 has_pending_immediate,
                 quic_next_tick_us,
-                // SAFETY: per fn contract.
-                unsafe { &*vm },
                 &mut now,
             );
             let now_ns = now.map_or(bun_uws::NOW_NS_UNKNOWN, |t| t.ns());
@@ -1166,8 +1164,6 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
                 &mut timespec,
                 has_pending_immediate,
                 quic_next_tick_us,
-                // SAFETY: per fn contract.
-                unsafe { &*vm },
                 &mut now,
             );
             let now_ns = now.map_or(bun_uws::NOW_NS_UNKNOWN, |t| t.ns());

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1181,8 +1181,6 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     // SAFETY: per fn contract.
     #[cfg(unix)]
     timer_all().drain_timers(unsafe { &*vm });
-    #[cfg(not(unix))]
-    let _ = state;
 
     // SAFETY: per fn contract.
     unsafe { (*vm).on_after_event_loop() };

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -191,19 +191,20 @@ impl StatWatcherScheduler {
         // the per-thread `runtime_state()` (single JS thread; see jsc_hooks.rs).
         // SAFETY: main-thread-only per fn contract; `runtime_state()` is non-null
         // after `bun_runtime::init()`. Raw-ptr-per-field re-entry pattern.
-        let timer_all = unsafe { &mut (*crate::jsc_hooks::runtime_state()).timer };
+        let timer_all = crate::jsc_hooks::timer_all();
         // SAFETY: `this` is live: a scheduler ref is held for the whole call by
         // every caller (`set_interval`'s caller, `timer_callback`'s `&mut self`,
         // `shutdown_for_exit`'s `RareData` ref) or, for `StatWatcherTimerUpdate`
         // (whose `scheduler` is a non-owning `ParentRef`), by the watcher's
         // `RefPtr<StatWatcherScheduler>` held across the hop.
-        let elt = unsafe { core::ptr::addr_of_mut!((*this).event_loop_timer) };
+        let elt = unsafe {
+            crate::timer::TimerRef::from_raw(core::ptr::addr_of_mut!((*this).event_loop_timer))
+        };
 
         // if the interval is 0 means that we stop the timer
         if interval == 0 {
             // if the timer is active we need to remove it
-            // SAFETY: `elt` is the live embedded EventLoopTimer.
-            if unsafe { (*elt).state } == EventLoopTimerState::ACTIVE {
+            if elt.state() == EventLoopTimerState::ACTIVE {
                 timer_all.remove(elt);
             }
             return;
@@ -233,7 +234,6 @@ impl StatWatcherScheduler {
             || self.vm().script_execution_status() != jsc::ScriptExecutionStatus::Running;
 
         self.event_loop_timer.state = EventLoopTimerState::FIRED;
-        self.event_loop_timer.heap = Default::default();
 
         if has_been_cleared || self.is_shutdown.load(Ordering::Relaxed) {
             return;

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -287,6 +287,11 @@ unsafe extern "C" {
 }
 
 impl QuicEndpoint {
+    #[inline]
+    fn timer_ref(&self) -> crate::timer::TimerRef {
+        crate::timer::TimerRef::new(self, |e| &e.event_loop_timer)
+    }
+
     /// Links this endpoint into the loop's driver list. Idempotent.
     fn link_loop_driver(&self) {
         if self.nq_registered.replace(true) {
@@ -1581,10 +1586,7 @@ impl QuicEndpoint {
         // time-driven state (RTO, ACK delay, idle) and the deferred close.
         self.mark_driver_pending();
         let next = bun_core::Timespec::ms_from_now(bun_core::TimespecMockMode::ForceRealTime, 1);
-        timer_all().update(
-            crate::timer::TimerRef::new(self, |e| &e.event_loop_timer),
-            &next,
-        );
+        timer_all().update(self.timer_ref(), &next);
     }
 
     fn rearm_timer(&self) {
@@ -1622,10 +1624,7 @@ impl QuicEndpoint {
                 bun_core::TimespecMockMode::ForceRealTime,
                 ms as i64,
             );
-            timer_all().update(
-                crate::timer::TimerRef::new(self, |e| &e.event_loop_timer),
-                &next,
-            );
+            timer_all().update(self.timer_ref(), &next);
         }
     }
 
@@ -2073,7 +2072,7 @@ impl QuicEndpoint {
         // Unlink first: the driver walk must never reach a freed endpoint.
         self.unlink_loop_driver();
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
-            timer_all().remove(crate::timer::TimerRef::new(self, |e| &e.event_loop_timer));
+            timer_all().remove(self.timer_ref());
         }
         for engine in [
             self.server_engine.replace(null_mut()),
@@ -2121,10 +2120,7 @@ impl QuicEndpoint {
         self.poll_ref.with_mut(|p| p.ref_(bun_io::js_vm_ctx()));
         self.pending_endpoint_close.set(true);
         let next = bun_core::Timespec::ms_from_now(bun_core::TimespecMockMode::ForceRealTime, 1);
-        timer_all().update(
-            crate::timer::TimerRef::new(self, |e| &e.event_loop_timer),
-            &next,
-        );
+        timer_all().update(self.timer_ref(), &next);
     }
 
     fn apply_server_session_options(
@@ -2646,7 +2642,7 @@ impl QuicEndpoint {
         // Remove the timer before the backing storage drops, or a later heap
         // operation dereferences the freed node.
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
-            timer_all().remove(crate::timer::TimerRef::new(&*self, |e| &e.event_loop_timer));
+            timer_all().remove(self.timer_ref());
         }
         self.release_native();
     }

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -14,7 +14,7 @@ use bun_jsc::{
 use bun_lsquic_sys as lsquic;
 use bun_uws as uws;
 
-use crate::jsc_hooks::timer_all_mut as timer_all;
+use crate::jsc_hooks::timer_all;
 use crate::timer::{EventLoopTimer, EventLoopTimerState, EventLoopTimerTag};
 
 use super::callbacks;
@@ -1582,9 +1582,7 @@ impl QuicEndpoint {
         self.mark_driver_pending();
         let next = bun_core::Timespec::ms_from_now(bun_core::TimespecMockMode::ForceRealTime, 1);
         timer_all().update(
-            core::ptr::addr_of!(self.event_loop_timer)
-                .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>()
-                .cast_mut(),
+            crate::timer::TimerRef::new(self, |e| &e.event_loop_timer),
             &next,
         );
     }
@@ -1625,9 +1623,7 @@ impl QuicEndpoint {
                 ms as i64,
             );
             timer_all().update(
-                core::ptr::addr_of!(self.event_loop_timer)
-                    .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>()
-                    .cast_mut(),
+                crate::timer::TimerRef::new(self, |e| &e.event_loop_timer),
                 &next,
             );
         }
@@ -2077,7 +2073,7 @@ impl QuicEndpoint {
         // Unlink first: the driver walk must never reach a freed endpoint.
         self.unlink_loop_driver();
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
-            timer_all().remove(self.event_loop_timer.as_ptr());
+            timer_all().remove(crate::timer::TimerRef::new(self, |e| &e.event_loop_timer));
         }
         for engine in [
             self.server_engine.replace(null_mut()),
@@ -2126,9 +2122,7 @@ impl QuicEndpoint {
         self.pending_endpoint_close.set(true);
         let next = bun_core::Timespec::ms_from_now(bun_core::TimespecMockMode::ForceRealTime, 1);
         timer_all().update(
-            core::ptr::addr_of!(self.event_loop_timer)
-                .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>()
-                .cast_mut(),
+            crate::timer::TimerRef::new(self, |e| &e.event_loop_timer),
             &next,
         );
     }
@@ -2652,7 +2646,7 @@ impl QuicEndpoint {
         // Remove the timer before the backing storage drops, or a later heap
         // operation dereferences the freed node.
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
-            timer_all().remove(self.event_loop_timer.as_ptr());
+            timer_all().remove(crate::timer::TimerRef::new(&*self, |e| &e.event_loop_timer));
         }
         self.release_native();
     }

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -108,7 +108,7 @@ pub struct Handlers {
     pub(crate) on_keylog: fn(*mut (), &[u8]),
 }
 
-use crate::jsc_hooks::timer_all_mut as timer_all;
+use crate::jsc_hooks::timer_all;
 
 /// Lazily create-and-cache a JS host-function callback in `shadow`, mirrored
 /// into the owning `JSTLSSocket` wrapper's visited `values:` slot (the GC
@@ -359,10 +359,8 @@ impl UpgradedDuplex {
                 vm.script_execution_status() != bun_jsc::ScriptExecutionStatus::Running
             });
 
-        self.event_loop_timer.with_mut(|t| {
-            t.state = EventLoopTimerState::FIRED;
-            t.heap = Default::default();
-        });
+        self.event_loop_timer
+            .with_mut(|t| t.state = EventLoopTimerState::FIRED);
 
         if has_been_cleared {
             return;
@@ -589,7 +587,7 @@ impl UpgradedDuplex {
 
     fn set_timeout_in_milliseconds(&self, ms: c_uint) {
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
-            timer_all().remove(self.event_loop_timer.as_ptr());
+            timer_all().remove(crate::timer::TimerRef::new(self, |d| &d.event_loop_timer));
         }
         self.current_timeout.set(ms);
 
@@ -609,11 +607,7 @@ impl UpgradedDuplex {
                 nsec: next.nsec,
             };
         });
-        timer_all().insert(
-            core::ptr::addr_of!(self.event_loop_timer)
-                .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>()
-                .cast_mut(),
-        );
+        timer_all().insert(crate::timer::TimerRef::new(self, |d| &d.event_loop_timer));
     }
 
     #[uws_callback(export = "UpgradedDuplex__set_timeout")]

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -53,7 +53,7 @@ pub type CertError = crate::socket::upgraded_duplex::CertError;
 
 type WrapperType = SSLWrapper<*mut WindowsNamedPipe>;
 
-use crate::jsc_hooks::timer_all_mut as timer_all;
+use crate::jsc_hooks::timer_all;
 
 pub struct WindowsNamedPipe {
     pub(crate) wrapper: JsCell<Option<WrapperType>>,
@@ -538,10 +538,8 @@ impl WindowsNamedPipe {
         let has_been_cleared = self.event_loop_timer.get().state == EventLoopTimerState::CANCELLED
             || self.vm.script_execution_status() != bun_jsc::ScriptExecutionStatus::Running;
 
-        self.event_loop_timer.with_mut(|t| {
-            t.state = EventLoopTimerState::FIRED;
-            t.heap = Default::default();
-        });
+        self.event_loop_timer
+            .with_mut(|t| t.state = EventLoopTimerState::FIRED);
 
         if has_been_cleared {
             return;
@@ -1032,7 +1030,7 @@ impl WindowsNamedPipe {
 
     pub(crate) fn set_timeout_in_milliseconds(&self, ms: c_uint) {
         if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
-            timer_all().remove(self.event_loop_timer.as_ptr());
+            timer_all().remove(crate::timer::TimerRef::new(self, |p| &p.event_loop_timer));
         }
         self.current_timeout.set(ms);
 
@@ -1051,11 +1049,7 @@ impl WindowsNamedPipe {
                 nsec: next.nsec,
             };
         });
-        timer_all().insert(
-            core::ptr::addr_of!(self.event_loop_timer)
-                .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>()
-                .cast_mut(),
-        );
+        timer_all().insert(crate::timer::TimerRef::new(self, |p| &p.event_loop_timer));
     }
 
     #[bun_uws::uws_callback(export = "WindowsNamedPipe__set_timeout")]

--- a/src/runtime/socket/uws_handlers.rs
+++ b/src/runtime/socket/uws_handlers.rs
@@ -14,7 +14,6 @@ use core::ffi::{c_int, c_void};
 use core::ptr::NonNull;
 
 use bun_uws::{ConnectingSocket, NewSocketHandler};
-use bun_uws_sys::thunk;
 use bun_uws_sys::thunk::ExtSlot;
 use bun_uws_sys::vtable::Handler as VHandler;
 use bun_uws_sys::{CloseCode, us_bun_verify_error_t, us_socket_t};
@@ -336,42 +335,48 @@ impl LiftJsResult for JsResult<()> {
 macro_rules! impl_ns_socket_events_forward {
     ($Owner:ty, $Handler:ty) => {
         impl<const SSL: bool> NsSocketEvents<$Owner, SSL> for $Handler {
-            fn on_open(this: &mut $Owner, s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
+            fn on_open(this: ThisPtr<$Owner>, s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
                 Self::on_open(this, s).lift()
             }
             fn on_data(
-                this: &mut $Owner,
+                this: ThisPtr<$Owner>,
                 s: NewSocketHandler<SSL>,
                 data: &[u8],
             ) -> bun_jsc::JsResult<()> {
                 Self::on_data(this, s, data).lift()
             }
-            fn on_writable(this: &mut $Owner, s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
+            fn on_writable(
+                this: ThisPtr<$Owner>,
+                s: NewSocketHandler<SSL>,
+            ) -> bun_jsc::JsResult<()> {
                 Self::on_writable(this, s).lift()
             }
             fn on_close(
-                this: &mut $Owner,
+                this: ThisPtr<$Owner>,
                 s: NewSocketHandler<SSL>,
                 code: i32,
                 reason: Option<*mut c_void>,
             ) -> bun_jsc::JsResult<()> {
                 Self::on_close(this, s, code, reason).lift()
             }
-            fn on_timeout(this: &mut $Owner, s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
+            fn on_timeout(
+                this: ThisPtr<$Owner>,
+                s: NewSocketHandler<SSL>,
+            ) -> bun_jsc::JsResult<()> {
                 Self::on_timeout(this, s).lift()
             }
-            fn on_end(this: &mut $Owner, s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
+            fn on_end(this: ThisPtr<$Owner>, s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
                 Self::on_end(this, s).lift()
             }
             fn on_connect_error(
-                this: &mut $Owner,
+                this: ThisPtr<$Owner>,
                 s: NewSocketHandler<SSL>,
                 code: i32,
             ) -> bun_jsc::JsResult<()> {
                 Self::on_connect_error(this, s, code).lift()
             }
             fn on_handshake(
-                this: &mut $Owner,
+                this: ThisPtr<$Owner>,
                 s: NewSocketHandler<SSL>,
                 ok: i32,
                 err: us_bun_verify_error_t,
@@ -495,46 +500,49 @@ where
 
 /// The callbacks live on a separate namespace `H` (the driver's pre-existing
 /// `SocketHandler(ssl)` adapter) rather than as methods on the owner type
-/// itself. Ext stores `*Owner`; it is optional because a connect/accept can
+/// itself. Ext stores the owner's `ThisPtr` (written by the driver's connect
+/// path from its root pointer); it is optional because a connect/accept can
 /// fail and dispatch `on_close` / `on_connect_error` BEFORE the caller has
 /// had a chance to stash `this` in the freshly-calloc'd ext slot.
 ///
 /// In Rust the "separate namespace" becomes a trait `NsSocketEvents` whose
-/// methods take `&mut Owner` as the first parameter; each driver's
-/// `SocketHandler<SSL>` zero-sized type implements it.
+/// methods take the owner as a [`ThisPtr`] (the drivers are refcounted and a
+/// handler may release the last ref or re-enter through the same socket, so no
+/// `&mut Owner` may span the call); each driver's `SocketHandler<SSL>`
+/// zero-sized type implements it.
 trait NsSocketEvents<Owner, const SSL: bool> {
-    fn on_open(_this: &mut Owner, _s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
+    fn on_open(_this: ThisPtr<Owner>, _s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
         Ok(())
     }
     fn on_data(
-        _this: &mut Owner,
+        _this: ThisPtr<Owner>,
         _s: NewSocketHandler<SSL>,
         _data: &[u8],
     ) -> bun_jsc::JsResult<()> {
         Ok(())
     }
-    fn on_writable(_this: &mut Owner, _s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
+    fn on_writable(_this: ThisPtr<Owner>, _s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
         Ok(())
     }
     fn on_close(
-        _this: &mut Owner,
+        _this: ThisPtr<Owner>,
         _s: NewSocketHandler<SSL>,
         _code: i32,
         _reason: Option<*mut c_void>,
     ) -> bun_jsc::JsResult<()> {
         Ok(())
     }
-    fn on_timeout(_this: &mut Owner, _s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
+    fn on_timeout(_this: ThisPtr<Owner>, _s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
         Ok(())
     }
-    fn on_long_timeout(_this: &mut Owner, _s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
+    fn on_long_timeout(_this: ThisPtr<Owner>, _s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
         Ok(())
     }
-    fn on_end(_this: &mut Owner, _s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
+    fn on_end(_this: ThisPtr<Owner>, _s: NewSocketHandler<SSL>) -> bun_jsc::JsResult<()> {
         Ok(())
     }
     fn on_connect_error(
-        _this: &mut Owner,
+        _this: ThisPtr<Owner>,
         _s: NewSocketHandler<SSL>,
         _code: i32,
     ) -> bun_jsc::JsResult<()> {
@@ -542,7 +550,7 @@ trait NsSocketEvents<Owner, const SSL: bool> {
     }
     /// Default no-op covers adapters that leave the handshake slot unbound.
     fn on_handshake(
-        _this: &mut Owner,
+        _this: ThisPtr<Owner>,
         _s: NewSocketHandler<SSL>,
         _ok: i32,
         _err: us_bun_verify_error_t,
@@ -558,7 +566,7 @@ where
     Owner: 'static,
     H: NsSocketEvents<Owner, SSL> + 'static,
 {
-    type Ext = ExtSlot<Owner>;
+    type Ext = Option<ThisPtr<Owner>>;
 
     const HAS_ON_OPEN: bool = true;
     const HAS_ON_DATA: bool = true;
@@ -572,50 +580,45 @@ where
     const HAS_ON_HANDSHAKE: bool = true;
 
     fn on_open(ext: &mut Self::Ext, s: *mut us_socket_t, _is_client: bool, _ip: &[u8]) {
-        let Some(this) = ext.owner_mut() else { return };
+        let Some(this) = *ext else { return };
         fold(H::on_open(this, wrap::<SSL>(s)));
     }
     fn on_data(ext: &mut Self::Ext, s: *mut us_socket_t, data: &[u8]) {
-        let Some(this) = ext.owner_mut() else { return };
+        let Some(this) = *ext else { return };
         fold(H::on_data(this, wrap::<SSL>(s), data));
     }
     fn on_writable(ext: &mut Self::Ext, s: *mut us_socket_t) {
-        let Some(this) = ext.owner_mut() else { return };
+        let Some(this) = *ext else { return };
         fold(H::on_writable(this, wrap::<SSL>(s)));
     }
     fn on_close(ext: &mut Self::Ext, s: *mut us_socket_t, code: i32, reason: Option<*mut c_void>) {
-        let Some(this) = ext.owner_mut() else { return };
+        let Some(this) = *ext else { return };
         fold(H::on_close(this, wrap::<SSL>(s), code, reason));
     }
     fn on_timeout(ext: &mut Self::Ext, s: *mut us_socket_t) {
-        let Some(this) = ext.owner_mut() else { return };
+        let Some(this) = *ext else { return };
         fold(H::on_timeout(this, wrap::<SSL>(s)));
     }
     fn on_long_timeout(ext: &mut Self::Ext, s: *mut us_socket_t) {
-        let Some(this) = ext.owner_mut() else { return };
+        let Some(this) = *ext else { return };
         fold(H::on_long_timeout(this, wrap::<SSL>(s)));
     }
     fn on_end(ext: &mut Self::Ext, s: *mut us_socket_t) {
-        let Some(this) = ext.owner_mut() else { return };
+        let Some(this) = *ext else { return };
         fold(H::on_end(this, wrap::<SSL>(s)));
     }
     fn on_connect_error(ext: &mut Self::Ext, s: *mut us_socket_t, code: i32) {
         // Close before notify — see RawPtrHandler::on_connect_error.
-        let this = ext.get();
+        let this = *ext;
         // `us_socket_t` is an `opaque_ffi!` ZST — `opaque_mut` is the safe
         // deref (`s` is a live socket passed by the trampoline).
         us_socket_t::opaque_mut(s).close(CloseCode::failure);
-        // SAFETY: snapshot of the ext slot taken before close; unique heap
-        // owner, single-threaded dispatch (same contract as `ExtSlot::owner_mut`).
-        if let Some(t) = unsafe { thunk::ext_owner(&this) } {
+        if let Some(t) = this {
             fold(H::on_connect_error(t, wrap::<SSL>(s), code));
         }
     }
     fn on_connecting_error(c: *mut ConnectingSocket, code: i32) {
-        let Some(this) = ConnectingSocket::opaque_mut(c)
-            .ext::<ExtSlot<Owner>>()
-            .owner_mut()
-        else {
+        let Some(this) = *ConnectingSocket::opaque_mut(c).ext::<Option<ThisPtr<Owner>>>() else {
             return;
         };
         fold(H::on_connect_error(
@@ -630,7 +633,7 @@ where
         ok: bool,
         err: us_bun_verify_error_t,
     ) {
-        let Some(this) = ext.owner_mut() else { return };
+        let Some(this) = *ext else { return };
         fold(H::on_handshake(this, wrap::<SSL>(s), ok as i32, err));
     }
 }

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -27,10 +27,8 @@ pub(crate) use group_begin;
 /// Recover this thread's `timer::All` heap (jsc/runtime crate cycle: `vm.timer` is `()` in
 /// the low-tier `VirtualMachine`; the real value lives in `RuntimeState`).
 #[inline]
-pub(super) fn vm_timer<'a>() -> &'a mut crate::timer::All {
-    // SAFETY: `runtime_state()` is non-null after `bun_runtime::init()`;
-    // single JS thread, raw-ptr-per-field re-entry pattern (jsc_hooks.rs).
-    unsafe { &mut (*crate::jsc_hooks::runtime_state()).timer }
+pub(super) fn vm_timer() -> &'static crate::timer::All {
+    crate::jsc_hooks::timer_all()
 }
 
 /// `bun.timespec.orderIgnoreEpoch` — epoch == "no timeout", treated as +∞.
@@ -982,14 +980,14 @@ impl BunTest {
             bun_core::scoped_log!(bun_test_group, "-> setting timer to {:?}", min_timeout);
             if self.timer.next != ElTimespec::EPOCH {
                 bun_core::scoped_log!(bun_test_group, "-> removing existing timer");
-                vm_timer().remove(&raw mut self.timer);
+                vm_timer().remove(crate::timer::TimerRef::from_mut(self, |t| &mut t.timer));
             }
             // `EventLoopTimer.next` uses the event-loop crate's local
             // `Timespec` (distinct from `bun_core::Timespec`); convert by field.
             self.timer.next = ElTimespec { sec: min_timeout.sec, nsec: min_timeout.nsec };
             if self.timer.next != ElTimespec::EPOCH {
                 bun_core::scoped_log!(bun_test_group, "-> inserting timer");
-                vm_timer().insert(&raw mut self.timer);
+                vm_timer().insert(crate::timer::TimerRef::from_mut(self, |t| &mut t.timer));
                 if debug::group::get_log_enabled() {
                     let duration = min_timeout.since_now_force_real_time();
                     bun_core::scoped_log!(bun_test_group, "-> timer duration: {}", duration);
@@ -1359,7 +1357,7 @@ impl Drop for BunTest {
 
         if self.timer.state == EventLoopTimerState::ACTIVE {
             // must remove an active timer to prevent UAF (if the timer were to trigger after BunTest deinit)
-            vm_timer().remove(&raw mut self.timer);
+            vm_timer().remove(crate::timer::TimerRef::from_mut(self, |t| &mut t.timer));
         }
 
         for entry in self.extra_execution_entries.drain(..) {

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -206,7 +206,7 @@ impl<'a> TestRunner<'a> {
             return;
         }
         let _ = vm;
-        bun_test::vm_timer().remove(&raw mut active_file.timer);
+        bun_test::vm_timer().remove(crate::timer::TimerRef::from_mut(active_file, |t| &mut t.timer));
     }
 
 

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -4,13 +4,11 @@ use bun_threading::RwLock;
 
 use bun_core::Environment;
 use bun_core::Timespec;
+use core::cell::Cell;
+
 use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSHostFn, JSValue, JsResult};
-use crate::api::cron::CronJob;
 use crate::jsc::virtual_machine::VirtualMachine;
-use crate::timer::{
-    AbortSignalTimeout, ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag,
-    InHeap, TimerObjectInternals, TimeoutObject, TimerHeap,
-};
+use crate::timer::{EventLoopTimerState, InHeap, TimerHeap, TimerRef};
 
 // JSMock C++ bindings (fake timers are only used by bun:test, so these stay local).
 unsafe extern "C" {
@@ -18,14 +16,22 @@ unsafe extern "C" {
     safe fn JSMock__getCurrentUnixTimeMs() -> f64;
 }
 
-#[derive(Default)]
 pub struct FakeTimers {
-    active: bool,
+    active: Cell<bool>,
     /// The sorted fake timers. TimerHeap is not optimal here because we need these operations:
     /// - peek/takeFirst (provided by TimerHeap)
     /// - peekLast (cannot be implemented efficiently with TimerHeap)
     /// - count (cannot be implemented efficiently with TimerHeap)
     pub(crate) timers: TimerHeap,
+}
+
+impl Default for FakeTimers {
+    fn default() -> Self {
+        Self {
+            active: Cell::new(false),
+            timers: TimerHeap::new(InHeap::Fake),
+        }
+    }
 }
 
 // `date_now_offset` is stored as `AtomicU64` (f64 bits) so the static is `Sync`
@@ -122,67 +128,38 @@ extern "C" fn Bun__FakeTimers__setSystemTime(global: &JSGlobalObject, ms: f64) {
 
 use crate::jsc_hooks::timer_all;
 
-#[inline]
-fn from_el_timespec(t: &ElTimespec) -> Timespec {
-    Timespec { sec: t.sec, nsec: t.nsec }
-}
-
-/// Owners of the nodes [`FakeTimers::clear`] popped, still to be told their
-/// timer is gone. Released only once the `FakeTimers` borrow has ended: these
-/// paths re-enter `timer::All` (`TimerObjectInternals::cancel` → `All::remove`,
-/// `Timeout` deinit → `timer_remove`).
+/// Owners of the slots [`FakeTimers::clear`] popped, still to be told their
+/// timer is gone: marking `state = CANCELLED` alone would strand a
+/// `TimeoutObject` (the heap's ref and its `this_value` Strong pin each
+/// other), leave an `AbortSignal.timeout()` box as its signal's `m_timeout`
+/// (pinning an observed signal's wrapper), and leave a `Bun.cron()` job keeping
+/// the event loop alive. Releasing re-enters `timer::All`.
 #[derive(Default)]
 #[must_use]
-struct ClearedTimers {
-    /// Marking `state = CANCELLED` alone strands the `Box<TimeoutObject>`: its
-    /// refcount sticks at 2 (wrapper +1 from `init_with`, heap +1 from
-    /// `reschedule`) and `internals.this_value` still GC-roots the wrapper, so
-    /// neither side ever frees.
-    pinned: Vec<core::ptr::NonNull<TimerObjectInternals>>,
-    /// Likewise, an unlinked `AbortSignal.timeout()` timer is still its
-    /// signal's `m_timeout`, and `JSAbortSignalOwner::isReachableFromOpaqueRoots`
-    /// pins an observed signal's wrapper for as long as that is set. Only the
-    /// signal's `cancelTimer()` clears it (and frees the box).
-    signal_timeouts: Vec<*mut AbortSignalTimeout>,
-    /// A `Bun.cron()` job keeps the event loop alive until it is stopped.
-    cron_jobs: Vec<*mut CronJob>,
-}
+struct ClearedTimers(Vec<TimerRef>);
 
 impl ClearedTimers {
-    fn release(self, vm: *mut VirtualMachine) {
-        for p in self.pinned {
-            TimerObjectInternals::release_heap_pin(p, vm);
-        }
-        for t in self.signal_timeouts {
-            // SAFETY: `clear` popped `t` from the fake heap, so its box is
-            // still owned by a live signal; JS thread; the `FakeTimers` borrow
-            // ended before this call. `t` is freed by the call.
-            unsafe { AbortSignalTimeout::discard(t) };
-        }
-        for job in self.cron_jobs {
-            // SAFETY: `clear` popped `job`'s node from the fake heap, so the
-            // job was scheduled and its JS wrapper (strong while scheduled)
-            // keeps it alive; no JS has run since; the `FakeTimers` borrow
-            // ended before this call.
-            CronJob::stop_dropped_from_fake_heap(unsafe { bun_ptr::ThisPtr::new(job) });
+    fn release(self, vm: &VirtualMachine) {
+        for t in self.0 {
+            crate::dispatch::cancel_js_timer(t, vm);
         }
     }
 }
 
 impl FakeTimers {
     pub(crate) fn is_active(&self) -> bool {
-        self.active
+        self.active.get()
     }
 
-    fn activate(&mut self, js_now: f64, global: &JSGlobalObject) {
-        self.active = true;
+    fn activate(&self, js_now: f64, global: &JSGlobalObject) {
+        self.active.set(true);
         CURRENT_TIME.set(global, &Timespec::EPOCH, Some(js_now));
     }
 
-    fn deactivate(&mut self, global: &JSGlobalObject) -> ClearedTimers {
+    fn deactivate(&self, global: &JSGlobalObject) -> ClearedTimers {
         let cleared = self.clear();
         CURRENT_TIME.clear(global);
-        self.active = false;
+        self.active.set(false);
         cleared
     }
 
@@ -191,54 +168,31 @@ impl FakeTimers {
     /// `cancel_all_timeout_objects` (which runs after the outgoing global's
     /// JS has stopped) can walk the still-populated fake heap and release
     /// `TimeoutObject` pins and discard `AbortSignalTimeout` timers.
-    pub(crate) fn reset_for_isolation(&mut self, global: &JSGlobalObject) {
+    pub(crate) fn reset_for_isolation(&self, global: &JSGlobalObject) {
         CURRENT_TIME.clear(global);
-        self.active = false;
+        self.active.set(false);
     }
 
     /// Pop every fake timer. Popping only unlinks the nodes; the owners that
     /// need to hear about it are returned for the caller to release.
-    fn clear(&mut self) -> ClearedTimers {
+    fn clear(&self) -> ClearedTimers {
         let mut cleared = ClearedTimers::default();
         while let Some(timer) = self.timers.delete_min() {
-            // SAFETY: `delete_min` returned a live node; the owner it belongs
-            // to stays live until the caller's release pass.
-            unsafe {
-                (*timer).in_heap = InHeap::None;
-                (*timer).state = EventLoopTimerState::CANCELLED;
-                match (*timer).tag {
-                    EventLoopTimerTag::TimeoutObject => {
-                        let parent = TimeoutObject::from_timer_ptr(timer);
-                        cleared.pinned.push(core::ptr::NonNull::new_unchecked(
-                            core::ptr::addr_of_mut!((*parent).internals),
-                        ));
-                    }
-                    EventLoopTimerTag::AbortSignalTimeout => {
-                        cleared
-                            .signal_timeouts
-                            .push(AbortSignalTimeout::from_timer_ptr(timer));
-                    }
-                    EventLoopTimerTag::CronJob => {
-                        cleared.cron_jobs.push(CronJob::from_timer_ptr(timer));
-                    }
-                    tag => debug_assert!(
-                        false,
-                        "{} timer in the fake heap has no release path",
-                        <&'static str>::from(tag),
-                    ),
-                }
-            }
+            timer.set_state(EventLoopTimerState::CANCELLED);
+            debug_assert!(
+                timer.tag().allow_fake_timers(),
+                "{} timer in the fake heap has no release path",
+                <&'static str>::from(timer.tag()),
+            );
+            cleared.0.push(timer);
         }
 
         cleared
     }
 
     fn execute_next(global: &JSGlobalObject) -> JsResult<bool> {
-        // SAFETY: `timer_all()` is the live per-thread `All`; the borrow ends
-        // at this statement, before `fire` re-enters `All::insert`.
-        let next = match unsafe { (*timer_all()).fake_timers.timers.delete_min() } {
-            Some(n) => n,
-            None => return Ok(false),
+        let Some(next) = timer_all().fake_timers.timers.delete_min() else {
+            return Ok(false);
         };
 
         Self::fire(global, next)?;
@@ -249,21 +203,17 @@ impl FakeTimers {
     /// clock is a timer drain of its own: like `All::drain_timers`, a
     /// timer whose callback threw is reported and the drain goes on; only the
     /// VM's termination stops it, thrown to the `jest` host function driving it.
-    fn fire(global: &JSGlobalObject, next: *mut EventLoopTimer) -> JsResult<()> {
-        let _vm = global.bun_vm();
+    fn fire(global: &JSGlobalObject, next: TimerRef) -> JsResult<()> {
+        let vm = global.bun_vm();
 
-        // SAFETY: `next` was just popped from our heap; live until callback completes.
-        let now_el = unsafe { (*next).next };
-        let now = from_el_timespec(&now_el);
+        let now = next.next();
         if Environment::CI_ASSERT {
             let prev = CURRENT_TIME.get_timespec_now();
             debug_assert!(prev.is_some());
             debug_assert!(now.eql(&prev.unwrap()) || now.greater(&prev.unwrap()));
         }
         CURRENT_TIME.set(global, &now, None);
-        // SAFETY: `next` is live; `fire` takes `*mut Self` (noalias re-entrancy)
-        // and an erased `*mut ()` for the VM.
-        let fired = unsafe { EventLoopTimer::fire(next, &now_el, bun_jsc::virtual_machine::VirtualMachine::get_mut_ptr().cast()) };
+        let fired = crate::dispatch::fire_timer(next, &now, vm);
         match fired {
             Ok(()) => Ok(()),
             Err(err) => bun_jsc::task::report_error_or_terminate(global, err)
@@ -272,38 +222,28 @@ impl FakeTimers {
     }
 
     fn execute_until(global: &JSGlobalObject, until: Timespec) -> JsResult<()> {
-        let all = timer_all();
-        'outer: loop {
-            let next = 'blk: {
-                // SAFETY: `all` is the live per-thread `All`; each borrow
-                // lasts one statement and none spans `fire`.
-                let Some(peek) = (unsafe { (*all).fake_timers.timers.peek() }) else {
-                    break 'outer;
-                };
-                // SAFETY: `peek` is the heap root; live while linked.
-                if from_el_timespec(unsafe { &(*peek).next }).greater(&until) {
-                    break 'outer;
-                }
-                // bun.assert always evaluates its arg; debug_assert! does NOT in release.
-                // Hoist the side-effecting delete_min() out so the timer is removed in all builds.
-                // SAFETY: as above.
-                let min = unsafe { (*all).fake_timers.timers.delete_min() }.expect("unreachable");
-                debug_assert!(core::ptr::eq(min, peek));
-                break 'blk min;
+        let timers = &timer_all().fake_timers.timers;
+        loop {
+            let Some(peek) = timers.peek() else {
+                break;
             };
+            if peek.next().greater(&until) {
+                break;
+            }
+            // bun.assert always evaluates its arg; debug_assert! does NOT in release.
+            // Hoist the side-effecting delete_min() out so the timer is removed in all builds.
+            let next = timers.delete_min().expect("unreachable");
+            debug_assert!(next == peek);
             Self::fire(global, next)?;
         }
         Ok(())
     }
 
     fn execute_only_pending_timers(global: &JSGlobalObject) -> JsResult<()> {
-        // SAFETY: `timer_all()` is the live per-thread `All`.
-        let until = match unsafe { (*timer_all()).fake_timers.timers.find_max() } {
-            // SAFETY: `t` is reachable in the heap and live while linked.
-            Some(t) => from_el_timespec(unsafe { &(*t).next }),
-            None => return Ok(()),
+        let Some(last) = timer_all().fake_timers.timers.find_max() else {
+            return Ok(());
         };
-        Self::execute_until(global, until)
+        Self::execute_until(global, last.next())
     }
 
     fn execute_all_timers(global: &JSGlobalObject) -> JsResult<()> {
@@ -317,8 +257,7 @@ impl FakeTimers {
 // ===
 
 fn error_unless_fake_timers(global: &JSGlobalObject) -> JsResult<()> {
-    // SAFETY: per-thread `timer::All`, live for the VM lifetime.
-    if unsafe { (*timer_all()).fake_timers.is_active() } {
+    if timer_all().fake_timers.is_active() {
         return Ok(());
     }
     Err(global.throw(format_args!(
@@ -384,8 +323,7 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
         }
     }
 
-    // SAFETY: per-thread `timer::All`; `activate` does not re-enter `All`.
-    unsafe { (*timer_all()).fake_timers.activate(js_now, global) };
+    timer_all().fake_timers.activate(js_now, global);
 
     // Set setTimeout.clock = true to signal that fake timers are enabled.
     // This is used by testing-library/react to detect if jest.advanceTimersByTime should be called.
@@ -396,9 +334,8 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
 
 #[bun_jsc::host_fn]
 fn use_real_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    // SAFETY: per-thread `timer::All`; the borrow ends before `release`.
-    let cleared = unsafe { (*timer_all()).fake_timers.deactivate(global) };
-    cleared.release(global.bun_vm_ptr());
+    let cleared = timer_all().fake_timers.deactivate(global);
+    cleared.release(global.bun_vm());
 
     // Remove the setTimeout.clock marker when switching back to real timers.
     set_fake_timer_marker(global, false)?;
@@ -473,8 +410,7 @@ fn run_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValu
 fn get_timer_count(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
     error_unless_fake_timers(global)?;
 
-    // SAFETY: per-thread `timer::All`, live for the VM lifetime.
-    let count = unsafe { (*timer_all()).fake_timers.timers.count() };
+    let count = timer_all().fake_timers.timers.count();
 
     Ok(JSValue::js_number(count as f64))
 }
@@ -483,17 +419,15 @@ fn get_timer_count(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSVa
 fn clear_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     error_unless_fake_timers(global)?;
 
-    // SAFETY: per-thread `timer::All`; the borrow ends before `release`.
-    let cleared = unsafe { (*timer_all()).fake_timers.clear() };
-    cleared.release(global.bun_vm_ptr());
+    let cleared = timer_all().fake_timers.clear();
+    cleared.release(global.bun_vm());
 
     Ok(frame.this())
 }
 
 #[bun_jsc::host_fn]
 fn is_fake_timers(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
-    // SAFETY: per-thread `timer::All`, live for the VM lifetime.
-    let is_active = unsafe { (*timer_all()).fake_timers.is_active() };
+    let is_active = timer_all().fake_timers.is_active();
 
     Ok(JSValue::from(is_active))
 }

--- a/src/runtime/timer/DateHeaderTimer.rs
+++ b/src/runtime/timer/DateHeaderTimer.rs
@@ -13,20 +13,15 @@
 //!
 //! Note that we only check for potential updates ot this timer once per event loop tick.
 
+use crate::jsc_hooks::timer_all_opt;
 use bun_jsc::virtual_machine::VirtualMachine;
-use bun_uws::Loop;
 
-use crate::jsc_hooks::timer_all;
-
-#[unsafe(no_mangle)]
-extern "C" fn Bun__internal_ensureDateHeaderTimerIsEnabled(loop_: *mut Loop) {
-    if let Some(vm_ptr) = VirtualMachine::get_or_null() {
-        // SAFETY: loop_ is a valid uws Loop pointer passed from C++ and lives
-        // for the call duration.
-        let loop_ref = unsafe { &*loop_ };
-        // SAFETY: single JS thread; `timer_all()` returns the live per-thread
-        // `All` (non-null after init). `update_date_header_timer_if_necessary`
-        // takes the VM by raw pointer to avoid aliased-`&mut` (jsc/runtime crate cycle).
-        unsafe { (*timer_all()).update_date_header_timer_if_necessary(loop_ref, vm_ptr) };
+// HOST_EXPORT(Bun__internal_ensureDateHeaderTimerIsEnabled, c)
+pub fn ensure_date_header_timer_is_enabled(loop_: &bun_uws::Loop) {
+    if VirtualMachine::get_or_null().is_none() {
+        return;
+    }
+    if let Some(all) = timer_all_opt() {
+        all.update_date_header_timer_if_necessary(loop_, VirtualMachine::get());
     }
 }

--- a/src/runtime/timer/EventLoopDelayMonitor.rs
+++ b/src/runtime/timer/EventLoopDelayMonitor.rs
@@ -1,30 +1,20 @@
 use bun_jsc::JSValue;
-use bun_jsc::virtual_machine::VirtualMachine;
 
-// Export functions for C++
-#[unsafe(no_mangle)]
-extern "C" fn Timer_enableEventLoopDelayMonitoring(
-    vm: *mut VirtualMachine,
+use crate::jsc_hooks::timer_all;
+
+// HOST_EXPORT(Timer_enableEventLoopDelayMonitoring, c)
+pub fn enable_event_loop_delay_monitoring(
+    vm: &bun_jsc::virtual_machine::VirtualMachine,
     histogram: JSValue,
     resolution_ms: i32,
 ) {
-    // SAFETY: vm is a valid non-null pointer passed from C++.
-    let vm = unsafe { &mut *vm };
-    // `vm.timer` is `()` (jsc/runtime crate cycle) — recover `All` via runtime_state().
-    let state = crate::jsc_hooks::runtime_state();
-    // SAFETY: `runtime_state()` is non-null after `bun_runtime::init()`; single
-    // JS thread, raw-ptr-per-field re-entry pattern (jsc_hooks.rs).
-    unsafe {
-        (*state)
-            .timer
-            .event_loop_delay
-            .enable(vm, histogram, resolution_ms)
-    };
+    let all = timer_all();
+    all.event_loop_delay
+        .enable(vm, all, histogram, resolution_ms);
 }
 
-#[unsafe(no_mangle)]
-extern "C" fn Timer_disableEventLoopDelayMonitoring() {
-    let state = crate::jsc_hooks::runtime_state();
-    // SAFETY: see `Timer_enableEventLoopDelayMonitoring`.
-    unsafe { (*state).timer.event_loop_delay.disable() };
+// HOST_EXPORT(Timer_disableEventLoopDelayMonitoring, c)
+pub fn disable_event_loop_delay_monitoring() {
+    let all = timer_all();
+    all.event_loop_delay.disable(all);
 }

--- a/src/runtime/timer/ImmediateObject.rs
+++ b/src/runtime/timer/ImmediateObject.rs
@@ -1,14 +1,36 @@
+use core::cell::Cell;
+
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{JSGlobalObject, JSValue};
+use bun_ptr::{JsCell, RefPtr, ThisPtr};
 
-use super::{Kind, TimerObjectInternals};
+use super::{EventLoopTimer, IdMap, Kind, Maps, TimerObject, TimerObjectInternals};
 
 // `jsc.Codegen.JSImmediate` — the C++ JSCell wrapper stays generated; this
-// struct is the `m_ctx` payload. Struct + `RefCounted`/`Default` impls + the
+// struct is the `m_ctx` payload. Struct + `RefCounted`/`Drop` impls + the
 // forwarder host-fns (`to_primitive`/`do_ref`/`do_unref`/`has_ref`/
-// `get_destroyed`/`dispose`/`constructor`/`finalize`/`ref_`/`deref`/`deinit`/
-// `init_with`) — see `impl_timer_object!` in `super` (timer/mod.rs).
+// `get_destroyed`/`dispose`/`constructor`/`finalize`/`init_with`) — see
+// `impl_timer_object!` in `super` (timer/mod.rs).
 super::impl_timer_object!(ImmediateObject, ImmediateObject, "Immediate");
+
+impl TimerObject for ImmediateObject {
+    #[inline]
+    fn internals(&self) -> &TimerObjectInternals {
+        &self.internals
+    }
+    #[inline]
+    fn event_loop_timer(&self) -> &JsCell<EventLoopTimer> {
+        &self.event_loop_timer
+    }
+    #[inline]
+    fn heap_ref(&self) -> &Cell<Option<RefPtr<Self>>> {
+        &self.heap_ref
+    }
+    #[inline]
+    fn id_map(maps: &mut Maps, _kind: Kind) -> &mut IdMap<Self> {
+        &mut maps.set_immediate
+    }
+}
 
 impl ImmediateObject {
     pub(crate) fn init(
@@ -20,35 +42,19 @@ impl ImmediateObject {
         Self::init_with(global, id, Kind::SetImmediate, 0, callback, arguments)
     }
 
-    /// Thin forwarder to
-    /// `internals.run_immediate_task`. Reached from `bun_jsc::event_loop`
-    /// via `__bun_run_immediate_task` (definer in [`crate::dispatch`]).
-    ///
-    /// Returns `true` if an exception was thrown.
-    ///
-    /// # Safety
-    /// `this` was produced by `enqueue_immediate_task` from a live
-    /// heap-allocated `ImmediateObject`; `vm` is the live per-thread VM.
+    /// Reached from `bun_jsc::event_loop` via `__bun_run_immediate_task`
+    /// (definer in [`crate::dispatch`]). Returns `true` if an exception was
+    /// thrown. `this` carries the immediate queue's ref; it may be gone once
+    /// this returns.
     #[inline]
-    pub(crate) unsafe fn run_immediate_task(this: *mut Self, vm: *mut VirtualMachine) -> bool {
-        // SAFETY: per fn contract — `this` is live; `internals` is an embedded
-        // field. Do NOT form `&mut *this` (the body may `deref()` and free).
-        // `run_immediate_task` takes `*mut Self` (noalias re-entrancy).
-        unsafe {
-            TimerObjectInternals::run_immediate_task(core::ptr::addr_of_mut!((*this).internals), vm)
-        }
+    pub(crate) fn run_immediate_task(this: ThisPtr<Self>, vm: &VirtualMachine) -> bool {
+        TimerObject::run_immediate_task(this, vm)
     }
 
-    /// # Safety
-    /// `this` must be a live heap-allocated `ImmediateObject`.
+    /// Release the immediate queue's ref without running the callback (VM
+    /// teardown). `this` may be gone once this returns.
     #[inline]
-    pub(crate) unsafe fn cancel_pending(this: *mut Self, vm: *mut VirtualMachine) {
-        // SAFETY: do not form `&mut *this` — the body derefs and may free `*this`.
-        unsafe {
-            TimerObjectInternals::cancel_pending_immediate(
-                core::ptr::addr_of_mut!((*this).internals),
-                vm,
-            );
-        }
+    pub(crate) fn cancel_pending(this: ThisPtr<Self>, _vm: &VirtualMachine) {
+        TimerObject::cancel_pending_immediate(this);
     }
 }

--- a/src/runtime/timer/TimeoutObject.rs
+++ b/src/runtime/timer/TimeoutObject.rs
@@ -1,13 +1,38 @@
+use core::cell::Cell;
+
 use bun_jsc::generated::JSTimeout as js;
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
+use bun_ptr::{JsCell, RefPtr, ThisPtr};
 
-use super::Kind;
+use super::{EventLoopTimer, IdMap, Kind, Maps, TimerObject, TimerObjectInternals};
 
-// Struct + `RefCounted`/`Default` impls + the forwarder host-fns
+// Struct + `RefCounted`/`Drop` impls + the forwarder host-fns
 // (`to_primitive`/`do_ref`/`do_unref`/`has_ref`/`get_destroyed`/`dispose`/
-// `constructor`/`finalize`/`ref_`/`deref`/`deinit`/`init_with`) — see
-// `impl_timer_object!` in `super` (timer/mod.rs).
+// `constructor`/`finalize`/`init_with`) — see `impl_timer_object!` in `super`
+// (timer/mod.rs).
 super::impl_timer_object!(TimeoutObject, TimeoutObject, "Timeout");
+
+impl TimerObject for TimeoutObject {
+    #[inline]
+    fn internals(&self) -> &TimerObjectInternals {
+        &self.internals
+    }
+    #[inline]
+    fn event_loop_timer(&self) -> &JsCell<EventLoopTimer> {
+        &self.event_loop_timer
+    }
+    #[inline]
+    fn heap_ref(&self) -> &Cell<Option<RefPtr<Self>>> {
+        &self.heap_ref
+    }
+    #[inline]
+    fn id_map(maps: &mut Maps, kind: Kind) -> &mut IdMap<Self> {
+        match kind {
+            Kind::SetInterval => &mut maps.set_interval,
+            _ => &mut maps.set_timeout,
+        }
+    }
+}
 
 impl TimeoutObject {
     pub(crate) fn init(
@@ -23,16 +48,20 @@ impl TimeoutObject {
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn do_refresh(
-        this: &Self,
+        this: ThisPtr<Self>,
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        this.internals.do_refresh(global, frame.this())
+        TimerObject::do_refresh(this, global, frame.this())
     }
 
     #[bun_jsc::host_fn(method)]
-    pub fn close(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        this.internals.cancel(global.bun_vm_ptr());
+    pub fn close(
+        this: ThisPtr<Self>,
+        _global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        TimerObject::cancel(this);
         Ok(frame.this())
     }
 
@@ -41,16 +70,12 @@ impl TimeoutObject {
     // Signature does not match the standard `host_fn(getter/setter)` shape; the
     // `#[JsClass]` derive emits the C-ABI shims directly.
 
-    pub(crate) fn get_on_timeout(
-        _this: &Self,
-        this_value: JSValue,
-        _global: &JSGlobalObject,
-    ) -> JSValue {
+    pub(crate) fn get_on_timeout(&self, this_value: JSValue, _global: &JSGlobalObject) -> JSValue {
         js::callback_get_cached(this_value).unwrap()
     }
 
     pub(crate) fn set_on_timeout(
-        _this: &Self,
+        &self,
         this_value: JSValue,
         global: &JSGlobalObject,
         value: JSValue,
@@ -59,7 +84,7 @@ impl TimeoutObject {
     }
 
     pub(crate) fn get_idle_timeout(
-        _this: &Self,
+        &self,
         this_value: JSValue,
         _global: &JSGlobalObject,
     ) -> JSValue {
@@ -67,7 +92,7 @@ impl TimeoutObject {
     }
 
     pub(crate) fn set_idle_timeout(
-        _this: &Self,
+        &self,
         this_value: JSValue,
         global: &JSGlobalObject,
         value: JSValue,
@@ -75,39 +100,26 @@ impl TimeoutObject {
         js::idle_timeout_set_cached(this_value, global, value);
     }
 
-    pub(crate) fn get_repeat(
-        _this: &Self,
-        this_value: JSValue,
-        _global: &JSGlobalObject,
-    ) -> JSValue {
+    pub(crate) fn get_repeat(&self, this_value: JSValue, _global: &JSGlobalObject) -> JSValue {
         js::repeat_get_cached(this_value).unwrap()
     }
 
-    pub(crate) fn set_repeat(
-        _this: &Self,
-        this_value: JSValue,
-        global: &JSGlobalObject,
-        value: JSValue,
-    ) {
+    pub(crate) fn set_repeat(&self, this_value: JSValue, global: &JSGlobalObject, value: JSValue) {
         js::repeat_set_cached(this_value, global, value);
     }
 
-    pub(crate) fn get_idle_start(
-        _this: &Self,
-        this_value: JSValue,
-        _global: &JSGlobalObject,
-    ) -> JSValue {
+    pub(crate) fn get_idle_start(&self, this_value: JSValue, _global: &JSGlobalObject) -> JSValue {
         js::idle_start_get_cached(this_value).unwrap()
     }
 
     pub(crate) fn set_idle_start(
-        this: &Self,
+        &self,
         this_value: JSValue,
         global: &JSGlobalObject,
         value: JSValue,
     ) {
         if let Some(ms) = value.get_number() {
-            this.internals.set_idle_start(ms);
+            TimerObject::set_idle_start(self, ms);
         }
         js::idle_start_set_cached(this_value, global, value);
     }

--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -7,62 +7,46 @@
 //! `DateHeaderTimer`, …) live in `mod.rs`; this module only adds the JS-facing
 //! `impl super::All { … }` surface plus the C-ABI export thunks.
 
-#![allow(clippy::missing_safety_doc)]
-
 use bun_core::String as BunString;
 use bun_core::{Timespec, TimespecMockMode};
 use bun_jsc::virtual_machine::VirtualMachine;
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass as _, JsResult, StringJsc as _};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, StringJsc as _};
+use bun_ptr::ThisPtr;
 use bun_uws::Loop as UwsLoop;
 
 use super::{
-    All, CountdownOverflowBehavior, DateHeaderTimer, EventLoopTimer, EventLoopTimerState,
-    EventLoopTimerTag, ImmediateObject, Kind, TimeoutObject, TimeoutWarning, TimerObjectInternals,
+    All, CountdownOverflowBehavior, DateHeaderTimer, EventLoopTimerState, ImmediateObject, Kind,
+    TimeoutObject, TimeoutWarning, TimerObject,
 };
-use crate::jsc_hooks::{timer_all, timer_all_mut};
+use crate::jsc_hooks::{timer_all, timer_all_opt};
 
 // ════════════════════════════════════════════════════════════════════════════
 // JS-facing surface on `super::All`
 // ════════════════════════════════════════════════════════════════════════════
 
-impl All {
-    #[unsafe(no_mangle)]
-    pub(crate) extern "C" fn Bun__Timer__getNextID() -> i32 {
-        let all = timer_all();
-        if all.is_null() {
-            return 0;
-        }
-        // SAFETY: `all` is the live per-thread `All`; single-threaded JS heap.
-        unsafe {
-            (*all).last_id = (*all).last_id.wrapping_add(1);
-            (*all).last_id
-        }
-    }
+// HOST_EXPORT(Bun__Timer__getNextID, c)
+pub fn get_next_id() -> i32 {
+    let Some(all) = timer_all_opt() else {
+        return 0;
+    };
+    all.next_id().wrapping_add(1)
+}
 
-    /// # Safety
-    /// `vm` must point to the live per-thread `VirtualMachine`.
-    // Forwards `vm` to `DateHeaderTimer::enable` without dereferencing it here;
-    // the raw pointer is intentional (avoids aliased-`&mut` across the
-    // jsc/runtime crate cycle — see DateHeaderTimer.rs). Opaque-token
-    // forwarding makes not_unsafe_ptr_arg_deref a false positive.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+impl All {
     pub(crate) fn update_date_header_timer_if_necessary(
-        &mut self,
+        &self,
         loop_: &UwsLoop,
-        vm: *mut VirtualMachine,
+        vm: &VirtualMachine,
     ) {
         if loop_.should_enable_date_header_timer() {
-            // `is_date_timer_active()` is private to mod.rs; inline.
-            if self.date_header_timer.event_loop_timer.state != EventLoopTimerState::ACTIVE {
-                // SAFETY: caller contract guarantees `vm` is valid.
-                unsafe {
-                    self.date_header_timer.enable(
-                        vm,
-                        // Be careful to avoid adding extra calls to bun.timespec.now()
-                        // when it's not needed.
-                        &Timespec::now(TimespecMockMode::ForceRealTime),
-                    );
-                }
+            if self.date_header_timer.event_loop_timer.get().state != EventLoopTimerState::ACTIVE {
+                self.date_header_timer.enable(
+                    vm,
+                    self,
+                    // Be careful to avoid adding extra calls to bun.timespec.now()
+                    // when it's not needed.
+                    &Timespec::now(TimespecMockMode::ForceRealTime),
+                );
             }
         } else {
             // don't un-schedule it here.
@@ -127,7 +111,7 @@ impl All {
 
     /// Convert an arbitrary JavaScript value to a number of milliseconds used to schedule a timer.
     fn js_value_to_countdown(
-        &mut self,
+        &self,
         global_this: &JSGlobalObject,
         countdown: JSValue,
         overflow_behavior: CountdownOverflowBehavior,
@@ -156,8 +140,8 @@ impl All {
                                 countdown_double,
                                 TimeoutWarning::TimeoutOverflowWarning,
                             )?;
-                        } else if countdown_double < 0.0 && !self.warned_negative_number {
-                            self.warned_negative_number = true;
+                        } else if countdown_double < 0.0 && !self.warned_negative_number.get() {
+                            self.warned_negative_number.set(true);
                             Self::warn_invalid_countdown(
                                 global_this,
                                 countdown_double,
@@ -166,9 +150,9 @@ impl All {
                         } else if !countdown.is_undefined()
                             && countdown.is_number()
                             && countdown_double.is_nan()
-                            && !self.warned_not_number
+                            && !self.warned_not_number.get()
                         {
-                            self.warned_not_number = true;
+                            self.warned_not_number.set(true);
                             Self::warn_invalid_countdown(
                                 global_this,
                                 countdown_double,
@@ -196,9 +180,8 @@ impl All {
     ) -> JsResult<JSValue> {
         bun_jsc::mark_binding!();
         debug_assert!(!promise.is_empty() && !countdown.is_empty());
-        let all = timer_all_mut();
-        let id = all.last_id;
-        all.last_id = all.last_id.wrapping_add(1);
+        let all = timer_all();
+        let id = all.next_id();
 
         let countdown_int =
             all.js_value_to_countdown(global, countdown, CountdownOverflowBehavior::Clamp, true)?;
@@ -220,9 +203,8 @@ impl All {
     ) -> JsResult<JSValue> {
         bun_jsc::mark_binding!();
         debug_assert!(!callback.is_empty() && !arguments.is_empty());
-        let all = timer_all_mut();
-        let id = all.last_id;
-        all.last_id = all.last_id.wrapping_add(1);
+        let all = timer_all();
+        let id = all.next_id();
 
         let wrapped_callback = callback.with_async_context_if_needed(global);
         Ok(ImmediateObject::init(
@@ -241,9 +223,8 @@ impl All {
     ) -> JsResult<JSValue> {
         bun_jsc::mark_binding!();
         debug_assert!(!callback.is_empty() && !arguments.is_empty() && !countdown.is_empty());
-        let all = timer_all_mut();
-        let id = all.last_id;
-        all.last_id = all.last_id.wrapping_add(1);
+        let all = timer_all();
+        let id = all.next_id();
 
         let wrapped_callback = callback.with_async_context_if_needed(global);
         let countdown_int =
@@ -266,9 +247,8 @@ impl All {
     ) -> JsResult<JSValue> {
         bun_jsc::mark_binding!();
         debug_assert!(!callback.is_empty() && !arguments.is_empty() && !countdown.is_empty());
-        let all = timer_all_mut();
-        let id = all.last_id;
-        all.last_id = all.last_id.wrapping_add(1);
+        let all = timer_all();
+        let id = all.next_id();
 
         let wrapped_callback = callback.with_async_context_if_needed(global);
         let countdown_int =
@@ -291,17 +271,16 @@ impl All {
         (f64::from(id) == number).then_some(id)
     }
 
-    fn remove_timer_by_id(&mut self, id: i32) -> Option<*mut TimeoutObject> {
-        let value: *mut EventLoopTimer = if let Some(idx) = self.maps.set_timeout.get_index(&id) {
-            self.maps.set_timeout.swap_remove_at(idx).1
-        } else {
-            let idx = self.maps.set_interval.get_index(&id)?;
-            self.maps.set_interval.swap_remove_at(idx).1
-        };
-        // SAFETY: entry value points to EventLoopTimer embedded in a TimeoutObject
-        debug_assert!(unsafe { (*value).tag } == EventLoopTimerTag::TimeoutObject);
-        // SAFETY: entry value points to TimeoutObject.event_loop_timer
-        Some(unsafe { TimeoutObject::from_timer_ptr(value) })
+    fn remove_timer_by_id(&self, id: i32) -> Option<ThisPtr<TimeoutObject>> {
+        self.maps.with_mut(|maps| {
+            let entry = if let Some(idx) = maps.set_timeout.get_index(&id) {
+                maps.set_timeout.swap_remove_at(idx).1
+            } else {
+                let idx = maps.set_interval.get_index(&id)?;
+                maps.set_interval.swap_remove_at(idx).1
+            };
+            Some(entry.this_ptr())
+        })
     }
 
     pub(crate) fn clear_timer(
@@ -311,10 +290,9 @@ impl All {
     ) -> JsResult<()> {
         bun_jsc::mark_binding!();
 
-        let vm = global_this.bun_vm_ptr();
-        let all = timer_all_mut();
+        let all = timer_all();
 
-        let timer: Option<*mut TimerObjectInternals> = 'brk: {
+        let timer: ThisPtr<TimeoutObject> = 'brk: {
             if timer_id_value.is_number() {
                 // Node.js looks the id up by value (`knownTimersById[id]`): a double holding an
                 // integer names the same timer as the int32. Anything else clears nothing.
@@ -325,8 +303,7 @@ impl All {
                 let Some(t) = all.remove_timer_by_id(id) else {
                     return Ok(());
                 };
-                // SAFETY: t is a valid TimeoutObject pointer
-                break 'brk Some(unsafe { core::ptr::addr_of_mut!((*t).internals) });
+                break 'brk t;
             } else if timer_id_value.is_string_literal() {
                 // Primitive string only (JSType::String) — boxed `new String(..)`
                 // must fall through to `from_js` below and be a no-op, matching
@@ -383,34 +360,27 @@ impl All {
                 let Some(t) = all.remove_timer_by_id(parsed) else {
                     return Ok(());
                 };
-                // SAFETY: t is a valid TimeoutObject pointer
-                break 'brk Some(unsafe { core::ptr::addr_of_mut!((*t).internals) });
+                break 'brk t;
             }
 
-            if let Some(timeout) = TimeoutObject::from_js(timer_id_value) {
+            if let Some(timeout) = timer_id_value.as_class_this_ptr::<TimeoutObject>() {
                 // clearImmediate should be a noop if anything other than an Immediate is passed to it.
                 if kind != Kind::SetImmediate {
-                    // SAFETY: `timeout` is a valid TimeoutObject pointer
-                    break 'brk Some(unsafe { core::ptr::addr_of_mut!((*timeout).internals) });
-                } else {
-                    return Ok(());
+                    break 'brk timeout;
                 }
-            } else if let Some(immediate) = ImmediateObject::from_js(timer_id_value) {
+                return Ok(());
+            } else if let Some(immediate) = timer_id_value.as_class_this_ptr::<ImmediateObject>() {
                 // setImmediate can only be cleared by clearImmediate, not by clearTimeout or clearInterval.
                 if kind == Kind::SetImmediate {
-                    // SAFETY: `immediate` is a valid ImmediateObject pointer
-                    break 'brk Some(unsafe { core::ptr::addr_of_mut!((*immediate).internals) });
-                } else {
-                    return Ok(());
+                    TimerObject::cancel(immediate);
                 }
+                return Ok(());
             } else {
-                break 'brk None;
+                return Ok(());
             }
         };
 
-        let Some(timer) = timer else { return Ok(()) };
-        // SAFETY: timer points to a live TimerObjectInternals
-        unsafe { (*timer).cancel(vm) };
+        TimerObject::cancel(timer);
         Ok(())
     }
 
@@ -449,39 +419,22 @@ impl DateHeaderTimer {
     /// 1. If the timer was recently updated (< 1 second ago), just reschedule it
     /// 2. If the timer is stale (> 1 second since last update), update the date
     ///    immediately and reschedule
-    ///
-    /// # Safety
-    /// `vm` must point to the live per-thread `VirtualMachine`; its `uws_loop()`
-    /// must outlive this call.
-    unsafe fn enable(&mut self, vm: *mut VirtualMachine, now: &Timespec) {
-        debug_assert!(self.event_loop_timer.state != EventLoopTimerState::ACTIVE);
+    fn enable(&self, vm: &VirtualMachine, all: &All, now: &Timespec) {
+        debug_assert!(self.event_loop_timer.get().state != EventLoopTimerState::ACTIVE);
 
-        // `EventLoopTimer.next` is the lower-tier `ElTimespec` stub
-        // (same `{sec,nsec}` layout) until bun_event_loop switches to bun_core::Timespec.
-        let last_update = Timespec {
-            sec: self.event_loop_timer.next.sec,
-            nsec: self.event_loop_timer.next.nsec,
-        };
+        let last_update = self.event_loop_timer.get().next;
         let elapsed = now.duration(&last_update).ms();
 
         // If the last update was more than 1 second ago, the date is stale
         if elapsed >= 1000 {
             // Update the date immediately since it's stale
             // updateDate() is an expensive function.
-            // SAFETY: `vm` is the live per-thread VM; `uws_loop()` returns its
-            // owned uws loop, which outlives this call.
-            unsafe { (*(*vm).uws_loop()).update_date() };
+            vm.uws_loop_mut().update_date();
 
-            let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-            // SAFETY: single JS thread; nothing `All::update` touches overlaps
-            // `date_header_timer`, which `self` aliases (raw-ptr-per-field
-            // re-entry pattern, see jsc_hooks.rs).
-            unsafe { (*Self::timer_all()).update(elt, &now.add_ms(1000)) };
+            all.update(self.timer_ref(), &now.add_ms(1000));
         } else {
             // The date was updated recently, just reschedule for the next second
-            let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-            // SAFETY: see above — disjoint-field access on `All`.
-            unsafe { (*Self::timer_all()).insert(elt) };
+            all.insert(self.timer_ref());
         }
     }
 }

--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -293,6 +293,11 @@ impl All {
         let all = timer_all();
 
         let timer: ThisPtr<TimeoutObject> = 'brk: {
+            // Immediates have no numeric id (Node.js: `clearImmediate` only
+            // accepts the Immediate object), so a primitive never names one.
+            if kind == Kind::SetImmediate && !timer_id_value.is_object() {
+                return Ok(());
+            }
             if timer_id_value.is_number() {
                 // Node.js looks the id up by value (`knownTimersById[id]`): a double holding an
                 // integer names the same timer as the int32. Anything else clears nothing.

--- a/src/runtime/timer/WTFTimer.rs
+++ b/src/runtime/timer/WTFTimer.rs
@@ -3,112 +3,103 @@
 //!
 //! jsc/runtime crate cycle: the low-tier `bun_jsc::VirtualMachine.timer` is a
 //! `()` placeholder, so this module resolves the timer heap through
-//! [`crate::jsc_hooks::runtime_state`] instead — the same pattern
-//! `TimerObjectInternals` uses.
+//! [`crate::jsc_hooks::timer_all`] instead.
 
-use core::ffi::c_void;
 use core::ptr::{self, NonNull};
-use core::sync::atomic::{AtomicPtr, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 
 use bun_core::{Timespec, TimespecMockMode};
+use bun_ptr::{BackRef, JsCell};
 
 use crate::jsc::virtual_machine::VirtualMachine;
 use crate::webcore::script_execution_context::Identifier as ScriptExecutionContextIdentifier;
 
-use super::{
-    ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, InHeap, IntrusiveField,
-};
+use super::{All, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, TimerRef};
 
 const NS_PER_S: i64 = bun_core::time::NS_PER_S as i64;
 
 bun_opaque::opaque_ffi! {
     /// This is `WTF::RunLoop::TimerBase` from WebKit — opaque FFI handle.
-    pub(crate) struct RunLoopTimer;
+    pub struct RunLoopTimer;
 }
 
 impl RunLoopTimer {
-    /// Takes `NonNull` (not `&self`) so callers holding the raw FFI handle
-    /// don't need an `unsafe { as_ref() }` just to forward it — `NonNull<T>`
-    /// is ABI-identical to `*mut T` and the extern is `safe fn`.
+    /// Run the C++ timer. Its `fired()` may destroy the `TimerBase` — and with
+    /// it the `WTFTimer` this handle was read from — so callers hold no
+    /// `&WTFTimer` across this call.
     #[inline]
-    fn fire(this: NonNull<RunLoopTimer>) {
+    pub(crate) fn fire(this: NonNull<RunLoopTimer>) {
         WTFTimer__fire(this)
     }
 }
 
-/// A timer created by WTF code and invoked by Bun's event loop.
-pub(crate) struct WTFTimer {
-    // Backref to the owning VirtualMachine (captured from the thread-local VM
-    // in `WTFTimer__create`); never owned here. The C++ `RunLoop::TimerBase`
-    // that owns this wrapper lives on the VM's run loop, so the VM outlives
-    // the timer.
-    vm: NonNull<VirtualMachine>,
+/// A timer created by WTF code and invoked by Bun's event loop. Owned (boxed)
+/// by the C++ `RunLoop::TimerBase` that `WTFTimer__create`d it; `update` /
+/// `cancel` may arrive from any thread.
+pub struct WTFTimer {
+    /// `Timer::All` of the VM whose JS thread created this timer. The C++
+    /// `RunLoop::TimerBase` that owns this wrapper lives on that VM's run loop
+    /// and is destroyed with the JSC VM, before `RuntimeState` (which holds
+    /// `All`) is freed. Off that thread only `wtf_arm`/`wtf_disarm`/the
+    /// `wtf_timers` lock may be used through it.
+    timers: BackRef<All>,
     // FFI handle into WebKit's RunLoop::TimerBase; owned by C++.
     run_loop_timer: NonNull<RunLoopTimer>,
-    pub(crate) event_loop_timer: EventLoopTimer,
-    // Backref into `vm.eventLoop().imminent_gc_timer`. Low tier stores
-    // `AtomicPtr<()>` (PORTING.md §Dispatch); `self` is cast to `*mut ()` at
-    // each compare_exchange (the hook in `dispatch.rs` casts back to
-    // `*mut WTFTimer`).
-    imminent: bun_ptr::BackRef<AtomicPtr<()>>,
-    repeat: bool,
+    /// Linked into `All.wtf_timers`. Unlike every other `JsCell`, this one is
+    /// shared across threads: it is only read or written under that heap's lock.
+    pub(crate) event_loop_timer: JsCell<EventLoopTimer>,
+    /// `vm.eventLoop().imminent_gc_timer`. Low tier stores `AtomicPtr<()>`
+    /// (§Dispatch); `self` is published as `*mut ()` and `__bun_run_wtf_timer`
+    /// (in `dispatch.rs`) recovers the `&WTFTimer`.
+    imminent: BackRef<AtomicPtr<()>>,
+    repeat: AtomicBool,
     script_execution_context_id: ScriptExecutionContextIdentifier,
 }
 
 bun_event_loop::impl_timer_owner!(WTFTimer; from_timer_ptr => event_loop_timer);
 
 impl WTFTimer {
-    /// Fire the underlying `RunLoop::TimerBase`,
-    /// removing `self` from the timer heap first if it's currently scheduled.
-    /// Reached from `bun_jsc::event_loop` via `__bun_run_wtf_timer`
-    /// (definer in [`crate::dispatch`]).
-    ///
-    /// # Safety
-    /// `this` was published by [`WTFTimer::update`] into
-    /// `imminent_gc_timer` and remains live; `vm` is the live VM that owns
-    /// this timer.
-    pub(crate) unsafe fn run(this: *mut Self, vm: *mut VirtualMachine) {
-        // SAFETY: per fn contract — `this` is live; `ThisPtr` vends only fresh
-        // short-lived `&Self` per Deref so no `&WTFTimer` spans the
-        // `All::wtf_disarm` raw write to `event_loop_timer`.
-        let t = unsafe { bun_ptr::ThisPtr::new(this) };
-        // SAFETY: `vm` is the live VM that owns this timer's heap.
-        unsafe {
-            let state = crate::jsc_hooks::runtime_state_of(vm);
-            (*state)
-                .timer
-                .wtf_disarm(ptr::addr_of_mut!((*this).event_loop_timer));
-        }
-        t.run_without_removing();
+    #[inline]
+    fn timer_ref(&self) -> TimerRef {
+        TimerRef::new(self, |t| &t.event_loop_timer)
     }
 
+    /// The identity `imminent_gc_timer` knows this timer by.
     #[inline]
-    fn run_without_removing(&self) {
-        RunLoopTimer::fire(self.run_loop_timer);
+    fn as_opaque(&self) -> *mut () {
+        ptr::from_ref(self).cast_mut().cast()
+    }
+
+    /// `imminent_gc_timer` named this timer (see `update`): unlink it and hand
+    /// back the C++ timer for the caller (`__bun_run_wtf_timer` in
+    /// [`crate::dispatch`]) to [`RunLoopTimer::fire`] once no `&self` is live.
+    pub(crate) fn take_for_run(&self) -> NonNull<RunLoopTimer> {
+        self.timers.wtf_disarm(self.timer_ref());
+        self.run_loop_timer
     }
 
     #[bun_uws::uws_callback(export = "WTFTimer__isActive", no_catch)]
     pub(crate) fn is_active(&self) -> bool {
-        if self.event_loop_timer.state == EventLoopTimerState::ACTIVE {
+        let state = {
+            let _lock = self.timers.wtf_timers.lock();
+            self.event_loop_timer.get().state
+        };
+        if state == EventLoopTimerState::ACTIVE {
             return true;
         }
-        // `imminent` is a `BackRef` into the VM's event loop, which outlives this timer.
-        let loaded = self.imminent.load(Ordering::SeqCst);
-        // Null can never equal `this`, so a single pointer compare suffices.
-        loaded.cast_const().cast::<WTFTimer>() == ptr::from_ref(self)
+        // Null can never equal `self`, so a single pointer compare suffices.
+        self.imminent.load(Ordering::SeqCst) == self.as_opaque()
     }
 
     #[bun_uws::uws_callback(export = "WTFTimer__secondsUntilTimer", no_catch)]
     pub(crate) fn seconds_until_timer(&self) -> f64 {
-        if self.event_loop_timer.state == EventLoopTimerState::ACTIVE {
-            let next = &self.event_loop_timer.next;
-            // bun_event_loop carries a local `Timespec` stub; re-pack
-            // into bun_core::Timespec to call `duration`.
-            let until = Timespec {
-                sec: next.sec,
-                nsec: next.nsec,
-            }
-            .duration(&Timespec::now(TimespecMockMode::ForceRealTime));
+        let (state, next) = {
+            let _lock = self.timers.wtf_timers.lock();
+            let timer = self.event_loop_timer.get();
+            (timer.state, timer.next)
+        };
+        if state == EventLoopTimerState::ACTIVE {
+            let until = next.duration(&Timespec::now(TimespecMockMode::ForceRealTime));
             let sec = until.sec as f64;
             let nsec = until.nsec as f64;
             return sec + nsec / NS_PER_S as f64;
@@ -116,31 +107,21 @@ impl WTFTimer {
         f64::INFINITY
     }
 
-    /// # Safety
-    /// `this` must point at a live heap-allocated `WTFTimer`.
-    pub(crate) unsafe fn update(this: *mut Self, seconds: f64, repeat: bool) {
-        let self_opaque = this.cast::<()>();
-        // SAFETY: per fn contract — `this` is live; `ThisPtr` vends only fresh
-        // short-lived `&Self` per Deref. Copy the `BackRef` out so the
-        // subsequent `&AtomicPtr` borrow is detached from `*this`.
-        let t = unsafe { bun_ptr::ThisPtr::new(this) };
-        let imminent_br = t.imminent;
-        let imminent = imminent_br.get();
-
+    pub(crate) fn update(&self, seconds: f64, repeat: bool) {
         // There's only one of these per VM, and each VM has its own imminent_gc_timer.
         // Only set imminent if it's not already set to avoid overwriting another timer.
         if seconds.partial_cmp(&0.0) != Some(core::cmp::Ordering::Greater) {
-            let _ = imminent.compare_exchange(
+            let _ = self.imminent.compare_exchange(
                 ptr::null_mut(),
-                self_opaque,
+                self.as_opaque(),
                 Ordering::SeqCst,
                 Ordering::SeqCst,
             );
             return;
         }
         // Clear imminent if this timer was the one that set it.
-        let _ = imminent.compare_exchange(
-            self_opaque,
+        let _ = self.imminent.compare_exchange(
+            self.as_opaque(),
             ptr::null_mut(),
             Ordering::SeqCst,
             Ordering::SeqCst,
@@ -161,147 +142,91 @@ impl WTFTimer {
             interval.nsec -= NS_PER_S;
         }
 
-        // SAFETY: `t.vm` owns this timer's heap; `wtf_arm` is safe from any thread.
-        unsafe {
-            let state = crate::jsc_hooks::runtime_state_of(t.vm.as_ptr());
-            (*state)
-                .timer
-                .wtf_arm(ptr::addr_of_mut!((*this).event_loop_timer), &interval);
-            (*this).repeat = repeat;
-        }
+        self.timers.wtf_arm(self.timer_ref(), interval);
+        self.repeat.store(repeat, Ordering::Relaxed);
     }
 
-    /// # Safety
-    /// `this` must point at a live heap-allocated `WTFTimer`.
-    pub(crate) unsafe fn cancel(this: *mut Self) {
-        // SAFETY: per fn contract — `this` outlives this scope. `ThisPtr` vends
-        // only fresh short-lived `&Self` per Deref.
-        let t = unsafe { bun_ptr::ThisPtr::new(this) };
-
-        if t.script_execution_context_id.valid() {
+    pub(crate) fn cancel(&self) {
+        if self.script_execution_context_id.valid() {
             // Only clear imminent if this timer was the one that set it.
-            let self_opaque = this.cast::<()>();
-            // `imminent` is a `BackRef` into the VM's event loop, which
-            // outlives this timer.
-            let imminent_br = t.imminent;
-            let _ = imminent_br.compare_exchange(
-                self_opaque,
+            let _ = self.imminent.compare_exchange(
+                self.as_opaque(),
                 ptr::null_mut(),
                 Ordering::SeqCst,
                 Ordering::SeqCst,
             );
 
-            // SAFETY: `t.vm` owns this timer's heap; `wtf_disarm` is safe from
-            // any thread and is a no-op for a node that is no longer linked.
-            unsafe {
-                let state = crate::jsc_hooks::runtime_state_of(t.vm.as_ptr());
-                (*state)
-                    .timer
-                    .wtf_disarm(ptr::addr_of_mut!((*this).event_loop_timer));
-            }
+            // No-op for a slot that is no longer linked.
+            self.timers.wtf_disarm(self.timer_ref());
         }
     }
 
-    /// `EventLoopTimer.fire` dispatch arm body for `Tag::WTFTimer`.
-    ///
-    /// # Safety
-    /// `this` is the container of an `EventLoopTimer` just popped from
-    /// `All.wtf_timers`; `_vm` is the live per-thread VM.
-    pub(crate) unsafe fn fire(this: *mut Self, _now: &ElTimespec, _vm: *mut VirtualMachine) {
-        // SAFETY: per fn contract — `this` is live; `ThisPtr` vends only fresh
-        // short-lived `&Self` per Deref.
-        let t = unsafe { bun_ptr::ThisPtr::new(this) };
+    /// Timer-heap dispatch arm for `Tag::WTFTimer`: `self`'s slot was just
+    /// popped from `All.wtf_timers`. Hands back the C++ timer for the caller to
+    /// [`RunLoopTimer::fire`] once no `&self` is live.
+    pub(crate) fn take_for_fire(&self) -> NonNull<RunLoopTimer> {
         // Only clear imminent if this timer was the one that set it.
-        let self_opaque = this.cast::<()>();
-        // `imminent` is a `BackRef` into the VM's event loop, which outlives
-        // this timer.
-        let imminent_br = t.imminent;
-        let _ = imminent_br.compare_exchange(
-            self_opaque,
+        let _ = self.imminent.compare_exchange(
+            self.as_opaque(),
             ptr::null_mut(),
             Ordering::SeqCst,
             Ordering::SeqCst,
         );
-        t.run_without_removing();
-    }
-
-    /// # Safety
-    /// `this` must be the unique owner of a `WTFTimer` produced by `WTFTimer__create`.
-    pub(crate) unsafe fn deinit(this: *mut Self) {
-        // SAFETY: per fn contract.
-        unsafe { Self::cancel(this) };
-        // SAFETY: `WTFTimer__create` handed its `Box` over via `heap::into_raw`,
-        // so `heap::take` is the paired reclaim.
-        drop(unsafe { bun_core::heap::take(this) });
+        self.run_loop_timer
     }
 }
 
-/// A `WTF::RunLoop` timer on this thread, backed by this thread's event loop. Null when the thread has no Bun
+impl Drop for WTFTimer {
+    fn drop(&mut self) {
+        self.cancel();
+    }
+}
+
+/// A `WTF::RunLoop` timer on this thread, backed by this thread's event loop. `None` when the thread has no Bun
 /// `VirtualMachine` (a `JSC::VM` on a bundler thread generating bytecode, say): the timer then never fires, which
 /// `RunLoop::TimerBase` accepts.
-///
-/// # Safety
-/// `run_loop_timer` must be a non-null, live `WTF::RunLoop::TimerBase` owned
-/// by the caller for the lifetime of the returned `WTFTimer`.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn WTFTimer__create(run_loop_timer: *mut RunLoopTimer) -> *mut c_void {
-    let Some(vm) = VirtualMachine::get_or_null() else {
-        return ptr::null_mut();
-    };
+// HOST_EXPORT(WTFTimer__create, c)
+pub fn create(
+    run_loop_timer: core::ptr::NonNull<crate::timer::wtf_timer::RunLoopTimer>,
+) -> Option<Box<crate::timer::WTFTimer>> {
+    if !VirtualMachine::is_loaded() {
+        return None;
+    }
 
-    // SAFETY: `vm` is the thread-local VirtualMachine; `run_loop_timer` is
-    // non-null per caller contract; `event_loop().imminent_gc_timer` lives as
-    // long as the VM.
-    let this = unsafe {
-        let vm_ref = &*vm;
-        let el = &*vm_ref.event_loop();
-        Box::new(WTFTimer {
-            vm: NonNull::new_unchecked(vm),
-            imminent: bun_ptr::BackRef::new(&el.imminent_gc_timer),
-            event_loop_timer: EventLoopTimer {
-                next: ElTimespec {
-                    sec: i64::MAX,
-                    nsec: 0,
-                },
-                tag: EventLoopTimerTag::WTFTimer,
-                state: EventLoopTimerState::CANCELLED,
-                heap: IntrusiveField::default(),
-                in_heap: InHeap::None,
+    let vm = VirtualMachine::get();
+    Some(Box::new(WTFTimer {
+        timers: BackRef::new(crate::jsc_hooks::timer_all()),
+        imminent: BackRef::new(&vm.event_loop_mut().imminent_gc_timer),
+        event_loop_timer: JsCell::new(EventLoopTimer::new(
+            EventLoopTimerTag::WTFTimer,
+            EventLoopTimerState::CANCELLED,
+            Timespec {
+                sec: i64::MAX,
+                nsec: 0,
             },
-            run_loop_timer: NonNull::new_unchecked(run_loop_timer),
-            repeat: false,
-            script_execution_context_id: ScriptExecutionContextIdentifier(
-                vm_ref.initial_script_execution_context_identifier as u32,
-            ),
-        })
-    };
-
-    bun_core::heap::into_raw(this).cast::<c_void>()
+        )),
+        run_loop_timer,
+        repeat: AtomicBool::new(false),
+        script_execution_context_id: ScriptExecutionContextIdentifier(
+            vm.initial_script_execution_context_identifier as u32,
+        ),
+    }))
 }
 
-/// # Safety
-/// `this` must point at a live `WTFTimer` produced by [`WTFTimer__create`].
-#[unsafe(no_mangle)]
-unsafe extern "C" fn WTFTimer__update(this: *mut WTFTimer, seconds: f64, repeat: bool) {
-    // SAFETY: per fn contract.
-    unsafe { WTFTimer::update(this, seconds, repeat) };
+// HOST_EXPORT(WTFTimer__update, c)
+pub fn update(this: &crate::timer::WTFTimer, seconds: f64, repeat: bool) {
+    this.update(seconds, repeat);
 }
 
-/// # Safety
-/// `this` must be the unique owner of a `WTFTimer` produced by
-/// [`WTFTimer__create`]; it is freed by this call.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn WTFTimer__deinit(this: *mut WTFTimer) {
-    // SAFETY: per fn contract.
-    unsafe { WTFTimer::deinit(this) };
+/// Frees `this`.
+// HOST_EXPORT(WTFTimer__deinit, c)
+pub fn deinit(this: Box<crate::timer::WTFTimer>) {
+    drop(this);
 }
 
-/// # Safety
-/// `this` must point at a live `WTFTimer` produced by [`WTFTimer__create`].
-#[unsafe(no_mangle)]
-unsafe extern "C" fn WTFTimer__cancel(this: *mut WTFTimer) {
-    // SAFETY: per fn contract.
-    unsafe { WTFTimer::cancel(this) };
+// HOST_EXPORT(WTFTimer__cancel, c)
+pub fn cancel(this: &crate::timer::WTFTimer) {
+    this.cancel();
 }
 
 unsafe extern "C" {

--- a/src/runtime/timer/WTFTimer.rs
+++ b/src/runtime/timer/WTFTimer.rs
@@ -6,7 +6,7 @@
 //! [`crate::jsc_hooks::timer_all`] instead.
 
 use core::ptr::{self, NonNull};
-use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use core::sync::atomic::{AtomicPtr, Ordering};
 
 use bun_core::{Timespec, TimespecMockMode};
 use bun_ptr::{BackRef, JsCell};
@@ -52,7 +52,6 @@ pub struct WTFTimer {
     /// (§Dispatch); `self` is published as `*mut ()` and `__bun_run_wtf_timer`
     /// (in `dispatch.rs`) recovers the `&WTFTimer`.
     imminent: BackRef<AtomicPtr<()>>,
-    repeat: AtomicBool,
     script_execution_context_id: ScriptExecutionContextIdentifier,
 }
 
@@ -107,7 +106,7 @@ impl WTFTimer {
         f64::INFINITY
     }
 
-    pub(crate) fn update(&self, seconds: f64, repeat: bool) {
+    pub(crate) fn update(&self, seconds: f64, _repeat: bool) {
         // There's only one of these per VM, and each VM has its own imminent_gc_timer.
         // Only set imminent if it's not already set to avoid overwriting another timer.
         if seconds.partial_cmp(&0.0) != Some(core::cmp::Ordering::Greater) {
@@ -143,7 +142,6 @@ impl WTFTimer {
         }
 
         self.timers.wtf_arm(self.timer_ref(), interval);
-        self.repeat.store(repeat, Ordering::Relaxed);
     }
 
     pub(crate) fn cancel(&self) {
@@ -206,7 +204,6 @@ pub fn create(
             },
         )),
         run_loop_timer,
-        repeat: AtomicBool::new(false),
         script_execution_context_id: ScriptExecutionContextIdentifier(
             vm.initial_script_execution_context_identifier as u32,
         ),

--- a/src/runtime/timer/WTFTimer.rs
+++ b/src/runtime/timer/WTFTimer.rs
@@ -37,11 +37,11 @@ impl RunLoopTimer {
 /// by the C++ `RunLoop::TimerBase` that `WTFTimer__create`d it; `update` /
 /// `cancel` may arrive from any thread.
 pub struct WTFTimer {
-    /// `Timer::All` of the VM whose JS thread created this timer. The C++
-    /// `RunLoop::TimerBase` that owns this wrapper lives on that VM's run loop
-    /// and is destroyed with the JSC VM, before `RuntimeState` (which holds
-    /// `All`) is freed. Off that thread only `wtf_arm`/`wtf_disarm`/the
-    /// `wtf_timers` lock may be used through it.
+    /// `Timer::All` of the VM whose JS thread created this timer. Live while
+    /// `script_execution_context_id` is valid; a C++ `RunLoop::TimerBase` can
+    /// outlive `RuntimeState` (which holds `All`) on Worker teardown, so
+    /// `cancel`/`Drop` only follow this after that check. Off the JS thread
+    /// only `wtf_arm`/`wtf_disarm`/the `wtf_timers` lock may be used through it.
     timers: BackRef<All>,
     // FFI handle into WebKit's RunLoop::TimerBase; owned by C++.
     run_loop_timer: NonNull<RunLoopTimer>,
@@ -154,7 +154,9 @@ impl WTFTimer {
                 Ordering::SeqCst,
             );
 
-            // No-op for a slot that is no longer linked.
+            // No-op for a slot that is no longer linked. Not reached once the
+            // context is gone: `timers` may already be freed by then (see the
+            // field), and nothing walks `wtf_timers` after that point.
             self.timers.wtf_disarm(self.timer_ref());
         }
     }

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -205,7 +205,7 @@ pub mod event_loop_delay_monitor;
 
 /// `clearTimeout(id)` lookup table: the object's `Drop` removes its entry, so
 /// every `BackRef` in here points at a live timer.
-pub(crate) type IdMap<T> = ArrayHashMap<i32, BackRef<T, bun_ptr::Mut>>;
+pub(crate) type IdMap<T> = ArrayHashMap<i32, BackRef<T, bun_ptr::Root>>;
 
 /// i32 is exposed to JavaScript and can be used with clearTimeout, clearInterval, etc.
 #[derive(Default)]

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -1,26 +1,26 @@
 //! Timer subsystem: setTimeout/setInterval/setImmediate scheduling and the
 //! event-loop timer heap.
 
+use core::cell::Cell;
+
 use bun_collections::ArrayHashMap;
 use bun_core::{Timespec, TimespecMockMode};
 #[cfg(windows)]
 use bun_libuv_sys::UvHandle as _;
+use bun_ptr::{BackRef, JsCell};
 #[cfg(windows)]
 use bun_sys::windows::libuv as uv;
 use bun_threading::Guarded;
 
-// Low-tier timer node + tag (per §Dispatch hot-path list, the `match tag`
-// dispatch lives in this crate; `bun_event_loop` only stores `(tag, ptr)`).
-pub use bun_event_loop::EventLoopTimer::{
-    EventLoopTimer, InHeap, IntrusiveField, State as EventLoopTimerState, Tag as EventLoopTimerTag,
-};
-// bun_event_loop carries a local `Timespec` stub instead of
-// `bun_core::Timespec`. Same `{sec: i64, nsec: i64}` shape; alias it here so
-// `fire()`/`next` accesses type-check without a transmute.
-// TODO: remove this alias once the lower tier switches to `bun_core::Timespec`.
+/// `EventLoopTimer.next`'s type; the low tier re-exports `bun_core::Timespec`.
 pub(crate) use bun_event_loop::EventLoopTimer::Timespec as ElTimespec;
+pub use bun_event_loop::EventLoopTimer::{
+    EventLoopTimer, InHeap, State as EventLoopTimerState, Tag as EventLoopTimerTag, TimerHeap,
+    TimerOwner, TimerRef,
+};
 
 use crate::jsc::JSValue;
+use crate::jsc::virtual_machine::VirtualMachine;
 
 // ─── JS-facing surface (`impl All { set_timeout / clear_* / … }`) ────────────
 // Named `timer` so codegen (`generated_js2native.rs`) resolves
@@ -32,25 +32,21 @@ pub mod timer;
 
 // ─── impl_timer_object! ──────────────────────────────────────────────────────
 // Shared scaffold for `TimeoutObject` / `ImmediateObject`: both are a
-// `#[JsClass]` payload of `{ref_count, event_loop_timer, internals}` whose
-// JS-facing host-fns are pure forwarders to `TimerObjectInternals`. The macro
+// `#[JsClass]` payload of `{ref_count, event_loop_timer, internals, heap_ref}`
+// whose JS-facing host-fns are pure forwarders to [`TimerObject`]. The macro
 // emits the parts shared by both types so each `*.rs` file holds only its
-// type-specific surface (`init`, `do_refresh`, cached-prop accessors,
-// `run_immediate_task`).
+// type-specific surface (`init`, `do_refresh`, cached-prop accessors, the
+// [`TimerObject`] impl).
 //
 // Emits, at the call-site module path (so `#[JsClass]`/`#[host_fn]` produce the
 // same extern symbol names as before — `Timeout__create`, `TimeoutPrototype__*`,
 // `ImmediateClass__construct`, …):
-//   - `#[bun_jsc::JsClass(name = $js_name)] pub struct $T { … }`
+//   - `#[bun_jsc::JsClass(name = $js_name)] #[derive(RefCounted)] pub struct $T { … }`
 //   - `bun_event_loop::impl_timer_owner!($T; from_timer_ptr => event_loop_timer)`
-//   - `impl RefCounted for $T` (intrusive `ref_count` field, `deinit` destructor)
-//   - `impl Default for $T` (`EventLoopTimer::init_paused(EventLoopTimerTag::$tag)`)
-//   - `impl $T`: `ref_`/`deref`/`deinit`/`init_with`/`constructor`/`finalize`
-//     and the forwarder host-fns `to_primitive`/`do_ref`/`do_unref`/`has_ref`/
-//     `get_destroyed`/`dispose`.
-//
-// Type-specific items (`init`, `do_refresh`, `close`, cached-prop get/set,
-// `run_immediate_task`) go in a *second* `impl $T` block in the caller's file.
+//   - `impl Drop for $T` (unlinks from `All` before the box is freed)
+//   - `impl $T`: `init_with`/`constructor`/`finalize` and the forwarder
+//     host-fns `to_primitive`/`do_ref`/`do_unref`/`has_ref`/`get_destroyed`/
+//     `dispose`.
 //
 // Paths in the body are written `super::…` / `::crate_name::…` because the
 // macro is invoked *from the child module* (`super::impl_timer_object!(…)`),
@@ -61,62 +57,28 @@ macro_rules! impl_timer_object {
         #[derive(::bun_ptr::RefCounted)]
         pub struct $T {
             pub ref_count: ::bun_ptr::RefCount<Self>,
-            pub event_loop_timer: super::EventLoopTimer,
+            pub event_loop_timer: ::bun_ptr::JsCell<super::EventLoopTimer>,
             pub internals: super::TimerObjectInternals,
+            /// The ref held while this timer is scheduled — by the timer heap
+            /// for a `Timeout`, by the event loop's immediate queue for an
+            /// `Immediate`. Released when it fires for the last time or is
+            /// cancelled.
+            pub heap_ref: ::core::cell::Cell<Option<::bun_ptr::RefPtr<Self>>>,
         }
 
         ::bun_event_loop::impl_timer_owner!($T; from_timer_ptr => event_loop_timer);
 
-        impl ::core::ops::Drop for $T {
+        impl Drop for $T {
             fn drop(&mut self) {
-                // SAFETY: last ref gone; JS thread with RuntimeState installed.
-                unsafe { self.internals.deinit() }
-            }
-        }
-
-        impl ::core::default::Default for $T {
-            fn default() -> Self {
-                Self {
-                    ref_count: ::bun_ptr::RefCount::init(),
-                    // `init_paused`: next=EPOCH, state=PENDING, heap zeroed.
-                    event_loop_timer: super::EventLoopTimer::init_paused(
-                        super::EventLoopTimerTag::$tag,
-                    ),
-                    // Default-constructed here, then overwritten in `init()`.
-                    internals: super::TimerObjectInternals::default(),
-                }
+                <Self as super::TimerObject>::unschedule_for_drop(self);
             }
         }
 
         impl $T {
-            // Re-export the refcount mixin's ops as inherent fns so
-            // `TimerObjectInternals`'s `container_of` dispatch resolves.
-
-            /// Increment the intrusive refcount.
-            ///
-            /// # Safety
-            /// `this` must point to a live, `heap::alloc`-allocated `Self`.
-            #[inline]
-            pub unsafe fn ref_(this: *mut Self) {
-                // SAFETY: caller contract.
-                unsafe { ::bun_ptr::RefCount::<Self>::ref_(this) }
-            }
-
-            /// Decrement the intrusive refcount; on zero drops the `Box`.
-            /// After this returns `this` may dangle.
-            ///
-            /// # Safety
-            /// `this` must point to a live, `heap::alloc`-allocated `Self`.
-            #[inline]
-            pub unsafe fn deref(this: *mut Self) {
-                // SAFETY: caller contract.
-                unsafe { ::bun_ptr::RefCount::<Self>::deref(this) }
-            }
-
             /// Shared body of `TimeoutObject::init` / `ImmediateObject::init`:
-            /// heap-allocate → `to_js_ptr` → `internals.init` →
-            /// inspector `did_schedule_async_call`. The per-type `init` fn
-            /// picks `kind`/`interval` and forwards here.
+            /// allocate → wrap in the JS cell → schedule → inspector
+            /// `did_schedule_async_call`. The per-type `init` fn picks
+            /// `kind`/`interval` and forwards here.
             pub fn init_with(
                 global: &::bun_jsc::JSGlobalObject,
                 id: i32,
@@ -125,30 +87,25 @@ macro_rules! impl_timer_object {
                 callback: ::bun_jsc::JSValue,
                 arguments: ::bun_jsc::JSValue,
             ) -> ::bun_jsc::JSValue {
-                // Heap-allocate; `*mut Self` is the
-                // `m_ctx` payload of the codegen'd JSCell wrapper. Ownership
-                // transfers to the wrapper via `to_js_ptr`; freed by
-                // `deref → deinit → heap::take`.
-                let payload: *mut Self =
-                    ::bun_core::heap::into_raw(::std::boxed::Box::new(Self::default()));
-                // SAFETY: `to_js_ptr` is the `#[JsClass]`-generated `*__create`
-                // shim; `payload` is a fresh heap allocation whose ownership
-                // transfers to the GC wrapper.
-                let js_value = unsafe { Self::to_js_ptr(payload, global) };
-                // Round-trip ABI check.
+                let vm = global.bun_vm();
+                let timer = ::bun_ptr::RefPtr::new(Self {
+                    ref_count: ::bun_ptr::RefCount::init(),
+                    event_loop_timer: ::bun_ptr::JsCell::new(super::EventLoopTimer::init_paused(
+                        super::EventLoopTimerTag::$tag,
+                    )),
+                    internals: super::TimerObjectInternals::new(id, kind, interval, vm),
+                    heap_ref: ::core::cell::Cell::new(None),
+                });
+                // `timer`'s ref moves to the JS wrapper (released via `finalize`).
+                let js_value = Self::to_js_nonnull(timer.as_non_null(), global);
                 debug_assert!(
-                    <Self as ::bun_jsc::JsClass>::from_js(js_value) == Some(payload),
+                    <Self as ::bun_jsc::JsClass>::from_js(js_value) == Some(timer.as_ptr()),
                     concat!($js_name, "__create ABI mismatch"),
                 );
+                let this = timer.into_this_ptr();
                 let _keep = ::bun_jsc::EnsureStillAlive(js_value);
-                // SAFETY: `payload` was just allocated above and is exclusively
-                // owned here; `internals.init()` writes every field.
-                unsafe {
-                    (*payload).internals.init(
-                        js_value, global, id, kind, interval, callback, arguments,
-                    );
-                }
-                if global.bun_vm().as_mut().is_inspector_enabled() {
+                <Self as super::TimerObject>::schedule(this, js_value, global, callback, arguments);
+                if vm.is_inspector_enabled() {
                     ::bun_jsc::Debugger::did_schedule_async_call(
                         global,
                         ::bun_jsc::Debugger::AsyncCallType::DOMTimer,
@@ -171,59 +128,62 @@ macro_rules! impl_timer_object {
 
             #[::bun_jsc::host_fn(method)]
             pub fn to_primitive(
-                this: &Self,
+                this: ::bun_ptr::ThisPtr<Self>,
                 _global: &::bun_jsc::JSGlobalObject,
                 _frame: &::bun_jsc::CallFrame,
             ) -> ::bun_jsc::JsResult<::bun_jsc::JSValue> {
-                this.internals.to_primitive()
+                <Self as super::TimerObject>::to_primitive(this)
             }
 
             #[::bun_jsc::host_fn(method)]
             pub fn do_ref(
-                this: &Self,
-                global: &::bun_jsc::JSGlobalObject,
+                &self,
+                _global: &::bun_jsc::JSGlobalObject,
                 frame: &::bun_jsc::CallFrame,
             ) -> ::bun_jsc::JsResult<::bun_jsc::JSValue> {
-                this.internals.do_ref(global, frame.this())
+                <Self as super::TimerObject>::do_ref(self, frame.this())
             }
 
             #[::bun_jsc::host_fn(method)]
             pub fn do_unref(
-                this: &Self,
-                global: &::bun_jsc::JSGlobalObject,
+                &self,
+                _global: &::bun_jsc::JSGlobalObject,
                 frame: &::bun_jsc::CallFrame,
             ) -> ::bun_jsc::JsResult<::bun_jsc::JSValue> {
-                this.internals.do_unref(global, frame.this())
+                <Self as super::TimerObject>::do_unref(self, frame.this())
             }
 
             #[::bun_jsc::host_fn(method)]
             pub fn has_ref(
-                this: &Self,
+                &self,
                 _global: &::bun_jsc::JSGlobalObject,
                 _frame: &::bun_jsc::CallFrame,
             ) -> ::bun_jsc::JsResult<::bun_jsc::JSValue> {
-                this.internals.has_ref()
+                <Self as super::TimerObject>::has_ref(self)
             }
 
+            /// `.classes.ts` `refCounted: true` — runs on the mutator thread
+            /// during lazy sweep, before the wrapper's ref is dropped. Do not
+            /// touch any `JSValue`/`Strong` content.
             pub fn finalize(&self) {
-                self.internals.finalize()
+                self.internals.this_value.with_mut(|r| r.finalize())
             }
 
             #[::bun_jsc::host_fn(getter)]
             pub fn get_destroyed(
-                this: &Self,
+                &self,
                 _global: &::bun_jsc::JSGlobalObject,
             ) -> ::bun_jsc::JsResult<::bun_jsc::JSValue> {
-                Ok(::bun_jsc::JSValue::from(this.internals.get_destroyed()))
+                Ok(::bun_jsc::JSValue::from(<Self as super::TimerObject>::get_destroyed(self)))
             }
 
             #[::bun_jsc::host_fn(method)]
             pub fn dispose(
-                this: &Self,
-                global: &::bun_jsc::JSGlobalObject,
+                this: ::bun_ptr::ThisPtr<Self>,
+                _global: &::bun_jsc::JSGlobalObject,
                 _frame: &::bun_jsc::CallFrame,
             ) -> ::bun_jsc::JsResult<::bun_jsc::JSValue> {
-                this.internals.cancel(global.bun_vm_ptr());
+                <Self as super::TimerObject>::cancel(this);
                 Ok(::bun_jsc::JSValue::UNDEFINED)
             }
         }
@@ -238,162 +198,69 @@ pub mod timeout_object;
 pub mod immediate_object;
 
 #[path = "DateHeaderTimer.rs"]
-mod date_header_timer_draft;
+pub mod date_header_timer;
 
 #[path = "EventLoopDelayMonitor.rs"]
-mod event_loop_delay_monitor_draft;
+pub mod event_loop_delay_monitor;
 
-// ─── TimerHeap ───────────────────────────────────────────────────────────────
-// Real intrusive pairing-heap (meld/remove/combine_siblings) implemented in
-// `bun_io::heap::Intrusive`. `EventLoopTimer` now embeds the real
-// `bun_io::heap::IntrusiveField` and impls `HeapNode` in its defining crate
-// (`bun_event_loop`), so the orphan-rule block is gone. `TimerHeap` is a thin
-// newtype that adapts `*mut T` ↔ `Option<*mut T>` for the existing call-sites
-// (`All::insert/remove/next/get_timeout`).
-
-/// Stateless context for the heap comparator.
-#[derive(Default)]
-pub(crate) struct TimerHeapCtx;
-
-impl bun_io::heap::HeapContext<EventLoopTimer> for TimerHeapCtx {
-    #[inline]
-    unsafe fn less(&self, a: *mut EventLoopTimer, b: *mut EventLoopTimer) -> bool {
-        // SAFETY: `Intrusive` only ever calls `less` with non-null nodes that
-        // are live members of the heap (caller invariant on insert/meld).
-        EventLoopTimer::less((), unsafe { &*a }, unsafe { &*b })
-    }
-}
-
-#[derive(Default)]
-pub struct TimerHeap(bun_io::heap::Intrusive<EventLoopTimer, TimerHeapCtx>);
-
-impl TimerHeap {
-    #[inline]
-    pub(crate) fn peek(&self) -> Option<*mut EventLoopTimer> {
-        let r = self.0.peek();
-        if r.is_null() { None } else { Some(r) }
-    }
-
-    /// # Safety
-    /// `v` is a valid, exclusively-owned node not currently in any heap
-    /// (its `IntrusiveField` links are null).
-    #[inline]
-    unsafe fn insert(&mut self, v: *mut EventLoopTimer) {
-        // SAFETY: forwarded — see fn contract.
-        unsafe { self.0.insert(v) };
-    }
-
-    /// # Safety
-    /// `v` is a node currently in *this* heap.
-    #[inline]
-    unsafe fn remove(&mut self, v: *mut EventLoopTimer) {
-        // SAFETY: forwarded — see fn contract.
-        unsafe { self.0.remove(v) };
-    }
-
-    #[inline]
-    pub(crate) fn delete_min(&mut self) -> Option<*mut EventLoopTimer> {
-        // SAFETY: all reachable nodes were inserted via `insert()` and remain
-        // live until popped (intrusive invariant maintained by `All`).
-        let r = unsafe { self.0.delete_min() };
-        if r.is_null() { None } else { Some(r) }
-    }
-
-    #[inline]
-    pub(crate) fn find_max(&self) -> Option<*mut EventLoopTimer> {
-        // SAFETY: all reachable nodes were inserted via `insert()` and remain
-        // live for the heap's lifetime (intrusive invariant maintained by `All`).
-        let r = unsafe { self.0.find_max() };
-        if r.is_null() { None } else { Some(r) }
-    }
-
-    #[inline]
-    pub(crate) fn count(&self) -> usize {
-        // SAFETY: all reachable nodes were inserted via `insert()` and remain
-        // live for the heap's lifetime (intrusive invariant maintained by `All`).
-        unsafe { self.0.count() }
-    }
-}
+/// `clearTimeout(id)` lookup table: the object's `Drop` removes its entry, so
+/// every `BackRef` in here points at a live timer.
+pub(crate) type IdMap<T> = ArrayHashMap<i32, BackRef<T, bun_ptr::Mut>>;
 
 /// i32 is exposed to JavaScript and can be used with clearTimeout, clearInterval, etc.
-pub(crate) type TimeoutMap = ArrayHashMap<i32, *mut EventLoopTimer>;
-
 #[derive(Default)]
 pub struct Maps {
-    pub(crate) set_timeout: TimeoutMap,
-    pub(crate) set_interval: TimeoutMap,
-    pub(crate) set_immediate: TimeoutMap,
-}
-
-impl Maps {
-    #[inline]
-    fn get(&mut self, kind: Kind) -> &mut TimeoutMap {
-        match kind {
-            Kind::SetTimeout => &mut self.set_timeout,
-            Kind::SetInterval => &mut self.set_interval,
-            Kind::SetImmediate => &mut self.set_immediate,
-        }
-    }
+    pub(crate) set_timeout: IdMap<TimeoutObject>,
+    pub(crate) set_interval: IdMap<TimeoutObject>,
+    pub(crate) set_immediate: IdMap<ImmediateObject>,
 }
 
 // ─── FakeTimers ──────────────────────────────────────────────────────────────
 // Real definition lives in `runtime/test_runner/timers/FakeTimers.rs` and
-// depends on `TimerHeap` (defined above). Now that `pub mod test_runner` is
-// declared in lib.rs, re-export so `All.fake_timers` and the test_runner
+// depends on `TimerHeap`. Re-export so `All.fake_timers` and the test_runner
 // host fns see the same nominal type.
 pub(crate) use crate::test_runner::timers::fake_timers::FakeTimers;
 
-// ─── DateHeaderTimer / EventLoopDelayMonitor (struct-only) ───────────────────
-// Method bodies (`enable`/`run`) call `vm.timer.*` and `vm.uws_loop()` which
-// need `VirtualMachine.timer: All` (currently `()` in bun_jsc). Struct shape
-// is real so `All` embeds them by value with the correct layout.
+// ─── DateHeaderTimer / EventLoopDelayMonitor ─────────────────────────────────
 
 pub struct DateHeaderTimer {
-    pub(crate) event_loop_timer: EventLoopTimer,
+    pub(crate) event_loop_timer: JsCell<EventLoopTimer>,
 }
+bun_event_loop::impl_timer_owner!(DateHeaderTimer; from_timer_ptr => event_loop_timer);
 impl Default for DateHeaderTimer {
     fn default() -> Self {
         Self {
-            event_loop_timer: EventLoopTimer::init_paused(EventLoopTimerTag::DateHeaderTimer),
+            event_loop_timer: JsCell::new(EventLoopTimer::init_paused(
+                EventLoopTimerTag::DateHeaderTimer,
+            )),
         }
     }
 }
 impl DateHeaderTimer {
     #[inline]
-    fn timer_all() -> *mut All {
-        crate::jsc_hooks::timer_all()
+    fn timer_ref(&self) -> TimerRef {
+        TimerRef::new(self, |t| &t.event_loop_timer)
     }
 
     /// Refresh the cached `Date:` header and
     /// reschedule for 1s later iff there are active connections.
-    pub(crate) fn run(&mut self, vm: &mut bun_jsc::virtual_machine::VirtualMachine) {
-        self.event_loop_timer.state = EventLoopTimerState::FIRED;
-        // `uws_loop_mut` is the audited safe accessor (loop owned by the VM,
-        // separate allocation from `RuntimeState.timer` so no aliasing with
-        // `&mut self`).
+    pub(crate) fn run(&self, vm: &VirtualMachine, all: &All) {
+        self.event_loop_timer
+            .with_mut(|t| t.state = EventLoopTimerState::FIRED);
         let loop_ = vm.uws_loop_mut();
         let now = Timespec::now(TimespecMockMode::ForceRealTime);
 
         // Record when we last ran it.
-        self.event_loop_timer.next = ElTimespec {
-            sec: now.sec,
-            nsec: now.nsec,
-        };
+        self.event_loop_timer.with_mut(|t| t.next = now);
 
         // updateDate() is an expensive function.
         loop_.update_date();
 
         if loop_.internal_loop_data.sweep_timer_count > 0 {
             // Reschedule it automatically for 1 second later.
-            let next = now.add_ms(1000);
-            self.event_loop_timer.next = ElTimespec {
-                sec: next.sec,
-                nsec: next.nsec,
-            };
-            let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-            // SAFETY: single JS thread; nothing `All::insert` touches
-            // overlaps `date_header_timer`, which `self` aliases.
-            unsafe { (*Self::timer_all()).insert(elt) };
+            self.event_loop_timer
+                .with_mut(|t| t.next = now.add_ms(1000));
+            all.insert(self.timer_ref());
         }
     }
 }
@@ -401,90 +268,79 @@ impl DateHeaderTimer {
 pub struct EventLoopDelayMonitor {
     /// Weak, so a leaked monitor does not pin the retired `--isolate` realm.
     /// `stop_active_handles` drops it before `~VM` (`All` outlives the heap).
-    histogram: bun_jsc::Weak<()>,
-    pub(crate) event_loop_timer: EventLoopTimer,
-    pub(crate) resolution_ms: i32,
-    pub(crate) last_fire_ns: u64,
-    pub(crate) enabled: bool,
+    histogram: JsCell<bun_jsc::Weak<()>>,
+    pub(crate) event_loop_timer: JsCell<EventLoopTimer>,
+    pub(crate) resolution_ms: Cell<i32>,
+    pub(crate) last_fire_ns: Cell<u64>,
+    pub(crate) enabled: Cell<bool>,
 }
+bun_event_loop::impl_timer_owner!(EventLoopDelayMonitor; from_timer_ptr => event_loop_timer);
 impl Default for EventLoopDelayMonitor {
     fn default() -> Self {
         Self {
-            histogram: bun_jsc::Weak::default(),
-            event_loop_timer: EventLoopTimer::init_paused(EventLoopTimerTag::EventLoopDelayMonitor),
-            resolution_ms: 10,
-            last_fire_ns: 0,
-            enabled: false,
+            histogram: JsCell::new(bun_jsc::Weak::default()),
+            event_loop_timer: JsCell::new(EventLoopTimer::init_paused(
+                EventLoopTimerTag::EventLoopDelayMonitor,
+            )),
+            resolution_ms: Cell::new(10),
+            last_fire_ns: Cell::new(0),
+            enabled: Cell::new(false),
         }
     }
 }
 impl EventLoopDelayMonitor {
     #[inline]
-    fn timer_all() -> *mut All {
-        crate::jsc_hooks::timer_all()
+    fn timer_ref(&self) -> TimerRef {
+        TimerRef::new(self, |t| &t.event_loop_timer)
     }
 
-    fn enable(
-        &mut self,
-        vm: &mut bun_jsc::virtual_machine::VirtualMachine,
-        histogram: JSValue,
-        resolution_ms: i32,
-    ) {
-        self.disable();
-        self.histogram = bun_jsc::Weak::create_passive(histogram, vm.global());
-        self.resolution_ms = resolution_ms;
-        self.enabled = true;
+    fn enable(&self, vm: &VirtualMachine, all: &All, histogram: JSValue, resolution_ms: i32) {
+        self.disable(all);
+        self.histogram
+            .set(bun_jsc::Weak::create_passive(histogram, vm.global()));
+        self.resolution_ms.set(resolution_ms);
+        self.enabled.set(true);
 
         // Schedule timer
         let now = Timespec::now(TimespecMockMode::ForceRealTime);
-        let next = now.add_ms(i64::from(resolution_ms));
-        self.event_loop_timer.next = ElTimespec {
-            sec: next.sec,
-            nsec: next.nsec,
-        };
-        let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-        // SAFETY: single JS thread; nothing `All::insert` touches overlaps
-        // `event_loop_delay`, which `self` aliases.
-        unsafe { (*Self::timer_all()).insert(elt) };
+        self.event_loop_timer
+            .with_mut(|t| t.next = now.add_ms(i64::from(resolution_ms)));
+        all.insert(self.timer_ref());
     }
 
-    pub(crate) fn disable(&mut self) {
-        if !self.enabled {
+    pub(crate) fn disable(&self, all: &All) {
+        if !self.enabled.get() {
             return;
         }
-        self.enabled = false;
-        self.histogram = bun_jsc::Weak::default();
-        self.last_fire_ns = 0;
+        self.enabled.set(false);
+        self.histogram.set(bun_jsc::Weak::default());
+        self.last_fire_ns.set(0);
         // FIRED (not linked) when called from `on_fire`.
-        if self.event_loop_timer.state == EventLoopTimerState::ACTIVE {
-            let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-            // SAFETY: see `enable` — disjoint-field access on `All`.
-            unsafe { (*Self::timer_all()).remove(elt) };
+        if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
+            all.remove(self.timer_ref());
         }
     }
 
     /// Record `now - last_fire_ns`
     /// into the JS histogram and reschedule.
-    pub(crate) fn on_fire(
-        &mut self,
-        _vm: &mut bun_jsc::virtual_machine::VirtualMachine,
-        now: &bun_event_loop::EventLoopTimer::Timespec,
-    ) {
-        self.event_loop_timer.state = EventLoopTimerState::FIRED;
-        if !self.enabled {
+    pub(crate) fn on_fire(&self, now: &Timespec, all: &All) {
+        self.event_loop_timer
+            .with_mut(|t| t.state = EventLoopTimerState::FIRED);
+        if !self.enabled.get() {
             return;
         }
-        let Some(histogram) = self.histogram.get() else {
-            self.disable();
+        let Some(histogram) = self.histogram.get().get() else {
+            self.disable(all);
             return;
         };
 
         let now_ns = now.ns();
-        if self.last_fire_ns > 0 {
-            let expected_ns = u64::try_from(self.resolution_ms)
+        let last_fire_ns = self.last_fire_ns.get();
+        if last_fire_ns > 0 {
+            let expected_ns = u64::try_from(self.resolution_ms.get())
                 .expect("int cast")
                 .saturating_mul(1_000_000);
-            let actual_ns = now_ns - self.last_fire_ns;
+            let actual_ns = now_ns - last_fire_ns;
 
             if actual_ns > expected_ns {
                 let delay_ns =
@@ -499,80 +355,27 @@ impl EventLoopDelayMonitor {
             }
         }
 
-        self.last_fire_ns = now_ns;
+        self.last_fire_ns.set(now_ns);
 
         // Reschedule
-        let next = Timespec {
-            sec: now.sec,
-            nsec: now.nsec,
-        }
-        .add_ms(i64::from(self.resolution_ms));
-        self.event_loop_timer.next = ElTimespec {
-            sec: next.sec,
-            nsec: next.nsec,
-        };
-        let elt: *mut EventLoopTimer = &raw mut self.event_loop_timer;
-        // SAFETY: see `enable` — disjoint-field access on `All`.
-        unsafe { (*Self::timer_all()).insert(elt) };
+        let next = now.add_ms(i64::from(self.resolution_ms.get()));
+        self.event_loop_timer.with_mut(|t| t.next = next);
+        all.insert(self.timer_ref());
     }
 }
 
 // ─── TimerObjectInternals / TimeoutObject / ImmediateObject ─────────────────
 
 pub mod timer_object_internals;
-pub use timer_object_internals::{Flags as TimerFlags, TimerObjectInternals};
+pub use timer_object_internals::{Flags as TimerFlags, TimerObject, TimerObjectInternals};
 
 /// `jsc.WebCore.AbortSignal.Timeout` — real struct lives in `bun_jsc` (which
-/// this crate depends on). Re-exported here so `All::update`'s
-/// field-parent-pointer epoch-bump and `dispatch::fire_timer` resolve the same
+/// this crate depends on). Re-exported here so `dispatch` resolves the same
 /// `event_loop_timer`/`flags` offsets the low tier wrote.
 pub use crate::jsc::abort_signal::Timeout as AbortSignalTimeout;
 
 pub use self::immediate_object::ImmediateObject;
 pub use self::timeout_object::TimeoutObject;
-
-/// Recover the
-/// [`TimerFlags`] slot for the three JS-timer container tags
-/// (`TimeoutObject` / `ImmediateObject` / `AbortSignalTimeout`), else `None`.
-///
-/// Returns a raw `NonNull` so the caller decides read vs. write:
-/// [`EventLoopTimer::less`] reads `.epoch()` on the heap-compare hot path;
-/// [`All::update`] writes `.set_epoch()` on the JS thread. The two
-/// `internals.flags` arms store `Cell<TimerFlags>`; `Cell<T>` is
-/// `#[repr(transparent)]` so the `addr_of!` → `.cast()` is layout-sound.
-///
-/// # Safety
-/// `t` points at a live [`EventLoopTimer`] whose `tag` was set at
-/// construction and never re-tagged (the JS-timer-tag invariant). When the
-/// tag matches, `t` is the `event_loop_timer` field of the named container
-/// with whole-container provenance.
-#[inline]
-pub(crate) unsafe fn js_timer_flags_ptr(
-    t: *const EventLoopTimer,
-) -> Option<core::ptr::NonNull<TimerFlags>> {
-    use core::ptr::{NonNull, addr_of};
-    // SAFETY: caller contract — `t` is live; tag invariant per fn docs.
-    unsafe {
-        let p: *const TimerFlags = match (*t).tag {
-            EventLoopTimerTag::TimeoutObject => {
-                let parent = TimeoutObject::from_timer_ptr(t);
-                addr_of!((*parent).internals.flags).cast()
-            }
-            EventLoopTimerTag::ImmediateObject => {
-                let parent = ImmediateObject::from_timer_ptr(t);
-                addr_of!((*parent).internals.flags).cast()
-            }
-            // `AbortSignal.Timeout` stores
-            // `flags` directly (not under `.internals`, not `Cell`-wrapped).
-            EventLoopTimerTag::AbortSignalTimeout => {
-                let parent = AbortSignalTimeout::from_timer_ptr(t);
-                addr_of!((*parent).flags)
-            }
-            _ => return None,
-        };
-        Some(NonNull::new_unchecked(p.cast_mut()))
-    }
-}
 
 /// A timer created by WTF code and invoked by Bun's event loop.
 #[path = "WTFTimer.rs"]
@@ -581,26 +384,33 @@ pub(crate) use wtf_timer::WTFTimer;
 
 // ─── All ─────────────────────────────────────────────────────────────────────
 
+/// The per-VM timer state. Lives in `RuntimeState` (boxed, JS-thread-owned,
+/// stable address for the VM's lifetime) and is reached through
+/// [`crate::jsc_hooks::timer_all`]. Every method takes `&self`: timer
+/// callbacks re-enter this struct (a `setInterval` callback calling
+/// `clearTimeout`, `refresh()`, `setTimeout`, …), so state is held in
+/// `Cell`/`JsCell` and no `&mut All` ever exists. Only `wtf_timers` is touched
+/// off the JS thread (under its lock).
 pub(crate) struct All {
-    pub(crate) last_id: i32,
-    pub(crate) thread_id: std::thread::ThreadId,
+    last_id: Cell<i32>,
+    thread_id: std::thread::ThreadId,
     pub(crate) timers: TimerHeap,
-    pub(crate) active_timer_count: i32,
+    active_timer_count: Cell<i32>,
     #[cfg(windows)]
-    pub(crate) uv_timer: bun_sys::windows::libuv::Timer,
+    uv_timer: JsCell<uv::Timer>,
     /// Whether we have emitted a warning for passing a negative timeout duration
-    pub(crate) warned_negative_number: bool,
+    warned_negative_number: Cell<bool>,
     /// Whether we have emitted a warning for passing NaN for the timeout duration
-    pub(crate) warned_not_number: bool,
+    warned_not_number: Cell<bool>,
     /// Incremented when timers are scheduled or rescheduled. See
-    /// TimerObjectInternals.epoch. Masked to 25 bits on increment.
-    pub(crate) epoch: u32,
-    pub(crate) immediate_ref_count: i32,
+    /// TimerFlags.epoch. Masked to 25 bits on increment.
+    epoch: Cell<u32>,
+    immediate_ref_count: Cell<i32>,
     #[cfg(windows)]
-    pub(crate) uv_idle: bun_sys::windows::libuv::uv_idle_t,
+    uv_idle: JsCell<uv::uv_idle_t>,
     pub(crate) event_loop_delay: EventLoopDelayMonitor,
     pub(crate) fake_timers: FakeTimers,
-    pub(crate) maps: Maps,
+    pub(crate) maps: JsCell<Maps>,
     pub(crate) date_header_timer: DateHeaderTimer,
     pub(crate) wtf_timers: Guarded<TimerHeap>,
 }
@@ -608,24 +418,38 @@ pub(crate) struct All {
 impl All {
     pub(crate) fn init() -> Self {
         Self {
-            last_id: 1,
+            last_id: Cell::new(1),
             thread_id: std::thread::current().id(),
-            timers: TimerHeap::default(),
-            active_timer_count: 0,
+            timers: TimerHeap::new(InHeap::Regular),
+            active_timer_count: Cell::new(0),
             #[cfg(windows)]
-            uv_timer: bun_core::ffi::zeroed(),
-            warned_negative_number: false,
-            warned_not_number: false,
-            epoch: 0,
-            immediate_ref_count: 0,
+            uv_timer: JsCell::new(bun_core::ffi::zeroed()),
+            warned_negative_number: Cell::new(false),
+            warned_not_number: Cell::new(false),
+            epoch: Cell::new(0),
+            immediate_ref_count: Cell::new(0),
             #[cfg(windows)]
-            uv_idle: bun_core::ffi::zeroed(),
+            uv_idle: JsCell::new(bun_core::ffi::zeroed()),
             event_loop_delay: EventLoopDelayMonitor::default(),
             fake_timers: FakeTimers::default(),
-            maps: Maps::default(),
+            maps: JsCell::new(Maps::default()),
             date_header_timer: DateHeaderTimer::default(),
-            wtf_timers: Guarded::init(TimerHeap::default()),
+            wtf_timers: Guarded::init(TimerHeap::new(InHeap::Wtf)),
         }
+    }
+
+    /// Hand out the next JS-visible timer id.
+    #[inline]
+    pub(crate) fn next_id(&self) -> i32 {
+        let id = self.last_id.get();
+        self.last_id.set(id.wrapping_add(1));
+        id
+    }
+
+    /// The epoch a freshly created JS timer starts with (see [`TimerFlags`]).
+    #[inline]
+    pub(crate) fn epoch(&self) -> u32 {
+        self.epoch.get()
     }
 
     #[inline]
@@ -636,37 +460,25 @@ impl All {
         );
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn insert(&mut self, timer: *mut EventLoopTimer) {
+    pub(crate) fn insert(&self, timer: TimerRef) {
         self.assert_js_thread();
-        // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
-        let tag = unsafe { (*timer).tag };
+        let tag = timer.tag();
         debug_assert!(tag != EventLoopTimerTag::WTFTimer, "use wtf_arm");
 
         // Bump the global epoch into the per-timer flags so equal-deadline JS
         // timers (setTimeout/setInterval/AbortSignal.timeout) fire in insertion
         // order. Before heap insert: `EventLoopTimer::less` reads epoch as tiebreak.
-        // SAFETY: `timer` is live (caller contract).
-        if let Some(flags) = unsafe { js_timer_flags_ptr(timer) } {
-            self.epoch = self.epoch.wrapping_add(1) & ((1u32 << 25) - 1);
-            // SAFETY: `flags` points into the live container recovered above.
-            unsafe { (*flags.as_ptr()).set_epoch(self.epoch) };
+        let next_epoch = self.epoch.get().wrapping_add(1) & ((1u32 << 25) - 1);
+        if crate::dispatch::set_js_timer_epoch(timer, next_epoch) {
+            self.epoch.set(next_epoch);
         }
 
         if self.fake_timers.is_active() && tag.allow_fake_timers() {
-            // SAFETY: see fn contract
-            unsafe {
-                self.fake_timers.timers.insert(timer);
-                (*timer).state = EventLoopTimerState::ACTIVE;
-                (*timer).in_heap = InHeap::Fake;
-            }
+            self.fake_timers.timers.insert(timer);
+            timer.set_state(EventLoopTimerState::ACTIVE);
         } else {
-            // SAFETY: see fn contract
-            unsafe {
-                self.timers.insert(timer);
-                (*timer).state = EventLoopTimerState::ACTIVE;
-                (*timer).in_heap = InHeap::Regular;
-            }
+            self.timers.insert(timer);
+            timer.set_state(EventLoopTimerState::ACTIVE);
             #[cfg(windows)]
             self.ensure_uv_timer();
         }
@@ -678,17 +490,21 @@ impl All {
     /// handle queue when the teardown closes the loop — before this struct's
     /// storage is freed.
     #[cfg(windows)]
-    pub(crate) fn close_loop_handles_for_vm_teardown(&mut self) {
-        unsafe extern "C" fn timer_closed(_: *mut uv::Timer) {}
-        unsafe extern "C" fn idle_closed(_: *mut uv::uv_idle_t) {}
-        if !self.uv_timer.data.is_null() {
-            self.uv_timer.stop();
-            self.uv_timer.close(timer_closed);
-        }
-        if !self.uv_idle.data.is_null() {
-            self.uv_idle.stop();
-            self.uv_idle.close(idle_closed);
-        }
+    pub(crate) fn close_loop_handles_for_vm_teardown(&self) {
+        extern "C" fn timer_closed(_: *mut uv::Timer) {}
+        extern "C" fn idle_closed(_: *mut uv::uv_idle_t) {}
+        self.uv_timer.with_mut(|timer| {
+            if !timer.data.is_null() {
+                timer.stop();
+                timer.close(timer_closed);
+            }
+        });
+        self.uv_idle.with_mut(|idle| {
+            if !idle.data.is_null() {
+                idle.stop();
+                idle.close(idle_closed);
+            }
+        });
     }
 
     /// Lazily `uv_timer_init` the
@@ -696,7 +512,7 @@ impl All {
     /// across both heaps. On Windows there is no epoll/kqueue fallback; this
     /// `uv_timer_t` is the ONLY thing that wakes `uv_run` for JS timers.
     #[cfg(windows)]
-    fn ensure_uv_timer(&mut self) {
+    fn ensure_uv_timer(&self) {
         // `vm` here means the OWNING VM (the one this timer is embedded in),
         // not the calling thread's. Guard the TLS fallback so a cross-thread
         // caller fails loudly instead of silently arming a fresh `uv_loop_t`
@@ -705,41 +521,26 @@ impl All {
             self.thread_id == std::thread::current().id(),
             "ensure_uv_timer: called off the owning JS thread; TLS loop/VM would diverge from vm.event_loop_handle",
         );
-        if self.uv_timer.data.is_null() {
-            self.uv_timer.init(uv::Loop::get());
-            self.uv_timer.data =
-                bun_jsc::virtual_machine::VirtualMachine::get_mut_ptr().cast::<core::ffi::c_void>();
-            self.uv_timer.unref();
-        }
-        debug_assert!(
-            !self.uv_timer.is_closing(),
-            "timer scheduled after teardown closed the heap's uv timer"
-        );
+        self.uv_timer.with_mut(|timer| {
+            if timer.data.is_null() {
+                timer.init(uv::Loop::get());
+                // `data` is only a non-null "initialized" sentinel.
+                timer.data = VirtualMachine::get_mut_ptr().cast::<core::ffi::c_void>();
+                timer.unref();
+            }
+            debug_assert!(
+                !timer.is_closing(),
+                "timer scheduled after teardown closed the heap's uv timer"
+            );
+        });
 
-        let reg_next = self.timers.peek().map(|timer| {
-            // SAFETY: `peek` returns a live heap node.
-            let next = unsafe { &(*timer).next };
-            Timespec {
-                sec: next.sec,
-                nsec: next.nsec,
-            }
-        });
-        let wtf_next = self.wtf_timers.lock().peek().map(|timer| {
-            // SAFETY: `peek` returns a live heap node.
-            let next = unsafe { &(*timer).next };
-            Timespec {
-                sec: next.sec,
-                nsec: next.nsec,
-            }
-        });
+        let reg_next = self.timers.peek().map(TimerRef::next);
+        let wtf_next = self.wtf_timers.lock().peek().map(TimerRef::next);
         let Some(next_ts) = Self::soonest(reg_next, wtf_next) else {
             return;
         };
 
-        // SAFETY: `uv_timer.data` is non-null past the lazy-init block, so
-        // `uv_timer_init` has run and the handle's `loop` field points at
-        // the owning VM's live `uv_loop_t` (== `vm.uvLoop()` per spec).
-        unsafe { uv::uv_update_time(self.uv_timer.get_loop()) };
+        self.uv_timer.get().update_loop_time();
         let now = Timespec::now(TimespecMockMode::ForceRealTime);
         let wait = if next_ts.greater(&now) {
             next_ts.duration(&now)
@@ -751,116 +552,72 @@ impl All {
         // https://github.com/nodejs/node/blob/f552c86fecd6c2ba9e832ea129b731dd63abdbe2/src/env.cc#L1512
         let wait_ms = core::cmp::max(1, wait.ms_unsigned());
 
-        // SAFETY: `uv_timer_init` ran above; the handle is live.
-        let due_in = unsafe { uv::uv_timer_get_due_in(&self.uv_timer) };
-        // Restarting an overdue handle shifts the wakeup out by 1ms. Done
-        // on every insert, the already-due callback never runs.
-        if !(self.uv_timer.is_active() && due_in <= wait_ms) {
-            self.uv_timer.start(wait_ms, 0, Some(Self::on_uv_timer));
-        }
+        let active_timer_count = self.active_timer_count.get();
+        self.uv_timer.with_mut(|timer| {
+            // Restarting an overdue handle shifts the wakeup out by 1ms. Done
+            // on every insert, the already-due callback never runs.
+            if !(timer.is_active() && timer.get_due_in() <= wait_ms) {
+                timer.start(wait_ms, 0, Some(Self::on_uv_timer));
+            }
 
-        if self.active_timer_count > 0 {
-            self.uv_timer.ref_();
-        } else {
-            self.uv_timer.unref();
-        }
+            if active_timer_count > 0 {
+                timer.ref_();
+            } else {
+                timer.unref();
+            }
+        });
     }
 
     /// libuv timer callback; drain due
-    /// timers then re-arm for the next deadline. Only ever invoked by libuv
-    /// (coerces to the `uv_timer_cb` fn-pointer type at the `Timer::start`
-    /// call site); body wraps its derefs explicitly.
+    /// timers then re-arm for the next deadline. Only ever invoked by libuv on
+    /// the loop's (= this `All`'s) thread, so the handle pointer is not needed:
+    /// the thread's `All` is the one that armed it.
     #[cfg(windows)]
-    extern "C" fn on_uv_timer(uv_timer_t: *mut uv::Timer) {
-        // SAFETY: `uv_timer_t` is the address of `All.uv_timer` (libuv passes
-        // back exactly the handle pointer we registered in `ensure_uv_timer`);
-        // recover the containing `All` via container_of.
-        let all: *mut All = unsafe { bun_core::from_field_ptr!(All, uv_timer, uv_timer_t) };
-        // SAFETY: `data` was set to the VM ptr in `ensure_uv_timer` (non-null).
-        let vm: *mut () = unsafe { (*uv_timer_t).data.cast() };
-        // SAFETY: callback fires on the JS thread (libuv invokes on the loop's
-        // thread); `all` is live for the VM lifetime. `drain_timers` may
-        // re-enter `(*runtime_state()).timer` — it forms only short-lived
-        // `&mut All` around heap pop/peek, so the raw-ptr deref here is sound.
-        unsafe { (*all).drain_timers(vm) };
-        // SAFETY: see above; re-arm for the next-soonest deadline (if any).
-        unsafe { (*all).ensure_uv_timer() };
+    extern "C" fn on_uv_timer(_: *mut uv::Timer) {
+        let all = crate::jsc_hooks::timer_all();
+        all.drain_timers(VirtualMachine::get());
+        all.ensure_uv_timer();
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn remove(&mut self, timer: *mut EventLoopTimer) {
+    pub(crate) fn remove(&self, timer: TimerRef) {
         self.assert_js_thread();
-        // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
-        // Note (§Forbidden aliased-&mut): `TimerHeap::remove` forms a
-        // fresh `&mut EventLoopTimer` via `(*v).heap()` for the same
-        // allocation, so we must NOT hold a `&mut *timer` across that call.
-        // Read `in_heap` and write the post-remove bookkeeping via raw deref.
-        match unsafe { (*timer).in_heap } {
-            InHeap::None => {
-                // can't remove a timer that was not inserted
-                debug_assert!(false);
+        match timer.in_heap() {
+            InHeap::Regular => self.timers.remove(timer),
+            InHeap::Fake => self.fake_timers.timers.remove(timer),
+            // can't remove a timer that was not inserted
+            InHeap::None | InHeap::Wtf => {
+                debug_assert!(false, "remove: timer is in {:?}", timer.in_heap())
             }
-            // SAFETY: timer is in `self.timers` per `in_heap`
-            InHeap::Regular => unsafe { self.timers.remove(timer) },
-            // SAFETY: timer is in `self.fake_timers.timers` per `in_heap`
-            InHeap::Fake => unsafe { self.fake_timers.timers.remove(timer) },
         }
-        // SAFETY: `timer` is still a valid live EventLoopTimer.
-        unsafe {
-            (*timer).in_heap = InHeap::None;
-            (*timer).state = EventLoopTimerState::CANCELLED;
-        }
+        timer.set_state(EventLoopTimerState::CANCELLED);
     }
 
     /// Remove the EventLoopTimer if necessary, then re-insert at `time`.
-    ///
-    /// # Safety
-    /// `timer` must point to a live `EventLoopTimer` with whole-container
-    /// provenance for its tag (see [`js_timer_flags_ptr`]).
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn update(&mut self, timer: *mut EventLoopTimer, time: &Timespec) {
+    pub(crate) fn update(&self, timer: TimerRef, time: &Timespec) {
         self.assert_js_thread();
-        // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
-        // Read `state` via raw deref so we don't hold a `&mut *timer` across
-        // `remove` (which also `&mut`-derefs the same pointer); overlapping
-        // `&mut` is UB under Stacked Borrows.
-        if unsafe { (*timer).state } == EventLoopTimerState::ACTIVE {
+        if timer.in_heap() != InHeap::None {
             self.remove(timer);
         }
 
-        // SAFETY: `timer` is still a valid live EventLoopTimer; safe to derive
-        // an exclusive reference now that no other borrow is outstanding.
-        // `time` cannot alias `timer.next`: `time` is a `&bun_core::Timespec`
-        // while `next` is `ElTimespec` — distinct types, so safe code cannot
-        // construct the alias. Re-add a
-        // `debug_assert!(!core::ptr::eq(time as *const _ as *const u8, &raw const (*timer).next as *const u8))`
-        // when the Timespec types unify (see the ElTimespec alias note at the
-        // top of this file).
-        let timer_ref = unsafe { &mut *timer };
-        timer_ref.next.sec = time.sec;
-        timer_ref.next.nsec = time.nsec;
+        timer.set_next(*time);
 
         // `insert` bumps the global epoch and writes it into the per-timer
         // flags so equal-deadline JS timers fire in refresh order.
         self.insert(timer);
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn wtf_arm(&mut self, timer: *mut EventLoopTimer, time: &Timespec) {
-        // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
-        debug_assert!(unsafe { (*timer).tag } == EventLoopTimerTag::WTFTimer);
+    /// (Re)arm a `WTFTimer`. Any thread.
+    fn wtf_arm(&self, timer: TimerRef, time: Timespec) {
+        debug_assert!(timer.tag() == EventLoopTimerTag::WTFTimer);
         {
-            let mut wtf = self.wtf_timers.lock();
-            // SAFETY: `timer` is live; its state and heap links only change under this guard.
-            unsafe {
-                if (*timer).state == EventLoopTimerState::ACTIVE {
-                    wtf.remove(timer);
-                }
-                (*timer).next.sec = time.sec;
-                (*timer).next.nsec = time.nsec;
-                wtf.insert(timer);
-                (*timer).state = EventLoopTimerState::ACTIVE;
+            let wtf = self.wtf_timers.lock();
+            // The slot's state and heap links only change under this guard.
+            if timer.state() == EventLoopTimerState::ACTIVE {
+                wtf.remove(timer);
             }
+            timer.set_next(time);
+            wtf.insert(timer);
+            timer.set_state(EventLoopTimerState::ACTIVE);
         }
         #[cfg(windows)]
         if self.thread_id == std::thread::current().id() {
@@ -868,59 +625,41 @@ impl All {
         }
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn wtf_disarm(&mut self, timer: *mut EventLoopTimer) {
-        // SAFETY: caller guarantees `timer` is a valid live EventLoopTimer.
-        debug_assert!(unsafe { (*timer).tag } == EventLoopTimerTag::WTFTimer);
-        let mut wtf = self.wtf_timers.lock();
-        // SAFETY: `timer` is live; its state and heap links only change under this guard.
-        unsafe {
-            if (*timer).state == EventLoopTimerState::ACTIVE {
-                wtf.remove(timer);
-                (*timer).state = EventLoopTimerState::CANCELLED;
-            }
+    /// Disarm a `WTFTimer`; no-op if it is not linked. Any thread.
+    fn wtf_disarm(&self, timer: TimerRef) {
+        debug_assert!(timer.tag() == EventLoopTimerTag::WTFTimer);
+        let wtf = self.wtf_timers.lock();
+        // The slot's state and heap links only change under this guard.
+        if timer.state() == EventLoopTimerState::ACTIVE {
+            wtf.remove(timer);
+            timer.set_state(EventLoopTimerState::CANCELLED);
         }
     }
 
-    unsafe fn drain_due_wtf_timers(
-        this: *mut Self,
+    fn drain_due_wtf_timers(
+        &self,
         maybe_now: &mut Option<Timespec>,
-        vm: *mut (),
+        vm: &VirtualMachine,
     ) -> Option<Timespec> {
         loop {
-            let min = {
-                // SAFETY: `this` is live; the guard drops before `fire`.
-                let mut wtf = unsafe { &(*this).wtf_timers }.lock();
-                let min = wtf.peek()?;
-                // SAFETY: `peek` returned a live heap node.
-                let min_next = unsafe {
-                    Timespec {
-                        sec: (*min).next.sec,
-                        nsec: (*min).next.nsec,
-                    }
-                };
+            let (min, now) = {
+                // The guard drops before `fire`.
+                let wtf = self.wtf_timers.lock();
+                let min_next = wtf.peek()?.next();
                 let now = *maybe_now
                     .get_or_insert_with(|| Timespec::now(TimespecMockMode::ForceRealTime));
                 if min_next.greater(&now) {
                     return Some(min_next);
                 }
                 let min = wtf.delete_min().expect("peek succeeded");
-                // SAFETY: `min` is the node `peek` returned above.
-                unsafe { (*min).state = EventLoopTimerState::FIRED };
-                min
+                min.set_state(EventLoopTimerState::FIRED);
+                (min, now)
             };
-            let now = maybe_now.expect("set before the pop");
-            let el_now = ElTimespec {
-                sec: now.sec,
-                nsec: now.nsec,
-            };
-            // SAFETY: `min` is live; no guard or borrow of `All` is held here.
-            let fired = unsafe { EventLoopTimer::fire(min, &el_now, vm) };
+            let fired = crate::dispatch::fire_timer(min, &now, vm);
             // WTF timers run JSC-internal work, not user JS; a stop found here
             // is the loop's to act on at its next gate, and the heap's next
             // deadline is still reported to the poll.
-            // SAFETY: `vm` is the erased per-thread VM per fn contract.
-            let _ = unsafe { fold_timer(vm, fired) };
+            let _ = fold_timer(vm, fired);
         }
     }
 
@@ -936,23 +675,15 @@ impl All {
     /// Returns `true` if `spec` was written. `now_out` receives the monotonic reading this
     /// took, if any, for the caller to share with the tick (see `NOW_NS_UNKNOWN`).
     ///
-    /// Note (b2): `vm` is erased per §Dispatch (the caller is in
-    /// `bun_jsc::event_loop` which can't name `bun_runtime`). The two reads
-    /// it needs — `event_loop.immediate_tasks.len()` and the QUIC tick — are
-    /// passed in pre-computed until the cycle is broken.
-    ///
-    /// # Safety
-    /// `vm` is the erased `*mut VirtualMachine` for the calling JS thread and
-    /// must remain live across any `EventLoopTimer::fire` re-entry.
-    // Forwards `vm` to `__bun_fire_timer` without dereferencing it;
-    // not_unsafe_ptr_arg_deref is a false positive on opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    /// Note (b2): the caller is in `bun_jsc::event_loop`, which can't name
+    /// `bun_runtime`. The two reads it needs — `event_loop.immediate_tasks.len()`
+    /// and the QUIC tick — are passed in pre-computed until the cycle is broken.
     pub(crate) fn get_timeout(
-        &mut self,
+        &self,
         spec: &mut Timespec,
         has_pending_immediate: bool,
         quic_next_tick_us: Option<i64>,
-        vm: *mut (), /* erased *mut VirtualMachine, forwarded to fire() */
+        vm: &VirtualMachine,
         now_out: &mut Option<Timespec>,
     ) -> bool {
         #[cfg(unix)]
@@ -963,21 +694,10 @@ impl All {
         #[cfg(not(unix))]
         let _ = has_pending_immediate;
 
-        let this: *mut Self = self;
         let maybe_now: &mut Option<Timespec> = now_out;
 
-        // SAFETY: `this` is the live per-thread `All`; `vm` per fn contract.
-        let wtf_next = unsafe { Self::drain_due_wtf_timers(this, maybe_now, vm) };
-
-        // SAFETY: `this` is live, and only this thread touches the regular heap.
-        let reg_next = (unsafe { &*this }).timers.peek().map(|min| {
-            // SAFETY: `peek` returns a live heap node.
-            let next = unsafe { &(*min).next };
-            Timespec {
-                sec: next.sec,
-                nsec: next.nsec,
-            }
-        });
+        let wtf_next = self.drain_due_wtf_timers(maybe_now, vm);
+        let reg_next = self.timers.peek().map(TimerRef::next);
 
         let Some(next) = Self::soonest(wtf_next, reg_next) else {
             if let Some(us) = quic_next_tick_us {
@@ -1020,197 +740,116 @@ impl All {
 
     /// Pop the next due timer. `now` is filled lazily on first call so we
     /// don't pay for `clock_gettime` when the heap is empty.
-    fn next(&mut self, has_set_now: &mut bool, now: &mut Timespec) -> Option<*mut EventLoopTimer> {
+    fn next(&self, has_set_now: &mut bool, now: &mut Timespec) -> Option<TimerRef> {
         let timer = self.timers.peek()?;
         if !*has_set_now {
             // Real clock: this heap is the opt-out-of-fake-timers set.
             *now = Timespec::now(TimespecMockMode::ForceRealTime);
             *has_set_now = true;
         }
-        // SAFETY: peek returns a live heap node
-        let next = unsafe { &(*timer).next };
-        if (Timespec {
-            sec: next.sec,
-            nsec: next.nsec,
-        })
-        .greater(now)
-        {
+        if timer.next().greater(now) {
             return None;
         }
         let deleted = self.timers.delete_min().expect("peek succeeded");
-        debug_assert!(core::ptr::eq(deleted, timer));
+        debug_assert!(deleted == timer);
         Some(timer)
     }
 
-    /// # Safety
-    /// `vm` is the erased `*mut VirtualMachine` for the calling JS thread and
-    /// must remain live across any `EventLoopTimer::fire` re-entry.
-    // Forwards `vm` to `__bun_fire_timer` without dereferencing it;
-    // not_unsafe_ptr_arg_deref is a false positive on opaque-token forwarding.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn drain_timers(&mut self, vm: *mut () /* erased *mut VirtualMachine */) {
-        // Note (§Forbidden aliased-&mut): fired handlers re-enter `vm.timer`
-        // (e.g. setInterval reschedule → `vm.timer.update(...)`, `cancel()` →
-        // `vm.timer.remove(...)`). In Rust those re-entrant calls resolve to
-        // `(*runtime_state()).timer.{update,remove}()`, minting a fresh
-        // `&mut All` to this same allocation while the outer `&mut self` is
-        // live → UB under Stacked Borrows. Convert `self` to a raw pointer
-        // up-front and form a *short-lived* `&mut` only around `next()`,
-        // dropping it before `fire()` so no `&mut All` is held across the
-        // re-entrant call (mirroring the raw-ptr pattern in
-        // `TimerObjectInternals::run_immediate_task`).
-        //
-        // TODO: the call-site auto-ref at jsc_hooks.rs (`(*state).timer
-        // .drain_timers(...)`) still creates a `&mut All` for the call frame
-        // itself; switch it to `All::drain_timers(core::ptr::addr_of_mut!(
-        // (*state).timer), vm)` and change this signature to `this: *mut Self`.
-        let this: *mut Self = self;
-
+    /// Fire every due timer. Handlers re-enter `self` (setInterval reschedule
+    /// → `update`, `clearTimeout` → `remove`, …), which is why nothing here
+    /// holds a borrow of the heap across `fire_timer`.
+    pub(crate) fn drain_timers(&self, vm: &VirtualMachine) {
         let mut wtf_now: Option<Timespec> = None;
-        // SAFETY: `this` is the live per-thread `All`; `vm` per fn contract.
-        let _ = unsafe { Self::drain_due_wtf_timers(this, &mut wtf_now, vm) };
+        let _ = self.drain_due_wtf_timers(&mut wtf_now, vm);
 
         let mut now = Timespec { sec: 0, nsec: 0 };
         let mut has_set_now = false;
-        loop {
-            // SAFETY: `this` derived from `&mut self`; short-lived exclusive
-            // borrow scoped to this `next()` call only — dropped before fire().
-            let Some(t) = (unsafe { &mut *this }).next(&mut has_set_now, &mut now) else {
-                break;
-            };
-            // Note: re-pack into bun_event_loop's local Timespec stub
-            // until the lower tier unifies on bun_core::Timespec.
-            let el_now = ElTimespec {
-                sec: now.sec,
-                nsec: now.nsec,
-            };
-            // SAFETY: `t` was just popped from the intrusive heap and is live.
-            // `fire` dispatches through the FIRE_TIMER hook (§Dispatch hot
-            // path) and may re-enter `(*runtime_state()).timer` — no `&mut`
-            // to `All` is live here.
-            let fired = unsafe { EventLoopTimer::fire(t, &el_now, vm) };
-            // SAFETY: `vm` per fn contract.
-            if unsafe { fold_timer(vm, fired) }.is_err() {
+        while let Some(t) = self.next(&mut has_set_now, &mut now) {
+            let fired = crate::dispatch::fire_timer(t, &now, vm);
+            if fold_timer(vm, fired).is_err() {
                 break;
             }
         }
     }
 
-    /// # Safety
-    /// `uws_loop` must point to the calling VM's live uws loop.
-    // `uws_loop` is an FFI handle held as `*mut` by every caller; contract is
-    // documented in `# Safety` above. Cannot be `&mut` without breaking the
-    // out-of-file call sites that hold raw pointers.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn increment_immediate_ref(&mut self, delta: i32, uws_loop: *mut bun_uws_sys::Loop) {
-        let old = self.immediate_ref_count;
+    pub(crate) fn increment_immediate_ref(&self, delta: i32) {
+        let old = self.immediate_ref_count.get();
         let new = old + delta;
-        self.immediate_ref_count = new;
+        self.immediate_ref_count.set(new);
         if old <= 0 && new > 0 {
             #[cfg(not(windows))]
-            // SAFETY: caller passes the VM's live uws loop
-            unsafe { &mut *uws_loop }.ref_();
+            VirtualMachine::get().uws_loop_mut().ref_();
             #[cfg(windows)]
             {
                 // Lazy-init the idle handle and start
                 // it with a no-op callback so `uv_run` does not block in poll
                 // while immediates are pending (matches Node.js).
-                if self.uv_idle.data.is_null() {
-                    self.uv_idle.init(uv::Loop::get());
-                    // Note: `data` is only used as a
-                    // non-null "initialized" sentinel — never dereferenced.
-                    self.uv_idle.data = bun_jsc::virtual_machine::VirtualMachine::get_mut_ptr()
-                        .cast::<core::ffi::c_void>();
-                }
-                self.uv_idle.start(Some(Self::on_uv_idle_noop));
+                self.uv_idle.with_mut(|idle| {
+                    if idle.data.is_null() {
+                        idle.init(uv::Loop::get());
+                        // `data` is only a non-null "initialized" sentinel.
+                        idle.data = VirtualMachine::get_mut_ptr().cast::<core::ffi::c_void>();
+                    }
+                    idle.start(Some(Self::on_uv_idle_noop));
+                });
             }
         } else if old > 0 && new <= 0 {
             #[cfg(not(windows))]
-            // SAFETY: caller passes the VM's live uws loop
-            unsafe { &mut *uws_loop }.unref();
+            VirtualMachine::get().uws_loop_mut().unref();
             #[cfg(windows)]
-            if !self.uv_idle.data.is_null() {
-                self.uv_idle.stop();
-            }
+            self.uv_idle.with_mut(|idle| {
+                if !idle.data.is_null() {
+                    idle.stop();
+                }
+            });
         }
-        #[cfg(windows)]
-        let _ = uws_loop;
     }
 
     /// Empty `uv_idle` callback. Its presence alone
     /// keeps `uv_run` from blocking in the poll phase; the body is a no-op.
-    /// No preconditions (the handle pointer is unused), so the fn is safe; the
-    /// safe fn item coerces into the `uv_idle_cb` fn-pointer slot.
     #[cfg(windows)]
     extern "C" fn on_uv_idle_noop(_: *mut uv::uv_idle_t) {
         // prevent libuv from polling forever
     }
 
-    /// # Safety
-    /// `uws_loop` must point to the calling VM's live uws loop.
-    // `uws_loop` is an FFI handle held as `*mut` by every caller; contract is
-    // documented in `# Safety` above. Cannot be `&mut` without breaking the
-    // out-of-file call sites that hold raw pointers.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn increment_timer_ref(&mut self, delta: i32, uws_loop: *mut bun_uws_sys::Loop) {
-        let old = self.active_timer_count;
+    pub(crate) fn increment_timer_ref(&self, delta: i32) {
+        let old = self.active_timer_count.get();
         let new = old + delta;
         debug_assert!(new >= 0);
-        self.active_timer_count = new;
+        self.active_timer_count.set(new);
         if old <= 0 && new > 0 {
             #[cfg(not(windows))]
-            // SAFETY: caller passes the VM's live uws loop
-            unsafe { &mut *uws_loop }.ref_();
+            VirtualMachine::get().uws_loop_mut().ref_();
             // `uv_timer.ref()` is intentionally unconditional (no `data !=
             // null` guard). Invariant: every path that reaches a positive
             // `active_timer_count` first inserts a timer, and `insert`
             // → `ensure_uv_timer` lazily `uv_timer_init`s the handle. Guarding
             // here would silently drop the ref and let the loop exit early.
             #[cfg(windows)]
-            self.uv_timer.ref_();
+            self.uv_timer.with_mut(|t| t.ref_());
         } else if old > 0 && new <= 0 {
             #[cfg(not(windows))]
-            // SAFETY: caller passes the VM's live uws loop
-            unsafe { &mut *uws_loop }.unref();
+            VirtualMachine::get().uws_loop_mut().unref();
             #[cfg(windows)]
-            self.uv_timer.unref();
+            self.uv_timer.with_mut(|t| t.unref());
         }
-        #[cfg(windows)]
-        let _ = uws_loop;
+    }
+
+    /// Every slot linked into `timers` or `fake_timers.timers`.
+    fn linked_timers(&self) -> Vec<TimerRef> {
+        let mut nodes = self.timers.to_vec();
+        nodes.append(&mut self.fake_timers.timers.to_vec());
+        nodes
     }
 
     /// VM teardown, after `cancel_all_timeout_objects`: unlink every timer still
     /// in either heap, whatever its kind. Owners keep their nodes (now
     /// `CANCELLED`, which their own `state == ACTIVE` checks respect); nothing
-    /// can fire afterwards even if the loop turns again.
-    ///
-    /// # Safety
-    /// `this` is the live per-thread `All`; JS thread; never on a VM that keeps running.
-    pub(crate) unsafe fn disarm_all_for_vm_teardown(this: *mut Self) {
-        let mut nodes: Vec<*mut EventLoopTimer> = Vec::new();
-        let mut stack: Vec<*mut EventLoopTimer> = Vec::new();
-        // SAFETY: fn contract.
-        let roots = unsafe { [(*this).timers.0.root, (*this).fake_timers.timers.0.root] };
-        for root in roots {
-            if !root.is_null() {
-                stack.push(root);
-            }
-        }
-        while let Some(node) = stack.pop() {
-            // SAFETY: intrusive-heap invariant — reachable nodes are live while linked.
-            let (child, next) = unsafe { ((*node).heap.child, (*node).heap.next) };
-            if !child.is_null() {
-                stack.push(child);
-            }
-            if !next.is_null() {
-                stack.push(next);
-            }
-            nodes.push(node);
-        }
-        for node in nodes {
-            // SAFETY: collected from the live heap above; `remove` relinks the
-            // others but every node stays a valid allocation owned elsewhere.
-            unsafe { (*this).remove(node) };
+    /// can fire afterwards even if the loop turns again. JS thread; never on a
+    /// VM that keeps running.
+    pub(crate) fn disarm_all_for_vm_teardown(&self) {
+        for node in self.linked_timers() {
+            self.remove(node);
         }
     }
 
@@ -1221,84 +860,27 @@ impl All {
     /// every `AbortSignal.timeout()` timer through its signal so the signal
     /// stops reporting an active timer.
     ///
-    /// # Safety
-    /// JS thread only, with the TLS `RuntimeState` still installed and `vm`
-    /// the live per-thread VM. Must run BEFORE JSC teardown
-    /// (`Zig__GlobalObject__destructOnExit` / `WebWorker__teardownJSCVM`) and
-    /// BEFORE `runtime_state` is nulled — the GC sweep frees the
-    /// `TimeoutObject` boxes whose `event_loop_timer` fields the heap nodes
-    /// alias, and the `AbortSignal`s that own the `AbortSignalTimeout` boxes.
-    pub(crate) unsafe fn cancel_all_timeout_objects(
-        this: *mut Self,
-        vm: *mut crate::jsc::virtual_machine::VirtualMachine,
-    ) {
-        let mut to_cancel: Vec<*const TimerObjectInternals> = Vec::new();
-        let mut signal_timeouts: Vec<*mut AbortSignalTimeout> = Vec::new();
-        let mut stack: Vec<*mut EventLoopTimer> = Vec::new();
-
-        // SAFETY: `this` is the live per-thread `All` (JS thread only).
-        let roots = unsafe { [(*this).timers.0.root, (*this).fake_timers.timers.0.root] };
-        for root in roots {
-            if !root.is_null() {
-                stack.push(root);
-            }
-        }
-        while let Some(node) = stack.pop() {
-            // SAFETY: intrusive-heap invariant — every node reachable from a
-            // root is a live `EventLoopTimer` while linked. Read-only walk.
-            let (tag, child, next) =
-                unsafe { ((*node).tag, (*node).heap.child, (*node).heap.next) };
-            if !child.is_null() {
-                stack.push(child);
-            }
-            if !next.is_null() {
-                stack.push(next);
-            }
-            match tag {
-                EventLoopTimerTag::TimeoutObject => {
-                    // SAFETY: tag invariant — `node` IS the `event_loop_timer`
-                    // field of a live `TimeoutObject`.
-                    let parent = unsafe { TimeoutObject::from_timer_ptr(node) };
-                    // SAFETY: `parent` points at the live `TimeoutObject` recovered
-                    // above; `addr_of!` projects the in-bounds `internals` field.
-                    to_cancel.push(unsafe { core::ptr::addr_of!((*parent).internals) });
+    /// JS thread only. Must run BEFORE JSC teardown
+    /// (`Zig__GlobalObject__destructOnExit` / `WebWorker__teardownJSCVM`) — the
+    /// GC sweep frees the `TimeoutObject` boxes whose `event_loop_timer` slots
+    /// the heap links, and the `AbortSignal`s that own the `AbortSignalTimeout`
+    /// boxes.
+    pub(crate) fn cancel_all_timeout_objects(&self, vm: &VirtualMachine) {
+        let mut timeouts: Vec<TimerRef> = Vec::new();
+        let mut signal_timeouts: Vec<TimerRef> = Vec::new();
+        for t in self.linked_timers() {
+            match t.tag() {
+                EventLoopTimerTag::TimeoutObject | EventLoopTimerTag::ImmediateObject => {
+                    timeouts.push(t)
                 }
-                EventLoopTimerTag::ImmediateObject => {
-                    // SAFETY: tag invariant — see above.
-                    let parent = unsafe { ImmediateObject::from_timer_ptr(node) };
-                    // SAFETY: `parent` points at the live `ImmediateObject` recovered
-                    // above; `addr_of!` projects the in-bounds `internals` field.
-                    to_cancel.push(unsafe { core::ptr::addr_of!((*parent).internals) });
-                }
-                EventLoopTimerTag::AbortSignalTimeout => {
-                    // SAFETY: tag invariant — `node` IS the `event_loop_timer`
-                    // field of a live boxed `abort_signal::Timeout`.
-                    signal_timeouts.push(unsafe { AbortSignalTimeout::from_timer_ptr(node) });
-                }
+                EventLoopTimerTag::AbortSignalTimeout => signal_timeouts.push(t),
                 _ => {}
             }
         }
-
-        for internals in to_cancel {
-            // SAFETY: each pointer was collected from the live heap; the
-            // parent box is still alive (the +1 ref `cancel()` releases is
-            // exactly the one keeping it pinned). `cancel()` may free the
-            // parent on the final deref — never touched again.
-            unsafe { (*internals).cancel(vm) };
-        }
-
-        // `AbortSignal.timeout()` boxes are owned by the C++ `AbortSignal`, so
-        // each one is handed back to its signal, which unlinks and frees it and
-        // clears `m_timeout`. Only unlinking the node here would leave every
-        // observed signal's wrapper (under `--isolate`: the retired global its
-        // listeners close over) pinned by `isReachableFromOpaqueRoots` for the
-        // rest of the process; see `Timeout::discard`.
-        for t in signal_timeouts {
-            // SAFETY: each `t` was collected from the live heap above, so its
-            // box (and therefore its owning signal) is still alive; JS thread;
-            // no borrow of `*this` is held across the call (`discard` re-enters
-            // `remove` through `timer_remove`). `t` is freed by the call.
-            unsafe { AbortSignalTimeout::discard(t) };
+        // Each call may free the owner (the `+1` it releases is exactly the one
+        // keeping it pinned) and re-enters `remove`; no heap borrow is held.
+        for t in timeouts.into_iter().chain(signal_timeouts) {
+            crate::dispatch::cancel_js_timer(t, vm);
         }
     }
 }
@@ -1352,24 +934,18 @@ const NS_PER_US: i64 = bun_core::time::NS_PER_US as i64;
 
 /// The timer drain's fold: report what a fired timer's handler left pending
 /// as uncaught, or — if it is the VM's termination — tell the drain to stop.
-///
-/// # Safety
-/// `vm` is the erased per-thread `*mut VirtualMachine`.
 #[inline]
-unsafe fn fold_timer(
-    vm: *mut (),
+fn fold_timer(
+    vm: &VirtualMachine,
     fired: bun_event_loop::JsResult<()>,
 ) -> Result<(), bun_jsc::Stopped> {
     #[cold]
     #[inline(never)]
-    unsafe fn report(vm: *mut (), err: bun_jsc::JsError) -> Result<(), bun_jsc::Stopped> {
-        // SAFETY: fn contract.
-        let global = unsafe { (*vm.cast::<bun_jsc::virtual_machine::VirtualMachine>()).global() };
-        bun_jsc::task::report_error_or_terminate(global, err)
+    fn report(vm: &VirtualMachine, err: bun_jsc::JsError) -> Result<(), bun_jsc::Stopped> {
+        bun_jsc::task::report_error_or_terminate(vm.global(), err)
     }
     match fired {
         Ok(()) => Ok(()),
-        // SAFETY: fn contract.
-        Err(err) => unsafe { report(vm, err) },
+        Err(err) => report(vm, err),
     }
 }

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -579,15 +579,17 @@ impl All {
         all.ensure_uv_timer();
     }
 
+    /// Disarm `timer`: unlink it if it is linked (a slot that already left the
+    /// heap — popped to fire, or never inserted — is fine) and mark it
+    /// `CANCELLED`. This is the one "remove if armed" entry point; callers need
+    /// not check first.
     pub(crate) fn remove(&self, timer: TimerRef) {
         self.assert_js_thread();
         match timer.in_heap() {
             InHeap::Regular => self.timers.remove(timer),
             InHeap::Fake => self.fake_timers.timers.remove(timer),
-            // can't remove a timer that was not inserted
-            InHeap::None | InHeap::Wtf => {
-                debug_assert!(false, "remove: timer is in {:?}", timer.in_heap())
-            }
+            InHeap::None => {}
+            InHeap::Wtf => debug_assert!(false, "use wtf_disarm"),
         }
         timer.set_state(EventLoopTimerState::CANCELLED);
     }
@@ -606,12 +608,12 @@ impl All {
         self.insert(timer);
     }
 
-    /// (Re)arm a `WTFTimer`. Any thread.
+    /// (Re)arm a `WTFTimer`. Any thread; the slot is only touched under the
+    /// `wtf_timers` lock.
     fn wtf_arm(&self, timer: TimerRef, time: Timespec) {
-        debug_assert!(timer.tag() == EventLoopTimerTag::WTFTimer);
         {
             let wtf = self.wtf_timers.lock();
-            // The slot's state and heap links only change under this guard.
+            debug_assert!(timer.tag() == EventLoopTimerTag::WTFTimer);
             if timer.state() == EventLoopTimerState::ACTIVE {
                 wtf.remove(timer);
             }
@@ -625,25 +627,23 @@ impl All {
         }
     }
 
-    /// Disarm a `WTFTimer`; no-op if it is not linked. Any thread.
+    /// Disarm a `WTFTimer`; no-op if it is not linked. Any thread; the slot
+    /// is only touched under the `wtf_timers` lock.
     fn wtf_disarm(&self, timer: TimerRef) {
-        debug_assert!(timer.tag() == EventLoopTimerTag::WTFTimer);
         let wtf = self.wtf_timers.lock();
-        // The slot's state and heap links only change under this guard.
+        debug_assert!(timer.tag() == EventLoopTimerTag::WTFTimer);
         if timer.state() == EventLoopTimerState::ACTIVE {
             wtf.remove(timer);
             timer.set_state(EventLoopTimerState::CANCELLED);
         }
     }
 
-    fn drain_due_wtf_timers(
-        &self,
-        maybe_now: &mut Option<Timespec>,
-        vm: &VirtualMachine,
-    ) -> Option<Timespec> {
+    /// Fire every due `WTFTimer` and return the next WTF deadline, if any. The
+    /// popped slot is only read under the lock; once it drops nothing here
+    /// touches the slot again (a GC thread may re-arm it concurrently).
+    fn drain_due_wtf_timers(&self, maybe_now: &mut Option<Timespec>) -> Option<Timespec> {
         loop {
-            let (min, now) = {
-                // The guard drops before `fire`.
+            let min = {
                 let wtf = self.wtf_timers.lock();
                 let min_next = wtf.peek()?.next();
                 let now = *maybe_now
@@ -653,13 +653,11 @@ impl All {
                 }
                 let min = wtf.delete_min().expect("peek succeeded");
                 min.set_state(EventLoopTimerState::FIRED);
-                (min, now)
+                min
             };
-            let fired = crate::dispatch::fire_timer(min, &now, vm);
-            // WTF timers run JSC-internal work, not user JS; a stop found here
-            // is the loop's to act on at its next gate, and the heap's next
-            // deadline is still reported to the poll.
-            let _ = fold_timer(vm, fired);
+            // Only `WTFTimer`s are ever in this heap. They run JSC-internal
+            // work, not user JS, so there is nothing to fold.
+            crate::dispatch::fire_wtf_timer(min);
         }
     }
 
@@ -683,7 +681,6 @@ impl All {
         spec: &mut Timespec,
         has_pending_immediate: bool,
         quic_next_tick_us: Option<i64>,
-        vm: &VirtualMachine,
         now_out: &mut Option<Timespec>,
     ) -> bool {
         #[cfg(unix)]
@@ -696,7 +693,7 @@ impl All {
 
         let maybe_now: &mut Option<Timespec> = now_out;
 
-        let wtf_next = self.drain_due_wtf_timers(maybe_now, vm);
+        let wtf_next = self.drain_due_wtf_timers(maybe_now);
         let reg_next = self.timers.peek().map(TimerRef::next);
 
         let Some(next) = Self::soonest(wtf_next, reg_next) else {
@@ -760,7 +757,7 @@ impl All {
     /// holds a borrow of the heap across `fire_timer`.
     pub(crate) fn drain_timers(&self, vm: &VirtualMachine) {
         let mut wtf_now: Option<Timespec> = None;
-        let _ = self.drain_due_wtf_timers(&mut wtf_now, vm);
+        let _ = self.drain_due_wtf_timers(&mut wtf_now);
 
         let mut now = Timespec { sec: 0, nsec: 0 };
         let mut has_set_now = false;

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -96,9 +96,7 @@ unsafe extern "C" {
 /// `refresh()`, the `_destroyed` getter), so all state is in `Cell`/`JsCell`.
 /// Methods that may drop the heap's ref (and with it possibly the last ref)
 /// take `ThisPtr<Self>`; after they release it `this` may be gone.
-pub trait TimerObject:
-    bun_ptr::RefCounted + TimerOwner + Sized + 'static
-{
+pub trait TimerObject: bun_ptr::RefCounted + TimerOwner + Sized + 'static {
     fn internals(&self) -> &TimerObjectInternals;
     fn event_loop_timer(&self) -> &JsCell<EventLoopTimer>;
     /// The slot for the ref held while this timer is scheduled (see the

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -1,28 +1,28 @@
-//! `TimerObjectInternals` — fields shared by `TimeoutObject` / `ImmediateObject`.
+//! `TimerObjectInternals` — fields shared by `TimeoutObject` / `ImmediateObject`,
+//! and [`TimerObject`] — the behaviour shared by both, generic over the
+//! owning type so the timer slot, the heap's ref and the id map are reached
+//! through `self` instead of a `container_of`.
 //!
-//! Struct + `Flags` packed-u32 state machine. `run_immediate_task()` +
-//! helpers (`event_loop_timer`/`ref_`/`deref_`/
-//! `set_enable_keeping_event_loop_alive`/`run`) drive the
-//! `__bun_run_immediate_task` dispatch path. `fire()` + `reschedule()`/
-//! `should_reschedule_timer()`/`convert_to_interval()` drive the
-//! `FIRE_TIMER` dispatch path (Timeout/Immediate arms). `init()` backs the
-//! `TimeoutObject::init` / `ImmediateObject::init` constructors.
+//! `run_immediate_task()` drives the `__bun_run_immediate_task` dispatch
+//! path; `fire()` + `reschedule()`/`should_reschedule_timer()`/
+//! `convert_to_interval()` drive the timer-heap dispatch path
+//! (Timeout/Immediate arms); `schedule()` backs the `TimeoutObject::init` /
+//! `ImmediateObject::init` constructors.
+
+use core::cell::Cell;
 
 use bun_core::{Timespec, TimespecMockMode};
+use bun_ptr::{BackRef, JsCell, RefPtr, ThisPtr};
 
-use crate::jsc::JsCell;
+use crate::jsc::virtual_machine::VirtualMachine;
 use crate::jsc::{
     Debugger, JSGlobalObject, JSValue, JsRef, JsResult, ScriptExecutionStatus,
     generated::{JSImmediate, JSTimeout},
 };
-use core::cell::Cell;
-// Note: `bun_jsc::VirtualMachine` is a *module* alias; the struct lives at
-// `virtual_machine::VirtualMachine`.
-use crate::jsc::virtual_machine::VirtualMachine;
+use crate::jsc_hooks::timer_all;
 
 use super::{
-    ElTimespec, EventLoopTimer, EventLoopTimerState, ID, ImmediateObject, Kind, KindBig,
-    TimeoutObject,
+    EventLoopTimer, EventLoopTimerState, ID, IdMap, Kind, KindBig, Maps, TimerOwner, TimerRef,
 };
 
 /// Data that TimerObject and ImmediateObject have in common.
@@ -38,6 +38,19 @@ pub struct TimerObjectInternals {
 }
 
 impl TimerObjectInternals {
+    pub(crate) fn new(id: i32, kind: Kind, interval: u32, vm: &VirtualMachine) -> Self {
+        let mut flags = Flags::default();
+        flags.set_kind(kind);
+        flags.set_epoch(timer_all().epoch());
+        Self {
+            id,
+            interval: Cell::new(interval),
+            this_value: JsCell::new(JsRef::empty()),
+            flags: Cell::new(flags),
+            generation: vm.test_isolation_generation,
+        }
+    }
+
     /// Read-modify-write `self.flags` through the `Cell` (R-2: `flags` is
     /// `Cell<Flags>` so the write is interior-mutable, callable from
     /// `&self` host-fns that re-enter JS).
@@ -47,17 +60,14 @@ impl TimerObjectInternals {
         f(&mut fl);
         self.flags.set(fl);
     }
-}
 
-impl Default for TimerObjectInternals {
-    fn default() -> Self {
-        Self {
-            id: -1,
-            interval: Cell::new(0),
-            this_value: JsCell::new(JsRef::empty()),
-            flags: Cell::new(Flags::default()),
-            generation: 0,
+    #[inline]
+    pub(crate) fn async_id(&self) -> u64 {
+        ID {
+            id: self.id,
+            kind: self.flags.get().kind().into(),
         }
+        .async_id()
     }
 }
 
@@ -66,10 +76,6 @@ impl Default for TimerObjectInternals {
 // can name it without a forward dep on this crate. Re-exported here so existing
 // `TimerObjectInternals`/`All::update` callers see the same nominal type.
 pub use bun_event_loop::EventLoopTimer::TimerFlags as Flags;
-
-// ──────────────────────────────────────────────────────────────────────────
-// `runImmediateTask` path for `__bun_run_immediate_task` (dispatch.rs).
-// ──────────────────────────────────────────────────────────────────────────
 
 // C++ symbol emitted from ImmediateList.cpp / setTimeout.cpp; already linked.
 unsafe extern "C" {
@@ -81,306 +87,172 @@ unsafe extern "C" {
     ) -> bool;
 }
 
-/// Typed result of `@fieldParentPtr("internals", self)` discriminated by
-/// `flags.kind()`. Raw `*mut` (NOT `&mut`) so callers may hold it across
-/// re-entrant JS calls without minting an aliased `&mut` (PORTING.md
-/// §Forbidden — the callback can reach the same field via `cancel()`/
-/// `refresh()`). Provenance is `&self`-derived (read-only); the `*mut` is a
-/// type-only cast — writes must go through `Cell`/`UnsafeCell` fields.
-enum TimerParent {
-    Immediate(*mut ImmediateObject),
-    Timeout(*mut TimeoutObject),
-}
+/// The behaviour shared by [`TimeoutObject`](super::TimeoutObject) and
+/// [`ImmediateObject`](super::ImmediateObject).
+///
+/// Re-entrancy: every method that runs the JS callback takes
+/// `this: ThisPtr<Self>` / `&self` (never `&mut`) — the callback can reach
+/// this same object again through its JS wrapper (`clearTimeout()`,
+/// `refresh()`, the `_destroyed` getter), so all state is in `Cell`/`JsCell`.
+/// Methods that may drop the heap's ref (and with it possibly the last ref)
+/// take `ThisPtr<Self>`; after they release it `this` may be gone.
+pub trait TimerObject:
+    bun_ptr::RefCounted<DestructorCtx = ()> + TimerOwner + Sized + 'static
+{
+    fn internals(&self) -> &TimerObjectInternals;
+    fn event_loop_timer(&self) -> &JsCell<EventLoopTimer>;
+    /// The slot for the ref held while this timer is scheduled (see the
+    /// struct field docs).
+    fn heap_ref(&self) -> &Cell<Option<RefPtr<Self>>>;
+    /// The `clearTimeout(id)` table a timer of `kind` registers in.
+    fn id_map(maps: &mut Maps, kind: Kind) -> &mut IdMap<Self>;
 
-impl TimerObjectInternals {
-    /// `@fieldParentPtr("internals", self)` — the single `container_of` site.
-    /// Every other helper (`event_loop_timer`, `ref_`, `deref`, `init`,
-    /// `event_loop_timer_state`) routes through this so the `from_field_ptr!`
-    /// invariant — `flags.kind()` ⇔ container type, established in `init()` —
-    /// lives in exactly one place.
     #[inline]
-    fn parent_ptr(&self) -> TimerParent {
-        bun_core::assert_not_freeze!(TimerObjectInternals, TimerParent);
-        let this = std::ptr::from_ref::<Self>(self).cast_mut();
-        match self.flags.get().kind() {
-            // SAFETY: `kind == SetImmediate` ⇒ `self` is the `internals` field
-            // of a live `ImmediateObject` (set in `init()`).
-            Kind::SetImmediate => TimerParent::Immediate(unsafe {
-                bun_core::from_field_ptr!(ImmediateObject, internals, this)
-            }),
-            // SAFETY: `kind ∈ {SetTimeout, SetInterval}` ⇒ `self` is the
-            // `internals` field of a live `TimeoutObject`.
-            Kind::SetTimeout | Kind::SetInterval => TimerParent::Timeout(unsafe {
-                bun_core::from_field_ptr!(TimeoutObject, internals, this)
-            }),
-        }
-    }
-
-    /// `@fieldParentPtr("internals", self).event_loop_timer`. Returns a raw
-    /// pointer (NOT `&mut`) so callers can hold it across re-entrant JS calls
-    /// without minting aliased `&mut` (PORTING.md §Forbidden — the callback
-    /// may reach this same field via `cancel()`/`refresh()`).
-    fn event_loop_timer(&self) -> *mut EventLoopTimer {
-        match self.parent_ptr() {
-            // SAFETY: `p` points into a live container per `parent_ptr()`.
-            TimerParent::Immediate(p) => unsafe { core::ptr::addr_of_mut!((*p).event_loop_timer) },
-            // SAFETY: as above.
-            TimerParent::Timeout(p) => unsafe { core::ptr::addr_of_mut!((*p).event_loop_timer) },
-        }
-    }
-
-    /// Increment the parent container's intrusive refcount.
-    fn ref_(&self) {
-        match self.parent_ptr() {
-            // SAFETY: `p` is a live container per `parent_ptr()`.
-            TimerParent::Immediate(p) => unsafe { ImmediateObject::ref_(p) },
-            // SAFETY: as above.
-            TimerParent::Timeout(p) => unsafe { TimeoutObject::ref_(p) },
-        }
-    }
-
-    /// Release a `TimeoutObject`/`ImmediateObject` that was unlinked from a
-    /// timer heap by something other than [`Self::cancel`] (e.g.
-    /// `FakeTimers::clear`'s `delete_min` drain). Downgrades the `Strong` JS
-    /// pin and releases the `+1` taken by `reschedule()`, so GC can collect
-    /// the wrapper and the box frees on the final deref.
-    ///
-    /// `cancel()` skips its own `remove`/`deref` because `state` is already
-    /// `CANCELLED`, which is why the explicit `deref` follows.
-    ///
-    /// `vm` is the live per-thread VM; no borrow of `All` may be live across
-    /// this call (`cancel()` reaches `All::remove`, which forms its own
-    /// `&mut All`).
-    pub(crate) fn release_heap_pin(this: core::ptr::NonNull<Self>, vm: *mut VirtualMachine) {
-        // SAFETY: caller guarantees the parent box is live (refcount ≥ 1).
-        let internals = unsafe { this.as_ref() };
-        internals.cancel(vm);
-        internals.deref();
-    }
-
-    /// Decrement the parent container's intrusive refcount; frees on 0.
-    /// After this returns, `self` may be dangling — do not touch.
-    fn deref(&self) {
-        match self.parent_ptr() {
-            // SAFETY: `p` is a live container per `parent_ptr()`.
-            TimerParent::Immediate(p) => unsafe { ImmediateObject::deref(p) },
-            // SAFETY: as above.
-            TimerParent::Timeout(p) => unsafe { TimeoutObject::deref(p) },
-        }
+    fn timer_ref(&self) -> TimerRef {
+        TimerRef::new(self, Self::event_loop_timer)
     }
 
     #[inline]
-    pub(crate) fn async_id(&self) -> u64 {
-        ID {
-            id: self.id,
-            kind: self.flags.get().kind().into(),
-        }
-        .async_id()
+    fn event_loop_timer_state(&self) -> EventLoopTimerState {
+        self.event_loop_timer().get().state
     }
 
-    /// Note (jsc/runtime crate cycle): the low-tier
-    /// `bun_jsc::VirtualMachine.timer` is `()`,
-    /// so resolve `Timer::All` via the per-thread `RuntimeState` instead.
-    fn set_enable_keeping_event_loop_alive(&self, vm: *mut VirtualMachine, enable: bool) {
-        if self.flags.get().is_keeping_event_loop_alive() == enable {
+    #[inline]
+    fn set_event_loop_timer_state(&self, state: EventLoopTimerState) {
+        self.event_loop_timer().with_mut(|t| t.state = state);
+    }
+
+    /// Take the scheduled-timer ref on behalf of the heap / immediate queue,
+    /// unless it is already held.
+    #[inline]
+    fn hold_heap_ref(this: ThisPtr<Self>) {
+        let slot = this.heap_ref();
+        let held = slot.take();
+        slot.set(Some(held.unwrap_or_else(|| RefPtr::from_this(this))));
+    }
+
+    /// Release the scheduled-timer ref, if held. May free `this`.
+    #[inline]
+    fn release_heap_ref(this: ThisPtr<Self>) {
+        if let Some(held) = this.heap_ref().take() {
+            held.deref();
+        }
+    }
+
+    fn set_enable_keeping_event_loop_alive(&self, enable: bool) {
+        let internals = self.internals();
+        if internals.flags.get().is_keeping_event_loop_alive() == enable {
             return;
         }
-        self.update_flags(|f| f.set_is_keeping_event_loop_alive(enable));
+        internals.update_flags(|f| f.set_is_keeping_event_loop_alive(enable));
 
-        let state = crate::jsc_hooks::runtime_state();
-        debug_assert!(!state.is_null(), "RuntimeState not installed");
-        // SAFETY: `vm` is the live per-thread VM (hook contract); field read only.
-        let uws_loop = unsafe { (*vm).uws_loop() };
         let delta = if enable { 1 } else { -1 };
-        match self.flags.get().kind() {
-            // SAFETY: `state` points at the boxed per-thread `RuntimeState`;
-            // single-threaded JS heap so no concurrent `&mut` to `.timer`.
-            Kind::SetTimeout | Kind::SetInterval => unsafe {
-                (*state).timer.increment_timer_ref(delta, uws_loop)
-            },
+        match internals.flags.get().kind() {
+            Kind::SetTimeout | Kind::SetInterval => timer_all().increment_timer_ref(delta),
             // setImmediate has slightly different event loop logic
-            // SAFETY: as above.
-            Kind::SetImmediate => unsafe {
-                (*state).timer.increment_immediate_ref(delta, uws_loop)
-            },
+            Kind::SetImmediate => timer_all().increment_immediate_ref(delta),
         }
     }
 
-    /// Invoke the JS callback via the
-    /// C++ `Bun__JSTimeout__call` thunk (which handles exceptions internally).
-    /// Returns `true` if an exception was thrown.
-    ///
-    /// Note (noalias re-entrancy): takes `*mut Self`, NOT `&mut self`.
-    /// The JS callback can re-enter `cancel()`/`do_refresh()` on this same
-    /// object via a fresh `&mut Self` derived from the JS wrapper's `m_ptr`.
-    /// With `&mut self` here, LLVM's `noalias` lets it keep `self.flags` in a
-    /// register across the FFI call, so `set_in_callback(false)`'s RMW
-    /// clobbers the `has_cleared_timer` bit that `cancel()` set — the interval
-    /// re-fires forever. A raw pointer carries no aliasing guarantee, so use
-    /// one here.
-    ///
-    /// # Safety
-    /// `this` points at a live `TimerObjectInternals` embedded in its parent
-    /// container, pinned for the duration of the call by the caller's `ref_()`.
-    /// Both callers (`fire`, `run_immediate_task`) also take `*mut Self`, so
-    /// no `noalias` `&mut Self` is live anywhere in the call chain across
-    /// `Bun__JSTimeout__call` — inlining is safe.
-    unsafe fn run(
-        this: *mut Self,
-        global_this: *mut JSGlobalObject,
+    /// Invoke the JS callback via the C++ `Bun__JSTimeout__call` thunk (which
+    /// handles exceptions internally). Returns `true` if an exception was
+    /// thrown. The caller pins `self` with a ref across the call.
+    fn run(
+        &self,
+        global: &JSGlobalObject,
         timer: JSValue,
         callback: JSValue,
         arguments: JSValue,
         async_id: u64,
-        vm: *mut VirtualMachine,
+        vm: &VirtualMachine,
     ) -> bool {
-        // SAFETY: `this` live per fn contract; pinned by caller's `ref_()`.
-        // `&Self` (NOT `&mut`) — fields are `Cell`/`JsCell` so re-entrant JS
-        // touching this object via another `&Self` is sound (no `noalias`).
-        let s = unsafe { &*this };
-        // `JSGlobalObject` is an `opaque_ffi!` ZST — `opaque_ref` is the safe
-        // deref (panics on null; `vm.global` is never null).
-        let global = JSGlobalObject::opaque_ref(global_this);
-        // SAFETY: `vm` is the live per-thread VM (hook contract).
-        if unsafe { (*vm).is_inspector_enabled() } {
+        let internals = self.internals();
+        if vm.is_inspector_enabled() {
             Debugger::will_dispatch_async_call(global, Debugger::AsyncCallType::DOMTimer, async_id);
         }
 
         // Bun__JSTimeout__call handles exceptions.
         // `Cell<Flags>` RMW so the `in_callback` write reaches memory before JS
-        // runs (re-entrant `_destroyed` getter reads it via a different pointer).
-        s.update_flags(|f| f.set_in_callback(true));
+        // runs (re-entrant `_destroyed` getter reads it through the wrapper).
+        internals.update_flags(|f| f.set_in_callback(true));
         let result = Bun__JSTimeout__call(global, timer, callback, arguments);
         // No early returns between the `in_callback` set and this clear.
-        // `Cell<Flags>` RMW: must reload `flags` from memory — re-entrant
-        // `cancel()` may have set `has_cleared_timer` / cleared
-        // `is_keeping_event_loop_alive`.
-        s.update_flags(|f| f.set_in_callback(false));
+        // Fresh `Cell` read: re-entrant `cancel()` may have set
+        // `has_cleared_timer` / cleared `is_keeping_event_loop_alive`.
+        internals.update_flags(|f| f.set_in_callback(false));
 
-        // SAFETY: as above.
-        if unsafe { (*vm).is_inspector_enabled() } {
+        if vm.is_inspector_enabled() {
             Debugger::did_dispatch_async_call(global, Debugger::AsyncCallType::DOMTimer, async_id);
         }
 
         result
     }
 
-    /// Out-param constructor; `self` is
-    /// the embedded `internals` field of a freshly `heap::alloc`'d
-    /// `ImmediateObject`/`TimeoutObject`. Cannot be
-    /// reshaped to `-> Self` because the body needs the parent pointer to
-    /// enqueue/reschedule before returning.
-    ///
-    /// Note (jsc/runtime crate cycle): `vm.timer.epoch` resolved via `runtime_state()`
-    /// (low-tier `VirtualMachine.timer` is `()`).
-    pub(crate) fn init(
-        &mut self,
+    /// Constructor tail: wire the JS wrapper's cached slots and hand the timer
+    /// to the heap (`Timeout`) or the immediate queue (`Immediate`).
+    fn schedule(
+        this: ThisPtr<Self>,
         timer: JSValue,
         global: &JSGlobalObject,
-        id: i32,
-        kind: Kind,
-        interval: u32,
         callback: JSValue,
         arguments: JSValue,
     ) {
-        let vm = VirtualMachine::get_mut_ptr();
-        let state = crate::jsc_hooks::runtime_state();
-        debug_assert!(!state.is_null(), "RuntimeState not installed");
-
-        *self = Self {
-            id,
-            flags: {
-                let mut f = Flags::default();
-                f.set_kind(kind);
-                // SAFETY: `state` is the boxed per-thread `RuntimeState`.
-                f.set_epoch(unsafe { (*state).timer.epoch });
-                Cell::new(f)
-            },
-            interval: Cell::new(interval),
-            // SAFETY: `vm` is the live per-thread VM; field read only.
-            generation: unsafe { (*vm).test_isolation_generation },
-            this_value: JsCell::new(JsRef::empty()),
-        };
-
-        if kind == Kind::SetImmediate {
+        let internals = this.internals();
+        if internals.flags.get().kind() == Kind::SetImmediate {
             JSImmediate::arguments_set_cached(timer, global, arguments);
             JSImmediate::callback_set_cached(timer, global, callback);
-            // `flags.kind` was just set to `SetImmediate` above.
-            let TimerParent::Immediate(parent) = self.parent_ptr() else {
-                unreachable!()
-            };
-            // SAFETY: `vm` is the live per-thread VM. Low tier stores `*mut ()`
-            // (PORTING.md §Dispatch); `__bun_run_immediate_task` casts it back
-            // to `*mut ImmediateObject`.
-            unsafe { (*vm).enqueue_immediate_task(parent.cast()) };
-            self.set_enable_keeping_event_loop_alive(vm, true);
+            // Low tier stores `*mut ()` (§Dispatch); `__bun_run_immediate_task`
+            // recovers the `ThisPtr<ImmediateObject>`.
+            global
+                .bun_vm()
+                .event_loop_mut()
+                .enqueue_immediate_task(this.as_ptr().cast());
+            this.set_enable_keeping_event_loop_alive(true);
             // ref'd by event loop
-            self.ref_();
+            Self::hold_heap_ref(this);
         } else {
             JSTimeout::arguments_set_cached(timer, global, arguments);
             JSTimeout::callback_set_cached(timer, global, callback);
             JSTimeout::idle_timeout_set_cached(
                 timer,
                 global,
-                JSValue::js_number(f64::from(interval)),
+                JSValue::js_number(f64::from(internals.interval.get())),
             );
             JSTimeout::repeat_set_cached(
                 timer,
                 global,
-                if kind == Kind::SetInterval {
-                    JSValue::js_number(f64::from(interval))
+                if internals.flags.get().kind() == Kind::SetInterval {
+                    JSValue::js_number(f64::from(internals.interval.get()))
                 } else {
                     JSValue::NULL
                 },
             );
 
-            // this increments the refcount and sets _idleStart
-            self.reschedule(timer, vm, global.as_ptr());
+            // this takes the heap's ref and sets _idleStart
+            Self::reschedule(this, timer, global);
         }
 
-        self.this_value.with_mut(|r| r.set_strong(timer, global));
+        internals
+            .this_value
+            .with_mut(|r| r.set_strong(timer, global));
     }
 
-    /// Returns `true` if an
-    /// exception was thrown.
-    ///
-    /// Note (noalias re-entrancy): takes `*mut Self`, NOT `&mut self`.
-    /// `Self::run` re-enters JS which can `cancel()`/`do_refresh()` this same
-    /// object via the JS wrapper's `m_ptr`. With `&mut self` LLVM may cache
-    /// `self.flags`/`event_loop_timer().state` across the call and clobber the
-    /// re-entrant write (see `run()` doc). Use a raw
-    /// pointer; helper calls `(*this).foo()` materialise short-lived `&mut`
-    /// scoped to each statement only — none span the JS call.
-    ///
-    /// Also takes `*mut VirtualMachine` (NOT `&mut`) — the body calls
-    /// `vm.event_loop().enter()` then re-enters JS which may itself touch the
-    /// VM/EventLoop; aliased `&mut` would be UB.
-    ///
-    /// # Safety
-    /// `this` points at a live `TimerObjectInternals` embedded in its
-    /// `ImmediateObject` parent (FIRE_TIMER hook contract); `vm` is the live
-    /// per-thread VM.
-    pub(crate) unsafe fn run_immediate_task(this: *mut Self, vm: *mut VirtualMachine) -> bool {
-        // SAFETY: per fn contract — `this` live. `&Self` (NOT `&mut`) — fields
-        // are `Cell`/`JsCell` so re-entrant JS touching this object via another
-        // `&Self` is sound (no `noalias`). Last use of `s` is the final
-        // `s.deref()` below; `*this` may be freed only after that point.
-        let s = unsafe { &*this };
+    /// `__bun_run_immediate_task` body. Returns `true` if an exception was
+    /// thrown.
+    fn run_immediate_task(this: ThisPtr<Self>, vm: &VirtualMachine) -> bool {
+        let s = this.internals();
         let cleared = s.flags.get().has_cleared_timer()
             // The VM's stop was requested: nothing more enters script (as `fire`).
-            // SAFETY: `vm` is the live per-thread VM (hook contract).
-            || unsafe { (*vm).script_execution_status() } != ScriptExecutionStatus::Running
-            // SAFETY: as above.
-            || s.generation != unsafe { (*vm).test_isolation_generation }
+            || vm.script_execution_status() != ScriptExecutionStatus::Running
+            || s.generation != vm.test_isolation_generation
             // unref'd setImmediate callbacks should only run if there are things
             // keeping the event loop alive other than setImmediates
             || (!s.flags.get().is_keeping_event_loop_alive()
-                // SAFETY: `vm` live per hook contract.
-                && !unsafe { (*vm).is_event_loop_alive_excluding_immediates() });
+                && !vm.is_event_loop_alive_excluding_immediates());
         if cleared {
-            s.set_enable_keeping_event_loop_alive(vm, false);
+            this.set_enable_keeping_event_loop_alive(false);
             s.this_value.with_mut(|r| r.downgrade());
-            s.deref();
+            Self::release_heap_ref(this);
             return false;
         }
 
@@ -389,48 +261,40 @@ impl TimerObjectInternals {
             panic!("TimerObjectInternals.runImmediateTask: this_object is null");
             #[cfg(not(debug_assertions))]
             {
-                s.set_enable_keeping_event_loop_alive(vm, false);
-                s.deref();
+                this.set_enable_keeping_event_loop_alive(false);
+                Self::release_heap_ref(this);
                 return false;
             }
         };
-        // SAFETY: `vm` is live; `global` is the per-VM JSGlobalObject pointer.
-        let global_this = unsafe { (*vm).global };
+        let global = vm.global();
         s.this_value.with_mut(|r| r.downgrade());
-        s.set_event_loop_timer_state(EventLoopTimerState::FIRED);
-        s.set_enable_keeping_event_loop_alive(vm, false);
+        this.set_event_loop_timer_state(EventLoopTimerState::FIRED);
+        this.set_enable_keeping_event_loop_alive(false);
         timer.ensure_still_alive();
 
-        // SAFETY: `vm` is live; `event_loop()` returns `*mut` to the embedded
-        // EventLoop. Re-entrancy is permitted by the raw-ptr contract above.
-        unsafe { (*(*vm).event_loop()).enter() };
+        vm.event_loop_mut().enter();
         let callback =
             JSImmediate::callback_get_cached(timer).expect("ImmediateObject callback slot");
         let arguments =
             JSImmediate::arguments_get_cached(timer).expect("ImmediateObject arguments slot");
 
         let exception_thrown = {
-            s.ref_();
+            let _pin = this.ref_guard();
             let async_id = s.async_id();
-            // SAFETY: `this` is the live `internals` per fn contract; `ref_()`
-            // above pins the parent across re-entrancy.
-            let result =
-                unsafe { Self::run(this, global_this, timer, callback, arguments, async_id, vm) };
-            // `Self::run` has no early return so the deref ordering below is
-            // preserved. After the second `deref()` `*this` may be
-            // freed; do not touch it past this block.
-            // Fresh read: re-entrant `cancel()`/`refresh()` may have changed
-            // `state` (`ref_()` above pins the parent).
-            if s.event_loop_timer_state() == EventLoopTimerState::FIRED {
-                s.deref();
+            let result = this.run(global, timer, callback, arguments, async_id, vm);
+            // Fresh read: re-entrant `cancel()` may have changed `state`.
+            if this.event_loop_timer_state() == EventLoopTimerState::FIRED {
+                Self::release_heap_ref(this);
             }
-            s.deref();
             result
+            // `_pin` drops here; after that `this` may be gone.
         };
         // --- after this point, the timer is no longer guaranteed to be alive ---
 
-        // SAFETY: `vm` is live; see `enter()` note above.
-        if unsafe { (*(*vm).event_loop()).exit_maybe_drain_microtasks(!exception_thrown) }.is_err()
+        if vm
+            .event_loop_mut()
+            .exit_maybe_drain_microtasks(!exception_thrown)
+            .is_err()
         {
             return true;
         }
@@ -438,69 +302,36 @@ impl TimerObjectInternals {
         exception_thrown
     }
 
-    /// # Safety
-    /// `this` must be the live `internals` of a queued `ImmediateObject`.
-    pub(crate) unsafe fn cancel_pending_immediate(this: *mut Self, vm: *mut VirtualMachine) {
-        // SAFETY: per fn contract.
-        let s = unsafe { &*this };
-        s.set_enable_keeping_event_loop_alive(vm, false);
-        s.this_value.with_mut(|r| r.downgrade());
-        s.deref();
+    /// VM-teardown release of the immediate queue's ref on a still-queued
+    /// `ImmediateObject`, without running it.
+    fn cancel_pending_immediate(this: ThisPtr<Self>) {
+        this.set_enable_keeping_event_loop_alive(false);
+        this.internals().this_value.with_mut(|r| r.downgrade());
+        Self::release_heap_ref(this);
     }
 
-    /// `EventLoopTimer.fire` dispatch
-    /// arm body for `Tag::TimeoutObject`/`Tag::ImmediateObject`. Pops the JS
-    /// timer, invokes its callback via `run()`, then either reschedules
-    /// (setInterval / `t._repeat`) or releases the heap ref.
-    ///
-    /// Note: takes `*mut VirtualMachine` (NOT `&mut`) — the body calls
-    /// `vm.event_loop().enter()` then re-enters JS which may itself touch the
-    /// VM/EventLoop (and `(*runtime_state()).timer` via `cancel()`/`refresh()`);
-    /// aliased `&mut` would be UB. Dereference per-use under `// SAFETY:`.
-    ///
-    /// Note (noalias re-entrancy): takes `*mut Self`, NOT `&mut self`.
-    /// `Self::run` re-enters JS which can `cancel()`/`do_refresh()` this same
-    /// object via the JS wrapper's `m_ptr`. With `&mut self` LLVM may cache
-    /// `self.flags`/`event_loop_timer().state` across the call and dead-store
-    /// the post-call reloads in `should_reschedule_timer`/`is_timer_done` —
-    /// the interval re-fires forever. Use a raw pointer;
-    /// helper calls `(*this).foo()` materialise short-lived `&mut` scoped to
-    /// each statement only — none span the JS call.
-    ///
-    /// Note (jsc/runtime crate cycle): `vm.timer` resolved via
-    /// `crate::jsc_hooks::runtime_state()` — low-tier `VirtualMachine.timer`
-    /// is `()` (see `set_enable_keeping_event_loop_alive`).
-    ///
-    /// # Safety
-    /// `this` points at a live `TimerObjectInternals` embedded in its
-    /// `TimeoutObject`/`ImmediateObject` parent (FIRE_TIMER hook contract);
-    /// `vm` is the live per-thread VM.
-    pub(crate) unsafe fn fire(this: *mut Self, _now: &ElTimespec, vm: *mut VirtualMachine) {
-        // SAFETY: per fn contract — `this` live. `&Self` (NOT `&mut`) — fields
-        // are `Cell`/`JsCell` so re-entrant JS touching this object via another
-        // `&Self` is sound (no `noalias`; LLVM cannot cache `Cell` reads across
-        // `Self::run`). Last use of `s` is the final `s.deref()` at the end of
-        // the pinned block; `*this` may be freed only after that point.
-        let s = unsafe { &*this };
+    /// Timer-heap dispatch arm for `Tag::TimeoutObject`/`Tag::ImmediateObject`:
+    /// the JS timer's slot was just popped; invoke its callback via `run()`,
+    /// then either reschedule (setInterval / `t._repeat`) or release the heap's
+    /// ref.
+    fn fire(this: ThisPtr<Self>, vm: &VirtualMachine) {
+        let s = this.internals();
         let id = s.id;
         let kind: KindBig = s.flags.get().kind().into();
         let async_id = ID { id, kind };
-        let has_been_cleared = s.event_loop_timer_state() == EventLoopTimerState::CANCELLED
+        let has_been_cleared = this.event_loop_timer_state() == EventLoopTimerState::CANCELLED
             || s.flags.get().has_cleared_timer()
-            // SAFETY: `vm` is the live per-thread VM (hook contract).
-            || unsafe { (*vm).script_execution_status() } != ScriptExecutionStatus::Running
-            // SAFETY: `vm` live per hook contract.
-            || s.generation != unsafe { (*vm).test_isolation_generation };
+            || vm.script_execution_status() != ScriptExecutionStatus::Running
+            || s.generation != vm.test_isolation_generation;
 
-        s.set_event_loop_timer_state(EventLoopTimerState::FIRED);
+        this.set_event_loop_timer_state(EventLoopTimerState::FIRED);
 
-        // SAFETY: `vm` is live; `global` is the per-VM JSGlobalObject pointer.
-        let global_this = unsafe { (*vm).global };
+        let global = vm.global();
         let Some(this_object) = s.this_value.get().try_get() else {
-            s.set_enable_keeping_event_loop_alive(vm, false);
+            this.set_enable_keeping_event_loop_alive(false);
             s.update_flags(|f| f.set_has_cleared_timer(true));
             s.this_value.with_mut(|r| r.downgrade());
-            s.deref();
+            Self::release_heap_ref(this);
             return;
         };
 
@@ -528,19 +359,17 @@ impl TimerObjectInternals {
         };
 
         if has_been_cleared || !callback.to_boolean() {
-            // SAFETY: `vm`/`global_this` live per hook contract.
-            if unsafe { (*vm).is_inspector_enabled() } {
+            if vm.is_inspector_enabled() {
                 Debugger::did_cancel_async_call(
-                    // `opaque_ffi!` ZST — safe deref; `vm.global` never null.
-                    JSGlobalObject::opaque_ref(global_this),
+                    global,
                     Debugger::AsyncCallType::DOMTimer,
                     async_id.async_id(),
                 );
             }
-            s.set_enable_keeping_event_loop_alive(vm, false);
+            this.set_enable_keeping_event_loop_alive(false);
             s.update_flags(|f| f.set_has_cleared_timer(true));
             s.this_value.with_mut(|r| r.downgrade());
-            s.deref();
+            Self::release_heap_ref(this);
             return;
         }
 
@@ -557,32 +386,19 @@ impl TimerObjectInternals {
         }
         this_object.ensure_still_alive();
 
-        let state = crate::jsc_hooks::runtime_state();
-        debug_assert!(!state.is_null(), "RuntimeState not installed");
-
-        // SAFETY: `vm` is live; `event_loop()` returns `*mut` to the embedded
-        // EventLoop. Re-entrancy is permitted by the raw-ptr contract above.
-        unsafe { (*(*vm).event_loop()).enter() };
+        vm.event_loop_mut().enter();
         {
             // Ensure it stays alive for this scope.
-            s.ref_();
-            // The matching `deref()` is at the end of this
-            // block. Every path through the labelled-block + `is_timer_done`
-            // tail reaches it (no `return` between here and the deref).
+            let _pin = this.ref_guard();
 
-            // SAFETY: `this` is the live `internals` per fn contract; `ref_()`
-            // above pins the parent across re-entrancy.
-            let _ = unsafe {
-                Self::run(
-                    this,
-                    global_this,
-                    this_object,
-                    callback,
-                    arguments,
-                    async_id.async_id(),
-                    vm,
-                )
-            };
+            let _ = this.run(
+                global,
+                this_object,
+                callback,
+                arguments,
+                async_id.async_id(),
+                vm,
+            );
 
             match kind {
                 KindBig::SetTimeout | KindBig::SetInterval => {
@@ -594,47 +410,29 @@ impl TimerObjectInternals {
                 KindBig::SetImmediate => {}
             }
 
-            // Every `s.flags.get()` below is a fresh `Cell` read — re-entrant
-            // `cancel()`/`refresh()` writes during `Self::run` above are
-            // observed (no `noalias` on `Cell` contents).
+            // Every `s.flags.get()` / `state` read below is fresh — re-entrant
+            // `cancel()`/`refresh()` writes during `run` above are observed.
             let is_timer_done = 'is_timer_done: {
                 // Node doesn't drain microtasks after each timer callback.
                 if kind == KindBig::SetInterval {
-                    if !s.should_reschedule_timer(repeat, idle_timeout) {
+                    if !this.should_reschedule_timer(repeat, idle_timeout) {
                         break 'is_timer_done true;
                     }
-                    // `ref_()` above pins the parent across the deref.
-                    match s.event_loop_timer_state() {
+                    match this.event_loop_timer_state() {
                         EventLoopTimerState::FIRED => {
                             // If we didn't clear the setInterval, reschedule it starting from
-                            // SAFETY: `state` is the boxed per-thread `RuntimeState`;
-                            // single-threaded JS heap so no concurrent `&mut` to
-                            // `.timer`. `event_loop_timer()` derives a fresh raw
-                            // ptr (no `&mut` aliasing across `update`).
-                            unsafe {
-                                (*state)
-                                    .timer
-                                    .update(s.event_loop_timer(), &time_before_call)
-                            };
+                            timer_all().update(this.timer_ref(), &time_before_call);
 
                             if s.flags.get().has_js_ref() {
-                                s.set_enable_keeping_event_loop_alive(vm, true);
+                                this.set_enable_keeping_event_loop_alive(true);
                             }
 
-                            // The ref count doesn't change. It wasn't decremented.
+                            // The heap keeps its ref.
                         }
                         EventLoopTimerState::ACTIVE => {
-                            // The developer called timer.refresh() synchronously in the callback.
-                            // SAFETY: as above.
-                            unsafe {
-                                (*state)
-                                    .timer
-                                    .update(s.event_loop_timer(), &time_before_call)
-                            };
-
-                            // Balance out the ref count.
-                            // the transition from "FIRED" -> "ACTIVE" caused it to increment.
-                            s.deref();
+                            // The developer called timer.refresh() synchronously in the callback;
+                            // `reschedule()` saw the heap's ref still held and re-linked under it.
+                            timer_all().update(this.timer_ref(), &time_before_call);
                         }
                         _ => {
                             break 'is_timer_done true;
@@ -644,30 +442,26 @@ impl TimerObjectInternals {
                     if kind == KindBig::SetTimeout && !repeat.is_null() {
                         if let Some(num) = idle_timeout.get_number() {
                             if num != -1.0 {
-                                // reschedule() inside convertToInterval will see state == .FIRED
-                                // and add a ref; fall through to the switch below so the .ACTIVE
-                                // arm can balance it.
-                                s.convert_to_interval(global_this, this_object, repeat, vm);
+                                // reschedule() inside convertToInterval re-links under the
+                                // heap's still-held ref; the .ACTIVE arm below keeps it.
+                                Self::convert_to_interval(this, global, this_object, repeat);
                             }
                         }
                     }
 
-                    // `ref_()` above pins the parent across the deref.
-                    match s.event_loop_timer_state() {
+                    match this.event_loop_timer_state() {
                         EventLoopTimerState::FIRED => {
                             break 'is_timer_done true;
                         }
                         EventLoopTimerState::ACTIVE => {
                             // The developer called timer.refresh() synchronously in the callback,
-                            // or the timer was converted to an interval via t._repeat. Balance out
-                            // the ref count: the transition from "FIRED" -> "ACTIVE" via
-                            // reschedule() caused it to increment.
-                            s.deref();
+                            // or the timer was converted to an interval via t._repeat. It is
+                            // linked again; the heap keeps its ref.
                         }
                         _ => {
                             // The developer called clearTimeout() synchronously in the callback.
-                            // cancel() saw state == .FIRED and skipped its deref, so release the
-                            // heap ref here.
+                            // cancel() saw state == .FIRED and left the heap's ref, so release
+                            // it here.
                             break 'is_timer_done true;
                         }
                     }
@@ -677,37 +471,28 @@ impl TimerObjectInternals {
             };
 
             if is_timer_done {
-                s.set_enable_keeping_event_loop_alive(vm, false);
+                this.set_enable_keeping_event_loop_alive(false);
                 // The timer will not be re-entered into the event loop at this point.
-                s.deref();
+                Self::release_heap_ref(this);
             }
-
-            // End of pinned scope. After
-            // this `*this` may be freed; do not touch past this block.
-            s.deref();
+            // `_pin` drops here; after that `this` may be gone.
         }
         // --- after this point, the timer is no longer guaranteed to be alive ---
 
-        // SAFETY: `vm` is live; see `enter()` note above.
-        unsafe { (*(*vm).event_loop()).exit() };
+        vm.event_loop_mut().exit();
     }
 
     /// A `setTimeout` whose
     /// `t._repeat` was assigned promotes itself to a `setInterval` after its
     /// first fire (Node `lib/internal/timers.js:613`).
-    ///
-    /// Note: takes `vm` explicitly instead of `global.bun_vm()` so the
-    /// raw-ptr contract from `fire()` is preserved (no fresh `&mut VM`).
-    /// `&self` (not `&mut`) — all writes go through `Cell`/`JsCell`; the sole
-    /// caller (`fire()`) holds only a `&Self`.
     fn convert_to_interval(
-        &self,
-        global: *mut JSGlobalObject,
+        this: ThisPtr<Self>,
+        global: &JSGlobalObject,
         timer: JSValue,
         repeat: JSValue,
-        vm: *mut VirtualMachine,
     ) {
-        debug_assert!(self.flags.get().kind() == Kind::SetTimeout);
+        let internals = this.internals();
+        debug_assert!(internals.flags.get().kind() == Kind::SetTimeout);
 
         let new_interval: u32 = if let Some(num) = repeat.get_number() {
             if num < 1.0 || num > f64::from(u32::MAX >> 1) {
@@ -720,18 +505,17 @@ impl TimerObjectInternals {
         };
 
         // https://github.com/nodejs/node/blob/a7cbb904745591c9a9d047a364c2c188e5470047/lib/internal/timers.js#L613
-        // `opaque_ffi!` ZST — safe deref; `vm.global` never null.
-        let global_ref = JSGlobalObject::opaque_ref(global);
-        JSTimeout::idle_timeout_set_cached(timer, global_ref, repeat);
-        self.this_value
-            .with_mut(|r| r.set_strong(timer, global_ref));
-        self.update_flags(|f| f.set_kind(Kind::SetInterval));
-        self.interval.set(new_interval);
-        self.reschedule(timer, vm, global);
+        JSTimeout::idle_timeout_set_cached(timer, global, repeat);
+        internals
+            .this_value
+            .with_mut(|r| r.set_strong(timer, global));
+        internals.update_flags(|f| f.set_kind(Kind::SetInterval));
+        internals.interval.set(new_interval);
+        Self::reschedule(this, timer, global);
     }
 
     fn should_reschedule_timer(&self, repeat: JSValue, idle_timeout: JSValue) -> bool {
-        if self.flags.get().kind() == Kind::SetInterval && repeat.is_null() {
+        if self.internals().flags.get().kind() == Kind::SetInterval && repeat.is_null() {
             return false;
         }
         if let Some(num) = idle_timeout.get_number() {
@@ -742,18 +526,12 @@ impl TimerObjectInternals {
         true
     }
 
-    /// Re-insert the parent's
-    /// `EventLoopTimer` into the heap at `now + interval`. Called from
-    /// `init()`, `do_refresh()`, and `convert_to_interval()` above.
-    ///
-    /// Note (jsc/runtime crate cycle): `vm.timer` resolved via `runtime_state()`.
-    pub(crate) fn reschedule(
-        &self,
-        timer: JSValue,
-        vm: *mut VirtualMachine,
-        global_this: *mut JSGlobalObject,
-    ) {
-        if self.flags.get().kind() == Kind::SetImmediate {
+    /// (Re-)insert the timer's slot into the heap at `now + interval`, taking
+    /// the heap's ref if it is not already held. Called from `schedule()`,
+    /// `do_refresh()`, and `convert_to_interval()`.
+    fn reschedule(this: ThisPtr<Self>, timer: JSValue, global: &JSGlobalObject) {
+        let internals = this.internals();
+        if internals.flags.get().kind() == Kind::SetImmediate {
             return;
         }
 
@@ -762,149 +540,94 @@ impl TimerObjectInternals {
         let repeat = JSTimeout::repeat_get_cached(timer).expect("TimeoutObject repeat slot");
 
         // https://github.com/nodejs/node/blob/a7cbb904745591c9a9d047a364c2c188e5470047/lib/internal/timers.js#L612
-        if !self.should_reschedule_timer(repeat, idle_timeout) {
+        if !this.should_reschedule_timer(repeat, idle_timeout) {
             return;
         }
 
-        let state = crate::jsc_hooks::runtime_state();
-        debug_assert!(!state.is_null(), "RuntimeState not installed");
-
         let now = Timespec::now(TimespecMockMode::AllowMockedTime);
-        let scheduled_time = now.add_ms(i64::from(self.interval.get()));
-        let was_active = self.event_loop_timer_state() == EventLoopTimerState::ACTIVE;
+        let scheduled_time = now.add_ms(i64::from(internals.interval.get()));
+        let was_active = this.event_loop_timer_state() == EventLoopTimerState::ACTIVE;
         if was_active {
-            // SAFETY: `state` is the boxed per-thread `RuntimeState`; fresh
-            // `&mut` to `.timer` for this call only.
-            unsafe { (*state).timer.remove(self.event_loop_timer()) };
+            timer_all().remove(this.timer_ref());
         } else {
-            self.ref_();
+            Self::hold_heap_ref(this);
         }
 
-        // SAFETY: as above — `event_loop_timer()` derives a fresh raw ptr (no
-        // `&mut` aliasing across `update`).
-        unsafe {
-            (*state)
-                .timer
-                .update(self.event_loop_timer(), &scheduled_time)
-        };
-        self.update_flags(|f| f.set_has_cleared_timer(false));
+        timer_all().update(this.timer_ref(), &scheduled_time);
+        internals.update_flags(|f| f.set_has_cleared_timer(false));
 
         // Set _idleStart to the current monotonic timestamp in milliseconds
         // This mimics Node.js's behavior where _idleStart is the libuv timestamp when the timer was scheduled
         JSTimeout::idle_start_set_cached(
             timer,
-            // `opaque_ffi!` ZST — safe deref; `vm.global` never null.
-            JSGlobalObject::opaque_ref(global_this),
+            global,
             JSValue::js_number(now.ms_unsigned() as f64),
         );
 
-        if self.flags.get().has_js_ref() {
-            self.set_enable_keeping_event_loop_alive(vm, true);
+        if internals.flags.get().has_js_ref() {
+            this.set_enable_keeping_event_loop_alive(true);
         }
     }
 
-    /// Final teardown, invoked from the parent container's `Drop` (count hit
-    /// zero). Unlinks the parent from every `Timer::All` data structure it may
-    /// still be reachable from so the free cannot leave a dangling
-    /// `*mut EventLoopTimer` in the heap or a leaked keep-alive count.
-    /// `this_value` is released by `JsRef: Drop` right after.
-    ///
-    /// # Safety
-    /// `self` is the `internals` field of a live heap-allocated
-    /// `TimeoutObject`/`ImmediateObject` whose refcount has just reached zero.
-    /// The per-thread `RuntimeState` and `VirtualMachine` are installed (always
-    /// true on the JS thread by the time a timer can be dropped).
-    pub(crate) unsafe fn deinit(&mut self) {
-        let vm = VirtualMachine::get_mut_ptr();
-        let kind = self.flags.get().kind();
+    /// `Drop` body (the refcount reached zero): unlink `self` from every
+    /// `timer::All` structure it may still be reachable from so the imminent
+    /// free cannot leave a dangling slot in the heap, a dangling id-map entry,
+    /// or a leaked keep-alive count. `this_value` is released by `JsRef: Drop`.
+    fn unschedule_for_drop(&mut self) {
+        let kind = self.internals().flags.get().kind();
+        let id = self.internals().id;
 
-        let state = crate::jsc_hooks::runtime_state();
-        debug_assert!(!state.is_null(), "RuntimeState not installed");
-
-        // (b) `vm.timer.remove(eventLoopTimer())` if state == .ACTIVE — without
-        //     this the freed parent stays linked into `All.timers` and the next
-        //     `delete_min`/`drain_timers` dereferences freed memory.
         if self.event_loop_timer_state() == EventLoopTimerState::ACTIVE {
-            // SAFETY: `state` is the boxed per-thread `RuntimeState`;
-            // single-threaded JS heap so no concurrent `&mut` to `.timer`.
-            unsafe { (*state).timer.remove(self.event_loop_timer()) };
+            timer_all().remove(self.timer_ref());
         }
 
-        // (c) `vm.timer.maps.get(kind).swapRemove(id)` if
-        //     `has_accessed_primitive` — drops the i32→*mut EventLoopTimer
-        //     entry minted by `to_primitive`. Swap-remove: the id map is only
-        //     ever keyed into, never iterated in order, and `deinit` runs for
-        //     every id-accessed timer a GC sweep collects, so the ordered
-        //     remove's O(n) shift + index rebuild here was O(n²) across a
-        //     sweep.
-        if self.flags.get().has_accessed_primitive() {
-            // SAFETY: as above — fresh `&mut` to `.timer.maps` for this call.
-            let map = unsafe { (*state).timer.maps.get(kind) };
-            if map.swap_remove(&self.id) {
-                // If this map got
-                // large, shrink it back down. Keys are i32, values are one
-                // pointer (~12 bytes per entry), so 21,000 timers accessed by
-                // ID ≈ 252 KiB; reclaim once the slack exceeds 256 KiB.
-                const ENTRY_SIZE: usize =
-                    core::mem::size_of::<i32>() + core::mem::size_of::<*mut EventLoopTimer>();
-                let allocated_bytes = map.capacity() * ENTRY_SIZE;
-                let used_bytes = map.count() * ENTRY_SIZE;
-                if allocated_bytes - used_bytes > 256 * 1024 {
-                    map.shrink_and_free(map.count() + 8);
+        // Drop the `id → timer` entry minted by `to_primitive`. Swap-remove: the
+        // id map is only ever keyed into, never iterated in order, and this runs
+        // for every id-accessed timer a GC sweep collects, so the ordered
+        // remove's O(n) shift + index rebuild here was O(n²) across a sweep.
+        if self.internals().flags.get().has_accessed_primitive() {
+            timer_all().maps.with_mut(|maps| {
+                let map = Self::id_map(maps, kind);
+                if map.swap_remove(&id) {
+                    // If this map got
+                    // large, shrink it back down. Keys are i32, values are one
+                    // pointer (~12 bytes per entry), so 21,000 timers accessed by
+                    // ID ≈ 252 KiB; reclaim once the slack exceeds 256 KiB.
+                    const ENTRY_SIZE: usize =
+                        core::mem::size_of::<i32>() + core::mem::size_of::<*mut EventLoopTimer>();
+                    let allocated_bytes = map.capacity() * ENTRY_SIZE;
+                    let used_bytes = map.count() * ENTRY_SIZE;
+                    if allocated_bytes - used_bytes > 256 * 1024 {
+                        map.shrink_and_free(map.count() + 8);
+                    }
+                } else if kind == Kind::SetInterval {
+                    // A `setTimeout` promoted to a `setInterval` by
+                    // `convert_to_interval()` keeps the entry minted by
+                    // `to_primitive` in `maps.set_timeout`. Remove it from there
+                    // too, or `remove_timer_by_id` would hand out a dangling
+                    // entry after the parent is freed.
+                    maps.set_timeout.swap_remove(&id);
                 }
-            } else if kind == Kind::SetInterval {
-                // A `setTimeout` promoted to a `setInterval` by
-                // `convert_to_interval()` keeps the entry minted by
-                // `to_primitive` in `maps.set_timeout`. Remove it from there
-                // too, or `remove_timer_by_id` would hand out a dangling
-                // `*mut EventLoopTimer` after the parent is freed.
-                // SAFETY: as above.
-                unsafe { (*state).timer.maps.set_timeout.swap_remove(&self.id) };
-            }
+            });
         }
 
-        // (d) `setEnableKeepingEventLoopAlive(vm, false)` — without this a
-        //     dropped-while-ref'd timer leaks `active_timer_count` /
-        //     `immediate_ref_count` and the process hangs at exit.
-        self.set_enable_keeping_event_loop_alive(vm, false);
-    }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// JS-host-method facade — `do_ref`/`do_unref`/`do_refresh`/`has_ref`/
-// `to_primitive`/`get_destroyed`/`finalize`/`cancel`, called from
-// `TimeoutObject.rs` / `ImmediateObject.rs` host-fn shims.
-// ──────────────────────────────────────────────────────────────────────────
-impl TimerObjectInternals {
-    /// Read-only `container_of` to the owning `EventLoopTimer.state`.
-    ///
-    /// Single back-ref deref site for the read path: every former
-    /// `unsafe { (*self.event_loop_timer()).state }` routes through here.
-    fn event_loop_timer_state(&self) -> EventLoopTimerState {
-        // SAFETY: ptr into the live parent per `parent_ptr()`; read-only deref.
-        unsafe { (*self.event_loop_timer()).state }
+        // Without this a dropped-while-ref'd timer leaks `active_timer_count` /
+        // `immediate_ref_count` and the process hangs at exit.
+        self.set_enable_keeping_event_loop_alive(false);
     }
 
-    /// Write the owning `EventLoopTimer.state`. Paired write-side accessor for
-    /// [`event_loop_timer_state`]; centralises the back-ref deref so call sites
-    /// stay safe.
-    fn set_event_loop_timer_state(&self, state: EventLoopTimerState) {
-        // SAFETY: ptr into the live parent per `parent_ptr()`. `state` is a
-        // plain `Copy` enum; writes happen on the single JS thread, and
-        // `event_loop_timer()` returns a raw `*mut` precisely so re-entrant
-        // `cancel()`/`refresh()` cannot alias a `&mut` (see its doc comment).
-        unsafe { (*self.event_loop_timer()).state = state };
-    }
+    // ──────────────────────────────────────────────────────────────────────
+    // JS-host-method facade — `do_ref`/`do_unref`/`do_refresh`/`has_ref`/
+    // `to_primitive`/`get_destroyed`/`cancel`, called from the
+    // `TimeoutObject.rs` / `ImmediateObject.rs` host-fn shims.
+    // ──────────────────────────────────────────────────────────────────────
 
-    pub(crate) fn do_ref(
-        &self,
-        _global: &JSGlobalObject,
-        this_value: JSValue,
-    ) -> JsResult<JSValue> {
+    fn do_ref(&self, this_value: JSValue) -> JsResult<JSValue> {
         this_value.ensure_still_alive();
 
-        let did_have_js_ref = self.flags.get().has_js_ref();
-        self.update_flags(|f| f.set_has_js_ref(true));
+        let internals = self.internals();
+        let did_have_js_ref = internals.flags.get().has_js_ref();
+        internals.update_flags(|f| f.set_has_js_ref(true));
 
         // https://github.com/nodejs/node/blob/a7cbb904745591c9a9d047a364c2c188e5470047/lib/internal/timers.js#L256
         // and
@@ -914,24 +637,21 @@ impl TimerObjectInternals {
         // has `has_cleared_timer == false` but is still destroyed. Calling `.unref(); .ref()`
         // on such a timer would otherwise leak an event-loop ref and hang the process.
         if !did_have_js_ref && !self.get_destroyed() {
-            self.set_enable_keeping_event_loop_alive(VirtualMachine::get_mut_ptr(), true);
+            self.set_enable_keeping_event_loop_alive(true);
         }
 
         Ok(this_value)
     }
 
-    pub(crate) fn do_unref(
-        &self,
-        _global: &JSGlobalObject,
-        this_value: JSValue,
-    ) -> JsResult<JSValue> {
+    fn do_unref(&self, this_value: JSValue) -> JsResult<JSValue> {
         this_value.ensure_still_alive();
 
-        let did_have_js_ref = self.flags.get().has_js_ref();
-        self.update_flags(|f| f.set_has_js_ref(false));
+        let internals = self.internals();
+        let did_have_js_ref = internals.flags.get().has_js_ref();
+        internals.update_flags(|f| f.set_has_js_ref(false));
 
         if did_have_js_ref {
-            self.set_enable_keeping_event_loop_alive(VirtualMachine::get_mut_ptr(), false);
+            self.set_enable_keeping_event_loop_alive(false);
         }
 
         Ok(this_value)
@@ -939,100 +659,81 @@ impl TimerObjectInternals {
 
     /// Node's deadline is `_idleStart + _idleTimeout`; writing `_idleStart`
     /// must move the heap entry so `t2._idleStart = t1._idleStart` works.
-    pub(crate) fn set_idle_start(&self, idle_start_ms: f64) {
-        if self.flags.get().kind() == Kind::SetImmediate
-            || self.flags.get().has_cleared_timer()
+    fn set_idle_start(&self, idle_start_ms: f64) {
+        let internals = self.internals();
+        if internals.flags.get().kind() == Kind::SetImmediate
+            || internals.flags.get().has_cleared_timer()
             || self.event_loop_timer_state() != EventLoopTimerState::ACTIVE
             || !idle_start_ms.is_finite()
         {
             return;
         }
 
-        let state = crate::jsc_hooks::runtime_state();
-        debug_assert!(!state.is_null(), "RuntimeState not installed");
-
         let ms = (idle_start_ms as i64)
-            .saturating_add(i64::from(self.interval.get()))
+            .saturating_add(i64::from(internals.interval.get()))
             .max(0);
         let scheduled_time = Timespec::EPOCH.add_ms(ms);
-        // SAFETY: `state` is the boxed per-thread `RuntimeState`; fresh
-        // `&mut` to `.timer` for this call only. The timer is ACTIVE so
-        // `update()` removes then re-inserts with no refcount change.
-        unsafe {
-            (*state)
-                .timer
-                .update(self.event_loop_timer(), &scheduled_time)
-        };
+        // The timer is ACTIVE so `update()` removes then re-inserts; the heap
+        // keeps its ref.
+        timer_all().update(self.timer_ref(), &scheduled_time);
     }
 
-    pub(crate) fn do_refresh(
-        &self,
+    fn do_refresh(
+        this: ThisPtr<Self>,
         global_object: &JSGlobalObject,
         this_value: JSValue,
     ) -> JsResult<JSValue> {
+        let internals = this.internals();
         // Immediates do not have a refresh function, and our binding generator should not let this
         // function be reached even if you override the `this` value calling a Timeout object's
         // `refresh` method
-        debug_assert!(self.flags.get().kind() != Kind::SetImmediate);
+        debug_assert!(internals.flags.get().kind() != Kind::SetImmediate);
 
         // setImmediate does not support refreshing and we do not support refreshing after cleanup
-        if self.id == -1
-            || self.flags.get().kind() == Kind::SetImmediate
-            || self.flags.get().has_cleared_timer()
+        if internals.id == -1
+            || internals.flags.get().kind() == Kind::SetImmediate
+            || internals.flags.get().has_cleared_timer()
         {
             return Ok(this_value);
         }
 
-        self.this_value
+        internals
+            .this_value
             .with_mut(|r| r.set_strong(this_value, global_object));
-        self.reschedule(
-            this_value,
-            VirtualMachine::get_mut_ptr(),
-            global_object.as_ptr(),
-        );
+        Self::reschedule(this, this_value, global_object);
 
         Ok(this_value)
     }
 
-    pub(crate) fn has_ref(&self) -> JsResult<JSValue> {
+    fn has_ref(&self) -> JsResult<JSValue> {
         Ok(JSValue::from(
-            self.flags.get().is_keeping_event_loop_alive(),
+            self.internals().flags.get().is_keeping_event_loop_alive(),
         ))
     }
 
-    /// First access mints an
-    /// `id → *mut EventLoopTimer` entry in `All.maps` so `clearTimeout(+t)` /
-    /// `clearImmediate(+t)` (numeric-id form) can resolve it.
-    ///
-    /// Note (jsc/runtime crate cycle): `vm.timer.maps` resolved via `runtime_state()`.
-    pub(crate) fn to_primitive(&self) -> JsResult<JSValue> {
-        if !self.flags.get().has_accessed_primitive() {
-            self.update_flags(|f| f.set_has_accessed_primitive(true));
-            let state = crate::jsc_hooks::runtime_state();
-            debug_assert!(!state.is_null(), "RuntimeState not installed");
-            // Note: reshaped for borrowck — capture `event_loop_timer` ptr
-            // before borrowing `(*state).timer.maps`.
-            let elt = self.event_loop_timer();
-            // SAFETY: `state` is the boxed per-thread `RuntimeState`;
-            // single-threaded JS heap so no concurrent `&mut` to `.timer.maps`.
-            unsafe {
-                (*state)
-                    .timer
-                    .maps
-                    .get(self.flags.get().kind())
-                    .put(self.id, elt)
-            }?;
+    /// First access mints an `id → timer` entry in `All.maps` so
+    /// `clearTimeout(+t)` / `clearImmediate(+t)` (numeric-id form) can resolve
+    /// it. `Drop` removes the entry.
+    fn to_primitive(this: ThisPtr<Self>) -> JsResult<JSValue> {
+        let internals = this.internals();
+        if !internals.flags.get().has_accessed_primitive() {
+            internals.update_flags(|f| f.set_has_accessed_primitive(true));
+            let kind = internals.flags.get().kind();
+            timer_all()
+                .maps
+                .with_mut(|maps| Self::id_map(maps, kind).put(internals.id, BackRef::from(this)))?;
         }
-        Ok(JSValue::js_number(f64::from(self.id)))
+        Ok(JSValue::js_number(f64::from(internals.id)))
     }
 
     /// Getter for `_destroyed`
     /// on JS Timeout and Immediate objects.
-    pub(crate) fn get_destroyed(&self) -> bool {
-        if self.flags.get().has_cleared_timer() {
+    fn get_destroyed(&self) -> bool {
+        let internals = self.internals();
+        if internals.flags.get().has_cleared_timer() {
             return true;
         }
-        if self.flags.get().in_callback() {
+        if internals.flags.get().in_callback() {
             return false;
         }
         match self.event_loop_timer_state() {
@@ -1041,43 +742,40 @@ impl TimerObjectInternals {
         }
     }
 
-    /// `.classes.ts` finalizer hook.
-    /// Runs on the mutator thread during lazy sweep; do not touch any
-    /// `JSValue`/`Strong` content here.
-    pub fn finalize(&self) {
-        self.this_value.with_mut(|r| r.finalize());
-    }
-
     /// `clearTimeout`/`clearInterval`
-    /// / `clearImmediate` / `Timeout#[Symbol.dispose]` body.
-    ///
-    /// Note: takes `*mut VirtualMachine` (NOT `&mut`) — callers hand over
-    /// `global.bun_vm()` (raw ptr) and the body forwards to
-    /// `set_enable_keeping_event_loop_alive` which already uses the raw-ptr
-    /// contract. `vm.timer` resolved via `runtime_state()` (jsc/runtime crate cycle).
-    pub(crate) fn cancel(&self, vm: *mut VirtualMachine) {
-        self.set_enable_keeping_event_loop_alive(vm, false);
-        self.update_flags(|f| f.set_has_cleared_timer(true));
+    /// / `clearImmediate` / `Timeout#[Symbol.dispose]` body. May free `this`.
+    fn cancel(this: ThisPtr<Self>) {
+        let internals = this.internals();
+        this.set_enable_keeping_event_loop_alive(false);
+        internals.update_flags(|f| f.set_has_cleared_timer(true));
 
-        if self.flags.get().kind() == Kind::SetImmediate {
+        if internals.flags.get().kind() == Kind::SetImmediate {
             // Release the strong reference so the GC can collect the JS object.
             // The immediate task is still in the event loop queue and will be skipped
             // by runImmediateTask when it sees has_cleared_timer == true.
-            self.this_value.with_mut(|r| r.downgrade());
+            internals.this_value.with_mut(|r| r.downgrade());
             return;
         }
 
-        let was_active = self.event_loop_timer_state() == EventLoopTimerState::ACTIVE;
-        self.set_event_loop_timer_state(EventLoopTimerState::CANCELLED);
-        self.this_value.with_mut(|r| r.downgrade());
+        let was_active = this.event_loop_timer_state() == EventLoopTimerState::ACTIVE;
+        this.set_event_loop_timer_state(EventLoopTimerState::CANCELLED);
+        internals.this_value.with_mut(|r| r.downgrade());
 
         if was_active {
-            let state = crate::jsc_hooks::runtime_state();
-            debug_assert!(!state.is_null(), "RuntimeState not installed");
-            // SAFETY: `state` is the boxed per-thread `RuntimeState`;
-            // single-threaded JS heap so no concurrent `&mut` to `.timer`.
-            unsafe { (*state).timer.remove(self.event_loop_timer()) };
-            self.deref();
+            timer_all().remove(this.timer_ref());
+            Self::release_heap_ref(this);
+        }
+    }
+
+    /// [`cancel`](Self::cancel) on behalf of something other than the timer
+    /// itself (VM teardown, the fake clock's `clear`), which may already have
+    /// popped the slot: also releases the heap's ref when `cancel()` finds the
+    /// slot no longer `ACTIVE`. May free `this`.
+    fn release_heap_entry(this: ThisPtr<Self>) {
+        let held = this.heap_ref().take();
+        Self::cancel(this);
+        if let Some(held) = held {
+            held.deref();
         }
     }
 }

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -412,6 +412,10 @@ pub trait TimerObject: bun_ptr::RefCounted + TimerOwner + Sized + 'static {
                 // Node doesn't drain microtasks after each timer callback.
                 if kind == KindBig::SetInterval {
                     if !this.should_reschedule_timer(repeat, idle_timeout) {
+                        // Stopped Node-style (`_repeat = null` / `_idleTimeout = -1`)
+                        // rather than through `cancel()`, so nothing has let go of
+                        // the wrapper yet.
+                        s.this_value.with_mut(|r| r.downgrade());
                         break 'is_timer_done true;
                     }
                     match this.event_loop_timer_state() {

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -97,7 +97,7 @@ unsafe extern "C" {
 /// Methods that may drop the heap's ref (and with it possibly the last ref)
 /// take `ThisPtr<Self>`; after they release it `this` may be gone.
 pub trait TimerObject:
-    bun_ptr::RefCounted<DestructorCtx = ()> + TimerOwner + Sized + 'static
+    bun_ptr::RefCounted + TimerOwner + Sized + 'static
 {
     fn internals(&self) -> &TimerObjectInternals;
     fn event_loop_timer(&self) -> &JsCell<EventLoopTimer>;
@@ -134,9 +134,7 @@ pub trait TimerObject:
     /// Release the scheduled-timer ref, if held. May free `this`.
     #[inline]
     fn release_heap_ref(this: ThisPtr<Self>) {
-        if let Some(held) = this.heap_ref().take() {
-            held.deref();
-        }
+        drop(this.heap_ref().take());
     }
 
     fn set_enable_keeping_event_loop_alive(&self, enable: bool) {
@@ -279,7 +277,7 @@ pub trait TimerObject:
             JSImmediate::arguments_get_cached(timer).expect("ImmediateObject arguments slot");
 
         let exception_thrown = {
-            let _pin = this.ref_guard();
+            let _pin = RefPtr::from_this(this);
             let async_id = s.async_id();
             let result = this.run(global, timer, callback, arguments, async_id, vm);
             // Fresh read: re-entrant `cancel()` may have changed `state`.
@@ -389,7 +387,7 @@ pub trait TimerObject:
         vm.event_loop_mut().enter();
         {
             // Ensure it stays alive for this scope.
-            let _pin = this.ref_guard();
+            let _pin = RefPtr::from_this(this);
 
             let _ = this.run(
                 global,
@@ -774,8 +772,6 @@ pub trait TimerObject:
     fn release_heap_entry(this: ThisPtr<Self>) {
         let held = this.heap_ref().take();
         Self::cancel(this);
-        if let Some(held) = held {
-            held.deref();
-        }
+        drop(held);
     }
 }

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1,16 +1,18 @@
+use core::cell::Cell;
 use core::ffi::c_void;
 
 use crate::socket::{SSLConfig, SSLConfigFromJs};
 use bun_boringssl as boringssl;
 use bun_core::{String as BunString, strings};
 use bun_event_loop::EventLoopTimer as Timer;
+use bun_event_loop::EventLoopTimer::TimerRef;
 use bun_io::KeepAlive;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
     self as jsc, CallFrame, GlobalRef, JSArray, JSGlobalObject, JSMap, JSPromise, JSValue, JsCell,
     JsRef, JsResult,
 };
-use bun_ptr::{AsCtxPtr, BackRef, RefPtr};
+use bun_ptr::{BackRef, RefPtr, ThisPtr};
 use bun_uws as uws;
 
 use super::protocol_jsc;
@@ -298,8 +300,8 @@ impl JSValkeyClient {
 // `from_field_ptr!`, but belt-and-suspenders against any path that assumes
 // `*mut JSValkeyClient` and `*mut ValkeyClient` alias (the socket ext slot did
 // — see `connect()` below).
-#[repr(C)]
 #[derive(bun_ptr::RefCounted)]
+#[repr(C)]
 pub struct JSValkeyClient {
     pub(crate) client: JsCell<valkey::ValkeyClient>,
     pub(crate) global_object: GlobalRef,
@@ -307,21 +309,32 @@ pub struct JSValkeyClient {
     pub poll_ref: JsCell<KeepAlive>,
 
     pub(crate) _subscription_ctx: JsCell<SubscriptionCtx>,
-    /// `SSL_CTX` for `tls: { …custom CA… }`. `tls: true` borrows
-    /// `RareData.defaultClientSslCtx()` instead; `tls: false` leaves this null.
-    pub(crate) _secure: JsCell<Option<boringssl::c::OwnedSslCtx>>,
+    /// The `SSL_CTX` ref for `tls: { …custom CA… }`, reused across reconnects.
+    /// `tls: true` borrows `RareData.defaultClientSslCtx()` instead; `tls: false`
+    /// leaves this `None`.
+    pub(crate) _secure: JsCell<Option<bun_boringssl_sys::OwnedSslCtx>>,
 
     pub(crate) timer: RefCountedTimer,
     pub(crate) reconnect_timer: RefCountedTimer,
     pub(crate) ref_count: bun_ptr::RefCount<JSValkeyClient>,
+    /// This allocation's root pointer, for the `&self` entry points (host fns,
+    /// `ValkeyClient::parent()`) that take or hand out refs on it.
+    this_ptr: Cell<Option<BackRef<JSValkeyClient, bun_ptr::Root>>>,
+    /// The ref held for the socket whose ext slot points here: set when
+    /// `connect()` opens one, released by that socket's one close event
+    /// (`on_close` / `on_connect_error`, or `ValkeyClient::close()` for a
+    /// half-open socket).
+    pub(crate) socket_ref: Cell<Option<RefPtr<JSValkeyClient>>>,
+    pub(crate) auto_flusher: jsc::AutoFlusher<JSValkeyClient>,
 }
 
 /// Intrusive [`EventLoopTimer`] slot that owns one strong ref on
-/// [`JSValkeyClient`] (`held_ref`) while armed, so [`disarm`] and
-/// [`take_fire_ref`] release it exactly once even when the
+/// [`JSValkeyClient`] while armed: [`arm`] takes it into `held`, and
+/// [`disarm`] / [`take_fire_ref`] release it exactly once even when the
 /// fire/close/reconnect paths re-enter each other.
 ///
 /// [`EventLoopTimer`]: Timer::EventLoopTimer
+/// [`arm`]: Self::arm
 /// [`disarm`]: Self::disarm
 /// [`take_fire_ref`]: Self::take_fire_ref
 #[repr(C)]
@@ -329,16 +342,19 @@ pub struct RefCountedTimer {
     // Must be first (offset 0): `dispatch.rs` recovers `*mut JSValkeyClient`
     // from the fired `*const EventLoopTimer` via `offset_of!(.., timer)`.
     event_loop_timer: JsCell<Timer::EventLoopTimer>,
-    held_ref: JsCell<Option<RefPtr<JSValkeyClient>>>,
+    held: Cell<Option<RefPtr<JSValkeyClient>>>,
+    /// Which of the owner's slots this is, for [`TimerRef::new`].
+    slot: fn(&JSValkeyClient) -> &JsCell<Timer::EventLoopTimer>,
 }
 
 const _: () = assert!(core::mem::offset_of!(RefCountedTimer, event_loop_timer) == 0);
 
 impl RefCountedTimer {
-    fn new(tag: Timer::Tag) -> Self {
+    fn new(tag: Timer::Tag, slot: fn(&JSValkeyClient) -> &JsCell<Timer::EventLoopTimer>) -> Self {
         Self {
             event_loop_timer: JsCell::new(Timer::EventLoopTimer::init_paused(tag)),
-            held_ref: JsCell::new(None),
+            held: Cell::new(None),
+            slot,
         }
     }
 
@@ -347,10 +363,18 @@ impl RefCountedTimer {
         self.event_loop_timer.get().state
     }
 
+    #[inline]
+    fn is_held(&self) -> bool {
+        let held = self.held.take();
+        let is_held = held.is_some();
+        self.held.set(held);
+        is_held
+    }
+
     /// Insert into the VM timer heap to fire after `ms`, taking the keep-alive
     /// ref if not already held. Disarms first if currently active.
     fn arm(&self, owner: &JSValkeyClient, ms: u32) {
-        let _guard = owner.ref_guard();
+        let _guard = owner.ref_scope();
         if self.state() == Timer::State::ACTIVE {
             self.disarm(owner);
         }
@@ -367,32 +391,19 @@ impl RefCountedTimer {
                 nsec: now.nsec,
             }
         });
-        let vm = std::ptr::from_ref::<VirtualMachine>(owner.client.get().vm).cast_mut();
-        // SAFETY: `vm` is the live per-thread VM; the timer is an unlinked
-        // field of the boxed `JSValkeyClient` (stable address until disarmed).
-        unsafe {
-            VirtualMachine::timer_insert(
-                vm,
-                core::ptr::addr_of!(self.event_loop_timer)
-                    .cast::<bun_event_loop::EventLoopTimer::EventLoopTimer>()
-                    .cast_mut(),
-            )
-        };
-        if self.held_ref.get().is_none() {
-            self.held_ref.set(Some(owner.ref_guard()));
+        crate::jsc_hooks::timer_all().insert(TimerRef::new(owner, self.slot));
+        if !self.is_held() {
+            self.held.set(Some(RefPtr::from_this(owner.this_ptr())));
         }
     }
 
     /// Remove from the VM timer heap and release the keep-alive ref if held.
     fn disarm(&self, owner: &JSValkeyClient) {
         if self.state() == Timer::State::ACTIVE {
-            let vm = std::ptr::from_ref::<VirtualMachine>(owner.client.get().vm).cast_mut();
-            // SAFETY: `vm` is the live per-thread VM; the timer is currently
-            // linked into the heap (state == ACTIVE checked above).
-            unsafe { VirtualMachine::timer_remove(vm, self.event_loop_timer.as_ptr()) };
+            crate::jsc_hooks::timer_all().remove(TimerRef::new(owner, self.slot));
         }
-        // The caller's ref keeps `owner` live past this call.
-        self.held_ref.set(None);
+        // The caller's own ref keeps `owner` alive past this release.
+        drop(self.held.take());
     }
 
     /// Mark fired and hand the keep-alive ref (if held) to the callback scope.
@@ -400,7 +411,7 @@ impl RefCountedTimer {
     fn take_fire_ref(&self) -> Option<RefPtr<JSValkeyClient>> {
         self.event_loop_timer
             .with_mut(|t| t.state = Timer::State::FIRED);
-        self.held_ref.take()
+        self.held.take()
     }
 }
 
@@ -412,29 +423,27 @@ bun_event_loop::impl_timer_owner!(JSValkeyClient;
 // `Js` (= `jsc.Codegen.JSRedisClient`) is re-exported above; `to_js`/`from_js`
 // live in that generated module.
 
-impl Drop for JSValkeyClient {
-    fn drop(&mut self) {
-        debug_assert!(self.client.get().socket.is_closed());
-        debug_assert!(self.timer.held_ref.get().is_none());
-        debug_assert!(self.reconnect_timer.held_ref.get().is_none());
-        self.client_mut().shutdown(None);
-        self.poll_ref.with_mut(|r| r.disable());
-        self.stop_timers();
-        self.ref_count.assert_no_refs();
-    }
-}
-
 impl JSValkeyClient {
-    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
+    /// This allocation's root pointer (see the `this_ptr` field).
     #[inline]
-    pub(crate) fn ref_guard(&self) -> RefPtr<Self> {
-        // SAFETY: `self` is the live heap allocation.
-        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
+    pub(crate) fn this_ptr(&self) -> ThisPtr<Self> {
+        self.this_ptr
+            .get()
+            .expect("JSValkeyClient used before JSValkeyClient::new")
+            .this_ptr()
+    }
+    /// Hold a ref on `self` for the guard's lifetime (across re-entrant
+    /// connect/close/fail paths).
+    #[inline]
+    pub(crate) fn ref_scope(&self) -> RefPtr<Self> {
+        RefPtr::from_this(self.this_ptr())
     }
     #[inline]
-    pub(crate) fn new(init: JSValkeyClient) -> *mut JSValkeyClient {
-        // bun.TrivialNew(@This()) → heap::alloc(Box::new(init))
-        bun_core::heap::into_raw(Box::new(init))
+    pub(crate) fn new(init: JSValkeyClient) -> ThisPtr<JSValkeyClient> {
+        // The JS wrapper adopts this first ref (`finalize` releases it).
+        let this = RefPtr::new(init).into_this_ptr();
+        this.this_ptr.set(Some(this.into()));
+        this
     }
 
     /// Convenience accessor for the per-thread JS VM stored on `client`.
@@ -445,19 +454,14 @@ impl JSValkeyClient {
 
     // ─── R-2 interior-mutability helpers ────────────────────────────────────
 
-    /// Mutable projection of the inner protocol client through `&self`.
+    /// Run `f` against the inner protocol client.
     ///
     /// `ValkeyClient` is the protocol state machine (not itself JS-exposed);
-    /// every method on it still takes `&mut self`. This is the single audited
-    /// escape hatch — callers must keep the returned borrow short and not hold
-    /// it across a call that re-enters JS and re-derives the same client.
+    /// every method on it still takes `&mut self`, reached through this
+    /// closure-scoped [`JsCell::with_mut`].
     #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub(super) fn client_mut(&self) -> &mut valkey::ValkeyClient {
-        // SAFETY: R-2 single-JS-thread invariant (see `JsCell` docs). The
-        // `&mut` is fresh per call site; reentrancy through
-        // `ValkeyClient::parent()` forms a shared `&JSValkeyClient` only.
-        unsafe { self.client.get_mut() }
+    pub(super) fn with_client<R>(&self, f: impl FnOnce(&mut valkey::ValkeyClient) -> R) -> R {
+        self.client.with_mut(f)
     }
 
     // Factory function to create a new Valkey client from JS
@@ -473,7 +477,7 @@ impl JSValkeyClient {
         callframe: &CallFrame,
         js_this: JSValue,
     ) -> JsResult<*mut JSValkeyClient> {
-        Self::create(global_object, callframe.arguments(), js_this)
+        Self::create(global_object, callframe.arguments(), js_this).map(ThisPtr::as_ptr)
     }
 
     /// Create a Valkey client that does not have an associated JS object nor a SubscriptionCtx.
@@ -482,7 +486,7 @@ impl JSValkeyClient {
     pub(crate) fn create_no_js_no_pubsub(
         global_object: &JSGlobalObject,
         arguments: &[JSValue],
-    ) -> JsResult<*mut JSValkeyClient> {
+    ) -> JsResult<ThisPtr<JSValkeyClient>> {
         let global_object = GlobalRef::from(global_object);
         let vm: &'static VirtualMachine = global_object.bun_vm();
         let vm_ref = vm;
@@ -732,14 +736,20 @@ impl JSValkeyClient {
                 read_buffer: Default::default(),
                 reply_scanner: Default::default(),
                 retry_attempts: 0,
-                auto_flusher: Default::default(),
             }),
             global_object,
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::default()),
             _secure: JsCell::new(None),
-            timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionTimeout),
-            reconnect_timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionReconnect),
+            timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionTimeout, |c| {
+                &c.timer.event_loop_timer
+            }),
+            reconnect_timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionReconnect, |c| {
+                &c.reconnect_timer.event_loop_timer
+            }),
+            this_ptr: Cell::new(None),
+            socket_ref: Cell::new(None),
+            auto_flusher: Default::default(),
         }))
     }
 
@@ -747,10 +757,9 @@ impl JSValkeyClient {
         global_object: &JSGlobalObject,
         arguments: &[JSValue],
         js_this: JSValue,
-    ) -> JsResult<*mut JSValkeyClient> {
+    ) -> JsResult<ThisPtr<JSValkeyClient>> {
         let new_client_ptr = JSValkeyClient::create_no_js_no_pubsub(global_object, arguments)?;
-        // SAFETY: just allocated above
-        let new_client = unsafe { &*new_client_ptr };
+        let new_client: &JSValkeyClient = &new_client_ptr;
 
         // Initially, we only need to hold a weak reference to the JS object.
         new_client.this_value.set(JsRef::init_weak(js_this));
@@ -770,7 +779,7 @@ impl JSValkeyClient {
     pub(crate) fn clone_without_connecting(
         &self,
         global_object: &JSGlobalObject,
-    ) -> Result<*mut JSValkeyClient, bun_alloc::AllocError> {
+    ) -> Result<ThisPtr<JSValkeyClient>, bun_alloc::AllocError> {
         let global_object = GlobalRef::from(global_object);
         let vm: &'static VirtualMachine = global_object.bun_vm();
 
@@ -844,14 +853,20 @@ impl JSValkeyClient {
                 read_buffer: Default::default(),
                 reply_scanner: Default::default(),
                 retry_attempts: 0,
-                auto_flusher: Default::default(),
             }),
             global_object,
             this_value: JsCell::new(JsRef::empty()),
             poll_ref: JsCell::new(KeepAlive::default()),
             _secure: JsCell::new(None),
-            timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionTimeout),
-            reconnect_timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionReconnect),
+            timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionTimeout, |c| {
+                &c.timer.event_loop_timer
+            }),
+            reconnect_timer: RefCountedTimer::new(Timer::Tag::ValkeyConnectionReconnect, |c| {
+                &c.reconnect_timer.event_loop_timer
+            }),
+            this_ptr: Cell::new(None),
+            socket_ref: Cell::new(None),
+            auto_flusher: Default::default(),
         }))
     }
 
@@ -861,7 +876,7 @@ impl JSValkeyClient {
             self._subscription_ctx.get().is_subscriber
         );
         debug_assert!(self.client.get().status == valkey::Status::Connected);
-        let _guard = self.ref_guard();
+        let _guard = self.ref_scope();
 
         if !self._subscription_ctx.get().is_subscriber {
             let flags = &self.client.get().flags;
@@ -886,7 +901,7 @@ impl JSValkeyClient {
             "removeSubscription: entering, has subscriptions: {}",
             self.has_subscriptions()
         );
-        let _guard = self.ref_guard();
+        let _guard = self.ref_scope();
 
         // This is the last subscription, restore original flags
         if !self.has_subscriptions() {
@@ -897,8 +912,8 @@ impl JSValkeyClient {
                     s.original_enable_auto_pipelining,
                 )
             };
-            self.client_mut().flags.enable_offline_queue = q;
-            self.client_mut().flags.enable_auto_pipelining = p;
+            self.with_client(|c| c.flags.enable_offline_queue = q);
+            self.with_client(|c| c.flags.enable_auto_pipelining = p);
             self._subscription_ctx.with_mut(|s| s.is_subscriber = false);
             debug!("removeSubscription: calling updatePollRef");
             self.update_poll_ref();
@@ -927,7 +942,7 @@ impl JSValkeyClient {
         global_object: &JSGlobalObject,
         this_value: JSValue,
     ) -> JsResult<JSValue> {
-        let _guard = self.ref_guard();
+        let _guard = self.ref_scope();
 
         // If already connected, resolve immediately
         if self.client.get().status == valkey::Status::Connected {
@@ -946,12 +961,12 @@ impl JSValkeyClient {
         Js::connection_promise_set_cached(this_value, global_object, promise);
 
         // If was manually closed, reset that flag
-        self.client_mut().flags.is_manually_closed = false;
+        self.with_client(|c| c.flags.is_manually_closed = false);
         // Explicit connect() should also clear the sticky `failed` flag so the
         // client can recover after prior connection attempts exhausted retries.
         // Without this, every subsequent command rejects with "Connection has
         // failed" forever — see https://github.com/oven-sh/bun/issues/29925.
-        self.client_mut().flags.failed = false;
+        self.with_client(|c| c.flags.failed = false);
         let self_br = BackRef::new(self);
         let _update = scopeguard::guard(self_br, |p| p.update_poll_ref());
 
@@ -975,8 +990,8 @@ impl JSValkeyClient {
 
         match self.client.get().status {
             valkey::Status::Disconnected => {
-                self.client_mut().flags.is_reconnecting = true;
-                self.client_mut().retry_attempts = 0;
+                self.with_client(|c| c.flags.is_reconnecting = true);
+                self.with_client(|c| c.retry_attempts = 0);
                 self.reconnect()?;
             }
             _ => {}
@@ -1002,7 +1017,7 @@ impl JSValkeyClient {
     ) -> JsResult<JSValue> {
         // `disconnect()` -> `close()` can dispatch `on_close` synchronously,
         // which derefs. Hold a ref so `&self` stays live across the call.
-        let _guard = self.ref_guard();
+        let _guard = self.ref_scope();
 
         match self.client.get().status {
             valkey::Status::NeverConnected => return Ok(JSValue::UNDEFINED),
@@ -1011,7 +1026,7 @@ impl JSValkeyClient {
             }
             _ => {}
         }
-        self.client_mut().disconnect()?;
+        self.with_client(|c| c.disconnect())?;
         Ok(JSValue::UNDEFINED)
     }
 
@@ -1024,7 +1039,7 @@ impl JSValkeyClient {
         // `on_valkey_close` adopts none. The caller's scoped ref covers the
         // call.
         self.reconnect_timer.disarm(self);
-        self.client_mut().on_close()
+        self.with_client(|c| c.on_close())
     }
 
     // `onconnect`/`onclose` are declared with `this: true` in
@@ -1044,22 +1059,22 @@ impl JSValkeyClient {
             .arm(self, self.client.get().get_timeout_interval());
     }
 
-    pub(crate) fn on_connection_timeout(&self) -> JsResult<()> {
+    pub(crate) fn on_connection_timeout(this: ThisPtr<Self>) -> JsResult<()> {
         debug!("onConnectionTimeout");
 
-        let _guard = self.ref_guard();
-        let _timer_ref = self.timer.take_fire_ref();
-        if self.client.get().flags.failed {
+        let _guard = RefPtr::from_this(this);
+        let _timer_ref = this.timer.take_fire_ref();
+        if this.client.get().flags.failed {
             return Ok(());
         }
 
-        if self.client.get().get_timeout_interval() == 0 {
-            self.reset_connection_timeout();
+        if this.client.get().get_timeout_interval() == 0 {
+            this.reset_connection_timeout();
             return Ok(());
         }
 
         let mut buf = [0u8; 128];
-        match self.client.get().status {
+        match this.client.get().status {
             valkey::Status::Connected => {
                 use std::io::Write;
                 let mut cur = &mut buf[..];
@@ -1067,12 +1082,12 @@ impl JSValkeyClient {
                 write!(
                     &mut cur,
                     "Idle timeout reached after {}ms",
-                    self.client.get().idle_timeout_interval_ms
+                    this.client.get().idle_timeout_interval_ms
                 )
                 .expect("unreachable");
                 let len = start - cur.len();
                 let msg = &buf[..len];
-                self.client_fail(msg, protocol::RedisError::IdleTimeout)
+                this.client_fail(msg, protocol::RedisError::IdleTimeout)
             }
             valkey::Status::NeverConnected
             | valkey::Status::Disconnected
@@ -1083,12 +1098,12 @@ impl JSValkeyClient {
                 write!(
                     &mut cur,
                     "Connection timeout reached after {}ms",
-                    self.client.get().connection_timeout_ms
+                    this.client.get().connection_timeout_ms
                 )
                 .expect("unreachable");
                 let len = start - cur.len();
                 let msg = &buf[..len];
-                self.client_fail(msg, protocol::RedisError::ConnectionTimeout)
+                this.client_fail(msg, protocol::RedisError::ConnectionTimeout)
             }
         }
     }
@@ -1107,30 +1122,31 @@ impl JSValkeyClient {
     /// marks the close as manual for the task to honour. `update_poll_ref`
     /// keeps the wrapper and the event loop alive for it like a dial would.
     fn close_without_socket_next_tick(&self) {
-        self.client_mut().status = valkey::Status::Connecting;
+        self.with_client(|c| c.status = valkey::Status::Connecting);
         self.update_poll_ref();
         self.enqueue_deferred_close(DeferredClose::WithoutSocket);
     }
 
     fn enqueue_deferred_close(&self, what: DeferredClose) {
-        let task = jsc::Task::from_boxed(Box::new(ValkeyDeferredClose {
-            ctx: self.ref_guard(),
+        // The task's ref is released by the task, whether it runs or the VM
+        // tears down first (`RunOnce::cancelled`).
+        let task = Box::new(ValkeyDeferredClose {
+            ctx: RefPtr::from_this(self.this_ptr()),
             what,
-        }));
-        // SAFETY: VM-owned event loop pointer; uniquely accessed on the JS thread.
-        unsafe {
-            (*self.vm().event_loop()).enqueue_task(task);
-        }
+        });
+        self.vm()
+            .event_loop_mut()
+            .enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new_boxed(task));
     }
 
-    pub(crate) fn on_reconnect_timer(&self) -> JsResult<()> {
+    pub(crate) fn on_reconnect_timer(this: ThisPtr<Self>) -> JsResult<()> {
         debug!("Reconnect timer fired, attempting to reconnect");
 
-        let _guard = self.ref_guard();
-        let _timer_ref = self.reconnect_timer.take_fire_ref();
+        let _guard = RefPtr::from_this(this);
+        let _timer_ref = this.reconnect_timer.take_fire_ref();
 
         // Execute reconnection logic
-        self.reconnect()
+        this.reconnect()
     }
 
     pub(crate) fn reconnect(&self) -> JsResult<()> {
@@ -1156,7 +1172,7 @@ impl JSValkeyClient {
         }
 
         // Ref to keep this alive during the reconnection
-        let _guard = self.ref_guard();
+        let _guard = self.ref_scope();
 
         // Ref the poll to keep event loop alive during connection
         self.poll_ref.with_mut(|r| {
@@ -1189,14 +1205,9 @@ impl JSValkeyClient {
         // Now counting idle time, not connect time.
         self.reset_connection_timeout();
 
-        let self_ptr = self.as_ctx_ptr();
-        let _defer = scopeguard::guard(self_ptr, |p| {
-            // SAFETY: `p` was `self.as_ctx_ptr()` at guard creation; the caller
-            // holds an intrusive ref across this scope so `*p` is live here.
-            unsafe {
-                (*p).client_mut().on_writable();
-                (*p).update_poll_ref();
-            }
+        let _defer = scopeguard::guard(BackRef::new(self), |p| {
+            p.with_client(|c| c.on_writable());
+            p.update_poll_ref();
         });
         let global_object = self.global_object;
         let _exit = self.vm().enter_event_loop_scope();
@@ -1211,8 +1222,7 @@ impl JSValkeyClient {
                 Err(err) if global_object.has_pending_termination_exception() => return Err(err),
                 Err(err) => {
                     let error = global_object.take_exception(err);
-                    let client = self.client_mut();
-                    client.flags.connection_promise_returns_client = false;
+                    self.with_client(|c| c.flags.connection_promise_returns_client = false);
                     let rejected = match Js::connection_promise_get_cached(this_value) {
                         Some(promise) => {
                             Js::connection_promise_set_cached(
@@ -1228,12 +1238,12 @@ impl JSValkeyClient {
                     // `fail_with_js_value` closes the socket itself; a second close here would
                     // hit whatever a connect() from `onclose` just opened.
                     return match rejected {
-                        Ok(()) => client.fail_with_js_value(&global_object, error),
-                        Err(_) => {
-                            client.flags.is_manually_closed = true;
-                            let closed = client.close(uws::CloseCode::Failure);
+                        Ok(()) => self.with_client(|c| c.fail_with_js_value(&global_object, error)),
+                        Err(_) => self.with_client(|c| {
+                            c.flags.is_manually_closed = true;
+                            let closed = c.close(uws::CloseCode::Failure);
                             rejected.and(closed)
-                        }
+                        }),
                     };
                 }
             };
@@ -1257,7 +1267,7 @@ impl JSValkeyClient {
                     debug!("Resolving connection promise with HELLO response");
                     js_promise.resolve(&global_object, hello_value)?;
                 }
-                self.client_mut().flags.connection_promise_returns_client = false;
+                self.with_client(|c| c.flags.connection_promise_returns_client = false);
             }
         }
         Ok(())
@@ -1267,9 +1277,9 @@ impl JSValkeyClient {
     ///
     /// `SubscriptionCtx` will invoke this to communicate that it has added a new listener.
     pub(crate) fn on_new_subscription_callback_insert(&self) {
-        let _guard = self.ref_guard();
+        let _guard = self.ref_scope();
 
-        self.client_mut().on_writable();
+        self.with_client(|c| c.on_writable());
         self.update_poll_ref();
     }
 
@@ -1277,11 +1287,11 @@ impl JSValkeyClient {
         debug_assert!(self.is_subscriber());
         debug_assert!(self.this_value.get().is_strong());
 
-        let _guard = self.ref_guard();
+        let _guard = self.ref_scope();
 
         let _ = value;
 
-        self.client_mut().on_writable();
+        self.with_client(|c| c.on_writable());
         self.update_poll_ref();
     }
 
@@ -1289,7 +1299,7 @@ impl JSValkeyClient {
         debug_assert!(self.is_subscriber());
         debug_assert!(self.this_value.get().is_strong());
 
-        self.client_mut().on_writable();
+        self.with_client(|c| c.on_writable());
         self.update_poll_ref();
         Ok(())
     }
@@ -1333,7 +1343,7 @@ impl JSValkeyClient {
             return;
         }
 
-        self.client_mut().on_writable();
+        self.with_client(|c| c.on_writable());
         self.update_poll_ref();
     }
 
@@ -1395,7 +1405,7 @@ impl JSValkeyClient {
     // Callback for when Valkey client times out
 
     pub(crate) fn client_fail(&self, message: &[u8], err: protocol::RedisError) -> JsResult<()> {
-        self.client_mut().fail(message, err)
+        self.with_client(|c| c.fail(message, err))
     }
 
     fn close_socket_next_tick(&self) {
@@ -1407,10 +1417,12 @@ impl JSValkeyClient {
         self.enqueue_deferred_close(DeferredClose::Socket);
     }
 
+    /// Runs before the JS wrapper's ref is dropped; the allocation may
+    /// outlive this call if other refs remain.
     pub fn finalize(&self) {
         self.stop_timers();
         self.this_value.with_mut(|t| t.finalize());
-        self.client_mut().flags.finalized = true;
+        self.with_client(|c| c.flags.finalized = true);
         self.close_socket_next_tick();
         // `_subscription_ctx` is three inline bools (no allocation, no GC
         // ref); `is_subscriber` can legitimately still be set here if the
@@ -1429,19 +1441,13 @@ impl JSValkeyClient {
         // this client alongside the new one's.
         debug_assert!(self.client.get().socket.is_closed());
         if self.client.get().status == valkey::Status::NeverConnected {
-            self.client_mut().status = valkey::Status::Disconnected;
+            self.with_client(|c| c.status = valkey::Status::Disconnected);
         }
 
-        let _guard = self.ref_guard();
+        let _guard = self.ref_scope();
 
         let is_tls = self.client.get().tls != valkey::TLS::None;
-        let vm = self.client.get().vm.as_mut();
-        let loop_ = vm.uws_loop();
-        let group: *mut uws::SocketGroup = if is_tls {
-            vm.rare_data().valkey_group::<true>(loop_)
-        } else {
-            vm.rare_data().valkey_group::<false>(loop_)
-        };
+        let vm = self.client.get().vm;
 
         // Populate `_secure` first, then handle the failure branch outside the
         // borrow of `self.client.tls`.
@@ -1463,7 +1469,7 @@ impl JSValkeyClient {
             false
         };
         if tls_ctx_failed {
-            self.client_mut().flags.enable_auto_reconnect = false;
+            self.with_client(|c| c.flags.enable_auto_reconnect = false);
             self.client_fail(
                 b"Failed to create TLS context",
                 protocol::RedisError::ConnectionClosed,
@@ -1474,43 +1480,47 @@ impl JSValkeyClient {
         let ssl_ctx: Option<*mut uws::SslCtx> = match &self.client.get().tls {
             valkey::TLS::None => None,
             valkey::TLS::Enabled => Some(crate::jsc_hooks::default_client_ssl_ctx(vm)),
-            valkey::TLS::Custom(_) => Some(self._secure.get().as_ref().unwrap().as_ptr()),
+            valkey::TLS::Custom(_) => Some(self._secure.get().as_ref().unwrap().as_ptr().cast()),
+        };
+        let vm = vm.as_mut();
+        let loop_ = vm.uws_loop();
+        let group: &mut uws::SocketGroup = if is_tls {
+            vm.rare_data().valkey_group::<true>(loop_)
+        } else {
+            vm.rare_data().valkey_group::<false>(loop_)
         };
 
-        self.client_mut().status = valkey::Status::Connecting;
+        self.with_client(|c| c.status = valkey::Status::Connecting);
         self.update_poll_ref();
         let errdefer_status = scopeguard::guard(BackRef::new(self), |p| {
-            p.client_mut().status = valkey::Status::Disconnected;
+            p.with_client(|c| c.status = valkey::Status::Disconnected);
             p.update_poll_ref();
         });
-        // The socket ext slot is typed `ExtSlot<JSValkeyClient>`
+        // The socket ext slot is typed `Option<ThisPtr<JSValkeyClient>>`
         // (uws_handlers.rs `Valkey<SSL> = NsHandler<JSValkeyClient, …>`); store
         // the OUTER pointer, not the inner `ValkeyClient`, or dispatch will
-        // mis-type and re-offset it (`on_open` → `this.client_mut()` adds
+        // mis-type and re-offset it (`on_open` → `this.client` adds
         // `offsetof(JSValkeyClient, client)` again → garbage `&mut ValkeyClient`).
-        // Reshaped for borrowck — `address` is a field of `client`; go through a
-        // raw pointer. `Address::connect` only reads host/path bytes and forwards
-        // `owner_ptr` opaquely (no overlapping write).
-        let owner_ptr: *mut JSValkeyClient = std::ptr::from_ref::<JSValkeyClient>(self).cast_mut();
-        let client_ptr: *mut valkey::ValkeyClient = self.client.as_ptr();
-        // Socket keep-alive ref. Forgotten once there is a socket to own it;
-        // adopted by the guard at the entry of the socket's close event
+        let this = self.this_ptr();
+        // Socket keep-alive ref. Held in `socket_ref` for the socket about to
+        // own it; released at the entry of that socket's close event
         // (`SocketHandler::on_close`, `SocketHandler::on_connect_error`, or
         // `ValkeyClient::close()` for a half-open socket), which is the one
-        // event uSockets delivers for every socket this returns.
-        let socket_ref = self.ref_guard();
-        // SAFETY: `client_ptr` is live; `group` is the lazy-initialised per-VM
-        // `SocketGroup` (stable for the VM's lifetime). `ssl_ctx` is a +1-ref
-        // BoringSSL `SSL_CTX*` (or None) forwarded opaquely to usockets.
-        let socket = unsafe {
-            (*client_ptr)
-                .address
-                .connect(owner_ptr, &mut *group, ssl_ctx, is_tls)
-        }?;
-        self.client_mut().socket = socket;
+        // event uSockets delivers for every socket this returns — or right
+        // here if no socket was opened.
+        let prev = self.socket_ref.replace(Some(RefPtr::from_this(this)));
+        debug_assert!(prev.is_none(), "valkey socket_ref already held");
+        let socket =
+            match self.with_client(|c| c.address.connect(this.as_ptr(), group, ssl_ctx, is_tls)) {
+                Ok(socket) => socket,
+                Err(err) => {
+                    drop(self.socket_ref.take());
+                    return Err(err);
+                }
+            };
+        self.with_client(|c| c.socket = socket);
         // Disarm on success: the socket now owns the keep-alive ref.
         scopeguard::ScopeGuard::into_inner(errdefer_status);
-        let _ = socket_ref.into_raw();
         Ok(())
     }
 
@@ -1522,13 +1532,13 @@ impl JSValkeyClient {
     ) -> Result<*mut JSPromise, crate::Error> {
         // Keep `*self` alive across re-entrant connect/close paths below;
         // the host-fn shim passes a bare `&self` with no ref of its own.
-        let _guard = self.ref_guard();
+        let _guard = self.ref_scope();
 
         self.ensure_dialing();
 
         let self_br = BackRef::new(self);
         let _update = scopeguard::guard(self_br, |p| p.update_poll_ref());
-        self.client_mut().send(global_this, command)
+        self.with_client(|c| c.send(global_this, command))
     }
 
     /// Start the first dial if the client has never connected. Every command
@@ -1635,11 +1645,37 @@ impl JSValkeyClient {
     }
 }
 
+/// Runs when the last ref is released (`RefCounted` reclaims the box).
+impl Drop for JSValkeyClient {
+    fn drop(&mut self) {
+        // No refs remain; nothing below may mint one.
+        self.this_ptr.set(None);
+        debug_assert!(self.client.get().socket.is_closed());
+        debug_assert!(!self.timer.is_held());
+        debug_assert!(!self.reconnect_timer.is_held());
+        // Releases our `SSL_CTX` ref.
+        self._secure.set(None);
+        self.with_client(|c| c.shutdown(None));
+        self.poll_ref.with_mut(|r| r.disable());
+        self.stop_timers();
+        self.ref_count.assert_no_refs();
+    }
+}
+
 // The ~160 command host-fns are inherent
 // methods on `JSValkeyClient` via the `impl JSValkeyClient` block in
 // `js_valkey_functions.rs`, so no re-export is needed (and `pub use` of impl
 // methods is not legal Rust). Keep `fns` referenced so the sibling module is
 // linked into the build.
+
+impl jsc::AutoFlushTarget for JSValkeyClient {
+    fn auto_flusher(&self) -> &jsc::AutoFlusher<Self> {
+        &self.auto_flusher
+    }
+    fn on_auto_flush(this: ThisPtr<Self>) -> bool {
+        this.with_client(|c| c.on_auto_flush())
+    }
+}
 
 // ───────────────────────────────────────────────────────────────────────────
 // SocketHandler
@@ -1664,13 +1700,15 @@ impl<const SSL: bool> SocketHandler<SSL> {
         }
     }
 
-    pub(crate) fn on_open(this: &JSValkeyClient, socket: SocketType<SSL>) -> JsResult<()> {
-        this.client_mut().socket = Self::socket(socket);
-        this.client_mut().on_open(Self::socket(socket))
+    pub(crate) fn on_open(this: ThisPtr<JSValkeyClient>, socket: SocketType<SSL>) -> JsResult<()> {
+        this.with_client(|c| {
+            c.socket = Self::socket(socket);
+            c.on_open(Self::socket(socket))
+        })
     }
 
     pub(crate) fn on_handshake(
-        this: &JSValkeyClient,
+        this: ThisPtr<JSValkeyClient>,
         _socket: SocketType<SSL>,
         success: i32,
         ssl_error: uws::us_bun_verify_error_t,
@@ -1691,8 +1729,8 @@ impl<const SSL: bool> SocketHandler<SSL> {
             ),
         );
         let handshake_success = success == 1;
-        let _guard = this.ref_guard();
-        let _update = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
+        let _guard = RefPtr::from_this(this);
+        let _update = scopeguard::guard(this, |p| p.update_poll_ref());
         let vm = this.client.get().vm;
         if handshake_success {
             if this.client.get().tls.reject_unauthorized(vm) {
@@ -1707,19 +1745,11 @@ impl<const SSL: bool> SocketHandler<SSL> {
                 // fall back to the host from the connection URL. Unix-domain
                 // sockets have no hostname to verify, so skip the identity check
                 // for redis+tls+unix:// / valkey+tls+unix:// connections.
-                let ssl_ptr: *mut boringssl::c::SSL = this
-                    .client
-                    .get()
-                    .socket
-                    .get_native_handle()
-                    .unwrap_or(core::ptr::null_mut())
-                    .cast();
-                // SAFETY: SSL_get_servername returns null or NUL-terminated.
-                let mut hostname: &[u8] = if let Some(servername) =
-                    unsafe { boringssl::c::SSL_get_servername(ssl_ptr, 0).as_ref() }
-                {
-                    // SAFETY: NUL-terminated
-                    unsafe { bun_core::ffi::cstr(std::ptr::from_ref(servername).cast()) }.to_bytes()
+                let socket = this.client.get().socket;
+                let ssl = socket.ssl_mut();
+                let servername = ssl.as_deref().and_then(|ssl| ssl.servername());
+                let mut hostname: &[u8] = if let Some(servername) = servername {
+                    servername
                 } else {
                     match &this.client.get().address {
                         valkey::Address::Host { host, .. } => &host[..],
@@ -1737,9 +1767,9 @@ impl<const SSL: bool> SocketHandler<SSL> {
                     hostname = &hostname[1..hostname.len() - 1];
                 }
                 if !hostname.is_empty()
-                    // SAFETY: in the TLS handshake-success path the socket's native
-                    // handle is a live `SSL*`.
-                    && !boringssl::check_server_identity(unsafe { &mut *ssl_ptr }, hostname)
+                    && !socket
+                        .ssl_mut()
+                        .is_some_and(|ssl| boringssl::check_server_identity(ssl, hostname))
                 {
                     let err = this
                         .global_object
@@ -1754,7 +1784,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
                     return Self::fail_handshake(this, vm, err);
                 }
             }
-            this.client_mut().start()?;
+            this.with_client(|c| c.start())?;
         } else {
             // if we are here is because the server rejected us, and the error_no is the cause of
             // this no matter if reject_unauthorized is false, because we were disconnected by the
@@ -1765,7 +1795,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     fn fail_handshake_with_verify_error(
-        this: &JSValkeyClient,
+        this: ThisPtr<JSValkeyClient>,
         vm: &VirtualMachine,
         ssl_error: &uws::us_bun_verify_error_t,
     ) -> JsResult<()> {
@@ -1775,42 +1805,49 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     fn fail_handshake(
-        this: &JSValkeyClient,
+        this: ThisPtr<JSValkeyClient>,
         _vm: &VirtualMachine,
         err_value: JSValue,
     ) -> JsResult<()> {
         let _exit = this.vm().enter_event_loop_scope();
-        this.client_mut()
-            .fail_with_js_value(&this.global_object, err_value)
+        let global = this.global_object;
+        this.with_client(|c| c.fail_with_js_value(&global, err_value))
     }
 
     pub(crate) const ON_HANDSHAKE: Option<
-        fn(&JSValkeyClient, SocketType<SSL>, i32, uws::us_bun_verify_error_t) -> JsResult<()>,
+        fn(
+            ThisPtr<JSValkeyClient>,
+            SocketType<SSL>,
+            i32,
+            uws::us_bun_verify_error_t,
+        ) -> JsResult<()>,
     > = if SSL { Some(Self::on_handshake) } else { None };
 
     pub fn on_close(
-        this: &JSValkeyClient,
+        this: ThisPtr<JSValkeyClient>,
         _socket: SocketType<SSL>,
         _code: i32,
         _reason: Option<*mut c_void>,
     ) -> JsResult<()> {
         debug!("Socket closed.");
-        let _guard = this.ref_guard();
-        // SAFETY: takes over the keep-alive ref `connect()` handed to this
-        // socket; this is its one close event. Released after `_defer` runs,
-        // while `_guard` still holds the client.
-        let _socket_ref = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
+        let _guard = RefPtr::from_this(this);
+        // The keep-alive ref `connect()` took for this socket; this is its one
+        // close event. Released after `_defer` runs, while `_guard` still
+        // holds the client.
+        let _socket_ref = this.socket_ref.take();
         // Ensure the socket pointer is updated.
-        this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
-        // Before `on_close()`: it runs `onclose` and settles the connect()
-        // promise, and a connect() called from either must see Disconnected.
-        this.client_mut().status = valkey::Status::Disconnected;
-        let _defer = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
+        this.with_client(|c| {
+            c.socket = Socket::SocketTcp(uws::SocketTCP::detached());
+            // Before `on_close()`: it runs `onclose` and settles the connect()
+            // promise, and a connect() called from either must see Disconnected.
+            c.status = valkey::Status::Disconnected;
+        });
+        let _defer = scopeguard::guard(this, |p| p.update_poll_ref());
 
-        this.client_mut().on_close()
+        this.with_client(|c| c.on_close())
     }
 
-    pub(crate) fn on_end(this: &JSValkeyClient, socket: SocketType<SSL>) {
+    pub(crate) fn on_end(this: ThisPtr<JSValkeyClient>, socket: SocketType<SSL>) {
         let _ = this;
         let _ = socket;
 
@@ -1820,38 +1857,38 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     pub(crate) fn on_connect_error(
-        this: &JSValkeyClient,
+        this: ThisPtr<JSValkeyClient>,
         _socket: SocketType<SSL>,
         _code: i32,
     ) -> JsResult<()> {
         // Ensure the socket pointer is updated.
-        this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
-        let _guard = this.ref_guard();
-        // SAFETY: as in `on_close`; a dial that fails gets this event instead.
-        let _socket_ref = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
-        this.client_mut().status = valkey::Status::Disconnected;
-        let _defer = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
+        this.with_client(|c| c.socket = Socket::SocketTcp(uws::SocketTCP::detached()));
+        let _guard = RefPtr::from_this(this);
+        // As in `on_close`; a dial that fails gets this event instead.
+        let _socket_ref = this.socket_ref.take();
+        this.with_client(|c| c.status = valkey::Status::Disconnected);
+        let _defer = scopeguard::guard(this, |p| p.update_poll_ref());
 
-        this.client_mut().on_close()
+        this.with_client(|c| c.on_close())
     }
 
-    pub(crate) fn on_timeout(this: &JSValkeyClient, socket: SocketType<SSL>) {
+    pub(crate) fn on_timeout(this: ThisPtr<JSValkeyClient>, socket: SocketType<SSL>) {
         debug!("Socket timed out.");
 
-        this.client_mut().socket = Self::socket(socket);
+        this.with_client(|c| c.socket = Self::socket(socket));
         // Handle socket timeout
     }
 
     pub(crate) fn on_data(
-        this: &JSValkeyClient,
+        this: ThisPtr<JSValkeyClient>,
         socket: SocketType<SSL>,
         data: &[u8],
     ) -> JsResult<()> {
         // Ensure the socket pointer is updated.
-        this.client_mut().socket = Self::socket(socket);
+        this.with_client(|c| c.socket = Self::socket(socket));
 
-        let _guard = this.ref_guard();
-        let result = this.client_mut().on_data(data);
+        let _guard = RefPtr::from_this(this);
+        let result = this.with_client(|c| c.on_data(data));
         if this.client.get().status == valkey::Status::Connected {
             this.reset_connection_timeout();
         }
@@ -1859,10 +1896,10 @@ impl<const SSL: bool> SocketHandler<SSL> {
         result
     }
 
-    pub(crate) fn on_writable(this: &JSValkeyClient, socket: SocketType<SSL>) {
-        this.client_mut().socket = Self::socket(socket);
-        let _guard = this.ref_guard();
-        this.client_mut().on_writable();
+    pub(crate) fn on_writable(this: ThisPtr<JSValkeyClient>, socket: SocketType<SSL>) {
+        this.with_client(|c| c.socket = Self::socket(socket));
+        let _guard = RefPtr::from_this(this);
+        this.with_client(|c| c.on_writable());
         this.update_poll_ref();
     }
 }
@@ -1959,46 +1996,42 @@ enum DeferredClose {
 }
 
 pub(crate) struct ValkeyDeferredClose {
-    /// Keeps the client alive until the task runs or is released.
+    /// Keeps the client alive until the task runs or is released unrun.
     ctx: RefPtr<JSValkeyClient>,
     what: DeferredClose,
 }
 
-impl ValkeyDeferredClose {
-    #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
-    pub(crate) fn run(self: Box<Self>) {
-        let this: &JSValkeyClient = &self.ctx;
+impl bun_event_loop::ManagedTask::RunOnce for ValkeyDeferredClose {
+    fn run(self) -> JsResult<()> {
+        let this = self.ctx.this_ptr();
+        // Released when this scope ends.
+        let _enqueue_ref = self.ctx;
         match self.what {
-            DeferredClose::Socket => {
-                crate::dispatch::fold(this.client_mut().close(uws::CloseCode::FastShutdown))
-            }
+            DeferredClose::Socket => this.with_client(|c| c.close(uws::CloseCode::FastShutdown)),
             DeferredClose::WithoutSocket => {
                 // Holding Connecting (see `close_without_socket_next_tick`)
                 // and the gate in `reconnect()` keep every dial entry out.
                 debug_assert!(this.client.get().socket.is_closed());
-                // No socket ref to give back: `connect()` forgets it only once
+                // No socket ref to give back: `connect()` keeps it only once
                 // it has a socket, and this task exists because it never did.
-                this.client_mut().status = valkey::Status::Disconnected;
-                let closed = this.client_mut().on_close();
+                this.with_client(|c| c.status = valkey::Status::Disconnected);
+                let closed = this.with_client(|c| c.on_close());
                 this.update_poll_ref();
-                crate::dispatch::fold(closed);
+                closed
             }
         }
     }
-}
 
-impl bun_event_loop::Taskable for ValkeyDeferredClose {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ValkeyDeferredClose;
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — boxed at the enqueue site.
-        let task = unsafe { bun_core::heap::take(this) };
-        match task.what {
+    /// The VM is going away and the queued task will never run.
+    fn cancelled(self) {
+        match self.what {
             // Script-free bookkeeping; do it.
-            DeferredClose::Socket => task.run(),
-            // The VM is going away: `on_close()` would run `onclose`, so only
-            // give back what `close_without_socket_next_tick` took.
+            DeferredClose::Socket => crate::dispatch::fold(self.run()),
+            // `on_close()` would run `onclose`, so only give back what
+            // `close_without_socket_next_tick` took.
             DeferredClose::WithoutSocket => {
-                task.ctx.poll_ref.with_mut(|r| r.disable());
+                self.ctx.poll_ref.with_mut(|r| r.disable());
+                drop(self.ctx);
             }
         }
     }

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -10,15 +10,14 @@ use super::protocol_jsc as protocol;
 use super::valkey;
 use super::valkey_command_body::{Args as CommandArgs, Command, Meta as CommandMeta};
 
-/// Reinterpret an ASCII byte-string literal as `&str` for the
+/// An ASCII byte-string literal as `&str` for the
 /// `throw_invalid_argument_type` family (which take `&'static str`).
-/// SAFETY: every command/method name passed to the `cmd_*!` macros is a
-/// static ASCII byte-string literal, so it is always valid UTF-8.
 #[inline(always)]
 const fn bname(b: &'static [u8]) -> &'static str {
-    // SAFETY: every caller passes a `b"..."` ASCII literal (command/method
-    // names from the `cmd_*!` macros), which is guaranteed valid UTF-8.
-    unsafe { core::str::from_utf8_unchecked(b) }
+    match core::str::from_utf8(b) {
+        Ok(s) => s,
+        Err(_) => panic!("command names are ASCII literals"),
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1824,7 +1823,7 @@ impl JSValkeyClient {
         // `upsert_receive_handler`'s exit guard re-enters `on_writable` /
         // `update_poll_ref` before `send()` is reached; hold a ref so `*this`
         // stays live across those calls.
-        let _guard = this.ref_guard();
+        let _guard = this.ref_scope();
 
         let [channel_or_many, handler_callback] = frame.arguments_as_array::<2>();
         let mut redis_channels: Vec<JSArgument> = Vec::with_capacity(1);
@@ -1937,7 +1936,7 @@ impl JSValkeyClient {
     ) -> JsResult<JSValue> {
         // Hold a ref so `*this` stays live across the handler-map updates and
         // the `send()` below.
-        let _guard = this.ref_guard();
+        let _guard = this.ref_scope();
 
         // Check if we're in subscription mode
         require_subscriber(this, b"unsubscribe")?;
@@ -2081,11 +2080,9 @@ impl JSValkeyClient {
         let _ = frame;
 
         let new_client_ptr = this.clone_without_connecting(global)?;
-        // SAFETY: clone_without_connecting returns a freshly allocated, leaked
-        // JSValkeyClient (heap::alloc); valid for the rest of this scope.
-        let new_client: &JSValkeyClient = unsafe { &*new_client_ptr };
+        let new_client: &JSValkeyClient = &new_client_ptr;
 
-        let new_client_js = JSValkeyClient::ptr_to_js(new_client_ptr, global);
+        let new_client_js = JSValkeyClient::ptr_to_js(new_client_ptr.as_ptr(), global);
         new_client.this_value.set(JsRef::init_weak(new_client_js));
         new_client
             ._subscription_ctx
@@ -2095,10 +2092,7 @@ impl JSValkeyClient {
             && !this.client.get().flags.is_manually_closed
         {
             // Use strong reference during connection to prevent premature GC
-            new_client
-                .client_mut()
-                .flags
-                .connection_promise_returns_client = true;
+            new_client.with_client(|c| c.flags.connection_promise_returns_client = true);
             return new_client.do_connect(global, new_client_js);
         }
 

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -7,7 +7,6 @@ use bun_collections::OffsetByteList;
 use bun_core::UnwrapOrOom;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{GlobalRef, JSGlobalObject, JSPromise, JSValue, JsResult};
-use bun_ptr::RefPtr;
 use bun_uws::{self as uws, AnySocket, SocketGroup, SocketKind, SslCtx};
 use bun_valkey::valkey_protocol as protocol;
 use bun_valkey::valkey_protocol::{RESPValue, RedisError};
@@ -276,8 +275,6 @@ pub struct ValkeyClient {
     pub(crate) flags: ConnectionFlags,
 
     // Auto-pipelining
-    pub(crate) auto_flusher: AutoFlusher,
-
     pub(crate) vm: &'static VirtualMachine,
 }
 
@@ -295,7 +292,7 @@ struct DeferredFailure {
     queue: command::entry::Queue,
 }
 
-impl DeferredFailure {
+impl bun_event_loop::ManagedTask::RunOnce for DeferredFailure {
     fn run(self) -> JsResult<()> {
         debug!("running deferred failure");
         let mut this = self;
@@ -307,20 +304,14 @@ impl DeferredFailure {
             err,
         )
     }
+}
 
+impl DeferredFailure {
     fn enqueue(self: Box<Self>) {
         debug!("enqueueing deferred failure");
-        // The Box is leaked into a raw pointer here and reconstituted inside the trampoline.
-        fn run_raw(ptr: *mut DeferredFailure) -> bun_event_loop::JsResult<()> {
-            // SAFETY: `ptr` was produced by `heap::alloc` below; we are the sole owner.
-            let this = unsafe { bun_core::heap::take(ptr) };
-            DeferredFailure::run(*this)
-        }
-        let managed_task =
-            bun_jsc::ManagedTask::ManagedTask::new(bun_core::heap::into_raw(self), run_raw);
         VirtualMachine::get()
             .event_loop_mut()
-            .enqueue_task(managed_task);
+            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new_boxed(self));
     }
 }
 
@@ -333,7 +324,7 @@ fn reader_pos(reader: &protocol::ValkeyReader<'_>) -> usize {
 // SAFETY: `ValkeyClient` lives at `JSValkeyClient.client` (intrusive embed).
 // `JsCell<ValkeyClient>` is `#[repr(transparent)]`, so the field offset is
 // unchanged. Every `JSValkeyClient` method this reaches is `&self`.
-bun_core::impl_field_parent! { ValkeyClient => JSValkeyClient.client; fn parent; fn mut parent_ptr; }
+bun_core::impl_field_parent! { ValkeyClient => JSValkeyClient.client; fn parent; }
 
 impl ValkeyClient {
     /// Clean up resources used by the Valkey client
@@ -366,28 +357,23 @@ impl ValkeyClient {
 
     // ** Auto-pipelining **
     fn register_auto_flusher(&mut self, vm: &VirtualMachine) {
-        if !self.auto_flusher.registered.get() {
-            AutoFlusher::register_deferred_microtask_with_type_unchecked::<Self>(self, vm);
-            self.auto_flusher.registered.set(true);
-        }
+        bun_jsc::AutoFlusher::register(self.parent().this_ptr(), vm);
     }
 
     fn unregister_auto_flusher(&mut self) {
-        if self.auto_flusher.registered.get() {
-            AutoFlusher::unregister_deferred_microtask_with_type::<Self>(self, self.vm);
-            self.auto_flusher.registered.set(false);
-        }
+        let vm = self.vm;
+        self.parent().auto_flusher.unregister(vm);
     }
 
-    // Drain auto-pipelined commands
+    // Drain auto-pipelined commands. The return value is whether to stay
+    // registered for the next drain.
     pub(crate) fn on_auto_flush(&mut self) -> bool {
         // Don't process if not connected or already processing
         if self.status != Status::Connected {
-            self.auto_flusher.registered.set(false);
             return false;
         }
 
-        let _guard = self.parent().ref_guard();
+        let _guard = self.parent().ref_scope();
 
         // Start draining the command queue
         let mut total_bytelength: usize = 0;
@@ -426,11 +412,8 @@ impl ValkeyClient {
 
         let _ = self.flush_data();
 
-        let have_more = !self.queue.is_empty();
-        self.auto_flusher.registered.set(have_more);
-
         // Return true if we should schedule another flush
-        have_more
+        !self.queue.is_empty()
     }
     // ** End of auto-pipelining **
 
@@ -647,11 +630,11 @@ impl ValkeyClient {
         if !is_semi_socket {
             return thrown;
         }
-        // SAFETY: takes over the keep-alive ref `connect()` handed to this
-        // socket, as `SocketHandler::on_close` does for one uSockets closes.
-        // Every caller of `close()` holds a scoped ref of its own, so the
-        // client outlives this scope.
-        let _socket_ref = unsafe { RefPtr::from_raw(self.parent_ptr()) };
+        // The keep-alive ref `connect()` took for this socket, released here
+        // as `SocketHandler::on_close` does for one uSockets closes. Every
+        // caller of `close()` holds a scoped ref of its own, so the client
+        // outlives this scope.
+        let _socket_ref = self.parent().socket_ref.take();
         self.status = Status::Disconnected;
         let closed = self.on_close();
         thrown.and(closed)
@@ -1364,7 +1347,7 @@ impl ValkeyClient {
     }
 
     pub(crate) fn on_writable(&mut self) {
-        let _guard = self.parent().ref_guard();
+        let _guard = self.parent().ref_scope();
         self.send_next_command();
     }
 
@@ -1544,22 +1527,6 @@ impl ValkeyClient {
 
     pub(crate) fn on_valkey_close(&mut self) -> JsResult<()> {
         self.parent().on_valkey_close()
-    }
-}
-
-// Auto-pipelining
-use crate::webcore::{AutoFlusher, HasAutoFlusher};
-
-impl HasAutoFlusher for ValkeyClient {
-    #[inline]
-    fn auto_flusher(&self) -> &AutoFlusher {
-        &self.auto_flusher
-    }
-    unsafe fn on_auto_flush(this: *mut Self) -> bool {
-        // SAFETY: `this` was registered as `&ValkeyClient` cast to `*mut c_void`;
-        // `DeferredTaskQueue::run` is single-threaded (drained on the JS thread after
-        // microtasks), so no aliasing across the call.
-        unsafe { (*this).on_auto_flush() }
     }
 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -387,28 +387,6 @@ pub trait BlobExt {
     fn is_all_ascii(&self) -> Option<bool>;
 }
 
-/// C-ABI trampoline for `Blob::shared_view` so C++ (`ZigGeneratedClasses`)
-/// can read blob bytes.
-///
-/// # Safety
-/// `this` must be a live `*const Blob` (the codegen `m_ctx` payload obtained
-/// via `Blob__fromJS`), valid for shared read for the duration of the call.
-/// `len` must be a writable `usize` out-param (caller stack slot). Kept as a
-/// raw-pointer ABI (not `&Blob`/`&mut usize`) because the sole Rust caller is
-/// the type-erased `SqlRuntimeHooks` vtable in `hw_exports.rs`, which forwards
-/// `*const c_void` without materialising a reference.
-#[unsafe(no_mangle)]
-pub(crate) unsafe extern "C" fn Bun__Blob__sharedView(
-    this: *const Blob,
-    len: *mut usize,
-) -> *const u8 {
-    // SAFETY: preconditions documented on the fn item above.
-    let view = unsafe { (*this).shared_view() };
-    // SAFETY: `len` is a valid writable out-param per the fn safety contract.
-    unsafe { *len = view.len() };
-    view.as_ptr()
-}
-
 #[allow(non_snake_case, clippy::too_many_arguments)]
 impl BlobExt for Blob {
     fn get_form_data_encoding(&self) -> Option<Box<bun_core::form_data::AsyncFormData>> {

--- a/src/sha_hmac/sha.rs
+++ b/src/sha_hmac/sha.rs
@@ -130,6 +130,12 @@ macro_rules! new_evp {
                 this
             }
 
+            /// One-shot digest with BoringSSL's built-in implementation.
+            pub fn digest(bytes: &[u8], out: &mut [u8; $digest_size]) {
+                // SAFETY: a null `ENGINE*` selects the default implementation.
+                unsafe { Self::hash(bytes, out, ptr::null_mut()) }
+            }
+
             /// # Safety
             /// `engine` must be null (default engine) or a live `ENGINE*`.
             pub unsafe fn hash(

--- a/src/sql_jsc/Cargo.toml
+++ b/src/sql_jsc/Cargo.toml
@@ -25,6 +25,7 @@ bun_boringssl_sys.workspace = true
 bun_core.workspace = true
 bun_collections.workspace = true
 bun_event_loop.workspace = true
+bun_http.workspace = true
 bun_jsc.workspace = true
 bun_ptr.workspace = true
 bun_sha_hmac.workspace = true

--- a/src/sql_jsc/jsc.rs
+++ b/src/sql_jsc/jsc.rs
@@ -6,7 +6,7 @@
 //! `bun_io`** so the `#[bun_jsc::JsClass]` / `#[bun_jsc::host_fn]` proc-macros
 //! see identical types. SQL-specific helpers that `bun_jsc` doesn't expose at
 //! this tier are provided as extension traits ([`JSGlobalObjectSqlExt`],
-//! [`VirtualMachineSqlExt`], [`EventLoopSqlExt`]).
+//! [`VirtualMachineSqlExt`]).
 //!
 //! [`RareData`] here is the **per-VM SQL state** (`mysql_context` /
 //! `postgresql_context`) that `bun_runtime::jsc_hooks::RuntimeState` owns by
@@ -16,9 +16,7 @@
 
 #![warn(unused_must_use)]
 
-use core::ffi::{c_char, c_void};
 use core::marker::PhantomData;
-use core::ptr::NonNull;
 
 // ──────────────────────────────────────────────────────────────────────────
 // Core handles — re-exported from `bun_jsc` so proc-macro generated wrappers
@@ -87,20 +85,9 @@ pub use bun_jsc::system_error::verify_error_to_js;
 /// code `BORINGSSL`. Body mirrors `bun_runtime::crypto::boringssl_jsc::err_to_js`
 /// (unreachable from here without a cycle).
 fn boringssl_err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
-    const PREFIX: &[u8] = b"BoringSSL ";
-    let mut outbuf = [0u8; 128 + 1 + PREFIX.len()];
-    outbuf[..PREFIX.len()].copy_from_slice(PREFIX);
-    let message_buf = &mut outbuf[PREFIX.len()..];
-    // SAFETY: `message_buf` is a valid writable buffer of `message_buf.len()` bytes.
-    unsafe {
-        bun_boringssl_sys::ERR_error_string_n(
-            err_code,
-            message_buf.as_mut_ptr().cast::<core::ffi::c_char>(),
-            message_buf.len(),
-        );
-    }
-    let error_message: &[u8] = bun_core::slice_to_nul(&outbuf[..]);
-    if error_message.len() == PREFIX.len() {
+    let mut buf = [0u8; 128];
+    let reason = bun_boringssl_sys::err_error_string_n(err_code, &mut buf);
+    if reason.is_empty() {
         return global
             .err(
                 ErrorCode::BORINGSSL,
@@ -111,7 +98,7 @@ fn boringssl_err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
     global
         .err(
             ErrorCode::BORINGSSL,
-            format_args!("{}", bstr::BStr::new(error_message)),
+            format_args!("BoringSSL {}", bstr::BStr::new(reason)),
         )
         .to_js()
 }
@@ -166,7 +153,6 @@ pub(crate) trait JSGlobalObjectSqlExt {
     /// `&mut VirtualMachine`; this `&`-receiver form is for SQL callsites that
     /// only need shared access.
     fn sql_vm(&self) -> &VirtualMachine;
-    fn sql_vm_ptr(&self) -> *mut VirtualMachine;
 }
 
 impl JSGlobalObjectSqlExt for JSGlobalObject {
@@ -180,10 +166,6 @@ impl JSGlobalObjectSqlExt for JSGlobalObject {
         // audited deref in bun_jsc); the VM is a process-lifetime singleton.
         self.bun_vm()
     }
-    #[inline]
-    fn sql_vm_ptr(&self) -> *mut VirtualMachine {
-        JSC__JSGlobalObject__bunVM(self).cast::<VirtualMachine>()
-    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -193,7 +175,7 @@ impl JSGlobalObjectSqlExt for JSGlobalObject {
 // structs that round-tripped through Rust→Rust extern "C" shims
 // (Bun__VM__global / Bun__VM__eventLoop / Bun__EventLoop__enterLoop / …)
 // were a layering workaround. SQL-specific accessors that bun_jsc doesn't
-// expose at this tier (sql_state(), timer(), ssl_ctx_cache()) are provided
+// expose at this tier (with_sql_state(), timer_insert()/timer_remove()) are provided
 // as the [VirtualMachineSqlExt] extension trait.
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -204,8 +186,8 @@ pub use bun_jsc::virtual_machine::VirtualMachine;
 // ──────────────────────────────────────────────────────────────────────────
 // SqlRuntimeHooks — manual cold-path vtable (CYCLEBREAK §Dispatch).
 //
-// `bun_runtime` owns the per-VM `RuntimeState` (timer heap, SSLContextCache,
-// SSLConfig parser, Blob accessors) and *depends on* this crate, so direct
+// `bun_runtime` owns the per-VM `RuntimeState` (timer heap, SSLConfig parser)
+// and *depends on* this crate, so direct
 // imports would cycle. Instead of Rust→Rust `extern "C"` shims (which let the
 // two sides disagree on pointee types — the previous local `EventLoopTimer` /
 // `SSLConfig` stubs were layout-incompatible with what `hw_exports.rs` wrote),
@@ -215,40 +197,14 @@ pub use bun_jsc::virtual_machine::VirtualMachine;
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct SqlRuntimeHooks {
-    /// `&mut runtime_state().sql_rare` — this crate's [`RareData`] storage.
-    pub sql_rare: unsafe fn(*mut VirtualMachine) -> *mut RareData,
-    /// `&mut runtime_state().timer` — opaque `bun_runtime::timer::All`.
-    pub timer_heap: unsafe fn(*mut VirtualMachine) -> *mut c_void,
-    /// `Timer.All.insert` — push an intrusive `EventLoopTimer` into the heap.
-    pub timer_insert: unsafe fn(heap: *mut c_void, *mut EventLoopTimer),
-    /// `Timer.All.remove`.
-    pub timer_remove: unsafe fn(heap: *mut c_void, *mut EventLoopTimer),
-    /// `&mut runtime_state().ssl_ctx_cache` — opaque `SSLContextCache`.
-    pub ssl_ctx_cache: unsafe fn(*mut VirtualMachine) -> *mut c_void,
-    /// `SSLContextCache::getOrCreateOpts` — digest-keyed weak `SSL_CTX*` cache.
-    pub ssl_ctx_get_or_create: unsafe fn(
-        cache: *mut c_void,
-        opts: &bun_uws::us_bun_socket_context_options_t,
-        err: &mut bun_uws::create_bun_socket_error_t,
-    ) -> Option<OwnedSslCtx>,
-    /// `SSLConfig::fromJS` — parse a JS TLS-options object. Returns a boxed
-    /// `bun_runtime::socket::SSLConfig` (caller frees via `ssl_config_free`),
-    /// or null when the value contained no TLS config / threw (caller checks
-    /// `global.has_exception()`).
-    pub ssl_config_from_js: unsafe fn(&JSGlobalObject, JSValue) -> *mut c_void,
-    /// Drop a boxed `SSLConfig` returned by `ssl_config_from_js`.
-    pub ssl_config_free: unsafe fn(*mut c_void),
-    /// `SSLConfig::asUSocketsForClientVerification`.
-    pub ssl_config_as_usockets_client:
-        unsafe fn(*const c_void) -> bun_uws::us_bun_socket_context_options_t,
-    /// `SSLConfig.server_name` — null when unset.
-    pub ssl_config_server_name: unsafe fn(*const c_void) -> *const c_char,
-    /// `SSLConfig.reject_unauthorized`.
-    pub ssl_config_reject_unauthorized: unsafe fn(*const c_void) -> i32,
-    /// `Blob::needsToReadFile`.
-    pub blob_needs_to_read_file: unsafe fn(*const c_void) -> bool,
-    /// `Blob::sharedView` — returns `(ptr, len)` borrowing the immutable store.
-    pub blob_shared_view: unsafe fn(*const c_void, out_len: *mut usize) -> *const u8,
+    /// Run a closure against this thread's [`RareData`] (`runtime_state().sql_rare`).
+    pub with_sql_state: fn(&mut dyn FnMut(&mut RareData)),
+    /// `Timer.All.insert` / `Timer.All.remove` on this thread's timer heap.
+    pub timer_insert: fn(TimerRef),
+    pub timer_remove: fn(TimerRef),
+    /// `SSLConfig.fromJS` — parse a JS TLS-options object; `None` when the
+    /// value carried no TLS options.
+    pub ssl_config_from_js: fn(&JSGlobalObject, JSValue) -> JsResult<Option<bun_http::SSLConfig>>,
 }
 
 unsafe extern "Rust" {
@@ -269,7 +225,7 @@ fn hooks() -> &'static SqlRuntimeHooks {
 /// The bun_jsc::rare_data::RareData slots for these are opaque
 /// (cycle break: bun_jsc cannot name bun_sql_jsc types), so the storage lives
 /// in bun_runtime::jsc_hooks::RuntimeState.sql_rare and is reached via
-/// [VirtualMachineSqlExt::sql_state].
+/// [VirtualMachineSqlExt::with_sql_state].
 #[repr(C)]
 pub struct RareData {
     pub mysql_context: crate::mysql::MySQLContext,
@@ -279,44 +235,34 @@ pub struct RareData {
 /// SQL-specific accessors on [VirtualMachine] for state owned by the
 /// higher-tier bun_runtime::jsc_hooks::RuntimeState.
 pub(crate) trait VirtualMachineSqlExt {
-    /// RareData.{mysql,postgresql}_context. Named sql_state to avoid
-    /// shadowing the inherent VirtualMachine::rare_data() (which returns the
-    /// bun_jsc RareData holding the per-protocol SocketGroups).
-    fn sql_state(&mut self) -> &mut RareData;
-    /// vm.timer — the Timer::All heap, owned by RuntimeState.
-    fn timer(&mut self) -> &mut TimerHeap;
-    /// RareData.ssl_ctx_cache — owned by RuntimeState.
-    fn ssl_ctx_cache(&mut self) -> &mut SslCtxCache;
+    /// RareData.{mysql,postgresql}_context. `f` must not re-enter anything
+    /// that reaches this state.
+    fn with_sql_state<R>(&self, f: impl FnOnce(&mut RareData) -> R) -> R;
+    /// Link / unlink one of a connection's timer slots on vm.timer.
+    fn timer_insert(&self, timer: TimerRef);
+    fn timer_remove(&self, timer: TimerRef);
     /// bun_io::EventLoopCtx for the JS-thread VM, for KeepAlive::{ref_,unref}.
     fn vm_ctx(&self) -> bun_io::EventLoopCtx;
     /// Lazy-init `RareData`'s per-protocol uws [`bun_uws::SocketGroup`].
     fn postgres_socket_group<const SSL: bool>(&mut self) -> &mut bun_uws::SocketGroup;
     /// See [`Self::postgres_socket_group`].
     fn mysql_socket_group<const SSL: bool>(&mut self) -> &mut bun_uws::SocketGroup;
-    // NOTE: `event_loop_mut` lives on `VirtualMachine` as a safe inherent
-    // accessor (single audited deref under the JS-thread-singleton invariant);
-    // the former unsafe trait shim here was dead — inherent methods always win
-    // method resolution over this extension trait.
 }
 impl VirtualMachineSqlExt for VirtualMachine {
     #[inline]
-    fn sql_state(&mut self) -> &mut RareData {
-        // SAFETY: hook returns `&mut runtime_state().sql_rare`; non-null on
-        // the JS thread once `init_runtime_state` has run.
-        unsafe { &mut *(hooks().sql_rare)(self) }
+    fn with_sql_state<R>(&self, f: impl FnOnce(&mut RareData) -> R) -> R {
+        let mut f = Some(f);
+        let mut out = None;
+        (hooks().with_sql_state)(&mut |state| out = Some((f.take().unwrap())(state)));
+        out.unwrap()
     }
     #[inline]
-    fn timer(&mut self) -> &mut TimerHeap {
-        // SAFETY: hook returns `&mut runtime_state().timer`; non-null after
-        // `init_runtime_state`. `TimerHeap` is an opaque newtype over the
-        // `*mut c_void` so callers stay typed.
-        unsafe { &mut *(hooks().timer_heap)(self).cast::<TimerHeap>() }
+    fn timer_insert(&self, timer: TimerRef) {
+        (hooks().timer_insert)(timer)
     }
     #[inline]
-    fn ssl_ctx_cache(&mut self) -> &mut SslCtxCache {
-        // SAFETY: hook returns `&mut runtime_state().ssl_ctx_cache`; non-null
-        // after `init_runtime_state`.
-        unsafe { &mut *(hooks().ssl_ctx_cache)(self).cast::<SslCtxCache>() }
+    fn timer_remove(&self, timer: TimerRef) {
+        (hooks().timer_remove)(timer)
     }
     #[inline]
     fn vm_ctx(&self) -> bun_io::EventLoopCtx {
@@ -334,20 +280,6 @@ impl VirtualMachineSqlExt for VirtualMachine {
     }
 }
 
-/// RAII enter()/exit() for [EventLoop] — wraps the inherent (unsafe,
-/// raw-pointer) bun_jsc::event_loop::EventLoop::enter_scope.
-pub(crate) trait EventLoopSqlExt {
-    fn entered(&mut self) -> EventLoopGuard;
-}
-impl EventLoopSqlExt for EventLoop {
-    #[inline]
-    fn entered(&mut self) -> EventLoopGuard {
-        // SAFETY: self is the live VM-owned event loop; the guard holds the
-        // raw pointer so no &mut is held across re-entrant JS.
-        unsafe { EventLoop::enter_scope(self) }
-    }
-}
-
 // ──────────────────────────────────────────────────────────────────────────
 // Timer heap / EventLoopTimer.
 //
@@ -360,81 +292,21 @@ impl EventLoopSqlExt for EventLoop {
 // mis-routed.
 //
 // `Timer::All` (the heap container) lives in `bun_runtime::RuntimeState`;
-// reached via [`SqlRuntimeHooks::timer_heap`] / `timer_insert` / `timer_remove`.
+// reached via [`SqlRuntimeHooks::timer_insert`] / `timer_remove`.
 // ──────────────────────────────────────────────────────────────────────────
 
 pub use bun_event_loop::EventLoopTimer::{
-    EventLoopTimer, State as EventLoopTimerState, Tag as EventLoopTimerTag,
+    EventLoopTimer, State as EventLoopTimerState, Tag as EventLoopTimerTag, TimerRef,
 };
 
-// `bun_runtime::timer::All` — heap of `EventLoopTimer`. Opaque on this side
-// (the layout is high-tier); insert/remove forward to `bun_runtime` via the
-// [`SqlRuntimeHooks`] vtable.
-bun_opaque::opaque_ffi! { pub struct TimerHeap; }
-impl TimerHeap {
-    pub(crate) fn insert(&mut self, t: *mut EventLoopTimer) {
-        // SAFETY: `self` is `&mut runtime_state().timer`; `t` is a live
-        // intrusive heap node whose provenance covers its container.
-        unsafe { (hooks().timer_insert)(self._p.get().cast::<c_void>(), t) }
-    }
-    pub(crate) fn remove(&mut self, t: &mut EventLoopTimer) {
-        // SAFETY: `self` is `&mut runtime_state().timer`; `t` was previously
-        // inserted by the caller.
-        unsafe { (hooks().timer_remove)(self._p.get().cast::<c_void>(), t) }
-    }
-}
+pub use bun_jsc::{AutoFlushTarget, AutoFlusher};
 
 // ──────────────────────────────────────────────────────────────────────────
-// AutoFlusher — thin VM-taking wrapper over
-// bun_jsc::event_loop::EventLoop::deferred_tasks.
-// ──────────────────────────────────────────────────────────────────────────
-
-#[derive(Default, Debug)]
-pub struct AutoFlusher {
-    pub(crate) registered: bool,
-}
-
-/// SQL connection types implement this to participate in deferred flushing.
-pub trait HasAutoFlush: Sized {
-    fn on_auto_flush(this: *mut Self) -> bool;
-}
-
-impl AutoFlusher {
-    pub(crate) fn register_deferred_microtask_with_type_unchecked<T: HasAutoFlush>(
-        this: *mut T,
-        vm: &VirtualMachine,
-    ) {
-        // Body is fully safe — `cast()` is safe and `on_auto_flush` takes a
-        // raw pointer by value. `ctx` is the `*mut T` registered below; the
-        // queue feeds it back unchanged. A safe `extern "C" fn` coerces to the
-        // `DeferredRepeatingTask` fn-pointer type.
-        extern "C" fn trampoline<T: HasAutoFlush>(ctx: *mut c_void) -> bool {
-            T::on_auto_flush(ctx.cast::<T>())
-        }
-        // `event_loop_mut()` is the canonical safe `&mut EventLoop` accessor
-        // (single audited deref inside `VirtualMachine`); `deferred_tasks` is an
-        // embedded field with stable address for the VM lifetime.
-        let q = &mut vm.event_loop_mut().deferred_tasks;
-        q.post_task(NonNull::new(this.cast::<c_void>()), trampoline::<T>);
-    }
-    pub(crate) fn unregister_deferred_microtask_with_type<T>(this: *mut T, vm: &VirtualMachine) {
-        // See register_deferred_microtask_with_type_unchecked.
-        let q = &mut vm.event_loop_mut().deferred_tasks;
-        q.unregister_task(NonNull::new(this.cast::<c_void>()));
-    }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// api::ServerConfig::SSLConfig — opaque handle to a boxed
-// `bun_runtime::socket::SSLConfig`.
+// api::ServerConfig::SSLConfig — the connection's TLS options.
 //
-// The full `SSLConfig` (~18 fields incl. `Vec`/`CString`) is high-tier (it
-// pulls in `node::fs`/`webcore::Blob`). The previous 3-field local mirror was
-// passed as `*mut c_void` storage to `Bun__SSLConfig__fromJS`, which `.write()`
-// the full struct into the 16-byte stack slot — stack overflow / UB. Storage
-// now lives in `bun_runtime`; this side holds only an owning pointer and
-// reaches the two fields SQL actually reads (`server_name`,
-// `reject_unauthorized`) via [`SqlRuntimeHooks`].
+// Parsing a JS `tls: {...}` object needs `node:fs` / `Blob` (high tier), so it
+// goes through [`SqlRuntimeHooks::ssl_config_from_js`]; the parsed
+// `bun_http::SSLConfig` is owned here.
 // ──────────────────────────────────────────────────────────────────────────
 
 pub mod api {
@@ -442,48 +314,24 @@ pub mod api {
     pub mod server_config {
         use super::*;
 
-        /// Owning handle to a `Box<bun_runtime::socket::SSLConfig>`. `None` =
-        /// the default-constructed config — callers that pass
-        /// `tls: true` get an SSLConfig with no overrides.
+        /// A connection's TLS options. `None` inside = `tls: true`: the
+        /// defaults, with no overrides.
         #[derive(Default)]
-        pub struct SSLConfig(Option<NonNull<c_void>>);
-
-        // SAFETY: the boxed `bun_runtime::socket::SSLConfig` is `Send` (only
-        // `CString`/`Vec`/`AtomicU64` fields); the handle moves between
-        // construction and the connection struct on the same JS thread anyway.
-        unsafe impl Send for SSLConfig {}
-
-        impl Drop for SSLConfig {
-            fn drop(&mut self) {
-                if let Some(p) = self.0.take() {
-                    // SAFETY: `p` was returned by `ssl_config_from_js` and not
-                    // yet freed (Option::take guarantees single drop).
-                    unsafe { (hooks().ssl_config_free)(p.as_ptr()) }
-                }
-            }
-        }
+        pub struct SSLConfig(Option<bun_http::SSLConfig>);
 
         impl SSLConfig {
-            /// `SSLConfig.server_name` — the SNI hostname C string, or null
-            /// when unset / default.
+            /// The SNI hostname, if one was configured.
             #[inline]
-            pub(crate) fn server_name(&self) -> *const c_char {
-                match self.0 {
-                    None => core::ptr::null(),
-                    // SAFETY: live boxed SSLConfig; hook returns a borrow into
-                    // its `Option<CString>` field, valid for `self`'s lifetime.
-                    Some(p) => unsafe { (hooks().ssl_config_server_name)(p.as_ptr()) },
-                }
+            pub(crate) fn server_name(&self) -> Option<&core::ffi::CStr> {
+                self.0
+                    .as_ref()
+                    .and_then(bun_http::SSLConfig::server_name_cstr)
             }
 
             /// `SSLConfig.reject_unauthorized` — non-zero rejects on verify error.
             #[inline]
             pub(crate) fn reject_unauthorized(&self) -> i32 {
-                match self.0 {
-                    None => 0,
-                    // SAFETY: live boxed SSLConfig.
-                    Some(p) => unsafe { (hooks().ssl_config_reject_unauthorized)(p.as_ptr()) },
-                }
+                self.0.as_ref().map_or(0, |c| c.reject_unauthorized)
             }
 
             /// `SSLConfig.fromJS(vm, global, value)` — VM is accepted but
@@ -493,13 +341,11 @@ pub mod api {
                 global: &JSGlobalObject,
                 value: JSValue,
             ) -> JsResult<Option<Self>> {
-                // SAFETY: hook contract — may run JS getters / throw.
-                let p = unsafe { (hooks().ssl_config_from_js)(global, value) };
-                if global.has_exception() {
-                    debug_assert!(p.is_null());
-                    return Err(JsError::Thrown);
+                match (hooks().ssl_config_from_js)(global, value) {
+                    Ok(config) => Ok(config.map(|c| Self(Some(c)))),
+                    Err(JsError::OutOfMemory) => Err(global.throw_out_of_memory()),
+                    Err(e) => Err(e),
                 }
-                Ok(NonNull::new(p).map(|p| Self(Some(p))))
             }
 
             /// `SSLConfig.asUSocketsForClientVerification` — projects to the
@@ -509,14 +355,13 @@ pub mod api {
             pub(crate) fn as_usockets_for_client_verification(
                 &self,
             ) -> bun_uws::us_bun_socket_context_options_t {
-                match self.0 {
+                match &self.0 {
                     None => bun_uws::us_bun_socket_context_options_t {
                         request_cert: 1,
                         reject_unauthorized: 0,
                         ..Default::default()
                     },
-                    // SAFETY: live boxed SSLConfig.
-                    Some(p) => unsafe { (hooks().ssl_config_as_usockets_client)(p.as_ptr()) },
+                    Some(c) => c.as_usockets_for_client_verification(),
                 }
             }
         }
@@ -529,78 +374,7 @@ pub mod api {
 }
 
 pub mod webcore {
-    pub use super::AutoFlusher;
-    use super::*;
-
-    // Opaque view of `bun_runtime::webcore::Blob`. Never constructed by value
-    // on this side — SQL only ever holds `*mut Blob` recovered from a JS
-    // wrapper's `m_ctx` via `value.as_::<Blob>()`. Field accessors route
-    // through [`SqlRuntimeHooks`]; the `from_js`/`from_js_direct` codegen
-    // externs are real C++ symbols (generate-classes.ts), not Rust shims.
-    bun_opaque::opaque_ffi! { pub struct Blob; }
-    impl Blob {
-        pub(crate) fn needs_to_read_file(&self) -> bool {
-            // SAFETY: `self` is a live `*const bun_runtime::webcore::Blob`
-            // (codegen m_ctx payload).
-            unsafe { (hooks().blob_needs_to_read_file)(self._p.get() as *const c_void) }
-        }
-        pub(crate) fn shared_view(&self) -> &[u8] {
-            let mut len: usize = 0;
-            // SAFETY: `self` is a live `*const Blob`; the returned ptr/len
-            // borrow the Blob's store, which is immutable for its lifetime.
-            let ptr =
-                unsafe { (hooks().blob_shared_view)(self._p.get() as *const c_void, &raw mut len) };
-            if ptr.is_null() || len == 0 {
-                return &[];
-            }
-            // SAFETY: hook guarantees `ptr[..len]` valid while the Blob lives.
-            unsafe { core::slice::from_raw_parts(ptr, len) }
-        }
-    }
-    impl super::JsClass for Blob {
-        fn from_js(value: JSValue) -> Option<*mut Self> {
-            let p = Blob__fromJS(value);
-            if p.is_null() {
-                None
-            } else {
-                Some(p.cast::<Self>())
-            }
-        }
-        fn from_js_direct(value: JSValue) -> Option<*mut Self> {
-            let p = Blob__fromJSDirect(value);
-            if p.is_null() {
-                None
-            } else {
-                Some(p.cast::<Self>())
-            }
-        }
-        fn to_js(self, _global: &JSGlobalObject) -> JSValue {
-            // The opaque view is zero-sized and unconstructible (no `pub`
-            // ctor); real callers go through `bun_runtime::webcore::Blob::to_js`.
-            // Safe `unreachable!` so a stray generic-over-`JsClass` call panics
-            // with a diagnostic instead of invoking UB.
-            unreachable!(
-                "webcore::Blob is an opaque view on the sql_jsc side; \
-                 construct via bun_runtime::webcore::Blob"
-            )
-        }
-        fn get_constructor(global: &JSGlobalObject) -> JSValue {
-            Blob__getConstructor(global)
-        }
-    }
-
-    // C++ codegen symbols (generate-classes.ts) — NOT Rust→Rust shims.
-    // SAFETY (safe fn): `JSValue` is a by-value scalar; `JSGlobalObject` is an
-    // opaque `UnsafeCell`-backed handle, so `&JSGlobalObject` is ABI-identical
-    // to a non-null `JSGlobalObject*` with write provenance.
-    // C++ declares these `extern JSC_CALLCONV` (= SysV ABI on win-x64), so
-    // import via `jsc_abi_extern!` — plain `extern "C"` is the Win64 ABI on
-    // Windows and would pass args in the wrong registers.
-    bun_jsc::jsc_abi_extern! {
-        safe fn Blob__fromJS(value: JSValue) -> *mut c_void;
-        safe fn Blob__fromJSDirect(value: JSValue) -> *mut c_void;
-        safe fn Blob__getConstructor(global: &JSGlobalObject) -> JSValue;
-    }
+    pub use bun_jsc::webcore::Blob;
 }
 
 /// `bun_jsc::JsClass` — generic downcast trait backing `JSValue::as_<T>()`.
@@ -645,9 +419,8 @@ pub mod codegen {
 // ──────────────────────────────────────────────────────────────────────────
 // JSFunction — host-function constructor.
 //
-// `bun_jsc::JSFunction` exists, but its `create` signature differs; the SQL
-// callsites only need the `JSHostFn` thunk plumbing, kept local so callers
-// don't churn.
+// Forwards to `bun_jsc::JSFunction::create`; kept local for the
+// [`IntoJSHostFn`] plumbing that lets callsites pass safe Rust fns.
 // ──────────────────────────────────────────────────────────────────────────
 
 #[repr(C)]
@@ -699,13 +472,10 @@ where
             where [F: Fn(&JSGlobalObject, &CallFrame) -> JsResult<JSValue> + Copy + 'static]
             {
                 let f: F = bun_core::ffi::conjure_zst::<F>();
-                // JSC passes live non-null `*JSGlobalObject` / `*CallFrame`; both
-                // strictly outlive the host-fn call, satisfying the `ParentRef`
-                // invariant. Safe `From<NonNull>` + `Deref` collapse the per-thunk
-                // raw `&*ptr` pair to one audited deref site in `bun_ptr`.
-                let global = bun_ptr::ParentRef::from(NonNull::new(g).expect("JSC host fn: global non-null"));
-                let frame = bun_ptr::ParentRef::from(NonNull::new(c).expect("JSC host fn: callframe non-null"));
-                match f(&global, &frame) {
+                // JSC passes its live global / call frame; both are opaque handles.
+                let global = bun_opaque::opaque_deref(g);
+                let frame = bun_opaque::opaque_deref(c);
+                match f(global, frame) {
                     Ok(v) => v,
                     Err(JsError::OutOfMemory) => { let _ = global.throw_out_of_memory(); JSValue::ZERO }
                     Err(_) => JSValue::ZERO,
@@ -731,52 +501,17 @@ where
             where [F: Fn(&JSGlobalObject, &CallFrame) -> JSValue + Copy + 'static]
             {
                 let f: F = bun_core::ffi::conjure_zst::<F>();
-                // JSC passes live non-null pointers; both outlive the host-fn
-                // call (the `ParentRef` invariant). Safe `Deref` recovers `&T`.
-                let global = bun_ptr::ParentRef::from(NonNull::new(g).expect("JSC host fn: global non-null"));
-                let frame = bun_ptr::ParentRef::from(NonNull::new(c).expect("JSC host fn: callframe non-null"));
-                f(&global, &frame)
+                // JSC passes its live global / call frame; both are opaque handles.
+                let global = bun_opaque::opaque_deref(g);
+                let frame = bun_opaque::opaque_deref(c);
+                f(global, frame)
             }
         }
         thunk::<F>
     }
 }
 
-#[repr(u8)]
-#[derive(Clone, Copy, Default)]
-pub enum ImplementationVisibility {
-    #[default]
-    Public = 0,
-    Private = 1,
-    PrivateRecursive = 2,
-}
-#[repr(u8)]
-#[derive(Clone, Copy, Default)]
-pub enum Intrinsic {
-    #[default]
-    None = 0,
-}
-#[derive(Clone, Copy, Default)]
-pub struct CreateJSFunctionOptions {
-    pub(crate) implementation_visibility: ImplementationVisibility,
-    pub(crate) intrinsic: Intrinsic,
-    pub(crate) constructor: Option<JSHostFn>,
-}
-
-unsafe extern "C" {
-    // `&JSGlobalObject` is ABI-identical to a non-null `*const JSGlobalObject`;
-    // remaining args are by-value scalars/fn-ptrs. No caller-side memory
-    // preconditions remain → `safe fn`.
-    safe fn JSFunction__createFromZig(
-        global: &JSGlobalObject,
-        fn_name: &bun_core::String,
-        implementation: JSHostFn,
-        arg_count: u32,
-        implementation_visibility: ImplementationVisibility,
-        intrinsic: Intrinsic,
-        constructor: Option<JSHostFn>,
-    ) -> JSValue;
-}
+pub use bun_jsc::js_function::CreateJSFunctionOptions;
 
 /// `bun_jsc::JSValue::put_host_functions`-shaped helper for the SQL binding
 /// objects. Macro (not fn) because each entry's `$f` is a *distinct* fn-item
@@ -805,21 +540,17 @@ impl JSFunction {
     /// `-> JsResult<JSValue>` via [`IntoJSHostFn`].
     pub(crate) fn create<M, F: IntoJSHostFn<M>>(
         global: &JSGlobalObject,
-        name: &str,
+        name: &'static str,
         implementation: F,
         arg_count: u32,
         opts: CreateJSFunctionOptions,
     ) -> JSValue {
-        let implementation: JSHostFn = implementation.into_js_host_fn();
-        let fn_name = bun_core::String::from_bytes(name.as_bytes());
-        JSFunction__createFromZig(
+        bun_jsc::JSFunction::create(
             global,
-            &fn_name,
-            implementation,
+            name,
+            implementation.into_js_host_fn(),
             arg_count,
-            opts.implementation_visibility,
-            opts.intrinsic,
-            opts.constructor,
+            opts,
         )
     }
 }
@@ -834,18 +565,12 @@ pub(crate) mod call_frame {
     /// Cursor over a `&[JSValue]`.
     pub(crate) struct ArgumentsSlice<'a> {
         remaining: &'a [JSValue],
-        _vm: *const c_void,
     }
     impl<'a> ArgumentsSlice<'a> {
         /// Generic over the VM handle so it accepts both the local
-        /// [`VirtualMachine`] and `bun_jsc`'s (callers pass `global.bun_vm()`,
-        /// which returns a raw `*mut VirtualMachineRef`). The VM is not
-        /// dereferenced, so it's accepted by-value and dropped.
+        /// [`VirtualMachine`] and `bun_jsc`'s. The VM is not used.
         pub(crate) fn init<V>(_vm: V, slice: &'a [JSValue]) -> Self {
-            Self {
-                remaining: slice,
-                _vm: core::ptr::null(),
-            }
+            Self { remaining: slice }
         }
         /// Return the head **and** advance.
         #[inline]
@@ -855,47 +580,4 @@ pub(crate) mod call_frame {
             Some(*first)
         }
     }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// MarkedArgumentBuffer::run — C++-side trampoline. `bun_jsc::MarkedArgumentBuffer`
-// exposes `new(f)`; the SQL callsites use the lower-level `run(ctx, fn_ptr)`
-// shape, kept here as a free fn (cannot add inherent methods to a foreign type).
-// ──────────────────────────────────────────────────────────────────────────
-
-// Opaque handle to `bun_runtime::api::SSLContextCache` (owned by
-// `RuntimeState`). Reached via [`VirtualMachineSqlExt::ssl_ctx_cache`]; backed
-// by [`SqlRuntimeHooks::ssl_ctx_cache`] / `ssl_ctx_get_or_create`.
-use bun_boringssl_sys::OwnedSslCtx;
-
-bun_opaque::opaque_ffi! { pub struct SslCtxCache; }
-impl SslCtxCache {
-    pub(crate) fn get_or_create_opts(
-        &mut self,
-        opts: &bun_uws::us_bun_socket_context_options_t,
-        err: &mut bun_uws::create_bun_socket_error_t,
-    ) -> Option<OwnedSslCtx> {
-        // SAFETY: `self` is `&mut runtime_state().ssl_ctx_cache`; `opts`/`err`
-        // are caller stack locals.
-        unsafe { (hooks().ssl_ctx_get_or_create)(self._p.get().cast::<c_void>(), opts, err) }
-    }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// extern "C" — **C++** JSC bindings (src/jsc/bindings/bindings.cpp) used by
-// the extension traits above. No Rust-defined symbols are declared here; all
-// `bun_runtime` cross-calls go through [`SqlRuntimeHooks`] so the compiler
-// type-checks both sides at the registration site.
-// ──────────────────────────────────────────────────────────────────────────
-unsafe extern "C" {
-    // JSValue — by-value `JSValue` (encoded NaN-boxed u64) + scalar args; the
-    // C++ side reads no caller memory and upholds no invariants the caller must
-    // discharge, so these are `safe fn`.
-
-    // JSGlobalObject — `&JSGlobalObject` is ABI-identical to a non-null
-    // `*const JSGlobalObject`; the reference type discharges the validity
-    // precondition, so `safe fn`. Returned pointer is opaque (caller derefs
-    // under its own SAFETY obligation).
-    safe fn JSC__JSGlobalObject__bunVM(this: &JSGlobalObject) -> *mut c_void;
-
 }

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -2,16 +2,15 @@ use core::cell::Cell;
 use core::ffi::c_void;
 
 use crate::jsc::{
-    CallFrame, EventLoopSqlExt as _, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag,
-    GlobalRef, HasAutoFlush, JSGlobalObject, JSValue, JsCell, JsRef, JsResult, KeepAlive,
-    VirtualMachine, VirtualMachineSqlExt as _, codegen::js_mysql_connection as js,
-    webcore::AutoFlusher,
+    AutoFlushTarget, AutoFlusher, CallFrame, EventLoopTimer, EventLoopTimerState,
+    EventLoopTimerTag, GlobalRef, JSGlobalObject, JSValue, JsCell, JsRef, JsResult, KeepAlive,
+    TimerRef, VirtualMachine, VirtualMachineSqlExt as _, codegen::js_mysql_connection as js,
 };
 use crate::shared::CachedStructure;
 use crate::shared::connection_ctor_args::ConnectionCtorArgs;
 use bun_core::strings;
 use bun_core::{TimespecMockMode, timespec};
-use bun_ptr::{AsCtxPtr, BackRef, ParentRef, RefPtr};
+use bun_ptr::{BackRef, RefPtr, ThisPtr};
 use bun_sql::mysql::MySQLQueryResult;
 use bun_sql::mysql::protocol::any_mysql_error::Error as AnyMySQLErrorT;
 use bun_sql::mysql::protocol::error_packet::ErrorPacket;
@@ -48,6 +47,7 @@ bun_core::declare_scope!(MySQLConnection, visible);
 // offsets.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct JSMySQLConnection {
+    // Intrusive refcount (`CellRefCounted`); the last release runs `Drop`.
     ref_count: Cell<u32>,
     js_value: JsCell<JsRef>,
     // LIFETIMES.tsv: JSC_BORROW — assigned from createInstance param; never freed
@@ -59,27 +59,33 @@ pub struct JSMySQLConnection {
     poll_ref: JsCell<KeepAlive>,
 
     // pub(crate): MySQLRequestQueue::advance reaches `connection.get().queue`
-    // via a `ParentRef<JSMySQLConnection>` shared borrow; the inner protocol
-    // struct's `get_js_connection()` recovers the embedding via
-    // `from_field_ptr!` (offset unchanged — `JsCell` is transparent).
+    // via `&JSMySQLConnection`; the inner protocol struct's
+    // `js_connection_ref()` recovers the embedding via `from_field_ptr!`
+    // (offset unchanged — `JsCell` is transparent).
     pub(crate) connection: JsCell<my_sql_connection::MySQLConnection>,
 
-    pub(crate) auto_flusher: JsCell<AutoFlusher>,
+    pub(crate) auto_flusher: AutoFlusher<JSMySQLConnection>,
 
     pub(crate) idle_timeout_interval_ms: u32,
     pub(crate) connection_timeout_ms: u32,
     /// Before being connected, this is a connection timeout timer.
     /// After being connected, this is an idle timeout timer.
-    // Private — intrusive heap node; cross-crate `container_of` goes through
-    // [`Self::from_timer_ptr`] instead of `offset_of!` on the field.
-    timer: JsCell<EventLoopTimer>,
+    // Intrusive heap node; `bun_runtime::dispatch` recovers `Self` from it by
+    // `offset_of!` (`JsCell` is `#[repr(transparent)]`).
+    pub timer: JsCell<EventLoopTimer>,
 
     /// This timer controls the maximum lifetime of a connection.
     /// It starts when the connection successfully starts (i.e. after handshake is complete).
     /// It stops when the connection is closed.
     pub(crate) max_lifetime_interval_ms: u32,
-    // Private — see `timer`; recovered via [`Self::from_max_lifetime_timer_ptr`].
-    max_lifetime_timer: JsCell<EventLoopTimer>,
+    // See `timer`.
+    pub max_lifetime_timer: JsCell<EventLoopTimer>,
+    /// This allocation's root pointer, for the `&self` paths that take refs on
+    /// it (`ref_guard`, the socket ext slot, the auto-flush registration).
+    this_ptr: Cell<Option<BackRef<JSMySQLConnection, bun_ptr::Root>>>,
+    /// The ref held for the socket whose ext slot points here: taken by the
+    /// TCP `on_open`, released by `on_close`.
+    socket_ref: Cell<Option<RefPtr<JSMySQLConnection>>>,
 }
 
 bun_event_loop::impl_timer_owner!(JSMySQLConnection;
@@ -89,21 +95,31 @@ bun_event_loop::impl_timer_owner!(JSMySQLConnection;
 
 bun_jsc::impl_js_class_via_generated!(JSMySQLConnection => crate::jsc::codegen::js_mysql_connection);
 
-impl Drop for JSMySQLConnection {
-    fn drop(&mut self) {
-        self.stop_timers();
-        let ctx = self.vm_ctx();
-        self.poll_ref.with_mut(|p| p.unref(ctx));
-        self.unregister_auto_flusher();
-    }
-}
-
 impl JSMySQLConnection {
-    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
+    /// This allocation's root pointer (see the `this_ptr` field).
+    #[inline]
+    pub(crate) fn this_ptr(&self) -> ThisPtr<Self> {
+        self.this_ptr
+            .get()
+            .expect("JSMySQLConnection used before create_instance")
+            .this_ptr()
+    }
+
+    /// Takes a ref on `self` now and releases it on drop (which may free
+    /// `self`).
     #[inline]
     fn ref_guard(&self) -> RefPtr<Self> {
-        // SAFETY: `self` is the live heap allocation.
-        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
+        RefPtr::from_this(self.this_ptr())
+    }
+
+    #[inline]
+    fn timer_ref(&self) -> TimerRef {
+        TimerRef::new(self, |c| &c.timer)
+    }
+
+    #[inline]
+    fn max_lifetime_timer_ref(&self) -> TimerRef {
+        TimerRef::new(self, |c| &c.max_lifetime_timer)
     }
 
     /// Shared borrow of the JS-thread `VirtualMachine` singleton stored in this
@@ -113,23 +129,11 @@ impl JSMySQLConnection {
     fn vm(&self) -> &VirtualMachine {
         self.vm.get()
     }
-    /// Short-lived `&mut VirtualMachine` for the few `vm.timer()` callers
-    /// (jsc shim's `timer()` is `&mut self`). The VM is a JS-thread singleton;
-    /// we never hold two `&mut` to it at once in this module.
-    fn vm_mut(&self) -> &'static mut VirtualMachine {
-        VirtualMachine::get_mut()
-    }
-
-    /// `&mut EventLoop` for `entered()`/`run_callback`. One audited unsafe
-    /// here replaces the per-site `unsafe { self.vm().event_loop_mut() }` —
-    /// the loop is a disjoint heap allocation owned by the JS-thread VM
-    /// singleton; single-thread affinity ⇒ no two `&mut EventLoop` coexist.
+    /// `&mut EventLoop` for `run_callback`; the loop is owned by the JS-thread
+    /// VM singleton (see `VirtualMachine::event_loop_mut`).
     #[inline]
-    fn event_loop(&self) -> &'static mut crate::jsc::EventLoop {
-        // `vm_mut()` yields the process-lifetime `'static mut VM` (see above);
-        // the owned event loop lives for the VM's lifetime. Single-JS-thread
-        // invariant ⇒ callers never overlap `&mut`.
-        self.vm_mut().event_loop_mut()
+    fn event_loop(&self) -> &mut crate::jsc::EventLoop {
+        self.vm().event_loop_mut()
     }
 
     #[inline]
@@ -138,84 +142,64 @@ impl JSMySQLConnection {
     }
 }
 
-impl HasAutoFlush for JSMySQLConnection {
-    fn on_auto_flush(this: *mut Self) -> bool {
-        // `this` is the live `*mut JSMySQLConnection` registered with the
-        // deferred-task queue; the queue runs on the JS thread. R-2: deref as
-        // shared — `on_auto_flush` body takes `&self`. `ParentRef` (lifetime-
-        // erased `&T`) centralises the backref deref under its own invariant.
-        ParentRef::from(core::ptr::NonNull::new(this).expect("auto-flush ctx non-null"))
-            .on_auto_flush()
+impl AutoFlushTarget for JSMySQLConnection {
+    fn auto_flusher(&self) -> &AutoFlusher<Self> {
+        &self.auto_flusher
+    }
+
+    /// Whether to stay registered for the next drain.
+    fn on_auto_flush(this: ThisPtr<Self>) -> bool {
+        bun_core::scoped_log!(MySQLConnection, "onAutoFlush");
+        if this.connection.get().has_backpressure() {
+            // if we have backpressure, wait for onWritable
+            return false;
+        }
+
+        // drain as much as we can
+        this.drain_internal();
+
+        // if we dont have backpressure and if we still have data to send, return true otherwise return false and wait for onWritable
+        this.connection.get().can_flush()
     }
 }
 
 impl JSMySQLConnection {
     // ─── R-2 interior-mutability helpers ────────────────────────────────────
 
-    /// Mutable projection of the inner protocol connection through `&self`.
+    /// Run `f` against the inner protocol connection.
     ///
     /// `my_sql_connection::MySQLConnection` is the protocol state machine (not
-    /// itself JS-exposed); every method on it still takes `&mut self`. This is
-    /// the single audited escape hatch — callers must keep the returned borrow
-    /// short and not hold it across a call that re-enters JS and re-derives
-    /// the same connection.
+    /// itself JS-exposed); every method on it still takes `&mut self`, reached
+    /// through this closure-scoped [`JsCell::with_mut`].
     #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn connection_mut(&self) -> &mut my_sql_connection::MySQLConnection {
-        // SAFETY: R-2 single-JS-thread invariant (see `JsCell` docs). The
-        // `&mut` is fresh per call site; reentrancy through
-        // `MySQLConnection::get_js_connection()` forms a shared
-        // `&JSMySQLConnection` only.
-        unsafe { self.connection.get_mut() }
+    fn with_connection<R>(
+        &self,
+        f: impl FnOnce(&mut my_sql_connection::MySQLConnection) -> R,
+    ) -> R {
+        self.connection.with_mut(f)
     }
 
     // ────────────────────────────────────────────────────────────────────────
 
-    pub(crate) fn on_auto_flush(&self) -> bool {
-        bun_core::scoped_log!(MySQLConnection, "onAutoFlush");
-        if self.connection.get().has_backpressure() {
-            self.auto_flusher.with_mut(|a| a.registered = false);
-            // if we have backpressure, wait for onWritable
-            return false;
-        }
-
-        // drain as much as we can
-        self.drain_internal();
-
-        // if we dont have backpressure and if we still have data to send, return true otherwise return false and wait for onWritable
-        let keep_flusher_registered = self.connection.get().can_flush();
-        self.auto_flusher
-            .with_mut(|a| a.registered = keep_flusher_registered);
-        keep_flusher_registered
-    }
-
     fn register_auto_flusher(&self) {
-        if !self.auto_flusher.get().registered // should not be registered
+        if !self.auto_flusher.is_registered() // should not be registered
             && self.connection.get().can_flush()
         {
-            AutoFlusher::register_deferred_microtask_with_type_unchecked(
-                self.as_ctx_ptr(),
-                self.vm(),
-            );
-            self.auto_flusher.with_mut(|a| a.registered = true);
+            AutoFlusher::register(self.this_ptr(), self.vm());
         }
     }
 
     fn unregister_auto_flusher(&self) {
-        if self.auto_flusher.get().registered {
-            AutoFlusher::unregister_deferred_microtask_with_type(self.as_ctx_ptr(), self.vm());
-            self.auto_flusher.with_mut(|a| a.registered = false);
-        }
+        self.auto_flusher.unregister(self.vm());
     }
 
     fn stop_timers(&self) {
         bun_core::scoped_log!(MySQLConnection, "stopTimers");
         if self.timer.get().state == EventLoopTimerState::ACTIVE {
-            self.timer.with_mut(|t| self.vm_mut().timer().remove(t));
+            self.vm().timer_remove(self.timer_ref());
         }
         if self.max_lifetime_timer.get().state == EventLoopTimerState::ACTIVE {
-            self.max_lifetime_timer
-                .with_mut(|t| self.vm_mut().timer().remove(t));
+            self.vm().timer_remove(self.max_lifetime_timer_ref());
         }
     }
 
@@ -236,7 +220,7 @@ impl JSMySQLConnection {
         let interval = self.get_timeout_interval();
         bun_core::scoped_log!(MySQLConnection, "resetConnectionTimeout {}", interval);
         if self.timer.get().state == EventLoopTimerState::ACTIVE {
-            self.timer.with_mut(|t| self.vm_mut().timer().remove(t));
+            self.vm().timer_remove(self.timer_ref());
         }
         if self.connection.get().status == my_sql_connection::Status::Failed
             || self.connection.get().is_processing_data()
@@ -248,11 +232,7 @@ impl JSMySQLConnection {
         self.timer.with_mut(|t| {
             t.next = timespec::ms_from_now(TimespecMockMode::ForceRealTime, interval.into());
         });
-        // whole-struct provenance: the fire path recovers the container from this pointer.
-        let t = core::ptr::addr_of!(self.timer)
-            .cast::<EventLoopTimer>()
-            .cast_mut();
-        self.vm_mut().timer().insert(t);
+        self.vm().timer_insert(self.timer_ref());
     }
 
     pub fn on_connection_timeout(&self) {
@@ -338,11 +318,7 @@ impl JSMySQLConnection {
                 self.max_lifetime_interval_ms.into(),
             );
         });
-        // whole-struct provenance: the fire path recovers the container from this pointer.
-        let t = core::ptr::addr_of!(self.max_lifetime_timer)
-            .cast::<EventLoopTimer>()
-            .cast_mut();
-        self.vm_mut().timer().insert(t);
+        self.vm().timer_insert(self.max_lifetime_timer_ref());
     }
 
     // Exported via the `.classes.ts` codegen (`MySQLConnectionClass__construct`).
@@ -355,9 +331,9 @@ impl JSMySQLConnection {
         )))
     }
 
-    pub(crate) fn enqueue_request(&self, item: RefPtr<JSMySQLQuery>) {
+    pub(crate) fn enqueue_request(&self, item: ThisPtr<JSMySQLQuery>) {
         bun_core::scoped_log!(MySQLConnection, "enqueueRequest");
-        self.connection_mut().enqueue_request(item);
+        self.with_connection(|c| c.enqueue_request(item));
         self.reset_connection_timeout();
         self.register_auto_flusher();
     }
@@ -366,11 +342,11 @@ impl JSMySQLConnection {
         bun_core::scoped_log!(MySQLConnection, "drainInternal");
         // Raw-pointer RAII guard so no reference is live across the potential
         // free.
-        let _guard = self.ref_guard();
-        let _loop_guard = self.event_loop().entered();
+        let _ref = self.ref_guard();
+        let _loop_guard = self.vm().enter_event_loop_scope();
         self.ensure_js_value_is_alive();
         if let Err(my_sql_connection::FlushQueueError::AuthenticationFailed) =
-            self.connection_mut().flush_queue()
+            self.with_connection(|c| c.flush_queue())
         {
             self.fail(
                 b"Authentication failed",
@@ -386,6 +362,7 @@ impl JSMySQLConnection {
         }
     }
 
+    /// Runs before the JS wrapper's ref is dropped.
     pub fn finalize(&self) {
         bun_core::scoped_log!(MySQLConnection, "finalize");
         self.js_value.with_mut(|r| r.finalize());
@@ -420,15 +397,15 @@ impl JSMySQLConnection {
         global_object: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // SAFETY: JS-thread only; short-lived `&mut` to the singleton VM via raw ptr,
-        // no other live borrow in this scope.
+        // `bun_vm()` → `&'static VirtualMachine` (per-thread singleton); `as_mut()`
+        // is the canonical safe escape hatch for `mysql_socket_group()`.
         let vm = global_object.bun_vm().as_mut();
         let arguments = callframe.arguments();
-        let Some(args) = ConnectionCtorArgs::<SSLMode>::parse(global_object, &mut *vm, arguments)?
-        else {
+        let Some(args) = ConnectionCtorArgs::<SSLMode>::parse(global_object, vm, arguments)? else {
             return Ok(JSValue::ZERO);
         };
-        let (secure, tls_config) = (args.secure, args.tls_config);
+        // `secure` / `tls_config` are dropped with `args` on every early return
+        // until they move into the connection below.
 
         let path_str = arguments[8].to_bun_string(global_object)?;
 
@@ -460,13 +437,15 @@ impl JSMySQLConnection {
         let _ = use_unnamed_prepared_statements;
         let allow_public_key_retrieval = callframe.argument(15).to_boolean();
 
-        let ptr: *mut JSMySQLConnection = bun_core::heap::into_raw(Box::new(JSMySQLConnection {
+        let (secure, tls_config) = (args.secure, args.tls_config);
+
+        // The initial ref is the one the JS wrapper adopts below (or that the
+        // connect-failure path releases).
+        let initial: RefPtr<JSMySQLConnection> = RefPtr::new(JSMySQLConnection {
             ref_count: Cell::new(1),
             js_value: JsCell::new(JsRef::empty()),
             global_object: GlobalRef::from(global_object),
-            vm: BackRef::from(
-                core::ptr::NonNull::new(VirtualMachine::get_mut_ptr()).expect("vm singleton"),
-            ),
+            vm: BackRef::new(global_object.bun_vm()),
             poll_ref: JsCell::new(KeepAlive::default()),
             connection: JsCell::new(my_sql_connection::MySQLConnection::init(
                 database,
@@ -477,7 +456,7 @@ impl JSMySQLConnection {
                 args.ssl_mode,
                 allow_public_key_retrieval,
             )),
-            auto_flusher: JsCell::new(AutoFlusher::default()),
+            auto_flusher: AutoFlusher::default(),
             idle_timeout_interval_ms: u32::try_from(idle_timeout).expect("int cast"),
             connection_timeout_ms: u32::try_from(connection_timeout).expect("int cast"),
             max_lifetime_interval_ms: u32::try_from(max_lifetime).expect("int cast"),
@@ -487,12 +466,11 @@ impl JSMySQLConnection {
             max_lifetime_timer: JsCell::new(EventLoopTimer::init_paused(
                 EventLoopTimerTag::MySQLConnectionMaxLifetime,
             )),
-        }));
-        // `heap::into_raw` is `Box::into_raw` — never null. `ParentRef` wraps
-        // the freshly-boxed allocation as a lifetime-erased `&Self` (R-2: every
-        // field is interior-mutable, so shared access suffices for the writes
-        // below); we hold the only reference.
-        let this = ParentRef::from(core::ptr::NonNull::new(ptr).expect("heap::into_raw non-null"));
+            this_ptr: Cell::new(None),
+            socket_ref: Cell::new(None),
+        });
+        initial.this_ptr.set(Some(initial.this_ptr().into()));
+        let this: ThisPtr<JSMySQLConnection> = initial.this_ptr();
 
         {
             let hostname = args.hostname_str.to_utf8();
@@ -506,7 +484,7 @@ impl JSMySQLConnection {
                     uws::DispatchKind::Mysql,
                     None,
                     &path[..],
-                    ptr,
+                    this.as_ptr(),
                     false,
                 )
             } else {
@@ -516,29 +494,26 @@ impl JSMySQLConnection {
                     None,
                     hostname.slice(),
                     args.port,
-                    ptr,
+                    this.as_ptr(),
                     false,
                 )
             };
             let socket = match result {
                 Ok(s) => s,
                 Err(e) => {
-                    let _ = this;
-                    // SAFETY: `ptr` is the freshly-boxed allocation; sole owner.
-                    // `this` (a `ParentRef`) is not used past this point, so no
-                    // borrow outlives the `heap::take` inside `deinit`.
-                    unsafe { Self::deref(ptr) };
+                    // Sole owner: releasing the initial ref frees the connection.
+                    drop(initial);
                     return Err(global_object
                         .throw_error(bun_jsc::CrateError::from(e), "failed to connect to mysql"));
                 }
             };
-            this.connection_mut()
-                .set_socket(AnySocket::SocketTcp(socket));
+            this.with_connection(|c| c.set_socket(AnySocket::SocketTcp(socket)));
         }
-        this.connection_mut().status = my_sql_connection::Status::Connecting;
+        this.with_connection(|c| c.status = my_sql_connection::Status::Connecting);
         this.reset_connection_timeout();
         this.poll_ref.with_mut(|p| p.r#ref(vm.vm_ctx()));
-        let js_value = js::to_js(ptr, global_object);
+        // The JS wrapper adopts the initial ref (released by `finalize`).
+        let js_value = js::to_js(initial.into_this_ptr().as_ptr(), global_object);
         js_value.ensure_still_alive();
         this.js_value
             .with_mut(|r| r.set_strong(js_value, global_object));
@@ -573,8 +548,8 @@ impl JSMySQLConnection {
     ) -> JsResult<JSValue> {
         this.stop_timers();
 
-        // R-2: `&Self` is `Copy`, so the scopeguard closure captures a shared
-        // reborrow and the body's `connection_mut()` borrow is non-overlapping.
+        // `&Self` is `Copy`, so the scopeguard closure captures a shared
+        // reborrow and the body's `with_connection()` borrow is non-overlapping.
         scopeguard::defer! {
             this.update_reference_type();
         }
@@ -595,7 +570,7 @@ impl JSMySQLConnection {
             }
             S::Connected | S::Disconnected | S::Failed => {
                 let queries = this.get_queries_array();
-                this.connection_mut().clean_queue_and_close(None, queries);
+                this.with_connection(|c| c.clean_queue_and_close(None, queries));
             }
         }
         Ok(JSValue::UNDEFINED)
@@ -628,19 +603,19 @@ impl JSMySQLConnection {
     }
     #[inline]
     pub(crate) fn can_pipeline(&self) -> bool {
-        self.connection_mut().can_pipeline()
+        self.connection.get().queue.can_pipeline(self)
     }
     #[inline]
     pub(crate) fn can_prepare_query(&self) -> bool {
-        self.connection_mut().can_prepare_query()
+        self.connection.get().queue.can_prepare_query(self)
     }
     #[inline]
     pub(crate) fn can_execute_query(&self) -> bool {
-        self.connection_mut().can_execute_query()
+        self.connection.get().queue.can_execute_query(self)
     }
     #[inline]
     pub(crate) fn get_writer(&self) -> NewWriter<my_sql_connection::Writer> {
-        self.connection_mut().writer()
+        self.connection.get().writer()
     }
 
     fn fail_fmt(&self, error_code: AnyMySQLErrorT, args: core::fmt::Arguments<'_>) {
@@ -655,17 +630,13 @@ impl JSMySQLConnection {
     }
 
     fn fail_with_js_value(&self, value: JSValue) {
-        // Runs on every exit path. Re-enter through a raw pointer so no
-        // reference is live across the potential free in `deref()`. LIFO drop
-        // order: the `defer!` body runs first, then `_guard` releases the count.
-        let p = ParentRef::new(self);
-        let _guard = self.ref_guard();
+        // Runs on every exit path. LIFO drop order: the `defer!` body runs
+        // first, then `_ref` releases the count (which may free `self`).
+        let _ref = self.ref_guard();
         scopeguard::defer! {
-            // `_guard` has not yet dropped, so `*p` is still live; `ParentRef`
-            // yields a fresh `&Self` per access (R-2: every callee is `&self`).
-            let queries = p.get_queries_array();
-            p.connection_mut().clean_queue_and_close(Some(value), queries);
-            p.update_reference_type();
+            let queries = self.get_queries_array();
+            self.with_connection(|c| c.clean_queue_and_close(Some(value), queries));
+            self.update_reference_type();
         }
         self.stop_timers();
 
@@ -673,7 +644,7 @@ impl JSMySQLConnection {
             return;
         }
 
-        self.connection_mut().status = my_sql_connection::Status::Failed;
+        self.with_connection(|c| c.status = my_sql_connection::Status::Failed);
         let Some(on_close) = self.consume_on_close_callback(&self.global_object) else {
             return;
         };
@@ -724,53 +695,46 @@ impl JSMySQLConnection {
     pub(crate) fn on_result_row<C: bun_sql::mysql::protocol::ReaderContext>(
         &self,
         request: &JSMySQLQuery,
-        statement: &mut MySQLStatement,
+        statement: &MySQLStatement,
         reader: NewReader<C>,
     ) -> Result<(), OnResultRowError> {
         let result_mode = request.get_result_mode();
         let mut structure: JSValue = JSValue::UNDEFINED;
-        // `MySQLStatement::structure(&mut self) -> &CachedStructure`
-        // would keep `*statement` exclusively borrowed for the lifetime of the
-        // returned ref, blocking the `&statement.columns` / `fields_flags` reads
-        // below. Stash a `ParentRef` (lifetime-erased `&T`)
-        // and `as_deref` at the `to_js` call site — `*statement`
-        // outlives this fn (held via `request`'s intrusive ref), satisfying
-        // the `ParentRef` liveness invariant.
-        let cached_structure: Option<ParentRef<CachedStructure>> = match result_mode {
+        let cached_structure: Option<&CachedStructure> = match result_mode {
             ResultMode::Objects => {
                 // Build unconditionally (matches postgres) so toJS always has
                 // either a Structure or a names array.
                 let owner = self.js_value.get().try_get().unwrap_or_default();
                 let cs = statement.structure(owner, &self.global_object);
                 structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);
-                Some(ParentRef::new(cs))
+                Some(cs)
             }
             // no need to check for duplicate fields or structure
             ResultMode::Raw | ResultMode::Values => None,
         };
-        let fields_flags = statement.fields_flags;
+        let fields_flags = statement.fields_flags.get();
+        let columns = statement.columns.get();
         let mut row = ResultSet::Row {
             global_object: &self.global_object,
-            columns: &statement.columns,
+            columns,
             binary: !request.is_simple(),
             raw: result_mode == ResultMode::Raw,
             bigint: request.is_bigint_supported(),
             values: Box::default(),
+            storage: Default::default(),
         };
         if let Err(e) = row.decode(reader) {
             if e == AnyMySQLErrorT::ShortRead {
                 return Err(OnResultRowError::ShortRead);
             }
-            self.connection_mut()
+            self.connection
+                .get()
                 .queue
                 .mark_current_request_as_finished(request);
             request.reject(self.get_queries_array(), e);
             return Ok(());
         }
         let pending_value = request.get_pending_value().unwrap_or(JSValue::UNDEFINED);
-        // `ParentRef::Deref` recovers `&CachedStructure`; `*statement` is live
-        // and not mutably borrowed for the duration of this `to_js` call.
-        let cached_structure = cached_structure.as_deref();
         // Process row data
         let row_value = row
             .to_js(
@@ -782,17 +746,16 @@ impl JSMySQLConnection {
                 cached_structure,
             )
             .map_err(|_| OnResultRowError::JSError)?;
-        // `Row<'_>` has a Drop impl, so its `&statement.columns` borrow lives to
-        // end-of-scope; drop it now so `statement.result_count += 1` may take `&mut`.
         drop(row);
         if let Some(err) = self.global_object.try_take_exception() {
-            self.connection_mut()
+            self.connection
+                .get()
                 .queue
                 .mark_current_request_as_finished(request);
             request.reject_with_js_value(self.get_queries_array(), err);
             return Ok(());
         }
-        statement.result_count += 1;
+        statement.result_count.set(statement.result_count.get() + 1);
 
         if pending_value.is_empty_or_undefined_or_null() {
             request.set_pending_value(row_value);
@@ -841,12 +804,40 @@ impl JSMySQLConnection {
         }
     }
 
-    pub(crate) fn get_statement_from_signature_name(
+    /// The cached statement for `signature` plus `true` (a new ref; the
+    /// signature is dropped), or a fresh `Pending` statement built from it that
+    /// the connection's map now also references plus `false`.
+    pub(crate) fn statement_for_signature(
         &self,
-        signature_name: &[u8],
-    ) -> Result<my_sql_connection::PreparedStatementsMapGetOrPutResult<'_>, bun_core::AllocError>
-    {
-        self.connection_mut().statements.get_or_put(signature_name)
+        signature: crate::mysql::protocol::Signature,
+    ) -> Result<(RefPtr<MySQLStatement>, bool), bun_core::AllocError> {
+        self.with_connection(|c| {
+            let entry = c.statements.get_or_put(&signature.name)?;
+            if entry.found_existing {
+                let existing = entry
+                    .value_ptr
+                    .as_ref()
+                    .expect("cached statement slots are always filled");
+                return Ok((existing.clone(), true));
+            }
+            // One ref for the caller, one for the map entry.
+            let stmt = MySQLStatement::new(signature, super::my_sql_statement::Status::Pending);
+            *entry.value_ptr = Some(stmt.clone());
+            Ok((stmt, false))
+        })
+    }
+}
+
+/// Runs when the last ref is released (`CellRefCounted` reclaims the box).
+impl Drop for JSMySQLConnection {
+    fn drop(&mut self) {
+        // No refs remain; nothing below may mint one.
+        self.this_ptr.set(None);
+        self.stop_timers();
+        let ctx = self.vm_ctx();
+        self.poll_ref.with_mut(|p| p.unref(ctx));
+        self.unregister_auto_flusher();
+        self.connection.get_mut_unique().cleanup();
     }
 }
 
@@ -865,16 +856,17 @@ impl<const SSL: bool> SocketHandler<SSL> {
         }
     }
 
-    pub fn on_open(this: &JSMySQLConnection, s: NewSocketHandler<SSL>) {
+    pub fn on_open(this: ThisPtr<JSMySQLConnection>, s: NewSocketHandler<SSL>) {
         let socket = Self::socket(s);
         let is_tcp = matches!(socket, AnySocket::SocketTcp(_));
-        this.connection_mut().set_socket(socket);
+        this.with_connection(|c| c.set_socket(socket));
 
         if is_tcp {
             // This handshake is not TLS handleshake is actually the MySQL handshake
             // When a connection is upgraded to TLS, the onOpen callback is called again and at this moment we dont wanna to change the status to handshaking
-            this.connection_mut().status = my_sql_connection::Status::Handshaking;
-            this.ref_(); // keep a ref for the socket
+            this.with_connection(|c| c.status = my_sql_connection::Status::Handshaking);
+            // keep a ref for the socket
+            this.socket_ref.set(Some(RefPtr::from_this(this)));
         }
         // Only set up the timers after all status changes are complete — the timers rely on the status to determine timeouts.
         this.setup_max_lifetime_timer_if_necessary();
@@ -883,18 +875,18 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     fn on_handshake(
-        this: &JSMySQLConnection,
+        this: ThisPtr<JSMySQLConnection>,
         _: NewSocketHandler<SSL>,
         success: i32,
         ssl_error: uws::us_bun_verify_error_t,
     ) {
-        let handshake_was_successful = match this.connection_mut().do_handshake(success, ssl_error)
-        {
-            Ok(v) => v,
-            Err(e) => {
-                return this.fail_fmt(e, format_args!("Failed to send handshake response"));
-            }
-        };
+        let handshake_was_successful =
+            match this.with_connection(|c| c.do_handshake(success, ssl_error)) {
+                Ok(v) => v,
+                Err(e) => {
+                    return this.fail_fmt(e, format_args!("Failed to send handshake response"));
+                }
+            };
         if !handshake_was_successful {
             let v = crate::jsc::verify_error_to_js(&ssl_error, &this.global_object);
             this.fail_with_js_value(v);
@@ -902,23 +894,24 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     pub const ON_HANDSHAKE: Option<
-        fn(&JSMySQLConnection, NewSocketHandler<SSL>, i32, uws::us_bun_verify_error_t),
+        fn(ThisPtr<JSMySQLConnection>, NewSocketHandler<SSL>, i32, uws::us_bun_verify_error_t),
     > = if SSL { Some(Self::on_handshake) } else { None };
 
     pub fn on_close(
-        this: &JSMySQLConnection,
+        this: ThisPtr<JSMySQLConnection>,
         _: NewSocketHandler<SSL>,
         _: i32,
         _: Option<*mut c_void>,
     ) {
-        // Takes over the socket ref taken in on_open.
-        // SAFETY: `this` is live and that ref is outstanding.
-        let _guard = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
+        // Releases the socket ref taken in on_open at scope end (which may
+        // free the connection).
+        let _ref = this.socket_ref.take();
         // usockets frees this socket at end-of-tick; drop the stored pointer
         // now so nothing (timer callbacks, do_close) dereferences it after
         // the free.
-        this.connection_mut()
-            .set_socket(AnySocket::SocketTcp(SocketTCP::detached()));
+        this.with_connection(|c| c.set_socket(AnySocket::SocketTcp(SocketTCP::detached())));
+        // Nothing left to flush to.
+        this.unregister_auto_flusher();
         // A close before the handshake finished means the server (or an
         // intermediary like a container port proxy) accepted the TCP
         // connection but went away before completing startup — e.g. the
@@ -942,50 +935,44 @@ impl<const SSL: bool> SocketHandler<SSL> {
         this.fail(message, err);
     }
 
-    pub fn on_end(_: &JSMySQLConnection, socket: NewSocketHandler<SSL>) {
+    pub fn on_end(_: ThisPtr<JSMySQLConnection>, socket: NewSocketHandler<SSL>) {
         // no half closed sockets
         socket.close(uws::CloseKind::Normal);
     }
 
-    pub fn on_connect_error(this: &JSMySQLConnection, _: NewSocketHandler<SSL>, _: i32) {
+    pub fn on_connect_error(this: ThisPtr<JSMySQLConnection>, _: NewSocketHandler<SSL>, _: i32) {
         // The dispatch trampoline already closed the connecting socket; it is
         // freed at end-of-tick, so detach before any user-visible callback.
-        this.connection_mut()
-            .set_socket(AnySocket::SocketTcp(SocketTCP::detached()));
+        this.with_connection(|c| c.set_socket(AnySocket::SocketTcp(SocketTCP::detached())));
         this.fail(b"Failed to connect", AnyMySQLErrorT::ConnectionRefused);
     }
 
-    pub fn on_timeout(this: &JSMySQLConnection, _: NewSocketHandler<SSL>) {
+    pub fn on_timeout(this: ThisPtr<JSMySQLConnection>, _: NewSocketHandler<SSL>) {
         this.fail(b"Connection timeout", AnyMySQLErrorT::ConnectionTimedOut);
     }
 
-    pub fn on_data(this: &JSMySQLConnection, _: NewSocketHandler<SSL>, data: &[u8]) {
-        // Both guards re-enter via raw pointer so no reference is live across
-        // the potential free. Guard drop order is LIFO, so `_guard` (deref) runs
-        // last.
-        let p = ParentRef::new(this);
-        let _guard = this.ref_guard();
+    pub fn on_data(this: ThisPtr<JSMySQLConnection>, _: NewSocketHandler<SSL>, data: &[u8]) {
+        // Guard drop order is LIFO, so `_ref` (deref, which may free the
+        // connection) runs last.
+        let _ref = this.ref_guard();
 
         scopeguard::defer! {
-            // `_guard` has not yet dropped, so `*p` is still live; `ParentRef`
-            // yields a fresh `&JSMySQLConnection` per access (R-2: every
-            // callee is `&self`).
-            if p.connection.get().status == my_sql_connection::Status::Connected {
-                p.reset_connection_timeout();
+            if this.connection.get().status == my_sql_connection::Status::Connected {
+                this.reset_connection_timeout();
             }
-            p.update_reference_type();
-            p.register_auto_flusher();
+            this.update_reference_type();
+            this.register_auto_flusher();
         }
-        let _loop_guard = this.event_loop().entered();
+        let _loop_guard = this.vm().enter_event_loop_scope();
         this.ensure_js_value_is_alive();
 
-        if let Err(e) = this.connection_mut().read_and_process_data(data) {
+        if let Err(e) = this.with_connection(|c| c.read_and_process_data(data)) {
             this.on_error(None, e);
         }
     }
 
-    pub fn on_writable(this: &JSMySQLConnection, _: NewSocketHandler<SSL>) {
-        this.connection_mut().reset_backpressure();
+    pub fn on_writable(this: ThisPtr<JSMySQLConnection>, _: NewSocketHandler<SSL>) {
+        this.with_connection(|c| c.reset_backpressure());
         this.drain_internal();
     }
 }

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -1,14 +1,13 @@
 use core::cell::Cell;
-use core::ptr::NonNull;
 
 use crate::jsc::codegen::{js_mysql_connection, js_mysql_query as js};
 use crate::jsc::{
-    self as jsc, CallFrame, JSGlobalObject, JSGlobalObjectSqlExt as _, JSValue, JsRef, JsResult,
-    VirtualMachine, VirtualMachineSqlExt as _,
+    self as jsc, CallFrame, JSGlobalObject, JSValue, JsRef, JsResult, VirtualMachine,
+    VirtualMachineSqlExt as _,
 };
 use crate::shared::query_ctor_args::QueryCtorArgs;
 use bun_jsc::JsCell;
-use bun_ptr::{AsCtxPtr, BackRef, ParentRef, RefPtr};
+use bun_ptr::{BackRef, RefPtr, ThisPtr};
 use bun_sql::mysql::MySQLQueryResult;
 use bun_sql::mysql::protocol::any_mysql_error::{self as AnyMySQLError};
 use bun_sql::postgres::command_tag::CommandTag;
@@ -45,14 +44,28 @@ pub struct JSMySQLQuery {
     vm: BackRef<VirtualMachine>,
     global_object: BackRef<JSGlobalObject>,
     query: JsCell<MySQLQuery>,
+    /// This allocation's root pointer, for the `&self` paths that take refs
+    /// on it (`ref_guard`, the connection's request queue).
+    this_ptr: Cell<Option<BackRef<JSMySQLQuery, bun_ptr::Root>>>,
 }
 
+// Intrusive refcount (`CellRefCounted`): held as `RefPtr` (request queue, JS
+// wrapper) / `ref_guard()`; the last release drops the box (`Drop` below).
+
 impl JSMySQLQuery {
-    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
+    /// This allocation's root pointer (see the `this_ptr` field).
     #[inline]
-    pub(crate) fn ref_guard(&self) -> RefPtr<Self> {
-        // SAFETY: `self` is the live heap allocation.
-        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
+    pub(crate) fn this_ptr(&self) -> ThisPtr<Self> {
+        self.this_ptr
+            .get()
+            .expect("JSMySQLQuery used before create_instance")
+            .this_ptr()
+    }
+
+    /// Holds a ref on `self` for the guard's scope.
+    #[inline]
+    pub(crate) fn ref_guard(&self) -> bun_ptr::RefPtr<Self> {
+        bun_ptr::RefPtr::from_this(self.this_ptr())
     }
 
     pub fn estimated_size(&self) -> usize {
@@ -68,6 +81,7 @@ impl JSMySQLQuery {
             .throw_invalid_arguments(format_args!("MySQLQuery cannot be constructed directly")))
     }
 
+    /// Runs before the JS wrapper's ref is dropped.
     pub fn finalize(&self) {
         debug!("MySQLQuery finalize");
         self.this_value.with_mut(|v| v.finalize());
@@ -87,26 +101,23 @@ impl JSMySQLQuery {
             simple,
         } = QueryCtorArgs::parse(global_this, callframe.arguments())?;
 
-        let this_ptr = bun_core::heap::into_raw(Box::new(Self {
+        // The initial ref is the one the JS wrapper adopts below.
+        let this: ThisPtr<Self> = RefPtr::new(Self {
             this_value: JsCell::new(JsRef::empty()),
             ref_count: Cell::new(1),
-            // Stored with full write provenance for later `&mut *p` at use sites.
-            vm: BackRef::from(
-                NonNull::new(global_this.sql_vm_ptr()).expect("sql_vm_ptr() is non-null"),
-            ),
+            vm: BackRef::new(global_this.bun_vm()),
             global_object: BackRef::new(global_this),
             query: JsCell::new(MySQLQuery::init(
                 query.to_bun_string(global_this)?,
                 bigint,
                 simple,
             )),
-        }));
-        // `heap::into_raw` is `Box::into_raw` — never null. Uniquely owned here
-        // until handed to the JS wrapper. R-2: every field is interior-mutable,
-        // so a shared `ParentRef` deref is sufficient even for the writes below.
-        let this = ParentRef::from(NonNull::new(this_ptr).expect("heap::into_raw non-null"));
+            this_ptr: Cell::new(None),
+        })
+        .into_this_ptr();
+        this.this_ptr.set(Some(this.into()));
 
-        let this_value = js::to_js(this_ptr, global_this);
+        let this_value = js::to_js(this.as_ptr(), global_this);
         this_value.ensure_still_alive();
         this.this_value.with_mut(|v| v.set_weak(this_value));
 
@@ -156,7 +167,7 @@ impl JSMySQLQuery {
             }
             return Err(jsc::JsError::Thrown);
         }
-        connection.enqueue_request(this.ref_guard());
+        connection.enqueue_request(this.this_ptr());
         Ok(JSValue::UNDEFINED)
     }
 
@@ -248,11 +259,8 @@ impl JSMySQLQuery {
         js_tag.ensure_still_alive();
 
         let Some(function) = self
-            .vm_mut()
-            .sql_state()
-            .mysql_context
-            .on_query_resolve_fn
-            .get()
+            .vm()
+            .with_sql_state(|s| s.mysql_context.on_query_resolve_fn.get())
         else {
             return;
         };
@@ -336,11 +344,8 @@ impl JSMySQLQuery {
         debug_assert!(!js_error.is_empty(), "js_error is zero");
         js_error.ensure_still_alive();
         let Some(function) = self
-            .vm_mut()
-            .sql_state()
-            .mysql_context
-            .on_query_reject_fn
-            .get()
+            .vm()
+            .with_sql_state(|s| s.mysql_context.on_query_reject_fn.get())
         else {
             return;
         };
@@ -446,12 +451,12 @@ impl JSMySQLQuery {
         self.query.get().get_result_mode()
     }
     // TODO: isolate statement modification away from the connection
-    pub(crate) fn get_statement(&self) -> Option<&mut MySQLStatement> {
+    pub(crate) fn get_statement(&self) -> Option<&MySQLStatement> {
         self.query.get().get_statement()
     }
 
     pub(crate) fn mark_as_prepared(&self) {
-        self.query.with_mut(|q| q.mark_as_prepared());
+        self.query.get().mark_as_prepared();
     }
 
     #[inline]
@@ -514,10 +519,6 @@ impl JSMySQLQuery {
     fn vm(&self) -> &VirtualMachine {
         self.vm.get()
     }
-    #[inline]
-    fn vm_mut(&self) -> &'static mut VirtualMachine {
-        VirtualMachine::get_mut()
-    }
     /// `&mut EventLoop` for `run_callback`. Routes through the inherent safe
     /// `VirtualMachine::event_loop_mut` accessor — the loop is a disjoint heap
     /// allocation owned by the JS-thread VM singleton stored in `self.vm`;
@@ -529,6 +530,14 @@ impl JSMySQLQuery {
     #[inline]
     fn global_object(&self) -> &JSGlobalObject {
         self.global_object.get()
+    }
+}
+
+/// Runs when the last ref is released (`CellRefCounted` reclaims the box).
+impl Drop for JSMySQLQuery {
+    fn drop(&mut self) {
+        self.this_ptr.set(None);
+        self.query.get_mut_unique().cleanup();
     }
 }
 

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -1,6 +1,9 @@
-use crate::jsc::{JSValue, VirtualMachineSqlExt as _};
+use core::cell::Cell;
+
+use crate::jsc::{JSValue, JsCell, VirtualMachineSqlExt as _};
 use bun_boringssl_sys::OwnedSslCtx;
 use bun_collections::{OffsetByteList, StringHashMap, VecExt};
+use bun_ptr::{BackRef, RefPtr, ThisPtr};
 use bun_uws::{self as uws, AnySocket as Socket};
 
 use bun_sql::mysql::Capabilities;
@@ -41,7 +44,6 @@ use crate::mysql::js_mysql_connection::JSMySQLConnection;
 use crate::mysql::js_mysql_query::JSMySQLQuery;
 use crate::mysql::my_sql_request_queue::MySQLRequestQueue;
 use crate::mysql::my_sql_statement::{self as mysql_statement, MySQLStatement, Param};
-use bun_ptr::RefPtr;
 
 pub use bun_sql::mysql::protocol::error_packet::ErrorPacket;
 // Re-export so callers can write `my_sql_connection::Status::Connected`
@@ -56,9 +58,11 @@ pub struct MySQLConnection {
     socket: Socket,
     pub(crate) status: ConnectionState,
 
-    write_buffer: OffsetByteList,
-    read_buffer: OffsetByteList,
-    last_message_start: u32,
+    // `JsCell`/`Cell`: also reached through the `Writer` / `Reader` adapters
+    // while a `&mut self` method is running.
+    write_buffer: JsCell<OffsetByteList>,
+    read_buffer: JsCell<OffsetByteList>,
+    last_message_start: Cell<u32>,
     sequence_id: u8,
 
     // TODO: move it to JSMySQLConnection
@@ -94,9 +98,9 @@ impl Default for MySQLConnection {
         Self {
             socket: Socket::SocketTcp(uws::SocketTCP::detached()),
             status: ConnectionState::Disconnected,
-            write_buffer: OffsetByteList::default(),
-            read_buffer: OffsetByteList::default(),
-            last_message_start: 0,
+            write_buffer: JsCell::new(OffsetByteList::default()),
+            read_buffer: JsCell::new(OffsetByteList::default()),
+            last_message_start: Cell::new(0),
             sequence_id: 0,
             queue: MySQLRequestQueue::init(),
             statements: PreparedStatementsMap::default(),
@@ -125,7 +129,7 @@ impl Default for MySQLConnection {
 
 // SAFETY: `MySQLConnection` is the `connection` field embedded inside
 // `JSMySQLConnection`; never constructed standalone.
-bun_core::impl_field_parent! { MySQLConnection => JSMySQLConnection.connection; fn js_connection_ref; fn mut get_js_connection; }
+bun_core::impl_field_parent! { MySQLConnection => JSMySQLConnection.connection; fn js_connection_ref; }
 
 impl MySQLConnection {
     pub(crate) fn init(
@@ -158,36 +162,11 @@ impl MySQLConnection {
         }
     }
 
-    pub(crate) fn can_pipeline(&mut self) -> bool {
-        let js_connection = self.js_connection_ref();
-        js_connection
-            .connection
-            .get()
-            .queue
-            .can_pipeline(js_connection)
-    }
-    pub(crate) fn can_prepare_query(&mut self) -> bool {
-        let js_connection = self.js_connection_ref();
-        js_connection
-            .connection
-            .get()
-            .queue
-            .can_prepare_query(js_connection)
-    }
-    pub(crate) fn can_execute_query(&mut self) -> bool {
-        let js_connection = self.js_connection_ref();
-        js_connection
-            .connection
-            .get()
-            .queue
-            .can_execute_query(js_connection)
-    }
-
     #[inline]
     pub(crate) fn is_able_to_write(&self) -> bool {
         self.status == ConnectionState::Connected
             && !self.flags.contains(ConnectionFlags::HAS_BACKPRESSURE)
-            && (self.write_buffer.len() as usize) < MAX_PIPELINE_SIZE
+            && (self.write_buffer.get().len() as usize) < MAX_PIPELINE_SIZE
     }
 
     #[inline]
@@ -208,7 +187,7 @@ impl MySQLConnection {
         !self.flags.contains(ConnectionFlags::HAS_BACKPRESSURE) // if has backpressure we need to wait for onWritable event
             && self.status == ConnectionState::Connected // and we need to be connected
             // we need data to send
-            && (self.write_buffer.len() > 0
+            && (self.write_buffer.get().len() > 0
                 || self
                     .queue
                     .current()
@@ -217,11 +196,11 @@ impl MySQLConnection {
 
     #[inline]
     pub(crate) fn is_idle(&self) -> bool {
-        self.queue.current().is_none() && self.write_buffer.len() == 0
+        self.queue.current().is_none() && self.write_buffer.get().len() == 0
     }
 
     #[inline]
-    pub(crate) fn enqueue_request(&mut self, request: RefPtr<JSMySQLQuery>) {
+    pub(crate) fn enqueue_request(&mut self, request: ThisPtr<JSMySQLQuery>) {
         self.queue.add(request);
     }
 
@@ -239,20 +218,11 @@ impl MySQLConnection {
         Ok(())
     }
 
-    /// reshaped for borrowck — `self.queue.advance(js_connection)`
-    /// would alias `&mut self.queue` with `&mut JSMySQLConnection` (which
-    /// embeds `self`). Route through a single raw root:
-    /// `MySQLRequestQueue::advance` takes only `*mut JSMySQLConnection` and
-    /// reaches the queue via `ParentRef`/`JsCell` shared borrows (all queue
-    /// fields are interior-mutable), so no `&mut` to the queue bytes is ever
-    /// materialised concurrently with the connection backref.
+    /// `MySQLRequestQueue::advance` takes the embedding `JSMySQLConnection`
+    /// and reaches the queue through it (all queue fields are interior-mutable),
+    /// so no `&mut` to the queue is materialised alongside the connection.
     fn advance(&mut self) {
-        let js_connection = self.get_js_connection();
-        // `js_connection` is the `@fieldParentPtr` of `self` — non-null, live,
-        // full-allocation provenance. advance() only forms shared borrows of it
-        // (queue mutation goes through `Cell`/`JsCell`); the raw pointer is
-        // wrapped via the safe `ParentRef::from(NonNull)` inside.
-        MySQLRequestQueue::advance(js_connection);
+        MySQLRequestQueue::advance(self.js_connection_ref());
     }
 
     fn flush_data(&mut self) {
@@ -262,7 +232,8 @@ impl MySQLConnection {
             return;
         }
 
-        let chunk = self.write_buffer.remaining();
+        let write_buffer = self.write_buffer.get();
+        let chunk = write_buffer.remaining();
         if chunk.is_empty() {
             return;
         }
@@ -277,13 +248,13 @@ impl MySQLConnection {
             let wrote_usize = usize::try_from(wrote).expect("int cast");
             SocketMonitor::write(&chunk[0..wrote_usize]);
             self.write_buffer
-                .consume(u32::try_from(wrote_usize).expect("int cast"));
+                .with_mut(|b| b.consume(u32::try_from(wrote_usize).expect("int cast")));
         }
     }
 
     pub(crate) fn close(&mut self) {
         self.socket.close(uws::CloseKind::Normal);
-        self.write_buffer = OffsetByteList::default();
+        self.write_buffer.set(OffsetByteList::default());
     }
 
     pub(crate) fn clean_queue_and_close(
@@ -304,6 +275,22 @@ impl MySQLConnection {
         self.close();
     }
 
+    pub(crate) fn cleanup(&mut self) {
+        let _queue = core::mem::replace(&mut self.queue, MySQLRequestQueue::init());
+        // _queue dropped at scope exit
+        let _write_buffer = core::mem::take(&mut self.write_buffer);
+        let _read_buffer = core::mem::take(&mut self.read_buffer);
+        let statements = core::mem::take(&mut self.statements);
+        let _tls_config = core::mem::take(&mut self.tls_config);
+
+        // The map holds a ref on every cached prepared statement.
+        drop(statements);
+
+        self.auth_data = Vec::new();
+        // Releases our `SSL_CTX` ref.
+        self.secure = None;
+    }
+
     pub(crate) fn upgrade_to_tls(&mut self) -> Result<(), FlushQueueError> {
         // Only adopt if we're currently a plain TCP socket.
         let Socket::SocketTcp(tcp) = &self.socket else {
@@ -319,32 +306,22 @@ impl MySQLConnection {
             .as_mut()
             .mysql_socket_group::<true>();
 
-        // SAFETY: `secure` is set to a live `SSL_CTX*` before TLS upgrade is
-        // requested.
-        let ssl_ctx = unsafe {
-            &mut *self
-                .secure
+        let ssl_ctx = bun_boringssl_sys::SSL_CTX::opaque_mut(
+            self.secure
                 .as_ref()
                 .expect("secure SSL_CTX must be set before upgradeToTLS")
-                .as_ptr()
-        };
-        let server_name = self.tls_config.server_name();
-        let sni = if server_name.is_null() {
-            None
-        } else {
-            // SAFETY: `server_name` is a NUL-terminated C string owned by
-            // `tls_config` for the connection lifetime.
-            Some(unsafe { bun_core::ffi::cstr(server_name) })
-        };
-        // `Option<NonNull<T>>` is an 8-byte null-niche optional; using
+                .as_ptr(),
+        );
+        let sni = self.tls_config.server_name();
+        // `Option<ThisPtr<T>>` is an 8-byte null-niche optional; using
         // `Option<*mut T>` here would request 16 bytes (separate discriminant)
         // and desync with the trampoline reader (uws_handlers.rs) which reads
-        // the slot as `Option<NonNull<_>>`.
-        let ext_size = core::mem::size_of::<Option<core::ptr::NonNull<JSMySQLConnection>>>() as i32;
+        // the slot as `Option<ThisPtr<_>>`.
+        let ext_size = core::mem::size_of::<Option<ThisPtr<JSMySQLConnection>>>() as i32;
 
-        // SAFETY: `raw` is a live connected `us_socket_t*`; adopt_tls may
-        // realloc and return a different ptr.
-        let Some(new_socket) = (unsafe { &mut *raw }).adopt_tls(
+        // `raw` is a live connected `us_socket_t*`; adopt_tls may realloc and
+        // return a different ptr.
+        let Some(new_socket) = uws::us_socket_t::opaque_mut(raw).adopt_tls(
             tls_group,
             bun_uws::SocketKind::MysqlTls,
             ssl_ctx,
@@ -358,15 +335,12 @@ impl MySQLConnection {
             return Err(FlushQueueError::AuthenticationFailed);
         };
 
-        let js_connection = self.get_js_connection();
+        let js_connection = self.js_connection_ref().this_ptr();
         let new_socket = new_socket.as_ptr();
-        // SAFETY: `new_socket` is a live us_socket_t freshly returned by
-        // `adopt_tls`; ext storage was sized for
-        // `Option<NonNull<JSMySQLConnection>>` above. One `&mut` reborrow
-        // drives both safe inherent methods (`ext` / `start_tls_handshake`).
-        let sock = unsafe { &mut *new_socket };
-        *sock.ext::<Option<core::ptr::NonNull<JSMySQLConnection>>>() =
-            core::ptr::NonNull::new(js_connection);
+        // `new_socket` is a live us_socket_t freshly returned by `adopt_tls`;
+        // ext storage was sized for `Option<ThisPtr<JSMySQLConnection>>` above.
+        let sock = uws::us_socket_t::opaque_mut(new_socket);
+        *sock.ext::<Option<ThisPtr<JSMySQLConnection>>>() = Some(js_connection);
         self.socket = Socket::SocketTls(uws::SocketTLS {
             socket: uws::InternalSocket::Connected(new_socket),
         });
@@ -419,27 +393,14 @@ impl MySQLConnection {
                         // match the intended host. Absence of a configured server name is
                         // not a license to skip the check — fail closed.
                         if self.ssl_mode == SSLMode::VerifyFull {
-                            let servername = self.tls_config.server_name();
-                            if servername.is_null() {
+                            let Some(servername) = self.tls_config.server_name() else {
                                 self.tls_status = TLSStatus::SslFailed;
                                 return Ok(false);
-                            }
-                            // SAFETY: native handle of a connected TLS socket is `SSL*`.
-                            let ssl_ptr: *mut bun_boringssl_sys::SSL = self
-                                .socket
-                                .get_native_handle()
-                                .map(|h| h.cast())
-                                .unwrap_or(core::ptr::null_mut());
-                            // SAFETY: `server_name` is a NUL-terminated C string owned by
-                            // `tls_config` for the connection lifetime.
-                            let hostname = unsafe { bun_core::ffi::cstr(servername) }.to_bytes();
-                            if ssl_ptr.is_null()
-                                || !bun_boringssl::check_server_identity(
-                                    // SAFETY: `ssl_ptr` is non-null (checked by the short-circuit above) and live (handshake just succeeded).
-                                    unsafe { &mut *ssl_ptr },
-                                    hostname,
-                                )
-                            {
+                            };
+                            let hostname = servername.to_bytes();
+                            if !self.socket.ssl_mut().is_some_and(|ssl| {
+                                bun_boringssl::check_server_identity(ssl, hostname)
+                            }) {
                                 self.tls_status = TLSStatus::SslFailed;
                                 return Ok(false);
                             }
@@ -467,7 +428,7 @@ impl MySQLConnection {
 
         SocketMonitor::read(data);
 
-        if self.read_buffer.remaining().is_empty() {
+        if self.read_buffer.get().remaining().is_empty() {
             // StackReader takes `&Cell<usize>` (interior mutability)
             // so the post-error read of `offset`/`consumed` doesn't conflict.
             let consumed = core::cell::Cell::new(0usize);
@@ -489,12 +450,13 @@ impl MySQLConnection {
                             data.len()
                         );
 
-                        self.read_buffer.head = 0;
-                        self.last_message_start = 0;
-                        self.read_buffer.byte_list.clear();
-                        self.read_buffer
-                            .write(&data[offset.get()..])
-                            .unwrap_or_else(|_| panic!("failed to write to read buffer"));
+                        self.last_message_start.set(0);
+                        self.read_buffer.with_mut(|rb| {
+                            rb.head = 0;
+                            rb.byte_list.clear();
+                            rb.write(&data[offset.get()..])
+                                .unwrap_or_else(|_| panic!("failed to write to read buffer"));
+                        });
                     } else {
                         bun_core::handle_error_return_trace(err);
                         self.flags.remove(ConnectionFlags::IS_PROCESSING_DATA);
@@ -507,14 +469,14 @@ impl MySQLConnection {
         }
 
         {
-            self.read_buffer.head = self.last_message_start;
-
-            self.read_buffer
-                .write(data)
-                .unwrap_or_else(|_| panic!("failed to write to read buffer"));
-            // reshaped for borrowck — `self.process_packets(self.buffered_reader())`
-            // borrows `&mut self` twice. Construct the reader first; it holds a
-            // `*mut Self` so the second borrow doesn't conflict.
+            let last_message_start = self.last_message_start.get();
+            self.read_buffer.with_mut(|rb| {
+                rb.head = last_message_start;
+                rb.write(data)
+                    .unwrap_or_else(|_| panic!("failed to write to read buffer"));
+            });
+            // The reader holds back-references to the `read_buffer` /
+            // `last_message_start` cells, so it does not borrow `self`.
             let reader = self.buffered_reader();
             match self.process_packets(reader) {
                 Ok(()) => {}
@@ -530,9 +492,9 @@ impl MySQLConnection {
                         bun_core::scoped_log!(
                             MySQLConnection,
                             "Received short read: last_message_start: {}, head: {}, len: {}",
-                            self.last_message_start,
-                            self.read_buffer.head,
-                            self.read_buffer.byte_list.len()
+                            self.last_message_start.get(),
+                            self.read_buffer.get().head,
+                            self.read_buffer.get().byte_list.len()
                         );
                     }
 
@@ -541,8 +503,8 @@ impl MySQLConnection {
                 }
             }
 
-            self.last_message_start = 0;
-            self.read_buffer.head = 0;
+            self.last_message_start.set(0);
+            self.read_buffer.with_mut(|rb| rb.head = 0);
         }
         self.flags.remove(ConnectionFlags::IS_PROCESSING_DATA);
         Ok(())
@@ -1017,7 +979,7 @@ impl MySQLConnection {
             // MySQLStatement intrusive ref_/deref_ (bun_ptr) is deliberately
             // skipped here; the queue's ref on `request` keeps the statement
             // alive for the duration of this call.
-            match statement.status {
+            match statement.status.get() {
                 mysql_statement::Status::Pending => {
                     return Err(AnyMySQLError::UnexpectedPacket);
                 }
@@ -1034,13 +996,16 @@ impl MySQLConnection {
                     // message bytes into an owned packet up front — re-entrant
                     // JS in `on_error_packet` may release the statement, so
                     // the packet handed to it must not borrow into it.
-                    let error_response = ErrorPacket {
-                        header: statement.error_response.header,
-                        error_code: statement.error_response.error_code,
-                        sql_state_marker: statement.error_response.sql_state_marker,
-                        sql_state: statement.error_response.sql_state,
-                        error_message: Data::create(statement.error_response.error_message.slice())
-                            .unwrap_or(Data::Empty),
+                    let error_response = {
+                        let e = statement.error_response.get();
+                        ErrorPacket {
+                            header: e.header,
+                            error_code: e.error_code,
+                            sql_state_marker: e.sql_state_marker,
+                            sql_state: e.sql_state,
+                            error_message: Data::create(e.error_message.slice())
+                                .unwrap_or(Data::Empty),
+                        }
                     };
                     // The queue flush is an explicit call after
                     // `on_error_packet` below.
@@ -1048,10 +1013,9 @@ impl MySQLConnection {
                     self.queue.mark_as_ready_for_query();
                     self.queue.mark_current_request_as_finished(request);
                     // R-2: `on_error_packet` is `&self`; route through the
-                    // audited `js_connection_ref()` container_of accessor (one
-                    // centralised unsafe). `*self` sits inside the parent's
-                    // `JsCell`, so re-entrant `connection_mut()` does not alias
-                    // this outer shared borrow.
+                    // audited `js_connection_ref()` container_of accessor.
+                    // `*self` sits inside the parent's `JsCell`, so re-entrant
+                    // `with_connection()` does not alias this outer shared borrow.
                     self.js_connection_ref()
                         .on_error_packet(Some(request), &error_response);
                     let _ = self.flush_queue();
@@ -1151,18 +1115,19 @@ impl MySQLConnection {
         Ok(())
     }
 
-    pub(crate) fn writer(&mut self) -> NewWriter<Writer> {
+    pub(crate) fn writer(&self) -> NewWriter<Writer> {
         NewWriter {
             wrapped: Writer {
-                connection: std::ptr::from_mut::<Self>(self),
+                write_buffer: BackRef::new(&self.write_buffer),
             },
         }
     }
 
-    pub(crate) fn buffered_reader(&mut self) -> NewReader<Reader> {
+    pub(crate) fn buffered_reader(&self) -> NewReader<Reader> {
         NewReader {
             wrapped: Reader {
-                connection: std::ptr::from_mut::<Self>(self),
+                read_buffer: BackRef::new(&self.read_buffer),
+                last_message_start: BackRef::new(&self.last_message_start),
             },
         }
     }
@@ -1226,19 +1191,19 @@ impl MySQLConnection {
             })
     }
 
-    fn check_if_prepared_statement_is_done(&mut self, statement: &mut MySQLStatement) {
+    fn check_if_prepared_statement_is_done(&mut self, statement: &MySQLStatement) {
         bun_core::scoped_log!(
             MySQLConnection,
             "checkIfPreparedStatementIsDone: {} {} {} {}",
-            statement.columns_received,
-            statement.params_received,
-            statement.columns.len(),
-            statement.params.len()
+            statement.columns_received.get(),
+            statement.params_received.get(),
+            statement.columns.get().len(),
+            statement.params.get().len()
         );
-        if statement.columns_received as usize == statement.columns.len()
-            && statement.params_received as usize == statement.params.len()
+        if statement.columns_received.get() as usize == statement.columns.get().len()
+            && statement.params_received.get() as usize == statement.params.get().len()
         {
-            statement.status = mysql_statement::Status::Prepared;
+            statement.status.set(mysql_statement::Status::Prepared);
             self.flags.remove(ConnectionFlags::WAITING_TO_PREPARE);
             self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
             self.queue.mark_as_ready_for_query();
@@ -1266,15 +1231,14 @@ impl MySQLConnection {
         let _request_guard = request.ref_guard();
         // `ThisPtr::get` borrows the local `request` (Copy), not `*self`.
         let request: &JSMySQLQuery = request.get();
-        // `get_statement()` derefs the intrusive `*mut MySQLStatement` held by
-        // the request (separate heap allocation, never aliases `*self`); the
-        // returned `&mut` is rooted in the local `ThisPtr`, not `self.queue`,
+        // The statement is a separate heap allocation held by the request's
+        // ref; the borrow is rooted in the local `request`, not `self.queue`,
         // so `&mut self` calls below do not conflict.
         let Some(statement) = request.get_statement() else {
             debug!("Unexpected prepared statement packet missing statement");
             return Err(AnyMySQLError::UnexpectedPacket);
         };
-        if statement.statement_id > 0 {
+        if statement.statement_id.get() > 0 {
             // In legacy protocol (CLIENT_DEPRECATE_EOF not negotiated), the server sends
             // intermediate EOF packets between param definitions and column definitions,
             // and after column definitions. We must consume these EOF packets and only
@@ -1292,18 +1256,27 @@ impl MySQLConnection {
                 return Ok(());
             }
             let extended_type_info = self.mariadb_capabilities.MARIADB_CLIENT_EXTENDED_TYPE_INFO;
-            if (statement.params_received as usize) < statement.params.len() {
+            let params_received = statement.params_received.get() as usize;
+            let columns_received = statement.columns_received.get() as usize;
+            if params_received < statement.params.get().len() {
                 let mut column = ColumnDefinition41::default();
                 column.decode(&mut reader, extended_type_info)?;
-                statement.params[statement.params_received as usize] = Param {
-                    r#type: column.column_type,
-                    flags: column.flags,
-                };
-                statement.params_received += 1;
-            } else if (statement.columns_received as usize) < statement.columns.len() {
-                statement.columns[statement.columns_received as usize]
-                    .decode(&mut reader, extended_type_info)?;
-                statement.columns_received += 1;
+                statement.params.with_mut(|params| {
+                    params[params_received] = Param {
+                        r#type: column.column_type,
+                        flags: column.flags,
+                    }
+                });
+                statement
+                    .params_received
+                    .set(statement.params_received.get() + 1);
+            } else if columns_received < statement.columns.get().len() {
+                statement.columns.with_mut(|columns| {
+                    columns[columns_received].decode(&mut reader, extended_type_info)
+                })?;
+                statement
+                    .columns_received
+                    .set(statement.columns_received.get() + 1);
             }
             // In CLIENT_DEPRECATE_EOF mode, there are no trailing EOF packets, so
             // we check completion after each column/param definition. In legacy mode,
@@ -1325,27 +1298,31 @@ impl MySQLConnection {
 
                 // Get the current request
 
-                statement.statement_id = ok.statement_id;
+                statement.statement_id.set(ok.statement_id);
 
                 // Read parameter definitions if any
                 if ok.num_params > 0 {
                     // Slots are overwritten as param-definition packets
                     // arrive, so the initial value is a placeholder.
-                    statement.params = (0..ok.num_params as usize)
-                        .map(|_| Param {
-                            r#type: FieldType::MYSQL_TYPE_NULL,
-                            flags: ColumnFlags::default(),
-                        })
-                        .collect();
-                    statement.params_received = 0;
+                    statement.params.set(
+                        (0..ok.num_params as usize)
+                            .map(|_| Param {
+                                r#type: FieldType::MYSQL_TYPE_NULL,
+                                flags: ColumnFlags::default(),
+                            })
+                            .collect(),
+                    );
+                    statement.params_received.set(0);
                 }
 
                 // Read column definitions if any
                 if ok.num_columns > 0 {
-                    statement.columns = (0..ok.num_columns as usize)
-                        .map(|_| ColumnDefinition41::default())
-                        .collect();
-                    statement.columns_received = 0;
+                    statement.columns.set(
+                        (0..ok.num_columns as usize)
+                            .map(|_| ColumnDefinition41::default())
+                            .collect(),
+                    );
+                    statement.columns_received.set(0);
                 }
 
                 self.check_if_prepared_statement_is_done(statement);
@@ -1358,7 +1335,7 @@ impl MySQLConnection {
                 // The queue advance is an explicit call after
                 // `on_error_packet` below.
                 self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
-                statement.status = mysql_statement::Status::Failed;
+                statement.status.set(mysql_statement::Status::Failed);
                 // err.error_message is a Data{ .temporary = ... } slice into the socket read
                 // buffer which will be overwritten by the next packet. The statement is cached
                 // in this.statements and its error_response may be read later via
@@ -1367,24 +1344,22 @@ impl MySQLConnection {
                 // reconstruct field-by-field with an owned dupe of the message
                 // — the scalar fields (header / error_code / sql_state) are
                 // all Copy.
-                statement.error_response = ErrorPacket {
+                statement.error_response.set(ErrorPacket {
                     header: err.header,
                     error_code: err.error_code,
                     sql_state_marker: err.sql_state_marker,
                     sql_state: err.sql_state,
                     error_message: Data::create(err.error_message.slice())
                         .map_err(|_| AnyMySQLError::OutOfMemory)?,
-                };
+                });
                 self.queue.mark_as_ready_for_query();
                 self.queue.mark_current_request_as_finished(request);
 
                 // R-2: `on_error_packet` is `&self`; `js_connection_ref()` is
-                // the audited container_of accessor (one centralised unsafe).
-                // The `&JSMySQLConnection` it yields lives only for this call —
-                // identical footprint to the prior `(*ptr).on_error_packet()`
-                // temporary — and `*self` sits inside the parent's `JsCell`, so
-                // re-entrant `connection_mut()` does not alias the outer
-                // shared borrow.
+                // the audited container_of accessor. The `&JSMySQLConnection`
+                // it yields lives only for this call, and `*self` sits inside
+                // the parent's `JsCell`, so re-entrant `with_connection()` does
+                // not alias the outer shared borrow.
                 self.js_connection_ref()
                     .on_error_packet(Some(request), &err);
                 self.advance();
@@ -1405,10 +1380,7 @@ impl MySQLConnection {
     // reshaped for borrowck — `request` comes from `self.queue` so
     // passing `&mut self` alongside `&mut JSMySQLQuery` would alias. `request`
     // is `&JSMySQLQuery` (R-2: fully interior-mutable, so a shared borrow is
-    // sound across the re-entrant `on_query_result` callback). The statement is
-    // re-fetched via the single-unsafe `request.get_statement()` accessor at
-    // each touch point so no `&mut MySQLStatement` spans the re-entrant
-    // `on_query_result` call (which may itself call `get_statement()`).
+    // sound across the re-entrant `on_query_result` callback).
     fn handle_result_set_ok(
         &mut self,
         request: &JSMySQLQuery,
@@ -1431,14 +1403,12 @@ impl MySQLConnection {
             self.queue.mark_current_request_as_finished(request);
         }
 
-        // Short-lived borrow via the audited accessor; dropped before the
-        // re-entrant `on_query_result` call below.
-        let result_count = request.get_statement().map_or(0, |s| s.result_count);
+        let result_count = request.get_statement().map_or(0, |s| s.result_count.get());
         // R-2: `on_query_result` is `&self`; `js_connection_ref()` is the
         // audited container_of accessor. The `&JSMySQLConnection` lives only for
         // this call (same footprint as the prior `(*ptr).on_query_result()`
         // temporary). `*self` sits inside the parent's `JsCell` (`UnsafeCell`),
-        // so re-entrant `connection_mut()` writes through SharedRW provenance
+        // so re-entrant `with_connection()` writes through SharedRW provenance
         // independent of this outer shared borrow.
         self.js_connection_ref().on_query_result(
             request,
@@ -1450,7 +1420,6 @@ impl MySQLConnection {
             },
         );
 
-        // Re-fetch (fresh `&mut`) so no borrow spanned the JS callback above.
         if let Some(s) = request.get_statement() {
             s.reset();
         }
@@ -1503,7 +1472,7 @@ impl MySQLConnection {
 
                 // R-2: `on_error_packet` is `&self`; route through the audited
                 // `js_connection_ref()` container_of accessor. `*self` lives
-                // inside the parent's `JsCell`, so re-entrant `connection_mut()`
+                // inside the parent's `JsCell`, so re-entrant `with_connection()`
                 // does not alias this outer shared borrow.
                 self.js_connection_ref()
                     .on_error_packet(Some(request), &err);
@@ -1511,19 +1480,14 @@ impl MySQLConnection {
             }
 
             packet_type => {
-                // `get_statement()` derefs the intrusive `*mut MySQLStatement`
-                // held by the request (separate heap allocation); the `&mut` is
-                // rooted in the local `ThisPtr`, not `self`, so `&mut self`
-                // calls below do not conflict. `handle_result_set_ok` re-fetches
-                // via the same accessor; `on_result_row` reborrows `&mut`.
+                // The statement is a separate heap allocation held by the
+                // request's ref; the borrow is rooted in the local `request`,
+                // not `self`, so `&mut self` calls below do not conflict.
                 let Some(statement) = request.get_statement() else {
                     debug!("Unexpected result set packet");
                     return Err(AnyMySQLError::UnexpectedPacket);
                 };
-                if !statement
-                    .execution_flags
-                    .contains(mysql_statement::ExecutionFlags::HEADER_RECEIVED)
-                {
+                if !statement.has_execution_flag(mysql_statement::ExecutionFlags::HEADER_RECEIVED) {
                     if packet_type == PacketType::OK {
                         // if packet type is OK it means the query is done and no results are returned
                         ok.decode_internal(reader)?;
@@ -1552,18 +1516,18 @@ impl MySQLConnection {
                     if header.field_count > 4096 {
                         return Err(AnyMySQLError::UnexpectedPacket);
                     }
-                    if statement.columns.len() as u64 != header.field_count {
+                    if statement.columns.get().len() as u64 != header.field_count {
                         bun_core::scoped_log!(
                             MySQLConnection,
                             "header field count mismatch: {} != {}",
-                            statement.columns.len(),
+                            statement.columns.get().len(),
                             header.field_count
                         );
-                        if !statement.columns.is_empty() {
+                        if !statement.columns.get().is_empty() {
                             // Clear the slice before the fallible alloc below. If the alloc
                             // fails, MySQLStatement.deinit() would otherwise iterate and free
                             // the already-freed columns again (use-after-free / double-free).
-                            statement.columns = Vec::new();
+                            statement.columns.set(Vec::new());
                         }
                         // Fallible allocation: field_count is server-controlled
                         // (lenenc int up to 2^64-1), so a panicking `collect()`
@@ -1575,31 +1539,36 @@ impl MySQLConnection {
                             .try_reserve_exact(field_count)
                             .map_err(|_| AnyMySQLError::OutOfMemory)?;
                         columns.resize_with(field_count, ColumnDefinition41::default);
-                        statement.columns = columns;
-                        statement.columns_received = 0;
-                        statement.cached_structure = Default::default();
-                        statement.fields_flags = Default::default();
+                        statement.columns.set(columns);
+                        statement.columns_received.set(0);
+                        statement.cached_structure.set(Default::default());
+                        statement.fields_flags.set(Default::default());
                     }
+                    statement.insert_execution_flag(
+                        mysql_statement::ExecutionFlags::NEEDS_DUPLICATE_CHECK,
+                    );
                     statement
-                        .execution_flags
-                        .insert(mysql_statement::ExecutionFlags::NEEDS_DUPLICATE_CHECK);
-                    statement
-                        .execution_flags
-                        .insert(mysql_statement::ExecutionFlags::HEADER_RECEIVED);
+                        .insert_execution_flag(mysql_statement::ExecutionFlags::HEADER_RECEIVED);
                     return Ok(());
-                } else if (statement.columns_received as usize) < statement.columns.len() {
-                    let changed = statement.columns[statement.columns_received as usize].decode(
-                        &mut reader,
-                        self.mariadb_capabilities.MARIADB_CLIENT_EXTENDED_TYPE_INFO,
-                    )?;
+                } else if (statement.columns_received.get() as usize)
+                    < statement.columns.get().len()
+                {
+                    let index = statement.columns_received.get() as usize;
+                    let extended_type_info =
+                        self.mariadb_capabilities.MARIADB_CLIENT_EXTENDED_TYPE_INFO;
+                    let changed = statement.columns.with_mut(|columns| {
+                        columns[index].decode(&mut reader, extended_type_info)
+                    })?;
                     if changed {
-                        statement.cached_structure = Default::default();
-                        statement.fields_flags = Default::default();
-                        statement
-                            .execution_flags
-                            .insert(mysql_statement::ExecutionFlags::NEEDS_DUPLICATE_CHECK);
+                        statement.cached_structure.set(Default::default());
+                        statement.fields_flags.set(Default::default());
+                        statement.insert_execution_flag(
+                            mysql_statement::ExecutionFlags::NEEDS_DUPLICATE_CHECK,
+                        );
                     }
-                    statement.columns_received += 1;
+                    statement
+                        .columns_received
+                        .set(statement.columns_received.get() + 1);
                 } else {
                     // A 0xFE-prefixed packet at this point is either the end-of-result
                     // terminator or a row whose first column is a length-encoded integer
@@ -1618,16 +1587,15 @@ impl MySQLConnection {
                             // Legacy protocol: EOF packets delimit sections of the result set.
                             // Handle the intermediate EOF (between column defs and rows) and
                             // the final EOF (after all rows) differently.
-                            if !statement
-                                .execution_flags
-                                .contains(mysql_statement::ExecutionFlags::COLUMNS_EOF_RECEIVED)
-                            {
+                            if !statement.has_execution_flag(
+                                mysql_statement::ExecutionFlags::COLUMNS_EOF_RECEIVED,
+                            ) {
                                 // Intermediate EOF between column definitions and row data - skip it
                                 let mut eof = EOFPacket::default();
                                 eof.decode_internal(reader)?;
-                                statement
-                                    .execution_flags
-                                    .insert(mysql_statement::ExecutionFlags::COLUMNS_EOF_RECEIVED);
+                                statement.insert_execution_flag(
+                                    mysql_statement::ExecutionFlags::COLUMNS_EOF_RECEIVED,
+                                );
                                 return Ok(());
                             }
                             // Final EOF after all row data - terminates the result set
@@ -1651,10 +1619,9 @@ impl MySQLConnection {
 
                     // R-2: `on_result_row` is `&self`; route through the audited
                     // `js_connection_ref()` container_of accessor. The
-                    // `&JSMySQLConnection` is held only for this call (identical
-                    // footprint to the prior `(*ptr).on_result_row()` temporary);
-                    // `*self` sits inside the parent's `JsCell`, so re-entrant
-                    // `connection_mut()` does not alias this shared borrow.
+                    // `&JSMySQLConnection` is held only for this call; `*self`
+                    // sits inside the parent's `JsCell`, so re-entrant
+                    // `with_connection()` does not alias this shared borrow.
                     self.js_connection_ref()
                         .on_result_row(request, statement, reader)?;
                 }
@@ -1670,103 +1637,66 @@ pub enum FlushQueueError {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Writer / Reader — protocol-layer adapters wrapping the connection's
-// OffsetByteList buffers. Hold `*mut MySQLConnection` (Copy) so they satisfy
-// `bun_sql::mysql::protocol::new_{reader,writer}::{Reader,Writer}Context: Copy`.
+// Writer / Reader — protocol-layer adapters over the connection's buffer cells
+// (LIFETIMES.tsv BACKREF). They are only constructed by `writer()` /
+// `buffered_reader()` on a live connection and consumed within that call (never
+// stored), so the connection outlives them; `Copy` so they satisfy
+// `bun_sql::mysql::protocol::new_{reader,writer}::{Reader,Writer}Context`.
 // ──────────────────────────────────────────────────────────────────────────
 
 #[derive(Clone, Copy)]
 pub struct Writer {
-    pub(crate) connection: *mut MySQLConnection,
-}
-
-impl Writer {
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn write_buffer(&self) -> &mut OffsetByteList {
-        // SAFETY: `self.connection` is never null — `Writer` is only ever
-        // constructed by `MySQLConnection::writer(&mut self)` from a live
-        // `&mut MySQLConnection`, and the `NewWriter<Writer>` is consumed
-        // before that connection is dropped (it is never stored).
-        //
-        // Raw-pointer field projection (`addr_of_mut!`) avoids materializing
-        // an intermediate `&mut MySQLConnection`, which could alias the
-        // caller's own `&mut self` (see the aliasing note on `Reader` below).
-        // Callers never touch `write_buffer` through `&mut self` while a
-        // `Writer` is live, so no two `&mut OffsetByteList` coexist.
-        unsafe { &mut *core::ptr::addr_of_mut!((*self.connection).write_buffer) }
-    }
+    write_buffer: BackRef<JsCell<OffsetByteList>>,
 }
 
 impl WriterContext for Writer {
     fn write(self, data: &[u8]) -> Result<(), AnyMySQLError> {
-        self.write_buffer()
-            .write(data)
+        self.write_buffer
+            .with_mut(|b| b.write(data))
             .map_err(|_| AnyMySQLError::OutOfMemory)?;
         Ok(())
     }
 
     fn pwrite(self, data: &[u8], index: usize) -> Result<(), AnyMySQLError> {
-        let byte_list = &mut self.write_buffer().byte_list;
-        byte_list.slice_mut()[index..][..data.len()].copy_from_slice(data);
+        self.write_buffer
+            .with_mut(|b| b.byte_list.slice_mut()[index..][..data.len()].copy_from_slice(data));
         Ok(())
     }
 
     fn offset(self) -> usize {
-        self.write_buffer().len() as usize
+        self.write_buffer.get().get().len() as usize
     }
 
     fn truncate(self, offset: usize) {
-        let buffer = self.write_buffer();
-        let head = buffer.head as usize;
-        buffer.byte_list.truncate(head + offset);
+        self.write_buffer.with_mut(|buffer| {
+            let head = buffer.head as usize;
+            buffer.byte_list.truncate(head + offset);
+        });
     }
 }
 
 #[derive(Clone, Copy)]
 pub struct Reader {
-    pub(crate) connection: *mut MySQLConnection,
+    read_buffer: BackRef<JsCell<OffsetByteList>>,
+    last_message_start: BackRef<Cell<u32>>,
 }
 
-// Aliasing: `Reader` is constructed from `&mut MySQLConnection`
-// and then threaded through `process_packets(&mut self, reader)` — i.e. the
-// raw `*mut` and a live `&mut self` coexist. Materializing a whole-struct
-// `&mut MySQLConnection` here would alias that `&mut self` (Stacked Borrows
-// UB). Instead the accessors below project only the specific field(s) the
-// reader touches via `addr_of_mut!`, matching `Writer` above.
 impl Reader {
     #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn read_buffer(&self) -> &mut OffsetByteList {
-        // SAFETY: `self.connection` points at a live `MySQLConnection` for the
-        // duration of the read call (NewReader is constructed by
-        // `MySQLConnection::buffered_reader(&mut self)` and never stored).
-        // Raw-pointer field projection (`addr_of_mut!`) avoids materializing an
-        // intermediate `&mut MySQLConnection`, which would alias the caller's
-        // live `&mut self` in `process_packets`. `process_packets` never touches
-        // `read_buffer` through its own `&mut self` while a `Reader` is live, so
-        // no two `&mut OffsetByteList` coexist.
-        unsafe { &mut *core::ptr::addr_of_mut!((*self.connection).read_buffer) }
-    }
-
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn last_message_start(&self) -> &mut u32 {
-        // SAFETY: same justification as `read_buffer()` — disjoint field
-        // projection from a non-null connection pointer that outlives the
-        // `Reader`; `process_packets` does not access `last_message_start`
-        // through `&mut self` while the reader is live.
-        unsafe { &mut *core::ptr::addr_of_mut!((*self.connection).last_message_start) }
+    fn read_buffer(&self) -> &OffsetByteList {
+        self.read_buffer.get().get()
     }
 }
 
 impl ReaderContext for Reader {
     fn mark_message_start(self) {
-        *self.last_message_start() = self.read_buffer().head;
+        self.last_message_start.set(self.read_buffer().head);
     }
 
     fn set_offset_from_start(self, offset: usize) {
-        self.read_buffer().head = *self.last_message_start() + (offset as u32);
+        let start = self.last_message_start.get().get();
+        self.read_buffer
+            .with_mut(|rb| rb.head = start + (offset as u32));
     }
 
     fn peek(&self) -> &[u8] {
@@ -1774,24 +1704,25 @@ impl ReaderContext for Reader {
     }
 
     fn skip(self, count: isize) {
-        let rb = self.read_buffer();
-        if count < 0 {
-            let abs_count = count.unsigned_abs();
-            if abs_count > rb.head as usize {
-                rb.head = 0;
+        self.read_buffer.with_mut(|rb| {
+            if count < 0 {
+                let abs_count = count.unsigned_abs();
+                if abs_count > rb.head as usize {
+                    rb.head = 0;
+                    return;
+                }
+                rb.head -= u32::try_from(abs_count).expect("int cast");
                 return;
             }
-            rb.head -= u32::try_from(abs_count).expect("int cast");
-            return;
-        }
 
-        let ucount: usize = usize::try_from(count).expect("int cast");
-        if rb.head as usize + ucount > rb.byte_list.len() {
-            rb.head = rb.byte_list.len() as u32;
-            return;
-        }
+            let ucount: usize = usize::try_from(count).expect("int cast");
+            if rb.head as usize + ucount > rb.byte_list.len() {
+                rb.head = rb.byte_list.len() as u32;
+                return;
+            }
 
-        rb.head += u32::try_from(ucount).expect("int cast");
+            rb.head += u32::try_from(ucount).expect("int cast");
+        });
     }
 
     fn ensure_capacity(self, count: usize) -> bool {
@@ -1822,11 +1753,8 @@ impl ReaderContext for Reader {
     }
 }
 
-/// `None` only transiently, inside `get_or_put` before the new statement is stored.
+/// The connection's ref on each cached prepared statement (`None` only
+/// transiently, while `statement_for_signature` fills a fresh slot).
 pub(crate) type PreparedStatementsMap = StringHashMap<Option<RefPtr<MySQLStatement>>>;
-/// Result of `PreparedStatementsMap::get_or_put` — surfaced for
-/// `JSMySQLConnection::get_statement_from_signature_name`.
-pub(crate) type PreparedStatementsMapGetOrPutResult<'a> =
-    bun_collections::hash_map::GetOrPutResult<'a, Option<RefPtr<MySQLStatement>>>;
 
 const MAX_PIPELINE_SIZE: usize = u16::MAX as usize; // about 64KB per connection

--- a/src/sql_jsc/mysql/MySQLContext.rs
+++ b/src/sql_jsc/mysql/MySQLContext.rs
@@ -10,11 +10,10 @@ pub struct MySQLContext {
 // The binding object is built in Rust (`mysql.rs` registers this fn through
 // `put_host_functions!`/`IntoJSHostFn`), so no C symbol is needed.
 pub(crate) fn init(global: &JSGlobalObject, frame: &CallFrame) -> JSValue {
-    // `bun_vm()` → `&'static VirtualMachine` (per-thread singleton); `as_mut()`
-    // is the canonical safe escape hatch for the shrinking set of `&mut self`
-    // helpers like `sql_state()` — one audited unsafe lives in bun_jsc.
-    let ctx = &mut global.bun_vm().as_mut().sql_state().mysql_context;
-    ctx.on_query_resolve_fn.set(global, frame.argument(0));
-    ctx.on_query_reject_fn.set(global, frame.argument(1));
+    global.bun_vm().with_sql_state(|state| {
+        let ctx = &mut state.mysql_context;
+        ctx.on_query_resolve_fn.set(global, frame.argument(0));
+        ctx.on_query_reject_fn.set(global, frame.argument(1));
+    });
     JSValue::UNDEFINED
 }

--- a/src/sql_jsc/mysql/MySQLQuery.rs
+++ b/src/sql_jsc/mysql/MySQLQuery.rs
@@ -20,14 +20,13 @@ use crate::shared::query_binding_iterator::QueryBindingIterator;
 
 use super::js_mysql_connection::MySQLConnection;
 use super::my_sql_statement::{self as my_sql_statement, ExecutionFlags, MySQLStatement};
-use bun_ptr::RefPtr;
 
 bun_core::define_scoped_log!(debug, MySQLQuery, visible);
 
 pub struct MySQLQuery {
-    /// Shared with the connection's `PreparedStatementsMap` (each holder owns
-    /// one ref).
-    statement: Option<RefPtr<MySQLStatement>>,
+    /// This query's ref on its statement; the connection's
+    /// `PreparedStatementsMap` may hold another on the same statement.
+    statement: Option<bun_ptr::RefPtr<MySQLStatement>>,
     query: BunString,
 
     status: Status,
@@ -97,20 +96,19 @@ impl Flags {
 }
 
 impl MySQLQuery {
-    fn bind(
-        &mut self,
+    fn bind<'a>(
         param_types: &[Param],
         global_object: &JSGlobalObject,
         binding_value: JSValue,
         columns_value: JSValue,
-        roots: &mut MarkedArgumentBuffer,
-    ) -> Result<Vec<Value>, AnyMySQLError> {
+        roots: &'a MarkedArgumentBuffer,
+    ) -> Result<Vec<Value<'a>>, AnyMySQLError> {
         let mut iter = QueryBindingIterator::init(binding_value, columns_value, global_object)
             .map_err(js_error_to_mysql)?;
 
         let mut i: u32 = 0;
         let len = param_types.len();
-        let mut params: Vec<Value> = Vec::with_capacity(len);
+        let mut params: Vec<Value<'a>> = Vec::with_capacity(len);
         // errdefer { for params[0..i] deinit; free(params) } — deleted: `Vec<Value>` drops on `?`.
 
         while let Some(js_value) = iter.next().map_err(js_error_to_mysql)? {
@@ -142,35 +140,28 @@ impl MySQLQuery {
             return Err(AnyMySQLError::WrongNumberOfParametersProvided);
         }
 
-        self.status = Status::Binding;
         Ok(params)
     }
 
-    /// `statement` is a raw `*mut MySQLStatement` (not `&mut`) because the sole caller,
-    /// `run_prepared_query`, must derive it from `self.statement` and then call this
-    /// `&mut self` method — a `&mut MySQLStatement` rooted in `*self` would overlap that
-    /// reborrow.
+    /// Bind and execute this query's (prepared) statement.
     fn bind_and_execute<C: WriterContext>(
         &mut self,
         writer: NewWriter<C>,
-        statement: *mut MySQLStatement,
         global_object: &JSGlobalObject,
         binding_value: JSValue,
         columns_value: JSValue,
     ) -> Result<(), AnyMySQLError> {
         {
-            // `statement` is non-null and kept alive by the intrusive ref held in
-            // `self.statement` for the duration of this call; no other `&mut` to it
-            // exists (caller passes the raw pointer before reborrowing `self`). This
-            // block only reads — `ParentRef` yields `&T`.
-            let stmt = bun_ptr::ParentRef::from(
-                core::ptr::NonNull::new(statement).expect("bind_and_execute: statement non-null"),
-            );
+            let stmt = self
+                .statement
+                .as_deref()
+                .expect("bind_and_execute: statement set");
+            let params_len = stmt.params.get().len();
             debug_assert!(
-                stmt.params.len() == stmt.params_received as usize && stmt.statement_id > 0,
+                params_len == stmt.params_received.get() as usize && stmt.statement_id.get() > 0,
                 "statement is not prepared",
             );
-            if stmt.signature.fields.len() != stmt.params.len() {
+            if stmt.signature.fields.len() != params_len {
                 return Err(AnyMySQLError::WrongNumberOfParametersProvided);
             }
         }
@@ -187,61 +178,49 @@ impl MySQLQuery {
         // centralised in `bun_jsc`, so no per-site `Ctx` struct + `extern "C"`
         // thunk is needed here.
         MarkedArgumentBuffer::new(|roots| {
-            self.bind_and_execute_impl(
-                writer,
-                statement,
-                global_object,
-                binding_value,
-                columns_value,
-                roots,
-            )
+            self.bind_and_execute_impl(writer, global_object, binding_value, columns_value, roots)
         })
     }
 
     fn bind_and_execute_impl<C: WriterContext>(
         &mut self,
         writer: NewWriter<C>,
-        statement: *mut MySQLStatement,
         global_object: &JSGlobalObject,
         binding_value: JSValue,
         columns_value: JSValue,
         roots: &mut MarkedArgumentBuffer,
     ) -> Result<(), AnyMySQLError> {
-        // SAFETY: `statement` was copied from `self.statement` by `run_prepared_query`;
-        // the intrusive ref held there keeps the allocation alive across this call. The
-        // caller passes the raw pointer before reborrowing `self`, so this is the only
-        // live mutable access path to the statement for the duration of this function.
-        let statement = unsafe { &mut *statement };
+        let statement: &MySQLStatement = self
+            .statement
+            .as_deref()
+            .expect("bind_and_execute: statement set");
 
         // Bind before touching the writer so a bind failure (user-triggerable via JS
         // getters / param-count mismatch) doesn't leave a partial packet header in
         // the connection's write buffer.
-        let params = self.bind(
+        let params = Self::bind(
             &statement.signature.fields,
             global_object,
             binding_value,
             columns_value,
             roots,
         )?;
+        self.status = Status::Binding;
         // `defer execute.deinit()` — `params: Vec<Value>` drops at end of scope.
 
         let execute = prepared_statement::Execute {
-            statement_id: statement.statement_id,
+            statement_id: statement.statement_id.get(),
             flags: 0,
             iteration_count: 1,
             param_types: &statement.signature.fields,
-            new_params_bind_flag: statement
-                .execution_flags
-                .contains(ExecutionFlags::NEED_TO_SEND_PARAMS),
+            new_params_bind_flag: statement.has_execution_flag(ExecutionFlags::NEED_TO_SEND_PARAMS),
             params: &params,
         };
 
         let mut packet = writer.start(0)?;
         execute.write(writer)?;
         packet.end()?;
-        statement
-            .execution_flags
-            .remove(ExecutionFlags::NEED_TO_SEND_PARAMS);
+        statement.remove_execution_flag(ExecutionFlags::NEED_TO_SEND_PARAMS);
         self.status = Status::Running;
         Ok(())
     }
@@ -255,10 +234,11 @@ impl MySQLQuery {
         let query_str = self.query.to_utf8();
         let writer = connection.get_writer();
         if self.statement.is_none() {
-            self.statement = Some(RefPtr::new(MySQLStatement::new(
+            // The query is the only owner of a simple statement.
+            self.statement = Some(MySQLStatement::new(
                 Signature::empty(),
                 my_sql_statement::Status::Parsing,
-            )));
+            ));
         }
         mysql_request::execute_query(query_str.slice(), writer)?;
 
@@ -292,10 +272,12 @@ impl MySQLQuery {
                 }
             };
             query_str = Some(query);
-            // errdefer signature.deinit() — `Signature: Drop` handles the error path; on the
-            // found_existing success path below we explicitly drop it.
-            let entry = match connection.get_statement_from_signature_name(&signature.name) {
-                Ok(e) => e,
+            // errdefer signature.deinit() — `Signature: Drop` handles the error path.
+            // For a signature the connection has already prepared, this is a
+            // new ref on that statement (the signature is dropped); otherwise
+            // a fresh statement the connection's map now also references.
+            let (stmt, found_existing) = match connection.statement_for_signature(signature) {
+                Ok(v) => v,
                 Err(err) => {
                     // `err` is `bun_core::AllocError`; `throw_error` takes
                     // `crate::Error` (`From<AllocError>` → OutOfMemory).
@@ -305,36 +287,20 @@ impl MySQLQuery {
                 }
             };
 
-            match entry.value_ptr {
-                Some(stmt) => {
-                    if stmt.status == my_sql_statement::Status::Failed {
-                        let error_response = stmt.error_response.to_js(global_object);
-                        // If the statement failed, we need to throw the error
-                        let _ = global_object.throw_value(error_response);
-                        return Err(crate::Error::JSError);
-                    }
-                    self.statement = Some(stmt.clone());
-                }
-                slot @ None => {
-                    let stmt = RefPtr::new(MySQLStatement::new(
-                        signature,
-                        my_sql_statement::Status::Pending,
-                    ));
-                    self.statement = Some(stmt.clone());
-                    *slot = Some(stmt);
-                }
+            if found_existing && stmt.status.get() == my_sql_statement::Status::Failed {
+                let error_response = stmt.error_response.get().to_js(global_object);
+                drop(stmt);
+                // If the statement failed, we need to throw the error
+                let _ = global_object.throw_value(error_response);
+                return Err(crate::Error::JSError);
             }
+            self.statement = Some(stmt);
         }
-        // `stmt` is kept alive by the ref in `self.statement`; separate heap
-        // allocation (never aliases `*self`). `ParentRef` collapses the
-        // read-only derefs below into one safe `Deref`; the `.Pending` arm's
-        // status write goes through `get_statement()`.
-        let stmt = self.statement.as_ref().expect("set above").as_non_null();
-        let (stmt, stmt_ref) = (stmt.as_ptr(), bun_ptr::ParentRef::from(stmt));
-        match stmt_ref.status {
+        let stmt: &MySQLStatement = self.statement.as_deref().expect("self.statement set above");
+        match stmt.status.get() {
             my_sql_statement::Status::Failed => {
                 debug!("failed");
-                let error_response = stmt_ref.error_response.to_js(global_object);
+                let error_response = stmt.error_response.get().to_js(global_object);
                 // If the statement failed, we need to throw the error
                 let _ = global_object.throw_value(error_response);
                 return Err(crate::Error::JSError);
@@ -343,14 +309,9 @@ impl MySQLQuery {
                 if connection.can_pipeline() {
                     debug!("bindAndExecute");
                     let writer = connection.get_writer();
-                    // Pass the raw `*mut MySQLStatement` separately from `&mut self`.
-                    if let Err(err) = self.bind_and_execute(
-                        writer,
-                        stmt,
-                        global_object,
-                        binding_value,
-                        columns_value,
-                    ) {
+                    if let Err(err) =
+                        self.bind_and_execute(writer, global_object, binding_value, columns_value)
+                    {
                         if !global_object.has_exception() {
                             let _ = global_object.throw_value(mysql_error_to_js(
                                 global_object,
@@ -379,13 +340,7 @@ impl MySQLQuery {
                             global_object.throw_sql_error(err.into(), "failed to prepare query");
                         return Err(crate::Error::JSError);
                     }
-                    // `self.statement` was set in both branches above; route
-                    // through the single-unsafe accessor instead of a raw
-                    // `(*stmt)` deref so the write goes via the same audited
-                    // intrusive-pointer path as every other status mutation.
-                    self.get_statement()
-                        .expect("self.statement set above")
-                        .status = my_sql_statement::Status::Parsing;
+                    stmt.status.set(my_sql_statement::Status::Parsing);
                 }
             }
         }
@@ -458,6 +413,11 @@ impl MySQLQuery {
         true
     }
 
+    pub(crate) fn cleanup(&mut self) {
+        drop(self.statement.take());
+        self.query = BunString::EMPTY;
+    }
+
     #[inline]
     pub(crate) fn is_completed(&self) -> bool {
         self.status == Status::Success || self.status == Status::Fail
@@ -481,7 +441,7 @@ impl MySQLQuery {
         self.status == Status::Pending
             && self
                 .get_statement()
-                .is_some_and(|s| s.status == my_sql_statement::Status::Parsing)
+                .is_some_and(|s| s.status.get() == my_sql_statement::Status::Parsing)
     }
 
     #[inline]
@@ -505,27 +465,21 @@ impl MySQLQuery {
     }
 
     #[inline]
-    pub(crate) fn mark_as_prepared(&mut self) {
+    pub(crate) fn mark_as_prepared(&self) {
         if self.status == Status::Pending {
             if let Some(statement) = self.get_statement() {
-                if statement.status == my_sql_statement::Status::Parsing
-                    && statement.params.len() == statement.params_received as usize
-                    && statement.statement_id > 0
+                if statement.status.get() == my_sql_statement::Status::Parsing
+                    && statement.params.get().len() == statement.params_received.get() as usize
+                    && statement.statement_id.get() > 0
                 {
-                    statement.status = my_sql_statement::Status::Prepared;
+                    statement.status.set(my_sql_statement::Status::Prepared);
                 }
             }
         }
     }
 
     #[inline]
-    #[allow(clippy::mut_from_ref)] // goes through a raw intrusive pointer; see SAFETY note below
-    pub(crate) fn get_statement(&self) -> Option<&mut MySQLStatement> {
-        // SAFETY: kept alive by the ref we hold. Returning `&mut` permits
-        // shared mutation through the intrusive pointer; the lifetime is
-        // bounded by `&self`, which owns one ref.
-        self.statement
-            .as_ref()
-            .map(|stmt| unsafe { &mut *stmt.as_ptr() })
+    pub(crate) fn get_statement(&self) -> Option<&MySQLStatement> {
+        self.statement.as_deref()
     }
 }

--- a/src/sql_jsc/mysql/MySQLRequestQueue.rs
+++ b/src/sql_jsc/mysql/MySQLRequestQueue.rs
@@ -1,9 +1,8 @@
 use crate::jsc::JSValue;
 use bun_jsc::JsCell;
-use bun_ptr::{ParentRef, RefPtr};
+use bun_ptr::{RefPtr, ThisPtr};
 use bun_sql::mysql::protocol::any_mysql_error::Error as AnyMySQLError;
 use core::cell::Cell;
-use core::ptr::NonNull;
 use std::collections::VecDeque;
 
 use crate::mysql::js_mysql_query::JSMySQLQuery;
@@ -14,15 +13,15 @@ use crate::mysql::js_mysql_connection::JSMySQLConnection as MySQLConnection;
 
 bun_core::define_scoped_log!(debug, MySQLRequestQueue, visible);
 
+/// Each entry is the ref the queue holds on that request, released when the
+/// entry leaves the queue.
 type Queue = VecDeque<RefPtr<JSMySQLQuery>>;
 
 pub struct MySQLRequestQueue {
-    // All fields are interior-mutable so `advance()` can mutate via the
-    // `ParentRef<Self>` backref (yields `&Self`) without per-site `unsafe`
-    // raw-pointer writes. The queue is single-JS-thread (embedded inside the
+    // All fields are interior-mutable so `advance()` can run against the
+    // `&Self` reached through the connection while its callees re-enter the
+    // connection. The queue is single-JS-thread (embedded inside the
     // connection's `JsCell`), so `Cell`/`JsCell`'s `!Sync` story is fine.
-    // `requests` uses `JsCell` (closure-scoped `with_mut`) since `VecDeque`
-    // mutators need `&mut Queue`.
     requests: JsCell<Queue>,
 
     pipelined_requests: Cell<u32>,
@@ -50,12 +49,12 @@ impl MySQLRequestQueue {
     }
 
     #[inline]
-    pub(crate) fn mark_as_ready_for_query(&mut self) {
+    pub(crate) fn mark_as_ready_for_query(&self) {
         self.is_ready_for_query.set(true);
     }
 
     #[inline]
-    pub(crate) fn mark_as_prepared(&mut self) {
+    pub(crate) fn mark_as_prepared(&self) {
         self.waiting_to_prepare.set(false);
         if let Some(request) = self.current() {
             debug!("markAsPrepared markAsPrepared");
@@ -81,7 +80,7 @@ impl MySQLRequestQueue {
             && connection.is_able_to_write()
     }
 
-    pub(crate) fn mark_current_request_as_finished(&mut self, item: &JSMySQLQuery) {
+    pub(crate) fn mark_current_request_as_finished(&self, item: &JSMySQLQuery) {
         self.waiting_to_prepare.set(false);
         if item.is_being_prepared() {
             debug!("markCurrentRequestAsFinished markAsPrepared");
@@ -97,43 +96,40 @@ impl MySQLRequestQueue {
         }
     }
 
-    /// takes only `connection` (the embedding `JSMySQLConnection`)
-    /// as a **raw pointer** and derives the queue backref locally. The queue is
-    /// a field of `*connection` — but every `MySQLRequestQueue` field is
-    /// interior-mutable (`Cell` / `JsCell`), so a `ParentRef<Self>` (yields
-    /// `&Self` only) suffices for *all* access below; no `&mut Self` / raw
-    /// `(*this)` writes are needed. `run()` / `is_able_to_write()` re-read
-    /// queue scalars via `connection.can_execute_query()` etc., which is sound
-    /// for the same reason (shared-only reborrows of `Cell`-wrapped state).
-    ///
-    /// The `connection` raw pointer is consumed via the safe
-    /// `ParentRef::from(NonNull)` constructor (null checked at the boundary),
-    /// so a function-level guard adds nothing — caller liveness/provenance is
-    /// the `ParentRef` contract.
-    pub(crate) fn advance(connection: *mut MySQLConnection) {
-        // R-2: every `JSMySQLConnection` method reached below is `&self`
-        // (interior mutability), so a `ParentRef` (yields `&T` only) collapses
-        // the per-site `unsafe { (*connection).… }` / `&*connection` derefs.
-        let conn_ref =
-            ParentRef::from(NonNull::new(connection).expect("advance: connection non-null"));
-        // The inner protocol struct is wrapped in `JsCell` (`UnsafeCell`); its
-        // `.queue` field is reached via shared borrow and re-wrapped as a
-        // `ParentRef<Self>` so the borrow is detached from `conn_ref`'s
-        // momentary `Deref` lifetime. All queue mutation below goes through
-        // `Cell`/`JsCell` interior mutability — `&Self` is sufficient.
-        let queue_ref: ParentRef<Self> = ParentRef::new(&conn_ref.connection.get().queue);
+    /// The queued request at `offset`; the queue's ref keeps it alive while
+    /// the entry is queued.
+    #[inline]
+    fn request_at(&self, offset: usize) -> Option<ThisPtr<JSMySQLQuery>> {
+        self.requests.get().get(offset).map(RefPtr::this_ptr)
+    }
+
+    /// If `request` is the FIFO head, pop it and drop the queue's ref on it
+    /// (which may free it).
+    fn discard_if_head(&self, request: ThisPtr<JSMySQLQuery>) {
+        let head = self.requests.with_mut(|q| match q.front() {
+            Some(front) if core::ptr::eq(front.as_ptr(), request.as_ptr()) => q.pop_front(),
+            _ => None,
+        });
+        drop(head);
+    }
+
+    /// Drive the queue: run/prepare pending requests until the connection
+    /// can't take more, then drop completed entries off the head. The queue is
+    /// `connection`'s own (`connection.connection.queue`); every callee below
+    /// is `&self` on interior-mutable state, so re-entry through the
+    /// connection is sound.
+    pub(crate) fn advance(connection: &MySQLConnection) {
+        let queue: &Self = &connection.connection.get().queue;
         // reshaped for borrowck — the cleanup that must run at function exit
         // became a post-block pass; early returns become
         // `break 'advance` so cleanup always runs at function exit.
         'advance: {
             let mut offset: usize = 0;
 
-            while queue_ref.requests.get().len() > offset && conn_ref.is_able_to_write() {
-                // The queue's `RefPtr` keeps the request live. `JSMySQLQuery`
-                // is a separate heap allocation — never aliases the queue or
-                // `*connection`. R-2: `ParentRef` yields `&T` only — every
-                // method body is `&self` (interior mutability).
-                let req = ParentRef::from(queue_ref.requests.get()[offset].as_non_null());
+            while connection.is_able_to_write() {
+                let Some(req) = queue.request_at(offset) else {
+                    break;
+                };
 
                 if req.is_completed() {
                     if offset > 0 {
@@ -142,20 +138,20 @@ impl MySQLRequestQueue {
                         continue;
                     }
                     debug!("isCompleted");
-                    queue_ref.requests.with_mut(|q| q.pop_front());
+                    queue.discard_if_head(req);
                     continue;
                 }
 
                 if req.is_being_prepared() {
                     debug!("isBeingPrepared");
-                    queue_ref.waiting_to_prepare.set(true);
+                    queue.waiting_to_prepare.set(true);
                     // cannot continue the queue until the current request is marked as prepared
                     break 'advance;
                 }
                 if req.is_running() {
                     debug!("isRunning");
-                    let total_requests_running = (queue_ref.pipelined_requests.get()
-                        + queue_ref.nonpipelinable_requests.get())
+                    let total_requests_running = (queue.pipelined_requests.get()
+                        + queue.nonpipelinable_requests.get())
                         as usize;
                     if offset < total_requests_running {
                         offset += total_requests_running;
@@ -167,43 +163,33 @@ impl MySQLRequestQueue {
 
                 // `run()` *does* read queue scalars
                 // (`can_execute_query`/`can_pipeline`/`can_prepare_query`),
-                // but only through `conn_ref`'s shared reborrow into the same
+                // but only through `connection`'s shared reborrow into the same
                 // `Cell`-wrapped fields — overlapping shared reads are sound.
-                if let Err(err) = req.run(conn_ref.get()) {
+                if let Err(err) = req.run(connection) {
                     debug!("run failed");
-                    // R-2: `on_error` takes `&self`.
-                    conn_ref.on_error(Some(req.get()), err);
-                    if offset == 0
-                        && (queue_ref.requests.get().front())
-                            .is_some_and(|f| core::ptr::eq(f.as_ptr(), req.get()))
-                    {
-                        queue_ref.requests.with_mut(|q| q.pop_front());
+                    connection.on_error(Some(req.get()), err);
+                    if offset == 0 {
+                        queue.discard_if_head(req);
                     }
                     offset += 1;
                     continue;
                 }
                 if req.is_being_prepared() {
                     debug!("isBeingPrepared");
-                    // R-2: `reset_connection_timeout` takes `&self`; touches
-                    // timer state outside the queue.
-                    conn_ref.reset_connection_timeout();
-                    queue_ref.is_ready_for_query.set(false);
-                    queue_ref.waiting_to_prepare.set(true);
+                    connection.reset_connection_timeout();
+                    queue.is_ready_for_query.set(false);
+                    queue.waiting_to_prepare.set(true);
                     break 'advance;
                 } else if req.is_running() {
-                    // R-2: `reset_connection_timeout` takes `&self`; touches
-                    // timer state outside the queue.
-                    conn_ref.reset_connection_timeout();
+                    connection.reset_connection_timeout();
                     debug!("isRunning after run");
-                    queue_ref.is_ready_for_query.set(false);
+                    queue.is_ready_for_query.set(false);
 
                     if req.is_pipelined() {
-                        queue_ref
+                        queue
                             .pipelined_requests
-                            .set(queue_ref.pipelined_requests.get() + 1);
-                        // `can_pipeline` takes `&self` + `&MySQLConnection`;
-                        // both are shared reborrows — overlapping reads are sound.
-                        if queue_ref.can_pipeline(conn_ref.get()) {
+                            .set(queue.pipelined_requests.get() + 1);
+                        if queue.can_pipeline(connection) {
                             debug!("pipelined requests");
                             offset += 1;
                             continue;
@@ -211,24 +197,23 @@ impl MySQLRequestQueue {
                         break 'advance;
                     }
                     debug!("nonpipelinable requests");
-                    queue_ref
+                    queue
                         .nonpipelinable_requests
-                        .set(queue_ref.nonpipelinable_requests.get() + 1);
+                        .set(queue.nonpipelinable_requests.get() + 1);
                 }
                 break 'advance;
             }
         }
 
-        // An item may be in the success or failed state and still be inside the queue (see deinit later comments)
-        // so we do the cleanup here
-        while queue_ref
-            .requests
-            .get()
-            .front()
-            .is_some_and(|req| req.is_completed())
-        {
-            debug!("isCompleted discard after advance");
-            queue_ref.requests.with_mut(|q| q.pop_front());
+        while let Some(req) = queue.request_at(0) {
+            // An item may be in the success or failed state and still be inside the queue (see deinit later comments)
+            // so we do the cleanup her
+            if req.is_completed() {
+                debug!("isCompleted discard after advance");
+                queue.discard_if_head(req);
+                continue;
+            }
+            break;
         }
     }
 
@@ -242,15 +227,16 @@ impl MySQLRequestQueue {
         }
     }
 
-    pub(crate) fn add(&mut self, req: RefPtr<JSMySQLQuery>) {
+    /// Append `request`, taking the queue's ref on it.
+    pub(crate) fn add(&self, request: ThisPtr<JSMySQLQuery>) {
         debug!("add");
-        if req.is_being_prepared() {
+        if request.is_being_prepared() {
             self.is_ready_for_query.set(false);
             self.waiting_to_prepare.set(true);
-        } else if req.is_running() {
+        } else if request.is_running() {
             self.is_ready_for_query.set(false);
 
-            if req.is_pipelined() {
+            if request.is_pipelined() {
                 self.pipelined_requests
                     .set(self.pipelined_requests.get() + 1);
             } else {
@@ -258,44 +244,52 @@ impl MySQLRequestQueue {
                     .set(self.nonpipelinable_requests.get() + 1);
             }
         }
-        self.requests.with_mut(|q| q.push_back(req));
+        let held = RefPtr::from_this(request);
+        self.requests.with_mut(|q| q.push_back(held));
     }
 
-    /// The queue's `RefPtr` keeps the pointee live; `JSMySQLQuery` is a
-    /// separate heap allocation and fully interior-mutable, so a shared
-    /// `&JSMySQLQuery` via `Deref` is sound across `&mut self` on the connection.
+    /// The queue's head request, if any. The queue holds a ref on every stored
+    /// request, so the handle is valid while the entry is queued; `JSMySQLQuery`
+    /// is a separate, fully interior-mutable heap allocation, so the `&` it
+    /// yields is sound across `&mut` on the embedding connection.
     #[inline]
-    pub(crate) fn current(&self) -> Option<bun_ptr::ThisPtr<JSMySQLQuery>> {
-        self.requests.get().front().map(RefPtr::this_ptr)
+    pub(crate) fn current(&self) -> Option<ThisPtr<JSMySQLQuery>> {
+        self.request_at(0)
     }
 
-    pub(crate) fn clean(&mut self, reason: Option<JSValue>, queries_array: JSValue) {
+    pub(crate) fn clean(&self, reason: Option<JSValue>, queries_array: JSValue) {
         // reject()/rejectWithJSValue() run JS which can synchronously call .close()
         // (or otherwise fail the connection) and re-enter clean(). Swap the queue
         // into a local first so the re-entrant call sees an empty queue instead of
         // deref()'ing + discard()'ing the same requests out from under us.
-        let requests = self.requests.replace(Queue::new());
+        let mut requests = self.requests.replace(Queue::new());
         self.pipelined_requests.set(0);
         self.nonpipelinable_requests.set(0);
         self.waiting_to_prepare.set(false);
 
-        for req in requests {
-            if !req.is_completed() {
+        while let Some(request) = requests.pop_front() {
+            // Each request's ref is released at the end of the loop body.
+            if !request.is_completed() {
                 if let Some(r) = reason {
-                    req.reject_with_js_value(queries_array, r);
+                    request.reject_with_js_value(queries_array, r);
                 } else {
-                    req.reject(queries_array, AnyMySQLError::ConnectionClosed);
+                    request.reject(queries_array, AnyMySQLError::ConnectionClosed);
                 }
             }
+            drop(request);
         }
     }
 }
 
 impl Drop for MySQLRequestQueue {
     fn drop(&mut self) {
-        for req in self.requests.replace(Queue::new()) {
+        while let Some(request) = self.requests.get_mut_unique().pop_front() {
             // We cannot touch JS here
-            req.mark_as_failed();
+            request.mark_as_failed();
+            drop(request);
         }
+        self.pipelined_requests.set(0);
+        self.nonpipelinable_requests.set(0);
+        self.waiting_to_prepare.set(false);
     }
 }

--- a/src/sql_jsc/mysql/MySQLStatement.rs
+++ b/src/sql_jsc/mysql/MySQLStatement.rs
@@ -1,6 +1,6 @@
 use core::cell::Cell;
 
-use crate::jsc::{JSGlobalObject, JSValue};
+use crate::jsc::{JSGlobalObject, JSValue, JsCell};
 
 use crate::mysql::protocol::Signature;
 use crate::shared::CachedStructure;
@@ -13,43 +13,47 @@ pub use bun_sql::mysql::mysql_param::Param;
 
 bun_core::declare_scope!(MySQLStatement, hidden);
 
+// Intrusive single-thread refcount (`CellRefCounted`). Shared between the owning query and the connection's prepared-statement map
+// (each holds a `RefPtr`), so every field written after construction is
+// interior-mutable and the statement is only ever reached as `&Self`.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct MySQLStatement {
-    pub(crate) cached_structure: CachedStructure,
+    pub(crate) cached_structure: JsCell<CachedStructure>,
     ref_count: Cell<u32>,
-    pub(crate) statement_id: u32,
-    pub(crate) params: Vec<Param>,
-    pub(crate) params_received: u32,
+    pub(crate) statement_id: Cell<u32>,
+    pub(crate) params: JsCell<Vec<Param>>,
+    pub(crate) params_received: Cell<u32>,
 
-    pub(crate) columns: Vec<ColumnDefinition41>,
-    pub(crate) columns_received: u32,
+    pub(crate) columns: JsCell<Vec<ColumnDefinition41>>,
+    pub(crate) columns_received: Cell<u32>,
 
     pub(crate) signature: Signature,
-    pub(crate) status: Status,
-    pub(crate) error_response: ErrorPacket,
-    pub(crate) execution_flags: ExecutionFlags,
-    pub(crate) fields_flags: DataCellFlags,
-    pub(crate) result_count: u64,
+    pub(crate) status: Cell<Status>,
+    pub(crate) error_response: JsCell<ErrorPacket>,
+    pub(crate) execution_flags: Cell<ExecutionFlags>,
+    pub(crate) fields_flags: Cell<DataCellFlags>,
+    pub(crate) result_count: Cell<u64>,
 }
 
 impl MySQLStatement {
-    /// Callers supply the signature and status; every other field takes its default.
-    pub(crate) fn new(signature: Signature, status: Status) -> Self {
-        Self {
-            cached_structure: CachedStructure::default(),
+    /// A new statement with one ref, owned by the returned handle; every other
+    /// field takes its default.
+    pub(crate) fn new(signature: Signature, status: Status) -> bun_ptr::RefPtr<Self> {
+        bun_ptr::RefPtr::new(Self {
+            cached_structure: JsCell::new(CachedStructure::default()),
             ref_count: Cell::new(1),
-            statement_id: 0,
-            params: Vec::new(),
-            params_received: 0,
-            columns: Vec::new(),
-            columns_received: 0,
+            statement_id: Cell::new(0),
+            params: JsCell::new(Vec::new()),
+            params_received: Cell::new(0),
+            columns: JsCell::new(Vec::new()),
+            columns_received: Cell::new(0),
             signature,
-            status,
-            error_response: ErrorPacket::default(),
-            execution_flags: ExecutionFlags::default(),
-            fields_flags: DataCellFlags::default(),
-            result_count: 0,
-        }
+            status: Cell::new(status),
+            error_response: JsCell::new(ErrorPacket::default()),
+            execution_flags: Cell::new(ExecutionFlags::default()),
+            fields_flags: Cell::new(DataCellFlags::default()),
+            result_count: Cell::new(0),
+        })
     }
 }
 
@@ -77,44 +81,62 @@ impl Default for ExecutionFlags {
 pub use bun_sql::shared::statement_status::Status;
 
 impl MySQLStatement {
-    pub(crate) fn reset(&mut self) {
-        self.result_count = 0;
-        self.columns_received = 0;
-        self.execution_flags = ExecutionFlags::default();
+    #[inline]
+    pub(crate) fn has_execution_flag(&self, flag: ExecutionFlags) -> bool {
+        self.execution_flags.get().contains(flag)
     }
 
-    fn check_for_duplicate_fields(&mut self) {
-        if !self
-            .execution_flags
-            .contains(ExecutionFlags::NEEDS_DUPLICATE_CHECK)
-        {
+    #[inline]
+    pub(crate) fn insert_execution_flag(&self, flag: ExecutionFlags) {
+        let mut flags = self.execution_flags.get();
+        flags.insert(flag);
+        self.execution_flags.set(flags);
+    }
+
+    #[inline]
+    pub(crate) fn remove_execution_flag(&self, flag: ExecutionFlags) {
+        let mut flags = self.execution_flags.get();
+        flags.remove(flag);
+        self.execution_flags.set(flags);
+    }
+
+    pub(crate) fn reset(&self) {
+        self.result_count.set(0);
+        self.columns_received.set(0);
+        self.execution_flags.set(ExecutionFlags::default());
+    }
+
+    fn check_for_duplicate_fields(&self) {
+        if !self.has_execution_flag(ExecutionFlags::NEEDS_DUPLICATE_CHECK) {
             return;
         }
-        self.execution_flags
-            .remove(ExecutionFlags::NEEDS_DUPLICATE_CHECK);
+        self.remove_execution_flag(ExecutionFlags::NEEDS_DUPLICATE_CHECK);
 
-        self.fields_flags =
-            dedupe_columns(self.columns.iter_mut().rev().map(|c| &mut c.name_or_index));
+        let flags = self.columns.with_mut(|columns| {
+            dedupe_columns(columns.iter_mut().rev().map(|c| &mut c.name_or_index))
+        });
+        self.fields_flags.set(flags);
     }
 
-    // Returning `&CachedStructure`
-    // to avoid moving out of `self`; callers may need `.clone()` if they require
-    // an owned copy.
+    /// The cached JSC structure for this statement's columns, building it on
+    /// first use.
     pub(crate) fn structure(
-        &mut self,
+        &self,
         owner: JSValue,
         global_object: &JSGlobalObject,
     ) -> &CachedStructure {
-        if self.cached_structure.has() {
-            return &self.cached_structure;
+        if !self.cached_structure.get().has() {
+            self.check_for_duplicate_fields();
+            let columns = self.columns.get();
+            self.cached_structure.with_mut(|cs| {
+                cs.build_from_columns(
+                    global_object,
+                    owner,
+                    columns.iter().map(|c| &c.name_or_index),
+                )
+            });
         }
-        self.check_for_duplicate_fields();
-        self.cached_structure.build_from_columns(
-            global_object,
-            owner,
-            self.columns.iter().map(|c| &c.name_or_index),
-        );
-        &self.cached_structure
+        self.cached_structure.get()
     }
 }
 

--- a/src/sql_jsc/mysql/MySQLValue.rs
+++ b/src/sql_jsc/mysql/MySQLValue.rs
@@ -13,7 +13,7 @@ use bun_sql::mysql::protocol::any_mysql_error;
 use bun_sql::mysql::protocol::prepared_statement::ExecuteParam;
 use bun_sql::shared::Data;
 
-use crate::jsc::webcore::Blob;
+use bun_jsc::PinnedBytes;
 
 pub(crate) fn field_type_from_js(
     global_object: &JSGlobalObject,
@@ -115,7 +115,7 @@ pub(crate) fn field_type_from_js(
     Ok(FieldType::MYSQL_TYPE_VARCHAR)
 }
 
-pub(crate) enum Value {
+pub(crate) enum Value<'a> {
     Null,
     Bool(bool),
     Short(i16),
@@ -128,47 +128,28 @@ pub(crate) enum Value {
     Double(f64),
 
     String(Utf8Bytes<'static>),
-    Bytes(Bytes),
+    Bytes(Bytes<'a>),
     Date(DateTime),
     Time(Time),
 }
 
 /// BLOB parameter bytes. `MySQLQuery.bind()` fills every `Value` before
 /// `execute.write()` reads any of them, and converting later parameters
-/// can run user JS (array index getters, toJSON, toString coercion). That
-/// JS could `transfer()`/detach an earlier ArrayBuffer, or drop the last
-/// JS reference to it and force GC, while we still hold a borrowed slice
-/// into it. Pinning the backing `ArrayBuffer` makes it non-detachable for
-/// the duration (`transfer()` then hands the user a copy), and the
-/// caller's stack-scoped `MarkedArgumentBuffer` roots the wrapper so GC
-/// can't sweep the cell whose `RefPtr<ArrayBuffer>` keeps the storage
-/// alive — `params` is on the malloc heap and isn't scanned. `Drop`
-/// unpins.
-pub struct Bytes {
-    pub(crate) slice: Utf8Bytes<'static>,
-    /// JS ArrayBuffer/view to `unpinArrayBuffer` in `Drop`. `JSValue::ZERO`
-    /// when the slice is owned (FastTypedArray dupe), borrowed from a
-    /// Blob store (nothing to unpin), or empty. GC rooting of this value
-    /// is the caller's responsibility via the `MarkedArgumentBuffer`
-    /// passed to `from_js`.
-    pub(crate) pinned: JSValue,
+/// can run user JS (array index getters, toJSON, toString coercion) that
+/// could `transfer()`/detach an earlier ArrayBuffer or drop the last JS
+/// reference to it. ArrayBuffer/view bytes are therefore [`PinnedBytes`]
+/// (pinned + rooted in the bind's `MarkedArgumentBuffer` for `'a`); a Blob's
+/// store is immutable from JS, so rooting its wrapper there is enough.
+pub(crate) enum Bytes<'a> {
+    Pinned(PinnedBytes<'a>),
+    Blob(&'a [u8]),
 }
 
-impl Default for Bytes {
-    fn default() -> Self {
-        Self {
-            slice: Utf8Bytes::EMPTY,
-            pinned: JSValue::ZERO,
-        }
-    }
-}
-
-impl Drop for Bytes {
-    fn drop(&mut self) {
-        if !self.pinned.is_empty() {
-            // `pinned` is rooted by the caller's MarkedArgumentBuffer for the
-            // lifetime of this Value (see struct doc); the FFI itself is `safe fn`.
-            JSC__JSValue__unpinArrayBuffer(self.pinned);
+impl Bytes<'_> {
+    fn slice(&self) -> &[u8] {
+        match self {
+            Bytes::Pinned(b) => b.slice(),
+            Bytes::Blob(b) => b,
         }
     }
 }
@@ -205,7 +186,7 @@ fn validate_bigint<T: bun_core::Integer>(
         .map_err(js_error_to_mysql)
 }
 
-impl ExecuteParam for Value {
+impl ExecuteParam for Value<'_> {
     fn is_null(&self) -> bool {
         matches!(self, Value::Null)
     }
@@ -262,7 +243,7 @@ impl ExecuteParam for Value {
                 });
             }
             Value::Bytes(b) => {
-                let s = b.slice.slice();
+                let s = b.slice();
                 return Ok(if s.is_empty() {
                     Data::Empty
                 } else {
@@ -275,14 +256,14 @@ impl ExecuteParam for Value {
     }
 }
 
-impl Value {
+impl<'a> Value<'a> {
     pub(crate) fn from_js(
         value: JSValue,
         global_object: &JSGlobalObject,
         field_type: FieldType,
         unsigned: bool,
-        roots: &mut MarkedArgumentBuffer,
-    ) -> Result<Value, any_mysql_error::Error> {
+        roots: &'a MarkedArgumentBuffer,
+    ) -> Result<Value<'a>, any_mysql_error::Error> {
         if value.is_empty_or_undefined_or_null() {
             return Ok(Value::Null);
         }
@@ -333,41 +314,12 @@ impl Value {
                     // Pin the backing ArrayBuffer so it stays non-detachable
                     // until Value drop unpins it; borrowing the slice is
                     // then safe without a copy. See `Bytes`.
-                    let mut ptr: *const u8 = core::ptr::null();
-                    let mut len: usize = 0;
-                    return match JSC__JSValue__borrowBytesForOffThread(value, &mut ptr, &mut len) {
-                        // detached / null
-                        0 => Ok(Value::Bytes(Bytes::default())),
-                        // FastTypedArray — tiny, GC-movable vector; dupe.
-                        1 => Ok(Value::Bytes(Bytes {
-                            // SAFETY: ptr/len returned from helper are valid for the
-                            // duration of this call; copied immediately.
-                            slice: Utf8Bytes::Owned(
-                                unsafe { core::slice::from_raw_parts(ptr, len) }.to_vec(),
-                            ),
-                            pinned: JSValue::ZERO,
-                        })),
-                        // Oversize/Wasteful/DataView/JSArrayBuffer — pinned
-                        // by the helper. Root the wrapper so GC can't
-                        // collect it (and free the backing store despite
-                        // the pin) if user JS drops the last reference from
-                        // a later parameter.
-                        kind @ (2 | 3) => {
-                            roots.append(value);
-                            Ok(Value::Bytes(Bytes {
-                                // SAFETY: backing storage is pinned or held (bufferless view) and
-                                // rooted via `roots`; slice stays valid until Bytes::drop unpins.
-                                slice: Utf8Bytes::Borrowed(unsafe {
-                                    core::slice::from_raw_parts(ptr, len)
-                                }),
-                                pinned: if kind == 2 { value } else { JSValue::ZERO },
-                            }))
-                        }
-                        _ => unreachable!(),
-                    };
+                    return Ok(Value::Bytes(Bytes::Pinned(
+                        roots.pin_bytes(value).unwrap_or(PinnedBytes::EMPTY),
+                    )));
                 }
 
-                if let Some(blob) = value.as_class_ref::<Blob>() {
+                if let Some(blob) = value.as_class_ref::<crate::jsc::webcore::Blob>() {
                     if blob.needs_to_read_file() {
                         return Err(js_error_to_mysql(global_object.throw_invalid_arguments(
                             format_args!("File blobs are not supported"),
@@ -378,10 +330,7 @@ impl Value {
                     // the last reference and force GC. Root the wrapper so
                     // the store survives until execute.write() has read it.
                     roots.append(value);
-                    return Ok(Value::Bytes(Bytes {
-                        slice: Utf8Bytes::Borrowed(blob.shared_view()),
-                        pinned: JSValue::ZERO,
-                    }));
+                    return Ok(Value::Bytes(Bytes::Blob(blob.shared_view())));
                 }
 
                 if value.is_string() {
@@ -802,20 +751,4 @@ fn gregorian_date(days: i32) -> Date {
         month: m,
         day: u8::try_from(d + 1).expect("int cast"),
     }
-}
-
-unsafe extern "C" {
-    /// By-value `JSValue`; C++ side null-checks and reads its own heap state.
-    /// No caller-side preconditions → `safe fn`.
-    safe fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
-    /// 0 = detached/null, 1 = FastTypedArray (GC-movable — caller should dupe;
-    /// no unpin needed), 2 = pinned an existing ArrayBuffer (caller must
-    /// `unpinArrayBuffer`), 3 = held a bufferless OversizeTypedArray (nothing to unpin; root it as for 2).
-    /// Out-params are `&mut` (same ABI as `*mut`), so the only obligation left
-    /// is on the *returned* slice, not the call itself → `safe fn`.
-    safe fn JSC__JSValue__borrowBytesForOffThread(
-        v: JSValue,
-        out_ptr: &mut *const u8,
-        out_len: &mut usize,
-    ) -> i32;
 }

--- a/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
+++ b/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
@@ -1,6 +1,6 @@
 use crate::jsc::JSGlobalObject;
 use crate::mysql::my_sql_value::{DateTime, Time};
-use crate::shared::sql_data_cell::SQLDataCell;
+use crate::shared::sql_data_cell::{CellStorage, SQLDataCell};
 use bun_sql::mysql::mysql_types as types;
 use bun_sql::mysql::mysql_types::FieldType;
 use bun_sql::mysql::protocol::new_reader::{NewReader, ReaderContext};
@@ -13,6 +13,7 @@ bun_core::declare_scope!(MySQLDecodeBinaryValue, visible);
 pub(crate) const BINARY_CHARSET: u16 = 63;
 
 pub(crate) fn decode_binary_value<Context: ReaderContext>(
+    storage: &mut CellStorage,
     global_object: &JSGlobalObject,
     field_type: types::FieldType,
     column_length: u32,
@@ -96,7 +97,7 @@ pub(crate) fn decode_binary_value<Context: ReaderContext>(
                 }
                 let mut buffer = bun_core::fmt::ItoaBuf::new();
                 let slice = bun_core::fmt::itoa(&mut buffer, val);
-                return Ok(SQLDataCell::string(slice));
+                return Ok(SQLDataCell::string(storage, slice));
             }
             let val = reader.int::<i64>()?;
             if val >= i32::MIN as i64 && val <= i32::MAX as i64 {
@@ -107,7 +108,7 @@ pub(crate) fn decode_binary_value<Context: ReaderContext>(
             }
             let mut buffer = bun_core::fmt::ItoaBuf::new();
             let slice = bun_core::fmt::itoa(&mut buffer, val);
-            Ok(SQLDataCell::string(slice))
+            Ok(SQLDataCell::string(storage, slice))
         }
         FieldType::MYSQL_TYPE_FLOAT => {
             if raw {
@@ -127,7 +128,7 @@ pub(crate) fn decode_binary_value<Context: ReaderContext>(
         }
         FieldType::MYSQL_TYPE_TIME => {
             match reader.byte()? {
-                0 => Ok(SQLDataCell::string(b"00:00:00")),
+                0 => Ok(SQLDataCell::string(storage, b"00:00:00")),
                 l @ (8 | 12) => {
                     let data = reader.read(l as usize)?;
                     let time = Time::from_data(&data)?;
@@ -168,7 +169,7 @@ pub(crate) fn decode_binary_value<Context: ReaderContext>(
                         break 'brk &buffer[..32 - remaining];
                     };
                     // reshaped for borrowck — compute remaining before re-borrowing buffer
-                    Ok(SQLDataCell::string(slice))
+                    Ok(SQLDataCell::string(storage, slice))
                 }
                 _ => Err(crate::Error::InvalidBinaryValue),
             }
@@ -204,7 +205,7 @@ pub(crate) fn decode_binary_value<Context: ReaderContext>(
                 return Ok(SQLDataCell::raw(Some(&data)));
             }
             let string_data = reader.encode_len_string()?;
-            Ok(SQLDataCell::string(string_data.slice()))
+            Ok(SQLDataCell::string(storage, string_data.slice()))
         }
 
         // When the column contains a binary string we return a Buffer otherwise a string
@@ -230,7 +231,7 @@ pub(crate) fn decode_binary_value<Context: ReaderContext>(
             if binary && character_set == BINARY_CHARSET {
                 return Ok(SQLDataCell::raw(Some(&string_data)));
             }
-            Ok(SQLDataCell::string(string_data.slice()))
+            Ok(SQLDataCell::string(storage, string_data.slice()))
         }
 
         FieldType::MYSQL_TYPE_JSON => {
@@ -239,7 +240,7 @@ pub(crate) fn decode_binary_value<Context: ReaderContext>(
                 return Ok(SQLDataCell::raw(Some(&data)));
             }
             let string_data = reader.encode_len_string()?;
-            Ok(SQLDataCell::json(string_data.slice()))
+            Ok(SQLDataCell::json(storage, string_data.slice()))
         }
         FieldType::MYSQL_TYPE_BIT => {
             // BIT(1) is a special case, it's a boolean

--- a/src/sql_jsc/mysql/protocol/ResultSet.rs
+++ b/src/sql_jsc/mysql/protocol/ResultSet.rs
@@ -11,7 +11,7 @@ use bun_sql::shared::Data;
 use bun_sql::shared::SQLQueryResultMode;
 
 use crate::shared::CachedStructure;
-use crate::shared::sql_data_cell::{Flags as SQLDataCellFlags, SQLDataCell};
+use crate::shared::sql_data_cell::{CellStorage, Flags as SQLDataCellFlags, SQLDataCell};
 
 use super::decode_binary_value::{self, decode_binary_value};
 
@@ -21,7 +21,9 @@ bun_core::declare_scope!(MySQLResultSet, visible);
 
 pub(crate) struct Row<'a> {
     pub values: Box<[SQLDataCell]>,
-    // `columns` is borrowed from the connection's column-definition buffer; see deinit note below.
+    /// Owns what `values` point at; see [`CellStorage`].
+    pub storage: CellStorage,
+    // `columns` is borrowed from the connection's column-definition buffer.
     pub columns: &'a [ColumnDefinition41],
     pub binary: bool,
     pub raw: bool,
@@ -64,6 +66,7 @@ impl<'a> Row<'a> {
 
     fn parse_value_and_set_cell(
         &self,
+        storage: &mut CellStorage,
         cell: &mut SQLDataCell,
         column: &ColumnDefinition41,
         value: &Data,
@@ -133,16 +136,16 @@ impl<'a> Row<'a> {
                     }
                 }
 
-                *cell = SQLDataCell::string(value.slice());
+                *cell = SQLDataCell::string(storage, value.slice());
             }
             MYSQL_TYPE_JSON => {
-                *cell = SQLDataCell::json(value.slice());
+                *cell = SQLDataCell::json(storage, value.slice());
             }
 
             MYSQL_TYPE_TIME => {
                 // lets handle TIME special case as string
                 // -838:59:50 to 838:59:59 is valid
-                *cell = SQLDataCell::string(value.slice());
+                *cell = SQLDataCell::string(storage, value.slice());
             }
             MYSQL_TYPE_DATE | MYSQL_TYPE_DATETIME | MYSQL_TYPE_TIMESTAMP => {
                 // MySQL's DATE/DATETIME/TIMESTAMP text has no timezone, so parse
@@ -162,7 +165,7 @@ impl<'a> Row<'a> {
             // carry the BINARY flag and charset 63, so the catch-all arm's binary-charset
             // heuristic would wrongly return them as a Buffer.
             MYSQL_TYPE_NEWDECIMAL => {
-                *cell = SQLDataCell::string(value.slice());
+                *cell = SQLDataCell::string(storage, value.slice());
             }
             MYSQL_TYPE_BIT => {
                 // BIT(1) is a special case, it's a boolean
@@ -183,7 +186,7 @@ impl<'a> Row<'a> {
                 {
                     *cell = SQLDataCell::raw(value);
                 } else {
-                    *cell = SQLDataCell::string(value.slice());
+                    *cell = SQLDataCell::string(storage, value.slice());
                 }
             }
         }
@@ -193,12 +196,8 @@ impl<'a> Row<'a> {
         &mut self,
         reader: NewReader<Context>,
     ) -> Result<(), AnyMySQLError> {
-        let cells = vec![SQLDataCell::null(); self.columns.len()].into_boxed_slice();
-        let mut cells = scopeguard::guard(cells, |mut cells| {
-            for value in cells.iter_mut() {
-                value.deinit();
-            }
-        });
+        let mut cells = vec![SQLDataCell::null(); self.columns.len()].into_boxed_slice();
+        let mut storage = CellStorage::default();
 
         for (index, value) in cells.iter_mut().enumerate() {
             if let Some(result) = decode_length_int(reader.peek()) {
@@ -220,7 +219,7 @@ impl<'a> Row<'a> {
                         reader.skip(result.bytes_read);
                         let string_data =
                             reader.read(usize::try_from(result.value).expect("int cast"))?;
-                        self.parse_value_and_set_cell(value, column, &string_data);
+                        self.parse_value_and_set_cell(&mut storage, value, column, &string_data);
                     }
                 }
                 value.set_column(
@@ -232,7 +231,8 @@ impl<'a> Row<'a> {
             }
         }
 
-        self.values = scopeguard::ScopeGuard::into_inner(cells);
+        self.values = cells;
+        self.storage = storage;
         Ok(())
     }
 
@@ -247,12 +247,8 @@ impl<'a> Row<'a> {
         let bitmap_bytes = (self.columns.len() + 7 + 2) / 8;
         let null_bitmap = reader.read(bitmap_bytes)?;
 
-        let cells = vec![SQLDataCell::null(); self.columns.len()].into_boxed_slice();
-        let mut cells = scopeguard::guard(cells, |mut cells| {
-            for value in cells.iter_mut() {
-                value.deinit();
-            }
-        });
+        let mut cells = vec![SQLDataCell::null(); self.columns.len()].into_boxed_slice();
+        let mut storage = CellStorage::default();
         // Skip first 2 bits of null bitmap (reserved)
         let bitmap_offset: usize = 2;
 
@@ -266,6 +262,7 @@ impl<'a> Row<'a> {
                 *value = SQLDataCell::null();
             } else {
                 *value = decode_binary_value(
+                    &mut storage,
                     self.global_object,
                     column.column_type,
                     column.column_length,
@@ -287,7 +284,8 @@ impl<'a> Row<'a> {
             value.set_column(u32::try_from(i).expect("int cast"), &column.name_or_index);
         }
 
-        self.values = scopeguard::ScopeGuard::into_inner(cells);
+        self.values = cells;
+        self.storage = storage;
         Ok(())
     }
 
@@ -297,17 +295,5 @@ impl<'a> Row<'a> {
         reader: NewReader<Context>,
     ) -> Result<(), AnyMySQLError> {
         self.decode_internal(reader)
-    }
-}
-
-impl<'a> Drop for Row<'a> {
-    fn drop(&mut self) {
-        for value in self.values.iter_mut() {
-            // SQLDataCell deliberately has no `impl Drop` — it is an FFI struct
-            // whose ownership is normally transferred to C++ — so the cells
-            // still owned by this row must be freed manually here.
-            value.deinit();
-        }
-        // self.columns is intentionally left out.
     }
 }

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -10,8 +10,8 @@ use bun_sql::postgres::postgres_types::AnyPostgresError;
 use bun_sql::shared::data::Data;
 use bun_sql::shared::sql_query_result_mode::SQLQueryResultMode as PostgresSQLQueryResultMode;
 
-pub(crate) use crate::shared::sql_data_cell::SQLDataCell;
 pub use crate::shared::sql_data_cell::{Array, Flags, Raw, Tag, TypedArray, Value};
+pub(crate) use crate::shared::sql_data_cell::{CellStorage, SQLDataCell};
 
 type Result<T, E = AnyPostgresError> = core::result::Result<T, E>;
 
@@ -43,31 +43,18 @@ fn parse_date_time_text(
     bun_string_jsc::parse_date(&str, global_object).map_err(crate::jsc::js_error_to_postgres)
 }
 
-fn parse_bytea(hex: &[u8]) -> Result<SQLDataCell> {
+fn parse_bytea(storage: &mut CellStorage, hex: &[u8]) -> Result<SQLDataCell> {
     let len = hex.len() / 2;
     let mut buf: Vec<u8> = Vec::new();
     buf.try_reserve_exact(len)
         .map_err(|_| AnyPostgresError::OutOfMemory)?;
-    // SAFETY: the decoder only writes into the spare bytes and returns how many it filled.
-    let written = unsafe {
-        bun_core::vec::fill_spare(&mut buf, 0, |spare| {
-            match bun_core::decode_hex_to_bytes(&mut spare[..len], hex) {
-                Ok(written) => (written, Ok(written)),
-                Err(_) => (0, Err(AnyPostgresError::InvalidByteSequence)),
-            }
-        })
-    }?;
-    // `SQLDataCell::deinit` frees this as a `Box<[u8]>` of exactly `written` bytes.
-    let ptr = bun_core::heap::into_raw(buf.into_boxed_slice()).cast::<u8>();
-
-    Ok(SQLDataCell {
-        tag: Tag::Bytea,
-        value: Value {
-            bytea: [ptr as usize, written],
-        },
-        free_value: 1,
-        ..Default::default()
-    })
+    buf.resize(len, 0);
+    let written = bun_core::decode_hex_to_bytes(&mut buf, hex)
+        .map_err(|_| AnyPostgresError::InvalidByteSequence)?;
+    buf.truncate(written);
+    Ok(SQLDataCell::bytea(
+        storage.hold_bytes(buf.into_boxed_slice()),
+    ))
 }
 
 fn unescape_postgres_string<'a>(input: &[u8], buffer: &'a mut [u8]) -> crate::Result<&'a mut [u8]> {
@@ -130,6 +117,7 @@ const MAX_ARRAY_NESTING_DEPTH: usize = 100;
 // PERF: `array_type` and `is_json_sub_array` are only used in value
 // position (branch selectors), never type position. Profile if it shows up on a hot path.
 fn parse_array(
+    storage: &mut CellStorage,
     bytes: &[u8],
     bigint: bool,
     array_type: types::Tag,
@@ -160,15 +148,7 @@ fn parse_array(
         });
     }
 
-    // errdefer { for cell in array { cell.deinit() }; array.deinit() }
-    // → scopeguard: SQLDataCell has FFI-side resources that Vec::drop won't release.
-    let array = scopeguard::guard(Vec::<SQLDataCell>::new(), |mut a| {
-        for cell in a.iter_mut() {
-            cell.deinit();
-        }
-        // Vec storage drops here
-    });
-    let mut array = array;
+    let mut array = Vec::<SQLDataCell>::new();
 
     let mut stack_buffer = [0u8; 16 * 1024];
 
@@ -193,6 +173,7 @@ fn parse_array(
         } else if ch == opening_brace {
             let mut sub_array_offset: usize = 0;
             let sub_array = parse_array(
+                storage,
                 slice,
                 bigint,
                 array_type,
@@ -228,7 +209,10 @@ fn parse_array(
                     let bytea_bytes = &slice[1..current_idx];
                     if bytea_bytes.starts_with(b"\\\\x") {
                         // its a bytea string lets parse it as a bytea
-                        array.push(parse_bytea(&bytea_bytes[3..][0..bytea_bytes.len() - 3])?);
+                        array.push(parse_bytea(
+                            storage,
+                            &bytea_bytes[3..][0..bytea_bytes.len() - 3],
+                        )?);
                         slice = try_slice(slice, current_idx + 1);
                         continue;
                     }
@@ -260,7 +244,7 @@ fn parse_array(
                     };
                     let unescaped = unescape_postgres_string(str_bytes, buffer)
                         .map_err(|_| AnyPostgresError::InvalidByteSequence)?;
-                    array.push(SQLDataCell::json(unescaped));
+                    array.push(SQLDataCell::json(storage, unescaped));
                     slice = try_slice(slice, current_idx + 1);
                     continue;
                 }
@@ -269,7 +253,7 @@ fn parse_array(
             let str_bytes = &slice[1..current_idx];
             if str_bytes.is_empty() {
                 // empty string
-                array.push(SQLDataCell::string(b""));
+                array.push(SQLDataCell::string(storage, b""));
                 slice = try_slice(slice, current_idx + 1);
                 continue;
             }
@@ -283,7 +267,7 @@ fn parse_array(
             };
             let string_bytes = unescape_postgres_string(str_bytes, buffer)
                 .map_err(|_| AnyPostgresError::InvalidByteSequence)?;
-            array.push(SQLDataCell::string(string_bytes));
+            array.push(SQLDataCell::string(storage, string_bytes));
 
             slice = try_slice(slice, current_idx + 1);
             continue;
@@ -356,9 +340,9 @@ fn parse_array(
                     } else {
                         // the only escape sequency possible here is \b
                         if element == b"\\b" {
-                            array.push(SQLDataCell::string(b"\x08"));
+                            array.push(SQLDataCell::string(storage, b"\x08"));
                         } else {
-                            array.push(SQLDataCell::string(element));
+                            array.push(SQLDataCell::string(storage, element));
                         }
                     }
                     slice = try_slice(slice, current_idx);
@@ -558,7 +542,7 @@ fn parse_array(
                                                 .ok_or(AnyPostgresError::UnsupportedArrayFormat)?,
                                         ));
                                     } else {
-                                        array.push(SQLDataCell::string(element));
+                                        array.push(SQLDataCell::string(storage, element));
                                     }
                                     slice = try_slice(slice, current_idx);
                                     continue;
@@ -585,6 +569,7 @@ fn parse_array(
                                 if slice[0] == b'[' {
                                     let mut sub_array_offset: usize = 0;
                                     let sub_array = parse_array(
+                                        storage,
                                         slice,
                                         bigint,
                                         array_type,
@@ -616,17 +601,11 @@ fn parse_array(
         return Err(AnyPostgresError::UnsupportedArrayFormat);
     }
 
-    // disarm errdefer
-    let mut array = core::mem::ManuallyDrop::new(scopeguard::ScopeGuard::into_inner(array));
-    let len = array.len() as u32;
-    let cap = array.capacity() as u32;
-    let ptr = array.as_mut_ptr();
     Ok(SQLDataCell {
         tag: Tag::Array,
         value: Value {
-            array: Array { ptr, len, cap },
+            array: storage.hold_array(array),
         },
-        free_value: 1,
         ..Default::default()
     })
 }
@@ -634,6 +613,7 @@ fn parse_array(
 // Helper: typed-array binary path shared by .int4_array / .float4_array.
 // Monomorphized over the element type.
 fn from_bytes_typed_array<Elem: bun_sql::postgres::types::tag::WireByteSwap>(
+    storage: &mut CellStorage,
     tag: types::Tag,
     bytes: &[u8],
 ) -> Result<SQLDataCell> {
@@ -702,13 +682,13 @@ fn from_bytes_typed_array<Elem: bun_sql::postgres::types::tag::WireByteSwap>(
     // — the `readonly` LLVM parameter attribute lets the optimizer elide
     // those writes, which in the release-asan build left the header `len`
     // un-byte-swapped (3 → 0x03000000) and produced a 192MB OOB memcpy in
-    // SQLClient.cpp. Parse into an owned buffer instead; freed via
-    // `free_value = 1` after C++ has copied it into the JS typed array.
+    // SQLClient.cpp. Parse into a buffer held by `storage` instead, which
+    // C++ copies into the JS typed array.
     let array_len = array_len as usize;
     let elem_size = size_of::<Elem>();
     let out_bytes = array_len * elem_size;
-    let (head_ptr, free_value) = if array_len == 0 {
-        (core::ptr::null_mut::<u8>(), 0u8)
+    let head_ptr = if array_len == 0 {
+        core::ptr::null_mut::<u8>()
     } else {
         let mut out: Box<[u8]> = vec![0u8; out_bytes].into_boxed_slice();
         for i in 0..array_len {
@@ -724,7 +704,7 @@ fn from_bytes_typed_array<Elem: bun_sql::postgres::types::tag::WireByteSwap>(
                 .wire_byte_swap();
             val.write_unaligned_ne_bytes(&mut out[i * elem_size..(i + 1) * elem_size]);
         }
-        (Box::into_raw(out).cast::<u8>(), 1u8)
+        storage.hold_bytes(out).as_ptr().cast_mut()
     };
 
     Ok(SQLDataCell {
@@ -738,12 +718,12 @@ fn from_bytes_typed_array<Elem: bun_sql::postgres::types::tag::WireByteSwap>(
                 type_: js_typed_array_type,
             },
         },
-        free_value,
         ..Default::default()
     })
 }
 
 fn from_bytes(
+    storage: &mut CellStorage,
     binary: bool,
     bigint: bool,
     oid: types::Tag,
@@ -755,16 +735,16 @@ fn from_bytes(
         // TODO: .int2_array, .float8_array
         T::int4_array => {
             if binary {
-                from_bytes_typed_array::<i32>(T::int4_array, bytes)
+                from_bytes_typed_array::<i32>(storage, T::int4_array, bytes)
             } else {
-                parse_array(bytes, bigint, T::int4_array, global_object, None, false, 0)
+                parse_array(storage, bytes, bigint, T::int4_array, global_object, None, false, 0)
             }
         }
         T::float4_array => {
             if binary {
-                from_bytes_typed_array::<f32>(T::float4_array, bytes)
+                from_bytes_typed_array::<f32>(storage, T::float4_array, bytes)
             } else {
-                parse_array(bytes, bigint, T::float4_array, global_object, None, false, 0)
+                parse_array(storage, bytes, bigint, T::float4_array, global_object, None, false, 0)
             }
         }
         T::int2 => {
@@ -802,7 +782,7 @@ fn from_bytes(
                     bun_core::fmt::parse_decimal::<i64>(bytes).unwrap_or(0),
                 ))
             } else {
-                Ok(SQLDataCell::string(bytes))
+                Ok(SQLDataCell::string(storage, bytes))
             }
         }
         T::float8 => {
@@ -831,13 +811,13 @@ fn from_bytes(
                 // if is binary format lets display as a string because JS cant handle it in a safe way
                 let result = parse_binary_numeric(bytes, &mut numeric_buffer)
                     .map_err(|_| AnyPostgresError::UnsupportedNumericFormat)?;
-                Ok(SQLDataCell::string(result.slice()))
+                Ok(SQLDataCell::string(storage, result.slice()))
             } else {
                 // nice text is actually what we want here
-                Ok(SQLDataCell::string(bytes))
+                Ok(SQLDataCell::string(storage, bytes))
             }
         }
-        T::jsonb | T::json => Ok(SQLDataCell::json(bytes)),
+        T::jsonb | T::json => Ok(SQLDataCell::json(storage, bytes)),
         T::bool => {
             if binary {
                 Ok(SQLDataCell::bool(!bytes.is_empty() && bytes[0] == 1))
@@ -886,7 +866,7 @@ fn from_bytes(
                     let mut buffer = [0u8; 32];
                     let len = Postgres__formatTime(microseconds, &mut buffer, 32);
 
-                    Ok(SQLDataCell::string(&buffer[0..len]))
+                    Ok(SQLDataCell::string(storage, &buffer[0..len]))
                 } else if tag == T::timetz && bytes.len() == 12 {
                     // PostgreSQL sends timetz as microseconds since midnight (8 bytes) + timezone offset in seconds (4 bytes)
                     let microseconds = i64::from_ne_bytes(bytes[0..8].try_into().expect("infallible: size matches")).swap_bytes();
@@ -896,26 +876,22 @@ fn from_bytes(
                     let mut buffer = [0u8; 48];
                     let len = Postgres__formatTimeTz(microseconds, tz_offset_seconds, &mut buffer, 48);
 
-                    Ok(SQLDataCell::string(&buffer[0..len]))
+                    Ok(SQLDataCell::string(storage, &buffer[0..len]))
                 } else {
                     Err(AnyPostgresError::InvalidBinaryData)
                 }
             } else {
                 // Text format - just return as string
-                Ok(SQLDataCell::string(bytes))
+                Ok(SQLDataCell::string(storage, bytes))
             }
         }
 
         T::bytea => {
             if binary {
-                Ok(SQLDataCell {
-                    tag: Tag::Bytea,
-                    value: Value { bytea: [bytes.as_ptr() as usize, bytes.len()] },
-                    ..Default::default()
-                })
+                Ok(SQLDataCell::bytea(bytes))
             } else {
                 if bytes.starts_with(b"\\x") {
-                    return parse_bytea(&bytes[2..]);
+                    return parse_bytea(storage, &bytes[2..]);
                 }
                 Err(AnyPostgresError::UnsupportedByteaFormat)
             }
@@ -967,8 +943,8 @@ fn from_bytes(
         | T::timetz_array
         | T::timestamp_array
         | T::timestamptz_array
-        | T::interval_array) => parse_array(bytes, bigint, tag, global_object, None, false, 0),
-        _ => Ok(SQLDataCell::string(bytes)),
+        | T::interval_array) => parse_array(storage, bytes, bigint, tag, global_object, None, false, 0),
+        _ => Ok(SQLDataCell::string(storage, bytes)),
     }
 }
 
@@ -1207,6 +1183,8 @@ pub(crate) fn parse_binary_float4(bytes: &[u8]) -> Result<f32, AnyPostgresError>
 
 pub(crate) struct Putter<'a> {
     pub list: &'a mut [SQLDataCell],
+    /// Owns what the cells in `list` point at; see [`CellStorage`].
+    pub storage: CellStorage,
     pub fields: &'a [protocol::FieldDescription],
     pub binary: bool,
     pub bigint: bool,
@@ -1277,6 +1255,7 @@ impl<'a> Putter<'a> {
             };
             *cell = if let Some(data) = optional_bytes {
                 from_bytes(
+                    &mut self.storage,
                     (field.binary || self.binary) && tag.is_binary_format_supported(),
                     self.bigint,
                     tag,

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -286,7 +286,7 @@ pub(crate) fn prepare_and_query_with_signature<Context: WriterContext>(
     query: &[u8],
     array_value: JSValue,
     mut writer: protocol::NewWriter<Context>,
-    signature: &mut Signature,
+    signature: &Signature,
 ) -> Result<(), AnyPostgresError> {
     write_query(
         query,
@@ -330,8 +330,8 @@ pub(crate) fn bind_and_execute<Context: WriterContext>(
         global,
         array_value,
         columns_value,
-        &statement.parameters,
-        &statement.fields,
+        statement.parameters.get(),
+        statement.fields.get(),
         writer,
     )?;
     let exec = protocol::Execute {
@@ -386,12 +386,13 @@ pub(crate) fn parse_and_bind_and_execute<Context: WriterContext>(
     // Bind — use server-provided types if available (binary format), otherwise
     // fall back to signature types (text format for unknowns). The server will
     // handle text-to-type conversion based on the parameter types from Parse.
-    let param_fields = if !statement.parameters.is_empty() {
-        &statement.parameters[..]
+    let parameters = statement.parameters.get();
+    let param_fields = if !parameters.is_empty() {
+        &parameters[..]
     } else {
         &statement.signature.fields[..]
     };
-    let result_fields = &statement.fields;
+    let result_fields = statement.fields.get();
 
     write_bind(
         name,
@@ -531,7 +532,8 @@ pub(crate) fn on_data<Context: ReaderContext>(
     }
 }
 
-/// Each entry holds a ref on its query.
+// `bun.LinearFifo(*PostgresSQLQuery, .Dynamic)` — each entry is the ref the
+// queue holds on that query, released when the entry is discarded.
 pub(crate) type Queue = std::collections::VecDeque<bun_ptr::RefPtr<PostgresSQLQuery>>;
 
 use crate::postgres::postgres_sql_connection::{SslMode, TlsStatus};

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -4,21 +4,19 @@ use core::cell::Cell;
 use core::ffi::c_void;
 use core::sync::atomic::{AtomicU32, Ordering};
 
-use crate::jsc::EventLoopTimer;
-use crate::jsc::webcore::AutoFlusher;
 use crate::jsc::{
-    self as jsc, CallFrame, HasAutoFlush, JSGlobalObject, JSValue, JsResult, Strong,
-    VirtualMachine, VirtualMachineSqlExt as _, bun_string_jsc,
+    self as jsc, AutoFlushTarget, AutoFlusher, CallFrame, JSGlobalObject, JSValue, JsResult,
+    Strong, VirtualMachine, VirtualMachineSqlExt as _, bun_string_jsc,
 };
+use crate::jsc::{EventLoopTimer, TimerRef};
 use bun_boringssl as BoringSSL;
 use bun_boringssl_sys::OwnedSslCtx;
 use bun_collections::{OffsetByteList, StringHashMap, StringMap};
 use bun_core::strings;
 use bun_core::{self};
 use bun_io::KeepAlive;
-use bun_ptr::{AsCtxPtr, BackRef, ParentRef, RefPtr};
+use bun_ptr::{BackRef, RefPtr, ThisPtr};
 use bun_uws as uws;
-use core::ptr::NonNull;
 
 use crate::jsc::{EventLoopTimerState, EventLoopTimerTag};
 use crate::postgres::AuthenticationState;
@@ -54,7 +52,8 @@ bun_core::define_scoped_log!(debug, Postgres, visible);
 
 const MAX_PIPELINE_SIZE: usize = u16::MAX as usize; // about 64KB per connection
 
-/// `None` only transiently, inside `get_or_put` before the new statement is stored.
+/// The connection's ref on each cached named statement (`None` while a slot
+/// is reserved but the statement is not built yet).
 type PreparedStatementsMap = StringHashMap<Option<RefPtr<PostgresSQLStatement>>>;
 
 pub mod js {
@@ -64,7 +63,7 @@ pub mod js {
 impl jsc::JsClass for PostgresSQLConnection {
     fn to_js(self, global: &JSGlobalObject) -> JSValue {
         // Ownership transfers to the JSC wrapper's m_ctx; freed via `finalize`.
-        js::to_js(bun_core::heap::into_raw(Box::new(self)), global)
+        js::to_js(Self::new(self).into_this_ptr().as_ptr(), global)
     }
     fn from_js(value: JSValue) -> Option<*mut Self> {
         js::from_js(value)
@@ -96,8 +95,8 @@ use crate::jsc::verify_error_to_js;
 pub struct PostgresSQLConnection {
     pub(crate) socket: JsCell<Socket>,
     pub(crate) status: Cell<Status>,
-    // Private — intrusive refcount invariant; reach via `ref_()`/`deref()`
-    // (provided by `#[derive(CellRefCounted)]` above).
+    // Intrusive refcount (`CellRefCounted`); refs are held as `RefPtr`, and
+    // the last release runs `Drop`.
     ref_count: Cell<u32>,
 
     pub(crate) write_buffer: JsCell<OffsetByteList>,
@@ -121,8 +120,7 @@ pub struct PostgresSQLConnection {
     // every connection it creates. Only ever borrowed via `global()`.
     pub(crate) global_object: BackRef<JSGlobalObject>,
     // JSC_BORROW: process-lifetime singleton. `BackRef` so `vm()` is a safe
-    // deref; constructed via `new_mut` (write provenance from `&mut *vm_ptr`)
-    // so `vm_mut()`'s `&mut *as_ptr()` is sound.
+    // deref.
     pub(crate) vm: BackRef<VirtualMachine>,
     pub(crate) statements: JsCell<PreparedStatementsMap>,
     pub(crate) prepared_statement_id: Cell<u64>,
@@ -148,7 +146,7 @@ pub struct PostgresSQLConnection {
 
     pub(crate) authentication_state: JsCell<AuthenticationState>,
 
-    /// `us_ssl_ctx_t` built from `tls_config` at construct time. Applied via
+    /// `SSL_CTX` built from `tls_config` at construct time. Applied via
     /// `us_socket_adopt_tls` when the server replies `S` to the SSLRequest.
     pub(crate) secure: Option<OwnedSslCtx>,
     pub(crate) tls_config: jsc::api::ServerConfig::SSLConfig,
@@ -162,22 +160,23 @@ pub struct PostgresSQLConnection {
 
     /// Before being connected, this is a connection timeout timer.
     /// After being connected, this is an idle timeout timer.
-    // Private — intrusive heap node; cross-crate `container_of` goes through
-    // [`Self::from_timer_ptr`] instead of `offset_of!` on the field. `JsCell`
-    // is `#[repr(transparent)]` so the byte offset of the inner
-    // `EventLoopTimer` equals `offset_of!(Self, timer)`.
-    timer: JsCell<EventLoopTimer>,
+    // Intrusive heap node; `bun_runtime::dispatch` recovers `Self` from it by
+    // `offset_of!` (`JsCell` is `#[repr(transparent)]`).
+    pub timer: JsCell<EventLoopTimer>,
 
     /// This timer controls the maximum lifetime of a connection.
     /// It starts when the connection successfully starts (i.e. after handshake is complete).
     /// It stops when the connection is closed.
     pub(crate) max_lifetime_interval_ms: u32,
-    // Private — see `timer`; recovered via [`Self::from_max_lifetime_timer_ptr`].
-    max_lifetime_timer: JsCell<EventLoopTimer>,
-    pub(crate) auto_flusher: JsCell<AutoFlusher>,
+    // See `timer`.
+    pub max_lifetime_timer: JsCell<EventLoopTimer>,
+    pub(crate) auto_flusher: AutoFlusher<PostgresSQLConnection>,
 
     /// Interned notification channel names; see `channel_name_js`.
     channel_names: JsCell<Vec<InternedChannel>>,
+    /// This allocation's root pointer, for the `&self` paths that take refs on
+    /// it (`ref_guard`, the socket ext slot, the auto-flush registration).
+    this_ptr: Cell<Option<BackRef<PostgresSQLConnection, bun_ptr::Root>>>,
 }
 
 struct InternedChannel {
@@ -189,18 +188,6 @@ bun_event_loop::impl_timer_owner!(PostgresSQLConnection;
     from_timer_ptr => timer,
     from_max_lifetime_timer_ptr => max_lifetime_timer,
 );
-
-impl Drop for PostgresSQLConnection {
-    fn drop(&mut self) {
-        self.disconnect();
-        self.stop_timers();
-        // `free_sensitive`: the connection options carry the password.
-        for b in self.options_buf.iter_mut() {
-            // SAFETY: plain byte write; volatile so it is not elided.
-            unsafe { core::ptr::write_volatile(b, 0) };
-        }
-    }
-}
 
 impl PostgresSQLConnection {
     // ─── R-2 interior-mutability helpers ─────────────────────────────────────
@@ -229,27 +216,53 @@ impl PostgresSQLConnection {
         self.vm.get()
     }
 
-    /// `&mut VirtualMachine` for the few `vm.timer()` / `vm.sql_state()` callers
-    /// whose trait methods take `&mut self`. The VM is a JS-thread singleton; we
-    /// never hold two `&mut` to it at once in this module. Explicit `'static` so
-    /// the return does not reborrow `*self` — callers pair this with
-    /// `self.timer.with_mut(|t| ...)` in the same expression.
+    /// `&mut VirtualMachine` for `postgres_socket_group()`. The VM is a
+    /// JS-thread singleton; the borrow is not held across re-entrant calls.
     #[inline]
-    fn vm_mut(&self) -> &'static mut VirtualMachine {
-        VirtualMachine::get_mut()
+    fn vm_mut(&self) -> &mut VirtualMachine {
+        self.vm().as_mut()
     }
 
-    /// `&mut EventLoop` for `enter`/`exit`/`run_callback`. One audited unsafe
-    /// here replaces the per-site `unsafe { self.vm().event_loop_mut() }` —
-    /// the loop is a disjoint heap allocation owned by the JS-thread VM
-    /// singleton (see [`vm_mut`]); single-thread affinity ⇒ no two
-    /// `&mut EventLoop` ever coexist.
+    /// `&mut EventLoop` for `enter`/`exit`/`run_callback`; the loop is owned
+    /// by the JS-thread VM singleton (see `VirtualMachine::event_loop_mut`).
     #[inline]
-    fn event_loop(&self) -> &'static mut crate::jsc::EventLoop {
-        // `vm_mut()` yields the process-lifetime `'static mut VM` (see above);
-        // the event loop it owns lives for the VM's lifetime. Single-JS-thread
-        // invariant ⇒ callers never hold two `&mut EventLoop` at once.
-        self.vm_mut().event_loop_mut()
+    fn event_loop(&self) -> &mut crate::jsc::EventLoop {
+        self.vm().event_loop_mut()
+    }
+
+    /// This allocation's root pointer (see the `this_ptr` field).
+    #[inline]
+    pub(crate) fn this_ptr(&self) -> ThisPtr<Self> {
+        self.this_ptr
+            .get()
+            .expect("PostgresSQLConnection used before PostgresSQLConnection::new")
+            .this_ptr()
+    }
+
+    /// Holds a ref on `self` for the guard's scope (re-entrant paths).
+    #[inline]
+    fn ref_guard(&self) -> RefPtr<Self> {
+        RefPtr::from_this(self.this_ptr())
+    }
+
+    /// Heap-allocate the connection. The returned ref is the one its JS
+    /// wrapper adopts: hand it over with `into_this_ptr()` + `js::to_js`
+    /// (released by `finalize`), or `deref()` it to free an unwrapped
+    /// connection.
+    fn new(init: Self) -> RefPtr<Self> {
+        let this = RefPtr::new(init);
+        this.this_ptr.set(Some(this.this_ptr().into()));
+        this
+    }
+
+    #[inline]
+    fn timer_ref(&self) -> TimerRef {
+        TimerRef::new(self, |c| &c.timer)
+    }
+
+    #[inline]
+    fn max_lifetime_timer_ref(&self) -> TimerRef {
+        TimerRef::new(self, |c| &c.max_lifetime_timer)
     }
 
     /// `KeepAlive::{ref_,unref}` take an `EventLoopCtx` (manual vtable, lives in
@@ -280,98 +293,73 @@ impl PostgresSQLConnection {
         self.password.slice()
     }
 
-    /// Project `&mut SASL` from `authentication_state` if it is currently the
-    /// `Sasl` variant. One audited [`JsCell::get_mut`] here replaces the three
-    /// per-site unchecked `authentication_state.get_mut()` derefs in the SASL
-    /// handshake arms of [`on`](Self::on).
-    ///
-    /// SAFETY (encapsulated): single-JS-thread; callers hold the returned
-    /// `&mut SASL` only for the synchronous packet-handler body and drop it
-    /// before any call that touches `authentication_state` again
-    /// (`self.writer()` / `self.flush_data()` / `self.fail()` do not).
+    /// Run `f` against the SCRAM state if `authentication_state` is currently
+    /// the `Sasl` variant (else `None`). `f` must not reach
+    /// `authentication_state` again (`self.writer()` / `self.flush_data()` /
+    /// `self.fail()` do not).
     #[inline]
-    #[allow(clippy::mut_from_ref)] // body projects through `JsCell` (UnsafeCell-backed); see SAFETY note
-    fn sasl_state_mut(&self) -> Option<&mut crate::postgres::sasl::SASL> {
-        // SAFETY: see doc comment — single-JS-thread, no re-entrant access to
-        // `authentication_state` for the borrow's lifetime.
-        match unsafe { self.authentication_state.get_mut() } {
-            AuthenticationState::Sasl(s) => Some(s),
+    fn with_sasl<R>(&self, f: impl FnOnce(&mut crate::postgres::sasl::SASL) -> R) -> Option<R> {
+        self.authentication_state.with_mut(|state| match state {
+            AuthenticationState::Sasl(s) => Some(f(s)),
             _ => None,
-        }
+        })
     }
 }
 
-impl HasAutoFlush for PostgresSQLConnection {
-    fn on_auto_flush(this: *mut Self) -> bool {
-        // `this` is the live `PostgresSQLConnection` registered with the
-        // deferred-task queue (via `register_auto_flusher`, which passes
-        // `self.as_ctx_ptr()` — never null); the queue runs on the JS thread.
-        // R-2: `ParentRef` yields `&T` only — body takes `&self`.
-        let this = ParentRef::from(NonNull::new(this).expect("auto-flush ctx non-null"));
-        this.on_auto_flush_impl()
+impl AutoFlushTarget for PostgresSQLConnection {
+    fn auto_flusher(&self) -> &AutoFlusher<Self> {
+        &self.auto_flusher
     }
-}
 
-impl PostgresSQLConnection {
-    fn on_auto_flush_impl(&self) -> bool {
-        if self.flags.get().contains(ConnectionFlags::HAS_BACKPRESSURE) {
+    /// Whether to stay registered for the next drain.
+    fn on_auto_flush(this: ThisPtr<Self>) -> bool {
+        if this.flags.get().contains(ConnectionFlags::HAS_BACKPRESSURE) {
             debug!("onAutoFlush: has backpressure");
-            self.auto_flusher.with_mut(|a| a.registered = false);
             // if we have backpressure, wait for onWritable
             return false;
         }
-        let _guard = self.ref_guard();
+        let _guard = this.ref_guard();
         debug!("onAutoFlush: draining");
         // drain as much as we can
-        self.drain_internal();
+        this.drain_internal();
 
         // if we dont have backpressure and if we still have data to send, return true otherwise return false and wait for onWritable
-        let keep_flusher_registered = !self.flags.get().contains(ConnectionFlags::HAS_BACKPRESSURE)
-            && self.write_buffer.get().len() > 0;
+        let keep_flusher_registered = !this.flags.get().contains(ConnectionFlags::HAS_BACKPRESSURE)
+            && this.write_buffer.get().len() > 0;
         debug!(
             "onAutoFlush: keep_flusher_registered: {}",
             keep_flusher_registered
         );
-        self.auto_flusher
-            .with_mut(|a| a.registered = keep_flusher_registered);
         keep_flusher_registered
     }
+}
 
+impl PostgresSQLConnection {
     fn register_auto_flusher(&self) {
         let data_to_send = self.write_buffer.get().len();
         debug!(
             "registerAutoFlusher: backpressure: {} registered: {} data_to_send: {}",
             self.flags.get().contains(ConnectionFlags::HAS_BACKPRESSURE),
-            self.auto_flusher.get().registered,
+            self.auto_flusher.is_registered(),
             data_to_send
         );
 
-        if !self.auto_flusher.get().registered // should not be registered
+        if !self.auto_flusher.is_registered() // should not be registered
             && !self.flags.get().contains(ConnectionFlags::HAS_BACKPRESSURE) // if has backpressure we need to wait for onWritable event
             && data_to_send > 0 // we need data to send
             && self.status.get() == Status::Connected
         // and we need to be connected
         {
-            AutoFlusher::register_deferred_microtask_with_type_unchecked::<Self>(
-                self.as_ctx_ptr(),
-                self.vm(),
-            );
-            self.auto_flusher.with_mut(|a| a.registered = true);
+            AutoFlusher::register(self.this_ptr(), self.vm());
         }
     }
 
     fn unregister_auto_flusher(&self) {
         debug!(
             "unregisterAutoFlusher registered: {}",
-            self.auto_flusher.get().registered
+            self.auto_flusher.is_registered()
         );
-        if self.auto_flusher.get().registered {
-            AutoFlusher::unregister_deferred_microtask_with_type::<Self>(
-                self.as_ctx_ptr(),
-                self.vm(),
-            );
-            self.auto_flusher.with_mut(|a| a.registered = false);
-        }
+        self.auto_flusher.unregister(self.vm());
     }
 
     fn get_timeout_interval(&self) -> u32 {
@@ -383,12 +371,11 @@ impl PostgresSQLConnection {
     }
 
     pub(crate) fn disable_connection_timeout(&self) {
-        self.timer.with_mut(|t| {
-            if t.state == EventLoopTimerState::ACTIVE {
-                self.vm_mut().timer().remove(t);
-            }
-            t.state = EventLoopTimerState::CANCELLED;
-        });
+        if self.timer.get().state == EventLoopTimerState::ACTIVE {
+            self.vm().timer_remove(self.timer_ref());
+        }
+        self.timer
+            .with_mut(|t| t.state = EventLoopTimerState::CANCELLED);
     }
 
     pub(crate) fn reset_connection_timeout(&self) {
@@ -401,25 +388,19 @@ impl PostgresSQLConnection {
             return;
         }
         let interval = self.get_timeout_interval();
+        if self.timer.get().state == EventLoopTimerState::ACTIVE {
+            self.vm().timer_remove(self.timer_ref());
+        }
+        if interval == 0 {
+            return;
+        }
         self.timer.with_mut(|t| {
-            if t.state == EventLoopTimerState::ACTIVE {
-                self.vm_mut().timer().remove(t);
-            }
-            if interval == 0 {
-                return;
-            }
             t.next = bun_core::Timespec::ms_from_now(
                 bun_core::TimespecMockMode::ForceRealTime,
                 i64::from(interval),
             );
         });
-        if interval != 0 {
-            // whole-struct provenance: the fire path recovers the container from this pointer.
-            let t = core::ptr::addr_of!(self.timer)
-                .cast::<EventLoopTimer>()
-                .cast_mut();
-            self.vm_mut().timer().insert(t);
-        }
+        self.vm().timer_insert(self.timer_ref());
     }
 
     bun_jsc::cached_prop_hostfns! {
@@ -453,34 +434,23 @@ impl PostgresSQLConnection {
             return;
         };
 
-        // SAFETY: `secure` is set to a live `SSL_CTX*` before `setup_tls` is
-        // reached.
-        let ssl_ctx = unsafe {
-            &mut *self
-                .secure
+        let ssl_ctx = bun_boringssl_sys::SSL_CTX::opaque_mut(
+            self.secure
                 .as_ref()
                 .expect("secure SSL_CTX must be set before setupTLS")
-                .as_ptr()
-        };
-        let server_name = self.tls_config.server_name();
-        let sni = if server_name.is_null() {
-            None
-        } else {
-            // SAFETY: `server_name` is a NUL-terminated C string owned by
-            // `tls_config` for the connection lifetime.
-            Some(unsafe { bun_core::ffi::cstr(server_name) })
-        };
+                .as_ptr(),
+        );
+        let sni = self.tls_config.server_name();
         // The ext slot is an 8-byte null-niche
-        // optional pointer, `Option<NonNull<T>>`; using
+        // optional pointer, `Option<ThisPtr<T>>`; using
         // `Option<*mut T>` here would request 16 bytes (separate discriminant)
         // and desync with the trampoline reader (uws_handlers.rs) which reads
-        // the slot as `Option<NonNull<_>>`.
-        let ext_size =
-            core::mem::size_of::<Option<core::ptr::NonNull<PostgresSQLConnection>>>() as i32;
+        // the slot as `Option<ThisPtr<_>>`.
+        let ext_size = core::mem::size_of::<Option<ThisPtr<PostgresSQLConnection>>>() as i32;
 
-        // SAFETY: `raw` is a live connected `us_socket_t*`; adopt_tls may
-        // realloc and return a different ptr.
-        let Some(new_socket) = (unsafe { &mut *raw }).adopt_tls(
+        // `raw` is a live connected `us_socket_t*`; adopt_tls may realloc and
+        // return a different ptr.
+        let Some(new_socket) = uws::us_socket_t::opaque_mut(raw).adopt_tls(
             tls_group,
             bun_uws::SocketKind::PostgresTls,
             ssl_ctx,
@@ -498,13 +468,10 @@ impl PostgresSQLConnection {
             return;
         };
         let new_socket = new_socket.as_ptr();
-        // SAFETY: `new_socket` is a live us_socket_t freshly returned by
-        // `adopt_tls`; ext slot is sized for `Option<NonNull<PostgresSQLConnection>>`
-        // above. One `&mut` reborrow drives both safe inherent methods
-        // (`ext` / `start_tls_handshake`).
-        let sock = unsafe { &mut *new_socket };
-        *sock.ext::<Option<core::ptr::NonNull<PostgresSQLConnection>>>() =
-            core::ptr::NonNull::new(self.as_ctx_ptr());
+        // `new_socket` is a live us_socket_t freshly returned by `adopt_tls`;
+        // ext slot is sized for `Option<ThisPtr<PostgresSQLConnection>>` above.
+        let sock = uws::us_socket_t::opaque_mut(new_socket);
+        *sock.ext::<Option<ThisPtr<PostgresSQLConnection>>>() = Some(self.this_ptr());
         self.socket.set(Socket::SocketTls(uws::SocketTLS {
             socket: uws::InternalSocket::Connected(new_socket),
         }));
@@ -526,11 +493,7 @@ impl PostgresSQLConnection {
                 i64::from(self.max_lifetime_interval_ms),
             );
         });
-        // whole-struct provenance: the fire path recovers the container from this pointer.
-        let t = core::ptr::addr_of!(self.max_lifetime_timer)
-            .cast::<EventLoopTimer>()
-            .cast_mut();
-        self.vm_mut().timer().insert(t);
+        self.vm().timer_insert(self.max_lifetime_timer_ref());
     }
 
     pub fn on_connection_timeout(&self) {
@@ -614,14 +577,10 @@ impl PostgresSQLConnection {
     }
 
     fn update_has_pending_activity(&self) {
-        let a: u32 = if !self.requests.get().is_empty() {
-            1
-        } else {
-            0
-        };
+        let a: u32 = if self.requests.get().len() > 0 { 1 } else { 0 };
         let b: u32 = match self.status.get() {
             // Terminal states: nothing more will happen on this connection, so
-            // allow GC to collect the JS wrapper (and ultimately call deinit()).
+            // allow GC to collect the JS wrapper (whose finalizer releases its ref).
             // We must still outlive the socket's onClose callback — for SSL
             // sockets `close(.normal)` defers the actual close until the peer's
             // close_notify arrives, so the struct must stay alive until then.
@@ -664,10 +623,16 @@ impl PostgresSQLConnection {
         self.update_has_pending_activity();
     }
 
+    /// Runs before the JS wrapper's ref is dropped; the allocation may
+    /// outlive this call if other refs remain.
     pub fn finalize(&self) {
         debug!("PostgresSQLConnection finalize");
         self.stop_timers();
         self.js_value.with_mut(|r| r.finalize());
+        // The wrapper stays alive while Connected (`has_pending_activity`),
+        // so a registration here means the VM is tearing down: drop it so
+        // the wrapper's release can free the connection.
+        self.unregister_auto_flusher();
     }
 
     pub(crate) fn flush_data_and_reset_timeout(&self) {
@@ -715,7 +680,7 @@ impl PostgresSQLConnection {
 
         self.status.set(Status::Failed);
 
-        let _guard = self.ref_guard();
+        let guard = self.ref_guard();
         // we defer the refAndClose so the on_close will be called first before we reject the pending requests
         let on_close_opt = self.consume_on_close_callback(self.global());
         if let Some(on_close) = on_close_opt {
@@ -739,6 +704,7 @@ impl PostgresSQLConnection {
             );
         }
         self.ref_and_close(Some(value));
+        drop(guard);
         self.update_has_pending_activity();
     }
 
@@ -878,25 +844,13 @@ impl PostgresSQLConnection {
                         }
 
                         if self.ssl_mode == SSLMode::VerifyFull {
-                            let servername = self.tls_config.server_name();
-                            let ok = if servername.is_null() {
-                                false
-                            } else {
-                                // SAFETY: native handle of a connected TLS socket is `SSL*`.
-                                let ssl_ptr: *mut BoringSSL::c::SSL = self
-                                    .socket
-                                    .get()
-                                    .get_native_handle()
-                                    .map_or(core::ptr::null_mut(), |p| p.cast());
-                                // SAFETY: `servername` is a NUL-terminated C string owned by `tls_config`.
-                                let hostname =
-                                    unsafe { bun_core::ffi::cstr(servername) }.to_bytes();
-                                // SAFETY: `ssl_ptr` is the live SSL* of a connected TLS socket.
-                                !ssl_ptr.is_null()
-                                    && BoringSSL::check_server_identity(
-                                        unsafe { &mut *ssl_ptr },
-                                        hostname,
-                                    )
+                            let ok = match self.tls_config.server_name() {
+                                None => false,
+                                Some(servername) => {
+                                    self.socket.get().ssl_mut().is_some_and(|ssl| {
+                                        BoringSSL::check_server_identity(ssl, servername.to_bytes())
+                                    })
+                                }
                             };
                             if !ok {
                                 let v = verify_error_to_js(&ssl_error, self.global());
@@ -1070,15 +1024,15 @@ impl PostgresSQLConnection {
 #[bun_jsc::host_fn(export = "PostgresSQLConnection__createInstance")]
 pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
     // `bun_vm()` → `&'static VirtualMachine` (per-thread singleton); `as_mut()`
-    // is the canonical safe escape hatch (one audited unsafe in bun_jsc) for
-    // `&mut self` helpers like `ssl_ctx_cache()` / `postgres_socket_group()`.
+    // is the canonical safe escape hatch for `&mut self` helpers like
+    // `postgres_socket_group()`.
     let vm = global_object.bun_vm().as_mut();
     let arguments = callframe.arguments();
-    let Some(args) = ConnectionCtorArgs::<SSLMode>::parse(global_object, &mut *vm, arguments)?
-    else {
+    let Some(args) = ConnectionCtorArgs::<SSLMode>::parse(global_object, vm, arguments)? else {
         return Ok(JSValue::ZERO);
     };
-    let (secure, tls_config) = (args.secure, args.tls_config);
+    // `secure` / `tls_config` are dropped with `args` on every early return
+    // until they move into the connection below.
 
     // `StringBuilder::append` takes `&mut self` and returns a borrow
     // of the backing buffer, so successive appends can't keep their `&[u8]`
@@ -1159,8 +1113,10 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
     let max_lifetime = arguments[13].to_int32();
     let use_unnamed_prepared_statements = arguments[14].as_boolean();
 
-    let ptr: *mut PostgresSQLConnection =
-        bun_core::heap::into_raw(Box::new(PostgresSQLConnection {
+    let (secure, tls_config) = (args.secure, args.tls_config);
+
+    let initial: RefPtr<PostgresSQLConnection> =
+        PostgresSQLConnection::new(PostgresSQLConnection {
             socket: JsCell::new(Socket::SocketTcp(uws::SocketTCP {
                 socket: uws::InternalSocket::Detached,
             })),
@@ -1175,9 +1131,7 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
             pending_requests: Cell::new(0),
             poll_ref: JsCell::new(KeepAlive::default()),
             global_object: BackRef::new(global_object),
-            vm: BackRef::from(
-                core::ptr::NonNull::new(VirtualMachine::get_mut_ptr()).expect("vm singleton"),
-            ),
+            vm: BackRef::new(global_object.bun_vm()),
             statements: JsCell::new(PreparedStatementsMap::default()),
             prepared_statement_id: Cell::new(0),
             pending_activity_count: AtomicU32::new(0),
@@ -1212,14 +1166,11 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
             max_lifetime_timer: JsCell::new(EventLoopTimer::init_paused(
                 EventLoopTimerTag::PostgresSQLConnectionMaxLifetime,
             )),
-            auto_flusher: JsCell::new(AutoFlusher::default()),
+            auto_flusher: AutoFlusher::default(),
             channel_names: JsCell::new(Vec::new()),
-        }));
-
-    // `heap::into_raw` is `Box::into_raw` — never null. Sole owner until
-    // `to_js` below. R-2: every field is interior-mutable, so a shared
-    // `ParentRef` deref is sufficient for the writes below.
-    let this = ParentRef::from(core::ptr::NonNull::new(ptr).expect("heap::into_raw non-null"));
+            this_ptr: Cell::new(None),
+        });
+    let this: ThisPtr<PostgresSQLConnection> = initial.this_ptr();
 
     {
         let hostname = args.hostname_str.to_utf8();
@@ -1235,7 +1186,7 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
                 uws::SocketKind::Postgres,
                 None,
                 path_slice,
-                ptr,
+                this.as_ptr(),
                 false,
             )
         } else {
@@ -1245,7 +1196,7 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
                 None,
                 hostname.slice(),
                 args.port,
-                ptr,
+                this.as_ptr(),
                 false,
             )
         };
@@ -1253,8 +1204,8 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
         this.socket.set(Socket::SocketTcp(match result {
             Ok(s) => s,
             Err(err) => {
-                // SAFETY: fresh allocation, sole ref.
-                drop(unsafe { bun_core::heap::take(ptr) });
+                // Sole owner: releasing the initial ref frees the connection.
+                drop(initial);
                 return Err(global_object.throw_error(
                     bun_jsc::CrateError::from(err),
                     "failed to connect to postgresql",
@@ -1267,7 +1218,8 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
     this.update_has_pending_activity();
     this.reset_connection_timeout();
     this.poll_ref.with_mut(|r| r.ref_(this.vm_ctx()));
-    let js_value = js::to_js(ptr, global_object);
+    // The JS wrapper adopts the initial ref.
+    let js_value = js::to_js(initial.into_this_ptr().as_ptr(), global_object);
     js_value.ensure_still_alive();
     this.js_value.set(crate::jsc::JsRef::init_weak(js_value));
     js::onconnect_set_cached(js_value, global_object, on_connect);
@@ -1296,16 +1248,16 @@ impl<const SSL: bool> SocketHandler<SSL> {
     /// (on_open / on_handshake / on_connect_error / on_timeout / on_data / on_writable). `on_close` and `on_end`
     /// intentionally do NOT route through this — they forward unconditionally.
     #[inline]
-    fn guarded(this: &PostgresSQLConnection, f: impl FnOnce(&PostgresSQLConnection)) {
-        f(this)
+    fn guarded(this: ThisPtr<PostgresSQLConnection>, f: impl FnOnce(&PostgresSQLConnection)) {
+        f(&this)
     }
 
-    pub fn on_open(this: &PostgresSQLConnection, socket: SocketType<SSL>) {
+    pub fn on_open(this: ThisPtr<PostgresSQLConnection>, socket: SocketType<SSL>) {
         Self::guarded(this, |t| t.on_open(Self::socket(socket)));
     }
 
     fn on_handshake(
-        this: &PostgresSQLConnection,
+        this: ThisPtr<PostgresSQLConnection>,
         _: SocketType<SSL>,
         success: i32,
         ssl_error: uws::us_bun_verify_error_t,
@@ -1314,11 +1266,11 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     pub const ON_HANDSHAKE: Option<
-        fn(&PostgresSQLConnection, SocketType<SSL>, i32, uws::us_bun_verify_error_t),
+        fn(ThisPtr<PostgresSQLConnection>, SocketType<SSL>, i32, uws::us_bun_verify_error_t),
     > = if SSL { Some(Self::on_handshake) } else { None };
 
     pub fn on_close(
-        this: &PostgresSQLConnection,
+        this: ThisPtr<PostgresSQLConnection>,
         _socket: SocketType<SSL>,
         _: i32,
         _: Option<*mut c_void>,
@@ -1331,11 +1283,15 @@ impl<const SSL: bool> SocketHandler<SSL> {
         this.on_close();
     }
 
-    pub fn on_end(this: &PostgresSQLConnection, _socket: SocketType<SSL>) {
+    pub fn on_end(this: ThisPtr<PostgresSQLConnection>, _socket: SocketType<SSL>) {
         this.on_close();
     }
 
-    pub fn on_connect_error(this: &PostgresSQLConnection, _socket: SocketType<SSL>, _: i32) {
+    pub fn on_connect_error(
+        this: ThisPtr<PostgresSQLConnection>,
+        _socket: SocketType<SSL>,
+        _: i32,
+    ) {
         // The dispatch trampoline already closed the connecting socket; it is
         // freed at end-of-tick, so detach before any user-visible callback.
         this.socket
@@ -1343,15 +1299,15 @@ impl<const SSL: bool> SocketHandler<SSL> {
         Self::guarded(this, |t| t.on_connect_error());
     }
 
-    pub fn on_timeout(this: &PostgresSQLConnection, _socket: SocketType<SSL>) {
+    pub fn on_timeout(this: ThisPtr<PostgresSQLConnection>, _socket: SocketType<SSL>) {
         Self::guarded(this, |t| t.on_timeout());
     }
 
-    pub fn on_data(this: &PostgresSQLConnection, _socket: SocketType<SSL>, data: &[u8]) {
+    pub fn on_data(this: ThisPtr<PostgresSQLConnection>, _socket: SocketType<SSL>, data: &[u8]) {
         Self::guarded(this, |t| t.on_data(data));
     }
 
-    pub fn on_writable(this: &PostgresSQLConnection, _socket: SocketType<SSL>) {
+    pub fn on_writable(this: ThisPtr<PostgresSQLConnection>, _socket: SocketType<SSL>) {
         Self::guarded(this, |t| t.on_drain());
     }
 }
@@ -1410,16 +1366,12 @@ impl PostgresSQLConnection {
     }
 
     pub(crate) fn stop_timers(&self) {
-        self.timer.with_mut(|t| {
-            if t.state == EventLoopTimerState::ACTIVE {
-                self.vm_mut().timer().remove(t);
-            }
-        });
-        self.max_lifetime_timer.with_mut(|t| {
-            if t.state == EventLoopTimerState::ACTIVE {
-                self.vm_mut().timer().remove(t);
-            }
-        });
+        if self.timer.get().state == EventLoopTimerState::ACTIVE {
+            self.vm().timer_remove(self.timer_ref());
+        }
+        if self.max_lifetime_timer.get().state == EventLoopTimerState::ACTIVE {
+            self.vm().timer_remove(self.max_lifetime_timer_ref());
+        }
     }
 
     fn clean_up_requests(&self, js_reason: Option<JSValue>) {
@@ -1430,21 +1382,18 @@ impl PostgresSQLConnection {
         // black_box launder (b818e70e1c57-style) is no longer needed.
         // The connection is kept alive by the caller's `ref_and_close` ref
         // bracket for the duration of this loop, so re-entry never frees `*self`.
-        // The queue's `RefPtr` keeps the query live. R-2: `ParentRef` yields
-        // `&T` only — `PostgresSQLQuery` is Cell/JsCell-backed.
         while let Some(request) = self.current() {
             match request.status.get() {
                 // pending we will fail the request and the stmt will be marked as error ConnectionClosed too
                 QueryStatus::Pending => {
                     self.note_request_written();
-                    let Some(stmt) = request.statement_mut() else {
+                    let Some(stmt) = request.statement() else {
                         // The deref/discard at the bottom of the loop is intentionally skipped here.
                         continue;
                     };
-                    stmt.error_response = Some(StatementError::PostgresError(
+                    stmt.fail(StatementError::PostgresError(
                         AnyPostgresError::ConnectionClosed,
                     ));
-                    stmt.status = StatementStatus::Failed;
                     let global = self.global();
                     if let Some(reason) = js_reason {
                         request.on_js_error(reason, global);
@@ -1471,15 +1420,8 @@ impl PostgresSQLConnection {
                 // just ignore success and fail cases
                 QueryStatus::Success | QueryStatus::Fail => {}
             }
-            self.discard_request(&request);
+            self.discard_request(request);
         }
-    }
-
-    /// Hold a ref on `self` for the guard's lifetime (across re-entrant JS).
-    #[inline]
-    fn ref_guard(&self) -> RefPtr<Self> {
-        // SAFETY: `self` is the live heap allocation.
-        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
     }
 
     fn ref_and_close(&self, js_reason: Option<JSValue>) {
@@ -1505,31 +1447,41 @@ impl PostgresSQLConnection {
         }
     }
 
-    /// Shared borrow of the queue's head request, if any.
-    ///
-    /// The queue's `RefPtr` keeps every stored query live; `PostgresSQLQuery`
-    /// is `Cell`/`JsCell`-backed (R-2), so a shared `&` is sound even across
-    /// re-entrant JS. Returned as a [`ParentRef`] (lifetime-erased `&T` via
-    /// safe `Deref`) so it survives the queue being mutated underneath.
-    fn current(&self) -> Option<ParentRef<PostgresSQLQuery>> {
-        self.requests
-            .get()
-            .front()
-            .map(|req| ParentRef::from(req.as_non_null()))
+    /// The queue's head request, if any. The queue holds a ref on every
+    /// request it stores, so the handle stays valid while the entry is queued;
+    /// `PostgresSQLQuery` is `Cell`/`JsCell`-backed, so the shared borrows it
+    /// yields are sound across re-entrant JS.
+    fn current(&self) -> Option<ThisPtr<PostgresSQLQuery>> {
+        self.request_at(0)
     }
 
-    /// Pop the FIFO head if it is still `request` (re-entrant JS may already
-    /// have removed it), dropping the queue's ref.
+    /// The queued request at `offset` (see [`current`](Self::current)).
     #[inline]
-    fn discard_request(&self, request: &PostgresSQLQuery) {
-        if self
-            .requests
-            .get()
-            .front()
-            .is_some_and(|f| core::ptr::eq(f.as_ptr(), request))
-        {
-            self.requests.with_mut(|q| q.pop_front());
-        }
+    fn request_at(&self, offset: usize) -> Option<ThisPtr<PostgresSQLQuery>> {
+        self.requests.get().get(offset).map(RefPtr::this_ptr)
+    }
+
+    /// Append `request`, taking the queue's ref on it. `false` on allocation
+    /// failure.
+    pub(crate) fn enqueue_request(&self, request: ThisPtr<PostgresSQLQuery>) -> bool {
+        self.requests.with_mut(|q| {
+            if q.try_reserve(1).is_err() {
+                return false;
+            }
+            q.push_back(RefPtr::from_this(request));
+            true
+        })
+    }
+
+    /// If `request` is the FIFO head, pop it and drop the queue's ref on it
+    /// (which may free it).
+    #[inline]
+    fn discard_request(&self, request: ThisPtr<PostgresSQLQuery>) {
+        let head = self.requests.with_mut(|q| match q.front() {
+            Some(front) if core::ptr::eq(front.as_ptr(), request.as_ptr()) => q.pop_front(),
+            _ => None,
+        });
+        drop(head);
     }
 
     pub(crate) fn has_query_running(&self) -> bool {
@@ -1567,6 +1519,22 @@ impl PostgresSQLConnection {
             && !flags.contains(ConnectionFlags::WAITING_TO_PREPARE) // cannot pipeline when waiting prepare
             && !flags.contains(ConnectionFlags::HAS_BACKPRESSURE) // dont make sense to buffer more if we have backpressure
             && (self.write_buffer.get().len() as usize) < MAX_PIPELINE_SIZE // buffer is too big need to flush before pipeline more
+    }
+}
+
+/// Runs when the last ref is released (`CellRefCounted` reclaims the box).
+impl Drop for PostgresSQLConnection {
+    fn drop(&mut self) {
+        // No refs remain; nothing below may mint one.
+        self.this_ptr.set(None);
+        self.disconnect();
+        self.stop_timers();
+        // The statements map owns a ref to each statement, the queue one to each request.
+        self.statements.get_mut_unique().clear();
+        self.requests.with_mut(|q| q.clear());
+        // Zero the connection string (password) before its buffer frees.
+        bun_alloc::free_sensitive(core::mem::take(&mut self.options_buf));
+        // `secure` (SSL_CTX ref) and `tls_config` release on field drop.
     }
 }
 
@@ -1792,18 +1760,16 @@ impl PostgresSQLConnection {
         // expanded as a closure called at every return point below.
         macro_rules! defer_cleanup {
             ($self:ident) => {{
-                // The queue's `RefPtr` keeps the query live. R-2: `ParentRef`
-                // yields `&T` only — `PostgresSQLQuery` is Cell/JsCell-backed.
                 while let Some(result) = $self.current() {
                     // An item may be in the success or failed state and still be inside the queue (see deinit later comments)
                     // so we do the cleanup here
                     match result.status.get() {
                         QueryStatus::Success => {
-                            $self.discard_request(&result);
+                            $self.discard_request(result);
                             continue;
                         }
                         QueryStatus::Fail => {
-                            $self.discard_request(&result);
+                            $self.discard_request(result);
                             continue;
                         }
                         _ => break, // truly current item
@@ -1812,12 +1778,11 @@ impl PostgresSQLConnection {
             }};
         }
 
-        while self.requests.get().len() > offset
-            && !self.flags.get().contains(ConnectionFlags::HAS_BACKPRESSURE)
-        {
-            // The queue's `RefPtr` keeps the query live. R-2: `ParentRef`
-            // yields `&T` only — `PostgresSQLQuery` is Cell/JsCell-backed.
-            let req = ParentRef::from(self.requests.get()[offset].as_non_null());
+        while !self.flags.get().contains(ConnectionFlags::HAS_BACKPRESSURE) {
+            let Some(req) = self.request_at(offset) else {
+                break;
+            };
+            let req_ptr = req;
             match req.status.get() {
                 QueryStatus::Pending => {
                     // Optimistically account for this request leaving Pending; the
@@ -1858,7 +1823,7 @@ impl PostgresSQLConnection {
                                 req.on_write_fail(err, self.global(), self.get_queries_array());
                             }
                             if offset == 0 {
-                                self.discard_request(&req);
+                                self.discard_request(req_ptr);
                             } else {
                                 // deinit later
                                 req.status.set(QueryStatus::Fail);
@@ -1874,23 +1839,24 @@ impl PostgresSQLConnection {
                         defer_cleanup!(self);
                         return;
                     } else {
-                        if let Some(statement) = req.statement_mut() {
-                            match statement.status {
+                        if let Some(statement) = req.statement() {
+                            match statement.status.get() {
                                 StatementStatus::Failed => {
                                     debug!("stmt failed");
-                                    debug_assert!(statement.error_response.is_some());
+                                    debug_assert!(statement.error_response.get().is_some());
                                     // `postgres_sql_statement::Error` is not Clone (owns
                                     // protocol::ErrorResponse). Convert to JSValue and forward via
                                     // on_js_error instead of moving the cached error out.
-                                    if let Some(ref e) = statement.error_response {
-                                        let ev = match e.to_js(self.global()) {
+                                    if statement.error_response.get().is_some() {
+                                        let ev = match statement.error_response_to_js(self.global())
+                                        {
                                             Ok(v) => v,
                                             Err(err) => self.global().take_error(err),
                                         };
                                         req.on_js_error(ev, self.global());
                                     }
                                     if offset == 0 {
-                                        self.discard_request(&req);
+                                        self.discard_request(req_ptr);
                                     } else {
                                         // deinit later
                                         req.status.set(QueryStatus::Fail);
@@ -1905,7 +1871,7 @@ impl PostgresSQLConnection {
                                             "query value was freed earlier than expected"
                                         );
                                         if offset == 0 {
-                                            self.discard_request(&req);
+                                            self.discard_request(req_ptr);
                                         } else {
                                             // deinit later
                                             req.status.set(QueryStatus::Fail);
@@ -1919,7 +1885,9 @@ impl PostgresSQLConnection {
                                     let columns_value =
                                         postgres_sql_query::js::columns_get_cached(this_value)
                                             .unwrap_or_default();
-                                    req.update_flags(|f| f.binary = !statement.fields.is_empty());
+                                    req.update_flags(|f| {
+                                        f.binary = !statement.fields.get().is_empty()
+                                    });
 
                                     if self
                                         .flags
@@ -1954,7 +1922,7 @@ impl PostgresSQLConnection {
                                                 );
                                             }
                                             if offset == 0 {
-                                                self.discard_request(&req);
+                                                self.discard_request(req_ptr);
                                             } else {
                                                 // deinit later
                                                 req.status.set(QueryStatus::Fail);
@@ -1986,7 +1954,7 @@ impl PostgresSQLConnection {
                                                 );
                                             }
                                             if offset == 0 {
-                                                self.discard_request(&req);
+                                                self.discard_request(req_ptr);
                                             } else {
                                                 // deinit later
                                                 req.status.set(QueryStatus::Fail);
@@ -2041,7 +2009,7 @@ impl PostgresSQLConnection {
                                                 "query value was freed earlier than expected"
                                             );
                                             if offset == 0 {
-                                                self.discard_request(&req);
+                                                self.discard_request(req_ptr);
                                             } else {
                                                 // deinit later
                                                 req.status.set(QueryStatus::Fail);
@@ -2061,15 +2029,13 @@ impl PostgresSQLConnection {
                                                 query_str.slice(),
                                                 binding_value,
                                                 self.writer(),
-                                                &mut statement.signature,
+                                                &statement.signature,
                                             )
                                         {
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {
-                                                statement.status = StatementStatus::Failed;
-                                                statement.error_response =
-                                                    Some(StatementError::PostgresError(err));
+                                                statement.fail(StatementError::PostgresError(err));
                                                 req.on_write_fail(
                                                     err,
                                                     self.global(),
@@ -2077,7 +2043,7 @@ impl PostgresSQLConnection {
                                                 );
                                             }
                                             if offset == 0 {
-                                                self.discard_request(&req);
+                                                self.discard_request(req_ptr);
                                             } else {
                                                 // deinit later
                                                 req.status.set(QueryStatus::Fail);
@@ -2093,7 +2059,7 @@ impl PostgresSQLConnection {
                                             f.insert(ConnectionFlags::WAITING_TO_PREPARE);
                                         });
                                         req.status.set(QueryStatus::Binding);
-                                        statement.status = StatementStatus::Parsing;
+                                        statement.status.set(StatementStatus::Parsing);
                                         self.flush_data_and_reset_timeout();
                                         defer_cleanup!(self);
                                         return;
@@ -2116,7 +2082,7 @@ impl PostgresSQLConnection {
                                                 "query value was freed earlier than expected"
                                             );
                                             debug_assert!(offset == 0);
-                                            self.discard_request(&req);
+                                            self.discard_request(req_ptr);
                                             continue;
                                         };
                                         let binding_value =
@@ -2141,9 +2107,7 @@ impl PostgresSQLConnection {
                                             if let Some(err_) = self.global().try_take_exception() {
                                                 req.on_js_error(err_, self.global());
                                             } else {
-                                                statement.status = StatementStatus::Failed;
-                                                statement.error_response =
-                                                    Some(StatementError::PostgresError(err));
+                                                statement.fail(StatementError::PostgresError(err));
                                                 req.on_write_fail(
                                                     err,
                                                     self.global(),
@@ -2151,7 +2115,7 @@ impl PostgresSQLConnection {
                                                 );
                                             }
                                             debug_assert!(offset == 0);
-                                            self.discard_request(&req);
+                                            self.discard_request(req_ptr);
                                             debug!(
                                                 "parseAndBindAndExecute failed: {}",
                                                 <&'static str>::from(err)
@@ -2163,7 +2127,7 @@ impl PostgresSQLConnection {
                                             f.insert(ConnectionFlags::WAITING_TO_PREPARE);
                                         });
                                         req.status.set(QueryStatus::Binding);
-                                        statement.status = StatementStatus::Parsing;
+                                        statement.status.set(StatementStatus::Parsing);
                                         req.update_flags(|f| f.counter = RequestCounter::Pipelined);
                                         self.pipelined_requests
                                             .set(self.pipelined_requests.get() + 1);
@@ -2187,9 +2151,7 @@ impl PostgresSQLConnection {
                                         if let Some(err_) = self.global().try_take_exception() {
                                             req.on_js_error(err_, self.global());
                                         } else {
-                                            statement.error_response =
-                                                Some(StatementError::PostgresError(err));
-                                            statement.status = StatementStatus::Failed;
+                                            statement.fail(StatementError::PostgresError(err));
                                             req.on_write_fail(
                                                 err,
                                                 self.global(),
@@ -2197,7 +2159,7 @@ impl PostgresSQLConnection {
                                             );
                                         }
                                         debug_assert!(offset == 0);
-                                        self.discard_request(&req);
+                                        self.discard_request(req_ptr);
                                         debug!("write query failed: {}", <&'static str>::from(err));
                                         continue;
                                     }
@@ -2205,9 +2167,7 @@ impl PostgresSQLConnection {
                                         if let Some(err_) = self.global().try_take_exception() {
                                             req.on_js_error(err_, self.global());
                                         } else {
-                                            statement.error_response =
-                                                Some(StatementError::PostgresError(err));
-                                            statement.status = StatementStatus::Failed;
+                                            statement.fail(StatementError::PostgresError(err));
                                             req.on_write_fail(
                                                 err,
                                                 self.global(),
@@ -2215,7 +2175,7 @@ impl PostgresSQLConnection {
                                             );
                                         }
                                         debug_assert!(offset == 0);
-                                        self.discard_request(&req);
+                                        self.discard_request(req_ptr);
                                         debug!(
                                             "write query (sync) failed: {}",
                                             <&'static str>::from(err)
@@ -2226,7 +2186,7 @@ impl PostgresSQLConnection {
                                         f.remove(ConnectionFlags::IS_READY_FOR_QUERY);
                                         f.insert(ConnectionFlags::WAITING_TO_PREPARE);
                                     });
-                                    statement.status = StatementStatus::Parsing;
+                                    statement.status.set(StatementStatus::Parsing);
                                     // Parse+Describe+Sync written; Bind+Execute deferred to the
                                     // next advance(), so the request is still pending on the wire.
                                     self.note_request_pending();
@@ -2274,7 +2234,7 @@ impl PostgresSQLConnection {
                         offset += 1;
                         continue;
                     }
-                    self.discard_request(&req);
+                    self.discard_request(req_ptr);
                     continue;
                 }
                 QueryStatus::Fail => {
@@ -2283,7 +2243,7 @@ impl PostgresSQLConnection {
                         offset += 1;
                         continue;
                     }
-                    self.discard_request(&req);
+                    self.discard_request(req_ptr);
                     continue;
                 }
             }
@@ -2325,16 +2285,10 @@ impl PostgresSQLConnection {
                 }
 
                 let statement = request
-                    .statement_mut()
+                    .statement()
                     .ok_or(AnyPostgresError::ExpectedStatement)?;
                 let mut structure: JSValue = JSValue::UNDEFINED;
-                // reshaped for borrowck — `statement.structure()` borrows
-                // `&mut *statement` and returns `&CachedStructure`; capture it as a
-                // `ParentRef` (lifetime-erased `&T`) so `&statement.fields` below
-                // does not conflict, and `as_deref` for `to_js` at the call site.
-                // `*statement` outlives this arm (held via `request.statement`'s
-                // intrusive ref), satisfying the `ParentRef` liveness invariant.
-                let mut cached_structure: Option<ParentRef<PostgresCachedStructure>> = None;
+                let mut cached_structure: Option<&PostgresCachedStructure> = None;
                 let request_flags = request.flags.get();
                 // explicit use switch without else so if new modes are added, we don't forget to check for duplicate fields
                 match request_flags.result_mode {
@@ -2342,16 +2296,18 @@ impl PostgresSQLConnection {
                         let owner = self.js_value.get().try_get().unwrap_or_default();
                         let cs = statement.structure(owner, self.global());
                         structure = cs.js_value().unwrap_or(JSValue::UNDEFINED);
-                        cached_structure = Some(ParentRef::new(cs));
+                        cached_structure = Some(cs);
                     }
                     SQLQueryResultMode::Raw | SQLQueryResultMode::Values => {
                         // no need to check for duplicate fields or structure
                     }
                 }
+                let fields = statement.fields.get();
 
                 let mut putter = DataCell::Putter {
                     list: &mut [],
-                    fields: &statement.fields,
+                    storage: Default::default(),
+                    fields,
                     binary: request_flags.binary,
                     bigint: request_flags.bigint,
                     global_object: self.global(),
@@ -2361,23 +2317,18 @@ impl PostgresSQLConnection {
                 let mut stack_buf = [DataCell::SQLDataCell::default(); 70];
                 let max_inline = jsc::JSObject::max_inline_capacity() as usize;
                 let mut heap_cells: Vec<DataCell::SQLDataCell>;
-                let mut free_cells = false;
-                let cells: &mut [DataCell::SQLDataCell] = if statement.fields.len() >= max_inline {
-                    heap_cells = (0..statement.fields.len())
+                let cells: &mut [DataCell::SQLDataCell] = if fields.len() >= max_inline {
+                    heap_cells = (0..fields.len())
                         .map(|_| DataCell::SQLDataCell::default())
                         .collect();
-                    free_cells = true;
                     &mut heap_cells
                 } else {
-                    &mut stack_buf[..statement.fields.len().min(max_inline)]
+                    &mut stack_buf[..fields.len().min(max_inline)]
                 };
                 // Seed with the field's column kind so a short DataRow still
                 // matches the Structure built from these fields.
                 for (i, c) in cells.iter_mut().enumerate() {
-                    *c = DataCell::SQLDataCell::null_for_column(
-                        i as u32,
-                        &statement.fields[i].name_or_index,
-                    );
+                    *c = DataCell::SQLDataCell::null_for_column(i as u32, &fields[i].name_or_index);
                 }
                 putter.list = cells;
 
@@ -2389,25 +2340,8 @@ impl PostgresSQLConnection {
                 } else {
                     protocol::DataRow::decode((), &mut reader, |(), i, b| putter.put(i, b))
                 };
-                // Cell cleanup (deinit each cell, then free the buffer)
-                // runs on ALL exits (decode error, to_js error, success). `putter.count` is final
-                // after `decode` (the only writer is `Putter::put_impl`, and `to_js` does not
-                // touch it), so capture it by value — no raw-ptr read needed. `cells_ptr` stays
-                // raw because the guard must run after `putter.to_js(&mut self)` releases its
-                // borrow, which a `&mut [SQLDataCell]` capture would block.
-                let cells_ptr: *mut DataCell::SQLDataCell = putter.list.as_mut_ptr();
-                let count = putter.count;
-                scopeguard::defer! {
-                    // SAFETY: cells_ptr points into stack_buf/heap_cells, both declared
-                    // earlier in this block and outliving this guard; `count` is the
-                    // post-decode element count and never exceeds the slice length.
-                    unsafe {
-                        for i in 0..count {
-                            (*cells_ptr.add(i)).deinit();
-                        }
-                    }
-                    // `if free_cells free(cells)`: heap_cells Vec drops at scope end.
-                };
+                // The cells' heap data (`putter.storage`) and `heap_cells`
+                // drop at scope end, on every exit.
                 decode_result?;
 
                 let Some(this_value) = request.this_value.get().try_get() else {
@@ -2421,11 +2355,9 @@ impl PostgresSQLConnection {
                     self.global(),
                     pending_value,
                     structure,
-                    statement.fields_flags,
+                    statement.fields_flags.get(),
                     request_flags.result_mode,
-                    // `ParentRef::Deref` recovers `&CachedStructure`; statement
-                    // outlives this call (held via `request.statement` ref).
-                    cached_structure.as_deref(),
+                    cached_structure,
                 )?;
 
                 if pending_value.is_empty() {
@@ -2435,8 +2367,6 @@ impl PostgresSQLConnection {
                         result,
                     );
                 }
-
-                let _ = free_cells; // heap_cells dropped at scope end; defer! above runs cell.deinit()
             }
             MessageType::CopyData => {
                 // Decode to consume the message from the stream; the payload is unused.
@@ -2518,12 +2448,12 @@ impl PostgresSQLConnection {
             MessageType::ParseComplete => {
                 reader.eat_message(&protocol::PARSE_COMPLETE)?;
                 let request = self.current().ok_or(AnyPostgresError::ExpectedRequest)?;
-                if let Some(statement) = request.statement_mut() {
+                if let Some(statement) = request.statement() {
                     // if we have params wait for parameter description
-                    if statement.status == StatementStatus::Parsing
+                    if statement.status.get() == StatementStatus::Parsing
                         && statement.signature.fields.is_empty()
                     {
-                        statement.status = StatementStatus::Prepared;
+                        statement.status.set(StatementStatus::Prepared);
                         self.update_flags(|f| f.remove(ConnectionFlags::WAITING_TO_PREPARE));
                     }
                 }
@@ -2539,19 +2469,17 @@ impl PostgresSQLConnection {
                         return Err(AnyPostgresError::ExpectedRequest);
                     }
                 };
-                let statement = match request.statement_mut() {
+                let statement = match request.statement() {
                     Some(s) => s,
                     None => {
                         drop(description.parameters);
                         return Err(AnyPostgresError::ExpectedStatement);
                     }
                 };
-                if !statement.parameters.is_empty() {
-                    // Box<[T]> drop frees old slice.
-                }
-                statement.parameters = description.parameters;
-                if statement.status == StatementStatus::Parsing {
-                    statement.status = StatementStatus::Prepared;
+                // Box<[T]> drop frees the old slice.
+                statement.parameters.set(description.parameters);
+                if statement.status.get() == StatementStatus::Parsing {
+                    statement.status.set(StatementStatus::Prepared);
                     self.update_flags(|f| f.remove(ConnectionFlags::WAITING_TO_PREPARE));
                 }
             }
@@ -2562,7 +2490,7 @@ impl PostgresSQLConnection {
                     Some(r) => r,
                     None => return Err(AnyPostgresError::ExpectedRequest),
                 };
-                let statement = match request.statement_mut() {
+                let statement = match request.statement() {
                     Some(s) => s,
                     None => return Err(AnyPostgresError::ExpectedStatement),
                 };
@@ -2573,10 +2501,10 @@ impl PostgresSQLConnection {
                 // invalidate state derived from them so the next DataRow builds
                 // the correct structure instead of reusing a stale cached one.
                 // Vec<FieldDescription> drop runs each field's Drop.
-                statement.fields = description.fields.into_vec();
-                statement.cached_structure = Default::default();
-                statement.needs_duplicate_check = true;
-                statement.fields_flags = Default::default();
+                statement.fields.set(description.fields.into_vec());
+                statement.cached_structure.set(Default::default());
+                statement.needs_duplicate_check.set(true);
+                statement.fields_flags.set(Default::default());
             }
             MessageType::Authentication => {
                 let auth = protocol::Authentication::decode_internal(&mut reader)?;
@@ -2595,19 +2523,17 @@ impl PostgresSQLConnection {
                             .set(AuthenticationState::Sasl(Default::default()));
 
                         let mut mechanism_buf = [0u8; 128];
-                        // `sasl` borrow ends before `self.writer()`/`self.flush_data()`
-                        // below (neither touches `authentication_state`).
-                        let Some(sasl) = self.sasl_state_mut() else {
-                            unreachable!()
-                        };
-                        let mechanism = {
-                            use std::io::Write as _;
-                            let mut cursor = &mut mechanism_buf[..];
-                            let _ = write!(cursor, "n,,n=*,r={}", bstr::BStr::new(sasl.nonce()));
-                            let written = 128 - cursor.len();
-                            mechanism_buf[written] = 0;
-                            &mechanism_buf[..written]
-                        };
+                        let written = self
+                            .with_sasl(|sasl| {
+                                use std::io::Write as _;
+                                let mut cursor = &mut mechanism_buf[..];
+                                let _ =
+                                    write!(cursor, "n,,n=*,r={}", bstr::BStr::new(sasl.nonce()));
+                                128 - cursor.len()
+                            })
+                            .expect("unreachable");
+                        mechanism_buf[written] = 0;
+                        let mechanism = &mechanism_buf[..written];
                         let response = protocol::SASLInitialResponse {
                             mechanism: Data::Temporary(bun_ptr::RawSlice::new(b"SCRAM-SHA-256")),
                             data: Data::Temporary(bun_ptr::RawSlice::new(mechanism)),
@@ -2619,162 +2545,173 @@ impl PostgresSQLConnection {
                     }
                     protocol::Authentication::SASLContinue(cont) => {
                         let password: &[u8] = self.password();
-                        // `sasl` borrow ends before `self.writer()`/`self.flush_data()`
-                        // below (neither touches `authentication_state`).
-                        let Some(sasl) = self.sasl_state_mut() else {
+                        let Some(payload) =
+                            self.with_sasl(|sasl| -> Result<Vec<u8>, AnyPostgresError> {
+                                if sasl.status != SASLStatus::Init {
+                                    debug!("Unexpected SASLContinue for SASL state");
+                                    return Err(AnyPostgresError::UnexpectedMessage);
+                                }
+                                debug!("SASLContinue");
+
+                                // RFC 5802 §5.1: the server's combined nonce MUST begin with
+                                // the client nonce we sent in the client-first-message.
+                                if !cont.r.slice().starts_with(sasl.nonce()) {
+                                    debug!(
+                                        "SASLContinue server nonce does not start with client nonce"
+                                    );
+                                    return Err(AnyPostgresError::InvalidMessage);
+                                }
+
+                                let iteration_count = cont.iteration_count()?;
+                                // RFC 7677 §4: SCRAM-SHA-256 requires a minimum of 4096
+                                // iterations. Cap the upper bound to avoid a CPU-burn DoS
+                                // from a malicious/MITM'd server sending i ≈ u32::MAX.
+                                if !(4096..=10_000_000).contains(&iteration_count) {
+                                    debug!(
+                                        "SASLContinue iteration count out of range: {}",
+                                        iteration_count
+                                    );
+                                    return Err(AnyPostgresError::InvalidMessage);
+                                }
+
+                                // Bound the *encoded* length before allocating: a
+                                // malicious/MITM'd server can otherwise force an
+                                // arbitrarily large decode_alloc here. 1024 decoded
+                                // bytes ≈ 1368 base64 chars; round up generously.
+                                let server_salt_b64 = cont.s.slice();
+                                if server_salt_b64.is_empty() || server_salt_b64.len() > 2048 {
+                                    debug!(
+                                        "SASLContinue encoded salt length out of range: {}",
+                                        server_salt_b64.len()
+                                    );
+                                    return Err(AnyPostgresError::InvalidMessage);
+                                }
+                                let server_salt_decoded_base64 = bun_base64::decode_alloc(
+                                    server_salt_b64,
+                                )
+                                .map_err(|e| match e {
+                                    bun_base64::DecodeAllocError::DecodingFailed => {
+                                        AnyPostgresError::SASL_SIGNATURE_INVALID_BASE64
+                                    }
+                                })?;
+                                if server_salt_decoded_base64.is_empty()
+                                    || server_salt_decoded_base64.len() > 1024
+                                {
+                                    debug!(
+                                        "SASLContinue salt length out of range: {}",
+                                        server_salt_decoded_base64.len()
+                                    );
+                                    return Err(AnyPostgresError::InvalidMessage);
+                                }
+                                sasl.compute_salted_password(
+                                    &server_salt_decoded_base64,
+                                    iteration_count,
+                                    password,
+                                )
+                                .map_err(pg_err)?;
+                                drop(server_salt_decoded_base64);
+
+                                let mut auth_string: Vec<u8> = Vec::new();
+                                {
+                                    use std::io::Write as _;
+                                    let _ = write!(
+                                        &mut auth_string,
+                                        "n=*,r={},r={},s={},i={},c=biws,r={}",
+                                        bstr::BStr::new(sasl.nonce()),
+                                        bstr::BStr::new(cont.r.slice()),
+                                        bstr::BStr::new(cont.s.slice()),
+                                        bstr::BStr::new(cont.i.slice()),
+                                        bstr::BStr::new(cont.r.slice()),
+                                    );
+                                }
+                                sasl.compute_server_signature(&auth_string)
+                                    .map_err(pg_err)?;
+
+                                let client_key = sasl.client_key();
+                                let client_key_signature =
+                                    sasl.client_key_signature(&client_key, &auth_string);
+                                let mut client_key_xor_buffer = [0u8; 32];
+                                debug_assert_eq!(client_key.len(), client_key_signature.len());
+                                for ((out, a), b) in client_key_xor_buffer
+                                    .iter_mut()
+                                    .zip(client_key.iter())
+                                    .zip(client_key_signature.iter())
+                                {
+                                    *out = a ^ b;
+                                }
+
+                                // base64 of 32 bytes → ceil(32/3)*4 = 44; +4 slack.
+                                let mut client_key_xor_base64_buf = [0u8; 48];
+                                let xor_base64_len = bun_base64::encode(
+                                    &mut client_key_xor_base64_buf,
+                                    &client_key_xor_buffer,
+                                );
+
+                                let mut payload: Vec<u8> = Vec::new();
+                                {
+                                    use std::io::Write as _;
+                                    let _ = write!(
+                                        &mut payload,
+                                        "c=biws,r={},p={}",
+                                        bstr::BStr::new(cont.r.slice()),
+                                        bstr::BStr::new(
+                                            &client_key_xor_base64_buf[..xor_base64_len]
+                                        ),
+                                    );
+                                }
+
+                                sasl.status = SASLStatus::Continue;
+                                Ok(payload)
+                            })
+                        else {
                             debug!("Unexpected SASLContinue for authentication state");
                             return Err(AnyPostgresError::UnexpectedMessage);
                         };
-
-                        if sasl.status != SASLStatus::Init {
-                            debug!("Unexpected SASLContinue for SASL state");
-                            return Err(AnyPostgresError::UnexpectedMessage);
-                        }
-                        debug!("SASLContinue");
-
-                        // RFC 5802 §5.1: the server's combined nonce MUST begin with
-                        // the client nonce we sent in the client-first-message.
-                        if !cont.r.slice().starts_with(sasl.nonce()) {
-                            debug!("SASLContinue server nonce does not start with client nonce");
-                            return Err(AnyPostgresError::InvalidMessage);
-                        }
-
-                        let iteration_count = cont.iteration_count()?;
-                        // RFC 7677 §4: SCRAM-SHA-256 requires a minimum of 4096
-                        // iterations. Cap the upper bound to avoid a CPU-burn DoS
-                        // from a malicious/MITM'd server sending i ≈ u32::MAX.
-                        if !(4096..=10_000_000).contains(&iteration_count) {
-                            debug!(
-                                "SASLContinue iteration count out of range: {}",
-                                iteration_count
-                            );
-                            return Err(AnyPostgresError::InvalidMessage);
-                        }
-
-                        // Bound the *encoded* length before allocating: a
-                        // malicious/MITM'd server can otherwise force an
-                        // arbitrarily large decode_alloc here. 1024 decoded
-                        // bytes ≈ 1368 base64 chars; round up generously.
-                        let server_salt_b64 = cont.s.slice();
-                        if server_salt_b64.is_empty() || server_salt_b64.len() > 2048 {
-                            debug!(
-                                "SASLContinue encoded salt length out of range: {}",
-                                server_salt_b64.len()
-                            );
-                            return Err(AnyPostgresError::InvalidMessage);
-                        }
-                        let server_salt_decoded_base64 = bun_base64::decode_alloc(server_salt_b64)
-                            .map_err(|e| match e {
-                                bun_base64::DecodeAllocError::DecodingFailed => {
-                                    AnyPostgresError::SASL_SIGNATURE_INVALID_BASE64
-                                }
-                            })?;
-                        if server_salt_decoded_base64.is_empty()
-                            || server_salt_decoded_base64.len() > 1024
-                        {
-                            debug!(
-                                "SASLContinue salt length out of range: {}",
-                                server_salt_decoded_base64.len()
-                            );
-                            return Err(AnyPostgresError::InvalidMessage);
-                        }
-                        sasl.compute_salted_password(
-                            &server_salt_decoded_base64,
-                            iteration_count,
-                            password,
-                        )
-                        .map_err(pg_err)?;
-                        drop(server_salt_decoded_base64);
-
-                        let mut auth_string: Vec<u8> = Vec::new();
-                        {
-                            use std::io::Write as _;
-                            let _ = write!(
-                                &mut auth_string,
-                                "n=*,r={},r={},s={},i={},c=biws,r={}",
-                                bstr::BStr::new(sasl.nonce()),
-                                bstr::BStr::new(cont.r.slice()),
-                                bstr::BStr::new(cont.s.slice()),
-                                bstr::BStr::new(cont.i.slice()),
-                                bstr::BStr::new(cont.r.slice()),
-                            );
-                        }
-                        sasl.compute_server_signature(&auth_string)
-                            .map_err(pg_err)?;
-
-                        let client_key = sasl.client_key();
-                        let client_key_signature =
-                            sasl.client_key_signature(&client_key, &auth_string);
-                        let mut client_key_xor_buffer = [0u8; 32];
-                        debug_assert_eq!(client_key.len(), client_key_signature.len());
-                        for ((out, a), b) in client_key_xor_buffer
-                            .iter_mut()
-                            .zip(client_key.iter())
-                            .zip(client_key_signature.iter())
-                        {
-                            *out = a ^ b;
-                        }
-
-                        // base64 of 32 bytes → ceil(32/3)*4 = 44; +4 slack.
-                        let mut client_key_xor_base64_buf = [0u8; 48];
-                        let xor_base64_len = bun_base64::encode(
-                            &mut client_key_xor_base64_buf,
-                            &client_key_xor_buffer,
-                        );
-
-                        let mut payload: Vec<u8> = Vec::new();
-                        {
-                            use std::io::Write as _;
-                            let _ = write!(
-                                &mut payload,
-                                "c=biws,r={},p={}",
-                                bstr::BStr::new(cont.r.slice()),
-                                bstr::BStr::new(&client_key_xor_base64_buf[..xor_base64_len]),
-                            );
-                        }
+                        let payload = payload?;
 
                         let response = protocol::SASLResponse {
                             data: Data::Temporary(bun_ptr::RawSlice::new(payload.as_slice())),
                         };
 
-                        sasl.status = SASLStatus::Continue;
                         response.write_internal(&mut self.writer())?;
                         self.flush_data();
                     }
                     protocol::Authentication::SASLFinal { data: final_data } => {
-                        // `sasl` borrow ends before `self.fail()` /
-                        // `self.authentication_state.with_mut()` below.
-                        let Some(sasl) = self.sasl_state_mut() else {
+                        // This will usually start with "v="
+                        let comparison_signature = final_data.slice();
+                        let Some(verdict) = self.with_sasl(|sasl| -> Result<bool, AnyPostgresError> {
+                            if sasl.status != SASLStatus::Continue {
+                                debug!("SASLFinal - Unexpected SASLContinue for SASL state");
+                                return Err(AnyPostgresError::UnexpectedMessage);
+                            }
+
+                            if sasl.server_signature_len == 0 {
+                                debug!("SASLFinal - Server signature is empty");
+                                return Err(AnyPostgresError::UnexpectedMessage);
+                            }
+
+                            let server_signature = sasl.server_signature();
+
+                            if comparison_signature.len() < 2
+                                || !BoringSSL::c::constant_time_eq(
+                                    server_signature,
+                                    &comparison_signature[2..],
+                                )
+                            {
+                                debug!(
+                                    "SASLFinal - SASL Server signature mismatch\nExpected: {}\nActual: {}",
+                                    bstr::BStr::new(server_signature),
+                                    bstr::BStr::new(&comparison_signature[2..])
+                                );
+                                Ok(false)
+                            } else {
+                                Ok(true)
+                            }
+                        }) else {
                             debug!("SASLFinal - Unexpected SASLContinue for authentication state");
                             return Err(AnyPostgresError::UnexpectedMessage);
                         };
-
-                        if sasl.status != SASLStatus::Continue {
-                            debug!("SASLFinal - Unexpected SASLContinue for SASL state");
-                            return Err(AnyPostgresError::UnexpectedMessage);
-                        }
-
-                        if sasl.server_signature_len == 0 {
-                            debug!("SASLFinal - Server signature is empty");
-                            return Err(AnyPostgresError::UnexpectedMessage);
-                        }
-
-                        let server_signature = sasl.server_signature();
-
-                        // This will usually start with "v="
-                        let comparison_signature = final_data.slice();
-
-                        if comparison_signature.len() < 2
-                            || !BoringSSL::c::constant_time_eq(
-                                server_signature,
-                                &comparison_signature[2..],
-                            )
-                        {
-                            debug!(
-                                "SASLFinal - SASL Server signature mismatch\nExpected: {}\nActual: {}",
-                                bstr::BStr::new(server_signature),
-                                bstr::BStr::new(&comparison_signature[2..])
-                            );
+                        if !verdict? {
                             self.fail(
                                 b"The server did not return the correct signature",
                                 AnyPostgresError::SASL_SIGNATURE_MISMATCH,
@@ -2936,25 +2873,26 @@ impl PostgresSQLConnection {
                 // `on_js_error` to avoid double-ownership of the non-Clone ErrorResponse.
                 let js_err =
                     crate::postgres::protocol::error_response_jsc::to_js(&err, self.global());
-                if let Some(stmt) = request.statement_mut() {
-                    if stmt.status == StatementStatus::Parsing {
-                        stmt.status = StatementStatus::Failed;
-                        stmt.error_response = Some(
-                            crate::postgres::postgres_sql_statement::Error::Protocol(err),
-                        );
-                        // The request still holds another ref; this cannot drop to 0.
-                        let stmt_ptr: *const PostgresSQLStatement = core::ptr::from_ref(&*stmt);
-                        self.statements.with_mut(|m| {
+                if let Some(stmt) = request.statement() {
+                    if stmt.status.get() == StatementStatus::Parsing {
+                        stmt.fail(crate::postgres::postgres_sql_statement::Error::Protocol(
+                            err,
+                        ));
+                        // Drop the map's entry (and ref) if it is this statement;
+                        // the request still holds its own ref.
+                        let map_ref = self.statements.with_mut(|m| {
                             let name = &stmt.signature.name[..];
-                            if m.get(name).is_some_and(|p| {
-                                core::ptr::eq(
-                                    p.as_ref().map_or(core::ptr::null(), |p| p.as_ptr()),
-                                    stmt_ptr,
-                                )
-                            }) {
-                                m.remove(name);
+                            let is_this = m.get(name).is_some_and(|slot| {
+                                slot.as_ref()
+                                    .is_some_and(|p| core::ptr::eq(p.as_ptr(), stmt))
+                            });
+                            if is_this {
+                                m.remove(name).flatten()
+                            } else {
+                                None
                             }
                         });
+                        drop(map_ref);
                     }
                 }
                 // If `err` was not moved into stmt above, it drops here automatically.

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1461,16 +1461,10 @@ impl PostgresSQLConnection {
         self.requests.get().get(offset).map(RefPtr::this_ptr)
     }
 
-    /// Append `request`, taking the queue's ref on it. `false` on allocation
-    /// failure.
-    pub(crate) fn enqueue_request(&self, request: ThisPtr<PostgresSQLQuery>) -> bool {
-        self.requests.with_mut(|q| {
-            if q.try_reserve(1).is_err() {
-                return false;
-            }
-            q.push_back(RefPtr::from_this(request));
-            true
-        })
+    /// Append `request`, taking the queue's ref on it.
+    pub(crate) fn enqueue_request(&self, request: ThisPtr<PostgresSQLQuery>) {
+        self.requests
+            .with_mut(|q| q.push_back(RefPtr::from_this(request)));
     }
 
     /// If `request` is the FIFO head, pop it and drop the queue's ref on it

--- a/src/sql_jsc/postgres/PostgresSQLContext.rs
+++ b/src/sql_jsc/postgres/PostgresSQLContext.rs
@@ -15,13 +15,11 @@ impl PostgresSQLContext {
     // Registered directly as `init` via `put_host_functions!` in
     // `postgres.rs`, so no exported symbol is needed.
     pub(crate) fn init(global: &JSGlobalObject, frame: &CallFrame) -> JSValue {
-        // `bun_vm()` → `&'static VirtualMachine` (per-thread singleton);
-        // `as_mut()` is the canonical safe escape hatch for the shrinking set
-        // of `&mut self` helpers like `sql_state()` — one audited unsafe lives
-        // in bun_jsc.
-        let ctx = &mut global.bun_vm().as_mut().sql_state().postgresql_context;
-        ctx.on_query_resolve_fn.set(global, frame.argument(0));
-        ctx.on_query_reject_fn.set(global, frame.argument(1));
+        global.bun_vm().with_sql_state(|state| {
+            let ctx = &mut state.postgresql_context;
+            ctx.on_query_resolve_fn.set(global, frame.argument(0));
+            ctx.on_query_reject_fn.set(global, frame.argument(1));
+        });
         JSValue::UNDEFINED
     }
 }

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -499,10 +499,7 @@ impl PostgresSQLQuery {
             } else {
                 this.status.set(Status::Pending);
             }
-            if !connection.enqueue_request(this.this_ptr()) {
-                release_query_ref();
-                return Err(global_object.throw_out_of_memory());
-            }
+            connection.enqueue_request(this.this_ptr());
             if this.status.get() == Status::Pending {
                 connection.note_request_pending();
             }
@@ -755,10 +752,7 @@ impl PostgresSQLQuery {
             }
         }
 
-        if !connection.enqueue_request(this.this_ptr()) {
-            release_query_ref();
-            return Err(global_object.throw_out_of_memory());
-        }
+        connection.enqueue_request(this.this_ptr());
         if this.status.get() == Status::Pending {
             connection.note_request_pending();
         }

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -452,7 +452,6 @@ impl PostgresSQLQuery {
         let this_value = callframe.this();
         let binding_value = js::binding_get_cached(this_value).unwrap_or_default();
         let query_str = this.query.to_utf8();
-        // query_str: Utf8Slice<'_> — Drop frees.
         let writer = connection.writer();
         // Shared cleanup for every error-return path below: drop any statement
         // ref this query took.
@@ -656,13 +655,12 @@ impl PostgresSQLQuery {
                         &signature,
                     ) {
                         if has_connection_entry {
-                            // A re-entrant run may have filled the reserved slot.
-                            if let Some(Some(stmt)) = connection
-                                .statements
-                                .with_mut(|m| m.remove(&signature.name[..]))
-                            {
-                                stmt.deref();
-                            }
+                            // A re-entrant run may have filled the reserved slot; release it.
+                            drop(
+                                connection
+                                    .statements
+                                    .with_mut(|m| m.remove(&signature.name[..])),
+                            );
                         }
                         drop(signature);
                         release_query_ref();
@@ -692,13 +690,12 @@ impl PostgresSQLQuery {
                         writer,
                     ) {
                         if has_connection_entry {
-                            // A re-entrant run may have filled the reserved slot.
-                            if let Some(Some(stmt)) = connection
-                                .statements
-                                .with_mut(|m| m.remove(&signature.name[..]))
-                            {
-                                stmt.deref();
-                            }
+                            // A re-entrant run may have filled the reserved slot; release it.
+                            drop(
+                                connection
+                                    .statements
+                                    .with_mut(|m| m.remove(&signature.name[..])),
+                            );
                         }
                         drop(signature);
                         release_query_ref();
@@ -706,13 +703,12 @@ impl PostgresSQLQuery {
                     }
                     if let Err(err) = writer.write(&protocol::SYNC) {
                         if has_connection_entry {
-                            // A re-entrant run may have filled the reserved slot.
-                            if let Some(Some(stmt)) = connection
-                                .statements
-                                .with_mut(|m| m.remove(&signature.name[..]))
-                            {
-                                stmt.deref();
-                            }
+                            // A re-entrant run may have filled the reserved slot; release it.
+                            drop(
+                                connection
+                                    .statements
+                                    .with_mut(|m| m.remove(&signature.name[..])),
+                            );
                         }
                         drop(signature);
                         release_query_ref();

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -8,7 +8,7 @@ use crate::jsc::{
 use crate::shared::query_ctor_args::QueryCtorArgs;
 use bun_core::String as BunString;
 use bun_jsc::JsCell;
-use bun_ptr::{AsCtxPtr, RefPtr};
+use bun_ptr::{BackRef, RefPtr, ThisPtr};
 
 use super::PostgresSQLConnection;
 use super::PostgresSQLStatement;
@@ -38,7 +38,8 @@ pub use crate::jsc::codegen::JSPostgresSQLQuery as js;
 // previous `from_mut(self)` raw-pointer dances papered over.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct PostgresSQLQuery {
-    /// Shared with the connection's named-statement map (each holder owns one ref).
+    /// The ref this query holds on its statement (also referenced by the
+    /// connection's prepared-statement map for named statements).
     pub(crate) statement: JsCell<Option<RefPtr<PostgresSQLStatement>>>,
     pub(crate) query: BunString,
 
@@ -46,24 +47,38 @@ pub struct PostgresSQLQuery {
 
     pub(crate) status: Cell<Status>,
 
-    // bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) — intrusive single-thread refcount.
-    // `#[derive(CellRefCounted)]` provides `ref_()`/`deref()` and the `AnyRefCounted`
-    // bridge so `RefPtr<PostgresSQLQuery>` brackets re-entrant callback paths.
+    // Intrusive single-thread refcount (`CellRefCounted`): held as `RefPtr`
+    // (connection request queue, JS wrapper) / `ref_guard()` (re-entrant paths).
     ref_count: Cell<u32>,
 
     pub(crate) flags: Cell<Flags>,
+    /// This allocation's root pointer, for the `&self` paths that take refs
+    /// on it (`ref_guard`, the connection's request queue).
+    this_ptr: Cell<Option<BackRef<PostgresSQLQuery, bun_ptr::Root>>>,
 }
 
-impl Default for PostgresSQLQuery {
-    fn default() -> Self {
-        Self {
+impl Drop for PostgresSQLQuery {
+    fn drop(&mut self) {
+        self.release_statement();
+    }
+}
+
+impl PostgresSQLQuery {
+    /// Heap-allocate a query; the returned ref is the one its JS wrapper
+    /// adopts (`js::to_js`; released by `finalize`).
+    fn new(query: BunString, flags: Flags) -> ThisPtr<Self> {
+        let this = RefPtr::new(Self {
             statement: JsCell::new(None),
-            query: BunString::EMPTY,
+            query,
             this_value: JsCell::new(JsRef::empty()),
             status: Cell::new(Status::Pending),
             ref_count: Cell::new(1),
-            flags: Cell::new(Flags::default()),
-        }
+            flags: Cell::new(flags),
+            this_ptr: Cell::new(None),
+        })
+        .into_this_ptr();
+        this.this_ptr.set(Some(this.into()));
+        this
     }
 }
 
@@ -109,8 +124,6 @@ impl Default for Flags {
 pub use bun_sql::shared::query_status::Status;
 
 impl PostgresSQLQuery {
-    // `ref_()`/`deref()` provided by `#[derive(CellRefCounted)]`.
-
     // ─── R-2 interior-mutability helpers ─────────────────────────────────────
 
     /// Read-modify-write the `Cell<Flags>` through `&self`.
@@ -121,35 +134,31 @@ impl PostgresSQLQuery {
         self.flags.set(v);
     }
 
-    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
+    /// This allocation's root pointer (see the `this_ptr` field).
+    #[inline]
+    pub(crate) fn this_ptr(&self) -> ThisPtr<Self> {
+        self.this_ptr
+            .get()
+            .expect("PostgresSQLQuery used before PostgresSQLQuery::new")
+            .this_ptr()
+    }
+
+    /// Holds a ref on `self` for the guard's scope.
     #[inline]
     pub(crate) fn ref_guard(&self) -> RefPtr<Self> {
-        // SAFETY: `self` is the live heap allocation.
-        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
+        RefPtr::from_this(self.this_ptr())
     }
 
-    /// Dereference the intrusive `statement` pointer as `&mut`. Mirrors
-    /// [`MySQLQuery::get_statement`]: one unchecked deref here replaces N inline
-    /// raw-pointer derefs at every protocol dispatch site in
-    /// `PostgresSQLConnection::on`.
-    ///
-    /// Kept alive by the ref this query holds. All mutation is
-    /// single-JS-thread so the `&mut` is exclusive for the borrow's lifetime;
-    /// callers must not hold two results live simultaneously (the request
-    /// FIFO never does).
+    /// This query's statement, if it has one yet.
     #[inline]
-    #[allow(clippy::mut_from_ref)] // intrusive pointer; see doc comment
-    pub(crate) fn statement_mut(&self) -> Option<&mut PostgresSQLStatement> {
-        // SAFETY: see doc comment.
-        self.statement
-            .get()
-            .as_ref()
-            .map(|p| unsafe { &mut *p.as_ptr() })
+    pub(crate) fn statement(&self) -> Option<&PostgresSQLStatement> {
+        self.statement.get().as_deref()
     }
 
+    /// Release the ref this query holds on its `statement`, clearing the field.
     #[inline]
     pub(crate) fn release_statement(&self) {
-        self.statement.set(None);
+        drop(self.statement.replace(None));
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -167,6 +176,7 @@ impl PostgresSQLQuery {
         Some(target)
     }
 
+    /// Runs before the JS wrapper's ref is dropped.
     pub fn finalize(&self) {
         bun_core::scoped_log!(Postgres, "PostgresSQLQuery finalize");
         self.this_value.with_mut(|r| r.finalize());
@@ -179,7 +189,7 @@ impl PostgresSQLQuery {
         queries_array: JSValue,
     ) {
         // R-2: every field touched below is `Cell`/`JsCell`-backed, so `&self`
-        // is sufficient and `noalias` is suppressed. `RefPtr` brackets the
+        // is sufficient and `noalias` is suppressed. `ref_guard()` brackets the
         // JS-re-entrant `run_callback` so a re-entrant `deref()` cannot free
         // `*self` mid-body.
         let _guard = self.ref_guard();
@@ -192,13 +202,9 @@ impl PostgresSQLQuery {
             return;
         };
 
-        // SAFETY: JS-thread only; short-lived `&mut` to the singleton VM, no other live borrow.
-        let vm = crate::jsc::VirtualMachine::get().as_mut();
+        let vm = crate::jsc::VirtualMachine::get();
         let function = vm
-            .sql_state()
-            .postgresql_context
-            .on_query_reject_fn
-            .get()
+            .with_sql_state(|s| s.postgresql_context.on_query_reject_fn.get())
             .unwrap();
         let event_loop = vm.event_loop_mut();
         let js_err = postgres_error_to_js(global_object, None, err);
@@ -215,7 +221,7 @@ impl PostgresSQLQuery {
     }
 
     pub(crate) fn on_js_error(&self, err: JSValue, global_object: &JSGlobalObject) {
-        // R-2: see `on_write_fail` — `&self` + Cell/JsCell, RefPtr brackets re-entry.
+        // R-2: see `on_write_fail` — `&self` + Cell/JsCell, `ref_guard()` brackets re-entry.
         let _guard = self.ref_guard();
         self.status.set(Status::Fail);
         let Some(this_value) = self.this_value.get().try_get() else {
@@ -226,13 +232,9 @@ impl PostgresSQLQuery {
             return;
         };
 
-        // SAFETY: JS-thread only; short-lived `&mut` to the singleton VM, no other live borrow.
-        let vm = crate::jsc::VirtualMachine::get().as_mut();
+        let vm = crate::jsc::VirtualMachine::get();
         let function = vm
-            .sql_state()
-            .postgresql_context
-            .on_query_reject_fn
-            .get()
+            .with_sql_state(|s| s.postgresql_context.on_query_reject_fn.get())
             .unwrap();
         let event_loop = vm.event_loop_mut();
         event_loop.run_callback(
@@ -272,7 +274,7 @@ impl PostgresSQLQuery {
         connection: JSValue,
         is_last: bool,
     ) {
-        // R-2: see `on_write_fail` — `&self` + Cell/JsCell, RefPtr brackets re-entry.
+        // R-2: see `on_write_fail` — `&self` + Cell/JsCell, `ref_guard()` brackets re-entry.
         let _guard = self.ref_guard();
         self.status.set(if is_last {
             Status::Success
@@ -299,13 +301,9 @@ impl PostgresSQLQuery {
             return;
         };
 
-        // SAFETY: JS-thread only; short-lived `&mut` to the singleton VM, no other live borrow.
-        let vm = crate::jsc::VirtualMachine::get().as_mut();
+        let vm = crate::jsc::VirtualMachine::get();
         let function = vm
-            .sql_state()
-            .postgresql_context
-            .on_query_resolve_fn
-            .get()
+            .with_sql_state(|s| s.postgresql_context.on_query_resolve_fn.get())
             .unwrap();
         let event_loop = vm.event_loop_mut();
 
@@ -356,26 +354,19 @@ impl PostgresSQLQuery {
             simple,
         } = QueryCtorArgs::parse(global_this, callframe.arguments())?;
 
-        let ptr = bun_core::heap::into_raw(Box::new(PostgresSQLQuery::default()));
-
-        // SAFETY: ptr was just allocated and is the m_ctx payload; toJS wraps it in the JSCell.
-        let this_value = js::to_js(ptr, global_this);
-        this_value.ensure_still_alive();
-
-        // SAFETY: ptr is exclusively owned here until returned to JS.
-        // Note: `PostgresSQLQuery` implements `Drop`, so functional-record-update
-        // (`..Default::default()`) is forbidden (E0509). `ptr` was already
-        // `default()`-initialised by `Box::new` above, so just overwrite the
-        // three non-default fields in place.
-        unsafe {
-            (*ptr).query = query.to_bun_string(global_this)?;
-            (*ptr).this_value.set(JsRef::init_weak(this_value));
-            (*ptr).flags.set(Flags {
+        let this = PostgresSQLQuery::new(
+            query.to_bun_string(global_this)?,
+            Flags {
                 bigint,
                 simple,
                 ..Default::default()
-            });
-        }
+            },
+        );
+
+        // The JS wrapper adopts the allocation's first ref.
+        let this_value = js::to_js(this.as_ptr(), global_this);
+        this_value.ensure_still_alive();
+        this.this_value.set(JsRef::init_weak(this_value));
 
         js::binding_set_cached(this_value, global_this, values);
         js::pending_value_set_cached(this_value, global_this, pending_value);
@@ -432,14 +423,13 @@ impl PostgresSQLQuery {
         Ok(JSValue::UNDEFINED)
     }
 
+    // The connection's request queue takes its own ref on `this` (`RefPtr::from_this`)
+    // once the query is enqueued; the JS wrapper (on-stack for this call) holds the other.
     pub fn do_run(
         this: &Self,
         global_object: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // R-2: `this` is the live m_ctx payload for `callframe.this()`; the JS
-        // wrapper is on-stack so GC cannot finalize it. Every mutated field is
-        // `Cell`/`JsCell`-backed, so `&Self` suffices.
         let arguments = callframe.arguments();
         // `from_js_ref` wraps the m_ctx payload in a `ParentRef` — the JS wrapper
         // is on-stack (rooted by `arguments[0]`) so GC cannot finalize it for the
@@ -462,10 +452,13 @@ impl PostgresSQLQuery {
         let this_value = callframe.this();
         let binding_value = js::binding_get_cached(this_value).unwrap_or_default();
         let query_str = this.query.to_utf8();
+        // query_str: Utf8Slice<'_> — Drop frees.
         let writer = connection.writer();
-        // The queue entry's ref: keeps the query alive until the server
-        // answers; dropped on every error return below.
-        let queued = this.ref_guard();
+        // Shared cleanup for every error-return path below: drop any statement
+        // ref this query took.
+        let release_query_ref = || {
+            this.release_statement();
+        };
         // Shared error tail: throw `err` as a postgres error unless an exception
         // is already pending.
         let throw_write_error = |msg: &[u8], err: AnyPostgresError| -> JsError {
@@ -482,21 +475,16 @@ impl PostgresSQLQuery {
         if this.flags.get().simple {
             bun_core::scoped_log!(Postgres, "executeQuery");
 
-            // NOTE: PostgresSQLStatement implements Drop, so functional-record-update
-            // (`..Default::default()`) is forbidden (E0509). Build + mutate instead.
-            let stmt = {
-                let mut s = PostgresSQLStatement::default();
-                s.signature = Signature::empty();
-                s.status = StatementStatus::Parsing;
-                RefPtr::new(s)
-            };
             // Query is simple and it's the only owner of the statement
-            this.statement.set(Some(stmt));
+            this.statement.set(Some(PostgresSQLStatement::new(
+                Signature::empty(),
+                StatementStatus::Parsing,
+            )));
 
             let can_execute = !connection.has_query_running();
             if can_execute {
                 if let Err(err) = PostgresRequest::execute_query(query_str.slice(), writer) {
-                    this.release_statement();
+                    release_query_ref();
                     return Err(throw_write_error(b"failed to execute query", err));
                 }
                 {
@@ -512,7 +500,10 @@ impl PostgresSQLQuery {
             } else {
                 this.status.set(Status::Pending);
             }
-            connection.requests.with_mut(|q| q.push_back(queued));
+            if !connection.enqueue_request(this.this_ptr()) {
+                release_query_ref();
+                return Err(global_object.throw_out_of_memory());
+            }
             if this.status.get() == Status::Pending {
                 connection.note_request_pending();
             }
@@ -540,7 +531,7 @@ impl PostgresSQLQuery {
         let columns_value: JSValue =
             js::columns_get_cached(this_value).unwrap_or(JSValue::UNDEFINED);
 
-        let mut signature = match Signature::generate(
+        let signature = match Signature::generate(
             global_object,
             query_str.slice(),
             binding_value,
@@ -563,11 +554,9 @@ impl PostgresSQLQuery {
         let has_params = signature.fields.len() > 0;
         let mut did_write = false;
         'enqueue: {
-            // Note: `connection_entry_value` is a *mut into connection.statements value slot;
-            // holding a `&mut` across other &mut connection borrows below trips borrowck, so
-            // store the raw slot pointer and re-dereference at use sites.
-            let mut connection_entry_value: Option<*mut Option<RefPtr<PostgresSQLStatement>>> =
-                None;
+            // Whether `connection.statements` has a slot reserved under
+            // `signature.name` for the statement this query will create.
+            let mut has_connection_entry = false;
             if !connection
                 .flags
                 .get()
@@ -580,18 +569,18 @@ impl PostgresSQLQuery {
                     .statements
                     .get()
                     .get(&signature.name[..])
-                    .and_then(|slot| slot.clone());
-                if let Some(existing_stmt) = existing_stmt {
-                    this.statement.set(Some(existing_stmt));
-                    let stmt = this.statement_mut().expect("statement set above");
+                    .and_then(|slot| slot.as_ref().cloned());
+                if let Some(stmt) = existing_stmt {
+                    // This query's ref on the shared statement.
+                    this.statement.set(Some(stmt));
+                    let stmt = this.statement().expect("statement set above");
                     drop(signature);
 
-                    match stmt.status {
+                    match stmt.status.get() {
                         StatementStatus::Failed => {
                             // `error_response` is `Some` when status == Failed.
-                            let error_response =
-                                stmt.error_response.as_ref().unwrap().to_js(global_object);
-                            this.statement.set(None);
+                            let error_response = stmt.error_response_to_js(global_object);
+                            this.release_statement();
                             return Err(global_object.throw_value(error_response?));
                         }
                         StatementStatus::Prepared => {
@@ -602,7 +591,7 @@ impl PostgresSQLQuery {
                             if (!connection.has_query_running() || connection.can_pipeline())
                                 && connection.pending_requests.get() == 0
                             {
-                                this.update_flags(|f| f.binary = !stmt.fields.is_empty());
+                                this.update_flags(|f| f.binary = !stmt.fields.get().is_empty());
                                 bun_core::scoped_log!(Postgres, "bindAndExecute");
 
                                 // bindAndExecute will bind + execute, it will change to running after binding is complete
@@ -613,7 +602,7 @@ impl PostgresSQLQuery {
                                     columns_value,
                                     writer,
                                 ) {
-                                    this.release_statement();
+                                    release_query_ref();
                                     return Err(throw_write_error(
                                         b"failed to bind and execute query",
                                         err,
@@ -638,24 +627,19 @@ impl PostgresSQLQuery {
 
                     break 'enqueue;
                 }
-                // `JsCell::with_mut` scopes the `&mut PreparedStatementsMap` to
-                // the `get_or_put` call (single-JS-thread; no re-entry into JS
-                // until after the raw value-slot ptr is captured). Extract the
-                // raw slot ptr while the borrow is live so the remainder of
-                // this block needs no further `&mut` to the map.
-                let entry_value_ptr = match connection.statements.with_mut(|s| {
-                    s.get_or_put(&signature.name)
-                        .map(|e| std::ptr::from_mut(e.value_ptr))
-                }) {
-                    Ok(v) => v,
-                    Err(err) => {
-                        drop(signature);
-                        this.release_statement();
-                        return Err(global_object
-                            .throw_error(crate::Error::from(err), "failed to allocate statement"));
-                    }
-                };
-                connection_entry_value = Some(entry_value_ptr);
+                // Reserve the map slot now (empty) so an allocation failure
+                // surfaces before anything is written; filled in below once
+                // the statement exists.
+                if let Err(err) = connection
+                    .statements
+                    .with_mut(|s| s.get_or_put(&signature.name).map(|_| ()))
+                {
+                    drop(signature);
+                    release_query_ref();
+                    return Err(global_object
+                        .throw_error(crate::Error::from(err), "failed to allocate statement"));
+                }
+                has_connection_entry = true;
             }
             let can_execute = !connection.has_query_running();
 
@@ -669,15 +653,15 @@ impl PostgresSQLQuery {
                         query_str.slice(),
                         binding_value,
                         writer,
-                        &mut signature,
+                        &signature,
                     ) {
-                        if connection_entry_value.is_some() {
+                        if has_connection_entry {
                             let _ = connection
                                 .statements
                                 .with_mut(|m| m.remove(&signature.name[..]));
                         }
                         drop(signature);
-                        this.release_statement();
+                        release_query_ref();
                         return Err(throw_write_error(b"failed to prepare and query", err));
                     }
                     {
@@ -703,23 +687,23 @@ impl PostgresSQLQuery {
                         &signature.fields,
                         writer,
                     ) {
-                        if connection_entry_value.is_some() {
+                        if has_connection_entry {
                             let _ = connection
                                 .statements
                                 .with_mut(|m| m.remove(&signature.name[..]));
                         }
                         drop(signature);
-                        this.release_statement();
+                        release_query_ref();
                         return Err(throw_write_error(b"failed to write query", err));
                     }
                     if let Err(err) = writer.write(&protocol::SYNC) {
-                        if connection_entry_value.is_some() {
+                        if has_connection_entry {
                             let _ = connection
                                 .statements
                                 .with_mut(|m| m.remove(&signature.name[..]));
                         }
                         drop(signature);
-                        this.release_statement();
+                        release_query_ref();
                         return Err(throw_write_error(b"failed to flush", err));
                     }
                     {
@@ -735,46 +719,38 @@ impl PostgresSQLQuery {
                 // parseAndBindAndExecute(), preventing PgBouncer from splitting them.
             }
             {
-                // we only have connection_entry_value if we are using named prepared statements
-                if let Some(entry_value) = connection_entry_value {
+                let stmt = PostgresSQLStatement::new(
+                    signature,
+                    if did_write {
+                        StatementStatus::Parsing
+                    } else {
+                        StatementStatus::Pending
+                    },
+                );
+                // we only have a connection entry if we are using named prepared statements
+                if has_connection_entry {
                     connection
                         .prepared_statement_id
                         .set(connection.prepared_statement_id.get() + 1);
-                    // One ref for this.statement, one for the connection.statements map.
-                    let stmt = {
-                        let mut s = PostgresSQLStatement::default();
-                        s.signature = signature;
-                        s.status = if did_write {
-                            StatementStatus::Parsing
-                        } else {
-                            StatementStatus::Pending
-                        };
-                        RefPtr::new(s)
-                    };
-                    this.statement.set(Some(stmt.clone()));
-
-                    // SAFETY: `entry_value` points into `connection.statements` and the map has
-                    // not been mutated since `get_or_put`. `get_or_put` runs only after the
-                    // existing-entry probe missed, so the slot it hands back was
-                    // default-initialised to `None`.
-                    unsafe { *entry_value = Some(stmt) };
-                } else {
-                    let stmt = {
-                        let mut s = PostgresSQLStatement::default();
-                        s.signature = signature;
-                        s.status = if did_write {
-                            StatementStatus::Parsing
-                        } else {
-                            StatementStatus::Pending
-                        };
-                        RefPtr::new(s)
-                    };
-                    this.statement.set(Some(stmt));
+                    // Two refs: one for this.statement, one for the
+                    // connection.statements map slot reserved above.
+                    let for_map = stmt.clone();
+                    connection.statements.with_mut(|m| {
+                        match m.get_mut(&for_map.signature.name[..]) {
+                            Some(slot @ None) => *slot = Some(for_map),
+                            // Gone, or already filled by a re-entrant run.
+                            _ => drop(for_map),
+                        }
+                    });
                 }
+                this.statement.set(Some(stmt));
             }
         }
 
-        connection.requests.with_mut(|q| q.push_back(queued));
+        if !connection.enqueue_request(this.this_ptr()) {
+            release_query_ref();
+            return Err(global_object.throw_out_of_memory());
+        }
         if this.status.get() == Status::Pending {
             connection.note_request_pending();
         }

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -656,9 +656,13 @@ impl PostgresSQLQuery {
                         &signature,
                     ) {
                         if has_connection_entry {
-                            let _ = connection
+                            // A re-entrant run may have filled the reserved slot.
+                            if let Some(Some(stmt)) = connection
                                 .statements
-                                .with_mut(|m| m.remove(&signature.name[..]));
+                                .with_mut(|m| m.remove(&signature.name[..]))
+                            {
+                                stmt.deref();
+                            }
                         }
                         drop(signature);
                         release_query_ref();
@@ -688,9 +692,13 @@ impl PostgresSQLQuery {
                         writer,
                     ) {
                         if has_connection_entry {
-                            let _ = connection
+                            // A re-entrant run may have filled the reserved slot.
+                            if let Some(Some(stmt)) = connection
                                 .statements
-                                .with_mut(|m| m.remove(&signature.name[..]));
+                                .with_mut(|m| m.remove(&signature.name[..]))
+                            {
+                                stmt.deref();
+                            }
                         }
                         drop(signature);
                         release_query_ref();
@@ -698,9 +706,13 @@ impl PostgresSQLQuery {
                     }
                     if let Err(err) = writer.write(&protocol::SYNC) {
                         if has_connection_entry {
-                            let _ = connection
+                            // A re-entrant run may have filled the reserved slot.
+                            if let Some(Some(stmt)) = connection
                                 .statements
-                                .with_mut(|m| m.remove(&signature.name[..]));
+                                .with_mut(|m| m.remove(&signature.name[..]))
+                            {
+                                stmt.deref();
+                            }
                         }
                         drop(signature);
                         release_query_ref();

--- a/src/sql_jsc/postgres/PostgresSQLStatement.rs
+++ b/src/sql_jsc/postgres/PostgresSQLStatement.rs
@@ -1,6 +1,6 @@
 use core::cell::Cell;
 
-use crate::jsc::{JSGlobalObject, JSValue, JsResult};
+use crate::jsc::{JSGlobalObject, JSValue, JsCell, JsResult};
 
 use crate::postgres::error_jsc::postgres_error_to_js;
 use crate::postgres::signature::Signature;
@@ -13,35 +13,20 @@ use bun_sql::postgres::postgres_types::int4;
 
 bun_core::declare_scope!(Postgres, visible);
 
+// Intrusive single-thread refcount (`CellRefCounted`). Shared between the owning query and the connection's prepared-statement map
+// (each holds a `RefPtr`), so every field written after construction is
+// interior-mutable and the statement is only ever reached as `&Self`.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct PostgresSQLStatement {
-    pub(crate) cached_structure: PostgresCachedStructure,
+    pub(crate) cached_structure: JsCell<PostgresCachedStructure>,
     ref_count: Cell<u32>,
-    pub(crate) fields: Vec<protocol::FieldDescription>,
-    pub(crate) parameters: Box<[int4]>,
+    pub(crate) fields: JsCell<Vec<protocol::FieldDescription>>,
+    pub(crate) parameters: JsCell<Box<[int4]>>,
     pub(crate) signature: Signature,
-    pub(crate) status: Status,
-    pub(crate) error_response: Option<Error>,
-    pub(crate) needs_duplicate_check: bool,
-    pub(crate) fields_flags: DataCellFlags,
-}
-
-impl Default for PostgresSQLStatement {
-    fn default() -> Self {
-        // Callers must set `signature`. This Default
-        // exists only to mirror the per-field `= ...` initializers.
-        Self {
-            cached_structure: PostgresCachedStructure::default(),
-            ref_count: Cell::new(1),
-            fields: Vec::new(),
-            parameters: Box::default(),
-            signature: Signature::default(),
-            status: Status::Pending,
-            error_response: None,
-            needs_duplicate_check: true,
-            fields_flags: DataCellFlags::default(),
-        }
-    }
+    pub(crate) status: Cell<Status>,
+    pub(crate) error_response: JsCell<Option<Error>>,
+    pub(crate) needs_duplicate_check: Cell<bool>,
+    pub(crate) fields_flags: Cell<DataCellFlags>,
 }
 
 pub enum Error {
@@ -67,34 +52,66 @@ impl Error {
 pub use bun_sql::shared::statement_status::Status;
 
 impl PostgresSQLStatement {
-    pub(crate) fn check_for_duplicate_fields(&mut self) {
-        if !self.needs_duplicate_check {
-            return;
-        }
-        self.needs_duplicate_check = false;
-
-        self.fields_flags =
-            dedupe_columns(self.fields.iter_mut().rev().map(|f| &mut f.name_or_index));
+    /// A new statement with one ref, owned by the returned handle.
+    pub(crate) fn new(signature: Signature, status: Status) -> bun_ptr::RefPtr<Self> {
+        bun_ptr::RefPtr::new(Self {
+            cached_structure: JsCell::new(PostgresCachedStructure::default()),
+            ref_count: Cell::new(1),
+            fields: JsCell::new(Vec::new()),
+            parameters: JsCell::new(Box::default()),
+            signature,
+            status: Cell::new(status),
+            error_response: JsCell::new(None),
+            needs_duplicate_check: Cell::new(true),
+            fields_flags: Cell::new(DataCellFlags::default()),
+        })
     }
 
-    // Note: returning
-    // `&CachedStructure` here to avoid moving out of `self` (CachedStructure owns
-    // a `Box<[ExternColumnIdentifier]>` and a `StrongOptional`, neither `Copy`).
+    /// The stored error as a JS value (`undefined` if none is stored).
+    pub(crate) fn error_response_to_js(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
+        match self.error_response.get() {
+            Some(e) => e.to_js(global_object),
+            None => Ok(JSValue::UNDEFINED),
+        }
+    }
+
+    /// Record `err` and mark the statement failed.
+    pub(crate) fn fail(&self, err: Error) {
+        self.status.set(Status::Failed);
+        self.error_response.set(Some(err));
+    }
+
+    pub(crate) fn check_for_duplicate_fields(&self) {
+        if !self.needs_duplicate_check.get() {
+            return;
+        }
+        self.needs_duplicate_check.set(false);
+
+        let flags = self.fields.with_mut(|fields| {
+            dedupe_columns(fields.iter_mut().rev().map(|f| &mut f.name_or_index))
+        });
+        self.fields_flags.set(flags);
+    }
+
+    /// The cached JSC structure for this statement's columns, building it on
+    /// first use.
     pub(crate) fn structure(
-        &mut self,
+        &self,
         owner: JSValue,
         global_object: &JSGlobalObject,
     ) -> &PostgresCachedStructure {
-        if self.cached_structure.has() {
-            return &self.cached_structure;
+        if !self.cached_structure.get().has() {
+            self.check_for_duplicate_fields();
+            let fields = self.fields.get();
+            self.cached_structure.with_mut(|cs| {
+                cs.build_from_columns(
+                    global_object,
+                    owner,
+                    fields.iter().map(|f| &f.name_or_index),
+                )
+            });
         }
-        self.check_for_duplicate_fields();
-        self.cached_structure.build_from_columns(
-            global_object,
-            owner,
-            self.fields.iter().map(|f| &f.name_or_index),
-        );
-        &self.cached_structure
+        self.cached_structure.get()
     }
 }
 

--- a/src/sql_jsc/postgres/SASL.rs
+++ b/src/sql_jsc/postgres/SASL.rs
@@ -67,35 +67,14 @@ impl SASL {
         password: &[u8],
     ) -> crate::Result<()> {
         // Note: `bun_runtime::crypto::EVP::pbkdf2` is a thin wrapper over
-        // BoringSSL's `PKCS5_PBKDF2_HMAC` with `EVP_sha256`. Inlined here to
-        // avoid the `bun_runtime` dep (which would create a cycle through
-        // `bun_jsc`); `bun_boringssl_sys` is already a direct dependency.
+        // BoringSSL's `PKCS5_PBKDF2_HMAC` with `EVP_sha256`.
         use bun_boringssl_sys as boringssl;
-        use core::ffi::c_uint;
 
         self.salted_password_created = true;
         let out = &mut self.salted_password_bytes;
         out.fill(0);
         boringssl::ERR_clear_error();
-        // SAFETY: password/salt/out are valid for the given lengths;
-        // `EVP_sha256()` returns a static EVP_MD singleton.
-        let rc = unsafe {
-            boringssl::PKCS5_PBKDF2_HMAC(
-                if password.is_empty() {
-                    core::ptr::null()
-                } else {
-                    password.as_ptr()
-                },
-                password.len(),
-                salt_bytes.as_ptr(),
-                salt_bytes.len(),
-                iteration_count as c_uint,
-                boringssl::EVP_sha256(),
-                out.len(),
-                out.as_mut_ptr(),
-            )
-        };
-        if rc <= 0 {
+        if !boringssl::pbkdf2_hmac_sha256(password, salt_bytes, iteration_count as u32, out) {
             return Err(crate::Error::PBKDFD2);
         }
         Ok(())
@@ -133,13 +112,9 @@ impl SASL {
     pub(crate) fn client_key_signature(&self, client_key: &[u8], auth_string: &[u8]) -> [u8; 32] {
         use bun_sha_hmac::SHA256;
         let mut sha_digest = [0u8; SHA256::DIGEST];
-        // BoringSSL's `EVP_DigestInit_ex` never reads its `ENGINE*`
-        // argument (see vendor/boringssl/crypto/fipsmodule/digest/digest.cc.inc;
-        // the parameter exists only for OpenSSL API compatibility). Passing
-        // null is bit-identical, so the upward hook is intentionally dropped —
-        // same rationale as `s3_signing::credentials::boring_engine`.
-        // SAFETY: engine is null (default).
-        unsafe { SHA256::hash(client_key, &mut sha_digest, core::ptr::null_mut()) };
+        // BoringSSL's `EVP_DigestInit_ex` never reads its `ENGINE*` argument,
+        // so the default engine is bit-identical to the VM's.
+        SHA256::digest(client_key, &mut sha_digest);
         hmac(&sha_digest, auth_string).unwrap()
     }
 

--- a/src/sql_jsc/shared/CachedStructure.rs
+++ b/src/sql_jsc/shared/CachedStructure.rs
@@ -1,4 +1,4 @@
-use core::mem::{ManuallyDrop, MaybeUninit};
+use core::mem::ManuallyDrop;
 
 use crate::jsc::{ExternColumnIdentifier, JSGlobalObject, JSObject, JSValue, StrongOptional};
 use bun_sql::shared::ColumnIdentifier;
@@ -34,10 +34,9 @@ impl CachedStructure {
     /// Populate this `CachedStructure` from a column-identifier sequence —
     /// the shared body of `{Postgres,MySQL}SQLStatement::structure()`.
     ///
-    /// Builds an `ExternColumnIdentifier` array on the stack when the
-    /// non-duplicate count fits in `JSObject::max_inline_capacity()` (then
-    /// bakes it into a JSC `Structure`), otherwise heap-allocates and stores
-    /// the boxed slice on `self.fields`. Duplicates are skipped. Callers must
+    /// Builds an `ExternColumnIdentifier` array and, when the non-duplicate
+    /// count fits in `JSObject::max_inline_capacity()`, bakes it into a JSC
+    /// `Structure`; otherwise stores the boxed slice on `self.fields`. Duplicates are skipped. Callers must
     /// have already run their `check_for_duplicate_fields()` pass so that
     /// `ColumnIdentifier::Duplicate` tags are present.
     ///
@@ -51,33 +50,13 @@ impl CachedStructure {
     ) where
         I: Iterator<Item = &'a ColumnIdentifier> + Clone,
     {
-        // lets avoid most allocations
-        // SAFETY: `[MaybeUninit<T>; N]` is always sound to `assume_init` — every
-        // element is itself `MaybeUninit` and thus has no validity invariant.
-        let mut stack_ids: [MaybeUninit<ExternColumnIdentifier>; 70] =
-            unsafe { MaybeUninit::uninit().assume_init() };
         // lets de duplicate the fields early
         let non_duplicated_count = columns
             .clone()
             .filter(|c| !matches!(c, ColumnIdentifier::Duplicate))
             .count();
 
-        let max_inline = JSObject::max_inline_capacity() as usize;
-        // Initialized to empty so the `> max_inline` branch below can
-        // unconditionally `into_boxed_slice()` it; in the `<= max_inline`
-        // branch it stays empty and is never read.
-        let mut heap_ids: Vec<ExternColumnIdentifier> = Vec::new();
-        let ids: &mut [MaybeUninit<ExternColumnIdentifier>] = if non_duplicated_count <= max_inline
-        {
-            &mut stack_ids[..non_duplicated_count]
-        } else {
-            heap_ids = Vec::with_capacity(non_duplicated_count);
-            // Spare capacity is exactly the uninitialized `[MaybeUninit<T>]` view
-            // we need; fully initialized in the loop below before any read.
-            &mut heap_ids.spare_capacity_mut()[..non_duplicated_count]
-        };
-
-        let mut i: usize = 0;
+        let mut ids: Vec<ExternColumnIdentifier> = Vec::with_capacity(non_duplicated_count);
         for name_or_index in columns {
             if matches!(name_or_index, ColumnIdentifier::Duplicate) {
                 continue;
@@ -99,29 +78,24 @@ impl CachedStructure {
                 ColumnIdentifier::Index(_) => 1,
                 ColumnIdentifier::Duplicate => 0,
             };
-            ids[i].write(out);
-            i += 1;
+            ids.push(out);
         }
 
-        if non_duplicated_count > max_inline {
-            // SAFETY: `heap_ids` has capacity `non_duplicated_count` and every
-            // slot in [0..non_duplicated_count] was initialized in the loop above.
-            unsafe { heap_ids.set_len(non_duplicated_count) };
-            // Ownership transfer of heap `ids` to CachedStructure, which
-            // becomes responsible for freeing the alloc'd slice.
-            self.set(global_object, None, Some(heap_ids.into_boxed_slice()));
+        if non_duplicated_count > JSObject::max_inline_capacity() as usize {
+            // Ownership transfer of `ids` to CachedStructure, which becomes
+            // responsible for freeing the slice.
+            self.set(global_object, None, Some(ids.into_boxed_slice()));
         } else {
-            // SAFETY: every `ids[..len]` slot was initialized in the loop above.
-            let ids: &mut [ExternColumnIdentifier] = unsafe { ids.assume_init_mut() };
-            // C++ copies each name into an `Identifier`; the stack buffer
-            // outlives the call and its atoms are released right after.
-            // SAFETY: `owner` is a cell; `ids` is a valid initialized buffer.
-            let structure = unsafe {
-                JSObject::create_structure(global_object, owner, ids.len() as u32, ids.as_mut_ptr())
-            };
-            // SAFETY: initialized above; not read again.
-            unsafe { core::ptr::drop_in_place(ids) };
-            self.set(global_object, Some(structure), None);
+            // Baked into a JSC `Structure`; C++ copies the names it needs.
+            self.set(
+                global_object,
+                Some(JSObject::create_structure_for(
+                    global_object,
+                    owner,
+                    &mut ids,
+                )),
+                None,
+            );
         }
     }
 }

--- a/src/sql_jsc/shared/ConnectionCtorArgs.rs
+++ b/src/sql_jsc/shared/ConnectionCtorArgs.rs
@@ -3,8 +3,7 @@
 //! tls, ...)` host functions, through the per-VM `SSL_CTX*` cache lookup.
 
 use crate::jsc::{
-    JSGlobalObject, JSValue, JsResult, VirtualMachine, VirtualMachineSqlExt as _,
-    api::server_config::SSLConfig,
+    JSGlobalObject, JSValue, JsResult, VirtualMachine, api::server_config::SSLConfig,
 };
 use bun_boringssl_sys::OwnedSslCtx;
 use bun_uws as uws;
@@ -42,7 +41,7 @@ pub(crate) struct ConnectionCtorArgs<M> {
     pub database_str: bun_core::String,
     pub ssl_mode: M,
     pub tls_config: SSLConfig,
-    /// Moves into the connection.
+    /// The `SSL_CTX` reference the connection will own.
     pub secure: Option<OwnedSslCtx>,
 }
 
@@ -51,7 +50,7 @@ impl<M: SslModeArg> ConnectionCtorArgs<M> {
     /// already pending and the caller should `return Ok(JSValue::ZERO)`.
     pub(crate) fn parse(
         global_object: &JSGlobalObject,
-        vm: &mut VirtualMachine,
+        vm: &VirtualMachine,
         arguments: &[JSValue],
     ) -> JsResult<Option<Self>> {
         let hostname_str = arguments[0].to_bun_string(global_object)?;
@@ -73,7 +72,7 @@ impl<M: SslModeArg> ConnectionCtorArgs<M> {
             tls_config = if tls_object.is_boolean() && tls_object.to_boolean() {
                 SSLConfig::default()
             } else if tls_object.is_object() {
-                match SSLConfig::from_js(&mut *vm, global_object, tls_object) {
+                match SSLConfig::from_js(vm, global_object, tls_object) {
                     Ok(opt) => opt.unwrap_or_default(),
                     Err(_) => return Ok(None),
                 }
@@ -92,9 +91,10 @@ impl<M: SslModeArg> ConnectionCtorArgs<M> {
             // `SSLContextCache` shares one `SSL_CTX*` per distinct config
             // across pooled connections and reconnects.
             let mut err = uws::create_bun_socket_error_t::none;
-            secure = vm
-                .ssl_ctx_cache()
-                .get_or_create_opts(&tls_config.as_usockets_for_client_verification(), &mut err);
+            secure = vm.ssl_ctx_cache_get_or_create(
+                &tls_config.as_usockets_for_client_verification(),
+                &mut err,
+            );
             if secure.is_none() {
                 drop(tls_config);
                 return Err(

--- a/src/sql_jsc/shared/SQLDataCell.rs
+++ b/src/sql_jsc/shared/SQLDataCell.rs
@@ -1,5 +1,4 @@
 use core::ptr;
-use core::slice;
 
 use crate::jsc::{ExternColumnIdentifier, JSGlobalObject, JSType, JSValue, JsError, JsResult};
 use bun_collections::StringHashMap;
@@ -7,14 +6,12 @@ use bun_core::UnwrapOrOom as _;
 use bun_core::wtf::WTFStringImpl;
 use bun_sql::shared::{ColumnIdentifier, Data};
 
-// Note: This entire type is passed by pointer
-// across FFI to C++ (`JSC__constructObjectFromDataCell`). Field layout is
-// load-bearing. LIFETIMES.tsv classifies several pointer fields as owned/shared/
-// borrowed (Vec / RefPtr / &[u8]), but those Rust types either change size
-// (fat slice ptrs) or add Drop semantics that a `#[repr(C)] union` cannot host
-// without `ManuallyDrop`. Raw thin pointers are kept for FFI fidelity; ownership
-// semantics from LIFETIMES.tsv are noted per-field below and enforced in
-// `deinit`. Revisit only if the C++ side (SQLClient.cpp) is ever ported.
+// Note: This entire type is passed by pointer across FFI to C++
+// (`JSC__constructObjectFromDataCell`), which copies what it needs out of each
+// cell. Field layout is load-bearing. A cell owns nothing: every pointer in
+// `Value` borrows either the connection's read buffer or the row's
+// [`CellStorage`], which the decoder keeps alive until the C++ call returns.
+// `free_value` stays in the layout for SQLClient.cpp and is always 0.
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -25,6 +22,45 @@ pub struct SQLDataCell {
     pub(crate) free_value: u8,
     pub(crate) is_indexed_column: u8,
     pub(crate) index: u32,
+}
+
+/// Owns the heap data one row's cells point into — decoded strings, unescaped
+/// `bytea`, text-array element vectors, byte-swapped typed arrays — until C++
+/// has copied them into JS values.
+#[derive(Default)]
+pub struct CellStorage {
+    strings: Vec<bun_core::String>,
+    bytes: Vec<Box<[u8]>>,
+    arrays: Vec<Vec<SQLDataCell>>,
+}
+
+impl CellStorage {
+    /// Keep `string` alive for the row and return the `StringImpl*` C++ reads
+    /// (null for a non-WTF/empty string).
+    pub(crate) fn hold_string(&mut self, string: bun_core::String) -> WTFStringImpl {
+        let ptr = string.leak_wtf_impl();
+        if !ptr.is_null() {
+            self.strings.push(bun_core::String::adopt_wtf_impl(ptr));
+        }
+        ptr
+    }
+
+    /// Keep `bytes` alive for the row and return where they now live.
+    pub(crate) fn hold_bytes(&mut self, bytes: Box<[u8]>) -> &[u8] {
+        self.bytes.push(bytes);
+        self.bytes.last().unwrap()
+    }
+
+    /// Keep `cells` alive for the row and return the array header C++ reads.
+    pub(crate) fn hold_array(&mut self, mut cells: Vec<SQLDataCell>) -> Array {
+        let array = Array {
+            ptr: cells.as_mut_ptr(),
+            len: cells.len() as u32,
+            cap: cells.capacity() as u32,
+        };
+        self.arrays.push(cells);
+        array
+    }
 }
 
 impl Default for SQLDataCell {
@@ -63,9 +99,7 @@ pub enum Tag {
 #[derive(Copy, Clone)]
 pub union Value {
     pub(crate) null: u8,
-    // LIFETIMES.tsv: SHARED → conceptually `Option<RefPtr<WTFStringImpl>>`.
-    // Kept as a raw thin pointer (`*mut WTFStringImplStruct`) because this
-    // is a `#[repr(C)] union` crossing FFI; `deinit()` derefs by tag.
+    // Borrowed from the row's `CellStorage` (or null).
     pub(crate) string: WTFStringImpl,
     pub(crate) float8: f64,
     pub(crate) int4: i32,
@@ -74,7 +108,7 @@ pub union Value {
     pub(crate) date: f64,
     pub(crate) date_with_time_zone: f64,
     pub(crate) bytea: [usize; 2],
-    // LIFETIMES.tsv: SHARED — same rationale as `string`.
+    // Borrowed from the row's `CellStorage` (or null).
     pub(crate) json: WTFStringImpl,
     pub(crate) array: Array,
     pub(crate) typed_array: TypedArray,
@@ -83,15 +117,11 @@ pub union Value {
     pub(crate) uint8: u64,
 }
 
-// Clone/Copy: bitwise — `ptr` is logically OWNED (freed by `deinit`), but the
-// type is `#[repr(C)]` POD passed across FFI by value. Ownership
-// is single-writer by convention; never call `deinit` on more than one copy.
+/// Header of a `Vec<SQLDataCell>` held in the row's [`CellStorage`]; C++
+/// reads `ptr[..len]`.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Array {
-    // LIFETIMES.tsv: OWNED → Vec<SQLDataCell>. Kept as raw ptr/len/cap because
-    // C++ reads these three fields directly across FFI; reconstructed as Vec in
-    // `deinit` to free.
     pub(crate) ptr: *mut SQLDataCell,
     pub(crate) len: u32,
     pub(crate) cap: u32,
@@ -107,36 +137,6 @@ impl Default for Array {
     }
 }
 
-impl Array {
-    pub(crate) fn slice(&mut self) -> &mut [SQLDataCell] {
-        if self.ptr.is_null() {
-            return &mut [];
-        }
-        // SAFETY: ptr is non-null and points to at least `len` initialized
-        // cells (invariant upheld by producers — postgres/DataCell.rs decomposes
-        // a `Vec<SQLDataCell>` into these fields). Genuine FFI: ptr/len/cap are
-        // thin C fields read directly by C++ (SQLClient.cpp), so this cannot be
-        // a `Vec` field without breaking ABI.
-        unsafe { slice::from_raw_parts_mut(self.ptr, self.len as usize) }
-    }
-
-    pub(crate) fn deinit(&mut self) {
-        let p = self.ptr;
-        let cap = self.cap as usize;
-        self.ptr = ptr::null_mut();
-        self.len = 0;
-        self.cap = 0;
-        if p.is_null() {
-            return;
-        }
-        // SAFETY: ptr/len/cap originate from a `Vec<SQLDataCell>` decomposed
-        // by the producer (postgres/DataCell.rs `parse_array`), i.e. a
-        // Vec-shaped allocation from the global allocator. Reconstruct and drop.
-        // Elements were already deinit'd by the caller; SQLDataCell has no Drop.
-        unsafe { drop(Vec::from_raw_parts(p, 0, cap)) };
-    }
-}
-
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Raw {
@@ -147,100 +147,16 @@ pub struct Raw {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct TypedArray {
-    // LIFETIMES.tsv: BORROW_PARAM → Option<&'a [u8]>. Kept as thin raw ptr for
-    // #[repr(C)] FFI layout (a Rust slice ref is a fat pointer). free_value=0
-    // for typed_array producers, so deinit's free path is effectively dead for
-    // borrowed buffers.
+    // Borrowed from the row's `CellStorage`; thin raw ptrs for the
+    // #[repr(C)] FFI layout (a Rust slice ref is a fat pointer).
     pub(crate) head_ptr: *mut u8,
-    // LIFETIMES.tsv: BORROW_FIELD → sub-slice of head_ptr; same rationale.
     pub(crate) ptr: *mut u8,
     pub(crate) len: u32,
     pub(crate) byte_len: u32,
     pub(crate) type_: JSType, // `type` is a Rust keyword
 }
 
-// Note: no `&mut [u8]` slice getters are provided. `len` is the typed-array
-// *element* count (consumed by SQLClient.cpp), not a byte length, so a
-// `&mut [u8; len]` view would be wrong for elements wider than u8; `deinit`
-// builds the fat pointer with the safe `ptr::slice_from_raw_parts_mut`
-// directly (no intermediate `&mut` reference).
-
 impl SQLDataCell {
-    // Note: kept as an explicit method, not `impl Drop` — this type is
-    // #[repr(C)], lives inside a C union, is bulk-passed to C++ by pointer, and
-    // freeing is gated on `free_value`. See PORTING.md §Idiom map (FFI types
-    // keep explicit destroy).
-    pub(crate) fn deinit(&mut self) {
-        if self.free_value == 0 {
-            return;
-        }
-
-        match self.tag {
-            Tag::String | Tag::Json => {
-                // SAFETY: tag ∈ {String, Json} ⇒ the active union field is a
-                // `WTFStringImpl` (`string` and `json` are both `*mut
-                // WTFStringImplStruct` overlaid at the same union offset, so
-                // reading either yields the same pointer). When non-null it
-                // points to a live WTF::StringImpl; `as_ref` folds the
-                // null-check and deref into one site.
-                if let Some(p) = unsafe { self.value.string.as_ref() } {
-                    p.deref();
-                }
-            }
-            Tag::Bytea => {
-                // SAFETY: tag == Bytea ⇒ `bytea` is the active union field.
-                let bytea = unsafe { self.value.bytea };
-                if bytea[1] == 0 {
-                    return;
-                }
-                let p = bytea[0] as *mut u8;
-                let len = bytea[1];
-                // Build the fat pointer with the safe `ptr::slice_from_raw_parts_mut`
-                // (no `&mut` reference materialized); only `Box::from_raw` is unsafe.
-                // SAFETY: the only `free_value=1` Bytea producer is `parse_bytea`
-                // (postgres/DataCell.rs), which stores the ptr/len of a
-                // `Box<[u8]>` of exactly `len` bytes, so the layout matches.
-                unsafe { drop(Box::<[u8]>::from_raw(ptr::slice_from_raw_parts_mut(p, len))) };
-            }
-            Tag::Array => {
-                // SAFETY: tag == Array ⇒ `array` is the active union field.
-                let array = unsafe { &mut self.value.array };
-                for cell in array.slice() {
-                    cell.deinit();
-                }
-                array.deinit();
-            }
-            Tag::TypedArray => {
-                // SAFETY: tag == TypedArray ⇒ `typed_array` is active.
-                let ta = unsafe { self.value.typed_array };
-                if !ta.head_ptr.is_null() && ta.byte_len != 0 {
-                    // Build the fat pointer with the safe
-                    // `ptr::slice_from_raw_parts_mut` (no `&mut` reference
-                    // materialized); only `Box::from_raw` is unsafe.
-                    // `len` is the *element* count (consumed by SQLClient.cpp
-                    // as the typed-array length); for any element wider than u8
-                    // that under-reports the allocation size, and
-                    // `Box::<[u8]>::from_raw`'s layout must match the
-                    // allocation, hence `byte_len`.
-                    // SAFETY: head_ptr was allocated via the global allocator
-                    // when free_value != 0. This branch is live: the postgres
-                    // binary-array path (DataCell.rs `from_bytes_typed_array`)
-                    // produces `free_value=1` cells whose `head_ptr` is
-                    // `Box::into_raw` of a `Box<[u8]>` of exactly `byte_len`
-                    // bytes, so the layout below matches the allocation.
-                    unsafe {
-                        drop(Box::<[u8]>::from_raw(ptr::slice_from_raw_parts_mut(
-                            ta.head_ptr,
-                            ta.byte_len as usize,
-                        )))
-                    };
-                }
-            }
-
-            _ => {}
-        }
-    }
-
     #[inline]
     pub(crate) fn null() -> SQLDataCell {
         SQLDataCell::default()
@@ -348,32 +264,42 @@ impl SQLDataCell {
         }
     }
 
-    /// Owned string cell: clones `bytes` into a WTFStringImpl, freed via
-    /// `free_value = 1`. Empty input becomes a null pointer, which the C++
-    /// side (SQLClient.cpp) renders as the empty string.
+    /// String cell: clones `bytes` into a WTFStringImpl held by `storage`.
+    /// Empty input becomes a null pointer, which the C++ side (SQLClient.cpp)
+    /// renders as the empty string.
     #[inline]
-    pub(crate) fn string(bytes: &[u8]) -> SQLDataCell {
+    pub(crate) fn string(storage: &mut CellStorage, bytes: &[u8]) -> SQLDataCell {
         SQLDataCell {
             tag: Tag::String,
             value: Value {
-                string: clone_utf8_or_null(bytes),
+                string: clone_utf8_or_null(storage, bytes),
             },
-            free_value: 1,
             ..Default::default()
         }
     }
 
-    /// Owned JSON cell: clones `bytes` into a WTFStringImpl, freed via
-    /// `free_value = 1`. Empty input becomes a null pointer, which the C++
-    /// side (SQLClient.cpp) renders as `null`.
+    /// JSON cell: clones `bytes` into a WTFStringImpl held by `storage`. Empty
+    /// input becomes a null pointer, which the C++ side (SQLClient.cpp)
+    /// renders as `null`.
     #[inline]
-    pub(crate) fn json(bytes: &[u8]) -> SQLDataCell {
+    pub(crate) fn json(storage: &mut CellStorage, bytes: &[u8]) -> SQLDataCell {
         SQLDataCell {
             tag: Tag::Json,
             value: Value {
-                json: clone_utf8_or_null(bytes),
+                json: clone_utf8_or_null(storage, bytes),
             },
-            free_value: 1,
+            ..Default::default()
+        }
+    }
+
+    /// `bytea` cell borrowing `bytes` (the read buffer or the row's storage).
+    #[inline]
+    pub(crate) fn bytea(bytes: &[u8]) -> SQLDataCell {
+        SQLDataCell {
+            tag: Tag::Bytea,
+            value: Value {
+                bytea: [bytes.as_ptr() as usize, bytes.len()],
+            },
             ..Default::default()
         }
     }
@@ -408,39 +334,31 @@ impl SQLDataCell {
         result_mode: u8,
         cached_structure: Option<&crate::shared::CachedStructure>,
     ) -> JsResult<JSValue> {
-        let (names, names_count) = match cached_structure.and_then(|c| c.fields.as_deref()) {
-            Some(f) => (f.as_ptr().cast_mut(), f.len() as u32),
-            None => (ptr::null_mut(), 0),
-        };
-
+        let names = cached_structure.and_then(|c| c.fields.as_deref());
         SQLDataCell::construct_object_from_data_cell(
             global_object,
             array,
             structure,
-            cells.as_mut_ptr(),
-            cells.len() as u32,
+            cells,
             flags,
             result_mode,
             names,
-            names_count,
         )
     }
 
-    // TODO: cppbind isn't yet able to detect slice parameters when the next is uint32_t
     pub(crate) fn construct_object_from_data_cell(
         global_object: &JSGlobalObject,
         encoded_array_value: JSValue,
         encoded_structure_value: JSValue,
-        cells: *mut SQLDataCell,
-        count: u32,
+        cells: &mut [SQLDataCell],
         flags: Flags,
         result_mode: u8,
-        // Accepts both a raw `*mut` (null == None) and an explicit
-        // `Option<*mut _>`; collapsed to a raw pointer for the FFI call below.
-        names_ptr: impl Into<Option<*mut ExternColumnIdentifier>>,
-        names_count: u32,
+        names: Option<&[ExternColumnIdentifier]>,
     ) -> JsResult<JSValue> {
-        let names_ptr: *mut ExternColumnIdentifier = names_ptr.into().unwrap_or(ptr::null_mut());
+        let (names_ptr, names_count) = match names {
+            Some(n) => (n.as_ptr(), n.len() as u32),
+            None => (ptr::null(), 0),
+        };
         // Open an `ExceptionValidationScope` so the C++
         // `DECLARE_THROW_SCOPE` inside
         // SQLClient.cpp's `toJS` (depth 0 → depth 1) has its post-call
@@ -453,8 +371,8 @@ impl SQLDataCell {
             global_object,
             encoded_array_value,
             encoded_structure_value,
-            cells,
-            count,
+            cells.as_mut_ptr(),
+            cells.len() as u32,
             flags,
             result_mode,
             names_ptr,
@@ -498,13 +416,12 @@ impl<'a> IntoOptionalData<'a> for Option<&'a mut Data> {
     }
 }
 
-/// Clones the bytes into a fresh `WTFStringImpl` whose +1 ref is transferred
-/// to the cell (`free_value = 1`). Empty input maps to a null pointer instead
-/// of allocating an empty string.
+/// Clones the bytes into a fresh `WTFStringImpl` held by `storage`. Empty
+/// input maps to a null pointer instead of allocating an empty string.
 #[inline]
-fn clone_utf8_or_null(bytes: &[u8]) -> WTFStringImpl {
+fn clone_utf8_or_null(storage: &mut CellStorage, bytes: &[u8]) -> WTFStringImpl {
     if !bytes.is_empty() {
-        bun_core::String::clone_utf8(bytes).leak_wtf_impl()
+        storage.hold_string(bun_core::String::clone_utf8(bytes))
     } else {
         ptr::null_mut()
     }
@@ -574,12 +491,10 @@ pub(crate) fn dedupe_columns<'a>(
 // extern this crate calls and its sole consumer is the wrapper above.
 unsafe extern "C" {
     // `&JSGlobalObject` is ABI-identical to a non-null `*const JSGlobalObject`;
-    // remaining params are by-value scalars + raw (ptr,len) slice pairs that
-    // the C++ side bounds-checks against `count`/`names_count`. The sole call
-    // site is the safe `construct_object_from_data_cell` wrapper above, which
-    // already accepts the same raw-pointer shape from safe code, so the
-    // memory-validity contract is identical → `safe fn`.
-    pub(crate) safe fn JSC__constructObjectFromDataCell(
+    // remaining params are by-value scalars + (ptr,len) pairs the sole caller
+    // (`construct_object_from_data_cell` above) takes from live slices, which
+    // the C++ side reads within `count`/`names_count` → `safe fn`.
+    safe fn JSC__constructObjectFromDataCell(
         global: &JSGlobalObject,
         encoded_array_value: JSValue,
         encoded_structure_value: JSValue,
@@ -587,7 +502,7 @@ unsafe extern "C" {
         count: u32,
         flags: Flags,
         result_mode: u8,
-        names: *mut ExternColumnIdentifier,
+        names: *const ExternColumnIdentifier,
         names_count: u32,
     ) -> JSValue;
 }

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -968,6 +968,15 @@ impl AnySocket {
         }
     }
 
+    /// The `SSL` handle of a connected TLS socket; `None` for TCP.
+    #[inline]
+    pub fn ssl_mut(&self) -> Option<&mut bun_boringssl_sys::SSL> {
+        match self {
+            AnySocket::SocketTcp(_) => None,
+            AnySocket::SocketTls(s) => s.ssl_mut(),
+        }
+    }
+
     any_socket_forward! {
         fn is_closed(&self) -> bool;
         fn is_shutdown(&self) -> bool;

--- a/test/js/web/timers/setImmediate.test.js
+++ b/test/js/web/timers/setImmediate.test.js
@@ -55,6 +55,22 @@ it("clearImmediate", async () => {
   await promise;
 });
 
+it("clearImmediate with a numeric or string id does not clear a timeout or interval (Node.js parity)", async () => {
+  const timeoutFired = Promise.withResolvers();
+  const intervalFired = Promise.withResolvers();
+  const t = setTimeout(() => timeoutFired.resolve(true), 1);
+  const i = setInterval(() => {
+    clearInterval(i);
+    intervalFired.resolve(true);
+  }, 1);
+  clearImmediate(+t);
+  clearImmediate(String(+t));
+  clearImmediate(+i);
+  clearImmediate(String(+i));
+  expect(await timeoutFired.promise).toBe(true);
+  expect(await intervalFired.promise).toBe(true);
+});
+
 it("setImmediate should not keep the process alive forever", async () => {
   let process = null;
   const success = async () => {

--- a/test/js/web/timers/setInterval.test.js
+++ b/test/js/web/timers/setInterval.test.js
@@ -1,5 +1,5 @@
 import { expect, it } from "bun:test";
-import { bunRun, isWindows } from "harness";
+import { bunEnv, bunExe, bunRun, isWindows } from "harness";
 import { join } from "path";
 
 it("setInterval", async () => {
@@ -133,3 +133,35 @@ it.concurrent(
   },
   30_000,
 );
+
+it.concurrent("an interval that stops itself via _repeat = null / _idleTimeout = -1 is collectable", async () => {
+  const code = /* js */ `
+    const { heapStats } = require("bun:jsc");
+    const N = 200;
+    let fired = 0;
+    await new Promise(resolve => {
+      for (let i = 0; i < N; i++) {
+        setInterval(function () {
+          if (i % 2) this._repeat = null;
+          else this._idleTimeout = -1;
+          if (++fired === N) resolve();
+        }, 1);
+      }
+    });
+    await new Promise(r => setTimeout(r, 10));
+    Bun.gc(true);
+    await new Promise(r => setTimeout(r, 10));
+    Bun.gc(true);
+    const left = heapStats().objectTypeCounts.Timeout ?? 0;
+    console.log(fired, left < N / 2 ? "collected" : "leaked " + left);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout.trim()).toBe("200 collected");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What

Same programme as #40055 … #40262. **Stacked on #40139** (base branch `claude/socket-zero-unsafe`) and includes #40187's timer branch by merge (needs `TimerRef`); retarget to main once those land.

`src/sql_jsc/`: `PostgresSQLConnection.rs` 21 → **0**, `MySQLConnection.rs` 14 → 0, `PostgresSQLQuery.rs` 10 → 0, `MySQLRequestQueue.rs` 9 → 0, `JSMySQLConnection.rs` 6 → 0, `CachedStructure.rs` 4 → 0, `MySQLQuery.rs`/`MySQLValue.rs`/`JSMySQLQuery.rs`/`SASL.rs`/`ConnectionCtorArgs.rs`/`*Context.rs` → 0, `jsc.rs` 35 → 1, `SQLDataCell.rs` 11 → 1, `DataCell.rs` 2 → 1 (residuals are all-`safe` extern blocks). `src/runtime/valkey_jsc/`: `js_valkey.rs` 33 → 0, `valkey.rs` 5 → 0, `js_valkey_functions.rs` 2 → 0. Collateral: `dispatch.rs` 99 → 88, `hw_exports.rs` 65 → 41 (`ValkeyDeferredClose` tag removed — it's a `ManagedTask` now).

- Connections are `CellRefCounted` with typed slots for the socket/timer/queued-task holders; `NsSocketEvents`/`SocketHandler::on_*` take `ThisPtr<Owner>`; request queues are `VecDeque<RefPtr<Query>>`; SQL timers arm through `timer_owner_this!`; `SqlRuntimeHooks` is `{with_sql_state, timer_insert(TimerRef), timer_remove(TimerRef), ssl_config_from_js}` (all safe; the Blob hook is gone — sql_jsc uses `bun_jsc::webcore::Blob` directly).
- New primitives: `bun_jsc::auto_flusher::{AutoFlusher<T>, AutoFlushTarget}` (holds a ref across the callback), `bun_jsc::url::OwnedUrl`, `JSObject::create_structure_for`, `JSValue::borrow_bytes_for_off_thread -> BorrowedBytes<'_>`, `From<RefPtr<T>> for ScopedRef<T>`, `JsCell::get_mut_unique(&mut self)`, `ManagedTask::{new_boxed, RunOnce}` (same as #40204's), `boringssl_sys::{pbkdf2_hmac_sha256, err_error_string_n}`, `bun_sha_hmac` `SHA*::digest`, `uws_sys::AnySocket::ssl_mut`.

Noted, unchanged shapes: `SQLDataCell` still carries raw `&[u8]` addresses as POD for `raw`/`bytea` (C++ consumes it synchronously); MySQL `Reader`/`Writer` back-refs alias the connection exactly as before.

Pre-existing bugs fixed in passing: `CachedStructure::build_from_columns` leaked one atom-string ref per named column per structure; Postgres `do_run` kept a raw pointer into the statements map across user-JS-running bind conversion (now re-looked-up by name); a re-entrant named-statement slot fill leaked; MySQL `on_close` would over-release if it fired without a TCP `on_open`. Left as-is and flagged: `clean_up_requests`' `Pending`-without-statement arm `continue`s without discarding.

### Testing

Debug+ASAN against Docker Postgres / MySQL / Redis: all 56 `test/js/sql/*.test.ts` pass except `should not timeout in long results` (1 pg + 3 mysql) which fails identically on the parent commit's debug build (10 s budget); `test/js/valkey/**` 1305 pass (`valkey-gc.test.ts`'s 3 LSAN cases identical on baseline — unsymbolized `bun:ffi` dlopen); third-party `pg`/`pg-gateway`/`postgres` pass. Hand-driven: 500 queued queries + close + GC, close mid-query, 20 pool open/close cycles (pg + mysql; wrapper counts return to baseline), a Worker with pg/mysql/redis connections and in-flight queries terminated × 6 — no ASAN output. clippy clean on all touched crates; `rust-check-all` windows-msvc + apple-darwin pass.