### PR TITLE
test(bake): settle stylesheet links on their load or error event in the client fixture

### DIFF
--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -1900,8 +1900,10 @@ class OutputLineStream extends EventEmitter {
 }
 
 export function indexHtmlScript(htmlFiles: string[]) {
+  // Routes are URL paths, so a nested file uses "/" on every platform.
+  htmlFiles = htmlFiles.map(file => file.replaceAll(path.sep, "/"));
   return [
-    ...htmlFiles.map((file, i) => `import html${i} from ${JSON.stringify("./" + file.replaceAll(path.sep, "/"))};`),
+    ...htmlFiles.map((file, i) => `import html${i} from ${JSON.stringify("./" + file)};`),
     "export default {",
     "  static: {",
     ...(htmlFiles.length === 1

--- a/test/bake/client-fixture.mjs
+++ b/test/bake/client-fixture.mjs
@@ -38,6 +38,8 @@ let windowGeneration = 0;
 let pendingAcks = () => 0;
 // Every ack sent so far; with `pendingAcks()` it tells the harness how many acks to expect in total.
 let acksSent = 0;
+// Settles once every stylesheet the current page links has loaded or failed.
+let stylesheetsSettled = Promise.resolve();
 let objectURLRegistry = new Map();
 let internalAPIs;
 
@@ -231,72 +233,8 @@ function createWindow(windowUrl) {
     },
     info: (...args) => {
       if (args[0]?.startsWith("[Bun] Hot-module-reloading socket connected")) {
-        // Wait for all CSS assets to be fully loaded before emitting the event
-        let checkAttempts = 0;
-        const MAX_CHECK_ATTEMPTS = 20; // Prevent infinite waiting
-
-        const checkCSSLoaded = () => {
-          checkAttempts++;
-
-          // Get all link elements with rel="stylesheet"
-          const styleLinks = window.document.querySelectorAll('link[rel="stylesheet"]');
-          // Get all style elements
-          const styleTags = window.document.querySelectorAll("style");
-          // Check for adoptedStyleSheets
-          const adoptedSheets = window.document.adoptedStyleSheets || [];
-
-          // If no stylesheets of any kind, just emit the event
-          if (styleLinks.length === 0 && styleTags.length === 0 && adoptedSheets.length === 0) {
-            process.nextTick(ackPageLoad);
-            return;
-          }
-
-          // Check if all stylesheets are loaded
-          let allLoaded = true;
-          let pendingCount = 0;
-
-          // Check link elements
-          for (const link of styleLinks) {
-            // If the stylesheet is not loaded yet
-            if (!link.sheet) {
-              allLoaded = false;
-              pendingCount++;
-            }
-          }
-
-          // Check style elements - these should be loaded immediately
-          for (const style of styleTags) {
-            if (!style.sheet) {
-              allLoaded = false;
-              pendingCount++;
-            }
-          }
-
-          // Check adoptedStyleSheets - these should be loaded immediately
-          for (const sheet of adoptedSheets) {
-            if (!sheet.cssRules) {
-              allLoaded = false;
-              pendingCount++;
-            }
-          }
-
-          if (allLoaded || checkAttempts >= MAX_CHECK_ATTEMPTS) {
-            // All CSS is loaded or we've reached max attempts, emit the event
-            if (checkAttempts >= MAX_CHECK_ATTEMPTS && !allLoaded) {
-              console.warn("[W] Reached maximum CSS load check attempts, proceeding anyway");
-            }
-            process.nextTick(ackPageLoad);
-          } else {
-            // Wait a bit and check again
-            console.info(
-              `[I] Waiting for ${pendingCount} CSS assets to load (attempt ${checkAttempts}/${MAX_CHECK_ATTEMPTS})...`,
-            );
-            setTimeout(checkCSSLoaded, 50);
-          }
-        };
-
-        // Start checking for CSS loaded state
-        checkCSSLoaded();
+        // Ack the page load once every stylesheet it links has loaded or failed.
+        stylesheetsSettled.then(() => process.nextTick(ackPageLoad));
       }
       if (args[0]?.startsWith("[WS] receive message")) return;
       if (args[0]?.startsWith("Updated modules:")) return;
@@ -430,6 +368,37 @@ async function loadPage() {
     process.exit(exitCodeMap.reloadFailed);
   }
   window.document.write(html);
+  stylesheetsSettled = settleStylesheets(window);
+}
+
+/**
+ * Resolves once every stylesheet `<link>` in the document has loaded or
+ * failed. happy-dom fetches each one after `document.write` returns, so the
+ * listeners miss no event: a load sets `link.sheet` and fires "load", a
+ * response that is not ok fires "error" (a 404 for a source tag the dev
+ * server left in a recovered page, for example) and leaves `sheet` null.
+ */
+function settleStylesheets(window) {
+  const links = [...window.document.querySelectorAll('link[rel="stylesheet"]')];
+  const pending = new Set(links.filter(link => !link.sheet));
+  // Only a diagnostic: the harness times out the page load on its own.
+  const diagnostic = setTimeout(() => {
+    const hrefs = [...pending].map(link => link.getAttribute("href"));
+    console.warn(`[W] Still waiting for ${pending.size} stylesheets to load or fail: ${hrefs.join(", ")}`);
+  }, 1000);
+  return Promise.all(
+    [...pending].map(
+      link =>
+        new Promise(resolve => {
+          const settle = () => {
+            pending.delete(link);
+            resolve();
+          };
+          link.addEventListener("load", settle);
+          link.addEventListener("error", settle);
+        }),
+    ),
+  ).finally(() => clearTimeout(diagnostic));
 }
 
 // Listen for control messages from the test harness

--- a/test/bake/dev/harness.test.ts
+++ b/test/bake/dev/harness.test.ts
@@ -35,6 +35,29 @@ devTest("a write after a fetch of a failing route waits for the reloaded page", 
   },
 });
 
+devTest("a stylesheet link that fails to load does not hold up the page load ack", {
+  files: {
+    "index.html": emptyHtmlFile({
+      // Nothing listens on port 1, and the dev server leaves an absolute URL alone.
+      styles: ["http://127.0.0.1:1/missing.css", "styles.css"],
+      body: "<h1>Hello</h1>",
+    }),
+    "styles.css": `h1 { color: red; }`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.style("h1").color.expect.toBe("red");
+    // happy-dom never gives the failed link a sheet, so waiting for one would
+    // wait forever. The fixture settles the link on its "error" event instead.
+    expect(await c.js`[...document.querySelectorAll('link[rel="stylesheet"]')].map(link => !!link.sheet)`).toEqual([
+      false,
+      true,
+    ]);
+    await c.hardReload();
+    await c.style("h1").color.expect.toBe("red");
+  },
+});
+
 devTest("expectElemText waits for a DOM update that lands after the ack", {
   files: {
     "index.html": emptyHtmlFile({


### PR DESCRIPTION
### Problem
- `test/bake/client-fixture.mjs` acks a page load only after every `<link rel="stylesheet">` has a `sheet`. It polled `link.sheet` every 50 ms and gave up after 1 s. happy-dom never gives a link whose request fails a sheet, so every such page paid the full second. A stale source tag after a failed CSS build (#40081) is one case, and in a project with several HTML routes it requests a path that 404s.
- `indexHtmlScript` in `test/bake/bake-harness.ts` built the route of a nested HTML file from `path.relative` output. On Windows `html/index.html` became the route `/html\index`, so `dev.client("/html")` got a 404.

### Fix
- `loadPage` attaches `load` and `error` listeners to each stylesheet link right after `document.write`. happy-dom starts the fetches after `document.write` returns and fires the events later, so no event is missed. The ack waits on that promise. A diagnostic warning names the links still pending after 1 s. The harness's own page load timeout stays the failure path.
- The route key of a nested HTML file uses `/` on every platform, as the import path already did.
- Verified: new case in `test/bake/dev/harness.test.ts`, a page with a stylesheet link to a closed port. It takes 2.0 s here and 4.1 s with the old fixture, which logs two "Reached maximum CSS load check attempts" warnings. `bun bd test test/bake/dev/` passes with this fixture (134 tests, run together with the css.test.ts of #40337), plus `test/bake/{dev-and-prod,framework-router,deinitialization,serve-plugins-dev-server}.test.ts`. Windows x64: `test/bake/dev/{css,harness,html,hot}.test.ts` pass.

### Background
- `devTest` spawns a dev server per case. `dev.client(route)` spawns a Node process that loads the page in happy-dom and acks over IPC once the HMR socket has connected and the stylesheets have settled. The harness waits for that ack before it returns the client.
- With several HTML files the harness maps each to its own route and serves 404 for every other path. With one file it serves that file for every path.

<details><summary>Notes</summary>

- Inline `<style>` elements and `adoptedStyleSheets` were also checked by the old poll. Both are synchronous in happy-dom, so the new code only waits on `<link>` elements.
- happy-dom 17 ignores `{ once: true }` on `addEventListener`, so the settle callback is idempotent instead.
- #39488 carries the same `indexHtmlScript` fix inside its consolidation. The second PR on top of this one, #40337, reworks `test/bake/dev/css.test.ts` into multi-route projects and needs both changes here.
- The old poll also covered links added by page scripts before the socket connected. No bake test has such a page: the dev server injects every stylesheet link server side.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bake/dev/harness.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bake/dev/harness.test.ts
bun test v1.4.1 (4448a2e21)

test/bake/dev/harness.test.ts:
Dev server testing directory: /tmp/bun-dev-test-6ogEZq
[0;30mdev|[0m Started development server: http://localhost:46613
[0;30mdev|[0m [39merror[0m[2m: [0m[1mCould not resolve: "styles.css". Maybe you need to "bun install"?[0m
[0;30mdev|[0m     [2mat [0m[36m/tmp/bun-dev-test-6ogEZq/harness1/index.html[0m
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [39merror[0m[2m: [0m[1mCould not resolve: "styles.css". Maybe you need to "bun install"?[0m
[0;30mdev|[0m     [2mat [0m[36m/tmp/bun-dev-test-6ogEZq/harness1/index.html[0m
[0;30mdev|[0m [32mReloaded in 97ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:harness-1: a write after a fetch of a failing route waits for the reloaded page [3197.05ms]
[0;30mdev|[0m Started development server: http://localhost:34905
[0;30mdev|[0m [32mBundled page in 139ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:harness-2: a stylesheet link that fails to load does not hold up the page load ack [2336.99ms]
[0;30mdev|[0m Started development server: http://localhost:41095
[0;30mdev|[0m [32mBundled page in 158ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:harness-3: expectElemText waits for a DOM update that lands after the ack [2581.92ms]
[0;30mdev|[0m Started development server: http://localhost:35367
[0;30mdev|[0m [32mBundled page in 143ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes..
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bake/bake-harness.ts     |   4 +-
 test/bake/client-fixture.mjs  | 101 +++++++++++++++---------------------------
 test/bake/dev/harness.test.ts |  23 ++++++++++
 3 files changed, 61 insertions(+), 67 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
test/bake/bake-harness.ts          6      1      0
test/bake/client-fixture.mjs       3      5      0
test/bake/dev/harness.test.ts      2      1      0
```

</details>

<!-- robobun:evidence:end -->