### PR TITLE
test(bake): speed up dev/hot.test.ts and tighten its assertions

### DIFF
--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -1,9 +1,14 @@
 // Hot tests ensure that the `import.meta.hot` interface is functional
+//
+// Every devTest boots a dev server and a happy-dom client. Together they cost
+// about half a second per case, so cases that start from the same project are
+// written as one sequence of edits on one server. Each step asserts the exact
+// console output of the update it triggers.
 import { expect } from "bun:test";
 import { renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { devTest, emptyHtmlFile } from "../bake-harness";
 
-devTest("import.meta.hot.accept basic", {
+devTest("import.meta.hot.accept: self-accept callbacks, then accept([deps])", {
   files: {
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
@@ -11,10 +16,19 @@ devTest("import.meta.hot.accept basic", {
     "index.ts": `
       console.log("Hello, world!");
     `,
+    // Imported by a later version of index.ts
+    "counter.ts": `
+      export const count = 1;
+    `,
+    "name.ts": `
+      export const name = "Alice";
+    `,
   },
   async test(dev) {
     await using c = await dev.client("/");
     await c.expectMessage("Hello, world!");
+
+    // A module that does not accept reloads the page when it changes.
     await c.expectReload(async () => {
       await dev.write(
         "index.ts",
@@ -28,6 +42,8 @@ devTest("import.meta.hot.accept basic", {
       );
     });
     await c.expectMessage("Hello, Bun!");
+
+    // The previous version's callback runs with the new module's exports.
     await dev.write(
       "index.ts",
       `
@@ -40,6 +56,9 @@ devTest("import.meta.hot.accept basic", {
       `,
     );
     await c.expectMessage(["method"], "Bun");
+
+    // A version without accept() is still swapped in, because the version it
+    // replaces accepted. The new body runs before the old callback.
     await dev.write(
       "index.ts",
       `
@@ -47,10 +66,76 @@ devTest("import.meta.hot.accept basic", {
       `,
     );
     await c.expectMessage("Without anything.", []);
+
+    // Now nothing accepts, so the next change reloads again.
     await c.expectReload(async () => {
       await dev.writeNoChanges("index.ts");
     });
     await c.expectMessage("Without anything.");
+
+    // accept([deps], cb): updates to the listed imports are applied in place.
+    await c.expectReload(async () => {
+      await dev.write(
+        "index.ts",
+        `
+          import { count } from "./counter.ts";
+          import { name } from "./name.ts";
+          console.log("Initial: " + name + " " + count);
+          globalThis.read = () => name + " " + count;
+
+          import.meta.hot.accept(["./counter.ts", "./name.ts"], (newModules) => {
+            if (newModules[0]) console.log("Counter updated: " + newModules[0].count);
+            if (newModules[1]) console.log("Name updated: " + newModules[1].name);
+          });
+        `,
+      );
+    });
+    await c.expectMessage("Initial: Alice 1");
+
+    await dev.write(
+      "counter.ts",
+      `
+        export const count = 2;
+      `,
+    );
+    await c.expectMessage("Counter updated: 2");
+    // The importer's live bindings see the new export.
+    expect(await c.js<string>`read()`).toBe("Alice 2");
+
+    await dev.write(
+      "name.ts",
+      `
+        export const name = "Bob";
+      `,
+    );
+    await c.expectMessage("Name updated: Bob");
+    expect(await c.js<string>`read()`).toBe("Bob 2");
+
+    // Both dependencies in one update
+    {
+      await using batch = await dev.batchChanges();
+      await dev.write(
+        "counter.ts",
+        `
+          export const count = 3;
+        `,
+      );
+      await dev.write(
+        "name.ts",
+        `
+          export const name = "Charlie";
+        `,
+      );
+    }
+    await c.expectMessageInAnyOrder("Counter updated: 3", "Name updated: Charlie");
+    expect(await c.js<string>`read()`).toBe("Charlie 3");
+
+    // Accepting dependencies does not make a module self-accepting: editing it
+    // reloads the page, and the fresh page sees the updated dependencies.
+    await c.expectReload(async () => {
+      await dev.writeNoChanges("index.ts");
+    });
+    await c.expectMessage("Initial: Charlie 3");
   },
 });
 devTest("import.meta.hot.accept patches imports", {
@@ -106,7 +191,6 @@ devTest("import.meta.hot.accept patches imports", {
   },
 });
 devTest("import.meta.hot.accept specifier", {
-  timeoutMultiplier: 3,
   files: {
     "index.html": emptyHtmlFile({
       scripts: ["a.ts"],
@@ -143,252 +227,111 @@ devTest("import.meta.hot.accept specifier", {
     `,
   },
   async test(dev) {
-    {
-      await using c = await dev.client("/", {
-        errors: [
-          "b.ts:3:24: error: Dependencies to `import.meta.hot.accept` must be statically analyzable module specifiers matching direct imports.",
-        ],
-      });
-      await dev.patch("b.ts", {
-        find: "oh no",
-        replace: "./d.ts",
-        errors: [
-          "b.ts:3:24: error: Dependencies to `import.meta.hot.accept` must be statically analyzable module specifiers matching direct imports.",
-        ],
-      });
-      await c.expectReload(async () => {
-        await dev.patch("b.ts", { find: "./d.ts", replace: "./d" });
-      });
-      // Module evaluation order is guaranteed since there are no top-level
-      // await. `hmr-module.ts` does not use promises for synchronous ESM.
-      await c.expectMessage("D", "B", "C", "A", "end");
-      await c.expectReload(async () => {
-        // D -> C -> A causes a page reload.
-        await dev.write(
-          "d.ts",
-          `
-            console.log("D2");
-            export default "hey2!";
-          `,
-        );
-      });
-      await c.expectMessage("D2", "B", "C", "A");
-    }
-    await dev.write(
-      "c.ts",
-      `
-        import './d';
-        import './unrelated';
-        console.log("C");
-        import.meta.hot.accept();
-      `,
-    );
-    {
-      await using c = await dev.client("/");
-      await c.expectMessage("D2", "B", "C", "A");
+    await using c = await dev.client("/", {
+      errors: [
+        "b.ts:3:24: error: Dependencies to `import.meta.hot.accept` must be statically analyzable module specifiers matching direct imports.",
+      ],
+    });
+    await dev.patch("b.ts", {
+      find: "oh no",
+      replace: "./d.ts",
+      errors: [
+        "b.ts:3:24: error: Dependencies to `import.meta.hot.accept` must be statically analyzable module specifiers matching direct imports.",
+      ],
+    });
+    await c.expectReload(async () => {
+      await dev.patch("b.ts", { find: "./d.ts", replace: "./d" });
+    });
+    // Module evaluation order is guaranteed since there are no top-level
+    // await. `hmr-module.ts` does not use promises for synchronous ESM.
+    await c.expectMessage("D", "B", "C", "A", "end");
+    await c.expectReload(async () => {
+      // D -> C -> A causes a page reload.
       await dev.write(
         "d.ts",
         `
-          console.log("D3");
-          export default "hey3!";
+          console.log("D2");
+          export default "hey2!";
         `,
       );
-      await c.expectMessage("D3", "C", "B:hey3!");
-
+    });
+    await c.expectMessage("D2", "B", "C", "A");
+    // C does not accept yet, so making it self-accept reloads one more time.
+    await c.expectReload(async () => {
       await dev.write(
         "c.ts",
         `
           import './d';
           import './unrelated';
           console.log("C");
-          import.meta.hot.accept("oh no", (newModule) => {
-            console.log('C:' + newModule.default);
-          });
-        `,
-        {
-          errors: [
-            "c.ts:4:24: error: Dependencies to `import.meta.hot.accept` must be statically analyzable module specifiers matching direct imports.",
-          ],
-        },
-      );
-      await dev.patch("c.ts", {
-        find: "oh no",
-        replace: "./d",
-      });
-      await c.expectMessage("C"); // no-reload because prev self-accepted
-      await dev.write(
-        "d.ts",
-        `
-          console.log("D4");
-          export default "hey4!";
           import.meta.hot.accept();
         `,
       );
-      // This order is guaranteed regardless of top-level await if it had existed.
-      await c.expectMessage("D4", "B:hey4!", "C:hey4!");
-      await dev.write(
-        "d.ts",
-        `
-          console.log("D5");
-          export default "hey5!";
-          import.meta.hot.accept();
-        `,
-      );
-      await c.expectMessage("D5", "B:hey5!", "C:hey5!");
-      await c.hardReload();
-      await c.expectMessage("D5", "B", "C", "A");
-      await dev.write(
-        "d.ts",
-        `
-          console.log("D6");
-          export default "hey6!";
-          import.meta.hot.accept();
-        `,
-      );
-      await c.expectMessage("D6", "B:hey6!", "C:hey6!");
-    }
-  },
-});
-devTest("import.meta.hot.accept multiple modules", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import { count } from "./counter.ts";
-      import { name } from "./name.ts";
-      console.log("Initial: " + name + " " + count);
-      
-      import.meta.hot.accept(["./counter.ts", "./name.ts"], (newModules) => {
-        if (newModules[0]) console.log("Counter updated: " + newModules[0].count);
-        if (newModules[1]) console.log("Name updated: " + newModules[1].name);
-      });
-    `,
-    "counter.ts": `
-      export const count = 1;
-    `,
-    "name.ts": `
-      export const name = "Alice";
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("Initial: Alice 1");
-
+    });
+    await c.expectMessage("D2", "B", "C", "A");
     await dev.write(
-      "counter.ts",
+      "d.ts",
       `
-        export const count = 2;
+        console.log("D3");
+        export default "hey3!";
       `,
     );
-
-    await c.expectMessage("Counter updated: 2");
-
-    await dev.write(
-      "name.ts",
-      `
-        export const name = "Bob";
-      `,
-    );
-
-    await c.expectMessage("Name updated: Bob");
-
-    // Test updating both files
-    {
-      await using batch = await dev.batchChanges();
-      await dev.write(
-        "counter.ts",
-        `
-          export const count = 3;
-        `,
-      );
-      await dev.write(
-        "name.ts",
-        `
-          export const name = "Charlie";
-        `,
-      );
-    }
-
-    await c.expectMessageInAnyOrder("Counter updated: 3", "Name updated: Charlie");
-  },
-});
-devTest("import.meta.hot.data persistence", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      // Initialize or retrieve stored value
-      import.meta.hot.data.count ??= 0;
-      console.log("Initial count: " + import.meta.hot.data.count);
-      
-      // Increment the count on each evaluation
-      import.meta.hot.data.count++;
-
-      // By using hot.data, you opt into implicit self-acceptance
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("Initial count: 0");
-    await dev.writeNoChanges("index.ts");
-    await c.expectMessage("Initial count: 1");
-    await dev.writeNoChanges("index.ts");
-    await c.expectMessage("Initial count: 2");
-    await dev.writeNoChanges("index.ts");
-    await c.expectMessage("Initial count: 3");
-  },
-});
-devTest("import.meta.hot.dispose cleanup", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      console.log("Setting up");
-      const id = setInterval(() => {}, 1000);
-      
-      import.meta.hot.dispose(() => {
-        console.log("Cleaning up");
-        clearInterval(id);
-      });
-      
-      import.meta.hot.accept();
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("Setting up");
+    await c.expectMessage("D3", "C", "B:hey3!");
 
     await dev.write(
-      "index.ts",
+      "c.ts",
       `
-        console.log("Setting up again");
-        const id = setInterval(() => {}, 1000);
-        
-        import.meta.hot.dispose(() => {
-          console.log("Cleaning up");
-          clearInterval(id);
+        import './d';
+        import './unrelated';
+        console.log("C");
+        import.meta.hot.accept("oh no", (newModule) => {
+          console.log('C:' + newModule.default);
         });
-        
+      `,
+      {
+        errors: [
+          "c.ts:4:24: error: Dependencies to `import.meta.hot.accept` must be statically analyzable module specifiers matching direct imports.",
+        ],
+      },
+    );
+    await dev.patch("c.ts", {
+      find: "oh no",
+      replace: "./d",
+    });
+    await c.expectMessage("C"); // no-reload because prev self-accepted
+    await dev.write(
+      "d.ts",
+      `
+        console.log("D4");
+        export default "hey4!";
         import.meta.hot.accept();
       `,
     );
-
-    await c.expectMessage("Cleaning up", "Setting up again");
-
+    // This order is guaranteed regardless of top-level await if it had existed.
+    await c.expectMessage("D4", "B:hey4!", "C:hey4!");
     await dev.write(
-      "index.ts",
+      "d.ts",
       `
-        console.log("Third setup");
+        console.log("D5");
+        export default "hey5!";
+        import.meta.hot.accept();
       `,
     );
-
-    await c.expectMessage("Cleaning up", "Third setup");
+    await c.expectMessage("D5", "B:hey5!", "C:hey5!");
+    await c.hardReload();
+    await c.expectMessage("D5", "B", "C", "A");
+    await dev.write(
+      "d.ts",
+      `
+        console.log("D6");
+        export default "hey6!";
+        import.meta.hot.accept();
+      `,
+    );
+    await c.expectMessage("D6", "B:hey6!", "C:hey6!");
   },
 });
-devTest("import.meta.hot invalid usage", {
+devTest("import.meta.hot: indirect usage, dispose, on/off, update acks, data", {
   files: {
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
@@ -424,51 +367,138 @@ devTest("import.meta.hot invalid usage", {
       '"import.meta.hot.accept" must be directly called with string literals for the specifiers. This way, the bundler can pre-process the arguments.',
       "import.meta.hot cannot be used indirectly.",
     );
-  },
-});
-devTest("import.meta.hot on/off events", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      console.log("Initial setup");
-      // Add event listener
-      import.meta.hot.on("vite:beforeUpdate", () => {
-        console.log("Before update event");
-      });
-      import.meta.hot.accept();
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("Initial setup");
+
+    // dispose: the callback runs before the new body, and receives hot.data.
+    // None of the accept() calls above registered, so this change reloads.
+    await c.expectReload(async () => {
+      await dev.write(
+        "index.ts",
+        `
+          console.log("Setting up");
+          import.meta.hot.dispose(data => {
+            console.log("Cleaning up, got " + (data === import.meta.hot.data ? "hot.data" : "something else"));
+          });
+          import.meta.hot.accept();
+        `,
+      );
+    });
+    await c.expectMessage("Setting up");
     await dev.write(
       "index.ts",
       `
-        console.log("Updated setup");
-        // Events implementation is partial according to docs
-        import.meta.hot.on("vite:beforeUpdate", () => {
-          console.log("Before update event 2");
+        console.log("Setting up again");
+        import.meta.hot.dispose(() => {
+          console.log("Cleaning up again");
         });
-        const handler = () => {
-          console.log("Another handler");
-        };
-        import.meta.hot.on("vite:beforeUpdate", handler);
-        // Remove the handler
-        import.meta.hot.off("vite:beforeUpdate", handler);
         import.meta.hot.accept();
       `,
     );
-    await c.expectMessage("Updated setup");
+    await c.expectMessage("Cleaning up, got hot.data", "Setting up again");
+    // The replaced version accepted, so a version without accept() is still
+    // swapped in, and its predecessor is disposed.
+    await dev.write(
+      "index.ts",
+      `
+        console.log("Third setup");
+      `,
+    );
+    await c.expectMessage("Cleaning up again", "Third setup");
+
+    // on/off: bun:beforeUpdate fires before the new body runs, and
+    // bun:afterUpdate fires after it. Listeners belong to the version that
+    // registered them and are removed when that version is replaced.
+    await c.expectReload(async () => {
+      await dev.write(
+        "index.ts",
+        `
+          console.log("Listening");
+          import.meta.hot.on("bun:beforeUpdate", () => {
+            console.log("before update (v1)");
+          });
+          import.meta.hot.on("bun:afterUpdate", () => {
+            console.log("after update (v1)");
+          });
+          import.meta.hot.accept();
+        `,
+      );
+    });
+    await c.expectMessage("Listening");
+    await dev.write(
+      "index.ts",
+      `
+        console.log("Listening again");
+        import.meta.hot.on("bun:beforeUpdate", () => {
+          console.log("before update (v2)");
+        });
+        const removed = () => {
+          console.log("removed handler");
+        };
+        import.meta.hot.on("bun:beforeUpdate", removed);
+        import.meta.hot.off("bun:beforeUpdate", removed);
+        import.meta.hot.on("bun:afterUpdate", () => {
+          console.log("after update (v2)");
+        });
+        import.meta.hot.accept();
+      `,
+    );
+    // v1's afterUpdate listener is gone by the time the update finishes.
+    await c.expectMessage("before update (v1)", "Listening again", "after update (v2)");
     await dev.write(
       "index.ts",
       `
         console.log("Third update");
+        globalThis.marker = "initial";
         import.meta.hot.accept();
       `,
     );
-    await c.expectMessage("Third update");
+    // v2 is still live when beforeUpdate fires, so only off() keeps the
+    // removed handler quiet here.
+    await c.expectMessage("before update (v2)", "Third update");
+
+    // dev.write resolves only after the new module body has run. The body
+    // parks on a promise until the test releases it. The client acks a hot
+    // update from bun:afterUpdate, so no ack may arrive while it is parked.
+    const acksBefore = c.acksReceived;
+    const pendingWrite = dev.write(
+      "index.ts",
+      `
+        console.log("parked");
+        await new Promise(resolve => {
+          globalThis.release = resolve;
+        });
+        globalThis.marker = "updated";
+        import.meta.hot.accept();
+      `,
+    );
+    await c.expectMessage("parked");
+    // The client answers this round trip after anything it already sent, so an
+    // ack sent on receipt of the update frame would be counted by now.
+    expect(await c.js`globalThis.marker`).toBe("initial");
+    expect(c.acksReceived).toBe(acksBefore);
+    await c.js`globalThis.release()`;
+    await pendingWrite;
+    expect(await c.js`globalThis.marker`).toBe("updated");
+
+    // data: writing to hot.data opts into implicit self-acceptance, the object
+    // survives each version, and dispose() receives it.
+    await dev.write(
+      "index.ts",
+      `
+        import.meta.hot.data.count ??= 0;
+        console.log("Initial count: " + import.meta.hot.data.count);
+        import.meta.hot.data.count++;
+        import.meta.hot.dispose(data => {
+          console.log("Disposing with count " + data.count);
+        });
+      `,
+    );
+    await c.expectMessage("Initial count: 0");
+    await dev.writeNoChanges("index.ts");
+    await c.expectMessage("Disposing with count 1", "Initial count: 1");
+    await dev.writeNoChanges("index.ts");
+    await c.expectMessage("Disposing with count 2", "Initial count: 2");
+    await dev.writeNoChanges("index.ts");
+    await c.expectMessage("Disposing with count 3", "Initial count: 3");
   },
 });
 devTest("hmr forwards every merged inotify sub-path from a directory batch", {
@@ -609,36 +639,5 @@ devTest("hot update frames are not delivered to application websocket topics", {
       ws.onclose = null;
       ws.close();
     }
-  },
-});
-
-devTest("dev.write resolves only after the new module body has run", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      globalThis.marker = "initial";
-      console.log("ready");
-      import.meta.hot.accept();
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("ready");
-    expect(await c.js`globalThis.marker`).toBe("initial");
-
-    await dev.write(
-      "index.ts",
-      `
-        await new Promise(r => setTimeout(r, 500));
-        globalThis.marker = "updated";
-        import.meta.hot.accept();
-      `,
-      // errors: null skips the post-write expectErrorOverlay poll (5 * 200ms),
-      // which would otherwise mask a premature ack.
-      { errors: null },
-    );
-    // dev.write resolves on bun:afterUpdate, i.e. after replaceModules has
-    // awaited the 500ms TLA. Acking on WS receipt would see "initial" here.
-    expect(await c.js`globalThis.marker`).toBe("updated");
   },
 });


### PR DESCRIPTION
### Problem
- `test/bake/dev/hot.test.ts` takes 13.26s on the ubuntu 25.04 x64 release lane (build #104578) for 11 cases, 8.7s locally.
- Each `devTest` boots a dev server (60ms) and a happy-dom client (330ms). Six cases share one starting project and pay this separately.
- Two assertions cannot fail. The on/off case listens on `vite:` events, which `hmr-module.ts:233` maps to `bun::x`, so they never fire. Its `off()` handler is on an event a replaced version never sees.

### Fix
- Six single-entry cases become two sequences on one server each. The specifier case reloads its client instead of spawning a second. 11 cases and 12 clients become 6 and 6. CI, same lane and shard: 9.62s (build #104806). Locally 5.3s. 65 expects (was 60).
- The on/off section uses `bun:` names and asserts the order `beforeUpdate` (live version), new body, `afterUpdate` (new version only). Its `off()` handler is on `beforeUpdate`, so a missing `off()` fails the test.
- The update-ack step parks the new body on a promise instead of a 500ms timer. After one round trip `c.acksReceived` must not have moved. A fixture that acks on frame receipt fails it 3 of 3 runs.
- Verified: `bun bd test test/bake/dev/hot.test.ts`, 5 runs. No harness change.

### Background
- `dev.client()` is a happy-dom page in a node process. `expectMessage` asserts its exact `console.log` output since the previous call.
- `dev.write` waits for the build and the client's ack, sent from `bun:afterUpdate` and counted in `acksReceived`.
- `replaceModules` replaces an accepted version in place: `beforeUpdate`, dispose callbacks (which drop its `on()` listeners), new body, old accept callback, `afterUpdate`. A non-accepting root reloads the page.

<details><summary>Notes</summary>

Per phase, release build, measured with local timing probes in the harness (not committed): server start 58ms, client spawn to page load 330ms to 430ms, each `dev.write` 55ms to 70ms, page reload 15ms to 30ms on top of its write, hardReload 68ms, client dispose 10ms, gracefulExit 30ms.

What each write waits on: 50ms of the 55ms is the fixed coalesce sleep in `batchChanges` (`bake-harness.ts`, from #34691). It lets split Windows `ReadDirectoryChangesW` events land before the batch is released. The dev server has no debounce of its own, so a late event would start a second bundle and a second update. This PR does not touch it. With 36 writes it is about 2s of the remaining 5.3s, the other 2s is the 6 client spawns.

Before (release, per case): accept basic 785ms, patches imports 700ms, specifier 1580ms to 1680ms, multiple modules 670ms, data 640ms, dispose 600ms, invalid usage 500ms, on/off 600ms, inotify 800ms to 900ms, app websocket 520ms to 670ms, dev.write sync 1080ms (500ms of it the top-level await).

After (release): sequence 1 980ms to 1110ms, patches imports 650ms to 710ms, specifier 1060ms to 1110ms, sequence 2 1070ms to 1150ms, inotify 710ms to 800ms, app websocket 500ms to 550ms.

Debug build (`bun bd test`, for the record only): before 31.9s and 32.9s. After 22.1s, 23.4s, 23.4s, and one 27.4s run.

CI, from the job logs of the `:ubuntu: 25.04 x64 - test-bun` shard that runs this file third: main 13.26s, this PR 9.62s. In both runs the first `dev.client()` of the file is the largest single cost, 5.5s on main and 4.2s here (server start to first `Bundled page`), because node and the 549 happy-dom modules are cold on the machine. Every later case costs 0.3s to 1.5s. That first spawn is a harness cost a per-file change cannot reach. Pre-bundling `client-fixture.mjs` with happy-dom into one file would shrink it for every bake file.

The macOS PR lane skips files whose recorded duration is 10s or more (`.buildkite/ci.mjs:833`, `--skip-slower-than=10000`). At 9.62s this file is marginally under that line again once `expected-durations.json` is regenerated.

Merged and restructured:
- "accept basic" and "accept multiple modules" are one sequence. `counter.ts` and `name.ts` are in the project from the start and imported by a later version of `index.ts`. New steps: `read()` asserts the importer's live bindings after each dependency update, and `writeNoChanges("index.ts")` asserts that a module which only accepts dependencies reloads the page, with the fresh page seeing `Initial: Charlie 3`.
- "invalid usage", "dispose cleanup", "on/off events", "dev.write resolves only after the new module body has run" and "data persistence" are one sequence, in that order. The data section is last because a module that wrote to `hot.data` is implicitly self-accepting afterwards, which would change how later sections transition.
- The specifier case: the write that makes `c.ts` self-accept now happens with the client connected, inside `expectReload`, because the old `c.ts` did not accept. The messages are the same as the old second client saw. `timeoutMultiplier: 3` dated from when each write also slept; the case now takes 1.1s against a 30s base timeout.
- dispose: the callback asserts `data === import.meta.hot.data`. The unasserted `setInterval` is gone. In the data section the dispose callback logs the count it was handed.

The inotify case (Linux only), the app websocket case (its own `bun.app.ts`) and "patches imports" keep their own servers.

Not pinned on purpose: the shape of the array passed to an `accept([deps])` callback for a batched update (`expectMessageInAnyOrder` stays), and whether a version that did not itself touch `hot.data` is self-accepting. Both are behaviors #39488 changes. #39488 also fixes the `vite:` alias and inserts about 1,100 lines into this file after the "accept multiple modules" block, so one of the two will need a rebase.

`test/expected-durations.json` still lists this file at 45s to 52s. The `update-test-durations` pipeline regenerates it from CI, so this PR does not edit it.

Ran: `test/bake/dev/hot.test.ts` with `bun bd test` 5 times and with the release build 6 times, plus the prettier check.

**Follow-up, not in this PR: run devTests concurrently.** A self-review of this change argued that the per-case boot cost belongs to the harness, which registers every case with a plain `jest.test` and kills every process in a module-level set at the end of each case (`bake-harness.ts:2074-2080`). I prototyped the change to measure it: a per-run set of owned processes instead of the global one, and `jest.test.concurrent` for non-stress cases. About 15 lines, reverted, nothing of it is in this diff.

| file | sequential | concurrent prototype |
|---|---|---|
| hot.test.ts on main, release | 8.7s | 1.6s |
| hot.test.ts this PR, release | 5.3s | 1.2s |
| hot.test.ts on main, debug | 32s | 10.9s |
| hot.test.ts this PR, debug | 23s | 9.0s |
| all of test/bake, release, 188 tests | (not measured) | 18s to 24s |

It is the bigger lever, but it is not a drop-in. 3 of 12 full-suite runs under the prototype had failures that do not happen sequentially: `bundle-8` and `bundle-15` each crashed the dev server once with `panic(main thread): abort() called` (release build, [crash report](https://bun.report/1.4.1/la27465985gGgggoG21klBi+gilD6p7q4D8j8w7D+k9w7D69l67D45m67D2lu/nD_0ri/nD0ri/nDmsj3nDwk3w5Dy9/vvB85kwvBuptxvB_0ri/nDmsj3nDwk3w5DAa)), and `server-sourcemap-1` failed twice 270ms into the case, in setup: `framework: "react"` cases share `installReactWithCache`, which concurrent cases race. Log lines of concurrent cases also interleave under the same `dev|` prefix. A harness PR needs those three fixed and a Windows and ASAN measurement first. Until then this per-file change is the safe one, and its merges do not hurt under concurrency: the file time becomes the longest single case, which is about 1.1s here either way.

Other points from the same review, and why the PR stays as it is:
- Conflict with #39488: acknowledged above. #39488 is itself conflicting with main. Its hot.test.ts hunks are additive blocks inserted after existing cases, plus a rewrite of the on/off case, so re-anchoring is mechanical.
- `vite:` coverage: the old case did not cover the alias. Its listeners never fired and nothing asserted on them. Asserting with `vite:` names on main would pin the bug. The runtime fix and its test are in #39488 (#37786 was closed in its favor).
- Failure granularity: each step in a merged sequence has a comment and an exact message list, so a failure names the step by line.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bake/dev/hot.test.ts

<!-- robobun:evidence:end -->