### PR TITLE
mimalloc: free(NULL) before init no longer faults (glibc 2.44 startup segfault)

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "a178e44af6dc2845c793a39fd62da583b3e9f0ff";
+const MIMALLOC_COMMIT = "7ac561abbf5fe407fab22f840076a75427c2085e";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -576,7 +576,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "2288897e2e716330490893d226b4f079f9da9e0c",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "a178e44af6dc2845c793a39fd62da583b3e9f0ff",
+    mimalloc: "7ac561abbf5fe407fab22f840076a75427c2085e",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "05f0fafaa3be31e31d7b4b5c17dc60f62c991171",


### PR DESCRIPTION
### Problem
- `mi_free(NULL)` before mimalloc has initialized faults at address 0: `free+0x28: movq (%rax,%rcx), %rdi ; rax = pmap->submaps[0] = NULL`. `_mi_unchecked_ptr_page` reads `submaps[0][0]` of the static initial page map with no submap check. That submap has been `NULL` since upstream dev3's 2-level page-map restructure (`d63979ae`), picked up by the Aug 13 fork sync (#37367). Upstream still has it.
- Bun's binaries are not affected today. `src/linker.lds` ends with `local: *;`, so the Linux `malloc`/`free` override stays private to the executable, and glibc 2.44's loader-time `free(NULL)` (`__newlocale`) reaches glibc's allocator. A build that exports the override dies before `main` (Claude Code 2.1.243 on Arch/CachyOS: anthropics/claude-code#89389 and about 12 duplicates).

### Fix
- Bump mimalloc to oven-sh/mimalloc `7ac561ab`. oven-sh/mimalloc#30 points `submaps[0]` at a static zero-initialized submap (64 KiB of `.bss`). The lookup yields no page and `mi_free` returns.
- The delta also carries oven-sh/mimalloc#28 (heap profile dump: grow the location table instead of spinning, free it, stop on a failed write). Nothing in `src/` calls `mi_prof_*`, so it is inert here.
- Update the pinned hash in `test/js/node/process/process.test.js`. It asserts the exact dependency commits in `process.versions` and failed on every test lane with the old hash.
- Verified: `test/js/node/process/process.test.js` (169 pass, debug build), and upstream `test-free-before-init` against bun's Linux release flags for both pins (Notes).

### Background
- mimalloc maps a pointer to its page through a 2-level page map, `submaps[hi][lo]`. Before `mi_process_init` runs, a static empty map stands in so that `free(NULL)` stays legal.
- On Linux bun builds mimalloc with `MI_MALLOC_OVERRIDE`. glibc's internal `free` calls reach it only if the executable exports the symbol.
- `.preinit_array` entries run before every constructor of the executable and its libraries. glibc 2.44's loader-time `free(NULL)` happens there, before mimalloc's constructor.

<details><summary>Notes</summary>

- Fail-before and fail-after for the mimalloc fix itself. I compiled `src/static.c` from `a178e44a` and from `7ac561ab` as C++ with the flags `scripts/build/deps/mimalloc.ts` emits for Linux release (`-O2 -fno-exceptions -fno-rtti -fvisibility=hidden -fPIC -DMI_STATIC_LIB -DMI_SKIP_COLLECT_ON_EXIT=1 -DMI_NO_PROCESS_DETACH=1 -DMI_DEFAULT_ALLOW_THP=0 -DMI_MALLOC_OVERRIDE -DMI_BUILD_RELEASE -fno-builtin-malloc -ftls-model=initial-exec`), clang 21, x64 glibc. I linked each with upstream `test/test-free-before-init.c`, which calls `free(NULL)` and `mi_free(NULL)` from `.preinit_array`. Old pin: `Segmentation fault`, exit 139. New pin: `test-free-before-init: ok`, exit 0.
- In the mimalloc PR: a new `test-free-before-init` target, Release `ctest` 23/23 and `MI_DEBUG_FULL` green on Ubuntu 24.04 arm64, gcc, `MI_OVERRIDE=ON`.
- Debug build with the new pin: `process.versions.mimalloc` reports `7ac561ab...`. `process.test.js`: 169 pass, 3 skip. With the released bun the `process.versions` test fails as expected (`Expected: "7ac561ab..."`, `Received: "a178e44a..."`).
- CI on fc8980bb: every build lane passed. Every test lane failed on `process.versions` only. `test/cli/run/require-cache.test.ts` also failed once on x64-asan, a 30 s timeout in a block the file marks "extra slow in debug builds". That file flaked in 5 of the last 30 main builds. I ran its cjs leak fixture under the same local debug build with both pins: 68 to 74 MB either way, so the pin does not move it.
- The ASAN lane builds mimalloc with the override off (`override = cfg.linux && !cfg.asan` in `mimalloc.ts`). There the page-map change is reachable only through a direct `mi_free`.
- The `prof.c` change is only on the dump path behind `mi_prof_enable`, which nothing in `src/` calls.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->