### PR TITLE
install: skip a deprecated latest dist-tag like npm does

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -941,12 +941,17 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     } else if dependency.behavior.is_peer() {
                                         warn_unmet_peer_dependency(this, name, &version);
                                     } else {
+                                        // A bare specifier has an empty version
+                                        // literal and resolves as `latest`.
+                                        let literal = this.lockfile.str(&version.literal);
+                                        let literal: &[u8] =
+                                            if literal.is_empty() { b"latest" } else { literal };
                                         bun_ast::add_error_pretty!(
                                             this.log_mut(),
                                             None,
                                             bun_ast::Loc::EMPTY,
                                             "No version matching \"{}\" found for specifier \"{}\"<r> <d>(but package exists)<r>",
-                                            bstr::BStr::new(this.lockfile.str(&version.literal)),
+                                            bstr::BStr::new(literal),
                                             bstr::BStr::new(this.lockfile.str(&name)),
                                         );
                                     }
@@ -2655,6 +2660,9 @@ fn get_or_put_resolved_package(
                         .is_dependency_of_workspace_in(t, dependency_id)
                 });
 
+            // Set when the `latest` tag points at a deprecated version, so the
+            // resolution ran with npm's `*`-range fallback instead of the tag.
+            let mut deprecated_latest_fallback = false;
             let version_result: Npm::FindVersionResult = match version.tag {
                 _ if latest_for_target => manifest.find_by_dist_tag_with_filter(
                     b"latest",
@@ -2662,11 +2670,24 @@ fn get_or_put_resolved_package(
                     this.options.minimum_release_age_excludes,
                 ),
                 // SAFETY: `version.tag` discriminates the union arm.
-                dependency::version::Tag::DistTag => manifest.find_by_dist_tag_with_filter(
-                    this.lockfile.str(&version.dist_tag().tag),
-                    this.options.minimum_release_age_ms,
-                    this.options.minimum_release_age_excludes,
-                ),
+                dependency::version::Tag::DistTag => {
+                    let tag = this.lockfile.str(&version.dist_tag().tag);
+                    if tag == b"latest" {
+                        deprecated_latest_fallback = manifest
+                            .find_by_dist_tag(b"latest")
+                            .is_some_and(|result| result.package.deprecated);
+                        manifest.find_by_latest_tag_with_filter(
+                            this.options.minimum_release_age_ms,
+                            this.options.minimum_release_age_excludes,
+                        )
+                    } else {
+                        manifest.find_by_dist_tag_with_filter(
+                            tag,
+                            this.options.minimum_release_age_ms,
+                            this.options.minimum_release_age_excludes,
+                        )
+                    }
+                }
                 dependency::version::Tag::Npm => manifest.find_best_version_with_filter(
                     &version.npm().version,
                     this.lockfile.buffers.string_bytes.as_slice(),
@@ -2767,6 +2788,12 @@ fn get_or_put_resolved_package(
 
                     return match version.tag {
                         dependency::version::Tag::Npm => Err(crate::Error::NoMatchingVersion),
+                        // A deprecated `latest` resolves like the range `*`
+                        // (npm parity), so report a version mismatch, not a
+                        // missing tag.
+                        dependency::version::Tag::DistTag if deprecated_latest_fallback => {
+                            Err(crate::Error::NoMatchingVersion)
+                        }
                         dependency::version::Tag::DistTag => Err(crate::Error::DistTagNotFound),
                         _ => unreachable!(),
                     };

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -941,8 +941,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                     } else if dependency.behavior.is_peer() {
                                         warn_unmet_peer_dependency(this, name, &version);
                                     } else {
-                                        // A bare specifier has an empty version
-                                        // literal and resolves as `latest`.
+                                        // A bare specifier has an empty literal.
                                         let literal = this.lockfile.str(&version.literal);
                                         let literal: &[u8] = if literal.is_empty() {
                                             b"latest"
@@ -2663,8 +2662,6 @@ fn get_or_put_resolved_package(
                         .is_dependency_of_workspace_in(t, dependency_id)
                 });
 
-            // Set when the `latest` tag points at a deprecated version, so the
-            // resolution ran with npm's `*`-range fallback instead of the tag.
             let mut deprecated_latest_fallback = false;
             let version_result: Npm::FindVersionResult = match version.tag {
                 _ if latest_for_target => manifest.find_by_dist_tag_with_filter(
@@ -2791,9 +2788,7 @@ fn get_or_put_resolved_package(
 
                     return match version.tag {
                         dependency::version::Tag::Npm => Err(crate::Error::NoMatchingVersion),
-                        // A deprecated `latest` resolves like the range `*`
-                        // (npm parity), so report a version mismatch, not a
-                        // missing tag.
+                        // The `latest` tag exists but resolved as the range `*`.
                         dependency::version::Tag::DistTag if deprecated_latest_fallback => {
                             Err(crate::Error::NoMatchingVersion)
                         }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -944,8 +944,11 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                         // A bare specifier has an empty version
                                         // literal and resolves as `latest`.
                                         let literal = this.lockfile.str(&version.literal);
-                                        let literal: &[u8] =
-                                            if literal.is_empty() { b"latest" } else { literal };
+                                        let literal: &[u8] = if literal.is_empty() {
+                                            b"latest"
+                                        } else {
+                                            literal
+                                        };
                                         bun_ast::add_error_pretty!(
                                             this.log_mut(),
                                             None,

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -68,9 +68,9 @@ impl PackageManager {
                     .manifests
                     .by_name_hash_in_memory(package_name, name_hash)?;
 
+                // Matches resolution: a deprecated `latest` is not "available".
                 if let Some(latest_version) = manifest
-                    .find_by_dist_tag_with_filter(
-                        b"latest",
+                    .find_by_latest_tag_with_filter(
                         self.options.minimum_release_age_ms,
                         self.options.minimum_release_age_excludes,
                     )
@@ -391,6 +391,12 @@ impl PackageManager {
                         Output::err_generic(
                             "<b>{}<r><d> failed to resolve<r>",
                             (failed_dep.version.literal.fmt(string_buf),),
+                        );
+                    } else if failed_dep.version.literal.slice(string_buf).is_empty() {
+                        // A bare specifier: print the name without a dangling `@`.
+                        Output::err_generic(
+                            "<b>{}<r><d> failed to resolve<r>",
+                            (bstr::BStr::new(failed_dep.name.slice(string_buf)),),
                         );
                     } else {
                         Output::err_generic(

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -737,7 +737,11 @@ pub struct PackageVersion {
 
     /// `hasInstallScript` field in registry API.
     pub(crate) has_install_script: bool,
-    pub(crate) _padding_tail: [u8; 2],
+
+    /// `"deprecated"` field in registry API (true when the version carries a
+    /// non-empty deprecation message).
+    pub(crate) deprecated: bool,
+    pub(crate) _padding_tail: [u8; 1],
 
     /// Unix timestamp when this version was published (0 if unknown)
     pub(crate) publish_timestamp_ms: f64,
@@ -765,7 +769,8 @@ impl Default for PackageVersion {
             cpu: Architecture::ALL,
             libc: Libc::NONE,
             has_install_script: false,
-            _padding_tail: [0; 2],
+            deprecated: false,
+            _padding_tail: [0; 1],
             publish_timestamp_ms: 0.0,
         }
     }
@@ -823,14 +828,18 @@ const _: () = {
         offset_of!(PackageVersion, man_dir)
             == offset_of!(PackageVersion, _padding_before_man_dir) + 4
     );
-    // gap between `has_install_script` (bool, ends at 230) and `publish_timestamp_ms` (align 8 → 232)
+    // gap between `deprecated` (bool, ends at 231) and `publish_timestamp_ms` (align 8 → 232)
     assert!(
-        offset_of!(PackageVersion, _padding_tail)
+        offset_of!(PackageVersion, deprecated)
             == offset_of!(PackageVersion, has_install_script) + size_of::<bool>()
     );
     assert!(
+        offset_of!(PackageVersion, _padding_tail)
+            == offset_of!(PackageVersion, deprecated) + size_of::<bool>()
+    );
+    assert!(
         offset_of!(PackageVersion, publish_timestamp_ms)
-            == offset_of!(PackageVersion, _padding_tail) + 2
+            == offset_of!(PackageVersion, _padding_tail) + 1
     );
 };
 
@@ -933,8 +942,9 @@ pub mod package_manifest {
         // - v0.0.5: added bundled dependencies
         // - v0.0.6: changed semver major/minor/patch to each use u64 instead of u32
         // - v0.0.7: added version publish times and extended manifest flag for minimum release age
+        // - v0.0.8: added per-version `deprecated` flag (stored in a former padding byte)
         const HEADER_BYTES: &'static str =
-            concat!("#!/usr/bin/env bun\n", "bun-npm-manifest-cache-v0.0.7\n");
+            concat!("#!/usr/bin/env bun\n", "bun-npm-manifest-cache-v0.0.8\n");
 
         // Field order is hardcoded (descending alignment). Re-verify if the
         // layout changes.
@@ -1470,12 +1480,14 @@ pub mod package_manifest {
                 let bin_tag_at =
                     core::mem::offset_of!(PackageVersion, bin) + core::mem::offset_of!(Bin, tag);
                 let install_script_at = core::mem::offset_of!(PackageVersion, has_install_script);
+                let deprecated_at = core::mem::offset_of!(PackageVersion, deprecated);
                 for raw_pkg in raw
                     .as_chunks::<{ core::mem::size_of::<PackageVersion>() }>()
                     .0
                 {
                     if !matches!(raw_pkg[bin_tag_at], 0..=4)
                         || !matches!(raw_pkg[install_script_at], 0 | 1)
+                        || !matches!(raw_pkg[deprecated_at], 0 | 1)
                     {
                         return Ok(None);
                     }
@@ -1598,6 +1610,7 @@ impl PackageManifest {
         group_buf: &[u8],
         minimum_release_age_ms: f64,
         newest_filtered: &mut Option<Semver::Version>,
+        skip_deprecated: bool,
     ) -> Option<FindVersionResult<'a>> {
         let mut prev_package_blocked_from_age: Option<&PackageVersion> = None;
         let mut best_version: Option<FindResult<'a>> = None;
@@ -1613,6 +1626,9 @@ impl PackageManifest {
             let version = versions[i];
             if group.satisfies(version, group_buf, &self.string_buf) {
                 let package = &packages[i];
+                if skip_deprecated && package.deprecated {
+                    continue;
+                }
                 if Self::is_package_version_too_recent(package, minimum_release_age_ms) {
                     if newest_filtered.is_none() {
                         *newest_filtered = Some(version);
@@ -1828,6 +1844,82 @@ impl PackageManifest {
         FindVersionResult::Err(FindVersionError::AllVersionsTooRecent)
     }
 
+    /// Resolution for the `latest` dist-tag, matching how npm resolves a bare
+    /// specifier (`npm install pkg` resolves the range `*` with a preference
+    /// for the `latest` tag): the tagged version wins, even when it is a
+    /// prerelease, unless that version is deprecated. When `latest` points at
+    /// a deprecated version, npm skips the tag and takes the highest release
+    /// that satisfies `*`, sorting deprecated versions last. `*` never matches
+    /// a prerelease, so the fallback fails when only prereleases exist.
+    pub fn find_by_latest_tag_with_filter(
+        &self,
+        minimum_release_age_ms: Option<f64>,
+        exclusions: Option<&[&[u8]]>,
+    ) -> FindVersionResult<'_> {
+        let latest_is_deprecated = self
+            .find_by_dist_tag(b"latest")
+            .is_some_and(|result| result.package.deprecated);
+        if !latest_is_deprecated {
+            return self.find_by_dist_tag_with_filter(b"latest", minimum_release_age_ms, exclusions);
+        }
+
+        let releases = self.pkg.releases.keys.get(&self.versions);
+        let packages = self.pkg.releases.values.get(&self.package_versions);
+
+        let min_age_gate_ms = match minimum_release_age_ms {
+            Some(min_age_ms) if !self.should_exclude_from_age_filter(exclusions) => {
+                Some(min_age_ms)
+            }
+            _ => None,
+        };
+        let Some(min_age_ms) = min_age_gate_ms else {
+            let mut i = releases.len();
+            while i > 0 {
+                i -= 1;
+                if !packages[i].deprecated {
+                    return FindVersionResult::Found(FindResult {
+                        version: releases[i],
+                        package: &packages[i],
+                    });
+                }
+            }
+            // Every release is deprecated: npm still installs the highest one.
+            if let (Some(&version), Some(package)) = (releases.last(), packages.last()) {
+                return FindVersionResult::Found(FindResult { version, package });
+            }
+            return FindVersionResult::Err(FindVersionError::NotFound);
+        };
+
+        let star = Semver::query::Group::star();
+        let mut newest_filtered: Option<Semver::Version> = None;
+        if let Some(result) = self.search_version_list(
+            releases,
+            packages,
+            &star,
+            b"",
+            min_age_ms,
+            &mut newest_filtered,
+            true,
+        ) {
+            return result;
+        }
+        if newest_filtered.is_some() {
+            return FindVersionResult::Err(FindVersionError::AllVersionsTooRecent);
+        }
+        if let Some(result) = self.search_version_list(
+            releases,
+            packages,
+            &star,
+            b"",
+            min_age_ms,
+            &mut newest_filtered,
+            false,
+        ) {
+            return result;
+        }
+        FindVersionResult::Err(FindVersionError::NotFound)
+    }
+
     pub fn find_best_version_with_filter(
         &self,
         group: &Semver::query::Group,
@@ -1892,6 +1984,7 @@ impl PackageManifest {
             group_buf,
             min_age_ms,
             &mut newest_filtered,
+            false,
         ) {
             return result;
         }
@@ -1904,6 +1997,7 @@ impl PackageManifest {
                 group_buf,
                 min_age_ms,
                 &mut newest_filtered,
+                false,
             ) {
                 return result;
             }
@@ -2436,6 +2530,16 @@ impl PackageManifest {
                     version_obj.and_then(|o| o.get(b"hasInstallScript"))
                 {
                     package_version.has_install_script = *val;
+                }
+
+                // The registry stores the deprecation message as a string. An
+                // empty string means the version was un-deprecated.
+                if let Some(deprecated) = version_obj.and_then(|o| o.get(b"deprecated")) {
+                    package_version.deprecated = match deprecated {
+                        JSON::E::JsonValue::String(str) => !str.slice().is_empty(),
+                        JSON::E::JsonValue::Boolean(val) => *val,
+                        _ => false,
+                    };
                 }
 
                 'bin: {

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1860,7 +1860,11 @@ impl PackageManifest {
             .find_by_dist_tag(b"latest")
             .is_some_and(|result| result.package.deprecated);
         if !latest_is_deprecated {
-            return self.find_by_dist_tag_with_filter(b"latest", minimum_release_age_ms, exclusions);
+            return self.find_by_dist_tag_with_filter(
+                b"latest",
+                minimum_release_age_ms,
+                exclusions,
+            );
         }
 
         let releases = self.pkg.releases.keys.get(&self.versions);

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1902,9 +1902,6 @@ impl PackageManifest {
         ) {
             return result;
         }
-        if newest_filtered.is_some() {
-            return FindVersionResult::Err(FindVersionError::AllVersionsTooRecent);
-        }
         if let Some(result) = self.search_version_list(
             releases,
             packages,
@@ -1915,6 +1912,9 @@ impl PackageManifest {
             false,
         ) {
             return result;
+        }
+        if newest_filtered.is_some() {
+            return FindVersionResult::Err(FindVersionError::AllVersionsTooRecent);
         }
         FindVersionResult::Err(FindVersionError::NotFound)
     }

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -738,8 +738,7 @@ pub struct PackageVersion {
     /// `hasInstallScript` field in registry API.
     pub(crate) has_install_script: bool,
 
-    /// `"deprecated"` field in registry API (true when the version carries a
-    /// non-empty deprecation message).
+    /// `"deprecated"` field in registry API (a non-empty deprecation message).
     pub(crate) deprecated: bool,
     pub(crate) _padding_tail: [u8; 1],
 
@@ -1844,13 +1843,9 @@ impl PackageManifest {
         FindVersionResult::Err(FindVersionError::AllVersionsTooRecent)
     }
 
-    /// Resolution for the `latest` dist-tag, matching how npm resolves a bare
-    /// specifier (`npm install pkg` resolves the range `*` with a preference
-    /// for the `latest` tag): the tagged version wins, even when it is a
-    /// prerelease, unless that version is deprecated. When `latest` points at
-    /// a deprecated version, npm skips the tag and takes the highest release
-    /// that satisfies `*`, sorting deprecated versions last. `*` never matches
-    /// a prerelease, so the fallback fails when only prereleases exist.
+    /// The `latest` tag wins, prerelease or not, unless that version is
+    /// deprecated. Then, like npm's `*` range: highest release, non-deprecated
+    /// preferred, prereleases excluded (so only-prerelease packuments fail).
     pub fn find_by_latest_tag_with_filter(
         &self,
         minimum_release_age_ms: Option<f64>,
@@ -2536,8 +2531,7 @@ impl PackageManifest {
                     package_version.has_install_script = *val;
                 }
 
-                // The registry stores the deprecation message as a string. An
-                // empty string means the version was un-deprecated.
+                // An empty message means the version was un-deprecated.
                 if let Some(deprecated) = version_obj.and_then(|o| o.get(b"deprecated")) {
                     package_version.deprecated = match deprecated {
                         JSON::E::JsonValue::String(str) => !str.slice().is_empty(),

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1246,8 +1246,9 @@ fn later_than(
         return Box::default();
     }
     let manifest_buf: &[u8] = &manifest.string_buf;
+    // Matches resolution: a deprecated `latest` is not "available".
     let latest = manifest
-        .find_by_dist_tag_with_filter(b"latest", min_age, excludes)
+        .find_by_latest_tag_with_filter(min_age, excludes)
         .unwrap()
         .map(|found| found.version)
         .filter(|latest| latest.order(v, manifest_buf, manifest_buf) == Ordering::Greater);

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -1188,10 +1188,13 @@ fn plan_edges(
                 (v, Some(v), later_than(manifest, v, min_age, excludes))
             } else {
                 let tag = want.version.dist_tag().tag.slice(buf);
-                let Some(found) = manifest
-                    .find_by_dist_tag_with_filter(tag, min_age, excludes)
-                    .unwrap()
-                else {
+                // Matches how re-resolution handles a deprecated `latest`.
+                let result = if tag == b"latest" {
+                    manifest.find_by_latest_tag_with_filter(min_age, excludes)
+                } else {
+                    manifest.find_by_dist_tag_with_filter(tag, min_age, excludes)
+                };
+                let Some(found) = result.unwrap() else {
                     continue;
                 };
                 if found.version.order(inst.current, manifest_buf, buf) == Ordering::Equal {

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -472,6 +472,21 @@ impl Group {
         }
     }
 
+    /// The `*` range (`>=0.0.0`): matches every release and no prerelease.
+    pub fn star() -> Group {
+        Group {
+            head: List {
+                head: Query {
+                    range: Range::init_wildcard(Version::default(), Wildcard::Major),
+                    next: None,
+                },
+                tail: None,
+                next: None,
+            },
+            ..Default::default()
+        }
+    }
+
     pub fn is_exact(&self) -> bool {
         self.head.next.is_none()
             && self.head.head.next.is_none()

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -2936,3 +2936,114 @@ it("bun add --trust keeps the new package when another --trust package is alread
     },
   });
 });
+
+describe("deprecated latest dist-tag", () => {
+  const packageJSON = { name: "foo", version: "0.0.1" };
+
+  async function runAdd(args: string[]) {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "add", ...args],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    return { out, err, exitCode };
+  }
+
+  it("fails when latest is a deprecated prerelease and no stable version exists", async () => {
+    const urls: string[] = [];
+    setHandler(
+      dummyRegistry(urls, {
+        "0.0.5-rc.123456789": { as: "0.0.5", deprecated: "bootstrap placeholder" },
+        latest: "0.0.5-rc.123456789",
+      }),
+    );
+    await writeFile(join(package_dir, "package.json"), JSON.stringify(packageJSON));
+
+    const { out, err, exitCode } = await runAdd(["baz"]);
+    expect(err).toContain('No version matching "latest" found for specifier "baz"');
+    expect(out).not.toContain("installed");
+    expect(exitCode).toBe(1);
+    expect(urls).toEqual([`${root_url}/baz`]);
+  });
+
+  it("falls back to the highest non-deprecated stable version when latest is deprecated", async () => {
+    const urls: string[] = [];
+    setHandler(
+      dummyRegistry(urls, {
+        "0.0.3": {},
+        "0.0.5": { deprecated: "broken release" },
+        latest: "0.0.5",
+      }),
+    );
+    await writeFile(join(package_dir, "package.json"), JSON.stringify(packageJSON));
+
+    const { out, err, exitCode } = await runAdd(["baz"]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("installed baz@0.0.3");
+    expect(exitCode).toBe(0);
+    expect(await file(join(package_dir, "package.json")).json()).toEqual({
+      ...packageJSON,
+      dependencies: { baz: "^0.0.3" },
+    });
+  });
+
+  it("falls back to a stable version when latest is a deprecated prerelease", async () => {
+    const urls: string[] = [];
+    setHandler(
+      dummyRegistry(urls, {
+        "0.0.3": {},
+        "0.0.5-rc.123456789": { as: "0.0.5", deprecated: "use the stable release" },
+        latest: "0.0.5-rc.123456789",
+      }),
+    );
+    await writeFile(join(package_dir, "package.json"), JSON.stringify(packageJSON));
+
+    const { out, err, exitCode } = await runAdd(["baz"]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("installed baz@0.0.3");
+    expect(exitCode).toBe(0);
+  });
+
+  it("still installs a prerelease latest that is not deprecated", async () => {
+    const urls: string[] = [];
+    setHandler(
+      dummyRegistry(urls, {
+        "0.0.3": {},
+        "0.0.5-rc.123456789": { as: "0.0.5" },
+        latest: "0.0.5-rc.123456789",
+      }),
+    );
+    await writeFile(join(package_dir, "package.json"), JSON.stringify(packageJSON));
+
+    const { out, err, exitCode } = await runAdd(["baz"]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("installed baz@0.0.5-rc.123456789");
+    expect(exitCode).toBe(0);
+  });
+
+  it("still follows an explicit dist-tag that points at a deprecated version", async () => {
+    const urls: string[] = [];
+    const registry = dummyRegistry(urls, {
+      "0.0.3": {},
+      "0.0.5-rc.123456789": { as: "0.0.5", deprecated: "bootstrap placeholder" },
+      latest: "0.0.5-rc.123456789",
+    });
+    setHandler(async request => {
+      const response = await registry(request);
+      if (request.url.endsWith(".tgz")) return response;
+      const manifest = await response.json();
+      manifest["dist-tags"].rc = "0.0.5-rc.123456789";
+      return Response.json(manifest);
+    });
+    await writeFile(join(package_dir, "package.json"), JSON.stringify(packageJSON));
+
+    const { out, err, exitCode } = await runAdd(["baz@rc"]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("installed baz@0.0.5-rc.123456789");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2884,6 +2884,51 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  it('should skip a deprecated latest-tagged version for a "latest" dependency', async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(
+        ctx,
+        dummyRegistryForContext(ctx, urls, {
+          "0.0.3": {},
+          "0.0.5": { deprecated: "broken release" },
+          latest: "0.0.5",
+        }),
+      );
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            baz: "latest",
+          },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await stderr.text();
+      expect(err).not.toContain("error:");
+      expect(err).toContain("Saved lockfile");
+      const out = await stdout.text();
+      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
+        expect.stringContaining("bun install v1."),
+        "",
+        "+ baz@0.0.3",
+        "",
+        "1 package installed",
+      ]);
+      expect(await exited).toBe(0);
+      expect(urls.sort()).toEqual([`${ctx.registry_url}baz`, `${ctx.registry_url}baz-0.0.3.tgz`]);
+    });
+  });
+
   it("should install latest with prereleases", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -830,6 +830,46 @@ describe("minimum-release-age", () => {
           });
         }
 
+        // TEST PACKAGE: deprecated-latest-package (`latest` tag -> deprecated
+        // prerelease; the only non-deprecated release is too recent; the older
+        // stable release is deprecated but old enough).
+        if (url.pathname === "/deprecated-latest-package") {
+          return Response.json({
+            name: "deprecated-latest-package",
+            "dist-tags": { latest: "2.0.0-rc.1" },
+            versions: {
+              "1.0.0": {
+                name: "deprecated-latest-package",
+                version: "1.0.0",
+                deprecated: "old broken release",
+                dist: {
+                  tarball: `${mockRegistryUrl}/deprecated-latest-package/-/deprecated-latest-package-1.0.0.tgz`,
+                },
+              },
+              "1.2.0": {
+                name: "deprecated-latest-package",
+                version: "1.2.0",
+                dist: {
+                  tarball: `${mockRegistryUrl}/deprecated-latest-package/-/deprecated-latest-package-1.2.0.tgz`,
+                },
+              },
+              "2.0.0-rc.1": {
+                name: "deprecated-latest-package",
+                version: "2.0.0-rc.1",
+                deprecated: "bootstrap placeholder",
+                dist: {
+                  tarball: `${mockRegistryUrl}/deprecated-latest-package/-/deprecated-latest-package-2.0.0-rc.1.tgz`,
+                },
+              },
+            },
+            time: {
+              "1.0.0": daysAgo(30),
+              "1.2.0": daysAgo(0.04),
+              "2.0.0-rc.1": daysAgo(30),
+            },
+          });
+        }
+
         // Serve tarballs
         if (url.pathname.includes(".tgz")) {
           // Match both regular and scoped package tarballs
@@ -1240,6 +1280,36 @@ describe("minimum-release-age", () => {
       // Should NOT error with "No version matching"
       expect(stderr.toLowerCase()).not.toContain("no version matching");
       expect(stderr.toLowerCase()).not.toContain("blocked by minimum-release-age");
+    });
+  });
+
+  describe("deprecated latest tag", () => {
+    test("falls back to an older deprecated stable when newer releases are too recent", async () => {
+      using dir = tempDir("deprecated-latest-min-age", {
+        "package.json": JSON.stringify({
+          dependencies: { "deprecated-latest-package": "latest" },
+        }),
+        "bunfig.toml": Bun.TOML.stringify({
+          install: {
+            minimumReleaseAge: 2 * SECONDS_PER_DAY,
+            registry: mockRegistryUrl,
+          },
+        }),
+      });
+
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      const lockfile = await Bun.file(`${dir}/bun.lock`).text();
+      expect(lockfile).toContain("deprecated-latest-package@1.0.0");
+      expect(exitCode).toBe(0);
     });
   });
 


### PR DESCRIPTION
Fixes #40310

### Problem
- `bun add omo-ai` installs `0.0.0-beta.0`, a 415-byte deprecated placeholder with no `bin`. npm fails with `ETARGET No matching version found for omo-ai@*`.
- The cause: a bare specifier resolves through the `latest` dist-tag, and `find_by_dist_tag` (src/install/npm.rs:1554) returns the tagged version with no deprecation check. Bun never parsed the packument's `deprecated` field at all.

### Fix
- `PackageVersion` gains a `deprecated: bool`, parsed from the packument and stored in a former padding byte (size stays 240, manifest cache header bumped to v0.0.8).
- `find_by_latest_tag_with_filter` resolves the `latest` tag with npm's rule: the tag wins, prerelease or not, unless the tagged version is deprecated. Then it takes the highest stable release, prefers non-deprecated ones, and fails when only prereleases exist. An explicit tag other than `latest` still resolves exactly.
- Verified against npm 11 with a local registry on six shapes (matrix in Notes). Bun now matches npm on all of them.
- Verified: `test/cli/install/bun-add.test.ts` (5 new tests, 3 fail on stock bun) and `test/cli/install/bun-install.test.ts` (1 new). Also ran `bun-install.test.ts`, `bun-install-registry.test.ts`, `minimum-release-age.test.ts`, `bun-update.test.ts`, `bun-update-transitive.test.ts`.

### Background
- A dist-tag is a named pointer (`latest`, `beta`) in the packument. A bare `bun add pkg` becomes the tag `latest`.
- npm-pick-manifest prefers `dist-tags.latest` for the `*` range but only when the manifest is not deprecated. Its `*` scan excludes prereleases and sorts deprecated versions last.
- The deprecated-prerelease-`latest` shape is what npm's trusted-publishing bootstrap flow leaves behind, so it recurs.
- #36630 adds the same `deprecated` manifest flag for the semver-range path (#7571, #25314). This PR covers the dist-tag path. Whichever lands second has a small mechanical rebase in `npm.rs`.

<details><summary>Notes</summary>

npm 11.16.0 probed against a local registry (and the real `omo-ai`):

| packument shape | npm bare install | bun before | bun after |
|---|---|---|---|
| `latest` = prerelease, not deprecated | installs the prerelease | same | same |
| `latest` = deprecated prerelease, only prereleases exist (`omo-ai`) | ETARGET | installs placeholder | error `No version matching "latest"` |
| `latest` = deprecated stable, older stable exists | older stable | deprecated stable | older stable |
| `latest` = deprecated prerelease, stable exists | stable | prerelease | stable |
| every stable deprecated | highest deprecated stable | same | same |
| explicit `pkg@beta` tag | follows the tag | same | same |

The issue frames the divergence as prerelease handling, but npm installs a non-deprecated prerelease `latest` just like bun does (first row). The real trigger for npm's refusal is the `deprecated` field: `npm-pick-manifest` skips the `latest` preference when `mani.deprecated` is set, and the `*` range scan then excludes prereleases. `omo-ai@0.0.0-beta.0` is deprecated ("Bootstrap placeholder so trusted publishing (OIDC) could be configured").

npm quirk not replicated: `npm i pkg@latest` (explicit) follows the tag even when deprecated, while bare `npm i pkg` refuses. Bun cannot distinguish the two spellings (both carry the dist-tag `latest`), so both get the safe bare-install semantics. An exact version or another tag still installs the deprecated version.

Other details:
- The `(vX available)` hints (`format_later_version_in_cache` and `later_than` in `update_transitive.rs`) and the transitive update plan's dist-tag rows now use the same resolution, so they never advertise a deprecated `latest` that a bare add would not pick.
- With `minimumReleaseAge`, the fallback reuses `search_version_list` (new `skip_deprecated` flag) over a `*` group (`Group::star()`, new in `bun_semver`). If the only non-deprecated stable releases are too recent, the resolution reports the age error instead of sidestepping to a deprecated version.
- The "failed to resolve" summary line printed `pkg@ failed to resolve` for a bare specifier (empty version literal). It now prints the name alone, and the "No version matching" error prints `latest` instead of `""`.
- `bun update --latest`, `bun outdated`, and `bun pm view` keep literal tag semantics: they report what `latest` points at.
- Review follow-ups: the minimum-release-age path tries the deprecated fallback before it reports the age error, with a test for that ordering.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts, test/cli/install/bun-add.test.ts

<!-- robobun:evidence:end -->
