### PR TITLE
Keep error stack frames alive until the first .stack read

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "1817c3c37f5dfc004a33dafac9f6adcf1a9641a4";
+export const WEBKIT_VERSION = "autobuild-preview-pr-511-a427c978";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -668,6 +668,13 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return {};
     }
 
+    // Once .stack is materialized the frames are gone and materializeErrorInfoIfNeeded never runs
+    // again, so frames stored now would never render and would stay alive for the whole life of
+    // the destination. Same no-op as Bun__attachAsyncStackFromPromise.
+    if (destination->hasMaterializedErrorInfo()) {
+        return JSC::JSValue::encode(jsUndefined());
+    }
+
     if (!destination->stackTrace()) {
         destination->captureStackTrace(vm, globalObject, 1);
     }

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -673,8 +673,17 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
     }
 
     if (source->stackTrace()) {
-        destination->stackTrace()->appendVector(*source->stackTrace());
-        source->stackTrace()->clear();
+        // ErrorInstance::visitChildren reads the frames under the cell lock. Take the two locks
+        // one after the other: source and destination can be the same error.
+        {
+            WTF::Locker locker { destination->cellLock() };
+            destination->stackTrace()->appendVector(*source->stackTrace());
+        }
+        {
+            WTF::Locker locker { source->cellLock() };
+            source->stackTrace()->clear();
+        }
+        vm.writeBarrier(destination);
     }
 
     return JSC::JSValue::encode(jsUndefined());
