### PR TITLE
Give Glob's native scan methods their own private names

### DIFF
--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -90,6 +90,8 @@ using namespace JSC;
     macro(filename) \
     macro(flush) \
     macro(format) \
+    macro(globScan) \
+    macro(globScanSync) \
     macro(handleEvent) \
     macro(headers) \
     macro(highWaterMark) \

--- a/src/js/builtins/Glob.ts
+++ b/src/js/builtins/Glob.ts
@@ -1,10 +1,10 @@
 interface Glob {
-  $pull(opts);
-  $resolveSync(opts);
+  $globScan(opts);
+  $globScanSync(opts);
 }
 
 export function scan(this: Glob, opts) {
-  const valuesPromise = this.$pull(opts);
+  const valuesPromise = this.$globScan(opts);
   async function* iter() {
     const values = (await valuesPromise) || [];
     yield* values;
@@ -13,7 +13,7 @@ export function scan(this: Glob, opts) {
 }
 
 export function scanSync(this: Glob, opts) {
-  const arr = this.$resolveSync(opts) || [];
+  const arr = this.$globScanSync(opts) || [];
   function* iter() {
     yield* arr;
   }

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -206,7 +206,7 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
 
     JSC::JSValue moduleName = callFrame->argument(0);
     JSValue from = callFrame->argument(1);
-    bool isESM = callFrame->argument(2).asBoolean();
+    bool isESM = callFrame->argument(2).isTrue();
     bool isRequireDotResolve = callFrame->argument(3).isTrue();
     JSValue userPathList = callFrame->argument(4);
     JSValue parentModule = callFrame->argument(5);

--- a/src/runtime/api/Glob.classes.ts
+++ b/src/runtime/api/Glob.classes.ts
@@ -21,14 +21,12 @@ export default [
       __scan: {
         fn: "__scan",
         length: 1,
-        // Wanted to use `resolve` and `resolveSync` but for some reason the
-        // resolve symbol was not working, even though `resolveSync` was.
-        privateSymbol: "pull",
+        privateSymbol: "globScan",
       },
       __scanSync: {
         fn: "__scanSync",
         length: 1,
-        privateSymbol: "resolveSync",
+        privateSymbol: "globScanSync",
       },
       match: {
         fn: "match",

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -938,6 +938,30 @@ test("scan handles a cwd with redundant trailing separators when following symli
   expect(exitCode).toBe(0);
 });
 
+// With `this === globalThis`, the private `@resolveSync` that scanSync calls is
+// the module resolver's internal entry point, called with a single argument.
+test("scanSync called with globalThis as this throws instead of crashing", async () => {
+  const script = `
+    try {
+      Bun.Glob.prototype.scanSync.call(globalThis, 4096);
+      console.log("no error");
+    } catch (e) {
+      console.log(e.code);
+    }
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("ERR_INVALID_ARG_TYPE");
+  expect(exitCode).toBe(0);
+});
+
 // A pattern segment that spells out a leading `.` is an explicit request for
 // that dotfile/dot-directory, so the `dot: false` default must not hide it.
 // This matches bash, picomatch, minimatch and fast-glob.

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -938,14 +938,15 @@ test("scan handles a cwd with redundant trailing separators when following symli
   expect(exitCode).toBe(0);
 });
 
-// With `this === globalThis`, the private `@resolveSync` that scanSync calls is
-// the module resolver's internal entry point, called with a single argument.
-// The private `@pull` that scan calls does not exist on globalThis at all.
-test("scanSync and scan called with globalThis as this throw instead of crashing", async () => {
+// `scan` and `scanSync` are JS builtins that reach the native scanner through
+// private names on `this`. Those names must not exist on any other object:
+// when `scanSync` used `@resolveSync`, the name the module resolver installs on
+// `globalThis`, `scanSync.call(globalThis, "fs")` resolved the module instead.
+test("scan and scanSync called with globalThis as this throw a TypeError", async () => {
   const script = `
     for (const fn of ["scanSync", "scan"]) {
       try {
-        Bun.Glob.prototype[fn].call(globalThis, 4096);
+        Bun.Glob.prototype[fn].call(globalThis, "fs");
         console.log(fn + ": no error");
       } catch (e) {
         console.log(fn + ": " + (e.code ?? e.name));
@@ -961,7 +962,7 @@ test("scanSync and scan called with globalThis as this throw instead of crashing
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout.trim()).toBe("scanSync: ERR_INVALID_ARG_TYPE\nscan: TypeError");
+  expect(stdout.trim()).toBe("scanSync: TypeError\nscan: TypeError");
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -940,13 +940,16 @@ test("scan handles a cwd with redundant trailing separators when following symli
 
 // With `this === globalThis`, the private `@resolveSync` that scanSync calls is
 // the module resolver's internal entry point, called with a single argument.
-test("scanSync called with globalThis as this throws instead of crashing", async () => {
+// The private `@pull` that scan calls does not exist on globalThis at all.
+test("scanSync and scan called with globalThis as this throw instead of crashing", async () => {
   const script = `
-    try {
-      Bun.Glob.prototype.scanSync.call(globalThis, 4096);
-      console.log("no error");
-    } catch (e) {
-      console.log(e.code);
+    for (const fn of ["scanSync", "scan"]) {
+      try {
+        Bun.Glob.prototype[fn].call(globalThis, 4096);
+        console.log(fn + ": no error");
+      } catch (e) {
+        console.log(fn + ": " + (e.code ?? e.name));
+      }
     }
   `;
 
@@ -958,7 +961,7 @@ test("scanSync called with globalThis as this throws instead of crashing", async
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout.trim()).toBe("ERR_INVALID_ARG_TYPE");
+  expect(stdout.trim()).toBe("scanSync: ERR_INVALID_ARG_TYPE\nscan: TypeError");
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
### Problem
- `Bun.Glob.prototype.scanSync.call(globalThis, "fs")` returns an iterator over the characters of `node:fs`. With a number as the argument, a debug build aborts with `ASSERTION FAILED: isBoolean()`.
- `scanSync` (`src/js/builtins/Glob.ts`) reaches its native half through the private name `@resolveSync` on `this`. `globalThis` has that name too: the module resolver (`src/jsc/bindings/ZigGlobalObject.cpp:2855`). So a Glob method with a foreign receiver ran the resolver, which reads its third argument with `asBoolean()`.

### Fix
- `Glob.classes.ts` now installs `__scan` and `__scanSync` under the new private names `@globScan` and `@globScanSync`, declared in `BunBuiltinNames.h`. `Glob.ts` calls those. No other object has them, so a foreign receiver throws `TypeError`.
- Correct because a private name is the contract between a builtin and its native half. Two natives that share one name can be swapped by any caller that controls `this`. `require` still reaches the resolver through `@resolveSync`.
- The resolver now reads `isESM` with `isTrue()`, the accessor the next line already uses. Release builds compiled both to the same comparison.
- Verified: `test/js/bun/glob/scan.test.ts`, "scan and scanSync called with globalThis as this throw a TypeError". Stock bun prints `scanSync: no error`. Also `test/js/bun/glob/`, `test/js/node/module/`, and `import-meta.test.js`.

### Background
- A private name such as `@globScan` is a property key that only builtin JS can spell. `privateSymbol` in a `.classes.ts` puts a native function on a prototype under one. A builtin reads it as `this.$globScan`.
- `pull` and `resolveSync` stay in the list for the stream sources and the resolver.
- Supersedes #32253, which had the `isTrue()` change alone.

<details><summary>Notes</summary>

- Repro on stock bun: `bun -e 'console.log([...Bun.Glob.prototype.scanSync.call(globalThis, "fs")])'` prints `["n","o","d","e",":","f","s"]`. With `"./package.json"` it prints the absolute path, one character per element. With `4096` it throws `ERR_INVALID_ARG_TYPE` (`The "id" argument must be of type string`), which is the resolver's validator. In a debug build the `4096` case aborts instead: `asBoolean()` is `ASSERT(isBoolean()); return asValue() == JSValue(JSTrue);` and `isTrue()` is the same comparison without the assert. A fuzzer found the abort.
- `scan` called `@pull`, which `globalThis` does not have, so it already threw `TypeError`. It is renamed for symmetry and to keep Glob's names off any object that has a `pull` private name.
- Builtin callers of `$resolveSync` after this change: `src/js/builtins/CommonJS.ts:19` (`require`) and `:151` (`require.resolve`). Both pass boolean literals, so no JS path reaches the `isTrue()` line with a non-boolean anymore.
- The test prints `e.code ?? e.name`, so a regression back to the resolver shows up as `no error` (string argument) or `ERR_INVALID_ARG_TYPE` (number argument) instead of `TypeError`. On the unfixed debug build the child aborts and stdout is empty.
- Timing probe on the debug build, 5000 iterations of `Array.fromAsync(glob.scan())` over three files: 5.5 s with the rename, 5.6 s without. `scanSync`: 3.0 s both ways. The `leaks > scan` tests (100k async iterations, 60 s timeout) and the six `glob.match` tests that scan the whole repo time out in the local container with and without the change. They pass in CI.
- Suites run with the debug build: `test/js/bun/glob/scan.test.ts`, `match.test.ts`, `proto.test.ts`, `path-length.test.ts`, `leak.test.ts` (sync cases), `test/js/node/module/module-resolve-filename-paths.test.js`, `test/js/node/module/node-module-module.test.js`, `test/js/bun/resolve/import-meta.test.js`.
- #36040 and #36044 (open) rewrite the Glob scan path and add a second prototype with `privateSymbol: "pull"` and `"resolveSync"`. Whichever lands second needs a rebase onto the new names.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/glob/scan.test.ts

<!-- robobun:evidence:end -->