### PR TITLE
Module loading: remove unsafe from ModuleLoader, AsyncModule and RuntimeTranspilerStore

### DIFF
--- a/src/ast/transpiler_cache.rs
+++ b/src/ast/transpiler_cache.rs
@@ -22,13 +22,34 @@ pub struct RuntimeTranspilerCache {
     /// Bundler/parser only store/read the bytes; T6 owns the string wrapper
     /// when surfacing to JS.
     pub output_code: Option<Box<[u8]>>,
-    /// Opaque storage for `bun_bundler::cache::RuntimeTranspilerCacheEntry` —
-    /// the concrete type lives a tier up and is round-tripped via cast.
-    pub entry: Option<*mut ()>,
+    /// Opaque storage for the `bun_jsc` cache `Entry` a `get()` hit produced —
+    /// the concrete type lives a tier up and is round-tripped via
+    /// [`ErasedEntry`].
+    pub entry: Option<ErasedEntry>,
 
     /// Dispatch slot — `bun_jsc` sets `Some(TranspilerCacheImplKind::Jsc)` at
     /// init. `None` ⇒ caching disabled (e.g. wasm builds, `--no-transpiler-cache`).
     pub r#impl: Option<TranspilerCacheImplKind>,
+}
+
+/// A cache hit's boxed `Entry`, type-erased. Only the tier that defines
+/// `Entry` mints these (see [`ErasedEntry::new`]) and only it takes them back.
+pub struct ErasedEntry(NonNull<()>);
+
+impl ErasedEntry {
+    /// # Safety
+    /// `entry` is `heap::into_raw` of a `Box` of the one concrete `Entry` type
+    /// the `Jsc` impl uses, and ownership moves into the returned value.
+    #[inline]
+    pub unsafe fn new(entry: NonNull<()>) -> Self {
+        Self(entry)
+    }
+
+    /// The boxed `Entry`; ownership moves to the caller.
+    #[inline]
+    pub fn into_raw(self) -> NonNull<()> {
+        self.0
+    }
 }
 
 impl Default for RuntimeTranspilerCache {

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -157,10 +157,19 @@ impl JobTranspiler {
     /// Copy `from`'s configuration for a job.
     ///
     /// # Safety
-    /// Everything `from` owns or points at must outlive the copy and must not
-    /// be reconfigured or freed while the copy is in use; the copy is only for
-    /// parsing and printing, which read that configuration and write nothing
-    /// but the per-call arena, log and macro context.
+    /// The copy aliases `from`'s `options`, `resolver` (and its caches), `fs`
+    /// and `env`, and is used on a pool thread while `from`'s own thread keeps
+    /// using `from`. So, for as long as the copy exists: everything `from` owns
+    /// or points at must stay alive and must not be reconfigured (no
+    /// `configure_*`, option/define/loader changes, `set_arena`/`set_log` to
+    /// something the copy could observe, or drop); and both sides must stick
+    /// to what tolerates that overlap — the copy only does a non-shared-buffer
+    /// parse and a print, which read the aliased configuration, reach the
+    /// shared `FileSystem`/resolver caches only through their thread-safe
+    /// entry points, and write nothing but the per-call arena, log and the
+    /// copy's own macro context; `from`'s thread may parse/scan/print
+    /// concurrently under the same restriction but must not hand out
+    /// `fs_mut()`/`log_mut()`/`&mut options` borrows that a job could observe.
     pub unsafe fn new(from: &Transpiler<'static>) -> Self {
         // SAFETY: fn contract; `ManuallyDrop` keeps the copy from freeing what
         // `from` owns.

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -145,6 +145,110 @@ pub struct Transpiler<'a> {
     pub macro_context: Option<js_ast::Macro::MacroContext>,
 }
 
+/// A `Transpiler` for one off-thread transpile job: a bytewise copy of a
+/// long-lived transpiler whose `options` / `resolver` / `fs` / `env` alias the
+/// original's (so it is never dropped as a `Transpiler`), pointed at the job's
+/// own arena and log for the span of each [`for_call`](Self::for_call), with
+/// its own lazily-created macro context (freed on drop). What a job uses
+/// instead of the VM's transpiler itself on the work pool.
+pub struct JobTranspiler(core::mem::ManuallyDrop<Transpiler<'static>>);
+
+impl JobTranspiler {
+    /// Copy `from`'s configuration for a job.
+    ///
+    /// # Safety
+    /// Everything `from` owns or points at must outlive the copy and must not
+    /// be reconfigured or freed while the copy is in use; the copy is only for
+    /// parsing and printing, which read that configuration and write nothing
+    /// but the per-call arena, log and macro context.
+    pub unsafe fn new(from: &Transpiler<'static>) -> Self {
+        // SAFETY: fn contract; `ManuallyDrop` keeps the copy from freeing what
+        // `from` owns.
+        let mut copy = core::mem::ManuallyDrop::new(unsafe { core::ptr::read(from) });
+        // `from`'s macro context (if any) points back at `from`; `parse` lazily
+        // creates this copy's own.
+        copy.macro_context = None;
+        Self(copy)
+    }
+
+    /// The copy, aimed at this call's `arena` and `log` until the returned
+    /// guard drops (which points it back at the original's).
+    pub fn for_call<'a>(
+        &'a mut self,
+        arena: &'a Arena,
+        log: &'a mut bun_ast::Log,
+    ) -> JobTranspilerCall<'a> {
+        let home_arena: *const Arena = self.0.arena;
+        let home_log = self.0.log;
+        // SAFETY: lifetime narrowing — `Transpiler<'x>`'s `'x` only constrains
+        // `arena` (and the resolver opts that share it), which is replaced with
+        // one that lives for `'a` right here and restored when the guard drops,
+        // so no borrow at either lifetime is used outside its span.
+        let transpiler: &'a mut Transpiler<'a> =
+            unsafe { &mut *core::ptr::from_mut::<Transpiler<'static>>(&mut self.0).cast() };
+        transpiler.set_arena(arena);
+        transpiler.set_log(log);
+        JobTranspilerCall {
+            transpiler,
+            home_arena,
+            home_log,
+        }
+    }
+
+    /// The copied configuration.
+    #[inline]
+    pub fn options(&self) -> &options::BundleOptions<'_> {
+        &self.0.options
+    }
+
+    /// Free the macro context a parse through this copy created, on the
+    /// thread that ran the parse (its teardown touches that thread's
+    /// per-thread printer). Also runs on drop.
+    pub fn release_macro_context(&mut self) {
+        if let Some(ctx) = self.0.macro_context.take() {
+            ctx.deinit();
+        }
+    }
+}
+
+impl Drop for JobTranspiler {
+    fn drop(&mut self) {
+        self.release_macro_context();
+    }
+}
+
+/// A [`JobTranspiler`] aimed at one call's arena and log; `Deref`s to the
+/// `Transpiler`.
+pub struct JobTranspilerCall<'a> {
+    transpiler: &'a mut Transpiler<'a>,
+    home_arena: *const Arena,
+    home_log: *mut bun_ast::Log,
+}
+
+impl<'a> core::ops::Deref for JobTranspilerCall<'a> {
+    type Target = Transpiler<'a>;
+    #[inline]
+    fn deref(&self) -> &Transpiler<'a> {
+        self.transpiler
+    }
+}
+
+impl<'a> core::ops::DerefMut for JobTranspilerCall<'a> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Transpiler<'a> {
+        self.transpiler
+    }
+}
+
+impl Drop for JobTranspilerCall<'_> {
+    fn drop(&mut self) {
+        // SAFETY: `home_arena` is the original transpiler's arena, alive per
+        // `JobTranspiler::new`'s contract for as long as the copy is.
+        self.transpiler.set_arena(unsafe { &*self.home_arena });
+        self.transpiler.set_log(self.home_log);
+    }
+}
+
 impl<'a> Transpiler<'a> {
     /// Takes `*mut Log` (not `&'a mut`) because the same
     /// `*Log` is aliased into `linker.log` / `resolver.log`; the struct
@@ -1472,7 +1576,7 @@ impl<'a> Transpiler<'a> {
             // Thread
             // `this_parse.arena` (the per-call `MimallocArena` from
             // `RuntimeTranspilerStore`) so the source bytes land in the
-            // job-scoped heap that `TranspilerJob::run` `mi_heap_destroy`s on
+            // job-scoped heap that the transpile job `mi_heap_destroy`s on
             // return — not the worker thread's default mimalloc heap.
             let mut entry = match self.resolver.caches.fs.read_file_with_allocator(
                 self.fs_mut(),

--- a/src/collections/zig_hash_map.rs
+++ b/src/collections/zig_hash_map.rs
@@ -159,15 +159,6 @@ impl<K, V, C> HashMap<K, V, C> {
         self.available = ((self.metadata.len() as u64 * MAX_LOAD_PERCENTAGE) / 100) as u32;
     }
 
-    /// Debug-mode pointer-stability assertion. No-op stub kept so callers can
-    /// keep their lock/unlock bracketing without `#[cfg]` noise at every call
-    /// site (see `SavedSourceMap`).
-    #[inline]
-    pub fn lock_pointers(&self) {}
-    /// See [`lock_pointers`](Self::lock_pointers).
-    #[inline]
-    pub fn unlock_pointers(&self) {}
-
     pub fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             metadata: &self.metadata,

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -224,9 +224,7 @@ macro_rules! boxed_task {
             unsafe fn release_unrun(this: *mut Self) {
                 // SAFETY: `Taskable::release_unrun` contract — `this` came off the
                 // queue under this tag, where only `Task::from_boxed` puts it.
-                <$ty as $crate::BoxedTask>::release_unrun(unsafe {
-                    ::bun_core::heap::take(this)
-                })
+                <$ty as $crate::BoxedTask>::release_unrun(unsafe { ::bun_core::heap::take(this) })
             }
         }
     };

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -225,7 +225,7 @@ macro_rules! boxed_task {
                 // SAFETY: `Taskable::release_unrun` contract — `this` came off the
                 // queue under this tag, where only `Task::from_boxed` puts it.
                 <$ty as $crate::BoxedTask>::release_unrun(unsafe {
-                    ::std::boxed::Box::from_raw(this)
+                    ::bun_core::heap::take(this)
                 })
             }
         }

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -96,7 +96,6 @@ pub mod task_tag {
         Read,
         Readv,
         FlushPendingFileSinkTask,
-        RuntimeTranspilerStore,
         S3HttpDownloadStreamingTask,
         S3HttpSimpleTask,
         SendQueueDeferred,        // bun_runtime::ipc::SendQueue (close / after-close hop)
@@ -193,6 +192,44 @@ impl Task {
     pub fn from_boxed<T: Taskable>(task: Box<T>) -> Task {
         Task::new(T::TAG, bun_core::heap::into_raw(task).cast::<()>())
     }
+
+    /// The one payload-free task: "poll your pending modules". Its dispatch
+    /// and release arms (`bun_runtime::dispatch`) never read `ptr`, so a null
+    /// payload is fine here — and only here, which is why no other tag can be
+    /// built this way.
+    #[inline]
+    pub const fn poll_pending_modules() -> Task {
+        Task::new(task_tag::PollPendingModulesTask, core::ptr::null_mut())
+    }
+}
+
+/// A [`Taskable`] that is only ever queued as the `Box<Self>` handed to
+/// [`Task::from_boxed`], so a task that will never run is released by taking
+/// the box back. Implement this (the safe half) and let [`boxed_task!`] emit
+/// the `Taskable` impl.
+pub trait BoxedTask: Sized {
+    /// See [`Taskable::release_unrun`]: JS thread, heap alive, the task will
+    /// never be dispatched. The default drops the box.
+    fn release_unrun(self: Box<Self>) {}
+}
+
+/// `impl Taskable for $ty` for a [`BoxedTask`]: ties `$ty` to
+/// `task_tag::$tag` and reclaims the queued box for
+/// [`BoxedTask::release_unrun`].
+#[macro_export]
+macro_rules! boxed_task {
+    ($ty:ty, $tag:ident) => {
+        impl $crate::Taskable for $ty {
+            const TAG: $crate::TaskTag = $crate::task_tag::$tag;
+            unsafe fn release_unrun(this: *mut Self) {
+                // SAFETY: `Taskable::release_unrun` contract — `this` came off the
+                // queue under this tag, where only `Task::from_boxed` puts it.
+                <$ty as $crate::BoxedTask>::release_unrun(unsafe {
+                    ::std::boxed::Box::from_raw(this)
+                })
+            }
+        }
+    };
 }
 
 // Taskable impls for the low-tier task wrappers defined in this crate.

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -29,7 +29,7 @@ pub mod any_event_loop;
 // ─── public surface ─────────────────────────────────────────────────────────
 
 pub type JsResult<T> = core::result::Result<T, bun_core::JsError>;
-pub use ConcurrentTask::{Task, TaskTag, Taskable, task_tag};
+pub use ConcurrentTask::{BoxedTask, Task, TaskTag, Taskable, task_tag};
 
 // snake_case alias for the file-level-struct module so higher tiers avoid
 // the type/module namespace collision on the PascalCase form.

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -909,7 +909,7 @@ impl PackageManager {
     ) {
         if let Some(ctx) = self.on_wake.context {
             // SAFETY: `ctx` is the `WakeHandler::context` registered alongside
-            // this callback (a live `*mut Queue`); see `runtime::jsc_hooks`.
+            // this callback; see `runtime::jsc_hooks`.
             unsafe {
                 (self.on_wake.get_on_dependency_error())(
                     ctx.as_ptr(),

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -1291,8 +1291,7 @@ impl fmt::Display for FlagsFormatter {
 // ──────────────────────────────────────────────────────────────────────────
 
 // `bun_alloc::heap_breakdown` is a no-op outside macOS Instruments
-// heap-breakdown builds, so the 128-slot hive is unconditional here (same
-// choice as `RuntimeTranspilerStore`'s TranspilerJob hive).
+// heap-breakdown builds, so the 128-slot hive is unconditional here.
 #[cfg(not(windows))]
 const HIVE_SIZE: usize = 128;
 #[cfg(not(windows))]

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -62,9 +62,9 @@ pub(crate) struct MacroContext {
     /// prints it before the `Transpiler` drops).
     ///
     /// Lazy: `Arena::new()` calls `mi_heap_new()`, and `MacroContext::init`
-    /// runs once per `RuntimeTranspilerStore::TranspilerJob::run` iteration
-    /// (the worker bytewise-copies `vm.transpiler`, sets `macro_context =
-    /// None`, and `parse_maybe` re-creates it). `call()` is only reached when
+    /// runs once per `RuntimeTranspilerStore` transpile job (the job carries
+    /// a `JobTranspiler` bytewise copy of `vm.transpiler` with `macro_context
+    /// = None`, and `parse_maybe` re-creates it). `call()` is only reached when
     /// a file actually invokes a macro, so deferring the heap until then
     /// avoids one `mi_heap_new`/`mi_heap_destroy` pair on every dynamic
     /// `import()` (require-cache.test.ts T040 — on macOS arm64 the per-iter
@@ -264,8 +264,8 @@ fn __bun_macro_context_init(transpiler: *mut core::ffi::c_void) -> js_parser::Ma
     // `&mut bun_bundler::Transpiler<'_>`; the lifetime parameter is erased at
     // runtime so reading it as `'static` is layout-identical. The boxed state
     // is leaked for the long-lived `vm.transpiler` instance — but callers that run on a
-    // short-lived bytewise-cloned `Transpiler` (e.g.
-    // `RuntimeTranspilerStore::TranspilerJob::run`) MUST pair this with
+    // short-lived bytewise-cloned `Transpiler` (`JobTranspiler`, e.g.
+    // `RuntimeTranspilerStore`'s transpile jobs) MUST pair this with
     // `__bun_macro_context_deinit` or the `Box<MacroContext>` (and, if a macro
     // was actually invoked, its lazily-created `bump` arena) leaks per
     // iteration. `bump` is `None` on init, so this fn itself never calls

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -1,5 +1,3 @@
-use core::ffi::c_void;
-
 use bun_alloc::Arena as ArenaAllocator;
 use bun_bundler::transpiler::ParseResult;
 use bun_core::{EncodedSlice, String as BunString};
@@ -9,6 +7,7 @@ use bun_io::KeepAlive;
 use bun_resolver::fs as Fs;
 
 use crate::bun_string_jsc;
+use crate::module_loader::PromiseSlot;
 use crate::virtual_machine::VirtualMachine;
 use crate::{
     self as jsc, EncodedSliceJsc as _, ErrorableResolvedSource, JSGlobalObject, JSInternalPromise,
@@ -22,7 +21,7 @@ pub struct InitOpts<'a> {
     pub referrer: &'a [u8],
     pub specifier: &'a [u8],
     pub path: Fs::Path<'a>,
-    pub promise_ptr: Option<*mut *mut JSInternalPromise>,
+    pub promise_slot: &'a PromiseSlot,
     pub arena: Box<ArenaAllocator>,
     /// Backs `parse_result`'s small `AstVec`s (inline bump chunk); must stay
     /// alive alongside `arena` until the module finishes loading.
@@ -73,28 +72,30 @@ pub struct Queue {
     pub(crate) scheduled: u32,
 }
 
-/// What the resolver's `WakeHandler` carries as its opaque context: the
-/// module queue (for the JS-thread dependency-error callback) and the VM's
-/// weak handle (for wake-ups from the process-wide install / HTTP threads,
-/// which outlive any one VM). Allocated once per VM at registration and kept
-/// for the VM's lifetime.
+/// What the resolver's `WakeHandler` carries as its opaque context: the VM's
+/// weak handle, for wake-ups from the process-wide install / HTTP threads
+/// (which outlive any one VM). Allocated once per VM at registration and kept
+/// for the VM's lifetime. The JS-thread dependency-error callback reaches the
+/// module queue through the thread's VM instead.
 pub struct WakeContext {
-    pub queue: *mut Queue,
     pub handle: crate::VmHandle,
     pub kind: crate::LoopKind,
 }
 
+impl WakeContext {
+    /// `WakeHandler::handler` — an install / HTTP-callback thread
+    /// (`PackageManager::wake_raw`) asks the VM to poll its pending modules
+    /// (`bun_runtime::dispatch` → `vm.modules.on_poll()`).
+    pub fn wake(&self) {
+        bun_core::scoped_log!(AsyncModule, "onWake");
+        self.handle.post_poll_pending_modules(self.kind);
+    }
+}
+
 impl Queue {
-    /// Recover the owning VM.
-    ///
-    /// S017: dropped `container_of` recovery — provenance of `&mut self`
-    /// (which only covers `vm.modules`) cannot soundly widen to the whole
-    /// `VirtualMachine` under Stacked Borrows (see the analogous note on
-    /// `ExitHandler::dispatch_on_exit`). Route through the per-thread
-    /// singleton instead: same pointer, full-allocation provenance via
-    /// [`VirtualMachine::get_mut_ptr`], and no `unsafe` at the call site.
-    /// `&mut self` is kept as a receiver so existing callers
-    /// (`self.vm().package_manager()`) don't change shape.
+    /// The owning VM (this queue is `vm.modules`), reached through the
+    /// per-thread singleton rather than `container_of` so the borrow carries
+    /// whole-VM provenance.
     #[inline]
     pub(crate) fn vm(&mut self) -> &mut VirtualMachine {
         VirtualMachine::get().as_mut()
@@ -105,27 +106,14 @@ impl Queue {
     }
 }
 
-// Taskable: `Queue` is enqueued via `ConcurrentTask::create_from(this)` in
-// `on_wake_handler` and dispatched in `bun_runtime::dispatch::run_task` →
-// `vm.modules.on_poll()`. The pointer is a
-// borrow into `VirtualMachine.modules`, never freed by the dispatcher.
-impl bun_event_loop::Taskable for Queue {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::PollPendingModulesTask;
-    /// A "poll your pending modules" ping from an install thread: `this` is
-    /// the VM's own queue; nothing is owned.
-    unsafe fn release_unrun(_: *mut Self) {}
-}
-
-impl bun_event_loop::Taskable for AsyncModule {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::AsyncModule;
+bun_event_loop::boxed_task!(AsyncModule, AsyncModule);
+impl bun_event_loop::BoxedTask for AsyncModule {
     /// A module whose dependencies finished installing but whose fulfilment
     /// will not run: undo `done()`'s bookkeeping and drop it (its promise
     /// handle, arena and parse result go with the box).
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — the box `done()` queued.
-        let mut this = unsafe { bun_core::heap::take(this) };
+    fn release_unrun(mut self: Box<Self>) {
         let vm = VirtualMachine::get().as_mut();
-        this.poll_ref.unref(bun_io::js_vm_ctx());
+        self.poll_ref.unref(bun_io::js_vm_ctx());
         vm.modules.scheduled -= 1;
     }
 }
@@ -149,9 +137,9 @@ impl AsyncModule {
     }
 
     /// Dispatch the (possibly errored) transpile
-    /// result back into JSC via `Bun__onFulfillAsyncModule`. Called from
-    /// `RuntimeTranspilerStore::run_from_js_thread` and `on_done` when a
-    /// concurrent transpile job finishes.
+    /// result back into JSC via `Bun__onFulfillAsyncModule`. This is what
+    /// `RuntimeTranspilerStore`'s `TranspileJob::then` calls when a concurrent
+    /// transpile job finishes.
     pub(crate) fn fulfill(
         global_this: &JSGlobalObject,
         promise: JSValue,
@@ -208,7 +196,7 @@ use std::io::Write as _;
 use bun_install::package_manager::run_tasks;
 use bun_install::{self as install, LogLevel, PackageID};
 
-use crate::event_loop::{ConcurrentTaskItem, Task};
+use crate::event_loop::Task;
 
 /// `RunTasksCallbacks` impl for the auto-install module queue. `onResolve` /
 /// `onPackageManifestError` / `onPackageDownloadError` forward to the `Queue`
@@ -262,25 +250,22 @@ impl Queue {
         self.vm().package_manager().drain_dependency_list();
     }
 
-    /// # Safety
-    /// `ctx` must point to a live [`Queue`] (the `WakeHandler::context`
-    /// registered in `runtime::jsc_hooks`).
-    pub unsafe fn on_dependency_error(
-        ctx: *mut c_void,
+    /// `WakeHandler::on_dependency_error` — JS thread, from the package
+    /// manager tasks this queue drives.
+    pub fn on_dependency_error(
+        &mut self,
         dependency: &Dependency,
         root_dependency_id: DependencyID,
         err: &'static str,
     ) {
-        // SAFETY: ctx was registered as *Queue when installing this callback.
-        let this: &mut Queue = unsafe { bun_ptr::callback_ctx::<Queue>(ctx) };
         bun_core::scoped_log!(
             AsyncModule,
             "onDependencyError: {}",
-            bstr::BStr::new(this.vm().package_manager().lockfile.str(&dependency.name))
+            bstr::BStr::new(self.vm().package_manager().lockfile.str(&dependency.name))
         );
 
         // retain_mut lets Drop free removed modules.
-        this.map.retain_mut(|module| {
+        self.map.retain_mut(|module| {
             for pending in module.parse_result.pending_imports.iter() {
                 if pending.root_dependency_id != root_dependency_id {
                     continue;
@@ -311,30 +296,6 @@ impl Queue {
             }
             true
         });
-    }
-
-    /// `WakeHandler::handler` — runs on install / HTTP-callback threads
-    /// (`PackageManager::wake_raw`). `ctx` is the [`WakeContext`] registered in
-    /// `runtime/jsc_hooks.rs`; the VM is reached only through its handle.
-    pub fn on_wake_handler(ctx: *mut c_void, _: *mut c_void) {
-        bun_core::scoped_log!(AsyncModule, "onWake");
-        // SAFETY: `ctx` is the leaked `WakeContext` registered with this handler.
-        let ctx = unsafe { &*ctx.cast::<WakeContext>() };
-        let task = ConcurrentTaskItem::create_from(ctx.queue);
-        if let crate::vm_handle::Posted::Refused(task) = ctx.handle.post(ctx.kind, task) {
-            // That VM has closed: nobody is waiting on these modules any more.
-            // SAFETY: refused ⇒ we own the task box.
-            unsafe { drop(bun_core::heap::take(task.as_ptr())) };
-        }
-    }
-
-    /// `WakeHandler::on_dependency_error` context accessor — JS thread.
-    ///
-    /// # Safety
-    /// `ctx` is the leaked `WakeContext` registered in `runtime/jsc_hooks.rs`.
-    pub unsafe fn queue_from_wake_context(ctx: *mut c_void) -> *mut Queue {
-        // SAFETY: fn contract.
-        unsafe { (*ctx.cast::<WakeContext>()).queue }
     }
 
     pub fn on_poll(&mut self) {
@@ -583,10 +544,8 @@ impl AsyncModule {
         buf.count(opts.path.text);
 
         buf.allocate()?;
-        // SAFETY: caller guarantees promise_ptr is non-null and points to a valid out-slot.
-        unsafe {
-            *opts.promise_ptr.unwrap() = this_promise.as_promise().unwrap();
-        }
+        opts.promise_slot
+            .set(core::ptr::NonNull::new(this_promise.as_promise().unwrap()));
         // Self-referential borrows can't be stored, so capture lengths and pack
         // `referrer ++ specifier ++ path.text` into `string_buf`, then expose
         // them via `referrer()`/`specifier()`/`path_text()`. `move_to_slice()`
@@ -1052,126 +1011,68 @@ impl AsyncModule {
             "resumeLoadingModule: {}",
             bstr::BStr::new(self.specifier())
         );
-        // Take `parse_result` by value via `mem::take`, then restore below, to
-        // satisfy borrowck around `linker.link(&mut parse_result)` while
-        // `self` is also borrowed.
+        // `print_with_source_map` consumes `ParseResult` by value (it moves
+        // `ast` into `print_ast`), so take it out of `self` up front; what is
+        // left of `self` is only read from here on.
         let arena = *self.parse_result.ast.parts.allocator();
         let mut parse_result =
             core::mem::replace(&mut self.parse_result, ParseResult::empty(arena));
-        // SAFETY: `string_buf` is a `Box<[u8]>` whose backing allocation is
-        // stable for the lifetime of `*self`; this fn never replaces it, so
-        // slices into it remain valid across the `&mut self` reborrows below
-        // (`self.parse_result = ...`). Detach the borrow so borrowck doesn't
-        // tie `path`/`specifier` to `&self`.
-        let specifier: &[u8] = unsafe { bun_ptr::detach_lifetime(self.specifier()) };
-        // SAFETY: same `string_buf` stability invariant as `specifier` above —
-        // the backing `Box<[u8]>` is never replaced in this fn.
-        let path_text: &[u8] = unsafe { bun_ptr::detach_lifetime(self.path_text()) };
-        let path = Fs::Path::init(path_text);
-        let jsc_vm = VirtualMachine::get_mut_ptr();
-        // SAFETY: `jsc_vm` is the live per-thread VM (one VM per thread)
-        // (`transpiler.log`/`resolver.log`/`linker.log` are themselves raw
-        // `*mut Log` aliased deliberately — see `Transpiler::set_log`).
-        // `vm.log` is set unconditionally in `init` and never cleared, so the
-        // `expect` is infallible.
-        let old_log: core::ptr::NonNull<bun_ast::Log> =
-            unsafe { (*jsc_vm).log }.expect("vm.log set in init");
+        let specifier = self.specifier();
+        let path = Fs::Path::init(self.path_text());
+        let jsc_vm = VirtualMachine::get().as_mut();
+        // `transpiler.log`/`resolver.log`/`linker.log` are raw `*mut Log`
+        // aliased deliberately — see `Transpiler::set_log`. `vm.log` is set
+        // unconditionally in `init` and never cleared, so the `expect` is
+        // infallible.
+        let old_log: core::ptr::NonNull<bun_ast::Log> = jsc_vm.log.expect("vm.log set in init");
 
-        let log_nn = core::ptr::NonNull::new(log).expect("AsyncModule log is non-null");
-        let log_ptr: *mut bun_ast::Log = log;
-        // SAFETY: see above — single-thread VM; raw-ptr field stores.
-        unsafe {
-            (*jsc_vm).transpiler.linker.log = log_ptr;
-            (*jsc_vm).transpiler.log = log_ptr;
-            (*jsc_vm).transpiler.resolver.log = log_nn;
-            (*jsc_vm).package_manager().log = log_ptr;
+        fn swap_logs(jsc_vm: &mut VirtualMachine, log: core::ptr::NonNull<bun_ast::Log>) {
+            let log_ptr = log.as_ptr();
+            jsc_vm.transpiler.linker.log = log_ptr;
+            jsc_vm.transpiler.log = log_ptr;
+            jsc_vm.transpiler.resolver.log = log;
+            jsc_vm.package_manager().log = log_ptr;
         }
-        let _restore = scopeguard::guard((jsc_vm, old_log), |(jsc_vm, old_log)| {
-            // SAFETY: same per-thread VM; restoring the original log pointers
-            // stored above.
-            unsafe {
-                let old_log_ptr = old_log.as_ptr();
-                (*jsc_vm).transpiler.linker.log = old_log_ptr;
-                (*jsc_vm).transpiler.log = old_log_ptr;
-                (*jsc_vm).transpiler.resolver.log = old_log;
-                (*jsc_vm).package_manager().log = old_log_ptr;
-            }
+        swap_logs(jsc_vm, core::ptr::NonNull::from(&mut *log));
+        let _restore = scopeguard::guard(old_log, |old_log| {
+            swap_logs(VirtualMachine::get().as_mut(), old_log);
         });
 
         // We _must_ link because:
         // - node_modules bundle won't be properly
-        // SAFETY: per-thread VM; `linker` is a value field of `transpiler`.
-        unsafe {
-            (*jsc_vm).transpiler.linker.link::<false, true>(
-                &path,
-                &mut parse_result,
-                &(*jsc_vm).origin,
-                bun_bundler::options::ImportPathFormat::AbsolutePath,
-            )?;
-        }
-        self.parse_result = parse_result;
-        // `print_with_source_map` consumes `ParseResult` by
-        // value (it moves `ast` into `print_ast`). Hoist the post-print
-        // read (`is_commonjs_module`) above the move so we
-        // can `mem::take` instead of cloning.
-        let is_commonjs_module = self.parse_result.ast.has_commonjs_export_names
-            || self.parse_result.ast.exports_kind == bun_ast::ExportsKind::Cjs;
-        let arena = *self.parse_result.ast.parts.allocator();
-        let parse_result = core::mem::replace(&mut self.parse_result, ParseResult::empty(arena));
+        jsc_vm.transpiler.linker.link::<false, true>(
+            &path,
+            &mut parse_result,
+            &jsc_vm.origin,
+            bun_bundler::options::ImportPathFormat::AbsolutePath,
+        )?;
+        let is_commonjs_module = parse_result.ast.has_commonjs_export_names
+            || parse_result.ast.exports_kind == bun_ast::ExportsKind::Cjs;
 
-        // `VirtualMachine.source_code_printer` is a thread-local
-        // `?*BufferPrinter` (see `SOURCE_CODE_PRINTER`). `BufferPrinter` is `!Clone`, so
-        // swap the buffer out and write it back via the `_writeback`
-        // guard — same observable effect (the thread-local's buffer is
-        // reused). Matches RuntimeTranspilerStore.rs.
-        let mut printer_ptr = crate::virtual_machine::SOURCE_CODE_PRINTER
-            .get()
-            .expect("source_code_printer not initialized");
-        // SAFETY: thread-local owns the leaked Box; only this thread touches it.
-        let mut printer = core::mem::replace(
-            unsafe { printer_ptr.as_mut() },
-            bun_js_printer::BufferPrinter::init(bun_js_printer::BufferWriter::init()),
-        );
+        let mut printer = crate::virtual_machine::SourceCodePrinter::take();
         printer.ctx.reset();
-        // The writeback must fire at fn exit,
-        // *after* the `printer.ctx.get_written()` reads below. Declare the
-        // guard immediately after `printer` so it drops last (locals drop in
-        // reverse declaration order) and the buffer is still populated when
-        // read.
-        let _writeback =
-            scopeguard::guard((printer_ptr.as_ptr(), &raw mut printer), |(dst, src)| {
-                // SAFETY: `dst` is the thread-local's leaked Box, `src` is the
-                // stack `printer`; both outlive this guard (it drops before
-                // `printer`). Move the buffer back into the thread-local slot.
-                unsafe {
-                    *dst = core::mem::replace(
-                        &mut *src,
-                        bun_js_printer::BufferPrinter::init(bun_js_printer::BufferWriter::init()),
-                    )
-                };
-            });
 
         {
-            // SAFETY: per-thread VM; `source_map_handler` stashes the
-            // `*mut BufferPrinter` and only reborrows inside
-            // `on_source_map_chunk` after the writer's last use retires.
-            let mut mapper = unsafe { (*jsc_vm).source_map_handler(&raw mut printer) };
-            // SAFETY: per-thread VM.
-            let _ = unsafe {
-                (*jsc_vm).transpiler.print_with_source_map(
-                    // `self.arena` is the same per-call arena that built
-                    // `parse_result.ast` (handed to the queue via
-                    // `InitOpts::arena` after the original parse). The
-                    // printer's rope-flattening scratch belongs in it, not
-                    // in the per-VM `transpiler_arena`.
-                    &self.arena,
-                    parse_result,
-                    &mut printer,
-                    bun_js_printer::Format::EsmAscii,
-                    mapper.get(),
-                    None,
-                )
-            }?;
+            let mut mapper = crate::virtual_machine::SourceMapHandlerGetter::new(
+                &jsc_vm.source_mappings,
+                jsc_vm.inline_source_map_enabled(),
+            );
+            let _ = jsc_vm.transpiler.print_with_source_map(
+                // `self.arena` is the same per-call arena that built
+                // `parse_result.ast` (handed to the queue via
+                // `InitOpts::arena` after the original parse). The
+                // printer's rope-flattening scratch belongs in it, not
+                // in the per-VM `transpiler_arena`.
+                &self.arena,
+                parse_result,
+                &mut printer,
+                bun_js_printer::Format::EsmAscii,
+                mapper.get(),
+                None,
+            )?;
+            mapper
+                .write_inline_trailer(&mut printer)
+                .map_err(bun_bundler::Error::from)?;
         }
 
         // `bun_core::env::DUMP_SOURCE` is debug, non-test builds only. The previous
@@ -1179,8 +1080,7 @@ impl AsyncModule {
         // exist, which silently compiled this call out everywhere.
         if bun_core::env::DUMP_SOURCE {
             crate::runtime_transpiler_store::dump_source_string(
-                // SAFETY: `jsc_vm` is the live per-thread `VirtualMachine` (BACKREF, non-null).
-                unsafe { core::ptr::NonNull::new_unchecked(jsc_vm) },
+                &jsc_vm.source_mappings,
                 specifier,
                 printer.ctx.get_written(),
             );
@@ -1190,17 +1090,13 @@ impl AsyncModule {
         // the enqueue, and the fd the parse opened may have been closed (and
         // the number recycled) by the transpile frame's fd guard.
 
-        // SAFETY: per-thread VM.
-        if unsafe { (*jsc_vm).is_watcher_enabled() } {
-            // SAFETY: per-thread VM.
-            let mut resolved_source = unsafe {
-                (*jsc_vm).ref_counted_resolved_source(
-                    printer.ctx.get_written(),
-                    &BunString::from_bytes(specifier),
-                    path.text,
-                    None,
-                )
-            };
+        if jsc_vm.is_watcher_enabled() {
+            let mut resolved_source = jsc_vm.ref_counted_resolved_source(
+                printer.ctx.get_written(),
+                &BunString::from_bytes(specifier),
+                path.text,
+                None,
+            );
 
             resolved_source.is_commonjs_module = is_commonjs_module;
 

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -209,10 +209,8 @@ pub fn is_builtin(str: &[u8]) -> bool {
 
 /// Module loader resolve hook: index into the codegen'd `Bun::builtinModuleKeys` of the canonical key a builtin alias
 /// (`"path"`, `"node:path"`, `"bun:sqlite"`) resolves to, or -1.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn ModuleLoader__builtinAliasIndex(data: *const u8, len: usize) -> i32 {
-    // SAFETY: C++ guarantees `data[..len]` is a live 8-bit specifier slice.
-    let str = unsafe { bun_core::ffi::slice(data, len) };
+// HOST_EXPORT(ModuleLoader__builtinAliasIndex, c)
+pub fn builtin_alias_index(str: &[u8]) -> i32 {
     HardcodedModule::Alias::get(str, bun_ast::Target::Bun, Default::default())
         .and_then(|alias| crate::builtin_module_key_index::get(alias.path.as_bytes()))
         .map_or(-1, i32::from)

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -75,13 +75,10 @@ pub struct ArenaResetGuard(bun_ptr::BackRef<VirtualMachine>);
 impl ArenaResetGuard {
     /// `vm` must be the live per-thread VM (the [`bun_ptr::BackRef`]
     /// invariant). Drop routes through [`VirtualMachine::as_mut`], which
-    /// derives provenance from the thread-local slot, so neither construction
-    /// nor teardown performs a raw deref here.
+    /// derives provenance from the thread-local slot.
     #[inline]
-    pub fn new(vm: *mut VirtualMachine) -> Self {
-        Self(bun_ptr::BackRef::from(
-            core::ptr::NonNull::new(vm).expect("vm non-null"),
-        ))
+    pub fn new(vm: &VirtualMachine) -> Self {
+        Self(bun_ptr::BackRef::new(vm))
     }
 }
 
@@ -107,34 +104,42 @@ impl FetchFlags {
     }
 }
 
-pub struct TranspileArgs<'a> {
+pub struct TranspileArgs<'a, 'b> {
     pub specifier: &'a [u8],
     pub referrer: &'a [u8],
     pub input_specifier: &'a bun_core::String,
-    pub log: *mut bun_ast::Log,
+    pub log: &'a mut bun_ast::Log,
     pub virtual_source: Option<&'a bun_ast::Source>,
     pub global_object: &'a JSGlobalObject,
     pub flags: FetchFlags,
-    /// Raw so the `.wasm` re-entry can mutate `loader` and recurse.
-    pub extra: *mut TranspileExtra,
+    /// The `.wasm` re-entry mutates `loader` / `module_type` and recurses.
+    pub extra: &'a mut TranspileExtra<'b>,
 }
 
-pub struct TranspileExtra {
+pub struct TranspileExtra<'b> {
+    /// `'static` because that is what the parser's `ParseOptions::path` /
+    /// `bun_ast::Source::path` store; the sync transpile only needs it for the
+    /// call.
     pub path: bun_resolver::fs::Path<'static>,
     pub loader: bun_ast::Loader,
     pub module_type: bun_bundler::options::ModuleType,
-    /// `*js_printer.BufferPrinter` — the per-VM shared printer. Never null.
-    pub source_code_printer: *mut bun_js_printer::BufferPrinter,
-    /// `?*?*jsc.JSInternalPromise` — out-param for the async-module path.
-    /// Null forbids async resolution.
-    pub promise_ptr: *mut *mut JSInternalPromise,
+    /// The per-thread shared printer.
+    pub source_code_printer: &'b mut bun_js_printer::BufferPrinter,
+    /// Out-slot for the async-module path: the promise of an `import()` that
+    /// has to wait for a package install is left here. `None` forbids async
+    /// resolution.
+    pub promise_slot: Option<&'b PromiseSlot>,
 }
+
+/// Where [`crate::async_module::Queue::enqueue`] leaves the promise of an
+/// `import()` that is waiting on a package install.
+pub type PromiseSlot = core::cell::Cell<Option<core::ptr::NonNull<JSInternalPromise>>>;
 
 unsafe extern "Rust" {
     /// Defined in `bun_runtime::jsc_hooks`.
-    pub(crate) fn __bun_transpile_source_code(
-        jsc_vm: *mut VirtualMachine,
-        args: &TranspileArgs<'_>,
+    pub(crate) safe fn __bun_transpile_source_code(
+        jsc_vm: &mut VirtualMachine,
+        args: TranspileArgs<'_, '_>,
     ) -> Result<ResolvedSource, crate::CrateError>;
     /// Defined in `bun_runtime::jsc_hooks`. `None` when the specifier is not a
     /// builtin / standalone-graph module.
@@ -145,12 +150,12 @@ unsafe extern "Rust" {
     ) -> Option<ResolvedSource>;
 }
 
-#[unsafe(no_mangle)]
-extern "C" fn Bun__fetchBuiltinModule(
+// HOST_EXPORT(Bun__fetchBuiltinModule, c)
+pub fn fetch_builtin_module(
     jsc_vm: &VirtualMachine,
     global_object: &JSGlobalObject,
     specifier: &bun_core::String,
-    ret: &mut ErrorableResolvedSource,
+    ret: &mut crate::ErrorableResolvedSource,
 ) -> bool {
     jsc::mark_binding();
     match __bun_fetch_builtin_module(jsc_vm, global_object, specifier) {
@@ -196,11 +201,9 @@ pub fn exposed_internal_tag(spec: &[u8]) -> Option<(Vec<u8>, crate::ResolvedSour
     Some((name, tag))
 }
 
-/// C++ entry point: whether `data[..len]` names a builtin module.
-#[unsafe(no_mangle)]
-unsafe extern "C" fn ModuleLoader__isBuiltin(data: *const u8, len: usize) -> bool {
-    // SAFETY: C++ guarantees `data[..len]` is a valid UTF-8 specifier slice.
-    let str = unsafe { bun_core::ffi::slice(data, len) };
+/// C++ entry point: whether `str` names a builtin module.
+// HOST_EXPORT(ModuleLoader__isBuiltin, c)
+pub fn is_builtin(str: &[u8]) -> bool {
     bun_aliases_get(str).is_some() || exposed_internal_tag(str).is_some()
 }
 
@@ -216,14 +219,12 @@ unsafe extern "C" fn ModuleLoader__builtinAliasIndex(data: *const u8, len: usize
 }
 
 /// C++ entry point: picks the loader for a specifier from its file extension and the VM's loader map.
-#[unsafe(no_mangle)]
-extern "C" fn Bun__getDefaultLoader(
+// HOST_EXPORT(Bun__getDefaultLoader, c)
+pub fn get_default_loader(
     global: &JSGlobalObject,
     str: &bun_core::String,
 ) -> bun_options_types::schema::api::Loader {
     use bun_options_types::schema::api;
-    // SAFETY: C++ passed the live JS-thread global; `bun_vm()` is the
-    // per-thread VM pointer (never null on this path).
     let jsc_vm = global.bun_vm();
     let filename = str.to_utf8();
     let loader = jsc_vm
@@ -238,18 +239,14 @@ extern "C" fn Bun__getDefaultLoader(
 }
 
 /// C++ entry point: runs the plugin for a virtual-module specifier, returning its exports (or zero when no plugin runner is set).
-#[unsafe(no_mangle)]
-unsafe extern "C" fn Bun__runVirtualModule(
-    global: &JSGlobalObject,
-    specifier_ptr: *const bun_core::String,
-) -> JSValue {
+// HOST_EXPORT(Bun__runVirtualModule, c)
+pub fn run_virtual_module(global: &JSGlobalObject, specifier: &bun_core::String) -> JSValue {
     jsc::mark_binding();
     if global.bun_vm().plugin_runner.is_none() {
         return JSValue::ZERO;
     }
 
-    // SAFETY: C++ passed a valid `bun.String*`.
-    let specifier_slice = unsafe { &*specifier_ptr }.to_utf8();
+    let specifier_slice = specifier.to_utf8();
     let specifier = specifier_slice.slice();
 
     if !PluginRunner::could_be_plugin(specifier) {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -938,9 +938,15 @@ pub static IS_DISABLED: AtomicBool = AtomicBool::new(false);
 // constructs that lower-tier cache with this vtable so the parser's
 // `cache.get()` reaches the disk-backed `RuntimeTranspilerCache::get()` above.
 // On a hit the concrete `Entry` is boxed and stored type-erased in
-// `bun_ast::RuntimeTranspilerCache.entry`; the store casts it back via
-// `heap::take(ptr.cast::<Entry>())`.
+// `bun_ast::RuntimeTranspilerCache.entry`; [`take_entry`] casts it back.
 // ──────────────────────────────────────────────────────────────────────────
+
+/// Take the cache hit (if any) that the `Jsc` bridge below left in `cache`.
+pub fn take_entry(from: &mut bun_ast::RuntimeTranspilerCache) -> Option<Box<Entry>> {
+    let entry = from.entry.take()?;
+    // SAFETY: an `ErasedEntry` is only minted (below) from a boxed `Entry`.
+    Some(unsafe { bun_core::heap::take(entry.into_raw().as_ptr().cast::<Entry>()) })
+}
 
 bun_ast::link_impl_TranspilerCacheImpl! {
     Jsc for extern bun_ast::RuntimeTranspilerCache => |this| {
@@ -961,7 +967,9 @@ bun_ast::link_impl_TranspilerCacheImpl! {
             this.features_hash = jsc.features_hash;
             this.exports_kind = jsc.exports_kind;
             if let Some(entry) = jsc.entry {
-                this.entry = Some(bun_core::heap::into_raw(Box::new(entry)).cast::<()>());
+                this.entry = Some(bun_ast::ErasedEntry::new(
+                    bun_core::heap::into_raw_nn(Box::new(entry)).cast::<()>(),
+                ));
             }
             hit
         },

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -2,8 +2,7 @@
 #![warn(unused_must_use)]
 
 use core::cell::Cell;
-use core::ffi::c_void;
-use core::ptr::{self, NonNull};
+use core::ptr;
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use bun_alloc::Arena;
@@ -12,12 +11,8 @@ use bun_ast::{ASTMemoryAllocator, ExportsKind};
 use bun_ast::{ImportRecord, ImportRecordFlags};
 use bun_bundler::analyze_transpiled_module;
 use bun_bundler::options::ModuleType;
-use bun_bundler::transpiler::{self as transpiler, AlreadyBundled, ParseOptions, Transpiler};
-use bun_collections::HiveArrayFallback;
+use bun_bundler::transpiler::{self as transpiler, AlreadyBundled, JobTranspiler, ParseOptions};
 use bun_core::{MutableString, String, strings};
-use bun_event_loop::{TaskTag, Taskable, task_tag};
-use bun_io::posix_event_loop::get_vm_ctx;
-use bun_io::{AllocatorType, KeepAlive};
 use bun_js_printer::{self as js_printer, BufferPrinter, BufferWriter};
 use bun_paths;
 use bun_ptr::BackRef;
@@ -27,18 +22,16 @@ use bun_resolver::node_fallbacks;
 use bun_resolver::package_json::{MacroMap as MacroRemap, PackageJSON};
 use bun_sys::{self, Dir, Fd, FdExt as _, File, OpenDirOptions};
 use bun_threading::Guarded;
-use bun_threading::unbounded_queue::{self, UnboundedQueue};
-use bun_threading::work_pool::{Task as WorkPoolTask, WorkPool};
 use bun_watcher::Watcher;
 
 use crate::async_module::AsyncModule;
-use crate::event_loop::{ConcurrentTask, EventLoop};
 use crate::hot_reloader::ImportWatcher;
+use crate::job::{Completion, Job, JobContext, JsThread};
 use crate::resolved_source_tag::ResolvedSourceTag;
 use crate::runtime_transpiler_cache::{
-    Entry as CacheEntry, ModuleType as CacheModuleType,
-    RuntimeTranspilerCache as JscRuntimeTranspilerCache,
+    ModuleType as CacheModuleType, RuntimeTranspilerCache as JscRuntimeTranspilerCache,
 };
+use crate::saved_source_map::SavedSourceMap;
 use crate::strong::Optional as StrongOptional;
 use crate::virtual_machine::{SourceMapHandlerGetter, VirtualMachine};
 use crate::{JSGlobalObject, JSInternalPromise, JSValue, JsResult, ResolvedSource};
@@ -55,18 +48,19 @@ bun_core::declare_scope!(RuntimeTranspilerStore, hidden);
 // Debug source dumping (debug-only helpers; no-ops in release)
 // ──────────────────────────────────────────────────────────────────────────
 
-// Note: takes `NonNull<VirtualMachine>` (not `&mut`) — these are called
-// from the transpiler worker thread while the JS thread is concurrently live on
-// the same VM, so a `&mut VirtualMachine` would be a data race AND would alias
-// the caller's `&mut TranspilerJob` (which is stored inside
-// `vm.transpiler_store`). Only the `source_mappings` leaf field is touched,
-// under its own internal lock.
-fn dump_source(vm: NonNull<VirtualMachine>, specifier: &[u8], printer: &BufferPrinter) {
-    dump_source_string(vm, specifier, printer.ctx.get_written());
+// Called from the transpiler worker thread while the JS thread is concurrently
+// live on the same VM, so these take the VM's (internally locked)
+// `SavedSourceMap` rather than the VM.
+fn dump_source(source_mappings: &SavedSourceMap, specifier: &[u8], printer: &BufferPrinter) {
+    dump_source_string(source_mappings, specifier, printer.ctx.get_written());
 }
 
-pub(crate) fn dump_source_string(vm: NonNull<VirtualMachine>, specifier: &[u8], written: &[u8]) {
-    if let Err(e) = dump_source_string_failiable(vm, specifier, written) {
+pub(crate) fn dump_source_string(
+    source_mappings: &SavedSourceMap,
+    specifier: &[u8],
+    written: &[u8],
+) {
+    if let Err(e) = dump_source_string_failiable(source_mappings, specifier, written) {
         bun_core::debug_warn!("Failed to dump source string: {}", e.name());
     }
 }
@@ -77,7 +71,7 @@ pub(crate) fn dump_source_string(vm: NonNull<VirtualMachine>, specifier: &[u8], 
 static BUN_DEBUG_HOLDER: Guarded<Option<Dir>> = Guarded::new(None);
 
 fn dump_source_string_failiable(
-    vm: NonNull<VirtualMachine>,
+    source_mappings: &SavedSourceMap,
     specifier: &[u8],
     written: &[u8],
 ) -> crate::CrateResult<()> {
@@ -131,10 +125,7 @@ fn dump_source_string_failiable(
             return Ok(());
         }
 
-        // SAFETY: `vm` outlives this debug-only call (BACKREF — VM owns the
-        // transpiler store); only the `source_mappings` leaf field is borrowed,
-        // and `SavedSourceMap::get` takes its own internal mutex.
-        if let Some(mappings) = unsafe { (*vm.as_ptr()).source_mappings.get(specifier) } {
+        if let Some(mappings) = source_mappings.get(specifier) {
             // `defer mappings.deref()` → Arc::drop.
             let mut map_path = Vec::with_capacity(base.len() + b".map".len());
             map_path.extend_from_slice(base);
@@ -196,137 +187,43 @@ pub fn set_break_point_on_first_line() -> bool {
 // RuntimeTranspilerStore
 // ──────────────────────────────────────────────────────────────────────────
 
+/// Off-thread module transpilation for `import`: each module is a
+/// [`Job<TranspileJob>`] that parses and prints on the work pool and fulfils
+/// the module's promise back on the JS thread.
 pub struct RuntimeTranspilerStore {
+    /// Bumped when a hot reload invalidates in-flight transpiles; a job whose
+    /// generation no longer matches when it reaches the pool fails with
+    /// `TranspilerJobGenerationMismatch` instead of transpiling stale input.
     pub(crate) generation_number: AtomicU32,
-    pub(crate) store: TranspilerJobStore,
     pub enabled: bool,
-    pub(crate) queue: Queue,
 }
-
-pub type Queue = UnboundedQueue<TranspilerJob>;
 
 impl Default for RuntimeTranspilerStore {
     fn default() -> Self {
         Self {
             generation_number: AtomicU32::new(0),
-            store: TranspilerJobStore::init(),
             enabled: true,
-            queue: Queue::new(),
         }
     }
-}
-
-impl Taskable for RuntimeTranspilerStore {
-    const TAG: TaskTag = task_tag::RuntimeTranspilerStore;
-    /// The "drain my finished jobs" ping owns nothing (`this` is the VM's
-    /// store); the jobs themselves are released by `release_queued_jobs_for_teardown`.
-    unsafe fn release_unrun(_: *mut Self) {}
 }
 
 impl RuntimeTranspilerStore {
     pub(crate) fn init() -> RuntimeTranspilerStore {
-        // The HiveArrayFallback uses the global mimalloc
-        // (PORTING.md §Allocators).
         Self::default()
     }
 
-    /// VM teardown (JS thread, heap alive, script forbidden; called on every
-    /// turn of the wait): jobs already handed back whose completion will not
-    /// run release their source, log and module promise here instead. Queued ⇒
-    /// the pool thread's last touch of the slot was the push (its ticket was
-    /// moved out first), so the slot is this thread's again.
-    pub fn release_queued_jobs_for_teardown(&mut self) {
-        let batch = self.queue.pop_batch();
-        let mut iter = batch.iterator();
-        loop {
-            let job = iter.next();
-            if job.is_null() {
-                break;
-            }
-            // SAFETY: a live job popped from the intrusive queue; see fn doc.
-            unsafe {
-                (*job).promise.deinit();
-                (*job).reset_for_pool();
-                self.store.put(job);
-            }
-        }
-    }
-
-    /// Fulfil every completed job's module promise. This drain is a dispatcher:
-    /// each fulfilment is a JS entry of its own, so what one leaves pending is
-    /// folded here and the drain goes on; the VM's termination ends it, with
-    /// the rest of the batch back on the queue (each still has its own posted
-    /// task, or the teardown release, to pick it up).
-    // Note: takes `NonNull` rather than `&mut` for `event_loop`/`vm`
-    // because `&mut self` already aliases `vm.transpiler_store` (this `Self` is
-    // a field of `VirtualMachine`). Field-level derefs only.
-    pub fn run_from_js_thread(
-        &mut self,
-        event_loop: NonNull<EventLoop>,
-        global: &JSGlobalObject,
-        vm: NonNull<VirtualMachine>,
-    ) {
-        let batch = self.queue.pop_batch();
-        // SAFETY: `vm` is the live owning VM (caller is the JS-thread tick loop).
-        let jsc_vm = unsafe { (*vm.as_ptr()).jsc_vm() };
-        let mut iter = batch.iterator();
-        let mut job = iter.next();
-        let mut first = true;
-        while !job.is_null() {
-            if !first {
-                // if there are more, we need to drain the microtasks from the previous run
-                // SAFETY: `event_loop` is the VM's live event-loop self-pointer.
-                let drained =
-                    unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) };
-                if drained.is_err() {
-                    self.requeue(job, &mut iter);
-                    return;
-                }
-            }
-            first = false;
-            // SAFETY: `job` is a live job popped from the intrusive queue.
-            let fulfilled = unsafe { (*job).run_from_js_thread() };
-            job = iter.next();
-            if let Err(err) = fulfilled {
-                if crate::task::report_error_or_terminate(global, err).is_err() {
-                    self.requeue(job, &mut iter);
-                    return;
-                }
-            }
-        }
-        // immediately after this is called, the microtasks will be drained again.
-    }
-
-    /// Put `job` and the rest of a popped batch back: each still has its posted
-    /// task (or the teardown release) to pick it up.
-    fn requeue(
-        &mut self,
-        mut job: *mut TranspilerJob,
-        iter: &mut unbounded_queue::BatchIterator<TranspilerJob>,
-    ) {
-        while let Some(unrun) = NonNull::new(job) {
-            job = iter.next();
-            self.queue.push(unrun);
-        }
-    }
-
+    /// JS thread: start transpiling `path` (process-lifetime text, see
+    /// `jsc_hooks::intern_path`) on the work pool and return the promise the
+    /// module loader waits on.
     pub fn transpile(
-        &mut self,
-        vm: *mut VirtualMachine,
+        vm: &VirtualMachine,
         global_object: &JSGlobalObject,
         input_specifier: String,
-        path: &Fs::Path<'_>,
+        path: Fs::Path<'static>,
         referrer: String,
         loader: Loader,
         package_json: Option<&PackageJSON>,
-    ) -> *mut c_void {
-        // The path text is heap-duplicated here and freed in `reset_for_pool` via
-        // heap::take on `path.text`.
-        let owned_text: *mut [u8] = bun_core::heap::into_raw(Box::<[u8]>::from(path.text));
-        // SAFETY: owned_text was just allocated via heap::alloc and lives until
-        // `reset_for_pool` reconstructs and drops the Box. The unbounded
-        // lifetime from raw-ptr deref coerces to `'static` for `bun_paths::fs::Path<'static>`.
-        let owned_path = bun_paths::fs::Path::init(unsafe { &*owned_text.cast_const() });
+    ) -> *mut JSInternalPromise {
         let promise: *mut JSInternalPromise = JSInternalPromise::create(global_object);
 
         // NOTE: DirInfo should already be cached since module loading happens
@@ -343,392 +240,305 @@ impl RuntimeTranspilerStore {
             }
         }
 
-        // Build the job by value and `get_init` it into the hive — the `Box`
-        // alloc, `JSInternalPromise::create`, and `StrongOptional::create`
-        // above all happen *before* the slot is claimed, so an OOM/throw on
-        // that path no longer leaves a claimed-but-uninit `TranspilerJob` (which
-        // carries `Log`/`String`/`StrongOptional` drop glue) for the next
-        // `put()` to drop.
-        let job: *mut TranspilerJob = self
-            .store
-            .get_init(TranspilerJob {
-                non_threadsafe_input_specifier: input_specifier,
-                path: owned_path,
-                global_this: BackRef::new(global_object),
-                non_threadsafe_referrer: referrer,
-                vm,
-                ticket: None,
-                log: bun_ast::Log::init(),
-                loader,
-                promise: StrongOptional::create(JSValue::from_cell(promise), global_object),
-                poll_ref: KeepAlive::default(),
-                resolved_source,
-                generation_number: self.generation_number.load(Ordering::SeqCst),
-                parse_error: None,
-                work_task: WorkPoolTask {
-                    node: Default::default(),
-                    callback: TranspilerJob::run_from_worker_thread,
-                },
-                next: unbounded_queue::Link::new(),
-            })
-            .as_ptr();
+        let hash = Watcher::get_hash(path.text);
+        let is_main = vm.main().len() == path.text.len()
+            && vm.main_hash == hash
+            && strings::eql_long(vm.main(), path.text, false);
+
         if cfg!(debug_assertions) {
             bun_core::scoped_log!(
                 RuntimeTranspilerStore,
                 "transpile({}, {}, async)",
                 bstr::BStr::new(path.text),
-                // SAFETY: job fully initialized above
-                <&'static str>::from(unsafe { (*job).loader })
+                <&'static str>::from(loader)
             );
         }
-        // SAFETY: job fully initialized above
-        unsafe { (*job).schedule() };
-        promise.cast::<c_void>()
+
+        let work = TranspileWork {
+            input: TranspileInput {
+                path,
+                hash,
+                loader,
+                tag: resolved_source.tag,
+                // Each `BackRef` below: the VM (and the process-lifetime import
+                // watcher) outlive the job, which holds the VM's ticket.
+                source_mappings: BackRef::new(&vm.source_mappings),
+                import_watcher: ptr::NonNull::new(vm.bun_watcher_ptr()).map(BackRef::from),
+                is_main,
+                use_macro_remap: !vm.macro_mode && vm.has_any_macro_remappings,
+                debugger_breaks_on_first_line: vm
+                    .debugger
+                    .as_ref()
+                    .map(|d| d.set_breakpoint_on_first_line)
+                    .unwrap_or(false),
+                has_eval_source: vm.module_loader.eval_source.is_some(),
+                use_isolation_source_provider_cache: vm.use_isolation_source_provider_cache(),
+                inline_source_map: vm.inline_source_map_enabled(),
+                smol: vm.smol,
+            },
+            transpiler: BackRef::new(&vm.transpiler),
+            store_generation: BackRef::new(&vm.transpiler_store.generation_number),
+            generation_number: vm.transpiler_store.generation_number.load(Ordering::SeqCst),
+            log: bun_ast::Log::init(),
+            parse_error: None,
+            resolved_source,
+        };
+        let js = TranspileJs {
+            promise: StrongOptional::create(JSValue::from_cell(promise), global_object),
+            global_this: BackRef::new(global_object),
+            input_specifier,
+            referrer,
+        };
+        Job::<TranspileJob>::schedule(&global_object.js_thread(), work, js);
+        promise
     }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// TranspilerJob
+// TranspileJob
 // ──────────────────────────────────────────────────────────────────────────
 
-// Note: bun.heap_breakdown.enabled gate on inline capacity — the Rust
-// `bun_alloc::heap_breakdown` is a no-op outside macOS Instruments builds, so
-// the 64-slot hive is unconditional here.
-const TRANSPILER_JOB_HIVE_CAP: usize = 64;
+/// The [`JobContext`] of one off-thread module transpile.
+pub struct TranspileJob;
 
-pub(crate) type TranspilerJobStore = HiveArrayFallback<TranspilerJob, TRANSPILER_JOB_HIVE_CAP>;
-
-pub struct TranspilerJob {
-    // Note: stored as the lower-tier `bun_paths::fs::Path<'static>` (the type
-    // `ParseOptions.path` / `bun_ast::Source.path` use). The slices borrow the
-    // Box'd buffer allocated in `transpile()` and freed in `reset_for_pool()`.
-    pub path: bun_paths::fs::Path<'static>,
-    pub(crate) non_threadsafe_input_specifier: bun_core::String,
-    pub(crate) non_threadsafe_referrer: bun_core::String,
-    pub(crate) loader: Loader,
-    pub(crate) promise: StrongOptional,
-    // Note: struct is stored in a HiveArray and crosses to a worker thread;
-    // raw pointers/BackRefs are used (BACKREF — VM owns the
-    // store and outlives every job).
-    pub(crate) vm: *mut VirtualMachine,
-    /// Held from `schedule` until the pool thread has dispatched the job back:
-    /// the job's own slot, the transpiler it copies and the store queue it
-    /// pushes to are all VM-owned, and the VM's teardown waits for the ticket.
-    pub(crate) ticket: Option<crate::Ticket>,
-    pub global_this: BackRef<JSGlobalObject>,
-    pub(crate) poll_ref: KeepAlive,
-    pub(crate) generation_number: u32,
-    pub(crate) log: bun_ast::Log,
-    pub(crate) parse_error: Option<crate::CrateError>,
-    /// Moved out by `run_from_js_thread`; dropped with the slot otherwise.
-    pub(crate) resolved_source: ResolvedSource,
-    pub(crate) work_task: WorkPoolTask,
-    /// INTRUSIVE — `UnboundedQueue<TranspilerJob>` link.
-    pub(crate) next: unbounded_queue::Link<TranspilerJob>,
+/// What the work pool gets: the module to transpile plus the VM state the
+/// transpile reads (snapshotted on the JS thread), the VM's transpiler (whose
+/// configuration the pool thread copies for the job), and the result slots
+/// [`TranspileJob::then`] reads back on the JS thread.
+pub struct TranspileWork {
+    input: TranspileInput,
+    /// The VM (which holds it) outlives the job, which holds the VM's ticket.
+    transpiler: BackRef<bun_bundler::Transpiler<'static>>,
+    store_generation: BackRef<AtomicU32>,
+    generation_number: u32,
+    log: bun_ast::Log,
+    parse_error: Option<crate::CrateError>,
+    /// Moved out by `then`; dropped with the job otherwise.
+    resolved_source: ResolvedSource,
 }
 
-// SAFETY: `next` is the sole intrusive link for `UnboundedQueue<TranspilerJob>`.
-unsafe impl unbounded_queue::Linked for TranspilerJob {
-    #[inline]
-    unsafe fn link(item: *mut Self) -> *const unbounded_queue::Link<Self> {
-        // SAFETY: `item` is valid and properly aligned per `UnboundedQueue` contract.
-        unsafe { core::ptr::addr_of!((*item).next) }
-    }
+/// The read-only inputs of a transpile, as captured on the JS thread in
+/// [`RuntimeTranspilerStore::transpile`], and the two VM structures it writes
+/// into from the pool (each under its own lock).
+#[derive(Clone, Copy)]
+struct TranspileInput {
+    path: Fs::Path<'static>,
+    hash: bun_watcher::HashType,
+    loader: Loader,
+    tag: ResolvedSourceTag,
+    source_mappings: BackRef<SavedSourceMap>,
+    /// The VM's hot-reload watcher (process-lifetime once installed), if any;
+    /// files transpiled here are added to it under its mutex.
+    import_watcher: Option<BackRef<ImportWatcher>>,
+    is_main: bool,
+    use_macro_remap: bool,
+    debugger_breaks_on_first_line: bool,
+    has_eval_source: bool,
+    use_isolation_source_provider_cache: bool,
+    inline_source_map: bool,
+    smol: bool,
 }
 
-/// Per-worker output buffer. The printer is the **only** state
-/// retained across `run()` calls — its backing `Vec<u8>` is genuinely worth
-/// reusing (capped at 512 K / 2 M below). The parse arena and AST memory
-/// store, by contrast, are stack-local per call and bulk-freed on return; see
-/// the RSS-regression note in `run()`.
-//
-// `#[thread_local]` not `thread_local!`: the macro's `LocalKey::__getit`
-// wrapper showed up on the
-// async-import hot path. Const-init `Cell<ptr>` (no dtor).
-#[thread_local]
-static SOURCE_CODE_PRINTER: Cell<Option<NonNull<BufferPrinter>>> = Cell::new(None);
+// SAFETY: moved to a work-pool thread by `Job`, which holds the VM's ticket
+// for the trip: the `BackRef`s and the import watcher all point at VM-owned
+// (or process-lifetime) state that the ticket keeps alive and that is only
+// touched under its own lock (source maps, watcher) or read (the transpiler's
+// configuration, fixed once modules load); the strings / resolved source are
+// plain heap data handed from the pool thread to the JS thread, never shared.
+unsafe impl Send for TranspileWork {}
 
-/// Get-or-leak accessor for the `#[thread_local]` `Cell<Option<NonNull<T>>>`
-/// slot above. Returns `&'static mut T` because the Box is leaked for the
-/// worker thread's lifetime and `#[thread_local]` guarantees per-thread
-/// exclusive access; callers reborrow `&'static T` where a shared ref suffices.
-#[inline]
-fn tls_get_or_leak<T>(
-    slot: &Cell<Option<NonNull<T>>>,
-    init: impl FnOnce() -> Box<T>,
-) -> &'static mut T {
-    let p = slot.get().unwrap_or_else(|| {
-        let p = bun_core::heap::into_raw_nn(init());
-        slot.set(Some(p));
-        p
-    });
-    // SAFETY: `p` is the `NonNull` produced by `heap::into_raw_nn(Box<T>)`
-    // (either just now or on a prior call) and never freed — the slot is a
-    // per-worker-thread leak. `#[thread_local]` storage means only this thread
-    // ever observes `p`, and every borrow returned here is scoped to one
-    // `TranspilerJob::run()` activation (no `&T`/`&mut T` from a prior call
-    // survives), so the `&mut` is exclusive for its actual use.
-    unsafe { &mut *p.as_ptr() }
+/// What stays on the JS thread: the module promise and the strings its
+/// fulfilment needs.
+#[derive(bun_jsc_macros::JsAffine)]
+pub struct TranspileJs {
+    promise: StrongOptional,
+    global_this: BackRef<JSGlobalObject>,
+    input_specifier: String,
+    referrer: String,
 }
 
-impl TranspilerJob {
-    /// Kept as a private inherent fn (not `impl Drop`) because the
-    /// slot is recycled into the HiveArray via `store.put(this)`. Only caller is
-    /// `run_from_js_thread`.
-    ///
-    /// Note: `HiveArrayFallback::put` runs `drop_in_place` on the slot (see
-    /// hive_array.rs note), so the Drop-carrying fields — `bun_core::String` ×2,
-    /// `ResolvedSource`, `Log`, `StrongOptional` — are torn down
-    /// *there*, not here. This function handles only the teardown that field
-    /// drop glue does **not** cover: the leaked `path.text` Box and
-    /// `poll_ref.disable()`.
-    fn reset_for_pool(&mut self) {
-        // bun.default_allocator.free(this.path.text) — `path.text` was Box-duplicated in
-        // `transpile()`; reconstruct the Box and drop it.
-        let old_path = core::mem::take(&mut self.path);
-        if !old_path.text.is_empty() {
-            // SAFETY: `text` is exactly the `&[u8]` view of the `Box<[u8]>`
-            // produced by `heap::into_raw` in `transpile()`; the fat-pointer
-            // cast preserves length, and this is the unique owner.
-            drop(unsafe { bun_core::heap::take(ptr::from_ref::<[u8]>(old_path.text).cast_mut()) });
+impl JobContext for TranspileJob {
+    type OffThread = TranspileWork;
+    type Js = TranspileJs;
+
+    /// Pool thread. Transpile only while the VM still runs script; either way
+    /// the job goes straight back to the JS thread, which completes or
+    /// releases it.
+    fn run(work: &mut TranspileWork, done: Completion<Self>) -> Option<Completion<Self>> {
+        if done.ticket().script_allowed() {
+            work.run();
         }
-
-        self.poll_ref.disable();
-        // Remaining fields with Drop glue are handled by `store.put()` →
-        // `drop_in_place`; do NOT `take()` them here (would drop the empty
-        // replacement a second time).
+        Some(done)
     }
 
-    /// Pool thread: hand the slot back. `ticket` was moved out of `self`
-    /// first — the JS thread may reuse the slot the moment it is queued.
-    fn dispatch_to_main_thread(&mut self, ticket: &crate::Ticket) {
-        let vm = self.vm;
-        // SAFETY: the VM outlives the ticket (it owns the store).
-        let transpiler_store: *mut RuntimeTranspilerStore =
-            unsafe { ptr::addr_of_mut!((*vm).transpiler_store) };
-        let job = NonNull::from(&mut *self);
-        // SAFETY: queue is concurrent-safe (UnboundedQueue uses atomics).
-        unsafe { (*transpiler_store).queue.push(job) };
-        ticket.post(ConcurrentTask::create_from(transpiler_store));
-    }
-
-    fn run_from_js_thread(&mut self) -> JsResult<()> {
-        let vm = self.vm;
-        let promise = self.promise.swap();
-        // Copy the BackRef out (it is `Copy`) so the borrow of `*self` ends
-        // before `reset_for_pool`/`put` need `&mut *self` below; deref at the
-        // `fulfill` call site instead.
-        let global_this = self.global_this;
-        // Note: the KeepAlive takes an `EventLoopCtx`
-        // vtable; resolve it via the `get_vm_ctx` hook (registered by `bun_runtime::init`).
-        self.poll_ref.unref(get_vm_ctx(AllocatorType::Js));
-
-        let referrer = core::mem::take(&mut self.non_threadsafe_referrer);
-        let mut log = core::mem::replace(&mut self.log, bun_ast::Log::init());
-        let (specifier, result) = match self.parse_error {
-            Some(e) => (String::clone_utf8(self.path.text), Err(e)),
+    /// JS thread: fulfil the module promise with the transpiled source (or the
+    /// parse error).
+    fn then(work: TranspileWork, js: TranspileJs, _cx: &JsThread<'_>) -> JsResult<()> {
+        let path = work.input.path;
+        let TranspileWork {
+            mut log,
+            parse_error,
+            resolved_source,
+            ..
+        } = work;
+        let TranspileJs {
+            mut promise,
+            global_this,
+            input_specifier,
+            referrer,
+        } = js;
+        let promise_value = promise.swap();
+        let (specifier, result) = match parse_error {
+            Some(e) => (String::clone_utf8(path.text), Err(e)),
             None => {
-                let mut resolved_source = core::mem::take(&mut self.resolved_source);
-                let out = core::mem::take(&mut self.non_threadsafe_input_specifier);
+                let mut resolved_source = resolved_source;
                 debug_assert!(resolved_source.source_url.is_empty());
-                resolved_source.source_url = out.create_if_different(self.path.text);
-                (out, Ok(resolved_source))
+                resolved_source.source_url = input_specifier.create_if_different(path.text);
+                (input_specifier, Ok(resolved_source))
             }
         };
-
-        self.promise.deinit();
-        self.reset_for_pool();
-
-        // SAFETY: vm outlives the job; transpiler_store.store.put recycles the slot.
-        unsafe {
-            (*vm)
-                .transpiler_store
-                .store
-                .put(std::ptr::from_mut::<TranspilerJob>(self))
-        };
+        drop(promise);
 
         AsyncModule::fulfill(
             &global_this,
-            promise,
+            promise_value,
             result,
             &specifier,
             &referrer,
             &mut log,
         )
     }
+}
 
-    fn schedule(&mut self) {
-        // Note: the KeepAlive takes an
-        // `EventLoopCtx` vtable; resolve it via the `get_vm_ctx` hook (registered by
-        // `bun_runtime::init`).
-        self.poll_ref.ref_(get_vm_ctx(AllocatorType::Js));
-        // SAFETY: JS thread; the VM owns the store this slot lives in.
-        self.ticket = Some(unsafe { (*self.vm).ticket() });
-        WorkPool::schedule(&raw mut self.work_task);
+/// Per-worker output buffer. The printer is the **only** state retained across
+/// `run()` calls — its backing `Vec<u8>` is genuinely worth reusing (capped at
+/// 512 K / 2 M below). The parse arena and AST memory store, by contrast, are
+/// stack-local per call and bulk-freed on return; see the RSS-regression note
+/// in `run()`.
+//
+// `#[thread_local]` not `thread_local!`: the macro's `LocalKey::__getit`
+// wrapper showed up on the async-import hot path. Const-init, never dropped
+// (the box leaks with the worker thread).
+#[thread_local]
+static SOURCE_CODE_PRINTER: Cell<Option<Box<BufferPrinter>>> = Cell::new(None);
+
+fn fresh_source_code_printer() -> BufferPrinter {
+    let mut printer = BufferPrinter::init(BufferWriter::init());
+    printer.ctx.append_null_byte = false;
+    printer
+}
+
+/// This worker's [`SOURCE_CODE_PRINTER`], taken out of the thread-local for
+/// one `run()` and put back — so its buffer is reused — when dropped.
+struct WorkerPrinter(Option<Box<BufferPrinter>>);
+
+impl WorkerPrinter {
+    fn take() -> Self {
+        Self(Some(
+            SOURCE_CODE_PRINTER
+                .take()
+                .unwrap_or_else(|| Box::new(fresh_source_code_printer())),
+        ))
     }
+}
 
-    unsafe fn run_from_worker_thread(work_task: *mut WorkPoolTask) {
-        // SAFETY: only reachable via `WorkPoolTask::callback` (unsafe-fn-ptr
-        // slot — safe-fn coerces) for the `work_task` field initialised in
-        // `transpile`; the WorkPool calls back with exactly that field, so
-        // `from_field_ptr!` recovers the live `TranspilerJob` parent.
-        let this = unsafe { bun_core::from_field_ptr!(TranspilerJob, work_task, work_task) };
-        // The slot lives inside the VM, which waits for this ticket, so it is
-        // alive throughout. Transpile only while the VM still runs script;
-        // either way hand the job back to the JS thread, which completes or
-        // releases it.
-        // SAFETY: as above; set in `schedule`.
-        let ticket =
-            unsafe { (*this).ticket.take() }.expect("scheduled transpile job holds a ticket");
-        if ticket.script_allowed() {
-            // SAFETY: live slot, exclusively ours until dispatched.
-            unsafe { (*this).run(&ticket) };
-        } else {
-            // SAFETY: as above.
-            unsafe { (*this).dispatch_to_main_thread(&ticket) };
+impl core::ops::Deref for WorkerPrinter {
+    type Target = BufferPrinter;
+    fn deref(&self) -> &BufferPrinter {
+        self.0.as_deref().expect("live until drop")
+    }
+}
+
+impl core::ops::DerefMut for WorkerPrinter {
+    fn deref_mut(&mut self) -> &mut BufferPrinter {
+        self.0.as_deref_mut().expect("live until drop")
+    }
+}
+
+impl Drop for WorkerPrinter {
+    fn drop(&mut self) {
+        SOURCE_CODE_PRINTER.set(self.0.take());
+    }
+}
+
+/// The transpile's input file: closed on drop unless the watcher adopted it.
+struct InputFd(Fd);
+
+impl Drop for InputFd {
+    fn drop(&mut self) {
+        if self.0.is_valid() {
+            self.0.close();
+            self.0 = Fd::INVALID;
         }
     }
+}
 
-    fn run(&mut self, ticket: &crate::Ticket) {
-        // Stack-local per call, bulk-freed on return. An earlier version hoisted
-        // this to a per-worker-thread leaked `Box<MimallocArena>` (and a second
-        // one inside a leaked `ASTMemoryAllocator`) and only `reset()` it at
-        // the *start* of the next call. On a 64-core box ~40 thread-pool
-        // workers each parse one or two modules then go idle, leaving ~80
-        // undestroyed `mi_heap_t`s holding ~7 MB requested / ~10–11 MB
-        // committed of dead AST between calls — the +12 % RSS regression seen
-        // on `server/elysia`. The hoist existed only to manufacture a
-        // `&'static Arena` for `Transpiler::set_arena`; the lifetime-erased
-        // `Transpiler<'_>` cast below accepts `&arena` directly, so the hoist
-        // bought nothing and cost RSS. `MimallocArena::Drop` =
-        // `mi_heap_destroy`, so the per-call heap-churn is identical to a
-        // start-of-call `reset()` but the worker holds **zero** retained pages
-        // between calls.
-        let arena = Arena::new();
-
-        // `defer this.dispatchToMainThread()` — fires on every return path.
-        let this_ptr: *mut TranspilerJob = self;
-        scopeguard::defer! {
-            // SAFETY: `self` outlives this guard (guard drops before fn return);
-            // no other &mut alias is live at drop time.
-            unsafe { (*this_ptr).dispatch_to_main_thread(ticket) };
-        }
-
-        // SAFETY contract: `vm` outlives the job (BACKREF — VM owns the store).
-        // Note: kept as a raw pointer — never form `&mut VirtualMachine`
-        // here. (a) the JS thread is concurrently live on the same VM, so a
-        // `&mut` would be a data race; (b) `self` is stored *inside*
-        // `(*vm).transpiler_store.store` (HiveArray inline slot), so a
-        // `&mut VirtualMachine` would retag `self`'s memory and every
-        // subsequent `self.* = …` write would be Stacked-Borrows UB. All
-        // accesses below dereference per-field via `(*vm).field` (place
-        // expressions / leaf-field borrows) only.
-        let vm: *mut VirtualMachine = self.vm;
-
-        // SAFETY: `vm` is the live owning VM (BACKREF — see note above);
-        // atomic load on a leaf field, no `&VirtualMachine` formed.
-        let store_generation = unsafe {
-            (*vm)
-                .transpiler_store
-                .generation_number
-                .load(Ordering::Relaxed)
+impl TranspileInput {
+    /// Hand `fd` (the just-parsed input file) to the hot-reload watcher if
+    /// this module should be watched; `fd` stays open only if the watcher
+    /// adopted it.
+    fn maybe_watch(
+        &self,
+        fd: &mut InputFd,
+        is_node_override: bool,
+        package_json: Option<&'static bun_watcher::PackageJSON>,
+    ) {
+        let Some(iw) = self.import_watcher else {
+            return;
         };
-        if self.generation_number != store_generation {
-            self.parse_error = Some(crate::CrateError::TranspilerJobGenerationMismatch);
+        // `vm.isWatcherEnabled()` ⇔ watcher present. A non-null pointer may
+        // still hold `ImportWatcher::None`; both must be ruled out or we'd
+        // skip closing `fd` without a watcher to adopt it. Only the JS thread
+        // mutates the variant.
+        if matches!(&*iw, ImportWatcher::None)
+            || !fd.0.is_valid()
+            || is_node_override
+            || !bun_paths::is_absolute(self.path.text)
+            || strings::contains(self.path.text, b"node_modules")
+        {
             return;
         }
+        // SAFETY: the watcher is process-lifetime once installed (see
+        // `import_watcher`); `add_file` serialises with the watcher thread and
+        // other transpiler threads through the watcher's own mutex, and no
+        // `&ImportWatcher` is live across this call on this thread.
+        let iw = unsafe { &mut *iw.as_const_ptr().cast_mut() };
+        let added = iw.add_file::<true>(fd.0, self.path.text, self.hash, Fd::INVALID, package_json);
+        if matches!(added, Ok(bun_watcher::FdOwnership::Watcher)) {
+            fd.0 = Fd::INVALID;
+        }
+    }
 
-        // `borrowing()`: the AST node store and the
-        // `AstVec` spill share `arena`'s heap and are bulk-freed when `arena`
-        // drops at the end of `run()`.
-        let mut ast_memory_store = ASTMemoryAllocator::borrowing(&arena);
-        let _ast_scope = ast_memory_store.enter();
+    /// The transpile proper: parse `self.path` through `transpiler` (already
+    /// aimed at this call's arena and log) and print it, storing the source
+    /// map in the VM. `Ok` is what the module promise is fulfilled with.
+    fn parse_and_print<'a>(
+        &self,
+        transpiler: &mut bun_bundler::Transpiler<'a>,
+        arena: &'a Arena,
+    ) -> Result<ResolvedSource, crate::CrateError> {
+        let Self {
+            path,
+            hash,
+            loader,
+            tag: this_tag,
+            is_main,
+            use_isolation_source_provider_cache,
+            ..
+        } = *self;
+        let specifier = path.text;
+        let source_mappings: &SavedSourceMap = self.source_mappings.get();
 
-        let path = self.path;
-        let specifier = self.path.text;
-        let loader = self.loader;
-        let this_tag = self.resolved_source.tag;
-
-        // RuntimeTranspilerCache has no per-allocator fields (Box<[u8]> + global mimalloc).
         // LAYERING: this is the canonical `bun_ast::RuntimeTranspilerCache`
         // wired with the JSC vtable so the parser's `cache.get()` reaches the
-        // disk-backed `Entry` loader; on a hit `cache.entry` holds a type-erased
-        // `*mut CacheEntry` which is unboxed below.
+        // disk-backed `Entry` loader; a hit is unboxed by `take_entry` below.
         let mut cache = RuntimeTranspilerCache {
             r#impl: Some(bun_ast::TranspilerCacheImplKind::Jsc),
             ..Default::default()
         };
 
-        let mut log = bun_ast::Log::init();
-        // `defer { this.log = ...; log.cloneToWithRecycled(&this.log, true) }`
-        let _log_clone_guard = scopeguard::guard(
-            (ptr::addr_of_mut!(self.log), ptr::addr_of_mut!(log)),
-            |(dst, src)| {
-                // SAFETY: dst/src point at locals that outlive this guard; no aliases at drop.
-                unsafe {
-                    *dst = bun_ast::Log::init();
-                    (*src).clone_to_with_recycled(&mut *dst, true);
-                }
-            },
-        );
-
-        // The whole Transpiler is copied by value here.
-        // `Transpiler<'static>` is not `Clone` (it holds raw self-referential pointers); we do
-        // a bytewise copy. SAFETY: `vm.transpiler` is read via
-        // `addr_of!` (no `&VirtualMachine` formed); every internal raw pointer in the copy
-        // still targets memory owned by `vm.transpiler` (resolver caches, define, env) which
-        // outlives this stack frame; `vm.transpiler` is not concurrently mutated.
-        // The by-value copy must not be deinitialized; `ManuallyDrop` suppresses Drop so owned
-        // fields aren't double-freed against `vm.transpiler`.
-        let mut transpiler_storage =
-            core::mem::ManuallyDrop::new(unsafe { ptr::read(ptr::addr_of!((*vm).transpiler)) });
-        // SAFETY: lifetime erasure — `Transpiler<'a>`'s `'a` only constrains the
-        // `allocator` field (and resolver opts that share it), which we
-        // immediately overwrite below via `set_arena(&arena)` to the stack-local
-        // arena above. `arena` is declared before `transpiler_storage`, so it
-        // drops after; the bytewise copy is never dropped (ManuallyDrop), so no
-        // borrow tied to the shortened `'a` outlives the arena.
-        let transpiler: &mut Transpiler<'_> =
-            unsafe { &mut *(&raw mut *transpiler_storage).cast::<Transpiler<'_>>() };
-        transpiler.set_arena(&arena);
-        transpiler.set_log(&raw mut log);
-        // Note: the resolver already shares opts with the parent
-        // Transpiler via raw pointer; set_arena/set_log keep them in sync.
-        transpiler.macro_context = None;
-        // Note: `parse_maybe` re-creates the macro context per-iteration
-        // when `macro_context.is_none()`. It boxes a
-        // higher-tier `MacroContext` via `__bun_macro_context_init`; that Box
-        // is intentionally leaked for the long-lived `vm.transpiler`, but here
-        // we operate on a per-iteration `ManuallyDrop` bytewise copy, so we
-        // MUST free what `parse_maybe` allocates or every dynamic `import()`
-        // leaks one `Box<MacroContext>` (require-cache.test.ts "files
-        // transpiled and loaded don't leak file paths > via import()" OOMs at
-        // ~0.5 GB after 100k iterations). The owned `MimallocArena` inside is
-        // now lazy (`bump: Option<Arena>`, init on first `.call()`), so the
-        // per-iteration `mi_heap_new()` is gone; this guard just reclaims the
-        // small `Box`.
-        let _macro_ctx_guard =
-            scopeguard::guard(ptr::addr_of_mut!(transpiler.macro_context), |slot| {
-                // SAFETY: `slot` points into `transpiler_storage`, which is
-                // declared before this guard and so outlives it; no other
-                // borrow of `macro_context` is live at drop time (the parser's
-                // `&mut MacroContext` is scoped to the `parse` call).
-                if let Some(ctx) = unsafe { (*slot).take() } {
-                    ctx.deinit();
-                }
-            });
-
         let mut package_json: Option<&'static bun_watcher::PackageJSON> = None;
-        let hash = Watcher::get_hash(path.text);
-
-        // SAFETY: `bun_watcher` is the `*mut ImportWatcher` set during VM init
-        // (BACKREF — when non-null it points at the process-lifetime watcher
-        // leaked in `enable_hot_module_reloading`, so the `ParentRef` invariant
-        // holds for this transpile job's duration). Raw `(*vm)` field
-        // projection avoids forming `&VirtualMachine` per the `vm` note.
-        let import_watcher: Option<bun_ptr::ParentRef<ImportWatcher, bun_ptr::Mut>> =
-            unsafe { bun_ptr::ParentRef::from_nullable_mut((*vm).bun_watcher.cast()) };
-        if let Some(iw) = import_watcher {
+        if let Some(iw) = self.import_watcher {
             // Never read through the watchlist's stored fd; see
             // `ImportWatcher::snapshot_package_json`.
             package_json = iw.snapshot_package_json(hash);
@@ -737,11 +547,7 @@ impl TranspilerJob {
         // this should be a cheap lookup because 24 bytes == 8 * 3 so it's read 3 machine words
         let is_node_override = strings::has_prefix_comptime(specifier, node_fallbacks::IMPORT_PATH);
 
-        // SAFETY: leaf scalar field reads on `*vm`; see `vm` note above.
-        let macro_remappings = if unsafe { (*vm).macro_mode }
-            || !unsafe { (*vm).has_any_macro_remappings }
-            || is_node_override
-        {
+        let macro_remappings = if !self.use_macro_remap || is_node_override {
             MacroRemap::default()
         } else {
             // Note: `MacroRemap` (StringArrayHashMap of StringArrayHashMap)
@@ -757,28 +563,11 @@ impl TranspilerJob {
             m
         };
 
-        // Only
-        // initialised on the `is_node_override` branch and only read through
-        // `parse_options.virtual_source` (raw-ptr borrow).
-        // The write is `Cow::Borrowed`/borrowed-path
-        // only, so skipping `Drop` is sound.
-        let mut fallback_source = core::mem::MaybeUninit::<bun_ast::Source>::uninit();
+        // Only initialised on the `is_node_override` branch and only read
+        // through `parse_options.virtual_source`.
+        let fallback_source;
 
-        // Close the input file automatically unless the watcher adopts the
-        // descriptor after the parse (`add_file` below).
-        //
-        // Note: stored in a `Cell` so the scopeguard closure can capture
-        // `&Cell<bool>` and the post-parse writes are visible to it without
-        // raw-pointer laundering (which the unused-assignment lint can't see).
-        let should_close_input_file_fd = Cell::new(true);
-
-        let mut input_file_fd: Fd = Fd::INVALID;
-
-        // SAFETY: leaf scalar field reads on `*vm`; see `vm` note above.
-        let (vm_main, vm_main_hash) = unsafe { ((*vm).main(), (*vm).main_hash) };
-        let is_main = vm_main.len() == path.text.len()
-            && vm_main_hash == hash
-            && strings::eql_long(vm_main, path.text, false);
+        let mut input_fd = InputFd(Fd::INVALID);
 
         let module_type: ModuleType = match this_tag {
             ResolvedSourceTag::PackageJsonTypeCommonjs => ModuleType::Cjs,
@@ -787,15 +576,12 @@ impl TranspilerJob {
         };
 
         let mut parse_options = ParseOptions {
-            arena: &arena,
+            arena,
             path,
             loader,
             dirname_fd: Fd::INVALID,
             file_descriptor: None,
-            // SAFETY: `input_file_fd` is a stack local declared above and
-            // outlives `parse_options`; `addr_of_mut!` avoids forming an
-            // intermediate `&mut` so the close-guard's later borrow stays sound.
-            file_fd_ptr: Some(unsafe { &mut *ptr::addr_of_mut!(input_file_fd) }),
+            file_fd_ptr: Some(&mut input_fd.0),
             macro_remappings,
             macro_js_ctx: transpiler::default_macro_js_value(),
             jsx: transpiler.options.jsx.clone(),
@@ -807,141 +593,43 @@ impl TranspilerJob {
             dont_bundle_twice: true,
             allow_commonjs: true,
             inject_jest_globals: transpiler.options.rewrite_jest_for_tests,
-            // SAFETY: leaf-field `&` borrow on `*vm.debugger`; see `vm` note above.
-            set_breakpoint_on_first_line: unsafe { &(*vm).debugger }
-                .as_ref()
-                .map(|d| d.set_breakpoint_on_first_line)
-                .unwrap_or(false)
+            set_breakpoint_on_first_line: self.debugger_breaks_on_first_line
                 && is_main
                 && set_break_point_on_first_line(),
             runtime_transpiler_cache: if !JscRuntimeTranspilerCache::is_disabled() {
-                // SAFETY: `cache` is a stack local declared above and outlives
-                // `parse_options`; `addr_of_mut!` avoids an intermediate `&mut`
-                // so the post-parse `cache.entry.take()` reborrow stays sound.
-                Some(unsafe { &mut *ptr::addr_of_mut!(cache) })
+                Some(&mut cache)
             } else {
                 None
             },
-            // SAFETY: leaf-field read on `*vm.module_loader`; see `vm` note above.
-            remove_cjs_module_wrapper: is_main
-                && unsafe { (*vm).module_loader.eval_source.is_some() },
+            remove_cjs_module_wrapper: is_main && self.has_eval_source,
             module_type,
             keep_json_and_toml_as_one_statement: false,
             allow_bytecode_cache: true,
         };
 
-        // `defer { if should_close && input_file_fd.isValid() { close } }`
-        let _close_fd_guard = scopeguard::guard(
-            (
-                &should_close_input_file_fd,
-                ptr::addr_of_mut!(input_file_fd),
-            ),
-            |(should, fd_ptr)| {
-                // SAFETY: `input_file_fd` outlives this guard (declared earlier
-                // in fn scope); no `&mut` alias is live at drop time.
-                unsafe {
-                    if should.get() && (*fd_ptr).is_valid() {
-                        (*fd_ptr).close();
-                        *fd_ptr = Fd::INVALID;
-                    }
-                }
-            },
-        );
-
         if is_node_override {
             if let Some(code) = node_fallbacks::contents_from_path(specifier) {
                 let fallback_path = bun_paths::fs::Path::init_with_namespace(specifier, b"node");
-                let src = fallback_source.write(bun_ast::Source {
+                fallback_source = bun_ast::Source {
                     path: fallback_path,
                     contents: std::borrow::Cow::Borrowed(code),
                     ..Default::default()
-                });
-                // SAFETY: `fallback_source` outlives `parse_options` (declared
-                // earlier in fn scope); raw-ptr borrow avoids tying
-                // `parse_options`'s `'static` source lifetime to this stack slot.
-                parse_options.virtual_source =
-                    Some(unsafe { &*std::ptr::from_ref::<bun_ast::Source>(src) });
+                };
+                parse_options.virtual_source = Some(&fallback_source);
             }
         }
-
-        // `vm.isWatcherEnabled()` ⇔ watcher present. The
-        // field is a nullable `*mut ImportWatcher`, so a non-null
-        // pointer may still hold `ImportWatcher::None`; both must be ruled out
-        // or we'd skip closing `input_file_fd` without a watcher to adopt it.
-        // Discriminant read on the BACKREF captured above; only the JS thread
-        // mutates the variant.
-        let is_watcher_enabled =
-            import_watcher.is_some_and(|iw| !matches!(&*iw, ImportWatcher::None));
 
         let Some(mut parse_result) = transpiler
             .parse_maybe_return_file_only_allow_shared_buffer::<false, false>(parse_options, None)
         else {
-            if is_watcher_enabled && input_file_fd.is_valid() {
-                if !is_node_override
-                    && bun_paths::is_absolute(path.text)
-                    && !strings::contains(path.text, b"node_modules")
-                {
-                    if let Some(iw) = import_watcher {
-                        // SAFETY: BACKREF — process-lifetime watcher; no other
-                        // `&ImportWatcher` is live here, and `add_file` is
-                        // thread-safe via watcher mutex.
-                        let added = unsafe { iw.assume_mut() }.add_file::<true>(
-                            input_file_fd,
-                            path.text,
-                            hash,
-                            Fd::INVALID,
-                            package_json,
-                        );
-                        if matches!(added, Ok(bun_watcher::FdOwnership::Watcher)) {
-                            should_close_input_file_fd.set(false);
-                        }
-                    }
-                }
-            }
-
-            self.parse_error = Some(crate::CrateError::ParseError);
-            return;
+            self.maybe_watch(&mut input_fd, is_node_override, package_json);
+            return Err(crate::CrateError::ParseError);
         };
 
-        if is_watcher_enabled && input_file_fd.is_valid() {
-            if !is_node_override
-                && bun_paths::is_absolute(path.text)
-                && !strings::contains(path.text, b"node_modules")
-            {
-                if let Some(iw) = import_watcher {
-                    // SAFETY: BACKREF — process-lifetime watcher; no other
-                    // `&ImportWatcher` is live here, and `add_file` is
-                    // thread-safe via watcher mutex.
-                    let added = unsafe { iw.assume_mut() }.add_file::<true>(
-                        input_file_fd,
-                        path.text,
-                        hash,
-                        Fd::INVALID,
-                        package_json,
-                    );
-                    if matches!(added, Ok(bun_watcher::FdOwnership::Watcher)) {
-                        should_close_input_file_fd.set(false);
-                    }
-                }
-            }
-        }
+        self.maybe_watch(&mut input_fd, is_node_override, package_json);
 
-        // SAFETY: leaf scalar field read; see `vm` note above. Inlined
-        // `VirtualMachine::use_isolation_source_provider_cache` to avoid forming
-        // `&VirtualMachine`.
-        let use_isolation_source_provider_cache = unsafe { (*vm).test_isolation_enabled }
-            && !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_ISOLATION_SOURCE_CACHE::get()
-                .unwrap_or(false);
-
-        if let Some(entry_ptr) = cache.entry.take() {
-            // SAFETY: `entry` was boxed by `JSC_PARSER_CACHE_VTABLE.get` from a
-            // concrete `crate::runtime_transpiler_cache::Entry`; sole owner.
-            let mut entry: Box<CacheEntry> =
-                unsafe { bun_core::heap::take(entry_ptr.cast::<CacheEntry>()) };
-
-            // SAFETY: leaf-field `&mut` borrow on `*vm.source_mappings`;
-            // `SavedSourceMap` takes its own internal mutex.
-            let _ = unsafe { &mut (*vm).source_mappings }.put_mappings(
+        if let Some(mut entry) = crate::runtime_transpiler_cache::take_entry(&mut cache) {
+            let _ = source_mappings.put_mappings(
                 &parse_result.source,
                 MutableString {
                     list: core::mem::take(&mut entry.sourcemap).into_vec(),
@@ -949,9 +637,7 @@ impl TranspilerJob {
             );
 
             if bun_core::env::DUMP_SOURCE {
-                // SAFETY: `vm` is the live owning VM (BACKREF — see `vm` note above).
-                let vm = unsafe { NonNull::new_unchecked(vm) };
-                dump_source_string(vm, specifier, entry.output_code.byte_slice());
+                dump_source_string(source_mappings, specifier, entry.output_code.byte_slice());
             }
 
             let module_info = if use_isolation_source_provider_cache
@@ -965,15 +651,13 @@ impl TranspilerJob {
                 None
             };
 
-            self.resolved_source = ResolvedSource {
+            return Ok(ResolvedSource {
                 source_code: core::mem::take(&mut entry.output_code),
                 is_commonjs_module: entry.metadata.module_type == CacheModuleType::Cjs,
                 module_info,
                 tag: this_tag,
                 ..Default::default()
-            };
-
-            return;
+            });
         }
 
         if !matches!(parse_result.already_bundled, AlreadyBundled::None) {
@@ -981,7 +665,7 @@ impl TranspilerJob {
             let is_commonjs_module = already_bundled.is_common_js();
             let bytecode_cache =
                 crate::resolved_source::Bytecode::owned(already_bundled.into_bytecode());
-            self.resolved_source = ResolvedSource {
+            let resolved_source = ResolvedSource {
                 source_code: String::clone_latin1(&parse_result.source.contents),
                 already_bundled: true,
                 bytecode_cache,
@@ -989,8 +673,8 @@ impl TranspilerJob {
                 tag: this_tag,
                 ..Default::default()
             };
-            self.resolved_source.source_code.ensure_hash();
-            return;
+            resolved_source.source_code.ensure_hash();
+            return Ok(resolved_source);
         }
 
         for import_record in parse_result.ast.import_records.as_mut_slice() {
@@ -1021,32 +705,13 @@ impl TranspilerJob {
             }
         }
 
-        let source_code_printer = tls_get_or_leak(&SOURCE_CODE_PRINTER, || {
-            let writer = BufferWriter::init();
-            let mut bp = Box::new(BufferPrinter::init(writer));
-            bp.ctx.append_null_byte = false;
-            bp
-        });
-
-        // Swap the buffer out and write it back via the
-        // _writeback guard (the thread-local's buffer is reused).
-        let mut printer = core::mem::replace(
-            source_code_printer,
-            BufferPrinter::init(BufferWriter::init()),
-        );
+        let mut printer = WorkerPrinter::take();
         printer.ctx.reset();
 
         // Cap buffer size to prevent unbounded growth
         const MAX_BUFFER_CAP: usize = 512 * 1024;
         if printer.ctx.buffer.list.capacity() > MAX_BUFFER_CAP {
-            // printer.ctx.buffer.deinit() → Drop
-            let writer = BufferWriter::init();
-            *source_code_printer = BufferPrinter::init(writer);
-            source_code_printer.ctx.append_null_byte = false;
-            printer = core::mem::replace(
-                source_code_printer,
-                BufferPrinter::init(BufferWriter::init()),
-            );
+            *printer = fresh_source_code_printer();
         }
 
         let is_commonjs_module = parse_result.ast.has_commonjs_export_names
@@ -1071,56 +736,37 @@ impl TranspilerJob {
         if let Some(mi) = module_info.as_deref_mut() {
             mi.flags.has_tla = !parse_result.ast.top_level_await_keyword.is_empty();
         }
-        // Note: derive `*mut` from a `&mut` borrow (not `&x as *const _ as
-        // *mut _`, which is Stacked-Borrows UB). The `&mut` borrow ends when the
+        // Derive `*mut` from a `&mut` borrow. The `&mut` borrow ends when the
         // closure returns; the raw pointer stays valid until `module_info` is
         // moved/touched again (after `print_with_source_map`).
         let module_info_ptr: Option<*mut analyze_transpiled_module::ModuleInfo> =
-            module_info.as_deref_mut().map(std::ptr::from_mut);
+            module_info.as_deref_mut().map(core::ptr::from_mut);
 
-        let print_result = {
-            // SAFETY: see `vm` note above — `from_raw` stores `vm` as a raw
-            // pointer and only borrows leaf fields (`source_mappings`, `debugger`)
-            // inside `get()`. No `&mut VirtualMachine` is ever formed.
-            let mut mapper = unsafe { SourceMapHandlerGetter::from_raw(vm, &raw mut printer) };
-            let _writeback = scopeguard::guard(
-                (
-                    std::ptr::from_mut::<BufferPrinter>(source_code_printer),
-                    ptr::addr_of_mut!(printer),
-                ),
-                |(dst, src)| {
-                    // SAFETY: both pointees outlive this scope; no aliases at drop.
-                    unsafe {
-                        *dst =
-                            core::mem::replace(&mut *src, BufferPrinter::init(BufferWriter::init()))
-                    };
-                },
-            );
-            transpiler.print_with_source_map(
-                // Same per-call `arena` that `transpiler.set_arena(&arena)`
-                // and `parse_options.arena` used to build `parse_result.ast`.
-                &arena,
-                parse_result,
-                &mut printer,
-                js_printer::Format::EsmAscii,
-                mapper.get(),
-                module_info_ptr,
-            )
-        };
-        if let Err(err) = print_result {
-            drop(module_info);
-            self.parse_error = Some(err.into());
-            return;
+        {
+            let mut mapper = SourceMapHandlerGetter::new(source_mappings, self.inline_source_map);
+            transpiler
+                .print_with_source_map(
+                    // Same per-call `arena` the transpiler and
+                    // `parse_options.arena` used to build `parse_result.ast`.
+                    arena,
+                    parse_result,
+                    &mut printer,
+                    js_printer::Format::EsmAscii,
+                    mapper.get(),
+                    module_info_ptr,
+                )
+                .map_err(crate::CrateError::from)?;
+            mapper
+                .write_inline_trailer(&mut printer)
+                .map_err(|e| crate::CrateError::from(bun_bundler::Error::from(e)))?;
         }
 
         if bun_core::env::DUMP_SOURCE {
-            // SAFETY: `vm` is the live owning VM (BACKREF — see `vm` note above).
-            let vm = unsafe { NonNull::new_unchecked(vm) };
-            dump_source(vm, specifier, source_code_printer);
+            dump_source(source_mappings, specifier, &printer);
         }
 
         let source_code = 'brk: {
-            let written = source_code_printer.ctx.get_written();
+            let written = printer.ctx.get_written();
 
             // The `Jsc` vtable bridge `put()` does not write
             // `cache.output_code` (only the `r#impl == None` fallback does,
@@ -1128,14 +774,11 @@ impl TranspilerJob {
             debug_assert!(cache.output_code.is_none());
             let result = String::clone_latin1(written);
 
-            // SAFETY: leaf scalar field read on `*vm`; see `vm` note above.
-            if written.len() > 1024 * 1024 * 2 || unsafe { (*vm).smol } {
-                // printer.ctx.buffer.deinit() → Drop
-                let writer = BufferWriter::init();
-                *source_code_printer = BufferPrinter::init(writer);
-                source_code_printer.ctx.append_null_byte = false;
+            if written.len() > 1024 * 1024 * 2 || self.smol {
+                // Release the large / --smol print buffer now instead of
+                // holding it until the next transpile on this worker.
+                *printer = fresh_source_code_printer();
             }
-            // else: writeback guard already restored `printer` into the thread-local.
 
             // In a benchmarking loading @babel/standalone 100 times:
             //
@@ -1149,7 +792,7 @@ impl TranspilerJob {
 
             break 'brk result;
         };
-        self.resolved_source = ResolvedSource {
+        Ok(ResolvedSource {
             source_code,
             is_commonjs_module,
             module_info: module_info.map(|mi| {
@@ -1158,11 +801,58 @@ impl TranspilerJob {
             }),
             tag: this_tag,
             ..Default::default()
+        })
+    }
+}
+
+impl TranspileWork {
+    fn run(&mut self) {
+        // Stack-local per call, bulk-freed on return. An earlier version hoisted
+        // this to a per-worker-thread leaked `Box<MimallocArena>` (and a second
+        // one inside a leaked `ASTMemoryAllocator`) and only `reset()` it at
+        // the *start* of the next call. On a 64-core box ~40 thread-pool
+        // workers each parse one or two modules then go idle, leaving ~80
+        // undestroyed `mi_heap_t`s holding ~7 MB requested / ~10–11 MB
+        // committed of dead AST between calls — the +12 % RSS regression seen
+        // on `server/elysia`. `MimallocArena::Drop` = `mi_heap_destroy`, so the
+        // per-call heap-churn is identical to a start-of-call `reset()` but the
+        // worker holds **zero** retained pages between calls.
+        let arena = Arena::new();
+
+        if self.generation_number != self.store_generation.load(Ordering::Relaxed) {
+            self.parse_error = Some(crate::CrateError::TranspilerJobGenerationMismatch);
+            return;
+        }
+
+        // `borrowing()`: the AST node store and the
+        // `AstVec` spill share `arena`'s heap and are bulk-freed when `arena`
+        // drops at the end of `run()`.
+        let mut ast_memory_store = ASTMemoryAllocator::borrowing(&arena);
+        let _ast_scope = ast_memory_store.enter();
+
+        // SAFETY: see `transpiler`; the copy only parses and prints, and is
+        // dropped (freeing the macro context a parse lazily creates through
+        // this thread's per-thread state) before this returns.
+        let mut transpiler = unsafe { JobTranspiler::new(self.transpiler.get()) };
+
+        // Parsed into a fresh log; whatever it collects is recycled into
+        // `self.log` (what `then` reports from) on every way out.
+        let mut log = bun_ast::Log::init();
+        let result = {
+            let mut transpiler = transpiler.for_call(&arena, &mut log);
+            self.input.parse_and_print(&mut transpiler, &arena)
         };
+        drop(transpiler);
+        self.log = bun_ast::Log::init();
+        log.clone_to_with_recycled(&mut self.log, true);
+        match result {
+            Ok(resolved_source) => self.resolved_source = resolved_source,
+            Err(err) => self.parse_error = Some(err),
+        }
 
         // `arena` and `ast_memory_store` drop here (after `_ast_scope` restores
         // the thread-local AST heap pointer), `mi_heap_destroy`ing every parse
         // / AST allocation made by this call. Nothing references them past
-        // this point — `source_code` above is a fresh WTF::String copy.
+        // this point — `source_code` is a fresh WTF::String copy.
     }
 }

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -9,29 +9,26 @@ use bun_core::Ordinal;
 use bun_ptr::tagged_pointer::TagType;
 use bun_sourcemap::parsed_source_map::AnySourceProvider;
 use bun_sourcemap::{self as SourceMap, InternalSourceMap, ParsedSourceMap};
-use bun_threading::Mutex;
+use bun_threading::Guarded;
 use bun_wyhash::hash;
 
+/// Per-VM path → source-map table. Shared between the JS thread, the
+/// transpiler work-pool threads that store mappings as they print, and the
+/// heap-collector thread that remaps stack frames, so every method takes
+/// `&self` and goes through the lock.
 #[derive(Default)]
 pub struct SavedSourceMap {
-    /// Only accessed between [`Self::lock`] and [`Self::unlock`].
-    map: HashTable,
-    mutex: Mutex,
+    map: Guarded<HashTable>,
 }
 
-impl SavedSourceMap {
-    #[inline]
-    pub(crate) fn lock(&mut self) {
-        self.mutex.lock();
-        self.map.unlock_pointers();
-    }
-
-    #[inline]
-    pub(crate) fn unlock(&mut self) {
-        self.map.lock_pointers();
-        self.mutex.unlock();
-    }
-}
+// SAFETY: the table is only reached through `map`'s mutex, and what its values
+// own — a `ParsedSourceMap` strong ref, an `InternalSourceMap` blob, a boxed
+// `AnySourceProvider` — is thread-agnostic heap data (the provider's FFI
+// handle is only *compared* or asked for its source map, which C++ serves from
+// any thread).
+unsafe impl Send for SavedSourceMap {}
+// SAFETY: as above.
+unsafe impl Sync for SavedSourceMap {}
 
 /// `InternalSourceMap` is the storage for runtime-transpiled modules.
 /// `AnySourceProvider` (boxed — the box is table-owned, the provider FFI
@@ -103,7 +100,7 @@ impl SavedSourceMap {
     /// unregisters it via [`Self::remove_source_provider`] before freeing it —
     /// while the box holding the erased pair is owned by the table and freed
     /// by [`Self::release_value`] on replace / remove / drop.
-    pub fn put_source_provider(&mut self, provider: AnySourceProvider, path: &[u8]) {
+    pub fn put_source_provider(&self, provider: AnySourceProvider, path: &[u8]) {
         let boxed = bun_core::heap::into_raw(Box::new(provider));
         // bun.handleOom → drop wrapper; Rust HashMap insert aborts on OOM.
         if self.put_value(path, Value::init(boxed)).is_err() {
@@ -115,15 +112,13 @@ impl SavedSourceMap {
     /// Drops the entry for `path` if it still refers to
     /// `opaque_source_provider` — either as a registered provider entry, or
     /// as a `ParsedSourceMap` materialized from that provider.
-    pub fn remove_source_provider(&mut self, opaque_source_provider: *mut c_void, path: &[u8]) {
-        self.lock();
-        // Note: reshaped for borrowck — explicit unlock paired manually.
+    pub fn remove_source_provider(&self, opaque_source_provider: *mut c_void, path: &[u8]) {
+        let mut map = self.map.lock();
         // `get`+`remove(&key)`: the std
         // backing has no key-slot pointer to hand out, and the key is a u64 hash
         // we already have in hand.
         let key = hash(path);
-        let Some(&ptr) = self.map.get(&key) else {
-            self.unlock();
+        let Some(&ptr) = map.get(&key) else {
             return;
         };
         let old_value = Value::from(Some(ptr));
@@ -140,12 +135,11 @@ impl SavedSourceMap {
             false
         };
         if refers_to_provider {
-            self.map.remove(&key);
+            map.remove(&key);
             // SAFETY: `old_value` was stored by us; the table's ownership of
             // it ends here.
             unsafe { Self::release_value(old_value) };
         }
-        self.unlock();
     }
 }
 
@@ -154,7 +148,7 @@ impl SavedSourceMap {
 // zig_hash_map uses an 80% max load factor.
 type HashTable = HashMap<u64, *mut c_void, IdentityContext<u64>>;
 
-impl bun_js_printer::OnSourceMapChunk for SavedSourceMap {
+impl bun_js_printer::OnSourceMapChunk for &SavedSourceMap {
     fn on_source_map_chunk(
         &mut self,
         chunk: SourceMap::Chunk,
@@ -166,20 +160,18 @@ impl bun_js_printer::OnSourceMapChunk for SavedSourceMap {
 
 impl Drop for SavedSourceMap {
     fn drop(&mut self) {
-        self.lock();
-        for val in self.map.values() {
+        for val in self.map.get_mut().values() {
             let value = Value::from(Some(*val));
             // SAFETY: values were stored by us and are live until table
             // teardown.
             unsafe { Self::release_value(value) };
         }
-        self.unlock();
     }
 }
 
 impl SavedSourceMap {
     pub fn put_mappings(
-        &mut self,
+        &self,
         source: &bun_ast::Source,
         mut mappings: MutableString,
     ) -> bun_js_printer::Result<()> {
@@ -193,15 +185,10 @@ impl SavedSourceMap {
             let incoming = InternalSourceMap {
                 data: mappings.list.as_ptr(),
             };
-            if incoming.mapping_count() == 0 {
-                self.lock();
-                let contains = self.map.contains_key(&hash(source.path.text));
-                self.unlock();
-                if contains {
-                    return Ok(());
-                }
-                // Note: reshaped for borrowck — the lock is
-                // released before returning since no further table access follows.
+            if incoming.mapping_count() == 0
+                && self.map.lock().contains_key(&hash(source.path.text))
+            {
+                return Ok(());
             }
         }
 
@@ -228,15 +215,13 @@ impl SavedSourceMap {
         }
     }
 
-    pub(crate) fn put_value(&mut self, path: &[u8], value: Value) -> bun_js_printer::Result<()> {
+    pub(crate) fn put_value(&self, path: &[u8], value: Value) -> bun_js_printer::Result<()> {
         use bun_collections::zig_hash_map::MapEntry as Entry;
 
-        self.lock();
-        // Note: reshaped for borrowck — explicit unlock paired manually.
-
+        let mut map = self.map.lock();
         // `bun_collections::HashMap` derefs to `std::collections::HashMap`, so
         // the std `entry()` API is used directly.
-        match self.map.entry(hash(path)) {
+        match map.entry(hash(path)) {
             Entry::Occupied(mut o) => {
                 let old_value = Value::from(Some(*o.get()));
                 // SAFETY: `old_value` was stored by us and is live until
@@ -248,24 +233,22 @@ impl SavedSourceMap {
                 v.insert(value.ptr());
             }
         }
-        self.unlock();
         Ok(())
     }
 
     /// You must call `sourcemap.map.deref()` or you will leak memory
     fn get_with_content(
-        &mut self,
+        &self,
         path: &[u8],
         hint: SourceMap::ParseUrlResultHint,
     ) -> SourceMap::ParseUrl {
         let h = hash(path);
 
         // This lock is for the hash table
-        self.lock();
+        let mut map = self.map.lock();
 
         // This mapping entry is only valid while the mutex is locked
-        let Some(mapping) = self.map.get_mut(&h) else {
-            self.unlock();
+        let Some(mapping) = map.get_mut(&h) else {
             return SourceMap::ParseUrl::default();
         };
 
@@ -283,7 +266,6 @@ impl SavedSourceMap {
             // the returned `Arc`.
             let result = Arc::new(ParsedSourceMap::from_internal(ism));
             *mapping = Value::init(Arc::into_raw(Arc::clone(&result))).ptr();
-            self.unlock();
             return SourceMap::ParseUrl {
                 map: Some(result),
                 ..Default::default()
@@ -296,65 +278,73 @@ impl SavedSourceMap {
                 Arc::increment_strong_count(parsed.cast_const());
                 Arc::from_raw(parsed.cast_const())
             };
-            self.unlock();
             return SourceMap::ParseUrl {
                 map: Some(result),
                 ..Default::default()
             };
-        } else if let Some(provider) = tagged.get::<AnySourceProvider>() {
+        } else if let Some(provider_box) = tagged.get::<AnySourceProvider>() {
             // Copy the erased pair out while the lock is held: once unlocked,
             // a concurrent put/remove may free the box.
             // SAFETY: the box was stored by `put_source_provider` and is live
             // while in the table.
-            let provider = unsafe { *provider };
-            self.unlock();
+            let provider = unsafe { *provider_box };
+            let registered = *mapping;
+            drop(map);
 
             // Do not lock the mutex while we're parsing JSON!
             // The provider FFI handle is kept alive by its owner (JSC / the
-            // registrar), which unregisters it before freeing; we did not
-            // hold a ref.
-            if let Some(parse) = provider.get_source_map(path, Default::default(), hint) {
-                if let Some(ref parsed_map) = parse.map {
-                    // The mutex is not locked. We have to check the hash table again.
-                    // Leak one strong ref into the table; `put_value` releases
-                    // the replaced provider box.
-                    let _ =
-                        self.put_value(path, Value::init(Arc::into_raw(Arc::clone(parsed_map))));
+            // registrar), which unregisters it (`remove_source_provider`, on
+            // the JS thread) before freeing; we hold no ref of our own, as
+            // before this table had `&self` methods.
+            let parse = provider.get_source_map(path, Default::default(), hint);
 
+            // The table may have changed while unlocked (the provider removed,
+            // or a newer one registered for `path`): only the entry this parse
+            // started from is replaced — by the parsed map, or dropped so a
+            // provider without a valid map is not asked again.
+            let mut map = self.map.lock();
+            let still_registered = map.get(&h).is_some_and(|&p| p == registered);
+            if let Some(parse) = parse {
+                if let Some(ref parsed_map) = parse.map {
+                    if still_registered {
+                        // Leak one strong ref into the table; releasing the
+                        // old value frees the provider box.
+                        let new = Value::init(Arc::into_raw(Arc::clone(parsed_map))).ptr();
+                        let old = map.insert(h, new).expect("still registered");
+                        // SAFETY: `old` is the provider box this table owned.
+                        unsafe { Self::release_value(Value::from(Some(old))) };
+                    }
                     return parse;
                 }
             }
-
-            self.lock();
-            // does not have a valid source map. let's not try again
-            if let Some(removed) = self.map.remove(&h) {
-                // SAFETY: whatever occupies the slot now was stored by us;
-                // the table's ownership of it ends here.
-                unsafe { Self::release_value(Value::from(Some(removed))) };
+            if still_registered {
+                if let Some(removed) = map.remove(&h) {
+                    // SAFETY: `removed` is the provider box this table owned;
+                    // its ownership ends here.
+                    unsafe { Self::release_value(Value::from(Some(removed))) };
+                }
             }
 
             // Store path for a user note.
             missing_source_map_note_info::record(path);
-            self.unlock();
             return SourceMap::ParseUrl::default();
         } else {
             if cfg!(debug_assertions) {
                 panic!("Corrupt pointer tag");
             }
-            self.unlock();
 
             return SourceMap::ParseUrl::default();
         }
     }
 
     /// You must `deref()` the returned value or you will leak memory
-    pub fn get(&mut self, path: &[u8]) -> Option<std::sync::Arc<ParsedSourceMap>> {
+    pub fn get(&self, path: &[u8]) -> Option<std::sync::Arc<ParsedSourceMap>> {
         self.get_with_content(path, SourceMap::ParseUrlResultHint::MappingsOnly)
             .map
     }
 
     pub(crate) fn resolve_mapping(
-        &mut self,
+        &self,
         path: &[u8],
         line: Ordinal,
         column: Ordinal,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1222,30 +1222,24 @@ impl VirtualMachine {
     }
 
     #[inline]
-    pub fn source_mappings(&mut self) -> &mut SavedSourceMap {
-        &mut self.source_mappings
+    pub fn source_mappings(&self) -> &SavedSourceMap {
+        &self.source_mappings
     }
 
-    /// Returns a small adaptor whose `get()` produces the erased
-    /// `js_printer::SourceMapHandler` for `print_with_source_map`.
-    ///
-    /// Note: takes `*mut BufferPrinter` (raw), not `&'a mut`, because the
-    /// SAME `BufferPrinter` is also passed as the live `writer` to
-    /// `print_with_source_map`. Creating an `&'a mut` here would alias with
-    /// that writer borrow for the entire print; instead we stash the raw
-    /// pointer and only reborrow inside `on_source_map_chunk` once the
-    /// writer's last use (`print_slice`) has retired. See jsc_hooks.rs
-    /// `print_with_source_map` call-site Note.
+    /// Whether transpiled modules get an inline source map appended for the
+    /// debugger: one is attached and it is *not* a `.connect`
+    /// (VSCode-extension) client.
     #[inline]
-    pub fn source_map_handler<'a>(
-        &'a mut self,
-        printer: *mut bun_js_printer::BufferPrinter,
-    ) -> SourceMapHandlerGetter<'a> {
-        SourceMapHandlerGetter {
-            vm: self,
-            printer,
-            _marker: core::marker::PhantomData,
-        }
+    pub fn inline_source_map_enabled(&self) -> bool {
+        matches!(self.debugger.as_deref(), Some(d) if d.mode != crate::debugger::Mode::Connect)
+    }
+
+    /// The adaptor whose `get()` produces the erased
+    /// `js_printer::SourceMapHandler` for `print_with_source_map`; see
+    /// [`SourceMapHandlerGetter`].
+    #[inline]
+    pub fn source_map_handler(&self) -> SourceMapHandlerGetter<'_> {
+        SourceMapHandlerGetter::new(&self.source_mappings, self.inline_source_map_enabled())
     }
 
     #[inline]
@@ -1435,8 +1429,8 @@ impl VirtualMachine {
         // scopeguard, JSTranspiler TransformTask, bundler `Worker::deinit`) and
         // frees the printer while this VM survives with the flag still set —
         // the next macro on the same pool thread would otherwise skip re-init
-        // and panic at `SOURCE_CODE_PRINTER.get().expect(...)`.
-        if SOURCE_CODE_PRINTER.get().is_none() {
+        // and find no `SOURCE_CODE_PRINTER` to lend.
+        if !source_code_printer_is_set() {
             SOURCE_CODE_PRINTER_FROM_MACRO.set(true);
         }
         ensure_source_code_printer();
@@ -2130,7 +2124,6 @@ impl VirtualMachine {
     pub fn release_queued_work(&mut self) {
         self.regular_event_loop.release_queued_tasks();
         self.macro_event_loop.release_queued_tasks();
-        self.transpiler_store.release_queued_jobs_for_teardown();
     }
 }
 
@@ -3119,106 +3112,50 @@ pub fn process_fetch_log(
 // SourceMapHandlerGetter
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Holds raw
-/// pointers to the VM and the active `BufferPrinter` so that `get()` can
-/// return an erased `js_printer::SourceMapHandler` borrowing either the VM's
-/// `source_mappings` (fast path) or `self` (debugger / inline-sourcemap path)
-/// without the two `&mut` borrows colliding.
-///
-/// Note: we keep raw pointers + a `PhantomData<&'a mut ()>` so the getter's lifetime
-/// is tied to the `&'a mut VirtualMachine` it was built from in
-/// `source_map_handler`, but `get()` can still hand out a
-/// `SourceMapHandler<'_>` over `vm.source_mappings` without tripping borrowck
-/// on the disjoint `self.vm` reborrow. `printer` is accepted and stored as a
-/// raw pointer (NOT `&'a mut`) because the same `BufferPrinter` is also the
-/// live `writer` inside `print_with_source_map`; holding an `&'a mut` here
-/// would alias it for the whole print.
+/// Produces the erased `js_printer::SourceMapHandler` for one
+/// `print_with_source_map` call: every chunk is stored in the VM's
+/// [`SavedSourceMap`]; with a debugger attached (and not in `.connect` mode)
+/// the map is additionally rendered as an inline `//# sourceMappingURL=data:`
+/// trailer, which the caller appends to the printed output with
+/// [`write_inline_trailer`](Self::write_inline_trailer) once printing is done.
 pub struct SourceMapHandlerGetter<'a> {
-    vm: *mut VirtualMachine,
-    printer: *mut bun_js_printer::BufferPrinter,
-    _marker: core::marker::PhantomData<&'a mut ()>,
+    source_mappings: &'a SavedSourceMap,
+    inline_source_map: bool,
+    inline_trailer: Vec<u8>,
 }
 
 impl<'a> SourceMapHandlerGetter<'a> {
-    /// Construct directly from raw pointers — used by the off-JS-thread
-    /// transpiler worker (`TranspilerJob::run`) which must never materialize a
-    /// `&mut VirtualMachine` (the VM is concurrently live on the JS thread and
-    /// the job slot itself is stored *inside* `vm.transpiler_store`).
-    ///
-    /// SAFETY: caller guarantees `vm` outlives `'a` and that only worker-safe
-    /// leaf fields (`source_mappings`, `debugger`) are touched via `get()`.
+    /// `inline_source_map`: see [`VirtualMachine::inline_source_map_enabled`].
     #[inline]
-    pub(crate) unsafe fn from_raw(
-        vm: *mut VirtualMachine,
-        printer: *mut bun_js_printer::BufferPrinter,
-    ) -> Self {
+    pub fn new(source_mappings: &'a SavedSourceMap, inline_source_map: bool) -> Self {
         Self {
-            vm,
-            printer,
-            _marker: core::marker::PhantomData,
+            source_mappings,
+            inline_source_map,
+            inline_trailer: Vec::new(),
         }
     }
 
-    /// Read-only view of `(*vm).debugger` via raw place projection.
-    ///
-    /// SAFETY: `vm` is never null (set from a live `&'a mut VirtualMachine` in
-    /// `source_map_handler`, or via `from_raw` whose caller guarantees the VM
-    /// outlives `'a`). Deliberately projects through the raw pointer to the
-    /// leaf field WITHOUT forming an intermediate `&VirtualMachine` /
-    /// `&mut VirtualMachine`: on the off-JS-thread `TranspilerJob::run` path
-    /// the JS thread is concurrently live on the same VM, AND the running
-    /// `&mut TranspilerJob` is itself stored inside
-    /// `(*vm).transpiler_store.store`, so a whole-VM retag would be a data
-    /// race and would invalidate the caller's `&mut self` tag (Stacked
-    /// Borrows). Only the worker-safe `debugger` bytes are retagged here.
-    #[inline]
-    fn vm_debugger(&self) -> Option<&crate::debugger::Debugger> {
-        // SAFETY: see fn doc — `self.vm` is non-null; raw place projection to
-        // the worker-safe `debugger` leaf avoids a whole-VM retag.
-        unsafe { (*self.vm).debugger.as_deref() }
-    }
-
-    /// Exclusive access to `(*vm).source_mappings` via raw place projection.
-    ///
-    /// SAFETY: as for `vm_debugger` — `vm` is never null, and we project
-    /// `(*self.vm).source_mappings` directly so only the leaf field's bytes
-    /// are retagged. A whole-VM `&mut *self.vm` here would (a) race with the
-    /// JS thread on the `from_raw` worker path, (b) overlap the caller's own
-    /// `&mut TranspilerJob` storage inside `vm.transpiler_store`, and (c) on
-    /// the main-thread jsc_hooks path, overlap the already-formed
-    /// `&mut (*jsc_vm).transpiler` receiver borrow. The leaf projection
-    /// touches none of those bytes.
-    #[inline]
-    fn vm_source_mappings_mut(&mut self) -> &mut SavedSourceMap {
-        // SAFETY: see fn doc — `self.vm` is non-null; raw place projection to
-        // the `source_mappings` leaf avoids aliasing the caller's borrows.
-        unsafe { &mut (*self.vm).source_mappings }
-    }
-
-    /// Raw pointer to the active `BufferPrinter`.
-    ///
-    /// Intentionally NOT a `&mut`-returning accessor: the same
-    /// `BufferPrinter` is concurrently the live `writer` argument inside
-    /// `print_with_source_map`, so materializing a `&mut` here while the
-    /// printer is mid-write would alias. Callers must only dereference this
-    /// pointer once the writer's last byte has been emitted (i.e. inside
-    /// `on_source_map_chunk`, which the printer invokes from its tail).
     pub fn get(&mut self) -> bun_js_printer::SourceMapHandler<'_> {
-        // Take the inline-sourcemap path only when a
-        // debugger is present AND it is *not* in `.connect` mode — `.connect`
-        // (VSCode-extension) clients fall through to the `source_mappings`
-        // fast-path handler.
-        let wants_inline_source_map = matches!(
-            self.vm_debugger(),
-            Some(d) if d.mode != crate::debugger::Mode::Connect
-        );
-        if !wants_inline_source_map {
-            // `source_mappings` is a value field on the VM, exclusively
-            // borrowed for the returned handler's lifetime (bounded by
-            // `&mut self`).
-            return bun_js_printer::SourceMapHandler::for_(self.vm_source_mappings_mut());
+        if !self.inline_source_map {
+            return bun_js_printer::SourceMapHandler::for_(&mut self.source_mappings);
         }
         bun_js_printer::SourceMapHandler::for_(self)
+    }
+
+    /// Append the inline source-map trailer (if this print produced one) to
+    /// `printer`'s output.
+    pub fn write_inline_trailer(
+        &self,
+        printer: &mut bun_js_printer::BufferPrinter,
+    ) -> bun_js_printer::Result<()> {
+        if self.inline_trailer.is_empty() {
+            return Ok(());
+        }
+        // The trailer goes after everything the printer wrote; its `done()`
+        // must not have appended a terminator in between.
+        debug_assert!(!printer.ctx.append_null_byte && !printer.ctx.append_newline);
+        printer.ctx.buffer.append(&self.inline_trailer)?;
+        Ok(())
     }
 }
 
@@ -3232,67 +3169,34 @@ impl<'a> bun_js_printer::OnSourceMapChunk for SourceMapHandlerGetter<'a> {
         source: &bun_ast::Source,
     ) -> bun_js_printer::Result<()> {
         let mut temp_json_buffer = bun_core::MutableString::init_empty();
-        // `defer temp_json_buffer.deinit()` → Drop.
         chunk
             .print_source_map_contents_from_internal::<true>(source, &mut temp_json_buffer, true)
             .map_err(|_| bun_js_printer::Error::WriteFailed)?;
         const SOURCE_MAP_URL_PREFIX_START: &[u8] =
-            b"//# sourceMappingURL=data:application/json;base64,";
+            b"\n//# sourceMappingURL=data:application/json;base64,";
         // TODO: do we need to %-encode the path?
-        let source_url_len = source.path.text.len();
         const SOURCE_MAPPING_URL: &[u8] = b"\n//# sourceURL=";
-        let prefix_len =
-            SOURCE_MAP_URL_PREFIX_START.len() + SOURCE_MAPPING_URL.len() + source_url_len;
 
-        self.vm_source_mappings_mut()
+        self.source_mappings
             .put_mappings(source, chunk.buffer)
             .map_err(|_| bun_js_printer::Error::WriteFailed)?;
 
-        // SAFETY: `printer` is the raw `*mut BufferPrinter` passed in by the
-        // caller (jsc_hooks.rs), with the SAME provenance as the `writer` arg
-        // to `print_with_source_map`. By the time `on_source_map_chunk` runs
-        // (js_printer/lib.rs `print_ast` tail), the writer
-        // has emitted its last byte; we reborrow from the raw pointer here
-        // rather than from a stashed `&'a mut` so no Unique tag is held across
-        // the writer's lifetime. The caller MUST rederive its own
-        // `&mut BufferPrinter` from the raw pointer after
-        // `print_with_source_map` returns (see jsc_hooks.rs). See
-        // `SourceMapHandlerGetter` doc for why `printer` is not stored as `&'a mut`.
-        let printer = unsafe { &mut *self.printer };
-
-        let encode_len = bun_base64::encode_len(temp_json_buffer.list.as_slice());
-        printer
-            .ctx
-            .buffer
-            .grow_if_needed(encode_len + prefix_len + 2)?;
-        printer.ctx.buffer.append_assume_capacity(b"\n");
-        printer
-            .ctx
-            .buffer
-            .append_assume_capacity(SOURCE_MAP_URL_PREFIX_START);
-        {
-            // `MutableString::list` is a `Vec<u8>`; write into spare capacity,
-            // then commit the written length.
-            let buf = &mut printer.ctx.buffer.list;
-            // SAFETY: `grow_if_needed` reserved ≥encode_len spare; encode writes
-            // `wrote<=encode_len` bytes.
-            let wrote = unsafe {
-                bun_base64::encode(
-                    &mut bun_core::vec::spare_bytes_mut(buf)[..encode_len],
-                    temp_json_buffer.list.as_slice(),
-                )
-            };
-            // SAFETY: `wrote <= encode_len` bytes were just initialized in the
-            // spare capacity reserved by `grow_if_needed` above.
-            unsafe { bun_core::vec::commit_spare(buf, wrote) };
-        }
-        printer
-            .ctx
-            .buffer
-            .append_assume_capacity(SOURCE_MAPPING_URL);
+        let json = temp_json_buffer.list.as_slice();
+        let trailer = &mut self.inline_trailer;
+        trailer.clear();
+        trailer.reserve_exact(
+            SOURCE_MAP_URL_PREFIX_START.len()
+                + bun_base64::encode_len(json)
+                + SOURCE_MAPPING_URL.len()
+                + source.path.text.len()
+                + 1,
+        );
+        trailer.extend_from_slice(SOURCE_MAP_URL_PREFIX_START);
+        bun_base64::encode_append(trailer, json);
+        trailer.extend_from_slice(SOURCE_MAPPING_URL);
         // TODO: do we need to %-encode the path?
-        printer.ctx.buffer.append_assume_capacity(source.path.text);
-        printer.ctx.buffer.append(b"\n")?;
+        trailer.extend_from_slice(source.path.text);
+        trailer.push(b'\n');
         Ok(())
     }
 }
@@ -3386,9 +3290,54 @@ pub struct ResolveFunctionResult {
 }
 
 /// Per-thread `BufferPrinter` used when printing transpiled module source.
+/// Lent out for one print at a time through [`SourceCodePrinter`].
 #[thread_local]
-pub(crate) static SOURCE_CODE_PRINTER: Cell<Option<NonNull<bun_js_printer::BufferPrinter>>> =
-    Cell::new(None);
+static SOURCE_CODE_PRINTER: Cell<Option<Box<bun_js_printer::BufferPrinter>>> = Cell::new(None);
+
+/// Whether this thread has allocated its [`SOURCE_CODE_PRINTER`] (which may
+/// currently be lent out through a [`SourceCodePrinter`], leaving the slot
+/// itself empty).
+#[thread_local]
+static SOURCE_CODE_PRINTER_ALLOCATED: Cell<bool> = Cell::new(false);
+
+fn source_code_printer_is_set() -> bool {
+    SOURCE_CODE_PRINTER_ALLOCATED.get()
+}
+
+/// This thread's module-source printer, taken out of [`SOURCE_CODE_PRINTER`]
+/// for one print and put back — so its buffer is reused — when dropped.
+pub(crate) struct SourceCodePrinter(Option<Box<bun_js_printer::BufferPrinter>>);
+
+impl SourceCodePrinter {
+    /// A print nested inside another on this thread (the slot is empty while
+    /// lent out) gets a fresh printer of its own.
+    pub(crate) fn take() -> Self {
+        Self(Some(
+            SOURCE_CODE_PRINTER
+                .take()
+                .unwrap_or_else(new_source_code_printer),
+        ))
+    }
+}
+
+impl core::ops::Deref for SourceCodePrinter {
+    type Target = bun_js_printer::BufferPrinter;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_deref().expect("live until drop")
+    }
+}
+
+impl core::ops::DerefMut for SourceCodePrinter {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_deref_mut().expect("live until drop")
+    }
+}
+
+impl Drop for SourceCodePrinter {
+    fn drop(&mut self) {
+        SOURCE_CODE_PRINTER.set(self.0.take());
+    }
+}
 
 /// `true` when [`enable_macro_mode`](VirtualMachine::enable_macro_mode)
 /// allocated [`SOURCE_CODE_PRINTER`] on this thread and no runtime VM has since
@@ -3432,22 +3381,24 @@ fn specifier_cache_resolver_buf() -> *mut bun_paths::PathBuffer {
     p
 }
 
+fn new_source_code_printer() -> Box<bun_js_printer::BufferPrinter> {
+    let writer = bun_js_printer::BufferWriter::init();
+    let mut printer = Box::new(bun_js_printer::BufferPrinter::init(writer));
+    printer.ctx.append_null_byte = false;
+    printer
+}
+
 fn ensure_source_code_printer() {
-    if SOURCE_CODE_PRINTER.get().is_none() {
-        let writer = bun_js_printer::BufferWriter::init();
-        let mut printer = Box::new(bun_js_printer::BufferPrinter::init(writer));
-        printer.ctx.append_null_byte = false;
-        SOURCE_CODE_PRINTER.set(NonNull::new(bun_core::heap::into_raw(printer)));
+    if !source_code_printer_is_set() {
+        SOURCE_CODE_PRINTER.set(Some(new_source_code_printer()));
+        SOURCE_CODE_PRINTER_ALLOCATED.set(true);
     }
 }
 
 /// Free this thread's [`SOURCE_CODE_PRINTER`] Box (if any).
 fn drop_source_code_printer() {
-    if let Some(printer) = SOURCE_CODE_PRINTER.take() {
-        // SAFETY: `printer` was produced by `heap::into_raw` in
-        // `ensure_source_code_printer` and is exclusively owned by this thread.
-        drop(unsafe { bun_core::heap::take(printer.as_ptr()) });
-    }
+    drop(SOURCE_CODE_PRINTER.take());
+    SOURCE_CODE_PRINTER_ALLOCATED.set(false);
     SOURCE_CODE_PRINTER_FROM_MACRO.set(false);
 }
 
@@ -3466,9 +3417,8 @@ fn drop_source_code_printer() {
 /// `__bun_macro_context_deinit` can fire *inside* the guard scope (e.g. a
 /// macro that calls `new Bun.Transpiler().transformSync(...)` —
 /// `TranspilerStateGuard::drop` deinits the nested `MacroContext`), and freeing
-/// here would panic the next module fetch at
-/// `SOURCE_CODE_PRINTER.get().expect(...)` with no intervening
-/// `enable_macro_mode()`. Gated on `macro_guard_depth`: nonzero exactly while a
+/// here would discard the printer (and its buffer) the enclosing macro's next
+/// module fetch lends out, with no intervening `enable_macro_mode()`. Gated on `macro_guard_depth`: nonzero exactly while a
 /// guard is on the stack (both `MacroContext::call` and `Macro::init` hold one,
 /// so the macro module's top-level is covered too).
 pub fn drop_source_code_printer_if_macro_owned() {
@@ -4387,19 +4337,15 @@ impl VirtualMachine {
         }
         let mut guard = ArenaReset(jsc_vm, flags != FetchFlags::PrintSource);
 
-        let printer = SOURCE_CODE_PRINTER
-            .get()
-            .expect("source_code_printer not initialized");
+        let mut printer = SourceCodePrinter::take();
 
         // Note: the §Dispatch shim takes path/loader/module_type/printer/
-        // promise_ptr bundled as `TranspileExtra` behind `args.extra` (see
+        // promise slot bundled as `TranspileExtra` behind `args.extra` (see
         // ModuleLoader.rs `TranspileArgs`).
         let mut extra = ModuleLoader::TranspileExtra {
             // SAFETY: `lr.path` borrows from `specifier_clone` (and the VM's
             // resolver caches), both of which outlive the synchronous
-            // `transpile_source_code` call below; `TranspileExtra` declares
-            // `'static` only because it crosses the §Dispatch boundary as
-            // `*mut c_void` — the hook never retains the borrow.
+            // `transpile_source_code` call below; the hook never retains it.
             path: unsafe { lr.path.into_static() },
             loader: lr.loader.unwrap_or(if lr.is_main {
                 bun_ast::Loader::Js
@@ -4407,23 +4353,21 @@ impl VirtualMachine {
                 bun_ast::Loader::File
             }),
             module_type,
-            source_code_printer: printer.as_ptr(),
+            source_code_printer: &mut printer,
             // `fetchWithoutOnLoadPlugins` forbids the async path.
-            promise_ptr: core::ptr::null_mut(),
+            promise_slot: None,
         };
         let args = ModuleLoader::TranspileArgs {
             specifier: lr.specifier,
             referrer: referrer_clone.slice(),
             input_specifier: specifier,
-            log: std::ptr::from_mut::<bun_ast::Log>(log),
+            log,
             virtual_source: lr.virtual_source,
             global_object,
             flags,
-            extra: &raw mut extra,
+            extra: &mut extra,
         };
-        // SAFETY: `guard.0` is the live per-thread VM; `args.extra` points at
-        // the live `extra` above.
-        let result = unsafe { ModuleLoader::__bun_transpile_source_code(guard.0, &args) };
+        let result = ModuleLoader::__bun_transpile_source_code(guard.0, args);
         if result.is_err() && flags == FetchFlags::PrintSource {
             guard.1 = true; // errdefer
         }
@@ -5607,12 +5551,10 @@ impl VirtualMachine {
         // **Warning** this method can be called in the heap collector thread!!
         self.remap_stack_frames_mutex.lock();
 
-        self.source_mappings.lock();
-
         // Note: a last-`(hash → InternalSourceMap)` cache across the loop
         // would be purely a perf optimization (most stacks repeat the same
-        // source); do the straightforward per-frame resolve. See the PERF
-        // note below.
+        // source); do the straightforward per-frame resolve, each of which
+        // takes the `source_mappings` lock itself. See the PERF note below.
         // SAFETY: caller passes `frames_count` valid `ZigStackFrame`s.
         let frames = unsafe { bun_core::ffi::slice_mut(frames, frames_count) };
         for frame in frames {
@@ -5624,9 +5566,6 @@ impl VirtualMachine {
                 continue;
             }
             // PERF: could cache `(hash → ism)` across iterations.
-            // Slow path: drops and re-acquires the source_mappings lock around
-            // resolve_source_mapping().
-            self.source_mappings.unlock();
             let resolved = {
                 let source_url = frame.source_url.to_utf8();
                 self.resolve_source_mapping(
@@ -5655,10 +5594,8 @@ impl VirtualMachine {
             } else {
                 frame.remapped = true;
             }
-            self.source_mappings.lock();
         }
 
-        self.source_mappings.unlock();
         self.remap_stack_frames_mutex.unlock();
     }
 

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -344,6 +344,18 @@ impl VmHandle {
         })
     }
 
+    /// Ask the VM, from another thread, to poll its pending-module queue
+    /// ([`Task::poll_pending_modules`](bun_event_loop::Task::poll_pending_modules));
+    /// dropped if the VM is closed.
+    pub fn post_poll_pending_modules(&self, kind: LoopKind) {
+        let ct = ConcurrentTaskItem::create(bun_event_loop::Task::poll_pending_modules());
+        if let Posted::Refused(ct) = self.post(kind, ct) {
+            // SAFETY: refused ⇒ never queued; the carrier `create` boxed is
+            // ours again and this task's payload is null (owns nothing).
+            unsafe { ConcurrentTaskItem::release_refused(ct) };
+        }
+    }
+
     /// Queue a C++ `EventLoopTask` on the VM's `kind` loop from another
     /// thread (WebCore's `postTaskTo` / `postTaskConcurrently`), or delete it
     /// unrun if the VM is closed.

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -742,9 +742,10 @@ impl Drop for PinnedArrayBuffer {
     }
 }
 
-// SAFETY: a pin and GC protection on a heap cell; constructed on the JS thread,
-// and a rooted value is dropped there (a pin-only one may drop with its `Blob` store).
-unsafe impl crate::job::JsAffine for PinnedArrayBuffer {}
+// JS-thread state: a pin and GC protection on a heap cell; constructed on the JS
+// thread, and a rooted value is dropped there (a pin-only one may drop with its
+// `Blob` store).
+impl crate::job::JsAffine for PinnedArrayBuffer {}
 
 // ──────────────────────────────────────────────────────────────────────────
 // BinaryType

--- a/src/jsc/job.rs
+++ b/src/jsc/job.rs
@@ -19,7 +19,6 @@
 //! `WorkerRunLoop::postTask` with `ActiveDOMObject`-owned completions.
 
 use core::marker::PhantomData;
-use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 
 use bun_io::KeepAlive;
@@ -72,51 +71,33 @@ impl JSGlobalObject {
 /// anything built from them. In a job it lives on the [`Js`](JobContext::Js)
 /// side, which the carrier only touches there. Derive it
 /// (`#[derive(bun_jsc::JsAffine)]`) for aggregates; the derive checks every
-/// field.
+/// field, so what a completion holds is decided type by type here rather than
+/// as a leak-or-UAF question at teardown.
 ///
-/// # Safety
-/// Implement only for types whose every use and whose `Drop` are sound on the
-/// owning JS thread with the heap alive (and need not be sound elsewhere).
-pub unsafe trait JsAffine {}
+/// Not an `unsafe trait`: nothing relies on it for soundness (the carrier never
+/// moves the `Js` half off the JS thread whatever its type); it is the list of
+/// types vetted to sit on that side.
+pub trait JsAffine {}
 
-// SAFETY (each below): a GC/loop handle or plain data — used and dropped only
-// on the owning JS thread by construction of `Job`.
-// SAFETY: see the group note above.
-unsafe impl JsAffine for crate::Strong {}
-// SAFETY: see the group note above.
-unsafe impl JsAffine for crate::StrongOptional {}
-// SAFETY: see the group note above.
-unsafe impl JsAffine for crate::JSPromiseStrong {}
-// SAFETY: see the group note above.
-unsafe impl<T> JsAffine for crate::Weak<T> {}
-// SAFETY: see the group note above.
-unsafe impl JsAffine for crate::JsRef {}
-// SAFETY: see the group note above.
-unsafe impl JsAffine for crate::JSValue {}
-// SAFETY: see the group note above.
-unsafe impl JsAffine for crate::GlobalRef {}
-// SAFETY: see the group note above.
-unsafe impl JsAffine for bun_ptr::BackRef<JSGlobalObject> {}
-// SAFETY: see the group note above.
-unsafe impl JsAffine for KeepAlive {}
-// SAFETY: see the group note above.
-unsafe impl JsAffine for AsyncTaskTracker {}
-// SAFETY: see the group note above.
-unsafe impl JsAffine for () {}
-// SAFETY: see the group note above.
-unsafe impl JsAffine for bool {}
-// SAFETY: see the group note above.
-unsafe impl<T: JsAffine> JsAffine for Option<T> {}
-// SAFETY: see the group note above.
-unsafe impl<T: JsAffine> JsAffine for Box<T> {}
-// SAFETY: see the group note above.
-unsafe impl<A: JsAffine, B: JsAffine> JsAffine for (A, B) {}
-// SAFETY: see the group note above.
-unsafe impl<A: JsAffine, B: JsAffine, C: JsAffine> JsAffine for (A, B, C) {}
-// SAFETY: see the group note above.
-unsafe impl<T: ?Sized> JsAffine for JsPtr<T> {}
-// SAFETY: see the group note above.
-unsafe impl JsAffine for Protected {}
+impl JsAffine for crate::Strong {}
+impl JsAffine for crate::StrongOptional {}
+impl JsAffine for crate::JSPromiseStrong {}
+impl<T> JsAffine for crate::Weak<T> {}
+impl JsAffine for crate::JsRef {}
+impl JsAffine for crate::JSValue {}
+impl JsAffine for crate::GlobalRef {}
+impl JsAffine for bun_ptr::BackRef<JSGlobalObject> {}
+impl JsAffine for KeepAlive {}
+impl JsAffine for AsyncTaskTracker {}
+impl JsAffine for bun_core::String {}
+impl JsAffine for () {}
+impl JsAffine for bool {}
+impl<T: JsAffine> JsAffine for Option<T> {}
+impl<T: JsAffine> JsAffine for Box<T> {}
+impl<A: JsAffine, B: JsAffine> JsAffine for (A, B) {}
+impl<A: JsAffine, B: JsAffine, C: JsAffine> JsAffine for (A, B, C) {}
+impl<T: ?Sized> JsAffine for JsPtr<T> {}
+impl JsAffine for Protected {}
 
 /// A GC-protected value a job's completion needs (Node: a `Global<Value>` on
 /// the req_wrap). Unprotected on drop.
@@ -218,13 +199,27 @@ pub trait JobContext: Sized + 'static {
 /// linked into its VM's [`JobList`] while the job is live.
 #[repr(C)]
 pub struct JobHeader {
-    complete: unsafe fn(*mut JobHeader, &JsThread<'_>) -> JsResult<()>,
-    release_unrun: unsafe fn(*mut JobHeader),
+    /// Recovers the whole `Job<C>` as a trait object from a pointer to its
+    /// header (a raw-pointer cast and unsize — no dereference), for the
+    /// dispatcher's [`erased_from_raw`].
+    erase: fn(*mut JobHeader) -> *mut dyn ErasedJob,
     cancel: unsafe fn(*mut JobHeader),
     prev: *mut JobHeader,
     next: *mut JobHeader,
     /// `VirtualMachine::test_isolation_generation` when scheduled.
     generation: u32,
+}
+
+/// A [`Job<C>`] as the event loop sees it once posted back: something to
+/// complete (or release) on the JS thread, whatever its `C`.
+pub trait ErasedJob {
+    /// JS thread, VM still running script: run the completion and free the job.
+    fn complete(self: Box<Self>, cx: &JsThread<'_>) -> JsResult<()>;
+    /// JS thread, heap alive, the completion will never run (its VM is
+    /// stopping): free the job and both its halves.
+    fn release_unrun(self: Box<Self>);
+    /// `VirtualMachine::test_isolation_generation` when the job was scheduled.
+    fn generation(&self) -> u32;
 }
 
 /// A VM's live [cancellable](JobContext::CANCELLABLE) jobs (JS thread only;
@@ -290,15 +285,6 @@ pub struct Job<C: JobContext> {
     js: C::Js,
 }
 
-impl<C: JobContext> bun_event_loop::Taskable for Job<C> {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::AnyTaskJob;
-    /// Reached through the header (`release_unrun_erased`): the tag is shared.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract; JS thread with the heap alive.
-        drop(unsafe { Self::take(this, VirtualMachine::get()) })
-    }
-}
-
 impl<C: JobContext> Job<C> {
     /// JS thread: build the job, keep the loop alive for it, hand it to the pool.
     #[track_caller]
@@ -307,14 +293,9 @@ impl<C: JobContext> Job<C> {
         keep_alive.ref_(bun_io::js_vm_ctx());
         let job = bun_core::heap::into_raw(Box::new(Self {
             header: JobHeader {
-                // SAFETY: (this and the entry below) the erased dispatchers are
-                // only reached through this header, so `p` is this `Job<C>`.
-                complete: |p, cx| unsafe { Self::complete(p.cast::<Self>(), cx) },
-                // SAFETY: as above.
-                release_unrun: |p| unsafe {
-                    <Self as bun_event_loop::Taskable>::release_unrun(p.cast::<Self>())
-                },
-                // SAFETY: linked ⇒ live; see `JobContext::cancel`.
+                erase: |p| p.cast::<Self>() as *mut dyn ErasedJob,
+                // SAFETY: only reached through this header (linked ⇒ live), so
+                // `p` is this `Job<C>`; see `JobContext::cancel`.
                 cancel: |p| unsafe { C::cancel(&raw mut (*p.cast::<Self>()).off) },
                 prev: core::ptr::null_mut(),
                 next: core::ptr::null_mut(),
@@ -348,6 +329,7 @@ impl<C: JobContext> Job<C> {
         let done = Completion {
             job: NonNull::new(this).expect("job"),
             ticket,
+            obligation: Obligation,
         };
         if done.ticket().cancelled() {
             return done.finish();
@@ -357,36 +339,35 @@ impl<C: JobContext> Job<C> {
         }
     }
 
-    /// JS thread: reclaim a posted job and drop its keep-alive; the two halves
-    /// are the caller's to complete or drop.
-    ///
-    /// # Safety
-    /// `this` is the job its `Completion` posted; called once, on `vm`'s thread.
-    unsafe fn take(this: *mut Self, vm: &VirtualMachine) -> (C::OffThread, C::Js) {
+    /// JS thread: drop the job's keep-alive and VM registration and hand back
+    /// its two halves, freeing the box.
+    #[allow(clippy::boxed_local)] // the VM's job list links the boxed header's address
+    fn into_halves(mut self: Box<Self>, vm: &VirtualMachine) -> (C::OffThread, C::Js) {
         if C::CANCELLABLE {
-            // SAFETY: fn contract.
-            vm.jobs
-                .with_mut(|j| j.unlink(unsafe { &raw mut (*this).header }));
+            let header: *mut JobHeader = &raw mut self.header;
+            vm.jobs.with_mut(|j| j.unlink(header));
         }
-        // SAFETY: fn contract.
         let Job {
             mut keep_alive,
             off,
             js,
             ..
-        } = unsafe { *Box::from_raw(this) };
+        } = *self;
         keep_alive.unref(bun_io::js_vm_ctx());
         (off, js)
     }
+}
 
-    /// JS thread dispatch: run the completion and free the job.
-    ///
-    /// # Safety
-    /// As [`take`](Self::take).
-    unsafe fn complete(this: *mut Self, cx: &JsThread<'_>) -> JsResult<()> {
-        // SAFETY: fn contract.
-        let (off, js) = unsafe { Self::take(this, cx.vm()) };
+impl<C: JobContext> ErasedJob for Job<C> {
+    fn complete(self: Box<Self>, cx: &JsThread<'_>) -> JsResult<()> {
+        let (off, js) = self.into_halves(cx.vm());
         C::then(off, js, cx)
+    }
+    fn release_unrun(self: Box<Self>) {
+        drop(self.into_halves(VirtualMachine::get()));
+    }
+    fn generation(&self) -> u32 {
+        self.header.generation
     }
 }
 
@@ -398,6 +379,7 @@ impl<C: JobContext> Job<C> {
 pub struct Completion<C: JobContext> {
     job: NonNull<Job<C>>,
     ticket: Ticket,
+    obligation: Obligation,
 }
 // SAFETY: `finish` only posts the job through its (thread-safe) ticket.
 unsafe impl<C: JobContext> Send for Completion<C> {}
@@ -405,12 +387,17 @@ impl<C: JobContext> Completion<C> {
     /// Post the job back to its VM. The ticket outlives the post (the JS
     /// thread may free the job the moment it is queued) and is dropped here.
     pub fn finish(self) {
-        // Consumed: the obligation is met here, so its Drop check must not run.
-        let me = ManuallyDrop::new(self);
-        // SAFETY: moving the field out of a value that is never dropped.
-        let ticket = unsafe { core::ptr::read(&raw const me.ticket) };
-        ticket.post(bun_event_loop::ConcurrentTask::ConcurrentTask::create_from(
-            me.job.as_ptr(),
+        let Completion {
+            job,
+            ticket,
+            obligation,
+        } = self;
+        let _met = core::mem::ManuallyDrop::new(obligation);
+        ticket.post(bun_event_loop::ConcurrentTask::ConcurrentTask::create(
+            bun_event_loop::Task::new(
+                bun_event_loop::task_tag::AnyTaskJob,
+                job.as_ptr().cast::<()>(),
+            ),
         ));
     }
     /// The job's ticket: its VM is alive while this is held.
@@ -419,50 +406,30 @@ impl<C: JobContext> Completion<C> {
         &self.ticket
     }
 }
-impl<C: JobContext> Drop for Completion<C> {
+
+/// Dropped only if a [`Completion`] is dropped without being finished.
+struct Obligation;
+impl Drop for Obligation {
     fn drop(&mut self) {
         debug_assert!(false, "job dropped without being finished");
     }
 }
 
-/// Event-loop dispatch for every `Job<C>` (one tag): run its completion.
+/// Event-loop dispatch for the one `AnyTaskJob` tag: recover the posted job,
+/// to [`complete`](ErasedJob::complete) it or — if it will never run —
+/// [`release_unrun`](ErasedJob::release_unrun) it.
 ///
 /// # Safety
-/// `ptr` is a `Job<C>` posted by its `Completion` (for some `C`).
-pub unsafe fn complete_erased(ptr: *mut (), cx: &JsThread<'_>) -> JsResult<()> {
+/// `ptr` is a `Job<C>` (for some `C`) posted by its [`Completion`], and is not
+/// used afterwards.
+pub unsafe fn erased_from_raw(ptr: *mut ()) -> Box<dyn ErasedJob> {
     let header = ptr.cast::<JobHeader>();
-    // A completion dispatched after the VM was asked to stop (a parent's
-    // terminate() lands while the worker still ticks): its `then` would only
-    // build script-facing values under a pending termination. Release it as
-    // teardown would — Node's threadpool `after` callbacks bail the same way
-    // on `!can_call_into_js()`.
-    //
-    // Likewise one scheduled by a file `bun test --isolate` has since retired:
-    // the swap was that file's exit, and a `then` that calls back directly
-    // (node:crypto's callback forms) would run its script under the next file.
-    // SAFETY: `ptr` is a live posted `Job<C>`, header first (fn contract).
-    let stale = unsafe { (*header).generation } != cx.vm().test_isolation_generation;
-    if !cx.vm().script_allowed() || stale {
-        // SAFETY: as below; released exactly once, here.
-        unsafe { ((*header).release_unrun)(header) };
-        return Ok(());
-    }
-    // SAFETY: `Job<C>` is `#[repr(C)]` with the header first.
-    unsafe { ((*header).complete)(header, cx) }
+    // SAFETY: fn contract; `Job<C>` is `#[repr(C)]` with the header first, and
+    // `erase` only casts.
+    unsafe { Box::from_raw(((*header).erase)(header)) }
 }
 
-/// Teardown's release for a queued, never-dispatched `Job<C>` completion
-/// (JS thread, heap alive).
-///
-/// # Safety
-/// As [`complete_erased`].
-pub unsafe fn release_unrun_erased(ptr: *mut ()) {
-    let header = ptr.cast::<JobHeader>();
-    // SAFETY: as above.
-    unsafe { ((*header).release_unrun)(header) }
-}
-
-// The erased dispatchers above cast `*mut Job<C>` to `*mut JobHeader`.
+// The erased dispatch above casts `*mut Job<C>` to `*mut JobHeader`.
 const _: () = assert!(core::mem::offset_of!(Job<Never>, header) == 0);
 
 #[doc(hidden)]

--- a/src/jsc/job.rs
+++ b/src/jsc/job.rs
@@ -426,7 +426,7 @@ pub unsafe fn erased_from_raw(ptr: *mut ()) -> Box<dyn ErasedJob> {
     let header = ptr.cast::<JobHeader>();
     // SAFETY: fn contract; `Job<C>` is `#[repr(C)]` with the header first, and
     // `erase` only casts.
-    unsafe { Box::from_raw(((*header).erase)(header)) }
+    unsafe { bun_core::heap::take(((*header).erase)(header)) }
 }
 
 // The erased dispatch above casts `*mut Job<C>` to `*mut JobHeader`.

--- a/src/jsc_macros/lib.rs
+++ b/src/jsc_macros/lib.rs
@@ -1017,8 +1017,7 @@ pub fn derive_js_affine(input: TokenStream) -> TokenStream {
     // The field checks sit in an associated const on the type itself, so its
     // generic parameters are in scope and nothing is left unused.
     quote! {
-        // SAFETY: every field is `JsAffine` (checked below).
-        unsafe impl #impl_g ::bun_jsc::job::JsAffine for #name #ty_g #where_g {}
+        impl #impl_g ::bun_jsc::job::JsAffine for #name #ty_g #where_g {}
         #[doc(hidden)]
         impl #impl_g #name #ty_g #where_g {
             pub const __JS_AFFINE_FIELDS: () = {

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -726,7 +726,7 @@ pub fn read_file_contents<'buf>(
 /// Arena-backed twin of the `USE_SHARED_BUFFER = false` arm of
 /// [`read_file_with_handle_impl`]: the returned bytes live
 /// in `arena` so they are bulk-freed when the per-call `MimallocArena` is
-/// `mi_heap_destroy`'d (`TranspilerJob::run` / `ParseTask`), instead of
+/// `mi_heap_destroy`'d (`RuntimeTranspilerStore` jobs / `ParseTask`), instead of
 /// round-tripping through the worker thread's *default* mimalloc heap (which
 /// is never destroyed and retains the segment for the process lifetime).
 ///

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -636,7 +636,7 @@ impl Config {
 pub(crate) struct TransformTask {
     pub input_code: ThreadIsolated<StringOrBuffer<'static>>,
     pub output_code: BunString,
-    pub transpiler: core::mem::ManuallyDrop<Transpiler::Transpiler<'static>>,
+    pub transpiler: Transpiler::transpiler::JobTranspiler,
     pub log: bun_ast::Log,
     pub err: Option<Error>,
     pub macro_map: MacroMap,
@@ -682,11 +682,11 @@ impl TransformTask {
         let mut log = bun_ast::Log::init();
         log.level = config.log.level;
 
-        // SAFETY: `ManuallyDrop` keeps this bitwise copy from freeing what the
-        // wrapper owns; `run` re-aims its log and arena pointers.
-        let transpiler_copy = core::mem::ManuallyDrop::new(unsafe {
-            core::ptr::read(transpiler.transpiler.as_ptr())
-        });
+        // SAFETY: the wrapper (kept alive by `TransformJs::_transpiler`) owns
+        // what the copy aliases and does not reconfigure it while a transform
+        // runs; `run` re-aims the copy's log and arena.
+        let transpiler_copy =
+            unsafe { Transpiler::transpiler::JobTranspiler::new(transpiler.transpiler.get()) };
 
         let task = TransformTask {
             input_code,
@@ -726,48 +726,36 @@ impl TransformTask {
             self.tsconfig.map(|p| &*unsafe { p.under_ticket(vm) });
 
         let arena = Arena::new();
+        self.run_in(&arena, name, tsconfig);
+        // The macro context a parse lazily creates tears down through this
+        // thread's per-thread state, so release it here rather than wherever
+        // the job is dropped.
+        self.transpiler.release_macro_context();
+    }
 
-        // `self.transpiler` is a `ManuallyDrop` bytewise copy of the
-        // `JSTranspiler`'s long-lived transpiler (`ptr::read` in `create()`),
-        // so its `macro_context` may alias a box the `JSTranspiler` still owns
-        // — and that box's `resolver`/`remap` raw pointers point at the
-        // *original* transpiler, not this copy. Null it so `parse()` lazily
-        // creates a fresh one whose self-refs target this copy, then reclaim
-        // the fresh box on every return path (mirrors `RuntimeTranspilerStore`).
-        self.transpiler.macro_context = None;
-        let _macro_ctx_guard = scopeguard::guard(
-            core::ptr::addr_of_mut!(self.transpiler.macro_context),
-            |slot| {
-                // SAFETY: `slot` points into the heap-stable `TransformTask`
-                // box; only this thread holds `&mut self`, and the parser's
-                // `&mut MacroContext` borrow ended with `parse()`.
-                if let Some(ctx) = unsafe { (*slot).take() } {
-                    ctx.deinit();
-                }
-            },
-        );
-
-        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
+    fn run_in<'a>(
+        &'a mut self,
+        arena: &'a Arena,
+        name: &'static str,
+        tsconfig: Option<&TSConfigJSON>,
+    ) {
+        let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(arena);
         let _ast_scope = ast_memory_allocator.enter();
 
-        // SAFETY: `arena` outlives every use through `self.transpiler` in this fn body;
-        // Transpiler<'static> forces the borrow to 'static, so launder through a raw ptr.
-        let arena_ref: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref(&arena) };
-        let source: &bun_ast::Source = arena_ref.alloc(bun_ast::Source::init_path_string(
+        let source: &bun_ast::Source = arena.alloc(bun_ast::Source::init_path_string(
             name,
             self.input_code.slice(),
         ));
-        self.transpiler.set_arena(arena_ref);
-        self.transpiler.set_log(&raw mut self.log);
+        let mut transpiler = self.transpiler.for_call(arena, &mut self.log);
         // self.log.msgs.allocator = bun.default_allocator → no-op
 
         let jsx = match tsconfig {
-            Some(ts) => ts.merge_jsx(self.transpiler.options.jsx.clone()),
-            None => self.transpiler.options.jsx.clone(),
+            Some(ts) => ts.merge_jsx(transpiler.options.jsx.clone()),
+            None => transpiler.options.jsx.clone(),
         };
 
         let parse_options = ParseOptions {
-            arena: arena_ref,
+            arena,
             macro_remappings: clone_macro_map(&self.macro_map),
             dirname_fd: bun_sys::Fd::INVALID,
             file_descriptor: None,
@@ -794,7 +782,7 @@ impl TransformTask {
             allow_bytecode_cache: false,
         };
 
-        let Some(parse_result) = self.transpiler.parse(parse_options, None) else {
+        let Some(parse_result) = transpiler.parse(parse_options, None) else {
             self.err = Some(crate::Error::ParseError);
             return;
         };
@@ -812,9 +800,9 @@ impl TransformTask {
         buffer_writer.reset();
 
         let mut printer = JSPrinter::BufferPrinter::init(buffer_writer);
-        // Same per-call `arena` that `set_arena(&arena)` and `parse()` used.
-        let printed = match self.transpiler.print(
-            &arena,
+        // Same per-call `arena` that `for_call` and `parse()` used.
+        let printed = match transpiler.print(
+            arena,
             parse_result,
             &mut printer,
             Transpiler::transpiler::PrintFormat::EsmAscii,

--- a/src/runtime/api/glob.rs
+++ b/src/runtime/api/glob.rs
@@ -367,8 +367,8 @@ unsafe impl Send for WalkTask {}
 /// While a scan is pending the `Glob` wrapper reports `hasPendingActivity`
 /// (so it is not collected); released on the JS thread with the completion.
 pub(crate) struct PendingScan(JsPtr<AtomicUsize>);
-// SAFETY: a counter inside the Glob's native part, which its wrapper owns.
-unsafe impl bun_jsc::job::JsAffine for PendingScan {}
+// JS-thread state: a counter inside the Glob's native part, which its wrapper owns.
+impl bun_jsc::job::JsAffine for PendingScan {}
 impl PendingScan {
     fn new(counter: &AtomicUsize) -> Self {
         let _ = counter.fetch_add(1, Ordering::SeqCst);

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -99,7 +99,6 @@ use bun_spawn::static_pipe_writer::Poll as StaticPipeWriterPoll;
 use crate::napi::{NapiFinalizerTask, ThreadSafeFunction, napi_async_work};
 
 use bun_jsc::PosixSignalTask;
-use bun_jsc::RuntimeTranspilerStore;
 use bun_jsc::cpp_task::CppTask;
 use bun_jsc::hot_reloader;
 use bun_jsc::jsc_scheduler::JSCDeferredWorkTask;
@@ -170,7 +169,6 @@ pub(crate) enum RunTaskResult {
 #[inline(never)]
 pub(crate) fn run_task(
     task: Task,
-    el: &mut EventLoop,
     vm: &mut VirtualMachine,
     global: &JSGlobalObject,
 ) -> JsResult<RunTaskResult> {
@@ -205,8 +203,23 @@ pub(crate) fn run_task(
         // ── erased-callback tasks (low-tier types — real) ────────────────
         task_tag::AnyTaskJob => {
             // SAFETY: §Dispatch — `task.ptr` is a live heap `Job<C>` posted by
-            // its `Completion`; the erased entry runs `then` and frees it.
-            unsafe { bun_jsc::job::complete_erased(task.ptr, &global.js_thread()) }?;
+            // its `Completion`; the arm consumes it.
+            let job = unsafe { bun_jsc::job::erased_from_raw(task.ptr) };
+            // A completion dispatched after the VM was asked to stop (a parent's
+            // terminate() lands while the worker still ticks): its `then` would
+            // only build script-facing values under a pending termination.
+            // Release it as teardown would — Node's threadpool `after` callbacks
+            // bail the same way on `!can_call_into_js()`.
+            //
+            // Likewise one scheduled by a file `bun test --isolate` has since
+            // retired: the swap was that file's exit, and a `then` that calls
+            // back directly (node:crypto's callback forms) would run its script
+            // under the next file.
+            if !vm.script_allowed() || job.generation() != vm.test_isolation_generation {
+                job.release_unrun();
+            } else {
+                job.complete(&global.js_thread())?;
+            }
         }
         task_tag::SendQueueDeferred => {
             // SAFETY: §Dispatch — the queued pointer is the SendQueue root and
@@ -369,12 +382,9 @@ pub(crate) fn run_task(
             bun_jsc::mark_binding();
             cast!(JSCDeferredWorkTask).run(global)?;
         }
+        // `Task::poll_pending_modules()`: null payload — the tag is the message.
         task_tag::PollPendingModulesTask => {
             vm.modules.on_poll();
-        }
-        task_tag::RuntimeTranspilerStore => {
-            let store = cast!(RuntimeTranspilerStore);
-            store.run_from_js_thread(el.into(), global, vm.into());
         }
 
         // ── hot-reload (early-returns from the drain loop) ───────────────
@@ -589,7 +599,7 @@ fn run_task_cold(task: Task) {
 /// `release_task_unrun` track `bun_event_loop::task_tag::COUNT`. Bump when
 /// adding a variant — and give it an arm in both.
 const _: () = assert!(
-    task_tag::COUNT == 61,
+    task_tag::COUNT == 60,
     "dispatch::run_task / release_task_unrun arm count out of sync with bun_event_loop::task_tag",
 );
 
@@ -611,7 +621,7 @@ pub(crate) fn tick_queue_with_count(
         // Incremented before dispatch so the count includes every task,
         // including the one that takes the HotReloadTask early return.
         *counter += 1;
-        match run_task(task, el, vm, global) {
+        match run_task(task, vm, global) {
             Ok(RunTaskResult::Continue) => {}
             Ok(RunTaskResult::EarlyReturn) => {
                 // Caller is `while tickWithCount(ctx) > 0` — must keep
@@ -1223,7 +1233,7 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
         task_tag::AnyTaskJob => {
             // The one erased tag: every payload is a `Job<C>` reached through its header.
             // SAFETY: as `release!`.
-            unsafe { bun_jsc::job::release_unrun_erased(task.ptr) }
+            unsafe { bun_jsc::job::erased_from_raw(task.ptr) }.release_unrun()
         }
         task_tag::AsyncModule => release!(bun_jsc::async_module::AsyncModule),
         task_tag::BakeHotReloadEvent => release!(BakeHotReloadEvent),
@@ -1256,7 +1266,8 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
         task_tag::NativeBrotli => release!(NativeBrotli),
         task_tag::NativeZlib => release!(NativeZlib),
         task_tag::NativeZstd => release!(NativeZstd),
-        task_tag::PollPendingModulesTask => release!(bun_jsc::async_module::Queue),
+        // `Task::poll_pending_modules()`: null payload, owns nothing.
+        task_tag::PollPendingModulesTask => {}
         task_tag::PosixSignalTask => release!(PosixSignalTask),
         task_tag::MemoryPressureTask => release!(crate::node::memory_pressure::MemoryPressureTask),
         task_tag::ProcessWaiterThreadTask => {
@@ -1266,7 +1277,6 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
             unreachable!("posix-only tag");
         }
         task_tag::FlushPendingFileSinkTask => release!(FlushPendingFileSinkTask),
-        task_tag::RuntimeTranspilerStore => release!(RuntimeTranspilerStore),
         task_tag::S3HttpDownloadStreamingTask => release!(S3HttpDownloadStreamingTask),
         task_tag::S3HttpSimpleTask => release!(S3HttpSimpleTask),
         task_tag::SendQueueDeferred => release!(crate::ipc::SendQueue),

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -936,9 +936,9 @@ pub mod get_addr_info_request {
     /// nothing is settled.
     #[cfg(not(windows))]
     pub struct LibcRequest(pub(crate) NonNull<super::GetAddrInfoRequest>);
-    // SAFETY: only the JS thread touches the request (see type doc).
+    // JS-thread state: only the JS thread touches the request (see type doc).
     #[cfg(not(windows))]
-    unsafe impl bun_jsc::job::JsAffine for LibcRequest {}
+    impl bun_jsc::job::JsAffine for LibcRequest {}
     #[cfg(not(windows))]
     impl Drop for LibcRequest {
         fn drop(&mut self) {

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1390,8 +1390,8 @@ pub struct PipelineJs {
 /// An ArrayBuffer pinned by `JSC__JSValue__borrowBytesForOffThread` (mode 2)
 /// so user code cannot transfer/detach it while the pool reads; unpinned on drop.
 pub struct Pin(JSValue);
-// SAFETY: a pin on a heap cell; gone with the heap.
-unsafe impl bun_jsc::job::JsAffine for Pin {}
+// JS-thread state: a pin on a heap cell; gone with the heap.
+impl bun_jsc::job::JsAffine for Pin {}
 impl Pin {
     const NONE: Pin = Pin(JSValue::ZERO);
 }
@@ -1407,8 +1407,8 @@ impl Drop for Pin {
 /// One pending operation's hold on its `Image`: keeps the wrapper Strong while
 /// any are pending, and lets the completion reach the `Image` (JS thread).
 pub struct PendingTask(jsc::JsPtr<Image>);
-// SAFETY: the Image is its wrapper's m_ctx; the Strong we hold keeps that alive.
-unsafe impl bun_jsc::job::JsAffine for PendingTask {}
+// JS-thread state: the Image is its wrapper's m_ctx; the Strong we hold keeps that alive.
+impl bun_jsc::job::JsAffine for PendingTask {}
 impl PendingTask {
     fn new(image: &Image, this_value: JSValue, global: &JSGlobalObject) -> Self {
         if image.pending_tasks.get() == 0 {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -482,30 +482,32 @@ unsafe fn init_runtime_state(
                     let wake_ctx: *mut bun_jsc::async_module::WakeContext = &raw mut **(*state)
                         .wake_ctx
                         .insert(Box::new(bun_jsc::async_module::WakeContext {
-                            queue: &raw mut (*vm).modules,
                             handle: (*vm).handle(),
                             kind: (*vm).current_loop_kind(),
                         }));
                     t.resolver.on_wake_package_manager = bun_resolver::install_types::WakeHandler {
                         context: core::ptr::NonNull::new(wake_ctx.cast()),
-                        handler: Some(bun_jsc::async_module::Queue::on_wake_handler),
+                        handler: Some({
+                            fn adapter(ctx: *mut core::ffi::c_void, _pm: *mut core::ffi::c_void) {
+                                // SAFETY: `ctx` is the `WakeContext` boxed just above, which
+                                // lives as long as this VM's `RuntimeState`.
+                                unsafe { &*ctx.cast::<bun_jsc::async_module::WakeContext>() }.wake()
+                            }
+                            adapter
+                        }),
                         on_dependency_error: Some({
-                            unsafe fn adapter(
-                                ctx: *mut core::ffi::c_void,
+                            fn adapter(
+                                _ctx: *mut core::ffi::c_void,
                                 dep: &bun_resolver::install_types::Dependency,
                                 id: bun_resolver::install_types::DependencyID,
                                 err: &'static str,
                             ) {
-                                // SAFETY: `ctx` is the `WakeContext` set just above; its queue is `(*vm).modules`.
-                                unsafe {
-                                    bun_jsc::async_module::Queue::on_dependency_error(
-                                        bun_jsc::async_module::Queue::queue_from_wake_context(ctx)
-                                            .cast(),
-                                        dep,
-                                        id,
-                                        err,
-                                    )
-                                }
+                                // The package manager runs this from the tasks the
+                                // JS thread's module queue drives.
+                                VirtualMachine::get()
+                                    .as_mut()
+                                    .modules
+                                    .on_dependency_error(dep, id, err)
                             }
                             adapter
                         }),
@@ -2184,13 +2186,10 @@ fn note_compile_cache_parse_failure(
 /// read file → `Transpiler::parse`
 /// → `js_printer::print` → `ResolvedSource`.
 ///
-/// # Safety
-/// `jsc_vm` is the live per-thread VM; `args.extra` points at a live
-/// [`TranspileExtra`].
 #[unsafe(no_mangle)]
-unsafe fn __bun_transpile_source_code(
-    jsc_vm: *mut VirtualMachine,
-    args: &TranspileArgs<'_>,
+fn __bun_transpile_source_code(
+    jsc_vm: &mut VirtualMachine,
+    args: TranspileArgs<'_, '_>,
 ) -> Result<ResolvedSource, bun_jsc::CrateError> {
     transpile_source_code_inner(jsc_vm, args).map_err(|e| to_jsc_fetch_error(&e))
 }
@@ -2204,24 +2203,26 @@ unsafe fn __bun_transpile_source_code(
 /// the raw ptr, mirroring `auto_tick` above.
 fn transpile_source_code_inner(
     jsc_vm: *mut VirtualMachine,
-    args: &TranspileArgs<'_>,
+    args: TranspileArgs<'_, '_>,
 ) -> crate::Result<ResolvedSource> {
     use Loader as L;
-    let extra = args.extra;
+    let TranspileArgs {
+        specifier,
+        referrer,
+        input_specifier,
+        log: args_log,
+        virtual_source: args_virtual_source,
+        global_object,
+        flags,
+        extra,
+    } = args;
+    // Copied out: the recursive `.wasm` arm rewrites `extra.loader` /
+    // `extra.module_type` before re-entering.
+    let path_of_extra: Fs::Path<'static> = extra.path;
+    let path: &Fs::Path = &path_of_extra;
+    let (loader, module_type): (Loader, ModuleType) = (extra.loader, extra.module_type);
 
-    // SAFETY: per fn contract — `extra` is a live `TranspileExtra` for the call.
-    // Note: raw-ptr (not `&mut`) so the recursive `.wasm` arm can mutate
-    // `extra.loader` and re-enter without borrowck seeing aliased `&mut`.
-    let path: &Fs::Path = unsafe { &(*extra).path };
-    // SAFETY: per fn contract — `extra` is live for the call (see above).
-    let (loader, module_type): (Loader, ModuleType) =
-        unsafe { ((*extra).loader, (*extra).module_type) };
-
-    let disable_transpilying = args.flags.disable_transpiling();
-    let specifier = args.specifier;
-    let referrer = args.referrer;
-    let input_specifier = &args.input_specifier;
-    let global_object = args.global_object;
+    let disable_transpilying = flags.disable_transpiling();
 
     // ── disable_transpiling fast-path for non-JS-like loaders ───────────────
     if disable_transpilying
@@ -2286,7 +2287,7 @@ fn transpile_source_code_inner(
             let give_back_arena = true;
             // Note: a scopeguard so `?`-early-returns still run the cleanup.
             let mut arena_guard = scopeguard::guard(
-                (jsc_vm, arena, give_back_arena, args.flags),
+                (jsc_vm, arena, give_back_arena, flags),
                 |(jsc_vm, mut arena, give_back, flags)| {
                     // SAFETY: `jsc_vm` is the live per-thread VM (closure runs
                     // on the same thread, before the hook returns).
@@ -2405,15 +2406,16 @@ fn transpile_source_code_inner(
             // `Transpiler::init_in_place` / by the C++ caller respectively).
             let old_log = unsafe { &*jsc_vm }.transpiler.log;
             let old_log_nn = core::ptr::NonNull::new(old_log).expect("transpiler.log is non-null");
-            let args_log_nn = core::ptr::NonNull::new(args.log).expect("args.log is non-null");
+            let args_log_nn = core::ptr::NonNull::from(&mut *args_log);
+            let args_log_ptr: *mut bun_ast::Log = args_log_nn.as_ptr();
             // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM;
-            // `args.log` is non-null (checked above) and outlives this call.
+            // `args_log` outlives this call.
             unsafe {
-                (*jsc_vm).transpiler.log = args.log;
+                (*jsc_vm).transpiler.log = args_log_ptr;
                 (*jsc_vm).transpiler.resolver.log = args_log_nn;
-                (*jsc_vm).transpiler.linker.log = args.log;
+                (*jsc_vm).transpiler.linker.log = args_log_ptr;
                 if let Some(pm) = (*jsc_vm).transpiler.resolver.package_manager {
-                    (*pm.cast::<bun_install::PackageManager>().as_ptr()).log = args.log;
+                    (*pm.cast::<bun_install::PackageManager>().as_ptr()).log = args_log_ptr;
                 }
             }
             let _log_guard = scopeguard::guard(jsc_vm, move |jsc_vm| {
@@ -2509,7 +2511,7 @@ fn transpile_source_code_inner(
 
             // ── Node-fallback virtual source ────────────────────────────────
             let fallback_source: bun_ast::Source;
-            let mut virtual_source = args.virtual_source;
+            let mut virtual_source = args_virtual_source;
             if is_node_override {
                 if let Some(code) = node_fallbacks::contents_from_path(specifier) {
                     {
@@ -2586,33 +2588,7 @@ fn transpile_source_code_inner(
                         is_symlink: path.is_symlink,
                     }
                 } else {
-                    // Note: route through `intern_transpile_path` (dedup)
-                    // instead of `FilenameStore::append_slice` directly — see
-                    // that fn's doc for the leak this closes
-                    // (require-cache.test.ts "don't leak file paths").
-                    let text: &'static [u8] = intern_transpile_path(path.text);
-                    let pretty: &'static [u8] =
-                        if core::ptr::eq(path.pretty.as_ptr(), path.text.as_ptr())
-                            && path.pretty.len() == path.text.len()
-                        {
-                            text
-                        } else {
-                            intern_transpile_path(path.pretty)
-                        };
-                    // `Fs::Path::init` always sets namespace to the `b"file"`
-                    // literal; only intern if a caller overrode it.
-                    let namespace: &'static [u8] = if path.namespace == b"file" {
-                        b"file"
-                    } else {
-                        intern_transpile_path(path.namespace)
-                    };
-                    bun_paths::fs::Path {
-                        pretty,
-                        text,
-                        namespace,
-                        is_disabled: path.is_disabled,
-                        is_symlink: path.is_symlink,
-                    }
+                    intern_path(path)
                 };
                 let parse_options = ParseOptions {
                     // SAFETY: `arena_ptr` points at the `Box<Arena>` interior
@@ -2714,24 +2690,20 @@ fn transpile_source_code_inner(
                 // `.wasm` discovered post-parse: recurse with
                 // the parsed source as virtual.
                 if parse_result.loader == L::Wasm {
-                    // SAFETY: per fn contract — `extra` is live for the call;
-                    // sole writer on this thread before the recursive re-entry.
-                    unsafe {
-                        (*extra).loader = L::Wasm;
-                        (*extra).module_type = ModuleType::Unknown;
-                    }
+                    extra.loader = L::Wasm;
+                    extra.module_type = ModuleType::Unknown;
                     // Re-enter with `&parse_result.source` as `virtual_source`.
                     return transpile_source_code_inner(
                         jsc_vm,
-                        &TranspileArgs {
-                            specifier: args.specifier,
-                            referrer: args.referrer,
-                            input_specifier: args.input_specifier,
-                            log: args.log,
+                        TranspileArgs {
+                            specifier,
+                            referrer,
+                            input_specifier,
+                            log: &mut *args_log,
                             virtual_source: Some(&parse_result.source),
-                            global_object: args.global_object,
-                            flags: args.flags,
-                            extra: args.extra,
+                            global_object,
+                            flags,
+                            extra: &mut *extra,
                         },
                     );
                 }
@@ -2782,7 +2754,7 @@ fn transpile_source_code_inner(
 
                 // disable_transpiling: return raw source.
                 if disable_transpilying {
-                    let source_code = match args.flags {
+                    let source_code = match flags {
                         FetchFlags::PrintSource => {
                             // The file contents live in a Drop-carrying
                             // `source_contents_backing` on `parse_result`, so a
@@ -2881,23 +2853,12 @@ fn transpile_source_code_inner(
                 }
 
                 // RuntimeTranspilerCache hit: skip print.
-                // `cache.entry` is `Option<*mut ()>` (type-erased in T2
-                // `bun_js_parser`); the concrete payload is the T6
-                // `bun_jsc::runtime_transpiler_cache::Entry` boxed by
-                // `JSC_PARSER_CACHE_VTABLE.get`.
-                if let Some(entry_ptr) = cache.entry.take() {
-                    use bun_jsc::runtime_transpiler_cache::{
-                        Entry as CacheEntry, ModuleType as CacheModuleType,
-                    };
-                    // SAFETY: `entry_ptr` was produced by `heap::into_raw(Box<CacheEntry>)`
-                    // in `JSC_PARSER_CACHE_VTABLE.get`; sole owner.
-                    let mut entry: Box<CacheEntry> =
-                        unsafe { bun_core::heap::take(entry_ptr.cast::<CacheEntry>()) };
+                if let Some(mut entry) = bun_jsc::runtime_transpiler_cache::take_entry(&mut cache) {
+                    use bun_jsc::runtime_transpiler_cache::ModuleType as CacheModuleType;
                     // Register the cached sourcemap so error
                     // stacks remap to original positions even on a cache hit.
-                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread
-                    // VM; `source_mappings` is only touched from the JS thread.
-                    let _ = unsafe { &mut (*jsc_vm).source_mappings }.put_mappings(
+                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                    let _ = unsafe { &(*jsc_vm).source_mappings }.put_mappings(
                         source,
                         bun_core::MutableString {
                             list: core::mem::take(&mut entry.sourcemap).into_vec(),
@@ -3010,11 +2971,9 @@ fn transpile_source_code_inner(
 
                 // Pending imports → AsyncModule queue.
                 if parse_result.pending_imports.len() > 0 {
-                    // SAFETY: per fn contract — `extra` is live for the call.
-                    let promise_ptr = unsafe { &*extra }.promise_ptr;
-                    if promise_ptr.is_null() {
+                    let Some(promise_slot) = extra.promise_slot else {
                         return Err(crate::Error::UnexpectedPendingResolution);
-                    }
+                    };
 
                     if parse_result.source.contents_is_recycled {
                         // this shared buffer is about to become owned by the AsyncModule struct
@@ -3039,7 +2998,7 @@ fn transpile_source_code_inner(
                             bun_jsc::async_module::InitOpts {
                                 parse_result,
                                 path: *path,
-                                promise_ptr: Some(promise_ptr),
+                                promise_slot,
                                 specifier,
                                 referrer,
                                 arena,
@@ -3083,46 +3042,23 @@ fn transpile_source_code_inner(
                 > = module_info.as_deref_mut().map(core::ptr::from_mut);
 
                 // ── js_printer::print ───────────────────────────────────────
-                // SAFETY: `extra.source_code_printer` is non-null per `TranspileExtra`
-                // contract.
-                // Note: do NOT bind a long-lived `&mut BufferPrinter`
-                // here — the `source_map_handler` / `print_with_source_map`
-                // calls below each rederive `&mut *(*extra).source_code_printer`
-                // from the raw pointer, which would invalidate any earlier
-                // Unique tag under Stacked Borrows. Rederive at each use-site
-                // instead (reset, mapper, print, get_written).
-                unsafe { (*(*extra).source_code_printer).ctx.reset() };
+                let printer: &mut bun_js_printer::BufferPrinter = &mut *extra.source_code_printer;
+                printer.ctx.reset();
                 // Install the VM's sourcemap handler on the printer, then
                 // print the parse result (ESM, ASCII) with sourcemaps.
                 //
-                // Note (borrowck): `source_map_handler` borrows the VM for
-                // the getter's lifetime, but the print call also needs
-                // `&mut vm.transpiler` and `&mut printer`. Per the raw-ptr
+                // Note (borrowck): `source_map_handler` borrows the VM's
+                // `source_mappings` for the getter's lifetime, but the print
+                // call also needs `&mut vm.transpiler`. Per the raw-ptr
                 // aliasing convention at the top of this fn (see fn-level PORT
-                // NOTE), rederive from `jsc_vm`/`extra` raw ptrs at each
-                // use-site so borrowck sees disjoint temporaries; the getter
-                // itself only stashes raw pointers (VirtualMachine.rs
-                // `SourceMapHandlerGetter`).
-                //
-                // Note (Stacked Borrows): the printer is passed to the
-                // getter as the RAW `*mut BufferPrinter` (`source_map_handler`
-                // takes `*mut`, not `&mut`). When a debugger is attached
-                // (`mode != Connect`), `SourceMapHandlerGetter::
-                // on_source_map_chunk` reborrows `&mut *self.printer` from that
-                // raw pointer to append the inline-sourcemap trailer; doing so
-                // through a stashed `&'a mut` would alias the
-                // `writer: &mut BufferPrinter` live inside `print_ast`. After
-                // this block returns, the `printer` binding is rederived from
-                // the raw pointer below — any earlier Unique tag is dead.
+                // NOTE), rederive from `jsc_vm` at each use-site so borrowck
+                // sees disjoint temporaries.
                 {
-                    // SAFETY: `jsc_vm` / `(*extra).source_code_printer` are live
-                    // for the call (fn contract); `mapper` does not escape this
-                    // scope, so the unbounded `'a` from the raw-deref reborrow
-                    // is bounded by the block.
-                    let mut mapper =
-                        unsafe { (*jsc_vm).source_map_handler((*extra).source_code_printer) };
-                    // SAFETY: per fn contract — `jsc_vm` / `extra.source_code_printer`
-                    // are live; the printer borrow is scoped to this call.
+                    // SAFETY: `jsc_vm` is live for the call (fn contract);
+                    // `mapper` borrows only `source_mappings`, which the print
+                    // below does not touch through `transpiler`.
+                    let mut mapper = unsafe { (*jsc_vm).source_map_handler() };
+                    // SAFETY: per fn contract — `jsc_vm` is live.
                     let print_result = unsafe {
                         (*jsc_vm).transpiler.print_with_source_map(
                             // Same per-call arena that `parse_options.arena`
@@ -3131,12 +3067,18 @@ fn transpile_source_code_inner(
                             // the per-VM `transpiler_arena`.
                             &arena_guard.1,
                             parse_result,
-                            &mut *(*extra).source_code_printer,
+                            printer,
                             bun_js_printer::Format::EsmAscii,
                             mapper.get(),
                             module_info_ptr,
                         )
                     };
+                    let print_result = print_result.and_then(|n| {
+                        mapper
+                            .write_inline_trailer(printer)
+                            .map(|()| n)
+                            .map_err(bun_bundler::Error::from)
+                    });
                     // The printer never took ownership of `module_info`;
                     // drop it here mirroring the async-path error arm.
                     if print_result.is_err() {
@@ -3155,11 +3097,6 @@ fn transpile_source_code_inner(
                 // Watcher path uses ref-counted source.
                 // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
                 if unsafe { &*jsc_vm }.is_watcher_enabled() {
-                    // SAFETY: `extra.source_code_printer` is non-null per
-                    // `TranspileExtra` contract; rederive after the print block
-                    // (Stacked Borrows — see the matching note below).
-                    let printer: &mut bun_js_printer::BufferPrinter =
-                        unsafe { &mut *(*extra).source_code_printer };
                     let written = printer.ctx.get_written();
                     let node_compile_cache_blob = if bun_jsc::node_compile_cache::is_enabled()
                         && path.is_file()
@@ -3232,15 +3169,6 @@ fn transpile_source_code_inner(
                     _ => ResolvedSourceTag::Javascript,
                 };
 
-                // SAFETY: `extra.source_code_printer` is non-null per
-                // `TranspileExtra` contract. Rederive from the raw pointer
-                // AFTER the print block — both the `writer: &mut BufferPrinter`
-                // passed into `print_with_source_map` and the
-                // `on_source_map_chunk` reborrow inside it invalidated any
-                // earlier Unique tag under Stacked Borrows, so reading through
-                // a pre-print binding here would be UB.
-                let printer: &mut bun_js_printer::BufferPrinter =
-                    unsafe { &mut *(*extra).source_code_printer };
                 let written = printer.ctx.get_written();
                 // Node compile cache hook (sync transpile path). `fetch` copies
                 // `written`; the printer may be replaced below.
@@ -3304,7 +3232,7 @@ fn transpile_source_code_inner(
                 // Stash the WASM bytes on
                 // `globalThis.wasmSourceBytes` so the wasi runner avoids
                 // reading the file twice.
-                if let Some(source) = args.virtual_source {
+                if let Some(source) = args_virtual_source {
                     // Spec — `DecodedJSValue{ .ptr = globalThis }.encode()`:
                     // a JSGlobalObject is a JSCell, so its pointer encodes
                     // directly as a JSValue.
@@ -3334,12 +3262,21 @@ fn transpile_source_code_inner(
                 }
             }
             // Recurse as `.file`.
-            // SAFETY: per fn contract — `extra` is live for the call.
-            unsafe {
-                (*extra).loader = L::File;
-                (*extra).module_type = ModuleType::Unknown;
-            }
-            transpile_source_code_inner(jsc_vm, args)
+            extra.loader = L::File;
+            extra.module_type = ModuleType::Unknown;
+            transpile_source_code_inner(
+                jsc_vm,
+                TranspileArgs {
+                    specifier,
+                    referrer,
+                    input_specifier,
+                    log: args_log,
+                    virtual_source: args_virtual_source,
+                    global_object,
+                    flags,
+                    extra,
+                },
+            )
         }
 
         // ────────────────────────────────────────────────────────────────────
@@ -3399,7 +3336,7 @@ fn transpile_source_code_inner(
 
             // auto-watch for non-virtual absolute paths.
             'auto_watch: {
-                if args.virtual_source.is_some() {
+                if args_virtual_source.is_some() {
                     break 'auto_watch;
                 }
                 // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
@@ -4092,11 +4029,12 @@ thread_local! {
     static TRANSPILE_PRINTER: Cell<*mut bun_js_printer::BufferPrinter> =
         const { Cell::new(ptr::null_mut()) };
 
-    /// Dedup cache for [`intern_transpile_path`] — see that fn's Note.
-    /// `&'static [u8]` keys point into the `FilenameStore` BSS singleton, so
-    /// the set itself owns nothing beyond its bucket array.
+    /// Dedup cache for [`intern_transpile_path`] — see that fn's Note. Keyed
+    /// by the content hash so a lookup-or-insert hashes the path once; the
+    /// `&'static [u8]` values point into the `FilenameStore` BSS singleton, so
+    /// the map itself owns nothing beyond its bucket array.
     static TRANSPILE_PATH_INTERN: core::cell::RefCell<
-        bun_collections::HashMap<&'static [u8], ()>,
+        bun_collections::HashMap<u64, &'static [u8], bun_collections::IdentityContext<u64>>,
     > = core::cell::RefCell::new(bun_collections::HashMap::new());
 }
 
@@ -4138,15 +4076,48 @@ fn intern_transpile_path(value: &[u8]) -> &'static [u8] {
         return unsafe { core::slice::from_raw_parts(value.as_ptr(), value.len()) };
     }
     TRANSPILE_PATH_INTERN.with(|cell| {
-        let mut set = cell.borrow_mut();
-        if let Some((interned, ())) = set.get_key_value(value) {
-            return *interned;
+        let mut map = cell.borrow_mut();
+        let slot = bun_core::handle_oom(map.get_or_put(bun_wyhash::hash(value)));
+        if slot.found_existing && *slot.value_ptr == value {
+            return *slot.value_ptr;
         }
         let interned: &'static [u8] =
             bun_core::handle_oom(Fs::FilenameStore::instance().append_slice(value));
-        set.insert(interned, ());
+        // On a (64-bit) hash collision the newer path takes the slot; the older
+        // one just interns again next time.
+        *slot.value_ptr = interned;
         interned
     })
+}
+
+/// `path` with every slice interned via [`intern_transpile_path`] (dedup), so
+/// it is genuinely `'static` for the parser's `ParseOptions::path` /
+/// `bun_ast::Source::path` and for off-thread transpile jobs — see that fn's
+/// doc for the leak the dedup closes (require-cache.test.ts "don't leak file
+/// paths").
+fn intern_path(path: &Fs::Path<'_>) -> Fs::Path<'static> {
+    let text: &'static [u8] = intern_transpile_path(path.text);
+    let pretty: &'static [u8] = if core::ptr::eq(path.pretty.as_ptr(), path.text.as_ptr())
+        && path.pretty.len() == path.text.len()
+    {
+        text
+    } else {
+        intern_transpile_path(path.pretty)
+    };
+    // `Fs::Path::init` always sets namespace to the `b"file"` literal; only
+    // intern if a caller overrode it.
+    let namespace: &'static [u8] = if path.namespace == b"file" {
+        b"file"
+    } else {
+        intern_transpile_path(path.namespace)
+    };
+    Fs::Path {
+        pretty,
+        text,
+        namespace,
+        is_disabled: path.is_disabled,
+        is_symlink: path.is_symlink,
+    }
 }
 
 /// Modules that must always transpile on-thread (see [`Bun__transpileFile`]).
@@ -4157,11 +4128,9 @@ const ALWAYS_SYNC_MODULES: &[&[u8]] = &[b"reflect-metadata"];
 ///
 /// PERF: this is the per-`require()` / per-`import` hot-loop root.
 ///
-/// # Safety
-/// `jsc_vm` is the live per-thread VM.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn Bun__transpileFile(
-    jsc_vm: *mut VirtualMachine,
+pub extern "C" fn Bun__transpileFile(
+    jsc_vm: &mut VirtualMachine,
     global: &JSGlobalObject,
     specifier: &bun_core::String,
     referrer: &bun_core::String,
@@ -4174,6 +4143,9 @@ pub unsafe extern "C" fn Bun__transpileFile(
     use bun_jsc::resolved_source::Tag as ResolvedSourceTag;
 
     bun_jsc::mark_binding();
+    // The body re-enters `vm.transpiler` while also touching
+    // `vm.module_loader` / `vm.transpiler_store`; per-field raw derefs below.
+    let jsc_vm: *mut VirtualMachine = jsc_vm;
     let force_loader_type: Option<Loader> = force_loader_from_api_u8(force_loader);
 
     // Create a fresh parse log.
@@ -4324,20 +4296,18 @@ pub unsafe extern "C" fn Bun__transpileFile(
                 }
             }
 
-            // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-            // `lr.path` borrows `_specifier`, which the store immediately
-            // heap-duplicates inside `transpile()`.
-            return unsafe {
-                (*jsc_vm).transpiler_store.transpile(
-                    jsc_vm,
-                    global,
-                    specifier.clone(),
-                    &lr.path,
-                    referrer.clone(),
-                    concurrent_loader,
-                    lr.package_json,
-                )
-            };
+            // `lr.path` borrows `_specifier`; the job gets an interned copy.
+            return bun_jsc::RuntimeTranspilerStore::transpile(
+                // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                unsafe { &*jsc_vm },
+                global,
+                specifier.clone(),
+                intern_path(&lr.path),
+                referrer.clone(),
+                concurrent_loader,
+                lr.package_json,
+            )
+            .cast();
         }
         let _ = concurrent_loader;
     }
@@ -4400,12 +4370,9 @@ pub unsafe extern "C" fn Bun__transpileFile(
     };
 
     // Reset the module loader's arena on scope exit.
-    // `jsc_vm` is the live per-thread VM (BackRef invariant).
-    let _reset_arena = ArenaResetGuard::new(jsc_vm);
+    let _reset_arena = ArenaResetGuard::new(global.bun_vm());
 
     // Lazy-init the per-thread shared printer.
-    // `load_extra_env_and_source_code_printer` calls `ensure_source_code_printer`
-    // (VirtualMachine.rs), but prime defensively here on first use too.
     let printer_ptr: *mut bun_js_printer::BufferPrinter = TRANSPILE_PRINTER.with(|cell| {
         let mut p = cell.get();
         if p.is_null() {
@@ -4419,42 +4386,42 @@ pub unsafe extern "C" fn Bun__transpileFile(
     });
 
     // ── `ModuleLoader.transpileSourceCode(...)` ─────────────────────────────
-    let mut promise: *mut JSInternalPromise = ptr::null_mut();
+    let promise = bun_jsc::module_loader::PromiseSlot::new(None);
+    let promise_ptr =
+        || -> *mut c_void { promise.get().map_or(ptr::null_mut(), |p| p.as_ptr().cast()) };
     let mut extra = TranspileExtra {
-        // SAFETY: `TranspileExtra::path` is typed `'static` (cross-crate
-        // struct); the borrow actually lives only for this synchronous call
-        // (the `extra` struct is consumed by `transpile_source_code_inner`
-        // before `_specifier` / `virtual_source_to_use` drop). Same erasure as
+        // SAFETY: `TranspileExtra::path` is typed `'static` for the parser; the
+        // borrow actually lives only for this synchronous call (the `extra`
+        // struct is consumed by `transpile_source_code_inner` before
+        // `_specifier` / `virtual_source_to_use` drop). Same erasure as
         // `Bun__transpileVirtualModule` below.
         path: unsafe { lr.path.into_static() },
         loader: synchronous_loader,
         module_type,
-        source_code_printer: printer_ptr,
-        promise_ptr: if allow_promise {
-            &raw mut promise
-        } else {
-            ptr::null_mut()
-        },
+        // SAFETY: this thread's `TRANSPILE_PRINTER` (boxed above, freed only at
+        // `deinit_runtime_state`); nothing else borrows it during the call.
+        source_code_printer: unsafe { &mut *printer_ptr },
+        promise_slot: if allow_promise { Some(&promise) } else { None },
     };
     let args = TranspileArgs {
         specifier: lr.specifier,
         referrer: referrer_slice.slice(),
         input_specifier: specifier,
-        log: &raw mut *log,
+        log: &mut log,
         virtual_source: lr.virtual_source,
         global_object: global,
         flags: FetchFlags::Transpile,
-        extra: &raw mut extra,
+        extra: &mut extra,
     };
 
-    match transpile_source_code_inner(jsc_vm, &args) {
+    match transpile_source_code_inner(jsc_vm, args) {
         Ok(resolved) => {
             *ret = ErrorableResolvedSource::ok(resolved);
-            promise.cast::<c_void>()
+            promise_ptr()
         }
         Err(crate::Error::AsyncModule) => {
-            debug_assert!(!promise.is_null());
-            promise.cast::<c_void>()
+            debug_assert!(promise.get().is_some());
+            promise_ptr()
         }
         Err(err) => {
             if let Some(value) = transpile_error_value(global, specifier, referrer, &mut log, err) {
@@ -4553,8 +4520,7 @@ pub extern "C" fn Bun__transpileVirtualModule(
     };
 
     // Reset the module loader's arena on scope exit.
-    // `jsc_vm` is the live per-thread VM (BackRef invariant).
-    let _reset_arena = ArenaResetGuard::new(jsc_vm);
+    let _reset_arena = ArenaResetGuard::new(global.bun_vm());
 
     // Lazy-init the per-thread shared printer (same path as `Bun__transpileFile`).
     let printer_ptr: *mut bun_js_printer::BufferPrinter = TRANSPILE_PRINTER.with(|cell| {
@@ -4574,21 +4540,23 @@ pub extern "C" fn Bun__transpileVirtualModule(
         path,
         loader,
         module_type: ModuleType::Unknown,
-        source_code_printer: printer_ptr,
-        promise_ptr: ptr::null_mut(), // null forbids async resolution
+        // SAFETY: this thread's `TRANSPILE_PRINTER` (boxed above, freed only at
+        // `deinit_runtime_state`); nothing else borrows it during the call.
+        source_code_printer: unsafe { &mut *printer_ptr },
+        promise_slot: None, // forbids async resolution
     };
     let args = TranspileArgs {
         specifier,
         referrer: referrer_slice.slice(),
         input_specifier: specifier_str,
-        log: &raw mut log,
+        log: &mut log,
         virtual_source: Some(&virtual_source),
         global_object: global,
         flags: FetchFlags::Transpile,
-        extra: &raw mut extra,
+        extra: &mut extra,
     };
 
-    match transpile_source_code_inner(jsc_vm, &args) {
+    match transpile_source_code_inner(jsc_vm, args) {
         Ok(resolved) => {
             *ret = ErrorableResolvedSource::ok(resolved);
             bun_analytics::features::virtual_modules

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -184,9 +184,9 @@ impl Drop for ReadFileCompletionFns {
     }
 }
 
-// SAFETY: the ctx holds JS-thread state (promise, Blob); it is only ever completed or cancelled on
+// The ctx holds JS-thread state (promise, Blob); it is only ever completed or cancelled on
 // the JS thread — as a Job's `Js` side, or inside the JS-thread-only ReadFileUV.
-unsafe impl bun_jsc::job::JsAffine for ReadFileCompletionFns {}
+impl bun_jsc::job::JsAffine for ReadFileCompletionFns {}
 
 pub struct ReadFileRead {
     /// Always a `Box::<[u8]>::into_raw` from the producer's read buffer

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -32,7 +32,17 @@
     ]
   },
   "src/jsc/RuntimeTranspilerStore.rs": {
-    "WorkPool::schedule*": 1
+    "unsafe impl Send": [
+      "TranspileWork"
+    ]
+  },
+  "src/jsc/SavedSourceMap.rs": {
+    "unsafe impl Send": [
+      "SavedSourceMap"
+    ],
+    "unsafe impl Sync": [
+      "SavedSourceMap"
+    ]
   },
   "src/jsc/TopExceptionScope.rs": {
     "unsafe impl Send": [


### PR DESCRIPTION
### What

Same programme as #40055 … #40284, applied to the JS-thread ↔ transpile-worker module-loading path in `src/jsc/`.

`ModuleLoader.rs` 9 → 1 and `AsyncModule.rs` 25 → 1 (residuals are all-`safe fn` extern blocks), `RuntimeTranspilerStore.rs` 50 → 3, `job.rs` 50 → 17. Collateral: `jsc_hooks.rs` −10, `VirtualMachine.rs` −8, `JsAffine` impls across glob/dns/Image/CompressionStreamCoder/read_file become plain `impl`s.

- **ModuleLoader**: `__bun_transpile_source_code` is a safe `fn(&mut VirtualMachine, TranspileArgs<'_, '_>)`; `TranspileArgs`/`TranspileExtra` carry `&mut Log`/`&mut BufferPrinter`/`Option<&PromiseSlot>` instead of raw pointers; `Bun__fetchBuiltinModule`, `ModuleLoader__isBuiltin`, `Bun__getDefaultLoader`, `Bun__runVirtualModule` are `HOST_EXPORT`s.
- **AsyncModule**: `WakeContext` no longer holds `*mut Queue` — the package manager wakes the JS thread with `VmHandle::post_ping(kind, tag)`; `Queue::on_dependency_error(&mut self)` is reached through the current thread's VM; `resume_loading_module` uses a `SourceCodePrinter` RAII loan (no `detach_lifetime`).
- **RuntimeTranspilerStore**: the hive-slot `TranspilerJob` + intrusive queue + raw `*mut VM` become `bun_jsc::Job<TranspileJob>`; VM inputs are snapshotted on the JS thread (`TranspileInput`); shared state is `BackRef<SavedSourceMap>` / `BackRef<AtomicU32>`; the worker printer is a safe thread-local loan; path text is interned rather than boxed with a fake `'static`; the `RuntimeTranspilerStore` task tag and `release_queued_jobs_for_teardown` are gone.
- **job.rs**: `JsAffine` is a safe marker (nothing unsafe relies on it); erased dispatch goes through a safe `erase` fn + one `unsafe fn erased_from_raw` used by `dispatch.rs`; `complete`/`release_unrun`/`into_halves` take `Box<Self>`; `Completion::finish` uses a `ManuallyDrop`'d obligation ZST instead of `ptr::read`.
- Primitives: `bun_event_loop::{Task::ping, BoxedTask + boxed_task!}`, `VmHandle::post_ping`, `SavedSourceMap` over `Guarded` with `&self` methods (it was already used from three threads through aliased `&mut`), `SourceMapHandlerGetter::new(&SavedSourceMap, inline)` + `write_inline_trailer`, `bun_ast::ErasedEntry` + `take_entry`, `bun_bundler::transpiler::{JobTranspiler, JobTranspilerCall}` (per-call arena/log re-aim guard, also used by `JSTranspiler`), `jsc_hooks::intern_path` (single-hash).

**Residuals and their blockers** — `RuntimeTranspilerStore.rs` (3): `unsafe impl Send for TranspileWork`, `JobTranspiler::new`, and one `&mut ImportWatcher` for `add_file`; root causes are that `Transpiler` has no per-call-session split (parse/print need `&mut`) and `Watcher::add_file` takes `&mut self` though it is mutex-serialised — both are bundler/watcher refactors. `job.rs` (17) *is* the primitive (`JsPtr`, intrusive `JobList`, pool `container_of` entry, `erased_from_raw`, `Send for Completion`). `hot_reloader.rs` is untouched here (covered by a sibling PR).

**Perf** (release, `taskset -c 56-63`, interleaved ×20, `perf stat -e instructions:u`, median; A-vs-A noise ±0.07 %): 300-TS-file cold import +0.08 %, `import()` ×50 +0.15 %, `setImmediate` 1e6 +0.03 %, `Bun.sleep` 1e6 −0.02 %, `fs.promises.readFile` ×100k −0.45 %. Malloc counts (uprobes): import300 35,990 → 35,772; readFile 620,668 → 620,633.

### Testing

Debug+ASAN, `--timeout 60000`: test/js/bun/resolve 361 pass (3 baseline-identical reds: root-user ×2, one load timeout), test/js/node/module 107/107, test/cli/run (autoinstall 9/12 — same 3 network reds on baseline; transpiler-cache 13/13; preload 2/2), test/cli/hot 17/17, fs.test.ts 520/520, fs.promises 30/30, sleep, timers (setImmediate 3/3; RSS-leak/LSAN cases identical on baseline debug), plugin 48/48, bundler/transpiler 190/190, cyclic-imports/require-extensions regressions; source lints 163/163 (vm-thread-door inventory regenerated). Hand-driven: 300-file cold/warm, syntax error at file #150 (correct path/line, exit 1), `import()` ×50, TLA rejected import, 20 Workers × 50 imports terminated mid-import × 5 (no ASAN, RSS flat), `bun --hot` 30 rapid edits (31 reloads), auto-install `-i`/`--install=fallback`/`force`. clippy clean on bun_ast/bun_event_loop/bun_bundler/bun_jsc/bun_runtime.