### PR TITLE
semver: fix 8-byte non-inlinable strings and cursor-relative tag offsets

### DIFF
--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -144,15 +144,9 @@ impl PackageManager {
             let mut version = parsed.version.min();
             let total = (version.tag.build.len() + version.tag.pre.len()) as usize;
             if total > 0 {
-                let len_before = tags_buf.len();
-                // `clone_into` writes exactly `total` bytes (build.len + pre.len)
-                // into `available` and advances it; zero-fill the tail first so
-                // we can hand it out as a safe `&mut [u8]` instead of slicing
-                // raw spare capacity.
-                tags_buf.resize(len_before + total, 0);
-                let mut available = &mut tags_buf[len_before..];
-                let new_version = version.clone_into(name, &mut available);
-                version = new_version;
+                let mut offset = tags_buf.len();
+                tags_buf.resize(offset + total, 0);
+                version = version.clone_into(name, tags_buf, &mut offset);
             }
 
             list.push(version);

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1846,12 +1846,11 @@ fn record_updating_package_versions(manager: &mut PackageManager) {
             let tag_total = original.tag.pre.len() + original.tag.build.len();
             if tag_total > 0 {
                 let mut tag_buf = vec![0u8; tag_total].into_boxed_slice();
-                let mut ptr = &mut tag_buf[..];
-                original.tag = original_resolution
-                    .npm()
-                    .version
-                    .tag
-                    .clone_into(&lockfile.buffers.string_bytes, &mut ptr);
+                original.tag = original_resolution.npm().version.tag.clone_into(
+                    &lockfile.buffers.string_bytes,
+                    &mut tag_buf,
+                    &mut 0,
+                );
 
                 entry_ptr.original_version_string_buf = tag_buf;
             }

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -576,8 +576,7 @@ pub(crate) fn register_moved(
         }
         let mut tag_buf =
             vec![0u8; current.tag.pre.len() + current.tag.build.len()].into_boxed_slice();
-        let mut cursor: &mut [u8] = &mut tag_buf;
-        let original = current.clone_into(buf, &mut cursor);
+        let original = current.clone_into(buf, &mut tag_buf, &mut 0);
         *entry.value_ptr = PackageUpdateInfo {
             original_version_literal: Box::default(),
             written_back: false,

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1341,7 +1341,7 @@ impl<'a> Package<'a> {
 
     pub(crate) fn clone(self, builder: &mut Semver::semver_string::Builder) -> PackageExternal {
         PackageExternal {
-            name: builder.append_utf8_without_pool::<Semver::String>(self.name, 0),
+            name: builder.append_without_pool::<Semver::String>(self.name, 0),
         }
     }
 

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -114,13 +114,15 @@ impl<T: VersionInt> VersionType<T> {
         Self::parse(SlicedString { buf: slice, slice })
     }
 
-    pub fn clone_into(self, slice: &[u8], buf: &mut &mut [u8]) -> Self {
+    /// Copies the tag strings into `buf` at `*offset` (advancing it); the
+    /// returned version's strings are offsets into the whole of `buf`.
+    pub fn clone_into(self, slice: &[u8], buf: &mut [u8], offset: &mut usize) -> Self {
         Self {
             major: self.major,
             minor: self.minor,
             patch: self.patch,
             _tag_padding: Default::default(),
-            tag: self.tag.clone_into(slice, buf),
+            tag: self.tag.clone_into(slice, buf, offset),
         }
     }
 
@@ -1016,29 +1018,21 @@ impl Tag {
         self.pre.order(&rhs.pre, lhs_buf, rhs_buf)
     }
 
-    pub fn clone_into(self, slice: &[u8], buf: &mut &mut [u8]) -> Tag {
-        let pre: SemverString;
-        let build: SemverString;
-
-        if self.pre.is_inline() {
-            pre = self.pre.value;
-        } else {
-            let pre_slice = self.pre.slice(slice);
-            buf[..pre_slice.len()].copy_from_slice(pre_slice);
-            // reshaped for borrowck —
-            // capture the init args before advancing `buf`.
-            pre = SemverString::init(buf, &buf[0..pre_slice.len()]);
-            *buf = &mut core::mem::take(buf)[pre_slice.len()..];
-        }
-
-        if self.build.is_inline() {
-            build = self.build.value;
-        } else {
-            let build_slice = self.build.slice(slice);
-            buf[..build_slice.len()].copy_from_slice(build_slice);
-            build = SemverString::init(buf, &buf[0..build_slice.len()]);
-            *buf = &mut core::mem::take(buf)[build_slice.len()..];
-        }
+    /// Copies `pre`/`build` into `buf` at `*offset` (advancing it); the
+    /// returned strings are offsets into the whole of `buf`.
+    pub fn clone_into(self, slice: &[u8], buf: &mut [u8], offset: &mut usize) -> Tag {
+        let mut copy = |s: ExternalString| -> SemverString {
+            if s.is_inline() {
+                return s.value;
+            }
+            let bytes = s.slice(slice);
+            let start = *offset;
+            *offset += bytes.len();
+            buf[start..*offset].copy_from_slice(bytes);
+            SemverString::init(buf, &buf[start..*offset])
+        };
+        let pre = copy(self.pre);
+        let build = copy(self.build);
 
         Tag {
             pre: ExternalString {
@@ -1209,5 +1203,39 @@ impl<T: VersionInt> Default for ParseResult<T> {
             version: Partial::default(),
             len: 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Version;
+    use crate::sliced_string::SlicedString;
+
+    fn parse(s: &[u8]) -> Version {
+        let r = Version::parse(SlicedString::init(s, s));
+        assert!(r.valid);
+        r.version.min()
+    }
+
+    #[test]
+    fn clone_into_offsets_are_relative_to_the_whole_buffer() {
+        let a_src: &[u8] = b"1.0.0-canary.20240101+build.aaaaaaaa";
+        let b_src: &[u8] = b"1.0.0-canary.20240315+build.bbbbbbbb";
+        let a = parse(a_src);
+        let b = parse(b_src);
+
+        let mut buf = vec![0u8; 128];
+        let mut offset = 0usize;
+        let a2 = a.clone_into(a_src, &mut buf, &mut offset);
+        let b2 = b.clone_into(b_src, &mut buf, &mut offset);
+        assert_eq!(
+            offset,
+            2 * ("canary.20240101".len() + "build.aaaaaaaa".len())
+        );
+
+        assert_eq!(a2.tag.pre.slice(&buf), b"canary.20240101");
+        assert_eq!(a2.tag.build.slice(&buf), b"build.aaaaaaaa");
+        assert_eq!(b2.tag.pre.slice(&buf), b"canary.20240315");
+        assert_eq!(b2.tag.build.slice(&buf), b"build.bbbbbbbb");
     }
 }

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -915,40 +915,8 @@ pub mod semver_string {
             self.append_with_hash::<T>(slice_, Self::string_hash(slice_))
         }
 
-        pub fn append_utf8_without_pool<T: BuilderStringType>(
-            &mut self,
-            slice_: &[u8],
-            hash: u64,
-        ) -> T {
-            if slice_.len() <= String::MAX_INLINE_LEN && strings::is_all_ascii(slice_) {
-                return T::from_init(self.allocated_slice(), slice_, hash);
-            }
-
-            debug_assert!(self.len <= self.cap); // didn't count everything
-            debug_assert!(self.ptr.is_some()); // must call allocate first
-
-            // reshaped for borrowck — compute final slice range, then borrow once.
-            let start = self.len;
-            let end = self.cap;
-            {
-                let dst = &mut self.ptr.as_mut().unwrap()[start..end];
-                dst[..slice_.len()].copy_from_slice(slice_);
-            }
-            self.len += slice_.len();
-
-            debug_assert!(self.len <= self.cap);
-
-            let allocated = &self.ptr.as_ref().unwrap()[0..self.cap];
-            let final_slice = &allocated[start..start + slice_.len()];
-            T::from_init(allocated, final_slice, hash)
-        }
-
         // SlicedString is not supported due to inline strings.
-        pub(crate) fn append_without_pool<T: BuilderStringType>(
-            &mut self,
-            slice_: &[u8],
-            hash: u64,
-        ) -> T {
+        pub fn append_without_pool<T: BuilderStringType>(&mut self, slice_: &[u8], hash: u64) -> T {
             if String::can_inline(slice_) {
                 return T::from_init(self.allocated_slice(), slice_, hash);
             }

--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -875,17 +875,17 @@ pub mod semver_string {
         pub fn count(&mut self, slice_: &[u8]) {
             self.count_with_hash(
                 slice_,
-                if slice_.len() >= String::MAX_INLINE_LEN {
-                    Self::string_hash(slice_)
-                } else {
+                if String::can_inline(slice_) {
                     u64::MAX
+                } else {
+                    Self::string_hash(slice_)
                 },
             )
         }
 
         #[inline]
         pub(crate) fn count_with_hash(&mut self, slice_: &[u8], hash: u64) {
-            if slice_.len() <= String::MAX_INLINE_LEN {
+            if String::can_inline(slice_) {
                 return;
             }
 
@@ -920,10 +920,8 @@ pub mod semver_string {
             slice_: &[u8],
             hash: u64,
         ) -> T {
-            if slice_.len() <= String::MAX_INLINE_LEN {
-                if strings::is_all_ascii(slice_) {
-                    return T::from_init(self.allocated_slice(), slice_, hash);
-                }
+            if slice_.len() <= String::MAX_INLINE_LEN && strings::is_all_ascii(slice_) {
+                return T::from_init(self.allocated_slice(), slice_, hash);
             }
 
             debug_assert!(self.len <= self.cap); // didn't count everything
@@ -951,7 +949,7 @@ pub mod semver_string {
             slice_: &[u8],
             hash: u64,
         ) -> T {
-            if slice_.len() <= String::MAX_INLINE_LEN {
+            if String::can_inline(slice_) {
                 return T::from_init(self.allocated_slice(), slice_, hash);
             }
             debug_assert!(self.len <= self.cap); // didn't count everything
@@ -978,7 +976,7 @@ pub mod semver_string {
             slice_: &[u8],
             hash: u64,
         ) -> T {
-            if slice_.len() <= String::MAX_INLINE_LEN {
+            if String::can_inline(slice_) {
                 return T::from_init(self.allocated_slice(), slice_, hash);
             }
 
@@ -1017,4 +1015,27 @@ pub mod semver_string {
         core::mem::size_of::<String>() == core::mem::size_of::<Pointer>(),
         "String types must be the same size",
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::semver_string::{Builder, String};
+
+    #[test]
+    fn builder_allocates_eight_byte_non_ascii_strings() {
+        // 8 bytes with the high bit set on the last byte cannot be inlined
+        // (that bit marks an out-of-line pointer), so the builder must count
+        // and copy it like any longer string.
+        let s: &[u8] = b"abcdef\xc3\xa9";
+        assert_eq!(s.len(), 8);
+        assert!(!String::can_inline(s));
+
+        let mut builder = Builder::default();
+        builder.count(s);
+        assert_eq!(builder.cap, 8);
+        builder.allocate().unwrap();
+        let out: String = builder.append::<String>(s);
+        assert_eq!(builder.len, 8);
+        assert_eq!(out.slice(builder.allocated_slice()), s);
+    }
 }

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2648,7 +2648,7 @@ describe.concurrent("bun-install", () => {
         join(ctx.package_dir, "package.json"),
         JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { bar: "0.0.2" } }),
       );
-      const { stderr, exited } = spawn({
+      const { stdout, stderr, exited } = spawn({
         cmd: [bunExe(), "install", "--save-text-lockfile"],
         cwd: ctx.package_dir,
         stdout: "pipe",
@@ -2656,7 +2656,7 @@ describe.concurrent("bun-install", () => {
         stderr: "pipe",
         env,
       });
-      const err = await stderr.text();
+      const [, err] = await Promise.all([stdout.text(), stderr.text()]);
       expect(err).toContain("Saved lockfile");
       expect(err).not.toContain("error:");
       const lock = await file(join(ctx.package_dir, "bun.lock")).text();

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -2632,6 +2632,39 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  it("records an 8-byte non-ASCII version range from a manifest", async () => {
+    // 8 bytes whose last byte has the high bit set cannot be stored inline in
+    // the lockfile's small-string encoding; it has to be copied like a longer
+    // string. "1.0.0-é" is 6 ASCII bytes + 0xC3 0xA9.
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(
+        ctx,
+        dummyRegistryForContext(ctx, urls, {
+          "0.0.2": { peerDependencies: { quux: "1.0.0-é" }, peerDependenciesMeta: { quux: { optional: true } } },
+        }),
+      );
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { bar: "0.0.2" } }),
+      );
+      const { stderr, exited } = spawn({
+        cmd: [bunExe(), "install", "--save-text-lockfile"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await stderr.text();
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      const lock = await file(join(ctx.package_dir, "bun.lock")).text();
+      expect(lock).toContain(`"peerDependencies": { "quux": "1.0.0-é" }`);
+      expect(await exited).toBe(0);
+    });
+  });
+
   it("should handle ^0.0.2-alpha.3+b4d in dependencies", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];


### PR DESCRIPTION
### What does this PR do?

The lockfile's small-string type (`semver::String`) stores up to 8 bytes inline unless the last byte has its high bit set, which marks an out-of-line `{offset, len}` pointer. Two places got that contract wrong:

- `semver::Builder::{count, append, append_without_pool, append_with_hash}` checked `len <= 8` instead of `String::can_inline`, so an 8-byte string ending in a byte ≥ 0x80 was never counted or copied into the string buffer and was recorded as a pointer computed from a slice that isn't in the buffer. In release it reads back as `""` (debug builds assert). This is reachable from a registry manifest: a dependency/peer range such as `"1.0.0-é"` was written to `bun.lock` as `"quux": ""`. `lockfile::StringBuilder` already used `can_inline`; `Builder` now does too.
- `Version::clone_into` / `Tag::clone_into` received only the advancing write cursor (`&mut &mut [u8]`), so the strings they produced were offsets from the cursor, not from the buffer they're later sliced against: `build` always got offset 0 (aliasing `pre`), and when several versions are cloned into one buffer (the disk-cache version list used by `--prefer-offline` auto-install) every version after the first pointed at the first one's tag text. They now take the destination buffer and a write offset; the three callers pass `(&mut buf, &mut 0)` / `(tags_buf, &mut offset)`.

No allocation or copy counts change.

### How did you verify your code works?

New case in `test/cli/install/bun-install.test.ts` serves a manifest whose version has `peerDependencies: { quux: "1.0.0-é" }` and checks the text lockfile; on 1.4.0 it records `"quux": ""`, with this change `"quux": "1.0.0-é"`. `#[test]`s in `bun_semver` cover the builder and `clone_into` with two pre+build versions in one buffer.