### PR TITLE
Keep thread-affine strings on their own thread (fetch unix path, object URLs, worker shell argv)

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 
 use bun_ast::{Loc, Log};
 use bun_core::FeatureFlags;
-use bun_core::{MutableString, Utf8Bytes};
+use bun_core::MutableString;
 use bun_threading::IntrusiveWorkTask as _;
 use bun_threading::thread_pool::{self, Batch, Task};
 use bun_url::{PercentEncoding, URL};
@@ -24,9 +24,9 @@ bun_core::declare_scope!(AsyncHTTP, visible);
 
 // Lifetime `'a` covers every borrowed input the caller hands in: `url`,
 // `http_proxy`, `request_header_buf`, the borrowed `HTTPRequestBody::Bytes`
-// payload, and `client.{header_buf,hostname,if_modified_since}`. Intrusive
-// fields (`real`, `next`) are raw pointers and thus lifetime-erased; the
-// HTTP-thread copy uses the same `'a` as the JS-thread original it mirrors.
+// payload, and `client.{header_buf,hostname,unix_socket_path,if_modified_since}`.
+// Intrusive fields (`real`, `next`) are raw pointers and thus lifetime-erased;
+// the HTTP-thread copy uses the same `'a` as the JS-thread original it mirrors.
 pub struct AsyncHTTP<'a> {
     pub response: Option<picohttp::Response<'static>>,
     pub request_headers: headers::EntryList,
@@ -191,7 +191,7 @@ fn make_client<'a>(
         signals,
         async_http_id,
         hostname,
-        unix_socket_path: Utf8Bytes::EMPTY,
+        unix_socket_path: b"",
         compress: None,
         compressed_request_body: Vec::new(),
         compressed_body_len: 0,
@@ -245,7 +245,7 @@ pub struct Options<'a> {
     pub proxy_headers: Option<Headers>,
     pub hostname: Option<&'a [u8]>,
     pub signals: Option<Signals>,
-    pub unix_socket_path: Option<Utf8Bytes<'static>>,
+    pub unix_socket_path: Option<&'a [u8]>,
     pub disable_timeout: Option<bool>,
     /// Per-request idle timeout override in seconds; see
     /// `HTTPClient::idle_timeout_seconds`.
@@ -315,7 +315,6 @@ impl<'a> AsyncHTTP<'a> {
 
     pub fn clear_data(&mut self) {
         self.response = None;
-        self.client.unix_socket_path = Utf8Bytes::EMPTY;
     }
 }
 
