### PR TITLE
Run Error.prepareStackTrace even when a GC happens before the first .stack read

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "c148a12dd82b9d88ea81d9d93840194f56490a61";
+export const WEBKIT_VERSION = "autobuild-preview-pr-510-8f7ed779";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -265,6 +265,11 @@ public:
     Bun::StrongRootBlock* m_strongRootBlockCursor { nullptr };
     JSC::Structure* m_strongRootBlockStructure { nullptr };
 
+    // Zig::GlobalObjects on this VM with a callable user Error.prepareStackTrace (ShadowRealm and
+    // `bun test --isolate` globals share the VM). VM::keepsErrorStackFramesAlive() is set while it
+    // is non-zero. Maintained by Zig::GlobalObject::setHasUserPrepareStackTrace.
+    unsigned realmsWithUserPrepareStackTrace { 0 };
+
     // Backing storage for Bun::IsolatedModuleCache (see IsolatedModuleCache.h).
     // All access should go through that class. Stored as the JSC base type to
     // avoid pulling ZigSourceProvider.h into this header; the cache class

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -670,7 +670,13 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
     }
 
     if (source->stackTrace()) {
-        destination->stackTrace()->appendVector(*source->stackTrace());
+        // ErrorInstance::visitChildren reads the frames from GC marking threads under the cell lock.
+        {
+            WTF::Locker locker { destination->cellLock() };
+            destination->stackTrace()->appendVector(*source->stackTrace());
+        }
+        vm.writeBarrier(destination);
+        WTF::Locker locker { source->cellLock() };
         source->stackTrace()->clear();
     }
 
