### PR TITLE
test(workers): speed up structured-clone.test.ts and tighten its assertions

### DIFF
--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -726,24 +726,25 @@ describe.concurrent("structuredClone with ArrayBuffer larger than serialization 
           Bun.gc(true);
         }
       `);
-      // The host's OOM killer reclaiming the child on a small CI runner before it reported
-      // anything is not a structuredClone failure; any other signal (SIGSEGV/SIGABRT/...) still is.
-      if (result.signalCode === "SIGKILL" && result.lines.length === 0) continue;
-      expect({ ...result, lines: result.lines.map(line => JSON.parse(line)) }).toEqual({
-        lines: batch.map(({ label, type, resizable = false }) => ({
-          label,
-          type,
-          byteLength: size,
-          first: 1,
-          last: 2,
-          // A view reports neither; a fixed-length ArrayBuffer reports maxByteLength === byteLength.
-          resizable: type === "ArrayBuffer" ? resizable : null,
-          maxByteLength: type === "ArrayBuffer" ? size : null,
-        })),
-        stderr: "",
-        signalCode: null,
-        exitCode: 0,
-      });
+      const lines = result.lines.map(line => JSON.parse(line));
+      const expected = batch.map(({ label, type, resizable = false }) => ({
+        label,
+        type,
+        byteLength: size,
+        first: 1,
+        last: 2,
+        // A view reports neither; a fixed-length ArrayBuffer reports maxByteLength === byteLength.
+        resizable: type === "ArrayBuffer" ? resizable : null,
+        maxByteLength: type === "ArrayBuffer" ? size : null,
+      }));
+      // The host's OOM killer reclaiming the child on a small CI runner is not a structuredClone
+      // failure: the cases the child reported before the kill are still checked, the rest are
+      // skipped. Any other signal (SIGSEGV/SIGABRT/...) still fails.
+      if (result.signalCode === "SIGKILL") {
+        expect(lines).toEqual(expected.slice(0, lines.length));
+        continue;
+      }
+      expect({ ...result, lines }).toEqual({ lines: expected, stderr: "", signalCode: null, exitCode: 0 });
     }
   }, 60_000);
 });

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -726,9 +726,9 @@ describe.concurrent("structuredClone with ArrayBuffer larger than serialization 
           Bun.gc(true);
         }
       `);
