### PR TITLE
cron: resolve spring-forward gaps in real-time order

### DIFF
--- a/docs/runtime/cron.mdx
+++ b/docs/runtime/cron.mdx
@@ -133,7 +133,7 @@ Bun.cron("0 9 * * *", handler, { tz: "America/New_York" });
 
 DST transitions:
 
-- **Spring-forward** — a schedule that lands in the missing hour fires that day, shifted forward by the gap (e.g. `30 2 * * *` runs at 3:30 on the spring-forward day). For multi-minute patterns inside the gap (`*/15 2 * * *`), only the first match fires.
+- **Spring-forward** — a fixed-time schedule that lands in the missing hour fires that day, shifted forward by the gap (e.g. `30 2 * * *` runs at 3:30 on the spring-forward day). For multi-minute patterns inside the gap (`*/15 2 * * *`), only the first match fires. A schedule whose minute or hour field is `*` (`0 * * * *`, `* 2 * * *`) runs on real time: it fires at the first existing minute it matches after the gap, so `* 2 * * *` does not run on the spring-forward day.
 - **Fall-back** — a fixed-time schedule in the duplicated hour (`30 1 * * *`) fires once, at the first occurrence. A schedule whose minute or hour field is `*` (`0 * * * *`, `* * * * *`) fires through **both** occurrences — once per real-time minute, matching crontab on Linux.
 
 ### Day-of-month and day-of-week interaction

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8394,9 +8394,11 @@ declare module "bun" {
      * matching uses OR logic per [POSIX cron](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html):
      * a date matches if **either** field matches.
      *
-     * DST: spring-forward times shift forward by the gap; in the fall-back
-     * duplicated hour, fixed-time schedules fire once (first occurrence) while
-     * schedules with `*` minute or hour fire through both occurrences.
+     * DST: in the spring-forward gap, fixed-time schedules fire once, shifted
+     * forward by the gap, while schedules with `*` minute or hour fire at the
+     * first existing minute they match; in the fall-back duplicated hour,
+     * fixed-time schedules fire once (first occurrence) while schedules with
+     * `*` minute or hour fire through both occurrences.
      *
      * @param expression - A cron expression or nickname (e.g. `"0,15,30,45 * * * *"`, `"0 9 * * MON-FRI"`, `"@hourly"`)
      * @param relativeDate - Starting point for the search (defaults to `Date.now()`). Accepts a `Date` or milliseconds since epoch.

--- a/src/runtime/api/cron_parser.rs
+++ b/src/runtime/api/cron_parser.rs
@@ -49,6 +49,19 @@ impl CronTz {
             }
         }
     }
