### PR TITLE
bun test: do not record sibling-worker CPU contention in --parallel timings

### DIFF
--- a/src/runtime/cli/test/parallel/Coordinator.rs
+++ b/src/runtime/cli/test/parallel/Coordinator.rs
@@ -356,7 +356,17 @@ impl<'a> Coordinator<'a> {
         }
     }
 
-    fn record_timing(&mut self, file_idx: u32, dispatched_at: i64) {
+    /// Normal completion: the worker-reported duration (wall time minus
+    /// run-queue wait), unaffected by sibling-worker contention.
+    fn record_timing_ms(&mut self, file_idx: u32, ms: u32) {
+        if let Some(t) = self.reporter.timings.as_mut() {
+            t.record(self.files[file_idx as usize].as_bytes(), ms);
+        }
+    }
+
+    /// Crash path: no file_done frame arrived; wall time since dispatch is
+    /// all there is.
+    fn record_timing_since(&mut self, file_idx: u32, dispatched_at: i64) {
         if let Some(t) = self.reporter.timings.as_mut() {
             t.record_since(self.files[file_idx as usize].as_bytes(), dispatched_at);
         }
@@ -449,7 +459,7 @@ impl<'a> Coordinator<'a> {
                 Output::flush();
             }
             frame::Kind::FileDone => {
-                let mut nums = [0u32; 9];
+                let mut nums = [0u32; 10];
                 for n in nums.iter_mut() {
                     *n = rd.u32();
                 }
@@ -463,6 +473,7 @@ impl<'a> Coordinator<'a> {
                     skipped_label,
                     files,
                     unhandled,
+                    duration_ms,
                 ] = nums;
                 if let Some(file) = self.test_records.get_mut(idx as usize) {
                     file.elapsed_ns = rd.u64();
@@ -496,7 +507,7 @@ impl<'a> Coordinator<'a> {
                     summary.files += files;
                 }
                 self.reporter.jest.unhandled_errors_between_tests += unhandled;
-                self.record_timing(idx, w.dispatched_at);
+                self.record_timing_ms(idx, duration_ms);
 
                 w.inflight = None;
                 self.files_done += 1;
@@ -602,7 +613,7 @@ impl<'a> Coordinator<'a> {
             if self.stop_reason == Some(StopReason::WorkerPanicked) && !panicked {
                 self.account_unfinished(idx, b"aborted: sibling worker panicked");
             } else {
-                self.record_timing(idx, w.dispatched_at);
+                self.record_timing_since(idx, w.dispatched_at);
                 if w.ipc.corrupt_frame.get() && !panicked {
                     self.account_crash(
                         idx,

--- a/src/runtime/cli/test/parallel/Frame.rs
+++ b/src/runtime/cli/test/parallel/Frame.rs
@@ -16,8 +16,9 @@ pub enum Kind {
     /// u64 elapsed_ns, u32 line, str name, u32 n × {str scope_name,
     /// u32 scope_line}, u32 has_failure [, str name, str message, str body]
     TestDone,
-    /// 9 × u32: file_idx, pass, fail, skip, todo, expectations, skipped_label,
-    /// files, unhandled; u64 elapsed_ns
+    /// 10 × u32: file_idx, pass, fail, skip, todo, expectations, skipped_label,
+    /// files, unhandled, duration_ms (wall time minus run-queue wait; see
+    /// `runqueue_wait_ns` in runner.rs); u64 elapsed_ns
     FileDone,
     /// 3 × str: failures, skips, todos (verbatim repeat-buffer bytes)
     RepeatBufs,

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -552,6 +552,7 @@ impl<'a> WorkerLoop<'a> {
             let before_unhandled = self.reporter.jest.unhandled_errors_between_tests;
             let started_ns =
                 bun_core::Timespec::now(bun_core::TimespecMockMode::ForceRealTime).ns();
+            let wait_before_ns = runqueue_wait_ns();
 
             // A worker never knows which file is its last, so preload-level hooks wrap every file (with or without --isolate).
             if let Err(err) = TestCommand::run(
@@ -581,6 +582,19 @@ impl<'a> WorkerLoop<'a> {
                 .ns()
                 .saturating_sub(started_ns);
 
+            // --timings gets the file's own cost, not scheduler queueing:
+            // contended wall time scales with the worker count and misbalances
+            // --shard. Subtract only when both samples exist; a lone
+            // after-sample would subtract the thread's cumulative wait from
+            // before this file.
+            let waited_ns = match (wait_before_ns, runqueue_wait_ns()) {
+                (Some(before), Some(after)) => after.saturating_sub(before),
+                _ => 0,
+            };
+            let duration_ms =
+                u32::try_from(elapsed_ns.saturating_sub(waited_ns) / bun_core::time::NS_PER_MS)
+                    .unwrap_or(u32::MAX);
+
             let after = *self.reporter.summary();
             wf.begin(frame::Kind::FileDone);
             for v in [
@@ -593,12 +607,31 @@ impl<'a> WorkerLoop<'a> {
                 after.skipped_because_label - before.skipped_because_label,
                 after.files - before.files,
                 self.reporter.jest.unhandled_errors_between_tests - before_unhandled,
+                duration_ms,
             ] {
                 wf.u32(v);
             }
             wf.u64(elapsed_ns);
             self.cmds.send(wf.finish());
         }
+    }
+}
+
+/// Nanoseconds this thread has spent runnable but waiting for a CPU (Linux:
+/// second field of /proc/thread-self/schedstat). None elsewhere or on a
+/// failed read; the caller then records plain wall time.
+fn runqueue_wait_ns() -> Option<u64> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        // "<running_ns> <waiting_ns> <timeslices>"
+        let contents = bun_sys::File::read_from(Fd::cwd(), b"/proc/thread-self/schedstat").ok()?;
+        let mut fields = bun_core::strings::tokenize_any(&contents, b" \n");
+        let _running = fields.next();
+        bun_core::fmt::parse_int::<u64>(fields.next()?, 10).ok()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        None
     }
 }
 

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isWindows, normalizeBunSnapshot, tempDir, tls } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux, isWindows, normalizeBunSnapshot, tempDir, tls } from "harness";
 
 test("--parallel: each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID", async () => {
   // Sleep so worker 0 is busy when workers 1/2 come online and pick up the
@@ -1327,4 +1327,85 @@ test("--parallel --no-isolate: a worker keeps one global and module registry acr
   expect(shared.stderr).toContain("3 pass");
   expect(shared.stderr).not.toContain("error:");
   expect(shared.exitCode).toBe(0);
+});
+
+// --update-timings under --parallel: a file's recorded duration must be a
+// property of the file, not of how many sibling workers contend for the CPU
+// (issue #40283). The worker measures each file's wall time and subtracts the
+// time its main thread spent waiting on the run queue, so an oversubscribed
+// run records roughly the same numbers as an uncontended one. The subtraction
+// reads /proc/thread-self/schedstat, so this only holds on Linux. taskset
+// pins both runs to two CPUs so the oversubscription factor is deterministic.
+const taskset = isLinux ? Bun.which("taskset") : null;
+test.skipIf(!taskset)("--update-timings under --parallel does not record sibling-worker contention", async () => {
+  // Pin to the first two CPUs this process may use (containers and cgroups
+  // restrict affinity, so "0,1" is not always allowed). If the pin still
+  // fails there is no deterministic contention to measure.
+  const allowed = (await Bun.file("/proc/self/status").text()).match(/Cpus_allowed_list:\s*(\S+)/)?.[1] ?? "";
+  const cpus: number[] = [];
+  for (const part of allowed.split(",")) {
+    const [lo, hi = lo] = part.split("-").map(Number);
+    for (let c = lo; c <= hi && cpus.length < 2; c++) cpus.push(c);
+    if (cpus.length >= 2) break;
+  }
+  if (cpus.length === 0) return;
+  const pin = [taskset!, "-c", cpus.join(",")];
+  const probe = Bun.spawnSync({ cmd: [...pin, bunExe(), "--version"], env: bunEnv });
+  if (probe.exitCode !== 0) return;
+
+  // Calibrate a fixed-work spin to ~60ms on this build. Debug/ASAN builds run
+  // the same iteration count slower; both child runs use the same constant,
+  // and only their ratio is asserted.
+  const spin = (n: number) => {
+    let x = 1;
+    for (let i = 0; i < n; i++) x = (x * 1103515245 + 12345) % 2147483648;
+    return x;
+  };
+  let iters = 1 << 14;
+  let dt = 0;
+  for (;;) {
+    const t0 = performance.now();
+    spin(iters);
+    dt = performance.now() - t0;
+    if (dt >= 30 || iters >= 1 << 26) break;
+    iters *= 2;
+  }
+  iters = Math.max(1, Math.ceil((iters * 60) / Math.max(dt, 1)));
+
+  const fixture =
+    `import {test, expect} from "bun:test";\n` +
+    `test("spin", () => { let x = 1; for (let i = 0; i < ${iters}; i++) x = (x * 1103515245 + 12345) % 2147483648; expect(x).toBeGreaterThanOrEqual(0); });\n`;
+
+  // One file per worker, all dispatched at once; returns the median recorded
+  // duration in milliseconds.
+  const medianRecorded = async (count: number) => {
+    const files: Record<string, string> = {};
+    for (let i = 0; i < count; i++) files[`f${i}.test.ts`] = fixture;
+    using dir = tempDir(`parallel-timings-${count}`, files);
+    await using proc = Bun.spawn({
+      cmd: [...pin, bunExe(), "test", `--parallel=${count}`, "--timings=t.json", "--update-timings"],
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("PARALLEL");
+    expect(stderr).toContain(`${count} pass`);
+    expect(exitCode).toBe(0);
+    const json = await Bun.file(`${dir}/t.json`).json();
+    const recorded = Object.values(json.files) as number[];
+    expect(recorded).toHaveLength(count);
+    recorded.sort((a, b) => a - b);
+    return recorded[Math.floor(count / 2)];
+  };
+
+  // Two workers on two pinned CPUs: uncontended baseline.
+  const baseline = await medianRecorded(2);
+  // Ten workers on the same two CPUs: ~5x oversubscribed. Before the fix the
+  // recorded duration was the coordinator-observed wall time, which scales
+  // with the oversubscription factor; with the run-queue wait subtracted it
+  // stays near the baseline.
+  const contended = await medianRecorded(10);
+  expect(contended).toBeLessThan(Math.max(baseline, 25) * 3);
 });


### PR DESCRIPTION
### Problem
- `bun test --parallel --update-timings` records contended wall time, so the numbers it writes cannot balance `--shard` (#40283). The reporter saw the recorded sum inflate 36x and the fastest file 50x at `--parallel=24`.
- The coordinator timed each file from dispatch to its `file_done` frame (`Coordinator.rs` `record_timing`, `Worker.dispatched_at`). With more workers than cores that wall time includes scheduler queueing, so it scales with the worker count, not with the file's own cost.

### Fix
- The worker now subtracts from its measured wall time the time its main thread spent runnable but waiting for a CPU (the second field of `/proc/thread-self/schedstat` on Linux). What remains is the file's CPU time plus genuine blocking (timers, IO), which is stable across worker counts.
- The `file_done` frame carries the result as a tenth u32, `duration_ms`. The coordinator records it for `--timings`. The wall-clock `elapsed_ns` that #40678 added for reporting is unchanged, and the crash path keeps coordinator-observed wall time because no `file_done` frame arrives.
- Platforms without run-queue accounting subtract 0, so the recorded value falls back to the worker-observed wall time.
- Verified: `test/cli/test/parallel.test.ts` (new test pins two CPUs with taskset and compares 10 workers against 2: stock bun records a 5x median and fails). Also the full `parallel.test.ts`, `test-shard.test.ts`, and `rust:check-all`.

### Background
- `--timings` is a per-file millisecond table. `--shard` packs shards by its sums, and `--parallel` dispatches slowest-first from it, so a contended harvest actively misbalances shards.
- `--parallel` runs a coordinator plus worker processes that exchange length-prefixed frames over fd 3. `file_done` already carried nine per-file counters and a wall-clock `elapsed_ns`.

<details><summary>Notes</summary>

Measured on 8 cores, 24 identical CPU-bound files, sum of recorded durations:

| binary | `--parallel=1` | `--parallel=24` |
|---|---|---|
| unfixed release | 225 ms | 758 ms (3.4x) |
| fixed debug | 4763 ms | 7235 ms (1.5x) |

The issue's happy-dom repro inflated 6.7x on this machine and 36x on the reporter's 12-core machine. The residual 1.5x is real: with 24 processes sharing 8 cores, each instruction retires slower (cache and memory-bandwidth contention), and that extra CPU time is genuinely consumed. The run-queue subtraction removes only the time the thread was not running at all.

Scope decisions:

- Per-thread run-queue delay exists only on Linux (`/proc/thread-self/schedstat`). macOS has `proc_pid_rusage` `ri_runnable_time`, but it is process-wide (all threads, including JSC background threads) and its exact semantics are undocumented, so subtracting it risks under-recording. Windows exposes no equivalent. Both keep the previous wall-time behavior, now measured in the worker.
- Pure process CPU time was rejected as the metric: a file that sleeps or awaits a server would record near zero and `--shard` would pack many such files into one shard, blowing wall-clock timeouts the other way.
- The serial path (`--parallel=1` or plain `bun test`) is unchanged: a single process measuring its own files is not contended.

Rebase on #40678: main moved the per-file measurement into the worker as a wall-clock `u64 elapsed_ns` in `file_done`, used for reporter output, but `--timings` still recorded coordinator wall time since dispatch. Resolved by keeping `elapsed_ns` as is, sampling the run-queue wait around the same window, and appending `duration_ms = elapsed_ns - waited_ns` as the tenth u32. `record_timing` is split into `record_timing_ms` (normal completion) and `record_timing_since` (crash path), matching main's `account_crash(idx, dispatched_at, ...)` shape.

The new test calibrates a fixed-iteration spin to about 60 ms on the build under test, runs one file per worker with `BUN_TEST_PARALLEL_SCALE_MS=0`, and asserts the 10-worker median stays under 3x the 2-worker median. It derives the pinned CPUs from `Cpus_allowed_list` because containers restrict affinity. It skips when `taskset` is unavailable or pinning fails. Three runs under the debug/ASAN build passed at about 3.8 s each.

</details>
<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/parallel.test.ts

<!-- robobun:evidence:end -->
