### PR TITLE
fetch: pool keep-alive connections for requests with checkServerIdentity

### DIFF
--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -157,6 +157,34 @@ impl<const SSL: bool> ActiveSocketExt<SSL> for ActiveSocket<SSL> {
     }
 }
 
+/// How the peer on a pooled connection was authenticated. Connections are
+/// only shared between requests that authenticate the same way (a
+/// `rejectUnauthorized: false` request may take any), so a verdict from a JS
+/// `checkServerIdentity` callback is never inherited by a request relying on
+/// the native check, or vice versa.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
+pub enum PeerVerification {
+    /// Established with `rejectUnauthorized: false`; neither the chain nor
+    /// the hostname was enforced.
+    #[default]
+    None,
+    /// Chain verified against the CA store; identity approved by a JS
+    /// `checkServerIdentity` callback at handshake time (like Node's
+    /// `https.Agent`, the callback is per connection, not per request).
+    Callback,
+    /// Chain verified and hostname matched by the native check.
+    Native,
+}
+
+impl PeerVerification {
+    /// Whether a request that verifies at `self` may take a pooled connection
+    /// verified at `pooled`.
+    #[inline]
+    pub(crate) fn admits(self, pooled: PeerVerification) -> bool {
+        self == PeerVerification::None || self == pooled
+    }
+}
+
 pub struct PooledSocket<const SSL: bool> {
     pub(crate) http_socket: HTTPSocket<SSL>,
     pub(crate) hostname_buf: [u8; MAX_KEEPALIVE_HOSTNAME],
@@ -164,12 +192,10 @@ pub struct PooledSocket<const SSL: bool> {
     pub(crate) port: u16,
     /// If you set `rejectUnauthorized` to `false`, the connection fails to verify,
     pub(crate) did_have_handshaking_error_while_reject_unauthorized_is_false: bool,
-    /// True if the TLS handshake for this socket ran with
-    /// `rejectUnauthorized=true` (i.e. `checkServerIdentity` was enforced).
-    /// A socket established with `rejectUnauthorized=false` never validated the
-    /// peer hostname, so a strict caller must not reuse it even when the chain
-    /// itself was CA-valid (`did_have_handshaking_error` stays false).
-    pub(crate) established_with_reject_unauthorized: bool,
+    /// A CA-valid but wrong-hostname cert leaves `did_have_handshaking_error`
+    /// false, so this is what keeps a strict caller off a connection whose
+    /// hostname was never checked natively.
+    pub(crate) verification: PeerVerification,
     /// The interned SSLConfig this socket was created with (None = default context).
     /// Owns a strong ref while the socket is in the keepalive pool.
     pub(crate) ssl_config: Option<ssl_config::SharedPtr>,
@@ -271,6 +297,7 @@ struct ExistingSocket<const SSL: bool> {
     tunnel: Option<crate::proxy_tunnel::RefPtr>,
     /// Non-null if the socket negotiated "h2"; ownership transferred.
     h2_session: Option<NonNull<h2::ClientSession>>,
+    verification: PeerVerification,
 }
 
 impl<const SSL: bool> ExistingSocket<SSL> {
@@ -596,7 +623,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
         &mut self,
         socket: HTTPSocket<SSL>,
         did_have_handshaking_error_while_reject_unauthorized_is_false: bool,
-        established_with_reject_unauthorized: bool,
+        verification: PeerVerification,
         hostname: &[u8],
         port: u16,
         ssl_config: Option<&ssl_config::SharedPtr>,
@@ -649,7 +676,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     hostname_len: hostname.len() as u8, // @truncate
                     port,
                     did_have_handshaking_error_while_reject_unauthorized_is_false,
-                    established_with_reject_unauthorized,
+                    verification,
                     // Clone a strong ref for the keepalive pool; the caller retains
                     // its own ref via HTTPClient.tls_props.
                     ssl_config: ssl_config.cloned(),
@@ -698,7 +725,8 @@ impl<const SSL: bool> HTTPContext<SSL> {
     #[allow(clippy::too_many_arguments)]
     fn existing_socket(
         &mut self,
-        reject_unauthorized: bool,
+        required_for_socket: PeerVerification,
+        required_for_target: PeerVerification,
         hostname: &[u8],
         port: u16,
         ssl_config: Option<*const SSLConfig>,
@@ -729,7 +757,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
             }
 
             if socket.did_have_handshaking_error_while_reject_unauthorized_is_false
-                && reject_unauthorized
+                && required_for_target > PeerVerification::None
             {
                 continue;
             }
@@ -763,30 +791,12 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 if !strings::eql_long(&socket.target_hostname, target_hostname, true) {
                     continue;
                 }
-                // A tunnel established with reject_unauthorized=false never
-                // ran checkServerIdentity — a CA-valid wrong-hostname cert
-                // leaves did_have_handshaking_error=false so the outer
-                // guard passes. Block a strict caller from reusing it.
-                if reject_unauthorized
-                    // proxy_tunnel.is_some() guaranteed by want_tunnel match above.
-                    && !socket
-                        .proxy_tunnel
-                        .as_ref()
-                        .unwrap()
-                        .established_with_reject_unauthorized
-                {
+                // proxy_tunnel.is_some() guaranteed by want_tunnel match above.
+                if !required_for_target.admits(socket.proxy_tunnel.as_ref().unwrap().verification) {
                     continue;
                 }
-            } else if SSL
-                // Same failure mode as the tunnel branch above, for direct
-                // HTTPS sockets: a socket established with
-                // reject_unauthorized=false never ran checkServerIdentity, so
-                // a CA-valid wrong-hostname cert leaves
-                // did_have_handshaking_error=false and the outer guard passes.
-                // Block a strict caller from reusing it.
-                && reject_unauthorized
-                && !socket.established_with_reject_unauthorized
-            {
+            }
+            if SSL && !required_for_socket.admits(socket.verification) {
                 continue;
             }
 
@@ -813,6 +823,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 let tunnel: Option<crate::proxy_tunnel::RefPtr> = socket.proxy_tunnel.take();
                 socket.target_hostname = Box::default();
                 let h2_session = socket.h2_session.take();
+                let verification = socket.verification;
                 // SAFETY: `socket_ptr` is a fully-initialized hive slot; the
                 // owned-heap fields (ssl_config/tunnel/target_hostname/h2_session)
                 // were just moved out / cleared, so the in-place drop in `put`
@@ -834,6 +845,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     socket: http_socket,
                     tunnel,
                     h2_session,
+                    verification,
                 });
             }
         }
