### PR TITLE
Remove dead code from bun_core, bun_jsc, bun_css, react_compiler, and two C++ bindings

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -105,7 +105,6 @@ new!(pub BUN_INSTALL_STREAMING_MIN_SIZE: unsigned, "BUN_INSTALL_STREAMING_MIN_SI
 // thread schedules a drain; collapses the per-chunk thread-pool futex wake
 // into roughly one per `threshold` bytes.
 new!(pub BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: unsigned, "BUN_INSTALL_STREAMING_DRAIN_THRESHOLD", { default: 256 * 1024 });
-new!(pub BUN_NEEDS_PROC_SELF_WORKAROUND: boolean, "BUN_NEEDS_PROC_SELF_WORKAROUND", { default: false });
 new!(pub BUN_OPTIONS: string, "BUN_OPTIONS", {});
 new!(pub BUN_POSTGRES_SOCKET_MONITOR: string, "BUN_POSTGRES_SOCKET_MONITOR", {});
 new!(pub BUN_POSTGRES_SOCKET_MONITOR_READER: string, "BUN_POSTGRES_SOCKET_MONITOR_READER", {});
@@ -150,9 +149,6 @@ platform_specific_new!(pub HOME: string, posix = "HOME", windows = "USERPROFILE"
 new!(pub HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET: string, "HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET", {});
 new!(pub IS_BUN_AUTO_UPDATE: boolean, "IS_BUN_AUTO_UPDATE", { default: false });
 new!(pub JENKINS_URL: string, "JENKINS_URL", {});
-// Dump mimalloc statistics at the end of the process. Note that this is not the same as
-// `MIMALLOC_VERBOSE`, documented here: https://microsoft.github.io/mimalloc/environment.html
-new!(pub MI_VERBOSE: boolean, "MI_VERBOSE", { default: false });
 new!(pub NO_COLOR: boolean, "NO_COLOR", { default: false });
 new!(pub NODE_CHANNEL_FD: string, "NODE_CHANNEL_FD", {});
 // A string, not a boolean: node suppresses warnings only when the value is
@@ -183,7 +179,6 @@ new!(pub TERM_PROGRAM: string, "TERM_PROGRAM", {});
 platform_specific_new!(pub TMP: string, posix = "TMP", windows = "TMP", {});
 platform_specific_new!(pub TMPDIR: string, posix = "TMPDIR", windows = "TMPDIR", {});
 new!(pub TMUX: string, "TMUX", {});
-new!(pub TODIUM: string, "TODIUM", {});
 platform_specific_new!(pub USER: string, posix = "USER", windows = "USERNAME", {});
 new!(pub WANTS_LOUD: boolean, "WANTS_LOUD", { default: false });
 // The same as system_root.

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1505,7 +1505,6 @@ pub enum ColorCode {
     Blue,
     Orange,
     Red,
-    Pink,
 }
 
 impl ColorCode {
@@ -1515,8 +1514,6 @@ impl ColorCode {
             ColorCode::Blue => "\x1b[34m",
             ColorCode::Orange => "\x1b[33m",
             ColorCode::Red => "\x1b[31m",
-            // light pink
-            ColorCode::Pink => "\x1b[38;5;206m",
         }
     }
 }

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -606,17 +606,6 @@ pub fn split_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'
     Some((&self_[..i], &self_[i + delimiter.len()..]))
 }
 
-/// `str::rsplit_once` for bytes with a multi-byte delimiter. An empty
-/// delimiter never matches.
-#[inline]
-pub fn rsplit_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
-    if delimiter.is_empty() {
-        return None;
-    }
-    let i = last_index_of(self_, delimiter)?;
-    Some((&self_[..i], &self_[i + delimiter.len()..]))
-}
-
 pub struct SplitIterator<'a> {
     pub(crate) buffer: &'a [u8],
     pub(crate) index: Option<usize>,

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -606,6 +606,17 @@ pub fn split_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'
     Some((&self_[..i], &self_[i + delimiter.len()..]))
 }
 
+/// `str::rsplit_once` for bytes with a multi-byte delimiter. An empty
+/// delimiter never matches.
+#[inline]
+pub fn rsplit_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
+    if delimiter.is_empty() {
+        return None;
+    }
+    let i = last_index_of(self_, delimiter)?;
+    Some((&self_[..i], &self_[i + delimiter.len()..]))
+}
+
 pub struct SplitIterator<'a> {
     pub(crate) buffer: &'a [u8],
     pub(crate) index: Option<usize>,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4392,7 +4392,6 @@ impl StmtList {
             StmtListWhich::InsideWrapperSuffix => {
                 self.inside_wrapper_suffix.extend_from_slice(stmts)
             }
-            StmtListWhich::AllStmts => self.all_stmts.extend_from_slice(stmts),
         }
     }
 
