### PR TITLE
s3: root the source ReadableStream for the life of a streaming upload

### DIFF
--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -573,8 +573,7 @@ pub struct S3UploadStreamWrapper {
     pub(crate) callback_context: *mut c_void,
     /// this is owned by the task not by the wrapper
     pub path: bun_ptr::RawSlice<u8>,
-    /// Pins the source ReadableStream when the native ByteStream fast-path is
-    /// taken (no JS reader to lock it). Empty on the `assign_to_stream` path.
+    /// Roots the source ReadableStream, and the JS pump reachable only through it, until this wrapper drops.
     pub readable_stream_ref: ReadableStreamStrong,
     pub global: GlobalRef, // JSC_BORROW
 }
@@ -992,6 +991,8 @@ pub(crate) fn upload_stream(
     // default-controller stream synchronously inside `assign_to_stream`.
     task.continue_stream();
 
+    ctx.readable_stream_ref = ReadableStreamStrong::init(readable_stream, global_this);
+
     // Native ByteStream fast-path: wire the source/sink handles directly so
     // bytes flow via `ByteStream::on_data` → `SinkHandle::write` without the JS
     // `readStreamIntoSink` pump.
@@ -1000,7 +1001,6 @@ pub(crate) fn upload_stream(
             sink.source = crate::webcore::streams::SourceHandle::ByteStream(byte_stream);
             byte_stream.sink.set(sink_handle);
             byte_stream.sink_paused.set(false);
-            ctx.readable_stream_ref = ReadableStreamStrong::init(readable_stream, global_this);
             readable_stream.lock_native(global_this);
             byte_stream.signal_consumer_attached();
 

--- a/test/js/bun/s3/s3-upload-stream-gc.test.ts
+++ b/test/js/bun/s3/s3-upload-stream-gc.test.ts
@@ -1,0 +1,156 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+
+// Once a streaming S3 upload starts, the only thing that refers to the source
+// stream is the native multipart upload. A GC while the upload is parked on
+// part backpressure must not collect the stream pump: the write must still
+// settle instead of hanging or crashing.
+//
+// `makeStream` defines `makeStream()`. `upload` is an expression that starts
+// one upload with `key` and `opts` in scope and evaluates to its promise.
+function fixture(makeStream: string, upload: string) {
+  return `
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (req.method === "POST" && url.searchParams.has("uploads")) {
+          return new Response(
+            "<InitiateMultipartUploadResult><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>",
+            { headers: { "content-type": "application/xml" } },
+          );
+        }
+        if (req.method === "PUT") {
+          await req.arrayBuffer();
+          // The client waits for this part to finish before it reads more of
+          // the stream. Nothing in JS refers to the stream at this point.
+          Bun.gc(true);
+          return new Response("", { headers: { ETag: '"etag"' } });
+        }
+        await req.text();
+        return new Response(
+          '<CompleteMultipartUploadResult><ETag>"etag-1"</ETag></CompleteMultipartUploadResult>',
+          { headers: { "content-type": "application/xml" } },
+        );
+      },
+    });
+    const credentials = {
+      endpoint: "http://127.0.0.1:" + server.port,
+      bucket: "bucket",
+      accessKeyId: "key",
+      secretAccessKey: "secret",
+      region: "us-east-1",
+    };
+    const client = new Bun.S3Client(credentials);
+    const partSize = 5 * 1024 * 1024;
+    const chunk = new Uint8Array(64 * 1024).fill(97);
+    const chunkCount = 2 * (partSize / chunk.byteLength) + 1;
+    await Bun.write("source.bin", new Uint8Array(chunkCount * chunk.byteLength).fill(97));
+    ${makeStream}
+    const results = await Promise.all(
+      [1, 2].map(queueSize => {
+        const key = "key-" + queueSize;
+        const opts = { partSize, queueSize, retry: 0 };
+        return (${upload}).then(() => "ok", e => "error:" + e.message);
+      }),
+    );
+    console.log(results.join(" "));
+    server.stop(true);
+  `;
+}
+
+// Everything is enqueued up front, so the pump parks with an unwritten batch tail.
+const eagerStream = `
+  function makeStream() {
+    return new ReadableStream({
+      start(controller) {
+        for (let i = 0; i < chunkCount; i++) controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+  }
+`;
+
+// Pulled one chunk at a time.
+const pulledStream = (tail: string) => `
+  function makeStream() {
+    let sent = 0;
+    return new ReadableStream({
+      pull(controller) {
+        if (sent === chunkCount) {
+          ${tail}
+          return;
+        }
+        controller.enqueue(chunk);
+        sent++;
+      },
+    });
+  }
+`;
+
+const env = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
+
+async function run(makeStream: string, upload: string) {
+  using dir = tempDir("s3-upload-stream-gc", {});
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture(makeStream, upload)],
+    env,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: normalizeBunSnapshot(stdout), stderr: normalizeBunSnapshot(stderr), exitCode };
+}
+
+const ok = {
+  exitCode: 0,
+  stderr: "",
+  stdout: "ok ok",
+};
+
+test.concurrent("S3Client.write(key, new Response(stream)) survives GC during backpressure", async () => {
+  expect(await run(eagerStream, `client.write(key, new Response(makeStream()), opts)`)).toEqual(ok);
+});
+
+test.concurrent("S3Client.write(key, new Request(url, { body: stream })) survives GC during backpressure", async () => {
+  expect(
+    await run(
+      pulledStream("controller.close();"),
+      `client.write(key, new Request("http://localhost/", { method: "PUT", body: makeStream() }), opts)`,
+    ),
+  ).toEqual(ok);
+});
+
+test.concurrent("fetch(s3://, { method: PUT, body: stream }) survives GC during backpressure", async () => {
+  expect(
+    await run(
+      pulledStream("controller.close();"),
+      `fetch("s3://bucket/" + key, { method: "PUT", body: makeStream(), s3: { ...credentials, ...opts } })`,
+    ),
+  ).toEqual(ok);
+});
+
+test.concurrent("s3file.write(Bun.file(path)) survives GC during backpressure", async () => {
+  // The file stream is created inside bun. JS never holds a reference to it.
+  expect(await run("", `client.file(key, opts).write(Bun.file("source.bin"))`)).toEqual(ok);
+});
+
+test.concurrent("S3 upload rejects with a stream error raised after GC during backpressure", async () => {
+  expect(
+    await run(
+      pulledStream(`controller.error(new Error("stream failed"));`),
+      `client.write(key, new Response(makeStream()), opts)`,
+    ),
+  ).toEqual({
+    exitCode: 0,
+    stderr: "",
+    stdout: "error:stream failed error:stream failed",
+  });
+});


