### PR TITLE
server: fix Server.url for Windows Unix socket paths

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -525,9 +525,19 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                         port: None,
                     }
                 } else {
+                    #[cfg(windows)]
+                    let hostname = {
+                        // On Windows, convert backslashes to forward slashes for valid URL format
+                        // Also handle drive letters like C:\test -> C:/test
+                        let path = std::str::from_utf8(unix).unwrap_or("");
+                        let converted = path.replace('\\', "/");
+                        converted.into_bytes()
+                    };
+                    #[cfg(not(windows))]
+                    let hostname = unix.to_vec();
                     URLFormatter {
                         proto: URLProto::Unix,
-                        hostname: Some(unix),
+                        hostname: Some(&hostname),
                         port: None,
                     }
                 }


### PR DESCRIPTION
Fixes #40182

## Summary
When using Bun.serve with unix path on Windows, the server.url property returned an invalid URL because Windows paths contain backslashes and colons.

## Changes
- Modified get_url_as_string() in src/runtime/server/mod.rs to convert backslashes to forward slashes on Windows for Unix socket paths.
- This produces valid URLs like unix://C:/test instead of unix://C:\test.

## Testing
- This change is Windows-specific (guarded by cfg(windows))
- Existing tests on Linux/macOS should be unaffected