### PR TITLE
test(bun test): run bun-test.test.ts concurrently and assert exit codes

### DIFF
--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,10 +1,60 @@
 import { spawnSync } from "bun";
-import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { describe, expect, it, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve, sep } from "node:path";
 
-describe("bun test", () => {
+// Every test spawns its own `bun test` in its own temp dir, so they run concurrently.
+describe.concurrent("bun test", () => {
+  // The default-timeout test needs 5 s of wall time. Its block comes first so that
+  // it overlaps with the rest of the file.
+  describe("--timeout", () => {
+    test("must provide a number timeout", async () => {
+      const stderr = await runTest({
+        args: ["--timeout", "foo"],
+        expectExitCode: 1,
+      });
+      expect(stderr).toContain('error: Invalid timeout: "foo"');
+    });
+    test("must provide non-negative timeout", async () => {
+      const stderr = await runTest({
+        args: ["--timeout", "-1"],
+        expectExitCode: 1,
+      });
+      expect(stderr).toContain('error: Invalid timeout: "-1"');
+    });
+    // The hanging test awaits a promise that never settles, so nothing races the
+    // timeout. `bun test` exits once the last test is done, so the pending
+    // promise costs nothing.
+    const hangingTest = `
+      import { test, expect } from "bun:test";
+      import { sleep } from "bun";
+      test("ok", async () => {
+        await expect(sleep(1)).resolves.toBeUndefined();
+      });
+      test("timeout", async () => {
+        await new Promise(() => {});
+      });
+    `;
+    test("timeout can be set to 30ms", async () => {
+      const stderr = await runTest({
+        args: ["--timeout", "30"],
+        input: hangingTest,
+        expectExitCode: 1,
+      });
+      expect(stderr).toContain("(fail) timeout");
+      expect(stderr).toContain("this test timed out after 30ms.");
+    });
+    test("timeout should default to 5000ms", async () => {
+      const stderr = await runTest({
+        input: hangingTest,
+        expectExitCode: 1,
+      });
+      expect(stderr).toContain("(pass) ok");
+      expect(stderr).toContain("(fail) timeout");
+      expect(stderr).toContain("this test timed out after 5000ms.");
+    }, 10000);
+  });
   test("running a non-existent absolute file path is a 1 exit code", () => {
     const spawn = Bun.spawnSync({
       cmd: [bunExe(), "test", join(import.meta.dirname, "non-existent.test.ts")],
@@ -15,8 +65,8 @@ describe("bun test", () => {
     });
     expect(spawn.exitCode).toBe(1);
   });
-  test("can provide no arguments", () => {
-    const stderr = runTest({
+  test("can provide no arguments", async () => {
+    const stderr = await runTest({
       args: [],
       input: [
         `
@@ -36,12 +86,13 @@ describe("bun test", () => {
           });
         `,
       ],
+      expectExitCode: 1,
     });
     expect(stderr).toContain("test #1");
     expect(stderr).toContain("test #2");
     expect(stderr).toContain("test #3");
   });
-  test("can provide a relative file", () => {
+  test("can provide a relative file", async () => {
     const path = join("path", "to", "relative.test.ts");
     const cwd = createTest(
       `
@@ -52,14 +103,15 @@ describe("bun test", () => {
     `,
       path,
     );
-    const stderr = runTest({
+    const stderr = await runTest({
       cwd,
       args: [path],
+      expectExitCode: 0,
     });
     expect(stderr).toContain(path);
   });
   // This fails on macOS because /private/var symlinks to /var
-  test.todo("can provide an absolute file", () => {
+  test.todo("can provide an absolute file", async () => {
     const path = join("path", "to", "absolute.test.ts");
     const cwd = createTest(
       `
@@ -71,13 +123,14 @@ describe("bun test", () => {
       path,
     );
     const absolutePath = resolve(cwd, path);
-    const stderr = runTest({
+    const stderr = await runTest({
       cwd,
       args: [absolutePath],
+      expectExitCode: 0,
     });
     expect(stderr).toContain(path);
   });
-  test("can provide a relative directory", () => {
+  test("can provide a relative directory", async () => {
     const path = join("path", "to", "relative.test.ts");
     const dir = dirname(path);
     const cwd = createTest(
@@ -89,13 +142,14 @@ describe("bun test", () => {
     `,
       path,
     );
-    const stderr = runTest({
+    const stderr = await runTest({
       cwd,
       args: [dir],
+      expectExitCode: 0,
     });
     expect(stderr).toContain(dir);
   });
-  test.todo("can provide an absolute directory", () => {
+  test.todo("can provide an absolute directory", async () => {
     const path = join("path", "to", "absolute.test.ts");
     const cwd = createTest(
       `
@@ -107,40 +161,41 @@ describe("bun test", () => {
       path,
     );
     const absoluteDir = resolve(cwd, dirname(path));
-    const stderr = runTest({
+    const stderr = await runTest({
       cwd,
       args: [absoluteDir],
+      expectExitCode: 0,
     });
     expect(stderr).toContain(path);
   });
 
   describe("when filters are provided", () => {
-    let dir: string;
-    beforeAll(() => {
-      const makeTest = (name: string, pass = true) => `
+    // No beforeAll: a hook is a barrier that would wait for every test declared above it.
+    it("if that filter is a path to a directory, will run all tests in that directory", async () => {
+      const makeTest = (name: string) => `
       import { test, expect } from "bun:test";
       test("${name}", () => {
-        expect(1).toBe(${pass ? 1 : 0});
+        expect(1).toBe(1);
       });
       `;
-      dir = tempDirWithFiles("bun-test-filtering", {
-        "foo.test.js": makeTest("foo"),
-        bar: {
-          "bar1.spec.tsx": makeTest("bar1"),
-          "bar2.spec.ts": makeTest("bar2"),
-        },
+      const stderr = await runTest({
+        input: [
+          { filename: "foo.test.js", contents: makeTest("foo") },
+          { filename: join("bar", "bar1.spec.tsx"), contents: makeTest("bar1") },
+          { filename: join("bar", "bar2.spec.ts"), contents: makeTest("bar2") },
+        ],
+        args: ["./bar"],
+        expectExitCode: 0,
       });
-    });
-
-    it("if that filter is a path to a directory, will run all tests in that directory", () => {
-      const stderr = runTest({ cwd: dir, args: ["./bar"] });
+      expect(stderr).toContain("(pass) bar1");
+      expect(stderr).toContain("(pass) bar2");
       expect(stderr).toContain("2 pass");
       expect(stderr).not.toContain("foo");
     });
   });
 
-  test("works with require", () => {
-    const stderr = runTest({
+  test("works with require", async () => {
+    const stderr = await runTest({
       args: [],
       input: [
         `
@@ -150,11 +205,12 @@ describe("bun test", () => {
           })
         `,
       ],
+      expectExitCode: 0,
     });
     expect(stderr).toContain("test #1");
   });
-  test("works with dynamic import", () => {
-    const stderr = runTest({
+  test("works with dynamic import", async () => {
+    const stderr = await runTest({
       args: [],
       input: `
         const { test, expect } = await import("bun:test");
@@ -162,10 +218,11 @@ describe("bun test", () => {
           expect().pass();
         })
       `,
+      expectExitCode: 0,
     });
     expect(stderr).toContain("test #1");
   });
-  test("works with cjs require", () => {
+  test("works with cjs require", async () => {
     const cwd = createTest(
       `
         const { test, expect } = require("bun:test");
@@ -175,12 +232,13 @@ describe("bun test", () => {
       `,
       "test.test.cjs",
     );
-    const stderr = runTest({
+    const stderr = await runTest({
       cwd,
+      expectExitCode: 0,
     });
     expect(stderr).toContain("test #1");
   });
-  test("works with cjs dynamic import", () => {
+  test("works with cjs dynamic import", async () => {
     const cwd = createTest(
       `
         const { test, expect } = await import("bun:test");
@@ -190,8 +248,9 @@ describe("bun test", () => {
       `,
       "test.test.cjs",
     );
-    const stderr = runTest({
+    const stderr = await runTest({
       cwd,
+      expectExitCode: 0,
     });
     expect(stderr).toContain("test #1");
   });
@@ -201,19 +260,21 @@ describe("bun test", () => {
     test.todo("can rerun with a provided value");
   });
   describe("--todo", () => {
-    test("should not run todo by default", () => {
-      const stderr = runTest({
+    test("should not run todo by default", async () => {
+      const stderr = await runTest({
         input: `
           import { test, expect } from "bun:test";
           test.todo("todo", async () => {
             console.error("should not run");
           });
         `,
+        expectExitCode: 0,
       });
+      expect(stderr).toContain("(todo) todo");
       expect(stderr).not.toContain("should not run");
     });
-    test("should run todo when enabled", () => {
-      const stderr = runTest({
+    test("should run todo when enabled", async () => {
+      const stderr = await runTest({
         args: ["--todo"],
         input: `
           import { test, expect } from "bun:test";
@@ -221,13 +282,14 @@ describe("bun test", () => {
             console.error("should run");
           });
         `,
+        expectExitCode: 1,
       });
       expect(stderr).toContain("should run");
     });
   });
   describe("only", () => {
-    test("should run nested describe.only", () => {
-      const stderr = runTest({
+    test("should run nested describe.only", async () => {
+      const stderr = await runTest({
         args: [],
         input: `
             import { test, describe } from "bun:test";
@@ -245,13 +307,14 @@ describe("bun test", () => {
             })
             `,
         env: { CI: "false" },
+        expectExitCode: 0,
       });
       expect(stderr).toContain("reachable");
       expect(stderr).not.toContain("unreachable");
       expect(stderr.match(/reachable/g)).toHaveLength(1);
     });
-    test("should skip non-only tests", () => {
-      const stderr = runTest({
+    test("should skip non-only tests", async () => {
+      const stderr = await runTest({
         args: [],
         input: `
           import { test, describe } from "bun:test";
@@ -289,6 +352,7 @@ describe("bun test", () => {
           });
         `,
         env: { CI: "false" },
+        expectExitCode: 0,
       });
       expect(stderr).toContain("reachable");
       expect(stderr).not.toContain("unreachable");
@@ -296,29 +360,32 @@ describe("bun test", () => {
     });
   });
   describe("--bail", () => {
-    test("must provide a number bail", () => {
-      const stderr = runTest({
+    test("must provide a number bail", async () => {
+      const stderr = await runTest({
         args: ["--bail=foo"],
+        expectExitCode: 1,
       });
       expect(stderr).toContain("expects a number");
     });
 
-    test("must provide non-negative bail", () => {
-      const stderr = runTest({
+    test("must provide non-negative bail", async () => {
+      const stderr = await runTest({
         args: ["--bail=-1"],
+        expectExitCode: 1,
       });
       expect(stderr).toContain("expects a number");
     });
 
-    test("should not be 0", () => {
-      const stderr = runTest({
+    test("should not be 0", async () => {
+      const stderr = await runTest({
         args: ["--bail=0"],
+        expectExitCode: 1,
       });
       expect(stderr).toContain("expects a number");
     });
 
-    test("bail should be 1 by default", () => {
-      const stderr = runTest({
+    test("bail should be 1 by default", async () => {
+      const stderr = await runTest({
         args: ["--bail"],
         input: `
           import { test, expect } from "bun:test";
@@ -329,13 +396,14 @@ describe("bun test", () => {
             expect(true).toBe(true);
           });
         `,
+        expectExitCode: 1,
       });
       expect(stderr).toContain("Bailed out after 1 failure");
       expect(stderr).not.toContain("test #2");
     });
 
-    test("should bail out after 3 failures", () => {
-      const stderr = runTest({
+    test("should bail out after 3 failures", async () => {
+      const stderr = await runTest({
         args: ["--bail=3"],
         input: `
           import { test, expect } from "bun:test";
@@ -352,90 +420,49 @@ describe("bun test", () => {
             expect(true).toBe(true);
           });
         `,
+        expectExitCode: 1,
       });
       expect(stderr).toContain("Bailed out after 3 failures");
       expect(stderr).not.toContain("test #4");
     });
   });
-  describe("--timeout", () => {
-    test("must provide a number timeout", () => {
-      const stderr = runTest({
-        args: ["--timeout", "foo"],
-      });
-      expect(stderr).toContain("Invalid timeout");
-    });
-    test("must provide non-negative timeout", () => {
-      const stderr = runTest({
-        args: ["--timeout", "-1"],
-      });
-      expect(stderr).toContain("Invalid timeout");
-    });
-    // TODO: https://github.com/oven-sh/bun/issues/8069
-    // This test crashes, which will pass because stderr contains "timed out"
-    // but the crash can also mean it hangs, which will end up failing.
-    // Possibly fixed by https://github.com/oven-sh/bun/pull/8076/files
-    test("timeout can be set to 30ms", () => {
-      const stderr = runTest({
-        args: ["--timeout", "30"],
-        input: `
-          import { test, expect } from "bun:test";
-          import { sleep } from "bun";
-          test("ok", async () => {
-            await expect(sleep(1)).resolves.toBeUndefined();
-          });
-          test("timeout", async () => {
-            await expect(sleep(64)).resolves.toBeUndefined();
-          });
-        `,
-      });
-      expect(stderr).toHaveTestTimedOutAfter(30);
-    });
-    test("timeout should default to 5000ms", () => {
-      const time = process.platform === "linux" ? 5005 : 5500;
-      const stderr = runTest({
-        input: `
-          import { test, expect } from "bun:test";
-          import { sleep } from "bun";
-          test("timeout", async () => {
-            await sleep(${time});
-          });
-        `,
-      });
-      expect(stderr).toHaveTestTimedOutAfter(5000);
-    }, 10000);
-  });
   describe("support for Github Actions", () => {
-    test("should not group logs by default", () => {
-      const stderr = runTest({
+    test("should not group logs by default", async () => {
+      const stderr = await runTest({
         env: {
           GITHUB_ACTIONS: undefined,
         },
+        expectExitCode: 0,
       });
       expect(stderr).not.toContain("::group::");
       expect(stderr).not.toContain("::endgroup::");
+      expect(stderr).toContain("Ran 0 tests across 1 file.");
     });
-    test("should not group logs when disabled", () => {
-      const stderr = runTest({
+    test("should not group logs when disabled", async () => {
+      const stderr = await runTest({
         env: {
           GITHUB_ACTIONS: "false",
         },
+        expectExitCode: 0,
       });
       expect(stderr).not.toContain("::group::");
       expect(stderr).not.toContain("::endgroup::");
+      expect(stderr).toContain("Ran 0 tests across 1 file.");
     });
-    test("should group logs when enabled", () => {
-      const stderr = runTest({
+    test("should group logs when enabled", async () => {
+      const stderr = await runTest({
         env: {
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 0,
       });
       expect(stderr).toContain("::group::");
       expect(stderr.match(/::group::/g)).toHaveLength(1);
       expect(stderr).toContain("::endgroup::");
       expect(stderr.match(/::endgroup::/g)).toHaveLength(1);
     });
-    test("should group logs with multiple files", () => {
-      const stderr = runTest({
+    test("should group logs with multiple files", async () => {
+      const stderr = await runTest({
         input: [
           `
             import { test, expect } from "bun:test";
@@ -457,14 +484,15 @@ describe("bun test", () => {
         env: {
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       expect(stderr).toContain("::group::");
       expect(stderr.match(/::group::/g)).toHaveLength(3);
       expect(stderr).toContain("::endgroup::");
       expect(stderr.match(/::endgroup::/g)).toHaveLength(3);
     });
-    test("should group logs with --rerun-each", () => {
-      const stderr = runTest({
+    test("should group logs with --rerun-each", async () => {
+      const stderr = await runTest({
         args: ["--rerun-each", "3"],
         input: [
           `
@@ -483,14 +511,15 @@ describe("bun test", () => {
         env: {
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       expect(stderr).toContain("::group::");
       expect(stderr.match(/::group::/g)).toHaveLength(6);
       expect(stderr).toContain("::endgroup::");
       expect(stderr.match(/::endgroup::/g)).toHaveLength(6);
     });
-    test("should not annotate errors by default", () => {
-      const stderr = runTest({
+    test("should not annotate errors by default", async () => {
+      const stderr = await runTest({
         input: `
           import { test, expect } from "bun:test";
           test("fail", () => {
@@ -500,11 +529,13 @@ describe("bun test", () => {
         env: {
           GITHUB_ACTIONS: undefined,
         },
+        expectExitCode: 1,
       });
+      expect(stderr).toContain("(fail) fail");
       expect(stderr).not.toContain("::error");
     });
-    test("should not annotate errors with inspect() by default", () => {
-      const stderr = runTest({
+    test("should not annotate errors with inspect() by default", async () => {
+      const stderr = await runTest({
         input: `
           import { test } from "bun:test";
           import { inspect } from "bun";
@@ -516,11 +547,13 @@ describe("bun test", () => {
         env: {
           GITHUB_ACTIONS: undefined,
         },
+        expectExitCode: 0,
       });
+      expect(stderr).toContain("(pass) inspect");
       expect(stderr).not.toContain("::error");
     });
-    test("should not annotate errors with inspect() when enabled", () => {
-      const stderr = runTest({
+    test("should not annotate errors with inspect() when enabled", async () => {
+      const stderr = await runTest({
         input: `
           import { test } from "bun:test";
           import { inspect } from "bun";
@@ -532,22 +565,25 @@ describe("bun test", () => {
         env: {
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 0,
       });
+      expect(stderr).toContain("(pass) inspect");
       expect(stderr).not.toContain("::error");
     });
-    test("should annotate errors in the global scope", () => {
-      const stderr = runTest({
+    test("should annotate errors in the global scope", async () => {
+      const stderr = await runTest({
         input: `
           throw new Error();
         `,
         env: {
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error::/);
     });
-    test.each(["test", "describe"])("should annotate errors in a %s scope", type => {
-      const stderr = runTest({
+    test.each(["test", "describe"])("should annotate errors in a %s scope", async type => {
+      const stderr = await runTest({
         input: `
           import { ${type} } from "bun:test";
           ${type}("fail", () => {
@@ -557,26 +593,31 @@ describe("bun test", () => {
         env: {
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error::/);
     });
-    test.each(["beforeAll", "beforeEach", "afterEach", "afterAll"])("should annotate errors in a %s callback", type => {
-      const stderr = runTest({
-        input: `
+    test.each(["beforeAll", "beforeEach", "afterEach", "afterAll"])(
+      "should annotate errors in a %s callback",
+      async type => {
+        const stderr = await runTest({
+          input: `
           import { test, ${type} } from "bun:test";
           ${type}(() => {
             throw new Error();
           });
           test("test", () => {});
         `,
-        env: {
-          GITHUB_ACTIONS: "true",
-        },
-      });
-      expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error::/);
-    });
-    test("should annotate errors with escaped strings", () => {
-      const stderr = runTest({
+          env: {
+            GITHUB_ACTIONS: "true",
+          },
+          expectExitCode: 1,
+        });
+        expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error::/);
+      },
+    );
+    test("should annotate errors with escaped strings", async () => {
+      const stderr = await runTest({
         input: `
           import { test, expect } from "bun:test";
           test("fail", () => {
@@ -587,13 +628,14 @@ describe("bun test", () => {
           FORCE_COLOR: "1",
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=.*::/);
       expect(stderr).toMatch(/error: expect\(received\)\.toBe\(expected\)/); // stripped ansi
       expect(stderr).toMatch(/Expected: false%0AReceived: true%0A/); // escaped newlines
     });
-    test("should annotate errors without a stack", () => {
-      const stderr = runTest({
+    test("should annotate errors without a stack", async () => {
+      const stderr = await runTest({
         input: `
           import { test, expect } from "bun:test";
           test("fail", () => {
@@ -604,11 +646,12 @@ describe("bun test", () => {
           FORCE_COLOR: "1",
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       expect(stderr).toMatch(/::error file=.*,line=\d+,col=\d+,title=error: Oops!::/m);
     });
-    test("should annotate an error message containing non-ASCII bytes", () => {
-      const stderr = runTest({
+    test("should annotate an error message containing non-ASCII bytes", async () => {
+      const stderr = await runTest({
         input: `
           import { test } from "bun:test";
           test("fail", () => {
@@ -619,12 +662,13 @@ describe("bun test", () => {
           FORCE_COLOR: "1",
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
       expect(annotation).toMatch(/^::error file=.*,line=\d+,col=\d+,title=error: hello é world::%0A {6}at /);
     });
-    test("should annotate an error message containing emoji and newlines", () => {
-      const stderr = runTest({
+    test("should annotate an error message containing emoji and newlines", async () => {
+      const stderr = await runTest({
         input: `
           import { test } from "bun:test";
           test("fail", () => {
@@ -635,14 +679,15 @@ describe("bun test", () => {
           FORCE_COLOR: "1",
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
       expect(annotation).toMatch(
         /^::error file=.*,line=\d+,col=\d+,title=error: before 😋 after::second 😋 line%0A {6}at /,
       );
     });
-    test("should percent-encode metacharacters in the annotation file property", () => {
-      const stderr = runTest({
+    test("should percent-encode metacharacters in the annotation file property", async () => {
+      const stderr = await runTest({
         input: [
           {
             filename: "odd,name%path.test.ts",
@@ -657,14 +702,15 @@ describe("bun test", () => {
         env: {
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
       expect(annotation).toMatch(
         /^::error file=(.*[\\/])?odd%2Cname%25path\.test\.ts,line=\d+,col=\d+,title=error: boom::/,
       );
     });
-    test("should percent-encode metacharacters in the annotation title", () => {
-      const stderr = runTest({
+    test("should percent-encode metacharacters in the annotation title", async () => {
+      const stderr = await runTest({
         input: `
           import { test } from "bun:test";
           test("fail", () => {
@@ -677,14 +723,15 @@ describe("bun test", () => {
           FORCE_COLOR: "1",
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
       expect(annotation).toMatch(
         /^::error file=.*,line=\d+,col=\d+,title=Odd%3AName%2CWith%25Chars: alpha%3A one%2C two 100%25::beta: three, four%0A {6}at /,
       );
     });
-    test("should keep a function name containing a newline on the annotation line", () => {
-      const stderr = runTest({
+    test("should keep a function name containing a newline on the annotation line", async () => {
+      const stderr = await runTest({
         input: `
           import { test } from "bun:test";
           function inner() {
@@ -699,13 +746,14 @@ describe("bun test", () => {
           FORCE_COLOR: "1",
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
       expect(annotation).toMatch(/^::error file=.*,line=\d+,col=\d+,title=error: boom::/);
       expect(annotation).toContain("%0A      at odd%0Aname (");
     });
-    test("should annotate a test timeout", () => {
-      const stderr = runTest({
+    test("should annotate a test timeout", async () => {
+      const stderr = await runTest({
         input: `
           import { test } from "bun:test";
           test("time out", async () => {
@@ -716,16 +764,17 @@ describe("bun test", () => {
           FORCE_COLOR: "1",
           GITHUB_ACTIONS: "true",
         },
+        expectExitCode: 1,
       });
       expect(stderr).toMatch(/::error title=error: Test \"time out\" timed out after \d+ms::/);
     });
-    test("should annotate an error thrown from a source whose URL is longer than a path buffer", () => {
+    test("should annotate an error thrown from a source whose URL is longer than a path buffer", async () => {
       // Longer than a path buffer on every platform (98302 bytes on Windows).
       const padding = 100_000;
       const dataUrlModule = 'export default function fromDataUrl() { throw new Error("boom"); }//';
       const base64 = btoa(dataUrlModule + Buffer.alloc(padding, "x").toString());
       const longPath = "/" + Buffer.alloc(padding, "y").toString();
-      const stderr = runTest({
+      const stderr = await runTest({
         input: `
           import { test } from "bun:test";
           test("data url", async () => {
@@ -751,7 +800,7 @@ describe("bun test", () => {
       expect(longSourceUrl).toStartWith(`::error file=${longPath},line=1,col=`);
       expect(longSourceUrl).toContain(`%0A      at fromLongPath (${longPath}:1:`);
     });
-    test("should make the annotation file relative to GITHUB_WORKSPACE only when it is a path", () => {
+    test("should make the annotation file relative to GITHUB_WORKSPACE only when it is a path", async () => {
       const cwd = createTest([
         {
           filename: "workspace.test.ts",
@@ -766,7 +815,7 @@ describe("bun test", () => {
           `,
         },
       ]);
-      const stderr = runTest({
+      const stderr = await runTest({
         cwd,
         env: {
           GITHUB_ACTIONS: "true",
@@ -783,14 +832,14 @@ describe("bun test", () => {
     });
   });
   describe(".each", () => {
-    test("should run tests with test.each", () => {
+    test("should run tests with test.each", async () => {
       const numbers = [
         [1, 2, 3],
         [1, 1, 2],
         [3, 4, 7],
       ];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: [],
         input: `
           import { test, expect } from "bun:test";
@@ -799,19 +848,20 @@ describe("bun test", () => {
             expect(a + b).toBe(e);
           });
         `,
+        expectExitCode: 0,
       });
       numbers.forEach(numbers => {
         expect(stderr).toContain(`${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
       });
     });
-    test("should allow tests run with test.each to be skipped", () => {
+    test("should allow tests run with test.each to be skipped", async () => {
       const numbers = [
         [1, 2, 3],
         [1, 1, 2],
         [3, 4, 7],
       ];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: ["-t", "$a"],
         input: `
           import { test, expect } from "bun:test";
@@ -820,19 +870,20 @@ describe("bun test", () => {
             expect(a + b).toBe(e);
           });
         `,
+        expectExitCode: 1,
       });
       numbers.forEach(numbers => {
         expect(stderr).not.toContain(`(pass) ${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
       });
     });
-    test("should allow tests run with test.each to be matched", () => {
+    test("should allow tests run with test.each to be matched", async () => {
       const numbers = [
         [1, 2, 3],
         [1, 1, 2],
         [3, 4, 7],
       ];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: ["-t", "1 \\+"],
         input: `
           import { test, expect } from "bun:test";
@@ -841,6 +892,7 @@ describe("bun test", () => {
             expect(a + b).toBe(e);
           });
         `,
+        expectExitCode: 0,
       });
       numbers.forEach(numbers => {
         if (numbers[0] === 1) {
@@ -850,14 +902,14 @@ describe("bun test", () => {
         }
       });
     });
-    test("should run tests with describe.each", () => {
+    test("should run tests with describe.each", async () => {
       const numbers = [
         [1, 2, 3],
         [1, 1, 2],
         [3, 4, 7],
       ];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: [],
         input: `
           import { test, expect, describe } from "bun:test";
@@ -868,19 +920,20 @@ describe("bun test", () => {
             });
           });
         `,
+        expectExitCode: 0,
       });
       numbers.forEach(numbers => {
         expect(stderr).toContain(`${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
       });
     });
-    test("check formatting for %i", () => {
+    test("check formatting for %i", async () => {
       const numbers = [
         [1, 2, 3],
         [1, 1, 2],
         [3, 4, 7],
       ];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: [],
         input: `
           import { test, expect } from "bun:test";
@@ -889,71 +942,75 @@ describe("bun test", () => {
             expect(a + b).toBe(e);
           });
         `,
+        expectExitCode: 0,
       });
       numbers.forEach(numbers => {
         expect(stderr).toContain(`${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
       });
     });
-    test("check formatting for %f", () => {
+    test("check formatting for %f", async () => {
       const numbers = [
         [1.4, 2.9, 4.3],
         [1, 1, 2],
         [3.1, 4.5, 7.6],
       ];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: [],
         input: `
           import { test, expect } from "bun:test";
 
           test.each(${JSON.stringify(numbers)})("%f + %f = %d", (a, b, e) => {
-            expect(a + b).toBe(e);
+            expect(a + b).toBeCloseTo(e);
           });
         `,
+        expectExitCode: 0,
       });
       numbers.forEach(numbers => {
         expect(stderr).toContain(`${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
       });
     });
-    test("check formatting for %d", () => {
+    test("check formatting for %d", async () => {
       const numbers = [
         [1.4, 2.9, 4.3],
         [1, 1, 2],
         [3.1, 4.5, 7.6],
       ];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: [],
         input: `
           import { test, expect } from "bun:test";
 
           test.each(${JSON.stringify(numbers)})("%f + %f = %d", (a, b, e) => {
-            expect(a + b).toBe(e);
+            expect(a + b).toBeCloseTo(e);
           });
         `,
+        expectExitCode: 0,
       });
       numbers.forEach(numbers => {
         expect(stderr).toContain(`${numbers[0]} + ${numbers[1]} = ${numbers[2]}`);
       });
     });
-    test("check formatting for %s", () => {
+    test("check formatting for %s", async () => {
       const strings = ["hello", "world", "foo"];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: [],
         input: `
           import { test, expect } from "bun:test";
 
           test.each(${JSON.stringify(strings)})("with a string: %s", (s) => {
-            expect(s).toBeType("string");
+            expect(s).toBeTypeOf("string");
           });
         `,
+        expectExitCode: 0,
       });
       strings.forEach(s => {
         expect(stderr).toContain(`with a string: ${s}`);
       });
     });
-    test("check formatting for %j", () => {
+    test("check formatting for %j", async () => {
       const input = [
         {
           foo: "bar",
@@ -965,7 +1022,7 @@ describe("bun test", () => {
         },
       ];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: [],
         input: `
           import { test, expect } from "bun:test";
@@ -974,10 +1031,11 @@ describe("bun test", () => {
             expect(o).toBe(o);
           });
         `,
+        expectExitCode: 0,
       });
       expect(stderr).toContain(`with an object: ${JSON.stringify(input[0])}`);
     });
-    test("check formatting for %o", () => {
+    test("check formatting for %o", async () => {
       const input = [
         {
           foo: "bar",
@@ -989,7 +1047,7 @@ describe("bun test", () => {
         },
       ];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: [],
         input: `
           import { test, expect } from "bun:test";
@@ -998,17 +1056,18 @@ describe("bun test", () => {
             expect(o).toBe(o);
           });
         `,
+        expectExitCode: 0,
       });
       expect(stderr).toContain(`with an object: ${JSON.stringify(input[0])}`);
     });
-    test("check formatting for %#", () => {
+    test("check formatting for %#", async () => {
       const numbers = [
         [1, 2, 3],
         [1, 1, 2],
         [3, 4, 7],
       ];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: [],
         input: `
           import { test, expect } from "bun:test";
@@ -1017,19 +1076,20 @@ describe("bun test", () => {
             expect(a + b).toBe(e);
           });
         `,
+        expectExitCode: 0,
       });
       numbers.forEach((_, idx) => {
         expect(stderr).toContain(`test number ${idx}:`);
       });
     });
-    test("check formatting for %%", () => {
+    test("check formatting for %%", async () => {
       const numbers = [
         [1, 2, 3],
         [1, 1, 2],
         [3, 4, 7],
       ];
 
-      const stderr = runTest({
+      const stderr = await runTest({
         args: [],
         input: `
           import { test, expect } from "bun:test";
@@ -1038,20 +1098,21 @@ describe("bun test", () => {
             expect(a + b).toBe(e);
           });
         `,
+        expectExitCode: 0,
       });
       expect(stderr).toContain(`%`);
     });
     test.todo("check formatting for %p", () => {});
 
     describe("$variable syntax", () => {
-      test("should replace $variables with object properties in test names", () => {
+      test("should replace $variables with object properties in test names", async () => {
         const cases = [
           { a: 1, b: 2, expected: 3 },
           { a: 5, b: 5, expected: 10 },
           { a: -1, b: 1, expected: 0 },
         ];
 
-        const stderr = runTest({
+        const stderr = await runTest({
           args: [],
           input: `
             import { test, expect } from "bun:test";
@@ -1061,6 +1122,7 @@ describe("bun test", () => {
               expect(a + b).toBe(expected);
             });
           `,
+          expectExitCode: 0,
         });
 
         expect(stderr).toContain("(pass) 1 + 2 = 3");
@@ -1069,10 +1131,10 @@ describe("bun test", () => {
         expect(stderr).toContain("3 pass");
       });
 
-      test("should show $variable literal when property doesn't exist", () => {
+      test("should show $variable literal when property doesn't exist", async () => {
         const cases = [{ a: 1 }, { a: 2 }];
 
-        const stderr = runTest({
+        const stderr = await runTest({
           args: [],
           input: `
             import { test, expect } from "bun:test";
@@ -1082,6 +1144,7 @@ describe("bun test", () => {
               expect(a).toBeDefined();
             });
           `,
+          expectExitCode: 0,
         });
 
         expect(stderr).toContain("(pass) value 1 with missing $nonexistent");
@@ -1089,13 +1152,13 @@ describe("bun test", () => {
         expect(stderr).toContain("2 pass");
       });
 
-      test("should work with describe.each", () => {
+      test("should work with describe.each", async () => {
         const cases = [
           { module: "fs", method: "readFile" },
           { module: "path", method: "join" },
         ];
 
-        const stderr = runTest({
+        const stderr = await runTest({
           args: [],
           input: `
             import { test, expect, describe } from "bun:test";
@@ -1108,6 +1171,7 @@ describe("bun test", () => {
               });
             });
           `,
+          expectExitCode: 0,
         });
 
         expect(stderr).toContain("fs module > has $method");
@@ -1115,13 +1179,13 @@ describe("bun test", () => {
         expect(stderr).toContain("2 pass");
       });
 
-      test("should work with complex property names", () => {
+      test("should work with complex property names", async () => {
         const cases = [
           { user_name: "john_doe", age: 30, is_active: true },
           { user_name: "jane_smith", age: 25, is_active: false },
         ];
 
-        const stderr = runTest({
+        const stderr = await runTest({
           args: [],
           input: `
             import { test, expect } from "bun:test";
@@ -1133,6 +1197,7 @@ describe("bun test", () => {
               expect(typeof is_active).toBe('boolean');
             });
           `,
+          expectExitCode: 0,
         });
 
         expect(stderr).toContain("(pass) user john_doe age 30 active true");
@@ -1140,13 +1205,13 @@ describe("bun test", () => {
         expect(stderr).toContain("2 pass");
       });
 
-      test("should coexist with % formatting for arrays", () => {
+      test("should coexist with % formatting for arrays", async () => {
         const numbers = [
           [1, 2, 3],
           [5, 5, 10],
         ];
 
-        const stderr = runTest({
+        const stderr = await runTest({
           args: [],
           input: `
             import { test, expect } from "bun:test";
@@ -1155,6 +1220,7 @@ describe("bun test", () => {
               expect(a + b).toBe(expected);
             });
           `,
+          expectExitCode: 0,
         });
 
         expect(stderr).toContain("(pass) 1 + 2 = 3");
@@ -1162,7 +1228,7 @@ describe("bun test", () => {
         expect(stderr).toContain("2 pass");
       });
 
-      test("should support nested property access", () => {
+      test("should support nested property access", async () => {
         const cases = [
           {
             user: { name: "Alice", profile: { city: "NYC" } },
@@ -1174,7 +1240,7 @@ describe("bun test", () => {
           },
         ];
 
-        const stderr = runTest({
+        const stderr = await runTest({
           args: [],
           input: `
             import { test, expect } from "bun:test";
@@ -1184,6 +1250,7 @@ describe("bun test", () => {
               expect(\`\${user.name} from \${user.profile.city}\`).toBe(expected);
             });
           `,
+          expectExitCode: 0,
         });
 
         expect(stderr).toContain("(pass) Alice from NYC");
@@ -1191,7 +1258,7 @@ describe("bun test", () => {
         expect(stderr).toContain("2 pass");
       });
 
-      test("should support array indexing with dot notation", () => {
+      test("should support array indexing with dot notation", async () => {
         const cases = [
           {
             users: [{ name: "Alice" }, { name: "Bob" }],
@@ -1203,7 +1270,7 @@ describe("bun test", () => {
           },
         ];
 
-        const stderr = runTest({
+        const stderr = await runTest({
           args: [],
           input: `
             import { test, expect } from "bun:test";
@@ -1213,6 +1280,7 @@ describe("bun test", () => {
               expect(users[0].name).toBe(first);
             });
           `,
+          expectExitCode: 0,
         });
 
         expect(stderr).toContain("(pass) first user is Alice");
@@ -1220,7 +1288,7 @@ describe("bun test", () => {
         expect(stderr).toContain("2 pass");
       });
 
-      test("handles edge cases with underscores and invalid identifiers", () => {
+      test("handles edge cases with underscores and invalid identifiers", async () => {
         const cases = [
           {
             _valid: "underscore",
@@ -1232,7 +1300,7 @@ describe("bun test", () => {
           },
         ];
 
-        const stderr = runTest({
+        const stderr = await runTest({
           args: [],
           input: `
             import { test, expect } from "bun:test";
@@ -1242,6 +1310,7 @@ describe("bun test", () => {
               expect(obj).toBeDefined();
             });
           `,
+          expectExitCode: 0,
         });
 
         expect(stderr).toContain("underscore");
@@ -1252,7 +1321,7 @@ describe("bun test", () => {
         expect(stderr).toContain("$hasspace");
       });
 
-      test("handles deeply nested properties with arrays", () => {
+      test("handles deeply nested properties with arrays", async () => {
         const cases = [
           {
             data: {
@@ -1265,7 +1334,7 @@ describe("bun test", () => {
           },
         ];
 
-        const stderr = runTest({
+        const stderr = await runTest({
           args: [],
           input: `
             import { test, expect } from "bun:test";
@@ -1275,17 +1344,18 @@ describe("bun test", () => {
               expect(obj).toBeDefined();
             });
           `,
+          expectExitCode: 0,
         });
 
         expect(stderr).toContain("First user: Alice with tag: admin");
       });
 
-      test("surfaces a throwing custom formatter in the interpolated value as a test error", () => {
+      test("surfaces a throwing custom formatter in the interpolated value as a test error", async () => {
         // The declaration throw aborts module evaluation, so each variant
         // needs its own file to be verified independently.
         const throwing = (message: string) =>
           `({ [Symbol.for("nodejs.util.inspect.custom")]() { throw new Error(${JSON.stringify(message)}); } })`;
-        const stderr = runTest({
+        const stderr = await runTest({
           args: [],
           expectExitCode: 1,
           input: [
@@ -1330,10 +1400,10 @@ describe("bun test", () => {
         expect(stderr).toContain("boom from describe.each %p");
       });
 
-      test("handles missing properties gracefully", () => {
+      test("handles missing properties gracefully", async () => {
         const cases = [{ a: 1 }];
 
-        const stderr = runTest({
+        const stderr = await runTest({
           args: [],
           input: `
             import { test, expect } from "bun:test";
@@ -1343,6 +1413,7 @@ describe("bun test", () => {
               expect(a).toBe(1);
             });
           `,
+          expectExitCode: 0,
         });
 
         expect(stderr).toContain("1 | $missing| $a.b.c| 1");
@@ -1350,8 +1421,8 @@ describe("bun test", () => {
     });
   });
 
-  test("Prints error when no test matches", () => {
-    const stderr = runTest({
+  test("Prints error when no test matches", async () => {
+    const stderr = await runTest({
       args: ["-t", "not-a-test"],
       input: `
         import { test, expect } from "bun:test";
@@ -1371,8 +1442,8 @@ describe("bun test", () => {
     `);
   });
 
-  test("Does not print the regex error when a test fails", () => {
-    const stderr = runTest({
+  test("Does not print the regex error when a test fails", async () => {
+    const stderr = await runTest({
       args: ["-t", "not-a-test"],
       input: `
         import { test, expect } from "bun:test";
@@ -1386,8 +1457,8 @@ describe("bun test", () => {
     expect(stderr).toContain("1 fail");
   });
 
-  test("Does not print the regex error when a test matches and a test passes", () => {
-    const stderr = runTest({
+  test("Does not print the regex error when a test matches and a test passes", async () => {
+    const stderr = await runTest({
       args: ["-t", "not-a-test"],
       input: `
         import { test, expect } from "bun:test";
@@ -1405,8 +1476,8 @@ describe("bun test", () => {
     expect(stderr).toContain("1 pass");
   });
 
-  test("path to a non-test.ts file will work", () => {
-    const stderr = runTest({
+  test("path to a non-test.ts file will work", async () => {
+    const stderr = await runTest({
       args: ["./index.ts"],
       input: [
         {
@@ -1419,12 +1490,13 @@ describe("bun test", () => {
           `,
         },
       ],
+      expectExitCode: 0,
     });
     expect(stderr).toContain("test #1");
   });
 
-  test("path to a non-test.ts without ./ will print a helpful hint", () => {
-    const stderr = runTest({
+  test("path to a non-test.ts without ./ will print a helpful hint", async () => {
+    const stderr = await runTest({
       args: ["index.ts"],
       input: [
         {
@@ -1437,13 +1509,14 @@ describe("bun test", () => {
           `,
         },
       ],
+      expectExitCode: 1,
     });
     expect(stderr).not.toContain("test #1");
-    expect(stderr).toContain("index.ts");
+    expect(stderr).toContain('note: To treat the "index.ts" filter as a path, run "bun test ./index.ts"');
   });
 
-  test("Skipped and todo tests are filtered out when not matching -t filter", () => {
-    const stderr = runTest({
+  test("Skipped and todo tests are filtered out when not matching -t filter", async () => {
+    const stderr = await runTest({
       args: ["-t", "should match"],
       input: `
         import { test, describe } from "bun:test";
@@ -1480,12 +1553,12 @@ describe("bun test", () => {
           });
         });
       `,
+      expectExitCode: 0,
     });
     expect(
       stderr
         .replace(/bun-test-(.*)\.test\.ts/, "bun-test-*.test.ts")
         .replace(/ \[[\d.]+ms\]/g, "") // Remove all timings
-        .replace(/Ran \d+ tests across \d+ files?\.\s*$/, "Ran 2 tests across 1 file.") // Normalize test counts
         .trim(),
     ).toMatchInlineSnapshot(`
       "bun-test-*.test.ts:
@@ -1830,7 +1903,8 @@ function createTest(input?: string | (string | { filename: string; contents: str
   return cwd;
 }
 
-function runTest({
+/** Runs `bun test` and returns its stderr. Async so that concurrent tests overlap. */
+async function runTest({
   input = "",
   cwd,
   args = [],
@@ -1842,20 +1916,21 @@ function runTest({
   args?: string[];
   env?: Record<string, string | undefined>;
   expectExitCode?: number;
-} = {}): string {
+} = {}): Promise<string> {
   cwd ??= createTest(input);
   try {
-    const { stderr, exitCode } = spawnSync({
+    await using proc = Bun.spawn({
       cwd,
       cmd: [bunExe(), "test", ...args],
       env: { ...bunEnv, AGENT: "0", ...env },
       stderr: "pipe",
       stdout: "ignore",
     });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
     if (expectExitCode !== undefined) {
-      expect(exitCode).toBe(expectExitCode);
+      expect(exitCode, `bun test exited with ${exitCode}, stderr:\n${stderr}`).toBe(expectExitCode);
     }
-    return stderr.toString();
+    return stderr;
   } finally {
     rmSync(cwd, { recursive: true });
   }

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -28,9 +28,8 @@ describe.concurrent("bun test", () => {
     // promise costs nothing.
     const hangingTest = `
       import { test, expect } from "bun:test";
-      import { sleep } from "bun";
-      test("ok", async () => {
-        await expect(sleep(1)).resolves.toBeUndefined();
+      test("ok", () => {
+        expect().pass();
       });
       test("timeout", async () => {
         await new Promise(() => {});


### PR DESCRIPTION
### Problem
- `test/cli/test/bun-test.test.ts` takes 13.5 s on the x64-asan lane (build #104578) and 33 s on a local debug build. It spawns 100 `bun test` children one at a time, because `runTest` uses `spawnSync`.
- 62 of the 73 `runTest` calls never check the exit code. That hid two broken fixtures: `%s` calls a matcher that does not exist, and `%f`/`%d` compare floats with `toBe`.
- The default-timeout case races `sleep(5005)` against the 5000 ms timeout.

### Fix
- `runTest` uses `Bun.spawn`, every call site awaits it, and the main `describe` is `describe.concurrent`. Cases and names are unchanged, so the other open PRs on this file rebase by adding `await`.
- The `--timeout` block comes first so that its 5 s case overlaps with the rest. The filter case builds its fixture inside the test, because a `beforeAll` hook is a barrier for the tests declared above it. Both timeout fixtures await a promise that never settles.
- Every `runTest` call passes `expectExitCode`, and a failed check prints the child's stderr. Cases with only `not.toContain` assertions also assert a line the run must print.
- Verified: `bun bd test test/cli/test/bun-test.test.ts`, 4 runs, 11.7 s to 11.9 s (104 tests). Before: 3 runs, 32.9 s to 33.6 s. The Notes explain why the first version of this PR was re-cut.

### Background
- Under ASAN, `bun test` runs at most 5 concurrent tests (`max_concurrency` in `src/options_types/context.rs`). The file's wall time is `max(5 s, child durations / 5)` plus 2 s to load `harness`. On CI the children take about 85 ms, so the 5 s case is the floor.

<details><summary>Notes</summary>

**Why this shape**

The first version of this PR (8f93c5b035) also merged same-fixture cases into shared spawns, switched stable outputs to inline snapshots, and changed `runTest` to return `{ stdout, stderr, snapshot, exitCode }`. A self-review measured it against a concurrency-only variant:

- local debug ASAN: main 32.8 s, concurrency-only 11.4 s, full rewrite 9.0 s to 10.1 s
- CI x64-asan: main 13.5 s, full rewrite 5.3 s (build #104831); the concurrency-only variant is also bound by the 5 s default-timeout case
- open PRs that touch this file: 38. Merged onto the concurrency-only shape, 26 conflict on adjacent lines; onto the full rewrite, 31 conflict over about 4000 lines, and 17 of them call the old sync `runTest`.

The 2 s local gain of the rewrite did not pay for that, so the PR is re-cut to the small shape. #33704 (open, conflicting, 53 files) has a hunk for this file with the same conversion; this PR supersedes that hunk.

**Fixture bugs found by the exit code checks**

- `check formatting for %s` called `expect(s).toBeType("string")`, which does not exist. Every child test failed. It now calls `toBeTypeOf`.
- `check formatting for %f` and `%d` asserted `expect(1.4 + 2.9).toBe(4.3)`, which fails in floating point. They now use `toBeCloseTo`.

**Other changes**

- The `-t` snapshot no longer rewrites the `Ran ...` line to a fixed count before comparing.
- The 30 ms case asserts `(fail) timeout` and the exact `timed out after 30ms.` message. It does not assert that the fast `ok` test passes: on the Windows 2019 x64 lane, `ok` exceeded 30 ms under 20 concurrent children (build #104816).
- `path to a non-test.ts without ./` asserts the `note: To treat the "index.ts" filter as a path` hint.
- The stale comment about #8069 (fixed by #8076) is gone.

**Timing**

- Local debug ASAN, before: 33.63 s, 32.94 s, 33.05 s.
- Local debug ASAN, after: 11.90 s, 11.74 s, 11.67 s, 11.69 s. Sum of per-test durations about 44 s, so the file is bound by the 5-slot ASAN limit locally.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->