### PR TITLE
Compiled executables: prefetch the startup bytecode on a cold start

### DIFF
--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -37,6 +37,9 @@ pub struct OutputFile {
     /// Position of this chunk in the order the runtime is expected to load it
     /// (see `chunk_load_order`); `u32::MAX` for anything that is not a chunk.
     pub load_order: u32,
+    /// The chunk is in the entry point's static import closure, i.e. it loads
+    /// before the first `import()`.
+    pub loads_at_startup: bool,
 }
 
 impl OutputFile {
@@ -63,6 +66,7 @@ impl OutputFile {
             source_index: IndexOptional::NONE,
             bake_extra: BakeExtra::default(),
             load_order: u32::MAX,
+            loads_at_startup: false,
         }
     }
 }
@@ -211,6 +215,7 @@ impl OutputFile {
             referenced_css_chunks: options.referenced_css_chunks,
             bake_extra: options.bake_extra,
             load_order: u32::MAX,
+            loads_at_startup: false,
         }
     }
 

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1316,10 +1316,13 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         }
     }
 
-    // Only `StandaloneModuleGraph::to_bytes` reads `load_order`.
+    // Only `StandaloneModuleGraph::to_bytes` reads these.
     if is_compile {
-        for (chunk_index, &position) in chunk_load_order(c, chunks).iter().enumerate() {
-            output_files.output_files[chunk_index].load_order = position;
+        let (order, startup_count) = chunk_load_order(chunks, &output_files.output_files);
+        for (chunk_index, &position) in order.iter().enumerate() {
+            let file = &mut output_files.output_files[chunk_index];
+            file.load_order = position;
+            file.loads_at_startup = position < startup_count;
         }
     }
 
@@ -1436,23 +1439,28 @@ fn append_internal_module_bytecode(
 /// load it: the entry point's static cross-chunk imports in evaluation order,
 /// then the closures of its dynamic imports, breadth-first. The standalone
 /// module graph lays modules out by this so booting faults in one run of pages
-/// rather than one page per chunk scattered across the payload.
-fn chunk_load_order(c: &LinkerContext, chunks: &[Chunk]) -> Vec<u32> {
-    let entry_point_kinds = c.graph.files.items_entry_point_kind();
+/// rather than one page per chunk scattered across the payload. Also returns
+/// how many of the positions make up the static closure of the entry point
+/// the executable runs: the first server-side one, as `to_bytes` picks it.
+/// `output_files[i]` is chunk `i`'s output file.
+fn chunk_load_order(chunks: &[Chunk], output_files: &[options::OutputFile]) -> (Vec<u32>, u32) {
     let mut visited = AutoBitSet::init_empty(chunks.len()).expect("oom");
     let mut order: Vec<u32> = Vec::with_capacity(chunks.len());
-    let mut dynamic_frontier: std::collections::VecDeque<u32> = chunks
-        .iter()
-        .enumerate()
-        .filter(|(_, chunk)| {
-            chunk.entry_point.is_entry_point()
-                && entry_point_kinds[chunk.entry_point.source_index() as usize].output_kind()
-                    == options::OutputKind::EntryPoint
-        })
-        .map(|(i, _)| i as u32)
-        .collect();
+    let entry_points = |side_is_client: bool| {
+        output_files[..chunks.len()]
+            .iter()
+            .enumerate()
+            .filter(move |(_, file)| {
+                file.output_kind == options::OutputKind::EntryPoint
+                    && (file.side == Some(options::Side::Client)) == side_is_client
+            })
+            .map(|(i, _)| i as u32)
+    };
+    let mut dynamic_frontier: std::collections::VecDeque<u32> =
+        entry_points(false).chain(entry_points(true)).collect();
 
     let mut stack: Vec<(u32, usize)> = Vec::new();
+    let mut startup_count: Option<u32> = None;
     while let Some(root) = dynamic_frontier.pop_front() {
         if visited.is_set(root as usize) {
             continue;
@@ -1481,6 +1489,8 @@ fn chunk_load_order(c: &LinkerContext, chunks: &[Chunk]) -> Vec<u32> {
                 }
             }
         }
+        // The first root is the entry point; everything placed so far is its static closure.
+        startup_count.get_or_insert(order.len() as u32);
     }
     for chunk_index in 0..chunks.len() as u32 {
         if !visited.is_set(chunk_index as usize) {
@@ -1492,7 +1502,7 @@ fn chunk_load_order(c: &LinkerContext, chunks: &[Chunk]) -> Vec<u32> {
     for (i, &chunk_index) in order.iter().enumerate() {
         position[chunk_index as usize] = i as u32;
     }
-    position
+    (position, startup_count.unwrap_or(0))
 }
 
 use crate::EntryPoint;

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -49,6 +49,9 @@ pub struct StandaloneModuleGraph {
     pub builtin_bytecode: Vec<(u32, *mut [u8])>,
     /// The one shared bytecode string table (`JSC::EncoderStringTable::serialize`) every chunk's payload references by ordinal; installed on the VM's `DecoderStringTable` at startup.
     pub bytecode_string_table: &'static [u8],
+    /// The first `startup_module_count` of `files` (table order = load order) are the entry
+    /// point's static import closure, i.e. what loads before the first `import()`.
+    pub startup_module_count: u32,
 }
 
 // We never want to hit the filesystem for these files
@@ -403,6 +406,57 @@ mod macho {
         // SAFETY: section data is `length` bytes immediately following the u64 header.
         Some((unsafe { slice_ptr.add(data_offset) }, length as usize))
     }
+
+    unsafe extern "C" {
+        /// `<mach-o/getsect.h>`: the named segment's load command in the main executable.
+        fn getsegbyname(
+            segname: *const core::ffi::c_char,
+        ) -> *const bun_sys::macho::segment_command_64;
+        /// `<mach-o/dyld.h>`: the path dyld loaded image `image_index` from.
+        fn _dyld_get_image_name(image_index: u32) -> *const core::ffi::c_char;
+    }
+
+    /// `F_RDADVISE` on the executable for the file bytes backing `[lo, hi)`: an
+    /// asynchronous read into the page cache that returns at once.
+    /// (`MADV_WILLNEED` blocks on Darwin until the pages are in, so it is no use
+    /// for overlapping I/O with startup.)
+    pub(super) fn read_ahead(lo: usize, hi: usize) {
+        // SAFETY: NUL-terminated segment name; returns null or a pointer into the
+        // main image's load commands, which live as long as the process.
+        let segment = unsafe { getsegbyname(c"__BUN".as_ptr()) };
+        if segment.is_null() {
+            return;
+        }
+        // SAFETY: non-null per the check above.
+        let segment = unsafe { &*segment };
+        let slide = bun_sys::c::_dyld_get_image_vmaddr_slide(0) as usize;
+        let segment_start = (segment.vmaddr as usize).wrapping_add(slide);
+        let segment_end = segment_start.saturating_add(segment.filesize as usize);
+        if lo < segment_start || hi > segment_end {
+            return;
+        }
+        // SAFETY: image 0 is the main executable; dyld keeps its NUL-terminated
+        // path alive for the life of the process.
+        let exe_path = unsafe { bun_core::ZStr::from_c_ptr(_dyld_get_image_name(0)) };
+        let Ok(file) = bun_sys::File::open(exe_path, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0)
+        else {
+            return;
+        };
+        let advisory = libc::radvisory {
+            ra_offset: (lo - segment_start + segment.fileoff as usize) as libc::off_t,
+            ra_count: (hi - lo).min(i32::MAX as usize) as core::ffi::c_int,
+        };
+        // SAFETY: `advisory` is a valid `struct radvisory` for the duration of
+        // the call; the fd stays open until `file` drops below.
+        let rc = unsafe { libc::fcntl(file.fd().native(), libc::F_RDADVISE, &advisory) };
+        bun_core::scoped_log!(
+            super::StandaloneModuleGraph,
+            "prefetch: F_RDADVISE offset={} count={} rc={}",
+            advisory.ra_offset,
+            advisory.ra_count,
+            rc
+        );
+    }
 }
 
 #[cfg(windows)]
@@ -473,6 +527,36 @@ mod elf {
         }
         // SAFETY: payload_len bytes follow the 8-byte header at `target`.
         Some((unsafe { target.add(8) }, payload_len as usize))
+    }
+
+    /// `MADV_WILLNEED` over `[lo, hi)`: queues page-cache readahead for the
+    /// file bytes backing the mapping and returns once the I/O is submitted.
+    /// Issued in 128 KiB pieces because one call reads at most
+    /// `max(bdi->io_pages, ra_pages)` (device dependent, 128 KiB on some).
+    pub(super) fn read_ahead(lo: usize, hi: usize) {
+        const PIECE: usize = 128 * 1024;
+        let mut at = lo & !(bun_alloc::page_size() - 1);
+        while at < hi {
+            let len = PIECE.min(hi - at);
+            // SAFETY: `[at, at + len)` lies inside the mapped executable
+            // image; `MADV_WILLNEED` neither reads nor writes through it.
+            let rc =
+                unsafe { libc::madvise(at as *mut core::ffi::c_void, len, libc::MADV_WILLNEED) };
+            if rc != 0 {
+                bun_core::scoped_log!(
+                    super::StandaloneModuleGraph,
+                    "prefetch: madvise failed errno={}",
+                    bun_sys::last_errno()
+                );
+                return;
+            }
+            at += len;
+        }
+        bun_core::scoped_log!(
+            super::StandaloneModuleGraph,
+            "prefetch: MADV_WILLNEED {} bytes",
+            hi - lo
+        );
     }
 }
 
@@ -673,7 +757,10 @@ bitflags::bitflags! {
         const HAS_BUILTIN_BYTECODE          = 1 << 6;
         /// After the builtin-bytecode table: one `StringPointer` to the shared bytecode string table (`JSC::EncoderStringTable::serialize`), which every chunk's payload references by ordinal.
         const HAS_BYTECODE_STRING_TABLE     = 1 << 7;
-        // _padding: u24
+        /// After the string-table pointer: `u32` count of leading modules (in table order) that make up the
+        /// entry point's static import closure, i.e. load before the first `import()`; `prefetch_startup_pages` reads ahead what they need.
+        const HAS_STARTUP_MODULE_COUNT      = 1 << 8;
+        // _padding: u23
     }
 }
 
@@ -704,6 +791,7 @@ impl StandaloneModuleGraph {
                 flags: Flags::default(),
                 builtin_bytecode: Vec::new(),
                 bytecode_string_table: &[],
+                startup_module_count: 0,
             });
         }
 