-      // The host's OOM killer reclaiming the child on a small CI runner is not a
-      // structuredClone failure; any other signal (SIGSEGV/SIGABRT/...) still is.
-      if (result.signalCode === "SIGKILL") continue;
+      // The host's OOM killer reclaiming the child on a small CI runner before it reported
+      // anything is not a structuredClone failure; any other signal (SIGSEGV/SIGABRT/...) still is.
+      if (result.signalCode === "SIGKILL" && result.lines.length === 0) continue;
       expect({ ...result, lines: result.lines.map(line => JSON.parse(line)) }).toEqual({
         lines: batch.map(({ label, type, resizable = false }) => ({
           label,

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,6 +1,6 @@
 import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
-import { bunEnv, bunExe, isASAN, tls } from "harness";
+import { bunEnv, bunExe, tls } from "harness";
 import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
 import { BlockList } from "node:net";
 import { deflate } from "node:zlib";
@@ -34,9 +34,8 @@ function jscSerializeRoundtrip(value: any) {
   return cloned;
 }
 
-// The child scripts below reply through Bun.write(Bun.stdout) rather than process.stdout:
-// the first touch of process.stdout loads the node:stream/node:tty machinery, which costs
-// most of a second per child in a debug build.
+// The child scripts reply through Bun.write(Bun.stdout): the first touch of process.stdout
+// loads node:stream, which costs most of a second per child in a debug build.
 
 // Cold variant: a brand-new Bun process per clone, so the deserialize happens in a
 // completely fresh JSC VM (empty object pool, first-touch platform-object structures).
@@ -601,10 +600,7 @@ function createBlob(arr: number[]): Blob {
   return new Blob([view]);
 }
 
-// A child process runs each case inside its own function and collects between cases, so a
-// child that runs several cases peaks at one source, one serialization buffer, and one clone.
-// The two tests are independent, so they overlap.
-describe.concurrent("structuredClone with ArrayBuffer larger than serialization buffer capacity", () => {
+describe("structuredClone with ArrayBuffer larger than serialization buffer capacity", () => {
   async function runInChild(script: string) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script],
@@ -619,7 +615,8 @@ describe.concurrent("structuredClone with ArrayBuffer larger than serialization 
   // The serialization buffer is a WTF::Vector<uint8_t> capped at 2GiB. Cloning an
   // ArrayBuffer at or above that size must throw DataCloneError instead of aborting.
   // SharedArrayBuffer shares its backing store (no serialization copy), so it
-  // succeeds regardless of size. Nothing here copies 2GiB, so one child runs all cases.
+  // succeeds regardless of size. Nothing here copies 2GiB, so one child runs all cases,
+  // collecting between them so only one buffer is mapped at a time.
   test("at or above 2GiB: copies throw DataCloneError, SharedArrayBuffers are shared", async () => {
     const cases = [
       ["ArrayBuffer", "new ArrayBuffer(2 ** 31)", "DOMException DataCloneError"],
@@ -660,93 +657,69 @@ describe.concurrent("structuredClone with ArrayBuffer larger than serialization 
     });
   });
 
-  // A large-but-under-2GiB ArrayBuffer nested inside an object/array fills the serialization
-  // buffer to its reserved capacity; the subsequent terminator write then triggers vector
-  // growth. The default 1.5x growth exceeds the 2GiB cap and would crash. These cases must
-  // succeed and round-trip correctly since the total serialized size still fits under 2GiB.
+  // A large-but-under-2GiB ArrayBuffer nested inside an object fills the serialization buffer
+  // to its reserved capacity; the subsequent terminator write then triggers vector growth. The
+  // default 1.5x growth exceeds the 2GiB cap and would crash. These cases must succeed and
+  // round-trip correctly since the total serialized size still fits under 2GiB.
   //
-  // Five clones of 1.5 GB take about 10 s even in a release build: the time goes to the kernel
-  // faulting in the serialization buffer and the clone, hence the explicit timeout. Each case
-  // gets its own child so the peak stays near 3 GB: mimalloc keeps freed pages for a moment,
-  // and two cases in one process overlap to about 4.5 GB, which the 8 GB CI runners cannot
-  // spare. Under ASAN the allocator unmaps freed pages at once, so the peak does not grow, and
-  // one child for all cases saves a process start plus the shadow-memory page faults per case.
-  test("nested ArrayBuffers under 2GiB clone without crashing and round-trip", async () => {
-    // The smallest size (plus margin) whose 1.5x serialization-buffer growth
-    // exceeds the 2GiB cap (2**31 / 1.5 = ~1.43e9); peak child memory is ~3x.
-    const size = 1_500_000_000;
-    // `pick` is the path of the ArrayBuffer or view inside the value `v`.
-    const cases: {
-      label: string;
-      value: string;
-      pick: string;
-      type: "ArrayBuffer" | "Uint8Array";
-      resizable?: true;
-    }[] = [
-      { label: "ArrayBuffer in object", value: "{ h: new ArrayBuffer(size) }", pick: "v.h", type: "ArrayBuffer" },
-      { label: "ArrayBuffer in array", value: "[new ArrayBuffer(size)]", pick: "v[0]", type: "ArrayBuffer" },
-      { label: "Uint8Array in object", value: "{ h: new Uint8Array(size) }", pick: "v.h", type: "Uint8Array" },
-      { label: "nested ArrayBuffer", value: "{ a: { b: new ArrayBuffer(size) } }", pick: "v.a.b", type: "ArrayBuffer" },
-      {
-        label: "resizable ArrayBuffer in object",
-        value: "{ h: new ArrayBuffer(size, { maxByteLength: size }) }",
-        pick: "v.h",
-        type: "ArrayBuffer",
-        resizable: true,
-      },
-    ];
-    const casesPerChild = isASAN ? cases.length : 1;
-    for (let i = 0; i < cases.length; i += casesPerChild) {
-      const batch = cases.slice(i, i + casesPerChild);
-      const caseList = batch.map(c => `["${c.label}", () => (${c.value}), v => ${c.pick}]`).join(", ");
+  // One case per distinct serializer path: a plain ArrayBuffer, an ArrayBufferView (its own
+  // header and deserializer), and a resizable ArrayBuffer (its own tag and reservation). An
+  // array or a nested object around the buffer reaches the same endObject() terminator write
+  // after the same reservation, so those containers add nothing here. Each case gets its own
+  // child: a clone is about 3 GB of fresh pages (source, serialization buffer, clone) and the
+  // kernel work to fault them in is most of the time.
+  const size = 1_500_000_000; // smallest (plus margin) whose 1.5x growth exceeds 2GiB: 2**31 / 1.5 = ~1.43e9
+  for (const { label, value, type, resizable } of [
+    { label: "ArrayBuffer", value: "new ArrayBuffer(size)", type: "ArrayBuffer", resizable: false },
+    { label: "Uint8Array", value: "new Uint8Array(size)", type: "Uint8Array", resizable: null },
+    {
+      label: "resizable ArrayBuffer",
+      value: "new ArrayBuffer(size, { maxByteLength: size })",
+      type: "ArrayBuffer",
+      resizable: true,
+    },
+  ]) {
+    test(`${label} in an object under 2GiB clones without crashing and round-trips`, async () => {
       const result = await runInChild(`
         const size = ${size};
-        function run(label, make, pick) {
-          const v = make();
-          // Mark both ends of the source so the check proves the bytes were copied, not only the
-          // length. Two pages are touched; the rest of the source stays unmapped.
-          const source = pick(v);
-          const sourceBytes = source instanceof ArrayBuffer ? new Uint8Array(source) : source;
-          sourceBytes[0] = 1;
-          sourceBytes[size - 1] = 2;
-          const out = pick(structuredClone(v));
-          const bytes = out instanceof ArrayBuffer ? new Uint8Array(out) : out;
-          return {
-            label,
-            type: out.constructor.name,
-            byteLength: bytes.byteLength,
-            first: bytes[0],
-            last: bytes[size - 1],
-            resizable: out.resizable ?? null,
-            maxByteLength: out.maxByteLength ?? null,
-          };
-        }
-        for (const [label, make, pick] of [${caseList}]) {
-          console.log(JSON.stringify(run(label, make, pick)));
-          Bun.gc(true);
-        }
+        const v = { h: ${value} };
+        // Mark both ends of the source so the check proves the bytes were copied, not only the
+        // length. Two pages are touched; the rest of the source stays unmapped.
+        const sourceBytes = v.h instanceof ArrayBuffer ? new Uint8Array(v.h) : v.h;
+        sourceBytes[0] = 1;
+        sourceBytes[size - 1] = 2;
+        const out = structuredClone(v).h;
+        const bytes = out instanceof ArrayBuffer ? new Uint8Array(out) : out;
+        console.log(JSON.stringify({
+          type: out.constructor.name,
+          byteLength: bytes.byteLength,
+          first: bytes[0],
+          last: bytes[size - 1],
+          resizable: out.resizable ?? null,
+          maxByteLength: out.maxByteLength ?? null,
+        }));
       `);
-      const lines = result.lines.map(line => JSON.parse(line));
-      const expected = batch.map(({ label, type, resizable = false }) => ({
-        label,
-        type,
-        byteLength: size,
-        first: 1,
-        last: 2,
-        // A view reports neither; a fixed-length ArrayBuffer reports maxByteLength === byteLength.
-        resizable: type === "ArrayBuffer" ? resizable : null,
-        maxByteLength: type === "ArrayBuffer" ? size : null,
-      }));
-      // The host's OOM killer reclaiming the child on a small CI runner is not a structuredClone
-      // failure: the cases the child reported before the kill are still checked, the rest are
-      // skipped. Any other signal (SIGSEGV/SIGABRT/...) still fails.
-      if (result.signalCode === "SIGKILL") {
-        expect(lines).toEqual(expected.slice(0, lines.length));
-        continue;
-      }
-      expect({ ...result, lines }).toEqual({ lines: expected, stderr: "", signalCode: null, exitCode: 0 });
-    }
-  }, 60_000);
+      // The host's OOM killer reclaiming the child on a small CI runner is not a
+      // structuredClone failure; any other signal (SIGSEGV/SIGABRT/...) still is.
+      if (result.signalCode === "SIGKILL" && result.lines.length === 0) return;
+      expect({ ...result, lines: result.lines.map(line => JSON.parse(line)) }).toEqual({
+        lines: [
+          {
+            type,
+            byteLength: size,
+            first: 1,
+            last: 2,
+            // A view reports neither; a fixed-length ArrayBuffer reports maxByteLength === byteLength.
+            resizable,
+            maxByteLength: type === "ArrayBuffer" ? size : null,
+          },
+        ],
+        stderr: "",
+        signalCode: null,
+        exitCode: 0,
+      });
+    });
+  }
 });
 
 // A repeated object is serialized as an ObjectReferenceTag holding an index into the

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -1,6 +1,6 @@
 import { deserialize, serialize } from "bun:jsc";
 import { openSync } from "fs";
-import { bunEnv, bunExe, tls } from "harness";
+import { bunEnv, bunExe, isASAN, tls } from "harness";
 import { createPrivateKey, createPublicKey, createSecretKey, KeyObject, X509Certificate } from "node:crypto";
 import { BlockList } from "node:net";
 import { deflate } from "node:zlib";
@@ -34,27 +34,32 @@ function jscSerializeRoundtrip(value: any) {
   return cloned;
 }
 
+// The child scripts below reply through Bun.write(Bun.stdout) rather than process.stdout:
+// the first touch of process.stdout loads the node:stream/node:tty machinery, which costs
+// most of a second per child in a debug build.
+
 // Cold variant: a brand-new Bun process per clone, so the deserialize happens in a
 // completely fresh JSC VM (empty object pool, first-touch platform-object structures).
 function jscSerializeRoundtripCrossProcessCold(original: any) {
-  const serialized = serialize(original);
-
   const result = Bun.spawnSync({
     cmd: [
       bunExe(),
       "-e",
       `
-    import {deserialize, serialize} from "bun:jsc";
-    const serialized = deserialize(await Bun.stdin.bytes());
-    const cloned = serialize(serialized);
-    process.stdout.write(cloned);
+    import { deserialize, serialize } from "bun:jsc";
+    await Bun.write(Bun.stdout, serialize(deserialize(await Bun.stdin.bytes())));
     `,
     ],
     env: bunEnv,
-    stdin: serialized,
+    stdin: serialize(original),
     stdout: "pipe",
-    stderr: "inherit",
+    stderr: "pipe",
   });
+  if (!result.success) {
+    throw new Error(
+      `cold cross-process child failed (code ${result.exitCode}, signal ${result.signalCode})\n${result.stderr}`,
+    );
+  }
   return deserialize(result.stdout);
 }
 
@@ -75,11 +80,11 @@ const crossProcessChildScript = `
         chunks = [buf];
         break;
       }
-      const cloned = serialize(deserialize(buf.subarray(4, 4 + len)));
+      // serialize() returns a SharedArrayBuffer; Buffer.concat needs a view of it.
+      const cloned = new Uint8Array(serialize(deserialize(buf.subarray(4, 4 + len))));
       const header = Buffer.alloc(4);
       header.writeUInt32LE(cloned.byteLength, 0);
-      process.stdout.write(header);
-      process.stdout.write(cloned);
+      await Bun.write(Bun.stdout, Buffer.concat([header, cloned]));
       chunks = [buf.subarray(4 + len)];
       total -= 4 + len;
     }
@@ -216,10 +221,8 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
       const cloned = await structuredCloneFn(input);
       expect(cloned).toBeInstanceOf(Array);
       expect(cloned).not.toBe(input);
-      expect(cloned.length).toEqual(input.length);
-      for (const x in input) {
-        expect(cloned[x]).toBe(input[x]);
-      }
+      // toStrictEqual compares with Object.is (-0 vs 0, NaN) and keeps holes distinct from undefined.
+      expect(cloned).toStrictEqual(input);
     });
     test("Object with primitives", async () => {
       const input: any = {
@@ -250,37 +253,28 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
       expect(cloned).toBeInstanceOf(Object);
       expect(cloned).not.toBeInstanceOf(Array);
       expect(cloned).not.toBe(input);
-      for (const x in input) {
-        expect(cloned[x]).toBe(input[x]);
-      }
+      // toStrictEqual requires the `undefined` key to exist on the clone, not only to read as undefined.
+      expect(cloned).toStrictEqual(input);
     });
 
     test("map", async () => {
-      const input = new Map();
-      input.set("a", 1);
-      input.set("b", 2);
-      input.set("c", 3);
+      const input = new Map([
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ]);
       const cloned = await structuredCloneFn(input);
       expect(cloned).toBeInstanceOf(Map);
       expect(cloned).not.toBe(input);
-      expect(cloned.size).toEqual(input.size);
-      for (const [key, value] of input) {
-        expect(cloned.get(key)).toBe(value);
-      }
+      expect(cloned).toEqual(input);
     });
 
     test("set", async () => {
-      const input = new Set();
-      input.add("a");
-      input.add("b");
-      input.add("c");
+      const input = new Set(["a", "b", "c"]);
       const cloned = await structuredCloneFn(input);
       expect(cloned).toBeInstanceOf(Set);
       expect(cloned).not.toBe(input);
-      expect(cloned.size).toEqual(input.size);
-      for (const value of input) {
-        expect(cloned.has(value)).toBe(true);
-      }
+      expect(cloned).toEqual(input);
     });
 
     // The cross-process transport only adds a process hop over the in-process byte round
@@ -382,26 +376,42 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         expect(cloned.name).toBe(blob.name);
         expect(cloned.size).toBe(blob.size);
       });
-      describe("dom file", async () => {
+      describe("dom file", () => {
+        async function describeFile(file: File) {
+          return {
+            name: file.name,
+            type: file.type,
+            size: file.size,
+            lastModified: file.lastModified,
+            text: await file.text(),
+          };
+        }
         test("without lastModified", async () => {
           const file = new File(["hi"], "example.txt", { type: "text/plain" });
           expect(file.lastModified).toBeGreaterThan(0);
-          expect(file.name).toBe("example.txt");
-          expect(file.size).toBe(2);
           const cloned = await structuredCloneFn(file);
-          expect(cloned.lastModified).toBe(file.lastModified);
-          expect(cloned.name).toBe(file.name);
-          expect(cloned.size).toBe(file.size);
+          expect(cloned).toBeInstanceOf(File);
+          expect(cloned).not.toBe(file);
+          expect(await describeFile(cloned)).toEqual({
+            name: "example.txt",
+            type: file.type,
+            size: 2,
+            lastModified: file.lastModified,
+            text: "hi",
+          });
         });
         test("with lastModified", async () => {
           const file = new File(["hi"], "example.txt", { type: "text/plain", lastModified: 123 });
-          expect(file.lastModified).toBe(123);
-          expect(file.name).toBe("example.txt");
-          expect(file.size).toBe(2);
           const cloned = await structuredCloneFn(file);
-          expect(cloned.lastModified).toBe(123);
-          expect(cloned.name).toBe(file.name);
-          expect(cloned.size).toBe(file.size);
+          expect(cloned).toBeInstanceOf(File);
+          expect(cloned).not.toBe(file);
+          expect(await describeFile(cloned)).toEqual({
+            name: "example.txt",
+            type: file.type,
+            size: 2,
+            lastModified: 123,
+            text: "hi",
+          });
         });
       });
       test("unpaired high surrogate (invalid utf-8)", async () => {
@@ -424,12 +434,14 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
     if (structuredCloneFn === structuredClone) {
       describe("net.BlockList works", () => {
         test("simple", () => {
-          const net = require("node:net");
-          const blocklist = new net.BlockList();
+          const blocklist = new BlockList();
           blocklist.addAddress("123.123.123.123");
           const newlist = structuredCloneFn(blocklist);
+          expect(newlist).toBeInstanceOf(BlockList);
+          expect(newlist).not.toBe(blocklist);
           expect(newlist.check("123.123.123.123")).toBeTrue();
-          expect(!newlist.check("123.123.123.124")).toBeTrue();
+          expect(newlist.check("123.123.123.124")).toBeFalse();
+          // Like node, the clone wraps the same native list as the original.
           newlist.addAddress("123.123.123.124");
           expect(blocklist.check("123.123.123.124")).toBeTrue();
           expect(newlist.check("123.123.123.124")).toBeTrue();
@@ -440,8 +452,13 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         test("ArrayBuffer", () => {
           const buffer = Uint8Array.from([1]).buffer;
           const cloned = structuredCloneFn(buffer, { transfer: [buffer] });
-          expect(buffer.byteLength).toBe(0);
-          expect(cloned.byteLength).toBe(1);
+          expect(cloned).toBeInstanceOf(ArrayBuffer);
+          expect(cloned).not.toBe(buffer);
+          expect({
+            detached: buffer.detached,
+            byteLength: buffer.byteLength,
+            clonedBytes: new Uint8Array(cloned),
+          }).toEqual({ detached: true, byteLength: 0, clonedBytes: new Uint8Array([1]) });
         });
         test("A detached ArrayBuffer cannot be transferred", () => {
           const buffer = new ArrayBuffer(2);
@@ -505,9 +522,14 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
         });
         test("Transferring a non-transferable platform object fails", () => {
           const blob = new Blob();
-          expect(() => {
+          let error: unknown;
+          try {
             structuredCloneFn(blob, { transfer: [blob] });
-          }).toThrow(DOMException);
+          } catch (e) {
+            error = e;
+          }
+          expect(error).toBeInstanceOf(DOMException);
+          expect((error as DOMException).name).toBe("DataCloneError");
         });
         // https://html.spec.whatwg.org/multipage/structured-data.html#dom-structuredclone
         // `transfer` is a WebIDL sequence<object>: it is converted (and may throw)
@@ -543,18 +565,14 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
 }
 
 async function compareBlobs(original: Blob, cloned: Blob) {
-  expect(cloned).toBeInstanceOf(Blob);
+  // A plain Blob must come back as a plain Blob, not as a File.
+  expect(Object.getPrototypeOf(cloned)).toBe(Blob.prototype);
   expect(cloned).not.toBe(original);
-  expect(cloned.size).toBe(original.size);
-  expect(cloned.type).toBe(original.type);
-  const ab1 = await new Response(cloned).arrayBuffer();
-  const ab2 = await new Response(original).arrayBuffer();
-  expect(ab1.byteLength).toBe(ab2.byteLength);
-  const ta1 = new Uint8Array(ab1);
-  const ta2 = new Uint8Array(ab2);
-  for (let i = 0; i < ta1.length; i++) {
-    expect(ta1[i]).toBe(ta2[i]);
-  }
+  expect({ size: cloned.size, type: cloned.type, bytes: await cloned.bytes() }).toEqual({
+    size: original.size,
+    type: original.type,
+    bytes: await original.bytes(),
+  });
 }
 
 function encode_cesu8(codeunits: number[]): number[] {
@@ -583,92 +601,151 @@ function createBlob(arr: number[]): Blob {
   return new Blob([view]);
 }
 
-describe("structuredClone with ArrayBuffer larger than serialization buffer capacity", () => {
+// A child process runs each case inside its own function and collects between cases, so a
+// child that runs several cases peaks at one source, one serialization buffer, and one clone.
+// The two tests are independent, so they overlap.
+describe.concurrent("structuredClone with ArrayBuffer larger than serialization buffer capacity", () => {
+  async function runInChild(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { lines: stdout.split("\n").filter(Boolean), stderr, signalCode: proc.signalCode, exitCode };
+  }
+
   // The serialization buffer is a WTF::Vector<uint8_t> capped at 2GiB. Cloning an
   // ArrayBuffer at or above that size must throw DataCloneError instead of aborting.
   // SharedArrayBuffer shares its backing store (no serialization copy), so it
-  // succeeds regardless of size. Run in a subprocess so the ~2GiB allocation
-  // does not bloat the test runner.
-  for (const [label, expr, expected] of [
-    ["ArrayBuffer", "new ArrayBuffer(2 ** 31)", "DataCloneError"],
-    ["resizable ArrayBuffer", "new ArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })", "DataCloneError"],
-    ["SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31)", "SHARED"],
-    ["growable SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })", "SHARED"],
-    ["Uint8Array", "new Uint8Array(2 ** 31)", "DataCloneError"],
-  ] as const) {
-    test(label, async () => {
-      const script = `
-        let buf;
+  // succeeds regardless of size. Nothing here copies 2GiB, so one child runs all cases.
+  test("at or above 2GiB: copies throw DataCloneError, SharedArrayBuffers are shared", async () => {
+    const cases = [
+      ["ArrayBuffer", "new ArrayBuffer(2 ** 31)", "DOMException DataCloneError"],
+      [
+        "resizable ArrayBuffer",
+        "new ArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })",
+        "DOMException DataCloneError",
+      ],
+      ["SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31)", "SHARED"],
+      ["growable SharedArrayBuffer", "new SharedArrayBuffer(2 ** 31, { maxByteLength: 2 ** 31 + 1 })", "SHARED"],
+      ["Uint8Array", "new Uint8Array(2 ** 31)", "DOMException DataCloneError"],
+    ] as const;
+    const caseList = cases.map(([label, expr]) => `["${label}", () => ${expr}]`).join(", ");
+    const result = await runInChild(`
+      function run(make) {
+        const buf = make();
+        let cloned;
         try {
-          buf = ${expr};
-        } catch {
-          console.log("SKIP");
-          process.exit(0);
-        }
-        try {
-          const cloned = structuredClone(buf);
-          console.log(cloned instanceof SharedArrayBuffer && cloned.byteLength === buf.byteLength ? "SHARED" : "UNEXPECTED_SUCCESS");
+          cloned = structuredClone(buf);
         } catch (e) {
-          console.log(e.name);
+          return e.constructor.name + " " + e.name;
         }
-      `;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", script],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "inherit",
-      });
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-      expect([expected, "SKIP"]).toContain(stdout.trim());
-      expect(exitCode).toBe(0);
+        if (!(cloned instanceof SharedArrayBuffer)) return "UNEXPECTED_SUCCESS " + cloned.constructor.name;
+        // A shared clone sees a write made through the original after cloning.
+        new Uint8Array(buf)[0] = 42;
+        return cloned.byteLength === buf.byteLength && new Uint8Array(cloned)[0] === 42 ? "SHARED" : "NOT_SHARED";
+      }
+      for (const [label, make] of [${caseList}]) {
+        console.log(label + ": " + run(make));
+        Bun.gc(true);
+      }
+    `);
+    expect(result).toEqual({
+      lines: cases.map(([label, , expected]) => `${label}: ${expected}`),
+      stderr: "",
+      signalCode: null,
+      exitCode: 0,
     });
-  }
+  });
 
   // A large-but-under-2GiB ArrayBuffer nested inside an object/array fills the serialization
   // buffer to its reserved capacity; the subsequent terminator write then triggers vector
   // growth. The default 1.5x growth exceeds the 2GiB cap and would crash. These cases must
   // succeed and round-trip correctly since the total serialized size still fits under 2GiB.
-  for (const [label, expr, check] of [
-    ["ArrayBuffer in object", "{ h: new ArrayBuffer(size) }", "r.h.byteLength === size"],
-    ["ArrayBuffer in array", "[new ArrayBuffer(size)]", "r[0].byteLength === size"],
-    ["Uint8Array in object", "{ h: new Uint8Array(size) }", "r.h.byteLength === size"],
-    ["nested ArrayBuffer", "{ a: { b: new ArrayBuffer(size) } }", "r.a.b.byteLength === size"],
-    [
-      "resizable ArrayBuffer in object",
-      "{ h: new ArrayBuffer(size, { maxByteLength: size }) }",
-      "r.h.byteLength === size",
-    ],
-  ] as const) {
-    test(`${label} under 2GiB clones without crashing`, async () => {
-      // The smallest size (plus margin) whose 1.5x serialization-buffer growth
-      // exceeds the 2GiB cap (2**31 / 1.5 = ~1.43e9); peak child memory is ~3x.
-      const script = `
-        const size = 1_500_000_000;
-        let v;
-        try {
-          v = ${expr};
-        } catch {
-          console.log("SKIP");
-          process.exit(0);
+  //
+  // Five clones of 1.5 GB take about 10 s even in a release build: the time goes to the kernel
+  // faulting in the serialization buffer and the clone, hence the explicit timeout. Each case
+  // gets its own child so the peak stays near 3 GB: mimalloc keeps freed pages for a moment,
+  // and two cases in one process overlap to about 4.5 GB, which the 8 GB CI runners cannot
+  // spare. Under ASAN the allocator unmaps freed pages at once, so the peak does not grow, and
+  // one child for all cases saves a process start plus the shadow-memory page faults per case.
+  test("nested ArrayBuffers under 2GiB clone without crashing and round-trip", async () => {
+    // The smallest size (plus margin) whose 1.5x serialization-buffer growth
+    // exceeds the 2GiB cap (2**31 / 1.5 = ~1.43e9); peak child memory is ~3x.
+    const size = 1_500_000_000;
+    // `pick` is the path of the ArrayBuffer or view inside the value `v`.
+    const cases: {
+      label: string;
+      value: string;
+      pick: string;
+      type: "ArrayBuffer" | "Uint8Array";
+      resizable?: true;
+    }[] = [
+      { label: "ArrayBuffer in object", value: "{ h: new ArrayBuffer(size) }", pick: "v.h", type: "ArrayBuffer" },
+      { label: "ArrayBuffer in array", value: "[new ArrayBuffer(size)]", pick: "v[0]", type: "ArrayBuffer" },
+      { label: "Uint8Array in object", value: "{ h: new Uint8Array(size) }", pick: "v.h", type: "Uint8Array" },
+      { label: "nested ArrayBuffer", value: "{ a: { b: new ArrayBuffer(size) } }", pick: "v.a.b", type: "ArrayBuffer" },
+      {
+        label: "resizable ArrayBuffer in object",
+        value: "{ h: new ArrayBuffer(size, { maxByteLength: size }) }",
+        pick: "v.h",
+        type: "ArrayBuffer",
+        resizable: true,
+      },
+    ];
+    const casesPerChild = isASAN ? cases.length : 1;
+    for (let i = 0; i < cases.length; i += casesPerChild) {
+      const batch = cases.slice(i, i + casesPerChild);
+      const caseList = batch.map(c => `["${c.label}", () => (${c.value}), v => ${c.pick}]`).join(", ");
+      const result = await runInChild(`
+        const size = ${size};
+        function run(label, make, pick) {
+          const v = make();
+          // Mark both ends of the source so the check proves the bytes were copied, not only the
+          // length. Two pages are touched; the rest of the source stays unmapped.
+          const source = pick(v);
+          const sourceBytes = source instanceof ArrayBuffer ? new Uint8Array(source) : source;
+          sourceBytes[0] = 1;
+          sourceBytes[size - 1] = 2;
+          const out = pick(structuredClone(v));
+          const bytes = out instanceof ArrayBuffer ? new Uint8Array(out) : out;
+          return {
+            label,
+            type: out.constructor.name,
+            byteLength: bytes.byteLength,
+            first: bytes[0],
+            last: bytes[size - 1],
+            resizable: out.resizable ?? null,
+            maxByteLength: out.maxByteLength ?? null,
+          };
         }
-        const r = structuredClone(v);
-        console.log((${check}) ? "OK" : "BAD_ROUNDTRIP");
-      `;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", script],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "inherit",
-      });
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        for (const [label, make, pick] of [${caseList}]) {
+          console.log(JSON.stringify(run(label, make, pick)));
+          Bun.gc(true);
+        }
+      `);
       // The host's OOM killer reclaiming the child on a small CI runner is not a
       // structuredClone failure; any other signal (SIGSEGV/SIGABRT/...) still is.
-      if (proc.signalCode === "SIGKILL" && stdout === "") return;
-      expect(["OK", "SKIP"]).toContain(stdout.trim());
-      expect(proc.signalCode).toBe(null);
-      expect(exitCode).toBe(0);
-    });
-  }
+      if (result.signalCode === "SIGKILL") continue;
+      expect({ ...result, lines: result.lines.map(line => JSON.parse(line)) }).toEqual({
+        lines: batch.map(({ label, type, resizable = false }) => ({
+          label,
+          type,
+          byteLength: size,
+          first: 1,
+          last: 2,
+          // A view reports neither; a fixed-length ArrayBuffer reports maxByteLength === byteLength.
+          resizable: type === "ArrayBuffer" ? resizable : null,
+          maxByteLength: type === "ArrayBuffer" ? size : null,
+        })),
+        stderr: "",
+        signalCode: null,
+        exitCode: 0,
+      });
+    }
+  }, 60_000);
 });
 
 // A repeated object is serialized as an ObjectReferenceTag holding an index into the
@@ -734,8 +811,7 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
       for (let i = 0; i < 300; i++) input.push((1n << 64n) + BigInt(i));
       input.push(o);
       const c = await structuredCloneFn(input);
-      expect(c[300]).toBe((1n << 64n) + 299n);
-      expect(c[301]).toEqual({ marker: "hello" });
+      expect(c).toEqual(input);
       expect(c[301]).toBe(c[0]);
     });
   });


### PR DESCRIPTION
### Problem
- `test/js/web/workers/structured-clone.test.ts` takes 16.7 s on the debian 13 x64-asan lane (build 104578), 10.8 s on x64 release.
- The five "under 2GiB clones without crashing" children take 15 s of that. Three of them (object, array, nested object) exercise the same serializer write.
- Several assertions checked one field, looped `toBe` over bytes, or accepted `SKIP`.

### Fix
- The under-2GiB block keeps one case per distinct serializer path: plain ArrayBuffer, ArrayBufferView, resizable ArrayBuffer. The array and nested-object containers reach the same `endObject()` terminator write after the same reservation. One child per case, as before.
- One child runs the five "at or above 2GiB" cases. They never copy.
- The cross-process children reply through `Bun.write(Bun.stdout)`. The first touch of `process.stdout` loads node:stream, about 0.7 s per child in a debug build.
- `toStrictEqual` or `toEqual` on whole values: primitives, Map, Set, Blob bytes, File fields, and each child's stdout, stderr, signal, and exit code. The big-buffer children report the clone's type, length, end bytes, `resizable`, and `maxByteLength`.
- Verified: `bun bd test test/js/web/workers/structured-clone.test.ts` 30.39 s and 30.21 s before, 17.46 s and 16.30 s after. Release (`USE_SYSTEM_BUN=1`): 12.94 s and 12.35 s before, 7.70 s after.

### Background
- The serialization buffer is a `WTF::Vector<uint8_t>` capped at 2 GiB. `ensureBufferCapacity` in `SerializedScriptValue.cpp` clamps the 1.5x growth to that cap. A case needs a 1.5 GB payload to reach it and writes about 3 GB of fresh pages, which is most of the time in any build.
- The serializer reserves the exact payload size (`SerializedScriptValue.cpp:1307`, `:1320`), fills it, and the next write is the container's `endObject()` terminator. Only the view header and the resizable tag change the bytes around it.

<details><summary>Notes</summary>

Test count goes from 235 to 229: the "at or above 2GiB" table is one test with all five cases asserted by label, and the under-2GiB table drops the "ArrayBuffer in array" and "nested ArrayBuffer" variants. Small-payload clones of ArrayBuffers inside arrays and objects stay covered by the primitives, transfer, and identity tests in this file.

Trace for the dropped variants: `{ h: AB }` goes ObjectStartState, write("h"), dumpIfTerminal, `tryReserveCapacity(size + 1 + 8 + byteLength)`, fill, ObjectStartVisitMember with no members left, `endObject()`. `[AB]` goes ArrayStartState, write(index), the same dumpIfTerminal and reservation, ArrayStartVisitMember with index == length and no non-index properties, `endObject()`. `{ a: { b: AB } }` is the object case at the inner object; the outer `endObject()` then finds capacity. All three growth writes are `write(TerminatorTag)` through `writeLittleEndian<uint32_t>` with size == capacity.

Per-test times before (debug ASAN, local): the five under-2GiB children 3.4 to 4.2 s each, the cold cross-process children 1.03 to 1.09 s each, the warm cross-process child's first test 1.02 s, the at-or-above-2GiB children 0.27 to 0.29 s each. After: three under-2GiB children 3.3 s each, cold children 0.29 s, warm first test 0.32 s, the at-or-above-2GiB child 0.4 s.

The `SKIP` path for a failed allocation is gone: the allocation is a lazy virtual mapping, so it fails per environment, not at random, and a failure should be visible. The SIGKILL escape for a host OOM kill (from #32488) stays unchanged: a child that reported nothing and died by SIGKILL is skipped.

An earlier revision batched the five cases into one child under ASAN. Measured: the batch saved about 3 s under ASAN but nothing in release, where mimalloc keeps freed pages for its purge delay and two cases overlap to 4.5 GB of RSS (a single case peaks at 2.9 GB). Dropping the redundant variants saves more on every lane without an allocator-dependent topology. The describe is not concurrent: the test runner (`Execution.rs`, `kill_dangling_processes_on_timeout`) does not kill a timed-out test's children when the concurrent group has more than one test.

Left alone: the file-from-path and file-from-fd tests (open PR #31329 changes that area) and the transferables test that #37966 inserts after.

Also ran with the CI env (`BUN_JSC_validateExceptionChecks=1`, `BUN_DESTRUCT_VM_ON_EXIT=1`, LSan on): all pass, child stderr stays empty. Windows x64 canary: 10.86 s before, 10.58 s with the earlier five-child revision.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/workers/structured-clone.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/workers/structured-clone.test.ts
bun test v1.4.1 (4448a2e21)

test/js/web/workers/structured-clone.test.ts:
(pass) structuredClone > primitive undefined [4.91ms]
(pass) structuredClone > primitive null [0.57ms]
(pass) structuredClone > primitive true [0.45ms]
(pass) structuredClone > primitive false [0.38ms]
(pass) structuredClone > primitive string, empty string [0.32ms]
(pass) structuredClone > primitive string, lone high surrogate [1.13ms]
(pass) structuredClone > primitive string, lone low surrogate [0.34ms]
(pass) structuredClone > primitive string, NUL [0.32ms]
(pass) structuredClone > primitive string, astral character [0.51ms]
(pass) structuredClone > primitive number, 0.2 [0.36ms]
(pass) structuredClone > primitive number, 0 [0.32ms]
(pass) structuredClone > primitive number, -0 [0.35ms]
(pass) structuredClone > primitive number, NaN [0.62ms]
(pass) structuredClone > primitive number, Infinity [0.33ms]
(pass) structuredClone > primitive number, -Infinity [0.82ms]
(pass) structuredClone > primitive number, 9007199254740992 [0.35ms]
(pass) structuredClone > primitive number, -9007199254740992 [1.21ms]
(pass) structuredClone > primitive number, 9007199254740994 [0.39ms]
(pass) structuredClone > primitive number, -9007199254740994 [0.38ms]
(pass) structuredClone > primitive BigInt, 0n [0.39ms]
(pass) structuredClone > primitive BigInt, -0n [0.39ms]
(pass) structuredClone > primitive BigInt, -9007199254740994000n [0.38ms]
(pass) structuredClone > primitive BigInt, -9007199254740994000900719925474099400090071992547409940009007199254740994000n [0.53ms]
(pass) structuredClone > Array with primitives [6.45ms]
(pass) structuredClone > Object with primitives [9.20ms]
(pass) structuredClone > map [5.41ms]
(pass) structuredClone > set [5.18ms]
(pass) structuredClone > duplicated references preserve identity > Date [3.27ms]
(pass) structuredClone > duplicated references
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/workers/structured-clone.test.ts | 328 +++++++++++++++------------
 1 file changed, 189 insertions(+), 139 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
test/js/web/workers/structured-clone.test.ts     12     28      0
```

</details>

<!-- robobun:evidence:end -->