### PR TITLE
test(bake): speed up dev/bundle.test.ts and tighten its assertions

### DIFF
--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -1,13 +1,90 @@
 // Bundle tests are tests concerning bundling bugs that only occur in DevServer.
+// Independent cases share one dev server, with one route or page each.
 import { expect } from "bun:test";
-import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
+import { Dev, devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
-devTest("import identifier doesnt get renamed", {
+/**
+ * Expects the "Build Failed" page for `route`. Each of `errors` is matched
+ * against the failure payload the page embeds (base64 of the serialized failures).
+ */
+async function expectBuildFailedPage(dev: Dev, route: string, ...errors: string[]) {
+  const res = await dev.fetch(route);
+  const html = await res.text();
+  expect(html).toContain("<title>Bun - Build Failed</title>");
+  if (errors.length > 0) {
+    const encoded = html.match(/atob\("([^"]*)"\)/)?.[1];
+    expect(encoded).toBeString();
+    const payload = atob(encoded!);
+    for (const error of errors) {
+      expect(payload).toContain(error);
+    }
+  }
+  expect(res.status).toBe(500);
+}
+
+/** Fetches an HTML route and returns the client bundle its page links to. */
+async function servedClientBundle(dev: Dev, route: string): Promise<string> {
+  const page = await dev.fetch(route);
+  expect(page.status).toBe(200);
+  const scripts = [...(await page.text()).matchAll(/<script[^>]*\ssrc="([^"]+)"/g)].map(m => m[1]);
+  expect(scripts).toHaveLength(1);
+  const bundle = await dev.fetch(scripts[0]);
+  expect(bundle.status).toBe(200);
+  return bundle.text();
+}
+
+// The module table is the object literal the bundle calls the HMR runtime with,
+// followed by the config object. ESM entries print as
+// `"file": [imports, exports, stars, (hmr) => {...}, flag],` and CommonJS
+// entries as `"file"(hmr, module, exports) {...},`.
+const moduleTableStart = "})({\n";
+const moduleTableEnd = "\n}, {\n  main: ";
+const moduleTableEntry = /^ {2}"((?:[^"\\]|\\.)*)"(?:: \[|\()/gm;
+
+/** The module table of a client bundle, one entry per line group. */
+function moduleTable(bundle: string): string {
+  const end = bundle.lastIndexOf(moduleTableEnd);
+  expect(end, "module table not found in the served bundle").not.toBe(-1);
+  // In a release build the HMR runtime before the table is one minified line.
+  const start = bundle.lastIndexOf(moduleTableStart, end);
+  expect(start, "module table not found in the served bundle").not.toBe(-1);
+  return bundle.slice(start + moduleTableStart.length, end + 1);
+}
+
+/** Project-relative paths of the modules in a client bundle, sorted. */
+function servedModules(bundle: string): string[] {
+  return [...moduleTable(bundle).matchAll(moduleTableEntry)].map(m => m[1].replaceAll("\\\\", "/")).sort();
+}
+
+/** The module table entry printed for one file of a client bundle. */
+function servedModule(bundle: string, file: string): string {
+  const table = moduleTable(bundle);
+  const entries = [...table.matchAll(moduleTableEntry)];
+  const index = entries.findIndex(m => m[1].replaceAll("\\\\", "/") === file);
+  expect(index, `${file} is not in the served bundle`).not.toBe(-1);
+  const start = entries[index].index!;
+  const end = index + 1 < entries.length ? entries[index + 1].index! : table.length;
+  return table.slice(start, end).replace(/^ {2}/gm, "").trimEnd();
+}
+
+/** The files of the node_modules package `pkg` among `modules`, sorted. */
+function packageFiles(modules: string[], pkg: string): string[] {
+  const prefix = `node_modules/${pkg}/`;
+  return modules.filter(file => file.startsWith(prefix)).map(file => file.slice(prefix.length));
+}
+
+/** The files of the node_modules package `pkg` in the bundle currently served for `route`. */
+async function bundledPackageFiles(dev: Dev, route: string, pkg: string): Promise<string[]> {
+  return packageFiles(servedModules(await servedClientBundle(dev, route)), pkg);
+}
+
+devTest("server routes: import identifier is not renamed, import_<name> collision, development condition", {
   framework: minimalFramework,
   files: {
-    "db.ts": `export const abc = "123";`,
-    "routes/index.ts": `
-      import { abc } from '../db';
+    // Each route has its own copy of db.ts so that both generate an `import_db` binding.
+    "identifier/db.ts": `export const abc = "123";`,
+    "routes/identifier.ts": `
+      import { abc } from '../identifier/db';
       export default function (req, meta) {
         let v1 = "";
         const v2 = v1
@@ -16,25 +93,10 @@ devTest("import identifier doesnt get renamed", {
         return new Response('Hello, ' + v2 + '!');
       }
     `,
-  },
-  async test(dev) {
-    await dev.fetch("/").equals("Hello, 123!");
-    await dev.write("db.ts", `export const abc = "456";`);
-    await dev.fetch("/").equals("Hello, 456!");
-    await dev.patch("routes/index.ts", {
-      find: "Hello",
-      replace: "Bun",
-    });
-    await dev.fetch("/").equals("Bun, 456!");
-  },
-});
-devTest("symbol collision with import identifier", {
-  framework: minimalFramework,
-  files: {
-    "db.ts": `export const abc = "123";`,
-    "routes/index.ts": `
+    "collision/db.ts": `export const abc = "123";`,
+    "routes/collision.ts": `
       let import_db = 987;
-      import { abc } from '../db';
+      import { abc } from '../collision/db';
       export default function (req, meta) {
         let v1 = "";
         const v2 = v1
@@ -43,16 +105,6 @@ devTest("symbol collision with import identifier", {
         return new Response('Hello, ' + v2 + ', ' + import_db + '!');
       }
     `,
-  },
-  async test(dev) {
-    await dev.fetch("/").equals("Hello, 123, 987!");
-    await dev.write("db.ts", `export const abc = "456";`);
-    await dev.fetch("/").equals("Hello, 456, 987!");
-  },
-});
-devTest('uses "development" condition', {
-  framework: minimalFramework,
-  files: {
     "node_modules/example/package.json": JSON.stringify({
       name: "example",
       version: "1.0.0",
@@ -65,7 +117,7 @@ devTest('uses "development" condition', {
     }),
     "node_modules/example/development.js": `export default "development";`,
     "node_modules/example/production.js": `export default "production";`,
-    "routes/index.ts": `
+    "routes/condition.ts": `
       import environment from 'example';
       export default function (req, meta) {
         return new Response('Environment: ' + environment);
@@ -73,44 +125,121 @@ devTest('uses "development" condition', {
     `,
   },
   async test(dev) {
-    await dev.fetch("/").equals("Environment: development");
+    // --- import identifier doesnt get renamed ---
+    await dev.fetch("/identifier").equals("Hello, 123!");
+    await dev.write("identifier/db.ts", `export const abc = "456";`);
+    await dev.fetch("/identifier").equals("Hello, 456!");
+    await dev.patch("routes/identifier.ts", {
+      find: "Hello",
+      replace: "Bun",
+    });
+    await dev.fetch("/identifier").equals("Bun, 456!");
+
+    // --- symbol collision with import identifier ---
+    await dev.fetch("/collision").equals("Hello, 123, 987!");
+    await dev.write("collision/db.ts", `export const abc = "456";`);
+    await dev.fetch("/collision").equals("Hello, 456, 987!");
+
+    // --- uses "development" condition ---
+    await dev.fetch("/condition").equals("Environment: development");
+
+    // The edits above did not touch the other routes.
+    await dev.fetch("/identifier").equals("Bun, 456!");
+    await dev.fetch("/").expect404();
   },
 });
-devTest("importing a file before it is created", {
+devTest("client import rules: missing file, html import, bun builtin, html import with text loader", {
   files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
+    "before-created.html": emptyHtmlFile({ scripts: ["before-created.ts"] }),
+    "before-created.ts": `
       import { abc } from './second';
       console.log('value: ' + abc);
     `,
+    "import-html.html": emptyHtmlFile({ scripts: ["import-html.ts"] }),
+    "import-html.ts": `
+      import html from "./import-html.html";
+      console.log(html);
+    `,
+    "import-bun.html": emptyHtmlFile({ scripts: ["import-bun.ts"] }),
+    "import-bun.ts": `
+      import bun from "bun";
+      console.log(bun);
+    `,
+    "text-loader.html": emptyHtmlFile({ scripts: ["text-loader.ts"] }),
+    "text-loader.ts": `
+      import html from "./app.html" with { type: "text" };
+      console.log(html);
+    `,
+    "app.html": "<div>hello world</div>",
   },
+  // app.html is imported as text, it is not a route.
+  htmlFiles: ["before-created.html", "import-html.html", "import-bun.html", "text-loader.html"],
   async test(dev) {
-    await using c = await dev.client("/", {
-      errors: [`index.ts:1:21: error: Could not resolve: "./second"`],
-    });
+    // Build errors are published to every connected client, so each failing
+    // case ends by fixing its file before the next case opens a page.
 
-    await c.expectReload(async () => {
-      await dev.write("second.ts", `export const abc = "456";`);
-    });
+    // --- importing a file before it is created ---
+    await expectBuildFailedPage(dev, "/before-created", 'Could not resolve: "./second"');
+    {
+      await using c = await dev.client("/before-created", {
+        errors: [`before-created.ts:1:21: error: Could not resolve: "./second"`],
+      });
+      await c.expectReload(async () => {
+        await dev.write("second.ts", `export const abc = "456";`);
+      });
+      await c.expectMessage("value: 456");
+    }
 
-    await c.expectMessage("value: 456");
+    // --- importing html file ---
+    await expectBuildFailedPage(dev, "/import-html", "Browser builds cannot import HTML files.");
+    {
+      await using c = await dev.client("/import-html", {
+        errors: ["import-html.ts:1:18: error: Browser builds cannot import HTML files."],
+      });
+      await c.expectReload(async () => {
+        await dev.write("import-html.ts", `console.log("html import removed");`);
+      });
+      await c.expectMessage("html import removed");
+    }
+
+    // --- importing bun on the client ---
+    await expectBuildFailedPage(dev, "/import-bun", 'Browser build cannot import Bun builtin: "bun"');
+    {
+      await using c = await dev.client("/import-bun", {
+        errors: ['import-bun.ts:1:17: error: Browser build cannot import Bun builtin: "bun"'],
+      });
+      await c.expectReload(async () => {
+        await dev.write("import-bun.ts", `console.log("bun import removed");`);
+      });
+      await c.expectMessage("bun import removed");
+    }
+
+    // --- importing html file with text loader (#18154) ---
+    // The attribute picks the text loader, so the html file is a module with
+    // its text as the export instead of a route.
+    const bundle = await servedClientBundle(dev, "/text-loader");
+    expect(servedModules(bundle)).toEqual(["app.html", "text-loader.html", "text-loader.ts"]);
+    expect(servedModule(bundle, "app.html")).toMatchInlineSnapshot(`
+      ""app.html"(hmr) {
+        hmr.cjs.exports = "<div>hello world</div>"; // bun .s_lazy_export
+      },"
+    `);
   },
 });
-devTest("default export same-scope handling", {
+devTest("client module forms: import.meta.main, default export scoping, commonjs forms", {
   files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
+    "import-meta-main.html": emptyHtmlFile({ scripts: ["import-meta-main.ts"] }),
+    "import-meta-main.ts": `
+      console.log(import.meta.main);
+    `,
+
+    "default-export.html": emptyHtmlFile({ scripts: ["default-export.ts"] }),
+    "default-export.ts": `
       import.meta.hot.accept();
-      await import("./fixture1.ts"); 
-      console.log((new ((await import("./fixture2.ts")).default)).a); 
-      await import("./fixture3.ts"); 
-      console.log((new ((await import("./fixture4.ts")).default)).result); 
+      await import("./fixture1.ts");
+      console.log((new ((await import("./fixture2.ts")).default)).a);
+      await import("./fixture3.ts");
+      console.log((new ((await import("./fixture4.ts")).default)).result);
       console.log((await import("./fixture5.ts")).default);
       console.log((await import("./fixture6.ts")).default);
       console.log((await import("./fixture7.ts")).default());
@@ -165,40 +294,81 @@ devTest("default export same-scope handling", {
       export default function named(flag = true) { return flag ? "TEN" : "ELEVEN" };
       console.log(named());
     `,
+
+    "commonjs.html": emptyHtmlFile({ scripts: ["commonjs.ts"] }),
+    "commonjs.ts": `
+      import cjs from "./cjs.js";
+      console.log(cjs);
+    `,
+    "cjs.js": `
+      module.exports.field = {};
+    `,
   },
   async test(dev) {
-    await using c = await dev.client("/", { storeHotChunks: true });
-    c.expectMessage(
-      //
-      "ONE",
-      "TWO",
-      "THREE",
-      "FOUR",
-      "FIVE",
-      "SIX",
-      "SEVEN",
-      "EIGHT",
-      "NINE",
-      "TEN",
-      "ELEVEN",
+    // --- import.meta.main ---
+    // There is no single entry point, so it is inlined as `false`, in an ES
+    // module and in a CommonJS module alike.
+    const esm = await servedClientBundle(dev, "/import-meta-main");
+    expect(servedModule(esm, "import-meta-main.ts")).toMatchInlineSnapshot(`
+      ""import-meta-main.ts": [ [], [], [], (hmr) => {
+        console.log(false);
+      }, false],"
+    `);
+    await dev.write(
+      "import-meta-main.ts",
+      `
+        require;
+        console.log(import.meta.main);
+      `,
     );
+    const cjs = await servedClientBundle(dev, "/import-meta-main");
+    expect(servedModule(cjs, "import-meta-main.ts")).toMatchInlineSnapshot(`
+      ""import-meta-main.ts"(hmr) {
+        hmr.require;
+        console.log(false);
+      },"
+    `);
 
-    const filesExpectingMove = Object.entries(dev.options.files)
-      .filter(([, content]) => content.includes("MOVE"))
-      .map(([path]) => path);
-    for (const file of filesExpectingMove) {
-      await dev.writeNoChanges(file);
-      const chunk = await c.getMostRecentHmrChunk();
-      expect(chunk).toMatch(/default:\s*(function|class)\s*MOVE/);
+    // --- default export same-scope handling ---
+    {
+      await using c = await dev.client("/default-export", { storeHotChunks: true });
+      await c.expectMessage("ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN", "EIGHT", "NINE", "TEN", "ELEVEN");
+
+      // A named default export keeps its declaration, so the HMR chunk exports
+      // the class or function by name.
+      await dev.writeNoChanges("fixture4.ts");
+      expect(await c.getMostRecentHmrChunk()).toMatch(/default:\s*class\s+MOVE\b/);
+      await dev.writeNoChanges("fixture8.ts");
+      expect(await c.getMostRecentHmrChunk()).toMatch(/default:\s*function\s+MOVE\b/);
+
+      await dev.writeNoChanges("fixture7.ts");
+      expect(await c.getMostRecentHmrChunk()).toMatch(/default:\s*function\b/);
+      // Since fixture7.ts is not marked as accepting, it will bubble the update
+      // to `default-export.ts`, re-evaluate it and some of the dependencies.
+      await c.expectMessage("TWO", "FOUR", "FIVE", "SEVEN", "EIGHT", "NINE", "ELEVEN");
     }
 
-    await dev.writeNoChanges("fixture7.ts");
-    const chunk = await c.getMostRecentHmrChunk();
-    expect(chunk).toMatch(/default:\s*function/);
-
-    // Since fixture7.ts is not marked as accepting, it will bubble the update
-    // to `index.ts`, re-evaluate it and some of the dependencies.
-    c.expectMessage("TWO", "FOUR", "FIVE", "SEVEN", "EIGHT", "NINE", "ELEVEN");
+    // --- commonjs forms ---
+    // Nothing accepts updates, so every rewrite of cjs.js reloads the page.
+    {
+      await using c = await dev.client("/commonjs");
+      await c.expectMessage({ field: {} });
+      const forms: [source: string, field: string][] = [
+        [`exports.field = "1";`, "1"],
+        [`let theExports = exports; theExports.field = "2";`, "2"],
+        [`let theModule = module; theModule.exports.field = "3";`, "3"],
+        [`let { exports } = module; exports.field = "4";`, "4"],
+        [`var { exports } = module; exports.field = "4.5";`, "4.5"],
+        [`let theExports = module.exports; theExports.field = "5";`, "5"],
+        [`require; eval("module.exports.field = '6'");`, "6"],
+      ];
+      for (const [source, field] of forms) {
+        await c.expectReload(async () => {
+          await dev.write("cjs.js", source);
+        });
+        await c.expectMessage({ field });
+      }
+    }
   },
 });
 devTest("directory cache bust case #17576", {
@@ -299,6 +469,12 @@ devTest("removing 'use client' from a component with a pending resolution failur
         return new Response('page: ' + (typeof Comp.marker));
       }
     `,
+    // Only requested at the very end, to show the server still serves.
+    "routes/alive.ts": `
+      export default function (req, meta) {
+        return new Response('alive');
+      }
+    `,
     "components/Comp.ts": `
       "use client";
       export const marker = "initial";
@@ -318,7 +494,7 @@ devTest("removing 'use client' from a component with a pending resolution failur
     // and the client graph owns the key string for Comp.ts. Sibling.ts
     // fails to resolve './sibling-missing' under the browser target,
     // leaving a client-graph Dep on the components/ directory watch.
-    await dev.fetch("/");
+    await expectBuildFailedPage(dev, "/", 'Could not resolve: "./sibling-missing"');
 
     // Re-bundle Comp.ts with a failing import while it is still a CCB.
     // With separateSSRGraph the re-parse runs under the browser target,
@@ -353,9 +529,10 @@ devTest("removing 'use client' from a component with a pending resolution failur
     // a heap-use-after-free here and the dev server aborts.
     await dev.write("components/missing.ts", `export const value = "ok";`, { errors: null });
 
-    // The server must still be alive and responding.
-    const res = await dev.fetch("/");
-    expect(res).toBeInstanceOf(Response);
+    // The server must still be alive and responding: the index route still
+    // fails because of Sibling.ts, and an untouched route renders.
+    expect((await dev.fetch("/")).status).toBe(500);
+    await dev.fetch("/alive").equals("alive");
   },
 });
 devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
@@ -373,7 +550,7 @@ devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
   },
   async test(dev) {
     // Initial bundle: both imports fail and attach deps to the sub/ watch.
-    await dev.fetch("/");
+    await expectBuildFailedPage(dev, "/", 'Could not resolve: "./sub/a"', 'Could not resolve: "./sub/b"');
 
     {
       await using _ = await dev.batchChanges({ errors: null });
@@ -388,9 +565,8 @@ devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
       await dev.write("sub/a.ts", `export {};`);
     }
 
-    // The server should still respond.
-    const res = await dev.fetch("/");
-    expect(res).toBeInstanceOf(Response);
+    // The server should still respond, with the rebuilt import-free page.
+    expect(servedModules(await servedClientBundle(dev, "/"))).toEqual(["index.html", "index.ts"]);
 
     // Test teardown sends graceful-exit, which calls DevServer.deinit.
     // Before the fix, deinit iterated every dependencies.items slot and
@@ -398,470 +574,338 @@ devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
     // AllocationScope's invalid-free panic.
   },
 });
-devTest("importing html file", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import html from "./index.html";
-      console.log(html);
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ["index.ts:1:18: error: Browser builds cannot import HTML files."],
-    });
-  },
-});
-devTest("importing html file with text loader (#18154)", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import html from "./app.html" with { type: "text" };
-      console.log(html);
-    `,
-    "app.html": "<div>hello world</div>",
-  },
-  htmlFiles: ["index.html"],
-  async test(dev) {
-    await using c = await dev.client("/", {});
-    await c.expectMessage("<div>hello world</div>");
-  },
-});
-devTest("importing bun on the client", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import bun from "bun";
-      console.log(bun);
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ['index.ts:1:17: error: Browser build cannot import Bun builtin: "bun"'],
-    });
-  },
-});
-devTest("import.meta.main", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      console.log(import.meta.main);
-      import.meta.hot.accept();
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage(false); // import.meta.main is always false because there is no single entry point
-
-    await dev.write(
-      "index.ts",
-      `
-        require;
-        console.log(import.meta.main);
-      `,
-    );
-    await c.expectMessage(false);
-  },
-});
-devTest("commonjs forms", {
-  timeoutMultiplier: 2,
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import cjs from "./cjs.js";
-      console.log(cjs);
-    `,
-    "cjs.js": `
-      module.exports.field = {};
-    `,
-  },
-  async test(dev) {
-    console.log("Initial");
-    await using c = await dev.client("/");
-    console.log("  expecting message");
-    await c.expectMessage({ field: {} });
-    console.log("  expecting reload");
-    await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `exports.field = "1";`);
-      console.log("  now reloading");
-    });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "1" });
-    console.log("Second");
-    console.log("  expecting reload");
-    await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `let theExports = exports; theExports.field = "2";`);
-    });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "2" });
-    console.log("Third");
-    console.log("  expecting reload");
-    await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `let theModule = module; theModule.exports.field = "3";`);
-    });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "3" });
-    console.log("Fourth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `let { exports } = module; exports.field = "4";`);
-    });
-    await c.expectMessage({ field: "4" });
-    console.log("Fifth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `var { exports } = module; exports.field = "4.5";`);
-    });
-    await c.expectMessage({ field: "4.5" });
-    console.log("Sixth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `let theExports = module.exports; theExports.field = "5";`);
-    });
-    await c.expectMessage({ field: "5" });
-    console.log("Seventh");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `require; eval("module.exports.field = '6'");`);
-    });
-    await c.expectMessage({ field: "6" });
-  },
-});
 
 // --- Barrel optimization tests ---
 
-devTest("barrel optimization skips unused submodules", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { Alpha } from 'barrel-lib';
-      console.log('got: ' + Alpha);
-    `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
+/** A `sideEffects: false` package whose `main` is a re-export barrel. */
+function barrelPackage(name: string, files: Record<string, string>) {
+  const out: Record<string, string> = {
+    [`node_modules/${name}/package.json`]: JSON.stringify({
+      name,
       version: "1.0.0",
       main: "./index.js",
       sideEffects: false,
     }),
-    "node_modules/barrel-lib/index.js": `
-      export { Alpha } from './alpha.js';
-      export { Beta } from './beta.js';
-      export { Gamma } from './gamma.js';
-    `,
-    "node_modules/barrel-lib/alpha.js": `export const Alpha = "ALPHA";`,
-    "node_modules/barrel-lib/beta.js": `export const Beta = <<<SYNTAX_ERROR>>>;`,
-    "node_modules/barrel-lib/gamma.js": `export const Gamma = <<<SYNTAX_ERROR>>>;`,
-  },
-  async test(dev) {
-    // Beta.js and Gamma.js have syntax errors.
-    // If barrel optimization works, they are never parsed, so no error.
-    await using c = await dev.client("/");
-    await c.expectMessage("got: ALPHA");
-  },
-});
+  };
+  for (const [file, contents] of Object.entries(files)) {
+    out[`node_modules/${name}/${file}`] = contents;
+  }
+  return out;
+}
 
