### PR TITLE
test(password): speed up password.test.ts and tighten its assertions

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -341,27 +341,23 @@ export async function runFixtureMaxRSS(fixture: string, expected: unknown) {
 /**
  * Runs `cmd` (a script that prints `{"deltaMiB": number}` as its last stdout
  * line) under bun with ASAN quarantine disabled, and asserts the delta is below
- * `release` MiB (or `debug` MiB under ASAN/debug builds). `env` adds to or
- * overrides `bunEnv` for the child.
+ * `release` MiB (or `debug` MiB under ASAN/debug builds).
  */
 export async function expectRssDeltaBelow(
   cmd: string[] /* args after bunExe(), e.g. ["--smol", "-e", code] or [fixturePath] */,
   bounds: { release: number; debug: number },
-  env: NodeJS.Dict<string> = {},
 ): Promise<void> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...cmd],
     env: {
       ...bunEnv,
-      ...env,
       // ASAN's quarantine pins freed blocks and keeps RSS at peak.
-      ASAN_OPTIONS: [
-        env.ASAN_OPTIONS ?? bunEnv.ASAN_OPTIONS,
-        "quarantine_size_mb=0",
-        "thread_local_quarantine_size_kb=0",
-      ]
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
         .filter(Boolean)
         .join(":"),
+      // mimalloc returns freed pages to the OS only after a delay, so a reading
+      // taken right after a free can still hold about 1 MiB of them.
+      MIMALLOC_PURGE_DELAY: "0",
     },
     stdout: "pipe",
     stderr: "pipe",

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -341,16 +341,19 @@ export async function runFixtureMaxRSS(fixture: string, expected: unknown) {
 /**
  * Runs `cmd` (a script that prints `{"deltaMiB": number}` as its last stdout
  * line) under bun with ASAN quarantine disabled, and asserts the delta is below
- * `release` MiB (or `debug` MiB under ASAN/debug builds).
+ * `release` MiB (or `debug` MiB under ASAN/debug builds). `env` adds to or
+ * overrides `bunEnv` for the child.
  */
 export async function expectRssDeltaBelow(
   cmd: string[] /* args after bunExe(), e.g. ["--smol", "-e", code] or [fixturePath] */,
   bounds: { release: number; debug: number },
+  env: NodeJS.Dict<string> = {},
 ): Promise<void> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...cmd],
     env: {
       ...bunEnv,
+      ...env,
       // ASAN's quarantine pins freed blocks and keeps RSS at peak.
       ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
         .filter(Boolean)

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -355,7 +355,11 @@ export async function expectRssDeltaBelow(
       ...bunEnv,
       ...env,
       // ASAN's quarantine pins freed blocks and keeps RSS at peak.
-      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
+      ASAN_OPTIONS: [
+        env.ASAN_OPTIONS ?? bunEnv.ASAN_OPTIONS,
+        "quarantine_size_mb=0",
+        "thread_local_quarantine_size_kb=0",
+      ]
         .filter(Boolean)
         .join(":"),
     },

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -3,85 +3,132 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 
 const placeholder = "hey";
+const argonVariants = ["argon2id", "argon2i", "argon2d"] as const;
+type ArgonVariant = (typeof argonVariants)[number];
 
-// argon2id iterates so slowly under debug/ASAN that the 60 000 warm-up
-// iterations blow past the 90 s test timeout before the leak check even
-// starts. The leak numbers are only meaningful on release anyway — skip
-// the whole suite on debug so the rest of the file can run.
+// PHC string: a 32-byte salt and a 32-byte hash, both base64 without padding.
+function argon2Hash(algorithm: ArgonVariant, memoryCost: number, timeCost: number) {
+  return new RegExp(
+    `^\\$${algorithm}\\$v=19\\$m=${memoryCost},t=${timeCost},p=1\\$[A-Za-z0-9+/]{43}\\$[A-Za-z0-9+/]{43}$`,
+  );
+}
+
+// Modular crypt string: a 22-char salt and a 31-char hash in bcrypt's own base64 alphabet.
+function bcryptHash(cost: number) {
+  return new RegExp(`^\\$2b\\$${String(cost).padStart(2, "0")}\\$[./A-Za-z0-9]{53}$`);
+}
+
+const typeError = (code: string, message: string) => expect.objectContaining({ name: "TypeError", code, message });
+const unknownAlgorithm = (fn: "hash" | "verify") =>
+  typeError(
+    "ERR_INVALID_ARG_TYPE",
+    `Expected algorithm to be a unknown algorithm, expected one of: "bcrypt", "argon2id", "argon2d", "argon2i" (default is "argon2id") for '${fn}'.`,
+  );
+const verifyError = (code: string, reason: string) =>
+  expect.objectContaining({ code, message: `Password verification failed with error "${reason}"` });
+const unsupportedAlgorithm = verifyError("PASSWORD_UNSUPPORTED_ALGORITHM", "UnsupportedAlgorithm");
+const invalidEncoding = verifyError("PASSWORD_INVALID_ENCODING", "InvalidEncoding");
+const weakParameters = verifyError("PASSWORD_WEAK_PARAMETERS", "WeakParameters");
+
+// The leak this guards (#29913) was the encoded hash string, about 100 bytes
+// per hash() or hashSync() call that was never freed. On a release build it
+// shows as 110 to 170 bytes of RSS growth per call, so the check needs tens of
+// thousands of calls and a flat baseline. The JIT is off because tier-up
+// allocates several MiB in the middle of the loop. The JS heap is collected
+// every 2000 calls because each call leaves a string behind. ASAN's quarantine
+// is off because it pins freed blocks. With that, the fixed build stays within
+// 0.2 MiB over 60k calls.
+//
+// A debug build hashes about 200x slower, so the suite does not run there.
 describe.skipIf(isDebug)("does not leak", () => {
-  async function run(code: string) {
+  async function expectRssGrowthBelow(calls: string, warmup: number, measured: number, limitMiB: number) {
+    const code = /* js */ `
+      const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+      const opts = { algorithm: "argon2id", memoryCost: 8, timeCost: 1 };
+      const chunk = 2000;
+      async function run(n) {
+        for (let done = 0; done < n; done += chunk) {
+          ${calls}
+          Bun.gc(true);
+        }
+      }
+      await run(${warmup});
+      const before = rss();
+      await run(${measured});
+      console.log(JSON.stringify({ deltaMiB: (rss() - before) / 1024 / 1024 }));
+    `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "--smol", "-e", code],
-      env: bunEnv,
-      stdout: "inherit",
+      env: {
+        ...bunEnv,
+        BUN_JSC_useJIT: "0",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
+          .filter(Boolean)
+          .join(":"),
+      },
+      stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    // Only fail on a non-zero exit. ASAN builds may emit startup warnings on
-    // stderr that are not errors, so don't require stderr to be empty.
-    if (exitCode !== 0) throw new Error(stderr || `exited with code ${exitCode}`);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr.trim()).toBe("");
+    const { deltaMiB } = JSON.parse(stdout);
+    expect(deltaMiB).toBeLessThan(limitMiB);
+    expect(exitCode).toBe(0);
   }
 
+  // Unfixed (Bun 1.3.13): 5.6 to 9.6 MiB. Fixed: 0 +- 0.2 MiB. ASAN's redzones
+  // make a leaked block larger, and its allocator is noisier without a quarantine.
   test("hashSync", async () => {
-    await run(/* js */ `
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
-        const opts = { algorithm: "argon2id", memoryCost: 8, timeCost: 1 };
-        // Large warm-up so the JSC heap and allocator arenas reach steady state
-        // before we start measuring (debug/ASAN builds especially need this).
-        for (let i = 0; i < 60000; i++) Bun.password.hashSync("hey", opts);
-        Bun.gc(true);
-        const before = rss();
-        for (let i = 0; i < 60000; i++) Bun.password.hashSync("hey", opts);
-        Bun.gc(true);
-        const growthMB = (rss() - before) / 1024 / 1024;
-        // ASAN's free quarantine (default 256 MB) plus redzones and glibc page
-        // retention inflate RSS even when nothing is leaking.
-        const limit = ${isASAN ? 400 : 4};
-        if (growthMB > limit) throw new Error("leaked " + growthMB.toFixed(2) + "MB (limit " + limit + "MB)");
-      `);
-  }, 90_000);
+    await expectRssGrowthBelow(
+      /* js */ `for (let i = 0; i < chunk; i++) Bun.password.hashSync("hey", opts);`,
+      4_000,
+      60_000,
+      isASAN ? 6 : 4,
+    );
+  });
 
