### PR TITLE
Lay out the --compile module graph in load order

### DIFF
--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -34,6 +34,9 @@ pub struct OutputFile {
     pub referenced_css_chunks: Box<[Index]>,
     pub source_index: IndexOptional,
     pub bake_extra: BakeExtra,
+    /// Position of this chunk in the order the runtime is expected to load it
+    /// (see `chunk_load_order`); `u32::MAX` for anything that is not a chunk.
+    pub load_order: u32,
 }
 
 impl OutputFile {
@@ -59,6 +62,7 @@ impl OutputFile {
             referenced_css_chunks: Box::default(),
             source_index: IndexOptional::NONE,
             bake_extra: BakeExtra::default(),
+            load_order: u32::MAX,
         }
     }
 }
@@ -206,6 +210,7 @@ impl OutputFile {
             entry_point_index: options.entry_point_index,
             referenced_css_chunks: options.referenced_css_chunks,
             bake_extra: options.bake_extra,
+            load_order: u32::MAX,
         }
     }
 

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1294,8 +1294,11 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         }
     }
 
-    for (chunk_index, &position) in chunk_load_order(c, chunks).iter().enumerate() {
-        output_files.output_files[chunk_index].load_order = position;
+    // Only `StandaloneModuleGraph::to_bytes` reads `load_order`.
+    if is_compile {
+        for (chunk_index, &position) in chunk_load_order(c, chunks).iter().enumerate() {
+            output_files.output_files[chunk_index].load_order = position;
+        }
     }
 
     if is_standalone {

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1294,6 +1294,10 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         }
     }
 
+    for (chunk_index, &position) in chunk_load_order(c, chunks).iter().enumerate() {
+        output_files.output_files[chunk_index].load_order = position;
+    }
+
     if is_standalone {
         // For standalone mode, filter to HTML output files plus the .map files
         // of the inlined chunks (linked/external sourcemaps).
@@ -1315,6 +1319,69 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
     }
 
     Ok(output_files.take())
