### PR TITLE
test(bake): speed up dev/css.test.ts and tighten its assertions

### DIFF
--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -1,299 +1,830 @@
-// CSS tests concern bundling bugs with CSS files
+// CSS tests concern bundling bugs with CSS files.
+//
+// Starting a dev server and a browser client each cost a process spawn, so
+// independent cases share one dev server: one route per case, each case
+// leaves its route working. A comment names the case each block covers.
 import { expect } from "bun:test";
 import assert from "node:assert";
+import type { Dev } from "../bake-harness";
 import { devTest, emptyHtmlFile, imageFixtures } from "../bake-harness";
 
-devTest("css file with syntax error does not kill old styles", {
+/** The stylesheet URLs the dev server injected into an HTML route (source `<link>` tags are ignored). */
+async function stylesheetUrls(dev: Dev, route: string): Promise<string[]> {
+  const res = await dev.fetch(route);
+  const html = await res.text();
+  expect(res.status).toBe(200);
+  return [...html.matchAll(/<link rel="stylesheet" href="(\/_bun\/asset\/[0-9a-f]{16}\.css)">/g)].map(m => m[1]);
+}
+
+async function fetchCss(dev: Dev, url: string): Promise<string> {
+  const res = await dev.fetch(url);
+  expect(res.status).toBe(200);
+  expect(res.headers.get("Content-Type")).toBe("text/css;charset=utf-8");
+  return res.text();
+}
+
+/** The exact stylesheet served for a route that links exactly one stylesheet. */
+async function servedCss(dev: Dev, route: string): Promise<string> {
+  const urls = await stylesheetUrls(dev, route);
+  expect(urls).toHaveLength(1);
+  return fetchCss(dev, urls[0]);
+}
+
+/** Replaces an inlined image fixture with its name so a snapshot stays readable. */
+function redactInlineAssets(css: string): string {
+  return css
+    .replaceAll(imageFixtures.bun.toString("base64"), "<bun.png>")
+    .replaceAll(imageFixtures.bun2.toString("base64"), "<bun2.png>");
+}
+
+/**
+ * Expects the error page. A fetch of a failing route re-bundles it, which
+ * confuses a connected client that has the route's real page loaded (#31908),
+ * so only call it when no such client exists or when the HTML file itself fails.
+ */
+async function expectBuildFailed(dev: Dev, route: string) {
+  const res = await dev.fetch(route);
+  expect(await res.text()).toContain("<title>Bun - Build Failed</title>");
+  expect(res.status).toBe(500);
+}
+
+devTest("hot updates through @import graphs", {
   files: {
-    "styles.css": `
+    // css import another css file
+    "import.html": emptyHtmlFile({ styles: ["import.css"] }),
+    "import.css": `
+      @import "./imported.css";
       body {
         color: red;
       }
     `,
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `hello world`,
+    "imported.css": `
+      h1 {
+        color: blue;
+      }
+    `,
+    // circular css imports handle hot reload
+    "circular.html": emptyHtmlFile({
+      styles: ["circular-a.css"],
+      body: `
+        <div class="a">hello</div>
+        <div class="b">hello</div>
+      `,
     }),
+    "circular-a.css": `
+      @import "./circular-b.css";
+      .a { color: red; }
+    `,
+    "circular-b.css": `
+      @import "./circular-a.css";
+      .b { color: blue; }
+    `,
+    // removing and re-adding css import
+    "toggle.html": emptyHtmlFile({ styles: ["toggle.css"] }),
+    "toggle.css": `
+      @import "./toggle-colors.css";
+      .main { background: white; }
+    `,
+    "toggle-colors.css": `
+      .colored { color: blue; }
+    `,
   },
   async test(dev) {
-    await using c = await dev.client("/");
-    await c.style("body").color.expect.toBe("red");
-    await dev.write(
-      "styles.css",
-      `
+    // css import another css file
+    {
+      await using c = await dev.client("/import");
+      await c.style("h1").color.expect.toBe("#00f");
+      await c.style("body").color.expect.toBe("red");
+      expect(await servedCss(dev, "/import")).toMatchInlineSnapshot(`
+        "/* imported.css */
+        h1 {
+          color: #00f;
+        }
+
+        /* import.css */
         body {
           color: red;
-          background-color
         }
-      `,
-      {
-        errors: ["styles.css:4:1: error: Unexpected end of input"],
-      },
-    );
-    await c.style("body").color.expect.toBe("red");
-    await dev.write(
-      "styles.css",
-      `
+        "
+      `);
+
+      await dev.write(
+        "imported.css",
+        `
+          h1 {
+            color: green;
+          }
+        `,
+      );
+      await c.style("h1").color.expect.toBe("green");
+      await c.style("body").color.expect.toBe("red");
+      // A fresh load of the page gets the updated chunk too.
+      expect(await servedCss(dev, "/import")).toMatchInlineSnapshot(`
+        "/* imported.css */
+        h1 {
+          color: green;
+        }
+
+        /* import.css */
         body {
           color: red;
-          background-color: blue;
         }
-      `,
-    );
-    await c.style("body").backgroundColor.expect.toBe("#00f");
-    await dev.write("styles.css", ` `, { dedent: false });
-    await c.style("body").notFound();
+        "
+      `);
+
+      // Check that the styles still work after a reload
+      await c.hardReload();
+      await c.style("h1").color.expect.toBe("green");
+      await c.style("body").color.expect.toBe("red");
+    }
+
+    // circular css imports handle hot reload
+    {
+      await using c = await dev.client("/circular");
+      await c.style(".a").color.expect.toBe("red");
+      await c.style(".b").color.expect.toBe("#00f");
+      expect(await servedCss(dev, "/circular")).toMatchInlineSnapshot(`
+        "/* circular-b.css */
+        .b {
+          color: #00f;
+        }
+
+        /* circular-a.css */
+        .a {
+          color: red;
+        }
+        "
+      `);
+
+      // Modify one of the circular dependencies
+      await dev.write(
+        "circular-a.css",
+        `
+          @import "./circular-b.css";
+          .a { color: green; }
+        `,
+      );
+      await c.style(".a").color.expect.toBe("green");
+      await c.style(".b").color.expect.toBe("#00f");
+      expect(await servedCss(dev, "/circular")).toMatchInlineSnapshot(`
+        "/* circular-b.css */
+        .b {
+          color: #00f;
+        }
+
+        /* circular-a.css */
+        .a {
+          color: green;
+        }
+        "
+      `);
+    }
+
+    // removing and re-adding css import
+    {
+      await using c = await dev.client("/toggle");
+      await c.style(".colored").color.expect.toBe("#00f");
+      const withImport = await servedCss(dev, "/toggle");
+      expect(withImport).toMatchInlineSnapshot(`
+        "/* toggle-colors.css */
+        .colored {
+          color: #00f;
+        }
+
+        /* toggle.css */
+        .main {
+          background: #fff;
+        }
+        "
+      `);
+
+      // Remove the import
+      await dev.write(
+        "toggle.css",
+        `
+          /* @import "./toggle-colors.css"; */
+          .main { background: white; }
+        `,
+      );
+      await c.style(".colored").notFound();
+      await c.style(".main").backgroundColor.expect.toBe("#fff");
+      const withoutImport = await servedCss(dev, "/toggle");
+      expect(withoutImport).toMatchInlineSnapshot(`
+        "/* toggle.css */
+        .main {
+          background: #fff;
+        }
+        "
+      `);
+
+      // A change to the file that is no longer imported must not rebuild the
+      // stylesheet nor notify any clients.
+      await c.expectNoWebSocketActivity(async () => {
+        await dev.write("toggle-colors.css", `.colored { color: yellow; }`);
+        await dev.write("toggle-colors.css", `.colored { color: blue; }`);
+      });
+      await c.style(".colored").notFound();
+      expect(await servedCss(dev, "/toggle")).toBe(withoutImport);
+
+      // Re-add the import
+      await dev.write(
+        "toggle.css",
+        `
+          @import "./toggle-colors.css";
+          .main { background: white; }
+        `,
+      );
+      await c.style(".colored").color.expect.toBe("#00f");
+      await c.style(".main").backgroundColor.expect.toBe("#fff");
+      expect(await servedCss(dev, "/toggle")).toBe(withImport);
+    }
   },
 });
-devTest("css file with initial syntax error gets recovered", {
+
+devTest("hot updates through shared imports, assets and script imports", {
   files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
+    // multiple stylesheets importing same dependency
+    "shared-first.html": emptyHtmlFile({
+      styles: ["shared-first.css"],
+      body: `
+        <div class="first">hello</div>
+        <div class="shared">hello</div>
+      `,
+    }),
+    "shared-second.html": emptyHtmlFile({
+      styles: ["shared-second.css"],
+      body: `
+        <div class="second">hello</div>
+        <div class="shared">hello</div>
+      `,
+    }),
+    "shared-first.css": `
+      @import "./shared.css";
+      .first { color: red; }
+    `,
+    "shared-second.css": `
+      @import "./shared.css";
+      .second { color: blue; }
+    `,
+    "shared.css": `
+      .shared { color: green; }
+    `,
+    // asset referenced in css
+    "asset.html": emptyHtmlFile({ styles: ["asset.css"] }),
+    "asset.css": `
+      body {
+        background-image: url(./asset.png);
+      }
+    `,
+    "asset.png": imageFixtures.bun,
+    // add new css import later
+    "script.html": emptyHtmlFile({
+      scripts: ["script.ts"],
       body: `hello world`,
     }),
-    "styles.css": `
+    "script.ts": `
+      // import "./script.css";
+      export default function () {
+        return "hello world";
+      }
+      import.meta.hot.accept();
+    `,
+    "script.css": `
+      body {
+        color: red;
+      }
+    `,
+  },
+  async test(dev) {
+    // multiple stylesheets importing same dependency
+    {
+      await using c1 = await dev.client("/shared-first");
+      await using c2 = await dev.client("/shared-second");
+      await c1.style(".first").color.expect.toBe("red");
+      await c2.style(".second").color.expect.toBe("#00f");
+      await c1.style(".shared").color.expect.toBe("green");
+      await c2.style(".shared").color.expect.toBe("green");
+      expect(await servedCss(dev, "/shared-first")).toMatchInlineSnapshot(`
+        "/* shared.css */
+        .shared {
+          color: green;
+        }
+
+        /* shared-first.css */
+        .first {
+          color: red;
+        }
+        "
+      `);
+      expect(await servedCss(dev, "/shared-second")).toMatchInlineSnapshot(`
+        "/* shared.css */
+        .shared {
+          color: green;
+        }
+
+        /* shared-second.css */
+        .second {
+          color: #00f;
+        }
+        "
+      `);
+
+      await dev.write(
+        "shared.css",
+        `
+          .shared { color: yellow; }
+        `,
+      );
+      await c1.style(".shared").color.expect.toBe("#ff0");
+      await c2.style(".shared").color.expect.toBe("#ff0");
+      await c1.style(".first").color.expect.toBe("red");
+      await c2.style(".second").color.expect.toBe("#00f");
+      // Both roots were rebuilt on the server, not just patched in the clients.
+      expect(await servedCss(dev, "/shared-first")).toMatchInlineSnapshot(`
+        "/* shared.css */
+        .shared {
+          color: #ff0;
+        }
+
+        /* shared-first.css */
+        .first {
+          color: red;
+        }
+        "
+      `);
+      expect(await servedCss(dev, "/shared-second")).toMatchInlineSnapshot(`
+        "/* shared.css */
+        .shared {
+          color: #ff0;
+        }
+
+        /* shared-second.css */
+        .second {
+          color: #00f;
+        }
+        "
+      `);
+    }
+
+    // asset referenced in css
+    {
+      await using c = await dev.client("/asset");
+      let backgroundImage = await c.style("body").backgroundImage;
+      assert(backgroundImage);
+      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
+      // The served stylesheet is the chunk with the asset inlined and nothing
+      // else: CSS never gets a source map, so no debugId trailer either.
+      expect(redactInlineAssets(await servedCss(dev, "/asset"))).toMatchInlineSnapshot(`
+        "/* asset.css */
+        body {
+          background-image: url("data:image/png;base64,<bun.png>");
+        }
+        "
+      `);
+
+      await dev.write("asset.png", imageFixtures.bun2);
+      backgroundImage = await c.style("body").backgroundImage;
+      assert(backgroundImage);
+      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun2);
+      expect(redactInlineAssets(await servedCss(dev, "/asset"))).toMatchInlineSnapshot(`
+        "/* asset.css */
+        body {
+          background-image: url("data:image/png;base64,<bun2.png>");
+        }
+        "
+      `);
+    }
+
+    // add new css import later
+    {
+      await using c = await dev.client("/script");
+      await c.style("body").notFound();
+      expect(await stylesheetUrls(dev, "/script")).toStrictEqual([]);
+
+      await dev.patch("script.ts", { find: "// import", replace: "import" });
+      await c.style("body").color.expect.toBe("red");
+      expect(await servedCss(dev, "/script")).toMatchInlineSnapshot(`
+        "/* script.css */
+        body {
+          color: red;
+        }
+        "
+      `);
+
+      await dev.patch("script.ts", { find: "import", replace: "// import" });
+      await c.style("body").notFound();
+      expect(await stylesheetUrls(dev, "/script")).toStrictEqual([]);
+    }
+  },
+});
+
+devTest("bundling errors in stylesheets and recovering from them", {
+  files: {
+    // syntax error crash
+    "crash.html": emptyHtmlFile({ styles: ["crash.css"], body: `hello world` }),
+    "crash.css": `
+      body {
+        background-image: url
+      }
+    `,
+    // css url resolve error on hot reload is recoverable
+    "resolve.html": emptyHtmlFile({ styles: ["resolve.css"], body: `hello world` }),
+    "resolve.css": `
+      body {
+        color: red;
+      }
+    `,
+    // css file with syntax error does not kill old styles
+    "keep.html": emptyHtmlFile({ styles: ["keep.css"], body: `hello world` }),
+    "keep.css": `
+      body {
+        color: red;
+      }
+    `,
+    // css file with initial syntax error gets recovered
+    "initial.html": emptyHtmlFile({ styles: ["initial.css"], body: `hello world` }),
+    "initial.css": `
       body {
         color: red;
       }}
     `,
   },
   async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ["styles.css:3:3: error: Unexpected end of input"],
-    });
-    // hard reload to dismiss the error overlay
-    await c.expectReload(async () => {
+    // syntax error crash
+    {
+      // `url` without parentheses is a plain identifier value.
+      expect(await servedCss(dev, "/crash")).toMatchInlineSnapshot(`
+        "/* crash.css */
+        body {
+          background-image: url;
+        }
+        "
+      `);
+      // previously: panic(main thread): Asset double unref: 0000000000000000
+      await dev.patch("crash.css", { find: "url\n", replace: "url(\n" });
+      await expectBuildFailed(dev, "/crash");
       await dev.write(
-        "styles.css",
+        "crash.css",
         `
           body {
             color: red;
           }
         `,
       );
-    });
-    await c.style("body").color.expect.toBe("red");
-    await dev.write(
-      "styles.css",
-      `
+      expect(await servedCss(dev, "/crash")).toMatchInlineSnapshot(`
+        "/* crash.css */
         body {
-          color: blue;
+          color: red;
         }
-      `,
-    );
-    await c.style("body").color.expect.toBe("#00f");
-    await dev.write(
-      "styles.css",
-      `
-        body {
-          color: blue;
-        }}
-      `,
-      {
-        errors: ["styles.css:3:3: error: Unexpected end of input"],
-      },
-    );
-  },
-});
-devTest("add new css import later", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
-      body: `hello world`,
-    }),
-    "index.ts": `
-      // import "./styles.css";
-      export default function () {
-        return "hello world";
-      }
-      import.meta.hot.accept();
-    `,
-    "styles.css": `
-      body {
-        color: red;
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.style("body").notFound();
-    await dev.patch("index.ts", { find: "// import", replace: "import" });
-    await c.style("body").color.expect.toBe("red");
-    await dev.patch("index.ts", { find: "import", replace: "// import" });
-    await c.style("body").notFound();
-  },
-});
-devTest("css import another css file", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-    }),
-    "styles.css": `
-      @import "./second.css";
-      body {
-        color: red;
-      }
-    `,
-    "second.css": `
-      h1 {
-        color: blue;
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    // Verify initial build
-    await c.style("h1").color.expect.toBe("#00f");
-    await c.style("body").color.expect.toBe("red");
+        "
+      `);
+    }
 
