### PR TITLE
spawn: fire the Terminal exit callback when a detached child of an existing terminal exits

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -438,6 +438,8 @@ When passing an existing `Terminal` object:
 - The `exit` callback fires when you call `terminal.close()`, not when each subprocess exits
 - Use `proc.exited` to detect individual subprocess exits
 
+Exception: a child spawned with `detached: true` is a session leader, and the PTY is torn down when that child exits. Any remaining output is delivered to `data`, then the `exit` callback fires, and the terminal cannot be passed to another spawn afterwards.
+
 ### Platform differences
 
 `Bun.Terminal` uses `openpty()` on Linux and macOS, and ConPTY (`CreatePseudoConsole`) on Windows. The core behavior is the same on every platform: the child sees a TTY, `write()` reaches the child's stdin, child output reaches the `data` callback, and `resize()` updates the child's view. A few details differ:

--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -438,7 +438,7 @@ When passing an existing `Terminal` object:
 - The `exit` callback fires when you call `terminal.close()`, not when each subprocess exits
 - Use `proc.exited` to detect individual subprocess exits
 
-Exception: a child spawned with `detached: true` is a session leader, and the PTY is torn down when that child exits. Any remaining output is delivered to `data`, then the `exit` callback fires, and the terminal cannot be passed to another spawn afterwards.
+Exception: a child spawned with `detached: true` is a session leader, and the PTY is torn down when that child exits. Any remaining output is delivered to `data`, then the `exit` callback fires, and the terminal cannot be passed to another spawn afterward.
 
 ### Platform differences
 

--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -438,7 +438,7 @@ When passing an existing `Terminal` object:
 - The `exit` callback fires when you call `terminal.close()`, not when each subprocess exits
 - Use `proc.exited` to detect individual subprocess exits
 
-Exception: a child spawned with `detached: true` is a session leader, and the PTY is torn down when that child exits. Any remaining output is delivered to `data`, then the `exit` callback fires, and the terminal cannot be passed to another spawn afterward.
+Exception (POSIX): a child spawned with `detached: true` is a session leader, and the PTY is torn down when that child exits. Any remaining output is delivered to `data`, then the `exit` callback fires, and the terminal cannot be passed to another spawn afterward. ConPTY has no session-leader teardown, so on Windows a detached child behaves like a non-detached one.
 
 ### Platform differences
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7715,6 +7715,11 @@ declare module "bun" {
        * await proc2.exited;
        * terminal.close();
        * ```
+       *
+       * Exception: with `detached: true` the child is a session leader, and
+       * the PTY is torn down when it exits. The terminal's `exit` callback
+       * fires at that point, and the terminal cannot be passed to another
+       * spawn afterwards.
        */
       terminal?: TerminalOptions | Terminal;
     }
@@ -8483,6 +8488,11 @@ declare module "bun" {
      * Callback invoked when the PTY stream closes (EOF or read error).
      * `exitCode` is a PTY lifecycle status (0 = clean EOF, 1 = error), NOT the subprocess exit code.
      * Use {@link Subprocess.exited} or the `onExit` callback for the process exit information.
+     *
+     * For a terminal created inline by `Bun.spawn`, and for an existing
+     * terminal whose child was spawned with `detached: true`, the PTY is torn
+     * down when that child exits and this callback fires then, after any
+     * remaining output was delivered to `data`.
      * @param terminal The terminal instance
      * @param exitCode PTY lifecycle status (0 for EOF, 1 for error)
      * @param signal Always `null`; reserved for future signal reporting

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7716,10 +7716,10 @@ declare module "bun" {
        * terminal.close();
        * ```
        *
-       * Exception: with `detached: true` the child is a session leader, and
-       * the PTY is torn down when it exits. The terminal's `exit` callback
-       * fires at that point, and the terminal cannot be passed to another
-       * spawn afterward.
+       * Exception (POSIX): with `detached: true` the child is a session
+       * leader, and the PTY is torn down when it exits. The terminal's `exit`
+       * callback fires at that point, and the terminal cannot be passed to
+       * another spawn afterward.
        */
       terminal?: TerminalOptions | Terminal;
     }
