### PR TITLE
Add agentic-bun: multi-agent dispatcher for `ollama launch claude`

### DIFF
--- a/packages/agentic-bun/README.md
+++ b/packages/agentic-bun/README.md
@@ -1,0 +1,220 @@
+# agentic-bun
+
+A thin Bun CLI that turns a few plain-text answers into one or more **Claude Code**
+agents running against a **local Ollama model**, via `ollama launch claude`.
+
+It is a dispatcher, not an agent runtime. There is no tool-calling loop, no planner
+object, no memory store. Each agent is a real `claude` process, so file editing, shell
+access and web fetch come from Claude Code's own harness. This project owns exactly
+four things: the wizard, the prompts, process fan-out, and the report at the end.
+
+```
+wizard / flags ─► one prompt per agent ─► N × ollama launch claude -- -p "<prompt>" ─► prefixed live output ─► summary
+```
+
+## Requirements
+
+- **Bun** 1.1+ (developed on 1.3.11).
+- **Ollama** 0.14.0+ for the Anthropic-compatible API; **0.15+** for the `ollama launch`
+  subcommand this tool drives. Check with `ollama --version`. If `ollama launch` errors
+  with `unknown command`, upgrade Ollama.
+- **At least one pulled model**: `ollama pull qwen2.5-coder:7b`.
+- `ollama launch claude` installs/launches the Claude Code CLI and sets
+  `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` for it. With
+  `--direct` this tool sets those itself and runs `claude` directly, which needs the
+  `claude` CLI on `PATH`.
+
+## Dependencies
+
+**Zero.** Nothing is installed; `package.json` has no `dependencies` or
+`devDependencies` field at all. Subprocesses use `Bun.spawn`, questions use the built-in
+`node:readline/promises`, and the tests use `bun:test`.
+
+## Install
+
+```sh
+cd packages/agentic-bun
+bun link                 # optional: puts `agentic-bun` on your PATH
+bun run src/cli.ts --help
+```
+
+## Usage
+
+```sh
+# Interactive: three to five questions, then it runs.
+agentic-bun
+
+# One agent, no questions.
+agentic-bun -y -g "explain what src/resolver does" -m qwen2.5-coder:7b
+
+# Three agents; the model splits the goal into three tasks first.
+agentic-bun -y -g "add streaming to the CSV reader" -n 3
+
+# Three agents, tasks you wrote yourself, two at a time.
+agentic-bun -t "implement the reader" -t "write tests" -t "update the docs" -c 2
+
+# Let the agents actually edit files, and pass anything else straight to claude.
+agentic-bun -g "fix the lint errors" -n 2 --permission-mode acceptEdits -- --verbose
+
+# See the exact commands without running anything.
+agentic-bun --dry-run -g "..." -n 2
+
+# Machine-readable: captures output instead of streaming it.
+agentic-bun --json -y -g "audit the error paths" -n 4 > report.json
+```
+
+Run `agentic-bun --help` for the full flag list.
+
+### Notes on behaviour
+
+- **Headless by default.** Every agent runs as `claude -p <prompt>`, so it never waits
+  for terminal input. By default Claude Code will refuse tool calls that need
+  permission; pass `--permission-mode acceptEdits` (or `bypassPermissions`) if you want
+  the agents to change files.
+- **Agents share one working tree.** Each agent's prompt lists the other agents' tasks
+  and tells it to stay in its lane and not to commit, push, or run repo-wide destructive
+  commands. That is a prompt-level convention, not a sandbox — give unrelated tasks to
+  unrelated directories if you need real isolation.
+- **Concurrency** defaults to `min(agents, 4)`; override with `-c`.
+- **Timeouts:** each agent is killed after `--timeout` seconds (default 900) and reported
+  as `timeout`.
+- **Exit code** is 0 only if every agent exited 0. Ctrl-C terminates all live agents.
+- Nothing is written to disk, no session is saved, and the process exits when the last
+  agent does.
+
+## Which `ollama launch` flags were verified
+
+**None on the build machine.** Ollama could not be installed in the environment this was
+developed in (no `ollama` binary, and the outbound proxy blocks `ollama.com`), so
+`ollama launch --help` was never run against a real install. Rather than hard-code the
+flags from the spec, the tool **probes at startup** and adapts:
+
+| Probe                  | What it does                                                                                                                                                                        |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ollama --version`     | Warns if older than 0.14.0.                                                                                                                                                         |
+| `ollama launch --help` | If the subcommand is missing, exits with an upgrade hint. `--model` and `--yes` are only passed if the help text advertises them; if either is missing you get a `note:` on stderr. |
+| `ollama list`          | Auto-selects the model when exactly one is installed; otherwise offers a numbered list.                                                                                             |
+
+`-- <args>` passthrough is used unconditionally (with a `note:` if the help text does not
+document it), because there is no way to detect it other than trying. If a future Ollama
+changes the surface further, `--direct` skips `ollama launch` entirely and runs `claude`
+against `$OLLAMA_HOST` (default `http://localhost:11434`) with the Anthropic-compatible
+environment variables set locally.
+
+**Verified on the build machine:** the `claude` flags used (`-p`, `--model`,
+`--permission-mode`) exist on Claude Code 2.1.243.
+
+## Test transcript
+
+Ollama is unavailable here, so this run uses `test/fixtures/ollama-stub.sh` — a stub that
+answers `--version` / `list` / `launch --help` like the real CLI, records the argv it was
+launched with, and prints a canned agent reply. It exercises the whole tool; only the
+model is fake. (The stub's absolute path is shortened to `ollama` below; the tool prints
+the resolved binary path.)
+
+```console
+$ agentic-bun --dry-run -g "add streaming to the CSV reader" \
+    -t "implement the streaming reader" -t "write tests for it"
+note: using the only installed model, qwen2.5-coder:7b.
+# a1: implement the streaming reader
+ollama launch claude --model qwen2.5-coder:7b --yes -- -p 'You are agent 1 of 2 working in parallel on one shared objective.
+
+OBJECTIVE
+add streaming to the CSV reader
+
+YOUR TASK
+implement the streaming reader
+
+TASKS OWNED BY THE OTHER AGENTS (do not do these)
+  2. write tests for it
+
+RULES
+- Work inside /tmp/demo.
+- Do only your task. If your task needs something another agent owns, assume it will exist and note the assumption in your summary instead of doing their work.
+- The other agents are editing this same working tree right now. Do not run repo-wide destructive commands (git checkout/reset/clean/stash, mass reformat, dependency reinstall) and do not commit or push.
+- Prefer edits scoped to the files your task names.
+
+When you are finished, print a short summary: what you changed, which files you touched, and anything you could not do.'
+
+# a2: write tests for it
+ollama launch claude --model qwen2.5-coder:7b --yes -- -p 'You are agent 2 of 2 ...'
+
+$ agentic-bun -g "add streaming to the CSV reader" \
+    -t "implement the streaming reader" -t "write tests for it"
+note: using the only installed model, qwen2.5-coder:7b.
+Running 2 agent(s) in /tmp/demo on qwen2.5-coder:7b (concurrency 2).
+[a1] edited src/csv.ts; all tests pass
+[a2] edited src/csv.ts; all tests pass
+
+Summary
+  a1   ok             0.0s  implement the streaming reader
+  a2   ok             0.0s  write tests for it
+  2/2 agents succeeded.
+```
+
+Interactive wizard, same stub, under a real pty:
+
+```console
+$ agentic-bun
+What do you want done? add tests for the parser
+Which directory should the agents work in? [/tmp/demo]
+How many agents should run in parallel? [1] 2
+Describe each agent's task, one per line. Press Enter on an empty line to let the model split the goal for you.
+  agent 1: cover the happy path
+  agent 2: cover the error path
+Installed models:
+  1. qwen2.5-coder:7b
+  2. glm-4.7-flash
+Which model? [1] 2
+Running 2 agent(s) in /tmp/demo on glm-4.7-flash (concurrency 2).
+[a1] agent finished
+[a2] agent finished
+
+Summary
+  a1   ok             0.0s  cover the happy path
+  a2   ok             0.0s  cover the error path
+  2/2 agents succeeded.
+```
+
+**Not yet verified end to end against a real Ollama install.** Everything above the model
+boundary is exercised by the tests; the one unverified step is whether the installed
+`ollama launch` accepts the flags in the order this tool emits them.
+
+## Tests
+
+```sh
+cd packages/agentic-bun
+bun test test/            # 42 tests
+```
+
+No debug build of Bun is needed — this package is plain TypeScript and never calls into
+Bun's native code, so it runs on the system `bun` (same exception the repo makes for
+`packages/bun-types`).
+
+- `test/unit.test.ts` — version/model/help parsing, command construction for both launch
+  and direct modes, prompt contents, plan parsing, argument parsing.
+  `tsc --noEmit` was **not** run: this checkout has no `node_modules`, so
+  `@types/node` cannot resolve. Run `bun install` at the repo root first if you want
+  to typecheck.
+
+- `test/cli.test.ts` — the CLI end to end against the stub: preflight failures, dry runs,
+  streaming with per-agent prefixes, `--json` reports, timeouts, the wizard, and
+  concurrency. The concurrency tests are timing-free: the stub blocks until N agents are
+  alive at once, so parallel runs pass and serialized runs deliberately do not.
+
+## Files
+
+| File            | Purpose                                                            |
+| --------------- | ------------------------------------------------------------------ |
+| `src/cli.ts`    | Flags, wizard, preflight, planning call, summary. Read this first. |
+| `src/ollama.ts` | Probing the local Ollama install.                                  |
+| `src/plan.ts`   | Prompt strings and parsing the model's task list.                  |
+| `src/runner.ts` | Spawning the agents, the concurrency pool, output multiplexing.    |
+
+## Scope note
+
+The original handoff brief for this tool listed multi-agent orchestration as a non-goal
+and asked for a single-shot dispatcher. The request this was built against asked for
+multiple agents, so fan-out was added: a concurrency pool, per-agent prompts and a
+combined report. The brief's real constraint is intact — there is still no agent loop,
+planner or tool framework here, only N invocations of a harness that already exists.

