### PR TITLE
Add leak tests for Bun.serve unix option and Transpiler reject path

### DIFF
--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -664,12 +664,18 @@ describe("Bun.serve unix socket validation", () => {
   });
 
   test("unix option does not leak the string", async () => {
-    // The hostname + unix combination throws before any socket is bound, so
-    // this drives the option parsing alone.
+    // Both calls throw before any socket is bound, so this drives the option
+    // parsing alone. The first throws as soon as it sees hostname + unix. The
+    // second accepts the unix path and throws later for the missing handler.
     const code = /* js */ `
       const base = Buffer.alloc(512 * 1024, "x").toString();
+      function expectThrow(fn, fragment) {
+        try { fn(); } catch (e) { if (e.message.includes(fragment)) return; throw e; }
+        throw new Error("expected Bun.serve() to throw: " + fragment);
+      }
       function once(i) {
-        try { Bun.serve({ hostname: "127.0.0.1", unix: "/tmp/" + i + base, fetch() {} }); } catch {}
+        expectThrow(() => Bun.serve({ hostname: "127.0.0.1", unix: "/tmp/a" + i + base, fetch() {} }), "both hostname and unix");
+        expectThrow(() => Bun.serve({ unix: "/tmp/b" + i + base }), "fetch");
       }
       for (let i = 0; i < 20; i++) once(i);
       Bun.gc(true);
@@ -679,7 +685,8 @@ describe("Bun.serve unix socket validation", () => {
       console.log(JSON.stringify({ deltaMiB: (process.memoryUsage.rss() - before) / 1024 / 1024 }));
     `;
 
-    // Unfixed: ~100 MiB. Fixed: allocator slack only.
+    // Unfixed: at least 100 MiB per leaking call site (200 resident copies of
+    // the 512 KiB path). Fixed: allocator slack only.
     await expectRssDeltaBelow(["--smol", "-e", code], { release: 40, debug: 55 });
   });
 

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -1,6 +1,6 @@
 import { serve } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isWindows, tmpdirSync } from "../../../harness";
+import { expectRssDeltaBelow, isWindows, tmpdirSync } from "../../../harness";
 
 const defaultHostname = "localhost";
 
@@ -661,6 +661,26 @@ describe("Bun.serve unix socket validation", () => {
         },
       }),
     ).toThrow();
