### PR TITLE
install: stop the isolated linker's fallback link from racing between an npm: alias and the real package name

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -942,6 +942,27 @@ pub(crate) fn build_store(
                 if info.peers.eql(curr_peers, &eql_ctx) {
                     // dedupe! depend on the already created entry
 
+                    // The fallback-link claim follows the first dependency
+                    // whose name matches the package name, including one that
+                    // dedupes into an existing entry (#40355).
+                    if manager.options.hoist && curr_dep_id != invalid_dependency_id {
+                        let pkg_name = pkg_names[pkg_id as usize].slice(string_buf);
+                        let dep_name = dependencies[curr_dep_id as usize].name.slice(string_buf);
+                        if dep_name == pkg_name {
+                            if let Some(claim) = hidden_hoisted.get_mut(pkg_name) {
+                                if claim.aliased {
+                                    let entry_hoisted = store_entries.items_hoisted_mut();
+                                    entry_hoisted[claim.entry_id.get() as usize] = false;
+                                    entry_hoisted[info.entry_id.get() as usize] = true;
+                                    *claim = HiddenHoistClaim {
+                                        entry_id: info.entry_id,
+                                        aliased: false,
+                                    };
+                                }
+                            }
+                        }
+                    }
+
                     let mut entries = store_entries.slice();
                     // disjoint-column views via `split_mut`.
                     let store::entry::EntryColumnsMut {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -79,6 +79,15 @@ struct DedupeInfo {
     peers: store::node::Peers,
 }
 
+/// Which store entry owns the `node_modules/.bun/node_modules/<pkg name>`
+/// fallback link, and whether its dependency name is an alias (`npm:`) of the
+/// package name.
+#[derive(Clone, Copy, Default)]
+struct HiddenHoistClaim {
+    entry_id: store::entry::Id,
+    aliased: bool,
+}
+
 #[derive(Clone, Copy)]
 struct QueuedEntry {
     node_id: store::node::Id,
@@ -892,7 +901,7 @@ pub(crate) fn build_store(
 
     let mut public_hoisted: StringArrayHashMap<()> = StringArrayHashMap::default();
 
-    let mut hidden_hoisted: StringArrayHashMap<()> = StringArrayHashMap::default();
+    let mut hidden_hoisted: StringArrayHashMap<HiddenHoistClaim> = StringArrayHashMap::default();
 
     // Second pass: Deduplicate nodes when the pkg_id and peer set match an existing entry.
     'next_entry: while let Some(entry) = entry_queue.read_item() {
@@ -1007,6 +1016,9 @@ pub(crate) fn build_store(
 
         let new_entry_parents: Vec<store::entry::Id> = vec![entry.entry_parent_id];
 
+        let new_entry_id: store::entry::Id =
+            store::entry::Id::from(u32::try_from(store_entries.len()).expect("int cast"));
+
         let hoisted = 'hoisted: {
             if !manager.options.hoist {
                 break 'hoisted false;
@@ -1016,21 +1028,39 @@ pub(crate) fn build_store(
                 break 'hoisted false;
             }
 
+            // The fallback link is created under the package name, so the
+            // claim is keyed on the package name. Keying on the dependency
+            // name lets an `npm:` alias and the real name each claim the same
+            // link, and the install tasks then race for it (#40355).
+            let pkg_name = pkg_names[pkg_id as usize].slice(string_buf);
+
+            if let Some(hoist_pattern) = &manager.options.hoist_pattern {
+                if !hoist_pattern.is_match(pkg_name) {
+                    break 'hoisted false;
+                }
+            }
+
             let dep_name = dependencies[new_entry_dep_id as usize]
                 .name
                 .slice(string_buf);
+            let aliased = dep_name != pkg_name;
 
-            let Some(hoist_pattern) = &manager.options.hoist_pattern else {
-                let hoist_entry = hidden_hoisted.get_or_put(dep_name)?;
-                break 'hoisted !hoist_entry.found_existing;
-            };
-
-            if hoist_pattern.is_match(dep_name) {
-                let hoist_entry = hidden_hoisted.get_or_put(dep_name)?;
-                break 'hoisted !hoist_entry.found_existing;
+            let hoist_entry = hidden_hoisted.get_or_put(pkg_name)?;
+            if hoist_entry.found_existing {
+                // A dependency whose name matches the package name takes the
+                // link over an aliased claim, so the fallback mirrors
+                // `node_modules/<pkg name>` when that link exists.
+                if aliased || !hoist_entry.value_ptr.aliased {
+                    break 'hoisted false;
+                }
+                let prev_entry_id = hoist_entry.value_ptr.entry_id;
+                store_entries.items_hoisted_mut()[prev_entry_id.get() as usize] = false;
             }
-
-            break 'hoisted false;
+            *hoist_entry.value_ptr = HiddenHoistClaim {
+                entry_id: new_entry_id,
+                aliased,
+            };
+            break 'hoisted true;
         };
 
         let new_entry = StoreEntry {
@@ -1044,8 +1074,7 @@ pub(crate) fn build_store(
             scripts: core::cell::Cell::new(None),
         };
 
-        let new_entry_id: store::entry::Id =
-            store::entry::Id::from(u32::try_from(store_entries.len()).expect("int cast"));
+        debug_assert!(new_entry_id.get() as usize == store_entries.len());
         store_entries.append(new_entry)?;
 
         if let Some(entry_parent_id) = entry.entry_parent_id.try_get() {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -3655,6 +3655,37 @@ describe("hoist", () => {
     }
   });
 
+  test("fallback link follows the real name when it dedupes into an alias's store entry", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+    });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "hoist-alias-dedupe",
+        dependencies: {
+          // same version as the real name, so the real name dedupes into the
+          // store entry the alias created instead of creating its own
+          "an-alias": "npm:no-deps@1.0.0",
+          "no-deps": "1.0.0",
+          // brings in transitive no-deps@2.0.0, which must not take the
+          // fallback link from the root's no-deps@1.0.0
+          "one-fixed-dep": "2.0.0",
+        },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    expect(readlinkSync(join(packageDir, "node_modules", "no-deps"))).toBe(
+      join(".bun", "no-deps@1.0.0", "node_modules", "no-deps"),
+    );
+    expect(readlinkSync(join(packageDir, "node_modules", ".bun", "node_modules", "no-deps"))).toBe(
+      join("..", "no-deps@1.0.0", "node_modules", "no-deps"),
+    );
+  });
+
   test("package reachable only through an npm: alias gets a fallback link", async () => {
     const { packageJson, packageDir } = await registry.createTestDir({
       bunfigOpts: { linker: "isolated" },
@@ -3675,6 +3706,32 @@ describe("hoist", () => {
     expect(readlinkSync(join(packageDir, "node_modules", ".bun", "node_modules", "no-deps"))).toBe(
       join("..", "no-deps@2.0.0", "node_modules", "no-deps"),
     );
+  });
+
+  test("hoistPattern matches the package name, not the alias name", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated", hoistPattern: "no-deps" },
+    });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "hoist-pattern-alias",
+        dependencies: {
+          // the alias name does not match the pattern, the package name does
+          "an-alias": "npm:no-deps@2.0.0",
+          // the package name does not match the pattern
+          "a-dep": "1.0.1",
+        },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    expect(readlinkSync(join(packageDir, "node_modules", ".bun", "node_modules", "no-deps"))).toBe(
+      join("..", "no-deps@2.0.0", "node_modules", "no-deps"),
+    );
+    expect(existsSync(join(packageDir, "node_modules", ".bun", "node_modules", "a-dep"))).toBeFalse();
   });
 
   test("npmrc hoist=false", async () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -3612,6 +3612,71 @@ describe("hoist", () => {
     expect(existsSync(join(packageDir, "node_modules", ".bun", "node_modules"))).toBeFalse();
   });
 
+  // issue #40355: the fallback link is keyed on the package name, so a
+  // dependency and an `npm:` alias resolving to the same package name must not
+  // both claim `node_modules/.bun/node_modules/<name>` and race for it.
+  test("npm: alias does not race the real name for the fallback link", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+    });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "hoist-alias-race",
+        dependencies: {
+          // the alias name sorts before the real name, so its store entry
+          // claims the fallback link first and must hand it over
+          "an-alias": "npm:no-deps@2.0.0",
+          "no-deps": "1.0.0",
+        },
+      }),
+    );
+
+    // before the fix both store entries wrote the link from parallel install
+    // tasks and the last writer won, so repeat fresh installs to catch a
+    // racy wrong winner
+    for (let i = 0; i < 5; i++) {
+      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+      await runBunInstall(bunEnv, packageDir, { savesLockfile: i === 0 });
+
+      // the root links are stable
+      expect(readlinkSync(join(packageDir, "node_modules", "no-deps"))).toBe(
+        join(".bun", "no-deps@1.0.0", "node_modules", "no-deps"),
+      );
+      expect(readlinkSync(join(packageDir, "node_modules", "an-alias"))).toBe(
+        join(".bun", "no-deps@2.0.0", "node_modules", "no-deps"),
+      );
+
+      // the fallback link mirrors node_modules/no-deps on every install
+      expect(readlinkSync(join(packageDir, "node_modules", ".bun", "node_modules", "no-deps"))).toBe(
+        join("..", "no-deps@1.0.0", "node_modules", "no-deps"),
+      );
+    }
+  });
+
+  test("package reachable only through an npm: alias gets a fallback link", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({
+      bunfigOpts: { linker: "isolated" },
+    });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "hoist-alias-only",
+        dependencies: {
+          "an-alias": "npm:no-deps@2.0.0",
+        },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+
+    expect(readlinkSync(join(packageDir, "node_modules", ".bun", "node_modules", "no-deps"))).toBe(
+      join("..", "no-deps@2.0.0", "node_modules", "no-deps"),
+    );
+  });
+
   test("npmrc hoist=false", async () => {
     const { packageJson, packageDir } = await registry.createTestDir({
       bunfigOpts: { linker: "isolated" },


### PR DESCRIPTION
### Problem
- With the isolated linker, a dependency and an `npm:` alias that resolve to the same package name (for example `typescript` plus `@typescript/native: npm:typescript@7`) both write the fallback link `node_modules/.bun/node_modules/typescript`. The install tasks run in parallel and the last writer wins, so identical installs of the same lockfile flip between versions.
- The cause: the hoist claim in `build_store` keys on the dependency name (`src/install/isolated_install.rs:1024`), so each alias name gets its own claim. The link itself is created under the package name (`Installer.rs:2148`), so the claims collide on disk.

### Fix
- Key the claim on the package name. Only one store entry per package name gets `hoisted = true`, so exactly one task writes each fallback link.
- A dependency whose name matches the package name takes the claim from an aliased holder. This also covers the dedupe path, where the real name joins the store entry an alias created instead of creating its own. The fallback then mirrors `node_modules/<name>` when that root link exists, which is what consumers that rely on peer or undeclared resolution expect (#25336 reports the same directory).
- `hoistPattern` now matches the package name instead of the alias name. The link is created under the package name, so the pattern and the link now agree.
- Verified: `test/cli/install/isolated-install.test.ts` (four new tests, the race test fails on stock bun on the first install). Also ran the full file (86 tests), `public-hoist-pattern.test.ts`, and `config-precedence.test.ts`.

### Background
- The isolated linker installs every package into a store at `node_modules/.bun/<name>@<version>/node_modules/<name>` and symlinks declared dependencies next to each consumer.
- `node_modules/.bun/node_modules` is the hidden fallback (pnpm's hoist). It sits on the upward resolution path of every store entry, so a store package can resolve a package it never declared, such as an optional peer.
- `build_store` runs single threaded and marks one entry per name as `hoisted`. Each hoisted entry's install task later writes its fallback link from a thread pool, so two entries hoisted under one name race.

<details><summary>Notes</summary>

- Reproduced with the issue's two-dependency setup: the first install already picks the alias target (`typescript@7`) for the fallback while `node_modules/typescript` points at 6, and repeated installs flip between the two. With more dependencies the flip rate grows (scheduling noise).
- Claim order is the store build's BFS order, which is deterministic, so the winner is now deterministic as well: the first non-aliased dependency in BFS order, or the first aliased one when no non-aliased dependency exists. Root direct dependencies come first in BFS, so a root dependency always beats transitive ones.
- The dedupe edge case (review finding, fixed in d8b82cc): an alias and the real name at the same version dedupe into one store entry, and the claim stayed marked as aliased. A transitive dependency at another version could then take the link from the root's version. The dedupe path now moves the claim to the deduped-into entry when the dependency name matches the package name.
- Claim moves only happen from an aliased holder to a non-aliased one, and `hoisted` is not read until after `build_store` returns, so mutating the flags there is safe.
- A package reachable only through aliases keeps a fallback link (covered by a test).
- `publicHoistPattern` is untouched: root links for public hoists are created under the alias name, so keying those on the dependency name stays coherent.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->