### PR TITLE
tls: do not fail a pending write when the peer half-closes cleanly

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2070,16 +2070,25 @@ struct us_socket_t *us_internal_ssl_on_close(struct us_socket_t *s, int code, vo
   return ret;
 }
 
-/* The EOF dispatch below is scoped to uWS HTTP server sockets: their
- * context's onEnd owns the EOF (premature-EOF clientError
- * HPE_INVALID_EOF_STATE, CONNECT/Upgrade half-open, pipeline drain after
- * FIN), and closing without dispatching silently skipped all of it for
- * node:https. Every other TLS socket kind predates the dispatch and
- * synthesizes its JS 'end' from the close event, so they keep the
- * historical force-close (dispatching for them strands sockets whose end
- * handler expects the transport to close underneath it). */
-static int ssl_wants_eof_dispatch(struct us_socket_t *s) {
+static int ssl_is_uws_http_tls(struct us_socket_t *s) {
   return us_socket_kind(s) == BUN_SOCKET_KIND_UWS_HTTP_TLS;
+}
+
+/* EOF dispatch only for kinds whose user layer consumes 'end' + honors
+ * allow_half_open (uWS HTTP server: their context's onEnd owns the EOF;
+ * Bun.connect/listen, which node:tls rides on). All other TLS kinds derive
+ * EOF from close and keep the historical force-close (dispatching for them
+ * strands sockets whose end handler expects the transport to close
+ * underneath it). */
+static int ssl_wants_eof_dispatch(struct us_socket_t *s) {
+  unsigned char kind = us_socket_kind(s);
+  if (kind == BUN_SOCKET_KIND_UWS_HTTP_TLS) {
+    return 1;
+  }
+  /* Mid-handshake EOF keeps the force-close so JS surfaces it as a failed
+   * handshake (ECONNRESET "socket hang up", like Node) not a clean 'end'. */
+  return kind == BUN_SOCKET_KIND_BUN_SOCKET_TLS &&
+         s->ssl_handshake_state == HANDSHAKE_COMPLETED;
 }
 
 /* Deliver the plaintext EOF to the user layer once, like the plain-TCP path
@@ -2204,7 +2213,7 @@ struct us_socket_t *us_internal_ssl_on_writable(struct us_socket_t *s) {
    * onWritable clears the teardown timeout armed at shutdown. node sockets
    * still get write-completion dispatch after a half-close in either
    * direction. */
-  if (ssl_wants_eof_dispatch(s) && us_internal_ssl_is_shut_down(s)) return s;
+  if (ssl_is_uws_http_tls(s) && us_internal_ssl_is_shut_down(s)) return s;
 
   if (s->ssl_handshake_state == HANDSHAKE_COMPLETED) {
     s = us_dispatch_writable(s);

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2130,11 +2130,15 @@ struct us_socket_t *us_internal_ssl_on_end(struct us_socket_t *s) {
     if (!s || us_socket_is_closed(s)) {
       return s;
     }
-    if (s->flags.allow_half_open) {
+    if (s->flags.allow_half_open &&
+        (ssl_gone(s) || !(SSL_get_shutdown(s_ssl(s)) & SSL_SENT_SHUTDOWN))) {
       /* Keep the write side alive like the plain-TCP half-open branch in
        * loop.c: TCP permits writing after a received FIN, so queued
        * responses still flush and the app's own end() completes the
-       * shutdown. */
+       * shutdown. With SENT_SHUTDOWN both directions are closed; fall
+       * through so a deferred graceful close completes (mirrors the
+       * ZERO_RETURN path; loop.c raw-closes this case first on the
+       * epoll/kqueue backend, the libuv one reaches here). */
       return s;
     }
   }
@@ -2322,11 +2326,15 @@ restart:
           if (ssl_wants_eof_dispatch(s)) {
             s = ssl_deliver_eof(s);
             if (!s || ssl_gone(s)) return NULL;
-            if (s->flags.allow_half_open) {
+            if (s->flags.allow_half_open &&
+                !(SSL_get_shutdown(s_ssl(s)) & SSL_SENT_SHUTDOWN)) {
               /* close_notify only ended the peer's write side; ours may
                * still flush queued bytes, and the app's own end() completes
                * the shutdown (ssl_handle_shutdown sees RECEIVED_SHUTDOWN and
-               * finishes immediately). */
+               * finishes immediately). With SENT_SHUTDOWN both directions are
+               * closed and nothing is left to hold open: fall through so the
+               * deferred graceful close (code 0, no FIN sent) completes here
+               * instead of waiting for a FIN that may never come. */
               return s;
             }
           }

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -86,7 +86,10 @@ void JSNodeHTTPServerSocket::close()
                 flushPartialResponseBeforeClose<false>(socket);
             }
         }
-        us_socket_close(socket, 0, nullptr);
+        /* socket.destroy() → forceful close: CLEAN_SHUTDOWN would wait on the
+         * peer's close_notify, which an allowHalfOpen peer never sends, pinning
+         * the fd and event loop. */
+        us_socket_close(socket, LIBUS_SOCKET_CLOSE_CODE_FAST_SHUTDOWN, nullptr);
     }
 }
 

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -86,9 +86,7 @@ void JSNodeHTTPServerSocket::close()
                 flushPartialResponseBeforeClose<false>(socket);
             }
         }
