### PR TITLE
css: bump the default browser targets to baseline widely available

### DIFF
--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -22,11 +22,10 @@ Bun's CSS parser and bundler is a direct port of LightningCSS, with a bundling a
 
 By default, Bun's CSS bundler targets the following browsers:
 
-- Edge 80+
-- Firefox 78+
-- Chrome 80+
-- Safari 14+
-- Opera 67+
+- Chrome 107+
+- Edge 107+
+- Firefox 104+
+- Safari 16+
 
 ## Syntax Lowering
 

--- a/src/css/targets.rs
+++ b/src/css/targets.rs
@@ -187,15 +187,14 @@ pub struct Browsers {
 }
 
 // convert_from_string is not const-evaluable; compute once lazily.
+// Vite 7's default build target ("baseline-widely-available"):
+// https://github.com/vitejs/vite/blob/v7.0.0/packages/vite/src/node/constants.ts
+// (ESBUILD_BASELINE_WIDELY_AVAILABLE_TARGET)
+// Note that convert_from_string keeps the LOWEST version per browser, so an
+// es-year entry here would drag every browser down to that year's versions.
 static BROWSER_DEFAULT: std::sync::LazyLock<Browsers> = std::sync::LazyLock::new(|| {
-    Browsers::convert_from_string(&[
-        b"es2020", // support import.meta.url
-        b"edge88",
-        b"firefox78",
-        b"chrome87",
-        b"safari14",
-    ])
-    .expect("unreachable")
+    Browsers::convert_from_string(&[b"chrome107", b"edge107", b"firefox104", b"safari16"])
+        .expect("unreachable")
 });
 
 impl Browsers {

--- a/src/css/targets.rs
+++ b/src/css/targets.rs
@@ -187,11 +187,8 @@ pub struct Browsers {
 }
 
 // convert_from_string is not const-evaluable; compute once lazily.
-// Vite 7's default build target ("baseline-widely-available"):
-// https://github.com/vitejs/vite/blob/v7.0.0/packages/vite/src/node/constants.ts
-// (ESBUILD_BASELINE_WIDELY_AVAILABLE_TARGET)
-// Note that convert_from_string keeps the LOWEST version per browser, so an
-// es-year entry here would drag every browser down to that year's versions.
+// Vite 7's default build target ("baseline-widely-available"). Do not add an
+// es-year entry: convert_from_string keeps the lowest version per browser.
 static BROWSER_DEFAULT: std::sync::LazyLock<Browsers> = std::sync::LazyLock::new(|| {
     Browsers::convert_from_string(&[b"chrome107", b"edge107", b"firefox104", b"safari16"])
         .expect("unreachable")

--- a/test/bundler/css/is-selector-21169.test.ts
+++ b/test/bundler/css/is-selector-21169.test.ts
@@ -14,14 +14,6 @@ describe("css", () => {
     onAfterBundle(api) {
       api.expectFile("/out/index.css").toMatchInlineSnapshot(`
         "/* index.css */
-        .foo:-webkit-any(input:checked) {
-          color: red;
-        }
-
-        .foo:-moz-any(input:checked) {
-          color: red;
-        }
-
         .foo:is(input:checked) {
           color: red;
         }

--- a/test/bundler/css/where-selector-list-40364.test.ts
+++ b/test/bundler/css/where-selector-list-40364.test.ts
@@ -1,0 +1,118 @@
+import { describe } from "bun:test";
+import { itBundled } from "../expectBundled";
+
+// https://github.com/oven-sh/bun/issues/40364
+// The default browser targets must support :is()/:where(), so a selector
+// list that uses them stays one rule instead of being split per selector.
+describe("css", () => {
+  itBundled("css/where-selector-list-preserved", {
+    files: {
+      "index.css": /* css */ `
+        :where(.a .b), :where(.c) {
+          color: red;
+          padding: 4px;
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        "/* index.css */
+        :where(.a .b), :where(.c) {
+          color: red;
+          padding: 4px;
+        }
+        "
+      `);
+    },
+  });
+
+  itBundled("css/where-selector-list-preserved-minified", {
+    files: {
+      "index.css": /* css */ `
+        :where(.a .b), :where(.c) {
+          color: red;
+          padding: 4px;
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    minifyWhitespace: true,
+    minifySyntax: true,
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        ":where(.a .b),:where(.c){color:red;padding:4px}
+        "
+      `);
+    },
+  });
+
+  itBundled("css/is-selector-list-preserved", {
+    files: {
+      "index.css": /* css */ `
+        :is(.a .b), :is(.c) {
+          color: red;
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        "/* index.css */
+        :is(.a .b), .c {
+          color: red;
+        }
+        "
+      `);
+    },
+  });
+
+  // firefox 104 (in the default targets) lacks :has(), so the list is
+  // downleveled, but into a single :is()-wrapped rule instead of one rule
+  // per selector with duplicated declarations.
+  itBundled("css/has-selector-list-not-duplicated", {
+    files: {
+      "index.css": /* css */ `
+        :has(.a), :has(.c) {
+          color: red;
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    minifyWhitespace: true,
+    minifySyntax: true,
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        ":is(:has(.a),:has(.c)){color:red}
+        "
+      `);
+    },
+  });
+
+  itBundled("css/where-selector-list-with-pseudo-elements-preserved", {
+    files: {
+      "index.css": /* css */ `
+        :where(.a)::before, :where(.c)::before, :where(.a)::after, :where(.c)::after {
+          content: "";
+          position: absolute;
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        "/* index.css */
+        :where(.a):before, :where(.c):before, :where(.a):after, :where(.c):after {
+          content: "";
+          position: absolute;
+        }
+        "
+      `);
+    },
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5483,6 +5483,28 @@ describe("css tests", () => {
       },
     );
 
+    // https://github.com/oven-sh/bun/issues/21169
+    prefix_test(
+      "a:is(input:checked) {color:red}",
+      `
+      a:-webkit-any(input:checked) {
+        color: red;
+      }
+
+      a:-moz-any(input:checked) {
+        color: red;
+      }
+
+      a:is(input:checked) {
+        color: red;
+      }
+      `,
+      {
+        safari: 11 << 16,
+        firefox: 50 << 16,
+      },
+    );
+
     prefix_test(
       "a:lang(en, fr) {color:red}",
       `

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -237,7 +237,7 @@ console.log("How...dashing?");
   text-align: center;
   max-width: 800px;
   margin: 2rem auto;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+  font-family: system-ui, sans-serif;
 }
 
 button {

--- a/test/regression/issue/25785.test.ts
+++ b/test/regression/issue/25785.test.ts
@@ -1,5 +1,8 @@
+import { cssInternals } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
 import { tempDir } from "harness";
+
+const { prefixTest } = cssInternals;
 
 // Regression test for https://github.com/oven-sh/bun/issues/25785
 // CSS logical border-radius properties were being silently dropped
@@ -37,30 +40,30 @@ test("CSS bundler should preserve logical border-radius properties", async () =>
 
   const output = await result.outputs[0].text();
 
-  // Logical properties are compiled to physical properties with LTR/RTL rules
-  // .test1 with border-start-start-radius compiles to border-top-left-radius (LTR) and border-top-right-radius (RTL)
+  // The default browser targets support logical border-radius properties, so
+  // each one passes through unchanged instead of being dropped.
   expect(output).toContain(".test1");
-  expect(output).toContain("border-top-left-radius");
-  expect(output).toContain("border-top-right-radius");
+  expect(output).toContain("border-start-start-radius");
 
-  // .test2 with border-end-start-radius compiles to border-bottom-left-radius (LTR) and border-bottom-right-radius (RTL)
   expect(output).toContain(".test2");
-  expect(output).toContain("border-bottom-left-radius");
-  expect(output).toContain("border-bottom-right-radius");
+  expect(output).toContain("border-end-start-radius");
 
-  // .test3 with border-start-end-radius
   expect(output).toContain(".test3");
+  expect(output).toContain("border-start-end-radius");
 
-  // .test4 with border-end-end-radius
   expect(output).toContain(".test4");
+  expect(output).toContain("border-end-end-radius");
 
   // Physical property should also be preserved
   expect(output).toContain(".test5");
+  expect(output).toContain("border-top-left-radius");
 });
 
-test("CSS bundler should handle logical border-radius with targets that compile logical properties", async () => {
-  using dir = tempDir("issue-25785-compiled", {
-    "test.css": `
+test("CSS bundler should handle logical border-radius with targets that compile logical properties", () => {
+  // Safari 14 does not support logical border-radius properties, so they are
+  // compiled to physical properties with LTR/RTL rules instead of dropped.
+  const output = prefixTest(
+    `
 .test1 {
   border-start-start-radius: 0.75rem;
 }
@@ -74,29 +77,18 @@ test("CSS bundler should handle logical border-radius with targets that compile 
   border-end-end-radius: 0.75rem;
 }
 `,
-  });
+    "",
+    { safari: 14 << 16 },
+  );
 
-  const result = await Bun.build({
-    entrypoints: [`${dir}/test.css`],
-    outdir: `${dir}/dist`,
-    experimentalCss: true,
-    minify: false,
-    // Target older browsers that don't support logical properties
-    target: "browser",
-  });
-
-  expect(result.success).toBe(true);
-  expect(result.outputs.length).toBe(1);
-
-  const output = await result.outputs[0].text();
-
-  // When logical properties are compiled down, they should produce physical properties
-  // with :lang() selectors to handle LTR/RTL
   // At minimum, the output should NOT be empty (the bug caused empty output)
   expect(output.trim().length).toBeGreaterThan(0);
 
-  // Should have some border-radius output (compiled to physical)
-  expect(output).toMatch(/border-.*-radius/);
+  // Should have border-radius output compiled to physical properties
+  expect(output).toContain("border-top-left-radius");
+  expect(output).toContain("border-top-right-radius");
+  expect(output).toContain("border-bottom-left-radius");
+  expect(output).toContain("border-bottom-right-radius");
 
   // All classes should be present in the output
   expect(output).toContain(".test1");

--- a/test/regression/issue/25794.test.ts
+++ b/test/regression/issue/25794.test.ts
@@ -1,13 +1,10 @@
+import { cssInternals } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-test("CSS logical properties should not be stripped when nested rules are present", async () => {
-  // Test for regression of issue #25794: CSS logical properties (e.g., inset-inline-end)
-  // are stripped from bundler output when they appear in a nested selector that also
-  // contains further nested rules (like pseudo-elements).
+const { prefixTest } = cssInternals;
 
-  await using dir = tempDir("css-logical-properties-nested", {
-    "input.css": `.test-longform {
+const source = `.test-longform {
   background-color: teal;
 
   &.test-longform--end {
@@ -18,7 +15,15 @@ test("CSS logical properties should not be stripped when nested rules are presen
     }
   }
 }
-`,
+`;
+
+test("CSS logical properties should not be stripped when nested rules are present", async () => {
+  // Test for regression of issue #25794: CSS logical properties (e.g., inset-inline-end)
+  // are stripped from bundler output when they appear in a nested selector that also
+  // contains further nested rules (like pseudo-elements).
+
+  await using dir = tempDir("css-logical-properties-nested", {
+    "input.css": source,
   });
 
   await using proc = Bun.spawn({
@@ -31,7 +36,7 @@ test("CSS logical properties should not be stripped when nested rules are presen
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  // Verify the output CSS contains the logical property fallbacks
+  // Verify the output CSS preserves the logical property
   const outputContent = await Bun.file(`${dir}/out/input.css`).text();
 
   // Helper function to normalize CSS output for snapshots
@@ -41,46 +46,35 @@ test("CSS logical properties should not be stripped when nested rules are presen
       .trim();
   }
 
-  // The output should contain LTR/RTL fallback rules for inset-inline-end
-  // inset-inline-end: 20px should generate:
-  // - right: 20px for LTR languages
-  // - left: 20px for RTL languages
-  // The bundler generates vendor-prefixed variants for browser compatibility
+  // The default browser targets support inset-inline-end, so it passes
+  // through unchanged. The bug stripped the declaration entirely.
   expect(normalizeCSSOutput(outputContent)).toMatchInlineSnapshot(`
     "/* [path] */
     .test-longform {
       background-color: teal;
     }
 
-    .test-longform.test-longform--end:not(:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
-      right: 20px;
-    }
-
-    .test-longform.test-longform--end:not(:-moz-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
-      right: 20px;
-    }
-
-    .test-longform.test-longform--end:not(:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi))) {
-      right: 20px;
-    }
-
-    .test-longform.test-longform--end:-webkit-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
-      left: 20px;
-    }
-
-    .test-longform.test-longform--end:-moz-any(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
-      left: 20px;
-    }
-
-    .test-longform.test-longform--end:is(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
-      left: 20px;
+    .test-longform.test-longform--end {
+      inset-inline-end: 20px;
     }
 
     .test-longform.test-longform--end:after {
-      content: "";
+      content: \"\";
     }"
   `);
 
   // Should exit successfully
   expect(exitCode).toBe(0);
+});
+
+test("CSS logical properties in nested rules survive compiling for old targets", () => {
+  // Safari 14 does not support inset-inline-end, so it is compiled to
+  // left/right fallbacks with :lang() selectors. The bug stripped the
+  // declaration when the rule also contained further nested rules.
+  const output = prefixTest(source, "", { safari: 14 << 16 });
+
+  expect(output).toContain("right: 20px");
+  expect(output).toContain("left: 20px");
+  expect(output).toContain("content:");
+  expect(output).toContain("background-color: teal");
 });

--- a/test/regression/issue/27458.test.ts
+++ b/test/regression/issue/27458.test.ts
@@ -1,28 +1,23 @@
+import { cssInternals } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
 
-test("CSS bundler maps logical border-radius properties to correct physical properties", async () => {
-  using dir = tempDir("css-logical-border-radius", {
-    "input.css": `.box {
+const { prefixTest } = cssInternals;
+
+// https://github.com/oven-sh/bun/issues/27458
+// Safari 14 does not support logical border-radius properties, so they are
+// compiled to physical properties with LTR/RTL variants.
+test("CSS bundler maps logical border-radius properties to correct physical properties", () => {
+  const output = prefixTest(
+    `.box {
   border-start-start-radius: var(--r, 20px);
   border-start-end-radius: var(--r, 20px);
   border-end-start-radius: var(--r, 20px);
   border-end-end-radius: var(--r, 20px);
 }
 `,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "build", "input.css", "--target=browser", "--outdir", "out"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  const output = await Bun.file(`${dir}/out/input.css`).text();
+    "",
+    { safari: 14 << 16 },
+  );
 
   // Each logical property must map to its own distinct physical property.
   // The output contains LTR and RTL variants (with :lang() selectors), so
@@ -40,6 +35,4 @@ test("CSS bundler maps logical border-radius properties to correct physical prop
   expect((firstBlock.match(/border-top-right-radius/g) || []).length).toBe(1);
   expect((firstBlock.match(/border-bottom-right-radius/g) || []).length).toBe(1);
   expect((firstBlock.match(/border-bottom-left-radius/g) || []).length).toBe(1);
-
-  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- A selector list that uses `:where()` or `:has()` is split into one rule per selector, and the declaration block is duplicated into each: `:where(.a .b), :where(.c) { color: red }` becomes two rules. The reporter measured +26.6% on a real stylesheet (#40364).
- The split is correct downleveling for the default CSS browser targets (`BROWSER_DEFAULT` in `src/css/targets.rs:190`), copied from vite 4's old `'modules'` target. `Browsers::convert_from_string` keeps the lowest version per browser, so the `es2020` entry dragged the effective floor to chrome 80, edge 80, firefox 78, safari 14. Those predate `:is()` and `:where()` (chrome 88).

### Fix
- Bump the default to vite 7's default build target, "baseline-widely-available": chrome 107, edge 107, firefox 104, safari 16.
- `:is()` and `:where()` lists are now supported natively and stay one rule. A `:has()` list is still downleveled (firefox 104 lacks `:has()`), but into a single `:is()`-wrapped rule with no duplicated declarations.
- lightningcss given the same targets produces byte-identical output, both before and after this change, so the split logic itself is untouched.
- Verified: `test/bundler/css/where-selector-list-40364.test.ts` (all 5 cases fail on stock bun). Also ran `test/bundler/css/`, `test/js/bun/css/`, and the CSS-adjacent bundler suites (esbuild/css, html, loader, splitting, bun-build-api).

### Background
- Bun applies hardcoded browser targets when it bundles CSS for `target: "browser"`. There is no user-facing option yet (#40361). `Targets::for_bundler_target` selects `BROWSER_DEFAULT`. Runtime targets (`bun`, `node`) apply no browsers and are unaffected.
- When a target lacks a selector feature, the minify pass (it runs even with `minify: false`) wraps the list in `:is()`, or splits the rule per selector when `:is()` itself is unsupported. The split path is what the issue observed.
- `test/bundler/css/is-selector-21169.test.ts` no longer sees `:-webkit-any` prefixing under the default targets. The downlevel path it guarded is now covered with explicit old targets in `test/js/bun/css/css.test.ts`.

<details><summary>Notes</summary>

- Repro before: `:where(.a .b), :where(.c) { color: red; padding: 4px }` with `Bun.build({ minify: true })` printed `:where(.a .b){color:red;padding:4px}:where(.c){color:red;padding:4px}`. After: `:where(.a .b),:where(.c){color:red;padding:4px}`, identical to lightningcss 1.30.1 with no targets.
- `:has(.a), :has(.c) { color: red }` before: two rules. After: `:is(:has(.a),:has(.c)){color:red}`, identical to lightningcss with chrome 107, edge 107, firefox 104, safari 16.
- A single-compound `:is()` still unwraps: `:is(.c)` prints as `.c`. Covered in the new test file.
- Color downleveling is reduced but not gone: `oklch()` now emits two values (hex + `lab()`) instead of three (chrome 107 lacks `oklch()`, safari 16 has it). Making targets configurable is #40361.
- Vite 7 constant: `ESBUILD_BASELINE_WIDELY_AVAILABLE_TARGET = ['chrome107', 'edge107', 'firefox104', 'safari16.0']` in `packages/vite/src/node/constants.ts`.
- `test/js/bun/css/css-fuzz.test.ts` and one perf-bound test in `nested-vendor-prefix-duplication.test.ts` time out in my debug ASAN environment with and without this change (verified against a baseline build of main). All other CSS suites pass: 2377 pass, 0 fail across `test/bundler/css/` + `css.test.ts` + `color.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/css/is-selector-21169.test.ts" "test/bundler/css/where-selector-list-40364.test.ts" test/js/bun/css/css.test.ts
bun test v1.4.1 (4448a2e21)

test/bundler/css/is-selector-21169.test.ts:
10 |       `,
11 |     },
12 |     outdir: "/out",
13 |     entryPoints: ["/index.css"],
14 |     onAfterBundle(api) {
15 |       api.expectFile("/out/index.css").toMatchInlineSnapshot(`
                                            ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* index.css */
+ .foo:-webkit-any(input:checked) {
+   color: red;
+ }
+ 
+ .foo:-moz-any(input:checked) {
+   color: red;
+ }
+ 
  .foo:is(input:checked) {
    color: red;
  }
  "
  

- Expected  - 0
+ Received  + 8

      at onAfterBundle (/workspace/bun/test/bundler/css/is-selector-21169.test.ts:15:40)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1591:7)
(fail) css > css/is-selector [591.30ms]

test/bundler/css/where-selector-list-40364.test.ts:
15 |       `,
16 |     },
17 |     outdir: "/out",
18 |     entryPoints: ["/inde
... (truncated)

release without fix: 6 failed, 67 skipped
bun test v1.4.0-canary.1 (4448a2e21)

test/bundler/css/is-selector-21169.test.ts:
10 |       `,
11 |     },
12 |     outdir: "/out",
13 |     entryPoints: ["/index.css"],
14 |     onAfterBundle(api) {
15 |       api.expectFile("/out/index.css").toMatchInlineSnapshot(`
                                            ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* index.css */
+ .foo:-webkit-any(input:checked) {
+   color: red;
+ }
+ 
+ .foo:-moz-any(input:checked) {
+   color: red;
+ }
+ 
  .foo:is(input:checked) {
    color: red;
  }
  "
  

- Expected  - 0
+ Received  + 8

      at onAfterBundle (/workspace/bun/test/bundler/css/is-selector-21169.test.ts:15:40)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1591:7)
(fail) css > css/is-selector [14.11ms]

test/bundler/css/where-selector-list-40364.test.ts:
15 |       `,
16 |     },
17 |     outdir: "/out",
18 |     entryPoints: ["/index.css"],
19 |     onAfterBundle(api) {
20 |       api.expectFile("/out/index.css").toMatchInlineSnapshot(`
                                            ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* index.css */
- :where(.a .b), :w
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/css/is-selector-21169.test.ts" "test/bundler/css/where-selector-list-40364.test.ts" test/js/bun/css/css.test.ts
bun test v1.4.1 (4448a2e21)

test/bundler/css/is-selector-21169.test.ts:
(pass) css > css/is-selector [615.17ms]

test/bundler/css/where-selector-list-40364.test.ts:
(pass) css > css/where-selector-list-preserved [112.20ms]
(pass) css > css/where-selector-list-preserved-minified [162.25ms]
(pass) css > css/is-selector-list-preserved [99.09ms]
(pass) css > css/has-selector-list-not-duplicated [121.16ms]
(pass) css > css/where-selector-list-with-pseudo-elements-preserved [135.79ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [2.87ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.05ms]
Output div
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0dbbbf1c9b
  features     baseline

23 deps, 129 codegen, 1172 objects in 778ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [5.00ms]
[3/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 KB  (entry point)

[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/targets.rs                                 |  15 ++-
 test/bundler/css/is-selector-21169.test.ts         |   8 --
 test/bundler/css/where-selector-list-40364.test.ts | 118 +++++++++++++++++++++
 test/js/bun/css/css.test.ts                        |  22 ++++
 4 files changed, 147 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/css/targets.rs                                      1      2      0
test/bundler/css/is-selector-21169.test.ts              1      2      0
test/bundler/css/where-selector-list-40364.test.ts      1      2      0
test/js/bun/css/css.test.ts                             3      1      0
```

</details>

<!-- robobun:evidence:end -->