### PR DESCRIPTION
### Problem
- `S3Client.write(key, new Response(stream), { partSize, queueSize })` crashes or hangs when JS holds no other reference to `stream`. GC collects the pump while the upload is parked on part backpressure. The next UploadPart response fires `JSSinkController__onReady` into dead cells: `rsisContinueAfterReady` (`BunStreamSource.cpp:1076`) downcasts a zapped `m_pendingBatch`, SEGV at 0x10. If the sweep runs first, the controller's destructor finalizes the sink and `write()` stays pending forever.
- The cause is `upload_stream` (`s3/client.rs:1036`). It set `readable_stream_ref` only on the native ByteStream fast path. On the `assign_to_stream` path nothing rooted the stream, and `sink.source` holds the controller unrooted by design (`Sink.rs:603`).

### Fix
- Take the `ReadableStreamStrong` on the source stream before both paths. The wrapper's `Drop` releases it.
- Correct because the operation cell documents this invariant (`JSReadStreamIntoSinkOperation.h:3`: "Rust Strong -> stream -> reader -> this -> m_sink / m_result"). `FileSink::assign_to_stream` and `Bun.write(file, stream)` take the same Strong.
- Verified: `test/js/bun/s3/s3-upload-stream-gc.test.ts`, one row per upload source (Response body, Request body, `fetch` PUT to `s3://`, `Bun.file()` source, stream error). All 5 hang on main and 1.4.0. Also all of `test/js/bun/s3/` on the debug build.

### Background
- A streaming S3 upload runs the stream through `readStreamIntoSink`, a native pump feeding a `NetworkSink`. With `queueSize` parts in flight the sink returns a pending promise and the pump parks until `source.ready()`.
- `SourceHandle::JSController` is the sink's handle back to the pump. It stores the controller cell's raw `JSValue` bits without rooting it. The sink's owner keeps the stream alive instead.
- The pump graph hangs off the stream: `stream.m_reader -> reader.m_pipeOperation -> op -> { m_sink, m_result, m_pendingBatch }`.

<details><summary>Notes</summary>

**Sibling entry points.** Every streaming upload source reaches `upload_stream`: `S3Client.write(key, new Response(stream))`, `S3Client.write(key, new Request(url, { body: stream }))`, `fetch("s3://bucket/key", { method: "PUT", body: stream })` (`fetch.rs:1806`), and `s3file.write(Bun.file(path))` (a `FileReader` source is not a `ByteStream`, so it also takes the JS pump arm, and JS never holds that stream). All four hang on 1.4.0 with a `Bun.gc(true)` in the stub's UploadPart handler and complete on this branch. The test has one row per source.

**Repro.** One upload of a 10 MiB + 1 chunk stream against a loopback stub that calls `Bun.gc(true)` in its UploadPart handler. With no JS reference to the stream: 1.4.0 hangs 3/3 (release panic `Segmentation fault at address 0x0` on the fuzz script), the debug build hangs 2/2. With the stream pushed into a global array the same script completes in 0.5 s. The original fuzz script (72 uploads, natural GC plus junk allocation) completes every round on the fixed ASAN build.

