### PR TITLE
test(tls): cover pause() and pauseOnConnect around the handshake on accepted and dialed sockets

### DIFF
--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1942,3 +1942,165 @@ it.skipIf(!nodeExe())(
     }
   },
 );
+
+describe("a dialed socket paused before its handshake completed", () => {
+  // The TLS handle has to read to complete the handshake. Node starts its reads from
+  // the read(0) that runs after the 'connect' listeners, so a pause() from one of them
+  // never stops the handle. Bun's handle reads from the start and a pause() must not
+  // stop it either while the handshake is in flight.
+  type Dialed = {
+    client: TLSSocket;
+    socket: TLSSocket;
+    onread: string[];
+    fence: () => Promise<void>;
+    [Symbol.dispose]: () => void;
+  };
+
+  async function dial(options: {
+    pauseOnConnect?: boolean;
+    onread?: boolean;
+    onConnect?: (client: TLSSocket) => void;
+    afterDial?: (client: TLSSocket) => void;
+  }): Promise<Dialed> {
+    const accepted = Promise.withResolvers<TLSSocket>();
+    const server = tls.createServer(COMMON_CERT_, accepted.resolve);
+    server.on("tlsClientError", accepted.reject);
+    // A second connection is the fence: its bytes reach this process after the server's
+    // reply reached the client's receive buffer.
+    const probe = net.createServer();
+    let client: TLSSocket | undefined;
+    const dispose = () => {
+      client?.destroy();
+      server.close();
+      probe.close();
+    };
+    try {
+      await Promise.all([
+        once(server.listen(0, "127.0.0.1"), "listening"),
+        once(probe.listen(0, "127.0.0.1"), "listening"),
+      ]);
+      const onread: string[] = [];
+      const dialed = tlsConnect({
+        port: (server.address() as AddressInfo).port,
+        host: "127.0.0.1",
+        rejectUnauthorized: false,
+        pauseOnConnect: options.pauseOnConnect,
+        onread: options.onread
+          ? {
+              buffer: Buffer.alloc(1024),
+              callback: (n: number, buf: Buffer) => onread.push(String(buf.subarray(0, n))),
+            }
+          : undefined,
+      } as tls.ConnectionOptions);
+      client = dialed;
+      if (options.onConnect) dialed.on("connect", () => options.onConnect!(dialed));
+      options.afterDial?.(dialed);
+      const [socket] = await Promise.all([accepted.promise, once(dialed, "secureConnect")]);
+      const fence = async () => {
+        const probed = Promise.withResolvers<void>();
+        probe.once("connection", s => s.once("data", () => probed.resolve()));
+        const probeClient = net.connect((probe.address() as AddressInfo).port, "127.0.0.1", () => probeClient.end("x"));
+        await probed.promise;
+      };
+      return { client: dialed, socket, onread, fence, [Symbol.dispose]: dispose };
+    } catch (error) {
+      dispose();
+      throw error;
+    }
+  }
+
+  async function untilBuffered(socket: TLSSocket, length: number) {
+    const deadline = performance.now() + 10_000;
+    while (socket.readableLength < length) {
+      if (performance.now() > deadline) throw new Error(`readableLength stayed at ${socket.readableLength}`);
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+  }
+
+  async function writeReply(socket: TLSSocket) {
+    await new Promise<void>((resolve, reject) => socket.write("from-server", err => (err ? reject(err) : resolve())));
+  }
+
+  async function roundTripAfterResume(client: TLSSocket, socket: TLSSocket) {
+    const received = once(client, "data");
+    client.resume();
+    expect(String((await received)[0])).toBe("from-server");
+    const reply = once(socket, "data");
+    client.write("from-client");
+    expect(String((await reply)[0])).toBe("from-client");
+    const clientClosed = once(client, "close");
+    socket.end();
+    client.end();
+    await clientClosed;
+  }
+
+  it("pause() in a 'connect' listener: the handshake completes and the reply waits in the stream's buffer", async () => {
+    using t = await dial({ onConnect: client => client.pause() });
+    const { client, socket } = t;
+    expect({ paused: client.isPaused(), flowing: client.readableFlowing }).toEqual({ paused: true, flowing: false });
+    await writeReply(socket);
+    // Like Node: the handle reads, the decrypted bytes wait in the paused stream.
+    await untilBuffered(client, "from-server".length);
+    expect({ paused: client.isPaused(), readableLength: client.readableLength }).toEqual({
+      paused: true,
+      readableLength: "from-server".length,
+    });
+    await roundTripAfterResume(client, socket);
+  });
+
+  // Socket.prototype.pause stops an onread handle as soon as `connecting` is false, which
+  // afterConnect clears before it emits 'connect'. The handshake still needs the reads, so
+  // it never completes. Node's handle is not reading yet inside the listener, and its
+  // onread callback gets the reply once it is.
+  it.todo("pause() in a 'connect' listener of an onread socket: the handshake still completes", async () => {
+    using t = await dial({ onread: true, onConnect: client => client.pause() });
+    const { client, socket } = t;
+    expect(client.isPaused()).toBe(true);
+    await writeReply(socket);
+    await t.fence();
+    expect(t.onread).toEqual(["from-server"]);
+    const reply = once(socket, "data");
+    client.write("from-client");
+    expect(String((await reply)[0])).toBe("from-client");
+    const clientClosed = once(client, "close");
+    socket.end();
+    client.end();
+    await clientClosed;
+  });
+
+  // pauseOnConnect on a dialed socket is Bun's option (node-net.test.ts "applies to a dialed
+  // socket"). For TLS the pause waits for the handshake.
+  it("pauseOnConnect: the handshake completes, then the socket reads nothing until resume()", async () => {
+    using t = await dial({ pauseOnConnect: true });
+    const { client, socket } = t;
+    expect({ paused: client.isPaused(), flowing: client.readableFlowing }).toEqual({ paused: true, flowing: false });
+    await writeReply(socket);
+    await t.fence();
+    // The handle stopped reading once the handshake completed, so the reply stays in the kernel.
+    expect({ paused: client.isPaused(), bytesRead: client.bytesRead }).toEqual({ paused: true, bytesRead: 0 });
+    await roundTripAfterResume(client, socket);
+  });
+
+  // The native pause runs when the handshake completes, after this resume(), and nothing
+  // starts the handle again: the stream reports flowing but the socket reads nothing. (A
+  // listener attached after 'secureConnect' would hide it: on('data') calls resume() again,
+  // which starts the handle once `connecting` is false.)
+  it.todo("pauseOnConnect: a resume() before 'secureConnect' is not undone by the handshake", async () => {
+    const received = Promise.withResolvers<string>();
+    using t = await dial({
+      pauseOnConnect: true,
+      afterDial: client => {
+        client.resume();
+        client.once("data", chunk => received.resolve(String(chunk)));
+      },
+    });
+    const { client, socket } = t;
+    expect(client.isPaused()).toBe(false);
+    await writeReply(socket);
+    expect(await received.promise).toBe("from-server");
+    const clientClosed = once(client, "close");
+    socket.end();
+    client.end();
+    await clientClosed;
+  });
+});

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2671,3 +2671,105 @@ describe("pauseOnConnect", () => {
     }
   });
 });
