### PR TITLE
mimalloc: free(NULL) before the allocator initializes no longer faults (glibc 2.44 startup crash)

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "a178e44af6dc2845c793a39fd62da583b3e9f0ff";
+const MIMALLOC_COMMIT = "942b8342575bdece649438ca76f32276a019c51e";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -576,7 +576,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "2288897e2e716330490893d226b4f079f9da9e0c",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "a178e44af6dc2845c793a39fd62da583b3e9f0ff",
+    mimalloc: "942b8342575bdece649438ca76f32276a019c51e",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "05f0fafaa3be31e31d7b4b5c17dc60f62c991171",


### PR DESCRIPTION
### What does this PR do?

Bumps mimalloc to `942b8342` on oven-sh/mimalloc `bun-dev3-v2`, which merges oven-sh/mimalloc#30.

`mi_free(NULL)` before mimalloc has initialized faults at address 0. The static initial page map (`mi_page_map_empty`, upstream's fix for microsoft/mimalloc#1341) has carried `submaps[0] = NULL` since upstream dev3's 2-level page-map restructure (`d63979ae`), and the release-mode lookup (`_mi_unchecked_ptr_page`) reads `submaps[0][0]` without checking the submap:

```
free+0x28:  movq (%rax,%rcx), %rdi     ; rax = pmap->submaps[0] = NULL
```

The Aug 13 fork sync (#37367) picked that up; upstream dev3 still has the bug. The fix points `submaps[0]` at a static zero-initialized submap (64 KiB of `.bss`, untouched unless something frees before init), so the lookup yields no page and `mi_free` returns. Only the pin moves here.

**How this gets hit:** glibc 2.44 refactored `__newlocale` into a wrapper that ends with an unconditional `free(tmp_buffer)` (a leak fix for the `LOCPATH` buffer), so every `newlocale(LC_ALL, "C", NULL)` is now one `free(NULL)`. libstdc++'s iostream initializer is `init_priority(90)` and calls exactly that through `std::locale()`, and 90 sorts before mimalloc's `constructor(101)` — so on glibc 2.44 (Arch, CachyOS, Fedora rawhide) any binary that exports the override crashes in `.init_array`, before `main()`. That's also the `nix`-on-Arch crash in microsoft/mimalloc#1341.

**Does this affect oven-sh/bun binaries?** Not today: `linker.lds` keeps the Linux `malloc`/`free` override private to the executable, so libc's internal `free` still goes to glibc's allocator. It bites any build that exports the override; taking it here so the fork doesn't carry a pin divergence and so the next person to export it doesn't rediscover this.

### How did you verify your code works?

In oven-sh/mimalloc#30: a new `test-free-before-init` calls `free(NULL)`/`mi_free(NULL)` from `.preinit_array` — before any constructor. Linux (Ubuntu 24.04 arm64, gcc, `MI_OVERRIDE=ON`): segfaults (exit 139) without the fix, passes with it; Release `ctest` 23/23 and `MI_DEBUG_FULL` green.

Also checked on a Linux build that exports the override, with an `LD_PRELOAD` library whose constructor calls `free(NULL)` (volatile pointer so gcc can't elide it; `dladdr` confirms it binds to the executable's `free`): old pin → SIGSEGV, this pin → `bun --version` prints normally.

Not built end-to-end here — CI is the build; nothing else in the pin delta.
