### PR TITLE
bun test: rebuild process.argv for each test file

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4882,6 +4882,7 @@ impl VirtualMachine {
         self.main_resolved_path = bun_core::String::empty();
         self.main_hash = bun_watcher::Watcher::get_hash(entry_path);
         self.overridden_main.deinit();
+        crate::cpp::Bun__Process__resetArgv(self.global());
 
         self.event_loop_mut().ensure_waker();
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -390,6 +390,7 @@ unsafe extern "C" {
 
     safe fn Process__dispatchOnBeforeExit(global: &JSGlobalObject, code: u8);
     safe fn Process__dispatchOnExit(global: &JSGlobalObject, code: u8);
+    safe fn Bun__Process__resetArgv(global: &JSGlobalObject);
     safe fn Bun__closeAllSQLiteDatabasesForTermination(global: &JSGlobalObject);
     safe fn Bun__closeAllNodeSqliteDatabasesForTermination(global: &JSGlobalObject);
     safe fn Bun__WebView__closeAllForTermination();
@@ -4882,7 +4883,7 @@ impl VirtualMachine {
         self.main_resolved_path = bun_core::String::empty();
         self.main_hash = bun_watcher::Watcher::get_hash(entry_path);
         self.overridden_main.deinit();
-        crate::cpp::Bun__Process__resetArgv(self.global());
+        Bun__Process__resetArgv(self.global());
 
         self.event_loop_mut().ensure_waker();
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -46,6 +46,9 @@
 #include <JavaScriptCore/LazyProperty.h>
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
+#include <JavaScriptCore/JSModuleLoader.h>
+#include <JavaScriptCore/JSModuleNamespaceObject.h>
+#include <JavaScriptCore/ModuleRegistryEntry.h>
 #include "wtf-bindings.h"
 #include "EventLoopTask.h"
 #include "JSEventListener.h"
@@ -356,11 +359,10 @@ static char* toFileURI(std::string_view path)
     size_t escape_count = 0;
     for (char ch : path) {
 #if OS(WINDOWS)
-        if (ch == '\\') {
-            continue;
-        }
-#endif
+        if (needs_escape(ch) && ch != '\\') {
+#else
         if (needs_escape(ch)) {
+#endif
             ++escape_count;
         }
     }
@@ -1588,17 +1590,17 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
 #if OS(LINUX)
             // SIGKILL and SIGSTOP cannot be handled, and JSC needs its own signal handler to
             // suspend and resume the JS thread which we must not override.
-            bool canHandle = signalNumber != SIGKILL && signalNumber != SIGSTOP && signalNumber != g_wtfConfig.sigThreadSuspendResume;
+            if (signalNumber != SIGKILL && signalNumber != SIGSTOP && signalNumber != g_wtfConfig.sigThreadSuspendResume) {
 #elif OS(DARWIN) || OS(FREEBSD)
             // these signals cannot be handled
-            bool canHandle = signalNumber != SIGKILL && signalNumber != SIGSTOP;
+            if (signalNumber != SIGKILL && signalNumber != SIGSTOP) {
 #elif OS(WINDOWS)
             // windows has no SIGSTOP
-            bool canHandle = signalNumber != SIGKILL;
+            if (signalNumber != SIGKILL) {
 #else
 #error unknown OS
 #endif
-            if (canHandle) {
+
                 if (isAdded) {
                     if (!signalToContextIdsMap->contains(signalNumber)) {
                         SignalHandleValue signal_handle = {
@@ -3140,37 +3142,64 @@ JSC_DEFINE_CUSTOM_SETTER(setProcessArgv, (JSGlobalObject * globalObject, Encoded
     return true;
 }
 
+static void repointOwnDataProperty(VM& vm, JSObject* object, const Identifier& name, JSValue value)
+{
+    unsigned attributes = 0;
+    PropertyOffset offset = object->structure()->get(vm, name, attributes);
+    if (!isValidOffset(offset) || (attributes & PropertyAttribute::AccessorOrCustomAccessorOrValue)) {
+        return;
+    }
+    object->putDirect(vm, name, value, attributes);
+}
+
+// A process property can have copies: process and Bun reify a static table
+// entry into an own data property on first read, and node:process binds the
+// export the first time it is imported. After the canonical value changes,
+// point every copy that exists at the new value. A live accessor needs nothing.
+void repointProcessProperty(Zig::GlobalObject* globalObject, const Identifier& name, JSValue value)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (globalObject->hasProcessObject()) {
+        repointOwnDataProperty(vm, globalObject->processObject(), name, value);
+    }
+    if (globalObject->m_bunObject.isInitialized()) {
+        repointOwnDataProperty(vm, globalObject->bunObject(), name, value);
+    }
+
+    auto* entry = globalObject->moduleLoader()->registryEntry(Identifier::fromString(vm, "node:process"_s));
+    if (!entry || !isModuleEvaluated(entry->record())) {
+        return;
+    }
+    auto* moduleNamespace = entry->record()->getModuleNamespace(globalObject);
+    RETURN_IF_EXCEPTION(scope, void());
+    scope.release();
+    moduleNamespace->overrideExportValue(globalObject, name, value);
+}
+
 // process.argv[1] is the VM's current entry point. The test runner moves the
-// entry point from file to file, so the cached array must be dropped for the
-// next file. Bun.argv reifies to the same array on first access, so repoint it
-// when it is already an own property.
-extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__Process__resetArgv(Zig::GlobalObject* globalObject)
+// entry point from file to file, so the cached array is rebuilt and every copy
+// of the old one is repointed.
+extern "C" void Bun__Process__resetArgv(Zig::GlobalObject* globalObject)
 {
     if (!globalObject->hasProcessObject()) {
         return;
     }
 
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* process = globalObject->processObject();
     process->clearArgv();
 
-    if (!globalObject->m_bunObject.isInitialized()) {
-        return;
-    }
-    auto* bunObject = globalObject->bunObject();
-    auto argvIdentifier = JSC::Identifier::fromString(vm, "argv"_s);
-    if (!bunObject->getDirect(vm, argvIdentifier)) {
-        return;
-    }
-
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue argv = process->getArgv(globalObject);
+    if (!scope.exception()) {
+        repointProcessProperty(globalObject, Identifier::fromString(vm, "argv"_s), argv);
+    }
     if (auto* exception = scope.exception()) [[unlikely]] {
         CLEAR_IF_EXCEPTION(scope);
         Bun__reportError(globalObject, JSValue::encode(exception));
-        return;
     }
-    bunObject->putDirect(vm, argvIdentifier, argv, JSC::PropertyAttribute::DontDelete | 0);
 }
 
 extern "C" EncodedJSValue Bun__Process__getExecArgv(JSGlobalObject* lexicalGlobalObject)

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3152,7 +3152,7 @@ static void repointOwnDataProperty(VM& vm, JSObject* object, const Identifier& n
     object->putDirect(vm, name, value, attributes);
 }
 
-// process and Bun reify the property into an own value on first read; node:process binds it on first import.
+// process and Bun reify the property into an own value on first read; the node:process and bun modules bind it on first import.
 void repointProcessProperty(Zig::GlobalObject* globalObject, const Identifier& name, JSValue value)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -3165,14 +3165,16 @@ void repointProcessProperty(Zig::GlobalObject* globalObject, const Identifier& n
         repointOwnDataProperty(vm, globalObject->bunObject(), name, value);
     }
 
-    auto* entry = globalObject->moduleLoader()->registryEntry(Identifier::fromString(vm, "node:process"_s));
-    if (!entry || !isModuleEvaluated(entry->record())) {
-        return;
+    for (auto moduleKey : { "node:process"_s, "bun"_s }) {
+        auto* entry = globalObject->moduleLoader()->registryEntry(Identifier::fromString(vm, moduleKey));
+        if (!entry || !isModuleEvaluated(entry->record())) {
+            continue;
+        }
+        auto* moduleNamespace = entry->record()->getModuleNamespace(globalObject);
+        RETURN_IF_EXCEPTION(scope, void());
+        moduleNamespace->overrideExportValue(globalObject, name, value);
+        RETURN_IF_EXCEPTION(scope, void());
     }
-    auto* moduleNamespace = entry->record()->getModuleNamespace(globalObject);
-    RETURN_IF_EXCEPTION(scope, void());
-    scope.release();
-    moduleNamespace->overrideExportValue(globalObject, name, value);
 }
 
 // argv[1] is the VM's entry point, which the test runner changes for every file.

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3152,10 +3152,7 @@ static void repointOwnDataProperty(VM& vm, JSObject* object, const Identifier& n
     object->putDirect(vm, name, value, attributes);
 }
 
-// A process property can have copies: process and Bun reify a static table
-// entry into an own data property on first read, and node:process binds the
-// export the first time it is imported. After the canonical value changes,
-// point every copy that exists at the new value. A live accessor needs nothing.
+// process and Bun reify the property into an own value on first read; node:process binds it on first import.
 void repointProcessProperty(Zig::GlobalObject* globalObject, const Identifier& name, JSValue value)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -3178,9 +3175,7 @@ void repointProcessProperty(Zig::GlobalObject* globalObject, const Identifier& n
     moduleNamespace->overrideExportValue(globalObject, name, value);
 }
 
-// process.argv[1] is the VM's current entry point. The test runner moves the
-// entry point from file to file, so the cached array is rebuilt and every copy
-// of the old one is repointed.
+// argv[1] is the VM's entry point, which the test runner changes for every file.
 extern "C" void Bun__Process__resetArgv(Zig::GlobalObject* globalObject)
 {
     if (!globalObject->hasProcessObject()) {

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -356,10 +356,11 @@ static char* toFileURI(std::string_view path)
     size_t escape_count = 0;
     for (char ch : path) {
 #if OS(WINDOWS)
-        if (needs_escape(ch) && ch != '\\') {
-#else
-        if (needs_escape(ch)) {
+        if (ch == '\\') {
+            continue;
+        }
 #endif
+        if (needs_escape(ch)) {
             ++escape_count;
         }
     }
@@ -1587,17 +1588,17 @@ static void onDidChangeListeners(EventEmitter& eventEmitter, const Identifier& e
 #if OS(LINUX)
             // SIGKILL and SIGSTOP cannot be handled, and JSC needs its own signal handler to
             // suspend and resume the JS thread which we must not override.
-            if (signalNumber != SIGKILL && signalNumber != SIGSTOP && signalNumber != g_wtfConfig.sigThreadSuspendResume) {
+            bool canHandle = signalNumber != SIGKILL && signalNumber != SIGSTOP && signalNumber != g_wtfConfig.sigThreadSuspendResume;
 #elif OS(DARWIN) || OS(FREEBSD)
             // these signals cannot be handled
-            if (signalNumber != SIGKILL && signalNumber != SIGSTOP) {
+            bool canHandle = signalNumber != SIGKILL && signalNumber != SIGSTOP;
 #elif OS(WINDOWS)
             // windows has no SIGSTOP
-            if (signalNumber != SIGKILL) {
+            bool canHandle = signalNumber != SIGKILL;
 #else
 #error unknown OS
 #endif
-
+            if (canHandle) {
                 if (isAdded) {
                     if (!signalToContextIdsMap->contains(signalNumber)) {
                         SignalHandleValue signal_handle = {
@@ -3137,6 +3138,39 @@ JSC_DEFINE_CUSTOM_SETTER(setProcessArgv, (JSGlobalObject * globalObject, Encoded
     JSValue value = JSValue::decode(encodedValue);
     process->setArgv(globalObject, value);
     return true;
+}
+
+// process.argv[1] is the VM's current entry point. The test runner moves the
+// entry point from file to file, so the cached array must be dropped for the
+// next file. Bun.argv reifies to the same array on first access, so repoint it
+// when it is already an own property.
+extern "C" [[ZIG_EXPORT(nothrow)]] void Bun__Process__resetArgv(Zig::GlobalObject* globalObject)
+{
+    if (!globalObject->hasProcessObject()) {
+        return;
+    }
+
+    auto& vm = JSC::getVM(globalObject);
+    auto* process = globalObject->processObject();
+    process->clearArgv();
+
+    if (!globalObject->m_bunObject.isInitialized()) {
+        return;
+    }
+    auto* bunObject = globalObject->bunObject();
+    auto argvIdentifier = JSC::Identifier::fromString(vm, "argv"_s);
+    if (!bunObject->getDirect(vm, argvIdentifier)) {
+        return;
+    }
+
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    JSValue argv = process->getArgv(globalObject);
+    if (auto* exception = scope.exception()) [[unlikely]] {
+        CLEAR_IF_EXCEPTION(scope);
+        Bun__reportError(globalObject, JSValue::encode(exception));
+        return;
+    }
+    bunObject->putDirect(vm, argvIdentifier, argv, JSC::PropertyAttribute::DontDelete | 0);
 }
 
 extern "C" EncodedJSValue Bun__Process__getExecArgv(JSGlobalObject* lexicalGlobalObject)

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -139,6 +139,10 @@ public:
     inline JSObject* bindingNatives() { return m_bindingNatives.getInitializedOnMainThread(this); }
 };
 
+// Points every existing copy of a process property (reified on process or Bun,
+// bound in node:process) at `value` after the canonical one changed.
+void repointProcessProperty(Zig::GlobalObject*, const JSC::Identifier& name, JSC::JSValue value);
+
 JSC_DECLARE_HOST_FUNCTION(Process_functionDlopen);
 
 // Routes its argument onto the uncaught-exception path. Used by the

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -139,8 +139,7 @@ public:
     inline JSObject* bindingNatives() { return m_bindingNatives.getInitializedOnMainThread(this); }
 };
 
-// Points every existing copy of a process property (reified on process or Bun,
-// bound in node:process) at `value` after the canonical one changed.
+// Points every existing copy of a process property (on process, on Bun, in node:process) at `value`.
 void repointProcessProperty(Zig::GlobalObject*, const JSC::Identifier& name, JSC::JSValue value);
 
 JSC_DECLARE_HOST_FUNCTION(Process_functionDlopen);

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -91,6 +91,7 @@ public:
 
     JSValue getArgv(JSGlobalObject* globalObject);
     void setArgv(JSGlobalObject* globalObject, JSValue argv);
+    void clearArgv() { m_argv.clear(); }
 
     JSValue getExecArgv(JSGlobalObject* globalObject);
     void setExecArgv(JSGlobalObject* globalObject, JSValue execArgv);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -959,22 +959,10 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
     auto* shared = createSharedEnvironmentVariablesMap(globalObject).getObject();
     globalObject->m_processEnvObject.set(vm, globalObject, shared);
 
-    auto envIdentifier = JSC::Identifier::fromString(vm, "env"_s);
-
-    // process.env may already be reified as an own property on the process object;
-    // overwrite it so it resolves to the shared variant.
-    if (globalObject->hasProcessObject()) {
-        JSObject* processObject = globalObject->processObject();
-        processObject->putDirect(vm, envIdentifier, shared, 0);
-    }
-
-    // Bun.env reifies to the same object at startup; repoint it too, or it keeps
-    // observing the orphaned pre-swap env and silently diverges from process.env.
-    if (globalObject->m_bunObject.isInitialized()) {
-        JSObject* bunObject = globalObject->bunObject();
-        if (bunObject->getDirect(vm, envIdentifier))
-            bunObject->putDirect(vm, envIdentifier, shared, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete);
-    }
+    // process.env, Bun.env and `import { env } from "node:process"` may already
+    // hold the orphaned pre-swap env. Point each one that exists at the shared variant.
+    repointProcessProperty(globalObject, JSC::Identifier::fromString(vm, "env"_s), shared);
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
     return store;
 }

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -959,8 +959,7 @@ RefPtr<SharedEnvStore> ensureSharedEnvStoreForWorker(Zig::GlobalObject* globalOb
     auto* shared = createSharedEnvironmentVariablesMap(globalObject).getObject();
     globalObject->m_processEnvObject.set(vm, globalObject, shared);
 
-    // process.env, Bun.env and `import { env } from "node:process"` may already
-    // hold the orphaned pre-swap env. Point each one that exists at the shared variant.
+    // process.env, Bun.env and the node:process env export may still hold the orphaned pre-swap env.
     repointProcessProperty(globalObject, JSC::Identifier::fromString(vm, "env"_s), shared);
     RETURN_IF_EXCEPTION(scope, nullptr);
 

--- a/src/jsc/bindings/ModuleLoader.h
+++ b/src/jsc/bindings/ModuleLoader.h
@@ -24,8 +24,7 @@ using namespace JSC;
 
 class JSCommonJSModule;
 
-// True once the record has run: a cyclic module evaluated without error, or a
-// synthetic module that has been linked.
+// A cyclic module evaluated without error, or a synthetic module that has been linked.
 bool isModuleEvaluated(JSC::AbstractModuleRecord*);
 
 typedef uint8_t OnLoadResultType;

--- a/src/jsc/bindings/ModuleLoader.h
+++ b/src/jsc/bindings/ModuleLoader.h
@@ -16,12 +16,17 @@ class GlobalObject;
 
 namespace JSC {
 class JSPromise;
+class AbstractModuleRecord;
 }
 
 namespace Bun {
 using namespace JSC;
 
 class JSCommonJSModule;
+
+// True once the record has run: a cyclic module evaluated without error, or a
+// synthetic module that has been linked.
+bool isModuleEvaluated(JSC::AbstractModuleRecord*);
 
 typedef uint8_t OnLoadResultType;
 const OnLoadResultType OnLoadResultTypeError = 0;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -713,7 +713,7 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__createForTestIsolation(Zig::G
     return globalObject;
 }
 
-static bool isModuleEvaluated(JSC::AbstractModuleRecord* record)
+bool Bun::isModuleEvaluated(JSC::AbstractModuleRecord* record)
 {
     if (!record)
         return false;

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1810,6 +1810,79 @@ describe("bun test", () => {
       expect(exitCode).toBe(0);
     });
   });
+
+  describe.concurrent("process.argv", () => {
+    // Each file reports what it sees next to its own path, so the assertions
+    // hold whichever file runs first.
+    const argvProbe = /* ts */ `
+      import { test } from "bun:test";
+      test("argv", () => {
+        console.log("ARGV " + JSON.stringify({
+          file: import.meta.path,
+          argv1: process.argv[1],
+          bunArgv1: Bun.argv[1],
+          same: Bun.argv === process.argv,
+        }));
+      });
+    `;
+
+    function parseProbes(stdout: string) {
+      return stdout
+        .split("\n")
+        .filter(line => line.startsWith("ARGV "))
+        .map(line => JSON.parse(line.slice("ARGV ".length)));
+    }
+
+    test("argv[1] is the current file, not the first file that read process.argv", async () => {
+      using dir = tempDir("bun-test-argv", { "a.test.ts": argvProbe, "b.test.ts": argvProbe });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "./a.test.ts", "./b.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      const probes = parseProbes(stdout);
+      expect(probes.map(p => basename(p.file)).sort()).toEqual(["a.test.ts", "b.test.ts"]);
+      for (const probe of probes) {
+        expect(probe).toEqual({ file: probe.file, argv1: probe.file, bunArgv1: probe.file, same: true });
+      }
+      expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
+    });
+
+    test("a file that replaces process.argv does not leak it into the next file", async () => {
+      using dir = tempDir("bun-test-argv-replace", {
+        "a.test.ts": /* ts */ `
+          import { test } from "bun:test";
+          test("replace", () => {
+            process.argv = ["custom", "argv"];
+            process.argv.push("--flag");
+          });
+        `,
+        "b.test.ts": argvProbe,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "./a.test.ts", "./b.test.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // Files run in argument order, so a.test.ts has replaced argv before b.test.ts reads it.
+      const [aStart, bStart] = [stderr.indexOf("a.test.ts:"), stderr.indexOf("b.test.ts:")];
+      expect(aStart).toBeGreaterThanOrEqual(0);
+      expect(aStart).toBeLessThan(bStart);
+      const probes = parseProbes(stdout);
+      expect(probes).toHaveLength(1);
+      expect(probes[0]).toEqual({ file: probes[0].file, argv1: probes[0].file, bunArgv1: probes[0].file, same: true });
+      expect(basename(probes[0].file)).toBe("b.test.ts");
+      expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
+    });
+  });
 });
 
 function createTest(input?: string | (string | { filename: string; contents: string })[], filename?: string): string {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1813,15 +1813,20 @@ describe("bun test", () => {
 
   describe.concurrent("process.argv", () => {
     // Each file reports what it sees next to its own path, so the assertions
-    // hold whichever file runs first.
+    // hold whichever file runs first. The same array is reachable as process.argv,
+    // Bun.argv, and the node:process named and namespace exports.
     const argvProbe = /* ts */ `
       import { test } from "bun:test";
+      import { argv } from "node:process";
+      import * as nodeProcess from "process";
       test("argv", () => {
         console.log("ARGV " + JSON.stringify({
           file: import.meta.path,
           argv1: process.argv[1],
           bunArgv1: Bun.argv[1],
-          same: Bun.argv === process.argv,
+          namedArgv1: argv[1],
+          namespaceArgv1: nodeProcess.argv[1],
+          same: Bun.argv === process.argv && argv === process.argv && nodeProcess.argv === process.argv,
         }));
       });
     `;
@@ -1831,6 +1836,10 @@ describe("bun test", () => {
         .split("\n")
         .filter(line => line.startsWith("ARGV "))
         .map(line => JSON.parse(line.slice("ARGV ".length)));
+    }
+
+    function expectedProbe(file: string) {
+      return { file, argv1: file, bunArgv1: file, namedArgv1: file, namespaceArgv1: file, same: true };
     }
 
     test("argv[1] is the current file, not the first file that read process.argv", async () => {
@@ -1846,7 +1855,7 @@ describe("bun test", () => {
       const probes = parseProbes(stdout);
       expect(probes.map(p => basename(p.file)).sort()).toEqual(["a.test.ts", "b.test.ts"]);
       for (const probe of probes) {
-        expect(probe).toEqual({ file: probe.file, argv1: probe.file, bunArgv1: probe.file, same: true });
+        expect(probe).toEqual(expectedProbe(probe.file));
       }
       expect(stderr).toContain("2 pass");
       expect(exitCode).toBe(0);
@@ -1877,7 +1886,7 @@ describe("bun test", () => {
       expect(aStart).toBeLessThan(bStart);
       const probes = parseProbes(stdout);
       expect(probes).toHaveLength(1);
-      expect(probes[0]).toEqual({ file: probes[0].file, argv1: probes[0].file, bunArgv1: probes[0].file, same: true });
+      expect(probes[0]).toEqual(expectedProbe(probes[0].file));
       expect(basename(probes[0].file)).toBe("b.test.ts");
       expect(stderr).toContain("2 pass");
       expect(exitCode).toBe(0);

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1814,19 +1814,19 @@ describe("bun test", () => {
   describe.concurrent("process.argv", () => {
     // Each file reports what it sees next to its own path, so the assertions
     // hold whichever file runs first. The same array is reachable as process.argv,
-    // Bun.argv, and the node:process named and namespace exports.
+    // Bun.argv, and the exports of the node:process and bun modules.
     const argvProbe = /* ts */ `
       import { test } from "bun:test";
       import { argv } from "node:process";
       import * as nodeProcess from "process";
+      import { argv as bunModuleArgv } from "bun";
       test("argv", () => {
+        const copies = [Bun.argv, argv, nodeProcess.argv, bunModuleArgv];
         console.log("ARGV " + JSON.stringify({
           file: import.meta.path,
           argv1: process.argv[1],
-          bunArgv1: Bun.argv[1],
-          namedArgv1: argv[1],
-          namespaceArgv1: nodeProcess.argv[1],
-          same: Bun.argv === process.argv && argv === process.argv && nodeProcess.argv === process.argv,
+          copies1: copies.map(copy => copy[1]),
+          same: copies.every(copy => copy === process.argv),
         }));
       });
     `;
@@ -1839,7 +1839,7 @@ describe("bun test", () => {
     }
 
     function expectedProbe(file: string) {
-      return { file, argv1: file, bunArgv1: file, namedArgv1: file, namespaceArgv1: file, same: true };
+      return { file, argv1: file, copies1: [file, file, file, file], same: true };
     }
 
     test("argv[1] is the current file, not the first file that read process.argv", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1959,6 +1959,36 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
   expect(exitCode).toBe(0);
 });
 
+// The swap has to reach every copy of process.env that already exists: Bun.env and
+// the `env` export of node:process, both of which are bound on first read.
+test("Bun.env and the node:process env export follow the SHARE_ENV swap", async () => {
+  using dir = tempDir("share-env-copies", {
+    "main.mjs": /* js */ `
+      import { env } from "node:process";
+      import { Worker, SHARE_ENV } from "node:worker_threads";
+      const before = { named: env, bun: Bun.env };
+      const worker = new Worker("process.env.FROM_WORKER = 'yes'", { eval: true, env: SHARE_ENV });
+      await new Promise((resolve, reject) => worker.on("exit", resolve).on("error", reject));
+      console.log(JSON.stringify({
+        swapped: process.env !== before.named,
+        named: env === process.env,
+        bun: Bun.env === process.env,
+        fromWorker: env.FROM_WORKER,
+      }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ swapped: true, named: true, bun: true, fromWorker: "yes" });
+  expect(exitCode).toBe(0);
+});
+
 test("terminating a worker stops the workers it spawned", async () => {
   // The leaf heartbeats to the main thread over a MessagePort routed through the
   // middle worker. Terminating the middle worker must stop the leaf, which the main

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1960,11 +1960,14 @@ test("the SHARE_ENV founding thread's process.env stays live after the swap", as
 });
 
 // The swap has to reach every copy of process.env that already exists: Bun.env and
-// the `env` export of node:process, both of which are bound on first read.
+// the `env` export of node:process, both of which are bound on first read. An
+// `import { env } from "bun"` is not one: the transpiler turns it into a
+// destructure of globalThis.Bun, a snapshot like `const { env } = Bun`.
 test("Bun.env and the node:process env export follow the SHARE_ENV swap", async () => {
   using dir = tempDir("share-env-copies", {
     "main.mjs": /* js */ `
       import { env } from "node:process";
+      import * as bunModule from "bun";
       import { Worker, SHARE_ENV } from "node:worker_threads";
       const before = { named: env, bun: Bun.env };
       const worker = new Worker("process.env.FROM_WORKER = 'yes'", { eval: true, env: SHARE_ENV });
@@ -1973,7 +1976,8 @@ test("Bun.env and the node:process env export follow the SHARE_ENV swap", async 
         swapped: process.env !== before.named,
         named: env === process.env,
         bun: Bun.env === process.env,
-        fromWorker: env.FROM_WORKER,
+        bunModule: bunModule.env === process.env,
+        fromWorker: [env.FROM_WORKER, Bun.env.FROM_WORKER],
       }));
     `,
   });
@@ -1985,7 +1989,13 @@ test("Bun.env and the node:process env export follow the SHARE_ENV swap", async 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({ swapped: true, named: true, bun: true, fromWorker: "yes" });
+  expect(JSON.parse(stdout)).toEqual({
+    swapped: true,
+    named: true,
+    bun: true,
+    bunModule: true,
+    fromWorker: ["yes", "yes"],
+  });
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
### Problem
- In a multi-file `bun test` run, later files see the path of the first file that read `process.argv` in `process.argv[1]`.
- `Process::getArgv` (`src/jsc/bindings/BunProcess.cpp:3113`) builds the array once with `argv[1] = vm.main()` and caches it in `m_argv`. `reload_entry_point_for_test_runner` (`src/jsc/VirtualMachine.rs:4880`) resets the other `main`-derived caches, not this one. `Bun.argv` and the `node:process` `argv` export alias the array.

### Fix
- Add `Bun__Process__resetArgv`, called beside the other per-file resets. It clears `m_argv`, rebuilds the array, and repoints every copy.
- `repointProcessProperty(global, name, value)` covers a reified own data property on `process` or `Bun`, and the `node:process` and `bun` module bindings through `overrideExportValue`. The `SHARE_ENV` swap in `JSEnvironmentVariableMap.cpp` had its own copy that missed the binding. It uses the helper now.
- Correct because `argv[1]` is defined as the current entry point, `--isolate` already gives each file a fresh `process` object, and every alias stays identical to `process.argv`.
- Verified: `test/cli/test/bun-test.test.ts` (2 new tests) and `worker_threads.test.ts` (1 new test), all failing on 1.4.0. Also `worker.test.ts`, `test/js/bun/test/mock/`.

### Background
- `bun test` runs all files in one process and global by default. `main` is the current entry path.
- `process.argv` is a custom accessor on the C++ `Process` object that caches the array in `m_argv`. `Bun.argv` is a `PropertyCallback`: the first read stores the result as a plain own property.
- `node:process` is a synthetic ES module with lazy exports: `import { argv }` reads `process.argv` once and keeps that value. `overrideExportValue` rewrites the binding and its namespace entry, as `mock.module` does.

<details><summary>Notes</summary>

The symptom that surfaced this: `test/js/web/workers/worker.test.ts` "argv / execArgv options" computes its expectation from `process.argv[1]` and fails when another file that read argv runs before it in the same process.

Repro on bun 1.4.0 (`a.test.ts` and `b.test.ts` each log `process.argv.slice(1)` and `Bun.main`):

```
$ bun test ./a.test.ts ./b.test.ts
A_ARGV ["/tmp/argv-repro/a.test.ts"]
B_ARGV ["/tmp/argv-repro/a.test.ts"] MAIN /tmp/argv-repro/b.test.ts
```

With the fix, `B_ARGV` is `b.test.ts`. The same holds for `Bun.argv`, `import { argv } from "node:process"`, `import * as p from "process"`, under `--rerun-each 2`, under `--isolate`, and with a `--preload` script that reads `process.argv` and `Bun.argv` before the first file. `BUN_JSC_validateExceptionChecks=1` is clean on both the test-runner path and the `SHARE_ENV` path.

Semantics chosen: each file starts with a fresh `process.argv`, so a file that assigns `process.argv = [...]` does not leak that into the next file (second new test). This matches `--isolate`, where each file gets a new `process` object, and matches `Bun.main`, whose per-file override is also dropped. Trade-off: a `--preload` script that mutates `process.argv` in place affects only the first file in default mode (preloads run once there). Under `--isolate` preloads run per file, so they are re-applied.

History. The first revision repointed only `Bun.argv`. A self-review found that `import { argv } from "node:process"` kept the first file's array, so `argv === process.argv` turned false in later files. That is what `repointProcessProperty` covers now. The first revision also declared the hook with `[[ZIG_EXPORT]]`, which needed two brace rewrites elsewhere in `BunProcess.cpp` so the codegen parser could see it. The hook is now a plain `extern "C"` with a `safe fn` in the existing block at `VirtualMachine.rs:378`, like its neighbours, and those rewrites are gone.

Imports of `"bun"` are rewritten by the transpiler to `globalThis.Bun` (`src/js_printer/lib.rs:5702`, `:2487`), so `import { argv } from "bun"` is a snapshot taken when the importing module evaluates, like `const { argv } = Bun`. A module evaluated after the reset reads the repointed `Bun.argv`. The `bun` module record is only in the registry when the loader fetches it directly, and the loop covers that case.

`process.mainModule` is the remaining `main`-derived value that can go stale across files. It is a `PropertyCallback` too, but its value (`requireMap.get(Bun.main)`) does not exist yet when the per-file reset runs, so it cannot use this mechanism. #33805 turns it into a live accessor.

Two preexisting failures in this container are unrelated: `process.test.js > process` needs `$USER`, and `process-args.test.js > args exclude run` hits its 5 s timeout under the ASAN build with or without this change. Three `worker.test.ts` "terminate() races" tests are timing-bound under the ASAN build (one runs at 4.9 s against a 5 s timeout) and fail the same way without this change.

Hand-off from another robobun session that hit the stale `argv[1]` while working on `worker.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->