### PR TITLE
node:http: bound the header count with the engine's min, not the live Math.min

### DIFF
--- a/src/js/node/_http_common.ts
+++ b/src/js/node/_http_common.ts
@@ -122,7 +122,7 @@ function parserOnHeadersComplete(
 
   // If parser.maxHeaderPairs <= 0 assume that there's no limit.
   const maxHeaderPairs = parser.maxHeaderPairs;
-  if (maxHeaderPairs > 0) n = Math.min(n, maxHeaderPairs);
+  if (maxHeaderPairs > 0) n = $min(n, maxHeaderPairs);
 
   incoming._addHeaderLines(headers, n);
 

--- a/test/js/node/http/node-http-primoridals.test.ts
+++ b/test/js/node/http/node-http-primoridals.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 const Response = globalThis.Response;
 const Request = globalThis.Request;
@@ -127,4 +128,45 @@ test("Overriding Request, Response, Headers, and Blob should not break node:http
     globalThis.Headers = Headers;
     globalThis.Blob = Blob;
   }
+});
+
+// The response header count is bounded with the engine's own min(), so a
+// user-patched Math.min cannot make IncomingMessage read past the flat
+// [name, value, ...] header array.
+test("a patched Math.min does not reach IncomingMessage header parsing", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const http = require("http");
+      const server = http.createServer((req, res) => {
+        res.setHeader("x-server", "1");
+        res.end("ok");
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const origMin = Math.min;
+        Math.min = (...args) => origMin(...args) + 1;
+        process.on("uncaughtException", err => {
+          console.log("UNCAUGHT:", err.message);
+          process.exit(1);
+        });
+        http.get({ host: "127.0.0.1", port: server.address().port, headers: { "x-h": "v" } }, res => {
+          res.resume();
+          res.on("end", () => {
+            Math.min = origMin;
+            console.log("client: got", res.statusCode, res.headers["x-server"]);
+            server.close();
+          });
+        });
+      });
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("client: got 200 1\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- Since 1.4.0, a user patch of `Math.min` that changes its result makes every `node:http` response throw an uncaught `TypeError: undefined is not an object (evaluating 'field')` from `matchKnownFields` (`_http_incoming.ts`). Bun 1.3.14 and Node v26 are not affected.
- `parserOnHeadersComplete` in `src/js/node/_http_common.ts:125` clamps the header count with the live `Math.min`. With `Math.min` off by one, `_addHeaderLines` reads one pair past the end of the flat `[name, value, ...]` header array and passes `undefined` as a field name.

### Fix
- Clamp with `$min`, the `@min` link-time constant. It is the engine's own copy of `Math.min` and user code cannot reach it. This is the same construct `internal/fs/streams.ts` already uses.
- Node does the equivalent with its `MathMin` primordial in `lib/_http_common.js`.
- Verified: `test/js/node/http/node-http-primoridals.test.ts` (new test, fails on stock 1.4.0). Also `node-http.test.ts`, `node-http-parser.test.ts`, `node-http-maxHeaderSize.test.ts`, and the upstream `test-http-max-headers-count.js` / `test-http-parser*.js`.

### Background
- `maxHeaderPairs` is the parser-side cap that implements `server.maxHeadersCount`. It bounds how many header pairs the `IncomingMessage` materializes.
- A `$`-prefixed name in `src/js` is a JSC private name. `$min` resolves at bytecode compile time to a function object the runtime created at global object init, not through a property lookup on `Math`.
- The repro: load `node:http`, then set `Math.min = (...a) => orig(...a) + 1` and run one `http.get` against a local server.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-primoridals.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/170] gen ErrorCode+*.h
[2/170] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/170] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/debug/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[4/170] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - Fr
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/node/http/node-http-primoridals.test.ts:
closing time
(pass) Overriding Request, Response, Headers, and Blob should not break node:http server [27.21ms]
164 |     ],
165 |     env: bunEnv,
166 |     stderr: "pipe",
167 |   });
168 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
169 |   expect(stdout).toBe("client: got 200 1\n");
                       ^
error: expect(received).toBe(expected)

- "client: got 200 1
+ "UNCAUGHT: undefined is not an object (evaluating 'field')
  "

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/http/node-http-primoridals.test.ts:169:18)
(fail) a patched Math.min does not reach IncomingMessage header parsing [43.58ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [233.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-primoridals.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/http/node-http-primoridals.test.ts:
closing time
(pass) Overriding Request, Response, Headers, and Blob should not break node:http server [1512.30ms]
(pass) a patched Math.min does not reach IncomingMessage header parsing [2336.78ms]

 2 pass
 0 fail
 4 expect() calls
Ran 2 tests across 1 file. [5.85s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 643ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/130] gen ErrorCode+*.h
[2/130] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/130] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[4/130] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 244 extern-C blocks audited
[5/130] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/run
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_common.ts                     |  2 +-
 test/js/node/http/node-http-primoridals.test.ts | 42 +++++++++++++++++++++++++
 2 files changed, 43 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/js/node/_http_common.ts                          1      1      0
test/js/node/http/node-http-primoridals.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->