@@ -912,12 +924,8 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     .find(|s| {
                         s.has_headroom()
                             && s.matches(hostname, port, cfg, host_header_hash)
-                            // Same guard as the pool path: a session whose TLS
-                            // handshake ran with reject_unauthorized=false never
-                            // validated the peer hostname, so a strict caller
-                            // must not multiplex onto it.
-                            && (!client.flags.reject_unauthorized
-                                || s.established_with_reject_unauthorized)
+                            // Same guard as the pool path (`existing_socket`).
+                            && client.socket_verification().admits(s.verification)
                     });
                 if let Some(session) = reusable {
                     h2::ClientSession::adopt(session, client);
@@ -925,12 +933,10 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 }
                 let cfg_nn = cfg.and_then(|p| NonNull::new(p.cast_mut()));
                 for pc in &mut self.pending_h2_connects {
-                    // Same strictness guard as the active-session loop above: a
-                    // strict caller must not coalesce onto an in-flight connect
-                    // that was initiated with reject_unauthorized=false, since
-                    // the resulting session won't have validated the peer.
+                    // Same guard as the active-session loop above, applied to
+                    // an in-flight connect before its session exists.
                     if pc.matches(hostname, port, cfg_nn, host_header_hash)
-                        && (!client.flags.reject_unauthorized || pc.reject_unauthorized)
+                        && client.socket_verification().admits(pc.verification)
                     {
                         // client outlives the pending connect (resolved before
                         // its terminal callback fires).
@@ -941,6 +947,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
             }
         }
 
