### PR TITLE
Bun.build / Bun.Transpiler: remove unsafe from JSBundler, the completion task and JSTranspiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "bun_sys",
  "bun_threading",
  "bun_url",
+ "bun_uws",
  "bun_watcher",
  "bun_wyhash",
  "bun_zstd",

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -5,8 +5,7 @@ use bun_core::{self, Output, zstr};
 use bun_io as Async;
 use bun_threading::unbounded_queue::{Node, UnboundedQueue};
 
-use crate::bundle_v2::{FileMap, JSBundlerPlugin, dispatch};
-use crate::{BundleV2, Transpiler};
+use crate::Transpiler;
 
 /// Used to keep the bundle thread from spinning on Windows
 #[cfg(windows)]
@@ -41,8 +40,8 @@ pub enum BundleV2Result {
 /// - `configureBundler` is used to configure `Bundler`.
 /// - `completeOnBundleThread` is used to tell the task that it is done.
 // The trait bound lives on the `impl` (not the struct) so the
-// `singleton` static can name `BundleThread<JSBundleCompletionTask>` before T6
-// provides the `CompletionStruct` impl for the forward-decl.
+// `singleton` static can name `BundleThread<C>` before T6 (`bun_runtime`)
+// provides the `CompletionStruct` impl.
 pub(crate) struct BundleThread<C: Node> {
     pub(crate) waker: Async::Waker,
     pub(crate) ready_event: ResetEvent,
@@ -55,33 +54,24 @@ pub(crate) struct BundleThread<C: Node> {
 /// Trait capturing the interface a completion task must satisfy.
 ///
 /// The trait accessors keep the generic `BundleThread<C>`
-/// layout-agnostic. The concrete impl lives in T6 (`bun_bundler_jsc`).
+/// layout-agnostic. The concrete impl lives in T6 (`bun_runtime`). The bundle
+/// thread owns the boxed task from [`singleton::enqueue`] until it has run (or
+/// declined to run) it, and drops it there; results leave through
+/// [`complete_on_bundle_thread`](Self::complete_on_bundle_thread).
 pub trait CompletionStruct: Node + Send + 'static {
     /// `bump` is the per-build mimalloc heap that backs `transpiler`, so the
-    /// two share lifetime `'a` (option fields like `optimize_imports: &'a
-    /// StringSet` borrow from `bump`).
+    /// two share lifetime `'a`.
     fn configure_bundler<'a>(
         &mut self,
         transpiler: &mut Transpiler<'a>,
         bump: &'a Arena,
     ) -> Result<(), crate::Error>;
     /// Bundle thread, on dequeue: `false` if the owner released this build
-    /// while it was still queued ([`free_released_unstarted`] then frees it).
+    /// while it was still queued; it is then dropped unrun.
     fn try_start(&mut self) -> bool;
-    fn free_released_unstarted(this: *mut Self);
     fn complete_on_bundle_thread(&mut self);
     fn set_result(&mut self, result: BundleV2Result);
     fn set_log(&mut self, log: bun_ast::Log);
-    fn set_transpiler(&mut self, this: *mut BundleV2<'_>);
-    fn plugins(&self) -> Option<NonNull<JSBundlerPlugin>>;
-    /// Returns the file map if non-empty; a single accessor so the opaque
-    /// `FileMap` layout stays in T6.
-    fn file_map(&mut self) -> Option<NonNull<FileMap>>;
-    /// Returns a §Dispatch handle (erased owner + `&'static` vtable) the impl
-    /// provides, so the bundler can read `result == .err` / `is_cancelled`,
-    /// and post plugin hops to the owning VM, without naming the concrete
-    /// struct.
-    fn as_js_bundle_completion_task(&mut self) -> dispatch::CompletionHandle;
 
     /// `Transpiler<'a>` has borrow-carrying fields (`arena: &'a Arena`,
     /// `resolver: Resolver<'a>`) that cannot be zero-init'd, so the allocate +
@@ -99,7 +89,7 @@ pub trait CompletionStruct: Node + Send + 'static {
     /// Constructs the `BundleV2`, wires `plugins`/`completion`/`file_map`,
     /// and runs the bundle.
     ///
-    /// This body is `JSBundleCompletionTask`-specific, so the
+    /// This body is `Bun.build`-specific, so the
     /// construction + run is delegated to the trait impl in T6, which has
     /// access to the concrete event-loop / work-pool wiring. The shared
     /// scaffolding (arena, AST arena push/pop, log copy,
@@ -168,9 +158,11 @@ impl<C: CompletionStruct> BundleThread<C> {
     /// # Safety
     /// `instance` must point to a live `BundleThread` whose bundle thread has been
     /// spawned (so `waker` is initialized). Called concurrently with `thread_main`.
-    pub(crate) unsafe fn enqueue(instance: *mut Self, completion: *mut C) {
-        // SAFETY: `completion` is a live, caller-owned task node (non-null).
-        let completion = unsafe { core::ptr::NonNull::new_unchecked(completion) };
+    pub(crate) unsafe fn enqueue(instance: *mut Self, completion: Box<C>) {
+        // SAFETY: `heap::into_raw` of a `Box` is never null; the bundle thread
+        // takes the box back in `thread_main`.
+        let completion =
+            unsafe { core::ptr::NonNull::new_unchecked(bun_core::heap::into_raw(completion)) };
         // SAFETY: field projections via raw ptr — `thread_main` on the bundle thread
         // accesses the same struct concurrently, so we never materialize `&mut Self`.
         // `UnboundedQueue::push` takes `&self` (lock-free MPSC). `Waker::wake` takes
@@ -215,6 +207,9 @@ impl<C: CompletionStruct> BundleThread<C> {
             timer.start(u64::MAX, u64::MAX, Some(timer_callback));
         }
 
+        // What every build's Mini event loop ticks (`MiniEventLoop::init`).
+        singleton::LOOP.store(bun_uws::Loop::get(), core::sync::atomic::Ordering::Release);
+
         let mut has_bundled = false;
         loop {
             loop {
@@ -224,21 +219,20 @@ impl<C: CompletionStruct> BundleThread<C> {
                 if completion.is_null() {
                     break;
                 }
-                // SAFETY: queue stores non-null *mut C pushed via enqueue(); owner keeps it alive
-                // until complete_on_bundle_thread() signals completion — unless it
-                // released the build while it sat here (its VM went away).
-                if !unsafe { (*completion).try_start() } {
-                    C::free_released_unstarted(completion);
+                // SAFETY: the queue only holds the boxes `enqueue` leaked into it.
+                let mut completion = unsafe { bun_core::heap::take(completion) };
+                // Its owner released the build while it sat here (its VM went
+                // away): nothing of the owner's may be touched, so drop it unrun.
+                if !completion.try_start() {
+                    drop(completion);
                     continue;
                 }
-                // SAFETY: as above; started ⇒ the owner waits for us.
-                let completion = unsafe { &mut *completion };
                 // SAFETY: `generation` is only read/written on this (bundle) thread.
                 let generation = unsafe { (*instance).generation };
                 // `panic = "abort"` → a Rust panic on this thread enters the
                 // crash-handler hook and aborts the whole process.
                 // No `catch_unwind` — there is nothing to catch.
-                match Self::generate_in_new_thread(completion, generation) {
+                match Self::generate_in_new_thread(&mut completion, generation) {
                     Ok(()) => {}
                     Err(err) => {
                         completion.set_result(BundleV2Result::Err(err));
@@ -326,9 +320,8 @@ impl<C: CompletionStruct> BundleThread<C> {
         //
         // SAFETY: both pointers are the unique `&'a mut` slots returned by
         // `bump.alloc(...)` above; nothing else holds a reference to either
-        // past `init_and_run` (`set_transpiler` was cleared by
-        // `deinit_without_freeing_arena`, `pop()` restored the AST-allocator
-        // thread-local). The arena bytes themselves are bulk-freed afterwards
+        // past `init_and_run` (its `BundleV2` is gone, `pop()` restored the
+        // AST-allocator thread-local). The arena bytes themselves are bulk-freed afterwards
         // by `heap`'s `Drop` — `drop_in_place` only releases the *embedded
         // global-heap* state, so there is no double free.
         unsafe {
@@ -346,9 +339,9 @@ impl<C: CompletionStruct> BundleThread<C> {
 /// bundle thread may not be needed.
 // Rust forbids generic statics, so the storage is
 // type-erased (`*mut ()`) and the accessor functions are generic over `C`.
-// In practice exactly one `C` (`JSBundleCompletionTask`) is ever used — see
+// In practice exactly one `C` (`bun_runtime`'s `BundleJob`) is ever used — see
 // `get`'s safety contract — so the
-// erased static is sound. T6 (`bun_bundler_jsc`) calls these with its concrete
+// erased static is sound. T6 (`bun_runtime`) calls these with its concrete
 // completion-task type.
 pub mod singleton {
     use super::*;
@@ -369,6 +362,24 @@ pub mod singleton {
     unsafe impl Sync for Instance {}
 
     static INSTANCE: std::sync::OnceLock<Instance> = std::sync::OnceLock::new();
+
+    /// The bundle thread's uws loop (what its per-build Mini event loop ticks),
+    /// once the thread runs; it never exits, so the loop is never freed.
+    pub(super) static LOOP: core::sync::atomic::AtomicPtr<bun_uws::Loop> =
+        core::sync::atomic::AtomicPtr::new(core::ptr::null_mut());
+
+    /// Wake the bundle thread's event loop out of an idle wait (any thread), so
+    /// a build waiting on plugins re-checks whether its owner cancelled it. A
+    /// no-op before the thread exists.
+    pub fn wake() {
+        let l = LOOP.load(core::sync::atomic::Ordering::Acquire);
+        if !l.is_null() {
+            // SAFETY: the bundle thread's loop; that thread never exits, so the
+            // loop is live for the rest of the process, and `us_wakeup_loop` is
+            // the cross-thread entry point.
+            unsafe { bun_uws::us_wakeup_loop(l) };
+        }
+    }
 
     // Blocks the calling thread until the bun build thread is created.
     // OnceLock also blocks other callers of this function until the first caller is done.
@@ -406,14 +417,10 @@ pub mod singleton {
             .cast::<BundleThread<C>>()
     }
 
-    pub fn enqueue<C: CompletionStruct>(completion: *mut C) {
-        // Validate the caller's pointer at the public boundary so the unsafe
-        // path below never receives null.
-        let completion = NonNull::new(completion).unwrap_or_else(|| {
-            Output::panic(format_args!("BundleThread enqueue: null completion"))
-        });
+    /// Hand `completion` to the bundle thread, which runs it and drops it.
+    pub fn enqueue<C: CompletionStruct>(completion: Box<C>) {
         // SAFETY: `get()` returns the leaked 'static singleton whose bundle thread is
         // running; `BundleThread::enqueue` only performs raw-ptr field projections.
-        unsafe { BundleThread::enqueue(get::<C>(), completion.as_ptr()) };
+        unsafe { BundleThread::enqueue(get::<C>(), completion) };
     }
 }

--- a/src/bundler/Cargo.toml
+++ b/src/bundler/Cargo.toml
@@ -54,6 +54,7 @@ bun_sourcemap.workspace = true
 bun_sys.workspace = true
 bun_threading.workspace = true
 bun_url.workspace = true
+bun_uws.workspace = true
 bun_watcher.workspace = true
 bun_wyhash.workspace = true
 # `bundle_v2.rs:ContentHasher` uses xxh64. Streaming xxh64 comes

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1454,7 +1454,7 @@ pub mod parse_worker {
                 let ctx = unsafe { task.ctx() };
 
                 // Check FileMap for in-memory files first
-                if let Some(file_map) = ctx.file_map {
+                if let Some(file_map) = &ctx.file_map {
                     if let Some(file_contents) = file_map.get(file_path.text) {
                         break 'brk Ok(CacheEntry {
                             contents: crate::cache::Contents::SharedBuffer {

--- a/src/bundler/barrel_imports.rs
+++ b/src/bundler/barrel_imports.rs
@@ -110,7 +110,7 @@ fn apply_barrel_optimization_impl(
     };
     let source_index = result.source.index.0;
 
-    let is_explicit = if let Some(oi) = this.transpiler().options.optimize_imports {
+    let is_explicit = if let Some(oi) = &this.transpiler().options.optimize_imports {
         oi.map.contains(result.package_name.slice())
     } else {
         false

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -45,9 +45,6 @@ pub use crate::ParseTask;
 /// `jsc::api::JSBundler::Plugin` — re-exported from the canonical def below.
 pub use api::JSBundler::Plugin as JSBundlerPlugin;
 
-/// `BundleV2.JSBundleCompletionTask` — re-exported from the canonical def below.
-pub use bv2_impl::JSBundleCompletionTask;
-
 /// `jsc::api::JSBundler::FileMap` — re-exported from the canonical def below.
 pub use api::JSBundler::FileMap;
 
@@ -99,9 +96,8 @@ pub struct BundleV2<'a> {
     /// Populated from `transpiler.options.dev_server` + the runtime-registered vtable at
     /// construction. All ~15 DevServer call sites go through this.
     pub dev_server: Option<dispatch::DevServerHandle>,
-    /// In-memory files that can be used as entrypoints or imported.
-    /// This is a pointer to the FileMap in the completion config.
-    pub file_map: Option<&'a FileMap>,
+    /// In-memory files that can be used as entrypoints or imported (`Bun.build({ files })`).
+    pub file_map: Option<std::sync::Arc<FileMap>>,
     pub(crate) source_code_length: usize,
 
     /// There is a race condition where an onResolve plugin may schedule a task
@@ -736,7 +732,7 @@ pub mod bv2_impl {
                 // obligations are on `this`/`BunString` — discharged by `&`.
                 #[link_name = "JSBundlerPlugin__matchOnLoad"]
                 safe fn JSBundlerPlugin__matchOnLoad(
-                    this: &mut Plugin,
+                    this: &Plugin,
                     namespace_string: &mut BunString,
                     path: &mut BunString,
                     context: *mut core::ffi::c_void,
@@ -745,7 +741,7 @@ pub mod bv2_impl {
                 );
                 #[link_name = "JSBundlerPlugin__matchOnResolve"]
                 safe fn JSBundlerPlugin__matchOnResolve(
-                    this: &mut Plugin,
+                    this: &Plugin,
                     namespace_string: &mut BunString,
                     path: &mut BunString,
                     importer: &mut BunString,
@@ -833,7 +829,7 @@ pub mod bv2_impl {
                 }
 
                 pub(crate) fn match_on_load(
-                    &mut self,
+                    &self,
                     path: &[u8],
                     namespace: &[u8],
                     context: *mut core::ffi::c_void,
@@ -858,7 +854,7 @@ pub mod bv2_impl {
                 }
 
                 pub(crate) fn match_on_resolve(
-                    &mut self,
+                    &self,
                     path: &[u8],
                     namespace: &[u8],
                     importer: &[u8],
@@ -1178,29 +1174,42 @@ pub mod bv2_impl {
                 /// was cancelled before it was handed over): answer it as cancelled, from whichever thread
                 /// holds it, through the bundle thread's queue like every other answer.
                 pub fn answer_cancelled(&mut self) {
-                    self.value = ResolveValue::Err(cancelled_msg(&self.import_record.source_file));
-                    // SAFETY: `bv2` outlives every request of its pass (it cannot finish before this answer).
-                    unsafe { &mut *self.bv2 }.on_resolve_async(self);
+                    self.answer(ResolveValue::Err(cancelled_msg(
+                        &self.import_record.source_file,
+                    )));
+                }
+                /// The request's one answer, from whichever thread holds it: hand it back to the bundle
+                /// thread through its queue.
+                pub fn answer(&mut self, value: ResolveValue) {
+                    self.value = value;
+                    // SAFETY: `bv2` (set by `init`) outlives every request of its pass (it cannot finish
+                    // before this answer).
+                    unsafe { self.bv2.as_mut() }
+                        .expect("Resolve::init")
+                        .on_resolve_async(self);
+                }
+                /// The plugin chain this request is put to (JS thread).
+                pub fn plugin(&self) -> &Plugin {
+                    // SAFETY: `bv2` (set by `init`) is a valid backref, and its `plugins` (a protected
+                    // C++ cell) is `Some` whenever requests are dispatched
+                    // (`enqueue_on_js_loop_for_plugins`) and outlives every request of the pass.
+                    unsafe { self.bv2.as_ref() }
+                        .expect("Resolve::init")
+                        .plugins_ref()
+                        .expect("plugins")
                 }
                 pub fn run_on_js_thread(&mut self) {
                     let kind = self.import_record.kind;
                     // reshaped for borrowck — capture the erased self
                     // pointer before borrowing fields immutably for the FFI call.
                     let self_ptr = std::ptr::from_mut::<Self>(self).cast::<core::ffi::c_void>();
-                    // SAFETY: `bv2` is a valid backref set by `init`; the plugin
-                    // storage is disjoint from `self`, so the `&mut JSBundlerPlugin`
-                    // returned by `plugins_mut()` does not alias the
-                    // `&self.import_record.*` borrows below.
-                    unsafe { &mut *self.bv2 }
-                        .plugins_mut()
-                        .expect("plugins")
-                        .match_on_resolve(
-                            &self.import_record.specifier,
-                            &self.import_record.namespace,
-                            &self.import_record.source_file,
-                            self_ptr,
-                            kind,
-                        );
+                    self.plugin().match_on_resolve(
+                        &self.import_record.specifier,
+                        &self.import_record.namespace,
+                        &self.import_record.source_file,
+                        self_ptr,
+                        kind,
+                    );
                 }
             }
 
@@ -1314,9 +1323,79 @@ pub mod bv2_impl {
                 }
                 /// As `Resolve::answer_cancelled`.
                 pub fn answer_cancelled(&mut self) {
-                    self.value = LoadValue::Err(cancelled_msg(&self.path));
-                    // SAFETY: as `Resolve::answer_cancelled`.
-                    unsafe { &mut *self.bv2 }.on_load_async(self);
+                    self.answer(LoadValue::Err(cancelled_msg(&self.path)));
+                }
+                /// As `Resolve::answer`.
+                pub fn answer(&mut self, value: LoadValue) {
+                    self.value = value;
+                    // SAFETY: as `Resolve::answer`.
+                    unsafe { self.bv2.as_mut() }
+                        .expect("Load::init")
+                        .on_load_async(self);
+                }
+                /// As `Resolve::plugin`.
+                pub fn plugin(&self) -> &Plugin {
+                    // SAFETY: as `Resolve::plugin`.
+                    unsafe { self.bv2.as_ref() }
+                        .expect("Load::init")
+                        .plugins_ref()
+                        .expect("plugins")
+                }
+                /// The plugin called `.defer()` on this load (JS thread): tell the loop running the bundle
+                /// — `parse_task.ctx`'s, which is not the plugins' loop when `Bun.build` runs the bundler on
+                /// its own Mini event loop — so it parks this load's scan-counter unit
+                /// ([`BundleV2::on_notify_defer`]).
+                pub fn notify_deferred(&mut self) {
+                    // SAFETY: `parse_task.ctx` and `bv2` are valid backrefs; `r#loop()`
+                    // points at a live `AnyEventLoop` owned by the bundle thread /
+                    // runtime for the duration of the bundle.
+                    unsafe {
+                        let ctx = (*self.parse_task).ctx.expect("ParseTask.ctx unset");
+                        // SAFETY: write provenance from `ParseTask::init`; bundle outlives plugin.
+                        let any_loop = ctx
+                            .assume_mut()
+                            .r#loop()
+                            .expect("BundleV2.linker.loop must be set before plugins run");
+                        match &mut *any_loop.as_ptr() {
+                            bun_event_loop::AnyEventLoop::Js { .. } => {
+                                let ct =
+                                    bun_event_loop::ConcurrentTask::ConcurrentTask::from_callback(
+                                        std::ptr::from_mut::<Load>(self),
+                                        Self::on_notify_defer_js,
+                                    );
+                                let poster = (*ctx.as_mut_ptr())
+                                    .js_poster
+                                    .as_ref()
+                                    .expect("JS-owned bundle has a poster");
+                                if let bun_event_loop::Posted::Refused(ct) = poster.post(ct) {
+                                    // Owning JS VM torn down mid-bundle: the notify never runs.
+                                    bun_event_loop::ConcurrentTask::ConcurrentTask::release_refused(
+                                        ct,
+                                    );
+                                }
+                            }
+                            bun_event_loop::AnyEventLoop::Mini(mini) => {
+                                mini.enqueue_task_concurrent_with_extra_ctx::<Load, BundleV2<'static>>(
+                                    std::ptr::from_mut::<Load>(self),
+                                    Self::on_notify_defer_mini,
+                                    core::mem::offset_of!(Load, defer_task),
+                                );
+                            }
+                        }
+                    }
+                }
+                fn on_notify_defer_js(load: *mut Load) -> bun_event_loop::JsResult<()> {
+                    // SAFETY: task contract — `load` is the live request `notify_deferred` posted; this
+                    // runs on the loop that runs the bundle (bake: the plugins' own), so it is the
+                    // bundle thread here. `bv2` outlives every request of its pass.
+                    unsafe { BundleV2::on_notify_defer(&mut *load, &mut *(*load).bv2) };
+                    Ok(())
+                }
+                fn on_notify_defer_mini(load: *mut Load, ctx: *mut BundleV2<'static>) {
+                    // SAFETY: callback contract — `load` was passed as the `Context` arg to
+                    // `enqueue_task_concurrent_with_extra_ctx`; `ctx` is the bundle-thread
+                    // `BundleV2` backref the mini loop's tick supplies as `extra`.
+                    unsafe { BundleV2::on_notify_defer(&mut *load, &mut *ctx) };
                 }
                 pub fn run_on_js_thread(&mut self) {
                     let is_server_side = self.bake_graph() != crate::bake_types::Graph::Client;
@@ -1324,20 +1403,13 @@ pub mod bv2_impl {
                     // reshaped for borrowck — capture the erased self
                     // pointer before borrowing fields immutably for the FFI call.
                     let self_ptr = std::ptr::from_mut::<Self>(self).cast::<core::ffi::c_void>();
-                    // SAFETY: `bv2` is a valid backref set by `init`; the plugin
-                    // storage is disjoint from `self`, so the `&mut JSBundlerPlugin`
-                    // returned by `plugins_mut()` does not alias the
-                    // `&self.path` / `&self.namespace` borrows below.
-                    unsafe { &mut *self.bv2 }
-                        .plugins_mut()
-                        .expect("plugins")
-                        .match_on_load(
-                            &self.path,
-                            &self.namespace,
-                            self_ptr,
-                            default_loader,
-                            is_server_side,
-                        );
+                    self.plugin().match_on_load(
+                        &self.path,
+                        &self.namespace,
+                        self_ptr,
+                        default_loader,
+                        is_server_side,
+                    );
                 }
             }
             impl bun_event_loop::Taskable for Load {
@@ -1560,68 +1632,25 @@ pub mod bv2_impl {
             )
         }
 
-        /// CYCLEBREAK GENUINE: `JSBundleCompletionTask` — the
-        /// concrete struct lives in `bun_runtime` (its fields name `Config`/
-        /// `Plugin`/`HTMLBundle::Route`). The bundler reads exactly two things
-        /// from it (whether the result is an error, and the concurrent-task
-        /// enqueue), so the high tier hands the bundler an erased owner +
-        /// `&'static` vtable pair (same shape as [`DevServerHandle`]).
-        pub struct CompletionDispatch {
+        /// What the bundler needs from the `Bun.build` that started it (whose
+        /// state lives in `bun_runtime`): whether its VM gave up on the build,
+        /// and a way to post plugin hops to that VM.
+        pub trait CompletionDispatch: Send + Sync {
             /// Whether the VM that owns the plugins is shutting down: stop
             /// waiting for their answers and fail the build (any thread).
-            pub is_cancelled: unsafe fn(core::ptr::NonNull<super::JSBundleCompletionTask>) -> bool,
-            /// Folds the event-loop field access + enqueue so the bundler
-            /// needn't name the JSC event-loop type.
-            pub enqueue_task_concurrent: unsafe fn(
-                core::ptr::NonNull<super::JSBundleCompletionTask>,
-                *mut bun_event_loop::ConcurrentTask::ConcurrentTask,
-            ),
-        }
-        #[derive(Copy, Clone)]
-        pub struct CompletionHandle {
-            pub owner: core::ptr::NonNull<super::JSBundleCompletionTask>,
-            pub vtable: &'static CompletionDispatch,
-        }
-        // SAFETY: erased `*mut JSBundleCompletionTask` backref — set by the JS
-        // thread, read by the bundle thread; `enqueue_task_concurrent` is the only
-        // cross-thread call and it goes through `jsc::EventLoop`'s lock-free queue.
-        unsafe impl Send for CompletionHandle {}
-        // Intentionally not `Sync`: the opaque owner (`JSBundleCompletionTask`)
-        // is modeled as `!Sync`, and this wrapper exposes `is_cancelled(&self)`
-        // in addition to the lock-free enqueue path, so blanket `&CompletionHandle`
-        // sharing across threads is not justified. The handle only needs to *move*
-        // to the bundle thread (`Send`), not be shared. If a cross-thread `&` ever
-        // becomes necessary, split out an enqueue-only wrapper and make only that
-        // type `Sync`.
-        impl CompletionHandle {
-            #[inline]
-            pub(crate) fn is_cancelled(&self) -> bool {
-                // SAFETY: vtable contract.
-                unsafe { (self.vtable.is_cancelled)(self.owner) }
-            }
-            #[inline]
-            pub(crate) fn enqueue_task_concurrent(
+            fn is_cancelled(&self) -> bool;
+            /// Queue `task` on the owning VM's event loop and wake it (any thread).
+            fn enqueue_task_concurrent(
                 &self,
                 task: core::ptr::NonNull<bun_event_loop::ConcurrentTask::ConcurrentTask>,
-            ) {
-                // SAFETY: vtable contract.
-                unsafe { (self.vtable.enqueue_task_concurrent)(self.owner, task.as_ptr()) }
-            }
+            );
         }
+        pub type CompletionHandle = std::sync::Arc<dyn CompletionDispatch>;
     }
 
     /// `bun.jsc.AnyEventLoop` — re-export the linker's alias
     /// (`Option<NonNull<bun_event_loop::AnyEventLoop>>`).
     pub use crate::linker_context_mod::EventLoop;
-
-    // `JSBundleCompletionTask` — typed-ptr marker for
-    // `BundleV2.completion`. The concrete struct lives in `bun_runtime` (its
-    // fields name `Config`/`Plugin`/`HTMLBundle::Route`); the bundler only ever
-    // holds a `NonNull<JSBundleCompletionTask>` inside [`dispatch::CompletionHandle`]
-    // and never dereferences it. Nomicon opaque-FFI pattern: ZST with
-    // `PhantomData<(*mut u8, PhantomPinned)>` so it is `!Send + !Sync + !Unpin`
-    // and has no usable size/layout in this crate.
-    bun_opaque::opaque_ffi! { pub struct JSBundleCompletionTask; }
 
     /// Erase `&[u8]` to `&'static [u8]` for storage in lifetime-erased
     /// `Path<'static>` slots (`ImportRecord.path`, `Graph.input_files`).
@@ -1657,16 +1686,15 @@ pub mod bv2_impl {
     pub use super::{BakeOptions, BundleV2, PendingImport};
 
     impl<'a> BundleV2<'a> {
-        /// Folds the JS-loop lookup + enqueue so the bundler never dereferences
-        /// `JSBundleCompletionTask` (its layout lives in `bun_runtime`); the
-        /// `completion` handle carries the `&'static` vtable.
+        /// Folds the JS-loop lookup + enqueue so the bundler never names the
+        /// `Bun.build` state (its layout lives in `bun_runtime`).
         pub(crate) fn enqueue_on_js_loop_for_plugins(
             &mut self,
             task: NonNull<bun_event_loop::ConcurrentTask::ConcurrentTask>,
         ) {
             debug_assert!(self.plugins.is_some());
-            if let Some(completion) = self.completion {
-                // From Bun.build — the completion posts it to its VM (through its ticket, via the vtable).
+            if let Some(completion) = &self.completion {
+                // From Bun.build — the completion posts it to its VM (through its ticket).
                 completion.enqueue_task_concurrent(task);
                 return;
             }
@@ -2351,12 +2379,14 @@ pub mod bv2_impl {
                 Fs::PathName::init(&import_record.source_file).dir_with_trailing_slash();
 
             // Check the FileMap first for in-memory files
-            if let Some(file_map) = self.file_map {
-                if let Some(_file_map_result) = file_map.resolve(
-                    self.arena(),
-                    &import_record.source_file,
-                    &import_record.specifier,
-                ) {
+            {
+                if let Some(_file_map_result) = self.file_map.as_deref().and_then(|file_map| {
+                    file_map.resolve(
+                        self.arena(),
+                        &import_record.source_file,
+                        &import_record.specifier,
+                    )
+                }) {
                     let file_map_result = _file_map_result;
                     let mut path_primary = file_map_result.path_pair.primary;
                     // reshaped for borrowck — `get_or_put` borrows `*self` mutably via
@@ -3187,8 +3217,11 @@ pub mod bv2_impl {
                 }
 
                 // Check FileMap first for in-memory entry points
-                if let Some(file_map) = self.file_map {
-                    if let Some(file_map_result) = file_map.resolve(self.arena(), b"", entry_point)
+                {
+                    if let Some(file_map_result) = self
+                        .file_map
+                        .as_deref()
+                        .and_then(|file_map| file_map.resolve(self.arena(), b"", entry_point))
                     {
                         let _ = self.enqueue_entry_item(
                             &mut { file_map_result },
@@ -6412,10 +6445,10 @@ pub mod bv2_impl {
                 let transpiler: &mut Transpiler<'a> = unsafe { &mut *transpiler_ptr };
 
                 // Check the FileMap first for in-memory files
-                if let Some(file_map) = self.file_map {
-                    if let Some(_file_map_result) =
+                {
+                    if let Some(_file_map_result) = self.file_map.as_deref().and_then(|file_map| {
                         file_map.resolve(self.arena(), source.path.text, import_record.path.text)
-                    {
+                    }) {
                         let mut file_map_result = _file_map_result;
                         let mut path_primary = file_map_result.path_pair.primary;
                         let import_record_loader = import_record.loader.unwrap_or_else(|| {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2379,79 +2379,73 @@ pub mod bv2_impl {
                 Fs::PathName::init(&import_record.source_file).dir_with_trailing_slash();
 
             // Check the FileMap first for in-memory files
-            {
-                if let Some(_file_map_result) = self.file_map.as_deref().and_then(|file_map| {
-                    file_map.resolve(
-                        self.arena(),
-                        &import_record.source_file,
-                        &import_record.specifier,
+            if let Some(_file_map_result) = self.file_map.as_deref().and_then(|file_map| {
+                file_map.resolve(
+                    self.arena(),
+                    &import_record.source_file,
+                    &import_record.specifier,
+                )
+            }) {
+                let file_map_result = _file_map_result;
+                let mut path_primary = file_map_result.path_pair.primary;
+                // reshaped for borrowck — `get_or_put` borrows `*self` mutably via
+                // `self.graph`; capture the slot as `*mut u32` so subsequent `self.*` calls
+                // type-check. SAFETY: `path_to_source_index_map(target)` is not mutated again
+                // until after the last `*value_ptr` access below.
+                let (found_existing, value_ptr): (bool, *mut u32) = {
+                    let entry = self
+                        .path_to_source_index_map(target)
+                        .get_or_put(path_primary.text)
+                        .expect("oom");
+                    (
+                        entry.found_existing,
+                        std::ptr::from_mut::<u32>(entry.value_ptr),
                     )
-                }) {
-                    let file_map_result = _file_map_result;
-                    let mut path_primary = file_map_result.path_pair.primary;
-                    // reshaped for borrowck — `get_or_put` borrows `*self` mutably via
-                    // `self.graph`; capture the slot as `*mut u32` so subsequent `self.*` calls
-                    // type-check. SAFETY: `path_to_source_index_map(target)` is not mutated again
-                    // until after the last `*value_ptr` access below.
-                    let (found_existing, value_ptr): (bool, *mut u32) = {
-                        let entry = self
-                            .path_to_source_index_map(target)
-                            .get_or_put(path_primary.text)
-                            .expect("oom");
-                        (
-                            entry.found_existing,
-                            std::ptr::from_mut::<u32>(entry.value_ptr),
-                        )
+                };
+                if !found_existing {
+                    let loader: Loader = 'brk: {
+                        let record: &mut ImportRecord =
+                            &mut self.graph.ast.items_import_records_mut()
+                                [import_record.importer_source_index as usize]
+                                .as_mut_slice()
+                                [import_record.import_record_index as usize];
+                        if let Some(out_loader) = record.loader {
+                            break 'brk out_loader;
+                        }
+                        // SAFETY: see `transpiler` note above.
+                        break 'brk Fs::Path::init(path_primary.text)
+                            .loader(unsafe { &(*transpiler).options.loaders })
+                            .unwrap_or(Loader::File);
                     };
-                    if !found_existing {
-                        let loader: Loader = 'brk: {
-                            let record: &mut ImportRecord =
-                                &mut self.graph.ast.items_import_records_mut()
-                                    [import_record.importer_source_index as usize]
-                                    .as_mut_slice()
-                                    [import_record.import_record_index as usize];
-                            if let Some(out_loader) = record.loader {
-                                break 'brk out_loader;
-                            }
-                            // SAFETY: see `transpiler` note above.
-                            break 'brk Fs::Path::init(path_primary.text)
-                                .loader(unsafe { &(*transpiler).options.loaders })
-                                .unwrap_or(Loader::File);
-                        };
-                        // For virtual files, use the path text as-is (no relative path computation needed).
-                        path_primary.pretty = self.arena().alloc_slice_copy(path_primary.text);
-                        let mut tmp_source = bun_ast::Source {
-                            path: path_as_static(&path_primary),
-                            contents: std::borrow::Cow::Borrowed(&b""[..]),
-                            ..Default::default()
-                        };
-                        let idx = self
-                            .enqueue_parse_task(
-                                &file_map_result,
-                                &mut tmp_source,
-                                loader,
-                                import_record.original_target,
-                            )
-                            .expect("oom");
-                        // SAFETY: see `value_ptr` note above.
-                        unsafe { *value_ptr = idx };
-                        let record: &mut ImportRecord =
-                            &mut self.graph.ast.items_import_records_mut()
-                                [import_record.importer_source_index as usize]
-                                .as_mut_slice()
-                                [import_record.import_record_index as usize];
-                        record.source_index = Index::init(idx);
-                    } else {
-                        let record: &mut ImportRecord =
-                            &mut self.graph.ast.items_import_records_mut()
-                                [import_record.importer_source_index as usize]
-                                .as_mut_slice()
-                                [import_record.import_record_index as usize];
-                        // SAFETY: see `value_ptr` note above.
-                        record.source_index = Index::init(unsafe { *value_ptr });
-                    }
-                    return;
+                    // For virtual files, use the path text as-is (no relative path computation needed).
+                    path_primary.pretty = self.arena().alloc_slice_copy(path_primary.text);
+                    let mut tmp_source = bun_ast::Source {
+                        path: path_as_static(&path_primary),
+                        contents: std::borrow::Cow::Borrowed(&b""[..]),
+                        ..Default::default()
+                    };
+                    let idx = self
+                        .enqueue_parse_task(
+                            &file_map_result,
+                            &mut tmp_source,
+                            loader,
+                            import_record.original_target,
+                        )
+                        .expect("oom");
+                    // SAFETY: see `value_ptr` note above.
+                    unsafe { *value_ptr = idx };
+                    let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
+                        [import_record.importer_source_index as usize]
+                        .as_mut_slice()[import_record.import_record_index as usize];
+                    record.source_index = Index::init(idx);
+                } else {
+                    let record: &mut ImportRecord = &mut self.graph.ast.items_import_records_mut()
+                        [import_record.importer_source_index as usize]
+                        .as_mut_slice()[import_record.import_record_index as usize];
+                    // SAFETY: see `value_ptr` note above.
+                    record.source_index = Index::init(unsafe { *value_ptr });
                 }
+                return;
             }
 
             let mut had_busted_dir_cache = false;
@@ -3217,20 +3211,18 @@ pub mod bv2_impl {
                 }
 
                 // Check FileMap first for in-memory entry points
+                if let Some(file_map_result) = self
+                    .file_map
+                    .as_deref()
+                    .and_then(|file_map| file_map.resolve(self.arena(), b"", entry_point))
                 {
-                    if let Some(file_map_result) = self
-                        .file_map
-                        .as_deref()
-                        .and_then(|file_map| file_map.resolve(self.arena(), b"", entry_point))
-                    {
-                        let _ = self.enqueue_entry_item(
-                            &mut { file_map_result },
-                            true,
-                            self.transpiler.options.target,
-                            None,
-                        )?;
-                        continue;
-                    }
+                    let _ = self.enqueue_entry_item(
+                        &mut { file_map_result },
+                        true,
+                        self.transpiler.options.target,
+                        None,
+                    )?;
+                    continue;
                 }
 
                 // no plugins were matched
@@ -6445,67 +6437,60 @@ pub mod bv2_impl {
                 let transpiler: &mut Transpiler<'a> = unsafe { &mut *transpiler_ptr };
 
                 // Check the FileMap first for in-memory files
-                {
-                    if let Some(_file_map_result) = self.file_map.as_deref().and_then(|file_map| {
-                        file_map.resolve(self.arena(), source.path.text, import_record.path.text)
-                    }) {
-                        let mut file_map_result = _file_map_result;
-                        let mut path_primary = file_map_result.path_pair.primary;
-                        let import_record_loader = import_record.loader.unwrap_or_else(|| {
-                            Fs::Path::init(path_primary.text)
-                                .loader(&transpiler.options.loaders)
-                                .unwrap_or(Loader::File)
-                        });
-                        import_record.loader = Some(import_record_loader);
+                if let Some(_file_map_result) = self.file_map.as_deref().and_then(|file_map| {
+                    file_map.resolve(self.arena(), source.path.text, import_record.path.text)
+                }) {
+                    let mut file_map_result = _file_map_result;
+                    let mut path_primary = file_map_result.path_pair.primary;
+                    let import_record_loader = import_record.loader.unwrap_or_else(|| {
+                        Fs::Path::init(path_primary.text)
+                            .loader(&transpiler.options.loaders)
+                            .unwrap_or(Loader::File)
+                    });
+                    import_record.loader = Some(import_record_loader);
 
-                        if let Some(id) =
-                            self.path_to_source_index_map(target).get(path_primary.text)
-                        {
-                            import_record.source_index = Index::init(id);
-                            continue;
-                        }
-
-                        let resolve_entry =
-                            resolve_queue.get_or_put(path_primary.text).expect("oom");
-                        if resolve_entry.found_existing {
-                            // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
-                            import_record.path =
-                                path_as_static(&unsafe { &**resolve_entry.value_ptr }.path);
-                            continue;
-                        }
-
-                        // For virtual files, use the path text as-is (no relative path computation needed).
-                        // SAFETY: arena outlives the bundle pass; raw-pointer detour erases the
-                        // `&self` lifetime so the resulting `&'static [u8]` doesn't pin `self`
-                        // (otherwise `path_primary: Path<'static>` forces `&self: 'static`,
-                        // cascading borrow conflicts into every `&mut self` call below).
-                        path_primary.pretty = unsafe {
-                            bun_ptr::detach_lifetime(
-                                self.arena().alloc_slice_copy(path_primary.text),
-                            )
-                        };
-                        import_record.path = path_as_static(&path_primary);
-                        let _ = path_primary.text; // key already interned by get_or_put
-                        bun_core::scoped_log!(
-                            Bundle,
-                            "created ParseTask from FileMap: {}",
-                            bstr::BStr::new(&path_primary.text)
-                        );
-                        file_map_result.path_pair.primary = path_primary;
-                        // Arena-owned.
-                        let resolve_task_val =
-                            ParseTask::init(&file_map_result, bun_ast::Index::INVALID, self);
-                        // SAFETY: arena outlives the bundle pass.
-                        let resolve_task: &mut ParseTask = self.arena_create(resolve_task_val);
-                        resolve_task.known_target = target;
-                        // Use transpiler JSX options, applying force_node_env like the disk path does
-                        resolve_task.jsx = transpiler.options.jsx.clone();
-                        resolve_task.jsx.development = transpiler.options.forced_jsx_development();
-                        resolve_task.loader = Some(import_record_loader);
-                        resolve_task.side_effects = bun_ast::SideEffects::HasSideEffects;
-                        *resolve_entry.value_ptr = resolve_task;
+                    if let Some(id) = self.path_to_source_index_map(target).get(path_primary.text) {
+                        import_record.source_index = Index::init(id);
                         continue;
                     }
+
+                    let resolve_entry = resolve_queue.get_or_put(path_primary.text).expect("oom");
+                    if resolve_entry.found_existing {
+                        // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
+                        import_record.path =
+                            path_as_static(&unsafe { &**resolve_entry.value_ptr }.path);
+                        continue;
+                    }
+
+                    // For virtual files, use the path text as-is (no relative path computation needed).
+                    // SAFETY: arena outlives the bundle pass; raw-pointer detour erases the
+                    // `&self` lifetime so the resulting `&'static [u8]` doesn't pin `self`
+                    // (otherwise `path_primary: Path<'static>` forces `&self: 'static`,
+                    // cascading borrow conflicts into every `&mut self` call below).
+                    path_primary.pretty = unsafe {
+                        bun_ptr::detach_lifetime(self.arena().alloc_slice_copy(path_primary.text))
+                    };
+                    import_record.path = path_as_static(&path_primary);
+                    let _ = path_primary.text; // key already interned by get_or_put
+                    bun_core::scoped_log!(
+                        Bundle,
+                        "created ParseTask from FileMap: {}",
+                        bstr::BStr::new(&path_primary.text)
+                    );
+                    file_map_result.path_pair.primary = path_primary;
+                    // Arena-owned.
+                    let resolve_task_val =
+                        ParseTask::init(&file_map_result, bun_ast::Index::INVALID, self);
+                    // SAFETY: arena outlives the bundle pass.
+                    let resolve_task: &mut ParseTask = self.arena_create(resolve_task_val);
+                    resolve_task.known_target = target;
+                    // Use transpiler JSX options, applying force_node_env like the disk path does
+                    resolve_task.jsx = transpiler.options.jsx.clone();
+                    resolve_task.jsx.development = transpiler.options.forced_jsx_development();
+                    resolve_task.loader = Some(import_record_loader);
+                    resolve_task.side_effects = bun_ast::SideEffects::HasSideEffects;
+                    *resolve_entry.value_ptr = resolve_task;
+                    continue;
                 }
 
                 let mut had_busted_dir_cache = false;

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1380,7 +1380,7 @@ pub struct BundleOptions<'a> {
     /// When set, barrel files from these packages will only load submodules
     /// that are actually imported. Also, any file with sideEffects: false
     /// in its package.json is automatically a barrel candidate.
-    pub optimize_imports: Option<&'a StringSet>,
+    pub optimize_imports: Option<std::sync::Arc<StringSet>>,
 }
 
 // B-3 UNIFIED: was a local dup of `bun_options_types::bundle_enums::ForceNodeEnv`
@@ -1550,7 +1550,7 @@ impl<'a> BundleOptions<'a> {
             supports_multiple_outputs: self.supports_multiple_outputs,
             force_node_env: self.force_node_env,
             ignore_module_resolution_errors: self.ignore_module_resolution_errors,
-            optimize_imports: self.optimize_imports,
+            optimize_imports: self.optimize_imports.clone(),
         }
     }
 

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -145,13 +145,271 @@ pub struct Transpiler<'a> {
     pub macro_context: Option<js_ast::Macro::MacroContext>,
 }
 
+/// A `Transpiler` that owns the arena it was initialised in (its "home"
+/// arena: defines, option strings) and points at a resting `Log` between
+/// calls, for holders that are not themselves process-lifetime
+/// (`Bun.Transpiler`). What it lends never outlives the home arena: [`get`]
+/// borrows at `self`'s lifetime, [`with_mut`] cannot name the arena's
+/// lifetime, and [`with_call`] hands out a [`TranspilerCall`] aimed at one
+/// call's arena and log and aims it back afterwards. Off-thread jobs get a
+/// [`JobTranspiler`] copy ([`new_job`]) that keeps the shared storage alive;
+/// while any is out, the transpiler cannot be reconfigured ([`with_mut`]
+/// panics), only used ([`with_call`]).
+///
+/// [`get`]: Self::get
+/// [`with_mut`]: Self::with_mut
+/// [`with_call`]: Self::with_call
+/// [`new_job`]: Self::new_job
+pub struct OwnedTranspiler(
+    std::sync::Arc<OwnedTranspilerInner>,
+    /// `!Send`/`!Sync`: the transpiler runs macros on, and logs to, its VM.
+    core::marker::PhantomData<*mut ()>,
+);
+
+struct OwnedTranspilerInner {
+    /// Reached only through the one `OwnedTranspiler` handle; `JobTranspiler`s
+    /// hold the `Arc` to keep what their copy aliases alive and never touch it.
+    transpiler: core::cell::UnsafeCell<core::mem::ManuallyDrop<Transpiler<'static>>>,
+    /// `Box::into_raw`; freed in `Drop`, after `transpiler`.
+    arena: *mut Arena,
+    home_log: *mut bun_ast::Log,
+}
+
+// SAFETY: `transpiler` is only read or written through the one `OwnedTranspiler`
+// handle, which is `!Send`/`!Sync`; the other `Arc` holders (`JobTranspiler`)
+// never touch it, and dropping it on their thread frees plain heap data (a
+// macro context is released by whoever created it, see
+// `release_macro_context` on both types).
+unsafe impl Send for OwnedTranspilerInner {}
+// SAFETY: as above — a shared `&OwnedTranspilerInner` gives access to nothing.
+unsafe impl Sync for OwnedTranspilerInner {}
+
+impl Drop for OwnedTranspilerInner {
+    fn drop(&mut self) {
+        // SAFETY: sole owner at drop; the transpiler (which borrows the arena)
+        // goes first, then the arena `new` leaked.
+        unsafe {
+            core::mem::ManuallyDrop::drop(self.transpiler.get_mut());
+            drop(bun_core::heap::take(self.arena));
+        }
+    }
+}
+
+impl OwnedTranspiler {
+    /// Build a transpiler in `arena`, which the result owns from here on. `log`
+    /// is where it logs outside [`with_call`](Self::with_call) and must outlive
+    /// the result. `init` cannot name the arena's lifetime, so whatever it
+    /// returns borrows only `arena` (or true statics).
+    pub fn new<E>(
+        arena: Box<Arena>,
+        log: *mut bun_ast::Log,
+        init: impl for<'a> FnOnce(&'a Arena, *mut bun_ast::Log) -> Result<Transpiler<'a>, E>,
+    ) -> Result<Self, E> {
+        let arena = bun_core::heap::into_raw(arena);
+        // SAFETY: `arena` is live until `OwnedTranspilerInner::drop`, which drops
+        // the transpiler first; the `'static` view never leaves this type (see
+        // the struct doc).
+        let transpiler = match init(unsafe { &*arena }, log) {
+            Ok(t) => t,
+            Err(e) => {
+                // SAFETY: nothing borrows it (init failed).
+                drop(unsafe { bun_core::heap::take(arena) });
+                return Err(e);
+            }
+        };
+        Ok(Self(
+            std::sync::Arc::new(OwnedTranspilerInner {
+                transpiler: core::cell::UnsafeCell::new(core::mem::ManuallyDrop::new(transpiler)),
+                arena,
+                home_log: log,
+            }),
+            core::marker::PhantomData,
+        ))
+    }
+
+    /// The transpiler, for reading its configuration.
+    #[inline]
+    pub fn get(&self) -> &Transpiler<'_> {
+        // SAFETY: see `OwnedTranspilerInner::transpiler` — this handle is the
+        // only accessor; `&self` rules out a concurrent `with_mut`/`with_call`.
+        unsafe { &**self.0.transpiler.get() }
+    }
+
+    /// The transpiler, for (re)configuring it before any job copy exists (a
+    /// copy aliases the configuration, so replacing any of it then would free
+    /// what the copy reads: panics instead). `f` cannot name the home arena's
+    /// lifetime, so it can store nothing shorter-lived in the transpiler.
+    pub fn with_mut<R>(&mut self, f: impl for<'a> FnOnce(&mut Transpiler<'a>) -> R) -> R {
+        // Copies only come from `new_job(&self)`, so none can appear during `f`.
+        assert!(
+            std::sync::Arc::strong_count(&self.0) == 1,
+            "OwnedTranspiler reconfigured while job copies are alive",
+        );
+        // SAFETY: as `get`; `&mut self` makes this the only live borrow.
+        f(unsafe { &mut **self.0.transpiler.get() })
+    }
+
+    /// Run `f` with the transpiler aimed at this call's `arena` and `log`
+    /// (parsing and printing allocate from and log to them), through a handle
+    /// that can parse, print and manage the macro context but not replace the
+    /// transpiler or its configuration; it is aimed back at its homes afterwards.
+    pub fn with_call<'a, R>(
+        &'a mut self,
+        arena: &'a Arena,
+        log: &'a mut bun_ast::Log,
+        f: impl FnOnce(&mut TranspilerCall<'_, 'a>) -> R,
+    ) -> R {
+        struct Restore<'t> {
+            inner: &'t OwnedTranspilerInner,
+            arena: *const Arena,
+            log: *mut bun_ast::Log,
+        }
+        impl Drop for Restore<'_> {
+            fn drop(&mut self) {
+                // SAFETY: the `&mut OwnedTranspiler` borrow `with_call` holds makes
+                // this the only access; `arena`/`log` are what the transpiler was
+                // aimed at before this call (its homes, unless calls nest), which
+                // outlive it.
+                unsafe {
+                    let t: &mut Transpiler<'static> = &mut **self.inner.transpiler.get();
+                    t.set_arena(&*self.arena);
+                    t.set_log(self.log);
+                }
+            }
+        }
+        // SAFETY: as `get`.
+        let (prev_arena, prev_log) = unsafe {
+            let t = &**self.0.transpiler.get();
+            (core::ptr::from_ref::<Arena>(t.arena), t.log)
+        };
+        let restore = Restore {
+            inner: &self.0,
+            arena: prev_arena,
+            log: prev_log,
+        };
+        // SAFETY: lifetime narrowing — `Transpiler<'x>` is covariant in `'x`; the
+        // `&mut` is only reachable through `TranspilerCall`, which exposes no
+        // `'x`-typed slot for writing, and `restore` aims `arena`/`log` back
+        // before `'a` ends (on return or unwind) while `self` stays exclusively
+        // borrowed, so the narrowed value is never observed at `'static`.
+        let t: &mut Transpiler<'a> = unsafe {
+            &mut *core::ptr::from_mut::<Transpiler<'static>>(&mut **restore.inner.transpiler.get())
+                .cast::<Transpiler<'a>>()
+        };
+        t.set_arena(arena);
+        t.set_log(log);
+        let r = f(&mut TranspilerCall(t));
+        drop(restore);
+        r
+    }
+
+    /// A [`JobTranspiler`] copy of this transpiler's configuration for an
+    /// off-thread job; it keeps this transpiler's storage alive, and while it
+    /// is, the configuration it aliases cannot change ([`with_mut`](Self::with_mut)).
+    pub fn new_job(&self) -> JobTranspiler {
+        // SAFETY: `JobTranspiler::new`'s contract — the copy holds `self.0`, so
+        // what it aliases outlives it and (see `with_mut`) is not reconfigured;
+        // it is aimed at the homes, not at whatever a `with_call` in progress lent.
+        unsafe {
+            let mut job = JobTranspiler::new(&**self.0.transpiler.get());
+            job.0.set_arena(&*self.0.arena);
+            job.0.set_log(self.0.home_log);
+            job.1 = Some(std::sync::Arc::clone(&self.0));
+            job
+        }
+    }
+
+    /// Free the macro context a parse or scan through this transpiler created
+    /// (job copies have their own), on the thread that ran it.
+    pub fn release_macro_context(&mut self) {
+        // SAFETY: as `get`; `&mut self` makes this the only live borrow, and the
+        // macro context is not part of what job copies alias.
+        if let Some(ctx) = unsafe { &mut **self.0.transpiler.get() }
+            .macro_context
+            .take()
+        {
+            ctx.deinit();
+        }
+    }
+
+    /// The home arena: lives as long as `self` and every job copy.
+    #[inline]
+    pub fn arena(&self) -> &Arena {
+        // SAFETY: live until `OwnedTranspilerInner::drop`.
+        unsafe { &*self.0.arena }
+    }
+}
+
+/// An [`OwnedTranspiler`]'s transpiler aimed at one call's arena and log: it
+/// parses and prints, and its macro context can be taken or replaced, but the
+/// transpiler and its configuration cannot be.
+pub struct TranspilerCall<'t, 'a>(&'t mut Transpiler<'a>);
+
+impl<'a> TranspilerCall<'_, 'a> {
+    #[inline]
+    pub fn options(&self) -> &options::BundleOptions<'a> {
+        &self.0.options
+    }
+    /// This call's log.
+    #[inline]
+    pub fn log_mut(&mut self) -> &mut bun_ast::Log {
+        self.0.log_mut()
+    }
+    #[inline]
+    pub fn parse(
+        &mut self,
+        this_parse: ParseOptions<'a, '_>,
+        client_entry_point: Option<&mut EntryPoints::ClientEntryPoint>,
+    ) -> Option<ParseResult<'a>> {
+        self.0.parse(this_parse, client_entry_point)
+    }
+    #[inline]
+    pub fn print(
+        &mut self,
+        print_arena: &Arena,
+        result: ParseResult,
+        writer: &mut js_printer::BufferPrinter,
+        format: js_printer::Format,
+    ) -> crate::Result<usize> {
+        self.0.print(print_arena, result, writer, format)
+    }
+    /// The transpiler's macro context slot (lazily created by `parse`).
+    #[inline]
+    pub fn macro_context(&mut self) -> &mut Option<js_ast::Macro::MacroContext> {
+        &mut self.0.macro_context
+    }
+    /// Create the macro context if there is none, and return it together with
+    /// the defines, for a scan pass.
+    pub fn macro_context_and_define(
+        &mut self,
+    ) -> (&mut js_ast::Macro::MacroContext, &crate::defines::Define) {
+        if self.0.macro_context.is_none() {
+            let mc = js_ast::Macro::MacroContext::init(self.0);
+            self.0.macro_context = Some(mc);
+        }
+        (
+            self.0.macro_context.as_mut().unwrap(),
+            &self.0.options.define,
+        )
+    }
+}
+
 /// A `Transpiler` for one off-thread transpile job: a bytewise copy of a
 /// long-lived transpiler whose `options` / `resolver` / `fs` / `env` alias the
 /// original's (so it is never dropped as a `Transpiler`), pointed at the job's
 /// own arena and log for the span of each [`for_call`](Self::for_call), with
 /// its own lazily-created macro context (freed on drop). What a job uses
 /// instead of the VM's transpiler itself on the work pool.
-pub struct JobTranspiler(core::mem::ManuallyDrop<Transpiler<'static>>);
+pub struct JobTranspiler(
+    core::mem::ManuallyDrop<Transpiler<'static>>,
+    /// What the copy aliases, when that is an [`OwnedTranspiler`]'s.
+    Option<std::sync::Arc<OwnedTranspilerInner>>,
+);
+
+// SAFETY: a `JobTranspiler` moves to the thread that runs the job and is used
+// there alone; what it aliases from its source is configuration that source
+// only reads while copies are out (`new`'s contract).
+unsafe impl Send for JobTranspiler {}
 
 impl JobTranspiler {
     /// Copy `from`'s configuration for a job.
@@ -170,6 +428,9 @@ impl JobTranspiler {
     /// copy's own macro context; `from`'s thread may parse/scan/print
     /// concurrently under the same restriction but must not hand out
     /// `fs_mut()`/`log_mut()`/`&mut options` borrows that a job could observe.
+    /// [`OwnedTranspiler::new_job`] discharges the no-reconfiguration half at
+    /// runtime (`with_mut` panics while a copy is alive); the VM's own
+    /// transpiler is configured once, before any job is scheduled.
     pub unsafe fn new(from: &Transpiler<'static>) -> Self {
         // SAFETY: fn contract; `ManuallyDrop` keeps the copy from freeing what
         // `from` owns.
@@ -177,7 +438,7 @@ impl JobTranspiler {
         // `from`'s macro context (if any) points back at `from`; `parse` lazily
         // creates this copy's own.
         copy.macro_context = None;
-        Self(copy)
+        Self(copy, None)
     }
 
     /// The copy, aimed at this call's `arena` and `log` until the returned

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -131,6 +131,31 @@ pub struct Task {
     pub ptr: *mut (),
 }
 
+/// A task whose queued pointer is a [`ThisPtr`](bun_ptr::ThisPtr) to
+/// `Target`, which keeps itself alive for the task; the dispatcher runs it or
+/// releases it through here. A zero-sized hop type per tag, declared next to
+/// `Target` with its own `unsafe impl` stating the ref protocol.
+///
+/// # Safety
+/// `TAG` is dispatched (in `bun_runtime::dispatch`) to this impl and no other
+/// task type uses it; and `Target`'s protocol keeps the pointee of every
+/// [`task`](Self::task) it queues alive until `run` / `release_unrun` (a
+/// `RefPtr` slot held for the queued task, or an owner that outlives the queue).
+pub unsafe trait TaskHop {
+    type Target;
+    /// The tag constant from [`task_tag`]; the `bun_runtime::dispatch` match
+    /// arms MUST agree.
+    const TAG: TaskTag;
+    fn run(this: bun_ptr::ThisPtr<Self::Target>) -> crate::JsResult<()>;
+    /// As [`Taskable::release_unrun`].
+    fn release_unrun(this: bun_ptr::ThisPtr<Self::Target>);
+
+    #[inline]
+    fn task(this: bun_ptr::ThisPtr<Self::Target>) -> Task {
+        Task::new(Self::TAG, this.as_ptr().cast::<()>())
+    }
+}
+
 /// What it takes to be queued as a [`Task`]: a tag, and how the task is
 /// freed when it will never run. Implement on every type that can be
 /// enqueued; the impl lives in whatever crate owns the type.

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -29,7 +29,7 @@ pub mod any_event_loop;
 // ─── public surface ─────────────────────────────────────────────────────────
 
 pub type JsResult<T> = core::result::Result<T, bun_core::JsError>;
-pub use ConcurrentTask::{BoxedTask, Task, TaskTag, Taskable, task_tag};
+pub use ConcurrentTask::{BoxedTask, Task, TaskHop, TaskTag, Taskable, task_tag};
 
 // snake_case alias for the file-level-struct module so higher tiers avoid
 // the type/module namespace collision on the PascalCase form.

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -47,11 +47,31 @@ extern "C" void OnBeforeParseResult__reset(OnBeforeParseResult* result);
 #define WRAP_BUNDLER_PLUGIN(argName) jsDoubleNumber(std::bit_cast<double>(reinterpret_cast<uintptr_t>(argName)))
 #define UNWRAP_BUNDLER_PLUGIN(callFrame) reinterpret_cast<void*>(std::bit_cast<uintptr_t>(callFrame->argument(0).asDouble()))
 
-/// These are native callbacks to be run after their associated JS version is run
-extern "C" void JSBundlerPlugin__addError(void*, void*, JSC::EncodedJSValue, uint8_t);
-extern "C" void JSBundlerPlugin__onLoadAsync(void*, void*, JSC::EncodedJSValue, JSC::EncodedJSValue);
-extern "C" void JSBundlerPlugin__onResolveAsync(void*, void*, JSC::EncodedJSValue, JSC::EncodedJSValue, JSC::EncodedJSValue);
+/// These are native callbacks to be run after their associated JS version is run. `context` is the
+/// bundler's `Resolve*` (RequestKind::Resolve) or `Load*` (RequestKind::Load).
+extern "C" void JSBundlerPlugin__addErrorResolve(void*, JSC::JSGlobalObject*, JSC::EncodedJSValue);
+extern "C" void JSBundlerPlugin__addErrorLoad(void*, JSC::JSGlobalObject*, JSC::EncodedJSValue);
+extern "C" void JSBundlerPlugin__answerCancelledResolve(void*);
+extern "C" void JSBundlerPlugin__answerCancelledLoad(void*);
+extern "C" void JSBundlerPlugin__onLoadAsync(void*, JSC::JSGlobalObject*, JSC::EncodedJSValue, JSC::EncodedJSValue);
+extern "C" void JSBundlerPlugin__onResolveAsync(void*, JSC::JSGlobalObject*, JSC::EncodedJSValue, JSC::EncodedJSValue, JSC::EncodedJSValue);
 extern "C" JSC::EncodedJSValue JSBundlerPlugin__onDefer(void*, JSC::JSGlobalObject*);
+
+static void JSBundlerPlugin__addError(void* context, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue exception, uint8_t kind)
+{
+    if (kind == static_cast<uint8_t>(BundlerPlugin::RequestKind::Resolve))
+        JSBundlerPlugin__addErrorResolve(context, globalObject, exception);
+    else
+        JSBundlerPlugin__addErrorLoad(context, globalObject, exception);
+}
+
+static void JSBundlerPlugin__answerCancelled(BundlerPlugin::RequestKind kind, void* context)
+{
+    if (kind == BundlerPlugin::RequestKind::Resolve)
+        JSBundlerPlugin__answerCancelledResolve(context);
+    else
+        JSBundlerPlugin__answerCancelledLoad(context);
+}
 
 JSC_DECLARE_HOST_FUNCTION(jsBundlerPluginFunction_addFilter);
 JSC_DECLARE_HOST_FUNCTION(jsBundlerPluginFunction_addError);
@@ -124,13 +144,12 @@ public:
     static JSBundlerPlugin* create(JSC::VM& vm,
         JSC::JSGlobalObject* globalObject,
         JSC::Structure* structure,
-        void* config,
         BunPluginTarget target,
         JSBundlerPluginAddErrorCallback addError = JSBundlerPlugin__addError,
         JSBundlerPluginOnLoadAsyncCallback onLoadAsync = JSBundlerPlugin__onLoadAsync,
         JSBundlerPluginOnResolveAsyncCallback onResolveAsync = JSBundlerPlugin__onResolveAsync)
     {
-        JSBundlerPlugin* ptr = new (NotNull, JSC::allocateCell<JSBundlerPlugin>(vm)) JSBundlerPlugin(vm, globalObject, structure, config, target,
+        JSBundlerPlugin* ptr = new (NotNull, JSC::allocateCell<JSBundlerPlugin>(vm)) JSBundlerPlugin(vm, globalObject, structure, target,
             addError,
             onLoadAsync,
             onResolveAsync);
@@ -171,10 +190,10 @@ public:
     }
 
 private:
-    JSBundlerPlugin(JSC::VM& vm, JSC::JSGlobalObject* global, JSC::Structure* structure, void* config, BunPluginTarget target,
+    JSBundlerPlugin(JSC::VM& vm, JSC::JSGlobalObject* global, JSC::Structure* structure, BunPluginTarget target,
         JSBundlerPluginAddErrorCallback addError, JSBundlerPluginOnLoadAsyncCallback onLoadAsync, JSBundlerPluginOnResolveAsyncCallback onResolveAsync)
         : Base(vm, structure)
-        , plugin(BundlerPlugin(config, target, addError, onLoadAsync, onResolveAsync))
+        , plugin(BundlerPlugin(target, addError, onLoadAsync, onResolveAsync))
         , m_globalObject(global)
     {
     }
@@ -426,7 +445,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_addError, (JSC::JSGlobalObject 
     JSBundlerPlugin* thisObject = uncheckedDowncast<JSBundlerPlugin>(callFrame->thisValue());
     void* context = UNWRAP_BUNDLER_PLUGIN(callFrame);
     if (auto kind = thisObject->plugin.takeRequest(context))
-        thisObject->plugin.addError(context, thisObject, JSValue::encode(callFrame->argument(1)), static_cast<uint8_t>(*kind));
+        thisObject->plugin.addError(context, globalObject, JSValue::encode(callFrame->argument(1)), static_cast<uint8_t>(*kind));
 
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
@@ -436,7 +455,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onLoadAsync, (JSC::JSGlobalObje
     if (thisObject->plugin.takeRequest(BundlerPlugin::RequestKind::Load, UNWRAP_BUNDLER_PLUGIN(callFrame))) {
         thisObject->plugin.onLoadAsync(
             UNWRAP_BUNDLER_PLUGIN(callFrame),
-            thisObject->plugin.config,
+            globalObject,
             JSValue::encode(callFrame->argument(1)),
             JSValue::encode(callFrame->argument(2)));
     }
@@ -449,7 +468,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onResolveAsync, (JSC::JSGlobalO
     if (thisObject->plugin.takeRequest(BundlerPlugin::RequestKind::Resolve, UNWRAP_BUNDLER_PLUGIN(callFrame))) {
         thisObject->plugin.onResolveAsync(
             UNWRAP_BUNDLER_PLUGIN(callFrame),
-            thisObject->plugin.config,
+            globalObject,
             JSValue::encode(callFrame->argument(1)),
             JSValue::encode(callFrame->argument(2)),
             JSValue::encode(callFrame->argument(3)));
@@ -523,8 +542,6 @@ extern "C" bool JSBundlerPlugin__anyMatches(Bun::JSBundlerPlugin* pluginObject, 
     return pluginObject->plugin.anyMatchesCrossThread(pluginObject->vm(), namespaceString, path, isOnLoad);
 }
 
-extern "C" void JSBundlerPlugin__answerCancelled(uint8_t kind, void* context);
-
 // The bundle thread hands an onResolve / onLoad request over to the plugins' (this) thread. From here it is
 // answered exactly once, on this thread: by the plugin, or as cancelled if the plugin can no longer run.
 template<typename BuildArguments>
@@ -533,7 +550,7 @@ static void dispatchRequest(Bun::JSBundlerPlugin* plugin, BundlerPlugin::Request
     JSC::JSGlobalObject* globalObject = plugin->globalObject();
     JSC::CallData callData = function ? JSC::getCallData(function) : JSC::CallData {};
     if (plugin->plugin.tombstoned || callData.type == JSC::CallData::Type::None) [[unlikely]] {
-        JSBundlerPlugin__answerCancelled(static_cast<uint8_t>(kind), context);
+        JSBundlerPlugin__answerCancelled(kind, context);
         return;
     }
     plugin->plugin.holdRequest(kind, context);
@@ -543,7 +560,7 @@ static void dispatchRequest(Bun::JSBundlerPlugin* plugin, BundlerPlugin::Request
     // cancelled (if the plugin has not answered already); the termination stays for the landing frame.
     auto cancel = [&] {
         if (plugin->plugin.takeRequest(kind, context))
-            JSBundlerPlugin__answerCancelled(static_cast<uint8_t>(kind), context);
+            JSBundlerPlugin__answerCancelled(kind, context);
     };
     JSC::MarkedArgumentBuffer arguments;
     buildArguments(globalObject, scope, arguments);
@@ -558,7 +575,7 @@ static void dispatchRequest(Bun::JSBundlerPlugin* plugin, BundlerPlugin::Request
         }
         // The plugin threw before answering: that is its answer.
         if (plugin->plugin.takeRequest(kind, context))
-            plugin->plugin.addError(context, plugin, JSC::JSValue::encode(exception), static_cast<uint8_t>(kind));
+            plugin->plugin.addError(context, globalObject, JSC::JSValue::encode(exception), static_cast<uint8_t>(kind));
     }
 }
 
@@ -599,7 +616,6 @@ extern "C" Bun::JSBundlerPlugin* JSBundlerPlugin__create(Zig::GlobalObject* glob
             globalObject->vm(),
             globalObject,
             globalObject->objectPrototype()),
-        nullptr,
         target);
 }
 
@@ -657,11 +673,6 @@ extern "C" JSC::EncodedJSValue JSBundlerPlugin__runSetupFunction(
     return JSValue::encode(result);
 }
 
-extern "C" void JSBundlerPlugin__setConfig(Bun::JSBundlerPlugin* plugin, void* config)
-{
-    plugin->plugin.config = config;
-}
-
 extern "C" void JSBundlerPlugin__drainDeferred(Bun::JSBundlerPlugin* pluginObject, bool rejected)
 {
     auto* globalObject = pluginObject->globalObject();
@@ -687,7 +698,7 @@ void BundlerPlugin::tombstone()
 {
     tombstoned = true;
     for (auto& [context, kind] : std::exchange(held, {}))
-        JSBundlerPlugin__answerCancelled(static_cast<uint8_t>(kind), context);
+        JSBundlerPlugin__answerCancelled(kind, context);
 }
 
 extern "C" void JSBundlerPlugin__tombstone(Bun::JSBundlerPlugin* plugin)

--- a/src/jsc/bindings/JSBundlerPlugin.h
+++ b/src/jsc/bindings/JSBundlerPlugin.h
@@ -10,9 +10,9 @@
 #include "WriteBarrierList.h"
 #include <wtf/HashMap.h>
 
-typedef void (*JSBundlerPluginAddErrorCallback)(void*, void*, JSC::EncodedJSValue, uint8_t);
-typedef void (*JSBundlerPluginOnLoadAsyncCallback)(void*, void*, JSC::EncodedJSValue, JSC::EncodedJSValue);
-typedef void (*JSBundlerPluginOnResolveAsyncCallback)(void*, void*, JSC::EncodedJSValue, JSC::EncodedJSValue, JSC::EncodedJSValue);
+typedef void (*JSBundlerPluginAddErrorCallback)(void*, JSC::JSGlobalObject*, JSC::EncodedJSValue, uint8_t);
+typedef void (*JSBundlerPluginOnLoadAsyncCallback)(void*, JSC::JSGlobalObject*, JSC::EncodedJSValue, JSC::EncodedJSValue);
+typedef void (*JSBundlerPluginOnResolveAsyncCallback)(void*, JSC::JSGlobalObject*, JSC::EncodedJSValue, JSC::EncodedJSValue, JSC::EncodedJSValue);
 typedef void (*JSBundlerPluginNativeOnBeforeParseCallback)(const OnBeforeParseArguments*, OnBeforeParseResult*);
 
 namespace Bun {
@@ -146,13 +146,12 @@ public:
     // and whatever its JS side delivers later is dropped.
     void tombstone();
 
-    BundlerPlugin(void* config, BunPluginTarget target, JSBundlerPluginAddErrorCallback addError, JSBundlerPluginOnLoadAsyncCallback onLoadAsync, JSBundlerPluginOnResolveAsyncCallback onResolveAsync)
+    BundlerPlugin(BunPluginTarget target, JSBundlerPluginAddErrorCallback addError, JSBundlerPluginOnLoadAsyncCallback onLoadAsync, JSBundlerPluginOnResolveAsyncCallback onResolveAsync)
         : addError(addError)
         , onLoadAsync(onLoadAsync)
         , onResolveAsync(onResolveAsync)
     {
         this->target = target;
-        this->config = config;
     }
 
     NamespaceList onLoad = {};
@@ -168,7 +167,6 @@ public:
     JSBundlerPluginAddErrorCallback addError;
     JSBundlerPluginOnLoadAsyncCallback onLoadAsync;
     JSBundlerPluginOnResolveAsyncCallback onResolveAsync;
-    void* config { nullptr };
     bool tombstoned { false };
 
 private:

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1,18 +1,15 @@
 //! `Bun.build()` plugin host + `BuildArtifact` JS wrapper.
 
 use bun_options_types::LoaderExt as _;
-use core::ffi::c_void;
 
 use crate::webcore::Blob;
 use crate::webcore::blob::BlobExt;
 use bun_ast::Target;
-use bun_bundler::BundleV2;
 use bun_bundler::options;
 use bun_collections::{StringMap, StringSet};
 use bun_core::MutableString;
 use bun_core::Output;
 use bun_core::String as BunString;
-use bun_jsc::ConcurrentTask::ConcurrentTask;
 use bun_jsc::bun_string_jsc;
 use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsError, JsResult, StringJsc as _};
 use bun_options_types::compile_target::CompileTarget;
@@ -536,16 +533,13 @@ pub mod js_bundler {
                     };
 
                     let is_last = i == (length as usize).saturating_sub(1);
-                    // SAFETY: bun_plugins is a valid pointer created/stored above
-                    let mut plugin_result = unsafe {
-                        (*bun_plugins).add_plugin(
-                            function,
-                            config,
-                            onstart_promise_array,
-                            is_last,
-                            false,
-                        )?
-                    };
+                    let mut plugin_result = Plugin::opaque_ref(bun_plugins).add_plugin(
+                        function,
+                        config,
+                        onstart_promise_array,
+                        is_last,
+                        false,
+                    )?;
 
                     if !plugin_result.is_empty_or_undefined_or_null() {
                         if let Some(promise) = plugin_result.as_any_promise() {
@@ -1092,11 +1086,9 @@ pub mod js_bundler {
             }
 
             if let Some(define) = config.get_own_object(global_this, "define")? {
-                // SAFETY: `get_own_object` only returns non-null live JSObject*.
-                let define_ref = unsafe { &*define };
                 let define_iter = jsc::JSPropertyIterator::init(
                     global_this,
-                    define_ref,
+                    define,
                     jsc::JSPropertyIteratorOptions {
                         skip_empty_name: true,
                         include_value: true,
@@ -1131,11 +1123,9 @@ pub mod js_bundler {
             }
 
             if let Some(loaders) = config.get_own_object(global_this, "loader")? {
-                // SAFETY: `get_own_object` only returns non-null live JSObject*.
-                let loaders_ref = unsafe { &*loaders };
                 let loader_iter = jsc::JSPropertyIterator::init(
                     global_this,
-                    loaders_ref,
+                    loaders,
                     jsc::JSPropertyIteratorOptions {
                         skip_empty_name: true,
                         include_value: true,
@@ -1388,15 +1378,16 @@ pub mod js_bundler {
         // `crate::api::js_bundle_completion_task` (bun_runtime owns it because its
         // fields name `Config`/`Plugin`/`HTMLBundle::Route`; lower-tier crates
         // cannot depend on those).
-        let mut completion = crate::api::js_bundle_completion_task::JSBundleCompletionTask::new(
+        let completion = crate::api::js_bundle_completion_task::JSBundleCompletionTask::new(
             config,
             plugins.and_then(core::ptr::NonNull::new),
             global_this,
         );
-        completion.promise = jsc::JSPromiseStrong::init(global_this);
-        let promise = completion.promise.value();
+        let promise = jsc::JSPromiseStrong::init(global_this);
+        let value = promise.value();
+        completion.promise.set(promise);
         completion.schedule();
-        Ok(promise)
+        Ok(value)
     }
 
     /// `Bun.build(config)`
@@ -1419,54 +1410,24 @@ pub mod js_bundler {
         Load, LoadSuccess, LoadValue, Resolve, ResolveSuccess, ResolveValue,
     };
 
-    /// `&mut BundleV2` for the live backref stored on `Resolve`/`Load`.
-    ///
-    /// Centralises the `*mut BundleV2 → &mut` deref so the C++-called thunks
-    /// (`JSBundlerPlugin__onResolveAsync`, `on_defer`, `…__onLoadAsync`,
-    /// `…__addError`, `on_notify_defer_raw`) stay safe at the call site. `bv2`
-    /// is the back-reference set in `Resolve::init`/`Load::init`; the
-    /// `BundleV2` heap allocation outlives every plugin callback (owner-
-    /// creates-child, single-JS-thread). The `BundleV2` storage is heap-
-    /// disjoint from `Resolve`/`Load`, so the returned `&mut` does not alias
-    /// the caller's `&mut Resolve`/`&mut Load`.
-    #[inline]
-    fn bv2_mut<'a>(bv2: *mut BundleV2<'static>) -> &'a mut BundleV2<'static> {
-        // SAFETY: see fn doc — live backref (owner-creates-child), single
-        // JS-thread, disjoint heap from the `Resolve`/`Load` callers borrow.
-        unsafe { &mut *bv2 }
-    }
+    // The C++ plugin object (`JSBundlerPlugin.cpp`) calls these with a request it still held
+    // (`BundlerPlugin::takeRequest`): the live `Resolve` / `Load` the bundle thread handed over in
+    // `dispatch`, answered exactly once, on this (the JS) thread — so the `&mut` is real.
 
-    /// `&mut Plugin` for the live `BundleV2` backref stored on `Resolve`/`Load`.
-    ///
-    /// Centralises the `Option<NonNull> → &mut T` deref so the three callers
-    /// (`JSBundlerPlugin__onResolveAsync`, `on_defer`,
-    /// `JSBundlerPlugin__onLoadAsync`) stay safe at the call site. `plugins`
-    /// is `Some` whenever the plugin chain is dispatched (asserted by
-    /// `enqueue_on_js_loop_for_plugins`). The `Plugin` storage is heap-
-    /// disjoint from `Resolve`/`Load`, so the returned `&mut` does not alias
-    /// the caller's `&mut Resolve`/`&mut Load`.
-    #[inline]
-    fn bv2_plugin<'a>(bv2: *mut BundleV2<'static>) -> &'a mut Plugin {
-        // SAFETY: see fn doc — `plugins.is_some()`, disjoint heap.
-        unsafe { &mut *bv2_mut(bv2).plugins.unwrap().as_ptr() }
-    }
-
-    #[unsafe(no_mangle)]
-    extern "C" fn JSBundlerPlugin__onResolveAsync(
-        resolve: &mut Resolve,
-        _unused: *mut c_void,
+    /// The `onResolve` chain's answer.
+    // HOST_EXPORT(JSBundlerPlugin__onResolveAsync, c)
+    pub fn on_resolve_async(
+        resolve: &mut crate::api::JSBundler::Resolve,
+        global: &JSGlobalObject,
         path_value: JSValue,
         namespace_value: JSValue,
         external_value: JSValue,
     ) {
-        // C++ calls this only for a request the plugin object still held (BundlerPlugin::takeRequest): it is
-        // the request's one answer, produced on this thread, so `&mut` is real.
-        if path_value.is_empty_or_undefined_or_null()
+        let value = if path_value.is_empty_or_undefined_or_null()
             || namespace_value.is_empty_or_undefined_or_null()
         {
-            resolve.value = ResolveValue::NoMatch;
+            ResolveValue::NoMatch
         } else {
-            let global = bv2_plugin(resolve.bv2).global_object();
             let path = path_value
                 .to_bun_string(global)
                 .expect("Unexpected: path is not a string")
@@ -1477,130 +1438,30 @@ pub mod js_bundler {
                 .expect("Unexpected: namespace is not a string")
                 .to_owned_slice()
                 .into_boxed_slice();
-            resolve.value = ResolveValue::Success(ResolveSuccess {
+            ResolveValue::Success(ResolveSuccess {
                 path,
                 namespace,
                 external: external_value.to_boolean(),
-            });
-        }
-
-        bv2_mut(resolve.bv2).on_resolve_async(resolve);
+            })
+        };
+        resolve.answer(value);
     }
 
-    bun_output::declare_scope!(BUNDLER_DEFERRED, hidden);
-
-    /// JSC-aware plumbing for `Load` (upstream owns `init`/`dispatch`/
-    /// `run_on_js_thread`/`bake_graph`). Only `on_defer` lives here because it
-    /// returns a `JSValue` and throws on the `JSGlobalObject`.
-    trait LoadJsExt {
-        fn on_defer(&mut self, global_object: &JSGlobalObject) -> JsResult<JSValue>;
-    }
-
-    impl LoadJsExt for Load {
-        fn on_defer(&mut self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
-            if self.called_defer {
-                return Err(global_object.throw(format_args!(
-                    "Can't call .defer() more than once within an onLoad plugin"
-                )));
-            }
-            self.called_defer = true;
-
-            bun_output::scoped_log!(
-                BUNDLER_DEFERRED,
-                "JSBundlerPlugin__onDefer(0x{:x}, {})",
-                std::ptr::from_ref(self) as usize,
-                bstr::BStr::new(&self.path)
-            );
-
-            // Notify the *bundler thread* about the deferral. This will
-            // decrement the pending item counter and increment the deferred
-            // counter. Must land on `parse_task.ctx`'s `r#loop()` (the loop
-            // running BundleV2), which is distinct from the
-            // `enqueue_on_js_loop_for_plugins` target (the plugin host's JS loop)
-            // when `Bun.build` runs the bundler on its own Mini event loop.
-            // SAFETY: `parse_task.ctx` and `bv2` are valid backrefs; `r#loop()`
-            // points at a live `AnyEventLoop` owned by the bundle thread /
-            // runtime for the duration of the bundle.
-            unsafe {
-                let ctx = (*self.parse_task).ctx.expect("ParseTask.ctx unset");
-                // SAFETY: write provenance from `ParseTask::init`; bundle outlives plugin.
-                let any_loop = ctx
-                    .assume_mut()
-                    .r#loop()
-                    .expect("BundleV2.linker.loop must be set before plugins run");
-                match &mut *any_loop.as_ptr() {
-                    bun_event_loop::AnyEventLoop::Js { .. } => {
-                        let ct = ConcurrentTask::from_callback(
-                            std::ptr::from_mut::<Load>(self),
-                            on_notify_defer_js,
-                        );
-                        let poster = (*ctx.as_mut_ptr())
-                            .js_poster
-                            .as_ref()
-                            .expect("JS-owned bundle has a poster");
-                        if let bun_event_loop::Posted::Refused(ct) = poster.post(ct) {
-                            // Owning JS VM torn down mid-bundle: the notify never runs.
-                            bun_event_loop::ConcurrentTask::ConcurrentTask::release_refused(ct);
-                        }
-                    }
-                    bun_event_loop::AnyEventLoop::Mini(mini) => {
-                        mini.enqueue_task_concurrent_with_extra_ctx::<Load, BundleV2<'static>>(
-                            std::ptr::from_mut::<Load>(self),
-                            on_notify_defer_mini_wrap,
-                            core::mem::offset_of!(Load, defer_task),
-                        );
-                    }
-                }
-
-                Ok(bv2_plugin(self.bv2).append_defer_promise())
-            }
-        }
-    }
-
-    fn on_notify_defer_js(load: *mut Load) -> bun_event_loop::JsResult<()> {
-        // SAFETY: task contract — `load` is the live request `on_defer` posted; this runs on the loop
-        // that runs the bundle (bake: the plugins' own), so it is the bundle thread here.
-        let load = unsafe { &mut *load };
-        BundleV2::on_notify_defer(load, bv2_mut(load.bv2));
-        Ok(())
-    }
-
-    fn on_notify_defer_mini_wrap(load: *mut Load, ctx: *mut BundleV2<'static>) {
-        // SAFETY: callback contract — `load` was passed as the `Context` arg to
-        // `enqueue_task_concurrent_with_extra_ctx`; `ctx` is the bundle-thread
-        // `BundleV2` backref the mini loop's tick supplies as `extra`.
-        BundleV2::on_notify_defer(unsafe { &mut *load }, unsafe { &mut *ctx });
-    }
-
-    /// # Safety
-    /// `load` must be the live `*mut Load` previously handed to C++ via
-    /// `Load::dispatch`, and `global` must be the plugin's owning
-    /// `JSGlobalObject`; both valid and exclusively accessed on the JS thread.
-    #[unsafe(no_mangle)]
-    unsafe extern "C" fn JSBundlerPlugin__onDefer(
-        load: *mut Load,
-        global: *mut JSGlobalObject,
-    ) -> JSValue {
-        // SAFETY: called from C++ with valid pointers
-        unsafe { jsc::to_js_host_call(&*global, || (&mut *load).on_defer(&*global)) }
-    }
-
-    #[unsafe(no_mangle)]
-    extern "C" fn JSBundlerPlugin__onLoadAsync(
-        this: &mut Load,
-        _unused: *mut c_void,
+    /// The `onLoad` chain's answer.
+    // HOST_EXPORT(JSBundlerPlugin__onLoadAsync, c)
+    pub fn on_load_async(
+        load: &mut crate::api::JSBundler::Load,
+        global: &JSGlobalObject,
         source_code_value: JSValue,
         loader_as_int: JSValue,
     ) {
         jsc::mark_binding();
-        // As `onResolveAsync`: the request's one answer.
-        if source_code_value.is_empty_or_undefined_or_null()
+        let value = if source_code_value.is_empty_or_undefined_or_null()
             || loader_as_int.is_empty_or_undefined_or_null()
         {
-            this.value = LoadValue::NoMatch;
+            LoadValue::NoMatch
         } else {
             let loader = api::Loader::from_raw(loader_as_int.as_int32() as u8);
-            let global = bv2_plugin(this.bv2).global_object();
             let source_code = match crate::node::StringOrBuffer::from_js_to_owned_slice(
                 global,
                 source_code_value,
@@ -1614,13 +1475,75 @@ pub mod js_bundler {
                     panic!("Unexpected: source_code is not a string");
                 }
             };
-            this.value = LoadValue::Success(LoadSuccess {
+            LoadValue::Success(LoadSuccess {
                 loader: bun_ast::Loader::from_api(loader),
                 source_code: source_code.into(),
-            });
-        }
+            })
+        };
+        load.answer(value);
+    }
 
-        bv2_mut(this.bv2).on_load_async(this);
+    /// The plugin threw (or called `addError`): that is its answer.
+    // HOST_EXPORT(JSBundlerPlugin__addErrorResolve, c)
+    pub fn add_error_resolve(
+        resolve: &mut crate::api::JSBundler::Resolve,
+        global: &JSGlobalObject,
+        exception: JSValue,
+    ) {
+        let msg = plugin_msg_from_js(global, &resolve.import_record.source_file, exception);
+        resolve.answer(ResolveValue::Err(msg));
+    }
+
+    /// As [`add_error_resolve`].
+    // HOST_EXPORT(JSBundlerPlugin__addErrorLoad, c)
+    pub fn add_error_load(
+        load: &mut crate::api::JSBundler::Load,
+        global: &JSGlobalObject,
+        exception: JSValue,
+    ) {
+        let msg = plugin_msg_from_js(global, &load.path, exception);
+        load.answer(LoadValue::Err(msg));
+    }
+
+    /// The plugins can no longer answer this request — their VM is shutting down
+    /// (`BundlerPlugin::tombstone`), or the hop arrived after that / could not call them: answer it as
+    /// cancelled, from this (the JS) thread like every other answer.
+    // HOST_EXPORT(JSBundlerPlugin__answerCancelledResolve, c)
+    pub fn answer_cancelled_resolve(resolve: &mut crate::api::JSBundler::Resolve) {
+        resolve.answer_cancelled();
+    }
+
+    /// As [`answer_cancelled_resolve`].
+    // HOST_EXPORT(JSBundlerPlugin__answerCancelledLoad, c)
+    pub fn answer_cancelled_load(load: &mut crate::api::JSBundler::Load) {
+        load.answer_cancelled();
+    }
+
+    bun_output::declare_scope!(BUNDLER_DEFERRED, hidden);
+
+    /// `.defer()` from an `onLoad` plugin, for a load the plugins still hold: park it on the bundle
+    /// thread until the current batch drains, and hand back the promise that resolves then.
+    // HOST_EXPORT(JSBundlerPlugin__onDefer, c)
+    pub fn on_defer(
+        load: &mut crate::api::JSBundler::Load,
+        global: &JSGlobalObject,
+    ) -> JsResult<JSValue> {
+        if load.called_defer {
+            return Err(global.throw(format_args!(
+                "Can't call .defer() more than once within an onLoad plugin"
+            )));
+        }
+        load.called_defer = true;
+
+        bun_output::scoped_log!(
+            BUNDLER_DEFERRED,
+            "JSBundlerPlugin__onDefer(0x{:x}, {})",
+            std::ptr::from_ref::<Load>(load) as usize,
+            bstr::BStr::new(&load.path)
+        );
+
+        load.notify_deferred();
+        Ok(load.plugin().append_defer_promise())
     }
 
     /// Opaque FFI handle for the C++ `JSBundlerPlugin`. The opaque type and
@@ -1629,10 +1552,8 @@ pub mod js_bundler {
     pub use bun_bundler::bundle_v2::api::JSBundler::Plugin;
 
     // `Plugin` is an `opaque_ffi!` handle (`repr(C)` + `UnsafeCell` marker), so
-    // `&mut Plugin`/`&Plugin` are ABI-identical to non-null pointers and the
-    // validity proof lives in the type. `runSetupFunction` and `globalObject`
-    // take `&Plugin` so `add_plugin` can hold a shared reborrow alongside the
-    // returned `&JSGlobalObject` without an `unsafe` escape hatch.
+    // `&Plugin` is ABI-identical to a non-null pointer and the validity proof
+    // lives in the type.
     unsafe extern "C" {
         safe fn JSBundlerPlugin__create(
             global: &JSGlobalObject,
@@ -1640,7 +1561,7 @@ pub mod js_bundler {
         ) -> *mut Plugin;
         safe fn JSBundlerPlugin__tombstone(plugin: &Plugin);
         safe fn JSBundlerPlugin__runOnEndCallbacks(
-            plugin: &mut Plugin,
+            plugin: &Plugin,
             build_promise: JSValue,
             build_result: JSValue,
             rejection: JSValue,
@@ -1649,8 +1570,7 @@ pub mod js_bundler {
         // strong ref), so the elided lifetime — output borrows `plugin` — is
         // sound and discharges the deref obligation at the type level.
         safe fn JSBundlerPlugin__globalObject(plugin: &Plugin) -> &JSGlobalObject;
-        safe fn JSBundlerPlugin__appendDeferPromise(plugin: &mut Plugin) -> JSValue;
-        safe fn JSBundlerPlugin__setConfig(plugin: &mut Plugin, config: *mut c_void);
+        safe fn JSBundlerPlugin__appendDeferPromise(plugin: &Plugin) -> JSValue;
         safe fn JSBundlerPlugin__runSetupFunction(
             plugin: &Plugin,
             object: JSValue,
@@ -1672,7 +1592,7 @@ pub mod js_bundler {
     pub trait PluginJscExt {
         fn create(global: &JSGlobalObject, target: jsc::BunPluginTarget) -> *mut Plugin;
         fn run_on_end_callbacks(
-            &mut self,
+            &self,
             global_this: &JSGlobalObject,
             build_promise: &jsc::JSPromise,
             build_result: JSValue,
@@ -1686,16 +1606,15 @@ pub mod js_bundler {
         /// (`.defer()`). JS thread.
         fn tombstone(&self);
         fn global_object(&self) -> &JSGlobalObject;
-        fn append_defer_promise(&mut self) -> JSValue;
+        fn append_defer_promise(&self) -> JSValue;
         fn add_plugin(
-            &mut self,
+            &self,
             object: JSValue,
             config: JSValue,
             onstart_promises_array: JSValue,
             is_last: bool,
             is_bake: bool,
         ) -> JsResult<JSValue>;
-        fn set_config(&mut self, config: *mut c_void);
         /// Thin FFI forward; the host-call wrapper / exception check is the
         /// caller's responsibility (`jsc::host_fn::from_js_host_call`).
         fn load_and_resolve_plugins_for_serve(
@@ -1714,7 +1633,7 @@ pub mod js_bundler {
         }
 
         fn run_on_end_callbacks(
-            &mut self,
+            &self,
             global_this: &JSGlobalObject,
             build_promise: &jsc::JSPromise,
             build_result: JSValue,
@@ -1765,12 +1684,12 @@ pub mod js_bundler {
             JSBundlerPlugin__globalObject(self)
         }
 
-        fn append_defer_promise(&mut self) -> JSValue {
+        fn append_defer_promise(&self) -> JSValue {
             JSBundlerPlugin__appendDeferPromise(self)
         }
 
         fn add_plugin(
-            &mut self,
+            &self,
             object: JSValue,
             config: JSValue,
             onstart_promises_array: JSValue,
@@ -1779,13 +1698,9 @@ pub mod js_bundler {
         ) -> JsResult<JSValue> {
             jsc::mark_binding();
             let _tracer = bun_core::perf::trace("JSBundler.addPlugin");
-            // `global_object` and `runSetupFunction` both take `&Plugin`, so a
-            // single shared reborrow of `*self` serves both the host-call guard
-            // and the closure body — no raw-pointer escape hatch needed.
-            let this: &Plugin = &*self;
-            jsc::from_js_host_call(this.global_object(), || {
+            jsc::from_js_host_call(self.global_object(), || {
                 JSBundlerPlugin__runSetupFunction(
-                    this,
+                    self,
                     object,
                     config,
                     onstart_promises_array,
@@ -1793,11 +1708,6 @@ pub mod js_bundler {
                     JSValue::from(is_bake),
                 )
             })
-        }
-
-        fn set_config(&mut self, config: *mut c_void) {
-            jsc::mark_binding();
-            JSBundlerPlugin__setConfig(self, config);
         }
 
         fn load_and_resolve_plugins_for_serve(
@@ -1819,8 +1729,11 @@ pub mod js_bundler {
     ///
     /// Runs on the JS thread, so allocations go through the global heap; the
     /// bundler arena is owned by another thread.
-    fn plugin_msg_from_js(plugin: &mut Plugin, file: &[u8], exception: JSValue) -> bun_ast::Msg {
-        let global = plugin.global_object();
+    fn plugin_msg_from_js(
+        global: &JSGlobalObject,
+        file: &[u8],
+        exception: JSValue,
+    ) -> bun_ast::Msg {
         match bun_ast_jsc::msg_from_js(global, file.to_vec(), exception) {
             Ok(msg) => msg,
             Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
@@ -1847,58 +1760,17 @@ pub mod js_bundler {
             }
         }
     }
-
-    /// # Safety
-    /// The plugin's answer to a request it still held is an error. `plugin` is the live `JSBundlerPlugin`
-    /// handle; `ctx` the live `*mut Resolve` (`kind == 0`) or `*mut Load` (`kind == 1`) handed over by
-    /// `dispatch`. JS thread.
-    #[unsafe(no_mangle)]
-    unsafe extern "C" fn JSBundlerPlugin__addError(
-        ctx: *mut c_void,
-        plugin: *mut Plugin,
-        exception: JSValue,
-        kind: u8,
-    ) {
-        // SAFETY: per fn contract.
-        let plugin = unsafe { &mut *plugin };
-        match kind {
-            0 => {
-                // SAFETY: per fn contract; the request's one answer.
-                let resolve = unsafe { bun_ptr::callback_ctx::<Resolve>(ctx) };
-                let msg = plugin_msg_from_js(plugin, &resolve.import_record.source_file, exception);
-                resolve.value = ResolveValue::Err(msg);
-                bv2_mut(resolve.bv2).on_resolve_async(resolve);
-            }
-            1 => {
-                // SAFETY: per fn contract; the request's one answer.
-                let load = unsafe { bun_ptr::callback_ctx::<Load>(ctx) };
-                let msg = plugin_msg_from_js(plugin, &load.path, exception);
-                load.value = LoadValue::Err(msg);
-                bv2_mut(load.bv2).on_load_async(load);
-            }
-            _ => unreachable!(),
-        }
-    }
-
-    /// The plugins can no longer answer this request — their VM is shutting down (BundlerPlugin::tombstone),
-    /// or the hop arrived after that / could not call them: answer it as cancelled, from this (the JS)
-    /// thread like every other answer, and hand it back to the bundle thread. `kind`: 0 = Resolve, 1 = Load.
-    #[unsafe(no_mangle)]
-    unsafe extern "C" fn JSBundlerPlugin__answerCancelled(kind: u8, ctx: *mut c_void) {
-        match kind {
-            // SAFETY: the live `*mut Resolve` handed over by `Resolve::dispatch`; its one answer.
-            0 => unsafe { bun_ptr::callback_ctx::<Resolve>(ctx) }.answer_cancelled(),
-            // SAFETY: as above, `*mut Load` from `Load::dispatch`.
-            1 => unsafe { bun_ptr::callback_ctx::<Load>(ctx) }.answer_cancelled(),
-            _ => unreachable!("RequestKind"),
-        }
-    }
 }
 
 pub use js_bundler as JSBundler;
 /// `jsc.API.JSBundler.Plugin` — re-exported for `crate::bake` (`SplitBundlerOptions.plugin`).
 pub use js_bundler::Plugin;
 pub(crate) use js_bundler::PluginJscExt;
+/// The plugin bridge's host exports, at this file's module path for `generated_host_exports`.
+pub use js_bundler::{
+    add_error_load, add_error_resolve, answer_cancelled_load, answer_cancelled_resolve, on_defer,
+    on_load_async, on_resolve_async,
+};
 
 /// Full `.classes.ts` payload — wraps a `webcore::Blob` plus
 /// `loader/path/hash/output_kind`. `.sourcemap` lives on the JS wrapper
@@ -1919,12 +1791,11 @@ pub use bun_bundler::options::OutputKind;
 
 /// `JSValue::as(Blob)` BuildArtifact fallback — declared
 /// `extern "Rust"` in `bun_jsc::webcore_types`; link-time resolved.
-#[unsafe(no_mangle)]
-fn __bun_blob_from_build_artifact(value: JSValue) -> Option<*mut Blob> {
+// HOST_EXPORT(__bun_blob_from_build_artifact, rust)
+pub fn blob_from_build_artifact(value: JSValue) -> Option<*mut crate::webcore::Blob> {
     <BuildArtifact as bun_jsc::JsClass>::from_js(value).map(|b| {
-        // SAFETY: `from_js` returns the non-null `*mut BuildArtifact` kept alive by
-        // the JS wrapper; `addr_of_mut!` only computes the field address (no deref).
-        unsafe { core::ptr::addr_of_mut!((*b).blob) }
+        b.wrapping_byte_add(core::mem::offset_of!(BuildArtifact, blob))
+            .cast::<Blob>()
     })
 }
 
@@ -2135,14 +2006,10 @@ impl BuildArtifact {
 
                 let sourcemap_value =
                     crate::generated_classes::js_BuildArtifact::sourcemap_get_cached(this_value);
-                if let Some((sm_value, sm_ptr)) =
-                    sourcemap_value.and_then(|v| v.as_::<BuildArtifact>().map(|p| (v, p)))
+                if let Some((sm_value, sm)) =
+                    sourcemap_value.and_then(|v| v.as_class_ref::<BuildArtifact>().map(|p| (v, p)))
                 {
-                    // SAFETY: `as_` returned a non-null wrapper-owned pointer;
-                    // `write_format` is `&self` so a shared borrow of `sm_ptr`
-                    // is sound even if it aliases `self`.
-                    unsafe { &*sm_ptr }
-                        .write_format::<F, W, ENABLE_ANSI_COLORS>(sm_value, formatter, writer)?;
+                    sm.write_format::<F, W, ENABLE_ANSI_COLORS>(sm_value, formatter, writer)?;
                 } else {
                     write!(
                         writer,

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -11,7 +11,9 @@ use bun_ast::Expr;
 use bun_ast::Loader;
 use bun_ast::{ImportRecord, ImportRecordFlags};
 use bun_bundler::options::{self, PackagesOption, SourceMapOption};
-use bun_bundler::transpiler::{MacroJSCtx, ParseOptions, ParseResult};
+use bun_bundler::transpiler::{
+    JobTranspiler, MacroJSCtx, OwnedTranspiler, ParseOptions, ParseResult, TranspilerCall,
+};
 use bun_bundler::{self as Transpiler};
 use bun_js_parser::lexer as JSLexer;
 use bun_js_parser::parser::Runtime;
@@ -38,17 +40,17 @@ use bun_options_types::schema::api;
 #[bun_jsc::JsClass(name = "Transpiler")]
 #[derive(bun_ptr::RefCounted)]
 pub struct JSTranspiler {
-    pub(crate) transpiler: JsCell<Transpiler::Transpiler<'static>>,
-    /// Read-only after construction EXCEPT for `config.log`, which is the
-    /// resting-state log that `transpiler.log: *mut Log` points at between
-    /// host-fn calls. `JsCell` so a `*mut Log` can be projected from `&self`.
-    pub(crate) config: JsCell<Config>,
+    /// Owns the arena the config strings and defines live in; aimed at
+    /// `self.log` between host-fn calls.
+    pub(crate) transpiler: JsCell<OwnedTranspiler>,
+    /// Read-only after construction (its `log` has moved to `self.log`).
+    pub(crate) config: Config,
+    /// The resting-state log `transpiler` points at between host-fn calls
+    /// (each call aims it at its own). Boxed: the transpiler is created before
+    /// `Self` has an address.
+    pub(crate) log: Box<JsCell<bun_ast::Log>>,
     pub(crate) scan_pass_result: JsCell<ScanPassResult>,
     pub(crate) buffer_writer: JsCell<Option<JSPrinter::BufferWriter>>,
-    // Arena bulk-frees the config strings. Boxed so its
-    // address is stable across the move into `Box<JSTranspiler>` —
-    // `transpiler.arena` holds a `&'static Arena` pointing into it.
-    pub arena: Box<Arena>,
     pub(crate) ref_count: bun_ptr::RefCount<JSTranspiler>,
 }
 
@@ -180,9 +182,7 @@ impl Config {
                     );
                 };
 
-                // SAFETY: `define_obj` is a non-null *mut JSObject (just returned by get_object()).
-                let define_obj_ref = unsafe { &*define_obj };
-                let define_iter = JSPropertyIterator::init(global, define_obj_ref, PROP_ITER_OPTS)?;
+                let define_iter = JSPropertyIterator::init(global, define_obj, PROP_ITER_OPTS)?;
                 // `defer define_iter.deinit()` → Drop
 
                 // `define_iter.i` is the property position, not a dense index of yielded
@@ -529,9 +529,7 @@ impl Config {
                     );
                 };
 
-                // SAFETY: `replace_obj` is non-null (just returned by get_object()).
-                let replace_obj_ref = unsafe { &*replace_obj };
-                let iter = JSPropertyIterator::init(global, replace_obj_ref, PROP_ITER_OPTS)?;
+                let iter = JSPropertyIterator::init(global, replace_obj, PROP_ITER_OPTS)?;
 
                 if iter.len > 0 {
                     bun_core::handle_oom(replacements.ensure_unused_capacity(iter.len));
@@ -630,28 +628,33 @@ impl Config {
 // threadlocal var transform_buffer_loaded: bool = false;
 
 // This is going to be hard to not leak
-/// `transpiler.transform()` off the JS thread. The parse/print state points
-/// into the owning `JSTranspiler`'s config (its `Transpiler` is bit-copied),
-/// which the job's Js side keeps alive and the pool borrow keeps valid.
+/// `transpiler.transform()` off the JS thread: a [`JobTranspiler`] copy of the
+/// owning `JSTranspiler`'s transpiler (which keeps what it aliases alive), and
+/// owned snapshots of the rest of its config.
 pub(crate) struct TransformTask {
     pub input_code: ThreadIsolated<StringOrBuffer<'static>>,
     pub output_code: BunString,
-    pub transpiler: Transpiler::transpiler::JobTranspiler,
+    pub transpiler: JobTranspiler,
     pub log: bun_ast::Log,
     pub err: Option<Error>,
     pub macro_map: MacroMap,
-    pub tsconfig: Option<jsc::JsPtr<TSConfigJSON>>,
+    pub tsconfig: TransformTsconfig,
     pub loader: Loader,
     pub replace_exports: bun_ast::runtime::ReplaceableExportMap,
 }
-// SAFETY: see the type doc — VM-owned config is read only under the pool
-// borrow; everything else is owned.
-unsafe impl Send for TransformTask {}
+
+/// What a transform reads of the `JSTranspiler`'s tsconfig.
+pub(crate) struct TransformTsconfig {
+    jsx: options::jsx::Pragma,
+    experimental_decorators: bool,
+    emit_decorator_metadata: bool,
+    use_define_for_class_fields: bool,
+}
 
 #[derive(bun_jsc::JsAffine)]
 pub(crate) struct TransformJs {
     promise: jsc::JSPromiseStrong,
-    /// The `JSTranspiler` wrapper whose config the task reads.
+    /// The `JSTranspiler` wrapper, so a transform in flight keeps it alive.
     _transpiler: jsc::Strong,
 }
 
@@ -667,6 +670,22 @@ impl jsc::JobContext for TransformTask {
     }
 }
 
+impl TransformTsconfig {
+    fn new(tsconfig: Option<&TSConfigJSON>, jsx: &options::jsx::Pragma) -> Self {
+        Self {
+            jsx: match tsconfig {
+                Some(ts) => ts.merge_jsx(jsx.clone()),
+                None => jsx.clone(),
+            },
+            experimental_decorators: tsconfig.is_some_and(|ts| ts.experimental_decorators),
+            emit_decorator_metadata: tsconfig.is_some_and(|ts| ts.emit_decorator_metadata),
+            use_define_for_class_fields: tsconfig
+                .and_then(|ts| ts.use_define_for_class_fields)
+                .unwrap_or(true),
+        }
+    }
+}
+
 impl TransformTask {
     // `pub const new = bun.TrivialNew(@This())` → Box::new
 
@@ -678,26 +697,20 @@ impl TransformTask {
         global: &JSGlobalObject,
         loader: Loader,
     ) -> JSValue {
-        let config = transpiler.config.get();
+        let config = &transpiler.config;
         let mut log = bun_ast::Log::init();
-        log.level = config.log.level;
+        log.level = transpiler.log.get().level;
 
-        // SAFETY: the wrapper (kept alive by `TransformJs::_transpiler`) owns
-        // what the copy aliases and does not reconfigure it while a transform
-        // runs; `run` re-aims the copy's log and arena.
-        let transpiler_copy =
-            unsafe { Transpiler::transpiler::JobTranspiler::new(transpiler.transpiler.get()) };
+        let owned = transpiler.transpiler.get();
+        let tsconfig = TransformTsconfig::new(config.tsconfig.as_deref(), &owned.get().options.jsx);
+        let transpiler_copy = owned.new_job();
 
         let task = TransformTask {
             input_code,
             output_code: BunString::EMPTY,
             transpiler: transpiler_copy,
             macro_map: clone_macro_map(&config.macro_map),
-            tsconfig: config
-                .tsconfig
-                .as_deref()
-                // SAFETY: points into the wrapper's config, kept alive by `TransformJs`.
-                .map(|t| unsafe { jsc::JsPtr::new(core::ptr::NonNull::from(t)) }),
+            tsconfig,
             log,
             err: None,
             loader,
@@ -719,26 +732,17 @@ impl TransformTask {
         value
     }
 
-    fn run(&mut self, vm: &jsc::Ticket) {
+    fn run(&mut self, _: &jsc::Ticket) {
         let name = self.loader.stdin_name();
-        // SAFETY: the wrapper's config, alive under the job's ticket (see `schedule`).
-        let tsconfig: Option<&TSConfigJSON> =
-            self.tsconfig.map(|p| &*unsafe { p.under_ticket(vm) });
-
         let arena = Arena::new();
-        self.run_in(&arena, name, tsconfig);
+        self.run_in(&arena, name);
         // The macro context a parse lazily creates tears down through this
         // thread's per-thread state, so release it here rather than wherever
         // the job is dropped.
         self.transpiler.release_macro_context();
     }
 
-    fn run_in<'a>(
-        &'a mut self,
-        arena: &'a Arena,
-        name: &'static str,
-        tsconfig: Option<&TSConfigJSON>,
-    ) {
+    fn run_in<'a>(&'a mut self, arena: &'a Arena, name: &'static str) {
         let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(arena);
         let _ast_scope = ast_memory_allocator.enter();
 
@@ -749,26 +753,19 @@ impl TransformTask {
         let mut transpiler = self.transpiler.for_call(arena, &mut self.log);
         // self.log.msgs.allocator = bun.default_allocator → no-op
 
-        let jsx = match tsconfig {
-            Some(ts) => ts.merge_jsx(transpiler.options.jsx.clone()),
-            None => transpiler.options.jsx.clone(),
-        };
-
         let parse_options = ParseOptions {
             arena,
             macro_remappings: clone_macro_map(&self.macro_map),
             dirname_fd: bun_sys::Fd::INVALID,
             file_descriptor: None,
             loader: self.loader,
-            jsx,
+            jsx: self.tsconfig.jsx.clone(),
             path: source.path,
             virtual_source: Some(source),
             replace_exports: self.replace_exports.entries.clone().expect("OOM"),
-            experimental_decorators: tsconfig.is_some_and(|ts| ts.experimental_decorators),
-            emit_decorator_metadata: tsconfig.is_some_and(|ts| ts.emit_decorator_metadata),
-            use_define_for_class_fields: tsconfig
-                .and_then(|ts| ts.use_define_for_class_fields)
-                .unwrap_or(true),
+            experimental_decorators: self.tsconfig.experimental_decorators,
+            emit_decorator_metadata: self.tsconfig.emit_decorator_metadata,
+            use_define_for_class_fields: self.tsconfig.use_define_for_class_fields,
             macro_js_ctx: MacroJSCtx::ZERO,
             file_fd_ptr: None,
             inject_jest_globals: false,
@@ -924,32 +921,21 @@ impl JSTranspiler {
     ) -> JsResult<*mut JSTranspiler> {
         let [config_arg] = callframe.arguments_as_array::<1>();
 
-        // NOTE: a non-POD field cannot be left uninitialized in a live Box
-        // (zeroed()/assume_init() on Transpiler is UB), so build `config` + `transpiler` on the
-        // stack first, then move both into the Box. Nothing observes the
-        // `Box<JSTranspiler>` address before construction completes. The
-        // address-sensitive pointers are `transpiler.arena` (points into the
-        // separately-boxed `arena`, whose address is move-stable) and
-        // `transpiler.log` (initially points at the stack-local `config.log`;
-        // it is re-pointed via `set_log` once the Box exists — see the NOTE
-        // below), so no up-front allocation / `MaybeUninit` in-place init is
-        // needed.
+        // `config` and the transpiler are built before the `Box<JSTranspiler>`
+        // exists; the address-sensitive parts (the arena the transpiler borrows,
+        // the resting log it points at) are separately heap-allocated so the
+        // move into the box leaves them in place.
         let mut config = Config {
             log: bun_ast::Log::init(),
             ..Default::default()
         };
         let arena = Box::new(Arena::new());
-        // SAFETY: `arena` is heap-allocated and moved (as a Box) into `Box<JSTranspiler>` below;
-        // its address is stable for the lifetime of the JSTranspiler. `Transpiler<'static>` forces
-        // the borrow to 'static, so launder through a raw ptr.
-        let arena_ref: &'static Arena =
-            unsafe { bun_ptr::detach_lifetime_ref::<Arena>(arena.as_ref()) };
 
         // errdefer { ... } — on any `?` below, stack `config`/`arena` drop and run Drop, which
         // covers config.log, config.tsconfig, arena. ref_count.clearWithoutDestructor is a
         // no-op when we never handed out refs. `bun.destroy(this)` → Box not yet created.
 
-        config.from_js(global, config_arg, arena_ref)?;
+        config.from_js(global, config_arg, &arena)?;
 
         if (config.log.warnings + config.log.errors) > 0 {
             return Err(global.throw_value(
@@ -959,90 +945,91 @@ impl JSTranspiler {
             ));
         }
 
-        // SAFETY: VirtualMachine::get() returns the live singleton on the JS thread.
-        let vm = VirtualMachine::get().as_mut();
-        let transpiler = match Transpiler::Transpiler::init(
-            arena_ref,
-            &raw mut config.log,
-            config.transform.clone(),
-            Some(vm.transpiler.env),
-        ) {
+        // The construction log becomes the resting log.
+        let log = Box::new(JsCell::new(core::mem::replace(
+            &mut config.log,
+            bun_ast::Log::init(),
+        )));
+        let log_has_any = |log: &JsCell<bun_ast::Log>| {
+            let log = log.get();
+            (log.warnings + log.errors) > 0
+        };
+
+        let vm = global.bun_vm();
+        let mut transpiler = match OwnedTranspiler::new(arena, log.as_ptr(), |arena, log_ptr| {
+            Transpiler::Transpiler::init(
+                arena,
+                log_ptr,
+                config.transform.clone(),
+                Some(vm.transpiler.env),
+            )
+        }) {
             Ok(t) => t,
             Err(err) => {
-                let log = &mut config.log;
-                if (log.warnings + log.errors) > 0 {
-                    return Err(global.throw_value(
-                        log.to_js(global, format_args!("Failed to create transpiler"))?,
-                    ));
+                if log_has_any(&log) {
+                    return Err(global.throw_value(log.with_mut(|log| {
+                        log.to_js(global, format_args!("Failed to create transpiler"))
+                    })?));
                 }
                 return Err(global.throw_error(err, "Error creating transpiler"));
             }
         };
 
-        let this: Box<JSTranspiler> = Box::new(JSTranspiler {
-            config: JsCell::new(config),
-            arena,
-            transpiler: JsCell::new(transpiler),
-            scan_pass_result: JsCell::new(ScanPassResult::init()),
-            buffer_writer: JsCell::new(None),
-            ref_count: bun_ptr::RefCount::init(),
+        // The transpiler is at its final address (inside `OwnedTranspiler`), so
+        // the self-referential linker wiring can happen now.
+        let configured = transpiler.with_mut(|transpiler| -> Result<(), bun_bundler::Error> {
+            transpiler.options.no_macros = config.no_macros;
+            transpiler.configure_linker_with_auto_jsx(false);
+            transpiler.options.env.behavior = options::EnvBehavior::disable;
+            transpiler.configure_defines()?;
+
+            if config.macro_map.count() > 0 {
+                transpiler.options.macro_remap = clone_macro_map(&config.macro_map);
+            }
+
+            // REPL mode disables DCE to preserve expressions like `42`
+            transpiler.options.dead_code_elimination =
+                config.dead_code_elimination && !config.repl_mode;
+            transpiler.options.minify_whitespace = config.minify_whitespace;
+
+            // Keep defaults for these
+            if config.minify_syntax {
+                transpiler.options.minify_syntax = true;
+            }
+
+            if config.minify_identifiers {
+                transpiler.options.minify_identifiers = true;
+            }
+
+            transpiler.options.transform_only = !transpiler.options.allow_runtime;
+
+            transpiler.options.tree_shaking = config.tree_shaking;
+            transpiler.options.trim_unused_imports = config.trim_unused_imports;
+            transpiler.options.allow_runtime = config.runtime.allow_runtime;
+            transpiler.options.auto_import_jsx = config.runtime.auto_import_jsx;
+            transpiler.options.inlining = config.runtime.inlining;
+            transpiler.options.hot_module_reloading = config.runtime.hot_module_reloading;
+            transpiler.options.react_fast_refresh = false;
+            transpiler.options.repl_mode = config.repl_mode;
+            Ok(())
         });
-        // errdefer past this point → `this: Box<_>` drops and runs Drop for JSTranspiler.
-
-        // NOTE: `config` was built on the stack and moved into the Box, so
-        // `transpiler.log` (a `*mut Log`) still points at the moved-from
-        // stack slot. Re-point it at the heap-stable field now that the Box exists.
-        // SAFETY: `this: Box<_>` is exclusively owned (init-time, before the JS
-        // wrapper exists) so projecting `&mut`/`*mut` from the JsCells is trivially
-        // alias-free.
-        let config = unsafe { this.config.get_mut() };
-        // SAFETY: same exclusive-ownership invariant as the line above — `this: Box<_>`
-        // is uniquely owned at init time, so `&mut` projection is alias-free.
-        let transpiler = unsafe { this.transpiler.get_mut() };
-        transpiler.set_log(&raw mut config.log);
-
-        transpiler.options.no_macros = config.no_macros;
-        transpiler.configure_linker_with_auto_jsx(false);
-        transpiler.options.env.behavior = options::EnvBehavior::disable;
-        if let Err(err) = transpiler.configure_defines() {
-            let log = &mut config.log;
-            if (log.warnings + log.errors) > 0 {
-                return Err(
-                    global.throw_value(log.to_js(global, format_args!("Failed to load define"))?)
-                );
+        if let Err(err) = configured {
+            if log_has_any(&log) {
+                return Err(global.throw_value(
+                    log.with_mut(|log| log.to_js(global, format_args!("Failed to load define")))?,
+                ));
             }
             return Err(global.throw_error(err, "Failed to load define"));
         }
 
-        if config.macro_map.count() > 0 {
-            transpiler.options.macro_remap = clone_macro_map(&config.macro_map);
-        }
-
-        // REPL mode disables DCE to preserve expressions like `42`
-        transpiler.options.dead_code_elimination =
-            config.dead_code_elimination && !config.repl_mode;
-        transpiler.options.minify_whitespace = config.minify_whitespace;
-
-        // Keep defaults for these
-        if config.minify_syntax {
-            transpiler.options.minify_syntax = true;
-        }
-
-        if config.minify_identifiers {
-            transpiler.options.minify_identifiers = true;
-        }
-
-        transpiler.options.transform_only = !transpiler.options.allow_runtime;
-
-        transpiler.options.tree_shaking = config.tree_shaking;
-        transpiler.options.trim_unused_imports = config.trim_unused_imports;
-        transpiler.options.allow_runtime = config.runtime.allow_runtime;
-        transpiler.options.auto_import_jsx = config.runtime.auto_import_jsx;
-        transpiler.options.inlining = config.runtime.inlining;
-        transpiler.options.hot_module_reloading = config.runtime.hot_module_reloading;
-        transpiler.options.react_fast_refresh = false;
-        transpiler.options.repl_mode = config.repl_mode;
-
+        let this: Box<JSTranspiler> = Box::new(JSTranspiler {
+            transpiler: JsCell::new(transpiler),
+            config,
+            log,
+            scan_pass_result: JsCell::new(ScanPassResult::init()),
+            buffer_writer: JsCell::new(None),
+            ref_count: bun_ptr::RefCount::init(),
+        });
         Ok(bun_core::heap::into_raw(this))
     }
 }
@@ -1054,133 +1041,46 @@ impl Drop for JSTranspiler {
         // for reuse across calls. The boxed `bun_js_parser_jsc::MacroContext`
         // behind `.data` has no `Drop` glue — release it explicitly.
         // `with_mut` borrow is closure-scoped; no JS re-entry inside.
-        self.transpiler.with_mut(|t| {
-            if let Some(ctx) = t.macro_context.take() {
-                ctx.deinit();
-            }
-        });
-        let log = self.transpiler.get().log;
-        if !log.is_null() {
-            // SAFETY: `transpiler.log` was set via `set_log` to `&mut self.config.log`
-            // (heap-stable for `Self`'s lifetime) and just checked non-null.
-            unsafe { (*log).clear_and_free() };
-        }
+        self.transpiler.with_mut(|t| t.release_macro_context());
+        self.log.with_mut(|log| log.clear_and_free());
         // scan_pass_result.{named_imports,import_records,used_symbols}.deinit() → field Drop
         // buffer_writer.?.buffer.deinit() → Option<BufferWriter>: Drop
         // config.tsconfig.deinit() → Option<Box<TSConfigJSON>>: Drop
-        // arena.deinit() → Arena: Drop
+        // transpiler (and the arena it owns) → OwnedTranspiler: Drop
     }
 }
 
-/// `scan` / `transform_sync` / `scan_imports` temporarily point the long-lived
-/// `Transpiler` at a stack-local `Arena`/`Log`; on EVERY exit (including `?`
-/// and early `return Err`) those must be restored before the locals drop, or
-/// the next method call dereferences a dangling allocator/log.
-struct TranspilerStateGuard {
-    transpiler: *mut Transpiler::Transpiler<'static>,
-    prev_arena: &'static Arena,
-    restore_log: *mut bun_ast::Log,
-    /// `Some(prev)` ⇒ also restore `macro_context` to `prev` (transformSync's
-    /// by-value snapshot). `None` ⇒ leave untouched (scan / scanImports only
-    /// restore log+allocator per spec).
-    prev_macro_context: Option<Option<JSAst::Macro::MacroContext>>,
+/// `transformSync` snapshots the transpiler's macro context and restores it on
+/// every exit, freeing the one the call created (the box behind its `data`
+/// pointer is heap-owned and `MacroContext` has no `Drop`, so overwriting it
+/// would strand the box). `scan` / `scanImports` leave theirs in place.
+struct MacroContextRestore<'r, 't, 'a> {
+    transpiler: &'r mut TranspilerCall<'t, 'a>,
+    prev: Option<Option<JSAst::Macro::MacroContext>>,
 }
 
-impl TranspilerStateGuard {
-    /// Mutable access to the guarded `Transpiler`.
-    ///
-    /// SAFETY: `self.transpiler` is always non-null — every construction site
-    /// initializes it from `js_transpiler.transpiler.as_ptr()` (the
-    /// `JsCell<Transpiler>` in the heap-stable `Box<JSTranspiler>`), which
-    /// outlives this stack-local guard. The guard is held as
-    /// `let _restore = ...;` and never touched between construction and `Drop`,
-    /// so no other `&mut Transpiler` projection from that `JsCell` is live when
-    /// this runs.
-    #[inline]
-    fn transpiler_mut(&mut self) -> &mut Transpiler::Transpiler<'static> {
-        // SAFETY: `self.transpiler` is non-null (set from `JsCell::as_ptr()` on the
-        // heap-stable `Box<JSTranspiler>`); the guard holds the only live `&mut`
-        // projection of that `JsCell` between construction and `Drop`.
-        unsafe { &mut *self.transpiler }
-    }
-
-    /// Raw `*mut Log` to restore on drop. Returned as a pointer (not `&mut`)
-    /// because the sole consumer, `Transpiler::set_log`, takes `*mut Log`, and
-    /// the pointee (`js_transpiler.config.log`) is never dereferenced by the
-    /// guard itself.
-    #[inline]
-    fn restore_log_ptr(&self) -> *mut bun_ast::Log {
-        self.restore_log
-    }
-}
-
-impl Drop for TranspilerStateGuard {
+impl Drop for MacroContextRestore<'_, '_, '_> {
     fn drop(&mut self) {
-        // `transpiler` and `restore_log` point into the heap-stable
-        // `Box<JSTranspiler>` (`self.transpiler` / `self.config.log`) which
-        // outlives this stack frame. The guard is declared after the temporary
-        // arena/log and so drops before them (reverse-decl order), ensuring the
-        // Transpiler never observes a dangling `&'static Arena`.
-        let restore_log = self.restore_log_ptr();
-        let prev_arena = self.prev_arena;
-        let prev_macro_context = self.prev_macro_context.take();
-        let transpiler = self.transpiler_mut();
-        transpiler.set_log(restore_log);
-        transpiler.arena = prev_arena;
-        if let Some(prev) = prev_macro_context {
-            // `transformSync` created a fresh MacroContext for this parse and
-            // stored it in `transpiler.macro_context`; the box behind its
-            // `data` pointer is heap-owned and `MacroContext` has no `Drop`,
-            // so overwriting it with `prev` would strand the box. Free it
-            // explicitly before restoring the outer state.
-            if let Some(new_ctx) = transpiler.macro_context.take() {
+        if let Some(prev) = self.prev.take() {
+            let slot = self.transpiler.macro_context();
+            if let Some(new_ctx) = slot.take() {
                 new_ctx.deinit();
             }
-            transpiler.macro_context = prev;
+            *slot = prev;
         }
     }
 }
 
 impl JSTranspiler {
-    // ─── R-2 interior-mutability helpers ─────────────────────────────────────
-
-    /// `*mut Log` to the resting-state `config.log`, projected through the
-    /// `JsCell<Config>` (UnsafeCell-backed, so the write provenance is sound).
-    #[inline]
-    fn config_log_ptr(&self) -> *mut bun_ast::Log {
-        // SAFETY: `as_ptr()` yields the `UnsafeCell` payload; `&raw mut` field
-        // projection forms no intermediate reference.
-        unsafe { &raw mut (*self.config.as_ptr()).log }
-    }
-
-    /// `&mut Transpiler` projection through `&self`.
-    ///
-    /// # Safety
-    ///
-    /// Caller must not hold another `&`/`&mut` to `self.transpiler` for the
-    /// borrow's lifetime. `Transpiler::parse` may re-enter JS via macros; if
-    /// that JS calls back into a `JSTranspiler` host-fn on *this same instance*
-    /// the inner `Transpiler` is re-borrowed — a pre-existing hazard that R-2's
-    /// outer-struct fix does not address. The R-2 invariant this upholds is
-    /// that no `noalias &mut JSTranspiler` is live across that re-entry.
-    #[inline]
-    #[allow(clippy::mut_from_ref)]
-    unsafe fn transpiler_mut(&self) -> &mut Transpiler::Transpiler<'static> {
-        // SAFETY: caller upholds the no-aliasing precondition documented on this
-        // `unsafe fn`; `JsCell::get_mut` projects through `UnsafeCell`.
-        unsafe { self.transpiler.get_mut() }
-    }
-
-    // ─────────────────────────────────────────────────────────────────────────
-
-    fn get_parse_result(
+    fn get_parse_result<'a>(
         &self,
-        arena: &'static Arena,
+        transpiler: &mut TranspilerCall<'_, 'a>,
+        arena: &'a Arena,
         code: &[u8],
         loader: Option<Loader>,
         macro_js_ctx: MacroJSCtx,
-    ) -> Option<ParseResult<'static>> {
-        let config = self.config.get();
+    ) -> Option<ParseResult<'a>> {
+        let config = &self.config;
         let name = config.default_loader.stdin_name();
 
         // In REPL mode, wrap potential object literals in parentheses
@@ -1205,8 +1105,8 @@ impl JSTranspiler {
             arena.alloc(bun_ast::Source::init_path_string(name, processed_code));
 
         let jsx = match config.tsconfig.as_deref() {
-            Some(ts) => ts.merge_jsx(self.transpiler.get().options.jsx.clone()),
-            None => self.transpiler.get().options.jsx.clone(),
+            Some(ts) => ts.merge_jsx(transpiler.options().jsx.clone()),
+            None => transpiler.options().jsx.clone(),
         };
 
         let parse_options = ParseOptions {
@@ -1245,8 +1145,7 @@ impl JSTranspiler {
             allow_bytecode_cache: false,
         };
 
-        // SAFETY: see `transpiler_mut` — `parse` may re-enter JS via macros.
-        unsafe { self.transpiler_mut() }.parse(parse_options, None)
+        transpiler.parse(parse_options, None)
     }
 
     #[bun_jsc::host_fn(method)]
@@ -1275,57 +1174,49 @@ impl JSTranspiler {
 
         let arena = Arena::new();
         let mut log = bun_ast::Log::init();
-        // SAFETY: `arena` outlives every use through `self.transpiler` in this fn body;
-        // `_restore` (declared after `arena`/`log`, so dropped first) restores
-        // `prev_arena` and `&self.config.log` before either local drops.
-        // `with_mut` borrow is closure-scoped; no JS re-entry inside.
-        let arena_ref: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref(&arena) };
-        let prev_arena = self.transpiler.with_mut(|t| {
-            let prev = t.arena;
-            t.set_arena(arena_ref);
-            t.set_log(&raw mut log);
-            prev
-        });
-        let _restore = TranspilerStateGuard {
-            transpiler: self.transpiler.as_ptr(),
-            prev_arena,
-            restore_log: self.config_log_ptr(),
-            prev_macro_context: None,
-        };
-
         let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
         let _ast_scope = ast_memory_allocator.enter();
 
-        let parse_result = self.get_parse_result(arena_ref, code, loader, MacroJSCtx::ZERO);
-        let log_ref = self.transpiler.get().log_mut();
-        let Some(mut parse_result) = parse_result else {
-            if (log_ref.warnings + log_ref.errors) > 0 {
-                return Err(global.throw_value(log_ref.to_js(global, format_args!("Parse error"))?));
-            }
-            return Err(global.throw(format_args!("Failed to parse")));
-        };
+        self.transpiler.with_mut(|t| {
+            t.with_call(&arena, &mut log, |transpiler| {
+                let parse_result =
+                    self.get_parse_result(transpiler, &arena, code, loader, MacroJSCtx::ZERO);
+                let log_ref = transpiler.log_mut();
+                let Some(mut parse_result) = parse_result else {
+                    if (log_ref.warnings + log_ref.errors) > 0 {
+                        return Err(
+                            global.throw_value(log_ref.to_js(global, format_args!("Parse error"))?)
+                        );
+                    }
+                    return Err(global.throw(format_args!("Failed to parse")));
+                };
 
-        if (log_ref.warnings + log_ref.errors) > 0 {
-            return Err(global.throw_value(log_ref.to_js(global, format_args!("Parse error"))?));
-        }
+                if (log_ref.warnings + log_ref.errors) > 0 {
+                    return Err(
+                        global.throw_value(log_ref.to_js(global, format_args!("Parse error"))?)
+                    );
+                }
 
-        let exports_label = EncodedSlice::latin1(b"exports");
-        let imports_label = EncodedSlice::latin1(b"imports");
-        let named_imports_value = named_imports_to_js(
-            global,
-            parse_result.ast.import_records.as_slice(),
-            self.config.get().trim_unused_imports.unwrap_or(false),
-        )?;
+                let exports_label = EncodedSlice::latin1(b"exports");
+                let imports_label = EncodedSlice::latin1(b"imports");
+                let named_imports_value = named_imports_to_js(
+                    global,
+                    parse_result.ast.import_records.as_slice(),
+                    self.config.trim_unused_imports.unwrap_or(false),
+                )?;
 
-        let named_exports_value = named_exports_to_js(global, &mut parse_result.ast.named_exports)?;
+                let named_exports_value =
+                    named_exports_to_js(global, &mut parse_result.ast.named_exports)?;
 
-        JSValue::create_object2(
-            global,
-            &imports_label,
-            &exports_label,
-            named_imports_value,
-            named_exports_value,
-        )
+                JSValue::create_object2(
+                    global,
+                    &imports_label,
+                    &exports_label,
+                    named_imports_value,
+                    named_exports_value,
+                )
+            })
+        })
     }
 
     #[bun_jsc::host_fn(method)]
@@ -1369,7 +1260,7 @@ impl JSTranspiler {
             break 'brk None;
         };
 
-        let default_loader = self.config.get().default_loader;
+        let default_loader = self.config.default_loader;
         Ok(TransformTask::schedule(
             self,
             callframe.this(),
@@ -1453,71 +1344,68 @@ impl JSTranspiler {
         let _ast_scope = ast_memory_allocator.enter();
 
         // NOTE: spec snapshots the WHOLE `this.transpiler` by value
-        // (`prev_bundler = this.transpiler`) and restores it on exit. `Transpiler` is not
-        // bitwise-copyable in Rust, so explicitly snapshot the fields the body mutates
-        // (`allocator`, `log`, `macro_context`) and restore them via RAII guard.
+        // (`prev_bundler = this.transpiler`) and restores it on exit. Here the
+        // per-call arena and log are `with_call`'s, and the macro context is
+        // snapshotted/restored by `MacroContextRestore`.
         let mut log = bun_ast::Log::init();
-        log.level = self.config.get().log.level;
-        // SAFETY: `arena` outlives every use through `self.transpiler` in this fn body;
-        // `_restore` (declared after `arena`/`log`, so dropped first) restores
-        // `prev_arena`, `&self.config.log`, and `prev_macro_context` before either drops.
-        // `with_mut` borrow is closure-scoped; no JS re-entry inside.
-        let arena_ref: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref(&arena) };
-        let (prev_arena, prev_macro_context) = self.transpiler.with_mut(|t| {
-            let prev_arena = t.arena;
-            // `take()` both reads the prior value AND nulls it.
-            let prev_mc = t.macro_context.take();
-            t.set_arena(arena_ref);
-            t.set_log(&raw mut log);
-            (prev_arena, prev_mc)
-        });
-        let _restore = TranspilerStateGuard {
-            transpiler: self.transpiler.as_ptr(),
-            prev_arena,
-            restore_log: self.config_log_ptr(),
-            prev_macro_context: Some(prev_macro_context),
-        };
+        log.level = self.log.get().level;
 
         // `MacroJSCtx` carries the encoded `JSValue` bits (`#[repr(transparent)] i64`).
         let macro_js_ctx: MacroJSCtx = MacroJSCtx(js_ctx_value.0 as i64);
-        let parse_result = self.get_parse_result(arena_ref, code, loader, macro_js_ctx);
-        let log_ref = self.transpiler.get().log_mut();
-        let Some(parse_result) = parse_result else {
-            if (log_ref.warnings + log_ref.errors) > 0 {
-                return Err(global.throw_value(log_ref.to_js(global, format_args!("Parse error"))?));
-            }
-            return Err(global.throw(format_args!("Failed to parse code")));
-        };
+        self.transpiler.with_mut(|t| {
+            t.with_call(&arena, &mut log, |transpiler| {
+                // `take()` both reads the prior value AND nulls it.
+                let prev_macro_context = transpiler.macro_context().take();
+                let restore = MacroContextRestore {
+                    transpiler,
+                    prev: Some(prev_macro_context),
+                };
+                let transpiler = &mut *restore.transpiler;
 
-        if (log_ref.warnings + log_ref.errors) > 0 {
-            return Err(global.throw_value(log_ref.to_js(global, format_args!("Parse error"))?));
-        }
+                let parse_result =
+                    self.get_parse_result(transpiler, &arena, code, loader, macro_js_ctx);
+                let log_ref = transpiler.log_mut();
+                let Some(parse_result) = parse_result else {
+                    if (log_ref.warnings + log_ref.errors) > 0 {
+                        return Err(
+                            global.throw_value(log_ref.to_js(global, format_args!("Parse error"))?)
+                        );
+                    }
+                    return Err(global.throw(format_args!("Failed to parse code")));
+                };
 
-        let mut buffer_writer = self.buffer_writer.replace(None).unwrap_or_else(|| {
-            let mut writer = JSPrinter::BufferWriter::init();
-            bun_core::handle_oom(writer.buffer.grow_if_needed(code.len()));
-            writer
-        });
+                if (log_ref.warnings + log_ref.errors) > 0 {
+                    return Err(
+                        global.throw_value(log_ref.to_js(global, format_args!("Parse error"))?)
+                    );
+                }
 
-        buffer_writer.reset();
-        let mut printer = JSPrinter::BufferPrinter::init(buffer_writer);
-        // SAFETY: see `transpiler_mut` — `print` does not re-enter JS.
-        // Same per-call `arena` that `set_arena(&arena)` and `parse()` used.
-        if let Err(err) = unsafe { self.transpiler_mut() }.print(
-            &arena,
-            parse_result,
-            &mut printer,
-            Transpiler::transpiler::PrintFormat::EsmAscii,
-        ) {
-            self.buffer_writer.set(Some(printer.ctx));
-            return Err(global.throw_error(err, "Failed to print code"));
-        }
+                let mut buffer_writer = self.buffer_writer.replace(None).unwrap_or_else(|| {
+                    let mut writer = JSPrinter::BufferWriter::init();
+                    bun_core::handle_oom(writer.buffer.grow_if_needed(code.len()));
+                    writer
+                });
 
-        // TODO: benchmark if pooling this way is faster or moving is faster
-        buffer_writer = printer.ctx;
-        let result = bun_string_jsc::create_utf8_for_js(global, buffer_writer.written());
-        self.buffer_writer.set(Some(buffer_writer));
-        result
+                buffer_writer.reset();
+                let mut printer = JSPrinter::BufferPrinter::init(buffer_writer);
+                // Same per-call `arena` that `with_call` and `parse()` used.
+                if let Err(err) = transpiler.print(
+                    &arena,
+                    parse_result,
+                    &mut printer,
+                    Transpiler::transpiler::PrintFormat::EsmAscii,
+                ) {
+                    self.buffer_writer.set(Some(printer.ctx));
+                    return Err(global.throw_error(err, "Failed to print code"));
+                }
+
+                // TODO: benchmark if pooling this way is faster or moving is faster
+                buffer_writer = printer.ctx;
+                let result = bun_string_jsc::create_utf8_for_js(global, buffer_writer.written());
+                self.buffer_writer.set(Some(buffer_writer));
+                result
+            })
+        })
     }
 }
 
@@ -1613,7 +1501,7 @@ impl JSTranspiler {
         args.eat();
         let code = code_holder.slice();
 
-        let mut loader: Loader = self.config.get().default_loader;
+        let mut loader: Loader = self.config.default_loader;
         if let Some(arg) = args.next() {
             if let Some(l) = loader_from_js(global, arg)? {
                 loader = l;
@@ -1629,63 +1517,44 @@ impl JSTranspiler {
 
         let arena = Arena::new();
         let mut log = bun_ast::Log::init();
-        // SAFETY: `arena` outlives every use through `self.transpiler` in this fn body;
-        // `_restore` (declared after `arena`/`log`, so dropped first) restores
-        // `prev_arena` and `&self.config.log` before either local drops.
-        // `with_mut` borrow is closure-scoped; no JS re-entry inside.
-        let prev_arena = self.transpiler.with_mut(|t| {
-            let prev = t.arena;
-            // SAFETY: `arena` outlives every use through `t` — `_restore` below
-            // restores `prev_arena` before `arena` drops (reverse-decl order).
-            t.set_arena(unsafe { bun_ptr::detach_lifetime_ref(&arena) });
-            t.set_log(&raw mut log);
-            prev
-        });
-        let _restore = TranspilerStateGuard {
-            transpiler: self.transpiler.as_ptr(),
-            prev_arena,
-            restore_log: self.config_log_ptr(),
-            prev_macro_context: None,
-        };
+        // What the transpiler itself logs during the call (macros); `scan` logs to `log`.
+        let mut call_log = bun_ast::Log::init();
 
         let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
         let _ast_scope = ast_memory_allocator.enter();
 
         let source = bun_ast::Source::init_path_string(loader.stdin_name(), code);
-        let jsx = match self.config.get().tsconfig.as_deref() {
-            Some(ts) => ts.merge_jsx(self.transpiler.get().options.jsx.clone()),
-            None => self.transpiler.get().options.jsx.clone(),
-        };
-
-        let mut opts = bun_js_parser::ParserOptions::init(jsx, loader);
-        // SAFETY: see `transpiler_mut`. The `&mut Transpiler` is reborrowed
-        // disjointly for `macro_context` (stored in `opts`) and `options.define`
-        // (raw-addr read) below; both end when `opts` is consumed by `scan()`.
-        let transpiler = unsafe { self.transpiler_mut() };
-        if transpiler.macro_context.is_none() {
-            let mc = JSAst::Macro::MacroContext::init(transpiler);
-            transpiler.macro_context = Some(mc);
-        }
-        opts.macro_context = transpiler.macro_context.as_mut();
-
-        // `options.define` is `Box<Define>` owned by the long-lived `Transpiler`;
-        // the parser borrows it for the arena lifetime.
-        let define = &*transpiler.options.define;
 
         // NOTE: spec calls `transpiler.resolver.caches.js.scan`. The
         // resolver-side `cache::JavaScript` is a fieldless shell with
         // no `scan` body; the real `scan` lives on `bun_bundler::cache::JavaScript`.
         // Both are stateless unit structs, so calling the bundler-crate one
         // directly is equivalent.
-        // SAFETY: `scan_pass_result` JsCell — `scan()` does not re-enter JS.
-        let scan_result = bun_bundler::cache::JavaScript::init().scan(
-            &arena,
-            unsafe { self.scan_pass_result.get_mut() },
-            opts,
-            define,
-            &mut log,
-            &source,
-        );
+        let scan_result = self.transpiler.with_mut(|t| {
+            t.with_call(&arena, &mut call_log, |transpiler| {
+                let jsx = match self.config.tsconfig.as_deref() {
+                    Some(ts) => ts.merge_jsx(transpiler.options().jsx.clone()),
+                    None => transpiler.options().jsx.clone(),
+                };
+                let mut opts = bun_js_parser::ParserOptions::init(jsx, loader);
+                // `options.define` is `Box<Define>` owned by the long-lived `Transpiler`;
+                // the parser borrows it for the arena lifetime.
+                let (macro_context, define) = transpiler.macro_context_and_define();
+                opts.macro_context = Some(macro_context);
+
+                self.scan_pass_result.with_mut(|scan_pass_result| {
+                    bun_bundler::cache::JavaScript::init().scan(
+                        &arena,
+                        scan_pass_result,
+                        opts,
+                        define,
+                        &mut log,
+                        &source,
+                    )
+                })
+            })
+        });
+        call_log.append_to_with_recycled(&mut log, true);
 
         // `scan_pass_result` must be reset on every exit past this point
         // (including the error paths). Compute the result, then reset
@@ -1708,7 +1577,7 @@ impl JSTranspiler {
             named_imports_to_js(
                 global,
                 self.scan_pass_result.get().import_records.as_slice(),
-                self.config.get().trim_unused_imports.unwrap_or(false),
+                self.config.trim_unused_imports.unwrap_or(false),
             )
         })();
         self.scan_pass_result.with_mut(|s| s.reset());

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1,35 +1,39 @@
-//! `JSBundleCompletionTask` — owns one in-flight `Bun.build()`.
+//! One in-flight `Bun.build()`: [`JSBundleCompletionTask`] is what stays on the
+//! JS thread (promise, keep-alive, plugins, the HTMLBundle route waiting on
+//! it), [`BundleJob`] is what the bundle thread runs and drops, and
+//! [`BuildShared`] is what both (and the running `BundleV2`) reach: the
+//! cancellation flags, the ticket that lets the bundle thread post back to
+//! this VM, and the slot the outcome comes back through.
 //!
-//! LAYERING: this type lives in `bun_runtime` (not `bun_bundler_jsc`) because
-//! its fields name `bun_runtime` types (`JSBundler::Config`, `Plugin`,
-//! `HTMLBundle::Route`). `bun_bundler_jsc` is a lower-tier crate and cannot
-//! depend on `bun_runtime`; keeping the struct there forces an opaque stub at
-//! every use site. The struct is defined here and `bun_bundler_jsc` consumes it
-//! through the `bun_bundler::bundle_v2::CompletionStruct` trait
-//! (layout-agnostic).
+//! LAYERING: these live in `bun_runtime` (not `bun_bundler_jsc`) because their
+//! fields name `bun_runtime` types (`JSBundler::Config`, `Plugin`,
+//! `HTMLBundle::Route`); the bundler sees `BundleJob` through
+//! [`CompletionStruct`] and `BuildShared` through [`CompletionDispatch`].
 
 use bun_options_types::TargetExt as _;
-use core::ptr::{self, NonNull};
+use core::cell::Cell;
+use core::ptr::NonNull;
+use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicU8, Ordering};
 use std::io::Write as _;
+use std::sync::Arc;
 
 use bun_alloc::Arena;
-use bun_bundler::bundle_v2::{
-    BundleV2, BundleV2Result, CompletionStruct, FileMap as Bv2FileMap,
-    JSBundleCompletionTask as Bv2OpaqueCompletion, JSBundlerPlugin, dispatch,
-};
+use bun_bundler::bundle_v2::dispatch::CompletionDispatch;
+use bun_bundler::bundle_v2::{BundleV2, BundleV2Result, CompletionStruct};
 use bun_bundler::options::{self, OutputFile, OutputKind, Side};
 use bun_bundler::output_file::Value as OutputFileValue;
 use bun_bundler::transpiler::Transpiler;
 use bun_core::env::OperatingSystem;
+use bun_event_loop::TaskHop;
 use bun_io::KeepAlive;
 use bun_jsc::WorkPool;
 use bun_jsc::bun_string_jsc;
-use bun_jsc::{self as jsc, JSGlobalObject, JSPromise, JSValue, LogJsc as _};
+use bun_jsc::{self as jsc, JSGlobalObject, JSPromise, JSValue, JsCell, LogJsc as _};
 use bun_options_types::WindowsOptions;
 use bun_options_types::schema::api;
 use bun_paths::resolve_path::{join_abs_string, join_abs_string_buf, platform};
 use bun_paths::{self as paths, SEP};
-use bun_ptr::{BackRef, RefCount, RefPtr};
+use bun_ptr::{BackRef, RefCount, RefPtr, ThisPtr};
 use bun_standalone_graph::StandaloneModuleGraph::{
     CompileErrorReason, CompileResult, Flags as StandaloneFlags, target_base_public_path,
     to_executable,
@@ -37,97 +41,127 @@ use bun_standalone_graph::StandaloneModuleGraph::{
 use bun_sys::Dir;
 #[cfg(not(windows))]
 use bun_sys::OpenDirOptions;
+use bun_threading::Guarded;
 
 use crate::api::js_bundler::js_bundler::{
     CompileOptions, Config as JSBundlerConfig, Plugin, PluginJscExt,
 };
 use crate::api::output_file_jsc::OutputFileJsc as _;
+use crate::jsc_hooks::ActiveHandle;
 use crate::node::fs::{self as node_fs, NodeFS, args as fs_args};
 use crate::node::types::{FileSystemFlags, PathLike, PathOrFileDescriptor, StringOrBuffer};
 use crate::server::html_bundle;
 
-/// See module doc for the layering rationale.
+/// The JS-thread side of a `Bun.build`. Reference-counted; `build_ref` is the
+/// in-flight build's reference (set in [`schedule`](Self::schedule), released
+/// by [`on_complete`](Self::on_complete), or by teardown for a build the bundle
+/// thread never started), and is what the completion hop's `ThisPtr` and the
+/// [`ActiveHandle`] registration point at.
 #[derive(bun_ptr::RefCounted)]
 #[ref_count(debug_name = "JSBundleCompletionTask")]
 pub struct JSBundleCompletionTask {
-    // NOTE: this should arguably be a thread-safe refcount, but it is the plain
-    // (non-atomic) `RefCount<Self>` — a pre-existing discrepancy. See the
-    // `unsafe impl Send` below for the thread-affinity constraint this imposes.
-    pub(crate) ref_count: RefCount<Self>,
-    pub(crate) config: JSBundlerConfig,
-    /// Held from creation until the bundle thread posts the completion (or the
-    /// JS thread releases it unstarted): how the bundle thread and its plugin
-    /// hops reach the VM that called Bun.build, and what makes it wait.
-    pub(crate) bundle_ticket: Option<jsc::Ticket>,
+    ref_count: RefCount<Self>,
+    build_ref: Cell<Option<RefPtr<Self>>>,
+    pub(crate) shared: Arc<BuildShared>,
     pub global_this: BackRef<JSGlobalObject>,
-    pub(crate) promise: jsc::JSPromiseStrong,
-    pub poll_ref: KeepAlive,
-    pub(crate) env: *mut bun_dotenv::Loader,
-    pub(crate) log: bun_ast::Log,
-    /// Set by the owner giving up on the result (HTMLBundle route torn down)
-    /// or by the VM's stop phase; read by `on_complete` (skip delivery) and by
-    /// the bundle thread (`CompletionDispatch::is_cancelled`: stop waiting on
-    /// plugins, fail the build).
-    pub(crate) cancelled: core::sync::atomic::AtomicBool,
-    /// The bundle thread's uws loop while this build runs there, so a
-    /// cancelling VM can wake its Mini loop out of an idle wait.
-    pub(crate) bundle_loop: core::sync::atomic::AtomicPtr<bun_uws::Loop>,
-    /// [`Stage`]: whether the (single, process-wide) bundle thread has taken
-    /// this build off its queue yet. A VM tearing down releases a build that
-    /// is still queued itself instead of waiting behind other VMs' builds.
-    pub(crate) stage: core::sync::atomic::AtomicU8,
-
+    pub(crate) promise: JsCell<jsc::JSPromiseStrong>,
+    poll_ref: JsCell<KeepAlive>,
+    /// The C++ `JSBundlerPlugin` cell, `protect()`ed; destroyed with this task
+    /// (or given up to the HTMLBundle route, which owns its server's plugins).
+    plugins: Cell<Option<NonNull<Plugin>>>,
     /// The route this build is for, kept alive until `on_complete` hands it
     /// the result.
-    pub(crate) html_build_task: Option<RefPtr<html_bundle::Route>>,
-
-    pub(crate) result: BundleV2Result,
-
-    /// intrusive queue link (UnboundedQueue)
-    pub(crate) next: bun_threading::Link<JSBundleCompletionTask>,
-    /// arena-owned by BundleThread heap
-    pub(crate) transpiler: *mut BundleV2<'static>,
-    pub(crate) plugins: Option<NonNull<Plugin>>,
+    pub(crate) html_build_task: Cell<Option<RefPtr<html_bundle::Route>>>,
     pub(crate) started_at_ns: u64,
+    /// The bundle thread's half, until `schedule` hands it over.
+    job: Option<Box<BundleJob>>,
+}
+
+/// What the bundle thread runs: the build's configuration going out, its log
+/// and result coming back (moved into [`BuildShared::outcome`] when done).
+pub struct BundleJob {
+    shared: Arc<BuildShared>,
+    outcome: Option<Box<BuildOutcome>>,
+    /// The owning VM's env loader (`vm.transpiler.env`), which the build's
+    /// transpiler reads; alive while the ticket is held.
+    env: AtomicPtr<bun_dotenv::Loader>,
+    /// The plugin cell the JS side owns; the running `BundleV2` matches paths
+    /// against it from the bundle thread.
+    plugins: AtomicPtr<Plugin>,
+    /// Intrusive link for the bundle thread's queue.
+    next: bun_threading::Link<BundleJob>,
+}
+bun_threading::intrusive_link!(BundleJob, next);
+
+/// Shared by the JS side, the bundle job and the running `BundleV2`.
+pub struct BuildShared {
+    /// Set by the owner giving up on the result (its VM's stop phase); read by
+    /// `on_complete` (skip delivery) and by the bundle thread
+    /// ([`CompletionDispatch::is_cancelled`]: stop waiting on plugins, fail
+    /// the build).
+    cancelled: AtomicBool,
+    /// [`Stage`].
+    stage: AtomicU8,
+    /// Held from creation until the bundle thread posts the completion (or the
+    /// JS thread releases a build that never started): how the bundle thread
+    /// and its plugin hops reach the VM that called `Bun.build`, and what
+    /// makes that VM wait for them.
+    ticket: Guarded<Option<jsc::Ticket>>,
+    /// The JS side's address, for the completion hop; it keeps itself alive
+    /// for that hop through `build_ref`.
+    js: AtomicPtr<JSBundleCompletionTask>,
+    /// The bundle thread's hand-back: taken by `on_complete`.
+    outcome: Guarded<Option<Box<BuildOutcome>>>,
+}
+
+/// What comes back from the bundle thread.
+pub struct BuildOutcome {
+    pub(crate) config: JSBundlerConfig,
+    pub(crate) log: bun_ast::Log,
+    pub(crate) result: BundleV2Result,
 }
 
 #[repr(u8)]
-pub(crate) enum Stage {
+enum Stage {
     /// On the bundle thread's queue; nothing there has touched it.
     Queued = 0,
     /// The bundle thread is (or was) running it.
     Started = 1,
-    /// Its VM is tearing down first and is releasing the JS side right now;
-    /// the bundle thread, if it dequeues it meanwhile, waits for
-    /// `ReleasedUnstarted` before freeing.
-    Releasing = 2,
-    /// The JS side is released and the count returned; the bundle thread
-    /// frees the rest when it dequeues it.
-    ReleasedUnstarted = 3,
+    /// Its VM tore down first and released the JS side; the bundle thread
+    /// drops the job unrun when it dequeues it.
+    Released = 2,
 }
 
 impl Drop for JSBundleCompletionTask {
     fn drop(&mut self) {
-        // Already `Done` (and this may be the bundle thread) for a build
-        // released unstarted; see `stop_for_vm_teardown`.
-        if self.poll_ref.is_active() {
-            self.poll_ref.disable();
-        }
+        self.poll_ref.with_mut(|p| {
+            if p.is_active() {
+                p.disable();
+            }
+        });
         if let Some(plugin) = self.plugins.take() {
-            // The FFI handle stashed at construction.
             Plugin::destroy(plugin.as_ptr());
         }
     }
 }
 
-// SAFETY: enqueued onto the bundle thread; field access is serialized by
-// the producer/consumer handshake (`UnboundedQueue` + `Waker`). Additionally,
-// `ref_count` is the non-atomic `RefCount<Self>` (a `Cell<u32>`; its
-// `ThreadLock` asserts single-thread affinity in debug builds only), so all
-// `ref_()`/`deref()` calls must happen on the JS thread — the bundle thread
-// may hold and transfer an already-taken +1 across the handshake but must
-// never touch the count itself.
-unsafe impl Send for JSBundleCompletionTask {}
+/// `task_tag::JSBundleCompletionTask`: the bundle thread posted the outcome.
+pub struct CompletionHop;
+// SAFETY: the only hop for `JSBundleCompletionTask`; `build_ref` keeps the task
+// alive from `schedule` until `on_complete` releases it.
+unsafe impl TaskHop for CompletionHop {
+    type Target = JSBundleCompletionTask;
+    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::JSBundleCompletionTask;
+    fn run(this: ThisPtr<JSBundleCompletionTask>) -> bun_event_loop::JsResult<()> {
+        JSBundleCompletionTask::on_complete(this)
+    }
+    /// A build handed back unrun during teardown (cancelled in the stop phase)
+    /// releases the keep-alive, plugin cell and promise against the live heap
+    /// without delivering.
+    fn release_unrun(this: ThisPtr<JSBundleCompletionTask>) {
+        let _ = JSBundleCompletionTask::on_complete(this);
+    }
+}
 
 impl JSBundleCompletionTask {
     /// An unscheduled build of `config`; see [`schedule`](Self::schedule).
@@ -136,37 +170,49 @@ impl JSBundleCompletionTask {
         plugins: Option<NonNull<Plugin>>,
         global_this: &JSGlobalObject,
     ) -> JSBundleCompletionTask {
+        let vm = global_this.bun_vm();
+        let shared = Arc::new(BuildShared {
+            cancelled: AtomicBool::new(false),
+            stage: AtomicU8::new(Stage::Queued as u8),
+            ticket: Guarded::new(Some(vm.ticket())),
+            js: AtomicPtr::new(core::ptr::null_mut()),
+            outcome: Guarded::new(None),
+        });
+        let job = Box::new(BundleJob {
+            shared: Arc::clone(&shared),
+            outcome: Some(Box::new(BuildOutcome {
+                config,
+                log: bun_ast::Log::init(),
+                result: BundleV2Result::Pending,
+            })),
+            env: AtomicPtr::new(vm.transpiler.env),
+            plugins: AtomicPtr::new(plugins.map_or(core::ptr::null_mut(), |p| p.as_ptr())),
+            next: bun_threading::Link::new(),
+        });
         JSBundleCompletionTask {
             ref_count: RefCount::init(),
-            config,
-            bundle_ticket: Some(global_this.bun_vm().ticket()),
+            build_ref: Cell::new(None),
+            shared,
             global_this: BackRef::new(global_this),
-            promise: jsc::JSPromiseStrong::default(),
-            poll_ref: KeepAlive::init(),
-            env: global_this.bun_vm().transpiler.env,
-            log: bun_ast::Log::init(),
-            cancelled: core::sync::atomic::AtomicBool::new(false),
-            bundle_loop: core::sync::atomic::AtomicPtr::new(ptr::null_mut()),
-            stage: core::sync::atomic::AtomicU8::new(Stage::Queued as u8),
-            html_build_task: None,
-            result: BundleV2Result::Pending,
-            next: bun_threading::Link::new(),
-            transpiler: ptr::null_mut(),
-            plugins,
+            promise: JsCell::new(jsc::JSPromiseStrong::default()),
+            poll_ref: JsCell::new(KeepAlive::init()),
+            plugins: Cell::new(plugins),
+            html_build_task: Cell::new(None),
             started_at_ns: 0,
+            job: Some(job),
         }
     }
 
     /// `BundleV2.createAndScheduleCompletionTask` — take a process-keepalive
-    /// ref and hand the task to the bundle-thread singleton. The one ref `new`
-    /// created travels with the task and is released by `on_complete_anytask`.
+    /// ref and hand the job to the bundle-thread singleton.
     pub(crate) fn schedule(mut self) {
-        self.poll_ref.ref_(self.global_this.bun_vm().loop_ctx());
-        let plugins = self.plugins;
-        let completion = RefPtr::new(self).into_raw();
-        if let Some(plugin) = plugins {
-            Plugin::opaque_mut(plugin.as_ptr()).set_config(completion.cast());
-        }
+        let job = self.job.take().expect("scheduled once");
+        let this = RefPtr::new(self);
+        let task = this.this_ptr();
+        task.poll_ref
+            .with_mut(|p| p.ref_(task.global_this.bun_vm().loop_ctx()));
+        task.shared.js.store(this.as_ptr(), Ordering::Release);
+        task.build_ref.set(Some(this));
 
         // Ensure this exists before we spawn the thread to prevent any race
         // conditions from creating two
@@ -174,10 +220,22 @@ impl JSBundleCompletionTask {
 
         // Out on the bundle thread from here until it posts the completion: it
         // reads this VM's env loader and the plugin cell, so the VM cancels it at
-        // teardown (registry) and waits for it (`bundle_ticket`).
-        crate::jsc_hooks::ActiveHandle::Bundle(NonNull::new(completion).expect("completion"))
-            .register();
-        bun_bundler::bundle_v2::singleton::enqueue::<JSBundleCompletionTask>(completion);
+        // teardown (registry) and waits for it (the ticket).
+        Self::active_handle(task).register();
+        bun_bundler::bundle_v2::singleton::enqueue(job);
+    }
+
+    fn active_handle(this: ThisPtr<Self>) -> ActiveHandle {
+        ActiveHandle::Bundle(NonNull::new(this.as_ptr()).expect("ThisPtr is non-null"))
+    }
+
+    /// Release the in-flight build's reference; the last touch of `this`.
+    fn release(this: ThisPtr<Self>) {
+        drop(this.build_ref.take());
+    }
+
+    fn plugins_ref(&self) -> Option<&Plugin> {
+        self.plugins.get().map(|p| Plugin::opaque_ref(p.as_ptr()))
     }
 }
 
@@ -194,8 +252,6 @@ fn opt_box(s: &[u8]) -> Option<Box<[u8]>> {
 /// Absolute, because the PE metadata operations need an absolute path.
 fn executable_path(config: &JSBundlerConfig, compile: &CompileOptions) -> Box<[u8]> {
     let mut outbuf = paths::path_buffer_pool::get();
-    // SAFETY: `FileSystem::instance()` is the process-lifetime singleton
-    // initialized during VM startup before any `Bun.build` is reachable.
     let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
     let outdir_slice = &config.outdir.list;
     let outfile_slice = &compile.outfile.list;
@@ -232,7 +288,7 @@ impl JSBundleCompletionTask {
     /// BundlePlugin.ts; false means the caller should resolve immediately.
     fn run_on_end_callbacks(
         global_this: &JSGlobalObject,
-        plugin: &mut Plugin,
+        plugin: &Plugin,
         promise: &JSPromise,
         build_result: JSValue,
         rejection: jsc::JsResult<JSValue>,
@@ -241,28 +297,14 @@ impl JSBundleCompletionTask {
         Ok(value != JSValue::UNDEFINED)
     }
 
-    /// Mutable borrow of the attached `Plugin`, if any.
-    ///
-    /// Centralises the `Option<NonNull> → Option<&mut T>` deref so callers
-    /// (`to_js_error` / `on_complete_anytask`) stay safe. The plugin is a C++
-    /// `JSBundlerPlugin` opaque created by [`PluginJscExt::create`] and
-    /// `protect()`-ed for the task's lifetime; it is freed only via
-    /// `Plugin::destroy` in `deinit` *after* `take()` clears `self.plugins`.
-    /// While the field is `Some` the pointee is therefore live, pinned, and
-    /// disjoint from `*self` (separate C++-heap allocation).
-    #[inline]
-    fn plugins_mut(&mut self) -> Option<&mut Plugin> {
-        // SAFETY: see fn doc — C++-heap opaque, live while `self.plugins` is
-        // `Some`, disjoint from `*self`. Single JS-mutator thread.
-        self.plugins.map(|p| unsafe { &mut *p.as_ptr() })
-    }
-
     fn to_js_error(
-        &mut self,
+        &self,
+        outcome: &BuildOutcome,
         promise: &mut JSPromise,
         global_this: &JSGlobalObject,
     ) -> jsc::JsResult<()> {
-        let throw_on_error = self.config.throw_on_error;
+        let throw_on_error = outcome.config.throw_on_error;
+        let log = &outcome.log;
 
         let build_result = JSValue::create_empty_object(global_this, 3);
         match JSValue::create_empty_array(global_this, 0) {
@@ -270,22 +312,17 @@ impl JSBundleCompletionTask {
             Err(e) => return promise.reject(global_this, Err(e)),
         };
         build_result.put(global_this, b"success", JSValue::FALSE);
-        match self.log.to_js_array(global_this) {
+        match log.to_js_array(global_this) {
             Ok(v) => build_result.put(global_this, b"logs", v),
             Err(e) => return promise.reject(global_this, Err(e)),
         };
 
-        let did_handle_callbacks = if self.plugins.is_some() {
-            // Compute `rejection` before borrowing the plugin so `&self.log`
-            // does not overlap the `&mut self` taken by `plugins_mut()`.
+        let did_handle_callbacks = if let Some(plugin) = self.plugins_ref() {
             let rejection = if throw_on_error {
-                self.log
-                    .to_js_aggregate_error(global_this, format_args!("Bundle failed"))
+                log.to_js_aggregate_error(global_this, format_args!("Bundle failed"))
             } else {
                 Ok(JSValue::UNDEFINED)
             };
-            // Checked `is_some` above; accessor encapsulates the deref.
-            let plugin = self.plugins_mut().unwrap();
             match Self::run_on_end_callbacks(global_this, plugin, promise, build_result, rejection)
             {
                 Ok(b) => b,
@@ -297,9 +334,8 @@ impl JSBundleCompletionTask {
 
         if !did_handle_callbacks {
             if throw_on_error {
-                let aggregate_error = self
-                    .log
-                    .to_js_aggregate_error(global_this, format_args!("Bundle failed"));
+                let aggregate_error =
+                    log.to_js_aggregate_error(global_this, format_args!("Bundle failed"));
                 return promise.reject(global_this, aggregate_error);
             } else {
                 return promise.resolve(global_this, build_result);
@@ -309,9 +345,12 @@ impl JSBundleCompletionTask {
     }
 
     /// Port of `JSBundleCompletionTask.doCompilation`.
-    fn do_compilation(&mut self, output_files: &mut Vec<OutputFile>) -> CompileResult {
-        let compile_options = self
-            .config
+    fn do_compilation(
+        &self,
+        config: &JSBundlerConfig,
+        output_files: &mut Vec<OutputFile>,
+    ) -> CompileResult {
+        let compile_options = config
             .compile
             .as_ref()
             .expect("Unexpected: No compile options provided");
@@ -327,7 +366,7 @@ impl JSBundleCompletionTask {
             return CompileResult::fail(CompileErrorReason::NoEntryPoint);
         };
 
-        let full_outfile_path = executable_path(&self.config, compile_options);
+        let full_outfile_path = executable_path(config, compile_options);
 
         let dirname: &[u8] = paths::dirname(&full_outfile_path).unwrap_or(b".");
         let basename: &[u8] = paths::basename(&full_outfile_path);
@@ -407,11 +446,8 @@ impl JSBundleCompletionTask {
             root_dir.fd,
             module_prefix,
             outfile_for_executable,
-            // SAFETY: `self.env` is the per-VM `DotEnv.Loader` stashed at
-            // construction; valid for the lifetime of the VirtualMachine, and
-            // nothing inside `to_executable` reaches it otherwise.
-            unsafe { &mut *self.env },
-            self.config.format,
+            self.global_this.bun_vm().transpiler.env_mut(),
+            config.format,
             &WindowsOptions {
                 hide_console: compile_options.windows_hide_console,
                 icon: opt_box(&compile_options.windows_icon_path.list),
@@ -489,10 +525,8 @@ impl JSBundleCompletionTask {
                     } else {
                         map_basename
                     };
-                    let bytes: &[u8] = match &output_files[i].value {
-                        OutputFileValue::Buffer { bytes } => bytes,
-                        // SAFETY: `Buffer` arm checked above.
-                        _ => unsafe { core::hint::unreachable_unchecked() },
+                    let OutputFileValue::Buffer { bytes } = &output_files[i].value else {
+                        unreachable!()
                     };
                     let write_result = NodeFS::write_file_with_path_buffer(
                         &mut pathbuf,
@@ -539,255 +573,199 @@ impl JSBundleCompletionTask {
         result
     }
 
-    pub(crate) fn on_complete_anytask(ctx: *mut Self) -> bun_event_loop::JsResult<()> {
-        crate::jsc_hooks::ActiveHandle::Bundle(NonNull::new(ctx).expect("completion")).unregister();
-        // SAFETY: `ctx` is the live heap allocation; takes over the +1 taken by
-        // the `complete_on_bundle_thread` enqueue.
-        let _guard = unsafe { RefPtr::from_raw(ctx) };
-        // SAFETY: `ctx` is the heap::alloc allocation registered in `task`,
-        // dispatched exactly once per task on the JS thread. Exclusive: the
-        // task has no JS-visible handle, the bundle thread's access ended when
-        // it enqueued this dispatch, and `_drop_ref` keeps the refcount above
-        // zero so re-entrant JS cannot free it.
-        unsafe { &mut *ctx }.on_complete()
-    }
-
     /// VM teardown's stop phase (JS thread): give up on the result.
     ///
     /// * Still queued behind other builds: release the JS side here (plugin
-    ///   cell, promise, keep-alive), return the count, and leave the inert rest
-    ///   for the bundle thread to free when it dequeues it — the VM does not
-    ///   wait behind other VMs' builds.
+    ///   cell, promise, keep-alive), return the ticket, and leave the job for
+    ///   the bundle thread to drop when it dequeues it — the VM does not wait
+    ///   behind other VMs' builds.
     /// * Already on the bundle thread: tombstone the plugin — which answers what
     ///   the plugins still hold as cancelled — then cancel and wake the bundle
     ///   thread; it consumes those answers, fails the build and posts the
     ///   completion, which teardown waits for and releases.
-    ///
-    /// # Safety
-    /// `this` is live (registered ⇒ its completion has not run); JS thread.
-    pub(crate) unsafe fn stop_for_vm_teardown(this: *mut Self) {
-        use core::sync::atomic::Ordering;
-        // SAFETY: fn contract; the plugin cell is protected by this task; the
-        // loop pointer is a thread's uws loop, valid for that thread's
-        // lifetime, and wakeup is thread-safe.
-        unsafe {
-            if (*this)
-                .stage
-                .compare_exchange(
-                    Stage::Queued as u8,
-                    Stage::Releasing as u8,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                )
-                .is_ok()
-            {
-                (*this).poll_ref.disable();
-                if let Some(plugin) = (*this).plugins.take() {
-                    Plugin::destroy(plugin.as_ptr());
-                }
-                (*this).promise = jsc::JSPromiseStrong::default();
-                (*this).bundle_ticket = None;
-                (*this).html_build_task = None;
-                // Publish only now: from here the bundle thread may free `this`.
-                (*this)
-                    .stage
-                    .store(Stage::ReleasedUnstarted as u8, Ordering::Release);
-                return;
+    pub(crate) fn stop_for_vm_teardown(this: ThisPtr<Self>) {
+        let shared = &this.shared;
+        if shared
+            .stage
+            .compare_exchange(
+                Stage::Queued as u8,
+                Stage::Released as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            this.poll_ref.with_mut(|p| p.disable());
+            if let Some(plugin) = this.plugins.take() {
+                Plugin::destroy(plugin.as_ptr());
             }
-            if let Some(plugins) = (*this).plugins {
-                crate::api::JSBundler::PluginJscExt::tombstone(plugins.as_ref());
-            }
-            (*this).cancelled.store(true, Ordering::Release);
-            let l = (*this).bundle_loop.load(Ordering::Acquire);
-            if !l.is_null() {
-                bun_uws::us_wakeup_loop(l);
-            }
+            this.promise.set(jsc::JSPromiseStrong::default());
+            *shared.ticket.lock() = None;
+            Self::release(this);
+            return;
         }
+        if let Some(plugins) = this.plugins.get() {
+            PluginJscExt::tombstone(Plugin::opaque_ref(plugins.as_ptr()));
+        }
+        shared.cancelled.store(true, Ordering::Release);
+        bun_bundler::bundle_v2::singleton::wake();
     }
 
-    fn on_complete(&mut self) -> bun_event_loop::JsResult<()> {
-        let this = self;
-        let vm = this.global_this.bun_vm_ptr();
-        // SAFETY: `vm` is the live per-thread VM (`global_this.bun_vm_ptr()`).
+    fn on_complete(this: ThisPtr<Self>) -> bun_event_loop::JsResult<()> {
+        Self::active_handle(this).unregister();
         this.poll_ref
-            .unref(unsafe { jsc::virtual_machine::VirtualMachine::event_loop_ctx(vm) });
-        if this.cancelled.load(core::sync::atomic::Ordering::Acquire) {
+            .with_mut(|p| p.unref(this.global_this.bun_vm().loop_ctx()));
+        let outcome = this.shared.outcome.lock().take();
+        let result = if this.shared.cancelled.load(Ordering::Acquire) {
+            Ok(())
+        } else {
+            this.deliver(
+                outcome.expect("the bundle thread posts the outcome before the completion"),
+            )
+        };
+        Self::release(this);
+        result
+    }
+
+    fn deliver(&self, mut outcome: Box<BuildOutcome>) -> bun_event_loop::JsResult<()> {
+        if let Some(html_build_task) = self.html_build_task.take() {
+            self.plugins.set(None);
+            html_build_task.on_complete(&mut outcome, self.started_at_ns);
             return Ok(());
         }
 
-        if let Some(html_build_task) = this.html_build_task.take() {
-            this.plugins = None;
-            html_build_task.on_complete(this);
-            return Ok(());
-        }
+        let global_this = self.global_this.get();
+        let mut promise_strong = self.promise.take();
+        let promise = promise_strong.swap();
 
-        // Copy the BackRef out (it is `Copy`) so `global_this` borrows a local
-        // instead of `*this` — `do_compilation`/`to_js_error` below need `&mut *this`.
-        let global_this_ref = this.global_this;
-        let global_this = global_this_ref.get();
-        // `Strong::swap` ties the returned `&mut JSPromise` to
-        // `&mut this.promise` even though the cell lives on the GC heap (raw
-        // ptr deref inside). Detach via raw ptr so `this` can be reborrowed
-        // for `result`/`config`/`log` below.
-        let promise: *mut JSPromise = this.promise.swap();
-        let promise = JSPromise::opaque_mut(promise);
-
-        // `do_compilation` borrows `&mut self` while needing
-        // `&mut output_files` from inside `self.result`. Temporarily move the
-        // Vec out via `take` so the method gets a disjoint `&mut self`.
-        if matches!(this.result, BundleV2Result::Value(_)) && this.config.compile.is_some() {
-            let mut output_files = match &mut this.result {
-                BundleV2Result::Value(build) => core::mem::take(&mut build.output_files),
-                // SAFETY: arm checked above.
-                _ => unsafe { core::hint::unreachable_unchecked() },
+        if matches!(outcome.result, BundleV2Result::Value(_)) && outcome.config.compile.is_some() {
+            let BundleV2Result::Value(build) = &mut outcome.result else {
+                unreachable!()
             };
-            let compile_result = this.do_compilation(&mut output_files);
-            // `defer compile_result.deinit()` — `CompileResult` is a Rust enum
-            // with owned `Vec<u8>` payloads; drops at end of scope.
+            let mut output_files = core::mem::take(&mut build.output_files);
+            let compile_result = self.do_compilation(&outcome.config, &mut output_files);
 
             if let CompileResult::Err(err) = &compile_result {
-                // `bun.handleOom(log.addError(..., bun.handleOom(dupe(..))))`
-                this.log.add_error_fmt(
+                outcome.log.add_error_fmt(
                     None,
                     bun_ast::Loc::EMPTY,
                     format_args!("{}", bstr::BStr::new(err.slice())),
                 );
-                // `this.result.value.deinit()` — owned fields drop with the
-                // overwrite below; `output_files` (moved out above) drops here.
                 drop(output_files);
-                this.result = BundleV2Result::Err(bun_bundler::Error::CompilationFailed);
+                outcome.result = BundleV2Result::Err(bun_bundler::Error::CompilationFailed);
             } else {
-                // Put the compacted output_files back.
-                match &mut this.result {
-                    BundleV2Result::Value(build) => build.output_files = output_files,
-                    // SAFETY: arm checked above.
-                    _ => unsafe { core::hint::unreachable_unchecked() },
-                }
+                let BundleV2Result::Value(build) = &mut outcome.result else {
+                    unreachable!()
+                };
+                build.output_files = output_files;
             }
         }
 
-        // `to_js_error` borrows `&mut self`, which would overlap a
-        // `&mut this.result` match scrutinee. Dispatch the pending/err arms
-        // first, then take a fresh `&mut` for Value.
-        if matches!(this.result, BundleV2Result::Pending) {
-            unreachable!();
+        match outcome.result {
+            BundleV2Result::Pending => unreachable!(),
+            BundleV2Result::Err(_) => return self.to_js_error(&outcome, promise, global_this),
+            BundleV2Result::Value(_) => {}
         }
-        if matches!(this.result, BundleV2Result::Err(_)) {
-            return this.to_js_error(promise, global_this);
+        let BundleV2Result::Value(build) = &mut outcome.result else {
+            unreachable!()
+        };
+        let config = &outcome.config;
+        let output_files = &mut build.output_files;
+        let output_files_js = match JSValue::create_empty_array(global_this, output_files.len()) {
+            Ok(v) => v,
+            Err(e) => return promise.reject(global_this, Err(e)),
+        };
+        if output_files_js == JSValue::ZERO {
+            panic!(
+                "Unexpected pending JavaScript exception in JSBundleCompletionTask.onComplete. This is a bug in Bun."
+            );
         }
-        match &mut this.result {
-            BundleV2Result::Value(build) => {
-                let output_files = &mut build.output_files;
-                let output_files_js =
-                    match JSValue::create_empty_array(global_this, output_files.len()) {
-                        Ok(v) => v,
-                        Err(e) => return promise.reject(global_this, Err(e)),
-                    };
-                if output_files_js == JSValue::ZERO {
-                    panic!(
-                        "Unexpected pending JavaScript exception in JSBundleCompletionTask.onComplete. This is a bug in Bun."
-                    );
-                }
 
-                // `output_file.to_js()` needs `&mut OutputFile` while the path
-                // computation reads `this.config`. Snapshot the config slices
-                // once outside the loop so the per-file `&mut` doesn't overlap
-                // `&this.config`.
-                let outdir_is_abs = !this.config.outdir.is_empty()
-                    && bun_paths::is_absolute(&this.config.outdir.list);
-                let outdir = this.config.outdir.list.clone();
-                let dir = this.config.dir.list.clone();
-                // SAFETY: `FileSystem::instance()` is the process-lifetime singleton
-                // initialized during VM startup before any `Bun.build` is reachable.
-                let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+        let outdir_is_abs =
+            !config.outdir.is_empty() && bun_paths::is_absolute(&config.outdir.list);
+        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
 
-                let mut to_assign_on_sourcemap = JSValue::ZERO;
-                for (i, output_file) in output_files.iter_mut().enumerate() {
-                    let path: Box<[u8]> = if !outdir.is_empty() {
-                        if outdir_is_abs {
-                            Box::from(join_abs_string::<platform::Auto>(
-                                &outdir,
-                                &[&output_file.dest_path],
-                            ))
-                        } else {
-                            Box::from(join_abs_string::<platform::Auto>(
-                                top_level_dir,
-                                &[&dir, &outdir, &output_file.dest_path],
-                            ))
-                        }
-                    } else {
-                        output_file.dest_path.clone()
-                    };
-                    let result = output_file.to_js(Some(&path), global_this);
-                    if to_assign_on_sourcemap != JSValue::ZERO {
-                        crate::generated_classes::js_BuildArtifact::sourcemap_set_cached(
-                            to_assign_on_sourcemap,
-                            global_this,
-                            result,
-                        );
-                        to_assign_on_sourcemap = JSValue::ZERO;
-                    }
-
-                    if output_file.source_map_index != u32::MAX {
-                        to_assign_on_sourcemap = result;
-                    }
-
-                    if let Err(e) = output_files_js.put_index(global_this, i as u32, result) {
-                        return promise.reject(global_this, Err(e));
-                    }
-                }
-
-                let build_output = JSValue::create_empty_object(global_this, 4);
-                build_output.put(global_this, b"outputs", output_files_js);
-                build_output.put(global_this, b"success", JSValue::TRUE);
-                match this.log.to_js_array(global_this) {
-                    Ok(v) => build_output.put(global_this, b"logs", v),
-                    Err(e) => return promise.reject(global_this, Err(e)),
-                };
-
-                // metafile: { json: <lazy parsed>, markdown?: string }
-                if let Some(metafile) = &build.metafile {
-                    let metafile_js_str =
-                        match bun_string_jsc::create_utf8_for_js(global_this, metafile) {
-                            Ok(v) => v,
-                            Err(e) => return promise.reject(global_this, Err(e)),
-                        };
-                    let metafile_md_str = match &build.metafile_markdown {
-                        Some(md) => match bun_string_jsc::create_utf8_for_js(global_this, md) {
-                            Ok(v) => v,
-                            Err(e) => return promise.reject(global_this, Err(e)),
-                        },
-                        None => JSValue::UNDEFINED,
-                    };
-                    Bun__setupLazyMetafile(
-                        global_this,
-                        build_output,
-                        metafile_js_str,
-                        metafile_md_str,
-                    );
-                }
-
-                let did_handle_callbacks = if let Some(plugin) = this.plugins_mut() {
-                    match Self::run_on_end_callbacks(
-                        global_this,
-                        plugin,
-                        promise,
-                        build_output,
-                        Ok(JSValue::UNDEFINED),
-                    ) {
-                        Ok(b) => b,
-                        Err(e) => return promise.reject(global_this, Err(e)),
-                    }
+        let mut to_assign_on_sourcemap = JSValue::ZERO;
+        for (i, output_file) in output_files.iter_mut().enumerate() {
+            let path: Box<[u8]> = if !config.outdir.is_empty() {
+                if outdir_is_abs {
+                    Box::from(join_abs_string::<platform::Auto>(
+                        &config.outdir.list,
+                        &[&output_file.dest_path],
+                    ))
                 } else {
-                    false
-                };
-
-                if !did_handle_callbacks {
-                    return promise.resolve(global_this, build_output);
+                    Box::from(join_abs_string::<platform::Auto>(
+                        top_level_dir,
+                        &[
+                            &config.dir.list,
+                            &config.outdir.list,
+                            &output_file.dest_path,
+                        ],
+                    ))
                 }
+            } else {
+                output_file.dest_path.clone()
+            };
+            let result = output_file.to_js(Some(&path), global_this);
+            if to_assign_on_sourcemap != JSValue::ZERO {
+                crate::generated_classes::js_BuildArtifact::sourcemap_set_cached(
+                    to_assign_on_sourcemap,
+                    global_this,
+                    result,
+                );
+                to_assign_on_sourcemap = JSValue::ZERO;
             }
-            // SAFETY: Pending/Err already returned above.
-            _ => unsafe { core::hint::unreachable_unchecked() },
+
+            if output_file.source_map_index != u32::MAX {
+                to_assign_on_sourcemap = result;
+            }
+
+            if let Err(e) = output_files_js.put_index(global_this, i as u32, result) {
+                return promise.reject(global_this, Err(e));
+            }
+        }
+
+        let build_output = JSValue::create_empty_object(global_this, 4);
+        build_output.put(global_this, b"outputs", output_files_js);
+        build_output.put(global_this, b"success", JSValue::TRUE);
+        match outcome.log.to_js_array(global_this) {
+            Ok(v) => build_output.put(global_this, b"logs", v),
+            Err(e) => return promise.reject(global_this, Err(e)),
+        };
+
+        // metafile: { json: <lazy parsed>, markdown?: string }
+        if let Some(metafile) = &build.metafile {
+            let metafile_js_str = match bun_string_jsc::create_utf8_for_js(global_this, metafile) {
+                Ok(v) => v,
+                Err(e) => return promise.reject(global_this, Err(e)),
+            };
+            let metafile_md_str = match &build.metafile_markdown {
+                Some(md) => match bun_string_jsc::create_utf8_for_js(global_this, md) {
+                    Ok(v) => v,
+                    Err(e) => return promise.reject(global_this, Err(e)),
+                },
+                None => JSValue::UNDEFINED,
+            };
+            Bun__setupLazyMetafile(global_this, build_output, metafile_js_str, metafile_md_str);
+        }
+
+        let did_handle_callbacks = if let Some(plugin) = self.plugins_ref() {
+            match Self::run_on_end_callbacks(
+                global_this,
+                plugin,
+                promise,
+                build_output,
+                Ok(JSValue::UNDEFINED),
+            ) {
+                Ok(b) => b,
+                Err(e) => return promise.reject(global_this, Err(e)),
+            }
+        } else {
+            false
+        };
+
+        if !did_handle_callbacks {
+            return promise.resolve(global_this, build_output);
         }
         Ok(())
     }
@@ -811,60 +789,38 @@ bun_jsc::jsc_abi_extern! {
     );
 }
 
-// ─── CompletionDispatch vtable ───────────────────────────────────────────────
-// §Dispatch — the bundler holds `JSBundleCompletionTask` as a
-// `dispatch::CompletionHandle` (erased owner + this `&'static` vtable) so the
-// struct layout stays in `bun_runtime`.
+// ─── What the running BundleV2 sees ──────────────────────────────────────────
 
-/// Recover `&JSBundleCompletionTask` from the opaque vtable owner pointer.
-///
-/// Centralises the `NonNull<Bv2OpaqueCompletion> → &JSBundleCompletionTask`
-/// cast+deref so the two `CompletionDispatch` thunks below stay safe at the
-/// call site (one accessor, N safe callers).
-#[inline]
-fn from_completion_handle<'a>(c: NonNull<Bv2OpaqueCompletion>) -> &'a JSBundleCompletionTask {
-    // SAFETY: `c` is the live backref the bundler stashed in
-    // `CompletionHandle.owner` (set from a `Box<JSBundleCompletionTask>` that
-    // outlives every dispatch call). The opaque marker and the concrete struct
-    // are the same allocation; only shared field reads follow.
-    unsafe { &*c.as_ptr().cast::<JSBundleCompletionTask>() }
-}
-
-static COMPLETION_VTABLE: dispatch::CompletionDispatch = dispatch::CompletionDispatch {
-    is_cancelled: |c| {
-        from_completion_handle(c)
-            .cancelled
-            .load(core::sync::atomic::Ordering::Acquire)
-    },
-    enqueue_task_concurrent: |c, task| {
-        // SAFETY: `task` is a fresh non-null `ConcurrentTask` passed through
-        // from the bundler vtable; the queue takes ownership.
-        unsafe {
-            let task = core::ptr::NonNull::new_unchecked(task);
-            from_completion_handle(c)
-                .bundle_ticket
-                .as_ref()
-                .expect("a running Bun.build holds a ticket")
-                .post(task);
-        }
-    },
-};
-
-// ─── CompletionStruct impl ───────────────────────────────────────────────────
-// Hands BundleThread the field accessors it needs without exposing the layout.
-// SAFETY: `next` is the sole intrusive link for `UnboundedQueue<JSBundleCompletionTask>`.
-unsafe impl bun_threading::Linked for JSBundleCompletionTask {
-    #[inline]
-    unsafe fn link(item: *mut Self) -> *const bun_threading::Link<Self> {
-        // SAFETY: `item` is valid and properly aligned per `UnboundedQueue` contract.
-        unsafe { core::ptr::addr_of!((*item).next) }
+impl CompletionDispatch for BuildShared {
+    fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+    fn enqueue_task_concurrent(
+        &self,
+        task: NonNull<bun_event_loop::ConcurrentTask::ConcurrentTask>,
+    ) {
+        self.ticket
+            .lock()
+            .as_ref()
+            .expect("a running Bun.build holds a ticket")
+            .post(task);
     }
 }
 
-impl CompletionStruct for JSBundleCompletionTask {
+// ─── What the bundle thread runs ─────────────────────────────────────────────
+
+impl BundleJob {
+    fn outcome(&mut self) -> &mut BuildOutcome {
+        self.outcome
+            .as_deref_mut()
+            .expect("the outcome leaves with complete_on_bundle_thread")
+    }
+}
+
+impl CompletionStruct for BundleJob {
     fn try_start(&mut self) -> bool {
-        use core::sync::atomic::Ordering;
-        self.stage
+        self.shared
+            .stage
             .compare_exchange(
                 Stage::Queued as u8,
                 Stage::Started as u8,
@@ -872,23 +828,6 @@ impl CompletionStruct for JSBundleCompletionTask {
                 Ordering::Acquire,
             )
             .is_ok()
-    }
-
-    #[allow(clippy::not_unsafe_ptr_arg_deref)] // trait contract: dequeued ⇒ sole owner
-    fn free_released_unstarted(this: *mut Self) {
-        use core::sync::atomic::Ordering;
-        // `try_start` lost to the VM's teardown, which may still be releasing
-        // the JS side (`Releasing`): a handful of stores on the JS thread.
-        // SAFETY: dequeued and not started ⇒ live until we free it below.
-        while unsafe { (*this).stage.load(Ordering::Acquire) } != Stage::ReleasedUnstarted as u8 {
-            core::hint::spin_loop();
-        }
-        // The VM released everything thread-affine (`stop_for_vm_teardown`);
-        // what is left — config, log, an empty promise slot, a `Done`
-        // keep-alive, the handle clone — is ours to drop here. The queue held
-        // the creation reference.
-        // SAFETY: dequeued ⇒ sole owner; nothing JS-affine remains.
-        drop(unsafe { bun_core::heap::take(this) });
     }
 
     /// Port of `JSBundleCompletionTask.configureBundler` — the post-init half
@@ -900,7 +839,7 @@ impl CompletionStruct for JSBundleCompletionTask {
         transpiler: &mut Transpiler<'a>,
         _bump: &'a Arena,
     ) -> bun_bundler::Result<()> {
-        let config = &mut self.config;
+        let config = &mut self.outcome().config;
 
         transpiler.options.env.behavior = config.env_behavior;
         transpiler.options.env.prefix = Box::from(config.env_prefix.list.as_slice());
@@ -1067,10 +1006,8 @@ impl CompletionStruct for JSBundleCompletionTask {
         transpiler.options.metafile_markdown_path =
             Box::from(config.metafile_markdown_path.list.as_slice());
         if config.optimize_imports.count() > 0 {
-            // SAFETY: `self.config` outlives `bump` and `optimize_imports` is not mutated
-            // during the bundle; a bump.alloc'd clone leaked (arena never runs Drop).
             transpiler.options.optimize_imports =
-                Some(unsafe { &*core::ptr::from_ref(&config.optimize_imports) });
+                Some(Arc::new(core::mem::take(&mut config.optimize_imports)));
         }
 
         if transpiler.options.compile_mode.is_executable() {
@@ -1124,52 +1061,36 @@ impl CompletionStruct for JSBundleCompletionTask {
         Ok(())
     }
 
+    /// The bundle thread's last touch of this VM's memory: hand the outcome
+    /// over, post the completion hop through the ticket, drop the ticket.
     fn complete_on_bundle_thread(&mut self) {
-        // The bundle thread's last touch of this task and of the VM's memory:
-        // move the ticket out (the JS thread may free `self` once queued),
-        // hand it back, drop the ticket.
-        self.bundle_loop
-            .store(ptr::null_mut(), core::sync::atomic::Ordering::Release);
-        let ticket = self
-            .bundle_ticket
+        let outcome = self.outcome.take();
+        let shared = &self.shared;
+        *shared.outcome.lock() = outcome;
+        let ticket = shared
+            .ticket
+            .lock()
             .take()
             .expect("a running Bun.build holds a ticket");
-        let this = std::ptr::from_mut::<Self>(self);
-        ticket.post(jsc::ConcurrentTask::create(jsc::Task::init(this)));
+        let js = shared.js.load(Ordering::Acquire);
+        ticket.post(jsc::ConcurrentTask::create(bun_event_loop::Task::new(
+            CompletionHop::TAG,
+            js.cast(),
+        )));
     }
     fn set_result(&mut self, result: BundleV2Result) {
-        self.result = result;
+        self.outcome().result = result;
     }
     fn set_log(&mut self, log: bun_ast::Log) {
-        self.log = log;
-    }
-    fn set_transpiler(&mut self, this: *mut BundleV2<'_>) {
-        self.transpiler = this.cast();
-    }
-    fn plugins(&self) -> Option<NonNull<JSBundlerPlugin>> {
-        // `Plugin` and `JSBundlerPlugin` are the same `bun_bundler` opaque.
-        self.plugins
-    }
-    fn file_map(&mut self) -> Option<NonNull<Bv2FileMap>> {
-        // `FileMap` and `Bv2FileMap` are the same `bun_bundler` type.
-        if self.config.files.map.is_empty() {
-            None
-        } else {
-            Some(NonNull::from(&mut self.config.files))
-        }
-    }
-    fn as_js_bundle_completion_task(&mut self) -> dispatch::CompletionHandle {
-        dispatch::CompletionHandle {
-            owner: NonNull::from(self).cast::<Bv2OpaqueCompletion>(),
-            vtable: &COMPLETION_VTABLE,
-        }
+        self.outcome().log = log;
     }
 
     fn create_and_configure_transpiler<'a>(
         &mut self,
         bump: &'a Arena,
     ) -> bun_bundler::Result<&'a mut Transpiler<'a>> {
-        let config = &self.config;
+        let outcome = self.outcome();
+        let config = &outcome.config;
         let opts = api::TransformOptions {
             define: if config.define.count() > 0 {
                 Some(api::StringMap {
@@ -1202,20 +1123,11 @@ impl CompletionStruct for JSBundleCompletionTask {
             ..Default::default()
         };
 
-        let log: *mut bun_ast::Log = &raw mut self.log;
-        let t = Transpiler::init(bump, log, opts, Some(self.env))?;
+        let env = self.env.load(Ordering::Relaxed);
+        let t = Transpiler::init(bump, &raw mut self.outcome().log, opts, Some(env))?;
         let transpiler: &'a mut Transpiler<'a> = bump.alloc(t);
-
-        // Post-init field wiring.
-        // Reborrow through a raw ptr so `&mut self` is usable
-        // again after handing `&'a mut Transpiler` (which is tied to `bump`,
-        // not `self`) to the trait method.
-        let tp: *mut Transpiler<'a> = transpiler;
-        // SAFETY: `tp` aliases nothing in `self`; lives in `bump`.
-        self.configure_bundler(unsafe { &mut *tp }, bump)?;
-        // SAFETY: `tp` was the unique `&'a mut` slot from `bump.alloc`; the
-        // reborrow above has ended.
-        Ok(unsafe { &mut *tp })
+        self.configure_bundler(transpiler, bump)?;
+        Ok(transpiler)
     }
 
     fn init_and_run<'a>(
@@ -1231,11 +1143,6 @@ impl CompletionStruct for JSBundleCompletionTask {
         let mut any_loop = bun_event_loop::AnyEventLoop::default();
         let event_loop: bun_bundler::linker_context_mod::EventLoop =
             Some(NonNull::from(&mut any_loop).cast::<bun_event_loop::AnyEventLoop>());
-        if let bun_event_loop::AnyEventLoop::Mini(mini) = &any_loop {
-            // So a cancelling VM can wake us out of an idle wait for plugins.
-            self.bundle_loop
-                .store(mini.loop_ptr(), core::sync::atomic::Ordering::Release);
-        }
 
         // `thread_pool` is the `WorkPool` singleton (`OnceLock`-backed,
         // process-lifetime, concurrently read by worker threads). Do NOT
@@ -1247,23 +1154,15 @@ impl CompletionStruct for JSBundleCompletionTask {
         // `Graph.heap` is a borrow, so reuse the caller-owned `bump`.
         let mut bv2 = BundleV2::init(transpiler, None, bump, event_loop, false, worker_pool, bump)?;
 
-        bv2.plugins = self.plugins();
-        bv2.completion = Some(self.as_js_bundle_completion_task());
-        // SAFETY: `file_map` returns a `NonNull` into `self.config.files`,
-        // which outlives `bv2` (both live until `generate_in_new_thread`
-        // returns). `BundleV2.file_map: Option<&'a FileMap>` — erase to `'a`.
-        bv2.file_map = self.file_map().map(|p| unsafe { &*p.as_ptr() });
-
-        self.set_transpiler(&raw mut *bv2);
+        bv2.plugins = NonNull::new(self.plugins.load(Ordering::Relaxed));
+        bv2.completion = Some(Arc::clone(&self.shared) as Arc<dyn CompletionDispatch>);
+        let config = &mut self.outcome().config;
+        if !config.files.map.is_empty() {
+            bv2.file_map = Some(Arc::new(core::mem::take(&mut config.files)));
+        }
 
         // Snapshot entry points as `&[&[u8]]`.
-        let entry_points: Vec<&[u8]> = self
-            .config
-            .entry_points
-            .keys()
-            .iter()
-            .map(|b| &**b)
-            .collect();
+        let entry_points: Vec<&[u8]> = config.entry_points.keys().iter().map(|b| &**b).collect();
 
         let run = bv2.run_from_js_in_new_thread(&entry_points);
 
@@ -1282,15 +1181,5 @@ impl CompletionStruct for JSBundleCompletionTask {
                 Err(err)
             }
         }
-    }
-}
-
-impl bun_event_loop::Taskable for JSBundleCompletionTask {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::JSBundleCompletionTask;
-    /// A Bun.build the bundle thread handed back during teardown (cancelled in
-    /// the stop phase): its completion releases the keep-alive, plugin cell
-    /// and promise against the live heap.
-    unsafe fn release_unrun(this: *mut Self) {
-        let _ = JSBundleCompletionTask::on_complete_anytask(this);
     }
 }

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1027,14 +1027,13 @@ impl CompletionStruct for BundleJob {
             {
                 match bun_standalone_graph::StandaloneModuleGraph::target_builtins(
                     &compile.compile_target,
-                    // SAFETY: `self.env` is the per-VM `DotEnv.Loader` stashed at construction; see `to_executable` below.
-                    unsafe { &mut *self.env },
+                    transpiler.env_mut(),
                     Some(&compile.executable_path.list[..]).filter(|p| !p.is_empty()),
                 ) {
                     Ok(Some(section)) => options::CompileTargetBuiltins::Target(section),
                     Ok(None) => options::CompileTargetBuiltins::None,
                     Err(err) => {
-                        self.log.add_error_fmt(
+                        transpiler.log_mut().add_error_fmt(
                             None,
                             bun_ast::Loc::EMPTY,
                             format_args!("{}", bstr::BStr::new(err.slice())),

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -187,6 +187,17 @@ pub(crate) fn run_task(
             task.ptr.cast::<$ty>()
         };
     }
+    /// `<$hop as TaskHop>::run` on the queued `ThisPtr`, SAFETY spelled once.
+    macro_rules! hop {
+        ($hop:ty) => {{
+            // SAFETY: §Dispatch — `task.tag` is `<$hop>::TAG`, set together with
+            // `task.ptr` from a `ThisPtr` whose pointee keeps itself alive for
+            // the queued task; not touched here after the call.
+            <$hop as bun_event_loop::TaskHop>::run(unsafe {
+                bun_ptr::ThisPtr::new(cast_ptr!(<$hop as bun_event_loop::TaskHop>::Target))
+            })
+        }};
+    }
     /// `CompressionStream::<T>::run_from_js_thread` takes `*mut T` (full
     /// allocation provenance — R-2) so its trailing `T::deref()` may free the box.
     macro_rules! compression_arm {
@@ -253,9 +264,7 @@ pub(crate) fn run_task(
             })?;
         }
         task_tag::JSBundleCompletionTask => {
-            crate::api::js_bundle_completion_task::JSBundleCompletionTask::on_complete_anytask(
-                cast_ptr!(crate::api::js_bundle_completion_task::JSBundleCompletionTask),
-            )?;
+            hop!(crate::api::js_bundle_completion_task::CompletionHop)?
         }
         task_tag::FetchTaskletPromiseSettle => {
             // SAFETY: boxed at the fetch completion site; the arm consumes it.
@@ -1229,6 +1238,15 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
             unsafe { <$ty as Taskable>::release_unrun(task.ptr.cast::<$ty>()) }
         }};
     }
+    /// `<$hop as TaskHop>::release_unrun` on the queued `ThisPtr`, SAFETY spelled once.
+    macro_rules! release_hop {
+        ($hop:ty) => {{
+            // SAFETY: as `release!`; the tag is `<$hop>::TAG`.
+            <$hop as bun_event_loop::TaskHop>::release_unrun(unsafe {
+                bun_ptr::ThisPtr::new(task.ptr.cast::<<$hop as bun_event_loop::TaskHop>::Target>())
+            })
+        }};
+    }
     match task.tag {
         task_tag::AnyTaskJob => {
             // The one erased tag: every payload is a `Job<C>` reached through its header.
@@ -1254,7 +1272,7 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
         task_tag::HotReloadTask => release!(hot_reloader::HotReloadTask),
         task_tag::WatchReloadTask => release!(hot_reloader::WatchReloadTask),
         task_tag::JSBundleCompletionTask => {
-            release!(crate::api::js_bundle_completion_task::JSBundleCompletionTask)
+            release_hop!(crate::api::js_bundle_completion_task::CompletionHop)
         }
         task_tag::JSCDeferredWorkTask => release!(JSCDeferredWorkTask),
         task_tag::ManagedTask => release!(ManagedTask),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1815,12 +1815,12 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
             // would still be dispatched against the finished pass. The build
             // runs on; its completion lands on the next file's global.
             ActiveHandle::Bundle(_) if reason == StopReason::TestIsolation => kept.push(kv.key),
-            // SAFETY: live until it unregisters in `on_complete_anytask`.
-            ActiveHandle::Bundle(c) => unsafe {
+            ActiveHandle::Bundle(c) => {
                 crate::api::js_bundle_completion_task::JSBundleCompletionTask::stop_for_vm_teardown(
-                    c.as_ptr(),
+                    // SAFETY: registered (from its `ThisPtr`) until `on_complete` unregisters ⇒ live.
+                    unsafe { bun_ptr::ThisPtr::new(c.as_ptr()) },
                 )
-            },
+            }
             // Live until it unregisters in `destroy_channel`.
             // SAFETY: registered ⇒ live; may free itself inside, not touched after.
             ActiveHandle::DnsResolver(r) => unsafe {

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -18,7 +18,7 @@ use bun_jsc::bun_string_jsc;
 use bun_ptr::{RefCount, RefPtr, ThisPtr};
 use bun_uws::{AnyRequest, AnyResponse};
 
-use crate::api::js_bundle_completion_task::JSBundleCompletionTask;
+use crate::api::js_bundle_completion_task::{BuildOutcome, JSBundleCompletionTask};
 use crate::api::js_bundler::js_bundler::{self as JSBundler, Config as JSBundlerConfig};
 use crate::api::output_file_jsc::OutputFileJsc as _;
 use crate::bake::dev_server::route_bundle;
@@ -477,7 +477,9 @@ impl Route {
         let mut completion_task = JSBundleCompletionTask::new(config, plugins, global);
         completion_task.started_at_ns = bun_core::util::Timespec::now_allow_mocked_time().ns();
         // While we're building, ensure this doesn't get freed.
-        completion_task.html_build_task = Some(RefPtr::from_this(this));
+        completion_task
+            .html_build_task
+            .set(Some(RefPtr::from_this(this)));
         this.state.set(State::Building);
         completion_task.schedule();
         Ok(())
@@ -495,19 +497,19 @@ impl Route {
     }
 
     /// Called by the build task, which holds a ref on this route across the call.
-    pub(crate) fn on_complete(&self, completion_task: &mut JSBundleCompletionTask) {
+    pub(crate) fn on_complete(&self, outcome: &mut BuildOutcome, started_at_ns: u64) {
         // Still allocated, even if it has been stopped and its JS wrapper
         // collected since: the route holds a pending request on it until
         // `finish_building` (see `schedule_bundle`).
         let server = self.server.get().expect("server set");
 
-        match &mut completion_task.result {
+        match &mut outcome.result {
             BundleV2Result::Err(err) => {
                 if bun_core::Environment::ENABLE_LOGS {
                     bun_output::scoped_log!(debug, "onComplete: err - {}", err);
                 }
                 let mut log = Log::init();
-                completion_task.log.clone_to_with_recycled(&mut log, true);
+                outcome.log.clone_to_with_recycled(&mut log, true);
                 self.set_build_error(server, log);
             }
             BundleV2Result::Value(bundle) => 'bundle: {
@@ -521,7 +523,7 @@ impl Route {
 
                 if server.config().is_development() {
                     let now = bun_core::util::Timespec::now_allow_mocked_time().ns();
-                    let duration = now.saturating_sub(completion_task.started_at_ns);
+                    let duration = now.saturating_sub(started_at_ns);
                     let duration_f64 = duration as f64 / 1_000_000_000.0;
 
                     bun_output::print_elapsed(duration_f64);

--- a/src/threading/unbounded_queue.rs
+++ b/src/threading/unbounded_queue.rs
@@ -63,6 +63,26 @@ pub unsafe trait Linked: Sized {
     unsafe fn link(item: *mut Self) -> *const Link<Self>;
 }
 
+/// `unsafe impl Linked for $T` through its embedded `$field: Link<$T>`: the
+/// projection is a fixed field, which is the whole of [`Linked`]'s contract.
+///
+/// ```ignore
+/// bun_threading::intrusive_link!(NetworkTask, next);
+/// ```
+#[macro_export]
+macro_rules! intrusive_link {
+    ($T:ty, $field:ident) => {
+        // SAFETY: always projects the same embedded `Link<Self>` field.
+        unsafe impl $crate::Linked for $T {
+            #[inline]
+            unsafe fn link(item: *mut Self) -> *const $crate::Link<Self> {
+                // SAFETY: `item` is valid and aligned per `UnboundedQueue`'s contract.
+                unsafe { ::core::ptr::addr_of!((*item).$field) }
+            }
+        }
+    };
+}
+
 // SAFETY: all four accessors route through `T::link(item)`, which by `Linked`'s
 // contract returns the same embedded `Link<Self>` field every time; `Link` is a
 // `#[repr(transparent)]` `AtomicPtr`, so atomic ops are truly atomic at the

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -79,22 +79,12 @@
       "Store"
     ]
   },
-  "src/runtime/api/JSTranspiler.rs": {
-    "unsafe impl Send": [
-      "TransformTask"
-    ]
-  },
   "src/runtime/api/bun/Terminal.rs": {
     "thread spawn": 1
   },
   "src/runtime/api/glob.rs": {
     "unsafe impl Send": [
       "WalkTask"
-    ]
-  },
-  "src/runtime/api/js_bundle_completion_task.rs": {
-    "unsafe impl Send": [
-      "JSBundleCompletionTask"
     ]
   },
   "src/runtime/bake/production.rs": {


### PR DESCRIPTION
### What

Same programme as #40055 … #40399, applied to the JS-facing bundler API. **Stacked on #40383** (base branch `claude/modload-zero-unsafe`, for `bun_jsc::Job` / `JobTranspiler`); retarget to main once that lands. Bundler *internals* (`bundle_v2`/`ParseTask`/`LinkerContext`) are out of scope here — only the completion-task/plugin boundary is typed.

`src/runtime/api/JSBundler.rs` 27 → 1 (all-`safe fn` extern block), `js_bundle_completion_task.rs` 26 → **0**, `JSTranspiler.rs` 22 → 0.

- **`JSBundleCompletionTask`** is split into a JS-side `JSBundleCompletionTask` (`RefCounted`, typed `build_ref` slot, completion delivered via a `TaskHop` on its `ThisPtr`, registered as `ActiveHandle::Bundle` for VM teardown), a bundle-side `BundleJob` (`Send` by construction, owned and dropped by the bundle thread), and `BuildShared` (`Arc`: cancel/stage atomics, `Guarded<Option<Ticket>>`, `Guarded<Option<Box<BuildOutcome>>>`). The old `Releasing` spin state is gone since the halves are separate allocations. `bun_bundler::BundleThread` takes `Box<C>` and drops it on the bundle thread; `bundle_v2::dispatch::CompletionDispatch` trait + `Arc<dyn CompletionDispatch>` replace the vtable struct and opaque marker; `BundleV2.file_map: Option<Arc<FileMap>>`, `BundleOptions.optimize_imports: Option<Arc<StringSet>>`.
- **Plugin bridge**: `JSBundlerPlugin__onResolveAsync/onLoadAsync/onDefer/addErrorResolve/addErrorLoad/answerCancelledResolve/answerCancelledLoad` are `HOST_EXPORT`s taking `&mut Resolve`/`&mut Load`/`&JSGlobalObject`; C++ `JSBundlerPlugin` callbacks take the global instead of the removed `config` pointer (`JSBundlerPlugin__setConfig` removed); `Resolve/Load::{answer, plugin(), notify_deferred}` live on the bundler side, null-checked.
- **`Bun.Transpiler`** holds `JsCell<OwnedTranspiler>`; per-call re-aiming through `with_call`/`TranspilerCall` (restricted handle, restores the previous arena/log so nested calls match); `TransformTask` is `Send` by construction (tsconfig bits snapshotted at schedule; `JobTranspiler` copy via `OwnedTranspiler::new_job`, with a job-copy-alive assert on `with_mut`).
- Primitives: `bun_bundler::transpiler::{OwnedTranspiler, TranspilerCall}` (`OwnedTranspiler` is `!Send/!Sync`; inner `Send/Sync` with SAFETY), `BundleThread::singleton::{enqueue(Box<C>), wake}`, `bun_threading::intrusive_link!`, `bun_event_loop::TaskHop` + dispatch `hop!`/`release_hop!` (same hunks as #40202).

Pre-existing issues noticed (unchanged): `Transpiler::for_worker` deep-clones `BundleOptions` per pool worker per `Bun.build` (~4 % of bundle-thread instructions); `html_build_task`'s `RefPtr` still leaks on the cancelled-at-teardown path.

**Perf** (release, `taskset -c 56-63`, `perf stat -e instructions:u`, interleaved): `transpiler.transformSync` ×1e4 **+0.01 %**. `Bun.build` of a 50-file project ×30 **+0.32 %**, ×100 +0.29–0.30 %; startup-only −0.15 %. Symbol-level sampling puts the delta in `Transpiler::for_worker` and `each_impl::<scan_imports_and_exports>` on the bundle thread — neither changed here (consistent with LTO layout perturbation from the `BundleOptions` field-type change); the JS thread is < 1 % of the profile. This is at the 0.3 % bar, stated rather than rounded away.

### Testing

Debug+ASAN: bun-build-api 56/56, bundler_plugin 56, bundler_defer 12, native-plugin 19, plugins.test 47, bundler_compile 74/75 (`HelloWorldWithProcessVersionsBun` fails identically on a main debug build — debug version string), bundler_compile_autoload 23, bundler_splitting 13, bun-build-compile 15, -sourcemap 9, -wasm 1, transpiler.test.js 190, repl-transform 36, tsconfig-uaf 3, error-gc-uaf 1, utf16-loader 5, parse-error-column 7, unsupported-loader 33, macro-test 22, decorators 24, decorator-metadata 5, jsx-tsconfig 2, bundler_html 22, bake/dev/plugins 3, esbuild/default 151/0, source lints. Hand-driven: `Bun.build` ×200 sequential / ×20 concurrent (temporary counter: both halves back to 0), onLoad throw / reject / never-resolves-then-exit, onResolve external, `.defer()`, `Bun.build({compile})` (binary runs), `files` + `optimizeImports`, a Worker terminated mid-build ×5 + completed ×1 (all released), `transform()` ×1e4 concurrent, `transformSync`/`scan`/`scanImports`/macros — exit 0, no ASAN output. clippy clean on bundler/runtime/threading/event_loop; `rust-check-all` windows-msvc + aarch64-darwin pass.