@@ -4400,7 +4399,6 @@ impl StmtList {
         match list {
             StmtListWhich::OutsideWrapperPrefix => self.outside_wrapper_prefix.push(stmt),
             StmtListWhich::InsideWrapperSuffix => self.inside_wrapper_suffix.push(stmt),
-            StmtListWhich::AllStmts => self.all_stmts.push(stmt),
         }
     }
 }
@@ -4409,5 +4407,4 @@ impl StmtList {
 pub enum StmtListWhich {
     OutsideWrapperPrefix,
     InsideWrapperSuffix,
-    AllStmts,
 }

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -868,7 +868,6 @@ impl<'a> CustomAtRuleParser for BundlerAtRuleParser<'a> {
 
 pub enum AtRulePrelude<T> {
     FontFace,
-    FontFeatureValues,
     FontPaletteValues(DashedIdent),
     CounterStyle(CustomIdent),
     Import {
@@ -1894,7 +1893,6 @@ mod rule_parsers {
                         }));
                     Ok(())
                 }
-                AtRulePrelude::FontFeatureValues => unreachable!(),
                 AtRulePrelude::Unknown { name, tokens } => {
                     this.rules.v.push(CssRule::Unknown(UnknownAtRule {
                         name,
@@ -2472,9 +2470,6 @@ mod stylesheet_impl {
             printer: &mut Printer<'a>,
             project_root: Option<&[u8]>,
         ) -> Result<(), PrintErr> {
-            // #[cfg(feature = "sourcemap")] { printer.sources = Some(&self.sources); }
-            // #[cfg(feature = "sourcemap")] if printer.source_map.is_some() { ... }
-
             for comment in &self.license_comments {
                 printer.write_str("/*")?;
                 printer.write_comment(comment)?;
@@ -2716,12 +2711,6 @@ mod stylesheet_impl {
             options: &PrinterOptions<'a>,
             import_info: Option<ImportInfo<'a>>,
         ) -> Result<ToCssResult, PrintErr> {
-            // #[cfg(feature = "sourcemap")]
-            // assert!(
-            //   options.source_map.is_none(),
-            //   "Source maps are not supported for style attributes"
-            // );
-
             let symbols = bun_ast::symbol::Map::init_list(Default::default());
             let mut dest: Vec<u8> = Vec::new();
             let mut printer = Printer::new(

--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -361,8 +361,6 @@ pub enum SelectorError {
     empty_selector,
     /// A `|` was expected in an attribute selector.
     expected_bar_in_attr(Token),
-    /// A namespace was expected.
-    expected_namespace(Str),
     /// An unexpected token was encountered in a namespace.
     explicit_namespace_unexpected_token(Token),
     /// An invalid pseudo class was encountered after a pseudo element.
@@ -383,8 +381,6 @@ pub enum SelectorError {
     no_qualified_name_in_attribute_selector(Token),
     /// An invalid token was encountered in a pseudo element.
     pseudo_element_expected_ident(Token),
-    /// An unexpected identifier was encountered.
-    unexpected_ident(Str),
     /// An unexpected token was encountered inside an attribute selector.
     unexpected_token_in_attribute_selector(Token),
     /// An unsupported pseudo class or pseudo element was encountered.
@@ -415,8 +411,6 @@ impl fmt::Display for SelectorError {
                 f.write_str("-webkit-scrollbar state found before -webkit-scrollbar pseudo-element")
             }
 
-            Self::expected_namespace(s) => write!(f, "Expected namespace '{}'", bs(*s)),
-            Self::unexpected_ident(s) => write!(f, "Unexpected identifier '{}'", bs(*s)),
             Self::unsupported_pseudo_class_or_element(s) => {
                 write!(f, "Unsupported pseudo-class or pseudo-element '{}'", bs(*s))
             }

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -112,7 +112,6 @@ impl<'a> ImportInfo<'a> {
 /// `Printer` also includes helper functions that assist with writing output
 /// that respects options such as `minify`, and `css_modules`.
 pub struct Printer<'a> {
-    // #[cfg(feature = "sourcemap")]
     pub(crate) sources: Option<&'a Vec<Box<[u8]>>>,
     pub dest: &'a mut dyn Write,
     pub(crate) loc: Location,

--- a/src/css/rules/container.rs
+++ b/src/css/rules/container.rs
@@ -337,9 +337,6 @@ pub struct ContainerRule<R> {
 
 impl<R> ContainerRule<R> {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> core::result::Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str("@container ")?;
         if let Some(name) = &self.name {
             name.to_css(dest)?;

--- a/src/css/rules/counter_style.rs
+++ b/src/css/rules/counter_style.rs
@@ -16,9 +16,6 @@ pub struct CounterStyleRule {
 
 impl CounterStyleRule {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str("@counter-style")?;
         super::custom_ident_to_css(&self.name, dest)?;
         super::decl_block_to_css(&self.declarations, dest)

--- a/src/css/rules/custom_media.rs
+++ b/src/css/rules/custom_media.rs
@@ -24,8 +24,6 @@ impl CustomMediaRule {
     }
 
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
         dest.write_str("@custom-media ")?;
         DashedIdentFns::to_css(&self.name, dest)?;
         dest.write_char(b' ')?;

--- a/src/css/rules/document.rs
+++ b/src/css/rules/document.rs
@@ -14,8 +14,6 @@ pub struct MozDocumentRule<R> {
 
 impl<R> MozDocumentRule<R> {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
         dest.write_str("@-moz-document url-prefix()")?;
         dest.block(|d| {
             d.newline()?;

--- a/src/css/rules/font_face.rs
+++ b/src/css/rules/font_face.rs
@@ -632,9 +632,6 @@ pub struct FontFaceRule {
 
 impl FontFaceRule {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str("@font-face")?;
         dest.whitespace()?;
         dest.write_char(b'{')?;

--- a/src/css/rules/font_palette_values.rs
+++ b/src/css/rules/font_palette_values.rs
@@ -19,9 +19,6 @@ pub struct FontPaletteValuesRule {
 
 impl FontPaletteValuesRule {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str("@font-palette-values ")?;
         super::dashed_ident_to_css(&self.name, dest)?;
         dest.whitespace()?;

--- a/src/css/rules/import.rs
+++ b/src/css/rules/import.rs
@@ -215,9 +215,6 @@ impl ImportRule {
             None
         };
 
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str("@import ")?;
         if let Some(d) = dep {
             // SAFETY: `placeholder` is arena-allocated by `css_modules::hash`

--- a/src/css/rules/keyframes.rs
+++ b/src/css/rules/keyframes.rs
@@ -215,9 +215,6 @@ pub struct KeyframesRule {
 
 impl KeyframesRule {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> core::result::Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         let mut first_rule = true;
 
         // VendorPrefix is `bitflags!`, so iterate the flag constants directly

--- a/src/css/rules/layer.rs
+++ b/src/css/rules/layer.rs
@@ -152,9 +152,6 @@ impl<R> LayerBlockRule<R> {
     }
 
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str("@layer")?;
         if let Some(name) = &self.name {
             dest.write_char(b' ')?;
@@ -192,8 +189,6 @@ impl LayerStatementRule {
     }
 
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
         if self.names.len() > 0 {
             dest.write_str("@layer ")?;
             css::to_css::from_list(self.names.slice(), dest)?;

--- a/src/css/rules/media.rs
+++ b/src/css/rules/media.rs
@@ -21,9 +21,6 @@ impl<R> MediaRule<R> {
             self.rules.to_css(dest)?;
             return Ok(());
         }
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str("@media ")?;
         self.query.to_css(dest)?;
         dest.block(|d| {

--- a/src/css/rules/namespace.rs
+++ b/src/css/rules/namespace.rs
@@ -15,9 +15,6 @@ pub struct NamespaceRule {
 
 impl NamespaceRule {
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str("@namespace ")?;
         if let Some(prefix) = &self.prefix {
             prefix.to_css(dest)?;

--- a/src/css/rules/nesting.rs
+++ b/src/css/rules/nesting.rs
@@ -12,8 +12,6 @@ pub struct NestingRule<R> {
 
 impl<R> NestingRule<R> {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
         if dest.context().is_none() {
             dest.write_str("@nest ")?;
         }

--- a/src/css/rules/page.rs
+++ b/src/css/rules/page.rs
@@ -88,9 +88,6 @@ pub struct PageMarginRule {
 
 impl PageMarginRule {
     fn to_css(&self, dest: &mut Printer) -> core::result::Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_char(b'@')?;
         self.margin_box.to_css(dest)?;
         super::decl_block_to_css(&self.declarations, dest)
@@ -122,8 +119,6 @@ pub struct PageRule {
 
 impl PageRule {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> core::result::Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
         dest.write_str("@page")?;
         if self.selectors.len() >= 1 {
             let firstsel = &self.selectors[0];

--- a/src/css/rules/property.rs
+++ b/src/css/rules/property.rs
@@ -16,9 +16,6 @@ pub struct PropertyRule {
 
 impl PropertyRule {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str("@property ")?;
         super::dashed_ident_to_css(&self.name, dest)?;
         dest.whitespace()?;

--- a/src/css/rules/scope.rs
+++ b/src/css/rules/scope.rs
@@ -21,9 +21,6 @@ pub struct ScopeRule<R> {
 impl<R> ScopeRule<R> {
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
         use crate::selectors::selector::serialize::serialize_selector_list;
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str("@scope")?;
         dest.whitespace()?;
         // The scope preludes get their own budget for `&` substitutions when

--- a/src/css/rules/starting_style.rs
+++ b/src/css/rules/starting_style.rs
@@ -11,9 +11,6 @@ pub struct StartingStyleRule<R> {
 
 impl<R> StartingStyleRule<R> {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str("@starting-style")?;
         dest.block(|d| {
             d.newline()?;

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -170,9 +170,6 @@ impl<R> StyleRule<R> {
         let has_declarations = supports_nesting || len > 0 || self.rules.v.len() == 0;
 
         if has_declarations {
-            //   #[cfg(feature = "sourcemap")]
-            //   dest.add_mapping(self.loc);
-
             // `dest.context()` borrows `dest`; copy the (Copy) raw
             // ctx field out so it doesn't conflict with the `&mut *dest` below.
             let ctx = dest.ctx;

--- a/src/css/rules/supports.rs
+++ b/src/css/rules/supports.rs
@@ -438,9 +438,6 @@ impl<R> SupportsRule<R> {
 
 impl<R> SupportsRule<R> {
     pub fn to_css(&self, dest: &mut Printer) -> core::result::Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_str(b"@supports ")?;
         self.condition.to_css(dest)?;
         dest.block(|d| {

--- a/src/css/rules/unknown.rs
+++ b/src/css/rules/unknown.rs
@@ -17,9 +17,6 @@ pub struct UnknownAtRule {
 
 impl UnknownAtRule {
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
-
         dest.write_char(b'@')?;
         dest.serialize_identifier(self.name)?;
 

--- a/src/css/rules/viewport.rs
+++ b/src/css/rules/viewport.rs
@@ -16,8 +16,6 @@ pub struct ViewportRule {
 
 impl ViewportRule {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // #[cfg(feature = "sourcemap")]
-        // dest.add_mapping(self.loc);
         dest.write_char(b'@')?;
         super::vendor_prefix_to_css(self.vendor_prefix, dest)?;
         dest.write_str("viewport")?;

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -2827,10 +2827,8 @@ pub enum SelectorParseErrorKind {
     InvalidPseudoClassAfterPseudoElement,
     MissingNestingSelector,
     MissingNestingPrefix,
-    ExpectedNamespace(Str),
     BadValueInAttr(Token),
     ExplicitNamespaceUnexpectedToken(Token),
-    UnexpectedIdent(Str),
     AmbiguousCssModuleClass(Str),
 }
 
@@ -2870,12 +2868,10 @@ impl SelectorParseErrorKind {
             K::InvalidPseudoClassAfterPseudoElement => S::invalid_pseudo_class_after_pseudo_element,
             K::MissingNestingSelector => S::missing_nesting_selector,
             K::MissingNestingPrefix => S::missing_nesting_prefix,
-            K::ExpectedNamespace(name) => S::expected_namespace(name),
             K::BadValueInAttr(token) => S::bad_value_in_attr(token),
             K::ExplicitNamespaceUnexpectedToken(token) => {
                 S::explicit_namespace_unexpected_token(token)
             }
-            K::UnexpectedIdent(ident) => S::unexpected_ident(ident),
             K::UnexpectedSelectorAfterPseudoElement(tok) => {
                 S::unexpected_selector_after_pseudo_element(tok)
             }

--- a/src/http/lshpack.rs
+++ b/src/http/lshpack.rs
@@ -35,7 +35,6 @@ pub struct DecodeResult {
     pub name: &'static [u8],
     pub value: &'static [u8],
     pub never_index: bool,
-    pub well_know: u16,
     /// offset of the next header position in src
     pub next: usize,
 }
@@ -82,7 +81,6 @@ impl HPACK {
             value,
             next: offset,
             never_index: header.never_index,
-            well_know: header.hpack_index,
         })
     }
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2831,12 +2831,6 @@ fn get_or_put_resolved_package(
                             &mut buf2,
                             &[folder_path],
                         )
-                        // break :blk Path.joinAbsStringBuf(
-                        //     strings.withoutSuffixComptime(this.original_package_json_path, "package.json"),
-                        //     &buf2,
-                        //     &[_]string{folder_path},
-                        //     .auto,
-                        // );
                     };
 
                     break 'res FolderResolution::get_or_put(

--- a/src/jsc/bindgen.rs
+++ b/src/jsc/bindgen.rs
@@ -31,20 +31,6 @@ pub trait Bindgen {
     fn convert_from_extern(extern_value: Self::ExternType) -> Self::ZigType;
 }
 
-pub struct BindgenTrivial<T>(PhantomData<T>);
-
-impl<T> Bindgen for BindgenTrivial<T> {
-    type ZigType = T;
-    type ExternType = T;
-    const SAME_REPR: bool = true;
-
-    fn convert_from_extern(extern_value: Self::ExternType) -> Self::ZigType {
-        extern_value
-    }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-
 pub struct BindgenStrongAny;
 
 impl Bindgen for BindgenStrongAny {

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -120,24 +120,6 @@ static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalO
     return stackStringValue;
 }
 
-static JSValue formatStackTraceToJSValueWithoutPrepareStackTrace(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites)
-{
-    JSValue prepareStackTrace = {};
-    if (lexicalGlobalObject->inherits<Zig::GlobalObject>()) {
-        if (auto prepare = globalObject->m_errorConstructorPrepareStackTraceValue.get()) {
-            prepareStackTrace = prepare;
-        }
-    } else {
-        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-
-        auto* errorConstructor = lexicalGlobalObject->m_errorStructure.constructor(globalObject);
-        prepareStackTrace = errorConstructor->getIfPropertyExists(lexicalGlobalObject, JSC::Identifier::fromString(vm, "prepareStackTrace"_s));
-        CLEAR_IF_EXCEPTION(scope);
-    }
-
-    return formatStackTraceToJSValue(vm, globalObject, lexicalGlobalObject, errorObject, callSites, prepareStackTrace);
-}
-
 WTF::String formatStackTrace(
     JSC::VM& vm,
     Zig::GlobalObject* globalObject,

--- a/src/jsc/bindings/node/crypto/JSVerify.cpp
+++ b/src/jsc/bindings/node/crypto/JSVerify.cpp
@@ -471,39 +471,4 @@ void setupJSVerifyClassStructure(LazyClassStructure::Initializer& init)
     init.setConstructor(constructor);
 }
 
-std::optional<ncrypto::EVPKeyPointer> keyFromPublicString(JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, const WTF::StringView& keyView)
-{
-    ncrypto::EVPKeyPointer::PublicKeyEncodingConfig publicConfig;
-    publicConfig.format = ncrypto::EVPKeyPointer::PKFormatType::PEM;
-
-    UTF8View keyUtf8(keyView);
-    auto keySpan = keyUtf8.span();
-
-    ncrypto::Buffer<const unsigned char> ncryptoBuf {
-        .data = reinterpret_cast<const unsigned char*>(keySpan.data()),
-        .len = keySpan.size(),
-    };
-
-    ncrypto::ClearErrorOnReturn clearErrorOnReturn;
-
-    auto publicRes = ncrypto::EVPKeyPointer::TryParsePublicKey(publicConfig, ncryptoBuf);
-    if (publicRes) {
-        ncrypto::EVPKeyPointer keyPtr(WTF::move(publicRes.value));
-        return keyPtr;
-    }
-
-    if (publicRes.error.value() == ncrypto::EVPKeyPointer::PKParseError::NOT_RECOGNIZED) {
-        ncrypto::EVPKeyPointer::PrivateKeyEncodingConfig privateConfig;
-        privateConfig.format = ncrypto::EVPKeyPointer::PKFormatType::PEM;
-        auto privateRes = ncrypto::EVPKeyPointer::TryParsePrivateKey(privateConfig, ncryptoBuf);
-        if (privateRes) {
-            ncrypto::EVPKeyPointer keyPtr(WTF::move(privateRes.value));
-            return keyPtr;
-        }
-    }
-
-    throwCryptoError(lexicalGlobalObject, scope, publicRes.openssl_error.value_or(0), "Failed to read public key"_s);
-    return std::nullopt;
-}
-
 } // namespace Bun

--- a/src/jsc/generated.rs
+++ b/src/jsc/generated.rs
@@ -129,9 +129,8 @@ pub type GenBlob = *mut core::ffi::c_void;
 
 type RawWTFStringImpl = *mut bun_core::WTFStringImplStruct;
 
-/// `BindgenOptional<T>::ExternType` for a `T` whose extern and Zig types are
-/// the same — `T` has no custom `OptionalExternType`, so the C++ side wraps
-/// it in a 2-arm tagged union
+/// `BindgenOptional<T>::ExternType` when `T` has no custom `OptionalExternType`:
+/// the C++ side wraps it in a 2-arm tagged union
 /// `{ data: union { _0: u8 /* unused */, _1: T }, tag: u8 }`.
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/src/jsc/generated.rs
+++ b/src/jsc/generated.rs
@@ -129,8 +129,9 @@ pub type GenBlob = *mut core::ffi::c_void;
 
 type RawWTFStringImpl = *mut bun_core::WTFStringImplStruct;
 
-/// `BindgenOptional(BindgenTrivial<T>).ExternType` — `T` has no custom
-/// `OptionalExternType`, so the C++ side wraps it in a 2-arm tagged union
+/// `BindgenOptional<T>::ExternType` for a `T` whose extern and Zig types are
+/// the same — `T` has no custom `OptionalExternType`, so the C++ side wraps
+/// it in a 2-arm tagged union
 /// `{ data: union { _0: u8 /* unused */, _1: T }, tag: u8 }`.
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/src/react_compiler/hir/environment.rs
+++ b/src/react_compiler/hir/environment.rs
@@ -76,12 +76,6 @@ pub struct Environment {
     // keyed by binding declaration position, for applying back to the Babel AST.
     pub renames: HirVec<BindingRename>,
 
-    // Node IDs of identifiers that are actual references to bindings.
-    // Used by codegen to filter type annotation renames — only rename identifiers
-    // whose node_id is in this set (type labels like ObjectTypeIndexer params
-    // are NOT in this set and should keep their original names).
-    pub reference_node_ids: HashSet<u32>,
-
     // Hoisted identifiers: tracks which bindings have already been hoisted
     // via DeclareContext to avoid duplicate hoisting.
     // Uses u32 to avoid depending on react_compiler_ast types.
@@ -190,7 +184,6 @@ impl Environment {
             instrument_gating_name: None,
             hook_guard_name: None,
             renames: AstAlloc::vec(),
-            reference_node_ids: HashSet::new(),
             hoisted_identifiers: HashSet::new(),
             validate_preserve_existing_memoization_guarantees: config
                 .validate_preserve_existing_memoization_guarantees,

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -279,7 +279,6 @@ pub struct HirFunction {
     pub name_hint: Option<StoreStr>,
     pub fn_type: ReactFunctionType,
     pub params: HirVec<ParamPattern>,
-    pub return_type_annotation: Option<StoreStr>,
     pub returns: Place,
     pub context: HirVec<Place>,
     pub body: HIR,
@@ -1245,11 +1244,6 @@ impl std::fmt::Display for Effect {
 #[derive(Debug, Clone)]
 pub struct SpreadPattern {
     pub place: Place,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Hole {
-    Hole,
 }
 
 #[derive(Debug, Clone)]

--- a/src/react_compiler/inference/analyse_functions.rs
+++ b/src/react_compiler/inference/analyse_functions.rs
@@ -202,7 +202,6 @@ fn placeholder_function() -> HirFunction {
         name_hint: None,
         fn_type: ReactFunctionType::Other,
         params: AstAlloc::vec(),
-        return_type_annotation: None,
         returns: Place {
             identifier: IdentifierId(0),
             effect: Effect::Unknown,

--- a/src/react_compiler/lowering/build_hir/mod.rs
+++ b/src/react_compiler/lowering/build_hir/mod.rs
@@ -322,7 +322,6 @@ pub(super) fn lower_inner<'h>(
                 ReactFunctionType::Other
             },
             params: hir_params,
-            return_type_annotation: None,
             returns,
             context,
             body: hir_body,

--- a/src/react_compiler/optimization/outline_jsx.rs
+++ b/src/react_compiler/optimization/outline_jsx.rs
@@ -477,7 +477,6 @@ fn emit_outlined_fn(
         name_hint: None,
         fn_type: ReactFunctionType::Other,
         params: hir_vec![ParamPattern::Place(props_obj)],
-        return_type_annotation: None,
         returns: returns_place,
         context: AstAlloc::vec(),
         body: HIR {

--- a/src/react_compiler/ssa/enter_ssa.rs
+++ b/src/react_compiler/ssa/enter_ssa.rs
@@ -502,7 +502,6 @@ pub(crate) fn placeholder_function() -> HirFunction {
         name_hint: None,
         fn_type: ReactFunctionType::Other,
         params: hir_vec![],
-        return_type_annotation: None,
         returns: Place {
             identifier: IdentifierId(0),
             effect: Effect::Unknown,

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1181,13 +1181,6 @@ impl CreateCommand {
             Output::flush();
         }
 
-        // if (unsupported_packages.@"styled-jsx") {
-        //     Output.prettyErrorln("\n", .{});
-        //     unsupported_packages.print();
-        //     Output.prettyErrorln("\n", .{});
-        //     Output.flush();
-        // }
-
         if !create_options.skip_git && !create_options.skip_install {
             bun_core::pretty!(
                 "\n<d>A local git repository was created for you and dependencies were installed automatically.<r>\n",

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -260,18 +260,6 @@ impl Drop for ShellSubprocess {
     }
 }
 
-// pub const Pipe = struct {
-//     writer: Writer = Writer{},
-//     parent: *Subprocess,
-//     src: WriterSrc,
-//
-//     writer: ?CapturedBufferedWriter = null,
-//
-//     status: Status = .{
-//         .pending = {},
-//     },
-// };
-
 pub type StaticPipeWriter = JscSubprocess::NewStaticPipeWriter<ShellSubprocess>;
 
 impl JscSubprocess::static_pipe_writer::StaticPipeWriterProcess for ShellSubprocess {

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -158,15 +158,6 @@ pub mod text {
         }
 
         write!(writer, "{:>7.2}", vals.functions * 100.0)?;
-        // writer.write_all(&pretty_fmt("<r><d> | <r>", ENABLE_COLORS))?;
-        // if ENABLE_COLORS {
-        //     // if vals.stmts < failing.stmts {
-        //     writer.write_all(&pretty_fmt("<d>", true))?;
-        //     // } else {
-        //     //     writer.write_all(&pretty_fmt("<d>", true))?;
-        //     // }
-        // }
-        // write!(writer, "{:>8.2}", vals.stmts * 100.0)?;
         writer.write_all(&pretty_fmt::<ENABLE_COLORS>("<r><d> | <r>"))?;
 
         if ENABLE_COLORS {

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -989,15 +989,6 @@ thread_local! {
 impl QueryStringMap {
     pub fn get_name_count(&mut self) -> usize {
         self.list.len()
-        // if (this.name_count == null) {
-        //     var count: usize = 0;
-        //     var iterate = this.iter();
-        //     while (iterate.next(&_name_count) != null) {
-        //         count += 1;
-        //     }
-        //     this.name_count = count;
-        // }
-        // return this.name_count.?;
     }
 
     pub fn iter(&self) -> Iterator<'_> {


### PR DESCRIPTION
Net -222 lines across 43 files. Every item has zero references in `src/`, `scripts/`, `test/`, `packages/` and the regenerated `build/debug/codegen/` output, and the removal builds.

### Removed

- bun_core: `ColorCode::Pink`, and the env var declarations `BUN_NEEDS_PROC_SELF_WORKAROUND`, `MI_VERBOSE`, `TODIUM` (declared in `env_var.rs`, read by nothing in Rust or C++).
- bun_jsc: `BindgenTrivial`, a `Bindgen` adapter no binding names. The `ExternOptional` doc comment in `generated.rs` that named it is reworded.
- bun_css: `AtRulePrelude::FontFeatureValues` (never constructed, its only arm was `unreachable!()`), the `SelectorParseErrorKind::{ExpectedNamespace, UnexpectedIdent}` kinds and the `SelectorError::{expected_namespace, unexpected_ident}` variants they mapped to, and the 24 commented-out `// #[cfg(feature = "sourcemap")]` / `// dest.add_mapping(self.loc)` pairs left from the lightningcss port. No `sourcemap` feature exists in `bun_css/Cargo.toml` and `Printer` has no `add_mapping`.
- react_compiler: the standalone `Hole` enum, `HirFunction::return_type_annotation` (set to `None` at all four constructors, never read), and `Environment::reference_node_ids` (always `HashSet::new()`, never read).
- bun_bundler: `StmtListWhich::AllStmts` and its two match arms. The `all_stmts` list itself stays, it is filled directly.
- bun_http: the write-only `DecodeResult::well_know` field. The `lshpack_header::hpack_index` FFI field it copied from is untouched.
- C++: `keyFromPublicString` in `JSVerify.cpp` (no declaration, no caller) and the `static` `formatStackTraceToJSValueWithoutPrepareStackTrace` in `FormatStackTraceForJS.cpp`.
- Commented-out Zig code in `url/lib.rs` (`get_name_count`), `cli/create_command.rs` (`unsupported_packages`), `shell/subproc.rs` (`pub const Pipe = struct`), `PackageManagerEnqueue.rs` (`Path.joinAbsStringBuf`) and `sourcemap_jsc/CodeCoverage.rs` (the statements column).

### How the Rust items were found

The workspace already denies `dead_code` and `unreachable_pub`, so every remaining dead item is a `pub` item that is reachable from its crate root. For each of the 95 non-proc-macro crates this run rewrote every `pub` item whose name has no reference outside the crate to `pub(crate)` (re-exports, `pub mod`, FFI exports and macro bodies left alone), ran `cargo check -p <crate>` with `--force-warn dead_code`, and iterated until no flagged item had an outside reference. The items above are what rustc then reported, minus platform-gated code, MultiArrayList schema fields, test-only helpers and items staged by their authors (see Notes).

### Verification

- `bun bd` (full debug build) passes.
- `bun run rust:check-all`: 12 of 12 target triples ok.
- `cargo fmt --check` and clang-format on the two C++ files are clean.
- `test/js/bun/css/css.test.ts`, `test/bundler/css/css-modules.test.ts`, `react-compiler-fixtures.test.ts` (3293 pass), `test/js/node/http2/h2-conformance.test.ts`, `test/cli/test/coverage.test.ts`, `test/js/node/crypto/crypto.key-objects.test.ts`, `node-crypto.test.js`, `test/js/bun/util/pathToFileURL.test.ts` all pass.

<details><summary>Notes</summary>

Left in place on purpose:

- `src/runtime/api/bun/h2/`: `Connection::{begin_header_block, send_header_block, send_push_promise}`, `hpack::Coder::take_pending_size_update`, `write_table_size_update`, `MAX_SIZE_UPDATE_BYTES`, `wire::MAX_FRAME_SIZE_DEFAULT` have no production caller but are covered by unit tests, and the module files carry `#![allow(dead_code)]` as part of the in-progress rewrite.
- `react_compiler/compile_result.rs` (`LoggerSourceLocation::from_loc`, `BindingRenameInfo::declaration_start`) and the four `logged_severity` methods in `diagnostics/mod.rs`: annotated as staged for logger wiring, same call as #39420.
- `isolated_install::Store::Entry::{peer_hash, entry_hash}`, `LinkerGraph` `JSMeta`/`File` fields, `LineOffsetTable` fields, `Graph::content_hash_for_additional_file`, `BundledAst::tla_check`: rustc reports them as never read because they are MultiArrayList schema structs. The generated `items_*` accessors read them.
- `OutputFile::owned_src_path_text`, `HTTPResponseMetadata::owned_buf`: never read, but they own the buffers that borrowed slices point into.
- `Environment::get_property_type` (react_compiler): test-only.
- `bun_core::fmt::ColorCode::{Blue, Orange, Red}` are constructed through `use ColorCode::*` in `Keyword::color_code`; only `Pink` was dead.
- `bun_core::strings::rsplit_once` has no caller, but `clippy.toml` names it as the replacement for the disallowed `str::rsplitn` and `bstr::ByteSlice::rsplit_once_str`, so it stays (review finding).
- `VM::has_termination_request`, `AbortSignal__Timeout__run`, `bun_core::util::EmbedKind` and the `bun_sys` constants are already removed by #40232 / #40172.

`ZigString::to_slice_fast` was also removed on main by #40374 while this PR was open; the rebase dropped the duplicate hunk.

Other scans that came back clean this run: unreferenced `extern "C"` declarations, FFI exports with no C++ or WebKit caller, `.rs` files outside every `mod` tree, `.cpp` files outside the build glob, `src/js` exports and top-level helpers, and C++ function definitions whose name appears nowhere else (574 files).

</details>