+  });
+
+  test("unix option does not leak the string", async () => {
+    // The hostname + unix combination throws before any socket is bound, so
+    // this drives the option parsing alone.
+    const code = /* js */ `
+      const base = Buffer.alloc(512 * 1024, "x").toString();
+      function once(i) {
+        try { Bun.serve({ hostname: "127.0.0.1", unix: "/tmp/" + i + base, fetch() {} }); } catch {}
+      }
+      for (let i = 0; i < 20; i++) once(i);
+      Bun.gc(true);
+      const before = process.memoryUsage.rss();
+      for (let i = 0; i < 200; i++) once(i);
+      Bun.gc(true);
+      console.log(JSON.stringify({ deltaMiB: (process.memoryUsage.rss() - before) / 1024 / 1024 }));
+    `;
+
+    // Unfixed: ~100 MiB. Fixed: allocator slack only.
+    await expectRssDeltaBelow(["--smol", "-e", code], { release: 40, debug: 55 });
   });
 
   describe("invalid unix socket paths should throw", () => {

--- a/test/js/bun/transpiler/transpiler-transform-output-leak.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-output-leak.test.ts
@@ -7,21 +7,24 @@ import { expectRssDeltaBelow } from "harness";
 test("transform() reject path does not leak the printed output", async () => {
   const code = /* js */ `
     const t = new Bun.Transpiler({ loader: "js" });
-    const payload = Buffer.alloc(256 * 1024, "a").toString();
     // "-->" at the start of a line is the legacy HTML close comment. The lexer
     // logs a warning, so parse and print succeed and transform() rejects.
-    const src = 'var big = "' + payload + '";\\n--> trailing\\nbig;\\n';
+    const source = kib => 'var big = "' + Buffer.alloc(kib * 1024, "a").toString() + '";\\n--> trailing\\nbig;\\n';
+    const warm = source(4), src = source(256);
+    const warmups = 100, iterations = 128;
     let rejected = 0;
-    async function once() { try { await t.transform(src); } catch { rejected++; } }
-    for (let i = 0; i < 20; i++) await once();
+    async function once(s) { try { await t.transform(s); } catch { rejected++; } }
+    // A small source warms the JIT and the work pool without the lexing cost.
+    for (let i = 0; i < warmups; i++) await once(warm);
     Bun.gc(true);
     const before = process.memoryUsage.rss();
-    for (let i = 0; i < 400; i++) await once();
+    for (let i = 0; i < iterations; i++) await once(src);
     Bun.gc(true);
-    if (rejected !== 420) throw new Error("expected every transform() to reject, got " + rejected);
+    if (rejected !== warmups + iterations) throw new Error("expected every transform() to reject, got " + rejected);
     console.log(JSON.stringify({ deltaMiB: (process.memoryUsage.rss() - before) / 1024 / 1024 }));
   `;
 
-  // Unfixed: ~100 MiB. Fixed: allocator slack only.
-  await expectRssDeltaBelow(["--smol", "-e", code], { release: 40, debug: 55 });
+  // Unfixed: at least 32 MiB (128 resident copies of the 256 KiB output).
+  // Fixed: under 3 MiB of allocator slack.
+  await expectRssDeltaBelow(["--smol", "-e", code], { release: 16, debug: 20 });
 });

--- a/test/js/bun/transpiler/transpiler-transform-output-leak.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-output-leak.test.ts
@@ -1,0 +1,27 @@
+import { test } from "bun:test";
+import { expectRssDeltaBelow } from "harness";
+
+// transform() runs on the work pool and keeps the printed output until the
+// promise settles. When the parse log holds a warning, the promise rejects
+// without handing that output to JS, so the task itself must release it.
+test("transform() reject path does not leak the printed output", async () => {
+  const code = /* js */ `
+    const t = new Bun.Transpiler({ loader: "js" });
+    const payload = Buffer.alloc(256 * 1024, "a").toString();
+    // "-->" at the start of a line is the legacy HTML close comment. The lexer
+    // logs a warning, so parse and print succeed and transform() rejects.
+    const src = 'var big = "' + payload + '";\\n--> trailing\\nbig;\\n';
+    let rejected = 0;
+    async function once() { try { await t.transform(src); } catch { rejected++; } }
+    for (let i = 0; i < 20; i++) await once();
+    Bun.gc(true);
+    const before = process.memoryUsage.rss();
+    for (let i = 0; i < 400; i++) await once();
+    Bun.gc(true);
+    if (rejected !== 420) throw new Error("expected every transform() to reject, got " + rejected);
+    console.log(JSON.stringify({ deltaMiB: (process.memoryUsage.rss() - before) / 1024 / 1024 }));
+  `;
+
+  // Unfixed: ~100 MiB. Fixed: allocator slack only.
+  await expectRssDeltaBelow(["--smol", "-e", code], { release: 40, debug: 55 });
+});

--- a/test/js/bun/transpiler/transpiler-transform-output-leak.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-output-leak.test.ts
@@ -11,16 +11,23 @@ test("transform() reject path does not leak the printed output", async () => {
     // logs a warning, so parse and print succeed and transform() rejects.
     const source = kib => 'var big = "' + Buffer.alloc(kib * 1024, "a").toString() + '";\\n--> trailing\\nbig;\\n';
     const warm = source(4), src = source(256);
-    const warmups = 100, iterations = 128;
-    let rejected = 0;
-    async function once(s) { try { await t.transform(s); } catch { rejected++; } }
+    // Only that warning may reject. Any other error is a different bug, and a
+    // resolve means the source no longer takes the reject path.
+    async function once(s) {
+      try {
+        await t.transform(s);
+      } catch (e) {
+        if (String(e.message).includes("legacy HTML single-line comment")) return;
+        throw e;
+      }
+      throw new Error("expected transform() to reject on the legacy HTML comment warning");
+    }
     // A small source warms the JIT and the work pool without the lexing cost.
-    for (let i = 0; i < warmups; i++) await once(warm);
+    for (let i = 0; i < 100; i++) await once(warm);
     Bun.gc(true);
     const before = process.memoryUsage.rss();
-    for (let i = 0; i < iterations; i++) await once(src);
+    for (let i = 0; i < 128; i++) await once(src);
     Bun.gc(true);
-    if (rejected !== warmups + iterations) throw new Error("expected every transform() to reject, got " + rejected);
     console.log(JSON.stringify({ deltaMiB: (process.memoryUsage.rss() - before) / 1024 / 1024 }));
   `;
 


### PR DESCRIPTION
### Problem
- #40238 made `bun_core::String` release its WTF ref on `Drop`. Two sites in its Fixes list have no test on main: `Bun.serve({ unix })` and the `Bun.Transpiler` reject path. Their fix PRs (#32287, #32370) are closed as superseded.
- Neither leak was user-reported, and #40238 closes both by construction. The tests pin that state.

### Fix
- Test-only. No source change.
- `test/js/bun/http/bun-serve-args.test.ts`: 200 rounds of two `Bun.serve` calls with a 512 KiB `unix` path. The first throws on hostname + unix. The second accepts the path and throws for the missing handler. Neither binds a socket.
- `test/js/bun/transpiler/transpiler-transform-output-leak.test.ts`: 128 transforms of a 256 KiB source that ends with a legacy HTML `-->` line. Only that warning may reject. Bounds: 16 MiB release, 20 MiB debug. Unfixed floor: 32 MiB of resident output copies.
- Verified: both pass on main at 44411167ac (debug ASAN, three runs each). Before #40238: 210 MiB and 35 MiB of RSS growth. After: 13 MiB and under 3 MiB.

### Background
- `bun_core::String` mirrors the C++ `BunString` and holds one ref on a `WTF::StringImpl`. Before #40238 it was `Copy` with no destructor, so callers had to `deref()` by hand.
- `expectRssDeltaBelow` (`harness`) spawns bun with the ASAN quarantine off and reads a `deltaMiB` line from stdout.
- Lexing costs about 35 ms per MiB on a debug build, so the transpiler test cannot afford the usual 100 MiB floor. A 4 KiB warmup removes the 8 to 10 MiB of first-run RSS growth and allows the tight bound.
- #40296 is the sibling test-only PR for three other sites on that list.

<details><summary>Notes</summary>

- Closed as superseded, with the original tests verified on main: #32285 (Postgres `FieldMessage`), #32287 (`Bun.serve` unix), #32313 (`JSS3Error`), #32370 (Transpiler `output_code`).
- Main already covers the other two sites from that batch: `test/js/sql/postgres-string-leak.test.ts` ("error response fields are not leaked") and `test/js/bun/s3/s3-stream-cancel-leak.test.ts` ("S3 error code/message are not leaked").
- Both leaks came from code audits of the Rust port, not from user reports. A regression would need a new manual ref hand-off at one of the two sites (an owned local in `ServerConfig.rs`, an owned field in `JSTranspiler.rs`).
- The unix test uses the same 40 MiB release and 55 MiB debug bounds as the other `expectRssDeltaBelow` tests.
- Unfixed measurements were taken on the last debug build before #40238 (4448a2e21), with that commit's bundled JS modules regenerated so the binary could load them.
- The unix fixture gives each call its own string. A shared JS string is flattened in place by the first `to_bun_string`, so two leaked refs would pin one copy and the growth would read as one site.
- The transpiler fixture rejects with a `BuildMessage` whose message is `Treating "-->" as the start of a legacy HTML single-line comment`. Any other rejection, or a resolve, fails the fixture.
- The first 50 to 100 transforms grow RSS by 8 to 10 MiB with any source size (JIT tiers and work pool state). The 4 KiB warmup pays that once at almost no lexing cost.
- A first version of the transpiler test ran 400 transforms of the 256 KiB source with the 40/55 MiB bounds. It took 4.0 to 5.0 s on a debug build, which is the default per-test timeout. The shrunk version takes 1.8 to 2.3 s here.
- An LSan variant (`Malloc=1`, `detect_leaks=1`) would be exact but runs on ASAN lanes only and costs about 5 s of symbolization per run. The RSS variant also guards release builds.
- `test/js/bun/transpiler/` holds one file per behavior, and the leak tests elsewhere in the tree are dedicated `*-leak.test.ts` files, so the transpiler test is a new file in that directory.
- Commands run: `bun bd test test/js/bun/http/bun-serve-args.test.ts` (60 pass, 0 fail) and `bun bd test test/js/bun/transpiler/transpiler-transform-output-leak.test.ts` (1 pass).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-args.test.ts

<!-- robobun:evidence:end -->