-        /* socket.destroy() → forceful close: CLEAN_SHUTDOWN would wait on the
-         * peer's close_notify, which an allowHalfOpen peer never sends, pinning
-         * the fd and event loop. */
+        // Forceful: code 0 defers the fd close until a close_notify reply that a half-open peer never sends.
         us_socket_close(socket, LIBUS_SOCKET_CLOSE_CODE_FAST_SHUTDOWN, nullptr);
     }
 }

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4662,3 +4662,47 @@ describe.concurrent("a socket closed by data() while its peer's reset is being d
     expect(exitCode).toBe(0);
   });
 });
+
+it("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async () => {
+  // Each end() sends close_notify and defers its fd close for the peer's
+  // reply. The reply arrives without a FIN, so the ZERO_RETURN path has to
+  // complete the deferred close instead of keeping the socket half-open.
+  const serverOpen = Promise.withResolvers<Socket>();
+  const serverClosed = Promise.withResolvers<void>();
+  const clientClosed = Promise.withResolvers<void>();
+  const serverShake = Promise.withResolvers<void>();
+  const clientShake = Promise.withResolvers<void>();
+
+  using server = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    allowHalfOpen: true,
+    tls: { key: tls.key, cert: tls.cert },
+    socket: {
+      open: s => serverOpen.resolve(s),
+      handshake: () => serverShake.resolve(),
+      data() {},
+      close: () => serverClosed.resolve(),
+    },
+  });
+  const client = await Bun.connect({
+    hostname: "127.0.0.1",
+    port: server.port,
+    allowHalfOpen: true,
+    tls: { ca: tls.cert },
+    socket: {
+      handshake: () => clientShake.resolve(),
+      data() {},
+      close: () => clientClosed.resolve(),
+    },
+  });
+
+  const serverSock = await serverOpen.promise;
+  await Promise.all([serverShake.promise, clientShake.promise]);
+
+  // Both sides end before either reads the peer's close_notify.
+  client.end();
+  serverSock.end();
+
+  await Promise.all([serverClosed.promise, clientClosed.promise]);
+});

--- a/test/regression/issue/40380.test.ts
+++ b/test/regression/issue/40380.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
+import { tls as certs } from "harness";
 import { once } from "node:events";
 import tls from "node:tls";
-import { tls as certs } from "harness";
 
 // https://github.com/oven-sh/bun/issues/40380
 // A backpressured node:tls write must not fail with ERR_SOCKET_CLOSED when the

