### PR TITLE
Upgrade WebKit to 8c4fd56347

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-503-d2654c3b";
+export const WEBKIT_VERSION = "cb61607f1a4bae79d7701965062634dee9efb349";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "c148a12dd82b9d88ea81d9d93840194f56490a61";
+export const WEBKIT_VERSION = "autobuild-preview-pr-503-d2654c3b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -123,6 +123,16 @@ declare function $resolvePromise<T>(promise: Promise<T>, value: NoInfer<T>): voi
  * Reject a promise with a value
  */
 declare function $rejectPromise(promise: Promise<unknown>, value: unknown): void;
+/**
+ * A new pending promise with the intrinsic %Promise.prototype%. Settle it with the
+ * `$resolvePromise` / `$rejectPromise` family. `$resolvePromise` and `$rejectPromise`
+ * require the promise to still be pending; the `...WithFirstResolvingFunctionCallCheck`
+ * variants behave like the resolving functions handed to a Promise executor and ignore
+ * every call after the first one.
+ */
+declare function $newPromise<T = unknown>(): Promise<T>;
+declare function $resolvePromiseWithFirstResolvingFunctionCallCheck<T>(promise: Promise<T>, value: NoInfer<T>): void;
+declare function $rejectPromiseWithFirstResolvingFunctionCallCheck(promise: Promise<unknown>, value: unknown): void;
 
 declare function $loadEsmIntoCjs(...args: any[]): TODO;
 declare function $getProxyInternalField(): TODO;
@@ -296,7 +306,6 @@ declare function $overridableRequire(this: JSCommonJSModule, id: string): any;
 declare function $toLength(length: number): number;
 declare function $isTypedArrayView(obj: unknown): obj is ArrayBufferView | DataView | Uint8Array;
 declare function $setStateToMax(target: any, state: number): void;
-declare function $newPromiseCapability(C: PromiseConstructor): TODO;
 /** @deprecated, use new TypeError instead */
 declare function $makeTypeError(message: string): TypeError;
 

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -123,14 +123,9 @@ declare function $resolvePromise<T>(promise: Promise<T>, value: NoInfer<T>): voi
  * Reject a promise with a value
  */
 declare function $rejectPromise(promise: Promise<unknown>, value: unknown): void;
-/**
- * A new pending promise with the intrinsic %Promise.prototype%. Settle it with the
- * `$resolvePromise` / `$rejectPromise` family. `$resolvePromise` and `$rejectPromise`
- * require the promise to still be pending; the `...WithFirstResolvingFunctionCallCheck`
- * variants behave like the resolving functions handed to a Promise executor and ignore
- * every call after the first one.
- */
+/** A new pending promise. `$resolvePromise` / `$rejectPromise` require it to still be pending. */
 declare function $newPromise<T = unknown>(): Promise<T>;
+/** Like the resolving functions of a Promise executor: calls after the first one are ignored. */
 declare function $resolvePromiseWithFirstResolvingFunctionCallCheck<T>(promise: Promise<T>, value: NoInfer<T>): void;
 declare function $rejectPromiseWithFirstResolvingFunctionCallCheck(promise: Promise<unknown>, value: unknown): void;
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1328,8 +1328,6 @@ function detachSocketListenersForHandoff(socket) {
   socket.removeListener("timeout", onNodeHTTPServerSocketTimeout);
   socket.on("end", onReadableStreamEnd);
 }
-// 'close' listener for a handed-off CONNECT/Upgrade socket: settles the promise
-// that keeps the native request callback open.
 function resolveHandoffPromise(promise) {
   $resolvePromise(promise, undefined);
 }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -752,7 +752,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             // Attach the internal close listener after the user's "connect"
             // handler ran: Node.js hands the socket over with no listeners and
             // tests assert socket.listenerCount("close") === 0 there.