@@ -8489,10 +8489,10 @@ declare module "bun" {
      * `exitCode` is a PTY lifecycle status (0 = clean EOF, 1 = error), NOT the subprocess exit code.
      * Use {@link Subprocess.exited} or the `onExit` callback for the process exit information.
      *
-     * For a terminal created inline by `Bun.spawn`, and for an existing
-     * terminal whose child was spawned with `detached: true`, the PTY is torn
-     * down when that child exits and this callback fires then, after any
-     * remaining output was delivered to `data`.
+     * For a terminal created inline by `Bun.spawn`, and on POSIX for an
+     * existing terminal whose child was spawned with `detached: true`, the
+     * PTY is torn down when that child exits and this callback fires then,
+     * after any remaining output was delivered to `data`.
      * @param terminal The terminal instance
      * @param exitCode PTY lifecycle status (0 for EOF, 1 for error)
      * @param signal Always `null`; reserved for future signal reporting

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7719,7 +7719,7 @@ declare module "bun" {
        * Exception: with `detached: true` the child is a session leader, and
        * the PTY is torn down when it exits. The terminal's `exit` callback
        * fires at that point, and the terminal cannot be passed to another
-       * spawn afterwards.
+       * spawn afterward.
        */
       terminal?: TerminalOptions | Terminal;
     }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -173,7 +173,8 @@ bitflags::bitflags! {
         const CONNECTED      = 1 << 4;
         const READER_DONE    = 1 << 5;
         const WRITER_DONE    = 1 << 6;
-        /// Set once an inline-created terminal is attached to a spawn; blocks
+        /// Set once an inline-created terminal is attached to a spawn, or the
+        /// pty slave was torn down after a detached child exited; blocks
         /// reuse. Windows: the ConDrv `\Reference` handle is released at spawn.
         /// POSIX: slave_fd is held until first exit (`drain_and_close_slave_fd`).
         const INLINE_SPAWNED = 1 << 7;
@@ -1795,6 +1796,13 @@ impl Terminal {
 
     fn on_reader_error(&self, err: &sys::Error) {
         bun_output::scoped_log!(Terminal, "onReaderError: {:?}", err);
+        // Linux reports EIO on the pty master once the last slave fd closes,
+        // where macOS reports EOF. Same lifecycle event, same exit status.
+        #[cfg(unix)]
+        if err.get_errno() == sys::E::EIO {
+            self.on_reader_finished(0);
+            return;
+        }
         // exit_code 1 = I/O error on PTY stream (not subprocess exit code)
         self.on_reader_finished(1);
     }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -800,15 +800,19 @@ fn spawn_maybe_sync(
                             return Err(global_this
                                 .throw_invalid_arguments(format_args!("terminal is closed")));
                         }
-                        if term.is_inline_spawned() {
-                            return Err(global_this.throw_invalid_arguments(format_args!(
-                                "terminal was created inline by a previous spawn and cannot be reused",
-                            )));
-                        }
+                        // Checked before INLINE_SPAWNED: the slave also closes
+                        // when a detached child of a user-created terminal
+                        // exits, and that case should not report the terminal
+                        // as inline-created.
                         #[cfg(unix)]
                         if term.get_slave_fd() == Fd::INVALID {
                             return Err(global_this.throw_invalid_arguments(format_args!(
-                                "terminal slave fd is no longer valid"
+                                "terminal's pty was closed after a previous child exited and cannot be reused"
+                            )));
+                        }
+                        if term.is_inline_spawned() {
+                            return Err(global_this.throw_invalid_arguments(format_args!(
+                                "terminal was created inline by a previous spawn and cannot be reused",
                             )));
                         }
                         #[cfg(not(unix))]
@@ -1482,10 +1486,21 @@ fn spawn_maybe_sync(
             // and the reader observes EOF without us having to tear ConPTY
             // down from on_process_exit.
             info.terminal.release_pseudoconsole_reference();
+            subprocess.update_flags(|f| f.insert(Subprocess::Flags::OWNS_TERMINAL));
         }
+    }
+    // The child runs setsid() when spawn passed it the pty slave (inline
+    // terminal) or when `detached` is set (the predicate bun-spawn.cpp uses).
+    // A session leader's exit ends the pty session: macOS revokes the pty in
+    // the kernel, so the terminal is unusable there anyway. Tear the slave
+    // down on exit so Linux matches: the master only reaches EIO (and the
+    // exit callback only fires) once every slave fd is closed, including
+    // ours. Existing terminals with non-detached children keep slave_fd for
+    // reuse.
+    #[cfg(unix)]
+    if subprocess.terminal.get().is_some() && (detached || spawn_options.pty_slave_fd >= 0) {
         subprocess.update_flags(|f| f.insert(Subprocess::Flags::OWNS_TERMINAL));
     }
-    // existing_terminal: don't close slave_fd - user manages lifecycle and can reuse
 
     // SAFETY: `subprocess_ptr` is the live JSC-allocated Subprocess that owns
     // `process` and outlives it (handler ctx invariant).

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -300,9 +300,12 @@ bitflags::bitflags! {
         const FINALIZED                    = 1 << 3;
         const DEREF_ON_STDIN_DESTROYED     = 1 << 4;
         const IS_STDIN_A_READABLE_STREAM   = 1 << 5;
-        /// Terminal was created inline by spawn (vs. an existing Terminal passed
-        /// by the caller). Owned terminals are closed when the subprocess exits
-        /// so the exit callback fires; borrowed terminals are left open for reuse.
+        /// This subprocess tears the terminal's pty slave down when it exits
+        /// (`drain_and_close_slave_fd`), so the reader reaches EOF/EIO and the
+        /// JS exit callback fires. Set for terminals created inline by spawn,
+        /// and on POSIX for a detached child attached to an existing Terminal
+        /// (a session leader whose exit already revokes the pty on macOS).
+        /// Other existing terminals are left open for reuse.
         const OWNS_TERMINAL                = 1 << 6;
         /// `handle_abort_signal` sent `kill_signal`; `on_process_exit` closes
         /// pipe readers instead of waiting on EOF a grandchild may never send.

--- a/test/js/bun/terminal/terminal-platform-gaps.test.ts
+++ b/test/js/bun/terminal/terminal-platform-gaps.test.ts
@@ -323,8 +323,9 @@ describe("Bun.Terminal platform behaviour", () => {
   });
 
   test("SAME: exit callback does NOT fire on child exit for existing terminal", async () => {
-    // Existing terminal: caller manages lifecycle and may reuse it, so child
-    // exit must not tear it down on either platform.
+    // Existing terminal, non-detached child: caller manages lifecycle and may
+    // reuse it, so child exit must not tear it down on either platform.
+    // (A detached child is different: see the tests below.)
     let fired = false;
     const terminal = new Bun.Terminal({
       exit() {
@@ -335,6 +336,51 @@ describe("Bun.Terminal platform behaviour", () => {
     await proc.exited;
     await Bun.sleep(100);
     expect(fired).toBe(false);
+    terminal.close();
+  });
+
+  // POSIX-only: `detached` makes the child a session leader. macOS revokes
+  // the pty when it exits; bun closes its slave copy on exit so Linux reaches
+  // EIO and behaves the same. ConPTY has no session-leader teardown.
+  test.skipIf(isWindows)("SAME: exit callback fires after a detached child exits (existing terminal)", async () => {
+    let output = "";
+    const ptyClosed = Promise.withResolvers<{ code: number; signal: string | null }>();
+    const terminal = new Bun.Terminal({
+      data(_t, chunk) {
+        output += Buffer.from(chunk).toString("latin1");
+      },
+      exit(_t, code, signal) {
+        ptyClosed.resolve({ code, signal });
+      },
+    });
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "process.stdout.write('MARKER')"],
+      env: bunEnv,
+      terminal,
+      detached: true,
+    });
+    await proc.exited;
+    // Fires without terminal.close(); all pending output is delivered first.
+    // Clean-EOF status on both platforms: macOS reads EOF after the kernel
+    // revoke, Linux reads EIO after the last slave closes and normalizes it.
+    expect(await ptyClosed.promise).toEqual({ code: 0, signal: null });
+    expect(output).toContain("MARKER");
+    terminal.close();
+  });
+
+  test.skipIf(isWindows)("SAME: terminal cannot be respawned after a detached child exits", async () => {
+    const ptyClosed = Promise.withResolvers<void>();
+    const terminal = new Bun.Terminal({
+      exit() {
+        ptyClosed.resolve();
+      },
+    });
+    const p1 = Bun.spawn({ cmd: [bunExe(), "-e", ""], env: bunEnv, terminal, detached: true });
+    await p1.exited;
+    await ptyClosed.promise;
+    expect(() => Bun.spawn({ cmd: [bunExe(), "-e", ""], env: bunEnv, terminal })).toThrow(
+      "terminal's pty was closed after a previous child exited and cannot be reused",
+    );
     terminal.close();
   });
 


### PR DESCRIPTION
### Problem

- The `exit` callback of a `Bun.Terminal` passed to `Bun.spawn` with `detached: true` never fires on Linux when the child exits. On macOS it fires. #40289 measured 0/400 spontaneous on Linux against 400/400 on macOS.
- Cause: bun keeps its copy of the pty slave fd open so the terminal stays reusable (`js_bun_spawn_bindings.rs:1528`). On Linux the master only reads EIO after the last slave fd closes. macOS fires anyway because the kernel revokes the pty when a session leader exits.

### Fix

- Set `OWNS_TERMINAL` whenever the child runs `setsid()` with the pty, the same predicate `bun-spawn.cpp` uses: a terminal created inline, or an existing terminal spawned with `detached`. The child's exit then runs the existing `drain_and_close_slave_fd` teardown: pending output reaches `data`, the slave closes, the reader hits EOF/EIO, and `exit` fires on both platforms.
- Normalize the EIO that Linux reports on the master after the last slave closes to exit status 0, the clean-EOF value macOS reports for the same event.
- Non-detached children of an existing terminal are unchanged: no teardown, terminal reusable. A spawn that reuses the terminal after the teardown throws a clear error. Docs and types carry the new exception.
- Verified: `test/js/bun/terminal/terminal-platform-gaps.test.ts` (two new tests, stock bun times out on both). Also terminal.test.ts, terminal-spawn, spawn.test.ts, repl, tty, regression/26286, and cargo check for windows-msvc and aarch64-darwin.

### Background

- A `Bun.Terminal` wraps a pty pair. Bun reads and writes the master, and the child gets dup'd slave fds as stdio. The `exit` callback fires when the master read ends.
- `detached: true` runs `setsid()` in the child, which makes it a session leader. When a session leader exits on macOS, the kernel revokes the pty, so the master reads EOF while bun still holds a slave fd. Linux has no revoke. The master returns EIO only once every slave fd in every process is closed.
- An existing terminal is documented as reusable across sequential spawns. That promise cannot hold for a detached child on macOS because of the kernel revoke. This PR draws the same line on both platforms: detached child exit ends the terminal, non-detached children keep reuse.

<details><summary>Notes</summary>

- Behavior narrowing: before this PR, Linux allowed reuse of an existing terminal after a detached child exited (macOS did not, the pty was revoked). Now both platforms reject it: `terminal's pty was closed after a previous child exited and cannot be reused`. No in-tree code relied on post-detached reuse.
- The reuse validation now checks slave-fd validity before `INLINE_SPAWNED`, so a torn-down user-created terminal is not reported as inline-created.
- Mixed concurrent children: if a non-detached sibling is still attached when the detached child exits, the sibling's slave fds keep the master alive. Output keeps flowing and `exit` fires when the sibling exits (the true end of the stream). macOS is harsher there: the kernel revoke cuts the sibling off at the detached child's exit.
- The EIO normalization also applies to inline terminals, which previously reported status 1 on Linux and 0 on macOS for the same clean teardown. No test pinned the old value.
- The issue's secondary finding (output delivered between `child.exited` and `close()` can race) is addressed for detached children by the synchronous drain in the teardown. For non-detached children of an existing terminal, #35851 covers the drain.
- Repro (issue script, rev3): 0/5 spontaneous before, 5/5 after, callback status `{code: 0, signal: null}`, latency matches the macOS shape (fires before the `proc.exited` continuation resumes).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/terminal/terminal-platform-gaps.test.ts

<!-- robobun:evidence:end -->