### PR TITLE
install: give each manifest cache write its own temporary file

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -17,6 +17,7 @@ use bun_url::{OwnedURL, URL};
 use bun_wyhash::Wyhash11;
 
 use crate::bin::{self, Bin};
+use crate::bun_fs::FileSystem;
 use crate::external_slice::ExternalPackageNameHashList;
 use crate::integrity::Integrity;
 use crate::{
@@ -1355,22 +1356,10 @@ pub mod package_manifest {
             cache_dir: Fd,
         ) -> Result<(), Error> {
             let file_id = Wyhash11::hash(0, this.name());
-            let mut dest_path_buf = [0u8; 512 + 64];
+            let mut tmp_path_buf = [0u8; 64];
+            let tmp_path = FileSystem::tmpname(b"npm", &mut tmp_path_buf, bun_core::fast_random())?;
             let mut out_path_buf =
                 [0u8; ("18446744073709551615".len() * 2) + "_".len() + ".npm".len() + 1];
-            let mut dest_path_stream = bun_io::FixedBufferStream::new_mut(&mut dest_path_buf);
-            let file_id_hex_fmt = bun_fmt::hex_int_lower::<16>(file_id);
-            let hex_timestamp: usize =
-                usize::try_from(bun_core::time::milli_timestamp().max(0)).expect("int cast");
-            let hex_timestamp_fmt = bun_fmt::hex_int_lower::<16>(hex_timestamp as u64);
-            write!(
-                dest_path_stream,
-                "{}.npm-{}",
-                file_id_hex_fmt, hex_timestamp_fmt
-            )?;
-            dest_path_stream.write_byte(0)?;
-            let pos = dest_path_stream.pos;
-            let tmp_path = bun_core::ZStr::from_buf_mut(&mut dest_path_buf, pos - 1);
             let out_path = Self::manifest_file_name(&mut out_path_buf, file_id, scope)?;
             Self::write_file(this, scope, tmp_path, tmpdir, cache_dir, out_path)
         }

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn, write } from "bun";
 import { install_test_helpers, npm_manifest_test_helpers } from "bun:internal-for-testing";