**Why hang vs crash.** `Bun.gc(true)` sweeps eagerly, so `~JSReadableNetworkSinkController` runs before the UploadPart response arrives. It calls `NetworkSink__controllerDetached` (clears `sink.source`) and `NetworkSink__finalize`. The later `on_writable` then finds no source and nothing resumes the pump. With a natural GC the cells are unmarked but not yet swept when `on_writable` fires, and `onReady` decodes a dead controller.

**Other `assign_to_stream` callers** already root the stream: `FetchTasklet` (`HTTPRequestBody::ReadableStream` Strong), `RequestContext` (`response_body_readable_stream_ref`), `FileSink` (`readable_stream`), `Blob.rs` write-to-file (`FileStreamWrapper.readable_stream_ref`), HTMLRewriter (`input_stream_set_cached` on the transform cell).

**Interaction with #39692.** That PR makes the wrapper's pump ref sound when the pump is collected before a VM teardown sweep, and one of its worker_threads rows asserts the pump is collected after two GCs. With this change the pump is not collectable while the upload is live (the wrapper holds the stream until it drops), so that oracle will need to change if both land.

**Seen on the way, not changed.** The S3 client resolves its proxy with `get_http_proxy(true, None, None)` and never consults `NO_PROXY`, so an `HTTP_PROXY` environment sends loopback S3 requests through the proxy (the test unsets the proxy variables for the child). Handed off separately.

**Unrelated local failures.** `s3-list-objects.test.ts` "Should work with big responses" and "Should fall back to NoSuchKey" time out on the debug build when the file runs as a whole (15 to 22 s each), pass alone and on the release build. #39692 notes the same.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-upload-stream-gc.test.ts"
bun test v1.4.1 (d578a8c70)

test/js/bun/s3/s3-upload-stream-gc.test.ts:
(fail) S3Client.write(key, new Response(stream)) survives GC during backpressure [5004.83ms]
  ^ this test timed out after 5000ms.
(fail) S3Client.write(key, new Request(url, { body: stream })) survives GC during backpressure [5005.43ms]
  ^ this test timed out after 5000ms.
(fail) fetch(s3://, { method: PUT, body: stream }) survives GC during backpressure [5000.12ms]
  ^ this test timed out after 5000ms.
(fail) s3file.write(Bun.file(path)) survives GC during backpressure [5000.11ms]
  ^ this test timed out after 5000ms.
(fail) S3 upload rejects with a stream error raised after GC during backpressure [5000.12ms]
  ^ this test timed out after 5000ms.

 0 pass
 5 fail
Ran 5 tests across 1 file. [7.05s]
error: script "bd" exited with code 1
__F:5:S:0

release without fix: 5 FAILED
bun test v1.4.1-canary.1 (d578a8c70)

test/js/bun/s3/s3-upload-stream-gc.test.ts:
(fail) S3Client.write(key, new Response(stream)) survives GC during backpressure [5000.28ms]
  ^ this test timed out after 5000ms.
(fail) S3Client.write(key, new Request(url, { body: stream })) survives GC during backpressure [5000.06ms]
  ^ this test timed out after 5000ms.
(fail) fetch(s3://, { method: PUT, body: stream }) survives GC during backpressure [5000.06ms]
  ^ this test timed out after 5000ms.
(fail) s3file.write(Bun.file(path)) survives GC during backpressure [5000.06ms]
  ^ this test timed out after 5000ms.
(fail) S3 upload rejects with a stream error raised after GC during backpressure [5000.06ms]
  ^ this test timed out after 5000ms.

 0 pass
 5 fail
Ran 5 tests across 1 file. [5.10s]
__F:5:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-upload-stream-gc.test.ts"
bun test v1.4.1 (d578a8c70)

test/js/bun/s3/s3-upload-stream-gc.test.ts:
(pass) S3Client.write(key, new Response(stream)) survives GC during backpressure [644.25ms]
(pass) S3 upload rejects with a stream error raised after GC during backpressure [574.40ms]
(pass) S3Client.write(key, new Request(url, { body: stream })) survives GC during backpressure [711.46ms]
(pass) fetch(s3://, { method: PUT, body: stream }) survives GC during backpressure [702.05ms]
(pass) s3file.write(Bun.file(path)) survives GC during backpressure [717.87ms]

 5 pass
 0 fail
 5 expect() calls
Ran 5 tests across 1 file. [2.86s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b6be7261fd
  features     baseline

23 deps, 131 codegen, 1172 objects in 619ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (d578a8c70)

Checked 26 installs across 63 packages (no changes) [7.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (d578a8c70)

Checked 1 install across 2 packages (no changes) [5.00ms]
[4/1244] gen bindgenv2
[5/1244] fetch zlib
[zlib] up to date
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (d578a8c70)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 8ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/s3/client.rs           |   6 +-
 test/js/bun/s3/s3-upload-stream-gc.test.ts | 156 +++++++++++++++++++++++++++++
 2 files changed, 159 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/webcore/s3/client.rs                4      6      0
test/js/bun/s3/s3-upload-stream-gc.test.ts      0      3      0
```

</details>

<!-- robobun:evidence:end -->