--- a/packages/agentic-bun/package.json
+++ b/packages/agentic-bun/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "agentic-bun",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Thin Bun CLI that fans a goal out to several Claude Code agents running on local Ollama models",
+  "type": "module",
+  "bin": {
+    "agentic-bun": "./src/cli.ts"
+  },
+  "scripts": {
+    "start": "bun run src/cli.ts",
+    "test": "bun test test/"
+  }
+}

--- a/packages/agentic-bun/src/cli.ts
+++ b/packages/agentic-bun/src/cli.ts
@@ -1,0 +1,520 @@
+#!/usr/bin/env bun
+/**
+ * agentic-bun - fan a goal out to several Claude Code agents running on local
+ * Ollama models.
+ *
+ * Flow: preflight the local ollama install -> ask a handful of plain questions
+ * (or take them from flags) -> turn the answers into one prompt per agent ->
+ * spawn `ollama launch claude ... -- -p <prompt>` per agent -> stream the
+ * output back with a per-agent prefix -> print a summary and exit.
+ */
+
+import { statSync } from "node:fs";
+import { resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { MIN_OLLAMA_VERSION, probeOllama, type OllamaProbe } from "./ollama.ts";
+import { buildAgentPrompt, buildPlannerPrompt, extractTaskList, toSpecs, type AgentSpec } from "./plan.ts";
+import { buildCommand, runAgents, type AgentResult, type Job, type RunnerOptions } from "./runner.ts";
+
+const VERSION = "0.1.0";
+const DEFAULT_TIMEOUT_SEC = 900;
+const DEFAULT_MAX_CONCURRENCY = 4;
+const MAX_AGENTS = 16;
+
+interface Options {
+  goal: string | null;
+  tasks: string[];
+  agents: number | null;
+  cwd: string;
+  model: string | null;
+  concurrency: number | null;
+  plan: boolean;
+  permissionMode: string | null;
+  direct: boolean;
+  dryRun: boolean;
+  json: boolean;
+  timeoutSec: number;
+  yes: boolean;
+  ollamaHost: string;
+  extraClaudeArgs: string[];
+  help: boolean;
+  version: boolean;
+}
+
+const HELP = `agentic-bun ${VERSION} - multi-agent dispatcher for \`ollama launch claude\`
+
+Usage:
+  agentic-bun [options] [-- <args passed to claude>]
+
+Run with no options to answer a few questions interactively.
+
+Options:
+  -g, --goal <text>        Overall objective.
+  -t, --task <text>        One agent's task. Repeat for more agents.
+  -n, --agents <n>         Number of agents. With no --task, the model splits the goal into this many.
+  -C, --cwd <dir>          Directory the agents work in (default: current directory).
+  -m, --model <name>       Ollama model. Auto-selected when exactly one is installed.
+  -c, --concurrency <n>    Max agents running at once (default: min(agents, ${DEFAULT_MAX_CONCURRENCY})).
+      --plan               Do not ask for per-agent tasks; let the model split the goal.
+      --permission-mode <m> Forwarded to claude (acceptEdits, bypassPermissions, ...).
+      --direct             Skip \`ollama launch\`; run \`claude\` against --ollama-host.
+      --ollama-host <url>  Ollama base URL for --direct (default: $OLLAMA_HOST or http://localhost:11434).
+      --timeout <sec>      Per-agent timeout (default: ${DEFAULT_TIMEOUT_SEC}).
+      --dry-run            Print the commands that would run, then exit.
+      --json               Capture output and print one JSON report at the end.
+  -y, --yes                Never prompt; fail if something is missing.
+  -h, --help               Show this help.
+  -v, --version            Show version.
+
+Examples:
+  agentic-bun
+  agentic-bun -g "add tests for the parser" -n 3 --model qwen2.5-coder:7b
+  agentic-bun -t "write the docs" -t "add the benchmark" --json
+  agentic-bun -g "fix lint" -n 2 -- --permission-mode acceptEdits --verbose
+`;
+
+export function parseArgs(argv: string[]): Options {
+  const opts: Options = {
+    goal: null,
+    tasks: [],
+    agents: null,
+    cwd: process.cwd(),
+    model: null,
+    concurrency: null,
+    plan: false,
+    permissionMode: null,
+    direct: false,
+    dryRun: false,
+    json: false,
+    timeoutSec: DEFAULT_TIMEOUT_SEC,
+    yes: false,
+    ollamaHost: process.env.OLLAMA_HOST ?? "http://localhost:11434",
+    extraClaudeArgs: [],
+    help: false,
+    version: false,
+  };
+
+  const args = [...argv];
+  const passthroughAt = args.indexOf("--");
+  if (passthroughAt !== -1) {
+    opts.extraClaudeArgs = args.slice(passthroughAt + 1);
+    args.length = passthroughAt;
+  }
+
+  const valueOf = (arg: string, inline: string | undefined, i: { v: number }): string => {
+    if (inline !== undefined) return inline;
+    const next = args[++i.v];
+    if (next === undefined) throw new Error(`${arg} needs a value`);
+    return next;
+  };
+
+  const cursor = { v: 0 };
+  for (; cursor.v < args.length; cursor.v++) {
+    const raw = args[cursor.v];
+    const eq = raw.indexOf("=");
+    const flag = raw.startsWith("--") && eq !== -1 ? raw.slice(0, eq) : raw;
+    const inline = raw.startsWith("--") && eq !== -1 ? raw.slice(eq + 1) : undefined;
+
+    switch (flag) {
+      case "-g":
+      case "--goal":
+        opts.goal = valueOf(flag, inline, cursor);
+        break;
+      case "-t":
+      case "--task":
+        opts.tasks.push(valueOf(flag, inline, cursor));
+        break;
+      case "-n":
+      case "--agents":
+        opts.agents = parseCount(valueOf(flag, inline, cursor), flag);
+        break;
+      case "-C":
+      case "--cwd":
+        opts.cwd = valueOf(flag, inline, cursor);
+        break;
+      case "-m":
+      case "--model":
+        opts.model = valueOf(flag, inline, cursor);
+        break;
+      case "-c":
+      case "--concurrency":
+        opts.concurrency = parseCount(valueOf(flag, inline, cursor), flag);
+        break;
+      case "--plan":
+        opts.plan = true;
+        break;
+      case "--permission-mode":
+        opts.permissionMode = valueOf(flag, inline, cursor);
+        break;
+      case "--direct":
+        opts.direct = true;
+        break;
+      case "--ollama-host":
+        opts.ollamaHost = valueOf(flag, inline, cursor);
+        break;
+      case "--timeout":
+        opts.timeoutSec = parseCount(valueOf(flag, inline, cursor), flag);
+        break;
+      case "--dry-run":
+        opts.dryRun = true;
+        break;
+      case "--json":
+        opts.json = true;
+        break;
+      case "-y":
+      case "--yes":
+        opts.yes = true;
+        break;
+      case "-h":
+      case "--help":
+        opts.help = true;
+        break;
+      case "-v":
+      case "--version":
+        opts.version = true;
+        break;
+      default:
+        throw new Error(`unknown option: ${raw}`);
+    }
+  }
+
+  if (opts.agents !== null && opts.agents > MAX_AGENTS) throw new Error(`--agents must be <= ${MAX_AGENTS}`);
+  if (opts.plan && opts.tasks.length)
+    throw new Error("--plan and --task are mutually exclusive: --task already says what each agent does");
+  return opts;
+}
+
+function parseCount(value: string, flag: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) throw new Error(`${flag} must be a positive integer, got "${value}"`);
+  return n;
+}
+
+/** Fail fast with an actionable message rather than a confusing spawn error. */
+function preflight(probe: OllamaProbe, opts: Options): string[] {
+  const problems: string[] = [];
+  const notes: string[] = [];
+
+  if (!probe.binary) {
+    if (!opts.direct) {
+      problems.push(
+        "`ollama` was not found on PATH. Install it from https://ollama.com, or use --direct with a reachable --ollama-host.",
+      );
+    }
+  } else {
+    if (!probe.versionOk) {
+      notes.push(`ollama ${probe.version ?? "(unknown version)"} detected; ${MIN_OLLAMA_VERSION}+ is recommended.`);
+    }
+    if (!opts.direct && !probe.launch.supported) {
+      problems.push(
+        "`ollama launch` is not available on this ollama version. Upgrade ollama, or pass --direct to run `claude` against the Ollama API yourself.",
+      );
+    }
+  }
+
+  if (!opts.direct && probe.launch.supported) {
+    if (!probe.launch.supportsModelFlag)
+      notes.push("`ollama launch` does not advertise --model; the model will be chosen by ollama.");
+    if (!probe.launch.supportsYesFlag)
+      notes.push("`ollama launch` does not advertise --yes; it may prompt interactively.");
+    if (!probe.launch.supportsPassthrough)
+      notes.push("`ollama launch --help` does not document `-- <args>` passthrough; trying it anyway.");
+  }
+
+  if (opts.direct && !Bun.which("claude")) {
+    problems.push("--direct needs the `claude` CLI on PATH. Install it from https://claude.com/code.");
+  }
+
+  for (const note of notes) console.error(`note: ${note}`);
+  return problems;
+}
+
+interface Answers {
+  goal: string;
+  cwd: string;
+  tasks: string[];
+  agentCount: number;
+  model: string | null;
+}
+
+async function runWizard(opts: Options, probe: OllamaProbe): Promise<Answers> {
+  // Questions and their echo go to stderr so stdout stays clean for --json/--dry-run.
+  // Lines are queued as readline emits them: piped input arrives in one burst, so a
+  // question asked later still finds its answer. EOF just means "use the default".
+  const rl = opts.yes
+    ? null
+    : createInterface({ input: process.stdin, output: process.stderr, terminal: Boolean(process.stdin.isTTY) });
+
+  let closed = false;
+  const pending: string[] = [];
+  const waiting: Array<(line: string | null) => void> = [];
+  rl?.on("line", line => {
+    const waiter = waiting.shift();
+    if (waiter) waiter(line);
+    else pending.push(line);
+  });
+  rl?.on("close", () => {
+    closed = true;
+    while (waiting.length) waiting.shift()!(null);
+  });
+  rl?.on("SIGINT", () => {
+    rl.close();
+    process.exit(130);
+  });
+
+  const ask = async (question: string, fallback = ""): Promise<string> => {
+    if (!rl) return fallback;
+    let line: string | null;
+    if (pending.length) {
+      process.stderr.write(`${question}\n`);
+      line = pending.shift()!;
+    } else if (closed) {
+      line = null;
+    } else {
+      process.stderr.write(question);
+      line = await new Promise<string | null>(resolve => waiting.push(resolve));
+    }
+    const trimmed = (line ?? "").trim();
+    return trimmed.length ? trimmed : fallback;
+  };
+
+  try {
+    // 1. goal
+    let goal = opts.goal ?? "";
+    if (!goal && opts.tasks.length) goal = opts.tasks.join("; ");
+    const askedGoal = !goal;
+    if (!goal) {
+      goal = await ask("What do you want done? ");
+      if (!goal) throw new Error("a goal is required (pass --goal, or answer the first question)");
+    }
+
+    // 2. working directory. Only worth asking someone who is already answering
+    // questions - anyone passing --goal/--task on the command line can pass --cwd too.
+    const cwd =
+      askedGoal && opts.cwd === process.cwd()
+        ? await ask(`Which directory should the agents work in? [${process.cwd()}] `, process.cwd())
+        : opts.cwd;
+
+    // 3. how many agents
+    let agentCount = opts.agents ?? opts.tasks.length;
+    if (!agentCount) {
+      const answer = await ask("How many agents should run in parallel? [1] ", "1");
+      agentCount = parseCount(answer, "agent count");
+      if (agentCount > MAX_AGENTS) throw new Error(`at most ${MAX_AGENTS} agents`);
+    }
+
+    // 4. per-agent tasks (only worth asking when there is more than one agent)
+    let tasks = [...opts.tasks];
+    if (!tasks.length && agentCount > 1 && !opts.plan && rl && !closed) {
+      console.error(
+        "Describe each agent's task, one per line. Press Enter on an empty line to let the model split the goal for you.",
+      );
+      for (let i = 0; i < agentCount; i++) {
+        const task = await ask(`  agent ${i + 1}: `);
+        if (!task) break;
+        tasks.push(task);
+      }
+    }
+    if (tasks.length && tasks.length !== agentCount) agentCount = tasks.length;
+    if (!tasks.length && agentCount === 1) tasks = [goal];
+
+    // 5. model
+    let model = opts.model;
+    if (!model) {
+      if (probe.models.length === 1) {
+        model = probe.models[0];
+        console.error(`note: using the only installed model, ${model}.`);
+      } else if (probe.models.length > 1 && rl && !closed) {
+        console.error("Installed models:");
+        probe.models.forEach((m, i) => console.error(`  ${i + 1}. ${m}`));
+        const answer = await ask(`Which model? [1] `, "1");
+        const index = Number(answer);
+        model =
+          Number.isInteger(index) && index >= 1 && index <= probe.models.length ? probe.models[index - 1] : answer;
+      } else if (probe.models.length > 1) {
+        model = probe.models[0];
+        console.error(`note: defaulting to ${model}; pass --model to choose another.`);
+      }
+    }
+
+    return { goal, cwd, tasks, agentCount, model };
+  } finally {
+    rl?.close();
+  }
+}
+
+function runnerOptions(
+  opts: Options,
+  probe: OllamaProbe,
+  model: string | null,
+  cwd: string,
+  agentCount: number,
+  capture: boolean,
+): RunnerOptions {
+  const useLaunch = !opts.direct && probe.launch.supported;
+  return {
+    ollamaBinary: probe.binary ?? "ollama",
+    claudeBinary: Bun.which("claude") ?? "claude",
+    useLaunch,
+    supportsModelFlag: probe.launch.supportsModelFlag,
+    supportsYesFlag: probe.launch.supportsYesFlag,
+    model,
+    cwd,
+    permissionMode: opts.permissionMode ?? undefined,
+    extraClaudeArgs: opts.extraClaudeArgs,
+    concurrency: opts.concurrency ?? Math.min(agentCount, DEFAULT_MAX_CONCURRENCY),
+    timeoutMs: opts.timeoutSec * 1000,
+    ollamaHost: opts.ollamaHost,
+    capture,
+    color: !capture && Boolean(process.stdout.isTTY) && !process.env.NO_COLOR,
+  };
+}
+
+/** One throwaway headless call that asks the model to split the goal. */
+async function planTasks(goal: string, count: number, cwd: string, runner: RunnerOptions): Promise<string[]> {
+  console.error(`Splitting the goal into ${count} tasks...`);
+  const job: Job = { id: "plan", task: "decompose the goal", prompt: buildPlannerPrompt(goal, count, cwd) };
+  const [result] = await runAgents([job], { ...runner, capture: true, concurrency: 1 });
+  const raw = `${result?.stdout ?? ""}\n${result?.stderr ?? ""}`;
+  const tasks = extractTaskList(raw).slice(0, count);
+  if (!tasks.length) {
+    const preview = raw.trim().slice(0, 500) || "(no output)";
+    throw new Error(
+      `could not read a task list from the model. It replied:\n${preview}\n\nPass --task explicitly instead.`,
+    );
+  }
+  if (tasks.length < count) console.error(`note: the model returned ${tasks.length} task(s) instead of ${count}.`);
+  return tasks;
+}
+
+function printSummary(results: AgentResult[]): number {
+  const failed = results.filter(r => r.exitCode !== 0);
+  console.error("");
+  console.error("Summary");
+  for (const r of results) {
+    const status = r.timedOut
+      ? "timeout"
+      : r.exitCode === 0
+        ? "ok"
+        : `exit ${r.exitCode ?? "?"}${r.signal ? ` (${r.signal})` : ""}`;
+    const seconds = (r.durationMs / 1000).toFixed(1);
+    console.error(`  ${r.id.padEnd(4)} ${status.padEnd(10)} ${seconds.padStart(7)}s  ${truncate(r.task, 60)}`);
+  }
+  console.error(`  ${results.length - failed.length}/${results.length} agents succeeded.`);
+  return failed.length ? 1 : 0;
+}
+
+function truncate(text: string, max: number): string {
+  const flat = text.replace(/\s+/g, " ").trim();
+  return flat.length <= max ? flat : `${flat.slice(0, max - 1)}…`;
+}
+
+export async function main(argv: string[]): Promise<number> {
+  let opts: Options;
+  try {
+    opts = parseArgs(argv);
+  } catch (err) {
+    console.error(`error: ${(err as Error).message}`);
+    console.error("run `agentic-bun --help` for usage.");
+    return 2;
+  }
+
+  if (opts.help) {
+    console.log(HELP);
+    return 0;
+  }
+  if (opts.version) {
+    console.log(VERSION);
+    return 0;
+  }
+
+  const probe = await probeOllama();
+  const problems = preflight(probe, opts);
+  if (problems.length) {
+    for (const problem of problems) console.error(`error: ${problem}`);
+    return 1;
+  }
+
+  let answers: Answers;
+  try {
+    answers = await runWizard(opts, probe);
+    answers.cwd = resolve(answers.cwd);
+    if (!statSync(answers.cwd, { throwIfNoEntry: false })?.isDirectory()) {
+      throw new Error(`${answers.cwd} is not a directory`);
+    }
+  } catch (err) {
+    console.error(`error: ${(err as Error).message}`);
+    return 1;
+  }
+
+  if (!answers.model && !process.env.ANTHROPIC_MODEL) {
+    console.error("error: no model selected and none installed. Run `ollama pull <model>`, or pass --model.");
+    return 1;
+  }
+
+  let specs: AgentSpec[];
+  const planningRunner = runnerOptions(opts, probe, answers.model, answers.cwd, 1, true);
+  if (answers.tasks.length) {
+    specs = toSpecs(answers.tasks);
+  } else if (opts.dryRun) {
+    // Nothing to plan against without calling the model; show the goal as one task.
+    specs = toSpecs([answers.goal]);
+    console.error(`note: --dry-run skips the planning call; showing 1 agent instead of ${answers.agentCount}.`);
+  } else {
+    try {
+      specs = toSpecs(await planTasks(answers.goal, answers.agentCount, answers.cwd, planningRunner));
+    } catch (err) {
+      console.error(`error: ${(err as Error).message}`);
+      return 1;
+    }
+  }
+
+  const jobs: Job[] = specs.map((spec, index) => ({
+    id: spec.id,
+    task: spec.task,
+    prompt: buildAgentPrompt({ goal: answers.goal, cwd: answers.cwd, spec, index, all: specs }),
+  }));
+
+  const runner = runnerOptions(opts, probe, answers.model, answers.cwd, jobs.length, opts.json);
+
+  if (opts.dryRun) {
+    for (const job of jobs) {
+      console.log(`# ${job.id}: ${truncate(job.task, 70)}`);
+      console.log(buildCommand(job.prompt, runner).map(quote).join(" "));
+      console.log("");
+    }
+    return 0;
+  }
+
+  console.error(
+    `Running ${jobs.length} agent(s) in ${answers.cwd}${answers.model ? ` on ${answers.model}` : ""} (concurrency ${runner.concurrency}).`,
+  );
+  const results = await runAgents(jobs, runner);
+
+  if (opts.json) {
+    console.log(
+      JSON.stringify(
+        {
+          goal: answers.goal,
+          cwd: answers.cwd,
+          model: answers.model,
+          agents: results,
+          ok: results.every(r => r.exitCode === 0),
+        },
+        null,
+        2,
+      ),
+    );
+    return results.every(r => r.exitCode === 0) ? 0 : 1;
+  }
+
+  return printSummary(results);
+}
+
+function quote(arg: string): string {
+  return /^[\w@%+=:,./-]+$/.test(arg) ? arg : `'${arg.replaceAll("'", `'\\''`)}'`;
+}
+
+if (import.meta.main) {
+  process.exit(await main(Bun.argv.slice(2)));
+}

--- a/packages/agentic-bun/src/ollama.ts
+++ b/packages/agentic-bun/src/ollama.ts
@@ -1,0 +1,135 @@
+/**
+ * Everything this tool knows about the local Ollama install.
+ *
+ * Ollama's CLI surface changes between releases, so nothing here is hard-coded:
+ * we shell out to `ollama --version`, `ollama launch --help` and `ollama list`
+ * once at startup and adapt the command we build to whatever is actually
+ * supported. See README.md for which flags were (and were not) verified.
+ */
+
+/** `ollama launch` landed in 0.15, but 0.14 is the floor for the Anthropic-compatible API. */
+export const MIN_OLLAMA_VERSION = "0.14.0";
+
+export interface LaunchCapabilities {
+  /** False when `ollama launch` is missing entirely (too old, or renamed). */
+  supported: boolean;
+  supportsModelFlag: boolean;
+  supportsYesFlag: boolean;
+  /** Whether `-- <args>` is forwarded to the underlying `claude` invocation. */
+  supportsPassthrough: boolean;
+  helpText: string;
+}
+
+export interface OllamaProbe {
+  binary: string | null;
+  version: string | null;
+  /** version >= MIN_OLLAMA_VERSION. Null version (unparseable) counts as not-ok. */
+  versionOk: boolean;
+  launch: LaunchCapabilities;
+  models: string[];
+}
+
+export interface CaptureResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  /** Combined stdout+stderr; CLIs disagree about where help goes. */
+  output: string;
+}
+
+/** Run a command to completion and capture its output. Never throws for a non-zero exit. */
+export async function capture(cmd: string[], opts: { cwd?: string; timeout?: number } = {}): Promise<CaptureResult> {
+  try {
+    const proc = Bun.spawn({
+      cmd,
+      cwd: opts.cwd,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: opts.timeout ?? 15_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { exitCode, stdout, stderr, output: stdout + stderr };
+  } catch (err) {
+    return { exitCode: null, stdout: "", stderr: String(err), output: String(err) };
+  }
+}
+
+export function parseVersion(text: string): string | null {
+  return text.match(/\b(\d+\.\d+\.\d+)/)?.[1] ?? null;
+}
+
+/** -1 / 0 / 1, comparing dotted numeric versions. Non-numeric suffixes are ignored. */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(n => parseInt(n, 10) || 0);
+  const pb = b.split(".").map(n => parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const d = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/** First column of `ollama list`, minus the header row. */
+export function parseModels(listOutput: string): string[] {
+  const models: string[] = [];
+  for (const line of listOutput.split("\n")) {
+    const name = line.trim().split(/\s+/)[0];
+    if (!name || name === "NAME" || name.startsWith("failed") || name.startsWith("Error")) continue;
+    models.push(name);
+  }
+  return models;
+}
+
+export function parseLaunchHelp(result: CaptureResult): LaunchCapabilities {
+  const help = result.output;
+  const unknown = /unknown command|unknown flag|is not a bun|command not found/i.test(help);
+  const supported = !unknown && (result.exitCode === 0 || /launch/i.test(help)) && help.trim().length > 0;
+  return {
+    supported,
+    supportsModelFlag: /(^|\s)--model\b/.test(help),
+    supportsYesFlag: /(^|\s)--yes\b/.test(help),
+    // Either an explicit `--` entry in the flag list, or prose describing passthrough.
+    supportsPassthrough: /(^|\s)--(\s|$)/m.test(help) || /pass(ed|es)?\s+(through|straight|directly)?\s*to/i.test(help),
+    helpText: help,
+  };
+}
+
+export async function probeOllama(binaryName = "ollama"): Promise<OllamaProbe> {
+  const binary = Bun.which(binaryName);
+  if (!binary) {
+    return {
+      binary: null,
+      version: null,
+      versionOk: false,
+      launch: {
+        supported: false,
+        supportsModelFlag: false,
+        supportsYesFlag: false,
+        supportsPassthrough: false,
+        helpText: "",
+      },
+      models: [],
+    };
+  }
+
+  const [versionRes, launchRes, listRes] = await Promise.all([
+    capture([binary, "--version"]),
+    capture([binary, "launch", "--help"]),
+    capture([binary, "list"]),
+  ]);
+
+  const version = parseVersion(versionRes.output);
+  return {
+    binary,
+    version,
+    versionOk: version !== null && compareVersions(version, MIN_OLLAMA_VERSION) >= 0,
+    launch: parseLaunchHelp(launchRes),
+    models: listRes.exitCode === 0 ? parseModels(listRes.stdout) : [],
+  };
+}

--- a/packages/agentic-bun/src/plan.ts
+++ b/packages/agentic-bun/src/plan.ts
@@ -1,0 +1,100 @@
+/**
+ * Prompt construction and goal decomposition.
+ *
+ * There is deliberately no planner here: when the user asks for the goal to be
+ * split, we ask the model to do it in one throwaway headless call and parse the
+ * list it prints. Everything else in this file is string building.
+ */
+
+export interface AgentSpec {
+  /** Short stable label used to prefix streamed output, e.g. "a1". */
+  id: string;
+  task: string;
+}
+
+export interface PromptContext {
+  goal: string;
+  cwd: string;
+  spec: AgentSpec;
+  index: number;
+  all: AgentSpec[];
+}
+
+/** The prompt handed to one agent. Single-agent runs skip the coordination section. */
+export function buildAgentPrompt({ goal, cwd, spec, index, all }: PromptContext): string {
+  const lines: string[] = [];
+
+  if (all.length === 1) {
+    lines.push(`Task: ${goal}`);
+    if (spec.task && spec.task !== goal) lines.push("", `Specifically: ${spec.task}`);
+    lines.push("", `Work inside ${cwd}.`);
+  } else {
+    lines.push(`You are agent ${index + 1} of ${all.length} working in parallel on one shared objective.`);
+    lines.push("", "OBJECTIVE", goal);
+    lines.push("", "YOUR TASK", spec.task);
+    lines.push("", "TASKS OWNED BY THE OTHER AGENTS (do not do these)");
+    for (const [i, other] of all.entries()) {
+      if (i === index) continue;
+      lines.push(`  ${i + 1}. ${other.task}`);
+    }
+    lines.push(
+      "",
+      "RULES",
+      `- Work inside ${cwd}.`,
+      "- Do only your task. If your task needs something another agent owns, assume it will exist and note the assumption in your summary instead of doing their work.",
+      "- The other agents are editing this same working tree right now. Do not run repo-wide destructive commands (git checkout/reset/clean/stash, mass reformat, dependency reinstall) and do not commit or push.",
+      "- Prefer edits scoped to the files your task names.",
+    );
+  }
+
+  lines.push(
+    "",
+    "When you are finished, print a short summary: what you changed, which files you touched, and anything you could not do.",
+  );
+  return lines.join("\n");
+}
+
+export function buildPlannerPrompt(goal: string, count: number, cwd: string): string {
+  return [
+    `Split the objective below into exactly ${count} independent tasks that ${count} engineers could work on at the same time in ${cwd} without editing the same files.`,
+    "",
+    "OBJECTIVE",
+    goal,
+    "",
+    `Reply with ONLY a JSON array of exactly ${count} strings. No prose, no markdown fences, no numbering. Each string is one self-contained task description.`,
+  ].join("\n");
+}
+
+/**
+ * Pull a task list out of a model reply. Tries a JSON array first (with or
+ * without surrounding chatter or code fences), then falls back to numbered or
+ * bulleted lines, which is what models emit when they ignore the format ask.
+ */
+export function extractTaskList(raw: string): string[] {
+  const fromJson = extractJsonArray(raw);
+  if (fromJson.length) return fromJson;
+
+  const bulleted: string[] = [];
+  for (const line of raw.split("\n")) {
+    const m = line.match(/^\s*(?:\d+[.)]|[-*])\s+(.{3,})$/);
+    if (m) bulleted.push(m[1].trim().replace(/^["'`]|["'`,]+$/g, ""));
+  }
+  return bulleted;
+}
+
+function extractJsonArray(raw: string): string[] {
+  const start = raw.indexOf("[");
+  const end = raw.lastIndexOf("]");
+  if (start === -1 || end <= start) return [];
+  try {
+    const parsed = JSON.parse(raw.slice(start, end + 1));
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string" && v.trim().length > 0).map(v => v.trim());
+  } catch {
+    return [];
+  }
+}
+
+export function toSpecs(tasks: string[]): AgentSpec[] {
+  return tasks.map((task, i) => ({ id: `a${i + 1}`, task: task.trim() }));
+}

