### PR TITLE
Windows: refuse a second reading pipe over a stdio fd instead of blocking in uv_pipe_open

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -1311,7 +1311,7 @@ impl WindowsBufferedReader {
         // Use the event loop from the parent, not the global one
         // This is critical for spawnSync to use its isolated loop
         let loop_ = self.vtable.loop_();
-        let source = match Source::open(loop_.cast(), fd) {
+        let source = match Source::open_for_reading(loop_.cast(), fd) {
             sys::Result::Err(err) => return sys::Result::Err(err),
             sys::Result::Ok(source) => source,
         };

--- a/src/io/source.rs
+++ b/src/io/source.rs
@@ -365,8 +365,12 @@ impl Source {
         }
     }
 
-    pub(crate) fn open_pipe(loop_: *mut uv::Loop, fd: Fd) -> bun_sys::Result<Box<Pipe>> {
-        bun_core::scoped_log!(PipeSource, "openPipe (fd = {})", fd);
+    pub(crate) fn open_pipe(
+        loop_: *mut uv::Loop,
+        fd: Fd,
+        reads: bool,
+    ) -> bun_sys::Result<Box<Pipe>> {
+        bun_core::scoped_log!(PipeSource, "openPipe (fd = {}, reads = {})", fd, reads);
         let mut pipe: Box<Pipe> = Box::new(bun_core::ffi::zeroed::<Pipe>());
         // we should never init using IPC here
         if let Some(err) = pipe.init(loop_, false).to_error(bun_sys::Tag::pipe) {
@@ -374,7 +378,12 @@ impl Source {
             return bun_sys::Result::Err(err);
         }
 
-        if let Some(err) = pipe.open(fd.uv()).to_error(bun_sys::Tag::open) {
+        let opened = if reads {
+            pipe.open_for_reading(fd.uv())
+        } else {
+            pipe.open(fd.uv())
+        };
+        if let Some(err) = opened.to_error(bun_sys::Tag::open) {
             // close_and_destroy() schedules a libuv close whose callback frees
             // the allocation. Hand the Box to libuv via into_raw so Drop does not double-free.
             let raw = bun_core::heap::into_raw(pipe);
@@ -426,7 +435,19 @@ impl Source {
         file
     }
 
+    /// Open `fd` for a writer.
     pub(crate) fn open(loop_: *mut uv::Loop, fd: Fd) -> bun_sys::Result<Source> {
+        Self::open_with(loop_, fd, false)
+    }
+
+    /// Open `fd` for a reader. A stdio pipe takes one reader at a time:
+    /// `EBUSY` while another reader's pipe is open over the same fd
+    /// (`uv::Pipe::open_for_reading`).
+    pub(crate) fn open_for_reading(loop_: *mut uv::Loop, fd: Fd) -> bun_sys::Result<Source> {
+        Self::open_with(loop_, fd, true)
+    }
+
+    fn open_with(loop_: *mut uv::Loop, fd: Fd, reads: bool) -> bun_sys::Result<Source> {
         let rc = uv::uv_guess_handle(fd.uv());
         bun_core::scoped_log!(
             PipeSource,
@@ -436,7 +457,7 @@ impl Source {
         );
 
         match rc {
-            uv::HandleType::NamedPipe => match Self::open_pipe(loop_, fd) {
+            uv::HandleType::NamedPipe => match Self::open_pipe(loop_, fd, reads) {
                 bun_sys::Result::Ok(pipe) => bun_sys::Result::Ok(Source::Pipe(pipe)),
                 bun_sys::Result::Err(err) => bun_sys::Result::Err(err),
             },

--- a/src/io/source.rs
+++ b/src/io/source.rs
@@ -440,9 +440,8 @@ impl Source {
         Self::open_with(loop_, fd, false)
     }
 
-    /// Open `fd` for a reader. A stdio pipe takes one reader at a time:
-    /// `EBUSY` while another reader's pipe is open over the same fd
-    /// (`uv::Pipe::open_for_reading`).
+    /// Open `fd` for a reader: `EBUSY` while another reader's pipe is open
+    /// over the same stdio fd (`uv::Pipe::open_for_reading`).
     pub(crate) fn open_for_reading(loop_: *mut uv::Loop, fd: Fd) -> bun_sys::Result<Source> {
         Self::open_with(loop_, fd, true)
     }

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -400,6 +400,9 @@ thread_local! {
 #[path = "open_handles.rs"]
 pub mod open_handles;
 
+#[path = "stdio_readers.rs"]
+mod stdio_readers;
+
 impl Loop {
     /// Returns this thread's
     /// libuv loop, lazily `uv_loop_init`ing it on first call. Each thread owns
@@ -587,6 +590,7 @@ unsafe extern "C" fn log_walk_cb(handle: *mut uv_handle_t, _data: *mut c_void) {
 unsafe extern "C" fn close_walk_cb(handle: *mut uv_handle_t, _data: *mut c_void) {
     // SAFETY: libuv passes a live handle.
     if unsafe { uv_is_closing(handle) } == 0 {
+        stdio_readers::release(handle);
         unsafe { uv_close(handle, None) };
     }
 }
@@ -663,6 +667,7 @@ pub unsafe trait UvHandle: Sized {
     #[inline]
     fn close(&mut self, cb: unsafe extern "C" fn(*mut Self)) {
         open_handles::remove(self.as_handle_mut());
+        stdio_readers::release(self.as_handle_mut());
         // SAFETY: `Self` embeds `uv_handle_t` at offset 0; cb is ABI-identical.
         unsafe {
             uv_close(
@@ -1194,6 +1199,19 @@ impl Pipe {
     pub fn open(&mut self, file: uv_file) -> ReturnCode {
         // SAFETY: pipe was `init`ed.
         unsafe { uv_pipe_open(self, file) }
+    }
+    /// [`open`](Self::open) for a pipe that will read. A stdio fd (0, 1, 2)
+    /// takes one reader at a time: `UV_EBUSY` while another pipe reads it
+    /// (see `stdio_readers`). The claim ends with this pipe's `uv_close`.
+    pub fn open_for_reading(&mut self, file: uv_file) -> ReturnCode {
+        if !stdio_readers::claim(file, ptr::from_mut(self)) {
+            return ReturnCode(UV_EBUSY);
+        }
+        let rc = self.open(file);
+        if rc.is_err() {
+            stdio_readers::release(self.as_handle_mut());
+        }
+        rc
     }
     #[inline]
     pub(crate) fn bind(&mut self, named_pipe: &[u8], flags: c_uint) -> ReturnCode {

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -590,8 +590,8 @@ unsafe extern "C" fn log_walk_cb(handle: *mut uv_handle_t, _data: *mut c_void) {
 unsafe extern "C" fn close_walk_cb(handle: *mut uv_handle_t, _data: *mut c_void) {
     // SAFETY: libuv passes a live handle.
     if unsafe { uv_is_closing(handle) } == 0 {
-        stdio_readers::release(handle);
         unsafe { uv_close(handle, None) };
+        stdio_readers::release(handle);
     }
 }
 
@@ -667,7 +667,6 @@ pub unsafe trait UvHandle: Sized {
     #[inline]
     fn close(&mut self, cb: unsafe extern "C" fn(*mut Self)) {
         open_handles::remove(self.as_handle_mut());
-        stdio_readers::release(self.as_handle_mut());
         // SAFETY: `Self` embeds `uv_handle_t` at offset 0; cb is ABI-identical.
         unsafe {
             uv_close(
@@ -678,6 +677,9 @@ pub unsafe trait UvHandle: Sized {
                 >(cb)),
             );
         }
+        // After `uv_close`: a pipe's parked read is cancelled by then, so the
+        // next reader of the fd never waits on it.
+        stdio_readers::release(self.as_handle_mut());
     }
     #[inline]
     fn has_ref(&self) -> bool {

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -401,7 +401,7 @@ thread_local! {
 pub mod open_handles;
 
 #[path = "stdio_readers.rs"]
-mod stdio_readers;
+pub mod stdio_readers;
 
 impl Loop {
     /// Returns this thread's
@@ -591,7 +591,7 @@ unsafe extern "C" fn close_walk_cb(handle: *mut uv_handle_t, _data: *mut c_void)
     // SAFETY: libuv passes a live handle.
     if unsafe { uv_is_closing(handle) } == 0 {
         unsafe { uv_close(handle, None) };
-        stdio_readers::release(handle);
+        stdio_readers::release(handle.cast());
     }
 }
 
@@ -679,7 +679,7 @@ pub unsafe trait UvHandle: Sized {
         }
         // After `uv_close`: a pipe's parked read is cancelled by then, so the
         // next reader of the fd never waits on it.
-        stdio_readers::release(self.as_handle_mut());
+        stdio_readers::release(self.as_handle_mut().cast());
     }
     #[inline]
     fn has_ref(&self) -> bool {
@@ -1205,12 +1205,12 @@ impl Pipe {
     /// [`open`](Self::open) for a reader: `UV_EBUSY` while another reader's
     /// pipe is open over the same stdio fd (`stdio_readers`).
     pub fn open_for_reading(&mut self, file: uv_file) -> ReturnCode {
-        if !stdio_readers::claim(file, ptr::from_mut(self)) {
+        if !stdio_readers::claim(file, ptr::from_mut(self).cast()) {
             return ReturnCode(UV_EBUSY);
         }
         let rc = self.open(file);
         if rc.is_err() {
-            stdio_readers::release(self.as_handle_mut());
+            stdio_readers::release(self.as_handle_mut().cast());
         }
         rc
     }

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -1200,9 +1200,8 @@ impl Pipe {
         // SAFETY: pipe was `init`ed.
         unsafe { uv_pipe_open(self, file) }
     }
-    /// [`open`](Self::open) for a pipe that will read. A stdio fd (0, 1, 2)
-    /// takes one reader at a time: `UV_EBUSY` while another pipe reads it
-    /// (see `stdio_readers`). The claim ends with this pipe's `uv_close`.
+    /// [`open`](Self::open) for a reader: `UV_EBUSY` while another reader's
+    /// pipe is open over the same stdio fd (`stdio_readers`).
     pub fn open_for_reading(&mut self, file: uv_file) -> ReturnCode {
         if !stdio_readers::claim(file, ptr::from_mut(self)) {
             return ReturnCode(UV_EBUSY);

--- a/src/libuv_sys/stdio_readers.rs
+++ b/src/libuv_sys/stdio_readers.rs
@@ -1,0 +1,61 @@
+//! The one reading `uv_pipe_t` open over each stdio fd (0, 1, 2), process-wide.
+//!
+//! `uv_pipe_open` on fd 0..=2 duplicates the CRT handle, so every pipe opened
+//! over the same stdio fd shares one kernel file object. The pipe a parent
+//! hands its child as stdio is, as a rule, synchronous (opened without
+//! `FILE_FLAG_OVERLAPPED`), and the kernel serialises every I/O request on a
+//! synchronous file object through that object's lock. libuv reads such a
+//! pipe with a zero-byte `ReadFile` parked on a thread-pool thread
+//! (`uv_pipe_zero_readfile_thread_proc`), which holds the lock until data or
+//! EOF arrives. Any other pipe over the same file object then blocks the loop
+//! thread: `uv_pipe_open` (`SetNamedPipeHandleState`, `NtQueryInformationFile`)
+//! while opening, and `PeekNamedPipe` / `ReadFile` in `uv__pipe_read_data`
+//! while reading.
+//!
+//! So a stdio fd takes one reader at a time, whatever mode its pipe is in.
+//! [`claim`] runs before the `uv_pipe_open` of a reader
+//! (`Pipe::open_for_reading`); [`release`] runs when the `uv_close` for any
+//! handle is issued (`UvHandle::close`, `close_walk_cb`). `uv__pipe_close`
+//! cancels the pending zero-byte read and closes the handle before it
+//! returns, so the next reader may open the fd as soon as the previous one's
+//! `uv_close` is issued, without a loop turn.
+//!
+//! Writers never claim: a `WriteFile` holds the lock only for the write, and
+//! process.stdout and `Bun.stdout.writer()` may each hold a pipe over fd 1.
+
+use super::*;
+
+use core::sync::atomic::{AtomicPtr, Ordering};
+
+static READERS: [AtomicPtr<uv_handle_t>; 3] = [
+    AtomicPtr::new(ptr::null_mut()),
+    AtomicPtr::new(ptr::null_mut()),
+    AtomicPtr::new(ptr::null_mut()),
+];
+
+fn slot(fd: uv_file) -> Option<&'static AtomicPtr<uv_handle_t>> {
+    READERS.get(usize::try_from(fd).ok()?)
+}
+
+/// Record `pipe` as the reader of `fd`. `false` when another pipe already
+/// reads it. Always `true` for a non-stdio fd: such a handle is not shared.
+pub(crate) fn claim(fd: uv_file, pipe: *mut Pipe) -> bool {
+    let Some(slot) = slot(fd) else {
+        return true;
+    };
+    slot.compare_exchange(
+        ptr::null_mut(),
+        pipe.cast(),
+        Ordering::AcqRel,
+        Ordering::Acquire,
+    )
+    .is_ok()
+}
+
+/// Forget `handle` as the reader of whichever stdio fd it holds. No-op for a
+/// handle that holds none.
+pub(crate) fn release(handle: *mut uv_handle_t) {
+    for slot in &READERS {
+        let _ = slot.compare_exchange(handle, ptr::null_mut(), Ordering::AcqRel, Ordering::Acquire);
+    }
+}

--- a/src/libuv_sys/stdio_readers.rs
+++ b/src/libuv_sys/stdio_readers.rs
@@ -1,52 +1,51 @@
-//! The one reading `uv_pipe_t` open over each stdio fd (0, 1, 2), process-wide.
+//! The one reader of each stdio fd (0, 1, 2) that is a pipe, process-wide.
 //!
-//! `uv_pipe_open` on fd 0..=2 duplicates the CRT handle, so all pipes over one
-//! stdio fd share one kernel file object. That object is synchronous (child
+//! `uv_pipe_open` on fd 0..=2 duplicates the CRT handle, so all handles over
+//! one stdio fd share one kernel file object. That object is synchronous (child
 //! stdio pipes are opened without `FILE_FLAG_OVERLAPPED`), so the kernel runs
-//! its I/O requests one at a time. libuv reads it with a zero-byte `ReadFile`
-//! parked on a pool thread, which holds that turn until data arrives; a second
-//! pipe over the same object then blocks the loop thread in `uv_pipe_open`
-//! (`SetNamedPipeHandleState`) and later in `PeekNamedPipe`.
+//! its I/O requests one at a time. A read that waits for input holds that turn:
+//! libuv's zero-byte `ReadFile` parked on a pool thread for a `uv_pipe_t`, or
+//! the `ReadFile` of a `uv_fs_read`. Any other handle over the same object then
+//! blocks the loop thread in `uv_pipe_open` (`SetNamedPipeHandleState`) and
+//! later in `PeekNamedPipe`.
 //!
-//! A reader claims the fd before its `uv_pipe_open` (`Pipe::open_for_reading`)
-//! and gets `UV_EBUSY` while another reader holds it. `UvHandle::close` and
-//! `close_walk_cb` release it once `uv_close` has returned: by then the parked
-//! read is cancelled and the handle closed, so the next reader, on this thread
-//! or another, never waits on the old one and needs no loop turn. Writers do
-//! not claim: `process.stdout` and `Bun.stdout.writer()` each hold a pipe over
-//! fd 1, and a `WriteFile` holds its turn only while writing.
+//! A reader claims the fd before its first read (`Pipe::open_for_reading`,
+//! `ReadFileUV::on_file_open`) and gets `EBUSY` while another reader holds it.
+//! A pipe's claim ends in `UvHandle::close` and `close_walk_cb` once `uv_close`
+//! has returned: by then the parked read is cancelled and the handle closed, so
+//! the next reader, on this thread or another, never waits on the old one and
+//! needs no loop turn. A `uv_fs_read` reader's claim ends when its last read
+//! has completed. Writers do not claim: `process.stdout` and
+//! `Bun.stdout.writer()` each hold a pipe over fd 1, and a `WriteFile` holds
+//! its turn only while writing.
 
 use super::*;
 
 use core::sync::atomic::{AtomicPtr, Ordering};
 
-static READERS: [AtomicPtr<uv_handle_t>; 3] = [
+static READERS: [AtomicPtr<c_void>; 3] = [
     AtomicPtr::new(ptr::null_mut()),
     AtomicPtr::new(ptr::null_mut()),
     AtomicPtr::new(ptr::null_mut()),
 ];
 
-fn slot(fd: uv_file) -> Option<&'static AtomicPtr<uv_handle_t>> {
+fn slot(fd: uv_file) -> Option<&'static AtomicPtr<c_void>> {
     READERS.get(usize::try_from(fd).ok()?)
 }
 
-/// `false` when another pipe already reads `fd`. A non-stdio fd is not shared: always `true`.
-pub(crate) fn claim(fd: uv_file, pipe: *mut Pipe) -> bool {
+/// `false` when another reader already holds `fd`. `reader` is any address
+/// that is stable until [`release`]. A non-stdio fd is not shared: always `true`.
+pub fn claim(fd: uv_file, reader: *mut c_void) -> bool {
     let Some(slot) = slot(fd) else {
         return true;
     };
-    slot.compare_exchange(
-        ptr::null_mut(),
-        pipe.cast(),
-        Ordering::AcqRel,
-        Ordering::Acquire,
-    )
-    .is_ok()
+    slot.compare_exchange(ptr::null_mut(), reader, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
 }
 
-/// Forget `handle` as a stdio reader, if it is one.
-pub(crate) fn release(handle: *mut uv_handle_t) {
+/// Forget `reader` as a stdio reader, if it is one.
+pub fn release(reader: *mut c_void) {
     for slot in &READERS {
-        let _ = slot.compare_exchange(handle, ptr::null_mut(), Ordering::AcqRel, Ordering::Acquire);
+        let _ = slot.compare_exchange(reader, ptr::null_mut(), Ordering::AcqRel, Ordering::Acquire);
     }
 }

--- a/src/libuv_sys/stdio_readers.rs
+++ b/src/libuv_sys/stdio_readers.rs
@@ -1,27 +1,19 @@
 //! The one reading `uv_pipe_t` open over each stdio fd (0, 1, 2), process-wide.
 //!
-//! `uv_pipe_open` on fd 0..=2 duplicates the CRT handle, so every pipe opened
-//! over the same stdio fd shares one kernel file object. The pipe a parent
-//! hands its child as stdio is, as a rule, synchronous (opened without
-//! `FILE_FLAG_OVERLAPPED`), and the kernel serialises every I/O request on a
-//! synchronous file object through that object's lock. libuv reads such a
-//! pipe with a zero-byte `ReadFile` parked on a thread-pool thread
-//! (`uv_pipe_zero_readfile_thread_proc`), which holds the lock until data or
-//! EOF arrives. Any other pipe over the same file object then blocks the loop
-//! thread: `uv_pipe_open` (`SetNamedPipeHandleState`, `NtQueryInformationFile`)
-//! while opening, and `PeekNamedPipe` / `ReadFile` in `uv__pipe_read_data`
-//! while reading.
+//! `uv_pipe_open` on fd 0..=2 duplicates the CRT handle, so all pipes over one
+//! stdio fd share one kernel file object. That object is synchronous (child
+//! stdio pipes are opened without `FILE_FLAG_OVERLAPPED`), so the kernel runs
+//! its I/O requests one at a time. libuv reads it with a zero-byte `ReadFile`
+//! parked on a pool thread, which holds that turn until data arrives; a second
+//! pipe over the same object then blocks the loop thread in `uv_pipe_open`
+//! (`SetNamedPipeHandleState`) and later in `PeekNamedPipe`.
 //!
-//! So a stdio fd takes one reader at a time, whatever mode its pipe is in.
-//! [`claim`] runs before the `uv_pipe_open` of a reader
-//! (`Pipe::open_for_reading`); [`release`] runs when the `uv_close` for any
-//! handle is issued (`UvHandle::close`, `close_walk_cb`). `uv__pipe_close`
-//! cancels the pending zero-byte read and closes the handle before it
-//! returns, so the next reader may open the fd as soon as the previous one's
-//! `uv_close` is issued, without a loop turn.
-//!
-//! Writers never claim: a `WriteFile` holds the lock only for the write, and
-//! process.stdout and `Bun.stdout.writer()` may each hold a pipe over fd 1.
+//! A reader claims the fd before its `uv_pipe_open` (`Pipe::open_for_reading`)
+//! and gets `UV_EBUSY` while another reader holds it. `UvHandle::close` and
+//! `close_walk_cb` release it before `uv_close`, which cancels the parked read
+//! and closes the handle before it returns, so the next reader needs no loop
+//! turn. Writers do not claim: `process.stdout` and `Bun.stdout.writer()` each
+//! hold a pipe over fd 1, and a `WriteFile` holds its turn only while writing.
 
 use super::*;
 
@@ -37,8 +29,7 @@ fn slot(fd: uv_file) -> Option<&'static AtomicPtr<uv_handle_t>> {
     READERS.get(usize::try_from(fd).ok()?)
 }
 
-/// Record `pipe` as the reader of `fd`. `false` when another pipe already
-/// reads it. Always `true` for a non-stdio fd: such a handle is not shared.
+/// `false` when another pipe already reads `fd`. A non-stdio fd is not shared: always `true`.
 pub(crate) fn claim(fd: uv_file, pipe: *mut Pipe) -> bool {
     let Some(slot) = slot(fd) else {
         return true;
@@ -52,8 +43,7 @@ pub(crate) fn claim(fd: uv_file, pipe: *mut Pipe) -> bool {
     .is_ok()
 }
 
-/// Forget `handle` as the reader of whichever stdio fd it holds. No-op for a
-/// handle that holds none.
+/// Forget `handle` as a stdio reader, if it is one.
 pub(crate) fn release(handle: *mut uv_handle_t) {
     for slot in &READERS {
         let _ = slot.compare_exchange(handle, ptr::null_mut(), Ordering::AcqRel, Ordering::Acquire);

--- a/src/libuv_sys/stdio_readers.rs
+++ b/src/libuv_sys/stdio_readers.rs
@@ -10,10 +10,11 @@
 //!
 //! A reader claims the fd before its `uv_pipe_open` (`Pipe::open_for_reading`)
 //! and gets `UV_EBUSY` while another reader holds it. `UvHandle::close` and
-//! `close_walk_cb` release it before `uv_close`, which cancels the parked read
-//! and closes the handle before it returns, so the next reader needs no loop
-//! turn. Writers do not claim: `process.stdout` and `Bun.stdout.writer()` each
-//! hold a pipe over fd 1, and a `WriteFile` holds its turn only while writing.
+//! `close_walk_cb` release it once `uv_close` has returned: by then the parked
+//! read is cancelled and the handle closed, so the next reader, on this thread
+//! or another, never waits on the old one and needs no loop turn. Writers do
+//! not claim: `process.stdout` and `Bun.stdout.writer()` each hold a pipe over
+//! fd 1, and a `WriteFile` holds its turn only while writing.
 
 use super::*;
 

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -745,7 +745,7 @@ impl WindowsNamedPipe {
         );
 
         // SAFETY: as above.
-        if let Err(e) = unsafe { (*pipe).open(fd.uv()) }.to_result(bun_sys::Tag::open) {
+        if let Err(e) = unsafe { (*pipe).open_for_reading(fd.uv()) }.to_result(bun_sys::Tag::open) {
             self.discard_unadopted_pipe();
             return Err(e);
         }

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -1095,6 +1095,8 @@ impl<'a> ReadFileUV<'a> {
 
     pub fn finalize(this: *mut Self) {
         log!("ReadFileUV.finalize");
+        // No read is in flight any more, so the fd may take its next reader.
+        libuv::stdio_readers::release(this.cast());
         // SAFETY: `this` was heap-allocated in start(); we reclaim ownership here.
         let mut this_box = unsafe { bun_core::heap::take(this) };
         let event_loop = this_box.event_loop;
@@ -1156,6 +1158,22 @@ impl<'a> ReadFileUV<'a> {
     pub(crate) fn on_file_open(&mut self, opened_fd: Fd) {
         log!("ReadFileUV.onFileOpen");
         if self.errno.is_some() {
+            self.on_finish();
+            return;
+        }
+
+        // A stdio pipe takes one reader at a time (`libuv::stdio_readers`);
+        // `finalize` releases the claim.
+        if opened_fd.stdio_tag().is_some()
+            && libuv::uv_guess_handle(opened_fd.uv()) == libuv::HandleType::NamedPipe
+            && !libuv::stdio_readers::claim(opened_fd.uv(), core::ptr::from_mut(self).cast())
+        {
+            self.errno = Some(bun_errno::from_errno(bun_sys::E::BUSY as i32).into());
+            self.system_error = Some(
+                bun_sys::Error::from_code(bun_sys::E::BUSY, bun_sys::Tag::read)
+                    .to_system_error()
+                    .into(),
+            );
             self.on_finish();
             return;
         }

--- a/test/js/bun/util/bun-stdin-second-reader.test.ts
+++ b/test/js/bun/util/bun-stdin-second-reader.test.ts
@@ -2,11 +2,12 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 
 // On Windows a pipe inherited as stdin is a synchronous file object, and the
-// kernel serialises all I/O on it. libuv reads such a pipe through a zero-byte
-// ReadFile parked on a pool thread, which holds that serialisation lock until
-// data arrives. A second uv_pipe_t over fd 0 then blocks the JS thread inside
-// uv_pipe_open. Bun refuses the second reader with EBUSY instead, and frees
-// the fd for a new reader as soon as the first one is closed.
+// kernel serialises all I/O on it. A read that waits for input (libuv's
+// zero-byte ReadFile for a uv_pipe_t, or the ReadFile behind Bun.stdin.text())
+// holds that serialisation lock until data arrives. A second uv_pipe_t over
+// fd 0 then blocks the JS thread inside uv_pipe_open. Bun refuses the second
+// reader with EBUSY instead, and frees the fd for a new reader as soon as the
+// first one is closed.
 
 type Child = ReturnType<typeof spawnReader>;
 
@@ -187,6 +188,100 @@ test.concurrent.skipIf(!isWindows)(
     ]);
     expect(stderr).toBe("");
     expect(lines).toEqual(["net first", "r2 EBUSY open", "r3 opened", "r3 third"]);
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent.skipIf(!isWindows)(
+  "process.stdin fails with EBUSY while Bun.stdin.text() waits for input, and a reader opens once text() has finished",
+  async () => {
+    await using proc = spawnReader(`
+      ${helpers}
+      const all = Bun.stdin.text();
+      await nextTurn();
+      try {
+        process.stdin.on("data", d => out("stdin " + d.toString().trim()));
+        out("stdin attached");
+      } catch (e) {
+        out("stdin " + fail(e));
+      }
+      out("text " + JSON.stringify(await all));
+      const r3 = Bun.file(0).stream().getReader();
+      out("r3 " + text(await r3.read()));
+      process.exit(0);
+    `);
+    const [lines, stderr, exitCode] = await Promise.all([
+      readLines(proc, line => {
+        if (line === "stdin EBUSY open") {
+          feed(proc, "all of it");
+          proc.stdin.end();
+        }
+      }),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(lines).toEqual(["stdin EBUSY open", 'text "all of it\\n"', "r3 EOF"]);
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent.skipIf(!isWindows)(
+  "Bun.stdin.text() rejects with EBUSY while process.stdin is reading the pipe",
+  async () => {
+    await using proc = spawnReader(`
+      ${helpers}
+      let chunks = 0;
+      process.stdin.on("data", async d => {
+        out("stdin " + d.toString().trim());
+        if (++chunks === 2) process.exit(0);
+        await nextTurn();
+        try {
+          out("text " + JSON.stringify(await Bun.stdin.text()));
+        } catch (e) {
+          out("text " + fail(e));
+        }
+      });
+    `);
+    feed(proc, "first");
+    const [lines, stderr, exitCode] = await Promise.all([
+      readLines(proc, line => {
+        if (line === "text EBUSY read") feed(proc, "second");
+      }),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(lines).toEqual(["stdin first", "text EBUSY read", "stdin second"]);
+    expect(exitCode).toBe(0);
+  },
+);
+
+// The pipe stays claimed while process.stdin is paused: the two handles would
+// share one file object, and a resume() while the other reader waits for input
+// would block the JS thread again. Cancel or close the first reader instead.
+test.concurrent.skipIf(!isWindows)(
+  "Bun.file(0).stream() fails with EBUSY while a paused process.stdin still holds the pipe",
+  async () => {
+    await using proc = spawnReader(`
+      ${helpers}
+      process.stdin.once("data", async d => {
+        out("stdin " + d.toString().trim());
+        process.stdin.pause();
+        await nextTurn();
+        try {
+          Bun.file(0).stream().getReader();
+          out("r2 opened");
+        } catch (e) {
+          out("r2 " + fail(e));
+        }
+        process.exit(0);
+      });
+    `);
+    feed(proc, "first");
+    const [lines, stderr, exitCode] = await Promise.all([readLines(proc, () => {}), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(lines).toEqual(["stdin first", "r2 EBUSY open"]);
     expect(exitCode).toBe(0);
   },
 );

--- a/test/js/bun/util/bun-stdin-second-reader.test.ts
+++ b/test/js/bun/util/bun-stdin-second-reader.test.ts
@@ -76,11 +76,14 @@ test.concurrent.skipIf(!isWindows)(
       process.exit(0);
     `);
     feed(proc, "first");
-    const lines = await readLines(proc, line => {
-      if (line === "r2 EBUSY open") feed(proc, "second");
-      if (line === "r3 opened") feed(proc, "third");
-    });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [lines, stderr, exitCode] = await Promise.all([
+      readLines(proc, line => {
+        if (line === "r2 EBUSY open") feed(proc, "second");
+        if (line === "r3 opened") feed(proc, "third");
+      }),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
     expect(stderr).toBe("");
     expect(lines).toEqual(["r1 first", "r2 EBUSY open", "r1 second", "r3 opened", "r3 third"]);
     expect(exitCode).toBe(0);
@@ -106,10 +109,13 @@ test.concurrent.skipIf(!isWindows)(
       });
     `);
     feed(proc, "first");
-    const lines = await readLines(proc, line => {
-      if (line === "r2 EBUSY open") feed(proc, "second");
-    });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [lines, stderr, exitCode] = await Promise.all([
+      readLines(proc, line => {
+        if (line === "r2 EBUSY open") feed(proc, "second");
+      }),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
     expect(stderr).toBe("");
     expect(lines).toEqual(["stdin first", "r2 EBUSY open", "stdin second"]);
     expect(exitCode).toBe(0);
@@ -133,10 +139,13 @@ test.concurrent.skipIf(!isWindows)(
       process.exit(0);
     `);
     feed(proc, "first");
-    const lines = await readLines(proc, line => {
-      if (line === "net error") feed(proc, "second");
-    });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [lines, stderr, exitCode] = await Promise.all([
+      readLines(proc, line => {
+        if (line === "net error") feed(proc, "second");
+      }),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
     expect(stderr).toBe("");
     expect(lines).toEqual(["r1 first", "net error", "r1 second"]);
     expect(exitCode).toBe(0);

--- a/test/js/bun/util/bun-stdin-second-reader.test.ts
+++ b/test/js/bun/util/bun-stdin-second-reader.test.ts
@@ -152,6 +152,45 @@ test.concurrent.skipIf(!isWindows)(
   },
 );
 
+test.concurrent.skipIf(!isWindows)(
+  "Bun.file(0).stream() fails with EBUSY while net.connect({ fd: 0 }) reads the pipe, and opens once the socket is closed",
+  async () => {
+    await using proc = spawnReader(`
+      ${helpers}
+      const net = require("node:net");
+      const socket = net.connect({ fd: 0 });
+      socket.once("data", async d => {
+        out("net " + d.toString().trim());
+        await nextTurn();
+        try {
+          Bun.file(0).stream().getReader();
+          out("r2 opened");
+        } catch (e) {
+          out("r2 " + fail(e));
+        }
+        socket.once("close", async () => {
+          const r3 = Bun.file(0).stream().getReader();
+          out("r3 opened");
+          out("r3 " + text(await r3.read()));
+          process.exit(0);
+        });
+        socket.destroy();
+      });
+    `);
+    feed(proc, "first");
+    const [lines, stderr, exitCode] = await Promise.all([
+      readLines(proc, line => {
+        if (line === "r3 opened") feed(proc, "third");
+      }),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(lines).toEqual(["net first", "r2 EBUSY open", "r3 opened", "r3 third"]);
+    expect(exitCode).toBe(0);
+  },
+);
+
 test.concurrent("opening a second reader over a piped stdin does not block the event loop", async () => {
   await using proc = spawnReader(`
     ${helpers}

--- a/test/js/bun/util/bun-stdin-second-reader.test.ts
+++ b/test/js/bun/util/bun-stdin-second-reader.test.ts
@@ -1,0 +1,164 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+// On Windows a pipe inherited as stdin is a synchronous file object, and the
+// kernel serialises all I/O on it. libuv reads such a pipe through a zero-byte
+// ReadFile parked on a pool thread, which holds that serialisation lock until
+// data arrives. A second uv_pipe_t over fd 0 then blocks the JS thread inside
+// uv_pipe_open. Bun refuses the second reader with EBUSY instead, and frees
+// the fd for a new reader as soon as the first one is closed.
+
+type Child = ReturnType<typeof spawnReader>;
+
+function spawnReader(script: string) {
+  return Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function feed(proc: Child, line: string) {
+  proc.stdin.write(line + "\n");
+  proc.stdin.flush();
+}
+
+/** The child's stdout, one line at a time. `react` may answer a line on stdin. */
+async function readLines(proc: Child, react: (line: string) => void): Promise<string[]> {
+  const lines: string[] = [];
+  const decoder = new TextDecoder();
+  let rest = "";
+  for await (const chunk of proc.stdout) {
+    rest += decoder.decode(chunk, { stream: true });
+    let nl;
+    while ((nl = rest.indexOf("\n")) !== -1) {
+      const line = rest.slice(0, nl);
+      rest = rest.slice(nl + 1);
+      lines.push(line);
+      react(line);
+    }
+  }
+  return lines;
+}
+
+const helpers = /* js */ `
+  const out = s => process.stdout.write(s + "\\n");
+  const text = v => (v.done ? "EOF" : Buffer.from(v.value).toString().trim());
+  const fail = e => e.code + " " + e.syscall;
+  // The first reader's next zero-byte read is queued to the pool thread once
+  // the callback that delivered its chunk returns; open the second reader
+  // after that, as a later tick would.
+  const nextTurn = () => new Promise(resolve => setImmediate(resolve));
+`;
+
+test.concurrent.skipIf(!isWindows)(
+  "a second Bun.file(0) reader fails with EBUSY while the first waits for input, and opens once the first is cancelled",
+  async () => {
+    await using proc = spawnReader(`
+      ${helpers}
+      const r1 = Bun.file(0).stream().getReader();
+      out("r1 " + text(await r1.read()));
+      const pending = r1.read();
+      await nextTurn();
+      try {
+        Bun.file(0).stream().getReader();
+        out("r2 opened");
+      } catch (e) {
+        out("r2 " + fail(e));
+      }
+      out("r1 " + text(await pending));
+      await r1.cancel();
+      const r3 = Bun.file(0).stream().getReader();
+      out("r3 opened");
+      out("r3 " + text(await r3.read()));
+      process.exit(0);
+    `);
+    feed(proc, "first");
+    const lines = await readLines(proc, line => {
+      if (line === "r2 EBUSY open") feed(proc, "second");
+      if (line === "r3 opened") feed(proc, "third");
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(lines).toEqual(["r1 first", "r2 EBUSY open", "r1 second", "r3 opened", "r3 third"]);
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent.skipIf(!isWindows)(
+  "Bun.file(0).stream() fails with EBUSY while process.stdin is reading the pipe",
+  async () => {
+    await using proc = spawnReader(`
+      ${helpers}
+      let chunks = 0;
+      process.stdin.on("data", async d => {
+        out("stdin " + d.toString().trim());
+        if (++chunks === 2) process.exit(0);
+        await nextTurn();
+        try {
+          Bun.file(0).stream().getReader();
+          out("r2 opened");
+        } catch (e) {
+          out("r2 " + fail(e));
+        }
+      });
+    `);
+    feed(proc, "first");
+    const lines = await readLines(proc, line => {
+      if (line === "r2 EBUSY open") feed(proc, "second");
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(lines).toEqual(["stdin first", "r2 EBUSY open", "stdin second"]);
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent.skipIf(!isWindows)(
+  "net.connect({ fd: 0 }) fails while a Bun.file(0) reader waits for input",
+  async () => {
+    await using proc = spawnReader(`
+      ${helpers}
+      const net = require("node:net");
+      const r1 = Bun.file(0).stream().getReader();
+      out("r1 " + text(await r1.read()));
+      const pending = r1.read();
+      await nextTurn();
+      const socket = net.connect({ fd: 0 });
+      socket.on("data", d => out("net " + d.toString().trim()));
+      socket.on("error", () => out("net error"));
+      out("r1 " + text(await pending));
+      process.exit(0);
+    `);
+    feed(proc, "first");
+    const lines = await readLines(proc, line => {
+      if (line === "net error") feed(proc, "second");
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(lines).toEqual(["r1 first", "net error", "r1 second"]);
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.concurrent("opening a second reader over a piped stdin does not block the event loop", async () => {
+  await using proc = spawnReader(`
+    ${helpers}
+    const r1 = Bun.file(0).stream().getReader();
+    out("r1 " + text(await r1.read()));
+    r1.read().catch(() => {});
+    await nextTurn();
+    try {
+      Bun.file(0).stream().getReader().read().catch(() => {});
+    } catch {}
+    out("alive");
+    process.exit(0);
+  `);
+  feed(proc, "first");
+  const [lines, stderr, exitCode] = await Promise.all([readLines(proc, () => {}), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(lines).toEqual(["r1 first", "alive"]);
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- Windows, stdin is a pipe: a second reader over fd 0 while a first reader waits for input hangs the JS thread inside `uv_pipe_open`. Timers stop. `Bun.file(0).stream()` twice, `process.stdin` plus `Bun.file(0).stream()`, `process.stdin` after a pending `Bun.stdin.text()`, and `net.connect({ fd: 0 })` twice all do this. Found by repro during other stdin work, no user report. Reproduced with 1.4.1-canary and a debug build of main.
- The cause is kernel serialisation of a synchronous pipe. A read that waits for input holds the file object's lock: libuv's zero-byte `ReadFile` parked on a pool thread for a `uv_pipe_t` (`uv_pipe_zero_readfile_thread_proc`), or the `ReadFile` behind `uv_fs_read`. `uv_pipe_open` duplicates the fd 0 handle, so its `SetNamedPipeHandleState` waits for that lock. Once two pipes exist, `PeekNamedPipe` in `uv__pipe_read_data` blocks the same way while reading (`src/io/source.rs:368` opened a fresh `uv_pipe_t` per reader).

### Fix
- `bun_libuv_sys` tracks the one reader per stdio fd, process-wide (`src/libuv_sys/stdio_readers.rs`). `Pipe::open_for_reading` claims the fd before `uv_pipe_open`, `ReadFileUV::on_file_open` before its first `uv_fs_read`. A second reader gets `EBUSY`. `UvHandle::close` releases a pipe's claim once `uv_close` has returned, `ReadFileUV::finalize` a file read's. Writers keep `Pipe::open`.
- Correct because two readers over one synchronous file object cannot both be served by libuv: one of them blocks the loop thread in the kernel. An error at open is the only outcome that keeps the loop running. `uv__pipe_close` cancels the parked read and closes the handle before `uv_close` returns, so a reader opened right after the previous one is cancelled works, with no loop turn in between.
- The claim lasts from open to close, not from read start to read stop: a paused `process.stdin` keeps fd 0, so `Bun.file(0).stream()` gets `EBUSY` then (it opened on main). Two open pipes cannot be made safe, a `resume()` while the other waits for input blocks the loop again.
- Verified: `test/js/bun/util/bun-stdin-second-reader.test.ts`, 7 Windows cases and one cross-platform. Windows x64 debug build: the pipe cases time out on main (the child hangs), all pass with this change, 3 runs. Also ran `process-stdin`, `stdin-fixtures`, `spawn-streaming-stdin/stdout`, `filesink`, `bun-stdin-slice`, `socket`, `tty`, `spawn`, `child_process`, `spawn-ipc-gc` on Windows, and the new file on Linux.

### Background
- A Windows file object opened without `FILE_FLAG_OVERLAPPED` is synchronous: the I/O manager takes a per-object lock for each request, including `NtSetInformationFile` and `NtQueryInformationFile`, and holds it while a read waits for data. Child stdio pipes from bun, node, cmd.exe and .NET are synchronous.
- `uv_pipe_open` on fd 0, 1 or 2 calls `DuplicateHandle`, so every pipe over a stdio fd shares one file object. A fd above 2 is adopted as is and closed with the pipe.
- `Source` (`src/io/source.rs`) is the Windows I/O handle behind `WindowsBufferedReader` and `StreamingWriter`. `FileReader` (the native side of `Bun.file().stream()`) starts a reader on fd 0 for each new stream. `Bun.stdin.stream()` caches its stream per JS object, `Bun.file(0)` is a new object each call. `ReadFileUV` (`src/runtime/webcore/blob/read_file.rs`) is the Windows side of `Bun.stdin.text()/bytes()/json()`.
- The gate's fail-before run is on Linux. The hang needs the Windows pipe path, so the Windows-only tests skip there and the proof above is from Windows x64.

<details><summary>Notes</summary>

Repro (brief): parent spawns `child.js` with `stdin: "pipe"`. Child: `Bun.file(0).stream().getReader().read()`, wait 5 ms, `Bun.file(0).stream().getReader()`. With `BUN_DEBUG_PipeSource=1` the last line is the second `openPipe (fd = 0)`. With 1.4.1-canary the child hangs until the parent kills it after 8 s. `Bun.stdin.text()` with no input, 200 ms, then `process.stdin.on("data")` hangs the same way on main.

Why not share one `uv_pipe_t` between readers: a uv handle has one `data` pointer and one read callback. The stdin tty singleton has that shape and its owner-switch bugs are still being fixed (#39981). Why not fall back to `uv_fs_read`: a `ReadFile` on a pool thread holds the same lock while it waits, so the pipe reader's `PeekNamedPipe` on the loop thread blocks behind it, and a blocked `uv_fs_read` cannot be cancelled, so a paused reader loses the bytes it then receives.

Writers do not claim. `process.stdout` (a `fs.WriteStream` fast path) and `Bun.stdout.writer()` each open a pipe over fd 1 today. A `WriteFile` holds the lock only for the write itself.

The claim is released in `UvHandle::close` and in `close_walk_cb` (handles a worker left open at loop close), after `uv_close` returns so a reader on another thread never waits on the old parked read. Every pipe close path goes through one of them: `close_impl` (reader, writer), `Pipe::close_and_destroy`, `open_handles::stop_all_for_vm_teardown`. `ReadFileUV` releases in `finalize`, which every completion and error path reaches, after its last read completed. The shell's `IOReader` (`Bun.$` `cat` on stdin) also reads fd 0 with `uv_fs_read` and does not claim yet.

Error codes: the pipe reader throws `EBUSY open` from `getReader()` (where `ENOENT` for a missing file already surfaces). `Bun.stdin.text()` rejects `EBUSY read`. `net.connect({ fd: 0 })` reports the refusal as `ENOENT connect`: `WindowsNamedPipeContext::fail_and_release` hard-codes that code for every open or connect failure, and `handle_connect_error` maps unknown codes to ECONNREFUSED. The test for that direction asserts an error event and a live loop. Related open PRs pick other codes for neighbouring states: #35833 rejects a second concurrent `Bun.stdin.text()` on POSIX with `ERR_INVALID_STATE`, #39981 reports a second tty reader with libuv's `EALREADY`.

Overlap with #39981: it changes `Source::open` to `open(loop, fd, reader_ctx: Option<EventLoopCtx>)`. Whichever lands second rebases `src/io/source.rs` and `src/io/PipeReader.rs`: `reads` becomes `reader_ctx.is_some()` at the pipe arm, and `open_for_reading` goes away.

Linux, for comparison: two `Bun.file(0).stream()` readers on a piped stdin. The first gets every chunk, the second resolves nothing and reports nothing. Deduping the stream per stdio Store on all platforms is a separate change.

Unrelated on the Windows box: `bunshell.test.ts` tilde_expansion fails with `HOME` unset (5 tests), the same on main.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/bun-stdin-second-reader.test.ts

<!-- robobun:evidence:end -->