+
+    /// True when the wall-clock minute `dt` does not exist (spring-forward
+    /// gap) and `ms`, what `gregorian_to_ms` returned for it, is the instant
+    /// shifted past the gap: converting `ms` back yields a different minute.
+    /// `ms` is NaN past the Date range; that is not a gap.
+    fn in_gap(self, g: &JSGlobalObject, dt: GregorianDateTime, ms: f64) -> bool {
+        if ms.is_nan() {
+            return false;
+        }
+        let back = self.ms_to_gregorian(g, ms);
+        (back.year, back.month, back.day, back.hour, back.minute)
+            != (dt.year, dt.month, dt.day, dt.hour, dt.minute)
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -169,7 +182,8 @@ impl CronExpression {
     /// Convert a matching wall-clock `dt` to a real instant strictly after
     /// `from_ms`, handling DST. Returns None if no such instant exists for
     /// this wall-clock minute (fall-back FORMER already passed and the
-    /// schedule is fixed-time, so it fires once — cronie semantics).
+    /// schedule is fixed-time, so it fires once — cronie semantics; or the
+    /// minute is in a spring-forward gap and the schedule is wildcard).
     fn resolve_local_match(
         &self,
         global_object: &JSGlobalObject,
@@ -180,6 +194,11 @@ impl CronExpression {
     ) -> JsResult<Option<f64>> {
         let result =
             tz.gregorian_to_ms(global_object, dt.year, dt.month, dt.day, dt.hour, dt.minute)?;
+        // During spring-forward, `dt` does not exist and `result` is the
+        // instant shifted past the gap. With a sub-hour gap (Lord Howe,
+        // Chatham) wall-clock order and real-time order differ there: the
+        // shifted 02:10 is the real 02:40, after the existing 02:35.
+        let in_gap = tz.in_gap(global_object, dt, result);
         // During fall-back, `result` is the FORMER occurrence and the wall-clock
         // walk steps over the second one. For schedules with `*` minute or `*`
         // hour, scan real-time minutes (capped at the largest DST shift) to
@@ -191,6 +210,11 @@ impl CronExpression {
         //   (b) result <= from_ms — `dt` is ambiguous and mapped to its
         //       earlier instant, already past; the later instant may match.
         if self.minutes == ALL_MINUTES || self.hours == ALL_HOURS {
+            // A wildcard schedule runs on real time: skip the shifted instant
+            // and let the walk reach the first existing minute after the gap.
+            if in_gap {
+                return Ok(None);
+            }
             let wall_from = global_object.gregorian_date_time_to_ms_utc(
                 from_dt.year,
                 from_dt.month,
@@ -215,6 +239,19 @@ impl CronExpression {
                     }
                     probe += MINUTE_MS;
                 }
+            }
+        } else if in_gap {
+            // A fixed-time schedule fires once at the shifted instant, unless
+            // an existing minute before it matches. Real instants before the
+            // transition map to wall-clock minutes the walk already rejected,
+            // so only the last MAX_DST_SHIFT_MIN minutes before `result` can.
+            let lo = ((result - MAX_DST_SHIFT_MIN * MINUTE_MS) / MINUTE_MS).ceil() * MINUTE_MS;
+            let mut probe = (((from_ms / MINUTE_MS).floor() + 1.0) * MINUTE_MS).max(lo);
+            while probe < result {
+                if self.matches_instant(global_object, tz, probe) {
+                    return Ok(Some(probe));
+                }
+                probe += MINUTE_MS;
             }
         }
         Ok(if result > from_ms { Some(result) } else { None })

--- a/test/js/bun/cron/cron-local-time.test.ts
+++ b/test/js/bun/cron/cron-local-time.test.ts
@@ -137,6 +137,63 @@ describe.concurrent("Bun.cron.parse — DST transitions", () => {
     expect(next).toBe("2025-10-04T15:45:00.000Z");
   });
 
+  test("Lord Howe: 30-minute spring-forward gap — wildcard hour fires at the first existing hour", async () => {
+    // 2025-10-05 02:00 LHST (+10:30) → 02:30 LHDT (+11); 2:00-2:29 don't exist.
+    // The gap-shifted instant for 02:00 is 02:30, which "0 * * * *" does not
+    // match. The hourly chain must walk 1:00 → 3:00 → 4:00, not fire at 2:30.
+    expect(await chainInTZ("Australia/Lord_Howe", "0 * * * *", "2025-10-04T13:59:00Z", 3)).toEqual([
+      "2025-10-04T14:30:00.000Z", // 1:00 LHST
+      "2025-10-04T16:00:00.000Z", // 3:00 LHDT
+      "2025-10-04T17:00:00.000Z", // 4:00 LHDT
+    ]);
+  });
+
+  test("Lord Howe: 30-minute spring-forward gap — minute list fires in real-time order", async () => {
+    // From 1:50 LHST, "10,35,40 * * * *": wall-clock 2:10 (in the gap) maps to
+    // 2:40 LHDT, but the existing minute 2:35 LHDT comes first.
+    expect(await chainInTZ("Australia/Lord_Howe", "10,35,40 * * * *", "2025-10-04T15:20:00Z", 3)).toEqual([
+      "2025-10-04T15:35:00.000Z", // 2:35 LHDT
+      "2025-10-04T15:40:00.000Z", // 2:40 LHDT
+      "2025-10-04T16:10:00.000Z", // 3:10 LHDT
+    ]);
+  });
+
+  test("Lord Howe: 30-minute spring-forward gap — fixed-time minute list does not skip an existing minute", async () => {
+    // "10,35,40 2 * * *" from 1:50 LHST: wall-clock 2:10 is in the gap and shifts
+    // to 2:40 LHDT. The existing 2:35 fires first, then 2:40, then the next day.
+    expect(await chainInTZ("Australia/Lord_Howe", "10,35,40 2 * * *", "2025-10-04T15:20:00Z", 3)).toEqual([
+      "2025-10-04T15:35:00.000Z", // 2:35 LHDT
+      "2025-10-04T15:40:00.000Z", // 2:40 LHDT
+      "2025-10-05T15:10:00.000Z", // next day 2:10 LHDT
+    ]);
+  });
+
+  test("Chatham: 60-minute gap at 02:45 — wildcard minute fires at the first existing minute of the hour", async () => {
+    // Pacific/Chatham 2025-09-28 02:45 CHAST (+12:45) → 03:45 CHADT (+13:45); 2:45-3:44 don't exist.
+    // "* 3 * * *" from 2:00: the first existing minute of hour 3 is 3:45, not the
+    // gap-shifted 4:00.
+    expect(await chainInTZ("Pacific/Chatham", "* 3 * * *", "2025-09-27T13:15:00Z", 2)).toEqual([
+      "2025-09-27T14:00:00.000Z", // 3:45 CHADT
+      "2025-09-27T14:01:00.000Z", // 3:46 CHADT
+    ]);
+  });
+
+  test("Chatham: 60-minute gap at 02:45 — fixed-time schedule fires at an existing minute before the shifted one", async () => {
+    // "0,50 3 * * *" from 2:00 CHAST: 3:00 is in the gap and shifts to 4:00 CHADT,
+    // but 3:50 CHADT exists and comes first. Then the next day.
+    expect(await chainInTZ("Pacific/Chatham", "0,50 3 * * *", "2025-09-27T13:15:00Z", 2)).toEqual([
+      "2025-09-27T14:05:00.000Z", // 3:50 CHADT
+      "2025-09-28T13:15:00.000Z", // next day 3:00 CHADT
+    ]);
+  });
+
+  test("spring-forward: every-minute schedule pinned to the missing hour skips the day", async () => {
+    // "* 2 * * *" runs on real time (wildcard minute). 2:xx EST does not exist
+    // on 2025-03-09, and 3:xx EDT is not hour 2, so the next run is the next day.
+    const next = await parseInTZ("America/New_York", "* 2 * * *", "2025-03-09T06:59:00Z"); // = 01:59 EST
+    expect(next).toBe("2025-03-10T06:00:00.000Z"); // 2025-03-10 02:00 EDT
+  });
+
   test("Lord Howe: 30-minute fall-back — wildcard fires through repeated half-hour", async () => {
     // 2025-04-06 02:00 LHDT (+11) → 01:30 LHST (+10:30); 1:30-1:59 repeats.
     // After first 1:59 (14:59Z), every-minute → second 1:30 (15:00Z).
@@ -245,6 +302,21 @@ describe.concurrent("Bun.cron.parse — { tz } option", () => {
       "2025-11-02T05:00:00.000Z", // 1st 1:00 EDT
       "2025-11-02T06:00:00.000Z", // 2nd 1:00 EST
       "2025-11-02T07:00:00.000Z", // 2:00 EST
+    ]);
+  });
+
+  test("DST via tz option (Lord Howe 30-minute spring-forward gap, wildcard hour)", async () => {
+    const out = await evalInTZ(
+      "UTC",
+      `let t = new Date("2025-10-04T13:59:00Z");
+       const seq = [];
+       for (let i = 0; i < 3; i++) { t = Bun.cron.parse("0 * * * *", t, {tz: "Australia/Lord_Howe"}); seq.push(t.toISOString()); }
+       process.stdout.write(JSON.stringify(seq))`,
+    );
+    expect(JSON.parse(out)).toEqual([
+      "2025-10-04T14:30:00.000Z", // 1:00 LHST
+      "2025-10-04T16:00:00.000Z", // 3:00 LHDT (2:00-2:29 don't exist)
+      "2025-10-04T17:00:00.000Z", // 4:00 LHDT
     ]);
   });
 


### PR DESCRIPTION
### Problem
- When a wall-clock candidate falls in a spring-forward gap, `Bun.cron.parse` (and the in-process scheduler) can return a minute the schedule does not match, or skip an earlier real match. `* 2 * * *` fires once at 03:00 on the spring-forward day in every one hour gap zone. In `Australia/Lord_Howe` (30 minute gap) `0 * * * *` fires at 02:30, and `10,35,40 2 * * *` returns 02:40 and never 02:35.
- The cause is `resolve_local_match` (`src/runtime/api/cron_parser.rs:187`). `gregorian_to_ms` resolves a minute that does not exist to the instant shifted past the gap, and the function accepted it without a check. Inside a gap, wall-clock order and real-time order differ.

### Fix
- Detect the gap with `CronTz::in_gap`: convert the resolved instant back to wall-clock time and compare the minute. A NaN result (past the Date range) is not a gap.
- Wildcard schedules (`*` minute or `*` hour) run on real time: reject the candidate and let the walk in `next()` continue to the first existing minute after the gap.
- Fixed-time schedules still fire once at the shifted instant (documented: `30 2 * * *` at 03:30), unless an existing minute before it matches. That scan is bounded by `MAX_DST_SHIFT_MIN`.
- Verified: `test/js/bun/cron/cron-local-time.test.ts` (7 new tests, all fail on the current build). Also `cron-parse.test.ts`, `in-process-cron.test.ts`, and a brute-force oracle over 9 zones (4950 checks, 5 wildcard divergences before, 0 after).

### Background
- `CronExpression::next` walks wall-clock minutes in order. `resolve_local_match` turns a match into a real instant and handles DST: a fall-back repeats an hour (a minute scan recovers the second occurrence), a spring-forward removes one.
- `CronTz` is the process zone or a named IANA zone from `{ tz }`. Both conversions go through JSC and shift a non-existent wall-clock time forward by the gap.
- "Wildcard" means the minute or hour field is `*`. These run on real time. The others are fixed-time and follow the run-once rules cronie uses. The docs and `bun.d.ts` now state the wildcard rule for spring-forward.

<details><summary>Notes</summary>

More cases from the oracle, before the fix: `* 3 * * *` in `Pacific/Chatham` (gap 02:45 to 03:45) fires at 04:00 and skips 03:45 to 03:59. `0,50 3 * * *` there returns 04:00 and never 03:50. `* 2 * * *` in `Antarctica/Troll` (two hour gap) fires at hour 4.

With a one hour gap aligned to the hour, the shifted minute of a `*` hour schedule still matches (`0 * * * *` at 02:00 shifts to 03:00), so only `*` minute schedules pinned to the gap hour, and zones with a gap that does not align to the hour (Lord Howe, Chatham), showed the bug.

Why "reject and continue the walk" is enough for wildcard schedules: all real instants before the transition correspond 1:1 to wall-clock minutes the walk already rejected. After the transition the correspondence is 1:1 again. So the first wall-clock candidate that exists is the first real instant that matches.

Why the fixed-time scan is bounded: real instants before the transition were rejected by the walk (same argument), and the transition is at most `MAX_DST_SHIFT_MIN` (120) minutes before the shifted instant. Only those minutes can hold an existing match the walk has not seen yet.

Behavior change for one hour gaps: `* 2 * * *` pinned to the missing hour used to fire once at 03:00 (a minute with hour 3). It now skips the spring-forward day, as cronie does for wildcard jobs. `0 * * * *`, `*/15 * * * *`, `30 2 * * *`, `*/15 2 * * *` and the other existing DST tests are unchanged.

Oracle: for 9 zones (UTC, Los_Angeles, New_York, Tokyo, London, Lord_Howe, Chatham, Santiago, Troll), 11 expressions and 10 start times around DST transitions, chain 5 results and check each against `Intl.DateTimeFormat` in the zone: the result matches the expression and no real minute between the start and the result matches. The fixed-time divergences that remain are the documented rules: fire once in a fall-back, fire shifted in a gap.

`Bun.cron.parse("* * * * *", 8.64e15, { tz })` still walks for a long time before it returns null. That is the existing behavior on main. #36894 fixes it. The `in_gap` NaN check keeps that PR's tail change effective once both land.

The `impossible day/month (Feb 30) returns null quickly` test in `cron-parse.test.ts` fails on a debug build when it is the first `Bun.cron.parse` call in the process (ICU cold start, about 150 ms here, the bound is 50 ms). It does not call `resolve_local_match`. #36894 adds a warm-up call for this.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cron/cron-local-time.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/168] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/168] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 243 extern-C blocks audited
[3/168] gen cpp.rs (cppbind)
[4/168] gen BunProcess.lut.h
Generating /workspace/bun/build/debug/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/168] gen JS modules (bundle-modules)
Preprocess modules (7331ms)
Bundle modules (41ms)
Postprocesss modules (34ms)
Bundle Functions (445ms)
Generate Code (23ms)

[7.89s] Bundled "src/js" for development
  2786 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[5/167] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[6/167] cc ob
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/bun/cron/cron-local-time.test.ts:
(pass) Bun.cron.parse — local time zone > 0 9 * * * in UTC is 9am UTC [23.73ms]
(pass) Bun.cron.parse — local time zone > 0 9 * * * in America/Los_Angeles is 9am Pacific (PDT = UTC-7) [25.21ms]
(pass) Bun.cron.parse — local time zone > 0 9 * * * in Asia/Tokyo is 9am JST (UTC+9, no DST) [25.79ms]
(pass) Bun.cron.parse — DST transitions > spring-forward: schedule in the missing hour fires shifted forward (same day) [25.11ms]
(pass) Bun.cron.parse — DST transitions > fall-back: schedule in the duplicated hour fires at the first occurrence [25.10ms]
(pass) Bun.cron.parse — DST transitions > fall-back: starting from the second occurrence does not return a time before from [25.13ms]
(pass) Bun.cron.parse — DST transitions > fall-back: wildcard hour fires through both occurrences (cronie semantics) [25.07ms]
(pass) Bun.cron.parse — DST transitions > fall-back: every-minute fires through both occurrences [25.47ms]
(pass) Bun.cron.parse — DST transitions > fall-back: every-minute chained from the transition walks the repeated hour [26.37ms]
(pass) Bun.cron.parse — DST transiti
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/cron/cron-local-time.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/cron/cron-local-time.test.ts:
(pass) Bun.cron.parse — local time zone > 0 9 * * * in UTC is 9am UTC [1116.78ms]
(pass) Bun.cron.parse — DST transitions > spring-forward: schedule in the missing hour fires shifted forward (same day) [1105.34ms]
(pass) Bun.cron.parse — local time zone > 0 9 * * * in America/Los_Angeles is 9am Pacific (PDT = UTC-7) [1203.73ms]
(pass) Bun.cron.parse — local time zone > 0 9 * * * in Asia/Tokyo is 9am JST (UTC+9, no DST) [1174.78ms]
(pass) Bun.cron.parse — local time zone > weekday matching uses local day-of-week (0 12 * * MON across the dateline) [1180.04ms]
(pass) Bun.cron.parse — DST transitions > fall-back: schedule in the duplicated hour fires at the first occurrence [1105.94ms]
(pass) Bun.cron.parse — DST transitions > fall-back: starting from the second occurrence does not return a time before from [1107.19ms]
(pass) Bun.cron.parse — DST transitions > fall-back: wildcard hour fires through both occurrence
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     325db52bf6
  features     baseline

23 deps, 129 codegen, 1172 objects in 703ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [31.00ms]
[2/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[3/1217] gen bindgenv2
[4/1217] fetch tinycc
[tinycc] up to date
[5/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1216] fetch zlib
[zlib] up to date
[7/1216] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [5.00ms]
[8/1216] gen ErrorCode+*.h
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1216] instal
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/cron.mdx                    |  2 +-
 packages/bun-types/bun.d.ts              |  8 ++--
 src/runtime/api/cron_parser.rs           | 39 ++++++++++++++++-
 test/js/bun/cron/cron-local-time.test.ts | 72 ++++++++++++++++++++++++++++++++
 4 files changed, 116 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
docs/runtime/cron.mdx                         1      2      0
packages/bun-types/bun.d.ts                   1      1      0
src/runtime/api/cron_parser.rs                5      9      0
test/js/bun/cron/cron-local-time.test.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->