@@ -726,21 +814,6 @@ impl StandaloneModuleGraph {
         // local (`CompiledModuleGraphFile` is `Copy`/POD), so no `&T` ever points at unaligned memory.
         let modules_list_count = modules_list_bytes.len() / size_of::<CompiledModuleGraphFile>();
         let modules_list_base = modules_list_bytes.as_ptr();
-        let source_hashes: Option<&[u8]> = if offsets.flags.contains(Flags::HAS_SOURCE_HASHES) {
-            // SAFETY: written by `to_bytes` directly after the module table; read-only subrange.
-            Some(unsafe {
-                slice_to(
-                    raw_const,
-                    raw_len,
-                    StringPointer {
-                        offset: offsets.modules_ptr.offset + offsets.modules_ptr.length,
-                        length: (modules_list_count * size_of::<u32>()) as u32,
-                    },
-                )
-            })
-        } else {
-            None
-        };
 
         if offsets.entry_point_id as usize > modules_list_count {
             return Err(crate::Error::CorruptedModuleGraphEntryPointIDIsGreaterThanModuleListCount);
@@ -751,24 +824,42 @@ impl StandaloneModuleGraph {
             // SAFETY: callers pass offsets of records `to_bytes` wrote inside `[0, raw_len)`; unaligned-safe read.
             unsafe { core::ptr::read_unaligned(raw_const.add(at).cast::<u32>()) }
         };
+
+        // The optional records `to_bytes` chains directly after the module table, in `Flags` bit order.
+        let mut record_at =
+            offsets.modules_ptr.offset as usize + offsets.modules_ptr.length as usize;
+
+        let source_hashes: Option<&[u8]> = if offsets.flags.contains(Flags::HAS_SOURCE_HASHES) {
+            let length = modules_list_count * size_of::<u32>();
+            // SAFETY: written by `to_bytes` directly after the module table; read-only subrange.
+            let hashes = unsafe {
+                slice_to(
+                    raw_const,
+                    raw_len,
+                    StringPointer {
+                        offset: record_at as u32,
+                        length: length as u32,
+                    },
+                )
+            };
+            record_at += length;
+            Some(hashes)
+        } else {
+            None
+        };
+
         let mut builtin_bytecode: Vec<(u32, *mut [u8])> = Vec::new();
         if offsets.flags.contains(Flags::HAS_BUILTIN_BYTECODE) {
-            let table_offset = offsets.modules_ptr.offset as usize
-                + offsets.modules_ptr.length as usize
-                + if source_hashes.is_some() {
-                    modules_list_count * size_of::<u32>()
-                } else {
-                    0
-                };
-            let count = read_u32(table_offset) as usize;
+            let count = read_u32(record_at) as usize;
+            record_at += size_of::<u32>();
             builtin_bytecode.reserve(count);
-            for i in 0..count {
-                let record = table_offset + size_of::<u32>() + i * 3 * size_of::<u32>();
-                let id = read_u32(record);
+            for _ in 0..count {
+                let id = read_u32(record_at);
                 let pointer = StringPointer {
-                    offset: read_u32(record + 4),
-                    length: read_u32(record + 8),
+                    offset: read_u32(record_at + 4),
+                    length: read_u32(record_at + 8),
                 };
+                record_at += 3 * size_of::<u32>();
                 // SAFETY: same provenance rules as `File::bytecode`: a writable subrange JSC may patch in place.
                 let bytes = unsafe { slice_to_mut(raw_ptr, raw_len, pointer) };
                 builtin_bytecode.push((id, bytes));
@@ -777,32 +868,24 @@ impl StandaloneModuleGraph {
 
         let bytecode_string_table: &'static [u8] =
             if offsets.flags.contains(Flags::HAS_BYTECODE_STRING_TABLE) {
-                let builtin_count = if offsets.flags.contains(Flags::HAS_BUILTIN_BYTECODE) {
-                    builtin_bytecode.len()
-                } else {
-                    0
-                };
-                let record_at = offsets.modules_ptr.offset as usize
-                    + offsets.modules_ptr.length as usize
-                    + if source_hashes.is_some() {
-                        modules_list_count * size_of::<u32>()
-                    } else {
-                        0
-                    }
-                    + if offsets.flags.contains(Flags::HAS_BUILTIN_BYTECODE) {
-                        size_of::<u32>() + builtin_count * 3 * size_of::<u32>()
-                    } else {
-                        0
-                    };
                 let ptr = StringPointer {
                     offset: read_u32(record_at),
                     length: read_u32(record_at + 4),
                 };
+                record_at += 2 * size_of::<u32>();
                 // SAFETY: `to_bytes` placed the serialized table via `append_bytecode_aligned` into a read-only, disjoint subrange.
                 unsafe { slice_to(raw_const, raw_len, ptr) }
             } else {
                 &[]
             };
+
+        let startup_module_count = if offsets.flags.contains(Flags::HAS_STARTUP_MODULE_COUNT)
+            && record_at + size_of::<u32>() <= raw_len
+        {
+            read_u32(record_at)
+        } else {
+            0
+        };
 
         let mut modules = StringArrayHashMap::<File>::new();
         modules.reserve(modules_list_count);
@@ -875,6 +958,7 @@ impl StandaloneModuleGraph {
             );
         }
 
+        let module_count = modules.count();
         modules.lock_pointers(); // make the pointers stable forever
 
         // Keys are posix-separated already (see `to_bytes`), so byte-scan for `/`.
@@ -906,6 +990,7 @@ impl StandaloneModuleGraph {
             flags: offsets.flags,
             builtin_bytecode,
             bytecode_string_table,
+            startup_module_count: startup_module_count.min(module_count as u32),
         })
     }
 
@@ -1084,7 +1169,7 @@ pub(crate) fn to_bytes(
     string_builder.cap +=
         (size_of::<CompiledModuleGraphFile>() + size_of::<u32>()) * output_files.len();
     string_builder.cap += TRAILER.len();
-    string_builder.cap += 16 + size_of::<u32>();
+    string_builder.cap += 16 + 2 * size_of::<u32>();
     string_builder.cap += size_of::<Offsets>();
     string_builder.count_z(compile_exec_argv);
 
@@ -1128,8 +1213,20 @@ pub(crate) fn to_bytes(
         .position(|f| core::ptr::eq(*f, entry_point_file))
         .unwrap();
 
+    // The internal-module bytecode and the string table go right after the
+    // last startup module's bytecode, so everything a cold start decodes
+    // before the first `import()` is one run of pages (`prefetch_startup_pages`).
+    let startup_module_count = module_files
+        .iter()
+        .take_while(|f| f.loads_at_startup)
+        .count();
+    let mut shared_bytecode: Option<(Vec<u8>, StringPointer)> = None;
+
     let mut modules: Vec<CompiledModuleGraphFile> = Vec::with_capacity(module_files.len());
-    for &output_file in &module_files {
+    for (i, &output_file) in module_files.iter().enumerate() {
+        if i == startup_module_count {
+            shared_bytecode = Some(append_shared_bytecode(&mut string_builder, output_files));
+        }
         let buf_bytes = output_file.value.as_slice();
 
         let bytecode: StringPointer = 'brk: {
@@ -1256,43 +1353,8 @@ pub(crate) fn to_bytes(
         });
     }
 
-    // Ahead-of-time bytecode for internal modules rides in the same front region as module bytecode.
-    let mut builtin_bytecode_table: Vec<u8> = Vec::new();
-    {
-        let mut count: u32 = 0;
-        builtin_bytecode_table.extend_from_slice(&0u32.to_le_bytes());
-        for output_file in output_files {
-            if output_file.output_kind != options::OutputKind::BuiltinBytecode {
-                continue;
-            }
-            let options::OutputFileValue::Buffer { bytes } = &output_file.value else {
-                continue;
-            };
-            let Some(id) = core::str::from_utf8(&output_file.dest_path)
-                .ok()
-                .and_then(|s| s.parse::<u32>().ok())
-            else {
-                continue;
-            };
-            let pointer = append_bytecode_aligned(&mut string_builder, bytes);
-            builtin_bytecode_table.extend_from_slice(&id.to_le_bytes());
-            builtin_bytecode_table.extend_from_slice(&pointer.offset.to_le_bytes());
-            builtin_bytecode_table.extend_from_slice(&pointer.length.to_le_bytes());
-            count += 1;
-        }
-        builtin_bytecode_table[0..4].copy_from_slice(&count.to_le_bytes());
-    }
-
-    let mut bytecode_string_table_ptr = StringPointer::default();
-    for output_file in output_files {
-        if output_file.output_kind != options::OutputKind::BytecodeStringTable {
-            continue;
-        }
-        let options::OutputFileValue::Buffer { bytes } = &output_file.value else {
-            continue;
-        };
-        bytecode_string_table_ptr = append_bytecode_aligned(&mut string_builder, bytes);
-    }
+    let (builtin_bytecode_table, bytecode_string_table_ptr) = shared_bytecode
+        .unwrap_or_else(|| append_shared_bytecode(&mut string_builder, output_files));
 
     // Region layout after the bytecode/module_info run above: source maps
     // (unread until an error prints), then every file's source text as one run
@@ -1380,10 +1442,14 @@ pub(crate) fn to_bytes(
         let _ = string_builder.append_count(&record);
         flags |= Flags::HAS_BYTECODE_STRING_TABLE;
     }
+    let _ = string_builder.append_count(&(startup_module_count as u32).to_le_bytes());
+    flags |= Flags::HAS_STARTUP_MODULE_COUNT;
+    let compile_exec_argv_ptr = string_builder.append_count_z(compile_exec_argv);
+
     let offsets = Offsets {
         entry_point_id: entry_point_id as u32,
         modules_ptr,
-        compile_exec_argv_ptr: string_builder.append_count_z(compile_exec_argv),
+        compile_exec_argv_ptr,
         byte_count: string_builder.len,
         flags,
     };
@@ -2462,86 +2528,11 @@ impl StandaloneModuleGraph {
     /// sets it globally, and returns the pointer.
     pub fn from_executable() -> crate::Result<Option<*mut StandaloneModuleGraph>> {
         #[cfg(target_os = "macos")]
-        {
-            let Some((base, len)) = macho::get_data() else {
-                return Ok(None);
-            };
-            if len < size_of::<Offsets>() + TRAILER.len() {
-                bun_core::debug_warn!("bun standalone module graph is too small to be valid");
-                return Ok(None);
-            }
-            // SAFETY: `[len - Offsets - TRAILER, len)` is in-bounds (checked above) and
-            // read-only; build short-lived views via raw `read_unaligned` so no `&[u8]`
-            // ever spans the writable bytecode region carried in `base`'s provenance.
-            let offsets_ptr = unsafe { base.add(len - size_of::<Offsets>() - TRAILER.len()) };
-            // SAFETY: `[len - TRAILER.len(), len)` is in-bounds (length checked above) and read-only.
-            let trailer_bytes = unsafe {
-                core::slice::from_raw_parts(base.add(len - TRAILER.len()), TRAILER.len())
-            };
-            if trailer_bytes != TRAILER {
-                bun_core::debug_warn!("bun standalone module graph has invalid trailer");
-                return Ok(None);
-            }
-            // SAFETY: offsets_ptr has at least size_of::<Offsets>() bytes.
-            let offsets: Offsets =
-                unsafe { core::ptr::read_unaligned(offsets_ptr.cast::<Offsets>()) };
-            return from_bytes_alloc(base, len, offsets).map(Some);
-        }
-
+        let data = macho::get_data();
         #[cfg(windows)]
-        {
-            let Some((base, len)) = pe::get_data() else {
-                return Ok(None);
-            };
-            if len < size_of::<Offsets>() + TRAILER.len() {
-                bun_core::debug_warn!("bun standalone module graph is too small to be valid");
-                return Ok(None);
-            }
-            // SAFETY: `[len - Offsets - TRAILER, len)` is in-bounds (checked above) and
-            // read-only; build short-lived views via raw `read_unaligned` so no `&[u8]`
-            // ever spans the writable bytecode region carried in `base`'s provenance.
-            let offsets_ptr = unsafe { base.add(len - size_of::<Offsets>() - TRAILER.len()) };
-            // SAFETY: `[len - TRAILER.len(), len)` is in-bounds (length checked above) and read-only.
-            let trailer_bytes = unsafe {
-                core::slice::from_raw_parts(base.add(len - TRAILER.len()), TRAILER.len())
-            };
-            if trailer_bytes != TRAILER {
-                bun_core::debug_warn!("bun standalone module graph has invalid trailer");
-                return Ok(None);
-            }
-            // SAFETY: offsets_ptr has at least size_of::<Offsets>() bytes.
-            let offsets: Offsets =
-                unsafe { core::ptr::read_unaligned(offsets_ptr.cast::<Offsets>()) };
-            return from_bytes_alloc(base, len, offsets).map(Some);
-        }
-
+        let data = pe::get_data();
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
-        {
-            let Some((base, len)) = elf::get_data() else {
-                return Ok(None);
-            };
-            if len < size_of::<Offsets>() + TRAILER.len() {
-                bun_core::debug_warn!("bun standalone module graph is too small to be valid");
-                return Ok(None);
-            }
-            // SAFETY: `[len - Offsets - TRAILER, len)` is in-bounds (checked above) and
-            // read-only; build short-lived views via raw `read_unaligned` so no `&[u8]`
-            // ever spans the writable bytecode region carried in `base`'s provenance.
-            let offsets_ptr = unsafe { base.add(len - size_of::<Offsets>() - TRAILER.len()) };
-            // SAFETY: `[len - TRAILER.len(), len)` is in-bounds (length checked above) and read-only.
-            let trailer_bytes = unsafe {
-                core::slice::from_raw_parts(base.add(len - TRAILER.len()), TRAILER.len())
-            };
-            if trailer_bytes != TRAILER {
-                bun_core::debug_warn!("bun standalone module graph has invalid trailer");
-                return Ok(None);
-            }
-            // SAFETY: offsets_ptr has at least size_of::<Offsets>() bytes.
-            let offsets: Offsets =
-                unsafe { core::ptr::read_unaligned(offsets_ptr.cast::<Offsets>()) };
-            return from_bytes_alloc(base, len, offsets).map(Some);
-        }
-
+        let data = elf::get_data();
         #[cfg(not(any(
             target_os = "macos",
             windows,
@@ -2549,9 +2540,76 @@ impl StandaloneModuleGraph {
             target_os = "android",
             target_os = "freebsd"
         )))]
-        {
-            unreachable!()
+        let data: Option<(*mut u8, usize)> = None;
+        let Some((base, len)) = data else {
+            return Ok(None);
+        };
+        if len < size_of::<Offsets>() + TRAILER.len() {
+            bun_core::debug_warn!("bun standalone module graph is too small to be valid");
+            return Ok(None);
         }
+        // SAFETY: `[len - Offsets - TRAILER, len)` is in-bounds (checked above) and
+        // read-only; build short-lived views via raw `read_unaligned` so no `&[u8]`
+        // ever spans the writable bytecode region carried in `base`'s provenance.
+        let offsets_ptr = unsafe { base.add(len - size_of::<Offsets>() - TRAILER.len()) };
+        // SAFETY: `[len - TRAILER.len(), len)` is in-bounds (length checked above) and read-only.
+        let trailer_bytes =
+            unsafe { core::slice::from_raw_parts(base.add(len - TRAILER.len()), TRAILER.len()) };
+        if trailer_bytes != TRAILER {
+            bun_core::debug_warn!("bun standalone module graph has invalid trailer");
+            return Ok(None);
+        }
+        // SAFETY: offsets_ptr has at least size_of::<Offsets>() bytes.
+        let offsets: Offsets = unsafe { core::ptr::read_unaligned(offsets_ptr.cast::<Offsets>()) };
+        let graph = from_bytes_alloc(base, len, offsets)?;
+        // SAFETY: `from_bytes_alloc` just allocated `graph` for the life of the process.
+        unsafe { &*graph }.prefetch_startup_pages();
+        Ok(Some(graph))
+    }
+
+    /// Starts reading the payload pages the entry point's static import closure
+    /// needs — its modules' bytecode (or source text when there is none), the
+    /// internal-module bytecode and the string table, one run by construction
+    /// (`to_bytes`) — so on a cold start the disk reads overlap JSC
+    /// initialization instead of arriving one page fault at a time while the
+    /// bytecode decodes. Pages already cached cost nothing; errors are ignored.
+    /// `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1` skips it.
+    fn prefetch_startup_pages(&self) {
+        if self.startup_module_count == 0
+            || bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE::get()
+                .unwrap_or(false)
+        {
+            return;
+        }
+        let startup = &self.files.values()[..self.startup_module_count as usize];
+        let span = if startup.iter().any(|f| !f.bytecode.is_empty()) {
+            address_span(
+                startup
+                    .iter()
+                    .flat_map(|f| [f.bytecode, f.module_info])
+                    .chain(self.builtin_bytecode.iter().map(|&(_, bytes)| bytes))
+                    .map(|bytes| (bytes.cast::<u8>().cast_const(), bytes.len()))
+                    .chain([(
+                        self.bytecode_string_table.as_ptr(),
+                        self.bytecode_string_table.len(),
+                    )]),
+            )
+        } else {
+            address_span(
+                startup
+                    .iter()
+                    .map(|f| (f.contents.as_bytes().as_ptr(), f.contents.len())),
+            )
+        };
+        let Some((lo, hi)) = span else {
+            return;
+        };
+        #[cfg(target_os = "macos")]
+        macho::read_ahead(lo, hi);
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+        elf::read_ahead(lo, hi);
+        #[cfg(windows)]
+        let _ = (lo, hi);
     }
 
     /// Hint to the kernel that the embedded source text is unlikely to be
@@ -2620,24 +2678,71 @@ impl StandaloneModuleGraph {
         if !self.flags.contains(Flags::SOURCE_TEXT_CONTIGUOUS) {
             return None;
         }
-        let (mut lo, mut hi) = (usize::MAX, 0usize);
-        for file in self.files.values() {
-            let contents = file.contents.as_bytes();
-            if contents.is_empty() {
-                continue;
-            }
-            let start = contents.as_ptr() as usize;
-            lo = lo.min(start);
-            hi = hi.max(start + contents.len());
-        }
-        if lo >= hi {
-            return None;
-        }
+        let (lo, hi) = address_span(
+            self.files
+                .values()
+                .iter()
+                .map(|f| (f.contents.as_bytes().as_ptr(), f.contents.len())),
+        )?;
         let page = bun_alloc::page_size();
         let start = (lo + page - 1) & !(page - 1);
         let end = hi & !(page - 1);
         (end > start).then_some((start, end))
     }
+}
+
+/// `[lo, hi)` covering every non-empty `(ptr, len)` region, or `None` if there is none.
+fn address_span(regions: impl Iterator<Item = (*const u8, usize)>) -> Option<(usize, usize)> {
+    let (lo, hi) = regions
+        .filter(|&(_, len)| len != 0)
+        .fold((usize::MAX, 0usize), |(lo, hi), (ptr, len)| {
+            (lo.min(ptr as usize), hi.max(ptr as usize + len))
+        });
+    (lo < hi).then_some((lo, hi))
+}
+
+/// Writes the ahead-of-time bytecode of the internal modules and the shared
+/// bytecode string table. Returns the builtin table (`u32 count`, then `count`
+/// × `{ u32 id, StringPointer bytes }`) and the string table's pointer.
+fn append_shared_bytecode(
+    string_builder: &mut bun_core::StringBuilder,
+    output_files: &[OutputFile],
+) -> (Vec<u8>, StringPointer) {
+    let mut builtin_bytecode_table: Vec<u8> = Vec::new();
+    let mut count: u32 = 0;
+    builtin_bytecode_table.extend_from_slice(&0u32.to_le_bytes());
+    for output_file in output_files {
+        if output_file.output_kind != options::OutputKind::BuiltinBytecode {
+            continue;
+        }
+        let options::OutputFileValue::Buffer { bytes } = &output_file.value else {
+            continue;
+        };
+        let Some(id) = core::str::from_utf8(&output_file.dest_path)
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        let pointer = append_bytecode_aligned(string_builder, bytes);
+        builtin_bytecode_table.extend_from_slice(&id.to_le_bytes());
+        builtin_bytecode_table.extend_from_slice(&pointer.offset.to_le_bytes());
+        builtin_bytecode_table.extend_from_slice(&pointer.length.to_le_bytes());
+        count += 1;
+    }
+    builtin_bytecode_table[0..4].copy_from_slice(&count.to_le_bytes());
+
+    let mut bytecode_string_table_ptr = StringPointer::default();
+    for output_file in output_files {
+        if output_file.output_kind != options::OutputKind::BytecodeStringTable {
+            continue;
+        }
+        let options::OutputFileValue::Buffer { bytes } = &output_file.value else {
+            continue;
+        };
+        bytecode_string_table_ptr = append_bytecode_aligned(string_builder, bytes);
+    }
+    (builtin_bytecode_table, bytecode_string_table_ptr)
 }
 
 /// JSC reads cached bytecode in place and expects its start 128-byte aligned once mapped. The section data begins

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -53,6 +53,82 @@ describe("bundler", () => {
       },
     });
 
+    // The payload records how many leading modules make up the entry point's
+    // static import closure, and writes the internal-module bytecode and string
+    // table right after them, so a cold start prefetches one run. Lazily
+    // imported chunks come after that run.
+    itBundled("compile/splitting/StartupModulesPrecedeLazyChunks", {
+      compile: true,
+      splitting: true,
+      bytecode: true,
+      format: "esm",
+      files: {
+        "/entry.ts": /* js */ `
+          import "./shared";
+          console.log("mark:entry");
+          await import("./lazy1");
+        `,
+        "/lazy1.ts": /* js */ `
+          import "./shared";
+          console.log("mark:lazy1");
+        `,
+        "/shared.ts": /* js */ `
+          console.log("mark:shared");
+        `,
+      },
+      run: {
+        stdout: "mark:shared\nmark:entry\nmark:lazy1",
+      },
+      onAfterBundle(api) {
+        const file = readFileSync(api.outfile);
+        const trailer = file.lastIndexOf("\n---- Bun! ----\n", undefined, "latin1");
+        expect(trailer).toBeGreaterThan(0);
+        // `Offsets { byte_count: usize, modules_ptr: StringPointer, entry_point_id: u32, compile_exec_argv_ptr: StringPointer, flags: u32 }`
+        const offsets = trailer - 32;
+        const base = offsets - Number(file.readBigUInt64LE(offsets));
+        const modules = { offset: file.readUInt32LE(offsets + 8), length: file.readUInt32LE(offsets + 12) };
+        const flags = file.readUInt32LE(offsets + 28);
+        const u32 = (at: number) => file.readUInt32LE(base + at);
+        // Three chunks of 52 bytes each; anything else means the layout above is stale.
+        expect(modules.length).toBe(3 * 52);
+
+        // Records chained after the module table, in `Flags` bit order.
+        let at = modules.offset + modules.length;
+        const count = modules.length / 52;
+        if (flags & (1 << 5)) at += count * 4; // source hashes
+        expect(flags & (1 << 6), "Flags::HAS_BUILTIN_BYTECODE").not.toBe(0);
+        const builtinCount = u32(at);
+        at += 4 + builtinCount * 12;
+        expect(flags & (1 << 7), "Flags::HAS_BYTECODE_STRING_TABLE").not.toBe(0);
+        const stringTable = { offset: u32(at), length: u32(at + 4) };
+        at += 8;
+        expect(flags & (1 << 8), "Flags::HAS_STARTUP_MODULE_COUNT").not.toBe(0);
+        const startupCount = u32(at);
+
+        // `CompiledModuleGraphFile`: name, contents, sourcemap, bytecode, module_info, bytecode_origin_path
+        // (StringPointer each), then 4 bytes. Chunks are numbered, so identify them by their source text.
+        const index: Record<string, number> = {};
+        const bytecodeEnd: number[] = [];
+        for (let i = 0; i < count; i++) {
+          const record = base + modules.offset + i * 52;
+          const contents = { offset: file.readUInt32LE(record + 8), length: file.readUInt32LE(record + 12) };
+          const bytecode = { offset: file.readUInt32LE(record + 24), length: file.readUInt32LE(record + 28) };
+          expect(bytecode.length, `module ${i} has bytecode`).toBeGreaterThan(0);
+          bytecodeEnd.push(bytecode.offset + bytecode.length);
+          const source = file.toString("latin1", base + contents.offset, base + contents.offset + contents.length);
+          for (const name of ["entry", "lazy1", "shared"]) {
+            if (source.includes(`mark:${name}"`)) index[name] = i;
+          }
+        }
+        expect(startupCount).toBe(2);
+        expect([index.shared, index.entry].sort()).toEqual([0, 1]);
+        expect(index.lazy1).toBe(2);
+        // The string table sits between the startup modules' bytecode and the lazy chunk's.
+        expect(stringTable.offset).toBeGreaterThanOrEqual(Math.max(bytecodeEnd[0], bytecodeEnd[1]));
+        expect(stringTable.offset + stringTable.length).toBeLessThanOrEqual(bytecodeEnd[2]);
+      },
+    });
+
     itBundled("compile/splitting/RelativePathsAcrossChunks", {
       compile: true,
       splitting: true,


### PR DESCRIPTION
### What does this PR do?

On a cold start (executable not in the page cache), a `bun build --compile --bytecode` binary faults its bytecode in one page at a time while JSC decodes it. macOS does essentially no readahead for page faults on a mapped executable: touching a 24 MB bytecode run sequentially costs ~1,500 I/Os (36 ms), while one read request for the same bytes completes in ~5 ms.

This records, at build time, what loading the entry point's static import closure needs, and has the runtime ask the kernel to read it ahead before JSC initialization, so the disk reads overlap startup instead of being taken one fault at a time:

- `to_bytes` writes the internal-module bytecode and the bytecode string table right after the last startup module's bytecode (before any lazily imported chunk), so everything decoded before the first `import()` is one contiguous run by construction. It appends `u32 startup_module_count` (`Flags::HAS_STARTUP_MODULE_COUNT`) to the optional-record chain after the module table; the linker computes that count in `chunk_load_order` (rooted at the first server-side entry point, the one `to_bytes` picks).
- `from_executable` computes the span at runtime from the first `startup_module_count` modules (bytecode + module_info, or source text when there is no bytecode) plus the builtin bytecode and string table, and issues:
  - macOS: `fcntl(F_RDADVISE)` on the executable for the backing file range (found via `getsegbyname("__BUN")` + slide). `MADV_WILLNEED` is synchronous on Darwin (11 ms for 24 MB), so it is no use for overlapping I/O.
  - Linux/FreeBSD: `madvise(MADV_WILLNEED)` in 128 KiB pieces, since one call reads at most `max(bdi->io_pages, ra_pages)` (device dependent).
  - Windows: no-op.
- `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1` skips it, like the existing `MADV_DONTNEED` hint. Old runtimes ignore the new record; new runtimes treat its absence as "no prefetch".
- The three copies of the trailer parsing in `from_executable` are folded into one, and `from_bytes` walks the optional-record chain with a cursor.

Warm starts are unaffected: `F_RDADVISE` on cached pages returns immediately.

### Measurements

macOS arm64 (16 KiB pages), release builds, executable evicted from the page cache before each run (`msync(MS_INVALIDATE)`), variants interleaved, medians. "off" is the same binary with `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1`.

| | main | this PR | this PR, off | warm |
|---|---|---|---|---|
| 40,000-function app (bytecode 21 MB + string table 2.3 MB, one run) | 156 ms | **125 ms** | 155 ms | 31 ms / 32 ms |
| 1,800-chunk `--splitting` app, `--help` | 388 ms | **344 ms** | 382 ms | 103 ms |
| same app, first UI render | 636 ms | **596 ms** | 636 ms | ~290 ms |

For the splitting app the entry's static closure is only 8 modules (117 KB) because it `import()`s everything; the gain there comes from the builtin bytecode + string table (15 MB), of which first render uses 93%. Prefetching the first dynamic-import level as well (698 chunks, 62 MB) was tried and rejected: `--help` gets faster (264 ms) but first render gets slower (389 vs 367 ms) and `--version` loses its gain, because the large read competes with the faults startup is actually waiting on.

`F_RDADVISE` for 24 MB returns in 0.5 ms; the pages are resident ~5 ms later.

### How did you verify your code works?

- New `compile/splitting/StartupModulesPrecedeLazyChunks` in `test/bundler/bundler_compile_splitting.test.ts`: parses the payload and checks `startup_module_count == 2`, that `entry`/`shared` are the first two modules, and that the string table sits between their bytecode and the lazy chunk's. Fails on an unpatched build.
- `bundler_compile_splitting.test.ts`, `standalone-madvise-tla.test.ts` pass; `bundler_compile.test.ts` passes except for tests that need `listen()` / codesign time in this sandbox (identical on `main`).
- Drove a debug build on a splitting + bytecode executable with `BUN_DEBUG_StandaloneModuleGraph=1`: `F_RDADVISE offset=<segment fileoff + 128> count=<entry + shared bytecode + string table>`, correct output order, nothing issued with the flag set; an HTML-import app (client chunk present) prefetches only the server entry's run.
- `cargo check` for darwin, linux-gnu, windows-msvc, freebsd targets.
