### PR TITLE
bun test: apply command line flags after bunfig.toml so they override [test] keys

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -379,6 +379,8 @@ Enable the dots reporter, which prints one dot per test. Default `false`.
 dots = true
 ```
 
+Equivalent to the `--dots` flag.
+
 #### `test.reporter.junit`
 
 Enable JUnit XML reporting and specify the output file path.
@@ -388,7 +390,7 @@ Enable JUnit XML reporting and specify the output file path.
 junit = "test-results.xml"
 ```
 
-CI systems and other tools can consume the report.
+CI systems and other tools can consume the report. The `--reporter-outfile` CLI flag overrides the output file path.
 
 ## Package manager
 

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -549,10 +549,6 @@ impl<'a> Parser<'a> {
 
                 if let Some(expr) = test.get(b"rerunEach") {
                     self.expect(&expr, ExprTag::ENumber)?;
-                    if self.ctx.test_options.retry != 0 {
-                        self.add_error(expr.loc, b"\"rerunEach\" cannot be used with \"retry\"")?;
-                        return Ok(());
-                    }
                     self.ctx.test_options.repeat_count =
                         num_to_u32(expr.as_number().expect("infallible: type checked"));
                 }

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -533,31 +533,18 @@ impl<'a> Parser<'a> {
                         expr.as_bool().expect("infallible: type checked");
                 }
 
-                let mut randomize_from_config: Option<bool> = None;
-
                 if let Some(expr) = test.get(b"randomize") {
                     self.expect(&expr, ExprTag::EBoolean)?;
-                    randomize_from_config = expr.as_bool();
                     self.ctx.test_options.randomize =
                         expr.as_bool().expect("infallible: type checked");
                 }
 
+                // `parse_test_command_options` checks `seed` against `randomize` after the flags apply.
                 if let Some(expr) = test.get(b"seed") {
                     self.expect(&expr, ExprTag::ENumber)?;
-                    let seed_value =
-                        num_to_u32(expr.as_number().expect("infallible: type checked"));
-
-                    // Validate that randomize is true when seed is specified
-                    let has_randomize_true =
-                        randomize_from_config.unwrap_or(self.ctx.test_options.randomize);
-                    if !has_randomize_true {
-                        self.add_error(
-                            expr.loc,
-                            b"\"seed\" can only be used when \"randomize\" is true",
-                        )?;
-                    }
-
-                    self.ctx.test_options.seed = Some(seed_value);
+                    self.ctx.test_options.seed = Some(num_to_u32(
+                        expr.as_number().expect("infallible: type checked"),
+                    ));
                 }
 
                 if let Some(expr) = test.get(b"rerunEach") {
@@ -670,10 +657,6 @@ impl<'a> Parser<'a> {
 
                 if let Some(expr) = test.get(b"pathIgnorePatterns") {
                     'brk: {
-                        // Only skip if --path-ignore-patterns was explicitly passed via CLI
-                        if self.ctx.test_options.path_ignore_patterns_from_cli {
-                            break 'brk;
-                        }
                         match &expr.data {
                             ExprData::EString(s) => {
                                 self.ctx.test_options.path_ignore_patterns =

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -410,7 +410,6 @@ pub struct TestOptions {
     pub bail: u32,
     pub coverage: CodeCoverageOptions,
     pub path_ignore_patterns: Vec<Box<[u8]>>,
-    pub path_ignore_patterns_from_cli: bool,
     pub test_filter_pattern: Option<Box<[u8]>>,
     /// `?*bun.jsc.RegularExpression` — typed as opaque to keep this file free
     /// of `jsc/` references. Read via `test_filter_regex()`.
@@ -494,7 +493,6 @@ impl Default for TestOptions {
             bail: 0,
             coverage: CodeCoverageOptions::default(),
             path_ignore_patterns: Vec::new(),
-            path_ignore_patterns_from_cli: false,
             test_filter_pattern: None,
             test_filter_regex: None,
             // Under ASAN every spawned `bun` child is several-× heavier in

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1699,6 +1699,10 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
 /// shard / parallel / seed / etc. Split out of [`parse`] so the `bun run <script>`
 /// and bare-`bun <file>` hot path (`USES_GLOBAL_OPTIONS` ⇒ `parse` runs on every
 /// invocation) doesn't carry the test-runner flag handling in its instruction pages.
+///
+/// Runs after bunfig.toml is loaded, so every write here overrides a `[test]` key.
+/// Write a field only when its flag is present (`|=`, or gate on `args.flag`): a
+/// plain `= args.flag(..)` resets the bunfig value whenever the flag is absent.
 #[cold]
 #[inline(never)]
 fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
@@ -1932,7 +1936,7 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
             ctx.test_options.timings_files.push((*path).into());
         }
     }
-    ctx.test_options.update_timings = args.flag(b"--update-timings");
+    ctx.test_options.update_timings |= args.flag(b"--update-timings");
     if ctx.test_options.update_timings && ctx.test_options.timings_files.is_empty() {
         bun_core::pretty_errorln!(
             "<r><red>error<r>: --update-timings requires --timings, e.g. --timings=.bun-test-timings.json --update-timings"
@@ -1946,9 +1950,13 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
     ctx.test_options.pass_with_no_tests |= args.flag(b"--pass-with-no-tests");
     ctx.test_options.concurrent |= args.flag(b"--concurrent");
     ctx.test_options.randomize |= args.flag(b"--randomize");
+    ctx.test_options.test_worker |= args.flag(b"--test-worker");
     let no_isolate = args.flag(b"--no-isolate");
-    ctx.test_options.isolate = args.flag(b"--isolate") && !no_isolate;
-    ctx.test_options.test_worker = args.flag(b"--test-worker");
+    if no_isolate {
+        ctx.test_options.isolate = false;
+    } else if args.flag(b"--isolate") {
+        ctx.test_options.isolate = true;
+    }
 
     if let Some(parallel_str) = args.option(b"--parallel") {
         let parsed: u32 = if !parallel_str.is_empty() {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -888,15 +888,16 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
         }
     }
 
-    if cmd == CommandTag::TestCommand {
-        parse_test_command_options(&args, ctx);
-    }
-
     ctx.args.absolute_working_dir = Some(cwd);
     ctx.positionals = slice_to_owned(args.positionals());
 
     if command::LOADS_CONFIG[cmd] {
         load_config_with_cmd_args(cmd, &args, ctx)?;
+    }
+
+    // After the config load, so a `bun test` flag overrides its `[test]` key.
+    if cmd == CommandTag::TestCommand {
+        parse_test_command_options(&args, ctx);
     }
 
     let mut opts: api::TransformOptions = ctx.args.clone();
@@ -1799,7 +1800,6 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
     if !args.options(b"--path-ignore-patterns").is_empty() {
         ctx.test_options.path_ignore_patterns =
             slice_to_owned(args.options(b"--path-ignore-patterns"));
-        ctx.test_options.path_ignore_patterns_from_cli = true;
     }
 
     if let Some(bail) = args.option(b"--bail") {
@@ -1939,12 +1939,13 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
         );
         Global::exit(1);
     }
-    ctx.test_options.update_snapshots = args.flag(b"--update-snapshots");
-    ctx.test_options.run_todo = args.flag(b"--todo");
-    ctx.test_options.only = args.flag(b"--only");
-    ctx.test_options.pass_with_no_tests = args.flag(b"--pass-with-no-tests");
-    ctx.test_options.concurrent = args.flag(b"--concurrent");
-    ctx.test_options.randomize = args.flag(b"--randomize");
+    // `|=`: bunfig.toml is already applied, and an absent flag must not reset its key.
+    ctx.test_options.update_snapshots |= args.flag(b"--update-snapshots");
+    ctx.test_options.run_todo |= args.flag(b"--todo");
+    ctx.test_options.only |= args.flag(b"--only");
+    ctx.test_options.pass_with_no_tests |= args.flag(b"--pass-with-no-tests");
+    ctx.test_options.concurrent |= args.flag(b"--concurrent");
+    ctx.test_options.randomize |= args.flag(b"--randomize");
     let no_isolate = args.flag(b"--no-isolate");
     ctx.test_options.isolate = args.flag(b"--isolate") && !no_isolate;
     ctx.test_options.test_worker = args.flag(b"--test-worker");
@@ -1999,6 +2000,15 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
                 Global::exit(1);
             }
         };
+    }
+
+    // Only a bunfig `seed` can reach this without `randomize`: `--seed` sets both.
+    if ctx.test_options.seed.is_some() && !ctx.test_options.randomize {
+        bun_core::pretty_errorln!(
+            "<r><red>error<r>: \"seed\" can only be used when \"randomize\" is true"
+        );
+        Output::flush();
+        Global::exit(1);
     }
 }
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2005,7 +2005,7 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
     // Only a bunfig `seed` can reach this without `randomize`: `--seed` sets both.
     if ctx.test_options.seed.is_some() && !ctx.test_options.randomize {
         bun_core::pretty_errorln!(
-            "<r><red>error<r>: \"seed\" can only be used when \"randomize\" is true"
+            "<r><red>error<r>: \"seed\" in bunfig.toml can only be used when \"randomize\" is true or --randomize is passed"
         );
         Output::flush();
         Global::exit(1);

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -313,12 +313,10 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
     // (see test_command.rs handle_test_completed), which the coordinator would
     // misread as a crash. Cross-worker bail is handled at file granularity by
     // the coordinator instead.
-    if opts.repeat_count > 0 {
-        argv.push(print_z(format_args!("--rerun-each={}", opts.repeat_count))?);
-    }
-    if opts.retry > 0 {
-        argv.push(print_z(format_args!("--retry={}", opts.retry))?);
-    }
+    // Always forwarded: a worker reloads bunfig.toml, and 0 may be the
+    // coordinator's `--retry 0` override of a `[test] retry` key.
+    argv.push(print_z(format_args!("--rerun-each={}", opts.repeat_count))?);
+    argv.push(print_z(format_args!("--retry={}", opts.retry))?);
     argv.push(print_z(format_args!(
         "--max-concurrency={}",
         opts.max_concurrency

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -313,8 +313,7 @@ fn build_worker_argv(ctx: &Command::ContextData) -> crate::Result<Box<[bun_spawn
     // (see test_command.rs handle_test_completed), which the coordinator would
     // misread as a crash. Cross-worker bail is handled at file granularity by
     // the coordinator instead.
-    // Always forwarded: a worker reloads bunfig.toml, and 0 may be the
-    // coordinator's `--retry 0` override of a `[test] retry` key.
+    // Forwarded even when 0: the worker reloads bunfig.toml, and 0 may override its `[test]` key.
     argv.push(print_z(format_args!("--rerun-each={}", opts.repeat_count))?);
     argv.push(print_z(format_args!("--retry={}", opts.retry))?);
     argv.push(print_z(format_args!(

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 
 describe("bunfig.toml test options", () => {
   test("randomize with seed produces consistent order", async () => {
@@ -195,5 +197,204 @@ describe("bunfig.toml test options", () => {
     const output = stdout + stderr;
     // 2 tests * 2 reruns = 4 total test runs
     expect(output).toContain("4 pass");
+  });
+
+  // A `bun test` flag wins over the same `[test]` key in bunfig.toml.
+  describe("[test] keys and command line flags", () => {
+    const files = {
+      "helper.ts": `
+        export function covered() { return 1; }
+        export function uncovered() { return 2; }
+      `,
+      "a.test.ts": `
+        import { test, expect } from "bun:test";
+        import { covered } from "./helper";
+        test("alpha", () => expect(covered()).toBe(1));
+        test("bravo", () => expect(2).toBe(2));
+      `,
+    };
+
+    async function runTest(dir: string, ...flags: string[]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", ...flags, "a.test.ts"],
+        env: bunEnv,
+        cwd: dir,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    test.concurrent("--reporter-outfile wins over [test.reporter] junit", async () => {
+      using dir = tempDir("bunfig-reporter-outfile-cli", {
+        ...files,
+        "bunfig.toml": `[test.reporter]\njunit = "from-bunfig.xml"`,
+      });
+
+      const { stderr, exitCode } = await runTest(
+        String(dir),
+        "--reporter=junit",
+        `--reporter-outfile=${join(String(dir), "cli.xml")}`,
+      );
+      expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
+
+      expect(existsSync(join(String(dir), "from-bunfig.xml"))).toBe(false);
+      const xml = readFileSync(join(String(dir), "cli.xml"), "utf8");
+      expect(xml).toContain("<testsuites");
+      expect(xml).toContain('name="alpha"');
+      expect(xml).toContain('name="bravo"');
+    });
+
+    test.concurrent("--reporter-outfile without --reporter names the file for [test.reporter] junit", async () => {
+      using dir = tempDir("bunfig-reporter-outfile-only", {
+        ...files,
+        "bunfig.toml": `[test.reporter]\njunit = "from-bunfig.xml"`,
+      });
+
+      const { stderr, exitCode } = await runTest(String(dir), `--reporter-outfile=${join(String(dir), "cli.xml")}`);
+      expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
+
+      expect(existsSync(join(String(dir), "from-bunfig.xml"))).toBe(false);
+      expect(readFileSync(join(String(dir), "cli.xml"), "utf8")).toContain('name="alpha"');
+    });
+
+    test.concurrent("[test.reporter] junit writes its own path when the command line has no outfile", async () => {
+      using dir = tempDir("bunfig-reporter-junit-default", {
+        ...files,
+        "bunfig.toml": `[test.reporter]\njunit = "from-bunfig.xml"`,
+      });
+
+      const { stderr, exitCode } = await runTest(String(dir));
+      expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
+
+      expect(readFileSync(join(String(dir), "from-bunfig.xml"), "utf8")).toContain('name="alpha"');
+    });
+
+    test.concurrent("--dots wins over [test.reporter] dots = false", async () => {
+      using dir = tempDir("bunfig-reporter-dots-cli", {
+        ...files,
+        "bunfig.toml": `[test.reporter]\ndots = false`,
+      });
+
+      const { stdout, stderr, exitCode } = await runTest(String(dir), "--dots");
+      expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
+
+      const output = stdout + stderr;
+      expect(output).toContain("..");
+      expect(output).not.toContain("(pass)");
+    });
+
+    test.concurrent("[test.reporter] dots = true still applies next to --reporter=junit", async () => {
+      using dir = tempDir("bunfig-reporter-dots-and-junit", {
+        ...files,
+        "bunfig.toml": `[test.reporter]\ndots = true`,
+      });
+
+      const { stdout, stderr, exitCode } = await runTest(
+        String(dir),
+        "--reporter=junit",
+        `--reporter-outfile=${join(String(dir), "cli.xml")}`,
+      );
+      expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
+
+      const output = stdout + stderr;
+      expect(output).toContain("..");
+      expect(output).not.toContain("(pass)");
+      expect(readFileSync(join(String(dir), "cli.xml"), "utf8")).toContain('name="alpha"');
+    });
+
+    test.concurrent("--reporter=junit accepts the outfile from [test.reporter] junit", async () => {
+      using dir = tempDir("bunfig-reporter-junit-flag-only", {
+        ...files,
+        "bunfig.toml": `[test.reporter]\njunit = "from-bunfig.xml"`,
+      });
+
+      const { stderr, exitCode } = await runTest(String(dir), "--reporter=junit");
+      expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
+
+      expect(readFileSync(join(String(dir), "from-bunfig.xml"), "utf8")).toContain('name="alpha"');
+    });
+
+    test.concurrent("--coverage wins over [test] coverage = false", async () => {
+      using dir = tempDir("bunfig-coverage-cli", {
+        ...files,
+        "bunfig.toml": `[test]\ncoverage = false`,
+      });
+
+      const { stdout, stderr, exitCode } = await runTest(String(dir), "--coverage");
+      expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
+
+      const output = stdout + stderr;
+      expect(output).toContain("% Funcs");
+      expect(output).toContain("helper.ts");
+    });
+
+    test.concurrent("--only-failures wins over [test] onlyFailures = false", async () => {
+      using dir = tempDir("bunfig-only-failures-cli", {
+        ...files,
+        "bunfig.toml": `[test]\nonlyFailures = false`,
+      });
+
+      const { stdout, stderr, exitCode } = await runTest(String(dir), "--only-failures");
+      expect(stderr).toContain("2 pass");
+      expect(exitCode).toBe(0);
+
+      expect(stdout + stderr).not.toContain("(pass)");
+    });
+
+    test.concurrent("--randomize wins over [test] randomize = false", async () => {
+      using dir = tempDir("bunfig-randomize-cli", {
+        ...files,
+        "bunfig.toml": `[test]\nrandomize = false`,
+      });
+
+      const { stderr, exitCode } = await runTest(String(dir), "--randomize");
+      expect(stderr).toContain("2 pass");
+      expect(stderr).toMatch(/--seed=\d+/);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("--randomize satisfies the randomize requirement of [test] seed", async () => {
+      using dir = tempDir("bunfig-seed-cli-randomize", {
+        ...files,
+        "bunfig.toml": `[test]\nseed = 2444615283`,
+      });
+
+      const { stderr, exitCode } = await runTest(String(dir), "--randomize");
+      expect(stderr).toContain("2 pass");
+      expect(stderr).toContain("--seed=2444615283");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("--rerun-each wins over [test] rerunEach", async () => {
+      using dir = tempDir("bunfig-rerun-each-cli", {
+        ...files,
+        "bunfig.toml": `[test]\nrerunEach = 3`,
+      });
+
+      const { stderr, exitCode } = await runTest(String(dir), "--rerun-each", "1");
+      expect(stderr).toContain("2 pass");
+      expect(stderr).not.toContain("6 pass");
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("--rerun-each still conflicts with [test] retry", async () => {
+      using dir = tempDir("bunfig-retry-vs-cli-rerun-each", {
+        ...files,
+        "bunfig.toml": `[test]\nretry = 2`,
+      });
+
+      const { stderr, exitCode } = await runTest(String(dir), "--rerun-each", "2");
+      expect(stderr).toMatch(/retry.* cannot be used with .*rerun/i);
+      expect(exitCode).toBe(1);
+    });
   });
 });

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -238,13 +238,12 @@ describe("bunfig.toml test options", () => {
         `--reporter-outfile=${join(String(dir), "cli.xml")}`,
       );
       expect(stderr).toContain("2 pass");
-      expect(exitCode).toBe(0);
-
       expect(existsSync(join(String(dir), "from-bunfig.xml"))).toBe(false);
       const xml = readFileSync(join(String(dir), "cli.xml"), "utf8");
       expect(xml).toContain("<testsuites");
       expect(xml).toContain('name="alpha"');
       expect(xml).toContain('name="bravo"');
+      expect(exitCode).toBe(0);
     });
 
     test.concurrent("--reporter-outfile without --reporter names the file for [test.reporter] junit", async () => {
@@ -255,10 +254,9 @@ describe("bunfig.toml test options", () => {
 
       const { stderr, exitCode } = await runTest(String(dir), `--reporter-outfile=${join(String(dir), "cli.xml")}`);
       expect(stderr).toContain("2 pass");
-      expect(exitCode).toBe(0);
-
       expect(existsSync(join(String(dir), "from-bunfig.xml"))).toBe(false);
       expect(readFileSync(join(String(dir), "cli.xml"), "utf8")).toContain('name="alpha"');
+      expect(exitCode).toBe(0);
     });
 
     test.concurrent("[test.reporter] junit writes its own path when the command line has no outfile", async () => {
@@ -269,9 +267,8 @@ describe("bunfig.toml test options", () => {
 
       const { stderr, exitCode } = await runTest(String(dir));
       expect(stderr).toContain("2 pass");
-      expect(exitCode).toBe(0);
-
       expect(readFileSync(join(String(dir), "from-bunfig.xml"), "utf8")).toContain('name="alpha"');
+      expect(exitCode).toBe(0);
     });
 
     test.concurrent("--dots wins over [test.reporter] dots = false", async () => {
@@ -282,11 +279,10 @@ describe("bunfig.toml test options", () => {
 
       const { stdout, stderr, exitCode } = await runTest(String(dir), "--dots");
       expect(stderr).toContain("2 pass");
-      expect(exitCode).toBe(0);
-
       const output = stdout + stderr;
       expect(output).toContain("..");
       expect(output).not.toContain("(pass)");
+      expect(exitCode).toBe(0);
     });
 
     test.concurrent("[test.reporter] dots = true still applies next to --reporter=junit", async () => {
@@ -301,12 +297,11 @@ describe("bunfig.toml test options", () => {
         `--reporter-outfile=${join(String(dir), "cli.xml")}`,
       );
       expect(stderr).toContain("2 pass");
-      expect(exitCode).toBe(0);
-
       const output = stdout + stderr;
       expect(output).toContain("..");
       expect(output).not.toContain("(pass)");
       expect(readFileSync(join(String(dir), "cli.xml"), "utf8")).toContain('name="alpha"');
+      expect(exitCode).toBe(0);
     });
 
     test.concurrent("--reporter=junit accepts the outfile from [test.reporter] junit", async () => {
@@ -317,9 +312,8 @@ describe("bunfig.toml test options", () => {
 
       const { stderr, exitCode } = await runTest(String(dir), "--reporter=junit");
       expect(stderr).toContain("2 pass");
-      expect(exitCode).toBe(0);
-
       expect(readFileSync(join(String(dir), "from-bunfig.xml"), "utf8")).toContain('name="alpha"');
+      expect(exitCode).toBe(0);
     });
 
     test.concurrent("--coverage wins over [test] coverage = false", async () => {
@@ -330,11 +324,10 @@ describe("bunfig.toml test options", () => {
 
       const { stdout, stderr, exitCode } = await runTest(String(dir), "--coverage");
       expect(stderr).toContain("2 pass");
-      expect(exitCode).toBe(0);
-
       const output = stdout + stderr;
       expect(output).toContain("% Funcs");
       expect(output).toContain("helper.ts");
+      expect(exitCode).toBe(0);
     });
 
     test.concurrent("--only-failures wins over [test] onlyFailures = false", async () => {
@@ -345,9 +338,8 @@ describe("bunfig.toml test options", () => {
 
       const { stdout, stderr, exitCode } = await runTest(String(dir), "--only-failures");
       expect(stderr).toContain("2 pass");
-      expect(exitCode).toBe(0);
-
       expect(stdout + stderr).not.toContain("(pass)");
+      expect(exitCode).toBe(0);
     });
 
     test.concurrent("--randomize wins over [test] randomize = false", async () => {

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -330,6 +330,32 @@ describe("bunfig.toml test options", () => {
       expect(exitCode).toBe(0);
     });
 
+    test.concurrent("--coverage-reporter wins over [test] coverageReporter", async () => {
+      using dir = tempDir("bunfig-coverage-reporter-cli", {
+        ...files,
+        "bunfig.toml": `[test]\ncoverage = true\ncoverageReporter = "lcov"`,
+      });
+
+      const { stdout, stderr, exitCode } = await runTest(String(dir), "--coverage-reporter", "text");
+      expect(stderr).toContain("2 pass");
+      expect(stdout + stderr).toContain("% Funcs");
+      expect(existsSync(join(String(dir), "coverage", "lcov.info"))).toBe(false);
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("--coverage-dir wins over [test] coverageDir", async () => {
+      using dir = tempDir("bunfig-coverage-dir-cli", {
+        ...files,
+        "bunfig.toml": `[test]\ncoverage = true\ncoverageReporter = "lcov"\ncoverageDir = "from-bunfig"`,
+      });
+
+      const { stderr, exitCode } = await runTest(String(dir), "--coverage-dir", "from-cli");
+      expect(stderr).toContain("2 pass");
+      expect(existsSync(join(String(dir), "from-bunfig"))).toBe(false);
+      expect(readFileSync(join(String(dir), "from-cli", "lcov.info"), "utf8")).toContain("SF:");
+      expect(exitCode).toBe(0);
+    });
+
     test.concurrent("--only-failures wins over [test] onlyFailures = false", async () => {
       using dir = tempDir("bunfig-only-failures-cli", {
         ...files,

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -414,5 +414,40 @@ describe("bunfig.toml test options", () => {
       expect(stderr).toMatch(/retry.* cannot be used with .*rerun/i);
       expect(exitCode).toBe(1);
     });
+
+    // A --parallel worker loads bunfig.toml again. It must receive the
+    // coordinator's --retry 0, or the bunfig retry would apply in the worker.
+    // Two files: with one file the coordinator runs it in-process, no worker.
+    test.concurrent("--retry 0 wins over [test] retry in --parallel workers", async () => {
+      const failsOnce = (marker: string) => `
+        import { test } from "bun:test";
+        import { existsSync, writeFileSync } from "node:fs";
+        test("fails on the first attempt", () => {
+          const marker = import.meta.dir + "/${marker}";
+          if (!existsSync(marker)) {
+            writeFileSync(marker, "");
+            throw new Error("first attempt");
+          }
+        });
+      `;
+      using dir = tempDir("bunfig-retry-parallel-cli", {
+        "one.test.ts": failsOnce("first-attempt-one"),
+        "two.test.ts": failsOnce("first-attempt-two"),
+        "bunfig.toml": `[test]\nretry = 2`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--parallel=2", "--retry", "0"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const output = stdout + stderr;
+      expect(output).not.toContain("(attempt 2)");
+      expect(output).toContain("2 fail");
+      expect(exitCode).toBe(1);
+    });
   });
 });

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -392,6 +392,19 @@ describe("bunfig.toml test options", () => {
       expect(exitCode).toBe(0);
     });
 
+    test.concurrent("--seed wins over [test] seed", async () => {
+      using dir = tempDir("bunfig-seed-cli", {
+        ...files,
+        "bunfig.toml": `[test]\nrandomize = true\nseed = 2`,
+      });
+
+      const { stderr, exitCode } = await runTest(String(dir), "--seed", "1");
+      expect(stderr).toContain("2 pass");
+      expect(stderr).toContain("--seed=1");
+      expect(stderr).not.toContain("--seed=2");
+      expect(exitCode).toBe(0);
+    });
+
     test.concurrent("--rerun-each wins over [test] rerunEach", async () => {
       using dir = tempDir("bunfig-rerun-each-cli", {
         ...files,


### PR DESCRIPTION
### Problem
- With `[test.reporter] junit = "from-bunfig.xml"` in bunfig.toml, `bun test --reporter=junit --reporter-outfile=cli.xml` writes `from-bunfig.xml` and never creates `cli.xml`. The same inversion hits `coverage` (#12216), `reporter.dots`, `onlyFailures`, `randomize`, `rerunEach` and `retry`, although the docs promise that the flag wins.
- Cause: `Arguments::parse` (`src/runtime/cli/Arguments.rs`) applied the `bun test` flags before it loaded bunfig.toml. Every other flag group runs after the load. The loader's `[test]` block (`src/bunfig/bunfig.rs`) then overwrote the flag values.

### Fix
- Move the `parse_test_command_options` call below `load_config_with_cmd_args`. Enable-only flags (`--randomize`, `--only`, ...) use `|=`, and `--isolate`/`--no-isolate` set `isolate` only when present, so an absent flag keeps the bunfig value. Every write in that function is now an override.
- The seed-requires-randomize check moves from the loader to the end of the flag parse, where both sources are known, so a bunfig `seed` with `--randomize` keeps working.
- `path_ignore_patterns_from_cli`, the one guard written for the old order, is removed. The `--parallel` coordinator now forwards `--retry` and `--rerun-each` to workers even when they are 0, because a worker loads bunfig.toml again (`src/runtime/cli/test/parallel/runner.rs`).
- Correct because `[test]` now follows the rule of every other bunfig section: the file is the default, the flag is the override.
- Verified: `test/cli/bunfig-test-options.test.ts` (16 new tests, stock bun fails 12), the `bun test` CLI suites and `test/config/bunfig`.

### Background
- `TestOptions` (`src/options_types/context.rs`) holds the `bun test` settings. Its two writers are the flag parser in `Arguments.rs` and the `[test]` block in `bunfig.rs`. The later writer wins per field.
- `bun test` reads one bunfig.toml, not the global file (`command_tag.rs`, `read_global_config`).
- Behavior changes only when a key and its flag are both present, plus two deltas: `--reporter=junit` is accepted when bunfig supplies the junit path, and a bunfig `retry` with `--rerun-each` errors from the flag parser instead of the bunfig parser (exit 1 both ways).

Closes #12216

<details><summary>Notes</summary>

- Repro: a temp dir with the bunfig above and one test file. `bun test --reporter=junit --reporter-outfile=cli.xml ./b.test.ts` then `ls *.xml` prints only `from-bunfig.xml` on bun 1.4.0. With this change it prints only `cli.xml`.
- The first version of this PR guarded only the two `[test.reporter]` assignments in the loader (`reporter_outfile.is_none()`, `!reporters.dots`). A review of that diff found that the same order problem exists for every `[test]` key, that the guards were a second idiom next to `path_ignore_patterns_from_cli`, and that an "assign only when unset" guard would make a first-loaded file win over a second one if bun ever loads two bunfig files for `bun test` (#28727). The reorder fixes the cause instead.
- The Zig version had the same order (Arguments.zig:497-699 before the rewrite), so this is not a rewrite regression.
- #36669 and #28547 (both closed in favor of this PR) guarded `coverage`, `coverageReporter` and `coverageDir` with `_from_cli` flags. The order change covers those keys, so the guards are not needed. Their `--coverage-reporter` and `--coverage-dir` cases are in the test file here.
- Open PRs on the same lines: #39258, #39259 and #39260 add `[test] parallel`, `concurrent` and `timeout` with `_from_cli` guards. After this lands the guards are dead code, and #39258 can rely on the presence-gated `isolate` write to keep the value it sets from bunfig. #30284 keeps `path_ignore_patterns_from_cli`, which this PR deletes. #38599, #33198 and #38611 handle `bun run`, which loads bunfig.toml after the flags, so a reorder cannot help there. They are untouched by this PR.
- No `[test]` key maps to `isolate`, `test_worker` or `update_timings` today. Their writes are presence-gated so that `parse_test_command_options` has one contract (see its doc comment) and a future key is not reset by an absent flag.
- The `--reporter=junit requires --reporter-outfile` check is unchanged in code. It now runs after the load, so a bunfig junit path satisfies it.
- The `retry` handler in the loader still rejects `retry` and `rerunEach` in one file. The mirror check in the `rerunEach` handler could no longer fire (the loader runs before any flag, and `retry` is read after `rerunEach`), so it is removed. A cross-source conflict is caught by the existing `--retry cannot be used with --rerun-each` check at the end of the flag parse.
- The seed error loses the bunfig.toml line pointer because the check no longer runs inside the parser. The message now names bunfig.toml and `--randomize` instead.
- `--parallel` workers: with one test file the coordinator runs it in-process, so a worker test needs two files. Before this PR a coordinator that resolved `--retry 0` over `[test] retry = 2` forwarded nothing, and the worker retried twice.
- `[test] smol` has the same `=` clobber at `Arguments.rs:1187`, in the shared runtime block. #38611 fixes it for both load orders and is left as is.
- Docs: `docs/runtime/bunfig.mdx` now names the CLI flag for `test.reporter.dots` and `test.reporter.junit`, like the other `[test]` keys.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/bunfig-test-options.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/bunfig-test-options.test.ts:
(pass) bunfig.toml test options > randomize with seed produces consistent order [642.08ms]
(pass) bunfig.toml test options > seed without randomize errors [189.69ms]
(pass) bunfig.toml test options > seed with randomize=false errors [121.85ms]
(pass) bunfig.toml test options > rerunEach option works [294.45ms]
(pass) bunfig.toml test options > all test options together [360.67ms]
236 |         String(dir),
237 |         "--reporter=junit",
238 |         `--reporter-outfile=${join(String(dir), "cli.xml")}`,
239 |       );
240 |       expect(stderr).toContain("2 pass");
241 |       expect(existsSync(join(String(dir), "from-bunfig.xml"))).toBe(false);
                                                                     ^
error: expect(received).toBe(expected)

Expected: false
Received: true

      at <anonymous> (/workspace/bun/test/cli/bunfig-test-options.test.ts:241:64)
(fail) bunfig.toml test options > [test] keys and command line fl
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (61966e810)

test/cli/bunfig-test-options.test.ts:
(pass) bunfig.toml test options > randomize with seed produces consistent order [18.28ms]
(pass) bunfig.toml test options > seed without randomize errors [3.28ms]
(pass) bunfig.toml test options > seed with randomize=false errors [2.08ms]
(pass) bunfig.toml test options > rerunEach option works [7.90ms]
(pass) bunfig.toml test options > all test options together [6.51ms]
(pass) bunfig.toml test options > [test] keys and command line flags > --reporter-outfile wins over [test.reporter] junit [13.21ms]
(pass) bunfig.toml test options > [test] keys and command line flags > --reporter-outfile without --reporter names the file for [test.reporter] junit [12.30ms]
(pass) bunfig.toml test options > [test] keys and command line flags > [test.reporter] junit writes its own path when the command line has no outfile [11.65ms]
(pass) bunfig.toml test options > [test] keys and command line flags > --dots wins over [test.reporter] dots = false [10.93ms]
(pass) bunfig.toml test options > [test] keys and command line flags > [test.reporter] dots = true still applies next to --reporter=junit [10.44ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/bunfig-test-options.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/bunfig-test-options.test.ts:
(pass) bunfig.toml test options > randomize with seed produces consistent order [697.58ms]
(pass) bunfig.toml test options > seed without randomize errors [120.26ms]
(pass) bunfig.toml test options > seed with randomize=false errors [116.32ms]
(pass) bunfig.toml test options > rerunEach option works [289.42ms]
(pass) bunfig.toml test options > all test options together [295.38ms]
(pass) bunfig.toml test options > [test] keys and command line flags > --reporter-outfile wins over [test.reporter] junit [294.20ms]
(pass) bunfig.toml test options > [test] keys and command line flags > --reporter-outfile without --reporter names the file for [test.reporter] junit [284.23ms]
(pass) bunfig.toml test options > [test] keys and command line flags > [test.reporter] junit writes its own path when the command line has no outfile [286.31ms]
(pass) bunfig.toml test options > [test] keys and command line flags > --dots wins over [test.reporter] dots 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 628ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/126] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/126] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 244 extern-C blocks audited
[3/126] gen cpp.rs (cppbind)
[4/126] gen JS modules (bundle-modules)
Preprocess modules (7525ms)
Bundle modules (38ms)
Postprocesss modules (177ms)
Bundle Functions (467ms)
Generate Code (47ms)

[8.26s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[4/125] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   C
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/bunfig.mdx                 |   4 +-
 src/bunfig/bunfig.rs                    |  29 +---
 src/options_types/context.rs            |   2 -
 src/runtime/cli/Arguments.rs            |  46 ++++--
 src/runtime/cli/test/parallel/runner.rs |   9 +-
 test/cli/bunfig-test-options.test.ts    | 267 ++++++++++++++++++++++++++++++++
 6 files changed, 309 insertions(+), 48 deletions(-)
```

</details>

**gate history** · 4 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
docs/runtime/bunfig.mdx                      1      1      0
src/bunfig/bunfig.rs                         8      7      0
src/options_types/context.rs                 1      2      0
src/runtime/cli/Arguments.rs                 9      9      0
src/runtime/cli/test/parallel/runner.rs      7      3      0
test/cli/bunfig-test-options.test.ts         4      7      0
```

</details>

<!-- robobun:evidence:end -->
