### PR TITLE
test(install): compare stderr exactly and pin package.json and bun.lock in bun-add-catalog.test.ts

### DIFF
--- a/test/cli/install/bun-add-catalog.test.ts
+++ b/test/cli/install/bun-add-catalog.test.ts
@@ -733,7 +733,10 @@ describe.concurrent("bun add --catalog", () => {
       const cwd = from === "member" ? dir.pkg1Dir : dir.packageDir;
       const { stdout, stderr, exitCode } = await dir.add(cwd, "no-deps", "--catalog", "--dry-run");
 
-      expect(summary(stdout)).toBe("pkg1@workspace:packages/pkg1\ninstalled no-deps@2.0.0\n\ndone");
+      // The listing prints the workspace path with the native separator.
+      expect(summary(stdout).replaceAll("\\", "/")).toBe(
+        "pkg1@workspace:packages/pkg1\ninstalled no-deps@2.0.0\n\ndone",
+      );
       expect(stderr).toBe("");
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);

--- a/test/cli/install/bun-add-catalog.test.ts
+++ b/test/cli/install/bun-add-catalog.test.ts
@@ -2,7 +2,7 @@ import { file, write } from "bun";
 import { readTarball } from "bun:internal-for-testing";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted } from "harness";
 import { join } from "path";
 
 const registry = new VerdaccioRegistry();
@@ -15,14 +15,27 @@ afterAll(() => {
   registry.stop();
 });
 
-const PKG1 = JSON.stringify({ name: "pkg1", version: "1.0.0" });
+type Json = Record<string, any>;
+
+const PKG1_JSON = { name: "pkg1", version: "1.0.0" };
+const PKG1 = JSON.stringify(PKG1_JSON);
 // `bun add` re-prints the package.json it edits; fixtures asserted byte-for-byte afterwards are written in that shape.