@@ -721,7 +727,12 @@ JSC_DEFINE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter, (JSGlobalObject * g
         WTF::Vector<JSC::StackFrame> emptyTrace;
         result = computeErrorInfoToJSValue(vm, emptyTrace, line, column, sourceURL, errorObject, nullptr);
     } else {
-        auto ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>(WTF::move(*stackTrace));
+        auto ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>();
+        {
+            // ErrorInstance::visitChildren reads the frames from GC marking threads under the cell lock.
+            WTF::Locker locker { errorObject->cellLock() };
+            *ownedStackTrace = WTF::move(*stackTrace);
+        }
         JSC::MarkedArgumentBuffer protectedFrameCells;
         protectedFrameCells.ensureCapacity(ownedStackTrace->size() * 2);
         for (auto& frame : *ownedStackTrace) {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1093,11 +1093,17 @@ JSC_DEFINE_CUSTOM_SETTER(errorConstructorPrepareStackTraceSetter,
     auto& vm = JSC::getVM(lexicalGlobalObject);
     Zig::GlobalObject* thisObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     JSValue value = JSValue::decode(encodedValue);
-    if (value == thisObject->m_errorConstructorPrepareStackTraceInternalValue.get(thisObject)) {
+    bool isUserValue = value != thisObject->m_errorConstructorPrepareStackTraceInternalValue.get(thisObject);
+    if (!isUserValue) {
         thisObject->m_errorConstructorPrepareStackTraceValue.clear();
     } else {
         thisObject->m_errorConstructorPrepareStackTraceValue.set(vm, thisObject, value);
     }
+
+    // The callback runs at the first .stack read and needs the error's frames. JSC holds them
+    // weakly and renders the stack string in the GC end phase once one dies, where no JS can run.
+    // Keep them alive while a user formatter is installed, as V8 does.
+    vm.setKeepsErrorStackFramesAlive(isUserValue && value.isCallable());
 
     return true;
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1015,6 +1015,8 @@ GlobalObject::GlobalObject(JSC::VM& vm, JSC::Structure* structure, WebCore::Scri
 
 GlobalObject::~GlobalObject()
 {
+    // A `bun test --isolate` global that dies with a formatter installed must not keep the VM flag set.
+    setHasUserPrepareStackTrace(false);
     m_scriptExecutionContext->globalObjectDestroyed();
     m_scriptExecutionContext->deref();
 }
@@ -1099,13 +1101,26 @@ JSC_DEFINE_CUSTOM_SETTER(errorConstructorPrepareStackTraceSetter,
     } else {
         thisObject->m_errorConstructorPrepareStackTraceValue.set(vm, thisObject, value);
     }
+    thisObject->setHasUserPrepareStackTrace(isUserValue && value.isCallable());
+
+    return true;
+}
+
+void GlobalObject::setHasUserPrepareStackTrace(bool value)
+{
+    if (m_hasUserPrepareStackTrace == value)
+        return;
+    m_hasUserPrepareStackTrace = value;
 
     // The callback runs at the first .stack read and needs the error's frames. JSC holds them
     // weakly and renders the stack string in the GC end phase once one dies, where no JS can run.
-    // Keep them alive while a user formatter is installed, as V8 does.
-    vm.setKeepsErrorStackFramesAlive(isUserValue && value.isCallable());
-
-    return true;
+    // Keep them alive while any realm on this VM has a user formatter, as V8 does.
+    auto& count = WebCore::clientData(vm())->realmsWithUserPrepareStackTrace;
+    if (value)
+        count++;
+    else
+        count--;
+    vm().setKeepsErrorStackFramesAlive(count > 0);
 }
 
 #pragma mark - Globals

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -429,6 +429,10 @@ public:
     double INSPECT_MAX_BYTES = 50;
     bool isInsideErrorPrepareStackTraceCallback = false;
 
+    // Whether this realm has a callable user Error.prepareStackTrace. Counted per VM in
+    // JSVMClientData::realmsWithUserPrepareStackTrace, which drives VM::keepsErrorStackFramesAlive().
+    void setHasUserPrepareStackTrace(bool);
+
     template<typename T>
     using LazyPropertyOfGlobalObject = LazyProperty<JSGlobalObject, T>;
 
@@ -826,6 +830,7 @@ public:
 
 private:
     InFlightRejections* m_rejectedPromisesBeingProcessed { nullptr };
+    bool m_hasUserPrepareStackTrace { false };
 };
 
 class EvalGlobalObject : public GlobalObject {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1294,4 +1294,20 @@ describe("Error.prepareStackTrace when a GC runs before the first .stack read", 
       exitCode: 0,
     });
   });
+
+  test("another realm on the same VM resetting its own formatter does not affect this one", async () => {
+    // A ShadowRealm gets its own Zig::GlobalObject on the same VM, with its own Error.prepareStackTrace.
+    using dir = tempDir("prepare-stack-trace-gc-realms", {
+      "fixture.mjs": [
+        `Error.prepareStackTrace = (error, sites) => "custom:" + error.message;`,
+        `const realm = new ShadowRealm();`,
+        `realm.evaluate("Error.prepareStackTrace = (error, sites) => 'shadow:' + error.message; Error.prepareStackTrace = undefined; 0");`,
+        `const error = new Function("return new Error('main')")();`,
+        `Bun.gc(true);`,
+        `console.log(JSON.stringify({ stack: error.stack }));`,
+      ].join("\n"),
+    });
+
+    expect(await runFixture(dir, [])).toEqual({ result: { stack: "custom:main" }, stderr: "", exitCode: 0 });
+  });
 });

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1,6 +1,6 @@
 import { nativeFrameForTesting } from "bun:internal-for-testing";
 import { noInline } from "bun:jsc";
