### PR TITLE
install: match a star range to a versionless workspace when package.json is reparsed

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -981,28 +981,30 @@ impl Diff {
         )
     }
 
-    /// `Dependency::eql`, plus one case: the two sides can tag the same edge
-    /// `workspace` and `npm` (`map_dep_to_pkg` and the npm-lock migration
-    /// disagree with the package.json reparse). A star range matches any
-    /// workspace, so an unchanged literal is the same manifest edge.
+    /// `Dependency::eql`, plus one case: loading bun.lock stores a dependency
+    /// that resolved to a workspace package as a workspace edge
+    /// (`map_dep_to_pkg`), while the package.json reparse keeps the textual
+    /// npm range when the workspace has no version a star range satisfies.
+    /// The workspace still matches the star range, so an unchanged literal is
+    /// the same manifest edge. `reparse_links_workspace` is the precondition:
+    /// `link_workspace_packages` is on and the name is still a workspace in
+    /// the reparsed lockfile.
     fn deps_match(
         to_dep: &Dependency,
         from_dep: &Dependency,
         to_buf: &[u8],
         from_buf: &[u8],
+        reparse_links_workspace: bool,
     ) -> bool {
         if Dependency::eql(to_dep, from_dep, to_buf, from_buf) {
             return true;
         }
-        let star_workspace_pair = |ws: &dependency::Version, npm: &dependency::Version| {
-            ws.tag == dependency::version::Tag::Workspace
-                && npm.tag == dependency::version::Tag::Npm
-                && npm.npm().version.is_star()
-        };
-        from_dep.name_hash == to_dep.name_hash
+        reparse_links_workspace
+            && from_dep.version.tag == dependency::version::Tag::Workspace
+            && to_dep.version.tag == dependency::version::Tag::Npm
+            && to_dep.version.npm().version.is_star()
+            && from_dep.name_hash == to_dep.name_hash
             && from_dep.name.len() == to_dep.name.len()
-            && (star_workspace_pair(&from_dep.version, &to_dep.version)
-                || star_workspace_pair(&to_dep.version, &from_dep.version))
             && strings::eql_long(
                 from_dep.version.literal.slice(from_buf),
                 to_dep.version.literal.slice(to_buf),
@@ -1452,6 +1454,11 @@ impl Diff {
                 from_dep,
                 to_lockfile.buffers.string_bytes.as_slice(),
                 from_lockfile.buffers.string_bytes.as_slice(),
+                pm.options.link_workspace_packages
+                    && to_lockfile
+                        .workspace_paths
+                        .get(&from_dep.name_hash)
+                        .is_some(),
             ) {
                 if let Some(updates) = update_requests {
                     if updates.is_empty()

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1878,13 +1878,13 @@ impl Package<u64> {
                 // (`PackageManagerEnqueue`): a versionless workspace still
                 // satisfies a wildcard range.
                 let satisfies = match workspace_version {
-                    Some(workspace_version) => dependency_version
-                        .npm()
-                        .version
-                        .satisfies(workspace_version, buf, buf),
-                    None => {
-                        workspace_path.is_some() && dependency_version.npm().version.is_star()
+                    Some(workspace_version) => {
+                        dependency_version
+                            .npm()
+                            .version
+                            .satisfies(workspace_version, buf, buf)
                     }
+                    None => workspace_path.is_some() && dependency_version.npm().version.is_star(),
                 };
                 if pm.options.link_workspace_packages && satisfies {
                     // `String::sliced` takes `&'a self`; bind the unwrapped

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1874,9 +1874,7 @@ impl Package<u64> {
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
             }
             dependency::version::Tag::Npm => {
-                // Mirrors the resolver's workspace match
-                // (`PackageManagerEnqueue`): a versionless workspace still
-                // satisfies a wildcard range.
+                // A versionless workspace satisfies a wildcard range, the same rule as `PackageManagerEnqueue`.
                 let satisfies = match workspace_version {
                     Some(workspace_version) => {
                         dependency_version

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -981,12 +981,10 @@ impl Diff {
         )
     }
 
-    /// `Dependency::eql`, plus one normalization case: bun.lock
-    /// (`map_dep_to_pkg`) and the npm-lock migration store a dependency that
-    /// resolved to a workspace package as a workspace edge, while the
-    /// package.json reparse keeps the textual npm range (or the other way
-    /// around). A star range matches any workspace, so when the literal is
-    /// unchanged the manifest edge did not change.
+    /// `Dependency::eql`, plus one case: the two sides can tag the same edge
+    /// `workspace` and `npm` (`map_dep_to_pkg` and the npm-lock migration
+    /// disagree with the package.json reparse). A star range matches any
+    /// workspace, so an unchanged literal is the same manifest edge.
     fn deps_match(
         to_dep: &Dependency,
         from_dep: &Dependency,

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -981,6 +981,37 @@ impl Diff {
         )
     }
 
+    /// `Dependency::eql`, plus one normalization case: bun.lock
+    /// (`map_dep_to_pkg`) and the npm-lock migration store a dependency that
+    /// resolved to a workspace package as a workspace edge, while the
+    /// package.json reparse keeps the textual npm range (or the other way
+    /// around). A star range matches any workspace, so when the literal is
+    /// unchanged the manifest edge did not change.
+    fn deps_match(
+        to_dep: &Dependency,
+        from_dep: &Dependency,
+        to_buf: &[u8],
+        from_buf: &[u8],
+    ) -> bool {
+        if Dependency::eql(to_dep, from_dep, to_buf, from_buf) {
+            return true;
+        }
+        let star_workspace_pair = |ws: &dependency::Version, npm: &dependency::Version| {
+            ws.tag == dependency::version::Tag::Workspace
+                && npm.tag == dependency::version::Tag::Npm
+                && npm.npm().version.is_star()
+        };
+        from_dep.name_hash == to_dep.name_hash
+            && from_dep.name.len() == to_dep.name.len()
+            && (star_workspace_pair(&from_dep.version, &to_dep.version)
+                || star_workspace_pair(&to_dep.version, &from_dep.version))
+            && strings::eql_long(
+                from_dep.version.literal.slice(from_buf),
+                to_dep.version.literal.slice(to_buf),
+                true,
+            )
+    }
+
     // The root summary's `remove` is the count of distinct names removed across root + workspaces.
     fn generate_inner(
         pm: &mut PackageManager,
@@ -1418,7 +1449,7 @@ impl Diff {
             let cur_to_i = to_i;
             to_i += 1;
 
-            if Dependency::eql(
+            if Self::deps_match(
                 &to_deps!()[cur_to_i],
                 from_dep,
                 to_lockfile.buffers.string_bytes.as_slice(),
@@ -1874,46 +1905,43 @@ impl Package<u64> {
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
             }
             dependency::version::Tag::Npm => {
-                // A versionless workspace satisfies a wildcard range, the same rule as `PackageManagerEnqueue`.
-                let satisfies = match workspace_version {
-                    Some(workspace_version) => {
+                if let Some(workspace_version) = workspace_version {
+                    let satisfies =
                         dependency_version
                             .npm()
                             .version
-                            .satisfies(workspace_version, buf, buf)
-                    }
-                    None => workspace_path.is_some() && dependency_version.npm().version.is_star(),
-                };
-                if pm.options.link_workspace_packages && satisfies {
-                    // `String::sliced` takes `&'a self`; bind the unwrapped
-                    // value so the borrow outlives the parse call.
-                    let wp = workspace_path.unwrap();
-                    let path = wp.sliced(buf);
-                    if let Some(mut dep) = dependency::parse_with_tag(
-                        external_alias.value,
-                        Some(external_alias.hash),
-                        path.slice,
-                        dependency::version::Tag::Workspace,
-                        &path,
-                        Some(&mut *log),
-                        Some(&mut *pm),
-                    ) {
-                        // Whole-struct move so `Drop` frees the old npm
-                        // chain; keep the existing `literal`.
-                        dep.literal = dependency_version.literal;
-                        dependency_version = dep;
-                    }
-                } else if workspace_version.is_some() {
-                    // It doesn't satisfy, but a workspace shares the same name. Override the workspace with the other dependency
-                    for dep in &mut package_dependencies[0..dependencies_count as usize] {
-                        if dep.name_hash == name_hash && dep.behavior.is_workspace() {
-                            *dep = Dependency {
-                                behavior: group.behavior,
-                                name: external_alias.value,
-                                name_hash: external_alias.hash,
-                                version: dependency_version,
-                            };
-                            return Ok(None);
+                            .satisfies(workspace_version, buf, buf);
+                    if pm.options.link_workspace_packages && satisfies {
+                        // `String::sliced` takes `&'a self`; bind the unwrapped
+                        // value so the borrow outlives the parse call.
+                        let wp = workspace_path.unwrap();
+                        let path = wp.sliced(buf);
+                        if let Some(mut dep) = dependency::parse_with_tag(
+                            external_alias.value,
+                            Some(external_alias.hash),
+                            path.slice,
+                            dependency::version::Tag::Workspace,
+                            &path,
+                            Some(&mut *log),
+                            Some(&mut *pm),
+                        ) {
+                            // Whole-struct move so `Drop` frees the old npm
+                            // chain; keep the existing `literal`.
+                            dep.literal = dependency_version.literal;
+                            dependency_version = dep;
+                        }
+                    } else {
+                        // It doesn't satisfy, but a workspace shares the same name. Override the workspace with the other dependency
+                        for dep in &mut package_dependencies[0..dependencies_count as usize] {
+                            if dep.name_hash == name_hash && dep.behavior.is_workspace() {
+                                *dep = Dependency {
+                                    behavior: group.behavior,
+                                    name: external_alias.value,
+                                    name_hash: external_alias.hash,
+                                    version: dependency_version,
+                                };
+                                return Ok(None);
+                            }
                         }
                     }
                 }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1010,11 +1010,19 @@ impl Diff {
         to_npm.version.is_star()
             && from_dep.name_hash == to_dep.name_hash
             && from_dep.name.len() == to_dep.name.len()
+            // The same path, not only the same name: a relocated workspace is
+            // an update.
             && to_workspace_paths
                 .get(&semver::string::Builder::string_hash(
                     to_npm.name.slice(to_buf),
                 ))
-                .is_some()
+                .is_some_and(|to_path| {
+                    strings::eql_long(
+                        from_dep.version.workspace().slice(from_buf),
+                        to_path.slice(to_buf),
+                        true,
+                    )
+                })
             && strings::eql_long(
                 from_dep.version.literal.slice(from_buf),
                 to_dep.version.literal.slice(to_buf),

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1874,43 +1874,48 @@ impl Package<u64> {
                     .append::<String>(if relative.is_empty() { b"." } else { relative });
             }
             dependency::version::Tag::Npm => {
-                if let Some(workspace_version) = workspace_version {
-                    let satisfies =
-                        dependency_version
-                            .npm()
-                            .version
-                            .satisfies(workspace_version, buf, buf);
-                    if pm.options.link_workspace_packages && satisfies {
-                        // `String::sliced` takes `&'a self`; bind the unwrapped
-                        // value so the borrow outlives the parse call.
-                        let wp = workspace_path.unwrap();
-                        let path = wp.sliced(buf);
-                        if let Some(mut dep) = dependency::parse_with_tag(
-                            external_alias.value,
-                            Some(external_alias.hash),
-                            path.slice,
-                            dependency::version::Tag::Workspace,
-                            &path,
-                            Some(&mut *log),
-                            Some(&mut *pm),
-                        ) {
-                            // Whole-struct move so `Drop` frees the old npm
-                            // chain; keep the existing `literal`.
-                            dep.literal = dependency_version.literal;
-                            dependency_version = dep;
-                        }
-                    } else {
-                        // It doesn't satisfy, but a workspace shares the same name. Override the workspace with the other dependency
-                        for dep in &mut package_dependencies[0..dependencies_count as usize] {
-                            if dep.name_hash == name_hash && dep.behavior.is_workspace() {
-                                *dep = Dependency {
-                                    behavior: group.behavior,
-                                    name: external_alias.value,
-                                    name_hash: external_alias.hash,
-                                    version: dependency_version,
-                                };
-                                return Ok(None);
-                            }
+                // Mirrors the resolver's workspace match
+                // (`PackageManagerEnqueue`): a versionless workspace still
+                // satisfies a wildcard range.
+                let satisfies = match workspace_version {
+                    Some(workspace_version) => dependency_version
+                        .npm()
+                        .version
+                        .satisfies(workspace_version, buf, buf),
+                    None => {
+                        workspace_path.is_some() && dependency_version.npm().version.is_star()
+                    }
+                };
+                if pm.options.link_workspace_packages && satisfies {
+                    // `String::sliced` takes `&'a self`; bind the unwrapped
+                    // value so the borrow outlives the parse call.
+                    let wp = workspace_path.unwrap();
+                    let path = wp.sliced(buf);
+                    if let Some(mut dep) = dependency::parse_with_tag(
+                        external_alias.value,
+                        Some(external_alias.hash),
+                        path.slice,
+                        dependency::version::Tag::Workspace,
+                        &path,
+                        Some(&mut *log),
+                        Some(&mut *pm),
+                    ) {
+                        // Whole-struct move so `Drop` frees the old npm
+                        // chain; keep the existing `literal`.
+                        dep.literal = dependency_version.literal;
+                        dependency_version = dep;
+                    }
+                } else if workspace_version.is_some() {
+                    // It doesn't satisfy, but a workspace shares the same name. Override the workspace with the other dependency
+                    for dep in &mut package_dependencies[0..dependencies_count as usize] {
+                        if dep.name_hash == name_hash && dep.behavior.is_workspace() {
+                            *dep = Dependency {
+                                behavior: group.behavior,
+                                name: external_alias.value,
+                                name_hash: external_alias.hash,
+                                version: dependency_version,
+                            };
+                            return Ok(None);
                         }
                     }
                 }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -986,25 +986,35 @@ impl Diff {
     /// (`map_dep_to_pkg`), while the package.json reparse keeps the textual
     /// npm range when the workspace has no version a star range satisfies.
     /// The workspace still matches the star range, so an unchanged literal is
-    /// the same manifest edge. `reparse_links_workspace` is the precondition:
-    /// `link_workspace_packages` is on and the name is still a workspace in
-    /// the reparsed lockfile.
+    /// the same manifest edge. The workspace lookup keys on the npm target
+    /// name, like `parse_dependency` and the resolver, so an `npm:` alias of
+    /// a workspace matches too.
     fn deps_match(
         to_dep: &Dependency,
         from_dep: &Dependency,
         to_buf: &[u8],
         from_buf: &[u8],
-        reparse_links_workspace: bool,
+        link_workspace_packages: bool,
+        to_workspace_paths: &lockfile::NameHashMap,
     ) -> bool {
         if Dependency::eql(to_dep, from_dep, to_buf, from_buf) {
             return true;
         }
-        reparse_links_workspace
-            && from_dep.version.tag == dependency::version::Tag::Workspace
-            && to_dep.version.tag == dependency::version::Tag::Npm
-            && to_dep.version.npm().version.is_star()
+        if !link_workspace_packages
+            || from_dep.version.tag != dependency::version::Tag::Workspace
+            || to_dep.version.tag != dependency::version::Tag::Npm
+        {
+            return false;
+        }
+        let to_npm = to_dep.version.npm();
+        to_npm.version.is_star()
             && from_dep.name_hash == to_dep.name_hash
             && from_dep.name.len() == to_dep.name.len()
+            && to_workspace_paths
+                .get(&semver::string::Builder::string_hash(
+                    to_npm.name.slice(to_buf),
+                ))
+                .is_some()
             && strings::eql_long(
                 from_dep.version.literal.slice(from_buf),
                 to_dep.version.literal.slice(to_buf),
@@ -1454,11 +1464,8 @@ impl Diff {
                 from_dep,
                 to_lockfile.buffers.string_bytes.as_slice(),
                 from_lockfile.buffers.string_bytes.as_slice(),
-                pm.options.link_workspace_packages
-                    && to_lockfile
-                        .workspace_paths
-                        .get(&from_dep.name_hash)
-                        .is_some(),
+                pm.options.link_workspace_packages,
+                &to_lockfile.workspace_paths,
             ) {
                 if let Some(updates) = update_requests {
                     if updates.is_empty()

--- a/test/cli/install/bun-dedupe.test.ts
+++ b/test/cli/install/bun-dedupe.test.ts
@@ -754,6 +754,19 @@ test.concurrent("workspace package edge is re-pointed when run from the workspac
   await runBunInstall(installEnv(packageDir), packageDir, { frozenLockfile: true });
 });
 
+// #40393: a "*" range on a versionless workspace package resolves to the workspace,
+// so the package.json reparse must agree with bun.lock instead of refusing.
+test.concurrent("star dep on a versionless workspace package is in sync", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+  await Promise.all([
+    write(packageJson, JSON.stringify({ name: "root", workspaces: ["app1", "package1"] })),
+    write(join(packageDir, "app1", "package.json"), JSON.stringify({ name: "app1", dependencies: { package1: "*" } })),
+    write(join(packageDir, "package1", "package.json"), JSON.stringify({ name: "package1" })),
+  ]);
+  await runBunInstall(installEnv(packageDir), packageDir);
+  await expectAlreadyDeduplicated(packageDir, 3);
+});
+
 test.concurrent("corrupt bun.lock fails without rewriting it", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();
   await write(packageJson, JSON.stringify({ name: "foo", dependencies: { "no-deps": "1.0.0" } }));

--- a/test/cli/install/bun-dedupe.test.ts
+++ b/test/cli/install/bun-dedupe.test.ts
@@ -754,18 +754,26 @@ test.concurrent("workspace package edge is re-pointed when run from the workspac
   await runBunInstall(installEnv(packageDir), packageDir, { frozenLockfile: true });
 });
 
-// #40393: a "*" range on a versionless workspace package resolves to the workspace,
-// so the package.json reparse must agree with bun.lock instead of refusing.
-test.concurrent("star dep on a versionless workspace package is in sync", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir();
-  await Promise.all([
-    write(packageJson, JSON.stringify({ name: "root", workspaces: ["app1", "package1"] })),
-    write(join(packageDir, "app1", "package.json"), JSON.stringify({ name: "app1", dependencies: { package1: "*" } })),
-    write(join(packageDir, "package1", "package.json"), JSON.stringify({ name: "package1" })),
-  ]);
-  await runBunInstall(installEnv(packageDir), packageDir);
-  await expectAlreadyDeduplicated(packageDir, 3);
-});
+// #40393: a "*" range resolves to a workspace even when the workspace has no version,
+// or a prerelease version, so the package.json reparse must agree with bun.lock instead of refusing.
+for (const [label, pkg1] of [
+  ["versionless", { name: "package1" }],
+  ["prerelease", { name: "package1", version: "1.0.0-alpha" }],
+] as const) {
+  test.concurrent(`star dep on a ${label} workspace package is in sync`, async () => {
+    const { packageDir, packageJson } = await registry.createTestDir();
+    await Promise.all([
+      write(packageJson, JSON.stringify({ name: "root", workspaces: ["app1", "package1"] })),
+      write(
+        join(packageDir, "app1", "package.json"),
+        JSON.stringify({ name: "app1", dependencies: { package1: "*" } }),
+      ),
+      write(join(packageDir, "package1", "package.json"), JSON.stringify(pkg1)),
+    ]);
+    await runBunInstall(installEnv(packageDir), packageDir);
+    await expectAlreadyDeduplicated(packageDir, 3);
+  });
+}
 
 test.concurrent("corrupt bun.lock fails without rewriting it", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();

--- a/test/cli/install/bun-dedupe.test.ts
+++ b/test/cli/install/bun-dedupe.test.ts
@@ -756,18 +756,16 @@ test.concurrent("workspace package edge is re-pointed when run from the workspac
 
 // #40393: a "*" range resolves to a workspace even when the workspace has no version,
 // or a prerelease version, so the package.json reparse must agree with bun.lock instead of refusing.
-for (const [label, pkg1] of [
-  ["versionless", { name: "package1" }],
-  ["prerelease", { name: "package1", version: "1.0.0-alpha" }],
+for (const [label, deps, pkg1] of [
+  ["versionless", { package1: "*" }, { name: "package1" }],
+  ["prerelease", { package1: "*" }, { name: "package1", version: "1.0.0-alpha" }],
+  ["aliased versionless", { aliased: "npm:package1@*" }, { name: "package1" }],
 ] as const) {
   test.concurrent(`star dep on a ${label} workspace package is in sync`, async () => {
     const { packageDir, packageJson } = await registry.createTestDir();
     await Promise.all([
       write(packageJson, JSON.stringify({ name: "root", workspaces: ["app1", "package1"] })),
-      write(
-        join(packageDir, "app1", "package.json"),
-        JSON.stringify({ name: "app1", dependencies: { package1: "*" } }),
-      ),
+      write(join(packageDir, "app1", "package.json"), JSON.stringify({ name: "app1", dependencies: deps })),
       write(join(packageDir, "package1", "package.json"), JSON.stringify(pkg1)),
     ]);
     await runBunInstall(installEnv(packageDir), packageDir);

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -575,6 +575,23 @@ test.concurrent("workspaces: prunes workspace folders, keeps workspace links, ru
   expect(existsSync(join(nm, "a-dep"))).toBeFalse();
 });
 
+// #40393: a "*" range on a versionless workspace package resolves to the workspace,
+// so the package.json reparse must agree with bun.lock instead of refusing.
+test.concurrent("workspaces: star dep on a versionless workspace package is in sync", async () => {
+  const { packageDir: dir, packageJson } = await registry.createTestDir();
+  await Promise.all([
+    write(packageJson, JSON.stringify({ name: "root", workspaces: ["app1", "package1"] })),
+    write(join(dir, "app1", "package.json"), JSON.stringify({ name: "app1", dependencies: { package1: "*" } })),
+    write(join(dir, "package1", "package.json"), JSON.stringify({ name: "package1" })),
+  ]);
+  await runBunInstall(installEnv(dir), dir);
+
+  const { stdout, stderr, exitCode } = await prune(dir);
+  expect(out(stdout)).toBe(`${BANNER}\n\n${NOTHING(2, 1)}`);
+  expect(stderr).not.toContain(OUT_OF_SYNC);
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("keeps dependencies bundled inside a package", async () => {
   const dir = await setup({ name: "foo", dependencies: { "bundled-transitive": "1.0.0" } });
   const bundled = join(dir, "node_modules", "bundled-transitive", "node_modules", "no-deps", "package.json");

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -577,21 +577,23 @@ test.concurrent("workspaces: prunes workspace folders, keeps workspace links, ru
 
 // #40393: a "*" range resolves to a workspace even when the workspace has no version,
 // or a prerelease version, so the package.json reparse must agree with bun.lock instead of refusing.
-for (const [label, pkg1] of [
-  ["versionless", { name: "package1" }],
-  ["prerelease", { name: "package1", version: "1.0.0-alpha" }],
+for (const [label, deps, pkg1, checked] of [
+  ["versionless", { package1: "*" }, { name: "package1" }, 2],
+  ["prerelease", { package1: "*" }, { name: "package1", version: "1.0.0-alpha" }, 2],
+  // the alias adds a third installed link, node_modules/aliased
+  ["aliased versionless", { aliased: "npm:package1@*" }, { name: "package1" }, 3],
 ] as const) {
   test.concurrent(`workspaces: star dep on a ${label} workspace package is in sync`, async () => {
     const { packageDir: dir, packageJson } = await registry.createTestDir();
     await Promise.all([
       write(packageJson, JSON.stringify({ name: "root", workspaces: ["app1", "package1"] })),
-      write(join(dir, "app1", "package.json"), JSON.stringify({ name: "app1", dependencies: { package1: "*" } })),
+      write(join(dir, "app1", "package.json"), JSON.stringify({ name: "app1", dependencies: deps })),
       write(join(dir, "package1", "package.json"), JSON.stringify(pkg1)),
     ]);
     await runBunInstall(installEnv(dir), dir);
 
     const { stdout, stderr, exitCode } = await prune(dir);
-    expect(out(stdout)).toBe(`${BANNER}\n\n${NOTHING(2, 1)}`);
+    expect(out(stdout)).toBe(`${BANNER}\n\n${NOTHING(checked, 1)}`);
     expect(stderr).not.toContain(OUT_OF_SYNC);
     expect(exitCode).toBe(0);
   });

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -599,6 +599,27 @@ for (const [label, deps, pkg1, checked] of [
   });
 }
 
+// A relocated versionless workspace is a real change: prune refuses until bun install runs.
+test.concurrent("workspaces: star dep on a relocated versionless workspace is out of sync", async () => {
+  const { packageDir: dir, packageJson } = await registry.createTestDir();
+  await Promise.all([
+    write(packageJson, JSON.stringify({ name: "root", workspaces: ["app1", "package1"] })),
+    write(join(dir, "app1", "package.json"), JSON.stringify({ name: "app1", dependencies: { package1: "*" } })),
+    write(join(dir, "package1", "package.json"), JSON.stringify({ name: "package1" })),
+  ]);
+  await runBunInstall(installEnv(dir), dir);
+
+  renameSync(join(dir, "package1"), join(dir, "moved"));
+  await write(packageJson, JSON.stringify({ name: "root", workspaces: ["app1", "moved"] }));
+  expectRefused(await prune(dir));
+
+  await runBunInstall(installEnv(dir), dir);
+  const { stdout, stderr, exitCode } = await prune(dir);
+  expect(out(stdout)).toBe(`${BANNER}\n\n${NOTHING(2, 1)}`);
+  expect(stderr).not.toContain(OUT_OF_SYNC);
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("keeps dependencies bundled inside a package", async () => {
   const dir = await setup({ name: "foo", dependencies: { "bundled-transitive": "1.0.0" } });
   const bundled = join(dir, "node_modules", "bundled-transitive", "node_modules", "no-deps", "package.json");

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -575,22 +575,27 @@ test.concurrent("workspaces: prunes workspace folders, keeps workspace links, ru
   expect(existsSync(join(nm, "a-dep"))).toBeFalse();
 });
 
-// #40393: a "*" range on a versionless workspace package resolves to the workspace,
-// so the package.json reparse must agree with bun.lock instead of refusing.
-test.concurrent("workspaces: star dep on a versionless workspace package is in sync", async () => {
-  const { packageDir: dir, packageJson } = await registry.createTestDir();
-  await Promise.all([
-    write(packageJson, JSON.stringify({ name: "root", workspaces: ["app1", "package1"] })),
-    write(join(dir, "app1", "package.json"), JSON.stringify({ name: "app1", dependencies: { package1: "*" } })),
-    write(join(dir, "package1", "package.json"), JSON.stringify({ name: "package1" })),
-  ]);
-  await runBunInstall(installEnv(dir), dir);
+// #40393: a "*" range resolves to a workspace even when the workspace has no version,
+// or a prerelease version, so the package.json reparse must agree with bun.lock instead of refusing.
+for (const [label, pkg1] of [
+  ["versionless", { name: "package1" }],
+  ["prerelease", { name: "package1", version: "1.0.0-alpha" }],
+] as const) {
+  test.concurrent(`workspaces: star dep on a ${label} workspace package is in sync`, async () => {
+    const { packageDir: dir, packageJson } = await registry.createTestDir();
+    await Promise.all([
+      write(packageJson, JSON.stringify({ name: "root", workspaces: ["app1", "package1"] })),
+      write(join(dir, "app1", "package.json"), JSON.stringify({ name: "app1", dependencies: { package1: "*" } })),
+      write(join(dir, "package1", "package.json"), JSON.stringify(pkg1)),
+    ]);
+    await runBunInstall(installEnv(dir), dir);
 
-  const { stdout, stderr, exitCode } = await prune(dir);
-  expect(out(stdout)).toBe(`${BANNER}\n\n${NOTHING(2, 1)}`);
-  expect(stderr).not.toContain(OUT_OF_SYNC);
-  expect(exitCode).toBe(0);
-});
+    const { stdout, stderr, exitCode } = await prune(dir);
+    expect(out(stdout)).toBe(`${BANNER}\n\n${NOTHING(2, 1)}`);
+    expect(stderr).not.toContain(OUT_OF_SYNC);
+    expect(exitCode).toBe(0);
+  });
+}
 
 test.concurrent("keeps dependencies bundled inside a package", async () => {
   const dir = await setup({ name: "foo", dependencies: { "bundled-transitive": "1.0.0" } });

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -311,6 +311,35 @@ test.concurrent("successfully installs workspace when path already exists in nod
   });
 });
 
+// #40396: the lockfile diff treats a locked workspace edge and a reparsed "*" range as the
+// same edge. That must not keep a registry resolution once a same-name workspace appears.
+test.concurrent("star dep re-resolves to a newly added workspace", async () => {
+  using ctx = await setupTest();
+  const { packageDir, env } = ctx;
+  await Promise.all([
+    write(
+      join(packageDir, "package.json"),
+      JSON.stringify({ name: "root", workspaces: ["app1"], dependencies: { "no-deps": "*" } }),
+    ),
+    write(join(packageDir, "app1", "package.json"), JSON.stringify({ name: "app1" })),
+  ]);
+  let { exited } = await runBunInstall(env, packageDir);
+  expect(await exited).toBe(0);
+  expect((await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).version).toBe("2.0.0");
+
+  // add a same-name versioned workspace that "*" satisfies
+  await Promise.all([
+    write(
+      join(packageDir, "package.json"),
+      JSON.stringify({ name: "root", workspaces: ["app1", "no-deps"], dependencies: { "no-deps": "*" } }),
+    ),
+    write(join(packageDir, "no-deps", "package.json"), JSON.stringify({ name: "no-deps", version: "9.9.9" })),
+  ]);
+  ({ exited } = await runBunInstall(env, packageDir));
+  expect(await exited).toBe(0);
+  expect((await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).version).toBe("9.9.9");
+});
+
 test.concurrent("adding workspace in workspace edits package.json with correct version (workspace:*)", async () => {
   using ctx = await setupTest();
   const { packageDir, env } = ctx;


### PR DESCRIPTION
### Problem
- After a clean `bun install`, `bun prune` and `bun dedupe` exit 1 with `error: bun.lock does not match package.json, nothing to prune`. It happens when a workspace depends on a sibling workspace through `"*"` and the sibling has no `version` field, or a prerelease version. Fixes #40393.
- The resolver links a `"*"` range to such a workspace (`PackageManagerEnqueue.rs:2580`, from #10899), and the bun.lock loader stores that edge as a workspace edge (`map_dep_to_pkg`, bun.lock.rs:3480). The package.json reparse keeps the textual npm range, because no entry in `workspace_versions` satisfies it. The diff then sees workspace against npm and reports a phantom update.

### Fix
- Compare the edges at the diff (`Diff::deps_match`, Package.rs): a locked workspace edge equals a reparsed npm star range with the same literal. A star range matches any workspace, so the manifest edge did not change.
- The check only runs when `link_workspace_packages` is on and the reparsed lockfile still has that workspace at the same path, looked up by the npm target name (so an `npm:` alias of a workspace matches too). A removed or relocated workspace, or the reverse direction (a locked registry resolution against a reparsed workspace edge), still reports an update and re-resolves.
- Install, resolution, and parsing are untouched. The tolerance only stops the diff from reporting this one edge shape as updated when the package.json text did not change.
- Verified: new tests in `test/cli/install/bun-prune.test.ts` and `bun-dedupe.test.ts` (versionless, prerelease, and aliased variants, all six fail on stock bun), plus a registry-to-workspace transition guard in `bun-workspaces.test.ts`. Also ran bun-prune, bun-dedupe, bun-workspaces, bun-lock, frozen-lockfile-pruned, isolated-install, and migration suites.

### Background
- `bun prune` and `bun dedupe` guard against a stale lockfile: they reparse the root and workspace package.json files into a fresh lockfile and diff it against the loaded bun.lock. Any dependency change aborts the command.
- A dependency keeps its literal (`"*"`) in bun.lock but can change its tag. `lockfileVersion` >= 1 stores a dependency that resolved to a workspace package as a workspace edge.
- `workspace_versions` only has an entry when the workspace manifest has a `version` field, and `"*"` does not satisfy a prerelease version, so the reparse cannot reproduce the loader's tag for these edges.

<details><summary>Notes</summary>

Repro:

```
printf '{"name":"root","workspaces":["app1","package1"]}' > package.json
printf '{"name":"app1","dependencies":{"package1":"*"}}' > app1/package.json
printf '{"name":"package1"}' > package1/package.json
bun install   # Done! Checked 3 packages (no changes)
bun prune     # error: bun.lock does not match package.json, nothing to prune
```

`bun prune --verbose` shows the phantom diff: `Workspace package "app1" has added 0 dependencies, removed 0 dependencies, and updated 1 dependencies`. Instrumenting `Diff::generate_inner` shows `from(tag=Workspace, literal="*")` against `to(tag=Npm, literal="*")`.

History of the approach, both turns driven by review and CI findings:

1. The first approach converted the edge during the reparse (`parse_dependency`), mirroring the resolver's rule. That fixed the bun.lock direction but broke `test/cli/install/migration/complex-workspace.test.ts` in CI: the npm-lock migration (`migration/npm_lock.rs`) stores the same edge as an npm range, so the conversion created the phantom diff in the other direction and the install re-resolved the whole tree, losing pinned alias versions (`npm:svelte@*` jumped from the locked 1.0.0 to 4.1.2). The diff is the only place that sees both sides, so the fix moved there.
2. The first diff-level version accepted the workspace-npm pair in both directions. Review flagged the reverse direction: a `"*"` edge locked to a registry package could keep that resolution after a same-name workspace appears. The exact reported scenario does not reproduce (the new workspace adds other diffs that force re-resolution, the new bun-workspaces test covers it), but a no-other-diff variant exists (a `linkWorkspacePackages` flip), so the reverse arm is gone and the forward arm is gated on the reparse still linking that workspace.

The prerelease case fails because `Group::satisfies` routes a prerelease version through `satisfies_pre`, which requires a comparator with a matching prerelease tuple, so `"*"` does not satisfy `1.0.0-alpha`. The resolver still links it through its `is_star` arm.

A related pre-existing gap stays out of scope: an edge whose plain name or `catalog:` value resolved to a different workspace package (for example `"not-body-parser": "*"` in the complex-workspace fixture, where the name does not match any workspace, or a catalog star naming a sibling workspace) still phantom-diffs on load, because the reparse cannot know the target. Same class, different producer, behavior unchanged from main. A plain `npm:` alias of a workspace is covered: the lookup keys on the npm target name.

Checked by hand: install then prune, dedupe, and `--frozen-lockfile` install pass for the versionless, prerelease, and root-level-dependency cases, and for a package-lock.json migration of the same tree. `node_modules/package1` still symlinks to the workspace folder and the written bun.lock text is unchanged.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-prune.test.ts

<!-- robobun:evidence:end -->