-    // Hot reload
-    await dev.write(
-      "second.css",
-      `
-        h1 {
-          color: green;
-        }
-      `,
-    );
-    await c.style("h1").color.expect.toBe("green");
-    await c.style("body").color.expect.toBe("red");
-
-    // Check that the styles still work after a reload
-    await c.hardReload();
-    await c.style("h1").color.expect.toBe("green");
-    await c.style("body").color.expect.toBe("red");
-  },
-});
-devTest("asset referenced in css", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-    }),
-    "styles.css": `
-      body {
-        background-image: url(./bun.png);
-      }
-    `,
-    "bun.png": imageFixtures.bun,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    let backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
-    // The served stylesheet is the chunk with the asset reference resolved and
-    // nothing else: CSS never gets a source map, so no debugId trailer either.
-    const stylesheetHref = (await (await dev.fetch("/")).text()).match(/<link rel="stylesheet"[^>]*href="([^"]+)"/)![1];
-    const stylesheet = await (await dev.fetch(stylesheetHref)).text();
-    expect(stylesheet).toContain("background-image:");
-    expect(stylesheet).not.toContain("debugId");
-    await dev.write("bun.png", imageFixtures.bun2);
-    backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun2);
-  },
-});
-devTest("syntax error crash", {
-  files: {
-    "styles.css": `
-      body {
-        background-image: url
-      }
-    `,
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `hello world`,
-    }),
-  },
-  async test(dev) {
-    expect((await dev.fetch("/")).status).toBe(200);
-    // previously: panic(main thread): Asset double unref: 0000000000000000
-    await dev.patch("styles.css", { find: "url\n", replace: "url(\n" });
-    expect((await dev.fetch("/")).status).toBe(500);
-  },
-});
-devTest("css url resolve error on hot reload is recoverable", {
-  files: {
-    "styles.css": `
-      body {
-        color: red;
-      }
-    `,
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `hello world`,
-    }),
-  },
-  async test(dev) {
+    // css url resolve error on hot reload is recoverable
     {
-      await using c = await dev.client("/");
-      await c.style("body").color.expect.toBe("red");
-      // A CSS file that parses but fails import resolution must fail the
-      // rebuild with an error instead of being treated as a valid CSS chunk.
-      // previously: panic: assertion failed: !chunk.content.is_css()
+      {
+        await using c = await dev.client("/resolve");
+        await c.style("body").color.expect.toBe("red");
+        // A CSS file that parses but fails import resolution must fail the
+        // rebuild with an error instead of being treated as a valid CSS chunk.
+        // previously: panic: assertion failed: !chunk.content.is_css()
+        await dev.write(
+          "resolve.css",
+          `
+            body {
+              background-image: url(./missing.png);
+            }
+          `,
+          {
+            errors: ['resolve.css:2:21: error: Could not resolve: "./missing.png"'],
+          },
+        );
+        await c.style("body").color.expect.toBe("red");
+      }
+      // The failing route is fetched and recovered without a connected client:
+      // a fetch re-bundles the route, and both that and the recovery ship the
+      // HTML route as a JS module without the route-reload flag, which trips a
+      // client-side debug assert (tracked in https://github.com/oven-sh/bun/issues/31908).
+      await expectBuildFailed(dev, "/resolve");
       await dev.write(
-        "styles.css",
+        "resolve.css",
         `
           body {
-            background-image: url(./missing.png);
+            color: blue;
+          }
+        `,
+      );
+      expect(await servedCss(dev, "/resolve")).toMatchInlineSnapshot(`
+        "/* resolve.css */
+        body {
+          color: #00f;
+        }
+        "
+      `);
+    }
+
+    // css file with syntax error does not kill old styles
+    {
+      await using c = await dev.client("/keep");
+      await c.style("body").color.expect.toBe("red");
+      await dev.write(
+        "keep.css",
+        `
+          body {
+            color: red;
+            background-color
           }
         `,
         {
-          errors: ['styles.css:2:21: error: Could not resolve: "./missing.png"'],
+          errors: ["keep.css:4:1: error: Unexpected end of input"],
         },
       );
-    }
-    // The failing route is fetched and recovered without a connected client: a
-    // fetch re-bundles the route, and both that and the recovery ship the HTML
-    // route as a JS module without the route-reload flag, which trips a
-    // client-side debug assert (tracked in https://github.com/oven-sh/bun/issues/31908).
-    expect((await dev.fetch("/")).status).toBe(500);
-    await dev.write(
-      "styles.css",
-      `
+      // Not fetched while broken: this client has the page loaded (see expectBuildFailed).
+      await c.style("body").color.expect.toBe("red");
+
+      await dev.write(
+        "keep.css",
+        `
+          body {
+            color: red;
+            background-color: blue;
+          }
+        `,
+      );
+      await c.style("body").backgroundColor.expect.toBe("#00f");
+      expect(await servedCss(dev, "/keep")).toMatchInlineSnapshot(`
+        "/* keep.css */
         body {
-          color: blue;
+          color: red;
+          background-color: #00f;
         }
-      `,
-    );
-    expect((await dev.fetch("/")).status).toBe(200);
+        "
+      `);
+
+      await dev.write("keep.css", ` `, { dedent: false });
+      await c.style("body").notFound();
+      expect(await servedCss(dev, "/keep")).toMatchInlineSnapshot(`
+        "/* keep.css */
+
+        "
+      `);
+    }
+
+    // css file with initial syntax error gets recovered
+    {
+      let blue: string;
+      {
+        await using c = await dev.client("/initial", {
+          errors: ["initial.css:3:3: error: Unexpected end of input"],
+        });
+        // The client loaded the error page, not the route's page, so a fetch is safe.
+        await expectBuildFailed(dev, "/initial");
+        // hard reload to dismiss the error overlay
+        await c.expectReload(async () => {
+          await dev.write(
+            "initial.css",
+            `
+              body {
+                color: red;
+              }
+            `,
+          );
+        });
+        await c.style("body").color.expect.toBe("red");
+        await dev.write(
+          "initial.css",
+          `
+            body {
+              color: blue;
+            }
+          `,
+        );
+        await c.style("body").color.expect.toBe("#00f");
+        blue = await servedCss(dev, "/initial");
+        expect(blue).toMatchInlineSnapshot(`
+          "/* initial.css */
+          body {
+            color: #00f;
+          }
+          "
+        `);
+        await dev.write(
+          "initial.css",
+          `
+            body {
+              color: blue;
+            }}
+          `,
+          {
+            errors: ["initial.css:3:3: error: Unexpected end of input"],
+          },
+        );
+        await c.style("body").color.expect.toBe("#00f");
+      }
+      // The client that had this page loaded is gone, see expectBuildFailed.
+      await expectBuildFailed(dev, "/initial");
+      // Recovering a second time serves the stylesheet again.
+      await dev.write(
+        "initial.css",
+        `
+          body {
+            color: blue;
+          }
+        `,
+      );
+      expect(await servedCss(dev, "/initial")).toBe(blue);
+    }
   },
 });