-import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { copyFileSync, mkdirSync } from "fs";
 import { cp, exists, lstat, mkdir, readlink, rename, rm, writeFile } from "fs/promises";
 import {
@@ -9863,6 +9863,148 @@ test("npm manifest cache entries are only reused for the package name they were 
 
   expect(parseManifest(byName["no-deps"], registryUrl()).name).toBe("no-deps");
   expect(exitCode).toBe(0);
+});
+
+// A manifest cache entry is written to a temporary file in the temporary
+// directory and renamed into the cache directory. Every install on the machine
+// shares the temporary directory, so the temporary file name has to be unique
+// per writer. It used to be the package name hash and the current millisecond:
+// two installs that saved the same package in the same millisecond opened one
+// file, and the rename of one moved the other's bytes into its cache (an entry
+// for the wrong registry) or left it with no entry at all. Linux writes the
+// entry with O_TMPFILE and does not use the name.
+describe("manifest cache temporary files", () => {
+  const { parseManifest } = npm_manifest_test_helpers;
+  const name = "shared-temp-name";
+  const tarballPath = `/${name}-1.0.0.tgz`;
+  let tarball: Uint8Array;
+  beforeAll(async () => {
+    tarball = await new Bun.Archive(
+      { "package/package.json": JSON.stringify({ name, version: "1.0.0" }) },
+      { compress: "gzip" },
+    ).bytes();
+  });
+
+  function cacheDirOf(cwd: string) {
+    return join(cwd, ".bun-cache");
+  }
+
+  async function cacheEntries(cwd: string) {
+    return (await readdirSorted(cacheDirOf(cwd))).filter(entry => entry.endsWith(".npm"));
+  }
+
+  /**
+   * Serves `name` to the project at `cwd`. The manifest response waits for
+   * `hold`. The tarball response waits until the manifest's cache entry exists
+   * (bun install writes it from a thread pool task it does not wait for before
+   * exiting, so this keeps the install alive until the entry is on disk), or
+   * gives up after a few seconds so a lost write still ends as a failed assertion.
+   */
+  function serveRegistry(cwd: string, hold: () => Promise<void> = async () => {}) {
+    return Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const { origin, pathname } = new URL(request.url);
+        if (pathname === tarballPath) {
+          const deadline = Date.now() + 5_000;
+          while ((await cacheEntries(cwd)).length === 0 && Date.now() < deadline) await Bun.sleep(10);
+          return new Response(tarball);
+        }
+        if (pathname !== `/${name}`) return new Response("not found", { status: 404 });
+        await hold();
+        return Response.json({
+          name,
+          "dist-tags": { latest: "1.0.0" },
+          versions: { "1.0.0": { name, version: "1.0.0", dist: { tarball: `${origin}${tarballPath}` } } },
+        });
+      },
+    });
+  }
+
+  /** Installs `name` into the project at `cwd`, with its own cache directory, and returns the cache entry it left, by package name. */
+  async function installAndReadCache(cwd: string, registryHref: string) {
+    const cacheDir = cacheDirOf(cwd);
+    mkdirSync(cacheDir, { recursive: true });
+    await Promise.all([
+      write(join(cwd, "package.json"), JSON.stringify({ name: "app", dependencies: { [name]: "1.0.0" } })),
+      write(join(cwd, "bunfig.toml"), `[install]\nregistry = "${registryHref}"\n`),
+    ]);
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir },
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain(`+ ${name}@1.0.0`);
+    expect(exitCode).toBe(0);
+
+    // parseManifest rejects an entry that was saved for another registry.
+    const entries = await cacheEntries(cwd);
+    try {
+      return {
+        entries,
+        cached: entries.length === 1 ? parseManifest(join(cacheDir, entries[0]), registryHref).name : undefined,
+      };
+    } catch (error) {
+      return { entries, cached: String(error) };
+    }
+  }
+
+  test("concurrent installs saving the same manifest keep their own cache entries", async () => {
+    const installs = 4;
+    for (let round = 0; round < 3; round++) {
+      // Every registry holds its manifest response until all of them have been
+      // asked, so the installs parse and save the manifest at the same time.
+      let asked = 0;
+      const { promise: allAsked, resolve: release } = Promise.withResolvers<void>();
+      const projects = Array.from({ length: installs }, (_, i) => join(packageDir, `round-${round}-${i}`));
+      const registries = projects.map(cwd =>
+        serveRegistry(cwd, () => {
+          if (++asked === installs) release();
+          return allAsked;
+        }),
+      );
+      try {
+        const results = await Promise.all(projects.map((cwd, i) => installAndReadCache(cwd, registries[i].url.href)));
+        expect({ round, cached: results.map(result => result.cached) }).toEqual({
+          round,
+          cached: Array(installs).fill(name),
+        });
+      } finally {
+        for (const server of registries) server.stop(true);
+      }
+    }
+  });
+
+  test("the temporary file is not named after the package and the current millisecond", async () => {
+    // A cold install caches the manifest as <hash of name>-<hash of registry url>.npm.
+    const first = join(packageDir, "first");
+    await using registry = serveRegistry(first);
+    const { entries, cached } = await installAndReadCache(first, registry.url.href);
+    expect(cached).toBe(name);
+    const nameHash = entries[0].slice(0, entries[0].indexOf("-"));
+    expect(nameHash).toMatch(/^[0-9a-f]{16}$/);
+
+    // Hold the manifest response until a directory sits at the old temporary
+    // file name of this package for every millisecond of the next seconds. An
+    // install that picks such a name cannot open it (EISDIR) and saves nothing.
+    const second = join(packageDir, "second");
+    const { promise: trapReady, resolve: trapIsReady } = Promise.withResolvers<void>();
+    await using trapped = serveRegistry(second, () => trapReady);
+    const installed = installAndReadCache(second, trapped.url.href);
+    const tmpDir = String(env.BUN_TMPDIR);
+    mkdirSync(tmpDir, { recursive: true });
+    const start = Date.now() - 100;
+    for (let ms = start; ms < Date.now() + 3_000 && ms < start + 10_000; ms++) {
+      mkdirSync(join(tmpDir, `${nameHash}.npm-${ms.toString(16).padStart(16, "0")}`));
+    }
+    trapIsReady();
+    expect((await installed).cached).toBe(name);
+  });
 });
 
 describe("manifest conditional requests", () => {


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-lock.test.ts` > "peer no published version satisfies" > "declared by a registry package" (from #38851) fails on main about every fourth build (build 104990). `expect(registry.requests).toEqual([])` at bun-lock.test.ts:1778 receives `["/peer-target"]`: the manifest cache has no usable entry for `peer-target`. It has two causes. #40073 covers the first, the `save_async` exit race. This PR fixes the second.
- `Serializer::save` (src/install/npm.rs:1352) named the temporary file `<name hash>.npm-<milliseconds>` in the temporary directory every bun process shares. The four concurrent peer tests all save `peer-target`, and two saves in one millisecond opened one file. Windows, release build, four installs saving one package at once: 77 of 80 lost their entry. Linux uses `O_TMPFILE` today; #38916 starts using the name on Linux too, so this fix has to land first.

### Fix
- `Serializer::save` names the file with `FileSystem::tmpname`, as `TarballStream` already does. Correct because the name no longer depends on anything two processes share.
- Two tests in `bun-install-registry.test.ts`: four synchronized installs keep their own valid entries, and an install still caches its manifest when directories occupy the old temporary names. The second fails 3 of 3 on Windows without the fix and passes 5 of 5 with it. The test registry serves the tarball only after the cache entry exists, so neither test depends on the exit race.
- Verified: `bun bd test test/cli/install/bun-install-registry.test.ts` (250 pass) on Linux, both new tests on Windows.

### Background
- Manifest cache: each fetched manifest is serialized to `<cache dir>/<name hash>-<registry hash>.npm`. Within the response's `max-age`, a later install resolves from that file and makes no request.
- `write_file` opens the temporary file with `O_CREAT | O_TRUNC`, writes, then renames it into the cache. Two processes on one name write one file. On macOS the second rename fails and the first cache holds the second's bytes, which `load_by_file` rejects. On Windows `rename_at_w` moves by handle, so the second rename moves the file out of the first cache again.
- The exit race: `save_async` writes the entry from a thread pool task that `bun install` does not wait for, by design (#37203). The test change in #39190 works around it for the bun-lock test. The harness flag in #40073 removes it from every install test.

<details><summary>Notes</summary>

Probe (Windows, 16 vCPUs): one registry and one project per install, `dependencies: { "peer-target": "2.0.1" }`, each registry holds its manifest response until all four have been asked, then all respond at once. After exit, the `.npm` entry is read and checked for the install's own registry origin.

| binary | temp dir | rounds | ok | missing | wrong registry |
| --- | --- | --- | --- | --- | --- |
| 1.4.1-canary.1 (release, unfixed) | shared `%TEMP%` | 20 | 3 | 60 | 17 |
| 1.4.1-canary.1 (release, unfixed) | shared, responses not synchronized | 40 | 135 | 17 | 8 |
| 1.4.1-canary.1 (release, unfixed) | one per install | 40 | 160 | 0 | 0 |
| debug, unfixed | shared | 20 | 74 | 3 | 3 |
| debug, this branch | shared | 20 | 80 | 0 | 0 |

The unfixed debug build loses far fewer entries than the release build because its slower parse spreads the four saves over several milliseconds. That is also why the concurrent test detects the bug almost always on release lanes and only sometimes on a debug build. The directory test fails deterministically on a debug build (3 of 3 and, in an earlier shape of the test, 5 of 5 on Windows).

Windows mechanism in detail: `open_file_at_windows` maps `O_CREAT | O_TRUNC` to `FILE_OVERWRITE_IF` with `FILE_SHARE_READ | WRITE | DELETE`, so every process opens and truncates the same file. `rename_at_w` (src/sys/windows/mod.rs:1933) opens the source by path and then moves it by handle. When two processes have opened the path before either moves it, both moves succeed: the second one relocates the file out of the first process's cache. That process sees a successful save and has no entry, which is the "no entry, no error" case in the probe.

`FileSystem::tmpname` (src/resolver/lib.rs:198) formats `.<random ^ nanoseconds>-<counter>.<ext>`. The temporary directory probe in `PackageManagerDirectories.rs` and `TarballStream::open_destination` use it the same way.

Test registry and the exit race: both new tests read the cache after the install exits. To keep them independent of the `save_async` exit race, the registry answers the tarball request only once a `.npm` entry exists in the project's cache (polling with a 5 second deadline, after which it answers anyway so a lost write ends as a failed assertion instead of a hang). The tarball is requested after the manifest is parsed, so the install cannot finish before its entry is on disk.

Sequencing: #38916 changes the Linux `O_TMPFILE` path to link the file into the temporary directory under `tmp_path` before renaming it over an existing entry, which makes the name load-bearing on Linux. This PR should land before it. #39190 (the bun-lock warm-up loop) and #40073 (harness flag) handle the exit race; an earlier shape of this PR carried #39190's commit, which the self-review flagged as a duplicate of an open PR, so it was dropped.

Gate: the fixed code path is not reachable on Linux today (`O_TMPFILE`), so the new tests pass on Linux with and without the fix. The fail-before proof is the Windows run above.

Also run: `cargo clippy -p bun_install`, clean.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts, test/cli/install/bun-lock.test.ts

<!-- robobun:evidence:end -->