### PR TITLE
install: remove every unsafe from src/install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
  "bun_output_tags",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -405,7 +405,7 @@ dependencies = [
  "bun_output_tags",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -471,7 +471,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -493,7 +493,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -776,6 +776,7 @@ dependencies = [
  "bun_core",
  "bun_semver",
  "bun_wyhash",
+ "bytemuck",
  "strum",
 ]
 
@@ -931,7 +932,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1355,6 +1356,7 @@ dependencies = [
  "bun_collections",
  "bun_core",
  "bun_wyhash",
+ "bytemuck",
 ]
 
 [[package]]
@@ -1759,6 +1761,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "byteorder"
@@ -1973,7 +1989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1996,7 +2012,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2007,7 +2023,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2028,7 +2044,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2089,7 +2105,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2110,7 +2126,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2472,7 +2488,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2531,7 +2547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2733,7 +2749,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2811,7 +2827,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2825,6 +2841,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2848,7 +2875,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2945,7 +2972,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3135,7 +3162,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3151,7 +3178,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3216,7 +3243,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -1580,6 +1580,19 @@ impl Log {
         }
     }
 
+    /// Move every message (and the counts and owned backing strings) into
+    /// `other`, leaving `self` empty.
+    pub fn transfer_to(&mut self, other: &mut Log) {
+        other.msgs.append(&mut self.msgs);
+        other.errors += self.errors;
+        other.warnings += self.warnings;
+        self.errors = 0;
+        self.warnings = 0;
+        other.owned_strings.append(&mut self.owned_strings);
+        // See `reset` — the scan cache goes with the messages.
+        self.line_column_tracker = None;
+    }
+
     pub fn append_to_with_recycled(&mut self, other: &mut Log, recycled: bool) {
         self.clone_to_with_recycled(other, recycled);
         self.msgs.clear();

--- a/src/bun_core/Progress.rs
+++ b/src/bun_core/Progress.rs
@@ -199,6 +199,9 @@ pub struct Node {
     // cli/) pass string literals; the alternative would be threading a
     // lifetime through `Node`/`Progress`.
     pub name: &'static [u8],
+    /// A name assembled at runtime (see [`Node::set_name_parts`]); shown
+    /// instead of `name` when non-empty.
+    pub name_buf: InlineName,
     pub unit: Unit,
     /// Must be handled atomically to be thread-safe.
     pub(crate) recently_updated_child: AtomicPtr<Node>,
@@ -208,12 +211,43 @@ pub struct Node {
     pub unprotected_completed_items: AtomicUsize,
 }
 
+/// Inline storage for a progress node name built from parts (emoji +
+/// package name); longer names are cut to fit.
+#[derive(Clone, Copy)]
+pub struct InlineName {
+    len: u16,
+    bytes: [u8; InlineName::CAPACITY],
+}
+
+impl InlineName {
+    pub const CAPACITY: usize = 382;
+    pub const EMPTY: InlineName = InlineName {
+        len: 0,
+        bytes: [0; InlineName::CAPACITY],
+    };
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes[..self.len as usize]
+    }
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl Default for InlineName {
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
 impl Default for Node {
     fn default() -> Self {
         Self {
             context: ptr::null_mut(),
             parent: ptr::null_mut(),
             name: b"",
+            name_buf: InlineName::EMPTY,
             unit: Unit::None,
             recently_updated_child: AtomicPtr::new(ptr::null_mut()),
             unprotected_estimated_total_items: AtomicUsize::new(0),
@@ -256,6 +290,18 @@ impl Node {
         self.parent
     }
 
+    /// Replace the displayed name with the concatenation of `parts`.
+    pub fn set_name_parts(&mut self, parts: &[&[u8]]) {
+        let mut len = 0usize;
+        for part in parts {
+            let take = part.len().min(InlineName::CAPACITY - len);
+            self.name_buf.bytes[len..len + take].copy_from_slice(&part[..take]);
+            len += take;
+        }
+        self.name_buf.len = len as u16;
+        self.name = b"";
+    }
+
     /// Create a new child progress node. Thread-safe.
     /// Call `Node.end` when done.
     /// You probably want to call `activate` on the return value.
@@ -265,6 +311,7 @@ impl Node {
             context: self.context,
             parent: std::ptr::from_mut::<Node>(self),
             name,
+            name_buf: InlineName::EMPTY,
             unit: Unit::None,
             recently_updated_child: AtomicPtr::new(ptr::null_mut()),
             unprotected_estimated_total_items: AtomicUsize::new(estimated_total_items),
@@ -369,6 +416,7 @@ impl Progress {
             context: std::ptr::from_mut::<Progress>(self),
             parent: ptr::null_mut(),
             name,
+            name_buf: InlineName::EMPTY,
             unit: Unit::None,
             recently_updated_child: AtomicPtr::new(ptr::null_mut()),
             unprotected_estimated_total_items: AtomicUsize::new(estimated_total_items),
@@ -531,7 +579,7 @@ impl Progress {
             let mut need_ellipse = false;
             let mut maybe_node: *mut Node = &raw mut self.root;
             while !maybe_node.is_null() {
-                let (name, unit, eti, completed_items);
+                let (name, name_buf, unit, eti, completed_items);
                 // SAFETY: walking the recently_updated_child chain under
                 // update_mutex; nodes are caller-owned and outlive this call
                 // per API contract. Read every field through the raw pointer
@@ -541,6 +589,7 @@ impl Progress {
                 // tag derived from it under Stacked Borrows.
                 unsafe {
                     name = (*maybe_node).name;
+                    name_buf = (*maybe_node).name_buf;
                     unit = (*maybe_node).unit;
                     eti = (*maybe_node)
                         .unprotected_estimated_total_items
@@ -551,6 +600,11 @@ impl Progress {
                     maybe_node = (*maybe_node).recently_updated_child.load(Ordering::Acquire);
                 }
                 let current_item = completed_items + 1;
+                let name: &[u8] = if name_buf.is_empty() {
+                    name
+                } else {
+                    name_buf.as_bytes()
+                };
 
                 if need_ellipse {
                     self.buf_write(&mut end, format_args!("... "));

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -717,6 +717,13 @@ pub use bun_alloc::SEP;
 pub struct PathBuffer(pub [u8; MAX_PATH_BYTES]);
 impl PathBuffer {
     pub const ZEROED: Self = Self([0; MAX_PATH_BYTES]);
+    /// View the first `MAX_PATH_BYTES` of `bytes` as a `PathBuffer`.
+    #[inline]
+    pub fn from_slice_mut(bytes: &mut [u8]) -> Option<&mut Self> {
+        let arr: &mut [u8; MAX_PATH_BYTES] = bytes.get_mut(..MAX_PATH_BYTES)?.try_into().ok()?;
+        // SAFETY: `PathBuffer` is `repr(transparent)` over `[u8; MAX_PATH_BYTES]`.
+        Some(unsafe { &mut *core::ptr::from_mut(arr).cast::<Self>() })
+    }
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
         &mut self.0

--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -564,6 +564,19 @@ impl<K, V, C, A: MapAllocator> ArrayHashMap<K, V, C, A> {
         self.drop_index();
     }
 
+    /// Resize to `n` entries, filling new slots with `key`/`value`; the
+    /// caller overwrites them (`keys_mut`/`values_mut`) and calls `re_index`.
+    pub fn resize_entries(&mut self, n: usize, key: K, value: V)
+    where
+        K: Clone,
+        V: Clone,
+    {
+        self.keys.resize(n, key);
+        self.values.resize(n, value);
+        self.hashes.resize(n, 0);
+        self.drop_index();
+    }
+
     /// Insert/replace using an externally-supplied
     /// hash/eql context instead of the stored `C`. Used when `C = AutoContext`
     /// can't satisfy `K: Hash` (e.g. `bun_semver::String`, whose hash needs the
@@ -977,6 +990,23 @@ impl<K, V, C: ArrayHashContext<K>, A: MapAllocator> ArrayHashMap<K, V, C, A> {
     pub fn get_ptr_mut(&mut self, key: &K) -> Option<&mut V> {
         let i = self.get_index(key)?;
         Some(&mut self.values[i])
+    }
+
+    /// Replace the contents with `keys`/`values` (equal lengths) and rebuild
+    /// the index.
+    pub fn set_from_slices(&mut self, keys: &[K], values: &[V]) -> Result<(), AllocError>
+    where
+        K: Clone,
+        V: Clone,
+    {
+        assert_eq!(keys.len(), values.len());
+        self.keys.clear();
+        self.values.clear();
+        self.hashes.clear();
+        self.keys.extend_from_slice(keys);
+        self.values.extend_from_slice(values);
+        self.hashes.resize(keys.len(), 0);
+        self.re_index()
     }
 
     /// Recompute every stored hash from the current keys. Call after mutating

--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -121,13 +121,13 @@ impl AnyEventLoop {
 
     /// Raw-pointer tick loop for callers whose `is_done`
     /// callback may reborrow the struct that *contains* this `AnyEventLoop`
-    /// (e.g. `bun_install::PackageManager::sleep_until`, where the closure's
-    /// `is_done` does `&mut *closure.manager` and that `PackageManager` owns
-    /// `event_loop` by value). Holding a `&mut Self` across `is_done` in that
+    /// (e.g. `bun_bundler::bundle_v2`, where `is_done` reborrows the context
+    /// that owns the loop). Holding a `&mut Self` across `is_done` in that
     /// case is UB under Stacked Borrows — the callback's whole-struct Unique
     /// retag pops the field borrow. This variant reborrows `*this`
     /// per-iteration *after* `is_done` returns, so no `&mut Self` is live
-    /// while the callback runs.
+    /// while the callback runs. Callers that can restructure should prefer
+    /// [`sleep_tick`](Self::sleep_tick) in their own loop.
     ///
     /// # Safety
     /// `this` must be valid for `&mut` access for the duration of the call,
@@ -144,19 +144,24 @@ impl AnyEventLoop {
             // SAFETY: per fn contract — reborrow strictly after `is_done`
             // returns; the borrow ends at the bottom of this loop body before
             // the next `is_done` call.
-            match unsafe { &mut *this } {
-                AnyEventLoop::Js { owner } => {
-                    owner.tick();
-                    owner.auto_tick();
-                }
-                AnyEventLoop::Mini(mini) => {
-                    // One iteration only — we cannot call the *looping*
-                    // `MiniEventLoop::tick` here because that would hold
-                    // `&mut mini` across `is_done`. A single `tick_once`
-                    // borrow ends at the bottom of this match arm before the
-                    // next `is_done` reborrow.
-                    mini.tick_once(context);
-                }
+            unsafe { &mut *this }.sleep_tick(context);
+        }
+    }
+
+    /// One iteration of the [`tick_raw`](Self::tick_raw) loop body, for
+    /// callers that own the `is_done` loop themselves (e.g.
+    /// `bun_install::PackageManager::sleep_until`). `context` is forwarded to
+    /// mini-loop tasks that carry extra context; pass null when none are queued.
+    pub fn sleep_tick(&mut self, context: *mut core::ffi::c_void) {
+        match self {
+            AnyEventLoop::Js { owner } => {
+                owner.tick();
+                owner.auto_tick();
+            }
+            AnyEventLoop::Mini(mini) => {
+                // One iteration only — the *looping* `MiniEventLoop::tick`
+                // would hold `&mut mini` across the caller's `is_done`.
+                mini.tick_once(context);
             }
         }
     }
@@ -201,6 +206,35 @@ impl AnyEventLoop {
     pub fn wakeup(&mut self) {
         // SAFETY: `r#loop()` returns a valid live loop pointer.
         unsafe { (*self.r#loop()).wakeup() };
+    }
+
+    /// A `Send + Sync` handle other threads use to wake this loop. The holder
+    /// must not outlive the loop (BACKREF): the main-thread and mini loops
+    /// live for the process/thread; a JS worker's loop until its VM is torn
+    /// down.
+    #[inline]
+    pub fn waker(&mut self) -> LoopWaker {
+        // SAFETY: `r#loop()` is this loop's live uws loop.
+        LoopWaker(bun_ptr::BackRef::new(unsafe { &*self.r#loop() }))
+    }
+}
+
+/// Cross-thread wakeup handle for an event loop's uSockets loop
+/// ([`AnyEventLoop::waker`], which states the holder's obligation).
+#[derive(Clone, Copy)]
+pub struct LoopWaker(bun_ptr::BackRef<UwsLoop>);
+
+// SAFETY: the only operation is `us_wakeup_loop`, which uSockets documents as
+// callable from any thread (it signals the loop's async wakeup handle); the
+// pointee is never otherwise read or written through this handle.
+unsafe impl Send for LoopWaker {}
+// SAFETY: as above — `wakeup(&self)` is thread-safe.
+unsafe impl Sync for LoopWaker {}
+
+impl LoopWaker {
+    #[inline]
+    pub fn wakeup(self) {
+        self.0.get().wakeup_from_any_thread();
     }
 }
 
@@ -387,6 +421,17 @@ impl EventLoopHandle {
     pub fn set_as_parent_of(self, uws_loop: &mut UwsLoop) {
         let (tag, ptr) = self.into_tag_ptr();
         uws_loop.internal_loop_data.set_parent_raw(tag, ptr);
+    }
+
+    /// [`set_as_parent_of`](Self::set_as_parent_of) this handle's own uws
+    /// loop ([`EventLoopHandle::r#loop`]).
+    #[inline]
+    pub fn set_as_parent_of_own_loop(self) {
+        let uws_loop = self.r#loop();
+        // SAFETY: `r#loop()` is this handle's live uws loop (per-thread
+        // singleton for mini loops, VM-lifetime for JS loops); the write is a
+        // plain field store on the owning thread.
+        self.set_as_parent_of(unsafe { &mut *uws_loop });
     }
 
     pub fn from_any(any: &mut AnyEventLoop) -> EventLoopHandle {

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -36,7 +36,7 @@ pub use ConcurrentTask::{Task, TaskTag, Taskable, task_tag};
 pub use DeferredTaskQueue as deferred_task_queue;
 
 pub use any_event_loop::{
-    AnyEventLoop, EventLoopHandle, EventLoopTask, JsPoster, JsPosterVTable, Posted,
+    AnyEventLoop, EventLoopHandle, EventLoopTask, JsPoster, JsPosterVTable, LoopWaker, Posted,
 };
 pub use bun_io::PipeReadScratch;
 

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -51,9 +51,111 @@ pub struct AsyncHTTP<'a> {
     pub elapsed: u64,
 
     pub(crate) signals: Signals,
+
+    /// Buffers `url` / `client.header_buf` / `client.http_proxy` may borrow
+    /// from when the request was built with [`OwnedRequest::new`].
+    /// Declared last so it is dropped after every field that points into it.
+    owned: OwnedRequestBuffers,
 }
 
 bun_threading::intrusive_work_task!(['a] AsyncHTTP<'a>, task);
+
+/// Backing storage for a request that owns the bytes its URL, header block
+/// and proxy URL are parsed from (see [`OwnedRequest::new`]).
+#[derive(Default)]
+pub struct OwnedRequestBuffers {
+    pub url: Box<[u8]>,
+    pub headers: Box<[u8]>,
+    pub proxy_url: Option<Box<[u8]>>,
+}
+
+/// A request that owns the bytes its URL, header block and proxy URL are
+/// parsed from. The [`AsyncHTTP`] inside borrows them, so it is only reachable
+/// through accessors whose borrows end with `&self`; it is scheduled with
+/// [`crate::schedule_owned_request`].
+pub struct OwnedRequest {
+    http: AsyncHTTP<'static>,
+}
+
+impl OwnedRequest {
+    /// [`AsyncHTTP::init`] over `buffers`. `if_modified_since` is a range of
+    /// `buffers.headers`.
+    pub fn new(
+        buffers: OwnedRequestBuffers,
+        method: Method,
+        headers: headers::EntryList,
+        static_headers_buf: Option<&'static [u8]>,
+        redirect_type: FetchRedirect,
+        mut options: Options<'static>,
+        if_modified_since: Option<core::ops::Range<usize>>,
+    ) -> OwnedRequest {
+        // SAFETY: the boxed bytes are moved into `http.owned` below and are
+        // neither replaced nor freed while `http` is alive (this type keeps it
+        // private, and every accessor rebinds borrows to `&self`); a
+        // `Box<[u8]>`'s heap bytes do not move when the box does.
+        let (url_buf, headers_buf, proxy_buf): (
+            &'static [u8],
+            &'static [u8],
+            Option<&'static [u8]>,
+        ) = unsafe {
+            (
+                bun_ptr::detach_lifetime(&buffers.url),
+                bun_ptr::detach_lifetime(&buffers.headers),
+                buffers
+                    .proxy_url
+                    .as_deref()
+                    .map(|p| bun_ptr::detach_lifetime(p)),
+            )
+        };
+        let url = URL::parse(url_buf);
+        if let Some(proxy) = proxy_buf {
+            options.http_proxy = Some(URL::parse(proxy));
+        }
+        let mut http = AsyncHTTP::init(
+            method,
+            url,
+            headers,
+            static_headers_buf.unwrap_or(headers_buf),
+            b"",
+            noop_callback(),
+            redirect_type,
+            options,
+        );
+        if let Some(range) = if_modified_since {
+            http.client.if_modified_since = &headers_buf[range];
+        }
+        http.owned = buffers;
+        OwnedRequest { http }
+    }
+
+    /// The URL bytes the request was built from.
+    #[inline]
+    pub fn url(&self) -> &[u8] {
+        &self.http.owned.url
+    }
+
+    /// Nanoseconds the request took (once it has finished).
+    #[inline]
+    pub fn elapsed(&self) -> u64 {
+        self.http.elapsed
+    }
+
+    #[inline]
+    pub fn client_flags_mut(&mut self) -> &mut crate::Flags {
+        &mut self.http.client.flags
+    }
+
+    #[inline]
+    pub fn set_verbose(&mut self, verbose: crate::HTTPVerboseLevel) {
+        self.http.client.verbose = verbose;
+    }
+
+    /// Point the result callback at `ctx` and add the request to `batch`.
+    pub(crate) fn schedule_with(&mut self, callback: HTTPClientResultCallback, batch: &mut Batch) {
+        self.http.result_callback = callback;
+        self.http.schedule(batch);
+    }
+}
 
 // SAFETY: `next` is the sole intrusive link for `UnboundedQueue(AsyncHTTP, .next)`.
 // Only implemented for the lifetime-erased form — the queue is heterogeneous
@@ -454,6 +556,7 @@ impl<'a> AsyncHTTP<'a> {
             async_http_id,
             elapsed: 0,
             signals,
+            owned: OwnedRequestBuffers::default(),
         };
         if let Some(val) = options.unix_socket_path {
             this.client.unix_socket_path = val;
@@ -597,7 +700,7 @@ fn send_sync_callback(
     // `read_item`.
     unsafe {
         result.body_into(&mut (*(*this).response_buffer).list);
-        (*this).write_item(result.detach_lifetime());
+        (*this).write_item(result.without_body());
     }
 }
 

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -49,7 +49,7 @@ pub mod thread_safe_stream_buffer;
 pub mod websocket;
 
 // ── crate-root re-exports ──
-pub use async_http::AsyncHTTP;
+pub use async_http::{AsyncHTTP, OwnedRequest, OwnedRequestBuffers};
 pub use certificate_info::CertificateInfo;
 pub use decompressor::Decompressor;
 pub use header_builder::HeaderBuilder;
@@ -516,16 +516,10 @@ impl<'a> HTTPClientResult<'a> {
         }
     }
 
-    /// Widen the borrow to `'static` for self-referential storage.
-    ///
-    /// `body` is the only lifetime-carrying field; it borrows the HTTP
-    /// thread's `decoded_body` scratch buffer, which is cleared immediately
-    /// after the callback returns, so the stored form carries `body: &[]`.
-    ///
-    /// # Safety
-    /// Caller must not read `.body` from the returned value.
+    /// This result without the borrowed `body` (see [`body_into`](Self::body_into)
+    /// for taking the bytes first), so it can be stored.
     #[inline]
-    pub unsafe fn detach_lifetime(self) -> HTTPClientResult<'static> {
+    pub fn without_body(self) -> HTTPClientResult<'static> {
         HTTPClientResult {
             body: &[],
             body_owned: self.body_owned,
@@ -594,6 +588,76 @@ impl HTTPClientResultCallback {
         cb.release_at_shutdown = Some(release);
         cb
     }
+}
+
+/// A request context that is boxed on the scheduling thread, owned by the
+/// HTTP thread while the request is in flight, and handed back with the
+/// terminal result. `request_mut` is the [`OwnedRequest`] it embeds.
+pub trait OwnedRequestContext: HttpThreadContext + Sized + 'static {
+    fn request_mut(&mut self) -> &mut OwnedRequest;
+    /// A non-terminal result (`result.has_more`); runs on the HTTP thread.
+    fn on_progress(&mut self, result: HTTPClientResult<'_>);
+    /// The terminal result; runs on the HTTP thread. The request already
+    /// holds its final state.
+    fn on_done(self: Box<Self>, result: HTTPClientResult<'_>);
+}
+
+/// Marker: the type's [`OwnedRequestContext`] callbacks run on the HTTP
+/// thread, so everything they touch is theirs alone or synchronized.
+///
+/// # Safety
+/// That claim; implement through [`http_thread_context!`], which states it
+/// at the type.
+pub unsafe trait HttpThreadContext {}
+
+/// Implements [`HttpThreadContext`]: the type's request callbacks
+/// (`on_progress`/`on_done`) are its HTTP-thread entry points and only touch
+/// state that is theirs alone or synchronized with other threads.
+#[macro_export]
+macro_rules! http_thread_context {
+    ($ty:ty) => {
+        // SAFETY: see the macro doc.
+        unsafe impl $crate::HttpThreadContext for $ty {}
+    };
+}
+
+/// Hand `ctx` to the HTTP thread: its request's result callback is pointed
+/// at `ctx` and the request is added to `batch` (see `HTTPThread::schedule`).
+pub fn schedule_owned_request<T: OwnedRequestContext>(
+    ctx: Box<T>,
+    batch: &mut bun_threading::thread_pool::Batch,
+) {
+    let raw = Box::into_raw(ctx);
+    // SAFETY: `raw` was just leaked and is not shared until `batch` runs.
+    let request = unsafe { (*raw).request_mut() };
+    request.schedule_with(
+        HTTPClientResultCallback::new::<T>(raw, owned_request_callback::<T>),
+        batch,
+    );
+}
+
+fn owned_request_callback<T: OwnedRequestContext>(
+    ctx: *mut T,
+    async_http: *mut AsyncHTTP<'static>,
+    result: HTTPClientResult<'_>,
+) {
+    if result.has_more {
+        // SAFETY: `ctx` is the box `schedule_owned_request` leaked; the HTTP
+        // thread is its only user until the terminal callback.
+        unsafe { &mut *ctx }.on_progress(result);
+        return;
+    }
+    // SAFETY: `async_http` is the HTTP thread's bitwise copy of the request
+    // `schedule_owned_request` scheduled, and `real` points back at that
+    // request (inside `*ctx`, so still alive); its final state goes back the
+    // same way, and the thread frees its copy without dropping it.
+    unsafe {
+        let real = (*async_http).real.expect("set by the HTTP thread");
+        core::ptr::write(real.as_ptr(), core::ptr::read(async_http));
+    }
+    // SAFETY: as above; the terminal callback hands the box back.
+    let ctx = unsafe { Box::from_raw(ctx) };
+    ctx.on_done(result);
 }
 
 // Exists for heap stats reasons.

--- a/src/install/Cargo.toml
+++ b/src/install/Cargo.toml
@@ -17,7 +17,7 @@ shim_standalone = []
 workspace = true
 
 [dependencies]
-bytemuck = "1"
+bytemuck = { version = "1", features = ["derive"] }
 strum.workspace = true
 thiserror.workspace = true
 bstr.workspace = true

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -1,21 +1,20 @@
-use core::mem::MaybeUninit;
-use core::ptr::{self, NonNull};
+use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use crate::bun_fs::{FileSystem, FilenameStore};
 use bun_collections::HashMap;
 use bun_core::{self, fmt::quote};
 use bun_core::{MutableString, strings};
 use bun_http::{
-    self as http, AsyncHTTP, HTTPClientResult, HTTPClientResultCallback, HTTPVerboseLevel,
-    HeaderBuilder, async_http::Options as AsyncHTTPOptions,
+    self as http, HTTPClientResult, HTTPVerboseLevel, HeaderBuilder, OwnedRequestBuffers,
+    async_http::Options as AsyncHTTPOptions,
 };
-use bun_threading::thread_pool::Batch;
 use bun_url::URL;
 
 use crate::extract_tarball;
 use crate::npm::{self as npm, PackageManifest};
-use crate::{ExtractTarball, PackageManager, PatchTask, TarballStream, Task};
+use crate::{ExtractTarball, PackageManager, TarballStream, Task};
 
 // Adapter so `StringOrTinyString::init_append_if_needed` can intern overflow
 // names into the resolver's filename arena. The bun_sys-level `FilenameStore` exposes `append` /
@@ -38,73 +37,41 @@ pub(crate) fn filename_store_appender() -> FilenameStoreAppender<'static> {
 }
 
 pub struct NetworkTask {
-    // Self-referential: borrows `url_buf` / `header_buf` owned by
-    // sibling fields, so the lifetime is erased to `'static`.
-    // `MaybeUninit` because the slot comes from `HiveArrayFallback`
-    // as *uninitialized* memory (often zero-page on first mmap, but not
-    // guaranteed — `claim()`'s heap fallback is `Box::new_uninit()`) and is
-    // overwritten by plain `=` in `for_manifest`/`for_tarball`.
-    // `MaybeUninit<T>` is the spec-correct mapping for that semantic — unlike
-    // `ManuallyDrop<T>`, it suppresses `T`'s validity invariant, so
-    // materializing `&mut NetworkTask` after `write_init` (which leaves this
-    // field bitwise-untouched) is sound even though `AsyncHTTP` contains
-    // niche-bearing fields (`Decompressor` enum, `Option<NonNull>`). The
-    // HTTP-thread bitwise copy in `notify`
-    // (`ptr::write(real, ptr::read(async_http))`) targets the inner `AsyncHTTP`
-    // directly via `*mut AsyncHTTP`, which is sound because `MaybeUninit<T>`
-    // is `#[repr(transparent)]`.
-    pub(crate) unsafe_http_client: MaybeUninit<AsyncHTTP<'static>>,
+    /// The request; it owns the URL and header buffers it points into.
+    /// `None` until `for_manifest`/`for_tarball` builds it.
+    pub(crate) http: Option<http::OwnedRequest>,
     pub(crate) response: HTTPClientResult<'static>,
     pub(crate) task_id: crate::package_manager_task::Id,
-    // Owned in both `for_manifest` (toOwnedSlice) and `for_tarball`. Aliasing
-    // `tarball.url` in the latter would be a self-reference
-    // into `callback`; owning avoids that at the cost of one copy per tarball download.
-    pub(crate) url_buf: Box<[u8]>,
-    pub(crate) header_buf: Box<[u8]>,
     pub(crate) retried: u16,
     pub(crate) response_buffer: MutableString,
-    // BACKREF: PackageManager owns this task via `preallocated_network_tasks`.
-    // ParentRef constructed via `from_raw_mut` so `assume_mut` retains write
-    // provenance for `for_manifest`/`for_tarball` (which call `pm.log_mut()`).
-    pub(crate) package_manager: bun_ptr::ParentRef<PackageManager, bun_ptr::Mut>,
+    /// Read-only on the HTTP thread (`shared`); the manager is leaked for the
+    /// process and outlives every task.
+    pub(crate) package_manager: bun_ptr::BackRef<PackageManager>,
     pub(crate) callback: Callback,
-    /// Key in patchedDependencies in package.json
-    // `'static` because NetworkTask is stored lifetime-less in
-    // `PreallocatedNetworkTasks`; PatchTask's `'a` is a BACKREF on
-    pub(crate) apply_patch_task: Option<Box<PatchTask>>,
     pub(crate) next: bun_threading::Link<NetworkTask>,
 
     /// Producer/consumer buffer that feeds tarball bytes from the HTTP thread
     /// to a worker running libarchive. `None` when streaming extraction is
-    /// disabled or this task is not a tarball download.
-    pub(crate) tarball_stream: Option<Box<TarballStream>>,
-    /// Extract `Task` pre-created on the main thread so the HTTP thread can
-    /// schedule it on the worker pool as soon as the first body chunk arrives.
-    // `'static` matches `PreallocatedTaskStore =
-    // HiveArrayFallback<Task<'static>, 64>` which this slot is borrowed from
-    // and returned to (`discard_unused_streaming_state`).
-    pub(crate) streaming_extract_task: *mut Task<'static>,
+    /// disabled or this task is not a tarball download. Shared with the
+    /// worker draining it; the stream owns the extract `Task` that carries
+    /// the result (and eventually this network task) back to the main thread.
+    pub(crate) tarball_stream: Option<Arc<TarballStream>>,
+    /// The pre-created extract `Task` between a streamed attempt that failed
+    /// mid-body and its retry (`reset_streaming_for_retry` builds a new
+    /// stream around it).
+    pub(crate) streaming_extract_task: Option<Box<Task>>,
     /// Set by the HTTP thread the first time it commits this request to
-    /// the streaming path. Once true, `notify` never pushes this task to
-    /// `async_network_task_queue` — the extract Task published by
-    /// `TarballStream.finish()` owns the NetworkTask's lifetime instead
-    /// (its `resolve_tasks` handler returns it to the pool). Also read by
-    /// the main-thread fallback / retry paths in `run_tasks` to assert
+    /// the streaming path. Once true, the terminal callback hands this task
+    /// to the stream instead of `async_network_task_queue` — the extract Task
+    /// published by `TarballStream::finish()` owns it from then on. Also read
+    /// by the main-thread fallback / retry paths in `run_tasks` to assert
     /// the stream was never started.
     pub(crate) streaming_committed: bool,
     /// Backing store for the streaming signal the HTTP client polls.
     pub(crate) signal_store: http::signals::Store,
 }
 
-// SAFETY: `next` is the sole intrusive link and is only ever read/written via
-// these accessors by `UnboundedQueue<NetworkTask>`.
-unsafe impl bun_threading::Linked for NetworkTask {
-    #[inline]
-    unsafe fn link(item: *mut Self) -> *const bun_threading::Link<Self> {
-        // SAFETY: `item` is valid and properly aligned per `UnboundedQueue` contract.
-        unsafe { core::ptr::addr_of!((*item).next) }
-    }
-}
+bun_threading::intrusive_linked!(NetworkTask, next);
 
 /// The network-backed subset of `crate::package_manager_task::Tag` (git
 /// clone/checkout run as thread-pool tasks, never as network tasks).
@@ -143,227 +110,153 @@ pub(crate) type DedupeMap = HashMap<
 >;
 
 impl NetworkTask {
-    /// Access the HTTP client after `for_manifest`/`for_tarball` (or `notify`'s
-    /// bitwise copy) has initialized it. The field is `MaybeUninit` only to keep
-    /// `&mut NetworkTask` sound between `write_init` and the `for_*` overwrite.
+    /// The HTTP client, once `for_manifest`/`for_tarball` has built it.
     #[inline]
-    pub(crate) fn http_mut(&mut self) -> &mut AsyncHTTP<'static> {
-        // SAFETY: every caller is reached only after `unsafe_http_client` was
-        // populated via `MaybeUninit::new(AsyncHTTP::init(..))` (or the
-        // `ptr::write(real, ..)` in `notify`).
-        unsafe { self.unsafe_http_client.assume_init_mut() }
+    pub(crate) fn http_mut(&mut self) -> &mut http::OwnedRequest {
+        self.http.as_mut().expect("NetworkTask request built")
+    }
+    #[inline]
+    pub(crate) fn http(&self) -> &http::OwnedRequest {
+        self.http.as_ref().expect("NetworkTask request built")
+    }
+    /// The URL this task was built for.
+    #[inline]
+    pub(crate) fn url_buf(&self) -> &[u8] {
+        self.http().url()
     }
 
-    /// BACKREF accessor — single `unsafe` deref for the set-once
-    /// `package_manager` `ParentRef` so `for_manifest`/`for_tarball` call
-    /// sites are safe. Lifetime is decoupled from `&self` (the manager is the
-    /// process singleton that owns this task and outlives it).
-    ///
-    /// # Safety (encapsulated)
-    /// `package_manager` is constructed via `ParentRef::from_raw_mut` (write
-    /// provenance) in `write_init`; the `for_*` builders run on the
-    /// single-threaded main setup path, so no overlapping `&mut
-    /// PackageManager` exists for the returned borrow.
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn pm_mut<'a>(&self) -> &'a mut PackageManager {
-        // SAFETY: see fn doc — BACKREF, write provenance, single-threaded.
-        unsafe { self.package_manager.assume_mut() }
+    pub(crate) fn new(
+        task_id: crate::package_manager_task::Id,
+        package_manager: &PackageManager,
+    ) -> Box<NetworkTask> {
+        Box::new(NetworkTask {
+            http: None,
+            response: HTTPClientResult::default(),
+            task_id,
+            retried: 0,
+            response_buffer: MutableString::init_empty(),
+            package_manager: bun_ptr::BackRef::new(package_manager),
+            callback: Callback::LocalTarball,
+            next: bun_threading::Link::new(),
+            tarball_stream: None,
+            streaming_extract_task: None,
+            streaming_committed: false,
+            signal_store: http::signals::Store::default(),
+        })
+    }
+}
+
+bun_http::http_thread_context!(NetworkTask);
+
+/// The HTTP thread owns a `NetworkTask` while its request is in flight
+/// (`PackageManager::flush_network_queue` → `bun_http::schedule_owned_request`)
+/// and hands it back through here.
+impl http::OwnedRequestContext for NetworkTask {
+    fn request_mut(&mut self) -> &mut http::OwnedRequest {
+        self.http_mut()
     }
 
-    // Signature matches `HTTPClientResultCallback::new::<NetworkTask>`'s
-    // `fn(*mut T, *mut AsyncHTTP, HTTPClientResult<'_>)` shape so it can be
-    // installed directly without a separate trampoline.
-    fn notify(
-        this: *mut NetworkTask,
-        async_http: *mut AsyncHTTP<'static>,
-        mut result: HTTPClientResult<'_>,
-    ) {
-        // `this` is the NetworkTask erased into the callback ctx in
-        // `get_completion_callback`; the HTTP thread is the sole writer for
-        // this call. It stays a raw receiver: both exits below (`on_chunk(..,
-        // true, ..)` and the queue push) hand `this` to another thread, so no
-        // `&mut NetworkTask` may outlive them and every pointer handed off is
-        // derived from the raw `this`.
-        //
-        // SAFETY: `async_http` is the threadlocal AsyncHTTP the HTTP client
-        // passes to every completion callback; live for this call.
-        let async_http = unsafe { &mut *async_http };
-        // SAFETY: `this` is live (see above). `on_chunk` takes `*mut Self`
-        // (freely-aliasing) because a worker may be inside `drain()`
-        // concurrently, so `stream` is a raw pointer, never `&mut TarballStream`.
-        // SAFETY: `this` is live and non-null (raw receiver from the completion callback).
-        let stream =
-            unsafe { (*this).tarball_stream.as_deref_mut() }.map(ptr::from_mut::<TarballStream>);
-        if let Some(stream) = stream {
-            // Runs on the HTTP thread. With response-body streaming enabled,
-            // `notify` is called once per body chunk (has_more=true) and once
-            // more at the end (has_more=false). `result.body` borrows the
-            // HTTP client's scratch buffer and is cleared after this callback
-            // returns, so we must consume it before returning.
-
-            // `metadata` is only populated on the first callback that
-            // carries response headers. Cache the status code so both the
-            // main thread and later chunk callbacks can see it.
-            if let Some(m) = result.metadata.take() {
-                // SAFETY: `stream` is the live heap-allocated `TarballStream`.
-                unsafe {
-                    (*stream).status_code = m.response.status_code;
-                    if let http::BodySize::ContentLength(len) = result.body_size {
-                        (*stream).content_length = Some(len);
-                    }
-                }
-                // New attempt's headers arrived — drop any bytes buffered from
-                // a prior failed attempt (pre-refactor `HTTPClient::start()`
-                // did this via `body_out_str.reset()`).
-                // SAFETY: `this` is live; the HTTP thread is its sole writer here.
-                unsafe {
-                    (*this).response.metadata = Some(m);
-                    (*this).response_buffer.reset();
-                }
+    /// A body chunk of a streamed tarball download (`has_more`). Only
+    /// requests built with the `response_body_streaming` signal get these.
+    /// `result.body` borrows the HTTP client's scratch buffer and is cleared
+    /// after this returns, so it is consumed here.
+    fn on_progress(&mut self, mut result: HTTPClientResult<'_>) {
+        let Some(stream) = self.tarball_stream.clone() else {
+            self.stash_body(&mut result);
+            return;
+        };
+        self.record_streaming_head(&stream, &mut result);
+        let chunk = result.body_bytes();
+        if self.streaming_committed || self.can_stream(&stream, &result) {
+            if !chunk.is_empty() {
+                // The drain task is scheduled by `on_chunk` (guarded by its own
+                // `draining` atomic) so it runs at most once at a time, releases
+                // the worker on ARCHIVE_RETRY, and is re-enqueued by the next
+                // chunk. Pending-task accounting stays balanced:
+                // `TarballStream::finish()` publishes exactly one of the extract
+                // Task (to `resolve_tasks`) or, when the connection failed
+                // mid-body, this NetworkTask (to `async_network_task_queue`).
+                self.streaming_committed = true;
+                stream.on_chunk(chunk);
             }
+            return;
+        }
+        // Non-2xx response (or too small to stream) still delivering its body:
+        // accumulate in `response_buffer` so the main thread can inspect it.
+        self.response_buffer.list.extend_from_slice(chunk);
+    }
 
-            let chunk = result.body_bytes();
-
-            // Only commit to streaming extraction once we've seen a 2xx
-            // status *and* the tarball is large enough to be worth the
-            // overhead. For small bodies, or any 4xx/5xx / transport error,
-            // fall back to the buffered path so the existing retry and
-            // error-reporting code in `run_tasks` keeps working.
-            // SAFETY: raw-ptr field reads on the live `stream`/`this`.
-            let status_code = unsafe { (*stream).status_code };
-            let ok_status = status_code >= 200 && status_code <= 299;
-            let big_enough = match result.body_size {
-                http::BodySize::ContentLength(len) => len >= TarballStream::min_size(),
-                // No Content-Length (chunked encoding): we can't know up
-                // front, so stream — it avoids an unbounded buffer.
-                _ => true,
-            };
-            // SAFETY: `this` is live; the HTTP thread is its sole writer here.
-            let committed = unsafe { (*this).streaming_committed };
-
-            if committed || (ok_status && big_enough && result.fail.is_none()) {
-                if result.has_more {
-                    if !chunk.is_empty() {
-                        // The drain task is scheduled by `on_chunk`
-                        // (guarded by its own `draining` atomic) so it
-                        // runs at most once at a time, releases the
-                        // worker on ARCHIVE_RETRY, and is re-enqueued by
-                        // the next chunk. Pending-task accounting stays
-                        // balanced: `TarballStream.finish()` publishes
-                        // exactly one of the extract Task (to
-                        // `resolve_tasks`) or, when the connection failed
-                        // mid-body, this NetworkTask (to
-                        // `async_network_task_queue`).
-                        // SAFETY: `this` is live; the HTTP thread is its sole writer here.
-                        unsafe { (*this).streaming_committed = true };
-                        // SAFETY: `stream` is the live heap-allocated
-                        // `TarballStream` owned by this task.
-                        unsafe { TarballStream::on_chunk(stream, chunk, false, None) };
-                    }
-                    return;
-                }
-
-                // Final callback. If we've already started streaming, hand
-                // over the last bytes and close; the drain task will run
-                // once more, finish up and push to `resolve_tasks`. If not
-                // (whole body arrived in one go, or too small), fall through
-                // so the buffered extractor handles it.
-                if committed {
-                    // SAFETY: see the `on_chunk` call above — `stream` is
-                    // live and `on_chunk` takes `*mut Self` per its
-                    // freely-aliasing contract.
-                    unsafe {
-                        TarballStream::on_chunk(
-                            stream,
-                            chunk,
-                            true,
-                            result.fail.map(crate::Error::from),
-                        )
-                    };
-                    // Do NOT touch `this` — or anything it owns — after
-                    // this point: `on_chunk(…, true, …)` sets `closed` and
-                    // schedules a drain that may reach `finish()` on a
-                    // worker thread before we return here. `finish()`
-                    // frees `response_buffer`, publishes the extract Task
-                    // to `resolve_tasks`, and the main thread's processing
-                    // of that Task returns this NetworkTask to
-                    // `preallocated_network_tasks` (poisoning it under
-                    // ASAN). The NetworkTask is therefore *not* pushed to
-                    // `async_network_task_queue` here; the extract Task
-                    // owns its lifetime from now on.
-                    return;
-                }
-            } else if result.has_more {
-                // Non-2xx response (or too small to stream) still
-                // delivering its body: accumulate in `response_buffer` so
-                // the main thread can inspect it. Do not enqueue until the
-                // stream ends.
-                // SAFETY: `this` is live; the HTTP thread is its sole writer here.
-                unsafe { (*this).response_buffer.list.extend_from_slice(chunk) };
+    fn on_done(mut self: Box<Self>, mut result: HTTPClientResult<'_>) {
+        if let Some(stream) = self.tarball_stream.clone() {
+            self.record_streaming_head(&stream, &mut result);
+            if self.streaming_committed {
+                // Hand over the last bytes and ourselves; the drain task runs
+                // once more, finishes up and publishes the extract Task (which
+                // then owns this network task) to `resolve_tasks`.
+                let err = result.fail.map(crate::Error::from);
+                TarballStream::on_last_chunk(stream, self, result.body_bytes(), err);
                 return;
             }
-            // Fall through to the normal completion path for anything that
-            // did not commit: the buffered extractor / retry logic in
-            // `run_tasks` handles it exactly as it would without
-            // streaming support.
+            // Whole body arrived in one go, too small, or an error status:
+            // the buffered extractor / retry logic in `run_tasks` handles it
+            // exactly as it would without streaming support.
         }
 
-        // Stash this callback's body bytes into our own accumulation buffer
-        // before `detach_lifetime` clears `result.body` to `&[]`. Covers the
-        // non-streaming manifest path and the tarball fall-through above.
+        self.stash_body(&mut result);
+        // Metadata captured on an earlier streaming callback; the final
+        // `result` won't have it.
+        let saved_metadata = self.response.metadata.take();
+        self.response = result.without_body();
+        if self.response.metadata.is_none() {
+            self.response.metadata = saved_metadata;
+        }
+        let shared = self.package_manager.get().shared;
+        shared.async_network_task_queue.push(self);
+        shared.wake();
+    }
+}
+
+impl NetworkTask {
+    /// Move this callback's body bytes into `response_buffer`.
+    fn stash_body(&mut self, result: &mut HTTPClientResult<'_>) {
         if result.metadata.is_some() {
-            // First callback of a fresh attempt on the non-streaming path —
-            // clear stale bytes from a prior retry. The streaming fall-through
-            // already `.take()`d metadata and reset above, so this is a no-op
-            // there and accumulated chunks are preserved.
-            // SAFETY: `this` is live; the HTTP thread is its sole writer here.
-            unsafe { (*this).response_buffer.reset() };
+            // First callback of a fresh attempt — clear stale bytes from a
+            // prior retry.
+            self.response_buffer.reset();
         }
-        // SAFETY: `this` is live; the HTTP thread is its sole writer here.
-        unsafe { result.body_into(&mut (*this).response_buffer.list) };
+        result.body_into(&mut self.response_buffer.list);
+    }
 
-        // BACKREF — PackageManager owns this task and outlives it. `notify`
-        // runs on the HTTP thread, so we never materialize a `&mut
-        // PackageManager` here (the main thread may hold one concurrently);
-        // field access goes through `addr_of!` and the cross-thread
-        // `wake_raw` path, mirroring `TarballStream::finish` /
-        // `isolated_install::Installer::Task::callback`.
-        //
-        // SAFETY: `this` is live and non-null; `package_manager` is the
-        // owning-manager BACKREF, valid for the task's lifetime.
-        let pm = unsafe { (*this).package_manager.as_mut_ptr() };
-        // SAFETY: `this` is non-null (raw receiver from the callback).
-        let this_ptr = unsafe { ptr::NonNull::new_unchecked(this) };
-        // The wake happens at the end of the fn (no
-        // early returns past this point).
+    /// `metadata` is only populated on the first callback that carries
+    /// response headers; keep the status code for later chunk callbacks.
+    fn record_streaming_head(&mut self, stream: &TarballStream, result: &mut HTTPClientResult<'_>) {
+        if let Some(m) = result.metadata.take() {
+            let content_length = match result.body_size {
+                http::BodySize::ContentLength(len) => Some(len),
+                _ => None,
+            };
+            stream.set_response_head(m.response.status_code, content_length);
+            // New attempt's headers arrived — drop any bytes buffered from a
+            // prior failed attempt.
+            self.response.metadata = Some(m);
+            self.response_buffer.reset();
+        }
+    }
 
-        // SAFETY: `real` is set by the HTTP thread before invoking the
-        // completion callback.
-        unsafe {
-            let real = async_http.real.expect("unreachable").as_ptr();
-            ptr::write(real, ptr::read(async_http));
-        }
-        // SAFETY: the HTTP thread is the sole writer for this call; nothing
-        // exclusive to `*this` outlives this block, which ends before the
-        // cross-thread push below. `detach_lifetime` erases the callback-scoped
-        // `'_` to `'static` and clears `body` to `&[]`; the body bytes were
-        // stashed into `(*this).response_buffer` above.
-        unsafe {
-            // Preserve metadata captured on an earlier streaming callback; the
-            // final `result` won't have it.
-            let saved_metadata = (*this).response.metadata.take();
-            (*this).response = result.detach_lifetime();
-            if (*this).response.metadata.is_none() {
-                (*this).response.metadata = saved_metadata;
-            }
-        }
-        // SAFETY: `pm` is a live BACKREF; `async_network_task_queue` is
-        // internally synchronized (`UnboundedQueue::push` takes `&self`).
-        unsafe {
-            (*ptr::addr_of!((*pm).async_network_task_queue)).push(this_ptr);
-            PackageManager::wake_raw(pm);
-        }
+    /// Only commit to streaming extraction once we've seen a 2xx status *and*
+    /// the tarball is large enough to be worth the overhead. For small bodies,
+    /// or any 4xx/5xx / transport error, the buffered path keeps the existing
+    /// retry and error-reporting code in `run_tasks` working.
+    fn can_stream(&self, stream: &TarballStream, result: &HTTPClientResult<'_>) -> bool {
+        let status_code = stream.status_code();
+        let ok_status = (200..=299).contains(&status_code);
+        let big_enough = match result.body_size {
+            http::BodySize::ContentLength(len) => len >= TarballStream::min_size(),
+            // No Content-Length (chunked encoding): we can't know up front, so
+            // stream — it avoids an unbounded buffer.
+            _ => true,
+        };
+        ok_status && big_enough && result.fail.is_none()
     }
 }
 
@@ -466,18 +359,15 @@ impl bun_core::output::ErrName for ForManifestError {
 impl NetworkTask {
     pub(crate) fn for_manifest(
         &mut self,
+        log: &mut bun_ast::Log,
+        env: &bun_dotenv::Loader,
         name: &[u8],
         scope: &npm::registry::Scope,
         loaded_manifest: Option<&PackageManifest>,
         is_optional: bool,
         needs_extended: bool,
     ) -> Result<(), ForManifestError> {
-        let pm = self.pm_mut();
-        // SAFETY: `pm.log` is the long-lived `*mut Log` the package manager
-        // was constructed with.
-        let log = pm.log_mut();
-
-        self.url_buf = 'blk: {
+        let url_buf: Box<[u8]> = 'blk: {
             // Not all registries support scoped package names when fetching the manifest.
             // registry.npmjs.org supports both "@storybook%2Faddons" and "@storybook/addons"
             // Other registries like AWS codeartifact only support the former.
@@ -606,14 +496,18 @@ impl NetworkTask {
             header_builder.count("If-Modified-Since", last_modified);
         }
 
-        let headers_buf: &'static [u8] = if header_builder.header_count > 0 {
+        // `client.if_modified_since` must point into memory the request owns,
+        // so a copy of `last_modified` rides at the end of the header buffer.
+        let mut if_modified_since: Option<core::ops::Range<usize>> = None;
+        let mut header_buf: Box<[u8]> = Box::default();
+        let static_headers_buf: Option<&'static [u8]> = if header_builder.header_count > 0 {
             let accept_header = if needs_extended {
                 ACCEPT_HEADER_VALUE_EXTENDED
             } else {
                 ACCEPT_HEADER_VALUE
             };
             header_builder.count("Accept", accept_header);
-            let trailing_last_modified = !last_modified.is_empty() && !etag.is_empty();
+            let trailing_last_modified = !last_modified.is_empty();
             if trailing_last_modified {
                 header_builder.content.count(last_modified);
             }
@@ -632,16 +526,12 @@ impl NetworkTask {
             let last_modified_start = header_builder.content.len;
             if trailing_last_modified {
                 let _ = header_builder.content.append(last_modified);
+                if_modified_since =
+                    Some(last_modified_start..last_modified_start + last_modified.len());
             }
             debug_assert_eq!(header_builder.content.len, header_builder.content.cap);
-            self.header_buf = header_builder.content.move_to_slice();
-            if trailing_last_modified {
-                // SAFETY: `self.header_buf` outlives the request; it is freed when the slot returns to the pool.
-                last_modified =
-                    unsafe { bun_ptr::detach_lifetime(&self.header_buf[last_modified_start..]) };
-            }
-            // SAFETY: same invariant as `last_modified` above.
-            unsafe { bun_ptr::detach_lifetime(&*self.header_buf) }
+            header_buf = header_builder.content.move_to_slice();
+            None
         } else {
             let header_buf: &'static str = if needs_extended {
                 EXTENDED_HEADERS_BUF
@@ -659,36 +549,43 @@ impl NetworkTask {
                 },
             })?;
             header_builder.header_count = 1;
-            self.header_buf = Box::default();
-            header_buf.as_bytes()
+            Some(header_buf.as_bytes())
         };
 
         self.response_buffer = MutableString::init(0)?;
 
-        // SAFETY: `self.url_buf` outlives the request, same as `header_buf` above (see `s3/simple_request.rs`).
-        let url = URL::parse(unsafe { bun_ptr::detach_lifetime(&self.url_buf) });
-        let http_proxy = pm.http_proxy(&url);
-        let completion_callback = self.get_completion_callback();
-        // MaybeUninit overwrite — see field doc; old slot value is
-        // either uninitialized (fresh hive slot) or a stale bitwise copy from
-        // `notify`, neither of which is safe/meaningful to drop.
-        self.unsafe_http_client = MaybeUninit::new(AsyncHTTP::init(
+        let proxy_url = env
+            .get_http_proxy_for(&URL::parse(&url_buf))
+            .map(|proxy| Box::<[u8]>::from(proxy.href));
+        let force_last_modified = if_modified_since.is_some()
+            && bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_LAST_MODIFIED_PRETEND_304
+                .get()
+                .unwrap_or(false);
+        self.http = Some(http::OwnedRequest::new(
+            OwnedRequestBuffers {
+                url: url_buf,
+                headers: header_buf,
+                proxy_url,
+            },
             http::Method::GET,
-            url,
             header_builder.entries,
-            headers_buf,
-            b"",
-            completion_callback,
+            static_headers_buf,
             http::FetchRedirect::Follow,
-            AsyncHTTPOptions {
-                http_proxy,
-                ..Default::default()
+            AsyncHTTPOptions::default(),
+            // Incase the ETag causes invalidation, we fallback to the last modified date.
+            if force_last_modified {
+                if_modified_since
+            } else {
+                None
             },
         ));
-        self.http_mut().client.flags.reject_unauthorized = pm.tls_reject_unauthorized();
+        self.http_mut().client_flags_mut().reject_unauthorized = env.get_tls_reject_unauthorized();
+        if force_last_modified {
+            self.http_mut().client_flags_mut().force_last_modified = true;
+        }
 
         if PackageManager::verbose_install() {
-            self.http_mut().client.verbose = HTTPVerboseLevel::Headers;
+            self.http_mut().set_verbose(HTTPVerboseLevel::Headers);
         }
 
         self.callback = Callback::PackageManifest {
@@ -701,32 +598,10 @@ impl NetworkTask {
         };
 
         if PackageManager::verbose_install() {
-            self.http_mut().client.verbose = HTTPVerboseLevel::Headers;
-        }
-
-        // Incase the ETag causes invalidation, we fallback to the last modified date.
-        if !last_modified.is_empty()
-            && bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_LAST_MODIFIED_PRETEND_304
-                .get()
-                .unwrap_or(false)
-        {
-            self.http_mut().client.flags.force_last_modified = true;
-            // SAFETY: `last_modified` points into `self.header_buf` or into the manifest `string_buf` cloned into `self.callback`; both outlive the request.
-            self.http_mut().client.if_modified_since =
-                unsafe { bun_ptr::detach_lifetime(last_modified) };
+            self.http_mut().set_verbose(HTTPVerboseLevel::Headers);
         }
 
         Ok(())
-    }
-
-    pub(crate) fn get_completion_callback(&mut self) -> HTTPClientResultCallback {
-        // `HTTPClientResultCallback::new`
-        // performs type erasure over a `fn(*mut T, *mut AsyncHTTP, _)`.
-        HTTPClientResultCallback::new::<NetworkTask>(self, Self::notify)
-    }
-
-    pub(crate) fn schedule(&mut self, batch: &mut Batch) {
-        self.http_mut().schedule(batch);
     }
 }
 
@@ -772,27 +647,25 @@ impl bun_core::output::ErrName for ForTarballError {
 impl NetworkTask {
     pub(crate) fn for_tarball(
         &mut self,
+        log: &mut bun_ast::Log,
+        env: &bun_dotenv::Loader,
+        string_bytes: &[u8],
         tarball_: ExtractTarball,
         scope: &npm::registry::Scope,
         authorization: Authorization,
     ) -> Result<(), ForTarballError> {
-        let pm = self.pm_mut();
-
         let tarball_url = tarball_.url.slice();
-        self.url_buf = if tarball_url.is_empty() {
-            // SAFETY: `value` is the `Npm` variant on this code path —
-            // `for_tarball` is only reached for npm tarball downloads
-            // (callers gate on `resolution.tag == .npm`).
+        let mut url_buf: Box<[u8]> = if tarball_url.is_empty() {
             let version = tarball_.resolution.npm().version;
             Box::from(extract_tarball::build_url(
                 scope.url.href(),
                 &tarball_.name,
                 version,
-                pm.lockfile.buffers.string_bytes.as_slice(),
+                string_bytes,
             )?)
         } else {
             // Owning the copy (rather than aliasing `tarball.url`)
-            // avoids a self-reference into `callback` (see `url_buf` field doc).
+            // avoids a self-reference into `callback`.
             Box::<[u8]>::from(tarball_url)
         };
         self.callback = Callback::Extract(tarball_);
@@ -800,15 +673,13 @@ impl NetworkTask {
             unreachable!()
         };
 
-        if !(self.url_buf.starts_with(b"https://") || self.url_buf.starts_with(b"http://")) {
-            // SAFETY: `pm.log` is the long-lived `*mut Log` the package
-            // manager was constructed with.
-            pm.log_mut().add_error_fmt(
+        if !(url_buf.starts_with(b"https://") || url_buf.starts_with(b"http://")) {
+            log.add_error_fmt(
                 None,
                 bun_ast::Loc::EMPTY,
                 format_args!(
                     "Expected tarball URL to start with https:// or http://, got {} while fetching package {}",
-                    quote(&self.url_buf),
+                    quote(&url_buf),
                     quote(tarball.name.slice()),
                 ),
             );
@@ -816,11 +687,11 @@ impl NetworkTask {
         }
 
         // Userinfo becomes a header and leaves the URL: `bun_url` keeps it in `origin`, which the redirect same-origin check compares.
-        let url_authorization: Option<Vec<u8>> = match split_url_userinfo(&self.url_buf) {
+        let url_authorization: Option<Vec<u8>> = match split_url_userinfo(&url_buf) {
             Some((userinfo, url_without_userinfo)) => {
                 let value =
                     (!userinfo.is_empty()).then(|| basic_authorization_from_userinfo(userinfo));
-                self.url_buf = url_without_userinfo;
+                url_buf = url_without_userinfo;
                 value
             }
             None => None,
@@ -842,7 +713,7 @@ impl NetworkTask {
         // out; without normalization those installs lose the `Authorization`
         // header and fail with 401.
         let send_auth = matches!(authorization, Authorization::AllowAuthorization) && {
-            let tarball = URL::parse(&self.url_buf);
+            let tarball = URL::parse(&url_buf);
             let registry = scope.url.url();
             tarball.protocol == registry.protocol
                 && tarball.hostname == registry.hostname
@@ -866,36 +737,27 @@ impl NetworkTask {
             _ => None,
         };
 
-        let header_buf: &'static [u8] = if header_builder.header_count > 0 {
+        let header_buf: Box<[u8]> = if header_builder.header_count > 0 {
             header_builder.allocate()?;
             match &url_authorization {
                 Some(value) => header_builder.append("Authorization", value),
                 None => append_auth(&mut header_builder, scope),
             }
             debug_assert_eq!(header_builder.content.len, header_builder.content.cap);
-            self.header_buf = header_builder.content.move_to_slice();
-            // SAFETY: `self.header_buf` outlives the request; it is freed when the slot returns to the pool.
-            unsafe { bun_ptr::detach_lifetime(&*self.header_buf) }
+            header_builder.content.move_to_slice()
         } else {
-            self.header_buf = Box::default();
-            b""
+            Box::default()
         };
 
-        // SAFETY: lifetime extension — `url_buf` is a heap allocation owned by
-        // `*self`, which outlives the HTTP request. `AsyncHTTP::init` demands a
-        // `'static` borrow because the HTTP thread reads it concurrently. See
-        // the identical pattern in `for_manifest` above.
-        let url = URL::parse(unsafe { bun_ptr::detach_lifetime(&self.url_buf) });
-
-        let mut http_options = AsyncHTTPOptions {
-            http_proxy: pm.http_proxy(&url),
-            ..Default::default()
-        };
+        let proxy_url = env
+            .get_http_proxy_for(&URL::parse(&url_buf))
+            .map(|proxy| Box::<[u8]>::from(proxy.href));
+        let mut http_options = AsyncHTTPOptions::default();
 
         if extract_tarball::uses_streaming_extraction() {
-            // Tell the HTTP client to invoke `notify` for every body chunk
-            // instead of buffering the whole response. `notify` pushes each
-            // chunk into `tarball_stream`, which schedules a drain task on
+            // Tell the HTTP client to report every body chunk (`on_progress`,
+            // then `on_done`) instead of buffering the whole response. Those
+            // push each chunk into `tarball_stream`, which schedules a drain task on
             // `thread_pool`; the drain task calls into libarchive until it
             // reports ARCHIVE_RETRY (out of input), then returns so the
             // worker can be reused for other install work. The next chunk
@@ -903,8 +765,8 @@ impl NetworkTask {
             // — resumes exactly where it stopped.
             //
             // The stream itself is created by the caller (see
-            // `generateNetworkTaskForTarball`) because it needs the
-            // pre-allocated `Task` that carries the final result.
+            // `generate_network_task_for_tarball`) because it needs the
+            // `Task` (`streaming_extract_task`) that carries the final result.
             //
             // Only wire up the one signal we need; `Signals.Store.to()`
             // would also publish `aborted`/`cert_errors`/etc., which makes
@@ -922,23 +784,22 @@ impl NetworkTask {
             });
         }
 
-        let completion_callback = self.get_completion_callback();
-        // MaybeUninit overwrite — see field doc; old slot value is
-        // either uninitialized (fresh hive slot) or a stale bitwise copy from
-        // `notify`, neither of which is safe/meaningful to drop.
-        self.unsafe_http_client = MaybeUninit::new(AsyncHTTP::init(
+        self.http = Some(http::OwnedRequest::new(
+            OwnedRequestBuffers {
+                url: url_buf,
+                headers: header_buf,
+                proxy_url,
+            },
             http::Method::GET,
-            url,
             header_builder.entries,
-            header_buf,
-            b"",
-            completion_callback,
+            None,
             http::FetchRedirect::Follow,
             http_options,
+            None,
         ));
-        self.http_mut().client.flags.reject_unauthorized = pm.tls_reject_unauthorized();
+        self.http_mut().client_flags_mut().reject_unauthorized = env.get_tls_reject_unauthorized();
         if PackageManager::verbose_install() {
-            self.http_mut().client.verbose = HTTPVerboseLevel::Headers;
+            self.http_mut().set_verbose(HTTPVerboseLevel::Headers);
         }
 
         Ok(())
@@ -947,25 +808,10 @@ impl NetworkTask {
     /// Release any streaming-extraction resources that were never used because
     /// the request errored before a drain was scheduled. Called on the main
     /// thread from `run_tasks` when falling back to the buffered path.
-    pub(crate) fn discard_unused_streaming_state(&mut self, manager: &mut PackageManager) {
+    pub(crate) fn discard_unused_streaming_state(&mut self) {
         debug_assert!(!self.streaming_committed);
-        if let Some(stream) = self.tarball_stream.take() {
-            drop(stream);
-        }
-        if !self.streaming_extract_task.is_null() {
-            // ARENA: returned to `preallocated_resolve_tasks` pool, not freed.
-            // SAFETY: `streaming_extract_task` was obtained from this same
-            // `preallocated_resolve_tasks` pool via `get_init()` and is not aliased
-            // (cleared immediately below); `put()` runs `Task::drop` on the
-            // slot — the Task was fully initialized via
-            // `enqueue::create_extract_task_for_streaming` so this is sound.
-            unsafe {
-                manager
-                    .preallocated_resolve_tasks
-                    .put(self.streaming_extract_task);
-            }
-            self.streaming_extract_task = ptr::null_mut();
-        }
+        drop(self.tarball_stream.take());
+        drop(self.streaming_extract_task.take());
     }
 
     /// Prepare this task for another HTTP attempt. A stream that never ran is
@@ -973,76 +819,11 @@ impl NetworkTask {
     /// `TarballStream::finish`) is replaced, keeping the same extract Task.
     pub(crate) fn reset_streaming_for_retry(&mut self) {
         debug_assert!(!self.streaming_committed);
-        if let Some(stream) = self.tarball_stream.as_deref_mut() {
+        if let Some(stream) = self.tarball_stream.as_deref() {
             stream.reset_for_retry();
-        } else if !self.streaming_extract_task.is_null() {
-            let manager = self.package_manager.as_mut_ptr();
-            let this: *mut NetworkTask = self;
-            // SAFETY: `init` returns a fresh heap allocation owned here.
-            self.tarball_stream = Some(unsafe {
-                bun_core::heap::take(TarballStream::init(
-                    self.streaming_extract_task,
-                    this,
-                    manager,
-                ))
-            });
+        } else if let Some(extract_task) = self.streaming_extract_task.take() {
+            self.tarball_stream = Some(TarballStream::new(extract_task, self.package_manager));
         }
         self.response = HTTPClientResult::default();
-    }
-
-    /// Initialize a freshly-vended pool slot in place — a full struct overwrite
-    /// that resets every other field to its struct default. The slot may be
-    /// uninitialized heap memory (from `HiveArrayFallback::claim()`'s
-    /// `Box::new_uninit()` fallback) or stale (reused hive slot whose prior
-    /// contents ARE now dropped on `put` since 1e76047), so each field is
-    /// written via `addr_of_mut!().write()` without dropping the previous
-    /// value — the slot is freshly poisoned/uninit from `claim()`.
-    ///
-    /// Caller-initialized fields (`unsafe_http_client`, `callback`,
-    /// `response_buffer`) are written here with drop-safe
-    /// placeholders so subsequent `=` assignments in `for_manifest`/
-    /// `for_tarball` do not drop uninitialized memory. `unsafe_http_client`
-    /// stays bitwise-untouched (it is `MaybeUninit`, so leaving it uninit is
-    /// sound under the `&mut NetworkTask` the caller forms next; it is
-    /// overwritten without drop by `for_manifest`/`for_tarball`).
-    ///
-    /// # Safety
-    /// `slot` must be the unique handle to a `HiveArrayFallback<NetworkTask>`
-    /// slot returned by `claim()`; its prior contents are treated as garbage
-    /// (no destructors run).
-    pub(crate) unsafe fn write_init(
-        slot: *mut NetworkTask,
-        task_id: crate::package_manager_task::Id,
-        package_manager: *mut PackageManager,
-        apply_patch_task: Option<Box<PatchTask>>,
-    ) {
-        use core::ptr::addr_of_mut;
-        // SAFETY: caller contract (see fn `# Safety`) — `slot` is the unique
-        // handle to a freshly-vended `HiveArrayFallback` slot whose prior
-        // contents are garbage; every field is written without dropping.
-        unsafe {
-            addr_of_mut!((*slot).task_id).write(task_id);
-            // SAFETY: `package_manager` is the live owner of this task; write
-            // provenance is required for `for_manifest`/`for_tarball`'s
-            // `assume_mut`, so callers pass `*mut` (not `*const`).
-            addr_of_mut!((*slot).package_manager)
-                .write(bun_ptr::ParentRef::from_raw_mut(package_manager));
-            addr_of_mut!((*slot).apply_patch_task).write(apply_patch_task);
-            // Struct-default fields.
-            addr_of_mut!((*slot).response).write(HTTPClientResult::default());
-            addr_of_mut!((*slot).url_buf).write(Box::default());
-            addr_of_mut!((*slot).header_buf).write(Box::default());
-            addr_of_mut!((*slot).retried).write(0);
-            addr_of_mut!((*slot).next).write(bun_threading::Link::new());
-            addr_of_mut!((*slot).tarball_stream).write(None);
-            addr_of_mut!((*slot).streaming_extract_task).write(ptr::null_mut());
-            addr_of_mut!((*slot).streaming_committed).write(false);
-            addr_of_mut!((*slot).signal_store).write(http::signals::Store::default());
-            // Caller-initialized fields: write drop-safe placeholders so the
-            // plain `=` in `for_manifest`/`for_tarball` drops a valid value.
-            // (`unsafe_http_client` is `MaybeUninit` — left uninitialized.)
-            addr_of_mut!((*slot).response_buffer).write(MutableString::init_empty());
-            addr_of_mut!((*slot).callback).write(Callback::LocalTarball);
-        }
     }
 }

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -5,15 +5,15 @@ use bun_core::Progress::Progress;
 use bun_core::{Global, Output};
 use bun_core::{MutableString, ZStr};
 use bun_paths::strings;
-use bun_paths::{self as path, OSPathChar, OSPathSlice, SEP, SEP_STR};
+use bun_paths::{self as path, OSPathChar, OSPathSlice, SEP};
 use bun_semver::String as SemverString;
 #[cfg(not(windows))]
 use bun_sys::OpenDirOptions;
 use bun_sys::{self as sys, Dir, EntryKind, Fd, FdExt, walker_skippable};
-use bun_threading::thread_pool::{Batch, Node as ThreadPoolNode};
-use bun_threading::work_pool::Task as WorkPoolTask;
+use bun_threading::ThreadPool;
 #[cfg(windows)]
-use bun_threading::{ThreadPool, WaitGroup};
+use bun_threading::WaitGroup;
+use bun_threading::work_pool::Task as WorkPoolTask;
 
 use crate::package_installer::NodeModulesFolder;
 use crate::{
@@ -29,19 +29,58 @@ pub struct PackageInstall<'a> {
     /// short-lived `Dir` held by the caller — `PackageInstall` never closes it.
     pub(crate) cache_dir: Fd,
     pub(crate) cache_dir_subpath: &'a ZStr,
-    // TODO: `destination_dir_subpath` aliases into `destination_dir_subpath_buf`;
-    // borrowck will reject simultaneous &ZStr + &mut [u8]. Consider storing only the len.
-    pub(crate) destination_dir_subpath: &'a ZStr,
+    /// `destination_dir_subpath_buf[..destination_dir_subpath_len]` is the
+    /// destination inside `node_modules`, NUL-terminated; the tail is scratch
+    /// for `<dest>/.bun-tag`-style probes.
     pub(crate) destination_dir_subpath_buf: &'a mut [u8],
-
-    pub(crate) progress: Option<&'a mut Progress>,
+    pub(crate) destination_dir_subpath_len: usize,
 
     pub(crate) package_name: SemverString,
     pub(crate) package_version: &'a [u8],
     pub(crate) patch: Option<Patch>,
 
     pub(crate) node_modules: &'a NodeModulesFolder,
-    pub lockfile: &'a Lockfile,
+}
+
+/// What an install needs from the package manager. On the main thread that
+/// is the manager itself; a patch task on a worker only has the lockfile.
+pub enum InstallEnv<'m> {
+    Manager(&'m mut PackageManager),
+    Worker {
+        lockfile: &'m Lockfile,
+        thread_pool: &'m ThreadPool,
+    },
+}
+
+impl InstallEnv<'_> {
+    fn lockfile(&self) -> &Lockfile {
+        match self {
+            InstallEnv::Manager(m) => &m.lockfile,
+            InstallEnv::Worker { lockfile, .. } => lockfile,
+        }
+    }
+    fn thread_pool(&self) -> &ThreadPool {
+        match self {
+            InstallEnv::Manager(m) => &m.thread_pool,
+            InstallEnv::Worker { thread_pool, .. } => thread_pool,
+        }
+    }
+    fn progress(&mut self) -> Option<&mut Progress> {
+        match self {
+            InstallEnv::Manager(m) if m.options.log_level.show_progress() => Some(&mut m.progress),
+            _ => None,
+        }
+    }
+}
+
+impl PackageInstall<'_> {
+    #[inline]
+    pub(crate) fn destination_dir_subpath(&self) -> &ZStr {
+        ZStr::from_buf(
+            &*self.destination_dir_subpath_buf,
+            self.destination_dir_subpath_len,
+        )
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -98,7 +137,6 @@ impl Method {
             2 => Method::Hardlink,
             3 => Method::Copyfile,
             4 => Method::Symlink,
-            // Was @enumFromInt; cold atomic-load decode so the panic branch is fine.
             _ => unreachable!(),
         }
     }
@@ -249,13 +287,10 @@ impl Step {
     }
 }
 
-// PORTING.md §Global mutable state: install-main-thread enum. `RacyCell`
-// (no `Atomic<Method>`) — writers are the CLI option-load and the
-// clonefile/hardlink fallback in `install_with_method`, all on the install
-// main thread; isolated_install workers snapshot via `supported_method()`
-// once at startup. Stored as the `repr(u8)` discriminant so reads/writes are
-// lock-free atomics (S015: AtomicU8 instead of RacyCell — single-writer path
-// so `Relaxed` adds no contention).
+// Writers are the CLI option-load and the clonefile/hardlink fallback while
+// installing, all on the install main thread; isolated_install workers
+// snapshot via `supported_method()` once at startup. Stored as the `repr(u8)`
+// discriminant; single writer, so `Relaxed` suffices.
 pub(crate) static SUPPORTED_METHOD: AtomicU8 = AtomicU8::new(if cfg!(target_os = "macos") {
     Method::Clonefile as u8
 } else {
@@ -323,8 +358,8 @@ fn mkdir_recursive_os_path(fullpath: &bun_core::WStr) -> sys::Maybe<()> {
     match sys::mkdir_w(fullpath) {
         Ok(()) => return Ok(()),
         Err(err) => match err.get_errno() {
-            // `mkpath_np` on macOS also checks EISDIR; on Windows EEXIST suffices.
-            // NodeFS additionally probes `directoryExistsAt`; the package-install
+            // macOS's mkpath also checks EISDIR; on Windows EEXIST suffices.
+            // node:fs additionally probes `directory_exists_at`; the package-install
             // call sites discard the result (`_ =`) so a bare Ok matches behaviour.
             E::EISDIR | E::EEXIST => return Ok(()),
             E::ENOENT => {
@@ -430,51 +465,39 @@ fn open_dir_a(dir: Fd, subpath: &[u8]) -> crate::Result<Dir> {
 // (takes `Fd`/`&ZStr`, returns `Maybe<()>`). The wrapper preserves the errno
 // via `Error::get_errno()` for the per-errno branching below.
 
-// ───────────────────────────── NewTaskQueue ─────────────────────────────
+// ───────────────────────────── HardLinkWindowsInstallTask ─────────────────────────────
 
+/// One batch of hardlink tasks (a single package install); the tasks report
+/// into it and the installer waits on it.
 #[cfg(windows)]
-pub(crate) struct NewTaskQueue<TaskType> {
-    pub(crate) thread_pool: &'static ThreadPool,
-    /// One-shot, first-write-wins handoff of the failed task from a worker
-    /// thread to the consumer that called `wait()`. A `Mutex<Option<Box<_>>>`
-    /// makes ownership explicit (vs. the original `AtomicPtr`, which forced
-    /// every reader to remember `Box::from_raw` and risked leaks/double-free).
-    pub(crate) errored_task: bun_threading::Guarded<Option<Box<TaskType>>>,
-    pub(crate) wait_group: WaitGroup,
+struct HardLinkBatch {
+    /// First-write-wins error from a worker thread for the caller of `wait()`.
+    errored: bun_threading::Guarded<Option<crate::Error>>,
+    wait_group: WaitGroup,
 }
 
 #[cfg(windows)]
-impl<TaskType> NewTaskQueue<TaskType> {
-    pub(crate) fn complete_one(&self) {
-        self.wait_group.finish();
+impl HardLinkBatch {
+    fn new() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
+            errored: bun_threading::Guarded::new(None),
+            wait_group: WaitGroup::init(),
+        })
     }
 
-    /// # Safety
-    /// `task` must point to a live, Box-allocated `TaskType` whose ownership is
-    /// being handed to the thread pool; the worker reclaims it in its callback.
-    pub(crate) unsafe fn push(&self, task: *mut TaskType)
-    where
-        TaskType: HasWorkPoolTask,
-    {
+    fn push(
+        self: &std::sync::Arc<Self>,
+        thread_pool: &ThreadPool,
+        task: HardLinkWindowsInstallTask,
+    ) {
         self.wait_group.add_one();
-        // SAFETY: caller contract — `task` is a valid Box-allocated task; `.task()`
-        // is the intrusive node field.
-        self.thread_pool.schedule(Batch::from(unsafe {
-            std::ptr::from_mut::<WorkPoolTask>((*task).task())
-        }));
+        thread_pool.schedule_owned(Box::new(task));
     }
 
-    pub(crate) fn wait(&self) {
+    fn wait(&self) {
         self.wait_group.wait();
     }
 }
-
-#[cfg(windows)]
-pub(crate) trait HasWorkPoolTask {
-    fn task(&mut self) -> &mut WorkPoolTask;
-}
-
-// ───────────────────────────── HardLinkWindowsInstallTask ─────────────────────────────
 
 #[cfg(windows)]
 struct HardLinkWindowsInstallTask {
@@ -486,67 +509,20 @@ struct HardLinkWindowsInstallTask {
     src_len: usize,
     basename: u16,
     task: WorkPoolTask,
-    err: Option<crate::Error>,
+    batch: std::sync::Arc<HardLinkBatch>,
 }
 
 #[cfg(windows)]
-impl HasWorkPoolTask for HardLinkWindowsInstallTask {
-    fn task(&mut self) -> &mut WorkPoolTask {
-        &mut self.task
-    }
-}
-
-#[cfg(windows)]
-type HardLinkQueue = NewTaskQueue<HardLinkWindowsInstallTask>;
-
-// PORTING.md §Global mutable state: written once on the main thread by
-// `init_queue()` before any worker `run_from_thread_pool` reads it; workers
-// only ever take `&HardLinkQueue` (all queue methods are `&self`).
-#[cfg(windows)]
-static HARDLINK_QUEUE: bun_core::RacyCell<core::mem::MaybeUninit<HardLinkQueue>> =
-    bun_core::RacyCell::new(core::mem::MaybeUninit::uninit());
+bun_threading::owned_task!(HardLinkWindowsInstallTask, task);
 
 #[cfg(windows)]
 impl HardLinkWindowsInstallTask {
-    fn init_queue() -> &'static HardLinkQueue {
-        // SAFETY: called once per install batch on the install main thread before any
-        // push(). Returns a shared ref so worker threads in run_from_thread_pool() may
-        // safely alias it via HARDLINK_QUEUE.assume_init_ref(); all queue methods take
-        // &self.
-        //
-        // `INITIALIZED` is *not* the cross-thread publication edge — it is read and
-        // written only here, on the main thread, so `Relaxed` is sufficient. Workers
-        // never observe HARDLINK_QUEUE until after `push()` → `ThreadPool::schedule()`,
-        // whose internal Release/Acquire on the task queue is what publishes the
-        // first-call `MaybeUninit::write` below.
-        //
-        // On re-init we only drain `errored_task` through its own mutex instead of
-        // re-assigning the whole struct: `wait_group`'s counter is already 0 and
-        // `thread_pool` points at the process-wide `PackageManager` singleton that
-        // never changes, so a fresh write would be a no-op anyway.
-        static INITIALIZED: core::sync::atomic::AtomicBool =
-            core::sync::atomic::AtomicBool::new(false);
-        unsafe {
-            if INITIALIZED.swap(true, Ordering::Relaxed) {
-                let q = (*HARDLINK_QUEUE.get()).assume_init_ref();
-                *q.errored_task.lock() = None;
-                debug_assert_eq!(
-                    q.thread_pool as *const ThreadPool,
-                    core::ptr::from_ref(&PackageManager::get().thread_pool),
-                    "PackageManager singleton changed between install batches",
-                );
-            } else {
-                (*HARDLINK_QUEUE.get()).write(HardLinkQueue {
-                    thread_pool: &PackageManager::get().thread_pool,
-                    errored_task: bun_threading::Guarded::new(None),
-                    wait_group: WaitGroup::init(),
-                });
-            }
-            (*HARDLINK_QUEUE.get()).assume_init_ref()
-        }
-    }
-
-    fn init(src: &[OSPathChar], dest: &[OSPathChar], basename: &[OSPathChar]) -> *mut Self {
+    fn new(
+        batch: &std::sync::Arc<HardLinkBatch>,
+        src: &[OSPathChar],
+        dest: &[OSPathChar],
+        basename: &[OSPathChar],
+    ) -> Self {
         let allocation_size = src.len() + 1 + dest.len() + 1;
 
         let mut combined = vec![0u16; allocation_size].into_boxed_slice();
@@ -556,41 +532,23 @@ impl HardLinkWindowsInstallTask {
         remaining[..dest.len()].copy_from_slice(dest);
         remaining[dest.len()] = 0;
 
-        bun_core::heap::into_raw(Box::new(Self {
+        Self {
             bytes: combined,
             src_len: src.len(),
             basename: basename.len() as u16, // @truncate
-            task: WorkPoolTask {
-                callback: Self::run_from_thread_pool,
-                node: ThreadPoolNode::default(),
-            },
-            err: None,
-        }))
+            task: WorkPoolTask::default(),
+            batch: batch.clone(),
+        }
     }
 
-    fn run_from_thread_pool(task: *mut WorkPoolTask) {
-        // SAFETY: task points to the `task` field of a HardLinkWindowsInstallTask.
-        let self_: *mut Self = unsafe { bun_core::from_field_ptr!(Self, task, task) };
-        // SAFETY: HARDLINK_QUEUE initialized by init_queue() before scheduling.
-        let queue = unsafe { (*HARDLINK_QUEUE.get()).assume_init_ref() };
-        scopeguard::defer! { queue.complete_one(); }
-
-        // SAFETY: self_ is valid until we reclaim the Box below.
-        if let Some(err) = unsafe { (*self_).run() } {
-            unsafe { (*self_).err = Some(err) };
-            // SAFETY: self_ was heap-allocated in init(); reclaim ownership now.
-            let boxed = unsafe { bun_core::heap::take(self_) };
-            // First-write-wins: keep only the first error. Any later failing task
-            // simply drops its Box here (leaking it would also leak the inner
-            // `Box<[u16]>` per failed file).
-            let mut slot = queue.errored_task.lock();
+    fn run_owned(mut self: Box<Self>) {
+        if let Some(err) = self.run() {
+            let mut slot = self.batch.errored.lock();
             if slot.is_none() {
-                *slot = Some(boxed);
+                *slot = Some(err);
             }
-            return;
         }
-        // SAFETY: self_ was heap-allocated in init().
-        unsafe { drop(bun_core::heap::take(self_)) };
+        self.batch.wait_group.finish();
     }
 
     fn run(&mut self) -> Option<crate::Error> {
@@ -623,8 +581,7 @@ impl HardLinkWindowsInstallTask {
                         bun_core::fmt::fmt_path_u16(&dest[..dest_len], Default::default())
                     );
                 }
-                // SAFETY: FFI — dest is a valid NUL-terminated u16 buffer.
-                unsafe { windows::DeleteFileW(dest.as_ptr()) };
+                windows::delete_file_w(bun_core::WStr::from_buf(dest, dest_len));
                 if windows::CreateHardLinkW(dest.as_ptr(), src.as_ptr(), None) != 0 {
                     return None;
                 }
@@ -652,8 +609,12 @@ impl HardLinkWindowsInstallTask {
             }}
         }
 
-        // SAFETY: FFI — src/dest are valid NUL-terminated u16 buffers.
-        if unsafe { windows::CopyFileW(src.as_ptr(), dest.as_ptr(), 0) } != 0 {
+        let (src, dest) = self.bytes.split_at(src_len + 1);
+        if windows::copy_file_w(
+            bun_core::WStr::from_buf(src, src_len),
+            bun_core::WStr::from_buf(dest, dest_len),
+            false,
+        ) {
             return None;
         }
 
@@ -666,30 +627,22 @@ impl HardLinkWindowsInstallTask {
 struct UninstallTask {
     absolute_path: Box<[u8]>,
     task: WorkPoolTask,
+    shared: &'static crate::package_manager::Shared,
 }
 
+bun_threading::owned_task!(UninstallTask, task);
+
 impl UninstallTask {
-    fn run(task: *mut WorkPoolTask) {
-        // SAFETY: task points to the `task` field of an UninstallTask.
-        let uninstall_task: *mut Self = unsafe { bun_core::from_field_ptr!(Self, task, task) };
+    fn run_owned(self: Box<Self>) {
+        let shared = self.shared;
+        Self::delete(&self);
+        // The task must be freed before the main thread can observe pending_tasks==0.
+        drop(self);
+        shared.pending_tasks.fetch_sub(1, Ordering::Release);
+        shared.wake();
+    }
 
-        // declared *before* the Box is reclaimed so it drops *after* the
-        // Box — Rust drops locals in reverse declaration order. The task must be freed
-        // before the main thread can observe pending_tasks==0.
-        scopeguard::defer! {
-            let pm = crate::package_manager::get();
-            // SAFETY: `pending_tasks` is `AtomicU32`; raw-pointer field projection
-            // avoids materializing `&mut PackageManager` from a worker thread (the
-            // main thread holds the install borrow). `wake_raw` is the documented
-            // thread-safe wake path that never forms `&mut PackageManager`.
-            unsafe {
-                (*pm).pending_tasks.fetch_sub(1, Ordering::Release);
-                PackageManager::wake_raw(pm);
-            }
-        }
-
-        // SAFETY: heap-allocated in uninstall_before_install; reclaim ownership here.
-        let uninstall_task = unsafe { bun_core::heap::take(uninstall_task) };
+    fn delete(uninstall_task: &Self) {
         let mut debug_timer = Output::DebugTimer::start();
 
         let dirname =
@@ -731,7 +684,7 @@ impl UninstallTask {
             let _ = &mut debug_timer;
             bun_output::scoped_log!(
                 install,
-                "deleteTree({}, {}) = {}",
+                "delete_tree({}, {}) = {}",
                 bstr::BStr::new(basename),
                 bstr::BStr::new(dirname),
                 debug_timer
@@ -751,7 +704,7 @@ impl<'a> PackageInstall<'a> {
         let bunhashtag = buntaghashbuf_make(&mut buf, patchfile_contents_hash);
 
         let patch_tag_path = path::resolve_path::join_z::<path::platform::Posix>(&[
-            self.destination_dir_subpath.as_bytes(),
+            self.destination_dir_subpath().as_bytes(),
             bunhashtag,
         ]);
 
@@ -775,61 +728,73 @@ impl<'a> PackageInstall<'a> {
         true
     }
 
+    /// `<dest>/<name>` as a `ZStr` in the scratch tail of
+    /// `destination_dir_subpath_buf`; [`restore_subpath`] puts the NUL back.
+    fn subpath_child(&mut self, name: &[u8]) -> &ZStr {
+        let dest_len = self.destination_dir_subpath_len;
+        let buf = &mut *self.destination_dir_subpath_buf;
+        buf[dest_len] = SEP;
+        buf[dest_len + 1..dest_len + 1 + name.len()].copy_from_slice(name);
+        buf[dest_len + 1 + name.len()] = 0;
+        ZStr::from_buf(&*buf, dest_len + 1 + name.len())
+    }
+
+    fn restore_subpath(&mut self) {
+        self.destination_dir_subpath_buf[self.destination_dir_subpath_len] = 0;
+    }
+
     // 1. verify that .bun-tag exists (was it installed from bun?)
     // 2. check .bun-tag against the resolved version
-    fn verify_git_resolution(&mut self, repo: &Repository, root_node_modules_dir: &Dir) -> bool {
-        let dest_len = self.destination_dir_subpath.len();
-        let suffix: &[u8] = &[SEP, b'.', b'b', b'u', b'n', b'-', b't', b'a', b'g'];
-        // Reshaped for borrowck — write into buf via raw indices.
-        self.destination_dir_subpath_buf[dest_len..dest_len + suffix.len()].copy_from_slice(suffix);
-        self.destination_dir_subpath_buf[dest_len + SEP_STR.len() + b".bun-tag".len()] = 0;
-        // SAFETY: NUL written above.
-        let bun_tag_path = unsafe {
-            ZStr::from_raw_mut(
-                self.destination_dir_subpath_buf.as_mut_ptr(),
-                dest_len + SEP_STR.len() + b".bun-tag".len(),
-            )
-        };
-        let _restore = scopeguard::guard(
-            self.destination_dir_subpath_buf.as_mut_ptr(),
-            // SAFETY: p points into destination_dir_subpath_buf which outlives this scope;
-            // dest_len < buf capacity (was the prior NUL position).
-            move |p| unsafe { *p.add(dest_len) = 0 },
-        );
-
-        let Ok(bun_tag_file) = self
-            .node_modules
-            .read_small_file(root_node_modules_dir, bun_tag_path)
-        else {
+    fn verify_git_resolution(
+        &mut self,
+        lockfile: &Lockfile,
+        repo: &Repository,
+        root_node_modules_dir: &Dir,
+    ) -> bool {
+        let node_modules = self.node_modules;
+        let bun_tag_path = self.subpath_child(b".bun-tag");
+        let bun_tag_file = node_modules.read_small_file(root_node_modules_dir, bun_tag_path);
+        self.restore_subpath();
+        let Ok(bun_tag_file) = bun_tag_file else {
             return false;
         };
         strings::eql_long(
-            repo.resolved.slice(&self.lockfile.buffers.string_bytes),
+            repo.resolved.slice(&lockfile.buffers.string_bytes),
             &bun_tag_file.bytes,
             true,
         )
     }
 
-    pub(crate) fn verify(&mut self, resolution: &Resolution, root_node_modules_dir: &Dir) -> bool {
+    pub(crate) fn verify(
+        &mut self,
+        lockfile: &Lockfile,
+        resolution: &Resolution,
+        root_node_modules_dir: &Dir,
+    ) -> bool {
         let verified = match resolution.tag {
             resolution::Tag::Git => {
-                self.verify_git_resolution(resolution.git(), root_node_modules_dir)
+                self.verify_git_resolution(lockfile, resolution.git(), root_node_modules_dir)
             }
             resolution::Tag::Github => {
-                self.verify_git_resolution(resolution.github(), root_node_modules_dir)
+                self.verify_git_resolution(lockfile, resolution.github(), root_node_modules_dir)
             }
             resolution::Tag::Root => self.verify_transitive_symlinked_folder(root_node_modules_dir),
             resolution::Tag::Folder => {
-                if self
-                    .lockfile
-                    .is_workspace_tree_id(self.node_modules.tree_id)
-                {
-                    self.verify_package_json_name_and_version(root_node_modules_dir, resolution.tag)
+                if lockfile.is_workspace_tree_id(self.node_modules.tree_id) {
+                    self.verify_package_json_name_and_version(
+                        lockfile,
+                        root_node_modules_dir,
+                        resolution.tag,
+                    )
                 } else {
                     self.verify_transitive_symlinked_folder(root_node_modules_dir)
                 }
             }
-            _ => self.verify_package_json_name_and_version(root_node_modules_dir, resolution.tag),
+            _ => self.verify_package_json_name_and_version(
+                lockfile,
+                root_node_modules_dir,
+                resolution.tag,
+            ),
         };
 
         if let Some(patch) = self.patch {
@@ -845,7 +810,7 @@ impl<'a> PackageInstall<'a> {
     // it might not exist
     fn verify_transitive_symlinked_folder(&self, root_node_modules_dir: &Dir) -> bool {
         self.node_modules
-            .directory_exists_at(root_node_modules_dir, self.destination_dir_subpath)
+            .directory_exists_at(root_node_modules_dir, self.destination_dir_subpath())
     }
 
     fn get_installed_package_json_source(
@@ -854,34 +819,38 @@ impl<'a> PackageInstall<'a> {
         mutable: &mut MutableString,
         resolution_tag: resolution::Tag,
     ) -> Option<bun_ast::Source> {
-        let mut total: usize = 0;
-        let mut read: usize;
         mutable.reset();
         mutable.expand_to_capacity();
 
-        let dest_len = self.destination_dir_subpath.len();
-        // Write the literal directly into the path buffer; no intermediate Vec.
-        let suffix: &[u8] = &[
-            SEP, b'p', b'a', b'c', b'k', b'a', b'g', b'e', b'.', b'j', b's', b'o', b'n',
-        ];
-        self.destination_dir_subpath_buf[dest_len..dest_len + suffix.len()].copy_from_slice(suffix);
-        self.destination_dir_subpath_buf[dest_len + SEP_STR.len() + b"package.json".len()] = 0;
-        // SAFETY: NUL written above.
-        let package_json_path = unsafe {
-            ZStr::from_raw_mut(
-                self.destination_dir_subpath_buf.as_mut_ptr(),
-                dest_len + SEP_STR.len() + b"package.json".len(),
-            )
-        };
-        let _restore = scopeguard::guard(
-            self.destination_dir_subpath_buf.as_mut_ptr(),
-            // SAFETY: p points into destination_dir_subpath_buf which outlives this scope;
-            // dest_len < buf capacity (was the prior NUL position).
-            move |p| unsafe { *p.add(dest_len) = 0 },
+        let node_modules = self.node_modules;
+        let package_name_len = self.package_name.len();
+        let package_version_len = self.package_version.len();
+        let package_json_path = self.subpath_child(b"package.json");
+        let source = Self::read_package_json_source(
+            node_modules,
+            root_node_modules_dir,
+            package_json_path,
+            mutable,
+            resolution_tag,
+            package_name_len,
+            package_version_len,
         );
+        self.restore_subpath();
+        source
+    }
 
-        let package_json_file = self
-            .node_modules
+    fn read_package_json_source(
+        node_modules: &NodeModulesFolder,
+        root_node_modules_dir: &Dir,
+        package_json_path: &ZStr,
+        mutable: &mut MutableString,
+        resolution_tag: resolution::Tag,
+        package_name_len: usize,
+        package_version_len: usize,
+    ) -> Option<bun_ast::Source> {
+        let mut total: usize = 0;
+        let mut read: usize;
+        let package_json_file = node_modules
             .open_file(root_node_modules_dir, package_json_path)
             .ok()?;
 
@@ -897,7 +866,6 @@ impl<'a> PackageInstall<'a> {
             total += read;
 
             mutable.expand_to_capacity();
-            // Reshaped for borrowck — recompute remain after grow.
             remain = &mut mutable.list[total..];
 
             if remain.len() < 1024 {
@@ -910,15 +878,12 @@ impl<'a> PackageInstall<'a> {
         }
 
         // If it's not long enough to have {"name": "foo", "version": "1.2.0"}, there's no way it's valid
-        let minimum =
-            if resolution_tag == resolution::Tag::Workspace && self.package_version.is_empty() {
-                // workspaces aren't required to have a version
-                br#"{"name":""}"#.len() + self.package_name.len()
-            } else {
-                br#"{"name":"","version":""}"#.len()
-                    + self.package_name.len()
-                    + self.package_version.len()
-            };
+        let minimum = if resolution_tag == resolution::Tag::Workspace && package_version_len == 0 {
+            // workspaces aren't required to have a version
+            br#"{"name":""}"#.len() + package_name_len
+        } else {
+            br#"{"name":"","version":""}"#.len() + package_name_len + package_version_len
+        };
 
         if total < minimum {
             return None;
@@ -932,6 +897,7 @@ impl<'a> PackageInstall<'a> {
 
     fn verify_package_json_name_and_version(
         &mut self,
+        lockfile: &Lockfile,
         root_node_modules_dir: &Dir,
         resolution_tag: resolution::Tag,
     ) -> bool {
@@ -1000,8 +966,7 @@ impl<'a> PackageInstall<'a> {
         }
 
         // lastly, check the name.
-        package_json_checker.found_name()
-            == self.package_name.slice(&self.lockfile.buffers.string_bytes)
+        package_json_checker.found_name() == self.package_name.slice(&lockfile.buffers.string_bytes)
     }
 
     // ───────────────────────────── install backends ─────────────────────────────
@@ -1073,7 +1038,7 @@ impl<'a> PackageInstall<'a> {
         }
 
         let subdir = match destination_dir.make_open_path(
-            self.destination_dir_subpath.as_bytes(),
+            self.destination_dir_subpath().as_bytes(),
             OpenDirOptions::default(),
         ) {
             Ok(d) => d,
@@ -1089,12 +1054,11 @@ impl<'a> PackageInstall<'a> {
     // https://www.unix.com/man-page/mojave/2/fclonefileat/
     #[cfg(target_os = "macos")]
     fn install_with_clonefile(&mut self, destination_dir: &Dir) -> crate::Result<InstallResult> {
-        if self.destination_dir_subpath.as_bytes()[0] == b'@' {
-            if let Some(slash) = strings::index_of_char_z(self.destination_dir_subpath, SEP) {
+        if self.destination_dir_subpath().as_bytes()[0] == b'@' {
+            if let Some(slash) = strings::index_of_char_z(self.destination_dir_subpath(), SEP) {
                 let slash = slash as usize;
                 self.destination_dir_subpath_buf[slash] = 0;
-                // SAFETY: NUL written above.
-                let subdir = ZStr::from_buf(self.destination_dir_subpath_buf, slash);
+                let subdir = ZStr::from_buf(&*self.destination_dir_subpath_buf, slash);
                 let _ = sys::mkdirat(destination_dir, subdir, 0o755);
                 self.destination_dir_subpath_buf[slash] = SEP;
             }
@@ -1104,7 +1068,7 @@ impl<'a> PackageInstall<'a> {
             self.cache_dir,
             self.cache_dir_subpath,
             destination_dir.fd(),
-            self.destination_dir_subpath,
+            self.destination_dir_subpath(),
         ) {
             Ok(()) => Ok(InstallResult::Success),
             Err(e) => match e.get_errno() {
@@ -1128,7 +1092,7 @@ impl<'a> PackageInstall<'a> {
         method: Method,
     ) -> Result<InstallDirState, Box<Failure>> {
         let destbase = destination_dir;
-        let destpath = self.destination_dir_subpath;
+        let destpath = self.destination_dir_subpath();
 
         let cached_package_dir = match {
             #[cfg(windows)]
@@ -1153,7 +1117,6 @@ impl<'a> PackageInstall<'a> {
             Err(err) => return Err(Failure::boxed(err, Step::OpeningCacheDir, None)),
         };
 
-        // `bun.OSPathLiteral("node_modules")` — u8 on posix / u16 on windows.
         #[cfg(windows)]
         const NODE_MODULES_LIT: &OSPathSlice = &[
             b'n' as u16,
@@ -1209,16 +1172,8 @@ impl<'a> PackageInstall<'a> {
             let mut buf = bun_paths::w_path_buffer_pool::get();
             let mut buf2 = bun_paths::w_path_buffer_pool::get();
 
-            // SAFETY: FFI — destbase.fd() is an open handle; buf is a valid writable
-            // WPathBuffer of the passed length.
-            let dest_path_length = unsafe {
-                windows::GetFinalPathNameByHandleW(
-                    destbase.fd().native(),
-                    buf.as_mut_ptr(),
-                    u32::try_from(buf.len()).expect("int cast"),
-                    0,
-                )
-            } as usize;
+            let dest_path_length =
+                windows::get_final_path_name_by_handle_w(destbase.fd().native(), &mut buf[..], 0);
             if dest_path_length == 0 || dest_path_length >= buf.len() {
                 let err = crate::Error::Sys(if dest_path_length == 0 {
                     windows::last_system_errno()
@@ -1243,16 +1198,8 @@ impl<'a> PackageInstall<'a> {
             let _ = mkdir_recursive_os_path(fullpath);
             let to_copy_buf_off = fullpath.len();
 
-            // SAFETY: FFI — the walker's root is the open cache directory; buf2 is a
-            // valid writable WPathBuffer of the passed length.
-            let cache_path_length = unsafe {
-                windows::GetFinalPathNameByHandleW(
-                    walker.root().native(),
-                    buf2.as_mut_ptr(),
-                    u32::try_from(buf2.len()).expect("int cast"),
-                    0,
-                )
-            } as usize;
+            let cache_path_length =
+                windows::get_final_path_name_by_handle_w(walker.root().native(), &mut buf2[..], 0);
             if cache_path_length == 0 || cache_path_length >= buf2.len() {
                 let err = crate::Error::Sys(if cache_path_length == 0 {
                     windows::last_system_errno()
@@ -1279,7 +1226,11 @@ impl<'a> PackageInstall<'a> {
         }
     }
 
-    fn install_with_copyfile(&mut self, destination_dir: &Dir) -> InstallResult {
+    fn install_with_copyfile(
+        &mut self,
+        progress: Option<&mut Progress>,
+        destination_dir: &Dir,
+    ) -> InstallResult {
         let mut state = match self.init_install_dir(destination_dir, Method::Copyfile) {
             Ok(state) => state,
             Err(failure) => return InstallResult::Failure(failure),
@@ -1294,10 +1245,8 @@ impl<'a> PackageInstall<'a> {
         #[cfg(not(windows))]
         type WinOffset = ();
 
-        // Two overlapping slices into the same buffer (`head` is the whole
-        // buffer, `to_copy_into` is its tail) would be two live aliasing
-        // `&mut [u16]`, which is UB — pass head buffer + tail offset and
-        // reslice inside.
+        // Takes the whole buffer plus the tail's offset (not two slices of
+        // one buffer) and reslices inside.
         fn copy(
             destination_dir_: &Dir,
             walker: &mut Walker,
@@ -1339,16 +1288,7 @@ impl<'a> PackageInstall<'a> {
 
                     match entry.kind {
                         EntryKind::Directory => {
-                            // SAFETY: FFI — src/dest are valid NUL-terminated WStr buffers built
-                            // into head1/head2 above.
-                            if unsafe {
-                                windows::CreateDirectoryExW(
-                                    src.as_ptr(),
-                                    dest.as_ptr(),
-                                    core::ptr::null_mut(),
-                                )
-                            } == 0
-                            {
+                            if !windows::create_directory_ex_w(src, dest) {
                                 let _ = bun_sys::MakePath::make_path_u16(
                                     destination_dir_,
                                     entry.path.as_slice(),
@@ -1357,15 +1297,12 @@ impl<'a> PackageInstall<'a> {
                         }
                         EntryKind::File => {
                             // `dest` can be a hardlink of `src`, which CopyFileW cannot overwrite.
-                            // SAFETY: FFI — src/dest are valid NUL-terminated WStr buffers.
-                            let copy_file =
-                                || unsafe { windows::CopyFileW(src.as_ptr(), dest.as_ptr(), 1) } != 0;
+                            let copy_file = || windows::copy_file_w(src, dest, true);
                             if !copy_file() {
                                 let copied = match windows::Win32Error::get() {
                                     windows::Win32Error::FILE_EXISTS
                                     | windows::Win32Error::ALREADY_EXISTS => {
-                                        // SAFETY: FFI — dest is a valid NUL-terminated WStr buffer.
-                                        unsafe { windows::DeleteFileW(dest.as_ptr()) };
+                                        let _ = windows::delete_file_w(dest);
                                         copy_file()
                                     }
                                     _ => {
@@ -1418,7 +1355,7 @@ impl<'a> PackageInstall<'a> {
 
                     bun_output::scoped_log!(
                         install,
-                        "createFile {} {}\n",
+                        "create_file {} {}\n",
                         destination_dir_.fd(),
                         bstr::BStr::new(entry.path.as_bytes())
                     );
@@ -1513,22 +1450,14 @@ impl<'a> PackageInstall<'a> {
         let result = copy(
             &state.subdir,
             &mut state.walker,
-            self.progress.as_deref_mut(),
+            progress,
             state.to_copy_buf_off,
             &mut state.buf[..],
             state.to_copy_buf2_off,
             &mut state.buf2[..],
         );
         #[cfg(not(windows))]
-        let result = copy(
-            &state.subdir,
-            &mut state.walker,
-            self.progress.as_deref_mut(),
-            (),
-            (),
-            (),
-            (),
-        );
+        let result = copy(&state.subdir, &mut state.walker, progress, (), (), (), ());
 
         if let Err(err) = result {
             return InstallResult::fail(err, Step::CopyingFiles, None);
@@ -1537,7 +1466,11 @@ impl<'a> PackageInstall<'a> {
         InstallResult::Success
     }
 
-    fn install_with_hardlink(&mut self, dest_dir: &Dir) -> crate::Result<InstallResult> {
+    fn install_with_hardlink(
+        &mut self,
+        thread_pool: &ThreadPool,
+        dest_dir: &Dir,
+    ) -> crate::Result<InstallResult> {
         let mut state = match self.init_install_dir(dest_dir, Method::Hardlink) {
             Ok(state) => state,
             Err(failure) => return Ok(InstallResult::Failure(failure)),
@@ -1552,11 +1485,10 @@ impl<'a> PackageInstall<'a> {
         #[cfg(not(windows))]
         type WinOffset = ();
 
-        // Two overlapping slices into the same buffer (`head` is the whole
-        // buffer, `to_copy_into` is its tail) would be two live aliasing
-        // `&mut [u16]`, which is UB — pass head buffer + tail offset and
-        // reslice inside.
+        // Takes the whole buffer plus the tail's offset (not two slices of
+        // one buffer) and reslices inside.
         fn copy(
+            thread_pool: &ThreadPool,
             destination_dir: &Dir,
             walker: &mut Walker,
             to_copy_into1_offset: WinOffset,
@@ -1565,16 +1497,21 @@ impl<'a> PackageInstall<'a> {
             head2: WinSlice<'_>,
         ) -> crate::Result<()> {
             #[cfg(not(windows))]
-            let _ = (to_copy_into1_offset, head1, to_copy_into2_offset, head2);
+            let _ = (
+                thread_pool,
+                to_copy_into1_offset,
+                head1,
+                to_copy_into2_offset,
+                head2,
+            );
             #[cfg(windows)]
             let _ = destination_dir;
             #[cfg(windows)]
-            let queue = HardLinkWindowsInstallTask::init_queue();
+            let queue = HardLinkBatch::new();
             // on Windows, tasks already pushed to `queue` are running on
-            // worker threads; an early `?` here would return before `queue.wait()`,
-            // letting the caller re-enter `init_queue()` and reset the WaitGroup
-            // while workers are still inside `complete_one()` (data race on the
-            // counter/condvar). Capture loop errors and always fall through to wait.
+            // worker threads; an early `?` here would return before `queue.wait()`
+            // while workers still report into the batch. Capture loop errors and
+            // always fall through to wait.
             #[cfg(windows)]
             let mut loop_err: Option<crate::Error> = None;
 
@@ -1660,15 +1597,15 @@ impl<'a> PackageInstall<'a> {
                     head2[src_len] = 0;
                     let src = bun_core::WStr::from_buf(head2, src_len);
 
-                    // SAFETY: `init` returns a fresh Box-allocated task; ownership
-                    // transfers to the thread pool, reclaimed in `run_from_thread_pool`.
-                    unsafe {
-                        queue.push(HardLinkWindowsInstallTask::init(
+                    queue.push(
+                        thread_pool,
+                        HardLinkWindowsInstallTask::new(
+                            &queue,
                             src.as_slice(),
                             dest.as_slice(),
                             entry.basename.as_slice(),
-                        ));
-                    }
+                        ),
+                    );
                 }
             }
 
@@ -1681,10 +1618,8 @@ impl<'a> PackageInstall<'a> {
                 }
 
                 // No tasks are running after `wait()`, so `.take()` is uncontended.
-                if let Some(task) = queue.errored_task.lock().take() {
-                    if let Some(err) = task.err {
-                        return Err(err);
-                    }
+                if let Some(err) = queue.errored.lock().take() {
+                    return Err(err);
                 }
             }
 
@@ -1693,6 +1628,7 @@ impl<'a> PackageInstall<'a> {
 
         #[cfg(windows)]
         let result = copy(
+            thread_pool,
             &state.subdir,
             &mut state.walker,
             state.to_copy_buf_off,
@@ -1701,7 +1637,15 @@ impl<'a> PackageInstall<'a> {
             &mut state.buf2[..],
         );
         #[cfg(not(windows))]
-        let result = copy(&state.subdir, &mut state.walker, (), (), (), ());
+        let result = copy(
+            thread_pool,
+            &state.subdir,
+            &mut state.walker,
+            (),
+            (),
+            (),
+            (),
+        );
 
         if let Err(err) = result {
             #[cfg(windows)]
@@ -1760,10 +1704,8 @@ impl<'a> PackageInstall<'a> {
         #[cfg(not(windows))]
         type Head2Char = u8;
 
-        // Two overlapping slices into the same buffer (`head` is the whole
-        // buffer, `to_copy_into` is its tail) would be two live aliasing
-        // `&mut`, which is UB — pass head buffer + tail offset and reslice
-        // inside.
+        // Takes the whole buffer plus the tail's offset (not two slices of
+        // one buffer) and reslices inside.
         fn copy(
             destination_dir: &Dir,
             walker: &mut Walker,
@@ -1789,7 +1731,6 @@ impl<'a> PackageInstall<'a> {
                             head2[to_copy_into2_offset..target_len]
                                 .copy_from_slice(entry.path.as_bytes());
                             head2[target_len] = 0;
-                            // SAFETY: NUL written above.
                             let target = ZStr::from_buf(head2, target_len);
 
                             if let Err(err) =
@@ -1832,16 +1773,7 @@ impl<'a> PackageInstall<'a> {
 
                     match entry.kind {
                         EntryKind::Directory => {
-                            // SAFETY: FFI — src/dest are valid NUL-terminated WStr buffers built
-                            // into head1/head2 above.
-                            if unsafe {
-                                windows::CreateDirectoryExW(
-                                    src.as_ptr(),
-                                    dest.as_ptr(),
-                                    core::ptr::null_mut(),
-                                )
-                            } == 0
-                            {
+                            if !windows::create_directory_ex_w(src, dest) {
                                 let _ = bun_sys::MakePath::make_path_u16(
                                     destination_dir,
                                     entry.path.as_slice(),
@@ -1924,7 +1856,11 @@ impl<'a> PackageInstall<'a> {
         Ok(InstallResult::Success)
     }
 
-    pub(crate) fn uninstall_before_install(&self, destination_dir: &Dir) {
+    pub(crate) fn uninstall_before_install(
+        &self,
+        manager: &mut PackageManager,
+        destination_dir: &Dir,
+    ) {
         let mut rand_path_buf = [0u8; 48];
         let rand_bytes = bun_core::fast_random().to_ne_bytes();
         let temp_path = {
@@ -1934,13 +1870,12 @@ impl<'a> PackageInstall<'a> {
                 .expect("infallible: in-memory write");
             let written = 48 - cursor.len();
             rand_path_buf[written] = 0;
-            // SAFETY: NUL written at [written].
             ZStr::from_buf(&rand_path_buf, written)
         };
 
         match sys::renameat(
             destination_dir.fd(),
-            self.destination_dir_subpath,
+            self.destination_dir_subpath(),
             destination_dir.fd(),
             temp_path,
         ) {
@@ -1974,29 +1909,13 @@ impl<'a> PackageInstall<'a> {
                     bun_fs::FileSystem::instance().top_level_dir(),
                     &[&self.node_modules.path, temp_path.as_bytes()],
                 );
-                let task = bun_core::heap::into_raw(Box::new(UninstallTask {
+                manager.total_tasks += 1;
+                manager.shared.pending_tasks.fetch_add(1, Ordering::Relaxed);
+                manager.thread_pool.schedule_owned(Box::new(UninstallTask {
                     absolute_path: absolute_path.to_vec().into_boxed_slice(),
-                    task: WorkPoolTask {
-                        callback: UninstallTask::run,
-                        node: ThreadPoolNode::default(),
-                    },
+                    task: WorkPoolTask::default(),
+                    shared: manager.shared,
                 }));
-                let pm = crate::package_manager::get();
-                // SAFETY: `uninstall_before_install` runs on the install main thread.
-                // Raw-pointer field projection avoids forming `&mut PackageManager`
-                // (the caller `PackageInstaller` already holds one); `total_tasks` is
-                // main-thread-only state, `pending_tasks` is atomic. Mirrors
-                // `increment_pending_tasks`.
-                unsafe {
-                    *core::ptr::addr_of_mut!((*pm).total_tasks) += 1;
-                    (*pm).pending_tasks.fetch_add(1, Ordering::Relaxed);
-                }
-                // SAFETY: task is a valid heap allocation; .task is the intrusive node.
-                PackageManager::get()
-                    .thread_pool
-                    .schedule(Batch::from(unsafe {
-                        core::ptr::addr_of_mut!((*task).task)
-                    }));
             }
         }
     }
@@ -2036,15 +1955,16 @@ impl<'a> PackageInstall<'a> {
 
     pub(crate) fn install_from_link(
         &mut self,
+        manager: &mut PackageManager,
         skip_delete: bool,
         destination_dir: &Dir,
     ) -> InstallResult {
-        let dest_path = self.destination_dir_subpath;
         // If this fails, we don't care.
         // we'll catch it the next error
-        if !skip_delete && dest_path.as_bytes() != b"." {
-            self.uninstall_before_install(destination_dir);
+        if !skip_delete && self.destination_dir_subpath().as_bytes() != b"." {
+            self.uninstall_before_install(manager, destination_dir);
         }
+        let dest_path = self.destination_dir_subpath();
 
         // `None` when there is no directory component.
         let dirname_slice =
@@ -2059,7 +1979,7 @@ impl<'a> PackageInstall<'a> {
         let mut to_buf = bun_paths::path_buffer_pool::get();
         // Open the target relative to cache_dir, then resolve its canonical path.
         // Returning a borrow of `to_buf` from an `FnMut` closure is rejected by
-        // borrowck, so inline the open/getFdPath/close.
+        // borrowck, so inline the open/get_fd_path/close.
         // `bun_sys::Error::into()` would yield raw errno tags (`ENOENT`/`EACCES`),
         // so map the openat errno to the named error tag to preserve the
         // user-visible error tag
@@ -2106,16 +2026,11 @@ impl<'a> PackageInstall<'a> {
         {
             use bun_sys::windows;
             let mut wbuf = bun_paths::w_path_buffer_pool::get();
-            // SAFETY: FFI — destination_dir.fd() is an open handle; wbuf is a valid writable
-            // WPathBuffer of the passed length.
-            let dest_path_length = unsafe {
-                windows::GetFinalPathNameByHandleW(
-                    destination_dir.fd().native(),
-                    wbuf.as_mut_ptr(),
-                    u32::try_from(wbuf.len()).expect("int cast"),
-                    0,
-                )
-            } as usize;
+            let dest_path_length = windows::get_final_path_name_by_handle_w(
+                destination_dir.fd().native(),
+                &mut wbuf[..],
+                0,
+            );
             if dest_path_length == 0 || dest_path_length >= wbuf.len() {
                 let err = crate::Error::Sys(if dest_path_length == 0 {
                     windows::last_system_errno()
@@ -2136,7 +2051,6 @@ impl<'a> PackageInstall<'a> {
                 wbuf[i] = bun_paths::SEP_WINDOWS as u16;
                 i += 1;
                 wbuf[i] = 0;
-                // SAFETY: NUL written at [i].
                 let fullpath = bun_core::WStr::from_buf(&wbuf[..], i);
 
                 let _ = mkdir_recursive_os_path(fullpath);
@@ -2152,12 +2066,10 @@ impl<'a> PackageInstall<'a> {
             offset += dest.len();
             dest_buf[offset] = 0;
 
-            // SAFETY: NUL written at [offset].
             let dest_z = ZStr::from_buf(&dest_buf, offset);
 
             let to_len = to_path.len();
             to_buf[to_len] = 0;
-            // SAFETY: NUL written at [to_len].
             let target_z = ZStr::from_buf(&to_buf, to_len);
 
             // https://github.com/npm/cli/blob/162c82e845d410ede643466f9f8af78a312296cc/workspaces/arborist/lib/arborist/reify.js#L738
@@ -2166,7 +2078,7 @@ impl<'a> PackageInstall<'a> {
                 Err(err_) => 'brk: {
                     let mut err = err_;
                     if err.get_errno() == sys::E::EEXIST {
-                        let _ = sys::rmdirat(destination_dir.fd(), self.destination_dir_subpath);
+                        let _ = sys::rmdirat(destination_dir.fd(), self.destination_dir_subpath());
                         match sys::symlink_or_junction(dest_z, target_z, None) {
                             Err(e) => err = e,
                             Ok(_) => break 'brk,
@@ -2213,11 +2125,9 @@ impl<'a> PackageInstall<'a> {
             let mut target_buf = bun_paths::path_buffer_pool::get();
             target_buf[..target.len()].copy_from_slice(target);
             target_buf[target.len()] = 0;
-            // SAFETY: NUL written above.
             let target_z = ZStr::from_buf(&target_buf, target.len());
             let mut dest_name_buf = [0u8; 512];
             dest_name_buf[..dest.len()].copy_from_slice(dest);
-            // SAFETY: zero-initialized; NUL at [dest.len()].
             let dest_z = ZStr::from_buf(&dest_name_buf, dest.len());
             if let Err(err) = sys::symlinkat(target_z, dest_dir.fd(), dest_z) {
                 return InstallResult::fail(err.into(), Step::LinkingDependency, None);
@@ -2298,6 +2208,7 @@ impl<'a> PackageInstall<'a> {
 
     pub(crate) fn install(
         &mut self,
+        mut env: InstallEnv<'_>,
         skip_delete: bool,
         destination_dir: &Dir,
         method_: Method,
@@ -2307,15 +2218,17 @@ impl<'a> PackageInstall<'a> {
 
         // If this fails, we don't care.
         // we'll catch it the next error
-        if !skip_delete && self.destination_dir_subpath.as_bytes() != b"." {
-            self.uninstall_before_install(destination_dir);
+        if !skip_delete && self.destination_dir_subpath().as_bytes() != b"." {
+            if let InstallEnv::Manager(manager) = &mut env {
+                self.uninstall_before_install(manager, destination_dir);
+            }
         }
 
         let mut supported_method_to_use = method_;
 
         if resolution_tag == resolution::Tag::Folder
-            && !self
-                .lockfile
+            && !env
+                .lockfile()
                 .is_workspace_tree_id(self.node_modules.tree_id)
         {
             supported_method_to_use = Method::Symlink;
@@ -2370,7 +2283,7 @@ impl<'a> PackageInstall<'a> {
             }
             #[allow(unused_labels)]
             Method::Hardlink => 'outer: {
-                match self.install_with_hardlink(destination_dir) {
+                match self.install_with_hardlink(env.thread_pool(), destination_dir) {
                     Ok(result) => return result,
                     Err(err) => {
                         #[cfg(not(windows))]
@@ -2414,7 +2327,7 @@ impl<'a> PackageInstall<'a> {
         }
 
         // TODO: linux io_uring
-        self.install_with_copyfile(destination_dir)
+        self.install_with_copyfile(env.progress(), destination_dir)
     }
 }
 

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -10,10 +10,8 @@ use bun_semver::String;
 use bun_sys::{self as Syscall, Dir, Fd};
 
 use crate::bin_real as bin;
-use crate::bin_real::Bin;
-use crate::bun_bunfig::Arguments as Command;
 use crate::bun_fs::FileSystem;
-use crate::bun_progress::{Node as ProgressNode, Progress};
+use crate::bun_progress::Node as ProgressNode;
 
 use crate::lifecycle_script_runner::LifecycleScriptSubprocess;
 // `Lockfile` here is the in-crate `crate::lockfile::Lockfile` (the
@@ -21,12 +19,10 @@ use crate::lifecycle_script_runner::LifecycleScriptSubprocess;
 // imported for `tree::Id` / `Tree` / `package::*`, all of
 // which are the same types re-exported through `crate::lockfile`.
 use crate::lockfile::Lockfile;
-use crate::lockfile_real::package::{
-    self as Package, PackageColumns, scripts::Scripts as PackageScripts,
-};
+use crate::lockfile_real::package::{PackageColumns, scripts::Scripts as PackageScripts};
 use crate::lockfile_real::{self as lockfile, Tree};
 use crate::network_task::ForTarballError;
-use crate::package_install::{self, PackageInstall};
+use crate::package_install::{self, InstallEnv, PackageInstall};
 use crate::package_manager::{self, Options, PackageManager};
 use crate::package_manager_real::progress_strings::ProgressStrings;
 use crate::package_manager_task as task;
@@ -34,8 +30,8 @@ use crate::patch_install::{self, PatchTask};
 use crate::postinstall_optimizer::{self, PostinstallOptimizer};
 use crate::resolution::{self, Resolution};
 use crate::{
-    DependencyID, DependencyInstallContext, ExtractData, PackageID, PackageNameHash,
-    TaskCallbackContext, TruncatedPackageNameHash, invalid_package_id,
+    DependencyID, DependencyInstallContext, ExtractData, PackageID, TaskCallbackContext,
+    TruncatedPackageNameHash, invalid_package_id,
 };
 
 bun_output::declare_scope!(PackageInstaller, hidden);
@@ -49,19 +45,7 @@ pub struct PendingLifecycleScript {
 }
 
 pub struct PackageInstaller<'a> {
-    /// BACKREF into the singleton. Raw pointer (not
-    /// `&'a mut`) because the install loop also re-borrows the same object
-    /// via the caller's `this`/`mgr_ptr` (e.g. `run_tasks(this, &mut installer)`
-    /// in `hoisted_install`); a `&'a mut` here would assert exclusivity that
-    /// the call shape contradicts. Never null. Access via `manager()` /
-    /// `manager_mut()`.
-    pub(crate) manager: *mut PackageManager,
-    /// BACKREF into `(*manager).lockfile`. Same aliasing
-    /// rationale as `manager`; the column-slice fields below also point into
-    /// it. Never null. Access via `lockfile()` / `lockfile_mut()`.
-    pub lockfile: *mut Lockfile,
-    /// BACKREF into `(*manager).progress`. Never null.
-    pub(crate) progress: *mut Progress,
+    pub manager: &'a mut PackageManager,
 
     /// relative paths from `next` will be copied into this list.
     pub(crate) node_modules: NodeModulesFolder,
@@ -71,27 +55,10 @@ pub struct PackageInstaller<'a> {
     pub(crate) force_install: bool,
     pub(crate) root_node_modules_folder: Dir,
     pub(crate) summary: &'a mut package_install::Summary,
-    // No `options` backref field — every caller reads via
-    // `self.manager().options` so the shared borrow stays a child of the live
-    // `&mut PackageManager` Unique tag rather than a sibling raw.
-    // The following slice fields alias into `self.lockfile.packages` (BACKREF).
-    // Stored as `RawSlice<T>` (raw `*const [T]`, `usize` len) — the lockfile's
-    // `MultiArrayList<Package>` column buffers outlive this `PackageInstaller`
-    // and are only ever *grown*, never freed; `fix_cached_lockfile_package_slices`
-    // re-snapshots after a grow. `RawSlice` carries no lifetime, so the
-    // assignment sites do not need a `&'a → &'a` lifetime-detach round-trip.
-    // Every `resolutions` call site is a read (`&raw const self.resolutions[i]`),
-    // so it is also `RawSlice` here.
-    pub(crate) metas: bun_ptr::RawSlice<Package::Meta>,
-    pub(crate) names: bun_ptr::RawSlice<String>,
-    pub(crate) pkg_name_hashes: bun_ptr::RawSlice<PackageNameHash>,
-    pub(crate) bins: bun_ptr::RawSlice<Bin>,
-    pub(crate) resolutions: bun_ptr::RawSlice<Resolution>,
     pub(crate) node: &'a mut ProgressNode,
     pub(crate) destination_dir_subpath_buf: PathBuffer,
     pub(crate) folder_path_buf: PathBuffer,
     pub(crate) successfully_installed: Bitset,
-    pub(crate) command_ctx: Command::Context<'a>,
     pub(crate) current_tree_id: lockfile::tree::Id,
     /// Trees that live under a self-contained workspace: packages there are copied
     /// (real files) rather than hardlinked/cloned/symlinked from the cache, so tools
@@ -243,7 +210,7 @@ impl NodeModulesFolder {
         }
     }
 
-    fn make_and_open_dir(&mut self, root: &Dir) -> crate::Result<Dir> {
+    fn make_and_open_dir(&self, root: &Dir) -> crate::Result<Dir> {
         let out = 'brk: {
             #[cfg(unix)]
             {
@@ -276,6 +243,29 @@ impl NodeModulesFolder {
     }
 }
 
+/// Where a `PackageInstall`'s `cache_dir_subpath` lives.
+#[derive(Clone, Copy)]
+enum Subpath {
+    Static(&'static ZStr),
+    /// `folder_path_buf[..len]`, NUL at `len`.
+    Folder(usize),
+}
+
+impl Subpath {
+    const DOT: Subpath = Subpath::Static(ZStr::from_static(b".\0"));
+    #[inline]
+    fn of(z: &ZStr) -> Subpath {
+        Subpath::Folder(z.len())
+    }
+    #[inline]
+    fn get(self, folder_path_buf: &PathBuffer) -> &ZStr {
+        match self {
+            Subpath::Static(z) => z,
+            Subpath::Folder(len) => ZStr::from_buf(&folder_path_buf[..], len),
+        }
+    }
+}
+
 pub struct TreeContext {
     /// Each tree (other than the root tree) can accumulate packages it cannot install until
     /// each parent tree has installed their packages. We keep arrays of these pending
@@ -287,15 +277,14 @@ pub struct TreeContext {
     /// being able to install it's dependencies
     pub(crate) pending_installs: Vec<DependencyInstallContext>,
 
-    pub(crate) binaries: bin::PriorityQueue,
+    /// Drained in dependency-name order by `link_tree_bins`.
+    pub(crate) binaries: Vec<DependencyID>,
 
     /// Number of installed dependencies. Could be successful or failure.
     pub(crate) install_count: usize,
 }
 
 type TreeContextId = lockfile::tree::Id;
-
-// TreeContext::deinit dropped — Vec and Bin::PriorityQueue impl Drop.
 
 /// Finds the tree whose `node_modules` contains `target_pkg_id`, walked in
 /// Node resolution order from `<start_tree>/<alias>/`: the child tree at
@@ -402,61 +391,6 @@ fn print_package_version<'a>(
 }
 
 impl<'a> PackageInstaller<'a> {
-    // ──────────────────────────────────────────────────────────────────────
-    // BACKREF accessors
-    //
-    // `manager` / `lockfile` / `options` point at allocations *outside*
-    // `Self` (the singleton `PackageManager`, its boxed `Lockfile`, and its
-    // `options` field), so a `&mut PackageManager` returned here never
-    // overlaps `*self`. The `_mut` accessors take `&self` (not `&mut self`)
-    // so call sites retain field-disjoint borrow semantics — e.g.
-    // `self.manager_mut().spawn(self.command_ctx, ...)` — exactly as the
-    // original `&'a mut PackageManager` field allowed. The *return* lifetime
-    // is `'a` (not elided to the `&self` borrow) for the same reason: e.g.
-    // `link_tree_bins` does `let m = self.manager_mut(); let t = &mut
-    // self.trees[i];` — an elided return would keep `self` borrowed shared
-    // while `m` is live and reject the later `&mut self.trees` projection.
-    // The single-threaded install pass guarantees no two `&mut
-    // PackageManager` are live at once; callers must not hold the result
-    // across a call that re-derives one through another path.
-    // ──────────────────────────────────────────────────────────────────────
-
-    #[inline]
-    fn manager(&self) -> &'a PackageManager {
-        // SAFETY: BACKREF — never null; pointee outlives `'a`.
-        unsafe { &*self.manager }
-    }
-
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn manager_mut(&self) -> &'a mut PackageManager {
-        // SAFETY: BACKREF — never null; disjoint from `*self`; install pass
-        // is single-threaded so no concurrent `&mut PackageManager` exists.
-        unsafe { &mut *self.manager }
-    }
-
-    #[inline]
-    fn lockfile(&self) -> &'a Lockfile {
-        // SAFETY: BACKREF — never null; pointee outlives `'a`.
-        unsafe { &*self.lockfile }
-    }
-
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn lockfile_mut(&self) -> &'a mut Lockfile {
-        // SAFETY: BACKREF — never null; disjoint from `*self`; see `manager_mut`.
-        unsafe { &mut *self.lockfile }
-    }
-
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn progress_mut(&self) -> &'a mut Progress {
-        // SAFETY: BACKREF into `manager.progress` — never null; disjoint from
-        // `*self`; the install pass is single-threaded so no concurrent `&mut
-        // Progress` exists. Same shape as `manager_mut`/`lockfile_mut`.
-        unsafe { &mut *self.progress }
-    }
-
     /// Increments the number of installed packages for a tree id and runs available scripts
     /// if the tree is finished.
     // `should_install_packages` only gates a single call below, so it's a
@@ -471,7 +405,7 @@ impl<'a> PackageInstaller<'a> {
 
         let tree = &mut self.trees[tree_id as usize];
         let current_count = tree.install_count;
-        let max = self.lockfile().buffers.trees.as_slice()[tree_id as usize]
+        let max = self.manager.lockfile.buffers.trees.as_slice()[tree_id as usize]
             .dependencies
             .len as usize;
 
@@ -500,13 +434,12 @@ impl<'a> PackageInstaller<'a> {
 
         self.completed_trees.set(tree_id as usize);
 
-        if self.trees[tree_id as usize].binaries.count() > 0 {
+        if !self.trees[tree_id as usize].binaries.is_empty() {
             self.seen_bin_links.clear();
 
             let mut link_target_buf = bun_paths::path_buffer_pool::get();
             let mut link_dest_buf = bun_paths::path_buffer_pool::get();
             let mut link_rel_buf = bun_paths::path_buffer_pool::get();
-            // reshaped for borrowck — pass tree_id, re-borrow tree inside.
             self.link_tree_bins(
                 tree_id,
                 true,
@@ -535,12 +468,18 @@ impl<'a> PackageInstaller<'a> {
         link_rel_buf: &mut [u8],
         log_level: Options::LogLevel,
     ) {
-        let lockfile = self.lockfile();
-        let manager = self.manager_mut();
+        let PackageManager {
+            lockfile,
+            log,
+            options,
+            postinstall_optimizer,
+            update_requests,
+            ..
+        } = &mut *self.manager;
+        let lockfile: &Lockfile = lockfile;
         let string_buf = lockfile.buffers.string_bytes.as_slice();
         let mut node_modules_path: AbsPath =
             AbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
-        // `defer node_modules_path.deinit()` — AbsPath impls Drop.
 
         let pkgs = lockfile.packages.slice();
         let pkg_name_hashes = pkgs.items_name_hash();
@@ -553,11 +492,21 @@ impl<'a> PackageInstaller<'a> {
         let tree = &mut self.trees[tree_id as usize];
         let mut deferred: Vec<DependencyID> = Vec::new();
 
-        while let Some(dep_id) = tree.binaries.remove_or_null() {
+        let mut binaries = core::mem::take(&mut tree.binaries);
+        {
+            let dependencies = lockfile.buffers.dependencies.as_slice();
+            binaries.sort_unstable_by(|&a, &b| {
+                strings::order(
+                    dependencies[a as usize].name.slice(string_buf),
+                    dependencies[b as usize].name.slice(string_buf),
+                )
+            });
+        }
+        for dep_id in binaries {
             debug_assert!((dep_id as usize) < lockfile.buffers.dependencies.as_slice().len());
             let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
             debug_assert!(package_id != invalid_package_id);
-            let bin = self.bins[package_id as usize];
+            let bin = lockfile.packages.items_bin()[package_id as usize];
             debug_assert!(bin.tag != bin::Tag::None);
 
             let alias = lockfile.buffers.dependencies.as_slice()[dep_id as usize]
@@ -568,26 +517,23 @@ impl<'a> PackageInstaller<'a> {
             let mut can_retry_without_native_binlink_optimization = false;
             let mut target_node_modules_path_opt: Option<AbsPath> = None;
             let mut defer_this_bin = false;
-            // `defer if (target_node_modules_path_opt) |*path| path.deinit()` — Option<AbsPath> drops.
 
             'native_binlink_optimization: {
-                if !manager.postinstall_optimizer.is_native_binlink_enabled() {
+                if !postinstall_optimizer.is_native_binlink_enabled() {
                     break 'native_binlink_optimization;
                 }
                 // Check for native binlink optimization
                 let name_hash = pkg_name_hashes[package_id as usize];
                 if let Some(optimizer) =
-                    manager
-                        .postinstall_optimizer
-                        .get(&postinstall_optimizer::PkgInfo {
-                            name_hash,
-                            ..Default::default()
-                        })
+                    postinstall_optimizer.get(&postinstall_optimizer::PkgInfo {
+                        name_hash,
+                        ..Default::default()
+                    })
                 {
                     match optimizer {
                         PostinstallOptimizer::NativeBinlink => {
-                            let target_cpu = manager.options.cpu;
-                            let target_os = manager.options.os;
+                            let target_cpu = options.cpu;
+                            let target_os = options.os;
                             if let Some(replacement_pkg_id) =
                                 PostinstallOptimizer::get_native_binlink_replacement_package_id(
                                     pkg_resolutions_lists[package_id as usize]
@@ -643,11 +589,11 @@ impl<'a> PackageInstaller<'a> {
             }
             // globally linked packages shouls always belong to the root
             // tree (0).
-            let global = if !manager.options.global || tree_id != 0 {
+            let global = if !options.global || tree_id != 0 {
                 false
             } else {
                 'global: {
-                    for request in manager.update_requests.iter() {
+                    for request in update_requests.iter() {
                         if request.package_id == package_id {
                             break 'global true;
                         }
@@ -657,31 +603,16 @@ impl<'a> PackageInstaller<'a> {
             };
 
             loop {
-                // `node_modules_path` (mut) and `target_node_modules_path`
-                // (read-only) refer to the same buffer when no replacement is
-                // set. Derive both from a single `*mut` so the read pointer
-                // shares the write reference's provenance (a `*const` taken
-                // from `&node_modules_path` would be popped by the later
-                // `&mut` reborrow under stacked-borrows).
-                // SAFETY: `bin::Linker::link` only reads `target_node_modules_path` and
-                // never writes through it while `node_modules_path` is borrowed.
-                let nm_ptr: *mut AbsPath = &raw mut node_modules_path;
                 let mut bin_linker = bin::Linker {
                     bin,
-                    global_bin_path: manager.options.bin_path,
+                    global_bin_path: options.bin_path,
                     package_name: package_name_,
                     target_package_name,
                     string_buf,
                     extern_string_buf: lockfile.buffers.extern_strings.as_slice(),
                     seen: Some(&mut self.seen_bin_links),
-                    target_node_modules_path: target_node_modules_path_opt
-                        .as_ref()
-                        .map(std::ptr::from_ref::<AbsPath>)
-                        .unwrap_or_else(|| nm_ptr.cast_const()),
-                    // SAFETY: `nm_ptr` = `&raw mut node_modules_path` (live local); the only
-                    // other pointer derived from it is the read-only `target_node_modules_path`
-                    // above, which `bin::Linker::link` never writes through.
-                    node_modules_path: unsafe { &mut *nm_ptr },
+                    target_node_modules_path: target_node_modules_path_opt.as_ref(),
+                    node_modules_path: &mut node_modules_path,
                     abs_target_buf: link_target_buf,
                     abs_dest_buf: link_dest_buf,
                     rel_buf: link_rel_buf,
@@ -710,7 +641,7 @@ impl<'a> PackageInstaller<'a> {
                 if let Some(err) = bin_linker.err {
                     if log_level != Options::LogLevel::Silent {
                         bun_ast::add_error_pretty!(
-                            manager.log_mut(),
+                            log,
                             None,
                             bun_ast::Loc::EMPTY,
                             "Failed to link <b>{}<r>: {}",
@@ -719,8 +650,8 @@ impl<'a> PackageInstaller<'a> {
                         );
                     }
 
-                    if manager.options.enable.fail_early() {
-                        manager.crash();
+                    if options.enable.fail_early() {
+                        PackageManager::crash_with_log(options, log);
                     }
                 }
 
@@ -728,9 +659,7 @@ impl<'a> PackageInstaller<'a> {
             }
         }
 
-        for dep_id in deferred {
-            tree.binaries.add(dep_id).unwrap_or_oom();
-        }
+        tree.binaries.extend_from_slice(&deferred);
     }
 
     pub(crate) fn link_remaining_bins(&mut self, log_level: Options::LogLevel) {
@@ -744,8 +673,7 @@ impl<'a> PackageInstaller<'a> {
 
         let trees_len = self.trees.len();
         for tree_id in 0..trees_len {
-            // reshaped for borrowck — index instead of `for (self.trees, 0..) |*tree, tree_id|`.
-            if self.trees[tree_id].binaries.count() > 0 {
+            if !self.trees[tree_id].binaries.is_empty() {
                 self.seen_bin_links.clear();
                 self.node_modules.path.truncate(
                     strings::without_trailing_slash(FileSystem::instance().top_level_dir()).len()
@@ -754,9 +682,9 @@ impl<'a> PackageInstaller<'a> {
                 let (rel_path, _) = lockfile::tree::relative_path_and_depth::<
                     { lockfile::tree::IteratorPathStyle::NodeModules },
                 >(
-                    self.lockfile().buffers.trees.as_slice(),
-                    self.lockfile().buffers.dependencies.as_slice(),
-                    self.lockfile().buffers.string_bytes.as_slice(),
+                    self.manager.lockfile.buffers.trees.as_slice(),
+                    self.manager.lockfile.buffers.dependencies.as_slice(),
+                    self.manager.lockfile.buffers.string_bytes.as_slice(),
                     // `tree_id` ranges over `0..self.trees.len()`
                     // and tree IDs are u32 by construction; avoid the
                     // `try_from` panic-format path on this per-tree loop.
@@ -789,13 +717,11 @@ impl<'a> PackageInstaller<'a> {
             let optional = self.pending_lifecycle_scripts[i].optional;
             if self.can_run_scripts(tree_id) {
                 let entry = self.pending_lifecycle_scripts.swap_remove(i);
-                // reshaped for borrowck — `package_name` is `Box<[u8]>`;
-                // clone it for the error message since `entry.list` is moved into `spawn`.
+                // Cloned for the error message; `entry.list` is moved into the spawn.
                 let name: Box<[u8]> = entry.list.package_name.clone();
                 let output_in_foreground = false;
 
-                if let Err(err) = self.manager_mut().spawn_package_lifecycle_scripts(
-                    self.command_ctx,
+                if let Err(err) = self.manager.spawn_package_lifecycle_scripts(
                     entry.list,
                     optional,
                     output_in_foreground,
@@ -804,7 +730,7 @@ impl<'a> PackageInstaller<'a> {
                     if log_level != Options::LogLevel::Silent {
                         if log_level.show_progress() {
                             if Output::enable_ansi_colors_stderr() {
-                                self.progress_mut().log(format_args!(
+                                self.manager.progress.log(format_args!(
                                     bun_core::pretty_fmt!(
                                         "\n<r><red>error:<r> failed to spawn life-cycle scripts for <b>{s}<r>: {s}\n",
                                         true
@@ -813,7 +739,7 @@ impl<'a> PackageInstaller<'a> {
                                     err.name(),
                                 ));
                             } else {
-                                self.progress_mut().log(format_args!(
+                                self.manager.progress.log(format_args!(
                                     bun_core::pretty_fmt!(
                                         "\n<r><red>error:<r> failed to spawn life-cycle scripts for <b>{s}<r>: {s}\n",
                                         false
@@ -831,7 +757,7 @@ impl<'a> PackageInstaller<'a> {
                         }
                     }
 
-                    if self.manager().options.enable.fail_early() {
+                    if self.manager.options.enable.fail_early() {
                         Global::exit(1);
                     }
 
@@ -854,35 +780,28 @@ impl<'a> PackageInstaller<'a> {
 
         let trees_len = self.trees.len();
         for i in 0..trees_len {
-            // reshaped for borrowck — index instead of iter_mut.
             if FORCE
                 || Self::can_install_package_for_tree(
                     &self.completed_trees,
-                    self.lockfile().buffers.trees.as_slice(),
+                    self.manager.lockfile.buffers.trees.as_slice(),
                     // `i` ranges over `0..self.trees.len()`; tree
                     // IDs are u32 by construction.
                     i as u32,
                 )
             {
                 // If installing these packages completes the tree, we don't allow it
-                // to call `installAvailablePackages` recursively. Starting at id 0 and
+                // to call `install_available_packages` recursively. Starting at id 0 and
                 // going up ensures we will reach any trees that will be able to install
                 // packages upon completing the current tree
                 //
-                // spec iterates `tree.pending_installs.items` by struct
-                // copy (each `context.path` is the same allocation that lives in
-                // `pending_installs`) and `defer clearRetainingCapacity()` at the end.
-                // Drain by move (`mem::take`) to transfer ownership without the
-                // O(pending_installs) extra `.clone()` allocations and to leave
-                // `pending_installs` empty as the spec's defer does.
-                // `self.resolutions` is `RawSlice<Resolution>` (Copy); copy
-                // it out so the `&Resolution` argument below borrows the
-                // local, not `*self`, across the `&mut self` call.
-                let resolutions = self.resolutions;
+                // Drain by move (`mem::take`): no per-item clones, and
+                // `pending_installs` is left empty.
                 for context in core::mem::take(&mut self.trees[i].pending_installs) {
-                    let package_id = self.lockfile().buffers.resolutions.as_slice()
+                    let package_id = self.manager.lockfile.buffers.resolutions.as_slice()
                         [context.dependency_id as usize];
-                    let name = self.names[package_id as usize];
+                    let name = self.manager.lockfile.packages.items_name()[package_id as usize];
+                    let resolution =
+                        self.manager.lockfile.packages.items_resolution()[package_id as usize];
                     self.node_modules.tree_id = context.tree_id;
                     self.node_modules.path = context.path;
                     self.current_tree_id = context.tree_id;
@@ -898,7 +817,7 @@ impl<'a> PackageInstaller<'a> {
                         package_id,
                         log_level,
                         name,
-                        &resolutions[package_id as usize],
+                        &resolution,
                         needs_verify,
                         is_pending_package_install,
                     );
@@ -911,22 +830,19 @@ impl<'a> PackageInstaller<'a> {
     }
 
     pub(crate) fn complete_remaining_scripts(&mut self, log_level: Options::LogLevel) {
-        // reshaped for borrowck — drain by move since loop body needs `&mut
-        // self.manager` and `spawn_package_lifecycle_scripts` consumes the list.
         for entry in core::mem::take(&mut self.pending_lifecycle_scripts) {
             let package_name: Box<[u8]> = entry.list.package_name.clone();
             // .monotonic is okay because this value isn't modified from any other thread.
             // (Scripts are spawned on this thread.)
             while LifecycleScriptSubprocess::alive_count().load(Ordering::Relaxed)
-                >= self.manager().options.max_concurrent_lifecycle_scripts
+                >= self.manager.options.max_concurrent_lifecycle_scripts
             {
-                self.manager_mut().sleep();
+                self.manager.sleep();
             }
 
             let optional = entry.optional;
             let output_in_foreground = false;
-            if let Err(err) = self.manager_mut().spawn_package_lifecycle_scripts(
-                self.command_ctx,
+            if let Err(err) = self.manager.spawn_package_lifecycle_scripts(
                 entry.list,
                 optional,
                 output_in_foreground,
@@ -935,7 +851,7 @@ impl<'a> PackageInstaller<'a> {
                 if log_level != Options::LogLevel::Silent {
                     if log_level.show_progress() {
                         if Output::enable_ansi_colors_stderr() {
-                            self.progress_mut().log(format_args!(
+                            self.manager.progress.log(format_args!(
                                 bun_core::pretty_fmt!(
                                     "\n<r><red>error:<r> failed to spawn life-cycle scripts for <b>{s}<r>: {s}\n",
                                     true
@@ -944,7 +860,7 @@ impl<'a> PackageInstaller<'a> {
                                 err.name(),
                             ));
                         } else {
-                            self.progress_mut().log(format_args!(
+                            self.manager.progress.log(format_args!(
                                 bun_core::pretty_fmt!(
                                     "\n<r><red>error:<r> failed to spawn life-cycle scripts for <b>{s}<r>: {s}\n",
                                     false
@@ -962,7 +878,7 @@ impl<'a> PackageInstaller<'a> {
                     }
                 }
 
-                if self.manager().options.enable.fail_early() {
+                if self.manager.options.enable.fail_early() {
                     Global::exit(1);
                 }
 
@@ -973,21 +889,21 @@ impl<'a> PackageInstaller<'a> {
 
         // .monotonic is okay because this value isn't modified from any other thread.
         while self
-            .manager()
+            .manager
             .pending_lifecycle_script_tasks
             .load(Ordering::Relaxed)
             > 0
         {
-            self.manager_mut().report_slow_lifecycle_scripts();
+            self.manager.report_slow_lifecycle_scripts();
 
             if log_level.show_progress() {
-                if let Some(scripts_node) = self.manager_mut().scripts_node_mut() {
+                if let Some(scripts_node) = self.manager.scripts_node_mut() {
                     scripts_node.activate();
-                    self.manager_mut().progress.refresh();
+                    self.manager.progress.refresh();
                 }
             }
 
-            self.manager_mut().sleep();
+            self.manager.sleep();
         }
     }
 
@@ -1000,13 +916,13 @@ impl<'a> PackageInstaller<'a> {
         (deps.subset_of(&self.completed_trees.unmanaged)
             || deps.eql(&self.completed_trees.unmanaged))
             && LifecycleScriptSubprocess::alive_count().load(Ordering::Relaxed)
-                < self.manager().options.max_concurrent_lifecycle_scripts
+                < self.manager.options.max_concurrent_lifecycle_scripts
     }
 
     /// A tree can start installing packages when the parent has installed all its packages. If the parent
     /// isn't finished, we need to wait because it's possible a package installed in this tree will be deleted by the parent.
     // free fn (not `&self`) so callers can pass disjoint borrows
-    // (`&self.completed_trees` + `&self.lockfile().buffers.trees`) without
+    // (`&self.completed_trees` + `&self.manager.lockfile.buffers.trees`) without
     // tripping borrowck on the whole-`self` reborrow.
     fn can_install_package_for_tree(
         completed_trees: &Bitset,
@@ -1024,35 +940,14 @@ impl<'a> PackageInstaller<'a> {
         true
     }
 
-    // `pub fn deinit` dropped. All owned fields (`pending_lifecycle_scripts: Vec`,
-    // `completed_trees: Bitset`, `trees: Box<[TreeContext]>`, `tree_ids_to_trees_the_id_depends_on`,
-    // `node_modules`, `trusted_dependencies_from_update_requests`) impl Drop. Borrowed fields
-    // (`manager`, `lockfile`, etc.) are not freed.
-
-    /// Call when you mutate the length of `lockfile.packages`
-    pub(crate) fn fix_cached_lockfile_package_slices(&mut self) {
-        // These `RawSlice<T>` fields alias into `self.lockfile.packages`
-        // (BACKREF). `RawSlice::new` stores the raw `(ptr, len)` without a
-        // lifetime, so the borrow of `packages` ends at the end of each
-        // statement — no `&'a → &'a` detach round-trip needed.
-        // SAFETY (RawSlice invariant): `self.lockfile` is a BACKREF whose
-        // pointee outlives `'a`; the packages column buffers are not freed for
-        // the lifetime of this `PackageInstaller` (only grow, which is why
-        // this fn exists — to re-snapshot after growth).
-        let packages = self.lockfile_mut().packages.slice();
-        self.metas = bun_ptr::RawSlice::new(packages.items_meta());
-        self.names = bun_ptr::RawSlice::new(packages.items_name());
-        self.pkg_name_hashes = bun_ptr::RawSlice::new(packages.items_name_hash());
-        self.bins = bun_ptr::RawSlice::new(packages.items_bin());
-        self.resolutions = bun_ptr::RawSlice::new(packages.items_resolution());
-
-        // fixes an assertion failure where a transitive dependency is a git dependency newly added to the lockfile after the list of dependencies has been resized
-        // this assertion failure would also only happen after the lockfile has been written to disk and the summary is being printed.
-        if self.successfully_installed.bit_length() < self.lockfile().packages.len() {
-            let new = Bitset::init_empty(self.lockfile().packages.len()).unwrap_or_oom();
+    /// Grow `successfully_installed` to cover packages appended to the
+    /// lockfile since it was sized (e.g. a git dependency's transitive deps).
+    pub(crate) fn grow_successfully_installed(&mut self) {
+        let packages_len = self.manager.lockfile.packages.len();
+        if self.successfully_installed.bit_length() < packages_len {
+            let new = Bitset::init_empty(packages_len).unwrap_or_oom();
             let old = core::mem::replace(&mut self.successfully_installed, new);
             old.copy_into(&mut self.successfully_installed);
-            // `defer old.deinit(bun.default_allocator)` — Bitset impls Drop.
         }
     }
 
@@ -1064,36 +959,26 @@ impl<'a> PackageInstaller<'a> {
         data: &ExtractData,
         log_level: Options::LogLevel,
     ) {
-        let package_id = self.lockfile().buffers.resolutions.as_slice()[dependency_id as usize];
-        let name = self.names[package_id as usize];
-
-        // const resolution = &this.resolutions[package_id];
-        // const task_id = switch (resolution.tag) {
-        //     .git => Task.Id.forGitCheckout(data.url, data.resolved),
-        //     .github => Task.Id.forTarball(data.url),
-        //     .local_tarball => Task.Id.forTarball(this.lockfile.str(&resolution.value.local_tarball)),
-        //     .remote_tarball => Task.Id.forTarball(this.lockfile.str(&resolution.value.remote_tarball)),
-        //     .npm => Task.Id.forNPMPackage(name.slice(this.lockfile.buffers.string_bytes.items), resolution.value.npm.version),
-        //     else => unreachable,
-        // };
+        let package_id =
+            self.manager.lockfile.buffers.resolutions.as_slice()[dependency_id as usize];
+        let name = self.manager.lockfile.packages.items_name()[package_id as usize];
 
         // If a newly computed integrity hash is available (e.g. for a GitHub
         // tarball) and the lockfile doesn't already have one, persist it so
         // the lockfile gets re-saved with the hash.
         if data.integrity.tag.is_supported() {
-            let pkg_metas = self.lockfile_mut().packages.items_meta_mut();
+            let pkg_metas = self.manager.lockfile.packages.items_meta_mut();
             if !pkg_metas[package_id as usize].integrity.tag.is_supported() {
                 pkg_metas[package_id as usize].integrity = data.integrity;
-                self.manager_mut()
+                self.manager
                     .options
                     .enable
                     .set(Options::Enable::FORCE_SAVE_LOCKFILE, true);
             }
         }
 
-        if let Some(removed) = self.manager_mut().task_queue.fetch_remove(&task_id) {
+        if let Some(removed) = self.manager.task_queue.fetch_remove(&task_id) {
             let callbacks = removed.value;
-            // `defer callbacks.deinit(this.manager.allocator)` — Vec drops.
 
             // Manual save/restore of self.node_modules / self.current_tree_id
             // (see install_available_packages). Infallible body — both exit
@@ -1111,22 +996,21 @@ impl<'a> PackageInstaller<'a> {
                 return;
             }
 
-            // `self.resolutions` is `RawSlice<Resolution>` (Copy); copy out
-            // so the `&Resolution` argument borrows the local, not `*self`.
-            let resolutions = self.resolutions;
             for cb in callbacks.iter() {
                 let TaskCallbackContext::DependencyInstallContext(context) = cb else {
                     debug_assert!(false, "expected DependencyInstallContext");
                     continue;
                 };
-                let callback_package_id =
-                    self.lockfile().buffers.resolutions.as_slice()[context.dependency_id as usize];
+                let callback_package_id = self.manager.lockfile.buffers.resolutions.as_slice()
+                    [context.dependency_id as usize];
                 self.node_modules.tree_id = context.tree_id;
                 // `DependencyInstallContext.path: Vec<u8>` — clone since `cb` is `&`.
                 self.node_modules.path.clone_from(&context.path);
                 self.current_tree_id = context.tree_id;
                 let needs_verify = false;
                 let is_pending_package_install = false;
+                let resolution =
+                    self.manager.lockfile.packages.items_resolution()[callback_package_id as usize];
                 self.install_package_with_name_and_resolution(
                     // This id might be different from the id used to enqueue the task. Important
                     // to use the correct one because the package might be aliased with a different
@@ -1135,7 +1019,7 @@ impl<'a> PackageInstaller<'a> {
                     callback_package_id,
                     log_level,
                     name,
-                    &resolutions[callback_package_id as usize],
+                    &resolution,
                     needs_verify,
                     is_pending_package_install,
                 );
@@ -1148,7 +1032,9 @@ impl<'a> PackageInstaller<'a> {
         if cfg!(debug_assertions) {
             Output::panic(format_args!(
                 "Ran callback to install enqueued packages, but there was no task associated with it. {}:{} (dependency_id: {})",
-                bun_core::fmt::quote(name.slice(self.lockfile().buffers.string_bytes.as_slice())),
+                bun_core::fmt::quote(
+                    name.slice(self.manager.lockfile.buffers.string_bytes.as_slice())
+                ),
                 bun_core::fmt::quote(&data.url),
                 dependency_id,
             ));
@@ -1157,7 +1043,7 @@ impl<'a> PackageInstaller<'a> {
 
     fn get_installed_package_scripts_count(
         &mut self,
-        alias: &[u8],
+        alias: String,
         package_id: PackageID,
         resolution_tag: resolution::Tag,
         folder_path: &mut bun_paths::AutoAbsPath,
@@ -1168,7 +1054,7 @@ impl<'a> PackageInstaller<'a> {
         debug_assert!(package_id != 0);
         let mut count: usize = 0;
         let scripts = 'brk: {
-            let scripts = self.lockfile().packages.items_scripts()[package_id as usize];
+            let scripts = self.manager.lockfile.packages.items_scripts()[package_id as usize];
             if scripts.filled {
                 break 'brk scripts;
             }
@@ -1176,18 +1062,21 @@ impl<'a> PackageInstaller<'a> {
             let mut temp = PackageScripts::default();
             let mut temp_lockfile = Lockfile::default();
             temp_lockfile.init_empty();
-            // `defer temp_lockfile.deinit()` — Lockfile impls Drop.
             let mut string_builder = temp_lockfile.string_builder();
-            let log = self.manager().log_mut();
-            if let Err(err) = temp.fill_from_package_json(&mut string_builder, log, folder_path) {
+            if let Err(err) =
+                temp.fill_from_package_json(&mut string_builder, &mut self.manager.log, folder_path)
+            {
                 if log_level != Options::LogLevel::Silent {
                     Output::err_generic(
                         "failed to fill lifecycle scripts for <b>{}<r>: {}",
-                        (bstr::BStr::new(alias), err.name()),
+                        (
+                            bstr::BStr::new(self.manager.lockfile.str(&alias)),
+                            err.name(),
+                        ),
                     );
                 }
 
-                if self.manager().options.enable.fail_early() {
+                if self.manager.options.enable.fail_early() {
                     Global::crash();
                 }
 
@@ -1215,7 +1104,7 @@ impl<'a> PackageInstaller<'a> {
         if scripts.preinstall.is_empty() && scripts.install.is_empty() {
             let binding_dot_gyp_path = join_abs_string_z::<platform::Auto>(
                 self.node_modules.path.as_slice(),
-                &[alias, b"binding.gyp"],
+                &[self.manager.lockfile.str(&alias), b"binding.gyp"],
             );
             count += Syscall::exists(binding_dot_gyp_path) as usize;
         }
@@ -1237,20 +1126,14 @@ impl<'a> PackageInstaller<'a> {
         // pending packages if we're already draining them.
         is_pending_package_install: bool,
     ) {
-        // reshaped for borrowck — `string_bytes` is not mutated during install,
-        // so capture a raw slice once to avoid repeatedly re-borrowing `self.lockfile`
-        // across `&mut self` method calls below.
-        // SAFETY: `buffers.string_bytes` is append-only and never freed
-        // for the lifetime of this `PackageInstaller`.
-        let string_buf_ptr =
-            bun_ptr::RawSlice::new(self.lockfile().buffers.string_bytes.as_slice());
         macro_rules! string_buf {
             () => {
-                string_buf_ptr.slice()
+                self.manager.lockfile.buffers.string_bytes.as_slice()
             };
         }
 
-        let alias = self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize].name;
+        let alias =
+            self.manager.lockfile.buffers.dependencies.as_slice()[dependency_id as usize].name;
 
         // The alias is used as a path relative to `node_modules` for delete,
         // rename, and create operations. Refuse anything that could escape it.
@@ -1270,35 +1153,22 @@ impl<'a> PackageInstaller<'a> {
             return;
         }
 
-        // `PackageInstall` stores both `destination_dir_subpath: &mut ZStr`
-        // and `destination_dir_subpath_buf: &mut [u8]` aliasing the same bytes.
-        // Derive BOTH from a single `*mut PathBuffer`
-        // so neither `&mut` invalidates the other under stacked-borrows.
-        let subpath_buf_ptr: *mut PathBuffer = &raw mut self.destination_dir_subpath_buf;
-        let destination_dir_subpath: &mut ZStr = {
-            let alias_slice = alias.slice(string_buf!());
-            // SAFETY: `subpath_buf_ptr` is the unique borrow of the field; valid for
-            // the lifetime of this fn body.
-            let buf = unsafe { &mut *subpath_buf_ptr };
+        let destination_dir_subpath_len = {
+            let alias_slice = alias.slice(self.manager.lockfile.buffers.string_bytes.as_slice());
+            let buf = &mut self.destination_dir_subpath_buf;
             buf[..alias_slice.len()].copy_from_slice(alias_slice);
             buf[alias_slice.len()] = 0;
-            // SAFETY: buf[alias_slice.len()] == 0 written above; pointer derives from
-            // `subpath_buf_ptr` so it shares provenance with `destination_dir_subpath_buf`
-            // below.
-            unsafe { ZStr::from_raw_mut((*subpath_buf_ptr).as_mut_ptr(), alias_slice.len()) }
+            alias_slice.len()
         };
 
-        let pkg_name_hash = self.pkg_name_hashes[package_id as usize];
+        let pkg_name_hash = self.manager.lockfile.packages.items_name_hash()[package_id as usize];
 
         let mut resolution_buf = [0u8; 512];
         let mut resolution_spill = Vec::new();
         let package_version: &[u8] = if resolution.tag == resolution::Tag::Workspace {
             'brk: {
-                if let Some(workspace_version) = self
-                    .manager()
-                    .lockfile
-                    .workspace_versions
-                    .get(&pkg_name_hash)
+                if let Some(workspace_version) =
+                    self.manager.lockfile.workspace_versions.get(&pkg_name_hash)
                 {
                     break 'brk print_package_version(
                         &mut resolution_buf,
@@ -1319,8 +1189,8 @@ impl<'a> PackageInstaller<'a> {
         };
 
         let (patch_contents_hash, patch_name_and_version_hash, remove_patch) = 'brk: {
-            if self.manager().lockfile.patched_dependencies.count() == 0
-                && self.manager().patched_dependencies_to_remove.count() == 0
+            if self.manager.lockfile.patched_dependencies.count() == 0
+                && self.manager.patched_dependencies_to_remove.count() == 0
             {
                 break 'brk (None, None, false);
             }
@@ -1337,12 +1207,13 @@ impl<'a> PackageInstaller<'a> {
             let name_and_version_hash = bun_semver::string::Builder::string_hash(&name_and_version);
 
             let Some(patchdep) = self
-                .lockfile()
+                .manager
+                .lockfile
                 .patched_dependencies
                 .get(&name_and_version_hash)
             else {
                 let to_remove = self
-                    .manager()
+                    .manager
                     .patched_dependencies_to_remove
                     .contains(&name_and_version_hash);
                 if to_remove {
@@ -1373,36 +1244,26 @@ impl<'a> PackageInstaller<'a> {
             );
         };
 
-        // reshaped for borrowck — `PackageInstall` borrows several `self.*`
-        // fields while subsequent code also accesses `self.manager` / `self.node_modules`
-        // / `self.lockfile` mutably. Detach the borrows via a
-        // `ParentRef` so `installer`'s lifetime is independent of `&mut self`.
-        // BACKREF — none of these fields are dropped, moved, or resized while
-        // `installer` is alive (see `PackageInstaller` field docs).
-        let node_modules_ref = bun_ptr::ParentRef::<NodeModulesFolder>::new(&self.node_modules);
-        let mut installer = PackageInstall {
-            progress: if self.manager().options.log_level.show_progress() {
-                Some(self.progress_mut())
-            } else {
-                None
-            },
-            cache_dir: Fd::INVALID, // assigned below
-            destination_dir_subpath,
-            // SAFETY: `subpath_buf_ptr` = `&raw mut self.destination_dir_subpath_buf`; the
-            // field outlives `installer`. `destination_dir_subpath` above derives from the
-            // same raw pointer, so this `&mut` does not invalidate it under stacked-borrows.
-            destination_dir_subpath_buf: unsafe { (*subpath_buf_ptr).as_mut_slice() },
-            package_name: pkg_name,
-            patch: patch_contents_hash
-                .map(|contents_hash| package_install::Patch { contents_hash }),
-            package_version,
-            node_modules: node_modules_ref.get(),
-            // BACKREF accessor — `self.lockfile` is `*mut Lockfile` (never null,
-            // outlives `'a`); `lockfile()` centralises the raw deref so this
-            // site stays safe.
-            lockfile: self.lockfile(),
-            cache_dir_subpath: ZStr::EMPTY,
-        };
+        let patch =
+            patch_contents_hash.map(|contents_hash| package_install::Patch { contents_hash });
+        let mut cache_dir: Fd;
+        let cache_dir_subpath: Subpath;
+        // A `PackageInstall` over this installer's buffers, built per use so
+        // the buffers stay free between uses.
+        macro_rules! pkg_install {
+            () => {
+                PackageInstall {
+                    cache_dir,
+                    cache_dir_subpath: cache_dir_subpath.get(&self.folder_path_buf),
+                    destination_dir_subpath_buf: &mut self.destination_dir_subpath_buf,
+                    destination_dir_subpath_len,
+                    package_name: pkg_name,
+                    package_version,
+                    patch,
+                    node_modules: &self.node_modules,
+                }
+            };
+        }
         bun_output::scoped_log!(
             PackageInstaller,
             "Installing {}@{}",
@@ -1412,47 +1273,53 @@ impl<'a> PackageInstaller<'a> {
 
         match resolution.tag {
             resolution::Tag::Npm => {
-                installer.cache_dir_subpath = package_manager::cached_npm_package_folder_name(
-                    self.manager_mut(),
-                    pkg_name.slice(string_buf!()),
+                cache_dir = package_manager::get_cache_directory(self.manager);
+                cache_dir_subpath = Subpath::of(package_manager::cached_npm_package_folder_name(
+                    self.manager,
+                    &mut self.folder_path_buf,
+                    pkg_name.slice(self.manager.lockfile.buffers.string_bytes.as_slice()),
                     resolution.npm().version,
                     patch_contents_hash,
-                );
-                installer.cache_dir = package_manager::get_cache_directory(self.manager_mut());
+                ));
             }
             resolution::Tag::Git => {
-                installer.cache_dir_subpath = package_manager::cached_git_folder_name(
-                    self.manager_mut(),
+                cache_dir = package_manager::get_cache_directory(self.manager);
+                cache_dir_subpath = Subpath::of(package_manager::cached_git_folder_name(
+                    self.manager,
+                    &mut self.folder_path_buf,
                     resolution.git(),
                     patch_contents_hash,
-                );
-                installer.cache_dir = package_manager::get_cache_directory(self.manager_mut());
+                ));
             }
             resolution::Tag::Github => {
-                installer.cache_dir_subpath = package_manager::cached_github_folder_name(
-                    self.manager_mut(),
+                cache_dir = package_manager::get_cache_directory(self.manager);
+                cache_dir_subpath = Subpath::of(package_manager::cached_github_folder_name(
+                    self.manager,
+                    &mut self.folder_path_buf,
                     resolution.github(),
                     patch_contents_hash,
-                );
-                installer.cache_dir = package_manager::get_cache_directory(self.manager_mut());
+                ));
             }
             resolution::Tag::Folder => {
                 let folder_str = *resolution.folder();
                 let folder = folder_str.slice(string_buf!());
 
-                if self.lockfile().is_workspace_tree_id(self.current_tree_id) {
+                if self
+                    .manager
+                    .lockfile
+                    .is_workspace_tree_id(self.current_tree_id)
+                {
                     // Handle when a package depends on itself via file:
                     // example:
                     //   "mineflayer": "file:."
                     if folder.is_empty() || (folder.len() == 1 && folder[0] == b'.') {
-                        installer.cache_dir_subpath = ZStr::from_static(b".\0");
+                        cache_dir_subpath = Subpath::DOT;
                     } else {
                         self.folder_path_buf[..folder.len()].copy_from_slice(folder);
                         self.folder_path_buf[folder.len()] = 0;
-                        installer.cache_dir_subpath =
-                            ZStr::from_buf(&self.folder_path_buf, folder.len());
+                        cache_dir_subpath = Subpath::Folder(folder.len());
                     }
-                    installer.cache_dir = Fd::cwd();
+                    cache_dir = Fd::cwd();
                 } else {
                     // transitive folder dependencies are not hoisted
                     if folder.len() >= self.folder_path_buf.len()
@@ -1461,9 +1328,9 @@ impl<'a> PackageInstaller<'a> {
                             // package.json, so a folder path that reached here via an
                             // override was written by the user and is trusted the same
                             // as a direct dependency of the root.
-                            let dep = &self.lockfile().buffers.dependencies.as_slice()
+                            let dep = &self.manager.lockfile.buffers.dependencies.as_slice()
                                 [dependency_id as usize];
-                            !self.lockfile().overrides.contains_name(
+                            !self.manager.lockfile.overrides.contains_name(
                                 dep.name_hash,
                                 dep.name.slice(string_buf!()),
                                 string_buf!(),
@@ -1487,60 +1354,59 @@ impl<'a> PackageInstaller<'a> {
                     }
                     self.folder_path_buf[..folder.len()].copy_from_slice(folder);
                     self.folder_path_buf[folder.len()] = 0;
-                    // SAFETY: buf[folder.len()] == 0 written above
-                    installer.cache_dir_subpath =
-                        ZStr::from_buf(&self.folder_path_buf, folder.len());
+                    cache_dir_subpath = Subpath::Folder(folder.len());
 
                     // cache_dir might not be created yet (if it's in node_modules)
-                    installer.cache_dir = Fd::cwd();
+                    cache_dir = Fd::cwd();
                 }
             }
             resolution::Tag::LocalTarball => {
-                installer.cache_dir_subpath = package_manager::cached_tarball_folder_name(
-                    self.manager_mut(),
+                cache_dir = package_manager::get_cache_directory(self.manager);
+                cache_dir_subpath = Subpath::of(package_manager::cached_tarball_folder_name(
+                    self.manager,
+                    &mut self.folder_path_buf,
                     *resolution.local_tarball(),
                     patch_contents_hash,
-                );
-                installer.cache_dir = package_manager::get_cache_directory(self.manager_mut());
+                ));
             }
             resolution::Tag::RemoteTarball => {
-                installer.cache_dir_subpath = package_manager::cached_tarball_folder_name(
-                    self.manager_mut(),
+                cache_dir = package_manager::get_cache_directory(self.manager);
+                cache_dir_subpath = Subpath::of(package_manager::cached_tarball_folder_name(
+                    self.manager,
+                    &mut self.folder_path_buf,
                     *resolution.remote_tarball(),
                     patch_contents_hash,
-                );
-                installer.cache_dir = package_manager::get_cache_directory(self.manager_mut());
+                ));
             }
             resolution::Tag::Workspace => {
                 let folder_str = *resolution.workspace();
                 let folder = folder_str.slice(string_buf!());
                 // Handle when a package depends on itself
                 if folder.is_empty() || (folder.len() == 1 && folder[0] == b'.') {
-                    installer.cache_dir_subpath = ZStr::from_static(b".\0");
+                    cache_dir_subpath = Subpath::DOT;
                 } else {
                     self.folder_path_buf[..folder.len()].copy_from_slice(folder);
                     self.folder_path_buf[folder.len()] = 0;
-                    // SAFETY: buf[folder.len()] == 0 written above
-                    installer.cache_dir_subpath =
-                        ZStr::from_buf(&self.folder_path_buf, folder.len());
+                    cache_dir_subpath = Subpath::Folder(folder.len());
                 }
-                installer.cache_dir = Fd::cwd();
+                cache_dir = Fd::cwd();
             }
             resolution::Tag::Root => {
-                installer.cache_dir_subpath = ZStr::from_static(b".\0");
-                installer.cache_dir = Fd::cwd();
+                cache_dir_subpath = Subpath::DOT;
+                cache_dir = Fd::cwd();
             }
             resolution::Tag::Symlink => {
-                let directory = package_manager::global_link_dir(self.manager_mut());
+                let directory = package_manager::global_link_dir(self.manager);
 
                 let folder_str = *resolution.symlink();
                 let folder = folder_str.slice(string_buf!());
 
                 if folder.is_empty() || (folder.len() == 1 && folder[0] == b'.') {
-                    installer.cache_dir_subpath = ZStr::from_static(b".\0");
-                    installer.cache_dir = Fd::cwd();
+                    cache_dir_subpath = Subpath::DOT;
+                    cache_dir = Fd::cwd();
                 } else {
-                    let global_link_dir = package_manager::global_link_dir_path(self.manager_mut());
+                    // `global_link_dir` above opened it.
+                    let global_link_dir: &[u8] = &self.manager.global_link_dir_path;
                     let buf = self.folder_path_buf.as_mut_slice();
                     let mut len = 0usize;
                     buf[len..len + global_link_dir.len()].copy_from_slice(global_link_dir);
@@ -1552,9 +1418,8 @@ impl<'a> PackageInstaller<'a> {
                     buf[len..len + folder.len()].copy_from_slice(folder);
                     len += folder.len();
                     buf[len] = 0;
-                    // SAFETY: buf[len] == 0 written above
-                    installer.cache_dir_subpath = ZStr::from_buf(&self.folder_path_buf, len);
-                    installer.cache_dir = directory;
+                    cache_dir_subpath = Subpath::Folder(len);
+                    cache_dir = directory;
                 }
             }
             _ => {
@@ -1574,12 +1439,16 @@ impl<'a> PackageInstaller<'a> {
             || self.skip_verify_installed_version_number
             || !needs_verify
             || remove_patch
-            || !installer.verify(resolution, &self.root_node_modules_folder);
+            || !pkg_install!().verify(
+                &self.manager.lockfile,
+                resolution,
+                &self.root_node_modules_folder,
+            );
 
         if needs_install {
             if resolution.tag.can_enqueue_install_task()
-                && installer.package_missing_from_cache(
-                    self.manager_mut(),
+                && pkg_install!().package_missing_from_cache(
+                    self.manager,
                     package_id,
                     resolution.tag,
                 )
@@ -1621,9 +1490,9 @@ impl<'a> PackageInstaller<'a> {
                 match resolution.tag {
                     resolution::Tag::Git => {
                         if package_manager::enqueue_git_for_checkout(
-                            self.manager_mut(),
+                            self.manager,
                             dependency_id,
-                            alias.slice(string_buf!()),
+                            alias,
                             resolution,
                             context,
                             download_patch_hash,
@@ -1637,15 +1506,18 @@ impl<'a> PackageInstaller<'a> {
                         }
                     }
                     resolution::Tag::Github => {
-                        let url = self.manager_mut().alloc_github_url(resolution.github());
-                        // `defer this.manager.allocator.free(url)` — url: Vec<u8> drops.
+                        let url = self.manager.alloc_github_url(resolution.github());
+                        let url = strings::StringOrTinyString::init_append_if_needed(
+                            &url,
+                            &mut crate::network_task::filename_store_appender(),
+                        )
+                        .unwrap_or_oom();
                         match package_manager::enqueue_tarball_for_download(
-                            self.manager_mut(),
+                            self.manager,
                             dependency_id,
                             package_id,
-                            &url,
+                            url,
                             context,
-                            download_patch_hash,
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
@@ -1662,22 +1534,26 @@ impl<'a> PackageInstaller<'a> {
                     }
                     resolution::Tag::LocalTarball => {
                         package_manager::enqueue_tarball_for_reading(
-                            self.manager_mut(),
+                            self.manager,
                             dependency_id,
                             package_id,
-                            alias.slice(string_buf!()),
+                            alias,
                             resolution,
                             context,
                         );
                     }
                     resolution::Tag::RemoteTarball => {
+                        let url = strings::StringOrTinyString::init_append_if_needed(
+                            resolution.remote_tarball().slice(string_buf!()),
+                            &mut crate::network_task::filename_store_appender(),
+                        )
+                        .unwrap_or_oom();
                         match package_manager::enqueue_tarball_for_download(
-                            self.manager_mut(),
+                            self.manager,
                             dependency_id,
                             package_id,
-                            resolution.remote_tarball().slice(string_buf!()),
+                            url,
                             context,
-                            download_patch_hash,
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
@@ -1708,14 +1584,13 @@ impl<'a> PackageInstaller<'a> {
                         }
 
                         match package_manager::enqueue_package_for_download(
-                            self.manager_mut(),
-                            pkg_name.slice(string_buf!()),
+                            self.manager,
+                            pkg_name,
                             dependency_id,
                             package_id,
                             npm.version,
-                            npm.url.slice(string_buf!()),
+                            npm.url,
                             context,
-                            download_patch_hash,
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
@@ -1748,10 +1623,10 @@ impl<'a> PackageInstaller<'a> {
 
             // above checks if unpatched package is in cache, if not null apply patch in temp directory, copy
             // into cache, then install into node_modules
-            if let Some(patch_contents_hash) = installer.patch.as_ref().map(|p| p.contents_hash) {
-                if installer.patched_package_missing_from_cache(self.manager_mut(), package_id) {
+            if let Some(patch_contents_hash) = patch_contents_hash {
+                if pkg_install!().patched_package_missing_from_cache(self.manager, package_id) {
                     let mut task = PatchTask::new_apply_patch_hash(
-                        self.manager_mut(),
+                        self.manager,
                         package_id,
                         patch_contents_hash,
                         patch_name_and_version_hash.unwrap(),
@@ -1763,7 +1638,7 @@ impl<'a> PackageInstaller<'a> {
                             path: self.node_modules.path.clone(),
                         });
                     }
-                    package_manager::enqueue_patch_task(self.manager_mut(), task);
+                    package_manager::enqueue_patch_task(self.manager, task);
                     return;
                 }
             }
@@ -1771,7 +1646,7 @@ impl<'a> PackageInstaller<'a> {
             if !is_pending_package_install
                 && !Self::can_install_package_for_tree(
                     &self.completed_trees,
-                    self.lockfile().buffers.trees.as_slice(),
+                    self.manager.lockfile.buffers.trees.as_slice(),
                     self.current_tree_id,
                 )
             {
@@ -1816,27 +1691,35 @@ impl<'a> PackageInstaller<'a> {
             };
 
             let install_result: package_install::InstallResult = match resolution.tag {
-                resolution::Tag::Symlink | resolution::Tag::Workspace => {
-                    installer.install_from_link(self.skip_delete, &destination_dir)
-                }
+                resolution::Tag::Symlink | resolution::Tag::Workspace => pkg_install!()
+                    .install_from_link(self.manager, self.skip_delete, &destination_dir),
                 _ => 'result: {
                     if resolution.tag == resolution::Tag::Root
                         || (resolution.tag == resolution::Tag::Folder
-                            && !self.lockfile().is_workspace_tree_id(self.current_tree_id))
+                            && !self
+                                .manager
+                                .lockfile
+                                .is_workspace_tree_id(self.current_tree_id))
                     {
                         // This is a transitive folder dependency. It is installed with a single symlink to the target folder/file,
                         // and is not hoisted.
                         //
                         // A transitive `Resolution::Folder` declared by a local `file:` package
                         // is relative to the top-level dir (`Package::parse` normalized it), so
-                        // install it from `installer.cache_dir` (the cwd, set in the switch above).
+                        // install it from `cache_dir` (the cwd, set in the switch above).
                         if resolution.tag == resolution::Tag::Folder
-                            && self.lockfile().is_folder_tree_id(self.current_tree_id)
+                            && self
+                                .manager
+                                .lockfile
+                                .is_folder_tree_id(self.current_tree_id)
                         {
-                            break 'result installer.install(
+                            let mut install = pkg_install!();
+                            let method = install.get_install_method();
+                            break 'result install.install(
+                                InstallEnv::Manager(self.manager),
                                 self.skip_delete,
                                 &destination_dir,
-                                installer.get_install_method(),
+                                method,
                                 resolution.tag,
                             );
                         }
@@ -1869,15 +1752,22 @@ impl<'a> PackageInstaller<'a> {
                                 );
                             }
                         };
-                        installer.cache_dir = owned_cache_dir.fd();
+                        cache_dir = owned_cache_dir.fd();
 
+                        let mut install = pkg_install!();
                         let result = if resolution.tag == resolution::Tag::Root {
-                            installer.install_from_link(self.skip_delete, &destination_dir)
-                        } else {
-                            installer.install(
+                            install.install_from_link(
+                                self.manager,
                                 self.skip_delete,
                                 &destination_dir,
-                                installer.get_install_method(),
+                            )
+                        } else {
+                            let method = install.get_install_method();
+                            install.install(
+                                InstallEnv::Manager(self.manager),
+                                self.skip_delete,
+                                &destination_dir,
+                                method,
                                 resolution.tag,
                             )
                         };
@@ -1902,9 +1792,10 @@ impl<'a> PackageInstaller<'a> {
                     {
                         package_install::Method::Copyfile
                     } else {
-                        installer.get_install_method()
+                        pkg_install!().get_install_method()
                     };
-                    break 'result installer.install(
+                    break 'result pkg_install!().install(
+                        InstallEnv::Manager(self.manager),
                         self.skip_delete,
                         &destination_dir,
                         method,
@@ -1923,15 +1814,16 @@ impl<'a> PackageInstaller<'a> {
                         self.node.complete_one();
                     }
 
-                    if self.bins[package_id as usize].tag != bin::Tag::None {
+                    if self.manager.lockfile.packages.items_bin()[package_id as usize].tag
+                        != bin::Tag::None
+                    {
                         self.trees[self.current_tree_id as usize]
                             .binaries
-                            .add(dependency_id)
-                            .unwrap_or_oom();
+                            .push(dependency_id);
                     }
 
-                    let dep =
-                        &self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize];
+                    let dep = &self.manager.lockfile.buffers.dependencies.as_slice()
+                        [dependency_id as usize];
                     let dep_behavior = dep.behavior;
                     let truncated_dep_name_hash: TruncatedPackageNameHash =
                         dep.name_hash as TruncatedPackageNameHash;
@@ -1942,7 +1834,8 @@ impl<'a> PackageInstaller<'a> {
                         {
                             break 'brk (true, true);
                         }
-                        if self.lockfile().has_trusted_dependency(
+                        if self.manager.lockfile.has_trusted_dependency(
+                            &self.manager.options,
                             alias.slice(string_buf!()),
                             pkg_name.slice(string_buf!()),
                             resolution,
@@ -1957,14 +1850,13 @@ impl<'a> PackageInstaller<'a> {
                     {
                         let mut folder_path =
                             AutoAbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
-                        // `defer folder_path.deinit()` — AbsPath impls Drop.
                         folder_path
                             .append(alias.slice(string_buf!()))
                             .unwrap_or_oom();
 
                         'enqueue_lifecycle_scripts: {
                             if self
-                                .manager()
+                                .manager
                                 .postinstall_optimizer
                                 .should_ignore_lifecycle_scripts(
                                     &postinstall_optimizer::PkgInfo {
@@ -1976,12 +1868,12 @@ impl<'a> PackageInstaller<'a> {
                                         },
                                         version_buf: string_buf!(),
                                     },
-                                    self.lockfile().packages.items_resolutions()
+                                    self.manager.lockfile.packages.items_resolutions()
                                         [package_id as usize]
-                                        .get(self.lockfile().buffers.resolutions.as_slice()),
-                                    self.lockfile().packages.items_meta(),
-                                    self.manager().options.cpu,
-                                    self.manager().options.os,
+                                        .get(self.manager.lockfile.buffers.resolutions.as_slice()),
+                                    self.manager.lockfile.packages.items_meta(),
+                                    self.manager.options.cpu,
+                                    self.manager.options.os,
                                 )
                             {
                                 if PackageManager::verbose_install() {
@@ -1994,7 +1886,7 @@ impl<'a> PackageInstaller<'a> {
                             }
 
                             if self.enqueue_lifecycle_scripts(
-                                alias.slice(string_buf!()),
+                                alias,
                                 log_level,
                                 &mut folder_path,
                                 package_id,
@@ -2008,15 +1900,18 @@ impl<'a> PackageInstaller<'a> {
                                         } else {
                                             (alias, truncated_dep_name_hash)
                                         };
-                                    self.manager_mut()
-                                        .trusted_deps_to_add_to_package_json
-                                        .push(Box::<[u8]>::from(trusted_name.slice(string_buf!())));
+                                    self.manager.trusted_deps_to_add_to_package_json.push(Box::<
+                                        [u8],
+                                    >::from(
+                                        trusted_name.slice(string_buf!()),
+                                    ));
 
-                                    if self.lockfile().trusted_dependencies.is_none() {
-                                        self.lockfile_mut().trusted_dependencies =
+                                    if self.manager.lockfile.trusted_dependencies.is_none() {
+                                        self.manager.lockfile.trusted_dependencies =
                                             Some(Default::default());
                                     }
-                                    self.lockfile_mut()
+                                    self.manager
+                                        .lockfile
                                         .trusted_dependencies
                                         .as_mut()
                                         .unwrap()
@@ -2035,7 +1930,10 @@ impl<'a> PackageInstaller<'a> {
                             // these will never be blocked
                         }
                         _ => {
-                            if !is_trusted && self.metas[package_id as usize].has_install_script() {
+                            if !is_trusted
+                                && self.manager.lockfile.packages.items_meta()[package_id as usize]
+                                    .has_install_script()
+                            {
                                 // Check if the package actually has scripts. `hasInstallScript` can be false positive if a package is published with
                                 // an auto binding.gyp rebuild script but binding.gyp is excluded from the published files.
                                 let mut folder_path =
@@ -2046,7 +1944,7 @@ impl<'a> PackageInstaller<'a> {
                                     .unwrap_or_oom();
 
                                 let count = self.get_installed_package_scripts_count(
-                                    alias.slice(string_buf!()),
+                                    alias,
                                     package_id,
                                     resolution.tag,
                                     &mut folder_path,
@@ -2100,7 +1998,10 @@ impl<'a> PackageInstaller<'a> {
                         bun_core::pretty_errorln!(
                             "<r><red>error<r>: <b>{}<r> \"link:{}\" not found (try running 'bun link' in the intended package's folder)<r>",
                             cause.err.name(),
-                            bstr::BStr::new(self.names[package_id as usize].slice(string_buf!())),
+                            bstr::BStr::new(
+                                self.manager.lockfile.packages.items_name()[package_id as usize]
+                                    .slice(string_buf!())
+                            ),
                         );
                         self.summary.fail += 1;
                     } else if resolution.tag == resolution::Tag::Folder
@@ -2136,9 +2037,15 @@ impl<'a> PackageInstaller<'a> {
                                             "EACCES",
                                             "Permission denied while installing <b>{}<r>",
                                             (bstr::BStr::new(
-                                                self.names[package_id as usize].slice(
-                                                    self.lockfile().buffers.string_bytes.as_slice(),
-                                                ),
+                                                self.manager.lockfile.packages.items_name()
+                                                    [package_id as usize]
+                                                    .slice(
+                                                        self.manager
+                                                            .lockfile
+                                                            .buffers
+                                                            .string_bytes
+                                                            .as_slice(),
+                                                    ),
                                             ),),
                                         );
                                         if cfg!(debug_assertions) {
@@ -2150,7 +2057,7 @@ impl<'a> PackageInstaller<'a> {
 
                                 // `bun_sys::c::getuid`/`getgid` are local `safe fn`
                                 // redecls (zero args, read kernel process state —
-                                // no preconditions), so no `unsafe` needed.
+                                // no preconditions).
                                 // `st_mode` is u16 on FreeBSD, u32 elsewhere; widen.
                                 let st_mode = stat.st_mode as u32;
                                 let is_writable = if stat.st_uid == bun_sys::c::getuid() {
@@ -2178,7 +2085,8 @@ impl<'a> PackageInstaller<'a> {
                             "EACCES",
                             "Permission denied while installing <b>{}<r>",
                             (bstr::BStr::new(
-                                self.names[package_id as usize].slice(string_buf!()),
+                                self.manager.lockfile.packages.items_name()[package_id as usize]
+                                    .slice(string_buf!()),
                             ),),
                         );
 
@@ -2190,7 +2098,9 @@ impl<'a> PackageInstaller<'a> {
                             (
                                 bstr::BStr::new(cause.step.name()),
                                 bstr::BStr::new(
-                                    self.names[package_id as usize].slice(string_buf!()),
+                                    self.manager.lockfile.packages.items_name()
+                                        [package_id as usize]
+                                        .slice(string_buf!()),
                                 ),
                             ),
                         );
@@ -2209,7 +2119,7 @@ impl<'a> PackageInstaller<'a> {
             if !is_pending_package_install
                 && !Self::can_install_package_for_tree(
                     &self.completed_trees,
-                    self.lockfile().buffers.trees.as_slice(),
+                    self.manager.lockfile.buffers.trees.as_slice(),
                     self.current_tree_id,
                 )
             {
@@ -2225,14 +2135,15 @@ impl<'a> PackageInstaller<'a> {
 
             self.summary.skipped += 1;
 
-            if self.bins[package_id as usize].tag != bin::Tag::None {
+            if self.manager.lockfile.packages.items_bin()[package_id as usize].tag != bin::Tag::None
+            {
                 self.trees[self.current_tree_id as usize]
                     .binaries
-                    .add(dependency_id)
-                    .unwrap_or_oom();
+                    .push(dependency_id);
             }
 
-            let dep = &self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize];
+            let dep =
+                &self.manager.lockfile.buffers.dependencies.as_slice()[dependency_id as usize];
             let dep_behavior = dep.behavior;
             let truncated_dep_name_hash: TruncatedPackageNameHash =
                 dep.name_hash as TruncatedPackageNameHash;
@@ -2246,14 +2157,15 @@ impl<'a> PackageInstaller<'a> {
                 }
 
                 if let Some(added) = self
-                    .manager()
+                    .manager
                     .summary
                     .added_trusted_dependencies
                     .get(&truncated_dep_name_hash)
                 {
                     // is a new trusted dependency. need to enqueue scripts and maybe add to lockfile
                     if *added.name == *alias.slice(string_buf!())
-                        && self.lockfile().has_trusted_dependency(
+                        && self.manager.lockfile.has_trusted_dependency(
+                            &self.manager.options,
                             alias.slice(string_buf!()),
                             pkg_name.slice(string_buf!()),
                             resolution,
@@ -2274,7 +2186,7 @@ impl<'a> PackageInstaller<'a> {
 
                 'enqueue_lifecycle_scripts: {
                     if self
-                        .manager()
+                        .manager
                         .postinstall_optimizer
                         .should_ignore_lifecycle_scripts(
                             &postinstall_optimizer::PkgInfo {
@@ -2286,11 +2198,11 @@ impl<'a> PackageInstaller<'a> {
                                 },
                                 version_buf: string_buf!(),
                             },
-                            self.lockfile().packages.items_resolutions()[package_id as usize]
-                                .get(self.lockfile().buffers.resolutions.as_slice()),
-                            self.lockfile().packages.items_meta(),
-                            self.manager().options.cpu,
-                            self.manager().options.os,
+                            self.manager.lockfile.packages.items_resolutions()[package_id as usize]
+                                .get(self.manager.lockfile.buffers.resolutions.as_slice()),
+                            self.manager.lockfile.packages.items_meta(),
+                            self.manager.options.cpu,
+                            self.manager.options.os,
                         )
                     {
                         if PackageManager::verbose_install() {
@@ -2303,7 +2215,7 @@ impl<'a> PackageInstaller<'a> {
                     }
 
                     if self.enqueue_lifecycle_scripts(
-                        alias.slice(string_buf!()),
+                        alias,
                         log_level,
                         &mut folder_path,
                         package_id,
@@ -2318,16 +2230,18 @@ impl<'a> PackageInstaller<'a> {
                             };
 
                         if is_trusted_through_update_request {
-                            self.manager_mut()
+                            self.manager
                                 .trusted_deps_to_add_to_package_json
                                 .push(Box::<[u8]>::from(trusted_name.slice(string_buf!())));
                         }
 
                         if add_to_lockfile {
-                            if self.lockfile().trusted_dependencies.is_none() {
-                                self.lockfile_mut().trusted_dependencies = Some(Default::default());
+                            if self.manager.lockfile.trusted_dependencies.is_none() {
+                                self.manager.lockfile.trusted_dependencies =
+                                    Some(Default::default());
                             }
-                            self.lockfile_mut()
+                            self.manager
+                                .lockfile
                                 .trusted_dependencies
                                 .as_mut()
                                 .unwrap()
@@ -2365,7 +2279,7 @@ impl<'a> PackageInstaller<'a> {
     /// returns true if scripts are enqueued
     fn enqueue_lifecycle_scripts(
         &mut self,
-        folder_name: &[u8],
+        folder_name: String,
         log_level: Options::LogLevel,
         package_path: &mut bun_paths::AutoAbsPath,
         package_id: PackageID,
@@ -2373,13 +2287,13 @@ impl<'a> PackageInstaller<'a> {
         resolution: &Resolution,
     ) -> bool {
         let mut scripts: PackageScripts =
-            self.lockfile().packages.items_scripts()[package_id as usize];
-        let log = self.manager().log_mut();
+            self.manager.lockfile.packages.items_scripts()[package_id as usize];
         let scripts_list = match scripts.get_list(
-            log,
-            self.lockfile(),
+            &self.manager.options,
+            &mut self.manager.log,
+            &self.manager.lockfile,
             package_path,
-            folder_name,
+            self.manager.lockfile.str(&folder_name),
             resolution,
         ) {
             Ok(v) => v,
@@ -2387,34 +2301,34 @@ impl<'a> PackageInstaller<'a> {
                 if log_level != Options::LogLevel::Silent {
                     if log_level.show_progress() {
                         if Output::enable_ansi_colors_stderr() {
-                            self.progress_mut().log(format_args!(
+                            self.manager.progress.log(format_args!(
                                 bun_core::pretty_fmt!(
                                     "\n<r><red>error:<r> failed to enqueue lifecycle scripts for <b>{s}<r>: {s}\n",
                                     true
                                 ),
-                                bstr::BStr::new(folder_name),
+                                bstr::BStr::new(self.manager.lockfile.str(&folder_name)),
                                 err.name(),
                             ));
                         } else {
-                            self.progress_mut().log(format_args!(
+                            self.manager.progress.log(format_args!(
                                 bun_core::pretty_fmt!(
                                     "\n<r><red>error:<r> failed to enqueue lifecycle scripts for <b>{s}<r>: {s}\n",
                                     false
                                 ),
-                                bstr::BStr::new(folder_name),
+                                bstr::BStr::new(self.manager.lockfile.str(&folder_name)),
                                 err.name(),
                             ));
                         }
                     } else {
                         bun_core::pretty_errorln!(
                             "\n<r><red>error:<r> failed to enqueue lifecycle scripts for <b>{}<r>: {}\n",
-                            bstr::BStr::new(folder_name),
+                            bstr::BStr::new(self.manager.lockfile.str(&folder_name)),
                             err.name(),
                         );
                     }
                 }
 
-                if self.manager().options.enable.fail_early() {
+                if self.manager.options.enable.fail_early() {
                     Global::exit(1);
                 }
 
@@ -2428,22 +2342,11 @@ impl<'a> PackageInstaller<'a> {
             return false;
         };
 
-        if self
-            .manager()
-            .options
-            .do_
-            .contains(Options::Do::RUN_SCRIPTS)
-        {
-            // Bind once: two sequential `manager_mut()` derives would each
-            // create a fresh Unique from the raw root under SB, popping the
-            // first while `scripts_node` (derived through it) is still live.
-            // `scripts_node_mut()` takes `&self` and returns a backref to a
-            // caller stack-local (disjoint from `*m`), so a single `m` covers
-            // both the `total_scripts` write and `set_node_name`.
-            let m = self.manager_mut();
+        if self.manager.options.do_.contains(Options::Do::RUN_SCRIPTS) {
+            let m = &mut *self.manager;
             m.total_scripts += scripts_list.total as usize;
             if let Some(scripts_node) = m.scripts_node_mut() {
-                m.set_node_name::<true>(
+                PackageManager::set_node_name(
                     scripts_node,
                     &scripts_list.package_name,
                     ProgressStrings::SCRIPT_EMOJI.as_bytes(),
@@ -2468,13 +2371,10 @@ impl<'a> PackageInstaller<'a> {
     }
 
     pub(crate) fn install_package(&mut self, dep_id: DependencyID, log_level: Options::LogLevel) {
-        let package_id = self.lockfile().buffers.resolutions.as_slice()[dep_id as usize];
+        let package_id = self.manager.lockfile.buffers.resolutions.as_slice()[dep_id as usize];
 
-        let name = self.names[package_id as usize];
-        // `self.resolutions` is `RawSlice<Resolution>` (Copy); copy out so the
-        // `&Resolution` argument borrows the local, not `*self`, across the
-        // `&mut self` call.
-        let resolutions = self.resolutions;
+        let name = self.manager.lockfile.packages.items_name()[package_id as usize];
+        let resolution = self.manager.lockfile.packages.items_resolution()[package_id as usize];
 
         let needs_verify = true;
         let is_pending_package_install = false;
@@ -2483,7 +2383,7 @@ impl<'a> PackageInstaller<'a> {
             package_id,
             log_level,
             name,
-            &resolutions[package_id as usize],
+            &resolution,
             needs_verify,
             is_pending_package_install,
         );

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1,5 +1,5 @@
-use core::ffi::c_void;
 use core::cell::OnceCell;
+use core::ffi::c_void;
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::collections::VecDeque;
 use std::io::Write as _;

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1,5 +1,5 @@
 use core::ffi::c_void;
-use core::ptr::NonNull;
+use core::cell::OnceCell;
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::collections::VecDeque;
 use std::io::Write as _;
@@ -9,10 +9,8 @@ use crate::bun_fs as fs;
 use crate::bun_fs::FileSystem;
 use crate::bun_progress::{Node as ProgressNode, Progress};
 use crate::bun_schema::api as Api;
-use bun_collections::linear_fifo::{DynamicBuffer, StaticBuffer};
-use bun_collections::{
-    ArrayHashMap, HashMap, HiveArrayFallback, LinearFifo, StringArrayHashMap, index_sort,
-};
+use bun_collections::linear_fifo::DynamicBuffer;
+use bun_collections::{ArrayHashMap, HashMap, LinearFifo, StringArrayHashMap, index_sort};
 use bun_core::ZBox;
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
@@ -23,17 +21,14 @@ use bun_event_loop::{self, AnyEventLoop, EventLoopHandle};
 use bun_http as http;
 use bun_ini as ini;
 use bun_paths::resolve_path::{self, PosixToWinNormalizer, platform};
-use bun_paths::{DELIMITER, PathBuffer, SEP, SEP_STR};
+use bun_paths::{DELIMITER, SEP, SEP_STR};
 use bun_semver as Semver;
 use bun_sys::{self, Fd};
-use bun_threading::{ThreadPool, UnboundedQueue, thread_pool};
-use bun_transpiler as transpiler;
+use bun_threading::{ThreadPool, thread_pool};
 use bun_url::URL;
 
-// `bun.spawn.process.WaiterThread` — the force-waiter-thread flag was moved
-// down into `bun_spawn::process` (MOVE_DOWN b0); install just flips it during
-// init. The full waiter-thread machinery (queue, signalfd, loop) lives in
-// `bun_runtime::api::bun::process` and *reads* the same flag.
+// Install only flips the force-waiter-thread flag during init; the waiter
+// thread itself (queue, signalfd, loop) lives in `bun_runtime::api::bun::process`.
 use bun_spawn::process::WaiterThread;
 
 use crate::RunCommand;
@@ -103,9 +98,8 @@ pub mod options {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Only the `printHelp` text is needed by `CommandLineArguments::parse`. The
-// `exec()` body remains in bun_cli (it depends on tier-6 ScanCommand /
-// PackCommand etc. and is the *consumer* of install, not a dependency).
+// Only the help text is needed by `CommandLineArguments::parse`; the
+// commands themselves live in the runtime CLI.
 // ──────────────────────────────────────────────────────────────────────────
 pub(crate) struct PackageManagerCommand;
 
@@ -209,10 +203,9 @@ pub use directories::{
     cached_github_folder_name_print_auto, cached_npm_package_folder_name,
     cached_npm_package_folder_name_print, cached_npm_package_folder_print_basename,
     cached_tarball_folder_name, cached_tarball_folder_name_print, compute_cache_dir_and_subpath,
-    fetch_cache_directory_path, get_cache_directory, get_cache_directory_and_abs_path,
-    get_temporary_directory, global_link_dir, global_link_dir_path, is_folder_in_cache,
-    path_for_cached_npm_path, path_for_resolution, save_lockfile, setup_global_dir,
-    update_lockfile_if_needed, write_yarn_lock,
+    fetch_cache_directory_path, get_cache_directory, get_temporary_directory, global_link_dir,
+    global_link_dir_path, is_folder_in_cache, path_for_cached_npm_path, path_for_resolution,
+    save_lockfile, setup_global_dir, update_lockfile_if_needed, write_yarn_lock,
 };
 
 pub use self::package_manager_enqueue as enqueue;
@@ -238,7 +231,7 @@ pub use self::patch_package::PatchCommitResult;
 pub use self::run_tasks::{
     alloc_github_url, decrement_pending_tasks, drain_dependency_list, flush_dependency_queue,
     flush_network_queue, flush_patch_task_queue, generate_network_task_for_tarball,
-    get_network_task, has_created_network_task, increment_pending_tasks, is_network_task_required,
+    has_created_network_task, increment_pending_tasks, is_network_task_required,
     pending_task_count, run_tasks, schedule_tasks,
 };
 
@@ -256,9 +249,7 @@ pub(crate) type TaskCallbackList = Vec<TaskCallbackContext>;
 pub(crate) type TaskDependencyQueue =
     HashMap<Task::Id, TaskCallbackList /* , IdentityContext<Task::Id>, 80 */>;
 
-type PreallocatedTaskStore = HiveArrayFallback<Task::Task<'static>, 64>;
-type PreallocatedNetworkTasks = HiveArrayFallback<NetworkTask, 128>;
-type ResolveTaskQueue = UnboundedQueue<Task::Task<'static> /* , .next */>;
+type ResolveTaskQueue = bun_threading::OwnedQueue<Task::Task>;
 
 type RepositoryMap = HashMap<Task::Id, Fd /* , IdentityContext<Task::Id>, 80 */>;
 /// Git-commit task id -> the SHA it resolved, for the waiters that re-enter.
@@ -275,11 +266,35 @@ pub(crate) type FolderResolutionMap =
 pub(crate) type NpmAliasMap =
     HashMap<PackageNameHash, crate::dependency::Version /* , IdentityContext<u64>, 80 */>;
 
-type NetworkQueue = LinearFifo<*mut NetworkTask, StaticBuffer<*mut NetworkTask, 32>>;
-type PatchTaskFifo = LinearFifo<*mut PatchTask, StaticBuffer<*mut PatchTask, 32>>;
+/// Up to 32 tasks buffered on the main thread before they are flushed to
+/// their thread-pool batch.
+pub(crate) struct TaskFifo<T>(std::collections::VecDeque<Box<T>>);
 
-pub type PatchTaskQueue = UnboundedQueue<PatchTask /* , .next */>;
-pub type AsyncNetworkTaskQueue = UnboundedQueue<NetworkTask /* , .next */>;
+impl<T> TaskFifo<T> {
+    const CAPACITY: usize = 32;
+    fn new() -> Self {
+        Self(std::collections::VecDeque::with_capacity(Self::CAPACITY))
+    }
+    #[inline]
+    pub(crate) fn is_full(&self) -> bool {
+        self.0.len() >= Self::CAPACITY
+    }
+    #[inline]
+    pub(crate) fn push(&mut self, task: Box<T>) {
+        debug_assert!(!self.is_full());
+        self.0.push_back(task);
+    }
+    #[inline]
+    pub(crate) fn pop(&mut self) -> Option<Box<T>> {
+        self.0.pop_front()
+    }
+}
+
+type NetworkQueue = TaskFifo<NetworkTask>;
+type PatchTaskFifo = TaskFifo<PatchTask>;
+
+pub type PatchTaskQueue = bun_threading::OwnedQueue<PatchTask>;
+pub type AsyncNetworkTaskQueue = bun_threading::OwnedQueue<NetworkTask>;
 
 pub(crate) type SuccessFn = fn(&mut PackageManager, DependencyID, PackageID);
 pub(crate) type FailFn = fn(&mut PackageManager, &Dependency, PackageID, Error);
@@ -301,34 +316,28 @@ bun_output::declare_scope!(PackageManager, hidden);
 pub struct PackageManager {
     pub(crate) cache_directory: Option<bun_sys::Dir>,
     pub(crate) cache_directory_path: ZBox, // owned; process lifetime via the leaked singleton
-    pub root_dir: &'static mut fs::DirEntry,
-    // allocator dropped per §Allocators (was `bun.default_allocator`). For the
-    // handful of sites that allocated AST nodes via `Expr.allocate(manager.allocator, …)`
-    // — i.e. nodes that must outlive `Expr.Data.Store.reset()` across workspace
-    // iterations — use `ast_arena` instead. The manager is a leaked singleton, so
-    // this arena has process lifetime.
+    /// The resolver's directory-cache entry for the project root (lives as long as the resolver's directory cache).
+    pub root_dir: &'static fs::DirEntry,
+    /// AST nodes that must outlive `Expr.Data.Store.reset()` across workspace
+    /// iterations are allocated here. The manager is a leaked singleton, so
+    /// this arena has process lifetime.
     pub(crate) ast_arena: bun_alloc::Arena,
-    // Raw ptr rather than `&'a mut bun_ast::Log`: PackageManager is a leaked singleton
-    // stored in a `static`, which cannot carry a lifetime parameter. Invariant: the
-    // pointed-to Log must outlive every use of the singleton.
-    pub log: *mut bun_ast::Log,
-    pub(crate) resolve_tasks: ResolveTaskQueue,
+    /// The install log. In CLI mode `init()` re-points the command context's
+    /// `log` at this one, so the rest of the CLI reads and prints the same log.
+    pub log: Box<bun_ast::Log>,
+    /// Cross-thread state: what worker/HTTP threads use to hand results back
+    /// and wake the main loop. Leaked alongside the manager.
+    pub shared: &'static Shared,
     pub(crate) timestamp_for_manifest_cache_control: u32,
     pub(crate) extracted_count: u32,
     pub(crate) summary: Package::DiffSummary,
-    // Set once in `init()`/`init_with_runtime()` to the process-singleton
-    // `DotEnv.Loader` (leaked allocation; outlives the manager). `BackRef`
-    // encapsulates the liveness invariant so `env()` is a safe accessor.
-    pub env: Option<bun_ptr::BackRef<dot_env::Loader, bun_ptr::Mut>>,
+    pub env: EnvLoader,
     pub progress: Progress,
-    pub(crate) downloads_node: Option<*mut ProgressNode>, // BORROW_FIELD — points into self.progress
-    pub scripts_node: Option<NonNull<ProgressNode>>, // points to a caller stack-local Progress node; only valid while that caller frame is live
-    pub(crate) progress_name_buf: [u8; 768],
+    /// Children of `progress.root` while an install pass shows progress.
+    pub(crate) downloads_node: Option<ProgressNode>,
+    pub scripts_node: Option<ProgressNode>,
 
     pub(crate) track_installed_bin: TrackInstalledBin,
-
-    // progress bar stuff when not stack allocated
-    pub(crate) root_progress_node: *mut ProgressNode, // BORROW_FIELD — self.progress.start() returns &self.progress.root
 
     pub to_update: bool,
 
@@ -355,29 +364,26 @@ pub struct PackageManager {
     pub(crate) git_repositories: RepositoryMap,
     pub(crate) git_commits: GitCommitMap,
     /// Git tasks queued by `enqueue_git_task` and not yet started.
-    pub(crate) git_tasks: VecDeque<NonNull<Task::Task<'static>>>,
+    pub(crate) git_tasks: VecDeque<Box<Task::Task>>,
     /// Git tasks whose `git_runner::GitSubprocess` is alive.
     pub(crate) running_git_tasks: AtomicU32,
+    /// The environment for the `git` children, built on first use.
+    pub(crate) git_env: OnceCell<crate::repository::GitEnv>,
     pub(crate) appended_task_packages: AppendedTaskPackageMap,
 
     pub(crate) network_dedupe_map: crate::network_task::DedupeMap,
-    pub(crate) async_network_task_queue: AsyncNetworkTaskQueue,
     pub(crate) network_tarball_batch: thread_pool::Batch,
     pub(crate) network_resolve_batch: thread_pool::Batch,
     pub(crate) network_task_fifo: NetworkQueue,
     pub(crate) patch_apply_batch: thread_pool::Batch,
     pub(crate) patch_calc_hash_batch: thread_pool::Batch,
     pub(crate) patch_task_fifo: PatchTaskFifo,
-    pub(crate) patch_task_queue: PatchTaskQueue,
     /// We actually need to calculate the patch file hashes
     /// every single time, because someone could edit the patchfile at anytime
     ///
     /// TODO: Does this need to be atomic? It seems to be accessed only from the main thread.
     pub(crate) pending_pre_calc_hashes: AtomicU32,
-    pub pending_tasks: AtomicU32,
     pub total_tasks: u32,
-    pub(crate) preallocated_network_tasks: PreallocatedNetworkTasks,
-    pub(crate) preallocated_resolve_tasks: PreallocatedTaskStore,
 
     pub pending_lifecycle_script_tasks: AtomicU32,
     pub(crate) finished_installing: AtomicBool,
@@ -397,8 +403,6 @@ pub struct PackageManager {
     pub global_dir: Option<bun_sys::Dir>,
     pub(crate) global_link_dir_path: Box<[u8]>,
 
-    pub(crate) on_wake: WakeHandler,
-
     pub(crate) peer_dependencies: LinearFifo<DependencyID, DynamicBuffer<DependencyID>>,
 
     // name hash from alias package name -> aliased package dependency version info
@@ -406,7 +410,7 @@ pub struct PackageManager {
 
     pub(crate) event_loop: AnyEventLoop,
 
-    // During `installPackages` we learn exactly what dependencies from --trust
+    // While installing packages we learn exactly what dependencies from --trust
     // actually have scripts to run, and we add them to this list
     pub(crate) trusted_deps_to_add_to_package_json: Vec<Box<[u8]>>,
 
@@ -417,13 +421,13 @@ pub struct PackageManager {
     // workspace package. We keep track of the original here.
     pub original_package_json_path: ZBox,
 
-    // null means root. Used during `cleanWithLogger` to identifier which
+    // null means root. Used during `clean_with_logger` to identify which
     // workspace is adding/removing packages
     pub workspace_name_hash: Option<PackageNameHash>,
 
     pub workspace_package_json_cache: WorkspacePackageJSONCache,
 
-    // normally we have `UpdateRequests` to work with for adding/deleting/updating packages, but
+    // normally we have `UpdateRequest`s to work with for adding/deleting/updating packages, but
     // if `bun update` is used without any package names we need a way to keep information for
     // the original packages that are updating.
     //
@@ -461,9 +465,80 @@ pub struct PackageManager {
     pub(crate) patched_dependencies_to_remove:
         ArrayHashMap<PackageNameAndVersionHash, () /* , ArrayIdentityContext::U64, false */>,
 
-    pub(crate) active_lifecycle_scripts: crate::lifecycle_script_runner::List<'static>,
+    pub(crate) active_lifecycle_scripts: crate::lifecycle_script_runner::List,
     pub(crate) last_reported_slow_lifecycle_script_at: u64,
     pub(crate) cached_tick_for_slow_lifecycle_script_logging: u64,
+}
+
+/// The `.env`/environment loader the manager reads settings and proxies from.
+/// The CLI owns one; under the runtime it is the VM's, which the manager only
+/// reads.
+pub enum EnvLoader {
+    Owned(Box<dot_env::Loader>),
+    Vm(bun_ptr::BackRef<dot_env::Loader>),
+}
+
+impl EnvLoader {
+    #[inline]
+    pub fn get(&self) -> &dot_env::Loader {
+        match self {
+            EnvLoader::Owned(l) => l,
+            EnvLoader::Vm(l) => l.get(),
+        }
+    }
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut dot_env::Loader {
+        match self {
+            EnvLoader::Owned(l) => l,
+            EnvLoader::Vm(_) => {
+                unreachable!("the runtime's env loader is read-only to the package manager")
+            }
+        }
+    }
+}
+
+/// The part of the package manager that worker and HTTP threads touch. They
+/// never see `PackageManager` itself; they hold `&'static Shared`.
+pub struct Shared {
+    pub pending_tasks: AtomicU32,
+    /// Finished resolve/extract tasks, pushed by thread-pool workers.
+    pub(crate) resolve_tasks: ResolveTaskQueue,
+    /// Finished network tasks, pushed by the HTTP thread.
+    pub(crate) async_network_task_queue: AsyncNetworkTaskQueue,
+    /// Patch tasks that finished on the thread pool.
+    pub(crate) patch_task_queue: PatchTaskQueue,
+    waker: bun_event_loop::LoopWaker,
+    /// Installed by the runtime (`set_on_wake`) to nudge the JS loop.
+    on_wake: bun_threading::Guarded<WakeHandler>,
+}
+
+impl Shared {
+    fn new(waker: bun_event_loop::LoopWaker) -> &'static Shared {
+        Box::leak(Box::new(Shared {
+            pending_tasks: AtomicU32::new(0),
+            resolve_tasks: ResolveTaskQueue::new(),
+            async_network_task_queue: AsyncNetworkTaskQueue::new(),
+            patch_task_queue: PatchTaskQueue::new(),
+            waker,
+            on_wake: bun_threading::Guarded::new(WakeHandler::default()),
+        }))
+    }
+
+    /// Wake the main install loop (and the runtime's JS loop, if one installed
+    /// a handler). Callable from any thread.
+    pub fn wake(&self) {
+        let on_wake = *self.on_wake.lock();
+        on_wake.wake(core::ptr::null_mut());
+        self.waker.wakeup();
+    }
+
+    pub(crate) fn set_on_wake(&self, handler: WakeHandler) {
+        *self.on_wake.lock() = handler;
+    }
+
+    pub(crate) fn on_wake(&self) -> WakeHandler {
+        *self.on_wake.lock()
+    }
 }
 
 #[derive(Default)]
@@ -632,7 +707,7 @@ pub enum TrackInstalledBin {
 // MOVE_DOWN: data struct + accessors live in `bun_install_types::WakeHandler`
 // (single definition the resolver also stores). The `handler` second arg is
 // erased to `*mut c_void` there because that crate cannot name
-// `PackageManager`; `wake_raw()` casts it back at the call site.
+// `PackageManager`; `Shared::wake` passes null and the runtime handler ignores it.
 pub use bun_install_types::resolver_hooks::WakeHandler;
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -657,83 +732,23 @@ impl PackageManager {
         VERBOSE_INSTALL.store(v, core::sync::atomic::Ordering::Relaxed);
     }
 
-    /// Reborrow the externally-owned [`bun_ast::Log`].
-    ///
-    /// `log` is `*mut Log` (not `&'a mut Log`) only because `PackageManager` is
-    /// a leaked `'static` singleton stored in a global; threading the borrow
-    /// lifetime through `static INSTANCE` is deferred (see field comment). The
-    /// `Log` itself outlives the manager — it's the CLI-scope log allocated in
-    /// `Command::init` before the manager exists.
-    ///
-    /// The returned lifetime is **decoupled** from `&self`: callers routinely
-    /// hold a borrow into `self.lockfile`/`self.options` while appending an
-    /// error, and the `Log` is a disjoint allocation. It is the caller's
-    /// responsibility not to alias the returned `&mut Log` (single-threaded by
-    /// construction — only the main install loop touches `log`).
     #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub fn log_mut<'a>(&self) -> &'a mut bun_ast::Log {
-        let p = self.log;
-        // SAFETY: `self.log` is non-null for the manager's lifetime (set in
-        // `init`, never cleared) and the pointee is the CLI-scope `Log`, which
-        // outlives every `'a` a caller can name. Exclusive access is upheld by
-        // single-threaded use; see doc comment.
-        unsafe { &mut *p }
+    pub fn log_mut(&mut self) -> &mut bun_ast::Log {
+        &mut self.log
     }
 
-    /// Reborrow the active progress download node (`self.progress.root`-rooted).
-    /// Panics if no download node is active — callers gate on
-    /// `options.log_level.show_progress()`, which is the same condition that
-    /// populates `downloads_node`. Lifetime is decoupled from `&self` for the
-    /// same reason as [`log_mut`]: `Progress` is a stable allocation on the
-    /// leaked-singleton manager and callers interleave node updates with
-    /// disjoint `&mut self.X` field writes.
+    /// The active progress download node. Panics if no download node is
+    /// active — callers gate on `options.log_level.show_progress()`, which
+    /// is the same condition that populates `downloads_node`.
     #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub(crate) fn downloads_node_mut<'a>(&self) -> &'a mut ProgressNode {
-        let p = self.downloads_node.expect("downloads_node active");
-        // SAFETY: `downloads_node` points into `self.progress` (BORROW_FIELD);
-        // `Progress` is pinned for the manager's lifetime (leaked singleton)
-        // and the node is set before any caller reaches this path.
-        unsafe { &mut *p }
+    pub(crate) fn downloads_node_mut(&mut self) -> &mut ProgressNode {
+        self.downloads_node.as_mut().expect("downloads_node active")
     }
 
-    /// Reborrow the active scripts progress node, if any.
-    ///
-    /// Unlike [`downloads_node_mut`], this returns `Option` — `scripts_node` is
-    /// `None` until the install pass (hoisted/isolated) populates it with a
-    /// pointer to a stack-local `ProgressNode` that outlives the pass. Lifetime
-    /// is decoupled from `&self` for the same reason as [`downloads_node_mut`]:
-    /// callers interleave node updates with disjoint `&mut self.X` writes, and
-    /// the pointee lives on the *caller's* stack, not inside the manager.
-    /// Single-threaded by construction (main install loop only — see
-    /// `lifecycle_script_runner` "monotonic is okay" comments).
+    /// The active scripts progress node, if the install pass set one up.
     #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub(crate) fn scripts_node_mut<'a>(&self) -> Option<&'a mut ProgressNode> {
-        let mut p = self.scripts_node?;
-        // SAFETY: `scripts_node` is `Some(NonNull)` pointing at a caller
-        // stack-local `ProgressNode` that outlives the install pass; access is
-        // single-threaded (main install loop only).
-        Some(unsafe { p.as_mut() })
-    }
-
-    /// The global singleton accessor. Associated-fn spelling that forwards to
-    /// the free [`get`] so callers can write `PackageManager::get()`.
-    ///
-    /// Returns `&'static` (shared) — NOT `&'static mut`. Thread-pool workers
-    /// (`Repository` git ops, npm `SaveTask`, `UninstallTask::run`) call this
-    /// concurrently with the main thread; a shared ref is the only sound
-    /// shape. Mutating accessors (`increment_pending_tasks`, `wake`, …) take
-    /// `&self` and use interior atomics. For exclusive in-place mutation use
-    /// the raw [`get`] free fn with field projection (see its doc).
-    #[inline]
-    pub fn get() -> &'static PackageManager {
-        // SAFETY: `holder::RAW_PTR` is written once on the main thread by
-        // `allocate_package_manager()` before any caller of `get()`; the
-        // singleton lives for the process. Shared `&` aliases freely across
-        // threads.
-        unsafe { &*get() }
+    pub(crate) fn scripts_node_mut(&mut self) -> Option<&mut ProgressNode> {
+        self.scripts_node.as_mut()
     }
 
     /// Associated-fn spelling that forwards to the free [`init`] so callers
@@ -748,54 +763,18 @@ impl PackageManager {
     }
 }
 
-// Only consumer is `hasEnoughTimePassedBetweenWaitingMessages`.
+// Only consumer is `has_enough_time_passed_between_waiting_messages`.
 // Main-thread-only, so `Relaxed` suffices.
 static TIME_PASSER_LAST_TIME: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
 
-thread_local! {
-    // bun.ThreadlocalBuffers: heap-backed so only a pointer lives in TLS
-    // (see test/js/bun/binary/tls-segment-size).
-    static CACHED_PACKAGE_FOLDER_NAME_BUFS: core::cell::Cell<*mut PathBuffer> =
-        const { core::cell::Cell::new(core::ptr::null_mut()) };
-}
-
-#[inline]
-pub(crate) fn cached_package_folder_name_buf() -> *mut PathBuffer {
-    // bun.ThreadlocalBuffers semantics: lazily heap-allocate, return raw ptr into
-    // thread-local storage. Callers reborrow per-field; valid for the thread's lifetime.
-    CACHED_PACKAGE_FOLDER_NAME_BUFS.with(|c| {
-        let mut p = c.get();
-        if p.is_null() {
-            p = bun_core::heap::into_raw(Box::new(PathBuffer::ZEROED));
-            c.set(p);
-        }
-        p
-    })
-}
-
 mod holder {
     use super::PackageManager;
-    use bun_dotenv as dot_env;
-    // OWNED — global singleton, leaked.
-    // OnceLock<Box<PackageManager>> can't express allocate-then-fill
-    // (no `&mut` after set), so a raw ptr is used instead.
-    // PORTING.md §Global mutable state: ptr written once on main thread, read
-    // from worker threads → AtomicPtr (Release/Acquire pairs the publish).
-    pub(super) static RAW_PTR: core::sync::atomic::AtomicPtr<PackageManager> =
+    /// The leaked singleton, kept reachable from a global so leak checkers see
+    /// everything it owns as live. Never dereferenced.
+    pub(super) static LSAN_ROOT: core::sync::atomic::AtomicPtr<PackageManager> =
         core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
 
-    pub(super) static INITIALIZED: core::sync::atomic::AtomicBool =
-        core::sync::atomic::AtomicBool::new(false);
-
-    // Process-lifetime env storage for `init()`. Owned by the singleton, never
-    // freed. Avoids `Box::leak` per PORTING.md §Forbidden. Write-once during
-    // single-threaded init. `AtomicCell<*mut T>` — payload is `Copy` and
-    // pointer-sized, so `.store()` is a safe Release write.
-    pub(super) static ENV_LOADER: bun_core::AtomicCell<*mut dot_env::Loader> =
-        bun_core::AtomicCell::new(core::ptr::null_mut());
-
     /// Process-lifetime storage for `http::http_thread::InitOpts.abs_ca_file_name`.
-    /// `OnceLock` per PORTING.md §Forbidden — never `Box::leak` to mint `&'static`.
     pub(super) static ABS_CA_FILE_NAME: std::sync::OnceLock<Box<[u8]>> = std::sync::OnceLock::new();
 
     /// Process-lifetime storage for `http::http_thread::InitOpts.ca` C-strings
@@ -803,15 +782,19 @@ mod holder {
     /// reads these asynchronously after `init()` returns, so they must outlive
     /// the local that builds them.
     pub(super) static CA: std::sync::OnceLock<Vec<bun_core::ZBox>> = std::sync::OnceLock::new();
+
+    /// Absolute path of the root `package.json`, set once by `init()`.
+    pub(super) static ROOT_PACKAGE_JSON_PATH: std::sync::OnceLock<bun_core::ZBox> =
+        std::sync::OnceLock::new();
 }
 
-// PORTING.md §Global mutable state: single-thread (main) scratch buffers →
-// RacyCell. `ROOT_PACKAGE_JSON_PATH` is a slice into the buf above it; written
-// once in `init()`, read on main + CLI commands afterwards.
-static CWD_BUF: bun_core::RacyCell<PathBuffer> = bun_core::RacyCell::new(PathBuffer::ZEROED);
-static ROOT_PACKAGE_JSON_PATH_BUF: bun_core::RacyCell<PathBuffer> =
-    bun_core::RacyCell::new(PathBuffer::ZEROED);
-pub static ROOT_PACKAGE_JSON_PATH: bun_core::RacyCell<&ZStr> = bun_core::RacyCell::new(ZStr::EMPTY);
+/// Absolute path of the root `package.json` (empty before `PackageManager::init`).
+pub fn root_package_json_path() -> &'static ZStr {
+    holder::ROOT_PACKAGE_JSON_PATH
+        .get()
+        .map(|p| p.as_zstr())
+        .unwrap_or(ZStr::EMPTY)
+}
 
 // ──────────────────────────────────────────────────────────────────────────
 // impl PackageManager
@@ -830,40 +813,87 @@ impl PackageManager {
     pub fn load_lockfile_from_cwd<const ATTEMPT_OTHER: bool>(
         &mut self,
     ) -> lockfile::LoadResult<'_> {
-        let pm: *mut PackageManager = self;
-        // SAFETY: `self.lockfile` is `Box<Lockfile>` — its pointee lives in a
-        // separate heap allocation, so `&mut Lockfile` and `&mut PackageManager`
-        // never alias overlapping bytes. `Lockfile::load_from_cwd` reads
-        // `manager.options`/`manager.log` only and never re-projects
-        // `manager.lockfile`. Both raw pointers below are derived from `self`,
-        // so the caller's borrow stays on the Stacked-Borrows stack.
-        unsafe {
-            let lf: *mut Lockfile = &raw mut *(*pm).lockfile;
-            let log: *mut bun_ast::Log = (*pm).log;
-            (*lf).load_from_cwd::<ATTEMPT_OTHER>(Some(&mut *pm), &mut *log)
-        }
+        self.load_lockfile_from_cwd_detached::<ATTEMPT_OTHER>()
+            .attach(&mut self.lockfile)
+    }
+
+    /// [`load_lockfile_from_cwd`](Self::load_lockfile_from_cwd) whose result
+    /// does not keep `self.lockfile` borrowed.
+    pub fn load_lockfile_from_cwd_detached<const ATTEMPT_OTHER: bool>(
+        &mut self,
+    ) -> lockfile::DetachedLoadResult {
+        // `Lockfile::load_from_cwd` takes the manager as a separate argument
+        // while the receiver is `self.lockfile`; move the lockfile out for the
+        // call so the two borrows are disjoint, then put the loaded one back.
+        let mut lockfile = core::mem::take(&mut self.lockfile);
+        let result = self.with_log(|this, log| {
+            lockfile
+                .load_from_cwd::<ATTEMPT_OTHER>(Some(this), log)
+                .detach()
+        });
+        self.lockfile = lockfile;
+        result
+    }
+
+    /// Is `id` a direct dependency of the root (cwd workspace) package?
+    pub(crate) fn is_root_dependency(&mut self, id: DependencyID) -> bool {
+        // `RootPackageId::get` caches into `self`.
+        let root_id = self
+            .root_package_id
+            .get(&self.lockfile, self.workspace_name_hash);
+        crate::lockfile::package::PackageColumns::items_dependencies(
+            &self.lockfile.packages.slice(),
+        )[root_id as usize]
+            .contains(id)
+    }
+
+    /// Run `f` with `self.log` moved out, for callees that take the manager
+    /// and the log as separate arguments; anything logged through `self.log`
+    /// meanwhile is appended after.
+    pub fn with_log<R>(&mut self, f: impl FnOnce(&mut Self, &mut bun_ast::Log) -> R) -> R {
+        let mut log = core::mem::take(&mut self.log);
+        self.log.level = log.level;
+        let result = f(self, &mut log);
+        let mut meanwhile = core::mem::replace(&mut self.log, log);
+        meanwhile.transfer_to(&mut self.log);
+        result
+    }
+
+    /// Move everything this manager has logged so far into `dest` (the
+    /// runtime routes install diagnostics into whichever log the current
+    /// resolve/transpile reports through).
+    pub fn take_log_into(&mut self, dest: &mut bun_ast::Log) {
+        self.log.transfer_to(dest);
+    }
+
+    /// Run `f` with `self.lockfile` and `self.log` moved out, for callees that
+    /// take the lockfile, the manager and the log as separate arguments.
+    /// `self.lockfile` is empty meanwhile.
+    pub fn with_lockfile_and_log<R>(
+        &mut self,
+        f: impl FnOnce(&mut Lockfile, &mut Self, &mut bun_ast::Log) -> R,
+    ) -> R {
+        let mut lockfile = core::mem::take(&mut self.lockfile);
+        let result = self.with_log(|this, log| f(&mut lockfile, this, log));
+        self.lockfile = lockfile;
+        result
     }
 
     pub(crate) fn crash(&mut self) -> ! {
-        if self.options.log_level != package_manager_options::LogLevel::Silent {
-            // SAFETY: `self.log` points to a separate `bun_ast::Log` allocation (borrowed from
-            // `ctx.log`) that outlives the singleton. `&mut self` only covers the pointer field,
-            // not the pointee. `bun_ast::Log::print` takes `&self`,
-            // so we only need a shared borrow here — the sole invariant is
-            // that no `&mut bun_ast::Log` to the pointee is live, which holds on this path.
+        Self::crash_with_log(&self.options, &mut self.log)
+    }
+
+    pub(crate) fn crash_with_log(options: &Options, log: &mut bun_ast::Log) -> ! {
+        if options.log_level != package_manager_options::LogLevel::Silent {
             // `IntoLogWrite` is impl'd for `*mut io::Writer`, not `&mut`.
-            let _ = self
-                .log_mut()
-                .print(std::ptr::from_mut(Output::error_writer()));
+            let _ = log.print(std::ptr::from_mut(Output::error_writer()));
         }
         Global::crash();
     }
 
-    pub fn has_enough_time_passed_between_waiting_messages() -> bool {
-        // Main-thread only (also guards TIME_PASSER_LAST_TIME below); reads
-        // event_loop.iteration_number which is written only by the same main-thread tick loop.
-        // `Self::get()` is the safe `&'static PackageManager` singleton accessor.
-        let iter = Self::get().event_loop.iteration_number();
+    pub fn has_enough_time_passed_between_waiting_messages(&self) -> bool {
+        // Main-thread only (also guards TIME_PASSER_LAST_TIME below).
+        let iter = self.event_loop.iteration_number();
         if TIME_PASSER_LAST_TIME.load(core::sync::atomic::Ordering::Relaxed) < iter {
             TIME_PASSER_LAST_TIME.store(iter, core::sync::atomic::Ordering::Relaxed);
             return true;
@@ -871,30 +901,19 @@ impl PackageManager {
         false
     }
 
-    pub(crate) fn configure_env_for_scripts(
-        &mut self,
-        ctx: Command::Context,
-        log_level: package_manager_options::LogLevel,
-    ) -> Result<&mut transpiler::Transpiler<'static>, Error> {
-        // Compute once and return the cached value on
-        // subsequent calls. `Transpiler` is non-`Copy` (and self-referential via
-        // `linker.options = &options`), so cache by pointer in a process-static.
-        // SAFETY: `PackageManager` is a leaked singleton; main-thread-only call site.
-        let mut ptr = CONFIGURE_ENV_FOR_SCRIPTS_ONCE.load(core::sync::atomic::Ordering::Acquire);
-        if ptr.is_null() {
-            let t = configure_env_for_scripts_run(self, ctx, log_level)?;
-            ptr = bun_core::heap::into_raw(Box::new(t));
-            CONFIGURE_ENV_FOR_SCRIPTS_ONCE.store(ptr, core::sync::atomic::Ordering::Release);
+    /// The env loader, with everything lifecycle scripts expect in their
+    /// environment (`npm_config_user_agent`, `PATH` with a `node` shim, …)
+    /// added on first call.
+    pub(crate) fn configure_env_for_scripts(&mut self) -> Result<&mut dot_env::Loader, Error> {
+        if !CONFIGURED_ENV_FOR_SCRIPTS.load(Ordering::Acquire) {
+            configure_env_for_scripts_run(self)?;
+            CONFIGURED_ENV_FOR_SCRIPTS.store(true, Ordering::Release);
         }
-        // SAFETY: `ptr` is a leaked `Box<Transpiler>`; main-thread-only so the
-        // `&mut` is exclusive for the caller's scope.
-        Ok(unsafe { &mut *ptr })
+        Ok(self.env_mut())
     }
 
-    pub fn http_proxy(&self, url: &URL<'_>) -> Option<URL<'static>> {
-        // `env_mut()` yields an unbounded `&'a Loader` (process-lifetime
-        // singleton), so the returned `URL<'_>` borrows for `'static`.
-        self.env_mut().get_http_proxy_for(url)
+    pub fn http_proxy(&self, url: &URL<'_>) -> Option<URL<'_>> {
+        self.env().get_http_proxy_for(url)
     }
 
     pub fn tls_reject_unauthorized(&self) -> bool {
@@ -907,102 +926,27 @@ impl PackageManager {
         dependency_id: DependencyID,
         err: Error,
     ) {
-        if let Some(ctx) = self.on_wake.context {
-            // SAFETY: `ctx` is the `WakeHandler::context` registered alongside
-            // this callback (a live `*mut Queue`); see `runtime::jsc_hooks`.
-            unsafe {
-                (self.on_wake.get_on_dependency_error())(
-                    ctx.as_ptr(),
-                    dependency,
-                    dependency_id,
-                    err.name(),
-                );
-            }
-        }
+        self.shared
+            .on_wake()
+            .dependency_error(dependency, dependency_id, err.name());
     }
 
-    /// Raw-pointer wake for concurrent task-thread callers (see
-    /// `isolated_install::Installer::Task::callback`). Never materializes
-    /// `&mut PackageManager`, so two task threads finishing simultaneously do
-    /// not hold aliased exclusive borrows. `on_wake` is read-only; the handler
-    /// receives the raw `*mut`;
-    /// `event_loop.wakeup()` is the cross-thread signal and is
-    /// internally synchronized — we reach it via `addr_of_mut!` so the `&mut`
-    /// covers only the event-loop field, never the whole `PackageManager`.
-    ///
-    /// # Safety
-    /// `this` must point to a live `PackageManager` (BACKREF).
-    pub(crate) unsafe fn wake_raw(this: *mut Self) {
-        // SAFETY: caller guarantees `this` points to a live `PackageManager`; we
-        // only form field pointers via `addr_of!`/`addr_of_mut!` (no whole-struct
-        // borrow) and `wakeup()` is internally synchronized for cross-thread use.
-        unsafe {
-            let on_wake = &*core::ptr::addr_of!((*this).on_wake);
-            if let Some(ctx) = on_wake.context {
-                // `WakeHandler.handler`'s second arg is the erased
-                // `*mut PackageManager` (`bun_install_types` cannot name this
-                // type); cast back to `*mut c_void` here.
-                (on_wake.get_handler())(ctx.as_ptr(), this.cast::<c_void>());
-            }
-            (*core::ptr::addr_of_mut!((*this).event_loop)).wakeup();
-        }
-    }
-
-    /// Associated fn taking `*mut PackageManager` (NOT `&mut self`): every
-    /// `is_done_fn` body in this crate reborrows the *whole* `PackageManager`
-    /// from a raw pointer stashed in `C` (`&mut *closure.manager`). If this
-    /// were a `&mut self` method, that whole-struct Unique retag would pop
-    /// `self`'s tag (and the `&mut self.event_loop` borrow `tick` holds) under
-    /// Stacked Borrows, making the next loop-iteration deref UB.
-    ///
-    /// SAFETY: `this` must be valid for `&mut` access between callback
-    /// invocations; while `is_done_fn` runs, the callback owns the unique
-    /// `&mut PackageManager` and `sleep_until`/`tick_raw` hold no borrow.
-    pub(crate) unsafe fn sleep_until<C>(
-        this: *mut PackageManager,
-        closure: &mut C,
-        is_done_fn: fn(&mut C) -> bool,
+    /// Tick the event loop until `is_done(ctx)` returns true. `ctx` owns
+    /// access to the manager (see [`run_tasks::RunTasksCtx`]), so no borrow of
+    /// it (or of its `event_loop`) is held while `is_done` runs.
+    pub(crate) fn sleep_until<C: run_tasks::RunTasksCtx + ?Sized>(
+        ctx: &mut C,
+        mut is_done: impl FnMut(&mut C) -> bool,
     ) {
         Output::flush();
-        // `AnyEventLoop::tick_raw` takes the type-erased
-        // `(*mut c_void, fn(*mut c_void) -> bool)`; trampoline through a small wrapper so
-        // `is_done_fn` receives `&mut C` and can drive `run_tasks` / record `err`.
-        struct Erased<C> {
-            ctx: *mut C,
-            is_done: fn(&mut C) -> bool,
+        // A lifecycle script can finish without the loop seeing an event
+        // (its exit is reaped synchronously while spawning it), so pick those
+        // up before deciding to block.
+        Self::drain_lifecycle_scripts(ctx);
+        while !is_done(ctx) {
+            ctx.manager().event_loop.sleep_tick(core::ptr::null_mut());
+            Self::drain_lifecycle_scripts(ctx);
         }
-        fn trampoline<C>(p: *mut c_void) -> bool {
-            let erased = p as *const Erased<C>;
-            // SAFETY: `p` is the `Erased<C>` local we pass to `tick_raw` below. We only
-            // read its two POD fields here (no `&mut Erased` materialized — the local
-            // `&mut erased` borrow in the caller is still notionally live across the call).
-            let (ctx_ptr, is_done) = unsafe { ((*erased).ctx, (*erased).is_done) };
-            // SAFETY: `ctx_ptr` was derived from the caller's exclusive `closure: &mut C`
-            // and the caller does not touch `closure` again until `tick_raw` returns, so
-            // this is the unique live `&mut C` for the duration of the callback.
-            let ctx = unsafe { &mut *ctx_ptr };
-            is_done(ctx)
-        }
-        let mut erased = Erased::<C> {
-            ctx: std::ptr::from_mut::<C>(closure),
-            is_done: is_done_fn,
-        };
-        // Derive the event-loop pointer through `this`'s raw provenance (NOT
-        // via a `&mut self.event_loop` reborrow) so it shares `this`'s SRW tag
-        // and survives the callback's `&mut *this` retag.
-        // SAFETY: `this` is valid per fn contract; `&raw mut` does not create a
-        // reference, only a place projection.
-        let event_loop: *mut AnyEventLoop = unsafe { &raw mut (*this).event_loop };
-        // SAFETY: `tick_raw` reborrows `*event_loop` only between `is_done`
-        // calls (never across them), so the callback's `&mut PackageManager`
-        // never overlaps a live `&mut AnyEventLoop`.
-        unsafe {
-            AnyEventLoop::tick_raw(
-                event_loop,
-                (&raw mut erased).cast::<c_void>(),
-                trampoline::<C>,
-            )
-        };
     }
 
     pub(crate) fn ensure_temp_node_gyp_script(&mut self) -> Result<(), Error> {
@@ -1017,34 +961,15 @@ impl PackageManager {
         ensure_temp_node_gyp_script_run(self)
     }
 
-    // Helper: deref env (set-once BackRef to process-singleton loader)
     #[inline]
-    pub(crate) fn env(&self) -> &dot_env::Loader {
-        // `env` is set during init() and never None afterward; `BackRef::get`
-        // encapsulates the deref under the back-reference invariant.
-        self.env.as_ref().expect("env initialised").get()
-    }
-    #[cfg(bun_asan)]
-    pub fn deinit_caches(&mut self) {
-        self.workspace_package_json_cache = WorkspacePackageJSONCache::default();
-        self.update_requests = Box::default();
+    pub fn env(&self) -> &dot_env::Loader {
+        self.env.get()
     }
 
-    /// Reborrow the process-global env loader.
-    ///
-    /// Lifetime is decoupled from `&self` for the same reason as [`log_mut`] /
-    /// [`downloads_node_mut`]: the loader is a singleton-leaked allocation
-    /// outside the manager (set once in `init()`), and callers interleave env
-    /// mutation with disjoint `&mut self.X` field writes.
+    /// CLI mode only (the runtime's loader is read-only here).
     #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub fn env_mut<'a>(&self) -> &'a mut dot_env::Loader {
-        // SAFETY: `env` is set during `init()` and never None afterward; the
-        // pointee is a process-lifetime singleton (leaked `DotEnv.Loader`)
-        // that lives outside `self`, so the unbounded `'a` is sound under the
-        // same single-threaded contract as `log_mut`/`scripts_node_mut`.
-        // `BackRef` guarantees liveness; exclusivity is the caller's contract.
-        unsafe { &mut *self.env.expect("env initialised").as_ptr() }
+    pub fn env_mut(&mut self) -> &mut dot_env::Loader {
+        self.env.get_mut()
     }
 }
 
@@ -1052,42 +977,20 @@ impl PackageManager {
 // run-once wrappers
 // ──────────────────────────────────────────────────────────────────────────
 
-// `Transpiler` is non-`Copy` and self-referential, so cache
-// a process-static raw pointer.
-// PORTING.md §Global mutable state: init-once ptr → AtomicPtr.
-static CONFIGURE_ENV_FOR_SCRIPTS_ONCE: core::sync::atomic::AtomicPtr<
-    transpiler::Transpiler<'static>,
-> = core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
+static CONFIGURED_ENV_FOR_SCRIPTS: AtomicBool = AtomicBool::new(false);
 
-fn configure_env_for_scripts_run(
-    this: &mut PackageManager,
-    ctx: Command::Context,
-    log_level: package_manager_options::LogLevel,
-) -> Result<transpiler::Transpiler<'static>, Error> {
+fn configure_env_for_scripts_run(this: &mut PackageManager) -> Result<(), Error> {
     // We need to figure out the PATH and other environment variables
     // to do that, we re-use the code from bun run
     // this is expensive, it traverses the entire directory tree going up to the root
     // so we really only want to do it when strictly necessary
-    // `RunCommand::configure_env_for_run` fully initializes the slot via out-param.
-    // Transpiler is NOT
-    // all-zero-valid POD, so `zeroed()` is wrong; use MaybeUninit and assume_init after fill.
-    let mut this_transpiler_slot =
-        core::mem::MaybeUninit::<transpiler::Transpiler<'static>>::uninit();
-    // `self.env` is `Option<BackRef<Loader>>`; pass the raw pointer so
-    // the shim's `Transpiler::init` reuses the manager's loader instead of
-    // allocating a fresh singleton.
-    let env_ptr: Option<*mut dot_env::Loader> = this.env.map(|p| p.as_ptr());
-    let _ = RunCommand::configure_env_for_run(
-        ctx,
-        &mut this_transpiler_slot,
-        env_ptr,
-        log_level != package_manager_options::LogLevel::Silent,
-        false,
-    )?;
-    // SAFETY: the install-tier `RunCommand::configure_env_for_run` shim
-    // (lib.rs) `.write()`s the slot via `Transpiler::init` before returning
-    // `Ok` — same contract as the runtime impl (run_command.rs:628).
-    let this_transpiler = unsafe { this_transpiler_slot.assume_init() };
+    let quiet = !this.log.level.at_least(bun_ast::Level::Info);
+    let env = this.env_mut();
+    if dot_env::instance().is_none() {
+        dot_env::set_instance(env);
+    }
+    env.quiet = quiet;
+    RunCommand::configure_env_for_run(env);
 
     let init_cwd_entry = this.env_mut().map.get_or_put_without_value(b"INIT_CWD")?;
     if !init_cwd_entry.found_existing {
@@ -1108,7 +1011,7 @@ fn configure_env_for_scripts_run(
         // https://github.com/nodejs/node-gyp/blob/7d883b5cf4c26e76065201f85b0be36d5ebdcc0e/lib/build.js#L150-L184
         let thread_count = bun_core::get_thread_count();
         if thread_count > 2 {
-            let t_env = this_transpiler.env_mut();
+            let t_env = this.env_mut();
             if !t_env.has(b"JOBS") {
                 let mut int_buf = bun_core::fmt::ItoaBuf::new();
                 let jobs_str = bun_core::fmt::itoa(&mut int_buf, thread_count);
@@ -1131,7 +1034,7 @@ fn configure_env_for_scripts_run(
                 let current_path = this.env().get(b"PATH").unwrap_or(b"");
                 let mut path_var: Vec<u8> = Vec::with_capacity(current_path.len());
                 path_var.extend_from_slice(current_path);
-                let mut bun_path: &[u8] = b"";
+                let mut bun_path: &ZStr = ZStr::EMPTY;
                 if RunCommand::create_fake_temporary_node_executable(&mut path_var, &mut bun_path)
                     .is_err()
                 {
@@ -1143,7 +1046,7 @@ fn configure_env_for_scripts_run(
         }
     }
 
-    Ok(this_transpiler)
+    Ok(())
 }
 
 static ENSURE_TEMP_NODE_GYP_SCRIPT_ONCE: AtomicBool = AtomicBool::new(false);
@@ -1283,7 +1186,7 @@ fn http_thread_on_init_error(err: http::InitError, opts: &http::http_thread::Ini
     // stored slice length INCLUDES the trailing NUL. Re-derive the `&ZStr`
     // (NUL-stripped) once and use it for both the path resolver and the error
     // message so we don't print a literal `\0`.
-    // SAFETY: trailing-NUL invariant established by `init()` for any non-empty
+    // Trailing-NUL invariant established by `init()` for any non-empty
     // value; the empty default (`b""`) maps to `ZStr::EMPTY`.
     let abs_ca_z: &ZStr = if opts.abs_ca_file_name.is_empty() {
         ZStr::EMPTY
@@ -1328,50 +1231,116 @@ fn http_thread_on_init_error(err: http::InitError, opts: &http::http_thread::Ini
     Global::crash();
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// allocate / get singleton
-// ──────────────────────────────────────────────────────────────────────────
-
-fn allocate_package_manager() {
-    // Uninitialized memory, abort-on-OOM. The init() functions below write the full struct via
-    // `core::ptr::write` (no Drop on the uninit bytes).
-    let ptr =
-        bun_core::heap::into_raw(Box::<PackageManager>::new_uninit()).cast::<PackageManager>();
-    holder::RAW_PTR.store(ptr, core::sync::atomic::Ordering::Release);
-    #[cfg(bun_asan)]
-    bun_core::add_exit_callback(deinit_caches_at_exit);
+/// The fields of [`PackageManager`] that differ between the CLI and runtime
+/// constructors; everything else starts from the same defaults.
+struct NewOptions {
+    options: Options,
+    log: Box<bun_ast::Log>,
+    env: EnvLoader,
+    root_dir: &'static fs::DirEntry,
+    thread_pool: ThreadPool,
+    event_loop: AnyEventLoop,
+    shared: &'static Shared,
+    root_package_json_file: bun_sys::File,
+    original_package_json_path: ZBox,
+    workspace_package_json_cache: WorkspacePackageJSONCache,
+    workspace_name_hash: Option<PackageNameHash>,
+    subcommand: Subcommand,
+    root_package_json_name_at_time_of_init: Box<[u8]>,
 }
 
-#[cfg(bun_asan)]
-extern "C" fn deinit_caches_at_exit() {
-    if !bun_crash_handler::cli_state::is_main_thread() {
-        return;
+impl PackageManager {
+    fn new(o: NewOptions) -> PackageManager {
+        PackageManager {
+            cache_directory: None,
+            cache_directory_path: ZBox::from_bytes(b""),
+            root_dir: o.root_dir,
+            ast_arena: bun_alloc::Arena::new(),
+            log: o.log,
+            shared: o.shared,
+            timestamp_for_manifest_cache_control: 0,
+            extracted_count: 0,
+            summary: Default::default(),
+            env: o.env,
+            progress: Progress::default(),
+            downloads_node: None,
+            scripts_node: None,
+            track_installed_bin: TrackInstalledBin::None,
+            to_update: false,
+            subcommand: o.subcommand,
+            update_requests: Box::default(),
+            update_request_index: Default::default(),
+            audit_fix_pins: Box::default(),
+            root_package_json_name_at_time_of_init: o.root_package_json_name_at_time_of_init,
+            root_package_json_file: o.root_package_json_file,
+            root_package_id: RootPackageId::default(),
+            thread_pool: o.thread_pool,
+            task_batch: thread_pool::Batch::default(),
+            task_queue: TaskDependencyQueue::default(),
+            manifests: PackageManifestMap::default(),
+            folders: Default::default(),
+            git_repositories: RepositoryMap::default(),
+            git_commits: GitCommitMap::default(),
+            git_tasks: VecDeque::new(),
+            running_git_tasks: AtomicU32::new(0),
+            git_env: OnceCell::new(),
+            appended_task_packages: AppendedTaskPackageMap::default(),
+            network_dedupe_map: Default::default(),
+            network_tarball_batch: thread_pool::Batch::default(),
+            network_resolve_batch: thread_pool::Batch::default(),
+            network_task_fifo: NetworkQueue::new(),
+            patch_apply_batch: thread_pool::Batch::default(),
+            patch_calc_hash_batch: thread_pool::Batch::default(),
+            patch_task_fifo: PatchTaskFifo::new(),
+            pending_pre_calc_hashes: AtomicU32::new(0),
+            total_tasks: 0,
+            pending_lifecycle_script_tasks: AtomicU32::new(0),
+            finished_installing: AtomicBool::new(false),
+            total_scripts: 0,
+            root_lifecycle_scripts: None,
+            node_gyp_tempdir_name: Box::default(),
+            lockfile: Box::new(Lockfile::default()),
+            options: o.options,
+            preinstall_state: Vec::new(),
+            postinstall_optimizer: Default::default(),
+            global_link_dir: None,
+            global_dir: None,
+            global_link_dir_path: Box::default(),
+            peer_dependencies: LinearFifo::<DependencyID, DynamicBuffer<DependencyID>>::init(),
+            known_npm_aliases: NpmAliasMap::default(),
+            event_loop: o.event_loop,
+            trusted_deps_to_add_to_package_json: Vec::new(),
+            any_failed_to_install: false,
+            original_package_json_path: o.original_package_json_path,
+            workspace_name_hash: o.workspace_name_hash,
+            workspace_package_json_cache: o.workspace_package_json_cache,
+            updating_packages: StringArrayHashMap::default(),
+            updating_catalogs: Vec::new(),
+            update_target_workspaces: None,
+            named_update_reachable: None,
+            kept_patched: Vec::new(),
+            kept_patched_text: Vec::new(),
+            dedupe_report: None,
+            filtered_link_targets: None,
+            pending_filtered_write: None,
+            edited_package_jsons: Vec::new(),
+            catalog_add: add_catalog::State::default(),
+            patched_dependencies_to_remove: ArrayHashMap::default(),
+            active_lifecycle_scripts: Vec::new(),
+            last_reported_slow_lifecycle_script_at: 0,
+            cached_tick_for_slow_lifecycle_script_logging: 0,
+        }
     }
-    if !holder::INITIALIZED.load(core::sync::atomic::Ordering::Acquire) {
-        return;
-    }
-    let ptr = get();
-    if ptr.is_null() {
-        return;
-    }
-    // SAFETY: `deinit_caches()` only touches main-thread-owned fields.
-    unsafe { (*ptr).deinit_caches() };
 }
 
-/// Returns the raw singleton pointer.
-///
-/// Intentionally returns `*mut` rather than `&'static mut`: this accessor is
-/// invoked from thread-pool workers
-/// (`UninstallTask::run`, npm `SaveTask`, `Repository` git ops) concurrently
-/// with the main thread holding the `&mut PackageManager` returned by `init()`.
-/// Materializing `&'static mut` here would create aliased mutable references
-/// (UB). Callers must form their own narrowly-scoped reference via raw-pointer
-/// projection (e.g. `unsafe { &(*get()).cache_directory_path }`) and justify
-/// exclusivity / atomicity at the deref site.
-pub(crate) fn get() -> *mut PackageManager {
-    // `allocate_package_manager()` is the sole writer and runs on the main
-    // thread before any caller of `get()`; Acquire pairs with its Release.
-    holder::RAW_PTR.load(core::sync::atomic::Ordering::Acquire)
+/// Leak the manager for the process and record it as a leak-checker root.
+fn publish(manager: Box<PackageManager>) -> &'static mut PackageManager {
+    let manager = Box::leak(manager);
+    holder::LSAN_ROOT.store(
+        core::ptr::from_mut(manager),
+        core::sync::atomic::Ordering::Release,
+    );
+    manager
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1472,23 +1441,45 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
     );
 }
 
-/// Returns `&'static mut PackageManager` — the process-singleton (held in
-/// `holder::RAW_PTR`) is leaked for the process lifetime and `init()` is called
-/// exactly once on the single CLI dispatch thread. Every
-/// CLI command immediately reborrows the result as `&mut` for the command's
-/// duration; centralising the deref here removes a dozen identical
-/// `unsafe { &mut *ptr }` blocks at call sites.
-///
-/// Thread-pool workers (`UninstallTask::run`, npm `SaveTask`, `Repository` git ops)
-/// project `&(*get()).field` concurrently once tasks are scheduled — same
-/// aliasing story as before this change (the prior callers already held `&mut`
-/// across those points). The raw [`get`] accessor remains `*mut` for those
-/// worker-side projections.
+/// Builds the process's package manager (once, on the CLI dispatch thread)
+/// and leaks it; the caller holds the returned `&mut` for the command's
+/// duration. Worker threads only ever see [`Shared`] and read-only
+/// `BackRef`s handed to their tasks.
 pub fn init(
     ctx: Command::Context,
     cli: CommandLineArguments,
     subcommand: Subcommand,
 ) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
+    // The manager owns the install log from here on; the command context is
+    // re-pointed at it so the rest of the CLI reads and prints the same log.
+    // If setup fails, the context gets its previous log back with whatever
+    // was logged meanwhile.
+    let ctx_log = ctx.log;
+    let mut log = Box::new(bun_ast::Log::init());
+    {
+        let old = ctx.log_ref();
+        log.level = old.level;
+        log.clone_line_text = old.clone_line_text;
+    }
+    ctx.log_mut_checked().transfer_to(&mut log);
+    let mut log = Some(log);
+    let result = init_with_log(ctx, cli, subcommand, &mut log);
+    if let Some(mut log) = log {
+        ctx.log = ctx_log;
+        log.transfer_to(ctx.log_mut_checked());
+    }
+    result
+}
+
+fn init_with_log(
+    ctx: Command::Context,
+    cli: CommandLineArguments,
+    subcommand: Subcommand,
+    log_slot: &mut Option<Box<bun_ast::Log>>,
+) -> Result<(&'static mut PackageManager, Box<[u8]>), Error> {
+    let log = log_slot.as_mut().expect("set by init");
+    ctx.log = &raw mut **log;
+
     if cli.global {
         // Non-consuming peek: `ctx.install` is
         // `Option<Box<BunInstall>>` borrowed via `&mut ContextData`; reborrow with
@@ -1507,31 +1498,6 @@ pub fn init(
     bun_resolver::fs::FileSystem::init(None)?;
     let fs = FileSystem::instance();
     let top_level_dir_no_trailing_slash = strings::without_trailing_slash(fs.top_level_dir());
-    // SAFETY: CWD_BUF is a process-global path buffer only touched on the main thread.
-    // repr(transparent) makes the `*mut PathBuffer → *mut u8` cast sound.
-    unsafe {
-        let cwd_ptr = CWD_BUF.get().cast::<u8>();
-        #[cfg(windows)]
-        {
-            let _ = bun_paths::path_to_posix_buf::<u8>(
-                top_level_dir_no_trailing_slash,
-                &mut *CWD_BUF.get(),
-            );
-        }
-        #[cfg(not(windows))]
-        {
-            // Avoid memcpy alias when source and dest are the same
-            if cwd_ptr.cast_const() != top_level_dir_no_trailing_slash.as_ptr() {
-                core::ptr::copy_nonoverlapping(
-                    top_level_dir_no_trailing_slash.as_ptr(),
-                    cwd_ptr,
-                    top_level_dir_no_trailing_slash.len(),
-                );
-            }
-        }
-        #[cfg(windows)]
-        let _ = cwd_ptr;
-    }
 
     // Per-cfg const literal, no runtime alloc.
     #[cfg(windows)]
@@ -1545,17 +1511,8 @@ pub fn init(
     original_package_json_path_buf.extend_from_slice(SEP_PACKAGE_JSON);
     original_package_json_path_buf.push(0);
 
-    let path_len = top_level_dir_no_trailing_slash.len() + SEP_PACKAGE_JSON.len();
-    // SAFETY: NUL written at `path_len` above. Not `from_buf`: this borrow is
-    // intentionally detached — `original_package_json_path_buf` is mutated and
-    // re-sliced below (the directory-walk rewrites the tail in place), and
-    // borrowck cannot see that `original_package_json_path` is reassigned
-    // before the next use after each mutation.
-    let mut original_package_json_path =
-        unsafe { ZStr::from_raw(original_package_json_path_buf.as_ptr(), path_len) };
-    let original_cwd =
-        strings::without_suffix_comptime(original_package_json_path.as_bytes(), SEP_PACKAGE_JSON);
-    let original_cwd_clone = Box::<[u8]>::from(original_cwd);
+    let original_cwd_clone = Box::<[u8]>::from(top_level_dir_no_trailing_slash);
+    let original_cwd: &[u8] = &original_cwd_clone;
 
     let mut workspace_names = Package::WorkspaceMap::WorkspaceMap::init();
     let mut workspace_package_json_cache = WorkspacePackageJSONCache {
@@ -1588,7 +1545,6 @@ pub fn init(
                 package_json_path_buf[this_cwd.len()..this_cwd.len() + b"/package.json".len()]
                     .copy_from_slice(b"/package.json");
                 package_json_path_buf[this_cwd.len() + b"/package.json".len()] = 0;
-                // SAFETY: NUL written above
                 let package_json_path = ZStr::from_buf(
                     &package_json_path_buf[..],
                     this_cwd.len() + b"/package.json".len(),
@@ -1671,8 +1627,7 @@ pub fn init(
         original_package_json_path_buf.push(0);
 
         let new_path_len = this_cwd.len() + "/package.json".len();
-        // SAFETY: NUL written above
-        original_package_json_path =
+        let original_package_json_path =
             ZStr::from_buf(&original_package_json_path_buf[..], new_path_len);
         let child_cwd = &original_package_json_path.as_bytes()[..this_cwd.len()];
 
@@ -1706,24 +1661,13 @@ pub fn init(
                     let json_stat_size = json_file.get_end_pos()?;
                     let mut json_buf = vec![0u8; (json_stat_size + 64) as usize];
                     let json_len = json_file.pread_all(&mut json_buf, 0)?;
-                    // SAFETY: ROOT_PACKAGE_JSON_PATH_BUF is a process-global only touched on main
-                    // thread; `&raw mut` + explicit reborrow avoids the 2024 `static_mut_refs` deny.
-                    let json_path = unsafe {
-                        bun_sys::get_fd_path(
-                            json_file.handle,
-                            &mut *ROOT_PACKAGE_JSON_PATH_BUF.get(),
-                        )?
-                    };
+                    let mut json_path_buf = bun_paths::path_buffer_pool::get();
+                    let json_path = bun_sys::get_fd_path(json_file.handle, &mut json_path_buf)?;
                     let json_source =
                         bun_ast::Source::init_path_string(&*json_path, &json_buf[..json_len]);
                     initialize_store();
-                    // SAFETY: `ctx.log` is a borrow of the CLI's `Log`; valid for the
-                    // duration of `init()` (set by `Command::create()` before any install
-                    // entry point runs).
                     let parsed =
-                        crate::bun_json::ParsedJson::parse_package_json(&json_source, unsafe {
-                            &mut *ctx.log
-                        })?;
+                        crate::bun_json::ParsedJson::parse_package_json(&json_source, log)?;
                     let json = parsed.root;
                     if subcommand == Subcommand::Pm {
                         if let Some(name) = json.get(b"name").and_then(|e| {
@@ -1843,73 +1787,38 @@ pub fn init(
 
     let top_level_dir_z = ZBox::from_bytes(fs.top_level_dir());
     bun_sys::chdir(&top_level_dir_z)?;
-    // `loadConfig` was moved down into `bun_bunfig`
-    // (MOVE_DOWN b0) so install can call it directly — no fn-pointer hook.
-    // (`::`-qualified because `crate::bun_bunfig` is a legacy local shim mod.)
-    ::bun_bunfig::arguments::load_config(
+    bun_bunfig::arguments::load_config(
         bun_options_types::command_tag::Tag::InstallCommand,
         cli.config,
         ctx,
     )?;
-    // SAFETY: main-thread global
-    unsafe {
-        let tld = fs.top_level_dir();
-        let cwd = &mut *CWD_BUF.get();
-        cwd[..tld.len()].copy_from_slice(tld);
-        cwd[tld.len()] = 0;
-        // Route through the FsVTable setter so the resolver's cached cwd is
-        // rebound to the process-lifetime CWD_BUF (it was a transient slice
-        // until now). The slice excludes the NUL — `top_level_dir` is `[]u8`.
-        // PathBuffer is repr(transparent) over [u8; N], so the raw cast is sound.
-        fs.set_top_level_dir(bun_core::ffi::slice(CWD_BUF.get().cast::<u8>(), tld.len()));
-        // bun_sys exposes the non-Z `get_fd_path`;
-        // append the NUL ourselves so the static `&ZStr` invariant holds.
-        let root_buf = &mut *ROOT_PACKAGE_JSON_PATH_BUF.get();
-        let plen = if no_project {
+    {
+        let root_package_json_path = if no_project {
             // Where the file would be; nothing reads it in this mode.
-            let p = original_package_json_path.as_bytes();
-            root_buf[..p.len()].copy_from_slice(p);
-            p.len()
+            ZBox::from_vec_with_nul(original_package_json_path_buf.clone())
         } else {
-            bun_sys::get_fd_path(root_package_json_file.handle, root_buf)?.len()
+            let mut root_buf = bun_paths::path_buffer_pool::get();
+            ZBox::from_bytes(bun_sys::get_fd_path(
+                root_package_json_file.handle,
+                &mut root_buf,
+            )?)
         };
-        root_buf[plen] = 0;
-        ROOT_PACKAGE_JSON_PATH.write(ZStr::from_raw(root_buf.as_ptr(), plen));
+        let _ = holder::ROOT_PACKAGE_JSON_PATH.set(root_package_json_path);
     }
 
-    // Returns the resolver's BSSMap-owned
-    // `*EntriesOption` slot.
-    let entries_option = match fs.read_directory(fs.top_level_dir(), 0, true)? {
-        fs::EntriesOption::Entries(e) => {
-            // SAFETY: the BSSMap singleton owns `*e` for the process
-            // lifetime, and `init()` runs single-threaded before any other
-            // access — sole exclusive borrow is sound.
-            unsafe { &mut *std::ptr::from_mut::<fs::DirEntry>(*e) }
-        }
+    let root_dir: &'static fs::DirEntry = match fs.read_directory(fs.top_level_dir(), 0, true)? {
+        fs::EntriesOption::Entries(e) => &**e,
         fs::EntriesOption::Err(e) => return Err(e.canonical_error.into()),
     };
 
-    // SAFETY: `init()` runs once on the main thread before any other access to
-    // the singleton. Allocate into a process-lifetime static (same pattern as
-    // `holder::RAW_PTR`) instead of `Box::leak`.
-    let env: &mut dot_env::Loader = unsafe {
-        let loader_ptr = bun_core::heap::alloc(dot_env::Loader::init());
-        holder::ENV_LOADER.store(loader_ptr);
-        &mut *loader_ptr
-    };
+    let mut env = Box::new(dot_env::Loader::init());
 
     env.load_process()?;
     // Copy the listing's basenames out under `entries_mutex`; `.data` must
     // only be probed while the lock is held.
     let env_probe_keys = {
         let _entries_lock = FileSystem::instance().fs.entries_mutex.lock_guard();
-        dot_env::DirEntryKeys(
-            entries_option
-                .data
-                .iter()
-                .map(|(k, _)| Box::from(&**k))
-                .collect(),
-        )
+        dot_env::DirEntryKeys(root_dir.data.iter().map(|(k, _)| Box::from(&**k)).collect())
     };
     env.load(
         &env_probe_keys,
@@ -1954,12 +1863,12 @@ pub fn init(
         let registry_auth = if global_len > 0 {
             ini::load_npmrc_config(
                 &mut install,
-                env,
+                &env,
                 true,
                 &[ZStr::from_buf(&buf[..], global_len), &*npmrc_local],
             )
         } else {
-            ini::load_npmrc_config(&mut install, env, true, &[&*npmrc_local])
+            ini::load_npmrc_config(&mut install, &env, true, &[&*npmrc_local])
         };
 
         ini::apply_registry_auth(&mut bunfig_install, &registry_auth);
@@ -1993,223 +1902,27 @@ pub fn init(
         bun_sys::WindowsSymlinkOptions::set_has_failed_to_create_symlink(true);
     }
 
-    // SAFETY: main-thread init
     if PackageManager::verbose_install() {
         bun_core::pretty_errorln!("Cache Dir: {}", bstr::BStr::new(&options.cache_directory));
         Output::flush();
     }
 
-    drop(workspace_names); // workspace_names.map.deinit()
+    drop(workspace_names);
 
-    allocate_package_manager();
-    let manager_ptr: *mut PackageManager = get();
-    // var progress = Progress{};
-    // var node = progress.start(name: []const u8, estimated_total_items: usize)
-    // SAFETY: manager_ptr points to uninitialized memory from allocate_package_manager();
-    // we fully initialize it here field-by-field via `addr_of_mut!((*p).field).write(..)`.
-    //
-    // PERF NOTE — do NOT build `PackageManager` by value and `ptr::write` it.
-    // Rust has no result-location semantics, so a struct literal first
-    // materializes on the stack, and `PackageManager` embeds two
-    // `HiveArrayFallback` pools inline (`NetworkTask` × 128 ≈ 395 KB,
-    // `Task` × 64 ≈ 39 KB). The by-value form was measured at a 911 KB stack
-    // frame (objdump: `subq $0xde000,%r11` probe loop, ≈220 page faults) plus
-    // a ≈443 KB memcpy into the singleton. Per-field placement writes fields
-    // directly to the heap and keeps the frame under 16 KB.
-    unsafe {
-        let p = manager_ptr;
-        macro_rules! wr {
-            ($field:ident, $val:expr) => {
-                core::ptr::addr_of_mut!((*p).$field).write($val)
-            };
-        }
-        // The two large pools: in-place init that only zeros the 256 B
-        // occupancy bitset and leaves `[MaybeUninit<T>; N]` untouched — no
-        // stack temporary, no memcpy.
-        PreallocatedNetworkTasks::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_network_tasks
-        ));
-        PreallocatedTaskStore::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_resolve_tasks
-        ));
-
-        wr!(cache_directory, None);
-        wr!(cache_directory_path, ZBox::from_bytes(b""));
-        wr!(options, options);
-        wr!(
-            active_lifecycle_scripts,
-            crate::lifecycle_script_runner::List {
-                root: core::ptr::null_mut(),
-                // `lifecycle_script_runner::List`'s heap comparator never
-                // dereferences its context arg, so it is modeled as a ZST
-                // (`StartedAtCtx`) instead of threading a back-pointer.
-                context: crate::lifecycle_script_runner::StartedAtCtx,
-            }
-        );
-        wr!(network_task_fifo, NetworkQueue::init());
-        wr!(patch_task_fifo, PatchTaskFifo::init());
-        wr!(log, ctx.log);
-        wr!(root_dir, entries_option);
-        wr!(ast_arena, bun_alloc::Arena::new());
-        // reborrow `&mut *env` so the local stays usable for
-        // the post-construction `BUN_MANIFEST_CACHE` / `options.load`
-        // reads. `BackRef` stores a raw pointer —
-        // ending the reborrow here does not alias the later uses.
-        wr!(env, Some(bun_ptr::BackRef::new_mut(&mut *env)));
-        wr!(
-            thread_pool,
-            ThreadPool::init(thread_pool::Config {
-                max_threads: cpu_count,
-                ..Default::default()
-            })
-        );
-        wr!(resolve_tasks, ResolveTaskQueue::default());
-        // `Lockfile` contains `HashMap`/`Vec`/`NonNull` fields, so a
-        // zero-bit pattern is UB; allocate the real (empty) lockfile here directly.
-        // `Lockfile::default()` ≡ `Lockfile::init_empty()`.
-        wr!(lockfile, Box::new(Lockfile::default()));
-        wr!(root_package_json_file, root_package_json_file);
-        // .progress
-        wr!(event_loop, AnyEventLoop::init());
-        wr!(
-            original_package_json_path,
-            ZBox::from_vec_with_nul(original_package_json_path_buf)
-        );
-        wr!(workspace_package_json_cache, workspace_package_json_cache);
-        wr!(workspace_name_hash, workspace_name_hash);
-        wr!(subcommand, subcommand);
-        wr!(
-            root_package_json_name_at_time_of_init,
-            root_package_json_name_at_time_of_init
-        );
-
-        // remaining defaults:
-        wr!(timestamp_for_manifest_cache_control, 0);
-        wr!(extracted_count, 0);
-        wr!(summary, Default::default());
-        wr!(progress, Progress::default());
-        wr!(downloads_node, None);
-        wr!(scripts_node, None);
-        wr!(progress_name_buf, [0; 768]);
-        wr!(track_installed_bin, TrackInstalledBin::None);
-        wr!(root_progress_node, core::ptr::null_mut());
-        wr!(to_update, false);
-        wr!(update_requests, Box::default());
-        wr!(update_request_index, Default::default());
-        wr!(audit_fix_pins, Box::default());
-        wr!(root_package_id, RootPackageId::default());
-        wr!(task_batch, thread_pool::Batch::default());
-        wr!(task_queue, TaskDependencyQueue::default());
-        wr!(manifests, PackageManifestMap::default());
-        wr!(folders, Default::default());
-        wr!(git_repositories, RepositoryMap::default());
-        wr!(git_commits, GitCommitMap::default());
-        wr!(git_tasks, VecDeque::new());
-        wr!(running_git_tasks, AtomicU32::new(0));
-        wr!(appended_task_packages, AppendedTaskPackageMap::default());
-        wr!(network_dedupe_map, Default::default());
-        wr!(async_network_task_queue, AsyncNetworkTaskQueue::default());
-        wr!(network_tarball_batch, thread_pool::Batch::default());
-        wr!(network_resolve_batch, thread_pool::Batch::default());
-        wr!(patch_apply_batch, thread_pool::Batch::default());
-        wr!(patch_calc_hash_batch, thread_pool::Batch::default());
-        wr!(patch_task_queue, PatchTaskQueue::default());
-        wr!(pending_pre_calc_hashes, AtomicU32::new(0));
-        wr!(pending_tasks, AtomicU32::new(0));
-        wr!(total_tasks, 0);
-        wr!(pending_lifecycle_script_tasks, AtomicU32::new(0));
-        wr!(finished_installing, AtomicBool::new(false));
-        wr!(total_scripts, 0);
-        wr!(root_lifecycle_scripts, None);
-        wr!(node_gyp_tempdir_name, Box::default());
-        wr!(preinstall_state, Vec::new());
-        wr!(postinstall_optimizer, Default::default());
-        wr!(global_link_dir, None);
-        wr!(global_dir, None);
-        wr!(global_link_dir_path, Box::default());
-        wr!(on_wake, WakeHandler::default());
-        wr!(
-            peer_dependencies,
-            LinearFifo::<DependencyID, DynamicBuffer<DependencyID>>::init()
-        );
-        wr!(known_npm_aliases, NpmAliasMap::default());
-        wr!(trusted_deps_to_add_to_package_json, Vec::new());
-        wr!(any_failed_to_install, false);
-        wr!(updating_packages, StringArrayHashMap::default());
-        wr!(updating_catalogs, Vec::new());
-        wr!(update_target_workspaces, None);
-        wr!(named_update_reachable, None);
-        wr!(kept_patched, Vec::new());
-        wr!(kept_patched_text, Vec::new());
-        wr!(dedupe_report, None);
-        wr!(filtered_link_targets, None);
-        wr!(pending_filtered_write, None);
-        wr!(edited_package_jsons, Vec::new());
-        wr!(catalog_add, add_catalog::State::default());
-        wr!(patched_dependencies_to_remove, ArrayHashMap::default());
-        wr!(last_reported_slow_lifecycle_script_at, 0);
-        wr!(cached_tick_for_slow_lifecycle_script_logging, 0);
-    }
-    holder::INITIALIZED.store(true, core::sync::atomic::Ordering::Release);
-    // The per-field placement above fully initialized the singleton; the
-    // `&mut PackageManager` validity invariant now holds.
-    // We do NOT bind a long-lived `&'static mut` here: `http::HTTPThread::init`
-    // below spawns workers that deref `get()` concurrently, which would alias such a
-    // borrow under Stacked Borrows. Instead each statement forms its own narrowly-scoped
-    // reborrow via `unsafe { &mut *manager_ptr }`, dropped before the next raw-ptr use.
+    let mut event_loop = AnyEventLoop::init();
     {
-        // SAFETY: singleton fully initialized; main thread, no workers yet.
-        let manager = unsafe { &mut *manager_ptr };
-        // `r#loop()` returns the process-global `*mut uws::Loop`; build the
-        // handle from `&mut manager.event_loop` and write it back as the loop's
-        // parent so uSockets timers / lifecycle subprocess waiters can find the
-        // mini event loop on tick.
-        let uws_loop = manager.event_loop.r#loop();
-        // SAFETY: `uws_loop` is the live process-global `uws::Loop` (`r#loop()` above);
-        // the handle's backref is `manager.event_loop`, owned by the singleton.
-        let uws_loop = unsafe { &mut *uws_loop };
-        EventLoopHandle::from_any(&mut manager.event_loop).set_as_parent_of(uws_loop);
-    }
-    // The lockfile allocation is folded into the struct literal above
-    // (`Box::new(Lockfile::default())`) so we never construct a zeroed
-    // `Lockfile` only to drop it.
-
-    {
-        // make sure folder packages can find the root package without creating a new one
-        // Posix-normalize the
-        // separators before hashing; `FolderResolution.hash` is always fed `/`-separated
-        // bytes by every resolver-side caller. On Windows `get_fd_path` yields `\`, so
-        // hashing the raw bytes would seed a key the resolver never looks up — copy into
-        // a stack buffer and convert separators in place.
-        // SAFETY: ROOT_PACKAGE_JSON_PATH set above on the main thread.
-        let raw: &[u8] = unsafe { ROOT_PACKAGE_JSON_PATH.read() }.as_ref();
-        let mut buf = bun_paths::path_buffer_pool::get();
-        buf[..raw.len()].copy_from_slice(raw);
-        let normalized = &mut buf[..raw.len()];
-        resolve_path::dangerously_convert_path_to_posix_in_place::<u8>(normalized);
-        // SAFETY: singleton fully initialized; main thread, no workers yet.
-        unsafe { &mut *manager_ptr }.folders.put(
-            crate::resolvers::folder_resolver::hash(normalized),
-            FolderResolutionEntry {
-                abs_path: Box::<[u8]>::from(&*normalized),
-                resolution: FolderResolution::PackageId(0),
-            },
-        )?;
-        // normalized.deinit() → Drop (stack buffer)
-    }
-
-    // Set the thread-local global to point at the embedded mini loop
-    // (`bun_event_loop::mini_event_loop::GLOBAL`).
-    {
-        // SAFETY: singleton fully initialized; main thread, no workers yet.
-        let evl = unsafe { &mut (*manager_ptr).event_loop };
-        if let AnyEventLoop::Mini(mini) = evl {
+        // Write the handle back as the uws loop's parent so uSockets timers /
+        // lifecycle subprocess waiters can find the mini event loop on tick.
+        EventLoopHandle::from_any(&mut event_loop).set_as_parent_of_own_loop();
+        // Set the thread-local global to point at the embedded mini loop
+        // (`bun_event_loop::mini_event_loop::GLOBAL`).
+        if let AnyEventLoop::Mini(mini) = &mut event_loop {
             let mini_ptr: *mut MiniEventLoop = &raw mut **mini;
-            // Set ONLY `MiniEventLoop.global`,
-            // NOT `globalInitialized`. The distinction is load-bearing: a later
-            // `initGlobal(env, top_level_dir)` (e.g. from `bun pm pack` /
+            // Set ONLY `mini_event_loop::GLOBAL`,
+            // NOT `GLOBAL_INITIALIZED`. The distinction is load-bearing: a later
+            // `init_global(env, top_level_dir)` (e.g. from `bun pm pack` /
             // `pm version` lifecycle scripts → RunCommand::run_package_script_*)
-            // checks `globalInitialized` and, when false, allocates a FRESH mini
+            // checks `GLOBAL_INITIALIZED` and, when false, allocates a FRESH mini
             // with env/top_level_dir/uv-loop fully wired, then that becomes the
             // global. If we flip `GLOBAL_INITIALIZED` here, that call returns
             // *this* embedded mini instead — which was constructed without env,
@@ -2219,15 +1932,55 @@ pub fn init(
             mini_event_loop::GLOBAL.with(|g| g.set(mini_ptr));
         }
     }
+    let shared = Shared::new(event_loop.waker());
+
+    let manager = publish(Box::new(PackageManager::new(NewOptions {
+        options,
+        log: log_slot.take().expect("set by init"),
+        env: EnvLoader::Owned(env),
+        root_dir,
+        thread_pool: ThreadPool::init(thread_pool::Config {
+            max_threads: cpu_count,
+            ..Default::default()
+        }),
+        event_loop,
+        shared,
+        root_package_json_file,
+        original_package_json_path: ZBox::from_vec_with_nul(original_package_json_path_buf),
+        workspace_package_json_cache,
+        workspace_name_hash,
+        subcommand,
+        root_package_json_name_at_time_of_init,
+    })));
+
     {
-        // SAFETY: as above; scoped reborrow for the options/manifest-cache block.
-        let manager = unsafe { &mut *manager_ptr };
+        // make sure folder packages can find the root package without creating a new one
+        // Posix-normalize the
+        // separators before hashing; `FolderResolution.hash` is always fed `/`-separated
+        // bytes by every resolver-side caller. On Windows `get_fd_path` yields `\`, so
+        // hashing the raw bytes would seed a key the resolver never looks up — copy into
+        // a stack buffer and convert separators in place.
+        let raw: &[u8] = root_package_json_path().as_bytes();
+        let mut buf = bun_paths::path_buffer_pool::get();
+        buf[..raw.len()].copy_from_slice(raw);
+        let normalized = &mut buf[..raw.len()];
+        resolve_path::dangerously_convert_path_to_posix_in_place::<u8>(normalized);
+        manager.folders.put(
+            crate::resolvers::folder_resolver::hash(normalized),
+            FolderResolutionEntry {
+                abs_path: Box::<[u8]>::from(&*normalized),
+                resolution: FolderResolution::PackageId(0),
+            },
+        )?;
+    }
+
+    {
         if !manager.options.enable.cache() {
             manager.options.enable.set_manifest_cache(false);
             manager.options.enable.set_manifest_cache_control(false);
         }
 
-        if let Some(manifest_cache) = env.get(b"BUN_MANIFEST_CACHE") {
+        if let Some(manifest_cache) = manager.env().get(b"BUN_MANIFEST_CACHE") {
             if manifest_cache == b"1" {
                 manager.options.enable.set_manifest_cache(true);
                 manager.options.enable.set_manifest_cache_control(false);
@@ -2240,15 +1993,18 @@ pub fn init(
             }
         }
 
-        manager.options.load(
-            // SAFETY: ctx.log is the process-lifetime CLI log set by
-            // create_context_data(); single-threaded init region.
-            unsafe { &mut *ctx.log },
-            env,
-            Some(cli),
-            ctx.install.as_deref(),
-            subcommand,
-        )?;
+        {
+            let PackageManager {
+                options, log, env, ..
+            } = &mut *manager;
+            options.load(
+                log,
+                env.get_mut(),
+                Some(cli),
+                ctx.install.as_deref(),
+                subcommand,
+            )?;
+        }
 
         // `install.prefer = "offline"` in bunfig (also what `bun --prefer-offline` sets
         // for the runtime's auto-install) means prefer-offline for `bun install` too,
@@ -2275,16 +2031,9 @@ pub fn init(
         }
     }
 
-    // Singleton fully initialized; main thread, no workers yet. Wrapped once as
-    // `ParentRef` so the two read-only `options` projections below go through
-    // safe `Deref` instead of per-site raw deref. Safe `From<NonNull>`
-    // construction — `manager_ptr` is the live singleton address.
-    let mgr_ref = bun_ptr::ParentRef::<PackageManager>::from(
-        NonNull::new(manager_ptr).expect("manager singleton non-null"),
-    );
     let mut ca: Vec<ZBox> = Vec::new();
     {
-        let options = &mgr_ref.options;
+        let options = &manager.options;
         if !options.ca.is_empty() {
             ca = Vec::with_capacity(options.ca.len());
             debug_assert_eq!(ca.capacity(), options.ca.len());
@@ -2296,7 +2045,7 @@ pub fn init(
 
     let mut abs_ca_file_name: ZBox = ZBox::from_bytes(b"");
     {
-        let options = &mgr_ref.options;
+        let options = &manager.options;
         if !options.ca_file_name.is_empty() {
             // resolve with original cwd
             if bun_paths::is_absolute(options.ca_file_name) {
@@ -2320,7 +2069,7 @@ pub fn init(
             }
 
             // If any HTTP proxy is set, use a diferent limit
-            if env.has_http_proxy() {
+            if manager.env().has_http_proxy() {
                 break 'brk DEFAULT_MAX_SIMULTANEOUS_REQUESTS_FOR_BUN_INSTALL_FOR_PROXIES;
             }
 
@@ -2343,10 +2092,8 @@ pub fn init(
             .unwrap_or_default()
     };
     // `InitOpts.abs_ca_file_name: &'static [u8]` — process-lifetime config
-    // string. Park it in
-    // `holder::ABS_CA_FILE_NAME: OnceLock<Box<[u8]>>` per PORTING.md §Forbidden
-    // (never `Box::leak` to mint `&'static`). `init()` runs once on
-    // the main thread, so `.set()` cannot race; ignore the already-set case for
+    // string kept in `holder::ABS_CA_FILE_NAME`. `init()` runs once on the
+    // main thread, so `.set()` cannot race; ignore the already-set case for
     // hot-reload re-entry (the existing CA path stays valid for the process).
     let abs_ca_file_name_static: &'static [u8] = if abs_ca_file_name.is_empty() {
         b""
@@ -2364,7 +2111,10 @@ pub fn init(
 
     let timestamp_for_manifest_cache_control: u32 = 'brk: {
         if cfg!(debug_assertions) {
-            if let Some(cache_control) = env.get(b"BUN_CONFIG_MANIFEST_CACHE_CONTROL_TIMESTAMP") {
+            if let Some(cache_control) = manager
+                .env()
+                .get(b"BUN_CONFIG_MANIFEST_CACHE_CONTROL_TIMESTAMP")
+            {
                 // env-var bytes are not guaranteed UTF-8; parse on bytes directly
                 if let Ok(int) = bun_core::parse_int::<u32>(cache_control, 10) {
                     break 'brk int;
@@ -2374,88 +2124,37 @@ pub fn init(
 
         (u64::try_from(bun_core::time::timestamp().max(0)).expect("int cast")) as u32 // @truncate
     };
-    // SAFETY: singleton fully initialized. The HTTP thread is now live and may
-    // project `&(*get()).field` concurrently, but `timestamp_for_manifest_cache_control`
-    // is main-thread-only state; this raw-pointer place write does not materialize a
-    // `&mut PackageManager` that could alias worker projections.
-    unsafe {
-        (*manager_ptr).timestamp_for_manifest_cache_control = timestamp_for_manifest_cache_control;
-    }
+    manager.timestamp_for_manifest_cache_control = timestamp_for_manifest_cache_control;
 
-    // SAFETY: `manager_ptr` is `holder::RAW_PTR`, written once by
-    // `allocate_package_manager()` above and fully initialized via `ptr::write`
-    // earlier in this function. `init()` is called exactly once per process on
-    // the CLI dispatch thread; the returned `&'static mut` is the sole
-    // first-class reference handed out (worker threads project fields via the
-    // raw [`get`] accessor, never via this reference).
-    Ok((unsafe { &mut *manager_ptr }, original_cwd_clone))
+    Ok((manager, original_cwd_clone))
 }
 
 pub(crate) fn init_with_runtime(
     log: &mut bun_ast::Log,
-    // Used read-only (`Options::load` only ever reads `config.*`).
-    // Upstream storage is `Option<NonNull<api::BunInstall>>` (bundler + resolver
-    // opts); taking `&mut` here would force a const→mut provenance launder at
-    // the resolver call site.
+    // Read-only (`Options::load` only ever reads `config.*`); the resolver
+    // holds it as `Option<NonNull<api::BunInstall>>`.
     bun_install: Option<&Api::BunInstall>,
     cli: CommandLineArguments,
     env: &mut dot_env::Loader,
-) -> crate::Result<*mut PackageManager> {
-    // NB: not `bun_core::run_once!` — the body is fallible (reading the root
-    // directory hits ENOENT/EACCES at runtime when the cwd was deleted or is
-    // unreadable), and the failure must be sticky: `holder::RAW_PTR` stays
-    // null on failure, so later callers have to see the error instead of a
-    // null singleton.
-    static ONCE: std::sync::Once = std::sync::Once::new();
-    static INIT_ERROR: bun_core::Mutex<Option<crate::Error>> = bun_core::Mutex::new(None);
-    ONCE.call_once(|| {
-        if let Err(err) = init_with_runtime_once(log, bun_install, cli, env) {
-            *INIT_ERROR.lock() = Some(err);
-        }
-    });
-    match *INIT_ERROR.lock() {
-        None => Ok(get()),
-        Some(code) => Err(code),
-    }
-}
-
-fn init_with_runtime_once(
-    log: &mut bun_ast::Log,
-    bun_install: Option<&Api::BunInstall>,
-    cli: CommandLineArguments,
-    env: &mut dot_env::Loader,
-) -> crate::Result<()> {
+) -> crate::Result<&'static mut PackageManager> {
+    // `auto_installer::init_for_resolver` calls this at most once per process.
     if env.get(b"BUN_INSTALL_VERBOSE").is_some() {
         PackageManager::set_verbose_install(true);
     }
 
     // Read the root directory BEFORE allocating the singleton. This is
     // user-reachable failure (the cwd may have been deleted out from under the
-    // process, or be unreadable: ENOENT/EACCES/ENOTDIR), and bailing out here
-    // leaves `holder::RAW_PTR` null rather than pointing at an uninitialized
-    // manager. Returns the resolver's BSSMap-owned `*EntriesOption` slot.
+    // process, or be unreadable: ENOENT/EACCES/ENOTDIR). Returns the
+    // resolver's BSSMap-owned `EntriesOption` slot.
     let fs_instance = FileSystem::instance();
-    let root_dir = match fs_instance.read_directory(fs_instance.top_level_dir(), 0, true)? {
-        // SAFETY: the BSSMap singleton owns `*e` for the process lifetime,
-        // and runtime init runs once on the main thread before any other access.
-        fs::EntriesOption::Entries(e) => unsafe { &mut *std::ptr::from_mut::<fs::DirEntry>(*e) },
-        fs::EntriesOption::Err(e) => return Err(e.canonical_error.into()),
-    };
+    let root_dir: &'static fs::DirEntry =
+        match fs_instance.read_directory(fs_instance.top_level_dir(), 0, true)? {
+            fs::EntriesOption::Entries(e) => &**e,
+            fs::EntriesOption::Err(e) => return Err(e.canonical_error.into()),
+        };
 
     let cpu_count: u32 = u32::from(bun_core::get_thread_count());
-    allocate_package_manager();
-    // SAFETY: holder::RAW_PTR was just set by allocate_package_manager() to a
-    // freshly allocated, *uninitialized* PackageManager. Do NOT call `get()` /
-    // form `&mut PackageManager` yet — the struct contains niche-bearing fields
-    // (`Box`, `Vec`, `Option<NonNull<_>>`, `ZStr`) for which the uninit bit
-    // pattern is an invalid value, so materializing a reference is instant UB.
-    // Work through the raw pointer until `ptr::write` below has fully
-    // initialized it.
-    let manager_ptr: *mut PackageManager =
-        holder::RAW_PTR.load(core::sync::atomic::Ordering::Acquire);
 
-    // var progress = Progress{};
-    // var node = progress.start(name: []const u8, estimated_total_items: usize)
     let top_level_dir_no_trailing_slash =
         strings::without_trailing_slash(FileSystem::instance().top_level_dir());
     let mut original_package_json_path =
@@ -2467,172 +2166,48 @@ fn init_with_runtime_once(
         .copy_from_slice(b"/package.json");
     // last byte already 0 (sentinel)
 
-    // SAFETY: manager_ptr points to uninitialized memory; fully initialize
-    // field-by-field via `addr_of_mut!((*p).field).write(..)`. See the PERF
-    // NOTE in `init()` above — building `PackageManager` by value and
-    // `ptr::write`ing it materialized a ≈911 KB stack frame because of the
-    // two inline `HiveArrayFallback` pools; per-field placement writes
-    // directly to the heap singleton.
-    unsafe {
-        let p = manager_ptr;
-        macro_rules! wr {
-            ($field:ident, $val:expr) => {
-                core::ptr::addr_of_mut!((*p).$field).write($val)
-            };
-        }
-        // The two large pools: in-place init that only zeros the 256 B
-        // occupancy bitset and leaves `[MaybeUninit<T>; N]` untouched.
-        PreallocatedNetworkTasks::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_network_tasks
-        ));
-        PreallocatedTaskStore::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_resolve_tasks
-        ));
-
-        wr!(cache_directory, None);
-        wr!(cache_directory_path, ZBox::from_bytes(b""));
-        wr!(
-            options,
-            Options {
-                max_concurrent_lifecycle_scripts: cli
-                    .concurrent_scripts
-                    .unwrap_or((cpu_count * 2) as usize),
-                ..Default::default()
-            }
-        );
-        wr!(
-            active_lifecycle_scripts,
-            crate::lifecycle_script_runner::List {
-                root: core::ptr::null_mut(),
-                context: crate::lifecycle_script_runner::StartedAtCtx,
-            }
-        );
-        wr!(network_task_fifo, NetworkQueue::init());
-        wr!(log, std::ptr::from_mut(log));
-        wr!(root_dir, root_dir);
-        wr!(ast_arena, bun_alloc::Arena::new());
-        // reborrow `&mut *env` so the local stays usable for
-        // the post-construction `BUN_MANIFEST_CACHE` / `options.load`
-        // reads. `BackRef` stores a raw pointer —
-        // ending the reborrow here does not alias the later uses.
-        wr!(env, Some(bun_ptr::BackRef::new_mut(&mut *env)));
-        wr!(
-            thread_pool,
-            ThreadPool::init(thread_pool::Config {
-                max_threads: cpu_count,
-                ..Default::default()
-            })
-        );
-        // `Lockfile` holds `HashMap`/`Vec`/`NonNull` (zero-bit pattern is
-        // UB), so allocate the real empty lockfile here directly instead of a zeroed placeholder.
-        wr!(lockfile, Box::new(Lockfile::default()));
+    let event_loop = AnyEventLoop::js_current();
+    // The JS event loop's uws loop is created with the VM; `js_current()` only
+    // wraps the handle.
+    let shared = {
+        let mut event_loop = AnyEventLoop::js_current();
+        Shared::new(event_loop.waker())
+    };
+    let manager = publish(Box::new(PackageManager::new(NewOptions {
+        options: Options {
+            max_concurrent_lifecycle_scripts: cli
+                .concurrent_scripts
+                .unwrap_or((cpu_count * 2) as usize),
+            ..Default::default()
+        },
+        // Diagnostics collect here and are moved into whichever log the
+        // resolve/transpile in progress reports through; filter as it would.
+        log: Box::new(bun_ast::Log {
+            level: log.level,
+            ..bun_ast::Log::init()
+        }),
+        env: EnvLoader::Vm(bun_ptr::BackRef::new(env)),
+        root_dir,
+        thread_pool: ThreadPool::init(thread_pool::Config {
+            max_threads: cpu_count,
+            ..Default::default()
+        }),
+        event_loop,
+        shared,
         // `.root_package_json_file` is never read in the runtime
-        // path. Use the explicit invalid-fd sentinel rather than `mem::zeroed()` —
-        // on posix `Fd(0)` is stdin, not the invalid marker.
-        wr!(
-            root_package_json_file,
-            bun_sys::File::from_fd(Fd::invalid())
-        );
-        // erased *mut () set by tier-6; `js_current()` resolves the per-thread JS
-        // event loop via `bun_io::__bun_get_vm_ctx` (link-time, definer in bun_runtime).
-        wr!(event_loop, AnyEventLoop::js_current());
-        wr!(
-            original_package_json_path,
-            ZBox::from_vec_with_nul(original_package_json_path)
-        );
-        wr!(subcommand, Subcommand::Install);
-
-        // remaining defaults:
-        wr!(resolve_tasks, ResolveTaskQueue::default());
-        wr!(timestamp_for_manifest_cache_control, 0);
-        wr!(extracted_count, 0);
-        wr!(summary, Default::default());
-        wr!(progress, Progress::default());
-        wr!(downloads_node, None);
-        wr!(scripts_node, None);
-        wr!(progress_name_buf, [0; 768]);
-        wr!(track_installed_bin, TrackInstalledBin::None);
-        wr!(root_progress_node, core::ptr::null_mut());
-        wr!(to_update, false);
-        wr!(update_requests, Box::default());
-        wr!(update_request_index, Default::default());
-        wr!(audit_fix_pins, Box::default());
-        wr!(root_package_json_name_at_time_of_init, Box::default());
-        wr!(root_package_id, RootPackageId::default());
-        wr!(task_batch, thread_pool::Batch::default());
-        wr!(task_queue, TaskDependencyQueue::default());
-        wr!(manifests, PackageManifestMap::default());
-        wr!(folders, Default::default());
-        wr!(git_repositories, RepositoryMap::default());
-        wr!(git_commits, GitCommitMap::default());
-        wr!(git_tasks, VecDeque::new());
-        wr!(running_git_tasks, AtomicU32::new(0));
-        wr!(appended_task_packages, AppendedTaskPackageMap::default());
-        wr!(network_dedupe_map, Default::default());
-        wr!(async_network_task_queue, AsyncNetworkTaskQueue::default());
-        wr!(network_tarball_batch, thread_pool::Batch::default());
-        wr!(network_resolve_batch, thread_pool::Batch::default());
-        wr!(patch_apply_batch, thread_pool::Batch::default());
-        wr!(patch_calc_hash_batch, thread_pool::Batch::default());
-        wr!(patch_task_fifo, PatchTaskFifo::init());
-        wr!(patch_task_queue, PatchTaskQueue::default());
-        wr!(pending_pre_calc_hashes, AtomicU32::new(0));
-        wr!(pending_tasks, AtomicU32::new(0));
-        wr!(total_tasks, 0);
-        wr!(pending_lifecycle_script_tasks, AtomicU32::new(0));
-        wr!(finished_installing, AtomicBool::new(false));
-        wr!(total_scripts, 0);
-        wr!(root_lifecycle_scripts, None);
-        wr!(node_gyp_tempdir_name, Box::default());
-        wr!(preinstall_state, Vec::new());
-        wr!(postinstall_optimizer, Default::default());
-        wr!(global_link_dir, None);
-        wr!(global_dir, None);
-        wr!(global_link_dir_path, Box::default());
-        wr!(on_wake, WakeHandler::default());
-        wr!(
-            peer_dependencies,
-            LinearFifo::<DependencyID, DynamicBuffer<DependencyID>>::init()
-        );
-        wr!(known_npm_aliases, NpmAliasMap::default());
-        wr!(trusted_deps_to_add_to_package_json, Vec::new());
-        wr!(any_failed_to_install, false);
-        wr!(workspace_name_hash, None);
-        wr!(
-            workspace_package_json_cache,
-            WorkspacePackageJSONCache::default()
-        );
-        wr!(updating_packages, StringArrayHashMap::default());
-        wr!(updating_catalogs, Vec::new());
-        wr!(update_target_workspaces, None);
-        wr!(named_update_reachable, None);
-        wr!(kept_patched, Vec::new());
-        wr!(kept_patched_text, Vec::new());
-        wr!(dedupe_report, None);
-        wr!(filtered_link_targets, None);
-        wr!(pending_filtered_write, None);
-        wr!(edited_package_jsons, Vec::new());
-        wr!(catalog_add, add_catalog::State::default());
-        wr!(patched_dependencies_to_remove, ArrayHashMap::default());
-        wr!(last_reported_slow_lifecycle_script_at, 0);
-        wr!(cached_tick_for_slow_lifecycle_script_logging, 0);
-    }
-    holder::INITIALIZED.store(true, core::sync::atomic::Ordering::Release);
-    // SAFETY: per-field placement above fully initialized the PackageManager;
-    // the `&mut PackageManager` validity invariant now holds for the post-init
-    // body.
-    let manager = unsafe { &mut *manager_ptr };
-    // The lockfile allocation is folded into the struct literal above
-    // (`Box::new(Lockfile::default())`).
+        // path. Use the explicit invalid-fd sentinel — on posix `Fd(0)` is stdin.
+        root_package_json_file: bun_sys::File::from_fd(Fd::invalid()),
+        original_package_json_path: ZBox::from_vec_with_nul(original_package_json_path),
+        workspace_package_json_cache: WorkspacePackageJSONCache::default(),
+        workspace_name_hash: None,
+        subcommand: Subcommand::Install,
+        root_package_json_name_at_time_of_init: Box::default(),
+    })));
 
     if Output::enable_ansi_colors_stderr() {
         manager.progress = Progress::default();
         manager.progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
-        // `Progress::start` returns `&mut Node` borrowing `manager.progress.root`.
-        // Coerce to a raw pointer immediately so the borrow doesn't outlive the
-        // statement; `root_progress_node` is BORROW_FIELD into `self.progress`.
-        let node: *mut ProgressNode = manager.progress.start(b"", 0);
-        manager.root_progress_node = node;
+        let _ = manager.progress.start(b"", 0);
     } else {
         manager.options.log_level = package_manager_options::LogLevel::DefaultNoProgress;
     }
@@ -2661,8 +2236,7 @@ fn init_with_runtime_once(
     {
         Ok(()) => {}
         Err(e) => {
-            // only error.OutOfMemory possible
-            let _ = e;
+            let _ = e; // only out-of-memory is possible here
             bun_core::out_of_memory();
         }
     }
@@ -2681,16 +2255,13 @@ fn init_with_runtime_once(
     // self-aliasing receiver+argument pair Rust forbids. Split-borrow by
     // temporarily moving the boxed lockfile out so the `&mut PackageManager`
     // passed in does not alias the `&mut Lockfile` receiver.
-    // `root_dir` was moved into `*manager` above (the field is
-    // an unbounded `&mut DirEntry`, so the local reborrow is for `'static` and the
-    // original binding is dead). Read it back through `manager.root_dir`.
     // `.data` probes must hold `entries_mutex`.
     let has_lockb = {
         let _entries_lock = FileSystem::instance().fs.entries_mutex.lock_guard();
         manager.root_dir.has_comptime_query(b"bun.lockb")
     };
     if has_lockb {
-        let mut lockfile = core::mem::replace(&mut manager.lockfile, Box::new(Lockfile::default()));
+        let mut lockfile = core::mem::take(&mut manager.lockfile);
         match lockfile.load_from_cwd::<true>(Some(&mut *manager), log) {
             lockfile::LoadResult::Ok(_) => {}
             _ => lockfile.init_empty(),
@@ -2699,6 +2270,8 @@ fn init_with_runtime_once(
     } else {
         manager.lockfile.init_empty();
     }
+    // Anything the load logged through the manager goes to the runtime's log.
+    manager.log.append_to_with_recycled(log, false);
 
-    Ok(())
+    Ok(manager)
 }

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -493,12 +493,10 @@ const PRUNE_HELP_PARAMS: &[ParamType] = &[
     clap::param!("-h, --help                             Print this help menu"),
 ];
 
-// NOTE: `string` (= `[]const u8`) fields here are slices into process argv (owned by `clap::Args`
-// which itself lives for the program duration). They are never freed. Mapped to `&'static [u8]`
-// per PORTING.md (no `deinit`, never `allocator.free`d). An explicit lifetime would only
-// become necessary if `clap::Args` ever becomes scoped.
+// The `&'static [u8]` fields are slices into process argv (owned by
+// `clap::Args`, which lives for the program duration).
 //
-// `Clone` is needed because `updatePackageJSONAndInstall`
+// `Clone` is needed because `update_package_json_and_install`
 // passes `cli` by value into `PackageManager.init` while retaining its own
 // copy.
 #[derive(Clone)]
@@ -769,7 +767,7 @@ impl CommandLineArguments {
         // use <bar> to emphasize 'bar'
 
         match subcommand {
-            // fall back to HelpCommand.printWithReason
+            // fall back to HelpCommand.print_with_reason
             Subcommand::Install => {
                 let intro_text = r"
 <b>Usage<r>: <b><green>bun install<r> <cyan>[flags]<r> <blue>\<name\><r><d>@\<version\><r>

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -192,7 +192,6 @@ pub(crate) fn edit_patched_dependencies(
     patchfile_path: &[u8],
 ) -> Result<(), bun_alloc::AllocError> {
     let arena = &manager.ast_arena;
-    // const pkg_to_patch = manager.
     let mut patched_dependencies = E::Object::default();
     if let Some(query) = package_json.as_property(b"patchedDependencies") {
         if let bun_ast::ExprData::EObject(obj) = &query.expr.data {
@@ -230,14 +229,13 @@ pub fn edit_trusted_dependencies(
 ) -> Result<(), bun_alloc::AllocError> {
     let mut len = names_to_add.len();
 
-    let mut trusted_dependencies: &[Expr] = &[];
-    if let Some(query) = package_json.as_property(TRUSTED_DEPENDENCIES_STRING) {
-        if let bun_ast::ExprData::EArray(arr) = &query.expr.data {
-            // SAFETY: `arr` is a `StoreRef` into the AST arena which outlives
-            // this function; lifetime erased per the parser's `Str` convention.
-            trusted_dependencies = unsafe { bun_ptr::detach_lifetime(arr.items.slice()) };
-        }
-    }
+    let trusted_array = package_json
+        .as_property(TRUSTED_DEPENDENCIES_STRING)
+        .and_then(|query| query.expr.data.e_array());
+    let trusted_dependencies: &[Expr] = match &trusted_array {
+        Some(arr) => arr.items.slice(),
+        None => &[],
+    };
 
     let mut i = len;
     while i > 0 {
@@ -1053,8 +1051,7 @@ pub(crate) fn edit(
                                                     .expr
                                                     .data
                                                     .e_string()
-                                                    .expect("infallible: variant checked")
-                                                    .as_ptr(),
+                                                    .expect("infallible: variant checked"),
                                             );
                                             remaining -= 1;
                                         } else {
@@ -1107,8 +1104,7 @@ pub(crate) fn edit(
                                                     request.e_string = Some(
                                                         v.data
                                                             .e_string()
-                                                            .expect("infallible: variant checked")
-                                                            .as_ptr(),
+                                                            .expect("infallible: variant checked"),
                                                     );
                                                     remaining -= 1;
                                                     break 'dependency_group;
@@ -1208,8 +1204,7 @@ pub(crate) fn edit(
                         .unwrap()
                         .data
                         .e_string()
-                        .unwrap()
-                        .as_ptr(),
+                        .unwrap(),
                 );
                 break;
             }
@@ -1345,23 +1340,12 @@ pub(crate) fn edit(
     };
     for request in updates.iter_mut() {
         if let Some(e_string) = request.e_string {
-            // SAFETY: `e_string` is a `*mut E::EString` captured at one of two provenance sites:
-            //   (a) the freshly `Expr::allocate`d empty value string in `new_dependencies` (the
-            //       `e_string().unwrap().as_ptr()` call inside the `while k < new_dependencies.len()`
-            //       loop) — backed by `manager.ast_arena`, which is process-lifetime; or
-            //   (b) a pre-existing slot from the parsed `current_package_json` input tree
-            //       (`value.expr.data.e_string()` / `v.data.e_string()` in the earlier
-            //       dependency-group scan) — backed by the thread-local Expr
-            //       Store, which the *caller* guarantees stays live for the duration of `edit`
-            //       (it owns the parsed tree).
-            // Note: `ExprDisabler::scope()` at function entry is a debug guard that *forbids*
-            // Store use, not a keep-alive — it exists precisely so that the (a)-path nodes are
-            // never Store-backed. The `*current_package_json = Expr::allocate(...)` reassignments
-            // above only overwrite a Copy `Expr` handle; they never reset either arena. The Expr
-            // tree references the slot via `StoreRef` (a Copy `NonNull`) and no `&`/`&mut`
-            // derived from a `StoreRef` to the same `E::EString` is live inside this loop body,
-            // so this is the sole mutable borrow.
-            let e_string = unsafe { &mut *e_string };
+            // `e_string` points at either the freshly `Expr::allocate`d empty value
+            // string in `new_dependencies` (backed by `manager.ast_arena`,
+            // process-lifetime) or a slot of the parsed `current_package_json`
+            // tree (backed by the caller's Expr store); nothing else borrows it here.
+            let mut e_string = e_string;
+            let e_string = &mut *e_string;
             // `bun update <pkg>` keeps a `catalog:` reference; `bun add` still replaces it.
             if manager.subcommand == Subcommand::Update
                 && dependency::Tag::infer(e_string.data.slice()) == dependency::Tag::Catalog

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -9,7 +9,7 @@ use crate::repository::Repository;
 use bun_core::ZStr;
 use bun_core::{Global, Output, ZBox, env_var, fmt as bun_fmt};
 use bun_dotenv::Loader as DotEnvLoader;
-use bun_install::lockfile::{Format as LockfileFormat, LoadResult, Lockfile};
+use bun_install::lockfile::{Format as LockfileFormat, Lockfile};
 use bun_install::resolution::Tag as ResolutionTag;
 use bun_install::{PackageID, Resolution};
 use bun_paths::{self as path, AbsPath, PathBuffer, SEP};
@@ -18,14 +18,12 @@ use bun_semver::{self as Semver, String as SemverString};
 use bun_sys::FdDirExt;
 use bun_sys::{self as sys, Dir, Fd, File};
 
-use crate::bun_progress::Node as ProgressNode;
-
 use super::options::{self, Enable, LogLevel};
 use super::{Command, Options, PackageManager, ProgressStrings, Subcommand};
 
 // ───────────────────────────── method wrappers ───────────────────────────────
 // Thin `&mut self` shims so call sites can use method-style spelling
-// (`pm.getCacheDirectory()` / `pm.getTemporaryDirectory()`). The bodies live
+// (`pm.get_cache_directory()` / `pm.get_temporary_directory()`). The bodies live
 // in the free functions below to keep them callable without an `impl` path.
 
 impl PackageManager {
@@ -58,11 +56,6 @@ impl PackageManager {
     }
 
     #[inline]
-    pub(crate) fn get_cache_directory_and_abs_path(&mut self) -> (Fd, AbsPath) {
-        get_cache_directory_and_abs_path(self)
-    }
-
-    #[inline]
     pub(crate) fn get_temporary_directory(&mut self) -> &'static TemporaryDirectory {
         get_temporary_directory(self)
     }
@@ -76,45 +69,49 @@ impl PackageManager {
 /// use `Dir::borrow(&fd)` to call `&self` `Dir` methods on it.
 #[inline]
 pub fn get_cache_directory(this: &mut PackageManager) -> Fd {
-    // SAFETY: `&mut PackageManager` is exclusive over every field the raw
-    // path projects.
-    unsafe { get_cache_directory_raw(this) }
-}
-
-/// Raw-pointer entry for callers that hold a disjoint `&mut this.manifests`
-/// borrow (see `PackageManifestMap::by_name_hash_allow_expired`). Never
-/// materializes a `&mut PackageManager` covering the whole struct — only the
-/// disjoint `cache_directory`, `cache_directory_path`, `options.enable`, and
-/// `env` fields are projected, so an outstanding `&mut manifests` derived
-/// from the same provenance root stays valid under Stacked Borrows.
-///
-/// # Safety
-/// `this` must be valid for reads and writes for the call's duration, and the
-/// caller must hold no live borrow that overlaps the fields listed above.
-#[inline]
-pub(crate) unsafe fn get_cache_directory_raw(this: *mut PackageManager) -> Fd {
-    // SAFETY: caller contract — `cache_directory` is disjoint from any
-    // borrow the caller holds.
-    if let Some(d) = unsafe { (*this).cache_directory.as_ref() } {
+    if let Some(d) = this.cache_directory.as_ref() {
         return d.fd();
     }
-    // SAFETY: caller contract — `this` is valid and no live borrow overlaps
-    // `options.enable`/`options.cache_directory`/`env`/`cache_directory_path`.
-    let d = unsafe { ensure_cache_directory(this) };
+    let d = ensure_cache_directory(this);
     let fd = d.fd();
-    // SAFETY: as above; single writer.
-    unsafe { (*this).cache_directory = Some(d) };
+    this.cache_directory = Some(d);
     fd
 }
 
-#[inline]
-pub fn get_cache_directory_and_abs_path(this: &mut PackageManager) -> (Fd, AbsPath) {
-    let cache_dir = get_cache_directory(this);
-    (
-        cache_dir,
-        AbsPath::from(this.cache_directory_path.as_bytes())
-            .expect("cache_directory_path is absolute"),
-    )
+impl PackageManager {
+    /// The cache directory once opened (see [`get_cache_directory`]); worker
+    /// threads use this, so the main thread opens it before scheduling them.
+    #[inline]
+    pub fn cache_directory(&self) -> Fd {
+        self.cache_directory
+            .as_ref()
+            .expect("cache directory opened before use")
+            .fd()
+    }
+
+    #[inline]
+    pub fn cache_directory_and_abs_path(&self) -> (Fd, AbsPath) {
+        (
+            self.cache_directory(),
+            AbsPath::from(self.cache_directory_path.as_bytes())
+                .expect("cache_directory_path is absolute"),
+        )
+    }
+
+    /// The temporary directory once opened (see [`get_temporary_directory`]).
+    #[inline]
+    pub fn temporary_directory(&self) -> &'static TemporaryDirectory {
+        GET_TEMPORARY_DIRECTORY_ONCE
+            .get()
+            .expect("temporary directory opened before use")
+    }
+
+    /// Open the cache and temporary directories if they are not already, so
+    /// worker threads can read them through `&PackageManager`.
+    #[inline]
+    pub fn ensure_cache_and_temp_directories(&mut self) {
+        let _ = get_temporary_directory(self);
+    }
 }
 
 #[inline]
@@ -136,7 +133,7 @@ pub struct TemporaryDirectory {
 }
 
 // `TemporaryDirectory` is auto-`Send + Sync`: `Dir` wraps `Fd` (an integer),
-// `ZBox` wraps `Box<[u8]>`, and `&'static [u8]` is `Sync`. No `unsafe impl`.
+// `ZBox` wraps `Box<[u8]>`, and `&'static [u8]` is `Sync`.
 const _: fn() = || {
     fn assert<T: Send + Sync>() {}
     assert::<TemporaryDirectory>();
@@ -315,49 +312,29 @@ fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirecto
     }
 }
 
-/// # Safety
-/// See `get_cache_directory_raw` — only `options.enable`,
-/// `options.cache_directory` (read), `env`, and `cache_directory_path` are
-/// touched; caller must hold no overlapping borrow on those projections.
-/// Borrows into other `options` sub-fields (e.g. `options.registries` /
-/// `options.scope`) remain valid.
 #[cold]
 #[inline(never)]
-unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
+fn ensure_cache_directory(this: &mut PackageManager) -> Dir {
     loop {
-        // SAFETY: field projections through the caller-provided provenance
-        // root; see fn safety contract. Project `enable` narrowly so callers
-        // may hold borrows into disjoint `options` sub-fields.
-        if unsafe { (*this).options.enable.contains(Enable::CACHE) } {
-            // SAFETY: caller-provided provenance root; `env_mut()` itself
-            // encapsulates the BackRef deref + singleton-liveness invariant.
-            let env = unsafe { &*this }.env_mut();
-            // SAFETY: shared read of `options`; disjoint from `cache_directory_path`.
-            let cache_dir = fetch_cache_directory_path(env, Some(unsafe { &(*this).options }));
-            // SAFETY: see fn safety contract.
-            unsafe { (*this).cache_directory_path = ZBox::from_bytes(&cache_dir.path) };
+        if this.options.enable.contains(Enable::CACHE) {
+            let cache_dir = fetch_cache_directory_path(this.env.get(), Some(&this.options));
+            this.cache_directory_path = ZBox::from_bytes(&cache_dir.path);
 
             match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
                 Ok(d) => return d,
                 Err(_) => {
-                    // SAFETY: narrow `&mut enable` projection; disjoint from
-                    // any `&options.{registries,scope}` the caller may hold.
-                    unsafe { (*this).options.enable.set(Enable::CACHE, false) };
-                    // SAFETY: see fn safety contract.
-                    unsafe { (*this).cache_directory_path = ZBox::from_bytes(b"") };
+                    this.options.enable.set(Enable::CACHE, false);
+                    this.cache_directory_path = ZBox::from_bytes(b"");
                     continue;
                 }
             }
         }
 
-        // SAFETY: see fn safety contract.
-        unsafe {
-            (*this).cache_directory_path =
-                ZBox::from_bytes(path::resolve_path::join_abs_string::<path::platform::Auto>(
-                    FileSystem::instance().top_level_dir(),
-                    &[b"node_modules", b".cache"],
-                ))
-        };
+        this.cache_directory_path =
+            ZBox::from_bytes(path::resolve_path::join_abs_string::<path::platform::Auto>(
+                FileSystem::instance().top_level_dir(),
+                &[b"node_modules", b".cache"],
+            ));
 
         match Dir::cwd().make_open_path(b"node_modules/.cache", Default::default()) {
             Ok(d) => return d,
@@ -376,7 +353,7 @@ pub struct CacheDir {
     pub path: Vec<u8>,
 }
 
-pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Options>) -> CacheDir {
+pub fn fetch_cache_directory_path(env: &DotEnvLoader, options: Option<&Options>) -> CacheDir {
     if let Some(dir) = env.get(b"BUN_INSTALL_CACHE_DIR") {
         return CacheDir {
             path: FileSystem::instance().abs(&[dir]).to_vec(),
@@ -527,30 +504,28 @@ pub fn cached_git_folder_name_print<'a>(
     w.finish_z()
 }
 
-pub fn cached_git_folder_name(
+pub fn cached_git_folder_name<'a>(
     this: &PackageManager,
+    buf: &'a mut [u8],
     repository: &Repository,
     patch_hash: Option<u64>,
-) -> &'static ZStr {
-    cached_git_folder_name_print(
-        cached_package_folder_name_buf(),
-        this.lockfile.str(&repository.resolved),
-        patch_hash,
-    )
+) -> &'a ZStr {
+    cached_git_folder_name_print(buf, this.lockfile.str(&repository.resolved), patch_hash)
 }
 
-pub fn cached_git_folder_name_print_auto(
+pub fn cached_git_folder_name_print_auto<'a>(
     this: &PackageManager,
+    buf: &'a mut [u8],
     repository: &Repository,
     patch_hash: Option<u64>,
-) -> &'static ZStr {
+) -> &'a ZStr {
     if !repository.resolved.is_empty() {
-        return cached_git_folder_name(this, repository, patch_hash);
+        return cached_git_folder_name(this, buf, repository, patch_hash);
     }
 
     if !repository.repo.is_empty() && !repository.committish.is_empty() {
         let string_buf = this.lockfile.buffers.string_bytes.as_slice();
-        let mut w = ByteCursor::new(cached_package_folder_name_buf());
+        let mut w = ByteCursor::new(buf);
         w.put(b"@G@");
         w.put(repository.committish.slice(string_buf));
         w.put_cache_version(Some(CacheVersion::CURRENT));
@@ -574,25 +549,23 @@ pub fn cached_github_folder_name_print<'a>(
     w.finish_z()
 }
 
-pub fn cached_github_folder_name(
+pub fn cached_github_folder_name<'a>(
     this: &PackageManager,
+    buf: &'a mut [u8],
     repository: &Repository,
     patch_hash: Option<u64>,
-) -> &'static ZStr {
-    cached_github_folder_name_print(
-        cached_package_folder_name_buf(),
-        this.lockfile.str(&repository.resolved),
-        patch_hash,
-    )
+) -> &'a ZStr {
+    cached_github_folder_name_print(buf, this.lockfile.str(&repository.resolved), patch_hash)
 }
 
-pub fn cached_github_folder_name_print_auto(
+pub fn cached_github_folder_name_print_auto<'a>(
     this: &PackageManager,
+    buf: &'a mut [u8],
     repository: &Repository,
     patch_hash: Option<u64>,
-) -> &'static ZStr {
+) -> &'a ZStr {
     if !repository.resolved.is_empty() {
-        return cached_github_folder_name(this, repository, patch_hash);
+        return cached_github_folder_name(this, buf, repository, patch_hash);
     }
 
     if !repository.owner.is_empty()
@@ -600,7 +573,7 @@ pub fn cached_github_folder_name_print_auto(
         && !repository.committish.is_empty()
     {
         return cached_github_folder_name_print_guess(
-            cached_package_folder_name_buf(),
+            buf,
             this.lockfile.buffers.string_bytes.as_slice(),
             repository,
             patch_hash,
@@ -636,8 +609,6 @@ pub fn cached_npm_package_folder_name_print<'a>(
         cached_npm_package_folder_print_basename(buf, name, version, None, include_version_number)
             .as_bytes()
             .len();
-    // reshaped for borrowck — resume the cursor at the basename's
-    // tail instead of holding the returned `&ZStr` across the re-borrow.
     let scope_url = scope.url.url();
     let mut w = ByteCursor {
         buf,
@@ -677,19 +648,14 @@ fn cached_github_folder_name_print_guess<'a>(
     w.finish_z()
 }
 
-pub fn cached_npm_package_folder_name(
+pub fn cached_npm_package_folder_name<'a>(
     this: &PackageManager,
+    buf: &'a mut [u8],
     name: &[u8],
     version: Semver::Version,
     patch_hash: Option<u64>,
-) -> &'static ZStr {
-    cached_npm_package_folder_name_print(
-        this,
-        cached_package_folder_name_buf(),
-        name,
-        version,
-        patch_hash,
-    )
+) -> &'a ZStr {
+    cached_npm_package_folder_name_print(this, buf, name, version, patch_hash)
 }
 
 // TODO: normalize to alphanumeric
@@ -739,16 +705,13 @@ pub fn cached_tarball_folder_name_print<'a>(
     w.finish_z()
 }
 
-pub fn cached_tarball_folder_name(
+pub fn cached_tarball_folder_name<'a>(
     this: &PackageManager,
+    buf: &'a mut [u8],
     url: SemverString,
     patch_hash: Option<u64>,
-) -> &'static ZStr {
-    cached_tarball_folder_name_print(
-        cached_package_folder_name_buf(),
-        this.lockfile.str(&url),
-        patch_hash,
-    )
+) -> &'a ZStr {
+    cached_tarball_folder_name_print(buf, this.lockfile.str(&url), patch_hash)
 }
 
 pub fn is_folder_in_cache(this: &mut PackageManager, folder_path: &ZStr) -> bool {
@@ -787,7 +750,7 @@ pub fn setup_global_dir(manager: &mut PackageManager, ctx: &Command::Context) ->
     let path = FileSystem::instance()
         .dirname_store()
         .append(result.as_bytes_with_nul())?;
-    // SAFETY: `path` includes the trailing NUL (we appended `as_bytes_with_nul`)
+    // `path` includes the trailing NUL (we appended `as_bytes_with_nul`)
     // and lives for program lifetime in the dirname store.
     manager.options.bin_path = ZStr::from_slice_with_nul(path);
     Ok(())
@@ -871,8 +834,6 @@ pub fn path_for_cached_npm_path<'a>(
         None,
     );
     let cache_path_len = cache_path.as_bytes().len();
-    // reshaped for borrowck — drop borrow before mutating buffer
-
     debug_assert!(cache_path_buf[package_name.len()] == b'@');
 
     cache_path_buf[package_name.len()] = SEP;
@@ -919,7 +880,6 @@ pub fn path_for_resolution<'a>(
     resolution: &Resolution,
     buf: &'a mut PathBuffer,
 ) -> Result<&'a mut [u8], Error> {
-    // const folder_name = this.cachedNPMPackageFolderName(name, version);
     match resolution.tag {
         ResolutionTag::Npm => {
             let npm = *resolution.npm();
@@ -942,7 +902,7 @@ pub struct CacheDirAndSubpath<'a> {
     pub(crate) cache_dir_subpath: &'a ZStr,
 }
 
-/// this is copy pasted from `installPackageWithNameAndResolution()`
+/// this is copy pasted from `install_package_with_name_and_resolution()`
 /// it's not great to do this
 pub fn compute_cache_dir_and_subpath<'a>(
     manager: &mut PackageManager,
@@ -958,18 +918,20 @@ pub fn compute_cache_dir_and_subpath<'a>(
     match resolution.tag {
         ResolutionTag::Npm => {
             let version = resolution.npm().version;
-            cache_dir_subpath = cached_npm_package_folder_name(manager, name, version, patch_hash);
             cache_dir = get_cache_directory(manager);
+            cache_dir_subpath =
+                cached_npm_package_folder_name(manager, folder_path_buf, name, version, patch_hash);
         }
         ResolutionTag::Git => {
             let git = resolution.git();
-            cache_dir_subpath = cached_git_folder_name(manager, git, patch_hash);
             cache_dir = get_cache_directory(manager);
+            cache_dir_subpath = cached_git_folder_name(manager, folder_path_buf, git, patch_hash);
         }
         ResolutionTag::Github => {
             let github = resolution.github();
-            cache_dir_subpath = cached_github_folder_name(manager, github, patch_hash);
             cache_dir = get_cache_directory(manager);
+            cache_dir_subpath =
+                cached_github_folder_name(manager, folder_path_buf, github, patch_hash);
         }
         ResolutionTag::Folder => {
             let buf = manager.lockfile.buffers.string_bytes.as_slice();
@@ -988,13 +950,15 @@ pub fn compute_cache_dir_and_subpath<'a>(
         }
         ResolutionTag::LocalTarball => {
             let tarball = *resolution.local_tarball();
-            cache_dir_subpath = cached_tarball_folder_name(manager, tarball, patch_hash);
             cache_dir = get_cache_directory(manager);
+            cache_dir_subpath =
+                cached_tarball_folder_name(manager, folder_path_buf, tarball, patch_hash);
         }
         ResolutionTag::RemoteTarball => {
             let tarball = *resolution.remote_tarball();
-            cache_dir_subpath = cached_tarball_folder_name(manager, tarball, patch_hash);
             cache_dir = get_cache_directory(manager);
+            cache_dir_subpath =
+                cached_tarball_folder_name(manager, folder_path_buf, tarball, patch_hash);
         }
         ResolutionTag::Workspace => {
             let buf = manager.lockfile.buffers.string_bytes.as_slice();
@@ -1083,7 +1047,7 @@ pub fn attempt_to_create_package_json() -> Result<(), Error> {
 
 pub fn save_lockfile(
     this: &mut PackageManager,
-    load_result: &LoadResult,
+    load_result: &dyn crate::lockfile::LoadedFrom,
     save_format: LockfileFormat,
     had_any_diffs: bool,
     // NOTE(dylan-conway): this and `packages_len_before_install` can most likely be deleted
@@ -1095,10 +1059,8 @@ pub fn save_lockfile(
     if this.lockfile.is_empty() {
         if !this.options.dry_run {
             'delete: {
-                let delete_format = match load_result {
-                    LoadResult::NotFound => break 'delete,
-                    LoadResult::Err(err) => err.format,
-                    LoadResult::Ok(ok) => ok.format,
+                let Some(delete_format) = load_result.existing_format() else {
+                    break 'delete;
                 };
 
                 match sys::unlinkat(
@@ -1143,18 +1105,10 @@ pub fn save_lockfile(
         return Ok(false);
     }
 
-    // `Progress::start`
-    // returns `&mut Node` borrowing `this.progress`, which would conflict with
-    // the `&mut this` reborrows below. Stash as a raw pointer
-    // (the node lives inside `this.progress.root`).
-    let mut save_node: *mut ProgressNode = core::ptr::null_mut();
-
+    // The save node is `this.progress.root`.
     if log_level.show_progress() {
         this.progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
-        save_node = this.progress.start(ProgressStrings::save(), 0);
-        // SAFETY: `save_node` was just set by `progress.start()` and is non-null.
-        unsafe { (*save_node).activate() };
-
+        this.progress.start(ProgressStrings::save(), 0).activate();
         this.progress.refresh();
     }
 
@@ -1166,7 +1120,7 @@ pub fn save_lockfile(
     }
 
     if cfg!(debug_assertions) {
-        if !matches!(load_result, LoadResult::NotFound) {
+        if load_result.existing_format().is_some() {
             if load_result.loaded_from_text_lockfile() {
                 if !Lockfile::eql(
                     &this.lockfile,
@@ -1190,10 +1144,7 @@ pub fn save_lockfile(
     }
 
     if log_level.show_progress() {
-        // SAFETY: `save_node` was set to a non-null `&mut Node` in the
-        // matching `show_progress()` branch above and `this.progress` is
-        // unchanged in between.
-        unsafe { (*save_node).end() };
+        this.progress.root.end();
         this.progress.refresh();
         this.progress.root.end();
         this.progress = Default::default();
@@ -1209,9 +1160,9 @@ pub fn update_lockfile_if_needed(
     manager: &mut PackageManager,
     // The caller continues using
     // `load_result` after this call, so take it by shared reference.
-    load_result: &LoadResult,
+    load_result: &crate::lockfile::DetachedLoadResult,
 ) -> Result<(), Error> {
-    if let LoadResult::Ok(ok) = load_result {
+    if let crate::lockfile::DetachedLoadResult::Ok(ok) = load_result {
         if ok.serializer_result.packages_need_update {
             let mut slice = manager.lockfile.packages.slice();
             for meta in slice.items_meta_mut() {
@@ -1296,23 +1247,7 @@ impl CacheVersion {
 
 #[inline]
 fn verbose_install() -> bool {
-    // SAFETY: `VERBOSE_INSTALL` is set once during single-threaded CLI startup
-    // (PackageManagerOptions.load) and only read on the main thread.
     PackageManager::verbose_install()
-}
-
-/// Thread-local cached folder-name buffer accessor.
-/// Single-threaded install, non-reentrant scratch — the `&'static mut [u8]`
-/// is the unique live borrow at every call site. Callers must not hold the
-/// result across a call that re-enters this accessor (per-statement reborrow
-/// shape — same contract the prior `*mut [u8]` API imposed, now centralized
-/// here so the 6 call sites drop their `unsafe` block).
-#[inline]
-fn cached_package_folder_name_buf() -> &'static mut [u8] {
-    // SAFETY: single-threaded usage (install runs on one thread); the
-    // thread-local cell outlives all callers and only one `&mut` is taken at a
-    // time per call site (the buffer is reused non-reentrantly).
-    unsafe { (*super::cached_package_folder_name_buf()).as_mut_slice() }
 }
 
 /// `&'static ZStr` from a NUL-terminated literal.

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1301,12 +1301,15 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     Some(resolved) => resolved,
                     None => {
                         // Waits on a `git log` task; `run_tasks` fills `git_commits` and re-enters here.
-                        let url = this.lockfile.str(&dep.repo);
-                        let committish = this.lockfile.str(&dep.committish);
-                        let commit_id = Task::Id::for_git_commit(url, committish);
+                        let commit_id = Task::Id::for_git_commit(
+                            this.lockfile.str(&dep.repo),
+                            this.lockfile.str(&dep.committish),
+                        );
                         match this.git_commits.get(&commit_id) {
                             Some(resolved) => resolved.clone(),
                             None => {
+                                let url = interned(this.lockfile.str(&dep.repo));
+                                let committish = interned(this.lockfile.str(&dep.committish));
                                 let entry = this
                                     .task_queue
                                     .get_or_put_context(commit_id, ())
@@ -1328,8 +1331,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     return Ok(());
                                 }
 
-                                let url = interned(url);
-                                let committish = interned(committish);
                                 let task = enqueue_git_commit(
                                     this, commit_id, clone_id, alias, url, committish,
                                 );

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1,7 +1,4 @@
 use crate::lockfile::package::PackageColumns as _;
-use bun_ptr::detach_lifetime;
-use core::mem::ManuallyDrop;
-use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 
 use crate::bun_fs::FileSystem;
@@ -10,7 +7,6 @@ use bun_core::{StringOrTinyString, strings};
 use bun_paths as Path;
 use bun_semver::{self as Semver, String as SemverString};
 use bun_sys::Fd;
-use bun_threading::thread_pool as ThreadPool;
 
 use crate::_folder_resolver::{
     self as FolderResolution, FolderResolution as FolderResolutionValue, GlobalOrRelative,
@@ -43,7 +39,6 @@ use bun_install::{
 // `verbose_install()` call sites read the same.
 #[inline]
 fn verbose_install() -> bool {
-    // SAFETY: set once during single-threaded CLI startup; only read here.
     PackageManager::verbose_install()
 }
 
@@ -122,7 +117,7 @@ pub fn enqueue_dependency_list(
                     escape_backslashes: false,
                 },
             );
-            let log = this.log_mut();
+            let log = &mut this.log;
             if dependency.behavior.is_optional() || dependency.behavior.is_peer() {
                 log.add_warning_with_note(
                     None,
@@ -146,15 +141,22 @@ pub fn enqueue_dependency_list(
     this.drain_dependency_list();
 }
 
+fn interned(s: &[u8]) -> StringOrTinyString {
+    StringOrTinyString::init_append_if_needed(
+        s,
+        &mut crate::network_task::filename_store_appender(),
+    )
+    .expect("unreachable")
+}
+
 pub fn enqueue_tarball_for_download(
     this: &mut PackageManager,
     dependency_id: DependencyID,
     package_id: PackageID,
-    url: &[u8],
+    url: StringOrTinyString,
     task_context: TaskCallbackContext,
-    patch_name_and_version_hash: Option<u64>,
 ) -> Result<(), EnqueueTarballForDownloadError> {
-    let task_id = Task::Id::for_tarball(url);
+    let task_id = Task::Id::for_tarball(url.slice());
     if this.network_task_has_failed(task_id) {
         return Err(EnqueueTarballForDownloadError::AlreadyFailed);
     }
@@ -162,11 +164,7 @@ pub fn enqueue_tarball_for_download(
         let is_required = this.lockfile.buffers.dependencies[dependency_id as usize]
             .behavior
             .is_required();
-        let name = this
-            .lockfile
-            .str(&this.lockfile.packages.get(package_id as usize).name)
-            .to_vec();
-        if offline_tarball_miss(this, task_id, &name, is_required) {
+        if offline_tarball_miss(this, task_id, package_id, is_required) {
             return Err(EnqueueTarballForDownloadError::Offline);
         }
     }
@@ -192,15 +190,11 @@ pub fn enqueue_tarball_for_download(
         is_required,
         dependency_id,
         &package,
-        patch_name_and_version_hash,
         crate::network_task::Authorization::NoAuthorization,
     )? {
-        // reshaped for borrowck — `task: &mut NetworkTask` borrows
-        // `*this` (pool slot); reborrow as raw so `this.network_tarball_batch`
-        // is reachable.
-        let task: *mut NetworkTask = task;
-        // SAFETY: `task` is the unique handle to a freshly-vended pool slot.
-        unsafe { (*task).schedule(&mut this.network_tarball_batch) };
+        // The HTTP thread takes the task over until its terminal callback
+        // hands it back through `Shared::async_network_task_queue`.
+        bun_http::schedule_owned_request(task, &mut this.network_tarball_batch);
         if this.network_tarball_batch.len > 0 {
             let _ = this.schedule_tasks();
         }
@@ -212,20 +206,19 @@ pub fn enqueue_tarball_for_reading(
     this: &mut PackageManager,
     dependency_id: DependencyID,
     package_id: PackageID,
-    alias: &[u8],
+    alias: Semver::String,
     resolution: &Resolution,
     task_context: TaskCallbackContext,
 ) {
-    // reshaped for borrowck — `path` borrows
-    // `this.lockfile.buffers.string_bytes`; detach the slice lifetime so the
-    // `&mut PackageManager` reborrow for `enqueue_local_tarball` below does
-    // not conflict.
-    // SAFETY: caller passes `resolution.tag == LocalTarball`; the
-    // `local_tarball` arm is the active union field. `string_bytes` is not
-    // resized in this fn — `enqueue_local_tarball` copies `path` into the
-    // filename store before any append.
-    let path = this.lockfile.str_detached(resolution.local_tarball());
-    let task_id = Task::Id::for_tarball(path);
+    let (task_id, alias, path) = {
+        let string_buf = this.lockfile.buffers.string_bytes.as_slice();
+        let path = resolution.local_tarball().slice(string_buf);
+        (
+            Task::Id::for_tarball(path),
+            interned(alias.slice(string_buf)),
+            interned(path),
+        )
+    };
     let task_queue = this.task_queue.get_or_put(task_id).expect("unreachable");
     if !task_queue.found_existing {
         *task_queue.value_ptr = TaskCallbackList::default();
@@ -248,7 +241,7 @@ pub fn enqueue_tarball_for_reading(
         resolution,
         &integrity,
     );
-    this.task_batch.push(ThreadPool::Batch::from(task));
+    this.task_batch.push_owned(task);
 }
 
 /// Outcome of `enqueue_git_for_checkout`.
@@ -264,32 +257,30 @@ pub enum GitEnqueueResult {
 pub fn enqueue_git_for_checkout(
     this: &mut PackageManager,
     dependency_id: DependencyID,
-    alias: &[u8],
+    alias: Semver::String,
     resolution: &Resolution,
     task_context: TaskCallbackContext,
     patch_name_and_version_hash: Option<u64>,
 ) -> GitEnqueueResult {
-    // SAFETY: caller passes `resolution.tag == Git`; the `git` arm is the
-    // active union field. Copy out so the value no longer borrows
-    // `*resolution` while `*this` is mutably reborrowed below.
     let repository: Repository = *resolution.git();
-    // reshaped for borrowck — `url`/`resolved` borrow
-    // `this.lockfile.buffers.string_bytes`; detach the slice lifetimes so the
-    // `&mut PackageManager` reborrows for the enqueue callees below do not
-    // conflict.
-    // SAFETY: the enqueue callees copy these slices into the filename store
-    // and never resize `string_bytes` while they are live.
-    let url = this.lockfile.str_detached(&repository.repo);
-    let clone_id = Task::Id::for_git_clone(url);
-    let resolved = this.lockfile.str_detached(&repository.resolved);
-    let checkout_id = Task::Id::for_git_checkout(url, resolved);
+    let (clone_id, checkout_id, alias, resolved) = {
+        let string_buf = this.lockfile.buffers.string_bytes.as_slice();
+        let url = repository.repo.slice(string_buf);
+        let resolved = repository.resolved.slice(string_buf);
+        (
+            Task::Id::for_git_clone(url),
+            Task::Id::for_git_checkout(url, resolved),
+            interned(alias.slice(string_buf)),
+            interned(resolved),
+        )
+    };
     // --offline: decide before any queue registration, so an optional miss leaves
     // nothing behind and a later required edge still reaches the report
     if this.git_repositories.get(&clone_id).is_none() {
         let is_required = this.lockfile.buffers.dependencies[dependency_id as usize]
             .behavior
             .is_required();
-        if offline_git_miss(this, clone_id, alias, is_required) {
+        if offline_git_miss(this, clone_id, alias.slice(), is_required) {
             return GitEnqueueResult::OfflineMiss;
         }
     }
@@ -346,7 +337,7 @@ pub fn enqueue_git_for_checkout(
 fn offline_tarball_miss(
     this: &mut PackageManager,
     task_id: Task::Id,
-    name: &[u8],
+    package_id: PackageID,
     is_required: bool,
 ) -> bool {
     if this.options.offline != crate::package_manager_real::options::OfflineMode::Offline {
@@ -356,7 +347,9 @@ fn offline_tarball_miss(
         // reserve + mark failed so later dependents take the already-failed path
         let _ = this.has_created_network_task(task_id, true);
         this.mark_network_task_failed(task_id);
-        let _ = this.log_mut().add_error_fmt(
+        let name = this.lockfile.packages.items_name()[package_id as usize];
+        let name = this.lockfile.str(&name);
+        this.log.add_error_fmt(
             None,
             bun_ast::Loc::EMPTY,
             format_args!(
@@ -400,7 +393,7 @@ fn offline_git_miss(
             // reserve + mark failed: reported once, later dependents see the failure
             let _ = this.has_created_network_task(clone_id, true);
             this.mark_network_task_failed(clone_id);
-            let _ = this.log_mut().add_error_fmt(
+            let _ = this.log.add_error_fmt(
                 None,
                 bun_ast::Loc::EMPTY,
                 format_args!(
@@ -416,53 +409,38 @@ fn offline_git_miss(
     true
 }
 
-/// # Safety
-/// `network_task` must point to a live, exclusively-owned `NetworkTask` pool
-/// slot for the duration of the enqueued resolve task.
-pub unsafe fn enqueue_parse_npm_package(
+pub fn enqueue_parse_npm_package(
     this: &mut PackageManager,
     task_id: Task::Id,
     name: StringOrTinyString,
-    network_task: *mut NetworkTask,
-) -> *mut ThreadPool::Task {
-    // SAFETY: `this` is a live `&mut PackageManager`; `network_task` is a
-    // freshly-vended pool slot whose `'static` reborrow matches the
-    // `Task<'static>` slot lifetime.
-    let task_value = unsafe {
-        Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::PackageManifest,
-            request: crate::package_manager_task::Request {
-                package_manifest: ManuallyDrop::new(
-                    crate::package_manager_task::PackageManifestRequest {
-                        network: &mut *network_task,
-                        name,
-                    },
-                ),
-            },
-            id: task_id,
-            ..Task::uninit()
-        }
-    };
-    let task = this.preallocated_resolve_tasks.get_init(task_value);
-    // SAFETY: `task` points to a freshly initialized pool slot.
-    unsafe { &raw mut (*task.as_ptr()).threadpool_task }
+    network_task: Box<NetworkTask>,
+) -> Box<Task::Task> {
+    Task::Task::new(
+        this,
+        task_id,
+        crate::package_manager_task::Request::PackageManifest {
+            network: Some(network_task),
+            name,
+        },
+    )
 }
 
 pub fn enqueue_package_for_download(
     this: &mut PackageManager,
-    name: &[u8],
+    name: Semver::String,
     dependency_id: DependencyID,
     package_id: PackageID,
     version: Semver::Version,
-    url: &[u8],
+    url: Semver::String,
     task_context: TaskCallbackContext,
-    patch_name_and_version_hash: Option<u64>,
 ) -> Result<(), EnqueuePackageForDownloadError> {
-    let task_id = Task::Id::for_npm_package(name, version);
+    let (task_id, url) = {
+        let string_buf = this.lockfile.buffers.string_bytes.as_slice();
+        (
+            Task::Id::for_npm_package(name.slice(string_buf), version),
+            interned(url.slice(string_buf)),
+        )
+    };
     if this.network_task_has_failed(task_id) {
         return Err(EnqueuePackageForDownloadError::AlreadyFailed);
     }
@@ -470,7 +448,7 @@ pub fn enqueue_package_for_download(
         let is_required = this.lockfile.buffers.dependencies[dependency_id as usize]
             .behavior
             .is_required();
-        if offline_tarball_miss(this, task_id, name, is_required) {
+        if offline_tarball_miss(this, task_id, package_id, is_required) {
             return Err(EnqueuePackageForDownloadError::Offline);
         }
     }
@@ -497,13 +475,11 @@ pub fn enqueue_package_for_download(
         is_required,
         dependency_id,
         &package,
-        patch_name_and_version_hash,
         crate::network_task::Authorization::AllowAuthorization,
     )? {
-        // reshaped for borrowck — see `enqueue_tarball_for_download`.
-        let task: *mut NetworkTask = task;
-        // SAFETY: `task` is the unique handle to a freshly-vended pool slot.
-        unsafe { (*task).schedule(&mut this.network_tarball_batch) };
+        // The HTTP thread takes the task over until its terminal callback
+        // hands it back through `Shared::async_network_task_queue`.
+        bun_http::schedule_owned_request(task, &mut this.network_tarball_batch);
         if this.network_tarball_batch.len > 0 {
             let _ = this.schedule_tasks();
         }
@@ -569,8 +545,8 @@ pub fn enqueue_dependency_to_root(
     } as DependencyID;
 
     if this.lockfile.buffers.resolutions[dep_id as usize] == invalid_package_id {
-        // Copy to the stack: `enqueueDependencyWithMainAndSuccessFn` can call
-        // `Lockfile.Package.fromNPM`, which grows `buffers.dependencies` and
+        // Copy to the stack: `enqueue_dependency_with_main_and_success_fn` can call
+        // `Package::from_npm`, which grows `buffers.dependencies` and
         // would invalidate a pointer taken directly into it.
         let dependency = this.lockfile.buffers.dependencies[dep_id as usize].clone();
         if let Err(err) = enqueue_dependency_with_main_and_success_fn(
@@ -591,73 +567,38 @@ pub fn enqueue_dependency_to_root(
         id if id == invalid_package_id => 'brk: {
             this.drain_dependency_list();
 
-            struct Closure {
-                err: Option<crate::Error>,
-                // raw `*mut` — `sleep_until`
-                // also receives this pointer, so `&mut` here would alias.
-                manager: *mut PackageManager,
-                // `sleep_until` ticks the JS event loop, and JS run there can
-                // swap `manager.log` and leave it pointing at a dead stack
-                // `Log`. `is_done` re-asserts this snapshot before each poll.
-                log: *mut bun_ast::Log,
-            }
-            impl Closure {
-                fn is_done(&mut self) -> bool {
-                    // SAFETY: `self.manager` is the raw provenance root set
-                    // below; `sleep_until`/`tick_raw` hold no `&mut` across
-                    // this callback, so this is the unique live borrow.
-                    let manager = unsafe { &mut *self.manager };
-                    manager.log = self.log;
-                    if manager.pending_task_count() > 0 {
-                        // All callbacks void: `VoidRunTasksCallbacks` (below)
-                        // has `Ctx = ()` and every `HAS_* = false`.
-                        let log_level = manager.options.log_level;
-                        if let Err(err) = run_tasks::run_tasks::<VoidRunTasksCallbacks>(
-                            manager,
-                            &mut (),
-                            false,
-                            log_level,
-                        ) {
-                            self.err = Some(err);
-                            return true;
-                        }
-
-                        if verbose_install() && manager.pending_task_count() > 0 {
-                            if PackageManager::has_enough_time_passed_between_waiting_messages() {
-                                bun_core::pretty_errorln!(
-                                    "<d>[PackageManager]<r> waiting for {} tasks\n",
-                                    manager.pending_task_count()
-                                );
-                            }
-                        }
-                    }
-
-                    manager.pending_task_count() == 0
-                }
-            }
-
             if this.options.log_level.show_progress() {
                 this.start_progress_bar_if_none();
             }
 
-            let mgr: *mut PackageManager = this;
-            let mut closure = Closure {
-                err: None,
-                manager: mgr,
-                log: this.log,
-            };
-            // SAFETY: `mgr` derived from the live exclusive `this` borrow;
-            // `sleep_until` + `tick_raw` hold no `&mut PackageManager` across
-            // `Closure::is_done`, so the callback's `&mut *closure.manager`
-            // is the unique live borrow.
-            unsafe { PackageManager::sleep_until(mgr, &mut closure, Closure::is_done) };
+            let mut err: Option<crate::Error> = None;
+            PackageManager::sleep_until(this, |manager| {
+                if manager.pending_task_count() > 0 {
+                    let log_level = manager.options.log_level;
+                    if let Err(e) = run_tasks::run_tasks(manager, false, log_level) {
+                        err = Some(e);
+                        return true;
+                    }
+
+                    if verbose_install() && manager.pending_task_count() > 0 {
+                        if manager.has_enough_time_passed_between_waiting_messages() {
+                            bun_core::pretty_errorln!(
+                                "<d>[PackageManager]<r> waiting for {} tasks\n",
+                                manager.pending_task_count()
+                            );
+                        }
+                    }
+                }
+
+                manager.pending_task_count() == 0
+            });
 
             if this.options.log_level.show_progress() {
                 this.end_progress_bar();
                 Output::flush();
             }
 
-            if let Some(err) = closure.err {
+            if let Some(err) = err {
                 return DependencyToEnqueue::Failure(err);
             }
 
@@ -677,24 +618,16 @@ pub fn enqueue_dependency_to_root(
     }
 }
 
-/// All-void callback set used by `enqueueDependencyToRoot` and `runAndWaitFn`:
-/// `Ctx = ()`, no callbacks, so the `HAS_*` const-gates compile out the
-/// callback paths.
-struct VoidRunTasksCallbacks;
-impl run_tasks::RunTasksCallbacks for VoidRunTasksCallbacks {
-    type Ctx = ();
-}
-
-pub fn enqueue_network_task(this: &mut PackageManager, task: *mut NetworkTask) {
-    if this.network_task_fifo.writable_length() == 0 {
+pub fn enqueue_network_task(this: &mut PackageManager, task: Box<NetworkTask>) {
+    if this.network_task_fifo.is_full() {
         this.flush_network_queue();
     }
 
-    this.network_task_fifo.write_item_assume_capacity(task);
+    this.network_task_fifo.push(task);
 }
 
-/// Hands the task to the patch-task fifo as a raw pointer; it is reclaimed once
-/// in `run_tasks` after the thread pool pushes it onto `patch_task_queue`.
+/// Queues the task for the thread pool; `run_tasks` gets it back through
+/// `patch_task_queue`.
 pub fn enqueue_patch_task(this: &mut PackageManager, task: Box<PatchTask>) {
     bun_output::scoped_log!(
         PackageManager,
@@ -702,12 +635,11 @@ pub fn enqueue_patch_task(this: &mut PackageManager, task: Box<PatchTask>) {
         task,
         task.callback.tag_name()
     );
-    if this.patch_task_fifo.writable_length() == 0 {
+    if this.patch_task_fifo.is_full() {
         this.flush_patch_task_queue();
     }
 
-    this.patch_task_fifo
-        .write_item_assume_capacity(bun_core::heap::into_raw(task));
+    this.patch_task_fifo.push(task);
 }
 
 /// We need to calculate all the patchfile hashes at the beginning so we don't run into problems with stale hashes
@@ -719,12 +651,11 @@ pub fn enqueue_patch_task_pre(this: &mut PackageManager, mut task: Box<PatchTask
         task.callback.tag_name()
     );
     task.pre = true;
-    if this.patch_task_fifo.writable_length() == 0 {
+    if this.patch_task_fifo.is_full() {
         this.flush_patch_task_queue();
     }
 
-    this.patch_task_fifo
-        .write_item_assume_capacity(bun_core::heap::into_raw(task));
+    this.patch_task_fifo.push(task);
     let _ = this.pending_pre_calc_hashes.fetch_add(1, Ordering::Relaxed);
 }
 
@@ -803,7 +734,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             if let Some(aliased) = this.known_npm_aliases.get(&name_hash) {
                 let group = &dependency.version.npm().version;
                 let buf = this.lockfile.buffers.string_bytes.as_slice();
-                // SAFETY: `aliased` is always tag == Npm (known_npm_aliases only stores npm versions).
                 let mut curr_list: Option<&Semver::semver_query::List> =
                     Some(&aliased.npm().version.head);
                 while let Some(queries) = curr_list {
@@ -889,7 +819,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
         }
 
         // explicit copy here due to `dependency.version` becoming undefined
-        // when `getOrPutResolvedPackageWithFindResult` is called and resizes the list.
+        // when `get_or_put_resolved_package_with_find_result` is called and resizes the list.
         version_was_replaced = false;
         break 'version dependency.version.clone();
     };
@@ -925,7 +855,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     } else if dependency.behavior.is_peer() {
                                         warn_unmet_peer_dependency(this, name, &version);
                                     } else {
-                                        this.log_mut()
+                                        this.log
                     .add_error_fmt(
                                                 None,
                                                 bun_ast::Loc::EMPTY,
@@ -948,7 +878,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                         warn_unmet_peer_dependency(this, name, &version);
                                     } else {
                                         bun_ast::add_error_pretty!(
-                                            this.log_mut(),
+                                            &mut this.log,
                                             None,
                                             bun_ast::Loc::EMPTY,
                                             "No version matching \"{}\" found for specifier \"{}\"<r> <d>(but package exists)<r>",
@@ -967,7 +897,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                             this.options.minimum_release_age_ms.unwrap_or(0.0);
                                         if version.tag == dependency::version::Tag::DistTag {
                                             bun_ast::add_error_pretty!(
-                                                this.log_mut(),
+                                                &mut this.log,
                                                 None,
                                                 bun_ast::Loc::EMPTY,
                                                 "Package \"{}\" with tag \"{}\" not found<r> <d>(all versions blocked by minimum-release-age: {} seconds)<r>",
@@ -979,7 +909,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                             );
                                         } else {
                                             bun_ast::add_error_pretty!(
-                                                this.log_mut(),
+                                                &mut this.log,
                                                 None,
                                                 bun_ast::Loc::EMPTY,
                                                 "No version matching \"{}\" found for specifier \"{}\"<r> <d>(blocked by minimum-release-age: {} seconds)<r>",
@@ -998,7 +928,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     if let Some(fail) = fail_fn {
                                         fail(this, dependency, id, err);
                                     } else if version.tag == dependency::version::Tag::Folder {
-                                        this.log_mut()
+                                        this.log
                     .add_error_fmt(
                                                 None,
                                                 bun_ast::Loc::EMPTY,
@@ -1009,7 +939,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                 ),
                                             );
                                     } else {
-                                        this.log_mut().add_error_fmt(
+                                        this.log.add_error_fmt(
                                             None,
                                             bun_ast::Loc::EMPTY,
                                             format_args!(
@@ -1108,16 +1038,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             );
                         }
                     } else if version.tag.is_npm() {
-                        // reshaped for borrowck — `name_str` borrows
-                        // `this.lockfile.buffers.string_bytes`. Route the whole
-                        // branch through a raw root so the slice and the
-                        // `&mut PackageManager` calls below can coexist.
-                        // Snapshot the manifest disk-cache scalars while we
-                        // still hold `&mut this` exclusively — taking it via
-                        // `&mut *this_ptr` after `name_str`/`scope` exist
-                        // would pop their borrow-stack tags under SB.
                         let cache_ctx = this.manifest_disk_cache_ctx();
-                        let this_ptr: *mut PackageManager = this;
                         // Owned copy: `get_or_put_resolved_package_with_find_result`
                         // below appends to `string_bytes` (and may reallocate it),
                         // and `name_str` is still read afterwards on the
@@ -1148,27 +1069,24 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     this.options.minimum_release_age_ms.is_some();
                                 if this.options.enable.manifest_cache() {
                                     let mut expired = false;
-                                    // SAFETY: `this_ptr` is the live exclusive
-                                    // borrow's address; `options` is disjoint
-                                    // from `manifests`.
-                                    let scope: *const crate::npm::registry::Scope =
-                                        unsafe { &(*this_ptr).options }
-                                            .scope_for_package_name(&name_str);
-                                    // SAFETY: `manifests` projected from
-                                    // `this_ptr`; `cache_ctx` was snapshotted
-                                    // before `this_ptr` so the lookup holds
-                                    // only this disjoint field borrow.
-                                    if let Some(manifest) = unsafe {
-                                        (*this_ptr).manifests.by_name_hash_allow_expired(
-                                            cache_ctx,
-                                            &*scope,
-                                            &name_str,
-                                            name_hash,
-                                            Some(&mut expired),
-                                            needs_extended_manifest,
-                                        )
-                                    } {
-                                        loaded_manifest = Some(manifest.clone());
+                                    let cached = {
+                                        let PackageManager {
+                                            manifests, options, ..
+                                        } = &mut *this;
+                                        let scope = options.scope_for_package_name(&name_str);
+                                        manifests
+                                            .by_name_hash_allow_expired(
+                                                cache_ctx,
+                                                scope,
+                                                &name_str,
+                                                name_hash,
+                                                Some(&mut expired),
+                                                needs_extended_manifest,
+                                            )
+                                            .map(|m| m.clone())
+                                    };
+                                    if let Some(manifest) = cached {
+                                        loaded_manifest = Some(manifest);
 
                                         // If it's an exact package version already living in the cache
                                         // We can skip the network request, even if it's beyond the caching period
@@ -1202,7 +1120,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                     {
                                                         let package_name = this.lockfile.str(&name);
                                                         let min_age_seconds = min_age_ms / MS_PER_S;
-                                                        let _ = this.log_mut().add_error_fmt(
+                                                        let _ = this.log.add_error_fmt(
                                                             None,
                                                             bun_ast::Loc::EMPTY,
                                                             format_args!(
@@ -1215,26 +1133,16 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                         return Ok(());
                                                     }
                                                 }
-                                                // reshaped for borrowck — `find_result`
-                                                // borrows `loaded_manifest`; route the manifest
-                                                // through a `BackRef` so the `&mut PackageManager`
-                                                // call below doesn't conflict. `loaded_manifest`
-                                                // is owned by this stack frame and not touched
-                                                // until the call returns.
-                                                let manifest_ref = bun_ptr::BackRef::new(
-                                                    loaded_manifest.as_ref().unwrap(),
-                                                );
                                                 if let Some(new_resolve_result) =
                                                     get_or_put_resolved_package_with_find_result(
-                                                        // SAFETY: see `this_ptr` note above.
-                                                        unsafe { &mut *this_ptr },
+                                                        this,
                                                         name_hash,
                                                         name,
                                                         dependency,
                                                         &version,
                                                         id,
                                                         dependency.behavior,
-                                                        manifest_ref.get(),
+                                                        loaded_manifest.as_ref().unwrap(),
                                                         find_result,
                                                         install_peer,
                                                         success_fn,
@@ -1276,7 +1184,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     // later dependents take the already-failed path.
                                     if dependency.behavior.is_required() {
                                         this.mark_network_task_failed(task_id);
-                                        let _ = this.log_mut().add_error_fmt(
+                                        let _ = this.log.add_error_fmt(
                                             None,
                                             bun_ast::Loc::EMPTY,
                                             format_args!(
@@ -1297,23 +1205,15 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     );
                                 }
 
-                                // `get_network_task` touches only the
-                                // preallocated pool, not `string_bytes`;
-                                // `name_str` is an owned copy, so `this` is
-                                // free to reborrow `&mut`.
-                                let network_task = this.get_network_task();
-                                // SAFETY: `network_task` is the unique handle to a
-                                // freshly-vended pool slot. `write_init` resets every
-                                // defaulted field (callback is uninitialized and
-                                // overwritten by `for_manifest`).
-                                unsafe {
-                                    NetworkTask::write_init(network_task, task_id, this_ptr, None);
-                                }
-
-                                let scope = this.scope_for_package_name(&name_str);
-                                // SAFETY: network_task points to a valid initialized NetworkTask slot
-                                unsafe {
-                                    (*network_task).for_manifest(
+                                let mut network_task = NetworkTask::new(task_id, this);
+                                {
+                                    let PackageManager {
+                                        log, env, options, ..
+                                    } = &mut *this;
+                                    let scope = options.scope_for_package_name(&name_str);
+                                    network_task.for_manifest(
+                                        log,
+                                        env.get(),
                                         &name_str,
                                         scope,
                                         loaded_manifest.as_ref(),
@@ -1355,15 +1255,14 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 return Ok(());
             }
 
-            // reshaped for borrowck — `alias`/`url` borrow
-            // `this.lockfile.buffers.string_bytes`; detach the slice
-            // lifetimes so the `&mut PackageManager` reborrows for the
-            // enqueue callees below do not conflict.
-            // SAFETY: `string_bytes` is not resized in this branch; the
-            // enqueue callees copy the slices into the filename store.
-            let alias = this.lockfile.str_detached(&dependency.name);
-            let url = this.lockfile.str_detached(&dep.repo);
-            let clone_id = Task::Id::for_git_clone(url);
+            let (alias, clone_id) = {
+                let string_buf = this.lockfile.buffers.string_bytes.as_slice();
+                let url = dep.repo.slice(string_buf);
+                (
+                    interned(dependency.name.slice(string_buf)),
+                    Task::Id::for_git_clone(url),
+                )
+            };
             let ctx = if is_root {
                 TaskCallbackContext::RootDependency(id)
             } else {
@@ -1378,7 +1277,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     <&'static str>::from(version.tag),
                     bstr::BStr::new(this.lockfile.str(&name)),
                     bstr::BStr::new(this.lockfile.str(&version.literal)),
-                    bstr::BStr::new(url),
+                    bstr::BStr::new(this.lockfile.str(&dep.repo)),
                 );
             }
 
@@ -1395,7 +1294,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 } else {
                     let pkg_id = this.lockfile.buffers.resolutions[id as usize];
                     let pkg_res = this.lockfile.packages.items_resolution()[pkg_id as usize];
-                    // SAFETY: tag checked — `value.git` is the active union arm.
                     (pkg_res.tag == ResolutionTag::Git)
                         .then(|| this.lockfile.str(&pkg_res.git().resolved).to_vec())
                 };
@@ -1403,7 +1301,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     Some(resolved) => resolved,
                     None => {
                         // Waits on a `git log` task; `run_tasks` fills `git_commits` and re-enters here.
-                        let committish = this.lockfile.str_detached(&dep.committish);
+                        let url = this.lockfile.str(&dep.repo);
+                        let committish = this.lockfile.str(&dep.committish);
                         let commit_id = Task::Id::for_git_commit(url, committish);
                         match this.git_commits.get(&commit_id) {
                             Some(resolved) => resolved.clone(),
@@ -1429,6 +1328,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     return Ok(());
                                 }
 
+                                let url = interned(url);
+                                let committish = interned(committish);
                                 let task = enqueue_git_commit(
                                     this, commit_id, clone_id, alias, url, committish,
                                 );
@@ -1438,7 +1339,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         }
                     }
                 };
-                let checkout_id = Task::Id::for_git_checkout(url, &resolved);
+                let checkout_id =
+                    Task::Id::for_git_checkout(this.lockfile.str(&dep.repo), &resolved);
 
                 if needs_ctx {
                     if let Some(pkg_id) = resolve_from_appended_task(this, checkout_id, id) {
@@ -1469,6 +1371,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     return Ok(());
                 }
 
+                let resolved = interned(&resolved);
                 let task = enqueue_git_checkout(
                     this,
                     checkout_id,
@@ -1476,7 +1379,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     id,
                     alias,
                     &res,
-                    &resolved,
+                    resolved,
                     None,
                 );
                 this.enqueue_git_task(task);
@@ -1500,7 +1403,12 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 if this.has_created_network_task(clone_id, dependency.behavior.is_required()) {
                     return Ok(());
                 }
-                if offline_git_miss(this, clone_id, alias, dependency.behavior.is_required()) {
+                if offline_git_miss(
+                    this,
+                    clone_id,
+                    alias.slice(),
+                    dependency.behavior.is_required(),
+                ) {
                     return Ok(());
                 }
 
@@ -1547,9 +1455,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             } else {
                 TaskCallbackContext::Dependency(id)
             };
-            // reshaped for borrowck — `entry` mutably borrows
-            // `this.task_queue`; scope it tightly so the calls below can
-            // reborrow `*this`.
             {
                 let entry = this
                     .task_queue
@@ -1571,7 +1476,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             let generated = match run_tasks::generate_network_task_for_tarball(
                 this,
                 task_id,
-                &url,
+                interned(&url),
                 dependency.behavior.is_required(),
                 id,
                 &Package {
@@ -1580,7 +1485,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     resolution: res,
                     ..Package::default()
                 },
-                None,
                 crate::network_task::Authorization::NoAuthorization,
             ) {
                 // --offline miss: already reported (if required) / skipped (if optional)
@@ -1588,9 +1492,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 other => other?,
             };
             if let Some(network_task) = generated {
-                // reshaped for borrowck — see `enqueue_tarball_for_download`.
-                let nt: *mut NetworkTask = network_task;
-                enqueue_network_task(this, nt);
+                enqueue_network_task(this, network_task);
             }
             Ok(())
         }
@@ -1658,20 +1560,20 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             } else if dependency.behavior.is_required() {
                 if dependency_tag == dependency::version::Tag::Workspace {
                     bun_ast::add_error_pretty!(
-                        this.log_mut(),
+                        &mut this.log,
                         None,
                         bun_ast::Loc::EMPTY,
                         "Workspace dependency \"{}\" not found\n\nSearched in <b>{}<r>\n\nWorkspace documentation: https://bun.com/docs/install/workspaces\n\n",
                         bstr::BStr::new(this.lockfile.str(&name)),
                         PackageWorkspaceSearchPathFormatter {
-                            manager: this,
+                            lockfile: &this.lockfile,
                             version,
                             quoted: true
                         },
                     );
                 } else {
                     bun_ast::add_error_pretty!(
-                        this.log_mut(),
+                        &mut this.log,
                         None,
                         bun_ast::Loc::EMPTY,
                         "Package \"{}\" is not linked\n\nTo install a linked package:\n   <cyan>bun link my-pkg-name-from-package-json<r>\n\nTip: the package name is from package.json, which can differ from the folder name.\n\n",
@@ -1681,20 +1583,20 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             } else if this.options.log_level.is_verbose() {
                 if dependency_tag == dependency::version::Tag::Workspace {
                     bun_ast::add_warning_pretty!(
-                        this.log_mut(),
+                        &mut this.log,
                         None,
                         bun_ast::Loc::EMPTY,
                         "Workspace dependency \"{}\" not found\n\nSearched in <b>{}<r>\n\nWorkspace documentation: https://bun.com/docs/install/workspaces\n\n",
                         bstr::BStr::new(this.lockfile.str(&name)),
                         PackageWorkspaceSearchPathFormatter {
-                            manager: this,
+                            lockfile: &this.lockfile,
                             version,
                             quoted: true
                         },
                     );
                 } else {
                     bun_ast::add_warning_pretty!(
-                        this.log_mut(),
+                        &mut this.log,
                         None,
                         bun_ast::Loc::EMPTY,
                         "Package \"{}\" is not linked\n\nTo install a linked package:\n   <cyan>bun link my-pkg-name-from-package-json<r>\n\nTip: the package name is from package.json, which can differ from the folder name.\n\n",
@@ -1721,18 +1623,12 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 return Ok(());
             }
 
-            // reshaped for borrowck — `url` borrows `string_bytes`;
-            // detach the slice lifetime so the `&mut PackageManager` reborrows
-            // for the enqueue callees below do not conflict.
-            // SAFETY: the enqueue callees copy `url` into the filename store
-            // before any `string_bytes` resize.
-            let url = unsafe {
-                detach_lifetime(match &tarball.uri {
-                    dependency::tarball::Uri::Local(path) => this.lockfile.str(path),
-                    dependency::tarball::Uri::Remote(url) => this.lockfile.str(url),
-                })
+            let url_string = match &tarball.uri {
+                dependency::tarball::Uri::Local(path) => *path,
+                dependency::tarball::Uri::Remote(url) => *url,
             };
-            let task_id = Task::Id::for_tarball(url);
+            let url = interned(this.lockfile.str(&url_string));
+            let task_id = Task::Id::for_tarball(url.slice());
 
             if cfg!(debug_assertions) {
                 bun_output::scoped_log!(
@@ -1742,7 +1638,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                     <&'static str>::from(version.tag),
                     bstr::BStr::new(this.lockfile.str(&name)),
                     bstr::BStr::new(this.lockfile.str(&version.literal)),
-                    bstr::BStr::new(url),
+                    bstr::BStr::new(url.slice()),
                 );
             }
 
@@ -1758,7 +1654,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             } else {
                 TaskCallbackContext::Dependency(id)
             };
-            // reshaped for borrowck — scope `entry` tightly.
             {
                 let entry = this
                     .task_queue
@@ -1783,10 +1678,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         return Ok(());
                     }
 
-                    // SAFETY: `string_bytes` is not resized before
-                    // `enqueue_local_tarball` copies `dep_name` into the
-                    // filename store.
-                    let dep_name = this.lockfile.str_detached(&dependency.name);
+                    let dep_name = interned(this.lockfile.str(&dependency.name));
                     let task = enqueue_local_tarball(
                         this,
                         task_id,
@@ -1796,14 +1688,10 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         &res,
                         &Integrity::default(),
                     );
-                    this.task_batch.push(ThreadPool::Batch::from(task));
+                    this.task_batch.push_owned(task);
                 }
                 dependency::tarball::Uri::Remote(_) => {
-                    // `generate_network_task_for_tarball` returns
-                    // `&'a mut NetworkTask` tied to `this`; coerce to `*mut`
-                    // immediately so the `&mut *this` borrow ends before
-                    // `enqueue_network_task(this, …)` reborrows it (NLL).
-                    let network_task: Option<*mut NetworkTask> =
+                    let network_task: Option<Box<NetworkTask>> =
                         match run_tasks::generate_network_task_for_tarball(
                             this,
                             task_id,
@@ -1816,12 +1704,11 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                 resolution: res,
                                 ..Package::default()
                             },
-                            None,
                             crate::network_task::Authorization::NoAuthorization,
                         ) {
                             // --offline miss: already reported / skipped
                             Err(crate::network_task::ForTarballError::Offline) => return Ok(()),
-                            other => other?.map(std::ptr::from_mut::<NetworkTask>),
+                            other => other?,
                         };
                     if let Some(network_task) = network_task {
                         enqueue_network_task(this, network_task);
@@ -1838,12 +1725,12 @@ pub fn enqueue_dependency_with_main_and_success_fn(
 #[cold]
 #[inline(never)]
 fn warn_unmet_peer_dependency(
-    this: &PackageManager,
+    this: &mut PackageManager,
     name: SemverString,
     version: &dependency::Version,
 ) {
     bun_ast::add_warning_pretty!(
-        this.log_mut(),
+        &mut this.log,
         None,
         bun_ast::Loc::EMPTY,
         "No version matching \"{}\" found for peer dependency \"{}\"<r> <d>(but package exists)<r>",
@@ -1853,87 +1740,61 @@ fn warn_unmet_peer_dependency(
 }
 
 /// Allocate and initialise an `.extract` Task for an npm tarball.
-/// Shared by the buffered path (`enqueueExtractNPMPackage`) and the
-/// streaming path (`createExtractTaskForStreaming`) so both produce
+/// Shared by the buffered path (`enqueue_extract_npm_package`) and the
+/// streaming path (`create_extract_task_for_streaming`) so both produce
 /// an identical Task shape; only the return type differs.
-///
-/// Intentionally does *not* move `network_task.apply_patch_task`: the
-/// install phase creates its own PatchTask via `PackageInstaller`, so
-/// applying it here would run the patch twice.
 fn init_extract_task(
-    this: &mut PackageManager,
+    this: &PackageManager,
     tarball: &ExtractTarball,
-    network_task: *mut NetworkTask,
-) -> *mut Task::Task<'static> {
-    // SAFETY: `this` is a live `&mut PackageManager`; `network_task` is a
-    // freshly-vended pool slot whose `'static` reborrow matches the
-    // `Task<'static>` slot lifetime.
-    let task_value = unsafe {
-        Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::Extract,
-            request: crate::package_manager_task::Request {
-                extract: ManuallyDrop::new(crate::package_manager_task::ExtractRequest {
-                    network: &mut *network_task,
-                    tarball: ExtractTarball {
-                        skip_verify: !this
-                            .options
-                            .do_
-                            .contains(crate::package_manager_real::options::Do::VERIFY_INTEGRITY),
-                        ..*tarball
-                    },
-                }),
+    task_id: Task::Id,
+    network_task: Option<Box<NetworkTask>>,
+) -> Box<Task::Task> {
+    Task::Task::new(
+        this,
+        task_id,
+        crate::package_manager_task::Request::Extract {
+            network: network_task,
+            tarball: ExtractTarball {
+                skip_verify: !this
+                    .options
+                    .do_
+                    .contains(crate::package_manager_real::options::Do::VERIFY_INTEGRITY),
+                ..*tarball
             },
-            id: (*network_task).task_id,
-            ..Task::uninit()
-        }
-    };
-    this.preallocated_resolve_tasks
-        .get_init(task_value)
-        .as_ptr()
+        },
+    )
 }
 
 pub fn enqueue_extract_npm_package(
-    this: &mut PackageManager,
+    this: &PackageManager,
     tarball: &ExtractTarball,
-    network_task: *mut NetworkTask,
-) -> *mut ThreadPool::Task {
-    // SAFETY: init_extract_task returns a valid *mut Task
-    unsafe { &raw mut (*init_extract_task(this, tarball, network_task)).threadpool_task }
+    network_task: Box<NetworkTask>,
+) -> Box<Task::Task> {
+    let task_id = network_task.task_id;
+    init_extract_task(this, tarball, task_id, Some(network_task))
 }
 
 /// Allocate the extract Task up front so the streaming extractor can
-/// publish it to `resolve_tasks` when extraction finishes. Done on the
-/// main thread because `preallocated_resolve_tasks` is not thread-safe.
-/// The NetworkTask's pending-task slot is reused for the extraction so
-/// progress counters stay balanced.
+/// publish it to `resolve_tasks` when extraction finishes. The network task
+/// holds it (`streaming_extract_task`) until then, so `network` starts empty.
 pub fn create_extract_task_for_streaming(
-    this: &mut PackageManager,
+    this: &PackageManager,
     tarball: &ExtractTarball,
-    network_task: *mut NetworkTask,
-) -> *mut Task::Task<'static> {
-    init_extract_task(this, tarball, network_task)
+    task_id: Task::Id,
+) -> Box<Task::Task> {
+    init_extract_task(this, tarball, task_id, None)
 }
 
 fn enqueue_git_clone(
     this: &mut PackageManager,
     task_id: Task::Id,
-    name: &[u8],
+    name: StringOrTinyString,
     repository: &Repository,
     dependency: &Dependency,
     res: &Resolution,
     // if patched then we need to do apply step after network task is done
     patch_name_and_version_hash: Option<u64>,
-) -> NonNull<Task::Task<'static>> {
-    // Build the `Task` value *before* claiming a hive slot. Several initializers
-    // below (`.expect()`, `.unwrap()`, `panic!`) can unwind; doing them with the
-    // slot already claimed would leave a claimed-but-uninit `Task` (which carries
-    // `Log`/`Box<PatchTask>` drop glue) for the next `put()` to drop. With
-    // `get_init` the slot is claimed only after the value is fully constructed.
-    //
+) -> Box<Task::Task> {
     // The patched-dependency entry can be missing (or its hash not yet
     // computed) when install state went stale — e.g. the patch was removed
     // from package.json, leaving the hash only in
@@ -1948,48 +1809,30 @@ fn enqueue_git_clone(
                 .patchfile_hash()?,
         ))
     });
-    let value = Task::Task {
-        // `this` is a live `&mut PackageManager`; the task is owned by
-        // `this.preallocated_resolve_tasks` and never outlives the manager.
-        package_manager: Some(bun_ptr::ParentRef::from_ref_mut(&mut *this)),
-        log: bun_ast::Log::init(),
-        tag: crate::package_manager_task::Tag::GitClone,
-        request: crate::package_manager_task::Request {
-            git_clone: ManuallyDrop::new(crate::package_manager_task::GitCloneRequest {
-                name: StringOrTinyString::init_append_if_needed(
-                    name,
-                    &mut crate::network_task::filename_store_appender(),
-                )
-                .expect("unreachable"),
-                url: StringOrTinyString::init_append_if_needed(
-                    this.lockfile.str(&repository.repo),
-                    &mut crate::network_task::filename_store_appender(),
-                )
-                .expect("unreachable"),
-                res: *res,
-            }),
+    let request = crate::package_manager_task::Request::GitClone(
+        crate::package_manager_task::GitCloneRequest {
+            name,
+            url: interned(this.lockfile.str(&repository.repo)),
+            res: *res,
         },
-        id: task_id,
-        apply_patch_task: if let Some((h, patch_hash)) = patch {
-            let dep = dependency;
-            let pkg_id = match this
-                .lockfile
-                .package_index
-                .get(&dep.name_hash)
-                .unwrap_or_else(|| panic!("Package not found"))
-            {
-                PackageIndexEntry::Id(p) => *p,
-                PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
-            };
-            let mut pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
-            pt.callback.apply_mut().task_id = Some(task_id);
-            Some(pt)
-        } else {
-            None
-        },
-        ..Task::uninit()
-    };
-    this.preallocated_resolve_tasks.get_init(value)
+    );
+    let mut task = Task::Task::new(this, task_id, request);
+    if let Some((h, patch_hash)) = patch {
+        let dep = dependency;
+        let pkg_id = match this
+            .lockfile
+            .package_index
+            .get(&dep.name_hash)
+            .unwrap_or_else(|| panic!("Package not found"))
+        {
+            PackageIndexEntry::Id(p) => *p,
+            PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
+        };
+        let mut pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
+        pt.callback.apply_mut().task_id = Some(task_id);
+        task.apply_patch_task = Some(pt);
+    }
+    task
 }
 
 /// `git log`: resolves `committish` in the bare repository of `clone_id`.
@@ -1997,38 +1840,19 @@ fn enqueue_git_commit(
     this: &mut PackageManager,
     task_id: Task::Id,
     clone_id: Task::Id,
-    name: &[u8],
-    url: &[u8],
-    committish: &[u8],
-) -> NonNull<Task::Task<'static>> {
-    let value = Task::Task {
-        package_manager: Some(bun_ptr::ParentRef::from_ref_mut(&mut *this)),
-        log: bun_ast::Log::init(),
-        tag: crate::package_manager_task::Tag::GitCommit,
-        request: crate::package_manager_task::Request {
-            git_commit: ManuallyDrop::new(crate::package_manager_task::GitCommitRequest {
-                clone_id,
-                name: StringOrTinyString::init_append_if_needed(
-                    name,
-                    &mut crate::network_task::filename_store_appender(),
-                )
-                .expect("unreachable"),
-                url: StringOrTinyString::init_append_if_needed(
-                    url,
-                    &mut crate::network_task::filename_store_appender(),
-                )
-                .expect("unreachable"),
-                committish: StringOrTinyString::init_append_if_needed(
-                    committish,
-                    &mut crate::network_task::filename_store_appender(),
-                )
-                .expect("unreachable"),
-            }),
+    name: StringOrTinyString,
+    url: StringOrTinyString,
+    committish: StringOrTinyString,
+) -> Box<Task::Task> {
+    let request = crate::package_manager_task::Request::GitCommit(
+        crate::package_manager_task::GitCommitRequest {
+            clone_id,
+            name,
+            url,
+            committish,
         },
-        id: task_id,
-        ..Task::uninit()
-    };
-    this.preallocated_resolve_tasks.get_init(value)
+    );
+    Task::Task::new(this, task_id, request)
 }
 
 pub fn enqueue_git_checkout(
@@ -2036,12 +1860,12 @@ pub fn enqueue_git_checkout(
     task_id: Task::Id,
     dir: Fd,
     dependency_id: DependencyID,
-    name: &[u8],
+    name: StringOrTinyString,
     resolution: &Resolution,
-    resolved: &[u8],
+    resolved: StringOrTinyString,
     // if patched then we need to do apply step after network task is done
     patch_name_and_version_hash: Option<u64>,
-) -> NonNull<Task::Task<'static>> {
+) -> Box<Task::Task> {
     // The patched-dependency entry can be missing (or its hash not yet
     // computed) when install state went stale — e.g. the patch was removed
     // from package.json, leaving the hash only in
@@ -2056,139 +1880,90 @@ pub fn enqueue_git_checkout(
                 .patchfile_hash()?,
         ))
     });
-    // SAFETY: `this` is a live `&mut PackageManager`.
-    let task_value = unsafe {
-        Task::Task {
-            package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
-                PackageManager,
-            >(this))),
-            log: bun_ast::Log::init(),
-            tag: crate::package_manager_task::Tag::GitCheckout,
-            request: crate::package_manager_task::Request {
-                git_checkout: ManuallyDrop::new(crate::package_manager_task::GitCheckoutRequest {
-                    repo_dir: dir,
-                    resolution: *resolution,
-                    dependency_id,
-                    name: StringOrTinyString::init_append_if_needed(
-                        name,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    url: StringOrTinyString::init_append_if_needed(
-                        // `resolution.tag == Git` for the git-checkout path.
-                        this.lockfile.str(&resolution.git().repo),
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    resolved: StringOrTinyString::init_append_if_needed(
-                        resolved,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                }),
-            },
-            apply_patch_task: if let Some((h, patch_hash)) = patch {
-                let dep_name_hash =
-                    this.lockfile.buffers.dependencies[dependency_id as usize].name_hash;
-                let pkg_id = match this
-                    .lockfile
-                    .package_index
-                    .get(&dep_name_hash)
-                    .unwrap_or_else(|| panic!("Package not found"))
-                {
-                    PackageIndexEntry::Id(p) => *p,
-                    PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
-                };
-                let mut pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
-                pt.callback.apply_mut().task_id = Some(task_id);
-                Some(pt)
-            } else {
-                None
-            },
-            id: task_id,
-            ..Task::uninit()
-        }
-    };
-    this.preallocated_resolve_tasks.get_init(task_value)
+    let request = crate::package_manager_task::Request::GitCheckout(
+        crate::package_manager_task::GitCheckoutRequest {
+            repo_dir: dir,
+            resolution: *resolution,
+            dependency_id,
+            name,
+            // `resolution.tag == Git` for the git-checkout path.
+            url: interned(this.lockfile.str(&resolution.git().repo)),
+            resolved,
+        },
+    );
+    let mut task = Task::Task::new(this, task_id, request);
+    if let Some((h, patch_hash)) = patch {
+        let dep_name_hash = this.lockfile.buffers.dependencies[dependency_id as usize].name_hash;
+        let pkg_id = match this
+            .lockfile
+            .package_index
+            .get(&dep_name_hash)
+            .unwrap_or_else(|| panic!("Package not found"))
+        {
+            PackageIndexEntry::Id(p) => *p,
+            PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
+        };
+        let mut pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
+        pt.callback.apply_mut().task_id = Some(task_id);
+        task.apply_patch_task = Some(pt);
+    }
+    task
 }
 
 fn enqueue_local_tarball(
     this: &mut PackageManager,
     task_id: Task::Id,
     dependency_id: DependencyID,
-    name: &[u8],
-    path: &[u8],
+    name: StringOrTinyString,
+    path: StringOrTinyString,
     resolution: &Resolution,
     integrity: &Integrity,
-) -> *mut ThreadPool::Task {
+) -> Box<Task::Task> {
     // Resolve the on-disk tarball path here on the main thread. The task
     // callback runs on a ThreadPool worker and must not read
     // `lockfile.packages` / `lockfile.buffers.string_bytes`: those buffers
     // can be reallocated concurrently by the main thread while processing
-    // other dependencies (e.g. `appendPackage` / `StringBuilder.allocate`
-    // in `Package.fromNPM`).
+    // other dependencies (e.g. `append_package` / `StringBuilder::allocate`
+    // in `Package::from_npm`).
+    let cache_dir = get_cache_directory(this);
+    let temp_dir = get_temporary_directory(this).handle.fd();
     let mut abs_buf = bun_paths::path_buffer_pool::get();
-    let (tarball_path, normalize): (&[u8], bool) =
-        match local_tarball_base_dir(&this.lockfile, dependency_id, path) {
-            None => (path, true),
+    let (tarball_path, normalize): (StringOrTinyString, bool) =
+        match local_tarball_base_dir(&this.lockfile, dependency_id, path.slice()) {
+            None => (interned(path.slice()), true),
             Some(base_dir) => (
-                Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
+                interned(Path::resolve_path::join_abs_string_buf::<
+                    Path::platform::Auto,
+                >(
                     FileSystem::instance().top_level_dir(),
                     &mut abs_buf,
-                    &[base_dir, path],
-                ),
+                    &[base_dir, path.slice()],
+                )),
                 false,
             ),
         };
 
-    // Build the `Task` value *before* claiming a hive slot — the `.expect()`s
-    // below can unwind, and `Task` carries drop glue. See `enqueue_git_clone`.
-    let value = Task::Task {
-        // `this` is a live `&mut PackageManager`; the task is owned by
-        // `this.preallocated_resolve_tasks` and never outlives the manager.
-        package_manager: Some(bun_ptr::ParentRef::from_ref_mut(&mut *this)),
-        log: bun_ast::Log::init(),
-        tag: crate::package_manager_task::Tag::LocalTarball,
-        request: crate::package_manager_task::Request {
-            local_tarball: ManuallyDrop::new(crate::package_manager_task::LocalTarballRequest {
-                tarball: ExtractTarball {
-                    package_manager: bun_ptr::BackRef::new(this),
-                    name: StringOrTinyString::init_append_if_needed(
-                        name,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    resolution: *resolution,
-                    // `ExtractTarball::{cache_dir,temp_dir}` are borrowed views — the
-                    // descriptors are owned by the `PackageManager` singleton and the
-                    // `TemporaryDirectory` once-cell. They must be `Fd`, not owning `Dir`.
-                    cache_dir: get_cache_directory(this),
-                    temp_dir: get_temporary_directory(this).handle.fd(),
-                    dependency_id,
-                    integrity: *integrity,
-                    url: StringOrTinyString::init_append_if_needed(
-                        path,
-                        &mut crate::network_task::filename_store_appender(),
-                    )
-                    .expect("unreachable"),
-                    skip_verify: false,
-                    in_trusted_dependencies: false,
-                    github_resolved: StringOrTinyString::init(b""),
-                },
-                tarball_path: StringOrTinyString::init_append_if_needed(
-                    tarball_path,
-                    &mut crate::network_task::filename_store_appender(),
-                )
-                .expect("unreachable"),
-                normalize,
-            }),
+    let request = crate::package_manager_task::Request::LocalTarball {
+        tarball: ExtractTarball {
+            package_manager: bun_ptr::BackRef::new(this),
+            name,
+            resolution: *resolution,
+            // `ExtractTarball::{cache_dir,temp_dir}` are borrowed views — the
+            // descriptors are owned by the `PackageManager` singleton and the
+            // `TemporaryDirectory` once-cell. They must be `Fd`, not owning `Dir`.
+            cache_dir,
+            temp_dir,
+            dependency_id,
+            integrity: *integrity,
+            url: path,
+            skip_verify: false,
+            in_trusted_dependencies: false,
+            github_resolved: StringOrTinyString::init(b""),
         },
-        id: task_id,
-        ..Task::uninit()
+        tarball_path,
+        normalize,
     };
-    let task = this.preallocated_resolve_tasks.get_init(value).as_ptr();
-    // SAFETY: `get_init` just fully initialized the slot.
-    unsafe { &raw mut (*task).threadpool_task }
+    Task::Task::new(this, task_id, request)
 }
 
 /// The workspace or `file:` folder directory that `path` is relative to; `None` is the top-level dir.
@@ -2268,7 +2043,7 @@ fn root_workspace_package_id(
 
 pub(crate) enum ResolvedPackageTask {
     /// Pending network task to schedule
-    NetworkTask(*mut NetworkTask),
+    NetworkTask(Box<NetworkTask>),
 
     /// Apply patch task or calc patch hash task
     PatchTask(Box<PatchTask>),
@@ -2297,8 +2072,6 @@ fn get_or_put_resolved_package_with_find_result(
     install_peer: bool,
     success_fn: SuccessFn,
 ) -> crate::Result<Option<ResolvedPackageResult>> {
-    // reshaped for borrowck — `is_root_dependency(&self, &mut PackageManager, …)`
-    // borrows `this.lockfile` and `this` at once. Split via raw root.
     let should_update = this.to_update
         && if !this.update_requests.is_empty() {
             // bun update <name>: every in-scope <name> row (declared or `npm:<name>@…` aliased, see update_scope); other resolutions stay pinned.
@@ -2316,13 +2089,8 @@ fn get_or_put_resolved_package_with_find_result(
                     .is_dependency_of_workspace_in(targets, dependency_id)
         } else {
             // Bare `bun update`: direct deps of the cwd workspace; catalogs are root-scoped.
-            let this_ptr: *mut PackageManager = this;
-            // SAFETY: `is_root_dependency` reads `manager.root_dependency_list` /
-            // `manager.workspace_package_json_cache` only — disjoint from
-            // `manager.lockfile`.
             dependency.version.tag == dependency::version::Tag::Catalog
-                || unsafe { &*(*this_ptr).lockfile }
-                    .is_root_dependency(unsafe { &mut *this_ptr }, dependency_id)
+                || this.is_root_dependency(dependency_id)
         };
 
     // A patched package is held while the range still allows it (update_transitive holds the transitive rows the same way); audit fix does not set to_update and moves it.
@@ -2349,7 +2117,7 @@ fn get_or_put_resolved_package_with_find_result(
     // it when *every* candidate is an exact-pinned same-major sibling
     // (`uses-a-dep-1..10`). For deferred peers, suppress the satisfies-
     // fallback so only an exact `eql(find_result)` can bind here; everything
-    // else falls through to the `is_peer && !install_peer` defer below and is
+    // else falls through to the `is_peer && !install_peer` branch below and is
     // resolved deterministically by phase 2's descending-index scan in
     // `get_or_put_resolved_package`. `*` is left alone — it expresses no
     // version preference, and the "peer *" hoisting test depends on it
@@ -2379,133 +2147,127 @@ fn get_or_put_resolved_package_with_find_result(
         return Ok(None);
     }
 
-    // appendPackage sets the PackageID on the package
-    // reshaped for borrowck — `from_npm` takes both `&mut PackageManager`
-    // and `&mut Lockfile`, which alias through `this.lockfile`. Split via raw root.
-    let this_ptr: *mut PackageManager = this;
-    // SAFETY: `from_npm` reads `pm` fields disjoint from `pm.lockfile` (options /
-    // updating_packages), so the raw-pointer split does not alias.
-    let package = unsafe { &mut *(*this_ptr).lockfile }.append_package(&Package::from_npm(
-        unsafe { &mut *this_ptr },
-        unsafe { &mut *(*this_ptr).lockfile },
-        this.log_mut(),
-        manifest,
-        find_result.version,
-        find_result.package,
-        Features::NPM,
-    )?)?;
+    // append_package sets the PackageID on the package
+    let package = {
+        let PackageManager {
+            lockfile,
+            known_npm_aliases,
+            log,
+            ..
+        } = &mut *this;
+        let package = Package::from_npm(
+            known_npm_aliases,
+            lockfile,
+            log,
+            manifest,
+            find_result.version,
+            find_result.package,
+            Features::NPM,
+        )?;
+        lockfile.append_package(&package)?
+    };
 
     debug_assert!(package.meta.id != invalid_package_id);
     // Record exact-version pins so `Lockfile::get_package_id`'s
     // order-independence guard can tell them apart from range-resolved
     // entries (which it treats as network-order artefacts).
     if version.tag == dependency::version::Tag::Npm && version.npm().version.is_exact() {
-        // SAFETY: `this_ptr` is the sole live `&mut PackageManager` here;
-        // `lockfile.exact_pinned` is disjoint from `package` (returned
-        // by-value above).
-        unsafe { &mut *(*this_ptr).lockfile }.mark_exact_pin(package.meta.id);
+        this.lockfile.mark_exact_pin(package.meta.id);
     }
-    // Use scopeguard so success_fn runs on every
-    // return below (including the `?` paths). The guard owns the raw pointer so the
-    // `this` reborrow below doesn't conflict with the closure capture.
-    let mut guard = scopeguard::guard((this_ptr, package.meta.id), |(this_ptr, pkg_id)| {
-        // SAFETY: `this_ptr` came from the live exclusive `this` borrow; the
-        // guard fires after all reborrows of `this` below have ended.
-        success_fn(unsafe { &mut *this_ptr }, dependency_id, pkg_id);
-    });
-    // SAFETY: see above — sole live `&mut PackageManager` until scope exit.
-    let this: &mut PackageManager = unsafe { &mut *guard.0 };
-    // The scopeguard runs on ALL exits, never disarmed.
+    // `success_fn` runs on every return below (including the `?` paths).
+    let result = (|| -> crate::Result<Option<ResolvedPackageResult>> {
+        let this = &mut *this;
 
-    // non-null if the package is in "patchedDependencies"
-    let mut name_and_version_hash: Option<u64> = None;
-    let mut patchfile_hash: Option<u64> = None;
+        // non-null if the package is in "patchedDependencies"
+        let mut name_and_version_hash: Option<u64> = None;
+        let mut patchfile_hash: Option<u64> = None;
 
-    let result = match determine_preinstall_state(
-        this,
-        &package,
-        &mut name_and_version_hash,
-        &mut patchfile_hash,
-    ) {
-        // Is this package already in the cache?
-        // We don't need to download the tarball, but we should enqueue dependencies
-        install::PreinstallState::Done => Some(ResolvedPackageResult {
-            package,
-            is_first_time: true,
-            task: None,
-        }),
-        // Do we need to download the tarball?
-        install::PreinstallState::Extract => 'extract: {
-            // Skip tarball download when prefetch_resolved_tarballs is disabled (e.g., --lockfile-only)
-            if !this
-                .options
-                .do_
-                .contains(crate::package_manager_real::options::Do::PREFETCH_RESOLVED_TARBALLS)
-            {
+        let result = match determine_preinstall_state(
+            this,
+            &package,
+            &mut name_and_version_hash,
+            &mut patchfile_hash,
+        ) {
+            // Is this package already in the cache?
+            // We don't need to download the tarball, but we should enqueue dependencies
+            install::PreinstallState::Done => Some(ResolvedPackageResult {
+                package,
+                is_first_time: true,
+                task: None,
+            }),
+            // Do we need to download the tarball?
+            install::PreinstallState::Extract => 'extract: {
+                // Skip tarball download when prefetch_resolved_tarballs is disabled (e.g., --lockfile-only)
+                if !this
+                    .options
+                    .do_
+                    .contains(crate::package_manager_real::options::Do::PREFETCH_RESOLVED_TARBALLS)
+                {
+                    break 'extract Some(ResolvedPackageResult {
+                        package,
+                        is_first_time: true,
+                        task: None,
+                    });
+                }
+
+                let task_id = Task::Id::for_npm_package(
+                    this.lockfile.str(&name),
+                    package.resolution.npm().version,
+                );
+                debug_assert!(!this.network_dedupe_map.contains(&task_id));
+
                 break 'extract Some(ResolvedPackageResult {
                     package,
                     is_first_time: true,
-                    task: None,
+                    task: Some(ResolvedPackageTask::NetworkTask(
+                        run_tasks::generate_network_task_for_tarball(
+                            this,
+                            task_id,
+                            interned(manifest.str(&find_result.package.tarball_url)),
+                            behavior.is_required(),
+                            dependency_id,
+                            &package,
+                            // its npm.
+                            crate::network_task::Authorization::AllowAuthorization,
+                        )?
+                        .expect("unreachable"),
+                    )),
                 });
             }
-
-            let task_id = Task::Id::for_npm_package(
-                this.lockfile.str(&name),
-                package.resolution.npm().version,
-            );
-            debug_assert!(!this.network_dedupe_map.contains(&task_id));
-
-            break 'extract Some(ResolvedPackageResult {
+            install::PreinstallState::CalcPatchHash => Some(ResolvedPackageResult {
                 package,
                 is_first_time: true,
-                task: Some(ResolvedPackageTask::NetworkTask(
-                    run_tasks::generate_network_task_for_tarball(
+                task: Some(ResolvedPackageTask::PatchTask(
+                    PatchTask::new_calc_patch_hash(
                         this,
-                        task_id,
-                        manifest.str(&find_result.package.tarball_url),
-                        behavior.is_required(),
-                        dependency_id,
-                        &package,
-                        name_and_version_hash,
-                        // its npm.
-                        crate::network_task::Authorization::AllowAuthorization,
-                    )?
-                    .expect("unreachable"),
+                        name_and_version_hash.unwrap(),
+                        Some(EnqueueAfterState {
+                            pkg_id: package.meta.id,
+                            dependency_id,
+                            url: Box::<[u8]>::from(manifest.str(&find_result.package.tarball_url)),
+                        }),
+                    ),
                 )),
-            });
-        }
-        install::PreinstallState::CalcPatchHash => Some(ResolvedPackageResult {
-            package,
-            is_first_time: true,
-            task: Some(ResolvedPackageTask::PatchTask(
-                PatchTask::new_calc_patch_hash(
-                    this,
-                    name_and_version_hash.unwrap(),
-                    Some(EnqueueAfterState {
-                        pkg_id: package.meta.id,
-                        dependency_id,
-                        url: Box::<[u8]>::from(manifest.str(&find_result.package.tarball_url)),
-                    }),
-                ),
-            )),
-        }),
-        install::PreinstallState::ApplyPatch => Some(ResolvedPackageResult {
-            package,
-            is_first_time: true,
-            task: Some(ResolvedPackageTask::PatchTask(
-                PatchTask::new_apply_patch_hash(
-                    this,
-                    package.meta.id,
-                    patchfile_hash.unwrap(),
-                    name_and_version_hash.unwrap(),
-                ),
-            )),
-        }),
-        _ => unreachable!(),
-    };
+            }),
+            install::PreinstallState::ApplyPatch => Some(ResolvedPackageResult {
+                package,
+                is_first_time: true,
+                task: Some(ResolvedPackageTask::PatchTask(
+                    PatchTask::new_apply_patch_hash(
+                        this,
+                        package.meta.id,
+                        patchfile_hash.unwrap(),
+                        name_and_version_hash.unwrap(),
+                    ),
+                )),
+            }),
+            _ => unreachable!(),
+        };
 
-    Ok(result)
-    // `guard` drops here → success_fn(this, dependency_id, package.meta.id)
+        Ok(result)
+    })();
+    success_fn(this, dependency_id, package.meta.id);
+    result
 }
 
 fn get_or_put_resolved_package(
@@ -2532,7 +2294,7 @@ fn get_or_put_resolved_package(
                         if resolution_satisfies_dependency(this, &existing_resolution, version) {
                             success_fn(this, dependency_id, existing_id);
                             return Ok(Some(ResolvedPackageResult {
-                                // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
+                                // we must fetch it from the packages array again, incase the package array mutates the value in the `success_fn`
                                 package: *this.lockfile.packages.get(existing_id as usize),
                                 ..Default::default()
                             }));
@@ -2548,7 +2310,7 @@ fn get_or_put_resolved_package(
                                 && ver_tag == dependency::version::Tag::Github)
                         {
                             let existing_package = this.lockfile.packages.get(existing_id as usize);
-                            this.log_mut().add_warning_fmt(
+                            this.log.add_warning_fmt(
                                 None,
                                 bun_ast::Loc::EMPTY,
                                 format_args!(
@@ -2564,7 +2326,7 @@ fn get_or_put_resolved_package(
                             );
                             success_fn(this, dependency_id, existing_id);
                             return Ok(Some(ResolvedPackageResult {
-                                // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
+                                // we must fetch it from the packages array again, incase the package array mutates the value in the `success_fn`
                                 package: *this.lockfile.packages.get(existing_id as usize),
                                 ..Default::default()
                             }));
@@ -2599,7 +2361,7 @@ fn get_or_put_resolved_package(
                             let existing_package_id = list[0];
                             let existing_package =
                                 this.lockfile.packages.get(existing_package_id as usize);
-                            this.log_mut().add_warning_fmt(
+                            this.log.add_warning_fmt(
                                 None,
                                 bun_ast::Loc::EMPTY,
                                 format_args!(
@@ -2615,7 +2377,7 @@ fn get_or_put_resolved_package(
                             );
                             success_fn(this, dependency_id, list[0]);
                             return Ok(Some(ResolvedPackageResult {
-                                // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
+                                // we must fetch it from the packages array again, incase the package array mutates the value in the `success_fn`
                                 package: *this.lockfile.packages.get(existing_package_id as usize),
                                 ..Default::default()
                             }));
@@ -2662,213 +2424,190 @@ fn get_or_put_resolved_package(
                 }
             }
 
-            // Resolve the version from the loaded NPM manifest
-            // reshaped for borrowck — `name_str`/`manifest` borrow
-            // `*this`; route through a raw root so the `&mut PackageManager`
-            // calls below can coexist.
-            // Snapshot the disk-fallback scalars *before* establishing
-            // `this_ptr`: `manifest_disk_cache_ctx` takes `&mut self`, and
-            // materializing `&mut *this_ptr` after `name_str`/`scope` are
-            // derived from it would pop their borrow-stack tags under SB.
+            // Resolve the version from the loaded NPM manifest. `manifest`
+            // is held across `&mut PackageManager` calls that never touch
+            // `manifests`, so take the map out for the duration.
             let cache_ctx = this.manifest_disk_cache_ctx();
             let needs_ext = this.options.minimum_release_age_ms.is_some();
-            let this_ptr: *mut PackageManager = this;
-            // SAFETY: `string_bytes` is not resized between here and the
-            // `find_result` lookup; `manifest` lives in `this.manifests` and
-            // is only read. Detach the slice lifetime so `name_str` does not
-            // borrow `*this`.
-            let name_str = this.lockfile.str_detached(&name);
-
-            let scope = bun_ptr::BackRef::new(
-                // SAFETY: `this_ptr` is the live exclusive `this` borrow; `options`
-                // is read-only here and disjoint from the `manifests` mutation below.
-                unsafe { &(*this_ptr).options }.scope_for_package_name(name_str),
-            );
-            // SAFETY: `manifests` projected from `this_ptr`; the lookup holds
-            // only that disjoint field borrow alongside the shared `options`
-            // / `lockfile` projections above. `scope` points into
-            // `(*this_ptr).options`, disjoint from `manifests`.
-            let Some(manifest) = (unsafe { &mut (*this_ptr).manifests }).by_name_hash(
-                cache_ctx,
-                scope.get(),
-                name_str,
-                name_hash,
-                needs_ext,
-            ) else {
-                return Ok(None); // manifest might still be downloading. This feels unreliable.
-            };
-            let manifest: &Npm::PackageManifest = manifest;
-
-            // `bun update -r/--filter --latest`: resolve targeted workspaces' npm deps by dist-tag `latest`.
-            let latest_for_target = !version_was_replaced
-                && matches!(
-                    version.tag,
-                    dependency::version::Tag::Npm | dependency::version::Tag::DistTag
-                )
-                && this.to_update
-                && this.update_requests.is_empty()
-                && this
-                    .options
-                    .do_
-                    .contains(crate::package_manager::options::Do::UPDATE_TO_LATEST)
-                && this.update_target_workspaces.as_deref().is_some_and(|t| {
-                    this.lockfile
-                        .is_dependency_of_workspace_in(t, dependency_id)
-                });
-
-            let version_result: Npm::FindVersionResult = match version.tag {
-                _ if latest_for_target => manifest.find_by_dist_tag_with_filter(
-                    b"latest",
-                    this.options.minimum_release_age_ms,
-                    this.options.minimum_release_age_excludes,
-                ),
-                // SAFETY: `version.tag` discriminates the union arm.
-                dependency::version::Tag::DistTag => manifest.find_by_dist_tag_with_filter(
-                    this.lockfile.str(&version.dist_tag().tag),
-                    this.options.minimum_release_age_ms,
-                    this.options.minimum_release_age_excludes,
-                ),
-                dependency::version::Tag::Npm => manifest.find_best_version_with_filter(
-                    &version.npm().version,
-                    this.lockfile.buffers.string_bytes.as_slice(),
-                    this.options.minimum_release_age_ms,
-                    this.options.minimum_release_age_excludes,
-                ),
-                _ => unreachable!(),
-            };
-
-            let find_result_opt: Option<Npm::FindResult> = match version_result {
-                Npm::FindVersionResult::Found(result) => Some(result),
-                Npm::FindVersionResult::FoundWithFilter {
-                    result,
-                    newest_filtered,
-                } => 'blk: {
-                    let package_name = this.lockfile.str(&name);
-                    if this.options.log_level.is_verbose() {
-                        if let Some(newest) = &newest_filtered {
-                            let min_age_seconds =
-                                this.options.minimum_release_age_ms.unwrap_or(0.0) / MS_PER_S;
-                            let manifest_buf: &[u8] = &manifest.string_buf;
-                            match version.tag {
-                                dependency::version::Tag::DistTag => {
-                                    // SAFETY: `version.tag == DistTag`.
-                                    let tag_str = this.lockfile.str(&version.dist_tag().tag);
-                                    bun_core::pretty_errorln!(
-                                        "<d>[minimum-release-age]<r> <b>{}@{}<r> selected <green>{}<r> instead of <yellow>{}<r> due to {}-second filter",
-                                        bstr::BStr::new(package_name),
-                                        bstr::BStr::new(tag_str),
-                                        result.version.fmt(manifest_buf),
-                                        newest.fmt(manifest_buf),
-                                        min_age_seconds,
-                                    );
-                                }
-                                dependency::version::Tag::Npm => {
-                                    // SAFETY: `version.tag == Npm`.
-                                    let version_str = &version.npm().version.fmt(manifest_buf);
-                                    bun_core::pretty_errorln!(
-                                        "<d>[minimum-release-age]<r> <b>{}<r>@{}<r> selected <green>{}<r> instead of <yellow>{}<r> due to {}-second filter",
-                                        bstr::BStr::new(package_name),
-                                        version_str,
-                                        result.version.fmt(manifest_buf),
-                                        newest.fmt(manifest_buf),
-                                        min_age_seconds,
-                                    );
-                                }
-                                _ => unreachable!(),
-                            }
-                        }
-                    }
-
-                    break 'blk Some(result);
-                }
-                Npm::FindVersionResult::Err(err_type) => match err_type {
-                    Npm::FindVersionError::TooRecent
-                    | Npm::FindVersionError::AllVersionsTooRecent => {
-                        return Err(crate::Error::TooRecentVersion);
-                    }
-                    Npm::FindVersionError::NotFound => None, // Handle below with existing logic
-                },
-            };
-
-            let find_result = match find_result_opt {
-                Some(r) => r,
-                None => {
-                    'resolve_workspace_from_dist_tag: {
-                        // choose a workspace for a dist_tag only if a version was not found
-                        if version.tag == dependency::version::Tag::DistTag {
-                            let workspace_path = if this.lockfile.workspace_paths.count() > 0 {
-                                this.lockfile.workspace_paths.get(&name_hash)
-                            } else {
-                                None
-                            };
-                            if workspace_path.is_some() {
-                                let Some(workspace_package_id) =
-                                    root_workspace_package_id(&this.lockfile, name_hash)
-                                else {
-                                    break 'resolve_workspace_from_dist_tag;
-                                };
-                                // make sure verifyResolutions sees this resolution as a valid package id
-                                success_fn(this, dependency_id, workspace_package_id);
-                                return Ok(Some(ResolvedPackageResult {
-                                    package: *this
-                                        .lockfile
-                                        .packages
-                                        .get(workspace_package_id as usize),
-                                    is_first_time: false,
-                                    task: None,
-                                }));
-                            }
-                        }
-                    }
-
-                    // `Ok(None)` in the peer pass makes the caller reload the manifest and retry.
-                    if behavior.is_peer() && !install_peer {
-                        return Ok(None);
-                    }
-
-                    return match version.tag {
-                        dependency::version::Tag::Npm => Err(crate::Error::NoMatchingVersion),
-                        dependency::version::Tag::DistTag => Err(crate::Error::DistTagNotFound),
-                        _ => unreachable!(),
-                    };
-                }
-            };
-
-            let find_result = if version_was_replaced {
-                find_result
-            } else {
-                let locked = if latest_for_target {
-                    locked_version_in_lockfile(this, name_hash, version)
-                } else {
-                    locked_version_of_invoking_workspace_row(
-                        this,
-                        dependency,
-                        dependency_id,
-                        version,
-                    )
+            let mut manifests = core::mem::take(&mut this.manifests);
+            let result = (|| -> crate::Result<Option<ResolvedPackageResult>> {
+                let this = &mut *this;
+                let Some(manifest) = manifests.by_name_hash(
+                    cache_ctx,
+                    this.options
+                        .scope_for_package_name(this.lockfile.str(&name)),
+                    this.lockfile.str(&name),
+                    name_hash,
+                    needs_ext,
+                ) else {
+                    return Ok(None); // manifest might still be downloading. This feels unreliable.
                 };
-                keep_locked_if_ahead(manifest, find_result, &locked)
-            };
+                let manifest: &Npm::PackageManifest = manifest;
 
-            // reshaped for borrowck — `manifest`/`find_result`
-            // borrow `this.manifests`; detach via `BackRef` so the `&mut *this`
-            // call can proceed (`this.manifests` is not mutated by the callee).
-            let manifest_ref: bun_ptr::BackRef<Npm::PackageManifest> =
-                bun_ptr::BackRef::new(manifest);
-            get_or_put_resolved_package_with_find_result(
-                // SAFETY: see `this_ptr` note above.
-                unsafe { &mut *this_ptr },
-                name_hash,
-                name,
-                dependency,
-                version,
-                dependency_id,
-                behavior,
-                manifest_ref.get(),
-                find_result,
-                install_peer,
-                success_fn,
-            )
+                // `bun update -r/--filter --latest`: resolve targeted workspaces' npm deps by dist-tag `latest`.
+                let latest_for_target = !version_was_replaced
+                    && matches!(
+                        version.tag,
+                        dependency::version::Tag::Npm | dependency::version::Tag::DistTag
+                    )
+                    && this.to_update
+                    && this.update_requests.is_empty()
+                    && this
+                        .options
+                        .do_
+                        .contains(crate::package_manager::options::Do::UPDATE_TO_LATEST)
+                    && this.update_target_workspaces.as_deref().is_some_and(|t| {
+                        this.lockfile
+                            .is_dependency_of_workspace_in(t, dependency_id)
+                    });
+
+                let version_result: Npm::FindVersionResult = match version.tag {
+                    _ if latest_for_target => manifest.find_by_dist_tag_with_filter(
+                        b"latest",
+                        this.options.minimum_release_age_ms,
+                        this.options.minimum_release_age_excludes,
+                    ),
+                    dependency::version::Tag::DistTag => manifest.find_by_dist_tag_with_filter(
+                        this.lockfile.str(&version.dist_tag().tag),
+                        this.options.minimum_release_age_ms,
+                        this.options.minimum_release_age_excludes,
+                    ),
+                    dependency::version::Tag::Npm => manifest.find_best_version_with_filter(
+                        &version.npm().version,
+                        this.lockfile.buffers.string_bytes.as_slice(),
+                        this.options.minimum_release_age_ms,
+                        this.options.minimum_release_age_excludes,
+                    ),
+                    _ => unreachable!(),
+                };
+
+                let find_result_opt: Option<Npm::FindResult> = match version_result {
+                    Npm::FindVersionResult::Found(result) => Some(result),
+                    Npm::FindVersionResult::FoundWithFilter {
+                        result,
+                        newest_filtered,
+                    } => 'blk: {
+                        let package_name = this.lockfile.str(&name);
+                        if this.options.log_level.is_verbose() {
+                            if let Some(newest) = &newest_filtered {
+                                let min_age_seconds =
+                                    this.options.minimum_release_age_ms.unwrap_or(0.0) / MS_PER_S;
+                                let manifest_buf: &[u8] = &manifest.string_buf;
+                                match version.tag {
+                                    dependency::version::Tag::DistTag => {
+                                        let tag_str = this.lockfile.str(&version.dist_tag().tag);
+                                        bun_core::pretty_errorln!(
+                                            "<d>[minimum-release-age]<r> <b>{}@{}<r> selected <green>{}<r> instead of <yellow>{}<r> due to {}-second filter",
+                                            bstr::BStr::new(package_name),
+                                            bstr::BStr::new(tag_str),
+                                            result.version.fmt(manifest_buf),
+                                            newest.fmt(manifest_buf),
+                                            min_age_seconds,
+                                        );
+                                    }
+                                    dependency::version::Tag::Npm => {
+                                        let version_str = &version.npm().version.fmt(manifest_buf);
+                                        bun_core::pretty_errorln!(
+                                            "<d>[minimum-release-age]<r> <b>{}<r>@{}<r> selected <green>{}<r> instead of <yellow>{}<r> due to {}-second filter",
+                                            bstr::BStr::new(package_name),
+                                            version_str,
+                                            result.version.fmt(manifest_buf),
+                                            newest.fmt(manifest_buf),
+                                            min_age_seconds,
+                                        );
+                                    }
+                                    _ => unreachable!(),
+                                }
+                            }
+                        }
+
+                        break 'blk Some(result);
+                    }
+                    Npm::FindVersionResult::Err(err_type) => match err_type {
+                        Npm::FindVersionError::TooRecent
+                        | Npm::FindVersionError::AllVersionsTooRecent => {
+                            return Err(crate::Error::TooRecentVersion);
+                        }
+                        Npm::FindVersionError::NotFound => None, // Handle below with existing logic
+                    },
+                };
+
+                let find_result = match find_result_opt {
+                    Some(r) => r,
+                    None => {
+                        'resolve_workspace_from_dist_tag: {
+                            // choose a workspace for a dist_tag only if a version was not found
+                            if version.tag == dependency::version::Tag::DistTag {
+                                let workspace_path = if this.lockfile.workspace_paths.count() > 0 {
+                                    this.lockfile.workspace_paths.get(&name_hash)
+                                } else {
+                                    None
+                                };
+                                if workspace_path.is_some() {
+                                    let Some(workspace_package_id) =
+                                        root_workspace_package_id(&this.lockfile, name_hash)
+                                    else {
+                                        break 'resolve_workspace_from_dist_tag;
+                                    };
+                                    // make sure verify_resolutions sees this resolution as a valid package id
+                                    success_fn(this, dependency_id, workspace_package_id);
+                                    return Ok(Some(ResolvedPackageResult {
+                                        package: *this
+                                            .lockfile
+                                            .packages
+                                            .get(workspace_package_id as usize),
+                                        is_first_time: false,
+                                        task: None,
+                                    }));
+                                }
+                            }
+                        }
+
+                        // `Ok(None)` in the peer pass makes the caller reload the manifest and retry.
+                        if behavior.is_peer() && !install_peer {
+                            return Ok(None);
+                        }
+
+                        return match version.tag {
+                            dependency::version::Tag::Npm => Err(crate::Error::NoMatchingVersion),
+                            dependency::version::Tag::DistTag => Err(crate::Error::DistTagNotFound),
+                            _ => unreachable!(),
+                        };
+                    }
+                };
+
+                let find_result = if version_was_replaced {
+                    find_result
+                } else {
+                    let locked = if latest_for_target {
+                        locked_version_in_lockfile(this, name_hash, version)
+                    } else {
+                        locked_version_of_invoking_workspace_row(
+                            this,
+                            dependency,
+                            dependency_id,
+                            version,
+                        )
+                    };
+                    keep_locked_if_ahead(manifest, find_result, &locked)
+                };
+
+                get_or_put_resolved_package_with_find_result(
+                    this,
+                    name_hash,
+                    name,
+                    dependency,
+                    version,
+                    dependency_id,
+                    behavior,
+                    manifest,
+                    find_result,
+                    install_peer,
+                    success_fn,
+                )
+            })();
+            this.manifests = manifests;
+            result
         }
 
         dependency::version::Tag::Folder => {
@@ -2876,29 +2615,8 @@ fn get_or_put_resolved_package(
             let res: FolderResolutionValue = 'res: {
                 if this.lockfile.is_workspace_dependency(dependency_id) {
                     // relative to cwd
-                    // reshaped for borrowck — `folder_path` borrows
-                    // `string_bytes`; detach the slice lifetime so the
-                    // `&mut PackageManager` reborrow for `get_or_put` below
-                    // does not conflict.
-                    // SAFETY: `get_or_put` copies `folder_path_abs` into the
-                    // lockfile string buffer before any other mutation.
-                    let folder_path = this.lockfile.str_detached(&folder);
                     let mut buf2 = bun_paths::path_buffer_pool::get();
-                    let folder_path_abs = if bun_paths::is_absolute(folder_path) {
-                        folder_path
-                    } else {
-                        Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
-                            FileSystem::instance().top_level_dir(),
-                            &mut buf2,
-                            &[folder_path],
-                        )
-                        // break :blk Path.joinAbsStringBuf(
-                        //     strings.withoutSuffixComptime(this.original_package_json_path, "package.json"),
-                        //     &buf2,
-                        //     &[_]string{folder_path},
-                        //     .auto,
-                        // );
-                    };
+                    let folder_path_abs = abs_from_top_level(this.lockfile.str(&folder), &mut buf2);
 
                     break 'res FolderResolution::get_or_put(
                         GlobalOrRelative::Relative(dependency::version::Tag::Folder),
@@ -2983,30 +2701,15 @@ fn get_or_put_resolved_package(
                 }
             }
             // package name hash should be used to find workspace path from map
-            // SAFETY: `version.tag == Workspace` discriminates the union arm.
             let workspace_path_raw: SemverString = this
                 .lockfile
                 .workspace_paths
                 .get(&name_hash)
                 .copied()
                 .unwrap_or_else(|| *version.workspace());
-            // reshaped for borrowck — `workspace_path` may borrow
-            // `string_bytes`; detach the slice lifetime so the
-            // `&mut PackageManager` reborrow for `get_or_put` below does not
-            // conflict.
-            // SAFETY: `get_or_put` copies `workspace_path_u8` into the
-            // lockfile string buffer before any other mutation.
-            let workspace_path = this.lockfile.str_detached(&workspace_path_raw);
             let mut buf2 = bun_paths::path_buffer_pool::get();
-            let workspace_path_u8 = if bun_paths::is_absolute(workspace_path) {
-                workspace_path
-            } else {
-                Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
-                    FileSystem::instance().top_level_dir(),
-                    &mut buf2,
-                    &[workspace_path],
-                )
-            };
+            let workspace_path_u8 =
+                abs_from_top_level(this.lockfile.str(&workspace_path_raw), &mut buf2);
 
             let res = FolderResolution::get_or_put(
                 GlobalOrRelative::Relative(dependency::version::Tag::Workspace),
@@ -3018,18 +2721,10 @@ fn get_or_put_resolved_package(
             resolved_folder_package(this, res, dependency_id, success_fn)
         }
         dependency::version::Tag::Symlink => {
-            // reshaped for borrowck — `link_dir` / `symlink_path`
-            // borrow into `*this`; detach their lifetimes so the
-            // `&mut PackageManager` reborrow for `get_or_put` does not
-            // conflict.
-            // SAFETY: `global_link_dir_path` returns a slice into the lazily-
-            // initialized `PackageManager.global_link_dir_path` (a `Box<[u8]>`
-            // set once and never freed); `get_or_put` copies `symlink_path`
-            // into the lockfile string buffer before any other mutation.
-            // `version.tag == Symlink`.
-            let link_dir =
-                unsafe { detach_lifetime(package_manager_real::global_link_dir_path(this)) };
-            let symlink_path = this.lockfile.str_detached(version.symlink());
+            let mut buf = bun_paths::path_buffer_pool::get();
+            let mut buf2 = bun_paths::path_buffer_pool::get();
+            let link_dir = copy_into(package_manager_real::global_link_dir_path(this), &mut buf);
+            let symlink_path = copy_into(this.lockfile.str(version.symlink()), &mut buf2);
             let res = FolderResolution::get_or_put(
                 GlobalOrRelative::Global(link_dir),
                 version,
@@ -3041,6 +2736,25 @@ fn get_or_put_resolved_package(
         }
 
         _ => Ok(None),
+    }
+}
+
+/// `path` copied into `buf`, so it no longer borrows its source.
+fn copy_into<'b>(path: &[u8], buf: &'b mut bun_paths::PathBuffer) -> &'b [u8] {
+    buf[..path.len()].copy_from_slice(path);
+    &buf[..path.len()]
+}
+
+/// `path` made absolute against the top-level directory, into `buf`.
+fn abs_from_top_level<'b>(path: &[u8], buf: &'b mut bun_paths::PathBuffer) -> &'b [u8] {
+    if bun_paths::is_absolute(path) {
+        copy_into(path, buf)
+    } else {
+        Path::resolve_path::join_abs_string_buf::<Path::platform::Auto>(
+            FileSystem::instance().top_level_dir(),
+            buf,
+            &[path],
+        )
     }
 }
 
@@ -3175,7 +2889,7 @@ fn patched_package_satisfying(
 // `impl PackageManager` — inherent-method facade over the free fns above.
 //
 // Sibling files (PackageManagerLifecycle, …Directories,
-// runTasks) all expose an `impl PackageManager` block. Match that
+// run_tasks) all expose an `impl PackageManager` block. Match that
 // pattern here so cross-file callers can keep the `.method()` shape.
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -3190,18 +2904,10 @@ impl PackageManager {
         &mut self,
         dependency_id: DependencyID,
         package_id: PackageID,
-        url: &[u8],
+        url: StringOrTinyString,
         task_context: TaskCallbackContext,
-        patch_name_and_version_hash: Option<u64>,
     ) -> Result<(), EnqueueTarballForDownloadError> {
-        enqueue_tarball_for_download(
-            self,
-            dependency_id,
-            package_id,
-            url,
-            task_context,
-            patch_name_and_version_hash,
-        )
+        enqueue_tarball_for_download(self, dependency_id, package_id, url, task_context)
     }
 
     #[inline]
@@ -3209,7 +2915,7 @@ impl PackageManager {
         &mut self,
         dependency_id: DependencyID,
         package_id: PackageID,
-        alias: &[u8],
+        alias: Semver::String,
         resolution: &Resolution,
         task_context: TaskCallbackContext,
     ) {
@@ -3227,7 +2933,7 @@ impl PackageManager {
     pub(crate) fn enqueue_git_for_checkout(
         &mut self,
         dependency_id: DependencyID,
-        alias: &[u8],
+        alias: Semver::String,
         resolution: &Resolution,
         task_context: TaskCallbackContext,
         patch_name_and_version_hash: Option<u64>,
@@ -3245,13 +2951,12 @@ impl PackageManager {
     #[inline]
     pub(crate) fn enqueue_package_for_download(
         &mut self,
-        name: &[u8],
+        name: Semver::String,
         dependency_id: DependencyID,
         package_id: PackageID,
         version: Semver::Version,
-        url: &[u8],
+        url: Semver::String,
         task_context: TaskCallbackContext,
-        patch_name_and_version_hash: Option<u64>,
     ) -> Result<(), EnqueuePackageForDownloadError> {
         enqueue_package_for_download(
             self,
@@ -3261,7 +2966,6 @@ impl PackageManager {
             version,
             url,
             task_context,
-            patch_name_and_version_hash,
         )
     }
 }

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -16,11 +16,9 @@ use bun_sys as Syscall;
 use crate::bun_fs::FileSystem;
 
 use super::directories;
-use crate::lifecycle_script_runner::{
-    InstallCtx, LifecycleScriptSubprocess as RealLifecycleScriptSubprocess,
-};
+use crate::lifecycle_script_runner::LifecycleScriptSubprocess as RealLifecycleScriptSubprocess;
 use crate::lockfile_real::package::scripts::List as ScriptsList;
-use crate::package_manager_real::Command;
+use crate::package_manager_real::run_tasks;
 use crate::resolution_real::Tag as ResolutionTag;
 use bun_install::lockfile::{Lockfile, Package};
 use bun_install::{PackageID, PackageManager, PreinstallState, invalid_package_id};
@@ -31,17 +29,14 @@ impl PackageManager {
             return;
         }
 
-        let offset = self.preinstall_state.len();
         self.preinstall_state
             .reserve(count.saturating_sub(self.preinstall_state.len()));
-        // expandToCapacity + @memset(.., .unknown)
         self.preinstall_state
             .resize(self.preinstall_state.capacity(), PreinstallState::Unknown);
-        let _ = offset; // resize already fills [offset..] with Unknown
     }
 
     /// A separate `lockfile` parameter would only feed `lockfile.packages.len` into
-    /// `ensurePreinstallStateListCapacity`. Every caller passes
+    /// `ensure_preinstall_state_list_capacity`. Every caller passes
     /// `self.lockfile` (or an alias of it), which would alias `&mut self`;
     /// `self.lockfile` is read directly instead to keep
     /// borrowck happy.
@@ -114,18 +109,17 @@ impl PackageManager {
                     break 'brk Some(patched_dep.patchfile_hash().unwrap());
                 };
 
-                // SAFETY: each arm reads the union variant that matches the
-                // `pkg.resolution.tag` just dispatched on; `Resolution` is
-                // zero-initialised (`Value::zero()`) so even a stale tag yields
-                // POD bytes, never uninit.
+                let mut folder_path_buf = bun_paths::path_buffer_pool::get();
                 let folder_path: &ZStr = match pkg.resolution.tag {
                     ResolutionTag::Git => directories::cached_git_folder_name_print_auto(
                         self,
+                        &mut folder_path_buf,
                         pkg.resolution.git(),
                         patch_hash,
                     ),
                     ResolutionTag::Github => directories::cached_github_folder_name_print_auto(
                         self,
+                        &mut folder_path_buf,
                         pkg.resolution.github(),
                         patch_hash,
                     ),
@@ -135,6 +129,7 @@ impl PackageManager {
                             .slice(self.lockfile.buffers.string_bytes.as_slice());
                         directories::cached_npm_package_folder_name(
                             self,
+                            &mut folder_path_buf,
                             name,
                             pkg.resolution.npm().version,
                             patch_hash,
@@ -142,11 +137,13 @@ impl PackageManager {
                     }
                     ResolutionTag::LocalTarball => directories::cached_tarball_folder_name(
                         self,
+                        &mut folder_path_buf,
                         *pkg.resolution.local_tarball(),
                         patch_hash,
                     ),
                     ResolutionTag::RemoteTarball => directories::cached_tarball_folder_name(
                         self,
+                        &mut folder_path_buf,
                         *pkg.resolution.remote_tarball(),
                         patch_hash,
                     ),
@@ -209,33 +206,18 @@ impl PackageManager {
         self.pending_lifecycle_script_tasks.load(Ordering::Relaxed) == 0
     }
 
-    pub(crate) fn tick_lifecycle_scripts(&mut self) {
-        // reshaped for borrowck — `self.event_loop.tick_once(self)`
-        // would borrow `self` twice. Erase `self` to a raw context pointer
-        // first; `tick_once` only forwards it opaquely to task callbacks.
-        let ctx = std::ptr::from_mut::<PackageManager>(self).cast::<core::ffi::c_void>();
-        self.event_loop.tick_once(ctx);
+    /// Run event-loop callbacks once without blocking, then finish any
+    /// lifecycle scripts that completed.
+    pub(crate) fn tick_lifecycle_scripts<C: run_tasks::RunTasksCtx + ?Sized>(ctx: &mut C) {
+        // See `sleep_until`: a script reaped while spawning has no loop event.
+        Self::drain_lifecycle_scripts(ctx);
+        ctx.manager().event_loop.tick_once(core::ptr::null_mut());
+        Self::drain_lifecycle_scripts(ctx);
     }
 
     pub fn sleep(&mut self) {
         self.report_slow_lifecycle_scripts();
-        Output::flush();
-        // see `tick_lifecycle_scripts` — `is_done` callback reborrows
-        // `self` (the struct that owns `event_loop`), so use the raw-pointer
-        // `tick_raw` variant which only holds `&mut event_loop` between
-        // `is_done` calls.
-        let ctx = std::ptr::from_mut::<PackageManager>(self).cast::<core::ffi::c_void>();
-        let event_loop = core::ptr::addr_of_mut!(self.event_loop);
-        // SAFETY: `event_loop` is valid for the duration; `is_done` reborrows
-        // `*ctx` only while no `&mut event_loop` is live (per `tick_raw` contract).
-        unsafe {
-            bun_event_loop::AnyEventLoop::tick_raw(event_loop, ctx, |ctx| {
-                // SAFETY: `ctx` is the `*mut PackageManager` erased above; live
-                // for the duration of `sleep`.
-                let this = bun_ptr::callback_ctx::<PackageManager>(ctx);
-                this.has_no_more_pending_lifecycle_scripts()
-            });
-        }
+        PackageManager::sleep_until(self, |this| this.has_no_more_pending_lifecycle_scripts());
     }
 
     pub(crate) fn report_slow_lifecycle_scripts(&mut self) {
@@ -250,8 +232,7 @@ impl PackageManager {
             return;
         }
 
-        let longest_running = self.active_lifecycle_scripts.peek();
-        if longest_running.is_null() {
+        if self.active_lifecycle_scripts.is_empty() {
             return;
         }
         if self.cached_tick_for_slow_lifecycle_script_logging == self.event_loop.iteration_number()
@@ -259,12 +240,13 @@ impl PackageManager {
             return;
         }
         self.cached_tick_for_slow_lifecycle_script_logging = self.event_loop.iteration_number();
-        // SAFETY: `peek()` returned a non-null intrusive heap node owned by
-        // `active_lifecycle_scripts`; only read for its `started_at` /
-        // `package_name` fields below.
-        let longest_running = unsafe { &*longest_running };
+        let longest_running = &**self
+            .active_lifecycle_scripts
+            .iter()
+            .min_by_key(|script| script.started_at.get())
+            .expect("non-empty");
         let current_time = bun_core::Timespec::now_allow_mocked_time().ns();
-        let time_running = current_time.saturating_sub(longest_running.started_at);
+        let time_running = current_time.saturating_sub(longest_running.started_at.get());
         const NS_PER_S: u64 = 1_000_000_000;
         let interval: u64 = if log_level.is_verbose() {
             NS_PER_S * 5
@@ -301,12 +283,11 @@ impl PackageManager {
         );
 
         let buf = self.lockfile.buffers.string_bytes.as_slice();
-        // need to clone because this is a copy before Lockfile.cleanWithLogger
+        // need to clone because this is a copy before Lockfile::clean_with_logger
         let name = root_package.name.slice(buf);
 
         // `AutoAbsPath` is the SEP=auto alias.
         let mut top_level_dir = AutoAbsPath::init_top_level_dir();
-        // `defer top_level_dir.deinit()` — handled by Drop
 
         if root_package.scripts.has_any() {
             let add_node_gyp_rebuild_script = root_package.scripts.install.is_empty()
@@ -338,11 +319,10 @@ impl PackageManager {
     /// TODO: re-evaluate whether some variables still need to be atomic
     pub fn spawn_package_lifecycle_scripts(
         &mut self,
-        ctx: Command::Context<'_>,
         list: ScriptsList,
         optional: bool,
         foreground: bool,
-        install_ctx: Option<InstallCtx<'_>>,
+        entry_id: Option<crate::isolated_install::store::entry::Id>,
     ) -> Result<(), crate::Error> {
         let log_level = self.options.log_level;
         let mut any_scripts = false;
@@ -362,21 +342,16 @@ impl PackageManager {
         // `cwd` out so the PATH builder can borrow it independently.
         let cwd_owned: Vec<u8> = list.cwd.as_bytes().to_vec();
         let cwd: &[u8] = &cwd_owned;
-        let this_transpiler = self.configure_env_for_scripts(ctx, log_level)?;
-
-        let env_loader = this_transpiler.env_mut();
+        let env_loader = self.configure_env_for_scripts()?;
         let mut script_env = env_loader.map.clone_with_allocator()?;
-        // `defer script_env.map.deinit()` — handled by Drop
 
         // `script_env.put` below needs `&mut`; copy PATH out so the
         // shared borrow does not span it.
         let original_path: Vec<u8> = script_env.get(b"PATH").unwrap_or(b"").to_vec();
 
-        // `EnvPathOptions` is currently fieldless.
         let mut path = EnvPath::init_capacity(
             original_path.len() + 1 + b"node_modules/.bin".len() + cwd.len() + 1,
         )?;
-        // `defer PATH.deinit()` — handled by Drop
 
         let mut parent: Option<&[u8]> = Some(cwd);
 
@@ -423,14 +398,7 @@ impl PackageManager {
         };
 
         RealLifecycleScriptSubprocess::spawn_package_scripts(
-            self,
-            list,
-            envp,
-            shell_bin,
-            optional,
-            log_level,
-            foreground,
-            install_ctx,
+            self, list, envp, shell_bin, optional, log_level, foreground, entry_id,
         )?;
         Ok(())
     }

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -21,9 +21,8 @@ pub enum OfflineMode {
     Offline,
 }
 
-// `string` fields are `[]const u8` borrowed from CLI args / bunfig config,
-// which live for the process lifetime. There is no `deinit` on Options. Mapped to
-// `&'static [u8]` per PORTING.md (no lifetime params on structs).
+// The `&'static [u8]` fields borrow CLI args / bunfig config, which live for
+// the process lifetime.
 
 pub struct Options {
     pub log_level: LogLevel,
@@ -205,7 +204,6 @@ pub enum Access {
 }
 
 impl Access {
-    // was `bun.ComptimeEnumMap(Access)`; ≤8 entries → plain match on &[u8].
     pub fn from_str(str: &[u8]) -> Option<Access> {
         match str {
             b"public" => Some(Access::Public),
@@ -232,7 +230,6 @@ pub enum AuthType {
 }
 
 impl AuthType {
-    // was `bun.ComptimeEnumMap(AuthType)`; ≤8 entries → plain match on &[u8].
     pub(crate) fn from_str(str: &[u8]) -> Option<AuthType> {
         match str {
             b"legacy" => Some(AuthType::Legacy),
@@ -820,7 +817,6 @@ impl Options {
                 log.level = bun_ast::Level::Err;
                 bun_ast::DEFAULT_LOG_LEVEL.store(bun_ast::Level::Err);
             }
-            // SAFETY: main-thread CLI option load — single writer.
             super::PackageManager::set_verbose_install(cli.log_level.is_verbose());
 
             if cli.no_verify {
@@ -921,7 +917,6 @@ impl Options {
             } else {
                 LogLevel::Default
             };
-            // SAFETY: main-thread CLI option load — single writer.
             super::PackageManager::set_verbose_install(false);
         }
 
@@ -931,7 +926,6 @@ impl Options {
             self.enable.set(Enable::FORCE_SAVE_LOCKFILE, false);
         }
 
-        // moved from `defer { ... }` after scope assignment (see note above).
         self.did_override_default_scope = self.scope.url_hash != *Npm::registry::DEFAULT_URL_HASH;
 
         // The manifest cache is the data source for --prefer-offline/--offline; keep it on

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -43,7 +43,7 @@ pub fn assign_root_resolution(
 
 impl PackageManager {
     pub(crate) fn format_later_version_in_cache(
-        &mut self,
+        &self,
         package_name: &[u8],
         name_hash: PackageNameHash,
         resolution: &Resolution,
@@ -56,16 +56,7 @@ impl PackageManager {
                     return None;
                 }
 
-                // reshaped for borrowck —
-                // `this.manifests.byNameHash(this, …, .load_from_memory, …)`
-                // would require simultaneous `&mut self.manifests`
-                // (receiver) and `&mut self` (arg). The memory-only path touches
-                // nothing on `PackageManager` besides the map, so use the
-                // disjoint-borrow helper and read `self.options` / `self.lockfile`
-                // alongside the held `&mut self.manifests` field borrow.
-                let manifest = self
-                    .manifests
-                    .by_name_hash_in_memory(package_name, name_hash)?;
+                let manifest = self.manifests.in_memory(package_name, name_hash)?;
 
                 if let Some(latest_version) = manifest
                     .find_by_dist_tag_with_filter(
@@ -250,7 +241,6 @@ impl PackageManager {
     }
 
     pub(crate) fn assign_resolution(&mut self, dependency_id: DependencyID, package_id: PackageID) {
-        // reshaped for borrowck — capture lengths before mutable borrows.
         debug_assert!(
             (dependency_id as usize) < self.lockfile.buffers.resolutions.as_slice().len()
         );
@@ -273,7 +263,6 @@ impl PackageManager {
         dependency_id: DependencyID,
         package_id: PackageID,
     ) {
-        // reshaped for borrowck — capture lengths before mutable borrows.
         debug_assert!(
             (dependency_id as usize) < self.lockfile.buffers.resolutions.as_slice().len()
         );

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -2,17 +2,16 @@ use crate::lockfile::package::PackageColumns as _;
 use bun_collections::HashMap;
 use bun_core::Output;
 
-use crate::DependencyID;
 use crate::NetworkTask;
 use crate::PackageID;
-use crate::Resolution;
 use crate::invalid_package_id;
+use crate::lockfile::Lockfile;
 // Import the
 // *module* under the `Task` name so `Task::Id` resolves as a path (matches
-// `runTasks.rs` / `PackageManagerEnqueue.rs`).
+// `run_tasks.rs` / `PackageManagerEnqueue.rs`).
 use super::PackageManager;
 use super::enqueue;
-use super::run_tasks::{self, RunTasksCallbacks};
+use super::run_tasks;
 use crate::package_manager_task as Task;
 use crate::resolution::Tag as ResolutionTag;
 
@@ -60,304 +59,214 @@ fn start_manifest_task(
         manager.start_progress_bar_if_none();
     }
 
-    // reshaped for borrowck — `get_network_task()`
-    // borrows `&mut manager.preallocated_network_tasks`, so compute everything
-    // that needs `&manager` *before* taking that borrow, then populate the pool
-    // slot through a raw pointer (matches `runTasks::generate_network_task_for_tarball`).
-    let scope = bun_ptr::BackRef::new(manager.scope_for_package_name(pkg_name));
-    // Backref address only — stored, not dereffed in this function.
-    let manager_backref: *mut PackageManager = manager;
+    let mut task = NetworkTask::new(task_id, manager);
+    {
+        let PackageManager {
+            log, env, options, ..
+        } = &mut *manager;
+        let scope = options.scope_for_package_name(pkg_name);
+        task.for_manifest(
+            log,
+            env.get(),
+            pkg_name,
+            scope,
+            None,
+            !is_required,
+            needs_extended_manifest,
+        )?;
+    }
 
-    // Take the pool slot as a raw pointer so borrowck releases `manager` for the
-    // `enqueue_network_task` tail.
-    let net_ptr: *mut NetworkTask = run_tasks::get_network_task(manager);
-    // `write_init` is a full struct overwrite that resets every other field to
-    // its struct default. The slot may be uninitialized (heap fallback) or
-    // stale (reused hive slot).
-    // SAFETY: `net_ptr` is the unique handle to a freshly-vended pool slot; no
-    // other alias exists until we hand it to `enqueue_network_task`.
-    unsafe { NetworkTask::write_init(net_ptr, task_id, manager_backref, None) };
-    // SAFETY: `write_init` populated every field with a drop-safe value;
-    // `unsafe_http_client` is `MaybeUninit` and overwritten by `for_manifest`.
-    let task = unsafe { &mut *net_ptr };
-    // `scope` points into `manager.options` which is not mutated by
-    // `for_manifest` (it only writes the pool slot and `manager.log`).
-    task.for_manifest(
-        pkg_name,
-        scope.get(),
-        None,
-        !is_required,
-        needs_extended_manifest,
-    )?;
-
-    enqueue::enqueue_network_task(manager, net_ptr);
+    enqueue::enqueue_network_task(manager, task);
     Ok(())
 }
 
 #[derive(Clone, Copy)]
 pub enum Packages<'a> {
-    /// Every npm package in the lockfile; best-effort (the post-migration backfill), so failures are warnings.
-    All,
+    /// Every npm package in this lockfile (the one a migration is building,
+    /// not yet `manager.lockfile`); best-effort backfill, so failures are warnings.
+    All(&'a Lockfile),
     /// The direct dependencies of these workspace packages; a required one failing is an error, see [`print_fetch_failures`].
     Ids(&'a [PackageID]),
     /// The manifests of these packages themselves (by name), not of their dependencies; best-effort, so failures are warnings.
     Exact(&'a [PackageID]),
 }
 
-/// `RunTasksCallbacks` impl for the void-callback `runTasks` call in
-/// `populateManifestCache`.
-struct ManifestsOnlyCallbacks;
-impl RunTasksCallbacks for ManifestsOnlyCallbacks {
-    type Ctx = ();
-    const PROGRESS_BAR: bool = true;
-    const MANIFESTS_ONLY: bool = true;
+/// `RunTasksCtx` for the hook-less `run_tasks` call in
+/// `populate_manifest_cache`.
+struct ManifestsOnlyCtx<'a>(&'a mut PackageManager);
+impl run_tasks::RunTasksCtx for ManifestsOnlyCtx<'_> {
+    fn manager(&mut self) -> &mut PackageManager {
+        self.0
+    }
+    fn progress_bar(&self) -> bool {
+        true
+    }
+    fn manifests_only(&self) -> bool {
+        true
+    }
 }
 
-/// Populate the manifest cache for packages included from `root_pkg_ids`. Only manifests of
-/// direct dependencies of the `root_pkg_ids` are populated. If `root_pkg_ids` has length 0
-/// all packages in the lockfile will have their manifests fetched if necessary.
+/// An npm package whose manifest may need fetching: its name copied out of the
+/// lockfile string buffer so the manager can be mutated while it is in use.
+struct ManifestCandidate {
+    name: NameBuf,
+    is_required: bool,
+}
+
+/// npm package names are at most 214 bytes; anything longer cannot have come
+/// from a registry and is fetched with a heap copy instead.
+#[allow(clippy::large_enum_variant)] // the inline buffer is the point
+enum NameBuf {
+    Inline { buf: [u8; 214], len: u8 },
+    Heap(Box<[u8]>),
+}
+
+impl NameBuf {
+    fn new(name: &[u8]) -> NameBuf {
+        if name.len() <= 214 {
+            let mut buf = [0u8; 214];
+            buf[..name.len()].copy_from_slice(name);
+            NameBuf::Inline {
+                buf,
+                len: name.len() as u8,
+            }
+        } else {
+            NameBuf::Heap(Box::from(name))
+        }
+    }
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            NameBuf::Inline { buf, len } => &buf[..*len as usize],
+            NameBuf::Heap(b) => b,
+        }
+    }
+}
+
+fn npm_candidate(
+    lockfile: &Lockfile,
+    pkg_id: PackageID,
+    is_required: bool,
+) -> Option<ManifestCandidate> {
+    if lockfile.packages.items_resolution()[pkg_id as usize].tag != ResolutionTag::Npm {
+        return None;
+    }
+    let name = lockfile.packages.items_name()[pkg_id as usize]
+        .slice(lockfile.buffers.string_bytes.as_slice());
+    Some(ManifestCandidate {
+        name: NameBuf::new(name),
+        is_required,
+    })
+}
+
+fn fetch_manifest_if_uncached(
+    manager: &mut PackageManager,
+    candidate: &ManifestCandidate,
+) -> crate::Result<()> {
+    let cache_ctx = manager.manifest_disk_cache_ctx();
+    let name = candidate.name.as_slice();
+    let needs_extended_manifest = manager.options.minimum_release_age_ms.is_some();
+    let scope = manager.options.scope_for_package_name(name);
+    let cached = manager
+        .manifests
+        .by_name(cache_ctx, scope, name, needs_extended_manifest);
+    if cached.is_none() {
+        start_manifest_task(
+            manager,
+            name,
+            candidate.is_required,
+            needs_extended_manifest,
+        )?;
+        run_tasks::flush_network_queue(manager);
+        let _ = run_tasks::schedule_tasks(manager);
+    }
+    Ok(())
+}
+
+/// Populate the manifest cache for the packages `packages` selects (see
+/// [`Packages`]).
 pub fn populate_manifest_cache(
     manager: &mut PackageManager,
     packages: Packages<'_>,
 ) -> crate::Result<()> {
     let log_level = manager.options.log_level;
 
-    // heavy borrowck overlap — slices into
-    // `manager.lockfile` are held while the loop body calls `&mut`-taking methods on
-    // `manager`. The lockfile lives in `Box<Lockfile>` (stable address) and is
-    // not resized by anything below, so derive the slices through a raw
-    // provenance root and reborrow `manager` per-call.
-    let cache_ctx = manager.manifest_disk_cache_ctx();
-    let manager_ptr: *mut PackageManager = manager;
-    // BACKREF wrapper over the same provenance root for the read-only
-    // `options` projections in the loop body — collapses four per-site raw
-    // `(*manager_ptr).options` derefs into safe `Deref` through
-    // `ParentRef::get()`. Mutation (`manifests`, whole-`&mut PackageManager`)
-    // still goes through `manager_ptr` directly. Safe `From<NonNull>`
-    // construction — `manager_ptr` was just derived from `&mut *manager`.
-    let mgr_ref = bun_ptr::ParentRef::<PackageManager>::from(
-        core::ptr::NonNull::new(manager_ptr).expect("derived from &mut, non-null"),
-    );
-    // SAFETY: `manager_ptr` is the live exclusive borrow's address; we only
-    // take *shared* projections of `lockfile` here, and the loop body never
-    // mutates `lockfile.buffers` / `lockfile.packages`.
-    let lockfile = unsafe { &*core::ptr::addr_of!((*manager_ptr).lockfile) };
-    let resolutions = lockfile.buffers.resolutions.as_slice();
-    let dependencies = lockfile.buffers.dependencies.as_slice();
-    let string_buf = lockfile.buffers.string_bytes.as_slice();
-    let pkgs = lockfile.packages.slice();
-    let pkg_resolutions = pkgs.items_resolution();
-    let pkg_names = pkgs.items_name();
-    let pkg_dependencies = pkgs.items_dependencies();
-
     match packages {
-        Packages::All => {
+        Packages::All(lockfile) => {
             let mut seen_pkg_ids: HashMap<PackageID, ()> = HashMap::new();
 
-            for _dep_id in 0..dependencies.len() {
-                let dep_id: DependencyID = DependencyID::try_from(_dep_id).expect("int cast");
-
-                let pkg_id = resolutions[dep_id as usize];
+            for dep_id in 0..lockfile.buffers.dependencies.len() {
+                let pkg_id = lockfile.buffers.resolutions[dep_id];
                 if pkg_id == invalid_package_id {
                     continue;
                 }
 
-                // `getOrPut(pkg_id).found_existing` — value is `void`, so this is a set insert.
                 if seen_pkg_ids.insert(pkg_id, ()).is_some() {
                     continue;
                 }
 
-                let res = &pkg_resolutions[pkg_id as usize];
-                if res.tag != ResolutionTag::Npm {
+                let Some(candidate) = npm_candidate(lockfile, pkg_id, false) else {
                     continue;
-                }
-
-                let pkg_name = pkg_names[pkg_id as usize];
-                let pkg_name_slice = pkg_name.slice(string_buf);
-                // `options` is not mutated between here and the
-                // `start_manifest_task` call — read via the BACKREF `mgr_ref`.
-                let needs_extended_manifest = mgr_ref.options.minimum_release_age_ms.is_some();
-
-                // `scope_for_package_name` borrows only `options` (via the
-                // BACKREF `mgr_ref`); `manifests` is a disjoint field projected
-                // from the same raw provenance root. `by_name`'s `pm`-derived
-                // reads are hoisted into the by-value `cache_ctx`, so the call
-                // holds only `&mut manifests`.
-                let scope =
-                    bun_ptr::BackRef::new(mgr_ref.options.scope_for_package_name(pkg_name_slice));
-                // SAFETY: `manifests` is disjoint from `options`/`lockfile`;
-                // `manager_ptr` is the SRW root.
-                let cached = unsafe { &mut (*manager_ptr).manifests }.by_name(
-                    cache_ctx,
-                    scope.get(),
-                    pkg_name_slice,
-                    needs_extended_manifest,
-                );
-                if cached.is_none() {
-                    start_manifest_task(
-                        // SAFETY: `manager_ptr` is the SRW provenance root;
-                        // `start_manifest_task` only touches the network-task
-                        // pool / progress bar / log, never `lockfile.buffers`
-                        // or `lockfile.packages`, so the outstanding shared
-                        // slice (`pkg_name_slice`) stays valid.
-                        unsafe { &mut *manager_ptr },
-                        pkg_name_slice,
-                        false,
-                        needs_extended_manifest,
-                    )?;
-                }
-
-                // SAFETY: SRW root; network-queue flush does not mutate `lockfile`.
-                run_tasks::flush_network_queue(unsafe { &mut *manager_ptr });
-                // SAFETY: SRW root; task scheduler does not mutate `lockfile`.
-                let _ = run_tasks::schedule_tasks(unsafe { &mut *manager_ptr });
+                };
+                fetch_manifest_if_uncached(manager, &candidate)?;
+                // `.All` flushes after every candidate, cached or not.
+                run_tasks::flush_network_queue(manager);
+                let _ = run_tasks::schedule_tasks(manager);
             }
         }
         Packages::Ids(ids) => {
             for &root_pkg_id in ids {
-                let pkg_deps = pkg_dependencies[root_pkg_id as usize];
+                let pkg_deps = manager.lockfile.packages.items_dependencies()[root_pkg_id as usize];
                 for dep_id in pkg_deps.begin()..pkg_deps.end() {
                     let dep_id = dep_id as usize;
-                    if dep_id >= dependencies.len() {
+                    let (pkg_id, is_required) = {
+                        let buffers = &manager.lockfile.buffers;
+                        if dep_id >= buffers.dependencies.len() {
+                            continue;
+                        }
+                        let pkg_id = buffers.resolutions[dep_id];
+                        if pkg_id == invalid_package_id {
+                            continue;
+                        }
+                        (pkg_id, buffers.dependencies[dep_id].behavior.is_required())
+                    };
+                    let Some(candidate) = npm_candidate(&manager.lockfile, pkg_id, is_required)
+                    else {
                         continue;
-                    }
-                    let pkg_id = resolutions[dep_id];
-                    if pkg_id == invalid_package_id {
-                        continue;
-                    }
-                    let dep = &dependencies[dep_id];
-
-                    let resolution: &Resolution = &pkg_resolutions[pkg_id as usize];
-                    if resolution.tag != ResolutionTag::Npm {
-                        continue;
-                    }
-
-                    // `options` read via BACKREF `mgr_ref` — see provenance-root
-                    // note above.
-                    let needs_extended_manifest = mgr_ref.options.minimum_release_age_ms.is_some();
-                    let package_name = pkg_names[pkg_id as usize].slice(string_buf);
-                    // See disjoint-field note on the `.All` arm above.
-                    let scope =
-                        bun_ptr::BackRef::new(mgr_ref.options.scope_for_package_name(package_name));
-                    // SAFETY: `manifests` is disjoint from `options`/`lockfile`;
-                    // `manager_ptr` is the SRW root.
-                    let cached = unsafe { &mut (*manager_ptr).manifests }.by_name(
-                        cache_ctx,
-                        scope.get(),
-                        package_name,
-                        needs_extended_manifest,
-                    );
-                    if cached.is_none() {
-                        start_manifest_task(
-                            // SAFETY: `manager_ptr` is the SRW provenance
-                            // root; `start_manifest_task` only touches the
-                            // network-task pool / progress bar / log, never
-                            // `lockfile.buffers` or `lockfile.packages`, so
-                            // `package_name` stays valid.
-                            unsafe { &mut *manager_ptr },
-                            package_name,
-                            dep.behavior.is_required(),
-                            needs_extended_manifest,
-                        )?;
-
-                        // SAFETY: SRW root; network-queue flush does not mutate `lockfile`.
-                        run_tasks::flush_network_queue(unsafe { &mut *manager_ptr });
-                        // SAFETY: SRW root; task scheduler does not mutate `lockfile`.
-                        let _ = run_tasks::schedule_tasks(unsafe { &mut *manager_ptr });
-                    }
+                    };
+                    fetch_manifest_if_uncached(manager, &candidate)?;
                 }
             }
         }
         Packages::Exact(ids) => {
             for &pkg_id in ids {
-                if pkg_resolutions[pkg_id as usize].tag != ResolutionTag::Npm {
+                let Some(candidate) = npm_candidate(&manager.lockfile, pkg_id, false) else {
                     continue;
-                }
-                let package_name = pkg_names[pkg_id as usize].slice(string_buf);
-                let needs_extended_manifest = mgr_ref.options.minimum_release_age_ms.is_some();
-                let scope =
-                    bun_ptr::BackRef::new(mgr_ref.options.scope_for_package_name(package_name));
-                // SAFETY: `manifests` is disjoint from `options`/`lockfile`; `manager_ptr` is the SRW root.
-                let cached = unsafe { &mut (*manager_ptr).manifests }.by_name(
-                    cache_ctx,
-                    scope.get(),
-                    package_name,
-                    needs_extended_manifest,
-                );
-                if cached.is_none() {
-                    start_manifest_task(
-                        // SAFETY: SRW root; `start_manifest_task` never mutates `lockfile`, so `package_name` stays valid.
-                        unsafe { &mut *manager_ptr },
-                        package_name,
-                        false,
-                        needs_extended_manifest,
-                    )?;
-                    // SAFETY: SRW root; network-queue flush does not mutate `lockfile`.
-                    run_tasks::flush_network_queue(unsafe { &mut *manager_ptr });
-                    // SAFETY: SRW root; task scheduler does not mutate `lockfile`.
-                    let _ = run_tasks::schedule_tasks(unsafe { &mut *manager_ptr });
-                }
+                };
+                fetch_manifest_if_uncached(manager, &candidate)?;
             }
         }
     }
 
-    // SAFETY: provenance root; no live shared borrows of `*manager_ptr` remain.
-    let manager = unsafe { &mut *manager_ptr };
     run_tasks::flush_network_queue(manager);
     let _ = run_tasks::schedule_tasks(manager);
 
     if run_tasks::pending_task_count(manager) > 0 {
-        struct RunClosure {
-            // `sleep_until` also receives this raw pointer, so storing
-            // `&mut PackageManager` here would alias under Stacked Borrows.
-            manager: *mut PackageManager,
-            err: Option<crate::Error>,
-        }
-        impl RunClosure {
-            fn is_done(closure: &mut Self) -> bool {
-                // SAFETY: `closure.manager` is the raw provenance root set
-                // below; `sleep_until`/`tick_raw` hold no `&mut` across this
-                // callback, so this is the unique live borrow.
-                let manager = unsafe { &mut *closure.manager };
-                let log_level = manager.options.log_level;
-                // void RunTasksCallbacks — `extract_ctx` is unit. Do NOT pass
-                // `manager` as both receiver and ctx (aliased &mut); the generic
-                // context collapses to `&mut ()`.
-                if let Err(err) = run_tasks::run_tasks::<ManifestsOnlyCallbacks>(
-                    manager,
-                    &mut (),
-                    true,
-                    log_level,
-                ) {
-                    closure.err = Some(err);
-                    return true;
-                }
-
-                run_tasks::pending_task_count(manager) == 0
+        let mut err: Option<crate::Error> = None;
+        PackageManager::sleep_until(manager, |manager| {
+            let log_level = manager.options.log_level;
+            if let Err(e) = run_tasks::run_tasks(&mut ManifestsOnlyCtx(manager), true, log_level) {
+                err = Some(e);
+                return true;
             }
-        }
-
-        // Derive the raw provenance root first so both `sleep_until` and the
-        // closure body's `&mut *run_closure.manager` share the same SRW tag.
-        let mgr: *mut PackageManager = manager;
-        let mut run_closure = RunClosure {
-            manager: mgr,
-            err: None,
-        };
-        // SAFETY: `mgr` is derived from the live exclusive `manager` borrow;
-        // `sleep_until` is an associated fn taking `*mut PackageManager` and
-        // `tick_raw` holds no `&mut event_loop` across `is_done`, so the
-        // callback's `&mut *run_closure.manager` is the unique live borrow.
-        unsafe { PackageManager::sleep_until(mgr, &mut run_closure, RunClosure::is_done) };
+            run_tasks::pending_task_count(manager) == 0
+        });
 
         if log_level.show_progress() {
-            // SAFETY: `mgr` is still the live provenance root; `sleep_until`
-            // has returned so no competing borrow exists.
-            unsafe { (*mgr).end_progress_bar() };
+            manager.end_progress_bar();
             Output::flush();
         }
 
-        if let Some(err) = run_closure.err {
+        if let Some(err) = err {
             return Err(err);
         }
     }
@@ -366,8 +275,8 @@ pub fn populate_manifest_cache(
 }
 
 /// Prints the fetch failures a [`Packages::Ids`] pass logged; true when one of them is a required dependency's.
-pub fn print_fetch_failures(manager: &PackageManager) -> crate::Result<bool> {
-    let log = manager.log_mut();
+pub fn print_fetch_failures(manager: &mut PackageManager) -> crate::Result<bool> {
+    let log = &mut manager.log;
     let failed_required = log.has_errors();
     if !log.msgs.is_empty() {
         Output::flush();

--- a/src/install/PackageManager/ProgressStrings.rs
+++ b/src/install/PackageManager/ProgressStrings.rs
@@ -88,29 +88,11 @@ impl ProgressStrings {
 }
 
 impl PackageManager {
-    pub(crate) fn set_node_name<const IS_FIRST: bool>(
-        &mut self,
-        node: &mut ProgressNode,
-        name: &[u8],
-        emoji: &[u8],
-    ) {
-        // SAFETY: `node` is `self.downloads_node` / `self.scripts_node`, both of
-        // which point at storage owned by (or outliving) this `PackageManager`
-        // singleton; `progress_name_buf` is an inline field of that same
-        // singleton, so the buffer outlives every node that references it and
-        // erasing the slice lifetime to `'static` is sound.
-        unsafe {
-            let len = if Output::enable_ansi_colors_stderr() {
-                if IS_FIRST {
-                    self.progress_name_buf[..emoji.len()].copy_from_slice(emoji);
-                }
-                self.progress_name_buf[emoji.len()..][..name.len()].copy_from_slice(name);
-                emoji.len() + name.len()
-            } else {
-                self.progress_name_buf[..name.len()].copy_from_slice(name);
-                name.len()
-            };
-            node.name = bun_ptr::detach_lifetime(&self.progress_name_buf[..len]);
+    pub(crate) fn set_node_name(node: &mut ProgressNode, name: &[u8], emoji: &[u8]) {
+        if Output::enable_ansi_colors_stderr() {
+            node.set_name_parts(&[emoji, name]);
+        } else {
+            node.set_name_parts(&[name]);
         }
     }
 
@@ -122,21 +104,20 @@ impl PackageManager {
 
     pub(crate) fn start_progress_bar(&mut self) {
         self.progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
-        // `Progress::start` returns `&mut Node` borrowing `self.progress`;
-        // decay to a raw ptr immediately so the exclusive borrow ends before we
-        // re-borrow `&mut self` for `set_node_name` / `progress.refresh()`.
-        let node: *mut ProgressNode = self.progress.start(ProgressStrings::download(), 0);
+        let root = self.progress.start(b"", 0);
+        let node = root.start(ProgressStrings::download(), 0);
         self.downloads_node = Some(node);
-        self.set_node_name::<true>(
-            self.downloads_node_mut(),
+        let total_tasks = self.total_tasks;
+        let extracted_count = self.extracted_count;
+        let pending = self.pending_task_count();
+        let dn = self.downloads_node_mut();
+        Self::set_node_name(
+            dn,
             ProgressStrings::DOWNLOAD_NO_EMOJI_.as_bytes(),
             ProgressStrings::DOWNLOAD_EMOJI.as_bytes(),
         );
-        // `downloads_node` was just stashed above; route through the accessor
-        // (single unsafe site) instead of re-dereffing the raw `node` here.
-        let dn = self.downloads_node_mut();
-        dn.set_estimated_total_items((self.total_tasks + self.extracted_count) as usize);
-        dn.set_completed_items((self.total_tasks - self.pending_task_count()) as usize);
+        dn.set_estimated_total_items((total_tasks + extracted_count) as usize);
+        dn.set_completed_items((total_tasks - pending) as usize);
         dn.activate();
         self.progress.refresh();
     }
@@ -145,8 +126,6 @@ impl PackageManager {
         if self.downloads_node.is_none() {
             return;
         }
-        // Route through the accessor (single unsafe site) instead of a raw
-        // `(*downloads_node)` deref here.
         let dn = self.downloads_node_mut();
         let total = dn.unprotected_estimated_total_items.load(Ordering::Relaxed);
         dn.set_estimated_total_items(total);

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -33,10 +33,9 @@ pub struct UpdateRequest {
     pub(crate) package_id: PackageID,
     pub(crate) is_aliased: bool,
     pub failed: bool,
-    /// This must be cloned to handle when the AST store resets.
-    /// ARENA-owned (AST `Expr.Data` store) — raw pointer per LIFETIMES.tsv;
-    /// only valid while the store that allocated it is alive.
-    pub(crate) e_string: Option<*mut js_ast::E::String>,
+    /// This must be cloned to handle when the AST store resets: it lives in
+    /// the AST `Expr.Data` store and is only valid while that store is.
+    pub(crate) e_string: Option<bun_ast::StoreRef<js_ast::E::String>>,
 }
 
 impl Default for UpdateRequest {
@@ -70,13 +69,11 @@ pub struct UpdateRequestIndex(
 /// reachable. `UpdateRequest::name`/`version_buf` store raw `&'static`/
 /// `RawSlice` views because they may later be repointed at lockfile buffers.
 fn anchor_cli_bytes(b: Box<[u8]>) -> &'static [u8] {
-    static ANCHOR: bun_threading::Guarded<Vec<Box<[u8]>>> = bun_threading::Guarded::new(Vec::new());
-    let ptr: *const [u8] = &raw const *b;
-    ANCHOR.lock().push(b);
-    // SAFETY: `b`'s heap allocation is owned by `ANCHOR` for the rest of the
-    // process. `Box<[u8]>` is a fat pointer; pushing it into the Vec moves
-    // only the pointer, not the heap data.
-    unsafe { &*ptr }
+    static ANCHOR: bun_threading::Guarded<Vec<&'static [u8]>> =
+        bun_threading::Guarded::new(Vec::new());
+    let bytes: &'static [u8] = Box::leak(b);
+    ANCHOR.lock().push(bytes);
+    bytes
 }
 
 impl UpdateRequest {
@@ -123,7 +120,7 @@ impl UpdateRequest {
         }
     }
 
-    /// It is incorrect to call this function before Lockfile.cleanWithLogger() because
+    /// It is incorrect to call this function before Lockfile::clean_with_logger() because
     /// resolved_name should be populated if possible.
     ///
     /// `self` needs to be a pointer! If `self` is a copy and the name returned from

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -28,7 +28,7 @@ pub struct MapEntry {
     /// `StringHashMap` boxes its own key, so keep the duped copy alive here.
     _path_storage: bun_core::ZBox,
     /// Owns the arena that backs decoded string bytes inside `root`.
-    /// `deepClone` does *not* dupe escape-decoded `E.String.data` slices.
+    /// `deep_clone` does *not* dupe escape-decoded `E.String.data` slices.
     /// The parser takes a `&Arena`, so the arena must outlive the
     /// cached AST — hold it here so it drops with the entry.
     ///
@@ -59,7 +59,7 @@ impl Default for MapEntry {
 impl MapEntry {
     /// Re-parse `self.source.contents` into `self.root`.
     ///
-    /// `updatePackageJSONAndInstall` edits a copy of `root`, prints it, and
+    /// `update_package_json_and_install` edits a copy of `root`, prints it, and
     /// writes the printed JSON back into `source.contents`. The caller then
     /// invokes this to restore the invariant `root == parse(source)`.
     pub(crate) fn reparse_root(&mut self, log: &mut Log) -> Result<(), Error> {
@@ -152,10 +152,8 @@ impl WorkspacePackageJSONCache {
             &buf[..abs_package_json_path.len()]
         };
 
-        // reshaped for borrowck — we cannot hold an entry borrow across
-        // `self.map.remove`, so check
-        // membership up front and only insert into the map after a successful
-        // read+parse. Net map state is identical on every path.
+        // Membership is checked up front and the map only gains an entry after
+        // a successful read+parse.
         if self.map.contains_key(path) {
             let entry = self.map.get_mut(path).unwrap();
             if opts.guess_indentation && !entry.indentation_guessed {
@@ -166,14 +164,12 @@ impl WorkspacePackageJSONCache {
         }
 
         // Owned NUL-terminated copy reused
-        // both as the map key and the path handed to `File.toSource`. The
+        // both as the map key and the path handed to `File.to_source`. The
         // returned `Source` *borrows* its `path` slices from this allocation,
         // so it must outlive the cached `MapEntry` (stored as
         // `value.path_storage` below).
         let key = bun_core::ZBox::from_bytes(path);
 
-        // MOVE_DOWN: `bun.sys.File.toSource` lives in `bun_logger` (T1 → T2
-        // cyclebreak; `bun_sys` cannot name `Source`).
         let source = match bun_ast::to_source(&key, Default::default()) {
             Ok(s) => s,
             Err(err) => {

--- a/src/install/PackageManager/add_catalog.rs
+++ b/src/install/PackageManager/add_catalog.rs
@@ -683,14 +683,13 @@ fn settle_resolved_positional(
     package_json: &Expr,
     dependency_list: &[u8],
     flag: &[u8],
-    e_string: *mut E::EString,
+    e_string: bun_ast::StoreRef<E::EString>,
     target: &[u8],
     quiet: bool,
 ) -> Decision {
     let name: &[u8] = request.get_resolved_name(lockfile);
     let name_hash = lockfile.packages.items_name_hash()[request.package_id as usize];
-    // SAFETY: same slot `edit` just wrote through; see the write in `edit_target`.
-    let literal: &[u8] = unsafe { (*e_string).data }.slice();
+    let literal: &[u8] = e_string.data.slice();
 
     if keys_named(package_json, dependency_list, name) > 1 {
         refuse_declared(literal, target, name, flag);
@@ -769,7 +768,7 @@ pub(crate) fn edit_target(
     let flag_literal = flag.map(|name| StoreStr::new(reference_literal(arena, name)));
 
     for request in updates.iter_mut() {
-        let Some(e_string) = request.e_string else {
+        let Some(mut e_string) = request.e_string else {
             continue;
         };
         if !request.is_aliased {
@@ -791,8 +790,7 @@ pub(crate) fn edit_target(
                 quiet,
             );
             if decision == Decision::Convert {
-                // SAFETY: see the write at the bottom of this loop.
-                unsafe { (*e_string).data = flag_literal.expect("infallible: flag is Some") };
+                e_string.data = flag_literal.expect("infallible: flag is Some");
             }
             continue;
         }
@@ -828,8 +826,7 @@ pub(crate) fn edit_target(
                         Decision::Convert => flag_literal.expect("infallible: flag is Some"),
                         Decision::Keep => {
                             if let Some(slot) = existing {
-                                // SAFETY: see the write at the bottom of this loop.
-                                unsafe { (*e_string).data = slot };
+                                e_string.data = slot;
                             }
                             request.e_string = None;
                             continue;
@@ -842,8 +839,9 @@ pub(crate) fn edit_target(
                 _ => continue,
             }
         };
-        // SAFETY: same slot `edit` just wrote through (PackageJSONEditor.rs `request.e_string` loop); the tree it points into is still live and no other borrow of it exists here.
-        unsafe { (*e_string).data = literal };
+        // Same slot `edit` just wrote through (PackageJSONEditor.rs
+        // `request.e_string` loop); the tree it points into is still live.
+        e_string.data = literal;
     }
     Ok(())
 }
@@ -979,19 +977,45 @@ fn other_users_of(
 
 pub(crate) fn edit_root_entry_before_install(
     manager: &mut PackageManager,
-    root_package_json: &mut MapEntry,
+    root_package_json_path: &[u8],
 ) -> Result<(), crate::Error> {
     if manager.catalog_add.adds.is_empty() {
         return Ok(());
     }
-    let root = root_package_json.root;
+    let root = cached_root_entry(manager, root_package_json_path).0.root;
     edit_root_before_install(manager, &root)?;
+    let (root_package_json, log) = cached_root_entry(manager, root_package_json_path);
     print_package_json_into_cache_entry(root_package_json, root);
-    if let Err(err) = root_package_json.reparse_root(manager.log_mut()) {
+    if let Err(err) = root_package_json.reparse_root(log) {
         bun_core::pretty_errorln!("package.json failed to parse due to error {}", err.name());
         Global::crash();
     }
     Ok(())
+}
+
+/// The root `package.json` cache entry (loaded by the caller already).
+fn cached_root_entry<'m>(
+    manager: &'m mut PackageManager,
+    path: &[u8],
+) -> (&'m mut MapEntry, &'m mut bun_ast::Log) {
+    let PackageManager {
+        log,
+        workspace_package_json_cache,
+        ..
+    } = manager;
+    match workspace_package_json_cache.get_with_path(
+        log,
+        path,
+        crate::package_manager_real::workspace_package_json_cache::GetJSONOptions {
+            guess_indentation: true,
+            ..Default::default()
+        },
+    ) {
+        crate::package_manager_real::workspace_package_json_cache::GetResult::Entry(entry) => {
+            (entry, log)
+        }
+        _ => unreachable!("cached by the caller"),
+    }
 }
 
 /// Runs after `clean_with_logger`: puts moved entries back, replaces dist-tag seeds with the resolved range and writes the entries of nameless positionals; the lockfile catalog is re-derived from the file by `package_json_write_back`.

--- a/src/install/PackageManager/add_remove_with_filter.rs
+++ b/src/install/PackageManager/add_remove_with_filter.rs
@@ -50,7 +50,7 @@ fn print_log_and_crash(
     args: impl bun_core::output::FmtTuple,
 ) -> ! {
     let _ = manager
-        .log_mut()
+        .log
         .print(std::ptr::from_mut(Output::error_writer()));
     Output::err_generic(fmt, args);
     Global::crash();
@@ -66,7 +66,7 @@ pub(crate) fn load_workspace_members(manager: &mut PackageManager) -> WorkspaceM
     let root_path = root_package_json_path();
 
     let (root_expr, root_source, root_name): (bun_ast::Expr, bun_ast::Source, Box<[u8]>) = {
-        let log = manager.log_mut();
+        let log = &mut manager.log;
         match manager.workspace_package_json_cache.get_with_path(
             log,
             &root_path,
@@ -119,7 +119,7 @@ pub(crate) fn load_workspace_members(manager: &mut PackageManager) -> WorkspaceM
         _ => None,
     };
     if let Some((arr, loc)) = names {
-        let log = manager.log_mut();
+        let log = &mut manager.log;
         if let Err(err) = members.process_names_array(
             &mut manager.workspace_package_json_cache,
             log,
@@ -250,8 +250,20 @@ pub(crate) fn fetch_entry<'a>(
     manager: &'a mut PackageManager,
     target: &WorkspaceTarget,
 ) -> &'a mut MapEntry {
-    let log = manager.log_mut();
-    match manager.workspace_package_json_cache.get_with_path(
+    fetch_entry_and_log(manager, target).0
+}
+
+/// [`fetch_entry`], plus the manager's log for reporting on the entry.
+pub(crate) fn fetch_entry_and_log<'a>(
+    manager: &'a mut PackageManager,
+    target: &WorkspaceTarget,
+) -> (&'a mut MapEntry, &'a mut bun_ast::Log) {
+    let PackageManager {
+        log,
+        workspace_package_json_cache,
+        ..
+    } = manager;
+    let entry = match workspace_package_json_cache.get_with_path(
         log,
         &target.package_json_path,
         GetJSONOptions {
@@ -267,7 +279,8 @@ pub(crate) fn fetch_entry<'a>(
             );
             Global::crash();
         }
-    }
+    };
+    (entry, log)
 }
 
 pub(crate) fn fetch_entry_root(
@@ -282,8 +295,7 @@ pub(crate) fn store_entry(
     target: &WorkspaceTarget,
     root: bun_ast::Expr,
 ) {
-    let log = manager.log_mut();
-    let entry = fetch_entry(manager, target);
+    let (entry, log) = fetch_entry_and_log(manager, target);
     print_package_json_into_cache_entry(entry, root);
     if let Err(err) = entry.reparse_root(log) {
         bun_core::pretty_errorln!("package.json failed to parse due to error {}", err.name());
@@ -421,15 +433,10 @@ fn assign_requests(
         .map(Vec::as_slice)
         .collect();
     if !positionals.is_empty() {
-        let log = manager.log_mut();
         let subcommand = manager.subcommand;
-        UpdateRequest::parse(
-            Some(&mut *manager),
-            log,
-            &positionals,
-            &mut requests,
-            subcommand,
-        );
+        manager.with_log(|manager, log| {
+            UpdateRequest::parse(Some(manager), log, &positionals, &mut requests, subcommand)
+        });
     }
 
     let assigned = (0..targets.len())

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -29,8 +29,8 @@ use crate::PackageManager;
 use crate::config_version::ConfigVersion;
 use crate::hoisted_install::install_hoisted_packages;
 use crate::isolated_install::install_isolated_packages;
-use crate::lockfile_real::package::Diff;
 use crate::lockfile_real::package::PackageColumns as _;
+use crate::lockfile_real::package::{Diff, Updating};
 use crate::lockfile_real::{Printer, printer as LockfilePrinter};
 use crate::package_install::Summary as PackageInstallSummary;
 use crate::package_manager::Options::Enable;
@@ -39,7 +39,7 @@ use bun_install_types::NodeLinker::NodeLinker;
 
 // Free-function "methods" on `PackageManager` hosted in sibling modules
 // to avoid one giant `impl PackageManager` block.
-use crate::package_manager_real::run_tasks::{RunTasksCallbacks, run_tasks};
+use crate::package_manager_real::run_tasks::{RunTasksCtx, run_tasks};
 use crate::package_manager_real::{
     UpdateRequest, enqueue_dependency_list, enqueue_dependency_with_main, enqueue_patch_task_pre,
     save_lockfile, setup_global_dir, update_lockfile_if_needed, write_yarn_lock,
@@ -71,22 +71,10 @@ pub fn install_with_manager(
         }
     }
 
-    // reshaped for borrowck — `loadFromCwd` needs `manager`, `manager.lockfile`,
-    // and `manager.log` simultaneously. Route through a single
-    // raw provenance root so the three reborrows share a tag.
-    let load_result: lockfile::LoadResult = if manager.options.do_.load_lockfile() {
-        let mgr: *mut PackageManager = manager;
-        // SAFETY: `mgr` is the sole provenance root; `lockfile`, `*mgr`, and
-        // `*log` are disjoint storage. `load_from_cwd` only reads `manager`
-        // for option flags and writes through `lockfile`/`log`.
-        unsafe {
-            let log = (*mgr).log;
-            (*mgr)
-                .lockfile
-                .load_from_cwd::<true>(Some(&mut *mgr), &mut *log)
-        }
+    let load_result: lockfile::DetachedLoadResult = if manager.options.do_.load_lockfile() {
+        manager.load_lockfile_from_cwd_detached::<true>()
     } else {
-        lockfile::LoadResult::NotFound
+        lockfile::DetachedLoadResult::NotFound
     };
 
     update_lockfile_if_needed(manager, &load_result)?;
@@ -96,19 +84,20 @@ pub fn install_with_manager(
     // appended by manifest fetches in this resolve session.
     manager.lockfile.mark_loaded_packages();
 
-    let (config_version, changed_config_version) = load_result.choose_config_version();
+    let (config_version, changed_config_version) =
+        load_result.choose_config_version(&manager.lockfile);
     manager.options.config_version = Some(config_version);
 
     let mut root = lockfile::Package::default();
-    let mut needs_new_lockfile = !matches!(load_result, lockfile::LoadResult::Ok { .. })
-        || (load_result.ok().lockfile.buffers.dependencies.is_empty()
+    let mut needs_new_lockfile = !matches!(load_result, lockfile::DetachedLoadResult::Ok { .. })
+        || (manager.lockfile.buffers.dependencies.is_empty()
             && !manager.update_requests.is_empty());
 
     manager.options.enable.set(
         Enable::FORCE_SAVE_LOCKFILE,
         manager.options.enable.force_save_lockfile()
             || changed_config_version
-            || (matches!(load_result, lockfile::LoadResult::Ok { .. })
+            || (matches!(load_result, lockfile::DetachedLoadResult::Ok { .. })
                 // if migrated always save a new lockfile
                 && (load_result.ok().migrated != lockfile::Migrated::None
                     // if loaded from binary and save-text-lockfile is passed
@@ -125,7 +114,7 @@ pub fn install_with_manager(
     let mut transitive = TransitiveUpdate::default();
     // Reachability must be walked before the differ invalidates the root rows it is about to re-enqueue.
     if manager.to_update
-        && matches!(load_result, lockfile::LoadResult::Ok { .. })
+        && matches!(load_result, lockfile::DetachedLoadResult::Ok { .. })
         && !crate::update_scope::UpdateScope::of(&*manager).is_whole_workspace()
     {
         crate::update_scope::plan_named(manager);
@@ -138,13 +127,15 @@ pub fn install_with_manager(
     manager.progress = Default::default();
 
     match &load_result {
-        lockfile::LoadResult::Err(cause) => report_lockfile_load_error(manager, cause, log_level)?,
-        lockfile::LoadResult::Ok(ok) => {
+        lockfile::DetachedLoadResult::Err(cause) => {
+            report_lockfile_load_error(manager, cause, log_level)?
+        }
+        lockfile::DetachedLoadResult::Ok(_) => {
             if manager.subcommand == Subcommand::Update {
                 record_updating_package_versions(manager);
             }
             'differ: {
-                root = match ok.lockfile.root_package() {
+                root = match manager.lockfile.root_package() {
                     Some(r) => r,
                     None => {
                         needs_new_lockfile = true;
@@ -166,72 +157,40 @@ pub fn install_with_manager(
                 let source_copy = root_package_json_source(manager, root_package_json_path)?;
 
                 let mut resolver: () = ();
-                // `parse` needs `manager`, `manager.log` and a fresh
-                // stack `lockfile` simultaneously. Route through raw ptrs so
-                // borrowck doesn't see overlapping `&mut PackageManager` /
-                // `&mut Lockfile`.
-                {
-                    // `log_mut()` reads the BACKREF `self.log: *mut Log` and
-                    // returns the disjoint CLI `Log` allocation (lifetime
-                    // decoupled from `&self`), so call it safely through
-                    // `manager` *before* establishing the raw-ptr split — no
-                    // borrow on `*manager` survives into the `&mut *mgr` below.
-                    let log = manager.log_mut();
-                    let mgr: *mut PackageManager = manager;
+                manager.with_log(|manager, log| {
                     maybe_root.parse(
                         &mut lockfile,
-                        // SAFETY: `mgr` is the sole provenance root for `*manager`; `log` is a
-                        // disjoint backref and `lockfile` is a stack local, so this `&mut` is unique.
-                        unsafe { &mut *mgr },
+                        manager,
                         log,
                         &source_copy,
                         &mut resolver,
                         Features::main(),
-                    )?;
-                }
+                    )
+                })?;
                 let mut mapping = vec![invalid_package_id; maybe_root.dependencies.len as usize]
                     .into_boxed_slice();
-                // @memset already done via vec! init
 
-                // `Diff::generate` (in lockfile_real::package) needs `manager`,
-                // `manager.log`, `manager.lockfile` and a
-                // fresh `lockfile` simultaneously. Route through raw ptrs to satisfy
-                // borrowck.
                 manager.summary = {
-                    // `log_mut()` returns the disjoint CLI `Log` allocation
-                    // (BACKREF field, lifetime decoupled from `&self`); read it
-                    // and the `to_update` scalar safely through `manager`
-                    // *before* establishing the raw-ptr split so no borrow on
-                    // `*manager` survives into `mgr`'s `&mut` reborrows below.
-                    let log = manager.log_mut();
-                    let to_update = manager.to_update;
-                    let mgr: *mut PackageManager = manager;
-                    // SAFETY: `mgr` is the sole provenance root for the manager
-                    // from here on; `Diff::generate` reborrows disjoint fields
-                    // (`lockfile`, `update_requests`) through it. No other live
-                    // `&mut` to `*mgr` exists across the call.
-                    let from_lockfile: *mut Lockfile = unsafe { &raw mut *(*mgr).lockfile };
-                    let update_requests = if to_update {
-                        // SAFETY: shared reborrow of a field disjoint from `lockfile`; `mgr` is the
-                        // sole provenance root and `Diff::generate` does not mutate `update_requests`.
-                        Some(unsafe { &(&(*mgr).update_requests)[..] })
-                    } else {
-                        None
-                    };
-                    Diff::generate(
-                        // SAFETY: `mgr` is the sole provenance root; `Diff::generate` touches only
-                        // `PackageManager` fields disjoint from `lockfile`/`update_requests` via this.
-                        unsafe { &mut *mgr },
-                        log,
-                        // SAFETY: `from_lockfile` projects `(*mgr).lockfile`; `Diff::generate` never
-                        // reaches `manager.lockfile` through the `&mut *mgr` arg, so this is unique.
-                        unsafe { &mut *from_lockfile },
-                        &mut lockfile,
-                        &root,
-                        &maybe_root,
-                        update_requests,
-                        Some(&mut mapping[..]),
-                    )?
+                    let updating =
+                        manager
+                            .to_update
+                            .then_some(if manager.update_requests.is_empty() {
+                                Updating::Everything
+                            } else {
+                                Updating::Named
+                            });
+                    manager.with_lockfile_and_log(|from_lockfile, manager, log| {
+                        Diff::generate(
+                            manager,
+                            log,
+                            from_lockfile,
+                            &mut lockfile,
+                            &root,
+                            &maybe_root,
+                            updating,
+                            Some(&mut mapping[..]),
+                        )
+                    })?
                 };
 
                 had_any_diffs = manager.summary.has_diffs();
@@ -433,7 +392,6 @@ pub fn install_with_manager(
                             let pkg_name_and_version_hash = *key;
                             debug_assert!(value.patchfile_hash_is_null);
                             let gop = lf.patched_dependencies.entry(pkg_name_and_version_hash);
-                            // ArrayHashMap getOrPut semantics → entry API approximation
                             match gop {
                                 bun_collections::array_hash_map::MapEntry::Vacant(v) => {
                                     // `PatchedDep` has private padding/hash fields,
@@ -493,7 +451,7 @@ pub fn install_with_manager(
                         pinned_rows = enqueue_transitive(manager, &transitive, invalidates_rows)?;
                     }
 
-                    // `enqueueDependencyWithMain` can reach `Lockfile.Package.fromNPM`,
+                    // `enqueue_dependency_with_main` can reach `Package::from_npm`,
                     // which grows `buffers.dependencies` and may reallocate it.
                     // Iterate by index against a snapshot of the original length and
                     // copy each entry to the stack so neither the loop nor the callee
@@ -655,36 +613,16 @@ pub fn install_with_manager(
     transitive.print_plan(manager, &direct_deps_before, &named.moved);
     print_kept_patched(manager);
 
-    let had_errors_before_cleaning_lockfile = manager.log_mut().has_errors();
+    let had_errors_before_cleaning_lockfile = manager.log.has_errors();
     manager
-        .log_mut()
+        .log
         .print(std::ptr::from_mut(Output::error_writer()))?;
-    manager.log_mut().reset();
+    manager.log.reset();
     super::add_catalog::refuse_declared_positionals(manager);
 
     // This operation doesn't perform any I/O, so it should be relatively cheap.
-    // Both old and new lockfiles must stay live for the later
-    // `eql(lockfile_before_clean, ...)` checks, but `manager.lockfile: Box<Lockfile>`
-    // would move; compute the new lockfile first, then
-    // `mem::replace` so `lockfile_before_clean` owns the old box and `manager.lockfile` the new.
-    let new_lockfile = {
-        let mgr: *mut PackageManager = manager;
-        // SAFETY: `lockfile`, `update_requests`, and `*log` are disjoint storage
-        // within `*mgr`; `clean_with_logger` only reads `manager` for option flags
-        // and its preinstall_state, so a single raw provenance root keeps all
-        // reborrows under one tag (PORTING.md §Aliasing-split-borrow).
-        unsafe {
-            let log = (*mgr).log;
-            Lockfile::clean_with_logger(
-                &mut (*mgr).lockfile,
-                &mut *mgr,
-                &mut (*mgr).update_requests,
-                &mut *log,
-                log_level,
-            )?
-        }
-    };
-    let lockfile_before_clean = core::mem::replace(&mut manager.lockfile, new_lockfile);
+    // The old lockfile stays live for the later `eql(lockfile_before_clean, ...)` checks.
+    let lockfile_before_clean = Lockfile::clean_with_logger(manager, log_level)?;
     if manager.subcommand == Subcommand::Update && !manager.options.dry_run {
         Output::flush();
         crate::update_transitive::warn_orphaned_patches(manager);
@@ -724,206 +662,195 @@ pub fn install_with_manager(
 
     // append scripts to lockfile before generating new metahash
     manager.load_root_lifecycle_scripts(&root);
-    // `List.package_name` is `Box<[u8]>`, so dropping the whole `Option<List>`
-    // at scope exit frees it. Route through a raw provenance root because
-    // `manager: &mut` is reborrowed many times below; the guard fires once on
-    // the way out and is the only access at that point.
-    let mgr_for_root_scripts_cleanup: *mut PackageManager = manager;
-    scopeguard::defer! {
-        // SAFETY: `mgr_for_root_scripts_cleanup` was derived from the live
-        // exclusive `manager` borrow above; this guard runs once at scope exit
-        // (before `manager` is returned to the caller) and is the sole access
-        // to `*mgr_for_root_scripts_cleanup` at that instant.
-        unsafe { (*mgr_for_root_scripts_cleanup).root_lifecycle_scripts = None };
-    };
+    // The root scripts are this install's; drop them on the way out.
+    let result = (|| -> crate::Result<()> {
+        let manager = &mut *manager;
+        if let Some(root_scripts) = &manager.root_lifecycle_scripts {
+            root_scripts.append_to_lockfile(&mut manager.lockfile);
+        }
+        {
+            // Split borrow: the resolution/meta/scripts columns are read while
+            // pushing into `lockfile.scripts`.
+            let lockfile = &mut *manager.lockfile;
+            let packages = &lockfile.packages;
+            let string_bytes = lockfile.buffers.string_bytes.as_slice();
+            let lockfile_scripts = &mut lockfile.scripts;
+            for pkg_i in 0..packages.len() {
+                let resolution = packages.items_resolution()[pkg_i];
+                if resolution.tag != ResolutionTag::Workspace {
+                    continue;
+                }
+                let meta = packages.items_meta()[pkg_i];
+                if !meta.has_install_script() {
+                    continue;
+                }
+                let scripts = packages.items_scripts()[pkg_i];
+                let add_node_gyp = !scripts.has_any();
+                let (first_index, _, entries) = scripts.get_script_entries(
+                    string_bytes,
+                    ResolutionTag::Workspace,
+                    add_node_gyp,
+                );
 
-    if let Some(root_scripts) = &manager.root_lifecycle_scripts {
-        root_scripts.append_to_lockfile(&mut manager.lockfile);
-    }
-    {
-        // reshaped for borrowck — shared slices into the
-        // resolution/meta/scripts columns are held while pushing into
-        // `manager.lockfile.scripts`. Field-level split borrow keeps the two
-        // disjoint columns alive simultaneously without raw-pointer routing.
-        let lockfile = &mut *manager.lockfile;
-        let packages = &lockfile.packages;
-        let string_bytes = lockfile.buffers.string_bytes.as_slice();
-        let lockfile_scripts = &mut lockfile.scripts;
-        for pkg_i in 0..packages.len() {
-            let resolution = packages.items_resolution()[pkg_i];
-            if resolution.tag != ResolutionTag::Workspace {
-                continue;
-            }
-            let meta = packages.items_meta()[pkg_i];
-            if !meta.has_install_script() {
-                continue;
-            }
-            let scripts = packages.items_scripts()[pkg_i];
-            let add_node_gyp = !scripts.has_any();
-            let (first_index, _, entries) =
-                scripts.get_script_entries(string_bytes, ResolutionTag::Workspace, add_node_gyp);
+                debug_assert!(first_index != -1);
 
-            debug_assert!(first_index != -1);
-
-            // In the `add_node_gyp` arm the assert already guarantees
-            // `first_index != -1`, so a single guarded loop covers
-            // both paths exactly.
-            if first_index != -1 {
-                for (i, maybe_entry) in entries.into_iter().enumerate() {
-                    if let Some(entry) = maybe_entry {
-                        lockfile_scripts.hook_mut(i).push(entry);
+                // In the `add_node_gyp` arm the assert already guarantees
+                // `first_index != -1`, so a single guarded loop covers
+                // both paths exactly.
+                if first_index != -1 {
+                    for (i, maybe_entry) in entries.into_iter().enumerate() {
+                        if let Some(entry) = maybe_entry {
+                            lockfile_scripts.hook_mut(i).push(entry);
+                        }
                     }
                 }
             }
         }
-    }
 
-    if manager.options.global {
-        setup_global_dir(manager, &ctx)?;
-    }
+        if manager.options.global {
+            setup_global_dir(manager, &ctx)?;
+        }
 
-    let packages_len_before_install = manager.lockfile.packages.len();
+        let packages_len_before_install = manager.lockfile.packages.len();
 
-    if manager.options.enable.frozen_lockfile()
-        && !matches!(load_result, lockfile::LoadResult::NotFound)
-    {
-        'frozen_lockfile: {
-            let changed_section = frozen_changed_section(manager, root_package_json_path);
-            if changed_section.is_none() {
-                if load_result.loaded_from_text_lockfile() {
-                    if bun_core::handle_oom(Lockfile::eql(
-                        &manager.lockfile,
-                        &lockfile_before_clean,
-                        lockfile_before_clean.loaded_package_count as usize,
-                    )) {
+        if manager.options.enable.frozen_lockfile()
+            && !matches!(load_result, lockfile::DetachedLoadResult::NotFound)
+        {
+            'frozen_lockfile: {
+                let changed_section = frozen_changed_section(manager, root_package_json_path);
+                if changed_section.is_none() {
+                    if load_result.loaded_from_text_lockfile() {
+                        if bun_core::handle_oom(Lockfile::eql(
+                            &manager.lockfile,
+                            &lockfile_before_clean,
+                            lockfile_before_clean.loaded_package_count as usize,
+                        )) {
+                            break 'frozen_lockfile;
+                        }
+                    } else if !(manager
+                        .lockfile
+                        .has_meta_hash_changed(
+                            PackageManager::verbose_install()
+                                || manager.options.do_.print_meta_hash_string(),
+                            packages_len_before_install,
+                        )
+                        .unwrap_or(false))
+                    {
                         break 'frozen_lockfile;
                     }
-                } else if !(manager
-                    .lockfile
-                    .has_meta_hash_changed(
-                        PackageManager::verbose_install()
-                            || manager.options.do_.print_meta_hash_string(),
-                        packages_len_before_install,
-                    )
-                    .unwrap_or(false))
-                {
-                    break 'frozen_lockfile;
                 }
-            }
 
-            if log_level != Options::LogLevel::Silent {
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r><d>:<r> lockfile had changes, but lockfile is frozen"
-                );
-                if let Some(section) = changed_section {
+                if log_level != Options::LogLevel::Silent {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r><d>:<r> lockfile had changes, but lockfile is frozen"
+                    );
+                    if let Some(section) = changed_section {
+                        bun_core::note!(
+                            "{} in package.json changed since {} was saved",
+                            section,
+                            loaded_lockfile_name(&load_result)
+                        );
+                    }
                     bun_core::note!(
-                        "{} in package.json changed since {} was saved",
-                        section,
-                        loaded_lockfile_name(&load_result)
+                        "try re-running without <d>--frozen-lockfile<r> and commit the updated lockfile"
                     );
                 }
-                bun_core::note!(
-                    "try re-running without <d>--frozen-lockfile<r> and commit the updated lockfile"
-                );
+                Global::crash();
             }
-            Global::crash();
-        }
-    }
-
-    // BACKREF: `manager.lockfile` is a `Box<Lockfile>` whose allocation is
-    // never replaced for the remainder of this function (only its fields
-    // mutate). Wrap once as `ParentRef` so the two `save_lockfile` read sites
-    // below deref through the safe abstraction instead of per-site raw deref.
-    let lockfile_before_install = bun_ptr::ParentRef::<Lockfile>::new(&*manager.lockfile);
-
-    let save_format = load_result.save_format(&manager.options);
-
-    if manager.options.lockfile_only {
-        // save the lockfile and exit. make sure metahash is generated for binary lockfile
-        return save_lockfile_only(
-            manager,
-            ctx,
-            &load_result,
-            save_format,
-            had_any_diffs,
-            lockfile_before_install,
-            packages_len_before_install,
-            log_level,
-        );
-    }
-
-    let (workspace_filters, install_root_dependencies) =
-        get_workspace_filters(manager, original_cwd)?;
-    // `workspace_filters` drops at end of scope
-
-    let install_summary: PackageInstallSummary = 'install_summary: {
-        if !manager.options.do_.install_packages() {
-            break 'install_summary PackageInstallSummary::default();
         }
 
-        let mut linker = manager.options.node_linker;
-        loop {
-            match linker {
-                NodeLinker::Auto => match config_version {
-                    ConfigVersion::V0 => {
-                        linker = NodeLinker::Hoisted;
-                        continue;
-                    }
-                    ConfigVersion::V1 => {
-                        if !load_result.migrated_from_npm()
-                            && manager.lockfile.workspace_paths.len() > 0
-                        {
-                            linker = NodeLinker::Isolated;
+        // BACKREF: `manager.lockfile` is a `Box<Lockfile>` whose allocation is
+        // never replaced for the remainder of this function (only its fields
+        // mutate). Wrap once as `ParentRef` so the two `save_lockfile` read sites
+        // below deref through the safe abstraction instead of per-site raw deref.
+        let lockfile_before_install = bun_ptr::ParentRef::<Lockfile>::new(&*manager.lockfile);
+
+        let save_format = load_result.save_format(&manager.options);
+
+        if manager.options.lockfile_only {
+            // save the lockfile and exit. make sure metahash is generated for binary lockfile
+            return save_lockfile_only(
+                manager,
+                ctx,
+                &load_result,
+                save_format,
+                had_any_diffs,
+                lockfile_before_install,
+                packages_len_before_install,
+                log_level,
+            );
+        }
+
+        let (workspace_filters, install_root_dependencies) =
+            get_workspace_filters(manager, original_cwd)?;
+        // `workspace_filters` drops at end of scope
+
+        let install_summary: PackageInstallSummary = 'install_summary: {
+            if !manager.options.do_.install_packages() {
+                break 'install_summary PackageInstallSummary::default();
+            }
+
+            let mut linker = manager.options.node_linker;
+            loop {
+                match linker {
+                    NodeLinker::Auto => match config_version {
+                        ConfigVersion::V0 => {
+                            linker = NodeLinker::Hoisted;
                             continue;
                         }
-                        linker = NodeLinker::Hoisted;
-                        continue;
-                    }
-                },
+                        ConfigVersion::V1 => {
+                            if !load_result.migrated_from_npm()
+                                && manager.lockfile.workspace_paths.len() > 0
+                            {
+                                linker = NodeLinker::Isolated;
+                                continue;
+                            }
+                            linker = NodeLinker::Hoisted;
+                            continue;
+                        }
+                    },
 
-                NodeLinker::Hoisted => {
-                    let summary = install_hoisted_packages(
-                        manager,
-                        ctx,
-                        &workspace_filters,
-                        install_root_dependencies,
-                        log_level,
-                        None,
-                    )?;
-                    if summary.fail == 0
-                        && matches!(
-                            manager.subcommand,
-                            Subcommand::Dedupe | Subcommand::Audit | Subcommand::Update
-                        )
-                    {
-                        crate::prune::remove_collapsed_copies(manager, &lockfile_before_clean);
+                    NodeLinker::Hoisted => {
+                        let summary = install_hoisted_packages(
+                            manager,
+                            &workspace_filters,
+                            install_root_dependencies,
+                            log_level,
+                            None,
+                        )?;
+                        if summary.fail == 0
+                            && matches!(
+                                manager.subcommand,
+                                Subcommand::Dedupe | Subcommand::Audit | Subcommand::Update
+                            )
+                        {
+                            crate::prune::remove_collapsed_copies(manager, &lockfile_before_clean);
+                        }
+                        break 'install_summary summary;
                     }
-                    break 'install_summary summary;
-                }
 
-                NodeLinker::Isolated => {
-                    break 'install_summary install_isolated_packages(
-                        manager,
-                        ctx,
-                        install_root_dependencies,
-                        &workspace_filters,
-                        None,
-                    )?;
+                    NodeLinker::Isolated => {
+                        break 'install_summary install_isolated_packages(
+                            manager,
+                            install_root_dependencies,
+                            &workspace_filters,
+                            None,
+                        )?;
+                    }
                 }
             }
+        };
+
+        if log_level != Options::LogLevel::Silent {
+            manager
+                .log
+                .print(std::ptr::from_mut(Output::error_writer()))?;
         }
-    };
+        if had_errors_before_cleaning_lockfile || manager.log.has_errors() {
+            Global::crash();
+        }
 
-    if log_level != Options::LogLevel::Silent {
-        manager
-            .log_mut()
-            .print(std::ptr::from_mut(Output::error_writer()))?;
-    }
-    if had_errors_before_cleaning_lockfile || manager.log_mut().has_errors() {
-        Global::crash();
-    }
-
-    let did_meta_hash_change =
+        let did_meta_hash_change =
         // If the lockfile was frozen, we already checked it
         !manager.options.enable.frozen_lockfile()
             && if load_result.loaded_from_text_lockfile() {
@@ -938,120 +865,106 @@ pub fn install_with_manager(
                 )?
             };
 
-    // It's unnecessary work to re-save the lockfile if there are no changes.
-    // A loaded text lockfile is never re-saved just to bump its version: an
-    // existing `bun.lock` keeps the version it was written with.
-    let should_save_lockfile = saves_migrated_lockfile(&load_result, save_format)
+        // It's unnecessary work to re-save the lockfile if there are no changes.
+        // A loaded text lockfile is never re-saved just to bump its version: an
+        // existing `bun.lock` keeps the version it was written with.
+        let should_save_lockfile = saves_migrated_lockfile(&load_result, save_format)
         // check `save_lockfile` after checking if loaded from binary and save format is text
         // because `save_lockfile` is set to false for `--frozen-lockfile`
         || (manager.options.do_.save_lockfile()
             && (did_meta_hash_change
                 || had_any_diffs
                 || !manager.update_requests.is_empty()
-                || (matches!(load_result, lockfile::LoadResult::Ok { .. })
+                || (matches!(load_result, lockfile::DetachedLoadResult::Ok { .. })
                     && (load_result.ok().serializer_result.packages_need_update
                         || load_result.ok().serializer_result.migrated_from_lockb_v2))
                 || manager.lockfile.is_empty()
                 || manager.options.enable.force_save_lockfile()));
 
-    if should_save_lockfile {
-        save_lockfile(
-            manager,
-            &load_result,
-            save_format,
-            had_any_diffs,
-            lockfile_before_install.get(),
-            packages_len_before_install,
-            log_level,
-        )?;
-    }
+        if should_save_lockfile {
+            save_lockfile(
+                manager,
+                &load_result,
+                save_format,
+                had_any_diffs,
+                lockfile_before_install.get(),
+                packages_len_before_install,
+                log_level,
+            )?;
+        }
 
-    // Before root lifecycle scripts, which exit the process on failure.
-    super::package_json_write_back::flush(manager)?;
+        // Before root lifecycle scripts, which exit the process on failure.
+        super::package_json_write_back::flush(manager)?;
 
-    if needs_new_lockfile {
-        manager.summary.add = manager.lockfile.packages.len() as u32;
-    }
+        if needs_new_lockfile {
+            manager.summary.add = manager.lockfile.packages.len() as u32;
+        }
 
-    if manager.options.do_.save_yarn_lock() {
-        write_yarn_lock_with_progress(manager, log_level)?;
-    }
+        if manager.options.do_.save_yarn_lock() {
+            write_yarn_lock_with_progress(manager, log_level)?;
+        }
 
-    if manager.options.do_.run_scripts() && install_root_dependencies && !manager.options.global {
-        run_root_lifecycle_scripts(manager, ctx, log_level)?;
-    }
+        if manager.options.do_.run_scripts() && install_root_dependencies && !manager.options.global
+        {
+            run_root_lifecycle_scripts(manager, log_level)?;
+        }
 
-    if log_level != Options::LogLevel::Silent {
-        print_install_summary(
-            manager,
-            ctx,
-            &install_summary,
-            did_meta_hash_change,
-            requests_removed_from_lockfile,
-            log_level,
-        )?;
-    }
+        if log_level != Options::LogLevel::Silent {
+            print_install_summary(
+                manager,
+                ctx,
+                &install_summary,
+                did_meta_hash_change,
+                requests_removed_from_lockfile,
+                log_level,
+            )?;
+        }
 
-    if install_summary.fail > 0 {
-        manager.any_failed_to_install = true;
-    }
+        if install_summary.fail > 0 {
+            manager.any_failed_to_install = true;
+        }
 
-    Output::flush();
-    Ok(())
+        Output::flush();
+        Ok(())
+    })();
+    manager.root_lifecycle_scripts = None;
+    result
 }
 
-// ─── runAndWaitFn closure family ──────────────────────────────────────────
+// ─── run_and_wait closure family ──────────────────────────────────────────
 // A const-generic struct + three thin wrapper fns.
 
-/// `RunTasksCallbacks` impl for the void-callback `runTasks` call inside
-/// `runAndWaitFn::isDone` (no hooks, `progress_bar = true`). Only these
-/// flags differ from the default.
-struct InstallWaitCallbacks;
-impl RunTasksCallbacks for InstallWaitCallbacks {
-    type Ctx = ();
-    const PROGRESS_BAR: bool = true;
+/// `RunTasksCtx` for the hook-less `run_tasks` call inside
+/// `run_and_wait` / `is_done` (`progress_bar = true`).
+struct InstallWaitCtx<'a>(&'a mut PackageManager);
+impl RunTasksCtx for InstallWaitCtx<'_> {
+    fn manager(&mut self) -> &mut PackageManager {
+        self.0
+    }
+    fn progress_bar(&self) -> bool {
+        true
+    }
 }
 
-struct RunAndWaitClosure<const CHECK_PEERS: bool, const ONLY_PRE_PATCH: bool> {
-    // The caller also holds the same
-    // pointer to call `sleepUntil`. Storing `&mut PackageManager` would alias the outer
-    // borrow in `run_and_wait`. Keep a raw pointer; `run_and_wait` derives this pointer
-    // first and then reborrows *through it* for the `sleep_until` receiver, so both the
-    // receiver and the callback's reborrow share the same raw provenance root.
-    // See `run_and_wait` for the remaining `tick`/`event_loop` overlap note.
-    manager: *mut PackageManager,
-    err: Option<crate::Error>,
-}
+struct RunAndWaitClosure<const CHECK_PEERS: bool, const ONLY_PRE_PATCH: bool>;
 
 impl<const CHECK_PEERS: bool, const ONLY_PRE_PATCH: bool>
     RunAndWaitClosure<CHECK_PEERS, ONLY_PRE_PATCH>
 {
-    fn is_done(closure: &mut Self) -> bool {
-        // SAFETY: `closure.manager` is the raw provenance root set in `run_and_wait`.
-        // `sleep_until` is now an associated fn taking `*mut PackageManager` and
-        // `AnyEventLoop::tick_raw` reborrows the event loop only *between* `is_done`
-        // calls, so this `&mut PackageManager` is the unique live borrow for the
-        // duration of the callback (no `&mut event_loop` straddles it). The original
-        // `this: &mut` in `run_and_wait` is dead past the `let mgr = ...` line.
-        let this = unsafe { &mut *closure.manager };
+    fn is_done(this: &mut PackageManager, err: &mut Option<crate::Error>) -> bool {
         loop {
             if CHECK_PEERS {
-                if let Err(err) = this.process_peer_dependency_list() {
-                    closure.err = Some(err);
+                if let Err(e) = this.process_peer_dependency_list() {
+                    *err = Some(e);
                     return true;
                 }
             }
 
             this.drain_dependency_list();
 
-            // void RunTasksCallbacks — the trait dispatch needs a
-            // concrete `RunTasksCallbacks` impl; `extract_ctx` collapses to `()` so we
-            // do NOT pass `this` as both receiver and ctx (would alias `&mut`).
             let log_level = this.options.log_level;
-            if let Err(err) =
-                run_tasks::<InstallWaitCallbacks>(this, &mut (), CHECK_PEERS, log_level)
-            {
-                closure.err = Some(err);
+            if let Err(e) = run_tasks(&mut InstallWaitCtx(this), CHECK_PEERS, log_level) {
+                *err = Some(e);
                 return true;
             }
 
@@ -1073,7 +986,7 @@ impl<const CHECK_PEERS: bool, const ONLY_PRE_PATCH: bool>
         let pending_tasks = this.pending_task_count();
 
         if PackageManager::verbose_install() && pending_tasks > 0 {
-            if PackageManager::has_enough_time_passed_between_waiting_messages() {
+            if this.has_enough_time_passed_between_waiting_messages() {
                 bun_core::pretty_errorln!(
                     "<d>[PackageManager]<r> waiting for {} tasks\n",
                     pending_tasks,
@@ -1085,29 +998,12 @@ impl<const CHECK_PEERS: bool, const ONLY_PRE_PATCH: bool>
     }
 
     fn run_and_wait(this: &mut PackageManager) -> crate::Result<()> {
-        // Derive the raw pointer first and route *every* manager access through it.
-        // Previously `closure.manager` was taken from `this`, then `this` was reborrowed
-        // into `sleep_until`'s `&mut self` — under Stacked Borrows that reborrow popped
-        // the raw pointer's tag, so the later `&mut *closure.manager` in `is_done` used
-        // an invalidated provenance. Now `mgr` is the root: both the `sleep_until`
-        // receiver and the closure share it, and `this` is never touched again.
-        let mgr: *mut PackageManager = this;
-        let mut closure = RunAndWaitClosure::<CHECK_PEERS, ONLY_PRE_PATCH> {
-            manager: mgr,
-            err: None,
-        };
-
-        // SAFETY: `mgr` was just derived from the live exclusive `this` borrow above and
-        // is the sole access path for the manager from here on. `sleep_until` takes the
-        // raw pointer directly (no `&mut self` receiver) and `tick_raw` holds no
-        // `&mut event_loop` across `is_done`, so `closure.manager`'s reborrow inside the
-        // callback never invalidates a live tag.
-        unsafe { PackageManager::sleep_until(mgr, &mut closure, Self::is_done) };
-
-        if let Some(err) = closure.err {
-            return Err(err);
+        let mut err = None;
+        PackageManager::sleep_until(this, |this| Self::is_done(this, &mut err));
+        match err {
+            Some(err) => Err(err),
+            None => Ok(()),
         }
-        Ok(())
     }
 }
 
@@ -1234,22 +1130,14 @@ fn print_summary_tree(
     install_summary: &PackageInstallSummary,
     log_level: Options::LogLevel,
 ) -> crate::Result<()> {
-    // `Tree::print` reads `manager.{subcommand, workspace_name_hash, update_target_workspaces, updating_packages}` and writes `manager.{track_installed_bin, kept_patched_text, manifests}`, none overlapping the `Printer`'s `lockfile` / `options` / `update_requests` borrows.
-    let mgr: *mut PackageManager = this;
-    // `mgr` is the sole provenance root from here through the `Tree::print`
-    // call; the `Printer` reborrows shared `lockfile` / `options` /
-    // `update_requests`, and the `&mut *mgr` passed to `Tree::print` only
-    // touches disjoint `PackageManager` fields. Wrapped once as `ParentRef`
-    // so the three read-only field reborrows go through safe `Deref`
-    // instead of three per-site raw projections. Safe `From<NonNull>`
-    // construction — `mgr` was just derived from `&mut *this`.
-    let mgr_ref = bun_ptr::ParentRef::<PackageManager>::from(
-        core::ptr::NonNull::new(mgr).expect("derived from &mut, non-null"),
-    );
+    let mut print_state = crate::lockfile::printer_mods::tree_printer::PrintState {
+        kept_patched_text: core::mem::take(&mut this.kept_patched_text),
+        track_installed_bin: core::mem::take(&mut this.track_installed_bin),
+    };
     let printer = Printer {
-        lockfile: &mgr_ref.lockfile,
-        options: &mgr_ref.options,
-        updates: &mgr_ref.update_requests,
+        lockfile: &this.lockfile,
+        options: &this.options,
+        updates: &this.update_requests,
         successfully_installed: install_summary.successfully_installed.as_ref(),
     };
 
@@ -1258,27 +1146,20 @@ fn print_summary_tree(
     // We deliberately do not disable it after this.
     Output::enable_buffering();
     let writer = Output::writer_buffered();
-    // Runtime bool → const-generic dispatch.
-    if Output::enable_ansi_colors_stdout() {
-        LockfilePrinter::Tree::print::<_, true>(
-            &printer,
-            // SAFETY: `mgr` is the sole provenance root; `Tree::print` writes only fields
-            // disjoint from `printer`'s shared `lockfile`/`options`/`update_requests` borrows.
-            unsafe { &mut *mgr },
-            writer,
-            log_level,
-        )?;
+    let result = if Output::enable_ansi_colors_stdout() {
+        LockfilePrinter::Tree::print::<_, true>(&printer, this, &mut print_state, writer, log_level)
     } else {
         LockfilePrinter::Tree::print::<_, false>(
             &printer,
-            // SAFETY: `mgr` is the sole provenance root; `Tree::print` writes only fields
-            // disjoint from `printer`'s shared `lockfile`/`options`/`update_requests` borrows.
-            unsafe { &mut *mgr },
+            this,
+            &mut print_state,
             writer,
             log_level,
-        )?;
-    }
-    Ok(())
+        )
+    };
+    this.kept_patched_text = print_state.kept_patched_text;
+    this.track_installed_bin = print_state.track_installed_bin;
+    result
 }
 
 #[cold]
@@ -1435,7 +1316,7 @@ fn overrides_field_name(
     manager: &mut PackageManager,
     root_package_json_path: &ZStr,
 ) -> &'static str {
-    let log = manager.log_mut();
+    let log = &mut manager.log;
     let WorkspacePackageJsonCacheResult::Entry(entry) = manager
         .workspace_package_json_cache
         .get_with_path(log, root_package_json_path.as_bytes(), Default::default())
@@ -1450,7 +1331,7 @@ fn overrides_field_name(
     }
 }
 
-pub(crate) fn loaded_lockfile_name(load_result: &lockfile::LoadResult) -> &'static str {
+pub(crate) fn loaded_lockfile_name(load_result: &lockfile::DetachedLoadResult) -> &'static str {
     if load_result.loaded_from_binary_lockfile() {
         "bun.lockb"
     } else {
@@ -1461,12 +1342,10 @@ pub(crate) fn loaded_lockfile_name(load_result: &lockfile::LoadResult) -> &'stat
 /// Adds a contextual error for a dependency resolution failure.
 /// This provides better error messages than just propagating the raw error.
 /// The error is logged to manager.log, and the install will fail later when
-/// manager.log.hasErrors() is checked.
+/// manager.log.has_errors() is checked.
 #[cold]
 #[inline(never)]
 fn add_dependency_error(manager: &mut PackageManager, dependency: &Dependency, err: crate::Error) {
-    // reshaped for borrowck — capture the realname slice before
-    // taking `&mut` on `manager.log`.
     let realname = dependency.realname();
     let path = manager.lockfile.str(&realname).to_vec();
     let path_fmt = bun_core::fmt::fmt_path(
@@ -1480,7 +1359,7 @@ fn add_dependency_error(manager: &mut PackageManager, dependency: &Dependency, e
         },
     );
 
-    let log = manager.log_mut();
+    let log = &mut manager.log;
     if dependency.behavior.is_optional() || dependency.behavior.is_peer() {
         log.add_warning_with_note(
             None,
@@ -1527,11 +1406,11 @@ fn report_lockfile_load_error(
             bun_core::warn!("Ignoring lockfile");
         }
 
-        if manager.log_mut().errors > 0 {
+        if manager.log.errors > 0 {
             manager
-                .log_mut()
+                .log
                 .print(std::ptr::from_mut(Output::error_writer()))?;
-            manager.log_mut().reset();
+            manager.log.reset();
         }
         Output::flush();
     }
@@ -1767,9 +1646,6 @@ fn workspaces_reaching_request<'a>(
 #[inline(never)]
 fn record_updating_package_versions(manager: &mut PackageManager) {
     // existing lockfile, get the original version is updating
-    // reshaped for borrowck — the lockfile is read while
-    // also mutating `manager.updating_packages`. Field-level split
-    // borrow keeps the disjoint columns alive without raw pointers.
     let lockfile: &Lockfile = &manager.lockfile;
     let updating_packages = &mut manager.updating_packages;
     let packages = lockfile.packages.slice();
@@ -1869,7 +1745,7 @@ fn root_package_json_source(
     root_package_json_path: &ZStr,
 ) -> crate::Result<Source> {
     let (verb, err) = match manager.workspace_package_json_cache.get_with_path(
-        manager.log_mut(),
+        &mut manager.log,
         root_package_json_path.as_bytes(),
         Default::default(),
     ) {
@@ -1877,9 +1753,9 @@ fn root_package_json_source(
         WorkspacePackageJsonCacheResult::ReadErr(err) => ("read", err),
         WorkspacePackageJsonCacheResult::ParseErr(err) => ("parse", err),
     };
-    if manager.log_mut().errors > 0 {
+    if manager.log.errors > 0 {
         manager
-            .log_mut()
+            .log
             .print(std::ptr::from_mut(Output::error_writer()))?;
     }
     Output::err(
@@ -1894,7 +1770,7 @@ fn root_package_json_source(
 #[inline(never)]
 fn create_new_lockfile_and_enqueue(
     manager: &mut PackageManager,
-    load_result: &lockfile::LoadResult,
+    load_result: &lockfile::DetachedLoadResult,
     root_package_json_path: &ZStr,
     log_level: Options::LogLevel,
 ) -> crate::Result<lockfile::Package> {
@@ -1906,8 +1782,8 @@ fn create_new_lockfile_and_enqueue(
     // on-disk version so re-saving it still doesn't bump the format — matching
     // the "an existing lockfile keeps its version" behavior everywhere else.
     let preserved_text_version = match load_result {
-        lockfile::LoadResult::Ok(ok) if ok.format == lockfile::Format::Text => {
-            Some(ok.lockfile.text_lockfile_version)
+        lockfile::DetachedLoadResult::Ok(ok) if ok.format == lockfile::Format::Text => {
+            Some(manager.lockfile.text_lockfile_version)
         }
         _ => None,
     };
@@ -1917,7 +1793,7 @@ fn create_new_lockfile_and_enqueue(
     }
 
     if manager.options.enable.frozen_lockfile()
-        && !matches!(load_result, lockfile::LoadResult::NotFound)
+        && !matches!(load_result, lockfile::DetachedLoadResult::NotFound)
     {
         if log_level != Options::LogLevel::Silent {
             bun_core::pretty_errorln!(
@@ -1930,27 +1806,16 @@ fn create_new_lockfile_and_enqueue(
     let source_copy = root_package_json_source(manager, root_package_json_path)?;
 
     let mut resolver: () = ();
-    {
-        // `log_mut()` reads the BACKREF `self.log` and returns the disjoint
-        // CLI `Log` allocation (lifetime decoupled from `&self`); call it
-        // safely *before* the raw-ptr split.
-        let log = manager.log_mut();
-        let mgr: *mut PackageManager = manager;
-        // SAFETY: `mgr` is the sole provenance root; `parse` reborrows the
-        // disjoint `lockfile` field through it. No other live `&mut` to
-        // `*mgr` exists across the call.
+    manager.with_lockfile_and_log(|lockfile, manager, log| {
         root.parse(
-            // SAFETY: disjoint field projection through the sole provenance root `mgr`.
-            unsafe { &mut (*mgr).lockfile },
-            // SAFETY: `parse` touches only `PackageManager` fields disjoint from
-            // `lockfile` through this borrow; `mgr` is the sole provenance root.
-            unsafe { &mut *mgr },
+            lockfile,
+            manager,
             log,
             &source_copy,
             &mut resolver,
             Features::main(),
-        )?;
-    }
+        )
+    })?;
 
     root = manager.lockfile.append_package(&root)?;
 
@@ -2052,10 +1917,10 @@ fn wait_for_resolution(manager: &mut PackageManager) -> crate::Result<()> {
     }
 
     // Resolving a peer dep can create a NEW package whose own peer deps
-    // get re-queued to `peer_dependencies` during `drainDependencyList`.
+    // get re-queued to `peer_dependencies` during `drain_dependency_list`.
     // When all manifests are cached (synchronous resolution), no I/O tasks
-    // are spawned, so `pendingTaskCount() == 0`. We must drain the peer
-    // queue iteratively here — entering the event loop (`waitForPeers`)
+    // are spawned, so `pending_task_count() == 0`. We must drain the peer
+    // queue iteratively here — entering the event loop (`wait_for_peers`)
     // with zero pending I/O would block forever.
     while manager.peer_dependencies.readable_length() > 0 {
         manager.process_peer_dependency_list()?;
@@ -2163,13 +2028,13 @@ fn run_security_scanner(
 
 // bun.lockb / package-lock.json / yarn.lock / pnpm-lock.yaml -> bun.lock is written even under --frozen-lockfile.
 fn saves_migrated_lockfile(
-    load_result: &lockfile::LoadResult,
+    load_result: &lockfile::DetachedLoadResult,
     save_format: lockfile::Format,
 ) -> bool {
     save_format == lockfile::Format::Text
         && matches!(
             load_result,
-            lockfile::LoadResult::Ok(ok)
+            lockfile::DetachedLoadResult::Ok(ok)
                 if ok.format == lockfile::Format::Binary || ok.migrated != lockfile::Migrated::None
         )
 }
@@ -2180,7 +2045,7 @@ fn saves_migrated_lockfile(
 fn save_lockfile_only(
     manager: &mut PackageManager,
     ctx: Command::Context,
-    load_result: &lockfile::LoadResult,
+    load_result: &lockfile::DetachedLoadResult,
     save_format: lockfile::Format,
     had_any_diffs: bool,
     lockfile_before_install: bun_ptr::ParentRef<Lockfile>,
@@ -2250,9 +2115,6 @@ fn write_yarn_lock_with_progress(
     manager: &mut PackageManager,
     log_level: Options::LogLevel,
 ) -> crate::Result<()> {
-    // reshaped for borrowck — `Progress::start` returns
-    // `&mut self.root`, so re-access it via `manager.progress.root` after the
-    // `&mut manager` borrow ends instead of keeping a live `&mut Node`.
     let mut node_started = false;
     if log_level.show_progress() {
         manager.progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
@@ -2280,7 +2142,6 @@ fn write_yarn_lock_with_progress(
 #[inline(never)]
 fn run_root_lifecycle_scripts(
     manager: &mut PackageManager,
-    ctx: Command::Context,
     log_level: Options::LogLevel,
 ) -> crate::Result<()> {
     if let Some(scripts) = manager.root_lifecycle_scripts.take() {
@@ -2296,13 +2157,7 @@ fn run_root_lifecycle_scripts(
         let output_in_foreground = true;
         // `spawn_package_lifecycle_scripts` consumes by-value; `.take()`
         // moves it out (`package_name` is owned by the List and drops with it).
-        manager.spawn_package_lifecycle_scripts(
-            ctx,
-            scripts,
-            optional,
-            output_in_foreground,
-            None,
-        )?;
+        manager.spawn_package_lifecycle_scripts(scripts, optional, output_in_foreground, None)?;
 
         // .monotonic is okay because at this point, this value is only accessed from this
         // thread.

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -65,8 +65,7 @@ pub fn do_patch_commit(
 ) -> Result<Option<PatchCommitResult>, crate::Error> {
     let mut folder_path_buf = bun_paths::path_buffer_pool::get();
     let mut lockfile: Box<Lockfile> = Box::default();
-    let log = manager.log_mut();
-    match lockfile.load_from_cwd::<true>(Some(manager), log) {
+    match manager.with_log(|manager, log| lockfile.load_from_cwd::<true>(Some(manager), log)) {
         lockfile::LoadResult::NotFound => {
             Output::err_generic(
                 "Cannot find lockfile. Install packages with `<cyan>bun install<r>` before patching them.",
@@ -115,7 +114,6 @@ pub fn do_patch_commit(
         .root_package_id
         .get(&lockfile, manager.workspace_name_hash);
     let not_in_workspace_root = workspace_package_id != 0;
-    // reshaped for borrowck — owned buffer kept separately so `argument` can borrow it
     let mut argument_owned: Option<Box<[u8]>> = None;
     let argument: &[u8] = if arg_kind == PatchArgKind::Path
         && not_in_workspace_root
@@ -177,7 +175,7 @@ pub fn do_patch_commit(
                 };
 
             initialize_store();
-            let log = manager.log_mut();
+            let log = &mut manager.log;
             let parsed = match JSON::ParsedJson::parse_package_json(&package_json_source, log) {
                 Ok(p) => p,
                 Err(err) => {
@@ -208,16 +206,17 @@ pub fn do_patch_commit(
 
             let mut resolver: () = ();
             let mut package = Package::default();
-            let log = manager.log_mut();
-            package.parse_with_json::<()>(
-                &mut lockfile,
-                manager,
-                log,
-                &package_json_source,
-                json,
-                &mut resolver,
-                Features::FOLDER,
-            )?;
+            manager.with_log(|manager, log| {
+                package.parse_with_json::<()>(
+                    &mut lockfile,
+                    manager,
+                    log,
+                    &package_json_source,
+                    json,
+                    &mut resolver,
+                    Features::FOLDER,
+                )
+            })?;
 
             let actual_package = match lockfile.package_index.get(&package.name_hash) {
                 None => {
@@ -561,9 +560,9 @@ pub fn do_patch_commit(
 
     let patches_dir: &[u8] = match &manager.options.patch_features {
         PatchFeatures::Commit { patches_dir } => patches_dir,
-        // Reaching `doPatchCommit` implies `Subcommand::PatchCommit`, which always
+        // Reaching `do_patch_commit` implies `Subcommand::PatchCommit`, which always
         // sets `patch_features = .commit` in `Options::load`.
-        _ => unreachable!("patch_features must be Commit in doPatchCommit"),
+        _ => unreachable!("patch_features must be Commit in do_patch_commit"),
     };
 
     let path_in_patches_dir =
@@ -712,7 +711,6 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
         .root_package_id
         .get(&manager.lockfile, workspace_name_hash);
     let not_in_workspace_root = workspace_package_id != 0;
-    // reshaped for borrowck — owned buffer kept so `argument` can borrow it.
     let argument_owned: Option<Box<[u8]>>;
     let argument: &[u8] = if arg_kind == PatchArgKind::Path
         && not_in_workspace_root
@@ -751,7 +749,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                     };
 
                 initialize_store();
-                let log = manager.log_mut();
+                let log = &mut manager.log;
                 let parsed = match JSON::ParsedJson::parse_package_json(&package_json_source, log) {
                     Ok(p) => p,
                     Err(err) => {
@@ -782,25 +780,17 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
 
                 let mut resolver: () = ();
                 let mut package = Package::default();
-                let log = manager.log_mut();
-                // borrowck — `parse_with_json` needs `&mut Lockfile` and
-                // `&mut PackageManager` simultaneously, but the lockfile here is
-                // `manager.lockfile`. Temporarily move the Box out so the two
-                // borrows are disjoint; `parse_with_json` never reads `pm.lockfile`
-                // (it takes the lockfile as its own parameter). Restore before
-                // propagating any error so `manager` is never left half-torn.
-                let mut lockfile: Box<Lockfile> = core::mem::take(&mut manager.lockfile);
-                let parse_result = package.parse_with_json::<()>(
-                    &mut lockfile,
-                    manager,
-                    log,
-                    &package_json_source,
-                    json,
-                    &mut resolver,
-                    Features::FOLDER,
-                );
-                manager.lockfile = lockfile;
-                parse_result?;
+                manager.with_lockfile_and_log(|lockfile, manager, log| {
+                    package.parse_with_json::<()>(
+                        lockfile,
+                        manager,
+                        log,
+                        &package_json_source,
+                        json,
+                        &mut resolver,
+                        Features::FOLDER,
+                    )
+                })?;
                 let lockfile: &Lockfile = &manager.lockfile;
                 let strbuf = lockfile.buffers.string_bytes.as_slice();
 
@@ -948,7 +938,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
     //
     // With the isolated linker's global virtual store, `module_folder` is
     // reached *through* a `node_modules/.bun/<storepath>` symlink that points
-    // into `<cache>/links/`. `deleteTree(module_folder)` would follow that
+    // into `<cache>/links/`. `delete_tree(module_folder)` would follow that
     // symlink and wipe the shared global entry (and its dep symlinks)
     // underneath every other project, then FileCopier would write the user's
     // edits into the shared cache. Detach first: walk up `module_folder` to
@@ -1042,9 +1032,9 @@ fn is_real_dir_not_symlink(path: &[u8]) -> bool {
 
 fn detach_module_folder_from_shared_store(module_folder: &[u8]) {
     // `module_folder` reaches here normalised to forward slashes on every
-    // platform (see `pathToPosixBuf` in `preparePatch`). Re-normalise to the
+    // platform (see `prepare_patch`). Re-normalise to the
     // platform separator so `undo()`/`basename()` walk the path correctly on
-    // Windows and the lstat/getFileAttributes calls below see a native path.
+    // Windows and the lstat/get_file_attributes calls below see a native path.
     #[cfg(windows)]
     let mut native_buf = bun_paths::path_buffer_pool::get();
     #[cfg(windows)]
@@ -1088,7 +1078,7 @@ fn detach_module_folder_from_shared_store(module_folder: &[u8]) {
             // Windows directory symlinks/junctions are removed with rmdir,
             // file symlinks with unlink; on POSIX unlink covers both. If
             // removal fails the symlink is still live, and the caller's
-            // `deleteTree` + `FileCopier` would follow it into the shared
+            // `delete_tree` + `FileCopier` would follow it into the shared
             // global-store entry — so fail loudly here rather than silently
             // corrupting the cache.
             let remove_err: Option<sys::Error> = {
@@ -1211,11 +1201,9 @@ fn overwrite_package_in_node_modules_folder(
 
 type NodeModulesIterator<'a> = tree::Iterator<'a, { tree::IteratorPathStyle::NodeModules }>;
 
-// reshaped for borrowck — `tree::Iterator::next` returns an
-// `IteratorNext<'_>` borrowing the iterator's internal `path_buf`, so we
-// cannot return it from inside a `while let` (borrowck rejects the next
-// iteration's reborrow even though it's unreachable). Callers only need
-// `relative_path`, so copy it out into an owned `Vec<u8>`.
+// `tree::Iterator::next` returns an `IteratorNext<'_>` borrowing the
+// iterator's `path_buf`; callers only need `relative_path`, so it is copied
+// out into an owned `Vec<u8>`.
 
 fn node_modules_folder_for_dependency_ids(
     iterator: &mut NodeModulesIterator<'_>,

--- a/src/install/PackageManager/processDependencyList.rs
+++ b/src/install/PackageManager/processDependencyList.rs
@@ -54,7 +54,7 @@ impl<'a> ResolverContext for GitResolver<'a> {
     ) -> Result<ResolutionType<u64>, crate::Error> {
         // `git` and `github` share the `Repository` payload in the value union,
         // so writing through `.github` is correct for both tags.
-        // SAFETY: caller guarantees `tag` is `.git` or `.github` (see
+        // Caller guarantees `tag` is `.git` or `.github` (see
         // `process_extracted_tarball_package`); both store a `Repository`.
         let mut repo = *self.resolution.repository();
         repo.resolved = builder.append::<SemverString>(self.resolved);
@@ -148,17 +148,16 @@ impl PackageManager {
                         let package_json_source =
                             &bun_ast::Source::init_path_string(&json.path[..], &json.buf[..]);
 
-                        // SAFETY: `self` is a live `&mut PackageManager`; the callee
-                        // split-borrows `self.lockfile` / `self.log` (separate
-                        // allocations) alongside `self` for the call's duration.
-                        if let Err(err) = unsafe {
-                            pkg.parse_from_real_manager(
-                                std::ptr::from_mut::<PackageManager>(self),
+                        if let Err(err) = self.with_lockfile_and_log(|lockfile, pm, log| {
+                            pkg.parse(
+                                lockfile,
+                                pm,
+                                log,
                                 package_json_source,
                                 &mut resolver,
                                 Features::NPM,
                             )
-                        } {
+                        }) {
                             if log_level != LogLevel::Silent {
                                 let string_buf = self.lockfile.buffers.string_bytes.as_slice();
                                 Output::err(
@@ -192,7 +191,6 @@ impl PackageManager {
                         self.lockfile.buffers.string_bytes.as_slice(),
                         &self.lockfile.buffers.dependencies[dep_id as usize],
                     );
-                    // `defer manager.allocator.free(new_name)` — `new_name: Vec<u8>` drops at scope end.
 
                     {
                         let mut builder = self.lockfile.string_builder();
@@ -245,17 +243,16 @@ impl PackageManager {
                     resolution,
                 };
 
-                // SAFETY: `self` is a live `&mut PackageManager`; the callee
-                // split-borrows `self.lockfile` / `self.log` (separate
-                // allocations) alongside `self` for the call's duration.
-                if let Err(err) = unsafe {
-                    package.parse_from_real_manager(
-                        std::ptr::from_mut::<PackageManager>(self),
+                if let Err(err) = self.with_lockfile_and_log(|lockfile, pm, log| {
+                    package.parse(
+                        lockfile,
+                        pm,
+                        log,
                         package_json_source,
                         &mut resolver,
                         Features::NPM,
                     )
-                } {
+                }) {
                     if log_level != LogLevel::Silent {
                         let string_buf = self.lockfile.buffers.string_bytes.as_slice();
                         bun_core::pretty_errorln!(
@@ -299,9 +296,7 @@ impl PackageManager {
                     let package_json_source =
                         &bun_ast::Source::init_path_string(&json.path[..], &json.buf[..]);
                     initialize_store();
-                    // SAFETY: `self.log` is set once by `PackageManager::init()` and
-                    // never null while tasks run.
-                    let log = self.log_mut();
+                    let log = &mut self.log;
                     let parsed = match json::ParsedJson::parse_package_json(
                         package_json_source,
                         log,
@@ -421,29 +416,17 @@ impl PackageManager {
         Ok(())
     }
 
-    pub(crate) fn process_dependency_list<C>(
+    /// Returns whether any root dependency's resolution changed (the caller
+    /// runs its `on_resolve` hook if so).
+    pub(crate) fn process_dependency_list(
         &mut self,
-        dep_list: TaskCallbackList,
-        ctx: C,
-        on_resolve: Option<impl FnOnce(C)>,
+        dep_list: &TaskCallbackList,
         install_peer: bool,
-    ) -> Result<(), crate::Error> {
-        if !dep_list.is_empty() {
-            let dependency_list = dep_list;
-            let any_root = Cell::new(false);
-            for item in dependency_list.iter() {
-                self.process_dependency_list_item(item, Some(&any_root), install_peer)?;
-            }
-
-            if let Some(on_resolve) = on_resolve {
-                if any_root.get() {
-                    on_resolve(ctx);
-                }
-            }
-
-            // `dependency_list.deinit(this.allocator)` — owned `Vec`; drops here.
-            drop(dependency_list);
+    ) -> Result<bool, crate::Error> {
+        let any_root = Cell::new(false);
+        for item in dep_list.iter() {
+            self.process_dependency_list_item(item, Some(&any_root), install_peer)?;
         }
-        Ok(())
+        Ok(any_root.get())
     }
 }

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -3,29 +3,22 @@ use core::cell::Cell;
 use core::sync::atomic::Ordering;
 use std::io::Write as _;
 
+use bun_core::Output;
 use bun_core::strings;
-use bun_core::{Environment, Output};
 use bun_http::{self as http, AsyncHTTP};
-use bun_threading::thread_pool::Batch as ThreadPoolBatch;
 
 use crate::extract_tarball;
 use crate::network_task::Callback as NetworkTaskCallback;
 use crate::npm;
-use crate::patch_install::{Callback as PatchTaskCallback, PatchTask};
+use crate::patch_install::Callback as PatchTaskCallback;
 use crate::tarball_stream::TarballStream;
 use bun_install::{
     DependencyID, ExtractTarball, INVALID_PACKAGE_ID, NetworkTask, PackageID, PackageManifestError,
     Repository,
 };
 // Import the *module* under the `Task` name so `Task::Id` resolves as a path.
-use super::{
-    Command, PackageInstaller, PackageManager, ProgressStrings, Subcommand, TaskCallbackList,
-};
+use super::{PackageManager, ProgressStrings, Subcommand, TaskCallbackList};
 use super::{directories, enqueue};
-use crate::dependency::Behavior;
-use crate::isolated_install::installer as store_installer;
-use crate::isolated_install::store::{EntryColumns as _, NodeColumns as _};
-use crate::lifecycle_script_runner::InstallCtx;
 use crate::network_task::{Authorization, ForTarballError};
 use crate::package_manifest_map::Value as ManifestEntry;
 use bun_core::fmt::PathSep;
@@ -35,53 +28,56 @@ use bun_install::package_manager_task as Task;
 // (matches the `Task` module-alias pattern above and `CommandLineArguments.rs`).
 use super::package_manager_options as Options;
 use super::package_manager_options::{Do, Enable};
-use crate::isolated_install::store as Store;
 
 // ──────────────────────────────────────────────────────────────────────────
 // Callbacks trait
 // ──────────────────────────────────────────────────────────────────────────
 //
-// A single trait with associated consts gating the
-// optional hooks (default-unreachable bodies), plus associated-const tags for
-// the `Ctx` identity checks. The trait branches on three `Ctx` identities
-// (`PackageInstaller`, `Store.Installer`, neither), but there are six impls
-// across four `Ctx` shapes: `PackageInstaller` (`HoistedRunTasksCallbacks`),
-// `Store::Installer` (`StoreRunTasksCallbacks`), unit
-// (`VoidRunTasksCallbacks`, `ManifestsOnlyCallbacks`, `InstallWaitCallbacks`),
-// and `Queue` (`QueueRunTasksCallbacks` in `src/jsc/AsyncModule.rs`).
-pub trait RunTasksCallbacks {
-    /// Mirrors `Ctx` (the `extract_ctx` value type).
-    type Ctx;
+// Object-safe so the ~2k-line body of `run_tasks` is compiled once. The
+// context owns access to the `PackageManager` (`manager()`); `run_tasks`
+// re-derives it after every hook call so no `&mut PackageManager` is live
+// while a hook that can reach the same manager runs. Impls: `PackageInstaller`
+// (hoisted), `Store::Installer` (isolated), the void/manifests-only contexts in
+// this crate, and the auto-install `Queue` in `src/jsc/AsyncModule.rs`.
+pub trait RunTasksCtx {
+    fn manager(&mut self) -> &mut PackageManager;
 
-    const PROGRESS_BAR: bool = false;
-    const MANIFESTS_ONLY: bool = false;
+    fn progress_bar(&self) -> bool {
+        false
+    }
+    fn manifests_only(&self) -> bool {
+        false
+    }
+    fn has_on_extract(&self) -> bool {
+        false
+    }
+    fn has_on_package_manifest_error(&self) -> bool {
+        false
+    }
+    fn has_on_package_download_error(&self) -> bool {
+        false
+    }
+    fn has_on_resolve(&self) -> bool {
+        false
+    }
+    /// `PackageInstaller` (hoisted linker)
+    fn is_package_installer(&self) -> bool {
+        false
+    }
+    /// `Store::Installer` (isolated linker)
+    fn is_store_installer(&self) -> bool {
+        false
+    }
 
-    const HAS_ON_EXTRACT: bool = false;
-    const HAS_ON_PACKAGE_MANIFEST_ERROR: bool = false;
-    const HAS_ON_PACKAGE_DOWNLOAD_ERROR: bool = false;
-    const HAS_ON_RESOLVE: bool = false;
-
-    /// `Ctx == *PackageInstaller`
-    const IS_PACKAGE_INSTALLER: bool = false;
-    /// `Ctx == *Store.Installer`
-    const IS_STORE_INSTALLER: bool = false;
-
-    fn on_package_manifest_error(
-        _ctx: &mut Self::Ctx,
-        _name: &[u8],
-        _err: crate::Error,
-        _url: &[u8],
-    ) {
+    fn on_package_manifest_error(&mut self, _name: &[u8], _err: crate::Error, _url: &[u8]) {
         unreachable!()
     }
 
-    // `onPackageDownloadError` is called with two distinct shapes depending
-    // on the `Ctx`: `task.task_id: Task::Id` for the store installer,
-    // `package_id: PackageID` otherwise. Static dispatch via two trait
-    // methods lets impls receive the correctly-typed id without a
-    // `Task::Id` round-trip pun.
+    // `on_package_download_error` is called with two distinct shapes depending
+    // on the context: `task.task_id: Task::Id` for the store installer,
+    // `package_id: PackageID` otherwise.
     fn on_package_download_error_store(
-        _ctx: &mut Self::Ctx,
+        &mut self,
         _task_id: Task::Id,
         _name: &[u8],
         _resolution: &bun_install::Resolution,
@@ -91,7 +87,7 @@ pub trait RunTasksCallbacks {
         unreachable!()
     }
     fn on_package_download_error_pkg(
-        _ctx: &mut Self::Ctx,
+        &mut self,
         _package_id: PackageID,
         _name: &[u8],
         _resolution: &bun_install::Resolution,
@@ -102,233 +98,127 @@ pub trait RunTasksCallbacks {
     }
 
     fn on_extract_package_installer(
-        _ctx: &mut Self::Ctx,
+        &mut self,
         _task_id: Task::Id,
         _dependency_id: DependencyID,
-        _data: &mut bun_install::ExtractData,
+        _data: &bun_install::ExtractData,
         _log_level: Options::LogLevel,
     ) {
         unreachable!()
     }
-    fn on_extract_store_installer(_ctx: &mut Self::Ctx, _task_id: Task::Id) {
+    fn on_extract_store_installer(&mut self, _task_id: Task::Id) {
         unreachable!()
     }
 
-    fn on_resolve(_ctx: &mut Self::Ctx) {
+    fn on_resolve(&mut self) {
+        unreachable!()
+    }
+
+    /// `PackageInstaller` only: a patch task with an install context finished;
+    /// install the now-patched package into that context's `node_modules`.
+    fn on_patch_applied(
+        &mut self,
+        _install_context: &mut crate::patch_install::InstallContext,
+        _pkg_id: PackageID,
+        _pkg_name: bun_semver::String,
+        _log_level: Options::LogLevel,
+    ) {
+        unreachable!()
+    }
+
+    /// A lifecycle script run for a store entry finished (isolated installs).
+    fn on_lifecycle_script_event(
+        &mut self,
+        entry_id: crate::isolated_install::store::entry::Id,
+        event: crate::lifecycle_script_runner::EntryEvent,
+    ) {
+        let _ = (entry_id, event);
+        unreachable!("lifecycle script with a store entry outside the isolated installer");
+    }
+
+    /// `Store::Installer` only: drain the finished isolated-install tasks.
+    fn drain_store_tasks(&mut self, _log_level: Options::LogLevel) {
         unreachable!()
     }
 }
 
-/// Type-erased view of a `RunTasksCallbacks` impl, so the ~2k-line body of
-/// `run_tasks` is compiled once rather than once per callbacks type. Every fn
-/// pointer expects `ctx` to be the `*mut C::Ctx` it was erased alongside.
-struct ErasedCallbacks {
-    progress_bar: bool,
-    manifests_only: bool,
-    has_on_extract: bool,
-    has_on_package_manifest_error: bool,
-    has_on_package_download_error: bool,
-    has_on_resolve: bool,
-    is_package_installer: bool,
-    is_store_installer: bool,
-    on_package_manifest_error: fn(*mut (), &[u8], crate::Error, &[u8]),
-    on_package_download_error_store:
-        fn(*mut (), Task::Id, &[u8], &bun_install::Resolution, crate::Error, &[u8]),
-    on_package_download_error_pkg:
-        fn(*mut (), PackageID, &[u8], &bun_install::Resolution, crate::Error, &[u8]),
-    on_extract_package_installer:
-        fn(*mut (), Task::Id, DependencyID, &mut bun_install::ExtractData, Options::LogLevel),
-    on_extract_store_installer: fn(*mut (), Task::Id),
-    on_resolve: fn(*mut ()),
-}
-
-impl ErasedCallbacks {
-    fn of<C: RunTasksCallbacks>() -> Self {
-        /// Recovers the `&mut C::Ctx` that `run_tasks::<C>` erased.
-        fn ctx<'a, C: RunTasksCallbacks>(ctx: *mut ()) -> &'a mut C::Ctx {
-            // SAFETY: only ever called by `run_tasks_erased` with the pointer
-            // `run_tasks::<C>` erased from a `&mut C::Ctx`, which is the sole
-            // live handle to that context for the duration of the call.
-            unsafe { &mut *ctx.cast() }
-        }
-        Self {
-            progress_bar: C::PROGRESS_BAR,
-            manifests_only: C::MANIFESTS_ONLY,
-            has_on_extract: C::HAS_ON_EXTRACT,
-            has_on_package_manifest_error: C::HAS_ON_PACKAGE_MANIFEST_ERROR,
-            has_on_package_download_error: C::HAS_ON_PACKAGE_DOWNLOAD_ERROR,
-            has_on_resolve: C::HAS_ON_RESOLVE,
-            is_package_installer: C::IS_PACKAGE_INSTALLER,
-            is_store_installer: C::IS_STORE_INSTALLER,
-            on_package_manifest_error: |c, name, err, url| {
-                C::on_package_manifest_error(ctx::<C>(c), name, err, url)
-            },
-            on_package_download_error_store: |c, task_id, name, resolution, err, url| {
-                C::on_package_download_error_store(ctx::<C>(c), task_id, name, resolution, err, url)
-            },
-            on_package_download_error_pkg: |c, package_id, name, resolution, err, url| {
-                C::on_package_download_error_pkg(
-                    ctx::<C>(c),
-                    package_id,
-                    name,
-                    resolution,
-                    err,
-                    url,
-                )
-            },
-            on_extract_package_installer: |c, task_id, dependency_id, data, log_level| {
-                C::on_extract_package_installer(
-                    ctx::<C>(c),
-                    task_id,
-                    dependency_id,
-                    data,
-                    log_level,
-                )
-            },
-            on_extract_store_installer: |c, task_id| {
-                C::on_extract_store_installer(ctx::<C>(c), task_id)
-            },
-            on_resolve: |c| C::on_resolve(ctx::<C>(c)),
-        }
+/// `RunTasksCtx` for callers with no hooks: the manager itself.
+impl RunTasksCtx for PackageManager {
+    fn manager(&mut self) -> &mut PackageManager {
+        self
     }
 }
 
-impl ErasedCallbacks {
-    /// `ctx` *is* the installer when `is_package_installer` (`C::Ctx == PackageInstaller`).
-    fn package_installer<'a>(&self, ctx: *mut ()) -> &'a mut PackageInstaller<'a> {
-        debug_assert!(self.is_package_installer);
-        // SAFETY: `is_package_installer` means `C::Ctx == PackageInstaller`, and
-        // `ctx` is the erased `&mut C::Ctx` (see `ErasedCallbacks::of`).
-        unsafe { &mut *ctx.cast() }
-    }
-
-    /// `ctx` *is* the installer when `is_store_installer` (`C::Ctx == Store::Installer`).
-    fn store_installer<'a>(&self, ctx: *mut ()) -> &'a mut Store::Installer<'a> {
-        debug_assert!(self.is_store_installer);
-        // SAFETY: `is_store_installer` means `C::Ctx == Store::Installer`, and
-        // `ctx` is the erased `&mut C::Ctx` (see `ErasedCallbacks::of`).
-        unsafe { &mut *ctx.cast() }
-    }
-}
-
-/// Called from isolated_install on the main thread.
-pub fn run_tasks<C: RunTasksCallbacks>(
-    manager: &mut PackageManager,
-    extract_ctx: &mut C::Ctx,
+/// Drain finished network/extract/git/patch work into the lockfile and
+/// enqueue whatever it unblocks. Main thread only.
+pub fn run_tasks(
+    ctx: &mut dyn RunTasksCtx,
     install_peer: bool,
     log_level: Options::LogLevel,
 ) -> crate::Result<()> {
-    run_tasks_erased(
-        manager,
-        core::ptr::from_mut(extract_ctx).cast(),
-        &ErasedCallbacks::of::<C>(),
+    let mut state = RunState {
+        flags: CtxFlags {
+            manifests_only: ctx.manifests_only(),
+            has_on_extract: ctx.has_on_extract(),
+            has_on_package_manifest_error: ctx.has_on_package_manifest_error(),
+            has_on_package_download_error: ctx.has_on_package_download_error(),
+            has_on_resolve: ctx.has_on_resolve(),
+            is_package_installer: ctx.is_package_installer(),
+            is_store_installer: ctx.is_store_installer(),
+        },
+        has_updated_this_run: false,
+        has_network_error: false,
+        timestamp_this_tick: None,
         install_peer,
         log_level,
-    )
+    };
+    let result = run_tasks_body(ctx, &mut state);
+
+    let progress_bar = ctx.progress_bar();
+    let manager = ctx.manager();
+    manager.drain_dependency_list();
+
+    if log_level.show_progress() {
+        manager.start_progress_bar_if_none();
+
+        if progress_bar {
+            let completed_items = (manager.total_tasks - manager.pending_task_count()) as usize;
+            let total_tasks = manager.total_tasks as usize;
+            let node = manager.downloads_node_mut();
+            if completed_items != node.unprotected_completed_items.load(Ordering::Relaxed)
+                || state.has_updated_this_run
+            {
+                node.set_completed_items(completed_items);
+                node.set_estimated_total_items(total_tasks);
+            }
+        }
+        manager.downloads_node_mut().activate();
+        manager.progress.maybe_refresh();
+    }
+
+    result
 }
 
-fn run_tasks_erased(
-    manager: &mut PackageManager,
-    extract_ctx: *mut (),
-    cb: &ErasedCallbacks,
-    install_peer: bool,
-    log_level: Options::LogLevel,
-) -> crate::Result<()> {
-    // `Cell<bool>` so the `scopeguard::defer!` below can read it via `&self`
-    // while the loop body sets it — no raw-ptr provenance dance needed.
-    let has_updated_this_run = Cell::new(false);
-    let mut has_network_error = false;
+fn run_tasks_body(ctx: &mut dyn RunTasksCtx, state: &mut RunState) -> crate::Result<()> {
+    let log_level = state.log_level;
 
-    let mut timestamp_this_tick: Option<u32> = None;
-
-    // scopeguard captures `manager` via raw pointer because the loop
-    // body holds `&mut` to it for the function's duration; `has_updated_this_run`
-    // is a `Cell<bool>` so the guard captures it by shared ref. The guard runs
-    // on every exit (incl. `?` early-returns).
-    //
-    // Stacked Borrows: the raw pointers must remain the provenance root for all
-    // body accesses, otherwise the first direct use of the `&mut` fn params
-    // would pop the raw tags and the guard derefs become UB. We therefore
-    // shadow the params with reborrows *through* the raw pointers — every body
-    // use of `manager`/`extract_ctx` below is a child of `*_ptr`, so the
-    // pointers stay valid until the guards fire.
-    let manager_ptr: *mut PackageManager = manager;
-    // SAFETY: `manager_ptr` was just derived from the unique `&mut` fn param;
-    // reborrowing here yields the sole live `&mut` for the body. Dropped
-    // before the guards reborrow the same pointer. (`extract_ctx` is already a
-    // raw pointer and is only materialized as `&mut` inside the callbacks.)
-    let manager = unsafe { &mut *manager_ptr };
-    scopeguard::defer! {
-        // SAFETY: guard drops after every body borrow of `manager` has ended
-        // (scope exit or `?` unwind); `manager_ptr` retains provenance because
-        // the body only ever accessed that allocation through reborrows of it.
-        let manager = unsafe { &mut *manager_ptr };
-        manager.drain_dependency_list();
-
-        if log_level.show_progress() {
-            manager.start_progress_bar_if_none();
-
-            if cb.progress_bar {
-                let completed_items = (manager.total_tasks - manager.pending_task_count()) as usize;
-                // SAFETY: `downloads_node` set by `start_progress_bar_if_none`;
-                // points into `manager.progress` which is live.
-                let node = manager.downloads_node_mut();
-                if completed_items != node.unprotected_completed_items.load(Ordering::Relaxed)
-                    || has_updated_this_run.get()
-                {
-                    node.set_completed_items(completed_items);
-                    node.set_estimated_total_items(manager.total_tasks as usize);
-                }
-            }
-            manager.downloads_node_mut().activate();
-            manager.progress.maybe_refresh();
-        }
-    };
-
-    let patch_tasks_batch = manager.patch_task_queue.pop_batch();
-    let mut patch_tasks_iter = patch_tasks_batch.iterator();
-    loop {
-        let ptask_ptr = patch_tasks_iter.next();
-        if ptask_ptr.is_null() {
-            break;
-        }
-        // SAFETY: `next()` returned non-null; node is exclusively owned by this
-        // batch. `ptask_ptr` is the `Box` that `enqueue_patch_task` /
-        // `enqueue_patch_task_pre` handed to the fifo via `heap::into_raw`;
-        // reclaim ownership exactly once here so the `Box` drops at end of
-        // iteration on every path.
-        let mut ptask = unsafe { bun_core::heap::take(ptask_ptr) };
+    for mut ptask in ctx.manager().shared.patch_task_queue.drain() {
+        let manager = ctx.manager();
         debug_assert!(manager.pending_task_count() > 0);
         manager.decrement_pending_tasks();
         ptask.run_from_main_thread(manager, log_level)?;
         if let PatchTaskCallback::Apply(apply) = &mut ptask.callback {
             if apply.logger.errors == 0 {
-                if cb.has_on_extract {
+                if ctx.has_on_extract() {
                     if let Some(_task_id) = apply.task_id {
                         // autofix
-                    } else if cb.is_package_installer {
-                        if let Some(ctx) = apply.install_context.as_mut() {
-                            // `extract_ctx` *is* the installer here.
-                            let installer: &mut PackageInstaller =
-                                cb.package_installer(extract_ctx);
-                            let path = core::mem::take(&mut ctx.path);
-                            installer.node_modules.path = path;
-                            installer.current_tree_id = ctx.tree_id;
-                            let pkg_id = apply.pkg_id;
-                            let resolution =
-                                &manager.lockfile.packages.items_resolution()[pkg_id as usize];
-
-                            // Downloaded, so already known to need an install.
-                            let needs_verify = false;
-                            let is_pending_package_install = false;
-                            installer.install_package_with_name_and_resolution(
-                                ctx.dependency_id,
-                                pkg_id,
-                                log_level,
+                    } else if ctx.is_package_installer() {
+                        if let Some(install_context) = apply.install_context.as_mut() {
+                            ctx.on_patch_applied(
+                                install_context,
+                                apply.pkg_id,
                                 apply.pkgname,
-                                resolution,
-                                needs_verify,
-                                is_pending_package_install,
+                                log_level,
                             );
                         }
                     }
@@ -340,132 +230,77 @@ fn run_tasks_erased(
         }
     }
 
-    if cb.is_store_installer {
-        // We obtain the
-        // installer via the trait downcast and access PackageManager only
-        // through `installer.manager` for the duration of this block, never
-        // via the function-scope `manager` shadow, so the two `&mut` do not
-        // overlap in use.
-        let installer: &mut Store::Installer<'_> = cb.store_installer(extract_ctx);
-        let installer_ptr: *mut Store::Installer<'_> = installer;
-        let batch = installer.task_queue.pop_batch();
-        let mut iter = batch.iterator();
-        loop {
-            let task_ptr = iter.next();
-            if task_ptr.is_null() {
-                break;
-            }
-            // SAFETY: `next()` returned non-null; node is exclusively owned by this batch.
-            let task = unsafe { &mut *task_ptr };
-            match &task.result {
-                store_installer::Result::None => {
-                    if Environment::CI_ASSERT {
-                        unreachable!();
-                    }
-                    installer
-                        .on_task_complete(task.entry_id, store_installer::CompleteState::Success);
-                }
-                store_installer::Result::Err(_) => {
-                    // Move the error out: `on_task_fail` takes `&mut installer`, which owns `task`.
-                    let store_installer::Result::Err(err) =
-                        core::mem::replace(&mut task.result, store_installer::Result::None)
-                    else {
-                        unreachable!()
-                    };
-                    installer.on_task_fail(task.entry_id, &err);
-                }
-                store_installer::Result::Blocked => {
-                    installer.on_task_blocked(task.entry_id);
-                }
-                &store_installer::Result::RunScripts(list) => {
-                    let entry_id = task.entry_id;
-                    let node_id = installer.store.entries.items_node_id()[entry_id.get() as usize];
-                    let dep_id = installer.store.nodes.items_dep_id()[node_id.get() as usize];
-                    let dep = &installer.lockfile().buffers.dependencies[dep_id as usize];
-                    let optional = dep.behavior.contains(Behavior::OPTIONAL);
-                    // SAFETY: `list` is the per-entry scripts slot owned by
-                    // `store.entries.items_scripts()[entry_id]`; this Task is
-                    // its sole consumer (see Installer.rs Yield::RunScripts).
-                    let list_val = unsafe { (*list).clone() };
-                    // reshaped for borrowck — `Command::Context<'a>`
-                    // is `&'a mut ContextData`; reborrow instead of moving the
-                    // field out of `*installer`.
-                    let command_ctx: Command::Context<'_> = &mut *installer.command_ctx;
-                    // `installer.manager == manager` (same allocation,
-                    // see fn-signature note); call via the body shadow which is a
-                    // reborrow of `manager_ptr` — no extra unsafe alias needed.
-                    let spawn_res = manager.spawn_package_lifecycle_scripts(
-                        command_ctx,
-                        list_val,
-                        optional,
-                        false,
-                        Some(InstallCtx {
-                            entry_id,
-                            installer: installer_ptr,
-                        }),
-                    );
-                    if let Err(err) = spawn_res {
-                        // .monotonic is okay for the same reason as `.done`: we popped this
-                        // task from the `UnboundedQueue`, and the task is no longer running.
-                        installer.store.entries.items_step()[entry_id.get() as usize]
-                            .store(store_installer::Step::Done as u32, Ordering::Relaxed);
-                        installer
-                            .on_task_fail(entry_id, &store_installer::TaskError::RunScripts(err));
-                    }
-                }
-                store_installer::Result::Done => {
-                    if Environment::CI_ASSERT {
-                        // .monotonic is okay because we should have already synchronized with the
-                        // completed task thread by virtue of popping from the `UnboundedQueue`.
-                        let step = installer.store.entries.items_step()
-                            [task.entry_id.get() as usize]
-                            .load(Ordering::Relaxed);
-                        assert!(step == store_installer::Step::Done as u32);
-                    }
-                    installer
-                        .on_task_complete(task.entry_id, store_installer::CompleteState::Success);
-                }
-            }
-        }
+    if ctx.is_store_installer() {
+        ctx.drain_store_tasks(log_level);
     }
 
-    let network_tasks_batch = manager.async_network_task_queue.pop_batch();
-    let mut network_tasks_iter = network_tasks_batch.iterator();
-    loop {
-        let task_ptr = network_tasks_iter.next();
-        if task_ptr.is_null() {
-            break;
-        }
-        // SAFETY: `next()` returned non-null; node is exclusively owned by this batch.
-        let task = unsafe { &mut *task_ptr };
+    for task in ctx.manager().shared.async_network_task_queue.drain() {
+        process_network_task(ctx, state, task)?;
+    }
+
+    for mut task in ctx.manager().shared.resolve_tasks.drain() {
+        process_resolve_task(ctx, state, &mut task)?;
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct CtxFlags {
+    manifests_only: bool,
+    has_on_extract: bool,
+    has_on_package_manifest_error: bool,
+    has_on_package_download_error: bool,
+    has_on_resolve: bool,
+    is_package_installer: bool,
+    is_store_installer: bool,
+}
+
+struct RunState {
+    flags: CtxFlags,
+    has_updated_this_run: bool,
+    has_network_error: bool,
+    timestamp_this_tick: Option<u32>,
+    install_peer: bool,
+    log_level: Options::LogLevel,
+}
+
+fn process_network_task(
+    ctx: &mut dyn RunTasksCtx,
+    state: &mut RunState,
+    mut task: Box<NetworkTask>,
+) -> crate::Result<()> {
+    let RunState {
+        flags,
+        has_updated_this_run,
+        has_network_error,
+        timestamp_this_tick,
+        install_peer,
+        log_level,
+    } = state;
+    let (flags, install_peer, log_level) = (*flags, *install_peer, *log_level);
+    let manager = ctx.manager();
+    {
         debug_assert!(manager.pending_task_count() > 0);
         manager.decrement_pending_tasks();
-        // We cannot free the network task at the end of this scope.
-        // It may continue to be referenced in a future task.
 
-        match &mut task.callback {
+        // The callback data moves on with the task (retry) or into the
+        // resolve task built from it below.
+        match core::mem::replace(&mut task.callback, NetworkTaskCallback::LocalTarball) {
             NetworkTaskCallback::PackageManifest {
-                loaded_manifest,
-                name,
+                mut loaded_manifest,
+                name: name_owned,
                 is_extended_manifest,
             } => {
-                // reshaped for borrowck — capture the name's slice
-                // pointer (`StringOrTinyString` is self-referential and not
-                // `Clone`) so the loop body can read `name` after the
-                // `&mut task.callback` borrow ends.
-                // SAFETY: `name` lives in `task.callback` which outlives this
-                // match arm (the task is only `put` back to the pool by a later
-                // resolve-task pass, never inside this loop iteration).
-                let name = unsafe { bun_ptr::detach_lifetime(name.slice()) };
-                let is_extended_manifest = *is_extended_manifest;
+                let name = name_owned.slice();
                 if log_level.show_progress() {
-                    if !has_updated_this_run.get() {
-                        manager.set_node_name::<true>(
+                    if !*has_updated_this_run {
+                        PackageManager::set_node_name(
                             manager.downloads_node_mut(),
                             name,
                             ProgressStrings::DOWNLOAD_EMOJI.as_bytes(),
                         );
-                        has_updated_this_run.set(true);
+                        *has_updated_this_run = true;
                     }
                 }
 
@@ -477,7 +312,7 @@ fn run_tasks_erased(
                     Some(m) => task.response.fail.is_some() && m.response.status_code < 400,
                 };
                 if download_failed {
-                    throttle_after_network_error(manager, &mut has_network_error);
+                    throttle_after_network_error(manager, has_network_error);
                 }
 
                 // Handle retry-able errors.
@@ -499,11 +334,9 @@ fn run_tasks_erased(
 
                     if task.retried < manager.options.max_retry_count {
                         task.retried += 1;
-                        enqueue::enqueue_network_task(manager, task_ptr);
-
                         if manager.options.log_level.is_verbose() {
                             bun_ast::add_warning_pretty!(
-                                manager.log_mut(),
+                                &mut manager.log,
                                 None,
                                 bun_ast::Loc::EMPTY,
                                 "{} downloading package manifest <b>{}<r>. Retry {}/{}...",
@@ -513,8 +346,14 @@ fn run_tasks_erased(
                                 manager.options.max_retry_count,
                             );
                         }
+                        task.callback = NetworkTaskCallback::PackageManifest {
+                            loaded_manifest,
+                            name: name_owned,
+                            is_extended_manifest,
+                        };
+                        enqueue::enqueue_network_task(manager, task);
 
-                        continue;
+                        return Ok(());
                     }
                 }
 
@@ -527,13 +366,13 @@ fn run_tasks_erased(
                         .map(crate::Error::from)
                         .unwrap_or(crate::Error::HTTPError);
 
-                    if cb.has_on_package_manifest_error {
-                        (cb.on_package_manifest_error)(extract_ctx, name, err, &task.url_buf);
+                    if flags.has_on_package_manifest_error {
+                        ctx.on_package_manifest_error(name, err, task.url_buf());
                     } else {
                         let fmt_args = (err.name(), name);
                         if manager.is_network_task_required(task.task_id) {
                             bun_ast::add_error_pretty!(
-                                manager.log_mut(),
+                                &mut manager.log,
                                 None,
                                 bun_ast::Loc::EMPTY,
                                 "{} downloading package manifest <b>{}<r>",
@@ -542,7 +381,7 @@ fn run_tasks_erased(
                             );
                         } else {
                             bun_ast::add_warning_pretty!(
-                                manager.log_mut(),
+                                &mut manager.log,
                                 None,
                                 bun_ast::Loc::EMPTY,
                                 "{} downloading package manifest <b>{}<r>",
@@ -563,12 +402,12 @@ fn run_tasks_erased(
                         }
                     }
 
-                    continue;
+                    return Ok(());
                 };
                 let response = &metadata.response;
 
                 if response.status_code > 399 {
-                    if cb.has_on_package_manifest_error {
+                    if flags.has_on_package_manifest_error {
                         let err: PackageManifestError = match response.status_code {
                             400 => PackageManifestError::PackageManifestHTTP400,
                             401 => PackageManifestError::PackageManifestHTTP401,
@@ -579,19 +418,14 @@ fn run_tasks_erased(
                             _ => PackageManifestError::PackageManifestHTTP5xx,
                         };
 
-                        (cb.on_package_manifest_error)(
-                            extract_ctx,
-                            name,
-                            err.into(),
-                            &task.url_buf,
-                        );
+                        ctx.on_package_manifest_error(name, err.into(), task.url_buf());
 
-                        continue;
+                        return Ok(());
                     }
 
                     if manager.is_network_task_required(task.task_id) {
                         bun_ast::add_error_pretty!(
-                            manager.log_mut(),
+                            &mut manager.log,
                             None,
                             bun_ast::Loc::EMPTY,
                             "<r><red><b>GET<r><red> {}<d> - {}<r>",
@@ -600,7 +434,7 @@ fn run_tasks_erased(
                         );
                     } else {
                         bun_ast::add_warning_pretty!(
-                            manager.log_mut(),
+                            &mut manager.log,
                             None,
                             bun_ast::Loc::EMPTY,
                             "<r><yellow><b>GET<r><yellow> {}<d> - {}<r>",
@@ -619,18 +453,13 @@ fn run_tasks_erased(
                         }
                     }
 
-                    continue;
+                    return Ok(());
                 }
 
                 if log_level.is_verbose() {
                     bun_core::pretty_error!("    ");
                     Output::print_elapsed(
-                        // SAFETY: `unsafe_http_client` was initialized by
-                        // `for_manifest`/`for_tarball` before `schedule()`;
-                        // direct field access (not `task.http()`) to keep the
-                        // split borrow with `&mut task.callback` above.
-                        (unsafe { task.unsafe_http_client.assume_init_ref() }.elapsed as f64)
-                            / bun_core::time::NS_PER_MS as f64,
+                        (task.http().elapsed() as f64) / bun_core::time::NS_PER_MS as f64,
                     );
                     bun_core::pretty_error!(
                         "\n<d>Downloaded <r><green>{}<r> versions\n",
@@ -648,15 +477,12 @@ fn run_tasks_erased(
                         if timestamp_this_tick.is_none() {
                             let now = u64::try_from(bun_core::time::timestamp().max(0))
                                 .expect("int cast");
-                            timestamp_this_tick = Some((now as u32).saturating_add(300));
+                            *timestamp_this_tick = Some((now as u32).saturating_add(300));
                         }
 
                         manifest.pkg.public_max_age = timestamp_this_tick.unwrap();
 
-                        // reshaped for borrowck —
-                        // `bun_collections::HashMap` lacks `get_or_put` for
-                        // non-`Default` values, so insert by-value (overwriting
-                        // any prior entry) and reborrow.
+                        // Insert by value (overwriting any prior entry) and reborrow.
                         let name_hash = manifest.pkg.name.hash;
                         manager
                             .manifests
@@ -664,15 +490,8 @@ fn run_tasks_erased(
                             .insert(name_hash, ManifestEntry::Manifest(manifest));
 
                         if manager.options.enable.contains(Enable::MANIFEST_CACHE) {
-                            // reshaped for borrowck — compute the
-                            // `&mut`-taking directory accessors first so the
-                            // shared `scope_for_package_name` / `manifests`
-                            // borrows below do not overlap them. `save_async`
-                            // only needs `&PackageManifest`, so reborrow the
-                            // freshly-inserted entry immutably alongside the
-                            // scope (both `&manager`, no conflict).
-                            let tmp_fd = directories::get_temporary_directory(manager).handle.fd;
-                            let cache_fd = directories::get_cache_directory(manager);
+                            let _ = directories::get_temporary_directory(manager);
+                            let _ = directories::get_cache_directory(manager);
                             npm::package_manifest::Serializer::save_async(
                                 manager
                                     .manifests
@@ -680,14 +499,13 @@ fn run_tasks_erased(
                                     .get(&name_hash)
                                     .unwrap()
                                     .manifest(),
-                                manager.scope_for_package_name(name),
-                                tmp_fd,
-                                cache_fd,
+                                manager.options.scope_for_package_name(name),
+                                manager,
                             );
                         }
 
-                        if cb.manifests_only {
-                            continue;
+                        if flags.manifests_only {
+                            return Ok(());
                         }
 
                         let dependency_list_entry = manager
@@ -697,49 +515,28 @@ fn run_tasks_erased(
 
                         let dependency_list = core::mem::take(dependency_list_entry);
 
-                        process_dependency_list_for_ctx(
-                            cb,
-                            manager,
-                            dependency_list,
-                            extract_ctx,
-                            install_peer,
-                        )?;
+                        if manager.process_dependency_list(&dependency_list, install_peer)?
+                            && flags.has_on_resolve
+                        {
+                            ctx.on_resolve();
+                        }
 
-                        continue;
+                        return Ok(());
                     }
                 }
 
-                // reshaped — `enqueue_parse_npm_package` takes
-                // `StringOrTinyString` by value; reconstruct from the slice we
-                // captured (the original lives in `task.callback`, which the
-                // enqueued resolve Task takes ownership of via `network`).
-                let name_tiny = strings::StringOrTinyString::init_append_if_needed(
-                    name,
-                    &mut crate::network_task::filename_store_appender(),
-                )
-                .expect("unreachable");
-                // reshaped for borrowck — split the nested `&mut
-                // manager` borrows (`task_batch.push` vs. `enqueue_*`).
-                // SAFETY: `task_ptr` is non-null (checked by the iterator loop guard)
-                // and exclusively owned by this batch; `manager` is the live PackageManager.
-                let queued = unsafe {
-                    enqueue::enqueue_parse_npm_package(manager, task.task_id, name_tiny, task_ptr)
+                let task_id = task.task_id;
+                // The parse task reads the manifest bits back off the network task.
+                task.callback = NetworkTaskCallback::PackageManifest {
+                    loaded_manifest,
+                    name: name_owned,
+                    is_extended_manifest,
                 };
-                manager.task_batch.push(ThreadPoolBatch::from(queued));
+                let queued = enqueue::enqueue_parse_npm_package(manager, task_id, name_owned, task);
+                manager.task_batch.push_owned(queued);
             }
-            NetworkTaskCallback::Extract(extract) => {
-                // reshaped for borrowck — `extract` borrows
-                // `task.callback`; the body also calls `&mut self` methods on
-                // `task` (`reset_streaming_for_retry`,
-                // `discard_unused_streaming_state`) which only touch disjoint
-                // fields. Detach via raw pointer (mirroring the
-                // `PackageManifest` arm above) so those calls don't overlap.
-                let extract_ptr: *mut ExtractTarball = extract;
-                // SAFETY: `extract` lives in `task.callback`, which outlives
-                // this match arm; the methods called on `task` below never
-                // touch `task.callback` (see `NetworkTask::reset_streaming_*`
-                // / `discard_unused_streaming_state`).
-                let extract = unsafe { &mut *extract_ptr };
+            NetworkTaskCallback::Extract(tarball) => {
+                let extract = &tarball;
                 // A committed stream publishes its result through the extract
                 // Task, except when the connection failed mid-body:
                 // `TarballStream::finish()` then un-commits and sends the
@@ -751,7 +548,7 @@ fn run_tasks_erased(
                     Some(m) => task.response.fail.is_some() && m.response.status_code < 400,
                 };
                 if download_failed {
-                    throttle_after_network_error(manager, &mut has_network_error);
+                    throttle_after_network_error(manager, has_network_error);
                 }
 
                 if download_failed
@@ -773,11 +570,9 @@ fn run_tasks_erased(
                     if task.retried < manager.options.max_retry_count {
                         task.retried += 1;
                         task.reset_streaming_for_retry();
-                        enqueue::enqueue_network_task(manager, task_ptr);
-
                         if manager.options.log_level.is_verbose() {
                             bun_ast::add_warning_pretty!(
-                                manager.log_mut(),
+                                &mut manager.log,
                                 None,
                                 bun_ast::Loc::EMPTY,
                                 "{} downloading tarball <b>{}@{}<r>. Retrying {}/{}...",
@@ -790,17 +585,19 @@ fn run_tasks_erased(
                                 manager.options.max_retry_count,
                             );
                         }
+                        task.callback = NetworkTaskCallback::Extract(tarball);
+                        enqueue::enqueue_network_task(manager, task);
 
-                        continue;
+                        return Ok(());
                     }
                 }
 
                 // Past this point we will not retry. If streaming state was
                 // allocated but never scheduled, release it now so the
-                // pre-created Task goes back to the pool and the stream
-                // buffers are freed. The buffered `enqueueExtractNPMPackage`
-                // path below allocates its own Task.
-                task.discard_unused_streaming_state(manager);
+                // pre-created Task and the stream buffers are freed. The
+                // buffered `enqueue_extract_npm_package` path below allocates
+                // its own Task.
+                task.discard_unused_streaming_state();
 
                 let Some(metadata) = task.response.metadata.as_ref().filter(|_| !download_failed)
                 else {
@@ -812,7 +609,7 @@ fn run_tasks_erased(
 
                     // The download will not be retried for this task_id. Mark
                     // the dedupe entry as failed so a later
-                    // `enqueuePackageForDownload` for the same package observes
+                    // `enqueue_package_for_download` for the same package observes
                     // the failure and fails fast instead of either waiting
                     // forever on a callback that never arrives (entry kept) or
                     // re-running the entire download+retry cycle (entry removed).
@@ -821,34 +618,32 @@ fn run_tasks_erased(
                     let is_required = manager.is_network_task_required(task.task_id);
                     manager.mark_network_task_failed(task.task_id);
 
-                    if cb.has_on_package_download_error {
-                        if cb.is_store_installer {
-                            (cb.on_package_download_error_store)(
-                                extract_ctx,
+                    if flags.has_on_package_download_error {
+                        if flags.is_store_installer {
+                            ctx.on_package_download_error_store(
                                 task.task_id,
                                 extract.name.slice(),
                                 &extract.resolution,
                                 err,
-                                &task.url_buf,
+                                task.url_buf(),
                             );
                         } else {
                             let package_id = manager.lockfile.buffers.resolutions
                                 [extract.dependency_id as usize];
-                            (cb.on_package_download_error_pkg)(
-                                extract_ctx,
+                            ctx.on_package_download_error_pkg(
                                 package_id,
                                 extract.name.slice(),
                                 &extract.resolution,
                                 err,
-                                &task.url_buf,
+                                task.url_buf(),
                             );
                         }
-                        continue;
+                        return Ok(());
                     }
 
                     if is_required {
                         bun_ast::add_error_pretty!(
-                            manager.log_mut(),
+                            &mut manager.log,
                             None,
                             bun_ast::Loc::EMPTY,
                             "{} downloading tarball <b>{}@{}<r>",
@@ -860,7 +655,7 @@ fn run_tasks_erased(
                         );
                     } else {
                         bun_ast::add_warning_pretty!(
-                            manager.log_mut(),
+                            &mut manager.log,
                             None,
                             bun_ast::Loc::EMPTY,
                             "{} downloading tarball <b>{}@{}<r>",
@@ -886,7 +681,7 @@ fn run_tasks_erased(
                         drop(removed);
                     }
 
-                    continue;
+                    return Ok(());
                 };
 
                 let response = &metadata.response;
@@ -900,7 +695,7 @@ fn run_tasks_erased(
                     let is_required = manager.is_network_task_required(task.task_id);
                     manager.mark_network_task_failed(task.task_id);
 
-                    if cb.has_on_package_download_error {
+                    if flags.has_on_package_download_error {
                         let err = match response.status_code {
                             400 => crate::Error::TarballHTTP400,
                             401 => crate::Error::TarballHTTP401,
@@ -911,33 +706,31 @@ fn run_tasks_erased(
                             _ => crate::Error::TarballHTTP5xx,
                         };
 
-                        if cb.is_store_installer {
-                            (cb.on_package_download_error_store)(
-                                extract_ctx,
+                        if flags.is_store_installer {
+                            ctx.on_package_download_error_store(
                                 task.task_id,
                                 extract.name.slice(),
                                 &extract.resolution,
                                 err,
-                                &task.url_buf,
+                                task.url_buf(),
                             );
                         } else {
                             let package_id = manager.lockfile.buffers.resolutions
                                 [extract.dependency_id as usize];
-                            (cb.on_package_download_error_pkg)(
-                                extract_ctx,
+                            ctx.on_package_download_error_pkg(
                                 package_id,
                                 extract.name.slice(),
                                 &extract.resolution,
                                 err,
-                                &task.url_buf,
+                                task.url_buf(),
                             );
                         }
-                        continue;
+                        return Ok(());
                     }
 
                     if is_required {
                         bun_ast::add_error_pretty!(
-                            manager.log_mut(),
+                            &mut manager.log,
                             None,
                             bun_ast::Loc::EMPTY,
                             "<r><red><b>GET<r><red> {}<d> - {}<r>",
@@ -946,7 +739,7 @@ fn run_tasks_erased(
                         );
                     } else {
                         bun_ast::add_warning_pretty!(
-                            manager.log_mut(),
+                            &mut manager.log,
                             None,
                             bun_ast::Loc::EMPTY,
                             "<r><yellow><b>GET<r><yellow> {}<d> - {}<r>",
@@ -969,18 +762,13 @@ fn run_tasks_erased(
                         drop(removed);
                     }
 
-                    continue;
+                    return Ok(());
                 }
 
                 if log_level.is_verbose() {
                     bun_core::pretty_error!("    ");
                     Output::print_elapsed(
-                        // SAFETY: `unsafe_http_client` was initialized by
-                        // `for_manifest`/`for_tarball` before `schedule()`;
-                        // direct field access (not `task.http()`) to keep the
-                        // split borrow with `&mut task.callback` above.
-                        (unsafe { task.unsafe_http_client.assume_init_ref() }.elapsed as f64)
-                            / bun_core::time::NS_PER_MS as f64,
+                        (task.http().elapsed() as f64) / bun_core::time::NS_PER_MS as f64,
                     );
                     bun_core::pretty_error!(
                         "<d> Downloaded <r><green>{}<r> tarball\n",
@@ -990,50 +778,41 @@ fn run_tasks_erased(
                 }
 
                 if log_level.show_progress() {
-                    if !has_updated_this_run.get() {
-                        manager.set_node_name::<true>(
+                    if !*has_updated_this_run {
+                        PackageManager::set_node_name(
                             manager.downloads_node_mut(),
                             extract.name.slice(),
                             ProgressStrings::EXTRACT_EMOJI.as_bytes(),
                         );
-                        has_updated_this_run.set(true);
+                        *has_updated_this_run = true;
                     }
                 }
 
-                // reshaped for borrowck — split nested `&mut manager`.
-                let queued = enqueue::enqueue_extract_npm_package(manager, &*extract, task_ptr);
-                manager.task_batch.push(ThreadPoolBatch::from(queued));
+                let queued = enqueue::enqueue_extract_npm_package(manager, &tarball, task);
+                manager.task_batch.push_owned(queued);
             }
             _ => unreachable!(),
         }
     }
+    Ok(())
+}
 
-    let resolve_tasks_batch = manager.resolve_tasks.pop_batch();
-    let mut resolve_tasks_iter = resolve_tasks_batch.iterator();
-    loop {
-        let task_ptr = resolve_tasks_iter.next();
-        if task_ptr.is_null() {
-            break;
-        }
+fn process_resolve_task(
+    ctx: &mut dyn RunTasksCtx,
+    state: &mut RunState,
+    task: &mut Task::Task,
+) -> crate::Result<()> {
+    let RunState {
+        flags,
+        has_updated_this_run,
+        install_peer,
+        log_level,
+        ..
+    } = state;
+    let (flags, install_peer, log_level) = (*flags, *install_peer, *log_level);
+    let mut manager = ctx.manager();
+    {
         debug_assert!(manager.pending_task_count() > 0);
-        // raw-ptr capture — borrowck would reject overlapping `&mut`
-        // with the loop body. Guard runs on every `continue`/`?`/fallthrough.
-        // Phase B: have the iterator yield a pool guard that puts back on Drop.
-        // SAFETY: `task_ptr` non-null per loop guard; node exclusively owned by this batch.
-        let task = unsafe { &mut *task_ptr };
-        // The per-iteration scopeguards capture the function-scope provenance
-        // root (`manager_ptr`) — the body shadow `manager` is a reborrow of
-        // that same root (see drain `defer!` setup), so dereffing the root in a
-        // guard is valid both before *and* after every body use of the shadow
-        // under Stacked Borrows.
-        scopeguard::defer! {
-            // SAFETY: `manager_ptr` is the provenance root for every body access
-            // to `manager`; `task_ptr` is the sole live handle to this pool slot.
-            unsafe {
-                (*task_ptr).deinit_payload();
-                (*manager_ptr).preallocated_resolve_tasks.put(task_ptr);
-            }
-        };
         manager.decrement_pending_tasks();
 
         if !task.log.msgs.is_empty() {
@@ -1047,44 +826,18 @@ fn run_tasks_erased(
             task.log.reset();
         }
 
-        match task.tag {
+        match task.tag() {
             Task::Tag::PackageManifest => {
-                // capture the `*mut NetworkTask` up front — the
-                // `&'a mut NetworkTask` field can't be moved out through
-                // `ManuallyDrop`'s immutable `Deref` inside the defer body.
-                let net_ptr: *mut NetworkTask = {
-                    let req = task.request_package_manifest_mut();
-                    &raw mut *req.network
-                };
-                scopeguard::defer! {
-                    // SAFETY: see the put-task `defer!` above — `manager_ptr` is the
-                    // function-scope provenance root; `net_ptr` is the network task
-                    // owned by this resolve task and is returned to the pool here.
-                    // `unsafe_http_client` is `MaybeUninit` so `put()`'s
-                    // `drop_in_place<NetworkTask>` skips it — drop manually
-                    // (HTTP completed, so it IS init) so the inner
-                    // `AsyncHTTP.{request,response}_headers: EntryList` don't
-                    // leak per put/get cycle.
-                    unsafe {
-                        (*net_ptr).unsafe_http_client.assume_init_drop();
-                        (*manager_ptr).preallocated_network_tasks.put(net_ptr);
-                    }
-                };
                 if task.status == Task::Status::Fail {
-                    let req = task.request_package_manifest();
-                    let name = req.name.slice();
+                    let (name, network) = task.request_package_manifest();
+                    let name = name.slice();
                     let err = task.err.unwrap_or(crate::Error::Failed);
 
-                    if cb.has_on_package_manifest_error {
-                        (cb.on_package_manifest_error)(
-                            extract_ctx,
-                            name,
-                            err,
-                            &req.network.url_buf,
-                        );
+                    if flags.has_on_package_manifest_error {
+                        ctx.on_package_manifest_error(name, err, network.url_buf());
                     } else {
                         bun_ast::add_error_pretty!(
-                            manager.log_mut(),
+                            &mut manager.log,
                             None,
                             bun_ast::Loc::EMPTY,
                             "{} parsing package manifest for <b>{}<r>",
@@ -1093,26 +846,22 @@ fn run_tasks_erased(
                         );
                     }
 
-                    continue;
+                    return Ok(());
                 }
-                debug_assert!(task.tag == Task::Tag::PackageManifest);
-                // SAFETY: tag-guarded read of the active union arm; default placeholder restored immediately.
-                let manifest: npm::PackageManifest = unsafe {
-                    let m = core::mem::ManuallyDrop::take(&mut task.data.package_manifest);
-                    task.data.package_manifest =
-                        core::mem::ManuallyDrop::new(npm::PackageManifest::default());
-                    m
+                let Task::Data::PackageManifest(manifest) =
+                    core::mem::replace(&mut task.data, Task::Data::None)
+                else {
+                    unreachable!()
                 };
                 let name_hash = manifest.pkg.name.hash;
-                let progress_name: Option<Vec<u8>> = (!cb.manifests_only
-                    && log_level.show_progress()
-                    && !has_updated_this_run.get())
-                .then(|| manifest.name().to_vec());
+                let progress_name: Option<Vec<u8>> =
+                    (!flags.manifests_only && log_level.show_progress() && !*has_updated_this_run)
+                        .then(|| manifest.name().to_vec());
 
                 manager.manifests.insert(name_hash, manifest)?;
 
-                if cb.manifests_only {
-                    continue;
+                if flags.manifests_only {
+                    return Ok(());
                 }
 
                 let dependency_list_entry = manager
@@ -1121,61 +870,27 @@ fn run_tasks_erased(
                     .expect("infallible: task queued");
                 let dependency_list = core::mem::take(dependency_list_entry);
 
-                process_dependency_list_for_ctx(
-                    cb,
-                    manager,
-                    dependency_list,
-                    extract_ctx,
-                    install_peer,
-                )?;
+                if manager.process_dependency_list(&dependency_list, install_peer)?
+                    && flags.has_on_resolve
+                {
+                    ctx.on_resolve();
+                }
+                let manager = ctx.manager();
 
                 if let Some(name) = progress_name {
-                    manager.set_node_name::<true>(
+                    PackageManager::set_node_name(
                         manager.downloads_node_mut(),
                         &name,
                         ProgressStrings::DOWNLOAD_EMOJI.as_bytes(),
                     );
-                    has_updated_this_run.set(true);
+                    *has_updated_this_run = true;
                 }
             }
             Task::Tag::Extract | Task::Tag::LocalTarball => {
-                // capture the `*mut NetworkTask` up front (only for the
-                // Extract arm) so the defer body need not move the `&mut` out
-                // through `ManuallyDrop`'s immutable `Deref`.
-                let net_ptr: *mut NetworkTask = if task.tag == Task::Tag::Extract {
-                    let req = task.request_extract_mut();
-                    &raw mut *req.network
-                } else {
-                    core::ptr::null_mut()
-                };
-                scopeguard::defer! {
-                    if !net_ptr.is_null() {
-                        // SAFETY: see the put-task `defer!` above — `manager_ptr` is the
-                        // function-scope provenance root; `net_ptr` (checked non-null) is
-                        // the network task owned by this resolve task.
-                        // `unsafe_http_client` is `MaybeUninit` so `put()`'s drop
-                        // skips it — drop manually so headers don't leak.
-                        unsafe {
-                            (*net_ptr).unsafe_http_client.assume_init_drop();
-                            (*manager_ptr).preallocated_network_tasks.put(net_ptr);
-                        }
-                    }
-                };
-
-                // SAFETY: `task.tag` selects the active `task.request` union arm.
-                let tarball = unsafe {
-                    match task.tag {
-                        Task::Tag::Extract => &task.request.extract.tarball,
-                        Task::Tag::LocalTarball => &task.request.local_tarball.tarball,
-                        _ => unreachable!(),
-                    }
-                };
+                let tarball = task.request_tarball();
                 let dependency_id = tarball.dependency_id;
                 let mut package_id = manager.lockfile.buffers.resolutions[dependency_id as usize];
-                // SAFETY: `tarball` borrows `task.request` which is reborrowed
-                // `&mut` below; the backing `StringOrTinyString` lives in the
-                // pooled `Task` for the whole iteration and is not mutated.
-                let alias = unsafe { bun_ptr::detach_lifetime(tarball.name.slice()) };
+                let alias = tarball.name.slice();
                 let resolution = &tarball.resolution;
 
                 if task.status == Task::Status::Fail {
@@ -1183,7 +898,7 @@ fn run_tasks_erased(
 
                     // Extract-task failure (integrity check, libarchive error, etc.)
                     // is symmetric with the HTTP 4xx/5xx branch above: mark the
-                    // dedupe entry as failed so a later `enqueuePackageForDownload`
+                    // dedupe entry as failed so a later `enqueue_package_for_download`
                     // for this `task_id` fails fast instead of waiting on this
                     // failed one forever or re-downloading it. Runs before the
                     // callback branch so `Store.Installer` (which `continue`s from
@@ -1191,41 +906,29 @@ fn run_tasks_erased(
                     // `local_tarball` tasks (they never populate the map).
                     manager.mark_network_task_failed(task.id);
 
-                    if cb.has_on_package_download_error {
-                        // SAFETY: `task.tag` selects the active `task.request` union arm.
-                        let fail_url: &[u8] = unsafe {
-                            match task.tag {
-                                Task::Tag::Extract => &(*task.request.extract.network).url_buf,
-                                Task::Tag::LocalTarball => {
-                                    task.request.local_tarball.tarball.url.slice()
-                                }
-                                _ => unreachable!(),
-                            }
+                    if flags.has_on_package_download_error {
+                        let fail_url: &[u8] = match &task.request {
+                            Task::Request::Extract { network, .. } => network
+                                .as_ref()
+                                .expect("extract task owns its network task")
+                                .url_buf(),
+                            Task::Request::LocalTarball { tarball, .. } => tarball.url.slice(),
+                            _ => unreachable!(),
                         };
-                        if cb.is_store_installer {
-                            (cb.on_package_download_error_store)(
-                                extract_ctx,
-                                task.id,
-                                alias,
-                                resolution,
-                                err,
-                                fail_url,
+                        if flags.is_store_installer {
+                            ctx.on_package_download_error_store(
+                                task.id, alias, resolution, err, fail_url,
                             );
                         } else {
-                            (cb.on_package_download_error_pkg)(
-                                extract_ctx,
-                                package_id,
-                                alias,
-                                resolution,
-                                err,
-                                fail_url,
+                            ctx.on_package_download_error_pkg(
+                                package_id, alias, resolution, err, fail_url,
                             );
                         }
-                        continue;
+                        return Ok(());
                     }
 
                     bun_ast::add_error_pretty!(
-                        manager.log_mut(),
+                        &mut manager.log,
                         None,
                         bun_ast::Loc::EMPTY,
                         "{} extracting tarball from <b>{}<r>",
@@ -1235,35 +938,31 @@ fn run_tasks_erased(
 
                     // Void-callback fallback (resolve phase): drain the
                     // `task_queue` entry too so a later install-phase
-                    // `enqueuePackageForDownload` doesn't wedge on `found_existing`.
+                    // `enqueue_package_for_download` doesn't wedge on `found_existing`.
                     if let Some(removed) = manager.task_queue.remove(&task.id) {
                         drop(removed);
                     }
 
-                    continue;
+                    return Ok(());
                 }
 
                 manager.extracted_count += 1;
                 bun_core::analytics::Features::extracted_packages_inc();
 
-                if cb.has_on_extract {
-                    if cb.is_package_installer {
-                        cb.package_installer(extract_ctx)
-                            .fix_cached_lockfile_package_slices();
-                        (cb.on_extract_package_installer)(
-                            extract_ctx,
+                if flags.has_on_extract {
+                    if flags.is_package_installer {
+                        ctx.on_extract_package_installer(
                             task.id,
                             dependency_id,
-                            // SAFETY: `task.tag` is Extract/LocalTarball — `data.extract`
-                            // is the active union arm.
-                            unsafe { &mut task.data.extract },
+                            task.data_extract(),
                             log_level,
                         );
-                    } else if cb.is_store_installer {
-                        (cb.on_extract_store_installer)(extract_ctx, task.id);
+                    } else if flags.is_store_installer {
+                        ctx.on_extract_store_installer(task.id);
                     } else {
                         unreachable!("unexpected context type");
                     }
+                    manager = ctx.manager();
                 } else if let Some(pkg) = manager.process_extracted_tarball_package(
                     &mut package_id,
                     dependency_id,
@@ -1277,58 +976,53 @@ fn run_tasks_erased(
                     // Record the appended package so a later-enqueued dependency
                     // on this same tarball can resolve; see `AppendedTaskPackageMap`.
                     manager.appended_task_packages.insert(task.id, pkg.meta.id);
-                    'handle_pkg: {
-                        // In the middle of an install, you could end up needing to downlaod the github tarball for a dependency
-                        // We need to make sure we resolve the dependencies first before calling the onExtract callback
-                        // TODO: move this into a separate function
+                    // In the middle of an install, you could end up needing to downlaod the github tarball for a dependency
+                    // We need to make sure we resolve the dependencies first before calling the on_extract callback
+                    if let Some(entry) = manager.task_queue.get_mut(&task.id) {
+                        let dependency_list: TaskCallbackList = core::mem::take(entry);
                         let any_root = Cell::new(false);
-                        let dependency_list: TaskCallbackList = {
-                            let Some(entry) = manager.task_queue.get_mut(&task.id) else {
-                                break 'handle_pkg;
-                            };
-                            core::mem::take(entry)
-                        };
+                        let result = (|| -> crate::Result<()> {
+                            for dep in dependency_list.into_iter() {
+                                match dep {
+                                    bun_install::TaskCallbackContext::Dependency(id)
+                                    | bun_install::TaskCallbackContext::RootDependency(id) => {
+                                        let version = &mut manager.lockfile.buffers.dependencies
+                                            [id as usize]
+                                            .version;
+                                        match version.tag {
+                                            bun_install::DependencyVersionTag::Git => {
+                                                version.git_mut().package_name = pkg.name;
+                                            }
+                                            bun_install::DependencyVersionTag::Github => {
+                                                version.github_mut().package_name = pkg.name;
+                                            }
+                                            bun_install::DependencyVersionTag::Tarball => {
+                                                version.tarball_mut().package_name = pkg.name;
+                                            }
 
-                        scopeguard::defer! {
-                            if cb.has_on_resolve && any_root.get() {
-                                (cb.on_resolve)(extract_ctx);
-                            }
-                        };
-
-                        for dep in dependency_list.into_iter() {
-                            match dep {
-                                bun_install::TaskCallbackContext::Dependency(id)
-                                | bun_install::TaskCallbackContext::RootDependency(id) => {
-                                    let version = &mut manager.lockfile.buffers.dependencies
-                                        [id as usize]
-                                        .version;
-                                    match version.tag {
-                                        bun_install::DependencyVersionTag::Git => {
-                                            version.git_mut().package_name = pkg.name;
+                                            // `else` is reachable if this package is from `overrides`. Version in `lockfile.buffer.dependencies`
+                                            // will still have the original.
+                                            _ => {}
                                         }
-                                        bun_install::DependencyVersionTag::Github => {
-                                            version.github_mut().package_name = pkg.name;
-                                        }
-                                        bun_install::DependencyVersionTag::Tarball => {
-                                            version.tarball_mut().package_name = pkg.name;
-                                        }
-
-                                        // `else` is reachable if this package is from `overrides`. Version in `lockfile.buffer.dependencies`
-                                        // will still have the original.
-                                        _ => {}
+                                        manager.process_dependency_list_item(
+                                            &dep,
+                                            Some(&any_root),
+                                            install_peer,
+                                        )?;
                                     }
-                                    manager.process_dependency_list_item(
-                                        &dep,
-                                        Some(&any_root),
-                                        install_peer,
-                                    )?;
-                                }
-                                _ => {
-                                    // if it's a node_module folder to install, handle that after we process all the dependencies within the onExtract callback.
-                                    manager.task_queue.get_mut(&task.id).unwrap().push(dep);
+                                    _ => {
+                                        // if it's a node_module folder to install, handle that after we process all the dependencies within the on_extract callback.
+                                        manager.task_queue.get_mut(&task.id).unwrap().push(dep);
+                                    }
                                 }
                             }
+                            Ok(())
+                        })();
+                        if flags.has_on_resolve && any_root.get() {
+                            ctx.on_resolve();
+                            manager = ctx.manager();
                         }
+                        result?;
                     }
                 } else if let Some(dependency_list_entry) =
                     manager.task_queue.get_mut(&Task::Id::for_manifest(
@@ -1340,24 +1034,19 @@ fn run_tasks_erased(
                     // Peer dependencies do not initiate any downloads of their own, thus need to be resolved here instead
                     let dependency_list = core::mem::take(dependency_list_entry);
 
-                    manager.process_dependency_list(
-                        dependency_list,
-                        (),
-                        None::<fn(())>,
-                        install_peer,
-                    )?;
+                    manager.process_dependency_list(&dependency_list, install_peer)?;
                 }
 
                 manager.set_preinstall_state(package_id, crate::PreinstallState::Done);
 
                 if log_level.show_progress() {
-                    if !has_updated_this_run.get() {
-                        manager.set_node_name::<true>(
+                    if !*has_updated_this_run {
+                        PackageManager::set_node_name(
                             manager.downloads_node_mut(),
                             alias,
                             ProgressStrings::EXTRACT_EMOJI.as_bytes(),
                         );
-                        has_updated_this_run.set(true);
+                        *has_updated_this_run = true;
                     }
                 }
             }
@@ -1370,9 +1059,9 @@ fn run_tasks_erased(
                 if task.status == Task::Status::Fail {
                     let err = task.err.unwrap_or(crate::Error::Failed);
 
-                    if cb.has_on_package_manifest_error {
-                        (cb.on_package_manifest_error)(extract_ctx, name, err, url);
-                    } else if cb.has_on_package_download_error && cb.is_store_installer {
+                    if flags.has_on_package_manifest_error {
+                        ctx.on_package_manifest_error(name, err, url);
+                    } else if flags.has_on_package_download_error && flags.is_store_installer {
                         // The isolated installer queued its entry contexts
                         // under `checkout_id`, not `clone_id`. A failed clone
                         // never reaches checkout, so drain every waiting
@@ -1380,7 +1069,6 @@ fn run_tasks_erased(
                         // forever on the entry's pending-task slot.
                         let mut drained_any = false;
                         if let Some(waiters) = manager.task_queue.remove(&task.id) {
-                            let pkg_resolutions = manager.lockfile.packages.items_resolution();
                             for waiter in waiters.iter() {
                                 let dep_id = match waiter {
                                     bun_install::TaskCallbackContext::Dependency(id) => *id,
@@ -1390,26 +1078,25 @@ fn run_tasks_erased(
                                 if pkg_id == INVALID_PACKAGE_ID {
                                     continue;
                                 }
-                                let res = &pkg_resolutions[pkg_id as usize];
+                                let res =
+                                    manager.lockfile.packages.items_resolution()[pkg_id as usize];
                                 if res.tag != bun_install::ResolutionTag::Git {
                                     continue;
                                 }
-                                // SAFETY: `res.tag == Git` checked just above —
-                                // `value.git` is the active union arm.
                                 let res_git = res.git();
                                 let checkout_id = Task::Id::for_git_checkout(
                                     manager.lockfile.str(&res_git.repo),
                                     manager.lockfile.str(&res_git.resolved),
                                 );
                                 drained_any = true;
-                                (cb.on_package_download_error_store)(
-                                    extract_ctx,
+                                ctx.on_package_download_error_store(
                                     checkout_id,
                                     name,
-                                    res,
+                                    &res,
                                     err,
                                     url,
                                 );
+                                manager = ctx.manager();
                             }
                         }
                         if !drained_any {
@@ -1417,14 +1104,10 @@ fn run_tasks_erased(
                             // above) — fall back to the clone task's own
                             // resolution so the originating entry is still
                             // released.
-                            // SAFETY: `clone.res.tag == Git` — git-clone tasks are
-                            // only enqueued for git resolutions; `value.git` is
-                            // the active union arm.
                             let resolved = &clone.res.git().resolved;
                             let checkout_id =
                                 Task::Id::for_git_checkout(url, manager.lockfile.str(resolved));
-                            (cb.on_package_download_error_store)(
-                                extract_ctx,
+                            ctx.on_package_download_error_store(
                                 checkout_id,
                                 name,
                                 &clone.res,
@@ -1434,7 +1117,7 @@ fn run_tasks_erased(
                         }
                     } else if log_level != Options::LogLevel::Silent {
                         bun_ast::add_error_pretty!(
-                            manager.log_mut(),
+                            &mut manager.log,
                             None,
                             bun_ast::Loc::EMPTY,
                             "{} cloning repository for <b>{}<r>",
@@ -1442,25 +1125,22 @@ fn run_tasks_erased(
                             bstr::BStr::new(name),
                         );
                     }
-                    continue;
+                    return Ok(());
                 }
 
                 manager.git_repositories.insert(task.id, repo_fd);
 
-                if cb.has_on_extract && cb.is_package_installer {
+                if flags.has_on_extract && flags.is_package_installer {
                     // Installing! The clone task is shared by every dependency on
                     // this repo URL; enqueue a checkout per waiter, not just one.
                     let Some(waiters) = manager.task_queue.remove(&task.id) else {
-                        continue;
+                        return Ok(());
                     };
                     for waiter in waiters.iter() {
                         let dep_id = match waiter {
                             bun_install::TaskCallbackContext::Dependency(id) => *id,
                             _ => continue,
                         };
-                        // reshaped for borrowck — copy the small `String` handles
-                        // so the `&manager.lockfile` borrow doesn't extend across
-                        // the `&mut manager` calls below.
                         let (dep_name_handle, is_required) = {
                             let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
                             (dep.name, dep.behavior.is_required())
@@ -1473,27 +1153,30 @@ fn run_tasks_erased(
                         if res.tag != bun_install::ResolutionTag::Git {
                             continue;
                         }
-                        // SAFETY: `res.tag == Git` checked just above —
-                        // `value.git` is the active union arm.
                         let git = *res.git();
-                        // SAFETY: `string_bytes` lives as long as `manager.lockfile`
-                        // and is not reallocated while resolve tasks are draining.
-                        let string_buf = unsafe {
-                            bun_ptr::detach_lifetime(
-                                manager.lockfile.buffers.string_bytes.as_slice(),
+                        let (checkout_id, dep_name, resolved) = {
+                            let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
+                            let repo = git.repo.slice(string_buf);
+                            let resolved = git.resolved.slice(string_buf);
+                            let appender = &mut crate::network_task::filename_store_appender();
+                            (
+                                Task::Id::for_git_checkout(repo, resolved),
+                                strings::StringOrTinyString::init_append_if_needed(
+                                    dep_name_handle.slice(string_buf),
+                                    appender,
+                                )
+                                .expect("unreachable"),
+                                strings::StringOrTinyString::init_append_if_needed(
+                                    resolved, appender,
+                                )
+                                .expect("unreachable"),
                             )
                         };
-                        let dep_name = dep_name_handle.slice(string_buf);
-                        let repo = git.repo.slice(string_buf);
-                        let resolved = git.resolved.slice(string_buf);
-
-                        let checkout_id = Task::Id::for_git_checkout(repo, resolved);
 
                         if manager.has_created_network_task(checkout_id, is_required) {
                             continue;
                         }
 
-                        // reshaped for borrowck — split nested `&mut manager`.
                         let queued = enqueue::enqueue_git_checkout(
                             manager,
                             checkout_id,
@@ -1513,23 +1196,22 @@ fn run_tasks_erased(
                         .remove(&task.id)
                         .expect("infallible: task queued");
 
-                    process_dependency_list_for_ctx(
-                        cb,
-                        manager,
-                        dependency_list,
-                        extract_ctx,
-                        install_peer,
-                    )?;
+                    if manager.process_dependency_list(&dependency_list, install_peer)?
+                        && flags.has_on_resolve
+                    {
+                        ctx.on_resolve();
+                        manager = ctx.manager();
+                    }
                 }
 
                 if log_level.show_progress() {
-                    if !has_updated_this_run.get() {
-                        manager.set_node_name::<true>(
+                    if !*has_updated_this_run {
+                        PackageManager::set_node_name(
                             manager.downloads_node_mut(),
                             name,
                             ProgressStrings::DOWNLOAD_EMOJI.as_bytes(),
                         );
-                        has_updated_this_run.set(true);
+                        *has_updated_this_run = true;
                     }
                 }
             }
@@ -1543,10 +1225,10 @@ fn run_tasks_erased(
                 if task.status == Task::Status::Fail {
                     let err = task.err.unwrap_or(crate::Error::Failed);
                     let _ = manager.task_queue.remove(&task.id);
-                    if cb.has_on_package_manifest_error {
-                        (cb.on_package_manifest_error)(extract_ctx, name, err, url);
+                    if flags.has_on_package_manifest_error {
+                        ctx.on_package_manifest_error(name, err, url);
                     } else {
-                        let _ = manager.log_mut().add_error_fmt(
+                        manager.log.add_error_fmt(
                             None,
                             bun_ast::Loc::EMPTY,
                             format_args!(
@@ -1556,29 +1238,26 @@ fn run_tasks_erased(
                             ),
                         );
                     }
-                    continue;
+                    return Ok(());
                 }
 
                 manager
                     .git_commits
-                    .insert(task.id, task.data_git_commit().clone());
+                    .insert(task.id, task.data_git_commit().to_vec());
 
                 // Each waiter re-enters the enqueue path and now finds the commit.
                 let dependency_list = manager
                     .task_queue
                     .remove(&task.id)
                     .expect("infallible: task queued");
-                process_dependency_list_for_ctx(
-                    cb,
-                    manager,
-                    dependency_list,
-                    extract_ctx,
-                    install_peer,
-                )?;
+                if manager.process_dependency_list(&dependency_list, install_peer)?
+                    && flags.has_on_resolve
+                {
+                    ctx.on_resolve();
+                }
             }
             Task::Tag::GitCheckout => {
-                // SAFETY: `task.tag == GitCheckout` — active union arm.
-                let git_checkout = unsafe { &*task.request.git_checkout };
+                let git_checkout = task.request_git_checkout();
                 let alias = &git_checkout.name;
                 let resolution = &git_checkout.resolution;
                 let mut package_id: PackageID = INVALID_PACKAGE_ID;
@@ -1586,22 +1265,18 @@ fn run_tasks_erased(
                 if task.status == Task::Status::Fail {
                     let err = task.err.unwrap_or(crate::Error::Failed);
 
-                    if cb.has_on_package_download_error && cb.is_store_installer {
-                        // SAFETY: `resolution.tag == Git` — git-checkout tasks are
-                        // only enqueued for git resolutions; `value.git` is the
-                        // active union arm.
-                        let repo = &resolution.git().repo;
-                        (cb.on_package_download_error_store)(
-                            extract_ctx,
+                    if flags.has_on_package_download_error && flags.is_store_installer {
+                        let repo = manager.lockfile.str(&resolution.git().repo).to_vec();
+                        ctx.on_package_download_error_store(
                             task.id,
                             alias.slice(),
                             resolution,
                             err,
-                            manager.lockfile.str(repo),
+                            &repo,
                         );
                     } else {
                         bun_ast::add_error_pretty!(
-                            manager.log_mut(),
+                            &mut manager.log,
                             None,
                             bun_ast::Loc::EMPTY,
                             "{} checking out repository for <b>{}<r>",
@@ -1610,32 +1285,25 @@ fn run_tasks_erased(
                         );
                     }
 
-                    continue;
+                    return Ok(());
                 }
 
-                if cb.has_on_extract {
+                if flags.has_on_extract {
                     // We've populated the cache, package already exists in memory. Call the package installer callback
                     // and don't enqueue dependencies
-                    if cb.is_package_installer {
-                        // TODO(dylan-conway) most likely don't need to call this now that the package isn't appended, but
-                        // keeping just in case for now
-                        cb.package_installer(extract_ctx)
-                            .fix_cached_lockfile_package_slices();
-
-                        (cb.on_extract_package_installer)(
-                            extract_ctx,
+                    if flags.is_package_installer {
+                        ctx.on_extract_package_installer(
                             task.id,
                             git_checkout.dependency_id,
-                            // SAFETY: `task.tag == GitCheckout` — `data.git_checkout`
-                            // is the active union arm.
-                            unsafe { &mut task.data.git_checkout },
+                            task.data_git_checkout(),
                             log_level,
                         );
-                    } else if cb.is_store_installer {
-                        (cb.on_extract_store_installer)(extract_ctx, task.id);
+                    } else if flags.is_store_installer {
+                        ctx.on_extract_store_installer(task.id);
                     } else {
                         unreachable!("unexpected context type");
                     }
+                    manager = ctx.manager();
                 } else if let Some(pkg) = manager.process_extracted_tarball_package(
                     &mut package_id,
                     git_checkout.dependency_id,
@@ -1649,76 +1317,64 @@ fn run_tasks_erased(
                     // Record the appended package so a later-enqueued dependency
                     // on this same repo+commit can resolve; see `AppendedTaskPackageMap`.
                     manager.appended_task_packages.insert(task.id, pkg.meta.id);
-                    'handle_pkg: {
+                    if let Some(entry) = manager.task_queue.get_mut(&task.id) {
+                        let dependency_list: TaskCallbackList = core::mem::take(entry);
                         let any_root = Cell::new(false);
-                        let dependency_list: TaskCallbackList = {
-                            let Some(entry) = manager.task_queue.get_mut(&task.id) else {
-                                break 'handle_pkg;
-                            };
-                            core::mem::take(entry)
-                        };
-
-                        scopeguard::defer! {
-                            if cb.has_on_resolve && any_root.get() {
-                                (cb.on_resolve)(extract_ctx);
-                            }
-                        };
-
-                        for dep in dependency_list.into_iter() {
-                            match dep {
-                                bun_install::TaskCallbackContext::Dependency(id)
-                                | bun_install::TaskCallbackContext::RootDependency(id) => {
-                                    // SAFETY: this branch is only reached for
-                                    // git dependencies — `version.tag == Git`.
-                                    let repo = unsafe {
-                                        &mut *manager.lockfile.buffers.dependencies[id as usize]
+                        let result = (|| -> crate::Result<()> {
+                            for dep in dependency_list.into_iter() {
+                                match dep {
+                                    bun_install::TaskCallbackContext::Dependency(id)
+                                    | bun_install::TaskCallbackContext::RootDependency(id) => {
+                                        // Only reached for git dependencies.
+                                        let repo = manager.lockfile.buffers.dependencies
+                                            [id as usize]
                                             .version
-                                            .value
-                                            .git
-                                    };
-                                    // SAFETY: `pkg.resolution.value` is an untagged union
-                                    // discriminated by `pkg.resolution.tag`;
-                                    // `Tag::Git` was checked when the resolution was set.
-                                    repo.resolved = pkg.resolution.git().resolved;
-                                    repo.package_name = pkg.name;
-                                    manager.process_dependency_list_item(
-                                        &dep,
-                                        Some(&any_root),
-                                        install_peer,
-                                    )?;
-                                }
-                                _ => {
-                                    // if it's a node_module folder to install, handle that after we process all the dependencies within the onExtract callback.
-                                    manager.task_queue.get_mut(&task.id).unwrap().push(dep);
+                                            .git_mut();
+                                        repo.resolved = pkg.resolution.git().resolved;
+                                        repo.package_name = pkg.name;
+                                        manager.process_dependency_list_item(
+                                            &dep,
+                                            Some(&any_root),
+                                            install_peer,
+                                        )?;
+                                    }
+                                    _ => {
+                                        // if it's a node_module folder to install, handle that after we process all the dependencies within the on_extract callback.
+                                        manager.task_queue.get_mut(&task.id).unwrap().push(dep);
+                                    }
                                 }
                             }
-                        }
-
+                            Ok(())
+                        })();
                         // Invariant: this branch only reachable when !HAS_ON_EXTRACT.
-                        debug_assert!(!cb.has_on_extract, "ctx should be void");
+                        debug_assert!(!flags.has_on_extract, "ctx should be void");
+                        if flags.has_on_resolve && any_root.get() {
+                            ctx.on_resolve();
+                            manager = ctx.manager();
+                        }
+                        result?;
                     }
                 }
 
                 if log_level.show_progress() {
-                    if !has_updated_this_run.get() {
-                        manager.set_node_name::<true>(
+                    if !*has_updated_this_run {
+                        PackageManager::set_node_name(
                             manager.downloads_node_mut(),
                             alias.slice(),
                             ProgressStrings::DOWNLOAD_EMOJI.as_bytes(),
                         );
-                        has_updated_this_run.set(true);
+                        *has_updated_this_run = true;
                     }
                 }
             }
         }
     }
-
     Ok(())
 }
 
 #[inline]
 pub fn pending_task_count(manager: &PackageManager) -> u32 {
-    manager.pending_tasks.load(Ordering::Acquire)
+    manager.shared.pending_tasks.load(Ordering::Acquire)
 }
 
 #[inline]
@@ -1727,12 +1383,15 @@ pub fn increment_pending_tasks(manager: &mut PackageManager, count: u32) {
     // .monotonic is okay because the start of a task doesn't carry any side effects that other
     // threads depend on (but finishing a task does). Note that this method should usually be called
     // before the task is actually spawned.
-    let _ = manager.pending_tasks.fetch_add(count, Ordering::Relaxed);
+    let _ = manager
+        .shared
+        .pending_tasks
+        .fetch_add(count, Ordering::Relaxed);
 }
 
 #[inline]
 pub fn decrement_pending_tasks(manager: &mut PackageManager) {
-    let _ = manager.pending_tasks.fetch_sub(1, Ordering::Release);
+    let _ = manager.shared.pending_tasks.fetch_sub(1, Ordering::Release);
 }
 
 impl PackageManager {
@@ -1751,24 +1410,22 @@ impl PackageManager {
 }
 
 pub fn flush_network_queue(this: &mut PackageManager) {
-    while let Some(network_task) = this.network_task_fifo.read_item() {
-        // SAFETY: fifo stores live `*mut NetworkTask` pushed by
-        // `enqueue_network_task`; exclusive ownership transferred here.
-        let nt = unsafe { &mut *network_task };
-        nt.schedule(if matches!(nt.callback, NetworkTaskCallback::Extract(_)) {
+    while let Some(network_task) = this.network_task_fifo.pop() {
+        // The HTTP thread takes the task over until its terminal callback
+        // hands it back through `Shared::async_network_task_queue`.
+        let batch = if matches!(network_task.callback, NetworkTaskCallback::Extract(_)) {
             &mut this.network_tarball_batch
         } else {
             &mut this.network_resolve_batch
-        });
+        };
+        bun_http::schedule_owned_request(network_task, batch);
     }
 }
 
 pub fn flush_patch_task_queue(this: &mut PackageManager) {
-    while let Some(patch_task) = this.patch_task_fifo.read_item() {
-        // SAFETY: fifo stores live `*mut PatchTask` pushed by
-        // `enqueue_patch_task`; exclusive ownership transferred here.
-        let pt = unsafe { &mut *patch_task };
-        pt.schedule(if matches!(pt.callback, PatchTaskCallback::Apply(_)) {
+    while let Some(patch_task) = this.patch_task_fifo.pop() {
+        let is_apply = matches!(patch_task.callback, PatchTaskCallback::Apply(_));
+        patch_task.schedule(if is_apply {
             &mut this.patch_apply_batch
         } else {
             &mut this.patch_calc_hash_batch
@@ -1814,6 +1471,11 @@ pub fn schedule_tasks(manager: &mut PackageManager) -> usize {
         + manager.patch_calc_hash_batch.len;
 
     manager.increment_pending_tasks(u32::try_from(count).expect("int cast"));
+    if manager.task_batch.len > 0 {
+        // Resolve tasks read the cache/temp directories on the worker.
+        let _ = directories::get_cache_directory(manager);
+        manager.ensure_cache_and_temp_directories();
+    }
     manager
         .thread_pool
         .schedule(core::mem::take(&mut manager.patch_apply_batch));
@@ -1836,22 +1498,12 @@ pub fn drain_dependency_list(this: &mut PackageManager) {
     // Step 2. If there were cached dependencies, go through all of those but don't download the devDependencies for them.
     flush_dependency_queue(this);
 
-    // SAFETY: `VERBOSE_INSTALL` is only mutated during single-threaded options
-    // parsing; reads here are race-free in practice.
     if PackageManager::verbose_install() {
         Output::flush();
     }
 
     // It's only network requests here because we don't store tarballs.
     let _ = schedule_tasks(this);
-}
-
-pub fn get_network_task(this: &mut PackageManager) -> *mut NetworkTask {
-    // Forget the slot token so its `Drop` does not release the slot — the
-    // caller owns the slot until a later `put()`.
-    core::mem::ManuallyDrop::new(this.preallocated_network_tasks.claim())
-        .addr()
-        .as_ptr()
 }
 
 pub fn alloc_github_url(this: &PackageManager, repository: &Repository) -> Vec<u8> {
@@ -1933,16 +1585,15 @@ fn throttle_after_network_error(manager: &PackageManager, has_network_error: &mu
     }
 }
 
-pub fn generate_network_task_for_tarball<'a>(
-    this: &'a mut PackageManager,
+pub fn generate_network_task_for_tarball(
+    this: &mut PackageManager,
     task_id: Task::Id,
-    url: &[u8],
+    url: strings::StringOrTinyString,
     is_required: bool,
     dependency_id: DependencyID,
     package: &Package,
-    patch_name_and_version_hash: Option<u64>,
     authorization: Authorization,
-) -> Result<Option<&'a mut NetworkTask>, ForTarballError> {
+) -> Result<Option<Box<NetworkTask>>, ForTarballError> {
     if has_created_network_task(this, task_id, is_required) {
         return Ok(None);
     }
@@ -1955,7 +1606,7 @@ pub fn generate_network_task_for_tarball<'a>(
             // reported once; later dependents see the failed dedupe entry
             mark_network_task_failed(this, task_id);
             let name = this.lockfile.str(&package.name).to_vec();
-            this.log_mut().add_error_fmt(
+            this.log.add_error_fmt(
                 None,
                 bun_ast::Loc::EMPTY,
                 format_args!(
@@ -1970,70 +1621,18 @@ pub fn generate_network_task_for_tarball<'a>(
         return Err(ForTarballError::Offline);
     }
 
-    // reshaped for borrowck —
-    // all `&mut this` uses (patch-task alloc, cache/temp dir, pool slot) happen
-    // first; the immutable `pkg_name`/`scope` borrows are taken afterwards and
-    // live only through `for_tarball`, leaving `this` free for the streaming
-    // tail.
-    // The patched-dependency entry can be missing (or its hash not yet
-    // computed) when install state went stale — e.g. the patch was removed
-    // from package.json, leaving the hash only in
-    // `patched_dependencies_to_remove`. Install the package unpatched instead
-    // of panicking.
-    let patch = patch_name_and_version_hash.and_then(|h| {
-        Some((
-            h,
-            this.lockfile
-                .patched_dependencies
-                .get(&h)?
-                .patchfile_hash()?,
-        ))
-    });
-    let apply_patch_task = if let Some((h, patch_hash)) = patch {
-        let mut task = PatchTask::new_apply_patch_hash(this, package.meta.id, patch_hash, h);
-        if let PatchTaskCallback::Apply(apply) = &mut task.callback {
-            apply.task_id = Some(task_id);
-        }
-        Some(task)
-    } else {
-        None
-    };
     // Borrowed views: `cache_dir` and `temp_dir` are owned by the `PackageManager`
     // singleton and the `TemporaryDirectory` once-cell, respectively. They flow
     // into `ExtractTarball::{cache_dir,temp_dir}`, which must be `Fd` (not `Dir`)
     // so the task's drop never closes them.
     let cache_dir = directories::get_cache_directory(this);
     let temp_dir = directories::get_temporary_directory(this).handle.fd();
-    // Backref address only — stored, not dereffed in this function. The tag is
-    // immediately popped by the next `this` use; that's fine for a stored
-    // back-pointer.
-    let this_backref: *mut PackageManager = this;
 
-    // Take the pool slot as a raw pointer so borrowck releases `this` for the
-    // streaming-setup tail. Reborrowed `&mut` per-statement below.
-    let net_ptr: *mut NetworkTask = get_network_task(this);
-    // Full struct overwrite that resets
-    // every other field (`retried`, `response`, `streaming_committed`,
-    // `tarball_stream`, `streaming_extract_task`, `next`, `url_buf`,
-    // `signal_store`) to its struct default. The slot may be uninitialized
-    // (`HiveArrayFallback::get()` heap fallback) or stale (reused hive slot).
-    // SAFETY: `net_ptr` is the unique handle to a freshly-vended pool slot; no
-    // other alias exists until we return it.
-    unsafe { NetworkTask::write_init(net_ptr, task_id, this_backref, apply_patch_task) };
-    // SAFETY: `write_init` populated every field with a drop-safe value;
-    // `unsafe_http_client` is `MaybeUninit` and overwritten by `for_tarball`.
-    let network_task = unsafe { &mut *net_ptr };
+    let mut network_task = NetworkTask::new(task_id, this);
 
     let pkg_name = this.lockfile.str(&package.name);
-    let scope = this.scope_for_package_name(pkg_name);
-
     let extract_tarball = ExtractTarball {
-        // BACKREF — `this_backref` is non-null (just derived from `&mut *this`)
-        // and the PackageManager outlives every ExtractTarball it enqueues.
-        // Safe `From<NonNull>` construction.
-        package_manager: bun_ptr::BackRef::from(
-            core::ptr::NonNull::new(this_backref).expect("derived from &mut, non-null"),
-        ),
+        package_manager: bun_ptr::BackRef::new(this),
         name: strings::StringOrTinyString::init_append_if_needed(
             pkg_name,
             &mut crate::network_task::filename_store_appender(),
@@ -2046,11 +1645,7 @@ pub fn generate_network_task_for_tarball<'a>(
         skip_verify: false,
         in_trusted_dependencies: this.lockfile.in_trusted_dependencies(pkg_name),
         integrity: package.meta.integrity,
-        url: strings::StringOrTinyString::init_append_if_needed(
-            url,
-            &mut crate::network_task::filename_store_appender(),
-        )
-        .expect("unreachable"),
+        url,
         // Copied here: extract workers must not read lockfile buffers.
         github_resolved: if package.resolution.tag == bun_install::ResolutionTag::Github {
             strings::StringOrTinyString::init_append_if_needed(
@@ -2063,46 +1658,40 @@ pub fn generate_network_task_for_tarball<'a>(
         },
     };
 
-    network_task.for_tarball(extract_tarball, scope, authorization)?;
-
-    if extract_tarball::uses_streaming_extraction() {
-        // Pre-create the extract Task and streaming state here on the
-        // main thread: `preallocated_resolve_tasks` is not thread-safe,
-        // and the streaming extractor needs a stable `Task` pointer so
-        // it can push the result onto `resolve_tasks` when it finishes.
-        //
-        // Borrowck/SB: `create_extract_task_for_streaming` / `TarballStream::init`
-        // need `&mut PackageManager` while `net_ptr` points into
-        // `this.preallocated_network_tasks`. The pool slot is disjoint from
-        // every other `this` field these calls touch (resolve-task pool,
-        // allocator, options) and the network-task pool is never reallocated
-        // or `put()` here, so we reborrow `*net_ptr` per-statement alongside
-        // `this`. Phase B: have `get_network_task` return a pool index so this
-        // intrusive-pointer pattern goes away.
-        // SAFETY: see disjointness note above.
-        let tarball_ref = unsafe {
-            let NetworkTaskCallback::Extract(t) = &(*net_ptr).callback else {
-                unreachable!()
-            };
-            t
-        };
-        let extract_task = enqueue::create_extract_task_for_streaming(this, tarball_ref, net_ptr);
-        // SAFETY: `net_ptr` is the unique handle to the freshly-vended pool slot
-        // (see `write_init` above); `TarballStream::init` returns a fresh
-        // `heap::alloc` which we reclaim ownership of exactly once here.
-        unsafe {
-            (*net_ptr).streaming_extract_task = extract_task;
-            (*net_ptr).tarball_stream = Some(bun_core::heap::take(TarballStream::init(
-                extract_task,
-                net_ptr,
-                this,
-            )));
-        }
+    {
+        let PackageManager {
+            log,
+            env,
+            options,
+            lockfile,
+            ..
+        } = &mut *this;
+        let scope = options.scope_for_package_name(lockfile.str(&package.name));
+        network_task.for_tarball(
+            log,
+            env.get(),
+            lockfile.buffers.string_bytes.as_slice(),
+            extract_tarball,
+            scope,
+            authorization,
+        )?;
     }
 
-    // SAFETY: final reborrow of the pool slot for the caller; `net_ptr` is the
-    // sole live handle (see above) and outlives nothing past this return.
-    Ok(Some(unsafe { &mut *net_ptr }))
+    if extract_tarball::uses_streaming_extraction() {
+        // Pre-create the extract Task and streaming state here on the main
+        // thread; the streaming extractor publishes that Task to
+        // `resolve_tasks` when it finishes.
+        let NetworkTaskCallback::Extract(tarball) = &network_task.callback else {
+            unreachable!()
+        };
+        let extract_task = enqueue::create_extract_task_for_streaming(this, tarball, task_id);
+        network_task.tarball_stream = Some(TarballStream::new(
+            extract_task,
+            bun_ptr::BackRef::new(&*this),
+        ));
+    }
+
+    Ok(Some(network_task))
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -2147,34 +1736,7 @@ impl PackageManager {
         network_task_has_failed(self, task_id)
     }
     #[inline]
-    pub(crate) fn get_network_task(&mut self) -> *mut NetworkTask {
-        get_network_task(self)
-    }
-    #[inline]
     pub(crate) fn alloc_github_url(&self, repository: &Repository) -> Vec<u8> {
         alloc_github_url(self, repository)
     }
-}
-
-/// Adapter wrapping the existing `PackageManager::process_dependency_list` so
-/// it can be driven by a `RunTasksCallbacks` impl, dispatching `on_resolve`
-/// if any root dep changed.
-fn process_dependency_list_for_ctx(
-    cb: &ErasedCallbacks,
-    manager: &mut PackageManager,
-    dependency_list: TaskCallbackList,
-    extract_ctx: *mut (),
-    install_peer: bool,
-) -> crate::Result<()> {
-    let on_resolve = cb.on_resolve;
-    manager.process_dependency_list(
-        dependency_list,
-        (),
-        if cb.has_on_resolve {
-            Some(move |()| on_resolve(extract_ctx))
-        } else {
-            None
-        },
-        install_peer,
-    )
 }

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -24,15 +24,16 @@ use bun_io::Loop as AsyncLoop;
 #[cfg(unix)]
 use bun_io::pipe_reader::PosixFlags;
 use bun_io::{BufferedReader, ReadState};
+use bun_ptr::JsCell;
 use bun_ptr::RefPtr;
+use bun_spawn::ProcessHandle;
 #[cfg(not(windows))]
 use bun_spawn::SpawnResultExt as _;
 use bun_spawn::subprocess::{self, StdioResult};
-use bun_spawn::{
-    self as spawn, Exited, Process, ProcessExit, ProcessExitKind, ProcessHandle, Rusage,
-    SpawnOptions, Status, Stdio,
-};
+use bun_spawn::{self as spawn, Exited, SpawnOptions, Status, Stdio};
 use bun_sys::{self, Fd, FdExt as _};
+use core::cell::Cell;
+use core::ffi::c_void;
 
 use crate::hoisted_install as HoistedInstall;
 use crate::isolated_install as IsolatedInstall;
@@ -87,7 +88,6 @@ impl SecurityScanResults {
 
 fn do_partial_install_of_security_scanner(
     manager: &mut PackageManager,
-    ctx: CommandContext,
     log_level: crate::package_manager::Options::LogLevel,
     security_scanner_pkg_id: PackageID,
 ) -> Result<(), Error> {
@@ -107,7 +107,6 @@ fn do_partial_install_of_security_scanner(
         | bun_install_types::NodeLinker::NodeLinker::Auto => {
             HoistedInstall::install_hoisted_packages(
                 manager,
-                ctx,
                 &[],
                 true,
                 log_level,
@@ -117,7 +116,6 @@ fn do_partial_install_of_security_scanner(
         bun_install_types::NodeLinker::NodeLinker::Isolated => {
             IsolatedInstall::install_isolated_packages(
                 manager,
-                ctx,
                 true,
                 &[],
                 packages_to_install,
@@ -280,7 +278,7 @@ fn scan_installing_scanner_if_needed(
         ScanAttemptResult::NeedsInstall(pkg_id) => {
             bun_core::prettyln!("<r><yellow>Attempting to install security scanner from npm...<r>");
             let log_level = manager.options.log_level;
-            do_partial_install_of_security_scanner(manager, command_ctx, log_level, pkg_id)?;
+            do_partial_install_of_security_scanner(manager, log_level, pkg_id)?;
             bun_core::prettyln!("<r><green><b>Security scanner installed successfully.<r>");
 
             let retry_result = attempt_security_scan_with_retry(
@@ -654,8 +652,6 @@ impl<'a> PackageCollector<'a> {
         let pkg_dependencies = pkgs.items_dependencies();
 
         while let Some(item) = self.queue.pop_front() {
-            // `defer mutable_item.{pkg,dep}_path.deinit(...)` — Vec drops at end of loop body.
-
             let pkg_id = item.pkg_id;
             let _ = item.dep_id; // Could be useful in the future for dependency-specific processing
 
@@ -747,9 +743,6 @@ impl<'a> JSONBuilder<'a> {
                 json_buf.extend_from_slice(b",\n");
             }
 
-            // SAFETY: `PackageCollector::process_queue` only inserts packages
-            // whose resolution tag is `Tag::Npm` into `package_paths`, so the
-            // `npm` union variant is the active field here.
             let npm = pkg_res.npm();
             if dep_id == invalid_dependency_id {
                 write!(
@@ -862,7 +855,6 @@ fn attempt_security_scan_with_retry(
         collector: &collector,
     };
     let json_data = json_builder.build_package_json()?;
-    // `defer manager.allocator.free(json_data)` — Box<[u8]> drops at scope exit.
 
     // destructure `collector` here to release its `&PackageManager`
     // borrow before constructing `SecurityScanSubprocess` (which needs `&mut`).
@@ -893,41 +885,31 @@ fn attempt_security_scan_with_retry(
             b"false"
         });
         new_code.extend_from_slice(&temp_source[index + suppress_placeholder.len()..]);
-        // reshaped for borrowck — drop borrow of `code` (via `temp_source`) before reassigning.
         code = new_code;
     }
 
     let event_loop_handle = EventLoopHandle::from_any(&mut manager.event_loop);
-    let mut scanner = Box::new(SecurityScanSubprocess {
-        manager,
+    let scanner = bun_ptr::OwnedThis::new(SecurityScanSubprocess {
+        log_level: manager.options.log_level,
         event_loop_handle,
         code: Box::<[u8]>::from(code.as_slice()),
         json_data: Box::<[u8]>::from(&*json_data),
-        process: None,
-        ipc_reader: BufferedReader::init::<SecurityScanSubprocess>(),
-        ipc_data: Vec::new(),
-        stderr_data: Vec::new(),
-        has_received_ipc: false,
-        exit_status: None,
-        remaining_fds: 0,
-        json_writer: None,
+        process: Cell::new(None),
+        ipc_reader: JsCell::new(BufferedReader::init::<SecurityScanSubprocess>()),
+        ipc_data: JsCell::new(Vec::new()),
+        has_received_ipc: Cell::new(false),
+        exit_status: Cell::new(None),
+        remaining_fds: Cell::new(0),
+        json_writer: Cell::new(None),
     });
-    // Cleanup of code/json_data/process handled by `Drop for SecurityScanSubprocess` when Box drops.
+    // Cleanup of code/json_data/process handled by `Drop for SecurityScanSubprocess`.
 
-    scanner.spawn()?;
+    SecurityScanSubprocess::spawn(scanner.this_ptr())?;
 
-    // `sleep_until` takes `*mut PackageManager` + `fn(&mut C) -> bool`; pass the
-    // boxed scanner as the closure context and a fn pointer that probes `is_done`.
-    fn scanner_is_done(scanner: &mut Box<SecurityScanSubprocess>) -> bool {
-        scanner.is_done()
-    }
-    let mgr: *mut PackageManager = scanner.manager;
-    // SAFETY: `scanner.manager` is the live exclusive `&mut PackageManager`
-    // borrow held by the subprocess; `sleep_until` + `tick_raw` hold no
-    // `&mut PackageManager` across `scanner_is_done`.
-    unsafe { PackageManager::sleep_until(mgr, &mut scanner, scanner_is_done) };
+    PackageManager::sleep_until(manager, |_| scanner.is_done());
 
     scanner.handle_results(
+        manager,
         &mut package_paths,
         start_time,
         packages_scanned,
@@ -939,55 +921,55 @@ fn attempt_security_scan_with_retry(
     )
 }
 
-pub struct SecurityScanSubprocess<'a> {
-    manager: &'a mut PackageManager,
+/// The scanner subprocess. Owned by `run` for the scan's duration; the
+/// process exit handler, the fd 3 reader and the fd 4 writer reach it through
+/// the `ThisPtr` its [`bun_ptr::OwnedThis`] lends, so everything they touch
+/// is a `Cell`.
+pub struct SecurityScanSubprocess {
+    log_level: crate::package_manager::Options::LogLevel,
     /// Stable storage for the io-layer opaque `bun_io::EventLoopHandle`
-    /// (which carries `*const EventLoopHandle`). `manager.event_loop` is an
-    /// `AnyEventLoop` — different layout — so its address is NOT a valid
-    /// substitute. Mirrors the pattern in `StaticPipeWriter::io_evtloop`.
+    /// (which carries `*const EventLoopHandle`). Mirrors the pattern in
+    /// `StaticPipeWriter::io_evtloop`.
     event_loop_handle: EventLoopHandle,
     code: Box<[u8]>,
     json_data: Box<[u8]>,
-    process: Option<ProcessHandle>,
-    ipc_reader: BufferedReader,
-    ipc_data: Vec<u8>,
-    stderr_data: Vec<u8>,
-    has_received_ipc: bool,
-    exit_status: Option<Status>,
-    remaining_fds: i8,
-    json_writer: Option<RefPtr<StaticPipeWriter>>,
+    process: Cell<Option<ProcessHandle>>,
+    ipc_reader: JsCell<BufferedReader>,
+    ipc_data: JsCell<Vec<u8>>,
+    has_received_ipc: Cell<bool>,
+    exit_status: Cell<Option<Status>>,
+    remaining_fds: Cell<i8>,
+    /// `create()`'s ref on the fd 4 writer, released by `on_close_io`.
+    json_writer: Cell<Option<RefPtr<StaticPipeWriter>>>,
 }
 
 // The generic `subprocess::StaticPipeWriter<P>` is
 // monomorphized on `'static` because the writer stores `*mut P` (raw backref —
 // lifetime is erased anyway) and the type alias must name a concrete `P`.
-pub(crate) type StaticPipeWriter = subprocess::StaticPipeWriter<SecurityScanSubprocess<'static>>;
+pub(crate) type StaticPipeWriter = subprocess::StaticPipeWriter<SecurityScanSubprocess>;
 
-// Wire the writer's `on_close` callback back to this type. Raw `*mut Self`
-// because the call is re-entrant: it may fire synchronously inside
-// `StaticPipeWriter::start()` while `finish_spawn` still has `&mut self` on
-// the stack (small JSON fits the pipe buffer → write completes → close).
-impl<'a> subprocess::StaticPipeWriterProcess for SecurityScanSubprocess<'a> {
+// The writer's `on_close` callback; may fire synchronously inside
+// `StaticPipeWriter::start()` while `finish_spawn` is still running (small
+// JSON fits the pipe buffer → write completes → close).
+impl subprocess::StaticPipeWriterProcess for SecurityScanSubprocess {
     const POLL_OWNER_TAG: bun_io::PollTag = bun_io::PollTag::SecurityScanStaticPipeWriter;
     fn on_close_io(this: bun_ptr::ThisPtr<Self>, kind: subprocess::StdioKind) {
-        // SAFETY: `this` is the `parent` backref passed to `StaticPipeWriter::create`;
-        // the subprocess outlives its writer (it owns the writer ref in `json_writer`).
-        // `finish_spawn` holds no Rust borrow on `self.json_writer` across `start()`
-        // (it clones the `RefPtr` first), so this `&mut` is unique for the call.
-        unsafe { (*this.as_ptr()).on_close_io(kind) };
+        this.get().on_close_io(kind);
     }
 }
 
 bun_spawn::link_impl_ProcessExit! {
-    SecurityScan for SecurityScanSubprocess<'static> => |this| {
-        on_process_exit(process, status, rusage) =>
-            (*this).on_process_exit(&mut *process, status, rusage),
+    SecurityScan for SecurityScanSubprocess => |this| {
+        on_process_exit(_process, status, _rusage) =>
+            (*this).on_process_exit(status),
     }
 }
 
-impl<'a> Drop for SecurityScanSubprocess<'a> {
+impl Drop for SecurityScanSubprocess {
     fn drop(&mut self) {
-        self.process = None;
+        // Detach the exit handler (so a late callback won't touch a dangling
+        // `self`) and release our process ref.
+        drop(self.process.take());
         // Dropping the writer can synchronously close it and re-enter
         // `on_close_io` through the parent backref; move it out first so that
         // sees `None`.
@@ -996,24 +978,25 @@ impl<'a> Drop for SecurityScanSubprocess<'a> {
 }
 
 // Wire the buffered-reader vtable to this type so `BufferedReader::init::<Self>()`
-// resolves. The reader stores `*mut Self` (set via `set_parent`) and calls back
-// through these raw-pointer hooks.
+// resolves. The reader stores our `ThisPtr` (set via `set_parent`) and calls
+// back through these hooks.
 bun_io::impl_buffered_reader_parent! {
-    SecurityScan for SecurityScanSubprocess<'a>;
+    SecurityScan for SecurityScanSubprocess;
+    borrow = this;
     has_on_read_chunk = true;
-    on_read_chunk   = |this, chunk, has_more| (*this).on_read_chunk(&chunk, has_more);
-    on_reader_done  = |this| (*this).on_reader_done();
-    on_reader_error = |this, err| (*this).on_reader_error(err);
-    loop_           = |this| (*this).loop_();
-    event_loop      = |this| (*this).event_loop_handle.as_event_loop_ctx();
+    on_read_chunk   = |this, chunk, has_more| this.get().on_read_chunk(&chunk, has_more);
+    on_reader_done  = |this| this.get().on_reader_done();
+    on_reader_error = |this, err| this.get().on_reader_error(err);
+    loop_           = |this| this.get().loop_();
+    event_loop      = |this| this.get().event_loop_handle.as_event_loop_ctx();
 }
 
-impl<'a> SecurityScanSubprocess<'a> {
-    pub(crate) fn spawn(&mut self) -> Result<(), Error> {
-        self.ipc_data = Vec::new();
-        self.stderr_data = Vec::new();
-        let parent: *mut Self = self;
-        self.ipc_reader.set_parent(parent.cast());
+impl SecurityScanSubprocess {
+    pub(crate) fn spawn(this: bun_ptr::ThisPtr<Self>) -> Result<(), Error> {
+        let me = this.get();
+        me.ipc_data.with_mut(|d| d.clear());
+        me.ipc_reader
+            .with_mut(|r| r.set_parent(this.as_ptr().cast::<c_void>()));
 
         // Two extra pipes for communicating with the scanner subprocess:
         // - fd 3: child writes JSON response, parent reads
@@ -1023,44 +1006,24 @@ impl<'a> SecurityScanSubprocess<'a> {
         // command-line length limits (>1MB), and we can't use stdin because scanners
         // may need stdin for their own setup (e.g. interactive prompts).
 
-        // fd 3 output pipe: bun.sys.pipe() + .pipe (inherit_fd) on both platforms.
+        // fd 3 output pipe: `bun_sys::pipe()`, inherited by the child on both platforms.
         let ipc_output_fds = match bun_sys::pipe() {
             Err(_) => return Err(crate::Error::IPCPipeFailed),
             Ok(fds) => fds,
         };
 
         let exec_path = bun_core::self_exe_path()?;
-
-        // Build
-        // owned NUL-terminated buffers so the pointers stay valid across the
-        // `spawn_process` FFI boundary.
-        let mut argv0_buf: Vec<u8> = exec_path.as_bytes().to_vec();
-        argv0_buf.push(0);
-        let mut argv3_buf: Vec<u8> = self.code.to_vec();
-        argv3_buf.push(0);
-        // Element type MUST be bare `*const c_char` (null sentinel), never
-        // `Option<*const c_char>`: raw pointers are already nullable, and
-        // `Option<*const T>` is a 2-word (tag, ptr) pair — casting that to
-        // `Argv` interleaves discriminant words and EFAULTs in the kernel.
-        let mut argv: [*const core::ffi::c_char; 5] = [
-            argv0_buf.as_ptr().cast(),
-            c"--no-install".as_ptr(),
-            c"-e".as_ptr(),
-            argv3_buf.as_ptr().cast(),
-            core::ptr::null(),
-        ];
-        const _: () = assert!(
-            core::mem::size_of::<[*const core::ffi::c_char; 5]>()
-                == 5 * core::mem::size_of::<usize>()
-        );
+        let code = bun_core::ZBox::from_bytes(&me.code);
+        let argv: [&core::ffi::CStr; 4] =
+            [exec_path.as_cstr(), c"--no-install", c"-e", code.as_cstr()];
 
         #[cfg(windows)]
         {
-            self.spawn_windows(&mut argv, ipc_output_fds)?;
+            Self::spawn_windows(this, &argv, ipc_output_fds)?;
         }
         #[cfg(not(windows))]
         {
-            self.spawn_posix(&mut argv, ipc_output_fds)?;
+            Self::spawn_posix(this, &argv, ipc_output_fds)?;
         }
 
         Ok(())
@@ -1072,10 +1035,11 @@ impl<'a> SecurityScanSubprocess<'a> {
     /// end comes back via spawned.extra_pipes.
     #[cfg(unix)]
     fn spawn_posix(
-        &mut self,
-        argv: &mut [*const core::ffi::c_char; 5],
+        this: bun_ptr::ThisPtr<Self>,
+        argv: &[&core::ffi::CStr],
         ipc_output_fds: [Fd; 2],
     ) -> Result<(), Error> {
+        let me = this.get();
         let extra_fds: Box<[Stdio]> = Box::new([
             Stdio::Pipe(ipc_output_fds[1]), // fd 3: child inherits write end
             Stdio::Buffer,                  // fd 4: socketpair, parent's end in extra_pipes
@@ -1090,26 +1054,20 @@ impl<'a> SecurityScanSubprocess<'a> {
             ..Default::default()
         };
 
-        // SAFETY: `argv` is a local null-terminated C-string array with a
-        // non-null argv[0]; `environ_ptr()` is the process environ block.
-        let mut spawned = unsafe {
-            spawn::spawn_process(
-                &spawn_options,
-                argv.as_mut_ptr().cast(),
-                bun_sys::environ_ptr(),
-            )
-        }?
-        .map_err(|e| e.to_zig_err())?;
-        // `defer spawned.extra_pipes.deinit()` — drops at scope exit.
+        let mut spawned =
+            spawn::spawn_process_cstr(&spawn_options, argv, spawn::SpawnEnv::Inherit)?
+                .map_err(|e| e.to_zig_err())?;
 
         ipc_output_fds[1].close();
 
         let _ = bun_sys::set_nonblocking(ipc_output_fds[0]);
-        self.ipc_reader.flags.insert(PosixFlags::NONBLOCKING);
-        self.ipc_reader.flags.remove(PosixFlags::SOCKET);
+        me.ipc_reader.with_mut(|r| {
+            r.flags.insert(PosixFlags::NONBLOCKING);
+            r.flags.remove(PosixFlags::SOCKET);
+        });
 
         let json_fd = spawned.extra_pipes[1].fd();
-        self.finish_spawn(&mut spawned, ipc_output_fds[0], move || {
+        Self::finish_spawn(this, &mut spawned, ipc_output_fds[0], move || {
             subprocess::stdio_result_from_fd(json_fd)
         })
     }
@@ -1122,26 +1080,25 @@ impl<'a> SecurityScanSubprocess<'a> {
     /// uv.Pipe for IOCP-based async writes.
     #[cfg(windows)]
     fn spawn_windows(
-        &mut self,
-        argv: &mut [*const core::ffi::c_char; 5],
+        this: bun_ptr::ThisPtr<Self>,
+        argv: &[&core::ffi::CStr],
         ipc_output_fds: [Fd; 2],
     ) -> Result<(), Error> {
         use bun_sys::ReturnCodeExt as _;
         use bun_sys::windows::libuv as uv;
 
-        let mut json_fds: [uv::uv_file; 2] = [0; 2];
-        // SAFETY: FFI — `json_fds` is a 2-element out-array; flags are valid.
-        let pipe_rc = unsafe { uv::uv_pipe(&mut json_fds, 0, uv::UV_NONBLOCK_PIPE as i32) };
-        if let Some(e) = pipe_rc.errno() {
-            ipc_output_fds[0].close();
-            ipc_output_fds[1].close();
-            return Err(bun_errno::from_errno(e as i32).into());
-        }
+        let me = this.get();
+        let json_fds = match uv::pipe_pair(0, uv::UV_NONBLOCK_PIPE as i32) {
+            Ok(fds) => fds,
+            Err(rc) => {
+                ipc_output_fds[0].close();
+                ipc_output_fds[1].close();
+                return Err(bun_errno::from_errno(rc.errno().map_or(0, |e| e as i32)).into());
+            }
+        };
         // Track ownership with optionals: None means the fd has been transferred
-        // or closed, so the errdefer skips it. Prevents double-close on error paths
+        // or closed, so the guard skips it. Prevents double-close on error paths
         // after pipe.open() takes ownership or after the explicit closes below.
-        // State is moved INTO the guard so later `= None` mutations are observed
-        // by the cleanup closure (PORTING.md: errdefer side-effects → scopeguard state).
         let mut fds = scopeguard::guard(
             (
                 Some(Fd::from_uv(json_fds[0])), // .0 = child_read_fd
@@ -1157,30 +1114,29 @@ impl<'a> SecurityScanSubprocess<'a> {
             },
         );
 
-        let pipe_ptr: *mut uv::Pipe =
-            bun_core::heap::into_raw(Box::new(bun_core::ffi::zeroed::<uv::Pipe>()));
-        // errdefer pipe.closeAndDestroy() until `StaticPipeWriter` takes the
-        // pipe (inside `finish_spawn`); from then on the writer's `Drop` closes
-        // it. libuv's close callback frees the allocation, so do NOT re-box on
-        // the cleanup path.
-        let pipe_taken = core::cell::Cell::new(false);
-        let mut pipe = scopeguard::guard(pipe_ptr, |p| {
-            if !pipe_taken.get() {
-                // SAFETY: p is the live Box-allocated uv_pipe_t; close_and_destroy
-                // schedules uv_close + frees the allocation.
-                unsafe { uv::Pipe::close_and_destroy(p) };
-            }
-        });
+        // On error, `close_and_destroy_pipe`: libuv's close callback frees the
+        // allocation. Stays armed across `ipc_reader.start()` inside
+        // finish_spawn (the pre-writer error window) so a registered-but-unowned
+        // uv handle is never leaked; disarmed once the writer takes the pipe.
+        let mut pipe = scopeguard::guard(
+            Some(Box::new(bun_core::ffi::zeroed::<uv::Pipe>())),
+            |pipe| {
+                if let Some(pipe) = pipe {
+                    bun_io::source::close_and_destroy_pipe(pipe);
+                }
+            },
+        );
         // `self.loop_()` already projects to the libuv `uv_loop_t*` on
         // Windows (see the `.uv_loop` projection in `loop_()`); pass through.
-        let uv_loop = self.loop_();
-        // SAFETY: *pipe was just heap-allocated above and is non-null.
-        if let Some(e) = unsafe { (**pipe).init(uv_loop, false) }.to_error(bun_sys::Tag::pipe) {
-            return Err(e.into());
-        }
-        if let Some(e) = unsafe { (**pipe).open(fds.1.unwrap().uv()) }.to_error(bun_sys::Tag::open)
+        let uv_loop = me.loop_();
         {
-            return Err(e.into());
+            let pipe = pipe.as_mut().expect("just set");
+            if let Some(e) = pipe.init(uv_loop, false).to_error(bun_sys::Tag::pipe) {
+                return Err(e.into());
+            }
+            if let Some(e) = pipe.open(fds.1.unwrap().uv()).to_error(bun_sys::Tag::open) {
+                return Err(e.into());
+            }
         }
         fds.1 = None; // pipe owns it now
 
@@ -1196,46 +1152,38 @@ impl<'a> SecurityScanSubprocess<'a> {
             cwd: Box::from(FileSystem::instance().top_level_dir()),
             extra_fds,
             windows: spawn::WindowsOptions {
-                loop_: EventLoopHandle::from_any(&mut self.manager.event_loop),
+                loop_: me.event_loop_handle,
                 ..Default::default()
             },
             ..Default::default()
         };
 
-        // SAFETY: `argv` is a local null-terminated C-string array with a
-        // non-null argv[0]; `environ_ptr()` is the process environ block.
-        let mut spawned = unsafe {
-            spawn::spawn_process(
-                &spawn_options,
-                argv.as_mut_ptr().cast(),
-                bun_sys::environ_ptr(),
-            )
-        }?
-        .map_err(|e| e.to_zig_err())?;
-        // `defer spawned.extra_pipes.deinit()` — drops at scope exit.
+        let mut spawned =
+            spawn::spawn_process_cstr(&spawn_options, argv, spawn::SpawnEnv::Inherit)?
+                .map_err(|e| e.to_zig_err())?;
 
         ipc_output_fds[1].close();
         fds.0.unwrap().close();
         fds.0 = None;
 
-        self.ipc_reader
-            .flags
-            .insert(bun_io::pipe_reader::WindowsFlags::NONBLOCKING);
+        me.ipc_reader.with_mut(|r| {
+            r.flags
+                .insert(bun_io::pipe_reader::WindowsFlags::NONBLOCKING)
+        });
 
-        // Hand the pipe to StaticPipeWriter lazily: the closure reconstitutes
-        // the Box at the exact `StaticPipeWriter::create` call site inside
-        // `finish_spawn`. If `finish_spawn` errors before that point
-        // (`ipc_reader.start()`), the closure drops as a no-op and the
-        // still-armed cleanup guard performs `close_and_destroy`.
-        self.finish_spawn(&mut spawned, ipc_output_fds[0], || {
-            pipe_taken.set(true);
-            // SAFETY: `pipe_ptr` is the same allocation produced by
-            // heap::alloc above and has not been freed; ownership transfers
-            // here exactly once.
-            StdioResult::Buffer(unsafe { bun_core::heap::take(pipe_ptr) })
+        // Hand the pipe to StaticPipeWriter lazily: the thunk runs at the
+        // exact `StaticPipeWriter::create` call site inside `finish_spawn`. If
+        // `finish_spawn` errors before that point (`ipc_reader.start()`), the
+        // thunk never runs and the still-armed cleanup guard performs
+        // `close_and_destroy`.
+        let pipe_slot = &mut *pipe;
+        Self::finish_spawn(this, &mut spawned, ipc_output_fds[0], move || {
+            StdioResult::Buffer(pipe_slot.take().expect("pipe handed over once"))
         })?;
 
-        // fd slots are already None.
+        // Success: pipe ownership now lives in StaticPipeWriter (the slot is
+        // `None`, so the guard is a no-op). fd slots are already None.
+        drop(pipe);
         scopeguard::ScopeGuard::into_inner(fds);
         Ok(())
     }
@@ -1243,7 +1191,7 @@ impl<'a> SecurityScanSubprocess<'a> {
     /// Common post-spawn setup: start the fd 3 reader, attach the process,
     /// start the fd 4 JSON writer, and begin watching for exit.
     fn finish_spawn(
-        &mut self,
+        this: bun_ptr::ThisPtr<Self>,
         spawned: &mut spawn::SpawnResult,
         ipc_read_fd: Fd,
         // Deferred constructor: a by-value
@@ -1251,69 +1199,50 @@ impl<'a> SecurityScanSubprocess<'a> {
         // allocation without `uv_close()` if `ipc_reader.start()` below failed,
         // leaking a registered libuv handle. Taking a thunk and calling it only
         // at the `StaticPipeWriter::create` site keeps the caller's
-        // `close_and_destroy` errdefer authoritative for the pre-writer window.
+        // `close_and_destroy_pipe` guard authoritative for the pre-writer window.
         make_json_stdio: impl FnOnce() -> StdioResult,
     ) -> Result<(), Error> {
+        let me = this.get();
         // Allocate the blob copy before registering any event loop callbacks. If
-        // this fails, nothing is registered yet and the caller's defer can safely
-        // destroy the struct.
-        let json_data_copy = Box::<[u8]>::from(&*self.json_data);
-        // routes through webcore::blob::Any (tier-6). The move-in pass adds
-        // `bun_sys::subprocess::Source::from_owned_bytes(Box<[u8]>)`.
+        // this fails, nothing is registered yet and the caller can safely drop
+        // the struct.
+        let json_data_copy = Box::<[u8]>::from(&*me.json_data);
         let json_source = subprocess::Source::from_owned_bytes(json_data_copy);
 
         // 2 = ipc_reader (fd 3) + json_writer (fd 4). Both must complete before
-        // isDone() returns true, otherwise we risk freeing this struct while
+        // is_done() returns true, otherwise we risk freeing this struct while
         // StaticPipeWriter still holds a pointer to it (child crash case).
-        self.remaining_fds = 2;
-        self.ipc_reader
-            .start(ipc_read_fd, true)
+        me.remaining_fds.set(2);
+        me.ipc_reader
+            .with_mut(|r| r.start(ipc_read_fd, true))
             .map_err(|e| e.to_zig_err())?;
 
-        // `to_process` consumes `SpawnResult` by value on POSIX (and
+        // `to_process_handle` consumes `SpawnResult` by value on POSIX (and
         // `&mut self` on Windows); take ownership of the result and let the
         // moved-from `*spawned` drop empty (`extra_pipes` already read).
-        let event_loop = EventLoopHandle::from_any(&mut self.manager.event_loop);
-        let process_handle = std::mem::take(spawned).to_process_handle(event_loop);
-        let process: *mut Process = process_handle.as_ptr();
-
-        // Derive the raw backref once and use it for all subsequent field
-        // access. `start()`/`watch_or_reap()` below may re-enter
-        // `on_close_io`/`on_process_exit` via this pointer while we are still
-        // inside this frame, so from here on we touch `*self` only through
-        // `parent` to keep a single provenance path (no overlapping `&mut`).
-        let parent: *mut Self = self;
-        // SAFETY: `process` is the freshly-allocated intrusive `*mut Process`
-        // (refcount == 1, owned by us); `parent` was just derived from
-        // `&mut self` and outlives `process` (it `deref`s it in `Drop`).
-        unsafe {
-            (*process).set_exit_handler(ProcessExit::new(ProcessExitKind::SecurityScan, parent));
-            (*parent).process = Some(process_handle);
-        }
+        let event_loop = me.event_loop_handle;
+        let process = std::mem::take(spawned).to_process_handle(event_loop);
+        // `start()`/`watch_or_reap()` below may re-enter
+        // `on_close_io`/`on_process_exit` through `this` while we are still
+        // inside this frame; everything they touch is a `Cell`.
+        process.set_exit_handler(this);
+        me.process.set(Some(process));
 
         // Assign the field BEFORE `start()`. `start()` may complete the write synchronously
         // (small JSON fits the 64KB pipe buffer on POSIX) and re-enter
-        // `on_close_io` via the `parent` backref; that callback must observe
-        // `json_writer.is_some()` to decrement `remaining_fds`, otherwise
-        // `is_done()` never returns true and `sleep_until` hangs.
-        // SAFETY: `parent` is the live boxed `self` (see note above).
-        let parent_this = unsafe { bun_ptr::ThisPtr::new(parent.cast()) };
-        let writer =
-            StaticPipeWriter::create(event_loop, parent_this, make_json_stdio(), json_source);
-        // Keep a duped ref locally so no borrow on `(*parent).json_writer` is
-        // held across `start()` — `on_close_io` may `.take()` the field.
+        // `on_close_io`; that callback must observe `json_writer.is_some()` to
+        // decrement `remaining_fds`, otherwise `is_done()` never returns true
+        // and `sleep_until` hangs.
+        let writer = StaticPipeWriter::create(event_loop, this, make_json_stdio(), json_source);
+        // Keep a duped ref locally so nothing reads `json_writer` across
+        // `start()` — `on_close_io` may `.take()` the field.
         let writer_local = writer.clone();
-        // SAFETY: see `parent` note above.
-        unsafe { (*parent).json_writer = Some(writer) };
+        me.json_writer.set(Some(writer));
 
-        // Error-cleanup guard over the FIELD (not a local),
-        // including a presence check on it — `start()` may already
-        // have re-entered and nulled it. State is the `parent` backref; disarmed
-        // via `into_inner` on the success path.
-        let guard = scopeguard::guard(parent, |parent| {
-            // SAFETY: `parent` points at the live `self` of `finish_spawn`; the
-            // guard only fires on early return inside this fn.
-            if let Some(w) = unsafe { (*parent).json_writer.take() } {
+        // Error-cleanup over the FIELD (not a local), including a presence
+        // check on it — `start()` may already have re-entered and nulled it.
+        let guard = scopeguard::guard((), |()| {
+            if let Some(w) = this.get().json_writer.take() {
                 StaticPipeWriter::detach_source(w.this_ptr());
             }
         });
@@ -1331,53 +1260,61 @@ impl<'a> SecurityScanSubprocess<'a> {
             return Err(crate::Error::JSONPipeWriterFailed);
         }
 
-        // SAFETY: `process` is live (we hold a ref); reached via the local raw
-        // ptr per the single-provenance note. `watch_or_reap` may re-enter
-        // `on_process_exit` synchronously (already-exited child).
-        match unsafe { (*process).watch_or_reap() } {
-            Err(_) => return Err(crate::Error::ProcessWatchFailed),
-            Ok(_) => {}
+        // `watch_or_reap` may re-enter `on_process_exit` synchronously
+        // (already-exited child).
+        let watched = {
+            let process = me.process.take().expect("set above");
+            let result = process.watch_or_reap();
+            me.process.set(Some(process));
+            result
+        };
+        if watched.is_err() {
+            return Err(crate::Error::ProcessWatchFailed);
         }
 
         scopeguard::ScopeGuard::into_inner(guard);
         Ok(())
     }
 
-    pub(crate) fn on_close_io(&mut self, _: subprocess::StdioKind) {
+    pub(crate) fn on_close_io(&self, _: subprocess::StdioKind) {
         if let Some(writer) = self.json_writer.take() {
             StaticPipeWriter::detach_source(writer.this_ptr());
-            self.remaining_fds -= 1;
+            drop(writer);
+            self.remaining_fds.set(self.remaining_fds.get() - 1);
         }
     }
 
     pub(crate) fn is_done(&self) -> bool {
-        self.exit_status.is_some() && self.remaining_fds == 0
+        let status = self.exit_status.take();
+        let exited = status.is_some();
+        self.exit_status.set(status);
+        exited && self.remaining_fds.get() == 0
     }
 
-    pub(crate) fn loop_(&mut self) -> *mut AsyncLoop {
-        self.manager.event_loop.native_loop()
+    pub(crate) fn loop_(&self) -> *mut AsyncLoop {
+        self.event_loop_handle.native_loop()
     }
 
-    pub(crate) fn on_reader_done(&mut self) {
-        self.has_received_ipc = true;
-        self.remaining_fds -= 1;
+    pub(crate) fn on_reader_done(&self) {
+        self.has_received_ipc.set(true);
+        self.remaining_fds.set(self.remaining_fds.get() - 1);
     }
 
-    pub(crate) fn on_reader_error(&mut self, err: bun_sys::Error) {
+    pub(crate) fn on_reader_error(&self, err: bun_sys::Error) {
         Output::err_generic("Failed to read security scanner IPC: {}", (err,));
-        self.has_received_ipc = true;
-        self.remaining_fds -= 1;
+        self.has_received_ipc.set(true);
+        self.remaining_fds.set(self.remaining_fds.get() - 1);
     }
 
-    pub(crate) fn on_read_chunk(&mut self, chunk: &[u8], _has_more: ReadState) -> bool {
-        self.ipc_data.extend_from_slice(chunk);
+    pub(crate) fn on_read_chunk(&self, chunk: &[u8], _has_more: ReadState) -> bool {
+        self.ipc_data.with_mut(|d| d.extend_from_slice(chunk));
         true
     }
 
-    pub(crate) fn on_process_exit(&mut self, _: &mut Process, status: Status, _: &Rusage) {
-        self.exit_status = Some(status);
+    pub(crate) fn on_process_exit(&self, status: Status) {
+        self.exit_status.set(Some(status));
 
-        if !self.has_received_ipc {
+        if !self.has_received_ipc.get() {
             // Do not tear
             // down `ipc_reader` here unconditionally: that races process-exit
             // against fd-3-readable: `ipc_reader.start()` only registers a
@@ -1400,7 +1337,7 @@ impl<'a> SecurityScanSubprocess<'a> {
             // If it bailed early (EAGAIN limit / unexpected errno / fd already
             // invalid) leave the FilePoll registered: the next `tick_once`
             // has no pending task, so it ticks uws, the poll delivers
-            // readable+HUP, `read_with_fn` drains to `Ok(0)`, and
+            // readable+HUP, the reader drains to `Ok(0)`, and
             // `on_reader_done` decrements `remaining_fds` exactly once.
             //
             // Windows reads via libuv (async) and the fd here is a uv-owned
@@ -1408,7 +1345,7 @@ impl<'a> SecurityScanSubprocess<'a> {
             // teardown (the libuv exit/read ordering is not the failing path).
             #[cfg(not(windows))]
             {
-                let fd = self.ipc_reader.get_fd();
+                let fd = self.ipc_reader.with_mut(|r| r.get_fd());
                 if fd != Fd::INVALID {
                     let mut saw_eof = false;
                     let mut buf = [0u8; 4096];
@@ -1420,7 +1357,7 @@ impl<'a> SecurityScanSubprocess<'a> {
                                 break;
                             }
                             Ok(n) => {
-                                self.ipc_data.extend_from_slice(&buf[..n]);
+                                self.ipc_data.with_mut(|d| d.extend_from_slice(&buf[..n]));
                                 spins = 0;
                             }
                             Err(e) => match e.get_errno() {
@@ -1438,7 +1375,8 @@ impl<'a> SecurityScanSubprocess<'a> {
                             },
                         }
                     }
-                    self.has_received_ipc = !self.ipc_data.is_empty();
+                    self.has_received_ipc
+                        .set(self.ipc_data.with_mut(|d| !d.is_empty()));
                     if !saw_eof {
                         // Drain bailed before EOF — payload may be incomplete
                         // and the write-end close not yet visible. Leave the
@@ -1458,13 +1396,14 @@ impl<'a> SecurityScanSubprocess<'a> {
             // Must use deinit() (close-without-reporting), NOT close(): close()
             // would re-enter on_reader_done and decrement remaining_fds a
             // second time, underflowing it and hanging sleep_until.
-            self.ipc_reader.deinit();
-            self.remaining_fds -= 1;
+            self.ipc_reader.with_mut(|r| r.deinit());
+            self.remaining_fds.set(self.remaining_fds.get() - 1);
         }
     }
 
     pub(crate) fn handle_results(
-        &mut self,
+        &self,
+        manager: &PackageManager,
         package_paths: &mut ArrayHashMap<PackageID, PackagePath>,
         start_time: i64,
         packages_scanned: usize,
@@ -1474,9 +1413,8 @@ impl<'a> SecurityScanSubprocess<'a> {
         _original_cwd: &[u8],         // Reserved for future use
         is_retry: bool,
     ) -> Result<ScanAttemptResult, Error> {
-        // `defer { ipc_data.deinit(); stderr_data.deinit(); }` — Vec fields drop with self.
-
-        let Some(status) = self.exit_status.clone() else {
+        let ipc_data = self.ipc_data.replace(Vec::new());
+        let Some(status) = self.exit_status.take() else {
             Output::err_generic(
                 "Security scanner terminated without an exit status. This is a bug in Bun.",
                 (),
@@ -1484,7 +1422,7 @@ impl<'a> SecurityScanSubprocess<'a> {
             return Err(crate::Error::SecurityScannerProcessFailedWithoutExitStatus);
         };
 
-        if self.ipc_data.is_empty() {
+        if ipc_data.is_empty() {
             match &status {
                 Status::Exited(Exited { code, .. }) => {
                     Output::err_generic(
@@ -1509,7 +1447,7 @@ impl<'a> SecurityScanSubprocess<'a> {
         }
 
         let json_source =
-            bun_ast::Source::init_path_string("ipc-message.json", self.ipc_data.as_slice());
+            bun_ast::Source::init_path_string("ipc-message.json", ipc_data.as_slice());
 
         let mut temp_log = bun_ast::Log::init();
 
@@ -1517,8 +1455,8 @@ impl<'a> SecurityScanSubprocess<'a> {
             Ok(e) => e,
             Err(e) => {
                 Output::err_generic("Security scanner sent invalid JSON: {}", (e.name(),));
-                if self.ipc_data.len() < 1000 {
-                    Output::err_generic("Response: {}", (BStr::new(&self.ipc_data),));
+                if ipc_data.len() < 1000 {
+                    Output::err_generic("Response: {}", (BStr::new(&ipc_data),));
                 }
                 return Err(crate::Error::InvalidIPCMessage);
             }
@@ -1653,7 +1591,7 @@ impl<'a> SecurityScanSubprocess<'a> {
         // if we got here then we got a result message so we can continue like normal
         let duration = bun_core::time::milli_timestamp() - start_time;
 
-        if self.manager.options.log_level == crate::package_manager::Options::LogLevel::Verbose {
+        if self.log_level == crate::package_manager::Options::LogLevel::Verbose {
             match &status {
                 Status::Exited(Exited { code, .. }) => {
                     if *code == 0 {
@@ -1684,8 +1622,7 @@ impl<'a> SecurityScanSubprocess<'a> {
                     );
                 }
             }
-        } else if self.manager.options.log_level
-            != crate::package_manager::Options::LogLevel::Silent
+        } else if self.log_level != crate::package_manager::Options::LogLevel::Silent
             && duration >= 1000
         {
             let maybe_hourglass = if Output::enable_ansi_colors_stderr() {
@@ -1717,7 +1654,7 @@ impl<'a> SecurityScanSubprocess<'a> {
         };
 
         let advisories =
-            parse_security_advisories_from_expr(self.manager, advisories_expr, package_paths)?;
+            parse_security_advisories_from_expr(manager, advisories_expr, package_paths)?;
 
         if !status.is_ok() {
             match &status {

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -102,7 +102,6 @@ pub fn update_package_json_and_install_with_manager(
     original_cwd: &[u8],
 ) -> Result<(), Error> {
     let mut update_requests = UpdateRequestArray::with_capacity(64);
-    // `defer update_requests.deinit(manager.allocator)` — handled by Drop.
 
     if manager.options.positionals.len() <= 1 {
         match manager.subcommand {
@@ -146,21 +145,13 @@ fn update_package_json_and_install_with_manager_with_updates_and_update_requests
 ) -> Result<(), Error> {
     let subcommand = manager.subcommand;
     if subcommand != Subcommand::PatchCommit && subcommand != Subcommand::Patch {
-        // reshaped for borrowck — `parse` returns a `&mut [UpdateRequest]`
-        // sub-slice of `update_requests`; we take its length and truncate the Vec so
-        // the next call can take the Vec by value.
-        let len = UpdateRequest::parse(
-            // `dependency::parse_with_tag` is the only consumer of `pm`; it inserts
-            // into `pm.known_npm_aliases` for `npm:`-aliased positionals.
-            Some(manager),
-            // SAFETY: `ctx.log` is set once during `Command::create()` (process-
-            // lifetime singleton) and is never null afterward.
-            unsafe { &mut *ctx.log },
-            positionals,
-            update_requests,
-            subcommand,
-        )
-        .len();
+        // `parse` returns a `&mut [UpdateRequest]` prefix of `update_requests`;
+        // take its length and truncate the Vec so it can be passed on by value.
+        // The manager is only needed for `known_npm_aliases` (`npm:`-aliased
+        // positionals).
+        let len = manager.with_log(|manager, log| {
+            UpdateRequest::parse(Some(manager), log, positionals, update_requests, subcommand).len()
+        });
         update_requests.truncate(len);
     } else {
         update_requests.clear();
@@ -177,19 +168,16 @@ fn update_package_json_and_install_with_manager_with_updates_and_update_requests
 fn update_package_json_and_install_with_manager_with_updates(
     manager: &mut PackageManager,
     ctx: Command::Context,
-    // reshaped for borrowck — taking by
-    // value lets us hand ownership to `manager.update_requests` (typed
-    // `Box<[UpdateRequest]>`) and re-borrow afterwards without
-    // aliasing `&mut manager`.
+    // By value: ownership moves into `manager.update_requests`.
     mut updates: Vec<UpdateRequest>,
     subcommand: Subcommand,
     original_cwd: &[u8],
 ) -> Result<(), Error> {
     let log_level = manager.options.log_level;
-    if manager.log_mut().errors > 0 {
+    if manager.log.errors > 0 {
         if log_level != LogLevel::Silent {
             let _ = manager
-                .log_mut()
+                .log
                 .print(std::ptr::from_mut(Output::error_writer()));
         }
         Global::crash();
@@ -231,9 +219,9 @@ fn update_package_json_and_install_with_manager_with_updates(
                         "failed to {s} lockfile: {s}",
                         (cause.step.verb(), cause.value.name()),
                     );
-                    if manager.log_mut().has_errors() {
+                    if manager.log.has_errors() {
                         let _ = manager
-                            .log_mut()
+                            .log
                             .print(std::ptr::from_mut(Output::error_writer()));
                     }
                 }
@@ -283,15 +271,26 @@ fn update_package_json_and_install_with_manager_with_updates(
 
     add_catalog::prepare(manager, &updates);
 
-    // reshaped for borrowck — `get_with_path` returns `&mut MapEntry`
-    // borrowed from `manager.workspace_package_json_cache`, but we then need
-    // `&mut *manager` for `PackageJSONEditor::edit` / `do_patch_commit` while still
-    // holding the entry. Demote to `*mut MapEntry` and re-
-    // borrow at point of use. The cache map is not mutated again until the
-    // next `get_with_path` call below, so the pointer remains valid.
-    let current_package_json_ptr: *mut MapEntry =
+    // `get_with_path` returns `&mut MapEntry` borrowed from
+    // `manager.workspace_package_json_cache`, but `PackageJSONEditor::edit` /
+    // `do_patch_commit` need `&mut *manager` in between; look the (cached)
+    // entry up again at each point of use.
+    fn current_package_json_entry(manager: &mut PackageManager) -> &mut MapEntry {
         match manager.workspace_package_json_cache.get_with_path(
-            manager.log_mut(),
+            &mut manager.log,
+            manager.original_package_json_path.as_bytes(),
+            GetJSONOptions {
+                guess_indentation: true,
+                ..Default::default()
+            },
+        ) {
+            GetResult::Entry(entry) => entry,
+            _ => unreachable!("cached above"),
+        }
+    }
+    let current_package_json: &mut MapEntry =
+        match manager.workspace_package_json_cache.get_with_path(
+            &mut manager.log,
             manager.original_package_json_path.as_bytes(),
             GetJSONOptions {
                 guess_indentation: true,
@@ -300,7 +299,7 @@ fn update_package_json_and_install_with_manager_with_updates(
         ) {
             GetResult::ParseErr(err) => {
                 let _ = manager
-                    .log_mut()
+                    .log
                     .print(std::ptr::from_mut(Output::error_writer()));
                 Output::err_generic(
                     "failed to parse package.json \"{s}\": {s}",
@@ -321,15 +320,11 @@ fn update_package_json_and_install_with_manager_with_updates(
                 );
                 Global::crash();
             }
-            GetResult::Entry(entry) => core::ptr::from_mut(entry),
+            GetResult::Entry(entry) => entry,
         };
-    // SAFETY: see note above — pointer into `manager.workspace_package_json_cache`,
-    // valid until the next `get_with_path`. No `&mut manager.workspace_package_json_cache`
-    // is taken across this borrow; `PackageJSONEditor` and `do_patch_commit` touch only
-    // disjoint manager fields.
-    let current_package_json: &mut MapEntry = unsafe { &mut *current_package_json_ptr };
     let mut current_package_json_root: bun_ast::Expr = current_package_json.root;
     let current_package_json_indent = current_package_json.indentation;
+    let current_package_json_source_len = current_package_json.source.contents.len();
 
     // If there originally was a newline at the end of their package.json, preserve it
     // so that we don't cause unnecessary diffs in their git history.
@@ -452,12 +447,12 @@ fn update_package_json_and_install_with_manager_with_updates(
 
     let mut buffer_writer = js_printer::BufferWriter::init();
     buffer_writer.buffer.list.reserve(
-        (current_package_json.source.contents.len() + 1)
-            .saturating_sub(buffer_writer.buffer.list.len()),
+        (current_package_json_source_len + 1).saturating_sub(buffer_writer.buffer.list.len()),
     );
     buffer_writer.append_newline = preserve_trailing_newline_at_eof_for_package_json;
     let mut package_json_writer = js_printer::BufferPrinter::init(buffer_writer);
 
+    let current_package_json = current_package_json_entry(manager);
     if let Err(e) = js_printer::print_json(
         &mut package_json_writer,
         current_package_json_root,
@@ -492,7 +487,23 @@ fn update_package_json_and_install_with_manager_with_updates(
     // (`current_package_json_root`), so re-parse the
     // printed source so the cached AST (consumed by `FolderResolver` for workspace
     // members during `install_with_manager`) reflects the new dependency list.
-    if let Err(err) = current_package_json.reparse_root(manager.log_mut()) {
+    let PackageManager {
+        log,
+        workspace_package_json_cache,
+        original_package_json_path,
+        ..
+    } = &mut *manager;
+    let GetResult::Entry(current_package_json) = workspace_package_json_cache.get_with_path(
+        log,
+        original_package_json_path.as_bytes(),
+        GetJSONOptions {
+            guess_indentation: true,
+            ..Default::default()
+        },
+    ) else {
+        unreachable!("cached above")
+    };
+    if let Err(err) = current_package_json.reparse_root(log) {
         bun_core::pretty_errorln!("package.json failed to parse due to error {}", err.name(),);
         Global::crash();
     }
@@ -529,12 +540,25 @@ fn update_package_json_and_install_with_manager_with_updates(
         root_package_json_path_buf[root_package_json_path_len] = 0;
         let root_package_json_path = &root_package_json_path_buf[..root_package_json_path_len];
 
-        // The lifetime of this pointer is only valid until the next call to `getWithPath`, which can happen after this scope.
-        // https://github.com/oven-sh/bun/issues/12288
-        // reshaped for borrowck — see `current_package_json_ptr` above.
-        let root_package_json_ptr: *mut MapEntry =
+        // The entry is only valid until the next `get_with_path`, which can happen
+        // after this scope (https://github.com/oven-sh/bun/issues/12288), so it is
+        // re-fetched at each use.
+        fn root_entry<'m>(manager: &'m mut PackageManager, path: &[u8]) -> &'m mut MapEntry {
             match manager.workspace_package_json_cache.get_with_path(
-                manager.log_mut(),
+                &mut manager.log,
+                path,
+                GetJSONOptions {
+                    guess_indentation: true,
+                    ..Default::default()
+                },
+            ) {
+                GetResult::Entry(entry) => entry,
+                _ => unreachable!("cached above"),
+            }
+        }
+        let root_package_json: &mut MapEntry =
+            match manager.workspace_package_json_cache.get_with_path(
+                &mut manager.log,
                 root_package_json_path,
                 GetJSONOptions {
                     guess_indentation: true,
@@ -543,7 +567,7 @@ fn update_package_json_and_install_with_manager_with_updates(
             ) {
                 GetResult::ParseErr(err) => {
                     let _ = manager
-                        .log_mut()
+                        .log
                         .print(std::ptr::from_mut(Output::error_writer()));
                     Output::err_generic(
                         "failed to parse package.json \"{s}\": {s}",
@@ -561,21 +585,18 @@ fn update_package_json_and_install_with_manager_with_updates(
                     );
                     Global::crash();
                 }
-                GetResult::Entry(entry) => core::ptr::from_mut(entry),
+                GetResult::Entry(entry) => entry,
             };
-        // SAFETY: pointer into `manager.workspace_package_json_cache`, valid until the
-        // next `get_with_path` (after this block). `edit_patched_dependencies` touches
-        // only disjoint manager fields.
-        let root_package_json: &mut MapEntry = unsafe { &mut *root_package_json_ptr };
+        let mut root_package_json_root: bun_ast::Expr = root_package_json.root;
 
         if let Some(stuff) = &not_in_workspace_root {
-            let mut root_package_json_root: bun_ast::Expr = root_package_json.root;
             PackageJSONEditor::edit_patched_dependencies(
                 manager,
                 &mut root_package_json_root,
                 &stuff.patch_key,
                 &stuff.patchfile_path,
             )?;
+            let root_package_json = root_entry(manager, root_package_json_path);
             let mut buffer_writer2 = js_printer::BufferWriter::init();
             buffer_writer2.buffer.list.reserve(
                 (root_package_json.source.contents.len() + 1)
@@ -620,13 +641,29 @@ fn update_package_json_and_install_with_manager_with_updates(
             && manager.update_requests.is_empty()
             && root_is_targeted
         {
-            let root_package_json_root: bun_ast::Expr = root_package_json.root;
             if PackageJSONEditor::edit_catalogs_before_update(manager, &root_package_json_root)?
                 && manager.options.do_.contains(Do::UPDATE_TO_LATEST)
             {
                 // entries now hold a temporary `latest`; refresh the cache so install resolves those.
+                let PackageManager {
+                    log,
+                    workspace_package_json_cache,
+                    ..
+                } = &mut *manager;
+                let GetResult::Entry(root_package_json) = workspace_package_json_cache
+                    .get_with_path(
+                        log,
+                        root_package_json_path,
+                        GetJSONOptions {
+                            guess_indentation: true,
+                            ..Default::default()
+                        },
+                    )
+                else {
+                    unreachable!("cached above")
+                };
                 print_package_json_into_cache_entry(root_package_json, root_package_json_root);
-                if let Err(err) = root_package_json.reparse_root(manager.log_mut()) {
+                if let Err(err) = root_package_json.reparse_root(log) {
                     bun_core::pretty_errorln!(
                         "package.json failed to parse due to error {}",
                         err.name(),
@@ -637,10 +674,9 @@ fn update_package_json_and_install_with_manager_with_updates(
         }
 
         if manager.options.add_catalog.is_some() && manager.workspace_name_hash.is_some() {
-            add_catalog::edit_root_entry_before_install(manager, root_package_json)?;
+            add_catalog::edit_root_entry_before_install(manager, root_package_json_path)?;
         }
 
-        // SAFETY: root_package_json_path_buf[root_package_json_path_len] == 0 written above
         break 'root_package_json_path ZStr::from_buf(
             &root_package_json_path_buf[..],
             root_package_json_path_len,
@@ -666,7 +702,7 @@ fn update_package_json_and_install_with_manager_with_updates(
                     let root_package_json_entry = match manager
                         .workspace_package_json_cache
                         .get_with_path(
-                            manager.log_mut(),
+                            &mut manager.log,
                             root_package_json_path.as_bytes(),
                             GetJSONOptions::default(),
                         )
@@ -785,7 +821,7 @@ pub fn update_package_json_and_install_and_cli(
     cli: CommandLineArguments,
 ) -> Result<(), Error> {
     let update_groups = cli.update_groups;
-    let (manager_ptr, original_cwd) = 'brk: {
+    let (manager, original_cwd) = 'brk: {
         match super::init(ctx, cli.clone(), subcommand) {
             Ok(v) => v,
             Err(e) => {
@@ -815,13 +851,8 @@ pub fn update_package_json_and_install_and_cli(
             }
         }
     };
-    // `defer ctx.allocator.free(original_cwd)` — `original_cwd: Box<[u8]>` drops at scope exit.
     let _original_cwd_owner: Box<[u8]> = original_cwd;
     let original_cwd: &[u8] = &_original_cwd_owner;
-    // SAFETY: `super::init` returns a `*mut PackageManager` to the process-static
-    // singleton. We are on the single CLI thread; no worker
-    // threads deref `get()` until `install_with_manager` spawns the HTTP thread.
-    let manager: &mut PackageManager = &mut *manager_ptr;
 
     if manager.options.should_print_command_name() {
         // `concatcp!` yields `&'static str`, but `format_args!` requires a string *literal*

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -1,8 +1,6 @@
 //! Schedule long-running callbacks for a task
 //! Slow stuff is broken into tasks, each can run independently without locks
 
-use core::mem::ManuallyDrop;
-
 use bun_ast::{Loc, Log};
 use bun_core::Output;
 use bun_core::StringOrTinyString;
@@ -16,74 +14,57 @@ use crate::{
     DependencyID, ExtractData, ExtractTarball, NetworkTask, PackageManager, PatchTask, Resolution,
 };
 
-/// `'a` is forced by LIFETIMES.tsv (BORROW_PARAM on `Request::*.network`).
-/// TODO: lifetime — Task lives in an intrusive cross-thread queue
-/// (`next`, `package_manager` BACKREF). A `&'a mut NetworkTask` cannot soundly
-/// cross that boundary; Phase B should likely demote to `*mut NetworkTask`.
-pub struct Task<'a> {
-    pub(crate) tag: Tag,
-    pub(crate) request: Request<'a>,
+/// A resolve/extract job. Built on the main thread, run once on a thread-pool
+/// worker ([`bun_threading::work_pool::OwnedTask::run`]), and handed back to
+/// the main thread through `Shared::resolve_tasks`.
+pub struct Task {
+    pub(crate) request: Request,
     pub(crate) data: Data,
-    /// default: `Status::Waiting`
     pub(crate) status: Status,
-    /// default: `thread_pool::Task { callback: Task::callback }`
     pub(crate) threadpool_task: thread_pool::Task,
     pub(crate) log: Log,
     pub(crate) id: Id,
-    /// default: `None`
     pub(crate) err: Option<crate::Error>,
-    /// BACKREF — owned by `PackageManager.preallocated_resolve_tasks`.
-    /// `None` only in `uninit()`; every scheduled task overwrites it.
-    pub(crate) package_manager: Option<bun_ptr::ParentRef<PackageManager, bun_ptr::Mut>>,
-    /// default: `None`
+    /// Read-only on the worker (options, cache/temp dirs, `shared`); the
+    /// manager is leaked for the process and outlives every task.
+    pub(crate) package_manager: bun_ptr::BackRef<PackageManager>,
     pub(crate) apply_patch_task: Option<Box<PatchTask>>,
-    /// The filesystem tail of a clone or checkout task; `callback` runs it. default: `None`
+    /// The filesystem tail of a clone or checkout task; `run_owned` runs it.
     pub(crate) git_finalize: Option<crate::git_runner::Finalize>,
-    /// INTRUSIVE — `bun.UnboundedQueue(Task, .next)`
-    /// default: null
-    pub(crate) next: bun_threading::Link<Task<'a>>,
+    /// INTRUSIVE — `OwnedQueue<Task>` link.
+    pub(crate) next: bun_threading::Link<Task>,
 }
 
-/// Callers MUST overwrite `tag`, `request`, `id`, `package_manager` before
-/// the task is observed. Exposed as a module-level fn so call sites that import this
-/// module as `Task` can write `..Task::uninit()` in struct-update position.
-#[inline]
-pub(crate) fn uninit() -> Task<'static> {
-    Task {
-        // Overwritten by every caller; placeholder value.
-        tag: Tag::PackageManifest,
-        // SAFETY: untagged unions of `ManuallyDrop<_>` — any bit pattern is
-        // valid storage and is never read before the caller overwrites it.
-        request: unsafe { bun_core::ffi::zeroed_unchecked() },
-        // SAFETY: untagged unions of `ManuallyDrop<_>` — any bit pattern is
-        // valid storage and is never read before the caller overwrites it.
-        data: unsafe { bun_core::ffi::zeroed_unchecked() },
-        // `Log` contains `Vec<Msg>` (NonNull invariant) so it cannot be
-        // `mem::zeroed()`; and struct-update `..Task::uninit()` *drops* the
-        // base value's `log` when the caller supplies their own, so this must
-        // be a valid (empty) Log either way.
-        log: Log::default(),
-        id: Id(0),
-        package_manager: None,
-        status: Status::Waiting,
-        threadpool_task: thread_pool::Task {
-            node: Default::default(),
-            callback: Task::callback,
-        },
-        err: None,
-        apply_patch_task: None,
-        git_finalize: None,
-        next: bun_threading::Link::new(),
+bun_threading::intrusive_linked!(Task, next);
+bun_threading::owned_task!(Task, threadpool_task);
+
+impl Task {
+    pub(crate) fn new(manager: &PackageManager, id: Id, request: Request) -> Box<Task> {
+        Box::new(Task {
+            request,
+            data: Data::None,
+            status: Status::Waiting,
+            threadpool_task: thread_pool::Task::default(),
+            log: Log::default(),
+            id,
+            err: None,
+            package_manager: bun_ptr::BackRef::new(manager),
+            apply_patch_task: None,
+            git_finalize: None,
+            next: bun_threading::Link::new(),
+        })
     }
-}
 
-// SAFETY: `next` is the sole intrusive link for `UnboundedQueue<Task>`;
-// `link()` always projects to it.
-unsafe impl<'a> bun_threading::Linked for Task<'a> {
     #[inline]
-    unsafe fn link(item: *mut Self) -> *const bun_threading::Link<Self> {
-        // SAFETY: `item` is valid and properly aligned per `UnboundedQueue` contract.
-        unsafe { core::ptr::addr_of!((*item).next) }
+    pub(crate) fn tag(&self) -> Tag {
+        match self.request {
+            Request::PackageManifest { .. } => Tag::PackageManifest,
+            Request::Extract { .. } => Tag::Extract,
+            Request::GitClone { .. } => Tag::GitClone,
+            Request::GitCommit { .. } => Tag::GitCommit,
+            Request::GitCheckout { .. } => Tag::GitCheckout,
+            Request::LocalTarball { .. } => Tag::LocalTarball,
+        }
     }
 }
 
@@ -110,13 +91,7 @@ impl Id {
         hasher.update(b"npm-package:");
         hasher.update(package_name);
         hasher.update(b"@");
-        // SAFETY: reading raw bytes of a POD value for hashing
-        hasher.update(unsafe {
-            bun_core::ffi::slice(
-                (&raw const package_version).cast::<u8>(),
-                core::mem::size_of::<semver::Version>(),
-            )
-        });
+        hasher.update(bytemuck::bytes_of(&package_version));
         Id(hasher.final_())
     }
 
@@ -161,121 +136,96 @@ impl Id {
     }
 }
 
-impl<'a> Task<'a> {
-    // ── Tag-checked projectors for the untagged `Request`/`Data` unions ────
-    // `Task.tag` is the single discriminant for both; every variant payload is
-    // POD or `ManuallyDrop`-wrapped (no drop on overwrite), so reading the
-    // wrong arm is well-defined garbage rather than UB. The macro's trailing
-    // `as *const $Ty` cast unwraps `ManuallyDrop<$Ty>` (`repr(transparent)`).
-    bun_core::extern_union_accessors! {
-        tag: tag as Tag, value: request;
-        PackageManifest => request_package_manifest @ package_manifest: PackageManifestRequest<'a>, mut request_package_manifest_mut;
-        Extract         => request_extract          @ extract:          ExtractRequest<'a>,         mut request_extract_mut;
-        GitClone        => request_git_clone        @ git_clone:        GitCloneRequest,            mut request_git_clone_mut;
-        GitCommit       => request_git_commit       @ git_commit:       GitCommitRequest,           mut request_git_commit_mut;
-        GitCheckout     => request_git_checkout     @ git_checkout:     GitCheckoutRequest,         mut request_git_checkout_mut;
-        LocalTarball    => request_local_tarball    @ local_tarball:    LocalTarballRequest,        mut request_local_tarball_mut;
+impl Task {
+    #[inline]
+    pub(crate) fn request_package_manifest(&self) -> (&StringOrTinyString, &NetworkTask) {
+        match &self.request {
+            Request::PackageManifest { name, network } => (
+                name,
+                network
+                    .as_deref()
+                    .expect("manifest task owns its network task"),
+            ),
+            _ => unreachable!(),
+        }
+    }
+    #[inline]
+    pub(crate) fn request_git_clone(&self) -> &GitCloneRequest {
+        match &self.request {
+            Request::GitClone(req) => req,
+            _ => unreachable!(),
+        }
+    }
+    #[inline]
+    pub(crate) fn request_git_commit(&self) -> &GitCommitRequest {
+        match &self.request {
+            Request::GitCommit(req) => req,
+            _ => unreachable!(),
+        }
+    }
+    #[inline]
+    pub(crate) fn request_git_checkout(&self) -> &GitCheckoutRequest {
+        match &self.request {
+            Request::GitCheckout(req) => req,
+            _ => unreachable!(),
+        }
     }
 
-    bun_core::extern_union_accessors! {
-        tag: tag as Tag, value: data;
-        GitCommit       => data_git_commit       @ git_commit:       Vec<u8>,     mut data_git_commit_mut;
-        GitCheckout     => data_git_checkout     @ git_checkout:     ExtractData, mut data_git_checkout_mut;
+    /// The tarball an `Extract`/`LocalTarball` task is for.
+    #[inline]
+    pub(crate) fn request_tarball(&self) -> &ExtractTarball {
+        match &self.request {
+            Request::Extract { tarball, .. } | Request::LocalTarball { tarball, .. } => tarball,
+            _ => unreachable!(),
+        }
     }
 
-    // ── Data projectors (multi-tag / by-value — kept hand-written) ─────────
-    // `Tag::LocalTarball` writes its result into `data.extract` (same payload
-    // type as `Tag::Extract`), so `data_extract*` accepts both tags.
     #[inline]
     pub(crate) fn data_extract(&self) -> &ExtractData {
-        debug_assert!(self.tag == Tag::Extract || self.tag == Tag::LocalTarball);
-        // SAFETY: tag-guarded; `ManuallyDrop` deref.
-        unsafe { &*self.data.extract }
+        match &self.data {
+            Data::Extract(d) => d,
+            _ => unreachable!(),
+        }
     }
     #[inline]
     pub(crate) fn data_git_clone(&self) -> Fd {
-        debug_assert!(self.tag == Tag::GitClone);
-        // SAFETY: tag-guarded; `Fd` is `Copy`.
-        unsafe { *self.data.git_clone }
-    }
-
-    pub(crate) fn deinit_payload(&mut self) {
-        // SAFETY: `tag` discriminates both unions, set once at enqueue.
-        unsafe {
-            match self.tag {
-                Tag::PackageManifest => {
-                    ManuallyDrop::drop(&mut self.request.package_manifest);
-                    ManuallyDrop::drop(&mut self.data.package_manifest);
-                }
-                Tag::Extract => {
-                    ManuallyDrop::drop(&mut self.request.extract);
-                    ManuallyDrop::drop(&mut self.data.extract);
-                }
-                Tag::GitClone => {
-                    ManuallyDrop::drop(&mut self.request.git_clone);
-                }
-                Tag::GitCommit => {
-                    ManuallyDrop::drop(&mut self.request.git_commit);
-                    ManuallyDrop::drop(&mut self.data.git_commit);
-                }
-                Tag::GitCheckout => {
-                    ManuallyDrop::drop(&mut self.request.git_checkout);
-                    ManuallyDrop::drop(&mut self.data.git_checkout);
-                }
-                Tag::LocalTarball => {
-                    ManuallyDrop::drop(&mut self.request.local_tarball);
-                    ManuallyDrop::drop(&mut self.data.extract);
-                }
-            }
+        match self.data {
+            Data::GitClone(fd) => fd,
+            _ => unreachable!(),
         }
+    }
+    #[inline]
+    pub(crate) fn data_git_commit(&self) -> &[u8] {
+        match &self.data {
+            Data::GitCommit(sha) => sha,
+            _ => unreachable!(),
+        }
+    }
+    #[inline]
+    pub(crate) fn data_git_checkout(&self) -> &ExtractData {
+        self.data_extract()
     }
 }
 
-impl<'a> Task<'a> {
-    pub(crate) unsafe fn callback(task: *mut thread_pool::Task) {
+impl Task {
+    /// Thread-pool entry point: run the request, then hand the task back to
+    /// the main thread.
+    fn run_owned(mut self: Box<Self>) {
         Output::Source::configure_thread();
 
-        // SAFETY: `task` points to the `threadpool_task` field of a `Task`
-        // (this is the only place this `thread_pool::Task` callback is registered).
-        let this_raw: *mut Task<'a> =
-            unsafe { bun_core::from_field_ptr!(Task, threadpool_task, task) };
-        // The terminal `resolve_tasks.push` hands the task to the main thread
-        // (which may recycle it while this fn still runs `Output::flush()`),
-        // so the pushed pointer is derived from the raw receiver, not from the
-        // `&mut` below, and nothing touches `this` after the push.
-        // SAFETY: `Task<'a>` is layout-identical for all `'a` (the lifetime is
-        // a phantom on `&mut NetworkTask` borrows that the queue never reads
-        // through); erasing to `'static` is sound for the queue.
-        let task = unsafe { core::ptr::NonNull::new_unchecked(this_raw) }.cast::<Task<'static>>();
-        // SAFETY: exclusive access — task runs on exactly one worker thread
-        let this: &mut Task<'a> = unsafe { &mut *this_raw };
-        // BACKREF (LIFETIMES.tsv:598) — `package_manager` outlives every task it
-        // owns. The `ParentRef` is `Copy` and gives safe `Deref` for the
-        // shared-read sites below; `manager` is kept as a raw `*mut` for the
-        // whole function because this callback runs on ThreadPool workers
-        // concurrently (and concurrently with the main thread), so binding a
-        // long-lived `&mut PackageManager` here would be aliased-`&mut` UB.
-        // Subfields touched cross-thread (`resolve_tasks`, `wake`) are reached
-        // through raw-ptr/shared accessors below; the few callees whose
-        // signatures still take `&mut PackageManager` (`get_cache_directory`,
-        // `get_package_metadata`) are dereferenced inline at the call boundary
-        // only.
-        let manager_ref = this.package_manager.expect("Task.package_manager unset");
-        let manager: *mut PackageManager = manager_ref.as_mut_ptr();
+        // The manager is only read here: options for the manifest scope, and
+        // the cache/temp directories, which the main thread opened before
+        // scheduling (`PackageManager::schedule_tasks`).
+        let manager_ref = self.package_manager;
+        let manager: &PackageManager = manager_ref.get();
+        let this = &mut *self;
 
-        // Body of the switch; arms exit via `break 'body;` so the
-        // trailing block (patch + push + wake) and `Output::flush()` run
-        // unconditionally afterwards.
         'body: {
-            match this.tag {
-                Tag::PackageManifest => {
-                    // SAFETY: tag == PackageManifest discriminates the union
-                    let manifest = unsafe { &mut *this.request.package_manifest };
-
-                    // split-borrow `manifest.network` so the mutable
-                    // `response_buffer` borrow doesn't overlap the immutable
-                    // `response`/`callback` reads below.
-                    let network = &mut *manifest.network;
+            match &mut this.request {
+                Request::PackageManifest { name, network } => {
+                    let network = network
+                        .as_mut()
+                        .expect("manifest task owns its network task");
                     // Take ownership so the
                     // multi-MB manifest buffer drops on every exit of this arm
                     // instead of staying live on the NetworkTask until recycle.
@@ -294,62 +244,42 @@ impl<'a> Task<'a> {
                             format_args!(
                                 "{} downloading package manifest {}",
                                 err.name(),
-                                bstr::BStr::new(manifest.name.slice()),
+                                bstr::BStr::new(name.slice()),
                             ),
                         );
                         this.err = Some(err);
                         this.status = Status::Fail;
-                        this.data = Data {
-                            package_manifest: ManuallyDrop::new(npm::PackageManifest::default()),
-                        };
+                        this.data = Data::PackageManifest(npm::PackageManifest::default());
                         break 'body;
                     };
 
-                    // `Callback` is a tagged enum, so destructure the variant.
-                    // SAFETY: tag == PackageManifest ⇒ the network task was
-                    // built by `NetworkTask::for_manifest` with this variant.
                     let crate::network_task::Callback::PackageManifest {
                         loaded_manifest,
                         is_extended_manifest,
                         ..
                     } = &network.callback
                     else {
-                        // SAFETY: tag == PackageManifest ⇒ the network task was
-                        // built by `NetworkTask::for_manifest` with this variant.
-                        unsafe { core::hint::unreachable_unchecked() }
+                        unreachable!("manifest network task built by `NetworkTask::for_manifest`")
                     };
                     let loaded_manifest = loaded_manifest.clone();
                     let is_extended_manifest = *is_extended_manifest;
 
-                    // Shared read of `manager.options` (never mutated by worker
-                    // threads) via the `ParentRef` safe `Deref`. Wrap as
-                    // `BackRef` so the `&PackageManager` autoref does not stay
-                    // live across the `&mut *manager` below.
-                    let scope = bun_ptr::BackRef::new(
-                        manager_ref.scope_for_package_name(manifest.name.slice()),
-                    );
+                    let scope = manager.scope_for_package_name(name.slice());
                     let package_manifest = match npm::Registry::get_package_metadata(
-                        // scope is borrowed from manager.options which is not
-                        // touched by get_package_metadata (only the cache-dir fields are).
-                        scope.get(),
+                        scope,
                         metadata.response,
                         body.slice(),
                         &mut this.log,
-                        manifest.name.slice(),
+                        name.slice(),
                         loaded_manifest,
-                        // SAFETY: see `manager` decl — short-lived `&mut` at call
-                        // boundary only (callee touches `cache_directory` /
-                        // `get_temporary_directory` lazily).
-                        unsafe { &mut *manager },
+                        manager,
                         is_extended_manifest,
                     ) {
                         Ok(v) => v,
                         Err(err) => {
                             this.err = Some(err);
                             this.status = Status::Fail;
-                            this.data = Data {
-                                package_manifest: ManuallyDrop::new(npm::PackageManifest::default()),
-                            };
+                            this.data = Data::PackageManifest(npm::PackageManifest::default());
                             break 'body;
                         }
                     };
@@ -358,32 +288,22 @@ impl<'a> Task<'a> {
                         npm::registry::PackageVersionResponse::Fresh(result)
                         | npm::registry::PackageVersionResponse::Cached(result) => {
                             this.status = Status::Success;
-                            this.data = Data {
-                                package_manifest: ManuallyDrop::new(result),
-                            };
+                            this.data = Data::PackageManifest(result);
                             break 'body;
                         }
                         npm::registry::PackageVersionResponse::NotFound => {
                             this.log.add_error_fmt(
                                 None,
                                 Loc::EMPTY,
-                                format_args!(
-                                    "404 - GET {}",
-                                    // `manifest` (split-borrow of
-                                    // `this.request`) is still live; reuse
-                                    // it instead of a fresh union deref.
-                                    bstr::BStr::new(manifest.name.slice()),
-                                ),
+                                format_args!("404 - GET {}", bstr::BStr::new(name.slice())),
                             );
                             this.status = Status::Fail;
-                            this.data = Data {
-                                package_manifest: ManuallyDrop::new(npm::PackageManifest::default()),
-                            };
+                            this.data = Data::PackageManifest(npm::PackageManifest::default());
                             break 'body;
                         }
                     }
                 }
-                Tag::Extract => {
+                Request::Extract { network, tarball } => {
                     // Streaming extraction never reaches this callback: the
                     // HTTP thread drives `TarballStream.drain_task`, which
                     // fills in `this.data`/`this.status` and pushes to
@@ -391,69 +311,53 @@ impl<'a> Task<'a> {
                     // This path is the buffered fallback — feature flag off,
                     // non-2xx status, or the whole body arrived in a single
                     // chunk before streaming could commit.
-
-                    // SAFETY: tag == Extract discriminates the union
-                    let extract = unsafe { &mut *this.request.extract };
+                    let network = network
+                        .as_mut()
+                        .expect("extract task owns its network task");
                     // Take ownership so the
                     // tarball body drops on every exit of this arm.
-                    let mut buffer = core::mem::take(&mut extract.network.response_buffer);
+                    let mut buffer = core::mem::take(&mut network.response_buffer);
 
-                    let result = match extract.tarball.run(&mut this.log, buffer.slice()) {
-                        Ok(v) => v,
+                    match tarball.run(&mut this.log, buffer.slice()) {
+                        Ok(result) => {
+                            this.data = Data::Extract(result);
+                            this.status = Status::Success;
+                        }
                         Err(err) => {
                             this.err = Some(err);
                             this.status = Status::Fail;
-                            this.data = Data {
-                                extract: ManuallyDrop::new(ExtractData::default()),
-                            };
-                            break 'body;
+                            this.data = Data::Extract(ExtractData::default());
                         }
-                    };
-
-                    this.data = Data {
-                        extract: ManuallyDrop::new(result),
-                    };
-                    this.status = Status::Success;
+                    }
                 }
-                Tag::GitClone | Tag::GitCheckout => {
+                Request::GitClone(_) | Request::GitCheckout(_) => {
                     crate::git_runner::Finalize::run(this);
                 }
-                Tag::GitCommit => {
+                Request::GitCommit(_) => {
                     unreachable!("a commit lookup completes on the install thread (git_runner.rs)")
                 }
-                Tag::LocalTarball => {
+                Request::LocalTarball {
+                    tarball,
+                    tarball_path,
+                    normalize,
+                } => {
                     // `tarball_path` and `normalize` are computed on the main thread when the
                     // task is enqueued. This callback runs on a ThreadPool worker and must not
                     // read `manager.lockfile.packages` / `manager.lockfile.buffers.string_bytes`:
                     // the main thread may reallocate those buffers concurrently while processing
                     // other dependencies.
-
-                    // SAFETY: tag == LocalTarball discriminates the union
-                    let req = unsafe { &mut *this.request.local_tarball };
-                    let tarball_path = req.tarball_path.slice();
-                    let normalize = req.normalize;
-
-                    let result = match read_and_extract(
-                        &req.tarball,
-                        tarball_path,
-                        normalize,
-                        &mut this.log,
-                    ) {
-                        Ok(v) => v,
+                    match read_and_extract(tarball, tarball_path.slice(), *normalize, &mut this.log)
+                    {
+                        Ok(result) => {
+                            this.data = Data::Extract(result);
+                            this.status = Status::Success;
+                        }
                         Err(err) => {
                             this.err = Some(err);
                             this.status = Status::Fail;
-                            this.data = Data {
-                                extract: ManuallyDrop::new(ExtractData::default()),
-                            };
-                            break 'body;
+                            this.data = Data::Extract(ExtractData::default());
                         }
-                    };
-
-                    this.data = Data {
-                        extract: ManuallyDrop::new(result),
-                    };
-                    this.status = Status::Success;
+                    }
                 }
             }
         }
@@ -461,29 +365,19 @@ impl<'a> Task<'a> {
         // Runs after the switch on all paths.
         if this.status == Status::Success {
             if let Some(mut pt) = this.apply_patch_task.take() {
-                // `defer pt.deinit()` → Box<PatchTask> drops at end of this block
                 bun_core::handle_oom(pt.apply());
-                // `apply_patch_task` is only ever populated with the Apply
-                // variant (see `new_apply_patch_hash`), so destructure it.
-                let crate::patch_install::Callback::Apply(apply) = &mut pt.callback else {
-                    // SAFETY: `apply_patch_task` is only ever populated with the
-                    // Apply variant (see `new_apply_patch_hash`).
-                    unsafe { core::hint::unreachable_unchecked() }
-                };
+                let apply = pt.callback.apply_mut();
                 if apply.logger.errors > 0 {
-                    // `defer pt.callback.apply.logger.deinit()` → `Log` drops with `pt`.
                     let _ = apply
                         .logger
                         .print(std::ptr::from_mut(Output::error_writer()));
                 }
             }
         }
-        // SAFETY: `UnboundedQueue::push` takes `&self` (lock-free), so reach it
-        // via a shared raw deref — no `&mut PackageManager` is formed.
-        unsafe {
-            (*core::ptr::addr_of!((*manager).resolve_tasks)).push(task);
-            PackageManager::wake_raw(manager);
-        }
+
+        let shared = manager.shared;
+        shared.resolve_tasks.push(self);
+        shared.wake();
 
         Output::flush();
     }
@@ -496,12 +390,10 @@ fn read_and_extract(
     log: &mut Log,
 ) -> crate::Result<ExtractData> {
     let bytes = if normalize {
-        // Resolves
-        // a user-provided relative path against `bun.fs.FileSystem.instance.top_level_dir`
-        // (the absolute project root cached at startup — NOT the live process cwd).
-        // `bun_sys::File::read_from_user_input` takes that base
-        // explicitly (T1 `bun_sys` cannot depend on T5 `bun_resolver::fs`), so thread it
-        // through here from the install crate's `FileSystem` shim.
+        // Resolves a user-provided relative path against
+        // `FileSystem::instance().top_level_dir()` (the absolute project root
+        // cached at startup — NOT the live process cwd), which
+        // `bun_sys::File::read_from_user_input` takes explicitly.
         File::read_from_user_input(
             Fd::cwd(),
             crate::bun_fs::FileSystem::instance().top_level_dir(),
@@ -510,7 +402,6 @@ fn read_and_extract(
     } else {
         File::read_from(Fd::cwd(), tarball_path)?
     };
-    // `defer allocator.free(bytes)` → Vec<u8> drops at scope exit
     tarball.run(log, &bytes)
 }
 
@@ -533,40 +424,43 @@ pub enum Status {
     Fail,
 }
 
-/// Untagged union. Discriminated externally by `Task.tag`.
-pub union Data {
-    pub(crate) package_manifest: ManuallyDrop<npm::PackageManifest>,
-    pub(crate) extract: ManuallyDrop<ExtractData>,
-    pub(crate) git_clone: ManuallyDrop<Fd>,
+pub enum Data {
+    /// Not yet run.
+    None,
+    PackageManifest(npm::PackageManifest),
+    /// `Extract`, `LocalTarball` and `GitCheckout` results.
+    Extract(ExtractData),
+    GitClone(Fd),
     /// The commit SHA.
-    pub(crate) git_commit: ManuallyDrop<Vec<u8>>,
-    pub(crate) git_checkout: ManuallyDrop<ExtractData>,
+    GitCommit(Vec<u8>),
 }
 
-/// Untagged union. Discriminated externally by `Task.tag`.
-pub union Request<'a> {
+pub enum Request {
     /// package name
     // todo: Registry URL
-    pub(crate) package_manifest: ManuallyDrop<PackageManifestRequest<'a>>,
-    pub(crate) extract: ManuallyDrop<ExtractRequest<'a>>,
-    pub(crate) git_clone: ManuallyDrop<GitCloneRequest>,
-    pub(crate) git_commit: ManuallyDrop<GitCommitRequest>,
-    pub(crate) git_checkout: ManuallyDrop<GitCheckoutRequest>,
-    pub(crate) local_tarball: ManuallyDrop<LocalTarballRequest>,
-}
-
-pub struct PackageManifestRequest<'a> {
-    pub(crate) name: StringOrTinyString,
-    // BORROW_PARAM per LIFETIMES.tsv
-    // TODO: lifetime — see note on `Task<'a>`; likely should demote to `*mut NetworkTask`.
-    pub(crate) network: &'a mut NetworkTask,
-}
-
-pub struct ExtractRequest<'a> {
-    // BORROW_PARAM per LIFETIMES.tsv
-    // TODO: lifetime — see note on `Task<'a>`; likely should demote to `*mut NetworkTask`.
-    pub(crate) network: &'a mut NetworkTask,
-    pub(crate) tarball: ExtractTarball,
+    PackageManifest {
+        name: StringOrTinyString,
+        /// `None` only once `run_tasks` has taken it back.
+        network: Option<Box<NetworkTask>>,
+    },
+    Extract {
+        /// `None` while a streaming download still holds the network task
+        /// (`NetworkTask::streaming_extract_task`), and once `run_tasks` has
+        /// taken it back.
+        network: Option<Box<NetworkTask>>,
+        tarball: ExtractTarball,
+    },
+    GitClone(GitCloneRequest),
+    GitCommit(GitCommitRequest),
+    GitCheckout(GitCheckoutRequest),
+    LocalTarball {
+        tarball: ExtractTarball,
+        /// Resolved by `enqueue_local_tarball` on the main thread; the worker must not read the lockfile.
+        tarball_path: StringOrTinyString,
+        /// When true, `tarball_path` is a user-provided path resolved relative to
+        /// cwd. When false, it is already an absolute path.
+        normalize: bool,
+    },
 }
 
 pub struct GitCloneRequest {
@@ -590,13 +484,4 @@ pub struct GitCheckoutRequest {
     pub(crate) url: StringOrTinyString,
     pub(crate) resolved: StringOrTinyString,
     pub(crate) resolution: Resolution,
-}
-
-pub struct LocalTarballRequest {
-    pub(crate) tarball: ExtractTarball,
-    /// Resolved by `enqueue_local_tarball` on the main thread; the worker must not read the lockfile.
-    pub(crate) tarball_path: StringOrTinyString,
-    /// When true, `tarball_path` is a user-provided path resolved relative to
-    /// cwd. When false, it is already an absolute path.
-    pub(crate) normalize: bool,
 }

--- a/src/install/PackageManifestMap.rs
+++ b/src/install/PackageManifestMap.rs
@@ -42,9 +42,9 @@ type ManifestHashMap =
 pub struct DiskCacheCtx {
     pub(crate) enable_manifest_cache: bool,
     pub(crate) enable_manifest_cache_control: bool,
-    /// `pm.getCacheDirectory()` — pre-opened so the lookup never needs `&mut
-    /// PackageManager`. `None` iff `enable_manifest_cache` is false (the only
-    /// branch that reads it is gated on that flag).
+    /// The package manager's cache directory. `None` iff
+    /// `enable_manifest_cache` is false (the only branch that reads it is
+    /// gated on that flag).
     pub(crate) cache_directory: Option<Fd>,
     pub(crate) timestamp_for_manifest_cache_control: u32,
     /// `--prefer-offline` / `--offline`: a cached manifest counts as fresh regardless of
@@ -91,14 +91,13 @@ impl PackageManifestMap {
         self.by_name_hash_allow_expired(ctx, scope, name, name_hash, None, needs_extended_manifest)
     }
 
-    /// `by_name_hash` without the disk fallback, so callers holding
-    /// `&mut PackageManager` can borrow only `pm.manifests`.
-    pub(crate) fn by_name_hash_in_memory(
-        &mut self,
+    /// A manifest already loaded into memory, without touching the disk cache.
+    pub(crate) fn in_memory(
+        &self,
         name: &[u8],
         name_hash: PackageNameHash,
-    ) -> Option<&mut npm::PackageManifest> {
-        match self.hash_map.get_mut(&name_hash)? {
+    ) -> Option<&npm::PackageManifest> {
+        match self.hash_map.get(&name_hash)? {
             Value::Manifest(m) if m.name() == name => Some(m),
             _ => None,
         }

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -1,8 +1,8 @@
 //! Resumable, non-blocking tarball extractor for `bun install`.
 //!
 //! The HTTP thread hands each body chunk to `on_chunk`, which appends to a
-//! small pending buffer and (if not already running) schedules
-//! `drain_task` on `PackageManager.thread_pool`. The drain task calls into
+//! small pending buffer and (if not already running) schedules the stream's
+//! drain task on `PackageManager.thread_pool`. The drain task calls into
 //! libarchive to gunzip and untar whatever is available, writing files as
 //! their data arrives, until libarchive asks for more compressed bytes
 //! than are currently buffered. At that point the read callback returns
@@ -17,35 +17,36 @@
 //! This lets `bun install` overlap download and extraction on the normal
 //! resolve thread pool without ever parking a worker on a condvar, and
 //! without holding the full compressed or decompressed tarball in memory.
+//!
+//! Ownership: the stream is shared (`Arc`) by the `NetworkTask` feeding it
+//! and the drain task consuming it. It owns the extract `Task` that carries
+//! the result to the main thread; with its final chunk the HTTP thread also
+//! hands over the `NetworkTask`, and `finish()` moves that into the extract
+//! `Task` before publishing it.
 
-use core::ffi::{c_int, c_void};
-use core::mem::ManuallyDrop;
 use core::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use bun_collections::VecExt;
 #[cfg(windows)]
 use bun_core::strings;
 use bun_core::{self, Output, ZBox, env_var, fmt as bun_fmt};
-use bun_libarchive::lib;
+use bun_libarchive::lib::{self, Header, StreamRead, StreamingArchive};
 use bun_paths::resolve_path::{self, platform};
 use bun_paths::{self, OSPathChar, OSPathSliceZ};
 #[cfg(not(windows))]
 use bun_sys::FdDirExt;
 use bun_sys::{self, Dir, Fd, FdExt, FileKind, Mode, O};
-use bun_threading::{Mutex, thread_pool};
+use bun_threading::Guarded;
 
 use crate::NetworkTask;
 use crate::bun_fs::FileSystem;
 use crate::integrity::{self, Integrity};
 use crate::package_manager_real::PackageManager;
 
-// `crate::Task` is a `()` stub; the real Task lives in `package_manager_task`.
-// `'static` is sound here because we only ever hold raw `*mut Task` and never
-// materialise a `&'static` borrow of the inner `Request` lifetime.
-type Task = crate::package_manager_task::Task<'static>;
+type Task = crate::package_manager_task::Task;
 
 type OSPathZ<'a> = &'a OSPathSliceZ;
-type OSPathZMut<'a> = &'a mut OSPathSliceZ;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Phase {
@@ -58,46 +59,63 @@ enum Phase {
     Done,
 }
 
-// `extract_task` / `package_manager` are raw pointers, not
-// `&'a mut` / `&'a`. This struct is heap-allocated (`heap::alloc`),
-// crosses threads via `drain_task`, and self-destroys in `finish()`, so a
-// borrowed lifetime cannot be sound. Holding `&'a mut Task` here while
-// `populate_result` materialises another `&mut Task` from a raw copy of it
-// would be aliased UB; raw pointers avoid forming aliased references.
 pub struct TarballStream {
-    // ---------------------------------------------------------------------
-    // Cross-thread producer state (HTTP → worker)
-    // ---------------------------------------------------------------------
-    mutex: Mutex,
+    /// Producer state (HTTP thread → worker); also read by the archive's
+    /// [`Source`].
+    incoming: Arc<Incoming>,
 
+    /// True while a drain task is either queued on the thread pool or
+    /// running. `on_chunk` sets it before scheduling; the drain clears it
+    /// when it runs out of input and decides to yield, with `incoming`
+    /// locked.
+    draining: AtomicBool,
+
+    /// Everything the drain task works on. Only one drain runs at a time
+    /// (`draining`), so this lock is never contended; it is a lock so the
+    /// shared stream can hand out `&mut`.
+    drain: Guarded<Drain>,
+
+    /// Thread-pool task that runs the drain. Re-enqueued whenever new data
+    /// arrives and no drain is currently in flight.
+    drain_task: bun_threading::SharedTask,
+
+    package_manager: bun_ptr::BackRef<PackageManager>,
+}
+
+bun_threading::arc_task!(TarballStream, drain_task);
+
+#[derive(Default)]
+struct Incoming {
+    state: Guarded<IncomingState>,
+}
+
+#[derive(Default)]
+struct IncomingState {
     /// Compressed .tgz bytes that have arrived from the HTTP thread but have
     /// not yet been consumed by libarchive.
     pending: Vec<u8>,
-
     /// True once the HTTP thread has delivered the final chunk (or an error).
     closed: bool,
-
     /// Set if the HTTP request failed mid-stream. Unless libarchive still
     /// reached end-of-archive and the digest verifies, this — not
     /// libarchive's truncation error — is the failure, and `finish()` hands
     /// the NetworkTask back to be retried as a failed download.
     http_err: Option<crate::Error>,
-
     /// Cached response status (metadata only arrives on the first callback).
-    pub(crate) status_code: u32,
+    status_code: u32,
+    /// `Content-Length` of the response, when the server sent one.
+    content_length: Option<usize>,
+    bytes_received: usize,
+    /// Arrives with the final chunk: the network task this stream was fed
+    /// by, for `finish()` to hand back to the main thread.
+    network_task: Option<Box<NetworkTask>>,
+}
 
-    /// True while a drain task is either queued on the thread pool or
-    /// running. `on_chunk` sets it before scheduling; `drain` clears it when
-    /// it runs out of input and decides to yield. Both transitions happen
-    /// with `mutex` held, and whoever does not own it stops touching `*this`
-    /// at the following `unlock()`.
-    draining: AtomicBool,
-
-    // ---------------------------------------------------------------------
-    // Drain-side state (touched only by one drain task at a time)
-    // ---------------------------------------------------------------------
+/// libarchive's input: the compressed bytes taken over from `incoming`.
+struct Source {
+    incoming: Arc<Incoming>,
     /// Bytes currently being consumed by libarchive. Populated by swapping
-    /// with `pending` under the mutex so the HTTP thread can keep appending
+    /// with `pending` under the lock so the HTTP thread can keep appending
     /// while libarchive decompresses without the lock held. libarchive's
     /// read callback hands out `reading[read_pos..]` and advances
     /// `read_pos`; the slice must remain valid until the next callback, so
@@ -105,9 +123,38 @@ pub struct TarballStream {
     reading: Vec<u8>,
     read_pos: usize,
     archive_holds_reading: bool,
+    /// Compressed bytes handed to libarchive by the read callback so far.
+    bytes_consumed: usize,
+    /// Incremental SHA over the *compressed* bytes, matching
+    /// `Integrity::verify` / `Integrity::for_bytes` in the buffered path.
+    hasher: integrity::Streaming,
+}
 
-    archive: Option<lib::ReadArchive>,
+#[allow(clippy::large_enum_variant)] // one per stream, inside the `Arc`
+enum ArchiveState {
+    Unopened(Source),
+    Open(StreamingArchive<Source>),
+}
 
+impl ArchiveState {
+    fn source_mut(&mut self) -> &mut Source {
+        match self {
+            ArchiveState::Unopened(source) => source,
+            ArchiveState::Open(archive) => archive.source_mut(),
+        }
+    }
+}
+
+struct Drain {
+    archive: ArchiveState,
+    files: Files,
+    /// Completion task that carries the final result back to the main
+    /// thread; `finish()` pushes it onto `resolve_tasks`.
+    extract_task: Option<Box<Task>>,
+}
+
+/// Per-entry output state (touched only by the drain task).
+struct Files {
     /// Where we are in the per-entry state machine between drain
     /// invocations. libarchive preserves everything else (filter buffers,
     /// zlib stream, tar header progress) on its own heap.
@@ -121,7 +168,7 @@ pub struct TarballStream {
     use_lseek: bool,
     /// Per-entry write cursors, carried across `write_data_block` calls so
     /// the sparse-file handling in `close_output_file` matches
-    /// `Archive.readDataIntoFd` exactly (which tracks these across its own
+    /// `Archive::read_data_into_fd` exactly (which tracks these across its own
     /// block loop). Reset in `begin_entry` when a new output file is opened.
     entry_actual_offset: i64,
     entry_final_offset: i64,
@@ -131,12 +178,7 @@ pub struct TarballStream {
     /// touches the filesystem.
     dest: Option<Fd>,
     /// Owned copy of the temp-directory name.
-    // `ZBox` is the owned NUL-terminated counterpart of `&ZStr`.
     tmpname: ZBox,
-
-    /// Incremental SHA over the *compressed* bytes, matching
-    /// `Integrity.verify` / `Integrity.forBytes` in the buffered path.
-    hasher: integrity::Streaming,
 
     /// Resolved first-directory name for GitHub tarballs (written to
     /// `.bun-tag` and used for the cache folder name).
@@ -149,29 +191,11 @@ pub struct TarballStream {
     #[cfg(unix)]
     deferred_symlinks: Vec<bun_libarchive::DeferredSymlink>,
 
-    bytes_received: usize,
-    /// Compressed bytes handed to libarchive by the read callback so far.
-    bytes_consumed: usize,
-    /// `Content-Length` of the response, when the server sent one.
-    pub(crate) content_length: Option<usize>,
     entry_count: u32,
     fail: Option<crate::Error>,
     /// libarchive's error string for `fail == Some(Fail)`.
     fail_detail: Vec<u8>,
     invalid_name: bool,
-
-    /// Thread-pool task that runs `drain`. Re-enqueued whenever new data
-    /// arrives and no drain is currently in flight.
-    drain_task: thread_pool::Task,
-
-    /// Completion task that carries the final result back to the main
-    /// thread. Populated by `finish()` and pushed onto `resolve_tasks` there.
-    /// BACKREF — `*mut Task` constructed via `ParentRef::from_raw_mut` so the
-    /// read-only `request_extract()` accessor in `open_destination` goes
-    /// through safe `Deref`; `finish()` recovers the raw via `as_mut_ptr()`.
-    extract_task: bun_ptr::ParentRef<Task, bun_ptr::Mut>,
-    network_task: *mut NetworkTask,
-    package_manager: *mut PackageManager,
 }
 
 impl TarballStream {
@@ -198,25 +222,13 @@ impl TarballStream {
         .expect("int cast")
     }
 
-    pub(crate) fn init(
-        extract_task: *mut Task,
-        network_task: *mut NetworkTask,
-        manager: *mut PackageManager,
-    ) -> *mut TarballStream {
-        // Caller guarantees `extract_task` is live for the lifetime of this
-        // stream (it is published back to the main thread only in `finish()`).
-        // Wrapped once as `ParentRef` so
-        // the union read goes through the centralised tag-checked
-        // `request_extract()` accessor; `extract` is the active `Request`
-        // variant for streaming tarballs (set by `enqueue_extract_npm_package`,
-        // `tag == Tag::Extract`).
-        let extract_task =
-            core::ptr::NonNull::new(extract_task).expect("extract_task non-null (Zig *Task)");
-        // SAFETY: `extract_task` is the caller's live task pointer.
-        let extract_task = unsafe {
-            bun_ptr::ParentRef::<Task, bun_ptr::Mut>::from_raw_mut(extract_task.as_ptr())
-        };
-        let tarball = &extract_task.request_extract().tarball;
+    /// A stream for the tarball `extract_task` describes; the task is
+    /// published to the main thread once extraction finishes.
+    pub(crate) fn new(
+        extract_task: Box<Task>,
+        manager: bun_ptr::BackRef<PackageManager>,
+    ) -> Arc<TarballStream> {
+        let tarball = extract_task.request_tarball();
 
         // For GitHub/URL/local tarballs we need a SHA-512 to record in the
         // lockfile even when there is no expected value to verify against,
@@ -249,452 +261,646 @@ impl TarballStream {
             compute_if_missing,
         );
 
-        // bun.TrivialNew(@This()) → heap::alloc(Box::new(...)). Pointer is
-        // recovered via `container_of` from the thread-pool callback and
-        // freed in `finish()` via heap::take.
-        bun_core::heap::into_raw(Box::new(TarballStream {
-            mutex: Mutex::new(),
-            pending: Vec::new(),
-            closed: false,
-            http_err: None,
-            status_code: 0,
+        // Shared by the HTTP thread and one pool worker at a time; everything
+        // mutable is under `Guarded` (see `ArcTask`).
+        #[allow(clippy::arc_with_non_send_sync)]
+        let incoming = Arc::new(Incoming::default());
+        #[allow(clippy::arc_with_non_send_sync)]
+        Arc::new(TarballStream {
+            incoming: Arc::clone(&incoming),
             draining: AtomicBool::new(false),
-            reading: Vec::new(),
-            read_pos: 0,
-            archive_holds_reading: false,
-            archive: None,
-            phase: Phase::WantHeader,
-            out_fd: None,
-            #[cfg(unix)]
-            use_pwrite: true,
-            use_lseek: true,
-            entry_actual_offset: 0,
-            entry_final_offset: 0,
-            dest: None,
-            tmpname: ZBox::from_bytes(b""),
-            hasher,
-            resolved_github_dirname,
-            want_first_dirname,
-            npm_mode,
-            #[cfg(unix)]
-            deferred_symlinks: Vec::new(),
-            bytes_received: 0,
-            bytes_consumed: 0,
-            content_length: None,
-            entry_count: 0,
-            fail: None,
-            fail_detail: Vec::new(),
-            invalid_name: false,
-            drain_task: thread_pool::Task {
-                node: thread_pool::Node::default(),
-                callback: drain_callback,
-            },
-            extract_task,
-            network_task,
+            drain: Guarded::new(Drain {
+                archive: ArchiveState::Unopened(Source {
+                    incoming,
+                    reading: Vec::new(),
+                    read_pos: 0,
+                    archive_holds_reading: false,
+                    bytes_consumed: 0,
+                    hasher,
+                }),
+                files: Files {
+                    phase: Phase::WantHeader,
+                    out_fd: None,
+                    #[cfg(unix)]
+                    use_pwrite: true,
+                    use_lseek: true,
+                    entry_actual_offset: 0,
+                    entry_final_offset: 0,
+                    dest: None,
+                    tmpname: ZBox::from_bytes(b""),
+                    resolved_github_dirname,
+                    want_first_dirname,
+                    npm_mode,
+                    #[cfg(unix)]
+                    deferred_symlinks: Vec::new(),
+                    entry_count: 0,
+                    fail: None,
+                    fail_detail: Vec::new(),
+                    invalid_name: false,
+                },
+                extract_task: Some(extract_task),
+            }),
+            drain_task: bun_threading::SharedTask::new(
+                <Self as bun_threading::ArcTask>::__callback,
+            ),
             package_manager: manager,
-        }))
+        })
+    }
+
+    /// The response headers arrived (HTTP thread).
+    pub(crate) fn set_response_head(&self, status_code: u32, content_length: Option<usize>) {
+        let mut incoming = self.incoming.state.lock();
+        incoming.status_code = status_code;
+        if content_length.is_some() {
+            incoming.content_length = content_length;
+        }
+    }
+
+    pub(crate) fn status_code(&self) -> u32 {
+        self.incoming.state.lock().status_code
     }
 
     /// Called from the HTTP thread for each response-body chunk. Returns
     /// without touching the filesystem or libarchive; actual processing is
-    /// deferred to `drain` on a worker so the HTTP event loop stays
+    /// deferred to the drain task on a worker so the HTTP event loop stays
     /// responsive.
-    ///
-    /// # Safety
-    /// `this` must be the live pointer returned by `init()`. Runs on the
-    /// HTTP thread concurrently with `drain()` on a worker, so this never
-    /// materialises `&mut TarballStream` — all access is via raw-ptr field
-    /// projection.
-    pub(crate) unsafe fn on_chunk(
-        this: *mut Self,
+    pub(crate) fn on_chunk(self: &Arc<Self>, chunk: &[u8]) {
+        self.push(chunk, false, None, None);
+    }
+
+    /// The final chunk (HTTP thread): the stream takes over `network_task`
+    /// and hands it back to the main thread from `finish()`.
+    pub(crate) fn on_last_chunk(
+        this: Arc<Self>,
+        network_task: Box<NetworkTask>,
+        chunk: &[u8],
+        err: Option<crate::Error>,
+    ) {
+        this.push(chunk, true, err, Some(network_task));
+        drop(this); // the network's ref
+    }
+
+    fn push(
+        self: &Arc<Self>,
         chunk: &[u8],
         is_last: bool,
         err: Option<crate::Error>,
+        network_task: Option<Box<NetworkTask>>,
     ) {
         let drain_threshold = Self::drain_threshold();
-        // SAFETY: see fn-level # Safety — `this` is live, raw-ptr field
-        // projection only (no `&mut TarballStream` formed).
-        unsafe {
-            (*this).mutex.lock();
+        let schedule = {
+            let mut incoming = self.incoming.state.lock();
             if !chunk.is_empty() {
-                (*this).pending.extend_from_slice(chunk);
-                (*this).bytes_received += chunk.len();
+                incoming.pending.extend_from_slice(chunk);
+                incoming.bytes_received += chunk.len();
             }
             if is_last {
-                (*this).closed = true;
+                incoming.closed = true;
             }
-            if let Some(e) = err {
-                (*this).http_err = Some(e);
+            if err.is_some() {
+                incoming.http_err = err;
             }
-            let pending_len = (*this).pending.len();
+            if let Some(network_task) = network_task {
+                incoming.network_task = Some(network_task);
+            }
+            let pending_len = incoming.pending.len();
 
             // Batch sub-threshold chunks so each one doesn't re-wake a worker
             // once the drain has yielded; `is_last`/`err` always schedule so
             // `finish()` never waits on the threshold.
-            let schedule = (is_last || err.is_some() || pending_len >= drain_threshold)
-                && !(*this).draining.swap(true, Ordering::AcqRel);
-            (*this).mutex.unlock();
+            (is_last || err.is_some() || pending_len >= drain_threshold)
+                && !self.draining.swap(true, Ordering::AcqRel)
+        };
 
-            if schedule {
-                Self::schedule_drain(this);
-            }
+        if schedule {
+            self.package_manager
+                .thread_pool
+                .schedule_arc(Arc::clone(self));
         }
     }
 
-    /// # Safety
-    /// `this` must be live and the caller must have just taken `draining`
-    /// (false -> true) with `mutex` held, so no worker is inside `drain()`.
-    /// Never forms `&mut TarballStream`.
-    unsafe fn schedule_drain(this: *mut Self) {
-        // SAFETY: see fn-level # Safety — `this` is live; `package_manager`
-        // outlives this stream (it owns the thread pool that runs us). Field
-        // projections via raw ptr — no `&mut TarballStream` is formed.
-        unsafe {
-            // `addr_of_mut!` (not `&mut (*this).drain_task`) so the raw
-            // pointer inherits `this`'s full-struct provenance: the
-            // thread-pool callback recovers the parent `*mut TarballStream`
-            // via `offset_of!`, which is OOB for a
-            // pointer whose provenance is limited to the `drain_task` field
-            // bytes. See ThreadPool.rs:442 for the same pattern.
-            (*(*this).package_manager)
-                .thread_pool
-                .schedule(thread_pool::Batch::from(core::ptr::addr_of_mut!(
-                    (*this).drain_task
-                )));
-        }
+    /// Prepare this stream for another HTTP attempt after a failed request
+    /// that never scheduled a drain.
+    pub(crate) fn reset_for_retry(&self) {
+        let mut incoming = self.incoming.state.lock();
+        incoming.pending.clear();
+        incoming.closed = false;
+        incoming.http_err = None;
+        incoming.status_code = 0;
+        incoming.bytes_received = 0;
+        incoming.content_length = None;
     }
 
     /// Pull whatever compressed bytes are available into libarchive, writing
     /// entries to disk, until libarchive reports `ARCHIVE_RETRY` (out of
     /// input — yield) or a terminal state (EOF / error — finish).
-    ///
-    /// # Safety
-    /// `this` must be the live pointer returned by `init()`. Runs on a
-    /// worker thread; the HTTP thread may concurrently call `on_chunk()`
-    /// touching the mutex-guarded producer fields, so this never holds a
-    /// `&mut TarballStream` across those accesses. May free `*this` (via
-    /// `finish`) — caller must not touch `this` after return.
-    unsafe fn drain(this: *mut Self) {
+    fn run_arc(self: Arc<Self>) {
         Output::Source::configure_thread();
 
-        // SAFETY: see fn-level # Safety — `this` is live; raw-ptr field
-        // projection only. The HTTP thread touches mutex-guarded producer
-        // fields concurrently; everything else is drain-local. `finish` may
-        // free `*this`; each `return` after it touches nothing.
-        unsafe {
-            loop {
-                if (*this).fail.is_none() && (*this).phase != Phase::Done {
-                    // Only pull bytes into `reading` while libarchive is still
-                    // going to consume them. After EOF/failure `step()` is
-                    // never called again, so appending here would let
-                    // `reading` grow by one HTTP chunk per wakeup for the
-                    // remainder of the download.
-                    let more = Self::take_pending(this);
+        let mut drain = self.drain.lock();
+        let drain = &mut *drain;
+        loop {
+            if drain.files.fail.is_none() && drain.files.phase != Phase::Done {
+                // Only pull bytes into `reading` while libarchive is still
+                // going to consume them. After EOF/failure `step()` is
+                // never called again, so appending here would let
+                // `reading` grow by one HTTP chunk per wakeup for the
+                // remainder of the download.
+                let more = drain.archive.source_mut().take_pending();
 
-                    if let Err(err) = Self::step(this) {
-                        // If the body was cut short by a transport error,
-                        // that is the failure; libarchive's complaint about
-                        // the truncated input is just its symptom.
-                        (*this).mutex.lock();
-                        let http_err = (*this).http_err;
-                        (*this).mutex.unlock();
-                        (*this).fail = Some(match (err, http_err) {
-                            (crate::Error::Fail, Some(http_err)) => http_err,
-                            (err, _) => err,
-                        });
-                        (*this).close_output_file();
-                    }
-
-                    if (*this).fail.is_none() && (*this).phase != Phase::Done {
-                        if more {
-                            continue;
-                        }
-                        // libarchive consumed everything we had. Yield the
-                        // worker until the HTTP thread delivers the next
-                        // chunk.
-                        (*this).mutex.lock();
-                        let again = !(*this).pending.is_empty() || (*this).closed;
-                        if !again {
-                            (*this).draining.store(false, Ordering::Release);
-                        }
-                        (*this).mutex.unlock();
-                        if again {
-                            continue;
-                        }
-                        return;
-                    }
+                if let Err(err) = drain.step() {
+                    // If the body was cut short by a transport error,
+                    // that is the failure; libarchive's complaint about
+                    // the truncated input is just its symptom.
+                    let http_err = self.incoming.state.lock().http_err;
+                    drain.files.fail = Some(match (err, http_err) {
+                        (crate::Error::Fail, Some(http_err)) => http_err,
+                        (err, _) => err,
+                    });
+                    drain.files.close_output_file();
                 }
 
-                // Terminal: archive finished or extraction failed. libarchive
-                // will not be called again, so `reading` is dead — drop it
-                // now rather than carrying its capacity until `finish()`.
-                // `reading` is drain-local (only the read callback touches
-                // it, and that runs inside `step()`), so this needs no lock.
-                (*this).reading = Vec::new();
-                (*this).read_pos = 0;
+                if drain.files.fail.is_none() && drain.files.phase != Phase::Done {
+                    if more {
+                        continue;
+                    }
+                    // libarchive consumed everything we had. Yield the
+                    // worker until the HTTP thread delivers the next
+                    // chunk.
+                    if self.more_or_stop_draining() {
+                        continue;
+                    }
+                    return;
+                }
+            }
 
-                (*this).mutex.lock();
+            // Terminal: archive finished or extraction failed. libarchive
+            // will not be called again, so `reading` is dead — drop it
+            // now rather than carrying its capacity until `finish()`.
+            {
+                let source = drain.archive.source_mut();
+                source.reading = Vec::new();
+                source.read_pos = 0;
+            }
+
+            let closed = {
+                let mut incoming = self.incoming.state.lock();
                 // Hash any bytes that arrived after libarchive hit
                 // end-of-archive so the integrity digest covers the full
                 // response (tar zero-padding, gzip footer). Skip this once
                 // an error is recorded — the digest won't be checked anyway.
-                if (*this).fail.is_none() && !(*this).pending.is_empty() {
-                    (*this).hasher.update(&(*this).pending);
+                if drain.files.fail.is_none() && !incoming.pending.is_empty() {
+                    drain.archive.source_mut().hasher.update(&incoming.pending);
                 }
                 // After EOF/failure we stop feeding libarchive but must keep
                 // consuming (and discarding) chunks until the HTTP thread
-                // closes the stream; freeing ourselves earlier would let the
-                // next `notify` dereference a dead pointer.
-                (*this).pending.clear();
-                let closed = (*this).closed;
-                (*this).mutex.unlock();
-                if closed {
-                    Self::finish(this);
-                    // `this` is freed; nothing below may touch it.
-                    return;
-                }
-
-                // Archive is done (or failed) but the HTTP response has not
-                // finished yet. Yield; the next `on_chunk` will reschedule us
-                // to discard the new bytes and eventually observe `closed`.
-                (*this).mutex.lock();
-                let again = !(*this).pending.is_empty() || (*this).closed;
-                if !again {
-                    (*this).draining.store(false, Ordering::Release);
-                }
-                (*this).mutex.unlock();
-                if again {
-                    continue;
-                }
+                // closes the stream.
+                incoming.pending.clear();
+                incoming.closed
+            };
+            if closed {
+                self.finish(drain);
                 return;
             }
-        } // unsafe
+
+            // Archive is done (or failed) but the HTTP response has not
+            // finished yet. Yield; the next `on_chunk` will reschedule us
+            // to discard the new bytes and eventually observe `closed`.
+            if self.more_or_stop_draining() {
+                continue;
+            }
+            return;
+        }
     }
 
+    /// With `incoming` locked: whether there is more to drain right now;
+    /// if not, clears `draining` so the next chunk schedules a new drain.
+    fn more_or_stop_draining(&self) -> bool {
+        let incoming = self.incoming.state.lock();
+        let again = !incoming.pending.is_empty() || incoming.closed;
+        if !again {
+            self.draining.store(false, Ordering::Release);
+        }
+        again
+    }
+
+    /// The stream is closed and drained: report the result through the
+    /// extract `Task` (or hand the `NetworkTask` back for a retry).
+    fn finish(&self, drain: &mut Drain) {
+        let shared = self.package_manager.get().shared;
+
+        drain.files.close_output_file();
+
+        // The HTTP thread delivered its final chunk (that's the only way
+        // `closed` gets set) together with the network task, so `http_err`
+        // is stable now.
+        let (http_err, mut network, content_length, bytes_received) = {
+            let mut incoming = self.incoming.state.lock();
+            (
+                incoming.http_err,
+                incoming
+                    .network_task
+                    .take()
+                    .expect("closed stream holds its network task"),
+                incoming.content_length,
+                incoming.bytes_received,
+            )
+        };
+        // The body has been consumed; release the buffer.
+        network.response_buffer = Default::default();
+
+        let mut task = drain.extract_task.take().expect("stream finishes once");
+        drain.populate_result(&mut task, http_err, content_length, bytes_received);
+
+        // Temp-dir cleanup must happen before we publish the task:
+        // `task.request.extract.tarball.temp_dir` becomes invalid once the
+        // main thread recycles the Task.
+        if task.status != TaskStatus::Success && !drain.files.tmpname.is_empty() {
+            // `populate_result` closes `dest` on the success path before the
+            // rename; the early-return failure paths leave it open, so close
+            // it here first — Windows can't remove an open directory.
+            if let Some(d) = drain.files.dest.take() {
+                d.close();
+            }
+            let _ = Dir::borrow(&task.request_tarball().temp_dir)
+                .delete_tree(drain.files.tmpname.as_bytes());
+        }
+
+        // This stream is done either way; the network task drops its handle.
+        network.tarball_stream = None;
+
+        if let Some(crate::Error::Http(err)) = task.err
+            && task.status != TaskStatus::Success
+        {
+            // The connection died before the body was complete: a failed
+            // download, not a failed extraction. Hand the NetworkTask back
+            // to `run_tasks` the way `on_done` does for one that failed
+            // before the body started, so it is retried/reported there. The
+            // extract Task stays with the NetworkTask for the next attempt.
+            network.response.fail = Some(err);
+            network.streaming_committed = false;
+            network.streaming_extract_task = Some(task);
+            shared.async_network_task_queue.push(network);
+            shared.wake();
+            return;
+        }
+
+        match &mut task.request {
+            crate::package_manager_task::Request::Extract { network: slot, .. } => {
+                *slot = Some(network);
+            }
+            _ => unreachable!(),
+        }
+
+        shared.resolve_tasks.push(task);
+        shared.wake();
+    }
+}
+
+impl Source {
     /// Move any bytes still sitting in `pending` into `reading` so the read
     /// callback can hand them to libarchive. Returns true if new bytes were
-    /// added or the stream is now closed.
-    ///
-    /// # Safety
-    /// `this` must be live. Called both from `drain()` and re-entrantly
-    /// from inside libarchive's read callback (while `step()` is on the
-    /// stack), so this must NOT materialise `&mut TarballStream` — all
-    /// access is via raw-ptr field projection. Producer fields (`pending`/`closed`)
-    /// are synchronised by `mutex`; drain-side fields (`reading`/
-    /// `read_pos`/`hasher`) are owned by the single active drain task.
-    unsafe fn take_pending(this: *mut Self) -> bool {
-        // SAFETY: see fn-level # Safety — raw-ptr field projection only.
-        unsafe {
-            (*this).mutex.lock();
+    /// added or the stream is now closed. Called both from the drain loop
+    /// and from inside libarchive's read callback.
+    fn take_pending(&mut self) -> bool {
+        let mut incoming = self.incoming.state.lock();
 
-            if (*this).pending.is_empty() {
-                let closed = (*this).closed;
-                (*this).mutex.unlock();
-                return closed;
-            }
+        if incoming.pending.is_empty() {
+            return incoming.closed;
+        }
 
-            // Hash before libarchive sees the bytes so integrity covers exactly
-            // what came off the socket.
-            (*this).hasher.update(&(*this).pending);
+        // Hash before libarchive sees the bytes so integrity covers exactly
+        // what came off the socket.
+        self.hasher.update(&incoming.pending);
 
-            if (*this).reading.len() == (*this).read_pos {
-                // Previous buffer fully consumed — swap so the HTTP thread can
-                // reuse its capacity without reallocating.
-                (*this).reading.clear();
-                core::mem::swap(&mut (*this).reading, &mut (*this).pending);
-                (*this).read_pos = 0;
-            } else {
-                // libarchive still holds a slice into `reading` (the read
-                // callback contract keeps the last-returned buffer valid until
-                // the next call). Appending would realloc and invalidate that
-                // slice, so instead shift the unconsumed tail down and append
-                // in place — the callback is not running concurrently with us
-                // (single drain at a time) and will be re-primed with the new
-                // base on its next invocation.
-                let read_pos = (*this).read_pos;
-                (*this).reading.drain_front(read_pos);
-                (*this).read_pos = 0;
-                (*this).reading.extend_from_slice(&(*this).pending);
-                (*this).pending.clear();
-            }
-            (*this).mutex.unlock();
-            true
-        } // unsafe
+        if self.reading.len() == self.read_pos {
+            // Previous buffer fully consumed — swap so the HTTP thread can
+            // reuse its capacity without reallocating.
+            self.reading.clear();
+            core::mem::swap(&mut self.reading, &mut incoming.pending);
+            self.read_pos = 0;
+        } else {
+            // libarchive still holds a slice into `reading` (the read
+            // callback contract keeps the last-returned buffer valid until
+            // the next call). Appending would realloc and invalidate that
+            // slice, so instead shift the unconsumed tail down and append
+            // in place — the callback is not running concurrently with us
+            // (single drain at a time) and will be re-primed with the new
+            // base on its next invocation.
+            let read_pos = self.read_pos;
+            self.reading.drain_front(read_pos);
+            self.read_pos = 0;
+            self.reading.extend_from_slice(&incoming.pending);
+            incoming.pending.clear();
+        }
+        true
     }
 
+    fn unread(&mut self) -> Option<&[u8]> {
+        let remaining = &self.reading[self.read_pos..];
+        if remaining.is_empty() {
+            return None;
+        }
+        self.read_pos = self.reading.len();
+        self.bytes_consumed += remaining.len();
+        self.archive_holds_reading = true;
+        Some(remaining)
+    }
+}
+
+bun_libarchive::stream_source!(Source);
+
+impl Source {
+    /// libarchive client read callback. Returns whatever compressed bytes are
+    /// currently buffered in `reading`; if none, `Retry` (when more data is still
+    /// expected) so libarchive unwinds with a resumable status, or `Eof` once the
+    /// HTTP response is complete. The bytes handed out live in `reading`, which
+    /// is only replaced once they are consumed (`archive_holds_reading`).
+    fn read_for_archive(&mut self) -> StreamRead<'_> {
+        if self.read_pos < self.reading.len() {
+            return StreamRead::Data(self.unread().expect("non-empty"));
+        }
+        self.archive_holds_reading = false;
+
+        // No data left in `reading`. Check for more under the lock —
+        // libarchive may have called us more than once for a single
+        // `step()` (e.g. gzip header + first deflate block), and `on_chunk`
+        // might have landed a fresh chunk in the meantime.
+        let (has_pending, closed) = {
+            let incoming = self.incoming.state.lock();
+            (!incoming.pending.is_empty(), incoming.closed)
+        };
+
+        if has_pending {
+            let _ = self.take_pending();
+            if self.read_pos < self.reading.len() {
+                return StreamRead::Data(self.unread().expect("non-empty"));
+            }
+        }
+
+        if closed {
+            return StreamRead::Eof;
+        }
+
+        // Tell libarchive to unwind with a resumable status. The BUN PATCHes
+        // in vendor/libarchive make every layer (filter_ahead → gzip → tar)
+        // preserve its state and propagate ARCHIVE_RETRY to our `step()`
+        // loop, which then returns so this worker can be reused.
+        StreamRead::Retry
+    }
+}
+
+impl Drain {
     /// Run libarchive until it needs more input (`Retry`) or hits a
     /// terminal state. All libarchive state persists on the heap, so
     /// returning from here and re-entering later is safe.
-    ///
-    /// # Safety
-    /// `this` must be live. Takes `*mut Self` (not `&mut self`) because
-    /// `open_archive()` hands `this` to libarchive as client_data and the
-    /// read callback dereferences it across MULTIPLE `step()` invocations.
-    /// A `&mut self` receiver would mint a fresh Unique tag on each call,
-    /// popping the SharedRW tag the stored client_data pointer carries and
-    /// leaving the callback with dead provenance (Stacked Borrows UB).
-    /// Threading the Box-rooted `*mut Self` from `drain()` keeps one
-    /// provenance alive for the lifetime of the archive.
-    unsafe fn step(this: *mut Self) -> crate::Result<()> {
-        // SAFETY: see fn-level # Safety — raw-ptr field projection only; no
-        // `&mut TarballStream` is held across any libarchive call (which may
-        // re-enter `archive_read_callback` and access `*this` via the same
-        // provenance). Transient `&mut *this` for `open_destination` /
-        // `begin_entry` / `write_data_block` / `close_output_file` is sound:
-        // those do not call into libarchive.
-        unsafe {
-            if (*this).archive.is_none() {
-                Self::open_archive(this)?;
+    fn step(&mut self) -> crate::Result<()> {
+        if let ArchiveState::Unopened(_) = self.archive {
+            let ArchiveState::Unopened(source) = core::mem::replace(
+                &mut self.archive,
+                ArchiveState::Unopened(Source {
+                    incoming: Arc::default(),
+                    reading: Vec::new(),
+                    read_pos: 0,
+                    archive_holds_reading: false,
+                    bytes_consumed: 0,
+                    hasher: integrity::Streaming::init(&Integrity::default(), false),
+                }),
+            ) else {
+                unreachable!()
+            };
+            match StreamingArchive::open_gzip_tar(source) {
+                Ok(archive) => self.archive = ArchiveState::Open(archive),
+                Err((source, detail)) => {
+                    self.archive = ArchiveState::Unopened(source);
+                    self.files.fail_detail = detail;
+                    return Err(crate::Error::Fail);
+                }
             }
-            if (*this).dest.is_none() {
-                (*this).open_destination()?;
-            }
+        }
+        if self.files.dest.is_none() {
+            let extract_task = self.extract_task.as_deref().expect("live until finish");
+            self.files.open_destination(extract_task)?;
+        }
 
-            // `archive` points to a libarchive heap allocation disjoint from
-            // `*this`; holding `&lib::Archive` across the loop does not
-            // alias any access to `*this`.
-            let archive: &lib::Archive = (*this).archive.as_deref().unwrap();
+        let ArchiveState::Open(archive) = &mut self.archive else {
+            unreachable!()
+        };
+        let files = &mut self.files;
 
-            loop {
-                match (*this).phase {
-                    Phase::Done => return Ok(()),
-                    Phase::WantHeader => {
-                        let mut entry: *mut lib::Entry = core::ptr::null_mut();
-                        match archive.read_next_header(&mut entry) {
-                            lib::Result::Retry if (*this).archive_holds_reading => continue,
-                            lib::Result::Retry => return Ok(()),
-                            lib::Result::Eof => {
-                                #[cfg(unix)]
-                                {
-                                    let dest = (*this).dest.unwrap();
-                                    let symlinks = core::mem::take(&mut (*this).deferred_symlinks);
-                                    bun_libarchive::create_deferred_symlinks(
-                                        dest, &symlinks, false,
-                                    );
-                                }
-                                (*this).phase = Phase::Done;
+        loop {
+            match files.phase {
+                Phase::Done => return Ok(()),
+                Phase::WantHeader => match archive.next_header() {
+                    (_, Header::Retry) => {
+                        if archive.source().archive_holds_reading {
+                            continue;
+                        }
+                        return Ok(());
+                    }
+                    (_, Header::Eof) => {
+                        #[cfg(unix)]
+                        {
+                            let dest = files.dest.unwrap();
+                            let symlinks = core::mem::take(&mut files.deferred_symlinks);
+                            bun_libarchive::create_deferred_symlinks(dest, &symlinks, false);
+                        }
+                        files.phase = Phase::Done;
+                        return Ok(());
+                    }
+                    (_, Header::Entry(entry)) => {
+                        files.begin_entry(entry)?;
+                    }
+                    (_, Header::Failed) => {
+                        files.fail_detail = archive.error_string().to_vec();
+                        return Err(crate::Error::Fail);
+                    }
+                },
+                Phase::WantData => {
+                    let mut offset: i64 = 0;
+                    let Some(block) = archive.next_block(&mut offset) else {
+                        // End of this entry's data.
+                        files.close_output_file();
+                        files.phase = Phase::WantHeader;
+                        continue;
+                    };
+                    match block.result {
+                        lib::Result::Retry => {
+                            if !archive.source().archive_holds_reading {
                                 return Ok(());
                             }
-                            lib::Result::Ok | lib::Result::Warn => {
-                                // libarchive returned OK/WARN with a valid entry
-                                // pointer owned by `archive`; it stays valid until
-                                // the next `read_next_header`. No other Rust
-                                // reference to it exists.
-                                (*this).begin_entry(&mut *entry)?;
-                            }
-                            lib::Result::Failed | lib::Result::Fatal => {
-                                (*this).fail_detail = archive.error_string().to_vec();
-                                return Err(crate::Error::Fail);
+                        }
+                        lib::Result::Ok | lib::Result::Warn => {
+                            if let Some(fd) = files.out_fd {
+                                files.write_data_block(fd, &block)?;
                             }
                         }
-                    }
-                    Phase::WantData => {
-                        let mut offset: i64 = 0;
-                        let Some(block) = archive.next(&mut offset) else {
-                            // End of this entry's data.
-                            (*this).close_output_file();
-                            (*this).phase = Phase::WantHeader;
-                            continue;
-                        };
-                        match block.result {
-                            lib::Result::Retry if !(*this).archive_holds_reading => return Ok(()),
-                            lib::Result::Ok | lib::Result::Warn => {
-                                if let Some(fd) = (*this).out_fd {
-                                    (*this).write_data_block(fd, &block)?;
-                                }
-                            }
-                            _ => {
-                                (*this).fail_detail = archive.error_string().to_vec();
-                                return Err(crate::Error::Fail);
-                            }
+                        _ => {
+                            files.fail_detail = archive.error_string().to_vec();
+                            return Err(crate::Error::Fail);
                         }
                     }
                 }
             }
-        } // unsafe
+        }
     }
 
-    /// # Safety
-    /// `this` must be live and rooted at the Box allocation (i.e. the
-    /// pointer threaded from `drain_callback` → `drain` → `step`, NOT a
-    /// `&mut self as *mut Self` reborrow). libarchive stores `this` as
-    /// client_data and `archive_read_callback` dereferences it across the
-    /// lifetime of the archive — see `step()` # Safety for the provenance
-    /// requirement.
-    unsafe fn open_archive(this: *mut Self) -> crate::Result<()> {
-        let archive = lib::ReadArchive::new();
-        // Bypass bidding entirely: the stream is always gzip → tar, and
-        // bidding would try to read-ahead before any bytes have arrived.
-        // With patches/libarchive/select-registered-only.patch,
-        // archive_read_append_filter / archive_read_set_format only select a
-        // filter/format that was already registered, so register gzip and tar
-        // first. Tar must also be registered before read_set_options (so the
-        // option has a slot) and set_format must come after it: libarchive's
-        // archive_set_format_option() clobbers `a->format` while dispatching,
-        // and losing the selected format means archive_read_open1() falls
-        // back to bidding, which fails when the first HTTP chunk is short.
-        // ARCHIVE_FILTER_GZIP = 1, ARCHIVE_FORMAT_TAR = 0x30000.
-        let _ = archive.read_support_filter_gzip();
-        // SAFETY: archive is a valid non-null handle from read_new(); FFI call has no other preconditions.
-        if unsafe { lib::archive_read_append_filter(archive.as_mut_ptr(), 1) } != 0 {
-            return Err(crate::Error::Fail);
-        }
-        let _ = archive.read_support_format_tar();
-        let _ = archive.read_set_options(c"read_concatenated_archives");
-        // SAFETY: archive is a valid non-null handle from read_new(); FFI call has no other preconditions.
-        if unsafe { lib::archive_read_set_format(archive.as_mut_ptr(), 0x30000) } != 0 {
-            return Err(crate::Error::Fail);
+    fn populate_result(
+        &mut self,
+        task: &mut Task,
+        http_err: Option<crate::Error>,
+        content_length: Option<usize>,
+        bytes_received: usize,
+    ) {
+        let files = &mut self.files;
+        let source = self.archive.source_mut();
+        let Task {
+            request,
+            log,
+            data,
+            err: task_err,
+            status,
+            ..
+        } = task;
+        let tarball = match request {
+            crate::package_manager_task::Request::Extract { tarball, .. } => &*tarball,
+            _ => unreachable!(),
+        };
+        *data = TaskData::Extract(Default::default());
+        *task_err = None;
+
+        if let Some(err) = files.fail {
+            if matches!(err, crate::Error::Http(_)) {
+                // Reported (or retried) by `run_tasks`; see `finish()`.
+            } else if files.invalid_name {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "Refusing to install package with invalid name \"{}\"",
+                        bun_fmt::s(tarball.name_and_basename().0),
+                    ),
+                );
+            } else {
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "{} extracting tarball for \"{}\"{}{} (at byte {} of {})",
+                        err.name(),
+                        bstr::BStr::new(tarball.name.slice()),
+                        if files.fail_detail.is_empty() {
+                            ""
+                        } else {
+                            ": "
+                        },
+                        bstr::BStr::new(&files.fail_detail),
+                        source.bytes_consumed,
+                        content_length
+                            .as_ref()
+                            .map_or(&"unknown" as &dyn core::fmt::Display, |n| n),
+                    ),
+                );
+            }
+            *task_err = Some(err);
+            *status = TaskStatus::Fail;
+            return;
         }
 
-        // SAFETY: archive is a valid handle; `this` outlives the archive
-        // (dropped below on failure, otherwise as a field of `*this`). See
-        // fn-level # Safety for why client_data must be the Box-rooted
-        // `this` and not a `&mut self`-derived pointer.
-        let rc_raw: c_int = unsafe {
-            lib::archive_read_open(
-                archive.as_mut_ptr(),
-                this.cast::<c_void>(),
-                None,
-                Some(archive_read_callback),
-                None,
-            )
-        };
-        // PORTING.md §Forbidden: `transmute::<c_int, enum>` is UB for any value not
-        // declared as a discriminant. Map known ARCHIVE_* codes explicitly and treat
-        // anything else as Fatal.
-        let rc: lib::Result = match rc_raw {
-            x if x == lib::Result::Ok as c_int => lib::Result::Ok,
-            x if x == lib::Result::Eof as c_int => lib::Result::Eof,
-            x if x == lib::Result::Retry as c_int => lib::Result::Retry,
-            x if x == lib::Result::Warn as c_int => lib::Result::Warn,
-            x if x == lib::Result::Failed as c_int => lib::Result::Failed,
-            _ => lib::Result::Fatal,
-        };
-        match rc {
-            lib::Result::Ok | lib::Result::Warn => {}
-            lib::Result::Retry => {
-                // open() runs the filter bidder which we bypassed, but the
-                // client open path may still probe; treat as transient.
-                // SAFETY: see fn-level # Safety — raw-ptr field write.
-                unsafe { (*this).archive = Some(archive) };
-                return Ok(());
-            }
-            _ => {
-                // SAFETY: see fn-level # Safety — raw-ptr field write.
-                unsafe { (*this).fail_detail = archive.error_string().to_vec() };
-                return Err(crate::Error::Fail);
+        if !tarball.skip_verify && tarball.integrity.tag.is_supported() {
+            if !source.hasher.verify() {
+                if let Some(http_err) = http_err {
+                    // libarchive found the end-of-archive marker but the
+                    // body still ended early (gzip trailer, tar padding):
+                    // the same failed download as above.
+                    *task_err = Some(http_err);
+                    *status = TaskStatus::Fail;
+                    return;
+                }
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "Integrity check failed for tarball: {}",
+                        bstr::BStr::new(tarball.name.slice()),
+                    ),
+                );
+                *task_err = Some(crate::Error::IntegrityCheckFailed);
+                *status = TaskStatus::Fail;
+                return;
             }
         }
-        // SAFETY: see fn-level # Safety — raw-ptr field write.
-        unsafe { (*this).archive = Some(archive) };
-        Ok(())
+
+        if tarball.resolution.tag == ResolutionTag::Github {
+            'insert_tag: {
+                if files.resolved_github_dirname.is_empty() {
+                    break 'insert_tag;
+                }
+                if bun_sys::File::openat(
+                    files.dest.unwrap(),
+                    bun_core::zstr!(".bun-tag"),
+                    O::WRONLY | O::CREAT | O::TRUNC | if cfg!(windows) { 0 } else { O::NOFOLLOW },
+                    0o664,
+                )
+                .and_then(|f| f.write_all(files.resolved_github_dirname))
+                .is_err()
+                {
+                    let _ = bun_sys::unlinkat(files.dest.unwrap(), bun_core::zstr!(".bun-tag"));
+                }
+            }
+        }
+
+        // Close the temp dir handle before renaming so Windows can move it.
+        if let Some(d) = files.dest.take() {
+            d.close();
+        }
+
+        let (name, basename) = tarball.name_and_basename();
+
+        let mut result = match tarball.move_to_cache_directory(
+            log,
+            files.tmpname.as_zstr(),
+            name,
+            basename,
+            files.resolved_github_dirname,
+        ) {
+            Ok(r) => r,
+            Err(err) => {
+                *task_err = Some(err);
+                *status = TaskStatus::Fail;
+                return;
+            }
+        };
+
+        match tarball.resolution.tag {
+            ResolutionTag::Github | ResolutionTag::RemoteTarball | ResolutionTag::LocalTarball => {
+                if tarball.integrity.tag.is_supported() {
+                    result.integrity = tarball.integrity;
+                } else {
+                    result.integrity = source.hasher.final_();
+                }
+            }
+            _ => {}
+        }
+
+        if PackageManager::verbose_install() {
+            bun_core::pretty_errorln!(
+                "[{}] Streamed {} tarball → {} entries<r>",
+                bstr::BStr::new(name),
+                bun_fmt::size(bytes_received, Default::default()),
+                files.entry_count,
+            );
+            Output::flush();
+        }
+
+        *data = TaskData::Extract(result);
+        *status = TaskStatus::Success;
     }
+}
 
-    fn open_destination(&mut self) -> crate::Result<()> {
-        // BACKREF: `extract_task` is live until `finish()` publishes it.
-        // `request_extract()` is the tag-checked union accessor (`tag ==
-        // Tag::Extract` for streaming tarballs).
-        let tarball = &self.extract_task.request_extract().tarball;
+impl Files {
+    fn open_destination(&mut self, extract_task: &Task) -> crate::Result<()> {
+        let tarball = extract_task.request_tarball();
         let (_, basename) = tarball.name_and_basename();
         let truncated_basename = &basename[0..basename.len().min(32)];
         let tmpname_suffix: &[u8] =
@@ -710,7 +916,6 @@ impl TarballStream {
             };
         let mut buf = bun_paths::path_buffer_pool::get();
         let tmpname = FileSystem::tmpname(tmpname_suffix, &mut buf[..], bun_core::fast_random())?;
-        // allocator.dupeZ → owned NUL-terminated copy.
         self.tmpname = ZBox::from_bytes(tmpname.as_bytes());
 
         self.dest = Some(
@@ -726,7 +931,7 @@ impl TarballStream {
 
     fn close_output_file(&mut self) {
         if let Some(fd) = self.out_fd {
-            // Same trailing-hole handling as `Archive.readDataIntoFd`:
+            // Same trailing-hole handling as `Archive::read_data_into_fd`:
             // extend the file to cover the furthest block we were asked
             // to write even if the pwrite/lseek fallback path left
             // `actual_offset` behind.
@@ -768,7 +973,6 @@ impl TarballStream {
             }
             #[cfg(not(windows))]
             {
-                // bun.asByteSlice(root) — on posix OSPathChar==u8, so this is a no-op cast.
                 self.resolved_github_dirname = FileSystem::instance()
                     .dirname_store()
                     .append(root)
@@ -780,14 +984,14 @@ impl TarballStream {
 
         if self.npm_mode && kind != FileKind::File {
             // npm tarballs only contain files; matching the libarchive path
-            // in Archiver.extractToDir we skip everything else.
+            // in Archiver::extract_to_dir we skip everything else.
             self.phase = Phase::WantData;
             self.out_fd = None;
             return Ok(());
         }
 
         // Strip the leading `package/` (or `<repo>-<sha>/` for GitHub) and
-        // normalise. Same transformation as Archiver.extractToDir so both
+        // normalise. Same transformation as Archiver::extract_to_dir so both
         // paths produce identical on-disk layouts.
         let mut tokenizer = pathname[..]
             .split(|c| *c == ('/' as OSPathChar))
@@ -819,43 +1023,41 @@ impl TarballStream {
             resolve_path::normalize_buf_t::<OSPathChar, platform::Auto>(rest, &mut norm_buf[..]);
         let norm_len = normalized.len();
         norm_buf[norm_len] = 0;
-        // SAFETY: norm_buf[norm_len] == 0 written above.
-        let path: OSPathZMut =
-            unsafe { OSPathSliceZ::from_raw_mut(norm_buf.as_mut_ptr(), norm_len) };
-        if path.is_empty() || (path.len() == 1 && path[0] == ('.' as OSPathChar)) {
-            self.phase = Phase::WantData;
-            self.out_fd = None;
-            return Ok(());
-        }
-        // `normalize_buf_t` collapses interior `..` but leaves a leading `..`
-        // on a relative input. Reject those so `openat(dest_fd, ...)` can
-        // never escape the temp extraction root. `Archiver.extractToDir`
-        // sees the same normalised path; this check is belt-and-braces on
-        // top of the integrity gate.
-        if path.len() >= 2
-            && path[0] == ('.' as OSPathChar)
-            && path[1] == ('.' as OSPathChar)
-            && (path.len() == 2 || path[2] == bun_paths::SEP as OSPathChar)
         {
-            self.phase = Phase::WantData;
-            self.out_fd = None;
-            return Ok(());
+            let path: &[OSPathChar] = &norm_buf[..norm_len];
+            if path.is_empty() || (path.len() == 1 && path[0] == ('.' as OSPathChar)) {
+                self.phase = Phase::WantData;
+                self.out_fd = None;
+                return Ok(());
+            }
+            // `normalize_buf_t` collapses interior `..` but leaves a leading `..`
+            // on a relative input. Reject those so `openat(dest_fd, ...)` can
+            // never escape the temp extraction root. `Archiver::extract_to_dir`
+            // sees the same normalised path; this check is belt-and-braces on
+            // top of the integrity gate.
+            if path.len() >= 2
+                && path[0] == ('.' as OSPathChar)
+                && path[1] == ('.' as OSPathChar)
+                && (path.len() == 2 || path[2] == bun_paths::SEP as OSPathChar)
+            {
+                self.phase = Phase::WantData;
+                self.out_fd = None;
+                return Ok(());
+            }
         }
         #[cfg(windows)]
         {
-            if bun_paths::is_absolute_windows_wtf16(&path[..]) {
+            if bun_paths::is_absolute_windows_wtf16(&norm_buf[..norm_len]) {
                 self.phase = Phase::WantData;
                 self.out_fd = None;
                 return Ok(());
             }
             if self.npm_mode {
-                apply_windows_npm_path_escapes(path);
+                apply_windows_npm_path_escapes(&mut norm_buf[..norm_len]);
             }
         }
 
-        // Mutation (Windows escape rewrite) is done; reborrow as shared so
-        // `path` and `path_slice` can coexist.
-        let path: OSPathZ = &*path;
+        let path: OSPathZ = OSPathSliceZ::from_buf(&norm_buf[..], norm_len);
         let path_slice: &[OSPathChar] = &path[..];
         let dest = self.dest.unwrap();
 
@@ -913,7 +1115,7 @@ impl TarballStream {
     }
 
     /// Write one data block from `archive_read_data_block`. Mirrors the
-    /// sparse/pwrite handling in `Archive.readDataIntoFd` but operates on a
+    /// sparse/pwrite handling in `Archive::read_data_into_fd` but operates on a
     /// single block so it can be interleaved with ARCHIVE_RETRY yields.
     /// `entry_actual_offset` / `entry_final_offset` persist across calls so
     /// `close_output_file` can perform the same trailing `ftruncate` the
@@ -979,290 +1181,9 @@ impl TarballStream {
             Err(e) => Err(e.to_zig_err().into()),
         }
     }
-
-    /// # Safety
-    /// `this` must be the live pointer returned by `init()`. Frees `*this`
-    /// — caller must not touch it after return. Takes a raw pointer (not
-    /// `&mut self`) so no Rust reference dangles across the
-    /// `heap::take` self-destruction.
-    // The `&(&(*task).request.extract)` wrappers below are deliberate — they
-    // sidestep `dangerous_implicit_autorefs` by making the ref explicit before
-    // the union deref. `needless_borrow` flags them as redundant but they are not.
-    #[allow(clippy::needless_borrow)]
-    unsafe fn finish(this: *mut Self) {
-        // SAFETY: see fn-level # Safety — `this`/`task`/`network`/`manager`
-        // are live raw pointers; this fn is the sole owner. After
-        // `heap::take(this)` nothing touches `this`.
-        unsafe {
-            // Fields are already raw pointers (see the struct-level note), so copying
-            // them out before `heap::take(this)` is just a pointer copy — no
-            // reborrow of `&mut Task` is ever materialised from a stored `&mut`.
-            let task: *mut Task = (*this).extract_task.as_mut_ptr();
-            let network: *mut NetworkTask = (*this).network_task;
-            let manager: *mut PackageManager = (*this).package_manager;
-
-            (*this).close_output_file();
-
-            // The HTTP thread has delivered the final `has_more=false` chunk
-            // (that's the only way `closed` gets set) and `notify()` does not
-            // touch `response_buffer` again after that hand-off, so we own it
-            // now. The main thread reads only `streaming_committed` when it
-            // later processes the NetworkTask, so freeing the buffer here is
-            // safe and matches the `defer buffer.deinit()` in the buffered
-            // `.extract` arm of `Task.callback`.
-            // SAFETY: see comment above; network_task is live until published below.
-            (*network).response_buffer = Default::default();
-
-            // The HTTP thread delivered its final chunk before `closed` was
-            // set, so `http_err` is stable without the lock.
-            let http_err = (*this).http_err;
-
-            // SAFETY: `task` is live until pushed onto `resolve_tasks` below.
-            // `(*this).extract_task` is a raw `*mut Task` (not `&mut`), so this
-            // is the only writer — no aliasing with a stored reference.
-            // `populate_result` does not touch `(*this).extract_task`.
-            (*this).populate_result(task, http_err);
-
-            // Temp-dir cleanup must happen before we release the stream or
-            // publish the task: both `(*this).tmpname` and
-            // `task.request.extract.tarball.temp_dir` become invalid once
-            // `Drop` runs / the main thread recycles the Task.
-            // SAFETY: task is live (see above).
-            if (*task).status != TaskStatus::Success && !(*this).tmpname.is_empty() {
-                // `populate_result` closes `dest` on the success path before the
-                // rename; the early-return failure paths leave it open, so close
-                // it here first — Windows can't remove an open directory.
-                if let Some(d) = (*this).dest.take() {
-                    d.close();
-                }
-                // SAFETY: task is live (see above). `request` is an untagged
-                // union; `extract` is the active variant. Explicit `&` (no
-                // implicit autoref through the raw-ptr deref) for the
-                // `ManuallyDrop` → `ExtractRequest` deref.
-                let _ = Dir::borrow(&(&(*task).request.extract).tarball.temp_dir)
-                    .delete_tree((*this).tmpname.as_bytes());
-            }
-
-            if let Some(crate::Error::Http(err)) = (*task).err
-                && (*task).status != TaskStatus::Success
-            {
-                // The connection died before the body was complete: a failed
-                // download, not a failed extraction. Hand the NetworkTask back
-                // to `run_tasks` the way `notify()` does for one that failed
-                // before the body started, so it is retried/reported there. The
-                // extract Task stays with the NetworkTask for the next attempt.
-                (*network).response.fail = Some(err);
-                (*network).streaming_committed = false;
-                drop((*network).tarball_stream.take());
-                (*manager)
-                    .async_network_task_queue
-                    .push(core::ptr::NonNull::new_unchecked(network));
-                PackageManager::wake_raw(manager);
-                return;
-            }
-
-            // The `Box<TarballStream>` lives in `(*network).tarball_stream`
-            // (runTasks.rs:1863 stores `Some(heap::take(init(..)))` there). Take
-            // it out via the Option and drop the Box — this both runs `Drop` and
-            // leaves `tarball_stream = None` so `HiveArray::put`'s
-            // `drop_in_place<NetworkTask>` (1e76047) does not double-free a
-            // dangling Box. Before 1e76047 the dangling `Some` was harmless
-            // (overwritten on next `get()`); now it use-after-frees.
-            debug_assert!(
-                (*network).tarball_stream.as_deref().map(std::ptr::from_ref)
-                    == Some(this.cast_const()),
-                "TarballStream::finish: network.tarball_stream != this",
-            );
-            drop((*network).tarball_stream.take());
-
-            // `task.apply_patch_task` is intentionally not touched: the
-            // buffered `.extract` path (`enqueue_extract_npm_package` →
-            // `Task.callback`) never populates it for npm tarballs either —
-            // patching is handled later by the install phase.
-            //
-            // Publish last: once the task is on `resolve_tasks` the main
-            // thread may immediately recycle it *and* the NetworkTask it
-            // references, so nothing below this line may touch either.
-            // SAFETY: manager/task outlive this stream by construction; manager
-            // is `*mut` and shared across
-            // threads, so we mutate via raw-ptr deref without forming a
-            // long-lived `&mut PackageManager`.
-            (*manager)
-                .resolve_tasks
-                .push(core::ptr::NonNull::new_unchecked(task));
-            PackageManager::wake_raw(manager);
-        } // unsafe
-    }
-
-    /// # Safety
-    /// `task` must be live and exclusively owned by this drain. Takes a raw
-    /// pointer so `tarball` (a borrow into
-    /// `task.request`) can coexist with writes to `task.log`/`task.data`.
-    // The `&(&(*task).request.extract)` wrapper below sidesteps
-    // `dangerous_implicit_autorefs`; `needless_borrow` is wrong here.
-    #[allow(clippy::needless_borrow)]
-    unsafe fn populate_result(&mut self, task: *mut Task, http_err: Option<crate::Error>) {
-        // SAFETY: see fn-level # Safety — `task` is live and exclusively
-        // owned by this drain; union field `extract` is the active variant
-        // for streaming tarballs (set by `enqueue_extract_npm_package`).
-        unsafe {
-            let tarball = &(&(*task).request.extract).tarball;
-            (*task).data = TaskData {
-                extract: ManuallyDrop::new(Default::default()),
-            };
-            (*task).err = None;
-
-            if let Some(err) = self.fail {
-                if matches!(err, crate::Error::Http(_)) {
-                    // Reported (or retried) by `run_tasks`; see `finish()`.
-                } else if self.invalid_name {
-                    (*task).log.add_error_fmt(
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        format_args!(
-                            "Refusing to install package with invalid name \"{}\"",
-                            bun_fmt::s(tarball.name_and_basename().0),
-                        ),
-                    );
-                } else {
-                    (*task).log.add_error_fmt(
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        format_args!(
-                            "{} extracting tarball for \"{}\"{}{} (at byte {} of {})",
-                            err.name(),
-                            bstr::BStr::new(tarball.name.slice()),
-                            if self.fail_detail.is_empty() {
-                                ""
-                            } else {
-                                ": "
-                            },
-                            bstr::BStr::new(&self.fail_detail),
-                            self.bytes_consumed,
-                            self.content_length
-                                .as_ref()
-                                .map_or(&"unknown" as &dyn core::fmt::Display, |n| n),
-                        ),
-                    );
-                }
-                (*task).err = Some(err);
-                (*task).status = TaskStatus::Fail;
-                return;
-            }
-
-            if !tarball.skip_verify && tarball.integrity.tag.is_supported() {
-                if !self.hasher.verify() {
-                    if let Some(http_err) = http_err {
-                        // libarchive found the end-of-archive marker but the
-                        // body still ended early (gzip trailer, tar padding):
-                        // the same failed download as above.
-                        (*task).err = Some(http_err);
-                        (*task).status = TaskStatus::Fail;
-                        return;
-                    }
-                    (*task).log.add_error_fmt(
-                        None,
-                        bun_ast::Loc::EMPTY,
-                        format_args!(
-                            "Integrity check failed for tarball: {}",
-                            bstr::BStr::new(tarball.name.slice()),
-                        ),
-                    );
-                    (*task).err = Some(crate::Error::IntegrityCheckFailed);
-                    (*task).status = TaskStatus::Fail;
-                    return;
-                }
-            }
-
-            if tarball.resolution.tag == ResolutionTag::Github {
-                'insert_tag: {
-                    if self.resolved_github_dirname.is_empty() {
-                        break 'insert_tag;
-                    }
-                    if bun_sys::File::openat(
-                        self.dest.unwrap(),
-                        bun_core::zstr!(".bun-tag"),
-                        O::WRONLY
-                            | O::CREAT
-                            | O::TRUNC
-                            | if cfg!(windows) { 0 } else { O::NOFOLLOW },
-                        0o664,
-                    )
-                    .and_then(|f| f.write_all(self.resolved_github_dirname))
-                    .is_err()
-                    {
-                        let _ = bun_sys::unlinkat(self.dest.unwrap(), bun_core::zstr!(".bun-tag"));
-                    }
-                }
-            }
-
-            // Close the temp dir handle before renaming so Windows can move it.
-            if let Some(d) = self.dest.take() {
-                d.close();
-            }
-
-            let (name, basename) = tarball.name_and_basename();
-
-            let mut result = match tarball.move_to_cache_directory(
-                &mut (*task).log,
-                self.tmpname.as_zstr(),
-                name,
-                basename,
-                self.resolved_github_dirname,
-            ) {
-                Ok(r) => r,
-                Err(err) => {
-                    (*task).err = Some(err);
-                    (*task).status = TaskStatus::Fail;
-                    return;
-                }
-            };
-
-            match tarball.resolution.tag {
-                ResolutionTag::Github
-                | ResolutionTag::RemoteTarball
-                | ResolutionTag::LocalTarball => {
-                    if tarball.integrity.tag.is_supported() {
-                        result.integrity = tarball.integrity;
-                    } else {
-                        result.integrity = self.hasher.final_();
-                    }
-                }
-                _ => {}
-            }
-
-            if PackageManager::verbose_install() {
-                bun_core::pretty_errorln!(
-                    "[{}] Streamed {} tarball → {} entries<r>",
-                    bstr::BStr::new(name),
-                    bun_fmt::size(self.bytes_received, Default::default()),
-                    self.entry_count,
-                );
-                Output::flush();
-            }
-
-            (*task).data = TaskData {
-                extract: ManuallyDrop::new(result),
-            };
-            (*task).status = TaskStatus::Success;
-        } // unsafe
-    }
-
-    /// Prepare this stream for another HTTP attempt after a failed request
-    /// that never scheduled a drain.
-    pub(crate) fn reset_for_retry(&mut self) {
-        self.mutex.lock();
-        self.pending.clear();
-        self.closed = false;
-        self.http_err = None;
-        self.status_code = 0;
-        self.bytes_received = 0;
-        self.content_length = None;
-        self.mutex.unlock();
-    }
 }
 
-impl Drop for TarballStream {
+impl Drop for Files {
     fn drop(&mut self) {
         if let Some(fd) = self.out_fd {
             fd.close();
@@ -1271,115 +1192,6 @@ impl Drop for TarballStream {
             d.close();
         }
     }
-}
-
-// Safe-fn: only ever invoked by `ThreadPool` via the `callback` fn-pointer
-// with the `*mut Task` we registered in `init()` (`drain_task.callback =
-// drain_callback`). The thread-pool contract — not the Rust caller —
-// guarantees `task` is live and points at `TarballStream.drain_task`, so the
-// preconditions of both unsafe ops below are discharged locally. Safe `fn`
-// coerces to the `unsafe fn(*mut Task)` field type.
-fn drain_callback(task: *mut thread_pool::Task) {
-    // SAFETY: thread-pool callback contract — `task` points to
-    // `TarballStream.drain_task`; recover the parent via offset_of.
-    let this: *mut TarballStream =
-        unsafe { bun_core::from_field_ptr!(TarballStream, drain_task, task) };
-    // SAFETY: the thread pool guarantees `task` is live for the duration of
-    // the callback, and only one drain runs at a time (see `draining` flag).
-    // `drain` may free `this`; nothing touches it after this call.
-    unsafe { TarballStream::drain(this) };
-}
-
-/// libarchive client read callback. Returns whatever compressed bytes
-/// are currently buffered in `reading`; if none, returns `ARCHIVE_RETRY`
-/// (when more data is still expected) so libarchive unwinds with a
-/// resumable status, or `0` (EOF) once the HTTP response is complete.
-///
-/// Safe-fn: only ever invoked by libarchive itself (never from Rust), with
-/// `ctx`/`out_buffer` it threaded through from `open_archive()`. Every
-/// pointer dereference inside carries its own SAFETY justification grounded
-/// in that setup, so there is no caller-side precondition to encode in the
-/// signature. The fn-pointer still coerces to the binding's expected type.
-extern "C" fn archive_read_callback(
-    _a: *mut lib::Archive,
-    ctx: *mut c_void,
-    out_buffer: *mut *const c_void,
-) -> lib::la_ssize_t {
-    // SAFETY: `ctx` is the Box-rooted `*mut TarballStream` threaded from
-    // `drain()` → `step()` → `open_archive()`; libarchive passes it back
-    // unchanged. `step()`/`open_archive()` take `*mut Self` (not
-    // `&mut self`) precisely so this pointer's provenance survives every
-    // re-entry — see `step()` # Safety. We keep `this` as a raw pointer and
-    // access fields through it directly; no `&mut TarballStream` is live anywhere on the
-    // call stack while libarchive runs. All fields touched here (`reading`,
-    // `read_pos`, `mutex`, `pending`, `closed`, `hasher`) are drain-side /
-    // mutex-guarded and are not accessed by `step()` across the FFI call
-    // boundary.
-    let this: *mut TarballStream = ctx.cast::<TarballStream>();
-
-    // SAFETY: `this` is valid (see above); `reading`/`read_pos` are owned by
-    // the single active drain task.
-    unsafe {
-        // Explicit `&` on the `Vec` field (no implicit autoref through the
-        // raw-ptr deref) for `Index::index`.
-        let remaining = &(&(*this).reading)[(*this).read_pos..];
-        if !remaining.is_empty() {
-            *out_buffer = remaining.as_ptr().cast();
-            (*this).read_pos = (*this).reading.len();
-            (*this).bytes_consumed += remaining.len();
-            (*this).archive_holds_reading = true;
-            return lib::la_ssize_t::try_from(remaining.len()).expect("int cast");
-        }
-        (*this).archive_holds_reading = false;
-    }
-
-    // No data left in `reading`. Check for more under the lock —
-    // libarchive may have called us more than once for a single
-    // `step()` (e.g. gzip header + first deflate block), and `on_chunk`
-    // might have landed a fresh chunk in the meantime.
-    // SAFETY: `mutex`/`pending`/`closed` accessed via raw ptr; producer side
-    // is synchronised by the mutex itself.
-    let (has_pending, closed) = unsafe {
-        (*this).mutex.lock();
-        let r = (!(*this).pending.is_empty(), (*this).closed);
-        (*this).mutex.unlock();
-        r
-    };
-
-    if has_pending {
-        // Pull the new bytes into `reading` and retry the read. We are
-        // the only consumer of `reading`/`read_pos`, and `take_pending`
-        // only touches producer state under the same mutex.
-        // SAFETY: `take_pending` takes `*mut Self` and accesses fields via
-        // raw-ptr projection, never forming `&mut TarballStream`; `step()`
-        // holds no `&mut TarballStream` across the libarchive call that
-        // re-entered us.
-        unsafe {
-            let _ = TarballStream::take_pending(this);
-            // Explicit `&` on the `Vec` field (no implicit autoref through
-            // the raw-ptr deref) for `Index::index`.
-            let again = &(&(*this).reading)[(*this).read_pos..];
-            if !again.is_empty() {
-                *out_buffer = again.as_ptr().cast();
-                (*this).read_pos = (*this).reading.len();
-                (*this).bytes_consumed += again.len();
-                (*this).archive_holds_reading = true;
-                return lib::la_ssize_t::try_from(again.len()).expect("int cast");
-            }
-        }
-    }
-
-    if closed {
-        // SAFETY: out_buffer is a valid out-param; ptr is unused when len==0.
-        unsafe { *out_buffer = this.cast() };
-        return 0;
-    }
-
-    // Tell libarchive to unwind with a resumable status. The BUN PATCHes
-    // in vendor/libarchive make every layer (filter_ahead → gzip → tar)
-    // preserve its state and propagate ARCHIVE_RETRY to our `step()`
-    // loop, which then returns so this worker can be reused.
-    lib::Result::Retry as lib::la_ssize_t
 }
 
 fn open_output_file(
@@ -1463,11 +1275,11 @@ fn make_directory(entry: &mut lib::Entry, dest_fd: Fd, path: OSPathZ, path_slice
 }
 
 #[cfg(windows)]
-fn apply_windows_npm_path_escapes(path: OSPathZMut) {
-    // Same transformation as Archiver.extractToDir: encode characters
+fn apply_windows_npm_path_escapes(path: &mut [OSPathChar]) {
+    // Same transformation as Archiver::extract_to_dir: encode characters
     // Windows rejects in filenames into the 0xf000 private-use range so
     // the extraction round-trips with node-tar.
-    let mut remain: &mut [OSPathChar] = path.as_mut_slice();
+    let mut remain: &mut [OSPathChar] = path;
     if strings::starts_with_windows_drive_letter_t(&*remain) {
         remain = &mut remain[2..];
     }

--- a/src/install/audit_fix.rs
+++ b/src/install/audit_fix.rs
@@ -406,9 +406,10 @@ fn take_manifest_error(msgs: &mut Vec<bun_ast::Msg>, name: &[u8]) -> (Box<[u8]>,
     )
 }
 
-fn print_manifest_unavailable(manager: &PackageManager, items: &[ManifestUnavailable]) {
-    let log = manager.log_mut();
-    if manager.options.log_level == LogLevel::Silent {
+fn print_manifest_unavailable(manager: &mut PackageManager, items: &[ManifestUnavailable]) {
+    let silent = manager.options.log_level == LogLevel::Silent;
+    let log = &mut manager.log;
+    if silent {
         log.reset();
         return;
     }
@@ -626,12 +627,18 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
         .set(Enable::MANIFEST_CACHE_CONTROL, false);
     let ids: Vec<PackageID> = instances.iter().map(|inst| inst.pkg_id).collect();
     populate_manifest_cache::populate_manifest_cache(manager, Packages::Exact(&ids))?;
-    let log_msgs = &mut manager.log_mut().msgs;
-
     let cache_ctx = manager.manifest_disk_cache_ctx();
-    let min_age = manager.options.minimum_release_age_ms;
-    let excludes = manager.options.minimum_release_age_excludes;
-    let buf = manager.lockfile.buffers.string_bytes.as_slice();
+    let PackageManager {
+        log,
+        options,
+        lockfile,
+        manifests,
+        ..
+    } = &mut *manager;
+    let log_msgs = &mut log.msgs;
+    let min_age = options.minimum_release_age_ms;
+    let excludes = options.minimum_release_age_excludes;
+    let buf = lockfile.buffers.string_bytes.as_slice();
 
     let mut fixes: Vec<PlannedFix> = Vec::new();
     let mut blocked: Vec<BlockedFix> = Vec::new();
@@ -643,8 +650,8 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
 
     for inst in instances {
         let mut expired = false;
-        let scope = manager.options.scope_for_package_name(&inst.name);
-        let Some(manifest) = manager.manifests.by_name_allow_expired(
+        let scope = options.scope_for_package_name(&inst.name);
+        let Some(manifest) = manifests.by_name_allow_expired(
             cache_ctx,
             scope,
             &inst.name,

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -21,12 +21,13 @@
 //! `value` union by plain assignment.
 
 use core::mem::{align_of, size_of};
+use core::ptr::NonNull;
 
 use bun_install_types::resolver_hooks as hooks;
 use bun_semver::{SlicedString, String as SemverString};
 
 use crate::dependency::{self, DependencyExt as _};
-use crate::lockfile::{self, Package};
+use crate::lockfile::Package;
 use crate::package_manager::package_manager_directories as directories;
 use crate::package_manager::package_manager_enqueue as enqueue;
 use crate::package_manager::package_manager_lifecycle as lifecycle;
@@ -197,17 +198,16 @@ impl hooks::AutoInstaller for PackageManager {
         // `PackageJsonView` interface so this impl does not need to name
         // `bun_resolver::PackageJSON` directly.
 
-        // Reshaped for borrowck — `string_builder!` borrows
-        // `self.lockfile` mutably while `dep.clone_in` needs `&mut self`.
-        // Use a raw pointer for the disjoint reborrow (same approach as
-        // `Package::from_package_json`).
-        let pm: *mut PackageManager = self;
-        // SAFETY: `pm` derives from `&mut self`; reborrows below are disjoint
-        // from `string_builder`'s borrow of `lockfile.{string_bytes,string_pool}`.
-        let lockfile: &mut lockfile::Lockfile = unsafe { &mut *(*pm).lockfile };
+        // `dep.clone_in` needs only the npm-alias registry alongside the
+        // string builder, so split the manager / lockfile by field.
+        let PackageManager {
+            lockfile,
+            known_npm_aliases,
+            ..
+        } = self;
+        let (mut string_builder, fields) = lockfile.string_builder_split();
 
         let mut package = Package::default();
-        let mut string_builder = crate::string_builder!(lockfile);
         let mut total_dependencies_count: u32 = 0;
 
         // --- Counting
@@ -223,8 +223,8 @@ impl hooks::AutoInstaller for PackageManager {
 
         string_builder.allocate()?;
 
-        let dependencies_list = &mut lockfile.buffers.dependencies;
-        let resolutions_list = &mut lockfile.buffers.resolutions;
+        let dependencies_list = fields.dependencies;
+        let resolutions_list = fields.resolutions;
         dependencies_list.reserve(total_dependencies_count as usize);
         resolutions_list.reserve(total_dependencies_count as usize);
 
@@ -248,10 +248,7 @@ impl hooks::AutoInstaller for PackageManager {
             if !dep.behavior.is_enabled(features) {
                 continue;
             }
-            // SAFETY: `pm` is the unique owner; `string_builder` borrows
-            // disjoint lockfile fields.
-            let pm_ref: &mut PackageManager = unsafe { &mut *pm };
-            match dep.clone_in(pm_ref, source_buf, &mut string_builder) {
+            match dep.clone_in(known_npm_aliases, source_buf, &mut string_builder) {
                 Ok(cloned) => dependencies[0] = cloned,
                 Err(e) => {
                     // `string_builder.clamp()` must run on the
@@ -292,7 +289,7 @@ impl hooks::AutoInstaller for PackageManager {
 
         string_builder.clamp();
 
-        let appended = lockfile.append_package(&package)?;
+        let appended = self.lockfile.append_package(&package)?;
         Ok(appended.meta.id)
     }
 
@@ -308,7 +305,7 @@ impl hooks::AutoInstaller for PackageManager {
     // ── PackageManager ops ────────────────────────────────────────────────
 
     fn set_on_wake(&mut self, handler: hooks::WakeHandler) {
-        self.on_wake = handler;
+        self.shared.set_on_wake(handler);
     }
 
     fn path_for_resolution<'b>(
@@ -317,19 +314,14 @@ impl hooks::AutoInstaller for PackageManager {
         resolution: &hooks::Resolution,
         buf: &'b mut [u8],
     ) -> Result<&'b [u8], bun_core::Error> {
-        // The resolver passes a `bun_paths::PathBuffer`-sized slice
-        // (`bufs!(path_in_global_disk_cache)`); reborrow it as the install
-        // signature's `&mut PathBuffer`.
-        debug_assert!(buf.len() >= bun_paths::MAX_PATH_BYTES);
-        // SAFETY: `PathBuffer` is `#[repr(transparent)]` over
-        // `[u8; MAX_PATH_BYTES]`; caller-provided slice is at least that long
-        // (asserted above).
-        let path_buf: &mut bun_paths::PathBuffer =
-            unsafe { &mut *buf.as_mut_ptr().cast::<bun_paths::PathBuffer>() };
+        // The resolver passes a `PathBuffer`-sized slice (`bufs!(path_in_global_disk_cache)`).
+        let path_buf =
+            bun_paths::PathBuffer::from_slice_mut(buf).expect("resolver passes a PathBuffer");
         let r = resolution_from_hooks(resolution);
-        let out = directories::path_for_resolution(self, package_id, &r, path_buf)
-            .map_err(bun_core::Error::from)?;
-        Ok(&*out)
+        let len = directories::path_for_resolution(self, package_id, &r, path_buf)
+            .map_err(bun_core::Error::from)?
+            .len();
+        Ok(&buf[..len])
     }
 
     fn get_preinstall_state(&self, package_id: PackageID) -> PreinstallState {
@@ -343,7 +335,6 @@ impl hooks::AutoInstaller for PackageManager {
         package_id: PackageID,
         resolution: &hooks::Resolution,
         ctx: hooks::TaskCallbackContext,
-        patch_name_and_version_hash: Option<u64>,
     ) -> Result<(), bun_core::Error> {
         let r = resolution_from_hooks(resolution);
         // Only the npm arm reaches this enqueue.
@@ -351,16 +342,20 @@ impl hooks::AutoInstaller for PackageManager {
         // the resolver (`resolution.tag == .npm`); the field-copy bridge
         // preserves the tag/union pairing.
         let npm = *r.npm();
-        let url = self.lockfile.str(&npm.url).to_vec();
+        debug_assert_eq!(
+            name,
+            self.lockfile
+                .str(&self.lockfile.packages.get(package_id as usize).name)
+        );
+        let name = self.lockfile.packages.get(package_id as usize).name;
         enqueue::enqueue_package_for_download(
             self,
             name,
             dependency_id,
             package_id,
             npm.version,
-            &url,
+            npm.url,
             crate::TaskCallbackContext::RootRequestId(ctx.root_request_id),
-            patch_name_and_version_hash,
         )
         .map_err(|e| crate::Error::from(e).into())
     }
@@ -434,62 +429,50 @@ impl hooks::AutoInstaller for PackageManager {
     }
 }
 
-// ─── Lazy factory (resolver → install link-time hook) ─────────────────────
+// ─── Lazy factory (registered with the resolver at startup) ────────────────
 //
 // `bun_resolver` cannot name `PackageManager` (it would create a dep cycle),
-// so it declares this `extern "Rust"` and we provide the body here. The
-// returned pointer is the process-static `PackageManager` singleton (`get()`),
-// upcast to the `dyn AutoInstaller` trait object the resolver stores.
-//
-// SAFETY (callee contract):
-//   • `log` is the resolver's `NonNull<bun_ast::Log>` (Transpiler-owned,
-//     process-lifetime; `init_with_runtime` stores it raw).
-//   • `install` is `BundleOptions.install` (`?*Api.BunInstall`). The pointee is
-//     the CLI-owned `Box<BunInstall>` (process-lifetime), read-only.
-//   • `env` is the resolver's unwrapped `env_loader` (Transpiler-owned,
-//     process-lifetime). `init_with_runtime` stores it as `NonNull<Loader>`.
-#[unsafe(no_mangle)]
-unsafe fn __bun_resolver_init_package_manager(
-    mut log: core::ptr::NonNull<bun_ast::Log>,
-    install: Option<core::ptr::NonNull<crate::bun_schema::api::BunInstall>>,
-    mut env: core::ptr::NonNull<bun_dotenv::Loader>,
-) -> core::result::Result<core::ptr::NonNull<dyn hooks::AutoInstaller>, bun_errno::SystemErrno> {
-    // ABI: the resolver-side `extern "Rust"` declaration names
-    // `bun_errno::SystemErrno` (both crates depend on bun_errno; carries the
-    // real errno name so resolve.test.ts sees `EACCES` not `Unexpected`). Keep
-    // both sides byte-identical or the `Result` layout diverges.
-    //
-    // Idempotent.
-    bun_http::http_thread::init(&Default::default());
+// so the runtime registers this with `bun_resolver::set_auto_installer_factory`.
+// `log` / `env` are the resolver's Transpiler-owned, process-lifetime log and
+// env loader; `install` is `BundleOptions.install`, read-only.
+pub fn init_for_resolver(
+    log: &mut bun_ast::Log,
+    bun_install: Option<&crate::bun_schema::api::BunInstall>,
+    env: &mut bun_dotenv::Loader,
+) -> core::result::Result<NonNull<dyn hooks::AutoInstaller>, bun_errno::SystemErrno> {
+    /// Address of the leaked runtime package manager (whoever dereferences it
+    /// upholds the manager's threading rules; see `Resolver::get_package_manager`).
+    struct Published(core::sync::atomic::AtomicPtr<PackageManager>);
+    static RUNTIME_MANAGER: std::sync::OnceLock<Result<Published, crate::Error>> =
+        std::sync::OnceLock::new();
 
-    // SAFETY: when `Some`, `install` points at a live `Api::BunInstall`
-    // (see `run_command::wire_transpiler_from_ctx`); read-only borrow.
-    let bun_install: Option<&crate::bun_schema::api::BunInstall> =
-        install.map(|p| unsafe { p.as_ref() });
-    // SAFETY: caller guarantees `log` / `env` point at process-lifetime
-    // Transpiler-owned storage with no aliasing `&mut` live across this call.
-    let (log_ref, env_ref): (&mut bun_ast::Log, &mut bun_dotenv::Loader) =
-        unsafe { (log.as_mut(), env.as_mut()) };
-
-    let pm: *mut PackageManager = crate::package_manager::init_with_runtime(
-        log_ref,
-        bun_install,
-        crate::package_manager::CommandLineArguments::default(),
-        env_ref,
-    )
-    .map_err(|e| match e {
-        crate::Error::Sys(errno) => errno,
-        crate::Error::Resolver(bun_resolver::Error::Sys(errno)) => errno,
-        other => {
-            log_ref.add_zig_error_with_note(
-                other.name(),
-                format_args!("while initializing the auto-install package manager"),
-            );
-            bun_errno::SystemErrno::EIO
+    let result = RUNTIME_MANAGER.get_or_init(|| {
+        bun_http::http_thread::init(&Default::default());
+        crate::package_manager::init_with_runtime(
+            log,
+            bun_install,
+            crate::package_manager::CommandLineArguments::default(),
+            env,
+        )
+        .map(|pm| Published(core::sync::atomic::AtomicPtr::new(core::ptr::from_mut(pm))))
+    });
+    match result {
+        Ok(Published(pm)) => {
+            let pm = NonNull::new(pm.load(core::sync::atomic::Ordering::Relaxed))
+                .expect("published manager is non-null");
+            let pm: NonNull<dyn hooks::AutoInstaller> = pm;
+            Ok(pm)
         }
-    })?;
-    // On success `init_with_runtime` returns the non-null `holder::RAW_PTR`
-    // singleton; upcast to the trait object the resolver stores.
-    Ok(core::ptr::NonNull::new(pm as *mut dyn hooks::AutoInstaller)
-        .expect("init_with_runtime returns the holder::RAW_PTR singleton"))
+        Err(err) => Err(match *err {
+            crate::Error::Sys(errno) => errno,
+            crate::Error::Resolver(bun_resolver::Error::Sys(errno)) => errno,
+            other => {
+                log.add_zig_error_with_note(
+                    other.name(),
+                    format_args!("while initializing the auto-install package manager"),
+                );
+                bun_errno::SystemErrno::EIO
+            }
+        }),
+    }
 }

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -20,7 +20,7 @@ use bun_sys::{self as sys, Fd, FdExt as _};
 
 use crate::bun_json::{Expr, ExprData};
 use crate::dependency::{Dependency, DependencyExt as _};
-use crate::install::{DependencyID, ExternalStringList};
+use crate::install::ExternalStringList;
 #[cfg(windows)]
 use crate::windows_shim::BinLinkingShim as WinBinLinkingShim;
 #[cfg(windows)]
@@ -34,7 +34,7 @@ bun_output::declare_scope!(BinLinker, hidden);
 /// - directory (relative to the package root)
 /// - map where keys are names of the binaries and values are file paths to the binaries
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, bytemuck::NoUninit, bytemuck::CheckedBitPattern)]
 pub struct Bin {
     pub tag: Tag,
     pub(crate) _padding_tag: [u8; 3],
@@ -48,9 +48,7 @@ impl Default for Bin {
         Bin {
             tag: Tag::None,
             _padding_tag: [0; 3],
-            value: Value {
-                map: ExternalStringList::default(),
-            },
+            value: Value::init_none(),
         }
     }
 }
@@ -62,24 +60,21 @@ impl Bin {
         extern_strings: &[ExternalString],
         builder: &mut B,
     ) -> u32 {
-        // SAFETY: tag determines the active union field
-        unsafe {
-            match self.tag {
-                Tag::File => builder.count(self.value.file.slice(buf)),
-                Tag::NamedFile => {
-                    builder.count(self.value.named_file[0].slice(buf));
-                    builder.count(self.value.named_file[1].slice(buf));
-                }
-                Tag::Dir => builder.count(self.value.dir.slice(buf)),
-                Tag::Map => {
-                    let list = self.value.map.get(extern_strings);
-                    for extern_string in list {
-                        builder.count(extern_string.slice(buf));
-                    }
-                    return list.len() as u32; // @truncate
-                }
-                _ => {}
+        match self.tag {
+            Tag::File => builder.count(self.value.file().slice(buf)),
+            Tag::NamedFile => {
+                builder.count(self.value.named_file()[0].slice(buf));
+                builder.count(self.value.named_file()[1].slice(buf));
             }
+            Tag::Dir => builder.count(self.value.dir().slice(buf)),
+            Tag::Map => {
+                let list = self.value.map().get(extern_strings);
+                for extern_string in list {
+                    builder.count(extern_string.slice(buf));
+                }
+                return list.len() as u32; // @truncate
+            }
+            _ => {}
         }
 
         0
@@ -97,45 +92,42 @@ impl Bin {
             return false;
         }
 
-        // SAFETY: tag was just checked to match the active union field
-        unsafe {
-            match l.tag {
-                Tag::None => true,
-                Tag::File => l.value.file.eql(r.value.file, l_buf, r_buf),
-                Tag::Dir => l.value.dir.eql(r.value.dir, l_buf, r_buf),
-                Tag::NamedFile => {
-                    l.value.named_file[0].eql(r.value.named_file[0], l_buf, r_buf)
-                        && l.value.named_file[1].eql(r.value.named_file[1], l_buf, r_buf)
+        match l.tag {
+            Tag::None => true,
+            Tag::File => l.value.file().eql(r.value.file(), l_buf, r_buf),
+            Tag::Dir => l.value.dir().eql(r.value.dir(), l_buf, r_buf),
+            Tag::NamedFile => {
+                l.value.named_file()[0].eql(r.value.named_file()[0], l_buf, r_buf)
+                    && l.value.named_file()[1].eql(r.value.named_file()[1], l_buf, r_buf)
+            }
+            Tag::Map => {
+                let l_list = l.value.map().get(l_extern_strings);
+                let r_list = r.value.map().get(r_extern_strings);
+                if l_list.len() != r_list.len() {
+                    return false;
                 }
-                Tag::Map => {
-                    let l_list = l.value.map.get(l_extern_strings);
-                    let r_list = r.value.map.get(r_extern_strings);
-                    if l_list.len() != r_list.len() {
-                        return false;
-                    }
 
-                    // assuming these maps are small without duplicate keys
-                    let mut i: usize = 0;
-                    'outer: while i < l_list.len() {
-                        let mut j: usize = 0;
-                        while j < r_list.len() {
-                            if l_list[i].hash == r_list[j].hash {
-                                if l_list[i + 1].hash != r_list[j + 1].hash {
-                                    return false;
-                                }
-
-                                i += 2;
-                                continue 'outer;
+                // assuming these maps are small without duplicate keys
+                let mut i: usize = 0;
+                'outer: while i < l_list.len() {
+                    let mut j: usize = 0;
+                    while j < r_list.len() {
+                        if l_list[i].hash == r_list[j].hash {
+                            if l_list[i + 1].hash != r_list[j + 1].hash {
+                                return false;
                             }
-                            j += 2;
-                        }
 
-                        // not found
-                        return false;
+                            i += 2;
+                            continue 'outer;
+                        }
+                        j += 2;
                     }
 
-                    true
+                    // not found
+                    return false;
                 }
+
+                true
             }
         }
     }
@@ -153,48 +145,49 @@ impl Bin {
         extern_strings_slice: &mut [ExternalString],
         builder: &mut B,
     ) -> Bin {
-        // SAFETY: tag determines the active union field
-        unsafe {
-            match self.tag {
-                Tag::None => Bin {
-                    tag: Tag::None,
-                    _padding_tag: [0; 3],
-                    value: Value::init_none(),
-                },
-                Tag::File => Bin {
-                    tag: Tag::File,
-                    _padding_tag: [0; 3],
-                    value: Value::init_file(builder.append_string(self.value.file.slice(buf))),
-                },
-                Tag::NamedFile => Bin {
-                    tag: Tag::NamedFile,
-                    _padding_tag: [0; 3],
-                    value: Value::init_named_file([
-                        builder.append_string(self.value.named_file[0].slice(buf)),
-                        builder.append_string(self.value.named_file[1].slice(buf)),
-                    ]),
-                },
-                Tag::Dir => Bin {
-                    tag: Tag::Dir,
-                    _padding_tag: [0; 3],
-                    value: Value::init_dir(builder.append_string(self.value.dir.slice(buf))),
-                },
-                Tag::Map => {
-                    for (i, extern_string) in
-                        self.value.map.get(prev_external_strings).iter().enumerate()
-                    {
-                        extern_strings_slice[i] =
-                            builder.append_external_string(extern_string.slice(buf));
-                    }
+        match self.tag {
+            Tag::None => Bin {
+                tag: Tag::None,
+                _padding_tag: [0; 3],
+                value: Value::init_none(),
+            },
+            Tag::File => Bin {
+                tag: Tag::File,
+                _padding_tag: [0; 3],
+                value: Value::init_file(builder.append_string(self.value.file().slice(buf))),
+            },
+            Tag::NamedFile => Bin {
+                tag: Tag::NamedFile,
+                _padding_tag: [0; 3],
+                value: Value::init_named_file([
+                    builder.append_string(self.value.named_file()[0].slice(buf)),
+                    builder.append_string(self.value.named_file()[1].slice(buf)),
+                ]),
+            },
+            Tag::Dir => Bin {
+                tag: Tag::Dir,
+                _padding_tag: [0; 3],
+                value: Value::init_dir(builder.append_string(self.value.dir().slice(buf))),
+            },
+            Tag::Map => {
+                for (i, extern_string) in self
+                    .value
+                    .map()
+                    .get(prev_external_strings)
+                    .iter()
+                    .enumerate()
+                {
+                    extern_strings_slice[i] =
+                        builder.append_external_string(extern_string.slice(buf));
+                }
 
-                    Bin {
-                        tag: Tag::Map,
-                        _padding_tag: [0; 3],
-                        value: Value::init_map(ExternalStringList::new(
-                            extern_strings_slice_off,
-                            extern_strings_slice.len() as u32,
-                        )),
-                    }
+                Bin {
+                    tag: Tag::Map,
+                    _padding_tag: [0; 3],
+                    value: Value::init_map(ExternalStringList::new(
+                        extern_strings_slice_off,
+                        extern_strings_slice.len() as u32,
+                    )),
                 }
             }
         }
@@ -238,9 +231,7 @@ impl Bin {
                 return Ok(Bin {
                     tag: Tag::File,
                     _padding_tag: [0; 3],
-                    value: Value {
-                        file: buf.append(str_)?,
-                    },
+                    value: Value::init_file(buf.append(str_)?),
                 });
             }
         }
@@ -262,9 +253,7 @@ impl Bin {
                 return Ok(Bin {
                     tag: Tag::NamedFile,
                     _padding_tag: [0; 3],
-                    value: Value {
-                        named_file: [buf.append(bin_name)?, buf.append(value)?],
-                    },
+                    value: Value::init_named_file([buf.append(bin_name)?, buf.append(value)?]),
                 });
             }
             _ => {
@@ -290,9 +279,10 @@ impl Bin {
                 return Ok(Bin {
                     tag: Tag::Map,
                     _padding_tag: [0; 3],
-                    value: Value {
-                        map: ExternalStringList::init(extern_strings.as_slice(), new),
-                    },
+                    value: Value::init_map(ExternalStringList::init(
+                        extern_strings.as_slice(),
+                        new,
+                    )),
                 });
             }
         }
@@ -307,9 +297,7 @@ impl Bin {
             return Ok(Bin {
                 tag: Tag::Dir,
                 _padding_tag: [0; 3],
-                value: Value {
-                    dir: buf.append(bin_str)?,
-                },
+                value: Value::init_dir(buf.append(bin_str)?),
             });
         }
         Ok(Bin::default())
@@ -324,123 +312,120 @@ impl Bin {
         write_indent: fn(&mut W, &mut u32) -> fmt::Result,
     ) -> fmt::Result {
         debug_assert!(self.tag != Tag::None);
-        // SAFETY: tag determines the active union field
-        unsafe {
-            if STYLE == ToJsonStyle::SingleLine {
-                match self.tag {
-                    Tag::None => {}
-                    Tag::File => {
-                        write!(
-                            writer,
-                            "{}",
-                            self.value.file.fmt_json(buf, Default::default())
-                        )?;
-                    }
-                    Tag::NamedFile => {
-                        writer.write_char('{')?;
-                        write!(
-                            writer,
-                            " {}: {} ",
-                            self.value.named_file[0].fmt_json(buf, Default::default()),
-                            self.value.named_file[1].fmt_json(buf, Default::default()),
-                        )?;
-                        writer.write_char('}')?;
-                    }
-                    Tag::Dir => {
-                        write!(
-                            writer,
-                            "{}",
-                            self.value.dir.fmt_json(buf, Default::default())
-                        )?;
-                    }
-                    Tag::Map => {
-                        writer.write_char('{')?;
-                        let list = self.value.map.get(extern_strings);
-                        let mut first = true;
-                        let mut i: usize = 0;
-                        while i < list.len() {
-                            if !first {
-                                writer.write_char(',')?;
-                            }
-                            first = false;
-                            write!(
-                                writer,
-                                " {}: {}",
-                                list[i].value.fmt_json(buf, Default::default()),
-                                list[i + 1].value.fmt_json(buf, Default::default()),
-                            )?;
-                            i += 2;
-                        }
-                        writer.write_str(" }")?;
-                    }
-                }
-
-                return Ok(());
-            }
-
-            let indent = indent.unwrap();
-
+        if STYLE == ToJsonStyle::SingleLine {
             match self.tag {
                 Tag::None => {}
                 Tag::File => {
                     write!(
                         writer,
                         "{}",
-                        self.value.file.fmt_json(buf, Default::default())
+                        self.value.file().fmt_json(buf, Default::default())
                     )?;
                 }
                 Tag::NamedFile => {
-                    writer.write_str("{\n")?;
-                    *indent += 1;
-                    write_indent(writer, indent)?;
-                    writeln!(
+                    writer.write_char('{')?;
+                    write!(
                         writer,
-                        "{}: {},",
-                        self.value.named_file[0].fmt_json(buf, Default::default()),
-                        self.value.named_file[1].fmt_json(buf, Default::default()),
+                        " {}: {} ",
+                        self.value.named_file()[0].fmt_json(buf, Default::default()),
+                        self.value.named_file()[1].fmt_json(buf, Default::default()),
                     )?;
-                    *indent -= 1;
-                    write_indent(writer, indent)?;
                     writer.write_char('}')?;
                 }
                 Tag::Dir => {
                     write!(
                         writer,
                         "{}",
-                        self.value.dir.fmt_json(buf, Default::default())
+                        self.value.dir().fmt_json(buf, Default::default())
                     )?;
                 }
                 Tag::Map => {
                     writer.write_char('{')?;
-                    *indent += 1;
-
-                    let list = self.value.map.get(extern_strings);
-                    let mut any = false;
+                    let list = self.value.map().get(extern_strings);
+                    let mut first = true;
                     let mut i: usize = 0;
                     while i < list.len() {
-                        if !any {
-                            any = true;
-                            writer.write_char('\n')?;
+                        if !first {
+                            writer.write_char(',')?;
                         }
-                        write_indent(writer, indent)?;
-                        writeln!(
+                        first = false;
+                        write!(
                             writer,
-                            "{}: {},",
+                            " {}: {}",
                             list[i].value.fmt_json(buf, Default::default()),
                             list[i + 1].value.fmt_json(buf, Default::default()),
                         )?;
                         i += 2;
                     }
-                    if !any {
-                        writer.write_char('}')?;
-                        *indent -= 1;
-                        return Ok(());
-                    }
-
-                    *indent -= 1;
-                    write_indent(writer, indent)?;
-                    writer.write_char('}')?;
+                    writer.write_str(" }")?;
                 }
+            }
+
+            return Ok(());
+        }
+
+        let indent = indent.unwrap();
+
+        match self.tag {
+            Tag::None => {}
+            Tag::File => {
+                write!(
+                    writer,
+                    "{}",
+                    self.value.file().fmt_json(buf, Default::default())
+                )?;
+            }
+            Tag::NamedFile => {
+                writer.write_str("{\n")?;
+                *indent += 1;
+                write_indent(writer, indent)?;
+                writeln!(
+                    writer,
+                    "{}: {},",
+                    self.value.named_file()[0].fmt_json(buf, Default::default()),
+                    self.value.named_file()[1].fmt_json(buf, Default::default()),
+                )?;
+                *indent -= 1;
+                write_indent(writer, indent)?;
+                writer.write_char('}')?;
+            }
+            Tag::Dir => {
+                write!(
+                    writer,
+                    "{}",
+                    self.value.dir().fmt_json(buf, Default::default())
+                )?;
+            }
+            Tag::Map => {
+                writer.write_char('{')?;
+                *indent += 1;
+
+                let list = self.value.map().get(extern_strings);
+                let mut any = false;
+                let mut i: usize = 0;
+                while i < list.len() {
+                    if !any {
+                        any = true;
+                        writer.write_char('\n')?;
+                    }
+                    write_indent(writer, indent)?;
+                    writeln!(
+                        writer,
+                        "{}: {},",
+                        list[i].value.fmt_json(buf, Default::default()),
+                        list[i + 1].value.fmt_json(buf, Default::default()),
+                    )?;
+                    i += 2;
+                }
+                if !any {
+                    writer.write_char('}')?;
+                    *indent -= 1;
+                    return Ok(());
+                }
+
+                *indent -= 1;
+                write_indent(writer, indent)?;
+                writer.write_char('}')?;
             }
         }
         Ok(())
@@ -454,15 +439,26 @@ impl Bin {
         }
     }
 
-    // ── Tag-checked union accessors ────────────────────────────────────────
-    // `Value` is a `Copy` POD union (largest member `ExternalStringList` is two
-    // `u32`s); reading the wrong variant is well-defined garbage.
-    bun_core::extern_union_accessors! {
-        tag: tag as Tag, value: value;
-        File      => file: String;
-        NamedFile => named_file: [String; 2];
-        Dir       => dir: String;
-        Map       => map: ExternalStringList;
+    // ── Tag-checked accessors ────────────────────────────────────────────────
+    #[inline]
+    pub fn file(&self) -> String {
+        debug_assert!(self.tag == Tag::File);
+        self.value.file()
+    }
+    #[inline]
+    pub fn named_file(&self) -> [String; 2] {
+        debug_assert!(self.tag == Tag::NamedFile);
+        self.value.named_file()
+    }
+    #[inline]
+    pub fn dir(&self) -> String {
+        debug_assert!(self.tag == Tag::Dir);
+        self.value.dir()
+    }
+    #[inline]
+    pub fn map(&self) -> ExternalStringList {
+        debug_assert!(self.tag == Tag::Map);
+        self.value.map()
     }
 }
 
@@ -478,78 +474,84 @@ pub enum ToJsonStyle {
 // `bin_real::StringBuilder` paths still resolve.
 pub use bun_semver::StringBuilder;
 
+/// The `bin` payload; which view is live is [`Bin::tag`]. Stored as raw
+/// words so every bit pattern read from a lockfile is valid.
 #[repr(C)]
-#[derive(Clone, Copy)]
-pub union Value {
-    /// no "bin", or empty "bin"
-    pub none: (),
+#[derive(Clone, Copy, Default, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Value {
+    words: [u32; 4],
+}
 
+impl Value {
+    /// no "bin", or empty "bin"
+    #[inline]
+    pub(crate) fn init_none() -> Value {
+        Value::default()
+    }
     /// "bin" is a string
     /// ```json
     /// "bin": "./bin/foo",
     /// ```
-    pub(crate) file: String,
-
-    // Single-entry map
+    #[inline]
+    pub(crate) fn init_file(file: String) -> Value {
+        Self::init_named_file([file, String::default()])
+    }
+    /// Single-entry map
     ///```json
     /// "bin": {
     ///     "babel": "./cli.js",
     /// }
     ///```
-    pub(crate) named_file: [String; 2],
-
+    #[inline]
+    pub(crate) fn init_named_file(named_file: [String; 2]) -> Value {
+        Value {
+            words: bytemuck::cast(named_file),
+        }
+    }
     /// "bin" is a directory
     ///```json
     /// "dirs": {
     ///     "bin": "./bin",
     /// }
     ///```
-    pub(crate) dir: String,
-    // "bin" is a map
+    #[inline]
+    pub(crate) fn init_dir(dir: String) -> Value {
+        Self::init_named_file([dir, String::default()])
+    }
+    /// "bin" is a map
     ///```json
     /// "bin": {
     ///     "babel": "./cli.js",
     ///     "babel-cli": "./cli.js",
     /// }
     ///```
-    pub(crate) map: ExternalStringList,
-}
-
-impl Value {
-    /// To avoid undefined memory between union values, we must zero initialize the union first.
-    #[inline]
-    pub(crate) fn init_none() -> Value {
-        // SAFETY: all-zero is a valid Value (largest member ExternalStringList is POD)
-        unsafe { bun_core::ffi::zeroed_unchecked() }
-    }
-    #[inline]
-    pub(crate) fn init_file(file: String) -> Value {
-        let mut v = Self::init_none();
-        v.file = file;
-        v
-    }
-    #[inline]
-    pub(crate) fn init_named_file(named_file: [String; 2]) -> Value {
-        let mut v = Self::init_none();
-        v.named_file = named_file;
-        v
-    }
-    #[inline]
-    pub(crate) fn init_dir(dir: String) -> Value {
-        let mut v = Self::init_none();
-        v.dir = dir;
-        v
-    }
     #[inline]
     pub(crate) fn init_map(map: ExternalStringList) -> Value {
-        let mut v = Self::init_none();
-        v.map = map;
-        v
+        Value {
+            words: [map.off, map.len, 0, 0],
+        }
+    }
+
+    #[inline]
+    pub fn file(&self) -> String {
+        self.named_file()[0]
+    }
+    #[inline]
+    pub fn dir(&self) -> String {
+        self.named_file()[0]
+    }
+    #[inline]
+    pub fn named_file(&self) -> [String; 2] {
+        bytemuck::cast(self.words)
+    }
+    #[inline]
+    pub fn map(&self) -> ExternalStringList {
+        ExternalStringList::new(self.words[0], self.words[1])
     }
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, bytemuck::NoUninit, bytemuck::CheckedBitPattern)]
 pub enum Tag {
     /// no bin field
     None = 0,
@@ -608,7 +610,7 @@ impl<'a> NamesIterator<'a> {
             return Ok(None);
         }
         if self.dir_iterator.is_none() {
-            let dir_str = *self.bin.dir();
+            let dir_str = self.bin.dir();
             let mut target = dir_str.slice(self.string_buffer);
             if strings::has_prefix(target, b"./") || strings::has_prefix(target, b".\\") {
                 target = &target[2..];
@@ -663,7 +665,7 @@ impl<'a> NamesIterator<'a> {
                 }
                 self.i += 1;
                 self.done = true;
-                let named = *self.bin.named_file();
+                let named = self.bin.named_file();
                 let base = path::basename(named[0].slice(self.string_buffer));
                 if strings::has_prefix(base, b"./") || strings::has_prefix(base, b".\\") {
                     return Ok(Some(strings::copy(&mut self.buf[..], &base[2..])));
@@ -673,7 +675,7 @@ impl<'a> NamesIterator<'a> {
 
             Tag::Dir => self.next_in_dir(),
             Tag::Map => {
-                let map = *self.bin.map();
+                let map = self.bin.map();
                 if self.i >= map.len as usize {
                     return Ok(None);
                 }
@@ -692,43 +694,6 @@ impl<'a> NamesIterator<'a> {
         }
     }
 }
-
-// BACKREF — `PackageInstaller` holds a
-// `&mut Lockfile` alongside a `Box<[TreeContext]>` whose `binaries` queues
-// alias into `lockfile.buffers`; a `&'a Vec<_>` borrow here would force the
-// `TreeContext.binaries` field to carry an unsatisfiable `'static` (the
-// installer outlives no concrete lifetime for its own self-borrowed buffers).
-pub struct PriorityQueueContext {
-    pub(crate) dependencies: bun_ptr::BackRef<Vec<Dependency>>,
-    pub(crate) string_buf: bun_ptr::BackRef<Vec<u8>>,
-}
-
-impl PriorityQueueContext {
-    fn less_than(&self, a: DependencyID, b: DependencyID) -> core::cmp::Ordering {
-        // `dependencies` / `string_buf` point at
-        // `lockfile.buffers.{dependencies,string_bytes}`, which are kept alive
-        // for the entire install (the `PackageInstaller` that owns this queue
-        // also borrows the same `Lockfile`). The Vecs may be reallocated by
-        // `fix_cached_lockfile_package_slices`, which is why we re-deref the
-        // `BackRef<Vec>` (header) on every compare instead of caching a slice.
-        let deps = self.dependencies.as_slice();
-        let buf = self.string_buf.as_slice();
-        let a_name = deps[a as usize].name.slice(buf);
-        let b_name = deps[b as usize].name.slice(buf);
-        strings::order(a_name, b_name)
-    }
-}
-
-impl bun_collections::PriorityCompare<DependencyID> for PriorityQueueContext {
-    #[inline]
-    fn compare(&self, a: &DependencyID, b: &DependencyID) -> core::cmp::Ordering {
-        self.less_than(*a, *b)
-    }
-}
-
-// Port of `std.PriorityQueue(DependencyID, PriorityQueueContext, lessThan)`.
-// Min-heap keyed by `PriorityQueueContext::less_than` (string-order of dep names).
-pub(crate) type PriorityQueue = bun_collections::PriorityQueue<DependencyID, PriorityQueueContext>;
 
 // https://github.com/npm/npm-normalize-package-bin/blob/574e6d7cd21b2f3dee28a216ec2053c2551f7af9/lib/index.js#L38
 fn normalized_bin_name(name: &[u8]) -> &[u8] {
@@ -795,15 +760,9 @@ fn bin_target_needs_resolved_containment_check(target: &[u8]) -> bool {
 pub struct Linker<'a> {
     pub bin: Bin,
 
-    /// Usually will be the same as `node_modules_path`.
-    /// Used to support native bin linking.
-    ///
-    /// This intentionally may alias `node_modules_path` (the common
-    /// case). A `&'a AbsPath` would
-    /// conflict with the `&'a mut AbsPath` borrow on `node_modules_path`, so
-    /// keep it as a raw pointer; the only read site dereferences it under a
-    /// SAFETY note in `build_target_package_dir`.
-    pub target_node_modules_path: *const AbsPath,
+    /// Used to support native bin linking. `None` means "same as
+    /// `node_modules_path`" (the common case).
+    pub target_node_modules_path: Option<&'a AbsPath>,
 
     /// Usually will be the same as `package_name`.
     /// Used to support native bin linking.
@@ -835,6 +794,14 @@ static UMASK: AtomicU32 = AtomicU32::new(0);
 static HAS_SET_UMASK: AtomicBool = AtomicBool::new(false);
 
 impl<'a> Linker<'a> {
+    #[cfg(not(windows))]
+    fn target_node_modules_path(&self) -> &[u8] {
+        match self.target_node_modules_path {
+            Some(p) => p.slice(),
+            None => self.node_modules_path.slice(),
+        }
+    }
+
     pub fn ensure_umask() {
         // Single-winner gate: only the thread that flips false->true performs
         // the temporary umask(0)/umask(prev) probe. A bare load+store would let
@@ -867,13 +834,11 @@ impl<'a> Linker<'a> {
             let bunx_suffix = w!(".bunx\x00");
             dest_buf[abs_dest_w_len..abs_dest_w_len + bunx_suffix.len()]
                 .copy_from_slice(bunx_suffix);
-            // SAFETY: dest_buf[abs_dest_w_len + ".bunx".len()] == 0 written above
             let abs_bunx_file =
                 bun_core::WStr::from_buf(&dest_buf[..], abs_dest_w_len + b".bunx".len());
             let _ = sys::unlink_w(abs_bunx_file);
             let exe_suffix = w!(".exe\x00");
             dest_buf[abs_dest_w_len..abs_dest_w_len + exe_suffix.len()].copy_from_slice(exe_suffix);
-            // SAFETY: dest_buf[abs_dest_w_len + ".exe".len()] == 0 written above
             let abs_exe_file =
                 bun_core::WStr::from_buf(&dest_buf[..], abs_dest_w_len + b".exe".len());
             let _ = sys::unlink_w(abs_exe_file);
@@ -995,8 +960,8 @@ impl<'a> Linker<'a> {
 
         // We have to do an atomic replace here, use a randomly generated
         // filename in the same folder, read the entire original file
-        // contents using bun.sys.File.readFrom, then write the temporary file, then
-        // overwite the old one with the new one via bun.sys.renameat. And
+        // contents using `File::read_from`, then write the temporary file, then
+        // overwite the old one with the new one via `renameat`. And
         // always unlink the old one. If it fails for any reason then exit
         // early.
         let mut tmpname_buf = [0u8; 1024];
@@ -1013,8 +978,6 @@ impl<'a> Linker<'a> {
             return;
         }
 
-        // reshaped for borrowck — bind the owned buffer first, then
-        // borrow `content` from it (or fall back to the stack `chunk`).
         let content_to_free: Box<[u8]>;
         let content: &[u8] = if chunk.len() >= shebang_buf.len() {
             // Partial read. Need to read the rest of the file.
@@ -1129,7 +1092,6 @@ impl<'a> Linker<'a> {
         let bunx_suffix = w!(".bunx\x00");
         dest_buf[abs_dest_w_len..abs_dest_w_len + bunx_suffix.len()].copy_from_slice(bunx_suffix);
 
-        // SAFETY: dest_buf[abs_dest_w_len + ".bunx".len()] == 0 written above
         let abs_bunx_file =
             bun_core::WStr::from_buf(&dest_buf[..], abs_dest_w_len + b".bunx".len());
 
@@ -1233,7 +1195,6 @@ impl<'a> Linker<'a> {
 
         let exe_suffix = w!(".exe\x00");
         dest_buf[abs_dest_w_len..abs_dest_w_len + exe_suffix.len()].copy_from_slice(exe_suffix);
-        // SAFETY: dest_buf[abs_dest_w_len + ".exe".len()] == 0 written above
         let abs_exe_file = bun_core::WStr::from_buf(&dest_buf[..], abs_dest_w_len + b".exe".len());
 
         if let Err(err) = sys::File::write_file_os_path(
@@ -1254,9 +1215,8 @@ impl<'a> Linker<'a> {
 
     #[cfg(not(windows))]
     fn create_symlink(&mut self, abs_target: &ZStr, abs_dest: &ZStr, global: bool) {
-        // hoisted from `defer { if (this.err == null) chmod }` — scopeguard
-        // cannot capture `&mut self.err` without conflicting with the body's writes,
-        // so each return path calls `Self::chmod_on_ok` explicitly instead.
+        // Each return path calls `Self::chmod_on_ok` explicitly (a guard
+        // could not capture `&mut self.err` alongside the body's writes).
 
         let abs_dest_dir = resolve_path::dirname::<PlatformAuto>(abs_dest.as_bytes());
         let rel_target =
@@ -1320,7 +1280,6 @@ impl<'a> Linker<'a> {
 
     #[cfg(not(windows))]
     fn chmod_on_ok(err: Option<Error>, abs_target: &ZStr) {
-        // hoisted from `defer` block in create_symlink
         if err.is_none() {
             let mode = 0o777 & !(UMASK.load(Ordering::Acquire) as Mode);
             let _ = sys::lchmod(abs_target, mode);
@@ -1329,12 +1288,8 @@ impl<'a> Linker<'a> {
 
     #[cfg(not(windows))]
     fn resolved_target_parent_escapes_package_dir(&self, abs_target: &ZStr) -> bool {
-        // SAFETY: `target_node_modules_path` is set at construction to either
-        // a caller-owned `AbsPath` or the same buffer as `node_modules_path`;
-        // both outlive `self` and are not mutated for the duration of this
-        // read.
         let dest_dir_without_trailing_slash =
-            strings::without_trailing_slash(unsafe { (*self.target_node_modules_path).slice() });
+            strings::without_trailing_slash(self.target_node_modules_path());
         let package_name = self.target_package_name.slice();
 
         let mut package_dir_buf = path::path_buffer_pool::get();
@@ -1509,7 +1464,7 @@ impl<'a> Linker<'a> {
             }
         }
 
-        // Nothing found; return the primary so `linkBinOrCreateShim` sets
+        // Nothing found; return the primary so `link_bin_or_create_shim` sets
         // `skipped_due_to_missing_bin` and the caller retries without the
         // redirect.
         resolve_path::join_abs_string_z::<PlatformAuto>(package_dir, &[target])
@@ -1517,12 +1472,11 @@ impl<'a> Linker<'a> {
 
     /// Length of `<node_modules>/<package>/` in `abs_target_buf`, `None` if a NUL no longer fits.
     pub(crate) fn build_target_package_dir(&mut self) -> Option<usize> {
-        // SAFETY: `target_node_modules_path` is set at construction to either
-        // a caller-owned `AbsPath` or the same buffer as `node_modules_path`;
-        // both outlive `self` and are not mutated for the duration of this
-        // read.
         let dest_dir_without_trailing_slash =
-            strings::without_trailing_slash(unsafe { (*self.target_node_modules_path).slice() });
+            strings::without_trailing_slash(match self.target_node_modules_path {
+                Some(p) => p.slice(),
+                None => self.node_modules_path.slice(),
+            });
         let package_name = self.target_package_name.slice();
 
         let buf = &mut *self.abs_target_buf;
@@ -1530,7 +1484,6 @@ impl<'a> Linker<'a> {
             return None;
         }
 
-        // reshaped for borrowck — track offset instead of remain.ptr arithmetic
         let mut off: usize = 0;
 
         buf[off..off + dest_dir_without_trailing_slash.len()]
@@ -1580,7 +1533,7 @@ impl<'a> Linker<'a> {
     // target: what the symlink points to
     // destination: where the symlink exists on disk
     pub fn link(&mut self, global: bool) {
-        let (Some(package_dir_len), Some(mut dest_off)) = (
+        let (Some(package_dir_len), Some(dest_off)) = (
             self.build_target_package_dir(),
             self.build_destination_dir(global),
         ) else {
@@ -1591,63 +1544,154 @@ impl<'a> Linker<'a> {
 
         debug_assert!(self.bin.tag != Tag::None);
 
-        // `link_bin_or_create_shim(&mut self, ..)`
-        // is called while `abs_target` / `abs_dest` borrow `self.abs_target_buf`
-        // / `self.abs_dest_buf`. `link_bin_or_create_shim` never reads or writes
-        // those two buffers (it only touches `rel_buf`, `node_modules_path`, `seen`, `err`,
-        // `skipped_due_to_missing_bin`). Detach the `abs_dest` borrow via a raw
-        // pointer so borrowck allows the disjoint access; the SAFETY invariant
-        // is that `abs_dest_buf` is not aliased mutably for the lifetime of the
-        // detached slice. `package_dir` (`abs_target_buf[0..package_dir_len]`)
-        // is re-derived inside each arm so no detached borrow is needed for it.
-        let abs_dest_buf_ptr: *mut u8 = self.abs_dest_buf.as_mut_ptr();
+        // `abs_target` / `abs_dest` live in these two buffers while
+        // `link_bin_or_create_shim(&mut self, ..)` runs (it never touches
+        // them), so hold them outside `self` for the body.
+        let abs_target_buf = core::mem::take(&mut self.abs_target_buf);
+        let abs_dest_buf = core::mem::take(&mut self.abs_dest_buf);
+        self.link_with_bufs(
+            global,
+            package_dir_len,
+            dest_off,
+            is_redirect,
+            abs_target_buf,
+            abs_dest_buf,
+        );
+        self.abs_target_buf = abs_target_buf;
+        self.abs_dest_buf = abs_dest_buf;
+    }
 
-        // SAFETY: tag determines the active union field
-        unsafe {
-            match self.bin.tag {
-                Tag::None => {}
-                Tag::File => {
-                    let file = self.bin.value.file;
-                    let target = file.slice(self.string_buf);
-                    if target.is_empty() || bin_target_escapes_package_dir(target) {
-                        return;
+    fn link_with_bufs(
+        &mut self,
+        global: bool,
+        package_dir_len: usize,
+        mut dest_off: usize,
+        is_redirect: bool,
+        abs_target_buf: &mut [u8],
+        abs_dest_buf: &mut [u8],
+    ) {
+        match self.bin.tag {
+            Tag::None => {}
+            Tag::File => {
+                let file = self.bin.value.file();
+                let target = file.slice(self.string_buf);
+                if target.is_empty() || bin_target_escapes_package_dir(target) {
+                    return;
+                }
+                let target_needs_resolved_containment_check =
+                    bin_target_needs_resolved_containment_check(target);
+
+                let unscoped_package_name =
+                    Dependency::unscoped_package_name(self.package_name.slice());
+
+                // for normalizing `target`
+                let abs_target: &ZStr = Self::resolve_bin_target(
+                    is_redirect,
+                    &abs_target_buf[0..package_dir_len],
+                    target,
+                    unscoped_package_name,
+                );
+
+                if unscoped_package_name.len() >= abs_dest_buf.len().saturating_sub(dest_off) {
+                    self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+                    return;
+                }
+                abs_dest_buf[dest_off..dest_off + unscoped_package_name.len()]
+                    .copy_from_slice(unscoped_package_name);
+                dest_off += unscoped_package_name.len();
+                abs_dest_buf[dest_off] = 0;
+                let abs_dest_len = dest_off;
+                let abs_dest = ZStr::from_buf(abs_dest_buf, abs_dest_len);
+
+                self.link_bin_or_create_shim(
+                    abs_target,
+                    abs_dest,
+                    global,
+                    target_needs_resolved_containment_check,
+                );
+            }
+            Tag::NamedFile => {
+                let named = self.bin.value.named_file();
+                let name = named[0].slice(self.string_buf);
+                let normalized_name = normalized_bin_name(name);
+                let target = named[1].slice(self.string_buf);
+                if normalized_name.is_empty()
+                    || target.is_empty()
+                    || bin_target_escapes_package_dir(target)
+                {
+                    return;
+                }
+                let target_needs_resolved_containment_check =
+                    bin_target_needs_resolved_containment_check(target);
+                if normalized_name.len() >= abs_dest_buf.len().saturating_sub(dest_off) {
+                    self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+                    return;
+                }
+
+                // for normalizing `target`
+                let abs_target: &ZStr = Self::resolve_bin_target(
+                    is_redirect,
+                    &abs_target_buf[0..package_dir_len],
+                    target,
+                    normalized_name,
+                );
+
+                abs_dest_buf[dest_off..dest_off + normalized_name.len()]
+                    .copy_from_slice(normalized_name);
+                dest_off += normalized_name.len();
+                abs_dest_buf[dest_off] = 0;
+                let abs_dest_len = dest_off;
+                let abs_dest = ZStr::from_buf(abs_dest_buf, abs_dest_len);
+
+                self.link_bin_or_create_shim(
+                    abs_target,
+                    abs_dest,
+                    global,
+                    target_needs_resolved_containment_check,
+                );
+            }
+            Tag::Map => {
+                let map = self.bin.value.map();
+                let mut i = map.begin();
+                let end = map.end();
+
+                let abs_dest_dir_end = dest_off;
+
+                while i < end {
+                    let bin_dest = self.extern_string_buf[i as usize].slice(self.string_buf);
+                    let normalized_bin_dest = normalized_bin_name(bin_dest);
+                    let bin_target =
+                        self.extern_string_buf[(i + 1) as usize].slice(self.string_buf);
+                    if bin_target.is_empty()
+                        || normalized_bin_dest.is_empty()
+                        || bin_target_escapes_package_dir(bin_target)
+                    {
+                        i += 2;
+                        continue;
                     }
                     let target_needs_resolved_containment_check =
-                        bin_target_needs_resolved_containment_check(target);
-
-                    let unscoped_package_name =
-                        Dependency::unscoped_package_name(self.package_name.slice());
-
-                    // for normalizing `target`
-                    let abs_target: &ZStr = {
-                        let package_dir = &self.abs_target_buf[0..package_dir_len];
-                        let r = Self::resolve_bin_target(
-                            is_redirect,
-                            package_dir,
-                            target,
-                            unscoped_package_name,
-                        );
-                        // SAFETY: `resolve_bin_target` writes into the thread-local
-                        // `PARSER_JOIN_INPUT_BUFFER` (via `join_abs_string_z`); the
-                        // returned slice does not actually borrow `self` or
-                        // `package_dir`. Detach the lifetime so `self` can be
-                        // re-borrowed mutably below.
-                        ZStr::from_raw(r.as_bytes().as_ptr(), r.len())
-                    };
-
-                    if unscoped_package_name.len()
-                        >= self.abs_dest_buf.len().saturating_sub(dest_off)
+                        bin_target_needs_resolved_containment_check(bin_target);
+                    if normalized_bin_dest.len()
+                        >= abs_dest_buf.len().saturating_sub(abs_dest_dir_end)
                     {
                         self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
                         return;
                     }
-                    self.abs_dest_buf[dest_off..dest_off + unscoped_package_name.len()]
-                        .copy_from_slice(unscoped_package_name);
-                    dest_off += unscoped_package_name.len();
-                    self.abs_dest_buf[dest_off] = 0;
+
+                    let abs_target: &ZStr = Self::resolve_bin_target(
+                        is_redirect,
+                        &abs_target_buf[0..package_dir_len],
+                        bin_target,
+                        normalized_bin_dest,
+                    );
+
+                    dest_off = abs_dest_dir_end;
+                    abs_dest_buf[dest_off..dest_off + normalized_bin_dest.len()]
+                        .copy_from_slice(normalized_bin_dest);
+                    dest_off += normalized_bin_dest.len();
+                    abs_dest_buf[dest_off] = 0;
                     let abs_dest_len = dest_off;
-                    // SAFETY: abs_dest_buf[abs_dest_len] == 0 written above; see note above.
-                    let abs_dest = ZStr::from_raw(abs_dest_buf_ptr, abs_dest_len);
+                    let abs_dest = ZStr::from_buf(abs_dest_buf, abs_dest_len);
 
                     self.link_bin_or_create_shim(
                         abs_target,
@@ -1655,189 +1699,74 @@ impl<'a> Linker<'a> {
                         global,
                         target_needs_resolved_containment_check,
                     );
+
+                    i += 2;
                 }
-                Tag::NamedFile => {
-                    let named = self.bin.value.named_file;
-                    let name = named[0].slice(self.string_buf);
-                    let normalized_name = normalized_bin_name(name);
-                    let target = named[1].slice(self.string_buf);
-                    if normalized_name.is_empty()
-                        || target.is_empty()
-                        || bin_target_escapes_package_dir(target)
-                    {
-                        return;
-                    }
-                    let target_needs_resolved_containment_check =
-                        bin_target_needs_resolved_containment_check(target);
-                    if normalized_name.len() >= self.abs_dest_buf.len().saturating_sub(dest_off) {
-                        self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
-                        return;
-                    }
-
-                    // for normalizing `target`
-                    let abs_target: &ZStr = {
-                        let package_dir = &self.abs_target_buf[0..package_dir_len];
-                        let r = Self::resolve_bin_target(
-                            is_redirect,
-                            package_dir,
-                            target,
-                            normalized_name,
-                        );
-                        // SAFETY: thread-local buffer; see Tag::File above.
-                        ZStr::from_raw(r.as_bytes().as_ptr(), r.len())
-                    };
-
-                    self.abs_dest_buf[dest_off..dest_off + normalized_name.len()]
-                        .copy_from_slice(normalized_name);
-                    dest_off += normalized_name.len();
-                    self.abs_dest_buf[dest_off] = 0;
-                    let abs_dest_len = dest_off;
-                    // SAFETY: abs_dest_buf[abs_dest_len] == 0 written above; see note above.
-                    let abs_dest = ZStr::from_raw(abs_dest_buf_ptr, abs_dest_len);
-
-                    self.link_bin_or_create_shim(
-                        abs_target,
-                        abs_dest,
-                        global,
-                        target_needs_resolved_containment_check,
-                    );
+            }
+            Tag::Dir => {
+                let dir = self.bin.value.dir();
+                let target = dir.slice(self.string_buf);
+                if target.is_empty() || bin_target_escapes_package_dir(target) {
+                    return;
                 }
-                Tag::Map => {
-                    let map = self.bin.value.map;
-                    let mut i = map.begin();
-                    let end = map.end();
+                // for normalizing `target`; copied out so `abs_target_buf`
+                // can be reused inside the loop body.
+                let mut abs_target_dir_buf = bun_paths::path_buffer_pool::get();
+                let abs_target_dir: &ZStr = {
+                    let package_dir = &abs_target_buf[0..package_dir_len];
+                    let r = resolve_path::join_abs_string_z::<PlatformAuto>(package_dir, &[target]);
+                    abs_target_dir_buf[..r.len() + 1].copy_from_slice(r.as_bytes_with_nul());
+                    ZStr::from_buf(&abs_target_dir_buf[..], r.len())
+                };
 
-                    let abs_dest_dir_end = dest_off;
-
-                    while i < end {
-                        let bin_dest = self.extern_string_buf[i as usize].slice(self.string_buf);
-                        let normalized_bin_dest = normalized_bin_name(bin_dest);
-                        let bin_target =
-                            self.extern_string_buf[(i + 1) as usize].slice(self.string_buf);
-                        if bin_target.is_empty()
-                            || normalized_bin_dest.is_empty()
-                            || bin_target_escapes_package_dir(bin_target)
-                        {
-                            i += 2;
-                            continue;
-                        }
-                        let target_needs_resolved_containment_check =
-                            bin_target_needs_resolved_containment_check(bin_target);
-                        if normalized_bin_dest.len()
-                            >= self.abs_dest_buf.len().saturating_sub(abs_dest_dir_end)
-                        {
-                            self.err =
-                                Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+                let target_dir = match sys::open_dir_absolute(abs_target_dir.as_bytes()) {
+                    Ok(d) => d,
+                    Err(err) => {
+                        if err.get_errno() == sys::Errno::ENOENT {
+                            // https://github.com/npm/cli/blob/366c07e2f3cb9d1c6ddbd03e624a4d73fbd2676e/node_modules/bin-links/lib/link-gently.js#L43
+                            // avoid erroring when the directory does not exist
                             return;
                         }
-
-                        let abs_target: &ZStr = {
-                            let package_dir = &self.abs_target_buf[0..package_dir_len];
-                            let r = Self::resolve_bin_target(
-                                is_redirect,
-                                package_dir,
-                                bin_target,
-                                normalized_bin_dest,
-                            );
-                            // SAFETY: thread-local buffer; see Tag::File above.
-                            ZStr::from_raw(r.as_bytes().as_ptr(), r.len())
-                        };
-
-                        dest_off = abs_dest_dir_end;
-                        self.abs_dest_buf[dest_off..dest_off + normalized_bin_dest.len()]
-                            .copy_from_slice(normalized_bin_dest);
-                        dest_off += normalized_bin_dest.len();
-                        self.abs_dest_buf[dest_off] = 0;
-                        let abs_dest_len = dest_off;
-                        // SAFETY: abs_dest_buf[abs_dest_len] == 0 written above; see note above.
-                        let abs_dest = ZStr::from_raw(abs_dest_buf_ptr, abs_dest_len);
-
-                        self.link_bin_or_create_shim(
-                            abs_target,
-                            abs_dest,
-                            global,
-                            target_needs_resolved_containment_check,
-                        );
-
-                        i += 2;
-                    }
-                }
-                Tag::Dir => {
-                    let dir = self.bin.value.dir;
-                    let target = dir.slice(self.string_buf);
-                    if target.is_empty() || bin_target_escapes_package_dir(target) {
+                        self.err = Some(err.into());
                         return;
                     }
-                    // for normalizing `target`
-                    let abs_target_dir: &ZStr = {
-                        let package_dir = &self.abs_target_buf[0..package_dir_len];
-                        let r =
-                            resolve_path::join_abs_string_z::<PlatformAuto>(package_dir, &[target]);
-                        // SAFETY: `join_abs_string_z` writes into the thread-local
-                        // `PARSER_JOIN_INPUT_BUFFER`; result does not borrow
-                        // `package_dir`. Detached so `abs_target_buf` can be
-                        // reused inside the loop body (see the SAFETY note below).
-                        ZStr::from_raw(r.as_bytes().as_ptr(), r.len())
-                    };
+                };
+                let _close = scopeguard::guard(target_dir, |fd| {
+                    let _ = sys::close(fd);
+                });
 
-                    let target_dir = match sys::open_dir_absolute(abs_target_dir.as_bytes()) {
-                        Ok(d) => d,
-                        Err(err) => {
-                            if err.get_errno() == sys::Errno::ENOENT {
-                                // https://github.com/npm/cli/blob/366c07e2f3cb9d1c6ddbd03e624a4d73fbd2676e/node_modules/bin-links/lib/link-gently.js#L43
-                                // avoid erroring when the directory does not exist
+                let abs_dest_dir_end = dest_off;
+
+                let mut iter = sys::iterate_dir(target_dir);
+                while let Some(entry) = iter.next().unwrap_or(None) {
+                    match entry.kind {
+                        sys::EntryKind::SymLink | sys::EntryKind::File => {
+                            let entry_name = entry.name.slice_u8();
+                            let abs_target: &ZStr =
+                                resolve_path::join_abs_string_buf_z::<PlatformAuto>(
+                                    abs_target_dir.as_bytes(),
+                                    &mut *abs_target_buf,
+                                    &[entry_name],
+                                );
+
+                            if entry_name.len()
+                                >= abs_dest_buf.len().saturating_sub(abs_dest_dir_end)
+                            {
+                                self.err =
+                                    Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
                                 return;
                             }
-                            self.err = Some(err.into());
-                            return;
+                            dest_off = abs_dest_dir_end;
+                            abs_dest_buf[dest_off..dest_off + entry_name.len()]
+                                .copy_from_slice(entry_name);
+                            dest_off += entry_name.len();
+                            abs_dest_buf[dest_off] = 0;
+                            let abs_dest_len = dest_off;
+                            let abs_dest = ZStr::from_buf(abs_dest_buf, abs_dest_len);
+
+                            self.link_bin_or_create_shim(abs_target, abs_dest, global, true);
                         }
-                    };
-                    let _close = scopeguard::guard(target_dir, |fd| {
-                        let _ = sys::close(fd);
-                    });
-
-                    let abs_dest_dir_end = dest_off;
-
-                    let mut iter = sys::iterate_dir(target_dir);
-                    while let Some(entry) = iter.next().unwrap_or(None) {
-                        match entry.kind {
-                            sys::EntryKind::SymLink | sys::EntryKind::File => {
-                                let entry_name = entry.name.slice_u8();
-                                // `self.abs_target_buf` is available now because `path::join_abs_string_z` copied everything into `parse_join_input_buffer`
-                                let abs_target: &ZStr = {
-                                    let r = resolve_path::join_abs_string_buf_z::<PlatformAuto>(
-                                        abs_target_dir.as_bytes(),
-                                        self.abs_target_buf,
-                                        &[entry_name],
-                                    );
-                                    // SAFETY: result lives in `self.abs_target_buf`, which
-                                    // `link_bin_or_create_shim` does not write to (only
-                                    // `rel_buf`/`node_modules_path`/`seen`/`err`/
-                                    // `skipped_due_to_missing_bin` are touched).
-                                    ZStr::from_raw(r.as_bytes().as_ptr(), r.len())
-                                };
-
-                                if entry_name.len()
-                                    >= self.abs_dest_buf.len().saturating_sub(abs_dest_dir_end)
-                                {
-                                    self.err = Some(crate::Error::Sys(
-                                        bun_errno::SystemErrno::ENAMETOOLONG,
-                                    ));
-                                    return;
-                                }
-                                dest_off = abs_dest_dir_end;
-                                self.abs_dest_buf[dest_off..dest_off + entry_name.len()]
-                                    .copy_from_slice(entry_name);
-                                dest_off += entry_name.len();
-                                self.abs_dest_buf[dest_off] = 0;
-                                let abs_dest_len = dest_off;
-                                // SAFETY: abs_dest_buf[abs_dest_len] == 0 written above; see note above.
-                                let abs_dest = ZStr::from_raw(abs_dest_buf_ptr, abs_dest_len);
-
-                                self.link_bin_or_create_shim(abs_target, abs_dest, global, true);
-                            }
-                            _ => {}
-                        }
+                        _ => {}
                     }
                 }
             }
@@ -1845,7 +1774,7 @@ impl<'a> Linker<'a> {
     }
 
     pub fn unlink(&mut self, global: bool) {
-        let (Some(package_dir_len), Some(mut dest_off)) = (
+        let (Some(package_dir_len), Some(dest_off)) = (
             self.build_target_package_dir(),
             self.build_destination_dir(global),
         ) else {
@@ -1855,136 +1784,138 @@ impl<'a> Linker<'a> {
 
         debug_assert!(self.bin.tag != Tag::None);
 
-        // see `link()` — detach abs_target_buf borrow via raw ptr.
-        let abs_target_buf_ptr: *const u8 = self.abs_target_buf.as_ptr();
-        // SAFETY: abs_target_buf is not written between here and use.
-        let package_dir = unsafe { bun_core::ffi::slice(abs_target_buf_ptr, package_dir_len) };
+        // `package_dir` lives in `abs_target_buf`; hold it outside `self` for the body.
+        let abs_target_buf = core::mem::take(&mut self.abs_target_buf);
+        self.unlink_with_buf(package_dir_len, dest_off, abs_target_buf);
+        self.abs_target_buf = abs_target_buf;
+    }
 
-        // SAFETY: tag determines the active union field
-        unsafe {
-            match self.bin.tag {
-                Tag::None => {}
-                Tag::File => {
-                    let unscoped_package_name =
-                        Dependency::unscoped_package_name(self.package_name.slice());
-                    if unscoped_package_name.len()
-                        >= self.abs_dest_buf.len().saturating_sub(dest_off)
+    fn unlink_with_buf(
+        &mut self,
+        package_dir_len: usize,
+        mut dest_off: usize,
+        abs_target_buf: &[u8],
+    ) {
+        let package_dir = &abs_target_buf[..package_dir_len];
+
+        match self.bin.tag {
+            Tag::None => {}
+            Tag::File => {
+                let unscoped_package_name =
+                    Dependency::unscoped_package_name(self.package_name.slice());
+                if unscoped_package_name.len() >= self.abs_dest_buf.len().saturating_sub(dest_off) {
+                    self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+                    return;
+                }
+                self.abs_dest_buf[dest_off..dest_off + unscoped_package_name.len()]
+                    .copy_from_slice(unscoped_package_name);
+                dest_off += unscoped_package_name.len();
+                self.abs_dest_buf[dest_off] = 0;
+                let abs_dest_len = dest_off;
+                let abs_dest = ZStr::from_buf(self.abs_dest_buf, abs_dest_len);
+
+                Self::unlink_bin_or_shim(abs_dest);
+            }
+            Tag::NamedFile => {
+                let named = self.bin.value.named_file();
+                let name = named[0].slice(self.string_buf);
+                let normalized_name = normalized_bin_name(name);
+                if normalized_name.is_empty() {
+                    return;
+                }
+                if normalized_name.len() >= self.abs_dest_buf.len().saturating_sub(dest_off) {
+                    self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+                    return;
+                }
+
+                self.abs_dest_buf[dest_off..dest_off + normalized_name.len()]
+                    .copy_from_slice(normalized_name);
+                dest_off += normalized_name.len();
+                self.abs_dest_buf[dest_off] = 0;
+                let abs_dest_len = dest_off;
+                let abs_dest = ZStr::from_buf(self.abs_dest_buf, abs_dest_len);
+
+                Self::unlink_bin_or_shim(abs_dest);
+            }
+            Tag::Map => {
+                let mut i = self.bin.value.map().begin();
+                let end = self.bin.value.map().end();
+
+                let abs_dest_dir_end = dest_off;
+
+                while i < end {
+                    let bin_dest = self.extern_string_buf[i as usize].slice(self.string_buf);
+                    let normalized_bin_dest = normalized_bin_name(bin_dest);
+                    if normalized_bin_dest.is_empty() {
+                        i += 2;
+                        continue;
+                    }
+                    if normalized_bin_dest.len()
+                        >= self.abs_dest_buf.len().saturating_sub(abs_dest_dir_end)
                     {
                         self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
                         return;
                     }
-                    self.abs_dest_buf[dest_off..dest_off + unscoped_package_name.len()]
-                        .copy_from_slice(unscoped_package_name);
-                    dest_off += unscoped_package_name.len();
+
+                    dest_off = abs_dest_dir_end;
+                    self.abs_dest_buf[dest_off..dest_off + normalized_bin_dest.len()]
+                        .copy_from_slice(normalized_bin_dest);
+                    dest_off += normalized_bin_dest.len();
                     self.abs_dest_buf[dest_off] = 0;
                     let abs_dest_len = dest_off;
                     let abs_dest = ZStr::from_buf(self.abs_dest_buf, abs_dest_len);
 
                     Self::unlink_bin_or_shim(abs_dest);
+
+                    i += 2;
                 }
-                Tag::NamedFile => {
-                    let named = self.bin.value.named_file;
-                    let name = named[0].slice(self.string_buf);
-                    let normalized_name = normalized_bin_name(name);
-                    if normalized_name.is_empty() {
+            }
+            Tag::Dir => {
+                let dir = self.bin.value.dir();
+                let target = dir.slice(self.string_buf);
+                if target.is_empty() {
+                    return;
+                }
+
+                let abs_target_dir =
+                    resolve_path::join_abs_string_z::<PlatformAuto>(package_dir, &[target]);
+
+                let target_dir = match sys::open_dir_absolute(abs_target_dir.as_bytes()) {
+                    Ok(d) => d,
+                    Err(err) => {
+                        self.err = Some(err.into());
                         return;
                     }
-                    if normalized_name.len() >= self.abs_dest_buf.len().saturating_sub(dest_off) {
-                        self.err = Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
-                        return;
-                    }
+                };
+                let _close = scopeguard::guard(target_dir, |fd| {
+                    let _ = sys::close(fd);
+                });
 
-                    self.abs_dest_buf[dest_off..dest_off + normalized_name.len()]
-                        .copy_from_slice(normalized_name);
-                    dest_off += normalized_name.len();
-                    self.abs_dest_buf[dest_off] = 0;
-                    let abs_dest_len = dest_off;
-                    let abs_dest = ZStr::from_buf(self.abs_dest_buf, abs_dest_len);
+                let abs_dest_dir_end = dest_off;
 
-                    Self::unlink_bin_or_shim(abs_dest);
-                }
-                Tag::Map => {
-                    let mut i = self.bin.value.map.begin();
-                    let end = self.bin.value.map.end();
-
-                    let abs_dest_dir_end = dest_off;
-
-                    while i < end {
-                        let bin_dest = self.extern_string_buf[i as usize].slice(self.string_buf);
-                        let normalized_bin_dest = normalized_bin_name(bin_dest);
-                        if normalized_bin_dest.is_empty() {
-                            i += 2;
-                            continue;
-                        }
-                        if normalized_bin_dest.len()
-                            >= self.abs_dest_buf.len().saturating_sub(abs_dest_dir_end)
-                        {
-                            self.err =
-                                Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
-                            return;
-                        }
-
-                        dest_off = abs_dest_dir_end;
-                        self.abs_dest_buf[dest_off..dest_off + normalized_bin_dest.len()]
-                            .copy_from_slice(normalized_bin_dest);
-                        dest_off += normalized_bin_dest.len();
-                        self.abs_dest_buf[dest_off] = 0;
-                        let abs_dest_len = dest_off;
-                        let abs_dest = ZStr::from_buf(self.abs_dest_buf, abs_dest_len);
-
-                        Self::unlink_bin_or_shim(abs_dest);
-
-                        i += 2;
-                    }
-                }
-                Tag::Dir => {
-                    let dir = self.bin.value.dir;
-                    let target = dir.slice(self.string_buf);
-                    if target.is_empty() {
-                        return;
-                    }
-
-                    let abs_target_dir =
-                        resolve_path::join_abs_string_z::<PlatformAuto>(package_dir, &[target]);
-
-                    let target_dir = match sys::open_dir_absolute(abs_target_dir.as_bytes()) {
-                        Ok(d) => d,
-                        Err(err) => {
-                            self.err = Some(err.into());
-                            return;
-                        }
-                    };
-                    let _close = scopeguard::guard(target_dir, |fd| {
-                        let _ = sys::close(fd);
-                    });
-
-                    let abs_dest_dir_end = dest_off;
-
-                    let mut iter = sys::iterate_dir(target_dir);
-                    while let Some(entry) = iter.next().unwrap_or(None) {
-                        match entry.kind {
-                            sys::EntryKind::SymLink | sys::EntryKind::File => {
-                                let entry_name = entry.name.slice_u8();
-                                if entry_name.len()
-                                    >= self.abs_dest_buf.len().saturating_sub(abs_dest_dir_end)
-                                {
-                                    self.err = Some(crate::Error::Sys(
-                                        bun_errno::SystemErrno::ENAMETOOLONG,
-                                    ));
-                                    return;
-                                }
-                                dest_off = abs_dest_dir_end;
-                                self.abs_dest_buf[dest_off..dest_off + entry_name.len()]
-                                    .copy_from_slice(entry_name);
-                                dest_off += entry_name.len();
-                                self.abs_dest_buf[dest_off] = 0;
-                                let abs_dest_len = dest_off;
-                                let abs_dest = ZStr::from_buf(self.abs_dest_buf, abs_dest_len);
-
-                                Self::unlink_bin_or_shim(abs_dest);
+                let mut iter = sys::iterate_dir(target_dir);
+                while let Some(entry) = iter.next().unwrap_or(None) {
+                    match entry.kind {
+                        sys::EntryKind::SymLink | sys::EntryKind::File => {
+                            let entry_name = entry.name.slice_u8();
+                            if entry_name.len()
+                                >= self.abs_dest_buf.len().saturating_sub(abs_dest_dir_end)
+                            {
+                                self.err =
+                                    Some(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+                                return;
                             }
-                            _ => {}
+                            dest_off = abs_dest_dir_end;
+                            self.abs_dest_buf[dest_off..dest_off + entry_name.len()]
+                                .copy_from_slice(entry_name);
+                            dest_off += entry_name.len();
+                            self.abs_dest_buf[dest_off] = 0;
+                            let abs_dest_len = dest_off;
+                            let abs_dest = ZStr::from_buf(self.abs_dest_buf, abs_dest_len);
+
+                            Self::unlink_bin_or_shim(abs_dest);
                         }
+                        _ => {}
                     }
                 }
             }

--- a/src/install/dedupe.rs
+++ b/src/install/dedupe.rs
@@ -7,9 +7,9 @@ use bun_collections::{DynamicBitSet, index_sort};
 use bun_core::{Global, Output, UnwrapOrOom as _, strings};
 
 use crate::lockfile::package::PackageColumns as _;
-use crate::lockfile::{LoadResult, Lockfile, Package, PackageIndexEntry};
+use crate::lockfile::{Lockfile, Package, PackageIndexEntry};
 use crate::package_manager::Options::{Enable, LogLevel};
-use crate::package_manager::ROOT_PACKAGE_JSON_PATH;
+use crate::package_manager::root_package_json_path;
 use crate::{
     Dependency, DependencyID, DependencyVersionTag, Features, GetJsonResult, PackageID,
     PackageManager, ResolutionTag, dependency, invalid_package_id,
@@ -628,19 +628,20 @@ fn reachable(lockfile: &Lockfile, resolutions: &[PackageID]) -> DynamicBitSet {
 
 pub fn dedupe_before_install(
     manager: &mut PackageManager,
-    load_result: &LoadResult<'_>,
+    load_result: &crate::lockfile::DetachedLoadResult,
 ) -> crate::Result<()> {
+    use crate::lockfile::DetachedLoadResult;
     let quiet = manager.options.log_level == LogLevel::Silent;
 
     match load_result {
-        LoadResult::NotFound => {
+        DetachedLoadResult::NotFound => {
             if !quiet {
                 Output::err_generic("missing lockfile, nothing to dedupe", ());
                 bun_core::note!("run 'bun install' first");
             }
             Global::exit(1);
         }
-        LoadResult::Err(cause) => {
+        DetachedLoadResult::Err(cause) => {
             if crate::migration::reported_unsupported_lockfile_version(cause) {
                 Global::exit(1);
             }
@@ -649,11 +650,11 @@ pub fn dedupe_before_install(
                     "failed to {s} lockfile: {s}",
                     (cause.step.verb(), cause.value.name()),
                 );
-                print_log_errors(manager.log_mut());
+                print_log_errors(&manager.log);
             }
             Global::crash();
         }
-        LoadResult::Ok(_) => {}
+        DetachedLoadResult::Ok(_) => {}
     }
 
     if manager
@@ -683,14 +684,14 @@ fn print_log_errors(log: &bun_ast::Log) {
 
 fn package_json_declares_dependencies(manager: &mut PackageManager) -> crate::Result<bool> {
     let quiet = manager.options.log_level == LogLevel::Silent;
-    let log = manager.log_mut();
-    // SAFETY: written once inside `PackageManager::init` on this thread; only read afterwards.
-    let path: &[u8] = unsafe { ROOT_PACKAGE_JSON_PATH.read() }.as_bytes();
-    let (source, json) =
-        match manager
-            .workspace_package_json_cache
-            .get_with_path(log, path, Default::default())
-        {
+    let path: &[u8] = root_package_json_path().as_bytes();
+    let (source, json) = {
+        let PackageManager {
+            log,
+            workspace_package_json_cache,
+            ..
+        } = &mut *manager;
+        match workspace_package_json_cache.get_with_path(log, path, Default::default()) {
             GetJsonResult::Entry(entry) => (entry.source.clone(), entry.root),
             GetJsonResult::ReadErr(err) | GetJsonResult::ParseErr(err) => {
                 if !quiet {
@@ -699,22 +700,25 @@ fn package_json_declares_dependencies(manager: &mut PackageManager) -> crate::Re
                 }
                 Global::exit(1);
             }
-        };
+        }
+    };
 
     let mut lockfile = Lockfile::default();
     let mut root = Package::default();
     let mut resolver: () = ();
-    if let Err(err) = root.parse_with_json::<()>(
-        &mut lockfile,
-        manager,
-        log,
-        &source,
-        json,
-        &mut resolver,
-        Features::main(),
-    ) {
+    if let Err(err) = manager.with_log(|manager, log| {
+        root.parse_with_json::<()>(
+            &mut lockfile,
+            manager,
+            log,
+            &source,
+            json,
+            &mut resolver,
+            Features::main(),
+        )
+    }) {
         if !quiet {
-            print_log_errors(log);
+            print_log_errors(&manager.log);
         }
         return Err(err);
     }

--- a/src/install/dependency.rs
+++ b/src/install/dependency.rs
@@ -306,7 +306,6 @@ const SIZE: usize = core::mem::size_of::<VersionExternal>()
     + core::mem::size_of::<String>();
 
 pub struct Context<'a> {
-    // allocator dropped (global mimalloc)
     pub(crate) log: &'a mut bun_ast::Log,
     pub(crate) buffer: &'a [u8],
     pub(crate) package_manager: Option<&'a mut PackageManager>,
@@ -316,7 +315,6 @@ pub(crate) fn to_dependency(this: External, ctx: &mut Context<'_>) -> Dependency
     let name = String {
         bytes: this[0..8].try_into().expect("infallible: size matches"),
     };
-    // SAFETY: same-size POD bitcast
     let name_hash: u64 =
         u64::from_ne_bytes(this[8..16].try_into().expect("infallible: size matches"));
     Dependency {
@@ -1093,6 +1091,28 @@ pub fn parse<'a, 'b>(
     )
 }
 
+/// [`parse`] for callers that hold only the npm-alias registry (e.g. a
+/// split-borrowed `PackageManager`).
+pub fn parse_with_alias_registry<'a>(
+    alias: String,
+    alias_hash: Option<PackageNameHash>,
+    dependency: &[u8],
+    sliced: &SlicedString,
+    log: Option<&'a mut bun_ast::Log>,
+    registry: Option<&mut dyn NpmAliasRegistry>,
+) -> Option<Version> {
+    let dep = strings::trim_left(dependency, b" \t\n\r");
+    parse_with_tag(
+        alias,
+        alias_hash,
+        dep,
+        Tag::infer(dep),
+        sliced,
+        log,
+        registry,
+    )
+}
+
 pub(crate) fn parse_with_optional_tag<'a, 'b>(
     alias: String,
     alias_hash: impl Into<Option<PackageNameHash>>,
@@ -1164,7 +1184,6 @@ pub(crate) fn parse_with_tag(
             let version = match Semver::query::parse(input, sliced.sub(input)) {
                 Ok(v) => v,
                 Err(_e) => {
-                    // error.OutOfMemory => bun.outOfMemory()
                     bun_core::out_of_memory();
                 }
             };

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -33,14 +33,14 @@ pub struct ExtractTarball {
     pub(crate) dependency_id: DependencyID,
     pub(crate) skip_verify: bool, // = false
     pub(crate) in_trusted_dependencies: bool,
-    pub(crate) integrity: Integrity, // = Integrity::default()
+    pub(crate) integrity: Integrity,
     pub(crate) url: StringOrTinyString,
     /// The lockfile's bun-tag (`repository.resolved`) for a Github resolution,
     /// copied out because extract workers must not read lockfile buffers. When
     /// set it names the cache folder and `.bun-tag` (cache lookups are keyed by
     /// it); empty on a fresh resolve, which uses the archive's root dir name.
     pub(crate) github_resolved: StringOrTinyString,
-    /// BACKREF: PackageManager owns the task pool that owns this struct.
+    /// The manager outlives every task that carries this.
     pub(crate) package_manager: bun_ptr::BackRef<PackageManager>,
 }
 
@@ -169,8 +169,8 @@ struct TlBufs {
 }
 
 thread_local! {
-    // bun.ThreadlocalBuffers: lazily heap-allocate so only a Box pointer lives in TLS
-    // (keeps PT_TLS MemSiz small — see test/js/bun/binary/tls-segment-size).
+    // Heap-allocated so only a Box pointer lives in TLS (keeps PT_TLS MemSiz
+    // small — see test/js/bun/binary/tls-segment-size).
     static TL_BUFS: RefCell<Box<TlBufs>> = RefCell::new(Box::new(TlBufs {
         final_path_buf: PathBuffer::ZEROED,
         folder_name_buf: PathBuffer::ZEROED,
@@ -284,7 +284,6 @@ impl ExtractTarball {
             use bun_libarchive::Archiver;
             let mut zlib_pool = Npm::Registry::BodyPool::get();
             zlib_pool.reset();
-            // `defer Npm.Registry.BodyPool.release(zlib_pool)` → PoolGuard's Drop releases.
 
             let time_started_for_verbose_logs: u64 = if PackageManager::verbose_install() {
                 bun_core::Timespec::now_allow_mocked_time().ns()
@@ -784,7 +783,7 @@ impl ExtractTarball {
                     }
                 };
                 json_buf = buf;
-                // `defer json_file.close()` → close after resolving path.
+                // Closed after resolving its path.
                 json_path = match json_file.get_path(&mut bufs.json_path_buf) {
                     Ok(p) => p,
                     Err(err) => {
@@ -868,9 +867,6 @@ impl ExtractTarball {
 
             let ret_json_path = FileSystem::instance().dirname_store().append(json_path)?;
 
-            // Lands in `Task.data.*` (untagged `ManuallyDrop` union); freed by
-            // `Task::deinit_payload()` at the `runTasks.rs` re-pool site, which
-            // calls it before `preallocated_resolve_tasks.put()`.
             Ok(ExtractData {
                 url: url.into(),
                 resolved: resolved.into(),

--- a/src/install/git_runner.rs
+++ b/src/install/git_runner.rs
@@ -2,8 +2,6 @@
 
 use core::cell::Cell;
 use core::ffi::{CStr, c_void};
-use core::mem::ManuallyDrop;
-use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 use std::ffi::CString;
 
@@ -17,11 +15,10 @@ use bun_paths as Path;
 use bun_ptr::{BackRef, JsCell, RefPtr, ThisPtr};
 #[cfg(unix)]
 use bun_spawn::SpawnResultExt as _;
-use bun_spawn::{Process, ProcessHandle, Rusage, SpawnEnv, SpawnOptions, Status};
+use bun_spawn::{ProcessHandle, SpawnEnv, SpawnOptions, Status};
 use bun_sys::Fd;
 #[cfg(windows)]
 use bun_sys::windows::libuv as uv;
-use bun_threading::thread_pool as ThreadPool;
 
 use crate::install::{ExtractData, ExtractDataJson};
 use crate::package_manager_task::{self as Task, Tag};
@@ -30,9 +27,14 @@ use crate::{Error, PackageManager};
 
 impl PackageManager {
     /// Queues a git task; it counts as pending from now on.
-    pub(crate) fn enqueue_git_task(&mut self, task: NonNull<Task::Task<'static>>) {
+    pub(crate) fn enqueue_git_task(&mut self, task: Box<Task::Task>) {
         self.increment_pending_tasks(1);
         self.git_tasks.push_back(task);
+    }
+
+    /// The environment for the `git` children, built on first use.
+    pub(crate) fn git_env(&self) -> &GitEnv {
+        self.git_env.get_or_init(|| GitEnv::new(self.env()))
     }
 
     /// Called from `schedule_tasks`; a finished task does not start the next one itself.
@@ -43,7 +45,8 @@ impl PackageManager {
                 break;
             };
             self.running_git_tasks.fetch_add(1, Ordering::Relaxed);
-            GitSubprocess::start(self, task);
+            let cache_dir = self.get_cache_directory();
+            GitSubprocess::start(self, cache_dir, task);
         }
     }
 }
@@ -80,30 +83,22 @@ pub(crate) enum Finalize {
 
 impl Finalize {
     /// Completes `task` from its `git_finalize`. Thread-pool side.
-    pub(crate) fn run(task: &mut Task::Task<'_>) {
+    pub(crate) fn run(task: &mut Task::Task) {
         let finalize = task
             .git_finalize
             .take()
             .expect("a clone or checkout task carries its finalize step");
         let result = match finalize {
-            Finalize::Repo(fd) => Ok(Task::Data {
-                git_clone: ManuallyDrop::new(fd),
-            }),
+            Finalize::Repo(fd) => Ok(Task::Data::GitClone(fd)),
             Finalize::PublishRepo(staging) => {
                 let name = task.request_git_clone().name.slice().to_vec();
                 staging
                     .publish(&mut task.log, &name, &bare_repo_folder_name(task.id))
-                    .map(|dir| Task::Data {
-                        git_clone: ManuallyDrop::new(dir.into_raw()),
-                    })
+                    .map(|dir| Task::Data::GitClone(dir.into_raw()))
             }
-            Finalize::CachedCheckout(dir) => read_package_json(task, dir).map(|data| Task::Data {
-                git_checkout: ManuallyDrop::new(data),
-            }),
+            Finalize::CachedCheckout(dir) => read_package_json(task, dir).map(Task::Data::Extract),
             Finalize::PublishCheckout(staging) => {
-                finish_checkout(task, staging).map(|data| Task::Data {
-                    git_checkout: ManuallyDrop::new(data),
-                })
+                finish_checkout(task, staging).map(Task::Data::Extract)
             }
             Finalize::Failed { staging, err } => {
                 if let Some(staging) = staging {
@@ -121,14 +116,9 @@ impl Finalize {
             Err(err) => {
                 task.status = Task::Status::Fail;
                 task.err = Some(err);
-                // `deinit_payload` drops the active `data` arm, so a failure writes one too.
-                task.data = match task.tag {
-                    Tag::GitClone => Task::Data {
-                        git_clone: ManuallyDrop::new(Fd::invalid()),
-                    },
-                    _ => Task::Data {
-                        git_checkout: ManuallyDrop::new(ExtractData::default()),
-                    },
+                task.data = match task.tag() {
+                    Tag::GitClone => Task::Data::GitClone(Fd::invalid()),
+                    _ => Task::Data::Extract(ExtractData::default()),
                 };
             }
         }
@@ -136,7 +126,7 @@ impl Finalize {
 }
 
 /// Strips the fresh checkout in `staging`, moves it into the cache, and reads its `package.json`.
-fn finish_checkout(task: &mut Task::Task<'_>, staging: CacheStaging) -> Result<ExtractData, Error> {
+fn finish_checkout(task: &mut Task::Task, staging: CacheStaging) -> Result<ExtractData, Error> {
     let req = task.request_git_checkout();
     let (name, resolved) = (req.name.slice().to_vec(), req.resolved.slice().to_vec());
 
@@ -190,7 +180,7 @@ fn finish_checkout(task: &mut Task::Task<'_>, staging: CacheStaging) -> Result<E
 
 /// Closes `package_dir`.
 fn read_package_json(
-    task: &mut Task::Task<'_>,
+    task: &mut Task::Task,
     package_dir: bun_sys::Dir,
 ) -> Result<ExtractData, Error> {
     let req = task.request_git_checkout();
@@ -346,9 +336,10 @@ pub(crate) struct GitSubprocess {
     ref_count: Cell<u32>,
     /// The single owning ref; `release` drops it and frees the runner.
     owner: Cell<Option<RefPtr<GitSubprocess>>>,
-    manager: BackRef<PackageManager, bun_ptr::Mut>,
-    /// Ours alone until `finish_on_pool` / `finish_commit` hands it on.
-    task: NonNull<Task::Task<'static>>,
+    /// Read-only here; the manager is leaked for the process.
+    manager: BackRef<PackageManager>,
+    /// `Some` until `finish_on_pool` / `finish_commit` hands it on.
+    task: JsCell<Option<Box<Task::Task>>>,
     tag: Tag,
     name: Box<[u8]>,
     event_loop: EventLoopHandle,
@@ -369,25 +360,20 @@ pub(crate) struct GitSubprocess {
 }
 
 impl GitSubprocess {
-    fn start(manager: &mut PackageManager, task: NonNull<Task::Task<'static>>) {
-        let cache_dir = manager.get_cache_directory();
+    fn start(manager: &mut PackageManager, cache_dir: Fd, task: Box<Task::Task>) {
         let event_loop = EventLoopHandle::from_any(&mut manager.event_loop);
-        // SAFETY: a queued git task is live and idle until its runner hands it on.
-        let (tag, name) = unsafe {
-            let t = task.as_ref();
-            let name: Box<[u8]> = match t.tag {
-                Tag::GitClone => t.request_git_clone().name.slice().into(),
-                Tag::GitCommit => t.request_git_commit().name.slice().into(),
-                Tag::GitCheckout => t.request_git_checkout().name.slice().into(),
-                _ => unreachable!("not a git task"),
-            };
-            (t.tag, name)
+        let tag = task.tag();
+        let name: Box<[u8]> = match tag {
+            Tag::GitClone => task.request_git_clone().name.slice().into(),
+            Tag::GitCommit => task.request_git_commit().name.slice().into(),
+            Tag::GitCheckout => task.request_git_checkout().name.slice().into(),
+            _ => unreachable!("not a git task"),
         };
         let runner = RefPtr::new(GitSubprocess {
             ref_count: Cell::new(1),
             owner: Cell::new(None),
-            manager: BackRef::new_mut(manager),
-            task,
+            manager: BackRef::new(manager),
+            task: JsCell::new(Some(task)),
             tag,
             name,
             event_loop,
@@ -420,21 +406,24 @@ impl GitSubprocess {
     }
 
     /// Call-scoped access to the task; see the field comment.
-    #[allow(clippy::mut_from_ref)]
-    fn task(&self) -> &mut Task::Task<'static> {
-        // SAFETY: the task is owned by `preallocated_resolve_tasks` and touched by
-        // nothing else while this runner holds it; every borrow here is call-scoped.
-        unsafe { &mut *self.task.as_ptr() }
+    fn with_task<R>(&self, f: impl FnOnce(&mut Task::Task) -> R) -> R {
+        self.task
+            .with_mut(|t| f(t.as_deref_mut().expect("the runner still holds its task")))
+    }
+
+    fn take_task(&self) -> Box<Task::Task> {
+        self.task
+            .with_mut(Option::take)
+            .expect("the runner still holds its task")
     }
 
     fn log_error(&self, args: core::fmt::Arguments<'_>) {
-        self.task()
-            .log
-            .add_error_fmt(None, bun_ast::Loc::EMPTY, args);
+        self.with_task(|t| t.log.add_error_fmt(None, bun_ast::Loc::EMPTY, args));
     }
 
     fn new_staging(&self) -> Result<Vec<u8>, Error> {
-        let staging = CacheStaging::new(self.cache_dir, &self.manager().cache_directory_path)?;
+        let staging =
+            CacheStaging::new(self.cache_dir, self.manager().cache_directory_path.as_bytes())?;
         let tmp_path = staging.tmp_path.clone();
         self.staging.set(Some(staging));
         Ok(tmp_path)
@@ -445,7 +434,7 @@ impl GitSubprocess {
     /// May free `this` on `Ok`.
     fn begin_clone(this: ThisPtr<Self>) -> Result<(), Error> {
         bun_analytics::features::git_dependencies.fetch_add(1, Ordering::Relaxed);
-        let url = this.task().request_git_clone().url.slice().to_vec();
+        let url = this.with_task(|t| t.request_git_clone().url.slice().to_vec());
         // Pushed in reverse so `pop` yields the https form first.
         this.urls.with_mut(|urls| {
             urls.extend(Repository::try_ssh(&url));
@@ -457,7 +446,7 @@ impl GitSubprocess {
 
         let offline = this.manager().options.offline
             == crate::package_manager_real::options::OfflineMode::Offline;
-        let folder_name = bare_repo_folder_name(this.task().id);
+        let folder_name = bare_repo_folder_name(this.with_task(|t| t.id));
         match bun_sys::Dir::borrow(&this.cache_dir)
             .open_dir_z(&bun_core::ZBox::from_bytes(&folder_name))
         {
@@ -468,7 +457,7 @@ impl GitSubprocess {
                     return Ok(());
                 }
                 let path = Path::resolve_path::join_abs_string::<Path::platform::Auto>(
-                    &this.manager().cache_directory_path,
+                    this.manager().cache_directory_path.as_bytes(),
                     &[&folder_name],
                 )
                 .to_vec();
@@ -515,11 +504,13 @@ impl GitSubprocess {
 
     /// May free `this` on `Ok`.
     fn begin_commit(this: ThisPtr<Self>) -> Result<(), Error> {
-        let req = this.task().request_git_commit();
-        let committish = req.committish.slice().to_vec();
+        let (clone_id, committish) = this.with_task(|t| {
+            let req = t.request_git_commit();
+            (req.clone_id, req.committish.slice().to_vec())
+        });
         let path = Path::resolve_path::join_abs_string::<Path::platform::Auto>(
-            &this.manager().cache_directory_path,
-            &[&bare_repo_folder_name(req.clone_id)],
+            this.manager().cache_directory_path.as_bytes(),
+            &[&bare_repo_folder_name(clone_id)],
         )
         .to_vec();
         this.step.set(Step::Log);
@@ -546,9 +537,10 @@ impl GitSubprocess {
     /// May free `this` on `Ok`.
     fn begin_checkout(this: ThisPtr<Self>) -> Result<(), Error> {
         bun_analytics::features::git_dependencies.fetch_add(1, Ordering::Relaxed);
-        let req = this.task().request_git_checkout();
-        let repo_dir = req.repo_dir;
-        let resolved = req.resolved.slice().to_vec();
+        let (repo_dir, resolved) = this.with_task(|t| {
+            let req = t.request_git_checkout();
+            (req.repo_dir, req.resolved.slice().to_vec())
+        });
         if !is_safe_resolved_tag(&resolved) {
             this.log_error(format_args!(
                 "invalid git commit \"{}\" for \"{}\"",
@@ -593,7 +585,8 @@ impl GitSubprocess {
     /// Spawns `git <args>` with stdout and stderr captured. On `Ok` the child
     /// may already have exited and freed `this`.
     fn spawn(this: ThisPtr<Self>, args: &[&[u8]]) -> Result<(), Error> {
-        let env = GitEnv::get(this.manager().env_mut());
+        let manager = this.manager();
+        let env = manager.git_env();
         let Some(git) = &env.git else {
             this.log_error(format_args!(
                 "\"git\" is not installed (needed for \"{}\")",
@@ -711,7 +704,7 @@ impl GitSubprocess {
             Ok(true) => {}
             Err(err) => {
                 if !process.has_exited() {
-                    process.on_exit(Status::Err(err), &bun_core::ffi::zeroed::<Rusage>());
+                    process.on_exit(Status::Err(err), &bun_spawn::process::rusage_zeroed());
                 }
             }
         }
@@ -729,7 +722,7 @@ impl GitSubprocess {
     }
 
     /// May free `this`.
-    fn on_process_exit(this: ThisPtr<Self>, _: &Process, status: Status, _: &Rusage) {
+    fn on_process_exit(this: ThisPtr<Self>, status: Status) {
         this.exit_status.set(Some(status));
         Self::maybe_finished(this);
     }
@@ -832,7 +825,8 @@ impl GitSubprocess {
                         .expect("checkout has a staging folder")
                         .tmp_path
                         .clone();
-                    let resolved = this.task().request_git_checkout().resolved.slice().to_vec();
+                    let resolved =
+                        this.with_task(|t| t.request_git_checkout().resolved.slice().to_vec());
                     this.step.set(Step::Checkout);
                     this.reset_polls();
                     // `is_safe_resolved_tag` rejected a leading `-`: not a git option.
@@ -909,40 +903,31 @@ impl GitSubprocess {
     }
 
     /// Hands a clone or checkout task to the thread pool for `finalize`.
-    /// `Task::callback` pushes the task onto `resolve_tasks`. Frees `this`.
+    /// `Task::run_owned` pushes the task onto `resolve_tasks`. Frees `this`.
     fn finish_on_pool(this: ThisPtr<Self>, finalize: Finalize) {
         debug_assert!(this.tag != Tag::GitCommit);
         let manager = this.manager;
-        let task = this.task;
-        this.task().git_finalize = Some(finalize);
+        let mut task = this.take_task();
+        task.git_finalize = Some(finalize);
         Self::release(this);
-        // SAFETY: the task is idle until the pool runs it.
-        let batch = ThreadPool::Batch::from(unsafe { &raw mut (*task.as_ptr()).threadpool_task });
-        manager.thread_pool.schedule(batch);
+        manager.get().thread_pool.schedule_owned(task);
     }
 
     /// Hands the finished commit lookup to `resolve_tasks`. Frees `this`.
     fn finish_commit(this: ThisPtr<Self>, result: Result<Vec<u8>, Error>) {
         debug_assert!(this.tag == Tag::GitCommit);
-        let manager = this.manager;
-        let task_ptr = this.task;
-        {
-            let task = this.task();
-            // `deinit_payload` drops the active `data` arm, so every path writes one.
-            let (status, err, sha) = match result {
-                Ok(sha) => (Task::Status::Success, None, sha),
-                Err(err) => (Task::Status::Fail, Some(err), Vec::new()),
-            };
-            task.status = status;
-            task.err = err;
-            task.data = Task::Data {
-                git_commit: ManuallyDrop::new(sha),
-            };
-        }
+        let shared = this.manager().shared;
+        let mut task = this.take_task();
+        let (status, err, sha) = match result {
+            Ok(sha) => (Task::Status::Success, None, sha),
+            Err(err) => (Task::Status::Fail, Some(err), Vec::new()),
+        };
+        task.status = status;
+        task.err = err;
+        task.data = Task::Data::GitCommit(sha);
         Self::release(this);
-        manager.resolve_tasks.push(task_ptr);
-        // SAFETY: the manager outlives every task; see `wake_raw`.
-        unsafe { PackageManager::wake_raw(manager.as_ptr()) };
+        shared.resolve_tasks.push(task);
+        shared.wake();
     }
 }
 
@@ -960,18 +945,17 @@ impl Drop for GitSubprocess {
 bun_spawn::link_impl_ProcessExit! {
     InstallGit for GitSubprocess => |this| {
         // SAFETY: `this` is the live runner installed via `set_exit_handler`.
-        on_process_exit(process, status, rusage) =>
-            GitSubprocess::on_process_exit(ThisPtr::new(this), &*process, status, rusage),
+        on_process_exit(_process, status, _rusage) =>
+            GitSubprocess::on_process_exit(ThisPtr::new(this), status),
     }
 }
 
 bun_io::impl_buffered_reader_parent! {
     InstallGit for GitSubprocess;
+    borrow = this;
     has_on_read_chunk = false;
-    // SAFETY: `this` is the live runner registered via `set_parent`.
-    on_reader_done  = |this| GitSubprocess::on_reader_done(ThisPtr::new(this));
-    // SAFETY: `this` is the live runner registered via `set_parent`.
-    on_reader_error = |this, err| GitSubprocess::on_reader_error(ThisPtr::new(this), err);
-    loop_           = |this| (*this).event_loop.native_loop();
-    event_loop      = |this| (*this).event_loop.as_event_loop_ctx();
+    on_reader_done  = |this| GitSubprocess::on_reader_done(this);
+    on_reader_error = |this, err| GitSubprocess::on_reader_error(this, err);
+    loop_           = |this| this.get().event_loop.native_loop();
+    event_loop      = |this| this.get().event_loop.as_event_loop_ctx();
 }

--- a/src/install/git_runner.rs
+++ b/src/install/git_runner.rs
@@ -422,8 +422,10 @@ impl GitSubprocess {
     }
 
     fn new_staging(&self) -> Result<Vec<u8>, Error> {
-        let staging =
-            CacheStaging::new(self.cache_dir, self.manager().cache_directory_path.as_bytes())?;
+        let staging = CacheStaging::new(
+            self.cache_dir,
+            self.manager().cache_directory_path.as_bytes(),
+        )?;
         let tmp_path = staging.tmp_path.clone();
         self.staging.set(Some(staging));
         Ok(tmp_path)

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -1,5 +1,4 @@
 use crate::lockfile::package::PackageColumns as _;
-use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 
 use bun_collections::{DynamicBitSet as Bitset, DynamicBitSetList, StringHashMap};
@@ -9,7 +8,6 @@ use bun_paths::SEP;
 use bun_sys::{self as sys, Dir, Fd};
 
 use crate::analytics;
-use crate::bun_bunfig::Arguments as Command;
 use crate::bun_fs::FileSystem;
 use crate::bun_progress::{Node as ProgressNode, Progress};
 
@@ -18,6 +16,7 @@ use crate::{DependencyID, ExtractData, PackageID};
 // Bring the `items_<field>{,_mut}()` column accessors for
 // `MultiArrayList::Slice<Package>` into scope.
 use crate::PackageManager;
+#[cfg(unix)]
 use crate::bin_real as bin;
 use crate::package_install;
 use crate::package_installer::{NodeModulesFolder, PackageInstaller, TreeContext};
@@ -26,30 +25,59 @@ use crate::package_manager_real::ProgressStrings;
 use crate::package_manager_real::run_tasks;
 use crate::package_manager_task as Task;
 
-/// `RunTasksCallbacks` impl for the hoisted-install loop, with
-/// `Ctx == PackageInstaller`.
-pub(crate) struct HoistedRunTasksCallbacks<'a>(core::marker::PhantomData<&'a mut ()>);
-
-impl<'a> run_tasks::RunTasksCallbacks for HoistedRunTasksCallbacks<'a> {
-    type Ctx = PackageInstaller<'a>;
-
-    const HAS_ON_EXTRACT: bool = true;
-    const IS_PACKAGE_INSTALLER: bool = true;
+/// `RunTasksCtx` for the hoisted-install loop: the installer owns access to
+/// the manager for the pass.
+impl run_tasks::RunTasksCtx for PackageInstaller<'_> {
+    fn manager(&mut self) -> &mut PackageManager {
+        self.manager
+    }
+    fn has_on_extract(&self) -> bool {
+        true
+    }
+    fn is_package_installer(&self) -> bool {
+        true
+    }
 
     fn on_extract_package_installer(
-        ctx: &mut Self::Ctx,
+        &mut self,
         task_id: Task::Id,
         dependency_id: DependencyID,
-        data: &mut ExtractData,
+        data: &ExtractData,
         log_level: package_manager::Options::LogLevel,
     ) {
-        ctx.install_enqueued_packages_after_extraction(task_id, dependency_id, &*data, log_level);
+        self.grow_successfully_installed();
+        self.install_enqueued_packages_after_extraction(task_id, dependency_id, data, log_level);
+    }
+
+    fn on_patch_applied(
+        &mut self,
+        install_context: &mut crate::patch_install::InstallContext,
+        pkg_id: PackageID,
+        pkg_name: bun_semver::String,
+        log_level: package_manager::Options::LogLevel,
+    ) {
+        let path = core::mem::take(&mut install_context.path);
+        self.node_modules.path = path;
+        self.current_tree_id = install_context.tree_id;
+        let resolution = self.manager.lockfile.packages.items_resolution()[pkg_id as usize];
+
+        // Downloaded, so already known to need an install.
+        let needs_verify = false;
+        let is_pending_package_install = false;
+        self.install_package_with_name_and_resolution(
+            install_context.dependency_id,
+            pkg_id,
+            log_level,
+            pkg_name,
+            &resolution,
+            needs_verify,
+            is_pending_package_install,
+        );
     }
 }
 
 pub(crate) fn install_hoisted_packages(
     this: &mut PackageManager,
-    ctx: Command::Context,
     workspace_filters: &[WorkspaceFilter],
     install_root_dependencies: bool,
     log_level: package_manager::Options::LogLevel,
@@ -57,110 +85,62 @@ pub(crate) fn install_hoisted_packages(
 ) -> crate::Result<package_install::Summary> {
     analytics::features::hoisted_bun_install.fetch_add(1, Ordering::Relaxed);
 
-    // Restore-buffers guard — side-effecting rollback,
-    // not a free. Captures `*mut PackageManager` so the guard can write back
-    // through the same provenance root the body uses (see `mgr_ptr` below).
-    let mgr_ptr: *mut PackageManager = this;
-    // SAFETY: `mgr_ptr` is freshly derived from the unique `&mut` fn param;
-    // shadowing `this` with a reborrow through it makes every body access a
-    // child of `mgr_ptr`, so the guard's later derefs keep provenance.
-    let this = unsafe { &mut *mgr_ptr };
+    let original_trees = this.lockfile.buffers.trees.clone();
+    let original_tree_dep_ids = this.lockfile.buffers.hoisted_dependencies.clone();
 
-    let original_trees = core::mem::take(&mut this.lockfile.buffers.trees);
-    let original_tree_dep_ids = core::mem::take(&mut this.lockfile.buffers.hoisted_dependencies);
-    // Put them back immediately — the rollback below restores the *taken*
-    // originals; `filter()` repopulates the live ones in-place.
-    this.lockfile.buffers.trees.clone_from(&original_trees);
-    this.lockfile
-        .buffers
-        .hoisted_dependencies
-        .clone_from(&original_tree_dep_ids);
+    let result = (|| {
+        crate::lockfile::Lockfile::filter(
+            this,
+            install_root_dependencies,
+            workspace_filters,
+            packages_to_install,
+        )?;
+        install_filtered(this, log_level)
+    })();
 
-    {
-        // `lockfile` is `Box<Lockfile>` so the heap object
-        // is disjoint from the `PackageManager` struct; snapshot raw `*mut
-        // Lockfile` and `*mut Log` first so `filter` can hold `&mut Lockfile`
-        // and `&mut PackageManager` simultaneously through `mgr_ptr`'s
-        // provenance root.
-        let log: *mut bun_ast::Log = this.log;
-        // SAFETY: `mgr_ptr` is the provenance root; `lockfile` is heap-owned
-        // via `Box`, so `*mut Lockfile` does not overlap `*mut PackageManager`.
-        let lockfile_ptr: *mut crate::lockfile::Lockfile = unsafe { &raw mut *(*mgr_ptr).lockfile };
-        // SAFETY: `log` is the always-live logger backref (never null);
-        // `mgr_ptr` see shadow-reborrow above.
-        unsafe {
-            (*lockfile_ptr).filter(
-                &mut *log,
-                &mut *mgr_ptr,
-                install_root_dependencies,
-                workspace_filters,
-                packages_to_install,
-            )?;
-        }
-    }
-    // Re-derive after `filter()` so every subsequent `this` use (progress
-    // setup through the install loop) is a fresh child of `mgr_ptr` under
-    // Stacked Borrows — `&mut *mgr_ptr` inside the block above popped the
-    // line-77 reborrow's tag.
-    // SAFETY: `mgr_ptr` is the provenance root derived from the unique `&mut`
-    // fn param; the line-77 reborrow's tag was popped by `&mut *mgr_ptr` in the
-    // block above, so no other borrow of `*mgr_ptr` is live here.
-    let this = unsafe { &mut *mgr_ptr };
+    // Restore-buffers: side-effecting rollback, not a free — `filter()`
+    // rewrote the live trees in place.
+    this.lockfile.buffers.trees = original_trees;
+    this.lockfile.buffers.hoisted_dependencies = original_tree_dep_ids;
 
-    let _restore_buffers = scopeguard::guard(
-        (original_trees, original_tree_dep_ids),
-        move |(trees, dep_ids)| {
-            // SAFETY: `mgr_ptr` is the provenance root for every body access to
-            // `this` (see shadow-reborrow above); guard runs after all body
-            // borrows have ended.
-            let this = unsafe { &mut *mgr_ptr };
-            this.lockfile.buffers.trees = trees;
-            this.lockfile.buffers.hoisted_dependencies = dep_ids;
-        },
-    );
+    result
+}
 
-    let mut download_node: ProgressNode;
+fn install_filtered(
+    this: &mut PackageManager,
+    log_level: package_manager::Options::LogLevel,
+) -> crate::Result<package_install::Summary> {
     let mut install_node: ProgressNode = ProgressNode::default();
-    let mut scripts_node: ProgressNode;
 
     if log_level.show_progress() {
-        // Hoist before the `&mut this.progress` borrow so the disjoint
-        // `this.lockfile` read doesn't overlap the live `root_node` reborrow.
         let hoisted_len = this.lockfile.buffers.hoisted_dependencies.len();
         let progress = &mut this.progress;
         progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
-        // `Progress::start` returns `&mut Node` (points into `progress.root`);
-        // keep it as a safe reborrow — it's only used to spawn the three
-        // children below and is dead before any other `this.*` write.
         let root_node = progress.start(b"", 0);
-        download_node = root_node.start(ProgressStrings::download(), 0);
+        let download_node = root_node.start(ProgressStrings::download(), 0);
         install_node = root_node.start(ProgressStrings::install(), hoisted_len);
-        scripts_node = root_node.start(ProgressStrings::script(), 0);
-        // The stored pointers target stack locals in this frame; they are
-        // cleared by `_end_progress` below before the frame returns, so
-        // `scripts_node_mut()` / `downloads_node_mut()` never observe a
-        // dangling pointer outside this call.
-        this.downloads_node = Some(core::ptr::addr_of_mut!(download_node));
-        this.scripts_node = NonNull::new(&raw mut scripts_node);
+        let scripts_node = root_node.start(ProgressStrings::script(), 0);
+        this.downloads_node = Some(download_node);
+        this.scripts_node = Some(scripts_node);
     }
 
-    // `defer { progress.root.end(); progress = .{} }`
-    let _end_progress = scopeguard::guard(log_level, move |log_level| {
-        if log_level.show_progress() {
-            // SAFETY: `mgr_ptr` provenance — see `_restore_buffers` note.
-            let this = unsafe { &mut *mgr_ptr };
-            this.progress.root.end();
-            this.progress = Progress::default();
-        }
-        // Defensive: the stored progress-node pointers target stack locals in
-        // this frame; clear them so `scripts_node_mut()` / `downloads_node_mut()`
-        // can't observe a dangling pointer after the install pass returns.
-        // SAFETY: `mgr_ptr` provenance — see `_restore_buffers` note.
-        let this = unsafe { &mut *mgr_ptr };
-        this.scripts_node = None;
-        this.downloads_node = None;
-    });
+    let result = install_with_progress(this, log_level, &mut install_node);
 
+    if log_level.show_progress() {
+        this.progress.root.end();
+        this.progress = Progress::default();
+    }
+    this.scripts_node = None;
+    this.downloads_node = None;
+
+    result
+}
+
+fn install_with_progress(
+    this: &mut PackageManager,
+    log_level: package_manager::Options::LogLevel,
+    install_node: &mut ProgressNode,
+) -> crate::Result<package_install::Summary> {
     // If there was already a valid lockfile and so we did not resolve, i.e. there was zero network activity
     // the packages could still not be in the cache dir
     // this would be a common scenario in a CI environment
@@ -218,209 +198,115 @@ pub(crate) fn install_hoisted_packages(
     let mut summary = package_install::Summary::default();
 
     {
-        // BACKREF — `Tree::Iterator` borrows the four buffer slices,
-        // and `PackageInstaller` simultaneously holds `&mut Lockfile` (plus
-        // `&[T]` column aliases into `lockfile.packages`). Snapshot raw `*const
-        // Vec<_>` headers here so the iterator's slice borrows are derived
-        // through `mgr_ptr` (the same provenance root as `installer.lockfile`),
-        // not through a `&this.lockfile.buffers.X` that the installer's `&mut
-        // Lockfile` would invalidate.
-        // SAFETY: `mgr_ptr` is the provenance root; `lockfile` is heap-owned
-        // via `Box`, so deref the Box for the heap addr.
-        // Each buffer lives at a fixed offset within it for the install pass —
-        // wrap them as `BackRef` once under a single SAFETY obligation.
-        let (lockfile_ptr, buf_trees, buf_hoisted, buf_deps, buf_strings): (
-            *mut crate::lockfile::Lockfile,
-            bun_ptr::BackRef<Vec<tree::Tree>>,
-            bun_ptr::BackRef<Vec<DependencyID>>,
-            bun_ptr::BackRef<Vec<crate::Dependency>>,
-            bun_ptr::BackRef<Vec<u8>>,
-        ) = unsafe {
-            let lockfile_ptr: *mut crate::lockfile::Lockfile = &raw mut *(*mgr_ptr).lockfile;
-            let buffers = core::ptr::addr_of_mut!((*lockfile_ptr).buffers);
-            (
-                lockfile_ptr,
-                bun_ptr::BackRef::from_raw(core::ptr::addr_of_mut!((*buffers).trees)),
-                bun_ptr::BackRef::from_raw(core::ptr::addr_of_mut!(
-                    (*buffers).hoisted_dependencies
-                )),
-                bun_ptr::BackRef::from_raw(core::ptr::addr_of_mut!((*buffers).dependencies)),
-                bun_ptr::BackRef::from_raw(core::ptr::addr_of_mut!((*buffers).string_bytes)),
-            )
-        };
-        // Safe `BackRef` view of the same heap `Lockfile` as `lockfile_ptr`
-        // (BACKREF — outlives this install pass). `From<NonNull>` is the
-        // safe constructor; the read-only column projections below go
-        // through `Deref` instead of a per-site raw deref.
-        let lockfile_ref = bun_ptr::BackRef::<crate::lockfile::Lockfile>::from(
-            core::ptr::NonNull::new(lockfile_ptr).expect("lockfile BACKREF non-null"),
-        );
-
-        // BACKREF — slices live for the duration of this block; `filter()` (the
-        // only buffer mutator) has already run.
-        let mut iterator = tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::from_slices(
-            buf_trees.as_slice(),
-            buf_hoisted.as_slice(),
-            buf_deps.as_slice(),
-            buf_strings.as_slice(),
-        );
+        let mut iterator = tree::Cursor::<{ tree::IteratorPathStyle::NodeModules }>::new();
 
         #[cfg(unix)]
         {
             bin::Linker::ensure_umask();
         }
 
-        let mut installer: PackageInstaller = 'brk: {
-            let (completed_trees, tree_ids_to_trees_the_id_depends_on) = 'trees: {
-                let trees = this.lockfile.buffers.trees.as_slice();
-                let completed_trees = Bitset::init_empty(trees.len())?;
-                let tree_ids_to_trees_the_id_depends_on =
-                    DynamicBitSetList::init_empty(trees.len(), trees.len())?;
+        let (completed_trees, tree_ids_to_trees_the_id_depends_on) = 'trees: {
+            let trees = this.lockfile.buffers.trees.as_slice();
+            let completed_trees = Bitset::init_empty(trees.len())?;
+            let tree_ids_to_trees_the_id_depends_on =
+                DynamicBitSetList::init_empty(trees.len(), trees.len())?;
 
-                {
-                    // For each tree id, traverse through it's parents and mark all visited tree
-                    // ids as dependents for the current tree parent
-                    let mut deps = Bitset::init_empty(trees.len())?;
-                    for _curr in trees {
-                        let mut curr = *_curr;
-                        tree_ids_to_trees_the_id_depends_on.set(curr.id as usize, curr.id as usize);
+            {
+                // For each tree id, traverse through it's parents and mark all visited tree
+                // ids as dependents for the current tree parent
+                let mut deps = Bitset::init_empty(trees.len())?;
+                for _curr in trees {
+                    let mut curr = *_curr;
+                    tree_ids_to_trees_the_id_depends_on.set(curr.id as usize, curr.id as usize);
 
-                        while curr.parent != tree::Tree::INVALID_ID {
-                            deps.set(curr.id as usize);
-                            tree_ids_to_trees_the_id_depends_on
-                                .set_union(curr.parent as usize, &deps.unmanaged);
-                            curr = trees[curr.parent as usize];
-                        }
-
-                        deps.unmanaged.set_all(false);
+                    while curr.parent != tree::Tree::INVALID_ID {
+                        deps.set(curr.id as usize);
+                        tree_ids_to_trees_the_id_depends_on
+                            .set_union(curr.parent as usize, &deps.unmanaged);
+                        curr = trees[curr.parent as usize];
                     }
+
+                    deps.unmanaged.set_all(false);
+                }
+            }
+
+            if cfg!(debug_assertions) {
+                if trees.len() > 0 {
+                    // last tree should only depend on one other
+                    debug_assert!(
+                        tree_ids_to_trees_the_id_depends_on
+                            .at(trees.len() - 1)
+                            .count()
+                            == 1
+                    );
+                    // and it should be itself
+                    debug_assert!(
+                        tree_ids_to_trees_the_id_depends_on
+                            .at(trees.len() - 1)
+                            .is_set(trees.len() - 1)
+                    );
+
+                    // root tree should always depend on all trees
+                    debug_assert!(tree_ids_to_trees_the_id_depends_on.at(0).count() == trees.len());
                 }
 
-                if cfg!(debug_assertions) {
-                    if trees.len() > 0 {
-                        // last tree should only depend on one other
-                        debug_assert!(
-                            tree_ids_to_trees_the_id_depends_on
-                                .at(trees.len() - 1)
-                                .count()
-                                == 1
-                        );
-                        // and it should be itself
-                        debug_assert!(
-                            tree_ids_to_trees_the_id_depends_on
-                                .at(trees.len() - 1)
-                                .is_set(trees.len() - 1)
-                        );
+                // a tree should always depend on itself
+                for j in 0..trees.len() {
+                    debug_assert!(tree_ids_to_trees_the_id_depends_on.at(j).is_set(j));
+                }
+            }
 
-                        // root tree should always depend on all trees
-                        debug_assert!(
-                            tree_ids_to_trees_the_id_depends_on.at(0).count() == trees.len()
-                        );
-                    }
+            break 'trees (completed_trees, tree_ids_to_trees_the_id_depends_on);
+        };
 
-                    // a tree should always depend on itself
-                    for j in 0..trees.len() {
-                        debug_assert!(tree_ids_to_trees_the_id_depends_on.at(j).is_set(j));
+        let force_install = this.options.enable.force_install();
+        let pkg_len = this.lockfile.packages.len();
+        let trees_count = this.lockfile.buffers.trees.len();
+        let trusted_deps = this.find_trusted_dependencies_from_update_requests();
+        let copy_trees = {
+            let self_contained = this.lockfile.self_contained_workspace_ids();
+            let mut set = Bitset::init_empty(trees_count)?;
+            if !self_contained.is_empty() {
+                for tid in 0..trees_count {
+                    let owner = this.lockfile.owning_workspace_of_tree(tid as tree::Id);
+                    if owner != 0 && self_contained.contains(&owner) {
+                        set.set(tid);
                     }
                 }
+            }
+            set
+        };
 
-                break 'trees (completed_trees, tree_ids_to_trees_the_id_depends_on);
-            };
-
-            // These slices potentially get resized during iteration
-            // so we want to make sure they're not accessible to the rest of this function
-            // to make mistakes harder
-            //
-            // BACKREF — the `PackageInstaller` slice fields are
-            // `bun_ptr::RawSlice<T>` (raw `*const [T]`, no lifetime), so
-            // wrapping each column with `RawSlice::new` stores the (ptr, len)
-            // without keeping a borrow live — no `&'a → &'a` detach
-            // round-trip needed. Derive through `lockfile_ptr` so the
-            // provenance root matches `installer.lockfile`/`installer.manager`.
-            // RawSlice invariant: `lockfile_ref` derived from `mgr_ptr`;
-            // the packages column buffers are not freed for the lifetime of
-            // `installer` (only grow, which is why
-            // `fix_cached_lockfile_package_slices` re-snapshots). Read-only
-            // projection via the safe `BackRef::Deref`.
-            let parts = lockfile_ref.packages.slice();
-            let metas = bun_ptr::RawSlice::new(parts.items_meta());
-            let bins = bun_ptr::RawSlice::new(parts.items_bin());
-            let names = bun_ptr::RawSlice::new(parts.items_name());
-            let pkg_name_hashes = bun_ptr::RawSlice::new(parts.items_name_hash());
-            let resolutions = bun_ptr::RawSlice::new(parts.items_resolution());
-
-            // Hoist the by-value reads out of the struct literal so they
-            // finish before the long-lived `&mut *mgr_ptr` borrow for
-            // `manager` begins (struct fields evaluate in source order).
-            let force_install = this.options.enable.force_install();
-            let pkg_len = this.lockfile.packages.len();
-            let trees_count = this.lockfile.buffers.trees.len();
-            let trusted_deps = this.find_trusted_dependencies_from_update_requests();
-
-            // `PackageInstaller.{manager,lockfile,progress}` are BACKREF raw
-            // pointers; copying
-            // `mgr_ptr` into them does not move `this`, so the body below
-            // keeps using `this` for `pending_task_count` / `run_tasks` /
-            // lifecycle ticks via the same provenance root.
-            break 'brk PackageInstaller {
-                manager: mgr_ptr,
-                metas,
-                bins,
-                names,
-                pkg_name_hashes,
-                resolutions,
-                lockfile: lockfile_ptr,
-                root_node_modules_folder: node_modules_folder,
-                node: &mut install_node,
-                node_modules: NodeModulesFolder {
-                    path: strings::without_trailing_slash(FileSystem::instance().top_level_dir())
-                        .to_vec(),
-                    tree_id: 0,
-                },
-                // SAFETY: `mgr_ptr` is the provenance root; raw place addr.
-                progress: unsafe { core::ptr::addr_of_mut!((*mgr_ptr).progress) },
-                skip_verify_installed_version_number,
-                skip_delete,
-                summary: &mut summary,
-                force_install,
-                successfully_installed: Bitset::init_empty(pkg_len)?,
-                command_ctx: ctx,
-                tree_ids_to_trees_the_id_depends_on,
-                completed_trees,
-                trees: 'trees: {
-                    let mut trees: Vec<TreeContext> = Vec::with_capacity(trees_count);
-                    for _i in 0..trees_count {
-                        trees.push(TreeContext {
-                            binaries: bin::PriorityQueue::init(bin::PriorityQueueContext {
-                                dependencies: buf_deps,
-                                string_buf: buf_strings,
-                            }),
-                            pending_installs: Vec::new(),
-                            install_count: 0,
-                        });
-                    }
-                    break 'trees trees.into_boxed_slice();
-                },
-                trusted_dependencies_from_update_requests: trusted_deps,
-                seen_bin_links: StringHashMap::<()>::default(),
-                destination_dir_subpath_buf: bun_paths::PathBuffer::ZEROED,
-                folder_path_buf: bun_paths::PathBuffer::ZEROED,
-                current_tree_id: tree::INVALID_ID,
-                pending_lifecycle_scripts: Vec::new(),
-                copy_trees: {
-                    let self_contained = this.lockfile.self_contained_workspace_ids();
-                    let mut set = Bitset::init_empty(trees_count)?;
-                    if !self_contained.is_empty() {
-                        for tid in 0..trees_count {
-                            let owner = this.lockfile.owning_workspace_of_tree(tid as tree::Id);
-                            if owner != 0 && self_contained.contains(&owner) {
-                                set.set(tid);
-                            }
-                        }
-                    }
-                    set
-                },
-            };
+        let mut installer = PackageInstaller {
+            manager: this,
+            root_node_modules_folder: node_modules_folder,
+            node: install_node,
+            node_modules: NodeModulesFolder {
+                path: strings::without_trailing_slash(FileSystem::instance().top_level_dir())
+                    .to_vec(),
+                tree_id: 0,
+            },
+            skip_verify_installed_version_number,
+            skip_delete,
+            summary: &mut summary,
+            force_install,
+            successfully_installed: Bitset::init_empty(pkg_len)?,
+            tree_ids_to_trees_the_id_depends_on,
+            completed_trees,
+            trees: (0..trees_count)
+                .map(|_| TreeContext {
+                    binaries: Vec::new(),
+                    pending_installs: Vec::new(),
+                    install_count: 0,
+                })
+                .collect(),
+            trusted_dependencies_from_update_requests: trusted_deps,
+            seen_bin_links: StringHashMap::<()>::default(),
+            destination_dir_subpath_buf: bun_paths::PathBuffer::ZEROED,
+            folder_path_buf: bun_paths::PathBuffer::ZEROED,
+            current_tree_id: tree::INVALID_ID,
+            pending_lifecycle_scripts: Vec::new(),
+            copy_trees,
         };
 
         installer.node_modules.path.push(SEP);
@@ -428,15 +314,23 @@ pub(crate) fn install_hoisted_packages(
         let top_level_len =
             strings::without_trailing_slash(FileSystem::instance().top_level_dir()).len() + 1;
 
-        while let Some(node_modules) = iterator.next(Some(&mut installer.completed_trees)) {
+        // Reused across folders: the dependency ids of the current
+        // `node_modules`, copied out so the lockfile is free while installing.
+        let mut dependencies: Vec<DependencyID> = Vec::new();
+        while let Some(node_modules) = iterator.next(
+            &installer.manager.lockfile,
+            Some(&mut installer.completed_trees),
+        ) {
             installer.node_modules.path.truncate(top_level_len);
             installer
                 .node_modules
                 .path
                 .extend_from_slice(node_modules.relative_path.as_bytes());
             installer.node_modules.tree_id = node_modules.tree_id;
-            let mut remaining: &[DependencyID] = node_modules.dependencies;
             installer.current_tree_id = node_modules.tree_id;
+            dependencies.clear();
+            dependencies.extend_from_slice(node_modules.dependencies);
+            let mut remaining: &[DependencyID] = &dependencies;
 
             // cache line is 64 bytes on ARM64 and x64
             // PackageIDs are 4 bytes
@@ -453,115 +347,67 @@ pub(crate) fn install_hoisted_packages(
 
                 // We want to minimize how often we call this function
                 // That's part of why we unroll this loop
-                if this.pending_task_count() > 0 {
-                    run_tasks::run_tasks::<HoistedRunTasksCallbacks>(
-                        this,
-                        &mut installer,
-                        true,
-                        log_level,
-                    )?;
-                    if !this.options.do_.install_packages() {
+                if installer.manager.pending_task_count() > 0 {
+                    run_tasks::run_tasks(&mut installer, true, log_level)?;
+                    if !installer.manager.options.do_.install_packages() {
                         return Err(crate::Error::InstallFailed);
                     }
                 }
-                this.tick_lifecycle_scripts();
-                this.report_slow_lifecycle_scripts();
+                PackageManager::tick_lifecycle_scripts(&mut installer);
+                installer.manager.report_slow_lifecycle_scripts();
             }
 
             for dependency_id in remaining {
                 installer.install_package(*dependency_id, log_level);
             }
 
-            run_tasks::run_tasks::<HoistedRunTasksCallbacks>(
-                this,
-                &mut installer,
-                true,
-                log_level,
-            )?;
-            if !this.options.do_.install_packages() {
+            run_tasks::run_tasks(&mut installer, true, log_level)?;
+            if !installer.manager.options.do_.install_packages() {
                 return Err(crate::Error::InstallFailed);
             }
 
-            this.tick_lifecycle_scripts();
-            this.report_slow_lifecycle_scripts();
+            PackageManager::tick_lifecycle_scripts(&mut installer);
+            installer.manager.report_slow_lifecycle_scripts();
         }
 
-        while this.pending_task_count() > 0 && this.options.do_.install_packages() {
-            struct Closure<'a, 'b> {
-                installer: &'a mut PackageInstaller<'b>,
-                err: Option<crate::Error>,
-                // raw `*mut` — `sleep_until`
-                // also receives this pointer, so `&mut` here would alias.
-                manager: *mut PackageManager,
-            }
-
-            impl<'a, 'b> Closure<'a, 'b> {
-                fn is_done(closure: &mut Self) -> bool {
-                    // SAFETY: `closure.manager` is the raw provenance root set
-                    // below; `sleep_until`/`tick_raw` hold no `&mut` across
-                    // this callback, so this is the unique live borrow.
-                    let manager = unsafe { &mut *closure.manager };
-                    let log_level = manager.options.log_level;
-                    if let Err(err) = run_tasks::run_tasks::<HoistedRunTasksCallbacks>(
-                        manager,
-                        closure.installer,
-                        true,
-                        log_level,
-                    ) {
-                        closure.err = Some(err);
-                    }
-
-                    if closure.err.is_some() {
-                        return true;
-                    }
-
-                    manager.report_slow_lifecycle_scripts();
-
-                    if PackageManager::verbose_install() && manager.pending_task_count() > 0 {
-                        let pending_task_count = manager.pending_task_count();
-                        if pending_task_count > 0
-                            && PackageManager::has_enough_time_passed_between_waiting_messages()
-                        {
-                            bun_core::pretty_errorln!(
-                                "<d>[PackageManager]<r> waiting for {} tasks\n",
-                                pending_task_count
-                            );
-                        }
-                    }
-
-                    manager.pending_task_count() == 0
-                        && manager.has_no_more_pending_lifecycle_scripts()
-                }
-            }
-
-            // Derive the raw provenance root *before* building the closure so
-            // both `sleep_until`'s `this` arg and `closure.manager` share the
-            // same SRW tag.
-            let mgr: *mut PackageManager = mgr_ptr;
-            let mut closure = Closure {
-                installer: &mut installer,
-                err: None,
-                manager: mgr,
-            };
-
+        while installer.manager.pending_task_count() > 0
+            && installer.manager.options.do_.install_packages()
+        {
+            let mut err: Option<crate::Error> = None;
             // Whenever the event loop wakes up, we need to call `run_tasks`
             // If we call sleep() instead of sleep_until(), it will wait forever until there are no more lifecycle scripts
             // which means it will not call run_tasks until _all_ current lifecycle scripts have finished running
-            // SAFETY: `mgr` is derived from the live exclusive `this` borrow;
-            // `sleep_until` + `tick_raw` hold no `&mut PackageManager` across
-            // `Closure::is_done`, so the callback's `&mut *closure.manager`
-            // is the unique live borrow.
-            unsafe { PackageManager::sleep_until(mgr, &mut closure, Closure::is_done) };
+            PackageManager::sleep_until(&mut installer, |installer| {
+                if let Err(e) = run_tasks::run_tasks(installer, true, log_level) {
+                    err = Some(e);
+                    return true;
+                }
 
-            if let Some(err) = closure.err {
+                let manager = &mut *installer.manager;
+                manager.report_slow_lifecycle_scripts();
+
+                if PackageManager::verbose_install() && manager.pending_task_count() > 0 {
+                    let pending_task_count = manager.pending_task_count();
+                    if pending_task_count > 0
+                        && manager.has_enough_time_passed_between_waiting_messages()
+                    {
+                        bun_core::pretty_errorln!(
+                            "<d>[PackageManager]<r> waiting for {} tasks\n",
+                            pending_task_count
+                        );
+                    }
+                }
+
+                manager.pending_task_count() == 0 && manager.has_no_more_pending_lifecycle_scripts()
+            });
+
+            if let Some(err) = err {
                 return Err(err);
             }
         }
-        this.tick_lifecycle_scripts();
-        this.report_slow_lifecycle_scripts();
+        PackageManager::tick_lifecycle_scripts(&mut installer);
+        installer.manager.report_slow_lifecycle_scripts();
 
-        // Index instead of `.iter()` so the immutable borrow of
-        // `installer.trees` doesn't overlap `&mut self`.
         for tree_idx in 0..installer.trees.len() {
             debug_assert!(installer.trees[tree_idx].pending_installs.len() == 0);
             // force = true
@@ -569,19 +415,17 @@ pub(crate) fn install_hoisted_packages(
         }
 
         // .monotonic is okay because this value is only accessed on this thread.
-        this.finished_installing.store(true, Ordering::Relaxed);
+        installer
+            .manager
+            .finished_installing
+            .store(true, Ordering::Relaxed);
         if log_level.show_progress() {
-            // Route through the stored `NonNull` (set above) instead of
-            // re-borrowing the `scripts_node` local directly: under Stacked
-            // Borrows a fresh `&mut local` here would invalidate the raw
-            // pointer that lifecycle-script callbacks dereference via
-            // `scripts_node_mut()` while we drain below.
-            if let Some(n) = this.scripts_node_mut() {
+            if let Some(n) = installer.manager.scripts_node_mut() {
                 n.activate();
             }
         }
 
-        if !this.options.do_.install_packages() {
+        if !installer.manager.options.do_.install_packages() {
             return Err(crate::Error::InstallFailed);
         }
 
@@ -603,15 +447,20 @@ pub(crate) fn install_hoisted_packages(
         installer.complete_remaining_scripts(log_level);
 
         // .monotonic is okay because this value is only accessed on this thread.
-        while this.pending_lifecycle_script_tasks.load(Ordering::Relaxed) > 0 {
-            this.report_slow_lifecycle_scripts();
-
-            this.sleep();
+        while installer
+            .manager
+            .pending_lifecycle_script_tasks
+            .load(Ordering::Relaxed)
+            > 0
+        {
+            installer.manager.report_slow_lifecycle_scripts();
+            PackageManager::sleep_until(&mut installer, |installer| {
+                installer.manager.has_no_more_pending_lifecycle_scripts()
+            });
         }
+        let this = &mut *installer.manager;
 
         if log_level.show_progress() {
-            // See `activate()` note above — reuse the stored `NonNull`'s
-            // provenance instead of re-borrowing the stack local.
             if let Some(n) = this.scripts_node_mut() {
                 n.end();
             }

--- a/src/install/hosted_git_info.rs
+++ b/src/install/hosted_git_info.rs
@@ -24,7 +24,7 @@
 //! ## `HostedGitInfo`
 //!
 //! This is the main API point of this library. It encapsulates information about a Git repository.
-//! To parse URLs into this structure, use the `fromUrl` member function.
+//! To parse URLs into this structure, use the `from_url` member function.
 //!
 //! ## `HostProvider`
 //!
@@ -229,10 +229,7 @@ impl HostedGitInfo {
     /// Given a URL-like (including shortcuts) string, parses it into a HostedGitInfo structure.
     /// The HostedGitInfo is valid only for as long as `git_url` is valid.
     pub fn from_url(git_url: &[u8]) -> Result<Option<Self>, HostedGitInfoError> {
-        // git_url_mut may carry two ownership semantics:
-        //  - It aliases `git_url`, in which case it must not be freed.
-        //  - It actually points to a new allocation, in which case it must be freed.
-        // Modeled as a Cow-like local; Drop handles the owned case.
+        // `git_url_mut` is either `git_url` itself or a view of `git_url_owned`.
         let git_url_owned: Option<Box<[u8]>>;
         let mut git_url_mut: &[u8] = git_url;
 
@@ -279,7 +276,6 @@ impl HostedGitInfo {
 
         // Shortcut path: github:user/repo, gitlab:user/repo, etc. (from-url.js line 68-96)
         let pathname_owned = parsed.url.pathname().to_owned_slice();
-        // Drop handles `defer allocator.free(pathname_owned)`.
 
         // Strip leading / (from-url.js line 69)
         let mut pathname: &[u8] = strings::trim_prefix(&pathname_owned, b"/");
@@ -344,7 +340,6 @@ pub fn parse_url(npa_str: &[u8]) -> Result<ParsedUrl<'_>, ParseUrlError> {
     // Certain users can provide values like user:password@github.com:foo/bar and we want to
     // "correct" the protocol to be git+ssh://user:password@github.com:foo/bar
     let proto_pair = normalize_protocol(npa_str);
-    // Drop handles `defer proto_pair.deinit()`.
 
     // TODO(markovejnovic): We might be able to avoid this allocation if we rework how jsc.URL
     //                      accepts strings.
@@ -674,7 +669,6 @@ impl<'a> UrlProtocolPair<'a> {
         // TODO(markovejnovic): There is a sad unnecessary allocation here that I don't know how to
         // get rid of -- in theory, the URL layer could allocate once.
         let new_str = strings::concat(parts);
-        // Drop handles `defer allocator.free(new_str)`.
         Parsed::from_utf8(&new_str)
     }
 }

--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -10,17 +10,15 @@ const SHA256_DIGEST_LEN: usize = 32;
 const SHA384_DIGEST_LEN: usize = 48;
 const SHA512_DIGEST_LEN: usize = 64;
 
+/// `#[repr(C)]` with a `u8` tag + `[u8; 64]`: size 65, align 1, no padding.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct Integrity {
     pub tag: Tag,
     /// Possibly a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) value initially
     /// We transform it though.
     pub value: [u8; DIGEST_BUF_LEN],
 }
-// SAFETY: `#[repr(C)]` with a `#[repr(transparent)] u8` tag + `[u8; 64]` →
-// size 65, align 1, no padding bytes, `Copy + 'static`. Every byte initialized.
-unsafe impl bytemuck::NoUninit for Integrity {}
 
 impl Default for Integrity {
     fn default() -> Self {
@@ -175,16 +173,12 @@ impl Integrity {
     pub(crate) fn for_bytes(bytes: &[u8]) -> Integrity {
         const LEN: usize = SHA512_DIGEST_LEN;
         let mut value: [u8; DIGEST_BUF_LEN] = EMPTY_DIGEST_BUF;
-        // SAFETY: engine is null (default).
-        unsafe {
-            Crypto::SHA512::hash(
-                bytes,
-                (&mut value[0..LEN])
-                    .try_into()
-                    .expect("infallible: size matches"),
-                core::ptr::null_mut(),
-            )
-        };
+        Crypto::SHA512::hash_with_default_engine(
+            bytes,
+            (&mut value[0..LEN])
+                .try_into()
+                .expect("infallible: size matches"),
+        );
         Integrity {
             tag: Tag::SHA512,
             value,
@@ -205,8 +199,7 @@ impl Integrity {
                 let ptr: &mut [u8; LEN] = (&mut digest[0..LEN])
                     .try_into()
                     .expect("infallible: size matches");
-                // SAFETY: engine is null (default).
-                unsafe { Crypto::SHA1::hash(bytes, ptr, core::ptr::null_mut()) };
+                Crypto::SHA1::hash_with_default_engine(bytes, ptr);
                 strings::eql_long(ptr, &sum[0..LEN], true)
             }
             Tag::SHA512 => {
@@ -214,8 +207,7 @@ impl Integrity {
                 let ptr: &mut [u8; LEN] = (&mut digest[0..LEN])
                     .try_into()
                     .expect("infallible: size matches");
-                // SAFETY: engine is null (default).
-                unsafe { Crypto::SHA512::hash(bytes, ptr, core::ptr::null_mut()) };
+                Crypto::SHA512::hash_with_default_engine(bytes, ptr);
                 strings::eql_long(ptr, &sum[0..LEN], true)
             }
             Tag::SHA256 => {
@@ -223,8 +215,7 @@ impl Integrity {
                 let ptr: &mut [u8; LEN] = (&mut digest[0..LEN])
                     .try_into()
                     .expect("infallible: size matches");
-                // SAFETY: engine is null (default).
-                unsafe { Crypto::SHA256::hash(bytes, ptr, core::ptr::null_mut()) };
+                Crypto::SHA256::hash_with_default_engine(bytes, ptr);
                 strings::eql_long(ptr, &sum[0..LEN], true)
             }
             Tag::SHA384 => {
@@ -232,8 +223,7 @@ impl Integrity {
                 let ptr: &mut [u8; LEN] = (&mut digest[0..LEN])
                     .try_into()
                     .expect("infallible: size matches");
-                // SAFETY: engine is null (default).
-                unsafe { Crypto::SHA384::hash(bytes, ptr, core::ptr::null_mut()) };
+                Crypto::SHA384::hash_with_default_engine(bytes, ptr);
                 strings::eql_long(ptr, &sum[0..LEN], true)
             }
             _ => false,
@@ -254,10 +244,11 @@ impl fmt::Display for Integrity {
         let mut base64_buf = [0u8; 512];
         let bytes = self.slice();
 
-        // SAFETY: base64 alphabet is pure ASCII.
-        f.write_str(unsafe {
-            core::str::from_utf8_unchecked(base64.encoder.encode(&mut base64_buf, bytes))
-        })?;
+        // base64 alphabet is pure ASCII.
+        f.write_str(
+            core::str::from_utf8(base64.encoder.encode(&mut base64_buf, bytes))
+                .expect("base64 is ASCII"),
+        )?;
 
         // consistentcy with yarn.lock
         match self.tag {
@@ -271,11 +262,8 @@ impl fmt::Display for Integrity {
 // lockfiles. A `#[repr(u8)] enum` would be UB for unknown discriminants, so we
 // use a transparent newtype with associated consts instead.
 #[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct Tag(pub u8);
-// SAFETY: `#[repr(transparent)]` newtype over `u8` — same layout as `u8`,
-// no padding, `Copy + 'static`.
-unsafe impl bytemuck::NoUninit for Tag {}
 
 impl Tag {
     pub(crate) const UNKNOWN: Tag = Tag(0);

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -40,8 +40,9 @@ use bun_sys::{self as sys, Fd};
 use bun_wyhash::{Wyhash, Wyhash11};
 
 use crate::analytics;
-use crate::bun_bunfig::Arguments as Command;
 use crate::bun_progress::{Node as ProgressNode, Progress};
+use crate::dependency::Behavior;
+use crate::lifecycle_script_runner::EntryEvent;
 use crate::lockfile::tree::is_filtered_dependency_or_workspace;
 use crate::lockfile::{self, Lockfile};
 use crate::package_manager::{self, PackageManager, WorkspaceFilter, run_tasks};
@@ -56,8 +57,7 @@ use store::{Entry as StoreEntry, EntryColumns as _, Node as StoreNode, NodeColum
 bun_output::define_scoped_log!(log, IsolatedInstall, visible);
 
 // ───────────────────────────────────────────────────────────────────────────
-// Inner helper types (hoisted from fn body — Rust does not allow local
-// struct decls that borrow outer locals via closures the same way).
+// Helper types for `build_store`
 // ───────────────────────────────────────────────────────────────────────────
 
 #[derive(Clone, Copy)]
@@ -107,18 +107,20 @@ struct WorkFrame {
     child: u32,
 }
 
-/// Compute entry_hash for the global virtual store. The hash makes a
-/// global-store directory name unique to this entry's *resolved* dependency
-/// closure, so two projects that resolve `react@18.3.1` to the same set of
-/// transitive versions share one on-disk entry, while a project that
-/// resolves a transitive dep to a different version gets its own.
-///
-/// Eligibility propagates: an entry is only global-store-eligible (hash != 0)
-/// when the package itself comes from an immutable cache (npm/git/tarball,
-/// unpatched, no lifecycle scripts) *and* every dependency it links to is
-/// also eligible. The second condition matters because dep symlinks live
-/// inside the global entry; baking a project-local path (workspace, folder)
-/// into a shared directory would break for every other consumer.
+// `build_store` computes each entry's `entry_hash` for the global virtual
+// store. The hash makes a global-store directory name unique to this entry's
+// *resolved* dependency closure, so two projects that resolve `react@18.3.1`
+// to the same set of transitive versions share one on-disk entry, while a
+// project that resolves a transitive dep to a different version gets its own.
+//
+// Eligibility propagates: an entry is only global-store-eligible (hash != 0)
+// when the package itself comes from an immutable cache (npm/git/tarball,
+// unpatched, no lifecycle scripts) *and* every dependency it links to is
+// also eligible. The second condition matters because dep symlinks live
+// inside the global entry; baking a project-local path (workspace, folder)
+// into a shared directory would break for every other consumer.
+
+/// `io::Write` adapter feeding a `Wyhash` (entry hashes).
 struct WyhashWriter<'a> {
     hasher: &'a mut Wyhash,
 }
@@ -133,77 +135,147 @@ impl<'a> std::io::Write for WyhashWriter<'a> {
     }
 }
 
-/// `RunTasksCallbacks` impl for the isolated-install loop, with
-/// `Ctx == store::Installer`.
-pub(crate) struct StoreRunTasksCallbacks<'a>(core::marker::PhantomData<&'a mut ()>);
+impl run_tasks::RunTasksCtx for store::Installer<'_> {
+    fn manager(&mut self) -> &mut PackageManager {
+        self.manager
+    }
+    fn has_on_extract(&self) -> bool {
+        true
+    }
+    fn has_on_package_download_error(&self) -> bool {
+        true
+    }
+    fn is_store_installer(&self) -> bool {
+        true
+    }
 
-impl<'a> run_tasks::RunTasksCallbacks for StoreRunTasksCallbacks<'a> {
-    type Ctx = store::Installer<'a>;
-
-    const HAS_ON_EXTRACT: bool = true;
-    const HAS_ON_PACKAGE_DOWNLOAD_ERROR: bool = true;
-    const IS_STORE_INSTALLER: bool = true;
-
-    fn on_extract_store_installer(ctx: &mut Self::Ctx, task_id: Task::Id) {
-        ctx.on_package_extracted(task_id);
+    fn on_extract_store_installer(&mut self, task_id: Task::Id) {
+        self.on_package_extracted(task_id);
     }
 
     fn on_package_download_error_store(
-        ctx: &mut Self::Ctx,
+        &mut self,
         id: Task::Id,
         name: &[u8],
         resolution: &Resolution,
         err: crate::Error,
         url: &[u8],
     ) {
-        ctx.on_package_download_error(id, name, resolution, err, url);
+        self.on_package_download_error(id, name, resolution, err, url);
     }
-}
 
-struct Wait<'a, 'b> {
-    installer: &'a mut store::Installer<'b>,
-    err: Option<crate::Error>,
-}
-
-impl<'a, 'b> Wait<'a, 'b> {
-    fn is_done(&mut self) -> bool {
-        // `Installer.manager` is a BACKREF raw pointer; `manager_mut()`
-        // materializes the unique `&mut PackageManager` for this main-thread
-        // tick without aliasing `&mut Installer`.
-        let pkg_manager = self.installer.manager_mut();
-        let log_level = pkg_manager.options.log_level;
-        // `run_tasks` must not call `installer.manager_mut()` — `pkg_manager`
-        // is the live `&mut PackageManager` for this call.
-        if let Err(err) = run_tasks::run_tasks::<StoreRunTasksCallbacks>(
-            pkg_manager,
-            self.installer,
-            true,
-            log_level,
-        ) {
-            self.err = Some(err);
-            return true;
-        }
-
-        let pkg_manager = self.installer.manager_mut();
-        if let Some(node) = pkg_manager.scripts_node_mut() {
-            // if we're just waiting for scripts, make it known.
-
-            // .monotonic is okay because this is just used for progress; we don't rely on
-            // any side effects from completed tasks.
-            let pending_lifecycle_scripts = pkg_manager
-                .pending_lifecycle_script_tasks
-                .load(Ordering::Relaxed);
-            // `+ 1` because the root task needs to wait for everything
-            if pending_lifecycle_scripts > 0
-                && pkg_manager.pending_task_count() <= pending_lifecycle_scripts + 1
-            {
-                node.activate();
-                pkg_manager.progress.refresh();
+    fn on_lifecycle_script_event(&mut self, entry_id: store::entry::Id, event: EntryEvent) {
+        let steps = self.store.entries.items_step();
+        match event {
+            EntryEvent::PreinstallDone => {
+                let previous_step = steps[entry_id.get() as usize]
+                    .swap(installer::Step::Binaries as u32, Ordering::Release);
+                debug_assert!(previous_step == installer::Step::RunPreinstall as u32);
+                self.start_task(entry_id);
+            }
+            EntryEvent::Done => {
+                let previous_step = steps[entry_id.get() as usize]
+                    .swap(installer::Step::Done as u32, Ordering::Release);
+                if bun_core::Environment::CI_ASSERT {
+                    debug_assert!(
+                        previous_step == installer::Step::RunPostInstallAndPrePostPrepare as u32
+                    );
+                }
+                self.on_task_complete(entry_id, installer::CompleteState::Success);
+            }
+            EntryEvent::Skipped => {
+                steps[entry_id.get() as usize]
+                    .store(installer::Step::Done as u32, Ordering::Release);
+                self.on_task_complete(entry_id, installer::CompleteState::Skipped);
             }
         }
-
-        pkg_manager.pending_task_count() == 0
     }
+
+    fn drain_store_tasks(&mut self, _log_level: crate::LogLevel) {
+        let batch = core::mem::take(&mut *self.task_queue.lock());
+        for (entry_id, result) in batch {
+            match result {
+                installer::Result::None => {
+                    if Environment::CI_ASSERT {
+                        unreachable!();
+                    }
+                    self.on_task_complete(entry_id, installer::CompleteState::Success);
+                }
+                installer::Result::Err(err) => {
+                    self.on_task_fail(entry_id, &err);
+                }
+                installer::Result::Blocked => {
+                    self.on_task_blocked(entry_id);
+                }
+                installer::Result::RunScripts => {
+                    let node_id = self.store.entries.items_node_id()[entry_id.get() as usize];
+                    let dep_id = self.store.nodes.items_dep_id()[node_id.get() as usize];
+                    let optional = self.lockfile().buffers.dependencies[dep_id as usize]
+                        .behavior
+                        .contains(Behavior::OPTIONAL);
+                    // This entry's task is parked until its scripts finish, so
+                    // the main thread is the slot's only user here.
+                    let list_val = {
+                        let slot = &self.store.entries.items_scripts()[entry_id.get() as usize];
+                        let list = slot.take().expect("RunScripts with no scripts");
+                        let clone = (*list).clone();
+                        slot.set(Some(list));
+                        clone
+                    };
+                    let spawn_res = self.manager.spawn_package_lifecycle_scripts(
+                        list_val,
+                        optional,
+                        false,
+                        Some(entry_id),
+                    );
+                    if let Err(err) = spawn_res {
+                        // Relaxed is okay for the same reason as `Done`: this result came out of
+                        // the `task_queue` lock, and the task is no longer running.
+                        self.store.entries.items_step()[entry_id.get() as usize]
+                            .store(installer::Step::Done as u32, Ordering::Relaxed);
+                        self.on_task_fail(entry_id, &installer::TaskError::RunScripts(err));
+                    }
+                }
+                installer::Result::Done => {
+                    if Environment::CI_ASSERT {
+                        // .monotonic is okay because we should have already synchronized with the
+                        // completed task thread by virtue of popping from the queue.
+                        let step = self.store.entries.items_step()[entry_id.get() as usize]
+                            .load(Ordering::Relaxed);
+                        assert!(step == installer::Step::Done as u32);
+                    }
+                    self.on_task_complete(entry_id, installer::CompleteState::Success);
+                }
+            }
+        }
+    }
+}
+
+fn wait_is_done(installer: &mut store::Installer<'_>, err: &mut Option<crate::Error>) -> bool {
+    let log_level = installer.manager.options.log_level;
+    if let Err(e) = run_tasks::run_tasks(installer, true, log_level) {
+        *err = Some(e);
+        return true;
+    }
+
+    let pkg_manager = &mut *installer.manager;
+    // if we're just waiting for scripts, make it known.
+    // .monotonic is okay because this is just used for progress; we don't rely on
+    // any side effects from completed tasks.
+    let pending_lifecycle_scripts = pkg_manager
+        .pending_lifecycle_script_tasks
+        .load(Ordering::Relaxed);
+    // `+ 1` because the root task needs to wait for everything
+    if pending_lifecycle_scripts > 0
+        && pkg_manager.pending_task_count() <= pending_lifecycle_scripts + 1
+    {
+        if let Some(node) = pkg_manager.scripts_node.as_mut() {
+            node.activate();
+            pkg_manager.progress.refresh();
+        }
+    }
+
+    pkg_manager.pending_task_count() == 0
 }
 
 /// Whether `build_store` reports how long each of its two passes took.
@@ -310,7 +382,7 @@ pub(crate) fn build_store(
                     pkg_id,
                     workspace_filters,
                     install_root_dependencies,
-                    manager,
+                    crate::lockfile::tree::HoistOptions::from_manager(manager),
                     lockfile,
                     resolutions,
                 ) {
@@ -380,7 +452,7 @@ pub(crate) fn build_store(
             0,
             workspace_filters,
             install_root_dependencies,
-            manager,
+            crate::lockfile::tree::HoistOptions::from_manager(manager),
             lockfile,
             resolutions,
         ) {
@@ -565,14 +637,13 @@ pub(crate) fn build_store(
 
                     // The skipped subtree would have walked up through this
                     // ancestor chain marking each node with its leaking peers.
-                    // DFS guarantees `dedupe_node`'s subtree is fully processed,
+                    // DFS guarantees `dedupe_node_id`'s subtree is fully processed,
                     // so its `peers` is exactly that set; propagate it here.
                     let set_ctx = store::node::TransitivePeerOrderedArraySetCtx {
                         string_buf,
                         pkg_names,
                     };
-                    // Reshaped for borrowck — clone the dedupe peers slice
-                    // before mutating node_peers.
+                    // Cloned: `node_peers` is mutated below.
                     let dedupe_peers: Vec<_> =
                         node_peers[dedupe_node_id.get() as usize].list.clone();
                     for peer in dedupe_peers {
@@ -642,7 +713,7 @@ pub(crate) fn build_store(
         }
 
         // TODO: make this sort in an order that allows peers to be resolved last
-        // and devDependency handling to match `hoistDependency`
+        // and devDependency handling to match `hoist_dependency`
         {
             let sorter = lockfile::DepSorter { lockfile };
             index_sort::sort_indices(&mut dep_ids_sort_buf, &mut |a, b| {
@@ -691,7 +762,7 @@ pub(crate) fn build_store(
                     entry.pkg_id,
                     workspace_filters,
                     install_root_dependencies,
-                    manager,
+                    crate::lockfile::tree::HoistOptions::from_manager(manager),
                     lockfile,
                     resolutions,
                 ) {
@@ -702,7 +773,7 @@ pub(crate) fn build_store(
                 let dep = &dependencies[dep_id as usize];
 
                 // TODO: handle duplicate dependencies. should be similar logic
-                // like we have for dev dependencies in `hoistDependency`
+                // like we have for dev dependencies in `hoist_dependency`
 
                 if !dep.behavior.is_peer() {
                     // simple case:
@@ -754,8 +825,6 @@ pub(crate) fn build_store(
                             break 'resolved_pkg_id (ids.pkg_id, false);
                         }
 
-                        // SAFETY: tag was checked == .Npm directly above for both
-                        // `peer_dep.version` and `res`.
                         let peer_dep_version = &peer_dep.version.npm().version;
                         let res_version = &res.npm().version;
 
@@ -1134,20 +1203,17 @@ pub(crate) fn build_store(
 /// Runs on main thread
 pub(crate) fn install_isolated_packages(
     manager: &mut PackageManager,
-    command_ctx: Command::Context,
     install_root_dependencies: bool,
     workspace_filters: &[WorkspaceFilter],
     packages_to_install: Option<&[PackageID]>,
 ) -> Result<crate::package_install::Summary, AllocError> {
     analytics::features::isolated_bun_install.fetch_add(1, Ordering::Relaxed);
 
-    // Take a raw pointer so column borrows below don't tie up `&mut manager`
-    // (which owns the lockfile).
-    let lockfile: *mut Lockfile = &raw mut *manager.lockfile;
-    // SAFETY: `lockfile` was just derived from `&raw mut *manager.lockfile`;
-    // `manager` outlives this function and no other `&mut Lockfile` is formed
-    // while this reborrow is live (column slices below borrow through it).
-    let lockfile: &mut Lockfile = unsafe { &mut *lockfile };
+    // Both need `&mut manager`; everything below reads the lockfile.
+    let trusted_from_update = manager.find_trusted_dependencies_from_update_requests();
+    // populates `cache_directory_path` as a side-effect.
+    let _ = manager.get_cache_directory();
+    let lockfile: &Lockfile = &manager.lockfile;
 
     let timings = if manager.options.log_level.is_verbose() {
         Timings::Print
@@ -1156,7 +1222,7 @@ pub(crate) fn install_isolated_packages(
     };
     let store: Store = build_store(
         &*manager,
-        &*lockfile,
+        lockfile,
         install_root_dependencies,
         workspace_filters,
         packages_to_install,
@@ -1188,8 +1254,6 @@ pub(crate) fn install_isolated_packages(
             // Packages newly trusted via `bun add --trust` (not yet written to the
             // lockfile) will have their lifecycle scripts run this install; treat
             // them the same as lockfile-trusted packages for eligibility.
-            let trusted_from_update = manager.find_trusted_dependencies_from_update_requests();
-
             let mut states = vec![State::Unvisited; store.entries.len()].into_boxed_slice();
 
             // Iterative DFS so dependency cycles (which the isolated graph permits)
@@ -1213,8 +1277,7 @@ pub(crate) fn install_isolated_packages(
 
                 while !stack.is_empty() {
                     let top_idx = stack.len() - 1;
-                    // Reshaped for borrowck — re-borrow `top` after each
-                    // potential `stack.push()` realloc.
+                    // Re-read `top` by index after each potential `stack.push()`.
                     let id = stack[top_idx].id;
                     let entry_idx = id.get() as usize;
 
@@ -1283,6 +1346,7 @@ pub(crate) fn install_isolated_packages(
                                     pkg_names[pkg_id as usize].slice(string_buf)
                                 };
                                 if lockfile.has_trusted_dependency(
+                                    &manager.options,
                                     dep_name,
                                     pkg_names[pkg_id as usize].slice(string_buf),
                                     pkg_res,
@@ -1478,8 +1542,7 @@ pub(crate) fn install_isolated_packages(
                                 }
                                 unreachable!();
                             };
-                            // Reshaped for borrowck — copy members to
-                            // avoid holding a borrow into scc_stack while mutating.
+                            // Copied: `scc_stack` is mutated while walking the members.
                             let members: Vec<u32> = scc_stack[start..].to_vec();
                             for &m in &members {
                                 on_stack[m as usize] = false;
@@ -1650,8 +1713,6 @@ pub(crate) fn install_isolated_packages(
             }
 
             // <cache_dir>/links — created lazily by the first task that misses.
-            // getCacheDirectory() populates `cache_directory_path` as a side-effect.
-            let _ = manager.get_cache_directory();
             let cache_dir_path = &manager.cache_directory_path;
             if cache_dir_path.is_empty() {
                 break 'global_store_path None;
@@ -1669,7 +1730,6 @@ pub(crate) fn install_isolated_packages(
     } else {
         None
     };
-    // (Drop frees global_store_path)
 
     // setup node_modules/.bun
     let is_new_bun_modules: bool = 'is_new_bun_modules: {
@@ -1777,8 +1837,6 @@ pub(crate) fn install_isolated_packages(
 
                         workspace_node_modules.append(b"node_modules").assume_ok();
 
-                        // Reshaped for borrowck — capture length instead
-                        // of `save()` so `rename_path` stays unborrowed.
                         let rename_path_save = rename_path.len();
                         rename_path
                             .append_fmt(format_args!(".old_{}_modules", BStr::new(&basename)))
@@ -1941,28 +1999,18 @@ pub(crate) fn install_isolated_packages(
     {
         // Conditionally initialized (only when progress is shown); definite-
         // initialization analysis guarantees no use before assignment.
-        let mut download_node: ProgressNode;
         let mut install_node: ProgressNode = ProgressNode::default();
-        let mut scripts_node: ProgressNode;
-        let progress: *mut Progress = &raw mut manager.progress;
-        // SAFETY: `progress` aliases `manager.progress`; reborrows below are
-        // disjoint from the other `manager.*` field accesses.
-        let progress = unsafe { &mut *progress };
 
         if manager.options.log_level.show_progress() {
+            let progress = &mut manager.progress;
             progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
-            // `Progress::start` returns `&mut Node` (points into `progress.root`);
-            // keep it as a safe reborrow — it's only used to spawn the three
-            // children below and is dead before the `manager.*` writes that
-            // follow (NLL), so no raw-ptr round-trip is needed.
             let root_node = progress.start(b"", 0);
-            download_node = root_node.start(ProgressStrings::download(), 0);
+            let download_node = root_node.start(ProgressStrings::download(), 0);
             install_node = root_node.start(ProgressStrings::install(), store.entries.len());
-            scripts_node = root_node.start(ProgressStrings::script(), 0);
+            let scripts_node = root_node.start(ProgressStrings::script(), 0);
 
-            manager.downloads_node = None;
-            manager.scripts_node = Some(core::ptr::NonNull::from(&mut scripts_node));
-            manager.downloads_node = Some(&raw mut download_node);
+            manager.scripts_node = Some(scripts_node);
+            manager.downloads_node = Some(download_node);
         }
 
         let nodes_slice = store.nodes.slice();
@@ -1975,71 +2023,40 @@ pub(crate) fn install_isolated_packages(
         let entry_dependencies = entries.items_dependencies();
         let entry_hoisted = entries.items_hoisted();
 
-        // Reborrow through a
-        // `BackRef` so `string_buf` / `pkgs` don't tie up `&mut lockfile` for
-        // the `Installer { lockfile, .. }` move below. `BackRef` is the
-        // canonical non-owning back-pointer wrapper; the lockfile lives for
-        // the full scope and the column buffers sliced here are read-only
-        // across the install loop (never mutated through `installer.lockfile`).
-        let lockfile_ptr: *mut Lockfile = lockfile;
-        let lockfile_ref = bun_ptr::BackRef::<Lockfile>::from(
-            core::ptr::NonNull::new(lockfile_ptr).expect("lockfile BACKREF non-null"),
-        );
-        let lockfile_ro: &Lockfile = lockfile_ref.get();
-        let string_buf = &lockfile_ro.buffers.string_bytes[..];
-
-        let pkgs = lockfile_ro.packages.slice();
-        let pkg_names = pkgs.items_name();
-        let pkg_name_hashes = pkgs.items_name_hash();
-        let pkg_resolutions = pkgs.items_resolution();
-
         let mut seen_entry_ids: HashMap<store::entry::Id, ()> = HashMap::default();
         seen_entry_ids.reserve(store.entries.len());
 
         // TODO: delete
         let mut seen_workspace_ids: HashMap<PackageID, ()> = HashMap::default();
 
-        // `installer::Task` carries `result: Result` (Drop via `TaskError`
-        // payloads) and a non-nullable fn-ptr in `thread_pool::Task`, so
-        // `assume_init()` on uninit memory is instant UB and a subsequent
-        // `*task = ..` would drop garbage. Instead, fully initialize each
-        // slot via `MaybeUninit::write` with a null `installer` back-pointer
-        // placeholder, finalize the slice, move it into `Installer`, then
-        // patch the back-pointer in a second loop once `installer` exists.
-        let tasks: Box<[installer::Task]> = {
-            let mut uninit: Box<[core::mem::MaybeUninit<installer::Task>]> =
-                Box::new_uninit_slice(store.entries.len());
-            for (i, slot) in uninit.iter_mut().enumerate() {
-                slot.write(installer::Task {
-                    entry_id: store::entry::Id::from(u32::try_from(i).expect("int cast")),
-                    // patched below once `installer` has an address — dangling
-                    // placeholder is never dereferenced
-                    installer: bun_ptr::BackRef::from(core::ptr::NonNull::dangling()),
-                    result: installer::Result::None,
-                    relink: installer::Relink::Off,
-                    task: bun_threading::thread_pool::Task {
-                        callback: installer::Task::callback,
-                        node: Default::default(),
-                    },
-                    next: bun_threading::Link::new(),
-                });
-            }
-            // SAFETY: every element was written in the loop above.
-            unsafe { uninit.assume_init() }
-        };
+        // Every slot gets its `installer` back-pointer in a second loop once
+        // `installer` exists.
+        let tasks = bun_threading::TaskSlots::new((0..store.entries.len()).map(|i| {
+            installer::Task::new(store::entry::Id::from(u32::try_from(i).expect("int cast")))
+        }));
 
         let show_progress = manager.options.log_level.show_progress();
-        let installed = DynamicBitSet::init_empty(lockfile.packages.len())?;
+        let installed = DynamicBitSet::init_empty(manager.lockfile.packages.len())?;
         let trusted_dependencies_from_update_requests =
             manager.find_trusted_dependencies_from_update_requests();
-        // `Installer.manager` is a BACKREF raw pointer; copying `manager_ptr`
-        // does not move `manager`, so the body keeps using `manager` via the
-        // shadow-reborrow below.
-        let manager_ptr: *mut PackageManager = manager;
+
+        // Worker tasks read these through `&PackageManager`, so open them on
+        // the main thread before any task starts.
+        let _ = manager.get_cache_directory();
+        if manager
+            .lockfile
+            .packages
+            .items_resolution()
+            .iter()
+            .any(|r| r.tag == ResolutionTag::Symlink)
+        {
+            let _ = crate::package_manager_real::directories::global_link_dir_path(manager);
+        }
+
+        let shared = manager.shared;
         let mut installer = store::Installer {
-            lockfile: lockfile_ptr,
-            manager: manager_ptr,
-            command_ctx,
+            manager,
+            shared,
             installed,
             install_node: if show_progress {
                 Some(&mut install_node)
@@ -2050,7 +2067,7 @@ pub(crate) fn install_isolated_packages(
             tasks,
             waiters_head: vec![store::entry::Id::INVALID; store.entries.len()].into_boxed_slice(),
             next_waiter: vec![store::entry::Id::INVALID; store.entries.len()].into_boxed_slice(),
-            trusted_dependencies_mutex: Default::default(),
+            trusted_additions: bun_threading::Guarded::new(Vec::new()),
             trusted_dependencies_from_update_requests,
             supported_backend: std::sync::atomic::AtomicU8::new(
                 PackageInstall::supported_method() as u8
@@ -2058,51 +2075,20 @@ pub(crate) fn install_isolated_packages(
             is_new_bun_modules,
             global_store_path: global_store_path
                 .as_deref()
-                .map(|b: &[u8]| -> &bun_core::ZStr {
-                    // SAFETY: `global_store_path` was built with a trailing NUL above.
-                    bun_core::ZStr::from_slice_with_nul(b)
-                }),
+                .map(|b: &[u8]| -> &bun_core::ZStr { bun_core::ZStr::from_slice_with_nul(b) }),
             global_store_tmp_suffix: fast_random(),
             summary: Default::default(),
             task_queue: Default::default(),
         };
-        // No long-lived `&mut PackageManager` reborrow here — `installer.start_task()`,
-        // `on_task_complete()`, and `on_task_fail()` below all reach the manager through
-        // `installer.manager_mut()` (the BACKREF), so a shadow `&mut` held across those
-        // calls would alias. Use `installer.manager()` / `installer.manager_mut()`
-        // per-statement instead.
-        // (Drop handles installer.deinit())
 
-        // The back-pointer is taken before
-        // the `tasks` borrow. `Task.installer` is typed
-        // `BackRef<Installer<'static>>` (raw back-ref, no real `'static` data),
-        // so erase the lifetime via a void-pointer cast — `*mut T` is invariant
-        // and won't coerce on its own.
-        let installer_ptr: *mut store::Installer<'static> =
-            (&raw mut installer).cast::<()>().cast();
-        let installer_backref =
-            bun_ptr::BackRef::from(core::ptr::NonNull::new(installer_ptr).unwrap());
-        for task in installer.tasks.iter_mut() {
-            task.installer = installer_backref;
-        }
-
-        // `append_store_path` runs on worker threads via `&Installer` and
-        // can't take `&mut PackageManager` there, so ensure the
-        // global link dir once on the main thread before any `.symlink`
-        // resolution can be reached by a task. Guarded so installs without
-        // `link:` deps don't touch the global dir.
-        if pkg_resolutions
-            .iter()
-            .any(|r| r.tag == ResolutionTag::Symlink)
-        {
-            let _ = crate::package_manager_real::directories::global_link_dir_path(
-                installer.manager_mut(),
-            );
+        let installer_backref = bun_ptr::BackRef::new(&installer);
+        for task in installer.tasks.iter() {
+            let _ = task.installer.set(installer_backref);
         }
 
         // add the pending task count upfront
         installer
-            .manager_mut()
+            .manager
             .increment_pending_tasks(u32::try_from(store.entries.len()).expect("int cast"));
         for _entry_id in 0..store.entries.len() {
             let entry_id = store::entry::Id::from(u32::try_from(_entry_id).expect("int cast"));
@@ -2111,13 +2097,20 @@ pub(crate) fn install_isolated_packages(
             let pkg_id = node_pkg_ids[node_id.get() as usize];
             let dep_id = node_dep_ids[node_id.get() as usize];
 
-            let pkg_name = pkg_names[pkg_id as usize];
-            let pkg_name_hash = pkg_name_hashes[pkg_id as usize];
-            let pkg_res: Resolution = pkg_resolutions[pkg_id as usize];
+            let (pkg_name, pkg_name_hash, pkg_res): (semver::String, PackageNameHash, Resolution) = {
+                let pkgs = installer.manager.lockfile.packages.slice();
+                (
+                    pkgs.items_name()[pkg_id as usize],
+                    pkgs.items_name_hash()[pkg_id as usize],
+                    pkgs.items_resolution()[pkg_id as usize],
+                )
+            };
 
             // Validate the package name and every dependency alias as
             // `node_modules/<name>` components before any filesystem work.
             {
+                let lockfile_ro: &Lockfile = &installer.manager.lockfile;
+                let string_buf = lockfile_ro.buffers.string_bytes.as_slice();
                 let mut unsafe_folder_name: Option<&[u8]> = None;
                 let name = pkg_name.slice(string_buf);
                 if !name.is_empty() && !crate::package_installer::alias_is_safe_install_target(name)
@@ -2217,7 +2210,7 @@ pub(crate) fn install_isolated_packages(
 
                     let uses_global_store = installer.entry_uses_global_store(entry_id);
 
-                    let needs_install = installer.manager().options.enable.force_install()
+                    let needs_install = installer.manager.options.enable.force_install()
                         // A freshly-created `node_modules/.bun` only implies the
                         // *project-local* entries are missing; global virtual-
                         // store entries persist across `rm -rf node_modules` and
@@ -2330,48 +2323,56 @@ pub(crate) fn install_isolated_packages(
                     }
 
                     // Downloads only produce the unpatched folder; `apply_package_patch` derives the rest.
-                    // SAFETY: each arm reads the union field that `pkg_res_tag`
-                    // (== `pkg_res.tag`) names as active.
-                    let cache_subpath_z: &bun_core::ZStr = match pkg_res_tag {
-                        ResolutionTag::Npm => package_manager::cached_npm_package_folder_name(
-                            installer.manager(),
-                            pkg_name.slice(string_buf),
-                            pkg_res.npm().version,
-                            None,
-                        ),
-                        ResolutionTag::Git => package_manager::cached_git_folder_name(
-                            installer.manager(),
-                            pkg_res.git(),
-                            None,
-                        ),
-                        ResolutionTag::Github => package_manager::cached_github_folder_name(
-                            installer.manager(),
-                            pkg_res.github(),
-                            None,
-                        ),
-                        ResolutionTag::LocalTarball => package_manager::cached_tarball_folder_name(
-                            installer.manager(),
-                            *pkg_res.local_tarball(),
-                            None,
-                        ),
-                        ResolutionTag::RemoteTarball => {
-                            package_manager::cached_tarball_folder_name(
-                                installer.manager(),
-                                *pkg_res.remote_tarball(),
-                                None,
-                            )
-                        }
-
-                        _ => unreachable!(),
-                    };
-                    let (cache_dir, cache_dir_path) =
-                        installer.manager_mut().get_cache_directory_and_abs_path();
-                    let _ = &cache_dir_path; // dropped at scope exit
-
-                    let missing_from_cache = match installer.manager().get_preinstall_state(pkg_id)
-                    {
+                    let cache_dir = installer.manager.cache_directory();
+                    let missing_from_cache = match installer.manager.get_preinstall_state(pkg_id) {
                         install::PreinstallState::Done => false,
                         _ => {
+                            let mut cache_subpath_buf = bun_paths::path_buffer_pool::get();
+                            let manager: &PackageManager = installer.manager;
+                            let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
+                            let cache_subpath_z: &bun_core::ZStr = match pkg_res_tag {
+                                ResolutionTag::Npm => {
+                                    package_manager::cached_npm_package_folder_name(
+                                        manager,
+                                        &mut cache_subpath_buf,
+                                        pkg_name.slice(string_buf),
+                                        pkg_res.npm().version,
+                                        None,
+                                    )
+                                }
+                                ResolutionTag::Git => package_manager::cached_git_folder_name(
+                                    manager,
+                                    &mut cache_subpath_buf,
+                                    pkg_res.git(),
+                                    None,
+                                ),
+                                ResolutionTag::Github => {
+                                    package_manager::cached_github_folder_name(
+                                        manager,
+                                        &mut cache_subpath_buf,
+                                        pkg_res.github(),
+                                        None,
+                                    )
+                                }
+                                ResolutionTag::LocalTarball => {
+                                    package_manager::cached_tarball_folder_name(
+                                        manager,
+                                        &mut cache_subpath_buf,
+                                        *pkg_res.local_tarball(),
+                                        None,
+                                    )
+                                }
+                                ResolutionTag::RemoteTarball => {
+                                    package_manager::cached_tarball_folder_name(
+                                        manager,
+                                        &mut cache_subpath_buf,
+                                        *pkg_res.remote_tarball(),
+                                        None,
+                                    )
+                                }
+
+                                _ => unreachable!(),
+                            };
                             let exists = package_manager::directories::is_package_in_cache_at(
                                 cache_dir,
                                 cache_subpath_z,
@@ -2379,7 +2380,7 @@ pub(crate) fn install_isolated_packages(
                             );
                             if exists {
                                 installer
-                                    .manager_mut()
+                                    .manager
                                     .set_preinstall_state(pkg_id, install::PreinstallState::Done);
                             }
                             !exists
@@ -2408,18 +2409,27 @@ pub(crate) fn install_isolated_packages(
 
                     let ctx = install::TaskCallbackContext::IsolatedPackageInstallContext(entry_id);
 
-                    let dep = &lockfile_ro.buffers.dependencies[dep_id as usize];
+                    let dep_name =
+                        installer.manager.lockfile.buffers.dependencies[dep_id as usize].name;
+                    // For error messages below, once the manager borrow is released.
+                    let describe = |installer: &store::Installer<'_>| -> (Vec<u8>, Vec<u8>) {
+                        let string_buf = installer.manager.lockfile.buffers.string_bytes.as_slice();
+                        (
+                            pkg_name.slice(string_buf).to_vec(),
+                            format!("{}", pkg_res.fmt(string_buf, bun_fmt::PathSep::Auto))
+                                .into_bytes(),
+                        )
+                    };
 
                     match pkg_res_tag {
                         ResolutionTag::Npm => {
-                            match installer.manager_mut().enqueue_package_for_download(
-                                pkg_name.slice(string_buf),
+                            match installer.manager.enqueue_package_for_download(
+                                pkg_name,
                                 dep_id,
                                 pkg_id,
                                 pkg_res.npm().version,
-                                pkg_res.npm().url.slice(string_buf),
+                                pkg_res.npm().url,
                                 ctx,
-                                patch_info.name_and_version_hash(),
                             ) {
                                 Ok(()) => {}
                                 Err(e) if e == crate::Error::Alloc(bun_alloc::AllocError) => {
@@ -2438,17 +2448,14 @@ pub(crate) fn install_isolated_packages(
                                     continue;
                                 }
                                 Err(err) => {
-                                    // error.InvalidURL
+                                    let (name, res) = describe(&installer);
                                     Output::err(
                                         err,
                                         "failed to enqueue package for download: {}@{}",
-                                        (
-                                            BStr::new(pkg_name.slice(string_buf)),
-                                            pkg_res.fmt(string_buf, bun_fmt::PathSep::Auto),
-                                        ),
+                                        (BStr::new(&name), BStr::new(&res)),
                                     );
                                     Output::flush();
-                                    if installer.manager().options.enable.fail_early() {
+                                    if installer.manager.options.enable.fail_early() {
                                         Global::exit(1);
                                     }
                                     // .monotonic is okay because an error means the task isn't
@@ -2462,9 +2469,9 @@ pub(crate) fn install_isolated_packages(
                             }
                         }
                         ResolutionTag::Git => {
-                            if installer.manager_mut().enqueue_git_for_checkout(
+                            if installer.manager.enqueue_git_for_checkout(
                                 dep_id,
-                                dep.name.slice(string_buf),
+                                dep_name,
                                 &pkg_res,
                                 ctx,
                                 patch_info.name_and_version_hash(),
@@ -2482,15 +2489,15 @@ pub(crate) fn install_isolated_packages(
                             // The `.git()` accessor has a `debug_assert_eq!(tag, Git)` that
                             // fires under `Github`, so use the tag-correct `.github()`
                             // (the two arms share `Repository` layout).
-                            let url = installer.manager().alloc_github_url(pkg_res.github());
-                            // (Drop frees url)
-                            match installer.manager_mut().enqueue_tarball_for_download(
-                                dep_id,
-                                pkg_id,
+                            let url = installer.manager.alloc_github_url(pkg_res.github());
+                            let url = bun_core::StringOrTinyString::init_append_if_needed(
                                 &url,
-                                ctx,
-                                patch_info.name_and_version_hash(),
-                            ) {
+                                &mut crate::network_task::filename_store_appender(),
+                            )?;
+                            match installer
+                                .manager
+                                .enqueue_tarball_for_download(dep_id, pkg_id, url, ctx)
+                            {
                                 Ok(()) => {}
                                 Err(e) if e == crate::Error::Alloc(bun_alloc::AllocError) => {
                                     bun_core::out_of_memory()
@@ -2508,16 +2515,14 @@ pub(crate) fn install_isolated_packages(
                                     continue;
                                 }
                                 Err(err) => {
+                                    let (name, res) = describe(&installer);
                                     Output::err(
                                         err,
                                         "failed to enqueue github package for download: {}@{}",
-                                        (
-                                            BStr::new(pkg_name.slice(string_buf)),
-                                            pkg_res.fmt(string_buf, bun_fmt::PathSep::Auto),
-                                        ),
+                                        (BStr::new(&name), BStr::new(&res)),
                                     );
                                     Output::flush();
-                                    if installer.manager().options.enable.fail_early() {
+                                    if installer.manager.options.enable.fail_early() {
                                         Global::exit(1);
                                     }
                                     // .monotonic is okay because an error means the task isn't
@@ -2531,22 +2536,23 @@ pub(crate) fn install_isolated_packages(
                             }
                         }
                         ResolutionTag::LocalTarball => {
-                            installer.manager_mut().enqueue_tarball_for_reading(
-                                dep_id,
-                                pkg_id,
-                                dep.name.slice(string_buf),
-                                &pkg_res,
-                                ctx,
+                            installer.manager.enqueue_tarball_for_reading(
+                                dep_id, pkg_id, dep_name, &pkg_res, ctx,
                             );
                         }
                         ResolutionTag::RemoteTarball => {
-                            match installer.manager_mut().enqueue_tarball_for_download(
-                                dep_id,
-                                pkg_id,
-                                pkg_res.remote_tarball().slice(string_buf),
-                                ctx,
-                                patch_info.name_and_version_hash(),
-                            ) {
+                            let url = {
+                                let string_buf =
+                                    installer.manager.lockfile.buffers.string_bytes.as_slice();
+                                bun_core::StringOrTinyString::init_append_if_needed(
+                                    pkg_res.remote_tarball().slice(string_buf),
+                                    &mut crate::network_task::filename_store_appender(),
+                                )?
+                            };
+                            match installer
+                                .manager
+                                .enqueue_tarball_for_download(dep_id, pkg_id, url, ctx)
+                            {
                                 Ok(()) => {}
                                 Err(e) if e == crate::Error::Alloc(bun_alloc::AllocError) => {
                                     bun_core::out_of_memory()
@@ -2564,16 +2570,14 @@ pub(crate) fn install_isolated_packages(
                                     continue;
                                 }
                                 Err(err) => {
+                                    let (name, res) = describe(&installer);
                                     Output::err(
                                         err,
                                         "failed to enqueue tarball for download: {}@{}",
-                                        (
-                                            BStr::new(pkg_name.slice(string_buf)),
-                                            pkg_res.fmt(string_buf, bun_fmt::PathSep::Auto),
-                                        ),
+                                        (BStr::new(&name), BStr::new(&res)),
                                     );
                                     Output::flush();
-                                    if installer.manager().options.enable.fail_early() {
+                                    if installer.manager.options.enable.fail_early() {
                                         Global::exit(1);
                                     }
                                     // .monotonic is okay because an error means the task isn't
@@ -2602,31 +2606,26 @@ pub(crate) fn install_isolated_packages(
             }
         }
 
-        if installer.manager().pending_task_count() > 0 {
-            let mgr: *mut PackageManager = manager_ptr;
-            let mut wait = Wait {
-                installer: &mut installer,
-                err: None,
-            };
-            // SAFETY: `mgr` is the same raw `manager_ptr` stored in
-            // `installer.manager`; `sleep_until` + `tick_raw` hold no
-            // `&mut PackageManager` across `Wait::is_done`.
-            unsafe { PackageManager::sleep_until(mgr, &mut wait, Wait::is_done) };
+        if installer.manager.pending_task_count() > 0 {
+            let mut err: Option<crate::Error> = None;
+            PackageManager::sleep_until(&mut installer, |installer| {
+                wait_is_done(installer, &mut err)
+            });
 
-            if let Some(err) = wait.err {
+            if let Some(err) = err {
                 Output::err(err, "failed to install packages", format_args!(""));
                 Global::exit(1);
             }
         }
 
-        if installer.manager().options.log_level.show_progress() {
-            progress.root.end();
-            *progress = Progress::default();
+        installer.apply_trusted_additions();
+
+        if installer.manager.options.log_level.show_progress() {
+            installer.manager.progress.root.end();
+            installer.manager.progress = Progress::default();
         }
-        // Defensive: clear the stack-local progress-node pointers so the
-        // accessors can't observe dangling pointers after this frame returns.
-        installer.manager_mut().scripts_node = None;
-        installer.manager_mut().downloads_node = None;
+        installer.manager.scripts_node = None;
+        installer.manager.downloads_node = None;
 
         if Environment::CI_ASSERT {
             let mut done = true;
@@ -2634,9 +2633,9 @@ pub(crate) fn install_isolated_packages(
                 store.entries.items_step().iter().enumerate()
             {
                 let entry_id = store::entry::Id::from(u32::try_from(_entry_id).expect("int cast"));
-                // .monotonic is okay because `Wait.isDone` should have already synchronized with
-                // the completed task threads, via popping from the `UnboundedQueue` in `runTasks`,
-                // and the .acquire load `pendingTaskCount`.
+                // Relaxed is okay because `wait_is_done` already synchronized with the completed
+                // task threads: results are drained under the `task_queue` lock in `run_tasks`,
+                // and `pending_task_count` is an acquire load.
                 let step = entry_step.load(Ordering::Relaxed);
 
                 if step == installer::Step::Done as u32 {
@@ -2653,7 +2652,7 @@ pub(crate) fn install_isolated_packages(
 
                 let deps = &store.entries.items_dependencies()[entry_id.get() as usize];
                 for dep in deps.slice() {
-                    // .monotonic is okay because `Wait.isDone` already synchronized with the tasks.
+                    // .monotonic is okay because `wait_is_done` already synchronized with the tasks.
                     let dep_step = entry_steps[dep.entry_id.get() as usize].load(Ordering::Relaxed);
                     if dep_step != installer::Step::Done as u32 {
                         log!(", parents:\n - ");

--- a/src/install/isolated_install/FileCloner.rs
+++ b/src/install/isolated_install/FileCloner.rs
@@ -5,7 +5,7 @@ use bun_sys::{self as sys, Errno, Fd, FdDirExt, FdExt};
 // macOS clonefileat only
 
 // `cache_dir_subpath` is borrowed mutably (rather than owned) so the caller's
-// path survives a clonefile→hardlink fallback (`continue 'backend` in
+// path survives a clonefile-to-hardlink fallback (`continue 'backend` in
 // `Installer::Task::run`). The borrow must be `&mut` because `Path::slice_z`
 // writes the NUL terminator into the pooled buf.
 #[allow(dead_code)]
@@ -39,7 +39,7 @@ impl FileCloner<'_> {
                     // Stale leftover (an earlier crash, or a re-run after the
                     // global-store staging directory wasn't cleaned). The
                     // global-store entry is published by an entry-level
-                    // rename in `commitGlobalStoreEntry`, so it's always safe
+                    // rename in `commit_global_store_entry`, so it's always safe
                     // to wipe and re-clone here — we're only ever writing
                     // into a per-process staging directory or a project-local
                     // path, never into a published shared directory.

--- a/src/install/isolated_install/FileCopier.rs
+++ b/src/install/isolated_install/FileCopier.rs
@@ -1,6 +1,3 @@
-#[cfg(windows)]
-use core::ptr;
-
 use bun_alloc::AllocError;
 #[cfg(not(windows))]
 use bun_core::{Global, fmt as bun_fmt};
@@ -36,20 +33,12 @@ impl FileCopier {
             src_path,
             dest_subpath,
             walker: {
-                let mut w = walker_skippable::walk(
-                    src_dir,
-                    // bun.default_allocator → deleted (global mimalloc)
-                    &[],
-                    skip_dirnames,
-                )?;
+                let mut w = walker_skippable::walk(src_dir, &[], skip_dirnames)?;
                 w.resolve_unknown_entry_types = true;
                 w
             },
         })
     }
-
-    // `Walker` owns its resources and drops automatically, so no explicit
-    // `Drop` impl is needed.
 
     pub(crate) fn copy(&mut self) -> sys::Result<()> {
         // `make_open_path` is u8-only; on Windows the OS-unit path is u16 so
@@ -73,7 +62,7 @@ impl FileCopier {
         ) {
             Ok(d) => d,
             Err(e) => {
-                // TODO: remove the need for this and implement openDir makePath makeOpenPath in bun
+                // TODO: remove the need for this and implement open_dir make_path make_open_path in bun
                 let errno: E = match e.get_errno() {
                     E::EACCES => E::EPERM,
                     other => other,
@@ -120,15 +109,10 @@ impl FileCopier {
 
                 let result: sys::Result<()> = match entry.kind {
                     EntryKind::Directory => {
-                        // SAFETY: FFI — both `slice_z()` are NUL-terminated WStrs.
-                        if unsafe {
-                            bun_sys::windows::CreateDirectoryExW(
-                                self.src_path.slice_z().as_ptr(),
-                                self.dest_subpath.slice_z().as_ptr(),
-                                ptr::null_mut(),
-                            )
-                        } == 0
-                        {
+                        if !bun_sys::windows::create_directory_ex_w(
+                            self.src_path.slice_z(),
+                            self.dest_subpath.slice_z(),
+                        ) {
                             let _ = bun_sys::make_path::make_path::<u16>(
                                 &dest_dir,
                                 entry.path.as_slice(),
@@ -224,10 +208,7 @@ impl FileCopier {
                         sys::Result::Ok(s) => s,
                         sys::Result::Err(_) => continue,
                     };
-                    // SAFETY: fchmod is safe to call with any fd + mode; errors are ignored (`_ =`).
-                    unsafe {
-                        let _ = bun_sys::c::fchmod(dest.handle().native(), stat.st_mode);
-                    }
+                    let _ = bun_sys::fchmod(dest.handle(), stat.st_mode as bun_sys::Mode);
                 }
 
                 match bun_sys::copy_file::copy_file_with_state(

--- a/src/install/isolated_install/Hardlinker.rs
+++ b/src/install/isolated_install/Hardlinker.rs
@@ -35,12 +35,7 @@ impl Hardlinker {
             src,
             dest,
             walker: {
-                let mut w = bun_sys::walker_skippable::walk(
-                    folder_dir,
-                    // bun.default_allocator dropped — global mimalloc
-                    &[],
-                    skip_dirnames,
-                )?;
+                let mut w = bun_sys::walker_skippable::walk(folder_dir, &[], skip_dirnames)?;
                 w.resolve_unknown_entry_types = true;
                 w
             },
@@ -77,14 +72,11 @@ impl Hardlinker {
                         )));
                     }
                 };
-                // SAFETY: `dest_cwd` is a sub-slice of `cwd_buf` by contract of
+                // `dest_cwd` is a sub-slice of `cwd_buf` by contract of
                 // `get_fd_path_w` (it returns `&mut out_buffer[off..]`).
-                // NB: capture `len`/`dest_ptr` first so NLL drops the `&mut cwd_buf`
-                // loan (held via `dest_cwd`) before `cwd_buf.as_ptr()` takes `&cwd_buf`
-                // — otherwise E0502 on x86_64-pc-windows-msvc.
                 let len = dest_cwd.len();
-                let dest_ptr = dest_cwd.as_ptr();
-                let off = unsafe { dest_ptr.offset_from(cwd_buf.as_ptr()) } as usize;
+                let dest_addr = dest_cwd.as_ptr() as usize;
+                let off = (dest_addr - cwd_buf.as_ptr() as usize) / core::mem::size_of::<u16>();
                 (off, len)
             };
 

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -7,7 +7,6 @@ use bun_core::{Environment, Global, Output};
 use bun_core::{ZStr, strings};
 use bun_paths::{self as paths, AbsPath, AutoAbsPath, AutoRelPath};
 use bun_sys::{self as sys, Fd};
-use bun_threading::{Mutex, UnboundedQueue, thread_pool};
 
 use bun_semver::String as SemverString;
 use bun_sys::{FdDirExt as _, FdExt as _};
@@ -16,7 +15,6 @@ use crate::bin_real;
 use crate::lockfile::package;
 use crate::lockfile_real::PackageIDSlice;
 use crate::package_install::{Method as InstallMethod, Summary as InstallSummary};
-use crate::package_manager_real::Command;
 use crate::postinstall_optimizer;
 use crate::postinstall_optimizer::PostinstallOptimizer;
 use crate::resolution;
@@ -54,8 +52,7 @@ type AutoPath = paths::Path<u8, { PathKind::ANY }, { PathSeparators::AUTO }>;
 type OsAutoAbsPath = AbsPath<paths::OSPathChar, { PathSeparators::AUTO }>;
 type OsAutoPath = paths::Path<paths::OSPathChar, { PathKind::ANY }, { PathSeparators::AUTO }>;
 type DefaultAbsPath = AbsPath<u8>;
-/// `node_modules/.bun` — the `MODULES_DIR_NAME` const is `&[u8]` and not
-/// usable in `const_format::concatcp!`, so spell the literal.
+/// `node_modules/.bun`, as a `&str` for `const_format::concatcp!`.
 const NODE_MODULES_BUN: &str = "node_modules/.bun";
 
 bun_output::declare_scope!(IsolatedInstaller, hidden);
@@ -64,32 +61,28 @@ macro_rules! debug {
 }
 
 pub struct Installer<'a> {
-    pub(crate) trusted_dependencies_mutex: Mutex,
-    /// BACKREF. Raw pointer (not `&'a mut`) for the same
-    /// reason as `manager`: `Task::run` executes concurrently on the thread
-    /// pool and each task derefs this field; a `&'a mut` would assert
-    /// exclusivity every concurrent task violates. Mutated only for
-    /// `lockfile.trusted_dependencies` (under `trusted_dependencies_mutex`,
-    /// narrowed via `addr_of_mut!`). Never null. Read via `lockfile()`.
-    pub lockfile: *mut Lockfile,
+    /// `--trust`ed packages a task found scripts for, as
+    /// `(name hash, name)`; merged into `lockfile.trusted_dependencies` and
+    /// `manager.trusted_deps_to_add_to_package_json` by the main thread once
+    /// every task is done (`apply_trusted_additions`).
+    pub(crate) trusted_additions:
+        bun_threading::Guarded<Vec<(TruncatedPackageNameHash, Box<[u8]>)>>,
 
     pub(crate) summary: InstallSummary,
     pub(crate) installed: Bitset,
     pub(crate) install_node: Option<&'a mut ProgressNode>,
     pub(crate) is_new_bun_modules: bool,
 
-    /// BACKREF. Raw pointer (not `&'a mut`) because
-    /// `Task::run`/`Task::callback` execute concurrently on the thread pool
-    /// and each derefs this field; a `&'a mut` here would assert exclusivity
-    /// every concurrent task violates. Never null. Access via `manager()` /
-    /// `manager_mut()` (main thread only for `_mut`).
-    pub(crate) manager: *mut PackageManager,
-    pub(crate) command_ctx: Command::Context<'a>,
+    /// The main thread mutates the manager through this; worker tasks reach
+    /// it read-only through their `BackRef<Installer>`.
+    pub(crate) manager: &'a mut PackageManager,
+    pub(crate) shared: &'static crate::package_manager::Shared,
 
     pub(crate) store: &'a Store,
 
-    pub(crate) task_queue: UnboundedQueue<Task>, // intrusive via .next
-    pub(crate) tasks: Box<[Task]>,
+    /// Finished (or parked) task runs for the main thread, oldest first.
+    pub(crate) task_queue: bun_threading::Guarded<Vec<(StoreEntryId, Result)>>,
+    pub(crate) tasks: bun_threading::TaskSlots<Task<'a>>,
 
     /// Stable Rust has no
     /// generic atomic-enum, so store the `#[repr(u8)]` discriminant and
@@ -120,61 +113,42 @@ pub struct Installer<'a> {
 }
 
 impl<'a> Installer<'a> {
-    // BACKREF accessors — `manager` points outside `Self`; see field doc.
     #[inline]
-    pub(crate) fn manager(&self) -> &'a PackageManager {
-        // SAFETY: BACKREF — never null; pointee outlives `'a`.
-        unsafe { &*self.manager }
+    pub(crate) fn manager(&self) -> &PackageManager {
+        self.manager
     }
     #[inline]
-    #[allow(clippy::mut_from_ref)]
-    pub(crate) fn manager_mut(&self) -> &'a mut PackageManager {
-        // SAFETY: BACKREF — never null; disjoint from `*self`. Return is `'a`
-        // (not elided) so `start_task` can hold it across `&mut self.tasks[i]`
-        // — same field-disjoint shape the prior `&'a mut` field permitted.
-        // Caller must be on the main thread (only main mutates
-        // `PackageManager`; `Task::run` / `Task::callback` on the pool read
-        // via the raw field, never this accessor). A
-        // `debug_assert!(is_main_thread())` is deferred until
-        // `bun_crash_handler::cli_state::set_main_thread_id` is actually
-        // wired at startup — today the sentinel is never set, so the assert
-        // would fire unconditionally.
-        unsafe { &mut *self.manager }
+    pub fn lockfile(&self) -> &Lockfile {
+        &self.manager.lockfile
     }
-    #[inline]
-    pub fn lockfile(&self) -> &'a Lockfile {
-        // SAFETY: BACKREF — never null; pointee outlives `'a`. Never aliased by
-        // a *whole-struct* `&mut Lockfile`; the single mutated field
-        // (`trusted_dependencies`) is written under
-        // `trusted_dependencies_mutex` via a raw narrowed `addr_of_mut!` place
-        // (Task::run), not a `&mut Lockfile`. Callers must not project into
-        // `trusted_dependencies` from this `&Lockfile` across a tick.
-        unsafe { &*self.lockfile }
+
+    /// Main thread, after every task has finished: record the `--trust`ed
+    /// packages tasks found scripts for.
+    pub(crate) fn apply_trusted_additions(&mut self) {
+        let additions = core::mem::take(&mut *self.trusted_additions.lock());
+        for (name_hash, name) in additions {
+            self.manager
+                .trusted_deps_to_add_to_package_json
+                .push(name.clone());
+            self.manager
+                .lockfile
+                .trusted_dependencies
+                .get_or_insert_with(Default::default)
+                .insert(name_hash, name);
+        }
     }
 
     /// Called from main thread
     pub(crate) fn start_task(&mut self, entry_id: StoreEntryId) {
-        let manager = self.manager_mut();
-        let task = &mut self.tasks[entry_id.get() as usize];
-        debug_assert!(matches!(
-            task.result,
-            // first time starting the task
-            Result::None
-            // the task returned to the main thread because it was blocked
-            | Result::Blocked
-            // the task returned to the main thread to spawn some scripts
-            | Result::RunScripts(_)
-        ));
-
-        task.result = Result::None;
-        manager
-            .thread_pool
-            .schedule(thread_pool::Batch::from(&raw mut task.task));
+        self.tasks
+            .schedule(&self.manager.thread_pool, entry_id.get() as usize);
     }
 
     /// Called from main thread, for an existing project-local store entry.
     pub(crate) fn start_relink_task(&mut self, entry_id: StoreEntryId) {
-        self.tasks[entry_id.get() as usize].relink = Relink::Pending;
+        self.tasks
+            .get(entry_id.get() as usize)
+            .set_relink(Relink::Pending);
         // .monotonic is okay because the task isn't running yet.
         self.store.entries.items_step()[entry_id.get() as usize]
             .store(Step::SymlinkDependencies as u32, Ordering::Relaxed);
@@ -182,7 +156,7 @@ impl<'a> Installer<'a> {
     }
 
     pub(crate) fn on_package_extracted(&mut self, task_id: crate::package_manager_task::Id) {
-        if let Some(removed) = self.manager_mut().task_queue.remove(&task_id) {
+        if let Some(removed) = self.manager.task_queue.remove(&task_id) {
             let store = self.store;
 
             let node_pkg_ids = store.nodes.items_pkg_id();
@@ -239,7 +213,7 @@ impl<'a> Installer<'a> {
     /// Called from main thread when a tarball download or extraction fails.
     /// Without this, the upfront pending-task slot for each waiting entry is
     /// never released and the install loop blocks forever on
-    /// `pendingTaskCount() == 0`.
+    /// `pending_task_count() == 0`.
     pub(crate) fn on_package_download_error(
         &mut self,
         task_id: crate::package_manager_task::Id,
@@ -248,7 +222,7 @@ impl<'a> Installer<'a> {
         err: crate::Error,
         url: &[u8],
     ) {
-        if let Some(removed) = self.manager_mut().task_queue.remove(&task_id) {
+        if let Some(removed) = self.manager.task_queue.remove(&task_id) {
             let callbacks = removed;
 
             let entry_steps = self.store.entries.items_step();
@@ -296,7 +270,7 @@ impl<'a> Installer<'a> {
         let node_pkg_ids = store.nodes.items_pkg_id();
         let pkg_id = node_pkg_ids[node_id.get() as usize];
         let mut patch_task = install::PatchTask::new_apply_patch_hash(
-            self.manager_mut(),
+            self.manager,
             pkg_id,
             patch.contents_hash,
             patch.name_and_version_hash,
@@ -445,14 +419,14 @@ impl<'a> Installer<'a> {
     }
 
     pub(crate) fn decrement_pending_tasks(&mut self) {
-        self.manager_mut().decrement_pending_tasks();
+        self.manager.decrement_pending_tasks();
     }
 
     /// Called from main thread
     pub(crate) fn on_task_blocked(&mut self, entry_id: StoreEntryId) {
         // race condition (fixed now): task decides it is blocked because one of its dependencies
         // has not finished. before the task can mark itself as blocked, the dependency finishes its
-        // install, causing the task to never finish because resumeUnblockedTasks is called before
+        // install, causing the task to never finish because resume_unblocked_tasks is called before
         // its state is set to blocked.
         //
         // fix: check if the task is unblocked after the task returns blocked, and only set/unset
@@ -509,13 +483,13 @@ impl<'a> Installer<'a> {
 
     /// Called from main thread
     pub(crate) fn on_task_complete(&mut self, entry_id: StoreEntryId, state: CompleteState) {
-        let state = match self.tasks[entry_id.get() as usize].relink {
+        let state = match self.tasks.get(entry_id.get() as usize).relink() {
             Relink::Unchanged => CompleteState::Skipped,
             Relink::Off | Relink::Pending | Relink::Changed => state,
         };
         if Environment::CI_ASSERT {
-            // .monotonic is okay because we should have already synchronized with the completed
-            // task thread by virtue of popping from the `UnboundedQueue`.
+            // Relaxed is okay: this result was taken out under the `task_queue` lock, which
+            // synchronizes with the completed task thread.
             assert!(
                 self.store.entries.items_step()[entry_id.get() as usize].load(Ordering::Relaxed)
                     == Step::Done as u32,
@@ -622,11 +596,23 @@ pub enum CompleteState {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
 pub enum Relink {
     Off,
     Pending,
     Unchanged,
     Changed,
+}
+
+impl Relink {
+    fn from_u8(v: u8) -> Relink {
+        match v {
+            0 => Relink::Off,
+            1 => Relink::Pending,
+            2 => Relink::Unchanged,
+            _ => Relink::Changed,
+        }
+    }
 }
 
 fn download_error_reason(e: crate::Error) -> &'static [u8] {
@@ -648,28 +634,36 @@ fn download_error_reason(e: crate::Error) -> &'static [u8] {
 // Task
 // ──────────────────────────────────────────────────────────────────────────
 
-pub struct Task {
+pub struct Task<'a> {
     pub(crate) entry_id: StoreEntryId,
-    /// BACKREF: `Installer` owns `tasks[]` and outlives every `Task`. Stored as
-    /// `BackRef` so worker-thread read sites use safe `Deref`/`get()` instead of
-    /// per-site raw-pointer derefs. Constructed with a `NonNull::dangling()`
-    /// placeholder (never dereferenced) and patched to the real address before
-    /// any `start_task` call — see `isolated_install.rs`.
-    pub(crate) installer: bun_ptr::BackRef<Installer<'static>>,
-
-    pub(crate) task: thread_pool::Task,
-    pub(crate) next: bun_threading::Link<Task>, // INTRUSIVE: bun.UnboundedQueue(Task, .next) link
-
-    pub(crate) result: Result,
-    pub(crate) relink: Relink,
+    /// BACKREF: `Installer` owns `tasks` and outlives every `Task`. Set once
+    /// the installer has its final address, before any `start_task` call —
+    /// see `isolated_install.rs`.
+    pub(crate) installer: std::sync::OnceLock<bun_ptr::BackRef<Installer<'a>>>,
+    /// A [`Relink`]; written by the main thread before the task starts and by
+    /// the task while it runs.
+    relink: AtomicU8,
 }
 
-// SAFETY: `next` is the sole intrusive link for `UnboundedQueue<Task>`.
-unsafe impl bun_threading::Linked for Task {
+impl<'a> Task<'a> {
+    pub(crate) fn new(entry_id: StoreEntryId) -> Task<'a> {
+        Task {
+            entry_id,
+            installer: std::sync::OnceLock::new(),
+            relink: AtomicU8::new(Relink::Off as u8),
+        }
+    }
     #[inline]
-    unsafe fn link(item: *mut Self) -> *const bun_threading::Link<Self> {
-        // SAFETY: `item` is valid and properly aligned per `UnboundedQueue` contract.
-        unsafe { core::ptr::addr_of!((*item).next) }
+    fn installer(&self) -> &Installer<'a> {
+        self.installer.get().expect("installer set").get()
+    }
+    #[inline]
+    fn relink(&self) -> Relink {
+        Relink::from_u8(self.relink.load(Ordering::Relaxed))
+    }
+    #[inline]
+    fn set_relink(&self, relink: Relink) {
+        self.relink.store(relink as u8, Ordering::Relaxed);
     }
 }
 
@@ -677,11 +671,8 @@ pub enum Result {
     None,
     Err(TaskError),
     Blocked,
-    // Kept raw (semantically `&mut package::scripts::List`): the pointee is
-    // owned by `store.entries.items(.scripts)[entry_id]`, which outlives every
-    // task; threading `'a` here is blocked by the `Installer<'static>` BackRef
-    // the queued `Task` already carries.
-    RunScripts(*mut package::scripts::List),
+    /// The scripts to run are in `store.entries.items_scripts()[entry_id]`.
+    RunScripts,
     Done,
 }
 
@@ -755,7 +746,6 @@ impl Step {
             6 => Step::RunPostInstallAndPrePostPrepare,
             7 => Step::Done,
             8 => Step::Blocked,
-            // Was @enumFromInt; cold atomic-load decode so the panic branch is fine.
             _ => unreachable!(),
         }
     }
@@ -763,9 +753,8 @@ impl Step {
 
 pub(crate) enum Yield {
     Yield,
-    // Kept raw (semantically `&mut package::scripts::List`): borrow of
-    // `entry_scripts`, owned by the store entry — see `Result::RunScripts`.
-    RunScripts(*mut package::scripts::List),
+    /// See `Result::RunScripts`.
+    RunScripts,
     Done,
     Blocked,
     Fail(TaskError),
@@ -777,7 +766,7 @@ impl Yield {
     }
 }
 
-impl Task {
+impl Task<'_> {
     /// Called from task thread
     fn next_step(&self, current_step: Step) -> Step {
         let next_step: Step = match current_step {
@@ -785,7 +774,7 @@ impl Task {
             Step::SymlinkDependencies => Step::CheckIfBlocked,
             Step::CheckIfBlocked => Step::SymlinkDependencyBinaries,
             Step::SymlinkDependencyBinaries => {
-                if self.relink == Relink::Off {
+                if self.relink() == Relink::Off {
                     Step::RunPreinstall
                 } else {
                     Step::Done
@@ -798,19 +787,7 @@ impl Task {
             Step::Done | Step::Blocked => unreachable!("unexpected step"),
         };
 
-        // SAFETY: `installer` is a BACKREF — the `Installer` owns `tasks[]` and
-        // outlives every `Task` it schedules; the pointer is never null.
-        //
-        // We deliberately do **not** materialize `&Installer` here: this runs on
-        // a thread-pool worker while the main thread may concurrently hold
-        // `&mut Installer` (e.g. `start_task` writing `tasks[i].result`, or
-        // `on_package_extracted`). A worker-side `&Installer` would alias that
-        // `&mut` under Stacked Borrows. Instead, raw-read the `store: &Store`
-        // field by value via `addr_of!` so no `&Installer` is formed — `Store`
-        // lives outside the `Installer` allocation and `items_step()` is atomic.
-        // This also avoids leaking the erased `'static` from
-        // `*mut Installer<'static>` into a whole-struct borrow.
-        let store: &Store = unsafe { *core::ptr::addr_of!((*self.installer.as_const_ptr()).store) };
+        let store: &Store = self.installer().store;
         store.entries.items_step()[self.entry_id.get() as usize]
             .store(next_step as u32, Ordering::Release);
 
@@ -818,44 +795,14 @@ impl Task {
     }
 
     /// Called from task thread
-    fn run(&mut self) -> core::result::Result<Yield, bun_alloc::AllocError> {
-        // SAFETY: installer outlives all tasks (BACKREF). `run()` executes on the
-        // thread pool concurrently across many `Task`s that all share the same
-        // `*mut Installer`, and `next_step()` re-derefs `self.installer` mid-loop —
-        // materializing `&mut Installer` here would alias both. Instead:
-        //   * `installer` is a shared `&Installer`; every Installer method called
-        //     below takes `&self`.
-        //   * `manager_ptr` / `lockfile_ptr` are reached by raw-reading their
-        //     pointer fields. They point to allocations *outside* `Installer`, so
-        //     they do not overlap `installer`. They stay RAW for the whole body —
-        //     binding a function-scoped `&mut PackageManager` / `&mut Lockfile`
-        //     here would mean every concurrent task thread holds an aliased
-        //     `&mut` to the same object (UB regardless of mutex discipline).
-        //     Per-site reborrows below are `&*manager_ptr` for read-only access,
-        //     and mutation is narrowed via `addr_of_mut!` to the single field
-        //     being written while `trusted_dependencies_mutex` is held.
-        //   * Never access `installer.manager.*` / mutate `installer.lockfile.*`
-        //     while these locals are live — that would reborrow through
-        //     `&Installer` and alias `*manager_ptr` / `*lockfile_ptr`.
-        let installer_ptr = self.installer;
-        let installer = installer_ptr.get();
-        let manager_ptr: *mut PackageManager = installer.manager;
-        let lockfile_ptr: *mut Lockfile = installer.lockfile;
-        // BACKREF — `manager_ptr` is non-null and the `PackageManager` outlives
-        // every `Task` (see top-of-fn note). Wrapped once as `ParentRef` so the
-        // read-only deref sites below go through safe `Deref`/`get()` instead
-        // of per-site `unsafe { &* }`. Mutation and narrowed `addr_of_mut!`
-        // field projections still go through the raw `manager_ptr` directly
-        // (same provenance tag as `manager_ref.ptr`). Safe `From<NonNull>`
-        // construction — non-null is guaranteed by the BACKREF field invariant.
-        let manager_ref = bun_ptr::ParentRef::<PackageManager>::from(
-            core::ptr::NonNull::new(manager_ptr).expect("Installer.manager BACKREF is non-null"),
-        );
-        // Read-only `&Lockfile` via the BACKREF accessor (centralised deref);
-        // same provenance as `&*lockfile_ptr`. `lockfile_ptr` itself is kept
-        // raw for the narrowed `addr_of_mut!((*lockfile_ptr).trusted_dependencies)`
-        // write under `trusted_dependencies_mutex` below.
-        let lockfile: &Lockfile = installer.lockfile();
+    fn run_steps(&self) -> core::result::Result<Yield, bun_alloc::AllocError> {
+        // `installer` (and through it the manager and lockfile) is shared
+        // read-only across every task thread; anything a task needs to record
+        // goes through `store.entries` (atomic / per-entry cells) or
+        // `installer.trusted_additions`.
+        let installer: &Installer<'_> = self.installer();
+        let manager_ref: &PackageManager = installer.manager;
+        let lockfile: &Lockfile = &manager_ref.lockfile;
 
         let pkgs = lockfile.packages.slice();
         let pkg_names = pkgs.items_name();
@@ -891,6 +838,7 @@ impl Task {
                 Step::LinkPackage => {
                     let current_step = Step::LinkPackage;
                     let string_buf = lockfile.buffers.string_bytes.as_slice();
+                    let mut cache_dir_subpath_buf = bun_paths::path_buffer_pool::get();
 
                     // Compute pkg_cache_dir_subpath; for .folder/.root the work happens inline and
                     // we `continue` to next step from inside the match.
@@ -993,24 +941,14 @@ impl Task {
 
                                         #[cfg(windows)]
                                         {
-                                            // Hoist a single `&mut [u16]` borrow so the raw pointer
-                                            // and length come from the SAME reborrow — calling
-                                            // `src_path.buf()` twice in the FFI arg list would take
-                                            // a fresh `&mut` for the len, invalidating the `*mut u16`
-                                            // derived from the first call under Stacked Borrows.
                                             let buf = src_path.buf();
                                             let cap = buf.len();
-                                            let ptr = buf.as_mut_ptr();
-                                            // SAFETY: FFI — `folder_dir` is an open handle; `ptr`
-                                            // points into a writable WPathBuffer of `cap` elements.
-                                            let src_path_len = unsafe {
-                                                bun_sys::windows::GetFinalPathNameByHandleW(
+                                            let src_path_len =
+                                                bun_sys::windows::get_final_path_name_by_handle_w(
                                                     folder_dir.native(),
-                                                    ptr,
-                                                    u32::try_from(cap).expect("int cast"),
+                                                    buf,
                                                     0,
-                                                )
-                                            };
+                                                );
 
                                             if src_path_len == 0 || src_path_len as usize >= cap {
                                                 return Ok(Yield::failure(TaskError::LinkPackage(
@@ -1093,29 +1031,31 @@ impl Task {
                                 Err(err) => return Ok(Yield::failure(err)),
                             };
 
-                            let manager = manager_ref.get();
-                            // SAFETY: `tag` discriminates the active `Resolution.value` variant
-                            // for each arm below.
+                            let manager = manager_ref;
                             match tag {
                                 ResolutionTag::Npm => directories::cached_npm_package_folder_name(
                                     manager,
+                                    &mut cache_dir_subpath_buf,
                                     pkg_name.slice(string_buf),
                                     pkg_res.npm().version,
                                     patch_info.contents_hash(),
                                 ),
                                 ResolutionTag::Git => directories::cached_git_folder_name(
                                     manager,
+                                    &mut cache_dir_subpath_buf,
                                     pkg_res.git(),
                                     patch_info.contents_hash(),
                                 ),
                                 ResolutionTag::Github => directories::cached_github_folder_name(
                                     manager,
+                                    &mut cache_dir_subpath_buf,
                                     pkg_res.github(),
                                     patch_info.contents_hash(),
                                 ),
                                 ResolutionTag::LocalTarball => {
                                     directories::cached_tarball_folder_name(
                                         manager,
+                                        &mut cache_dir_subpath_buf,
                                         *pkg_res.local_tarball(),
                                         patch_info.contents_hash(),
                                     )
@@ -1123,6 +1063,7 @@ impl Task {
                                 ResolutionTag::RemoteTarball => {
                                     directories::cached_tarball_folder_name(
                                         manager,
+                                        &mut cache_dir_subpath_buf,
                                         *pkg_res.remote_tarball(),
                                         patch_info.contents_hash(),
                                     )
@@ -1146,14 +1087,9 @@ impl Task {
                     let pkg_cache_dir_subpath =
                         AutoRelPath::from(pkg_cache_dir_subpath_init).assume_ok();
 
-                    // SAFETY: idempotent cache-dir initialization (once-init internally).
-                    // Scoped tightly so the `&mut PackageManager` does not outlive this
-                    // statement; no `&*manager_ptr` is live on this thread across it.
-                    // Concurrent task threads may race the same once-init path — that
-                    // is a data-level race the once-init guards, not an aliasing
-                    // violation here because no long-lived `&mut PackageManager` exists.
-                    let (cache_dir, cache_dir_path) =
-                        directories::get_cache_directory_and_abs_path(unsafe { &mut *manager_ptr });
+                    // Opened on the main thread before any task starts
+                    // (`install_isolated_packages`).
+                    let (cache_dir, cache_dir_path) = manager_ref.cache_directory_and_abs_path();
 
                     let uses_global_store = installer.entry_uses_global_store(self.entry_id);
 
@@ -1166,7 +1102,7 @@ impl Task {
                         // directory. Writing the new project-local tree
                         // *through* that link would mutate the shared entry
                         // underneath every other consumer; on Windows the
-                        // `.expect_missing` dep-symlink rewrite then bakes a
+                        // `ExpectMissing` dep-symlink rewrite then bakes a
                         // project-absolute junction target into the shared
                         // directory, which dangles after the next
                         // `rm -rf node_modules`. Detach first so the build
@@ -1242,9 +1178,8 @@ impl Task {
                         let _ = Fd::cwd().delete_tree(staging.slice());
                     }
 
-                    // reshaped for borrowck — `defer if (cached_package_dir) |d| d.close()`
-                    // becomes a guard that *owns* the `Option<Fd>` so the loop body can reassign
-                    // through `*cached_package_dir` without an outstanding closure borrow.
+                    // The guard *owns* the `Option<Fd>` so the loop body can reassign
+                    // through `*cached_package_dir` and it is still closed on every exit.
                     let mut cached_package_dir = scopeguard::guard(None::<Fd>, |dir| {
                         if let Some(d) = dir {
                             d.close();
@@ -1479,7 +1414,7 @@ impl Task {
 
                 Step::SymlinkDependencies => {
                     let current_step = Step::SymlinkDependencies;
-                    let relinking = self.relink != Relink::Off;
+                    let relinking = self.relink() != Relink::Off;
                     let strategy = if relinking
                         || matches!(pkg_res.tag, ResolutionTag::Root | ResolutionTag::Workspace)
                     {
@@ -1497,12 +1432,12 @@ impl Task {
 
                     if relinking {
                         if !changed {
-                            self.relink = Relink::Unchanged;
+                            self.set_relink(Relink::Unchanged);
                             entry_steps[self.entry_id.get() as usize]
                                 .store(Step::Done as u32, Ordering::Release);
                             return Ok(Yield::Done);
                         }
-                        self.relink = Relink::Changed;
+                        self.set_relink(Relink::Changed);
                     } else if installer.entry_uses_global_store(self.entry_id) {
                         match installer.link_project_to_global_store(self.entry_id) {
                             sys::Result::Ok(()) => {}
@@ -1603,6 +1538,7 @@ impl Task {
                             break 'brk (true, true);
                         }
                         if lockfile.has_trusted_dependency(
+                            &manager_ref.options,
                             dep.name.slice(string_buf),
                             pkg_name.slice(string_buf),
                             &pkg_res,
@@ -1623,7 +1559,7 @@ impl Task {
                         }
                         let mut pkg_scripts: package::scripts::Scripts =
                             pkg_script_lists[pkg_id as usize];
-                        let manager = manager_ref.get();
+                        let manager = manager_ref;
                         if is_trusted
                             && manager
                                 .postinstall_optimizer
@@ -1650,6 +1586,7 @@ impl Task {
                         let mut log = Log::init();
 
                         let scripts_list = match pkg_scripts.get_list(
+                            &manager_ref.options,
                             &mut log,
                             lockfile,
                             &mut pkg_cwd,
@@ -1666,15 +1603,11 @@ impl Task {
                             // Snapshot before boxing so the post-publish
                             // `first_index` check needs no raw-pointer deref.
                             let first_index = list.first_index;
-                            let clone: *mut package::scripts::List =
-                                bun_core::heap::into_raw(Box::new(list));
                             // Each Task is the sole writer for its own `entry_id`'s
                             // `scripts` slot; no other thread reads or writes it
                             // until this Task reaches
-                            // `Step::RunPostInstallAndPrePostPrepare`. The column
-                            // is `Cell<Option<*mut _>>` (see Store.rs) so writing
-                            // through `&Store` provenance is a safe `.set()`.
-                            entry_scripts[self.entry_id.get() as usize].set(Some(clone));
+                            // `Step::RunPostInstallAndPrePostPrepare`.
+                            entry_scripts[self.entry_id.get() as usize].set(Some(Box::new(list)));
 
                             if is_trusted_through_update_request {
                                 let (trusted_name, trusted_name_hash) =
@@ -1686,39 +1619,10 @@ impl Task {
                                     } else {
                                         (dep.name.slice(string_buf), truncated_dep_name_hash)
                                     };
-                                let trusted_dep_to_add: Box<[u8]> = Box::from(trusted_name);
-
-                                let _unlock = installer.trusted_dependencies_mutex.lock_guard();
-
-                                // SAFETY: `trusted_dependencies_mutex` is held. Narrow the
-                                // exclusive borrow to the single Vec field via raw place so
-                                // no `&mut PackageManager` is formed — concurrent task
-                                // threads' `&*manager_ptr` reborrows of other fields stay
-                                // valid.
-                                unsafe {
-                                    (*core::ptr::addr_of_mut!(
-                                        (*manager_ptr).trusted_deps_to_add_to_package_json
-                                    ))
-                                    .push(trusted_dep_to_add);
-                                }
-                                // SAFETY: `trusted_dependencies_mutex` is held, serializing
-                                // writers. Narrow to the single `trusted_dependencies` field
-                                // via raw place so no `&mut Lockfile` is ever formed — other
-                                // task threads hold `&Lockfile` (and the `pkgs`/`pkg_*`
-                                // slices above borrow it) for their entire run(), and those
-                                // borrows never touch `trusted_dependencies`.
-                                let trusted = unsafe {
-                                    &mut *core::ptr::addr_of_mut!(
-                                        (*lockfile_ptr).trusted_dependencies
-                                    )
-                                };
-                                if trusted.is_none() {
-                                    *trusted = Some(Default::default());
-                                }
-                                trusted
-                                    .as_mut()
-                                    .unwrap()
-                                    .insert(trusted_name_hash, Box::from(trusted_name));
+                                installer
+                                    .trusted_additions
+                                    .lock()
+                                    .push((trusted_name_hash, Box::from(trusted_name)));
                             }
 
                             if first_index != 0 {
@@ -1727,7 +1631,7 @@ impl Task {
                                 continue 'step;
                             }
 
-                            return Ok(Yield::RunScripts(clone));
+                            return Ok(Yield::RunScripts);
                         }
                     }
 
@@ -1801,15 +1705,6 @@ impl Task {
                         );
                     }
 
-                    // `target_node_modules_path` intentionally aliases
-                    // `node_modules_path` in the common (no-replacement) case —
-                    // the Linker field is a raw `*const AbsPath` for exactly
-                    // this reason.
-                    let target_nm_ptr: *const DefaultAbsPath =
-                        match target_node_modules_path.as_ref() {
-                            Some(p) => p,
-                            None => &raw const node_modules_path,
-                        };
                     let mut bin_linker = bin_real::Linker {
                         bin,
                         global_bin_path: manager_ref.options.bin_path,
@@ -1818,7 +1713,7 @@ impl Task {
                         string_buf,
                         extern_string_buf: lockfile.buffers.extern_strings.as_slice(),
                         seen: Some(&mut seen),
-                        target_node_modules_path: target_nm_ptr,
+                        target_node_modules_path: target_node_modules_path.as_ref(),
                         node_modules_path: &mut node_modules_path,
                         abs_target_buf: &mut *abs_target_buf,
                         abs_dest_buf: &mut *abs_dest_buf,
@@ -1832,7 +1727,7 @@ impl Task {
                     if target_node_modules_path.is_some()
                         && (bin_linker.skipped_due_to_missing_bin || bin_linker.err.is_some())
                     {
-                        bin_linker.target_node_modules_path = bin_linker.node_modules_path;
+                        bin_linker.target_node_modules_path = None;
                         bin_linker.target_package_name =
                             strings::StringOrTinyString::init(dep_name);
 
@@ -1874,16 +1769,11 @@ impl Task {
                     // This Task is the sole owner of its `entry_id`'s `scripts`
                     // slot; written (if at all) by this same Task in
                     // `Step::RunPreinstall` above, never touched concurrently.
-                    // `Cell::get` on a `Copy` payload — no unsafe needed.
-                    let Some(list) = entry_scripts[self.entry_id.get() as usize].get() else {
+                    let slot = &entry_scripts[self.entry_id.get() as usize];
+                    let Some(mut list) = slot.take() else {
                         step = self.next_step(current_step);
                         continue;
                     };
-                    // SAFETY: single-owner — `entry_scripts[entry_id]` holds a `*mut List`
-                    // boxed per-entry (see `Step::RunPreinstall` above), and each Task is
-                    // the unique consumer of its own `entry_id`. No other `&`/`&mut` to
-                    // this allocation is live.
-                    let list = unsafe { &mut *list };
 
                     if list.first_index == 0 {
                         for (i, item) in list.items[1..].iter().enumerate() {
@@ -1894,8 +1784,10 @@ impl Task {
                             }
                         }
                     }
+                    let first_index = list.first_index;
+                    slot.set(Some(list));
 
-                    if list.first_index == 0 {
+                    if first_index == 0 {
                         step = self.next_step(current_step);
                         continue;
                     }
@@ -1904,7 +1796,7 @@ impl Task {
                     // complete. the task does not have anymore work to complete
                     // so it does not return to the thread pool.
 
-                    return Ok(Yield::RunScripts(list));
+                    return Ok(Yield::RunScripts);
                 }
 
                 Step::Done => {
@@ -1918,95 +1810,74 @@ impl Task {
             }
         }
     }
+}
 
-    /// Called from task thread
-    pub(crate) unsafe fn callback(task: *mut thread_pool::Task) {
-        // SAFETY: task points to Task.task field
-        let this: &mut Task = unsafe { &mut *bun_core::from_field_ptr!(Task, task, task) };
+bun_threading::slot_task!(['a] Task<'a>);
 
-        let res = match this.run() {
+impl Task<'_> {
+    /// Runs on a worker thread.
+    fn run_slot(&self) {
+        let res = match self.run_steps() {
             Ok(r) => r,
             Err(_oom) => bun_core::out_of_memory(),
         };
 
-        // SAFETY: installer outlives all tasks (BACKREF). `callback` runs on the
-        // thread pool concurrently across many `Task`s sharing the same
-        // `*mut Installer` — never materialize `&mut Installer`. `task_queue.push`
-        // takes `&self` (lock-free); `store.entries` columns are atomic / per-entry;
-        // both are reached through a shared `&Installer`. `manager.wake()` is the
-        // cross-thread wakeup: route through `PackageManager::wake_raw` which never
-        // forms `&mut PackageManager`, so two threads finishing simultaneously do
-        // not hold aliased exclusive borrows ("deref it fresh per call" alone
-        // would not prevent the `&mut` lifetimes from overlapping).
-        let installer_ptr = this.installer;
-        let installer = installer_ptr.get();
-        let manager_ptr: *mut PackageManager = installer.manager;
+        // The installer (and through it the manager) is shared read-only by
+        // every task thread; results go back through `task_queue`, and
+        // `store.entries` columns are atomic / per-entry.
+        let installer: &Installer<'_> = self.installer();
+        let shared = installer.shared;
 
-        match res {
-            Yield::Yield => {}
-            Yield::RunScripts(list) => {
+        let result = match res {
+            Yield::Yield => return,
+            Yield::RunScripts => {
                 if Environment::CI_ASSERT {
-                    assert!(
-                        // `Cell::get` on a `Copy` payload — read-only check.
-                        installer.store.entries.items_scripts()[this.entry_id.get() as usize]
-                            .get()
-                            .is_some(),
-                    );
+                    let slot =
+                        &installer.store.entries.items_scripts()[self.entry_id.get() as usize];
+                    let list = slot.take();
+                    assert!(list.is_some());
+                    slot.set(list);
                 }
-                this.result = Result::RunScripts(list);
-                // SAFETY: `this` is a live `&mut Task`; ownership moves to the queue.
-                installer.task_queue.push(core::ptr::NonNull::from(this));
-                // SAFETY: `manager_ptr` is the non-null BACKREF; `PackageManager` outlives every `Task` (see fn-top SAFETY note).
-                unsafe { PackageManager::wake_raw(manager_ptr) };
+                Result::RunScripts
             }
             Yield::Done => {
                 if Environment::CI_ASSERT {
                     // .monotonic is okay because this should have been set by this thread.
                     assert!(
-                        installer.store.entries.items_step()[this.entry_id.get() as usize]
+                        installer.store.entries.items_step()[self.entry_id.get() as usize]
                             .load(Ordering::Relaxed)
                             == Step::Done as u32,
                     );
                 }
-                this.result = Result::Done;
-                // SAFETY: `this` is a live `&mut Task`; ownership moves to the queue.
-                installer.task_queue.push(core::ptr::NonNull::from(this));
-                // SAFETY: `manager_ptr` is the non-null BACKREF; `PackageManager` outlives every `Task` (see fn-top SAFETY note).
-                unsafe { PackageManager::wake_raw(manager_ptr) };
+                Result::Done
             }
             Yield::Blocked => {
                 if Environment::CI_ASSERT {
                     // .monotonic is okay because this should have been set by this thread.
                     assert!(
-                        installer.store.entries.items_step()[this.entry_id.get() as usize]
+                        installer.store.entries.items_step()[self.entry_id.get() as usize]
                             .load(Ordering::Relaxed)
                             == Step::CheckIfBlocked as u32,
                     );
                 }
-                this.result = Result::Blocked;
-                // SAFETY: `this` is a live `&mut Task`; ownership moves to the queue.
-                installer.task_queue.push(core::ptr::NonNull::from(this));
-                // SAFETY: `manager_ptr` is the non-null BACKREF; `PackageManager` outlives every `Task` (see fn-top SAFETY note).
-                unsafe { PackageManager::wake_raw(manager_ptr) };
+                Result::Blocked
             }
             Yield::Fail(err) => {
                 if Environment::CI_ASSERT {
                     // .monotonic is okay because this should have been set by this thread.
                     assert!(
-                        installer.store.entries.items_step()[this.entry_id.get() as usize]
+                        installer.store.entries.items_step()[self.entry_id.get() as usize]
                             .load(Ordering::Relaxed)
                             != Step::Done as u32,
                     );
                 }
-                installer.store.entries.items_step()[this.entry_id.get() as usize]
+                installer.store.entries.items_step()[self.entry_id.get() as usize]
                     .store(Step::Done as u32, Ordering::Release);
-                this.result = Result::Err(err);
-                // SAFETY: `this` is a live `&mut Task`; ownership moves to the queue.
-                installer.task_queue.push(core::ptr::NonNull::from(this));
-                // SAFETY: `manager_ptr` is the non-null BACKREF; `PackageManager` outlives every `Task` (see fn-top SAFETY note).
-                unsafe { PackageManager::wake_raw(manager_ptr) };
+                Result::Err(err)
             }
-        }
+        };
+        installer.task_queue.lock().push((self.entry_id, result));
+        shared.wake();
     }
 }
 
@@ -2373,13 +2244,6 @@ impl<'a> Installer<'a> {
                 );
             }
 
-            // see the matching note in `Step::LinkBinaries` —
-            // `target_node_modules_path` may alias `node_modules_path` and
-            // the Linker field is a raw `*const AbsPath` to permit that.
-            let target_nm_ptr: *const DefaultAbsPath = match target_node_modules_path.as_ref() {
-                Some(p) => p,
-                None => &raw const node_modules_path,
-            };
             let mut bin_linker = bin_real::Linker {
                 bin,
                 global_bin_path: self.manager().options.bin_path,
@@ -2388,7 +2252,7 @@ impl<'a> Installer<'a> {
                 extern_string_buf,
                 seen: Some(&mut seen),
                 node_modules_path: &mut node_modules_path,
-                target_node_modules_path: target_nm_ptr,
+                target_node_modules_path: target_node_modules_path.as_ref(),
                 target_package_name: if target_node_modules_path.is_some() {
                     target_package_name
                 } else {
@@ -2406,7 +2270,7 @@ impl<'a> Installer<'a> {
             if target_node_modules_path.is_some()
                 && (bin_linker.skipped_due_to_missing_bin || bin_linker.err.is_some())
             {
-                bin_linker.target_node_modules_path = bin_linker.node_modules_path;
+                bin_linker.target_node_modules_path = None;
                 bin_linker.target_package_name = package_name;
 
                 if self.manager().options.log_level.is_verbose() {
@@ -2565,7 +2429,7 @@ impl<'a> Installer<'a> {
         // Absolute target so the link is independent of where node_modules
         // lives (project root may itself be behind a symlink). Symlinker's
         // `target` field is RelPath-typed for the common in-tree case, so
-        // call sys.symlink/symlinkOrJunction directly here.
+        // call sys.symlink/symlink_or_junction directly here.
         fn do_symlink(d: &ZStr, t: &ZStr) -> sys::Result<()> {
             #[cfg(windows)]
             {
@@ -2671,7 +2535,7 @@ impl<'a> Installer<'a> {
         }
     }
 
-    /// Like `appendStoreNodeModulesPath`, but resolves to the *physical*
+    /// Like `append_store_node_modules_path`, but resolves to the *physical*
     /// location of the entry's `node_modules` directory: the global virtual
     /// store for global-eligible entries, or the project-local `.bun/` path
     /// otherwise. See `Which` for when to pass `.staging` vs `.final`.
@@ -2689,7 +2553,7 @@ impl<'a> Installer<'a> {
         self.append_store_node_modules_path(buf, entry_id);
     }
 
-    /// `appendStorePath` resolved to the entry's *physical* location. See
+    /// `append_store_path` resolved to the entry's *physical* location. See
     /// `Which` for when to pass `.staging` vs `.final`.
     pub(crate) fn append_real_store_path(
         &self,
@@ -2719,7 +2583,6 @@ impl<'a> Installer<'a> {
         let nodes = &self.store.nodes;
         let node_pkg_ids = nodes.items_pkg_id();
         let node_dep_ids = nodes.items_dep_id();
-        // let node_peers = nodes.items().peers;
 
         let pkgs = self.lockfile().packages.slice();
         let pkg_names = pkgs.items_name();

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -98,10 +98,7 @@ impl Drop for Store {
     fn drop(&mut self) {
         use entry::EntryColumns as _;
         for slot in self.entries.items_scripts() {
-            if let Some(list) = slot.take() {
-                // SAFETY: the installer returned only after every task finished, so nothing else references the list boxed in Installer's RunPreinstall step.
-                unsafe { bun_core::heap::destroy(list) };
-            }
+            drop(slot.take());
         }
         self.entries.drop_elements();
         self.nodes.drop_elements();
@@ -187,13 +184,10 @@ impl<T> OrderedArraySet<T> {
     const EMPTY: Self = Self { list: Vec::new() };
 
     pub(crate) fn init_capacity(n: usize) -> Result<Self, AllocError> {
-        // allocator param dropped — global mimalloc
         Ok(Self {
             list: Vec::with_capacity(n),
         })
     }
-
-    // `deinit` → handled by `Drop` on `Vec<T>`; nothing to write.
 
     pub(crate) fn slice(&self) -> &[T] {
         &self.list
@@ -225,7 +219,6 @@ impl<T: Copy> OrderedArraySet<T> {
         new: T,
         ctx: &impl OrderedArraySetCtx<T>,
     ) -> Result<(), AllocError> {
-        // allocator param dropped — global mimalloc
         for i in 0..self.list.len() {
             let existing = self.list[i];
             if ctx.eql(new, existing) {
@@ -291,20 +284,17 @@ pub mod entry {
         /// Two projects that resolve the same package to the same dependency closure
         /// share one global-store entry; if a transitive dep version differs, the
         /// hash differs and a new global-store entry is created. Computed after the
-        /// store is built (see `computeEntryHashes`). 0 means "do not use global store"
+        /// store is built (in `build_store`). 0 means "do not use global store"
         /// (root, workspace, folder, symlink, patched).
         pub entry_hash: u64,
 
-        // `Cell` because `Installer::Task::run` writes this slot
-        // from a task thread through `&Store` (each Task is the sole writer for
-        // its own `entry_id`; see Installer.rs). Without interior
-        // mutability the only access path is `&Store → &[Option<_>]` and the
-        // per-entry write would mutate through shared-reference provenance.
-        // Raw `*mut` instead of `Box` so reads don't move out of the cell.
-        // `Cell` (not `UnsafeCell`): payload is `Copy`, so `.get()/.set()` are
-        // zero-unsafe; `Cell` and `UnsafeCell` have identical `Send`/`!Sync`
-        // auto-traits, so the per-entry single-writer discipline is unchanged.
-        pub scripts: core::cell::Cell<Option<*mut package::scripts::List>>,
+        // `Cell` because `Installer::Task::run` writes this slot from a task
+        // thread through `&Store` (each Task is the sole writer for its own
+        // `entry_id`; see Installer.rs).
+        // Reads `take()` the box and `set()` it back; each entry's slot has a
+        // single owner at a time (its task, or the main thread while that task
+        // is parked), so the slot is never observed empty by anyone else.
+        pub scripts: core::cell::Cell<Option<Box<package::scripts::List>>>,
     }
 
     bun_collections::multi_array_columns! {
@@ -316,7 +306,7 @@ pub mod entry {
             hoisted: bool,
             peer_hash: PeerHash,
             entry_hash: u64,
-            scripts: core::cell::Cell<Option<*mut package::scripts::List>>,
+            scripts: core::cell::Cell<Option<Box<package::scripts::List>>>,
         }
     }
 

--- a/src/install/isolated_install/Symlinker.rs
+++ b/src/install/isolated_install/Symlinker.rs
@@ -79,7 +79,7 @@ impl Symlinker {
                                 // dest exists but isn't a symlink. If it's a real
                                 // directory, leave it: this is the `bun patch <pkg>`
                                 // workspace (a detached copy the user is editing
-                                // before `--commit`), and `deleteTree` here would
+                                // before `--commit`), and `delete_tree` here would
                                 // silently destroy their in-progress edits. If it's
                                 // a regular file, replace it.
                                 _ => {

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -2,12 +2,9 @@
 #![feature(adt_const_params)]
 
 // ──────────────────────────────────────────────────────────────────────────
-// Crate aliases — Phase-A drafts use the porting-doc crate names; map them
-// to the real workspace crates here so module bodies stay diff-minimal.
+// Crate aliases: module bodies name these crates by their short names, and
+// `bun_install::…` paths resolve from inside the crate.
 // ──────────────────────────────────────────────────────────────────────────
-// Self-alias so Phase-A drafts written against `bun_install::…` resolve
-// without rewriting every `use` (e.g. yarn.rs, extract_tarball.rs,
-// lifecycle_script_runner.rs).
 extern crate bun_sha_hmac as bun_sha;
 extern crate self as bun_install;
 // `bun_output::declare_scope!` / `scoped_log!` — the macros live at
@@ -35,29 +32,11 @@ pub(crate) mod bun_fs {
     pub(crate) use bun_resolver::fs::*;
 }
 
-/// `bun_progress` → re-export of the real `bun_core::Progress` (snapshot of
-/// pre-0.13 `std.Progress`). The earlier value-type counter shim was dropped
-/// once `ProgressStrings.rs`, `hoisted_install.rs`, `runTasks.rs` etc. started
-/// touching the full surface (`supports_ansi_escape_codes`, public `root`,
-/// `unprotected_*` atomics, `&mut Node` from `start()`); keeping a parallel
-/// type here just bifurcated `Node` identity across the crate.
+/// `bun_core::Progress` under the name the install code uses.
 pub(crate) mod bun_progress {
     pub(crate) use bun_core::Progress::{Node, Progress};
 }
 
-/// `bun_bunfig` → config-loading entrypoint. The real `bun_bunfig` crate now
-/// hosts `Arguments::loadConfig` (MOVE_DOWN b0); this local shim only adds the
-/// legacy `Arguments` alias (= `bun_options_types::context`) that
-/// `hoisted_install` / `isolated_install` import for `Transpiler::init`
-/// plumbing. Kept as a local module so those callers don't need updating; the
-/// crate-root `bun_bunfig` name shadows the extern crate, so callers needing
-/// the real crate spell it `::bun_bunfig`.
-pub(crate) mod bun_bunfig {
-
-    pub(crate) use bun_options_types::context as Arguments;
-}
-
-use core::cell::Cell;
 use core::fmt;
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -131,10 +110,7 @@ pub mod update_transitive;
 pub mod yarn;
 
 /// `repository` — re-export of the file-backed `repository_real` module
-/// (src/install/repository.rs). The earlier inline stub duplicated the
-/// `Repository` struct and stubbed `download`/`checkout`/`try_https` with
-/// `Err("RepositoryNotPorted")` / a partial rewrite table; the real module
-/// lives in the same crate with no dep cycle, so re-export it directly.
+/// (src/install/repository.rs).
 pub use repository_real as repository;
 
 /// `bin` — re-export of the file-backed `bin_real` module (src/install/bin.rs).
@@ -396,7 +372,6 @@ pub struct RunCommand;
 pub static PRETEND_TO_BE_NODE: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
-#[cfg(not(windows))]
 use bun_core::ZStr;
 
 impl RunCommand {
@@ -472,9 +447,8 @@ impl RunCommand {
     /// Returns a slice into a process-lifetime static buffer (includes trailing NUL).
     #[cfg(not(windows))]
     pub(crate) fn find_shell(path: &[u8], cwd: &[u8]) -> Option<&'static [u8]> {
-        // PORTING.md §Concurrency: `bun.once` + static buf → OnceLock. Store the
-        // result bytes (including NUL) directly in the OnceLock so the borrow is
-        // trivially `'static` — avoids the Mutex+data_ptr dance from the draft.
+        // The result bytes (including NUL) live in the OnceLock, so the borrow
+        // is trivially `'static`.
         static ONCE: std::sync::OnceLock<Option<Vec<u8>>> = std::sync::OnceLock::new();
 
         ONCE.get_or_init(|| {
@@ -497,7 +471,7 @@ impl RunCommand {
     #[cold]
     pub fn create_fake_temporary_node_executable(
         path: &mut Vec<u8>,
-        optional_bun_path: &mut &[u8],
+        optional_bun_path: &mut &'static ZStr,
     ) -> Result<(), crate::Error> {
         // If we are already running as "node", the path should exist
         if PRETEND_TO_BE_NODE.load(core::sync::atomic::Ordering::Relaxed) {
@@ -524,9 +498,7 @@ impl RunCommand {
             let argv0_z: &ZStr = if !optional_bun_path.is_empty() {
                 // When the caller pre-supplied a path, that path is the symlink
                 // target.
-                // SAFETY: callers pass a slice borrowed from a `ZStr` (argv[0] /
-                // self_exe_path / static literal), so `ptr[len] == 0` holds.
-                unsafe { ZStr::from_raw(optional_bun_path.as_ptr(), optional_bun_path.len()) }
+                *optional_bun_path
             } else {
                 // Ask the OS for the real absolute path first. Fall back to an
                 // absolute `argv[0]` only if that fails — never trust a bare
@@ -534,7 +506,7 @@ impl RunCommand {
                 // inner process's `argv[0]` IS `<BUN_NODE_DIR>/bun`.
                 match bun_core::self_exe_path() {
                     Ok(self_path) if !self_path.as_bytes().is_empty() => {
-                        *optional_bun_path = self_path.as_bytes();
+                        *optional_bun_path = self_path;
                         self_path
                     }
                     result => {
@@ -548,7 +520,7 @@ impl RunCommand {
                             return Ok(());
                         }
                         if argv0_bytes.first() == Some(&b'/') {
-                            *optional_bun_path = argv0_bytes;
+                            *optional_bun_path = argv0;
                             argv0
                         } else {
                             // No usable target — propagate the OS error when we
@@ -571,17 +543,14 @@ impl RunCommand {
 
             const NODE_LINK: &ZStr = {
                 const B: &[u8] = concatcp!(RunCommand::BUN_NODE_DIR, "/node\0").as_bytes();
-                // SAFETY: literal ends in NUL; len excludes it.
                 ZStr::from_static(B)
             };
             const BUN_LINK: &ZStr = {
                 const B: &[u8] = concatcp!(RunCommand::BUN_NODE_DIR, "/bun\0").as_bytes();
-                // SAFETY: literal ends in NUL; len excludes it.
                 ZStr::from_static(B)
             };
             const DIR_Z: &ZStr = {
                 const B: &[u8] = concatcp!(RunCommand::BUN_NODE_DIR, "\0").as_bytes();
-                // SAFETY: literal ends in NUL; len excludes it.
                 ZStr::from_static(B)
             };
 
@@ -650,15 +619,8 @@ impl RunCommand {
             let mut target_path_buffer = bun_paths::w_path_buffer_pool::get();
             let prefix: &[u16] = strings::w!("\\??\\");
 
-            // SAFETY: GetTempPathW writes at most `nBufferLength` WCHARs (incl.
-            // trailing NUL) into the offset slice; we reserve `prefix.len()` at
-            // the front for the NT object prefix.
-            let len = unsafe {
-                win::GetTempPathW(
-                    (target_path_buffer.len() - prefix.len()) as u32,
-                    target_path_buffer.as_mut_ptr().add(prefix.len()),
-                )
-            } as usize;
+            // `prefix.len()` is reserved at the front for the NT object prefix.
+            let len = win::get_temp_path_w(&mut target_path_buffer[prefix.len()..]);
             if len == 0 {
                 // Non-fatal; fall through and leave
                 // PATH unmodified. (No `RUN` scope is declared in this crate.)
@@ -709,19 +671,12 @@ impl RunCommand {
             let image_path = win::exe_path_w();
             for name in [strings::w!("\\node.exe\0"), strings::w!("\\bun.exe\0")] {
                 target_path_buffer[dir_slice_len..][..name.len()].copy_from_slice(name);
-                // `target_path_buffer` is mutated in place between FFI calls
-                // (the dir-NUL/backslash toggle below).
-                // Under Stacked Borrows a `*const` derived via `Deref::deref`
-                // is invalidated by the intervening `&mut` from `IndexMut`, so
-                // re-derive `as_ptr()` at each FFI call site instead of caching.
                 if win::CreateHardLinkW(target_path_buffer.as_ptr(), image_path.as_ptr(), None) == 0
                 {
                     match win::Win32Error::get() {
                         win::Win32Error::ALREADY_EXISTS => {}
                         _ => {
                             target_path_buffer[dir_slice_len] = 0;
-                            // SAFETY: `dir_slice_len` is in-bounds; the byte at
-                            // `dir_slice_len` was just set to NUL.
                             let dir_w =
                                 bun_core::WStr::from_buf(&target_path_buffer[..], dir_slice_len);
                             let _ = bun_sys::mkdir_w(dir_w);
@@ -755,63 +710,13 @@ impl RunCommand {
     }
 }
 
-/// Process-lifetime arena for the install-tier `Transpiler` constructed in
-/// `RunCommand::configure_env_for_run`. Mirrors `runner_arena()` in
-/// `runtime/cli/run_command.rs` — `bun_alloc::Arena` is `!Sync`, so guard a
-/// a raw `MaybeUninit` global with `Once` (PORTING.md §Forbidden bars
-/// `Box::leak`).
-fn install_runner_arena() -> &'static bun_alloc::Arena {
-    static ONCE: std::sync::Once = std::sync::Once::new();
-    // PORTING.md §Global mutable state: `Once`-guarded init; RacyCell because
-    // `Bump` is `!Sync` so `OnceLock<Arena>` can't be used.
-    static ARENA: bun_core::RacyCell<::core::mem::MaybeUninit<bun_alloc::Arena>> =
-        bun_core::RacyCell::new(::core::mem::MaybeUninit::uninit());
-    ONCE.call_once(|| {
-        // SAFETY: one-time init under `Once`; no concurrent writer.
-        unsafe { (*ARENA.get()).write(bun_alloc::Arena::new()) };
-    });
-    // SAFETY: initialized exactly once above. `configure_env_for_run` is only
-    // ever called from the single CLI dispatch thread, so the `!Sync` Bump is
-    // never observed concurrently.
-    unsafe { (*ARENA.get()).assume_init_ref() }
-}
-
 impl RunCommand {
-    /// DEP-CYCLE NOTE: the full implementation walks `bun_resolver::DirInfo`
-    /// and reads `package.json` via the resolver — T6 work that lives in
-    /// `bun_runtime::cli::RunCommand::configure_env_for_run`. The install
-    /// tier needs the *Transpiler-initialisation* half of that contract
-    /// because callers (`configure_env_for_scripts_run`) `assume_init()` the
-    /// out-param. This shim performs the init + the env-var seeding that has
-    /// no T6 dependency; the `*mut ()` return stands in for `*mut DirInfo`
-    /// (opaque to install — every caller discards it).
-    pub(crate) fn configure_env_for_run(
-        ctx: &mut bun_options_types::context::ContextData,
-        this_transpiler: &mut ::core::mem::MaybeUninit<bun_transpiler::Transpiler<'static>>,
-        env: Option<*mut bun_dotenv::Loader>,
-        _log_errors: bool,
-        store_root_fd: bool,
-    ) -> Result<*mut (), crate::Error> {
+    /// The env-var seeding half of `bun run`'s
+    /// `bun_runtime::cli::RunCommand::configure_env_for_run`; the `DirInfo`
+    /// walk / `npm_package_*` half lives in the runtime and lifecycle scripts
+    /// never had it.
+    pub(crate) fn configure_env_for_run(env_loader: &mut bun_dotenv::Loader) {
         use bun_core::Global;
-
-        let args = ctx.args.clone();
-        this_transpiler.write(bun_transpiler::Transpiler::init(
-            install_runner_arena(),
-            ctx.log,
-            args,
-            env,
-        )?);
-        // SAFETY: fully written on the line above.
-        let this_transpiler = unsafe { this_transpiler.assume_init_mut() };
-        this_transpiler.options.env.behavior =
-            bun_options_types::schema::api::DotEnvBehavior::load_all;
-        this_transpiler.resolver.care_about_bin_folder = true;
-        this_transpiler.resolver.care_about_scripts = true;
-        this_transpiler.resolver.store_fd = store_root_fd;
-
-        // Re-derive per-use rather than holding a long-lived `&mut` (avoids
-        // Stacked-Borrows overlap with `run_env_loader`).
-        let env_loader = this_transpiler.env_mut();
 
         // Propagate --no-orphans / [run] noOrphans to the script's env so any
         // Bun process the script spawns enables its own watchdog. The env
@@ -850,11 +755,6 @@ impl RunCommand {
                     .put_default(b"npm_execpath", self_exe.as_bytes());
             }
         }
-
-        // DirInfo walk / npm_package_* seeding is performed by the T6 impl
-        // (`bun_runtime::cli::RunCommand::configure_env_for_run`); install
-        // callers discard the return value.
-        Ok(core::ptr::null_mut())
     }
 }
 
@@ -897,10 +797,6 @@ impl<'a> StorePathFormatter<'a> {
     /// verbatim (mapping `/` and `\` to `+`). This is the byte-faithful sink; callers that
     /// need an on-disk store path (legal non-UTF-8 on Linux) must use this, not `Display`.
     pub(crate) fn write_to<W: std::io::Write>(&self, w: &mut W) -> std::io::Result<()> {
-        // if (!this.opts.replace_slashes) {
-        //     try writer.writeAll(this.str);
-        //     return;
-        // }
         for &c in self.str {
             match c {
                 b'/' | b'\\' => w.write_all(b"+")?,
@@ -948,27 +844,23 @@ pub(crate) fn initialize_mini_store() {
         memory_store: bun_ast::ASTMemoryAllocator,
     }
 
+    // Per-thread and never freed (the AST allocation hooks keep pointing at it).
     thread_local! {
-        static INSTANCE: Cell<Option<*mut MiniStore>> = const { Cell::new(None) };
+        static INSTANCE: core::cell::RefCell<Option<&'static mut MiniStore>> =
+            const { core::cell::RefCell::new(None) };
     }
 
     INSTANCE.with(|instance| {
-        if instance.get().is_none() {
+        let mut instance = instance.borrow_mut();
+        if instance.is_none() {
             let heap = Arena::new();
             let memory_store = bun_ast::ASTMemoryAllocator::new(&heap);
-            let mini_store = bun_core::heap::into_raw(Box::new(MiniStore { heap, memory_store }));
-            // SAFETY: just allocated, non-null, thread-local exclusive access
-            unsafe {
-                (*mini_store).memory_store.reset();
-                (*mini_store).memory_store.push();
-            }
-            instance.set(Some(mini_store));
+            let mini_store = Box::leak(Box::new(MiniStore { heap, memory_store }));
+            mini_store.memory_store.reset();
+            mini_store.memory_store.push();
+            *instance = Some(mini_store);
         } else {
-            // SAFETY: pointer was heap-allocated on this thread in the branch above and is
-            // never freed; INSTANCE is thread-local and `Cell::get` copies the raw pointer
-            // out (no borrow of the Cell is held), so this `&mut` is the sole live reference
-            // to the allocation for its entire scope — no aliasing.
-            let mini_store = unsafe { &mut *instance.get().unwrap() };
+            let mini_store = instance.as_mut().unwrap();
             // `ASTMemoryAllocator` collapses SFA+fallback into a single bumpalo arena,
             // so there is no stack-buffer watermark to inspect — `reset()` already
             // releases all bump allocations. The size gate is
@@ -1041,7 +933,9 @@ impl Aligner {
 }
 
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Debug, Default, bytemuck::NoUninit, bytemuck::CheckedBitPattern,
+)]
 pub enum Origin {
     #[default]
     Local = 0,

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -1,24 +1,23 @@
-use core::ffi::{c_char, c_void};
+use core::cell::Cell;
+use core::ffi::c_void;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::PackageManager;
-use crate::isolated_install::installer::{CompleteState, Installer, Step};
-use crate::isolated_install::store::{EntryColumns, entry};
+use crate::isolated_install::store::entry;
 use crate::lockfile_real::Scripts as LockfileScripts;
 use crate::lockfile_real::package::scripts::List as ScriptsList;
 use crate::package_manager_real::ProgressStrings;
 use bun_core::{Global, Output};
+use bun_event_loop::EventLoopHandle;
 use bun_io::BufferedReader;
-use bun_io::heap as io_heap;
 #[cfg(unix)]
 use bun_io::{FilePollFlag, PosixFlags};
+use bun_ptr::{JsCell, ThisPtr};
 
 use bun_core::ZStr;
 #[cfg(unix)]
 use bun_spawn::SpawnResultExt as _;
-use bun_spawn::{
-    Process, ProcessExit, ProcessExitKind, ProcessHandle, Rusage, SpawnOptions, Status,
-};
+use bun_spawn::{ProcessHandle, SpawnOptions, Status};
 #[cfg(unix)]
 use bun_sys::Fd;
 // `BufferedReaderParent::loop_` is typed `*mut bun_uws::Loop` (the
@@ -249,94 +248,48 @@ pub fn replace_package_manager_run(
     Ok(())
 }
 
-pub struct LifecycleScriptSubprocess<'a> {
+/// One package's lifecycle scripts, run one after the other as subprocesses.
+///
+/// Owned by `PackageManager::active_lifecycle_scripts`; the process exit
+/// handler and the two output readers reach it through the `ThisPtr` its
+/// [`bun_ptr::OwnedThis`] lends, so everything they touch is a `Cell`. Those
+/// callbacks only record what happened; the install loop picks finished
+/// scripts up in [`PackageManager::drain_lifecycle_scripts`], where the
+/// manager (and, for isolated installs, the store installer) is available.
+pub struct LifecycleScriptSubprocess {
     pub(crate) package_name: Box<[u8]>,
 
     pub(crate) scripts: ScriptsList,
-    pub(crate) current_script_index: u8,
+    pub(crate) current_script_index: Cell<u8>,
 
-    pub(crate) remaining_fds: i8,
-    /// `None` between scripts (`reset_polls`).
-    pub(crate) process: Option<ProcessHandle>,
-    pub(crate) stdout: OutputReader,
-    pub(crate) stderr: OutputReader,
-    pub(crate) has_called_process_exit: bool,
-    /// Stored as `BackRef` (not `&'a`) so
-    /// callbacks may mutate manager state (`active_lifecycle_scripts`,
-    /// `progress`, `scripts_node`) through the long-lived backref without
-    /// asserting unique-borrow over the whole `PackageManager`.
-    pub(crate) manager: bun_ptr::BackRef<PackageManager, bun_ptr::Mut>,
+    pub(crate) remaining_fds: Cell<i8>,
+    pub(crate) process: Cell<Option<ProcessHandle>>,
+    /// Set by the exit handler; `Some` once the current script's process is gone.
+    pub(crate) exit_status: Cell<Option<Status>>,
+    pub(crate) stdout: JsCell<OutputReader>,
+    pub(crate) stderr: JsCell<OutputReader>,
+    pub(crate) event_loop: EventLoopHandle,
     /// Owned by this
     /// struct so the `K=V\0` buffers stay alive across every async
-    /// `spawn_next_script` for the script chain; freed by `Drop`/`destroy`.
+    /// `spawn_next_script` for the script chain.
     pub(crate) envp: bun_dotenv::NullDelimitedEnvMap,
-    pub(crate) shell_bin: Option<&'a ZStr>,
+    pub(crate) shell_bin: Option<bun_core::ZBox>,
 
-    pub(crate) has_incremented_alive_count: bool,
+    pub(crate) has_incremented_alive_count: Cell<bool>,
 
     pub(crate) foreground: bool,
     pub(crate) optional: bool,
-    pub(crate) started_at: u64,
+    pub(crate) started_at: Cell<u64>,
 
-    pub(crate) ctx: Option<InstallCtx<'a>>,
-
-    pub(crate) heap: io_heap::IntrusiveField<LifecycleScriptSubprocess<'a>>,
+    /// The store entry these scripts run for (isolated installs).
+    pub(crate) entry_id: Option<entry::Id>,
 }
 
-pub struct InstallCtx<'a> {
-    pub(crate) entry_id: entry::Id,
-    /// Raw `*mut` for the same reason as
-    /// `LifecycleScriptSubprocess::manager` — `on_task_complete`/`start_task`
-    /// mutate Installer state from inside an exit-handler callback.
-    pub(crate) installer: *mut Installer<'a>,
-}
-
-impl<'a> InstallCtx<'a> {
-    /// BACKREF accessor — single `unsafe` deref for the set-once `installer`
-    /// pointer so call sites in `on_process_exit` are safe.
-    ///
-    /// SAFETY (encapsulated): `installer` is non-null and outlives every
-    /// `LifecycleScriptSubprocess` (the `Installer` owns the script-spawn
-    /// loop). Exit-handler callbacks run single-threaded on the main install
-    /// loop, so no other `&`/`&mut Installer` overlaps the returned borrow.
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    fn installer_mut(&self) -> &mut Installer<'a> {
-        // SAFETY: see fn doc.
-        unsafe { &mut *self.installer }
-    }
-}
-
-// `io_heap::Intrusive` takes the comparator via `HeapContext::less` on the
-// `Context` type, so `sort_by_started_at` is provided via a trait impl on a
-// ZST `StartedAtCtx`.
-#[derive(Default, Clone, Copy)]
-pub struct StartedAtCtx;
-pub type List<'a> = io_heap::Intrusive<LifecycleScriptSubprocess<'a>, StartedAtCtx>;
-
-impl<'a> io_heap::HeapNode for LifecycleScriptSubprocess<'a> {
-    #[inline]
-    fn heap(&mut self) -> &mut io_heap::IntrusiveField<Self> {
-        &mut self.heap
-    }
-}
-
-impl<'a> io_heap::HeapContext<LifecycleScriptSubprocess<'a>> for StartedAtCtx {
-    #[inline]
-    unsafe fn less(
-        &self,
-        a: *mut LifecycleScriptSubprocess<'a>,
-        b: *mut LifecycleScriptSubprocess<'a>,
-    ) -> bool {
-        // SAFETY: `a`/`b` are live heap nodes owned by the intrusive heap; the
-        // heap only calls `less` on nodes it has been handed via `insert`.
-        unsafe { (*a).started_at < (*b).started_at }
-    }
-}
+pub type List = Vec<bun_ptr::OwnedThis<LifecycleScriptSubprocess>>;
 
 static ALIVE_COUNT: AtomicUsize = AtomicUsize::new(0);
 
-impl<'a> LifecycleScriptSubprocess<'a> {
+impl LifecycleScriptSubprocess {
     /// Returns the
     /// global atomic so callers can write
     /// `LifecycleScriptSubprocess::alive_count().load(..)`.
@@ -351,35 +304,39 @@ use bun_sys::windows::libuv as uv;
 
 pub type OutputReader = BufferedReader;
 
-impl<'a> LifecycleScriptSubprocess<'a> {
-    /// Heap-allocate and return a raw pointer; this type is intrusive (heap field,
-    /// OutputReader parent backrefs), so it lives behind `*mut Self`.
-    pub(crate) fn new(init: Self) -> *mut Self {
-        bun_core::heap::into_raw(Box::new(init))
-    }
+/// What finishing a script means for the store entry it ran for.
+pub enum EntryEvent {
+    /// `preinstall` succeeded: the entry can move on to linking binaries.
+    PreinstallDone,
+    /// All scripts ran.
+    Done,
+    /// An optional dependency's script failed; the package was removed.
+    Skipped,
+}
 
-    #[inline]
-    fn manager(&self) -> &PackageManager {
-        // `manager` is non-null and outlives every subprocess (the
-        // `PackageManager` is the singleton install-loop owner).
-        self.manager.get()
-    }
-
+impl LifecycleScriptSubprocess {
     pub(crate) fn script_name(&self) -> &'static [u8] {
-        debug_assert!((self.current_script_index as usize) < LockfileScripts::NAMES.len());
-        LockfileScripts::NAMES[self.current_script_index as usize].as_bytes()
+        debug_assert!((self.current_script_index.get() as usize) < LockfileScripts::NAMES.len());
+        LockfileScripts::NAMES[self.current_script_index.get() as usize].as_bytes()
     }
 
-    pub(crate) fn on_reader_done(&mut self) {
-        debug_assert!(self.remaining_fds > 0);
-        self.remaining_fds -= 1;
-
-        self.maybe_finished();
+    /// The process is gone and both output pipes are drained.
+    #[inline]
+    pub(crate) fn is_finished(&self) -> bool {
+        let status = self.exit_status.take();
+        let exited = status.is_some();
+        self.exit_status.set(status);
+        exited && self.remaining_fds.get() == 0
     }
 
-    pub(crate) fn on_reader_error(&mut self, err: &bun_sys::Error) {
-        debug_assert!(self.remaining_fds > 0);
-        self.remaining_fds -= 1;
+    pub(crate) fn on_reader_done(&self) {
+        debug_assert!(self.remaining_fds.get() > 0);
+        self.remaining_fds.set(self.remaining_fds.get() - 1);
+    }
+
+    pub(crate) fn on_reader_error(&self, err: &bun_sys::Error) {
+        debug_assert!(self.remaining_fds.get() > 0);
+        self.remaining_fds.set(self.remaining_fds.get() - 1);
 
         bun_core::pretty_errorln!(
             "<r><red>error<r>: Failed to read <b>{}<r> script output from \"<b>{}<r>\" due to error <b>{} {}<r>",
@@ -389,19 +346,12 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             bstr::BStr::new(err.name()),
         );
         Output::flush();
-        self.maybe_finished();
     }
 
-    fn maybe_finished(&mut self) {
-        if !self.has_called_process_exit || self.remaining_fds != 0 {
-            return;
-        }
-
-        let Some(process) = &self.process else {
-            return;
-        };
-        let status = process.status.clone();
-        self.handle_exit(status);
+    /// This is called from the process's exit handler; the install loop
+    /// finishes the script in `PackageManager::drain_lifecycle_scripts`.
+    pub(crate) fn on_process_exit(&self, status: Status) {
+        self.exit_status.set(Some(status));
     }
 
     /// Posix-only: re-prime a recycled `PosixBufferedReader` for a fresh socket fd.
@@ -427,373 +377,290 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         let _ = fd;
     }
 
-    /// # Safety
-    /// `this` must be a live `*mut Self` (allocation-rooted or derived from a
-    /// caller-held `&mut Self`). Only the `manager` and `heap` fields are
-    /// touched via raw-pointer projection — no whole-struct `&mut Self` is
-    /// materialized — so callers may hold disjoint shared borrows into other
-    /// fields across this call (see `spawn_next_script_inner`).
-    unsafe fn ensure_not_in_heap(this: *mut Self) {
-        // SAFETY: caller contract — `this` is non-null and live.
-        unsafe {
-            let manager: *mut PackageManager = (*this).manager.as_ptr();
-            let heap = core::ptr::addr_of_mut!((*this).heap);
-            // SAFETY: `manager` is non-null and outlives every subprocess (see
-            // `Self::manager`); the install loop is single-threaded here.
-            let active = &mut (*manager).active_lifecycle_scripts;
-            if !(*heap).child.is_null()
-                || !(*heap).next.is_null()
-                || !(*heap).prev.is_null()
-                || core::ptr::eq(active.root, this as *const _)
-            {
-                // SAFETY: `this` was inserted via `insert(this)` with allocation-
-                // rooted provenance; the heap holds no other live `&mut` to it here.
-                active.remove(this.cast::<LifecycleScriptSubprocess<'static>>());
-            }
-        }
-    }
-
     /// Used to be called from multiple threads during isolated installs; now single-threaded
     /// TODO: re-evaluate whether some variables still need to be atomic
-    ///
-    /// # Safety
-    /// `this` must have been produced by `Self::new` (`heap::alloc`) and be uniquely
-    /// accessed by the caller for the duration of this call. The pointer is stored as a
-    /// long-lived backref (reader `parent`, intrusive-heap node, process exit handler),
-    /// so it must carry allocation-rooted provenance — passing a `*mut Self` coerced
-    /// from a transient `&mut Self` reborrow would leave dead Stacked Borrows tags once
-    /// the caller resumes using that borrow.
-    pub(crate) unsafe fn spawn_next_script(
-        this: *mut Self,
+    pub(crate) fn spawn_next_script(
+        this: ThisPtr<Self>,
+        manager: &mut PackageManager,
         next_script_index: u8,
     ) -> Result<(), crate::Error> {
         bun_core::analytics::Features::LIFECYCLE_SCRIPTS.fetch_add(1, Ordering::Relaxed);
 
-        // SAFETY: `this` is non-null and uniquely accessed (caller contract).
-        unsafe {
-            if !(*this).has_incremented_alive_count {
-                (*this).has_incremented_alive_count = true;
-                // .monotonic is okay because because this value is only used by hoisted installs, which
-                // only use this type on the main thread.
-                let _ = ALIVE_COUNT.fetch_add(1, Ordering::Relaxed);
-            }
+        let me = this.get();
+        if !me.has_incremented_alive_count.get() {
+            me.has_incremented_alive_count.set(true);
+            // .monotonic is okay because because this value is only used by hoisted installs, which
+            // only use this type on the main thread.
+            let _ = ALIVE_COUNT.fetch_add(1, Ordering::Relaxed);
         }
 
-        // The fallible body is split into
-        // `spawn_next_script_inner` with the cleanup running on the error branch. Both
-        // functions take the allocation-rooted `*mut Self` so that backrefs stored into the
-        // readers / intrusive heap / process exit handler retain valid Stacked Borrows
-        // provenance after we return — deriving them from a `&mut self` reborrow would
-        // leave dead tags once that borrow is popped by subsequent `self` uses, and the
-        // synchronous `process.on_exit` dispatch below would alias a second `&mut Self`.
-        // SAFETY: `this` is non-null and uniquely accessed (caller contract).
-        let result = unsafe { Self::spawn_next_script_inner(this, next_script_index) };
+        let result = Self::spawn_next_script_inner(this, manager, next_script_index);
         if result.is_err() {
-            // SAFETY: as above.
-            unsafe {
-                if (*this).has_incremented_alive_count {
-                    (*this).has_incremented_alive_count = false;
-                    // .monotonic is okay because because this value is only used by hoisted installs.
-                    let _ = ALIVE_COUNT.fetch_sub(1, Ordering::Relaxed);
-                }
-                Self::ensure_not_in_heap(this);
+            let me = this.get();
+            if me.has_incremented_alive_count.get() {
+                me.has_incremented_alive_count.set(false);
+                // .monotonic is okay because because this value is only used by hoisted installs.
+                let _ = ALIVE_COUNT.fetch_sub(1, Ordering::Relaxed);
             }
         }
         result
     }
 
-    /// # Safety
-    /// See [`Self::spawn_next_script`]. `this` is dereferenced for disjoint field
-    /// access only — no whole-struct `&mut Self` is held across any call that may
-    /// reenter via the stored exit-handler backref.
-    unsafe fn spawn_next_script_inner(
-        this: *mut Self,
+    fn spawn_next_script_inner(
+        this: ThisPtr<Self>,
+        manager: &mut PackageManager,
         next_script_index: u8,
     ) -> Result<(), crate::Error> {
-        // SAFETY: `this` is non-null and uniquely accessed (caller contract).
-        // Body wrapped in one block; per-field accesses do not materialize a
-        // whole-struct `&mut Self` across reentrant calls.
-        unsafe {
-            let manager: *mut PackageManager = (*this).manager.as_ptr();
-            let original_script = (*this).scripts.items[next_script_index as usize]
-                .as_ref()
-                .expect("script present");
-            let cwd = (*this).scripts.cwd.as_bytes();
-            (*this).stdout.set_parent(this.cast::<c_void>());
-            (*this).stderr.set_parent(this.cast::<c_void>());
+        let me = this.get();
+        let original_script = me.scripts.items[next_script_index as usize]
+            .as_ref()
+            .expect("script present");
+        let cwd = me.scripts.cwd.as_bytes();
+        let parent = this.as_ptr().cast::<c_void>();
+        me.stdout.with_mut(|r| r.set_parent(parent));
+        me.stderr.with_mut(|r| r.set_parent(parent));
 
-            // Raw-ptr receiver: touches only `heap`/`manager`, so the shared
-            // borrows `original_script`/`cwd` (into `(*this).scripts`) survive.
-            Self::ensure_not_in_heap(this);
+        me.current_script_index.set(next_script_index);
+        me.exit_status.set(None);
 
-            (*this).current_script_index = next_script_index;
-            (*this).has_called_process_exit = false;
+        let mut copy_script: Vec<u8> = Vec::with_capacity(original_script.len() + 1);
+        replace_package_manager_run(&mut copy_script, original_script)?;
+        copy_script.push(0);
+        let combined_script = ZStr::from_buf(&copy_script[..], copy_script.len() - 1);
 
-            let mut copy_script: Vec<u8> = Vec::with_capacity(original_script.len() + 1);
-            replace_package_manager_run(&mut copy_script, original_script)?;
-            copy_script.push(0);
-
-            // SAFETY: we just pushed a NUL byte at copy_script[len-1]; slice [..len-1] is the body.
-            let combined_script: &mut ZStr =
-                ZStr::from_raw_mut(copy_script.as_mut_ptr(), copy_script.len() - 1);
-
-            if (*this).foreground && (*manager).options.log_level != crate::LogLevel::Silent {
-                Output::command(Output::CommandArgv::Single(combined_script.as_bytes()));
-            } else if let Some(scripts_node) = (*manager).scripts_node_mut() {
-                (*manager).set_node_name::<true>(
-                    scripts_node,
-                    &(*this).package_name,
-                    ProgressStrings::SCRIPT_EMOJI.as_bytes(),
-                );
-                // .monotonic is okay because because this value is only used by hoisted installs, which
-                // only use this type on the main thread.
-                if (*manager).finished_installing.load(Ordering::Relaxed) {
-                    scripts_node.activate();
-                    (*manager).progress.refresh();
-                }
-            }
-
-            bun_output::scoped_log!(
-                Script,
-                "{} - {} $ {}",
-                bstr::BStr::new(&(*this).package_name),
-                bstr::BStr::new((*this).script_name()),
-                bstr::BStr::new(combined_script.as_bytes())
+        if me.foreground && manager.options.log_level != crate::LogLevel::Silent {
+            Output::command(Output::CommandArgv::Single(combined_script.as_bytes()));
+        } else if let Some(scripts_node) = manager.scripts_node.as_mut() {
+            PackageManager::set_node_name(
+                scripts_node,
+                &me.package_name,
+                ProgressStrings::SCRIPT_EMOJI.as_bytes(),
             );
+            // .monotonic is okay because because this value is only used by hoisted installs, which
+            // only use this type on the main thread.
+            if manager.finished_installing.load(Ordering::Relaxed) {
+                scripts_node.activate();
+                manager.progress.refresh();
+            }
+        }
 
-            // `[_]?[*:0]const u8` argv array with trailing null. Element type MUST be
-            // bare `*const c_char` (null sentinel), never `Option<*const c_char>` —
-            // raw pointers are already nullable, and `Option<*const T>` is a 2-word
-            // (tag, ptr) pair, not niche-optimized. Casting a `[Option<*const c_char>; N]`
-            // to `Argv` would interleave discriminant words and EFAULT in the kernel.
-            let mut argv: [*const c_char; 4] = if (*this).shell_bin.is_some() && !cfg!(windows) {
-                [
-                    (*this).shell_bin.unwrap().as_ptr().cast::<c_char>(),
-                    c"-c".as_ptr(),
-                    combined_script.as_ptr().cast::<c_char>(),
-                    core::ptr::null(),
-                ]
+        bun_output::scoped_log!(
+            Script,
+            "{} - {} $ {}",
+            bstr::BStr::new(&me.package_name),
+            bstr::BStr::new(me.script_name()),
+            bstr::BStr::new(combined_script.as_bytes())
+        );
+
+        let self_exe;
+        let argv0: &ZStr = match &me.shell_bin {
+            Some(shell) if !cfg!(windows) => shell,
+            _ => {
+                self_exe = bun_core::self_exe_path()?;
+                self_exe
+            }
+        };
+        let argv1: &ZStr = if me.shell_bin.is_some() && !cfg!(windows) {
+            ZStr::from_static(b"-c\0")
+        } else {
+            ZStr::from_static(b"exec\0")
+        };
+        let argv: [&core::ffi::CStr; 3] =
+            [argv0.as_cstr(), argv1.as_cstr(), combined_script.as_cstr()];
+        let envp: Vec<&core::ffi::CStr> = me.envp.iter().collect();
+
+        // OWNERSHIP:
+        // `bun_io::Source::Pipe` owns a `Box<uv::Pipe>` AND
+        // `spawn_process_windows` does `heap::take(ptr)` on the
+        // `Stdio::Buffer` pointer to produce a SECOND `Box<uv::Pipe>` in
+        // `WindowsStdioResult::Buffer` — pre-stashing here would create two
+        // `Box`es over one allocation (UAF + double-free when `spawned`
+        // drops). Instead allocate the raw heap pipe inline in the
+        // `Stdio::Buffer` arm below (so it is only allocated when actually
+        // passed to libuv) and take SOLE ownership from
+        // `spawned.stdout/stderr` after spawn — see the `#[cfg(windows)]`
+        // block below and `filter_run.rs` for the canonical pattern.
+        let spawn_options = SpawnOptions {
+            stdin: if me.foreground {
+                bun_spawn::Stdio::Inherit
             } else {
-                [
-                    bun_core::self_exe_path()?.as_ptr().cast::<c_char>(),
-                    c"exec".as_ptr(),
-                    combined_script.as_ptr().cast::<c_char>(),
-                    core::ptr::null(),
-                ]
-            };
-            const _: () = assert!(
-                core::mem::size_of::<[*const c_char; 4]>() == 4 * core::mem::size_of::<usize>()
-            );
+                bun_spawn::Stdio::Ignore
+            },
 
-            // OWNERSHIP:
-            // `bun_io::Source::Pipe` owns a `Box<uv::Pipe>` AND
-            // `spawn_process_windows` does `heap::take(ptr)` on the
-            // `Stdio::Buffer` pointer to produce a SECOND `Box<uv::Pipe>` in
-            // `WindowsStdioResult::Buffer` — pre-stashing here would create two
-            // `Box`es over one allocation (UAF + double-free when `spawned`
-            // drops). Instead allocate the raw heap pipe inline in the
-            // `Stdio::Buffer` arm below (so it is only allocated when actually
-            // passed to libuv) and take SOLE ownership from
-            // `spawned.stdout/stderr` after spawn — see the `#[cfg(windows)]`
-            // block below and `filter_run.rs` for the canonical pattern.
-            let spawn_options = SpawnOptions {
-                stdin: if (*this).foreground {
-                    bun_spawn::Stdio::Inherit
-                } else {
-                    bun_spawn::Stdio::Ignore
-                },
+            stdout: if manager.options.log_level == crate::LogLevel::Silent {
+                bun_spawn::Stdio::Ignore
+            } else if manager.options.log_level.is_verbose() || me.foreground {
+                bun_spawn::Stdio::Inherit
+            } else {
+                #[cfg(unix)]
+                {
+                    bun_spawn::Stdio::Buffer
+                }
+                #[cfg(not(unix))]
+                {
+                    // Ownership of this raw heap allocation transfers to
+                    // `spawn_process_windows`, which `heap::take`s it into
+                    // `spawned.stdout`.
+                    bun_spawn::Stdio::Buffer(bun_core::heap::into_raw(Box::new(
+                        bun_core::ffi::zeroed::<uv::Pipe>(),
+                    ))
+                        as bun_spawn::windows::UvPipePtr)
+                }
+            },
+            stderr: if manager.options.log_level == crate::LogLevel::Silent {
+                bun_spawn::Stdio::Ignore
+            } else if manager.options.log_level.is_verbose() || me.foreground {
+                bun_spawn::Stdio::Inherit
+            } else {
+                #[cfg(unix)]
+                {
+                    bun_spawn::Stdio::Buffer
+                }
+                #[cfg(not(unix))]
+                {
+                    // Ownership transfers to `spawned.stderr`.
+                    bun_spawn::Stdio::Buffer(bun_core::heap::into_raw(Box::new(
+                        bun_core::ffi::zeroed::<uv::Pipe>(),
+                    ))
+                        as bun_spawn::windows::UvPipePtr)
+                }
+            },
+            cwd: Box::<[u8]>::from(cwd),
 
-                stdout: if (*manager).options.log_level == crate::LogLevel::Silent {
-                    bun_spawn::Stdio::Ignore
-                } else if (*manager).options.log_level.is_verbose() || (*this).foreground {
-                    bun_spawn::Stdio::Inherit
-                } else {
-                    #[cfg(unix)]
-                    {
-                        bun_spawn::Stdio::Buffer
-                    }
-                    #[cfg(not(unix))]
-                    {
-                        // Ownership of this raw heap allocation transfers to
-                        // `spawn_process_windows`, which `heap::take`s it into
-                        // `spawned.stdout`.
-                        bun_spawn::Stdio::Buffer(bun_core::heap::into_raw(Box::new(
-                            bun_core::ffi::zeroed::<uv::Pipe>(),
-                        ))
-                            as bun_spawn::windows::UvPipePtr)
-                    }
-                },
-                stderr: if (*manager).options.log_level == crate::LogLevel::Silent {
-                    bun_spawn::Stdio::Ignore
-                } else if (*manager).options.log_level.is_verbose() || (*this).foreground {
-                    bun_spawn::Stdio::Inherit
-                } else {
-                    #[cfg(unix)]
-                    {
-                        bun_spawn::Stdio::Buffer
-                    }
-                    #[cfg(not(unix))]
-                    {
-                        // Ownership transfers to `spawned.stderr`.
-                        bun_spawn::Stdio::Buffer(bun_core::heap::into_raw(Box::new(
-                            bun_core::ffi::zeroed::<uv::Pipe>(),
-                        ))
-                            as bun_spawn::windows::UvPipePtr)
-                    }
-                },
-                cwd: Box::<[u8]>::from(cwd),
-
-                #[cfg(windows)]
-                windows: bun_spawn::WindowsOptions {
-                    loop_: bun_event_loop::EventLoopHandle::from_any(&mut (*manager).event_loop),
-                    ..Default::default()
-                },
-
-                stream: false,
+            #[cfg(windows)]
+            windows: bun_spawn::WindowsOptions {
+                loop_: me.event_loop,
                 ..Default::default()
-            };
+            },
 
-            (*this).remaining_fds = 0;
-            (*this).started_at =
-                bun_core::Timespec::now(bun_core::TimespecMockMode::AllowMockedTime).ns();
-            // Store the allocation-rooted `this` in the intrusive heap — not a `&mut self`
-            // reborrow, whose SB tag would be invalidated by the field accesses below.
-            (*manager)
-                .active_lifecycle_scripts
-                .insert(this.cast::<LifecycleScriptSubprocess<'static>>());
-            let spawned = match bun_spawn::spawn_process(
-                &spawn_options,
-                // argv is `[*const c_char; 4]` with trailing null — exactly the
-                // `[*:null]?[*:0]const u8` layout `spawn_process` expects (1 word/elt).
-                argv.as_mut_ptr().cast(),
-                (*this).envp.as_ptr().cast::<*const c_char>(),
-            ) {
-                Ok(Ok(s)) => s,
-                res => {
-                    #[cfg(windows)]
-                    {
-                        // `spawn_process_windows` only `heap::take`s the `Stdio::Buffer`
-                        // raw `*mut uv::Pipe` allocations on the SUCCESS path; on every
-                        // error return (uv_pipe_init failure, uv_spawn failure) ownership
-                        // stays with the caller. `WindowsStdio` has no `Drop`, so reclaim
-                        // and `uv_close`+free them explicitly here — otherwise the heap
-                        // `uv::Pipe`s leak (and, if already `uv_pipe_init`'d, remain
-                        // linked in the libuv loop's handle queue forever). Allocation
-                        // happens inline (see OWNERSHIP note above), so the error
-                        // path must be handled explicitly.
-                        let mut spawn_options = spawn_options;
-                        spawn_options.stdout.deinit();
-                        spawn_options.stderr.deinit();
-                    }
-                    res??;
-                    unreachable!();
+            stream: false,
+            ..Default::default()
+        };
+
+        me.remaining_fds.set(0);
+        me.started_at
+            .set(bun_core::Timespec::now(bun_core::TimespecMockMode::AllowMockedTime).ns());
+        let spawned = match bun_spawn::spawn_process_cstr(
+            &spawn_options,
+            &argv,
+            bun_spawn::SpawnEnv::Strings(&envp),
+        ) {
+            Ok(Ok(s)) => s,
+            res => {
+                #[cfg(windows)]
+                {
+                    // `spawn_process_windows` only `heap::take`s the `Stdio::Buffer`
+                    // raw `*mut uv::Pipe` allocations on the SUCCESS path; on every
+                    // error return (uv_pipe_init failure, uv_spawn failure) ownership
+                    // stays with the caller. `WindowsStdio` has no `Drop`, so reclaim
+                    // and `uv_close`+free them explicitly here — otherwise the heap
+                    // `uv::Pipe`s leak (and, if already `uv_pipe_init`'d, remain
+                    // linked in the libuv loop's handle queue forever). Allocation
+                    // happens inline (see OWNERSHIP note above), so the error
+                    // path must be handled explicitly.
+                    let mut spawn_options = spawn_options;
+                    spawn_options.stdout.deinit();
+                    spawn_options.stderr.deinit();
                 }
-            };
-            #[cfg(windows)]
-            let mut spawned = spawned;
+                res??;
+                unreachable!();
+            }
+        };
+        #[cfg(windows)]
+        let mut spawned = spawned;
 
-            #[cfg(unix)]
-            {
-                if let Some(stdout) = spawned.stdout {
-                    if !spawned.memfds[1] {
-                        (*this).stdout.set_parent(this.cast::<c_void>());
-                        let _ = bun_sys::set_nonblocking(stdout);
-                        (*this).remaining_fds += 1;
-
-                        Self::reset_output_flags(&mut (*this).stdout, stdout);
-                        (*this).stdout.start(stdout, true)?;
-                        if let Some(poll) = (*this).stdout.handle.get_poll() {
+        #[cfg(unix)]
+        {
+            if let Some(stdout) = spawned.stdout {
+                if !spawned.memfds[1] {
+                    let _ = bun_sys::set_nonblocking(stdout);
+                    me.remaining_fds.set(me.remaining_fds.get() + 1);
+                    me.stdout.with_mut(|r| {
+                        Self::reset_output_flags(r, stdout);
+                        r.start(stdout, true)?;
+                        if let Some(poll) = r.handle.get_poll() {
                             poll.set_flag(FilePollFlag::Socket);
                         }
-                    } else {
-                        (*this).stdout.set_parent(this.cast::<c_void>());
-                        (*this).stdout.start_memfd(stdout);
-                    }
+                        bun_sys::Result::Ok(())
+                    })?;
+                } else {
+                    me.stdout.with_mut(|r| r.start_memfd(stdout));
                 }
-                if let Some(stderr) = spawned.stderr {
-                    if !spawned.memfds[2] {
-                        (*this).stderr.set_parent(this.cast::<c_void>());
-                        let _ = bun_sys::set_nonblocking(stderr);
-                        (*this).remaining_fds += 1;
-
-                        Self::reset_output_flags(&mut (*this).stderr, stderr);
-                        (*this).stderr.start(stderr, true)?;
-                        if let Some(poll) = (*this).stderr.handle.get_poll() {
+            }
+            if let Some(stderr) = spawned.stderr {
+                if !spawned.memfds[2] {
+                    let _ = bun_sys::set_nonblocking(stderr);
+                    me.remaining_fds.set(me.remaining_fds.get() + 1);
+                    me.stderr.with_mut(|r| {
+                        Self::reset_output_flags(r, stderr);
+                        r.start(stderr, true)?;
+                        if let Some(poll) = r.handle.get_poll() {
                             poll.set_flag(FilePollFlag::Socket);
                         }
-                    } else {
-                        (*this).stderr.set_parent(this.cast::<c_void>());
-                        (*this).stderr.start_memfd(stderr);
-                    }
+                        bun_sys::Result::Ok(())
+                    })?;
+                } else {
+                    me.stderr.with_mut(|r| r.start_memfd(stderr));
                 }
             }
-            #[cfg(windows)]
-            {
-                // `spawn_process_windows` has already `heap::take`n the raw pipe
-                // pointers out of `Stdio::Buffer` into `spawned.{stdout,stderr}`
-                // as `WindowsStdioResult::Buffer(Box<uv::Pipe>)`. Take that Box
-                // out *here* (sole owner) and stash it in `source` BEFORE
-                // `start_with_current_pipe` (which reads `source.?.pipe`) and
-                // BEFORE `spawned` drops — otherwise the `Box<uv::Pipe>` is freed
-                // while libuv still has the handle queued (UAF) and the later
-                // `close_impl`→`on_pipe_close`→`heap::take` double-frees.
-                if let bun_spawn::SpawnedStdio::Buffer(pipe) = spawned.stdout.take() {
-                    (*this).stdout.set_source(bun_io::Source::Pipe(pipe));
-                    (*this).stdout.set_parent(this.cast::<c_void>());
-                    (*this).remaining_fds += 1;
-                    (*this).stdout.start_with_current_pipe()?;
-                }
-                if let bun_spawn::SpawnedStdio::Buffer(pipe) = spawned.stderr.take() {
-                    (*this).stderr.set_source(bun_io::Source::Pipe(pipe));
-                    (*this).stderr.set_parent(this.cast::<c_void>());
-                    (*this).remaining_fds += 1;
-                    (*this).stderr.start_with_current_pipe()?;
+        }
+        #[cfg(windows)]
+        {
+            // `spawned.{stdout,stderr}` own the `Box<uv::Pipe>`s. Move each
+            // into the reader's `source` BEFORE `start_with_current_pipe`
+            // (which reads the pipe from `source`) and BEFORE `spawned` drops —
+            // otherwise the pipe is freed while libuv still has the handle
+            // queued, and the later close callback frees it again.
+            if let bun_spawn::SpawnedStdio::Buffer(pipe) = spawned.stdout.take() {
+                me.remaining_fds.set(me.remaining_fds.get() + 1);
+                me.stdout.with_mut(|r| {
+                    r.set_source(bun_io::Source::Pipe(pipe));
+                    r.start_with_current_pipe()
+                })?;
+            }
+            if let bun_spawn::SpawnedStdio::Buffer(pipe) = spawned.stderr.take() {
+                me.remaining_fds.set(me.remaining_fds.get() + 1);
+                me.stderr.with_mut(|r| {
+                    r.set_source(bun_io::Source::Pipe(pipe));
+                    r.start_with_current_pipe()
+                })?;
+            }
+        }
+
+        let process = spawned.to_process_handle(me.event_loop);
+        process.set_exit_handler(this);
+        let watch = process.watch_or_reap();
+        let exited = process.has_exited();
+        let previous = me.process.replace(Some(process));
+        debug_assert!(previous.is_none(), "forgot to call `reset_polls`");
+
+        if let Err(err) = watch {
+            if !exited {
+                if let Some(process) = me.process.take() {
+                    process.on_exit(Status::Err(err), &bun_spawn::process::rusage_zeroed());
+                    me.process.set(Some(process));
                 }
             }
+        }
 
-            let event_loop = bun_event_loop::EventLoopHandle::from_any(&mut (*manager).event_loop);
-            debug_assert!((*this).process.is_none(), "forgot to call `reset_polls`");
-            let process: *mut Process = (*this)
-                .process
-                .insert(spawned.to_process_handle(event_loop))
-                .as_ptr();
-            // SAFETY: `this` is the allocation-rooted `LifecycleScriptSubprocess`;
-            // we hold no live `&mut Self` here, so the synchronous `on_exit`
-            // dispatch below may reenter `on_process_exit` through it without
-            // aliasing. It outlives `process`.
-            (*process).set_exit_handler(ProcessExit::new(ProcessExitKind::LifecycleScript, this));
-
-            if let Err(err) = (*process).watch_or_reap() {
-                if !(*process).has_exited() {
-                    // SAFETY: all-zero is a valid Rusage (#[repr(C)] POD).
-                    (*process).on_exit(Status::Err(err), &bun_core::ffi::zeroed::<Rusage>());
-                }
-            }
-
-            Ok(())
-        } // unsafe
+        Ok(())
     }
 
-    pub(crate) fn print_output(&mut self) {
-        if !self.manager().options.log_level.is_verbose() {
+    pub(crate) fn print_output(&self, manager: &PackageManager) {
+        if !manager.options.log_level.is_verbose() {
+            let (stdout_len, stderr_cap) = (
+                self.stdout
+                    .with_mut(|r| (r.final_buffer().len(), r.final_buffer().capacity())),
+                self.stderr.with_mut(|r| r.buffer().capacity()),
+            );
             // Reuse the memory
-            // Reshaped for borrowck — evaluate
-            // the stderr-capacity check first (immutable), then take the
-            // disjoint `stdout` mutable borrow, so `core::mem::take` only fires
-            // when all three clauses
-            // (`stdout.len==0 && stdout.cap>0 && stderr.buffer().cap==0`)
-            // hold — otherwise stdout's buffer is left
-            // in place for the `stdout.items.len +| stderr.items.len` check.
-            if self.stderr.buffer().capacity() == 0 {
-                let stdout = self.stdout.final_buffer();
-                if stdout.is_empty() && stdout.capacity() > 0 {
-                    let buf = core::mem::take(stdout);
-                    *self.stderr.buffer() = buf;
-                }
+            if stdout_len.0 == 0 && stdout_len.1 > 0 && stderr_cap == 0 {
+                let buf = self.stdout.with_mut(|r| core::mem::take(r.final_buffer()));
+                self.stderr.with_mut(|r| *r.buffer() = buf);
             }
 
-            let stdout_len = self.stdout.final_buffer().len();
-            let stderr_len = self.stderr.final_buffer().len();
+            let stdout_len = self.stdout.with_mut(|r| r.final_buffer().len());
+            let stderr_len = self.stderr.with_mut(|r| r.final_buffer().len());
 
             if stdout_len.saturating_add(stderr_len) == 0 {
                 return;
@@ -803,122 +670,114 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             Output::flush();
 
             if stdout_len > 0 {
-                let stdout = self.stdout.final_buffer();
-                let _ = Output::error_writer()
-                    .write_fmt(format_args!("{}\n", bstr::BStr::new(stdout.as_slice())));
-                stdout.clear();
-                stdout.shrink_to_fit();
+                self.stdout.with_mut(|r| {
+                    let stdout = r.final_buffer();
+                    let _ = Output::error_writer()
+                        .write_fmt(format_args!("{}\n", bstr::BStr::new(stdout.as_slice())));
+                    stdout.clear();
+                    stdout.shrink_to_fit();
+                });
             }
 
             if stderr_len > 0 {
-                let stderr = self.stderr.final_buffer();
-                let _ = Output::error_writer()
-                    .write_fmt(format_args!("{}\n", bstr::BStr::new(stderr.as_slice())));
-                stderr.clear();
-                stderr.shrink_to_fit();
+                self.stderr.with_mut(|r| {
+                    let stderr = r.final_buffer();
+                    let _ = Output::error_writer()
+                        .write_fmt(format_args!("{}\n", bstr::BStr::new(stderr.as_slice())));
+                    stderr.clear();
+                    stderr.shrink_to_fit();
+                });
             }
 
             Output::enable_buffering();
         }
     }
 
-    fn handle_exit(&mut self, status: Status) {
+    /// Runs on the install loop once [`is_finished`](Self::is_finished):
+    /// report the result and start the next script if there is one.
+    /// Returns `None` while the subprocess has more scripts to run (it was
+    /// put back on `manager.active_lifecycle_scripts`), otherwise what the
+    /// finish means for the store entry.
+    fn handle_exit(
+        owned: bun_ptr::OwnedThis<Self>,
+        manager: &mut PackageManager,
+    ) -> Option<(Option<entry::Id>, EntryEvent)> {
+        let this = owned.this_ptr();
+        let me = this.get();
+        let status = me.exit_status.take().expect("finished");
+        me.exit_status.set(Some(status.clone()));
         bun_output::scoped_log!(
             Script,
             "{} - {} finished {}",
-            bstr::BStr::new(&self.package_name),
-            bstr::BStr::new(self.script_name()),
+            bstr::BStr::new(&me.package_name),
+            bstr::BStr::new(me.script_name()),
             status
         );
 
-        if self.has_incremented_alive_count {
-            self.has_incremented_alive_count = false;
+        if me.has_incremented_alive_count.get() {
+            me.has_incremented_alive_count.set(false);
             // .monotonic is okay because because this value is only used by hoisted installs, which
             // only use this type on the main thread.
             let _ = ALIVE_COUNT.fetch_sub(1, Ordering::Relaxed);
         }
 
-        // SAFETY: `self` is live; the raw-ptr receiver touches only disjoint
-        // fields (`heap`/`manager`) — see `ensure_not_in_heap` doc.
-        unsafe { Self::ensure_not_in_heap(std::ptr::from_mut::<Self>(self)) };
-
         match status {
             Status::Exited(exit) => {
                 if exit.code > 0 {
-                    if self.optional {
-                        if let Some(ctx) = &self.ctx {
-                            let installer = ctx.installer_mut();
-                            installer.store.entries.items_step()[ctx.entry_id.get() as usize]
-                                .store(Step::Done as u32, Ordering::Release);
-                            installer.on_task_complete(ctx.entry_id, CompleteState::Skipped);
-                        }
-                        self.decrement_pending_script_tasks();
-                        self.deinit_and_delete_package();
-                        return;
+                    if me.optional {
+                        Self::decrement_pending_script_tasks(manager);
+                        me.deinit_and_delete_package(manager);
+                        return Some((me.entry_id, EntryEvent::Skipped));
                     }
-                    self.print_output();
+                    me.print_output(manager);
                     bun_core::pretty_errorln!(
                         "<r><red>error<r><d>:<r> <b>{}<r> script from \"<b>{}<r>\" exited with {}<r>",
-                        bstr::BStr::new(self.script_name()),
-                        bstr::BStr::new(&self.package_name),
+                        bstr::BStr::new(me.script_name()),
+                        bstr::BStr::new(&me.package_name),
                         exit.code,
                     );
-                    // SAFETY: `self` was created by `Self::new` (heap::alloc); uniquely owned here.
-                    unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
+                    drop(owned);
                     Output::flush();
                     Global::exit(exit.code as u32);
                 }
 
-                if !self.foreground
-                    && let Some(scripts_node) = self.manager().scripts_node_mut()
+                if !me.foreground
+                    && let Some(scripts_node) = manager.scripts_node.as_mut()
                 {
                     // .monotonic is okay because because this value is only used by hoisted
                     // installs, which only use this type on the main thread.
-                    if self.manager().finished_installing.load(Ordering::Relaxed) {
+                    if manager.finished_installing.load(Ordering::Relaxed) {
                         scripts_node.complete_one();
                     } else {
-                        // .monotonic because this is what `completeOne` does. This is the same
-                        // as `completeOne` but doesn't update the parent.
+                        // .monotonic because this is what `complete_one` does. This is the same
+                        // as `complete_one` but doesn't update the parent.
                         scripts_node
                             .unprotected_completed_items
                             .fetch_add(1, Ordering::Relaxed);
                     }
                 }
 
-                if let Some(ctx) = &self.ctx {
-                    match self.current_script_index {
+                if me.entry_id.is_some() {
+                    match me.current_script_index.get() {
                         // preinstall
                         0 => {
-                            let installer = ctx.installer_mut();
-                            let previous_step = installer.store.entries.items_step()
-                                [ctx.entry_id.get() as usize]
-                                .swap(Step::Binaries as u32, Ordering::Release);
-                            debug_assert!(previous_step == Step::RunPreinstall as u32);
-                            installer.start_task(ctx.entry_id);
-                            self.decrement_pending_script_tasks();
-                            // SAFETY: `self` was created by `Self::new` (heap::alloc); uniquely owned here.
-                            unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
-                            return;
+                            Self::decrement_pending_script_tasks(manager);
+                            return Some((me.entry_id, EntryEvent::PreinstallDone));
                         }
                         _ => {}
                     }
                 }
 
                 for new_script_index in
-                    (self.current_script_index as usize + 1)..LockfileScripts::NAMES.len()
+                    (me.current_script_index.get() as usize + 1)..LockfileScripts::NAMES.len()
                 {
-                    if self.scripts.items[new_script_index].is_some() {
-                        self.reset_polls();
-                        // SAFETY: `self` was created by `Self::new` (heap::alloc) and is
-                        // uniquely owned here; we do not touch `self` again on the
-                        // success path before `return`, so the stored backrefs derived
-                        // from this pointer are not invalidated by a later reborrow.
-                        if let Err(err) = unsafe {
-                            Self::spawn_next_script(
-                                std::ptr::from_mut::<Self>(self),
-                                u8::try_from(new_script_index).expect("int cast"),
-                            )
-                        } {
+                    if me.scripts.items[new_script_index].is_some() {
+                        me.reset_polls();
+                        if let Err(err) = Self::spawn_next_script(
+                            this,
+                            manager,
+                            u8::try_from(new_script_index).expect("int cast"),
+                        ) {
                             Output::err_generic(
                                 "Failed to run script <b>{}<r> due to error <b>{}<r>",
                                 (
@@ -928,45 +787,34 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                             );
                             Global::exit(1);
                         }
-                        return;
+                        manager.active_lifecycle_scripts.push(owned);
+                        return None;
                     }
                 }
 
                 if PackageManager::verbose_install() {
                     bun_core::pretty_errorln!(
                         "<r><d>[Scripts]<r> Finished scripts for <b>{}<r>",
-                        bun_core::fmt::quote(&self.package_name),
+                        bun_core::fmt::quote(&me.package_name),
                     );
                 }
 
-                if let Some(ctx) = &self.ctx {
-                    let installer = ctx.installer_mut();
-                    let previous_step = installer.store.entries.items_step()
-                        [ctx.entry_id.get() as usize]
-                        .swap(Step::Done as u32, Ordering::Release);
-                    if bun_core::Environment::CI_ASSERT {
-                        debug_assert!(self.current_script_index != 0);
-                        debug_assert!(
-                            previous_step == Step::RunPostInstallAndPrePostPrepare as u32
-                        );
-                    }
-                    let _ = previous_step;
-                    installer.on_task_complete(ctx.entry_id, CompleteState::Success);
+                if bun_core::Environment::CI_ASSERT && me.entry_id.is_some() {
+                    debug_assert!(me.current_script_index.get() != 0);
                 }
 
                 // the last script finished
-                self.decrement_pending_script_tasks();
-                // SAFETY: `self` was created by `Self::new` (heap::alloc); uniquely owned here.
-                unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
+                Self::decrement_pending_script_tasks(manager);
+                Some((me.entry_id, EntryEvent::Done))
             }
             Status::Signaled(signal) => {
-                self.print_output();
+                me.print_output(manager);
                 let signal_code = bun_sys::SignalCode::from(signal);
 
                 bun_core::pretty_errorln!(
                     "<r><red>error<r><d>:<r> <b>{}<r> script from \"<b>{}<r>\" terminated by {}<r>",
-                    bstr::BStr::new(self.script_name()),
-                    bstr::BStr::new(&self.package_name),
+                    bstr::BStr::new(me.script_name()),
+                    bstr::BStr::new(&me.package_name),
                     signal_code.fmt(Output::enable_ansi_colors_stderr()),
                 );
 
@@ -980,78 +828,52 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                 );
             }
             Status::Err(err) => {
-                if self.optional {
-                    if let Some(ctx) = &self.ctx {
-                        let installer = ctx.installer_mut();
-                        installer.store.entries.items_step()[ctx.entry_id.get() as usize]
-                            .store(Step::Done as u32, Ordering::Release);
-                        installer.on_task_complete(ctx.entry_id, CompleteState::Skipped);
-                    }
-                    self.decrement_pending_script_tasks();
-                    self.deinit_and_delete_package();
-                    return;
+                if me.optional {
+                    Self::decrement_pending_script_tasks(manager);
+                    me.deinit_and_delete_package(manager);
+                    return Some((me.entry_id, EntryEvent::Skipped));
                 }
 
                 bun_core::pretty_errorln!(
                     "<r><red>error<r>: Failed to run <b>{}<r> script from \"<b>{}<r>\" due to\n{}",
-                    bstr::BStr::new(self.script_name()),
-                    bstr::BStr::new(&self.package_name),
+                    bstr::BStr::new(me.script_name()),
+                    bstr::BStr::new(&me.package_name),
                     err,
                 );
-                // SAFETY: `self` was created by `Self::new` (heap::alloc); uniquely owned here.
-                unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
+                drop(owned);
                 Output::flush();
                 Global::exit(1);
             }
             _ => {
                 Output::panic(format_args!(
                     "error: Failed to run {} script from \"{}\" due to unexpected status\n{}",
-                    bstr::BStr::new(self.script_name()),
-                    bstr::BStr::new(&self.package_name),
+                    bstr::BStr::new(me.script_name()),
+                    bstr::BStr::new(&me.package_name),
                     status,
                 ));
             }
         }
     }
 
-    /// This function may free the *LifecycleScriptSubprocess
-    pub(crate) fn on_process_exit(&mut self, proc: *mut Process, _: Status, _: &Rusage) {
-        if self.process.as_ref().map(ProcessHandle::as_ptr) != Some(proc) {
-            bun_core::debug_warn!(
-                "<d>[LifecycleScriptSubprocess]<r> onProcessExit called with wrong process"
-            );
-            return;
+    pub(crate) fn reset_polls(&self) {
+        debug_assert!(self.remaining_fds.get() == 0);
+
+        if let Some(process) = self.process.take() {
+            process.close();
         }
-        self.has_called_process_exit = true;
-        self.maybe_finished();
+
+        self.stdout.with_mut(|r| {
+            r.deinit();
+            *r = OutputReader::init::<Self>();
+        });
+        self.stderr.with_mut(|r| {
+            r.deinit();
+            *r = OutputReader::init::<Self>();
+        });
     }
 
-    pub(crate) fn reset_polls(&mut self) {
-        debug_assert!(self.remaining_fds == 0);
-
-        self.process = None;
-
-        self.stdout.deinit();
-        self.stderr.deinit();
-        self.stdout = OutputReader::init::<Self>();
-        self.stderr = OutputReader::init::<Self>();
-    }
-
-    /// Consumes and frees a heap-allocated `LifecycleScriptSubprocess` created by [`Self::new`].
-    /// Cleanup side effects (`reset_polls`, `ensure_not_in_heap`) run via `Drop`.
-    ///
-    /// # Safety
-    /// `this` must have been produced by `Self::new` (`heap::alloc`) and not yet destroyed;
-    /// the caller must not use any outstanding `&`/`&mut` to `*this` after this returns.
-    pub(crate) unsafe fn destroy(this: *mut Self) {
-        // SAFETY: caller contract — `this` came from `heap::alloc` in `Self::new` and is
-        // uniquely owned here. Dropping the Box runs `Drop` (reset_polls + ensure_not_in_heap)
-        // then frees the allocation.
-        drop(unsafe { bun_core::heap::take(this) });
-    }
-
-    pub(crate) fn deinit_and_delete_package(&mut self) {
-        if self.manager().options.log_level.is_verbose() {
+    pub(crate) fn deinit_and_delete_package(&self, manager: &PackageManager) {
+        if manager.options.log_level.is_verbose() {
             bun_core::warn!(
                 "deleting optional dependency '{}' due to failed '{}' script",
                 bstr::BStr::new(&self.package_name),
@@ -1071,66 +893,49 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             };
             let _ = dir.delete_tree(basename);
         }
-
-        // SAFETY: `self` was created by `Self::new` (heap::alloc); uniquely owned here.
-        unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
     }
 
     pub(crate) fn spawn_package_scripts(
         manager: &mut PackageManager,
         list: ScriptsList,
         envp: bun_dotenv::NullDelimitedEnvMap,
-        shell_bin: Option<&'a ZStr>,
+        shell_bin: Option<&ZStr>,
         optional: bool,
         log_level: crate::LogLevel,
         foreground: bool,
-        ctx: Option<InstallCtx<'a>>,
+        entry_id: Option<entry::Id>,
     ) -> Result<(), crate::Error> {
         let package_name = list.package_name.clone();
-        let lifecycle_subprocess = Self::new(LifecycleScriptSubprocess {
-            manager: bun_ptr::BackRef::new_mut(manager),
+        let owned = bun_ptr::OwnedThis::new(LifecycleScriptSubprocess {
+            event_loop: EventLoopHandle::from_any(&mut manager.event_loop),
             envp,
-            shell_bin,
+            shell_bin: shell_bin.map(|z| bun_core::ZBox::from_bytes(z.as_bytes())),
             package_name,
             scripts: list,
             foreground,
             optional,
-            ctx,
-            // defaults:
-            current_script_index: 0,
-            remaining_fds: 0,
-            process: None,
-            stdout: OutputReader::init::<Self>(),
-            stderr: OutputReader::init::<Self>(),
-            has_called_process_exit: false,
-            has_incremented_alive_count: false,
-            started_at: 0,
-            heap: io_heap::IntrusiveField::default(),
+            entry_id,
+            current_script_index: Cell::new(0),
+            remaining_fds: Cell::new(0),
+            process: Cell::new(None),
+            exit_status: Cell::new(None),
+            stdout: JsCell::new(OutputReader::init::<Self>()),
+            stderr: JsCell::new(OutputReader::init::<Self>()),
+            has_incremented_alive_count: Cell::new(false),
+            started_at: Cell::new(0),
         });
-
-        // `new` returned a freshly boxed non-null ptr; we hold the only
-        // reference. Wrap once as `ParentRef` so the read-only field accesses
-        // below go through safe `Deref` instead of three per-site raw-deref
-        // blocks. The shared borrow ends (NLL) before `spawn_next_script` takes
-        // the raw `*mut` for exclusive access. Safe `From<NonNull>`
-        // construction — `Self::new` returns `Box::into_raw`, never null.
-        let lss = bun_ptr::ParentRef::<Self>::from(
-            core::ptr::NonNull::new(lifecycle_subprocess).expect("Box::into_raw is non-null"),
-        );
 
         if log_level.is_verbose() {
             bun_core::pretty_errorln!(
                 "<d>[Scripts]<r> Starting scripts for <b>\"{}\"<r>",
-                bstr::BStr::new(&lss.scripts.package_name),
+                bstr::BStr::new(&owned.scripts.package_name),
             );
         }
 
-        lss.increment_pending_script_tasks();
+        Self::increment_pending_script_tasks(manager);
 
-        let first_index = lss.scripts.first_index;
-        // SAFETY: `lifecycle_subprocess` is the allocation-rooted `heap::alloc` pointer
-        // from `Self::new`; passing it gives the stored backrefs stable provenance.
-        if let Err(err) = unsafe { Self::spawn_next_script(lifecycle_subprocess, first_index) } {
+        let first_index = owned.scripts.first_index;
+        if let Err(err) = Self::spawn_next_script(owned.this_ptr(), manager, first_index) {
             bun_core::pretty_errorln!(
                 "<r><red>error<r>: Failed to run script <b>{}<r> due to error <b>{}<r>",
                 bstr::BStr::new(LockfileScripts::NAMES[first_index as usize]),
@@ -1138,34 +943,71 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             );
             Global::exit(1);
         }
+        manager.active_lifecycle_scripts.push(owned);
 
         Ok(())
     }
 
-    fn increment_pending_script_tasks(&self) {
+    fn increment_pending_script_tasks(manager: &PackageManager) {
         // .monotonic is okay because this is just used for progress. Other threads
         // don't rely on side effects of tasks based on this value. (And in the case
         // of hoisted installs it's single-threaded.)
-        let _ = self
-            .manager()
+        let _ = manager
             .pending_lifecycle_script_tasks
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    fn decrement_pending_script_tasks(&self) {
+    fn decrement_pending_script_tasks(manager: &PackageManager) {
         // .monotonic is okay because this is just used for progress (see
         // `increment_pending_script_tasks`).
-        let _ = self
-            .manager()
+        let _ = manager
             .pending_lifecycle_script_tasks
             .fetch_sub(1, Ordering::Relaxed);
     }
 }
 
+impl PackageManager {
+    /// Finish every lifecycle script whose process has exited: print its
+    /// output, start its next script, or report the result to `ctx`.
+    pub(crate) fn drain_lifecycle_scripts<
+        C: crate::package_manager_real::run_tasks::RunTasksCtx + ?Sized,
+    >(
+        ctx: &mut C,
+    ) {
+        // `handle_exit` may spawn the next script, and that one can already
+        // be finished by the time it returns; keep going until none is.
+        loop {
+            let manager = ctx.manager();
+            let Some(i) = manager
+                .active_lifecycle_scripts
+                .iter()
+                .position(|script| script.is_finished())
+            else {
+                break;
+            };
+            let owned = manager.active_lifecycle_scripts.swap_remove(i);
+            if let Some((Some(entry_id), event)) =
+                LifecycleScriptSubprocess::handle_exit(owned, manager)
+            {
+                ctx.on_lifecycle_script_event(entry_id, event);
+            }
+        }
+    }
+}
+
+impl Drop for LifecycleScriptSubprocess {
+    fn drop(&mut self) {
+        self.reset_polls();
+        if self.has_incremented_alive_count.get() {
+            let _ = ALIVE_COUNT.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+}
+
 bun_spawn::link_impl_ProcessExit! {
-    LifecycleScript for LifecycleScriptSubprocess<'static> => |this| {
-        on_process_exit(process, status, rusage) =>
-            (*this).on_process_exit(process, status, rusage),
+    LifecycleScript for LifecycleScriptSubprocess => |this| {
+        on_process_exit(_process, status, _rusage) =>
+            (*this).on_process_exit(status),
     }
 }
 
@@ -1175,25 +1017,12 @@ bun_spawn::link_impl_ProcessExit! {
 // ──────────────────────────────────────────────────────────────────────────
 
 // No `on_read_chunk` — output is consumed only in `final_buffer`.
-// `manager.event_loop` is an `AnyEventLoop`; convert through
-// `EventLoopHandle::from_any` so the by-value `EventLoopCtx` carries the right
-// `kind`.
 bun_io::impl_buffered_reader_parent! {
-    LifecycleScript for LifecycleScriptSubprocess<'a>;
+    LifecycleScript for LifecycleScriptSubprocess;
+    borrow = this;
     has_on_read_chunk = false;
-    on_reader_done  = |this| (*this).on_reader_done();
-    on_reader_error = |this, err| (*this).on_reader_error(&err);
-    loop_           = |this| (*(*this).manager.as_ptr()).event_loop.native_loop();
-    event_loop = |this| bun_event_loop::EventLoopHandle::from_any(
-        &mut (*(*this).manager.as_ptr()).event_loop,
-    ).as_event_loop_ctx();
-}
-
-impl Drop for LifecycleScriptSubprocess<'_> {
-    fn drop(&mut self) {
-        self.reset_polls();
-        // SAFETY: `self` is live for the duration of `drop`; raw-ptr receiver
-        // touches only `heap`/`manager` (see `ensure_not_in_heap` doc).
-        unsafe { Self::ensure_not_in_heap(std::ptr::from_mut::<Self>(self)) };
-    }
+    on_reader_done  = |this| this.get().on_reader_done();
+    on_reader_error = |this, err| this.get().on_reader_error(&err);
+    loop_           = |this| this.get().event_loop.native_loop();
+    event_loop      = |this| this.get().event_loop.as_event_loop_ctx();
 }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -86,7 +86,6 @@ pub use self::lockfile_json_stringify_for_debugging::json_stringify;
 pub use self::override_map::OverrideMap;
 pub use self::package::Package;
 pub use self::tree::Tree;
-pub use crate::padding_checker::assert_no_uninitialized_padding;
 // Bring the derive-generated `items_*` column accessors (`PackageColumns` for
 // `MultiArrayList<Package>`, `PackageColumns` for `Slice<Package>`) into scope.
 use self::package::PackageColumns as _;
@@ -296,8 +295,6 @@ impl Scripts {
     }
 }
 
-// `deinit` becomes `Drop` — body only frees owned fields → delete entirely; Vec<Box<[u8]>> drops automatically.
-
 // ────────────────────────────────────────────────────────────────────────────
 // LoadResult
 // ────────────────────────────────────────────────────────────────────────────
@@ -365,7 +362,221 @@ pub enum LoadResult<'a> {
     Ok(LoadResultOk<'a>),
 }
 
+/// The `Ok` arm of a [`DetachedLoadResult`]: what loading found, without
+/// the lockfile itself (that is `PackageManager::lockfile`).
+pub struct LoadedLockfile {
+    pub migrated: Migrated,
+    pub serializer_result: Serializer::SerializerLoadResult,
+    pub format: LockfileFormat,
+}
+
+/// A [`LoadResult`] without its `&mut Lockfile`, so the lockfile can be moved
+/// (back into the manager) and the result re-attached to it.
+pub enum DetachedLoadResult {
+    NotFound,
+    Err(LoadResultErr),
+    Ok(LoadedLockfile),
+}
+
+impl DetachedLoadResult {
+    pub fn attach(self, lockfile: &mut Lockfile) -> LoadResult<'_> {
+        match self {
+            DetachedLoadResult::NotFound => LoadResult::NotFound,
+            DetachedLoadResult::Err(e) => LoadResult::Err(e),
+            DetachedLoadResult::Ok(ok) => LoadResult::Ok(LoadResultOk {
+                lockfile,
+                migrated: ok.migrated,
+                serializer_result: ok.serializer_result,
+                format: ok.format,
+            }),
+        }
+    }
+
+    pub(crate) fn loaded_from_text_lockfile(&self) -> bool {
+        match self {
+            DetachedLoadResult::NotFound => false,
+            DetachedLoadResult::Err(err) => err.format == LockfileFormat::Text,
+            DetachedLoadResult::Ok(ok) => ok.format == LockfileFormat::Text,
+        }
+    }
+
+    pub(crate) fn loaded_from_binary_lockfile(&self) -> bool {
+        match self {
+            DetachedLoadResult::NotFound => false,
+            DetachedLoadResult::Err(err) => err.format == LockfileFormat::Binary,
+            DetachedLoadResult::Ok(ok) => ok.format == LockfileFormat::Binary,
+        }
+    }
+
+    pub(crate) fn migrated_from_npm(&self) -> bool {
+        matches!(self, DetachedLoadResult::Ok(ok) if ok.migrated == Migrated::Npm)
+    }
+
+    pub(crate) fn migrated_from_pnpm(&self) -> bool {
+        matches!(self, DetachedLoadResult::Ok(ok) if ok.migrated == Migrated::Pnpm)
+    }
+
+    pub(crate) fn save_format(&self, options: &PackageManagerOptions) -> LockfileFormat {
+        match self {
+            DetachedLoadResult::NotFound => LoadResult::NotFound.save_format(options),
+            DetachedLoadResult::Err(err) => {
+                if options.save_text_lockfile == Some(true) {
+                    return LockfileFormat::Text;
+                }
+                err.format
+            }
+            DetachedLoadResult::Ok(ok) => {
+                Self::save_format_for_loaded(options, ok.migrated, ok.format)
+            }
+        }
+    }
+
+    fn save_format_for_loaded(
+        options: &PackageManagerOptions,
+        migrated: Migrated,
+        format: LockfileFormat,
+    ) -> LockfileFormat {
+        // loaded from an existing lockfile
+        if let Some(save_text_lockfile) = options.save_text_lockfile {
+            if save_text_lockfile {
+                return LockfileFormat::Text;
+            }
+
+            if migrated != Migrated::None {
+                return LockfileFormat::Binary;
+            }
+        }
+
+        if migrated != Migrated::None {
+            return LockfileFormat::Text;
+        }
+
+        format
+    }
+
+    /// See [`LoadResult::choose_config_version`]; `lockfile` is the loaded one.
+    pub(crate) fn choose_config_version(&self, lockfile: &Lockfile) -> (ConfigVersion, bool) {
+        match self {
+            DetachedLoadResult::NotFound | DetachedLoadResult::Err(_) => {
+                (ConfigVersion::CURRENT, true)
+            }
+            DetachedLoadResult::Ok(ok) => {
+                Self::config_version_for_loaded(ok.migrated, lockfile.saved_config_version)
+            }
+        }
+    }
+
+    fn config_version_for_loaded(
+        migrated: Migrated,
+        saved_config_version: Option<ConfigVersion>,
+    ) -> (ConfigVersion, bool) {
+        match migrated {
+            Migrated::None => {
+                if let Some(config_version) = saved_config_version {
+                    return (config_version, false);
+                }
+
+                // existing bun project without configVersion
+                (ConfigVersion::V0, true)
+            }
+            Migrated::Pnpm => (ConfigVersion::V1, true),
+            Migrated::Npm => (ConfigVersion::V0, true),
+            Migrated::Yarn => (ConfigVersion::V0, true),
+        }
+    }
+
+    bun_core::enum_unwrap!(pub DetachedLoadResult, Ok => fn ok / ok_mut -> LoadedLockfile);
+}
+
+/// A load result without its payload.
+pub enum LoadStatus<'a> {
+    NotFound,
+    Err(&'a LoadResultErr),
+    Ok,
+}
+
+/// What either shape of load result says about where the lockfile came from.
+pub trait LoadedFrom {
+    fn status(&self) -> LoadStatus<'_>;
+    fn loaded_from_text_lockfile(&self) -> bool;
+    fn loaded_from_binary_lockfile(&self) -> bool;
+    fn migrated_from_pnpm(&self) -> bool;
+    fn save_format(&self, options: &PackageManagerOptions) -> LockfileFormat;
+    /// The format of the lockfile on disk, if there was one (even unreadable).
+    fn existing_format(&self) -> Option<LockfileFormat>;
+}
+
+impl LoadedFrom for LoadResult<'_> {
+    fn status(&self) -> LoadStatus<'_> {
+        match self {
+            LoadResult::NotFound => LoadStatus::NotFound,
+            LoadResult::Err(err) => LoadStatus::Err(err),
+            LoadResult::Ok(_) => LoadStatus::Ok,
+        }
+    }
+    fn loaded_from_text_lockfile(&self) -> bool {
+        LoadResult::loaded_from_text_lockfile(self)
+    }
+    fn loaded_from_binary_lockfile(&self) -> bool {
+        LoadResult::loaded_from_binary_lockfile(self)
+    }
+    fn migrated_from_pnpm(&self) -> bool {
+        LoadResult::migrated_from_pnpm(self)
+    }
+    fn save_format(&self, options: &PackageManagerOptions) -> LockfileFormat {
+        LoadResult::save_format(self, options)
+    }
+    fn existing_format(&self) -> Option<LockfileFormat> {
+        match self {
+            LoadResult::NotFound => None,
+            LoadResult::Err(err) => Some(err.format),
+            LoadResult::Ok(ok) => Some(ok.format),
+        }
+    }
+}
+
+impl LoadedFrom for DetachedLoadResult {
+    fn status(&self) -> LoadStatus<'_> {
+        match self {
+            DetachedLoadResult::NotFound => LoadStatus::NotFound,
+            DetachedLoadResult::Err(err) => LoadStatus::Err(err),
+            DetachedLoadResult::Ok(_) => LoadStatus::Ok,
+        }
+    }
+    fn loaded_from_text_lockfile(&self) -> bool {
+        DetachedLoadResult::loaded_from_text_lockfile(self)
+    }
+    fn loaded_from_binary_lockfile(&self) -> bool {
+        DetachedLoadResult::loaded_from_binary_lockfile(self)
+    }
+    fn migrated_from_pnpm(&self) -> bool {
+        DetachedLoadResult::migrated_from_pnpm(self)
+    }
+    fn save_format(&self, options: &PackageManagerOptions) -> LockfileFormat {
+        DetachedLoadResult::save_format(self, options)
+    }
+    fn existing_format(&self) -> Option<LockfileFormat> {
+        match self {
+            DetachedLoadResult::NotFound => None,
+            DetachedLoadResult::Err(err) => Some(err.format),
+            DetachedLoadResult::Ok(ok) => Some(ok.format),
+        }
+    }
+}
+
 impl<'a> LoadResult<'a> {
+    pub fn detach(self) -> DetachedLoadResult {
+        match self {
+            LoadResult::NotFound => DetachedLoadResult::NotFound,
+            LoadResult::Err(e) => DetachedLoadResult::Err(e),
+            LoadResult::Ok(ok) => DetachedLoadResult::Ok(LoadedLockfile {
+                migrated: ok.migrated,
+                serializer_result: ok.serializer_result,
+                format: ok.format,
+            }),
+        }
+    }
+
     pub(crate) fn loaded_from_text_lockfile(&self) -> bool {
         match self {
             LoadResult::NotFound => false,
@@ -379,13 +590,6 @@ impl<'a> LoadResult<'a> {
             LoadResult::NotFound => false,
             LoadResult::Err(err) => err.format == LockfileFormat::Binary,
             LoadResult::Ok(ok) => ok.format == LockfileFormat::Binary,
-        }
-    }
-
-    pub(crate) fn migrated_from_npm(&self) -> bool {
-        match self {
-            LoadResult::Ok(ok) => ok.migrated == Migrated::Npm,
-            _ => false,
         }
     }
 
@@ -418,22 +622,7 @@ impl<'a> LoadResult<'a> {
                 err.format
             }
             LoadResult::Ok(ok) => {
-                // loaded from an existing lockfile
-                if let Some(save_text_lockfile) = options.save_text_lockfile {
-                    if save_text_lockfile {
-                        return LockfileFormat::Text;
-                    }
-
-                    if ok.migrated != Migrated::None {
-                        return LockfileFormat::Binary;
-                    }
-                }
-
-                if ok.migrated != Migrated::None {
-                    return LockfileFormat::Text;
-                }
-
-                ok.format
+                DetachedLoadResult::save_format_for_loaded(options, ok.migrated, ok.format)
             }
         }
     }
@@ -442,19 +631,10 @@ impl<'a> LoadResult<'a> {
     pub(crate) fn choose_config_version(&self) -> (ConfigVersion, bool) {
         match self {
             LoadResult::NotFound | LoadResult::Err(_) => (ConfigVersion::CURRENT, true),
-            LoadResult::Ok(ok) => match ok.migrated {
-                Migrated::None => {
-                    if let Some(config_version) = ok.lockfile.saved_config_version {
-                        return (config_version, false);
-                    }
-
-                    // existing bun project without configVersion
-                    (ConfigVersion::V0, true)
-                }
-                Migrated::Pnpm => (ConfigVersion::V1, true),
-                Migrated::Npm => (ConfigVersion::V0, true),
-                Migrated::Yarn => (ConfigVersion::V0, true),
-            },
+            LoadResult::Ok(ok) => DetachedLoadResult::config_version_for_loaded(
+                ok.migrated,
+                ok.lockfile.saved_config_version,
+            ),
         }
     }
 
@@ -472,7 +652,7 @@ impl<'a> LoadResult<'a> {
         }
     }
 
-    // Callers reach this only after `handleLoadLockfileErrors` has exited on
+    // Callers reach this only after `handle_load_lockfile_errors` has exited on
     // the `NotFound`/`Err` arms, so the variant is known-`Ok`.
     bun_core::enum_unwrap!(pub LoadResult, Ok => fn ok / ok_mut -> LoadResultOk<'a>);
 }
@@ -753,19 +933,6 @@ impl Lockfile {
         self.packages.items_dependencies()[0].contains(id)
     }
 
-    /// Is this a direct dependency of the workspace the install is taking place in?
-    pub(crate) fn is_root_dependency(
-        &self,
-        manager: &mut PackageManager,
-        id: DependencyID,
-    ) -> bool {
-        // `RootPackageId::get` caches into `manager`.
-        let root_id = manager
-            .root_package_id
-            .get(self, manager.workspace_name_hash);
-        self.packages.items_dependencies()[root_id as usize].contains(id)
-    }
-
     /// Is `id` a direct dependency of one of the `targets` workspaces?
     pub fn is_dependency_of_workspace_in(
         &self,
@@ -961,14 +1128,32 @@ impl Lockfile {
     // reporting, and the patched-dependency migration — are outlined so a
     // no-change `bun install` (install/fastify bench) does not page them in.
     #[inline(never)]
+    /// Rebuild `manager.lockfile` with only the packages still reachable.
+    /// The cleaned lockfile replaces `manager.lockfile`; the old one is returned.
     pub(crate) fn clean_with_logger(
-        &mut self,
         manager: &mut PackageManager,
-        updates: &mut [UpdateRequest],
-        log: &mut bun_ast::Log,
         log_level: LogLevel,
     ) -> Result<Box<Lockfile>, BunError> {
-        let old: &mut Lockfile = self;
+        let mut old_lockfile = core::mem::take(&mut manager.lockfile);
+        let result = Self::clean_into_new(&mut old_lockfile, manager, log_level);
+        match result {
+            Ok(new) => {
+                manager.lockfile = new;
+                Ok(old_lockfile)
+            }
+            Err(err) => {
+                manager.lockfile = old_lockfile;
+                Err(err)
+            }
+        }
+    }
+
+    #[inline(never)]
+    fn clean_into_new(
+        old: &mut Lockfile,
+        manager: &mut PackageManager,
+        log_level: LogLevel,
+    ) -> Result<Box<Lockfile>, BunError> {
         // Outlined cold: the verbose arm is debug-only and drags in
         // `Timer`/clock-syscall error formatting.
         let timer: Option<Timer> = if log_level.is_verbose() {
@@ -982,7 +1167,7 @@ impl Lockfile {
         // We will only shrink the number of packages here.
         // never grow
 
-        // preinstall_state is used during installPackages. the indexes(package ids) need
+        // preinstall_state is used while installing packages. the indexes(package ids) need
         // to be remapped. Also ensure `preinstall_state` has enough capacity to contain
         // all packages. It's possible it doesn't because non-npm packages do not use
         // preinstall state before linking stage.
@@ -1040,12 +1225,10 @@ impl Lockfile {
             clone_queue: clone_queue_,
             optional_peers: PendingResolutions::new(),
             keep_optional_peer_targets,
-            log,
             old_preinstall_state,
             manager: &mut *manager,
         };
 
-        // try clone_queue.ensureUnusedCapacity(root.dependencies.len);
         let _ = root.clone(&mut cloner)?;
 
         // Between here and `cloner.flush()`, `old`/`new`/`manager`
@@ -1089,13 +1272,11 @@ impl Lockfile {
 
                 workspace_paths_builder.allocate()?;
 
-                // SAFETY: capacity reserved by `ensure_total_capacity` above; every
-                // slot in `0..old.count()` is overwritten by the copy/zip loops below
-                // before `re_index()` reads them.
-                unsafe {
-                    new.workspace_paths
-                        .set_entries_len(old.workspace_paths.count())
-                };
+                new.workspace_paths.resize_entries(
+                    old.workspace_paths.count(),
+                    0,
+                    SemverString::default(),
+                );
 
                 debug_assert_eq!(
                     old.workspace_paths.values().len(),
@@ -1116,12 +1297,11 @@ impl Lockfile {
 
                 new.workspace_versions
                     .ensure_total_capacity(old.workspace_versions.count())?;
-                // SAFETY: capacity reserved immediately above; every slot is filled by
-                // the zip loop below before `re_index()`.
-                unsafe {
-                    new.workspace_versions
-                        .set_entries_len(old.workspace_versions.count())
-                };
+                new.workspace_versions.resize_entries(
+                    old.workspace_versions.count(),
+                    0,
+                    Semver::Version::default(),
+                );
                 for (src, dest) in versions
                     .iter()
                     .zip(new.workspace_versions.values_mut().iter_mut())
@@ -1160,11 +1340,11 @@ impl Lockfile {
             clean_migrate_patched_dependencies_cold(old, &mut new)?;
         }
 
-        if !updates.is_empty() {
+        if !manager.update_requests.is_empty() {
             new.bind_update_requests(
                 manager.pending_filtered_write.as_deref(),
                 manager.workspace_name_hash,
-                updates,
+                &mut manager.update_requests,
             );
         }
 
@@ -1196,7 +1376,6 @@ fn clean_verbose_report_cold(old: &Lockfile, new: &Lockfile, timer: Option<&Time
         "Clean lockfile: {} packages -> {} packages in {}\n",
         old.packages.len(),
         new.packages.len(),
-        // SAFETY: only entered when `log_level.is_verbose()`, which set `timer = Some(..)`.
         bun_core::fmt::fmt_duration_one_decimal(timer.unwrap().read()),
     );
 }
@@ -1272,7 +1451,6 @@ pub struct Cloner<'a> {
     pub lockfile: &'a mut Lockfile,
     pub(crate) old: &'a mut Lockfile,
     pub(crate) mapping: &'a mut [PackageID],
-    pub(crate) log: &'a mut bun_ast::Log,
     pub(crate) old_preinstall_state: Vec<Install::PreinstallState>,
     pub(crate) manager: &'a mut PackageManager,
 }
@@ -1308,7 +1486,7 @@ impl<'a> Cloner<'a> {
             .clear_cached_items_depending_on_lockfile_buffer();
 
         if self.lockfile.packages.len() != 0 {
-            self.lockfile.resolve(self.log)?;
+            self.lockfile.resolve(&mut self.manager.log)?;
         }
 
         // capacity is used for calculating byte size
@@ -1335,17 +1513,23 @@ impl Lockfile {
         Ok(())
     }
 
+    /// Re-hoist `manager.lockfile` for the packages an install selects.
     pub(crate) fn filter(
-        &mut self,
-        log: &mut bun_ast::Log,
         manager: &mut PackageManager,
         install_root_dependencies: bool,
         workspace_filters: &[WorkspaceFilter],
         packages_to_install: Option<&[PackageID]>,
     ) -> Result<(), tree::SubtreeError> {
-        self.hoist::<{ tree::BuilderMethod::Filter }>(
+        let PackageManager {
+            lockfile,
             log,
-            Some(manager),
+            options,
+            summary,
+            ..
+        } = manager;
+        lockfile.hoist::<{ tree::BuilderMethod::Filter }>(
+            log,
+            Some(tree::HoistOptions::new(options, summary)),
             install_root_dependencies,
             workspace_filters,
             packages_to_install,
@@ -1359,7 +1543,7 @@ impl Lockfile {
         log: &mut bun_ast::Log,
         // `tree::Builder` stores these unconditionally (Option/slice), so
         // accept the concrete shapes for all `METHOD`s.
-        manager: Option<&PackageManager>,
+        manager: Option<tree::HoistOptions<'_>>,
         install_root_dependencies: bool,
         workspace_filters: &[WorkspaceFilter],
         packages_to_install: Option<&[PackageID]>,
@@ -1376,9 +1560,6 @@ impl Lockfile {
         // `tree::Builder` stores `lockfile: ParentRef<Lockfile>` so
         // the `&mut buffers.resolutions` split-borrow below can coexist with
         // the read-only lockfile view inside the builder (see Tree.rs note).
-        // `ParentRef::new` captures `SharedReadOnly` provenance from `&*self`,
-        // which is exactly what `Builder` needs (it only ever `Deref`s); the
-        // `Builder` does not outlive this `&mut self` borrow.
         let lockfile_ref = bun_ptr::ParentRef::<Lockfile>::new(&*self);
         let mut builder = tree::Builder::<METHOD> {
             self_contained,
@@ -1428,7 +1609,7 @@ pub struct PendingResolution {
 pub(crate) type PendingResolutions = Vec<PendingResolution>;
 
 // ────────────────────────────────────────────────────────────────────────────
-// fetchNecessaryPackageMetadataAfterYarnOrPnpmMigration
+// fetch_necessary_package_metadata_after_yarn_or_pnpm_migration
 // ────────────────────────────────────────────────────────────────────────────
 
 impl Lockfile {
@@ -1440,7 +1621,7 @@ impl Lockfile {
     ) -> Result<(), AllocError> {
         if populate_manifest_cache::populate_manifest_cache(
             manager,
-            populate_manifest_cache::Packages::All,
+            populate_manifest_cache::Packages::All(self),
         )
         .is_err()
         {
@@ -1450,18 +1631,9 @@ impl Lockfile {
         manager.network_dedupe_map.clear();
 
         let cache_ctx = manager.manifest_disk_cache_ctx();
-        // `manifests` is a field of `manager`, and a `string_builder` is
-        // opened on `manager.lockfile` while `&manifest` is still held.
-        // Route the `manifests` projection
-        // through a raw root so it can coexist with the lockfile borrows;
-        // lockfile fields are taken from `self` (== `manager.lockfile`), never
-        // re-derived via `manager_ptr`. BACKREF `mgr_ref` wraps the same root
-        // for the read-only `options` projection so it goes through safe
-        // `ParentRef::Deref`.
-        let manager_ptr: *mut PackageManager = manager;
-        let mgr_ref = bun_ptr::ParentRef::<PackageManager>::from(
-            core::ptr::NonNull::new(manager_ptr).expect("derived from &mut, non-null"),
-        );
+        let PackageManager {
+            options, manifests, ..
+        } = manager;
         let mut pkgs = self.packages.slice();
         let len = pkgs.len();
 
@@ -1488,15 +1660,9 @@ impl Lockfile {
 
             match pkg_res.tag {
                 ResolutionTag::Npm => {
-                    // `options` read via BACKREF `mgr_ref` (see hoisted note
-                    // above); `manifests` and `lockfile` are non-overlapping
-                    // fields and nothing below resizes/relocates `manifests`
-                    // while `manifest` is held.
                     let pkg_name_str = pkg_name.slice(self.buffers.string_bytes.as_slice());
-                    let scope = mgr_ref.options.scope_for_package_name(pkg_name_str);
-                    // SAFETY: `manifests` projected from `manager_ptr`; the
-                    // call holds only that disjoint field.
-                    let Some(manifest) = unsafe { &mut (*manager_ptr).manifests }.by_name_hash(
+                    let scope = options.scope_for_package_name(pkg_name_str);
+                    let Some(manifest) = manifests.by_name_hash(
                         cache_ctx,
                         scope,
                         pkg_name_str,
@@ -1511,12 +1677,6 @@ impl Lockfile {
                         continue;
                     };
 
-                    // `manager.lockfile` is the same `Lockfile` as `self`. Re-deriving a
-                    // whole `&mut Lockfile` from `manager_ptr` here would create a
-                    // second mutable reference aliasing `self` (UB) — go through
-                    // `self` so the field-level borrows below stay disjoint from the
-                    // live `pkg_*` column views (those point into the columnar heap
-                    // allocation, not the `Lockfile` struct).
                     let mut builder = string_builder!(self);
 
                     let mut bin_extern_strings_count: u32 = 0;
@@ -1608,53 +1768,31 @@ impl<'a> Printer<'a> {
         let mut lockfile_path_buf1 = bun_paths::path_buffer_pool::get();
         let mut lockfile_path_buf2 = bun_paths::path_buffer_pool::get();
 
-        let mut lockfile_path: &ZStr = ZStr::EMPTY;
-        // Track which buffer backs `lockfile_path` so the chdir NUL-terminate
-        // step below can write into the *other* buffer. `resolve_path::z` does
-        // `output[..n].copy_from_slice(input)` (→ `ptr::copy_nonoverlapping`);
-        // passing a slice of `bufN` as `input` while taking `&mut bufN` as
-        // `output` is UB on overlapping ranges and would also corrupt
-        // `lockfile_path` (printed in the NotFound arm).
-        let mut path_in_buf2 = false;
-
+        // `lockfile_path` always ends up in `buf2`; `buf1` is scratch (cwd,
+        // then the NUL-terminated dirname for `chdir`).
+        let mut lockfile_path_len = 0usize;
         if !bun_paths::is_absolute(path) {
             // `bun_sys::getcwd` returns the length written into the
             // caller-owned buffer.
             let cwd_len = bun_sys::getcwd(&mut lockfile_path_buf1[..])?;
             let parts = [path];
-            // Copy `cwd` out of `buf1` so the
-            // join can write into `buf2` while `cwd` borrows `buf1` only.
             let cwd = &lockfile_path_buf1[..cwd_len];
-            let lockfile_path__len = resolve_path::join_abs_string_buf::<platform::Auto>(
+            lockfile_path_len = resolve_path::join_abs_string_buf::<platform::Auto>(
                 cwd,
                 &mut lockfile_path_buf2.0,
                 &parts,
             )
             .len();
-            lockfile_path_buf2[lockfile_path__len] = 0;
-            // SAFETY: NUL written at [len] above. Not `from_buf`: borrowck
-            // can't see that the `path_in_buf2` flag picks the *other* buffer
-            // for the chdir scratch write below, so the borrow must be detached.
-            lockfile_path =
-                unsafe { ZStr::from_raw(lockfile_path_buf2.as_ptr(), lockfile_path__len) };
-            path_in_buf2 = true;
         } else if !path.is_empty() {
-            lockfile_path_buf1[..path.len()].copy_from_slice(path);
-            lockfile_path_buf1[path.len()] = 0;
-            // SAFETY: NUL written at [len] above. See note above re. borrowck.
-            lockfile_path = unsafe { ZStr::from_raw(lockfile_path_buf1.as_ptr(), path.len()) };
+            lockfile_path_buf2[..path.len()].copy_from_slice(path);
+            lockfile_path_len = path.len();
         }
+        lockfile_path_buf2[lockfile_path_len] = 0;
+        let lockfile_path: &ZStr = ZStr::from_buf(&lockfile_path_buf2[..], lockfile_path_len);
 
         if !lockfile_path.as_bytes().is_empty() && lockfile_path.as_bytes()[0] == SEP {
             let dir = bun_paths::dirname(lockfile_path.as_bytes()).unwrap_or(SEP_STR.as_bytes());
-            // NUL-terminate into the buffer that does NOT back `lockfile_path`
-            // (see `path_in_buf2` note above). `buf1`'s cwd contents are dead
-            // after the join, so it is free for reuse here.
-            let dir_z = if path_in_buf2 {
-                resolve_path::z(dir, &mut lockfile_path_buf1)
-            } else {
-                resolve_path::z(dir, &mut lockfile_path_buf2)
-            };
+            let dir_z = resolve_path::z(dir, &mut lockfile_path_buf1);
             let _ = sys::chdir(dir_z);
         }
 
@@ -1731,24 +1869,16 @@ impl<'a> Printer<'a> {
             ..Default::default()
         };
 
-        // Capture the `'static` cwd slice
-        // before borrowing `fs.fs` mutably.
         let top_level_dir = fs.top_level_dir;
-        // Erase to raw so the `entries_mutex` reborrow below doesn't conflict
-        // with the `&mut self` borrow `read_directory` took.
-        let entries_option: *const Fs::EntriesOption =
-            fs.fs.read_directory(top_level_dir, None, 0, true)?;
+        let root_dir: &'static Fs::DirEntry = match fs.read_directory(top_level_dir, 0, true)? {
+            Fs::EntriesOption::Entries(e) => &**e,
+            Fs::EntriesOption::Err(e) => return Err(e.canonical_error.into()),
+        };
         // Copy the listing's basenames out under `entries_mutex`; `.data` must
         // only be probed while the lock is held.
         let entries = {
-            let _entries_lock = fs.fs.entries_mutex.lock_guard();
-            // SAFETY: BSSMap-owned slot; shared read under `entries_mutex`.
-            match unsafe { &*entries_option } {
-                Fs::EntriesOption::Entries(e) => {
-                    DotEnv::DirEntryKeys(e.data.iter().map(|(k, _)| Box::from(&**k)).collect())
-                }
-                Fs::EntriesOption::Err(e) => return Err(e.canonical_error.into()),
-            }
+            let _entries_lock = FileSystem::instance().fs.entries_mutex.lock_guard();
+            DotEnv::DirEntryKeys(root_dir.data.iter().map(|(k, _)| Box::from(&**k)).collect())
         };
 
         let mut env_loader = DotEnv::Loader::init();
@@ -1788,7 +1918,7 @@ impl<'a> Printer<'a> {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
-// verifyData / saveToDisk / rootPackage / str / initEmpty
+// verify_data / save_to_disk / root_package / str / init_empty
 // ────────────────────────────────────────────────────────────────────────────
 
 impl Lockfile {
@@ -1840,7 +1970,7 @@ impl Lockfile {
     /// Returns false when the lockfile on disk already had exactly these bytes and was left untouched.
     pub fn save_to_disk(
         &mut self,
-        load_result: &LoadResult<'_>,
+        load_result: &dyn LoadedFrom,
         options: &PackageManagerOptions,
     ) -> bool {
         let save_format = load_result.save_format(options);
@@ -1868,9 +1998,6 @@ impl Lockfile {
                     // The only write failure on an allocating writer is OOM.
                     bun_core::out_of_memory();
                 }
-
-                // writer.flush() catch error.WriteFailed -> OOM
-                // (Vec<u8> writer needs no flush)
 
                 break 'bytes writer_buf;
             }
@@ -1995,26 +2122,6 @@ impl Lockfile {
     #[inline]
     pub fn str<'a, T: bun_semver::Slicable>(&'a self, slicable: &'a T) -> &'a [u8] {
         slicable.slice(self.buffers.string_bytes.as_slice())
-    }
-
-    /// [`str`](Self::str) with the borrow detached from `self`.
-    ///
-    /// The install pipeline frequently needs to read a string out of
-    /// `buffers.string_bytes` and then call back into `&mut PackageManager`
-    /// (which owns the `Lockfile`). The caller would otherwise have to write
-    /// `unsafe { detach_lifetime(self.str(x)) }` at
-    /// every site. Consolidating that here keeps the SAFETY argument in one
-    /// place.
-    ///
-    /// SAFETY (internal): `string_bytes` is append-only for the lifetime of a
-    /// resolve/enqueue pass and is never reallocated while a detached slice is
-    /// live. The returned slice must not outlive the
-    /// `Lockfile`.
-    #[inline]
-    pub(crate) fn str_detached<'a, T: bun_semver::Slicable>(&self, slicable: &T) -> &'a [u8] {
-        // SAFETY: see doc comment — same invariant every prior call site
-        // already relied on via `bun_ptr::detach_lifetime`.
-        unsafe { bun_ptr::detach_lifetime(slicable.slice(self.buffers.string_bytes.as_slice())) }
     }
 
     /// Construct an empty Lockfile value in place.
@@ -2438,7 +2545,7 @@ impl Lockfile {
             len: 0,
             cap: 0,
             off: 0,
-            ptr: None,
+            allocated: false,
             string_bytes: &mut self.buffers.string_bytes,
             string_pool: &mut self.string_pool,
         }
@@ -2447,8 +2554,7 @@ impl Lockfile {
     /// Borrowck-approved disjoint split: returns a fresh `StringBuilder`
     /// (borrowing `buffers.string_bytes` + `string_pool`) alongside mutable
     /// references to every other `Lockfile` field a caller might need while
-    /// the builder is live. Use this instead of routing through
-    /// `*mut Lockfile` + `unsafe { &mut (*ptr).field }` reborrows.
+    /// the builder is live.
     #[inline]
     pub(crate) fn string_builder_split(&mut self) -> (StringBuilder<'_>, LockfileFields<'_>) {
         let Buffers {
@@ -2462,7 +2568,7 @@ impl Lockfile {
                 len: 0,
                 cap: 0,
                 off: 0,
-                ptr: None,
+                allocated: false,
                 string_bytes,
                 string_pool: &mut self.string_pool,
             },
@@ -2543,7 +2649,7 @@ pub struct StringBuilder<'a> {
     pub len: usize,
     pub cap: usize,
     pub off: usize,
-    pub ptr: Option<*mut u8>,
+    pub allocated: bool,
     pub string_bytes: &'a mut Vec<u8>,
     pub string_pool: &'a mut StringPool,
 }
@@ -2560,7 +2666,7 @@ macro_rules! string_builder {
             len: 0,
             cap: 0,
             off: 0,
-            ptr: None,
+            allocated: false,
             string_bytes: &mut $lockfile.buffers.string_bytes,
             string_pool: &mut $lockfile.string_pool,
         }
@@ -2587,7 +2693,7 @@ impl<'a> StringBuilder<'a> {
     #[inline]
     fn assert_not_allocated(&self) {
         if cfg!(debug_assertions) {
-            if self.ptr.is_some() {
+            if self.allocated {
                 Output::panic(format_args!(
                     "StringBuilder.count called after StringBuilder.allocate. This is a bug in Bun. Please make sure to call StringBuilder.count before allocating."
                 ));
@@ -2626,9 +2732,7 @@ impl<'a> StringBuilder<'a> {
         // `grow_default` precedent at :1578.
         string_bytes.resize(prev_len + self.cap, 0);
         self.off = prev_len;
-        // SAFETY: `string_bytes` was just resized to `prev_len + self.cap`, so
-        // offsetting its base pointer by `prev_len` stays within the allocation.
-        self.ptr = Some(unsafe { string_bytes.as_mut_ptr().add(prev_len) });
+        self.allocated = true;
         self.len = 0;
         Ok(())
     }
@@ -2641,7 +2745,7 @@ impl<'a> StringBuilder<'a> {
         }
 
         debug_assert!(self.len <= self.cap); // didn't count everything
-        debug_assert!(self.ptr.is_some()); // must call allocate first
+        debug_assert!(self.allocated); // must call allocate first
 
         let string_entry = self.string_pool.get_or_put(hash).expect("unreachable");
         if !string_entry.found_existing {
@@ -2754,13 +2858,6 @@ impl FormatVersion {
         FormatVersion::V3
     }
 }
-
-// ────────────────────────────────────────────────────────────────────────────
-// Drop (deinit)
-// ────────────────────────────────────────────────────────────────────────────
-
-// `deinit` only frees owned fields → handled by Drop on each field type.
-// No explicit Drop impl needed.
 
 // ────────────────────────────────────────────────────────────────────────────
 // EqlSorter
@@ -3105,14 +3202,7 @@ impl Lockfile {
         }
 
         let mut digest = ZERO_HASH;
-        // SAFETY: engine is null (default).
-        unsafe {
-            Crypto::SHA512_256::hash(
-                alphabetized_name_version_string,
-                &mut digest,
-                core::ptr::null_mut(),
-            )
-        };
+        Crypto::SHA512_256::hash_with_default_engine(alphabetized_name_version_string, &mut digest);
 
         Ok(digest)
     }
@@ -3128,8 +3218,6 @@ impl Lockfile {
 
         match version.tag {
             dependency::Tag::Npm => {
-                // SAFETY: tag checked == .npm above; `npm` is the active
-                // `dependency::Value` union field.
                 let npm_group = &version.npm().version;
                 // Only a resolution whose own tag is npm may be read through
                 // `Resolution::npm()`: the root package, workspace members, and
@@ -3248,7 +3336,7 @@ pub mod default_trusted_dependencies {
         MAP.has_with_hash(hash)
     }
 
-    /// Open-coded `hasContext` so the lookup key can borrow with any lifetime,
+    /// Open-coded lookup so the key can borrow with any lifetime,
     /// not just `'static`.
     pub(crate) fn has(name: &[u8]) -> bool {
         let hash = (SemverStringBuilder::string_hash(name) as u32) as u64;
@@ -3269,8 +3357,10 @@ impl Lockfile {
             .is_some_and(|trusted| trusted.contains(&hash))
     }
 
+    /// `options` decides which registry a default-trusted package must come from.
     pub fn has_trusted_dependency(
         &self,
+        options: &PackageManagerOptions,
         alias: &[u8],
         pkg_name: &[u8],
         resolution: &Resolution,
@@ -3309,10 +3399,7 @@ impl Lockfile {
         if url.is_empty() {
             return true;
         }
-        let registry = PackageManager::get()
-            .scope_for_package_name(pkg_name)
-            .url
-            .href();
+        let registry = options.scope_for_package_name(pkg_name).url.href();
         let Ok(canonical_url) = crate::extract_tarball::build_url_with_printer(
             registry,
             &strings::StringOrTinyString::init(pkg_name),
@@ -3364,7 +3451,7 @@ impl Lockfile {
 // ────────────────────────────────────────────────────────────────────────────
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, bytemuck::NoUninit, bytemuck::CheckedBitPattern)]
 pub struct PatchedDep {
     /// e.g. "patches/is-even@1.0.0.patch"
     pub(crate) path: SemverString,

--- a/src/install/lockfile/Buffers.rs
+++ b/src/install/lockfile/Buffers.rs
@@ -9,7 +9,7 @@ use bun_core::strings;
 // parent-module alias is spelled via its crate path instead.
 use super::{
     DependencyIDList, DependencyList, ExternalStringBuffer, Lockfile, PackageIDList, Stream,
-    StringBuffer, Tree, assert_no_uninitialized_padding, tree,
+    StringBuffer, Tree, tree,
 };
 use crate::lockfile_real as lockfile;
 use crate::package_manager_real::package_manager_options::Options as PackageManagerOptions;
@@ -29,9 +29,6 @@ pub struct Buffers {
     /// This is where all non-inlinable `Semver.String`s are stored.
     pub string_bytes: StringBuffer,
 }
-
-// The Vec-backed field types drop automatically; no explicit `Drop` impl is
-// needed.
 
 impl Buffers {
     pub(crate) fn preallocate(&mut self, that: &Buffers) -> Result<(), bun_alloc::AllocError> {
@@ -80,7 +77,11 @@ mod sizes {
     const _: () = assert!(ALIGN_TYPE_0 == align_of::<&[Tree]>());
 }
 
-pub(crate) fn read_array<T: Copy>(stream: &mut Stream) -> crate::Result<Vec<T>> {
+/// `T: CheckedBitPattern`: every element read from the (untrusted) lockfile is
+/// validated; for plain-data `T` that check is free.
+pub(crate) fn read_array<T: bytemuck::CheckedBitPattern>(
+    stream: &mut Stream,
+) -> crate::Result<Vec<T>> {
     let start_pos = stream.read_int_le::<u64>()?;
 
     // If its 0xDEADBEEF, then that means the value was never written in the lockfile.
@@ -139,19 +140,24 @@ pub(crate) fn read_array<T: Copy>(stream: &mut Stream) -> crate::Result<Vec<T>> 
 
     let start_pos = start_pos as usize;
     let end_pos = end_pos as usize;
-    // SAFETY: `start_pos..end_pos` is in-bounds (checked above) and the lockfile
-    // writer aligned the payload to `align_of::<T>()` via `Aligner::write`.
-    let misaligned: &[T] = unsafe {
-        bun_core::ffi::slice(
-            stream.buffer.as_ptr().add(start_pos).cast::<T>(),
-            (end_pos - start_pos) / size_of::<T>(),
-        )
-    };
-
-    Ok(misaligned.to_vec())
+    read_elements(&stream.buffer[start_pos..end_pos]).ok_or(crate::Error::CorruptLockfile)
 }
 
-pub(crate) fn write_array<S, T>(
+/// `bytes` as a `Vec<T>`, every element validated (free for plain-data `T`);
+/// `None` if one is not a valid `T`. One copy when `bytes` is aligned for `T`.
+pub(crate) fn read_elements<T: bytemuck::CheckedBitPattern>(bytes: &[u8]) -> Option<Vec<T>> {
+    use bytemuck::checked::{CheckedCastError, try_cast_slice, try_pod_read_unaligned};
+    match try_cast_slice::<u8, T>(bytes) {
+        Ok(elements) => Some(elements.to_vec()),
+        Err(CheckedCastError::InvalidBitPattern) => None,
+        Err(_) => bytes
+            .chunks_exact(size_of::<T>())
+            .map(|raw| try_pod_read_unaligned(raw).ok())
+            .collect(),
+    }
+}
+
+pub(crate) fn write_array<S, T: bytemuck::NoUninit>(
     stream: &mut S,
     array: &[T],
     prefix: &'static str,
@@ -162,17 +168,9 @@ where
     // `bun_io::Write` (append) — so there are never two `&mut` to one buffer.
     S: lockfile::PositionalStream + bun_io::Write,
 {
-    // This call is a zero-cost intent marker only — it carries no trait bound (see the
-    // doc comment on `assert_no_uninitialized_padding`). The actual compile-time
-    // enforcement is the per-type `const` field-offset asserts and the
-    // `layout_asserts` size/align pins in src/install/padding_checker.rs; any new
-    // `T` serialized through here must be added to that audit.
-    assert_no_uninitialized_padding(array);
-
-    // SAFETY: `T` has no uninitialized padding (audited via the per-type layout
-    // asserts in padding_checker.rs); reading its bytes is sound.
-    let bytes: &[u8] =
-        unsafe { bun_core::ffi::slice(array.as_ptr().cast::<u8>(), core::mem::size_of_val(array)) };
+    // `T: NoUninit` — and the per-type layout pins in padding_checker.rs keep
+    // the on-disk format stable.
+    let bytes: &[u8] = bytemuck::cast_slice(array);
 
     let start_pos = stream.get_pos()?;
     stream.write_int_le::<u64>(0xDEAD_BEEF)?;
@@ -192,8 +190,6 @@ where
         stream.write_all(bytes)?;
         let real_end_pos = stream.get_pos()? as u64;
         let positioned: [u64; 2] = [real_start_pos, real_end_pos];
-        // `[u64; 2]` and `[u8; 16]` are both `Pod` of equal size — `bytemuck`
-        // gives the byte view without `unsafe`.
         let positioned_bytes: &[u8; 16] = bytemuck::cast_ref(&positioned);
         let mut written: usize = 0;
         while written < 16 {
@@ -202,8 +198,6 @@ where
     } else {
         let real_end_pos = stream.get_pos()? as u64;
         let positioned: [u64; 2] = [real_end_pos, real_end_pos];
-        // `[u64; 2]` and `[u8; 16]` are both `Pod` of equal size — `bytemuck`
-        // gives the byte view without `unsafe`.
         let positioned_bytes: &[u8; 16] = bytemuck::cast_ref(&positioned);
         let mut written: usize = 0;
         while written < 16 {
@@ -247,7 +241,7 @@ where
         // Write the explicit `Tree.External` form so the on-disk layout is
         // independent of `repr(Rust)` field order: 20 bytes/tree, fields in
         // the `[id|dep_id|parent|off|len]` order that `load` decodes via
-        // `Tree.toTree`.
+        // `Tree::to_tree`.
         let mut clone: Vec<tree::External> = Vec::with_capacity(buffers.trees.len());
         for &item in buffers.trees.as_slice() {
             clone.push(Tree::to_external(item));
@@ -284,7 +278,7 @@ where
             bun_core::pretty_errorln!("Saving {} {}", buffers.dependencies.len(), "dependencies");
         }
 
-        // Dependencies have to be converted to .toExternal first
+        // Dependencies have to be converted to .to_external first
         // We store pointers in Version.Value, so we can't just write it directly
         let remaining = buffers.dependencies.as_slice();
 
@@ -293,8 +287,6 @@ where
             use bun_install::dependency::version::Tag;
             const SEP_WINDOWS: u8 = b'\\';
             for dep in remaining {
-                // SAFETY: `dep.version.value` is a tag-discriminated union; each
-                // arm reads only the field corresponding to `dep.version.tag`.
                 match dep.version.tag {
                     Tag::Folder => {
                         let folder = lockfile.str(dep.version.folder());
@@ -459,7 +451,6 @@ pub(crate) fn load(
     let string_buf = this.string_bytes.as_slice();
     let mut extern_context = dependency::Context {
         log,
-        // allocator dropped — global mimalloc
         buffer: string_buf,
         package_manager: pm_,
     };

--- a/src/install/lockfile/CatalogMap.rs
+++ b/src/install/lockfile/CatalogMap.rs
@@ -418,9 +418,6 @@ impl CatalogMap {
             });
     }
 
-    // No explicit `deinit`: `Map` and `ArrayHashMap<String, Map>` are owned
-    // collections whose `Drop` recursively frees the nested maps.
-
     /// Accepts `lockfile.buffers.string_bytes` directly (rather than the whole
     /// `Lockfile`) so callers can split-borrow the lockfile alongside a live
     /// `StringBuilder`.

--- a/src/install/lockfile/OverrideMap.rs
+++ b/src/install/lockfile/OverrideMap.rs
@@ -25,10 +25,9 @@ use super::package::PackageColumns as _;
 use super::package::workspace_map::WorkspaceMap;
 use super::package::{DependencyGroup, value_loc_of};
 use super::{Lockfile, StringBuilder, package::Package};
-// LAYERING NOTE: package.json is parsed by `bun_parsers::json` which
-// produces the T2 value-shaped `bun_ast::Expr` (aliased as
-// `crate::bun_json::Expr`), NOT the full T4 `bun_ast::Expr`. JSON parse
-// is always UTF-8, so `as_utf8_string_literal()` needs no allocator.
+// package.json is parsed by `bun_parsers::json` into the value-shaped
+// `bun_ast::Expr` (aliased as `crate::bun_json::Expr`). JSON parse is always
+// UTF-8, so `as_utf8_string_literal()` suffices.
 use crate::bun_json::Expr;
 
 declare_scope!(OverrideMap, visible);

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -15,9 +15,8 @@ use crate::dependency::{Behavior, DependencyExt as _, TagExt as _};
 use crate::repository::RepositoryExt as _;
 use crate::{
     self as install, Aligner, Bin, Dependency, ExternalStringList, ExternalStringMap, Features,
-    Npm, PackageID, PackageManager, PackageNameHash, Repository, TruncatedPackageNameHash,
-    UpdateRequest, bin, default_trusted_dependencies, dependency, initialize_store,
-    invalid_package_id,
+    Npm, PackageID, PackageManager, PackageNameHash, Repository, TruncatedPackageNameHash, bin,
+    default_trusted_dependencies, dependency, initialize_store, invalid_package_id,
 };
 // `Package.rs` is mounted as `crate::lockfile_real::package`; the parent module
 // (`super`) is the real `lockfile.rs`, distinct from the `crate::lockfile`
@@ -218,10 +217,8 @@ pub trait ResolverContext {
             false,
             "ResolverContext::resolution called on non-git resolver"
         );
-        // SAFETY: unreachable in practice; never dereferenced when the
-        // `IS_GIT_RESOLVER` gate is false. `ZEROED` is an associated const on a
-        // trait-bounded generic impl, which Rust refuses to evaluate in `const`
-        // position; a `static` (with `Sync` POD payload) sidesteps that.
+        // Unreachable in practice; never read when the `IS_GIT_RESOLVER`
+        // gate is false.
         static EMPTY: ResolutionType<u64> = ResolutionType::<u64>::ZEROED;
         &EMPTY
     }
@@ -259,7 +256,7 @@ impl ResolverContext for () {
 // `R` (six instantiations × ~49kB ≈ 292kB of identical machine code, plus a
 // duplicate `<()>` copy across CGUs). The associated consts become `&self`
 // predicates; everything else forwards 1:1. The generic `parse_with_json<R>`
-// stays as a thin shim that erases `&mut R` → `&mut dyn ResolverContextDyn`
+// stays as a thin shim that erases `&mut R` to `&mut dyn ResolverContextDyn`
 // and delegates to the non-generic `parse_with_json_impl`.
 //
 // `count`/`resolve` keep their `StringBuilder<'_>` borrow — lifetimes are
@@ -545,10 +542,10 @@ impl Package<u64> {
 
         let id = new.packages.len() as PackageID;
 
-        // `appendPackageWithID` borrows `&mut Lockfile` whole, so build the
+        // `append_package_with_id` borrows `&mut Lockfile` whole, so build the
         // `Package` value and clone the dependency strings *first* (only needs
         // disjoint buffer fields), drop the builder, then append, then write
-        // resolutions. `appendPackageWithID` touches `packages` /
+        // resolutions. `append_package_with_id` touches `packages` /
         // `package_index` / `string_bytes` only — none of which the dependency
         // pass mutates — so the reorder is observationally identical.
         let pkg_value = Package {
@@ -632,7 +629,7 @@ impl Package<u64> {
     }
 
     pub(crate) fn from_npm(
-        pm: &mut PackageManager,
+        npm_aliases: &mut dyn crate::dependency::NpmAliasRegistry,
         lockfile: &mut Lockfile,
         log: &mut bun_ast::Log,
         manifest: &Npm::PackageManifest,
@@ -804,13 +801,13 @@ impl Package<u64> {
                         name: name.value,
                         name_hash: name.hash,
                         behavior,
-                        version: Dependency::parse(
+                        version: crate::dependency::parse_with_alias_registry(
                             name.value,
                             Some(name.hash),
                             sliced.slice,
                             &sliced,
                             Some(&mut *log),
-                            Some(&mut *pm),
+                            Some(&mut *npm_aliases),
                         )
                         .unwrap_or_default(),
                     };
@@ -949,6 +946,15 @@ impl DiffSummary {
     }
 }
 
+/// What a `bun update` run is updating, for [`Diff::generate`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Updating {
+    /// Bare `bun update`: every dependency.
+    Everything,
+    /// `bun update <names>`: the manager's update requests.
+    Named,
+}
+
 impl Diff {
     // `Package` here is the canonical `Package<u64>` (the only
     // instantiation `Lockfile` ever holds). Dropping the generic avoids a
@@ -961,7 +967,7 @@ impl Diff {
         to_lockfile: &mut Lockfile,
         from: &Package,
         to: &Package,
-        update_requests: Option<&[UpdateRequest]>,
+        updating: Option<Updating>,
         id_mapping: Option<&mut [PackageID]>,
     ) -> crate::Result<DiffSummary> {
         let mut removed_names: Vec<PackageNameHash> = Vec::new();
@@ -972,7 +978,7 @@ impl Diff {
             to_lockfile,
             from,
             to,
-            update_requests,
+            updating,
             id_mapping,
             &mut removed_names,
         )
@@ -986,23 +992,22 @@ impl Diff {
         to_lockfile: &mut Lockfile,
         from: &Package,
         to: &Package,
-        update_requests: Option<&[UpdateRequest]>,
+        updating: Option<Updating>,
         mut id_mapping: Option<&mut [PackageID]>,
         removed_names: &mut Vec<PackageNameHash>,
     ) -> crate::Result<DiffSummary> {
         let mut summary = DiffSummary::default();
         let is_root = id_mapping.is_some();
-        let named_update_here = match update_requests {
-            Some(updates) if !updates.is_empty() => crate::update_scope::UpdateScope::of(&*pm)
-                .contains_workspace(
-                    from.resolution.tag == ResolutionTag::Root,
-                    from.name_hash,
-                    from.name
-                        .slice(from_lockfile.buffers.string_bytes.as_slice()),
-                ),
+        let named_update_here = match updating {
+            Some(Updating::Named) => crate::update_scope::UpdateScope::of(&*pm).contains_workspace(
+                from.resolution.tag == ResolutionTag::Root,
+                from.name_hash,
+                from.name
+                    .slice(from_lockfile.buffers.string_bytes.as_slice()),
+            ),
             _ => true,
         };
-        // `parseWithJSON` may grow `to_lockfile.buffers.dependencies` and
+        // `parse_with_json` may grow `to_lockfile.buffers.dependencies` and
         // invalidate the old slice, so `to_deps` is re-derived after it. Held as raw fat
         // pointers so the `&mut to_lockfile`/`&mut from_lockfile` reborrows below
         // (sort, recursive `generate`) don't conflict with these read views; the
@@ -1081,7 +1086,6 @@ impl Diff {
                     break 'catalogs;
                 }
 
-                // Reshaped for borrowck — see `overrides.sort` note above.
                 lockfile::CatalogMap::sort(&mut from_lockfile.catalogs, &from_lockfile.buffers);
                 lockfile::CatalogMap::sort(&mut to_lockfile.catalogs, &to_lockfile.buffers);
 
@@ -1445,8 +1449,8 @@ impl Diff {
                 to_lockfile.buffers.string_bytes.as_slice(),
                 from_lockfile.buffers.string_bytes.as_slice(),
             ) {
-                if let Some(updates) = update_requests {
-                    if updates.is_empty()
+                if let Some(updating) = updating {
+                    if updating == Updating::Everything
                         || (named_update_here
                             && pm.is_update_request(
                                 from_dep.name_hash,
@@ -1483,10 +1487,7 @@ impl Diff {
                         );
                         let _ = package_json_path.append(b"package.json");
 
-                        // `bun.sys.File.toSource` was removed from
-                        // T1 (`bun_sys`) because `bun_ast::Source` lives in T2.
-                        // Route through the workspace cache's path-based getter
-                        // instead, which both reads and parses.
+                        // The workspace cache's path-based getter both reads and parses.
                         let mut workspace_pkg = Package::default();
 
                         // The cache entry borrows `pm.workspace_package_json_cache`;
@@ -1538,7 +1539,7 @@ impl Diff {
                             to_lockfile,
                             &from_pkg,
                             &workspace_pkg,
-                            update_requests,
+                            updating,
                             None,
                             removed_names,
                         )?;
@@ -1575,8 +1576,8 @@ impl Diff {
             }
 
             // Changed literal: keep the locked resolution while it still satisfies the new range (npm's sticky rule), unless this row is being updated.
-            let is_explicit_update_target = matches!(update_requests, Some(updates)
-            if updates.is_empty()
+            let is_explicit_update_target = matches!(updating, Some(updating)
+            if updating == Updating::Everything
                 || (named_update_here
                     && pm.is_update_request(
                         from_dep.name_hash,
@@ -1708,36 +1709,6 @@ impl Package<u64> {
         self.parse_with_json::<R>(lockfile, pm, log, source, parsed.root, resolver, features)
     }
 
-    /// Borrow-splitting bridge for `PackageManager` callers
-    /// (`processDependencyList`, `folder_resolver`). Borrowck rejects passing
-    /// `manager.lockfile`, `manager`, `manager.log` as three separate args
-    /// overlapping `&mut self`, so split via raw
-    /// pointer here once instead of at every call site.
-    ///
-    /// # Safety
-    /// `manager` must point to a live `PackageManager` for the duration of the
-    /// call, and its `lockfile` / `log` fields must point to live allocations
-    /// disjoint from `*manager` itself.
-    pub(crate) unsafe fn parse_from_real_manager<R: ResolverContext>(
-        &mut self,
-        manager: *mut crate::package_manager_real::PackageManager,
-        source: &bun_ast::Source,
-        resolver: &mut R,
-        features: Features,
-    ) -> crate::Result<()> {
-        // SAFETY: `manager` points to a live `PackageManager` for the duration
-        // of this call (caller passes `self as *mut _`); `lockfile` and `log`
-        // are disjoint fields, and `parse_with_json` only reaches `manager`
-        // through the `pm` argument it receives here — no re-entrancy.
-        let (lockfile, pm, log) = unsafe {
-            let m = &mut *manager;
-            let lockfile: *mut Lockfile = &raw mut *m.lockfile;
-            let log: *mut bun_ast::Log = m.log;
-            (&mut *lockfile, &mut *manager, &mut *log)
-        };
-        self.parse(lockfile, pm, log, source, resolver, features)
-    }
-
     // The live `StringBuilder`
     // (also passed) already holds `&mut lockfile.buffers.string_bytes`. The
     // body only otherwise touches `workspace_paths` / `workspace_versions`,
@@ -1788,13 +1759,14 @@ impl Package<u64> {
         #[cfg(not(windows))]
         let external_version = string_builder.append::<String>(version);
 
-        // SAFETY: `buf` aliases `string_builder.string_bytes` while later
-        // `string_builder.append()` calls write into the *pre-reserved* tail
-        // (`allocate()` ran before this fn). No realloc occurs, so the detached
-        // borrow stays valid; a tracked `&[u8]` would needlessly lock the builder.
-        let buf: &[u8] =
-            unsafe { bun_ptr::detach_lifetime(string_builder.string_bytes.as_slice()) };
-        let sliced = external_version.sliced(buf);
+        // The lockfile string bytes as of each use (later `append`s write
+        // into the builder's pre-reserved tail).
+        macro_rules! buf {
+            () => {
+                string_builder.string_bytes.as_slice()
+            };
+        }
+        let sliced = external_version.sliced(buf!());
 
         let mut dependency_version = Dependency::parse_with_optional_tag(
             external_alias.value,
@@ -1807,12 +1779,14 @@ impl Package<u64> {
         )
         .unwrap_or_default();
         let mut workspace_range: Option<semver::query::Group> = None;
+        // Where `workspace_range`'s text starts within `external_version`.
+        let mut workspace_range_at = 0usize;
         #[allow(non_snake_case)]
         let FEATURES = features;
         let name_hash = match dependency_version.tag {
             dependency::version::Tag::Npm => {
                 let npm_name = dependency_version.npm().name;
-                semver::string::Builder::string_hash(npm_name.slice(buf))
+                semver::string::Builder::string_hash(npm_name.slice(buf!()))
             }
             dependency::version::Tag::Workspace => {
                 if strings::has_prefix(sliced.slice, b"workspace:") {
@@ -1828,6 +1802,7 @@ impl Package<u64> {
                                     semver::query::parse(&input[at as usize + 1..], sliced)
                                         .unwrap_or_else(|_| bun_core::out_of_memory()),
                                 );
+                                workspace_range_at = b"workspace:".len() + at as usize + 1;
                                 break 'brk semver::string::Builder::string_hash(
                                     &input[0..at as usize],
                                 );
@@ -1836,6 +1811,7 @@ impl Package<u64> {
                                 semver::query::parse(input, sliced)
                                     .unwrap_or_else(|_| bun_core::out_of_memory()),
                             );
+                            workspace_range_at = b"workspace:".len();
                         }
                         external_alias.hash
                     }
@@ -1867,14 +1843,14 @@ impl Package<u64> {
                 let Some(joined) = resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(
                     FileSystem::instance().top_level_dir(),
                     &mut folder_buf.0,
-                    &[source.path.name().dir, folder.slice(buf)],
+                    &[source.path.name().dir, folder.slice(buf!())],
                 ) else {
                     log.add_error_fmt(
                         source,
                         value_loc_of(source, key_loc),
                         format_args!(
                             "Dependency \"{}\" has an unsafe folder path",
-                            bstr::BStr::new(external_alias.slice(buf)),
+                            bstr::BStr::new(external_alias.slice(buf!())),
                         ),
                     );
                     return Err(crate::Error::InstallFailed);
@@ -1901,9 +1877,9 @@ impl Package<u64> {
                     workspace_versions,
                     name_hash,
                     &dependency_version.npm().version,
-                    buf,
+                    buf!(),
                 ) {
-                    let path = workspace_path.sliced(buf);
+                    let path = workspace_path.sliced(buf!());
                     if let Some(mut dep) = dependency::parse_with_tag(
                         external_alias.value,
                         Some(external_alias.hash),
@@ -1937,17 +1913,18 @@ impl Package<u64> {
                 if let Some(path) = workspace_path {
                     if let Some(range) = &workspace_range {
                         if let Some(ver) = workspace_version {
-                            if range.satisfies(ver, buf, buf) {
+                            if range.satisfies(ver, buf!(), buf!()) {
                                 dependency_version.value.workspace = path;
                                 break 'workspace;
                             }
                         }
 
                         // important to trim before len == 0 check. `workspace:foo@      ` should install successfully
-                        // SAFETY: `range.input` borrows `lockfile.buffers.string_bytes`
-                        // (set by `semver::query::parse` above), which is live here.
-                        let version_literal =
-                            strings::trim(unsafe { &*range.input }, &strings::WHITESPACE_CHARS);
+                        let external_version_text = external_version.slice(buf!());
+                        let version_literal = strings::trim(
+                            &external_version_text[workspace_range_at..],
+                            &strings::WHITESPACE_CHARS,
+                        );
                         if version_literal.is_empty()
                             || range.is_star()
                             || SemverVersion::is_tagged_version_only(version_literal)
@@ -1963,8 +1940,8 @@ impl Package<u64> {
                             bun_ast::Loc::EMPTY,
                             format_args!(
                                 "No matching version for workspace dependency \"{}\". Version: \"{}\"",
-                                bstr::BStr::new(external_alias.slice(buf)),
-                                bstr::BStr::new(dependency_version.literal.slice(buf)),
+                                bstr::BStr::new(external_alias.slice(buf!())),
+                                bstr::BStr::new(dependency_version.literal.slice(buf!())),
                             ),
                         );
                         return Err(crate::Error::InstallFailed);
@@ -1972,61 +1949,36 @@ impl Package<u64> {
 
                     dependency_version.value.workspace = path;
                 } else if features.is_main || features.is_workspace {
-                    // SAFETY: tag == Workspace selects the `workspace` union member.
-                    // Bind the (Copy) union field first so `slice()`'s `&self`
-                    // borrow has a named place to point at.
                     let workspace_str = *dependency_version.workspace();
-                    let workspace = workspace_str.slice(buf);
-                    let path =
-                        string_builder.append::<String>(if workspace == b"*" {
+                    let mut rel_buf = bun_paths::path_buffer_pool::get();
+                    let rel: &[u8] = {
+                        let workspace = workspace_str.slice(buf!());
+                        if workspace == b"*" {
                             b"*"
                         } else {
-                            'brk: {
-                                let mut buf2 = bun_paths::path_buffer_pool::get();
-                                let rel =
-                                    resolve_path::relative_platform::<path::platform::Auto, false>(
-                                        FileSystem::instance().top_level_dir(),
-                                        resolve_path::join_abs_string_buf::<path::platform::Auto>(
-                                            FileSystem::instance().top_level_dir(),
-                                            &mut buf2.0,
-                                            &[source.path.name().dir, workspace],
-                                        ),
-                                    );
-                                #[cfg(windows)]
-                                {
-                                    // With ALWAYS_COPY=false, `rel` may borrow
-                                    // RELATIVE_TO_BUF (resolve_path.rs early returns at L450/457/500/
-                                    // 522) or be `b""`. Re-deriving a slice of the common-path buf
-                                    // would yield stale bytes in those cases. Copy `rel` into the
-                                    // common-path scratch when it isn't already there, then convert
-                                    // and return that — returning `rel`'s bytes
-                                    // while avoiding aliasing UB.
-                                    let len = rel.len();
-                                    let common_raw = path::relative_to_common_path_buf();
-                                    // `PathBuffer` is `repr(transparent)` over `[u8; N]`, so the
-                                    // struct pointer equals `(&*common_raw).as_ptr()`.
-                                    let rel_is_common =
-                                        core::ptr::eq(rel.as_ptr(), common_raw.cast::<u8>());
-                                    // SAFETY: thread-local scratch; sole live mut borrow on this
-                                    // thread for the remainder of this block. When `rel` aliased
-                                    // it, its last use was the `.as_ptr()` above (NLL-dead);
-                                    // otherwise `rel` borrows a disjoint allocation.
-                                    let common = unsafe { &mut *common_raw };
-                                    if !rel_is_common {
-                                        // `rel` is into a disjoint thread-local (RELATIVE_TO_BUF)
-                                        // or `b""` (len==0 → no read).
-                                        common[..len].copy_from_slice(rel);
-                                    }
-                                    let s: &mut [u8] = &mut common[..len];
-                                    path::dangerously_convert_path_to_posix_in_place::<u8>(s);
-                                    break 'brk &*s;
-                                }
-                                #[cfg(not(windows))]
-                                break 'brk rel;
-                            }
-                        });
+                            let mut buf2 = bun_paths::path_buffer_pool::get();
+                            let abs = resolve_path::join_abs_string_buf::<path::platform::Auto>(
+                                FileSystem::instance().top_level_dir(),
+                                &mut buf2.0,
+                                &[source.path.name().dir, workspace],
+                            );
+                            let len = resolve_path::relative_platform_buf::<
+                                path::platform::Auto,
+                                true,
+                            >(
+                                &mut rel_buf.0, FileSystem::instance().top_level_dir(), abs
+                            )
+                            .len();
+                            #[cfg(windows)]
+                            path::dangerously_convert_path_to_posix_in_place::<u8>(
+                                &mut rel_buf.0[..len],
+                            );
+                            &rel_buf.0[..len]
+                        }
+                    };
+                    let path = string_builder.append::<String>(rel);
                     debug_assert!(path.len() > 0);
-                    debug_assert!(!bun_paths::is_absolute(path.slice(buf)));
+                    debug_assert!(!bun_paths::is_absolute(path.slice(buf!())));
                     dependency_version.value.workspace = path;
 
                     let workspace_entry = workspace_paths.get_or_put(name_hash)?;
@@ -2040,23 +1992,19 @@ impl Package<u64> {
                                 // `dependencies` & `workspaces` defined within the same `package.json`
                                 dependency::version::Tag::Npm => {
                                     semver::string::Builder::string_hash(
-                                        package_dep.realname().slice(buf),
+                                        package_dep.realname().slice(buf!()),
                                     ) == name_hash
-                                        // SAFETY: tag == Npm selects the `npm` union member.
-                                        && unsafe {
-                                            package_dep
-                                                .version
-                                                .value
-                                                .npm
-                                                .version
-                                                .satisfies(ver, buf, buf)
-                                        }
+                                        && package_dep.version.npm().version.satisfies(
+                                            ver,
+                                            buf!(),
+                                            buf!(),
+                                        )
                                 }
                                 // `workspace:*`
                                 dependency::version::Tag::Workspace => {
                                     found_matching_workspace
                                         && semver::string::Builder::string_hash(
-                                            package_dep.realname().slice(buf),
+                                            package_dep.realname().slice(buf!()),
                                         ) == name_hash
                                 }
                                 _ => false,
@@ -2071,7 +2019,7 @@ impl Package<u64> {
                         {
                             if package_dep.version.tag == dependency::version::Tag::Workspace
                                 && semver::string::Builder::string_hash(
-                                    package_dep.realname().slice(buf),
+                                    package_dep.realname().slice(buf!()),
                                 ) == name_hash
                             {
                                 package_dep.version = dependency_version;
@@ -2123,7 +2071,7 @@ impl Package<u64> {
                         let _ = write!(
                             &mut text,
                             "\"{}\" originally specified here",
-                            bstr::BStr::new(external_alias.slice(buf))
+                            bstr::BStr::new(external_alias.slice(buf!()))
                         );
                     }
                     notes.push(bun_ast::Data {
@@ -2141,7 +2089,7 @@ impl Package<u64> {
                         notes.into(),
                         format_args!(
                             "Duplicate dependency: \"{}\" specified in package.json",
-                            bstr::BStr::new(external_alias.slice(buf))
+                            bstr::BStr::new(external_alias.slice(buf!()))
                         ),
                     );
                 }
@@ -2182,9 +2130,28 @@ impl Package<u64> {
     ) -> crate::Result<()> {
         #[allow(non_snake_case)]
         let FEATURES = features;
-        // Function-local arena for `asString` transcoding (transcoded strings
+        // Function-local arena for `as_string` transcoding (transcoded strings
         // are only borrowed until `string_builder.append` copies them).
         let bump = bun_alloc::Arena::new();
+        // `--frozen-lockfile` tolerates a listed workspace that is missing on
+        // disk if the loaded lockfile knows it. That lockfile is `pm.lockfile`
+        // unless this parse writes straight into it (the caller then moved it
+        // out of the manager and it is `lockfile`): copy its workspace paths
+        // out before the string builder borrows it.
+        let own_workspace_paths: Option<&[&[u8]]> = (FEATURES.workspaces
+            && pm.options.enable.frozen_lockfile()
+            && pm.lockfile.packages.len() == 0
+            && lockfile.workspace_paths.count() != 0)
+            .then(|| {
+                let string_bytes = lockfile.buffers.string_bytes.as_slice();
+                &*bump.alloc_slice_fill_iter(
+                    lockfile
+                        .workspace_paths
+                        .values()
+                        .iter()
+                        .map(|path| &*bump.alloc_slice_copy(path.slice(string_bytes))),
+                )
+            });
         // split-borrow `string_bytes`/`string_pool` so the dozens of
         // disjoint `lockfile.{buffers.*, overrides, catalogs, workspace_*, …}`
         // accesses below pass borrowck. Reads of `lockfile.buffers.string_bytes`
@@ -2345,10 +2312,12 @@ impl Package<u64> {
             }
         }
 
-        let missing_workspace = if pm.options.enable.frozen_lockfile() {
-            workspace_map::MissingWorkspace::SkipIfInLockfile(&pm.lockfile)
-        } else {
+        let missing_workspace = if !pm.options.enable.frozen_lockfile() {
             workspace_map::MissingWorkspace::Error
+        } else if let Some(paths) = own_workspace_paths {
+            workspace_map::MissingWorkspace::SkipIfListed(paths)
+        } else {
+            workspace_map::MissingWorkspace::SkipIfInLockfile(&pm.lockfile)
         };
 
         for group in &dependency_groups {
@@ -2564,7 +2533,7 @@ impl Package<u64> {
                     .parse_count(workspaces_expr, &mut string_builder);
             }
 
-            // Count catalog strings in top-level package.json as well, since parseAppend
+            // Count catalog strings in top-level package.json as well, since parse_append
             // might process them later if no catalogs were found in workspaces
             lockfile.catalogs.parse_count(json, &mut string_builder);
 
@@ -2705,12 +2674,10 @@ impl Package<u64> {
                             debug_assert!(i == extern_strings.len());
                             self.bin = Bin {
                                 tag: bin::Tag::Map,
-                                value: bin::Value {
-                                    map: ExternalStringList::new(
-                                        current_len as u32,
-                                        extern_strings.len() as u32,
-                                    ),
-                                },
+                                value: bin::Value::init_map(ExternalStringList::new(
+                                    current_len as u32,
+                                    extern_strings.len() as u32,
+                                )),
                                 ..Default::default()
                             };
                         }
@@ -2722,9 +2689,9 @@ impl Package<u64> {
                     if !stri.data.is_empty() {
                         self.bin = Bin {
                             tag: bin::Tag::File,
-                            value: bin::Value {
-                                file: string_builder.append::<String>(&stri.data),
-                            },
+                            value: bin::Value::init_file(
+                                string_builder.append::<String>(&stri.data),
+                            ),
                             ..Default::default()
                         };
                         break 'bin;
@@ -2745,9 +2712,7 @@ impl Package<u64> {
                         if !str_.is_empty() {
                             self.bin = Bin {
                                 tag: bin::Tag::Dir,
-                                value: bin::Value {
-                                    dir: string_builder.append::<String>(str_),
-                                },
+                                value: bin::Value::init_dir(string_builder.append::<String>(str_)),
                                 ..Default::default()
                             };
                             break 'bin;
@@ -2932,7 +2897,6 @@ impl Package<u64> {
                         if let Some(version_string) = &entry.version {
                             let external_version =
                                 string_builder.append::<ExternalString>(version_string);
-                            // allocator.free(version_string); — Drop handles it (Box<[u8]>)
                             let sliced = external_version
                                 .value
                                 .sliced(string_builder.string_bytes.as_slice());
@@ -3179,28 +3143,54 @@ pub mod serializer {
         let end_at = stream.get_pos()?;
         stream.write_int_le::<u64>(0)?;
 
-        // `*mut u8` carries the pointer alignment, matching the
-        // `@alignOf(@TypeOf(list.bytes))` value serialized above.
+        // `*mut u8` carries the pointer alignment, matching the value
+        // serialized above.
         let pos = stream.get_pos()? as u64;
         let _ = Aligner::write::<*mut u8, _>(&mut *stream, pos)?;
 
         let really_begin_at = stream.get_pos()?;
-        let mut sliced = list.slice();
+        let sliced = list.slice();
 
         for field in PackageField::ALL {
-            // SAFETY: each `PackageField` discriminant corresponds to a column
-            // whose element size matches `SIZES_BYTES[field as usize]`; we
-            // address the column as raw bytes for serialisation.
-            let bytes: &[u8] = unsafe {
-                let _n = list.len();
-                let sz =
-                    bun_collections::multi_array_list::Slice::<Package<SemverIntType>>::field_size(
-                        field as usize,
-                    );
-                {
-                    let _ = sz;
-                    &*sliced.column_bytes_mut(field as usize)
+            // No uninitialized padding: `Package`'s field types are all
+            // `#[repr(C)]` with explicit padding zeroed by their
+            // `Default`/`init` paths (`bytemuck::NoUninit`).
+            let bytes: &[u8] = match field {
+                PackageField::Name => bytemuck::cast_slice(sliced.items::<"name", String>()),
+                PackageField::NameHash => {
+                    bytemuck::cast_slice(sliced.items::<"name_hash", PackageNameHash>())
                 }
+                PackageField::Resolution => {
+                    // copy each resolution to make sure the bytes past the
+                    // live payload are zero (deterministic lockfile output).
+                    let resolutions: &[Resolution<SemverIntType>] =
+                        sliced.items::<"resolution", Resolution<SemverIntType>>();
+                    #[cfg(debug_assertions)]
+                    {
+                        bun_output::scoped_log!(
+                            Lockfile,
+                            "save(\"{}\") = {} bytes",
+                            bstr::BStr::new(field.name()),
+                            mem::size_of_val(resolutions),
+                        );
+                    }
+                    for val in resolutions {
+                        let copy = val.copy();
+                        stream.write_all(&[copy.tag.0])?;
+                        stream.write_all(&copy._padding)?;
+                        stream.write_all(bytemuck::bytes_of(&copy.value))?;
+                    }
+                    continue;
+                }
+                PackageField::Dependencies => {
+                    bytemuck::cast_slice(sliced.items::<"dependencies", DependencySlice>())
+                }
+                PackageField::Resolutions => {
+                    bytemuck::cast_slice(sliced.items::<"resolutions", PackageIDSlice>())
+                }
+                PackageField::Meta => bytemuck::cast_slice(sliced.items::<"meta", Meta>()),
+                PackageField::Bin => bytemuck::cast_slice(sliced.items::<"bin", Bin>()),
+                PackageField::Scripts => bytemuck::cast_slice(sliced.items::<"scripts", Scripts>()),
             };
             #[cfg(debug_assertions)]
             {
@@ -3211,31 +3201,7 @@ pub mod serializer {
                     bytes.len(),
                 );
             }
-            // No uninitialized padding: `Package`'s field types are all
-            // `#[repr(C)]` with explicit padding zeroed by their
-            // `Default`/`init` paths.
-            if matches!(field, PackageField::Resolution) {
-                // copy each resolution to make sure the union is zero initialized
-                let resolutions: &[Resolution<SemverIntType>] =
-                    sliced.items::<"resolution", Resolution<SemverIntType>>();
-                for val in resolutions {
-                    // `ResolutionType::copy` builds a fresh zero-initialised
-                    // `Resolution` and writes only the active union member.
-                    // A bare `*val` would serialise
-                    // garbage in the inactive union bytes (non-deterministic
-                    // lockfile output).
-                    let copy = val.copy();
-                    // SAFETY: Resolution is #[repr(C)] POD; reading raw bytes is sound.
-                    stream.write_all(unsafe {
-                        bun_core::ffi::slice(
-                            (&raw const copy).cast::<u8>(),
-                            mem::size_of_val(&copy),
-                        )
-                    })?;
-                }
-            } else {
-                stream.write_all(bytes)?;
-            }
+            stream.write_all(bytes)?;
         }
 
         let really_end_at = stream.get_pos()?;
@@ -3251,10 +3217,9 @@ pub mod serializer {
         pub needs_update: bool,
     }
 
-    // The v2-migration arm
-    // below hard-codes `u32 → u64` (`VersionedURL.migrate()` returns `<u64>`).
-    // The only caller (`bun.lockb.rs`) instantiates at `u64`, so bind concretely
-    // instead of carrying a phantom generic that can't typecheck the migrate arm.
+    // Bound to `u64`: the v2-migration arm below widens `u32` to `u64`
+    // (`VersionedURL::migrate()` returns `<u64>`), and the only caller
+    // (`bun.lockb.rs`) instantiates at `u64`.
     pub(crate) fn load(
         stream: &mut Stream,
         end: usize,
@@ -3304,8 +3269,9 @@ pub mod serializer {
             let mut list_for_migrating_from_v2 = <List<u32>>::default();
 
             list_for_migrating_from_v2.ensure_total_capacity(list_len as usize)?;
-            // SAFETY: capacity reserved above; `load_fields` writes every column.
-            unsafe { list_for_migrating_from_v2.set_len(list_len as usize) };
+            for _ in 0..list_len {
+                list_for_migrating_from_v2.append_assume_capacity(Package::default());
+            }
 
             load_fields::<u32>(
                 stream,
@@ -3365,8 +3331,9 @@ pub mod serializer {
                 list.append(new)?;
             }
         } else {
-            // SAFETY: capacity reserved above; `load_fields` writes every column.
-            unsafe { list.set_len(list_len as usize) };
+            for _ in 0..list_len {
+                list.append_assume_capacity(Package::default());
+            }
             load_fields::<SemverIntType>(stream, end_at as u64, &mut list, &mut needs_update)?;
         }
 
@@ -3379,107 +3346,98 @@ pub mod serializer {
         list: &mut List<SemverIntType>,
         needs_update: &mut bool,
     ) -> crate::Result<()> {
-        let _n = list.len();
+        let n = list.len();
         let mut sliced = list.slice();
 
         for field in PackageField::ALL {
             let sz = bun_collections::multi_array_list::Slice::<Package<SemverIntType>>::field_size(
                 field as usize,
             );
-            // SAFETY: `items_raw` returns a column pointer with `n` elements of
-            // `sz` bytes each; the byte view is used solely for memcpy from the
-            // serialised lockfile stream.
-            let bytes: &mut [u8] = unsafe {
-                {
-                    let _ = sz;
-                    sliced.column_bytes_mut(field as usize)
+            let byte_len = n * sz;
+            let end_pos = stream.pos + byte_len;
+            if end_pos as u64 > end_at {
+                if matches!(field, PackageField::Scripts) {
+                    sliced
+                        .items_mut::<"scripts", Scripts>()
+                        .fill(Scripts::default());
+                    continue;
                 }
-            };
-            let end_pos = stream.pos + bytes.len();
-            if end_pos as u64 <= end_at {
-                let src = &stream.buffer[stream.pos..stream.pos + bytes.len()];
-                if matches!(field, PackageField::Resolution) {
-                    // Validate the tag discriminant on the *raw stream bytes*
-                    // before they are copied into the typed column. `ResolutionTag`
-                    // is a `#[repr(u8)]` enum with non-contiguous discriminants
-                    // (0,1,2,4,8,16,32,64,72,80,100); copying an out-of-range byte
-                    // into `ResolutionType.tag` and then reading it would be
-                    // immediate UB, and a `matches!` over all 11 typed variants is
-                    // provably exhaustive and would be optimized away. Check the
-                    // raw u8 here. Layout: `ResolutionType` is `#[repr(C)]
-                    // { tag: Tag, _padding: [u8; 7], value: ... }`, so the
-                    // discriminant is the first byte of each element.
-                    let stride = mem::size_of::<ResolutionType<SemverIntType>>();
-                    debug_assert!(stride != 0 && src.len().is_multiple_of(stride));
-                    for raw in src.chunks_exact(stride) {
+                return Err(crate::Error::LockfileValidationFailedInvalidPackageListRange);
+            }
+            let src = &stream.buffer[stream.pos..end_pos];
+            match field {
+                // Plain-data columns: every bit pattern is valid, copy the bytes.
+                PackageField::Name => {
+                    bytemuck::cast_slice_mut::<String, u8>(sliced.items_mut::<"name", String>())
+                        .copy_from_slice(src)
+                }
+                PackageField::NameHash => bytemuck::cast_slice_mut::<PackageNameHash, u8>(
+                    sliced.items_mut::<"name_hash", PackageNameHash>(),
+                )
+                .copy_from_slice(src),
+                PackageField::Dependencies => bytemuck::cast_slice_mut::<DependencySlice, u8>(
+                    sliced.items_mut::<"dependencies", DependencySlice>(),
+                )
+                .copy_from_slice(src),
+                PackageField::Resolutions => bytemuck::cast_slice_mut::<PackageIDSlice, u8>(
+                    sliced.items_mut::<"resolutions", PackageIDSlice>(),
+                )
+                .copy_from_slice(src),
+                // Columns with a tag / enum / bool: validate each element.
+                PackageField::Resolution => {
+                    // `Tag` is an open `u8` newtype, but only the known
+                    // discriminants (0,1,2,4,8,16,32,64,72,80,100) are accepted.
+                    // Layout: `{ tag: u8, _padding: [u8; 7], value }`.
+                    let col = sliced.items_mut::<"resolution", Resolution<SemverIntType>>();
+                    for (dst, raw) in col.iter_mut().zip(src.chunks_exact(sz)) {
                         if !matches!(raw[0], 0 | 1 | 2 | 4 | 8 | 16 | 32 | 64 | 72 | 80 | 100) {
                             return Err(crate::Error::LockfileValidationFailedInvalidResolutionTag);
                         }
+                        *dst = Resolution {
+                            tag: crate::resolution::Tag(raw[0]),
+                            _padding: [0; 7],
+                            value: bytemuck::pod_read_unaligned(&raw[8..]),
+                        };
                     }
                 }
-                if matches!(field, PackageField::Meta) {
-                    // Same hardening as `Resolution` above: `Meta` embeds two
-                    // `#[repr(u8)]` enums (`Origin` = 0..=2 and
-                    // `HasInstallScript` = 0..=2). Copying an out-of-range byte
-                    // into either field and reading it back as the enum would
-                    // be immediate UB, so check the raw stream bytes first.
-                    let stride = mem::size_of::<Meta>();
-                    let origin_at = mem::offset_of!(Meta, origin);
-                    let install_script_at = mem::offset_of!(Meta, has_install_script);
-                    debug_assert!(stride != 0 && src.len().is_multiple_of(stride));
-                    for raw in src.chunks_exact(stride) {
-                        if !matches!(raw[origin_at], 0..=2)
-                            || !matches!(raw[install_script_at], 0..=2)
-                        {
-                            return Err(crate::Error::LockfileValidationFailedInvalidPackageMeta);
-                        }
+                PackageField::Meta => {
+                    // `Meta` embeds two `#[repr(u8)]` enums (`Origin` = 0..=2 and
+                    // `HasInstallScript` = 0..=2).
+                    let col = sliced.items_mut::<"meta", Meta>();
+                    for (dst, raw) in col.iter_mut().zip(src.chunks_exact(sz)) {
+                        *dst = bytemuck::checked::try_pod_read_unaligned(raw).map_err(|_| {
+                            crate::Error::LockfileValidationFailedInvalidPackageMeta
+                        })?;
                     }
-                }
-                if matches!(field, PackageField::Bin) {
-                    // `Bin.tag` is a `#[repr(u8)]` enum with discriminants
-                    // 0..=4; validate it the same way before the copy.
-                    let stride = mem::size_of::<Bin>();
-                    let tag_at = mem::offset_of!(Bin, tag);
-                    debug_assert!(stride != 0 && src.len().is_multiple_of(stride));
-                    for raw in src.chunks_exact(stride) {
-                        if !matches!(raw[tag_at], 0..=4) {
-                            return Err(crate::Error::LockfileValidationFailedInvalidBinTag);
-                        }
-                    }
-                }
-                if matches!(field, PackageField::Scripts) {
-                    // `Scripts.filled` is a `bool`; validate the raw byte the
-                    // same way before the copy.
-                    let stride = mem::size_of::<Scripts>();
-                    let filled_at = mem::offset_of!(Scripts, filled);
-                    debug_assert!(stride != 0 && src.len().is_multiple_of(stride));
-                    for raw in src.chunks_exact(stride) {
-                        if !matches!(raw[filled_at], 0 | 1) {
-                            return Err(
-                                crate::Error::LockfileValidationFailedInvalidPackageScripts,
-                            );
-                        }
-                    }
-                }
-                bytes.copy_from_slice(src);
-                stream.pos = end_pos;
-                if matches!(field, PackageField::Meta) {
                     // need to check if any values were created from an older version of bun
                     // (currently just `has_install_script`). If any are found, the values need
                     // to be updated before saving the lockfile.
-                    let metas: &mut [Meta] = sliced.items_mut::<"meta", Meta>();
-                    for meta in metas {
+                    for meta in col.iter() {
                         if meta.needs_update() {
                             *needs_update = true;
                             break;
                         }
                     }
                 }
-            } else if matches!(field, PackageField::Scripts) {
-                bytes.fill(0);
-            } else {
-                return Err(crate::Error::LockfileValidationFailedInvalidPackageListRange);
+                PackageField::Bin => {
+                    // `Bin.tag` is a `#[repr(u8)]` enum with discriminants 0..=4.
+                    let col = sliced.items_mut::<"bin", Bin>();
+                    for (dst, raw) in col.iter_mut().zip(src.chunks_exact(sz)) {
+                        *dst = bytemuck::checked::try_pod_read_unaligned(raw)
+                            .map_err(|_| crate::Error::LockfileValidationFailedInvalidBinTag)?;
+                    }
+                }
+                PackageField::Scripts => {
+                    // `Scripts.filled` is a `bool`.
+                    let col = sliced.items_mut::<"scripts", Scripts>();
+                    for (dst, raw) in col.iter_mut().zip(src.chunks_exact(sz)) {
+                        *dst = bytemuck::checked::try_pod_read_unaligned(raw).map_err(|_| {
+                            crate::Error::LockfileValidationFailedInvalidPackageScripts
+                        })?;
+                    }
+                }
             }
+            stream.pos = end_pos;
         }
         Ok(())
     }

--- a/src/install/lockfile/Package/Meta.rs
+++ b/src/install/lockfile/Package/Meta.rs
@@ -11,7 +11,7 @@ use crate::lockfile_real::StringBuilder as LockfileStringBuilder;
 
 // TODO: remove origin. it doesnt do anything and can be inferred from the resolution
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, bytemuck::NoUninit, bytemuck::CheckedBitPattern)]
 pub struct Meta {
     pub(crate) origin: Origin,
     pub(crate) _padding_origin: u8,
@@ -37,7 +37,9 @@ pub struct Meta {
 }
 
 #[repr(u8)]
-#[derive(Copy, Clone, PartialEq, Eq, Default)]
+#[derive(
+    Copy, Clone, PartialEq, Eq, Default, Debug, bytemuck::NoUninit, bytemuck::CheckedBitPattern,
+)]
 pub enum HasInstallScript {
     Old = 0,
     #[default]

--- a/src/install/lockfile/Package/Scripts.rs
+++ b/src/install/lockfile/Package/Scripts.rs
@@ -20,7 +20,7 @@ bun_output::declare_scope!(Lockfile, hidden);
 const SCRIPT_NAMES_LEN: usize = LockfileScripts::NAMES.len();
 
 #[repr(C)]
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, bytemuck::NoUninit, bytemuck::CheckedBitPattern)]
 pub struct Scripts {
     pub(crate) preinstall: SemverString,
     pub(crate) install: SemverString,
@@ -289,6 +289,7 @@ impl Scripts {
 
     pub fn get_list(
         &mut self,
+        options: &crate::package_manager_real::Options,
         log: &mut bun_ast::Log,
         lockfile: &Lockfile,
         folder_path: &mut bun_paths::AutoAbsPath,
@@ -297,12 +298,10 @@ impl Scripts {
     ) -> Result<Option<List>, crate::Error> {
         if self.has_any() {
             let add_node_gyp_rebuild_script =
-                if lockfile.has_trusted_dependency(folder_name, folder_name, resolution)
+                if lockfile.has_trusted_dependency(options, folder_name, folder_name, resolution)
                     && self.install.is_empty()
                     && self.preinstall.is_empty()
                 {
-                    // `defer save.restore()` — `save()` returns an RAII guard that
-                    // restores the path length on Drop and derefs to the path.
                     let mut save = folder_path.save();
                     let _ = save.append(b"binding.gyp");
 
@@ -341,8 +340,6 @@ impl Scripts {
         let json_buf;
         let parsed;
         let json: Expr = {
-            // `defer save.restore()` — `save()` returns an RAII guard that
-            // restores the path length on Drop and derefs to the path.
             let mut save = folder_path.save();
             let _ = save.append(b"package.json");
 
@@ -370,14 +367,10 @@ impl Scripts {
         resolution_tag: ResolutionTag,
     ) -> Result<Option<List>, crate::Error> {
         let mut tmp = RealLockfile::init_empty_value();
-        // `defer tmp.deinit()` — `tmp` stays empty (only `string_builder` borrows it), so field
-        // auto-drop suffices; Lockfile has no `impl Drop`.
         let mut builder = tmp.string_builder();
         self.fill_from_package_json(&mut builder, log, folder_path)?;
 
         let add_node_gyp_rebuild_script = if self.install.is_empty() && self.preinstall.is_empty() {
-            // `defer save.restore()` — `save()` returns an RAII guard that
-            // restores the path length on Drop and derefs to the path.
             let mut save = folder_path.save();
             let _ = save.append(b"binding.gyp");
 
@@ -406,7 +399,7 @@ pub enum PrintFormat {
 }
 
 // `Clone` — `List` owns `cwd`/`package_name`/`items`, but
-// `runTasks.rs` (`.run_scripts` arm) and `lifecycle_script_runner` need a
+// `run_tasks.rs` (`.run_scripts` arm) and `lifecycle_script_runner` need a
 // by-value copy while the original allocation in `Store.entries.scripts`
 // must stay live for the post-install pass, so a deep clone is required.
 #[derive(Clone)]
@@ -462,8 +455,6 @@ impl List {
             }
         }
     }
-
-    // No manual deinit: `Box<[u8]>` fields drop automatically.
 
     pub(crate) fn append_to_lockfile(&self, lockfile: &mut Lockfile) {
         for (i, maybe_script) in self.items.iter().enumerate() {

--- a/src/install/lockfile/Package/WorkspaceMap.rs
+++ b/src/install/lockfile/Package/WorkspaceMap.rs
@@ -83,11 +83,9 @@ impl WorkspaceMap {
     }
 
     fn insert(&mut self, key: &[u8], value: Entry) -> Result<(), bun_alloc::AllocError> {
-        // No `bun.sys.exists(key)` debug check here: `key` is
-        // relative to the workspace root while `exists` resolves against process
-        // cwd — false positive whenever the two differ (e.g. `bun unlink` from a
-        // workspace package). Existence is already verified by the caller via
-        // `process_workspace_name`, so the check is dropped.
+        // No existence check on `key`: it is relative to the workspace root,
+        // not the process cwd (e.g. `bun unlink` from a workspace package), and
+        // the caller already verified it via `process_workspace_name`.
         let entry = self.map.get_or_put(key)?;
         if !entry.found_existing {
             *entry.key_ptr = Box::<[u8]>::from(key);
@@ -103,9 +101,6 @@ impl WorkspaceMap {
         Ok(())
     }
 }
-
-// Drop: all fields are owned (Box<[u8]> keys, Entry { Box<[u8]>, Option<Box<[u8]>> })
-// — Rust drops them automatically; no explicit `deinit` body needed.
 
 #[derive(Clone, Copy)]
 pub(crate) enum NamesArray<'a> {
@@ -153,6 +148,9 @@ pub(crate) enum MissingWorkspace<'a> {
     Error,
     Skip,
     SkipIfInLockfile(&'a Lockfile),
+    /// [`SkipIfInLockfile`](Self::SkipIfInLockfile) with the lockfile's
+    /// workspace paths already copied out (the lockfile is being written).
+    SkipIfListed(&'a [&'a [u8]]),
 }
 
 fn process_workspace_name(
@@ -216,7 +214,7 @@ fn process_workspace_name(
     };
     bun_output::scoped_log!(
         Lockfile,
-        "processWorkspaceName({}) = {}",
+        "process_workspace_name({}) = {}",
         BStr::new(abs_package_json_path),
         BStr::new(&entry.name)
     );
@@ -336,6 +334,15 @@ impl WorkspaceMap {
                                             workspace_dir_of(abs),
                                         ),
                                     )
+                                }),
+                            MissingWorkspace::SkipIfListed(paths) => abs_package_json_path
+                                .is_some_and(|abs| {
+                                    let rel = relative_workspace_path(
+                                        &mut rel_path_buf.0,
+                                        root_dir,
+                                        workspace_dir_of(abs),
+                                    );
+                                    paths.contains(&rel)
                                 }),
                         };
                         if tolerated {

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -1,5 +1,4 @@
 use core::marker::ConstParamTy;
-use core::mem::MaybeUninit;
 
 use bun_alloc::AllocError;
 use bun_collections::{ArrayHashMap, DynamicBitSet, MultiArrayList, index_sort};
@@ -25,7 +24,7 @@ use crate::{
 // id|dep_id|parent|off|len). Under `repr(Rust)` rustc may reorder fields and
 // the binary lockfile round-trip silently corrupts `dependencies`.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct Tree {
     pub(crate) id: Id,
 
@@ -70,12 +69,12 @@ impl Tree {
 // max number of node_modules folders
 pub(crate) const MAX_DEPTH: usize = (MAX_PATH_BYTES / b"node_modules".len()) + 1;
 
-/// Parent-id stack for [`relative_path_and_depth`] (32 KB on Windows, so not zeroed).
-pub(crate) type DepthBuf = [MaybeUninit<Id>; MAX_DEPTH];
+pub(crate) type DepthBuf = [Id; MAX_DEPTH];
 
+/// Scratch for [`relative_path_and_depth`]; one per iterator, not per tree.
 #[inline]
 pub(crate) fn depth_buf_uninit() -> DepthBuf {
-    [const { MaybeUninit::uninit() }; MAX_DEPTH]
+    [0; MAX_DEPTH]
 }
 
 impl Tree {
@@ -248,7 +247,6 @@ impl<'a, const PATH_STYLE: IteratorPathStyle> Iterator<'a, PATH_STYLE> {
             return None;
         }
 
-        // reshaped for borrowck — cannot mutably borrow completed_trees in loop while moved.
         let mut completed_trees = completed_trees;
 
         while trees[self.tree_id as usize].dependencies.len == 0 {
@@ -279,6 +277,85 @@ impl<'a, const PATH_STYLE: IteratorPathStyle> Iterator<'a, PATH_STYLE> {
         self.tree_id += 1;
 
         Some(IteratorNext {
+            relative_path,
+            dependencies: tree_dependencies,
+            tree_id: current_tree_id,
+            depth,
+        })
+    }
+}
+
+/// [`Iterator`] state without the borrowed buffers: the lockfile is passed to
+/// each [`next`](Self::next) call, so it may change (grow) between calls.
+pub struct Cursor<const PATH_STYLE: IteratorPathStyle> {
+    pub(crate) tree_id: Id,
+    pub(crate) path_buf: PathBuffer,
+    pub(crate) depth_stack: DepthBuf,
+}
+
+/// What [`Cursor::next`] found; `relative_path` borrows the cursor,
+/// `dependencies` the lockfile.
+pub struct CursorNext<'c, 'l> {
+    pub relative_path: &'c ZStr,
+    pub dependencies: &'l [DependencyID],
+    pub tree_id: Id,
+    pub depth: usize,
+}
+
+impl<const PATH_STYLE: IteratorPathStyle> Cursor<PATH_STYLE> {
+    pub fn new() -> Self {
+        let mut cursor = Self {
+            tree_id: 0,
+            path_buf: PathBuffer::ZEROED,
+            depth_stack: depth_buf_uninit(),
+        };
+        if PATH_STYLE == IteratorPathStyle::NodeModules {
+            cursor.path_buf[0..b"node_modules".len()].copy_from_slice(b"node_modules");
+        }
+        cursor
+    }
+
+    pub fn next<'c, 'l>(
+        &'c mut self,
+        lockfile: &'l Lockfile,
+        mut completed_trees: Option<&mut DynamicBitSet>,
+    ) -> Option<CursorNext<'c, 'l>> {
+        let trees = lockfile.buffers.trees.as_slice();
+
+        if (self.tree_id as usize) >= trees.len() {
+            return None;
+        }
+
+        while trees[self.tree_id as usize].dependencies.len == 0 {
+            if PATH_STYLE == IteratorPathStyle::NodeModules {
+                if let Some(ct) = completed_trees.as_deref_mut() {
+                    ct.set(self.tree_id as usize);
+                }
+            }
+            self.tree_id += 1;
+            if (self.tree_id as usize) >= trees.len() {
+                return None;
+            }
+        }
+
+        let current_tree_id = self.tree_id;
+        let tree = trees[current_tree_id as usize];
+        let tree_dependencies = tree
+            .dependencies
+            .get(lockfile.buffers.hoisted_dependencies.as_slice());
+
+        let (relative_path, depth) = relative_path_and_depth::<PATH_STYLE>(
+            trees,
+            lockfile.buffers.dependencies.as_slice(),
+            lockfile.buffers.string_bytes.as_slice(),
+            current_tree_id,
+            &mut self.path_buf,
+            &mut self.depth_stack,
+        );
+
+        self.tree_id += 1;
+
+        Some(CursorNext {
             relative_path,
             dependencies: tree_dependencies,
             tree_id: current_tree_id,
@@ -330,7 +407,7 @@ pub(crate) fn relative_path_and_depth<'b, const PATH_STYLE: IteratorPathStyle>(
                 path_buf[path_written] = 0;
                 return (ZStr::from_buf(path_buf, path_written), 0);
             }
-            depth_buf[depth_buf_len].write(parent_id);
+            depth_buf[depth_buf_len] = parent_id;
             parent_id = trees[parent_id as usize].parent;
             depth_buf_len += 1;
         }
@@ -355,9 +432,7 @@ pub(crate) fn relative_path_and_depth<'b, const PATH_STYLE: IteratorPathStyle>(
                 path_written += 1;
             }
 
-            // SAFETY: the parent walk above wrote `depth_buf[1..=depth]` and
-            // `1 <= depth_buf_len <= depth`.
-            let id = unsafe { depth_buf[depth_buf_len].assume_init() };
+            let id = depth_buf[depth_buf_len];
             let name = trees[id as usize].folder_name(dependencies, buf);
             if !folder_name_is_safe(name) {
                 Output::err_generic(
@@ -403,7 +478,7 @@ pub enum BuilderMethod {
     Resolvable,
 
     /// This will filter out disabled dependencies, resulting in more aggresive
-    /// hoisting compared to `.resolvable`. We skip dependencies based on 'os', 'cpu',
+    /// hoisting compared to `Resolvable`. We skip dependencies based on 'os', 'cpu',
     /// 'libc' (TODO), and omitted dependency types (`--omit=dev/peer/optional`).
     /// Dependencies of a disabled package are not included in the output.
     Filter,
@@ -413,9 +488,6 @@ pub enum BuilderMethod {
 // types, so `manager`/`workspace_filters`/`install_root_dependencies`/`packages_to_install`
 // are `Option<_>`/empty defaults and only meaningful when `METHOD == .Filter`.
 pub struct Builder<'a, const METHOD: BuilderMethod> {
-    // No allocator field: the sole construction site is `Lockfile.hoist()`,
-    // whose allocations are persistent, not arena-scoped. Global mimalloc is
-    // correct here; no `&'bump Bump` threading needed.
     pub(crate) list: MultiArrayList<BuilderEntry>,
     pub(crate) resolutions: &'a mut [PackageID],
     pub(crate) dependencies: &'a [Dependency],
@@ -436,7 +508,7 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
         ArrayHashMap<PackageNameHash, ArrayHashMap<DependencyID, ()>>,
     /// An optional peer got bound after its dependent was placed; see `Lockfile::resolve`.
     pub(crate) late_bound_optional_peer: bool,
-    pub(crate) manager: Option<&'a PackageManager>,
+    pub(crate) manager: Option<HoistOptions<'a>>,
     pub(crate) sort_buf: Vec<DependencyID>,
     pub(crate) workspace_filters: &'a [WorkspaceFilter],
     pub(crate) install_root_dependencies: bool,
@@ -447,13 +519,53 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
 
 pub struct BuilderEntry {
     pub tree: Tree,
-    pub dependencies: DependencyIDList,
+    pub dependencies: PlacedList,
+}
+
+/// A dependency placed in a tree, with its name hash alongside so the hoist
+/// scan (`hoist_dependency`) compares names without touching `Dependency`.
+#[derive(Clone, Copy)]
+pub struct Placed {
+    pub id: DependencyID,
+    pub name_hash: PackageNameHash,
+}
+pub type PlacedList = Vec<Placed>;
+
+/// What the `Filter` hoist reads from the package manager.
+#[derive(Clone, Copy)]
+pub struct HoistOptions<'a> {
+    pub cpu: crate::npm::Architecture,
+    pub os: crate::npm::OperatingSystem,
+    pub log_level: crate::LogLevel,
+    pub local_package_features: crate::Features,
+    pub remote_package_features: crate::Features,
+    pub pruned_workspaces: &'a [PackageNameHash],
+}
+
+impl<'a> HoistOptions<'a> {
+    pub fn new(
+        options: &crate::package_manager_real::Options,
+        summary: &'a crate::lockfile::package::DiffSummary,
+    ) -> HoistOptions<'a> {
+        HoistOptions {
+            cpu: options.cpu,
+            os: options.os,
+            log_level: options.log_level,
+            local_package_features: options.local_package_features,
+            remote_package_features: options.remote_package_features,
+            pruned_workspaces: &summary.pruned_workspaces,
+        }
+    }
+
+    pub fn from_manager(manager: &'a PackageManager) -> HoistOptions<'a> {
+        Self::new(&manager.options, &manager.summary)
+    }
 }
 
 bun_collections::multi_array_columns! {
     pub(crate) trait BuilderEntryColumns for BuilderEntry {
         tree: Tree,
-        dependencies: DependencyIDList,
+        dependencies: PlacedList,
     }
 }
 
@@ -493,7 +605,7 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 
         let mut slice = self.list.to_owned_slice();
         let mut trees: Vec<Tree> = slice.items_tree().to_vec();
-        let dependencies: &mut [DependencyIDList] = slice.items_dependencies_mut();
+        let dependencies: &mut [PlacedList] = slice.items_dependencies_mut();
 
         for tree in &trees {
             total += tree.dependencies.len;
@@ -509,7 +621,7 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
             // `tree.dependencies.len: u32`), so `len()` is provably < 2^32.
             // Avoid the `try_from` panic-format path on this per-tree hot loop.
             let off: u32 = dep_ids.len() as u32;
-            for &dep_id in child.iter() {
+            for &Placed { id: dep_id, .. } in child.iter() {
                 let pkg_id = self.resolutions[dep_id as usize];
                 if pkg_id == invalid_package_id {
                     // optional peers that never resolved
@@ -524,7 +636,6 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
             tree.dependencies.len = len;
         }
 
-        // queue / sort_buf / pending_optional_peers freed by Drop; explicit deinit removed.
         // The sole caller (`Lockfile::hoist`) drops the Builder immediately after clean().
 
         slice.deinit_owned();
@@ -545,7 +656,7 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     parent_pkg_id: PackageID,
     workspace_filters: &[WorkspaceFilter],
     install_root_dependencies: bool,
-    manager: &PackageManager,
+    manager: HoistOptions<'_>,
     lockfile: &Lockfile,
     resolutions: &[PackageID],
 ) -> bool {
@@ -566,21 +677,21 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
     let parent_res = &pkg_resolutions[parent_pkg_id as usize];
 
-    if pkg_metas[pkg_id as usize].is_disabled(manager.options.cpu, manager.options.os) {
-        if manager.options.log_level.is_verbose() {
+    if pkg_metas[pkg_id as usize].is_disabled(manager.cpu, manager.os) {
+        if manager.log_level.is_verbose() {
             let meta = &pkg_metas[pkg_id as usize];
             let name = lockfile.str(&pkg_names[pkg_id as usize]);
-            if !meta.os.is_match(manager.options.os) && !meta.arch.is_match(manager.options.cpu) {
+            if !meta.os.is_match(manager.os) && !meta.arch.is_match(manager.cpu) {
                 bun_core::pretty_errorln!(
                     "<d>Skip installing<r> <b>{}<r> <d>- cpu & os mismatch<r>",
                     bstr::BStr::new(name)
                 );
-            } else if !meta.os.is_match(manager.options.os) {
+            } else if !meta.os.is_match(manager.os) {
                 bun_core::pretty_errorln!(
                     "<d>Skip installing<r> <b>{}<r> <d>- os mismatch<r>",
                     bstr::BStr::new(name)
                 );
-            } else if !meta.arch.is_match(manager.options.cpu) {
+            } else if !meta.arch.is_match(manager.cpu) {
                 bun_core::pretty_errorln!(
                     "<d>Skip installing<r> <b>{}<r> <d>- cpu mismatch<r>",
                     bstr::BStr::new(name)
@@ -597,8 +708,8 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     let dep_features = match parent_res.tag {
         crate::resolution::Tag::Root
         | crate::resolution::Tag::Workspace
-        | crate::resolution::Tag::Folder => manager.options.local_package_features,
-        _ => manager.options.remote_package_features,
+        | crate::resolution::Tag::Folder => manager.local_package_features,
+        _ => manager.remote_package_features,
     };
 
     if !dep.behavior.is_enabled(dep_features) {
@@ -613,7 +724,7 @@ pub(crate) fn is_filtered_dependency_or_workspace(
         return !install_root_dependencies;
     }
 
-    if manager.summary.pruned_workspaces.contains(&dep.name_hash) {
+    if manager.pruned_workspaces.contains(&dep.name_hash) {
         return true;
     }
 
@@ -648,10 +759,9 @@ impl Tree {
                 dependency_id,
                 dependencies: DependencyIDSlice::default(),
             },
-            dependencies: DependencyIDList::default(),
+            dependencies: PlacedList::default(),
         })?;
 
-        // reshaped for borrowck.
         let next_id = (builder.list.len() - 1) as Id;
         // A self-contained workspace is a hoisting barrier: nothing below it may be
         // placed above its own node_modules.
@@ -673,8 +783,7 @@ impl Tree {
         let lockfile: &Lockfile = lockfile_ref.get();
         let pkgs = lockfile.packages.slice();
         let pkg_resolutions = pkgs.items_resolution();
-        // reshaped for borrowck — copy the `&'a [Dependency]` out of
-        // `builder` so `&dependencies[i]` does not keep `builder` borrowed.
+        // Copied out of `builder` so `&dependencies[i]` does not keep `builder` borrowed.
         let dependencies: &[Dependency] = builder.dependencies;
 
         builder.sort_buf.clear();
@@ -699,8 +808,7 @@ impl Tree {
             });
         }
 
-        // reshaped for borrowck — iterate over a snapshot of sort_buf indices since
-        // builder is mutably borrowed inside the loop.
+        // By index: `builder` (which owns `sort_buf`) is mutably borrowed inside the loop.
         let sort_buf_len = builder.sort_buf.len();
         'dep: for sort_idx in 0..sort_buf_len {
             let dep_id = builder.sort_buf[sort_idx];
@@ -746,7 +854,7 @@ impl Tree {
             let dependency = &dependencies[dep_id as usize];
 
             // An empty alias has no `node_modules/<name>` folder to escape, so
-            // don't treat it as unsafe — match the lockfile parser and isolated
+            // don't treat it as untrusted — match the lockfile parser and isolated
             // installer (`bun.lock.rs`, `isolated_install.rs`) which guard
             // `!name.is_empty()` here rather than failing the whole install.
             let dependency_name = dependency
@@ -890,9 +998,9 @@ impl Tree {
                     {
                         let mut list_slice = builder.list.slice();
                         let dependency_lists = list_slice.items_dependencies_mut();
-                        for placed_dep_id in dependency_lists[replace.id as usize].iter_mut() {
-                            if *placed_dep_id == replace.dep_id {
-                                *placed_dep_id = dep_id;
+                        for placed in dependency_lists[replace.id as usize].iter_mut() {
+                            if placed.id == replace.dep_id {
+                                placed.id = dep_id;
                             }
                         }
                     }
@@ -927,7 +1035,10 @@ impl Tree {
                     {
                         // Go through ListExt
                         // accessors sequentially so the &mut borrows do not overlap.
-                        builder.list.items_dependencies_mut()[dest.id as usize].push(dep_id);
+                        builder.list.items_dependencies_mut()[dest.id as usize].push(Placed {
+                            id: dep_id,
+                            name_hash: dependency.name_hash,
+                        });
                         builder.list.items_tree_mut()[dest.id as usize]
                             .dependencies
                             .len += 1;
@@ -947,7 +1058,6 @@ impl Tree {
             }
         }
 
-        // reshaped for borrowck — re-read `next` via index.
         let next: Tree = builder.list.items_tree()[next_id as usize];
         if next.dependencies.len == 0 {
             debug_assert!(builder.list.len() == (next.id as usize) + 1);
@@ -982,18 +1092,18 @@ impl Tree {
         // Tree is Copy — snapshot the fields we need so we don't hold a borrow of builder.list.
         let this: Tree = builder.list.items_tree()[self_id as usize];
         // The loop body only reads through `builder`; the recursive call comes after the loop.
-        let this_deps: &[DependencyID] = this
-            .dependencies
-            .get(builder.list.items_dependencies()[self_id as usize].as_slice());
-        // Keep the comparand in a register; `deps.get_unchecked` may alias `dependency`.
+        let this_deps: &[Placed] = &builder.list.items_dependencies()[self_id as usize];
+        debug_assert_eq!(this_deps.len(), this.dependencies.len as usize);
         let target_name_hash = dependency.name_hash;
-        for &dep_id in this_deps {
-            // SAFETY: `dep_id` was produced by the same lockfile that produced `deps`,
-            // so it is always in bounds.
-            let dep = unsafe { deps.get_unchecked(dep_id as usize) };
-            if dep.name_hash != target_name_hash {
+        for &Placed {
+            id: dep_id,
+            name_hash,
+        } in this_deps
+        {
+            if name_hash != target_name_hash {
                 continue;
             }
+            let dep = &deps[dep_id as usize];
 
             let res_id = builder.resolutions[dep_id as usize];
 

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -38,8 +38,8 @@ use super::override_map::ScopedOverride;
 use super::override_selector::{PackageSelector, parse_package_segment};
 use super::package::{Meta, PackageColumns as _, value_loc_of};
 use super::{
-    CatalogMap, DependencySlice, LoadResult, Lockfile as BinaryLockfile, OverrideMap, Package,
-    PackageIndexMap, PatchedDep, TrustedDependenciesSet, VersionHashMap, tree,
+    CatalogMap, DependencySlice, Lockfile as BinaryLockfile, OverrideMap, Package, PackageIndexMap,
+    PatchedDep, TrustedDependenciesSet, VersionHashMap, tree,
 };
 
 use bun_io::AsFmt;
@@ -173,7 +173,7 @@ impl<'a> TreeDepsSortCtx<'a> {
 }
 
 /// The slot order every existing bun.lock has its `trustedDependencies` and
-/// `patchedDependencies` in (`std.AutoHashMap(u64)`'s hash).
+/// `patchedDependencies` in (the hash Zig's `std.AutoHashMap(u64)` used).
 struct WrittenOrderContext;
 
 impl HashContext<u64> for WrittenOrderContext {
@@ -217,7 +217,7 @@ impl Stringifier {
     /// A walk-clean lockfile with scoped rules is stamped v3 whatever version was
     /// loaded. Without scoped rules a lockfile keeps its loaded v1/v2, and a fresh
     /// or v3-loaded one is walked down to v2, or to v1 on a v2-invariant violation
-    /// (off-registry npm tarball without a supported integrity, unsafe git
+    /// (off-registry npm tarball without a supported integrity, unvalidated git
     /// `.bun-tag`); that decision must not depend on the writer's `~/.npmrc`.
     ///
     /// Walks the package tree the same way the writer does — only packages that
@@ -281,10 +281,10 @@ impl Stringifier {
                         }
                     }
                     ResolutionTag::Git => {
-                        // An unsafe git `.bun-tag` is only rejected at v2, so
+                        // An unvalidated git `.bun-tag` is only rejected at v2, so
                         // staying at v1 keeps it loading. (A `github` tag is
                         // rejected at every version, so no lockfile version can
-                        // round-trip an unsafe one — nothing to gate here.)
+                        // round-trip an unvalidated one — nothing to gate here.)
                         if !crate::repository::is_safe_resolved_tag(
                             res.repository().resolved.slice(buf),
                         ) {
@@ -300,7 +300,7 @@ impl Stringifier {
 
     pub(crate) fn save_from_binary(
         lockfile: &mut BinaryLockfile,
-        load_result: &LoadResult,
+        load_result: &dyn crate::lockfile::LoadedFrom,
         options: &PackageManagerOptions,
         writer: &mut Writer,
     ) -> Result<(), WriteError> {
@@ -418,7 +418,6 @@ impl Stringifier {
                     workspace_sort_buf.push(pkg_id);
                 }
 
-                // local Sorter struct → closure
                 index_sort::sort_indices(&mut workspace_sort_buf, &mut |l, r| {
                     let l_res = &pkg_resolutions[l as usize];
                     let r_res = &pkg_resolutions[r as usize];
@@ -433,8 +432,6 @@ impl Stringifier {
                         writer,
                         indent,
                         workspace_pkg_id,
-                        // SAFETY: `workspace_sort_buf` only contains pkgs whose
-                        // resolution `tag == Workspace`.
                         *res.workspace(),
                         pkg_names,
                         pkg_name_hashes,
@@ -934,9 +931,6 @@ impl Stringifier {
                             )?;
 
                             // only write the registry if it's not the default. empty string means default registry
-                            // SAFETY: `tag == Npm` in this match arm.
-                            // `String::slice` ties the return to `&self` as well as `buf`, so
-                            // bind the union read to a local instead of slicing a temporary.
                             let url = res.npm().url;
                             let url_slice = url.slice(buf);
                             write!(
@@ -1165,14 +1159,8 @@ impl Stringifier {
             writer.write_all(b" \"bundled\": true")?;
         }
 
-        // TODO(dylan-conway)
-        // if (meta.libc != .all) {
-        //     try writer.writeAll(
-        //         \\"libc": [
-        //     );
-        //     try Negatable(Npm.Libc).toJson(meta.libc, writer);
-        //     try writer.writeAll("], ");
-        // }
+        // TODO(dylan-conway): also emit `"libc": [...]` (a `Negatable<Npm::Libc>`)
+        // when `meta.libc != Libc::ALL`, like `os`/`cpu` below.
 
         if meta.os != Npm::OperatingSystem::ALL {
             if any {
@@ -1682,8 +1670,6 @@ impl<T> PkgMap<T> {
         }
     }
 
-    // deinit → Drop (StringHashMap drops itself)
-
     fn get_or_put(
         &mut self,
         name: &[u8],
@@ -1814,8 +1800,6 @@ impl<T> PkgMap<T> {
         Err(ResolveError::InvalidPackageKey)
     }
 }
-
-// const PkgMap = struct {};
 
 fn object_rows(expr: &Expr) -> &[JSON::E::PropertyJSON] {
     match &expr.data {
@@ -2413,7 +2397,7 @@ pub(crate) fn parse_into_binary_lockfile(
     let mut workspace_pkgs_len: u32 = 0;
 
     if lockfile_version != Version::V0 {
-        // these are the `workspaceOnly` packages
+        // these are the workspace-only packages
         // snapshot the workspace-path handles up front so the loop
         // body can take `&mut *lockfile` (`parse_append_dependencies`,
         // `append_package_dedupe`) without conflicting with the
@@ -2842,10 +2826,8 @@ pub(crate) fn parse_into_binary_lockfile(
                                 pkg.meta.arch =
                                     Npm::negatable_from_json_value::<Npm::Architecture>(arch);
                             }
-                            // TODO(dylan-conway)
-                            // if (os_cpu_libc_obj.get("libc")) |libc| {
-                            //     pkg.meta.libc = Negatable(Npm.Libc).fromJson(allocator, libc);
-                            // }
+                            // TODO(dylan-conway): also read "libc" into `meta.libc` via
+                            // `negatable_from_json_value::<Npm::Libc>`, like os/cpu above.
                         }
                     }
                     ResolutionTag::Root => {
@@ -2977,7 +2959,7 @@ pub(crate) fn parse_into_binary_lockfile(
                         return Err(ParseError::InvalidPackageInfo);
                     };
 
-                    // Reject an unsafe `.bun-tag`. For `git`, `Repository::checkout`
+                    // Reject an unvalidated `.bun-tag`. For `git`, `Repository::checkout`
                     // re-validates with the same guard before building any cache
                     // path or invoking `git`, so this parse-time check is gated to
                     // v2+ — older git lockfiles keep loading without reopening the
@@ -3051,7 +3033,7 @@ pub(crate) fn parse_into_binary_lockfile(
 
         // The two `[0]` writes are done first via
         // sequential `&mut` accessors so the loops can take all column views
-        // immutably without overlapping exclusive borrows or `unsafe`.
+        // immutably without overlapping exclusive borrows.
         lockfile.packages.items_resolution_mut()[0] =
             Resolution::init(crate::resolution::TaggedValue::Root);
         lockfile.packages.items_meta_mut()[0].origin = Origin::Local;
@@ -3626,7 +3608,7 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
                     },
                 };
 
-                // after parseAppendDependencies has been called for each package the
+                // after parse_append_dependencies has been called for each package the
                 // size of lockfile.buffers.resolutions is set to the length of dependencies
                 // and values set to invalid_package_id before mapping.
                 lockfile.buffers.dependencies.push(dep);
@@ -3639,7 +3621,7 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
 
     {
         let bytes = lockfile.buffers.string_bytes.as_slice();
-        // `Dependency::cmp` is the total-order form of `isLessThan` (behavior group, then name ASC).
+        // `Dependency::cmp` is the total-order form of `is_less_than` (behavior group, then name ASC).
         index_sort::sort_slice_by(&mut lockfile.buffers.dependencies[off..], |a, b| {
             Dependency::cmp(bytes, a, b)
         });

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -25,9 +25,9 @@ use bun_core::strings;
 use bun_install::{PackageID, PackageManager, PackageNameAndVersionHash, PackageNameHash};
 use bun_semver::{self as semver, String as SemverString};
 
-// Serialized padding bytes must be deterministic; the per-field
-// save path zeroes padding explicitly (see the note in `save` and the
-// `assert_no_uninitialized_padding` invariant in `Package::Serializer`).
+// Serialized padding bytes must be deterministic; the per-field save path
+// writes `bytemuck::NoUninit` columns (see `Package::Serializer`), so there
+// are no uninitialized bytes to leak.
 
 const HEADER_BYTES: &[u8] = b"#!/usr/bin/env bun\nbun-lockfile-format-v0\n";
 
@@ -81,7 +81,7 @@ impl<'a> bun_io::Write for StreamType<'a> {
 }
 
 #[inline]
-fn write_array<T>(
+fn write_array<T: bytemuck::NoUninit>(
     stream: &mut StreamType<'_>,
     array: &[T],
     prefix: &'static str,
@@ -123,7 +123,7 @@ const _: () = {
 /// this invariant-free form instead and validate the flag before constructing
 /// the real `PatchedDep`.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct PatchedDepExternal {
     path: SemverString,
     _padding: [u8; 7],
@@ -174,8 +174,7 @@ pub(crate) fn save(
     end_pos: &mut usize,
 ) -> Result<(), Error> {
     // No defensive clone of `packages` is needed for byte-exact serialization:
-    // the per-field writers below already zero-pad via the
-    // `assert_no_uninitialized_padding` invariant.
+    // the per-field writers below only accept `bytemuck::NoUninit` columns.
 
     // `writer` and `stream` roles are collapsed into a single `StreamType`.
     let mut stream = StreamType { bytes };
@@ -422,8 +421,6 @@ pub(crate) fn load(
     }
 
     lockfile.format = FormatVersion::current();
-    // `lockfile.allocator = allocator;` dropped — global mimalloc.
-
     let _ = stream.read_all(&mut lockfile.meta_hash)?;
 
     let total_buffer_size = stream.read_int_le::<u64>()?;
@@ -437,7 +434,7 @@ pub(crate) fn load(
     lockfile.packages = packages_load_result.list;
 
     // `meta.id` is memcpy'd verbatim from disk with no range validation; a
-    // corrupt `bun.lockb` can make it garbage and trip `panic_bounds_check`
+    // corrupt `bun.lockb` can make it garbage and trip a bounds-check panic
     // in `Package::clone` / `preinstall_state` indexing later. Surface it
     // here as a parse error so the installer can warn + re-resolve instead
     // of aborting.
@@ -514,22 +511,10 @@ pub(crate) fn load(
                     lockfile
                         .workspace_versions
                         .ensure_total_capacity(workspace_versions_list.len())?;
-                    // SAFETY: capacity reserved above; both columns are fully
-                    // overwritten by `copy_from_slice` before `re_index` reads them.
-                    unsafe {
-                        lockfile
-                            .workspace_versions
-                            .set_entries_len(workspace_versions_list.len());
-                    }
-                    lockfile
-                        .workspace_versions
-                        .keys_mut()
-                        .copy_from_slice(&workspace_package_name_hashes);
-                    lockfile
-                        .workspace_versions
-                        .values_mut()
-                        .copy_from_slice(&workspace_versions_list);
-                    lockfile.workspace_versions.re_index()?;
+                    lockfile.workspace_versions.set_from_slices(
+                        &workspace_package_name_hashes,
+                        &workspace_versions_list,
+                    )?;
                 }
 
                 {
@@ -543,23 +528,9 @@ pub(crate) fn load(
                     lockfile
                         .workspace_paths
                         .ensure_total_capacity(workspace_paths_strings.len())?;
-
-                    // SAFETY: capacity reserved above; both columns are fully
-                    // overwritten by `copy_from_slice` before `re_index` reads them.
-                    unsafe {
-                        lockfile
-                            .workspace_paths
-                            .set_entries_len(workspace_paths_strings.len());
-                    }
                     lockfile
                         .workspace_paths
-                        .keys_mut()
-                        .copy_from_slice(&workspace_paths_hashes);
-                    lockfile
-                        .workspace_paths
-                        .values_mut()
-                        .copy_from_slice(&workspace_paths_strings);
-                    lockfile.workspace_paths.re_index()?;
+                        .set_from_slices(&workspace_paths_hashes, &workspace_paths_strings)?;
                 }
             } else {
                 stream.pos -= 8;
@@ -570,7 +541,7 @@ pub(crate) fn load(
     {
         let remaining_in_buffer = total_buffer_size.saturating_sub(stream.pos as u64);
 
-        // >= because `has_empty_trusted_dependencies_tag` is tag only
+        // >= because `HAS_EMPTY_TRUSTED_DEPENDENCIES_TAG` is tag only
         if remaining_in_buffer >= 8 && total_buffer_size <= stream.buffer.len() as u64 {
             let next_num = stream.read_int_le::<u64>()?;
             if remaining_in_buffer > 8 && next_num == HAS_TRUSTED_DEPENDENCIES_TAG {
@@ -608,10 +579,8 @@ pub(crate) fn load(
                     .ensure_total_capacity(overrides_name_hashes.len())?;
                 let override_versions_external: Vec<dependency::External> =
                     buffers::read_array(stream)?;
-                // reshaped for borrowck — `Context.buffer` borrows
-                // `lockfile.buffers.string_bytes` while we also need
-                // `&mut lockfile.overrides`. Split the disjoint fields up front so
-                // borrowck sees sibling borrows (no raw-ptr provenance laundering).
+                // Split borrow: `Context.buffer` borrows `buffers.string_bytes`
+                // while `overrides` is mutated.
                 let Lockfile {
                     buffers, overrides, ..
                 } = &mut *lockfile;
@@ -683,11 +652,8 @@ pub(crate) fn load(
 
                 let default_deps: Vec<dependency::External> = buffers::read_array(stream)?;
 
-                // reshaped for borrowck — `dependency::Context` /
-                // `ArrayHashContext` borrow `lockfile.buffers.string_bytes` while
-                // we also need `&mut lockfile.catalogs`. Split the disjoint
-                // fields up front so borrowck sees sibling borrows (no raw-ptr
-                // provenance laundering). `string_bytes` is not reallocated for
+                // Split borrow: the contexts borrow `buffers.string_bytes` while
+                // `catalogs` is mutated. `string_bytes` is not reallocated for
                 // the remainder of this block.
                 let Lockfile {
                     buffers, catalogs, ..
@@ -858,7 +824,6 @@ pub(crate) fn load(
             #[allow(clippy::single_match)]
             match resolution.tag {
                 ResolutionTag::Workspace => {
-                    // SAFETY: tag == Workspace discriminates the active union field.
                     lockfile
                         .workspace_paths
                         .put(name_hash, *resolution.workspace())?;

--- a/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
+++ b/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
@@ -411,7 +411,7 @@ where
                 BinTag::NamedFile => {
                     w.begin_object()?;
 
-                    let named_file = *pkg.bin.named_file();
+                    let named_file = pkg.bin.named_file();
                     w.object_field(b"name")?;
                     w.write(named_file[0].slice(sb))?;
 
@@ -427,7 +427,6 @@ where
                 BinTag::Map => {
                     w.begin_object()?;
 
-                    // SAFETY: tag == Map guards the `map` union field.
                     let data: &[ExternalString] =
                         pkg.bin.map().get(this.buffers.extern_strings.as_slice());
                     let mut bin_i: usize = 0;
@@ -630,14 +629,13 @@ fn encode_json_string(s: &[u8], out: &mut Vec<u8>) {
 /// are modelled.
 #[derive(Clone, Copy)]
 pub struct WriteStreamOptions {
-    /// `.whitespace = .indent_N` — number of spaces per nesting level. `0`
-    /// would be `.minified`; the binding always passes `2`.
+    /// Spaces per nesting level; the binding always passes `2`.
     pub indent: usize,
     pub emit_nonportable_numbers_as_strings: bool,
 }
 
 /// JSON write stream over an in-memory `Vec<u8>`, sufficient for
-/// `bun_install_js_bindings::jsParseLockfile`.
+/// `bun_install_jsc::install_binding::js_parse_lockfile`.
 pub struct WriteStream {
     pub(crate) out: Vec<u8>,
     opts: WriteStreamOptions,

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -14,13 +14,20 @@ use bun_sys::Fd;
 
 type Bitset = DynamicBitSet;
 
+/// The package-manager state printing the tree updates.
+pub struct PrintState {
+    pub kept_patched_text: Vec<u8>,
+    pub track_installed_bin: TrackInstalledBin,
+}
+
 fn print_installed_workspace_section<
     W,
     const ENABLE_ANSI_COLORS: bool,
     const PRINT_SECTION_HEADER: bool,
 >(
     this: &Printer,
-    manager: &mut PackageManager,
+    manager: &PackageManager,
+    print_state: &mut PrintState,
     writer: &mut W,
     workspace_package_id: PackageID,
     installed: &Bitset,
@@ -53,7 +60,6 @@ where
     // `updating_packages` holds one original per name, so a name declared by several owners (or groups) is one row.
     let mut update_dedupe: HashMap<PackageNameHash, ()> = HashMap::new();
 
-    // Reshaped for borrowck — `id_map` is reborrowed per call below.
     let mut id_map = id_map;
 
     // find the updated packages
@@ -124,9 +130,9 @@ where
             *printed_new_install = true;
             printed_update = true;
         }
-        if manager.subcommand == Subcommand::Update && !manager.kept_patched_text.is_empty() {
-            writer.write_all(&manager.kept_patched_text)?;
-            manager.kept_patched_text.clear();
+        if manager.subcommand == Subcommand::Update && !print_state.kept_patched_text.is_empty() {
+            writer.write_all(&print_state.kept_patched_text)?;
+            print_state.kept_patched_text.clear();
             *printed_new_install = true;
             printed_update = true;
         }
@@ -284,7 +290,7 @@ fn should_print_package_install(
 
 fn print_updated_package<W, const ENABLE_ANSI_COLORS: bool>(
     this: &Printer,
-    manager: &mut PackageManager,
+    manager: &PackageManager,
     update_info: &PackageUpdatePrintInfo,
     writer: &mut W,
 ) -> Result<(), crate::Error>
@@ -318,7 +324,7 @@ where
 }
 
 fn later_version_text(
-    manager: &mut PackageManager,
+    manager: &PackageManager,
     package_name: &[u8],
     name_hash: PackageNameHash,
     resolution: &Resolution,
@@ -378,7 +384,7 @@ where
 /// Packages registered by the transitive half of `bun update` are not rows of the walked workspaces, so the walk above never reaches them; the walked workspaces' own targets stay with them.
 fn print_transitive_updates<W, const ENABLE_ANSI_COLORS: bool>(
     this: &Printer,
-    manager: &mut PackageManager,
+    manager: &PackageManager,
     update_owners: &[PackageID],
     installed: &Bitset,
     writer: &mut W,
@@ -455,7 +461,7 @@ where
 
 fn print_installed_package<W, const ENABLE_ANSI_COLORS: bool>(
     this: &Printer,
-    manager: &mut PackageManager,
+    manager: &PackageManager,
     dependency: &Dependency,
     package_id: PackageID,
     writer: &mut W,
@@ -560,7 +566,8 @@ where
 /// - Prints a leading and trailing blank newline with diffs
 pub(crate) fn print<W, const ENABLE_ANSI_COLORS: bool>(
     this: &Printer,
-    manager: &mut PackageManager,
+    manager: &PackageManager,
+    print_state: &mut PrintState,
     writer: &mut W,
     log_level: install::package_manager::Options::LogLevel,
 ) -> Result<(), crate::Error>
@@ -568,7 +575,6 @@ where
     W: Write,
 {
     writer.write_str("\n")?;
-    // `allocator` param dropped — global mimalloc.
     let slice = this.lockfile.packages.slice();
     let bins: &[Bin] = slice.items_bin();
     let resolved: &[Resolution] = slice.items_resolution();
@@ -623,6 +629,7 @@ where
             print_installed_workspace_section::<W, ENABLE_ANSI_COLORS, false>(
                 this,
                 manager,
+                print_state,
                 writer,
                 0,
                 installed,
@@ -636,6 +643,7 @@ where
                 print_installed_workspace_section::<W, ENABLE_ANSI_COLORS, true>(
                     this,
                     manager,
+                    print_state,
                     writer,
                     workspace_package_id,
                     installed,
@@ -687,6 +695,7 @@ where
             print_installed_workspace_section::<W, ENABLE_ANSI_COLORS, false>(
                 this,
                 manager,
+                print_state,
                 writer,
                 workspace_package_id,
                 installed,
@@ -788,7 +797,7 @@ where
                 )?;
 
                 {
-                    if matches!(manager.track_installed_bin, TrackInstalledBin::Pending) {
+                    if matches!(print_state.track_installed_bin, TrackInstalledBin::Pending) {
                         // `bin_name`'s borrow of `iterator.buf` must end before
                         // the loop's `iterator.next()`.
                         if let Some(bin_name) = iterator.next().unwrap_or(None) {
@@ -801,7 +810,7 @@ where
                                 bstr::BStr::new(&owned[..]),
                             )?;
 
-                            manager.track_installed_bin = TrackInstalledBin::Basename(owned);
+                            print_state.track_installed_bin = TrackInstalledBin::Basename(owned);
                         }
                     }
 

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -508,9 +508,8 @@ pub mod registry {
             let final_href: Box<[u8]> = if needs_normalize {
                 url.href_without_auth()
             } else {
-                // reshaped for borrowck — `url` (borrowing
-                // `registry_url`) is dead on this branch (every path that
-                // mutated `url.pathname` also set `needs_normalize = true`).
+                // `url` is dead on this branch (every path that mutated
+                // `url.pathname` also set `needs_normalize = true`).
                 registry_url
             };
 
@@ -542,7 +541,7 @@ pub mod registry {
         log: &mut bun_ast::Log,
         package_name: &[u8],
         loaded_manifest: Option<PackageManifest>,
-        package_manager: &mut PackageManager,
+        package_manager: &PackageManager,
         is_extended_manifest: bool,
     ) -> Result<PackageVersionResponse, Error> {
         match response.status_code {
@@ -578,12 +577,7 @@ pub mod registry {
             is_extended_manifest,
         )? {
             if package_manager.options.enable.manifest_cache() {
-                package_manifest::Serializer::save_async(
-                    &package,
-                    scope,
-                    package_manager.get_temporary_directory().handle.fd,
-                    package_manager.get_cache_directory(),
-                );
+                package_manifest::Serializer::save_async(&package, scope, package_manager);
             }
 
             return Ok(PackageVersionResponse::Fresh(package));
@@ -598,7 +592,7 @@ pub use registry as Registry;
 // ──────────────────────────────────────────────────────────────────────────
 
 #[repr(C)]
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct DistTagMap {
     pub(crate) tags: ExternalStringList,
     pub(crate) versions: VersionSlice,
@@ -607,7 +601,7 @@ pub struct DistTagMap {
 pub(crate) type PackageVersionList = ExternalSlice<PackageVersion>;
 
 #[repr(C)]
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct ExternVersionMap {
     pub(crate) keys: VersionSlice,
     pub(crate) values: PackageVersionList,
@@ -642,8 +636,7 @@ pub(crate) fn negatable_from_json<T: NegatableEnum>(expr: &JSON::Expr) -> Result
     let mut this = T::NONE.negatable();
     if let JSON::ExprData::EArray(a) = &expr.data {
         for item in a.items.slice() {
-            // JSON parsed via `parse_utf8` always yields UTF-8 EStrings,
-            // so no transcode allocator is needed.
+            // JSON parsed via `parse_utf8` always yields UTF-8 EStrings.
             if let Some(value) = item.as_utf8_string_literal() {
                 this.apply(value);
             }
@@ -675,7 +668,7 @@ pub(crate) fn negatable_from_json_value<T: NegatableEnum>(value: &JSON::E::JsonV
 // ──────────────────────────────────────────────────────────────────────────
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, bytemuck::NoUninit, bytemuck::CheckedBitPattern)]
 pub struct PackageVersion {
     /// `"integrity"` field || `"shasum"` field
     /// https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#dist
@@ -776,7 +769,7 @@ impl PackageVersion {
         self.bundled_dependencies.is_invalid()
     }
 
-    /// Used by `Package.fromNPM` to walk dependency groups by name.
+    /// Used by `Package::from_npm` to walk dependency groups by name.
     pub(crate) fn dep_group(&self, field: &[u8]) -> ExternalStringMap {
         match field {
             b"dependencies" => self.dependencies,
@@ -837,7 +830,7 @@ const _: () = {
 // ──────────────────────────────────────────────────────────────────────────
 
 #[repr(C)]
-#[derive(Default, Clone, Copy)]
+#[derive(Default, Clone, Copy, bytemuck::NoUninit, bytemuck::CheckedBitPattern)]
 pub struct NpmPackage {
     /// HTTP response headers
     pub(crate) last_modified: SemverString,
@@ -945,16 +938,39 @@ pub mod package_manifest {
         "header bytes must be exactly 49 bytes long, length is not serialized"
     );
 
+    /// Where manifests are cached: the temporary directory a file is written
+    /// into and the cache directory it is renamed into (plus their absolute
+    /// paths, which Windows needs to reopen by path).
+    pub(crate) struct CacheDirs {
+        pub tmpdir: Fd,
+        pub cache_dir: Fd,
+        #[cfg(windows)]
+        pub tmpdir_path: &'static [u8],
+        #[cfg(windows)]
+        pub cache_dir_path: Box<[u8]>,
+    }
+
+    impl CacheDirs {
+        pub(crate) fn of(manager: &PackageManager) -> CacheDirs {
+            let tmp = manager.temporary_directory();
+            CacheDirs {
+                tmpdir: tmp.handle.fd,
+                cache_dir: manager.cache_directory(),
+                #[cfg(windows)]
+                tmpdir_path: tmp.path.as_bytes(),
+                #[cfg(windows)]
+                cache_dir_path: Box::from(manager.cache_directory_path.as_bytes()),
+            }
+        }
+    }
+
     impl Serializer {
-        pub(crate) fn write_array<W: bun_io::Write, T: Copy>(
+        pub(crate) fn write_array<W: bun_io::Write, T: bytemuck::NoUninit>(
             writer: &mut W,
             array: &[T],
             pos: &mut u64,
         ) -> Result<(), Error> {
-            // SAFETY: T is Copy POD; sliceAsBytes equivalent
-            let bytes = unsafe {
-                bun_core::ffi::slice(array.as_ptr().cast::<u8>(), core::mem::size_of_val(array))
-            };
+            let bytes: &[u8] = bytemuck::cast_slice(array);
             if bytes.is_empty() {
                 writer.write_int_le::<u64>(0)?;
                 *pos += 8;
@@ -988,25 +1004,13 @@ pub mod package_manifest {
             Ok(result_bytes)
         }
 
-        fn array_from_bytes<T: Copy>(result_bytes: &[u8]) -> &[T] {
-            if result_bytes.is_empty() {
-                return &[];
-            }
-            // SAFETY: alignment was advanced by Aligner::skip_amount; T is POD
-            unsafe {
-                bun_core::ffi::slice(
-                    result_bytes.as_ptr().cast::<T>(),
-                    result_bytes.len() / core::mem::size_of::<T>(),
-                )
-            }
-        }
-
-        pub fn read_array<'a, T: Copy>(
-            stream: &mut bun_io::FixedBufferStream<&'a [u8]>,
-        ) -> Result<&'a [T], Error> {
-            Ok(Self::array_from_bytes::<T>(Self::read_array_bytes::<T>(
-                stream,
-            )?))
+        /// The next array, each element validated (`None` when one is not a
+        /// valid `T`, i.e. the cache file is unusable).
+        pub fn read_array<T: bytemuck::CheckedBitPattern>(
+            stream: &mut bun_io::FixedBufferStream<&[u8]>,
+        ) -> Result<Option<Box<[T]>>, Error> {
+            let bytes = Self::read_array_bytes::<T>(stream)?;
+            Ok(crate::lockfile::buffers::read_elements(bytes).map(Vec::into_boxed_slice))
         }
 
         pub(crate) fn write<W: bun_io::Write>(
@@ -1028,20 +1032,8 @@ pub mod package_manifest {
             // Verify field order matches SIZES_FIELDS (descending alignment)
             // if the layout changes.
             {
-                // "pkg"
-                // SAFETY: NpmPackage is `#[repr(C)]`, `Copy`, and has **no
-                // implicit padding** — the two layout gaps are filled by
-                // explicit `_padding_*: [u8; N]` fields (zero-initialized via
-                // `Default`), and the `const _ = { offset_of!… }` block at the
-                // struct definition statically asserts no gap remains. Every
-                // byte of `this.pkg` is therefore initialized, so viewing it
-                // as `&[u8]` is sound.
-                let bytes = unsafe {
-                    bun_core::ffi::slice(
-                        (&raw const this.pkg).cast::<u8>(),
-                        core::mem::size_of::<NpmPackage>(),
-                    )
-                };
+                // "pkg" (`NoUninit`: explicit `_padding_*` fields, no gaps)
+                let bytes = bytemuck::bytes_of(&this.pkg);
                 pos += Aligner::write::<NpmPackage, W>(writer, pos)? as u64;
                 writer.write_all(bytes)?;
                 pos += bytes.len() as u64;
@@ -1061,10 +1053,10 @@ pub mod package_manifest {
             this: &PackageManifest,
             scope: &registry::Scope,
             tmp_path: &bun_core::ZStr,
-            tmpdir: Fd,
-            cache_dir: Fd,
+            dirs: &CacheDirs,
             outpath: &bun_core::ZStr,
         ) -> Result<(), Error> {
+            let (tmpdir, cache_dir) = (dirs.tmpdir, dirs.cache_dir);
             // 64 KB sounds like a lot but when you consider that this is only about 6 levels deep in the stack, it's not that much.
             let mut buffer: Vec<u8> = Vec::with_capacity(this.byte_length(scope) + 64);
             Serializer::write(this, scope, &mut buffer)?;
@@ -1076,15 +1068,10 @@ pub mod package_manifest {
             // We skip calling it when we are giving an absolute file path.
             // This needs many more call sites, doesn't have much impact on this location.
             let mut realpath_buf = bun_paths::path_buffer_pool::get();
-            // SAFETY: `crate::package_manager::get()` returns the live
-            // singleton; `get_temporary_directory` only mutates its
-            // lazy-init state and is called from the install thread.
-            #[cfg(windows)]
-            let tmpdir_stub = unsafe { (*crate::package_manager::get()).get_temporary_directory() };
             #[cfg(windows)]
             let path_to_use_for_opening_file =
                 bun_paths::resolve_path::join_abs_string_buf_z::<bun_paths::platform::Auto>(
-                    &tmpdir_stub.path,
+                    dirs.tmpdir_path,
                     &mut realpath_buf[..],
                     &[tmp_path.as_bytes()],
                 );
@@ -1156,7 +1143,7 @@ pub mod package_manifest {
             #[cfg(windows)]
             {
                 let mut realpath2_buf = bun_paths::path_buffer_pool::get();
-                let cache_dir_abs = &PackageManager::get().cache_directory_path;
+                let cache_dir_abs: &[u8] = &dirs.cache_dir_path;
                 let cache_path_abs =
                     bun_paths::resolve_path::join_abs_string_buf_z::<bun_paths::platform::Auto>(
                         cache_dir_abs,
@@ -1250,53 +1237,30 @@ pub mod package_manifest {
         pub(crate) fn save_async(
             this: &PackageManifest,
             scope: &registry::Scope,
-            tmpdir: Fd,
-            cache_dir: Fd,
+            manager: &PackageManager,
         ) {
-            use bun_threading::thread_pool::{
-                Batch as PoolBatch, Node as PoolNode, Task as PoolTask,
-            };
+            use bun_threading::thread_pool::Task as PoolTask;
 
             struct SaveTask {
                 manifest: PackageManifest,
                 // Owned: the thread-pool task can outlive the caller's borrow
                 // of the Registry.Scope, so it owns a clone.
                 scope: registry::Scope,
-                tmpdir: Fd,
-                cache_dir: Fd,
+                dirs: CacheDirs,
 
                 task: PoolTask,
             }
 
-            bun_threading::intrusive_work_task!(SaveTask, task);
+            bun_threading::owned_task!(SaveTask, task);
 
             impl SaveTask {
-                fn new(init: SaveTask) -> Box<SaveTask> {
-                    Box::new(init)
-                }
-
-                // Safe-fn: only ever invoked by `ThreadPool` via the `callback`
-                // fn-pointer with the `*mut PoolTask` we registered below
-                // (`heap::into_raw(SaveTask { task: .. })`). The thread-pool
-                // contract — not the Rust caller — guarantees `task` is live
-                // and points at `SaveTask.task`, so the precondition is
-                // discharged locally (matches `HardLinkWindowsInstallTask::
-                // run_from_thread_pool` in PackageInstall.rs). Safe `fn`
-                // coerces to the `unsafe fn(*mut Task)` field type.
-                fn run(task: *mut PoolTask) {
-                    use bun_threading::IntrusiveWorkTask as _;
+                fn run_owned(self: Box<Self>) {
                     let _tracer = bun_core::perf::trace("PackageManifest.Serializer.save");
+                    let save_task = self;
 
-                    // SAFETY: thread-pool callback contract — `task` points to
-                    // `SaveTask.task`; allocated via `heap::into_raw` in `save_async`.
-                    let save_task = unsafe { bun_core::heap::take(SaveTask::from_task_ptr(task)) };
-
-                    if let Err(err) = Serializer::save(
-                        &save_task.manifest,
-                        &save_task.scope,
-                        save_task.tmpdir,
-                        save_task.cache_dir,
-                    ) {
+                    if let Err(err) =
+                        Serializer::save(&save_task.manifest, &save_task.scope, &save_task.dirs)
+                    {
                         if PackageManager::verbose_install() {
                             bun_core::warn!(
                                 "Error caching manifest for {}: {}",
@@ -1309,20 +1273,12 @@ pub mod package_manifest {
                 }
             }
 
-            let task = bun_core::heap::into_raw(SaveTask::new(SaveTask {
+            manager.thread_pool.schedule_owned(Box::new(SaveTask {
                 manifest: this.clone(),
                 scope: scope.clone(),
-                tmpdir,
-                cache_dir,
-                task: PoolTask {
-                    node: PoolNode::default(),
-                    callback: SaveTask::run,
-                },
+                dirs: CacheDirs::of(manager),
+                task: PoolTask::default(),
             }));
-
-            // SAFETY: task is a valid Box-allocated SaveTask
-            let batch = PoolBatch::from(unsafe { core::ptr::addr_of_mut!((*task).task) });
-            PackageManager::get().thread_pool.schedule(batch);
         }
 
         fn manifest_file_name<'b>(
@@ -1351,8 +1307,7 @@ pub mod package_manifest {
         pub(crate) fn save(
             this: &PackageManifest,
             scope: &registry::Scope,
-            tmpdir: Fd,
-            cache_dir: Fd,
+            dirs: &CacheDirs,
         ) -> Result<(), Error> {
             let file_id = Wyhash11::hash(0, this.name());
             let mut tmp_path_buf = [0u8; 64];
@@ -1360,7 +1315,7 @@ pub mod package_manifest {
             let mut out_path_buf =
                 [0u8; ("18446744073709551615".len() * 2) + "_".len() + ".npm".len() + 1];
             let out_path = Self::manifest_file_name(&mut out_path_buf, file_id, scope)?;
-            Self::write_file(this, scope, tmp_path, tmpdir, cache_dir, out_path)
+            Self::write_file(this, scope, tmp_path, dirs, out_path)
         }
 
         pub(crate) fn load_by_file_id(
@@ -1393,7 +1348,6 @@ pub mod package_manifest {
         ) -> Result<Option<PackageManifest>, Error> {
             let _tracer = bun_core::perf::trace("PackageManifest.Serializer.loadByFile");
             let bytes = manifest_file.read_to_end()?;
-            // errdefer allocator.free(bytes) — Vec drops on error path
 
             if bytes.len() < Self::HEADER_BYTES.len() {
                 return Ok(None);
@@ -1435,45 +1389,38 @@ pub mod package_manifest {
             }
 
             // Keep the order in sync with `Serializer::write` and SIZES_FIELDS.
+            // Each `read_array` validates its elements (`Bin.tag`,
+            // `has_install_script`, ...); an invalid one busts the entry.
             {
                 pkg_stream.pos = pkg_stream
                     .pos
                     .next_multiple_of(core::mem::align_of::<NpmPackage>());
-                let flag_at =
-                    pkg_stream.pos + core::mem::offset_of!(NpmPackage, has_extended_manifest);
-                if !matches!(bytes.get(flag_at).copied(), Some(0 | 1)) {
+                let Some(raw) =
+                    bytes.get(pkg_stream.pos..pkg_stream.pos + core::mem::size_of::<NpmPackage>())
+                else {
+                    return Err(bun_core::Error::EndOfStream.into());
+                };
+                let Ok(pkg) = bytemuck::checked::try_pod_read_unaligned::<NpmPackage>(raw) else {
                     return Ok(None);
-                }
-                package_manifest.pkg = pkg_stream.read_struct::<NpmPackage>()?;
+                };
+                package_manifest.pkg = pkg;
+                pkg_stream.pos += core::mem::size_of::<NpmPackage>();
             }
-            package_manifest.string_buf = Self::read_array::<u8>(&mut pkg_stream)?.into();
-            package_manifest.versions =
-                Self::read_array::<Semver::Version>(&mut pkg_stream)?.into();
-            package_manifest.external_strings =
-                Self::read_array::<ExternalString>(&mut pkg_stream)?.into();
-            package_manifest.external_strings_for_versions =
-                Self::read_array::<ExternalString>(&mut pkg_stream)?.into();
-            package_manifest.package_versions = {
-                let raw = Self::read_array_bytes::<PackageVersion>(&mut pkg_stream)?;
-                let bin_tag_at =
-                    core::mem::offset_of!(PackageVersion, bin) + core::mem::offset_of!(Bin, tag);
-                let install_script_at = core::mem::offset_of!(PackageVersion, has_install_script);
-                for raw_pkg in raw
-                    .as_chunks::<{ core::mem::size_of::<PackageVersion>() }>()
-                    .0
-                {
-                    if !matches!(raw_pkg[bin_tag_at], 0..=4)
-                        || !matches!(raw_pkg[install_script_at], 0 | 1)
-                    {
-                        return Ok(None);
+            macro_rules! read_array {
+                ($ty:ty) => {
+                    match Self::read_array::<$ty>(&mut pkg_stream)? {
+                        Some(array) => array,
+                        None => return Ok(None),
                     }
-                }
-                Self::array_from_bytes::<PackageVersion>(raw).into()
-            };
-            package_manifest.extern_strings_bin_entries =
-                Self::read_array::<ExternalString>(&mut pkg_stream)?.into();
-            package_manifest.bundled_deps_buf =
-                Self::read_array::<PackageNameHash>(&mut pkg_stream)?.into();
+                };
+            }
+            package_manifest.string_buf = read_array!(u8);
+            package_manifest.versions = read_array!(Semver::Version);
+            package_manifest.external_strings = read_array!(ExternalString);
+            package_manifest.external_strings_for_versions = read_array!(ExternalString);
+            package_manifest.package_versions = read_array!(PackageVersion);
+            package_manifest.extern_strings_bin_entries = read_array!(ExternalString);
+            package_manifest.bundled_deps_buf = read_array!(PackageNameHash);
 
             Ok(Some(package_manifest))
         }
@@ -2024,15 +1971,12 @@ impl PackageManifest {
         public_max_age: u32,
         is_extended_manifest: bool,
     ) -> Result<Option<PackageManifest>, Error> {
-        // `bun_ast::Source::init_path_string` accepts borrowed `&[u8]` via
-        // `IntoStr`; the Source only lives for the duration of this function,
-        // so pass the caller's buffers through directly without manufacturing
-        // `'static` references here (PORTING.md §Forbidden lifetime extension).
+        // The Source only lives for the duration of this function and borrows
+        // the caller's buffers.
         let source = bun_ast::Source::init_path_string(expected_name, json_buffer);
         initialize_store();
-        // `initialize_mini_store` deliberately keeps the allocator pushed
-        // across calls (the AstAlloc state stays installed for the re-arm) and
-        // bulk-frees via `reset_retain_with_limit` on the next call — see
+        // `initialize_mini_store` keeps the AST store installed across calls
+        // and bulk-frees via `reset_retain_with_limit` on the next call — see
         // `initialize_mini_store` in lib.rs for why.
         let parsed = match JSON::ParsedJson::parse_npm_manifest(&source, log) {
             Ok(j) => j,
@@ -2651,7 +2595,6 @@ impl PackageManifest {
                     let has_meta_only_peers =
                         peer_deps_meta.is_some_and(|meta| !meta.properties().is_empty());
                     if items.len() > 0 || has_meta_only_peers {
-                        // reshaped for borrowck — index into all_extern_strings / version_extern_strings
                         let names_base = dependency_names_cursor;
                         let values_base = dependency_values_cursor;
 
@@ -2707,11 +2650,9 @@ impl PackageManifest {
                                 string_builder.append::<ExternalString>(version_str);
 
                             if !bundle_all_deps && bundled_deps_set.swap_remove(name_str) {
-                                // SAFETY: bundled_deps_buf sized in counting pass
-                                unsafe {
-                                    *bundled_deps_buf.as_mut_ptr().add(bundled_deps_offset) =
-                                        all_extern_strings[names_base + i].hash;
-                                }
+                                // sized in the counting pass
+                                bundled_deps_buf[bundled_deps_offset] =
+                                    all_extern_strings[names_base + i].hash;
                                 bundled_deps_offset += 1;
                             }
 

--- a/src/install/padding_checker.rs
+++ b/src/install/padding_checker.rs
@@ -32,25 +32,9 @@
 //! a union with unequal size fields.
 
 // Per-field `const _: () = assert!(offset_of!...)` proofs live next to each serialized
-// struct (e.g. `NpmPackage` / `PackageVersion` in npm.rs), and the `layout_asserts`
-// module below pins every serialized type's size/align against the on-disk spec.
-// The free function here is kept as the call-site-compatible entry point.
-
-/// Assertion that `T` has no uninitialized padding. See module docs.
-///
-/// The actual layout checking lives in the per-struct `const` offset asserts
-/// and `layout_asserts` pins; this function is a zero-cost call-site marker that
-/// documents intent. It takes a type-witness value (pass any value of `T` —
-/// or name `T` explicitly via turbofish and reference the fn item without calling).
-///
-/// The trait bound is intentionally *not* applied here: bounding the generic
-/// would force every `write_array<T>` caller to propagate
-/// `T: AssertNoUninitializedPadding`.
-#[inline(always)]
-#[allow(dropping_copy_types, clippy::needless_pass_by_value)]
-pub fn assert_no_uninitialized_padding<T>(_type_witness: T) {
-    // Body intentionally empty — the per-type `const` layout asserts are the check.
-}
+// struct (e.g. `NpmPackage` / `PackageVersion` in npm.rs), the `layout_asserts`
+// module below pins every serialized type's size/align against the on-disk spec,
+// and the writers are bounded on `bytemuck::NoUninit`.
 
 // Reference: what a manual padding audit of a serialized type must establish:
 //
@@ -80,9 +64,9 @@ pub fn assert_no_uninitialized_padding<T>(_type_witness: T) {
 //   );
 //
 // Recursion rules:
-//   - struct / union field  → require `FieldTy: AssertNoUninitializedPadding`
-//   - [T; N] field          → require `T: AssertNoUninitializedPadding`
-//   - Option<T> field       → require `T: AssertNoUninitializedPadding`
+//   - struct / union field  → require `FieldTy: bytemuck::NoUninit`
+//   - [T; N] field          → require `T: bytemuck::NoUninit`
+//   - Option<T> field       → require `T: bytemuck::NoUninit`
 //   - pointer field         → compile_error!("Expected no pointer types in ...")
 //   - anything else         → ok
 //

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -3,6 +3,7 @@ use crate::lockfile::package::PackageColumns as _;
 use bstr::BStr;
 
 use bun_ast::{Loc, Log};
+use bun_core::StringOrTinyString;
 use bun_core::ZBox;
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
@@ -10,7 +11,6 @@ use bun_paths as path;
 use bun_resolver::fs::FileSystem;
 use bun_semver::String as SemverString;
 use bun_sys::{self as sys, Fd, FdExt};
-use bun_threading::IntrusiveWorkTask as _;
 use bun_threading::thread_pool::{Batch, Node as ThreadPoolNode, Task as ThreadPoolTask};
 
 use crate::package_install::PackageInstall;
@@ -33,14 +33,9 @@ type BuntagHashBuf = [u8; MAX_BUNTAG_HASH_BUF_LEN];
 // `Dir::borrow(&fd)` where a `&Dir` is needed.
 
 pub struct PatchTask {
-    /// BACKREF. Stored as `BackRef` because the task
-    /// is held via raw pointer through the intrusive thread-pool queue while
-    /// the manager is concurrently borrowed `&mut` on the main thread; a `&`
-    /// reference here would alias that exclusive borrow under Stacked Borrows.
-    /// Constructed via `BackRef::new_mut` so the underlying pointer carries
-    /// write provenance for `PackageManager::wake_raw(*mut Self)`, which
-    /// writes the event-loop wake flag.
-    pub(crate) manager: bun_ptr::BackRef<PackageManager, bun_ptr::Mut>,
+    /// Read-only on the worker (lockfile strings, `shared`); the manager is
+    /// leaked for the process and outlives every task.
+    pub(crate) manager: bun_ptr::BackRef<PackageManager>,
     /// Borrowed view of the manager's temp directory fd (see comment at top of file).
     pub(crate) tempdir: Fd,
     pub(crate) project_dir: &'static [u8],
@@ -50,16 +45,8 @@ pub struct PatchTask {
     pub(crate) next: bun_threading::Link<PatchTask>,
 }
 
-bun_threading::intrusive_work_task!(PatchTask, task);
-
-// SAFETY: `next` is the sole intrusive link for `UnboundedQueue(PatchTask, .next)`.
-unsafe impl bun_threading::Linked for PatchTask {
-    #[inline]
-    unsafe fn link(item: *mut Self) -> *const bun_threading::Link<Self> {
-        // SAFETY: `item` is valid and properly aligned per `UnboundedQueue` contract.
-        unsafe { core::ptr::addr_of!((*item).next) }
-    }
-}
+bun_threading::owned_task!(PatchTask, task);
+bun_threading::intrusive_linked!(PatchTask, next);
 
 #[derive(strum::IntoStaticStr)]
 pub enum Callback {
@@ -135,51 +122,27 @@ pub struct InstallContext {
 }
 
 impl PatchTask {
-    /// # Safety
-    /// Only invoked by `ThreadPool` via the `callback` fn-pointer registered in
-    /// `new_calc_patch_hash` / `new_apply_patch_hash`. `task` must be live and
-    /// point at the `task` field of a heap-allocated `PatchTask`, with the pool
-    /// granting exclusive access for the duration of the call.
-    pub(crate) unsafe fn run_from_thread_pool(task: *mut ThreadPoolTask) {
-        // SAFETY: thread-pool callback contract — `task` points to the `task`
-        // field of a live `PatchTask` (set at construction); the pool runs
-        // each task at most once with exclusive access for the call.
-        let patch_task = unsafe { &mut *PatchTask::from_task_ptr(task) };
-        patch_task.run_from_thread_pool_impl();
-    }
-
-    pub(crate) fn run_from_thread_pool_impl(&mut self) {
+    /// Thread-pool entry point: run, then hand the task back to the main thread.
+    fn run_owned(mut self: Box<Self>) {
         bun_output::scoped_log!(
             InstallPatch,
-            "runFromThreadPoolImpl {}",
+            "run_owned {}",
             <&'static str>::from(&self.callback)
         );
-        // There are no early returns in the body, so the ordering
-        // (body → push → wake) is inlined below.
         match &mut self.callback {
             Callback::CalcHash(_) => {
                 let result = self.calc_hash();
                 if let Callback::CalcHash(ch) = &mut self.callback {
                     ch.result = result;
                 }
-                // Reshaped for borrowck — `calc_hash` borrows `&mut self`, so we
-                // cannot hold a `&mut ch` across the call.
             }
             Callback::Apply(_) => {
                 bun_core::handle_oom(self.apply());
             }
         }
-        let mgr = self.manager.as_ptr();
-        // SAFETY: `self.manager` is a long-lived BACKREF;
-        // the worker thread only touches the lock-free `patch_task_queue` and the
-        // event-loop wake atomics, neither of which alias data the main thread
-        // holds an exclusive borrow on.
-        unsafe {
-            (*mgr)
-                .patch_task_queue
-                .push(core::ptr::NonNull::from(&mut *self));
-            PackageManager::wake_raw(mgr);
-        }
+        let shared = self.manager.get().shared;
+        shared.patch_task_queue.push(self);
+        shared.wake();
     }
 
     pub(crate) fn run_from_main_thread(
@@ -305,19 +268,13 @@ impl PatchTask {
                         BStr::new(pkg_name.slice(&manager.lockfile.buffers.string_bytes))
                     );
 
-                    // SAFETY: every `Resolution` `Value` payload is `Copy`
-                    // POD and the union is zero-initialized (see the union
-                    // accessors in resolution.rs), so reading `.npm.version`
-                    // yields initialized bytes even when the active variant
-                    // is not `npm` — possibly stale, never uninit. This arm
-                    // is reachable for non-npm resolutions too (git/github/
-                    // tarball; see the TODO below), which then read garbage
-                    // version bytes into the task id, not UB.
-                    let pkg_npm_version = unsafe {
-                        manager.lockfile.packages.items_resolution()[pkg_id as usize]
-                            .value
-                            .npm
-                            .version
+                    let pkg_npm_version = {
+                        let res = &manager.lockfile.packages.items_resolution()[pkg_id as usize];
+                        if res.tag == crate::resolution_real::Tag::Npm {
+                            res.npm().version
+                        } else {
+                            bun_semver::Version::default()
+                        }
                     };
                     let task_id =
                         TaskId::for_npm_package(manager.lockfile.str(&pkg_name), pkg_npm_version);
@@ -327,16 +284,18 @@ impl PatchTask {
                         .behavior
                         .is_required();
                     let pkg_again: Package = *manager.lockfile.packages.get(pkg_id as usize);
-                    let network_task: *mut crate::NetworkTask =
+                    let network_task: Box<crate::NetworkTask> =
                         match package_manager::generate_network_task_for_tarball(
                             manager,
                             // TODO: not just npm package
                             task_id,
-                            url,
+                            StringOrTinyString::init_append_if_needed(
+                                url,
+                                &mut crate::network_task::filename_store_appender(),
+                            )?,
                             is_required,
                             dep_id,
                             &pkg_again,
-                            Some(name_and_version_hash),
                             match pkg_resolution_tag {
                                 crate::resolution_real::Tag::Npm => {
                                     Authorization::AllowAuthorization
@@ -388,7 +347,6 @@ impl PatchTask {
         };
         let log = &mut patch.logger;
         bun_output::scoped_log!(InstallPatch, "apply patch task");
-        // bun.assert(this.callback == .apply) — enforced by the match above.
 
         let dir = self.project_dir;
         let patchfile_path = &patch.patchfilepath;
@@ -462,36 +420,32 @@ impl PatchTask {
 
         // 3. copy the unpatched files into temp dir
         let cache_dir_subpath_z: &ZStr = patch.cache_dir_subpath_without_patch_hash.as_zstr();
-        // Borrowck — `tempdir_name` borrows `tmpname_buf` mutably, but
-        // `PackageInstall` also wants `&mut tmpname_buf[..]` for
-        // `destination_dir_subpath_buf`. `PackageInstall` assumes
-        // `destination_dir_subpath` is a prefix slice *into*
-        // `destination_dir_subpath_buf` (see `verifyGitResolution` /
-        // `verifyPackageJSONNameAndVersion`), and that aliasing can't be
-        // expressed with `&ZStr` + `&mut [u8]`, so use a separate buffer but
-        // mirror the prefix bytes so the invariant holds for any future call
-        // that reaches those paths.
+        // `tempdir_name` borrows `tmpname_buf`, and `PackageInstall` wants its
+        // own `destination_dir_subpath_buf` whose first
+        // `destination_dir_subpath_len` bytes are the subpath, so copy the name
+        // into a separate buffer.
         let mut dest_subpath_buf = [0u8; 1024];
         dest_subpath_buf[..tempdir_name.len() + 1]
             .copy_from_slice(tempdir_name.as_bytes_with_nul());
-        // Not `self.manager()` — `&mut self.callback` is live.
-        // BACKREF — read-only lockfile access while the task runs off-thread.
-        let lockfile = &self.manager.get().lockfile;
+        let manager = self.manager.get();
+        let lockfile = &manager.lockfile;
         let mut pkg_install = PackageInstall {
             cache_dir: patch.cache_dir,
             cache_dir_subpath: cache_dir_subpath_z,
-            destination_dir_subpath: tempdir_name,
+            destination_dir_subpath_len: tempdir_name.len(),
             destination_dir_subpath_buf: &mut dest_subpath_buf[..],
             patch: None,
-            progress: None,
             package_name: pkg_name,
             package_version: &resolution_label,
             // dummy value
             node_modules: &dummy_node_modules,
-            lockfile,
         };
 
         match pkg_install.install(
+            crate::package_install::InstallEnv::Worker {
+                lockfile,
+                thread_pool: &manager.thread_pool,
+            },
             true,
             sys::Dir::borrow(&system_tmpdir),
             InstallMethod::Copyfile,
@@ -707,8 +661,8 @@ impl PatchTask {
         Some(u64::from_le_bytes(digest[0..8].try_into().unwrap()))
     }
 
-    pub(crate) fn schedule(&mut self, batch: &mut Batch) {
-        batch.push(Batch::from(&raw mut self.task));
+    pub(crate) fn schedule(self: Box<Self>, batch: &mut Batch) {
+        batch.push_owned(self);
     }
 
     pub(crate) fn new_calc_patch_hash(
@@ -736,11 +690,11 @@ impl PatchTask {
                 result: None,
                 logger: Log::init(),
             }),
-            manager: bun_ptr::BackRef::new_mut(manager),
+            manager: bun_ptr::BackRef::new(manager),
             project_dir: FileSystem::instance().top_level_dir(),
             task: ThreadPoolTask {
                 node: ThreadPoolNode::default(),
-                callback: Self::run_from_thread_pool,
+                callback: <Self as bun_threading::work_pool::OwnedTask>::__callback,
             },
             pre: false,
             next: bun_threading::Link::new(),
@@ -789,8 +743,6 @@ impl PatchTask {
         let patch_hash_idx = strings::index_of(cache_dir_subpath_bytes, b"_patch_hash=")
             .unwrap_or_else(|| panic!("This is a bug in Bun."));
 
-        // need to dupe this as it's calculated using
-        // `PackageManager.cached_package_folder_name_buf` which may be modified
         let cache_dir_subpath = ZBox::from_bytes(cache_dir_subpath_bytes);
         let cache_dir_subpath_without_patch_hash =
             ZBox::from_bytes(&cache_dir_subpath_bytes[..patch_hash_idx]);
@@ -811,11 +763,11 @@ impl PatchTask {
                 task_id: None,
                 install_context: None,
             }),
-            manager: bun_ptr::BackRef::new_mut(pkg_manager),
+            manager: bun_ptr::BackRef::new(pkg_manager),
             project_dir: FileSystem::instance().top_level_dir(),
             task: ThreadPoolTask {
                 node: ThreadPoolNode::default(),
-                callback: Self::run_from_thread_pool,
+                callback: <Self as bun_threading::work_pool::OwnedTask>::__callback,
             },
             pre: false,
             next: bun_threading::Link::new(),

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -17,7 +17,7 @@ use crate::lockfile::tree::is_filtered_dependency_or_workspace;
 use crate::lockfile::{LoadResult, Lockfile, reachable, tree};
 use crate::lockfile_real::package::{Diff, DiffSummary, Package};
 use crate::package_manager::Options::{Enable, LogLevel};
-use crate::package_manager::ROOT_PACKAGE_JSON_PATH;
+use crate::package_manager::root_package_json_path;
 use crate::package_manager::workspace_selection::{self, RootSelection};
 use crate::{DependencyID, Features, PackageID, PackageManager, ResolutionTag, invalid_package_id};
 
@@ -250,7 +250,7 @@ pub fn prune(manager: &mut PackageManager, original_cwd: &[u8]) -> crate::Result
         Err(Some(name)) => {
             if !quiet {
                 Output::err_generic("failed to load lockfile: {s}", (name,));
-                print_log_errors(manager.log_mut());
+                print_log_errors(&manager.log);
             }
             Global::exit(1);
         }
@@ -535,62 +535,63 @@ pub(crate) fn exit_unless_lockfile_matches_package_json(
     };
     let quiet = manager.options.log_level == LogLevel::Silent;
 
-    let log = manager.log_mut();
-    // SAFETY: written once inside `PackageManager::init` on this thread; only read afterwards.
-    let path: &[u8] = unsafe { ROOT_PACKAGE_JSON_PATH.read() }.as_bytes();
-    let (source, json) = match manager
-        .workspace_package_json_cache
-        .get_with_path(log, path, Default::default())
-        .unwrap()
-    {
-        Ok(entry) => (entry.source.clone(), entry.root),
-        Err(err) => {
-            if !quiet {
-                print_log_errors(log);
-                Output::err(err, "failed to read {s}", (BStr::new(path),));
+    let path: &[u8] = root_package_json_path().as_bytes();
+    let (source, json) = {
+        let PackageManager {
+            log,
+            workspace_package_json_cache,
+            ..
+        } = &mut *manager;
+        match workspace_package_json_cache
+            .get_with_path(log, path, Default::default())
+            .unwrap()
+        {
+            Ok(entry) => (entry.source.clone(), entry.root),
+            Err(err) => {
+                if !quiet {
+                    print_log_errors(log);
+                    Output::err(err, "failed to read {s}", (BStr::new(path),));
+                }
+                Global::exit(1);
             }
-            Global::exit(1);
         }
     };
 
     let mut to_lockfile = Lockfile::default();
     let mut to_root = Package::default();
     let mut resolver: () = ();
-    let pm: *mut PackageManager = manager;
-    // SAFETY: same split as `hoist_install_tree`; neither call reaches `lockfile` through `pm`.
-    let summary = unsafe {
-        let parsed = to_root.parse_with_json::<()>(
+    let parsed = manager.with_log(|manager, log| {
+        to_root.parse_with_json::<()>(
             &mut to_lockfile,
-            &mut *pm,
+            manager,
             log,
             &source,
             json,
             &mut resolver,
             Features::main(),
-        );
-        match parsed {
-            Ok(()) => {
-                let mut mapping = vec![invalid_package_id; to_root.dependencies.len as usize];
-                let from_lockfile: *mut Lockfile = &raw mut *(*pm).lockfile;
-                Diff::generate(
-                    &mut *pm,
-                    log,
-                    &mut *from_lockfile,
-                    &mut to_lockfile,
-                    &root,
-                    &to_root,
-                    None,
-                    Some(&mut mapping[..]),
-                )
-            }
-            Err(err) => Err(err),
-        }
+        )
+    });
+    let summary = match parsed {
+        Ok(()) => manager.with_lockfile_and_log(|from_lockfile, manager, log| {
+            let mut mapping = vec![invalid_package_id; to_root.dependencies.len as usize];
+            Diff::generate(
+                manager,
+                log,
+                from_lockfile,
+                &mut to_lockfile,
+                &root,
+                &to_root,
+                None,
+                Some(&mut mapping[..]),
+            )
+        }),
+        Err(err) => Err(err),
     };
     let summary = match summary {
         Ok(summary) => summary,
         Err(err) => {
             if !quiet {
-                print_log_errors(log);
+                print_log_errors(&manager.log);
             }
             return Err(err);
         }
@@ -775,13 +776,7 @@ fn hoist_install_tree(
         hoisted_dependencies: core::mem::take(&mut manager.lockfile.buffers.hoisted_dependencies),
     };
     let result = with_install_features(manager, features, |manager| {
-        let pm: *mut PackageManager = manager;
-        // SAFETY: same split as `PackageManager::load_lockfile_from_cwd` — `lockfile` is its own `Box` allocation and the Filter builder only reads `manager.options`/`subcommand`/`summary`.
-        unsafe {
-            let lf: *mut Lockfile = &raw mut *(*pm).lockfile;
-            let log: *mut bun_ast::Log = (*pm).log;
-            (*lf).hoist::<{ tree::BuilderMethod::Filter }>(&mut *log, Some(&*pm), true, &[], None)
-        }
+        Lockfile::filter(manager, true, &[], None)
     });
     match result {
         Ok(_) => Ok(saved),
@@ -1777,7 +1772,7 @@ fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>>
             pkg_id,
             &[],
             true,
-            manager,
+            crate::lockfile::tree::HoistOptions::from_manager(manager),
             lockfile,
             resolutions,
         ) {

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -135,7 +135,8 @@ impl SloppyGlobalGitConfig {
 // once `RepositoryExt` is in scope.
 pub use bun_install_types::resolver_hooks::Repository;
 
-/// The environment every `git` the install spawns runs with (see `GitEnv::get`).
+/// The environment every `git` the install spawns runs with
+/// (`PackageManager::git_env`, built once on the install thread).
 pub(crate) struct GitEnv {
     /// `KEY=VALUE\0` array for spawn.
     pub(crate) envp: bun_dotenv::NullDelimitedEnvMap,
@@ -143,23 +144,8 @@ pub(crate) struct GitEnv {
     pub(crate) git: Option<ZBox>,
 }
 
-// Written once from the install thread (the only one that spawns git), then read-only.
-static GIT_ENV: bun_core::RacyCell<Option<GitEnv>> = bun_core::RacyCell::new(None);
-
 impl GitEnv {
-    pub(crate) fn get(loader: &mut bun_dotenv::Loader) -> &'static GitEnv {
-        let slot = GIT_ENV.get();
-        // SAFETY: only the install thread reaches this. The slot is written
-        // once, before any reference into it exists, and never reassigned.
-        unsafe {
-            if (*slot).is_none() {
-                *slot = Some(Self::init(loader));
-            }
-            (*slot).as_ref().unwrap()
-        }
-    }
-
-    fn init(loader: &mut bun_dotenv::Loader) -> GitEnv {
+    pub(crate) fn new(loader: &bun_dotenv::Loader) -> GitEnv {
         // No prompts by default: the install's own output would hide them.
         let mut map = bun_core::handle_oom(loader.map.clone_with_allocator());
 

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -67,16 +67,12 @@ pub(crate) type NpmVersionInfo = VersionedURLType<u64>;
 
 impl<SemverInt: VersionInt> Default for ResolutionType<SemverInt> {
     fn default() -> Self {
-        Self {
-            tag: Tag::Uninitialized,
-            _padding: [0; 7],
-            value: Value { uninitialized: () },
-        }
+        Self::ZEROED
     }
 }
 
-/// Rust-side equivalent of `bun.meta.Tagged(Value, Tag)` — a tagged view of `Value`
-/// used by [`ResolutionType::init`] / [`value_init`] to construct a zero-padded union.
+/// A tagged view of `Value` used by [`ResolutionType::init`] / [`value_init`]
+/// to construct the zero-padded storage.
 // `Tag` is a `#[repr(transparent)] struct Tag(u8)` with sparse `pub const`
 // associated values; the derive maps `Self::Variant` → `Tag::Variant` by name.
 #[derive(Clone, Copy, bun_core::EnumTag)]
@@ -96,15 +92,11 @@ pub enum TaggedValue<SemverInt: VersionInt> {
 }
 
 impl<SemverInt: VersionInt> ResolutionType<SemverInt> {
-    /// Const-evaluable zeroed sentinel. Mirrors `Default::default()` but usable
-    /// in `const` / `static` position (e.g. dummy `&'static Resolution` returns).
-    /// Only the tag/padding are guaranteed zero — the union payload is the
-    /// `uninitialized` variant, which is the only field a `Tag::Uninitialized`
-    /// reader may legally access.
+    /// Const-evaluable zeroed sentinel; also `Default::default()`.
     pub(crate) const ZEROED: Self = Self {
         tag: Tag::Uninitialized,
         _padding: [0; 7],
-        value: Value { uninitialized: () },
+        value: Value::ZEROED,
     };
 
     /// Construct from a tagged value, e.g. `Resolution::init(TaggedValue::Npm(...))`.
@@ -129,29 +121,74 @@ impl<SemverInt: VersionInt> ResolutionType<SemverInt> {
         Self::init(TaggedValue::Symlink(s))
     }
 
-    // ── Tag-checked union accessors ────────────────────────────────────────
-    // Every `Value` payload is `Copy` (`String` handles, `Repository`,
-    // `VersionedURLType`) and the union is zero-initialized, so reading the
-    // wrong variant is well-defined garbage — the macro debug-asserts the tag.
-    bun_core::extern_union_accessors! {
-        tag: tag as Tag, value: value;
-        Npm              => npm: VersionedURLType<SemverInt>, mut npm_mut;
-        Folder           => folder: String;
-        LocalTarball     => local_tarball: String;
-        RemoteTarball    => remote_tarball: String;
-        Workspace        => workspace: String;
-        Symlink          => symlink: String;
-        SingleFileModule => single_file_module: String;
-        Git              => git: Repository, mut git_mut;
-        Github           => github: Repository, mut github_mut;
+    // ── Tag-checked accessors ────────────────────────────────────────────────
+    // Every `Value` view is plain data over zeroed storage, so reading the
+    // wrong one is well-defined garbage — these debug-assert the tag.
+    #[inline]
+    pub fn npm(&self) -> &VersionedURLType<SemverInt> {
+        debug_assert!(self.tag == Tag::Npm);
+        self.value.npm()
+    }
+    #[inline]
+    pub fn npm_mut(&mut self) -> &mut VersionedURLType<SemverInt> {
+        debug_assert!(self.tag == Tag::Npm);
+        self.value.npm_mut()
+    }
+    #[inline]
+    pub fn folder(&self) -> &String {
+        debug_assert!(self.tag == Tag::Folder);
+        self.value.string()
+    }
+    #[inline]
+    pub fn local_tarball(&self) -> &String {
+        debug_assert!(self.tag == Tag::LocalTarball);
+        self.value.string()
+    }
+    #[inline]
+    pub fn remote_tarball(&self) -> &String {
+        debug_assert!(self.tag == Tag::RemoteTarball);
+        self.value.string()
+    }
+    #[inline]
+    pub fn workspace(&self) -> &String {
+        debug_assert!(self.tag == Tag::Workspace);
+        self.value.string()
+    }
+    #[inline]
+    pub fn symlink(&self) -> &String {
+        debug_assert!(self.tag == Tag::Symlink);
+        self.value.string()
+    }
+    #[inline]
+    pub fn single_file_module(&self) -> &String {
+        debug_assert!(self.tag == Tag::SingleFileModule);
+        self.value.string()
+    }
+    #[inline]
+    pub fn git(&self) -> &Repository {
+        debug_assert!(self.tag == Tag::Git);
+        self.value.repository()
+    }
+    #[inline]
+    pub fn git_mut(&mut self) -> &mut Repository {
+        debug_assert!(self.tag == Tag::Git);
+        self.value.repository_mut()
+    }
+    #[inline]
+    pub fn github(&self) -> &Repository {
+        debug_assert!(self.tag == Tag::Github);
+        self.value.repository()
+    }
+    #[inline]
+    pub fn github_mut(&mut self) -> &mut Repository {
+        debug_assert!(self.tag == Tag::Github);
+        self.value.repository_mut()
     }
     /// `git` or `github` payload — they share the [`Repository`] shape.
     #[inline]
     pub(crate) fn repository(&self) -> &Repository {
         debug_assert!(self.tag == Tag::Git || self.tag == Tag::Github);
-        // SAFETY: `git` and `github` occupy the same union slot type
-        // (`Repository`); tag asserted to be one of the two.
-        unsafe { &(*core::ptr::from_ref(&self.value)).git }
+        self.value.repository()
     }
 
     pub(crate) fn can_enqueue_install_task(&self) -> bool {
@@ -217,18 +254,11 @@ impl<SemverInt: VersionInt> ResolutionType<SemverInt> {
                     return Err(FromTextLockfileError::UnexpectedResolution);
                 }
 
-                Ok(Self {
-                    tag: Tag::Npm,
-                    _padding: [0; 7],
-                    value: Value {
-                        npm: VersionedURLType {
-                            version: parsed.version.min(),
-
-                            // will fill this later
-                            url: String::default(),
-                        },
-                    },
-                })
+                Ok(Self::init(TaggedValue::Npm(VersionedURLType {
+                    version: parsed.version.min(),
+                    // will fill this later
+                    url: String::default(),
+                })))
             }
 
             // covered above
@@ -922,36 +952,24 @@ impl<'a, SemverInt: VersionInt> fmt::Display for DebugFormatter<'a, SemverInt> {
 /// [`ResolutionType`] share the SAME nominal `value` type. Sharing the nominal
 /// type (rather than a layout-identical local duplicate) lets
 /// `auto_installer::resolution_from_hooks` copy `value` by plain assignment
-/// instead of `transmute`. Constructors that need the install-side
-/// zero-padded-init contract live below as free fns ([`value_zero`] /
-/// [`value_init`]) since inherent impls on a foreign type are forbidden.
+/// instead of `transmute`. The install-side tagged constructor lives below as
+/// a free fn ([`value_init`]) since inherent impls on a foreign type are forbidden.
 pub type Value<SemverInt> = bun_install_types::resolver_hooks::ResolutionValue<SemverInt>;
 
-#[inline]
-fn value_zero<SemverInt: VersionInt>() -> Value<SemverInt> {
-    // SAFETY: all-zero is a valid Value — every variant is POD with a valid
-    // all-zero representation (Semver String, Repository, VersionedURLType are
-    // all #[repr(C)] with no NonNull/NonZero fields).
-    unsafe { bun_core::ffi::zeroed_unchecked() }
-}
-
-/// To avoid undefined memory between union values, we must zero initialize the union first.
+/// Zeroed storage holding just `field`, so the bytes past it are deterministic.
 fn value_init<SemverInt: VersionInt>(field: TaggedValue<SemverInt>) -> Value<SemverInt> {
-    let mut value = value_zero::<SemverInt>();
     match field {
-        TaggedValue::Uninitialized => value.uninitialized = (),
-        TaggedValue::Root => value.root = (),
-        TaggedValue::Npm(v) => value.npm = v,
-        TaggedValue::Folder(v) => value.folder = v,
-        TaggedValue::LocalTarball(v) => value.local_tarball = v,
-        TaggedValue::Github(v) => value.github = v,
-        TaggedValue::Git(v) => value.git = v,
-        TaggedValue::Symlink(v) => value.symlink = v,
-        TaggedValue::Workspace(v) => value.workspace = v,
-        TaggedValue::RemoteTarball(v) => value.remote_tarball = v,
-        TaggedValue::SingleFileModule(v) => value.single_file_module = v,
+        TaggedValue::Uninitialized => Value::uninitialized(),
+        TaggedValue::Root => Value::root(),
+        TaggedValue::Npm(v) => Value::from_npm(&v),
+        TaggedValue::Github(v) | TaggedValue::Git(v) => Value::from_repository(&v),
+        TaggedValue::Folder(v)
+        | TaggedValue::LocalTarball(v)
+        | TaggedValue::Symlink(v)
+        | TaggedValue::Workspace(v)
+        | TaggedValue::RemoteTarball(v)
+        | TaggedValue::SingleFileModule(v) => Value::from_string(v),
     }
-    value
 }
 
 // Tag is non-exhaustive — values outside the named set are valid (lockfile

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 use bun_core::fmt::QuotedFormatter;
 use bun_core::{ZStr, strings};
-use bun_paths::{self, MAX_PATH_BYTES, PathBuffer, SEP, SEP_STR};
+use bun_paths::{self, PathBuffer, SEP, SEP_STR};
 use bun_resolver::fs::FileSystem;
 use bun_semver::{self as semver, String as SemverString};
 use bun_sys::{self, Fd, File, O};
@@ -28,54 +28,53 @@ pub enum FolderResolution {
 // The enum discriminant serves as the tag; expose an alias for it.
 
 pub(crate) struct PackageWorkspaceSearchPathFormatter<'a> {
-    pub manager: &'a PackageManager,
+    pub lockfile: &'a Lockfile,
     pub version: dependency::Version,
     pub quoted: bool,
 }
 
 impl<'a> fmt::Display for PackageWorkspaceSearchPathFormatter<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut joined = [0u8; MAX_PATH_BYTES + 2];
+        let mut joined = bun_paths::path_buffer_pool::get();
         // Caller constructs this formatter only when
         // `self.version.tag == .workspace`.
         let workspace = self.version.workspace();
         let str_to_use = self
-            .manager
             .lockfile
             .workspace_paths
             .get(&semver::string::Builder::string_hash(
-                self.manager.lockfile.str(workspace),
+                self.lockfile.str(workspace),
             ))
             .unwrap_or(workspace);
 
-        // SAFETY: joined[2..] is exactly MAX_PATH_BYTES bytes long.
-        let joined_path: &mut PathBuffer =
-            unsafe { &mut *joined.as_mut_ptr().add(2).cast::<PathBuffer>() };
-        let mut paths = normalize_package_json_path(
+        let paths = normalize_package_json_path(
             GlobalOrRelative::Relative(dependency::version::Tag::Workspace),
-            joined_path,
-            self.manager.lockfile.str(str_to_use),
+            &mut joined,
+            self.lockfile.str(str_to_use),
         );
 
-        if !strings::starts_with_char(paths.rel, b'.') && !strings::starts_with_char(paths.rel, SEP)
+        let mut prefixed = bun_paths::path_buffer_pool::get();
+        let rel: &[u8] = if !strings::starts_with_char(paths.rel, b'.')
+            && !strings::starts_with_char(paths.rel, SEP)
         {
-            joined[0] = b'.';
-            joined[1] = SEP;
-            // `paths.rel` points into `joined[2..]`; extend the view backward
-            // by the two bytes just written via safe slicing of `joined`.
-            let n = paths.rel.len() + 2;
-            paths.rel = &joined[..n];
-        }
+            let n = paths.rel.len();
+            prefixed[0] = b'.';
+            prefixed[1] = SEP;
+            prefixed[2..2 + n].copy_from_slice(paths.rel);
+            &prefixed[..2 + n]
+        } else {
+            paths.rel
+        };
 
         if self.quoted {
-            let quoted = QuotedFormatter { text: paths.rel };
+            let quoted = QuotedFormatter { text: rel };
             fmt::Display::fmt(&quoted, f)
         } else {
             // `fmt::Formatter` only accepts `&str`, so non-UTF-8 path bytes are emitted lossily
             // (U+FFFD) via `bstr::BStr`'s Display. Both current callers pass
             // `quoted = true`, so this branch is unreached today; if a future
             // caller needs byte-exact output it must use an `io::Write` sink.
-            write!(f, "{}", bstr::BStr::new(paths.rel))
+            write!(f, "{}", bstr::BStr::new(rel))
         }
     }
 }
@@ -268,52 +267,25 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
 
     let mut package: LockfilePackage = Default::default();
 
-    // Borrow splitting: `manager.lockfile`, `manager`, and `manager.log` are
-    // needed simultaneously; borrowck rejects the overlap on `&mut self`,
-    // so split via raw pointer once here. `lockfile` and `log` are disjoint
-    // fields of `PackageManager`, and `parse{,_with_json}` only reaches
-    // `manager` through the `pm` argument (no re-entrant access to
-    // `lockfile`/`log` via `pm`).
-    //
-    // `log_mut()` reads the BACKREF `self.log: *mut Log` and returns the
-    // disjoint CLI `Log` allocation (lifetime decoupled from `&self`); call it
-    // safely *before* establishing `manager_ptr` so `log` is derived from a
-    // separate allocation and is unaffected by the `&mut *manager_ptr`
-    // reborrows below.
-    let log: &mut bun_ast::Log = manager.log_mut();
-    let manager_ptr: *mut PackageManager = manager;
-
     if R::IS_WORKSPACE {
         let _tracer =
             bun_perf::trace(bun_perf::PerfEvent::FolderResolverReadPackageJSONFromDiskWorkspace);
 
-        // SAFETY: `manager_ptr` was just derived from the live `&mut PackageManager`
-        // argument; `log` points into a separate `Log` allocation (see the
-        // borrow-splitting comment above), so this `&mut` reborrow aliases no
-        // other live reference.
-        let json = unsafe { &mut *manager_ptr }
-            .workspace_package_json_cache
-            .get_with_path(log, abs.as_bytes(), Default::default())
-            .unwrap()?;
-        // `Expr` is `Copy`; take a raw pointer to `source` so the borrow on
-        // `workspace_package_json_cache` ends before `&mut *manager_ptr` is
-        // formed for `parse_with_json`.
-        let root: Expr = json.root;
-        let source: *const bun_ast::Source = &raw const json.source;
-
-        // SAFETY: see the borrow-splitting comment above.
-        unsafe {
-            let lockfile: *mut Lockfile = &raw mut *(*manager_ptr).lockfile;
-            package.parse_with_json::<R>(
-                &mut *lockfile,
-                &mut *manager_ptr,
+        let (source, root) = {
+            let PackageManager {
                 log,
-                &*source,
-                root,
-                resolver,
-                features,
-            )?;
-        }
+                workspace_package_json_cache,
+                ..
+            } = &mut *manager;
+            let json = workspace_package_json_cache
+                .get_with_path(log, abs.as_bytes(), Default::default())
+                .unwrap()?;
+            (json.source.clone(), json.root)
+        };
+
+        manager.with_lockfile_and_log(|lockfile, manager, log| {
+            package.parse_with_json::<R>(lockfile, manager, log, &source, root, resolver, features)
+        })?;
     } else {
         let _tracer =
             bun_perf::trace(bun_perf::PerfEvent::FolderResolverReadPackageJSONFromDiskFolder);
@@ -330,18 +302,9 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
             bun_ast::Source::init_path_string(abs.as_bytes(), body.list.as_slice())
         };
 
-        // SAFETY: see the borrow-splitting comment above.
-        unsafe {
-            let lockfile: *mut Lockfile = &raw mut *(*manager_ptr).lockfile;
-            package.parse::<R>(
-                &mut *lockfile,
-                &mut *manager_ptr,
-                log,
-                &source,
-                resolver,
-                features,
-            )?;
-        }
+        manager.with_lockfile_and_log(|lockfile, manager, log| {
+            package.parse::<R>(lockfile, manager, log, &source, resolver, features)
+        })?;
     }
 
     let has_scripts = package.scripts.has_any()
@@ -409,7 +372,6 @@ pub(crate) fn get_or_put(
         let abs_len = paths.abs.len();
         let rel_len = paths.rel.len();
         rel_buf[..rel_len].copy_from_slice(paths.rel);
-        // `paths` is dead past this point → `joined` is no longer borrowed.
         bun_paths::dangerously_convert_path_to_posix_in_place::<u8>(&mut joined[..abs_len]);
         bun_paths::dangerously_convert_path_to_posix_in_place::<u8>(&mut rel_buf[..rel_len]);
         (

--- a/src/install/update_scope.rs
+++ b/src/install/update_scope.rs
@@ -311,9 +311,9 @@ fn exit_on_lockfile_load_failure(manager: &mut PackageManager, subject: &[u8]) -
                     "failed to {s} lockfile: {s}",
                     (cause.step.verb(), cause.value.name()),
                 );
-                if manager.log_mut().has_errors() {
+                if manager.log.has_errors() {
                     let _ = manager
-                        .log_mut()
+                        .log
                         .print(std::ptr::from_mut(Output::error_writer()));
                 }
             }

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -14,7 +14,7 @@ use crate::lockfile::package::PackageColumns as _;
 use crate::lockfile::{Lockfile, PackageIndexEntry};
 use crate::npm::PackageManifest;
 use crate::package_manager::Options::LogLevel;
-use crate::package_manager::ROOT_PACKAGE_JSON_PATH;
+use crate::package_manager::root_package_json_path;
 use crate::package_manager_real::populate_manifest_cache::{self, Packages};
 use crate::package_manager_real::{PackageUpdateInfo, enqueue_dependency_with_main};
 use crate::update_scope::UpdateScope;
@@ -463,9 +463,10 @@ pub(crate) fn enqueue_peer_rows(
 }
 
 /// Pending log lines go to stderr; `--silent` drops everything but errors.
-fn print_log(manager: &PackageManager) -> crate::Result<()> {
-    let log = manager.log_mut();
-    if manager.options.log_level != LogLevel::Silent || log.has_errors() {
+fn print_log(manager: &mut PackageManager) -> crate::Result<()> {
+    let silent = manager.options.log_level == LogLevel::Silent;
+    let log = &mut manager.log;
+    if !silent || log.has_errors() {
         log.print(core::ptr::from_mut(Output::error_writer()))?;
     }
     log.reset();
@@ -718,9 +719,8 @@ pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) {
         return;
     }
     let keys: Vec<Box<[u8]>> = {
-        let log = manager.log_mut();
-        // SAFETY: written once inside `PackageManager::init` on this thread; only read afterwards.
-        let path: &[u8] = unsafe { ROOT_PACKAGE_JSON_PATH.read() }.as_bytes();
+        let log = &mut manager.log;
+        let path: &[u8] = root_package_json_path().as_bytes();
         let opts = GetJsonOptions {
             init_reset_store: false,
             ..Default::default()
@@ -853,15 +853,15 @@ fn newest_allowed(manager: &mut PackageManager, pkg_id: PackageID) -> Option<Box
 
 /// Pairs each unchecked `(name, version)` with the fetch failure the manifest task logged for it and reports both as one warning; nothing under `--silent`.
 fn warn_unchecked(
-    manager: &PackageManager,
+    manager: &mut PackageManager,
     msgs_before: usize,
     unchecked: &[(Box<[u8]>, Box<[u8]>)],
 ) {
     if unchecked.is_empty() {
         return;
     }
-    let log = manager.log_mut();
     let silent = manager.options.log_level == LogLevel::Silent;
+    let log = &mut manager.log;
     let mut used = DynamicBitSet::init_empty(log.msgs.len()).unwrap_or_oom();
     for (name, version) in unchecked {
         let reason = log
@@ -1126,7 +1126,7 @@ fn plan_edges(
     }
 
     let ids: Vec<PackageID> = instances.iter().map(|inst| inst.pkg_id).collect();
-    let msgs_before = manager.log_mut().msgs.len();
+    let msgs_before = manager.log.msgs.len();
     populate_manifest_cache::populate_manifest_cache(manager, Packages::Exact(&ids))?;
 
     let cache_ctx = manager.manifest_disk_cache_ctx();

--- a/src/install/windows-shim/bun_shim_impl.rs
+++ b/src/install/windows-shim/bun_shim_impl.rs
@@ -944,7 +944,7 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
 
     if !flags.is_valid() {
         // We want to return control flow back into bun.exe's main code, so that it can fall
-        // back to the slow path. For more explanation, see the comment on top of `tryStartupFromBunJS`.
+        // back to the slow path. For more explanation, see the comment on top of `try_startup_from_bun_js`.
         if !IS_STANDALONE && MODE == LauncherMode::Launch {
             return LauncherRet::LaunchFellThrough;
         }

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -87,7 +87,7 @@ pub(crate) struct ParsedGitUrl<'a> {
     pub(crate) repo: Option<&'a [u8]>,
     // Optional owned "https://github.com/{path}" buffer so the borrow
     // case stays zero-copy. Callers must check `owned_url` first: when it is `Some`,
-    // it supersedes `url` (see `into_resolved`).
+    // it supersedes `url`.
     pub(crate) owned_url: Option<Vec<u8>>,
 }
 
@@ -565,8 +565,7 @@ fn process_deps(
             }
 
             if let Some(pkg_id) = found_package_id {
-                // SAFETY: `deps_buf` is uninitialized spare capacity; `ptr::write` skips Drop.
-                unsafe { core::ptr::write(deps_buf.as_mut_ptr().add(count), dep) };
+                deps_buf[count] = dep;
                 res_buf[count] = pkg_id;
                 count += 1;
             }
@@ -788,18 +787,17 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         })?;
     }
 
-    // SAFETY: capacity reserved above to num_deps; we write past `len` through
-    // raw pointers into the reserved capacity and set `len` at the end.
-    let dependencies_base_ptr = this.buffers.dependencies.as_mut_ptr();
-    let resolutions_base_ptr = this.buffers.resolutions.as_mut_ptr();
-    let mut dependencies_buf: &mut [Dependency] = unsafe {
-        // SAFETY: capacity >= num_deps reserved above
-        bun_core::ffi::slice_mut(dependencies_base_ptr, num_deps as usize)
-    };
-    let mut resolutions_buf: &mut [PackageID] = unsafe {
-        // SAFETY: capacity >= num_deps reserved above
-        bun_core::ffi::slice_mut(resolutions_base_ptr, num_deps as usize)
-    };
+    // Fill `num_deps` slots of both buffers (held outside `this` while the
+    // string builder borrows it), then trim to what was actually written.
+    let deps_base = this.buffers.dependencies.len();
+    let mut all_dependencies = core::mem::take(&mut this.buffers.dependencies);
+    let mut all_resolutions = core::mem::take(&mut this.buffers.resolutions);
+    all_dependencies.resize(deps_base + num_deps as usize, Dependency::default());
+    all_resolutions.resize(deps_base + num_deps as usize, install::INVALID_PACKAGE_ID);
+    let mut dependencies_buf: &mut [Dependency] = &mut all_dependencies[deps_base..];
+    let mut resolutions_buf: &mut [PackageID] = &mut all_resolutions[deps_base..];
+    // Both cursors advance together; a slot's index is `num_deps - remaining`.
+    let slot_of = |remaining: usize| deps_base + num_deps as usize - remaining;
 
     let mut yarn_entry_to_package_id: Vec<PackageID> = vec![0; yarn_lock.entries.len()];
 
@@ -970,10 +968,9 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
 
         let name_hash = string_hash(name_to_use);
 
-        // reshaped for borrowck — compute the resolution before the
-        // `this.packages.append(...)` call so the per-field `sbuf!()` borrows of
-        // `this.buffers.string_bytes` don't overlap the two-phase reservation
-        // on `this.packages`.
+        // The resolution is computed before `this.packages.append(...)` so
+        // the `sbuf!()` borrows of `this.buffers.string_bytes` don't overlap
+        // the two-phase reservation on `this.packages`.
         let pkg_name = sbuf!().append_with_hash(name_to_use, name_hash)?;
         let resolution = 'blk: {
             if entry.workspace {
@@ -1149,28 +1146,20 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 let dep_name_string = sbuf!().append_with_hash(&dep.name, name_hash)?;
                 let version_string = sbuf!().append(&dep.version)?;
 
-                // SAFETY: `dependencies_buf` is uninitialized spare capacity; `ptr::write` skips Drop.
-                unsafe {
-                    core::ptr::write(
-                        dependencies_buf
-                            .as_mut_ptr()
-                            .add(actual_root_dep_count as usize),
-                        Dependency {
-                            name: dep_name_string,
-                            name_hash,
-                            version: Dependency::parse(
-                                dep_name_string,
-                                Some(name_hash),
-                                version_string.slice(this.buffers.string_bytes.as_slice()),
-                                &version_string.sliced(this.buffers.string_bytes.as_slice()),
-                                Some(&mut *log),
-                                Some(&mut *manager),
-                            )
-                            .unwrap_or_default(),
-                            behavior: behavior_for(dep.dep_type, false),
-                        },
-                    );
-                }
+                dependencies_buf[actual_root_dep_count as usize] = Dependency {
+                    name: dep_name_string,
+                    name_hash,
+                    version: Dependency::parse(
+                        dep_name_string,
+                        Some(name_hash),
+                        version_string.slice(this.buffers.string_bytes.as_slice()),
+                        &version_string.sliced(this.buffers.string_bytes.as_slice()),
+                        Some(&mut *log),
+                        Some(&mut *manager),
+                    )
+                    .unwrap_or_default(),
+                    behavior: behavior_for(dep.dep_type, false),
+                };
 
                 resolutions_buf[actual_root_dep_count as usize] = yarn_entry_to_package_id[idx];
                 actual_root_dep_count += 1;
@@ -1192,12 +1181,9 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             continue;
         }
 
-        let dependencies_start = dependencies_buf.as_mut_ptr();
-        let resolutions_start = resolutions_buf.as_mut_ptr();
+        let dependencies_start = slot_of(dependencies_buf.len());
+        let resolutions_start = slot_of(resolutions_buf.len());
 
-        // reshaped for borrowck — iterate by index and re-borrow
-        // `yarn_lock.entries[yarn_idx]` for each map so the shared borrow of
-        // `yarn_lock` passed into `process_deps` doesn't overlap an iterator.
         if let Some(deps) = yarn_lock.entries[yarn_idx].dependencies.as_ref() {
             let processed = process_deps(
                 deps,
@@ -1262,31 +1248,25 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             resolutions_buf = &mut resolutions_buf[processed..];
         }
 
-        // dependencies_start/dependencies_buf.as_ptr() are within the same allocation
-        let deps_len = (dependencies_buf.as_mut_ptr() as usize) - (dependencies_start as usize);
-        let deps_off = (dependencies_start as usize) - (dependencies_base_ptr as usize);
+        let deps_len = slot_of(dependencies_buf.len()) - dependencies_start;
         this.packages.items_dependencies_mut()[package_id as usize] =
             lockfile::DependencySlice::new(
-                u32::try_from(deps_off / core::mem::size_of::<Dependency>()).expect("int cast"),
-                u32::try_from(deps_len / core::mem::size_of::<Dependency>()).expect("int cast"),
+                u32::try_from(dependencies_start).expect("int cast"),
+                u32::try_from(deps_len).expect("int cast"),
             );
-        let res_off = (resolutions_start as usize) - (resolutions_base_ptr as usize);
-        let res_len = (resolutions_buf.as_mut_ptr() as usize) - (resolutions_start as usize);
+        let res_len = slot_of(resolutions_buf.len()) - resolutions_start;
         this.packages.items_resolutions_mut()[package_id as usize] =
             lockfile::DependencyIDSlice::new(
-                u32::try_from(res_off / core::mem::size_of::<PackageID>()).expect("int cast"),
-                u32::try_from(res_len / core::mem::size_of::<PackageID>()).expect("int cast"),
+                u32::try_from(resolutions_start).expect("int cast"),
+                u32::try_from(res_len).expect("int cast"),
             );
     }
 
-    let final_deps_len = ((dependencies_buf.as_mut_ptr() as usize)
-        - (dependencies_base_ptr as usize))
-        / core::mem::size_of::<Dependency>();
-    unsafe {
-        // SAFETY: all elements in 0..final_deps_len initialized above; capacity >= num_deps
-        this.buffers.dependencies.set_len(final_deps_len);
-        this.buffers.resolutions.set_len(final_deps_len);
-    }
+    let final_deps_len = slot_of(dependencies_buf.len());
+    all_dependencies.truncate(final_deps_len);
+    all_resolutions.truncate(final_deps_len);
+    this.buffers.dependencies = all_dependencies;
+    this.buffers.resolutions = all_resolutions;
 
     this.buffers.hoisted_dependencies.reserve(
         (this.buffers.dependencies.len() * 2)

--- a/src/install_types/Cargo.toml
+++ b/src/install_types/Cargo.toml
@@ -18,3 +18,4 @@ bun_core.workspace = true
 bun_ast.workspace = true
 bun_semver.workspace = true
 bun_wyhash.workspace = true
+bytemuck = { version = "1", features = ["derive"] }

--- a/src/install_types/NodeLinker.rs
+++ b/src/install_types/NodeLinker.rs
@@ -42,7 +42,7 @@ pub mod npm {
     impl Registry {
         pub const DEFAULT_URL: &'static str = "https://registry.npmjs.org/";
 
-        /// `bun.Wyhash11.hash(0, strings.withoutTrailingSlash(default_url))`
+        /// `bun.Wyhash11.hash(0, strings.without_trailing_slash(default_url))`
         /// — i.e. hash of `b"https://registry.npmjs.org"` (no trailing `/`).
         // Computed on use because `bun_wyhash::Wyhash11::hash` is not a
         // `const fn` (only `Wyhash::hash_const` — a different algorithm —
@@ -50,7 +50,7 @@ pub mod npm {
         #[inline]
         pub fn default_url_hash() -> u64 {
             use bun_wyhash::Wyhash11;
-            // strings.withoutTrailingSlash strips exactly one trailing '/'.
+            // strings.without_trailing_slash strips exactly one trailing '/'.
             Wyhash11::hash(
                 0,
                 &Self::DEFAULT_URL.as_bytes()[..Self::DEFAULT_URL.len() - 1],
@@ -173,11 +173,8 @@ bun_core::impl_tag_error!(FromExprError);
 bun_core::oom_from_alloc!(FromExprError);
 
 impl PnpmMatcher {
-    // `bun_ast::ExprData` exposes the real value-shaped enum
-    // (`EString`/`EArray` via `StoreRef<E::*>`). The arena-taking
-    // `E::String::slice` / `Expr::as_string_cloned` signatures get a local
-    // `bun_alloc::Arena` (PORTING.md §Allocators: AST=bumpalo) used only for
-    // transient UTF-16→UTF-8 transcoding inside `slice`/`string_cloned`.
+    // The local `bun_alloc::Arena` is only for transient UTF-16 to UTF-8
+    // transcoding inside `E::String::slice` / `Expr::as_string_cloned`.
     pub fn from_expr(
         expr: &ast::Expr,
         log: &mut bun_ast::Log,

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -44,6 +44,12 @@ pub struct ExternalSlice<T> {
     _marker: PhantomData<T>,
 }
 
+// SAFETY: two `u32`s and a zero-sized marker; `repr(C)`, no padding, and
+// every bit pattern is a valid (if out-of-range) index pair.
+unsafe impl<T: 'static> bytemuck::Zeroable for ExternalSlice<T> {}
+// SAFETY: as above.
+unsafe impl<T: 'static> bytemuck::Pod for ExternalSlice<T> {}
+
 // Manual impls: the `(off, len)` pair is unconditionally
 // copyable/comparable regardless of `Type`. `#[derive]` would add spurious
 // `T: Copy/Clone/Default/PartialEq` bounds via `PhantomData<T>`, breaking
@@ -148,7 +154,7 @@ impl<T> ExternalSlice<T> {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Default, Debug)]
+#[derive(Copy, Clone, Default, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct ExternalStringMap {
     pub name: ExternalStringList,
     pub value: ExternalStringList,
@@ -473,7 +479,7 @@ impl DependencyVersion {
     // Every payload is POD/arena-backed (`SemverString` handles, `Repository`,
     // `ManuallyDrop<NpmInfo>` over an arena-owned linked list), so reading the
     // "wrong" variant is not UB — it yields garbage. `_mut` variants let the
-    // handful of mutate-in-place call sites (`runTasks.rs` package-name
+    // handful of mutate-in-place call sites (`run_tasks.rs` package-name
     // back-patching, `Package.rs` workspace resolution) write through the
     // active arm without an `unsafe` block apiece.
     bun_core::extern_union_accessors! {
@@ -790,7 +796,7 @@ macro_rules! negatable_names {
 
 /// https://nodejs.org/api/os.html#osplatform
 #[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct OperatingSystem(pub u16);
 
 impl OperatingSystem {
@@ -859,7 +865,7 @@ negatable_names! { OperatingSystem: u16, OPERATING_SYSTEM_NAMES => [
 // ──────────────────────────────────────────────────────────────────────────
 
 #[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct Libc(pub u8);
 
 impl Libc {
@@ -886,7 +892,7 @@ negatable_names! { Libc: u8, LIBC_NAMES => [ b"musl" => MUSL, b"glibc" => GLIBC 
 /// https://docs.npmjs.com/cli/v8/configuring-npm/package-json#cpu
 /// https://nodejs.org/api/os.html#osarch
 #[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct Architecture(pub u16);
 
 impl Architecture {
@@ -959,7 +965,7 @@ negatable_names! { Architecture: u16, ARCHITECTURE_NAMES => [
 // name a real type instead of an opaque blob.
 
 #[repr(C)]
-#[derive(Copy, Default)]
+#[derive(Copy, Default, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct Repository {
     pub owner: SemverString,
     pub repo: SemverString,
@@ -1044,6 +1050,20 @@ pub struct VersionedURLType<SemverInt: bun_semver::version::VersionInt> {
     pub version: bun_semver::VersionType<SemverInt>,
 }
 
+// SAFETY: `repr(C)`; `url` is 8 bytes (align 1) followed directly by the
+// 8-aligned `VersionType`, so there is no padding, and both fields are `Pod`.
+unsafe impl<I: bun_semver::version::VersionInt> bytemuck::Zeroable for VersionedURLType<I> {}
+// SAFETY: as above.
+unsafe impl<I: bun_semver::version::VersionInt> bytemuck::Pod for VersionedURLType<I> {}
+const _: () = assert!(
+    core::mem::size_of::<VersionedURLType<u64>>()
+        == 8 + core::mem::size_of::<bun_semver::VersionType<u64>>()
+);
+const _: () = assert!(
+    core::mem::size_of::<VersionedURLType<u32>>()
+        == 8 + core::mem::size_of::<bun_semver::VersionType<u32>>()
+);
+
 // Manual `Copy`/`Clone` so the inherent buffer-relative `clone(&self, buf,
 // builder)` below does not collide with a derived `clone(&self)` at
 // method-resolution time, and to avoid the spurious `SemverInt: Copy` bound
@@ -1119,31 +1139,114 @@ pub enum ResolutionTag {
     SingleFileModule = 100,
 }
 
-/// Every
-/// payload is `()`, a `Semver.String` handle, a [`Repository`], or a
-/// [`VersionedURLType`] — all lower-tier `bun_semver` data, so the real union
-/// lives here (not an opaque `[u64; N]`). `bun_install::resolution` re-exports
-/// this and wraps it with constructors/formatters.
+/// The resolution payload: `()`, a `Semver.String` handle, a [`Repository`],
+/// or a [`VersionedURLType`], overlaid on zeroed storage the size of the
+/// largest. Which view is live is the enclosing resolution's tag; every view
+/// is plain data, so reading the wrong one is garbage, not UB.
+/// `bun_install::resolution` re-exports this and wraps it with
+/// constructors/formatters.
 #[repr(C)]
-#[derive(Clone, Copy)]
-pub union ResolutionValue<I: VersionInt> {
-    pub uninitialized: (),
-    pub root: (),
-    pub npm: VersionedURLType<I>,
-    pub folder: SemverString,
-    pub local_tarball: SemverString,
-    pub github: Repository,
-    pub git: Repository,
-    pub symlink: SemverString,
-    pub workspace: SemverString,
-    pub remote_tarball: SemverString,
-    pub single_file_module: SemverString,
+pub struct ResolutionValue<I: VersionInt> {
+    words: I::ResolutionStorage,
 }
+
+impl<I: VersionInt> Clone for ResolutionValue<I> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<I: VersionInt> Copy for ResolutionValue<I> {}
+
+// SAFETY: a single `repr(C)` field that is itself `Pod`.
+unsafe impl<I: VersionInt> bytemuck::Zeroable for ResolutionValue<I> {}
+// SAFETY: as above.
+unsafe impl<I: VersionInt> bytemuck::Pod for ResolutionValue<I> {}
 
 impl<I: VersionInt> Default for ResolutionValue<I> {
     #[inline]
     fn default() -> Self {
-        ResolutionValue { uninitialized: () }
+        Self::ZEROED
+    }
+}
+
+const _: () = assert!(core::mem::size_of::<ResolutionValue<u64>>() == 64);
+const _: () = assert!(core::mem::size_of::<ResolutionValue<u32>>() == 56);
+const _: () = assert!(core::mem::size_of::<VersionedURLType<u64>>() == 64);
+const _: () = assert!(core::mem::size_of::<VersionedURLType<u32>>() == 56);
+const _: () = assert!(core::mem::size_of::<Repository>() <= 56);
+
+impl<I: VersionInt> ResolutionValue<I> {
+    pub const ZEROED: Self = Self {
+        words: I::RESOLUTION_STORAGE_ZERO,
+    };
+
+    #[inline]
+    fn view<T: bytemuck::Pod>(&self) -> &T {
+        bytemuck::from_bytes(&bytemuck::bytes_of(&self.words)[..core::mem::size_of::<T>()])
+    }
+    #[inline]
+    fn view_mut<T: bytemuck::Pod>(&mut self) -> &mut T {
+        bytemuck::from_bytes_mut(
+            &mut bytemuck::bytes_of_mut(&mut self.words)[..core::mem::size_of::<T>()],
+        )
+    }
+    /// Zeroed storage holding `value` (so the bytes past it are deterministic).
+    #[inline]
+    fn holding<T: bytemuck::NoUninit>(value: &T) -> Self {
+        let mut this = Self::ZEROED;
+        let bytes = bytemuck::bytes_of(value);
+        bytemuck::bytes_of_mut(&mut this.words)[..bytes.len()].copy_from_slice(bytes);
+        this
+    }
+
+    #[inline]
+    pub fn uninitialized() -> Self {
+        Self::ZEROED
+    }
+    #[inline]
+    pub fn root() -> Self {
+        Self::ZEROED
+    }
+    #[inline]
+    pub fn from_npm(v: &VersionedURLType<I>) -> Self {
+        Self::holding(v)
+    }
+    #[inline]
+    pub fn from_repository(v: &Repository) -> Self {
+        Self::holding(v)
+    }
+    #[inline]
+    pub fn from_string(v: SemverString) -> Self {
+        Self::holding(&v)
+    }
+
+    #[inline]
+    pub fn npm(&self) -> &VersionedURLType<I> {
+        self.view()
+    }
+    #[inline]
+    pub fn npm_mut(&mut self) -> &mut VersionedURLType<I> {
+        self.view_mut()
+    }
+    /// The `git` / `github` view.
+    #[inline]
+    pub fn repository(&self) -> &Repository {
+        self.view()
+    }
+    #[inline]
+    pub fn repository_mut(&mut self) -> &mut Repository {
+        self.view_mut()
+    }
+    /// The `folder` / `local_tarball` / `symlink` / `workspace` /
+    /// `remote_tarball` / `single_file_module` view.
+    #[inline]
+    pub fn string(&self) -> &SemverString {
+        self.view()
+    }
+    #[inline]
+    pub fn string_mut(&mut self) -> &mut SemverString {
+        self.view_mut()
     }
 }
 
@@ -1163,7 +1266,7 @@ impl Default for Resolution {
         Self {
             tag: ResolutionTag::Uninitialized,
             _padding: [0; 7],
-            value: ResolutionValue { uninitialized: () },
+            value: ResolutionValue::ZEROED,
         }
     }
 }
@@ -1281,39 +1384,63 @@ pub struct TaskCallbackContext {
 /// loop when a network task completes. The resolver only stores and forwards
 /// it; the fields are `Option` so `Default` is all-None.
 ///
-/// `handler`'s second parameter (`*PackageManager`) is erased to
-/// `*mut c_void` because that concrete type lives in `bun_install` (a higher
-/// tier); `bun_install::PackageManager::wake` casts at the call site.
+/// `handler`'s second parameter (historically `*PackageManager`) is an
+/// opaque `*mut c_void`; `bun_install` passes null and the runtime's handler
+/// ignores it.
 /// `on_dependency_error`'s `Dependency` parameter is *not* erased — the type
 /// lives in this crate — so callers pass the borrow directly.
 // Clone: bitwise OK — `context` is a non-owning opaque backref the runtime
 // installed; the handler fn-ptrs are POD.
 #[derive(Default, Copy, Clone)]
 pub struct WakeHandler {
-    pub context: Option<NonNull<c_void>>,
-    pub handler: Option<fn(*mut c_void, *mut c_void)>,
-    pub on_dependency_error:
-        Option<unsafe fn(*mut c_void, &Dependency, DependencyID, &'static str)>,
+    context: Option<NonNull<c_void>>,
+    handler: Option<fn(*mut c_void, *mut c_void)>,
+    on_dependency_error: Option<fn(*mut c_void, &Dependency, DependencyID, &'static str)>,
 }
 
+// SAFETY: `context` is an opaque token that only `handler` /
+// `on_dependency_error` interpret, and `new`'s contract makes those callable
+// with it from any thread.
+unsafe impl Send for WakeHandler {}
+// SAFETY: as above; the struct is read-only once installed.
+unsafe impl Sync for WakeHandler {}
+
 impl WakeHandler {
-    #[inline]
-    pub fn get_handler(&self) -> fn(*mut c_void, *mut c_void) {
-        // `handler` is Some whenever `context` is Some: the sole installer
-        // (runtime::jsc_hooks) sets `context`, `handler`, and
-        // `on_dependency_error` together in one struct literal, and callers
-        // gate on `context.is_some()` before invoking — so this unwrap cannot
-        // fire.
-        self.handler.unwrap()
+    /// # Safety
+    /// `handler(context, _)` may be called from any thread (install workers,
+    /// the HTTP thread) and `on_dependency_error(context, ..)` from the thread
+    /// that drives the package manager, for as long as this handler is
+    /// installed; `context` must stay valid for both.
+    pub const unsafe fn new(
+        context: NonNull<c_void>,
+        handler: fn(*mut c_void, *mut c_void),
+        on_dependency_error: fn(*mut c_void, &Dependency, DependencyID, &'static str),
+    ) -> Self {
+        Self {
+            context: Some(context),
+            handler: Some(handler),
+            on_dependency_error: Some(on_dependency_error),
+        }
     }
 
+    /// Nudge the runtime that installed this handler (no-op when none did).
+    /// `manager` is the erased `*mut PackageManager` the handler signature
+    /// carries; the runtime handler ignores it.
     #[inline]
-    pub fn get_on_dependency_error(
-        &self,
-    ) -> unsafe fn(*mut c_void, &Dependency, DependencyID, &'static str) {
-        // Same invariant as `get_handler`: set together with `context` by the
-        // sole installer; callers gate on `context.is_some()`.
-        self.on_dependency_error.unwrap()
+    pub fn wake(&self, manager: *mut c_void) {
+        // `handler` is Some whenever `context` is Some: the sole installer
+        // (runtime::jsc_hooks) sets all three fields together.
+        if let (Some(ctx), Some(handler)) = (self.context, self.handler) {
+            handler(ctx.as_ptr(), manager);
+        }
+    }
+
+    /// Report a root dependency that failed to resolve to the runtime, if any.
+    #[inline]
+    pub fn dependency_error(&self, dep: &Dependency, id: DependencyID, err: &'static str) {
+        if let (Some(ctx), Some(f)) = (self.context, self.on_dependency_error) {
+            f(ctx.as_ptr(), dep, id, err);
+        }
     }
 }
 
@@ -1438,7 +1565,7 @@ pub trait AutoInstaller {
     ) -> core::result::Result<DependencyID, bun_core::Error>;
 
     // ── Lockfile writes ───────────────────────────────────────────────────
-    /// Port of `lockfile.appendPackage(Package.fromPackageJSON(...))` —
+    /// `lockfile.append_package(Package::parse(<package.json>))` —
     /// collapsed because `Package` itself is install-internal. Returns the
     /// id assigned to the appended package.
     fn lockfile_append_from_package_json(
@@ -1464,7 +1591,6 @@ pub trait AutoInstaller {
         package_id: PackageID,
         resolution: &Resolution,
         ctx: TaskCallbackContext,
-        patch_name_and_version_hash: Option<u64>,
     ) -> core::result::Result<(), bun_core::Error>;
     fn resolve_from_disk_cache(
         &mut self,

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -210,42 +210,50 @@ use bun_install::{self as install, LogLevel, PackageID};
 
 use crate::event_loop::{ConcurrentTaskItem, Task};
 
-/// `RunTasksCallbacks` impl for the auto-install module queue. `onResolve` /
+/// `RunTasksCtx` for the auto-install module queue. `onResolve` /
 /// `onPackageManifestError` / `onPackageDownloadError` forward to the `Queue`
-/// methods, `progress_bar` selected via const generic to match the
-/// `enable_ansi_colors_stderr` branch.
-struct QueueRunTasksCallbacks<const PROGRESS: bool>;
+/// methods; `progress_bar` matches the `enable_ansi_colors_stderr` branch.
+struct QueueRunTasks<'a> {
+    manager: &'a mut bun_install::PackageManager,
+    queue: &'a mut Queue,
+    progress_bar: bool,
+}
 
-impl<const PROGRESS: bool> run_tasks::RunTasksCallbacks for QueueRunTasksCallbacks<PROGRESS> {
-    type Ctx = Queue;
-
-    const PROGRESS_BAR: bool = PROGRESS;
-    const HAS_ON_PACKAGE_MANIFEST_ERROR: bool = true;
-    const HAS_ON_PACKAGE_DOWNLOAD_ERROR: bool = true;
-    const HAS_ON_RESOLVE: bool = true;
-
-    fn on_resolve(ctx: &mut Queue) {
-        Queue::on_resolve(ctx)
+impl run_tasks::RunTasksCtx for QueueRunTasks<'_> {
+    fn manager(&mut self) -> &mut bun_install::PackageManager {
+        self.manager
+    }
+    fn progress_bar(&self) -> bool {
+        self.progress_bar
+    }
+    fn has_on_package_manifest_error(&self) -> bool {
+        true
+    }
+    fn has_on_package_download_error(&self) -> bool {
+        true
+    }
+    fn has_on_resolve(&self) -> bool {
+        true
     }
 
-    fn on_package_manifest_error(
-        ctx: &mut Queue,
-        name: &[u8],
-        err: bun_install::Error,
-        url: &[u8],
-    ) {
-        ctx.on_package_manifest_error(name, err.name(), url)
+    fn on_resolve(&mut self) {
+        Queue::on_resolve(self.queue)
+    }
+
+    fn on_package_manifest_error(&mut self, name: &[u8], err: bun_install::Error, url: &[u8]) {
+        self.queue.on_package_manifest_error(name, err.name(), url)
     }
 
     fn on_package_download_error_pkg(
-        ctx: &mut Queue,
+        &mut self,
         package_id: PackageID,
         name: &[u8],
         resolution: &Resolution,
         err: bun_install::Error,
         url: &[u8],
     ) {
-        ctx.on_package_download_error(package_id, name, resolution, err.name(), url)
+        self.queue
+            .on_package_download_error(package_id, name, resolution, err.name(), url)
     }
 }
 
@@ -260,6 +268,12 @@ impl Queue {
         // allocator arg dropped (Vec uses global mimalloc).
         self.map.push(module);
         self.vm().package_manager().drain_dependency_list();
+        if let Some(log) = VirtualMachine::get().log_mut() {
+            VirtualMachine::get()
+                .as_mut()
+                .package_manager()
+                .take_log_into(log);
+        }
     }
 
     /// # Safety
@@ -314,7 +328,7 @@ impl Queue {
     }
 
     /// `WakeHandler::handler` — runs on install / HTTP-callback threads
-    /// (`PackageManager::wake_raw`). `ctx` is the [`WakeContext`] registered in
+    /// (`PackageManager`'s `Shared::wake`). `ctx` is the [`WakeContext`] registered in
     /// `runtime/jsc_hooks.rs`; the VM is reached only through its handle.
     pub fn on_wake_handler(ctx: *mut c_void, _: *mut c_void) {
         bun_core::scoped_log!(AsyncModule, "onWake");
@@ -352,18 +366,30 @@ impl Queue {
         // `container_of`-derived `*mut` reborrow.
         let pm = VirtualMachine::get().as_mut().package_manager();
 
-        if bun_core::output::enable_ansi_colors_stderr() {
+        let progress_bar = bun_core::output::enable_ansi_colors_stderr();
+        if progress_bar {
             pm.start_progress_bar_if_none();
-            run_tasks::run_tasks::<QueueRunTasksCallbacks<true>>(pm, self, true, LogLevel::Default)
-                .expect("unreachable");
-        } else {
-            run_tasks::run_tasks::<QueueRunTasksCallbacks<false>>(
-                pm,
-                self,
-                true,
-                LogLevel::DefaultNoProgress,
-            )
-            .expect("unreachable");
+        }
+        let mut ctx = QueueRunTasks {
+            manager: pm,
+            queue: self,
+            progress_bar,
+        };
+        run_tasks::run_tasks(
+            &mut ctx,
+            true,
+            if progress_bar {
+                LogLevel::Default
+            } else {
+                LogLevel::DefaultNoProgress
+            },
+        )
+        .expect("unreachable");
+        if let Some(log) = VirtualMachine::get().log_mut() {
+            VirtualMachine::get()
+                .as_mut()
+                .package_manager()
+                .take_log_into(log);
         }
     }
 
@@ -463,7 +489,7 @@ impl Queue {
         // `container_of`-derived `*mut` reborrow. The package manager is a
         // separate heap allocation, disjoint from `self` (= `vm.modules`).
         let pm = VirtualMachine::get().as_mut().package_manager();
-        if pm.pending_tasks.load(Ordering::Relaxed) > 0 {
+        if pm.shared.pending_tasks.load(Ordering::Relaxed) > 0 {
             return;
         }
 
@@ -1079,12 +1105,16 @@ impl AsyncModule {
 
         let log_nn = core::ptr::NonNull::new(log).expect("AsyncModule log is non-null");
         let log_ptr: *mut bun_ast::Log = log;
-        // SAFETY: see above — single-thread VM; raw-ptr field stores.
+        // SAFETY: see above — single-thread VM; raw-ptr field stores. The
+        // package manager keeps its own log; route what it has so far to the
+        // VM log and what it logs during the link to this module's log.
         unsafe {
             (*jsc_vm).transpiler.linker.log = log_ptr;
             (*jsc_vm).transpiler.log = log_ptr;
             (*jsc_vm).transpiler.resolver.log = log_nn;
-            (*jsc_vm).package_manager().log = log_ptr;
+            (*jsc_vm)
+                .package_manager()
+                .take_log_into(&mut *old_log.as_ptr());
         }
         let _restore = scopeguard::guard((jsc_vm, old_log), |(jsc_vm, old_log)| {
             // SAFETY: same per-thread VM; restoring the original log pointers
@@ -1094,7 +1124,7 @@ impl AsyncModule {
                 (*jsc_vm).transpiler.linker.log = old_log_ptr;
                 (*jsc_vm).transpiler.log = old_log_ptr;
                 (*jsc_vm).transpiler.resolver.log = old_log;
-                (*jsc_vm).package_manager().log = old_log_ptr;
+                (*jsc_vm).package_manager().take_log_into(&mut *log_ptr);
             }
         });
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4744,9 +4744,15 @@ impl VirtualMachine {
         jsc_vm.transpiler.resolver.log = NonNull::from(&mut log);
         jsc_vm.transpiler.linker.log = &raw mut log;
         if let Some(pm) = jsc_vm.transpiler.resolver.package_manager {
+            // The package manager keeps its own log; route what it has so far
+            // to the VM log and (below) what it logs during `_resolve` to `log`.
             // SAFETY: the `dyn AutoInstaller` is always `PackageManager`
-            // (sole impl — see `VirtualMachine::package_manager`).
-            unsafe { (*pm.cast::<bun_install::PackageManager>().as_ptr()).log = &raw mut log };
+            // (sole impl — see `VirtualMachine::package_manager`); `old_log`
+            // is the live VM log.
+            unsafe {
+                (*pm.cast::<bun_install::PackageManager>().as_ptr())
+                    .take_log_into(&mut *old_log.as_ptr())
+            };
         }
         // Note: the restore must fire on every exit
         // (including `?` from `ResolveMessage::create` below), so the VM's
@@ -4768,16 +4774,6 @@ impl VirtualMachine {
                 jsc_vm.transpiler.log = self.old_transpiler_log;
                 jsc_vm.transpiler.resolver.log = self.old_log;
                 jsc_vm.transpiler.linker.log = self.old_log.as_ptr();
-                // `_resolve` may have lazily created the PM with
-                // `pm.log = resolver.log` (our stack `log`), so restore even
-                // if it was `None` when we swapped.
-                if let Some(pm) = jsc_vm.transpiler.resolver.package_manager {
-                    // SAFETY: sole `dyn AutoInstaller` impl is `PackageManager`.
-                    unsafe {
-                        (*pm.cast::<bun_install::PackageManager>().as_ptr()).log =
-                            self.old_log.as_ptr();
-                    }
-                }
             }
         }
         let _restore = RestoreLog {
@@ -4797,6 +4793,11 @@ impl VirtualMachine {
             mode.is_esm(),
             IS_A_FILE_PATH,
         );
+        // `_resolve` may have lazily created the PM, so check again.
+        if let Some(pm) = jsc_vm.transpiler.resolver.package_manager {
+            // SAFETY: sole `dyn AutoInstaller` impl is `PackageManager`.
+            unsafe { (*pm.cast::<bun_install::PackageManager>().as_ptr()).take_log_into(&mut log) };
+        }
         if let Err(err_) = resolve_result {
             let err = err_;
             let import_kind = mode.import_kind();

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -895,10 +895,210 @@ pub mod lib {
         }
     }
 
-    // ── Archive::Iterator ──────────────────────────────────────────────────
-    // Thin
-    // wrapper that opens a tarball from memory and yields one
-    // `IteratorEntry` per `next()`, used by `bun publish <tarball>`.
+    // ── StreamingArchive ───────────────────────────────────────────────────
+    // A gzip+tar read archive fed incrementally by a caller-supplied source
+    // (`archive_read_open` with a read callback). With the resumable
+    // ARCHIVE_RETRY patches in vendor/libarchive, `next_header` / `next_block`
+    // return `Retry` when the source has no bytes yet and can be called again
+    // once it does.
+
+    /// What a [`StreamSource`] has for libarchive right now.
+    pub enum StreamRead<'a> {
+        /// The next bytes (see the trait's contract for how long they live).
+        Data(&'a [u8]),
+        /// Nothing yet; more will come.
+        Retry,
+        /// The input is complete.
+        Eof,
+    }
+
+    /// The input side of a [`StreamingArchive`].
+    ///
+    /// # Safety
+    /// libarchive keeps reading the bytes a [`StreamRead::Data`] returned
+    /// after `read` returns — until the next `read` call or until the
+    /// archive is dropped. The implementor must keep them allocated and
+    /// unchanged for that long, including across whatever it does to itself
+    /// through [`StreamingArchive::source_mut`]. Implement through
+    /// [`stream_source!`](crate::stream_source), which states this at the type.
+    pub unsafe trait StreamSource {
+        fn read(&mut self) -> StreamRead<'_>;
+    }
+
+    /// Implements [`StreamSource`] by forwarding to an inherent
+    /// `fn read_for_archive(&mut self) -> StreamRead<'_>`; the type keeps the
+    /// bytes it hands out alive and unchanged until its next
+    /// `read_for_archive` (the trait's contract).
+    #[macro_export]
+    macro_rules! stream_source {
+        ($ty:ty) => {
+            // SAFETY: see the macro doc — the type upholds the `StreamSource` contract.
+            unsafe impl $crate::lib::StreamSource for $ty {
+                #[inline]
+                fn read(&mut self) -> $crate::lib::StreamRead<'_> {
+                    <$ty>::read_for_archive(self)
+                }
+            }
+        };
+    }
+
+    /// What [`StreamingArchive::next_header`] found.
+    pub enum Header<'a> {
+        Entry(&'a mut Entry),
+        /// Out of input for now (see [`StreamRead::Retry`]).
+        Retry,
+        Eof,
+        Failed,
+    }
+
+    /// A read archive whose bytes come from `S`.
+    pub struct StreamingArchive<S: StreamSource> {
+        archive: core::mem::ManuallyDrop<ReadArchive>,
+        /// libarchive's `client_data`: a `Box<S>` we own through this
+        /// pointer (freed in `Drop`) so libarchive's copy stays valid.
+        source: core::ptr::NonNull<S>,
+    }
+
+    impl<S: StreamSource> Drop for StreamingArchive<S> {
+        fn drop(&mut self) {
+            // Close the archive first: it may still read from the source.
+            // SAFETY: dropped exactly once, here; not used afterwards.
+            unsafe { core::mem::ManuallyDrop::drop(&mut self.archive) };
+            // SAFETY: `source` is the `Box::into_raw` from `open_gzip_tar`,
+            // owned by us and no longer referenced by libarchive.
+            drop(unsafe { Box::from_raw(self.source.as_ptr()) });
+        }
+    }
+
+    impl<S: StreamSource> StreamingArchive<S> {
+        /// Open a gzip-compressed tar stream over `source`. On failure the
+        /// error string is returned with the source.
+        pub fn open_gzip_tar(source: S) -> core::result::Result<Self, (S, Vec<u8>)> {
+            let archive = ReadArchive::new();
+            let source = Box::new(source);
+            // Bypass bidding entirely: the stream is always gzip → tar, and
+            // bidding would try to read-ahead before any bytes have arrived.
+            // With patches/libarchive/select-registered-only.patch,
+            // archive_read_append_filter / archive_read_set_format only select a
+            // filter/format that was already registered, so register gzip and tar
+            // first. Tar must also be registered before read_set_options (so the
+            // option has a slot) and set_format must come after it: libarchive's
+            // archive_set_format_option() clobbers `a->format` while dispatching,
+            // and losing the selected format means archive_read_open1() falls
+            // back to bidding, which fails when the first chunk is short.
+            // ARCHIVE_FILTER_GZIP = 1, ARCHIVE_FORMAT_TAR = 0x30000.
+            let _ = archive.read_support_filter_gzip();
+            // SAFETY: `archive` is a live handle.
+            if unsafe { archive_read_append_filter(archive.as_mut_ptr(), 1) } != 0 {
+                let err = archive.error_string().to_vec();
+                return Err((*source, err));
+            }
+            let _ = archive.read_support_format_tar();
+            let _ = archive.read_set_options(c"read_concatenated_archives");
+            // SAFETY: `archive` is a live handle.
+            if unsafe { archive_read_set_format(archive.as_mut_ptr(), 0x30000) } != 0 {
+                let err = archive.error_string().to_vec();
+                return Err((*source, err));
+            }
+            let client_data: *mut S = Box::into_raw(source);
+            // SAFETY: `archive` is live; `client_data` is the boxed source,
+            // which `Self` owns (see `Drop`) for as long as the archive, and
+            // `stream_read_callback::<S>` casts it back to `S`.
+            let rc = unsafe {
+                archive_read_open(
+                    archive.as_mut_ptr(),
+                    client_data.cast::<c_void>(),
+                    None,
+                    Some(stream_read_callback::<S>),
+                    None,
+                )
+            };
+            // SAFETY: just leaked above; non-null.
+            let source = unsafe { core::ptr::NonNull::new_unchecked(client_data) };
+            // open() runs the filter bidder which we bypassed, but the client
+            // open path may still probe; treat ARCHIVE_RETRY as transient.
+            if rc == Result::Ok as c_int
+                || rc == Result::Warn as c_int
+                || rc == Result::Retry as c_int
+            {
+                Ok(Self {
+                    archive: core::mem::ManuallyDrop::new(archive),
+                    source,
+                })
+            } else {
+                let err = archive.error_string().to_vec();
+                drop(archive);
+                // SAFETY: the archive is closed, so nothing else refers to the box.
+                Err((*unsafe { Box::from_raw(source.as_ptr()) }, err))
+            }
+        }
+
+        #[inline]
+        pub fn source(&self) -> &S {
+            // SAFETY: we own the box; libarchive only touches it from inside
+            // our `&mut self` methods.
+            unsafe { self.source.as_ref() }
+        }
+        /// Not callable from inside [`StreamSource::read`] (libarchive holds
+        /// the source then); `&mut self` rules that out.
+        #[inline]
+        pub fn source_mut(&mut self) -> &mut S {
+            // SAFETY: as for `source`; `&mut self` makes this the only borrow.
+            unsafe { self.source.as_mut() }
+        }
+
+        /// `archive_read_next_header`. The entry is libarchive's and stays
+        /// valid until the next call on `self`.
+        pub fn next_header(&mut self) -> (Result, Header<'_>) {
+            let mut entry: *mut Entry = core::ptr::null_mut();
+            let r = self.archive.read_next_header(&mut entry);
+            let header = match r {
+                Result::Retry => Header::Retry,
+                Result::Eof => Header::Eof,
+                // SAFETY: on OK/WARN libarchive returns a valid entry owned by
+                // the archive, live until the next `read_next_header`; `&mut
+                // self` keeps any other borrow of it from existing.
+                Result::Ok | Result::Warn => Header::Entry(unsafe { &mut *entry }),
+                Result::Failed | Result::Fatal => Header::Failed,
+            };
+            (r, header)
+        }
+
+        /// `archive_read_data_block` for the current entry; `None` at its end.
+        #[inline]
+        pub fn next_block(&mut self, offset: &mut i64) -> Option<Block<'_>> {
+            self.archive.next(offset)
+        }
+
+        #[inline]
+        pub fn error_string(&self) -> &[u8] {
+            self.archive.error_string()
+        }
+    }
+
+    extern "C" fn stream_read_callback<S: StreamSource>(
+        _a: *mut Archive,
+        ctx: *mut c_void,
+        out_buffer: *mut *const c_void,
+    ) -> la_ssize_t {
+        // SAFETY: `ctx` is the boxed `S` registered in `open_gzip_tar`; libarchive
+        // calls this from inside a `&mut StreamingArchive<S>` method, so no other
+        // borrow of the source is live.
+        let source = unsafe { &mut *ctx.cast::<S>() };
+        match source.read() {
+            StreamRead::Data(bytes) => {
+                // SAFETY: `out_buffer` is libarchive's out-parameter.
+                unsafe { *out_buffer = bytes.as_ptr().cast() };
+                la_ssize_t::try_from(bytes.len()).expect("int cast")
+            }
+            StreamRead::Retry => Result::Retry as la_ssize_t,
+            StreamRead::Eof => {
+                // SAFETY: as above; the pointer is not read for a length of 0.
+                unsafe { *out_buffer = ctx.cast_const() };
+                0
+            }
+        }
+    }
 }
 
 use lib::Archive;

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -1172,6 +1172,15 @@ pub struct Pipe {
     pipe: pipe_u,
 }
 
+/// `uv_pipe`: a connected pipe pair `[read, write]` with the given
+/// `UV_NONBLOCK_PIPE`-style flags per end.
+pub fn pipe_pair(read_flags: c_int, write_flags: c_int) -> Result<[uv_file; 2], ReturnCode> {
+    let mut fds: [uv_file; 2] = [0; 2];
+    // SAFETY: `fds` is the 2-element out-array `uv_pipe` writes.
+    let rc = unsafe { uv_pipe(&mut fds, read_flags, write_flags) };
+    if rc.0 == 0 { Ok(fds) } else { Err(rc) }
+}
+
 impl Pipe {
     #[inline]
     pub fn ipc_remote_pid(&self) -> DWORD {

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -162,6 +162,19 @@ impl ContextData {
         unsafe { &mut *self.log }
     }
 
+    /// Exclusive access to the log through exclusive access to the context.
+    #[track_caller]
+    #[inline]
+    pub fn log_mut_checked(&mut self) -> &mut bun_ast::Log {
+        assert!(
+            !self.log.is_null(),
+            "ContextData::log_mut_checked() before create_context_data()"
+        );
+        // SAFETY: non-null (asserted), points at the process-static log or
+        // the package manager's; `&mut self` is the only path to it here.
+        unsafe { &mut *self.log }
+    }
+
     /// Shared-ref counterpart of [`log_mut`] for read-only inspection
     /// (`has_errors()`, `print()`).
     #[track_caller]

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -51,7 +51,8 @@ pub use tsconfig_json::TSConfigJSON;
 /// Re-export so dependents can spell `bun_resolver::install_types::AutoInstaller`.
 pub use ::bun_install_types::resolver_hooks as install_types;
 pub use resolver::{
-    AnyResolveWatcher, BrowserMapPathKind, Bufs, Dirname, Resolver, module_type_from_ext,
+    AnyResolveWatcher, AutoInstallerFactory, BrowserMapPathKind, Bufs, Dirname, Resolver,
+    module_type_from_ext, set_auto_installer_factory,
 };
 pub use result::{
     DebugLogs, DirEntryResolveQueueItem, ExternalKind, FlushMode, LoadResult, MatchResult,

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -20,23 +20,27 @@ use ::bun_install_types::resolver_hooks as Install;
 use ::bun_install_types::resolver_hooks::{AutoInstaller, Resolution};
 use ::bun_semver as Semver;
 
-// LAYERING: `PackageManager.initWithRuntime` lives in
-// `bun_install`, which depends on this crate. The lazy-init body is defined
-// `#[no_mangle]` in `bun_install::auto_installer` and resolved at link time
-// (same pattern as `__bun_regex_*` / `__BUN_RUNTIME_HOOKS`). `install` is the
-// `?*Api.BunInstall` (`self.opts.install`); `env` is the `*DotEnv.Loader`.
-unsafe extern "Rust" {
-    /// SAFETY (genuine FFI precondition — NOT a `safe fn` candidate): impl
-    /// reborrows `&mut *log` / `&mut *env` and reads `*install` if non-null.
-    /// All three must point at process-lifetime Transpiler-owned storage; the
-    /// returned `NonNull` names the `'static` `PackageManager` singleton.
-    /// Errs when the one-time init fails (e.g. the top-level directory is
-    /// unreadable); the failure is sticky across calls.
-    fn __bun_resolver_init_package_manager(
-        log: NonNull<bun_ast::Log>,
-        install: Option<NonNull<bun_options_types::schema::api::BunInstall>>,
-        env: NonNull<bun_dotenv::Loader>,
+// LAYERING: `PackageManager::init_with_runtime` lives in `bun_install`, which
+// depends on this crate, so the runtime registers it here at startup
+// ([`set_auto_installer_factory`]). `install` is the `?*Api.BunInstall`
+// (`self.opts.install`); `env` is the `*DotEnv.Loader`.
+/// Returns the process-wide auto-install package manager, creating it on the
+/// first call from any resolver. A failed first attempt is remembered and
+/// returned to every later caller (e.g. the top-level directory is unreadable).
+pub type AutoInstallerFactory =
+    fn(
+        log: &mut bun_ast::Log,
+        install: Option<&bun_options_types::schema::api::BunInstall>,
+        env: &mut bun_dotenv::Loader,
     ) -> core::result::Result<NonNull<dyn AutoInstaller>, bun_errno::SystemErrno>;
+
+static AUTO_INSTALLER_FACTORY: std::sync::OnceLock<AutoInstallerFactory> =
+    std::sync::OnceLock::new();
+
+/// Register the auto-installer factory (the runtime does this once at startup
+/// with `bun_install`'s).
+pub fn set_auto_installer_factory(factory: AutoInstallerFactory) {
+    let _ = AUTO_INSTALLER_FACTORY.set(factory);
 }
 use crate::cache::Set as CacheSet;
 use ::bun_resolve_builtins::{Alias as HardcodedAlias, Cfg as HardcodedAliasCfg};
@@ -496,8 +500,8 @@ pub struct Resolver<'a> {
     /// [`AutoInstaller`]; the resolver only sees the trait object so it stays
     /// below `bun_install` in the dep graph. `None` until the auto-install
     /// path is first reached: [`get_package_manager`] then initializes the
-    /// singleton through the link-time `__bun_resolver_init_package_manager`
-    /// factory and caches the pointer here. A failed init (e.g. unreadable
+    /// singleton through the registered [`AutoInstallerFactory`] and caches
+    /// the pointer here. A failed init (e.g. unreadable
     /// top-level directory) is returned as an error and leaves this `None`.
     pub package_manager: Option<NonNull<dyn AutoInstaller>>,
     pub on_wake_package_manager: Install::WakeHandler,
@@ -808,20 +812,16 @@ impl<'a> Resolver<'a> {
         unsafe { &mut *self.dir_cache }
     }
 
-    /// Lazily initializing
-    /// `PackageManager.initWithRuntime` here directly would
-    /// be a `bun_resolver → bun_install` cycle, so the lazy init is
-    /// dispatched through the link-time `extern "Rust"` factory
-    /// [`__bun_resolver_init_package_manager`] (defined `#[no_mangle]` in
-    /// `bun_install::auto_installer`). The factory performs
-    /// `HTTPThread.init` + `PackageManager.initWithRuntime` and returns the
-    /// process-static singleton as a `dyn AutoInstaller`. We then wire
-    /// `on_wake` and cache the pointer. Reached from
-    /// the auto-install path (`load_node_modules` global-cache block) when
-    /// [`use_package_manager`] is `true`. Errs (without caching, but sticky
-    /// inside the factory) when the one-time init fails, e.g. the top-level
-    /// directory was deleted or is unreadable — callers surface that as a
-    /// resolve failure rather than panicking.
+    /// The process-wide auto-install package manager, through the registered
+    /// [`AutoInstallerFactory`] (`bun_install::auto_installer::init_for_resolver`,
+    /// which creates it once per process and hands every resolver the same
+    /// one; naming `PackageManager` here would be a `bun_resolver →
+    /// bun_install` cycle). This resolver's `on_wake` is installed and the
+    /// pointer cached per resolver. Reached from the auto-install path
+    /// (`load_node_modules` global-cache block) when [`use_package_manager`]
+    /// is `true`. A failed first init (e.g. the top-level directory was
+    /// deleted or is unreadable) is sticky: every caller gets the error and
+    /// surfaces it as a resolve failure rather than panicking.
     pub fn get_package_manager(&mut self) -> crate::CrateResult<*mut dyn AutoInstaller> {
         if let Some(pm) = self.package_manager {
             return Ok(pm.as_ptr());
@@ -829,14 +829,23 @@ impl<'a> Resolver<'a> {
         let env: NonNull<DotEnv::Loader> = self
             .env_loader
             .expect("Resolver.env_loader must be set before auto-install");
-        // SAFETY: `__bun_resolver_init_package_manager` is defined
-        // `#[no_mangle]` in `bun_install::auto_installer` and linked into the
-        // final binary; `self.log` / `self.opts.install` / `env` point at
-        // process-lifetime storage (Transpiler-owned). The returned pointer
-        // names the `PackageManager` singleton (`'static`).
-        let pm: NonNull<dyn AutoInstaller> =
-            unsafe { __bun_resolver_init_package_manager(self.log, self.opts.install, env) }?;
-        // SAFETY: `pm` is the just-initialized singleton; sole `&mut` here.
+        let factory = *AUTO_INSTALLER_FACTORY
+            .get()
+            .expect("auto-installer factory registered at startup");
+        let (mut log, mut env) = (self.log, env);
+        // SAFETY: `self.log` / `self.opts.install` / `env` point at
+        // process-lifetime storage (Transpiler-owned) with no other `&mut`
+        // live across this call. The returned pointer names the leaked
+        // `PackageManager` (`'static`).
+        let pm: NonNull<dyn AutoInstaller> = unsafe {
+            factory(
+                log.as_mut(),
+                self.opts.install.map(|p| &*p.as_ptr()),
+                env.as_mut(),
+            )
+        }?;
+        // SAFETY: the leaked process singleton; resolvers run on the thread
+        // that owns it while they hold this borrow.
         unsafe { (*pm.as_ptr()).set_on_wake(self.on_wake_package_manager) };
         self.package_manager = Some(pm);
         Ok(pm.as_ptr())
@@ -848,7 +857,7 @@ impl<'a> Resolver<'a> {
     /// Option<NonNull<dyn AutoInstaller>>` field. The pointee is the
     /// process-static `PackageManager` singleton (set via
     /// [`get_package_manager`](Self::get_package_manager) /
-    /// `__bun_resolver_init_package_manager`), so it strictly outlives the
+    /// the [`AutoInstallerFactory`]), so it strictly outlives the
     /// resolver. `&mut self` ensures the returned `&mut dyn AutoInstaller` is
     /// the only live reference for its lifetime.
     #[inline]
@@ -3080,7 +3089,6 @@ impl<'a> Resolver<'a> {
                                                 resolved_package_id,
                                                 &resolution,
                                                 Install::TaskCallbackContext { root_request_id: 0 },
-                                                None,
                                             )
                                         {
                                             if let Some(d) = self.debug_logs.as_mut() {

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -10,7 +10,7 @@ use bun_install::audit_fix::{self, Advisory};
 use bun_install::lockfile::package::PackageColumns as _;
 use bun_install::lockfile::reachable;
 use bun_install::package_manager_real::command_line_arguments::AuditLevel;
-use bun_install::package_manager_real::{ROOT_PACKAGE_JSON_PATH, install_with_manager};
+use bun_install::package_manager_real::{install_with_manager, root_package_json_path};
 use bun_install::resolution::Tag as ResolutionTag;
 use bun_install::{CommandLineArguments, LogLevel, PackageManager, PackageNameHash, Subcommand};
 use bun_libdeflate_sys::libdeflate;
@@ -280,8 +280,7 @@ impl AuditCommand {
 
         audit_fix::prepare_install(pm, &plan)?;
 
-        // SAFETY: `ROOT_PACKAGE_JSON_PATH` is written exactly once inside `PackageManager::init`; only read thereafter.
-        let root_package_json_path = unsafe { ROOT_PACKAGE_JSON_PATH.read() };
+        let root_package_json_path = root_package_json_path();
         if let Err(e) = install_with_manager(pm, &mut *ctx, root_package_json_path, original_cwd) {
             InstallCommand::handle_error(crate::Error::from(e))?;
             Global::exit(1);

--- a/src/runtime/cli/dedupe_command.rs
+++ b/src/runtime/cli/dedupe_command.rs
@@ -1,6 +1,6 @@
 use bun_core::{Global, Output};
 use bun_install::package_manager_real::{
-    CommandLineArguments, PackageManager, ROOT_PACKAGE_JSON_PATH, Subcommand, install_with_manager,
+    CommandLineArguments, PackageManager, Subcommand, install_with_manager, root_package_json_path,
 };
 
 use crate::Command;
@@ -40,8 +40,7 @@ impl DedupeCommand {
             Output::flush();
         }
 
-        // SAFETY: `ROOT_PACKAGE_JSON_PATH` is written exactly once inside `PackageManager::init` above; only read thereafter.
-        let root_package_json_path = unsafe { ROOT_PACKAGE_JSON_PATH.read() };
+        let root_package_json_path = root_package_json_path();
         if let Err(e) =
             install_with_manager(manager, &mut *ctx, root_package_json_path, &original_cwd)
         {

--- a/src/runtime/cli/install_command.rs
+++ b/src/runtime/cli/install_command.rs
@@ -2,11 +2,11 @@ use crate::Error;
 use bun_bundler::bundle_v2::{DependenciesScanner, DependenciesScannerResult};
 use bun_core::{Global, Output};
 use bun_install::package_manager_real::{
-    CommandLineArguments, PackageManager, ROOT_PACKAGE_JSON_PATH, Subcommand, install_with_manager,
+    CommandLineArguments, PackageManager, Subcommand, install_with_manager, root_package_json_path,
     update_package_json_and_install_with_manager,
 };
 
-use crate::Cli;
+use crate::Command;
 use crate::build_command::BuildCommand;
 use crate::command::ContextData;
 
@@ -32,11 +32,10 @@ impl InstallCommand {
                 bun_install::Error::InstallFailed | bun_install::Error::InvalidPackageJSON
             )
         ) {
-            // SAFETY: `Cli::LOG_` is initialised once during single-threaded
-            // startup in `Cli::start()` before any command (including this
-            // one) is dispatched; no other `&mut` to it is live here.
-            let log = unsafe { (*Cli::LOG_.get()).assume_init_mut() };
-            let _ = log.print(std::ptr::from_mut(Output::error_writer()));
+            // The command context's log (the package manager's, once it is up).
+            let _ = Command::get()
+                .log_ref()
+                .print(std::ptr::from_mut(Output::error_writer()));
             Global::exit(1);
         }
         Err(e)
@@ -182,9 +181,7 @@ fn install_with_cli(ctx: &mut ContextData, cli: CommandLineArguments) -> Result<
         Output::flush();
     }
 
-    // SAFETY: `ROOT_PACKAGE_JSON_PATH` is written exactly once inside
-    // `PackageManager::init` (above) on this thread; only read thereafter.
-    let root_package_json_path = unsafe { ROOT_PACKAGE_JSON_PATH.read() };
+    let root_package_json_path = root_package_json_path();
     install_with_manager(manager, &mut *ctx, root_package_json_path, &original_cwd)?;
 
     if manager.any_failed_to_install {

--- a/src/runtime/cli/link_command.rs
+++ b/src/runtime/cli/link_command.rs
@@ -75,17 +75,16 @@ fn link(ctx: command::Context) -> crate::Result<()> {
             lockfile.init_empty();
 
             let mut resolver: () = ();
-            // `log_mut()` returns a borrow decoupled from `&self`; disjoint
-            // storage from `&mut PackageManager` (owned by the CLI `Context`).
-            let log = manager.log_mut();
-            package.parse::<()>(
-                &mut lockfile,
-                manager,
-                log,
-                &package_json_source,
-                &mut resolver,
-                Features::FOLDER,
-            )?;
+            manager.with_log(|manager, log| {
+                package.parse::<()>(
+                    &mut lockfile,
+                    manager,
+                    log,
+                    &package_json_source,
+                    &mut resolver,
+                    Features::FOLDER,
+                )
+            })?;
             let name = lockfile.str(&package.name);
             if name.is_empty() {
                 if manager.options.log_level != LogLevel::Silent {
@@ -221,20 +220,7 @@ fn link(ctx: command::Context) -> crate::Result<()> {
             let mut link_dest_buf = bun_paths::path_buffer_pool::get();
             let mut link_rel_buf = bun_paths::path_buffer_pool::get();
 
-            // `target_node_modules_path` (`&`) and `node_modules_path` (`&mut`)
-            // cannot alias the same value, so resolve the fd path twice (cheap:
-            // one `getFdPath` syscall) into two independent `AbsPath` buffers.
             let mut node_modules_path =
-                match <AbsPath>::init_fd_path(Fd::from_std_dir(&node_modules)) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        if manager.options.log_level != LogLevel::Silent {
-                            Output::err(e, "failed to link binary", ());
-                        }
-                        Global::crash();
-                    }
-                };
-            let target_node_modules_path =
                 match <AbsPath>::init_fd_path(Fd::from_std_dir(&node_modules)) {
                     Ok(p) => p,
                     Err(e) => {
@@ -250,7 +236,7 @@ fn link(ctx: command::Context) -> crate::Result<()> {
                 bin: package.bin,
                 node_modules_path: &mut node_modules_path,
                 global_bin_path: manager.options.bin_path,
-                target_node_modules_path: &raw const target_node_modules_path,
+                target_node_modules_path: None,
                 target_package_name: strings::StringOrTinyString::init(name),
 
                 // .destination_dir_subpath = destination_dir_subpath,

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -562,6 +562,9 @@ pub mod cli {
         // SAFETY: single-threaded process startup; `mimalloc` is already init.
         unsafe { (*super::CLI_ARENA.get()).write(bun_alloc::Arena::new()) };
 
+        // The resolver reaches the package manager (auto-install) through this.
+        bun_resolver::set_auto_installer_factory(bun_install::auto_installer::init_for_resolver);
+
         // (The panic hook is installed by `bun_crash_handler::init()` in `bin_entry::main`.)
         // SAFETY: just initialized above; single-threaded for the lifetime of `log`.
         let log = unsafe { (*LOG_.get()).assume_init_mut() };
@@ -569,8 +572,13 @@ pub mod cli {
             // Print accumulated diagnostics BEFORE the
             // generic `handle_root_error` "An internal error occurred (..)"
             // message. The bake production path returns `error.BuildFailed`
-            // with the actual parse/link errors sitting in `ctx.log` (== this
-            // `log`); without this print, users see only the opaque error name.
+            // with the actual parse/link errors sitting in `ctx.log` (this
+            // `log`, or the package manager's once it took over); without this
+            // print, users see only the opaque error name.
+            let log: &bun_ast::Log = match bun_options_types::context::try_get() {
+                Some(ctx) => ctx.log_ref(),
+                None => log,
+            };
             let _ = log.print(std::ptr::from_mut::<bun_core::io::Writer>(
                 bun_core::Output::error_writer(),
             ));

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -8,7 +8,7 @@ use bun_core::{Global, Output};
 use bun_glob as glob;
 use bun_install::dependency::{self, Behavior};
 use bun_install::lockfile::package::PackageColumns as _;
-use bun_install::lockfile::{LoadResult, LoadStep};
+use bun_install::lockfile::{DetachedLoadResult, LoadStep};
 use bun_install::package_manager::{
     LogLevel, Subcommand, WorkspaceFilter, populate_manifest_cache,
 };
@@ -83,38 +83,20 @@ impl OutdatedCommand {
     }
 
     fn outdated(
-        ctx: Command::Context,
+        _ctx: Command::Context,
         original_cwd: &[u8],
         manager: &mut PackageManager,
     ) -> crate::Result<()> {
-        // Reshaped for borrowck — `load_from_cwd` would otherwise alias
-        // `PackageManager` with its `lockfile` field. Project disjoint
-        // raw pointers from the singleton first; `load_from_cwd` only reads
-        // `manager.options` / migration helpers and never re-borrows
-        // `manager.lockfile` through the `pm` argument.
-        let pm_ptr: *mut PackageManager = manager;
         let not_silent = manager.options.log_level != LogLevel::Silent;
-        let log_ptr: *mut bun_ast::Log = manager.log;
-
-        // SAFETY: `lockfile` is the owned `Box<Lockfile>` field on the singleton;
-        // no other live `&mut Lockfile` exists at this point.
-        let lockfile: &mut bun_install::lockfile::Lockfile = unsafe { &mut *(*pm_ptr).lockfile };
-        // SAFETY: `manager.log` is set non-null by `PackageManager::init`.
-        let log = unsafe { &mut *log_ptr };
-        match lockfile.load_from_cwd::<true>(
-            // SAFETY: see comment above — `load_from_cwd` accesses `manager`
-            // fields disjoint from `lockfile`.
-            Some(unsafe { &mut *pm_ptr }),
-            log,
-        ) {
-            LoadResult::NotFound => {
+        match manager.load_lockfile_from_cwd_detached::<true>() {
+            DetachedLoadResult::NotFound => {
                 if not_silent {
                     Output::err_generic("missing lockfile, nothing outdated", ());
                     bun_core::note!("run 'bun install' first");
                 }
                 Global::crash();
             }
-            LoadResult::Err(cause) => {
+            DetachedLoadResult::Err(cause) => {
                 if not_silent
                     && !bun_install::migration::reported_unsupported_lockfile_version(&cause)
                 {
@@ -136,21 +118,15 @@ impl OutdatedCommand {
                             (cause.value.name(),),
                         ),
                     }
-                    if ctx.log_ref().has_errors() {
-                        // SAFETY: `log_ptr` aliases `manager.log` which is the
-                        // `*logger.Log` borrowed from `Command::Context`; no
-                        // other `&mut Log` is live here.
-                        let _ =
-                            unsafe { (*log_ptr).print(std::ptr::from_mut(Output::error_writer())) };
+                    if manager.log.has_errors() {
+                        let _ = manager
+                            .log
+                            .print(std::ptr::from_mut(Output::error_writer()));
                     }
                 }
                 Global::crash();
             }
-            LoadResult::Ok(_) => {
-                // `load_from_cwd(&mut self, ..)` populates the
-                // lockfile in place, so the `ok.lockfile: &mut Lockfile` reborrow
-                // is the same storage and no reassignment is needed.
-            }
+            DetachedLoadResult::Ok(_) => {}
         }
 
         if Output::enable_ansi_colors_stdout() {

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -74,9 +74,9 @@ fn file_to_source_at(dir: &Dir, path: &ZStr) -> bun_sys::Maybe<bun_ast::Source> 
 /// `&mut workspace_package_json_cache` borrow at the call site.
 #[inline]
 fn pm_log<'a>(m: *mut PackageManager) -> &'a mut bun_ast::Log {
-    // SAFETY: `m` came from `&mut PackageManager`; `log` is non-null after
-    // `PackageManager::init()`.
-    unsafe { &mut *(*m).log }
+    // SAFETY: `m` came from `&mut PackageManager`; `log` is a separate heap
+    // allocation from the fields borrowed alongside it.
+    unsafe { &mut (*m).log }
 }
 /// `manager.workspace_package_json_cache` field projection via raw pointer.
 #[inline]
@@ -87,11 +87,8 @@ fn pm_workspace_cache<'a>(
     unsafe { &mut (*m).workspace_package_json_cache }
 }
 #[inline]
-fn pm_env(m: &PackageManager) -> *mut bun_dotenv::Loader {
-    // Set during `PackageManager::init`.
-    m.env
-        .map(|p| p.as_ptr())
-        .expect("env set by PackageManager::init")
+fn pm_env(m: &mut PackageManager) -> *mut bun_dotenv::Loader {
+    m.env_mut()
 }
 #[inline]
 fn pm_run_scripts(m: &PackageManager) -> bool {
@@ -215,14 +212,10 @@ impl PackCommand {
         }
 
         let mut lockfile = Lockfile::default();
-        // `log` is non-null after `PackageManager::init()`.
-        let log_ptr: *mut bun_ast::Log = manager.log;
         let manager_ptr: *mut PackageManager = manager;
-        // SAFETY: `manager_ptr`/`log_ptr` came from live `&mut`; reborrowed
-        // disjointly (`log` is a separate allocation from the manager fields
-        // `load_from_cwd` touches).
-        let load_from_disk_result = lockfile
-            .load_from_cwd::<false>(Some(unsafe { &mut *manager_ptr }), unsafe { &mut *log_ptr });
+        let load_from_disk_result = manager
+            .with_log(|manager, log| lockfile.load_from_cwd::<false>(Some(manager), log).detach())
+            .attach(&mut lockfile);
 
         let lockfile_ref: Option<&Lockfile> = match load_from_disk_result {
             LoadResult::Ok(ok) => Some(&*ok.lockfile),
@@ -2009,6 +2002,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     // `Publish::Context`.
     let manager_ptr: *mut PackageManager = &raw mut *ctx.manager;
     let log_level = ctx.manager.options.log_level;
+    let silent = log_level == LogLevel::Silent;
     let bump = pack_bump();
     // Note: `workspace_package_json_cache` and `log` are disjoint fields on
     // `PackageManager`; route through raw-pointer field projections so the
@@ -2187,7 +2181,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                         b"prepublishOnly",
                         abs_workspace_path,
                         ctx.manager.env_mut(),
-                        ctx.manager.options.log_level == LogLevel::Silent,
+                        silent,
                     )?;
                 }
             }
@@ -2202,7 +2196,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                     b"prepack",
                     abs_workspace_path,
                     ctx.manager.env_mut(),
-                    ctx.manager.options.log_level == LogLevel::Silent,
+                    silent,
                 )?;
             }
         }
@@ -2216,7 +2210,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                     b"prepare",
                     abs_workspace_path,
                     ctx.manager.env_mut(),
-                    ctx.manager.options.log_level == LogLevel::Silent,
+                    silent,
                 )?;
             }
         }
@@ -2437,7 +2431,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                 b"postpack",
                 abs_workspace_path,
                 ctx.manager.env_mut(),
-                ctx.manager.options.log_level == LogLevel::Silent,
+                silent,
             )?;
         }
 
@@ -2922,7 +2916,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
             b"postpack",
             abs_workspace_path,
             ctx.manager.env_mut(),
-            ctx.manager.options.log_level == LogLevel::Silent,
+            silent,
         )?;
     }
 

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -6,7 +6,9 @@ use bun_core::fmt::PathSep;
 use bun_core::strings;
 use bun_core::{Global, Output, env_var, fmt as bun_fmt};
 use bun_install::dependency::Dependency;
-use bun_install::lockfile::{LoadResult, LoadStep, Lockfile, package::PackageColumns as _, tree};
+use bun_install::lockfile::{
+    DetachedLoadResult, LoadStatus, LoadStep, Lockfile, package::PackageColumns as _, tree,
+};
 use bun_install::npm as Npm;
 use bun_install::package_manager_real::{
     CommandLineArguments, Subcommand, fetch_cache_directory_path, get_cache_directory,
@@ -68,19 +70,22 @@ impl PackageManagerCommand {
     // Takes `LogLevel` instead of `&mut PackageManager` so callers
     // can keep `pm` mutably borrowed by `LoadResult` (which holds
     // `&mut Lockfile` into `pm.lockfile`) across this call.
-    pub(crate) fn handle_load_lockfile_errors(load_lockfile: &LoadResult<'_>, log_level: LogLevel) {
+    pub(crate) fn handle_load_lockfile_errors(
+        load_lockfile: &impl bun_install::lockfile::LoadedFrom,
+        log_level: LogLevel,
+    ) {
         Self::handle_load_lockfile_errors_for(load_lockfile, log_level, "");
     }
 
     pub(crate) fn handle_load_lockfile_errors_for(
-        load_lockfile: &LoadResult<'_>,
+        load_lockfile: &impl bun_install::lockfile::LoadedFrom,
         log_level: LogLevel,
         nothing_to: &str,
     ) {
         let not_silent = log_level != LogLevel::Silent;
 
-        match load_lockfile {
-            LoadResult::NotFound => {
+        match load_lockfile.status() {
+            LoadStatus::NotFound => {
                 if not_silent {
                     if nothing_to.is_empty() {
                         Output::err_generic("missing lockfile", ());
@@ -91,7 +96,7 @@ impl PackageManagerCommand {
                 }
                 Global::exit(1);
             }
-            LoadResult::Err(err) => {
+            LoadStatus::Err(err) => {
                 if not_silent && !migration::reported_unsupported_lockfile_version(err) {
                     Output::err_generic(
                         "failed to {s} lockfile: {s}",
@@ -100,7 +105,7 @@ impl PackageManagerCommand {
                 }
                 Global::exit(1);
             }
-            LoadResult::Ok(_) => {}
+            LoadStatus::Ok => {}
         }
     }
 
@@ -118,19 +123,9 @@ impl PackageManagerCommand {
         };
 
         let log_level = pm.options.log_level;
-        // Reshaped for borrowck — `pm.lockfile.load_from_bytes(pm, …)`
-        // is a self-referential split borrow. Derive both halves through `pm`
-        // (not the raw `pm_ptr`) so the outer borrow stays on the stack.
-        let pm_raw: *mut PackageManager = pm;
-        // SAFETY: `pm.lockfile` is `Box<Lockfile>` whose pointee lives in a
-        // separate heap allocation; `&mut Lockfile` and `&mut PackageManager`
-        // cannot alias. `load_from_bytes` reads `manager.options`/`manager.log`
-        // only and never re-projects `manager.lockfile`.
-        let load_lockfile = unsafe {
-            let lockfile: *mut Lockfile = &raw mut *(*pm_raw).lockfile;
-            let log: *mut bun_ast::Log = (*pm_raw).log;
-            (*lockfile).load_from_bytes(Some(&mut *pm_raw), bytes, &mut *log)
-        };
+        let load_lockfile = pm.with_lockfile_and_log(|lockfile, pm, log| {
+            lockfile.load_from_bytes(Some(pm), bytes, log).detach()
+        });
 
         Self::handle_load_lockfile_errors_for(&load_lockfile, log_level, "hash");
 
@@ -439,7 +434,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
 
                 let mut process_env = bun_dotenv::Loader::init();
                 process_env.load_process()?;
-                let cache_dir = fetch_cache_directory_path(&mut process_env, None);
+                let cache_dir = fetch_cache_directory_path(&process_env, None);
                 let mut rm_buf = bun_paths::path_buffer_pool::get();
                 let rm_dir = match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
                     Ok(d) => d,
@@ -553,7 +548,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             UntrustedCommand::exec(&mut *ctx, pm, args)?;
             Global::exit(0);
         } else if strings::eql_comptime(subcommand, b"trust") {
-            TrustCommand::exec(&mut *ctx, pm, args)?;
+            TrustCommand::exec(pm, args)?;
             Global::exit(0);
         } else if strings::eql_comptime(subcommand, b"ls") {
             let log_level = pm.options.log_level;
@@ -607,7 +602,12 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                     // package nested under an untrusted parent must still be
                     // shown. Walk every node_modules folder and print a flat
                     // list instead of pruning the tree.
-                    print_trusted_dependencies_flat(&first_directory, &directories, lockfile);
+                    print_trusted_dependencies_flat(
+                        &first_directory,
+                        &directories,
+                        lockfile,
+                        &pm.options,
+                    );
                 } else {
                     print_node_modules_folder_structure(
                         &first_directory,
@@ -663,6 +663,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                         let alias = dependencies[dep_id as usize].name.slice(string_bytes);
                         let pkg_name = pkg_names[package_id as usize].slice(string_bytes);
                         lockfile.has_trusted_dependency(
+                            &pm.options,
                             alias,
                             pkg_name,
                             &resolutions[package_id as usize],
@@ -716,47 +717,15 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 }
             }
             let log_level = pm.options.log_level;
-            // Reshaped for borrowck —
-            // `detect_and_load_other_lockfile(&pm.lockfile, .cwd(), pm, ctx.log)`
-            // is a self-referential split borrow. Derive both halves through
-            // `pm` (not the raw `pm_ptr`) so the outer borrow stays on the
-            // Stacked-Borrows stack.
-            let pm_raw: *mut PackageManager = pm;
-            // SAFETY: `pm.lockfile` is `Box<Lockfile>` whose pointee lives in a
-            // separate heap allocation; `&mut Lockfile` and `&mut PackageManager`
-            // cannot alias. `detect_and_load_other_lockfile` reads
-            // `manager.options`/`manager.log` only and never re-projects
-            // `manager.lockfile`.
-            let mut load_lockfile = unsafe {
-                let lockfile: *mut Lockfile = &raw mut *(*pm_raw).lockfile;
-                let log: *mut bun_ast::Log = (*pm_raw).log;
-                migration::detect_and_load_other_lockfile(
-                    &mut *lockfile,
-                    Fd::cwd(),
-                    &mut *pm_raw,
-                    &mut *log,
-                )
-            };
-            if matches!(load_lockfile, LoadResult::NotFound) {
+            let load_lockfile = pm.with_lockfile_and_log(|lockfile, pm, log| {
+                migration::detect_and_load_other_lockfile(lockfile, Fd::cwd(), pm, log).detach()
+            });
+            if matches!(load_lockfile, DetachedLoadResult::NotFound) {
                 bun_core::pretty_errorln!("<r><red>error<r>: could not find any other lockfile");
                 Global::exit(1);
             }
             Self::handle_load_lockfile_errors(&load_lockfile, log_level);
-            // Reshaped for borrowck — `save_to_disk` needs
-            // `&mut Lockfile` (self) and `&LoadResult` simultaneously, but
-            // `LoadResultOk.lockfile` already holds the only `&mut` into the
-            // boxed lockfile. Project that field to a raw pointer (no second
-            // Box-deref) so both arguments share one Stacked-Borrows lineage.
-            let lf: *mut Lockfile = &raw mut *load_lockfile.ok_mut().lockfile;
-            // SAFETY: `load_lockfile` is `Ok` (errors exited above). `lf` is a
-            // reborrow of `ok.lockfile`; `save_to_disk` reads `load_result` only
-            // for `save_format()` / `loaded_from_binary_lockfile()` (scalar
-            // `format`/`migrated` fields) and never dereferences `ok.lockfile`,
-            // so `&mut *lf` remains the sole live mutable view of the heap
-            // lockfile. `options` is read via `pm_raw` (disjoint allocation).
-            unsafe {
-                (*lf).save_to_disk(&load_lockfile, &(*pm_raw).options);
-            }
+            pm.lockfile.save_to_disk(&load_lockfile, &pm.options);
             Global::exit(0);
         } else if strings::eql_comptime(subcommand, b"version") {
             let positionals: &[&[u8]] = pm.options.positionals;
@@ -981,6 +950,7 @@ fn print_trusted_dependencies_flat(
     first_directory: &NodeModulesFolder,
     directories: &[NodeModulesFolder],
     lockfile: &Lockfile,
+    options: &bun_install::package_manager_real::Options,
 ) {
     let mut cwd_buf = bun_paths::path_buffer_pool::get();
     let path = match bun_sys::getcwd(&mut cwd_buf[..]) {
@@ -1013,7 +983,12 @@ fn print_trusted_dependencies_flat(
         }
         let alias = dependencies[dep_id as usize].name.slice(string_bytes);
         let pkg_name = pkg_names[package_id as usize].slice(string_bytes);
-        if lockfile.has_trusted_dependency(alias, pkg_name, &resolutions[package_id as usize]) {
+        if lockfile.has_trusted_dependency(
+            options,
+            alias,
+            pkg_name,
+            &resolutions[package_id as usize],
+        ) {
             seen.set(package_id as usize);
             trusted.push(dep_id);
         }

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -1,4 +1,3 @@
-use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 
 use bun_alloc::Arena as Bump;
@@ -6,13 +5,13 @@ use bun_collections::{ArrayHashMap, ArrayIdentityContext, StringArrayHashMap};
 use bun_core::strings;
 use bun_core::{Global, Output, Progress};
 use bun_install::lockfile::{
-    LoadResult, Lockfile,
+    Lockfile,
     package::PackageColumns as _,
     package::scripts::{List as ScriptsList, PrintFormat, Scripts},
     tree,
 };
 use bun_install::package_manager_real::{
-    PackageJSONEditor, ProgressStrings, ROOT_PACKAGE_JSON_PATH, update_lockfile_if_needed,
+    PackageJSONEditor, ProgressStrings, root_package_json_path, update_lockfile_if_needed,
 };
 use bun_install::{
     self as install, DEFAULT_TRUSTED_DEPENDENCIES_LIST, DependencyID, LifecycleScriptSubprocess,
@@ -57,26 +56,19 @@ impl UntrustedCommand {
         Output::flush();
 
         // Reshaped for borrowck — `LoadResult` returned by
-        // `load_lockfile_from_cwd` mutably borrows `pm.lockfile`, so all
-        // subsequent `pm` access goes through `pm_raw`. Same singleton pattern
-        // as `package_manager_command.rs::print_hash`.
-        let pm_raw: *mut PackageManager = pm;
         let log_level = pm.options.log_level;
-        let load_lockfile = pm.load_lockfile_from_cwd::<true>();
+        let load_lockfile = pm.load_lockfile_from_cwd_detached::<true>();
         PackageManagerCommand::handle_load_lockfile_errors_for(&load_lockfile, log_level, "list");
-        // SAFETY: `pm_raw` derived from `pm` above; `update_lockfile_if_needed`
-        // reads `load_result.serializer_result` (no `ok.lockfile` deref) and
-        // writes through `manager.lockfile`, which is the same heap allocation
-        // `load_lockfile` borrows but is never dereferenced via `load_lockfile`
-        // here.
-        unsafe { update_lockfile_if_needed(&mut *pm_raw, &load_lockfile)? };
+        update_lockfile_if_needed(pm, &load_lockfile)?;
 
-        // SAFETY: `load_lockfile` is not used past this point; `pm_raw` is the
-        // only path to the singleton for the rest of this fn (same as the
-        // original `pm`).
-        let pm: &mut PackageManager = unsafe { &mut *pm_raw };
-        let log: &mut bun_ast::Log = pm.log_mut();
-        let lockfile: &Lockfile = &pm.lockfile;
+        let PackageManager {
+            lockfile,
+            log,
+            options,
+            ..
+        } = &mut *pm;
+        let lockfile: &Lockfile = lockfile;
+        let options: &bun_install::package_manager_real::Options = options;
 
         let packages = lockfile.packages.slice();
         let scripts: &[Scripts] = packages.items_scripts();
@@ -97,7 +89,7 @@ impl UntrustedCommand {
             let alias = dep.name.slice(buf);
             let pkg_name = packages.items_name()[package_id as usize].slice(buf);
             let resolution = &resolutions[package_id as usize];
-            if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
+            if !lockfile.has_trusted_dependency(options, alias, pkg_name, resolution) {
                 untrusted_dep_ids.put(dep_id, ())?;
             }
         }
@@ -143,6 +135,7 @@ impl UntrustedCommand {
                 let _ = node_modules_path.append(alias);
 
                 let result = package_scripts.get_list(
+                    options,
                     log,
                     lockfile,
                     &mut node_modules_path,
@@ -238,11 +231,7 @@ impl TrustCommand {
         }
     }
 
-    pub(crate) fn exec(
-        ctx: Command::Context,
-        pm: &mut PackageManager,
-        args: &[&[u8]],
-    ) -> crate::Result<()> {
+    pub(crate) fn exec(pm: &mut PackageManager, args: &[&[u8]]) -> crate::Result<()> {
         bun_core::pretty_error!(
             "<r><b>bun pm trust <r><d>v{}<r>\n",
             Global::package_json_version_with_sha,
@@ -253,25 +242,10 @@ impl TrustCommand {
             Self::error_expected_args();
         }
 
-        // Reshaped for borrowck — see `UntrustedCommand::exec`.
-        // `load_lockfile` lives until `save_to_disk` near the end, so every
-        // `pm`/`pm.lockfile` access in between goes through `pm_raw`.
-        let pm_raw: *mut PackageManager = pm;
         let log_level = pm.options.log_level;
-        let load_lockfile = pm.load_lockfile_from_cwd::<true>();
+        let load_lockfile = pm.load_lockfile_from_cwd_detached::<true>();
         PackageManagerCommand::handle_load_lockfile_errors_for(&load_lockfile, log_level, "trust");
-        // `update_lockfile_if_needed` consumes `LoadResult` but we
-        // need it again for `save_to_disk`; inline the body (it only flips
-        // `meta.has_install_script` when `packages_need_update`).
-        if matches!(&load_lockfile, LoadResult::Ok(ok) if ok.serializer_result.packages_need_update)
-        {
-            // SAFETY: `pm_raw` derived from `pm` above; `load_lockfile` is not
-            // dereferenced concurrently. See `update_lockfile_if_needed`.
-            let mut slice = unsafe { (*pm_raw).lockfile.packages.slice() };
-            for meta in slice.items_meta_mut() {
-                meta.set_has_install_script(false);
-            }
-        }
+        update_lockfile_if_needed(pm, &load_lockfile)?;
 
         let mut packages_to_trust: Vec<&[u8]> = Vec::with_capacity(args[2..].len());
         for arg in &args[2..] {
@@ -286,10 +260,16 @@ impl TrustCommand {
             Self::error_expected_args();
         }
 
-        // SAFETY: `pm_raw` is the singleton; `pm.log` set at init, non-null.
-        let log: *mut bun_ast::Log = unsafe { (*pm_raw).log };
-        // SAFETY: `pm_raw` singleton; read-only `lockfile` borrow for the discovery phase.
-        let lockfile: &Lockfile = unsafe { &*(*pm_raw).lockfile };
+        // Discovery phase: the lockfile and options read-only, the log for
+        // `get_list` diagnostics.
+        let PackageManager {
+            lockfile,
+            log,
+            options,
+            ..
+        } = &mut *pm;
+        let lockfile: &Lockfile = lockfile;
+        let options: &bun_install::package_manager_real::Options = options;
 
         let buf = lockfile.buffers.string_bytes.as_slice();
         let packages = lockfile.packages.slice();
@@ -318,7 +298,7 @@ impl TrustCommand {
             let alias = dep.name.slice(buf);
             let pkg_name = packages.items_name()[package_id as usize].slice(buf);
             let resolution = &resolutions[package_id as usize];
-            if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
+            if !lockfile.has_trusted_dependency(options, alias, pkg_name, resolution) {
                 untrusted_dep_ids.put(dep_id, ())?;
             }
         }
@@ -375,9 +355,9 @@ impl TrustCommand {
                 let folder_saved = node_modules_path.len();
                 let _ = node_modules_path.append(alias);
 
-                // SAFETY: `log` derived from `pm.log`; single-threaded CLI.
                 let result = package_scripts.get_list(
-                    unsafe { &mut *log },
+                    options,
+                    log,
                     lockfile,
                     &mut node_modules_path,
                     alias,
@@ -400,6 +380,7 @@ impl TrustCommand {
                         for package_name_from_cli in &packages_to_trust {
                             if strings::eql_long(package_name_from_cli, alias, true)
                                 && !lockfile.has_trusted_dependency(
+                                    options,
                                     alias,
                                     packages.items_name()[package_id as usize].slice(buf),
                                     resolution,
@@ -439,22 +420,15 @@ impl TrustCommand {
             Global::crash();
         }
 
-        let mut scripts_node: Progress::Node;
-        // SAFETY: `pm_raw` singleton; `progress` is owned inline.
-        let show_progress = unsafe { (*pm_raw).options.log_level.show_progress() };
+        let show_progress = pm.options.log_level.show_progress();
 
         if show_progress {
-            // SAFETY: see above; `progress.start()` returns `&mut root` which is
-            // immediately consumed by `Node::start` (returns an owned `Node`
-            // with raw backrefs into `pm.progress`).
-            unsafe {
-                (*pm_raw).progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
-                scripts_node = (*pm_raw)
-                    .progress
-                    .start(b"", 0)
-                    .start(ProgressStrings::script(), scripts_count);
-                (*pm_raw).scripts_node = Some(NonNull::from(&mut scripts_node));
-            }
+            pm.progress.supports_ansi_escape_codes = Output::enable_ansi_colors_stderr();
+            let scripts_node = pm
+                .progress
+                .start(b"", 0)
+                .start(ProgressStrings::script(), scripts_count);
+            pm.scripts_node = Some(scripts_node);
         }
 
         // `scripts_at_depth.values()` is taken twice (run, then
@@ -467,14 +441,12 @@ impl TrustCommand {
                     continue;
                 }
 
-                // SAFETY: `pm_raw` singleton; `options` is CLI config set at init.
-                let max_concurrent = unsafe { (*pm_raw).options.max_concurrent_lifecycle_scripts };
+                let max_concurrent = pm.options.max_concurrent_lifecycle_scripts;
                 while LifecycleScriptSubprocess::alive_count().load(Ordering::Relaxed)
                     >= max_concurrent
                 {
-                    // SAFETY: `pm_raw` singleton; `options.log_level` is CLI config set at init.
-                    if unsafe { (*pm_raw).options.log_level.is_verbose() }
-                        && PackageManager::has_enough_time_passed_between_waiting_messages()
+                    if pm.options.log_level.is_verbose()
+                        && pm.has_enough_time_passed_between_waiting_messages()
                     {
                         bun_core::pretty_errorln!(
                             "<d>[PackageManager]<r> waiting for {} scripts\n",
@@ -482,106 +454,71 @@ impl TrustCommand {
                         );
                     }
 
-                    // SAFETY: `pm_raw` singleton.
-                    unsafe { (*pm_raw).sleep() };
+                    pm.sleep();
                 }
 
                 let output_in_foreground = false;
                 let optional = false;
-                // SAFETY: `pm_raw` singleton; `ctx` is the CLI `&mut ContextData`.
-                unsafe {
-                    (*pm_raw).spawn_package_lifecycle_scripts(
-                        &mut *ctx,
-                        info.scripts_list.clone(),
-                        optional,
-                        output_in_foreground,
-                        None,
-                    )?;
-                }
+                pm.spawn_package_lifecycle_scripts(
+                    info.scripts_list.clone(),
+                    optional,
+                    output_in_foreground,
+                    None,
+                )?;
 
-                // SAFETY: `pm_raw` singleton; `options.log_level` is CLI config set at init.
-                if unsafe { (*pm_raw).options.log_level.show_progress() } {
-                    // SAFETY: `scripts_node` initialized above when
-                    // `show_progress` was true at the same `log_level`.
-                    if let Some(sn) = unsafe { (*pm_raw).scripts_node } {
-                        // SAFETY: points at our stack-local `scripts_node`.
-                        unsafe { sn.as_ptr().as_mut().unwrap().activate() };
+                if pm.options.log_level.show_progress() {
+                    if let Some(sn) = pm.scripts_node.as_mut() {
+                        sn.activate();
                     }
-                    // SAFETY: `pm_raw` singleton; `progress` owned inline by `pm`.
-                    unsafe { (*pm_raw).progress.refresh() };
+                    pm.progress.refresh();
                 }
             }
 
-            // SAFETY: `pm_raw` singleton.
-            while unsafe {
-                (*pm_raw)
-                    .pending_lifecycle_script_tasks
-                    .load(Ordering::Relaxed)
-            } > 0
-            {
-                // SAFETY: `pm_raw` singleton; `sleep()` ticks the event loop on the CLI thread.
-                unsafe { (*pm_raw).sleep() };
+            while pm.pending_lifecycle_script_tasks.load(Ordering::Relaxed) > 0 {
+                pm.sleep();
             }
         }
 
         if show_progress {
-            // SAFETY: `pm_raw` singleton.
-            unsafe {
-                (*pm_raw).progress.root.end();
-                (*pm_raw).progress = Progress::Progress::default();
-                (*pm_raw).scripts_node = None;
-            }
+            pm.progress.root.end();
+            pm.progress = Progress::Progress::default();
+            pm.scripts_node = None;
         }
 
-        // SAFETY: `pm_raw` singleton; this scope takes over the descriptor
-        // (the original `pm.root_package_json_file` is replaced with INVALID so
-        // its eventual drop is a no-op).
-        let root_file = unsafe {
-            let fd = (*pm_raw).root_package_json_file.handle;
-            (*pm_raw).root_package_json_file.handle = bun_core::Fd::INVALID;
+        // This scope takes over the descriptor (the original
+        // `pm.root_package_json_file` is replaced with INVALID so its eventual
+        // drop is a no-op).
+        let root_file = {
+            let fd = pm.root_package_json_file.handle;
+            pm.root_package_json_file.handle = bun_core::Fd::INVALID;
             bun_sys::File::from_fd(fd)
         };
         let package_json_contents = root_file.read_to_end().map_err(crate::Error::from)?;
 
-        // SAFETY: `ROOT_PACKAGE_JSON_PATH` is set during `PackageManager::init`
-        // (single-threaded startup) and immutable thereafter.
         let package_json_source = bun_ast::Source::init_path_string(
-            unsafe { ROOT_PACKAGE_JSON_PATH.read() }.as_bytes(),
+            root_package_json_path().as_bytes(),
             package_json_contents.as_slice(),
         );
 
         let bump = Bump::new();
-        // SAFETY: `ctx.log` set by `Command::init`, non-null for the command.
-        // Layering: `parse_utf8` returns the T2
-        // `bun_ast::Expr`; `PackageJSONEditor` and
-        // `js_printer::print_json` consume the T4 `bun_ast::Expr`. Lift
-        // once via `From<T2> for T4` (same as `updatePackageJSONAndInstall` /
-        // `pack_command`).
-        let mut package_json: bun_ast::Expr = match bun_parsers::json::parse_utf8(
-            &package_json_source,
-            unsafe { ctx.log_mut() },
-            &bump,
-        ) {
-            Ok(v) => v,
-            Err(err) => {
-                let _ = ctx
-                    .log_ref()
-                    .print(std::ptr::from_mut(Output::error_writer()));
+        // `ctx.log` is the manager's log (`PackageManager::init`).
+        let mut package_json: bun_ast::Expr =
+            match bun_parsers::json::parse_utf8(&package_json_source, &mut pm.log, &bump) {
+                Ok(v) => v,
+                Err(err) => {
+                    let _ = pm.log.print(std::ptr::from_mut(Output::error_writer()));
 
-                Output::err_generic("failed to parse package.json: {s}", (err.name(),));
-                Global::crash();
-            }
-        };
+                    Output::err_generic("failed to parse package.json: {s}", (err.name(),));
+                    Global::crash();
+                }
+            };
 
         // now add the package names to lockfile.trustedDependencies and package.json `trustedDependencies`
         debug_assert!(!package_names_to_add.keys().is_empty());
 
         // could be null if these are the first packages to be trusted
-        // SAFETY: `pm_raw` singleton; mutates `lockfile.trusted_dependencies`.
-        unsafe {
-            if (*pm_raw).lockfile.trusted_dependencies.is_none() {
-                (*pm_raw).lockfile.trusted_dependencies = Some(Default::default());
-            }
+        if pm.lockfile.trusted_dependencies.is_none() {
+            pm.lockfile.trusted_dependencies = Some(Default::default());
         }
 
         let mut total_scripts_ran: usize = 0;
@@ -590,8 +527,7 @@ impl TrustCommand {
 
         Output::print(format_args!("\n"));
 
-        // SAFETY: `pm_raw` singleton; read-only borrow for printing.
-        let lockfile: &Lockfile = unsafe { &*(*pm_raw).lockfile };
+        let lockfile: &Lockfile = &pm.lockfile;
         let buf = lockfile.buffers.string_bytes.as_slice();
         for entry in scripts_at_depth.values().iter().rev() {
             for info in entry.iter() {
@@ -616,32 +552,13 @@ impl TrustCommand {
         )?;
 
         for name in package_names_to_add.keys() {
-            // SAFETY: `pm_raw` singleton; `trusted_dependencies` set Some above.
-            unsafe {
-                (*pm_raw)
-                    .lockfile
-                    .trusted_dependencies
-                    .as_mut()
-                    .unwrap()
-                    .put(
-                        bun_semver::string::Builder::string_hash(name)
-                            as install::TruncatedPackageNameHash,
-                        Box::<[u8]>::from(&**name),
-                    )?;
-            }
+            pm.lockfile.trusted_dependencies.as_mut().unwrap().put(
+                bun_semver::string::Builder::string_hash(name) as install::TruncatedPackageNameHash,
+                Box::<[u8]>::from(&**name),
+            )?;
         }
 
-        // Reshaped for borrowck — `save_to_disk` needs `&mut Lockfile`
-        // and `&LoadResult` simultaneously, but `LoadResultOk.lockfile` already
-        // holds the only `&mut`. Same projection pattern as `migrate` in
-        // `package_manager_command.rs`.
-        // SAFETY: `load_lockfile` is `Ok` (errors exited in
-        // `handle_load_lockfile_errors`). `save_to_disk` reads `load_result`
-        // only for `save_format()` (scalar `format`/`migrated` fields).
-        unsafe {
-            let lf: *mut Lockfile = &raw mut *(*pm_raw).lockfile;
-            (*lf).save_to_disk(&load_lockfile, &(*pm_raw).options);
-        }
+        pm.lockfile.save_to_disk(&load_lockfile, &pm.options);
 
         let mut buffer_writer = bun_js_printer::BufferWriter::init();
         buffer_writer.buffer.list.reserve(

--- a/src/runtime/cli/pm_update_package_json.rs
+++ b/src/runtime/cli/pm_update_package_json.rs
@@ -15,8 +15,8 @@ use bun_core::{Global, Output};
 use bun_install::package_manager_real::command_line_arguments::CommandLineArguments;
 use bun_install::package_manager_real::{Subcommand, update_package_json_and_install_and_cli};
 
+use crate::Command;
 use crate::build_command::BuildCommand;
-use crate::cli::Cli;
 use crate::command::{self, Context, ContextData};
 
 pub(crate) fn update_package_json_and_install_catch_error(
@@ -28,12 +28,10 @@ pub(crate) fn update_package_json_and_install_catch_error(
         Err(crate::Error::Install(
             bun_install::Error::InstallFailed | bun_install::Error::InvalidPackageJSON,
         )) => {
-            // SAFETY: `Cli::LOG_` is initialised once during single-threaded startup in
-            // `Cli::start()` before any command (including this one) is dispatched; we
-            // are on the single CLI thread in the install error path and no other
-            // `&mut Log` to it is live for the duration of this `print` call.
-            let log = unsafe { (*Cli::LOG_.get()).assume_init_mut() };
-            let _ = log.print(std::ptr::from_mut(Output::error_writer()));
+            // The command context's log (the package manager's, once it is up).
+            let _ = Command::get()
+                .log_ref()
+                .print(std::ptr::from_mut(Output::error_writer()));
             Global::exit(1);
         }
         Err(e) => Err(e),

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -582,8 +582,8 @@ impl PublishCommand {
                             );
                         }
                         FromTarballError::InvalidPackageJSON => {
-                            // SAFETY: `manager.log` is set once at init.
-                            let _ = unsafe { &mut *(*manager_ptr).log }
+                            // SAFETY: `manager_ptr` is the live manager.
+                            let _ = unsafe { &mut (*manager_ptr).log }
                                 .print(std::ptr::from_mut(Output::error_writer()));
                             Output::err_generic("failed to parse tarball package.json", ());
                         }
@@ -609,7 +609,7 @@ impl PublishCommand {
                 "\n<green> +<r> {}@{}{}",
                 bstr::BStr::new(&context.package_name),
                 bstr::BStr::new(dependency::without_build_tag(&context.package_version)),
-                if PackageManager::get().options.dry_run {
+                if context.manager.options.dry_run {
                     " (dry-run)"
                 } else {
                     ""
@@ -659,21 +659,22 @@ impl PublishCommand {
             "\n<green> +<r> {}@{}{}",
             bstr::BStr::new(&context.package_name),
             bstr::BStr::new(dependency::without_build_tag(&context.package_version)),
-            if PackageManager::get().options.dry_run {
+            if context.manager.options.dry_run {
                 " (dry-run)"
             } else {
                 ""
             },
         );
 
-        if PackageManager::get()
+        if context
+            .manager
             .options
             .do_
             .contains(install::PackageManagerDoStub::RUN_SCRIPTS)
         {
             let abs_workspace_path: Box<[u8]> =
                 strings::without_trailing_slash(strings::without_suffix_comptime(
-                    PackageManager::get().original_package_json_path.as_bytes(),
+                    context.manager.original_package_json_path.as_bytes(),
                     b"package.json",
                 ))
                 .into();
@@ -1104,10 +1105,11 @@ impl PublishCommand {
         print_buf: &mut Vec<u8>,
     ) -> Result<Box<[u8]>, GetOTPError> {
         let bump = bun_alloc::Arena::new();
-        let manager_log: &mut bun_ast::Log = ctx.manager.log_mut();
+        // invalid json is ignored (below), and so are its diagnostics
+        let mut parse_log = bun_ast::Log::init();
         let res_source = bun_ast::Source::init_path_string(b"???", response_buf.list.as_slice());
 
-        let res_json = match json_mod::parse_utf8(&res_source, manager_log, &bump) {
+        let res_json = match json_mod::parse_utf8(&res_source, &mut parse_log, &bump) {
             Ok(j) => Some(j),
             Err(e) => {
                 if e == bun_parsers::Error::Alloc(bun_alloc::AllocError) {
@@ -1307,7 +1309,7 @@ impl PublishCommand {
                             );
                             let otp_done_json = match json_mod::parse_utf8(
                                 &otp_done_source,
-                                manager_log,
+                                &mut parse_log,
                                 &done_bump,
                             ) {
                                 Ok(j) => j,

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1814,7 +1814,7 @@ impl RunCommand {
     #[inline]
     pub(crate) fn create_fake_temporary_node_executable(
         path: &mut Vec<u8>,
-        optional_bun_path: &mut &[u8],
+        optional_bun_path: &mut &'static ZStr,
     ) -> crate::Result<()> {
         bun_install::RunCommand::create_fake_temporary_node_executable(path, optional_bun_path)
             .map_err(Into::into)
@@ -1896,7 +1896,7 @@ impl RunCommand {
             .unwrap_or(false);
 
         let mut needs_to_force_bun = force_using_bun || !found_node;
-        let mut optional_bun_self_path: &[u8] = b"";
+        let mut optional_bun_self_path: &'static ZStr = ZStr::EMPTY;
 
         let mut new_path_len: usize = path.len() + 2;
 
@@ -1949,7 +1949,7 @@ impl RunCommand {
                     .unwrap_or_oom();
                 env_mut
                     .map
-                    .put(b"npm_execpath", optional_bun_self_path)
+                    .put(b"npm_execpath", optional_bun_self_path.as_bytes())
                     .unwrap_or_oom();
             }
 

--- a/src/runtime/cli/scan_command.rs
+++ b/src/runtime/cli/scan_command.rs
@@ -1,8 +1,8 @@
 use crate::Command;
 use crate::cli::package_manager_command::PackageManagerCommand;
 use bun_core::{Global, Output};
+use bun_install::PackageManager;
 use bun_install::package_manager::security_scanner;
-use bun_install::{Lockfile, PackageManager};
 
 pub(crate) struct ScanCommand;
 
@@ -33,22 +33,9 @@ impl ScanCommand {
 
         // Reshaped for borrowck — `manager.lockfile.load_from_cwd(&mut self,
         // Some(manager), log)` would alias `&mut *manager.lockfile` with `&mut *manager`.
-        // Project disjoint raw pointers from the singleton first; `load_from_cwd` only
-        // reads `manager.options`/migration helpers and never re-borrows `manager.lockfile`.
         {
             let log_level = manager.options.log_level;
-            let pm_ptr: *mut PackageManager = manager;
-            // SAFETY: `manager.log` is set non-null by `PackageManager::init`.
-            let log: &mut bun_ast::Log = unsafe { &mut *(*pm_ptr).log };
-            // SAFETY: `lockfile` is the owned `Box<Lockfile>` field on the singleton;
-            // no other live `&mut Lockfile` exists at this point.
-            let lockfile: &mut Lockfile = unsafe { &mut *(*pm_ptr).lockfile };
-            let load_result = lockfile.load_from_cwd::<true>(
-                // SAFETY: see comment above — `load_from_cwd` accesses `manager`
-                // fields disjoint from `lockfile`.
-                Some(unsafe { &mut *pm_ptr }),
-                log,
-            );
+            let load_result = manager.load_lockfile_from_cwd_detached::<true>();
             PackageManagerCommand::handle_load_lockfile_errors_for(&load_result, log_level, "scan");
         }
 

--- a/src/runtime/cli/unlink_command.rs
+++ b/src/runtime/cli/unlink_command.rs
@@ -74,17 +74,16 @@ fn unlink(ctx: &mut ContextData) -> crate::Result<()> {
             lockfile.init_empty();
 
             let mut resolver: () = ();
-            // `log_mut()` returns a borrow decoupled from `&self`; disjoint
-            // storage from `&mut PackageManager` (owned by the CLI `Context`).
-            let log = manager.log_mut();
-            package.parse::<()>(
-                &mut lockfile,
-                manager,
-                log,
-                &package_json_source,
-                &mut resolver,
-                Features::FOLDER,
-            )?;
+            manager.with_log(|manager, log| {
+                package.parse::<()>(
+                    &mut lockfile,
+                    manager,
+                    log,
+                    &package_json_source,
+                    &mut resolver,
+                    Features::FOLDER,
+                )
+            })?;
             let name = lockfile.str(&package.name);
             if name.is_empty() {
                 if manager.options.log_level != LogLevel::Silent {
@@ -172,21 +171,7 @@ fn unlink(ctx: &mut ContextData) -> crate::Result<()> {
             let mut link_dest_buf = bun_paths::path_buffer_pool::get();
             let mut link_rel_buf = bun_paths::path_buffer_pool::get();
 
-            // `target_node_modules_path` (`&`) and `node_modules_path` (`&mut`)
-            // cannot alias the same value, so resolve the fd path twice
-            // (cheap: one `getFdPath` syscall) into two independent `AbsPath`
-            // buffers.
             let mut node_modules_path =
-                match <AbsPath>::init_fd_path(Fd::from_std_dir(&node_modules)) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        if manager.options.log_level != LogLevel::Silent {
-                            Output::err(e, "failed to link binary", ());
-                        }
-                        Global::crash();
-                    }
-                };
-            let target_node_modules_path =
                 match <AbsPath>::init_fd_path(Fd::from_std_dir(&node_modules)) {
                     Ok(p) => p,
                     Err(e) => {
@@ -198,7 +183,7 @@ fn unlink(ctx: &mut ContextData) -> crate::Result<()> {
                 };
 
             let mut bin_linker = bin::Linker {
-                target_node_modules_path: &raw const target_node_modules_path,
+                target_node_modules_path: None,
                 target_package_name: strings::StringOrTinyString::init(name),
                 bin: package.bin,
                 node_modules_path: &mut node_modules_path,

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -335,13 +335,9 @@ impl UpdateInteractiveCommand {
                 Self::build_package_json_path(root_dir, workspace_path, &mut path_buf);
 
             // Load and parse the package.json
-            // Reshaped for borrowck — `log_mut()` returns a borrow
-            // decoupled from `&self`, so it can overlap the disjoint
-            // `workspace_package_json_cache` field borrow below.
-            let log = manager.log_mut();
             let package_json: &mut WorkspacePackageJsonCacheEntry =
                 match manager.workspace_package_json_cache.get_with_path(
-                    log,
+                    &mut manager.log,
                     package_json_path,
                     GetJsonOptions {
                         guess_indentation: true,
@@ -465,10 +461,9 @@ impl UpdateInteractiveCommand {
                 Self::build_package_json_path(root_dir, workspace_path, &mut path_buf);
 
             // Load and parse the package.json properly
-            let log = manager.log_mut();
             let package_json: &mut WorkspacePackageJsonCacheEntry =
                 match manager.workspace_package_json_cache.get_with_path(
-                    log,
+                    &mut manager.log,
                     package_json_path,
                     GetJsonOptions {
                         guess_indentation: true,

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -716,7 +716,7 @@ pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i6
             poll_arm!(StaticPipeWriterPoll<crate::shell::subproc::ShellSubprocess>)
         }
         poll_tag::SECURITY_SCAN_STATIC_PIPE_WRITER => {
-            poll_arm!(StaticPipeWriterPoll<bun_install::SecurityScanSubprocess<'_>>)
+            poll_arm!(StaticPipeWriterPoll<bun_install::SecurityScanSubprocess>)
         }
         // `bun.shell.Interpreter.IOWriter.Poll`
         poll_tag::SHELL_BUFFERED_WRITER => poll_arm!(ShellBufferedWriterPoll, |h| {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -486,30 +486,35 @@ unsafe fn init_runtime_state(
                             handle: (*vm).handle(),
                             kind: (*vm).current_loop_kind(),
                         }));
-                    t.resolver.on_wake_package_manager = bun_resolver::install_types::WakeHandler {
-                        context: core::ptr::NonNull::new(wake_ctx.cast()),
-                        handler: Some(bun_jsc::async_module::Queue::on_wake_handler),
-                        on_dependency_error: Some({
-                            unsafe fn adapter(
-                                ctx: *mut core::ffi::c_void,
-                                dep: &bun_resolver::install_types::Dependency,
-                                id: bun_resolver::install_types::DependencyID,
-                                err: &'static str,
-                            ) {
-                                // SAFETY: `ctx` is the `WakeContext` set just above; its queue is `(*vm).modules`.
-                                unsafe {
-                                    bun_jsc::async_module::Queue::on_dependency_error(
-                                        bun_jsc::async_module::Queue::queue_from_wake_context(ctx)
+                    // `wake_ctx` lives in `state` for the VM's lifetime; the wake
+                    // handler posts through the VM's thread-safe handle.
+                    t.resolver.on_wake_package_manager =
+                        bun_resolver::install_types::WakeHandler::new(
+                            core::ptr::NonNull::new(wake_ctx.cast()).expect("boxed above"),
+                            bun_jsc::async_module::Queue::on_wake_handler,
+                            {
+                                fn adapter(
+                                    ctx: *mut core::ffi::c_void,
+                                    dep: &bun_resolver::install_types::Dependency,
+                                    id: bun_resolver::install_types::DependencyID,
+                                    err: &'static str,
+                                ) {
+                                    // SAFETY: `ctx` is the `WakeContext` set just above; its queue is `(*vm).modules`.
+                                    unsafe {
+                                        bun_jsc::async_module::Queue::on_dependency_error(
+                                            bun_jsc::async_module::Queue::queue_from_wake_context(
+                                                ctx,
+                                            )
                                             .cast(),
-                                        dep,
-                                        id,
-                                        err,
-                                    )
+                                            dep,
+                                            id,
+                                            err,
+                                        )
+                                    }
                                 }
-                            }
-                            adapter
-                        }),
-                    };
+                                adapter
+                            },
+                        );
                     // Branch on `opts.graph` here — with a module graph,
                     // auto_jsx=true would
                     // `read_dir_info(cwd)` and cache its tsconfig.json BEFORE
@@ -2408,12 +2413,16 @@ fn transpile_source_code_inner(
             let args_log_nn = core::ptr::NonNull::new(args.log).expect("args.log is non-null");
             // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM;
             // `args.log` is non-null (checked above) and outlives this call.
+            // The package manager keeps its own log; route what it has so far
+            // to the transpiler log and what it logs during this transpile to
+            // `args.log`.
             unsafe {
                 (*jsc_vm).transpiler.log = args.log;
                 (*jsc_vm).transpiler.resolver.log = args_log_nn;
                 (*jsc_vm).transpiler.linker.log = args.log;
                 if let Some(pm) = (*jsc_vm).transpiler.resolver.package_manager {
-                    (*pm.cast::<bun_install::PackageManager>().as_ptr()).log = args.log;
+                    (*pm.cast::<bun_install::PackageManager>().as_ptr())
+                        .take_log_into(&mut *old_log);
                 }
             }
             let _log_guard = scopeguard::guard(jsc_vm, move |jsc_vm| {
@@ -2424,7 +2433,8 @@ fn transpile_source_code_inner(
                     (*jsc_vm).transpiler.resolver.log = old_log_nn;
                     (*jsc_vm).transpiler.linker.log = old_log;
                     if let Some(pm) = (*jsc_vm).transpiler.resolver.package_manager {
-                        (*pm.cast::<bun_install::PackageManager>().as_ptr()).log = old_log;
+                        (*pm.cast::<bun_install::PackageManager>().as_ptr())
+                            .take_log_into(&mut *args.log);
                     }
                 }
             });

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2370,13 +2370,11 @@ impl FetchTasklet {
         let prev_can_stream = task_ref.result.can_stream;
         // `result.body` borrows the HTTP thread's scratch buffer on non-terminal
         // callbacks; the terminal callback carries the bytes in `body_owned`
-        // instead. Capture both before `detach_lifetime` clears them in the
+        // instead. Capture both before `without_body` clears them in the
         // stored copy.
         let body: &[u8] = result.body;
         let body_owned: Vec<u8> = core::mem::take(&mut result.body_owned);
-        // SAFETY: lifetime erasure for non-body fields; `body` is stored as
-        // `&'static []` so no borrow escapes.
-        task_ref.result = unsafe { result.detach_lifetime() };
+        task_ref.result = result.without_body();
         // can_stream is a one-shot signal to start the request body stream; don't let a
         // later coalesced result clobber it before the JS thread sees it.
         task_ref.result.can_stream = task_ref.result.can_stream || prev_can_stream;

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -389,10 +389,7 @@ impl S3HttpSimpleTask {
     ) {
         let previous_metadata = self.result.metadata.take();
         result.body_into(&mut self.response_buffer.list);
-        // SAFETY: `result.body` (the only borrowed field) points at `self.response_buffer`,
-        // which lives for the task's lifetime — extending to `'static` here is sound for
-        // self-reference.
-        self.result = unsafe { result.detach_lifetime() };
+        self.result = result.without_body();
         if self.result.metadata.is_none() {
             self.result.metadata = previous_metadata;
         }

--- a/src/semver/Cargo.toml
+++ b/src/semver/Cargo.toml
@@ -15,3 +15,4 @@ bun_alloc.workspace = true
 bun_core.workspace = true
 bun_collections.workspace = true
 bun_wyhash.workspace = true
+bytemuck = { version = "1", features = ["derive"] }

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -15,19 +15,37 @@ pub type Version = VersionType<u64>;
 // from its integer parameter. Only u32 and u64 are instantiated.
 // ──────────────────────────────────────────────────────────────────────────
 
-pub trait VersionInt: Copy + Default + Eq + Ord + fmt::Display + 'static {
+/// The integer width of a [`VersionType`] (`u32` for old lockfiles, `u64`).
+///
+/// # Safety
+/// The layout promises `VersionType<Self>` and the lockfile types built on it
+/// are `Pod` under: `align_of::<Self>() <= 8`; `3 * size_of::<Self>() +
+/// size_of::<TagPadding>()` is a multiple of 8 (so `TagPadding` exactly fills
+/// the gap before the 8-aligned `tag`); and `ResolutionStorage` is an
+/// 8-aligned integer array of at least `8 + size_of::<VersionType<Self>>()`
+/// bytes.
+pub unsafe trait VersionInt:
+    bytemuck::Pod + Default + Eq + Ord + fmt::Display + 'static
+{
     const ZERO: Self;
     const MAX: Self;
     /// Explicit zeroed
     /// padding so lockfile byte-serialization is deterministic.
-    type TagPadding: Copy + Default + 'static;
+    type TagPadding: bytemuck::Pod + Default + 'static;
+    /// Raw storage for the largest lockfile resolution payload at this width
+    /// (a `VersionedURL`: `String` + `VersionType<Self>`), 8-byte aligned.
+    type ResolutionStorage: bytemuck::Pod + Default + PartialEq + Send + Sync + 'static;
+    const RESOLUTION_STORAGE_ZERO: Self::ResolutionStorage;
     fn parse_ascii(s: &[u8]) -> Option<Self>;
 }
 
-impl VersionInt for u64 {
+// SAFETY: layout asserted below (`VersionType<u64>` is 56 bytes, tag at 24).
+unsafe impl VersionInt for u64 {
     const ZERO: Self = 0;
     const MAX: Self = u64::MAX;
     type TagPadding = [u8; 0];
+    type ResolutionStorage = [u64; 8];
+    const RESOLUTION_STORAGE_ZERO: [u64; 8] = [0; 8];
     #[inline]
     fn parse_ascii(s: &[u8]) -> Option<Self> {
         // None for empty, any non-[0-9] byte, or overflow. Callers rely on
@@ -37,10 +55,13 @@ impl VersionInt for u64 {
     }
 }
 
-impl VersionInt for u32 {
+// SAFETY: layout asserted below (`VersionType<u32>` is 48 bytes, tag at 16).
+unsafe impl VersionInt for u32 {
     const ZERO: Self = 0;
     const MAX: Self = u32::MAX;
     type TagPadding = [u8; 4];
+    type ResolutionStorage = [u64; 7];
+    const RESOLUTION_STORAGE_ZERO: [u64; 7] = [0; 7];
     #[inline]
     fn parse_ascii(s: &[u8]) -> Option<Self> {
         bun_core::parse_unsigned::<u32>(s, 10).ok()
@@ -73,6 +94,13 @@ const _: () = {
     assert!(core::mem::offset_of!(VersionType<u64>, tag) == 24);
     assert!(core::mem::offset_of!(VersionType<u32>, tag) == 16);
 };
+
+// SAFETY: `repr(C)`, every field is `Pod` (`T`, `T::TagPadding`, `Tag`), and
+// `TagPadding` fills the only alignment gap (the `VersionInt` contract;
+// asserted above for both widths).
+unsafe impl<T: VersionInt> bytemuck::Zeroable for VersionType<T> {}
+// SAFETY: as above.
+unsafe impl<T: VersionInt> bytemuck::Pod for VersionType<T> {}
 
 impl<T: VersionInt> Default for VersionType<T> {
     fn default() -> Self {
@@ -925,7 +953,7 @@ impl<T: VersionInt> Partial<T> {
 // ──────────────────────────────────────────────────────────────────────────
 
 #[repr(C)]
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Default, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct Tag {
     pub pre: ExternalString,
     pub build: ExternalString,

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -160,7 +160,7 @@ pub mod external_string {
     use super::semver_string::{Formatter, String};
 
     #[repr(C)]
-    #[derive(Clone, Copy, Default)]
+    #[derive(Clone, Copy, Default, Debug, bytemuck::Pod, bytemuck::Zeroable)]
     pub struct ExternalString {
         pub value: String,
         pub hash: u64,
@@ -231,7 +231,7 @@ pub mod semver_string {
 
     /// String type that stores either an offset/length into an external buffer or a string inline directly
     #[repr(C)]
-    #[derive(Copy, Clone, PartialEq, Eq, Default)]
+    #[derive(Copy, Clone, PartialEq, Eq, Default, bytemuck::Pod, bytemuck::Zeroable)]
     pub struct String {
         /// This is three different types of string.
         /// 1. Empty string. If it's all zeroes, then it's an empty string.

--- a/src/sha_hmac/sha.rs
+++ b/src/sha_hmac/sha.rs
@@ -130,6 +130,12 @@ macro_rules! new_evp {
                 this
             }
 
+            /// One-shot digest with BoringSSL's default engine.
+            pub fn hash_with_default_engine(bytes: &[u8], out: &mut [u8; $digest_size]) {
+                // SAFETY: a null engine selects the default implementation.
+                unsafe { Self::hash(bytes, out, ptr::null_mut()) }
+            }
+
             /// # Safety
             /// `engine` must be null (default engine) or a live `ENGINE*`.
             pub unsafe fn hash(

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -507,6 +507,40 @@ pub fn CreateHardLinkW(
 
 pub use bun_windows_sys::externs::CopyFileW;
 
+/// `CopyFileW`; false on failure (see `Win32Error::get()`).
+pub fn copy_file_w(src: &bun_core::WStr, dest: &bun_core::WStr, fail_if_exists: bool) -> bool {
+    // SAFETY: both are NUL-terminated wide strings.
+    unsafe { CopyFileW(src.as_ptr(), dest.as_ptr(), fail_if_exists as BOOL) != 0 }
+}
+
+/// `DeleteFileW`; false on failure (see `Win32Error::get()`).
+pub fn delete_file_w(path: &bun_core::WStr) -> bool {
+    // SAFETY: NUL-terminated wide string.
+    unsafe { DeleteFileW(path.as_ptr()) != 0 }
+}
+
+/// `CreateDirectoryExW` with no security attributes; false on failure.
+pub fn create_directory_ex_w(template: &bun_core::WStr, new_directory: &bun_core::WStr) -> bool {
+    // SAFETY: both are NUL-terminated wide strings; null attributes are allowed.
+    unsafe {
+        CreateDirectoryExW(
+            template.as_ptr(),
+            new_directory.as_ptr(),
+            core::ptr::null_mut(),
+        ) != 0
+    }
+}
+
+/// `GetFinalPathNameByHandleW` into `buf`; the length written, or 0 /
+/// `>= buf.len()` on failure exactly as the Win32 call reports.
+pub fn get_final_path_name_by_handle_w(handle: HANDLE, buf: &mut [u16], flags: DWORD) -> usize {
+    // SAFETY: `buf` is writable for `buf.len()` code units.
+    unsafe {
+        externs::GetFinalPathNameByHandleW(handle, buf.as_mut_ptr(), buf.len() as u32, flags)
+            as usize
+    }
+}
+
 /// `bun.windows.Error` — alias for `Win32Error`.
 pub type Error = Win32Error;
 
@@ -542,6 +576,12 @@ pub use bun_windows_sys::externs::GetHostNameW;
 
 /// https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw
 pub use bun_windows_sys::externs::GetTempPathW;
+
+/// `GetTempPathW` into `buf`; the length written (0 on failure).
+pub fn get_temp_path_w(buf: &mut [u16]) -> usize {
+    // SAFETY: `buf` is writable for `buf.len()` code units.
+    unsafe { GetTempPathW(buf.len() as u32, buf.as_mut_ptr().cast_const()) as usize }
+}
 
 /// `GetCurrentProcessId` (processthreadsapi.h) — current PID. Safe wrapper:
 /// the underlying call has no preconditions and never fails.

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -451,6 +451,38 @@ impl Batch {
         }
     }
 
+    /// Queue a heap-allocated task; the pool owns the `Box` until
+    /// [`OwnedTask::run`](crate::work_pool::OwnedTask::run) receives it back on
+    /// a worker thread.
+    pub fn push_owned<T: crate::work_pool::OwnedTask>(&mut self, mut task: Box<T>) {
+        task.task_mut().callback = T::__callback;
+        let raw = Box::into_raw(task);
+        // SAFETY: `raw` is the live allocation just leaked; `field_of` projects
+        // to its embedded `Task`, which the pool hands to `T::__callback` once.
+        self.push(Batch::from(unsafe {
+            <T as bun_core::IntrusiveField<Task>>::field_of(raw)
+        }));
+    }
+
+    /// One reference to an [`ArcTask`](crate::work_pool::ArcTask); the pool
+    /// gives it back to `T::run` when the task runs. A value that is already
+    /// queued (not yet dequeued by a worker) is not queued again (the
+    /// reference is dropped); one whose `run` is in progress is.
+    pub fn push_arc<T: crate::work_pool::ArcTask>(&mut self, task: std::sync::Arc<T>) {
+        if task.shared_task().try_queue(T::__callback).is_none() {
+            return;
+        }
+        let raw = std::sync::Arc::into_raw(task);
+        // Offset the whole-allocation pointer (rather than reborrow the
+        // field) so the callback's walk back to `T` has provenance over all
+        // of it; the field is a `SharedTask`, which starts with the `Task`.
+        let node = raw
+            .wrapping_byte_add(T::TASK_OFFSET)
+            .cast::<Task>()
+            .cast_mut();
+        self.push(Batch::from(node));
+    }
+
     /// Another batch into this one, taking ownership of its tasks.
     pub fn push(&mut self, batch: Batch) {
         if batch.len == 0 {
@@ -646,6 +678,20 @@ impl ThreadPool {
             self.run_queue.push(&list);
         }
         self.force_spawn();
+    }
+
+    /// [`Batch::push_owned`] + [`schedule`](Self::schedule) for one task.
+    pub fn schedule_owned<T: crate::work_pool::OwnedTask>(&self, task: Box<T>) {
+        let mut batch = Batch::default();
+        batch.push_owned(task);
+        self.schedule(batch);
+    }
+
+    /// Schedule an [`ArcTask`](crate::work_pool::ArcTask); see [`Batch::push_arc`].
+    pub fn schedule_arc<T: crate::work_pool::ArcTask>(&self, task: std::sync::Arc<T>) {
+        let mut batch = Batch::default();
+        batch.push_arc(task);
+        self.schedule(batch);
     }
 
     /// Schedule a batch of tasks to be executed by some thread on the thread pool.

--- a/src/threading/lib.rs
+++ b/src/threading/lib.rs
@@ -13,6 +13,7 @@ pub mod reset_event;
 pub mod rwlock;
 #[path = "Semaphore.rs"]
 pub mod semaphore;
+pub mod task_slots;
 #[path = "ThreadPool.rs"]
 pub mod thread_pool;
 pub mod work_pool;
@@ -36,11 +37,12 @@ pub use reset_event::ResetEvent;
 pub use rwlock::RwLock;
 pub use semaphore::Semaphore;
 pub use signal_ring::SignalRing;
+pub use task_slots::{SharedTask, SlotTask, TaskSlots};
 pub use thread_pool::ThreadPool;
-pub use unbounded_queue::{Link, Linked, UnboundedQueue};
+pub use unbounded_queue::{Link, Linked, OwnedDrain, OwnedQueue, UnboundedQueue};
 pub use wait_group::WaitGroup;
 pub use work_pool::Task as WorkPoolTask;
-pub use work_pool::{IntrusiveWorkTask, OwnedTask, WorkPool};
+pub use work_pool::{ArcTask, IntrusiveWorkTask, OwnedTask, WorkPool};
 
 /// Returns a non-zero OS thread id.
 /// Used by `Mutex` debug deadlock detection and `Condition` (Windows).

--- a/src/threading/task_slots.rs
+++ b/src/threading/task_slots.rs
@@ -1,0 +1,265 @@
+//! Thread-pool work items that stay owned by (and shared with) their
+//! scheduler while they run: [`SharedTask`] is the queue node, [`TaskSlots`]
+//! a fixed set of them addressed by index.
+
+use core::cell::UnsafeCell;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use crate::thread_pool::{Batch, Node, Task, ThreadPool};
+
+/// An intrusive pool node for a value other threads keep referring to while
+/// it is queued. The pool links it through the `UnsafeCell`; `queued` makes
+/// "one outstanding schedule per node" structural rather than a caller rule.
+#[repr(C)]
+pub struct SharedTask {
+    /// First, so the pool's `*mut Task` is also this struct's address.
+    task: UnsafeCell<Task>,
+    queued: AtomicBool,
+}
+
+// SAFETY: `task` is only written (by us in `try_queue`, then by the pool)
+// between a successful `try_queue` and `release`, which `queued` serializes.
+unsafe impl Sync for SharedTask {}
+// SAFETY: as above.
+unsafe impl Send for SharedTask {}
+
+impl SharedTask {
+    pub const fn new(callback: unsafe fn(*mut Task)) -> Self {
+        Self {
+            task: UnsafeCell::new(Task {
+                node: Node {
+                    next: core::ptr::null_mut(),
+                },
+                callback,
+            }),
+            queued: AtomicBool::new(false),
+        }
+    }
+
+    /// Claim the node for one trip through the pool, to run `callback`;
+    /// `None` if it is already claimed (queued and not yet released).
+    #[inline]
+    pub fn try_queue(&self, callback: unsafe fn(*mut Task)) -> Option<*mut Task> {
+        if self.queued.swap(true, Ordering::AcqRel) {
+            return None;
+        }
+        let task = self.task.get();
+        // SAFETY: we hold the claim, so nothing else touches the node.
+        unsafe { (*task).callback = callback };
+        Some(task)
+    }
+
+    /// The callback is done with the node; it may be queued again.
+    #[inline]
+    pub fn release(&self) {
+        self.queued.store(false, Ordering::Release);
+    }
+}
+
+/// One unit of work in a [`TaskSlots`]. `run` executes on a worker thread
+/// while the scheduling thread keeps `&Self`; a slot scheduled again while
+/// its `run` is in progress runs again, possibly overlapping the first.
+///
+/// # Safety
+/// `run` may only touch state that is synchronized with every other holder
+/// of `&Self` and with an overlapping `run` of the same slot (the value is
+/// shared across threads for the run even if it is not `Sync`).
+/// [`slot_task!`](crate::slot_task) states that at the type.
+pub unsafe trait SlotTask: Sized {
+    fn run(&self);
+}
+
+/// Implements [`SlotTask`] by forwarding to an inherent `fn run_slot(&self)`,
+/// the type's worker-thread entry point: it must only touch state
+/// synchronized with the scheduling thread and with an overlapping `run_slot`
+/// of the same value (a slot can be claimed again as soon as its run starts).
+#[macro_export]
+macro_rules! slot_task {
+    ([$($gen:tt)*] $ty:ty) => {
+        // SAFETY: see the macro doc — `run_slot` is the type's cross-thread entry point.
+        unsafe impl<$($gen)*> $crate::task_slots::SlotTask for $ty {
+            #[inline]
+            fn run(&self) {
+                <$ty>::run_slot(self)
+            }
+        }
+    };
+    ($ty:ty) => {
+        $crate::slot_task!([] $ty);
+    };
+}
+
+#[repr(C)]
+struct Slot<T> {
+    /// First, so the pool's `*mut Task` is also the slot's address.
+    task: SharedTask,
+    /// The owning [`TaskSlots`]' outstanding-work count.
+    pending: *const AtomicUsize,
+    value: T,
+}
+
+/// `len` tasks addressed by index; [`schedule`](Self::schedule) runs slot
+/// `i`'s [`SlotTask::run`] on the pool. A slot that is already queued (not
+/// yet running) is not queued again. Dropping waits for every outstanding
+/// run, so a queued slot never outlives its storage.
+pub struct TaskSlots<T: SlotTask> {
+    slots: Box<[Slot<T>]>,
+    /// Queued-or-running slots; boxed so the slots can point at it.
+    pending: Box<AtomicUsize>,
+}
+
+// SAFETY: `Slot::pending` points into our own `Box<AtomicUsize>`; everything
+// else is `T` (bounded) and `SharedTask` (`Sync`).
+unsafe impl<T: SlotTask + Sync> Sync for TaskSlots<T> {}
+// SAFETY: as above.
+unsafe impl<T: SlotTask + Send> Send for TaskSlots<T> {}
+
+impl<T: SlotTask> TaskSlots<T> {
+    pub fn new(values: impl IntoIterator<Item = T>) -> Self {
+        let pending = Box::new(AtomicUsize::new(0));
+        let pending_ptr: *const AtomicUsize = &raw const *pending;
+        Self {
+            slots: values
+                .into_iter()
+                .map(|value| Slot {
+                    task: SharedTask::new(run_slot::<T>),
+                    pending: pending_ptr,
+                    value,
+                })
+                .collect(),
+            pending,
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+
+    #[inline]
+    pub fn get(&self, index: usize) -> &T {
+        &self.slots[index].value
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.slots.iter().map(|slot| &slot.value)
+    }
+
+    fn claim(&self, index: usize) -> Option<*mut Task> {
+        let slot: *const Slot<T> = &raw const self.slots[index];
+        // SAFETY: `slot` is a live element of `self.slots`.
+        unsafe { &(*slot).task }.try_queue(run_slot::<T>)?;
+        self.pending.fetch_add(1, Ordering::AcqRel);
+        // The whole-slot pointer (not a reborrow of the `task` field) so the
+        // callback's cast back to `Slot<T>` has provenance over `value`.
+        Some(slot.cast::<Task>().cast_mut())
+    }
+
+    /// Add slot `index` to `batch` (no-op if it is already queued).
+    pub fn push(&self, index: usize, batch: &mut Batch) {
+        if let Some(task) = self.claim(index) {
+            batch.push(Batch::from(task));
+        }
+    }
+
+    /// Run slot `index` on `pool` (no-op if it is already queued).
+    pub fn schedule(&self, pool: &ThreadPool, index: usize) {
+        if let Some(task) = self.claim(index) {
+            pool.schedule(Batch::from(task));
+        }
+    }
+}
+
+impl<T: SlotTask> Drop for TaskSlots<T> {
+    fn drop(&mut self) {
+        // A queued slot points into `slots`; wait it out rather than free it.
+        while self.pending.load(Ordering::Acquire) != 0 {
+            std::thread::yield_now();
+        }
+    }
+}
+
+unsafe fn run_slot<T: SlotTask>(task: *mut Task) {
+    // SAFETY: `task` is the address of a `#[repr(C)] Slot<T>` (see `claim`)
+    // inside a `TaskSlots<T>` that `Drop` keeps alive while `pending` is
+    // non-zero; the pool only runs what `claim` queued.
+    let slot = unsafe { &*task.cast::<Slot<T>>() };
+    let pending = slot.pending;
+    // The node is off the pool's queue now, so it may be queued again while
+    // `run` is still going (e.g. the scheduler reacting to what `run`
+    // publishes); `pending` keeps the storage alive for this run regardless.
+    slot.task.release();
+    slot.value.run();
+    // SAFETY: `pending` is the owning `TaskSlots`' boxed counter, alive until
+    // it reads zero (see `Drop`); `slot` is not touched past this point.
+    unsafe { &*pending }.fetch_sub(1, Ordering::AcqRel);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicU32};
+
+    struct SendTask(*mut Task);
+    // SAFETY: what the pool does — the claimed node is handed to one worker.
+    unsafe impl Send for SendTask {}
+    impl SendTask {
+        fn run_on_thread(self) -> std::thread::JoinHandle<()> {
+            std::thread::Builder::new()
+                .spawn(move || {
+                    let SendTask(task) = { self };
+                    // SAFETY: `task` came from `claim`, exactly as the pool gets it.
+                    unsafe { ((*task).callback)(task) };
+                })
+                .unwrap()
+        }
+    }
+
+    fn wait_for(cond: impl Fn() -> bool) {
+        while !cond() {
+            std::thread::yield_now();
+        }
+    }
+
+    /// The scheduler learns that a slot finished from something `run`
+    /// publishes, and may queue the slot again before `run` has returned.
+    /// That second claim must succeed.
+    #[test]
+    fn a_slot_claimed_again_while_its_run_is_returning_runs_again() {
+        struct Step {
+            runs: AtomicU32,
+            rescheduled: AtomicBool,
+        }
+        // SAFETY: every field is synchronized.
+        unsafe impl SlotTask for Step {
+            fn run(&self) {
+                let n = self.runs.fetch_add(1, Ordering::AcqRel) + 1;
+                if n == 1 {
+                    // Still inside `run` while the scheduler reacts.
+                    wait_for(|| self.rescheduled.load(Ordering::Acquire));
+                }
+            }
+        }
+
+        let slots = TaskSlots::new([Step {
+            runs: AtomicU32::new(0),
+            rescheduled: AtomicBool::new(false),
+        }]);
+        let step = slots.get(0);
+
+        let first = SendTask(slots.claim(0).expect("idle slot")).run_on_thread();
+        wait_for(|| step.runs.load(Ordering::Acquire) >= 1);
+        let second = slots.claim(0);
+        step.rescheduled.store(true, Ordering::Release);
+        first.join().unwrap();
+        let second = second.expect("claim while the first run is still inside `run`");
+        SendTask(second).run_on_thread().join().unwrap();
+        assert_eq!(step.runs.load(Ordering::Acquire), 2);
+        drop(slots);
+    }
+}

--- a/src/threading/unbounded_queue.rs
+++ b/src/threading/unbounded_queue.rs
@@ -333,3 +333,110 @@ impl<T: Node> UnboundedQueue<T> {
         self.back.0.load(Ordering::Acquire).is_null()
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OwnedQueue<T> — an `UnboundedQueue` whose nodes are `Box<T>`
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// An [`UnboundedQueue`] that owns its nodes: producers hand over a `Box<T>`,
+/// the consumer gets `Box<T>`s back. Multi-producer / single-consumer like the
+/// underlying queue.
+pub struct OwnedQueue<T: Node>(UnboundedQueue<T>);
+
+impl<T: Node> Default for OwnedQueue<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Node> OwnedQueue<T> {
+    #[inline]
+    pub const fn new() -> Self {
+        Self(UnboundedQueue::new())
+    }
+
+    /// Move `item` into the queue. Callable from any thread.
+    #[inline]
+    pub fn push(&self, item: Box<T>) {
+        // SAFETY: `Box::into_raw` is a live, uniquely-owned node.
+        self.0
+            .push(unsafe { NonNull::new_unchecked(Box::into_raw(item)) });
+    }
+
+    /// Take everything queued so far.
+    #[inline]
+    pub fn drain(&self) -> OwnedDrain<T> {
+        OwnedDrain(self.0.pop_batch().iterator())
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl<T: Node> Drop for OwnedQueue<T> {
+    fn drop(&mut self) {
+        self.drain().for_each(drop);
+    }
+}
+
+/// The nodes taken by [`OwnedQueue::drain`], in push order.
+pub struct OwnedDrain<T: Node>(BatchIterator<T>);
+
+impl<T: Node> Iterator for OwnedDrain<T> {
+    type Item = Box<T>;
+    #[inline]
+    fn next(&mut self) -> Option<Box<T>> {
+        let p = self.0.next();
+        if p.is_null() {
+            return None;
+        }
+        // SAFETY: every node in an `OwnedQueue` came from `Box::into_raw` in
+        // `push`, and `pop_batch` unlinked it from the queue, so this is the
+        // only pointer to it.
+        Some(unsafe { Box::from_raw(p) })
+    }
+}
+
+impl<T: Node> Drop for OwnedDrain<T> {
+    fn drop(&mut self) {
+        self.for_each(drop);
+    }
+}
+
+// SAFETY: the queue owns `Box<T>`s that move between the producer and consumer
+// threads, so it is `Send`/`Sync` exactly when `Box<T>: Send`.
+unsafe impl<T: Node + Send> Send for OwnedQueue<T> {}
+// SAFETY: as above — `push(&self)` from any thread moves a `T` across.
+unsafe impl<T: Node + Send> Sync for OwnedQueue<T> {}
+
+/// Implements [`Linked`] for a struct that embeds a `Link<Self>` field.
+///
+/// ```ignore
+/// bun_threading::intrusive_linked!(Task, next);
+/// bun_threading::intrusive_linked!(['a] Task<'a>, next);
+/// ```
+#[macro_export]
+macro_rules! intrusive_linked {
+    ([$($gen:tt)*] $ty:ty, $field:ident) => {
+        // SAFETY: always projects to the same embedded `Link<Self>` field.
+        unsafe impl<$($gen)*> $crate::Linked for $ty {
+            #[inline]
+            unsafe fn link(item: *mut Self) -> *const $crate::Link<Self> {
+                // SAFETY: `item` is valid per the `UnboundedQueue` contract.
+                unsafe { ::core::ptr::addr_of!((*item).$field) }
+            }
+        }
+    };
+    ($ty:ty, $field:ident) => {
+        // SAFETY: always projects to the same embedded `Link<Self>` field.
+        unsafe impl $crate::Linked for $ty {
+            #[inline]
+            unsafe fn link(item: *mut Self) -> *const $crate::Link<Self> {
+                // SAFETY: `item` is valid per the `UnboundedQueue` contract.
+                unsafe { ::core::ptr::addr_of!((*item).$field) }
+            }
+        }
+    };
+}

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -67,6 +67,67 @@ pub unsafe trait OwnedTask: IntrusiveWorkTask + Send + 'static {
     }
 }
 
+/// A value shared through [`Arc`](std::sync::Arc) that the pool runs:
+/// [`ThreadPool::schedule_arc`](crate::ThreadPool::schedule_arc) hands one
+/// reference to the pool and the callback turns it back into the `Arc` for
+/// [`run`](ArcTask::run). The embedded [`SharedTask`](crate::SharedTask) is
+/// a single queue node: scheduling a value that is already queued (not yet
+/// dequeued by a worker) is a no-op (the reference is dropped). The node is
+/// released before `run` is called, so a value scheduled again while its
+/// `run` is in progress runs again, possibly overlapping the first.
+///
+/// # Safety
+/// [`run`](ArcTask::run) executes on an arbitrary worker thread while other
+/// threads may hold the `Arc`, and may overlap another `run` of the same
+/// value: everything `run` touches must be synchronized with them, whether
+/// or not the type is `Send`/`Sync`. Prefer [`arc_task!`](crate::arc_task),
+/// which states that at the type.
+pub unsafe trait ArcTask: Sized + 'static {
+    fn run(self: std::sync::Arc<Self>);
+
+    /// The embedded queue node.
+    fn shared_task(&self) -> &crate::SharedTask;
+
+    /// Byte offset of the [`SharedTask`](crate::SharedTask) field.
+    const TASK_OFFSET: usize;
+
+    #[doc(hidden)]
+    unsafe fn __callback(task: *mut Task) {
+        // SAFETY: `task` is the `SharedTask` field (its first member) inside
+        // the allocation whose `Arc` `Batch::push_arc` turned into a raw
+        // pointer; the pool runs this callback exactly once for it.
+        let this = unsafe {
+            std::sync::Arc::from_raw(task.cast::<u8>().sub(Self::TASK_OFFSET).cast::<Self>())
+        };
+        this.shared_task().release();
+        this.run();
+    }
+}
+
+/// Implements [`ArcTask`] for a struct that embeds a `$field: SharedTask`
+/// and is scheduled via [`ThreadPool::schedule_arc`](crate::ThreadPool::schedule_arc);
+/// the implementor supplies an inherent `fn run_arc(self: Arc<Self>)`, the
+/// type's worker-thread entry point: it must only touch state synchronized
+/// with the other holders of the `Arc` and with an overlapping `run_arc` of the
+/// same value (it can be scheduled again as soon as a run starts).
+#[macro_export]
+macro_rules! arc_task {
+    ($ty:ty, $field:ident) => {
+        // SAFETY: see the macro doc — `run_arc` is the type's cross-thread entry point.
+        unsafe impl $crate::work_pool::ArcTask for $ty {
+            const TASK_OFFSET: usize = ::core::mem::offset_of!($ty, $field);
+            #[inline]
+            fn shared_task(&self) -> &$crate::SharedTask {
+                &self.$field
+            }
+            #[inline]
+            fn run(self: ::std::sync::Arc<Self>) {
+                <$ty>::run_arc(self)
+            }
+        }
+    };
+}
+
 /// Implements [`IntrusiveWorkTask`] for a struct that embeds an intrusive
 /// `task: Task` field. Expands to [`bun_core::intrusive_field!`] + a marker
 /// impl; brings [`IntrusiveWorkTask::from_task_ptr`] into scope for the
@@ -103,9 +164,8 @@ macro_rules! intrusive_work_task {
 /// The `Send` impl is part of the macro because every `OwnedTask` is *by
 /// construction* sent to a worker thread — the per-type fields (raw `*mut
 /// EventLoop`, `*const JSGlobalObject`) are auto-`!Send` only nominally. The
-/// safety obligation
-/// ("all fields are sound to move across threads") is restated once here
-/// rather than at every `WorkPool::schedule(addr_of_mut!((*p).task))` site.
+/// safety obligation ("all fields are sound to move across threads") is
+/// restated once here rather than at every `schedule_owned` site.
 #[macro_export]
 macro_rules! owned_task {
     ([$($gen:tt)*] $ty:ty, $field:ident) => {

--- a/src/uws_sys/Loop.rs
+++ b/src/uws_sys/Loop.rs
@@ -243,6 +243,14 @@ impl PosixLoop {
         unsafe { c::us_wakeup_loop(self) };
     }
 
+    /// [`wakeup`](Self::wakeup) from any thread: `us_wakeup_loop` only signals
+    /// the loop's async handle, which libuv/kqueue/epoll allow concurrently.
+    pub fn wakeup_from_any_thread(&self) {
+        // SAFETY: valid loop; the call does not touch loop state beyond the
+        // thread-safe async signal.
+        unsafe { c::us_wakeup_loop(core::ptr::from_ref(self).cast_mut()) };
+    }
+
     pub fn tick(&mut self) {
         // SAFETY: self is a valid loop pointer
         unsafe { c::us_loop_run_bun_tick(self, core::ptr::null(), NOW_NS_UNKNOWN) };
@@ -373,6 +381,14 @@ impl WindowsLoop {
     pub fn wakeup(&mut self) {
         // SAFETY: self is a valid loop pointer
         unsafe { c::us_wakeup_loop(self) };
+    }
+
+    /// [`wakeup`](Self::wakeup) from any thread: `us_wakeup_loop` only signals
+    /// the loop's async handle, which libuv/kqueue/epoll allow concurrently.
+    pub fn wakeup_from_any_thread(&self) {
+        // SAFETY: valid loop; the call does not touch loop state beyond the
+        // thread-safe async signal.
+        unsafe { c::us_wakeup_loop(core::ptr::from_ref(self).cast_mut()) };
     }
 
     #[inline]


### PR DESCRIPTION
### What

Same programme as #40055 … #40273, applied to the package manager. **Stacked on #40204** (base branch `claude/subprocess-zero-unsafe`; retarget to main once that lands).

`src/install/**` (excluding the freestanding `windows-shim`): **500 → 0** `unsafe` blocks/fns/impls (the three remaining `grep` hits are the user-facing strings "unsafe name"/"unsafe folder path"). Per file: `PackageManager.rs` 40, `TarballStream.rs` 36, `runTasks.rs` 35, `NetworkTask.rs` 33, `PackageManagerEnqueue.rs` 31, `PackageInstall.rs` 28, `PackageManagerTask.rs` 26, `lifecycle_script_runner.rs` 26, `isolated_install/Installer.rs` 20, `PopulateManifestCache.rs` 19, `PackageManagerDirectories.rs` 18, `security_scanner.rs` 15, `install_with_manager.rs` 14, `lockfile/Package.rs` 12, `hoisted_install.rs` 11, `lockfile.rs` 11, `bin.rs` 10, and the long tail (`npm`, `repository`, `integrity`, `patch_install`, `auto_installer`, `yarn`, `bun.lock`, `Buffers`, `Tree`, `resolution`, `folder_resolver`, …) — all → 0. Collateral in the CLI: `pm_trusted_command.rs` 26 → 0, `outdated`/`scan`/`audit`/`dedupe` → 0. 105 files, net −1,570 lines.

- **Thread-pool tasks**: `bun_threading::{SharedTask, TaskSlots<T: SlotTask>, ArcTask + Batch::push_arc / ThreadPool::schedule_arc, OwnedTask + schedule_owned, OwnedQueue<T>}` replace the raw `*mut PackageManager` back-pointer tasks; worker tasks read the manager through `BackRef` with the sharing obligation stated at the `slot_task!`/`arc_task!`/`http_thread_context!` macro (same sharing as before, now named).
- **Network**: `NetworkTask.http: Option<bun_http::OwnedRequest>` (owns URL/header/proxy buffers; accessors bounded by `&self`), `OwnedRequestContext` + `HttpThreadContext`, `schedule_owned_request`; `HTTPClientResult::without_body` replaces the `detach_lifetime` twin.
- **Extraction**: `bun_libarchive::StreamingArchive<S: StreamSource>` owns its source.
- **Lockfile / types**: `bun_semver::VersionInt` (layout contract), `Pod`/`Zeroable` for `VersionType<T>`, `ExternalSlice<T>`, `VersionedURLType<I>`, `ResolutionValue<I>` (union → `[u64; N]` storage with typed views) — `from_raw_parts` over serialized bytes become checked casts; `ArrayHashMap::set_from_slices`/`resize_entries`; `Log::transfer_to`; `PackageManager.log: Box<Log>` with `with_log`/`with_lockfile_and_log`.
- **Event loop / sys**: `bun_event_loop::LoopWaker(BackRef<UwsLoop>)` + `AnyEventLoop::waker()`, `Loop::wakeup_from_any_thread(&self)`; `bun_sys::windows::{copy_file_w, delete_file_w, create_directory_ex_w, get_final_path_name_by_handle_w, get_temp_path_w}`; `bun_resolver::set_auto_installer_factory` replaces the `#[no_mangle]` link hook.

Parity notes: lifecycle scripts reaped synchronously during spawn are drained before blocking; `--frozen-lockfile`'s missing-workspace check works when the parse target is the manager's own lockfile; the runtime (auto-install) manager's log inherits the host log level. Pre-existing bug fixed in passing: migration manifest prefetch iterated the (empty) manager lockfile instead of the one being loaded.

**Perf** (release, `taskset -c 56-63`, interleaved, 1,303-package project, warm cache): `perf stat -e instructions:u` warm `bun install` 139.84 M → 129.50 M (**−7.4 %**), `--frozen-lockfile` no-op 134.99 M → 124.57 M (**−7.7 %**) — the hoist dedupe loop now walks a `Placed { id, name_hash }` list instead of indirecting through `Dependency`. Syscalls (`strace -f -c`): warm identical (158,186 vs 158,185); no-op identical except mimalloc's purge-thread `madvise` jitter (equal with `MIMALLOC_PURGE_DELAY` pinned); peak RSS slightly lower.

### Testing

Debug+ASAN, `--timeout 60000`: all of `test/cli/install/*.test.ts` + `migration/*` — bun-install 238, bun-add 70, bun-install-registry 245 (+5 todo), lifecycle-scripts 122, isolated 82, update 158, update-transitive 174, update-lockfile-sync 77, workspaces 75, lock 40, lockb 7, migrate 125, patch 37, streaming-extract 23, pm 22, link 4, frozen-lockfile-pruned 101, prune 110, security-provider 43, bunx 34, security-scanner matrices 720 + 688, catalogs 89, add-filter 123, add-catalog 149, publish 46, pack 80, audit 182, dedupe 76, and the rest green. Not green and not this PR: `bun-install-registry` "auto-install > symlinks" (fails identically with system bun in this environment) and `bun-install-proxy` (needs Docker). Hand-driven against the Verdaccio harness — fresh install (hoisted + isolated), reinstall from lockfile, add/remove/update, 5-package workspaces, trusted/untrusted lifecycle scripts, overrides, patch, `bun pm ls/hash/cache`, integrity mismatch, 404 package, SIGINT mid-install: `bun.lock` and `node_modules` listings byte-identical vs system bun. clippy clean on all 17 touched crates; `rust-check-all` windows-msvc + apple-darwin pass.