### PR TITLE
Do not read user-writable globals when creating require.cache

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -223,10 +223,9 @@ export function requireESMFromHijackedExtension(this: JSCommonJSModule, id: stri
 }
 
 $visibility = "Private";
-export function createRequireCache() {
-  var moduleMap = new Map();
+export function createRequireCache(Proxy: ProxyConstructor, inspectCustom: symbol) {
   var inner = {
-    [Symbol.for("nodejs.util.inspect.custom")]() {
+    [inspectCustom]() {
       return { ...proxy };
     },
   };
@@ -254,7 +253,6 @@ export function createRequireCache() {
     },
 
     deleteProperty(_target, key: string) {
-      moduleMap.$delete(key);
       $requireMap.$delete(key);
       $esmRegistryDelete(key);
       $evictIsolationSourceProviderCache(key);

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -12,6 +12,8 @@
 #include <JavaScriptCore/CallData.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/IteratorOperations.h>
+#include <JavaScriptCore/ProxyConstructorInlines.h>
+#include <JavaScriptCore/Symbol.h>
 #include "JavaScriptCore/Completion.h"
 #include "JavaScriptCore/JSNativeStdFunction.h"
 #include "JSCommonJSExtensions.h"
@@ -1173,8 +1175,14 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
 
             auto* function = JSFunction::create(vm, globalObject, static_cast<JSC::FunctionExecutable*>(commonJSCreateRequireCacheCodeGenerator(vm)), globalObject);
 
+            // A LazyProperty initializer cannot throw, so the builtin must not
+            // read user-writable globals like `Proxy` or `Symbol`.
+            JSC::MarkedArgumentBuffer args;
+            args.append(JSC::ProxyConstructor::create(vm, JSC::ProxyConstructor::createStructure(vm, globalObject, globalObject->functionPrototype())));
+            args.append(JSC::Symbol::create(vm, vm.symbolRegistry().symbolForKey("nodejs.util.inspect.custom"_s)));
+
             NakedPtr<JSC::Exception> returnedException = nullptr;
-            auto result = JSC::profiledCall(globalObject, ProfilingReason::API, function, JSC::getCallData(function), globalObject, ArgList(), returnedException);
+            auto result = JSC::profiledCall(globalObject, ProfilingReason::API, function, JSC::getCallData(function), globalObject, args, returnedException);
             ASSERT(!returnedException);
             init.set(result.toObject(globalObject));
         });

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -1175,8 +1175,6 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
 
             auto* function = JSFunction::create(vm, globalObject, static_cast<JSC::FunctionExecutable*>(commonJSCreateRequireCacheCodeGenerator(vm)), globalObject);
 
-            // A LazyProperty initializer cannot throw, so the builtin must not
-            // read user-writable globals like `Proxy` or `Symbol`.
             JSC::MarkedArgumentBuffer args;
             args.append(JSC::ProxyConstructor::create(vm, JSC::ProxyConstructor::createStructure(vm, globalObject, globalObject->functionPrototype())));
             args.append(JSC::Symbol::create(vm, vm.symbolRegistry().symbolForKey("nodejs.util.inspect.custom"_s)));

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -832,6 +832,25 @@ console.log("survived", require("./late.js"));`,
       delete require.cache["util/types"];
     }
   });
+  test("require.cache does not depend on user-writable globals", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Proxy, Map, Symbol } = globalThis;
+globalThis.Proxy = globalThis.Map = globalThis.Symbol = undefined;
+const cache = require.cache;
+Object.assign(globalThis, { Proxy, Map, Symbol });
+console.log(Object.getPrototypeOf(cache), cache === require("node:module")._cache, Object.keys(cache).length, Bun.inspect(cache).includes("[eval]"));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("null true 1 true\n");
+    expect(exitCode).toBe(0);
+  });
   test("require a cjs file uses the 'module.exports' export", () => {
     expect(require("./esm_to_cjs_interop.mjs")).toEqual(Symbol.for("meow"));
   });

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -849,6 +849,7 @@ console.log(Object.getPrototypeOf(cache), cache === require("node:module")._cach
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("null true 1 true\n");
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
   test("require a cjs file uses the 'module.exports' export", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a process abort when user code replaces `Proxy`, `Map`, or `Symbol` on the global object and then reads `require.cache` (or `Module._cache`) for the first time. Found by fuzzing.

`require.cache` is a `LazyProperty` on the global object. Its initializer in `src/jsc/modules/NodeModuleModule.cpp` calls the `createRequireCache` builtin and asserts that the call does not throw. A `LazyProperty` initializer cannot fail: `LazyProperty::set` has `RELEASE_ASSERT(value)` and `callFunc` asserts that `init.set` ran. The builtin read `Map`, `Symbol.for` and `Proxy` through the global object. A script like this made the builtin throw:

```js
globalThis.Proxy = undefined;
console.log(typeof require.cache);
```

Debug builds hit `ASSERTION FAILED: !returnedException` at `NodeModuleModule.cpp`. Release builds (canary 4448a2e21) report `panic(main thread): abort() called` because `result.toObject()` returns null into `init.set`.

The fix makes the builtin independent of user-writable globals:

- The native initializer passes a `ProxyConstructor` it creates itself, and the registered `Symbol.for("nodejs.util.inspect.custom")` symbol, as arguments to the builtin.
- The builtin takes them as parameters instead of reading the globals.
- The unused `moduleMap` (`new Map()`) is removed. Nothing ever wrote to it.

Behavior of `require.cache` is unchanged: same traps, null prototype, same `console.log` output, and `require.cache === Module._cache`.

Not covered here: `console.log` of an object with a `[Symbol.for("nodejs.util.inspect.custom")]` method aborts in the same way when `Symbol` is replaced. That comes from the `util.inspect` lazy initializer in `ZigGlobalObject.cpp` and is tracked separately.

### How did you verify your code works?

- The repro above and the `Map = 1` and `Symbol.for = null` variants abort on the debug build before the fix and exit 0 after it.
- New test in `test/js/node/module/node-module-module.test.js`: a spawned `bun -e` script replaces `Proxy`, `Map` and `Symbol`, reads `require.cache`, restores the globals, and checks the null prototype, identity with `Module._cache`, the `[eval]` entry and the `Bun.inspect` output. The test fails with `USE_SYSTEM_BUN=1 bun test` and passes with `bun bd test`.
- `bun bd test test/js/node/module/node-module-module.test.js` (48 pass, 1 skip) and `test/js/node/module/require-extensions.test.ts` pass. In `test/cli/run/require-cache.test.ts`, "require.cache is not an empty object literal when inspected" passes. The RSS leak tests in that file time out in my container on main as well (the fixture detects ASAN by the `bun-asan` file name), so they are not related.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->