### PR TITLE
fetch: keep loading a collected Response's body while Bun.write() waits for it

### DIFF
--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2738,8 +2738,10 @@ impl FetchTasklet {
             //
             // 1. We are streaming, in which case we should not ignore the body.
             // 2. We were buffering, in which case
-            //    2a. if we have no promise, we should ignore the body.
-            //    2b. if we have a promise, we should keep loading the body.
+            //    2a. if nothing waits for the body, we should ignore the body.
+            //    2b. if a consumer waits for the whole body (`.text()` and friends hold
+            //        a promise, `Bun.write()` an `on_receive_value`), we should keep
+            //        loading the body.
             // 3. We never started buffering, in which case we should ignore the body.
             //
             // Inside a finalizer: decide from native state only.
@@ -2752,13 +2754,12 @@ impl FetchTasklet {
             }
 
             if let BodyValue::Locked(locked) = body {
-                if let Some(promise) = locked.promise {
-                    if promise.is_empty_or_undefined_or_null() {
-                        // Scenario 2b.
-                        this.ignore_remaining_response_body();
-                    }
-                } else {
-                    // Scenario 3.
+                let has_consumer = locked.on_receive_value.is_some()
+                    || locked
+                        .promise
+                        .is_some_and(|promise| !promise.is_empty_or_undefined_or_null());
+                if !has_consumer {
+                    // Scenario 2a or 3.
                     this.ignore_remaining_response_body();
                 }
             }

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -874,6 +874,59 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
     },
   );
 
+  // Bun.write registers `on_receive_value` on the Locked body and holds no
+  // reference to the Response. The fetch Response finalizer only counted a
+  // promise (`.text()` and friends) as a consumer, so a Response collected
+  // while its body was still arriving had its body discarded and the write
+  // never settled.
+  it("Bun.write(path, fetch()) settles when the Response is collected mid-download", async () => {
+    using dir = tempDir("bun-write-fetch-collected-response", {});
+    const dest = join(String(dir), "out.bin");
+    const CHUNK = 64 * 1024;
+    const { promise: gate, resolve: openGate } = Promise.withResolvers();
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        new Response(
+          new ReadableStream({
+            async pull(controller) {
+              controller.enqueue(new Uint8Array(CHUNK));
+              // Hold the rest of the body until the client's Response is gone.
+              await gate;
+              controller.enqueue(new Uint8Array(CHUNK));
+              controller.close();
+            },
+          }),
+        ),
+    });
+
+    let collected = false;
+    const registry = new FinalizationRegistry(() => (collected = true));
+    // Its own frame: once it returns, only the write promise is held.
+    async function start() {
+      const resp = await fetch(server.url);
+      registry.register(resp, null);
+      return Bun.write(dest, resp);
+    }
+    const written = start();
+    for (const until = performance.now() + 20_000; !collected && performance.now() < until; ) {
+      Bun.gc(true);
+      await Bun.sleep(10);
+    }
+    Bun.gc(true);
+    openGate();
+
+    // A write that never settles fails here instead of hanging the test.
+    let watchdog;
+    const neverSettled = new Promise(resolve => (watchdog = setTimeout(resolve, 5_000, "never settled")));
+    try {
+      const outcome = await Promise.race([written, neverSettled]);
+      expect({ collected, outcome }).toEqual({ collected: true, outcome: 2 * CHUNK });
+    } finally {
+      clearTimeout(watchdog);
+    }
+  }, 30_000);
+
   it("Bun.write(path, HTMLRewriter.transform(resp)) still resolves after out.body is touched", async () => {
     using dir = tempDir("bun-write-htmlrewriter-body", {});
     const dest = join(String(dir), "out.html");


### PR DESCRIPTION
### Problem
- `await Bun.write(path, await fetch(url))` never settles when the GC collects the `Response` while the body is still arriving. The last syntactic use of the `Response` is the `Bun.write` call, so any collection mid-download triggers it. No error, no abort, the process hangs. Fixes #40278.
- The cause is `FetchTasklet::on_response_finalize` (`src/runtime/webcore/fetch/FetchTasklet.rs:2754`). It treats a `Locked` body as unconsumed unless `.text()` and friends stored a promise on it. `Bun.write` registers `locked.on_receive_value` instead (`Blob.rs:5112`) and holds no reference to the `Response`. The finalizer then calls `ignore_remaining_response_body()`, which releases `native_response`, so `BodyValue::resolve` never runs and `then_wrap` never fires.

### Fix
- The finalizer counts `on_receive_value` as a consumer, the same as a promise. The body keeps loading into the native `Response` the tasklet still holds, `resolve` calls `then_wrap`, and the write settles with the byte count (or rejects with the network error).
- This is the same rule `Body.rs` already applies: `locked_to_native_stream` and `tee` treat a set `on_receive_value` as "a native consumer owns this body".
- #39690 carries the same one-line check inside a larger change to the abandoned-body policy. This PR is only the hang fix, so it can ship on its own. #39690 rebases on it.
- Verified: `test/js/bun/io/bun-write.test.js`, "Bun.write(path, fetch()) settles when the Response is collected mid-download". On 1.4.0 it fails with `outcome: "never settled"`. Also ran the rest of that file and the fetch suites listed in the notes.

### Background
- `FetchTasklet` is the native side of one `fetch()`. It holds one native ref to the `Response` (`native_response`) and a JSC `Weak` on the JS wrapper whose finalizer is `on_response_finalize`. The finalizer runs inside a GC sweep and reads native state only.
- A `Locked` body (`PendingValue` in `Body.rs`) is a body that has not fully arrived. A consumer waits for it in one of two ways: `.text()` and friends store a protected promise in `locked.promise`, `Bun.write` stores a callback in `locked.on_receive_value` and its task in `locked.task`.
- `ignore_remaining_response_body` is the path for a body nothing will read: it switches receive mode to `Ignore`, unrefs the event loop, and drops the tasklet's native `Response`.

<details><summary>Notes</summary>

Repro from the issue, run against 1.4.0 and the debug build of this branch: `HANG` before, `wrote 3932160` after. The control with the `Response` held in an outer scope completes on both.

The test holds the second half of the body behind a promise on the server, loops `Bun.gc(true)` until a `FinalizationRegistry` reports the `Response` collected, then releases the body. The write resolves with the full length on this branch. On 1.4.0 it never settles and the test fails on a 5 s watchdog. Eight repeated runs on the debug build, 250 ms to 1 s each.

Suites run on the debug build: `test/js/bun/io/bun-write.test.js` (50 pass, the 256 MiB `copyFileRange` copy exceeds its 5 s budget on this machine with or without the change), `fetch-response-finalizer-sweep`, `body-mixin-errors`, `body`, `fetch-backpressure` (the four h3 tests time out under the full file's concurrent load here and pass when run alone), `fetch-stream-cancel-leak`, `blob-write`, `fetch-abort-stream-body`, `body-stream`, `fetch-http3-client`, `fetch-leak` (the URLSearchParams fixture needs more than its 120 s budget on this machine, as noted in #39690).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->