### PR TITLE
bun:test: do not leave an exception pending while rendering a failure diff

### DIFF
--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use bun_core::Output;
-use bun_jsc::{JSGlobalObject, JSValue};
+use bun_jsc::{js_error_to_write_error, JSGlobalObject, JSValue};
 
 use super::diff::print_diff::{print_diff_main, DiffConfig};
 use super::pretty_format::{FormatOptions, JestPrettyFormat, MessageLevel};
@@ -44,23 +44,25 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
-            let _ = JestPrettyFormat::format(
+            JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&received),
                 1,
                 &mut received_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .map_err(js_error_to_write_error)?;
 
-            let _ = JestPrettyFormat::format(
+            JestPrettyFormat::format(
                 MessageLevel::Debug,
                 global_this,
                 core::slice::from_ref(&expected),
                 1,
                 &mut expected_buf,
                 fmt_options,
-            ); // TODO:
+            )
+            .map_err(js_error_to_write_error)?;
         }
 
         let mut received_slice: &[u8] = received_buf.as_slice();

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2885,7 +2885,11 @@ impl ExpectMatcherUtils {
         } else {
             bun_core::pretty_fmt!("<d>(<r><green>expected<r><d>)<r>", false)
         };
-        let buf = format!("{head}{not}{matcher_name}{expected_hint}\n\n{diff_formatter}\n");
+        let mut buf = String::new();
+        use fmt::Write as _;
+        if write!(buf, "{head}{not}{matcher_name}{expected_hint}\n\n{diff_formatter}\n").is_err() {
+            return Err(JsError::Thrown);
+        }
         bun_string_jsc::create_utf8_for_js(global_this, buf.as_bytes())
     }
 }

--- a/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
+++ b/test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
@@ -49,3 +49,91 @@ test("matcher utils propagate exceptions thrown while inspecting the value", asy
     exitCode: 0,
   });
 });
+
+// Rendering a failure diff inspects both values. When inspecting the received
+// value throws, the exception must not stay pending while the expected value
+// is inspected. The unfixed build aborts on that pending exception, so the
+// input runs in a child. The matcher reports its own failure, like the other
+// matchers do when their message cannot be rendered.
+test("failure diff does not crash when inspecting the received value throws", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        import { expect } from "bun:test";
+        const received = new Proxy([1], {
+          get(target, key, receiver) {
+            if (key === "0") throw new Error("inspect failed");
+            return Reflect.get(target, key, receiver);
+          },
+        });
+        const caught = {};
+        for (const matcher of ["toEqual", "toStrictEqual"]) {
+          try {
+            expect(received)[matcher]({});
+            caught[matcher] = "did not throw";
+          } catch (e) {
+            caught[matcher] = e.message.split("\\n")[0];
+          }
+        }
+        console.log(JSON.stringify(caught));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({
+      toEqual: "expect(received).toEqual(expected)",
+      toStrictEqual: "expect(received).toStrictEqual(expected)",
+    }),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+test("matcherHint propagates exceptions thrown while inspecting the value", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        import { expect } from "bun:test";
+        const received = new Proxy([1], {
+          get(target, key, receiver) {
+            if (key === "0") throw new Error("inspect failed");
+            return Reflect.get(target, key, receiver);
+          },
+        });
+        let caught;
+        expect.extend({
+          _hint(received, expected) {
+            try {
+              this.utils.matcherHint("_hint", received, expected);
+              caught = "did not throw";
+            } catch (e) {
+              caught = e.message;
+            }
+            return { pass: true, message: () => "" };
+          },
+        });
+        expect(received)._hint({});
+        console.log(JSON.stringify(caught));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify("inspect failed"),
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found abort in `bun:test`. A debug build hit `ASSERT_NO_PENDING_EXCEPTION` in `JSC__JSValue__getOwn` with a `RangeError: Maximum call stack size exceeded` pending, while `toStrictEqual` rendered its failure message.

`DiffFormatter::fmt` (`src/runtime/test_runner/diff_format.rs`) renders the `- Expected / + Received` diff for `toEqual`, `toStrictEqual`, `toBe`, `toMatchObject`, `toHaveBeenCalledWith` and the other diff matchers. It formats the received value, then the expected value, with `JestPrettyFormat::format`. It discarded the result of both calls (`let _ = ...; // TODO:`). When inspecting the received value threw, the exception stayed pending on the VM while the expected value was inspected. The next binding that asserts a clean VM aborted the process.

In the fuzzer case the thrown error was a stack overflow: the matcher ran in the deepest frame of a recursion that had just caught a `RangeError`, and formatting the received object overflowed again. A deterministic trigger is any value whose inspection throws, for example a `Proxy` with a throwing `get` trap:

```js
import { expect } from "bun:test";
const received = new Proxy([1], {
  get(t, k, r) {
    if (k === "0") throw new Error("boom");
    return Reflect.get(t, k, r);
  },
});
expect(received).toStrictEqual({});
```

Before: a debug build aborts. A release build throws the stray `boom` error instead of the matcher error, because `throw_value` refuses to override a pending exception.

After: `DiffFormatter::fmt` propagates the failure as `fmt::Error`, the same way `ZigFormatter`, `AllCallsFormatter` and the other `Display` impls in the test runner do. `create_error_instance` then clears the exception and throws the matcher error with the message rendered so far (`expect(received).toStrictEqual(expected)`). This matches what the other matchers already do when their message cannot be rendered (see `expect-symbol-toPrimitive-crash.test.ts`).

`matcherHint` rendered the same `Display` through `format!`, which panics when a `Display` returns `Err`. It now writes into a `String` and returns the pending exception to the caller. This matches the behavior of `stringify`, `printExpected` and `printReceived`.

### How did you verify your code works?

- The Proxy repro above reproduces the exact `assertNoExceptionExceptTermination` abort on the unfixed debug build. With the fix it throws the matcher error and exits 0.
- Added two tests to `test/js/bun/test/expect-extend-matcher-utils-throw.test.ts`:
  - `failure diff does not crash when inspecting the received value throws`: fails on the current release build (`boom` leaks out of `toEqual` and `toStrictEqual`), passes with the fix.
  - `matcherHint propagates exceptions thrown while inspecting the value`: guards the `format!` replacement.
- `bun bd test test/js/bun/test/expect.test.js` passes (415 tests). `expect-symbol-toPrimitive-crash`, `expect-stack-overflow-crash`, `expect-failure-message-angle-brackets`, `expect/huge-failure-message`, `expect/toHaveReturnedWith` and `expect-toHaveReturnedWith` pass too.
- `cargo fmt --all -- --check` passes.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/expect-extend-matcher-utils-throw.test.ts:
(pass) matcher utils propagate exceptions thrown while inspecting the value [743.29ms]
84 |     stdout: "pipe",
85 |     stderr: "pipe",
86 |   });
87 | 
88 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
89 |   expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
                                                           ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": "",
