### PR TITLE
Fix $ORIGIN RPATH lookups for native addons under auto-install

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -58,6 +58,8 @@ pub mod add_remove_with_filter;
 pub mod command_line_arguments;
 #[path = "PackageManager/install_with_manager.rs"]
 pub mod install_with_manager;
+#[path = "PackageManager/native_addon_links.rs"]
+pub mod native_addon_links;
 #[path = "PackageManager/PackageJSONEditor.rs"]
 pub mod package_json_editor;
 #[path = "PackageManager/package_json_write_back.rs"]

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -929,7 +929,20 @@ pub fn path_for_resolution<'a>(
             // borrow can't be held across it. Copy the name out first.
             let package_name = this.lockfile.str(&package_name_).to_vec();
 
-            path_for_cached_npm_path(this, buf, &package_name, npm.version)
+            let flat_len = path_for_cached_npm_path(this, buf, &package_name, npm.version)?.len();
+
+            #[cfg(not(windows))]
+            if let Some(store_len) = super::native_addon_links::maybe_store_path(
+                this,
+                package_id,
+                &package_name,
+                npm.version,
+                buf,
+            ) {
+                return Ok(&mut buf.0[..store_len]);
+            }
+
+            Ok(&mut buf.0[..flat_len])
         }
         _ => Ok(&mut buf.0[..0]),
     }

--- a/src/install/PackageManager/native_addon_links.rs
+++ b/src/install/PackageManager/native_addon_links.rs
@@ -134,6 +134,7 @@ fn flat_dir_has_native_addon(cache_dir: Fd, folder_name: &[u8]) -> Option<bool> 
             return None;
         }
     };
