### PR TITLE
jsc: implement CoerceTo for JSValue and drop the two get_optional_value shims

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -34,7 +34,6 @@
 "error_collapsed_to_bool:src/runtime/api/bun/h2_frame_parser.rs" = 32
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
-"reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
 "reimplemented_helper:src/runtime/hw_exports.rs" = 1
 "same_match_twice:src/runtime/cli/pack_command.rs" = 1
 "same_match_twice:src/runtime/cli/update_interactive_command.rs" = 2

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1888,6 +1888,13 @@ impl PutKey for &str {
 pub trait CoerceTo: Sized {
     fn coerce_from(v: JSValue, global: &JSGlobalObject) -> JsResult<Self>;
 }
+/// The value itself. `get_optional::<JSValue>` is then the undefined/null
+/// filtering read without a coercion.
+impl CoerceTo for JSValue {
+    fn coerce_from(v: JSValue, _global: &JSGlobalObject) -> JsResult<JSValue> {
+        Ok(v)
+    }
+}
 impl CoerceTo for i32 {
     fn coerce_from(v: JSValue, global: &JSGlobalObject) -> JsResult<i32> {
         // Fast-path numbers via

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -224,30 +224,6 @@ impl Default for Options {
     }
 }
 
-// Local extension shims for typed optional property reads. Typed
-// `getOptional` is not yet a single inherent generic on `bun_jsc::JSValue`;
-// these wrap `get` + the per-type coercion. `withAsyncContextIfNeeded` is the
-// inherent `JSValue::with_async_context_if_needed` in `bun_jsc` — call sites
-// resolve to that directly, no shim here.
-trait JSValueTerminalExt {
-    fn get_optional_i32(self, global: &JSGlobalObject, name: &[u8]) -> JsResult<Option<i32>>;
-    fn get_optional_value(self, global: &JSGlobalObject, name: &[u8]) -> JsResult<Option<JSValue>>;
-}
-impl JSValueTerminalExt for JSValue {
-    fn get_optional_i32(self, global: &JSGlobalObject, name: &[u8]) -> JsResult<Option<i32>> {
-        match self.get(global, name)? {
-            Some(v) if !v.is_undefined_or_null() => Ok(Some(v.coerce::<i32>(global)?)),
-            _ => Ok(None),
-        }
-    }
-    fn get_optional_value(self, global: &JSGlobalObject, name: &[u8]) -> JsResult<Option<JSValue>> {
-        match self.get(global, name)? {
-            Some(v) if !v.is_undefined_or_null() => Ok(Some(v)),
-            _ => Ok(None),
-        }
-    }
-}
-
 impl Options {
     /// Maximum length for terminal name (e.g., "xterm-256color")
     /// Longest known terminfo names are ~23 chars; 128 allows for custom terminals
@@ -261,13 +237,13 @@ impl Options {
         let mut options = Options::default();
         // errdefer options.deinit() — handled by Drop on early return.
 
-        if let Some(n) = js_options.get_optional_i32(global_object, b"cols")? {
+        if let Some(n) = js_options.get_optional::<i32>(global_object, b"cols")? {
             if n > 0 && n <= 65535 {
                 options.cols = u16::try_from(n).expect("int cast");
             }
         }
 
-        if let Some(n) = js_options.get_optional_i32(global_object, b"rows")? {
+        if let Some(n) = js_options.get_optional::<i32>(global_object, b"rows")? {
             if n > 0 && n <= 65535 {
                 options.rows = u16::try_from(n).expect("int cast");
             }
@@ -284,19 +260,19 @@ impl Options {
             options.term_name = slice;
         }
 
-        if let Some(v) = js_options.get_optional_value(global_object, b"data")? {
+        if let Some(v) = js_options.get_optional::<JSValue>(global_object, b"data")? {
             if v.is_cell() && v.is_callable() {
                 options.data_callback = Some(v.with_async_context_if_needed(global_object));
             }
         }
 
-        if let Some(v) = js_options.get_optional_value(global_object, b"exit")? {
+        if let Some(v) = js_options.get_optional::<JSValue>(global_object, b"exit")? {
             if v.is_cell() && v.is_callable() {
                 options.exit_callback = Some(v.with_async_context_if_needed(global_object));
             }
         }
 
-        if let Some(v) = js_options.get_optional_value(global_object, b"drain")? {
+        if let Some(v) = js_options.get_optional::<JSValue>(global_object, b"drain")? {
             if v.is_cell() && v.is_callable() {
                 options.drain_callback = Some(v.with_async_context_if_needed(global_object));
             }

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -68,18 +68,6 @@ fn get_boolean_loose(
     }
 }
 
-/// `JSValue.getOptional(JSValue, ..)` — local shim: filters undefined/null.
-fn get_optional_value(
-    target: JSValue,
-    global: &JSGlobalObject,
-    property: &[u8],
-) -> JsResult<Option<JSValue>> {
-    match target.get(global, property)? {
-        Some(v) if !v.is_undefined_or_null() => Ok(Some(v)),
-        _ => Ok(None),
-    }
-}
-
 /// `JSValue.getFunction` — local shim until `bun_jsc` grows it.
 fn get_function(
     target: JSValue,
@@ -204,14 +192,14 @@ impl UserOptions {
             );
         }
 
-        if let Some(js_options) = get_optional_value(config, global, b"bundlerOptions")? {
-            if let Some(server_options) = get_optional_value(js_options, global, b"server")? {
+        if let Some(js_options) = config.get_optional::<JSValue>(global, b"bundlerOptions")? {
+            if let Some(server_options) = js_options.get_optional::<JSValue>(global, b"server")? {
                 bundler_options.server = BuildConfigSubset::from_js(global, server_options)?;
             }
-            if let Some(client_options) = get_optional_value(js_options, global, b"client")? {
+            if let Some(client_options) = js_options.get_optional::<JSValue>(global, b"client")? {
                 bundler_options.client = BuildConfigSubset::from_js(global, client_options)?;
             }
-            if let Some(ssr_options) = get_optional_value(js_options, global, b"ssr")? {
+            if let Some(ssr_options) = js_options.get_optional::<JSValue>(global, b"ssr")? {
                 bundler_options.ssr = BuildConfigSubset::from_js(global, ssr_options)?;
             }
         }
@@ -409,7 +397,7 @@ impl BuildConfigSubset {
         let mut options = BuildConfigSubset::default();
 
         'brk: {
-            let Some(val) = get_optional_value(js_options, global, b"sourcemap")? else {
+            let Some(val) = js_options.get_optional::<JSValue>(global, b"sourcemap")? else {
                 break 'brk;
             };
             if let Some(sourcemap) = source_map_mode_from_js(global, val)? {
@@ -426,7 +414,8 @@ impl BuildConfigSubset {
         }
 
         'brk: {
-            let Some(minify_options) = get_optional_value(js_options, global, b"minify")? else {
+            let Some(minify_options) = js_options.get_optional::<JSValue>(global, b"minify")?
+            else {
                 break 'brk;
             };
             if minify_options.is_boolean() && minify_options.as_boolean() {
@@ -836,7 +825,7 @@ impl Framework {
             Some(ServerComponents {
                 separate_ssr_graph: 'brk: {
                     // Intentionally not using a truthiness check
-                    let prop = match get_optional_value(sc, global, b"separateSSRGraph")? {
+                    let prop = match sc.get_optional::<JSValue>(global, b"separateSSRGraph")? {
                         Some(p) => p,
                         None => {
                             return Err(global.throw_invalid_arguments(format_args!(
@@ -1093,7 +1082,7 @@ impl Framework {
             built_in_modules,
         };
 
-        if let Some(plugin_array) = get_optional_value(opts, global, b"plugins")? {
+        if let Some(plugin_array) = opts.get_optional::<JSValue>(global, b"plugins")? {
             bundler_options.parse_plugin_array(plugin_array, global)?;
         }
 


### PR DESCRIPTION
### Problem
- `Bun.Terminal` option parsing (`src/runtime/api/bun/Terminal.rs`) and the bake config parser (`src/runtime/bake/bake_body.rs`) each carry a private `get_optional_value` shim. Both read a property and map `undefined` or `null` to `None`. Their bodies are identical. mordant reports this as `reimplemented_helper` for `Terminal.rs`, accepted by the baseline line `"reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1`.
- `bun_jsc` already has this read as `JSValue::get_optional::<T>`. It only lacked a `CoerceTo` impl that hands the value back unchanged, so the two crates could not call it for a plain `JSValue`. The Terminal shim also duplicated `get_optional::<i32>` as `get_optional_i32`.

### Fix
- Add `impl CoerceTo for JSValue` in `src/jsc/JSValue.rs`. `coerce_from` returns the value. `get_optional::<JSValue>` is then the same read the shims did: `get`, then `None` for `undefined` or `null`.
- Delete the `JSValueTerminalExt` trait in `Terminal.rs` and the `get_optional_value` function in `bake_body.rs`. The 13 call sites use `get_optional::<JSValue>` or `get_optional::<i32>`.
- Behavior is unchanged. `JSValue::get_optional` has the same two steps as the shims: `get` returns `None` for a missing property and for `undefined`, then `is_undefined_or_null` filters `null`, then `coerce`. For `i32` the Terminal shim called the same `coerce::<i32>`.
- Verified: `cargo dylint --all -p bun_runtime` is clean against the edited baseline. `bun bd test test/js/bun/terminal/terminal.test.ts` and `bun bd test test/bake/dev/bundle.test.ts` pass.

### Background
- `JSValue::get(global, name)` returns `Ok(None)` when the property is missing or `undefined`, `Ok(Some(v))` otherwise, and `Err` when the getter throws.
- `CoerceTo` is the dispatch trait behind `JSValue::coerce::<T>()`. `i32` and `i64` implement it with ToNumber style conversions. `get_optional::<T>` composes `get`, the `null` filter, and `coerce::<T>`.
- mordant is the dylint lint pack CI runs through `bun run rust:mordant`. `mordant-baseline.toml` records, per lint and file, how many findings are accepted. `reimplemented_helper` flags two functions in one crate with the same signature and body.