-            socket.once("close", () => $resolvePromise(promise, undefined));
+            socket.once("close", resolveHandoffPromise.bind(undefined, promise));
             return promise;
           } else {
             // Node.js will close the socket and will NOT respond with 400 Bad Request
@@ -992,7 +992,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           // machinery; hold the native callback open until the raw socket
           // closes.
           const upgradePromise = $newPromise();
-          socket.once("close", () => $resolvePromise(upgradePromise, undefined));
+          socket.once("close", resolveHandoffPromise.bind(undefined, upgradePromise));
           return upgradePromise;
         } else if (
           server.requireHostHeader &&
@@ -1327,6 +1327,11 @@ function detachSocketListenersForHandoff(socket) {
   socket.removeListener("error", socketOnError);
   socket.removeListener("timeout", onNodeHTTPServerSocketTimeout);
   socket.on("end", onReadableStreamEnd);
+}
+// 'close' listener for a handed-off CONNECT/Upgrade socket: settles the promise
+// that keeps the native request callback open.
+function resolveHandoffPromise(promise) {
+  $resolvePromise(promise, undefined);
 }
 const kSocketTimeoutTimer = Symbol("socketTimeoutTimer");
 const kStreamingEnabled = Symbol("kStreamingEnabled");

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -740,7 +740,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             // The parser is detached: the socket is handed over with only
             // net.Socket's 'end' listener left, like Node.js.
             detachSocketListenersForHandoff(socket);
-            const { promise, resolve } = $newPromiseCapability(Promise);
+            const promise = $newPromise();
             // Pass the pipelined data (head buffer) if any was received with the CONNECT request
             const head = connectHead ? connectHead : kEmptyBuffer;
             // Node.js's parserOnIncoming: req.upgrade is true for CONNECT
@@ -752,7 +752,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             // Attach the internal close listener after the user's "connect"
             // handler ran: Node.js hands the socket over with no listeners and
             // tests assert socket.listenerCount("close") === 0 there.
-            socket.once("close", resolve);
+            socket.once("close", () => $resolvePromise(promise, undefined));
             return promise;
           } else {
             // Node.js will close the socket and will NOT respond with 400 Bad Request
@@ -831,7 +831,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         }
         drainMicrotasks();
 
-        let resolveFunction;
+        let pendingPromise: Promise<void> | undefined;
         let didFinish = false;
 
         const isRequestsLimitSet = typeof server.maxRequestsPerSocket === "number" && server.maxRequestsPerSocket > 0;
@@ -921,7 +921,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         }
         function onClose() {
           didFinish = true;
-          if (resolveFunction) resolveFunction();
+          if (pendingPromise) $resolvePromiseWithFirstResolvingFunctionCallCheck(pendingPromise, undefined);
         }
 
         if (!isPipelined) {
@@ -991,8 +991,8 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           // Like CONNECT: the connection is detached from the HTTP request
           // machinery; hold the native callback open until the raw socket
           // closes.
-          const { promise: upgradePromise, resolve: resolveUpgrade } = $newPromiseCapability(Promise);
-          socket.once("close", resolveUpgrade);
+          const upgradePromise = $newPromise();
+          socket.once("close", () => $resolvePromise(upgradePromise, undefined));
           return upgradePromise;
         } else if (
           server.requireHostHeader &&
@@ -1051,10 +1051,9 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           return;
         }
 
-        const { resolve, promise } = $newPromiseCapability(Promise);
-        resolveFunction = resolve;
+        pendingPromise = $newPromise();
 
-        return promise;
+        return pendingPromise;
       },
     });
 

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -1160,12 +1160,12 @@ Socket.prototype[SymbolAsyncDispose] = async function () {
   if (!this[kStateSymbol].handle) {
     return;
   }
-  const { promise, resolve, reject } = $newPromiseCapability(Promise);
+  const promise = $newPromise();
   this.close(err => {
     if (err) {
-      reject(err);
+      $rejectPromiseWithFirstResolvingFunctionCallCheck(promise, err);
     } else {
-      resolve();
+      $resolvePromiseWithFirstResolvingFunctionCallCheck(promise, undefined);
     }
   });
 

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -1161,7 +1161,7 @@ Socket.prototype[SymbolAsyncDispose] = async function () {
     return;
   }
   const promise = $newPromise();
-  this.close(onAsyncDisposeClosed.bind(undefined, promise));
+  this.close(FunctionPrototypeBind.$call(onAsyncDisposeClosed, undefined, promise));
 
   return promise;
 };

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -1161,16 +1161,18 @@ Socket.prototype[SymbolAsyncDispose] = async function () {
     return;
   }
   const promise = $newPromise();
-  this.close(err => {
-    if (err) {
-      $rejectPromiseWithFirstResolvingFunctionCallCheck(promise, err);
-    } else {
-      $resolvePromiseWithFirstResolvingFunctionCallCheck(promise, undefined);
-    }
-  });
+  this.close(onAsyncDisposeClosed.bind(undefined, promise));
 
   return promise;
 };