-devTest("circular css imports handle hot reload", {
+
+devTest("stylesheets created after the server starts, changing html link tags", {
   files: {
-    "index.html": emptyHtmlFile({
-      styles: ["a.css"],
+    // css import before create
+    "before.html": emptyHtmlFile({
+      styles: ["before.css"],
       body: `
-        <div class="a">hello</div>
-        <div class="b">hello</div>
+        <div>HELLO</div>
       `,
     }),
-    "a.css": `
-      @import "./b.css";
-      .a { color: red; }
+    // changing html file with link tag works
+    "relink.html": emptyHtmlFile({ styles: ["relink.css"] }),
+    "relink.css": `
+      .test {
+        color: blue;
+        font-size: 24px;
+      }
     `,
-    "b.css": `
-      @import "./a.css";
-      .b { color: blue; }
-    `,
+    // css import before create project relative: nested so "/style/..." differs from HTML-relative resolution
+    "html/index.html": emptyHtmlFile({
+      styles: ["/style/styles.css"],
+      body: `
+        <div>HELLO</div>
+      `,
+    }),
   },
   async test(dev) {
-    await using client = await dev.client("/");
-    await client.style(".a").color.expect.toBe("red");
-    await client.style(".b").color.expect.toBe("#00f");
+    // css import before create
+    {
+      await using c = await dev.client("/before", {
+        errors: ['before.html: error: Could not resolve: "before.css". Maybe you need to "bun install"?'],
+      });
+      await expectBuildFailed(dev, "/before");
+      await dev.write(
+        "before.css",
+        `
+          body {
+            background-image: url(before.png);
+          }
+        `,
+        {
+          errors: ['before.css:2:21: error: Could not resolve: "before.png". Maybe you need to "bun install"?'],
+        },
+      );
+      await expectBuildFailed(dev, "/before");
+      await c.expectReload(async () => {
+        await dev.write("before.png", imageFixtures.bun);
+      });
+      const backgroundImage = await c.style("body").backgroundImage;
+      assert(backgroundImage);
+      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
+      await dev.fetch("/before").expect.toContain("HELLO");
+      expect(redactInlineAssets(await servedCss(dev, "/before"))).toMatchInlineSnapshot(`
+        "/* before.css */
+        body {
+          background-image: url("data:image/png;base64,<bun.png>");
+        }
+        "
+      `);
+    }
 
-    // Modify one of the circular dependencies
-    await dev.write(
-      "a.css",
-      `
-        @import "./b.css";
-        .a { color: green; }
-      `,
-    );
-    await client.style(".a").color.expect.toBe("green");
-    await client.style(".b").color.expect.toBe("#00f");
+    // changing html file with link tag works
+    {
+      await using c = await dev.client("/relink");
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+      const testCss = await servedCss(dev, "/relink");
+      expect(testCss).toMatchInlineSnapshot(`
+        "/* relink.css */
+        .test {
+          color: #00f;
+          font-size: 24px;
+        }
+        "
+      `);
+
+      // Rewriting the HTML file unchanged reloads the page; the stylesheet survives the rebuild.
+      await c.expectReload(async () => {
+        await dev.writeNoChanges("relink.html");
+      });
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+      expect(await servedCss(dev, "/relink")).toBe(testCss);
+
+      await c.hardReload();
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+
+      await dev.write("relink.html", emptyHtmlFile({ styles: ["relink-other.css"] }), {
+        errors: ['relink.html: error: Could not resolve: "relink-other.css". Maybe you need to "bun install"?'],
+      });
+      // The HTML file itself fails, so fetching is safe with the page loaded; the page keeps its old stylesheet.
+      await expectBuildFailed(dev, "/relink");
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.expectReload(async () => {
+        await dev.write(
+          "relink-other.css",
+          `
+            .other {
+              color: red;
+            }
+          `,
+        );
+      });
+      await c.style(".other").color.expect.toBe("red");
+      await c.style(".test").notFound();
+      const otherCss = await servedCss(dev, "/relink");
+      expect(otherCss).toMatchInlineSnapshot(`
+        "/* relink-other.css */
+        .other {
+          color: red;
+        }
+        "
+      `);
+
+      await c.expectReload(async () => {
+        await dev.write("relink.html", emptyHtmlFile({ styles: ["relink.css"] }));
+      });
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+      await c.style(".other").notFound();
+      expect(await servedCss(dev, "/relink")).toBe(testCss);
+
+      await c.expectReload(async () => {
+        await dev.write("relink.html", emptyHtmlFile({ styles: ["relink-other.css", "relink.css"] }));
+      });
+      await c.style(".other").color.expect.toBe("red");
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+      // Each <link> becomes its own chunk. The graph trace decides the order
+      // they are linked in, so only the set is asserted here.
+      const urls = await stylesheetUrls(dev, "/relink");
+      const chunks = await Promise.all(urls.map(url => fetchCss(dev, url)));
+      expect(chunks.sort()).toStrictEqual([otherCss, testCss].sort());
+    }
+
+    // css import before create project relative
+    {
+      dev.mkdir("style"); // (See DevServer.zig "BUN-10968")
+      await using c = await dev.client("/html", {
+        errors: ['html/index.html: error: Could not resolve: "/style/styles.css"'],
+      });
+      await expectBuildFailed(dev, "/html");
+      await dev.write(
+        "style/styles.css",
+        `
+          body {
+            background-image: url(/assets/bun.png);
+          }
+        `,
+        {
+          errors: ['style/styles.css:2:21: error: Could not resolve: "/assets/bun.png"'],
+        },
+      );
+      // An absolute url() in CSS is not resolved against the project root, so this file is not a dependency.
+      await c.expectNoWebSocketActivity(async () => {
+        await dev.write("assets/bun.png", imageFixtures.bun, { errors: null });
+        await dev.delete("assets/bun.png", { errors: null });
+      });
+      await expectBuildFailed(dev, "/html");
+      await dev.write(
+        "style/styles.css",
+        `
+          body {
+            background-image: url(../assets/bun.png);
+          }
+        `,
+        {
+          errors: ['style/styles.css:2:21: error: Could not resolve: "../assets/bun.png"'],
+        },
+      );
+      await c.expectReload(async () => {
+        await dev.write("assets/bun.png", imageFixtures.bun);
+      });
+      const backgroundImage = await c.style("body").backgroundImage;
+      assert(backgroundImage);
+      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
+      await dev.fetch("/html").expect.toContain("HELLO");
+      expect(redactInlineAssets(await servedCss(dev, "/html"))).toMatchInlineSnapshot(`
+        "/* style/styles.css */
+        body {
+          background-image: url("data:image/png;base64,<bun.png>");
+        }
+        "
+      `);
+    }
   },
 });
+
 devTest("asset index stays valid after another css root is freed", {
   // Two independent CSS roots each get an entry in `DevServer.Assets`.
   // When the first one is freed (via a syntax error), its slot is removed
@@ -319,12 +850,22 @@ devTest("asset index stays valid after another css root is freed", {
   async test(dev) {
     // Bundle /first before /second so that `first.css` is registered at
     // a lower asset index than `second.css`.
-    {
-      await using c1 = await dev.client("/first");
-      await c1.style(".first").color.expect.toBe("red");
-    }
+    expect(await servedCss(dev, "/first")).toMatchInlineSnapshot(`
+      "/* first.css */
+      .first {
+        color: red;
+      }
+      "
+    `);
     await using c2 = await dev.client("/second");
     await c2.style(".second").color.expect.toBe("#00f");
+    expect(await servedCss(dev, "/second")).toMatchInlineSnapshot(`
+      "/* second.css */
+      .second {
+        color: #00f;
+      }
+      "
+    `);
 
     // Failing `first.css` frees its asset slot via `unrefByPath`, which
     // swap-removes it and moves the data for `second.css` into its slot.
@@ -347,6 +888,14 @@ devTest("asset index stays valid after another css root is freed", {
       { errors: null },
     );
     await c2.style(".second").color.expect.toBe("green");
+    const greenSecond = await servedCss(dev, "/second");
+    expect(greenSecond).toMatchInlineSnapshot(`
+      "/* second.css */
+      .second {
+        color: green;
+      }
+      "
+    `);
 
     // Fix the first file and ensure both pages still work afterwards.
     await dev.write(
@@ -356,12 +905,17 @@ devTest("asset index stays valid after another css root is freed", {
       `,
     );
     await c2.style(".second").color.expect.toBe("green");
-    {
-      await using c1 = await dev.client("/first");
-      await c1.style(".first").color.expect.toBe("#ff0");
-    }
+    expect(await servedCss(dev, "/second")).toBe(greenSecond);
+    expect(await servedCss(dev, "/first")).toMatchInlineSnapshot(`
+      "/* first.css */
+      .first {
+        color: #ff0;
+      }
+      "
+    `);
   },
 });
+
 devTest("css hot update carries the edited stylesheet when another root fails in the same rebuild", {
   files: {
     "bunfig.toml": `
@@ -420,6 +974,16 @@ devTest("css hot update carries the edited stylesheet when another root fails in
       await c2.style(".second").color.expect.toBe("green");
       await c1.style(".second").notFound();
     }
+    // Both clients are gone, see expectBuildFailed.
+    await expectBuildFailed(dev, "/first");
+    const greenSecond = await servedCss(dev, "/second");
+    expect(greenSecond).toMatchInlineSnapshot(`
+      "/* second.css */
+      .second {
+        color: green;
+      }
+      "
+    `);
 
     await dev.write(
       "first.css",
@@ -427,274 +991,18 @@ devTest("css hot update carries the edited stylesheet when another root fails in
         .first { color: yellow; }
       `,
     );
-    {
-      await using c2 = await dev.client("/second");
-      await c2.style(".second").color.expect.toBe("green");
-    }
+    expect(await servedCss(dev, "/second")).toBe(greenSecond);
     {
       await using c1 = await dev.client("/first");
       await c1.style(".first").color.expect.toBe("#ff0");
     }
-  },
-});
-devTest("multiple stylesheets importing same dependency", {
-  files: {
-    "first.html": emptyHtmlFile({
-      styles: ["first.css"],
-      body: `
-        <div class="first">hello</div>
-        <div class="shared">hello</div>
-      `,
-    }),
-    "second.html": emptyHtmlFile({
-      styles: ["second.css"],
-      body: `
-        <div class="second">hello</div>
-        <div class="shared">hello</div>
-      `,
-    }),
-    "first.css": `
-      @import "./shared.css";
-      .first { color: red; }
-    `,
-    "second.css": `
-      @import "./shared.css";
-      .second { color: blue; }
-    `,
-    "shared.css": `
-      .shared { color: green; }
-    `,
-  },
-  async test(dev) {
-    await using c1 = await dev.client("/first");
-    await using c2 = await dev.client("/second");
-    await c1.style(".first").color.expect.toBe("red");
-    await c2.style(".second").color.expect.toBe("#00f");
-    await c1.style(".shared").color.expect.toBe("green");
-    await c2.style(".shared").color.expect.toBe("green");
-
-    await dev.write(
-      "shared.css",
-      `
-        .shared { color: yellow; }
-      `,
-    );
-
-    await c1.style(".shared").color.expect.toBe("#ff0");
-    await c2.style(".shared").color.expect.toBe("#ff0");
-  },
-});
-devTest("removing and re-adding css import", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["main.css"],
-    }),
-    "main.css": `
-      @import "./colors.css";
-      .main { background: white; }
-    `,
-    "colors.css": `
-      .colored { color: blue; }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.style(".colored").color.expect.toBe("#00f");
-
-    // Remove the import
-    await dev.write(
-      "main.css",
-      `
-        /* @import "./colors.css"; */
-        .main { background: white; }
-      `,
-    );
-    await c.style(".colored").notFound();
-
-    // A change to 'colors.css' should not trigger a rebuild of 'main.css', nor notify any clients.
-    await c.expectNoWebSocketActivity(async () => {
-      await dev.write(
-        "colors.css",
-        `
-          .colored { color: yellow; }
-        `,
-      );
-      await dev.write(
-        "colors.css",
-        `
-          .colored { color: blue; }
-        `,
-      );
-    });
-    await c.style(".colored").notFound();
-
-    // Re-add the import
-    await dev.write(
-      "main.css",
-      `
-        @import "./colors.css";
-        .main { background: white; }
-      `,
-    );
-    await c.style(".colored").color.expect.toBe("#00f");
-    await c.style(".main").backgroundColor.expect.toBe("#fff");
-  },
-});
-devTest("changing html file with link tag works", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-    }),
-    "styles.css": `
-      .test {
-        color: blue;
-        font-size: 24px;
+    expect(await servedCss(dev, "/first")).toMatchInlineSnapshot(`
+      "/* first.css */
+      .first {
+        color: #ff0;
       }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-
-    await c.expectReload(async () => {
-      await dev.writeNoChanges("index.html");
-    });
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-
-    await c.hardReload();
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-
-    await dev.write(
-      "index.html",
-      emptyHtmlFile({
-        styles: ["other.css"],
-      }),
-      {
-        errors: ['index.html: error: Could not resolve: "other.css". Maybe you need to "bun install"?'],
-      },
-    );
-    await c.expectReload(async () => {
-      await dev.write(
-        "other.css",
-        `
-          .other {
-            color: red;
-          }
-        `,
-      );
-    });
-    await c.style(".other").color.expect.toBe("red");
-    await c.style(".test").notFound();
-    await c.expectReload(async () => {
-      await dev.write(
-        "index.html",
-        emptyHtmlFile({
-          styles: ["styles.css"],
-        }),
-      );
-    });
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-    await c.style(".other").notFound();
-    await c.expectReload(async () => {
-      await dev.write(
-        "index.html",
-        emptyHtmlFile({
-          styles: ["other.css", "styles.css"],
-        }),
-      );
-    });
-    await c.style(".other").color.expect.toBe("red");
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-  },
-});
-devTest("css import before create", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `
-        <div>HELLO</div>
-      `,
-    }),
-  },
-  async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ['index.html: error: Could not resolve: "styles.css". Maybe you need to "bun install"?'],
-    });
-    await dev.fetch("/").expect.not.toContain("HELLO");
-    await dev.write(
-      "styles.css",
-      `
-        body {
-          background-image: url(bun.png);
-        }
-      `,
-      {
-        errors: ['styles.css:2:21: error: Could not resolve: "bun.png". Maybe you need to "bun install"?'],
-      },
-    );
-    await c.expectReload(async () => {
-      await dev.write("bun.png", imageFixtures.bun);
-    });
-    const backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
-    await dev.fetch("/").expect.toContain("HELLO");
-  },
-});
-devTest("css import before create project relative", {
-  files: {
-    "html/index.html": emptyHtmlFile({
-      styles: ["/style/styles.css"],
-      body: `
-        <div>HELLO</div>
-      `,
-    }),
-  },
-  async test(dev) {
-    dev.mkdir("style"); // (See DevServer.zig "BUN-10968")
-    await using c = await dev.client("/", {
-      errors: ['html/index.html: error: Could not resolve: "/style/styles.css"'],
-    });
-    await dev.fetch("/").expect.not.toContain("HELLO");
-    await dev.write(
-      "style/styles.css",
-      `
-        body {
-          background-image: url(/assets/bun.png);
-        }
-      `,
-      {
-        errors: ['style/styles.css:2:21: error: Could not resolve: "/assets/bun.png"'],
-      },
-    );
-    await c.expectNoWebSocketActivity(async () => {
-      await dev.write("assets/bun.png", imageFixtures.bun, { errors: null });
-      await dev.delete("assets/bun.png", { errors: null });
-    });
-    await dev.fetch("/").expect.not.toContain("HELLO");
-    await dev.write(
-      "style/styles.css",
-      `
-        body {
-          background-image: url(../assets/bun.png);
-        }
-      `,
-      {
-        errors: ['style/styles.css:2:21: error: Could not resolve: "../assets/bun.png"'],
-      },
-    );
-    await c.expectReload(async () => {
-      await dev.write("assets/bun.png", imageFixtures.bun);
-    });
-    const backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
-    await dev.fetch("/").expect.toContain("HELLO");
+      "
+    `);
   },
 });
 


