### PR TITLE
install: derive the root tree dependency id from the dependency sentinel

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -12,7 +12,6 @@
 
 [bun_install]
 "defaulted_failure:src/install/npm.rs" = 1
-"interchangeable_aliases:src/install/lockfile/Tree.rs" = 1
 
 [bun_js_printer]
 "parallel_vecs:src/js_printer/lib.rs" = 1

--- a/src/install/lockfile/Buffers.rs
+++ b/src/install/lockfile/Buffers.rs
@@ -13,7 +13,10 @@ use super::{
 };
 use crate::lockfile_real as lockfile;
 use crate::package_manager_real::package_manager_options::Options as PackageManagerOptions;
-use crate::{Aligner, DependencyID, PackageID, PackageManager, dependency, invalid_package_id};
+use crate::{
+    Aligner, DependencyID, PackageID, PackageManager, dependency, invalid_dependency_id,
+    invalid_package_id,
+};
 
 #[derive(Default)]
 pub struct Buffers {
@@ -370,7 +373,7 @@ impl Buffers {
     ) -> crate::Result<DependencyID> {
         match package_id {
             0 => return Ok(tree::ROOT_DEP_ID),
-            id if id == invalid_package_id => return Ok(invalid_package_id),
+            id if id == invalid_package_id => return Ok(invalid_dependency_id),
             _ => {
                 // `dependency_visited` is captured once outside the loop
                 // instead of re-matched per iteration (borrowck).

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -52,14 +52,14 @@ impl Default for Tree {
 pub type Id = u32;
 
 const EXTERNAL_SIZE: usize = core::mem::size_of::<Id>()
-    + core::mem::size_of::<PackageID>()
+    + core::mem::size_of::<DependencyID>()
     + core::mem::size_of::<Id>()
     + core::mem::size_of::<DependencyIDSlice>();
 
 pub(crate) type External = [u8; EXTERNAL_SIZE];
 pub type List = Vec<Tree>;
 
-pub(crate) const ROOT_DEP_ID: DependencyID = invalid_package_id - 1;
+pub(crate) const ROOT_DEP_ID: DependencyID = invalid_dependency_id - 1;
 pub(crate) const INVALID_ID: Id = Id::MAX;
 
 impl Tree {


### PR DESCRIPTION
### Problem
- `src/install/lockfile/Tree.rs:62` defines `ROOT_DEP_ID: DependencyID = invalid_package_id - 1`. The value is a dependency id, but it is derived from the package id sentinel. `PackageID` and `DependencyID` are both `u32` aliases, so the mix-up compiles. mordant reports it as `interchangeable_aliases`, accepted by the baseline line `"interchangeable_aliases:src/install/lockfile/Tree.rs" = 1`.
- The same mix-up appears twice more next to it. `legacy_package_to_dependency_id` (`src/install/lockfile/Buffers.rs:373`) returns `invalid_package_id` from a `Result<DependencyID>`. `EXTERNAL_SIZE` in `Tree.rs` sizes the `dependency_id` column of the on-disk tree record with `size_of::<PackageID>()`.

### Fix
- Write `ROOT_DEP_ID` as `invalid_dependency_id - 1`, return `invalid_dependency_id` from `legacy_package_to_dependency_id`, and size the column with `size_of::<DependencyID>()`.
- No value changes. `INVALID_PACKAGE_ID` and `INVALID_DEPENDENCY_ID` are both `u32::MAX` (`src/install_types/resolver_hooks.rs:32`), so `ROOT_DEP_ID` stays `u32::MAX - 1` and the binary lockfile layout is the same. Each id is now derived from the sentinel of its own kind.
- Remove the baseline line.
- Verified: `cargo dylint --all -p bun_install` is clean against the edited baseline. `bun bd test` passes for `test/cli/install/bun-lock.test.ts`, `bun-lockb.test.ts`, `migrate-bun-lockb-v2.test.ts` and `hoist.test.ts`.

### Background
- The lockfile stores the `node_modules` layout as a list of `Tree` nodes. Each node records the `DependencyID` it was placed for. The root node uses the reserved `ROOT_DEP_ID`, which no real dependency can have. Old `bun.lockb` files stored package ids in that column, and `legacy_package_to_dependency_id` converts them on load.
- `PackageID` and `DependencyID` are both indexes into lockfile tables, but into different tables (packages and dependencies). A package sentinel used as a dependency id is only correct because the two sentinels happen to share a value.
- mordant is the dylint lint pack CI runs through `bun run rust:mordant`. `mordant-baseline.toml` records, per lint and file, how many findings are accepted. `interchangeable_aliases` flags a value declared under one integer alias that flows into a place declared under another.