+    walker.resolve_unknown_entry_types = true;
     let found = loop {
         match walker.next() {
             Ok(Some(entry)) => {
@@ -218,6 +219,7 @@ fn hardlink_tree(cache_dir: Fd, folder_name: &[u8], dest_dir: &Dir) -> bool {
             return false;
         }
     };
+    walker.resolve_unknown_entry_types = true;
     let ok = loop {
         match walker.next() {
             Ok(Some(entry)) => match entry.kind {

--- a/src/install/PackageManager/native_addon_links.rs
+++ b/src/install/PackageManager/native_addon_links.rs
@@ -420,8 +420,19 @@ fn ensure_dependency_links(
         match sys::readlinkat(cache_dir, link_z, &mut read_buf.0[..]) {
             Ok(n) if &read_buf.0[..n] == target_z.as_bytes() => {}
             Ok(_) => {
-                let _ = sys::unlinkat(cache_dir, link_z);
-                let _ = sys::symlinkat(target_z, cache_dir, link_z);
+                // Replace atomically: a concurrent dlopen must never observe
+                // the link as missing.
+                let mut tmp_link_buf = PathBuffer::uninit();
+                let hex = bun_fmt::u64_hex_fixed::<true, 16>(bun_core::fast_random());
+                let tmp_link_z = concat_z(
+                    &mut tmp_link_buf,
+                    &[STORE_DIR, b"/", folder_name, b"/node_modules/.tmp-", &hex],
+                );
+                if sys::symlinkat(target_z, cache_dir, tmp_link_z).is_ok()
+                    && sys::renameat(cache_dir, tmp_link_z, cache_dir, link_z).is_err()
+                {
+                    let _ = sys::unlinkat(cache_dir, tmp_link_z);
+                }
             }
             Err(err) if err.get_errno() == sys::E::ENOENT => {
                 if let Some(parent) = path::dirname(link_z.as_bytes()) {

--- a/src/install/PackageManager/native_addon_links.rs
+++ b/src/install/PackageManager/native_addon_links.rs
@@ -24,13 +24,13 @@
 
 #![cfg(not(windows))]
 
-use bun_core::{ZStr, fmt as bun_fmt, strings};
-use bun_semver::SlicedString;
-use bun_install::PackageID;
 use crate::lockfile_real::package::PackageColumns as _;
+use bun_core::{ZStr, fmt as bun_fmt, strings};
+use bun_install::PackageID;
 use bun_install::resolution::Tag as ResolutionTag;
 use bun_paths::{self as path, PathBuffer};
 use bun_semver as Semver;
+use bun_semver::SlicedString;
 use bun_sys::{self as sys, Dir, Fd, FdExt};
 
 use super::PackageManager;
@@ -79,7 +79,10 @@ pub(super) fn maybe_store_path(
 
     if sys::lstatat(cache_dir, entry_z).is_err() {
         let mut marker_buf = PathBuffer::uninit();
-        let marker_z = concat_z(&mut marker_buf, &[STORE_DIR, b"/", folder_name, SKIP_SUFFIX]);
+        let marker_z = concat_z(
+            &mut marker_buf,
+            &[STORE_DIR, b"/", folder_name, SKIP_SUFFIX],
+        );
         if sys::lstatat(cache_dir, marker_z).is_ok() {
             return None;
         }
@@ -251,10 +254,7 @@ enum LinkTarget {
     /// Edge not resolved in this process's lockfile (nothing `require`d the
     /// dependency). Pick the best cached version satisfying the range, the
     /// way offline resolution does.
-    FromDiskCache {
-        npm_name: Vec<u8>,
-        dep_index: u32,
-    },
+    FromDiskCache { npm_name: Vec<u8>, dep_index: u32 },
 }
 
 /// Create or refresh `node_modules/<dep>` symlinks in the store entry, one
@@ -339,12 +339,7 @@ fn ensure_dependency_links(
                 continue;
             };
 
-            bun_core::scoped_log!(
-                addon_links,
-                "dep {} alias {}",
-                dep_index,
-                bun_fmt::s(alias)
-            );
+            bun_core::scoped_log!(addon_links, "dep {} alias {}", dep_index, bun_fmt::s(alias));
             links.push(DepLink {
                 alias: alias.to_vec(),
                 target,

--- a/src/install/PackageManager/native_addon_links.rs
+++ b/src/install/PackageManager/native_addon_links.rs
@@ -232,6 +232,21 @@ fn hardlink_tree(cache_dir: Fd, folder_name: &[u8], dest_dir: &Dir) -> bool {
                         break false;
                     }
                 }
+                // Recreate symlinks verbatim. Dropping one would rename an
+                // incomplete view into place, and the view is never rebuilt.
+                sys::EntryKind::SymLink => {
+                    let mut link_target_buf = PathBuffer::uninit();
+                    let Ok(n) =
+                        sys::readlinkat(entry.dir, entry.basename, &mut link_target_buf.0[..])
+                    else {
+                        break false;
+                    };
+                    link_target_buf.0[n] = 0;
+                    let link_target_z = ZStr::from_buf(&link_target_buf.0, n);
+                    if sys::symlinkat(link_target_z, dest_dir.fd(), entry.path).is_err() {
+                        break false;
+                    }
+                }
                 _ => {}
             },
             Ok(None) => break true,

--- a/src/install/PackageManager/native_addon_links.rs
+++ b/src/install/PackageManager/native_addon_links.rs
@@ -471,7 +471,12 @@ fn cached_dep_path_from_disk(
         let index_dir = Dir::borrow(&cache_dir).open_at(npm_name).ok()?;
         let mut iter = sys::iterate_dir(index_dir.fd);
         while let Ok(Some(entry)) = iter.next() {
-            if entry.kind != sys::EntryKind::Directory && entry.kind != sys::EntryKind::SymLink {
+            // Accept Unknown: filesystems without d_type report every entry
+            // as Unknown, and the semver parse below rejects non-index names.
+            if !matches!(
+                entry.kind,
+                sys::EntryKind::Directory | sys::EntryKind::SymLink | sys::EntryKind::Unknown
+            ) {
                 continue;
             }
             let entry_name: Vec<u8> = entry.name.slice_u8().to_vec();

--- a/src/install/PackageManager/native_addon_links.rs
+++ b/src/install/PackageManager/native_addon_links.rs
@@ -1,0 +1,521 @@
+//! node_modules-shaped views of cached packages that ship native addons.
+//!
+//! Auto-install resolves modules straight out of the global cache, where each
+//! package lives in a flat dir (`<cache>/name@version@@@N`). Prebuilt native
+//! addons locate sibling shared libraries with `$ORIGIN`-relative RPATH
+//! entries that assume a node_modules layout (for example
+//! `$ORIGIN/../../sharp-libvips-linux-x64/lib`), so `dlopen` misses even
+//! though the library is one cache entry away. Symlinking the package dir
+//! does not help: the kernel resolves the `..` components of an RPATH
+//! candidate through the real parent directory, so only a layout whose real
+//! directories are node_modules-shaped can satisfy those entries.
+//!
+//! For a cached npm package that contains a `.node` file, this module builds
+//! `<cache>/.addon-links/<flat>/node_modules/<name>` with every file
+//! hardlinked from the flat dir, and symlinks each resolved dependency next
+//! to it (the same sibling shape the isolated-install store uses). The
+//! resolver then returns that view, so `$ORIGIN/../..` lands in the
+//! `node_modules` dir and the sibling symlink leads into the dependency's
+//! cache dir. Packages without a `.node` file get an empty marker file
+//! (`<flat>.skip`) so the directory scan runs only once per cache entry.
+//!
+//! Everything here is best-effort: on any failure the caller falls back to
+//! the flat dir, which is the previous behavior.
+
+#![cfg(not(windows))]
+
+use bun_core::{ZStr, fmt as bun_fmt, strings};
+use bun_semver::SlicedString;
+use bun_install::PackageID;
+use crate::lockfile_real::package::PackageColumns as _;
+use bun_install::resolution::Tag as ResolutionTag;
+use bun_paths::{self as path, PathBuffer};
+use bun_semver as Semver;
+use bun_sys::{self as sys, Dir, Fd, FdExt};
+
+use super::PackageManager;
+use super::package_manager_directories as directories;
+
+const STORE_DIR: &[u8] = b".addon-links";
+const SKIP_SUFFIX: &[u8] = b".skip";
+
+bun_core::declare_scope!(addon_links, hidden);
+
+/// If `package_name@version` is cached and contains a native addon, make sure
+/// the node_modules-shaped view exists, refresh its dependency symlinks from
+/// `package_id`'s resolutions, write the view's absolute package path into
+/// `buf`, and return its length. Returns `None` when the package has no
+/// native addon or the view cannot be built.
+pub(super) fn maybe_store_path(
+    this: &mut PackageManager,
+    package_id: PackageID,
+    package_name: &[u8],
+    version: Semver::Version,
+    buf: &mut PathBuffer,
+) -> Option<usize> {
+    if !crate::dependency::is_safe_install_folder_name(package_name) {
+        return None;
+    }
+
+    let cache_dir = directories::get_cache_directory(this);
+    if this.cache_directory_path.is_empty() {
+        return None;
+    }
+
+    let mut folder_name_buf = PathBuffer::uninit();
+    let folder_name_len = directories::cached_npm_package_folder_name_print(
+        this,
+        &mut folder_name_buf.0[..],
+        package_name,
+        version,
+        None,
+    )
+    .as_bytes()
+    .len();
+    let folder_name = &folder_name_buf.0[..folder_name_len];
+
+    let mut entry_buf = PathBuffer::uninit();
+    let entry_z = concat_z(&mut entry_buf, &[STORE_DIR, b"/", folder_name]);
+
+    if sys::lstatat(cache_dir, entry_z).is_err() {
+        let mut marker_buf = PathBuffer::uninit();
+        let marker_z = concat_z(&mut marker_buf, &[STORE_DIR, b"/", folder_name, SKIP_SUFFIX]);
+        if sys::lstatat(cache_dir, marker_z).is_ok() {
+            return None;
+        }
+
+        match flat_dir_has_native_addon(cache_dir, folder_name) {
+            Some(true) => {
+                if !build_store(cache_dir, folder_name, package_name, entry_z) {
+                    return None;
+                }
+            }
+            Some(false) => {
+                write_skip_marker(cache_dir, marker_z);
+                return None;
+            }
+            None => return None,
+        }
+    }
+
+    ensure_dependency_links(this, package_id, cache_dir, folder_name);
+
+    let len = path::resolve_path::join_abs_string_buf_z::<path::platform::Auto>(
+        this.cache_directory_path.as_bytes(),
+        &mut buf.0[..],
+        &[STORE_DIR, folder_name, b"node_modules", package_name],
+    )
+    .as_bytes()
+    .len();
+    Some(len)
+}
+
+fn concat_z<'a>(buf: &'a mut PathBuffer, parts: &[&[u8]]) -> &'a ZStr {
+    let mut at = 0;
+    for part in parts {
+        buf.0[at..at + part.len()].copy_from_slice(part);
+        at += part.len();
+    }
+    buf.0[at] = 0;
+    ZStr::from_buf(&buf.0, at)
+}
+
+/// `Some(true)` if any regular file under the flat dir ends in `.node`,
+/// `Some(false)` if none does, `None` if the scan failed.
+fn flat_dir_has_native_addon(cache_dir: Fd, folder_name: &[u8]) -> Option<bool> {
+    let fd = sys::open_dir_for_iteration(cache_dir, folder_name).ok()?;
+    let mut walker = match sys::walker_skippable::walk(fd, &[], &[]) {
+        Ok(w) => w,
+        Err(_) => {
+            fd.close();
+            return None;
+        }
+    };
+    let found = loop {
+        match walker.next() {
+            Ok(Some(entry)) => {
+                if entry.kind == sys::EntryKind::File
+                    && entry.basename.as_bytes().ends_with(b".node")
+                {
+                    break Some(true);
+                }
+            }
+            Ok(None) => break Some(false),
+            Err(_) => break None,
+        }
+    };
+    drop(walker);
+    fd.close();
+    found
+}
+
+fn write_skip_marker(cache_dir: Fd, marker_z: &ZStr) {
+    if let Some(parent) = path::dirname(marker_z.as_bytes()) {
+        let _ = bun_sys::make_path::make_path::<u8>(Dir::borrow(&cache_dir), parent);
+    }
+    let _ = sys::File::openat(cache_dir, marker_z, sys::O::WRONLY | sys::O::CREAT, 0o644);
+}
+
+/// Hardlink the flat dir's files into
+/// `.addon-links/<flat>/node_modules/<name>`, built in a temp dir and renamed
+/// into place so concurrent processes race safely. Returns `true` when the
+/// store entry exists afterwards (built here or by the rename-race winner).
+fn build_store(cache_dir: Fd, folder_name: &[u8], package_name: &[u8], entry_z: &ZStr) -> bool {
+    let mut tmp_buf = PathBuffer::uninit();
+    let hex = bun_fmt::u64_hex_fixed::<true, 16>(bun_core::fast_random());
+    let tmp_z = concat_z(&mut tmp_buf, &[STORE_DIR, b"/.tmp-", &hex]);
+
+    let mut dest_rel_buf = PathBuffer::uninit();
+    let dest_rel_z = concat_z(
+        &mut dest_rel_buf,
+        &[tmp_z.as_bytes(), b"/node_modules/", package_name],
+    );
+
+    let dest_dir = match bun_sys::make_path::make_open_path(
+        Dir::borrow(&cache_dir),
+        dest_rel_z.as_bytes(),
+        Default::default(),
+    ) {
+        Ok(dir) => dir,
+        Err(_) => {
+            let _ = cache_dir.delete_tree(tmp_z.as_bytes());
+            return false;
+        }
+    };
+
+    let linked = hardlink_tree(cache_dir, folder_name, &dest_dir);
+    drop(dest_dir);
+    if !linked {
+        let _ = cache_dir.delete_tree(tmp_z.as_bytes());
+        return false;
+    }
+
+    if let Some(parent) = path::dirname(entry_z.as_bytes()) {
+        let _ = bun_sys::make_path::make_path::<u8>(Dir::borrow(&cache_dir), parent);
+    }
+
+    match sys::renameat(cache_dir, tmp_z, cache_dir, entry_z) {
+        Ok(()) => true,
+        Err(err) => {
+            let _ = cache_dir.delete_tree(tmp_z.as_bytes());
+            // Another process renamed its own copy into place first.
+            matches!(err.get_errno(), sys::E::EEXIST | sys::E::ENOTEMPTY)
+        }
+    }
+}
+
+fn hardlink_tree(cache_dir: Fd, folder_name: &[u8], dest_dir: &Dir) -> bool {
+    let Ok(src_fd) = sys::open_dir_for_iteration(cache_dir, folder_name) else {
+        return false;
+    };
+    let mut walker = match sys::walker_skippable::walk(src_fd, &[], &[]) {
+        Ok(w) => w,
+        Err(_) => {
+            src_fd.close();
+            return false;
+        }
+    };
+    let ok = loop {
+        match walker.next() {
+            Ok(Some(entry)) => match entry.kind {
+                sys::EntryKind::Directory => {
+                    if bun_sys::make_path::make_path::<u8>(dest_dir, entry.path.as_bytes()).is_err()
+                    {
+                        break false;
+                    }
+                }
+                sys::EntryKind::File => {
+                    if sys::linkat(entry.dir, entry.basename, dest_dir.fd(), entry.path).is_err() {
+                        break false;
+                    }
+                }
+                _ => {}
+            },
+            Ok(None) => break true,
+            Err(_) => break false,
+        }
+    };
+    drop(walker);
+    src_fd.close();
+    ok
+}
+
+enum LinkTarget {
+    /// Resolved to an npm package: name the flat cache dir from its version.
+    Npm {
+        real_name: Vec<u8>,
+        version: Semver::Version,
+    },
+    /// Resolved to an absolute folder (a disk-cache folder resolution).
+    FolderPath(Vec<u8>),
+    /// Edge not resolved in this process's lockfile (nothing `require`d the
+    /// dependency). Pick the best cached version satisfying the range, the
+    /// way offline resolution does.
+    FromDiskCache {
+        npm_name: Vec<u8>,
+        dep_index: u32,
+    },
+}
+
+/// Create or refresh `node_modules/<dep>` symlinks in the store entry, one
+/// per dependency of `package_id` that maps to a cached package. The symlink
+/// name is the dependency's alias (the name `dlopen`'s RPATH and `require`
+/// see); the target is the dependency's flat cache dir.
+fn ensure_dependency_links(
+    this: &mut PackageManager,
+    package_id: PackageID,
+    cache_dir: Fd,
+    folder_name: &[u8],
+) {
+    struct DepLink {
+        alias: Vec<u8>,
+        target: LinkTarget,
+    }
+
+    let mut links: Vec<DepLink> = Vec::new();
+    {
+        let pkgs = this.lockfile.packages.slice();
+        let pkg_dependencies = pkgs.items_dependencies();
+        let pkg_resolutions = pkgs.items_resolution();
+        let pkg_names = pkgs.items_name();
+        let string_buf = this.lockfile.buffers.string_bytes.as_slice();
+
+        let Some(deps) = pkg_dependencies.get(package_id as usize).copied() else {
+            return;
+        };
+        bun_core::scoped_log!(
+            addon_links,
+            "pkg {} deps {}..{}",
+            package_id,
+            deps.begin(),
+            deps.end()
+        );
+        for dep_index in deps.begin()..deps.end() {
+            let Some(dep) = this.lockfile.buffers.dependencies.get(dep_index as usize) else {
+                continue;
+            };
+            let alias = dep.name.slice(string_buf);
+            if alias.is_empty() || !crate::dependency::is_safe_install_folder_name(alias) {
+                continue;
+            }
+
+            let dep_pkg_id = this
+                .lockfile
+                .buffers
+                .resolutions
+                .get(dep_index as usize)
+                .copied()
+                .unwrap_or(crate::INVALID_PACKAGE_ID);
+
+            let target = if dep_pkg_id != crate::INVALID_PACKAGE_ID
+                && (dep_pkg_id as usize) < pkg_resolutions.len()
+            {
+                let resolution = &pkg_resolutions[dep_pkg_id as usize];
+                match resolution.tag {
+                    ResolutionTag::Npm => LinkTarget::Npm {
+                        real_name: pkg_names[dep_pkg_id as usize].slice(string_buf).to_vec(),
+                        version: resolution.npm().version,
+                    },
+                    ResolutionTag::Folder => {
+                        let folder = resolution.folder().slice(string_buf);
+                        if folder.first() != Some(&b'/') {
+                            continue;
+                        }
+                        LinkTarget::FolderPath(folder.to_vec())
+                    }
+                    _ => continue,
+                }
+            } else if dep.version.tag == crate::dependency::Tag::Npm {
+                let npm_name = dep.version.npm().name.slice(string_buf);
+                if npm_name.is_empty() || !crate::dependency::is_safe_install_folder_name(npm_name)
+                {
+                    continue;
+                }
+                LinkTarget::FromDiskCache {
+                    npm_name: npm_name.to_vec(),
+                    dep_index,
+                }
+            } else {
+                continue;
+            };
+
+            bun_core::scoped_log!(
+                addon_links,
+                "dep {} alias {}",
+                dep_index,
+                bun_fmt::s(alias)
+            );
+            links.push(DepLink {
+                alias: alias.to_vec(),
+                target,
+            });
+        }
+    }
+
+    for link in &links {
+        let mut target_buf = PathBuffer::uninit();
+        let target_len = match &link.target {
+            LinkTarget::Npm { real_name, version } => {
+                let mut dep_folder_buf = PathBuffer::uninit();
+                let dep_folder_len = directories::cached_npm_package_folder_name_print(
+                    this,
+                    &mut dep_folder_buf.0[..],
+                    real_name,
+                    *version,
+                    None,
+                )
+                .as_bytes()
+                .len();
+
+                path::resolve_path::join_abs_string_buf_z::<path::platform::Auto>(
+                    this.cache_directory_path.as_bytes(),
+                    &mut target_buf.0[..],
+                    &[&dep_folder_buf.0[..dep_folder_len]],
+                )
+                .as_bytes()
+                .len()
+            }
+            LinkTarget::FolderPath(folder) => {
+                target_buf.0[..folder.len()].copy_from_slice(folder);
+                folder.len()
+            }
+            LinkTarget::FromDiskCache {
+                npm_name,
+                dep_index,
+            } => {
+                let Some(len) =
+                    cached_dep_path_from_disk(this, npm_name, *dep_index, &mut target_buf)
+                else {
+                    continue;
+                };
+                len
+            }
+        };
+        target_buf.0[target_len] = 0;
+        let target_z = ZStr::from_buf(&target_buf.0, target_len);
+
+        let mut link_buf = PathBuffer::uninit();
+        let link_z = concat_z(
+            &mut link_buf,
+            &[STORE_DIR, b"/", folder_name, b"/node_modules/", &link.alias],
+        );
+
+        let mut read_buf = PathBuffer::uninit();
+        match sys::readlinkat(cache_dir, link_z, &mut read_buf.0[..]) {
+            Ok(n) if &read_buf.0[..n] == target_z.as_bytes() => {}
+            Ok(_) => {
+                let _ = sys::unlinkat(cache_dir, link_z);
+                let _ = sys::symlinkat(target_z, cache_dir, link_z);
+            }
+            Err(err) if err.get_errno() == sys::E::ENOENT => {
+                if let Some(parent) = path::dirname(link_z.as_bytes()) {
+                    let _ = bun_sys::make_path::make_path::<u8>(Dir::borrow(&cache_dir), parent);
+                }
+                let _ = sys::symlinkat(target_z, cache_dir, link_z);
+            }
+            // Exists but is not a symlink (for example the package's own
+            // hardlinked dir): leave it alone.
+            Err(_) => {}
+        }
+    }
+}
+
+/// Resolve an unresolved npm dependency edge against the disk cache: list
+/// the install-index entries of `npm_name` (`<cache>/<name>/<version>@@@N`),
+/// pick the highest version satisfying the edge's range, and write that flat
+/// cache dir's absolute path into `buf`.
+fn cached_dep_path_from_disk(
+    this: &mut PackageManager,
+    npm_name: &[u8],
+    dep_index: u32,
+    buf: &mut PathBuffer,
+) -> Option<usize> {
+    let cache_dir = directories::get_cache_directory(this);
+
+    struct Candidate {
+        version: Semver::Version,
+        entry_name: Vec<u8>,
+    }
+    let mut candidates: Vec<Candidate> = Vec::new();
+    let mut tags_buf: Vec<u8> = Vec::new();
+    {
+        let index_dir = Dir::borrow(&cache_dir).open_at(npm_name).ok()?;
+        let mut iter = sys::iterate_dir(index_dir.fd);
+        while let Ok(Some(entry)) = iter.next() {
+            if entry.kind != sys::EntryKind::Directory && entry.kind != sys::EntryKind::SymLink {
+                continue;
+            }
+            let entry_name: &[u8] = entry.name.slice_u8();
+            // Index entries carry the cache-version suffix (`1.3.2@@@1`,
+            // possibly followed by `_patch_hash=...`); strip it before the
+            // semver parse.
+            let version_part = match strings::index_of(entry_name, b"@@@") {
+                Some(at) => &entry_name[..at],
+                None => entry_name,
+            };
+            let parsed = Semver::Version::parse(SlicedString::init(version_part, version_part));
+            if !parsed.valid || parsed.wildcard != Semver::query::Wildcard::None {
+                continue;
+            }
+            let mut version = parsed.version.min();
+            let total = (version.tag.build.len() + version.tag.pre.len()) as usize;
+            if total > 0 {
+                let len_before = tags_buf.len();
+                tags_buf.resize(len_before + total, 0);
+                let mut available = &mut tags_buf[len_before..];
+                version = version.clone_into(version_part, &mut available);
+            }
+            candidates.push(Candidate {
+                version,
+                entry_name: entry_name.to_vec(),
+            });
+        }
+    }
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let best = {
+        let dep = this.lockfile.buffers.dependencies.get(dep_index as usize)?;
+        if dep.version.tag != crate::dependency::Tag::Npm {
+            return None;
+        }
+        let query = &dep.version.npm().version;
+        let string_buf = this.lockfile.buffers.string_bytes.as_slice();
+
+        let mut best: Option<&Candidate> = None;
+        for candidate in &candidates {
+            if !query.satisfies(candidate.version, string_buf, tags_buf.as_slice()) {
+                continue;
+            }
+            match best {
+                Some(current)
+                    if Semver::Version::order_fn(
+                        tags_buf.as_slice(),
+                        candidate.version,
+                        current.version,
+                    ) != core::cmp::Ordering::Greater => {}
+                _ => best = Some(candidate),
+            }
+        }
+        best?
+    };
+
+    // The index entry is normally a symlink to the flat dir; resolve it. With
+    // the install index disabled it can be a real dir, which is the target
+    // itself.
+    let mut entry_rel_buf = PathBuffer::uninit();
+    let entry_rel_z = concat_z(&mut entry_rel_buf, &[npm_name, b"/", &best.entry_name]);
+    match sys::readlinkat(cache_dir, entry_rel_z, &mut buf.0[..]) {
+        Ok(n) => Some(n),
+        Err(_) => Some(
+            path::resolve_path::join_abs_string_buf_z::<path::platform::Auto>(
+                this.cache_directory_path.as_bytes(),
+                &mut buf.0[..],
+                &[npm_name, &best.entry_name],
+            )
+            .as_bytes()
+            .len(),
+        ),
+    }
+}

--- a/src/install/PackageManager/native_addon_links.rs
+++ b/src/install/PackageManager/native_addon_links.rs
@@ -394,6 +394,12 @@ fn ensure_dependency_links(
             &mut link_buf,
             &[STORE_DIR, b"/", folder_name, b"/node_modules/", &link.alias],
         );
+        bun_core::scoped_log!(
+            addon_links,
+            "link {} -> {}",
+            bun_fmt::s(link_z.as_bytes()),
+            bun_fmt::s(target_z.as_bytes())
+        );
 
         let mut read_buf = PathBuffer::uninit();
         match sys::readlinkat(cache_dir, link_z, &mut read_buf.0[..]) {
@@ -429,10 +435,10 @@ fn cached_dep_path_from_disk(
 
     struct Candidate {
         version: Semver::Version,
+        /// Owns the bytes the version's tag offsets point into.
         entry_name: Vec<u8>,
     }
     let mut candidates: Vec<Candidate> = Vec::new();
-    let mut tags_buf: Vec<u8> = Vec::new();
     {
         let index_dir = Dir::borrow(&cache_dir).open_at(npm_name).ok()?;
         let mut iter = sys::iterate_dir(index_dir.fd);
@@ -440,29 +446,27 @@ fn cached_dep_path_from_disk(
             if entry.kind != sys::EntryKind::Directory && entry.kind != sys::EntryKind::SymLink {
                 continue;
             }
-            let entry_name: &[u8] = entry.name.slice_u8();
-            // Index entries carry the cache-version suffix (`1.3.2@@@1`,
-            // possibly followed by `_patch_hash=...`); strip it before the
-            // semver parse.
-            let version_part = match strings::index_of(entry_name, b"@@@") {
+            let entry_name: Vec<u8> = entry.name.slice_u8().to_vec();
+            // Index entries append suffixes to the version: `@@@N` (cache
+            // version, maybe with `_patch_hash=...`) and `@@<host>@@@N` for a
+            // non-default registry. A semver version cannot contain `@`, so
+            // cut at the first `@@`. Parse from the owned copy: the version's
+            // tag offsets then stay valid against `entry_name` (the cut is a
+            // prefix, so offsets match the full buffer too). A shared tag
+            // buffer would not work here: `clone_into` stores offsets
+            // relative to the sub-slice it is given.
+            let version_part = match strings::index_of(&entry_name, b"@@") {
                 Some(at) => &entry_name[..at],
-                None => entry_name,
+                None => &entry_name[..],
             };
             let parsed = Semver::Version::parse(SlicedString::init(version_part, version_part));
             if !parsed.valid || parsed.wildcard != Semver::query::Wildcard::None {
                 continue;
             }
-            let mut version = parsed.version.min();
-            let total = (version.tag.build.len() + version.tag.pre.len()) as usize;
-            if total > 0 {
-                let len_before = tags_buf.len();
-                tags_buf.resize(len_before + total, 0);
-                let mut available = &mut tags_buf[len_before..];
-                version = version.clone_into(version_part, &mut available);
-            }
+            let version = parsed.version.min();
             candidates.push(Candidate {
                 version,
-                entry_name: entry_name.to_vec(),
+                entry_name,
             });
         }
     }
@@ -480,15 +484,15 @@ fn cached_dep_path_from_disk(
 
         let mut best: Option<&Candidate> = None;
         for candidate in &candidates {
-            if !query.satisfies(candidate.version, string_buf, tags_buf.as_slice()) {
+            if !query.satisfies(candidate.version, string_buf, &candidate.entry_name) {
                 continue;
             }
             match best {
                 Some(current)
-                    if Semver::Version::order_fn(
-                        tags_buf.as_slice(),
-                        candidate.version,
+                    if candidate.version.order(
                         current.version,
+                        &candidate.entry_name,
+                        &current.entry_name,
                     ) != core::cmp::Ordering::Greater => {}
                 _ => best = Some(candidate),
             }

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { mkdirSync } from "fs";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
+import { createHash } from "node:crypto";
+import { gzipSync } from "node:zlib";
 import { join } from "path";
 
 //   --install=<val>                 Configure auto-install behavior. One of "auto" (default, auto-installs when no node_modules), "fallback" (missing packages only), "force" (always).
@@ -83,6 +85,154 @@ test("auto-install in a project whose package.json has a name and version", asyn
   expect(requests).toContain("/pkg-that-does-not-exist-anywhere");
   expect(stderr).toContain("Cannot find package 'pkg-that-does-not-exist-anywhere'");
   expect(exitCode).toBe(1);
+});
+
+// Minimal ustar + gzip so the local registry can serve real tarballs without
+// a binary fixture. All entry names stay under the 100-byte ustar limit.
+function tarEntry(name: string, body: Buffer): Buffer[] {
+  const header = Buffer.alloc(512, 0);
+  header.write(name, 0, 100, "utf8");
+  const octal = (n: number, width: number) => n.toString(8).padStart(width - 1, "0") + "\0";
+  header.write(octal(0o644, 8), 100); // mode
+  header.write(octal(0, 8), 108); // uid
+  header.write(octal(0, 8), 116); // gid
+  header.write(octal(body.length, 12), 124); // size
+  header.write(octal(0, 12), 136); // mtime
+  header.fill(" ", 148, 156); // checksum placeholder
+  header.write("0", 156); // regular file
+  header.write("ustar\0", 257);
+  header.write("00", 263);
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += header[i];
+  header.write(octal(sum, 8), 148);
+  const pad = Buffer.alloc((512 - (body.length % 512)) % 512, 0);
+  return [header, body, pad];
+}
+
+function buildTarball(files: Record<string, string>): { tgz: Buffer; shasum: string; integrity: string } {
+  const blocks: Buffer[] = [];
+  for (const [path, body] of Object.entries(files)) {
+    blocks.push(...tarEntry(`package/${path}`, Buffer.from(body)));
+  }
+  blocks.push(Buffer.alloc(1024, 0)); // end-of-archive
+  const tgz = gzipSync(Buffer.concat(blocks));
+  return {
+    tgz,
+    shasum: createHash("sha1").update(tgz).digest("hex"),
+    integrity: "sha512-" + createHash("sha512").update(tgz).digest("base64"),
+  };
+}
+
+// Prebuilt native addons locate sibling shared libraries with
+// $ORIGIN-relative RPATH entries such as "$ORIGIN/../../lib-pkg/lib", which
+// assume a node_modules layout. Auto-install runs packages out of flat cache
+// dirs ("name@version@@@N"), so every candidate used to miss (#40269).
+// Packages with a .node file must resolve to a node_modules-shaped view
+// whose siblings link to their dependencies' cache dirs.
+test.skipIf(isWindows)("auto-install native addon packages resolve $ORIGIN-shaped RPATH siblings", async () => {
+  const tarballs: Record<string, { tgz: Buffer; shasum: string; integrity: string }> = {
+    "lib-pkg": buildTarball({
+      "package.json": JSON.stringify({ name: "lib-pkg", version: "1.2.3" }),
+      "lib/libfake.so": "not really a shared library\n",
+    }),
+    "addon-pkg": buildTarball({
+      "package.json": JSON.stringify({
+        name: "addon-pkg",
+        version: "1.0.0",
+        main: "index.js",
+        dependencies: { "lib-pkg": "^1.2.0" },
+      }),
+      "index.js": "module.exports = require.resolve('./lib/fake.node');\n",
+      "lib/fake.node": "not really a native addon\n",
+    }),
+  };
+  const versions: Record<string, string> = { "lib-pkg": "1.2.3", "addon-pkg": "1.0.0" };
+
+  using registry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const pathname = new URL(req.url).pathname;
+      const tgz = pathname.match(/^\/tarballs\/(.+)\.tgz$/);
+      if (tgz) {
+        const name = tgz[1];
+        if (!tarballs[name]) return new Response("not found", { status: 404 });
+        return new Response(tarballs[name].tgz, {
+          headers: { "content-type": "application/octet-stream" },
+        });
+      }
+      const name = pathname.slice(1);
+      if (!tarballs[name]) return new Response("not found", { status: 404 });
+      const version = versions[name];
+      const pkg = JSON.parse(
+        JSON.stringify({
+          name,
+          version,
+          dependencies: name === "addon-pkg" ? { "lib-pkg": "^1.2.0" } : undefined,
+        }),
+      );
+      pkg.dist = {
+        shasum: tarballs[name].shasum,
+        integrity: tarballs[name].integrity,
+        tarball: `http://127.0.0.1:${registry.port}/tarballs/${name}.tgz`,
+      };
+      return Response.json({
+        name,
+        "dist-tags": { latest: version },
+        versions: { [version]: pkg },
+      });
+    },
+  });
+
+  using dir = tempDir("autoinstall-addon-links", {
+    "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
+    "check.js": `
+      const fs = require("fs");
+      const path = require("path");
+      const addonPath = require("addon-pkg");
+      const origin = path.dirname(fs.realpathSync(addonPath));
+      // The same walk the dynamic linker does for the RPATH entry
+      // "$ORIGIN/../../lib-pkg/lib": plain string concatenation, so the
+      // kernel resolves ".." through the real parent dirs, exactly like
+      // dlopen. No path.join, which would collapse ".." textually.
+      const found = fs.existsSync(origin + "/../../lib-pkg/lib/libfake.so");
+      const shaped = origin.includes(path.sep + "node_modules" + path.sep + "addon-pkg" + path.sep);
+      console.log(JSON.stringify({ found, shaped }));
+    `,
+  });
+  const env = {
+    ...bunEnv,
+    BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+  };
+
+  // First run populates the cache through the local registry.
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "check.js"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  // Second run resolves from the warm cache (cached manifests, no lockfile
+  // edge for lib-pkg), which is the layout every pre-existing cache has.
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "check.js"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(JSON.parse(stdout)).toEqual({ found: true, shaped: true });
+    expect(exitCode).toBe(0);
+  }
 });
 
 test("--install=fallback to install missing packages", async () => {

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -129,116 +129,126 @@ function buildTarball(files: Record<string, string>): { tgz: Buffer; shasum: str
 // dirs ("name@version@@@N"), so every candidate used to miss (#40269).
 // Packages with a .node file must resolve to a node_modules-shaped view
 // whose siblings link to their dependencies' cache dirs.
-test.skipIf(isWindows)("auto-install native addon packages resolve $ORIGIN-shaped RPATH siblings", async () => {
-  const tarballs: Record<string, { tgz: Buffer; shasum: string; integrity: string }> = {
-    "lib-pkg": buildTarball({
-      "package.json": JSON.stringify({ name: "lib-pkg", version: "1.2.3" }),
-      "lib/libfake.so": "not really a shared library\n",
-    }),
-    "addon-pkg": buildTarball({
-      "package.json": JSON.stringify({
-        name: "addon-pkg",
-        version: "1.0.0",
-        main: "index.js",
-        dependencies: { "lib-pkg": "^1.2.0" },
+//
+// The scoped case mirrors sharp's real shape: @img/sharp-linux-x64 reaches
+// @img/sharp-libvips-linux-x64 through optionalDependencies, and its RPATH
+// walk lands in the scope dir (node_modules/@img).
+for (const { label, addonName, libName, depField } of [
+  { label: "unscoped dependency", addonName: "addon-pkg", libName: "lib-pkg", depField: "dependencies" },
+  { label: "scoped optionalDependency", addonName: "@img/addon-pkg", libName: "@img/lib-pkg", depField: "optionalDependencies" },
+]) {
+  test.skipIf(isWindows)(`auto-install native addon packages resolve $ORIGIN-shaped RPATH siblings (${label})`, async () => {
+    // The RPATH sibling lookup uses the last path component: from the addon's
+    // lib dir, "$ORIGIN/../.." is node_modules (or node_modules/@scope), and
+    // the sibling sits there under its unscoped basename.
+    const libBase = libName.split("/").pop()!;
+    const tarballs: Record<string, { tgz: Buffer; shasum: string; integrity: string }> = {
+      [libName]: buildTarball({
+        "package.json": JSON.stringify({ name: libName, version: "1.2.3" }),
+        "lib/libfake.so": "not really a shared library\n",
       }),
-      "index.js": "module.exports = require.resolve('./lib/fake.node');\n",
-      "lib/fake.node": "not really a native addon\n",
-    }),
-  };
-  const versions: Record<string, string> = { "lib-pkg": "1.2.3", "addon-pkg": "1.0.0" };
-
-  using registry = Bun.serve({
-    port: 0,
-    fetch(req) {
-      const pathname = new URL(req.url).pathname;
-      const tgz = pathname.match(/^\/tarballs\/(.+)\.tgz$/);
-      if (tgz) {
-        const name = tgz[1];
-        if (!tarballs[name]) return new Response("not found", { status: 404 });
-        return new Response(tarballs[name].tgz, {
-          headers: { "content-type": "application/octet-stream" },
-        });
-      }
-      const name = pathname.slice(1);
-      if (!tarballs[name]) return new Response("not found", { status: 404 });
-      const version = versions[name];
-      const pkg = JSON.parse(
-        JSON.stringify({
-          name,
-          version,
-          dependencies: name === "addon-pkg" ? { "lib-pkg": "^1.2.0" } : undefined,
+      [addonName]: buildTarball({
+        "package.json": JSON.stringify({
+          name: addonName,
+          version: "1.0.0",
+          main: "index.js",
+          [depField]: { [libName]: "^1.2.0" },
         }),
-      );
-      pkg.dist = {
-        shasum: tarballs[name].shasum,
-        integrity: tarballs[name].integrity,
-        tarball: `http://127.0.0.1:${registry.port}/tarballs/${name}.tgz`,
-      };
-      return Response.json({
-        name,
-        "dist-tags": { latest: version },
-        versions: { [version]: pkg },
-      });
-    },
-  });
+        "index.js": "module.exports = require.resolve('./lib/fake.node');\n",
+        "lib/fake.node": "not really a native addon\n",
+      }),
+    };
+    const versions: Record<string, string> = { [libName]: "1.2.3", [addonName]: "1.0.0" };
 
-  using dir = tempDir("autoinstall-addon-links", {
-    "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
-    "check.js": `
-      const fs = require("fs");
-      const path = require("path");
-      const addonPath = require("addon-pkg");
-      const origin = path.dirname(fs.realpathSync(addonPath));
-      // The same walk the dynamic linker does for the RPATH entry
-      // "$ORIGIN/../../lib-pkg/lib": plain string concatenation, so the
-      // kernel resolves ".." through the real parent dirs, exactly like
-      // dlopen. No path.join, which would collapse ".." textually.
-      const found = fs.existsSync(origin + "/../../lib-pkg/lib/libfake.so");
-      const shaped = origin.includes(path.sep + "node_modules" + path.sep + "addon-pkg" + path.sep);
-      console.log(JSON.stringify({ found, shaped }));
-    `,
-  });
-  const env = {
-    ...bunEnv,
-    BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
-  };
-
-  async function runCheck(script: string): Promise<{ found: boolean; shaped: boolean }> {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), script],
-      cwd: String(dir),
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
+    using registry = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const pathname = decodeURIComponent(new URL(req.url).pathname);
+        const tgz = pathname.match(/^\/tarballs\/(.+)\.tgz$/);
+        if (tgz) {
+          const name = tgz[1];
+          if (!tarballs[name]) return new Response("not found", { status: 404 });
+          return new Response(tarballs[name].tgz, {
+            headers: { "content-type": "application/octet-stream" },
+          });
+        }
+        const name = pathname.slice(1);
+        if (!tarballs[name]) return new Response("not found", { status: 404 });
+        const version = versions[name];
+        const pkg: Record<string, unknown> = { name, version };
+        if (name === addonName) pkg[depField] = { [libName]: "^1.2.0" };
+        pkg.dist = {
+          shasum: tarballs[name].shasum,
+          integrity: tarballs[name].integrity,
+          tarball: `http://127.0.0.1:${registry.port}/tarballs/${name}.tgz`,
+        };
+        return Response.json({
+          name,
+          "dist-tags": { latest: version },
+          versions: { [version]: pkg },
+        });
+      },
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
-    return JSON.parse(stdout);
-  }
 
-  // First run populates the cache through the local registry. The addon view
-  // is built during addon-pkg's own resolve, so `shaped` is deterministic.
-  // `found` is not asserted here: lib-pkg's extraction is asynchronous and
-  // nothing in check.js awaits it.
-  expect((await runCheck("check.js")).shaped).toBe(true);
+    using dir = tempDir("autoinstall-addon-links", {
+      "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
+      "check.js": `
+        const fs = require("fs");
+        const path = require("path");
+        const addonPath = require(${JSON.stringify(addonName)});
+        const origin = path.dirname(fs.realpathSync(addonPath));
+        // The same walk the dynamic linker does for the RPATH entry
+        // "$ORIGIN/../../${libBase}/lib": plain string concatenation, so the
+        // kernel resolves ".." through the real parent dirs, exactly like
+        // dlopen. No path.join, which would collapse ".." textually.
+        const found = fs.existsSync(origin + "/../../${libBase}/lib/libfake.so");
+        const shaped = origin.includes("/node_modules/" + ${JSON.stringify(addonName)} + "/");
+        console.log(JSON.stringify({ found, shaped }));
+      `,
+    });
+    const env = {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+    };
 
-  // Second run resolves from the warm cache with no lockfile edge for
-  // lib-pkg (the layout every pre-existing cache has), which exercises the
-  // disk-cache fallback for the sibling symlink.
-  expect(await runCheck("check.js")).toEqual({ found: true, shaped: true });
+    async function runCheck(script: string): Promise<{ found: boolean; shaped: boolean }> {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), script],
+        cwd: String(dir),
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+      return JSON.parse(stdout);
+    }
 
-  // Third run: drop the view. A warm cache must rebuild it and recreate the
-  // sibling symlink from scratch, with no leftover state from the first run.
-  rmSync(join(String(dir), ".bun-cache", ".addon-links"), { recursive: true, force: true });
-  expect(await runCheck("check.js")).toEqual({ found: true, shaped: true });
+    // First run populates the cache through the local registry. The addon view
+    // is built during the addon's own resolve, so `shaped` is deterministic.
+    // `found` is not asserted here: the library's extraction is asynchronous
+    // and nothing in check.js awaits it.
+    expect((await runCheck("check.js")).shaped).toBe(true);
 
-  // A skip marker on addon-pkg would disable the view permanently, so the
-  // detection must never write one for a package with a .node file.
-  const storeEntries = readdirSync(join(String(dir), ".bun-cache", ".addon-links"));
-  expect(storeEntries.some(f => f.startsWith("addon-pkg@") && f.endsWith(".skip"))).toBe(false);
-});
+    // Second run resolves from the warm cache with no lockfile edge for the
+    // library (the layout every pre-existing cache has), which exercises the
+    // disk-cache fallback for the sibling symlink.
+    expect(await runCheck("check.js")).toEqual({ found: true, shaped: true });
+
+    // Third run: drop the view. A warm cache must rebuild it and recreate the
+    // sibling symlink from scratch, with no leftover state from the first run.
+    rmSync(join(String(dir), ".bun-cache", ".addon-links"), { recursive: true, force: true });
+    expect(await runCheck("check.js")).toEqual({ found: true, shaped: true });
+
+    // A skip marker on the addon would disable the view permanently, so the
+    // detection must never write one for a package with a .node file.
+    const markerDir = join(String(dir), ".bun-cache", ".addon-links", ...addonName.split("/").slice(0, -1));
+    const addonBase = addonName.split("/").pop()!;
+    const storeEntries = readdirSync(markerDir);
+    expect(storeEntries.some(f => f.startsWith(`${addonBase}@`) && f.endsWith(".skip"))).toBe(false);
+  });
+}
 
 test("--install=fallback to install missing packages", async () => {
   const dir = tmpdirSync();

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync } from "fs";
+import { mkdirSync, rmSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { createHash } from "node:crypto";
 import { gzipSync } from "node:zlib";
@@ -204,25 +204,9 @@ test.skipIf(isWindows)("auto-install native addon packages resolve $ORIGIN-shape
     BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
   };
 
-  // First run populates the cache through the local registry.
-  {
+  async function runCheck(script: string): Promise<{ found: boolean; shaped: boolean }> {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "check.js"],
-      cwd: String(dir),
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
-  }
-
-  // Second run resolves from the warm cache (cached manifests, no lockfile
-  // edge for lib-pkg), which is the layout every pre-existing cache has.
-  {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "check.js"],
+      cmd: [bunExe(), script],
       cwd: String(dir),
       env,
       stdout: "pipe",
@@ -230,9 +214,25 @@ test.skipIf(isWindows)("auto-install native addon packages resolve $ORIGIN-shape
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).not.toContain("error:");
-    expect(JSON.parse(stdout)).toEqual({ found: true, shaped: true });
     expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
   }
+
+  // First run populates the cache through the local registry. The addon view
+  // is built during addon-pkg's own resolve, so `shaped` is deterministic.
+  // `found` is not asserted here: lib-pkg's extraction is asynchronous and
+  // nothing in check.js awaits it.
+  expect((await runCheck("check.js")).shaped).toBe(true);
+
+  // Second run resolves from the warm cache with no lockfile edge for
+  // lib-pkg (the layout every pre-existing cache has), which exercises the
+  // disk-cache fallback for the sibling symlink.
+  expect(await runCheck("check.js")).toEqual({ found: true, shaped: true });
+
+  // Third run: drop the view. A warm cache must rebuild it and recreate the
+  // sibling symlink from scratch, with no leftover state from the first run.
+  rmSync(join(String(dir), ".bun-cache", ".addon-links"), { recursive: true, force: true });
+  expect(await runCheck("check.js")).toEqual({ found: true, shaped: true });
 });
 
 test("--install=fallback to install missing packages", async () => {

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync } from "fs";
+import { mkdirSync, readdirSync, rmSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
 import { createHash } from "node:crypto";
 import { gzipSync } from "node:zlib";
@@ -233,6 +233,11 @@ test.skipIf(isWindows)("auto-install native addon packages resolve $ORIGIN-shape
   // sibling symlink from scratch, with no leftover state from the first run.
   rmSync(join(String(dir), ".bun-cache", ".addon-links"), { recursive: true, force: true });
   expect(await runCheck("check.js")).toEqual({ found: true, shaped: true });
+
+  // A skip marker on addon-pkg would disable the view permanently, so the
+  // detection must never write one for a package with a .node file.
+  const storeEntries = readdirSync(join(String(dir), ".bun-cache", ".addon-links"));
+  expect(storeEntries.some(f => f.startsWith("addon-pkg@") && f.endsWith(".skip"))).toBe(false);
 });
 
 test("--install=fallback to install missing packages", async () => {

--- a/test/cli/run/run-autoinstall.test.ts
+++ b/test/cli/run/run-autoinstall.test.ts
@@ -135,64 +135,71 @@ function buildTarball(files: Record<string, string>): { tgz: Buffer; shasum: str
 // walk lands in the scope dir (node_modules/@img).
 for (const { label, addonName, libName, depField } of [
   { label: "unscoped dependency", addonName: "addon-pkg", libName: "lib-pkg", depField: "dependencies" },
-  { label: "scoped optionalDependency", addonName: "@img/addon-pkg", libName: "@img/lib-pkg", depField: "optionalDependencies" },
+  {
+    label: "scoped optionalDependency",
+    addonName: "@img/addon-pkg",
+    libName: "@img/lib-pkg",
+    depField: "optionalDependencies",
+  },
 ]) {
-  test.skipIf(isWindows)(`auto-install native addon packages resolve $ORIGIN-shaped RPATH siblings (${label})`, async () => {
-    // The RPATH sibling lookup uses the last path component: from the addon's
-    // lib dir, "$ORIGIN/../.." is node_modules (or node_modules/@scope), and
-    // the sibling sits there under its unscoped basename.
-    const libBase = libName.split("/").pop()!;
-    const tarballs: Record<string, { tgz: Buffer; shasum: string; integrity: string }> = {
-      [libName]: buildTarball({
-        "package.json": JSON.stringify({ name: libName, version: "1.2.3" }),
-        "lib/libfake.so": "not really a shared library\n",
-      }),
-      [addonName]: buildTarball({
-        "package.json": JSON.stringify({
-          name: addonName,
-          version: "1.0.0",
-          main: "index.js",
-          [depField]: { [libName]: "^1.2.0" },
+  test.skipIf(isWindows)(
+    `auto-install native addon packages resolve $ORIGIN-shaped RPATH siblings (${label})`,
+    async () => {
+      // The RPATH sibling lookup uses the last path component: from the addon's
+      // lib dir, "$ORIGIN/../.." is node_modules (or node_modules/@scope), and
+      // the sibling sits there under its unscoped basename.
+      const libBase = libName.split("/").pop()!;
+      const tarballs: Record<string, { tgz: Buffer; shasum: string; integrity: string }> = {
+        [libName]: buildTarball({
+          "package.json": JSON.stringify({ name: libName, version: "1.2.3" }),
+          "lib/libfake.so": "not really a shared library\n",
         }),
-        "index.js": "module.exports = require.resolve('./lib/fake.node');\n",
-        "lib/fake.node": "not really a native addon\n",
-      }),
-    };
-    const versions: Record<string, string> = { [libName]: "1.2.3", [addonName]: "1.0.0" };
+        [addonName]: buildTarball({
+          "package.json": JSON.stringify({
+            name: addonName,
+            version: "1.0.0",
+            main: "index.js",
+            [depField]: { [libName]: "^1.2.0" },
+          }),
+          "index.js": "module.exports = require.resolve('./lib/fake.node');\n",
+          "lib/fake.node": "not really a native addon\n",
+        }),
+      };
+      const versions: Record<string, string> = { [libName]: "1.2.3", [addonName]: "1.0.0" };
 
-    using registry = Bun.serve({
-      port: 0,
-      fetch(req) {
-        const pathname = decodeURIComponent(new URL(req.url).pathname);
-        const tgz = pathname.match(/^\/tarballs\/(.+)\.tgz$/);
-        if (tgz) {
-          const name = tgz[1];
+      using registry = Bun.serve({
+        port: 0,
+        fetch(req) {
+          const pathname = decodeURIComponent(new URL(req.url).pathname);
+          const tgz = pathname.match(/^\/tarballs\/(.+)\.tgz$/);
+          if (tgz) {
+            const name = tgz[1];
+            if (!tarballs[name]) return new Response("not found", { status: 404 });
+            return new Response(tarballs[name].tgz, {
+              headers: { "content-type": "application/octet-stream" },
+            });
+          }
+          const name = pathname.slice(1);
           if (!tarballs[name]) return new Response("not found", { status: 404 });
-          return new Response(tarballs[name].tgz, {
-            headers: { "content-type": "application/octet-stream" },
+          const version = versions[name];
+          const pkg: Record<string, unknown> = { name, version };
+          if (name === addonName) pkg[depField] = { [libName]: "^1.2.0" };
+          pkg.dist = {
+            shasum: tarballs[name].shasum,
+            integrity: tarballs[name].integrity,
+            tarball: `http://127.0.0.1:${registry.port}/tarballs/${name}.tgz`,
+          };
+          return Response.json({
+            name,
+            "dist-tags": { latest: version },
+            versions: { [version]: pkg },
           });
-        }
-        const name = pathname.slice(1);
-        if (!tarballs[name]) return new Response("not found", { status: 404 });
-        const version = versions[name];
-        const pkg: Record<string, unknown> = { name, version };
-        if (name === addonName) pkg[depField] = { [libName]: "^1.2.0" };
-        pkg.dist = {
-          shasum: tarballs[name].shasum,
-          integrity: tarballs[name].integrity,
-          tarball: `http://127.0.0.1:${registry.port}/tarballs/${name}.tgz`,
-        };
-        return Response.json({
-          name,
-          "dist-tags": { latest: version },
-          versions: { [version]: pkg },
-        });
-      },
-    });
+        },
+      });
 
-    using dir = tempDir("autoinstall-addon-links", {
-      "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
-      "check.js": `
+      using dir = tempDir("autoinstall-addon-links", {
+        "bunfig.toml": `[install]\nregistry = "http://127.0.0.1:${registry.port}/"\n`,
+        "check.js": `
         const fs = require("fs");
         const path = require("path");
         const addonPath = require(${JSON.stringify(addonName)});
@@ -205,49 +212,50 @@ for (const { label, addonName, libName, depField } of [
         const shaped = origin.includes("/node_modules/" + ${JSON.stringify(addonName)} + "/");
         console.log(JSON.stringify({ found, shaped }));
       `,
-    });
-    const env = {
-      ...bunEnv,
-      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
-    };
-
-    async function runCheck(script: string): Promise<{ found: boolean; shaped: boolean }> {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), script],
-        cwd: String(dir),
-        env,
-        stdout: "pipe",
-        stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
-      return JSON.parse(stdout);
-    }
+      const env = {
+        ...bunEnv,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+      };
 
-    // First run populates the cache through the local registry. The addon view
-    // is built during the addon's own resolve, so `shaped` is deterministic.
-    // `found` is not asserted here: the library's extraction is asynchronous
-    // and nothing in check.js awaits it.
-    expect((await runCheck("check.js")).shaped).toBe(true);
+      async function runCheck(script: string): Promise<{ found: boolean; shaped: boolean }> {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), script],
+          cwd: String(dir),
+          env,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).not.toContain("error:");
+        expect(exitCode).toBe(0);
+        return JSON.parse(stdout);
+      }
 
-    // Second run resolves from the warm cache with no lockfile edge for the
-    // library (the layout every pre-existing cache has), which exercises the
-    // disk-cache fallback for the sibling symlink.
-    expect(await runCheck("check.js")).toEqual({ found: true, shaped: true });
+      // First run populates the cache through the local registry. The addon view
+      // is built during the addon's own resolve, so `shaped` is deterministic.
+      // `found` is not asserted here: the library's extraction is asynchronous
+      // and nothing in check.js awaits it.
+      expect((await runCheck("check.js")).shaped).toBe(true);
 
-    // Third run: drop the view. A warm cache must rebuild it and recreate the
-    // sibling symlink from scratch, with no leftover state from the first run.
-    rmSync(join(String(dir), ".bun-cache", ".addon-links"), { recursive: true, force: true });
-    expect(await runCheck("check.js")).toEqual({ found: true, shaped: true });
+      // Second run resolves from the warm cache with no lockfile edge for the
+      // library (the layout every pre-existing cache has), which exercises the
+      // disk-cache fallback for the sibling symlink.
+      expect(await runCheck("check.js")).toEqual({ found: true, shaped: true });
 
-    // A skip marker on the addon would disable the view permanently, so the
-    // detection must never write one for a package with a .node file.
-    const markerDir = join(String(dir), ".bun-cache", ".addon-links", ...addonName.split("/").slice(0, -1));
-    const addonBase = addonName.split("/").pop()!;
-    const storeEntries = readdirSync(markerDir);
-    expect(storeEntries.some(f => f.startsWith(`${addonBase}@`) && f.endsWith(".skip"))).toBe(false);
-  });
+      // Third run: drop the view. A warm cache must rebuild it and recreate the
+      // sibling symlink from scratch, with no leftover state from the first run.
+      rmSync(join(String(dir), ".bun-cache", ".addon-links"), { recursive: true, force: true });
+      expect(await runCheck("check.js")).toEqual({ found: true, shaped: true });
+
+      // A skip marker on the addon would disable the view permanently, so the
+      // detection must never write one for a package with a .node file.
+      const markerDir = join(String(dir), ".bun-cache", ".addon-links", ...addonName.split("/").slice(0, -1));
+      const addonBase = addonName.split("/").pop()!;
+      const storeEntries = readdirSync(markerDir);
+      expect(storeEntries.some(f => f.startsWith(`${addonBase}@`) && f.endsWith(".skip"))).toBe(false);
+    },
+  );
 }
 
 test("--install=fallback to install missing packages", async () => {


### PR DESCRIPTION
### Problem

- Auto-install (a run with no `node_modules`) loads packages from flat cache dirs (`<cache>/name@version@@@N`). Prebuilt native addons find sibling shared libraries with `$ORIGIN`-relative RPATH entries that assume a node_modules layout, so every candidate misses. `sharp` fails with `libvips-cpp.so.8.18.3: cannot open shared object file` and silently falls back to its wasm binding. Fixes #40269.
- A symlinked view cannot fix this. The kernel resolves the `..` components of an RPATH candidate through the real parent dir, so the real directory layout has to be node_modules-shaped.

### Fix

- When the resolver maps an auto-install package to its cache dir (`path_for_resolution`, `src/install/PackageManager/PackageManagerDirectories.rs:932`) and the package contains a `.node` file, it now returns `<cache>/.addon-links/<flat>/node_modules/<name>`. The new module `src/install/PackageManager/native_addon_links.rs` builds that view once per cache entry: files hardlinked from the flat dir, built in a temp dir and renamed into place.
- Each dependency of the package is symlinked next to it, so `$ORIGIN/../../<dep>/lib` resolves into the dependency's cache dir. An unresolved dependency edge (nothing `require`d it, the common case for a pre-existing cache) is resolved against the install index on disk, the way offline resolution does.
- Packages without a `.node` file get an empty `<flat>.skip` marker so the scan runs once. Everything is best-effort: on any failure the resolver returns the flat dir, which is the old behavior. Normal `bun install` paths are untouched, and the whole module is compiled out on Windows (no RPATH there).
- Verified: `test/cli/run/run-autoinstall.test.ts` (new test, two variants: an unscoped dependency and sharp's shape, a scoped optionalDependency; both fail on 1.4.1). Manually verified `sharp@0.35.3` loads its native binding and resizes an image on cold, warm, and pre-fix caches. Also ran the autoinstall and resolve suites and `bun-install-streaming-extract.test.ts`.

### Background

- This is the same shape pnpm and bun's isolated-install store use: the real dirs are `<key>/node_modules/<name>/...` and dependencies are symlinks beside the package. RPATH lookups walk up through real dirs and descend through the sibling symlink, which the kernel follows.
- Hardlinks are required because `$ORIGIN` is based on the real path of the loaded `.node`. A hardlink is a first-class name, so the view costs no disk space.
- sharp ships RPATH entries for the npm, pnpm, yarn, and Deno layouts. The npm-layout entry (`$ORIGIN/../../sharp-libvips-linux-x64/lib`) is the one the new view satisfies.

<details><summary>Notes</summary>

- Reproduced with `BUN_INSTALL_CACHE_DIR=<tmp> bun test.js` where test.js requires `sharp` in a dir without `node_modules`. The `.node`'s RPATH entries (from `readelf -d`) all miss against the flat layout. The library sits at `<cache>/@img/sharp-libvips-linux-x64@1.3.2@@@1/lib/`.
- Verified with a synthetic ELF pair that dlopen through a symlinked package dir fails even when the symlink view is node_modules-shaped: the kernel resolves `$ORIGIN/../..` through the real parent. The pnpm shape (real dirs + sibling symlink) loads.
- The dependency symlink target is the dependency's flat cache dir. That satisfies one level of sibling lookup, which is the ecosystem pattern (addon package + sibling library package). A chain of sibling hops through two native packages would need the dependency's own view; no known package does that.
- Unresolved dependency edges: the in-memory lockfile of an auto-install run only resolves an edge when something `require`s it. `sharp-libvips` is only touched by `dlopen`, so on a warm cache its edge stays unresolved. `cached_dep_path_from_disk` lists `<cache>/<name>/` index entries, strips the `@@@N` suffix (the semver parser rejects it), picks the highest version satisfying the edge's range, and readlinks the entry.
- The dependency symlinks are refreshed on every resolve: created when missing, repointed when the target changed (for example a different resolved version or a moved cache dir).
- Lifecycle scripts, `bun install` copy/hardlink/clonefile backends, and the install index are unchanged. The view is additive and lives in its own `.addon-links` namespace keyed by the flat folder name, which already carries the cache version.
- The wasm deadlock the issue also mentions (worker_threads globals) is a separate bug, see #35655.
- Review hardening: version candidates parse from per-entry buffers (the shared tag buffer compared the wrong bytes for prerelease tags), index entries from a non-default registry (`version@@host@@@N`) parse too, the view preserves package-internal symlinks, both walkers resolve unknown dirent types (NFS, FUSE), and a repointed sibling symlink is replaced atomically via rename.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-autoinstall.test.ts

<!-- robobun:evidence:end -->