+  // Unfixed: 12 to 14 MiB. Fixed: 0 MiB.
   test("hash", async () => {
-    await run(/* js */ `
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
-        const opts = { algorithm: "argon2id", memoryCost: 8, timeCost: 1 };
-        async function batch(n) {
-          const promises = [];
-          for (let i = 0; i < n; i++) promises.push(Bun.password.hash("hey", opts));
-          await Promise.all(promises);
-        }
-        for (let i = 0; i < 500; i++) await batch(100);
-        Bun.gc(true);
-        const before = rss();
-        for (let i = 0; i < 2000; i++) await batch(100);
-        Bun.gc(true);
-        const growthMB = (rss() - before) / 1024 / 1024;
-        // ASAN's free quarantine (default 256 MB) plus redzones and glibc page
-        // retention inflate RSS even when nothing is leaking.
-        const limit = ${isASAN ? 400 : 20};
-        if (growthMB > limit) throw new Error("leaked " + growthMB.toFixed(2) + "MB (limit " + limit + "MB)");
-      `);
-  }, 90_000);
+    await expectRssGrowthBelow(
+      /* js */ `
+        for (let j = 0; j < chunk / 100; j++) {
+          const batch = [];
+          for (let i = 0; i < 100; i++) batch.push(Bun.password.hash("hey", opts));
+          await Promise.all(batch);
+        }`,
+      10_000,
+      100_000,
+      isASAN ? 8 : 6,
+    );
+  });
 });
 
 describe("hash", () => {
-  describe("arguments parsing", () => {
-    for (let hash of [password.hash, password.hashSync]) {
+  for (const [name, hash, sync] of [
+    ["hash", password.hash, false],
+    ["hashSync", password.hashSync, true],
+  ] as const) {
+    describe(`${name} argument parsing`, () => {
       test("no blank password allowed", () => {
-        expect(() => hash("")).toThrow("password must not be empty");
+        expect(() => hash("")).toThrow(typeError("ERR_INVALID_ARG_TYPE", "password must not be empty"));
       });
 
       test("password is required", () => {
         // @ts-expect-error
-        expect(() => hash()).toThrow();
+        expect(() => hash()).toThrow(
+          typeError("ERR_MISSING_ARGS", "Not enough arguments to 'hash'. Expected 1, got 0."),
+        );
       });
 
       test("invalid algorithm throws", () => {
         // @ts-expect-error
-        expect(() => hash(placeholder, "scrpyt")).toThrow();
+        expect(() => hash(placeholder, "scrpyt")).toThrow(unknownAlgorithm("hash"));
         // @ts-expect-error
-        expect(() => hash(placeholder, 123)).toThrow();
+        expect(() => hash(placeholder, 123)).toThrow(
+          typeError("ERR_INVALID_ARG_TYPE", "Expected algorithm to be a string for 'hash'."),
+        );
 
+        // An object is read as options, so its toString() is not an algorithm name.
         expect(() =>
           hash(placeholder, {
             // @ts-expect-error
@@ -89,124 +136,82 @@ describe("hash", () => {
               return "scrypt";
             },
           }),
-        ).toThrow();
+        ).toThrow(typeError("ERR_INVALID_ARG_TYPE", "Expected options.algorithm to be a string for 'hash'."));
 
         expect(() =>
           hash(placeholder, {
             // @ts-expect-error
             algorithm: "poop",
           }),
-        ).toThrow();
+        ).toThrow(unknownAlgorithm("hash"));
 
-        expect(() =>
-          hash(placeholder, {
-            algorithm: "bcrypt",
-            cost: Infinity,
-          }),
-        ).toThrow();
-
-        expect(() =>
-          hash(placeholder, {
-            algorithm: "argon2id",
-            memoryCost: -1,
-          }),
-        ).toThrow();
+        const rounds = typeError("ERR_INVALID_ARG_TYPE", "Rounds must be an integer between 4 and 31");
+        for (const cost of [Infinity, -999, 3, 32]) {
+          expect(() => hash(placeholder, { algorithm: "bcrypt", cost })).toThrow(rounds);
+        }
+        // @ts-expect-error
+        expect(() => hash(placeholder, { algorithm: "bcrypt", cost: "10" })).toThrow(
+          typeError("ERR_INVALID_ARG_TYPE", "Expected cost to be a number for 'hash'."),
+        );
 
         // argon2 requires `memoryCost >= 8 * parallelism`; Bun hard-codes
         // `parallelism = 1`, so anything below 8 must throw rather than be
         // silently clamped (regression coverage for #30960).
-        for (const invalid of [1, 3, 7]) {
-          expect(() =>
-            hash(placeholder, {
-              algorithm: "argon2id",
-              memoryCost: invalid,
-            }),
-          ).toThrow("Memory cost must be at least 8");
+        const memory = typeError("ERR_INVALID_ARG_TYPE", "Memory cost must be at least 8");
+        for (const memoryCost of [-1, 0, 1, 3, 7]) {
+          expect(() => hash(placeholder, { algorithm: "argon2id", memoryCost })).toThrow(memory);
         }
 
-        expect(() =>
-          hash(placeholder, {
-            algorithm: "argon2id",
-            timeCost: -1,
-          }),
-        ).toThrow();
-
-        expect(() =>
-          hash(placeholder, {
-            algorithm: "bcrypt",
-            cost: -999,
-          }),
-        ).toThrow();
+        const time = typeError("ERR_INVALID_ARG_TYPE", "Time cost must be greater than 0");
+        for (const timeCost of [-1, 0]) {
+          expect(() => hash(placeholder, { algorithm: "argon2id", timeCost })).toThrow(time);
+        }
+        // @ts-expect-error
+        expect(() => hash(placeholder, { algorithm: "argon2id", timeCost: "2" })).toThrow(
+          typeError("ERR_INVALID_ARG_TYPE", "Expected timeCost to be a number for 'hash'."),
+        );
       });
 
       test("cost values are range-checked before ToInt32 narrowing", () => {
         // These used to wrap modulo 2^32 (cost: 2^32 + 4 hashed with cost 4)
         // or truncate (cost: 4.5 hashed with cost 4) instead of throwing.
-        expect(() =>
-          hash(placeholder, {
-            algorithm: "bcrypt",
-            cost: 2 ** 32 + 4,
-          }),
-        ).toThrow("Rounds must be an integer between 4 and 31");
+        const rounds = typeError("ERR_INVALID_ARG_TYPE", "Rounds must be an integer between 4 and 31");
+        for (const cost of [2 ** 32 + 4, 4.5]) {
+          expect(() => hash(placeholder, { algorithm: "bcrypt", cost })).toThrow(rounds);
+        }
 
-        expect(() =>
-          hash(placeholder, {
-            algorithm: "bcrypt",
-            cost: 4.5,
-          }),
-        ).toThrow("Rounds must be an integer between 4 and 31");
+        const time = typeError("ERR_INVALID_ARG_TYPE", "Time cost must be an integer between 1 and 4294967295");
+        for (const timeCost of [2 ** 32 + 2, 1.5, Infinity]) {
+          expect(() => hash(placeholder, { algorithm: "argon2id", timeCost })).toThrow(time);
+        }
 
-        expect(() =>
-          hash(placeholder, {
-            algorithm: "argon2id",
-            timeCost: 2 ** 32 + 2,
-          }),
-        ).toThrow("Time cost must be an integer between 1 and 4294967295");
+        const memory = typeError("ERR_INVALID_ARG_TYPE", "Memory cost must be an integer between 8 and 4294967295");
+        for (const memoryCost of [2 ** 32 + 4608, 8.5, Infinity]) {
+          expect(() => hash(placeholder, { algorithm: "argon2id", memoryCost })).toThrow(memory);
+        }
 
-        expect(() =>
-          hash(placeholder, {
-            algorithm: "argon2id",
-            timeCost: 1.5,
-          }),
-        ).toThrow("Time cost must be an integer between 1 and 4294967295");
-
-        expect(() =>
-          hash(placeholder, {
-            algorithm: "argon2id",
-            memoryCost: 2 ** 32 + 4608,
-          }),
-        ).toThrow("Memory cost must be an integer between 8 and 4294967295");
-
-        expect(() =>
-          hash(placeholder, {
-            algorithm: "argon2id",
-            memoryCost: 8.5,
-          }),
-        ).toThrow("Memory cost must be an integer between 8 and 4294967295");
-
-        // Non-finite values: NaN and -Infinity fail the lower-bound check,
-        // +Infinity fails the integer/upper-bound check.
+        // NaN and -Infinity fail the lower-bound check first.
         for (const timeCost of [NaN, -Infinity]) {
           expect(() => hash(placeholder, { algorithm: "argon2id", timeCost })).toThrow(
-            "Time cost must be greater than 0",
+            typeError("ERR_INVALID_ARG_TYPE", "Time cost must be greater than 0"),
           );
         }
-        expect(() => hash(placeholder, { algorithm: "argon2id", timeCost: Infinity })).toThrow(
-          "Time cost must be an integer between 1 and 4294967295",
-        );
         for (const memoryCost of [NaN, -Infinity]) {
           expect(() => hash(placeholder, { algorithm: "argon2id", memoryCost })).toThrow(
-            "Memory cost must be at least 8",
+            typeError("ERR_INVALID_ARG_TYPE", "Memory cost must be at least 8"),
           );
         }
-        expect(() => hash(placeholder, { algorithm: "argon2id", memoryCost: Infinity })).toThrow(
-          "Memory cost must be an integer between 8 and 4294967295",
-        );
       });
 
       test("coercion throwing doesn't crash", () => {
+        // The async form still coerces the password with ToString, so only the
+        // sync form's error is pinned.
+        const notAPassword = typeError(
+          "ERR_INVALID_ARG_TYPE",
+          "Expected password to be a string or TypedArray for 'hash'.",
+        );
         // @ts-expect-error
-        expect(() => hash(Symbol())).toThrow();
+        expect(() => hash(Symbol())).toThrow(sync ? notAPassword : TypeError);
         expect(() =>
           // @ts-expect-error
           hash({
@@ -214,10 +219,10 @@ describe("hash", () => {
               throw new Error("toString() failed");
             },
           }),
-        ).toThrow();
+        ).toThrow(sync ? notAPassword : Error);
       });
 
-      for (let ArrayBufferView of [
+      for (const ArrayBufferView of [
         Uint8Array,
         Uint16Array,
         Uint32Array,
@@ -230,21 +235,35 @@ describe("hash", () => {
         ArrayBuffer,
       ]) {
         test(`empty ${ArrayBufferView.name} throws`, () => {
-          expect(() => hash(new ArrayBufferView(0))).toThrow("password must not be empty");
+          expect(() => hash(new ArrayBufferView(0))).toThrow(
+            typeError("ERR_INVALID_ARG_TYPE", "password must not be empty"),
+          );
         });
       }
-    }
-  });
+    });
+  }
 });
 
 describe("verify", () => {
-  describe("arguments parsing", () => {
-    for (let verify of [password.verify, password.verifySync]) {
+  for (const [name, verify, sync] of [
+    ["verify", password.verify, false],
+    ["verifySync", password.verifySync, true],
+  ] as const) {
+    describe(`${name} argument parsing`, () => {
       test("minimum args", () => {
         // @ts-expect-error
-        expect(() => verify()).toThrow();
+        expect(() => verify()).toThrow(
+          typeError("ERR_MISSING_ARGS", "Not enough arguments to 'verify'. Expected 2, got 0."),
+        );
+        // The message does not count the arguments it did get.
         // @ts-expect-error
-        expect(() => verify("")).toThrow();
+        expect(() => verify("")).toThrow(
+          expect.objectContaining({
+            name: "TypeError",
+            code: "ERR_MISSING_ARGS",
+            message: expect.stringMatching(/^Not enough arguments to 'verify'\./),
+          }),
+        );
       });
 
       test("empty values return false", async () => {
@@ -254,9 +273,10 @@ describe("verify", () => {
 
       test("invalid algorithm throws", () => {
         // @ts-expect-error
-        expect(() => verify(placeholder, "$", "scrpyt")).toThrow();
+        expect(() => verify(placeholder, "$", "scrpyt")).toThrow(unknownAlgorithm("verify"));
+        const notAString = typeError("ERR_INVALID_ARG_TYPE", "Expected algorithm to be a string for 'verify'.");
         // @ts-expect-error
-        expect(() => verify(placeholder, "$", 123)).toThrow();
+        expect(() => verify(placeholder, "$", 123)).toThrow(notAString);
         expect(() =>
           // @ts-expect-error
           verify(placeholder, "$", {
@@ -264,40 +284,38 @@ describe("verify", () => {
               return "scrypt";
             },
           }),
-        ).toThrow();
+        ).toThrow(notAString);
       });
 
       test("coercion throwing doesn't crash", () => {
+        // The async form still coerces both arguments with ToString, so only
+        // the sync form's errors are pinned.
+        const notAPassword = typeError(
+          "ERR_INVALID_ARG_TYPE",
+          "Expected password to be a string or TypedArray for 'verify'.",
+        );
+        const notAHash = typeError("ERR_INVALID_ARG_TYPE", "Expected hash to be a string or TypedArray for 'verify'.");
+        const throwing = {
+          toString() {
+            throw new Error("toString() failed");
+          },
+        };
         // @ts-expect-error
-        expect(() => verify(Symbol(), Symbol())).toThrow();
-        expect(() =>
-          verify(
-            // @ts-expect-error
-            {
-              toString() {
-                throw new Error("toString() failed");
-              },
-            },
-            "valid",
-          ),
-        ).toThrow();
-        expect(() =>
-          // @ts-expect-error
-          verify("valid", {
-            toString() {
-              throw new Error("toString() failed");
-            },
-          }),
-        ).toThrow();
+        expect(() => verify(Symbol(), Symbol())).toThrow(sync ? notAPassword : TypeError);
+        // @ts-expect-error
+        expect(() => verify(throwing, "valid")).toThrow(sync ? notAPassword : Error);
+        // @ts-expect-error
+        expect(() => verify("valid", throwing)).toThrow(sync ? notAHash : Error);
       });
 
-      for (let ArrayBufferView of [
+      for (const ArrayBufferView of [
         Uint8Array,
         Uint16Array,
         Uint32Array,
         Int8Array,
         Int16Array,
         Int32Array,
+        Float16Array,
         Float32Array,
         Float64Array,
         ArrayBuffer,
@@ -308,19 +326,108 @@ describe("verify", () => {
           expect(await verify(new ArrayBufferView(0), "")).toBeFalse();
         });
       }
+    });
+  }
+});
+
+// Round trips use the cheapest parameters each algorithm accepts, so a hash
+// takes microseconds instead of the ~100 ms a default-cost hash takes. The
+// argon2 values are above the minimums so the test sees both options reach
+// the encoded string.
+const cheap: {
+  algorithm: Bun.Password.AlgorithmLabel;
+  options: Bun.Password.Argon2Algorithm | Bun.Password.BCryptAlgorithm;
+  format: RegExp;
+}[] = [
+  ...argonVariants.map(algorithm => ({
+    algorithm,
+    options: { algorithm, memoryCost: 16, timeCost: 3 },
+    format: argon2Hash(algorithm, 16, 3),
+  })),
+  { algorithm: "bcrypt", options: { algorithm: "bcrypt", cost: 4 }, format: bcryptHash(4) },
+];
+
+for (const { algorithm, options, format } of cheap) {
+  describe(algorithm, () => {
+    for (const [kind, input] of [
+      ["string", placeholder],
+      ["buffer", Buffer.from(placeholder)],
+    ] as const) {
+      describe(kind, () => {
+        // The same bytes in the other representation.
+        const other = typeof input === "string" ? Buffer.from(input) : input.toString();
+        const wrong = placeholder + "\0";
+
+        test("sync round trip", async () => {
+          const hashed = password.hashSync(input, options);
+          expect(hashed).toMatch(format);
+          // A fresh salt each call.
+          expect(password.hashSync(input, options)).not.toBe(hashed);
+
+          expect(password.verifySync(input, hashed)).toBeTrue();
+          expect(password.verifySync(other, hashed)).toBeTrue();
+          expect(password.verifySync(input, hashed, algorithm)).toBeTrue();
+          expect(await password.verify(input, hashed)).toBeTrue();
+          expect(password.verifySync(wrong, hashed)).toBeFalse();
+
+          // The plain password is not an encoded hash.
+          expect(() => password.verifySync(hashed, input)).toThrow(unsupportedAlgorithm);
+          expect(() => password.verifySync(hashed, input, algorithm)).toThrow(invalidEncoding);
+        });
+
+        test.concurrent("async round trip", async () => {
+          const hashed = await password.hash(input, options);
+          expect(hashed).toMatch(format);
+          expect(await password.hash(input, options)).not.toBe(hashed);
+
+          expect(await password.verify(input, hashed)).toBeTrue();
+          expect(await password.verify(other, hashed)).toBeTrue();
+          expect(await password.verify(input, hashed, algorithm)).toBeTrue();
+          expect(password.verifySync(input, hashed)).toBeTrue();
+          expect(await password.verify(wrong, hashed)).toBeFalse();
+
+          await expect(password.verify(hashed, input)).rejects.toThrow(unsupportedAlgorithm);
+          await expect(password.verify(hashed, input, algorithm)).rejects.toThrow(invalidEncoding);
+        });
+      });
     }
+  });
+}
+
+// The only hashes at the default cost (argon2: 64 MiB and 2 iterations,
+// bcrypt: cost 10). A default-cost argon2 hash takes about 100 ms on a release
+// build and 4 s on a debug build, so each algorithm hashes once, the tests run
+// concurrently, and the argon2 ones do not run on debug builds.
+describe.concurrent("default parameters", () => {
+  test.skipIf(isDebug)("no algorithm means argon2id", async () => {
+    const hashed = await password.hash(placeholder);
+    expect(hashed).toMatch(argon2Hash("argon2id", 65536, 2));
+    expect(await password.verify(placeholder, hashed)).toBeTrue();
+  });
+
+  for (const algorithm of argonVariants) {
+    test.skipIf(isDebug)(algorithm, async () => {
+      const hashed = await password.hash(placeholder, algorithm);
+      expect(hashed).toMatch(argon2Hash(algorithm, 65536, 2));
+      expect(await password.verify(placeholder, hashed, algorithm)).toBeTrue();
+    });
+  }
+
+  test("bcrypt", async () => {
+    const hashed = password.hashSync(placeholder, "bcrypt");
+    expect(hashed).toMatch(bcryptHash(10));
+    expect(await password.verify(placeholder, hashed, "bcrypt")).toBeTrue();
   });
 });
 
-// The async hashing tests below only await the thread-pooled password.hash /
-// password.verify on closure-local inputs (no shared mutable state, no RSS
-// assertions), so they can safely overlap.
 test.concurrent("bcrypt uses the SHA-512 of passwords longer than 72 characters", async () => {
-  const boop = Buffer.from("hey".repeat(100));
-  const hashed = await password.hash(boop, "bcrypt");
-  expect(await password.verify(boop, hashed, "bcrypt")).toBeTrue();
-  const boop2 = Buffer.from("hey".repeat(24));
-  expect(await password.verify(boop2, hashed, "bcrypt")).toBeFalse();
+  const long = Buffer.alloc(300, "hey");
+  const hashed = await password.hash(long, { algorithm: "bcrypt", cost: 4 });
+  expect(hashed).toMatch(bcryptHash(4));
+  expect(await password.verify(long, hashed, "bcrypt")).toBeTrue();
+  expect(await password.verify(long.toString(), hashed, "bcrypt")).toBeTrue();
+  // Plain bcrypt would truncate to 72 bytes and accept this prefix.
+  expect(await password.verify(Buffer.alloc(72, "hey"), hashed, "bcrypt")).toBeFalse();
 });
 
 test.concurrent("bcrypt pre-hashing does not break compatibility across Bun versions", async () => {
@@ -328,7 +435,7 @@ test.concurrent("bcrypt pre-hashing does not break compatibility across Bun vers
   // if we change the mechanism used to pre-hash long passwords so bcrypt doesn't truncate them,
   // then this hash will not be considered valid by later versions of Bun.
   const hash = "$2b$10$PsJ3/W82mzNJoP0rSblfvet2ab9jZg2aH7tIxr1B8uFLJwuWk/jTi";
-  const secret = "hello".repeat(100);
+  const secret = Buffer.alloc(500, "hello").toString();
   expect(await password.verify(secret, hash)).toBeTrue();
 });
 
@@ -341,7 +448,7 @@ test.concurrent("argon2 memoryCost at the 8 minimum is encoded faithfully (regre
   // The encoded PHC string must reflect the user-provided memoryCost, not a
   // silently clamped value. Before the fix, values below 8 were rounded up
   // while still reporting `m=8`; this pins the minimum at 8 as advertised.
-  expect(hashed).toContain("m=8,t=1,p=1");
+  expect(hashed).toMatch(argon2Hash("argon2id", 8, 1));
   expect(await password.verify("test", hashed)).toBeTrue();
 });
 
@@ -369,124 +476,10 @@ describe.concurrent("argon2 hashes with memoryCost below 8 from earlier Bun vers
 
   test("hashing with memoryCost below 8 is still rejected", () => {
     expect(() => password.hashSync("hello", { algorithm: "argon2id", memoryCost: 4 })).toThrow(
-      "Memory cost must be at least 8",
+      typeError("ERR_INVALID_ARG_TYPE", "Memory cost must be at least 8"),
     );
   });
 });
-
-const defaultAlgorithm = "argon2id";
-const algorithms = [undefined, "argon2id", "bcrypt"];
-const argons = ["argon2i", "argon2id", "argon2d"];
-
-for (let algorithmValue of algorithms) {
-  const prefix = algorithmValue === "bcrypt" ? "$2" : "$" + (algorithmValue || defaultAlgorithm);
-
-  describe(algorithmValue ? algorithmValue : "default", () => {
-    const hash = (value: string | TypedArray) => {
-      return algorithmValue ? password.hashSync(value, algorithmValue as any) : password.hashSync(value);
-    };
-
-    const hashSync = (value: string | TypedArray) => {
-      return algorithmValue ? password.hashSync(value, algorithmValue as any) : password.hashSync(value);
-    };
-
-    const verify = (pw: string | TypedArray, value: string | TypedArray) => {
-      return algorithmValue ? password.verify(pw, value, algorithmValue as any) : password.verify(pw, value);
-    };
-
-    const verifySync = (pw: string | TypedArray, value: string | TypedArray) => {
-      return algorithmValue ? password.verifySync(pw, value, algorithmValue as any) : password.verifySync(pw, value);
-    };
-
-    // Argon2 with the default `interactive_2id` params (64 MiB / 2 iter)
-    // is too slow under debug/ASAN to finish inside the per-test timeout;
-    // those invocations live in `password sync` (implicit default) and in
-    // the `runSlowTest` branch below (explicit default per algorithm). Gate
-    // them on release so the rest of the file still exercises the
-    // fast-path (bcrypt, arg-parsing, explicit `memoryCost: 8`).
-    const isArgonDefaults = algorithmValue === undefined || algorithmValue === "argon2id";
-    const skipSlowArgonOnDebug = isDebug && isArgonDefaults;
-
-    for (let input of [placeholder, Buffer.from(placeholder)]) {
-      describe(typeof input === "string" ? "string" : "buffer", () => {
-        test.skipIf(skipSlowArgonOnDebug)("password sync", () => {
-          const hashed = hashSync(input);
-          expect(hashed).toStartWith(prefix);
-          expect(verifySync(input, hashed)).toBeTrue();
-          expect(() => verifySync(hashed, input)).toThrow();
-          expect(verifySync(input + "\0", hashed)).toBeFalse();
-        });
-
-        describe("password", async () => {
-          async function runSlowTest(algorithm = algorithmValue as any) {
-            const hashed = await password.hash(input, algorithm);
-            const prefix = "$" + algorithm;
-            expect(hashed).toStartWith(prefix);
-            expect(await password.verify(input, hashed, algorithm)).toBeTrue();
-            expect(() => password.verify(hashed, input, algorithm)).toThrow();
-            expect(await password.verify(input + "\0", hashed, algorithm)).toBeFalse();
-          }
-
-          async function runSlowTestWithOptions(algorithmLabel: any) {
-            const algorithm = { algorithm: algorithmLabel, timeCost: 5, memoryCost: 8 };
-            const hashed = await password.hash(input, algorithm);
-            const prefix = "$" + algorithmLabel;
-            expect(hashed).toStartWith(prefix);
-            expect(hashed).toContain("t=5");
-            expect(hashed).toContain("m=8");
-            expect(hashed).toContain("p=1");
-            expect(await password.verify(input, hashed, algorithmLabel)).toBeTrue();
-            expect(() => password.verify(hashed, input, algorithmLabel)).toThrow();
-            expect(await password.verify(input + "\0", hashed, algorithmLabel)).toBeFalse();
-          }
-
-          async function runSlowBCryptTest() {
-            const algorithm = { algorithm: "bcrypt", cost: 4 } as const;
-            const hashed = await password.hash(input, algorithm);
-            const prefix = "$" + "2b";
-            expect(hashed).toStartWith(prefix);
-            expect(await password.verify(input, hashed, "bcrypt")).toBeTrue();
-            expect(() => password.verify(hashed, input, "bcrypt")).toThrow();
-            expect(await password.verify(input + "\0", hashed, "bcrypt")).toBeFalse();
-          }
-
-          if (algorithmValue === defaultAlgorithm) {
-            // these tests are very slow
-            // run the hashing tests in parallel
-            for (const a of argons) {
-              // `runSlowTest` uses default params; only `runSlowTestWithOptions`
-              // (memoryCost: 8) is fast enough for debug/ASAN.
-              test.concurrent(`${a}`, async () => {
-                if (!isDebug) await runSlowTest(a);
-                await runSlowTestWithOptions(a);
-              });
-            }
-            return;
-          }
-
-          async function defaultTest() {
-            const hashed = await hash(input);
-            expect(hashed).toStartWith(prefix);
-            expect(await verify(input, hashed)).toBeTrue();
-            expect(() => verify(hashed, input)).toThrow();
-            expect(await verify(input + "\0", hashed)).toBeFalse();
-          }
-
-          if (algorithmValue === "bcrypt") {
-            test.concurrent("bcrypt", async () => {
-              await defaultTest();
-              await runSlowBCryptTest();
-            });
-          } else {
-            test.skipIf(skipSlowArgonOnDebug)("default", async () => {
-              await defaultTest();
-            });
-          }
-        });
-      });
-    }
-  });
-}
 
 test("verify rejects encoded argon2 hashes with cost parameters above the supported maximums", async () => {
   // Hash with small, fast parameters so this test stays cheap on debug builds.
@@ -495,7 +488,7 @@ test("verify rejects encoded argon2 hashes with cost parameters above the suppor
     memoryCost: 8,
     timeCost: 1,
   });
-  expect(hashed).toContain("$m=8,t=1,p=1$");
+  expect(hashed).toMatch(argon2Hash("argon2id", 8, 1));
 
   // The untampered hash still verifies.
   expect(password.verifySync("correct horse", hashed)).toBeTrue();
@@ -504,33 +497,33 @@ test("verify rejects encoded argon2 hashes with cost parameters above the suppor
   // hash must be rejected up front instead of being honored.
   const hugeTime = hashed.replace(",t=1,", ",t=100000,");
   expect(hugeTime).not.toBe(hashed);
-  expect(() => password.verifySync("correct horse", hugeTime)).toThrow("WeakParameters");
-  await expect(password.verify("correct horse", hugeTime)).rejects.toThrow("WeakParameters");
+  expect(() => password.verifySync("correct horse", hugeTime)).toThrow(weakParameters);
+  await expect(password.verify("correct horse", hugeTime)).rejects.toThrow(weakParameters);
 
   // A memory cost above the ceiling is rejected before any allocation is
   // sized from the encoded string.
   const hugeMemory = hashed.replace("$m=8,", "$m=4294967294,");
   expect(hugeMemory).not.toBe(hashed);
-  expect(() => password.verifySync("correct horse", hugeMemory)).toThrow("WeakParameters");
-  await expect(password.verify("correct horse", hugeMemory)).rejects.toThrow("WeakParameters");
+  expect(() => password.verifySync("correct horse", hugeMemory)).toThrow(weakParameters);
+  await expect(password.verify("correct horse", hugeMemory)).rejects.toThrow(weakParameters);
 
   // A parallelism value above the ceiling is rejected as well.
   const hugeParallelism = hashed.replace(",p=1$", ",p=65$");
   expect(hugeParallelism).not.toBe(hashed);
-  expect(() => password.verifySync("correct horse", hugeParallelism)).toThrow("WeakParameters");
-  await expect(password.verify("correct horse", hugeParallelism)).rejects.toThrow("WeakParameters");
+  expect(() => password.verifySync("correct horse", hugeParallelism)).toThrow(weakParameters);
+  await expect(password.verify("correct horse", hugeParallelism)).rejects.toThrow(weakParameters);
 
   // The argon2 decoder accepts a leading `+` on the cost fields (Rust's integer
   // grammar), so the ceiling check must too rather than skipping the field.
   const plusMemory = hashed.replace("$m=8,", "$m=+4294967294,");
   expect(plusMemory).not.toBe(hashed);
-  expect(() => password.verifySync("correct horse", plusMemory)).toThrow("WeakParameters");
-  await expect(password.verify("correct horse", plusMemory)).rejects.toThrow("WeakParameters");
+  expect(() => password.verifySync("correct horse", plusMemory)).toThrow(weakParameters);
+  await expect(password.verify("correct horse", plusMemory)).rejects.toThrow(weakParameters);
 
   // A cost field the decoder can't parse is rejected up front as well.
   const junkMemory = hashed.replace("$m=8,", "$m=8x,");
-  expect(() => password.verifySync("correct horse", junkMemory)).toThrow("InvalidEncoding");
-  await expect(password.verify("correct horse", junkMemory)).rejects.toThrow("InvalidEncoding");
+  expect(() => password.verifySync("correct horse", junkMemory)).toThrow(invalidEncoding);
+  await expect(password.verify("correct horse", junkMemory)).rejects.toThrow(invalidEncoding);
 });
 
 test("verifySync reads the password buffer only after every argument has been coerced", () => {

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -1,6 +1,6 @@
 import { password } from "bun";
 import { describe, expect, test } from "bun:test";
-import { expectRssDeltaBelow, isDebug } from "harness";
+import { expectRssDeltaBelow, isASAN, isDebug } from "harness";
 
 const placeholder = "hey";
 const argonVariants = ["argon2id", "argon2i", "argon2d"] as const;
@@ -18,12 +18,25 @@ function bcryptHash(cost: number) {
   return new RegExp(`^\\$2b\\$${String(cost).padStart(2, "0")}\\$[./A-Za-z0-9]{53}$`);
 }
 
-const typeError = (code: string, message: string) => expect.objectContaining({ name: "TypeError", code, message });
-const unknownAlgorithm = (fn: "hash" | "verify") =>
-  typeError(
-    "ERR_INVALID_ARG_TYPE",
-    `Expected algorithm to be a unknown algorithm, expected one of: "bcrypt", "argon2id", "argon2d", "argon2i" (default is "argon2id") for '${fn}'.`,
-  );
+const typeError = (code: string, message: unknown) => expect.objectContaining({ name: "TypeError", code, message });
+
+// Matcher for an error message that names the function, given as a template
+// with `{fn}` in it. The async forms are pinned exactly. hashSync and
+// verifySync report themselves as 'hash' and 'verify', so for them the name is
+// left open rather than pinned to the wrong one.
+function named(name: string, sync: boolean, template: string, code = "ERR_INVALID_ARG_TYPE") {
+  const [before, after] = template.split("{fn}");
+  if (!sync) return typeError(code, before + name + after);
+  const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return typeError(code, expect.stringMatching(new RegExp(`^${escape(before)}\\w+${escape(after)}$`)));
+}
+
+// The message lists the accepted names. Its lead-in ("to be a unknown
+// algorithm, expected one of") is not pinned.
+const unknownAlgorithm = typeError(
+  "ERR_INVALID_ARG_TYPE",
+  expect.stringContaining('"bcrypt", "argon2id", "argon2d", "argon2i" (default is "argon2id")'),
+);
 const verifyError = (code: string, reason: string) =>
   expect.objectContaining({ code, message: `Password verification failed with error "${reason}"` });
 const unsupportedAlgorithm = verifyError("PASSWORD_UNSUPPORTED_ALGORITHM", "UnsupportedAlgorithm");
@@ -31,17 +44,18 @@ const invalidEncoding = verifyError("PASSWORD_INVALID_ENCODING", "InvalidEncodin
 const weakParameters = verifyError("PASSWORD_WEAK_PARAMETERS", "WeakParameters");
 
 // The leak this guards (#29913) was the encoded hash string, about 100 bytes
-// per hash() or hashSync() call that was never freed. On a release build it
-// shows as 110 to 170 bytes of RSS growth per call, so the check needs tens of
-// thousands of calls and a flat baseline. The JIT is off because tier-up
-// allocates several MiB in the middle of the loop. The JS heap is collected
-// every 2000 calls because each call leaves a string behind. ASAN's quarantine
-// is off because it pins freed blocks. With that, the fixed build stays within
-// 0.2 MiB over 60k calls.
+// per hash() or hashSync() call that was never freed. Bun 1.3.13 (unfixed)
+// shows it as about 100 bytes of RSS growth per call, so the check needs tens
+// of thousands of calls over a flat baseline. Two things keep the baseline
+// flat on top of what the harness does (mimalloc purge delay 0, ASAN
+// quarantine off): the warm-up runs past the JIT tier-up of the loop, which
+// commits about 3 MiB once before call 3000, and every chunk of 2000 calls
+// ends in a full GC, so the strings the calls leave behind never grow the
+// heap. The fixed build then reads 0 MiB.
 //
 // A debug build hashes about 200x slower, so the suite does not run there.
 describe.skipIf(isDebug)("does not leak", () => {
-  async function expectRssGrowthBelow(
+  function expectRssGrowthBelow(
     calls: string,
     warmup: number,
     measured: number,
@@ -62,22 +76,22 @@ describe.skipIf(isDebug)("does not leak", () => {
       await run(${measured});
       console.log(JSON.stringify({ deltaMiB: (rss() - before) / 1024 / 1024 }));
     `;
-    await expectRssDeltaBelow(["--smol", "-e", code], bounds, { BUN_JSC_useJIT: "0" });
+    return expectRssDeltaBelow(["--smol", "-e", code], bounds);
   }
 
-  // Unfixed (Bun 1.3.13): 5.6 to 9.6 MiB. Fixed: 0 +- 0.2 MiB. The `debug`
-  // bound applies to the ASAN lane: redzones make a leaked block larger, and
-  // the allocator is noisier without a quarantine.
+  // Release: unfixed 4 to 5 MiB, fixed 0 MiB. The `debug` bound is the ASAN
+  // lane, where a leaked block carries redzones and the allocator's baseline
+  // moves by a few MiB, so it measures more calls against a wider bound.
   test("hashSync", async () => {
     await expectRssGrowthBelow(
       /* js */ `for (let i = 0; i < chunk; i++) Bun.password.hashSync("hey", opts);`,
       4_000,
-      60_000,
-      { release: 4, debug: 6 },
+      isASAN ? 60_000 : 40_000,
+      { release: 2, debug: 6 },
     );
   });
 
-  // Unfixed: 12 to 14 MiB. Fixed: 0 MiB.
+  // Release: unfixed 4 to 6 MiB, fixed 0 to 1 MiB.
   test("hash", async () => {
     await expectRssGrowthBelow(
       /* js */ `
@@ -87,8 +101,8 @@ describe.skipIf(isDebug)("does not leak", () => {
           await Promise.all(batch);
         }`,
       10_000,
-      100_000,
-      { release: 6, debug: 8 },
+      isASAN ? 100_000 : 50_000,
+      { release: 2, debug: 8 },
     );
   });
 });
@@ -106,16 +120,16 @@ describe("hash", () => {
       test("password is required", () => {
         // @ts-expect-error
         expect(() => hash()).toThrow(
-          typeError("ERR_MISSING_ARGS", "Not enough arguments to 'hash'. Expected 1, got 0."),
+          named(name, sync, "Not enough arguments to '{fn}'. Expected 1, got 0.", "ERR_MISSING_ARGS"),
         );
       });
 
       test("invalid algorithm throws", () => {
         // @ts-expect-error
-        expect(() => hash(placeholder, "scrpyt")).toThrow(unknownAlgorithm("hash"));
+        expect(() => hash(placeholder, "scrpyt")).toThrow(unknownAlgorithm);
         // @ts-expect-error
         expect(() => hash(placeholder, 123)).toThrow(
-          typeError("ERR_INVALID_ARG_TYPE", "Expected algorithm to be a string for 'hash'."),
+          named(name, sync, "Expected algorithm to be a string for '{fn}'."),
         );
 
         // An object is read as options, so its toString() is not an algorithm name.
@@ -126,14 +140,14 @@ describe("hash", () => {
               return "scrypt";
             },
           }),
-        ).toThrow(typeError("ERR_INVALID_ARG_TYPE", "Expected options.algorithm to be a string for 'hash'."));
+        ).toThrow(named(name, sync, "Expected options.algorithm to be a string for '{fn}'."));
 
         expect(() =>
           hash(placeholder, {
             // @ts-expect-error
             algorithm: "poop",
           }),
-        ).toThrow(unknownAlgorithm("hash"));
+        ).toThrow(unknownAlgorithm);
 
         const rounds = typeError("ERR_INVALID_ARG_TYPE", "Rounds must be an integer between 4 and 31");
         for (const cost of [Infinity, -999, 3, 32]) {
@@ -141,7 +155,7 @@ describe("hash", () => {
         }
         // @ts-expect-error
         expect(() => hash(placeholder, { algorithm: "bcrypt", cost: "10" })).toThrow(
-          typeError("ERR_INVALID_ARG_TYPE", "Expected cost to be a number for 'hash'."),
+          named(name, sync, "Expected cost to be a number for '{fn}'."),
         );
 
         // argon2 requires `memoryCost >= 8 * parallelism`; Bun hard-codes
@@ -158,7 +172,7 @@ describe("hash", () => {
         }
         // @ts-expect-error
         expect(() => hash(placeholder, { algorithm: "argon2id", timeCost: "2" })).toThrow(
-          typeError("ERR_INVALID_ARG_TYPE", "Expected timeCost to be a number for 'hash'."),
+          named(name, sync, "Expected timeCost to be a number for '{fn}'."),
         );
       });
 
@@ -196,10 +210,7 @@ describe("hash", () => {
       test("coercion throwing doesn't crash", () => {
         // The async form still coerces the password with ToString, so only the
         // sync form's error is pinned.
-        const notAPassword = typeError(
-          "ERR_INVALID_ARG_TYPE",
-          "Expected password to be a string or TypedArray for 'hash'.",
-        );
+        const notAPassword = named(name, sync, "Expected password to be a string or TypedArray for '{fn}'.");
         // @ts-expect-error
         expect(() => hash(Symbol())).toThrow(sync ? notAPassword : TypeError);
         expect(() =>
@@ -243,16 +254,13 @@ describe("verify", () => {
       test("minimum args", () => {
         // @ts-expect-error
         expect(() => verify()).toThrow(
-          typeError("ERR_MISSING_ARGS", "Not enough arguments to 'verify'. Expected 2, got 0."),
+          named(name, sync, "Not enough arguments to '{fn}'. Expected 2, got 0.", "ERR_MISSING_ARGS"),
         );
-        // The message does not count the arguments it did get.
+        // The message reports "got 0" for a one-argument call too, so the
+        // count is not pinned here.
         // @ts-expect-error
         expect(() => verify("")).toThrow(
-          expect.objectContaining({
-            name: "TypeError",
-            code: "ERR_MISSING_ARGS",
-            message: expect.stringMatching(/^Not enough arguments to 'verify'\./),
-          }),
+          typeError("ERR_MISSING_ARGS", expect.stringMatching(/^Not enough arguments to '\w+'\. Expected 2, got /)),
         );
       });
 
@@ -263,8 +271,8 @@ describe("verify", () => {
 
       test("invalid algorithm throws", () => {
         // @ts-expect-error
-        expect(() => verify(placeholder, "$", "scrpyt")).toThrow(unknownAlgorithm("verify"));
-        const notAString = typeError("ERR_INVALID_ARG_TYPE", "Expected algorithm to be a string for 'verify'.");
+        expect(() => verify(placeholder, "$", "scrpyt")).toThrow(unknownAlgorithm);
+        const notAString = named(name, sync, "Expected algorithm to be a string for '{fn}'.");
         // @ts-expect-error
         expect(() => verify(placeholder, "$", 123)).toThrow(notAString);
         expect(() =>
@@ -280,11 +288,8 @@ describe("verify", () => {
       test("coercion throwing doesn't crash", () => {
         // The async form still coerces both arguments with ToString, so only
         // the sync form's errors are pinned.
-        const notAPassword = typeError(
-          "ERR_INVALID_ARG_TYPE",
-          "Expected password to be a string or TypedArray for 'verify'.",
-        );
-        const notAHash = typeError("ERR_INVALID_ARG_TYPE", "Expected hash to be a string or TypedArray for 'verify'.");
+        const notAPassword = named(name, sync, "Expected password to be a string or TypedArray for '{fn}'.");
+        const notAHash = named(name, sync, "Expected hash to be a string or TypedArray for '{fn}'.");
         const throwing = {
           toString() {
             throw new Error("toString() failed");

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -1,6 +1,6 @@
 import { password } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { expectRssDeltaBelow, isDebug } from "harness";
 
 const placeholder = "hey";
 const argonVariants = ["argon2id", "argon2i", "argon2d"] as const;
@@ -41,7 +41,12 @@ const weakParameters = verifyError("PASSWORD_WEAK_PARAMETERS", "WeakParameters")
 //
 // A debug build hashes about 200x slower, so the suite does not run there.
 describe.skipIf(isDebug)("does not leak", () => {
-  async function expectRssGrowthBelow(calls: string, warmup: number, measured: number, limitMiB: number) {
+  async function expectRssGrowthBelow(
+    calls: string,
+    warmup: number,
+    measured: number,
+    bounds: { release: number; debug: number },
+  ) {
     const code = /* js */ `
       const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
       const opts = { algorithm: "argon2id", memoryCost: 8, timeCost: 1 };
@@ -57,33 +62,18 @@ describe.skipIf(isDebug)("does not leak", () => {
       await run(${measured});
       console.log(JSON.stringify({ deltaMiB: (rss() - before) / 1024 / 1024 }));
     `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "--smol", "-e", code],
-      env: {
-        ...bunEnv,
-        BUN_JSC_useJIT: "0",
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
-          .filter(Boolean)
-          .join(":"),
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr.trim()).toBe("");
-    const { deltaMiB } = JSON.parse(stdout);
-    expect(deltaMiB).toBeLessThan(limitMiB);
-    expect(exitCode).toBe(0);
+    await expectRssDeltaBelow(["--smol", "-e", code], bounds, { BUN_JSC_useJIT: "0" });
   }
 
-  // Unfixed (Bun 1.3.13): 5.6 to 9.6 MiB. Fixed: 0 +- 0.2 MiB. ASAN's redzones
-  // make a leaked block larger, and its allocator is noisier without a quarantine.
+  // Unfixed (Bun 1.3.13): 5.6 to 9.6 MiB. Fixed: 0 +- 0.2 MiB. The `debug`
+  // bound applies to the ASAN lane: redzones make a leaked block larger, and
+  // the allocator is noisier without a quarantine.
   test("hashSync", async () => {
     await expectRssGrowthBelow(
       /* js */ `for (let i = 0; i < chunk; i++) Bun.password.hashSync("hey", opts);`,
       4_000,
       60_000,
-      isASAN ? 6 : 4,
+      { release: 4, debug: 6 },
     );
   });
 
@@ -98,7 +88,7 @@ describe.skipIf(isDebug)("does not leak", () => {
         }`,
       10_000,
       100_000,
-      isASAN ? 8 : 6,
+      { release: 6, debug: 8 },
     );
   });
 });


### PR DESCRIPTION
### Problem
- `test/js/bun/util/password.test.ts` took 13.6 s on the x64-asan lane (build #104578): 9.2 s in the two RSS leak checks (370k hashes), most of the rest in twelve tests that each ran three default-cost argon2 operations.
- Most assertions checked only a `$argon2id` or `$2` prefix and a bare `toThrow()`. The leak child was checked by exit code only.

### Fix
- The leak checks use the harness `expectRssDeltaBelow`, which now sets `MIMALLOC_PURGE_DELAY=0`: mimalloc returns freed pages after 100 ms, which put about 1 MiB of noise in each reading. With a full GC every 2000 calls the fixed build reads 0 MiB, so the release windows shrink to 44k sync and 60k async calls with 2 MiB bounds. Bun 1.3.13 (unfixed, #29913) reads 4 to 6 MiB there. ASAN keeps the larger windows.
- Default-cost hashing is one hash and one verify per algorithm spelling, run concurrently. Every other hash uses cheap parameters.
- Assertions check the full encoded string format, error name, code and message for every invalid input, exact codes for unparseable hashes, string-vs-Buffer verify, and stdout, stderr, exit code of the leak child. Three messages have defects (Notes) and are pinned by code plus their correct part.
- Verified: release 7.5 to 8.2 s before, 1.5 to 1.7 s after. Bun 1.3.13 fails exactly the two leak checks, 3 of 3 runs.

### Background
- argon2 output is a PHC string (`$argon2id$v=19$m=65536,t=2,p=1$<salt>$<hash>`), bcrypt a modular crypt string (`$2b$10$<salt><hash>`). A verify runs at the cost encoded in the string.
- The leak signal is about 100 bytes per call, so every other RSS movement (JIT tier-up, uncollected strings, mimalloc's purge delay, ASAN's quarantine) is removed, not outwaited. JIT tier-up commits about 3 MiB once before call 3000, inside the 4k warm-up.
- The debug build's argon2 takes 3.7 s per default-cost hash, so the leak suite and the default-cost argon2 tests keep their `isDebug` gating. CI runs release and release+ASAN only.

<details><summary>Notes</summary>

Harness: the `MIMALLOC_PURGE_DELAY` line is the only change to `test/harness.ts` against main. It lowers the readings of the other `expectRssDeltaBelow` callers and cannot raise them. `parse-args.test.mjs`, `expect-label.test.ts` and `module-sourcemap.test.js` still pass with it. (`html-rewriter-leak.test.ts` has one failure that reproduces on main's harness with the same binary, so it is unrelated.)

Message defects in `src/runtime/crypto/PasswordObject.rs` that the tests do not pin verbatim, for a follow-up:
- The unknown-algorithm message reads `Expected algorithm to be a unknown algorithm, expected one of: ...` because `UNKNOWN_PASSWORD_ALGORITHM_MESSAGE` is passed as the type name to `throw_invalid_argument_type` (lines 62, 167, 754, 829). The tests pin the list of accepted names.
- `hashSync` and `verifySync` errors name the function `'hash'` and `'verify'` (`AlgorithmValue::from_js` hard-codes "hash", the sync host functions pass "hash"/"verify"). The tests pin the message with the name left open for the sync forms and exact for the async forms.
- `verify("")` reports `Expected 2, got 0` because `throw_not_enough_arguments("verify", 2, 0)` hard-codes the count (lines 741, 816). The tests pin the code and the message up to the count.

Open PR #34442 doubles the old hashSync loop to 120k calls and raises its bound to 8 MB. It is already in conflict with main. This PR replaces that loop, so the two conflict; its intent (a real margin between noise and leak) is covered here by removing the noise sources instead of adding iterations.

Open PR #33702 makes the async `hash`/`verify` reject non-string, non-TypedArray arguments like the sync forms. The "coercion throwing doesn't crash" tests pin the sync-form error and keep a class-only `toThrow(TypeError)` / `toThrow(Error)` for the async form so that PR does not have to fight these assertions.

Cheap parameters used by the round trips: argon2 `memoryCost: 16, timeCost: 3` (above the minimums, so the test sees both options reach the encoded string) and bcrypt `cost: 4`. The default-cost tests cover no algorithm, `argon2id`, `argon2i`, `argon2d` and `bcrypt` (one `hashSync` call for bcrypt, async for the rest so the concurrent group is not blocked).

Probes behind the leak-check design (release builds, fixed 1.4.0 vs unfixed 1.3.13, argon2id `m=8,t=1`, full GC every 2000 calls, 8 runs each unless noted):
- Fixed, 4k + 60k sync: JIT on 1.00 MiB in 5 of 8, JIT off 1.00 MiB in 5 of 8, `MIMALLOC_PURGE_DELAY=0` 0.00 in 8 of 8 with either JIT setting. mimalloc's `purge_delay` is 100 in this build (`MIMALLOC_VERBOSE=1`), and the env var sets it to 0.
- Fixed, purge delay 0, JIT on: warm-up 2000 reads 3.00 in 8 of 8, warm-up 3000 or 4000 reads 0.00. With JIT off, warm-up 2000 reads 0.00. So the 3 MiB is JIT memory committed between call 2000 and 3000.
- Unfixed, purge delay 0, 4k warm-up: 3 to 4 MiB at 30k, 4 to 5 MiB at 40k (about 100 bytes per call). Async 10k + 50k: fixed 0 to 1 MiB, unfixed 4 to 6 MiB.
- Without the periodic GC the JS heap alone adds about 1 MiB per 4k to 8k calls. With the old settings (JIT on, no periodic GC, default purge delay) the fixed build drifted 6 to 10 MiB over 200k calls, which matches the 4.5 MB growth #34442 saw on Ubuntu 25.04.
- ASAN debug build, quarantine off: sync 4k + 20k reads 1.7 and 2.8 MiB with no leak, async 10k + 50k reads 0.9 to 2.0 MiB, async 10k + 100k reads 3.0 and 3.9 MiB. `allocator_release_to_os_interval_ms=0` does not lower these. With the quarantine on, RSS climbs about 60 MB per 5000 calls until it saturates near 700 MB, which the old 400 MB ASAN bound worked around.

CI on this PR before the window change (build #104828): every Linux and Windows lane 2.2 to 2.9 s, x64-asan 7.2 s, darwin aarch64 9.8 s (that lane runs 3157 files in two jobs, and the old 64k-call sync child took 5.6 s there). The smaller release windows cut the sync child from 64k to 44k calls and the async child from 110k to 60k.

The CI log for build #104578 has no per-test timings (dots reporter). The 5.2 s and 4.0 s come from the Buildkite `_bk;t=` timestamps between the first three dots.

Also ran: `bun bd test test/js/bun/util/password.test.ts` (85 pass, 6 skip), `USE_SYSTEM_BUN=1 bun test test/js/bun/util/password.test.ts` (91 pass, leak checks 8 of 8), prettier, and tsc on the file (no errors in it).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/password.test.ts

<!-- robobun:evidence:end -->