### PR TITLE
h2 server tests: fixture file with flags, shared session that reconnects; H2 = 2, H3 = 3

### DIFF
--- a/packages/bun-uws/src/Http2App.h
+++ b/packages/bun-uws/src/Http2App.h
@@ -52,7 +52,6 @@ struct H2App {
     void clearRoutes() { http2Context->clearRoutes(); }
     /* GOAWAY + close every connection. */
     void close() { http2Context->closeAll(); }
-    size_t closeIdle(bool closeWhenIdle = false) { return http2Context->closeIdle(closeWhenIdle); }
     void *getNativeHandle() { return http2Context; }
 };
 

--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -260,7 +260,7 @@ struct Http2Response {
     }
 
     Http2Response *writeHeader(std::string_view key, uint64_t value) {
-        char buf[std::numeric_limits<uint64_t>::digits10 + 1];
+        char buf[utils::U64_MAX_DIGITS];
         auto r = std::to_chars(buf, buf + sizeof(buf), value);
         return writeHeader(key, std::string_view{buf, (size_t)(r.ptr - buf)});
     }

--- a/packages/bun-uws/src/Http3Response.h
+++ b/packages/bun-uws/src/Http3Response.h
@@ -39,7 +39,7 @@ struct Http3Response {
     }
 
     Http3Response *writeHeader(std::string_view key, uint64_t value) {
-        char buf[24];
+        char buf[utils::U64_MAX_DIGITS];
         auto r = std::to_chars(buf, buf + sizeof(buf), value);
         return writeHeader(key, std::string_view{buf, (size_t)(r.ptr - buf)});
     }

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -75,7 +75,7 @@ public:
 
     /* Write an unsigned 64-bit integer */
     void writeUnsigned64(uint64_t value) {
-        char buf[20];
+        char buf[utils::U64_MAX_DIGITS];
         int length = utils::u64toa(value, buf);
 
         /* For now we do this copy */

--- a/packages/bun-uws/src/Utilities.h
+++ b/packages/bun-uws/src/Utilities.h
@@ -22,7 +22,9 @@
 
 /* Various common utilities */
 
+#include <cstddef>
 #include <cstdint>
+#include <limits>
 
 namespace uWS {
 
@@ -45,6 +47,10 @@ static inline bool isConnectionSpecificResponseField(std::string_view name, std:
 
 namespace utils {
 
+/* Decimal digits in the largest uint64_t (18446744073709551615). Sizes the
+ * buffers u64toa and std::to_chars write into; neither appends a terminator. */
+static constexpr size_t U64_MAX_DIGITS = std::numeric_limits<uint64_t>::digits10 + 1;
+
 inline int u32toaHex(uint32_t value, char *dst) {
     char palette[] = "0123456789abcdef";
     char temp[10];
@@ -64,7 +70,7 @@ inline int u32toaHex(uint32_t value, char *dst) {
 }
 
 inline int u64toa(uint64_t value, char *dst) {
-    char temp[20];
+    char temp[U64_MAX_DIGITS];
     char *p = temp;
     do {
         *p++ = (char) ((value % 10) + '0');

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -886,11 +886,7 @@ impl ClientSession {
         self.maybe_release();
     }
 
-    /// Frame request bodies and write them until the socket pushes back (a
-    /// short write; onWritable resumes) or nothing more can be framed. A
-    /// single drain→flush is not enough: when the flush fully succeeds no
-    /// writable event follows, so a body larger than the buffer high-water
-    /// mark with window to spare would stall.
+    /// Drain and flush until backpressure or nothing is left: a full flush raises no onWritable.
     fn pump_send_bodies(&mut self) -> Result<(), Error> {
         loop {
             let more = encode::drain_send_bodies(self);
@@ -902,9 +898,6 @@ impl ClientSession {
     }
 
     fn handle_writable(&mut self) {
-        if let Err(err) = self.flush() {
-            return self.fail_all(err);
-        }
         if let Err(err) = self.pump_send_bodies() {
             return self.fail_all(err);
         }

--- a/src/http/h2_client/dispatch.rs
+++ b/src/http/h2_client/dispatch.rs
@@ -487,9 +487,7 @@ fn dispatch_frame(
             // SAFETY: stream pointer valid for session lifetime.
             let stream = stream_mut(stream_ptr);
             if stream.rst_done {
-                // Only the first RST_STREAM decides the outcome; a later
-                // STREAM_CLOSED for DATA we had in flight must not clobber a
-                // response already completed by RST_STREAM(NO_ERROR).
+                // First RST_STREAM wins; a later STREAM_CLOSED for in-flight DATA is ignored.
                 return;
             }
             let had_response = stream.remote_closed();

--- a/src/http/h2_client/encode.rs
+++ b/src/http/h2_client/encode.rs
@@ -363,8 +363,7 @@ pub(crate) fn drain_send_body(session: &mut ClientSession, stream: &mut Stream, 
     }
 }
 
-/// Returns `true` when it stopped at `WRITE_BUFFER_HIGH_WATER` with body
-/// bytes still sendable, i.e. the caller should flush and call again.
+/// True if it stopped at `WRITE_BUFFER_HIGH_WATER` with body bytes still sendable.
 pub(crate) fn drain_send_bodies(session: &mut ClientSession) -> bool {
     // Round-robin: each pass gives every uploader at most one
     // remote_max_frame_size slice before the next stream gets a turn, so

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -30,11 +30,11 @@ extern "C" void CookieMap__write(CookieMap* cookie_map, JSC::JSGlobalObject* glo
     case UWSResponseKind::SSL:
         CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::HttpResponse<true>*>(arg2));
         break;
-    case UWSResponseKind::H3:
-        CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::Http3Response*>(arg2));
-        break;
     case UWSResponseKind::H2:
         CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::Http2Response*>(arg2));
+        break;
+    case UWSResponseKind::H3:
+        CookieMap__writeFetchHeadersToUWSResponse(cookie_map, global_this, reinterpret_cast<uWS::Http3Response*>(arg2));
         break;
     }
 }

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -924,11 +924,11 @@ extern "C" void WebCore__FetchHeaders__toUWSResponse(WebCore::FetchHeaders* arg0
     case UWSResponseKind::SSL:
         writeFetchHeadersToUWSResponse<true>(*arg0, reinterpret_cast<uWS::HttpResponse<true>*>(arg2));
         break;
-    case UWSResponseKind::H3:
-        writeFetchHeadersToStreamResponse<uWS::Http3Response, uWS::Http3ResponseData>(*arg0, reinterpret_cast<uWS::Http3Response*>(arg2));
-        break;
     case UWSResponseKind::H2:
         writeFetchHeadersToStreamResponse<uWS::Http2Response, uWS::Http2ResponseData>(*arg0, reinterpret_cast<uWS::Http2Response*>(arg2));
+        break;
+    case UWSResponseKind::H3:
+        writeFetchHeadersToStreamResponse<uWS::Http3Response, uWS::Http3ResponseData>(*arg0, reinterpret_cast<uWS::Http3Response*>(arg2));
         break;
     }
 }

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -60,8 +60,8 @@ enum class BunErrorKind : uint8_t {
 enum class UWSResponseKind : int32_t {
     TCP = 0,
     SSL = 1,
-    H3 = 2,
-    H2 = 3,
+    H2 = 2,
+    H3 = 3,
 };
 #endif
 

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -54,8 +54,8 @@ pub use bun_uws_sys::WebSocketUpgradeContext;
 pub enum ResponseKind {
     Tcp = 0,
     Ssl = 1,
-    H3 = 2,
-    H2 = 3,
+    H2 = 2,
+    H3 = 3,
 }
 
 impl ResponseKind {
@@ -64,8 +64,8 @@ impl ResponseKind {
         match resp {
             AnyResponse::TCP(_) => ResponseKind::Tcp,
             AnyResponse::SSL(_) => ResponseKind::Ssl,
-            AnyResponse::H3(_) => ResponseKind::H3,
             AnyResponse::H2(_) => ResponseKind::H2,
+            AnyResponse::H3(_) => ResponseKind::H3,
         }
     }
 }

--- a/test/js/bun/http/serve-http2-fixture.ts
+++ b/test/js/bun/http/serve-http2-fixture.ts
@@ -233,6 +233,13 @@ async function handler(req: Request, server: Bun.Server<undefined>): Promise<Res
       await promise;
       return new Response(req.signal.aborted ? "aborted" : "kept");
     }
+    // server.timeout(req, s), then sleep ms before answering.
+    case "/t": {
+      const s = url.searchParams.get("s")!;
+      server.timeout(req, Number(s));
+      await Bun.sleep(Number(url.searchParams.get("ms")));
+      return new Response("t" + s);
+    }
   }
   return new Response("not found: " + url.pathname, { status: 404 });
 }

--- a/test/js/bun/http/serve-http2-fixture.ts
+++ b/test/js/bun/http/serve-http2-fixture.ts
@@ -1,0 +1,245 @@
+// Server fixture for serve-http2.test.ts. One long-lived Bun.serve({ http2: true })
+// per describe block, driven over real sockets by the test. Prints its port as
+// JSON on stdout once listening and stops on stdin EOF.
+//
+//   bun serve-http2-fixture.ts --big-file <path> [--tls] [--no-http1] [--http3] [--idle-timeout <s>]
+import { serve } from "bun";
+import { tls as tlsCert } from "harness";
+import { parseArgs } from "node:util";
+
+const { values: args } = parseArgs({
+  options: {
+    tls: { type: "boolean", default: false },
+    http1: { type: "boolean", default: true },
+    http3: { type: "boolean", default: false },
+    "idle-timeout": { type: "string", default: "30" },
+    "big-file": { type: "string" },
+  },
+  allowNegative: true,
+});
+const bigFile = args["big-file"]!;
+
+const big = Buffer.alloc(5 * 1024 * 1024, "abcdefghijklmnop");
+let lateRead: PromiseWithResolvers<void> | undefined;
+
+const makeRoutes = () => ({
+  "/api/:id": (req: Bun.BunRequest<"/api/:id">) =>
+    new Response("id=" + req.params.id, { headers: { "x-route": "api" } }),
+  "/route-only": { POST: () => new Response("posted") },
+  "/static": new Response("from-static-route", { headers: { "content-type": "text/plain", etag: '"v1"' } }),
+  "/static-hop": new Response("hop", {
+    headers: { connection: "keep-alive", "keep-alive": "timeout=5", te: "gzip", "x-kept": "1" },
+  }),
+  "/file-hop": new Response(Bun.file(bigFile), { headers: { connection: "close", upgrade: "x", "x-kept": "1" } }),
+  "/file-route": Bun.file(bigFile),
+  "/cookies": (req: Bun.BunRequest) => {
+    req.cookies.set("seen", (req.cookies.get("seen") ?? "") + "x");
+    return new Response("ok");
+  },
+});
+
+const server = serve({
+  port: 0,
+  tls: args.tls ? tlsCert : undefined,
+  http2: true,
+  http1: args.http1,
+  http3: args.http3,
+  idleTimeout: Number(args["idle-timeout"]),
+  routes: makeRoutes(),
+  fetch: handler,
+  websocket: { message() {} },
+});
+
+async function handler(req: Request, server: Bun.Server<undefined>): Promise<Response | undefined> {
+  const url = new URL(req.url);
+  switch (url.pathname) {
+    case "/hello":
+      return new Response("hello", { headers: { "x-proto": "h2", "content-type": "text/plain" } });
+    case "/echo": {
+      const body = await req.text();
+      return new Response(body, {
+        status: 201,
+        headers: { "x-method": req.method, "x-echo": req.headers.get("x-echo") ?? "", "x-len": String(body.length) },
+      });
+    }
+    case "/echo-bytes": {
+      const body = await req.arrayBuffer();
+      return new Response(body, { headers: { "x-len": String(body.byteLength) } });
+    }
+    case "/digest": {
+      const hash = new Bun.CryptoHasher("sha256");
+      let n = 0;
+      for await (const chunk of req.body!) {
+        hash.update(chunk);
+        n += chunk.byteLength;
+      }
+      return new Response(hash.digest("hex"), { headers: { "x-len": String(n) } });
+    }
+    case "/big":
+      return new Response(big, { headers: { "content-type": "application/octet-stream" } });
+    case "/stream": {
+      let i = 0;
+      return new Response(
+        new ReadableStream({
+          pull(controller) {
+            if (i++ >= 64) return controller.close();
+            controller.enqueue(new TextEncoder().encode("chunk" + i + Buffer.alloc(1019, ";").toString()));
+          },
+        }),
+        { headers: { "content-type": "text/plain" } },
+      );
+    }
+    case "/file":
+      return new Response(Bun.file(bigFile));
+    case "/file-stream":
+      return new Response(Bun.file(bigFile).stream());
+    case "/status/204":
+      return new Response(null, { status: 204, headers: { "x-empty": "1" } });
+    case "/headers": {
+      const out: Record<string, string> = {};
+      for (const [k, v] of req.headers) out[k] = v;
+      return Response.json({ url: req.url, method: req.method, headers: out });
+    }
+    case "/set-cookies":
+      return new Response("ok", {
+        headers: [
+          ["set-cookie", "a=1"],
+          ["set-cookie", "b=2"],
+          ["x-multi", "1"],
+          ["x-multi", "2"],
+        ],
+      });
+    case "/many-headers": {
+      const h = new Headers();
+      for (let i = 0; i < 3000; i++) h.set("x-header-" + i, "x-value-" + i);
+      return new Response("ok", { headers: h });
+    }
+    case "/hop-headers":
+      return new Response("hi", {
+        headers: {
+          "transfer-encoding": "chunked",
+          connection: "close",
+          "keep-alive": "timeout=5",
+          upgrade: "websocket",
+          "proxy-connection": "x",
+          "x-kept": "1",
+        },
+      });
+    case "/empty":
+      return new Response("");
+    case "/pull-1mb": {
+      // 8 x 1 MiB, each pull resolved from a microtask so every write lands
+      // outside a socket event.
+      let i = 0;
+      return new Response(
+        new ReadableStream({
+          async pull(c) {
+            await null;
+            if (i++ < 8) c.enqueue(new Uint8Array(1 << 20).fill(i));
+            else c.close();
+          },
+        }),
+      );
+    }
+    case "/big-headers": {
+      const n = Number(url.searchParams.get("kb") ?? "12");
+      return new Response("x", { headers: { "x-pad": Buffer.alloc(n * 1024, "p").toString() } });
+    }
+    case "/small":
+      return Response.json({ ok: true });
+    case "/fixed":
+      return new Response(Buffer.alloc(Number(url.searchParams.get("n") ?? "264"), "a"));
+    case "/read-report": {
+      try {
+        await req.text();
+        console.error("READ-OK");
+      } catch {
+        console.error("READ-ERR");
+      }
+      return new Response("x");
+    }
+    case "/infinite":
+      return new Response(
+        new ReadableStream({
+          pull(c) {
+            c.enqueue(new Uint8Array(16384));
+          },
+          cancel() {
+            console.error("CANCELLED");
+          },
+        }),
+      );
+    case "/slow-read": {
+      // Consumes the body with a pause after every chunk; ?ms= sets the pause.
+      const ms = Number(url.searchParams.get("ms") ?? "0");
+      let n = 0;
+      for await (const c of req.body!) {
+        n += c.length;
+        if (ms) await Bun.sleep(ms);
+      }
+      return new Response(String(n));
+    }
+    case "/ip":
+      return Response.json(server.requestIP(req));
+    case "/upgrade":
+      return new Response(String(server.upgrade(req)), { status: 200 });
+    case "/ws":
+      if (server.upgrade(req)) return;
+      return new Response("upgrade failed", { status: 400 });
+    case "/late-read": {
+      // Reads the body only once GET /release-late-read arrives.
+      await (lateRead ??= Promise.withResolvers()).promise;
+      let n = 0;
+      for await (const c of req.body!) n += c.length;
+      return new Response(String(n));
+    }
+    case "/release-late-read":
+      (lateRead ??= Promise.withResolvers()).resolve();
+      lateRead = undefined;
+      return new Response("released");
+    case "/slow": {
+      await Bun.sleep(Number(url.searchParams.get("ms") ?? "50"));
+      return new Response("slow");
+    }
+    case "/abort": {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      req.signal.addEventListener("abort", () => {
+        console.error("ABORTED");
+        resolve();
+      });
+      await promise;
+      return new Response("unreachable");
+    }
+    case "/passthrough":
+      return new Response(req.body, { headers: { "x-passthrough": "1" } });
+    case "/stop":
+      setTimeout(() => server.stop(), 0);
+      return new Response("stopping");
+    case "/reload":
+      server.reload({
+        routes: { ...makeRoutes(), "/reloaded-route": new Response("after-reload") },
+        fetch: handler,
+        websocket: { message() {} },
+      });
+      return new Response("reloaded");
+    case "/keepalive": {
+      server.timeout(req, 0);
+      const { promise, resolve } = Promise.withResolvers<void>();
+      req.signal.addEventListener("abort", () => {
+        console.error("KEEPALIVE-ABORTED");
+        resolve();
+      });
+      setTimeout(resolve, Number(url.searchParams.get("ms")));
+      await promise;
+      return new Response(req.signal.aborted ? "aborted" : "kept");
+    }
+  }
+  return new Response("not found: " + url.pathname, { status: 404 });
+}
+
+console.log(JSON.stringify({ port: server.port }));
+process.stdin.on("end", () => {
+  server.stop(true);
+  process.stderr.write("", () => process.exit(0));
+});
+process.stdin.resume();

--- a/test/js/bun/http/serve-http2-helpers.ts
+++ b/test/js/bun/http/serve-http2-helpers.ts
@@ -17,18 +17,29 @@ export type Fixture = {
   [Symbol.asyncDispose](): Promise<void>;
 };
 
-// Not bunRun: that helper ignores stdin and awaits exit, and this server must
-// stay up for the whole describe block.
-export async function startFixture(opts: {
+export type FixtureOptions = {
   tls: boolean;
   http1?: boolean;
   http3?: boolean;
   idleTimeout?: number;
   execArgv?: string[];
-}): Promise<Fixture> {
+};
+
+// Not bunRun: that helper ignores stdin and awaits exit, and this server must
+// stay up for the whole describe block.
+export async function startFixture(opts: FixtureOptions): Promise<Fixture> {
   // The file behind the Bun.file routes. Per fixture, so that no module-level
   // hook has to outlive the test file that first imported this module.
   const dir = tempDir("serve-http2", { "big.bin": Buffer.alloc(3 * 1024 * 1024 + 17, "0123456789") });
+  try {
+    return await spawnFixture(opts, dir);
+  } catch (err) {
+    dir[Symbol.dispose]();
+    throw err;
+  }
+}
+
+async function spawnFixture(opts: FixtureOptions, dir: ReturnType<typeof tempDir>): Promise<Fixture> {
   const proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/bun/http/serve-http2-helpers.ts
+++ b/test/js/bun/http/serve-http2-helpers.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { bunEnv, bunExe, tempDir, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import http2 from "node:http2";
 import net from "node:net";
 import { join } from "node:path";
@@ -7,161 +7,8 @@ import tls from "node:tls";
 
 // ─── fixture ────────────────────────────────────────────────────────────────
 // One long-lived server per describe block, driven over real sockets. The
-// fixture reports its port on stdout and stops on stdin EOF.
-
-export const fixtureSource = (opts: { tls: boolean; http1?: boolean; http3?: boolean; extra?: string }) => `
-import { serve } from "bun";
-const big = Buffer.alloc(5 * 1024 * 1024, "abcdefghijklmnop");
-let lateRead;
-const makeRoutes = () => ({
-    "/api/:id": req => new Response("id=" + req.params.id, { headers: { "x-route": "api" } }),
-    "/route-only": { POST: () => new Response("posted") },
-    "/static": new Response("from-static-route", { headers: { "content-type": "text/plain", etag: '"v1"' } }),
-    "/static-hop": new Response("hop", { headers: { connection: "keep-alive", "keep-alive": "timeout=5", te: "gzip", "x-kept": "1" } }),
-    "/file-hop": new Response(Bun.file(process.env.BIG_FILE), { headers: { connection: "close", upgrade: "x", "x-kept": "1" } }),
-    "/file-route": Bun.file(process.env.BIG_FILE),
-    "/cookies": req => {
-      req.cookies.set("seen", (req.cookies.get("seen") ?? "") + "x");
-      return new Response("ok");
-    },
-});
-const routes = makeRoutes();
-const server = serve({
-  port: 0,
-  ${opts.tls ? `tls: ${JSON.stringify(tlsCert)},` : ""}
-  http2: true,
-  http1: ${opts.http1 ?? true},
-  ${opts.http3 ? "http3: true," : ""}
-  idleTimeout: Number(process.env.IDLE_TIMEOUT ?? 30),
-  routes,
-  fetch: handler,
-  websocket: { message() {} },
-  ${opts.extra ?? ""}
-});
-async function handler(req, server) {
-    const url = new URL(req.url);
-    switch (url.pathname) {
-      case "/hello":
-        return new Response("hello", { headers: { "x-proto": "h2", "content-type": "text/plain" } });
-      case "/echo": {
-        const body = await req.text();
-        return new Response(body, {
-          status: 201,
-          headers: { "x-method": req.method, "x-echo": req.headers.get("x-echo") ?? "", "x-len": String(body.length) },
-        });
-      }
-      case "/echo-bytes": {
-        const body = await req.arrayBuffer();
-        return new Response(body, { headers: { "x-len": String(body.byteLength) } });
-      }
-      case "/digest": {
-        const hash = new Bun.CryptoHasher("sha256");
-        let n = 0;
-        for await (const chunk of req.body) { hash.update(chunk); n += chunk.byteLength; }
-        return new Response(hash.digest("hex"), { headers: { "x-len": String(n) } });
-      }
-      case "/big":
-        return new Response(big, { headers: { "content-type": "application/octet-stream" } });
-      case "/stream": {
-        let i = 0;
-        return new Response(new ReadableStream({
-          pull(controller) {
-            if (i++ >= 64) return controller.close();
-            controller.enqueue(new TextEncoder().encode("chunk" + i + Buffer.alloc(1019, ";").toString()));
-          },
-        }), { headers: { "content-type": "text/plain" } });
-      }
-      case "/file":
-        return new Response(Bun.file(process.env.BIG_FILE));
-      case "/file-stream":
-        return new Response(Bun.file(process.env.BIG_FILE).stream());
-      case "/status/204":
-        return new Response(null, { status: 204, headers: { "x-empty": "1" } });
-      case "/headers": {
-        const out = {};
-        for (const [k, v] of req.headers) out[k] = v;
-        return Response.json({ url: req.url, method: req.method, headers: out });
-      }
-      case "/set-cookies":
-        return new Response("ok", { headers: [["set-cookie", "a=1"], ["set-cookie", "b=2"], ["x-multi", "1"], ["x-multi", "2"]] });
-      case "/many-headers": {
-        const h = new Headers();
-        for (let i = 0; i < 3000; i++) h.set("x-header-" + i, "x-value-" + i);
-        return new Response("ok", { headers: h });
-      }
-      case "/hop-headers":
-        return new Response("hi", { headers: { "transfer-encoding": "chunked", connection: "close", "keep-alive": "timeout=5", upgrade: "websocket", "proxy-connection": "x", "x-kept": "1" } });
-      case "/empty":
-        return new Response("");
-      case "/pull-1mb": {
-        let i = 0;
-        return new Response(new ReadableStream({ async pull(c) { await null; if (i++ < 8) c.enqueue(new Uint8Array(1 << 20).fill(i)); else c.close(); } }));
-      }
-      case "/big-headers": {
-        const n = Number(url.searchParams.get("kb") ?? "12");
-        return new Response("x", { headers: { "x-pad": Buffer.alloc(n * 1024, "p").toString() } });
-      }
-      case "/small":
-        return Response.json({ ok: true });
-      case "/fixed":
-        return new Response(Buffer.alloc(Number(url.searchParams.get("n") ?? "264"), "a"));
-      case "/read-report": {
-        try { await req.text(); console.error("READ-OK"); } catch { console.error("READ-ERR"); }
-        return new Response("x");
-      }
-      case "/infinite":
-        return new Response(new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(16384)); }, cancel() { console.error("CANCELLED"); } }));
-      case "/ip":
-        return Response.json(server.requestIP(req));
-      case "/upgrade":
-        return new Response(String(server.upgrade(req)), { status: 200 });
-      case "/ws":
-        if (server.upgrade(req)) return;
-        return new Response("upgrade failed", { status: 400 });
-      case "/late-read": {
-        // Reads the body only once GET /release-late-read arrives.
-        await (lateRead ??= Promise.withResolvers()).promise;
-        let n = 0;
-        for await (const c of req.body) n += c.length;
-        return new Response(String(n));
-      }
-      case "/release-late-read":
-        (lateRead ??= Promise.withResolvers()).resolve();
-        lateRead = undefined;
-        return new Response("released");
-      case "/slow": {
-        await Bun.sleep(Number(url.searchParams.get("ms") ?? "50"));
-        return new Response("slow");
-      }
-      case "/abort": {
-        const { promise, resolve } = Promise.withResolvers();
-        req.signal.addEventListener("abort", () => { console.error("ABORTED"); resolve(); });
-        await promise;
-        return new Response("unreachable");
-      }
-      case "/passthrough":
-        return new Response(req.body, { headers: { "x-passthrough": "1" } });
-      case "/stop":
-        setTimeout(() => server.stop(), 0);
-        return new Response("stopping");
-      case "/reload":
-        server.reload({ routes: { ...makeRoutes(), "/reloaded-route": new Response("after-reload") }, fetch: handler, websocket: { message() {} } });
-        return new Response("reloaded");
-      case "/keepalive": {
-        server.timeout(req, 0);
-        const { promise, resolve } = Promise.withResolvers();
-        req.signal.addEventListener("abort", () => { console.error("KEEPALIVE-ABORTED"); resolve(); });
-        setTimeout(resolve, Number(url.searchParams.get("ms")));
-        await promise;
-        return new Response(req.signal.aborted ? "aborted" : "kept");
-      }
-    }
-    return new Response("not found: " + url.pathname, { status: 404 });
-}
-console.log(JSON.stringify({ port: server.port }));
-process.stdin.on("end", () => { server.stop(true); process.stderr.write("", () => process.exit(0)); });
-process.stdin.resume();
-`;
+// server lives in serve-http2-fixture.ts; it reports its port on stdout and
+// stops on stdin EOF.
 
 export type Fixture = {
   port: number;
@@ -170,29 +17,32 @@ export type Fixture = {
   [Symbol.asyncDispose](): Promise<void>;
 };
 
-export let bigFileDir: ReturnType<typeof tempDir> | undefined;
-afterAll(() => {
-  bigFileDir?.[Symbol.dispose]();
-  bigFileDir = undefined;
-});
-export function bigFilePath() {
-  if (!bigFileDir) {
-    bigFileDir = tempDir("serve-http2", { "big.bin": Buffer.alloc(3 * 1024 * 1024 + 17, "0123456789") });
-  }
-  return join(String(bigFileDir), "big.bin");
-}
-
+// Not bunRun: that helper ignores stdin and awaits exit, and this server must
+// stay up for the whole describe block.
 export async function startFixture(opts: {
   tls: boolean;
   http1?: boolean;
   http3?: boolean;
-  extra?: string;
   idleTimeout?: number;
   execArgv?: string[];
 }): Promise<Fixture> {
+  // The file behind the Bun.file routes. Per fixture, so that no module-level
+  // hook has to outlive the test file that first imported this module.
+  const dir = tempDir("serve-http2", { "big.bin": Buffer.alloc(3 * 1024 * 1024 + 17, "0123456789") });
   const proc = Bun.spawn({
-    cmd: [bunExe(), ...(opts.execArgv ?? []), "-e", fixtureSource(opts)],
-    env: { ...bunEnv, BIG_FILE: bigFilePath(), IDLE_TIMEOUT: String(opts.idleTimeout ?? 30) },
+    cmd: [
+      bunExe(),
+      ...(opts.execArgv ?? []),
+      join(import.meta.dir, "serve-http2-fixture.ts"),
+      "--big-file",
+      join(String(dir), "big.bin"),
+      "--idle-timeout",
+      String(opts.idleTimeout ?? 30),
+      ...(opts.tls ? ["--tls"] : []),
+      ...(opts.http1 === false ? ["--no-http1"] : []),
+      ...(opts.http3 ? ["--http3"] : []),
+    ],
+    env: bunEnv,
     stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
@@ -217,20 +67,63 @@ export async function startFixture(opts: {
     async [Symbol.asyncDispose]() {
       proc.stdin.end();
       await proc.exited;
+      dir[Symbol.dispose]();
     },
   };
 }
 
 // ─── node:http2 client helpers ──────────────────────────────────────────────
 
-export function connectH2(port: number, secure: boolean): Promise<http2.ClientHttp2Session> {
+export function connectH2(
+  port: number,
+  secure: boolean,
+  options: http2.SecureClientSessionOptions = {},
+): Promise<http2.ClientHttp2Session> {
   return new Promise((resolve, reject) => {
     const session = http2.connect(`${secure ? "https" : "http"}://127.0.0.1:${port}`, {
       rejectUnauthorized: false,
+      ...options,
     });
     session.once("connect", () => resolve(session));
     session.once("error", reject);
   });
+}
+
+/** One node:http2 session shared by the tests of a describe block. The server
+ * closes a session that sits idle for the fixture's idleTimeout (30 s), and the
+ * raw-frame tests between two uses of it can take longer than that on a slow
+ * machine, so `get()` reconnects once the previous session is gone. Concurrent
+ * callers share one pending connect. */
+export class SharedSession {
+  #session: http2.ClientHttp2Session | undefined;
+  #connecting: Promise<http2.ClientHttp2Session> | undefined;
+
+  constructor(
+    private readonly port: number,
+    private readonly secure: boolean,
+  ) {}
+
+  get(): Promise<http2.ClientHttp2Session> {
+    if (this.#connecting) return this.#connecting;
+    const current = this.#session;
+    if (current && !current.destroyed && !current.closed) return Promise.resolve(current);
+    this.#connecting = connectH2(this.port, this.secure).then(
+      session => {
+        this.#session = session;
+        this.#connecting = undefined;
+        return session;
+      },
+      err => {
+        this.#connecting = undefined;
+        throw err;
+      },
+    );
+    return this.#connecting;
+  }
+
+  close() {
+    this.#session?.close();
+  }
 }
 
 export type H2Result = { status: number; headers: http2.IncomingHttpHeaders; body: Buffer };

--- a/test/js/bun/http/serve-http2-lifecycle.test.ts
+++ b/test/js/bun/http/serve-http2-lifecycle.test.ts
@@ -199,6 +199,24 @@ describe("Bun.serve http2 lifecycle", () => {
     session.close();
   }, 40000);
 
+  test("server.timeout(req, n) on h2: once the more permissive request ends, the remaining one's budget applies", async () => {
+    await using fx = await startFixture({ tls: false }); // idleTimeout 30
+    const session = await connectH2(fx.port, false);
+    const closed = new Promise<void>(r => session.once("close", () => r()));
+    // A keeps the 30 s default and answers after 1.5 s; B, opened while A is in
+    // flight, asks for 1 s and would answer after 60 s. While both are open the
+    // 30 s wins. Once A has retired, B's 1 s is the connection's budget: the
+    // server idles it out at the next 4 s tick, not 30 s later.
+    const a = request(session, { ":path": "/slow?ms=1500" });
+    const pending = request(session, { ":path": "/t?s=1&ms=60000" }).catch(e => e);
+    expect((await a).body.toString()).toBe("slow");
+    const t0 = Date.now();
+    await closed;
+    expect(Date.now() - t0).toBeLessThan(15000);
+    const result = await pending;
+    expect(result instanceof Error ? NaN : result.status).toBeNaN();
+  }, 30000);
+
   test("--max-http-header-size applies to h2 like HTTP/1.1", async () => {
     await using fx = await startFixture({ tls: false, execArgv: ["--max-http-header-size=4096"] });
     const big = Buffer.alloc(8192, "c").toString();

--- a/test/js/bun/http/serve-http2-lifecycle.test.ts
+++ b/test/js/bun/http/serve-http2-lifecycle.test.ts
@@ -187,11 +187,7 @@ describe("Bun.serve http2 lifecycle", () => {
   }
 
   test("server.timeout(req, n) on h2 is per connection: the most permissive open request wins", async () => {
-    await using fx = await startFixture({
-      tls: false,
-      idleTimeout: 8,
-      extra: `routes: { "/t": async (req, server) => { const u = new URL(req.url); server.timeout(req, Number(u.searchParams.get("s"))); await Bun.sleep(Number(u.searchParams.get("ms"))); return new Response("t" + u.searchParams.get("s")); } },`,
-    });
+    await using fx = await startFixture({ tls: false, idleTimeout: 8 });
     const session = await connectH2(fx.port, false);
     // One stream asks for 1 s, another for 30 s; both sleep 6 s. With per-request
     // semantics the first would be cut at the next tick; per-connection, 30 wins.

--- a/test/js/bun/http/serve-http2-lifecycle.test.ts
+++ b/test/js/bun/http/serve-http2-lifecycle.test.ts
@@ -127,14 +127,10 @@ describe("Bun.serve http2 lifecycle", () => {
 
   test("a paused (slowly read) request body does not idle out the connection", async () => {
     // usockets ticks timeouts in 4 s steps, so this needs real seconds.
-    await using fx = await startFixture({
-      tls: false,
-      idleTimeout: 2,
-      extra: `routes: { "/slow-read": async req => { let n = 0; for await (const c of req.body) { n += c.length; await Bun.sleep(700); } return new Response(String(n)); } },`,
-    });
+    await using fx = await startFixture({ tls: false, idleTimeout: 2 });
     const session = await connectH2(fx.port, false);
     const res = await new Promise<H2Result>((resolve, reject) => {
-      const r = session.request({ ":path": "/slow-read", ":method": "POST" }, { endStream: false });
+      const r = session.request({ ":path": "/slow-read?ms=700", ":method": "POST" }, { endStream: false });
       const chunks: Buffer[] = [];
       let headers: http2.IncomingHttpHeaders = {};
       r.on("response", h => (headers = h));

--- a/test/js/bun/http/serve-http2-protocol.test.ts
+++ b/test/js/bun/http/serve-http2-protocol.test.ts
@@ -1,10 +1,11 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import http2 from "node:http2";
 import {
   F,
   Fixture,
   PREFACE,
   RawH2,
+  SharedSession,
   T,
   baseHeaders,
   connectH2,
@@ -44,13 +45,17 @@ const barrier = async (raw: RawH2, tag: string) => {
 };
 
 let fx: Fixture;
+let shared: SharedSession;
 let session: http2.ClientHttp2Session;
 beforeAll(async () => {
   fx = await startFixture({ tls: secure });
-  session = await connectH2(fx.port, secure);
+  shared = new SharedSession(fx.port, secure);
+});
+beforeEach(async () => {
+  session = await shared.get();
 });
 afterAll(async () => {
-  session?.close();
+  shared?.close();
   await fx?.[Symbol.asyncDispose]();
   if (fx && fx.proc.exitCode !== 0) console.error(fx.stderr());
   expect(fx?.proc.signalCode ?? null).toBeNull();
@@ -899,14 +904,9 @@ describe.concurrent("Bun.serve http2 protocol", () => {
     expect((await raw.body(1)).toString()).toBe("ok");
     raw.close();
     // nghttp2's client defaults to 128 header pairs; raise it for this response.
-    const wide = http2.connect(`${secure ? "https" : "http"}://127.0.0.1:${fx.port}`, {
-      rejectUnauthorized: false,
+    const wide = await connectH2(fx.port, secure, {
       maxHeaderListPairs: 4000,
       settings: { maxHeaderListSize: 1 << 20 },
-    });
-    await new Promise<void>((res, rej) => {
-      wide.once("connect", () => res());
-      wide.once("error", rej);
     });
     const res = await request(wide, { ":path": "/many-headers" });
     wide.close();

--- a/test/js/bun/http/serve-http2.test.ts
+++ b/test/js/bun/http/serve-http2.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { randomBytes } from "crypto";
 import { bunEnv, bunExe, tempDir, tls as tlsCert } from "harness";
 import http2 from "node:http2";
@@ -10,6 +10,7 @@ import {
   Fixture,
   PREFACE,
   RawH2,
+  SharedSession,
   T,
   baseHeaders,
   connectH2,
@@ -24,14 +25,18 @@ import {
 for (const secure of [true, false]) {
   describe(`Bun.serve http2 (${secure ? "TLS + ALPN" : "cleartext prior-knowledge"})`, () => {
     let fx: Fixture;
+    let shared: SharedSession;
     let session: http2.ClientHttp2Session;
 
     beforeAll(async () => {
       fx = await startFixture({ tls: secure });
-      session = await connectH2(fx.port, secure);
+      shared = new SharedSession(fx.port, secure);
+    });
+    beforeEach(async () => {
+      session = await shared.get();
     });
     afterAll(async () => {
-      session.close();
+      shared.close();
       await fx[Symbol.asyncDispose]();
       if (fx.proc.exitCode !== 0) console.error(fx.stderr());
       expect(fx.proc.signalCode).toBeNull();


### PR DESCRIPTION
Follow-ups for #40137, rebased onto `claude/bun-serve-http2` at 015ad9b7e9 (the alii #3 review round and the main merges).

### Changes
- The inline server template moves to `test/js/bun/http/serve-http2-fixture.ts`. `startFixture` spawns it with flags: `--big-file`, `--idle-timeout`, `--tls`, `--no-http1`, `--http3`. `execArgv` still goes in front of the script. The `extra` route injection is gone: `/slow-read?ms=700` and `/t?s=<timeout>&ms=<sleep>` (the route of the per-connection `server.timeout` test) are fixture routes. (cirospaciari, `serve-http2.test.ts:14`)
- The Bun.file fixture is created per fixture and disposed with it (also when the spawn or the port read fails). The helpers module no longer registers an `afterAll` of its own: with the three files in one `bun test` process that hook runs at the end of the first file only, so a file that comes later leaves its directory behind.
- `SharedSession` holds the node:http2 session a describe block shares. The server closes a session that sits idle for the fixture's `idleTimeout` (30 s), which the raw-frame tests between two uses of it can exceed on a slow machine (the "session has been destroyed" cascade on darwin in build 105120). `get()` reconnects once the previous session is gone, and concurrent callers share one pending connect. Both suites with a shared session call it from `beforeEach`.
- `connectH2` takes session options. The 3000-header test uses it for `maxHeaderListPairs` and `SETTINGS_MAX_HEADER_LIST_SIZE`.
- New lifecycle test: a request that keeps the default budget answers while a sibling that asked for 1 s stays open. The connection is idled out at the next tick after the first one retires, not 30 s later. This pins the recompute on retire.
- `UWSResponseKind` and `ResponseKind`: `H2 = 2`, `H3 = 3`, and the switch arms follow that order. (cirospaciari, `headers-handwritten.h:58`)
- `src/http/h2_client`: the three doc comments and `handle_writable` carry the #40395 text, so the two PRs are byte-identical there and whichever lands second merges cleanly.
- `uWS::utils::U64_MAX_DIGITS` (`std::numeric_limits<uint64_t>::digits10 + 1`) sizes every uint64 decimal buffer: `u64toa`, `HttpResponse::writeUnsigned64`, `Http2Response::writeHeader`, `Http3Response::writeHeader`. `H2App::closeIdle` is removed, nothing called it.

### Verified
- `bun bd test` on the three h2 files plus `serve-http3.test.ts` in one process on the ASAN build: 311 pass. After the h2_client sync, fetch-http2-client (65), serve-http2 (74) and serve-http2-lifecycle (18) again: 157 pass.
- `bun-serve-cookies.test.ts` for the enum swap: passed on an earlier base, the enum hunk is unchanged since.

### Note on the evidence check
- The native changes here (enum renumbering, one constant for four buffer sizes, removal of an uncalled method) are behavior-neutral by design. No test can fail without them, so the fail-before check has nothing to prove for this PR. The test changes are verified by running the suites.
- The evidence runs also pull in `serve-body-leak.test.ts`, whose `leak <= 64 MB` RSS heuristic on the http/1.1 variant is the same as on main and jitters across runs (70 MB in one release run, 0 to 21 MB in others). This diff does not touch it.

<details><summary>Earlier revision</summary>

The first revision of this PR also fixed the deferred drain pass that never re-armed (`sweep()` reporting pending work so the deferred task stays registered) and the two `waitFor` loops that never yielded. Both landed on the base branch in 7f06a3427a55 and are gone from this diff.

</details>
