### PR TITLE
bundler: narrow the generated source index once with Index::init

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -1,8 +1,5 @@
-[bun_ast]
-
 [bun_bundler]
-"defaulted_failure:src/bundler/bundle_v2.rs" = 2
-"narrowed_two_ways:src/bundler/bundle_v2.rs" = 1
+"defaulted_failure:src/bundler/bundle_v2.rs" = 1
 
 [bun_core]
 "defaulted_failure:src/bun_core/string/immutable.rs" = 1
@@ -43,8 +40,6 @@
 "unchecked_construction:src/runtime/cli/pack_command.rs" = 2
 "unchecked_construction:src/runtime/server/HTMLBundle.rs" = 2
 "unchecked_construction:src/runtime/server/server_body.rs" = 5
-
-[bun_sql_jsc]
 
 [bun_sys]
 "error_collapsed_to_bool:src/sys/lib.rs" = 4

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3722,8 +3722,8 @@ pub mod bv2_impl {
             source_without_index: bun_ast::Source,
         ) -> Result<IndexInt, AllocError> {
             let mut new_source = source_without_index;
-            let source_index = self.graph.input_files.len();
-            new_source.index = bun_ast::Index(source_index as u32);
+            let source_index = Index::init(self.graph.input_files.len());
+            new_source.index = source_index;
             // `bun_ast::Source: !Clone` — manually dup the (all-Clone) fields.
             let task_source = bun_ast::Source {
                 path: new_source.path,
@@ -3768,7 +3768,7 @@ pub mod bv2_impl {
                     core::ptr::addr_of_mut!((*task).task)
                 }));
 
-            Ok(u32::try_from(source_index).expect("int cast"))
+            Ok(source_index.get())
         }
     }
 


### PR DESCRIPTION
### Problem
- `enqueue_server_component_generated_file` (`src/bundler/bundle_v2.rs:3725`) narrows the new source index twice. It writes `source_index as u32` into the `Source`, and it returns `u32::try_from(source_index).expect("int cast")` for the same value. The `as` cast wraps silently, the `try_from` panics. Two readers of one place disagree on what an out-of-range index means.
- This is the `narrowed_two_ways` finding mordant reports for `bundle_v2.rs`. The baseline line `"narrowed_two_ways:src/bundler/bundle_v2.rs" = 1` accepted it.

### Fix
- Narrow once: `let source_index = Index::init(self.graph.input_files.len())`. `Index::init` is the checked `TryInto` constructor the rest of the file already uses for source indexes. The `Source` and the return value both read that one `Index`.
- Remove the `narrowed_two_ways` baseline line.
- Also correct two stale baseline facts found with `MORDANT_BASELINE_WRITE=1 bun run rust:mordant` on current main at the pinned rev: `defaulted_failure:src/bundler/bundle_v2.rs` reports 1 site, not 2, and the empty `[bun_ast]` and `[bun_sql_jsc]` sections are not emitted by the writer.
- Verified: `cargo dylint --all -p bun_bundler` is clean against the edited baseline. `bun bd test test/bake/dev/bundle.test.ts -t "use client"` passes (the only caller is the "use client" reference proxy path).

### Background
- `bun_ast::Index` is the `u32` newtype for a source index. `Index::init(n)` converts with `TryInto` and panics on overflow. `Index::source(n)` truncates. `Index(n)` is the raw constructor.
- mordant is the dylint lint pack CI runs through `bun run rust:mordant`. `mordant-baseline.toml` records, per lint and file, how many findings are accepted. CI fails only when a count goes over.
- `narrowed_two_ways` flags an integer place that one site cuts down with `as` and another converts with `try_from`. The range check then lives in whichever reader remembered it.