+        client.flags.reused_socket_verification = PeerVerification::None;
         if client.is_keep_alive_possible() {
             let want_tunnel = client.http_proxy.is_some() && client.url.is_https();
             // CONNECT TCP target (writeProxyConnect line 346). The SNI
@@ -966,9 +973,9 @@ impl<const SSL: bool> HTTPContext<SSL> {
             } else {
                 0
             };
-
             if let Some(mut found) = self.existing_socket(
-                client.flags.reject_unauthorized,
+                client.socket_verification(),
+                client.target_verification(),
                 hostname,
                 port,
                 SSLConfig::raw_ptr(client.tls_props.as_ref()),
@@ -983,6 +990,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 },
             ) {
                 let sock = found.socket;
+                client.flags.reused_socket_verification = found.verification;
                 Self::set_socket_ext(
                     sock,
                     ActiveSocket::<SSL>::init(
@@ -1058,7 +1066,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     hostname: Box::<[u8]>::from(hostname),
                     port,
                     ssl_config: cfg,
-                    reject_unauthorized: client.flags.reject_unauthorized,
+                    verification: client.socket_verification(),
                     host_header_hash: client.proxy_auth_hash(),
                     ..Default::default()
                 });

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -7,7 +7,7 @@ use bun_core::scoped_log;
 use bun_uws as uws;
 
 use crate::http_cert_error::HTTPCertError;
-use crate::http_context::HTTPSocket;
+use crate::http_context::{HTTPSocket, PeerVerification};
 use crate::internal_state::{HTTPStage, Stage};
 use crate::ssl_config::SSLConfig;
 use crate::ssl_wrapper::{Handlers as SSLWrapperHandlers, InitError, SSLWrapper, WriteDataError};
@@ -56,12 +56,11 @@ pub struct ProxyTunnel {
     /// would re-pool with the flag erased, letting a later reject_unauthorized=true
     /// request silently reuse a tunnel whose cert failed validation.
     pub(crate) did_have_handshaking_error: bool,
-    /// Whether the inner TLS session was established with reject_unauthorized=true
-    /// (and therefore hostname-verified via checkServerIdentity). A CA-valid but
-    /// wrong-hostname cert produces error_no=0 so did_have_handshaking_error stays
-    /// false; without this flag, a strict caller could reuse a tunnel where
-    /// hostname was never checked.
-    pub(crate) established_with_reject_unauthorized: bool,
+    /// How the inner TLS peer was authenticated. A CA-valid but wrong-hostname
+    /// cert produces error_no=0 so did_have_handshaking_error stays false;
+    /// without this, a strict caller could reuse a tunnel where the hostname
+    /// was never checked natively.
+    pub(crate) verification: PeerVerification,
     pub(crate) ref_count: Cell<u32>,
 }
 
@@ -73,7 +72,7 @@ impl Default for ProxyTunnel {
             socket: Socket::None,
             write_buffer: bun_io::StreamBuffer::default(),
             did_have_handshaking_error: false,
-            established_with_reject_unauthorized: false,
+            verification: PeerVerification::None,
             ref_count: Cell::new(1),
         }
     }
