### PR TITLE
uws: end the 101 of an upgrade without the HTTP close gate

### DIFF
--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -110,12 +110,23 @@ public:
         return false;
     }
 
+    /* Ends the 101 of upgrade(): terminates the header section and marks the
+     * response done. Not internalEnd(), because the socket leaves HTTP right
+     * after: the connection close gate does not apply (Connection: close,
+     * HTTP/1.0 and close-when-idle describe the HTTP connection, not the
+     * WebSocket that takes over the socket), and the cork stays so the
+     * handshake batches with the first frames written from open(). */
+    void endUpgradeHandshake() {
+        HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
+        writeMark();
+        Super::write("\r\n", 2);
+        httpResponseData->state |= HttpResponseData<SSL>::HTTP_END_CALLED;
+        httpResponseData->markDone(this);
+    }
+
     /* Returns true on success, indicating that it might be feasible to write more data.
-     * Will start timeout if stream reaches totalSize or write failure.
-     * keepCorked: if true, skip the trailing uncork so the caller can batch
-     * more writes (used by upgrade() to batch the handshake with the first
-     * WebSocket frames). */
-    bool internalEnd(std::string_view data, uint64_t totalSize, bool optional, bool allowContentLength = true, bool closeConnection = false, bool keepCorked = false) {
+     * Will start timeout if stream reaches totalSize or write failure. */
+    bool internalEnd(std::string_view data, uint64_t totalSize, bool optional, bool allowContentLength = true, bool closeConnection = false) {
         /* Write status if not already done */
         writeStatus(HTTP_200_OK);
 
@@ -206,7 +217,7 @@ public:
                 if (closeIfDoneAndMarked(httpResponseData)) {
                     return true;
                 }
-            } else if (!keepCorked) {
+            } else {
                 this->uncork();
                 /* That uncork released our cork slot, so the cork() wrapper's
                  * post-uncork close gate will not run. When THIS socket is the
@@ -280,7 +291,7 @@ public:
                 /* We need to check if we should close this socket here now */
                 if (!Super::isCorked()) {
                     closeIfDoneAndMarked(httpResponseData);
-                }  else if (!keepCorked) {
+                } else {
                     this->uncork();
                     /* Same as the chunked arm above: the cork slot is gone, so
                      * run the close gate here unless THIS socket is the one
@@ -367,9 +378,7 @@ public:
             }
         }
 
-        /* keepCorked so the handshake stays buffered and can batch with the
-         * first WebSocket frames written in the open handler. */
-        internalEnd({nullptr, 0}, 0, false, false, false, true);
+        endUpgradeHandshake();
 
         /* Grab the httpContext from res */
         HttpContext<SSL> *httpContext = HttpContext<SSL>::fromSocket((struct us_socket_t *) this);

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -2231,6 +2231,160 @@ describe("server.upgrade() validates the opening handshake", () => {
   });
 });
 
+// The 101 switches protocols: the connection stops being HTTP, so the HTTP
+// layer's "close after this response" (the request said Connection: close or
+// was HTTP/1.0, or a graceful server.stop() marked the connection to close
+// once idle) does not apply to the WebSocket that takes over the socket. A
+// synchronous server.upgrade() always behaved that way. One made after an
+// await used to send the 101 and shut the socket down right under the new
+// WebSocket: open() ran on a dead socket, close() never ran, and the
+// ServerWebSocket leaked.
+describe.concurrent("server.upgrade() after an await on a connection the HTTP layer marked to close", () => {
+  const K = "dGhlIHNhbXBsZSBub25jZQ==";
+
+  function maskedFrame(opcode: number, payload: Buffer): Buffer {
+    const mask = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+    const masked = Buffer.from(payload.map((byte, i) => byte ^ mask[i % 4]));
+    return Buffer.concat([Buffer.from([0x80 | opcode, 0x80 | payload.length]), mask, masked]);
+  }
+
+  // Server frames are unmasked; every frame in this test has a short payload.
+  function parseServerFrames(buf: Buffer): { frames: { opcode: number; payload: Buffer }[]; rest: Buffer } {
+    const frames: { opcode: number; payload: Buffer }[] = [];
+    let offset = 0;
+    while (buf.length - offset >= 2) {
+      const opcode = buf[offset] & 0x0f;
+      const length = buf[offset + 1] & 0x7f;
+      if (length >= 126 || buf[offset + 1] & 0x80) throw new Error(`unexpected server frame header ${buf[offset + 1]}`);
+      if (buf.length - offset - 2 < length) break;
+      frames.push({ opcode, payload: buf.subarray(offset + 2, offset + 2 + length) });
+      offset += 2 + length;
+    }
+    return { frames, rest: buf.subarray(offset) };
+  }
+
+  async function upgradeAfterAwait(opts: {
+    requestLine: string;
+    headers: string[];
+    beforeUpgrade?: (server: Server) => void;
+    sync?: boolean;
+  }) {
+    const events: string[] = [];
+    const serverClosed = Promise.withResolvers<void>();
+    let upgradeResult: boolean | undefined;
+    using server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      async fetch(req, srv) {
+        // Leave the parser's stack, where the socket is corked.
+        if (!opts.sync) await new Promise(resolve => setImmediate(resolve));
+        opts.beforeUpgrade?.(srv);
+        upgradeResult = srv.upgrade(req);
+        if (upgradeResult) return;
+        return new Response("no", { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          events.push("open");
+          ws.send("from open()");
+        },
+        message(ws, message) {
+          events.push(`message:${message}`);
+          ws.send(`echo:${message}`);
+        },
+        close(ws, code) {
+          events.push(`close:${code}`);
+          serverClosed.resolve();
+        },
+      },
+    });
+
+    const socket = net.connect({ port: server.port, host: "127.0.0.1" });
+    const socketClosed = Promise.withResolvers<never>();
+    // Only observed through the races in `until` below.
+    socketClosed.promise.catch(() => {});
+    socket.on("error", error => socketClosed.reject(error));
+    socket.on("close", () => socketClosed.reject(new Error("the server closed the socket")));
+
+    let buffered = Buffer.alloc(0);
+    let onData = () => {};
+    socket.on("data", (chunk: Buffer) => {
+      buffered = Buffer.concat([buffered, chunk]);
+      onData();
+    });
+    // Rejects if the server closes the socket before the condition holds.
+    const until = <T>(condition: () => T | undefined) =>
+      Promise.race([
+        socketClosed.promise,
+        new Promise<T>(resolve => {
+          onData = () => {
+            const value = condition();
+            if (value !== undefined) resolve(value);
+          };
+          onData();
+        }),
+      ]);
+    const nextFrame = () =>
+      until(() => {
+        const { frames, rest } = parseServerFrames(buffered);
+        if (frames.length === 0) return undefined;
+        buffered = rest;
+        return frames[0];
+      });
+
+    await new Promise<void>(resolve => socket.once("connect", resolve));
+    socket.write(`${opts.requestLine}\r\nHost: 127.0.0.1\r\n${opts.headers.join("\r\n")}\r\n\r\n`);
+
+    const head = await until(() => {
+      const end = buffered.indexOf("\r\n\r\n");
+      if (end === -1) return undefined;
+      const head = buffered.subarray(0, end).toString();
+      buffered = buffered.subarray(end + 4);
+      return head;
+    });
+    expect(head.split("\r\n")[0]).toBe("HTTP/1.1 101 Switching Protocols");
+    expect(upgradeResult).toBe(true);
+
+    // The socket is a live WebSocket in both directions.
+    expect(await nextFrame()).toEqual({ opcode: 1, payload: Buffer.from("from open()") });
+    socket.write(maskedFrame(1, Buffer.from("hi")));
+    expect(await nextFrame()).toEqual({ opcode: 1, payload: Buffer.from("echo:hi") });
+
+    // A clean close reaches close() with the client's code.
+    socket.write(maskedFrame(8, Buffer.from([0x03, 0xe8])));
+    expect(await nextFrame()).toEqual({ opcode: 8, payload: Buffer.from([0x03, 0xe8]) });
+    socket.end();
+    await serverClosed.promise;
+    expect(events).toEqual(["open", "message:hi", "close:1000"]);
+  }
+
+  const handshake = [`Upgrade: websocket`, `Sec-WebSocket-Key: ${K}`, `Sec-WebSocket-Version: 13`];
+
+  it("Connection: close", async () => {
+    await upgradeAfterAwait({ requestLine: "GET / HTTP/1.1", headers: [...handshake, "Connection: close"] });
+  });
+
+  it("HTTP/1.0", async () => {
+    await upgradeAfterAwait({ requestLine: "GET / HTTP/1.0", headers: [...handshake, "Connection: Upgrade"] });
+  });
+
+  it("a graceful server.stop() during the await", async () => {
+    await upgradeAfterAwait({
+      requestLine: "GET / HTTP/1.1",
+      headers: [...handshake, "Connection: Upgrade"],
+      beforeUpgrade: srv => srv.stop(),
+    });
+  });
+
+  it("the synchronous path (Connection: close) is unchanged", async () => {
+    await upgradeAfterAwait({
+      requestLine: "GET / HTTP/1.1",
+      headers: [...handshake, "Connection: close"],
+      sync: true,
+    });
+  });
+});
+
 // server.upgrade() runs open() before it returns, and ws.close() runs close()
 // before it returns. A request handler (or a request's abort listener) that
 // calls one of them must still run to completion first: the nextTick and

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -1157,9 +1157,10 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
     key = "dGhlIHNhbXBsZSBub25jZQ==",
     version = "13",
     body = "",