+}
+
+/// Position of each chunk in the order a `--compile` executable is expected to
+/// load it: the entry point's static cross-chunk imports in evaluation order,
+/// then the closures of its dynamic imports, breadth-first. The standalone
+/// module graph lays modules out by this so booting faults in one run of pages
+/// rather than one page per chunk scattered across the payload.
+fn chunk_load_order(c: &LinkerContext, chunks: &[Chunk]) -> Vec<u32> {
+    let entry_point_kinds = c.graph.files.items_entry_point_kind();
+    let mut visited = AutoBitSet::init_empty(chunks.len()).expect("oom");
+    let mut order: Vec<u32> = Vec::with_capacity(chunks.len());
+    let mut dynamic_frontier: std::collections::VecDeque<u32> = chunks
+        .iter()
+        .enumerate()
+        .filter(|(_, chunk)| {
+            chunk.entry_point.is_entry_point()
+                && entry_point_kinds[chunk.entry_point.source_index() as usize].output_kind()
+                    == options::OutputKind::EntryPoint
+        })
+        .map(|(i, _)| i as u32)
+        .collect();
+
+    let mut stack: Vec<(u32, usize)> = Vec::new();
+    while let Some(root) = dynamic_frontier.pop_front() {
+        if visited.is_set(root as usize) {
+            continue;
+        }
+        visited.set(root as usize);
+        stack.push((root, 0));
+        // Post-order over static imports: a module's dependencies evaluate before it.
+        while let Some(&(chunk_index, next_import)) = stack.last() {
+            match chunks[chunk_index as usize]
+                .cross_chunk_imports
+                .get(next_import)
+            {
+                Some(import) => {
+                    stack.last_mut().unwrap().1 += 1;
+                    let dep = import.chunk_index;
+                    if import.import_kind == bun_ast::ImportKind::Dynamic {
+                        dynamic_frontier.push_back(dep);
+                    } else if !visited.is_set(dep as usize) {
+                        visited.set(dep as usize);
+                        stack.push((dep, 0));
+                    }
+                }
+                None => {
+                    stack.pop();
+                    order.push(chunk_index);
+                }
+            }
+        }
+    }
+    for chunk_index in 0..chunks.len() as u32 {
+        if !visited.is_set(chunk_index as usize) {
+            order.push(chunk_index);
+        }
+    }
+
+    let mut position = vec![0u32; chunks.len()];
+    for (i, &chunk_index) in order.iter().enumerate() {
+        position[chunk_index as usize] = i as u32;
+    }
+    position
 }
 
 use crate::EntryPoint;

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -968,9 +968,8 @@ pub(crate) fn to_bytes(
 
     string_builder.allocate()?;
 
-    let mut modules: Vec<CompiledModuleGraphFile> = Vec::with_capacity(module_count);
     let mut module_files: Vec<&OutputFile> = Vec::with_capacity(module_count);
-    let mut entry_point_id: Option<usize> = None;
+    let mut entry_point_file: Option<&OutputFile> = None;
     // `Graph::from_bytes` keys files by path; a repeat would shift `entry_point_id`.
     let mut seen_paths: StringArrayHashMap<()> = StringArrayHashMap::new();
 
@@ -979,9 +978,9 @@ pub(crate) fn to_bytes(
             continue;
         }
 
-        let options::OutputFileValue::Buffer { bytes: buf_bytes } = &output_file.value else {
+        if !matches!(output_file.value, options::OutputFileValue::Buffer { .. }) {
             continue;
-        };
+        }
 
         // Same `[name]` and `[hash]` means the same bytes: keep the first copy.
         if seen_paths
@@ -990,9 +989,26 @@ pub(crate) fn to_bytes(
         {
             continue;
         }
-        if entry_point_id.is_none() && is_entry_point(output_file) {
-            entry_point_id = Some(modules.len());
+        if entry_point_file.is_none() && is_entry_point(output_file) {
+            entry_point_file = Some(output_file);
         }
+        module_files.push(output_file);
+    }
+    let Some(entry_point_file) = entry_point_file else {
+        return Ok(Vec::new());
+    };
+    // Every per-module region below is written in load order (entry point's
+    // static imports first, then dynamic imports breadth-first) so the modules
+    // a process actually loads share pages instead of each dragging in its own.
+    module_files.sort_by_key(|f| f.load_order);
+    let entry_point_id = module_files
+        .iter()
+        .position(|f| core::ptr::eq(*f, entry_point_file))
+        .unwrap();
+
+    let mut modules: Vec<CompiledModuleGraphFile> = Vec::with_capacity(module_files.len());
+    for &output_file in &module_files {
+        let buf_bytes = output_file.value.as_slice();
 
         let bytecode: StringPointer = 'brk: {
             if output_file.bytecode_index != u32::MAX {
@@ -1140,7 +1156,6 @@ pub(crate) fn to_bytes(
             },
             sourcemap: StringPointer::default(),
         });
-        module_files.push(output_file);
     }
 
     // Region layout after the bytecode/module_info run above: source maps
@@ -1197,9 +1212,6 @@ pub(crate) fn to_bytes(
             modules.as_ptr().cast::<u8>(),
             modules.len() * size_of::<CompiledModuleGraphFile>(),
         )
-    };
-    let Some(entry_point_id) = entry_point_id else {
-        return Ok(Vec::new());
     };
     let offsets = Offsets {
         entry_point_id: entry_point_id as u32,

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -1,8 +1,54 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
+import { readFileSync } from "node:fs";
 import { itBundled } from "./expectBundled";
 
 describe("bundler", () => {
   describe("compile with splitting", () => {
+    // The embedded module graph is laid out in load order: the entry point's
+    // static imports (dependencies first), then each dynamic import's closure,
+    // breadth-first. Chunk index order would be entry, lazy1, lazy2, shared,
+    // shared2.
+    itBundled("compile/splitting/ModulesLaidOutInLoadOrder", {
+      compile: true,
+      splitting: true,
+      bytecode: true,
+      format: "esm",
+      files: {
+        "/entry.ts": /* js */ `
+          import "./shared";
+          console.log("mark:entry");
+          await import("./lazy1");
+        `,
+        "/lazy1.ts": /* js */ `
+          import "./shared";
+          import "./shared2";
+          console.log("mark:lazy1");
+          await import("./lazy2");
+        `,
+        "/lazy2.ts": /* js */ `
+          import "./shared2";
+          console.log("mark:lazy2");
+        `,
+        "/shared.ts": /* js */ `
+          console.log("mark:shared");
+        `,
+        "/shared2.ts": /* js */ `
+          console.log("mark:shared2");
+        `,
+      },
+      run: {
+        stdout: "mark:shared\nmark:entry\nmark:shared2\nmark:lazy1\nmark:lazy2",
+      },
+      onAfterBundle(api) {
+        const payload = readFileSync(api.outfile).toString("latin1");
+        const order = ["entry", "lazy1", "lazy2", "shared", "shared2"]
+          .map(name => ({ name, offset: payload.lastIndexOf(`mark:${name}"`) }))
+          .sort((a, b) => a.offset - b.offset)
+          .map(m => m.name);
+        expect(order).toEqual(["shared", "entry", "shared2", "lazy1", "lazy2"]);
+      },
+    });
+
     itBundled("compile/splitting/RelativePathsAcrossChunks", {
       compile: true,
       splitting: true,

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -42,7 +42,11 @@ describe("bundler", () => {
       onAfterBundle(api) {
         const payload = readFileSync(api.outfile).toString("latin1");
         const order = ["entry", "lazy1", "lazy2", "shared", "shared2"]
-          .map(name => ({ name, offset: payload.lastIndexOf(`mark:${name}"`) }))
+          .map(name => {
+            const offset = payload.lastIndexOf(`mark:${name}"`);
+            expect(offset, `marker mark:${name} not found in the payload`).toBeGreaterThanOrEqual(0);
+            return { name, offset };
+          })
           .sort((a, b) => a.offset - b.offset)
           .map(m => m.name);
         expect(order).toEqual(["shared", "entry", "shared2", "lazy1", "lazy2"]);


### PR DESCRIPTION
### What does this PR do?

Follow-up to #39912. That PR grouped the `--compile` payload by region; within each region modules were still written in chunk-index order. With `--splitting --format=esm --bytecode` an app can embed 1,000+ chunks, many of them small, so the modules a process actually loads at startup were interleaved with ones it never touches.

This writes every per-module region (bytecode + module info, source text, source maps) in **load order**:

1. the main entry point's static cross-chunk import closure, dependencies first (post-order = ESM evaluation order) — everything that loads before the first `import()` is one sequential run;
2. then dynamic `import()` targets breadth-first by distance from the entry, each immediately preceded by the chunks it statically imports that aren't placed yet — loading a lazy route reads one contiguous run;
3. anything not reachable from a JS entry point (CSS/HTML/assets) keeps its previous relative order at the end.

The linker already has the graph (`cross_chunk_imports`, including `ImportKind::Dynamic` edges), so `chunk_load_order` computes a position per chunk, it is stored on `OutputFile::load_order`, and `to_bytes` sorts by it. The payload format is unchanged; old and new runtimes interoperate in both directions.

### Measurements

Synthetic app: 1,150 chunks (900 lazily imported routes, 600 shared libs), 127 modules load at startup. Linux x64, 4 KiB pages, debug build; `drop_caches`, run, then `mincore()` over the executable attributed to regions via the module table (2 runs each, identical):

| | chunk-index order | load order |
|---|---|---|
| payload pages read at startup | 539 (2.11 MiB) | 498 (1.95 MiB) |
| bytecode pages read | 389 | 348 |
| modules with any bytecode page touched | 240 | 163 |

The effect is real but modest on 4 KiB pages: `computeChunks` already sorts `entry_point_id == 0` first and every shared chunk carries id 0, so the main entry's closure was already close to contiguous; the reorder mostly fixes the dynamic-import levels (a lazy chunk now sits next to its dependencies instead of at the far end of the payload) and turns kernel readahead from spill into prefetch. Per-module boundary savings scale with page size (16 KiB on macOS arm64).

The same measurement shows where startup bytes actually go, for follow-ups: the 127 startup modules need 1,014 KiB of bytecode for 97 KiB of source, and the source text of every loaded module is still read on a bytecode cache hit because `Zig::SourceProvider::hash()` hashes the full source to build the `SourceCodeKey` (`m_hash` is never pre-populated). Precomputing that hash at build time would leave source pages untouched at startup; that is a separate change.

### How did you verify your code works?

- New `compile/splitting/ModulesLaidOutInLoadOrder` in `test/bundler/bundler_compile_splitting.test.ts`: entry → shared, `import("./lazy1")` → shared2, `import("./lazy2")`; asserts the embedded order is `shared, entry, shared2, lazy1, lazy2` (chunk-index order is `entry, lazy1, lazy2, shared, shared2`, so it fails on an unpatched build) and that the executable prints in evaluation order.
- `bundler_compile_splitting.test.ts`, `standalone-madvise-tla.test.ts`, `bundler_compile.test.ts` pass (`compile/HelloWorldWithProcessVersionsBun` fails identically on `main` with a local debug build — version string mismatch, unrelated).
- Drove the debug build on the 1,150-chunk app with several route combinations and `--sourcemap`; bytecode cache hits unchanged (127/127).