+
+function onAsyncDisposeClosed(promise, err) {
+  if (err) {
+    $rejectPromiseWithFirstResolvingFunctionCallCheck(promise, err);
+  } else {
+    $resolvePromiseWithFirstResolvingFunctionCallCheck(promise, undefined);
+  }
+}
 
 function socketCloseNT(self) {
   self.emit("close");

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -564,13 +564,13 @@ async function once(emitter, type, options = kEmptyObject) {
   if (signal?.aborted) {
     throw $makeAbortError(undefined, { cause: signal?.reason });
   }
-  const { resolve, reject, promise } = $newPromiseCapability(Promise);
+  const promise = $newPromise();
   const errorListener = err => {
     emitter.removeListener(type, resolver);
     if (signal != null) {
       eventTargetAgnosticRemoveListener(signal, "abort", abortListener);
     }
-    reject(err);
+    $rejectPromiseWithFirstResolvingFunctionCallCheck(promise, err);
   };
   const resolver = (...args) => {
     if (typeof emitter.removeListener === "function") {
@@ -579,7 +579,7 @@ async function once(emitter, type, options = kEmptyObject) {
     if (signal != null) {
       eventTargetAgnosticRemoveListener(signal, "abort", abortListener);
     }
-    resolve(args);
+    $resolvePromiseWithFirstResolvingFunctionCallCheck(promise, args);
   };
   const opts = resistStopPropagation({ __proto__: null, once: true });
   eventTargetAgnosticAddListener(emitter, type, resolver, opts);
@@ -591,7 +591,7 @@ async function once(emitter, type, options = kEmptyObject) {
   function abortListener() {
     eventTargetAgnosticRemoveListener(emitter, type, resolver);
     eventTargetAgnosticRemoveListener(emitter, "error", errorListener);
-    reject($makeAbortError(undefined, { cause: signal?.reason }));
+    $rejectPromiseWithFirstResolvingFunctionCallCheck(promise, $makeAbortError(undefined, { cause: signal?.reason }));
   }
   if (signal != null) {
     eventTargetAgnosticAddListener(signal, "abort", abortListener, opts);

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -620,8 +620,10 @@ function convertProcessSignalToExitCode(signalCode) {
 
 let lazyAbortedRegistry: FinalizationRegistry<{
   ref: WeakRef<AbortSignal>;
-  unregisterToken: (...args: any[]) => void;
+  listener: (...args: any[]) => void;
 }>;
+// The promise is also the FinalizationRegistry unregister token: once the
+// signal aborts, the resource no longer needs its listener removed on GC.
 function onAbortedCallback(promise: Promise<void>) {
   lazyAbortedRegistry.unregister(promise);
 
@@ -642,19 +644,19 @@ function aborted(signal: AbortSignal, resource: object) {
   }
 
   const promise = $newPromise();
-  const unregisterToken = onAbortedCallback.bind(undefined, promise);
+  const listener = onAbortedCallback.bind(undefined, promise);
   signal.addEventListener(
     "abort",
     // Do not leak the current scope into the listener.
     // Instead, create a new function.
-    unregisterToken,
+    listener,
     resistStopPropagation({ __proto__: null, once: true }),
   );
 
   if (!lazyAbortedRegistry) {
-    lazyAbortedRegistry = new FinalizationRegistry(({ ref, unregisterToken }) => {
+    lazyAbortedRegistry = new FinalizationRegistry(({ ref, listener }) => {
       const signal = ref.deref();
-      if (signal) signal.removeEventListener("abort", unregisterToken);
+      if (signal) signal.removeEventListener("abort", listener);
     });
   }
 
@@ -665,9 +667,9 @@ function aborted(signal: AbortSignal, resource: object) {
     resource,
     {
       ref: new WeakRef(signal),
-      unregisterToken,
+      listener,
     },
-    unregisterToken,
+    promise,
   );
 
   return promise;

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -622,10 +622,10 @@ let lazyAbortedRegistry: FinalizationRegistry<{
   ref: WeakRef<AbortSignal>;
   unregisterToken: (...args: any[]) => void;
 }>;
-function onAbortedCallback(resolveFn: Function) {
-  lazyAbortedRegistry.unregister(resolveFn);
+function onAbortedCallback(promise: Promise<void>) {
+  lazyAbortedRegistry.unregister(promise);
 
-  resolveFn();
+  $resolvePromiseWithFirstResolvingFunctionCallCheck(promise, undefined);
 }
 
 function aborted(signal: AbortSignal, resource: object) {
@@ -641,8 +641,8 @@ function aborted(signal: AbortSignal, resource: object) {
     return Promise.$resolve();
   }
 
-  const { promise, resolve } = $newPromiseCapability(Promise);
-  const unregisterToken = onAbortedCallback.bind(undefined, resolve);
+  const promise = $newPromise();
+  const unregisterToken = onAbortedCallback.bind(undefined, promise);
   signal.addEventListener(
     "abort",
     // Do not leak the current scope into the listener.

--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -622,8 +622,6 @@ let lazyAbortedRegistry: FinalizationRegistry<{
   ref: WeakRef<AbortSignal>;
   listener: (...args: any[]) => void;
 }>;
-// The promise is also the FinalizationRegistry unregister token: once the
-// signal aborts, the resource no longer needs its listener removed on GC.
 function onAbortedCallback(promise: Promise<void>) {
   lazyAbortedRegistry.unregister(promise);
 

--- a/src/jsc/bindings/EncodeURIComponent.cpp
+++ b/src/jsc/bindings/EncodeURIComponent.cpp
@@ -1,5 +1,7 @@
 #include "EncodeURIComponent.h"
 
+#include <wtf/HexNumber.h>
+
 // from JSGlobalObjectFunctions.cpp
 
 namespace JSC {

--- a/test/js/bun/jsc/webkit-upgrade-8c4fd56347.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-8c4fd56347.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Coverage for the WebKit 8c4fd56347 sync (oven-sh/WebKit#503). Each case pins
+// an observable behavior difference between the previous JSC and the new one.
+
+describe.concurrent("WebKit 8c4fd56347 upgrade", () => {
+  test("Promise.try returns a native promise as-is (7f38ebbabf)", () => {
+    // PromiseResolve(C, value) instead of NewPromiseCapability(C): a native
+    // promise returned by the callback is the result, not wrapped.
+    const p = Promise.resolve(1);
+    expect(Promise.try(() => p)).toBe(p);
+  });
+
+  test("Uint8Array.prototype.setFromBase64 on a zero-length target reads nothing (b1701b3489)", () => {
+    // FromBase64 returns before it looks at any character when maxLength is 0,
+    // so input that is not base64 at all is accepted.
+    expect(new Uint8Array(0).setFromBase64("#")).toEqual({ read: 0, written: 0 });
+    expect(new Uint8Array(new ArrayBuffer(8), 4, 0).setFromBase64("====")).toEqual({ read: 0, written: 0 });
+    expect(() => Uint8Array.fromBase64("#")).toThrow(SyntaxError);
+  });
+
+  test("WebAssembly.Module.imports() descriptors have the spec shape (010e57fb4b)", () => {
+    // The js-types proposal's `type` field is only present with useWasmJSTypes.
+    // (module (import "env" "f" (func)))
+    const bytes = new Uint8Array([
+      0x00,
+      0x61,
+      0x73,
+      0x6d,
+      0x01,
+      0x00,
+      0x00,
+      0x00, // magic, version
+      0x01,
+      0x04,
+      0x01,
+      0x60,
+      0x00,
+      0x00, // type section: () -> ()
+      0x02,
+      0x09,
+      0x01,
+      0x03,
+      0x65,
+      0x6e,
+      0x76,
+      0x01,
+      0x66,
+      0x00,
+      0x00, // import section: env.f func 0
+    ]);
+    expect(WebAssembly.Module.imports(new WebAssembly.Module(bytes))).toEqual([
+      { module: "env", name: "f", kind: "function" },
+    ]);
+  });
+
+  test("the DFG keeps the overflow check of an otherwise unused ++ / -- (7711916200)", async () => {
+    // DFGFixupPhase cleared NodeMustGenerate on the CheckOverflow ArithAdd /
+    // ArithSub it lowered Inc / Dec to, so the check could be dead-code
+    // eliminated and the Int32 result silently wrapped.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        function inc(k) { let y = k; ++y; return (y | 0) === y; }
+        function dec(k) { let y = k; --y; return (y | 0) === y; }
+        for (let i = 0; i < 20000; ++i) { inc(1); dec(1); }
+        console.log(JSON.stringify([inc(2147483647), dec(-2147483648)]));
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        BUN_JSC_useConcurrentJIT: "0",
+        BUN_JSC_thresholdForJITAfterWarmUp: "10",
+        BUN_JSC_thresholdForOptimizeAfterWarmUp: "100",
+        BUN_JSC_thresholdForFTLOptimizeAfterWarmUp: "1000",
+      },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("[false,false]\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -66,7 +66,7 @@ test("node:dgram Symbol.asyncDispose closes the socket and resolves after 'close
   expect(events).toEqual(["close", "disposed"]);
   // The handle is gone, so disposing again resolves without touching the socket.
   await expect(socket[Symbol.asyncDispose]()).resolves.toBeUndefined();
-  expect(() => socket.address()).toThrow();
+  expect(() => socket.address()).toThrow(expect.objectContaining({ code: "ERR_SOCKET_DGRAM_NOT_RUNNING" }));
 });
 
 describe.skipIf(!isIPv6())("node:dgram", () => {

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -56,6 +56,19 @@ test("node:dgram close() inside 'message' handler stops remaining batch datagram
   expect(exitCode).toBe(0);
 });
 
+test("node:dgram Symbol.asyncDispose closes the socket and resolves after 'close'", async () => {
+  const socket = dgram.createSocket("udp4");
+  await new Promise(resolve => socket.bind(0, "127.0.0.1", resolve));
+  const events = [];
+  socket.on("close", () => events.push("close"));
+  await socket[Symbol.asyncDispose]();
+  events.push("disposed");
+  expect(events).toEqual(["close", "disposed"]);
+  // The handle is gone, so disposing again resolves without touching the socket.
+  await expect(socket[Symbol.asyncDispose]()).resolves.toBeUndefined();
+  expect(() => socket.address()).toThrow();
+});
+
 describe.skipIf(!isIPv6())("node:dgram", () => {
   it("adds membership successfully (IPv6)", () => {
     const socket = makeSocket6();

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -102,6 +102,35 @@ describe("node:events", () => {
     expect(p).toBeInstanceOf(Promise);
     await expect(p).rejects.toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
   });
+
+  test("once rejects with the value emitted on 'error' and removes both listeners", async () => {
+    const emitter = new EventEmitter();
+    const p = EventEmitter.once(emitter, "hey");
+    const err = new Error("boom");
+    emitter.emit("error", err);
+    await expect(p).rejects.toBe(err);
+    expect([emitter.listenerCount("hey"), emitter.listenerCount("error")]).toEqual([0, 0]);
+  });
+
+  test("once settles once when the event fires and the signal aborts afterwards", async () => {
+    const emitter = new EventEmitter();
+    const controller = new AbortController();
+    const p = EventEmitter.once(emitter, "hey", { signal: controller.signal });
+    emitter.emit("hey", 42);
+    controller.abort();
+    expect(await p).toEqual([42]);
+    expect([emitter.listenerCount("hey"), emitter.listenerCount("error")]).toEqual([0, 0]);
+  });
+
+  test("once resolves with the Event dispatched on an EventTarget and ignores later events", async () => {
+    const target = new EventTarget();
+    const p = EventEmitter.once(target, "ping");
+    const event = new Event("ping");
+    target.dispatchEvent(event);
+    target.dispatchEvent(new Event("ping"));
+    const [received] = await p;
+    expect(received).toBe(event);
+  });
 });
 
 describe("EventEmitter", () => {

--- a/test/js/node/util/test-aborted.test.ts
+++ b/test/js/node/util/test-aborted.test.ts
@@ -93,3 +93,16 @@ test("fails if not provided a resource", async () => {
     await expect(() => aborted(ac.signal, resource)).toThrow();
   }
 });
+
+test("aborted resolves every waiter on the same signal with undefined", async () => {
+  const ac = new AbortController();
+  const first = aborted(ac.signal, {});
+  const second = aborted(ac.signal, {});
+  expect([first, second]).toEqual([expect.any(Promise), expect.any(Promise)]);
+  expect(getEventListeners(ac.signal, "abort")).toHaveLength(2);
+  ac.abort();
+  // A second abort() is a no-op; the already-settled promises must not be touched.
+  ac.abort();
+  expect(await Promise.all([first, second])).toEqual([undefined, undefined]);
+  expect(getEventListeners(ac.signal, "abort")).toHaveLength(0);
+});


### PR DESCRIPTION
### Problem
- Bun's WebKit pin `aea1f010b6` is 412 upstream commits behind `8c4fd56347`, 90 of them in JavaScriptCore, WTF or bmalloc. oven-sh/WebKit#503 merges that range into the fork.
- Upstream removed the `@newPromiseCapability` private builtin (`38027ff0ec`). Six call sites in Bun's bundled modules use it, so `node:events`, `node:util`, `node:dgram` and the HTTP server fail to load (`Private symbol not found: newPromiseCapability`).
- #40263 and oven-sh/WebKit#501 were a parallel attempt at `55d9d9007f`, one WebCore-only commit ahead. Both are closed in favor of this pair.

### Fix
- oven-sh/WebKit#503 is merged. `WEBKIT_VERSION` is `cb61607f1a4bae79d7701965062634dee9efb349`, its merge commit on the fork's main (release `autobuild-cb61607f1a4bae79d7701965062634dee9efb349`, 42 tarballs). That commit is the preview build this PR was tested against (`d2654c3b`) plus oven-sh/WebKit `a0a80b2276` (an optional depth bound on `recursivelyGenerateUnlinkedCodeBlockForProgram/ForModuleProgram`).
- The six call sites create their promise with `$newPromise()` and settle it with `$resolvePromise` / `$rejectPromise`, or the `...WithFirstResolvingFunctionCallCheck` variants where a second settle is possible. `builtins.d.ts` follows.
- `EncodeURIComponent.cpp` includes `<wtf/HexNumber.h>` itself (upstream `314133b7a6` no longer does).
- Verified: `test/js/bun/jsc/webkit-upgrade-8c4fd56347.test.ts` pins four JavaScript-visible engine changes that fail at the current pin. The events, util and dgram tests cover the ported settlement paths.

### Background
- Bun links a prebuilt JavaScriptCore from oven-sh/WebKit releases. `scripts/build/deps/webkit.ts` names the release tag.
- Built-in modules (`src/js/`) go through JavaScriptCore's builtin compiler. A `$name` call becomes the private name `@name`, which has to exist in the engine.
- `$newPromise` creates a pending promise. `$resolvePromise` / `$rejectPromise` settle it and require it to be pending. The `...WithFirstResolvingFunctionCallCheck` variants ignore calls after the first, like a Promise executor's functions.

<details><summary>Notes</summary>

- Duplicate resolution: oven-sh/WebKit#501 and #503 have the same structure (main at `62f427b86f`, then #488's head `d0fae3b3c9`, then upstream/main) and the same `CachedTypes.cpp` resolution (the two files differ in comments and an unused alias). WTF and bmalloc are identical. The only upstream difference is WebCore's `55d9d9007f` (`MediaElementAudioSourceNode` use-after-free), which the JSCOnly port does not compile. #503 was kept because this PR's CI run was green (Build #104490). The test file `webkit-upgrade-8c4fd56347.test.ts` is carried over from #40263.
- oven-sh/WebKit#488 (upstream `baf4a9a7ec0b`) stopped merging after the fork's bytecode cache rework (#490, #493, #494, #497). The per-commit review of the upstream range (API and ABI changes, behavior changes, performance) and the conflict resolutions are in oven-sh/WebKit#503. The new conflict in this round is `CachedTypes.cpp`: the fork's new code block record layout against upstream moving the global-only fields (`features`, `lineCount`, source URL directives) to `UnlinkedGlobalCodeBlock` and deleting `m_jumpTargets`.
- The ported call sites (the changes of #40054, carried over): `node:events` (`once`), `node:util` (`aborted`), `node:dgram` (`Symbol.asyncDispose`) and the HTTP server (CONNECT, Upgrade, the per-request completion promise). `builtins.d.ts` declares `$newPromise`, `$resolvePromiseWithFirstResolvingFunctionCallCheck` and `$rejectPromiseWithFirstResolvingFunctionCallCheck` and drops `$newPromiseCapability`. `@newPromise` is a bytecode intrinsic and `@resolvePromise` / `@rejectPromise` are link-time constants, so they exist in every engine build. `util.aborted` registers and unregisters its `FinalizationRegistry` entry with the same token (the promise).
- Behavior changes in the upstream range that are visible from JavaScript: `Promise.try` follows the updated spec (`PromiseResolve` instead of `NewPromiseCapability`); the module map no longer caches fetch failures, so a second `import()` of a specifier whose load failed re-runs Bun's module loader instead of rejecting with the cached error; `Uint8Array.prototype.setFromBase64` on a zero-length target returns `{ read: 0, written: 0 }` without validating the input; `WebAssembly.Module.imports()/exports()` descriptors drop the non-standard `type` field; re-exported imported Wasm globals and tags keep object identity; a DFG `++`/`--` on an `int32` that overflows with an unused result now deoptimizes instead of wrapping (`7711916200`). The first, third, fourth and last of these are pinned by `test/js/bun/jsc/webkit-upgrade-8c4fd56347.test.ts`.
- Performance changes of note: `SymbolTableEntry` no longer allocates a `WatchpointSet` per watched variable until the DFG watches it (`cea233cede`); `Object.assign` with several sources clones the first one through `objectCloneFast` (`96ca975b2a`); `JSON.parse` allocates arrays once at their final size; `TypedArray.prototype.sort()` without a comparator uses a radix sort for 2/4/8-byte element types; `Map`/`Set` `forEach` is inlined in the DFG and FTL; `RegExp` cells shrink from 96 to 80 bytes; `UnlinkedFunctionCodeBlock` shrinks from 216 to 192 bytes.
- `src/jsc/bindings/NodeVMSyntheticModule.cpp` calls `SymbolTable::set(NoLockingNecessary, ...)`. After `cea233cede` only the locked overload exists. `NoLockingNecessary` converts to a `ConcurrentJSLocker`, so the call compiles unchanged.
- The upstream change to Linux thread scheduling (per-QOS `sched_setattr` on every WTF thread, `SCHED_BATCH` compiler threads on hosts with 4 or fewer cores) is gated off for Bun in the fork: Bun's threads keep inheriting the process scheduling attributes.
- Suites run on a local debug + ASAN build against the merged WebKit (`bun run build:local`): `test/js/bun/jsc`, `bun/jsc-stress` (116/116), `node/events`, `node/util`, `node/dgram`, `node/vm`, `node/module`, `bun/resolve`, `node/worker_threads`, `bun/wasm`, `web/url`, `web/atomics`, `node/http/node-http-connect`, `node/async_hooks`, `node/string_decoder`, `bundler/bundler_compile`, `bundler/bun-build-api`: 3,548 pass. The failures are 5 s timeouts under debug + ASAN, this machine's IPv6 multicast `ENODEV`, and one test that fails the same way at the current pin. `bun build --bytecode` output from that build loads and runs. A debug + ASAN build against the `autobuild-preview-pr-503-311eab61` prebuilt runs `test/js/bun/jsc/webkit-upgrade-8c4fd56347.test.ts`, `test/js/bun/jsc/webkit-upgrade-3722912f.test.ts`, `node/events/event-emitter.test.ts` and `node/util/test-aborted.test.ts`: 106 pass.
- Every push to oven-sh/WebKit#503 produces a new preview tag (`autobuild-preview-pr-503-<first 8 of the head sha>`), and this PR's `WEBKIT_VERSION` follows it. CI lanes that fetch the prebuilt fail on the download until that tag's Actions run has published the release.
- Rebase over #40201: Bun main moved its pin to the fork's `c148a12dd82b` and calls the bytecode APIs that release added (`EncoderStringTable`, persistent payloads). The `311eab61` preview predates them, so the branch could not rebase until oven-sh/WebKit#503 merged the fork's main (head `d2654c3b`, 0 commits behind). The rebase itself conflicted only on the `WEBKIT_VERSION` line. A debug + ASAN build against `autobuild-preview-pr-503-d2654c3b` passes `webkit-upgrade-8c4fd56347.test.ts`, `node/events/event-emitter.test.ts`, `node/util/test-aborted.test.ts`, `node/dgram` (except the IPv6 multicast `ENODEV` of this machine), `node/http/node-http-connect.test.ts`, `web/atomics`, `web/url`, `node/string_decoder` and `test/js/bun/jsc`. The compiled-executable bytecode paths of #40201 work against it: the aliasing run keeps 12 MB of instruction streams out of anonymous memory and 45 internal modules load from embedded bytecode. The failures on this machine are the DOMJIT hot loops and two `bun-build-compile` tests that exceed their timeouts under debug + ASAN (the compile alone takes 5 to 47 s here), and the nested `node-http-connect.node.mts` run that takes 5.0 s against a 5 s limit.
- The `$newPromiseCapability` call in `src/node-fallbacks/events.js` (the browser polyfill, not a JSC builtin) is a pre-existing bug and was reported separately by #40054.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/dgram/node-dgram.test.js

<!-- robobun:evidence:end -->


