### PR TITLE
bunx: fix process identity when the Windows fast path runs a bin in-process

### DIFF
--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -833,9 +833,9 @@ pub(crate) fn cron_register(global: &JSGlobalObject, frame: &CallFrame) -> JsRes
         }
     }
 
-    let bun_exe = match bun_core::self_exe_path() {
-        Ok(p) => p,
-        Err(_) => {
+    let bun_exe = match crate::node::process::exec_path_zstr() {
+        Some(p) => p,
+        None => {
             return Err(global.throw(format_args!("Failed to get bun executable path")));
         }
     };

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -429,10 +429,8 @@ pub(crate) static Bun__Node__DisabledWarnings: std::sync::OnceLock<Vec<Box<[u8]>
 
 #[allow(non_upper_case_globals)]
 /// Overrides `process.execPath` / `process.argv[0]`. Set once when the
-/// Windows bunx fast path boots a bin script inside the `bunx.exe` process:
-/// a child spawned from `process.execPath` (e.g. `child_process.fork`)
-/// would re-enter bunx CLI mode, so the override points at the sibling
-/// `bun.exe` instead.
+/// Windows bunx fast path boots a bin script inside `bunx.exe`, whose
+/// path children cannot be spawned from (it dispatches to bunx CLI mode).
 pub(crate) static Bun__Node__ExecPathOverride: std::sync::OnceLock<Box<[u8]>> =
     std::sync::OnceLock::new();
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -427,6 +427,15 @@ pub(crate) static Bun__Node__RedirectWarnings: std::sync::OnceLock<Box<[u8]>> =
 pub(crate) static Bun__Node__DisabledWarnings: std::sync::OnceLock<Vec<Box<[u8]>>> =
     std::sync::OnceLock::new();
 
+#[allow(non_upper_case_globals)]
+/// Overrides `process.execPath` / `process.argv[0]`. Set once when the
+/// Windows bunx fast path boots a bin script inside the `bunx.exe` process:
+/// a child spawned from `process.execPath` (e.g. `child_process.fork`)
+/// would re-enter bunx CLI mode, so the override points at the sibling
+/// `bun.exe` instead.
+pub(crate) static Bun__Node__ExecPathOverride: std::sync::OnceLock<Box<[u8]>> =
+    std::sync::OnceLock::new();
+
 /// Backing storage for [`cli_arena`]. Written exactly once in [`Cli::start`]
 /// during single-threaded process startup (before `Command::start`, hence
 /// before any `cli_arena()` / `cli_dupe` caller), then read freely — same

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -431,7 +431,7 @@ pub(crate) static Bun__Node__DisabledWarnings: std::sync::OnceLock<Vec<Box<[u8]>
 /// Overrides `process.execPath` / `process.argv[0]`. Set once when the
 /// Windows bunx fast path boots a bin script inside `bunx.exe`, whose
 /// path children cannot be spawned from (it dispatches to bunx CLI mode).
-pub(crate) static Bun__Node__ExecPathOverride: std::sync::OnceLock<Box<[u8]>> =
+pub(crate) static Bun__Node__ExecPathOverride: std::sync::OnceLock<bun_core::ZBox> =
     std::sync::OnceLock::new();
 
 /// Backing storage for [`cli_arena`]. Written exactly once in [`Cli::start`]

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -428,11 +428,36 @@ pub(crate) static Bun__Node__DisabledWarnings: std::sync::OnceLock<Vec<Box<[u8]>
     std::sync::OnceLock::new();
 
 #[allow(non_upper_case_globals)]
-/// Overrides `process.execPath` / `process.argv[0]`. Set once when the
-/// Windows bunx fast path boots a bin script inside `bunx.exe`, whose
+/// Overrides `process.execPath` / `process.argv[0]` / `npm_execpath`. Set
+/// once, at bunx dispatch on Windows, when the process is `bunx.exe`, whose
 /// path children cannot be spawned from (it dispatches to bunx CLI mode).
 pub(crate) static Bun__Node__ExecPathOverride: std::sync::OnceLock<bun_core::ZBox> =
     std::sync::OnceLock::new();
+
+/// When the process is `bunx.exe`, record the sibling `bun.exe` as the
+/// executable path before anything captures it (`npm_execpath` in the run
+/// env, `process.execPath` in the in-process fast path). A child spawned
+/// from `bunx.exe` re-enters bunx CLI mode (#40298). POSIX needs no
+/// override: `bunx` is a symlink and `self_exe_path` resolves through it.
+#[cfg(windows)]
+fn detect_bunx_exec_path_override() {
+    let Ok(self_exe) = bun::self_exe_path() else {
+        return;
+    };
+    let bytes = self_exe.as_bytes();
+    if !strings::eql_case_insensitive_ascii_check_length(bun_paths::basename(bytes), b"bunx.exe") {
+        return;
+    }
+    let Some(dir) = bun_paths::dirname(bytes) else {
+        return;
+    };
+    let mut sibling = Vec::with_capacity(dir.len() + b"\\bun.exe".len());
+    sibling.extend_from_slice(dir);
+    sibling.extend_from_slice(b"\\bun.exe");
+    if bun_sys::exists(&sibling) {
+        let _ = Bun__Node__ExecPathOverride.set(bun_core::ZBox::from_vec(sibling));
+    }
+}
 
 /// Backing storage for [`cli_arena`]. Written exactly once in [`Cli::start`]
 /// during single-threaded process startup (before `Command::start`, hence
@@ -1535,6 +1560,8 @@ pub mod command {
     #[cold]
     #[inline(never)]
     fn exec_bunx(log: &mut bun_ast::Log) -> CmdResult {
+        #[cfg(windows)]
+        detect_bunx_exec_path_override();
         let ctx = init(Tag::BunxCommand, log)?;
         let start_idx = if IS_BUNX_EXE.load(core::sync::atomic::Ordering::Relaxed) {
             0

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -4020,10 +4020,8 @@ impl BunXFastPath {
 
         if let Some(self_exe) = self_exe {
             let bytes = self_exe.as_bytes();
-            if strings::eql_case_insensitive_ascii_check_length(
-                paths::basename(bytes),
-                b"bunx.exe",
-            ) {
+            if strings::eql_case_insensitive_ascii_check_length(paths::basename(bytes), b"bunx.exe")
+            {
                 if let Some(dir) = paths::dirname(bytes) {
                     let mut sibling = Vec::with_capacity(dir.len() + b"\\bun.exe".len());
                     sibling.extend_from_slice(dir);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3998,6 +3998,62 @@ impl BunXFastPath {
         bun_core::scoped_log!(BUNX_FAST_PATH_LOG, "did not start via shim");
     }
 
+    /// The POSIX equivalent of this fast path execs the bin through the temp
+    /// `node` shim, so the child process carries no bun/bunx CLI flags in
+    /// argv and `process.execPath` resolves (through the shim symlink) to
+    /// `bun`. The in-process launch keeps the original argv
+    /// (`bunx --bun --no-install <pkg>`): the `process.execArgv` re-parse
+    /// would report the bunx CLI flags as runtime flags, and when invoked as
+    /// `bunx.exe` a `child_process.fork` child would re-enter bunx CLI mode
+    /// (#40298). Rewrite the global argv to the `bun <script> <args>` shape
+    /// and point `process.execPath` at the sibling `bun.exe` before the VM
+    /// boots.
+    fn assume_runtime_identity(script_path: &[u8], passthrough: &[Box<[u8]>]) {
+        fn leak_zstr(bytes: &[u8]) -> &'static ZStr {
+            let mut v = Vec::with_capacity(bytes.len() + 1);
+            v.extend_from_slice(bytes);
+            v.push(0);
+            ZStr::from_slice_with_nul(v.leak())
+        }
+
+        let self_exe: Option<&'static ZStr> = core::self_exe_path().ok();
+
+        if let Some(self_exe) = self_exe {
+            let bytes = self_exe.as_bytes();
+            if strings::eql_case_insensitive_ascii_check_length(
+                paths::basename(bytes),
+                b"bunx.exe",
+            ) {
+                if let Some(dir) = paths::dirname(bytes) {
+                    let mut sibling = Vec::with_capacity(dir.len() + b"\\bun.exe".len());
+                    sibling.extend_from_slice(dir);
+                    sibling.extend_from_slice(b"\\bun.exe");
+                    if sys::exists(&sibling) {
+                        let _ = cli::Bun__Node__ExecPathOverride.set(sibling.into_boxed_slice());
+                    }
+                }
+            }
+        }
+
+        let argv0: &'static ZStr = match cli::Bun__Node__ExecPathOverride.get() {
+            Some(path) => leak_zstr(path),
+            None => match self_exe {
+                Some(z) => z,
+                None => core::argv().get(0).unwrap_or(core::zstr!("bun")),
+            },
+        };
+
+        let mut new_argv: Vec<&'static ZStr> = Vec::with_capacity(2 + passthrough.len());
+        new_argv.push(argv0);
+        new_argv.push(leak_zstr(script_path));
+        for arg in passthrough {
+            new_argv.push(leak_zstr(arg));
+        }
+        // SAFETY: single-threaded CLI dispatch, before the VM boots; no
+        // concurrent `argv()` readers exist yet.
+        unsafe { core::set_argv(core::intern_argv(new_argv)) };
+    }
+
     fn direct_launch_callback(wpath: &mut [u16], ctx: bun_options_types::context::Context<'_>) {
         // SAFETY: process-lifetime static, single-threaded CLI dispatch.
         // `try_launch` (still on the call stack) holds live `&mut [u16]`
@@ -4014,6 +4070,7 @@ impl BunXFastPath {
             ::core::slice::from_raw_parts_mut(raw.cast::<u8>(), bun_paths::PATH_MAX_WIDE * 2)
         };
         let utf8 = strings::convert_utf16_to_utf8_in_buffer(out_buf, wpath);
+        Self::assume_runtime_identity(utf8, &ctx.passthrough);
         if let Err(err) = RunCommand::boot(ctx, utf8.to_vec().into_boxed_slice(), None) {
             // SAFETY: `ctx.log` was set in `create_context_data`.
             let _ = unsafe { &mut *ctx.log }.print(std::ptr::from_mut(Output::error_writer()));

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3998,16 +3998,11 @@ impl BunXFastPath {
         bun_core::scoped_log!(BUNX_FAST_PATH_LOG, "did not start via shim");
     }
 
-    /// The POSIX equivalent of this fast path execs the bin through the temp
-    /// `node` shim, so the child process carries no bun/bunx CLI flags in
-    /// argv and `process.execPath` resolves (through the shim symlink) to
-    /// `bun`. The in-process launch keeps the original argv
-    /// (`bunx --bun --no-install <pkg>`): the `process.execArgv` re-parse
-    /// would report the bunx CLI flags as runtime flags, and when invoked as
-    /// `bunx.exe` a `child_process.fork` child would re-enter bunx CLI mode
-    /// (#40298). Rewrite the global argv to the `bun <script> <args>` shape
-    /// and point `process.execPath` at the sibling `bun.exe` before the VM
-    /// boots.
+    /// Give the in-process launch the identity a POSIX bunx child gets by
+    /// exec'ing through the temp `node` shim: argv in the
+    /// `bun <script> <args>` shape (the `process.execArgv` re-parse must not
+    /// see bunx CLI flags) and `process.execPath` at the sibling `bun.exe`
+    /// (a fork of `bunx.exe` re-enters bunx CLI mode, #40298).
     fn assume_runtime_identity(script_path: &[u8], passthrough: &[Box<[u8]>]) {
         fn leak_zstr(bytes: &[u8]) -> &'static ZStr {
             let mut v = Vec::with_capacity(bytes.len() + 1);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -4022,14 +4022,14 @@ impl BunXFastPath {
                     sibling.extend_from_slice(dir);
                     sibling.extend_from_slice(b"\\bun.exe");
                     if sys::exists(&sibling) {
-                        let _ = cli::Bun__Node__ExecPathOverride.set(sibling.into_boxed_slice());
+                        let _ = cli::Bun__Node__ExecPathOverride.set(core::ZBox::from_vec(sibling));
                     }
                 }
             }
         }
 
         let argv0: &'static ZStr = match cli::Bun__Node__ExecPathOverride.get() {
-            Some(path) => leak_zstr(path),
+            Some(path) => path.as_zstr(),
             None => match self_exe {
                 Some(z) => z,
                 None => core::argv().get(0).unwrap_or(core::zstr!("bun")),

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -728,10 +728,10 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
         if env_loader.get(b"npm_execpath").is_none() {
             // we don't care if this fails
-            if let Ok(self_exe_path) = bun_core::self_exe_path() {
+            if let Some(exec_path) = crate::node::process::exec_path_bytes() {
                 env_loader
                     .map
-                    .put_default(b"npm_execpath", self_exe_path.as_bytes())
+                    .put_default(b"npm_execpath", exec_path)
                     .expect("unreachable");
             }
         }
@@ -4000,9 +4000,10 @@ impl BunXFastPath {
 
     /// Give the in-process launch the identity a POSIX bunx child gets by
     /// exec'ing through the temp `node` shim: argv in the
-    /// `bun <script> <args>` shape (the `process.execArgv` re-parse must not
-    /// see bunx CLI flags) and `process.execPath` at the sibling `bun.exe`
-    /// (a fork of `bunx.exe` re-enters bunx CLI mode, #40298).
+    /// `bun <BUN_OPTIONS> <script> <args>` shape (the `process.execArgv`
+    /// re-parse must not see bunx CLI flags) and argv[0] at the override
+    /// `cli::detect_bunx_exec_path_override` recorded (a fork of `bunx.exe`
+    /// re-enters bunx CLI mode, #40298).
     fn assume_runtime_identity(script_path: &[u8], passthrough: &[Box<[u8]>]) {
         fn leak_zstr(bytes: &[u8]) -> &'static ZStr {
             let mut v = Vec::with_capacity(bytes.len() + 1);
@@ -4011,33 +4012,25 @@ impl BunXFastPath {
             ZStr::from_slice_with_nul(v.leak())
         }
 
-        let self_exe: Option<&'static ZStr> = core::self_exe_path().ok();
-
-        if let Some(self_exe) = self_exe {
-            let bytes = self_exe.as_bytes();
-            if strings::eql_case_insensitive_ascii_check_length(paths::basename(bytes), b"bunx.exe")
-            {
-                if let Some(dir) = paths::dirname(bytes) {
-                    let mut sibling = Vec::with_capacity(dir.len() + b"\\bun.exe".len());
-                    sibling.extend_from_slice(dir);
-                    sibling.extend_from_slice(b"\\bun.exe");
-                    if sys::exists(&sibling) {
-                        let _ = cli::Bun__Node__ExecPathOverride.set(core::ZBox::from_vec(sibling));
-                    }
-                }
-            }
-        }
-
         let argv0: &'static ZStr = match cli::Bun__Node__ExecPathOverride.get() {
             Some(path) => path.as_zstr(),
-            None => match self_exe {
+            None => match core::self_exe_path().ok() {
                 Some(z) => z,
                 None => core::argv().get(0).unwrap_or(core::zstr!("bun")),
             },
         };
 
-        let mut new_argv: Vec<&'static ZStr> = Vec::with_capacity(2 + passthrough.len());
+        let bun_options_argc = core::bun_options_argc();
+        let mut new_argv: Vec<&'static ZStr> =
+            Vec::with_capacity(2 + bun_options_argc + passthrough.len());
         new_argv.push(argv0);
+        // BUN_OPTIONS tokens sit at argv[1..]; keep them so `process.execArgv`
+        // reports them, as the POSIX child does after its own env re-splice.
+        for i in 1..=bun_options_argc {
+            if let Some(z) = core::argv().get(i) {
+                new_argv.push(z);
+            }
+        }
         new_argv.push(leak_zstr(script_path));
         for arg in passthrough {
             new_argv.push(leak_zstr(arg));

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -26,9 +26,8 @@ extern "C" fn create_argv0(global_object: &JSGlobalObject) -> JSValue {
     EncodedSlice::from_bytes(argv0).to_js(global_object)
 }
 
-/// `process.execPath` bytes: the CLI-set override (the Windows bunx fast
-/// path boots the bin script inside `bunx.exe`, whose own path cannot be
-/// re-spawned as a runtime) or the resolved executable path.
+/// `process.execPath` bytes: the CLI-set override (Windows bunx in-process
+/// launch) or the resolved executable path.
 pub(crate) fn exec_path_bytes() -> Option<&'static [u8]> {
     if let Some(path) = crate::cli::Bun__Node__ExecPathOverride.get() {
         return Some(path);

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -26,13 +26,18 @@ extern "C" fn create_argv0(global_object: &JSGlobalObject) -> JSValue {
     EncodedSlice::from_bytes(argv0).to_js(global_object)
 }
 
-/// `process.execPath` bytes: the CLI-set override (Windows bunx in-process
-/// launch) or the resolved executable path.
-pub(crate) fn exec_path_bytes() -> Option<&'static [u8]> {
+/// `process.execPath` as a NUL-terminated `ZStr`: the CLI-set override
+/// (Windows bunx in-process launch) or the resolved executable path.
+pub(crate) fn exec_path_zstr() -> Option<&'static bun_core::ZStr> {
     if let Some(path) = crate::cli::Bun__Node__ExecPathOverride.get() {
-        return Some(path);
+        return Some(path.as_zstr());
     }
-    bun_core::self_exe_path().ok().map(|z| z.as_bytes())
+    bun_core::self_exe_path().ok()
+}
+
+/// [`exec_path_zstr`] as bytes.
+pub(crate) fn exec_path_bytes() -> Option<&'static [u8]> {
+    exec_path_zstr().map(|z| z.as_bytes())
 }
 
 #[unsafe(export_name = "Bun__Process__getExecPath")]

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -26,13 +26,23 @@ extern "C" fn create_argv0(global_object: &JSGlobalObject) -> JSValue {
     EncodedSlice::from_bytes(argv0).to_js(global_object)
 }
 
+/// `process.execPath` bytes: the CLI-set override (the Windows bunx fast
+/// path boots the bin script inside `bunx.exe`, whose own path cannot be
+/// re-spawned as a runtime) or the resolved executable path.
+pub(crate) fn exec_path_bytes() -> Option<&'static [u8]> {
+    if let Some(path) = crate::cli::Bun__Node__ExecPathOverride.get() {
+        return Some(path);
+    }
+    bun_core::self_exe_path().ok().map(|z| z.as_bytes())
+}
+
 #[unsafe(export_name = "Bun__Process__getExecPath")]
 extern "C" fn get_exec_path(global_object: &JSGlobalObject) -> JSValue {
-    let Ok(out) = bun_core::self_exe_path() else {
+    let Some(out) = exec_path_bytes() else {
         // if for any reason we are unable to get the executable path, we just return argv[0]
         return create_argv0(global_object);
     };
-    EncodedSlice::from_bytes(out.as_bytes()).to_js(global_object)
+    EncodedSlice::from_bytes(out).to_js(global_object)
 }
 
 /// A worker's `argv`/`execArgv` strings live in its parent-thread
@@ -359,9 +369,8 @@ mod _impl {
             // Even if they didn't type "bun", we still want to add it as argv[0]
             args_list.push(BunString::static_("bun"));
         } else {
-            let exe_path = bun_core::self_exe_path().ok();
-            args_list.push(match exe_path {
-                Some(str_) => BunString::borrow_utf8(str_.as_bytes()),
+            args_list.push(match super::exec_path_bytes() {
+                Some(bytes) => BunString::borrow_utf8(bytes),
                 None => BunString::static_("bun"),
             });
         }

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1587,8 +1587,8 @@ impl Interpreter {
         match event_loop {
             EventLoopHandle::Js { .. } => {
                 if int == 0 {
-                    if let Ok(p) = bun_core::self_exe_path() {
-                        out.extend_from_slice(p.as_bytes());
+                    if let Some(p) = crate::node::process::exec_path_bytes() {
+                        out.extend_from_slice(p);
                     }
                     return;
                 }

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -478,9 +478,7 @@ impl Cmd {
             match bun_which::which(&mut *path_buf, spawn_args.path, spawn_args.cwd, &first_arg) {
                 Some(z) => Some(z.as_bytes().to_vec()),
                 None if &first_arg[..] == b"bun" || &first_arg[..] == b"bun-debug" => {
-                    bun_core::self_exe_path()
-                        .ok()
-                        .map(|z| z.as_bytes().to_vec())
+                    crate::node::process::exec_path_bytes().map(<[u8]>::to_vec)
                 }
                 None => None,
             }

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -519,8 +519,8 @@ it.concurrent.skipIf(!isWindows)("bunx --bun in-process launch can fork children
   using dir = tempDir("bunx-bun-fork", {
     "package.json": JSON.stringify({ name: "repro", dependencies: { showexec: "file:./showexec" } }),
     "showexec/package.json": JSON.stringify({ name: "showexec", version: "1.0.0", bin: { showexec: "cli.js" } }),
-    "showexec/cli.js": `
-      console.log(JSON.stringify({ execPath: process.execPath, execArgv: process.execArgv }));
+    "showexec/cli.js": `#!/usr/bin/env node
+      console.log(JSON.stringify({ argv0: process.argv[0], execPath: process.execPath, execArgv: process.execArgv }));
       const { fork } = require("node:child_process");
       const cp = fork(require("node:path").join(__dirname, "child.js"));
       cp.on("exit", code => console.log("child exit", code));
@@ -541,7 +541,13 @@ it.concurrent.skipIf(!isWindows)("bunx --bun in-process launch can fork children
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await install.exited).toBe(0);
+  const [installOut, installErr, installExit] = await Promise.all([
+    install.stdout.text(),
+    install.stderr.text(),
+    install.exited,
+  ]);
+  expect(installErr).not.toContain("error:");
+  expect(installExit).toBe(0);
 
   await using proc = spawn({
     cmd: [join(exeDir, "bunx.exe"), "--bun", "--no-install", "showexec"],
@@ -550,13 +556,16 @@ it.concurrent.skipIf(!isWindows)("bunx --bun in-process launch can fork children
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [out, exited] = await Promise.all([proc.stdout.text(), proc.exited]);
+  const [out, err, exited] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   const state = JSON.parse(out.slice(0, out.indexOf("\n")));
-  expect(realpathSync(state.execPath).toLowerCase()).toBe(realpathSync(join(exeDir, "bun.exe")).toLowerCase());
+  const bunExePath = realpathSync(join(exeDir, "bun.exe")).toLowerCase();
+  expect(realpathSync(state.execPath).toLowerCase()).toBe(bunExePath);
+  expect(realpathSync(state.argv0).toLowerCase()).toBe(bunExePath);
   expect(state.execArgv).toEqual([]);
   expect(out).toContain("CHILD OK");
   expect(out).toContain("child exit 0");
+  expect(err).not.toContain("error:");
   expect(exited).toBe(0);
 });
 

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1,8 +1,8 @@
 import { spawn } from "bun";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { mkdir, rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, isWindows, readdirSorted, tmpdirSync } from "harness";
-import { chmodSync, copyFileSync, readdirSync, symlinkSync } from "node:fs";
+import { bunEnv, bunExe, isWindows, readdirSorted, tempDir, tmpdirSync } from "harness";
+import { chmodSync, copyFileSync, mkdirSync, readdirSync, realpathSync, symlinkSync } from "node:fs";
 import { tmpdir } from "os";
 import { delimiter, join, resolve } from "path";
 import { dummyAfterAll, dummyBeforeAll, dummyBeforeEach, dummyRegistry, getPort, setHandler } from "./dummy.registry";
@@ -508,6 +508,55 @@ it.concurrent("should handle postinstall scripts correctly with symlinked bunx",
   expect(err).not.toContain("error:");
   expect(err).not.toContain("Cannot find module 'exec'");
   expect(out.trim()).not.toContain(Bun.version);
+  expect(exited).toBe(0);
+});
+
+// #40298: on Windows, `bunx --bun <pkg>` runs a node-shebang bin script in the
+// same process instead of spawning a child. The process kept bunx's identity:
+// process.execPath pointed at bunx.exe (so a fork()ed child re-entered bunx
+// CLI mode) and process.execArgv carried the bunx CLI flags.
+it.concurrent.skipIf(!isWindows)("bunx --bun in-process launch can fork children (#40298)", async () => {
+  using dir = tempDir("bunx-bun-fork", {
+    "package.json": JSON.stringify({ name: "repro", dependencies: { showexec: "file:./showexec" } }),
+    "showexec/package.json": JSON.stringify({ name: "showexec", version: "1.0.0", bin: { showexec: "cli.js" } }),
+    "showexec/cli.js": `
+      console.log(JSON.stringify({ execPath: process.execPath, execArgv: process.execArgv }));
+      const { fork } = require("node:child_process");
+      const cp = fork(require("node:path").join(__dirname, "child.js"));
+      cp.on("exit", code => console.log("child exit", code));
+    `,
+    "showexec/child.js": `console.log("CHILD OK");`,
+  });
+  // The defect only reproduces when the executable is named bunx.exe, so run
+  // a copy of the test build under that name, with a bun.exe sibling.
+  const exeDir = join(String(dir), "exes");
+  mkdirSync(exeDir);
+  copyFileSync(bunExe(), join(exeDir, "bun.exe"));
+  copyFileSync(bunExe(), join(exeDir, "bunx.exe"));
+
+  await using install = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await install.exited).toBe(0);
+
+  await using proc = spawn({
+    cmd: [join(exeDir, "bunx.exe"), "--bun", "--no-install", "showexec"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, exited] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  const state = JSON.parse(out.slice(0, out.indexOf("\n")));
+  expect(realpathSync(state.execPath).toLowerCase()).toBe(realpathSync(join(exeDir, "bun.exe")).toLowerCase());
+  expect(state.execArgv).toEqual([]);
+  expect(out).toContain("CHILD OK");
+  expect(out).toContain("child exit 0");
   expect(exited).toBe(0);
 });
 

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -549,10 +549,14 @@ it.concurrent.skipIf(!isWindows)("bunx --bun in-process launch can fork children
   expect(installErr).not.toContain("error:");
   expect(installExit).toBe(0);
 
+  // An inherited npm_execpath (the test runner sets one) would win over the
+  // bunx-set default, so strip it.
+  const bunxEnv = { ...bunEnv, BUN_OPTIONS: "--smol" };
+  delete bunxEnv.npm_execpath;
   await using proc = spawn({
     cmd: [join(exeDir, "bunx.exe"), "--bun", "--no-install", "showexec"],
     cwd: String(dir),
-    env: { ...bunEnv, BUN_OPTIONS: "--smol" },
+    env: bunxEnv,
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -520,7 +520,7 @@ it.concurrent.skipIf(!isWindows)("bunx --bun in-process launch can fork children
     "package.json": JSON.stringify({ name: "repro", dependencies: { showexec: "file:./showexec" } }),
     "showexec/package.json": JSON.stringify({ name: "showexec", version: "1.0.0", bin: { showexec: "cli.js" } }),
     "showexec/cli.js": `#!/usr/bin/env node
-      console.log(JSON.stringify({ argv0: process.argv[0], execPath: process.execPath, execArgv: process.execArgv }));
+      console.log(JSON.stringify({ argv0: process.argv[0], execPath: process.execPath, execArgv: process.execArgv, npmExecpath: process.env.npm_execpath }));
       const { fork } = require("node:child_process");
       const cp = fork(require("node:path").join(__dirname, "child.js"));
       cp.on("exit", code => console.log("child exit", code));
@@ -552,7 +552,7 @@ it.concurrent.skipIf(!isWindows)("bunx --bun in-process launch can fork children
   await using proc = spawn({
     cmd: [join(exeDir, "bunx.exe"), "--bun", "--no-install", "showexec"],
     cwd: String(dir),
-    env: bunEnv,
+    env: { ...bunEnv, BUN_OPTIONS: "--smol" },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -562,7 +562,9 @@ it.concurrent.skipIf(!isWindows)("bunx --bun in-process launch can fork children
   const bunExePath = realpathSync(join(exeDir, "bun.exe")).toLowerCase();
   expect(realpathSync(state.execPath).toLowerCase()).toBe(bunExePath);
   expect(realpathSync(state.argv0).toLowerCase()).toBe(bunExePath);
-  expect(state.execArgv).toEqual([]);
+  expect(realpathSync(state.npmExecpath).toLowerCase()).toBe(bunExePath);
+  // BUN_OPTIONS flags stay in execArgv; the bunx CLI flags must not.
+  expect(state.execArgv).toEqual(["--smol"]);
   expect(out).toContain("CHILD OK");
   expect(out).toContain("child exit 0");
   expect(err).not.toContain("error:");


### PR DESCRIPTION
### Problem
- On Windows, `bunx --bun oxfmt` fails on HTML files with `Error: Worker exited unexpectedly`, then `error: Could not find an existing '' binary to run. Stopping because --no-install was passed.` (#40298). oxfmt formats HTML through tinypool, which calls `child_process.fork()`.
- On Windows, `bunx --bun` boots a node-shebang bin script inside the `bunx.exe` process (`BunXFastPath::direct_launch_callback`, `src/runtime/cli/run_command.rs`). The VM keeps bunx's identity: `process.execPath` is `bunx.exe`, so a forked child re-enters bunx CLI mode, and the `process.execArgv` re-parse reports the bunx CLI flags (`--bun --no-install`) as runtime flags and forwards them to the child.

### Fix
- Before the in-process launch boots the VM, rewrite the global argv to the `bun <script> <args>` shape. The `execArgv` re-parse then yields `[]`, the same as POSIX, where bunx execs the bin through the temp `node` shim and the child argv carries no bunx flags.
- When the executable is `bunx.exe`, point `process.execPath` and `process.argv[0]` at the sibling `bun.exe` (POSIX resolves this through `/proc/self/exe` because `bunx` is a symlink; on Windows `bunx.exe` is a real file). The override is set once, in the fast path only. The same-class sites use the same override: the `Bun.$` `$0` expansion, its `bun` fallback when `bun` is not on PATH, and the executable path that `Bun.Cron` writes into a scheduled task.
- `bun --bun run <bin>` and `bun x --bun <pkg>` go through the same callback and keep working: their executable is `bun.exe`, so only the argv rewrite applies.
- Verified: new test in `test/cli/install/bunx.test.ts` (Windows only, fails on bun 1.4.1, passes with the fix). Also ran the full `bunx.test.ts` and `test/js/node/process/process-args.test.js` on Windows, and the reporter's oxfmt case end to end (`Finished ... on 2 files`, exit 0).

### Background
- `bunx.exe` is a copy of `bun.exe`. The CLI dispatches into bunx mode when the executable basename is `bunx`, so a child spawned from `bunx.exe` parses its script path as a package name.
- The Windows fast path (`BunXFastPath`) skips the `.bin` wrapper exe: it reads the `.bunx` shim metadata, and when the shim targets node and `--bun` is set, it runs the script on the current process's VM instead of spawning.
- `process.execArgv` is not stored at parse time. It is re-derived from the process argv on access (`create_exec_argv` in `src/runtime/node/node_process.rs`), which is why the stale bunx argv leaked into it.

<details><summary>Notes</summary>

- Minimal repro (no oxfmt): a local package whose bin prints `process.execPath` / `process.execArgv` and forks a child. On Windows with bun 1.4.1: `execPath=...\bunx.exe`, `execArgv=["--bun","--no-install"]`, child exits 1 after printing the `--no-install` error. On linux: `execPath=.../bun`, `execArgv=[]`, child OK.
- `bun x --bun --no-install <pkg>` did not reproduce even before the fix: the execArgv re-parse stops at the first non-flag token (`x`), and the executable is `bun.exe`. Only the standalone `bunx.exe` entry point was broken. The test therefore runs a copy of the test build named `bunx.exe` with a `bun.exe` sibling.
- The `bun.exe` sibling override checks that the file exists and falls back to the current executable path otherwise.
- The test is Windows-only (`it.skipIf(!isWindows)`): the fast path is `#[cfg(windows)]` and POSIX bunx already re-execs.
- `test/cli/install/bunx.test.ts` has one failure on this machine, `should set "npm_config_user_agent" to bun`. It fails identically on a main build, so it is unrelated. `cargo check` for the windows target fails on main in `bun_jsc` (codegen-dependent); `bun bd` on Windows builds clean.
</details>

Fixes #40298

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bunx.test.ts

<!-- robobun:evidence:end -->
