### PR TITLE
bundler: do not abort on a Bun.build files specifier longer than a path buffer

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -894,38 +894,39 @@ pub mod bv2_impl {
                 pub map: bun_collections::StringHashMap<Box<[u8]>>,
             }
             impl FileMap {
-                pub(crate) fn get(&self, specifier: &[u8]) -> Option<&[u8]> {
+                /// Looks `specifier` up as a map key. Keys are stored with
+                /// forward slashes (`file_map_from_js`), so on Windows the
+                /// specifier is normalized into a path buffer first. A specifier
+                /// that does not fit one is never a key.
+                fn get_key_value(&self, specifier: &[u8]) -> Option<(&[u8], &[u8])> {
                     if self.map.is_empty() {
                         return None;
                     }
                     #[cfg(not(windows))]
                     {
-                        self.map.get(specifier).map(|b| b.as_ref())
+                        self.map
+                            .get_key_value(specifier)
+                            .map(|(key, value)| (key.as_ref(), value.as_ref()))
                     }
                     #[cfg(windows)]
                     {
                         let mut buf = bun_paths::path_buffer_pool::get();
+                        if specifier.len() > buf.len() {
+                            return None;
+                        }
                         let normalized =
                             bun_paths::resolve_path::path_to_posix_buf(specifier, &mut **buf);
-                        self.map.get(normalized).map(|b| b.as_ref())
+                        self.map
+                            .get_key_value(normalized)
+                            .map(|(key, value)| (key.as_ref(), value.as_ref()))
                     }
+                }
+                pub(crate) fn get(&self, specifier: &[u8]) -> Option<&[u8]> {
+                    self.get_key_value(specifier).map(|(_, value)| value)
                 }
                 #[inline]
                 pub fn contains(&self, specifier: &[u8]) -> bool {
-                    if self.map.is_empty() {
-                        return false;
-                    }
-                    #[cfg(not(windows))]
-                    {
-                        self.map.contains_key(specifier)
-                    }
-                    #[cfg(windows)]
-                    {
-                        let mut buf = bun_paths::path_buffer_pool::get();
-                        let normalized =
-                            bun_paths::resolve_path::path_to_posix_buf(specifier, &mut **buf);
-                        self.map.contains_key(normalized)
-                    }
+                    self.get_key_value(specifier).is_some()
                 }
                 /// Returns a `resolver::Result` for a file in the map, or `None` if
                 /// not found. Handles direct key matches and relative specifiers
@@ -957,25 +958,21 @@ pub mod bv2_impl {
                         unsafe { bun_ptr::detach_lifetime(arena.alloc_slice_copy(key)) }
                     };
 
-                    // Direct key match (must use `getKey` to return the map-owned
-                    // key, not the parameter).
-                    #[cfg(not(windows))]
-                    if let Some((key, _)) = self.map.get_key_value(specifier) {
-                        return Some(Self::result_for_key(dupe(key.as_ref())));
-                    }
-                    #[cfg(windows)]
-                    {
-                        let mut buf = bun_paths::path_buffer_pool::get();
-                        let normalized =
-                            bun_paths::resolve_path::path_to_posix_buf(specifier, &mut **buf);
-                        if let Some((key, _)) = self.map.get_key_value(normalized) {
-                            return Some(Self::result_for_key(dupe(key.as_ref())));
-                        }
+                    // Direct key match (must return the map-owned key, not the
+                    // parameter).
+                    if let Some((key, _)) = self.get_key_value(specifier) {
+                        return Some(Self::result_for_key(dupe(key)));
                     }
 
                     // Also try joining a relative specifier against the importer's
                     // directory. Relative = not posix-absolute and not Windows
                     // drive-absolute (e.g. `C:/`).
+                    //
+                    // The specifier is user input of any length (an import
+                    // string, a CSS `url()`), so every step below that writes
+                    // into a path buffer is bounds-checked. A join that does
+                    // not fit one is not a virtual file; the resolver then
+                    // handles the specifier like it does for a file on disk.
                     if !specifier.is_empty() && !bun_paths::is_absolute_loose(specifier) {
                         // `source_file` may itself be relative (e.g. on Windows
                         // when the bundler stores paths relative to cwd).
@@ -984,12 +981,15 @@ pub mod bv2_impl {
                             source_file
                         } else {
                             bun_resolver::fs::FileSystem::instance()
-                                .abs_buf(&[source_file], &mut *abs_source_buf)
+                                .abs_buf_checked(&[source_file], &mut *abs_source_buf)?
                         };
 
                         // Normalize `source_file` to forward slashes (Windows paths
                         // from the real filesystem may use backslashes).
                         let mut source_file_buf = bun_paths::path_buffer_pool::get();
+                        if abs_source_file.len() > source_file_buf.len() {
+                            return None;
+                        }
                         let normalized_source_file = bun_paths::resolve_path::path_to_posix_buf::<u8>(
                             abs_source_file,
                             &mut **source_file_buf,
@@ -1019,11 +1019,11 @@ pub mod bv2_impl {
                         };
                         // `.loose` preserves Windows drive letters; normalize
                         // separators in-place on Windows afterwards.
-                        let joined_len = bun_paths::resolve_path::join_abs_string_buf::<
+                        let joined_len = bun_paths::resolve_path::join_abs_string_buf_checked::<
                             bun_paths::platform::Loose,
                         >(
                             effective_source_dir, &mut **buf, &[specifier]
-                        )
+                        )?
                         .len();
                         if cfg!(windows) {
                             bun_paths::resolve_path::platform_to_posix_in_place::<u8>(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -894,10 +894,8 @@ pub mod bv2_impl {
                 pub map: bun_collections::StringHashMap<Box<[u8]>>,
             }
             impl FileMap {
-                /// Looks `specifier` up as a map key. Keys are stored with
-                /// forward slashes (`file_map_from_js`), so on Windows the
-                /// specifier is normalized into a path buffer first. A specifier
-                /// that does not fit one is never a key.
+                /// Keys are stored with forward slashes (`file_map_from_js`), so on
+                /// Windows the specifier is normalized before the lookup.
                 fn get_key_value(&self, specifier: &[u8]) -> Option<(&[u8], &[u8])> {
                     if self.map.is_empty() {
                         return None;
@@ -958,21 +956,16 @@ pub mod bv2_impl {
                         unsafe { bun_ptr::detach_lifetime(arena.alloc_slice_copy(key)) }
                     };
 
-                    // Direct key match (must return the map-owned key, not the
-                    // parameter).
+                    // Direct key match. Return the map-owned key, not the parameter.
                     if let Some((key, _)) = self.get_key_value(specifier) {
                         return Some(Self::result_for_key(dupe(key)));
                     }
 
                     // Also try joining a relative specifier against the importer's
                     // directory. Relative = not posix-absolute and not Windows
-                    // drive-absolute (e.g. `C:/`).
-                    //
-                    // The specifier is user input of any length (an import
-                    // string, a CSS `url()`), so every step below that writes
-                    // into a path buffer is bounds-checked. A join that does
-                    // not fit one is not a virtual file; the resolver then
-                    // handles the specifier like it does for a file on disk.
+                    // drive-absolute (e.g. `C:/`). A specifier can be any length
+                    // (a CSS `url()`); one that does not fit a path buffer is not
+                    // a virtual file and falls through to the resolver.
                     if !specifier.is_empty() && !bun_paths::is_absolute_loose(specifier) {
                         // `source_file` may itself be relative (e.g. on Windows
                         // when the bundler stores paths relative to cwd).

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -894,8 +894,7 @@ pub mod bv2_impl {
                 pub map: bun_collections::StringHashMap<Box<[u8]>>,
             }
             impl FileMap {
-                /// Keys are stored with forward slashes (`file_map_from_js`), so on
-                /// Windows the specifier is normalized before the lookup.
+                /// Keys are stored with forward slashes (`file_map_from_js`).
                 fn get_key_value(&self, specifier: &[u8]) -> Option<(&[u8], &[u8])> {
                     if self.map.is_empty() {
                         return None;
@@ -963,9 +962,7 @@ pub mod bv2_impl {
 
                     // Also try joining a relative specifier against the importer's
                     // directory. Relative = not posix-absolute and not Windows
-                    // drive-absolute (e.g. `C:/`). A specifier can be any length
-                    // (a CSS `url()`); one that does not fit a path buffer is not
-                    // a virtual file and falls through to the resolver.
+                    // drive-absolute (e.g. `C:/`).
                     if !specifier.is_empty() && !bun_paths::is_absolute_loose(specifier) {
                         // `source_file` may itself be relative (e.g. on Windows
                         // when the bundler stores paths relative to cwd).

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -657,6 +657,29 @@ describe("bundler files option", () => {
       });
     });
 
+    test("HTML script and stylesheet references report resolve errors", async () => {
+      const result = await buildInChild(`
+        const long = Buffer.alloc(131072, "A").toString();
+        const result = await Bun.build({
+          entrypoints: ["/index.html"],
+          files: {
+            "/index.html":
+              '<!doctype html><html><head><link rel="stylesheet" href="./' + long + '.css"></head>' +
+              '<body><script src="./' + long + '.js"></script></body></html>',
+          },
+          throw: false,
+        });
+        console.log(JSON.stringify({
+          success: result.success,
+          logs: result.logs.map(log => log.message.replace(long, "<long>")).sort(),
+        }));
+      `);
+      expect(result).toEqual({
+        success: false,
+        logs: ['Could not resolve: "./<long>.css"', 'Could not resolve: "./<long>.js"'],
+      });
+    });
+
     test("a relative entry point reports a resolve error", async () => {
       const result = await buildInChild(`
         const entryPoint = Buffer.alloc(131072, "A").toString() + ".js";

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("bundler files option", () => {
   test("basic in-memory file bundling", async () => {
@@ -600,5 +600,80 @@ describe("bundler files option", () => {
 
     const output = await result.outputs[0].text();
     expect(output).toContain("injected by plugin");
+  });
+
+  // Specifiers are joined onto the importer's directory to find a matching
+  // in-memory file. A specifier longer than a path buffer (4096 bytes on
+  // Linux, 1024 on macOS, 98302 on Windows) used to abort the process. These
+  // run in a child process because the bug is a crash.
+  describe.concurrent("specifiers longer than a path buffer", () => {
+    async function buildInChild(script: string) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return JSON.parse(stdout);
+    }
+
+    test("a CSS url() is kept as-is", async () => {
+      const result = await buildInChild(`
+        const url = "data:image/svg+xml," + Buffer.alloc(131072, "A").toString();
+        const result = await Bun.build({
+          entrypoints: ["/style.css"],
+          files: { "/style.css": '.x { background: url("' + url + '") }' },
+          throw: false,
+        });
+        const output = result.success ? await result.outputs[0].text() : "";
+        console.log(JSON.stringify({
+          success: result.success,
+          logs: result.logs.map(String),
+          outputHasUrl: output.includes(url),
+        }));
+      `);
+      expect(result).toEqual({ success: true, logs: [], outputHasUrl: true });
+    });
+
+    test("a relative import reports a resolve error", async () => {
+      const result = await buildInChild(`
+        const specifier = "./" + Buffer.alloc(131072, "A").toString() + ".js";
+        const result = await Bun.build({
+          entrypoints: ["/entry.js"],
+          files: { "/entry.js": 'import "' + specifier + '";' },
+          throw: false,
+        });
+        console.log(JSON.stringify({
+          success: result.success,
+          logs: result.logs.map(log => log.message.replace(specifier, "<specifier>")),
+        }));
+      `);
+      expect(result).toEqual({
+        success: false,
+        logs: ['Could not resolve: "<specifier>"'],
+      });
+    });
+
+    test("a relative entry point reports a resolve error", async () => {
+      const result = await buildInChild(`
+        const entryPoint = Buffer.alloc(131072, "A").toString() + ".js";
+        const result = await Bun.build({
+          entrypoints: [entryPoint],
+          files: { "/entry.js": "" },
+          throw: false,
+        });
+        console.log(JSON.stringify({
+          success: result.success,
+          logs: result.logs.map(log => log.message.replace(entryPoint, "<entry point>")),
+        }));
+      `);
+      expect(result).toEqual({
+        success: false,
+        logs: ['ModuleNotFound resolving "<entry point>" (entry point)'],
+      });
+    });
   });
 });


### PR DESCRIPTION
### Problem
- `Bun.build({ files })` aborts when an in-memory file holds a specifier longer than a path buffer: `panic: range end index 4096 out of range for slice of length 4095` (1024 on macOS, 98302 on Windows). Every loader reaches it: CSS `url()` and `@import`, JS `import`, `import()` and `require()`, HTML `<script src>` and `<link href>`. Any inline `data:` image over 4 KB in a virtual CSS file hits it. The same file from disk builds fine. Fixes #39252.
- Cause: `FileMap::resolve` (`src/bundler/bundle_v2.rs:1022`) treats every non-absolute specifier as relative and joins it onto the importer's directory with `join_abs_string_buf`, which writes into a fixed `PathBuffer` with no bounds check. On Windows, `get`, `contains` and `resolve` also copy the raw specifier into a `PathBuffer`, unchecked.

### Fix
- `FileMap::resolve` joins with `join_abs_string_buf_checked` and returns `None` when the result does not fit, the rule the resolver applies in `check_relative_path`. The specifier then reaches the resolver, which marks a `data:` URL external and reports `Could not resolve` for a too-long path.
- The importer path goes through `abs_buf_checked` and a length check before its separator normalization.
- One `get_key_value` helper replaces the three Windows separator normalizations. A specifier longer than a path buffer is never a key.
- Verified: `test/bundler/bundler_files.test.ts`, four new tests in a child process (CSS `url()`, JS import, HTML references, entry point), all abort on 1.4.0. Also `bundler_plugin`, `bundler_defer`, `bundler_naming`, `html-import-manifest`, `css/doesnt_crash`, `cargo check` for Windows.

### Background
- `files:` is the in-memory file map of `Bun.build`. Before the resolver runs, `FileMap::resolve` checks each import specifier against that map: by exact key, then joined onto the importer's directory.
- `PathBuffer` is `[u8; MAX_PATH_BYTES]`: 4096 bytes on Linux, 1024 on macOS, 98302 on Windows. `join_abs_string_buf` normalizes into it with plain indexing. The `_checked` variant returns `None` instead.
- The resolver parses `data:` URLs before any path join.

<details><summary>Notes</summary>

Related PRs:
- #38650 reworks how `files:` keys are stored (relative keys resolved against the cwd) and replaces the same join as part of that. It has been open since August 14. This PR is the minimal crash fix so that it can land on its own. Whichever lands second needs a small rebase in `FileMap::resolve`.
- #39256 was an earlier narrow version of this fix. It was closed in favor of #38650.
- #39626 covers a different site: the resolver itself (`load_as_file`, `load_extension`) panics on an absolute import path or entry point longer than a path buffer, with or without `files:`. That is out of scope here.
- #38696 covers another one: a `files:` key whose relative form does not fit a path buffer (for example `/` + 4090 bytes + `.js` with no imports at all) panics in `generic_path_with_pretty_initialized` (`relative_platform_buf`) while the entry point's display path is computed. This PR does not reach that site.

Repro on 1.4.0 and on main (`44411167`):

```js
const url = "data:image/svg+xml," + "A".repeat(4096 - 19);
const css = `.x { background: url("${url}") }\n`;
const r = await Bun.build({ entrypoints: ["/style.css"], files: { "/style.css": css } });
console.log(r.success);
```

Stack on a debug build (the crash handler only prints the top frames in release):

```
bun_paths::resolve_path::normalize_string_generic_tz  src/paths/resolve_path.rs:1076
bun_paths::resolve_path::join_abs_string_buf<Loose>    src/paths/resolve_path.rs:1672
bun_bundler::bundle_v2::...::JSBundler::FileMap::resolve  src/bundler/bundle_v2.rs:1022
bun_bundler::bundle_v2::BundleV2::resolve_import_records
bun_bundler::bundle_v2::BundleV2::run_resolution_for_parse_task
bun_bundler::bundle_v2::BundleV2::on_parse_task_complete
```

Checked on the fixed build: quoted and unquoted `url()`, `@font-face src`, `https:` and `#fragment` URLs of 64 KiB all build. A 128 KiB relative, bare or dynamic import, `require()`, CSS `@import`, and HTML `<script src>` / `<link href>` report `Could not resolve`, the same as from a disk file. A 128 KiB `data:` URL in an HTML `<img src>` is kept. Each of these aborts on 1.4.0 (`/usr/local/bin/bun`, `34cbb9a40`). Relative imports between virtual files, `..` segments, and a relative CSS `url()` to a virtual asset still resolve as before.

With the fix, a too-long specifier skips the relative join and reaches the resolver. A virtual file whose key itself is longer than a path buffer cannot be found through a relative specifier. Such keys are not supported elsewhere in the bundler either (output path computation uses path buffers).

Sentry BUN-4S5H (1.4.1-canary `abe2ad4f0`, Linux x64) is this crash, reached from a JS `import` whose specifier is `./` plus 2100 `a/` segments. The same guards also cover the importer side: a virtual file whose key is longer than a path buffer, reached by an exact key match, used to abort in `abs_buf` or `path_to_posix_buf` on its first relative import.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_files.test.ts
bun test v1.4.1 (4448a2e21)

test/bundler/bundler_files.test.ts:
(pass) bundler files option > basic in-memory file bundling [129.16ms]
(pass) bundler files option > in-memory file with imports [67.19ms]
(pass) bundler files option > in-memory file with relative imports (same directory) [84.60ms]
(pass) bundler files option > in-memory file with relative imports (subdirectory) [49.04ms]
(pass) bundler files option > in-memory file with relative imports (parent directory) [42.94ms]
(pass) bundler files option > in-memory file with relative imports between multiple files [42.54ms]
(pass) bundler files option > in-memory file with nested imports [43.76ms]
(pass) bundler files option > in-memory file with TypeScript [50.30ms]
(pass) bundler files option > in-memory file with JSX [242.61ms]
(pass) bundler files option > in-memory file with Blob content [45.77ms]
(pass) bundler files option > in-memory file with a file-backed Blob is rejected [30.44ms]
(pass) bundler files option > in-memory file with Uint8
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (939574e50)

test/bundler/bundler_files.test.ts:
(pass) bundler files option > basic in-memory file bundling [3.79ms]
(pass) bundler files option > in-memory file with imports [1.40ms]
(pass) bundler files option > in-memory file with relative imports (same directory) [1.61ms]
(pass) bundler files option > in-memory file with relative imports (subdirectory) [1.26ms]
(pass) bundler files option > in-memory file with relative imports (parent directory) [1.23ms]
(pass) bundler files option > in-memory file with relative imports between multiple files [0.96ms]
(pass) bundler files option > in-memory file with nested imports [0.90ms]
(pass) bundler files option > in-memory file with TypeScript [0.89ms]
(pass) bundler files option > in-memory file with JSX [5.06ms]
(pass) bundler files option > in-memory file with Blob content [2.13ms]
(pass) bundler files option > in-memory file with a file-backed Blob is rejected [0.91ms]
(pass) bundler files option > in-memory file with Uint8Array content [1.62ms]
(pass) bundler files option > in-memory file with ArrayBuffer content [2.36ms]
(pass) bundler files option > in-memory file with re-exports [1.46ms]

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_files.test.ts
bun test v1.4.1 (4448a2e21)

test/bundler/bundler_files.test.ts:
(pass) bundler files option > basic in-memory file bundling [138.75ms]
(pass) bundler files option > in-memory file with imports [70.73ms]
(pass) bundler files option > in-memory file with relative imports (same directory) [85.08ms]
(pass) bundler files option > in-memory file with relative imports (subdirectory) [84.82ms]
(pass) bundler files option > in-memory file with relative imports (parent directory) [45.01ms]
(pass) bundler files option > in-memory file with relative imports between multiple files [44.79ms]
(pass) bundler files option > in-memory file with nested imports [51.14ms]
(pass) bundler files option > in-memory file with TypeScript [49.94ms]
(pass) bundler files option > in-memory file with JSX [228.09ms]
(pass) bundler files option > in-memory file with Blob content [44.26ms]
(pass) bundler files option > in-memory file with a file-backed Blob is rejected [27.70ms]
(pass) bundler files option > in-memory file with Uint8
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 693ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m   Compiling^[[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
^[[1m^[[92m   Compiling^[[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs           |  58 +++++++++------------
 test/bundler/bundler_files.test.ts | 100 ++++++++++++++++++++++++++++++++++++-
 2 files changed, 123 insertions(+), 35 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/bundler/bundle_v2.rs               10      7      0
test/bundler/bundler_files.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->
