### PR TITLE
node:fs: stop openAsBlob from inferring MIME type from the extension

### DIFF
--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -53,11 +53,9 @@ function nullcallback(callback) {
 }
 const FunctionPrototypeBind = nullcallback.bind;
 
+// Not `Bun.file`: node never infers the MIME type from the file extension.
 const openAsBlobNative = $newRustFunction("node_fs_binding.rs", "open_as_blob", 2);
 
-// Unlike `Bun.file`, node never infers the MIME type from the file extension
-// (`blob.type` stays "") and stores an explicit `options.type` verbatim, so
-// this goes through a dedicated native constructor.
 function openAsBlob(path, options = kEmptyObject) {
   validateObject(options, "options");
   const type = options.type || "";

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -5,6 +5,8 @@ const {
   validateFunction,
   validateInteger,
   validateEncoding,
+  validateObject,
+  validateString,
   getValidatedPath,
   throwIfNullBytesInFileName,
 } = require("internal/validators");
@@ -51,8 +53,17 @@ function nullcallback(callback) {
 }
 const FunctionPrototypeBind = nullcallback.bind;
 
-function openAsBlob(path, options) {
-  return Promise.$resolve(Bun.file(path, options));
+const openAsBlobNative = $newRustFunction("node_fs_binding.rs", "open_as_blob", 2);
+
+// Unlike `Bun.file`, node never infers the MIME type from the file extension
+// (`blob.type` stays "") and stores an explicit `options.type` verbatim, so
+// this goes through a dedicated native constructor.
+function openAsBlob(path, options = kEmptyObject) {
+  validateObject(options, "options");
+  const type = options.type || "";
+  validateString(type, "options.type");
+  path = getValidatedPath(path);
+  return Promise.$resolve(openAsBlobNative(path, type));
 }
 
 var access = function access(path, mode, callback) {

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -8,6 +8,7 @@ const {
   validateObject,
   validateString,
   getValidatedPath,
+  getValidatedFsPath,
   throwIfNullBytesInFileName,
 } = require("internal/validators");
 
@@ -60,7 +61,7 @@ function openAsBlob(path, options = kEmptyObject) {
   validateObject(options, "options");
   const type = options.type || "";
   validateString(type, "options.type");
-  path = getValidatedPath(path);
+  path = getValidatedFsPath(path);
   return Promise.$resolve(openAsBlobNative(path, type));
 }
 

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -392,13 +392,18 @@ impl Blob {
 
     /// `Blob.hasContentTypeFromUser()` — `true` when the user set a type
     /// explicitly *or* the store is file/S3-backed (whose mime is sniffed).
+    /// Every caller uses this to decide whether `content_type` goes out as a
+    /// Content-Type header, so an empty type (`fs.openAsBlob`, an S3 blob
+    /// with no explicit type) must answer `false`: an empty header value is
+    /// not a content type.
     #[inline]
     pub fn has_content_type_from_user(&self) -> bool {
         self.content_type_was_set.get()
-            || self
-                .store()
-                .map(|s| matches!(s.data, store::Data::File(_) | store::Data::S3(_)))
-                .unwrap_or(false)
+            || (!self.content_type_slice().is_empty()
+                && self
+                    .store()
+                    .map(|s| matches!(s.data, store::Data::File(_) | store::Data::S3(_)))
+                    .unwrap_or(false))
     }
 
     /// `Blob.contentTypeOrMimeType()` — explicit `content_type` if set, else

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -405,9 +405,7 @@ pub(crate) fn rm_options_for_testing(
     Ok(obj)
 }
 
-/// `fs.openAsBlob(path, type)`: a file-backed Blob with node's type semantics
-/// (no MIME inference from the file extension, an explicit type stored
-/// verbatim). Argument validation happens in `src/js/node/fs.ts`.
+/// `fs.openAsBlob(path, type)`.
 #[bun_jsc::host_fn]
 pub(crate) fn open_as_blob(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     crate::webcore::blob::construct_blob_for_open_as_blob(global, frame)

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -405,6 +405,14 @@ pub(crate) fn rm_options_for_testing(
     Ok(obj)
 }
 
+/// `fs.openAsBlob(path, type)`: a file-backed Blob with node's type semantics
+/// (no MIME inference from the file extension, an explicit type stored
+/// verbatim). Argument validation happens in `src/js/node/fs.ts`.
+#[bun_jsc::host_fn]
+pub(crate) fn open_as_blob(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    crate::webcore::blob::construct_blob_for_open_as_blob(global, frame)
+}
+
 /// Test-only (`bun:internal-for-testing`): run a flags value through the same
 /// parser `fs.open` uses and return the numeric O_* mask, so node's
 /// `internal/fs/utils` `stringToFlags` tests can assert the production mapping.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4154,6 +4154,12 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
         blob.content_type
             .set(BlobContentType::Owned(std::sync::Arc::from(content_type)));
         blob.content_type_was_set.set(content_type_was_set);
+    } else {
+        // The wire value is authoritative: an empty type (`fs.openAsBlob`)
+        // must not be replaced by the extension-sniffed default the File arm
+        // put on the rebuilt blob.
+        blob.content_type.set(BlobContentType::default());
+        blob.content_type_was_set.set(false);
     }
 
     let blob_ptr = scopeguard::ScopeGuard::into_inner(blob_guard);
@@ -5669,6 +5675,16 @@ pub(crate) fn construct_blob_for_open_as_blob(
             global_object.throw_invalid_arguments(format_args!("Expected file path string"))
         );
     };
+
+    // Copy a Buffer path into owned bytes. Node's openAsBlob does not alias
+    // the caller's Buffer, and the store must not hold a JS ref: its
+    // finalizer-driven drop would unprotect the cell during a GC sweep.
+    if let PathOrFileDescriptor::Path(p) = &mut path {
+        if matches!(p, crate::webcore::node_types::PathLike::Buffer(_)) {
+            let owned = bun_core::handle_oom(bun_ptr::cow_slice::CowSlice::init_dupe(p.slice()));
+            *p = crate::webcore::node_types::PathLike::String(owned);
+        }
+    }
 
     let blob = Blob::find_or_create_file_from_path(&mut path, global_object, false);
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5665,8 +5665,9 @@ pub(crate) fn construct_blob_for_open_as_blob(
     let mut args = jsc::ArgumentsSlice::init(vm, arguments_slice);
 
     let Some(mut path) = PathOrFileDescriptor::from_js(global_object, &mut args)? else {
-        return Err(global_object
-            .throw_invalid_arguments(format_args!("Expected file path string")));
+        return Err(
+            global_object.throw_invalid_arguments(format_args!("Expected file path string"))
+        );
     };
 
     let blob = Blob::find_or_create_file_from_path(&mut path, global_object, false);

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5650,6 +5650,54 @@ pub(crate) fn construct_bun_file(
     Ok(unsafe { BlobExt::to_js(&*ptr, global_object) })
 }
 
+/// `fs.openAsBlob(path, type)` (node:fs compat). Unlike `Bun.file`, node never
+/// infers a MIME type from the file extension (`blob.type` stays `""`), and an
+/// explicit `options.type` is stored verbatim: no lowercasing, no interned
+/// charset promotion (`text/plain` must not become `text/plain;charset=utf-8`).
+/// Argument validation happens in `src/js/node/fs.ts`.
+pub(crate) fn construct_blob_for_open_as_blob(
+    global_object: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    // SAFETY: bun_vm() never returns null for a Bun-owned global.
+    let vm = global_object.bun_vm();
+    let arguments_slice = callframe.arguments();
+    let mut args = jsc::ArgumentsSlice::init(vm, arguments_slice);
+
+    let Some(mut path) = PathOrFileDescriptor::from_js(global_object, &mut args)? else {
+        return Err(global_object
+            .throw_invalid_arguments(format_args!("Expected file path string")));
+    };
+
+    let blob = Blob::find_or_create_file_from_path(&mut path, global_object, false);
+
+    // Drop the extension-sniffed mime `init_with_store` copied out of the
+    // file store.
+    blob.content_type.set(BlobContentType::default());
+    blob.content_type_was_set.set(false);
+
+    if arguments_slice.len() >= 2 {
+        let file_type = arguments_slice[1];
+        if file_type.is_string() {
+            let str = file_type.to_slice(global_object)?;
+            let slice = str.slice();
+            // Invalid types (bytes outside 0x20..=0x7E) stay "": content_type
+            // is written verbatim into outgoing HTTP headers.
+            if !slice.is_empty() && is_valid_blob_type(slice) {
+                blob.content_type
+                    .set(BlobContentType::Owned(std::sync::Arc::from(slice)));
+                blob.content_type_was_set.set(true);
+            }
+        }
+    }
+
+    let ptr = Blob::new(blob);
+    // SAFETY: ptr was just produced by heap::alloc in Blob::new. Spelled
+    // `BlobExt::to_js(&*ptr, ..)` to pick the `&self` impl over the by-value
+    // `JsClass::to_js`.
+    Ok(unsafe { BlobExt::to_js(&*ptr, global_object) })
+}
+
 // `find_or_create_file_from_path`: canonical impl lives later in this file
 // (runtime `check_s3: bool` form). Const-generic duplicate removed here.
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -160,6 +160,37 @@ it("fs.openAsBlob", async () => {
   expect((await openAsBlob(import.meta.path)).size).toBe(statSync(import.meta.path).size);
 });
 
+it("fs.openAsBlob does not infer the MIME type from the extension", async () => {
+  using dir = tempDir("open-as-blob", {
+    "nofileext": "hello",
+    "note.txt": "hello",
+    "x.png": "png!",
+  });
+  const noExt = await openAsBlob(join(String(dir), "nofileext"));
+  const txt = await openAsBlob(join(String(dir), "note.txt"));
+  const png = await openAsBlob(join(String(dir), "x.png"));
+  expect(noExt.type).toBe("");
+  expect(txt.type).toBe("");
+  expect(png.type).toBe("");
+  expect(await txt.text()).toBe("hello");
+});
+
+it("fs.openAsBlob stores an explicit options.type verbatim", async () => {
+  using dir = tempDir("open-as-blob-type", { "note.txt": "hello" });
+  const file = join(String(dir), "note.txt");
+  expect((await openAsBlob(file, { type: "text/plain" })).type).toBe("text/plain");
+  expect((await openAsBlob(file, { type: "TEXT/PLAIN" })).type).toBe("TEXT/PLAIN");
+  expect((await openAsBlob(file, { type: "" })).type).toBe("");
+  expect((await openAsBlob(file, { type: null })).type).toBe("");
+});
+
+it("fs.openAsBlob validates options like node", () => {
+  const invalidArgType = expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", name: "TypeError" });
+  expect(() => openAsBlob(import.meta.path, null)).toThrow(invalidArgType);
+  expect(() => openAsBlob(import.meta.path, "text/plain")).toThrow(invalidArgType);
+  expect(() => openAsBlob(import.meta.path, { type: 123 })).toThrow(invalidArgType);
+});
+
 it("writing to 1, 2 are possible", () => {
   expect(fs.writeSync(1, Buffer.from("\nhello-stdout-test\n"))).toBe(19);
   expect(fs.writeSync(2, Buffer.from("\nhello-stderr-test\n"))).toBe(19);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -175,6 +175,41 @@ it("fs.openAsBlob does not infer the MIME type from the extension", async () => 
   expect(await txt.text()).toBe("hello");
 });
 
+it("fs.openAsBlob accepts Buffer and URL paths", async () => {
+  using dir = tempDir("open-as-blob-path", { "note.txt": "hello" });
+  const file = join(String(dir), "note.txt");
+  const fromBuffer = await openAsBlob(Buffer.from(file));
+  expect(fromBuffer.type).toBe("");
+  expect(await fromBuffer.text()).toBe("hello");
+  const fromUrl = await openAsBlob(Bun.pathToFileURL(file));
+  expect(await fromUrl.text()).toBe("hello");
+});
+
+it("fs.openAsBlob body sends no Content-Type header when the type is empty", async () => {
+  using dir = tempDir("open-as-blob-fetch", { "note.txt": "hello" });
+  const file = join(String(dir), "note.txt");
+  let seen: (string | null)[] = [];
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      seen.push(req.headers.get("content-type"));
+      return new Response("ok");
+    },
+  });
+  await fetch(server.url, { method: "POST", body: await openAsBlob(file) });
+  await fetch(server.url, { method: "POST", body: await openAsBlob(file, { type: "text/plain" }) });
+  expect(seen).toEqual([null, "text/plain"]);
+});
+
+it("fs.openAsBlob type survives structuredClone", async () => {
+  using dir = tempDir("open-as-blob-clone", { "note.txt": "hello" });
+  const file = join(String(dir), "note.txt");
+  const clone = structuredClone(await openAsBlob(file));
+  expect(clone.type).toBe("");
+  expect(await clone.text()).toBe("hello");
+  expect(structuredClone(await openAsBlob(file, { type: "text/plain" })).type).toBe("text/plain");
+});
+
 it("fs.openAsBlob stores an explicit options.type verbatim", async () => {
   using dir = tempDir("open-as-blob-type", { "note.txt": "hello" });
   const file = join(String(dir), "note.txt");


### PR DESCRIPTION
### Problem
- `fs.openAsBlob()` infers the MIME type from the file extension. Node v26 leaves `blob.type === ""` unless `options.type` is given. On Bun, `openAsBlob("note.txt")` yields `text/plain;charset=utf-8` and `openAsBlob("nofileext")` yields `application/octet-stream`.
- An explicit `{ type: "text/plain" }` is rewritten to `text/plain;charset=utf-8`. Node stores the given type verbatim.
- The cause: `openAsBlob` was an alias for `Bun.file(path, options)` (`src/js/node/fs.ts:54`). `Bun.file` sniffs the type by design, and its interned MIME table promotes `text/plain` to the charset form.

### Fix
- Add `construct_blob_for_open_as_blob` (`src/runtime/webcore/Blob.rs`). It builds the same file-backed Blob as `Bun.file`, then clears the sniffed content type. An explicit type is stored verbatim as an owned byte string. A Buffer path is copied into owned bytes, so the store holds no JS ref.
- `openAsBlob` in `src/js/node/fs.ts` validates like Node (`validateObject`, `validateString`, `getValidatedFsPath`), so string, Buffer, and URL paths are accepted and bad options throw `ERR_INVALID_ARG_TYPE`.
- The empty type stays empty end to end: `has_content_type_from_user` answers false for an empty content type, so a fetch body sends no `Content-Type` header (Node sends none). The structured-clone deserializer takes the wire content type as authoritative, so `structuredClone(blob).type` stays `""`.
- Verified: `test/js/node/fs/fs.test.ts` (6 new tests, all fail on stock bun). Also the full `fs.test.ts`, `blob.test.ts`, `blob-write.test.ts`, `body.test.ts`, `structured-clone-blob-file.test.ts`, `workers/structured-clone.test.ts`, and `bun-serve-static.test.ts`.

### Background
- A file-backed Blob holds a `Store` whose `File` data carries a `MimeType` sniffed from the path extension. `Blob::init_with_store` copies that into the Blob's `content_type`, which backs the JS `type` getter.
- Bun interns common MIME strings. The interned entry for `text/plain` is the literal `text/plain;charset=utf-8`, so any type that resolves through the table picks up the charset.
- `has_content_type_from_user` decides whether a blob body's type goes out as a `Content-Type` header. It used to answer true for every file-backed store. An empty type now answers false, because an empty header value is not a content type.

<details><summary>Notes</summary>

Node v26.3.0 probe results that the fix matches:

- no options, `{}`, `{type: ""}`, `{type: null}` -> `""`
- `{type: "text/plain"}` -> `"text/plain"`, `{type: "TEXT/PLAIN"}` -> `"TEXT/PLAIN"`, `{type: " text/plain "}` -> `" text/plain "`
- `{type: 123}`, `openAsBlob(path, null)`, `openAsBlob(path, "text/plain")` -> throw `ERR_INVALID_ARG_TYPE` synchronously
- a POST `fetch` with an empty-type blob body sends no `Content-Type` header, an explicit type goes out verbatim

Known remaining divergences, out of scope here:

- Node throws `ERR_INVALID_ARG_VALUE` at `openAsBlob()` time for a missing file. Bun stays lazy like `Bun.file` and fails at read time with `ENOENT`.
- Node rejects a read after the file changed with a `NotReadableError` DOMException. Bun reports the underlying fs error.
- Node stores a type with non-ASCII bytes verbatim. Bun drops it to `""`: `content_type` is written verbatim into outgoing HTTP headers.
- In a `--compile` binary, an embedded `/$bunfs/` path still reports the sniffed type. That branch returns a refcount-shared store whose top-level `mime_type` carries the value, and mutating it would also change the cached `Bun.file` blob. Unchanged from before this PR.

Pre-existing bug found while testing, not addressed here: `Bun.file(Buffer.from(path))` holds a protected JS ref to the path Buffer in the blob store. When GC finalizes the blob during a sweep, the unprotect trips `JSCell::validateIsNotSweeping` in debug builds. Reproduces on main without this diff. `openAsBlob` sidesteps it by copying the path bytes.

Also ran `test/js/node/test/parallel/test-blob-createobjecturl.js` and `test-permission-fs-supported.js`. `fetch.test.ts` fails in this container on stock bun too (localhost connect refusals), so it is environmental.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->