### PR TITLE
Bun.Image: set error.code on sync body-encode errors

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8855,8 +8855,10 @@ declare module "bun" {
 
   namespace Image {
     /**
-     * Stable `error.code` values set on rejections from `Bun.Image` terminals.
-     * Branch on these instead of parsing the message.
+     * Stable `error.code` values on `Bun.Image` pipeline errors — set on
+     * rejections from the async terminals, and on the same errors thrown
+     * synchronously when a pipeline is used directly as a `Response` /
+     * `Request` body. Branch on these instead of parsing the message.
      *
      * - `ERR_IMAGE_FORMAT_UNSUPPORTED` — the requested format isn't available
      *   on this *machine* (HEIC/AVIF without the OS codec, TIFF on Linux).

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8865,6 +8865,7 @@ declare module "bun" {
      *   exceed `maxPixels`, or a path-backed input is over the 256 MiB cap.
      * - `ERR_IMAGE_DECODE_FAILED` / `ERR_IMAGE_ENCODE_FAILED` — codec error.
      * - `ERR_IMAGE_UNKNOWN_FORMAT` — input bytes didn't match any sniffer.
+     * - `ERR_OUT_OF_MEMORY` — a pipeline allocation failed.
      * - `ERR_INVALID_STATE` — the input ArrayBuffer was transferred between
      *   construction and the terminal call.
      * - File-backed inputs surface the underlying syscall code (`ENOENT`,
@@ -8876,6 +8877,7 @@ declare module "bun" {
       | "ERR_IMAGE_DECODE_FAILED"
       | "ERR_IMAGE_ENCODE_FAILED"
       | "ERR_IMAGE_UNKNOWN_FORMAT"
+      | "ERR_OUT_OF_MEMORY"
       | "ERR_INVALID_STATE";
 
     /**

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -670,10 +670,26 @@ fn reject_error(global: &JSGlobalObject, e: codecs::Error) -> JSValue {
 
 fn error_with_code(global: &JSGlobalObject, code: &ZStr, msg: &ZStr) -> JSValue {
     let err = global.create_error_instance(format_args!("{}", bstr::BStr::new(msg.as_bytes())));
+    // Instance creation can fail with a pending exception (VM termination,
+    // OOM); `put` on the empty value would deref null. Hand the empty value
+    // back — `throw_value`/reject propagate the pending exception.
+    if err.is_empty() {
+        return err;
+    }
     let code_js = jsc::bun_string_jsc::create_utf8_for_js(global, code.as_bytes())
         .unwrap_or(JSValue::UNDEFINED);
     err.put(global, b"code", code_js);
     err
+}
+
+/// One rendering for the detached-`ArrayBuffer` error so the async terminal
+/// and the sync body encode can't drift apart.
+fn detached_error(global: &JSGlobalObject) -> JSValue {
+    error_with_code(
+        global,
+        zstr!("ERR_INVALID_STATE"),
+        zstr!("Image: source ArrayBuffer was detached"),
+    )
 }
 
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
@@ -1124,15 +1140,8 @@ impl Image {
             Ok(i) => i,
             Err(PinError::Detached) => {
                 drop(deliver);
-                return Ok(JSPromise::rejected_promise(
-                    global,
-                    error_with_code(
-                        global,
-                        zstr!("ERR_INVALID_STATE"),
-                        zstr!("Image: source ArrayBuffer was detached"),
-                    ),
-                )
-                .as_value(global));
+                return Ok(JSPromise::rejected_promise(global, detached_error(global))
+                    .as_value(global));
             }
         };
         let work = PipelineTask {
@@ -1206,7 +1215,7 @@ impl Image {
         let (input, _pin) = match self.pin_for_task(this_value, global) {
             Ok(i) => i,
             Err(PinError::Detached) => {
-                return Err(global.throw(format_args!("Image: source ArrayBuffer was detached")));
+                return Err(global.throw_value(detached_error(global)));
             }
         };
         // `_pin` unpins at scope exit, after `run()` is done with the bytes.
@@ -1229,10 +1238,8 @@ impl Image {
                 self.last_height.set(i32::try_from(h).expect("int cast"));
                 Ok((out, format.mime()))
             }
-            TaskResult::Err(e) => Err(global.throw(format_args!(
-                "{}",
-                bstr::BStr::new(error_message(e).as_bytes())
-            ))),
+            // Same coded error shape as the async terminals reject with.
+            TaskResult::Err(e) => Err(global.throw_value(reject_error(global, e))),
             // Preserve errno/path/syscall instead of flattening to DecodeFailed.
             TaskResult::IoErr(e) => Err(global.throw_value(e.to_js(global))),
             TaskResult::Meta { .. } => unreachable!(),

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1169,6 +1169,22 @@ describe("Bun.Image", () => {
       expect(buf[0]).toBe(0xff);
       expect(buf[1]).toBe(0xd8);
     });
+
+    test("sync body-init errors carry the same error.code as async terminals", async () => {
+      const garbage = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+      await expect(new Bun.Image(garbage).png().bytes()).rejects.toMatchObject({
+        code: "ERR_IMAGE_UNKNOWN_FORMAT",
+      });
+      expect(() => new Response(new Bun.Image(garbage))).toThrowWithCode(Error, "ERR_IMAGE_UNKNOWN_FORMAT");
+    });
+
+    test("detached ArrayBuffer in sync body-init throws with ERR_INVALID_STATE", () => {
+      // Fresh copy — detaching gradientPng's own buffer would break other tests.
+      const ab = new Uint8Array(gradientPng).buffer;
+      const img = new Bun.Image(ab);
+      ab.transfer();
+      expect(() => new Response(img)).toThrowWithCode(Error, "ERR_INVALID_STATE");
+    });
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

Every async `Bun.Image` terminal rejects with an error that carries a stable `error.code` (`ERR_IMAGE_UNKNOWN_FORMAT`, `ERR_INVALID_STATE`, and so on), and the docs tell users to branch on it. The synchronous encode path used by `new Response(img)` / `new Request(url, { body: img })` threw bare `Error`s with only a message, so the same failure had a `.code` or not depending on which path ran the encode.

`encode_for_body` in `src/runtime/image/Image.rs` now throws the same coded errors the async terminals reject with, for both codec failures and the detached-ArrayBuffer case. Both paths build the detached error with one shared helper now, so the two sites can't drift apart. While in there: `error_with_code` bails out when error-instance creation fails with a pending exception (VM termination, OOM), because calling `put` on the empty value it returns would dereference null.

The `Image.ErrorCode` union also gains `ERR_OUT_OF_MEMORY`, which the runtime already emitted but the type didn't list.

### How did you verify your code works?

Two new tests in `test/js/bun/image/image.test.ts`, both using the `toThrowWithCode` harness matcher. Unknown-format bytes through `new Response(img)` have to throw with `ERR_IMAGE_UNKNOWN_FORMAT`, asserted next to the async terminal producing the same code, and a detached source buffer has to throw with `ERR_INVALID_STATE`. Both fail with `USE_SYSTEM_BUN=1`, each on the missing `.code`, and pass with the debug build. The full image test file passes (97 pass, 0 fail) and the bun-types fixture test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