+
+describe("an accepted socket whose stream state changes before or during its handshake", () => {
+  // Bun hands the same TLSSocket to 'connection', before the handshake, and to
+  // 'secureConnection'. A pause() from either listener may only hold the decrypted
+  // bytes back: Node's TLSWrap reads whatever the stream's paused state is, so the
+  // handshake completes and the bytes wait in the stream's buffer until resume().
+  // A pause that stopped the native reads would stall the handshake forever.
+  async function accept(options: {
+    pauseOnConnect?: boolean;
+    on?: Partial<Record<"connection" | "secureConnection", (socket: TLSSocket) => void>>;
+  }) {
+    const server = createServer({ ...COMMON_CERT, pauseOnConnect: options.pauseOnConnect });
+    const accepted = Promise.withResolvers<TLSSocket>();
+    for (const [event, listener] of Object.entries(options.on ?? {})) server.on(event, listener);
+    server.on("secureConnection", accepted.resolve);
+    server.on("tlsClientError", accepted.reject);
+    let client: TLSSocket | undefined;
+    const dispose = () => {
+      client?.destroy();
+      server.close();
+    };
+    try {
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      client = connect({
+        port: (server.address() as AddressInfo).port,
+        host: "127.0.0.1",
+        rejectUnauthorized: false,
+      });
+      const [socket] = await Promise.all([accepted.promise, once(client, "secureConnect")]);
+      return { client, socket, [Symbol.dispose]: dispose };
+    } catch (error) {
+      dispose();
+      throw error;
+    }
+  }
+
+  async function untilBuffered(socket: TLSSocket, length: number) {
+    const deadline = performance.now() + 10_000;
+    while (socket.readableLength < length) {
+      if (performance.now() > deadline) throw new Error(`readableLength stayed at ${socket.readableLength}`);
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+  }
+
+  async function endBothSides(client: TLSSocket, socket: TLSSocket) {
+    const clientClosed = once(client, "close");
+    socket.end();
+    client.end();
+    await clientClosed;
+  }
+
+  // The 'secureConnection' case also pins that the pause holds once the listener returned.
+  it.each(["connection", "secureConnection"] as const)(
+    "s.pause() in a '%s' listener completes the handshake and buffers the bytes until resume()",
+    async event => {
+      using t = await accept({ on: { [event]: socket => socket.pause() } });
+      const { client, socket } = t;
+      expect({ paused: socket.isPaused(), flowing: socket.readableFlowing }).toEqual({ paused: true, flowing: false });
+      const chunks: string[] = [];
+      // A 'data' listener leaves a paused stream paused.
+      socket.on("data", chunk => chunks.push(String(chunk)));
+      await new Promise<void>((resolve, reject) => client.write("hello", err => (err ? reject(err) : resolve())));
+      // The stream's buffer fills because the handle still reads. Like Node, 'data' waits for resume().
+      await untilBuffered(socket, 5);
+      expect({ chunks, flowing: socket.readableFlowing, readableLength: socket.readableLength }).toEqual({
+        chunks: [],
+        flowing: false,
+        readableLength: 5,
+      });
+      const received = once(socket, "data");
+      socket.resume();
+      await received;
+      expect(chunks).toEqual(["hello"]);
+      await endBothSides(client, socket);
+    },
+  );
+
+  it("pauseOnConnect: a resume() in the 'secureConnection' listener is not undone afterwards", async () => {
+    using t = await accept({ pauseOnConnect: true, on: { secureConnection: socket => socket.resume() } });
+    const { client, socket } = t;
+    expect({ paused: socket.isPaused(), flowing: socket.readableFlowing }).toEqual({ paused: false, flowing: true });
+    const received = once(socket, "data");
+    client.write("hello");
+    expect(String((await received)[0])).toBe("hello");
+    await endBothSides(client, socket);
+  });
+
+  // Node's TLSWrap reads ahead, so the paused socket sees the peer's close_notify and emits
+  // 'end' at once. Ours stops reading once the handshake completed, and a close_notify that
+  // arrives after that waits in the kernel until resume(). Plain net sockets behave like
+  // ours in both runtimes.
+  it.todo("pauseOnConnect: a socket still paused emits 'end' when the peer ends", async () => {
+    using t = await accept({ pauseOnConnect: true });
+    const { client, socket } = t;
+    const ended = once(socket, "end");
+    client.end();
+    await ended;
+    expect(socket.isPaused()).toBe(true);
+    socket.end();
+    await once(client, "close");
+  });
+});


### PR DESCRIPTION
### Problem
- A `pause()` on a TLS socket before its handshake used to stall it forever (`s.pause()` in a `tls.Server` `'connection'` listener, `pauseOnConnect` on a server or on `tls.connect`). Bun 1.4.0 hangs, Node completes.
- #39830 (e54bbfa70c) fixed it: `Socket.prototype.pause` no longer stops the native handle, and a `pauseOnConnect` TLS socket is paused after its handshake. Its tests do not cover the paths #35151 and #35148 tested.

### Fix
- Test only. `node-tls-server.test.ts`: a `pause()` from the `'connection'` or `'secureConnection'` listener completes the handshake and buffers the bytes until `resume()`. A `resume()` in the `'secureConnection'` listener of a `pauseOnConnect` server holds (#35148's case).
- `node-tls-connect.test.ts`: a `pause()` in a `'connect'` listener completes the handshake and buffers the reply like Node. `tls.connect({ pauseOnConnect: true })` reads nothing until `resume()`.
- Three neighbouring cells fail on main and are `it.todo` rows, the cause in a comment: an onread socket paused from its `'connect'` listener never completes the handshake (Node does), a `resume()` before `'secureConnect'` on a dialed `pauseOnConnect` socket is undone by the native pause, and a paused `pauseOnConnect` server socket does not see the peer's `end()` (Node does).
- Verified: `bun bd test test/js/node/tls/node-tls-server.test.ts` and `node-tls-connect.test.ts`, 10 runs each. With `--todo` the todo rows fail. On the 1.4.0 release binary the listener tests and the `pauseOnConnect` client test time out.

### Background
- Bun hands the same `TLSSocket` to `'connection'` (before the handshake) and to `'secureConnection'`. Node hands `'connection'` the plain `net.Socket`. In Bun a pre-handshake `pause()` acts on the socket that reads the handshake.
- Node's `TLSWrap` reads whatever the stream's paused state is. A paused `TLSSocket` buffers the decrypted bytes.

<details><summary>Notes</summary>

This closes out #35151 and #35148, which fixed the same hang in `src/js/node/net.ts` (a `secureConnecting` gate on the native pause, a Duplex-only pause for `pauseOnConnect`). Neither diff applies on main: #39830 rewrote `Socket.prototype.pause` and `ServerHandlers.handshake`. Their tests on main: the listener cases pass, and the server `pauseOnConnect` tests fail on one assertion main does not share. They expected the client's bytes in the stream's buffer (`readableLength` 5) while the socket is paused. Main keeps them in the kernel (`bytesRead` 0) until `resume()`, the choice #39830 made and pinned in `node-tls-server.test.ts`. Both deliver nothing before `resume()`.

The first version of this PR carried the upstream `test-tls-server-parent-constructor-options.js`. It is dropped here. Its second block asserts `'end'` on a `pauseOnConnect` socket that is still paused, which main does not implement: the test passes only because the client's close_notify arrives in the same read as its Finished (the client ends from `secureConnect`, in the same process). The `'end'` todo row pins the real behavior. The file lands with #35386, which touches the same path.

The three todo rows, in detail. (1) `Socket.prototype.pause` (net.ts) stops an onread handle once `connecting` is false, and `afterConnect` clears it before it emits `'connect'`, so a `pause()` from that listener stops the reads the handshake needs. Node's handle is not reading yet inside the listener (its `read(0)` runs after), and its onread callback gets the reply once it is. (2) For a dialed `pauseOnConnect` socket the native pause runs in `on_handshake` (`socket_body.rs`, `pause_on_connect_once`), after a `resume()` made while connecting, and nothing starts the handle again. A `'data'` listener attached after `'secureConnect'` hides it: `on('data')` calls `resume()`, which starts the handle once `connecting` is false. (3) A `pauseOnConnect` server socket is paused natively once the handshake completed, so a close_notify that arrives after that waits in the kernel until `resume()`. Plain net sockets behave like this in Node too. Node's TLS socket emits `'end'` at once.

Also ran the full `node-tls-server.test.ts` (79 pass, the `SNICallback runs even when the requested servername matches the bind hostname` failure is pre-existing on main here, a `localhost` resolution issue, see #35160) and `node-tls-connect.test.ts` (47 pass, 18 skip).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tls/node-tls-server.test.ts

<!-- robobun:evidence:end -->