### PR TITLE
inspect: do not call a $$typeof getter when checking for a React element

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2189,8 +2189,7 @@ pub mod formatter {
                 });
             }
 
-            // Is this a react element? The check and `print_jsx` read the
-            // element's own data properties only, so a user getter never runs.
+            // Is this a react element? Own data property only: a user getter never runs here.
             if js_type.is_object() && js_type != jsc::JSType::ProxyObject {
                 if let Some(typeof_symbol) = value.get_own_non_observable(global_this, "$$typeof") {
                     // React 18 and below

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -5065,12 +5065,11 @@ pub mod formatter {
                 let _qs = defer_restore!(self.quote_strings, prev_quote_strings);
                 self.quote_strings = true;
 
-                // A Proxy is read through its target, as `print_proxy` does, so no trap runs.
-                let props = if props.is_cell() && props.js_type() == jsc::JSType::ProxyObject {
-                    props.get_proxy_target()
-                } else {
-                    props
-                };
+                // A Proxy is read through its innermost target, so no trap runs.
+                let mut props = props;
+                while props.is_cell() && props.js_type() == jsc::JSType::ProxyObject {
+                    props = props.get_proxy_target();
+                }
                 let Some(props_obj) = props.get_object() else {
                     writer.write_all(b" />");
                     if writer.failed {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2189,9 +2189,10 @@ pub mod formatter {
                 });
             }
 
-            // Is this a react element?
+            // Is this a react element? Inspection never runs a user getter, so
+            // a `$$typeof` accessor is not a React element.
             if js_type.is_object() && js_type != jsc::JSType::ProxyObject {
-                if let Some(typeof_symbol) = value.get_own_truthy(global_this, "$$typeof")? {
+                if let Some(typeof_symbol) = value.get_own_non_observable(global_this, "$$typeof") {
                     // React 18 and below
                     if typeof_symbol.is_same_value(
                         JSValue::symbol_for(global_this, b"react.element"),

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2189,8 +2189,8 @@ pub mod formatter {
                 });
             }
 
-            // Is this a react element? Inspection never runs a user getter, so
-            // a `$$typeof` accessor is not a React element.
+            // Is this a react element? The check and `print_jsx` read the
+            // element's own data properties only, so a user getter never runs.
             if js_type.is_object() && js_type != jsc::JSType::ProxyObject {
                 if let Some(typeof_symbol) = value.get_own_non_observable(global_this, "$$typeof") {
                     // React 18 and below
@@ -4993,7 +4993,7 @@ pub mod formatter {
             let tag_name_slice: bun_core::ZigStringSlice;
             let mut is_tag_kind_primitive = false;
 
-            if let Some(type_value) = value.get(self.global_this, "type")? {
+            if let Some(type_value) = value.get_own_non_observable(self.global_this, "type") {
                 let _tag = Tag::get_advanced(type_value, self.global_this, tag_opts)?;
 
                 if _tag.cell == jsc::JSType::Symbol {
@@ -5030,7 +5030,7 @@ pub mod formatter {
                 writer.write_all(pf!("<r>").as_bytes());
             }
 
-            if let Some(key_value) = value.get(self.global_this, "key")? {
+            if let Some(key_value) = value.get_own_non_observable(self.global_this, "key") {
                 if !key_value.is_undefined_or_null() {
                     if needs_space {
                         writer.write_all(b" key=");
@@ -5061,11 +5061,17 @@ pub mod formatter {
                 }
             }
 
-            if let Some(props) = value.get(self.global_this, "props")? {
+            if let Some(props) = value.get_own_non_observable(self.global_this, "props") {
                 let prev_quote_strings = self.quote_strings;
                 let _qs = defer_restore!(self.quote_strings, prev_quote_strings);
                 self.quote_strings = true;
 
+                // A Proxy is read through its target, as `print_proxy` does, so no trap runs.
+                let props = if props.is_cell() && props.js_type() == jsc::JSType::ProxyObject {
+                    props.get_proxy_target()
+                } else {
+                    props
+                };
                 let Some(props_obj) = props.get_object() else {
                     writer.write_all(b" />");
                     if writer.failed {
@@ -5076,13 +5082,16 @@ pub mod formatter {
                 let props_iter = jsc::JSPropertyIterator::init(
                     self.global_this,
                     props_obj,
-                    jsc::PropertyIteratorOptions {
+                    jsc::JSPropertyIteratorOptions {
                         skip_empty_name: true,
                         include_value: true,
+                        own_properties_only: true,
+                        observable: false,
+                        only_non_index_properties: false,
                     },
                 )?;
 
-                let children_prop = props.get(self.global_this, "children")?;
+                let children_prop = props.get_own_non_observable(self.global_this, "children");
                 if props_iter.len > 0 {
                     {
                         self.indent += 1;

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2373,6 +2373,7 @@ impl JSValue {
     /// `JSValue.getOwnNonObservable` — own-property lookup that never runs
     /// user code. A Proxy trap or module namespace is not consulted, and an
     /// accessor or custom property yields `None` instead of a getter call.
+    /// Like `get` and `get_own_truthy`, an `undefined` value is `None`.
     pub fn get_own_non_observable(
         self,
         global: &JSGlobalObject,
@@ -2380,7 +2381,11 @@ impl JSValue {
     ) -> Option<JSValue> {
         let name = bun_core::String::borrow_utf8(property_name.as_ref());
         let v = JSC__JSValue__getOwnNonObservable(self, global, &name);
-        if v.is_empty() { None } else { Some(v) }
+        if v.is_empty() || v.is_undefined() {
+            None
+        } else {
+            Some(v)
+        }
     }
     /// `JSValue.getOwnObject` — own-property lookup; throws "{prop} must be an
     /// object" when the own-truthy value is not an object.

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2370,6 +2370,18 @@ impl JSValue {
             _ => Ok(None),
         }
     }
+    /// `JSValue.getOwnNonObservable` — own-property lookup that never runs
+    /// user code. A Proxy trap or module namespace is not consulted, and an
+    /// accessor or custom property yields `None` instead of a getter call.
+    pub fn get_own_non_observable(
+        self,
+        global: &JSGlobalObject,
+        property_name: impl AsRef<[u8]>,
+    ) -> Option<JSValue> {
+        let name = bun_core::String::borrow_utf8(property_name.as_ref());
+        let v = JSC__JSValue__getOwnNonObservable(self, global, &name);
+        if v.is_empty() { None } else { Some(v) }
+    }
     /// `JSValue.getOwnObject` — own-property lookup; throws "{prop} must be an
     /// object" when the own-truthy value is not an object.
     pub fn get_own_object(
@@ -2710,6 +2722,11 @@ unsafe extern "C" {
     ) -> bun_core::StringView<'a>;
     safe fn JSC__JSValue__symbolFor(global: &JSGlobalObject, key: &bun_core::String) -> JSValue;
     safe fn JSC__JSValue__getOwn(
+        this: JSValue,
+        global: &JSGlobalObject,
+        name: &bun_core::String,
+    ) -> JSValue;
+    safe fn JSC__JSValue__getOwnNonObservable(
         this: JSValue,
         global: &JSGlobalObject,
         name: &bun_core::String,

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2370,9 +2370,8 @@ impl JSValue {
             _ => Ok(None),
         }
     }
-    /// `JSValue.getOwnNonObservable` — own-property lookup that never runs
-    /// user code. A Proxy trap or module namespace is not consulted, and an
-    /// accessor or custom property yields `None` instead of a getter call.
+    /// `JSValue.getOwnNonObservable` — own data property lookup that never runs
+    /// user code: an accessor, a Proxy trap or a module namespace yields `None`.
     /// Like `get` and `get_own_truthy`, an `undefined` value is `None`.
     pub fn get_own_non_observable(
         self,

--- a/src/jsc/bindings/JSPropertyIterator.cpp
+++ b/src/jsc/bindings/JSPropertyIterator.cpp
@@ -164,17 +164,15 @@ extern "C" EncodedJSValue Bun__JSPropertyIterator__getNameAndValueNonObservable(
     }
 
     PropertySlot slot(object, PropertySlot::InternalMethodType::VMInquiry, vm.ptr());
-    // getPropertySlot, not getNonIndexPropertySlot: the names can include an index
-    // (a props object with a numeric key) and getNonIndexPropertySlot asserts on one.
+    // Not getNonIndexPropertySlot: it asserts on an index name, and the names can include one.
     auto has = object->getPropertySlot(globalObject, prop, slot);
     RETURN_IF_EXCEPTION(scope, {});
     if (!has || slot.isCustom()) {
         return {};
     }
 
-    // A JS accessor is reported as its GetterSetter cell, which the formatters print as
-    // [Getter]. The getter itself never runs. A data slot is read in place: getPureResult
-    // would return null for a slot without a structure offset, such as an index property.
+    // An accessor is reported as its GetterSetter cell (printed as [Getter]) and never runs.
+    // getPureResult is null for a slot without a structure offset (an index), so read in place.
     JSValue result;
     if (slot.isAccessor()) {
         result = slot.getterSetter();

--- a/src/jsc/bindings/JSPropertyIterator.cpp
+++ b/src/jsc/bindings/JSPropertyIterator.cpp
@@ -164,17 +164,25 @@ extern "C" EncodedJSValue Bun__JSPropertyIterator__getNameAndValueNonObservable(
     }
 
     PropertySlot slot(object, PropertySlot::InternalMethodType::VMInquiry, vm.ptr());
-    auto has = object->getNonIndexPropertySlot(globalObject, prop, slot);
+    // getPropertySlot, not getNonIndexPropertySlot: the names can include an index
+    // (a props object with a numeric key) and getNonIndexPropertySlot asserts on one.
+    auto has = object->getPropertySlot(globalObject, prop, slot);
     RETURN_IF_EXCEPTION(scope, {});
-    if (!has) {
-        return {};
-    }
-    if (slot.isAccessor() || slot.isCustom()) {
+    if (!has || slot.isCustom()) {
         return {};
     }
 
-    JSValue result = slot.getPureResult();
-    RETURN_IF_EXCEPTION(scope, {});
+    // A JS accessor is reported as its GetterSetter cell, which the formatters print as
+    // [Getter]. The getter itself never runs. A data slot is read in place: getPureResult
+    // would return null for a slot without a structure offset, such as an index property.
+    JSValue result;
+    if (slot.isAccessor()) {
+        result = slot.getterSetter();
+    } else if (slot.isValue()) {
+        result = slot.getValue(globalObject, prop);
+    } else {
+        return {};
+    }
 
     *propertyName = Bun::toString(prop.impl());
     return JSValue::encode(result);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4695,9 +4695,8 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__getOwn(JSC::EncodedJSValue JSValue0
     return JSValue::encode(slotValue);
 }
 
-// Own-property lookup that never runs user code. The slot is a VM inquiry, so a
-// Proxy trap or a module namespace evaluation is skipped, and an accessor or
-// custom property yields empty instead of a getter call.
+// Own data property lookup that never runs user code: an accessor, a Proxy trap
+// or a module namespace export yields empty.
 extern "C" JSC::EncodedJSValue JSC__JSValue__getOwnNonObservable(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* globalObject, BunString* propertyName)
 {
     ASSERT_NO_PENDING_EXCEPTION(globalObject);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4695,6 +4695,27 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__getOwn(JSC::EncodedJSValue JSValue0
     return JSValue::encode(slotValue);
 }
 
+// Own-property lookup that never runs user code. The slot is a VM inquiry, so a
+// Proxy trap or a module namespace evaluation is skipped, and an accessor or
+// custom property yields empty instead of a getter call.
+extern "C" JSC::EncodedJSValue JSC__JSValue__getOwnNonObservable(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* globalObject, BunString* propertyName)
+{
+    ASSERT_NO_PENDING_EXCEPTION(globalObject);
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    JSObject* object = JSC::JSValue::decode(JSValue0).getObject();
+    if (!object) return {};
+    WTF::String propertyNameString = propertyName->tag == BunStringTag::Empty ? WTF::emptyString() : propertyName->toWTFString(BunString::ZeroCopy);
+    auto identifier = JSC::Identifier::fromString(vm, propertyNameString);
+    auto property = JSC::PropertyName(identifier);
+    PropertySlot slot(object, PropertySlot::InternalMethodType::VMInquiry, &vm);
+    bool hasSlot = object->methodTable()->getOwnPropertySlot(object, globalObject, property, slot);
+    scope.assertNoExceptionExceptTermination();
+    if (!hasSlot || !slot.isValue()) return {};
+    return JSValue::encode(slot.getValue(globalObject, property));
+}
+
 JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue arg1)
 {
     ASSERT_NO_PENDING_EXCEPTION(globalObject);

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -496,8 +496,7 @@ impl Tag {
             return Tag::get(value.get_proxy_target(), global_this);
         }
 
-        // Is this a react element? The check and the `Tag::JSX` printer read the
-        // element's own data properties only, so a user getter never runs.
+        // Is this a react element? Own data property only: a user getter never runs here.
         if js_type.is_object() && js_type != JSType::ProxyObject {
             if let Some(typeof_symbol) = value.get_own_non_observable(global_this, "$$typeof") {
                 if typeof_symbol

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -496,9 +496,10 @@ impl Tag {
             return Tag::get(value.get_proxy_target(), global_this);
         }
 
-        // Is this a react element?
+        // Is this a react element? Formatting never runs a user getter, so a
+        // `$$typeof` accessor is not a React element.
         if js_type.is_object() && js_type != JSType::ProxyObject {
-            if let Some(typeof_symbol) = value.get_own_truthy(global_this, "$$typeof")? {
+            if let Some(typeof_symbol) = value.get_own_non_observable(global_this, "$$typeof") {
                 if typeof_symbol
                     .is_same_value(JSValue::symbol_for(global_this, b"react.element"), global_this)?
                     || typeof_symbol.is_same_value(

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -2040,12 +2040,11 @@ impl<'a> Formatter<'a> {
                         let prev_quote_strings = self.quote_strings;
                         self.quote_strings = true;
 
-                        // A Proxy is read through its target, so no trap runs.
-                        let props = if props.is_cell() && props.js_type() == JSType::ProxyObject {
-                            props.get_proxy_target()
-                        } else {
-                            props
-                        };
+                        // A Proxy is read through its innermost target, so no trap runs.
+                        let mut props = props;
+                        while props.is_cell() && props.js_type() == JSType::ProxyObject {
+                            props = props.get_proxy_target();
+                        }
 
                         // `quote_strings` (and nested `indent` scopes) must be restored on
                         // every exit, including thrown exceptions. Wrap the fallible body in a

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -496,8 +496,8 @@ impl Tag {
             return Tag::get(value.get_proxy_target(), global_this);
         }
 
-        // Is this a react element? Formatting never runs a user getter, so a
-        // `$$typeof` accessor is not a React element.
+        // Is this a react element? The check and the `Tag::JSX` printer read the
+        // element's own data properties only, so a user getter never runs.
         if js_type.is_object() && js_type != JSType::ProxyObject {
             if let Some(typeof_symbol) = value.get_own_non_observable(global_this, "$$typeof") {
                 if typeof_symbol
@@ -1968,7 +1968,7 @@ impl<'a> Formatter<'a> {
                     let tag_name_slice: ZigStringSlice;
                     let mut is_tag_kind_primitive = false;
 
-                    if let Some(type_value) = value.get(self.global_this, "type")? {
+                    if let Some(type_value) = value.get_own_non_observable(self.global_this, "type") {
                         let _tag = Tag::get(type_value, self.global_this)?;
 
                         if _tag.cell == JSType::Symbol {
@@ -2012,7 +2012,7 @@ impl<'a> Formatter<'a> {
                         );
                     }
 
-                    if let Some(key_value) = value.get(self.global_this, "key")? {
+                    if let Some(key_value) = value.get_own_non_observable(self.global_this, "key") {
                         if !key_value.is_undefined_or_null() {
                             if needs_space {
                                 writer.write_all(b" key=");
@@ -2037,9 +2037,16 @@ impl<'a> Formatter<'a> {
                         }
                     }
 
-                    if let Some(props) = value.get(self.global_this, "props")? {
+                    if let Some(props) = value.get_own_non_observable(self.global_this, "props") {
                         let prev_quote_strings = self.quote_strings;
                         self.quote_strings = true;
+
+                        // A Proxy is read through its target, so no trap runs.
+                        let props = if props.is_cell() && props.js_type() == JSType::ProxyObject {
+                            props.get_proxy_target()
+                        } else {
+                            props
+                        };
 
                         // `quote_strings` (and nested `indent` scopes) must be restored on
                         // every exit, including thrown exceptions. Wrap the fallible body in a
@@ -2050,13 +2057,16 @@ impl<'a> Formatter<'a> {
                         let props_iter = JSPropertyIterator::init(
                             self.global_this,
                             props_obj,
-                            jsc::PropertyIteratorOptions {
+                            jsc::JSPropertyIteratorOptions {
                                 skip_empty_name: true,
                                 include_value: true,
+                                own_properties_only: true,
+                                observable: false,
+                                only_non_index_properties: false,
                             },
                         )?;
 
-                        let children_prop = props.get(self.global_this, "children")?;
+                        let children_prop = props.get_own_non_observable(self.global_this, "children");
                         if props_iter.len > 0 {
                             {
                                 self.indent += 1;

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -407,6 +407,41 @@ test("inline snapshot does not call a $$typeof getter", () => {
   expect(element).toMatchInlineSnapshot(`<div id="x" />`);
 });
 
+test("inline snapshot of a React element does not call getters on its type, key, props or children", () => {
+  const $$typeof = Symbol.for("react.element");
+  let called = 0;
+  const getter = {
+    get() {
+      called++;
+      throw new Error("Test failed!");
+    },
+    enumerable: true,
+  };
+  const withGetter = (target: object, name: string) => Object.defineProperty(target, name, getter);
+
+  expect(withGetter({ $$typeof, props: {} }, "type")).toMatchInlineSnapshot(`<unknown />`);
+  expect(withGetter({ $$typeof, type: "div", props: {} }, "key")).toMatchInlineSnapshot(`<div />`);
+  expect(withGetter({ $$typeof, type: "div" }, "props")).toMatchInlineSnapshot(`<div />`);
+  expect({ $$typeof, type: "div", props: withGetter({}, "children") }).toMatchInlineSnapshot(`<div />`);
+  // An accessor prop prints like every other accessor.
+  expect({ $$typeof, type: "div", props: withGetter({}, "hidden") }).toMatchInlineSnapshot(
+    `<div hidden=[native code] />`,
+  );
+  // A Proxy props object is read through its target.
+  const trap = () => {
+    called++;
+    throw new Error("Test failed!");
+  };
+  const proxyProps = new Proxy({ id: "x" }, { get: trap, ownKeys: trap, getOwnPropertyDescriptor: trap });
+  expect({ $$typeof, type: "div", props: proxyProps }).toMatchInlineSnapshot(`<div id="x" />`);
+  expect(called).toBe(0);
+
+  // Data props, including a numeric key, still print.
+  expect({ $$typeof, type: "div", key: "k", props: { 0: "a", children: "hi" } }).toMatchInlineSnapshot(
+    `<div key="k" 0="a">hi</div>`,
+  );
+});
+
 class InlineSnapshotTester {
   tmpdir: string;
   tmpid: number;

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -371,6 +371,42 @@ test("basic unchanging inline snapshot", () => {
   );
 });
 
+test("inline snapshot does not call a $$typeof getter", () => {
+  // The React element check reads `$$typeof`. An accessor is printed like any other
+  // getter and never called, so it is not mistaken for a React element.
+  let called = 0;
+  const obj = {
+    get $$typeof() {
+      called++;
+      return Symbol.for("react.element");
+    },
+  };
+  expect(obj).toMatchInlineSnapshot(`
+{
+  "$$typeof": [native code],
+}
+`);
+  expect(called).toBe(0);
+
+  const throwing = {
+    get $$typeof() {
+      throw new Error("Test failed!");
+    },
+  };
+  expect([throwing, "after"]).toMatchInlineSnapshot(`
+[
+  {
+    "$$typeof": [native code],
+  },
+  "after",
+]
+`);
+
+  // A plain data property still marks a React element.
+  const element = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: { id: "x" } };
+  expect(element).toMatchInlineSnapshot(`<div id="x" />`);
+});
+
 class InlineSnapshotTester {
   tmpdir: string;
   tmpid: number;

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -427,13 +427,14 @@ test("inline snapshot of a React element does not call getters on its type, key,
   expect({ $$typeof, type: "div", props: withGetter({}, "hidden") }).toMatchInlineSnapshot(
     `<div hidden=[native code] />`,
   );
-  // A Proxy props object is read through its target.
+  // A Proxy props object, nested or not, is read through its innermost target.
   const trap = () => {
     called++;
     throw new Error("Test failed!");
   };
   const proxyProps = new Proxy({ id: "x" }, { get: trap, ownKeys: trap, getOwnPropertyDescriptor: trap });
   expect({ $$typeof, type: "div", props: proxyProps }).toMatchInlineSnapshot(`<div id="x" />`);
+  expect({ $$typeof, type: "div", props: new Proxy(proxyProps, {}) }).toMatchInlineSnapshot(`<div id="x" />`);
   expect(called).toBe(0);
 
   // Data props, including a numeric key, still print.

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -123,6 +123,41 @@ it("does not call a $$typeof getter while checking for a React element", () => {
   expect(Bun.inspect(element)).toBe('<div id="x" />');
 });
 
+it("prints a React element without calling getters on its type, key, props or children", () => {
+  const $$typeof = Symbol.for("react.element");
+  let called = 0;
+  const getter = {
+    get() {
+      called++;
+      throw new Error("Test failed!");
+    },
+    enumerable: true,
+  };
+  const withGetter = (target, name) => Object.defineProperty(target, name, getter);
+
+  expect(Bun.inspect(withGetter({ $$typeof, props: {} }, "type"))).toBe("<unknown />");
+  expect(Bun.inspect(withGetter({ $$typeof, type: "div", props: {} }, "key"))).toBe("<div />");
+  expect(Bun.inspect(withGetter({ $$typeof, type: "div" }, "props"))).toBe("<div />");
+  expect(Bun.inspect({ $$typeof, type: "div", props: withGetter({}, "children") })).toBe("<div />");
+  // An accessor prop prints like every other accessor.
+  expect(Bun.inspect({ $$typeof, type: "div", props: withGetter({ id: "x" }, "hidden") })).toBe(
+    '<div id="x" hidden=[Getter] />',
+  );
+  // A Proxy props object is read through its target.
+  const trap = () => {
+    called++;
+    throw new Error("Test failed!");
+  };
+  const proxyProps = new Proxy({ id: "x" }, { get: trap, ownKeys: trap, getOwnPropertyDescriptor: trap });
+  expect(Bun.inspect({ $$typeof, type: "div", props: proxyProps })).toBe('<div id="x" />');
+  expect(called).toBe(0);
+
+  // Data props, including a numeric key, still print.
+  expect(Bun.inspect({ $$typeof, type: "div", key: "k", props: { 0: "a", b: 1, children: "hi" } })).toBe(
+    '<div key="k" 0="a" b=1>hi</div>',
+  );
+});
+
 it("Timeout", () => {
   const id = setTimeout(() => {}, 0);
   expect(Bun.inspect(id)).toBe(`Timeout (#${+id})`);

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -143,13 +143,14 @@ it("prints a React element without calling getters on its type, key, props or ch
   expect(Bun.inspect({ $$typeof, type: "div", props: withGetter({ id: "x" }, "hidden") })).toBe(
     '<div id="x" hidden=[Getter] />',
   );
-  // A Proxy props object is read through its target.
+  // A Proxy props object, nested or not, is read through its innermost target.
   const trap = () => {
     called++;
     throw new Error("Test failed!");
   };
   const proxyProps = new Proxy({ id: "x" }, { get: trap, ownKeys: trap, getOwnPropertyDescriptor: trap });
   expect(Bun.inspect({ $$typeof, type: "div", props: proxyProps })).toBe('<div id="x" />');
+  expect(Bun.inspect({ $$typeof, type: "div", props: new Proxy(proxyProps, {}) })).toBe('<div id="x" />');
   expect(called).toBe(0);
 
   // Data props, including a numeric key, still print.

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -82,6 +82,47 @@ it("getter/setters", () => {
   expect(Bun.inspect(obj)).toBe("{\n" + "  foo: [Getter/Setter]," + "\n" + "}");
 });
 
+it("does not call a $$typeof getter while checking for a React element", () => {
+  let called = 0;
+  const obj = {
+    get $$typeof() {
+      called++;
+      return Symbol.for("react.element");
+    },
+  };
+
+  expect(Bun.inspect(obj)).toBe("{\n" + "  $$typeof: [Getter]," + "\n" + "}");
+  expect(called).toBe(0);
+
+  const throwing = {
+    get $$typeof() {
+      called++;
+      throw new Error("Test failed!");
+    },
+  };
+
+  expect(Bun.inspect(throwing)).toBe("{\n" + "  $$typeof: [Getter]," + "\n" + "}");
+  expect(Bun.inspect([throwing, "after"])).toBe('[\n  {\n    $$typeof: [Getter],\n  }, "after"\n]');
+  expect(Bun.inspect(new Map([[1, throwing]]))).toBe("Map(1) {\n  1: {\n    $$typeof: [Getter],\n  },\n}");
+  expect(Bun.inspect(new Set([throwing]))).toBe("Set(1) {\n  {\n    $$typeof: [Getter],\n  },\n}");
+  expect(Bun.inspect({ nested: throwing })).toBe("{\n  nested: {\n    $$typeof: [Getter],\n  },\n}");
+
+  const hidden = {};
+  Object.defineProperty(hidden, "$$typeof", {
+    get() {
+      called++;
+      throw new Error("Test failed!");
+    },
+    enumerable: false,
+  });
+  expect(() => Bun.inspect(hidden)).not.toThrow();
+  expect(called).toBe(0);
+
+  // A plain data property still marks a React element.
+  const element = { $$typeof: Symbol.for("react.element"), type: "div", key: null, ref: null, props: { id: "x" } };
+  expect(Bun.inspect(element)).toBe('<div id="x" />');
+});
+
 it("Timeout", () => {
   const id = setTimeout(() => {}, 0);
   expect(Bun.inspect(id)).toBe(`Timeout (#${+id})`);
@@ -641,6 +682,21 @@ describe.concurrent("Bun.inspect when a property lookup throws", () => {
       }
     `);
     expect(result).toEqual({ stdout: "threw: getPrototypeOf trap\n", stderr: "", exitCode: 0 });
+  });
+
+  it("prints a $$typeof getter as [Getter] instead of calling it", async () => {
+    // The React element check reads `$$typeof`. Like every other property, an accessor is
+    // printed as [Getter] and never called, so a throwing getter cannot abort console.log.
+    const result = await inspectInChild(`
+      const obj = { get $$typeof() { throw new Error("boom"); } };
+      console.log(obj);
+      console.log(new Map([[1, obj], [2, "after"]]));
+    `);
+    expect(result).toEqual({
+      stdout: "{\n  $$typeof: [Getter],\n}\n" + 'Map(2) {\n  1: {\n    $$typeof: [Getter],\n  },\n  2: "after",\n}\n',
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
   it("propagates an error thrown by toJSON while formatting", () => {


### PR DESCRIPTION
### Problem
- `console.log`, `Bun.inspect` and the `bun:test` formatter call a user `$$typeof` getter on every object, so a throwing getter aborts the output. Node prints `[Getter]` and never runs it.
- Cause: the React element check in `Tag::get_advanced` (`src/jsc/ConsoleObject.rs:2194`) and `Tag::get` (`pretty_format.rs:501`) uses `get_own_truthy`, which calls the getter.
- The JSX printers also read a React element's `type`, `key`, `props` and each prop through getters.

### Fix
- Add `JSValue::get_own_non_observable`, a `VMInquiry` own-property read that returns data values only. An accessor, Proxy trap or module namespace yields `None`.
- Use it for the `$$typeof` check and the element fields. Props go through the non-observable iterator, now yielding a JS accessor as `[Getter]` and reading index keys. A Proxy `props` is read through its innermost target.
- Inspection must not run user code for a value it only displays. Real React elements have own data properties, so their output is unchanged. One that inherits `type` now prints `<unknown />`.
- Verified: `test/js/bun/util/inspect.test.js` (three new tests) and `snapshot.test.ts` (two). Stock bun fails all five. Also the console, `node:util` and `inspect-error` suites.

### Background
- Bun prints a React element as JSX. An own `$$typeof` equal to `Symbol.for("react.element")` or its React 19 and fragment variants marks one.
- A JSC `PropertySlot` says whether a property is a data value, a JS accessor (`GetterSetter`) or a native getter. `slot.getValue` runs an accessor, `slot.isValue()` marks a data value.
- `InternalMethodType::VMInquiry` is the slot mode in which a Proxy reports no property and debug builds assert that no JS runs. The uncaught error printer, the iterator's other user, drops `GetterSetter` values and is unchanged.

<details><summary>Notes</summary>

Repro under the released binary (1.4.0-canary):

```js
const o = { get $$typeof() { throw new Error("boom"); } };
try { console.log(o); } catch (e) { console.log("caught:", e.message); }   // caught: boom
console.log(new Map([[1, o], [2, "after"]]));                              // prints "Map(2) {\n  1: " then throws
let count = 0;
console.log({ get $$typeof() { count++; return 1; } });                    // prints [Getter] but count is 1
```

Node prints `{ '$$typeof': [Getter] }` for each and `count` stays 0.

`bun:test` paths: `expect(o).toMatchInlineSnapshot()` formatted a getter that returns the React symbol as `<unknown />`, and a throwing getter failed the test with `Failed to pretty format value: `. A matcher failure message (`expect(o).toBeUndefined()`) was cut to `Received: ` because the formatter threw. All three now print the accessor (`[Getter]` in console output, `[native code]` in the snapshot serializer, which is how it already prints every other accessor).

The first revision of this PR changed the `$$typeof` read only. The self-review showed that the same object's `type`, `key`, `props` and `props.children` reads, and the props iterator, still ran user getters once `$$typeof` was a data React symbol: `{ $$typeof: Symbol.for("react.element"), get type() { throw } }` aborted `console.log` at `<`. The second commit converts those reads too.

Props iterator details. The non-observable read (`Bun__JSPropertyIterator__getNameAndValueNonObservable`, behind `JSPropertyIteratorOptions { observable: false }`) used `getNonIndexPropertySlot`, which asserts on an index name in debug builds, and `getPureResult`, which returns `null` for a slot without a structure offset (an index property stored in the butterfly). Both mattered only once the JSX printer, whose props can carry numeric keys, became a caller. The read now uses `getPropertySlot` and `slot.getValue` on a `slot.isValue()` slot, which decodes the stored value and runs nothing. `get_own_non_observable` maps `undefined` to `None` like `get` does, so the four field reads are drop-in replacements (`type: undefined` still prints `<unknown />`).

Edge cases checked under the debug build with `BUN_JSC_validateExceptionChecks=1` (no assertion, no getter runs): throwing getters for `type` (`<unknown />`), `key`, `props` and `props.children` (`<div />`), a throwing getter prop (`<div a=1 b=[Getter] c=3 />`), numeric prop keys (`<div 0="zero" 1="one" x=1 />`), `props` as a Proxy, or a Proxy of a Proxy, with throwing traps (`<div a=1 />`, read through the innermost target), `type: undefined`, `children: undefined`, a component function `type`, a Proxy whose target has a `$$typeof` getter, a null-prototype object, a class instance with a prototype getter, an array, a function, a typed array, a Map and an Error with an own `$$typeof` accessor, and a module namespace that exports `$$typeof`.

Not changed here: `type.displayName` / `Symbol.toStringTag` on a component are still read through `get_name_property` (a `static get displayName()` on a class component is a legitimate source for the tag name). An accessor `children` on a props object now hits the same stray separator (`<div id="x"  />`) that `children: undefined` already hits on main. #38957 fixes that separator logic. `react.transitional.element` is missing from the `bun:test` formatter's check on main. #38934 adds it.

`test/js/node/util/node-inspect-tests/parallel/util-inspect.test.js` "no assertion failures 2" and the parseArgs stress test hit their 5 s timeout under the debug ASAN build on this machine. Both time out the same way without this diff. `snapshot.test.ts` "error snapshots" expects colored output and fails the same way on the stock binary when stdout is not a TTY.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->