### PR TITLE
Throw RangeError instead of crashing when toMatchObject recurses too deep

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2067,9 +2067,14 @@ bool Bun__deepMatch(
     // Caller must ensure only objects are passed to this function.
     ASSERT(objValue.isCell());
     ASSERT(subsetValue.isCell());
+    VM& vm = globalObject->vm();
+    if (!vm.isSafeToRecurse()) [[unlikely]] {
+        throwStackOverflowError(globalObject, throwScope);
+        return false;
+    }
+
     // fast path for reference equality.
     if (objValue == subsetValue) return true;
-    VM& vm = globalObject->vm();
     JSObject* obj = objValue.getObject();
     JSObject* subsetObj = subsetValue.getObject();
 
@@ -2160,9 +2165,9 @@ bool Bun__deepMatch(
                 gcBuffer->append(subsetProp);
                 // property cycle detected
                 if (!didInsertProp.second || !didInsertSubset.second) continue;
-                if (!Bun__deepMatch<enableAsymmetricMatchers>(prop, seenObjProperties, subsetProp, seenSubsetProperties, globalObject, throwScope, gcBuffer, replacePropsWithAsymmetricMatchers, isMatchingObjectContaining)) {
-                    return false;
-                }
+                bool matched = Bun__deepMatch<enableAsymmetricMatchers>(prop, seenObjProperties, subsetProp, seenSubsetProperties, globalObject, throwScope, gcBuffer, replacePropsWithAsymmetricMatchers, isMatchingObjectContaining);
+                RETURN_IF_EXCEPTION(throwScope, false);
+                if (!matched) return false;
             }
         } else {
             auto same = JSC::sameValue(globalObject, prop, subsetProp);

--- a/test/js/bun/test/expect-stack-overflow-crash.test.ts
+++ b/test/js/bun/test/expect-stack-overflow-crash.test.ts
@@ -24,3 +24,35 @@ if(a&&b)console.log("OK")`,
   expect(stdout).toBe("OK\n");
   expect(exitCode).toBe(0);
 });
+
+// toMatchObject and Bun.deepMatch recurse natively into nested objects. A
+// chain deeper than the native stack must throw RangeError, not segfault.
+test.concurrent.each([
+  ["expect().toMatchObject()", "Bun.jest().expect(ra).toMatchObject(rb)"],
+  ["Bun.deepMatch()", "Bun.deepMatch(rb, ra)"],
+])("%s throws RangeError on deeply nested objects instead of crashing", async (_, compare) => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `let a = {}, b = {};
+const ra = a, rb = b;
+for (let i = 0; i < 100000; i++) { a.x = {}; b.x = {}; a = a.x; b = b.x; }
+try {
+  ${compare};
+  console.log("no throw");
+} catch (e) {
+  console.log(e instanceof RangeError, e.message);
+}`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("true Maximum call stack size exceeded.\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `expect(a).toMatchObject(b)` and `Bun.deepMatch(b, a)` on a deeply nested object chain kill the process with SIGSEGV. There is no `RangeError` and no crash banner, because the stack is already exhausted when the fault happens. Sentry BUN-4QF1: fault just below the stack guard in `Structure::getPropertyNamesFromStructure` under `JSObject::getOwnNonIndexPropertyNames`, reached from `Bun__deepMatch<false>` calling itself hundreds of times.
- The cause is `Bun__deepMatch` (`src/jsc/bindings/bindings.cpp:2055`). It recurses natively once per nested object property and has no stack check. `Bun__deepEquals` in the same file guards each level with `vm.isSafeToRecurse()` (`bindings.cpp:742`), so `toEqual` on the same input throws `RangeError: Maximum call stack size exceeded`.

### Fix
- Add the same `vm.isSafeToRecurse()` guard at the top of `Bun__deepMatch`. When the stack is nearly full it throws a stack overflow `RangeError` and returns false. This covers `toMatchObject`, snapshot property matchers, and `Bun.deepMatch`.
- Check for a pending exception after the recursive call before the next property lookup, the same pattern `Bun__deepEquals` uses after its recursive calls.
- `isSafeToRecurse()` compares the stack pointer against the VM stack limit, which keeps a 64 KB reserved zone. The guard fires about 15k levels deep on release Linux x64 and leaves enough stack for the throw and the unwind.
- Verified: `test/js/bun/test/expect-stack-overflow-crash.test.ts` (two new cases, both exit 139 on the unfixed build). Also ran `test/js/bun/test/expect.test.js`, `expect-extend.test.js`, `test/js/bun/bun-object/deep-match.spec.ts`, and `test/js/bun/test/snapshot-tests/`.

### Background
- `Bun__deepMatch` is the native subset matcher behind `toMatchObject`, `toMatchSnapshot(propertyMatchers)`, and `Bun.deepMatch`. For every property of the pattern object it reads the same property on the received object and, when both are objects, calls itself.
- `expect.objectContaining` is not affected. Inside that matcher, nested values go through `Bun__deepEquals`, which already has the guard. Self-referential objects are not affected either: the visited sets added in #15672 stop the recursion on a cycle.
- JSC exposes `VM::isSafeToRecurse()` for native code that recurses on behalf of JS. It returns false once the stack pointer passes the VM stack limit, and `throwStackOverflowError` raises the same `RangeError` the interpreter uses.

<details><summary>Notes</summary>

Probes on release 1.4.0 (Linux x64), 200k deep chain:

| input | result |
| --- | --- |
| `expect(ra).toMatchObject(rb)` | SIGSEGV, exit 139 |
| `Bun.deepMatch(rb, ra)` | SIGSEGV, exit 139 |
| `expect(ra).toEqual(expect.objectContaining(rb))` | RangeError |
| `expect({k: ra}).toMatchObject({k: expect.objectContaining(rb)})` | RangeError |
| `expect(ra).toEqual(rb)` | RangeError |
| `a.x = a` vs `b.x = b` | matches, no throw |

With the fix, all of the first two rows throw `RangeError: Maximum call stack size exceeded.` and the process exits 0. Also ran the fixed build with `BUN_JSC_validateExceptionChecks=1`, no assertion.

Overflow depth on release Linux x64 is between 14000 and 16000 (the VM caps its stack use at `maxPerThreadStackUsage`, 5 MB). On the debug ASAN build it is below 5000. The test uses 100000 levels. The test spawns a child so that a regression fails the test instead of killing the test runner.

#31059 carried the same guard since May but fell 2144 commits behind main and never got a review. This PR supersedes it.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-stack-overflow-crash.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/expect-stack-overflow-crash.test.ts:
(pass) expect does not crash when called after catching stack overflow [652.28ms]
50 |     stdout: "pipe",
51 |   });
52 | 
53 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
54 | 
55 |   expect(stdout).toBe("true Maximum call stack size exceeded.\n");
                      ^
error: expect(received).toBe(expected)

- "true Maximum call stack size exceeded.
- "
+ ""

- Expected  - 2
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/test/expect-stack-overflow-crash.test.ts:55:18)
(fail) expect().toMatchObject() throws RangeError on deeply nested objects instead of crashing [1386.00ms]
50 |     stdout: "pipe",
51 |   });
52 | 
53 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
54 | 
55 |   expect(stdout).toBe("true Maximum call stack size exceeded.\n");
        
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/bun/test/expect-stack-overflow-crash.test.ts:
(pass) expect does not crash when called after catching stack overflow [13.47ms]
50 |     stdout: "pipe",
51 |   });
52 | 
53 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
54 | 
55 |   expect(stdout).toBe("true Maximum call stack size exceeded.\n");
                      ^
error: expect(received).toBe(expected)

- "true Maximum call stack size exceeded.
- "
+ ""

- Expected  - 2
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/test/expect-stack-overflow-crash.test.ts:55:18)
(fail) expect().toMatchObject() throws RangeError on deeply nested objects instead of crashing [143.43ms]
50 |     stdout: "pipe",
51 |   });
52 | 
53 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
54 | 
55 |   expect(stdout).toBe("true Maximum call stack size exceeded.\n");
                      ^
error: expect(received).toBe(expected)

- "true Maximum call stack size exceeded.
- "
+ ""

- Expected  - 2
+ Received  + 1

      at <anonymous> (/workspace/bun/t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-stack-overflow-crash.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/expect-stack-overflow-crash.test.ts:
(pass) expect does not crash when called after catching stack overflow [548.54ms]
(pass) expect().toMatchObject() throws RangeError on deeply nested objects instead of crashing [1206.22ms]
(pass) Bun.deepMatch() throws RangeError on deeply nested objects instead of crashing [1199.35ms]

 3 pass
 0 fail
 8 expect() calls
Ran 3 tests across 1 file. [3.85s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 624ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 14s
[119/123] cxx obj/codegen/GeneratedFakeTimersConfig.cpp.o
[120/123] link bun-profile
[122/123] strip bun
[122/123] bun-profile --revision
1.4.1-canary.1+eac114caa
[build] done
bun test v1.4.1-canary.1 (eac114caa)

test/js/bun/test/expect-stack-overflow-crash.test.ts:
(pass) expect does not crash when called after catching stack overflow [12.59ms]
(pass) expect().toMatchObject() throws RangeError on deeply nested objects instead of crashing [28.08ms]
(pass) Bun.deepMatch() throws RangeError on deepl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp                      | 13 ++++++---
 .../bun/test/expect-stack-overflow-crash.test.ts   | 32 ++++++++++++++++++++++
 2 files changed, 41 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/jsc/bindings/bindings.cpp                             5      2      0
test/js/bun/test/expect-stack-overflow-crash.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->