-import { afterEach, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 const origPrepareStackTrace = Error.prepareStackTrace;
 afterEach(() => {
@@ -1193,4 +1193,105 @@ test("Error.prepareStackTrace call sites keep their own file when a hidden frame
     { showPrivateScriptsInStackTraces: "0", callSites: expected, stderr: "", exitCode: 0 },
     { showPrivateScriptsInStackTraces: "1", callSites: expected, stderr: "", exitCode: 0 },
   ]);
+});
+
+// JSC holds an error's stack frames weakly. Once a frame's callee dies, the GC renders the stack
+// string itself, where Error.prepareStackTrace cannot run. While a user formatter is installed, the
+// frames must stay alive until the first .stack read, so that a GC in between is not observable.
+describe("Error.prepareStackTrace when a GC runs before the first .stack read", () => {
+  async function runFixture(dir, args) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.mjs", ...args],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { result: stdout && JSON.parse(stdout), stderr, exitCode };
+  }
+
+  test("the formatter runs and receives the call sites", async () => {
+    // Each error's frames hold a callee that is garbage right after the call: the per-call closure
+    // of an async function body, and a `new Function` callee. Error.captureStackTrace goes through
+    // Bun's lazy .stack getter over the same frames.
+    using dir = tempDir("prepare-stack-trace-gc", {
+      "fixture.mjs": [
+        `import { basename } from "node:path";`,
+        `const callSites = {};`,
+        `Error.prepareStackTrace = (error, sites) => {`,
+        `  callSites[error.message] = sites.map(site => site.getFunctionName() + "@" + basename(site.getFileName()));`,
+        `  return "custom:" + error.message;`,
+        `};`,
+        `async function boom() {`,
+        `  throw new Error("async");`,
+        `}`,
+        `const fromAsync = await boom().catch(error => error);`,
+        `const fromNewFunction = new Function("return new Error('new-function')")();`,
+        `const fromCaptureStackTrace = new Function(`,
+        `  "const error = new Error('capture'); Error.captureStackTrace(error); return error;",`,
+        `)();`,
+        `if (process.argv[2] === "gc") Bun.gc(true);`,
+        `const stacks = {`,
+        `  async: fromAsync.stack,`,
+        `  newFunction: fromNewFunction.stack,`,
+        `  captureStackTrace: fromCaptureStackTrace.stack,`,
+        `};`,
+        `console.log(JSON.stringify({ stacks, callSites }));`,
+      ].join("\n"),
+    });
+
+    const [withoutGC, withGC] = await Promise.all([runFixture(dir, []), runFixture(dir, ["gc"])]);
+    expect(withoutGC).toEqual({
+      result: {
+        stacks: { async: "custom:async", newFunction: "custom:new-function", captureStackTrace: "custom:capture" },
+        callSites: {
+          "async": expect.arrayContaining(["boom@fixture.mjs"]),
+          "new-function": expect.arrayContaining(["anonymous@fixture.mjs"]),
+          "capture": expect.arrayContaining(["anonymous@fixture.mjs"]),
+        },
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+    // The GC must not be observable.
+    expect(withGC).toEqual(withoutGC);
+  });
+
+  test("a live error keeps its frames' callee alive until the first .stack read", async () => {
+    // Like V8: the frames are released when .stack is materialized. Whether a released callee is
+    // collected by a given GC is not asserted (it depends on the build), only that an unread error
+    // still holds it and that a formatter installed later is not used once it is reset.
+    using dir = tempDir("prepare-stack-trace-gc-frames", {
+      "fixture.mjs": [
+        `Error.prepareStackTrace = (error, sites) => "custom:" + error.message;`,
+        `function make(message) {`,
+        `  const callee = new Function("return new Error(" + JSON.stringify(message) + ")");`,
+        `  return { error: callee(), callee: new WeakRef(callee) };`,
+        `}`,
+        `const unread = make("unread");`,
+        `const read = make("read");`,
+        `const readStack = read.error.stack;`,
+        `Bun.gc(true);`,
+        `const unreadCalleeAlive = unread.callee.deref() !== undefined;`,
+        `const unreadStack = unread.error.stack;`,
+        `Error.prepareStackTrace = undefined;`,
+        `const afterReset = make("after-reset");`,
+        `Bun.gc(true);`,
+        `const afterResetFormatter = afterReset.error.stack.startsWith("custom:") ? "user" : "default";`,
+        `console.log(JSON.stringify({ unreadCalleeAlive, readStack, unreadStack, afterResetFormatter }));`,
+      ].join("\n"),
+    });
+
+    expect(await runFixture(dir, [])).toEqual({
+      result: {
+        unreadCalleeAlive: true,
+        readStack: "custom:read",
+        unreadStack: "custom:unread",
+        afterResetFormatter: "default",
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- With a user `Error.prepareStackTrace` installed, an error whose frames hold a dead callee at GC time gets the default stack string. Every error thrown from an async function hits this once a GC runs before the first `.stack` read (the async body is a per-call closure). Node runs the formatter.
- JSC holds the frames weakly. `ErrorInstance::reconcileWeakReferencesAtGCEnd` renders the string in the GC end phase through `computeErrorInfoWrapperToString` (`src/jsc/bindings/FormatStackTraceForJS.cpp:574`), where no JS can run, and drops the frames. The hook that honors `prepareStackTrace` runs only while the frames exist.

### Fix
- oven-sh/WebKit#510 adds `VM::setKeepsErrorStackFramesAlive(bool)`. While set, `ErrorInstance::visitChildren` marks the frames under the cell lock, so a live error keeps them until the first `.stack` read.
- The `Error.prepareStackTrace` setter counts the realms on the VM with a callable user formatter (`JSVMClientData::realmsWithUserPrepareStackTrace`) and keeps the flag set while the count is non-zero. A realm leaves the count when the property is reset or its global object dies.
- This is V8's model: V8 keeps the frames alive until the stack is formatted, and `prepareStackTrace` exists for V8 compatibility. Programs without a formatter keep JSC's weak frames and today's memory behavior.
- Verified: `test/js/node/v8/capture-stack-trace.test.js` (three new tests, all fail on stock bun). Also `test/js/bun/test/stack.test.ts`, `test/js/node/vm/vm.test.ts`, `test/js/node/util/util.test.js`.

### Background
- `ErrorInstance` is JSC's class behind every Error object. It captures a `Vector<StackFrame>` at creation and renders `error.stack` on first access.
- A `StackFrame` holds the callee function and its CodeBlock through `WriteBarrier`s that nothing marks, so an error nobody inspects does not pin functions.
- `visitChildren` is the GC marking hook of a cell. Marking threads run it concurrently with JS, so the frames are read under the cell lock, as `estimatedSize` does.
- Bun's `prepareStackTrace` support is `computeErrorInfoWrapperToJSValue`. It builds `CallSite` objects from the frames and calls the user function.

<details><summary>Notes</summary>

- `WEBKIT_VERSION` points at the preview build of oven-sh/WebKit#510 (`autobuild-preview-pr-510-8f7ed779`, the current pin c148a12d plus that change). Bump to the merged commit once #510 lands.
- `Error.appendStackTrace` and the lazy `.stack` getter now move frames under the cell lock, since marking threads read them.
- Known gaps, both with today's behavior: a formatter installed inside a node:vm context has no setter hook, so errors from that realm are not covered. A formatter installed after a GC already rendered an error's string does not run for that error.
- The count exists because a VM can host several `Zig::GlobalObject`s (ShadowRealm, `bun test --isolate`), each with its own `Error.prepareStackTrace`. A plain flag written by the last setter call let one realm clear it for another. The third test covers the ShadowRealm case. A collected `--isolate` global drops its count in `~GlobalObject`; that case is not asserted because whether a released callee is collected by a given GC is build dependent.
- The flag is a relaxed atomic read by marking threads. A stale read leaves that error's frames weak for the current cycle, which is today's behavior.
- Bun internals (`util.getCallSites`, the `isInsideNodeModules` check) install a formatter for one capture and restore the previous value. The count follows: one for that capture, zero after.
- Repro shapes: an async function body, a `new Function` callee, and `Error.captureStackTrace` inside a `new Function` callee, at the top level of a script. All three hit the GC end phase rendering on every run of stock bun 1.4.0 and of the debug ASAN build (30 and 8 runs). Shapes nested in a test function were build dependent, so the tests run the scripts in a child process.
- Whether a released callee is collected by a given `Bun.gc(true)` differs between the release and debug builds, so the tests do not assert it. They assert that an unread error keeps its callee alive (a `WeakRef` survives the GC) and that the formatter result is the same with and without a GC.
- The name/message header loss in the GC end phase rendering (#34398) is a separate path for programs without a formatter and is not changed here.

</details>