@@ -749,12 +748,10 @@ impl ProxyTunnel {
         // of the inner TLS session, not the client. adopt() restores it to the
         // next client so re-pooling doesn't erase it.
         self.did_have_handshaking_error = client.flags.did_have_handshaking_error;
-        // OR semantics — a lax client is allowed to reuse a strict tunnel (the
+        // max semantics — a lax client is allowed to reuse a strict tunnel (the
         // existingSocket guard only blocks the reverse). When that lax client
-        // detaches, it must not downgrade a hostname-verified TLS session to
-        // lax-established; once true, stays true.
-        self.established_with_reject_unauthorized =
-            self.established_with_reject_unauthorized || client.flags.reject_unauthorized;
+        // detaches, it must not downgrade a hostname-verified TLS session.
+        self.verification = self.verification.max(client.target_verification());
         // We intentionally leave wrapper.handlers.ctx stale here. The tunnel is
         // idle in the pool and no callbacks will fire until adopt() reattaches
         // a new owner and socket.

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -12,7 +12,7 @@ use bun_core::strings;
 use super::stream::{State as StreamState, Stream};
 use super::{dispatch, encode};
 use crate::h2_frame_parser as wire;
-use crate::http_context::HTTPSocket;
+use crate::http_context::{HTTPSocket, PeerVerification};
 use crate::http_request_body::HTTPRequestBody;
 use crate::internal_state::HTTPStage;
 use crate::lshpack;
@@ -57,10 +57,10 @@ pub struct ClientSession {
     pub(crate) port: u16,
     pub(crate) ssl_config: Option<ssl_config::SharedPtr>,
     pub(crate) did_have_handshaking_error: bool,
-    /// True if the TLS handshake ran with `rejectUnauthorized=true`. Carried
-    /// into the keepalive pool so a strict caller never reuses a session whose
-    /// hostname was never validated.
-    pub(crate) established_with_reject_unauthorized: bool,
+    /// How the TLS peer was authenticated; carried into the keepalive pool and
+    /// checked by the coalescing path so a caller only multiplexes onto a
+    /// session verified the way it would verify a fresh one.
+    pub(crate) verification: PeerVerification,
     pub(crate) host_header_hash: u64,
 
     /// Queued bytes for the socket; whole frames are written here and
@@ -344,7 +344,7 @@ impl ClientSession {
             port: client.connected_url.get_port_auto(),
             ssl_config: client.tls_props.clone(),
             did_have_handshaking_error: client.flags.did_have_handshaking_error,
-            established_with_reject_unauthorized: client.flags.reject_unauthorized,
+            verification: client.socket_verification(),
             host_header_hash: client.proxy_auth_hash(),
             write_buffer: bun_io::StreamBuffer::default(),
             read_buffer: Vec::new(),
@@ -1055,7 +1055,7 @@ impl ClientSession {
             HTTPClient::ssl_ctx_mut(self.ctx).release_socket(
                 self.socket,
                 self.did_have_handshaking_error,
-                self.established_with_reject_unauthorized,
+                self.verification,
                 &self.hostname,
                 self.port,
                 self.ssl_config.as_ref(),

--- a/src/http/h2_client/PendingConnect.rs
+++ b/src/http/h2_client/PendingConnect.rs
@@ -8,6 +8,7 @@ use bun_core::strings;
 
 use crate::HTTPClient;
 use crate::NewHTTPContext;
+use crate::PeerVerification;
 use crate::ssl_config::SSLConfig;
 
 #[derive(Default)]
@@ -16,12 +17,11 @@ pub struct PendingConnect {
     pub(crate) port: u16,
     // Compared by pointer identity only, never derefed/freed here; lifetime-erased.
     pub(crate) ssl_config: Option<NonNull<SSLConfig>>,
-    /// Whether the client that initiated this in-flight TLS connect requested
-    /// `rejectUnauthorized`. The eventual `ClientSession` records this as
-    /// `established_with_reject_unauthorized`; mirroring it here lets the
-    /// coalescing path apply the same strictness guard *before* the session
+    /// How the client that initiated this in-flight TLS connect will verify
+    /// the peer. The eventual `ClientSession` records the same value; mirroring
+    /// it here lets the coalescing path apply the guard *before* the session
     /// exists, so a strict caller never waits on a connect started by a lax one.
-    pub(crate) reject_unauthorized: bool,
+    pub(crate) verification: PeerVerification,
     pub(crate) host_header_hash: u64,
     // BACKREF: waiters are borrowed HTTP clients owned elsewhere; lifetime-erased.
     pub(crate) waiters: Vec<NonNull<HTTPClient<'static>>>,

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -55,7 +55,7 @@ pub use decompressor::Decompressor;
 pub use header_builder::HeaderBuilder;
 pub use headers::{Headers, HeadersExt};
 pub(crate) use http_cert_error::HTTPCertError;
-pub use http_context::{HTTPContext, HTTPSocket};
+pub use http_context::{HTTPContext, HTTPSocket, PeerVerification};
 pub use http_request_body::HTTPRequestBody;
 pub use http_thread::HttpThread as HTTPThread;
 pub use http_thread::shutdown_for_exit;
@@ -189,6 +189,9 @@ pub struct Flags {
     pub(crate) disable_keepalive: bool,
     pub(crate) disable_decompression: bool,
     pub(crate) did_have_handshaking_error: bool,
+    /// `PooledSocket::verification` of the socket this request took from the
+    /// pool, so a weaker request re-pooling it doesn't downgrade the record.
+    pub(crate) reused_socket_verification: PeerVerification,
     pub force_last_modified: bool,
     pub(crate) redirected: bool,
     pub(crate) proxy_tunneling: bool,
@@ -210,6 +213,7 @@ impl Default for Flags {
             disable_keepalive: false,
             disable_decompression: false,
             did_have_handshaking_error: false,
+            reused_socket_verification: PeerVerification::None,
             force_last_modified: false,
             redirected: false,
             proxy_tunneling: false,
@@ -1683,6 +1687,38 @@ impl<'a> HTTPClient<'a> {
 // ───────────────────────────── impl HTTPClient ─────────────────────────────
 
 impl<'a> HTTPClient<'a> {
+    /// How this request authenticates the target's TLS peer on a fresh handshake.
+    pub(crate) fn target_verification(&self) -> PeerVerification {
+        if !self.flags.reject_unauthorized {
+            PeerVerification::None
+        } else if self.signals.get(signals::Field::CertErrors) {
+            PeerVerification::Callback
+        } else {
+            PeerVerification::Native
+        }
+    }
+
+    /// How this request authenticates the peer of its outer socket on a fresh
+    /// handshake (an HTTPS proxy's own certificate always takes the native path).
+    pub(crate) fn socket_verification(&self) -> PeerVerification {
+        if self.http_proxy.is_some() {
+            if self.flags.reject_unauthorized {
+                PeerVerification::Native
+            } else {
+                PeerVerification::None
+            }
+        } else {
+            self.target_verification()
+        }
+    }
+
+    /// `PooledSocket::verification` to record when releasing the outer socket.
+    fn pooled_socket_verification(&self) -> PeerVerification {
+        self.flags
+            .reused_socket_verification
+            .max(self.socket_verification())
+    }
+
     pub(crate) fn check_server_identity<const IS_SSL: bool>(
         &mut self,
         socket: HttpSocket<IS_SSL>,
@@ -2227,11 +2263,6 @@ impl<'a> HTTPClient<'a> {
             if self.unix_socket_path.slice().len() > 0 {
                 return false;
             }
-            // A peer accepted by a per-request JS `checkServerIdentity` callback must
-            // not enter or leave the shared pool (same exclusion as `can_offer_h2`).
-            if self.signals.get(signals::Field::CertErrors) {
-                return false;
-            }
             // check state
             if self.state.flags.allow_keepalive && !self.flags.disable_keepalive {
                 return true;
@@ -2654,7 +2685,7 @@ impl<'a> HTTPClient<'a> {
             Self::ssl_ctx_mut(ctx).release_socket(
                 socket,
                 self.flags.did_have_handshaking_error && !self.flags.reject_unauthorized,
-                self.flags.reject_unauthorized,
+                self.pooled_socket_verification(),
                 self.connected_url.hostname,
                 self.connected_url.get_port_auto(),
                 self.tls_props.as_ref(),
@@ -4216,7 +4247,7 @@ impl<'a> HTTPClient<'a> {
                 Self::ssl_ctx_mut(ctx).release_socket(
                     socket,
                     self.flags.did_have_handshaking_error && !self.flags.reject_unauthorized,
-                    self.flags.reject_unauthorized,
+                    self.pooled_socket_verification(),
                     self.connected_url.hostname,
                     self.connected_url.get_port_auto(),
                     self.tls_props.as_ref(),
@@ -4402,7 +4433,7 @@ impl<'a> HTTPClient<'a> {
         Self::ssl_ctx_mut(ctx).release_socket(
             socket,
             self.flags.did_have_handshaking_error && !self.flags.reject_unauthorized,
-            self.flags.reject_unauthorized,
+            self.pooled_socket_verification(),
             self.url.hostname,
             self.url.get_port_auto(),
             self.tls_props.as_ref(),

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -857,6 +857,42 @@ test("HTTPS target through proxy with passing checkServerIdentity round-trips", 
   expect(verified).toEqual(["localhost"]);
 });
 
+test("HTTPS target through proxy reuses the tunnel across checkServerIdentity requests", async () => {
+  using target = Bun.serve({ port: 0, tls: tlsCert, fetch: () => new Response("ok") });
+  httpProxyServer.log.length = 0;
+  const verified: string[] = [];
+  const withCallback = () => ({
+    proxy: httpProxyServer.url,
+    tls: {
+      ca: tlsCert.cert,
+      checkServerIdentity(hostname: string) {
+        verified.push(hostname);
+        return undefined;
+      },
+    },
+  });
+  const connects = () => httpProxyServer.log.filter(l => l.startsWith("CONNECT")).length;
+
+  for (let i = 0; i < 3; i++) {
+    expect(await fetch(target.url, withCallback()).then(r => r.text())).toBe("ok");
+  }
+  expect(verified).toEqual(["localhost"]);
+  expect(connects()).toBe(1);
+
+  // A strict request without a callback does not inherit the callback-approved
+  // tunnel, and vice versa.
+  expect(await fetch(target.url, { proxy: httpProxyServer.url, tls: { ca: tlsCert.cert } }).then(r => r.text())).toBe(
+    "ok",
+  );
+  expect(connects()).toBe(2);
+  expect(await fetch(target.url, withCallback()).then(r => r.text())).toBe("ok");
+  expect(await fetch(target.url, { proxy: httpProxyServer.url, tls: { ca: tlsCert.cert } }).then(r => r.text())).toBe(
+    "ok",
+  );
+  expect(connects()).toBe(2);
+  expect(verified).toEqual(["localhost"]);
+});
+
 test("HTTPS target through proxy with rejecting checkServerIdentity transmits nothing to the target", async () => {
   // Raw TLS target so we can observe exactly which decrypted bytes (if any)
   // reach it before the pinning callback rejects the certificate.

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -525,10 +525,11 @@ describe.concurrent("fetch-tls", () => {
     }
   });
 
-  it("runs checkServerIdentity on its own connection for each request that supplies it", async () => {
+  // A keep-alive HTTPS server that counts accepted TCP connections (not
+  // completed handshakes, so a client that aborts after verifying still counts).
+  async function countingKeepAliveServer() {
     let connections = 0;
     const server = tls.createServer({ key: validTls.key, cert: validTls.cert }, socket => {
-      connections++;
       const chunks: Buffer[] = [];
       socket.on("data", chunk => {
         chunks.push(chunk);
@@ -539,31 +540,108 @@ describe.concurrent("fetch-tls", () => {
       });
       socket.on("error", () => {});
     });
-    try {
-      const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
-      server.listen(0, onListening);
-      await listening;
-      const port = (server.address() as import("node:net").AddressInfo).port;
-      const url = `https://127.0.0.1:${port}/`;
+    server.on("connection", () => connections++);
+    const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+    server.listen(0, onListening);
+    await listening;
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    return {
+      url: `https://127.0.0.1:${port}/`,
+      get connections() {
+        return connections;
+      },
+      [Symbol.dispose]() {
+        server.close();
+      },
+    };
+  }
 
-      const verified: string[] = [];
-      const tlsWithCallback = {
-        ca: validTls.cert,
-        checkServerIdentity(hostname: string) {
-          verified.push(hostname);
-          return undefined;
+  // https://github.com/oven-sh/bun/issues/40308
+  it("reuses the keep-alive connection across requests that supply checkServerIdentity", async () => {
+    using server = await countingKeepAliveServer();
+    const seen: { hostname: string; fingerprint: string }[] = [];
+    for (let i = 0; i < 4; i++) {
+      const res = await fetch(server.url, {
+        tls: {
+          ca: validTls.cert,
+          // fresh closure per request, as most callers write it
+          checkServerIdentity(hostname: string, cert: tls.PeerCertificate) {
+            seen.push({ hostname, fingerprint: cert.fingerprint256 });
+            return undefined;
+          },
         },
-      };
-
-      expect(await fetch(url, { tls: tlsWithCallback }).then(res => res.text())).toBe("ok");
-      expect(await fetch(url, { tls: { ca: validTls.cert } }).then(res => res.text())).toBe("ok");
-      expect(await fetch(url, { tls: tlsWithCallback }).then(res => res.text())).toBe("ok");
-
-      expect(verified).toEqual(["127.0.0.1", "127.0.0.1"]);
-      expect(connections).toBe(3);
-    } finally {
-      server.close();
+      });
+      expect(await res.text()).toBe("ok");
     }
+    // Like Node's https.Agent: the callback runs when a connection is
+    // established, and later requests reuse the approved connection.
+    expect(seen).toEqual([{ hostname: "127.0.0.1", fingerprint: expect.any(String) }]);
+    expect(server.connections).toBe(1);
+  });
+
+  it("keeps connections approved by checkServerIdentity and natively verified ones in separate pools", async () => {
+    using server = await countingKeepAliveServer();
+    const verified: string[] = [];
+    const tlsWithCallback = {
+      ca: validTls.cert,
+      checkServerIdentity(hostname: string) {
+        verified.push(hostname);
+        return undefined;
+      },
+    };
+
+    // 1st connection, identity approved by the callback.
+    expect(await fetch(server.url, { tls: tlsWithCallback }).then(res => res.text())).toBe("ok");
+    expect(server.connections).toBe(1);
+    // No callback: must verify natively on its own (2nd) connection rather than
+    // inherit the callback's verdict.
+    expect(await fetch(server.url, { tls: { ca: validTls.cert } }).then(res => res.text())).toBe("ok");
+    expect(server.connections).toBe(2);
+    // Each kind keeps reusing its own connection.
+    expect(await fetch(server.url, { tls: tlsWithCallback }).then(res => res.text())).toBe("ok");
+    expect(await fetch(server.url, { tls: { ca: validTls.cert } }).then(res => res.text())).toBe("ok");
+    expect(server.connections).toBe(2);
+    expect(verified).toEqual(["127.0.0.1"]);
+  });
+
+  it("a checkServerIdentity request never takes a pooled connection established with NODE_TLS_REJECT_UNAUTHORIZED=0", async () => {
+    // Self-signed and not in any CA store: only a lax request can connect.
+    // NODE_TLS_REJECT_UNAUTHORIZED (rather than tls.rejectUnauthorized) keeps
+    // lax and strict requests on the same default TLS context / pool key.
+    using server = await countingKeepAliveServer();
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const url = process.argv[1];
+          process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+          for (let i = 0; i < 2; i++) await fetch(url).then(r => r.text());
+          process.env.NODE_TLS_REJECT_UNAUTHORIZED = "1";
+          let calls = 0;
+          const result = await fetch(url, { tls: { checkServerIdentity: () => void calls++ } }).then(
+            r => r.text(),
+            e => e.code,
+          );
+          // Back to lax: the pooled connection is still there for it.
+          process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+          await fetch(url).then(r => r.text());
+          console.log(JSON.stringify({ result, calls }));
+        `,
+        server.url,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    // Had it taken the pooled connection, the request would have succeeded;
+    // instead it dialed its own (2nd) connection, which failed chain
+    // verification before the callback could run. The final lax request found
+    // the 1st connection still pooled.
+    expect(JSON.parse(stdout)).toEqual({ result: "DEPTH_ZERO_SELF_SIGNED_CERT", calls: 0 });
+    expect(server.connections).toBe(2);
+    expect(exitCode).toBe(0);
   });
 
   it("honors a tls.ciphers list on the request", async () => {


### PR DESCRIPTION
## What

Fixes #40308. Since 1.4.0 (#33072), a `fetch` whose `tls` options include a `checkServerIdentity` callback never entered or took from the keep-alive pool, so every request paid a full TCP+TLS handshake. 1.3.x pooled these.

This restores pooling while keeping the property #33072 was after — a peer accepted by a JS callback is not silently inherited by a request that relies on the native hostname check (and vice versa) — by keeping them in separate pools:

- Each pooled socket / CONNECT tunnel / h2 session records a `PeerVerification`: `None` (`rejectUnauthorized: false`), `Callback` (chain verified, identity approved by `checkServerIdentity`), or `Native` (chain + native hostname check). This replaces the `established_with_reject_unauthorized: bool` that already separated lax from strict.
- A request only takes a pooled connection verified the way it would verify a fresh one (`rejectUnauthorized: false` may take any). The level is sticky, so a lax request borrowing a strict connection doesn't downgrade it when re-pooling.
- The callback runs once per connection, when it is established — same as 1.3 and Node's `https.Agent` (whose pool key doesn't include `checkServerIdentity` either). Two different callbacks for the same host + TLS config share the `Callback` pool; a request that needs its callback consulted every time can pass `keepalive: false`.

I considered re-running the callback against the pooled peer certificate on every reuse; it works, but parks an idle keep-alive socket for a JS round-trip before the first byte is written, which turns ordinary server idle-closes / unsolicited 408s during that window into request failures (or double callback invocations on retry). Per-connection semantics avoid that and match prior behavior.

Issue repro (5 sequential fetches through a counting TCP proxy):

```
                              1.3.14   1.4.1   this PR
ca[] only                     1        1       1
ca[] + checkServerIdentity    1        5       1
```

## Tests

`test/js/web/fetch/fetch.tls.test.ts`:
- reuses one connection across callback-bearing requests (fresh closure each time); callback ran once
- callback-approved and natively-verified connections stay in separate pools and each keeps being reused
- a callback request never takes a connection established under `NODE_TLS_REJECT_UNAUTHORIZED=0` (fails its own chain verification instead)

`test/js/bun/http/proxy.test.ts`: same for a CONNECT tunnel through an HTTP proxy.

The first two and the proxy test fail on 1.4.1. Also ran `proxy.test.ts`, `proxy-stress-*.test.ts`, `fetch-keepalive.test.ts`, `fetch-http2-*.test.ts`, `node-http2.test.js`, `fetch-tls-cert.test.ts`, `node-tls-cert.test.ts`, `fetch.tls.wildcard.test.ts` locally (debug build), all passing. One of ~8 full `proxy.test.ts` runs reported "2 errors" between tests that I could not reproduce afterwards; flagging in case CI sees it.