-   "stdout": "{"toEqual":"expect(received).toEqual(expected)","toStrictEqual":"expect(received).toStrictEqual(expected)"}",
+   "exitCode": 134,
+   "stderr": 
+ "ASSERTION FAILED: Unexpected exception observed on thread Thread:0x72b6d40000c0 at:
+ The exception was thrown from thread Thread:0x72b6d40000c0 at:
+ Error Exception: inspect failed
+ 
+ !exception() || m_vm.hasPendingTerminationException()
+ /root/.bun/
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (8b0f39214)

test/js/bun/test/expect-extend-matcher-utils-throw.test.ts:
(pass) matcher utils propagate exceptions thrown while inspecting the value [14.24ms]
(pass) failure diff does not crash when inspecting the received value throws [6.44ms]
(pass) matcherHint propagates exceptions thrown while inspecting the value [5.39ms]

 3 pass
 0 fail
 3 expect() calls
Ran 3 tests across 1 file. [102.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-extend-matcher-utils-throw.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/expect-extend-matcher-utils-throw.test.ts:
(pass) matcher utils propagate exceptions thrown while inspecting the value [1064.52ms]
(pass) failure diff does not crash when inspecting the received value throws [413.91ms]
(pass) matcherHint propagates exceptions thrown while inspecting the value [329.40ms]

 3 pass
 0 fail
 3 expect() calls
Ran 3 tests across 1 file. [4.89s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 719ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/13] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 242 extern-C blocks audited
[1/13] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sour
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/diff_format.rs             | 12 +--
 src/runtime/test_runner/expect.rs                  |  6 +-
 .../test/expect-extend-matcher-utils-throw.test.ts | 88 ++++++++++++++++++++++
 3 files changed, 100 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/test_runner/diff_format.rs                        2      2      0
src/runtime/test_runner/expect.rs                             4      3      0
…t/js/bun/test/expect-extend-matcher-utils-throw.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->