### PR DESCRIPTION
Stacked on #40357 (client fixture and harness route fix). This PR only changes `test/bake/dev/css.test.ts`.

### Problem
- `test/bake/dev/css.test.ts` takes 20 s on Windows aarch64 CI (build #104578). Each of its 15 `devTest` cases starts its own dev server, and most spawn their own browser client. Those two process spawns dominate the file.
- Most cases only checked colors through the client. None checked the stylesheet the dev server serves, or that a failing route serves the build-failed page.

### Fix
- The 15 cases now run as 6 tests. Independent cases share one dev server, one route each, and each case leaves its route working. The two regression tests for `DevServer.Assets` stay alone because they depend on asset index order. No write, error expectation, or style assertion is dropped (Notes list the mapping).
- Every case now asserts the exact stylesheet the dev server serves (`toMatchInlineSnapshot`), that the page links exactly one injected stylesheet, and that a failing route serves the build-failed page. Inlined image assets are redacted to their fixture name.
- Verified locally: before 41.2 s and 41.7 s, after 26.1 s and 28.6 s (Linux, debug+ASAN). Windows x64 debug: 32.5 s and 31.9 s to 21.2 s and 21.2 s. `bun bd test test/bake/dev/` passes, 134 tests.
- CI, one run each: Windows 11 aarch64 20.2 s to 17.1 s, Windows 2019 x64 16.5 s to 12.3 s, Debian x64-asan 12.5 s to 9.4 s. Release Linux lanes gain 4 to 21 percent (Notes).

### Background
- `devTest` (test/bake/bake-harness.ts) writes the files into a temp project, spawns a dev server, and connects a synchronization socket. `dev.client(route)` spawns a Node process that loads the page in happy-dom and acks every build.
- With several HTML files the harness maps each one to its own route, `first.html` to `/first`, and serves 404 for other paths. This is why #40357 is needed first: a recovered page keeps a stale source `<link>` tag (#40081), and the old fixture waited 1 s for that link on four pages in this file.
- A CSS chunk starts with a `/* file.css */` comment per bundled file, so the served text shows the import order and the recovery state directly.

<details><summary>Notes</summary>

Merged cases, in order, with the route each one got:

- "hot updates through @import graphs": css import another css file (`/import`), circular css imports handle hot reload (`/circular`), removing and re-adding css import (`/toggle`).
- "hot updates through shared imports, assets and script imports": multiple stylesheets importing same dependency (`/shared-first`, `/shared-second`), asset referenced in css (`/asset`), add new css import later (`/script`).
- "bundling errors in stylesheets and recovering from them": syntax error crash (`/crash`), css url resolve error on hot reload is recoverable (`/resolve`), css file with syntax error does not kill old styles (`/keep`), css file with initial syntax error gets recovered (`/initial`).
- "stylesheets created after the server starts, changing html link tags": css import before create (`/before`), changing html file with link tag works (`/relink`), css import before create project relative (`/html`).
- "asset index stays valid after another css root is freed" and "css hot update carries the edited stylesheet when another root fails in the same rebuild" keep their own servers. The first one bundles `/first` with a fetch instead of a client, since only the asset registration order matters. The second one checks the untouched `/second` route through the served stylesheet after the recovery instead of a fourth client.

New assertions: `servedCss` snapshots after each state change, `expectBuildFailed` on failing routes (only where no client has the real page loaded, see #31908, or where the HTML file itself fails), and `stylesheetUrls(...)` is `[]` for the script route before its import exists. The order of two `<link>` chunks is not asserted: the graph trace decides it and it is not source order on main.

CI durations of this file, build #104578 (before) and #104955 (after), one run each: Windows 11 aarch64 20.17 s to 17.13 s, Windows 2019 x64 16.50 s to 12.29 s, Debian 13 x64-asan 12.51 s to 9.41 s, Alpine 3.23 x64 13.80 s to 10.86 s, Debian 13 aarch64 9.82 s to 8.79 s, Ubuntu 25.04 x64 10.98 s to 10.12 s, Debian 13 x64 11.69 s to 11.19 s.

What remains on CI. On release lanes a dev server costs little, so client spawns (16, was 20) and writes (about 60, unchanged) set the time. Each write also pays the 50 ms coalescing sleep in `Dev.batchChanges`, about 3 s per run of this file. Shortening it needs the dev server to skip a rebuild for a watcher event that changes nothing, otherwise a straggler event could notify a client inside an `expectNoWebSocketActivity` block.

Relation to other PRs. #39488 (a 119-file consolidation, changes requested) rewrites this file the same way: the same six groups, routes, and helper names (`stylesheetUrls`, `fetchCss`, `servedCss`, `expectBuildFailed`), plus tests for fixes that have not landed. A three-way merge of #39488 onto this PR has 15 conflict hunks in this file. They resolve mechanically: keep the #39488 blocks and re-add the assertions this PR has and #39488 lacks (the inline snapshots, `redactInlineAssets`, the extra `expectBuildFailed` calls). #40092 adds an assertion to "css file with initial syntax error gets recovered", which is now the `/initial` block of the third test. #33405 appends new tests after `extractCssUrl`, which stays the last function in the file.

Alternative shape. The per-case cost lives in the harness: one server per `jest.test`. A describe-scoped helper in `bake-harness.ts` (server in `beforeAll`, one `test` per case on its own route) would keep the 15 names in the test output and serve the other bake files the same way (#37112, #37118, #40315 and #40318 merge cases by hand too). The route-per-case layout, helpers and snapshots here carry over to such a helper unchanged. This PR does not add it: that is a harness design decision for a maintainer.

Time per operation on the Linux debug build: dev server start about 0.4 s, graceful exit about 1.1 s (of which 1.0 s is `require("bun:internal-for-testing")` in the debug build, 20 ms in a release build), client spawn about 0.6 s, write about 0.1 to 0.25 s.

Also ran: Windows x64 debug `test/bake/dev/{css,harness,html,hot}.test.ts`, all pass. Linux: `test/bake/dev-and-prod.test.ts`, `framework-router.test.ts`, `deinitialization.test.ts`, `serve-plugins-dev-server.test.ts`, all pass.
</details>