-devTest("barrel optimization: adding a new import triggers reload", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { Alpha } from 'barrel-lib';
-      console.log('result: ' + Alpha);
+interface StaticBarrelCase {
+  name: string;
+  /** The module that imports from the package(s) under test. It logs one line. */
+  consumer: string;
+  log: string;
+  files: Record<string, string>;
+  /** Per package, the files that end up in the bundle. The rest were deferred. */
+  bundled: Record<string, string[]>;
+}
+
+// Cases that only need a page to load once. One page imports every consumer, in this order.
+const staticBarrelCases: StaticBarrelCase[] = [
+  {
+    name: "barrel optimization skips unused submodules",
+    consumer: `
+      import { Alpha } from 'barrel-skip';
+      console.log('skip: ' + Alpha);
     `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
+    log: "skip: ALPHA",
+    // beta.js and gamma.js have syntax errors. The page only builds if the
+    // barrel optimization never parses them.
+    files: barrelPackage("barrel-skip", {
+      "index.js": `
+        export { Alpha } from './alpha.js';
+        export { Beta } from './beta.js';
+        export { Gamma } from './gamma.js';
+      `,
+      "alpha.js": `export const Alpha = "ALPHA";`,
+      "beta.js": `export const Beta = <<<SYNTAX_ERROR>>>;`,
+      "gamma.js": `export const Gamma = <<<SYNTAX_ERROR>>>;`,
     }),
-    "node_modules/barrel-lib/index.js": `
-      export { Alpha } from './alpha.js';
-      export { Beta } from './beta.js';
-      export { Gamma } from './gamma.js';
-    `,
-    "node_modules/barrel-lib/alpha.js": `export const Alpha = "ALPHA";`,
-    "node_modules/barrel-lib/beta.js": `export const Beta = "BETA";`,
-    "node_modules/barrel-lib/gamma.js": `export const Gamma = "GAMMA";`,
+    bundled: { "barrel-skip": ["alpha.js", "index.js"] },
   },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("result: ALPHA");
-
-    // Add a second import from the barrel — Beta was previously deferred,
-    // now needs to be loaded. The barrel file should be re-bundled with
-    // Beta un-deferred.
-    await c.expectReload(async () => {
-      await dev.write(
-        "index.ts",
-        `
-        import { Alpha, Beta } from 'barrel-lib';
-        console.log('result: ' + Alpha + ' ' + Beta);
-      `,
-      );
-    });
-    await c.expectMessage("result: ALPHA BETA");
-
-    // Add a third import
-    await c.expectReload(async () => {
-      await dev.write(
-        "index.ts",
-        `
-        import { Alpha, Beta, Gamma } from 'barrel-lib';
-        console.log('result: ' + Alpha + ' ' + Beta + ' ' + Gamma);
-      `,
-      );
-    });
-    await c.expectMessage("result: ALPHA BETA GAMMA");
-  },
-});
-
-devTest("barrel optimization: multi-file imports preserved across rebuilds", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { Alpha } from 'barrel-lib';
-      import { value } from './other';
-      console.log('result: ' + Alpha + ' ' + value);
-    `,
-    "other.ts": `
-      import { Beta } from 'barrel-lib';
-      export const value = Beta;
-    `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
-    "node_modules/barrel-lib/index.js": `
-      export { Alpha } from './alpha.js';
-      export { Beta } from './beta.js';
-      export { Gamma } from './gamma.js';
-    `,
-    "node_modules/barrel-lib/alpha.js": `export const Alpha = "ALPHA";`,
-    "node_modules/barrel-lib/beta.js": `export const Beta = "BETA";`,
-    "node_modules/barrel-lib/gamma.js": `export const Gamma = "GAMMA";`,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("result: ALPHA BETA");
-
-    // Edit only other.ts to also import Gamma. Alpha (from index.ts) must
-    // still be available even though index.ts is not re-parsed.
-    await c.expectReload(async () => {
-      await dev.write(
-        "other.ts",
-        `
-        import { Beta, Gamma } from 'barrel-lib';
-        export const value = Beta + ' ' + Gamma;
-      `,
-      );
-    });
-    await c.expectMessage("result: ALPHA BETA GAMMA");
-  },
-});
-
-devTest("barrel optimization: export star target not deferred (#27521)", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+  {
+    name: "barrel optimization: export star target not deferred (#27521)",
     // The user imports from consumer-lib, which is a non-barrel package
-    // that imports QueryClient from outer-lib.
-    "index.ts": `
-      import { useQuery } from 'consumer-lib';
-      console.log('result: ' + useQuery());
-    `,
-    // consumer-lib is NOT a barrel — it has real code that uses
-    // QueryClient from outer-lib. This mirrors @refinedev/core
+    // that imports QueryClient from outer-lib. This mirrors @refinedev/core
     // importing QueryClient from @tanstack/react-query.
-    "node_modules/consumer-lib/package.json": JSON.stringify({
-      name: "consumer-lib",
-      version: "1.0.0",
-      main: "./index.js",
-    }),
-    "node_modules/consumer-lib/index.js": `
-      import { QueryClient } from 'outer-lib';
-      export function useQuery() {
-        const client = new QueryClient();
-        return client instanceof QueryClient ? 'PASS' : 'FAIL';
-      }
+    consumer: `
+      import { useQuery } from 'consumer-lib';
+      console.log('export star: ' + useQuery());
     `,
-    // outer-lib is a barrel with sideEffects:false that re-exports
-    // everything from inner-lib via export *. Mirrors @tanstack/react-query.
-    "node_modules/outer-lib/package.json": JSON.stringify({
-      name: "outer-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
-    "node_modules/outer-lib/index.js": `
-      export * from 'inner-lib';
-      export { Unrelated } from './unrelated.js';
-    `,
-    "node_modules/outer-lib/unrelated.js": `export const Unrelated = "X";`,
-    // inner-lib is a barrel with sideEffects:false that re-exports
-    // from submodules. Mirrors @tanstack/query-core. Without the fix,
-    // the barrel optimizer defers queryClient.js because it doesn't
-    // know inner-lib is an export-star target (source_index is not
-    // set in dev-server mode), so QueryClient becomes undefined.
-    "node_modules/inner-lib/package.json": JSON.stringify({
-      name: "inner-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
-    "node_modules/inner-lib/index.js": `
-      export { QueryClient } from './queryClient.js';
-      export { Other } from './other.js';
-    `,
-    "node_modules/inner-lib/queryClient.js": `
-      export class QueryClient { constructor() { this.ready = true; } }
-    `,
-    "node_modules/inner-lib/other.js": `export const Other = "OTHER";`,
+    log: "export star: PASS",
+    files: {
+      "node_modules/consumer-lib/package.json": JSON.stringify({
+        name: "consumer-lib",
+        version: "1.0.0",
+        main: "./index.js",
+      }),
+      "node_modules/consumer-lib/index.js": `
+        import { QueryClient } from 'outer-lib';
+        export function useQuery() {
+          const client = new QueryClient();
+          return client instanceof QueryClient ? 'PASS' : 'FAIL';
+        }
+      `,
+      // outer-lib is a barrel with sideEffects:false that re-exports
+      // everything from inner-lib via export *. Mirrors @tanstack/react-query.
+      ...barrelPackage("outer-lib", {
+        "index.js": `
+          export * from 'inner-lib';
+          export { Unrelated } from './unrelated.js';
+        `,
+        "unrelated.js": `export const Unrelated = "X";`,
+      }),
+      // inner-lib is a barrel with sideEffects:false that re-exports
+      // from submodules. Mirrors @tanstack/query-core. Without the fix,
+      // the barrel optimizer defers queryClient.js because it doesn't
+      // know inner-lib is an export-star target (source_index is not
+      // set in dev-server mode), so QueryClient becomes undefined.
+      ...barrelPackage("inner-lib", {
+        "index.js": `
+          export { QueryClient } from './queryClient.js';
+          export { Other } from './other.js';
+        `,
+        "queryClient.js": `
+          export class QueryClient { constructor() { this.ready = true; } }
+        `,
+        "other.js": `export const Other = "OTHER";`,
+      }),
+    },
+    // outer-lib's unused re-export is still deferred. The export-star target is bundled whole.
+    bundled: {
+      "consumer-lib": ["index.js"],
+      "outer-lib": ["index.js"],
+      "inner-lib": ["index.js", "other.js", "queryClient.js"],
+    },
   },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("result: PASS");
-  },
-});
+  {
+    name: "barrel optimization: two export-from blocks pointing to the same source",
+    consumer: `
+      import { invariant } from 'barrel-split';
+      console.log('split export-from: ' + typeof invariant);
+    `,
+    log: "split export-from: function",
+    files: barrelPackage("barrel-split", {
+      "index.js": `
+        export {
+          createDataProperty,
+          defineProperty,
+        } from './utils.js';
 
-devTest("barrel optimization: two export-from blocks pointing to the same source", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { invariant } from 'barrel-lib';
-      console.log('got: ' + typeof invariant);
-    `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
+        export { unrelated } from './other.js';
+
+        export {
+          invariant,
+        } from './utils.js';
+      `,
+      "utils.js": `
+        export function createDataProperty() {}
+        export function defineProperty() {}
+        export function invariant(cond, msg) {
+          if (!cond) throw new Error(msg);
+        }
+      `,
+      "other.js": `export const unrelated = "OTHER";`,
     }),
-    "node_modules/barrel-lib/index.js": `
-      export {
-        createDataProperty,
-        defineProperty,
-      } from './utils.js';
-
-      export { unrelated } from './other.js';
-
-      export {
-        invariant,
-      } from './utils.js';
-    `,
-    "node_modules/barrel-lib/utils.js": `
-      export function createDataProperty() {}
-      export function defineProperty() {}
-      export function invariant(cond, msg) {
-        if (!cond) throw new Error(msg);
-      }
-    `,
-    "node_modules/barrel-lib/other.js": `export const unrelated = "OTHER";`,
+    bundled: { "barrel-split": ["index.js", "utils.js"] },
   },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("got: function");
-  },
-});
-
-// Regression: #28886
-// Consumer has TWO separate `import { X } from 'barrel'` statements for the
-// same barrel. HMR deduplicates the second into the first; the second's
-// import record is marked is_unused=true and never gets its path resolved.
-// Barrel optimization then fails to see the named import from the dedup'd
-// record and marks its target submodule as unused → submodule stays `{}` →
-// the export is `undefined` at runtime.
-devTest("barrel optimization: two import statements from the same barrel (#28886)", {
-  // Flakes on darwin in CI (timing); fix is platform-agnostic, coverage via linux/windows/alpine.
-  skip: ["darwin"],
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { Alpha } from 'barrel-lib';
-      import { Beta } from 'barrel-lib';
-      console.log('got: ' + Alpha() + ' ' + Beta());
+  {
+    // Regression: #28886
+    // Consumer has TWO separate `import { X } from 'barrel'` statements for the
+    // same barrel. HMR deduplicates the second into the first; the second's
+    // import record is marked is_unused=true and never gets its path resolved.
+    // Barrel optimization then fails to see the named import from the dedup'd
+    // record and marks its target submodule as unused → submodule stays `{}` →
+    // the export is `undefined` at runtime.
+    name: "barrel optimization: two import statements from the same barrel (#28886)",
+    consumer: `
+      import { Alpha } from 'barrel-twice';
+      import { Beta } from 'barrel-twice';
+      console.log('two imports: ' + Alpha() + ' ' + Beta());
     `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
+    log: "two imports: ALPHA BETA",
+    files: barrelPackage("barrel-twice", {
+      "index.js": `
+        export { Alpha } from './alpha.js';
+        export { Beta } from './beta.js';
+        export { Gamma } from './gamma.js';
+      `,
+      "alpha.js": `export const Alpha = () => "ALPHA";`,
+      "beta.js": `export const Beta = () => "BETA";`,
+      "gamma.js": `export const Gamma = () => "GAMMA";`,
     }),
-    "node_modules/barrel-lib/index.js": `
-      export { Alpha } from './alpha.js';
-      export { Beta } from './beta.js';
-      export { Gamma } from './gamma.js';
-    `,
-    "node_modules/barrel-lib/alpha.js": `export const Alpha = () => "ALPHA";`,
-    "node_modules/barrel-lib/beta.js": `export const Beta = () => "BETA";`,
-    "node_modules/barrel-lib/gamma.js": `export const Gamma = () => "GAMMA";`,
+    bundled: { "barrel-twice": ["alpha.js", "beta.js", "index.js"] },
   },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("got: ALPHA BETA");
-  },
-});
-
-devTest("barrel optimization: namespace re-export cycle through a star-exported module", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
+  {
+    name: "barrel optimization: namespace re-export cycle through a star-exported module",
+    consumer: `
       import { x, y, deepValue } from 'loop-lib';
       import { keep } from 'loop-lib/w.js';
       import { other } from 'loop-lib/g.js';
-      console.log('result: ' + typeof x + ' ' + y + ' ' + keep + ' ' + deepValue + ' ' + other);
+      console.log('cycle: ' + typeof x + ' ' + y + ' ' + keep + ' ' + deepValue + ' ' + other);
     `,
-    "node_modules/loop-lib/package.json": JSON.stringify({
-      name: "loop-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
+    log: "cycle: object Y KEEP DEEP OTHER",
+    files: barrelPackage("loop-lib", {
+      "index.js": `
+        export * from './t.js';
+      `,
+      "t.js": `
+        export { x } from './w.js';
+        export * from './r.js';
+        export * from './g.js';
+      `,
+      "w.js": `
+        import * as ns from './t.js';
+        export { ns as x };
+        export { keep } from './keep.js';
+      `,
+      "keep.js": `
+        export const keep = "KEEP";
+      `,
+      "r.js": `
+        export const y = "Y";
+      `,
+      "g.js": `
+        export { deepValue } from './deep.js';
+        export { other } from './other.js';
+      `,
+      "deep.js": `
+        export const deepValue = "DEEP";
+      `,
+      "other.js": `
+        export const other = "OTHER";
+      `,
     }),
-    "node_modules/loop-lib/index.js": `
-      export * from './t.js';
+    bundled: { "loop-lib": ["deep.js", "g.js", "index.js", "keep.js", "other.js", "r.js", "t.js", "w.js"] },
+  },
+];
+
+devTest("barrel optimization", {
+  files: {
+    "static.html": emptyHtmlFile({ scripts: ["static.ts"] }),
+    "static.ts": staticBarrelCases.map((_, i) => `import "./static-case-${i}.ts";`).join("\n"),
+    ...Object.fromEntries(staticBarrelCases.map((c, i) => [`static-case-${i}.ts`, c.consumer])),
+    ...Object.assign({}, ...staticBarrelCases.map(c => c.files)),
+
+    // --- barrel optimization: adding a new import triggers reload ---
+    "add.html": emptyHtmlFile({ scripts: ["add.ts"] }),
+    "add.ts": `
+      import { Alpha } from 'barrel-add';
+      console.log('result: ' + Alpha);
     `,
-    "node_modules/loop-lib/t.js": `
-      export { x } from './w.js';
-      export * from './r.js';
-      export * from './g.js';
+    ...barrelPackage("barrel-add", {
+      "index.js": `
+        export { Alpha } from './alpha.js';
+        export { Beta } from './beta.js';
+        export { Gamma } from './gamma.js';
+      `,
+      "alpha.js": `export const Alpha = "ALPHA";`,
+      "beta.js": `export const Beta = "BETA";`,
+      "gamma.js": `export const Gamma = "GAMMA";`,
+    }),
+
+    // --- barrel optimization: multi-file imports preserved across rebuilds ---
+    "multi.html": emptyHtmlFile({ scripts: ["multi.ts"] }),
+    "multi.ts": `
+      import { Alpha } from 'barrel-multi';
+      import { value } from './multi-other';
+      console.log('result: ' + Alpha + ' ' + value);
     `,
-    "node_modules/loop-lib/w.js": `
-      import * as ns from './t.js';
-      export { ns as x };
-      export { keep } from './keep.js';
+    "multi-other.ts": `
+      import { Beta } from 'barrel-multi';
+      export const value = Beta;
     `,
-    "node_modules/loop-lib/keep.js": `
-      export const keep = "KEEP";
-    `,
-    "node_modules/loop-lib/r.js": `
-      export const y = "Y";
-    `,
-    "node_modules/loop-lib/g.js": `
-      export { deepValue } from './deep.js';
-      export { other } from './other.js';
-    `,
-    "node_modules/loop-lib/deep.js": `
-      export const deepValue = "DEEP";
-    `,
-    "node_modules/loop-lib/other.js": `
-      export const other = "OTHER";
-    `,
+    ...barrelPackage("barrel-multi", {
+      "index.js": `
+        export { Alpha } from './alpha.js';
+        export { Beta } from './beta.js';
+        export { Gamma } from './gamma.js';
+      `,
+      "alpha.js": `export const Alpha = "ALPHA";`,
+      "beta.js": `export const Beta = "BETA";`,
+      "gamma.js": `export const Gamma = "GAMMA";`,
+    }),
   },
   async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("result: object Y KEEP DEEP OTHER");
+    // --- the single-load cases in `staticBarrelCases` ---
+    {
+      await using c = await dev.client("/static");
+      await c.expectMessage(...staticBarrelCases.map(staticCase => staticCase.log));
+    }
+    const modules = servedModules(await servedClientBundle(dev, "/static"));
+    for (const { name, bundled } of staticBarrelCases) {
+      for (const [pkg, files] of Object.entries(bundled)) {
+        expect(packageFiles(modules, pkg), `${name}: files of ${pkg} in the bundle`).toEqual(files);
+      }
+    }
+
+    // --- barrel optimization: adding a new import triggers reload ---
+    {
+      await using c = await dev.client("/add");
+      await c.expectMessage("result: ALPHA");
+      expect(await bundledPackageFiles(dev, "/add", "barrel-add")).toEqual(["alpha.js", "index.js"]);
+
+      // Add a second import from the barrel. Beta was previously deferred,
+      // now needs to be loaded. The barrel file should be re-bundled with
+      // Beta un-deferred.
+      await c.expectReload(async () => {
+        await dev.write(
+          "add.ts",
+          `
+            import { Alpha, Beta } from 'barrel-add';
+            console.log('result: ' + Alpha + ' ' + Beta);
+          `,
+        );
+      });
+      await c.expectMessage("result: ALPHA BETA");
+      expect(await bundledPackageFiles(dev, "/add", "barrel-add")).toEqual(["alpha.js", "beta.js", "index.js"]);
+
+      // Add a third import
+      await c.expectReload(async () => {
+        await dev.write(
+          "add.ts",
+          `
+            import { Alpha, Beta, Gamma } from 'barrel-add';
+            console.log('result: ' + Alpha + ' ' + Beta + ' ' + Gamma);
+          `,
+        );
+      });
+      await c.expectMessage("result: ALPHA BETA GAMMA");
+      expect(await bundledPackageFiles(dev, "/add", "barrel-add")).toEqual([
+        "alpha.js",
+        "beta.js",
+        "gamma.js",
+        "index.js",
+      ]);
+    }
+
+    // --- barrel optimization: multi-file imports preserved across rebuilds ---
+    {
+      await using c = await dev.client("/multi");
+      await c.expectMessage("result: ALPHA BETA");
+      expect(await bundledPackageFiles(dev, "/multi", "barrel-multi")).toEqual(["alpha.js", "beta.js", "index.js"]);
+
+      // Edit only multi-other.ts to also import Gamma. Alpha (from multi.ts)
+      // must still be available even though multi.ts is not re-parsed.
+      await c.expectReload(async () => {
+        await dev.write(
+          "multi-other.ts",
+          `
+            import { Beta, Gamma } from 'barrel-multi';
+            export const value = Beta + ' ' + Gamma;
+          `,
+        );
+      });
+      await c.expectMessage("result: ALPHA BETA GAMMA");
+      expect(await bundledPackageFiles(dev, "/multi", "barrel-multi")).toEqual([
+        "alpha.js",
+        "beta.js",
+        "gamma.js",
+        "index.js",
+      ]);
+    }
   },
 });


### PR DESCRIPTION
### Problem
- `test/bake/dev/bundle.test.ts` takes 16s on the alpine aarch64 lane (build #104578) and 50s on a local debug+ASAN build. Each of its 21 cases boots a dev server, and 17 spawn a happy-dom client. That fixed cost is most of the time.
- Some assertions are weak: `toBeInstanceOf(Response)` on a 500, two `expectMessage` calls that are never awaited, no check of the served bundle.

### Fix
- Cases that start from the same project share one dev server, one route or page each. 21 servers become 8, 17 clients become 10. No case is dropped. The cases with a `skip` or a `mainDir` stay on their own.
- Stronger assertions: the "Build Failed" page (status 500, embedded error text) for every failing route, the served bundle's module list (which barrel submodules were deferred) before and after each edit, inline snapshots of the served module for `import.meta.main` and the text loader.
- Timing, two runs each, same machine. Debug+ASAN: 58.1s and 50.3s before, 26.6s and 28.5s after. Release: 10.4s and 10.0s before, 7.1s and 7.5s after. `expect()` calls: 44 to 134.
- Verified: `bun bd test test/bake/dev/bundle.test.ts` (three runs) and `USE_SYSTEM_BUN=1 bun test test/bake/dev/bundle.test.ts` (five runs). The harness is not changed.

### Background
- `devTest` (test/bake/bake-harness.ts) boots one dev server per case. `dev.client()` spawns a node process with happy-dom that loads a page. `dev.write()` waits for the rebuild and for the client to apply it.
- The dev server bundles a route on its first request. Build errors go to every connected client, so a failing case on a shared server fixes its file before the next case opens a page.
- A barrel is a `sideEffects: false` package whose entry only re-exports. The dev server leaves out submodules nothing imports. The served bundle's module table lists the bundled modules.

<details><summary>Notes</summary>

**Per-case wall time, release build**

| before | ms | after | ms |
|---|---|---|---|
| import identifier doesnt get renamed | 206 | server routes (3 cases) | 272 |
| symbol collision with import identifier | 143 | client import rules (4 cases) | 1508 |
| uses "development" condition | 91 | client module forms (3 cases) | 1567 |
| importing a file before it is created | 519 | directory cache bust case #17576 | 552 |
| default export same-scope handling | 618 | deleting imported file shows error then recovers | 654 |
| directory cache bust case #17576 | 547 | removing 'use client' ... | 764 |
| deleting imported file shows error then recovers | 649 | deinit with a free-list slot ... | 145 |
| removing 'use client' ... | 761 | barrel optimization (7 cases) | 1436 |
| deinit with a free-list slot ... | 146 | | |
| importing html file | 442 | | |
| importing html file with text loader (#18154) | 438 | | |
| importing bun on the client | 427 | | |
| import.meta.main | 536 | | |
| commonjs forms | 942 | | |
| barrel optimization skips unused submodules | 519 | | |
| barrel optimization: adding a new import triggers reload | 598 | | |
| barrel optimization: multi-file imports preserved across rebuilds | 617 | | |
| barrel optimization: export star target not deferred (#27521) | 440 | | |
| barrel optimization: two export-from blocks pointing to the same source | 443 | | |
| barrel optimization: two import statements from the same barrel (#28886) | 435 | | |
| barrel optimization: namespace re-export cycle through a star-exported module | 446 | | |

A case with no client costs about 90ms in release (2s in debug+ASAN: 0.4s boot, 1.1s graceful exit). A client adds about 350ms in release (node startup plus the happy-dom import, node's compile cache only saves 50ms of it). A page reload adds 60 to 80ms.

**Where each original case went**

- "import identifier doesnt get renamed", "symbol collision with import identifier", 'uses "development" condition': routes `/identifier`, `/collision`, `/condition` of one `minimalFramework` server. Each of the first two has its own copy of `db.ts`, so both still generate an `import_db` binding and each edit is the same as before. A final check shows the edits to one route left the others alone.
- "importing a file before it is created", "importing html file", "importing bun on the client": pages of one server, each error still on the initial page load. Each case now also fixes its file and checks the reload and the logged message, so the html and bun cases gain a recovery check. "importing html file with text loader (#18154)" reads the served bundle instead of spawning a client: the module list is `app.html`, `text-loader.html`, `text-loader.ts`, and the `app.html` module is a text module with the file's content.
- "import.meta.main": reads the served module instead of spawning a client. The snapshot shows `console.log(false)` inlined in the ES module, and again after the `require;` edit turns the file into a CommonJS module.
- "default export same-scope handling": the `MOVE` check is split into `class MOVE` for fixture4.ts and `function MOVE` for fixture8.ts instead of one `(function|class)` regex. The two `expectMessage` calls are awaited.
- "commonjs forms": the same seven rewrite-and-reload rounds, as a loop over the forms. The `console.log` tracing and `timeoutMultiplier: 2` are gone. The rounds are not batched into one rebuild: a batch of several files is released 50ms after the first watcher event and can miss some of them.
- The five single-load barrel cases are one page, `static.html`, that imports one consumer module per case. Each case keeps its own package names (`barrel-skip`, `consumer-lib`/`outer-lib`/`inner-lib`, `barrel-split`, `barrel-twice`, `loop-lib`), and barrel state in the dev server is keyed by the barrel file's path, so the cases do not share any graph node. The `bundled` list per package is the new assertion: for example `barrel-skip` bundles only `alpha.js` and `index.js`, and `inner-lib` (an export-star target) is bundled whole while `outer-lib`'s unused re-export is deferred. "two import statements from the same barrel (#28886)" had `skip: ["darwin"]` for a timing flake; it now shares the page and the client with four cases that already run on darwin, so the skip is not carried over.
- "adding a new import triggers reload" and "multi-file imports preserved across rebuilds" keep their own pages and clients on the barrel server and also check the bundled package files after each edit.
- "removing 'use client' from a component with a pending resolution failure": the initial fetch checks the Build Failed page with `Could not resolve: "./sibling-missing"`. The final fetch checks status 500 and a new `routes/alive.ts` route renders. The route is a 500 both now (a runtime error page, #40113) and once #40113 is fixed (the Build Failed page for Sibling.ts).
- "deinit with a free-list slot in DirectoryWatchStore.dependencies": the initial fetch checks the Build Failed page with both errors, the final fetch checks the served module list is `index.html`, `index.ts`.

**Unchanged**: "directory cache bust case #17576" (`mainDir`) and "deleting imported file shows error then recovers" (`skip: ["win32"]`).

**Related PRs**: #40259 inserts a case after "deleting imported file shows error then recovers" and rebases cleanly. #40115 inserts a case after the 'use client' case, whose last lines changed here. #39375 inserts a case after "symbol collision with import identifier", now part of the server routes case. #37039 appends cases at the end of the file. #39488 rewrites this file with the same groupings as part of a larger change.

**Harness note**: the 'use client' case prints `WARN: Dev Server did not pick up any changed files` on its last write, as before. The created file resolves a dependency that no longer exists, so no rebuild happens and the harness waits 500ms for one.
</details>