--- a/packages/agentic-bun/src/runner.ts
+++ b/packages/agentic-bun/src/runner.ts
@@ -1,0 +1,196 @@
+/**
+ * Spawns one `claude` process per agent and supervises the pool.
+ *
+ * This is the whole "framework": there is no agent loop here. Each agent is a
+ * real Claude Code process launched through `ollama launch claude`, so file
+ * edits, shell access and web fetch come from that harness, not from us. All we
+ * own is fan-out, concurrency, output multiplexing and the final report.
+ */
+
+export interface Job {
+  id: string;
+  task: string;
+  prompt: string;
+}
+
+export interface RunnerOptions {
+  ollamaBinary: string;
+  claudeBinary: string;
+  /** false => bypass `ollama launch` and run `claude` against OLLAMA_HOST directly. */
+  useLaunch: boolean;
+  supportsModelFlag: boolean;
+  supportsYesFlag: boolean;
+  model: string | null;
+  cwd: string;
+  permissionMode?: string;
+  /** Forwarded verbatim to `claude` (everything after `--` on our own CLI). */
+  extraClaudeArgs: string[];
+  concurrency: number;
+  timeoutMs: number;
+  ollamaHost: string;
+  /** Capture output instead of streaming it live (used by --json). */
+  capture: boolean;
+  color: boolean;
+}
+
+export interface AgentResult {
+  id: string;
+  task: string;
+  command: string[];
+  exitCode: number | null;
+  signal: string | null;
+  timedOut: boolean;
+  startedAt: string;
+  durationMs: number;
+  stdout: string;
+  stderr: string;
+}
+
+const COLORS = ["\x1b[36m", "\x1b[35m", "\x1b[32m", "\x1b[33m", "\x1b[34m", "\x1b[31m"];
+const RESET = "\x1b[0m";
+
+export function buildCommand(prompt: string, opts: RunnerOptions): string[] {
+  const claudeArgs = ["-p", prompt];
+  if (!opts.useLaunch && opts.model) claudeArgs.push("--model", opts.model);
+  if (opts.permissionMode) claudeArgs.push("--permission-mode", opts.permissionMode);
+  claudeArgs.push(...opts.extraClaudeArgs);
+
+  if (!opts.useLaunch) return [opts.claudeBinary, ...claudeArgs];
+
+  const cmd = [opts.ollamaBinary, "launch", "claude"];
+  if (opts.model && opts.supportsModelFlag) cmd.push("--model", opts.model);
+  if (opts.supportsYesFlag) cmd.push("--yes");
+  cmd.push("--", ...claudeArgs);
+  return cmd;
+}
+
+/** Env for direct mode: the same variables `ollama launch claude` sets for us. */
+export function buildEnv(opts: RunnerOptions): Record<string, string | undefined> {
+  if (opts.useLaunch) return { ...process.env };
+  return {
+    ...process.env,
+    ANTHROPIC_BASE_URL: opts.ollamaHost,
+    ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN ?? "ollama",
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY ?? "ollama",
+  };
+}
+
+/** Reads a stream, splitting on newlines so multiplexed output stays line-aligned. */
+async function pump(
+  stream: ReadableStream<Uint8Array> | undefined,
+  onLine: (line: string) => void,
+  sink: string[],
+): Promise<void> {
+  if (!stream) return;
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for await (const chunk of stream) {
+    const text = decoder.decode(chunk, { stream: true });
+    sink.push(text);
+    buffer += text;
+    let nl: number;
+    while ((nl = buffer.indexOf("\n")) !== -1) {
+      onLine(buffer.slice(0, nl));
+      buffer = buffer.slice(nl + 1);
+    }
+  }
+  if (buffer.length) onLine(buffer);
+}
+
+async function runOne(job: Job, index: number, opts: RunnerOptions, live: Set<Bun.Subprocess>): Promise<AgentResult> {
+  const command = buildCommand(job.prompt, opts);
+  const startedAt = new Date().toISOString();
+  const t0 = performance.now();
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  const color = opts.color ? COLORS[index % COLORS.length] : "";
+  const reset = opts.color ? RESET : "";
+  const prefix = `${color}[${job.id}]${reset} `;
+  const write = (line: string) => process.stdout.write(`${prefix}${line}\n`);
+  const writeErr = (line: string) => process.stderr.write(`${prefix}${line}\n`);
+  const onOut = opts.capture ? () => {} : write;
+  const onErr = opts.capture ? () => {} : writeErr;
+
+  let proc: Bun.Subprocess;
+  try {
+    proc = Bun.spawn({
+      cmd: command,
+      cwd: opts.cwd,
+      env: buildEnv(opts),
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: opts.timeoutMs,
+      killSignal: "SIGKILL",
+    });
+  } catch (err) {
+    return {
+      id: job.id,
+      task: job.task,
+      command,
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      startedAt,
+      durationMs: Math.round(performance.now() - t0),
+      stdout: "",
+      stderr: `failed to spawn: ${err}`,
+    };
+  }
+
+  live.add(proc);
+  await Promise.all([
+    pump(proc.stdout as ReadableStream<Uint8Array>, onOut, stdoutChunks),
+    pump(proc.stderr as ReadableStream<Uint8Array>, onErr, stderrChunks),
+  ]);
+  const exitCode = await proc.exited;
+  live.delete(proc);
+
+  const signal = proc.signalCode ?? null;
+  return {
+    id: job.id,
+    task: job.task,
+    command,
+    exitCode,
+    signal,
+    // Bun kills on timeout with killSignal; a SIGKILL we did not send is the tell.
+    timedOut: signal === "SIGKILL" && Math.round(performance.now() - t0) >= opts.timeoutMs,
+    startedAt,
+    durationMs: Math.round(performance.now() - t0),
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
+}
+
+/** Runs every job, at most `concurrency` at a time. Results keep the input order. */
+export async function runAgents(jobs: Job[], opts: RunnerOptions): Promise<AgentResult[]> {
+  const results = new Array<AgentResult>(jobs.length);
+  const live = new Set<Bun.Subprocess>();
+  let next = 0;
+  let interrupted = false;
+
+  const onSignal = () => {
+    interrupted = true;
+    process.stderr.write("\nInterrupted - stopping agents...\n");
+    for (const proc of live) proc.kill("SIGTERM");
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
+  try {
+    const workers = Array.from({ length: Math.min(Math.max(1, opts.concurrency), jobs.length) }, async () => {
+      while (true) {
+        const i = next++;
+        if (i >= jobs.length || interrupted) return;
+        results[i] = await runOne(jobs[i], i, opts, live);
+      }
+    });
+    await Promise.all(workers);
+  } finally {
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+  }
+
+  return results.filter(Boolean);
+}

--- a/packages/agentic-bun/test/cli.test.ts
+++ b/packages/agentic-bun/test/cli.test.ts
@@ -1,0 +1,263 @@
+/**
+ * End-to-end tests for the dispatcher. Ollama is not installed in CI, so a stub
+ * `ollama` (test/fixtures/ollama-stub.sh) stands in for it: it answers
+ * --version/list/launch --help like the real CLI and records the argv of every
+ * launch so we can assert on the exact command the dispatcher built.
+ */
+import { describe, expect, test } from "bun:test";
+import { chmodSync, copyFileSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tempDir } from "../../../test/harness.ts";
+
+const CLI = join(import.meta.dir, "..", "src", "cli.ts");
+const STUB = join(import.meta.dir, "fixtures", "ollama-stub.sh");
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  dir: string;
+}
+
+/** Runs the CLI with a stubbed `ollama` (and `claude`) ahead of it on PATH. */
+async function runCli(args: string[], fake: Record<string, string> = {}, stdin?: string): Promise<RunResult> {
+  const dir = tempDir("agentic-bun", {});
+  const binDir = join(String(dir), "bin");
+  mkdirSync(binDir, { recursive: true });
+  for (const name of ["ollama", "claude"]) {
+    copyFileSync(STUB, join(binDir, name));
+    chmodSync(join(binDir, name), 0o755);
+  }
+
+  await using proc = Bun.spawn({
+    cmd: [process.execPath, CLI, ...args],
+    cwd: String(dir),
+    env: {
+      ...process.env,
+      // binDir first so the stubs shadow anything real on this machine.
+      PATH: `${binDir}:${process.env.PATH}`,
+      NO_COLOR: "1",
+      FAKE_DIR: String(dir),
+      FAKE_MODELS: "qwen2.5-coder:7b",
+      ...fake,
+    },
+    stdin: stdin === undefined ? "ignore" : new TextEncoder().encode(stdin),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, dir: String(dir) };
+}
+
+/** Every `ollama launch` argv the stub recorded, oldest first. */
+function invocations(dir: string): string[][] {
+  return readdirSync(dir)
+    .filter(name => name.startsWith("inv-") && name.endsWith(".args"))
+    .map(name => join(dir, name))
+    .map(path => readFileSync(path, "utf8").split("\x1e").slice(0, -1));
+}
+
+describe("preflight", () => {
+  test("explains how to fix a missing ollama", async () => {
+    const dir = tempDir("agentic-bun-empty", {});
+    mkdirSync(join(String(dir), "bin"), { recursive: true });
+    await using proc = Bun.spawn({
+      cmd: [process.execPath, CLI, "-t", "do a thing"],
+      env: { ...process.env, PATH: join(String(dir), "bin") },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("`ollama` was not found on PATH");
+    expect(exitCode).toBe(1);
+  });
+
+  test("explains how to fix an ollama without `launch`", async () => {
+    const result = await runCli(["-t", "do a thing"], { FAKE_NO_LAUNCH: "1" });
+    expect(result.stderr).toContain("`ollama launch` is not available");
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("warns about an old ollama but still runs", async () => {
+    const result = await runCli(["-t", "do a thing"], { FAKE_VERSION: "0.13.1" });
+    expect(result.stderr).toContain("0.14.0+ is recommended");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("rejects a working directory that does not exist", async () => {
+    const result = await runCli(["-t", "do a thing", "-C", "/definitely/not/here"]);
+    expect(result.stderr).toContain("/definitely/not/here is not a directory");
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("refuses to guess when stdin is not a terminal and no goal was given", async () => {
+    const result = await runCli([]);
+    expect(result.stderr).toContain("a goal is required");
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe("dry run", () => {
+  test("prints the exact command each agent would run", async () => {
+    const result = await runCli(["--dry-run", "-t", "write the docs", "-t", "add a benchmark"]);
+    expect(result.stdout).toContain("ollama launch claude --model qwen2.5-coder:7b --yes --");
+    expect(result.stdout).toContain("# a1: write the docs");
+    expect(result.stdout).toContain("# a2: add a benchmark");
+    expect(result.exitCode).toBe(0);
+    expect(invocations(result.dir)).toHaveLength(0);
+  });
+
+  test("drops --model/--yes when the installed ollama lacks them", async () => {
+    const result = await runCli(["--dry-run", "-t", "x"], { FAKE_NO_YES_FLAG: "1", FAKE_NO_MODEL_FLAG: "1" });
+    expect(result.stdout).not.toContain("--yes");
+    expect(result.stdout).not.toContain("--model");
+    expect(result.stderr).toContain("does not advertise --yes");
+  });
+
+  test("passes our own trailing args through to claude", async () => {
+    const result = await runCli(["--dry-run", "-t", "x", "--permission-mode", "acceptEdits", "--", "--verbose"]);
+    expect(result.stdout).toContain("--permission-mode acceptEdits --verbose");
+  });
+
+  test("--direct bypasses ollama launch", async () => {
+    const result = await runCli(["--dry-run", "--direct", "-t", "x"]);
+    expect(result.stdout).toContain("/claude -p ");
+    expect(result.stdout).not.toContain("ollama launch");
+  });
+});
+
+describe("running agents", () => {
+  test("streams every agent's output with its own prefix", async () => {
+    const result = await runCli(["-t", "write the docs", "-t", "add a benchmark"], { FAKE_STDOUT: "did the work" });
+    expect(result.stdout).toContain("[a1] did the work");
+    expect(result.stdout).toContain("[a2] did the work");
+    expect(result.stderr).toContain("2/2 agents succeeded.");
+    expect(result.exitCode).toBe(0);
+
+    const args = invocations(result.dir);
+    expect(args).toHaveLength(2);
+    for (const argv of args) {
+      expect(argv.slice(0, 6)).toEqual(["launch", "claude", "--model", "qwen2.5-coder:7b", "--yes", "--"]);
+      expect(argv[6]).toBe("-p");
+    }
+    // Each agent is told its own task and the other agent's task.
+    const prompts = args.map(argv => argv[7]).sort();
+    expect(prompts[0]).toContain("agent 1 of 2");
+    expect(prompts[0]).toContain("write the docs");
+    expect(prompts[0]).toContain("add a benchmark");
+  });
+
+  test("reports a failing agent and exits non-zero", async () => {
+    const result = await runCli(["-t", "break something"], { FAKE_EXIT: "7", FAKE_STDERR: "boom" });
+    expect(result.stderr).toContain("[a1] boom");
+    expect(result.stderr).toContain("exit 7");
+    expect(result.stderr).toContain("0/1 agents succeeded.");
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("--json captures output instead of streaming it", async () => {
+    const result = await runCli(["--json", "-g", "ship it", "-t", "one", "-t", "two"], { FAKE_STDOUT: "done" });
+    expect(result.stdout).not.toContain("[a1]");
+    const report = JSON.parse(result.stdout);
+    expect(report.ok).toBe(true);
+    expect(report.goal).toBe("ship it");
+    expect(report.model).toBe("qwen2.5-coder:7b");
+    expect(report.agents).toHaveLength(2);
+    expect(report.agents[0]).toMatchObject({ id: "a1", task: "one", exitCode: 0, timedOut: false });
+    expect(report.agents[0].stdout).toContain("done");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("kills an agent that overruns --timeout", async () => {
+    const result = await runCli(["--json", "-t", "hang", "--timeout", "1"], {
+      FAKE_PEERS: "2",
+      FAKE_PEER_WAIT_MS: "10000",
+    });
+    const report = JSON.parse(result.stdout);
+    expect(report.agents[0].timedOut).toBe(true);
+    expect(report.ok).toBe(false);
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe("concurrency", () => {
+  // The stub blocks until FAKE_PEERS agents are alive at once, so these two tests
+  // prove parallelism (and its absence) without depending on timing.
+  test("runs agents in parallel up to the concurrency limit", async () => {
+    const result = await runCli(["-t", "one", "-t", "two"], { FAKE_PEERS: "2" });
+    expect(result.stderr).toContain("concurrency 2");
+    expect(result.stderr).toContain("2/2 agents succeeded.");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("--concurrency 1 serializes them", async () => {
+    const result = await runCli(["-c", "1", "-t", "one", "-t", "two"], { FAKE_PEERS: "2", FAKE_PEER_WAIT_MS: "500" });
+    // Neither agent ever sees a peer, so the stub gives up with exit 3.
+    expect(result.stderr).toContain("concurrency 1");
+    expect(result.stderr).toContain("exit 3");
+    expect(result.stderr).toContain("0/2 agents succeeded.");
+  });
+});
+
+describe("planning", () => {
+  test("asks the model to split the goal, then runs one agent per task", async () => {
+    const plan = JSON.stringify(["parse the input", "render the output", "write the tests"]);
+    const result = await runCli(["-g", "build the thing", "-n", "3"], { FAKE_PLAN: plan });
+
+    expect(result.stderr).toContain("Splitting the goal into 3 tasks");
+    expect(result.stderr).toContain("3/3 agents succeeded.");
+    expect(result.exitCode).toBe(0);
+
+    const args = invocations(result.dir);
+    expect(args).toHaveLength(4); // one planner call + three agents
+    const prompts = args.map(argv => argv[argv.indexOf("-p") + 1]);
+    expect(prompts.some(p => p.includes("exactly 3"))).toBe(true);
+    for (const task of ["parse the input", "render the output", "write the tests"]) {
+      expect(prompts.filter(p => p.includes(task))).not.toHaveLength(0);
+    }
+  });
+
+  test("fails loudly when the model does not return a task list", async () => {
+    const result = await runCli(["-g", "build the thing", "-n", "2"], { FAKE_PLAN: "I cannot help with that." });
+    expect(result.stderr).toContain("could not read a task list");
+    expect(result.stderr).toContain("Pass --task explicitly");
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe("wizard", () => {
+  test("asks for the goal, directory, agent count and tasks", async () => {
+    const answers =
+      ["add tests for the parser", "", "2", "cover the happy path", "cover the error path", ""].join("\n") + "\n";
+    const result = await runCli(["--dry-run"], {}, answers);
+
+    expect(result.stderr).toContain("What do you want done?");
+    expect(result.stderr).toContain("How many agents should run in parallel?");
+    expect(result.stdout).toContain("# a1: cover the happy path");
+    expect(result.stdout).toContain("# a2: cover the error path");
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("offers a numbered model list when several are installed", async () => {
+    const answers = ["ship it", "", "1", "2"].join("\n") + "\n";
+    const result = await runCli(["--dry-run"], { FAKE_MODELS: "qwen2.5-coder:7b glm-4.7-flash" }, answers);
+
+    expect(result.stderr).toContain("1. qwen2.5-coder:7b");
+    expect(result.stderr).toContain("2. glm-4.7-flash");
+    expect(result.stdout).toContain("--model glm-4.7-flash");
+  });
+
+  test("keeps stdout free of wizard chatter", async () => {
+    const result = await runCli(["--json", "-t", "one"], { FAKE_STDOUT: "done" }, "");
+    expect(() => JSON.parse(result.stdout)).not.toThrow();
+  });
+
+  test("-y skips the wizard entirely", async () => {
+    const result = await runCli(["-y", "--dry-run"], {}, "should never be read\n");
+    expect(result.stderr).not.toContain("What do you want done?");
+    expect(result.stderr).toContain("a goal is required");
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/packages/agentic-bun/test/fixtures/ollama-stub.sh
+++ b/packages/agentic-bun/test/fixtures/ollama-stub.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Stand-in for the `ollama` CLI so the dispatcher can be tested without Ollama.
+# Behaviour is driven by FAKE_* environment variables set by the test.
+set -u
+DIR="${FAKE_DIR:-/tmp}"
+
+case "${1:-}" in
+  --version)
+    echo "ollama version is ${FAKE_VERSION:-0.15.2}"
+    exit 0
+    ;;
+  list)
+    printf 'NAME\tID\tSIZE\tMODIFIED\n'
+    if [ -n "${FAKE_MODELS:-}" ]; then
+      for m in ${FAKE_MODELS}; do printf '%s\tabc123\t4.7 GB\t2 days ago\n' "$m"; done
+    fi
+    exit 0
+    ;;
+  launch)
+    if [ "${2:-}" = "--help" ]; then
+      if [ -n "${FAKE_NO_LAUNCH:-}" ]; then
+        echo 'Error: unknown command "launch" for "ollama"' >&2
+        exit 1
+      fi
+      echo 'Usage: ollama launch [flags] <app> [-- <args>]'
+      echo 'Flags:'
+      echo '      --config         configure environment without launching'
+      [ -z "${FAKE_NO_MODEL_FLAG:-}" ] && echo '      --model string   model to run the app against'
+      [ -z "${FAKE_NO_YES_FLAG:-}" ] && echo '      --yes            skip interactive selectors'
+      echo '      --               args after this are passed straight to the app'
+      exit 0
+    fi
+    ;;
+esac
+
+# A real launch. Record the full argv (record-separated, since the prompt has newlines).
+printf '%s\036' "$@" > "$DIR/inv-$$.args"
+
+# Rendezvous mode: block until FAKE_PEERS agents are live at once, so the test can
+# prove the pool really does (or does not) run agents in parallel. A marker is left
+# behind on success (removing it could hide this agent from a peer still counting),
+# so this only models one rendezvous group per run.
+if [ -n "${FAKE_PEERS:-}" ]; then
+  mkdir -p "$DIR/live"
+  touch "$DIR/live/$$"
+  waited=0
+  cap="${FAKE_PEER_WAIT_MS:-5000}"
+  while [ "$(ls "$DIR/live" | wc -l)" -lt "$FAKE_PEERS" ]; do
+    if [ "$waited" -ge "$cap" ]; then rm -f "$DIR/live/$$"; exit 3; fi
+    sleep 0.05
+    waited=$((waited + 50))
+  done
+fi
+
+# The first launch answers the planner when FAKE_PLAN is set; later ones act as agents.
+if [ -n "${FAKE_PLAN:-}" ] && [ ! -e "$DIR/plan-used" ]; then
+  touch "$DIR/plan-used"
+  printf '%s\n' "$FAKE_PLAN"
+  exit 0
+fi
+
+printf '%s\n' "${FAKE_STDOUT:-agent finished}"
+[ -n "${FAKE_STDERR:-}" ] && printf '%s\n' "$FAKE_STDERR" >&2
+exit "${FAKE_EXIT:-0}"

--- a/packages/agentic-bun/test/unit.test.ts
+++ b/packages/agentic-bun/test/unit.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test";
+import { compareVersions, parseLaunchHelp, parseModels, parseVersion, type CaptureResult } from "../src/ollama.ts";
+import { buildAgentPrompt, buildPlannerPrompt, extractTaskList, toSpecs } from "../src/plan.ts";
+import { buildCommand, buildEnv, type RunnerOptions } from "../src/runner.ts";
+import { parseArgs } from "../src/cli.ts";
+
+function runnerOptions(overrides: Partial<RunnerOptions> = {}): RunnerOptions {
+  return {
+    ollamaBinary: "/usr/bin/ollama",
+    claudeBinary: "/usr/bin/claude",
+    useLaunch: true,
+    supportsModelFlag: true,
+    supportsYesFlag: true,
+    model: "qwen2.5-coder:7b",
+    cwd: "/repo",
+    extraClaudeArgs: [],
+    concurrency: 2,
+    timeoutMs: 1000,
+    ollamaHost: "http://localhost:11434",
+    capture: false,
+    color: false,
+    ...overrides,
+  };
+}
+
+function help(text: string, exitCode = 0): CaptureResult {
+  return { exitCode, stdout: text, stderr: "", output: text };
+}
+
+describe("ollama probe parsing", () => {
+  test("parses the version out of ollama's banner", () => {
+    expect(parseVersion("ollama version is 0.15.2")).toBe("0.15.2");
+    expect(parseVersion("client version is 0.14.3-rc1")).toBe("0.14.3");
+    expect(parseVersion("no numbers here")).toBeNull();
+  });
+
+  test("compares dotted versions", () => {
+    expect(compareVersions("0.15.2", "0.14.0")).toBe(1);
+    expect(compareVersions("0.13.9", "0.14.0")).toBe(-1);
+    expect(compareVersions("0.14.0", "0.14.0")).toBe(0);
+    expect(compareVersions("1.2", "1.2.0")).toBe(0);
+  });
+
+  test("reads model names from `ollama list`", () => {
+    const output = [
+      "NAME\tID\tSIZE\tMODIFIED",
+      "qwen2.5-coder:7b\tabc\t4.7 GB\t2 days ago",
+      "glm-4.7-flash\tdef\t3.1 GB\t1 week ago",
+      "",
+    ].join("\n");
+    expect(parseModels(output)).toEqual(["qwen2.5-coder:7b", "glm-4.7-flash"]);
+  });
+
+  test("detects launch flags from help text", () => {
+    const caps = parseLaunchHelp(
+      help(
+        [
+          "Usage: ollama launch [flags] <app>",
+          "  --model string  model to use",
+          "  --yes           skip selectors",
+          "  --              args after this go to the app",
+        ].join("\n"),
+      ),
+    );
+    expect(caps).toMatchObject({
+      supported: true,
+      supportsModelFlag: true,
+      supportsYesFlag: true,
+      supportsPassthrough: true,
+    });
+  });
+
+  test("notices flags that a future ollama might drop", () => {
+    const caps = parseLaunchHelp(help("Usage: ollama launch <app>\n  --config   configure only\n"));
+    expect(caps.supported).toBe(true);
+    expect(caps.supportsModelFlag).toBe(false);
+    expect(caps.supportsYesFlag).toBe(false);
+  });
+
+  test("treats an unknown subcommand as unsupported", () => {
+    expect(parseLaunchHelp(help('Error: unknown command "launch" for "ollama"', 1)).supported).toBe(false);
+    expect(parseLaunchHelp(help("", 1)).supported).toBe(false);
+  });
+});
+
+describe("command construction", () => {
+  test("wraps the prompt in `ollama launch claude -- -p`", () => {
+    expect(buildCommand("do the thing", runnerOptions())).toEqual([
+      "/usr/bin/ollama",
+      "launch",
+      "claude",
+      "--model",
+      "qwen2.5-coder:7b",
+      "--yes",
+      "--",
+      "-p",
+      "do the thing",
+    ]);
+  });
+
+  test("omits flags the installed ollama does not advertise", () => {
+    const cmd = buildCommand("x", runnerOptions({ supportsModelFlag: false, supportsYesFlag: false }));
+    expect(cmd).toEqual(["/usr/bin/ollama", "launch", "claude", "--", "-p", "x"]);
+  });
+
+  test("forwards permission mode and passthrough args to claude", () => {
+    const cmd = buildCommand("x", runnerOptions({ permissionMode: "acceptEdits", extraClaudeArgs: ["--verbose"] }));
+    expect(cmd.slice(cmd.indexOf("--"))).toEqual(["--", "-p", "x", "--permission-mode", "acceptEdits", "--verbose"]);
+  });
+
+  test("direct mode calls claude itself and points it at the ollama host", () => {
+    const opts = runnerOptions({ useLaunch: false });
+    expect(buildCommand("x", opts)).toEqual(["/usr/bin/claude", "-p", "x", "--model", "qwen2.5-coder:7b"]);
+    expect(buildEnv(opts)).toMatchObject({ ANTHROPIC_BASE_URL: "http://localhost:11434" });
+  });
+
+  test("launch mode does not rewrite the anthropic env vars", () => {
+    expect(buildEnv(runnerOptions()).ANTHROPIC_BASE_URL).toBe(process.env.ANTHROPIC_BASE_URL);
+  });
+});
+
+describe("prompts", () => {
+  const specs = toSpecs(["write the parser", "write the tests", "update the docs"]);
+
+  test("tells each agent what the others own", () => {
+    const prompt = buildAgentPrompt({ goal: "ship the feature", cwd: "/repo", spec: specs[1], index: 1, all: specs });
+    expect(prompt).toContain("agent 2 of 3");
+    expect(prompt).toContain("ship the feature");
+    expect(prompt).toContain("write the tests");
+    expect(prompt).toContain("write the parser");
+    expect(prompt).toContain("update the docs");
+    expect(prompt).toContain("Work inside /repo");
+    expect(prompt).toContain("do not commit or push");
+  });
+
+  test("skips the coordination section for a single agent", () => {
+    const one = toSpecs(["do it"]);
+    const prompt = buildAgentPrompt({ goal: "do it", cwd: "/repo", spec: one[0], index: 0, all: one });
+    expect(prompt).not.toContain("agent 1 of 1");
+    expect(prompt).toContain("Task: do it");
+  });
+
+  test("planner prompt asks for a fixed-size JSON array", () => {
+    expect(buildPlannerPrompt("ship it", 3, "/repo")).toContain("exactly 3");
+  });
+});
+
+describe("plan parsing", () => {
+  test("reads a bare JSON array", () => {
+    expect(extractTaskList('["one", "two"]')).toEqual(["one", "two"]);
+  });
+
+  test("reads a JSON array surrounded by chatter or fences", () => {
+    expect(extractTaskList('Sure!\n```json\n["one", "two"]\n```\nHope that helps.')).toEqual(["one", "two"]);
+  });
+
+  test("falls back to numbered or bulleted lines", () => {
+    expect(extractTaskList("1. first task\n2) second task\n- third task")).toEqual([
+      "first task",
+      "second task",
+      "third task",
+    ]);
+  });
+
+  test("returns nothing for unusable output", () => {
+    expect(extractTaskList("I cannot help with that.")).toEqual([]);
+  });
+});
+
+describe("argument parsing", () => {
+  test("collects repeated tasks and splits passthrough args", () => {
+    const opts = parseArgs([
+      "-g",
+      "goal",
+      "-t",
+      "a",
+      "-t",
+      "b",
+      "--json",
+      "--",
+      "--verbose",
+      "--permission-mode",
+      "auto",
+    ]);
+    expect(opts.goal).toBe("goal");
+    expect(opts.tasks).toEqual(["a", "b"]);
+    expect(opts.json).toBe(true);
+    expect(opts.extraClaudeArgs).toEqual(["--verbose", "--permission-mode", "auto"]);
+  });
+
+  test("accepts --flag=value", () => {
+    const opts = parseArgs(["--goal=ship it", "--agents=3", "--model=glm-4.7-flash"]);
+    expect(opts.goal).toBe("ship it");
+    expect(opts.agents).toBe(3);
+    expect(opts.model).toBe("glm-4.7-flash");
+  });
+
+  test("rejects bad input", () => {
+    expect(() => parseArgs(["--nope"])).toThrow(/unknown option/);
+    expect(() => parseArgs(["--agents", "0"])).toThrow(/positive integer/);
+    expect(() => parseArgs(["--agents", "99"])).toThrow(/<= 16/);
+    expect(() => parseArgs(["--goal"])).toThrow(/needs a value/);
+    expect(() => parseArgs(["--plan", "-t", "a"])).toThrow(/mutually exclusive/);
+  });
+});

--- a/packages/agentic-bun/tsconfig.json
+++ b/packages/agentic-bun/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
A zero-dependency Bun CLI that turns a short wizard (or flags) into one or more Claude Code agents running against a local Ollama model.

It is a dispatcher, not an agent runtime: each agent is a real `claude -p` process spawned through `ollama launch claude`, so tool use comes from that harness. This package owns the wizard, the per-agent prompts, the concurrency pool, output multiplexing and the final report.

- src/ollama.ts probes the local install at startup (`--version`, `launch --help`, `list`) and only passes `--model`/`--yes` when the help text advertises them, so a changed Ollama CLI degrades with a note instead of a spawn failure. `--direct` skips `ollama launch` and runs `claude` against $OLLAMA_HOST with the Anthropic-compatible env vars set locally.
- src/plan.ts builds the prompts. Multi-agent prompts list the sibling tasks and tell each agent to stay in its lane, not to commit, push, or run repo-wide destructive commands. Splitting a goal into N tasks is one throwaway model call, not a planner.
- src/runner.ts runs the pool: bounded concurrency, per-agent line prefixes, per-agent timeouts, SIGINT teardown, and a summary/JSON report.

Ollama could not be installed in the development environment (no binary, and the outbound proxy blocks ollama.com), so no flag was verified against a real install and no end-to-end run against a real model was performed. That is called out in the README. The 42 tests run the CLI end to end against a stub `ollama` that records the argv it was launched with; the concurrency tests use a rendezvous in the stub so they assert parallelism without depending on timing.

Runs on the system bun - this package is plain TypeScript and never calls into Bun's native code, so no debug build is involved.

### What does this PR do?

### How did you verify your code works?
