### PR TITLE
Bun.Image: add extract() for cropping to an exact region

### DIFF
--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -90,7 +90,7 @@ img.extract({ width: 400, height: 400 }); // left/top default to 0
 img.extract({ left: 200, top: 200, width: 400, height: 400 }).resize(100, 100); // crop, then resize
 ```
 
-`width` and `height` are required; `left` and `top` default to `0`. All four must be non-negative integers. A region that falls outside the image rejects with `ERR_IMAGE_BAD_EXTRACT_AREA` — nothing is clamped.
+`width` and `height` are required integers, at least 1; `left` and `top` are non-negative integers, defaulting to `0`. A region that falls outside the image rejects with `ERR_IMAGE_BAD_EXTRACT_AREA` — nothing is clamped.
 
 Operations run in a fixed order (rotate → flip → extract → resize), so the region addresses upright source pixels and a chained `resize()` scales the cropped region. Extracting _from_ a resized result isn't expressible in one pipeline; resize first, then feed the output to a second `Bun.Image`.
 

--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -80,6 +80,22 @@ img.resize(800, 600, { filter: "mitchell" });
 
 When the source is a JPEG and the target is at most half the source size, decode skips straight to the nearest M/8 IDCT scale. As a result, generating a thumbnail from a 24 MP photo never materializes the full-resolution buffer.
 
+## Extract
+
+Crop to an exact region of the source:
+
+```ts
+img.extract({ left: 100, top: 50, width: 800, height: 600 });
+img.extract({ width: 400, height: 400 }); // left/top default to 0
+img.extract({ left: 200, top: 200, width: 400, height: 400 }).resize(100, 100); // crop, then resize
+```
+
+`width` and `height` are required; `left` and `top` default to `0`. All four must be non-negative integers. A region that falls outside the image rejects with `ERR_IMAGE_BAD_EXTRACT_AREA` — nothing is clamped.
+
+Operations run in a fixed order (rotate → flip → extract → resize), so the region addresses upright source pixels and a chained `resize()` scales the cropped region. Extracting _from_ a resized result isn't expressible in one pipeline; resize first, then feed the output to a second `Bun.Image`.
+
+An extract turns off the JPEG reduced-scale decode described in Resize above, since the region is addressed in full-resolution pixels. `.placeholder()` ignores pipeline operations, `extract` included.
+
 ## Rotate · flip
 
 ```ts

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8924,6 +8924,8 @@ declare module "bun" {
      * - `ERR_IMAGE_TOO_MANY_PIXELS` — header dimensions or resize output
      *   exceed `maxPixels`, or a path-backed input is over the 256 MiB cap.
      * - `ERR_IMAGE_DECODE_FAILED` / `ERR_IMAGE_ENCODE_FAILED` — codec error.
+     * - `ERR_IMAGE_BAD_EXTRACT_AREA` — an `extract()` region falls outside
+     *   the image bounds.
      * - `ERR_IMAGE_UNKNOWN_FORMAT` — input bytes didn't match any sniffer.
      * - `ERR_INVALID_STATE` — the input ArrayBuffer was transferred between
      *   construction and the terminal call.
@@ -8935,6 +8937,7 @@ declare module "bun" {
       | "ERR_IMAGE_TOO_MANY_PIXELS"
       | "ERR_IMAGE_DECODE_FAILED"
       | "ERR_IMAGE_ENCODE_FAILED"
+      | "ERR_IMAGE_BAD_EXTRACT_AREA"
       | "ERR_IMAGE_UNKNOWN_FORMAT"
       | "ERR_INVALID_STATE";
 
@@ -8970,6 +8973,22 @@ declare module "bun" {
        * @default true
        */
       autoOrient?: boolean;
+    }
+
+    /**
+     * Rectangle for {@link Bun.Image.extract | `extract()`}, in pixels of the
+     * upright (post-rotation) source. `left`/`top` default to `0`;
+     * `width`/`height` are required and must be at least 1.
+     */
+    interface Region {
+      /** Left edge of the region. @default 0 */
+      left?: number;
+      /** Top edge of the region. @default 0 */
+      top?: number;
+      /** Width of the region, ≥ 1. */
+      width: number;
+      /** Height of the region, ≥ 1. */
+      height: number;
     }
 
     interface ResizeOptions {
@@ -9010,7 +9029,7 @@ declare module "bun" {
    *
    * Chainables overwrite (calling `.resize()` twice keeps the second). Order
    * of execution is fixed regardless of call order:
-   * `autoOrient → rotate → flip/flop → resize → modulate`.
+   * `autoOrient → rotate → flip/flop → extract → resize → modulate`.
    *
    * The source ICC colour profile (Display P3, Adobe RGB, Jpegli XYB, etc.)
    * is preserved through re-encode to JPEG, PNG, and WebP so non-sRGB
@@ -9065,6 +9084,13 @@ declare module "bun" {
 
     /** Set target dimensions. Omit `height` to keep the source aspect ratio. */
     resize(width: number, height?: number, options?: Image.ResizeOptions): this;
+    /**
+     * Crop to an exact region of the source, before any `resize()`. The
+     * region addresses upright (post-rotation) source pixels; a region that
+     * falls outside the image rejects with `ERR_IMAGE_BAD_EXTRACT_AREA`.
+     * Calling it again replaces the previous region.
+     */
+    extract(region: Image.Region): this;
     /** Rotate by a multiple of 90°. */
     rotate(degrees: number): this;
     /** Mirror about the x-axis (vertical). */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8977,8 +8977,8 @@ declare module "bun" {
 
     /**
      * Rectangle for {@link Bun.Image.extract | `extract()`}, in pixels of the
-     * upright (post-rotation) source. `left`/`top` default to `0`;
-     * `width`/`height` are required and must be at least 1.
+     * upright (post-rotation) source. `left`/`top` default to `0` and must be
+     * non-negative integers. `width`/`height` are required positive integers.
      */
     interface Region {
       /** Left edge of the region. @default 0 */
@@ -9086,9 +9086,11 @@ declare module "bun" {
     resize(width: number, height?: number, options?: Image.ResizeOptions): this;
     /**
      * Crop to an exact region of the source, before any `resize()`. The
-     * region addresses upright (post-rotation) source pixels; a region that
-     * falls outside the image rejects with `ERR_IMAGE_BAD_EXTRACT_AREA`.
-     * Calling it again replaces the previous region.
+     * region addresses upright (post-rotation) source pixels; `left`/`top`
+     * must be non-negative integers and `width`/`height` positive integers.
+     * A region that falls outside the image rejects with
+     * `ERR_IMAGE_BAD_EXTRACT_AREA`. Calling it again replaces the previous
+     * region.
      */
     extract(region: Image.Region): this;
     /** Rotate by a multiple of 90°. */

--- a/src/runtime/image/Image.classes.ts
+++ b/src/runtime/image/Image.classes.ts
@@ -37,6 +37,7 @@ export default [
     proto: {
       // Chainable mutators — record an op and return `this`.
       resize: { fn: "doResize", length: 2 },
+      extract: { fn: "doExtract", length: 1 },
       rotate: { fn: "doRotate", length: 1 },
       flip: { fn: "doFlip", length: 0 },
       flop: { fn: "doFlop", length: 0 },

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -190,19 +190,32 @@ impl Default for Resize {
     }
 }
 
+/// `.extract()` region, in upright (post-rotate/flip) source space. Bounds
+/// are validated against the decoded dimensions at execute time.
+#[derive(Clone, Copy)]
+pub struct Extract {
+    pub(crate) left: u32,
+    pub(crate) top: u32,
+    pub(crate) w: u32,
+    pub(crate) h: u32,
+}
+
 /// One slot per operation, not an op list — calling `.resize()` twice
 /// overwrites, it doesn't resize twice. This is Sharp's semantics and means
 /// the worker snapshot is a plain struct copy with a fixed execution order
 /// (`run()` below), no allocation, no "too many ops" edge.
 ///
-/// Execution order matches Sharp: (autoOrient) → rotate → flip/flop → resize
-/// → modulate. Rotate precedes resize so the target box is interpreted in
-/// upright space; modulate runs last so it operates on the fewest pixels.
+/// Execution order matches Sharp: (autoOrient) → rotate → flip/flop →
+/// extract → resize → modulate. Rotate precedes resize so the target box is
+/// interpreted in upright space; extract precedes resize (Sharp's
+/// pre-resize `extract`) so the region is addressed in source pixels;
+/// modulate runs last so it operates on the fewest pixels.
 #[derive(Clone, Copy, Default)]
 pub struct Pipeline {
     pub(crate) rotate: u16, // 0/90/180/270
     pub(crate) flip: bool,  // vertical
     pub(crate) flop: bool,  // horizontal
+    pub(crate) extract: Option<Extract>,
     pub(crate) resize: Option<Resize>,
     pub(crate) modulate: Option<Modulate>,
     /// Output settings from `.jpeg()/.png()/.webp()`. `None` ⇒ re-encode in
@@ -480,6 +493,56 @@ impl Image {
     }
 
     #[bun_jsc::host_fn(method)]
+    pub(crate) fn do_extract(
+        &self,
+        global: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let args = callframe.arguments();
+        if args.len() < 1 || !args[0].is_object() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "extract({{ left, top, width, height }})"
+            )));
+        }
+        let opt = args[0];
+        // Every present field must be an in-range integer — a clamped or
+        // truncated origin is a different crop than the one the caller asked
+        // for, and Sharp throws for the same inputs. (u32::MAX bound, not
+        // 0x3FFFF like resize: the output can never exceed the decoded
+        // source, and `crop` bounds-checks in u64.)
+        fn field(global: &JSGlobalObject, v: JSValue, name: &str, min: f64) -> JsResult<u32> {
+            let x = if v.is_number() { v.as_number() } else { f64::NAN };
+            if !(x >= min) || x > u32::MAX as f64 || x.fract() != 0.0 {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "extract: {name} must be an integer >= {min}"
+                )));
+            }
+            Ok(x as u32)
+        }
+        let mut e = Extract {
+            left: 0,
+            top: 0,
+            w: 0,
+            h: 0,
+        };
+        if let Some(v) = opt.get(global, "left")? {
+            e.left = field(global, v, "left", 0.0)?;
+        }
+        if let Some(v) = opt.get(global, "top")? {
+            e.top = field(global, v, "top", 0.0)?;
+        }
+        let (Some(w), Some(h)) = (opt.get(global, "width")?, opt.get(global, "height")?) else {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "extract: width and height are required"
+            )));
+        };
+        e.w = field(global, w, "width", 1.0)?;
+        e.h = field(global, h, "height", 1.0)?;
+        self.update_pipeline(|p| p.extract = Some(e));
+        Ok(callframe.this())
+    }
+
+    #[bun_jsc::host_fn(method)]
     pub(crate) fn do_rotate(
         &self,
         global: &JSGlobalObject,
@@ -635,6 +698,7 @@ fn error_code(e: codecs::Error) -> &'static ZStr {
         E::DecodeFailed => zstr!("ERR_IMAGE_DECODE_FAILED"),
         E::EncodeFailed => zstr!("ERR_IMAGE_ENCODE_FAILED"),
         E::TooManyPixels => zstr!("ERR_IMAGE_TOO_MANY_PIXELS"),
+        E::BadExtractArea => zstr!("ERR_IMAGE_BAD_EXTRACT_AREA"),
         E::UnsupportedOnPlatform => zstr!("ERR_IMAGE_FORMAT_UNSUPPORTED"),
         E::OutOfMemory => zstr!("ERR_OUT_OF_MEMORY"),
     }