-const pretty = (json: Record<string, unknown>) => JSON.stringify(json, null, 2);
+const pretty = (json: Json) => JSON.stringify(json, null, 2);
+const parse = (json: Json | string): Json => (typeof json === "string" ? JSON.parse(json) : json);
+/** `json` with `deps` added to (or replaced in) its dependencies. */
+const withDeps = (json: Json, deps: Record<string, string>) => ({
+  ...json,
+  dependencies: { ...json.dependencies, ...deps },
+});
 
 // CI's per-file BUN_INSTALL_CACHE_DIR overrides bunfig's cache; concurrent installs sharing it race on Windows.
 function envFor(packageDir: string) {
   return { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") };
 }
+
+// These two lines, and the count in the second one, only say what a run had to download, so stderr comes back without
+// them and callers compare the rest exactly: `Saved lockfile` when bun.lock was written, nothing when it was not.
+const PROGRESS_LINES = /^(?:Resolving dependencies|Resolved, downloaded and extracted \[\d+\])\n/gm;
 
 async function spawnBun(cwd: string, args: string[], env: Record<string, string | undefined>) {
   await using proc = Bun.spawn({
@@ -34,12 +47,83 @@ async function spawnBun(cwd: string, args: string[], env: Record<string, string 
     stdin: "ignore",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, exitCode };
+  return { stdout, stderr: stderr.replace(PROGRESS_LINES, ""), exitCode };
+}
+
+type Result = Awaited<ReturnType<typeof spawnBun>>;
+
+/** stdout without the `bun <command> v<version> (<sha>)` header and the timings: the package lines and the summary. */
+function summary(stdout: string) {
+  return stdout
+    .replace(/^bun [a-z ]+ v\S+ \([0-9a-f]+\)\n/, "")
+    .replace(/ ?\[[\d.]+m?s\] ?/g, "")
+    .trim();
+}
+
+/** The summary of a `bun install` that found node_modules complete, with either linker. */
+const NO_CHANGES = /^(?:Done! )?Checked (?:\d+ installs? across )?\d+ packages \(no changes\)$/;
+
+/** The command wrote bun.lock and printed nothing else: no warning, no note, no error. */
+function expectSaved({ stderr, exitCode }: Result) {
+  expect(stderr).toBe("Saved lockfile\n");
+  expect(exitCode).toBe(0);
+}
+
+/** The command found nothing to change in bun.lock and printed nothing. */
+function expectUnchanged({ stderr, exitCode }: Result) {
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+}
+
+const LOCK_ROW_KEYS = [
+  "name",
+  "version",
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+] as const;
+
+/** The `workspaces` row bun.lock keeps for a package.json: its name, version and dependency groups, nothing else. */
+const lockRow = (json: Json) =>
+  Object.fromEntries(LOCK_ROW_KEYS.filter(key => key in json).map(key => [key, json[key]]));
+
+/**
+ * The catalog objects bun reads from a root package.json: the ones inside a `workspaces` object when it has any, else
+ * the top-level ones. An empty object is not written to bun.lock.
+ */
+function catalogsOf(root: Json) {
+  const workspaces = root.workspaces;
+  const holder =
+    workspaces && !Array.isArray(workspaces) && ("catalog" in workspaces || "catalogs" in workspaces)
+      ? workspaces
+      : root;
+  const nonEmpty = (object: Json | undefined) => object !== undefined && Object.keys(object).length > 0;
+  return {
+    ...(nonEmpty(holder.catalog) && { catalog: holder.catalog }),
+    ...(nonEmpty(holder.catalogs) && { catalogs: holder.catalogs }),
+  };
+}
+
+/**
+ * The sections of bun.lock these tests pin: the workspace rows, the catalog objects, and the resolution of every
+ * package (the first entry of its tuple, `name@version`, or `name@<url>` for a tarball).
+ */
+function lockView(text: string) {
+  const { workspaces, catalog, catalogs, packages } = Bun.JSONC.parse(text) as Json;
+  return {
+    workspaces,
+    ...(catalog && { catalog }),
+    ...(catalogs && { catalogs }),
+    packages: Object.fromEntries(
+      Object.entries(packages as Record<string, unknown[]>).map(([key, row]) => [key, row[0]]),
+    ),
+  };
 }
 
 async function createDir(
-  root: Record<string, unknown> | string,
-  pkg1: Record<string, unknown> | string = PKG1,
+  root: Json | string,
+  pkg1: Json | string = PKG1,
   extraFiles: Record<string, string> = {},
   linker: "hoisted" | "isolated" = "hoisted",
 ) {
@@ -55,7 +139,10 @@ async function createDir(
   const rootPath = join(packageDir, "package.json");
   const pkg1Path = join(packageDir, "packages", "pkg1", "package.json");
   const pkg2Path = join(packageDir, "packages", "pkg2", "package.json");
+  const lockPath = join(packageDir, "bun.lock");
   const env = envFor(packageDir);
+  const members = "packages/pkg2/package.json" in extraFiles ? ["pkg1", "pkg2"] : ["pkg1"];
+  const lock = async () => lockView(await file(lockPath).text());
 
   return {
     packageDir,
@@ -63,7 +150,7 @@ async function createDir(
     run: (cwd: string, args: string[], spawnEnv: Record<string, string | undefined> = env) =>
       spawnBun(cwd, args, spawnEnv),
     add: (cwd: string, ...args: string[]) => spawnBun(cwd, ["add", ...args], env),
-    install: (options: Parameters<typeof runBunInstall>[2] = {}) => runBunInstall(env, packageDir, options),
+    install: () => spawnBun(packageDir, ["install"], env),
     pkg1Dir: join(packageDir, "packages", "pkg1"),
     pkg2Dir: join(packageDir, "packages", "pkg2"),
     rootPath,
@@ -74,99 +161,136 @@ async function createDir(
     rootText: () => file(rootPath).text(),
     pkg1Text: () => file(pkg1Path).text(),
     pkg2Text: () => file(pkg2Path).text(),
-    lockText: () => file(join(packageDir, "bun.lock")).text(),
-    lockExists: () => file(join(packageDir, "bun.lock")).exists(),
-    lock: async () => Bun.JSONC.parse(await file(join(packageDir, "bun.lock")).text()) as any,
+    lockText: () => file(lockPath).text(),
+    lockExists: () => file(lockPath).exists(),
+    lock,
     installed: (name: string) => file(join(packageDir, "node_modules", name, "package.json")).json(),
     installedExists: (name: string) => file(join(packageDir, "node_modules", name, "package.json")).exists(),
     memberInstalled: (member: string, name: string) =>
       file(join(packageDir, "packages", member, "node_modules", name, "package.json")).json(),
     store: () => readdirSorted(join(packageDir, "node_modules", ".bun")),
-    frozen: () => spawnBun(packageDir, ["install", "--frozen-lockfile"], env),
+    /**
+     * The package.json files are exactly `root`, `pkg1` and, when the workspace has one, `pkg2`, and bun.lock mirrors
+     * them: one `workspaces` row per file, the root's catalog objects, and a resolution for each member and each
+     * entry of `packages`.
+     */
+    expectFiles: async (expected: {
+      root: Json | string;
+      pkg1: Json | string;
+      pkg2?: Json | string;
+      packages: Json;
+    }) => {
+      const root = parse(expected.root);
+      const pkg1 = parse(expected.pkg1);
+      const workspaces: Json = { "": lockRow(root), "packages/pkg1": lockRow(pkg1) };
+      expect(await file(rootPath).json()).toStrictEqual(root);
+      expect(await file(pkg1Path).json()).toStrictEqual(pkg1);
+      if (members.includes("pkg2")) {
+        const pkg2 = parse(expected.pkg2!);
+        expect(await file(pkg2Path).json()).toStrictEqual(pkg2);
+        workspaces["packages/pkg2"] = lockRow(pkg2);
+      }
+      expect(await lock()).toStrictEqual({
+        workspaces,
+        ...catalogsOf(root),
+        packages: {
+          ...Object.fromEntries(members.map(member => [member, `${member}@workspace:packages/${member}`])),
+          ...expected.packages,
+        },
+      });
+    },
+    /** `bun install --frozen-lockfile` accepts package.json and bun.lock as written. */
+    frozenOk: async () => {
+      const { stderr, exitCode } = await spawnBun(packageDir, ["install", "--frozen-lockfile"], env);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+    /** A plain `bun install` afterwards finds package.json, bun.lock and node_modules in step: nothing to save or link. */
     installSavesNothing: async () => {
-      const { err } = await runBunInstall(env, packageDir, { savesLockfile: false });
-      expect(err).not.toContain("Saved lockfile");
+      const { stdout, stderr, exitCode } = await spawnBun(packageDir, ["install"], env);
+      expect(stderr).toBe("");
+      expect(summary(stdout)).toMatch(NO_CHANGES);
+      expect(exitCode).toBe(0);
+    },
+    /**
+     * `installSavesNothing` for a workspace with a tarball dependency. Every install re-extracts a tarball (its
+     * `version` cannot be checked against a URL or path, #8260), so the summary reports one package installed and is
+     * not pinned; bun.lock still has nothing to save.
+     */
+    installKeepsLockfile: async () => {
+      const { stderr, exitCode } = await spawnBun(packageDir, ["install"], env);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
     },
   };
 }
 
-const PKG2 = JSON.stringify({ name: "pkg2", version: "1.0.0" });
-const withPkg2 = (pkg2: Record<string, unknown> | string = PKG2) => ({
+const PKG2_JSON = { name: "pkg2", version: "1.0.0" };
+const PKG2 = JSON.stringify(PKG2_JSON);
+const withPkg2 = (pkg2: Json | string = PKG2) => ({
   "packages/pkg2/package.json": typeof pkg2 === "string" ? pkg2 : JSON.stringify(pkg2),
 });
 
-function expectOk({ stderr, exitCode }: { stderr: string; exitCode: number }) {
-  expect(stderr).not.toContain("error:");
-  expect(stderr).not.toContain("panic:");
-  expect(exitCode).toBe(0);
-}
-
-const workspacesObject = (catalogs: Record<string, unknown> = {}) => ({
+const workspacesObject = (catalogs: Json = {}) => ({
   name: "root",
   workspaces: { packages: ["packages/*"], ...catalogs },
 });
+
+/** The `--catalog` refusal for a workspace member named `pkg2`. */
+const PKG2_MESSAGE = 'error: --catalog cannot add a workspace package, but "pkg2" is the workspace at packages/pkg2\n';
 
 describe.concurrent("bun add --catalog", () => {
   test("default catalog from a workspace member", async () => {
     const dir = await createDir(workspacesObject({ catalog: {} }));
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+    expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+    await dir.expectFiles({
+      root: workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
+      pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+      packages: { "no-deps": "no-deps@2.0.0" },
+    });
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
 
-    const lock = await dir.lock();
-    expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-    expect(lock.packages["no-deps"][0]).toBe("no-deps@2.0.0");
-
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   test("named catalog creates the catalogs object", async () => {
     const dir = await createDir(workspacesObject({ catalog: { "no-deps": "1.0.0" } }));
 
-    expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=testing"));
+    expectSaved(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=testing"));
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:testing" });
-    expect((await dir.root()).workspaces).toStrictEqual({
-      packages: ["packages/*"],
-      catalog: { "no-deps": "1.0.0" },
-      catalogs: { testing: { "a-dep": "^1.0.10" } },
+    await dir.expectFiles({
+      root: workspacesObject({ catalog: { "no-deps": "1.0.0" }, catalogs: { testing: { "a-dep": "^1.0.10" } } }),
+      pkg1: withDeps(PKG1_JSON, { "a-dep": "catalog:testing" }),
+      packages: { "a-dep": "a-dep@1.0.10" },
     });
     expect((await dir.installed("a-dep")).version).toBe("1.0.10");
-
-    const lock = await dir.lock();
-    expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "a-dep": "catalog:testing" });
-    expect(lock.catalogs).toStrictEqual({ testing: { "a-dep": "^1.0.10" } });
   });
 
   describe("placement when no catalog is defined yet", () => {
     test("workspaces object gets workspaces.catalog", async () => {
       const dir = await createDir(workspacesObject());
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-      expect(await dir.root()).toStrictEqual({
-        name: "root",
-        workspaces: { packages: ["packages/*"], catalog: { "no-deps": "^2.0.0" } },
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+        packages: { "no-deps": "no-deps@2.0.0" },
       });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
     });
 
     test("workspaces array gets a top-level catalog", async () => {
       const dir = await createDir({ name: "root", workspaces: ["packages/*"] });
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-      expect(await dir.root()).toStrictEqual({
-        name: "root",
-        workspaces: ["packages/*"],
-        catalog: { "no-deps": "^2.0.0" },
+      await dir.expectFiles({
+        root: { name: "root", workspaces: ["packages/*"], catalog: { "no-deps": "^2.0.0" } },
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+        packages: { "no-deps": "no-deps@2.0.0" },
       });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
     });
   });
 
@@ -176,30 +300,31 @@ describe.concurrent("bun add --catalog", () => {
     test("default catalog", async () => {
       const dir = await createDir(topLevel);
 
-      expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, "a-dep", "--catalog"));
 
-      const root = await dir.root();
-      expect(root).toStrictEqual({
-        name: "root",
-        catalog: { "a-dep": "^1.0.10", "no-deps": "1.0.0" },
-        workspaces: ["packages/*"],
+      await dir.expectFiles({
+        root: { name: "root", catalog: { "a-dep": "^1.0.10", "no-deps": "1.0.0" }, workspaces: ["packages/*"] },
+        pkg1: withDeps(PKG1_JSON, { "a-dep": "catalog:" }),
+        packages: { "a-dep": "a-dep@1.0.10" },
       });
-      expect(Object.keys(root.catalog)).toStrictEqual(["a-dep", "no-deps"]);
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
+      expect(Object.keys((await dir.root()).catalog)).toStrictEqual(["a-dep", "no-deps"]);
     });
 
     test("named catalog", async () => {
       const dir = await createDir(topLevel);
 
-      expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=x"));
+      expectSaved(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=x"));
 
-      expect(await dir.root()).toStrictEqual({
-        name: "root",
-        catalog: { "no-deps": "1.0.0" },
-        catalogs: { x: { "a-dep": "^1.0.10" } },
-        workspaces: ["packages/*"],
+      await dir.expectFiles({
+        root: {
+          name: "root",
+          catalog: { "no-deps": "1.0.0" },
+          catalogs: { x: { "a-dep": "^1.0.10" } },
+          workspaces: ["packages/*"],
+        },
+        pkg1: withDeps(PKG1_JSON, { "a-dep": "catalog:x" }),
+        packages: { "a-dep": "a-dep@1.0.10" },
       });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:x" });
     });
 
     test("workspaces.catalog wins when a top-level catalog also exists", async () => {
@@ -209,18 +334,19 @@ describe.concurrent("bun add --catalog", () => {
         workspaces: { packages: ["packages/*"], catalog: { "no-deps": "1.0.0" } },
       });
 
-      expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, "a-dep", "--catalog"));
 
-      const root = await dir.root();
-      expect(root).toStrictEqual({
-        name: "root",
-        catalog: { "a-dep": "1.0.1" },
-        workspaces: { packages: ["packages/*"], catalog: { "a-dep": "^1.0.10", "no-deps": "1.0.0" } },
+      await dir.expectFiles({
+        root: {
+          name: "root",
+          catalog: { "a-dep": "1.0.1" },
+          workspaces: { packages: ["packages/*"], catalog: { "a-dep": "^1.0.10", "no-deps": "1.0.0" } },
+        },
+        pkg1: withDeps(PKG1_JSON, { "a-dep": "catalog:" }),
+        packages: { "a-dep": "a-dep@1.0.10" },
       });
-      expect(Object.keys(root.workspaces.catalog)).toStrictEqual(["a-dep", "no-deps"]);
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
+      expect(Object.keys((await dir.root()).workspaces.catalog)).toStrictEqual(["a-dep", "no-deps"]);
       expect((await dir.installed("a-dep")).version).toBe("1.0.10");
-      expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "1.0.0" });
 
       await dir.installSavesNothing();
     });
@@ -235,43 +361,42 @@ describe.concurrent("bun add --catalog", () => {
     test("--catalog before the package name does not swallow it", async () => {
       const dir = await createDir(workspacesObject());
 
-      expectOk(await dir.add(dir.pkg1Dir, "--catalog", "no-deps"));
+      expectSaved(await dir.add(dir.pkg1Dir, "--catalog", "no-deps"));
 
-      expect(await dir.root()).toStrictEqual(seeded);
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root: seeded,
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+        packages: { "no-deps": "no-deps@2.0.0" },
+      });
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^2.0.0" });
     });
 
     test("a word after --catalog is a package, not the catalog name", async () => {
       const dir = await createDir(workspacesObject());
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "a-dep"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "a-dep"));
 
-      const root = await dir.root();
-      expect(root).toStrictEqual({
-        name: "root",
-        workspaces: { packages: ["packages/*"], catalog: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" } },
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" } }),
+        pkg1: withDeps(PKG1_JSON, { "a-dep": "catalog:", "no-deps": "catalog:" }),
+        packages: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@2.0.0" },
       });
-      expect(Object.keys(root.workspaces.catalog)).toStrictEqual(["a-dep", "no-deps"]);
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:", "no-deps": "catalog:" });
+      expect(Object.keys((await dir.root()).workspaces.catalog)).toStrictEqual(["a-dep", "no-deps"]);
       expect((await dir.installed("a-dep")).version).toBe("1.0.10");
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^2.0.0" });
     });
 
     for (const flag of ["--catalog=", "--catalog= "]) {
       test(`${JSON.stringify(flag)} is the default catalog`, async () => {
         const dir = await createDir(workspacesObject());
 
-        expectOk(await dir.add(dir.pkg1Dir, "no-deps", flag));
+        expectSaved(await dir.add(dir.pkg1Dir, "no-deps", flag));
 
-        expect(await dir.root()).toStrictEqual(seeded);
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        const lock = await dir.lock();
-        expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-        expect(lock.catalogs).toBeUndefined();
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
+        await dir.expectFiles({
+          root: seeded,
+          pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+          packages: { "no-deps": "no-deps@2.0.0" },
+        });
 
         await dir.installSavesNothing();
       });
@@ -281,11 +406,14 @@ describe.concurrent("bun add --catalog", () => {
       const root = pretty(workspacesObject({ catalog: {} }));
       const dir = await createDir(root);
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--save-catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--save-catalog"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
+      await dir.expectFiles({
+        root,
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "^2.0.0" }),
+        packages: { "no-deps": "no-deps@2.0.0" },
+      });
       expect(await dir.rootText()).toBe(root);
-      expect((await dir.lock()).workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
     });
   });
 
@@ -298,99 +426,97 @@ describe.concurrent("bun add --catalog", () => {
       test(`bun add ${args.join(" ")} writes ${JSON.stringify(entry)}`, async () => {
         const dir = await createDir(workspacesObject({ catalog: {} }));
 
-        expectOk(await dir.add(dir.pkg1Dir, ...args));
+        expectSaved(await dir.add(dir.pkg1Dir, ...args));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": entry });
+        await dir.expectFiles({
+          root: workspacesObject({ catalog: { "no-deps": entry } }),
+          pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+          packages: { "no-deps": `no-deps@${installed}` },
+        });
         expect((await dir.installed("no-deps")).version).toBe(installed);
-        expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": entry });
       });
     }
   });
 
   // pnpm keeps an existing entry as written when a bare name is added to the catalog.
   test("a bare name reuses an existing catalog entry", async () => {
+    const root = workspacesObject({ catalog: { "no-deps": "^1.0.0" } });
     const pkg1 = pretty({ name: "pkg1", version: "1.0.0", dependencies: { "no-deps": "catalog:" } });
-    const dir = await createDir(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }), pkg1);
+    const dir = await createDir(root, pkg1);
 
-    await dir.install();
+    expectSaved(await dir.install());
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
     const lockBefore = await dir.lockText();
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+    expectUnchanged(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
+    await dir.expectFiles({ root, pkg1, packages: { "no-deps": "no-deps@1.1.0" } });
     expect(await dir.pkg1Text()).toBe(pkg1);
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
     expect(await dir.lockText()).toBe(lockBefore);
-    expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
 
     await dir.installSavesNothing();
   });
 
   test("an existing entry is reused by a new consumer without touching the other members", async () => {
+    const root = workspacesObject({ catalog: { "no-deps": "^1.0.0" } });
     const pkg1 = JSON.stringify({ name: "pkg1", dependencies: { "no-deps": "catalog:" } });
-    const dir = await createDir(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }), pkg1, withPkg2());
-    await dir.install();
+    const dir = await createDir(root, pkg1, withPkg2());
+    expectSaved(await dir.install());
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
-    const result = await dir.add(dir.pkg2Dir, "no-deps", "--catalog");
-    expectOk(result);
-    expect(result.stderr).not.toContain("note:");
+    expectSaved(await dir.add(dir.pkg2Dir, "no-deps", "--catalog"));
 
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-    expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+    await dir.expectFiles({
+      root,
+      pkg1,
+      pkg2: withDeps(PKG2_JSON, { "no-deps": "catalog:" }),
+      packages: { "no-deps": "no-deps@1.1.0" },
+    });
     expect(await dir.pkg1Text()).toBe(pkg1);
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
-    const lock = await dir.lock();
-    expect(lock.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-    expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
-
     await dir.installSavesNothing();
-    const { stderr, exitCode } = await dir.frozen();
-    expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
   });
 
   test("an existing entry wins over the range the target declares directly", async () => {
+    const root = workspacesObject({ catalog: { "no-deps": "1.0.0" } });
     const pkg2 = JSON.stringify({ name: "pkg2", dependencies: { "no-deps": "catalog:" } });
-    const dir = await createDir(
-      workspacesObject({ catalog: { "no-deps": "1.0.0" } }),
-      { name: "pkg1", dependencies: { "no-deps": "^1.0.0" } },
-      withPkg2(pkg2),
-    );
-    await dir.install();
+    const dir = await createDir(root, { name: "pkg1", dependencies: { "no-deps": "^1.0.0" } }, withPkg2(pkg2));
+    expectSaved(await dir.install());
 
     const result = await dir.add(dir.pkg1Dir, "no-deps", "--catalog");
-    expectOk(result);
-    expect(result.stderr).toContain('note: no-deps in pkg1 now follows the catalog entry "1.0.0" instead of "^1.0.0"');
+    expect(result.stderr).toBe(
+      'note: no-deps in pkg1 now follows the catalog entry "1.0.0" instead of "^1.0.0"\nSaved lockfile\n',
+    );
+    expect(result.exitCode).toBe(0);
 
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+    await dir.expectFiles({
+      root,
+      pkg1: { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+      pkg2,
+      packages: { "no-deps": "no-deps@1.0.0" },
+    });
     expect(await dir.pkg2Text()).toBe(pkg2);
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    const lockText = await dir.lockText();
-    expect(lockText).not.toContain("no-deps@1.1.0");
-    expect(lockText).not.toContain("no-deps@2.0.0");
 
     await dir.installSavesNothing();
   });
 
   test("--silent prints no note when the target's range differs from the entry", async () => {
-    const dir = await createDir(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }), {
-      name: "pkg1",
-      dependencies: { "no-deps": "1.0.0" },
-    });
+    const root = workspacesObject({ catalog: { "no-deps": "^1.0.0" } });
+    const dir = await createDir(root, { name: "pkg1", dependencies: { "no-deps": "1.0.0" } });
 
     const { stdout, stderr, exitCode } = await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--silent");
-    expect(stderr).not.toContain("note:");
     expect(stdout).toBe("");
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
+    await dir.expectFiles({
+      root,
+      pkg1: { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+      packages: { "no-deps": "no-deps@1.1.0" },
+    });
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
   });
 
@@ -401,17 +527,20 @@ describe.concurrent("bun add --catalog", () => {
     });
 
     const result = await dir.add(dir.packageDir, "no-deps", "--catalog");
-    expectOk(result);
-    expect(result.stderr).toContain(
-      'note: no-deps in package.json now follows the catalog entry "1.0.0" instead of "^1.0.0"',
+    expect(result.stderr).toBe(
+      'note: no-deps in package.json now follows the catalog entry "1.0.0" instead of "^1.0.0"\nSaved lockfile\n',
     );
+    expect(result.exitCode).toBe(0);
 
-    expect(await dir.root()).toStrictEqual({
-      dependencies: { "no-deps": "catalog:" },
-      workspaces: { packages: ["packages/*"], catalog: { "no-deps": "1.0.0" } },
+    await dir.expectFiles({
+      root: {
+        dependencies: { "no-deps": "catalog:" },
+        workspaces: { packages: ["packages/*"], catalog: { "no-deps": "1.0.0" } },
+      },
+      pkg1: PKG1,
+      packages: { "no-deps": "no-deps@1.0.0" },
     });
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    expect((await dir.lock()).workspaces[""].dependencies).toStrictEqual({ "no-deps": "catalog:" });
   });
 
   test("a tarball url the target declares is cataloged verbatim", async () => {
@@ -420,46 +549,42 @@ describe.concurrent("bun add --catalog", () => {
       name: "pkg1",
       dependencies: { "no-deps": tarball },
     });
-    await dir.install();
+    expectSaved(await dir.install());
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-    const result = await dir.add(dir.pkg1Dir, "no-deps", "--catalog");
-    expectOk(result);
-    expect(result.stderr).not.toContain("note:");
+    expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-    expect(await dir.pkg1()).toStrictEqual({ name: "pkg1", dependencies: { "no-deps": "catalog:" } });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": tarball });
+    await dir.expectFiles({
+      root: workspacesObject({ catalog: { "no-deps": tarball } }),
+      pkg1: { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+      packages: { "no-deps": `no-deps@${tarball}` },
+    });
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    const lock = await dir.lock();
-    expect(lock.catalog).toStrictEqual({ "no-deps": tarball });
-    expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
 
-    await dir.installSavesNothing();
+    await dir.installKeepsLockfile();
   });
 
   test("an explicit version equal to the existing entry leaves the root as it was", async () => {
     const root = pretty(workspacesObject({ catalog: { "a-dep": "1.0.1", "no-deps": "1.0.0" } }));
     const dir = await createDir(root);
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog"));
+    expectSaved(await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog"));
 
+    await dir.expectFiles({
+      root,
+      pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+      packages: { "no-deps": "no-deps@1.0.0" },
+    });
     expect(await dir.rootText()).toBe(root);
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "1.0.1", "no-deps": "1.0.0" });
   });
 
   describe("explicit version inside an existing range", () => {
     for (const linker of ["hoisted", "isolated"] as const) {
       test(`keeps the range and moves the installed version (${linker})`, async () => {
+        const root = workspacesObject({ catalog: { "no-deps": "^1.0.0" } });
         const member = (name: string) => pretty({ name, dependencies: { "no-deps": "catalog:" } });
-        const dir = await createDir(
-          workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
-          member("pkg1"),
-          withPkg2(member("pkg2")),
-          linker,
-        );
+        const dir = await createDir(root, member("pkg1"), withPkg2(member("pkg2")), linker);
         const installedVersions = async () =>
           linker === "isolated"
             ? [
@@ -467,12 +592,17 @@ describe.concurrent("bun add --catalog", () => {
                 (await dir.memberInstalled("pkg2", "no-deps")).version,
               ]
             : [(await dir.installed("no-deps")).version];
-        await dir.install();
+        expectSaved(await dir.install());
         expect(await installedVersions()).toStrictEqual(linker === "isolated" ? ["1.1.0", "1.1.0"] : ["1.1.0"]);
 
-        expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog"));
+        expectSaved(await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog"));
 
-        expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
+        await dir.expectFiles({
+          root,
+          pkg1: member("pkg1"),
+          pkg2: member("pkg2"),
+          packages: { "no-deps": "no-deps@1.0.0" },
+        });
         expect(await dir.pkg1Text()).toBe(member("pkg1"));
         expect(await dir.pkg2Text()).toBe(member("pkg2"));
         expect(await installedVersions()).toStrictEqual(linker === "isolated" ? ["1.0.0", "1.0.0"] : ["1.0.0"]);
@@ -480,16 +610,8 @@ describe.concurrent("bun add --catalog", () => {
           expect(await dir.store()).toContain("no-deps@1.0.0");
         }
 
-        const lock = await dir.lock();
-        expect(lock.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-        expect(lock.packages["no-deps"][0]).toBe("no-deps@1.0.0");
-        expect(await dir.lockText()).not.toContain("no-deps@1.1.0");
-
         await dir.installSavesNothing();
         expect(await installedVersions()).toStrictEqual(linker === "isolated" ? ["1.0.0", "1.0.0"] : ["1.0.0"]);
-        const { stderr, exitCode } = await dir.frozen();
-        expect(stderr).not.toContain("error:");
-        expect(exitCode).toBe(0);
       });
     }
 
@@ -500,14 +622,22 @@ describe.concurrent("bun add --catalog", () => {
         member("pkg1"),
         withPkg2(member("pkg2")),
       );
-      await dir.install();
+      expectSaved(await dir.install());
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@^2.0.0", "--catalog"));
+      const result = await dir.add(dir.pkg1Dir, "no-deps@^2.0.0", "--catalog");
+      expect(result.stderr).toBe(
+        'note: catalog entry no-deps changed from "^1.0.0" to "^2.0.0" (also used by pkg2)\nSaved lockfile\n',
+      );
+      expect(result.exitCode).toBe(0);
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
+        pkg1: member("pkg1"),
+        pkg2: member("pkg2"),
+        packages: { "no-deps": "no-deps@2.0.0" },
+      });
       expect(await dir.pkg2Text()).toBe(member("pkg2"));
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^2.0.0" });
     });
   });
 
@@ -517,12 +647,14 @@ describe.concurrent("bun add --catalog", () => {
       dependencies: { "dep-with-tags": "pre-1" },
     });
 
-    expectOk(await dir.add(dir.pkg1Dir, "dep-with-tags", "--catalog"));
+    expectSaved(await dir.add(dir.pkg1Dir, "dep-with-tags", "--catalog"));
 
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "dep-with-tags": "^1.0.1" });
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "dep-with-tags": "catalog:" });
+    await dir.expectFiles({
+      root: workspacesObject({ catalog: { "dep-with-tags": "^1.0.1" } }),
+      pkg1: { name: "pkg1", dependencies: { "dep-with-tags": "catalog:" } },
+      packages: { "dep-with-tags": "dep-with-tags@1.0.1" },
+    });
     expect((await dir.installed("dep-with-tags")).version).toBe("1.0.1");
-    expect((await dir.lock()).catalog).toStrictEqual({ "dep-with-tags": "^1.0.1" });
 
     await dir.installSavesNothing();
   });
@@ -533,12 +665,14 @@ describe.concurrent("bun add --catalog", () => {
       devDependencies: { "no-deps": "1.0.0" },
     });
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--dev"));
+    expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--dev"));
 
-    expect(await dir.pkg1()).toStrictEqual({ name: "pkg1", devDependencies: { "no-deps": "catalog:" } });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
+    await dir.expectFiles({
+      root: workspacesObject({ catalog: { "no-deps": "1.0.0" } }),
+      pkg1: { name: "pkg1", devDependencies: { "no-deps": "catalog:" } },
+      packages: { "no-deps": "no-deps@1.0.0" },
+    });
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "1.0.0" });
 
     await dir.installSavesNothing();
   });
@@ -546,48 +680,49 @@ describe.concurrent("bun add --catalog", () => {
   test("run from the workspace root", async () => {
     const dir = await createDir(workspacesObject({ catalog: {} }));
 
-    expectOk(await dir.add(dir.packageDir, "no-deps", "--catalog"));
+    expectSaved(await dir.add(dir.packageDir, "no-deps", "--catalog"));
 
-    expect(await dir.root()).toStrictEqual({
-      name: "root",
-      dependencies: { "no-deps": "catalog:" },
-      workspaces: { packages: ["packages/*"], catalog: { "no-deps": "^2.0.0" } },
+    await dir.expectFiles({
+      root: {
+        name: "root",
+        dependencies: { "no-deps": "catalog:" },
+        workspaces: { packages: ["packages/*"], catalog: { "no-deps": "^2.0.0" } },
+      },
+      pkg1: PKG1,
+      packages: { "no-deps": "no-deps@2.0.0" },
     });
     expect(await dir.pkg1Text()).toBe(PKG1);
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
 
-    const lock = await dir.lock();
-    expect(lock.workspaces[""].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   test("bun install <pkg> --catalog --dev", async () => {
     const dir = await createDir(workspacesObject({ catalog: {} }));
 
-    expectOk(await dir.run(dir.pkg1Dir, ["install", "no-deps", "--catalog", "--dev"]));
+    expectSaved(await dir.run(dir.pkg1Dir, ["install", "no-deps", "--catalog", "--dev"]));
 
-    const pkg1 = await dir.pkg1();
-    expect(pkg1.devDependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect(pkg1.dependencies).toBeUndefined();
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+    await dir.expectFiles({
+      root: workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
+      pkg1: { ...PKG1_JSON, devDependencies: { "no-deps": "catalog:" } },
+      packages: { "no-deps": "no-deps@2.0.0" },
+    });
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
   });
 
   test("several packages into a named catalog", async () => {
     const dir = await createDir(workspacesObject());
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "a-dep", "--catalog=libs"));
+    expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "a-dep", "--catalog=libs"));
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:libs", "no-deps": "catalog:libs" });
-    const root = await dir.root();
-    expect(root.workspaces.catalogs.libs).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^2.0.0" });
-    expect(Object.keys(root.workspaces.catalogs.libs)).toStrictEqual(["a-dep", "no-deps"]);
+    await dir.expectFiles({
+      root: workspacesObject({ catalogs: { libs: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" } } }),
+      pkg1: withDeps(PKG1_JSON, { "a-dep": "catalog:libs", "no-deps": "catalog:libs" }),
+      packages: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@2.0.0" },
+    });
+    expect(Object.keys((await dir.root()).workspaces.catalogs.libs)).toStrictEqual(["a-dep", "no-deps"]);
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
     expect((await dir.installed("a-dep")).version).toBe("1.0.10");
-    expect((await dir.lock()).catalogs).toStrictEqual({ libs: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" } });
   });
 
   for (const from of ["member", "root"] as const) {
@@ -596,12 +731,14 @@ describe.concurrent("bun add --catalog", () => {
       const [rootBefore, pkg1Before] = await Promise.all([dir.rootText(), dir.pkg1Text()]);
 
       const cwd = from === "member" ? dir.pkg1Dir : dir.packageDir;
-      const { stderr, exitCode } = await dir.add(cwd, "no-deps", "--catalog", "--dry-run");
+      const { stdout, stderr, exitCode } = await dir.add(cwd, "no-deps", "--catalog", "--dry-run");
 
-      expect(stderr).not.toContain("error:");
+      expect(summary(stdout)).toBe("pkg1@workspace:packages/pkg1\ninstalled no-deps@2.0.0\n\ndone");
+      expect(stderr).toBe("");
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);
       expect(await dir.lockExists()).toBeFalse();
+      expect(existsSync(join(dir.packageDir, "node_modules"))).toBeFalse();
       expect(exitCode).toBe(0);
     });
 
@@ -609,30 +746,23 @@ describe.concurrent("bun add --catalog", () => {
       const dir = await createDir(workspacesObject({ catalog: {} }));
 
       const cwd = from === "member" ? dir.pkg1Dir : dir.packageDir;
-      expectOk(await dir.add(cwd, "no-deps", "--catalog", "--lockfile-only"));
+      const result = await dir.add(cwd, "no-deps", "--catalog", "--lockfile-only");
+      expectSaved(result);
+      expect(summary(result.stdout)).toBe("Saved bun.lock (3 packages)");
 
-      const root = await dir.root();
-      expect(root.workspaces).toStrictEqual({ packages: ["packages/*"], catalog: { "no-deps": "^2.0.0" } });
-      if (from === "member") {
-        expect(root.dependencies).toBeUndefined();
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      } else {
-        expect(root.dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      const root = workspacesObject({ catalog: { "no-deps": "^2.0.0" } });
+      await dir.expectFiles({
+        root: from === "member" ? root : { ...root, dependencies: { "no-deps": "catalog:" } },
+        pkg1: from === "member" ? withDeps(PKG1_JSON, { "no-deps": "catalog:" }) : PKG1,
+        packages: { "no-deps": "no-deps@2.0.0" },
+      });
+      if (from === "root") {
         expect(await dir.pkg1Text()).toBe(PKG1);
       }
-
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-      expect(lock.workspaces[from === "member" ? "packages/pkg1" : ""].dependencies).toStrictEqual({
-        "no-deps": "catalog:",
-      });
-      expect(lock.packages["no-deps"][0]).toBe("no-deps@2.0.0");
       expect(existsSync(join(dir.packageDir, "node_modules"))).toBeFalse();
       expect(existsSync(join(dir.pkg1Dir, "node_modules"))).toBeFalse();
 
-      const { stderr, exitCode } = await dir.frozen();
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      await dir.frozenOk();
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
     });
   }
@@ -641,18 +771,14 @@ describe.concurrent("bun add --catalog", () => {
     test("--optional", async () => {
       const dir = await createDir(workspacesObject({ catalog: {} }));
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--optional"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--optional"));
 
-      expect(await dir.pkg1()).toStrictEqual({
-        name: "pkg1",
-        version: "1.0.0",
-        optionalDependencies: { "no-deps": "catalog:" },
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
+        pkg1: { ...PKG1_JSON, optionalDependencies: { "no-deps": "catalog:" } },
+        packages: { "no-deps": "no-deps@2.0.0" },
       });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-      expect(lock.workspaces["packages/pkg1"].optionalDependencies).toStrictEqual({ "no-deps": "catalog:" });
 
       await dir.installSavesNothing();
     });
@@ -664,22 +790,18 @@ describe.concurrent("bun add --catalog", () => {
         peerDependencies: { "no-deps": ">=1" },
       });
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--dev"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--dev"));
 
-      expect(await dir.pkg1()).toStrictEqual({
-        name: "pkg1",
-        devDependencies: { "no-deps": "catalog:" },
-        peerDependencies: { "no-deps": ">=1" },
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "1.0.0" } }),
+        pkg1: {
+          name: "pkg1",
+          devDependencies: { "no-deps": "catalog:" },
+          peerDependencies: { "no-deps": ">=1" },
+        },
+        packages: { "no-deps": "no-deps@1.0.0" },
       });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect(lock.workspaces["packages/pkg1"]).toStrictEqual({
-        name: "pkg1",
-        devDependencies: { "no-deps": "catalog:" },
-        peerDependencies: { "no-deps": ">=1" },
-      });
     });
 
     test("name only in peerDependencies, adding with --dev, matches plain add", async () => {
@@ -693,8 +815,8 @@ describe.concurrent("bun add --catalog", () => {
         plain.add(plain.pkg1Dir, "no-deps", "--dev"),
         catalog.add(catalog.pkg1Dir, "no-deps", "--dev", "--catalog"),
       ]);
-      expectOk(plainResult);
-      expectOk(catalogResult);
+      expectSaved(plainResult);
+      expectSaved(catalogResult);
 
       const plainPkg1 = await plain.pkg1();
       const catalogPkg1 = await catalog.pkg1();
@@ -706,14 +828,14 @@ describe.concurrent("bun add --catalog", () => {
     test("--peer", async () => {
       const dir = await createDir(workspacesObject({ catalog: {} }));
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--peer"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--peer"));
 
-      expect(await dir.pkg1()).toStrictEqual({
-        name: "pkg1",
-        version: "1.0.0",
-        peerDependencies: { "no-deps": "catalog:" },
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
+        pkg1: { ...PKG1_JSON, peerDependencies: { "no-deps": "catalog:" } },
+        packages: { "no-deps": "no-deps@2.0.0" },
       });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+      expect((await dir.installed("no-deps")).version).toBe("2.0.0");
     });
   });
 
@@ -722,52 +844,48 @@ describe.concurrent("bun add --catalog", () => {
     const pkg1 = pretty({ name: "pkg1", dependencies: { "no-deps": "catalog:testing" } });
     const testingRoot = workspacesObject({ catalogs: { testing: { "no-deps": "1.0.0" } } });
 
-    for (const { args, entry, installed } of [
-      { args: ["no-deps", "--catalog"], entry: "1.0.0", installed: "1.0.0" },
-      { args: ["no-deps", "--catalog=other"], entry: "1.0.0", installed: "1.0.0" },
-      { args: ["no-deps@1.1.0", "--catalog"], entry: "1.1.0", installed: "1.1.0" },
+    for (const { args, entry, installed, stderr } of [
+      { args: ["no-deps", "--catalog"], entry: "1.0.0", installed: "1.0.0", stderr: "" },
+      { args: ["no-deps", "--catalog=other"], entry: "1.0.0", installed: "1.0.0", stderr: "" },
+      {
+        args: ["no-deps@1.1.0", "--catalog"],
+        entry: "1.1.0",
+        installed: "1.1.0",
+        stderr: 'note: catalog entry no-deps changed from "1.0.0" to "1.1.0"\nSaved lockfile\n',
+      },
     ]) {
       test(`bun add ${args.join(" ")}`, async () => {
         const dir = await createDir(testingRoot, pkg1);
-        await dir.install();
+        expectSaved(await dir.install());
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-        expectOk(await dir.add(dir.pkg1Dir, ...args));
+        const result = await dir.add(dir.pkg1Dir, ...args);
+        expect(result.stderr).toBe(stderr);
+        expect(result.exitCode).toBe(0);
 
-        expect((await dir.root()).workspaces).toStrictEqual({
-          packages: ["packages/*"],
-          catalogs: { testing: { "no-deps": entry } },
+        await dir.expectFiles({
+          root: workspacesObject({ catalogs: { testing: { "no-deps": entry } } }),
+          pkg1,
+          packages: { "no-deps": `no-deps@${installed}` },
         });
         expect(await dir.pkg1Text()).toBe(pkg1);
         expect((await dir.installed("no-deps")).version).toBe(installed);
-
-        const lock = await dir.lock();
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:testing" });
-        expect(lock.catalog).toBeUndefined();
-        expect(lock.catalogs).toStrictEqual({ testing: { "no-deps": entry } });
 
         await dir.installSavesNothing();
       });
     }
 
     test("an explicit version inside the named entry's range moves the resolution within that catalog", async () => {
-      const dir = await createDir(workspacesObject({ catalogs: { testing: { "no-deps": "^1.0.0" } } }), pkg1);
-      await dir.install();
+      const root = workspacesObject({ catalogs: { testing: { "no-deps": "^1.0.0" } } });
+      const dir = await createDir(root, pkg1);
+      expectSaved(await dir.install());
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.0.1", "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps@1.0.1", "--catalog"));
 
-      expect((await dir.root()).workspaces).toStrictEqual({
-        packages: ["packages/*"],
-        catalogs: { testing: { "no-deps": "^1.0.0" } },
-      });
+      await dir.expectFiles({ root, pkg1, packages: { "no-deps": "no-deps@1.0.1" } });
       expect(await dir.pkg1Text()).toBe(pkg1);
       expect((await dir.installed("no-deps")).version).toBe("1.0.1");
-
-      const lock = await dir.lock();
-      expect(lock.catalog).toBeUndefined();
-      expect(lock.catalogs).toStrictEqual({ testing: { "no-deps": "^1.0.0" } });
-      expect(lock.packages["no-deps"][0]).toBe("no-deps@1.0.1");
 
       await dir.installSavesNothing();
     });
@@ -783,43 +901,32 @@ describe.concurrent("bun add --catalog", () => {
       test(`bun add no-deps ${flag} seeds that catalog and keeps the reference`, async () => {
         const dir = await createDir(workspacesObject(root), pkg1);
 
-        const result = await dir.add(dir.pkg1Dir, "no-deps", flag);
-        expectOk(result);
-        expect(result.stderr).not.toContain("note:");
+        expectSaved(await dir.add(dir.pkg1Dir, "no-deps", flag));
 
-        expect(await dir.pkg1Text()).toBe(pkg1);
-        expect((await dir.root()).workspaces).toStrictEqual({
-          packages: ["packages/*"],
-          ...root,
-          catalogs: { legacy: { "no-deps": "^2.0.0" } },
+        await dir.expectFiles({
+          root: workspacesObject({ ...root, catalogs: { legacy: { "no-deps": "^2.0.0" } } }),
+          pkg1,
+          packages: { "no-deps": "no-deps@2.0.0" },
         });
+        expect(await dir.pkg1Text()).toBe(pkg1);
         expect((await dir.installed("no-deps")).version).toBe("2.0.0");
 
-        const lock = await dir.lock();
-        expect(lock.catalog).toBeUndefined();
-        expect(lock.catalogs).toStrictEqual({ legacy: { "no-deps": "^2.0.0" } });
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:legacy" });
-
         await dir.installSavesNothing();
-        const { stderr, exitCode } = await dir.frozen();
-        expect(stderr).not.toContain("error:");
-        expect(exitCode).toBe(0);
       });
     }
 
     test("an explicit version is written into that catalog", async () => {
       const dir = await createDir(workspacesObject({ catalog: {} }), pkg1);
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog=other"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog=other"));
 
-      expect(await dir.pkg1Text()).toBe(pkg1);
-      expect((await dir.root()).workspaces).toStrictEqual({
-        packages: ["packages/*"],
-        catalog: {},
-        catalogs: { legacy: { "no-deps": "1.0.0" } },
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: {}, catalogs: { legacy: { "no-deps": "1.0.0" } } }),
+        pkg1,
+        packages: { "no-deps": "no-deps@1.0.0" },
       });
+      expect(await dir.pkg1Text()).toBe(pkg1);
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-      expect((await dir.lock()).catalogs).toStrictEqual({ legacy: { "no-deps": "1.0.0" } });
 
       await dir.installSavesNothing();
     });
@@ -829,56 +936,58 @@ describe.concurrent("bun add --catalog", () => {
     test("alias@npm:pkg is written verbatim, like plain add", async () => {
       const dir = await createDir(workspacesObject({ catalog: {} }));
 
-      expectOk(await dir.add(dir.pkg1Dir, "foo@npm:no-deps", "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, "foo@npm:no-deps", "--catalog"));
 
       expect((await dir.pkg1()).dependencies).toStrictEqual({ foo: "catalog:" });
       expect((await dir.root()).workspaces.catalog).toStrictEqual({ foo: "npm:no-deps" });
       expect((await dir.lock()).catalog).toStrictEqual({ foo: "npm:no-deps" });
       expect(await dir.installed("foo")).toMatchObject({ name: "no-deps", version: "2.0.0" });
 
-      const { err } = await dir.install({ savesLockfile: false });
-      expect(err).not.toContain("Saved lockfile");
+      await dir.installSavesNothing();
     });
 
     test("alias@npm:pkg@dist-tag gets the resolved range", async () => {
       const dir = await createDir(workspacesObject({ catalog: {} }));
 
-      expectOk(await dir.add(dir.pkg1Dir, "foo@npm:no-deps@latest", "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, "foo@npm:no-deps@latest", "--catalog"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ foo: "catalog:" });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ foo: "npm:no-deps@^2.0.0" });
-      expect((await dir.lock()).catalog).toStrictEqual({ foo: "npm:no-deps@^2.0.0" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { foo: "npm:no-deps@^2.0.0" } }),
+        pkg1: withDeps(PKG1_JSON, { foo: "catalog:" }),
+        packages: { foo: "no-deps@2.0.0" },
+      });
       expect(await dir.installed("foo")).toMatchObject({ name: "no-deps", version: "2.0.0" });
 
-      const { err } = await dir.install({ savesLockfile: false });
-      expect(err).not.toContain("Saved lockfile");
+      await dir.installSavesNothing();
     });
 
     test("name@tarball-url is written verbatim, dist-tags become a range", async () => {
       const dir = await createDir(workspacesObject({ catalog: {} }));
       const tarball = `${registry.registryUrl()}no-deps/-/no-deps-1.0.0.tgz`;
 
-      expectOk(await dir.add(dir.pkg1Dir, `no-deps@${tarball}`, "dep-with-tags@pre-1", "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, `no-deps@${tarball}`, "dep-with-tags@pre-1", "--catalog"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "dep-with-tags": "catalog:", "no-deps": "catalog:" });
-      const catalog = { "dep-with-tags": "^1.0.1", "no-deps": tarball };
-      expect((await dir.root()).workspaces.catalog).toStrictEqual(catalog);
-      expect((await dir.lock()).catalog).toStrictEqual(catalog);
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "dep-with-tags": "^1.0.1", "no-deps": tarball } }),
+        pkg1: withDeps(PKG1_JSON, { "dep-with-tags": "catalog:", "no-deps": "catalog:" }),
+        packages: { "dep-with-tags": "dep-with-tags@1.0.1", "no-deps": `no-deps@${tarball}` },
+      });
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
       expect((await dir.installed("dep-with-tags")).version).toBe("1.0.1");
 
-      const { err } = await dir.install({ savesLockfile: false });
-      expect(err).not.toContain("Saved lockfile");
+      await dir.installKeepsLockfile();
     });
 
     test("scoped package into a named catalog", async () => {
       const dir = await createDir(workspacesObject());
 
-      expectOk(await dir.add(dir.pkg1Dir, "@types/no-deps", "--catalog=types"));
+      expectSaved(await dir.add(dir.pkg1Dir, "@types/no-deps", "--catalog=types"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "@types/no-deps": "catalog:types" });
-      expect((await dir.root()).workspaces.catalogs).toStrictEqual({ types: { "@types/no-deps": "^2.0.0" } });
-      expect((await dir.lock()).catalogs).toStrictEqual({ types: { "@types/no-deps": "^2.0.0" } });
+      await dir.expectFiles({
+        root: workspacesObject({ catalogs: { types: { "@types/no-deps": "^2.0.0" } } }),
+        pkg1: withDeps(PKG1_JSON, { "@types/no-deps": "catalog:types" }),
+        packages: { "@types/no-deps": "@types/no-deps@2.0.0" },
+      });
       expect((await dir.installed("@types/no-deps")).version).toBe("2.0.0");
     });
 
@@ -890,125 +999,112 @@ describe.concurrent("bun add --catalog", () => {
           const dir = await createDir(workspacesObject({ catalog: {} }));
 
           const cwd = from === "member" ? dir.pkg1Dir : dir.packageDir;
-          const result = await dir.add(cwd, tarball(), "--catalog");
-          expectOk(result);
-          expect(result.stderr).not.toContain("note:");
+          expectSaved(await dir.add(cwd, tarball(), "--catalog"));
 
-          const root = await dir.root();
-          if (from === "member") {
-            expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-            expect(root.dependencies).toBeUndefined();
-          } else {
-            expect(root.dependencies).toStrictEqual({ "no-deps": "catalog:" });
+          const root = workspacesObject({ catalog: { "no-deps": tarball() } });
+          await dir.expectFiles({
+            root: from === "member" ? root : { ...root, dependencies: { "no-deps": "catalog:" } },
+            pkg1: from === "member" ? withDeps(PKG1_JSON, { "no-deps": "catalog:" }) : PKG1,
+            packages: { "no-deps": `no-deps@${tarball()}` },
+          });
+          if (from === "root") {
             expect(await dir.pkg1Text()).toBe(PKG1);
           }
-          expect(root.workspaces.catalog).toStrictEqual({ "no-deps": tarball() });
           expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-          const lock = await dir.lock();
-          expect(lock.catalog).toStrictEqual({ "no-deps": tarball() });
-          expect(lock.workspaces[from === "member" ? "packages/pkg1" : ""].dependencies).toStrictEqual({
-            "no-deps": "catalog:",
-          });
-
-          await dir.installSavesNothing();
-          const { stderr, exitCode } = await dir.frozen();
-          expect(stderr).not.toContain("error:");
-          expect(exitCode).toBe(0);
+          await dir.installKeepsLockfile();
         });
       }
 
       test("--filter puts every selected member on the entry", async () => {
         const dir = await createDir(workspacesObject({ catalog: {} }), PKG1, withPkg2());
 
-        expectOk(await dir.add(dir.packageDir, tarball(), "--catalog", "--filter", "pkg1", "--filter", "pkg2"));
+        expectSaved(await dir.add(dir.packageDir, tarball(), "--catalog", "--filter", "pkg1", "--filter", "pkg2"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        const root = await dir.root();
-        expect(root.dependencies).toBeUndefined();
-        expect(root.workspaces.catalog).toStrictEqual({ "no-deps": tarball() });
+        await dir.expectFiles({
+          root: workspacesObject({ catalog: { "no-deps": tarball() } }),
+          pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+          pkg2: withDeps(PKG2_JSON, { "no-deps": "catalog:" }),
+          packages: { "no-deps": `no-deps@${tarball()}` },
+        });
 
-        const lock = await dir.lock();
-        expect(lock.catalog).toStrictEqual({ "no-deps": tarball() });
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-
-        await dir.installSavesNothing();
+        await dir.installKeepsLockfile();
       });
 
       test("mixed with a named package", async () => {
         const dir = await createDir(workspacesObject({ catalog: {} }));
 
-        expectOk(await dir.add(dir.pkg1Dir, tarball(), "a-dep", "--catalog"));
+        expectSaved(await dir.add(dir.pkg1Dir, tarball(), "a-dep", "--catalog"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:", "no-deps": "catalog:" });
-        const catalog = (await dir.root()).workspaces.catalog;
-        expect(catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": tarball() });
-        expect(Object.keys(catalog)).toStrictEqual(["a-dep", "no-deps"]);
-        expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": tarball() });
+        await dir.expectFiles({
+          root: workspacesObject({ catalog: { "a-dep": "^1.0.10", "no-deps": tarball() } }),
+          pkg1: withDeps(PKG1_JSON, { "a-dep": "catalog:", "no-deps": "catalog:" }),
+          packages: { "a-dep": "a-dep@1.0.10", "no-deps": `no-deps@${tarball()}` },
+        });
+        expect(Object.keys((await dir.root()).workspaces.catalog)).toStrictEqual(["a-dep", "no-deps"]);
         expect((await dir.installed("a-dep")).version).toBe("1.0.10");
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-        await dir.installSavesNothing();
+        await dir.installKeepsLockfile();
       });
 
       test("the entry is inserted in alphabetical order", async () => {
         const dir = await createDir(workspacesObject({ catalog: { zzz: "1.0.0" } }));
 
-        expectOk(await dir.add(dir.pkg1Dir, tarball(), "--catalog"));
+        expectSaved(await dir.add(dir.pkg1Dir, tarball(), "--catalog"));
 
-        const catalog = (await dir.root()).workspaces.catalog;
-        expect(catalog).toStrictEqual({ "no-deps": tarball(), zzz: "1.0.0" });
-        expect(Object.keys(catalog)).toStrictEqual(["no-deps", "zzz"]);
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": tarball(), zzz: "1.0.0" });
+        await dir.expectFiles({
+          root: workspacesObject({ catalog: { "no-deps": tarball(), zzz: "1.0.0" } }),
+          pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+          packages: { "no-deps": `no-deps@${tarball()}` },
+        });
+        expect(Object.keys((await dir.root()).workspaces.catalog)).toStrictEqual(["no-deps", "zzz"]);
 
-        await dir.installSavesNothing();
+        await dir.installKeepsLockfile();
       });
 
       test("into a named catalog", async () => {
         const dir = await createDir(workspacesObject());
 
-        expectOk(await dir.add(dir.pkg1Dir, tarball(), "--catalog=vendored"));
+        expectSaved(await dir.add(dir.pkg1Dir, tarball(), "--catalog=vendored"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:vendored" });
-        expect((await dir.root()).workspaces.catalogs).toStrictEqual({ vendored: { "no-deps": tarball() } });
-        expect((await dir.lock()).catalogs).toStrictEqual({ vendored: { "no-deps": tarball() } });
+        await dir.expectFiles({
+          root: workspacesObject({ catalogs: { vendored: { "no-deps": tarball() } } }),
+          pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:vendored" }),
+          packages: { "no-deps": `no-deps@${tarball()}` },
+        });
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-        await dir.installSavesNothing();
+        await dir.installKeepsLockfile();
       });
 
       test("an identical entry is reused", async () => {
         const root = workspacesObject({ catalog: { "no-deps": tarball() } });
         const pkg2 = JSON.stringify({ name: "pkg2", dependencies: { "no-deps": "catalog:" } });
         const dir = await createDir(root, PKG1, withPkg2(pkg2));
-        await dir.install();
+        expectSaved(await dir.install());
 
-        const result = await dir.add(dir.pkg1Dir, tarball(), "--catalog");
-        expectOk(result);
-        expect(result.stderr).not.toContain("note:");
+        expectSaved(await dir.add(dir.pkg1Dir, tarball(), "--catalog"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        expect(await dir.root()).toStrictEqual(root);
+        await dir.expectFiles({
+          root,
+          pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+          pkg2,
+          packages: { "no-deps": `no-deps@${tarball()}` },
+        });
         expect(await dir.pkg2Text()).toBe(pkg2);
-        expect((await dir.lock()).workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
 
-        await dir.installSavesNothing();
-        const { stderr, exitCode } = await dir.frozen();
-        expect(stderr).not.toContain("error:");
-        expect(exitCode).toBe(0);
+        await dir.installKeepsLockfile();
       });
 
       test("re-running is a no-op", async () => {
         const dir = await createDir(workspacesObject({ catalog: {} }));
 
-        expectOk(await dir.add(dir.pkg1Dir, tarball(), "--catalog"));
+        expectSaved(await dir.add(dir.pkg1Dir, tarball(), "--catalog"));
         expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": tarball() });
         const [rootAfter, pkg1After, lockAfter] = await Promise.all([dir.rootText(), dir.pkg1Text(), dir.lockText()]);
 
-        expectOk(await dir.add(dir.pkg1Dir, tarball(), "--catalog"));
+        expectUnchanged(await dir.add(dir.pkg1Dir, tarball(), "--catalog"));
 
         expect(await dir.rootText()).toBe(rootAfter);
         expect(await dir.pkg1Text()).toBe(pkg1After);
@@ -1017,29 +1113,31 @@ describe.concurrent("bun add --catalog", () => {
 
       test("a different existing entry keeps the package direct", async () => {
         const root = workspacesObject({ catalog: { "no-deps": "^1.0.0" } });
-        const dir = await createDir(root, PKG1, withPkg2({ name: "pkg2", dependencies: { "no-deps": "catalog:" } }));
-        await dir.install();
+        const pkg2 = { name: "pkg2", dependencies: { "no-deps": "catalog:" } };
+        const dir = await createDir(root, PKG1, withPkg2(pkg2));
+        expectSaved(await dir.install());
 
         const result = await dir.add(dir.pkg1Dir, tarball(), "--catalog");
-        expectOk(result);
-        expect(result.stderr).toContain(
-          `note: no-deps in pkg1 keeps "${tarball()}" because the catalog entry is "^1.0.0"`,
+        expect(result.stderr).toBe(
+          `note: no-deps in pkg1 keeps "${tarball()}" because the catalog entry is "^1.0.0"\nSaved lockfile\n`,
         );
+        expect(result.exitCode).toBe(0);
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": tarball() });
-        expect(await dir.root()).toStrictEqual(root);
+        await dir.expectFiles({
+          root,
+          pkg1: withDeps(PKG1_JSON, { "no-deps": tarball() }),
+          pkg2,
+          packages: { "no-deps": `no-deps@${tarball()}`, "pkg2/no-deps": "no-deps@1.1.0" },
+        });
 
-        const lock = await dir.lock();
-        expect(lock.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": tarball() });
-        expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-
-        await dir.installSavesNothing();
+        await dir.installKeepsLockfile();
       });
 
       // The name is only known after both rows resolved, so this is refused before anything is written; `name@url` binds the declaration instead.
       describe("a name the target already declares", () => {
         const pkg1 = { name: "pkg1", dependencies: { "no-deps": "^1.0.0" } };
+        const refused = () =>
+          `error: --catalog cannot add "${tarball()}": pkg1 already declares no-deps\n  bun add no-deps@${tarball()} --catalog\n`;
 
         for (const { title, args } of [
           { title: "alone", args: () => [tarball()] },
@@ -1052,9 +1150,7 @@ describe.concurrent("bun add --catalog", () => {
 
             const { stderr, exitCode } = await dir.add(dir.pkg1Dir, ...args(), "--catalog");
 
-            expect(stderr).toEndWith(
-              `error: --catalog cannot add "${tarball()}": pkg1 already declares no-deps\n  bun add no-deps@${tarball()} --catalog\n`,
-            );
+            expect(stderr).toBe(refused());
             expect(await dir.rootText()).toBe(root);
             expect(await dir.pkg1Text()).toBe(pkg1Text);
             expect(await dir.lockExists()).toBeFalse();
@@ -1071,9 +1167,7 @@ describe.concurrent("bun add --catalog", () => {
 
           const { stderr, exitCode } = await dir.add(dir.packageDir, tarball(), "--catalog", "--filter", "pkg*");
 
-          expect(stderr).toEndWith(
-            `error: --catalog cannot add "${tarball()}": pkg1 already declares no-deps\n  bun add no-deps@${tarball()} --catalog\n`,
-          );
+          expect(stderr).toBe(refused());
           expect(await dir.rootText()).toBe(root);
           expect(await dir.pkg1Text()).toBe(pretty(pkg1));
           expect(await dir.pkg2Text()).toBe(pkg2Before);
@@ -1084,17 +1178,17 @@ describe.concurrent("bun add --catalog", () => {
         test("the suggested name@url spelling moves the declaration into the catalog", async () => {
           const dir = await createDir(workspacesObject({ catalog: {} }), pkg1);
 
-          expectOk(await dir.add(dir.pkg1Dir, `no-deps@${tarball()}`, "--catalog"));
+          expectSaved(await dir.add(dir.pkg1Dir, `no-deps@${tarball()}`, "--catalog"));
 
-          expect(await dir.pkg1()).toStrictEqual({ name: "pkg1", dependencies: { "no-deps": "catalog:" } });
+          await dir.expectFiles({
+            root: workspacesObject({ catalog: { "no-deps": tarball() } }),
+            pkg1: { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+            packages: { "no-deps": `no-deps@${tarball()}` },
+          });
           expect((await dir.pkg1Text()).match(/"no-deps"/g)).toHaveLength(1);
-          expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": tarball() });
-          const lock = await dir.lock();
-          expect(lock.catalog).toStrictEqual({ "no-deps": tarball() });
-          expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
           expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-          await dir.installSavesNothing();
+          await dir.installKeepsLockfile();
         });
       });
 
@@ -1103,38 +1197,37 @@ describe.concurrent("bun add --catalog", () => {
         await write(join(dir.packageDir, "vendor", "baz.tgz"), file(join(import.meta.dir, "baz-0.0.3.tgz")));
         const literal = join(dir.packageDir, "vendor", "baz.tgz").replaceAll("\\", "/");
 
-        expectOk(await dir.add(dir.pkg1Dir, literal, "--catalog"));
+        expectSaved(await dir.add(dir.pkg1Dir, literal, "--catalog"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ baz: "catalog:" });
-        expect((await dir.root()).workspaces.catalog).toStrictEqual({ baz: literal });
-        expect((await dir.lock()).catalog).toStrictEqual({ baz: literal });
+        await dir.expectFiles({
+          root: workspacesObject({ catalog: { baz: literal } }),
+          pkg1: withDeps(PKG1_JSON, { baz: "catalog:" }),
+          packages: { baz: `baz@${literal}` },
+        });
         expect((await dir.installed("baz")).version).toBe("0.0.3");
 
-        await dir.installSavesNothing();
+        await dir.installKeepsLockfile();
       });
 
       test("a url that fails to resolve writes nothing", async () => {
         const dir = await createDir(workspacesObject({ catalog: {} }));
         const [rootBefore, pkg1Before] = await Promise.all([dir.rootText(), dir.pkg1Text()]);
+        const url = `${registry.registryUrl()}no-deps/-/no-deps-9.9.9.tgz`;
 
-        const { stderr, exitCode } = await dir.add(
-          dir.pkg1Dir,
-          `${registry.registryUrl()}no-deps/-/no-deps-9.9.9.tgz`,
-          "--catalog",
+        const { stderr, exitCode } = await dir.add(dir.pkg1Dir, url, "--catalog");
+
+        expect(stderr).toBe(
+          `error: GET ${url} - 404\nerror: Invalid dependency name "${url}"\nerror: ${url} failed to resolve\n`,
         );
-
-        expect(stderr).toContain("error:");
         expect(await dir.rootText()).toBe(rootBefore);
         expect(await dir.pkg1Text()).toBe(pkg1Before);
         expect(await dir.lockExists()).toBeFalse();
-        expect(exitCode).not.toBe(0);
+        expect(exitCode).toBe(1);
       });
     });
   });
 
   describe("workspace sibling", () => {
-    const pkg2Message = 'error: --catalog cannot add a workspace package, but "pkg2" is the workspace at packages/pkg2';
-
     for (const from of ["member", "root"] as const) {
       test(`bare name is refused before anything is written (from ${from})`, async () => {
         const dir = await createDir(workspacesObject({ catalog: {} }), PKG1, withPkg2());
@@ -1143,7 +1236,7 @@ describe.concurrent("bun add --catalog", () => {
         const cwd = from === "member" ? dir.pkg1Dir : dir.packageDir;
         const { stderr, exitCode } = await dir.add(cwd, "pkg2", "--catalog");
 
-        expect(stderr).toContain(pkg2Message);
+        expect(stderr).toBe(PKG2_MESSAGE);
         expect(await dir.rootText()).toBe(rootBefore);
         expect(await dir.pkg1Text()).toBe(pkg1Before);
         expect(await dir.lockExists()).toBeFalse();
@@ -1158,7 +1251,7 @@ describe.concurrent("bun add --catalog", () => {
 
         const { stderr, exitCode } = await dir.add(dir.packageDir, positional, "--catalog", "--filter", "pkg1");
 
-        expect(stderr).toContain(pkg2Message);
+        expect(stderr).toBe(PKG2_MESSAGE);
         expect(await dir.rootText()).toBe(rootBefore);
         expect(await dir.pkg1Text()).toBe(pkg1Before);
         expect(await dir.lockExists()).toBeFalse();
@@ -1172,7 +1265,7 @@ describe.concurrent("bun add --catalog", () => {
 
       const { stderr, exitCode } = await dir.add(dir.pkg1Dir, "pkg2@1.0.0", "--catalog");
 
-      expect(stderr).toContain(pkg2Message);
+      expect(stderr).toBe(PKG2_MESSAGE);
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);
       expect(await dir.lockExists()).toBeFalse();
@@ -1185,7 +1278,7 @@ describe.concurrent("bun add --catalog", () => {
 
       const { stderr, exitCode } = await dir.add(dir.pkg1Dir, "root", "--catalog");
 
-      expect(stderr).toContain('error: --catalog cannot add a workspace package, but "root" is the workspace root');
+      expect(stderr).toBe('error: --catalog cannot add a workspace package, but "root" is the workspace root\n');
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);
       expect(await dir.lockExists()).toBeFalse();
@@ -1200,8 +1293,8 @@ describe.concurrent("bun add --catalog", () => {
 
       const { stderr, exitCode } = await dir.add(dir.pkg1Dir, "no-deps", "--catalog");
 
-      expect(stderr).toContain(
-        'error: --catalog cannot add a workspace package, but "no-deps" is the workspace at packages/no-deps',
+      expect(stderr).toBe(
+        'error: --catalog cannot add a workspace package, but "no-deps" is the workspace at packages/no-deps\n',
       );
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);
@@ -1210,6 +1303,7 @@ describe.concurrent("bun add --catalog", () => {
       expect(exitCode).toBe(1);
     });
 
+    // The exact stderr shows the refusal came first: no 404 and no "failed to resolve" for a-dep.
     for (const from of ["member", "root --filter pkg1"] as const) {
       test(`one refused name aborts the whole add before any network request (from ${from})`, async () => {
         const dir = await createDir(workspacesObject({ catalog: {} }), PKG1, withPkg2());
@@ -1220,9 +1314,7 @@ describe.concurrent("bun add --catalog", () => {
             ? await dir.add(dir.pkg1Dir, "a-dep", "pkg2", "--catalog")
             : await dir.add(dir.packageDir, "a-dep", "pkg2", "--catalog", "--filter", "pkg1");
 
-        expect(stderr).toContain(pkg2Message);
-        expect(stderr).not.toContain("404");
-        expect(stderr).not.toContain("failed to resolve");
+        expect(stderr).toBe(PKG2_MESSAGE);
         expect(await dir.rootText()).toBe(rootBefore);
         expect(await dir.pkg1Text()).toBe(pkg1Before);
         expect(await dir.lockExists()).toBeFalse();
@@ -1239,7 +1331,7 @@ describe.concurrent("bun add --catalog", () => {
         const cwd = from === "member" ? dir.pkg1Dir : dir.packageDir;
         const { stderr, exitCode } = await dir.add(cwd, "pkg2@workspace:*", "--catalog");
 
-        expect(stderr).toContain('error: --catalog cannot add a workspace package, but got "pkg2@workspace:*"');
+        expect(stderr).toBe('error: --catalog cannot add a workspace package, but got "pkg2@workspace:*"\n');
         expect(await dir.rootText()).toBe(rootBefore);
         expect(await dir.pkg1Text()).toBe(pkg1Before);
         expect(await dir.lockExists()).toBeFalse();
@@ -1253,7 +1345,7 @@ describe.concurrent("bun add --catalog", () => {
 
       const { stderr, exitCode } = await dir.add(dir.packageDir, "pkg2@workspace:*", "--catalog", "--filter", "pkg1");
 
-      expect(stderr).toContain('error: --catalog cannot add a workspace package, but got "pkg2@workspace:*"');
+      expect(stderr).toBe('error: --catalog cannot add a workspace package, but got "pkg2@workspace:*"\n');
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);
       expect(await dir.lockExists()).toBeFalse();
@@ -1262,6 +1354,9 @@ describe.concurrent("bun add --catalog", () => {
   });
 
   describe("local paths", () => {
+    const refused = (spec: string) =>
+      `error: --catalog cannot add "${spec}": a local path in the catalog would resolve from the workspace root, not from the package that added it\n`;
+
     for (const spec of ["foo@file:../vendor/foo", "foo@link:../vendor/foo", "foo@./vendor/foo"]) {
       test(`${spec} is refused`, async () => {
         const dir = await createDir(workspacesObject({ catalog: {} }));
@@ -1269,9 +1364,7 @@ describe.concurrent("bun add --catalog", () => {
 
         const { stderr, exitCode } = await dir.add(dir.pkg1Dir, spec, "--catalog");
 
-        expect(stderr).toContain(
-          `error: --catalog cannot add "${spec}": a local path in the catalog would resolve from the workspace root, not from the package that added it`,
-        );
+        expect(stderr).toBe(refused(spec));
         expect(await dir.rootText()).toBe(rootBefore);
         expect(await dir.pkg1Text()).toBe(pkg1Before);
         expect(await dir.lockExists()).toBeFalse();
@@ -1285,9 +1378,7 @@ describe.concurrent("bun add --catalog", () => {
 
       const { stderr, exitCode } = await dir.add(dir.pkg1Dir, "../../vendor/foo", "--catalog");
 
-      expect(stderr).toContain(
-        'error: --catalog cannot add "../../vendor/foo": a local path in the catalog would resolve from the workspace root, not from the package that added it',
-      );
+      expect(stderr).toBe(refused("../../vendor/foo"));
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);
       expect(await dir.lockExists()).toBeFalse();
@@ -1300,11 +1391,14 @@ describe.concurrent("bun add --catalog", () => {
       });
       const literal = `file:${join(dir.packageDir, "vendor", "foo").replaceAll("\\", "/")}`;
 
-      expectOk(await dir.add(dir.pkg1Dir, `foo@${literal}`, "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, `foo@${literal}`, "--catalog"));
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ foo: literal });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ foo: "catalog:" });
-      expect((await dir.lock()).catalog).toStrictEqual({ foo: literal });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { foo: literal } }),
+        pkg1: withDeps(PKG1_JSON, { foo: "catalog:" }),
+        // The lockfile resolves the folder relative to the workspace root.
+        packages: { "pkg1/foo": "foo@file:vendor/foo" },
+      });
       // Folder dependencies of a workspace are linked under that workspace's node_modules, not hoisted.
       expect(await dir.memberInstalled("pkg1", "foo")).toMatchObject({ name: "foo", version: "1.0.0" });
     });
@@ -1314,33 +1408,33 @@ describe.concurrent("bun add --catalog", () => {
     test("'*' alone edits the members and the root catalog, not the root's dependencies", async () => {
       const pkg1 = JSON.stringify({ name: "pkg1", dependencies: { "no-deps": "catalog:" } });
       const dir = await createDir(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }), pkg1, withPkg2());
-      await dir.install();
+      expectSaved(await dir.install());
 
-      expectOk(await dir.add(dir.packageDir, "a-dep", "--catalog", "--filter", "*"));
+      expectSaved(await dir.add(dir.packageDir, "a-dep", "--catalog", "--filter", "*"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:", "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
-      const root = await dir.root();
-      expect(root.dependencies).toBeUndefined();
-      expect(root.workspaces.catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
-      expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "a-dep": "^1.0.10", "no-deps": "^1.0.0" } }),
+        pkg1: { name: "pkg1", dependencies: { "a-dep": "catalog:", "no-deps": "catalog:" } },
+        pkg2: withDeps(PKG2_JSON, { "a-dep": "catalog:" }),
+        packages: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@1.1.0" },
+      });
 
       await dir.installSavesNothing();
     });
 
     test("an existing entry is reused for every selected member", async () => {
-      const dir = await createDir(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }), PKG1, withPkg2());
+      const root = workspacesObject({ catalog: { "no-deps": "^1.0.0" } });
+      const dir = await createDir(root, PKG1, withPkg2());
 
-      expectOk(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "*"));
+      expectSaved(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "*"));
 
-      const root = await dir.root();
-      expect(root.workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect(root.dependencies).toBeUndefined();
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root,
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+        pkg2: withDeps(PKG2_JSON, { "no-deps": "catalog:" }),
+        packages: { "no-deps": "no-deps@1.1.0" },
+      });
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
 
       await dir.installSavesNothing();
     });
@@ -1352,13 +1446,15 @@ describe.concurrent("bun add --catalog", () => {
         withPkg2(),
       );
 
-      expectOk(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg1", "--filter", "pkg2"));
+      expectSaved(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg1", "--filter", "pkg2"));
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
+        pkg1: { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+        pkg2: withDeps(PKG2_JSON, { "no-deps": "catalog:" }),
+        packages: { "no-deps": "no-deps@1.1.0" },
+      });
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
 
       await dir.installSavesNothing();
     });
@@ -1373,19 +1469,18 @@ describe.concurrent("bun add --catalog", () => {
       );
 
       const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*");
-      expectOk(result);
-      expect(result.stderr).toContain('note: no-deps in pkg2 keeps "1.0.1" because the catalog entry is "1.0.0"');
+      expect(result.stderr).toBe(
+        'note: no-deps in pkg2 keeps "1.0.1" because the catalog entry is "1.0.0"\nSaved lockfile\n',
+      );
+      expect(result.exitCode).toBe(0);
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "1.0.0" } }),
+        pkg1: { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+        pkg2,
+        packages: { "no-deps": "no-deps@1.0.0", "pkg2/no-deps": "no-deps@1.0.1" },
+      });
       expect(await dir.pkg2Text()).toBe(pkg2);
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "1.0.1" });
-      const lockText = await dir.lockText();
-      expect(lockText).toContain("no-deps@1.0.0");
-      expect(lockText).toContain("no-deps@1.0.1");
 
       await dir.installSavesNothing();
     });
@@ -1398,17 +1493,18 @@ describe.concurrent("bun add --catalog", () => {
       );
 
       const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*");
-      expectOk(result);
-      expect(result.stderr).toContain(
-        'note: no-deps in pkg2 now follows the catalog entry "^1.0.0" instead of "1.0.0"',
+      expect(result.stderr).toBe(
+        'note: no-deps in pkg2 now follows the catalog entry "^1.0.0" instead of "1.0.0"\nSaved lockfile\n',
       );
+      expect(result.exitCode).toBe(0);
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
+        pkg1: { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+        pkg2: { name: "pkg2", dependencies: { "no-deps": "catalog:" } },
+        packages: { "no-deps": "no-deps@1.1.0" },
+      });
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect(await dir.lockText()).not.toContain('no-deps@1.0.0"');
 
       await dir.installSavesNothing();
     });
@@ -1420,14 +1516,14 @@ describe.concurrent("bun add --catalog", () => {
         withPkg2({ name: "pkg2", dependencies: { "no-deps": "^1.0.0" } }),
       );
 
-      const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*");
-      expectOk(result);
-      expect(result.stderr).not.toContain("note:");
+      expectSaved(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*"));
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
+        pkg1: { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+        pkg2: { name: "pkg2", dependencies: { "no-deps": "catalog:" } },
+        packages: { "no-deps": "no-deps@1.1.0" },
+      });
 
       await dir.installSavesNothing();
     });
@@ -1439,39 +1535,42 @@ describe.concurrent("bun add --catalog", () => {
         withPkg2({ name: "pkg2", dependencies: { "no-deps": "^1.0.0" } }),
       );
 
-      const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*");
-      expectOk(result);
-      expect(result.stderr).not.toContain("note:");
+      expectSaved(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*"));
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+        pkg2: { name: "pkg2", dependencies: { "no-deps": "catalog:" } },
+        packages: { "no-deps": "no-deps@1.1.0" },
+      });
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
 
       await dir.installSavesNothing();
     });
 
     test("an entry the root already has is used by every selected member, with a note per member that declared something else", async () => {
+      const root = workspacesObject({ catalog: { "no-deps": "1.0.0" } });
       const dir = await createDir(
-        workspacesObject({ catalog: { "no-deps": "1.0.0" } }),
+        root,
         { name: "pkg1", dependencies: { "no-deps": "^1.0.0" } },
         withPkg2({ name: "pkg2", dependencies: { "no-deps": "2.0.0" } }),
       );
 
       const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*");
-      expectOk(result);
-      expect(result.stderr).toContain(
-        'note: no-deps in pkg1 now follows the catalog entry "1.0.0" instead of "^1.0.0"',
+      expect(result.stderr).toBe(
+        'note: no-deps in pkg1 now follows the catalog entry "1.0.0" instead of "^1.0.0"\n' +
+          'note: no-deps in pkg2 now follows the catalog entry "1.0.0" instead of "2.0.0"\n' +
+          "Saved lockfile\n",
       );
-      expect(result.stderr).toContain('note: no-deps in pkg2 now follows the catalog entry "1.0.0" instead of "2.0.0"');
+      expect(result.exitCode).toBe(0);
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root,
+        pkg1: { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+        pkg2: { name: "pkg2", dependencies: { "no-deps": "catalog:" } },
+        packages: { "no-deps": "no-deps@1.0.0" },
+      });
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
 
       await dir.installSavesNothing();
     });
@@ -1484,17 +1583,25 @@ describe.concurrent("bun add --catalog", () => {
         withPkg2(pkg2),
       );
 
-      const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*", "--silent");
-      expectOk(result);
-      expect(result.stderr).not.toContain("note:");
+      const { stdout, stderr, exitCode } = await dir.add(
+        dir.packageDir,
+        "no-deps",
+        "--catalog",
+        "--filter",
+        "pkg*",
+        "--silent",
+      );
+      expect(stdout).toBe("");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "1.0.0" } }),
+        pkg1: { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+        pkg2,
+        packages: { "no-deps": "no-deps@1.0.0", "pkg2/no-deps": "no-deps@1.0.1" },
+      });
       expect(await dir.pkg2Text()).toBe(pkg2);
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "1.0.1" });
 
       await dir.installSavesNothing();
     });
@@ -1507,26 +1614,15 @@ describe.concurrent("bun add --catalog", () => {
         withPkg2({ name: "pkg2" }),
       );
 
-      expectOk(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg1", "--filter", "pkg2"));
+      expectSaved(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg1", "--filter", "pkg2"));
 
-      expect(await dir.pkg1Text()).toBe(pkg1);
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      const root = await dir.root();
-      expect(root.dependencies).toBeUndefined();
-      expect(root.workspaces).toStrictEqual({
-        packages: ["packages/*"],
-        catalogs: { legacy: { "no-deps": "1.0.0" } },
-        catalog: { "no-deps": "^2.0.0" },
+      await dir.expectFiles({
+        root: workspacesObject({ catalogs: { legacy: { "no-deps": "1.0.0" } }, catalog: { "no-deps": "^2.0.0" } }),
+        pkg1,
+        pkg2: { name: "pkg2", dependencies: { "no-deps": "catalog:" } },
+        packages: { "no-deps": "no-deps@1.0.0", "pkg2/no-deps": "no-deps@2.0.0" },
       });
-
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-      expect(lock.catalogs).toStrictEqual({ legacy: { "no-deps": "1.0.0" } });
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:legacy" });
-      expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      const lockText = await dir.lockText();
-      expect(lockText).toContain("no-deps@1.0.0");
-      expect(lockText).toContain("no-deps@2.0.0");
+      expect(await dir.pkg1Text()).toBe(pkg1);
 
       await dir.installSavesNothing();
     });
@@ -1534,62 +1630,69 @@ describe.concurrent("bun add --catalog", () => {
     test("edits only the filtered member and the root catalog", async () => {
       const pkg1 = JSON.stringify({ name: "pkg1", dependencies: { "no-deps": "catalog:" } });
       const dir = await createDir(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }), pkg1, withPkg2());
-      await dir.install();
+      expectSaved(await dir.install());
 
-      expectOk(await dir.add(dir.packageDir, "a-dep", "--catalog", "--filter", "pkg2"));
+      expectSaved(await dir.add(dir.packageDir, "a-dep", "--catalog", "--filter", "pkg2"));
 
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
+      const root = workspacesObject({ catalog: { "a-dep": "^1.0.10", "no-deps": "^1.0.0" } });
+      await dir.expectFiles({
+        root,
+        pkg1,
+        pkg2: withDeps(PKG2_JSON, { "a-dep": "catalog:" }),
+        packages: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@1.1.0" },
+      });
       expect(await dir.pkg1Text()).toBe(pkg1);
-      const root = await dir.root();
-      expect(root.dependencies).toBeUndefined();
-      expect(root.workspaces.catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
-      expect(Object.keys(root.workspaces.catalog)).toStrictEqual(["a-dep", "no-deps"]);
-      expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
+      expect(Object.keys((await dir.root()).workspaces.catalog)).toStrictEqual(["a-dep", "no-deps"]);
       expect((await dir.installed("a-dep")).version).toBe("1.0.10");
 
-      expectOk(await dir.add(dir.packageDir, "a-dep", "--catalog", "--filter", "*", "--filter", "root"));
+      expectSaved(await dir.add(dir.packageDir, "a-dep", "--catalog", "--filter", "*", "--filter", "root"));
 
-      expect((await dir.root()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:", "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
+      await dir.expectFiles({
+        root: { ...root, dependencies: { "a-dep": "catalog:" } },
+        pkg1: { name: "pkg1", dependencies: { "a-dep": "catalog:", "no-deps": "catalog:" } },
+        pkg2: withDeps(PKG2_JSON, { "a-dep": "catalog:" }),
+        packages: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@1.1.0" },
+      });
 
-      const { err } = await dir.install({ savesLockfile: false });
-      expect(err).not.toContain("Saved lockfile");
+      await dir.installSavesNothing();
     });
 
     test("--only-missing skips members that already have the package", async () => {
       const pkg1 = { name: "pkg1", dependencies: { "no-deps": "^1.0.0" } };
       const dir = await createDir(workspacesObject({ catalog: {} }), pkg1, withPkg2());
 
-      expectOk(
+      expectSaved(
         await dir.add(dir.packageDir, "no-deps", "--catalog", "--only-missing", "--filter", "pkg1", "--filter", "pkg2"),
       );
 
-      expect(await dir.pkg1()).toStrictEqual(pkg1);
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
+        pkg1,
+        pkg2: withDeps(PKG2_JSON, { "no-deps": "catalog:" }),
+        packages: { "no-deps": "no-deps@1.1.0", "pkg2/no-deps": "no-deps@2.0.0" },
+      });
     });
 
     test("--only-missing with every member already having the package leaves the catalog empty", async () => {
+      const root = workspacesObject({ catalog: {} });
       const pkg1 = { name: "pkg1", dependencies: { "no-deps": "^1.0.0" } };
-      const dir = await createDir(workspacesObject({ catalog: {} }), pkg1);
+      const dir = await createDir(root, pkg1);
 
-      expectOk(await dir.add(dir.packageDir, "no-deps", "--catalog", "--only-missing", "--filter", "pkg1"));
+      expectSaved(await dir.add(dir.packageDir, "no-deps", "--catalog", "--only-missing", "--filter", "pkg1"));
 
-      expect(await dir.pkg1()).toStrictEqual(pkg1);
-      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: {} }));
+      await dir.expectFiles({ root, pkg1, packages: { "no-deps": "no-deps@1.1.0" } });
     });
   });
 
   test("--only-missing when the target already has the package leaves the catalog empty", async () => {
+    const root = workspacesObject({ catalog: {} });
     const pkg1 = { name: "pkg1", dependencies: { "no-deps": "^1.0.0" } };
-    const dir = await createDir(workspacesObject({ catalog: {} }), pkg1);
+    const dir = await createDir(root, pkg1);
     const rootBefore = await dir.rootText();
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--only-missing"));
+    expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--only-missing"));
 
-    expect(await dir.pkg1()).toStrictEqual(pkg1);
+    await dir.expectFiles({ root, pkg1, packages: { "no-deps": "no-deps@1.1.0" } });
     expect(await dir.rootText()).toBe(rootBefore);
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
   });
@@ -1602,21 +1705,25 @@ describe.concurrent("bun add --catalog", () => {
       member("pkg1"),
       withPkg2(member("pkg2")),
     );
-    await dir.install();
+    expectSaved(await dir.install());
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog"));
+    const result = await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog");
+    expect(result.stderr).toBe(
+      'note: catalog entry no-deps changed from "^2.0.0" to "1.0.0" (also used by pkg2)\nSaved lockfile\n',
+    );
+    expect(result.exitCode).toBe(0);
 
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
+    await dir.expectFiles({
+      root: workspacesObject({ catalog: { "no-deps": "1.0.0" } }),
+      pkg1: member("pkg1"),
+      pkg2: member("pkg2"),
+      packages: { "no-deps": "no-deps@1.0.0" },
+    });
     expect(await dir.pkg2Text()).toBe(member("pkg2"));
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    const lockText = await dir.lockText();
-    expect(lockText).not.toContain("no-deps@2.0.0");
-    expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "1.0.0" });
 
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   // Bun deviates from pnpm here: pnpm keeps the entry and writes the version directly into the member.
@@ -1628,15 +1735,23 @@ describe.concurrent("bun add --catalog", () => {
         member("pkg1"),
         withPkg2(member("pkg2")),
       );
-      await dir.install();
+      expectSaved(await dir.install());
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"));
+      const result = await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog");
+      expect(result.stderr).toBe(
+        'note: catalog entry no-deps changed from "^1.0.0" to "2.0.0" (also used by pkg2)\nSaved lockfile\n',
+      );
+      expect(result.exitCode).toBe(0);
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "2.0.0" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "2.0.0" } }),
+        pkg1: member("pkg1"),
+        pkg2: member("pkg2"),
+        packages: { "no-deps": "no-deps@2.0.0" },
+      });
       expect(await dir.pkg2Text()).toBe(member("pkg2"));
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      expect(await dir.lockText()).not.toContain("no-deps@1.1.0");
     });
 
     test("range declared directly by the target", async () => {
@@ -1644,12 +1759,15 @@ describe.concurrent("bun add --catalog", () => {
         name: "pkg1",
         dependencies: { "no-deps": "^1.0.0" },
       });
-      await dir.install();
+      expectSaved(await dir.install());
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"));
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "2.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "2.0.0" } }),
+        pkg1: { name: "pkg1", dependencies: { "no-deps": "catalog:" } },
+        packages: { "no-deps": "no-deps@2.0.0" },
+      });
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
     });
   });
@@ -1660,10 +1778,13 @@ describe.concurrent("bun add --catalog", () => {
       dependencies: { "a-dep": "1.0.1" },
     });
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+    expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "1.0.1", "no-deps": "catalog:" });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+    await dir.expectFiles({
+      root: workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
+      pkg1: { name: "pkg1", dependencies: { "a-dep": "1.0.1", "no-deps": "catalog:" } },
+      packages: { "a-dep": "a-dep@1.0.1", "no-deps": "no-deps@2.0.0" },
+    });
     expect((await dir.installed("a-dep")).version).toBe("1.0.1");
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
   });
@@ -1673,16 +1794,19 @@ describe.concurrent("bun add --catalog", () => {
       name: "pkg1",
       dependencies: { "no-deps": "^1.0.0" },
     });
-    await dir.install();
+    expectSaved(await dir.install());
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+    expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-    expect(await dir.pkg1Text()).toBe(pretty({ name: "pkg1", dependencies: { "no-deps": "catalog:" } }));
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
+    const pkg1 = pretty({ name: "pkg1", dependencies: { "no-deps": "catalog:" } });
+    await dir.expectFiles({
+      root: workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
+      pkg1,
+      packages: { "no-deps": "no-deps@1.1.0" },
+    });
+    expect(await dir.pkg1Text()).toBe(pkg1);
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-    expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-    expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
 
     await dir.installSavesNothing();
   });
@@ -1690,10 +1814,10 @@ describe.concurrent("bun add --catalog", () => {
   test("re-running the same add is idempotent", async () => {
     const dir = await createDir(workspacesObject({ catalog: {} }));
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+    expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
     const [rootAfter, pkg1After, lockAfter] = await Promise.all([dir.rootText(), dir.pkg1Text(), dir.lockText()]);
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+    expectUnchanged(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
     expect(await dir.rootText()).toBe(rootAfter);
     expect(await dir.pkg1Text()).toBe(pkg1After);
@@ -1705,18 +1829,19 @@ describe.concurrent("bun add --catalog", () => {
       workspacesObject({ catalogs: { other: { "a-dep": "1.0.1" }, testing: { "no-deps": "1.0.0" } } }),
     );
 
-    expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=testing"));
+    expectSaved(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=testing"));
 
-    const catalogs = { other: { "a-dep": "1.0.1" }, testing: { "a-dep": "^1.0.10", "no-deps": "1.0.0" } };
-    const root = await dir.root();
-    expect(root.workspaces.catalogs).toStrictEqual(catalogs);
-    expect(Object.keys(root.workspaces.catalogs.testing)).toStrictEqual(["a-dep", "no-deps"]);
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:testing" });
-    expect((await dir.lock()).catalogs).toStrictEqual(catalogs);
+    await dir.expectFiles({
+      root: workspacesObject({
+        catalogs: { other: { "a-dep": "1.0.1" }, testing: { "a-dep": "^1.0.10", "no-deps": "1.0.0" } },
+      }),
+      pkg1: withDeps(PKG1_JSON, { "a-dep": "catalog:testing" }),
+      packages: { "a-dep": "a-dep@1.0.10" },
+    });
+    expect(Object.keys((await dir.root()).workspaces.catalogs.testing)).toStrictEqual(["a-dep", "no-deps"]);
     expect((await dir.installed("a-dep")).version).toBe("1.0.10");
 
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   test("one package failing to resolve writes nothing", async () => {
@@ -1725,11 +1850,11 @@ describe.concurrent("bun add --catalog", () => {
 
     const { stderr, exitCode } = await dir.add(dir.pkg1Dir, "no-deps", "this-package-does-not-exist-xyz", "--catalog");
 
-    expect(stderr).toContain("error:");
+    expect(stderr).toBe(`error: GET ${registry.registryUrl()}this-package-does-not-exist-xyz - 404\n`);
     expect(await dir.rootText()).toBe(rootBefore);
     expect(await dir.pkg1Text()).toBe(pkg1Before);
     expect(await dir.lockExists()).toBeFalse();
-    expect(exitCode).not.toBe(0);
+    expect(exitCode).toBe(1);
   });
 
   for (const from of ["member", "root"] as const) {
@@ -1738,7 +1863,9 @@ describe.concurrent("bun add --catalog", () => {
       const [rootBefore, pkg1Before] = await Promise.all([dir.rootText(), dir.pkg1Text()]);
 
       const cwd = from === "member" ? dir.pkg1Dir : dir.packageDir;
-      expectOk(await dir.add(cwd, "no-deps", "--catalog", "--no-save"));
+      const result = await dir.add(cwd, "no-deps", "--catalog", "--no-save");
+      expectUnchanged(result);
+      expect(summary(result.stdout)).toBe("installed no-deps@2.0.0\n\n2 packages installed");
 
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);
@@ -1756,7 +1883,7 @@ describe.concurrent("bun add --catalog", () => {
       ) + "\n";
     const dir = await createDir(rootBefore);
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+    expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
     const rootText = await dir.rootText();
     expect(rootText).toBe(
@@ -1766,6 +1893,11 @@ describe.concurrent("bun add --catalog", () => {
         4,
       ) + "\n",
     );
+    await dir.expectFiles({
+      root: rootText,
+      pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+      packages: { "no-deps": "no-deps@2.0.0" },
+    });
   });
 
   // pnpm #7072: `catalog:` and `catalog:default` are one catalog, whether it is spelled `catalog` or `catalogs.default`.
@@ -1780,20 +1912,19 @@ describe.concurrent("bun add --catalog", () => {
       test(`${flag} reuses the entry spelled ${Object.keys(root)[0]}`, async () => {
         const otherReference = reference === "catalog:" ? "catalog:default" : "catalog:";
         const dir = await createDir(workspacesObject(root), PKG1, withPkg2(member("pkg2", otherReference)));
-        await dir.install();
+        expectSaved(await dir.install());
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-        expectOk(await dir.add(dir.pkg1Dir, "no-deps", flag));
+        expectSaved(await dir.add(dir.pkg1Dir, "no-deps", flag));
 
-        expect((await dir.root()).workspaces).toStrictEqual({ packages: ["packages/*"], ...root });
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": reference });
+        await dir.expectFiles({
+          root: workspacesObject(root),
+          pkg1: withDeps(PKG1_JSON, { "no-deps": reference }),
+          pkg2: member("pkg2", otherReference),
+          packages: { "no-deps": "no-deps@1.0.0" },
+        });
         expect(await dir.pkg2Text()).toBe(member("pkg2", otherReference));
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-
-        const lock = await dir.lock();
-        expect(lock.catalog).toStrictEqual(root.catalog);
-        expect(lock.catalogs).toStrictEqual(root.catalogs);
-        expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
 
         await dir.installSavesNothing();
       });
@@ -1806,13 +1937,17 @@ describe.concurrent("bun add --catalog", () => {
 
     test("both objects present: the one defining the name is reused", async () => {
       const dir = await createDir(bothObjects, PKG1, withPkg2(member("pkg2")));
-      await dir.install();
+      expectSaved(await dir.install());
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-      expect((await dir.root()).workspaces).toStrictEqual(bothObjects.workspaces);
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root: bothObjects,
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+        pkg2: member("pkg2"),
+        packages: { "no-deps": "no-deps@1.0.0" },
+      });
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
       await dir.installSavesNothing();
@@ -1820,22 +1955,24 @@ describe.concurrent("bun add --catalog", () => {
 
     test("both objects present: an explicit version replaces the entry where it is defined", async () => {
       const dir = await createDir(bothObjects, PKG1, withPkg2(member("pkg2")));
-      await dir.install();
+      expectSaved(await dir.install());
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"));
+      const result = await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog");
+      expect(result.stderr).toBe(
+        'note: catalog entry no-deps changed from "1.0.0" to "2.0.0" (also used by pkg2)\nSaved lockfile\n',
+      );
+      expect(result.exitCode).toBe(0);
 
-      expect((await dir.root()).workspaces).toStrictEqual({
-        packages: ["packages/*"],
-        catalog: { "a-dep": "1.0.1" },
-        catalogs: { default: { "no-deps": "2.0.0" } },
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "a-dep": "1.0.1" }, catalogs: { default: { "no-deps": "2.0.0" } } }),
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+        pkg2: member("pkg2"),
+        packages: { "no-deps": "no-deps@2.0.0" },
       });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
 
-      const { stderr, exitCode } = await dir.frozen();
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      await dir.frozenOk();
     });
 
     test("--catalog with an explicit version replaces the catalogs.default entry instead of adding a second catalog", async () => {
@@ -1844,27 +1981,25 @@ describe.concurrent("bun add --catalog", () => {
         member("pkg1"),
         withPkg2(member("pkg2", "catalog:default")),
       );
-      await dir.install();
+      expectSaved(await dir.install());
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"));
+      const result = await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog");
+      expect(result.stderr).toBe(
+        'note: catalog entry no-deps changed from "1.0.0" to "2.0.0" (also used by pkg2)\nSaved lockfile\n',
+      );
+      expect(result.exitCode).toBe(0);
 
-      expect((await dir.root()).workspaces).toStrictEqual({
-        packages: ["packages/*"],
-        catalogs: { default: { "no-deps": "2.0.0" } },
+      await dir.expectFiles({
+        root: workspacesObject({ catalogs: { default: { "no-deps": "2.0.0" } } }),
+        pkg1: member("pkg1"),
+        pkg2: member("pkg2", "catalog:default"),
+        packages: { "no-deps": "no-deps@2.0.0" },
       });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
       expect(await dir.pkg2Text()).toBe(member("pkg2", "catalog:default"));
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
 
-      const lock = await dir.lock();
-      expect(lock.catalog).toBeUndefined();
-      expect(lock.catalogs).toStrictEqual({ default: { "no-deps": "2.0.0" } });
-      expect(lock.packages["no-deps"][0]).toBe("no-deps@2.0.0");
-
-      const { stderr, exitCode } = await dir.frozen();
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      await dir.frozenOk();
     });
 
     test("--catalog=default with an explicit range replaces the singular catalog every catalog: reference resolves through", async () => {
@@ -1873,23 +2008,22 @@ describe.concurrent("bun add --catalog", () => {
         PKG1,
         withPkg2(member("pkg2")),
       );
-      await dir.install();
+      expectSaved(await dir.install());
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@^2.0.0", "--catalog=default"));
+      const result = await dir.add(dir.pkg1Dir, "no-deps@^2.0.0", "--catalog=default");
+      expect(result.stderr).toBe(
+        'note: catalog entry no-deps changed from "^1.0.0" to "^2.0.0" (also used by pkg2)\nSaved lockfile\n',
+      );
+      expect(result.exitCode).toBe(0);
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:default" });
-      expect((await dir.root()).workspaces).toStrictEqual({
-        packages: ["packages/*"],
-        catalog: { "no-deps": "^2.0.0" },
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:default" }),
+        pkg2: member("pkg2"),
+        packages: { "no-deps": "no-deps@2.0.0" },
       });
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-      expect(lock.catalogs).toBeUndefined();
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:default" });
-      expect(await dir.lockText()).not.toContain("no-deps@1.1.0");
 
       await dir.installSavesNothing();
     });
@@ -1897,31 +2031,34 @@ describe.concurrent("bun add --catalog", () => {
     test("--catalog=default with no catalog defined creates the singular catalog", async () => {
       const dir = await createDir(workspacesObject());
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog=default"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog=default"));
 
-      expect(await dir.root()).toStrictEqual({
-        name: "root",
-        workspaces: { packages: ["packages/*"], catalog: { "no-deps": "^2.0.0" } },
+      await dir.expectFiles({
+        root: workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:default" }),
+        packages: { "no-deps": "no-deps@2.0.0" },
       });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:default" });
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^2.0.0" });
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
     });
 
     test("bun update --latest refreshes a catalogs.default entry referenced as catalog:", async () => {
       const dir = await createDir(workspacesObject({ catalogs: { default: { "no-deps": "^1.0.0" } } }), member("pkg1"));
-      await dir.install();
+      expectSaved(await dir.install());
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
-      expectOk(await dir.run(dir.packageDir, ["update", "--latest"]));
+      const result = await dir.run(dir.packageDir, ["update", "--latest"]);
+      expectSaved(result);
+      expect(summary(result.stdout)).toBe("1 package installed");
 
-      expect((await dir.root()).workspaces.catalogs).toStrictEqual({ default: { "no-deps": "^2.0.0" } });
+      await dir.expectFiles({
+        root: workspacesObject({ catalogs: { default: { "no-deps": "^2.0.0" } } }),
+        pkg1: member("pkg1"),
+        packages: { "no-deps": "no-deps@2.0.0" },
+      });
       expect(await dir.pkg1Text()).toBe(member("pkg1"));
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      expect((await dir.lock()).catalogs).toStrictEqual({ default: { "no-deps": "^2.0.0" } });
 
-      const { err } = await dir.install({ savesLockfile: false });
-      expect(err).not.toContain("Saved lockfile");
+      await dir.installSavesNothing();
     });
 
     test("bun pm pack substitutes a catalogs.default entry referenced as catalog:", async () => {
@@ -1930,13 +2067,16 @@ describe.concurrent("bun add --catalog", () => {
         version: "1.0.0",
         peerDependencies: { "no-deps": "catalog:" },
       });
-      await dir.install();
+      expectSaved(await dir.install());
 
       const { stderr, exitCode } = await dir.run(dir.pkg1Dir, ["pm", "pack"]);
-      expect(stderr).not.toContain("error:");
+      expect(stderr).toBe("");
       expect(exitCode).toBe(0);
 
       const tarball = readTarball(join(dir.pkg1Dir, "pkg1-1.0.0.tgz"));
+      expect(tarball.entries.map((entry: { pathname: string }) => entry.pathname)).toStrictEqual([
+        "package/package.json",
+      ]);
       expect(JSON.parse(tarball.entries[0].contents)).toStrictEqual({
         name: "pkg1",
         version: "1.0.0",
@@ -1952,16 +2092,19 @@ describe.concurrent("bun add --catalog", () => {
       version: "1.0.0",
       peerDependencies: { "no-deps": "catalog:" },
     });
-    await dir.install();
+    expectSaved(await dir.install());
 
-    expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=x"));
+    expectSaved(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=x"));
     expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:x" });
 
     const { stderr, exitCode } = await dir.run(dir.pkg1Dir, ["pm", "pack"]);
-    expect(stderr).not.toContain("error:");
+    expect(stderr).toBe("");
     expect(exitCode).toBe(0);
 
     const tarball = readTarball(join(dir.pkg1Dir, "pkg1-1.0.0.tgz"));
+    expect(tarball.entries.map((entry: { pathname: string }) => entry.pathname)).toStrictEqual([
+      "package/package.json",
+    ]);
     expect(JSON.parse(tarball.entries[0].contents)).toStrictEqual({
       name: "pkg1",
       version: "1.0.0",
@@ -1979,23 +2122,26 @@ describe.concurrent("bun add --catalog", () => {
       withPkg2(member("pkg2")),
     );
 
-    expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=libs"));
-    expectOk(await dir.run(dir.pkg1Dir, ["remove", "no-deps"]));
-    expectOk(await dir.run(dir.pkg2Dir, ["remove", "no-deps"]));
+    expectSaved(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=libs"));
+    // pkg2 still uses no-deps after the first remove, so only the second one unlinks it.
+    for (const [cwd, removed] of [
+      [dir.pkg1Dir, "- no-deps\ndone"],
+      [dir.pkg2Dir, "- no-deps\n1 package removed"],
+    ]) {
+      const result = await dir.run(cwd, ["remove", "no-deps"]);
+      expectSaved(result);
+      expect(summary(result.stdout)).toBe(removed);
+    }
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:libs" });
-    expect((await dir.pkg2()).dependencies).toBeUndefined();
-    expect((await dir.root()).workspaces).toStrictEqual({
-      packages: ["packages/*"],
-      catalog: { "no-deps": "1.0.0" },
-      catalogs: { libs: { "a-dep": "^1.0.10" } },
+    await dir.expectFiles({
+      root: workspacesObject({ catalog: { "no-deps": "1.0.0" }, catalogs: { libs: { "a-dep": "^1.0.10" } } }),
+      pkg1: { name: "pkg1", dependencies: { "a-dep": "catalog:libs" } },
+      pkg2: { name: "pkg2" },
+      packages: { "a-dep": "a-dep@1.0.10" },
     });
-    const lock = await dir.lock();
-    expect(lock.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-    expect(lock.catalogs).toStrictEqual({ libs: { "a-dep": "^1.0.10" } });
+    expect(await dir.installedExists("no-deps")).toBeFalse();
 
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   // pnpm #8795: --frozen-lockfile notices a changed catalog entry.
@@ -2003,19 +2149,20 @@ describe.concurrent("bun add --catalog", () => {
     test(`--frozen-lockfile passes after the add and fails once the entry is edited (from ${from})`, async () => {
       const dir = await createDir(workspacesObject({ catalog: {} }));
 
-      expectOk(await dir.add(from === "member" ? dir.pkg1Dir : dir.packageDir, "no-deps", "--catalog"));
+      expectSaved(await dir.add(from === "member" ? dir.pkg1Dir : dir.packageDir, "no-deps", "--catalog"));
 
-      const frozen = await dir.run(dir.packageDir, ["install", "--frozen-lockfile"]);
-      expect(frozen.stderr).not.toContain("error:");
-      expect(frozen.exitCode).toBe(0);
+      await dir.frozenOk();
 
       const root = await dir.root();
       root.workspaces.catalog["no-deps"] = "1.0.0";
       await write(dir.rootPath, JSON.stringify(root));
 
       const { stderr, exitCode } = await dir.run(dir.packageDir, ["install", "--frozen-lockfile"]);
-      expect(stderr).toContain("error:");
-      expect(stderr).toContain("frozen-lockfile");
+      expect(stderr).toBe(
+        "error: lockfile had changes, but lockfile is frozen\n" +
+          "note: the catalog in package.json changed since bun.lock was saved\n" +
+          "note: try re-running without --frozen-lockfile and commit the updated lockfile\n",
+      );
       expect(exitCode).toBe(1);
     });
   }
@@ -2031,12 +2178,14 @@ describe.concurrent("bun add --catalog", () => {
     for (const args of [["update"], ["update", "--recursive"], ["update", "no-deps"], ["update", "no-deps@1.1.0"]]) {
       test(`survive bun ${args.join(" ")}`, async () => {
         const dir = await createDir(overriddenRoot, pkg1);
-        await dir.install();
+        expectSaved(await dir.install());
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-        expectOk(await dir.run(dir.pkg1Dir, args));
+        const result = await dir.run(dir.pkg1Dir, args);
+        expectUnchanged(result);
+        expect(summary(result.stdout)).toBe("Checked 2 installs across 3 packages (no changes)");
 
-        expect(await dir.pkg1()).toStrictEqual(pkg1);
+        await dir.expectFiles({ root: overriddenRoot, pkg1, packages: { "no-deps": "no-deps@1.0.0" } });
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
       });
     }
@@ -2044,20 +2193,19 @@ describe.concurrent("bun add --catalog", () => {
     test("survive bun add --catalog of another package", async () => {
       const dir = await createDir(overriddenRoot, pkg1);
 
-      expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog"));
+      expectSaved(await dir.add(dir.pkg1Dir, "a-dep", "--catalog"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:", "no-deps": "catalog:" });
-      const lock = await dir.lock();
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({
-        "a-dep": "catalog:",
-        "no-deps": "catalog:",
+      await dir.expectFiles({
+        root: {
+          ...workspacesObject({ catalog: { "a-dep": "^1.0.10", "no-deps": "^1.0.0" } }),
+          overrides: { "no-deps": "1.0.0" },
+        },
+        pkg1: { name: "pkg1", dependencies: { "a-dep": "catalog:", "no-deps": "catalog:" } },
+        packages: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@1.0.0" },
       });
-      expect(lock.catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-      const { stderr, exitCode } = await dir.frozen();
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      await dir.frozenOk();
     });
   });
 
@@ -2065,15 +2213,16 @@ describe.concurrent("bun add --catalog", () => {
   test("an override decides what --catalog records", async () => {
     const dir = await createDir({ ...workspacesObject({ catalog: {} }), overrides: { "no-deps": "1.0.0" } });
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+    expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-    expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
+    await dir.expectFiles({
+      root: { ...workspacesObject({ catalog: { "no-deps": "^1.0.0" } }), overrides: { "no-deps": "1.0.0" } },
+      pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+      packages: { "no-deps": "no-deps@1.0.0" },
+    });
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   // pnpm: a bare `add <name>` in a workspace whose default catalog lists <name> writes `catalog:`.
@@ -2084,37 +2233,31 @@ describe.concurrent("bun add --catalog", () => {
       const dir = await createDir(defaultRoot);
       const rootBefore = await dir.rootText();
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root: defaultRoot,
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+        packages: { "no-deps": "no-deps@1.1.0" },
+      });
       expect(await dir.rootText()).toBe(rootBefore);
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
-      const lock = await dir.lock();
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
-
       await dir.installSavesNothing();
-      const { stderr, exitCode } = await dir.frozen();
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
     });
 
     test("bare name from the root", async () => {
       const dir = await createDir(defaultRoot);
 
-      expectOk(await dir.add(dir.packageDir, "no-deps"));
+      expectSaved(await dir.add(dir.packageDir, "no-deps"));
 
-      const root = await dir.root();
-      expect(root.dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(root.workspaces).toStrictEqual(defaultRoot.workspaces);
+      await dir.expectFiles({
+        root: { ...defaultRoot, dependencies: { "no-deps": "catalog:" } },
+        pkg1: PKG1,
+        packages: { "no-deps": "no-deps@1.1.0" },
+      });
       expect(await dir.pkg1Text()).toBe(PKG1);
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-
-      const lock = await dir.lock();
-      expect(lock.workspaces[""].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
 
       await dir.installSavesNothing();
     });
@@ -2127,17 +2270,15 @@ describe.concurrent("bun add --catalog", () => {
         const root = pretty(workspacesObject({ catalogs: { default: { "no-deps": "^1.0.0" } } }));
         const dir = await createDir(root);
 
-        expectOk(await dir.add(dir.pkg1Dir, ...args));
+        expectSaved(await dir.add(dir.pkg1Dir, ...args));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+        await dir.expectFiles({
+          root,
+          pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+          packages: { "no-deps": "no-deps@1.1.0" },
+        });
         expect(await dir.rootText()).toBe(root);
         expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-
-        const lock = await dir.lock();
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        expect(lock.catalog).toBeUndefined();
-        expect(lock.catalogs).toStrictEqual({ default: { "no-deps": "^1.0.0" } });
-        expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
 
         await dir.installSavesNothing();
       });
@@ -2147,14 +2288,15 @@ describe.concurrent("bun add --catalog", () => {
       const dir = await createDir(defaultRoot);
       const rootBefore = await dir.rootText();
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--dev"));
+      expectSaved(await dir.add(dir.pkg1Dir, "no-deps", "--dev"));
 
-      const pkg1 = await dir.pkg1();
-      expect(pkg1.devDependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(pkg1.dependencies).toBeUndefined();
+      await dir.expectFiles({
+        root: defaultRoot,
+        pkg1: { ...PKG1_JSON, devDependencies: { "no-deps": "catalog:" } },
+        packages: { "no-deps": "no-deps@1.1.0" },
+      });
       expect(await dir.rootText()).toBe(rootBefore);
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-      expect((await dir.lock()).workspaces["packages/pkg1"].devDependencies).toStrictEqual({ "no-deps": "catalog:" });
     });
 
     for (const { title, args } of [
@@ -2167,12 +2309,15 @@ describe.concurrent("bun add --catalog", () => {
         const dir = await createDir(defaultRoot);
         const rootBefore = await dir.rootText();
 
-        expectOk(await dir.run(dir.pkg1Dir, args));
+        expectSaved(await dir.run(dir.pkg1Dir, args));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+        await dir.expectFiles({
+          root: defaultRoot,
+          pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+          packages: { "no-deps": "no-deps@1.1.0" },
+        });
         expect(await dir.rootText()).toBe(rootBefore);
         expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-        expect((await dir.lock()).workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
 
         await dir.installSavesNothing();
       });
@@ -2182,16 +2327,16 @@ describe.concurrent("bun add --catalog", () => {
       const dir = await createDir(defaultRoot, PKG1, withPkg2());
       const rootBefore = await dir.rootText();
 
-      expectOk(await dir.add(dir.packageDir, "no-deps", "--filter", "pkg1", "--filter", "pkg2"));
+      expectSaved(await dir.add(dir.packageDir, "no-deps", "--filter", "pkg1", "--filter", "pkg2"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      await dir.expectFiles({
+        root: defaultRoot,
+        pkg1: withDeps(PKG1_JSON, { "no-deps": "catalog:" }),
+        pkg2: withDeps(PKG2_JSON, { "no-deps": "catalog:" }),
+        packages: { "no-deps": "no-deps@1.1.0" },
+      });
       expect(await dir.rootText()).toBe(rootBefore);
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-
-      const lock = await dir.lock();
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
 
       await dir.installSavesNothing();
     });
@@ -2199,10 +2344,10 @@ describe.concurrent("bun add --catalog", () => {
     test("re-adding a package already on catalog: keeps the reference", async () => {
       const pkg1 = pretty({ name: "pkg1", dependencies: { "no-deps": "catalog:" } });
       const dir = await createDir(defaultRoot, pkg1);
-      await dir.install();
+      expectSaved(await dir.install());
       const [rootBefore, lockBefore] = await Promise.all([dir.rootText(), dir.lockText()]);
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps"));
+      expectUnchanged(await dir.add(dir.pkg1Dir, "no-deps"));
 
       expect(await dir.pkg1Text()).toBe(pkg1);
       expect(await dir.rootText()).toBe(rootBefore);
@@ -2213,10 +2358,10 @@ describe.concurrent("bun add --catalog", () => {
     test("an existing named reference is kept", async () => {
       const pkg1 = pretty({ name: "pkg1", dependencies: { "no-deps": "catalog:libs" } });
       const dir = await createDir(workspacesObject({ catalogs: { libs: { "no-deps": "1.0.0" } } }), pkg1);
-      await dir.install();
+      expectSaved(await dir.install());
       const [rootBefore, lockBefore] = await Promise.all([dir.rootText(), dir.lockText()]);
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps"));
+      expectUnchanged(await dir.add(dir.pkg1Dir, "no-deps"));
 
       expect(await dir.pkg1Text()).toBe(pkg1);
       expect(await dir.rootText()).toBe(rootBefore);
@@ -2225,47 +2370,69 @@ describe.concurrent("bun add --catalog", () => {
     });
 
     describe("explicit versions and unlisted names are added normally", () => {
-      for (const { spec, written, installed } of [
-        { spec: "no-deps@1.0.0", written: { "no-deps": "1.0.0" }, installed: "1.0.0" },
-        { spec: "no-deps@latest", written: { "no-deps": "^2.0.0" }, installed: "2.0.0" },
-        { spec: "no-deps@^2.0.0", written: { "no-deps": "^2.0.0" }, installed: "2.0.0" },
-        { spec: "a-dep", written: { "a-dep": "^1.0.10" }, installed: "1.0.10" },
-        { spec: "@types/no-deps", written: { "@types/no-deps": "^2.0.0" }, installed: "2.0.0" },
-        { spec: "foo@npm:no-deps", written: { foo: "npm:no-deps@^2.0.0" }, installed: "2.0.0" },
+      for (const { spec, written, installed, resolved } of [
+        { spec: "no-deps@1.0.0", written: { "no-deps": "1.0.0" }, installed: "1.0.0", resolved: "no-deps@1.0.0" },
+        { spec: "no-deps@latest", written: { "no-deps": "^2.0.0" }, installed: "2.0.0", resolved: "no-deps@2.0.0" },
+        { spec: "no-deps@^2.0.0", written: { "no-deps": "^2.0.0" }, installed: "2.0.0", resolved: "no-deps@2.0.0" },
+        { spec: "a-dep", written: { "a-dep": "^1.0.10" }, installed: "1.0.10", resolved: "a-dep@1.0.10" },
+        {
+          spec: "@types/no-deps",
+          written: { "@types/no-deps": "^2.0.0" },
+          installed: "2.0.0",
+          resolved: "@types/no-deps@2.0.0",
+        },
+        {
+          spec: "foo@npm:no-deps",
+          written: { foo: "npm:no-deps@^2.0.0" },
+          installed: "2.0.0",
+          resolved: "no-deps@2.0.0",
+        },
       ]) {
         test(`bun add ${spec}`, async () => {
           const dir = await createDir(defaultRoot);
           const rootBefore = await dir.rootText();
 
-          expectOk(await dir.add(dir.pkg1Dir, spec));
+          expectSaved(await dir.add(dir.pkg1Dir, spec));
 
-          expect((await dir.pkg1()).dependencies).toStrictEqual(written);
+          const [name] = Object.keys(written);
+          await dir.expectFiles({
+            root: defaultRoot,
+            pkg1: withDeps(PKG1_JSON, written),
+            packages: { [name]: resolved },
+          });
           expect(await dir.rootText()).toBe(rootBefore);
-          expect((await dir.installed(Object.keys(written)[0])).version).toBe(installed);
+          expect((await dir.installed(name)).version).toBe(installed);
         });
       }
 
       test("an explicit version replaces a named reference", async () => {
-        const dir = await createDir(workspacesObject({ catalogs: { libs: { "no-deps": "1.0.0" } } }), {
-          name: "pkg1",
-          dependencies: { "no-deps": "catalog:libs" },
-        });
+        const root = workspacesObject({ catalogs: { libs: { "no-deps": "1.0.0" } } });
+        const dir = await createDir(root, { name: "pkg1", dependencies: { "no-deps": "catalog:libs" } });
         const rootBefore = await dir.rootText();
 
-        expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.1.0"));
+        expectSaved(await dir.add(dir.pkg1Dir, "no-deps@1.1.0"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "1.1.0" });
+        await dir.expectFiles({
+          root,
+          pkg1: { name: "pkg1", dependencies: { "no-deps": "1.1.0" } },
+          packages: { "no-deps": "no-deps@1.1.0" },
+        });
         expect(await dir.rootText()).toBe(rootBefore);
         expect((await dir.installed("no-deps")).version).toBe("1.1.0");
       });
 
       test("named catalogs are not used without the flag", async () => {
-        const dir = await createDir(workspacesObject({ catalogs: { libs: { "no-deps": "1.0.0" } } }));
+        const root = workspacesObject({ catalogs: { libs: { "no-deps": "1.0.0" } } });
+        const dir = await createDir(root);
         const rootBefore = await dir.rootText();
 
-        expectOk(await dir.add(dir.pkg1Dir, "no-deps"));
+        expectSaved(await dir.add(dir.pkg1Dir, "no-deps"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
+        await dir.expectFiles({
+          root,
+          pkg1: withDeps(PKG1_JSON, { "no-deps": "^2.0.0" }),
+          packages: { "no-deps": "no-deps@2.0.0" },
+        });
         expect(await dir.rootText()).toBe(rootBefore);
         expect((await dir.installed("no-deps")).version).toBe("2.0.0");
       });
@@ -2282,7 +2449,7 @@ describe.concurrent("bun add --catalog", () => {
 
       const { stderr, exitCode } = await spawnBun(packageDir, ["add", "no-deps", "--catalog"], envFor(packageDir));
 
-      expect(stderr).toContain('error: --catalog requires a "workspaces" field in the root package.json');
+      expect(stderr).toBe('error: --catalog requires a "workspaces" field in the root package.json\n');
       expect(await file(join(packageDir, "package.json")).text()).toBe(before);
       expect(await file(join(packageDir, "bun.lock")).exists()).toBeFalse();
       expect(exitCode).toBe(1);
@@ -2296,8 +2463,9 @@ describe.concurrent("bun add --catalog", () => {
 
       const { stderr, exitCode } = await dir.add(dir.pkg1Dir, "a-dep", "--catalog");
 
-      expect(stderr).toContain(
-        'error: "no-deps" is defined in both "catalog" and "catalogs.default"; keep one of them',
+      // A code frame pointing at the `catalogs.default` entry precedes the message, and its location follows.
+      expect(stderr).toMatch(
+        /^\d+ \| +"no-deps": "2\.0\.0"\n +\^\nerror: "no-deps" is defined in both "catalog" and "catalogs\.default"; keep one of them\n {4}at .*package\.json:\d+:\d+\n$/,
       );
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);
@@ -2325,14 +2493,15 @@ describe.concurrent("bun add --catalog", () => {
       const [rootBefore, pkg1Before] = await Promise.all([dir.rootText(), dir.pkg1Text()]);
       const globalDir = join(dir.packageDir, ".bun-global");
 
-      const { stderr, exitCode } = await dir.run(dir.pkg1Dir, ["add", "no-deps", "--catalog", "-g"], {
+      const { stdout, stderr, exitCode } = await dir.run(dir.pkg1Dir, ["add", "no-deps", "--catalog", "-g"], {
         ...dir.env,
         BUN_INSTALL: globalDir,
         BUN_INSTALL_GLOBAL_DIR: join(globalDir, "install", "global"),
         BUN_INSTALL_BIN: join(globalDir, "bin"),
       });
 
-      expect(stderr).toContain("error: --catalog cannot be used with --global");
+      expect(stdout).toBe("");
+      expect(stderr).toBe("error: --catalog cannot be used with --global\n");
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);
       expect(await file(join(globalDir, "install", "global", "package.json")).exists()).toBeFalse();


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-add-catalog.test.ts` takes 14s on debian 13 x64-asan (build 104578): half is the verdaccio start as the first registry user in its shard, half is 272 `bun` children run 5 at a time (the ASAN `--max-concurrency` default, `src/options_types/context.rs:506`). It is already `describe.concurrent` throughout.
- Most of the 149 cases checked stderr with `not.toContain("error:")` and one or two fields of package.json and bun.lock. A new note, a stale row or a moved resolution passed.

### Fix
- `spawnBun` strips the two progress lines. Success cases then compare stderr exactly: `Saved lockfile`, nothing, or the note lines before it. Error cases compare the whole message.
- `expectFiles` (89 sites) compares every package.json and derives the bun.lock `workspaces` rows and catalog objects from them. Each case adds the resolution of every dependency, so a nested second version (`pkg2/no-deps`) is visible.
- `installSavesNothing` also pins the `(no changes)` summary. Tarball cases use `installKeepsLockfile`: every install re-extracts a tarball dependency (#8260, fix in #35576). The 9 `--frozen-lockfile` runs right after such an install are gone: it already showed bun.lock is in step. 272 spawns become 263.
- Verified: `bun bd test test/cli/install/bun-add-catalog.test.ts`, 149 pass in 5 runs. Wall time is unchanged within noise (Notes): no speedup is claimed.

### Background
- bun.lock repeats each member's dependency rows under `workspaces`, the root's catalog objects, and one `packages` row per resolved package, keyed by its hoisted path (`pkg2/no-deps` for a second version nested under a workspace).
- `bun install` prints `Saved lockfile` only when the bytes of bun.lock changed.

<details><summary>Notes</summary>

**CI timeline (build 104578, shard 01a03209-fdf7-4f04-a162-576b9c284b16, position 7/289).** Header at +0.07s, first dots at +7.12s, summary at +13.95s. The `coordinator: minio/mysql_tls/postgres_tls/mysql_plain ready` lines land inside the first window. Across the 20 x64-asan shards the first verdaccio file has 5.2s to 10.5s before its first dot, later ones 2.4s to 3.0s. Spawn arithmetic: 272 children / 5 in flight = 54 rounds, 6.8s / 54 = 125ms per child, which is about what a release ASAN `bun add` costs.

**Local measurements (debug ASAN, 16 cores, verdaccio under the release bun).** Old and new alternated on the same machine: 14.39s/15.12s against 14.33s/14.99s. `registry.start()` 1.1s. A single `bun add` in isolation is 190ms to 210ms cold, 150ms with a warm cache, `bun --version` 105ms, so process start is most of a spawn. `--max-concurrency=200` finishes in 9.5s but times out most cases at 5s: the work is CPU bound. Sum of per-test durations 53.9s with 6 children in flight at most. Each spawn removed saves about 25ms of CI wall time, so the 9 removed frozen runs are about 0.2s. Removing the pre-installs or the post-install checks would cut more, but each of them is a scenario (an existing lockfile, or a lockfile a later install accepts), so none was removed.

**What the stricter assertions surfaced.** (1) The `note: catalog entry ... changed` line, printed whenever an explicit version replaces an entry; with `(also used by <member>)` when other members reference it. (2) A plain `bun install` after any tarball `--catalog` add prints `1 package installed` every time, in a plain project too (probed with a non-workspace package.json): `verify_package_json_name_and_version` compares the installed `version` with the formatted resolution, which is the URL (`src/install/PackageInstaller.rs`, `resolution.fmt`). That is #8260; #35576 fixes it, after which the 11 `installKeepsLockfile` sites can become `installSavesNothing`. (3) `bun update --latest` on a `catalogs.default` entry prints only `1 package installed`; #38763 adds the update row and will update that line. (4) Hoisting after an add: the added tarball or range is hoisted and the version another member already had moves under that member (`pkg2/no-deps`), also for `--only-missing`.

**Assertion changes.** `expectOk` (`not.toContain("error:")`, `not.toContain("panic:")`) is replaced by `expectSaved` (108 sites) and `expectUnchanged` (8 sites: re-runs and adds that find the entry and reference already in place). Notes are pinned with their order: pkg1 before pkg2 in the two-note case. The `--dry-run` listing, the `--lockfile-only` summary (`Saved bun.lock (3 packages)`), `--no-save` (`installed no-deps@2.0.0` / `2 packages installed`), `bun remove` (`done` while pkg2 still uses it, `1 package removed` after), `bun update --latest` and `--silent` (empty stdout and stderr) pin stdout. The frozen failure pins the error and both notes. The both-catalogs error pins the code frame shape and the `at .../package.json:line:col` line. The expect() count drops from 1856 to 1274 because one `toStrictEqual` on the lockfile view replaces several per-field checks and the harness `runBunInstall` (6 expects per call) is no longer used.

**Left minimal on purpose.** "alias@npm:pkg is written verbatim, like plain add" (#39774 rewrites its expectations) and "name only in peerDependencies, adding with --dev, matches plain add" (#36284 does the same) keep their original shape; only `expectOk` became `expectSaved`.

**Also run.** `bunx prettier --check` clean. `tsc -p test/tsconfig.json` reports nothing for this file. Windows x64 (Server 2019, debug build of this branch): 149 pass in 9.3s. The only platform difference found was the `--dry-run` listing, which prints the workspace path with a backslash; the test compares it with forward slashes.
</details>
