### PR TITLE
runner: survive a failed os.userInfo() lookup and a vanished node test file instead of ending the shard

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -28,7 +28,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { availableParallelism, userInfo } from "node:os";
+import { availableParallelism } from "node:os";
 import { basename, dirname, extname, join, relative, sep } from "node:path";
 import { createInterface } from "node:readline";
 import { setTimeout as setTimeoutPromise } from "node:timers/promises";
@@ -53,6 +53,7 @@ import {
   getOs,
   getSecret,
   getShell,
+  getUserInfo,
   getWindowsExitReason,
   isAndroid,
   isBuildkite,
@@ -1774,7 +1775,7 @@ function getCombinedPath(execPath) {
 async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTimeout, env, stdout, stderr }) {
   const path = getCombinedPath(execPath);
   const tmpdirPath = mkdtempSync(join(tmpdir(), "buntmp-"));
-  const { username, homedir } = userInfo();
+  const { username, homedir } = getUserInfo();
   const shellPath = getShell();
   const bunEnv = {
     ...process.env,

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -838,7 +838,28 @@ async function runTests() {
       const absoluteTestPath = join(testsPath, testPath);
       const title = relative(cwd, absoluteTestPath).replaceAll(sep, "/");
       if (isNodeTest(testPath)) {
-        const testContent = readFileSync(absoluteTestPath, "utf-8");
+        let testContent;
+        try {
+          testContent = readFileSync(absoluteTestPath, "utf-8");
+        } catch (error) {
+          // Listed at startup, gone now (a wiped checkout). A failed step keeps
+          // the run going where a throw would end it with no summary.
+          const stdout = error.stack || String(error);
+          return runTest(
+            title,
+            async () => ({
+              testPath: title,
+              ok: false,
+              status: "fail",
+              error: `read error: ${error.code || error.message}`,
+              errors: [],
+              tests: [],
+              stdout,
+              stdoutPreview: stdout,
+            }),
+            concurrent,
+          );
+        }
         const flagsMatch = /^\/\/ Flags:[^\S\r\n]+(--[^\r\n]*)$/m.exec(testContent);
         const testFlags = flagsMatch
           ? flagsMatch[1].split(/\s+/).filter(flag => resolutionGatingFlags.has(flag.split("=")[0]))

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1547,11 +1547,45 @@ export function getHostname() {
 }
 
 /**
- * @returns {string}
+ * @typedef {object} UserInfo
+ * @property {string | undefined} username
+ * @property {string | undefined} homedir
+ */
+
+/** @type {UserInfo | undefined} */
+let cachedUserInfo;
+
+/**
+ * The name and home directory of the user that runs this process, resolved once.
+ *
+ * `os.userInfo()` looks the user up in the passwd database on every call. On
+ * macOS that lookup goes through opendirectoryd, which can answer ENOENT for
+ * the running user's uid while the host is in a bad state. The values do not
+ * change for the lifetime of the process, and the login session sets the same
+ * values in the environment, so a failed lookup falls back to them.
+ * @returns {UserInfo}
+ */
+export function getUserInfo() {
+  if (!cachedUserInfo) {
+    try {
+      const { username, homedir } = userInfo();
+      cachedUserInfo = { username, homedir };
+    } catch (error) {
+      cachedUserInfo = {
+        username: getEnv("USER", false) || getEnv("LOGNAME", false) || getEnv("USERNAME", false),
+        homedir: getEnv("HOME", false) || getEnv("USERPROFILE", false),
+      };
+      console.warn("os.userInfo() failed, using the environment instead:", cachedUserInfo, error);
+    }
+  }
+  return cachedUserInfo;
+}
+
+/**
+ * @returns {string | undefined}
  */
 export function getUsername() {
-  const { username } = userInfo();
-  return username;
+  return getUserInfo().username;
 }
 
 /**

--- a/test/internal/runner-step-errors.test.ts
+++ b/test/internal/runner-step-errors.test.ts
@@ -1,23 +1,26 @@
 /**
- * scripts/runner.node.mjs sets USER and HOME for every test process it spawns
- * from os.userInfo(), the passwd entry of the user that runs the runner. It
- * used to call os.userInfo() in spawnBun, once per test file, with no handler
- * for a failed lookup. On macOS the lookup goes through opendirectoryd, which
- * can answer ENOENT for the running user while the host is in a bad state. One
- * such answer threw out of runTests() and ended the shard between two test
- * files with no test failure to report.
+ * scripts/runner.node.mjs runs one step per test file through runTest(), which
+ * retries and reports a step whose result says it failed. An exception thrown
+ * from the step path is not a result: it left runTests() and ended the shard
+ * with no summary for the files that had run. Two per-file sync calls in that
+ * path threw when a macOS agent wiped its checkout under a live job:
  *
- * The runner now resolves the user once per process, through getUserInfo() in
- * scripts/utils.mjs, and falls back to the environment when the lookup fails.
+ * - spawnBun called os.userInfo() for every test file to set USER and HOME for
+ *   the child. The lookup goes through opendirectoryd, which answered ENOENT.
+ *   The runner now resolves the user once per process, through getUserInfo()
+ *   in scripts/utils.mjs, and falls back to the environment when the lookup
+ *   fails.
+ * - runOneTest read a node test file (test/js/node/test/parallel/...) before
+ *   its step began. A file that is gone by then is now a failed step.
  *
- * Each case runs a copy of the runner from a temporary repository layout with
- * two test files. The copy runs under node, as in CI, with bunExe() as the bun
- * under test. A module preloaded with --import replaces os.userInfo: it counts
- * the calls, writes the count to a file when the process exits, and either
- * throws the ENOENT error or forwards to the real function.
+ * Each case runs a copy of the runner from a temporary repository layout. The
+ * copy runs under node, as in CI, with bunExe() as the bun under test. A module
+ * preloaded with --import replaces os.userInfo: it counts the calls, writes the
+ * count to a file when the process exits, and either throws the ENOENT error
+ * or forwards to the real function.
  */
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, nodeExe, tempDir } from "harness";
+import { bunEnv, bunExe, nodeExe, tempDir, type DirectoryTree } from "harness";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -87,17 +90,16 @@ async function nodeUserInfo(): Promise<UserInfo> {
 }
 
 /**
- * Runs a copy of the runner over two test files that expect `expected(repo)`
- * as their USER and HOME. Returns the steps the runner logged, its exit code,
- * the number of os.userInfo() calls it made, and its stderr.
+ * Runs a copy of the runner over the test files in `files`, with os.userInfo
+ * failing or working. Returns the steps the runner logged, its exit code, the
+ * number of os.userInfo() calls it made, and its stderr.
  */
-async function runRunner(fails: boolean, expected: (repo: string) => UserInfo) {
-  using repo = tempDir("runner-user-info", {
+async function runRunner(fails: boolean, files: DirectoryTree) {
+  using repo = tempDir("runner-step-errors", {
     ...Object.fromEntries(runnerFiles.map(file => [file, readFileSync(join(repoRoot, file))])),
     "preload.mjs": preload(fails),
-    "test/first.test.ts": ({ root }) => testFile(expected(root)),
-    "test/second.test.ts": ({ root }) => testFile(expected(root)),
     "home": {},
+    ...files,
   });
   const callsPath = join(String(repo), "userinfo-calls.txt");
   await using proc = Bun.spawn({
@@ -134,11 +136,17 @@ async function runRunner(fails: boolean, expected: (repo: string) => UserInfo) {
   return { steps, exitCode, userInfoCalls: Number(readFileSync(callsPath, "utf8")), stderr };
 }
 
-describe.skipIf(!node)("runner.node.mjs os.userInfo()", () => {
+/** Two test files that expect `expected(repo)` as their USER and HOME. */
+const userInfoFiles = (expected: (repo: string) => UserInfo): DirectoryTree => ({
+  "test/first.test.ts": ({ root }) => testFile(expected(root)),
+  "test/second.test.ts": ({ root }) => testFile(expected(root)),
+});
+
+describe.skipIf(!node)("runner.node.mjs step errors", () => {
   test.concurrent(
     "a failed passwd lookup does not end the shard: the test files run with USER and HOME from the environment",
     async () => {
-      const { steps, exitCode, userInfoCalls, stderr } = await runRunner(true, environmentUser);
+      const { steps, exitCode, userInfoCalls, stderr } = await runRunner(true, userInfoFiles(environmentUser));
 
       expect(stderr).toContain("os.userInfo() failed, using the environment instead");
       expect({ steps, exitCode, userInfoCalls }).toEqual({
@@ -151,7 +159,10 @@ describe.skipIf(!node)("runner.node.mjs os.userInfo()", () => {
 
   test.concurrent("the passwd lookup runs once per process, not once per test file", async () => {
     const passwd = await nodeUserInfo();
-    const { steps, exitCode, userInfoCalls, stderr } = await runRunner(false, () => passwd);
+    const { steps, exitCode, userInfoCalls, stderr } = await runRunner(
+      false,
+      userInfoFiles(() => passwd),
+    );
 
     expect(stderr).not.toContain("os.userInfo() failed");
     expect({ steps, exitCode, userInfoCalls }).toEqual({
@@ -160,4 +171,26 @@ describe.skipIf(!node)("runner.node.mjs os.userInfo()", () => {
       userInfoCalls: 1,
     });
   });
+
+  test.concurrent(
+    "a node test file that is gone by the time its step starts is a failed step, not the end of the run",
+    async () => {
+      // The runner lists the node test at startup. The bun test runs first (node
+      // tests run in a later phase) and removes it before the runner reads it.
+      const nodeTest = "test/js/node/test/parallel/test-gone.js";
+      const { steps, exitCode } = await runRunner(false, {
+        "test/first.test.ts": ({ root }) => `
+        import { test } from "bun:test";
+        import { unlinkSync } from "node:fs";
+        test("removes the node test file", () => unlinkSync(${JSON.stringify(join(root, nodeTest))}));
+      `,
+        [nodeTest]: `console.log("never runs");`,
+      });
+
+      expect({ steps, exitCode }).toEqual({
+        steps: ["test/first.test.ts", nodeTest, `${nodeTest} - read error: ENOENT`],
+        exitCode: 1,
+      });
+    },
+  );
 });

--- a/test/internal/runner-user-info.test.ts
+++ b/test/internal/runner-user-info.test.ts
@@ -1,0 +1,163 @@
+/**
+ * scripts/runner.node.mjs sets USER and HOME for every test process it spawns
+ * from os.userInfo(), the passwd entry of the user that runs the runner. It
+ * used to call os.userInfo() in spawnBun, once per test file, with no handler
+ * for a failed lookup. On macOS the lookup goes through opendirectoryd, which
+ * can answer ENOENT for the running user while the host is in a bad state. One
+ * such answer threw out of runTests() and ended the shard between two test
+ * files with no test failure to report.
+ *
+ * The runner now resolves the user once per process, through getUserInfo() in
+ * scripts/utils.mjs, and falls back to the environment when the lookup fails.
+ *
+ * Each case runs a copy of the runner from a temporary repository layout with
+ * two test files. The copy runs under node, as in CI, with bunExe() as the bun
+ * under test. A module preloaded with --import replaces os.userInfo: it counts
+ * the calls, writes the count to a file when the process exits, and either
+ * throws the ENOENT error or forwards to the real function.
+ */
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, nodeExe, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+
+// The runner and the files it imports relative to itself. The `bun test`
+// processes it spawns read leaksan.supp from <cwd>/test/.
+const runnerFiles = [
+  "scripts/runner.node.mjs",
+  "scripts/utils.mjs",
+  "scripts/p-limit.mjs",
+  "scripts/yocto-queue.mjs",
+  "test/docker/prestart-map.mjs",
+  "test/leaksan.supp",
+];
+
+const node = nodeExe();
+
+type UserInfo = { username: string; homedir: string };
+
+// The user in the runner process's environment. HOME is the `home` directory
+// of the repository layout. When the passwd lookup works, the runner replaces
+// both with the passwd values.
+const environmentUser = (repo: string): UserInfo => ({ username: "runner-user", homedir: join(repo, "home") });
+
+/** A test file that asserts the USER and HOME the runner gave its process. */
+const testFile = (expected: UserInfo) => `
+  import { expect, test } from "bun:test";
+  test("USER and HOME come from the runner", () => {
+    expect({ username: process.env.USER, homedir: process.env.HOME }).toEqual(${JSON.stringify(expected)});
+  });
+`;
+
+/** Replaces os.userInfo for the whole runner process, the runner's ESM import of it included. */
+const preload = (fails: boolean) => `
+  import { writeFileSync } from "node:fs";
+  import { syncBuiltinESMExports } from "node:module";
+  import os from "node:os";
+  const real = os.userInfo;
+  let calls = 0;
+  os.userInfo = options => {
+    calls++;
+    if (${fails}) {
+      const error = new Error("A system error occurred: uv_os_get_passwd returned ENOENT (no such file or directory)");
+      error.code = "ERR_SYSTEM_ERROR";
+      throw error;
+    }
+    return real(options);
+  };
+  syncBuiltinESMExports();
+  process.on("exit", () => writeFileSync(process.env.USERINFO_CALLS_PATH, String(calls)));
+`;
+
+/** The passwd entry as node reports it, which is what the runner passes on when the lookup works. */
+async function nodeUserInfo(): Promise<UserInfo> {
+  await using proc = Bun.spawn({
+    cmd: [node!, "-p", "JSON.stringify(require('node:os').userInfo())"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) throw new Error(`node -p os.userInfo() exited with ${exitCode}:\n${stderr}`);
+  const { username, homedir } = JSON.parse(stdout);
+  return { username, homedir };
+}
+
+/**
+ * Runs a copy of the runner over two test files that expect `expected(repo)`
+ * as their USER and HOME. Returns the steps the runner logged, its exit code,
+ * the number of os.userInfo() calls it made, and its stderr.
+ */
+async function runRunner(fails: boolean, expected: (repo: string) => UserInfo) {
+  using repo = tempDir("runner-user-info", {
+    ...Object.fromEntries(runnerFiles.map(file => [file, readFileSync(join(repoRoot, file))])),
+    "preload.mjs": preload(fails),
+    "test/first.test.ts": ({ root }) => testFile(expected(root)),
+    "test/second.test.ts": ({ root }) => testFile(expected(root)),
+    "home": {},
+  });
+  const callsPath = join(String(repo), "userinfo-calls.txt");
+  await using proc = Bun.spawn({
+    cmd: [
+      node!,
+      `--import=${pathToFileURL(join(String(repo), "preload.mjs")).href}`,
+      join(String(repo), "scripts", "runner.node.mjs"),
+      `--exec-path=${bunExe()}`,
+      "--quiet",
+    ],
+    cwd: String(repo),
+    env: {
+      ...bunEnv,
+      // The copy has to take the runner's local code paths: no docker
+      // coordinator, no buildkite-agent, and --retries defaults to 0.
+      CI: undefined,
+      BUILDKITE: undefined,
+      GITHUB_ACTIONS: undefined,
+      USER: environmentUser(String(repo)).username,
+      HOME: environmentUser(String(repo)).homedir,
+      USERINFO_CALLS_PATH: callsPath,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // The runner logs "[n/total] <title>" when it starts a step and
+  // "[n/total] <title> - <error>" when the step fails.
+  const steps = Bun.stripANSI(stdout)
+    .split("\n")
+    .map(line => /^\s*\[\d+\/\d+\] (.*)$/.exec(line)?.[1])
+    .filter((step): step is string => step !== undefined);
+  if (steps.length === 0) throw new Error(`the runner ran no step:\n${stdout}${stderr}`);
+  return { steps, exitCode, userInfoCalls: Number(readFileSync(callsPath, "utf8")), stderr };
+}
+
+describe.skipIf(!node)("runner.node.mjs os.userInfo()", () => {
+  test.concurrent(
+    "a failed passwd lookup does not end the shard: the test files run with USER and HOME from the environment",
+    async () => {
+      const { steps, exitCode, userInfoCalls, stderr } = await runRunner(true, environmentUser);
+
+      expect(stderr).toContain("os.userInfo() failed, using the environment instead");
+      expect({ steps, exitCode, userInfoCalls }).toEqual({
+        steps: ["test/first.test.ts", "test/second.test.ts"],
+        exitCode: 0,
+        userInfoCalls: 1,
+      });
+    },
+  );
+
+  test.concurrent("the passwd lookup runs once per process, not once per test file", async () => {
+    const passwd = await nodeUserInfo();
+    const { steps, exitCode, userInfoCalls, stderr } = await runRunner(false, () => passwd);
+
+    expect(stderr).not.toContain("os.userInfo() failed");
+    expect({ steps, exitCode, userInfoCalls }).toEqual({
+      steps: ["test/first.test.ts", "test/second.test.ts"],
+      exitCode: 0,
+      userInfoCalls: 1,
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- A darwin shard died with `SystemError [ERR_SYSTEM_ERROR]: uv_os_get_passwd returned ENOENT` in `spawnBun` (`scripts/runner.node.mjs:1777`). 97 of 2923 files had run. None were reported (builds 104623, 104622, 103586, 73894).
- `spawnBun` called `os.userInfo()` per test file for the child's `USER` and `HOME`, and `runOneTest` reads a node test file before its step begins. A throw from either leaves `runTests()` and kills the runner.
- The cause is the macOS cleanup daemon (`scripts/agent.mjs:217-236`), which wipes the checkout and reboots the host under a live job. #34367 proposed a fix and was closed unmerged.

### Fix
- `getUserInfo()` in `scripts/utils.mjs` calls `os.userInfo()` once per process and caches it. `spawnBun` and `getUsername()` read from it.
- When the lookup throws, it falls back to `USER`/`LOGNAME`/`USERNAME` and `HOME`/`USERPROFILE`, set by the login session, and warns once.
- `runOneTest` reports a node test file it cannot read as a failed step (`read error: ENOENT`). These are the two throw sites the wipe reaches. Others remain: `mkdtempSync` and `readdirSync` in `spawnBun`, `realpathSync` in `getCombinedPath`, `appendFileSync` in `runTest`.
- Verified: `test/internal/runner-step-errors.test.ts` runs a runner copy under node. All 3 cases fail on main's scripts.

### Background
- `scripts/runner.node.mjs` is the CI test driver, run under node. `runTest` runs one step per test file, retries a step whose result says it failed, and reports it. An exception from the step function is not a result. It kills the runner.
- `os.userInfo()` is libuv's `uv_os_get_passwd`, a `getpwuid_r` lookup. On macOS `opendirectoryd` serves it. ENOENT means no entry.

<details><summary>Notes</summary>

Timeline from the job log of build 104623 (job 01a03222-6992-434c-97c1-591117311094, agent darwin-aarch64-26.6.1-1), times in ms:

```
222656  [96] serve-http3.test.ts: ENOENT test/js/node/test/fixtures/keys/agent1-key.pem
229930  [96] attempt 2: Test filter ".../serve-http3.test.ts" had no matches
240909  [96] attempt 3: spawn .../release/bun-darwin-aarch64-profile/bun-profile ENOENT
245925  [97] fetch-abort-slow-connect.test.ts: uv_os_get_passwd returned ENOENT, runner exits 1
```

The same four-step sequence is described in #34367 for `darwin-naan-x64` (build 73894) and in its later comments for builds 103586 and 104622: `/Library/LaunchDaemons/com.buildkite.cleanup.plist` runs `rm -rf .../builds/* ... && shutdown -r now` on a `StartCalendarInterval` of 06:27, with no check for a running job. `scripts/agent.mjs:217-236` still writes that plist. #34367 moved the wipe to an `agent-startup` hook and added an abort in `runTest` when `execPath` no longer exists. It was closed without a merge on 2026-08-24. Nothing open addresses the daemon.

What this PR does and does not change for that incident: the shard still fails once the binary is gone, through per-step spawn errors. The runner no longer dies on the passwd lookup or on a node test file that vanished, so the summary, the JUnit upload and the annotations for the files that ran are produced.

A self-review of the first revision asked for two things, both applied: the node-test read site, which the same wipe reaches before any spawn in the node-test phase (the majority of a darwin aarch64 shard), and an accurate account of what remains. It also raised the larger question of one guard in `runTest` for every throw from a step function, against per-site handling as here. That decision is left to a follow-up, which can reuse this test file's runner copy.

The runner's environment on the agent had `USER=administrator`, `LOGNAME=administrator`, `HOME=/Users/administrator`, so the fallback would have used the same values the passwd lookup returns.

Reproduction outside the test: copy `scripts/runner.node.mjs`, `scripts/utils.mjs`, `scripts/p-limit.mjs`, `scripts/yocto-queue.mjs`, `test/docker/prestart-map.mjs` and `test/leaksan.supp` into a directory with one `test/*.test.ts`, then run it under node with a `--import` preload that sets `os.userInfo` to throw and calls `module.syncBuiltinESMExports()`. The unfixed runner prints the stack from the CI log and exits 1 before any test runs. With a counting preload instead, the unfixed runner makes one `os.userInfo()` call per test file. For the read site, add `test/js/node/test/parallel/test-gone.js` and a bun test that removes it: the unfixed runner exits 1 at `runOneTest (runner.node.mjs:841)` without logging the node test.

Proof: `bun bd test test/internal/runner-step-errors.test.ts` passes (3 tests). With `scripts/runner.node.mjs` and `scripts/utils.mjs` checked out from `origin/main`, all 3 cases fail: the `spawnBun (runner.node.mjs:1777:33)` stack, `userInfoCalls: 2`, and no step logged for the node test. `USE_SYSTEM_BUN=1` does not distinguish the two, because the test copies the runner from the working tree and the bun binary is not what changes.

Other checks: `test/internal/source-lints/ci-annotations.test.ts` (8 pass, imports utils.mjs), `node --check` on both scripts, prettier on all three files.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/runner-step-errors.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/runner-step-errors.test.ts
bun test v1.4.1 (4448a2e21)

test/internal/runner-step-errors.test.ts:
(pass) runner.node.mjs step errors > a node test file that is gone by the time its step starts is a failed step, not the end of the run [1016.43ms]
(pass) runner.node.mjs step errors > a failed passwd lookup does not end the shard: the test files run with USER and HOME from the environment [1306.21ms]
(pass) runner.node.mjs step errors > the passwd lookup runs once per process, not once per test file [1313.90ms]

 3 pass
 0 fail
 5 expect() calls
Ran 3 tests across 1 file. [3.61s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/runner.node.mjs                  |  28 ++++-
 scripts/utils.mjs                        |  40 ++++++-
 test/internal/runner-step-errors.test.ts | 196 +++++++++++++++++++++++++++++++
 3 files changed, 258 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
scripts/runner.node.mjs                      11      4      0
scripts/utils.mjs                             4      1      0
test/internal/runner-step-errors.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->