@@ -649,6 +713,7 @@ fn error_message(e: codecs::Error) -> &'static ZStr {
         E::DecodeFailed => zstr!("Image: decode failed"),
         E::EncodeFailed => zstr!("Image: encode failed"),
         E::TooManyPixels => zstr!("Image: input exceeds maxPixels limit"),
+        E::BadExtractArea => zstr!("Image: extract area exceeds image bounds"),
         E::UnsupportedOnPlatform => zstr!(
             "Image: format not supported on this machine (HEIC/AVIF/TIFF require the OS codec; AVIF encode needs an AV1 encoder)"
         ),
@@ -1632,7 +1697,12 @@ impl PipelineTask {
         // can be over-shrunk and then upscaled, throwing away detail.
         // (flip/flop are pure mirrors that never change w/h, so the hint
         //  stays valid through them.)
-        let hint: codecs::DecodeHint = if let Some(r) = self.pipeline.resize {
+        // An extract disables the hint entirely: its coordinates address
+        // full-resolution source pixels, and the resize target applies to the
+        // extracted region — a reduced-scale decode would shift both.
+        let hint: codecs::DecodeHint = if self.pipeline.extract.is_some() {
+            codecs::DecodeHint::default()
+        } else if let Some(r) = self.pipeline.resize {
             let mut tw = r.w;
             // r.h==0 means "preserve aspect" — constrain on width only.
             let mut th = if r.h != 0 { r.h } else { r.w };
@@ -1923,7 +1993,7 @@ impl PipelineTask {
         Ok(())
     }
 
-    /// Fixed Sharp order: rotate → flip/flop → resize. Each stage replaces
+    /// Fixed Sharp order: rotate → flip/flop → extract → resize. Each stage replaces
     /// `d` in place; the old buffer is freed before assigning the new one so
     /// peak memory is at most 2× one frame. Every stage hand-swaps only the
     /// pixel slots — rotate/resize return a fresh `Decoded` with
@@ -1947,6 +2017,16 @@ impl PipelineTask {
         if p.flop {
             let next = codecs::flip(&d.rgba, d.width, d.height, true)?;
             d.rgba = next;
+        }
+        if let Some(e) = p.extract {
+            // Skip the whole-image identity region; `crop` bounds-checks and
+            // rejects everything else that doesn't fit.
+            if e.left != 0 || e.top != 0 || e.w != d.width || e.h != d.height {
+                let next = codecs::crop(&d.rgba, d.width, d.height, e.left, e.top, e.w, e.h)?;
+                d.rgba = next;
+                d.width = e.w;
+                d.height = e.h;
+            }
         }
         if let Some(r) = p.resize {
             let t = resolve_resize(r, d.width, d.height);

--- a/src/runtime/image/README.md
+++ b/src/runtime/image/README.md
@@ -28,7 +28,7 @@ The codecs themselves are vendored via `scripts/build/deps/{libjpeg-turbo,libspn
 
 1. Add a field to `Pipeline` in `Image.rs` (one slot per op — setters
    overwrite, there is no op list) and a stage in `PipelineTask.applyPipeline`
-   at the right point in the fixed `rotate → flip/flop → resize → modulate`
+   at the right point in the fixed `rotate → flip/flop → extract → resize → modulate`
    order.
 2. Add a `do<Name>` method that parses args, writes the slot, returns
    `callframe.this()`.

--- a/src/runtime/image/backend_coregraphics.rs
+++ b/src/runtime/image/backend_coregraphics.rs
@@ -37,6 +37,8 @@ impl From<codecs::Error> for BackendError {
             codecs::Error::OutOfMemory => Self::OutOfMemory,
             codecs::Error::UnknownFormat => Self::UnknownFormat,
             codecs::Error::UnsupportedOnPlatform => Self::UnsupportedOnPlatform,
+            // Backend ops never crop; arm exists only for totality.
+            codecs::Error::BadExtractArea => Self::DecodeFailed,
         }
     }
 }

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -239,6 +239,9 @@ pub enum Error {
     /// BEFORE allocating the full RGBA buffer.
     #[error("TooManyPixels")]
     TooManyPixels,
+    /// `.extract()` region falls outside the (post-rotate) image bounds.
+    #[error("BadExtractArea")]
+    BadExtractArea,
     /// HEIC/AVIF on a platform with no system backend (Linux), or the system
     /// backend declined and there's no static codec to fall back to.
     #[error("UnsupportedOnPlatform")]
@@ -780,5 +783,31 @@ pub(crate) fn flip(src: &[u8], w: u32, h: u32, horizontal: bool) -> Result<Vec<u
     };
     // SAFETY: the flip kernel is a permutation that stores every one of the w*h dst pixels.
     unsafe { bun_core::vec::commit_spare(&mut out, out_len) };
+    Ok(out)
+}
+
+pub(crate) fn crop(
+    src: &[u8],
+    sw: u32,
+    sh: u32,
+    x: u32,
+    y: u32,
+    cw: u32,
+    ch: u32,
+) -> Result<Vec<u8>, Error> {
+    // Widen before adding — x/y and cw/ch are user-controlled u32s whose sum
+    // can wrap. Error, don't clamp: a silently-shrunk crop is a different
+    // image than the one the caller asked for.
+    if (x as u64) + (cw as u64) > (sw as u64) || (y as u64) + (ch as u64) > (sh as u64) {
+        return Err(Error::BadExtractArea);
+    }
+    let src_stride: usize = (sw as usize) * 4;
+    let row_bytes: usize = (cw as usize) * 4;
+    let x_bytes: usize = (x as usize) * 4;
+    let mut out: Vec<u8> = Vec::with_capacity(row_bytes * (ch as usize));
+    for row in 0..(ch as usize) {
+        let s_off = ((y as usize) + row) * src_stride + x_bytes;
+        out.extend_from_slice(&src[s_off..s_off + row_bytes]);
+    }
     Ok(out)
 }

--- a/src/runtime/image/mod.rs
+++ b/src/runtime/image/mod.rs
@@ -59,5 +59,6 @@ pub mod thumbhash;
 #[path = "Image.rs"]
 pub mod image_body;
 pub use image_body::{
-    Deliver, Fit, Image, Input, Kind, Modulate, Pipeline, PipelineTask, Resize, Source, TaskResult,
+    Deliver, Extract, Fit, Image, Input, Kind, Modulate, Pipeline, PipelineTask, Resize, Source,
+    TaskResult,
 };

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -367,6 +367,118 @@ describe("Bun.Image", () => {
     });
   });
 
+  describe("extract", () => {
+    // Pixel value encodes its source coordinate, so any offset/size mistake
+    // in the crop shows up as a wrong colour, not just wrong dims.
+    const coordPng = makePng(8, 8, (x, y) => [x * 16, y * 16, 0, 255]);
+
+    test("extracts the exact region, pixel for pixel", async () => {
+      const out = await new Bun.Image(coordPng).extract({ left: 2, top: 3, width: 4, height: 2 }).png().bytes();
+      const { w, h, data } = decodePngRaw(out);
+      expect(w).toBe(4);
+      expect(h).toBe(2);
+      for (let y = 0; y < 2; y++) {
+        for (let x = 0; x < 4; x++) {
+          expect(rgbaAt(data, 4, x, y)).toEqual([(x + 2) * 16, (y + 3) * 16, 0, 255]);
+        }
+      }
+    });
+
+    test("left/top default to 0", async () => {
+      const { w, h, data } = decodePngRaw(await new Bun.Image(coordPng).extract({ width: 2, height: 2 }).png().bytes());
+      expect({ w, h }).toEqual({ w: 2, h: 2 });
+      expect(rgbaAt(data, 2, 0, 0)).toEqual([0, 0, 0, 255]);
+      expect(rgbaAt(data, 2, 1, 1)).toEqual([16, 16, 0, 255]);
+    });
+
+    test("a region flush with the far edge is in bounds", async () => {
+      const { w, h, data } = decodePngRaw(
+        await new Bun.Image(coordPng).extract({ left: 6, top: 6, width: 2, height: 2 }).png().bytes(),
+      );
+      expect({ w, h }).toEqual({ w: 2, h: 2 });
+      expect(rgbaAt(data, 2, 1, 1)).toEqual([7 * 16, 7 * 16, 0, 255]);
+    });
+
+    test("resize() applies to the extracted region", async () => {
+      // Extract a flat red quadrant, then box-downscale — every output pixel
+      // must still be pure red, proving resize ran on the crop.
+      const quads = makePng(8, 8, (x, y) => (x < 4 && y < 4 ? [255, 0, 0, 255] : [0, 0, 255, 255]));
+      const out = await new Bun.Image(quads)
+        .extract({ width: 4, height: 4 })
+        .resize(2, 2, { filter: "box" })
+        .png()
+        .bytes();
+      const { w, h, data } = decodePngRaw(out);
+      expect({ w, h }).toEqual({ w: 2, h: 2 });
+      for (let y = 0; y < 2; y++) {
+        for (let x = 0; x < 2; x++) {
+          expect(rgbaAt(data, 2, x, y)).toEqual([255, 0, 0, 255]);
+        }
+      }
+    });
+
+    test("region addresses the rotated (upright) image", async () => {
+      // After rotate(90) on cornersPng, dst(0,0) is the source's blue corner.
+      const out = await new Bun.Image(cornersPng).rotate(90).extract({ width: 1, height: 1 }).png().bytes();
+      const { w, h, data } = decodePngRaw(out);
+      expect({ w, h }).toEqual({ w: 1, h: 1 });
+      expect(rgbaAt(data, 1, 0, 0)).toEqual([0, 0, 255, 255]);
+    });
+
+    test("extract from a JPEG source with a queued resize stays coordinate-exact", async () => {
+      // Half red / half blue split at x=8; a decode-time downscale hint that
+      // wrongly survived the extract would shift the boundary.
+      const split = makePng(16, 16, x => (x < 8 ? [255, 0, 0, 255] : [0, 0, 255, 255]));
+      const jpeg = await new Bun.Image(split).jpeg({ quality: 95 }).bytes();
+      const out = await new Bun.Image(jpeg)
+        .extract({ left: 8, width: 8, height: 16 })
+        .resize(4, 4, { filter: "box" })
+        .png()
+        .bytes();
+      const { w, h, data } = decodePngRaw(out);
+      expect({ w, h }).toEqual({ w: 4, h: 4 });
+      const [r, , b] = rgbaAt(data, 4, 1, 1);
+      expect(b).toBeGreaterThan(200);
+      expect(r).toBeLessThan(60);
+    });
+
+    test("out-of-bounds region rejects with ERR_IMAGE_BAD_EXTRACT_AREA", async () => {
+      for (const region of [
+        { left: 10, top: 0, width: 10, height: 4 }, // overhangs right edge
+        { left: 0, top: 15, width: 4, height: 4 }, // overhangs bottom edge
+        { width: 17, height: 1 }, // wider than the source
+      ]) {
+        const p = new Bun.Image(gradientPng).extract(region).png().bytes();
+        await expect(p).rejects.toThrow(/extract area/);
+        await expect(p).rejects.toMatchObject({ code: "ERR_IMAGE_BAD_EXTRACT_AREA" });
+      }
+    });
+
+    test("whole-image region is the identity", async () => {
+      const out = await new Bun.Image(coordPng).extract({ width: 8, height: 8 }).png().bytes();
+      const { w, h, data } = decodePngRaw(out);
+      expect({ w, h }).toEqual({ w: 8, h: 8 });
+      expect(rgbaAt(data, 8, 7, 7)).toEqual([7 * 16, 7 * 16, 0, 255]);
+    });
+
+    test("invalid arguments throw synchronously", () => {
+      const img = new Bun.Image(gradientPng);
+      // @ts-expect-error missing argument
+      expect(() => img.extract()).toThrow();
+      // @ts-expect-error width/height required
+      expect(() => img.extract({ left: 0, top: 0 })).toThrow(/width and height/);
+      expect(() => img.extract({ width: 0, height: 4 })).toThrow(/width must be an integer/);
+      expect(() => img.extract({ width: 4, height: NaN })).toThrow(/height must be an integer/);
+      expect(() => img.extract({ width: 1.5, height: 4 })).toThrow(/width must be an integer/);
+      // Fields are never coerced or clamped — a shifted origin is a
+      // different crop, so strings and negatives throw like Sharp.
+      // @ts-expect-error left must be a number
+      expect(() => img.extract({ left: "2", width: 4, height: 4 })).toThrow(/left must be an integer/);
+      expect(() => img.extract({ left: -1, width: 4, height: 4 })).toThrow(/left must be an integer/);
+      expect(() => img.extract({ top: 0.5, width: 4, height: 4 })).toThrow(/top must be an integer/);
+    });
+  });
+
   test("path string input reads from disk", async () => {
     using dir = tempDir("bun-image", { "in.png": Buffer.from(gradientPng) });
     const meta = await new Bun.Image(join(String(dir), "in.png")).metadata();


### PR DESCRIPTION
### What does this PR do?

Adds `extract({ left, top, width, height })` to `Bun.Image`, same shape as Sharp's `extract()`. It crops the image to an exact pixel region.

The crop runs after rotate/flip and before resize, so the region is addressed in upright source pixels and a chained `resize()` scales the cropped region. `left` and `top` default to 0; all four fields must be non-negative integers (`width`/`height` at least 1) and anything else throws right away, the way Sharp does. If the region hangs off the edge of the image, the pipeline rejects with `ERR_IMAGE_BAD_EXTRACT_AREA` instead of clamping, since a clamped crop is a different image than the one you asked for. The code is included in the `Image.ErrorCode` type.

One subtlety: when a resize is queued, JPEG decode normally happens at a reduced IDCT scale. That would shift extract coordinates, so the decode hint is skipped whenever an extract is queued. The docs note this, along with `.placeholder()` ignoring pipeline ops.

The pipeline stage is in `src/runtime/image/Image.rs`; the pixel copy is `crop()` in `src/runtime/image/codecs.rs`, which bounds-checks the region itself and skips the copy entirely for a whole-image region. #30616 adds a similar helper for `fit: "cover"`, so whichever PR lands second gets a small conflict there.

### How did you verify your code works?

New tests in `test/js/bun/image/image.test.ts` under `describe("extract")`. The main one uses a fixture where each pixel's color encodes its own coordinates, so an off-by-one in the offsets shows up as a wrong color, not just wrong dimensions. The rest cover the left/top defaults, a region flush against the far edge, the whole-image identity region, extract followed by resize, extract after `rotate(90)`, a JPEG source with a queued resize (this exercises the decode-hint path), out-of-bounds rejection with the error code, and strict argument validation (strings, negatives, and fractions all throw).

They all fail with `USE_SYSTEM_BUN=1` and pass with the debug build. The whole image test file passes (104 pass, 0 fail), the bun-types fixture test passes for the `.d.ts` changes, and `bun run rust:check-all` compiles all targets — the macOS-only CoreGraphics backend has an exhaustive match over `codecs::Error` that the new variant extends, which a Linux-only check would not catch.

Closes #40421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