@@ -724,7 +733,12 @@ JSC_DEFINE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter, (JSGlobalObject * g
         WTF::Vector<JSC::StackFrame> emptyTrace;
         result = computeErrorInfoToJSValue(vm, emptyTrace, line, column, sourceURL, errorObject, nullptr);
     } else {
-        auto ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>(WTF::move(*stackTrace));
+        std::unique_ptr<WTF::Vector<JSC::StackFrame>> ownedStackTrace;
+        {
+            // ErrorInstance::visitChildren reads the frames under the cell lock.
+            WTF::Locker locker { errorObject->cellLock() };
+            ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>(WTF::move(*stackTrace));
+        }
         JSC::MarkedArgumentBuffer protectedFrameCells;
         protectedFrameCells.ensureCapacity(ownedStackTrace->size() * 2);
         for (auto& frame : *ownedStackTrace) {

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -668,9 +668,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return {};
     }
 
-    // Once .stack is materialized the frames are gone and materializeErrorInfoIfNeeded never runs
-    // again, so frames stored now would never render and would stay alive for the whole life of
-    // the destination. Same no-op as Bun__attachAsyncStackFromPromise.
+    // A materialized destination never renders frames again (same no-op as Bun__attachAsyncStackFromPromise).
     if (destination->hasMaterializedErrorInfo()) {
         return JSC::JSValue::encode(jsUndefined());
     }
@@ -680,8 +678,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
     }
 
     if (source->stackTrace()) {
-        // ErrorInstance::visitChildren reads the frames under the cell lock. Take the two locks
-        // one after the other: source and destination can be the same error.
+        // The GC reads these under the cell lock. Sequential scopes: source and destination can be the same error.
         {
             WTF::Locker locker { destination->cellLock() };
             destination->stackTrace()->appendVector(*source->stackTrace());

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -668,17 +668,14 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return {};
     }
 
-    // A materialized destination never renders frames again (same no-op as Bun__attachAsyncStackFromPromise).
-    if (destination->hasMaterializedErrorInfo()) {
-        return JSC::JSValue::encode(jsUndefined());
-    }
-
     if (!destination->stackTrace()) {
         destination->captureStackTrace(vm, globalObject, 1);
     }
 
     if (source->stackTrace()) {
-        // The GC reads these under the cell lock. Sequential scopes: source and destination can be the same error.
+        // ErrorInstance::visitChildren marks the frames under the cell lock, so each vector is
+        // mutated under its owner's lock, one at a time. The barrier re-greys an old destination
+        // that now points at young frames.
         {
             WTF::Locker locker { destination->cellLock() };
             destination->stackTrace()->appendVector(*source->stackTrace());

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -673,9 +673,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
     }
 
     if (source->stackTrace()) {
-        // ErrorInstance::visitChildren marks the frames under the cell lock, so each vector is
-        // mutated under its owner's lock, one at a time. The barrier re-greys an old destination
-        // that now points at young frames.
+        // The GC marks these under the cell lock; the barrier re-greys an old destination that now holds young frames.
         {
             WTF::Locker locker { destination->cellLock() };
             destination->stackTrace()->appendVector(*source->stackTrace());

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -737,23 +737,23 @@ JSC_DEFINE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter, (JSGlobalObject * g
         WTF::Vector<JSC::StackFrame> emptyTrace;
         result = computeErrorInfoToJSValue(vm, emptyTrace, line, column, sourceURL, errorObject, nullptr);
     } else {
-        std::unique_ptr<WTF::Vector<JSC::StackFrame>> ownedStackTrace;
-        {
-            // ErrorInstance::visitChildren reads the frames under the cell lock.
-            WTF::Locker locker { errorObject->cellLock() };
-            ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>(WTF::move(*stackTrace));
-        }
         JSC::MarkedArgumentBuffer protectedFrameCells;
-        protectedFrameCells.ensureCapacity(ownedStackTrace->size() * 2);
-        for (auto& frame : *ownedStackTrace) {
-            if (auto* callee = frame.callee())
-                protectedFrameCells.append(callee);
-            if (auto* codeBlock = frame.codeBlock())
-                protectedFrameCells.append(codeBlock);
-        }
+        protectedFrameCells.ensureCapacity(stackTrace->size() * 2);
         if (protectedFrameCells.hasOverflowed()) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return {};
+        }
+        std::unique_ptr<WTF::Vector<JSC::StackFrame>> ownedStackTrace;
+        {
+            // The GC reads the frames under the cell lock. Root the cells before the move takes them out of the error.
+            WTF::Locker locker { errorObject->cellLock() };
+            for (auto& frame : *stackTrace) {
+                if (auto* callee = frame.callee())
+                    protectedFrameCells.append(callee);
+                if (auto* codeBlock = frame.codeBlock())
+                    protectedFrameCells.append(codeBlock);
+            }
+            ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>(WTF::move(*stackTrace));
         }
         result = computeErrorInfoToJSValue(vm, *ownedStackTrace, line, column, sourceURL, errorObject, nullptr);
         errorObject->setStackFrames(vm, {});

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -175,3 +175,74 @@ test("Async functions frame should be included in stack trace", async () => {
         at async <anonymous> (file:NN:NN)"
   `);
 });
+
+test("error.stack is formatted lazily with live frames when a GC runs between creation and the first read", async () => {
+  // Every error here is created inside a function object that is unreachable by the time
+  // Bun.gc runs: the module's top-level callee before its first await, an IIFE, a .then
+  // callback, an async function prologue, and Error.captureStackTrace inside an IIFE.
+  // JSC used to hold the captured frames weakly and pre-render a frames-only string from the
+  // GC end phase once one of them died. That string had no message and skipped
+  // Error.prepareStackTrace.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const tla = new Error("tla message");
+       await 0;
+
+       let iife;
+       (function dies() { iife = new RangeError("iife message"); })();
+
+       let then;
+       await Promise.resolve().then(() => { then = new Error("then message"); });
+
+       async function prologue() { const e = new TypeError("prologue message"); await 0; return e; }
+       const asyncErr = await prologue();
+
+       let captured;
+       (function capturer() { captured = new Error("captured message"); Error.captureStackTrace(captured); })();
+
+       let pst;
+       (function pstFn() { pst = new Error("pst message"); })();
+
+       // Collect from a fresh microtask so no stale stack slot keeps a callee alive.
+       await 0;
+       Bun.gc(true);
+
+       const util = require("node:util");
+       const head = s => s.split("\\n")[0];
+       const results = {
+         tla: head(tla.stack),
+         iife: head(iife.stack),
+         iifeFrame: iife.stack.split("\\n")[1].trim().split(" (")[0],
+         then: head(then.stack),
+         prologue: head(asyncErr.stack),
+         prologueFrame: asyncErr.stack.split("\\n")[1].trim().split(" (")[0],
+         captured: head(captured.stack),
+         capturedFrame: captured.stack.split("\\n")[1].trim().split(" (")[0],
+         inspect: head(util.inspect(iife)),
+       };
+       Error.prepareStackTrace = (err, callSites) =>
+         "PST " + err.name + ": " + err.message + " | " + callSites.length + ":" + callSites[0].getFunctionName();
+       results.pst = head(pst.stack);
+       console.log(JSON.stringify(results));`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    tla: "Error: tla message",
+    iife: "RangeError: iife message",
+    iifeFrame: "at dies",
+    then: "Error: then message",
+    prologue: "TypeError: prologue message",
+    prologueFrame: "at prologue",
+    captured: "Error: captured message",
+    capturedFrame: "at capturer",
+    inspect: "RangeError: iife message",
+    pst: "PST Error: pst message | 2:pstFn",
+  });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -176,18 +176,20 @@ test("Async functions frame should be included in stack trace", async () => {
   `);
 });
 
-test("error.stack is formatted lazily with live frames when a GC runs between creation and the first read", async () => {
-  // Every error here is created inside a function object that is unreachable by the time
-  // Bun.gc runs: the module's top-level callee before its first await, an IIFE, a .then
-  // callback, an async function prologue, and Error.captureStackTrace inside an IIFE.
-  // JSC used to hold the captured frames weakly and pre-render a frames-only string from the
-  // GC end phase once one of them died. That string had no message and skipped
-  // Error.prepareStackTrace.
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `const tla = new Error("tla message");
+test.concurrent(
+  "error.stack is formatted lazily with live frames when a GC runs between creation and the first read",
+  async () => {
+    // Every error here is created inside a function object that is unreachable by the time
+    // Bun.gc runs: the module's top-level callee before its first await, an IIFE, a .then
+    // callback, an async function prologue, and Error.captureStackTrace inside an IIFE.
+    // JSC used to hold the captured frames weakly and pre-render a frames-only string from the
+    // GC end phase once one of them died. That string had no message and skipped
+    // Error.prepareStackTrace.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const tla = new Error("tla message");
        await 0;
 
        let iife;
@@ -226,28 +228,29 @@ test("error.stack is formatted lazily with live frames when a GC runs between cr
          "PST " + err.name + ": " + err.message + " | " + callSites.length + ":" + callSites[0].getFunctionName();
        results.pst = head(pst.stack);
        console.log(JSON.stringify(results));`,
-    ],
-    env: bunEnv,
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({
-    tla: "Error: tla message",
-    iife: "RangeError: iife message",
-    iifeFrame: "at dies",
-    then: "Error: then message",
-    prologue: "TypeError: prologue message",
-    prologueFrame: "at prologue",
-    captured: "Error: captured message",
-    capturedFrame: "at capturer",
-    inspect: "RangeError: iife message",
-    pst: "PST Error: pst message | 2:pstFn",
-  });
-  expect(exitCode).toBe(0);
-});
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      tla: "Error: tla message",
+      iife: "RangeError: iife message",
+      iifeFrame: "at dies",
+      then: "Error: then message",
+      prologue: "TypeError: prologue message",
+      prologueFrame: "at prologue",
+      captured: "Error: captured message",
+      capturedFrame: "at capturer",
+      inspect: "RangeError: iife message",
+      pst: "PST Error: pst message | 2:pstFn",
+    });
+    expect(exitCode).toBe(0);
+  },
+);
 
-test("frames stored into an old error are kept alive across an eden collection", async () => {
+test.concurrent("frames stored into an old error are kept alive across an eden collection", async () => {
   // Two full collections promote the errors before any frame is stored into them. The frames
   // stored afterwards are young and belong to function objects that die at once, so only the
   // write barrier fired by the store keeps them marked through the next eden collection. A
@@ -297,7 +300,7 @@ test("frames stored into an old error are kept alive across an eden collection",
 // An error keeps its captured frames alive until the first .stack read, as in V8. JSC used to hold
 // them weakly: once a frame's callee died, the GC rendered the stack string itself, where
 // Error.prepareStackTrace cannot run. A GC between the throw and the first read must not be observable.
-describe("Error.prepareStackTrace when a GC runs before the first .stack read", () => {
+describe.concurrent("Error.prepareStackTrace when a GC runs before the first .stack read", () => {
   async function runScript(script: string, args: string[] = []) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script, ...args],

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -246,3 +246,81 @@ test("error.stack is formatted lazily with live frames when a GC runs between cr
   });
   expect(exitCode).toBe(0);
 });
+
+test("frames stored into an old error are kept alive across an eden collection", async () => {
+  // Two full collections promote the errors before any frame is stored into them. The frames
+  // stored afterwards are young and belong to function objects that die at once, so only the
+  // write barrier fired by the store keeps them marked through the next eden collection. A
+  // missed barrier trips a debug assertion in ErrorInstance::reconcileWeakReferencesAtGCEnd.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { fullGC, edenGC } = require("bun:jsc");
+       const captured = new Error("captured message");
+       const dest = new Error("dest message");
+       fullGC();
+       fullGC();
+
+       (function capturer() { Error.captureStackTrace(captured); })();
+       let src;
+       (function srcFn() { src = new Error("src message"); })();
+       (function appender() { Error.appendStackTrace(src, dest); })();
+
+       await 0;
+       edenGC();
+       edenGC();
+
+       const head = s => s.split("\\n")[0];
+       const frames = s => s.split("\\n").slice(1).map(l => l.trim().split(" (")[0]).map(f => f.includes(":") ? "at <top>" : f);
+       console.log(JSON.stringify({
+         captured: head(captured.stack),
+         capturedFrames: frames(captured.stack),
+         dest: head(dest.stack),
+         destFrames: frames(dest.stack),
+       }));`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    captured: "Error: captured message",
+    capturedFrames: ["at capturer", "at <top>"],
+    dest: "Error: dest message",
+    destFrames: ["at <top>", "at srcFn", "at <top>"],
+  });
+  expect(exitCode).toBe(0);
+});
+
+test("Error.appendStackTrace onto an error whose .stack was already read is a no-op", async () => {
+  // After the first read the destination has no frames left to append to, so the call must not
+  // take the source's frames either.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const dest = new Error("dest message");
+       const before = dest.stack;
+       let src;
+       (function srcFn() { src = new Error("src message"); })();
+       Error.appendStackTrace(src, dest);
+       await 0;
+       Bun.gc(true);
+       console.log(JSON.stringify({
+         destUnchanged: dest.stack === before,
+         src: src.stack.split("\\n").slice(0, 2).map(l => l.trim().split(" (")[0]),
+       }));`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    destUnchanged: true,
+    src: ["Error: src message", "at srcFn"],
+  });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -1,5 +1,5 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, bunRun, normalizeBunSnapshot } from "harness";
 import { join } from "node:path";
 
@@ -323,4 +323,109 @@ test("Error.appendStackTrace onto an error whose .stack was already read is a no
     src: ["Error: src message", "at srcFn"],
   });
   expect(exitCode).toBe(0);
+});
+
+// An error keeps its captured frames alive until the first .stack read, as in V8. JSC used to hold
+// them weakly: once a frame's callee died, the GC rendered the stack string itself, where
+// Error.prepareStackTrace cannot run. A GC between the throw and the first read must not be observable.
+describe("Error.prepareStackTrace when a GC runs before the first .stack read", () => {
+  async function runScript(script: string, args: string[] = []) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script, ...args],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { result: stdout && JSON.parse(stdout), stderr, exitCode };
+  }
+
+  test("the formatter runs and receives the call sites", async () => {
+    // Each error's frames hold a callee that is garbage right after the call: the per-call closure
+    // of an async function body, and a `new Function` callee. Error.captureStackTrace goes through
+    // Bun's lazy .stack getter over the same frames.
+    const script = `
+      const callSites = {};
+      Error.prepareStackTrace = (error, sites) => {
+        callSites[error.message] = sites.map(site => site.getFunctionName());
+        return "custom:" + error.message;
+      };
+      async function boom() {
+        throw new Error("async");
+      }
+      const fromAsync = await boom().catch(error => error);
+      const fromNewFunction = new Function("return new Error('new-function')")();
+      const fromCaptureStackTrace = new Function(
+        "const error = new Error('capture'); Error.captureStackTrace(error); return error;",
+      )();
+      if (process.argv[1] === "gc") Bun.gc(true);
+      const stacks = {
+        async: fromAsync.stack,
+        newFunction: fromNewFunction.stack,
+        captureStackTrace: fromCaptureStackTrace.stack,
+      };
+      console.log(JSON.stringify({ stacks, callSites }));`;
+
+    const [withoutGC, withGC] = await Promise.all([runScript(script), runScript(script, ["gc"])]);
+    expect(withoutGC).toEqual({
+      result: {
+        stacks: { async: "custom:async", newFunction: "custom:new-function", captureStackTrace: "custom:capture" },
+        callSites: {
+          "async": expect.arrayContaining(["boom"]),
+          "new-function": expect.arrayContaining(["anonymous"]),
+          "capture": expect.arrayContaining(["anonymous"]),
+        },
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+    // The GC must not be observable.
+    expect(withGC).toEqual(withoutGC);
+  });
+
+  test("a live error keeps its frames' callee alive until the first .stack read", async () => {
+    // Like V8: the frames are released when .stack is materialized. Whether a released callee is
+    // collected by a given GC is not asserted (it depends on the build), only that an unread error
+    // still holds it, and that the formatter in place at the first read is the one that runs.
+    const script = `
+      Error.prepareStackTrace = (error, sites) => "custom:" + error.message;
+      function make(message) {
+        const callee = new Function("return new Error(" + JSON.stringify(message) + ")");
+        return { error: callee(), callee: new WeakRef(callee) };
+      }
+      const unread = make("unread");
+      const read = make("read");
+      const readStack = read.error.stack;
+      Bun.gc(true);
+      const unreadCalleeAlive = unread.callee.deref() !== undefined;
+      const unreadStack = unread.error.stack;
+      Error.prepareStackTrace = undefined;
+      const afterReset = make("after-reset");
+      Bun.gc(true);
+      const afterResetFormatter = afterReset.error.stack.startsWith("custom:") ? "user" : "default";
+      console.log(JSON.stringify({ unreadCalleeAlive, readStack, unreadStack, afterResetFormatter }));`;
+
+    expect(await runScript(script)).toEqual({
+      result: {
+        unreadCalleeAlive: true,
+        readStack: "custom:read",
+        unreadStack: "custom:unread",
+        afterResetFormatter: "default",
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("another realm on the same VM resetting its own formatter does not affect this one", async () => {
+    // A ShadowRealm gets its own global object on the same VM, with its own Error.prepareStackTrace.
+    const script = `
+      Error.prepareStackTrace = (error, sites) => "custom:" + error.message;
+      const realm = new ShadowRealm();
+      realm.evaluate("Error.prepareStackTrace = (error, sites) => 'shadow:' + error.message; Error.prepareStackTrace = undefined; 0");
+      const error = new Function("return new Error('main')")();
+      Bun.gc(true);
+      console.log(JSON.stringify({ stack: error.stack }));`;
+
+    expect(await runScript(script)).toEqual({ result: { stack: "custom:main" }, stderr: "", exitCode: 0 });
+  });
 });

--- a/test/js/bun/test/stack.test.ts
+++ b/test/js/bun/test/stack.test.ts
@@ -294,37 +294,6 @@ test("frames stored into an old error are kept alive across an eden collection",
   expect(exitCode).toBe(0);
 });
 
-test("Error.appendStackTrace onto an error whose .stack was already read is a no-op", async () => {
-  // After the first read the destination has no frames left to append to, so the call must not
-  // take the source's frames either.
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `const dest = new Error("dest message");
-       const before = dest.stack;
-       let src;
-       (function srcFn() { src = new Error("src message"); })();
-       Error.appendStackTrace(src, dest);
-       await 0;
-       Bun.gc(true);
-       console.log(JSON.stringify({
-         destUnchanged: dest.stack === before,
-         src: src.stack.split("\\n").slice(0, 2).map(l => l.trim().split(" (")[0]),
-       }));`,
-    ],
-    env: bunEnv,
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({
-    destUnchanged: true,
-    src: ["Error: src message", "at srcFn"],
-  });
-  expect(exitCode).toBe(0);
-});
-
 // An error keeps its captured frames alive until the first .stack read, as in V8. JSC used to hold
 // them weakly: once a frame's callee died, the GC rendered the stack string itself, where
 // Error.prepareStackTrace cannot run. A GC between the throw and the first read must not be observable.


### PR DESCRIPTION
Fixes #34398

### Problem
- A GC between an error's creation and its first `.stack` read degrades the stack: the header is a bare `Error` with no message, `Error.prepareStackTrace` never runs, and `Error.captureStackTrace` frames become a fixed string.
- Cause: JSC holds the captured frames of an `ErrorInstance` weakly. When a callee or code block in the trace dies, `ErrorInstance::reconcileWeakReferencesAtGCEnd` pre-renders the stack in the GC end phase through `computeErrorInfoWrapperToString` (`src/jsc/bindings/FormatStackTraceForJS.cpp:574`), which gets no instance and cannot run JS.
- Any frame whose function object is collected before the read triggers it: an IIFE, a `.then` callback, an async function prologue, module code before its first `await`.

### Fix
- oven-sh/WebKit#511: `ErrorInstance::visitChildren` marks every frame's callee and code block under the cell lock, as `Exception` does. The frames live until the error info is materialized or the error dies, as in V8. The first read then always takes the normal path.
- Bun: `Error.appendStackTrace` and the lazy `stack` getter mutate the frame vector under the cell lock, since the GC now reads it concurrently. `appendStackTrace` fires the write barrier its destination needs. Its other guards (materialized destination, self-append, unset `stackTraceLimit`) stay with #37370.
- `WEBKIT_VERSION` points at the preview build of oven-sh/WebKit#511. Move it to the merged commit once that lands.
- Verified: `test/js/bun/test/stack.test.ts` (five new tests: seven GC shapes, young frames in old errors across an eden collection, and the three `Error.prepareStackTrace` tests from #40352 covering call sites, callee retention and a ShadowRealm; all fail on 1.4.0), plus the suites listed in the notes.

### Background
- `error.stack` is lazy in JSC: `new Error()` captures `Vector<StackFrame>`, and Bun's `computeErrorInfoToJSValue` builds the string on first access, with `CallSite` objects and `Error.prepareStackTrace`.
- `reconcileWeakReferencesAtGCEnd` runs on every marked cell after marking and before sweeping. Upstream uses it so an unread trace does not keep functions alive. A write barrier tells the GC that a visited object now points at a new cell.
- Related: #40352 (oven-sh/WebKit#510) pins the same way but only while a user `Error.prepareStackTrace` is installed. #34408 (oven-sh/WebKit#302) restores only the header. This PR pins unconditionally, so one mechanism covers all three symptoms.

<details><summary>Notes</summary>

Census on bun 1.4.0 (`Bun.gc(true)` before the first `.stack` read; "header" is the first line):

| shape | header | `Error.prepareStackTrace` |
|---|---|---|
| module top level, before the first `await` | `Error` | not called |
| module top level, after an `await`, then another `await` before the GC | `Error` | not called |
| IIFE, no `await` anywhere | `Error` | not called |
| `.then` callback | `Error` | not called |
| async function prologue | `Error` | not called |
| `Error.captureStackTrace(err)` inside an IIFE | `Error` | not called |
| module top level, GC while that segment still runs | `Error: m` | called |

So "created after the first await is immune" is not the discriminator. Only a frame whose callee or code block is unmarked at the GC end is. Module code gets a fresh `JSCallee` per top-level-await segment, which is why the first `await` looked special. `util.inspect`, worker copies and structured clones read `.stack`, so they show the same header and are fixed the same way.

Why unconditional rather than gated on the formatter: the header loss and the `captureStackTrace` frame loss happen with no formatter installed, a formatter installed after the GC still has to run (it does in Node), and errors from node:vm contexts have no setter to hook. One mechanism, V8's, covers all of it.

The eden test has teeth: with the `vm.writeBarrier(destination)` in `appendStackTrace` removed, the debug build trips `ASSERT_NOT_REACHED` in `reconcileWeakReferencesAtGCEnd` on every run of that test (3/3), because the old destination was not re-greyed and its young frames stayed unmarked.

`Error.appendStackTrace` onto a destination whose `.stack` was already read stores frames that never render (the destination never materializes again). Before this change the GC end phase dropped them in release and asserted in debug; with the frames pinned they live as long as the destination. #37370 adds the early return for that case, so it is left to that PR.

Memory: an unread error keeps up to `Error.stackTraceLimit` callees and code blocks alive, with their scope chains, until the first `.stack` read. Node has the same retention. Reading `.stack` once, or dropping the error, releases them. The weak-frame fallback in `reconcileWeakReferencesAtGCEnd` stays for a frame stored without a write barrier, and asserts in debug builds. It never fired in the suites below.

The debug build keeps some callees alive through stale stack slots (the `.then` callback survives there), which is why the test collects from a fresh microtask. On the current pin the test fails on six of the seven fields in debug and on all seven in release. The gate's fail-before run cannot see this: the behavior change lives in the WebKit pin under `scripts/`, so main's `src/` with the new pin passes the tests too.

With the pre-render unreachable for live errors, the crash in #33584 (the GC end-phase renderer clearing an unrelated pending exception) has no path either.

Not changed: `Error.captureStackTrace(plainObject)` formats eagerly in Bun and lazily in Node (#33437, #35640). That is a separate difference.

Suites run on the debug build at the new pin: `error-gc-test`, `inspect-error`, `inspect-error-leak`, `capture-stack-trace`, `prepare-stack-trace-crash`, `fix-bindings-stack-trace`, `structured-clone`, `happy-dom-vm-16277`, `error-name-preservation`, `deno/v8/error`, `internal-sourcemap`, `external-sourcemap-stack-leak`, `node/vm/vm`, `node/util/util`, `test-error-prepare-stack-trace`, `test-util-getcallsites-preparestacktrace`, `test-shadow-realm-prepare-stack-trace`, `bun-jsc`, `worker_threads`, `web/workers/worker`, `node/process`, `node/fs/fs`, `web/abort`, `node/events`. `error-gc-test.test.js` and `inspect-error-leak.test.js` time out under debug+ASAN on this machine at both pins with the same durations. Three `worker.test.ts` lifecycle tests and `process.test.js` (`process.env.USER` unset) fail on this machine at both pins as well. `fuzzy-wuzzy.test.ts` hit an unrelated Valkey `debug_assert`, handed off separately.
</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 7 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/stack.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/10] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/10] gen cpp.rs (cppbind)
[2/10] cargo bun_runtime → libbun_runtime.a
[3/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
FAILED: obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronous-unwind-tables -Wno-c23-extensions -ffunction-sections -fdata-sections -faddrsig -fno-semantic-interposition -fno-delete-null-pointer-checks -fdiagnostics-color=always -ferror-limit=100 -std=gnu++23 -fsanitize=null -fno-sanitize-recover=all -fsanitize=bounds -fsanitize=return -fsanitize=nullability-arg -fsan
... (truncated)

release without fix: 5 failed, 1 skipped
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/test/stack.test.ts:
(pass) name property is used for function calls in Error.stack [0.13ms]
(pass) name property is used for function calls in Bun.inspect [0.42ms]
(todo) name property is used for function calls in Bun.inspect with bound object
(pass) err.line and err.column are set [9.57ms]
error: My custom error message
{
  message: "My custom error message",
  name: [Getter],
  line: 42,
  sourceURL: "http://example.com/test.js",
}
      at http://example.com/test.js:42

Bun v1.4.1-canary.1+65362b53b (Linux x64)
(pass) throwing inside an error suppresses the error and prints the stack [9.35ms]
(pass) uncaught error thrown from a data: URL module longer than a path buffer is annotated for GitHub Actions [9.94ms]
ENOENT: no such file or directory, open 'this-file-path-is-bad'
    path: "this-file-path-is-bad",
 syscall: "open",
   errno: -2,
    code: "ENOENT"


Bun v1.4.1-canary.1+65362b53b (Linux x64)
(pass) throwing inside an error suppresses the error and continues printing properties on the object [13.86ms]
Error: error from qux
    at qux (/workspace/bun/test/js/bun/test/stack.test.ts:162:16)
    at baz (/work
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/stack.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/test/stack.test.ts:
(pass) name property is used for function calls in Error.stack [37.14ms]
(pass) name property is used for function calls in Bun.inspect [20.51ms]
(todo) name property is used for function calls in Bun.inspect with bound object
(pass) err.line and err.column are set [388.30ms]
error: My custom error message
{
  message: "My custom error message",
  name: [Getter],
  line: 42,
  sourceURL: "http://example.com/test.js",
}
      at http://example.com/test.js:42

Bun v1.4.1-debug+65362b53b (Linux x64)
(pass) throwing inside an error suppresses the error and prints the stack [312.59ms]
(pass) uncaught error thrown from a data: URL module longer than a path buffer is annotated for GitHub Actions [379.96ms]
ENOENT: no such file or directory, open 'this-file-path-is-bad'
    path: "this-file-path-is-bad",
 syscall: "open",
   errno: -2,
    code: "ENOENT"


Bun v1.4.1-debug+65362b53b (Linux x64)
(pass) throwing inside an error suppresses the error and co
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     50839329c2
  features     baseline

23 deps, 131 codegen, 1172 objects in 919ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [5.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [8.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[8/1217] gen .bind.ts → GeneratedBindings.cpp
[9/1217] fetch zlib
[zlib] up to date
[10/1217] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts               |   2 +-
 src/jsc/bindings/FormatStackTraceForJS.cpp |  33 +++--
 test/js/bun/test/stack.test.ts             | 228 ++++++++++++++++++++++++++++-
 3 files changed, 251 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 10 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
scripts/build/deps/webkit.ts                    2      1      0
src/jsc/bindings/FormatStackTraceForJS.cpp      4      6      0
test/js/bun/test/stack.test.ts                  0      0      0
```

</details>

<!-- robobun:evidence:end -->