### PR TITLE
Don't jsCast a string-like value to JSString after an is_string() check

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6738,7 +6738,7 @@ fn wrap_unhandled_rejection_error_for_uncaught_exception(
     const MSG_1: &str = "This error originated either by throwing inside of an async function \
         without a catch block, or by rejecting a promise which was not handled with .catch(). \
         The promise rejected with the reason \"";
-    if reason_str.is_string() {
+    if reason_str.is_string_literal() {
         let view = reason_str.as_string().view(global_object)?;
         return Ok(global_object
             .err(

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -1999,7 +1999,7 @@ fn import_windows_socket_payload(
     else {
         return Ok(None);
     };
-    let hex_view = info_value.as_string().view(global)?;
+    let hex_view = info_value.to_js_string_view(global)?;
     let hex = hex_view.to_utf8();
     let expected = bun_uws::socket_transfer::bsd_socket_export_size() as usize;
     let mut info = vec![0u8; expected];

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -335,7 +335,7 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
         let atype = address_type.to_int32();
 
         let host_owned: Vec<u8> = if address.is_string() {
-            let mut v = address.as_string().view(global)?.to_owned_slice();
+            let mut v = address.to_js_string_view(global)?.to_owned_slice();
             v.push(0);
             v
         } else {
@@ -423,7 +423,10 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
         let atype: i32;
         if address_type.is_string() {
             is_udp = true;
-            atype = if address_type.as_string().view(global)?.eql_comptime(b"udp6") {
+            atype = if address_type
+                .to_js_string_view(global)?
+                .eql_comptime(b"udp6")
+            {
                 6
             } else {
                 4
@@ -450,7 +453,7 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
             if !address.is_string() {
                 return Err(global.throw_invalid_argument_type_value("address", "string", address));
             }
-            let path_view = address.as_string().view(global)?;
+            let path_view = address.to_js_string_view(global)?;
             let path_slice = path_view.to_utf8();
             let path_bytes = path_slice.slice();
             // SAFETY: sockaddr_un is plain C data; all-zero is a valid value.
@@ -603,7 +606,7 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
         let fd: c_int;
         let bound_family: c_int;
         if address.is_string() {
-            let addr_view = address.as_string().view(global)?;
+            let addr_view = address.to_js_string_view(global)?;
             let addr_slice = addr_view.to_utf8();
             let addr_bytes = addr_slice.slice();
             let mut addr_z: [u8; 256] = [0; 256];

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -249,7 +249,7 @@ impl JSValkeyClient {
         let Some(callbacks) = self.get_callbacks(global_object, channel_name)? else {
             debug!(
                 "No callbacks found for channel {}",
-                channel_name.as_string().view(global_object)?
+                channel_name.to_js_string_view(global_object)?
             );
             return Ok(());
         };


### PR DESCRIPTION
### What does this PR do?

`JSValue::is_string()` is true for `String`, `StringObject` and `DerivedStringObject` cells, but `JSValue::as_string()` is an unchecked `jsCast<JSString*>` (it debug-asserts `is_string_literal()`). A handful of sites paired the loose guard with the strict cast:

```rust
if address.is_string() {
    let view = address.as_string().view(global)?;   // StringObject here would be a bad cast
```

- `node_cluster_binding.rs` `clusterRawBind`: `address` / `addressType` (4 sites)
- `ipc.rs` (Windows): the socket-info hex string on an internal IPC message
- `js_valkey.rs`: a debug log that cast the channel name with no guard
- `VirtualMachine.rs` unhandled-rejection wrapper: guard tightened to `is_string_literal()` (its input comes from `Bun__noSideEffectsToString`, always a primitive)

The first three now read through `to_js_string_view()`, which runs `toString()` (a boxed string yields its primitive) and borrows the result, so the guard and the read agree.

The values reaching these sites today are produced by Bun's own JS — `net.Server.listen` / `dgram.bind` normalise `path`/`host`/`address` to primitive strings before `cluster._getServer`, and the IPC key is written by the IPC layer — so I could not construct a user-visible repro; this removes the mismatched pair rather than fixing an observed crash.

### How did you verify your code works?

Debug build; ran a cluster worker binding a UDP socket through the primary (`clusterRawBind` path), `test/js/node/test/parallel/test-cluster-dgram-1.js`, `test-cluster-dgram-reuse.js`, `test-cluster-net-listen.js`, and `--unhandled-rejections=strict` with a string rejection reason (wrapper path). `cargo check` for the Windows target covers the `ipc.rs` site.