--- a/test/regression/issue/40380.test.ts
+++ b/test/regression/issue/40380.test.ts
@@ -15,16 +15,18 @@ test("clean peer FIN does not fail a pending backpressured TLS write", async () 
     sock.pause(); // never read, so the client's write stays backpressured
     backpressured.promise.then(() => sock.end()); // then half-close cleanly
   });
-  server.listen(0);
-  await once(server, "listening");
-  const { port } = server.address() as { port: number };
-
-  const sock = tls.connect({ port, rejectUnauthorized: false });
-  const clientErrors: Error[] = [];
-  sock.on("error", err => clientErrors.push(err));
-  await once(sock, "secureConnect");
+  let sock: ReturnType<typeof tls.connect> | undefined;
 
   try {
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as { port: number };
+
+    sock = tls.connect({ port, rejectUnauthorized: false });
+    const clientErrors: Error[] = [];
+    sock.on("error", err => clientErrors.push(err));
+    await once(sock, "secureConnect");
+
     let writeErr: Error | null | undefined;
     let writeCbCalled = false;
     const flushed = sock.write(Buffer.alloc(64 << 20), err => {
@@ -49,7 +51,7 @@ test("clean peer FIN does not fail a pending backpressured TLS write", async () 
     expect(writeErr ?? null).toBe(null);
     if (writeCbCalled) expect(writeErr).toBe(null);
   } finally {
-    sock.destroy();
+    sock?.destroy();
     server.close();
   }
 });

--- a/test/regression/issue/40380.test.ts
+++ b/test/regression/issue/40380.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { once } from "node:events";
+import tls from "node:tls";
+import { tls as certs } from "harness";
+
+// https://github.com/oven-sh/bun/issues/40380
+// A backpressured node:tls write must not fail with ERR_SOCKET_CLOSED when the
+// peer half-closes cleanly (close_notify + FIN). Node leaves the write pending
+// and only emits 'end'; a later failure surfaces as a real errno.
+test("clean peer FIN does not fail a pending backpressured TLS write", async () => {
+  const backpressured = Promise.withResolvers<void>();
+
+  const server = tls.createServer(certs, sock => {
+    sock.on("error", () => {});
+    sock.pause(); // never read, so the client's write stays backpressured
+    backpressured.promise.then(() => sock.end()); // then half-close cleanly
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as { port: number };
+
+  const sock = tls.connect({ port, rejectUnauthorized: false });
+  const clientErrors: Error[] = [];
+  sock.on("error", err => clientErrors.push(err));
+  await once(sock, "secureConnect");
+
+  try {
+    let writeErr: Error | null | undefined;
+    let writeCbCalled = false;
+    const flushed = sock.write(Buffer.alloc(64 << 20), err => {
+      writeCbCalled = true;
+      writeErr = err;
+    });
+    // The 64 MB body cannot fit in the kernel and native buffers while the
+    // peer is paused, so the write parks on backpressure.
+    expect(flushed).toBe(false);
+    backpressured.resolve();
+
+    await once(sock, "end");
+    // The broken path fails the parked write synchronously inside the native
+    // close callback, before 'end' is emitted; the matching 'error' event is
+    // emitted one tick later. Let both land before asserting.
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(clientErrors).toEqual([]);
+    // The write is either still pending (Node 24) or completed cleanly
+    // (Bun 1.3.14). It must not have failed.
+    expect(writeErr ?? null).toBe(null);
+    if (writeCbCalled) expect(writeErr).toBe(null);
+  } finally {
+    sock.destroy();
+    server.close();
+  }
+});

--- a/test/regression/issue/40380.test.ts
+++ b/test/regression/issue/40380.test.ts
@@ -5,15 +5,17 @@ import tls from "node:tls";
 
 // https://github.com/oven-sh/bun/issues/40380
 // A backpressured node:tls write must not fail with ERR_SOCKET_CLOSED when the
-// peer half-closes cleanly (close_notify + FIN). Node leaves the write pending
-// and only emits 'end'; a later failure surfaces as a real errno.
+// peer half-closes cleanly (close_notify + FIN). The write stays parked and
+// completes once the peer drains it; the socket only emits 'end'.
 test("clean peer FIN does not fail a pending backpressured TLS write", async () => {
   const backpressured = Promise.withResolvers<void>();
+  const peerFinObserved = Promise.withResolvers<void>();
 
   const server = tls.createServer(certs, sock => {
     sock.on("error", () => {});
     sock.pause(); // never read, so the client's write stays backpressured
     backpressured.promise.then(() => sock.end()); // then half-close cleanly
+    peerFinObserved.promise.then(() => sock.resume()); // then drain the write
   });
   let sock: ReturnType<typeof tls.connect> | undefined;
 
@@ -27,29 +29,22 @@ test("clean peer FIN does not fail a pending backpressured TLS write", async () 
     sock.on("error", err => clientErrors.push(err));
     await once(sock, "secureConnect");
 
-    let writeErr: Error | null | undefined;
-    let writeCbCalled = false;
-    const flushed = sock.write(Buffer.alloc(64 << 20), err => {
-      writeCbCalled = true;
-      writeErr = err;
-    });
+    const writeDone = Promise.withResolvers<Error | null | undefined>();
+    const flushed = sock.write(Buffer.alloc(64 << 20), err => writeDone.resolve(err));
     // The 64 MB body cannot fit in the kernel and native buffers while the
     // peer is paused, so the write parks on backpressure.
     expect(flushed).toBe(false);
     backpressured.resolve();
 
+    // The peer's FIN only closed its write side. The parked write must
+    // survive it and complete once the peer starts reading again. The broken
+    // path destroys the socket instead and fails the write with
+    // ERR_SOCKET_CLOSED.
     await once(sock, "end");
-    // The broken path fails the parked write synchronously inside the native
-    // close callback, before 'end' is emitted; the matching 'error' event is
-    // emitted one tick later. Let both land before asserting.
-    await new Promise(resolve => setImmediate(resolve));
-    await new Promise(resolve => setImmediate(resolve));
-
-    expect(clientErrors).toEqual([]);
-    // The write is either still pending (Node 24) or completed cleanly
-    // (Bun 1.3.14). It must not have failed.
+    peerFinObserved.resolve();
+    const writeErr = await writeDone.promise;
     expect(writeErr ?? null).toBe(null);
-    if (writeCbCalled) expect(writeErr).toBe(null);
+    expect(clientErrors).toEqual([]);
   } finally {
     sock?.destroy();
     server.close();


### PR DESCRIPTION
### Problem

- A node:tls write that sits in backpressure fails with `Error: Socket is closed` (`ERR_SOCKET_CLOSED`) when the peer half-closes cleanly (close_notify + FIN). Node leaves the write pending and emits `end`. Regression from 1.3.14. It drops AWS SDK requests in production because the error carries no retryable errno (#40380).
- The cause: `ssl_wants_eof_dispatch` (`packages/bun-usockets/src/crypto/openssl.c:2081`) scopes the TLS EOF dispatch to uWS HTTP server sockets. A node:tls socket (`BUN_SOCKET_KIND_BUN_SOCKET_TLS`) skips the `end` dispatch and the `allow_half_open` path and force-closes. The JS close handler then fails the parked write.

### Fix

- Extend the EOF dispatch to `BUN_SOCKET_KIND_BUN_SOCKET_TLS` for established sessions. The peer's close_notify now delivers `end` and honors `allow_half_open`, like the plain-TCP FIN branch in `loop.c`. A mid-handshake EOF keeps the force-close so it still surfaces as a failed handshake (ECONNRESET "socket hang up").
- Skip the half-open early-return when `SSL_SENT_SHUTDOWN` is set. After our own `end()`, the fd close is deferred for exactly this close_notify, and both directions are closed, so `ssl_close` completes the deferred close. Without this, two peers that `end()` concurrently strand each other and pin both event loops (review finding, reproduced).
- `JSNodeHTTPServerSocket::close()` now closes with `FAST_SHUTDOWN`. destroy is forceful: code 0 defers the fd close for a close_notify reply that a half-open peer never sends.
- The dispatch change is the half-open change from #35535, extracted so it can ship on its own. Credit to @cirospaciari (co-authored).
- Verified: `test/regression/issue/40380.test.ts` (event-driven, no timers) fails with src/ and packages/ reverted to main and passes with the fix. A concurrent-end test in `test/js/bun/net/socket.test.ts` covers the deferred-close guard. Suites in Notes.

### Background

- uSockets defers the fd close of a gracefully ended TLS socket until the peer replies with close_notify. That reply arrives through the same `SSL_ERROR_ZERO_RETURN` path, which re-enters `ssl_close` with `SSL_SENT_SHUTDOWN` set and completes the close. The new guard preserves exactly that flow.
- `net.ts` always creates the native socket with `allowHalfOpen: true` and manages half-open in JS. On `end` with JS `allowHalfOpen: false`, the stream machinery calls `end()` after pending writes flush, which is Node's sequence.

<details><summary>Notes</summary>

Repro from the issue: a TLS server that pauses its socket and calls `sock.end()` while the client has a 64 MB write parked. Before the fix: `write failed: Socket is closed`. After: `peer FIN, write still pending — no error`, identical to Node 24.

The regression test gives the success path a positive terminal event: after the FIN the server resumes reading, the parked write drains, and the test awaits the write callback (null on the fixed build, ERR_SOCKET_CLOSED on main). Earlier versions settled with setImmediate, which raced the nextTick delivery of the failure and was flagged in review.

Stranding repro for the guard: two Bun TLS sockets with `allowHalfOpen: true` that `end()` concurrently. Each sends close_notify and defers its close. Without the guard, each peer's ZERO_RETURN parks in the half-open early-return and neither `close` ever fires. With the guard both sockets close. Instrumentation showed both sockets at shutdown state SENT|RECEIVED when stranded.

Suites run against the final build (linux x64, debug + ASAN):

- `test/js/node/tls/`: 260 pass, 1 fail. The failure (`SNICallback runs even when the requested servername matches the bind hostname`, ECONNREFUSED on localhost) fails identically on the unfixed release binary in this container. Environment, not this diff.
- `test/js/node/net/`: 250 pass, 10 fail, all within the 54 that fail on the unfixed release binary in this container (localhost resolution, public-internet DNS).
- `test/js/bun/net/socket.test.ts`, `tcp-server.test.ts`, `socket-retention.test.ts`: 13 fail, all within the 16 that fail on the unfixed release binary (same environment causes).
- `test/js/web/fetch/fetch.tls.test.ts`, `node-https-checkServerIdentity.test.ts`, `node-http-agent-tls-options.test.mts`: 49 pass, 0 fail.
- Upstream parallel files, all exit 0: test-tls-econnreset, test-tls-sni-servername, test-https-set-timeout-server, test-http-set-timeout-server, test-net-allow-half-open, test-tls-socket-allow-half-open-option, test-tls-client-destroy-soon, test-tls-close-error, test-tls-close-event-after-write, test-tls-destroy-stream, test-tls-destroy-stream-12, test-tls-destroy-whilst-write, test-tls-finished, test-tls-friendly-error-message, test-tls-junk-closes-server, test-tls-socket-close, test-tls-socket-destroy, test-tls-transport-destroy-after-own-gc, test-tls-streamwrap-buffersize.

#35535 found the same regression classes when it ran the full 269-file upstream TLS suite (test-tls-econnreset and test-tls-sni-servername without the handshake gate, and the https set-timeout hang without the destroy fix). Both guards are included here, and those files pass.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->