@@ -461,7 +460,6 @@ impl<'a> AsyncHTTP<'a> {
             signals,
         };
         if let Some(val) = options.unix_socket_path {
-            debug_assert!(this.client.unix_socket_path.slice().is_empty());
             this.client.unix_socket_path = val;
         }
         if let Some(val) = options.disable_timeout {
@@ -711,11 +709,11 @@ impl<'a> AsyncHTTP<'a> {
                 // (`start_queued_task`), so any owned field that was already
                 // populated at that point — `request_headers`,
                 // `client.header_entries`, `client.proxy_headers`,
-                // `client.proxy_settings`, `client.tls_props`,
-                // `client.unix_socket_path` — is *shared* with the original
-                // and must NOT be dropped here; the original drops them when
-                // its `Box<AsyncHTTP>` is reclaimed. Only the state the clone
-                // built up itself during request processing is torn down.
+                // `client.proxy_settings`, `client.tls_props` — is *shared*
+                // with the original and must NOT be dropped here; the original
+                // drops them when its `Box<AsyncHTTP>` is reclaimed. Only the
+                // state the clone built up itself during request processing is
+                // torn down.
                 {
                     // `handle_response_metadata` rewrites per-hop request state in
                     // place: `client.url`/`connected_url` become self-borrows into

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -409,16 +409,9 @@ impl HttpThread {
             // funnels through here before touching `https_context.{group,secure}`.
             self.ensure_https_context_init();
         }
-        // Note: borrowck — `slice()` borrows `client`; capture into a
-        // `bun_ptr::RawSlice` (encapsulated outlives-holder invariant) so the
-        // borrow of `client` ends before we hand `&mut client` to
-        // `connect_socket`. Backing storage is `client.unix_socket_path`, which
-        // `connect_socket` does not touch.
-        let unix_path = bun_ptr::RawSlice::new(client.unix_socket_path.slice());
+        let unix_path = client.unix_socket_path;
         if !unix_path.is_empty() {
-            return self
-                .context::<IS_SSL>()
-                .connect_socket(client, unix_path.slice());
+            return self.context::<IS_SSL>().connect_socket(client, unix_path);
         }
 
         if IS_SSL {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -648,7 +648,6 @@ pub(crate) fn hash_header_name(name: &[u8]) -> u64 {
 // `bun_uws::NewSocketHandler` methods (`ext`/`timeout`/`raw_write`/`flush`/
 // `shutdown`/`connect_group`/…) land.
 
-use bun_core::Utf8Bytes;
 use bun_url::URL;
 use core::ptr::NonNull;
 
@@ -791,8 +790,8 @@ fn no_proxy_matches(no_proxy_text: &[u8], hostname: &[u8], host: &[u8]) -> bool 
 // Many of these fields can be moved to a packed struct and use less space
 //
 // Lifetime `'a` ties every borrowed input — `url`, `http_proxy`, `header_buf`,
-// `if_modified_since`, `hostname`, and the borrowed `HTTPRequestBody::Bytes`
-// payload — to the caller's storage. The original port erased these to `'static`
+// `if_modified_since`, `hostname`, `unix_socket_path`, and the borrowed
+// `HTTPRequestBody::Bytes` payload — to the caller's storage. The original port erased these to `'static`
 // and lifetime-erased at every call site; threading the lifetime removes that hazard.
 // Intrusive raw-pointer backrefs (socket ext, h2/h3 streams) store the
 // lifetime-erased `HTTPClient<'static>` form via [`HTTPClient::as_erased_ptr`].
@@ -870,7 +869,7 @@ pub struct HTTPClient<'a> {
     pub(crate) signals: Signals,
     pub(crate) async_http_id: u32,
     pub(crate) hostname: Option<&'a [u8]>,
-    pub(crate) unix_socket_path: Utf8Bytes<'static>,
+    pub(crate) unix_socket_path: &'a [u8],
     /// `fetch({ compress })` — when set, the body is compressed lazily at
     /// write time (h1: `send_initial_request_payload`; h2/h3: at attach) so
     /// the output can borrow `LibdeflateState::shared_buffer`. Persists across
@@ -1943,7 +1942,7 @@ impl<'a> HTTPClient<'a> {
         // through a non-keepalive Agent or `agent: false` skip it, matching Node.
         //
         // TCP options do not apply to a unix socket.
-        if !self.flags.disable_keepalive && self.unix_socket_path.slice().is_empty() {
+        if !self.flags.disable_keepalive && self.unix_socket_path.is_empty() {
             let _ = socket.set_keep_alive(true, 60);
         }
 
@@ -1971,7 +1970,7 @@ impl<'a> HTTPClient<'a> {
         if self.flags.is_preconnect_only {
             return false;
         }
-        if self.unix_socket_path.slice().len() > 0 {
+        if !self.unix_socket_path.is_empty() {
             return false;
         }
         if matches!(
@@ -2020,7 +2019,7 @@ impl<'a> HTTPClient<'a> {
         if self.flags.is_preconnect_only {
             return false;
         }
-        if self.unix_socket_path.slice().len() > 0 {
+        if !self.unix_socket_path.is_empty() {
             return false;
         }
         if matches!(
@@ -2259,7 +2258,7 @@ impl<'a> HTTPClient<'a> {
     pub(crate) fn is_keep_alive_possible(&self) -> bool {
         if FeatureFlags::ENABLE_KEEPALIVE {
             // TODO keepalive for unix sockets
-            if self.unix_socket_path.slice().len() > 0 {
+            if !self.unix_socket_path.is_empty() {
                 return false;
             }
             // check state
@@ -2633,15 +2632,9 @@ impl<'a> HTTPClient<'a> {
             self.flags.is_streaming_request_body = false;
         }
 
-        // Decided before unix_socket_path is forgotten below: a unix-socket connection must not be pooled.
+        // Decided before unix_socket_path is cleared below: a unix-socket connection must not be pooled.
         let keep_alive_possible = self.is_keep_alive_possible();
-        // There is no struct copy-back
-        // (`sync_progress_from` skips owned fields) and the original retains
-        // its own `Owned(Vec)` aliasing the same allocation (the HTTP-thread
-        // clone was created via `ptr::read`). Dropping it here would
-        // double-free when the original later runs `clear_data()`. Forget the
-        // clone's view; the original is the sole owner.
-        let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
+        self.unix_socket_path = b"";
         // TODO: what we do with stream body?
         let request_body: &[u8] = if self.state.flags.resend_request_body_on_redirect
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
@@ -2863,7 +2856,7 @@ impl<'a> HTTPClient<'a> {
                 self.complete_connecting_process();
                 return;
             }
-            if self.http_proxy.is_some() || self.unix_socket_path.slice().len() > 0 {
+            if self.http_proxy.is_some() || !self.unix_socket_path.is_empty() {
                 self.fail(crate::Error::HTTP3Unsupported);
                 self.complete_connecting_process();
                 return;
@@ -4357,10 +4350,7 @@ impl<'a> HTTPClient<'a> {
         if matches!(self.state.original_request_body, HTTPRequestBody::Stream(_)) {
             self.flags.is_streaming_request_body = false;
         }
-        // See `do_redirect`: the HTTP-thread clone shares this allocation
-        // with the JS-thread original (created via `ptr::read`); dropping it
-        // here double-frees once the original runs `clear_data()`.
-        let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
+        self.unix_socket_path = b"";
         let request_body: &[u8] = if self.state.flags.resend_request_body_on_redirect
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
         {
@@ -4953,7 +4943,7 @@ impl<'a> HTTPClient<'a> {
                     // request to the same origin may be h3-eligible even if this
                     // one was pinned/proxied/sendfile.
                     if self.is_https()
-                        && self.unix_socket_path.slice().len() == 0
+                        && self.unix_socket_path.is_empty()
                         && !(self.flags.proxy_tunneling && self.proxy_tunnel.is_none())
                         && h3_alt_svc_enabled()
                     {

--- a/src/http/session_cache.rs
+++ b/src/http/session_cache.rs
@@ -182,7 +182,7 @@ unsafe extern "C" {
 pub(crate) fn eligible(client: &crate::HTTPClient<'_>) -> bool {
     client.flags.reject_unauthorized
         && !client.signals.get(signals::Field::CertErrors)
-        && client.unix_socket_path.slice().is_empty()
+        && client.unix_socket_path.is_empty()
         && !bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE
             .get()
             .unwrap_or(false)

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -142,10 +142,12 @@ pub struct Blob {
     pub name: bun_ptr::JsCell<bun_core::String>,
 }
 
-// SAFETY: `Blob` holds a raw `global_this` pointer which defaults to
-// `!Send`/`!Sync`. `Blob` moves across threads under `ObjectURLRegistry`'s
-// mutex and via the work-pool read/write tasks; `global_this` is an opaque
-// JSC handle only ever dereferenced on its owning JS thread.
+// SAFETY: a `Blob` reaches another thread only as an `ObjectURLRegistry`
+// entry (process-global, behind its mutex) or via the work-pool read/write
+// tasks that hand it back to the owning JS thread. Registry entries carry a
+// null `global_this` and a `to_thread_safe()` `name`, and every dupe handed
+// out is stamped with the resolving thread's global; `store` (`StoreRef`) and
+// `content_type` (`Arc<[u8]>`) are atomically refcounted.
 unsafe impl Send for Blob {}
 // SAFETY: concurrent `&Blob` access only occurs under `ObjectURLRegistry`'s
 // mutex or on the single owning JS thread; the `Cell` fields are never raced.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1479,7 +1479,7 @@ mod vm_loader_ctx {
             is_blob_url(spec) => crate::webcore::object_url_registry::is_blob_url(spec),
             resolve_blob(spec) => {
                 crate::webcore::object_url_registry::ObjectURLRegistry::singleton()
-                    .resolve_and_dupe(spec)
+                    .resolve_and_dupe(spec, &*(*this).global)
                     .map(|b| bun_core::heap::into_raw(Box::new(b)).cast::<()>())
             },
             blob_loader(b) => blob(b).get_loader(&*this),
@@ -3996,7 +3996,8 @@ unsafe fn get_loader_and_virtual_source<'a>(
     // `blob:` ObjectURL → in-memory virtual source.
     if crate::webcore::object_url_registry::is_blob_url(specifier) {
         match crate::webcore::object_url_registry::ObjectURLRegistry::singleton()
-            .resolve_and_dupe(&specifier[b"blob:".len()..])
+            // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+            .resolve_and_dupe(&specifier[b"blob:".len()..], unsafe { &*jsc_vm }.global())
         {
             Some(blob) => {
                 *blob_to_deinit = Some(blob);

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1623,7 +1623,8 @@ impl Interpreter {
                     if vm_args_utf8.len() != argv.len() {
                         vm_args_utf8.reserve(argv.len());
                         for arg in argv {
-                            vm_args_utf8.push(bun_core::String::retain_wtf_impl(*arg).into_utf8());
+                            vm_args_utf8
+                                .push(crate::node::process::worker_option_string(*arg).into_utf8());
                         }
                     }
                     out.extend_from_slice(vm_args_utf8[int as usize].slice());

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -39,9 +39,10 @@ const _: fn() = || {
 
 impl Entry {
     pub(crate) fn init(blob: &Blob) -> Box<Entry> {
-        Box::new(Entry {
-            blob: blob.dupe_with_content_type(true),
-        })
+        let blob = blob.dupe_with_content_type(true);
+        blob.global_this.set(core::ptr::null());
+        blob.name.with_mut(|name| name.to_thread_safe());
+        Box::new(Entry { blob })
     }
 }
 
@@ -66,11 +67,20 @@ impl ObjectURLRegistry {
         REGISTRY.get_or_init(ObjectURLRegistry::default)
     }
 
-    pub(crate) fn resolve_and_dupe(&self, pathname: &[u8]) -> Option<Blob> {
+    pub(crate) fn resolve_and_dupe(
+        &self,
+        pathname: &[u8],
+        global_object: &JSGlobalObject,
+    ) -> Option<Blob> {
         let uuid = uuid_from_pathname(pathname)?;
-        let map = self.map.lock();
-        map.get(&uuid.bytes)
-            .map(|e| e.blob.dupe_with_content_type(true))
+        let blob = self
+            .map
+            .lock()
+            .get(&uuid.bytes)?
+            .blob
+            .dupe_with_content_type(true);
+        blob.global_this.set(global_object);
+        Some(blob)
     }
 
     pub(crate) fn resolve_and_dupe_to_js(
@@ -78,7 +88,7 @@ impl ObjectURLRegistry {
         pathname: &[u8],
         global_object: &JSGlobalObject,
     ) -> Option<JSValue> {
-        let blob = Blob::new(self.resolve_and_dupe(pathname)?);
+        let blob = Blob::new(self.resolve_and_dupe(pathname, global_object)?);
         // SAFETY: `Blob::new` returns a freshly-boxed heap pointer.
         Some(unsafe { (*blob).to_js(global_object) })
     }

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1295,7 +1295,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // Support blob: urls
             if url_type == URLType::Blob {
                 if let Some(blob) =
-                    ObjectURLRegistry::singleton().resolve_and_dupe(url_path_decoded)
+                    ObjectURLRegistry::singleton().resolve_and_dupe(url_path_decoded, global_this)
                 {
                     url_string = BunString::create_format(format_args!(
                         "blob:{}",

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -162,6 +162,7 @@ pub struct FetchTasklet {
     pub(crate) upgraded_connection: bool,
     // Custom Hostname
     pub(crate) hostname: Option<Box<[u8]>>,
+    pub(crate) unix_socket_path: Utf8Bytes<'static>,
     pub(crate) is_waiting_body: bool,
     /// Set by `on_start_buffering_callback` (JS thread) and read by
     /// `callback()` (HTTP thread, under `mutex`): the body is being
@@ -479,6 +480,7 @@ impl FetchTasklet {
         if let Some(_hostname) = self.hostname.take() {
             // dropped by Box
         }
+        self.unix_socket_path = Utf8Bytes::EMPTY;
 
         if let Some(certificate) = self.result.certificate_info.take() {
             drop(certificate);
@@ -2041,6 +2043,7 @@ impl FetchTasklet {
             reject_unauthorized: fetch_options.reject_unauthorized,
             upgraded_connection: fetch_options.upgraded_connection,
             hostname: fetch_options.hostname,
+            unix_socket_path: fetch_options.unix_socket_path,
             is_waiting_body: false,
             is_buffering_body: AtomicBool::new(false),
             is_waiting_abort: false,
@@ -2103,21 +2106,22 @@ impl FetchTasklet {
 
         // This task gets queued on the HTTP thread.
         // `AsyncHTTP::init` takes several `&'static [u8]` borrows
-        // (headers_buf, request_body, hostname) that point into
-        // FetchTasklet-owned storage. The tasklet is heap-pinned via
+        // (headers_buf, request_body, hostname, unix_socket_path) that point
+        // into FetchTasklet-owned storage. The tasklet is heap-pinned via
         // `heap::alloc`, so erase the borrow lifetimes through raw pointers.
         // SAFETY: `fetch_tasklet_ptr` is a stable heap allocation that outlives
         // the AsyncHTTP (dropped together in `deinit`); the slices below borrow
-        // its `request_headers.buf`, `request_body`, and `hostname` fields
-        // which are not reallocated for the lifetime of the request.
+        // its `request_headers.buf`, `request_body`, `hostname`, and
+        // `unix_socket_path` fields which are not reallocated for the lifetime
+        // of the request.
         // SAFETY (`Interned::assume` — Population B, holder-backed):
         // `fetch_tasklet_ptr` is a `heap::alloc`'d `FetchTasklet` whose
-        // `request_headers.buf` / `request_body` / `hostname` fields are not
-        // reallocated for the request's lifetime, and the tasklet is freed in
-        // `deinit` only after the owned `AsyncHTTP` is dropped. NOT
-        // process-lifetime — these should become `RawSlice<u8>` once
-        // `AsyncHTTP::init` accepts holder-lifetime slices; `assume` names the
-        // owner so the widen is grep-able until then.
+        // `request_headers.buf` / `request_body` / `hostname` /
+        // `unix_socket_path` fields are not reallocated for the request's
+        // lifetime, and the tasklet is freed in `deinit` only after the owned
+        // `AsyncHTTP` is dropped. NOT process-lifetime — these should become
+        // `RawSlice<u8>` once `AsyncHTTP::init` accepts holder-lifetime slices;
+        // `assume` names the owner so the widen is grep-able until then.
         let headers_buf: &'static [u8] =
             unsafe { bun_ptr::Interned::assume(fetch_tasklet.request_headers.buf.as_slice()) }
                 .as_bytes();
@@ -2129,6 +2133,9 @@ impl FetchTasklet {
             .as_deref()
             // SAFETY: see block note above — same `FetchTasklet` owner.
             .map(|s| unsafe { bun_ptr::Interned::assume(s) }.as_bytes());
+        // SAFETY: see block note above — same `FetchTasklet` owner.
+        let unix_socket_path: &'static [u8] =
+            unsafe { bun_ptr::Interned::assume(fetch_tasklet.unix_socket_path.slice()) }.as_bytes();
         // `MultiArrayList` owns its
         // allocation, so clone; AsyncHTTP::init clones again for the client.
         let header_entries = bun_core::handle_oom(fetch_tasklet.request_headers.entries.clone());
@@ -2157,7 +2164,7 @@ impl FetchTasklet {
                 proxy_headers: fetch_options.proxy_headers,
                 hostname,
                 signals: Some(fetch_tasklet.signals),
-                unix_socket_path: Some(fetch_options.unix_socket_path),
+                unix_socket_path: Some(unix_socket_path),
                 disable_timeout: Some(fetch_options.disable_timeout),
                 idle_timeout_seconds: fetch_options.idle_timeout_seconds,
                 disable_keepalive: Some(fetch_options.disable_keepalive),

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -580,6 +580,54 @@ describe("web worker", () => {
       expect(stdout).toBe("PASS\n");
       expect(exitCode).toBe(0);
     });
+
+    // A blob: URL registered on one thread and consumed (fetch, import,
+    // blob().name, revoke) on another, with a named File; and `$1` in a
+    // worker's shell reading the worker's own argv.
+    test("named File object URL is usable from another thread; worker shell sees its argv", async () => {
+      using dir = tempDir("worker-object-url", {
+        "main.mjs": `import { Worker, isMainThread, parentPort, workerData } from "node:worker_threads";
+          if (isMainThread) {
+            const url = URL.createObjectURL(new File(['export default "módule"'], "nämé.mjs", { type: "text/javascript" }));
+            const w = new Worker(new URL(import.meta.url), { workerData: url, argv: ["ärg-one", "arg-two-longer-than-eight"] });
+            w.on("message", async m => {
+              console.log(JSON.stringify(m));
+              const back = await (await fetch(m.fromWorker)).blob();
+              console.log(back.name, await back.text());
+              URL.revokeObjectURL(url);
+              URL.revokeObjectURL(m.fromWorker);
+              Bun.gc(true);
+              await w.terminate();
+            });
+          } else {
+            const blob = await (await fetch(workerData)).blob();
+            const mod = (await import(workerData)).default;
+            const sh = (await Bun.$\`echo $1 $2\`.text()).trim();
+            const fromWorker = URL.createObjectURL(new File(["wörker"], "wörker.txt"));
+            Bun.gc(true);
+            parentPort.postMessage({ name: blob.name, type: blob.type, text: await blob.text(), mod, sh, fromWorker });
+          }`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.mjs"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      const [line1, line2] = stdout.trim().split("\n");
+      expect(JSON.parse(line1)).toEqual({
+        name: "nämé.mjs",
+        type: "text/javascript;charset=utf-8",
+        text: 'export default "módule"',
+        mod: "módule",
+        sh: expect.stringMatching(/ ärg-one$/),
+        fromWorker: expect.stringMatching(/^blob:/),
+      });
+      expect(line2).toBe("wörker.txt wörker");
+      expect(exitCode).toBe(0);
+    });
   });
 });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -588,7 +588,10 @@ describe("web worker", () => {
       using dir = tempDir("worker-object-url", {
         "main.mjs": `import { Worker, isMainThread, parentPort, workerData } from "node:worker_threads";
           if (isMainThread) {
-            const url = URL.createObjectURL(new File(['export default "módule"'], "nämé.mjs", { type: "text/javascript" }));
+            const file = new File(['export default "módule"'], "ignored.mjs", { type: "text/javascript" });
+            // Assigning .name stores a JS string on the Blob (the constructor's name lives in the byte store).
+            file.name = "nämé.mjs";
+            const url = URL.createObjectURL(file);
             const w = new Worker(new URL(import.meta.url), { workerData: url, argv: ["ärg-one", "arg-two-longer-than-eight"] });
             w.on("message", async m => {
               console.log(JSON.stringify(m));


### PR DESCRIPTION
### What does this PR do?

WTF string refcounts are atomic, but an atomized `StringImpl` belongs to one thread's atom table and must not be destroyed from another. Three places let a `bun_core::String` that may be such an impl be dropped (or ref'd) off its thread:

- `fetch(url, { unix })`: the socket path — `Utf8Bytes` that can hold a ref into the JS string — was stored in `HTTPClient` and bitwise-copied to the HTTP thread by `ptr::read`; two `ManuallyDrop` "forgets" on the redirect paths and a `clear_data()` reset kept it from being freed twice. It now has the same shape as `hostname`: the `FetchTasklet` owns the bytes on the JS thread and `HTTPClient<'a>` borrows `&'a [u8]`. The forgets and the reset are gone; no string type is left in `bun_http` for this field.
- `URL.createObjectURL`: the registry is process-global, but an entry was a straight `dupe()` of the creating thread's `Blob`, including its `global_this` and its `name`. A worker that `fetch()`ed/`import`ed/revoked that URL cloned and later dropped the creator's name, and got a Blob stamped with the creator's global. Entries are now stored with a null global and a `to_thread_safe()` name (one copy per `createObjectURL` of a named `File`), and `resolve_and_dupe(path, global)` stamps the resolving thread's global.
- `$0`…`$N` in `Bun.$` inside a worker took `retain_wtf_impl` on the parent thread's `WorkerOptions.argv` strings and held them for the interpreter's lifetime; it now copies them via the same `worker_option_string` helper `process.argv` uses.

### How did you verify your code works?

New `worker.test.ts` case: a named `File` object URL created on the main thread is fetched, imported, `.blob()`'d and revoked from a worker (and the reverse), and the worker's `Bun.$` reads its own `argv`. Debug+ASAN build driven through fetch over a unix socket, `fetch.unix.test.ts`, `blob.test.ts`, `bunshell.test.ts`, `worker.test.ts`, `serve.test.ts`.