-  }: { path?: string; key?: string; version?: string; body?: string } = {}) {
+    httpVersion = "1.1",
+  }: { path?: string; key?: string; version?: string; body?: string; httpVersion?: string } = {}) {
     return [
-      `GET ${path} HTTP/1.1`,
+      `GET ${path} HTTP/${httpVersion}`,
       "Host: localhost",
       "Connection: Upgrade",
       "Upgrade: websocket",
@@ -1239,6 +1240,36 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
     expect(connections).toHaveLength(1);
     expect(wss.clients.size).toBe(1);
     expect(await upgrade.received("\r\n\r\n")).toStartWith("HTTP/1.1 101 Switching Protocols\r\n");
+  });
+
+  // An HTTP/1.0 request has no keep-alive, but the 101 switches protocols: the
+  // close after the response ends with the HTTP exchange, not with the
+  // WebSocket that takes over the socket. From a later task the socket is
+  // outside the parser's corked write, and the HTTP layer used to shut it down
+  // right after the 101, under the new WebSocket (a use-after-free of the
+  // socket once the 'close' reached JS).
+  it("upgrades a live HTTP/1.0 socket from a later task", async () => {
+    await using upgrade = await receiveUpgrade(upgradeRequest({ httpVersion: "1.0" }));
+    const { req, socket, head, client } = upgrade;
+    const wss = new WebSocketServer({ noServer: true });
+    const closed = Promise.withResolvers<number>();
+    const clientClosed = new Promise<string>(resolve => client.once("close", () => resolve("client closed")));
+
+    await new Promise(resolve => setImmediate(resolve));
+    wss.handleUpgrade(req, socket, head, ws => {
+      ws.on("close", code => closed.resolve(code));
+      ws.send("from handleUpgrade");
+    });
+    expect(wss.clients.size).toBe(1);
+
+    // The 101, then the text frame sent from the callback (FIN + text, 18 bytes).
+    const received = await upgrade.received("from handleUpgrade");
+    expect(received).toStartWith("HTTP/1.1 101 Switching Protocols\r\n");
+    expect(received).toEndWith("\r\n\r\n\x81\x12from handleUpgrade");
+
+    // A masked Close(1000) from the client reaches the server's close handler.
+    client.write(Buffer.from([0x88, 0x82, 0x00, 0x00, 0x00, 0x00, 0x03, 0xe8]));
+    expect(await Promise.race([closed.promise, clientClosed])).toBe(1000);
   });
 
   it("returns without calling back when the socket was destroyed before handleUpgrade()", async () => {


### PR DESCRIPTION
### Problem
- `server.upgrade()` after an `await` on a `Connection: close` or HTTP/1.0 request sends the 101, then closes the socket: `open()` runs on a dead socket, `close()` never runs, the `ServerWebSocket` leaks. Same after a graceful `server.stop()` during the `await`.
- node:http (`ws` `handleUpgrade()` from a later task, HTTP/1.0): `AddressSanitizer: heap-use-after-free ... in us_socket_is_closed`.
- Cause: `HttpResponse::upgrade()` ended the 101 through `internalEnd()`, which, uncorked, runs the close gate, then built the WebSocket over the closed socket.

### Fix
- `upgrade()` ends the 101 with a new `endUpgradeHandshake()` (`HttpResponse.h:119`): headers terminated, response marked done, no close gate, no uncork. `internalEnd()` loses its `keepCorked` parameter, which only `upgrade()` set.
- Correct because the 101 switches protocols: `Connection: close`, HTTP/1.0 and close-when-idle describe the HTTP connection, which ends here, not the WebSocket that takes over the socket. The synchronous path and node's `ws` already do.
- #37447 edits the same hunk and asserts the opposite outcome. This lands first, then #37447 drops its post-`internalEnd` re-check and two `Connection: close` tests (Notes).
- Verified: `test/js/bun/websocket/websocket-server.test.ts` (4 new, 3 fail on main), `test/js/first_party/ws/ws.test.ts` (1 new, use-after-free on main), plus neighbouring suites (Notes).

### Background
- `HttpContext::onData` corks the socket while it parses. A synchronous `server.upgrade()` writes into it. After an `await`, writes reach the kernel at once.
- The close gate (`closeIfDoneAndMarked`) shuts an HTTP connection down once the response is complete and flushed and `shouldCloseConnection()` holds: `Connection: close`, HTTP/1.0 (`HttpContext.h:431`) or `HTTP_CLOSE_WHEN_IDLE` (graceful `server.stop()`).
- `upgrade()` destructs `HttpResponseData` and adopts the socket into the WebSocket context, which then owns it.

<details><summary>Notes</summary>

Repro against the released bun (1.4.0): a raw client sends `GET / HTTP/1.1` with `Upgrade: websocket`, `Connection: close` and a valid key to a server whose `fetch()` awaits `setImmediate` before `server.upgrade(req)`:

```
status line: HTTP/1.1 101 Switching Protocols
outcome: socket closed by the server
events: ["ws open", "upgrade returned true"]      // never "ws close"
```

`GET / HTTP/1.0` with `Connection: Upgrade` gives the same. With `Connection: Upgrade` and HTTP/1.1 the frame sent from `open()` arrives.

Why the gate fired only here: `internalEnd()` marks the response done and, uncorked, runs `closeIfDoneAndMarked()`. The status line and headers had already reached the kernel, so `hasFullyDrained()` was true. Corked (the synchronous path) the branch is skipped, and `onData` returns through its `upgradedWebSocket` arm, which has no gate. The `Connection: close` and HTTP/1.0 arms are as old as uWS. `HTTP_CLOSE_WHEN_IDLE` arrived in 1.4.0 with #37074, so an upgrade that completes after a graceful `server.stop()` worked in 1.3.x.

What happened after the close on main: `us_socket_adopt()` returns a closed socket unchanged, so `upgrade()` read the destructed `HttpResponseData`, placed `WebSocketData` over the closed socket's ext, and ran `open()`. The WebSocket never gets a close event because the HTTP context's `onClose` already ran, so the `ServerWebSocket`'s strong self-ref is never downgraded.

`endUpgradeHandshake()` does what `internalEnd({nullptr, 0}, 0, false, false, false, true)` did for the 101 (`writeStatus` was a no-op, the status was written, and the body is empty) minus the gate and the HTTP `resetTimeout()`, which `upgrade()` replaces with the WebSocket timeouts a few lines later. The 101 bytes on the wire are unchanged, Date header included.

#37447 (open): it makes `us_socket_adopt()` return NULL for a closed or shut down socket, adds an up-front closed/shut-down check to `upgrade()`, re-checks after `internalEnd()` and returns `nullptr` when the gate closed the socket, and makes the Rust callers free the `ServerWebSocket` on `nullptr`. Its tests "returns false for an async upgrade of a connection marked Connection: close" and "releases the ServerWebSocket of a refused upgrade" assert `upgradeResult: false` for the bytes this PR's tests assert `true` for, with the client left holding a 101. With this PR the gate never runs during `upgrade()`, so the post-`internalEnd` re-check has nothing to catch. The up-front check, the NULL return and the caller handling stay useful for a socket that is already closed or shut down when `upgrade()` runs (a possible peer-FIN path on node:http), so the order is: this PR, then #37447 rebased without the re-check and the two tests.

Graceful stop: #34961 (open) rewrites several existing tests to hold the upgrade in `fetch()` until after `server.stop()` and states that an in-flight request may still upgrade after a graceful stop. That is the async path this PR fixes, so the "graceful server.stop() during the await" case pins the behavior #34961 relies on.

node:http: a request with `Connection: close` and no `Upgrade` token is a normal request (no `'upgrade'` event, same as node). `Connection: close, Upgrade` does not set the close flag (uWS flags a `Connection` value of exactly 5 bytes), so HTTP/1.0 is the only node:http handshake that reached the gate. That one crashed the unfixed debug build under ASAN.

Out of scope, left as they are: whether `server.upgrade()` should refuse an HTTP/1.0 or `Connection: close` handshake (RFC 6455 4.2.1). The synchronous path accepts both today, and #35870 (open) proposes the `Connection: Upgrade` token check. If that lands first, the two `Connection: close` cases in `websocket-server.test.ts` need a rejected-handshake expectation instead. The HTTP/1.0 and graceful-stop cases are unaffected.

A peer FIN before the upgrade: Bun.serve closes the socket at once (`HttpContext::onEnd`), so `server.upgrade()` returns `false` through `is_aborted_or_ended()`. node:http marks the socket unreadable and `ws`'s `completeUpgrade()` destroys it before the native upgrade (#39642).

Local failures unrelated to this change: the `ServerWebSocket > send()` neighbours of the 30 s benchmark time out when the whole file runs concurrently on the debug build (they pass alone), and `bun-server.test.ts` has 4 tests that need `localhost`, IPv6 or outbound network in this container.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->