### PR TITLE
fetch h2 client: keep framing request bodies after a full flush, first RST_STREAM wins

### DIFF
--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -886,11 +886,8 @@ impl ClientSession {
         self.maybe_release();
     }
 
-    /// Frame request bodies and write them until the socket pushes back (a
-    /// short write; onWritable resumes) or nothing more can be framed. A
-    /// single drain→flush is not enough: when the flush fully succeeds no
-    /// writable event follows, so a body larger than the buffer high-water
-    /// mark with window to spare would stall.
+    /// Drain and flush until the socket pushes back (onWritable resumes) or nothing
+    /// is left to frame. A flush that writes everything raises no onWritable.
     fn pump_send_bodies(&mut self) -> Result<(), Error> {
         loop {
             let more = encode::drain_send_bodies(self);

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -886,8 +886,7 @@ impl ClientSession {
         self.maybe_release();
     }
 
-    /// Drain and flush until the socket pushes back (onWritable resumes) or nothing
-    /// is left to frame. A flush that writes everything raises no onWritable.
+    /// Drain and flush until backpressure or nothing is left: a full flush raises no onWritable.
     fn pump_send_bodies(&mut self) -> Result<(), Error> {
         loop {
             let more = encode::drain_send_bodies(self);

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -594,7 +594,7 @@ impl ClientSession {
         };
         client.state.response_stage = HTTPStage::Headers;
 
-        if let Err(err) = self.flush() {
+        if let Err(err) = self.pump_send_bodies() {
             self.fail_all(err);
             return;
         }
@@ -723,7 +723,7 @@ impl ClientSession {
         }
         self.rearm_timeout();
         encode::drain_send_body(self, stream_mut(stream), usize::MAX);
-        if let Err(err) = self.flush() {
+        if let Err(err) = self.pump_send_bodies() {
             self.fail_all(err);
         }
     }
@@ -830,8 +830,7 @@ impl ClientSession {
         if self.fatal_error.is_some() {
             return;
         }
-        encode::drain_send_bodies(self);
-        if let Err(err) = self.flush() {
+        if let Err(err) = self.pump_send_bodies() {
             return self.fail_all(err);
         }
 
@@ -887,12 +886,26 @@ impl ClientSession {
         self.maybe_release();
     }
 
+    /// Frame request bodies and write them until the socket pushes back (a
+    /// short write; onWritable resumes) or nothing more can be framed. A
+    /// single drain→flush is not enough: when the flush fully succeeds no
+    /// writable event follows, so a body larger than the buffer high-water
+    /// mark with window to spare would stall.
+    fn pump_send_bodies(&mut self) -> Result<(), Error> {
+        loop {
+            let more = encode::drain_send_bodies(self);
+            let backpressured = self.flush()?;
+            if !more || backpressured {
+                return Ok(());
+            }
+        }
+    }
+
     fn handle_writable(&mut self) {
         if let Err(err) = self.flush() {
             return self.fail_all(err);
         }
-        encode::drain_send_bodies(self);
-        if let Err(err) = self.flush() {
+        if let Err(err) = self.pump_send_bodies() {
             return self.fail_all(err);
         }
         self.reap_aborted();

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -898,9 +898,6 @@ impl ClientSession {
     }
 
     fn handle_writable(&mut self) {
-        if let Err(err) = self.flush() {
-            return self.fail_all(err);
-        }
         if let Err(err) = self.pump_send_bodies() {
             return self.fail_all(err);
         }

--- a/src/http/h2_client/dispatch.rs
+++ b/src/http/h2_client/dispatch.rs
@@ -487,9 +487,8 @@ fn dispatch_frame(
             // SAFETY: stream pointer valid for session lifetime.
             let stream = stream_mut(stream_ptr);
             if stream.rst_done {
-                // Only the first RST_STREAM decides the outcome; a later
-                // STREAM_CLOSED for DATA we had in flight must not clobber a
-                // response already completed by RST_STREAM(NO_ERROR).
+                // The first RST_STREAM decides; a second one (STREAM_CLOSED for
+                // DATA still in flight) must not overwrite it.
                 return;
             }
             let had_response = stream.remote_closed();

--- a/src/http/h2_client/dispatch.rs
+++ b/src/http/h2_client/dispatch.rs
@@ -487,8 +487,7 @@ fn dispatch_frame(
             // SAFETY: stream pointer valid for session lifetime.
             let stream = stream_mut(stream_ptr);
             if stream.rst_done {
-                // The first RST_STREAM decides; a second one (STREAM_CLOSED for
-                // DATA still in flight) must not overwrite it.
+                // First RST_STREAM wins; a later STREAM_CLOSED for in-flight DATA is ignored.
                 return;
             }
             let had_response = stream.remote_closed();

--- a/src/http/h2_client/dispatch.rs
+++ b/src/http/h2_client/dispatch.rs
@@ -486,6 +486,12 @@ fn dispatch_frame(
             };
             // SAFETY: stream pointer valid for session lifetime.
             let stream = stream_mut(stream_ptr);
+            if stream.rst_done {
+                // Only the first RST_STREAM decides the outcome; a later
+                // STREAM_CLOSED for DATA we had in flight must not clobber a
+                // response already completed by RST_STREAM(NO_ERROR).
+                return;
+            }
             let had_response = stream.remote_closed();
             stream.rst_done = true;
             stream.state = StreamState::Closed;

--- a/src/http/h2_client/encode.rs
+++ b/src/http/h2_client/encode.rs
@@ -363,8 +363,7 @@ pub(crate) fn drain_send_body(session: &mut ClientSession, stream: &mut Stream, 
     }
 }
 
-/// Returns `true` when it stopped at `WRITE_BUFFER_HIGH_WATER` with body
-/// bytes still sendable, i.e. the caller should flush and call again.
+/// True if it stopped at `WRITE_BUFFER_HIGH_WATER` with body bytes still sendable.
 pub(crate) fn drain_send_bodies(session: &mut ClientSession) -> bool {
     // Round-robin: each pass gives every uploader at most one
     // remote_max_frame_size slice before the next stream gets a turn, so

--- a/src/http/h2_client/encode.rs
+++ b/src/http/h2_client/encode.rs
@@ -363,12 +363,20 @@ pub(crate) fn drain_send_body(session: &mut ClientSession, stream: &mut Stream, 
     }
 }
 
-pub(crate) fn drain_send_bodies(session: &mut ClientSession) {
+/// Returns `true` when it stopped at `WRITE_BUFFER_HIGH_WATER` with body
+/// bytes still sendable, i.e. the caller should flush and call again.
+pub(crate) fn drain_send_bodies(session: &mut ClientSession) -> bool {
     // Round-robin: each pass gives every uploader at most one
     // remote_max_frame_size slice before the next stream gets a turn, so
     // the lowest-index stream can't monopolise conn_send_window.
     let slice: usize = session.remote_max_frame_size as usize;
-    while session.conn_send_window > 0 && session.write_buffer.size() < WRITE_BUFFER_HIGH_WATER {
+    loop {
+        if session.conn_send_window <= 0 {
+            return false;
+        }
+        if session.write_buffer.size() >= WRITE_BUFFER_HIGH_WATER {
+            return true;
+        }
         let mut progressed = false;
         // Iterating `session.streams.values()` while passing `session` mutably
         // to `drain_send_body` would conflict; iterate by index
@@ -388,7 +396,7 @@ pub(crate) fn drain_send_bodies(session: &mut ClientSession) {
             }
         }
         if !progressed {
-            break;
+            return false;
         }
     }
 }

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -482,6 +482,70 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
     );
   });
 
+  test("upload larger than the write-buffer high-water mark when the peer window never runs out", async () => {
+    // The peer advertises a 1 MiB stream window and a 16 MiB connection
+    // window, so flow control never pauses a 2 MB body; the client must keep
+    // framing after a flush that fully drains instead of waiting for a
+    // writable event that never comes.
+    const received = new Map<number, number>();
+    const server = nodetls.createServer({ ...tls, ALPNProtocols: ["h2"] }, socket => {
+      let buf = Buffer.alloc(0);
+      let prefaceSeen = false;
+      socket.on("error", () => {});
+      socket.on("data", chunk => {
+        buf = Buffer.concat([buf, chunk]);
+        if (!prefaceSeen) {
+          if (buf.length < 24) return;
+          buf = buf.subarray(24);
+          prefaceSeen = true;
+          // SETTINGS_INITIAL_WINDOW_SIZE (0x4) = 1 MiB, then open the connection window by 16 MiB.
+          socket.write(frame(4, 0, 0, Buffer.concat([Buffer.from([0, 4]), u32be(1 << 20)])));
+          socket.write(frame(8, 0, 0, u32be(1 << 24)));
+        }
+        while (buf.length >= 9) {
+          const len = buf.readUIntBE(0, 3);
+          if (buf.length < 9 + len) return;
+          const type = buf[3],
+            flags = buf[4],
+            id = buf.readUInt32BE(5) & 0x7fffffff;
+          buf = buf.subarray(9 + len);
+          if (type === 4 && !(flags & 1)) socket.write(frame(4, 1, 0));
+          if (type === 0) {
+            received.set(id, (received.get(id) ?? 0) + len);
+            // Top the stream window back up in 1 MiB steps so it is never the limiter.
+            if ((received.get(id)! & ((1 << 20) - 1)) < len) socket.write(frame(8, 0, id, u32be(1 << 20)));
+            if (flags & 1) {
+              socket.write(frame(1, 4, id, hpackStatus(200)));
+              socket.write(frame(0, 1, id, Buffer.from(String(received.get(id)))));
+            }
+          }
+        }
+      });
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = await spawnFetch(`
+        const opts = { method: "POST", tls: { rejectUnauthorized: false } };
+        const one = await fetch("https://localhost:${port}/", { ...opts, body: new Blob([new Uint8Array(2_000_000)]) });
+        console.log(one.status, await one.text());
+        const many = await Promise.all(
+          Array.from({ length: 4 }, () =>
+            fetch("https://localhost:${port}/", { ...opts, body: new Blob([new Uint8Array(512 * 1024)]) }).then(r => r.text()),
+          ),
+        );
+        console.log(many.join(","));
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("200 2000000\n524288,524288,524288,524288");
+      expect(exitCode).toBe(0);
+    } finally {
+      server.close();
+    }
+  });
+
   test("cold-start: parallel requests coalesce onto one TLS connect", async () => {
     let sessions = 0;
     const server = makeH2Server();
@@ -885,6 +949,31 @@ describe.concurrent("fetch() over HTTP/2 (BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CL
           expect(exitCode).toBe(0);
           expect(attempts).toBe(2);
           expect(state.connections).toBe(1);
+        },
+      );
+    });
+
+    test("RST_STREAM(NO_ERROR) after a complete response keeps the response; a later RST is ignored", async () => {
+      // RFC 9113 §8.1: the server may finish the response before the request
+      // body and reset with NO_ERROR; DATA we had in flight can then draw a
+      // second RST_STREAM(STREAM_CLOSED), which must not clobber the result.
+      await withRawH2Server(
+        (conn, id) => {
+          conn.headers(id, hpackStatus(200));
+          conn.data(id, "early", true);
+          conn.rst(id, http2.constants.NGHTTP2_NO_ERROR);
+          conn.rst(id, http2.constants.NGHTTP2_STREAM_CLOSED);
+        },
+        async url => {
+          await using proc = await spawnFetch(`
+            const body = new ReadableStream({ start(c) { c.enqueue(new Uint8Array(1024)); /* never closes */ } });
+            const r = await fetch("${url}", { method: "POST", body, duplex: "half", tls: { rejectUnauthorized: false } });
+            console.log(r.status, await r.text());
+          `);
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect(stderr).toBe("");
+          expect(stdout.trim()).toBe("200 early");
+          expect(exitCode).toBe(0);
         },
       );
     });


### PR DESCRIPTION
### Problem
- An upload over HTTP/2 (`fetch(url, { method: "POST", body })`) larger than 256 KiB stalls when the peer window never runs out. `drain_send_bodies` stops at `WRITE_BUFFER_HIGH_WATER` (`src/http/h2_client/encode.rs:377`) and the caller waits for `onWritable`. When the flush wrote everything, no writable event follows, so the rest of the body is never framed.
- A server that answers before the request body ends sends `RST_STREAM(NO_ERROR)` (RFC 9113 8.1). DATA the client had in flight can then draw a second `RST_STREAM(STREAM_CLOSED)`. `dispatch_frame` (`src/http/h2_client/dispatch.rs:489`) applied that second reset and the completed response became `TypeError: HTTP2StreamReset`.

### Fix
- `ClientSession::pump_send_bodies` loops drain then flush until the socket pushes back (a short write, `onWritable` resumes) or nothing more can be framed. `drain_send_bodies` now returns whether it stopped at the high-water mark with body bytes still sendable. All four call sites use the pump.
- The first `RST_STREAM` decides a stream's outcome. A reset on a stream with `rst_done` set returns early.
- Correct because the only thing that wakes the sender after a full flush is the sender itself, and because RFC 9113 5.1 lets the peer send frames that it queued before it saw our state change. Ignoring them is what a conforming endpoint does.
- Verified: `test/js/web/fetch/fetch-http2-client.test.ts`, two new tests against a raw-frame server. On the current canary they fail (5 s timeout, `HTTP2StreamReset`). The rest of the file passes with the change.

### Background
- `src/http/h2_client/` is the HTTP/2 client behind `fetch()` when `BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT` or `protocol: "http2"` is set. One `ClientSession` owns one TLS connection and multiplexes streams on it.
- `drain_send_bodies` frames request bodies into DATA frames, round robin across streams, bounded by the connection send window and by `WRITE_BUFFER_HIGH_WATER` (256 KiB) of unflushed output. `flush` writes the buffer to the socket and reports backpressure.
- These two bugs surfaced while testing #40137 (`Bun.serve({ http2: true })`) with `fetch` as the client. That server advertises a 1 MiB stream window and a 16 MiB connection window, and it answers before the request body is complete. The fix is client only and is split out of that PR.

<details><summary>Notes</summary>

The same diff is part of #40137 today, because its body-leak suite over HTTP/2 sends 512 KiB bodies and needs the upload fix. Once this PR lands, a merge of main removes it from that diff.

Fail-before, system bun 1.4.0-canary.1:

```
(fail) raw frame server > RST_STREAM(NO_ERROR) after a complete response keeps the response; a later RST is ignored
       expect(stderr).toBe("") received TypeError: HTTP2StreamReset fetching ...
(fail) upload larger than the write-buffer high-water mark when the peer window never runs out
       this test timed out after 5000ms
```

</details>
