### PR TITLE
Add jsc-exception-lint and fix the missing exception checks it finds

### DIFF
--- a/scripts/jsc-exception-lint/README.md
+++ b/scripts/jsc-exception-lint/README.md
@@ -1,0 +1,83 @@
+# jsc-exception-lint
+
+A static checker for JavaScriptCore exception discipline in Bun's C++ code.
+It finds the same class of bug that `BUN_JSC_validateExceptionChecks=1`
+finds at run time, without needing a test to execute the path.
+
+## Run
+
+```sh
+bun scripts/jsc-exception-lint/run.ts                 # whole tree
+bun scripts/jsc-exception-lint/run.ts src/jsc/bindings/BunObject.cpp
+bun scripts/jsc-exception-lint/run.ts --kind pending-call,thrown-call
+bun scripts/jsc-exception-lint/rust-externs.ts        # Rust externs vs C++ summaries
+```
+
+It needs a configured debug build (`build/debug/compile_commands.json` and
+the generated headers) and the LLVM 21 development package (`libclang-cpp`,
+`clang/` headers). Set `LLVM_DIR` if it is not under `/usr/lib/llvm-21`.
+
+The first run also parses the JavaScriptCore sources under `vendor/WebKit`
+to learn which JSC functions can throw. That takes about ten minutes and is
+cached in `build/debug/jsc-exception-lint/` per WebKit version.
+
+## What it checks
+
+JSC's validator works like this. Every function that can throw declares a
+`ThrowScope`. When a callee's scope is destroyed it sets
+`VM::m_needExceptionCheck`. The next `ThrowScope` constructor, and the next
+non-released `ThrowScope` destructor, assert that the bit is clear. Only
+`exception()` (which `RETURN_IF_EXCEPTION` expands to), `clearException()`
+and the `assertNoException` family clear it.
+
+The tool models that state machine over the clang CFG of every function. The
+abstract state is a set over `{clean, pending, thrown} x {released}`. A call
+to a callee that can throw moves the state to `pending`. A call to a thrower
+(`throw*`, `Bun::ERR::*`, `ThrowScope::throwException`) moves it to `thrown`.
+A check moves it to `clean`. `scope.release()` sets `released`.
+
+Kinds of finding:
+
+- `pending-call`: a callee that can throw is called while a check is
+  pending. The validator asserts here when the callee declares a scope. In
+  release the second call runs with the first exception still set and may
+  overwrite it.
+- `unchecked-exit`: the function returns while a check is pending and its
+  scope was not released. The validator asserts in the destructor. Use
+  `RETURN_IF_EXCEPTION` or `RELEASE_AND_RETURN`.
+- `scope-while-pending`: a `ThrowScope` is constructed while a check is
+  pending. Usually a second `DECLARE_THROW_SCOPE` in a function that already
+  has one.
+- `thrown-call`: a callee that can throw is called after this function
+  already threw. The first error is lost if the callee throws too.
+- `maybe-thrown-call` (hidden by default, `--kind maybe-thrown-call`): a
+  callee that can throw is called after a helper that may have thrown into
+  our scope and returned a failure value (`if (!readOption(...)) return;`
+  style helpers, lambdas with `RETURN_IF_EXCEPTION` inside). The analysis
+  cannot see the result test, so these need a human look.
+
+## How a callee is classified
+
+1. The lists in `nothrow.txt` win. Each line is `<qualified name> [kind]`.
+   `indirect:<member>` classifies calls through a function-pointer member
+   (method tables).
+2. `exception`, `clearException`, `assertNoException*`, `tryClearException`,
+   `hasExceptionsAfterHandlingTraps` on a scope or the VM are checks.
+   `release` is a release. `throwException` and functions named `throw*`
+   that take a global object or scope are throwers, as is `Bun::ERR::*`.
+3. A body visible in the translation unit (inline, template, same file,
+   lambda) is analyzed. A body that constructs a `ThrowScope` can throw. A
+   body with no scope that calls something that can throw is
+   "transparent": its callers see the exit states of its body. A body that
+   checks everything before it returns leaves no pending bit, like the
+   validator.
+4. A body seen by the summary passes (JavaScriptCore sources, then Bun's
+   sources) is classified from the recorded summary.
+5. Otherwise the JSC convention applies: a parameter of type
+   `JSGlobalObject*` (or a subclass) or `ThrowScope&` means it can throw.
+   Calls through function pointers use the signature the same way.
+
+Path sensitivity is limited to the exception state. A `toNumber()` guarded
+by `isNumber()` is still reported because the slow path exists. Use
+`asNumber()` after the type check instead. That is also what REVIEW.md asks
+for.

--- a/scripts/jsc-exception-lint/jsc-exception-lint.cpp
+++ b/scripts/jsc-exception-lint/jsc-exception-lint.cpp
@@ -298,7 +298,10 @@ static void loadSummaries(const std::string &path) {
     Summary s;
     if (!Summary::parseKind(cols[2], s.kind))
       continue;
-    s.exitStates = (StateSet)std::stoul(cols[3]);
+    unsigned exitStates = 0;
+    if (llvm::StringRef(cols[3]).getAsInteger(10, exitStates))
+      continue; // malformed line
+    s.exitStates = exitStates;
     s.verifiesAtEntry = cols[4] == "1";
     s.why = cols.size() > 5 ? cols[5] : "";
     auto it = gImported.find(cols[0]);

--- a/scripts/jsc-exception-lint/jsc-exception-lint.cpp
+++ b/scripts/jsc-exception-lint/jsc-exception-lint.cpp
@@ -1,0 +1,1098 @@
+// jsc-exception-lint: a clang LibTooling checker for JavaScriptCore exception
+// discipline in Bun's C++ bindings.
+//
+// JSC's debug-only validator (BUN_JSC_validateExceptionChecks=1) works like
+// this: every function that can throw declares a ThrowScope. When a callee's
+// ThrowScope is destroyed it "simulates a throw" by setting
+// VM::m_needExceptionCheck. The next ThrowScope constructor, and the next
+// non-released ThrowScope destructor, assert that the bit is clear. The bit is
+// cleared by ExceptionScope::exception() (RETURN_IF_EXCEPTION and friends
+// expand to that), VM::clearException(), and the assertNoException family.
+//
+// This tool models the same state machine statically over the clang CFG of
+// every function defined in Bun's bindings. Per function it tracks a set of
+// abstract states {clean, pending, thrown} x {released}. A call to a callee
+// that may throw moves the state to `pending`. A call to a thrower (throw*,
+// Bun::ERR::*) moves it to `thrown`. A check moves it to `clean`. An error is
+// reported when:
+//   - a may-throw callee is called while the state is `pending`
+//     ("call while an exception check is pending"),
+//   - a may-throw callee is called while the state is `thrown`
+//     ("call after throwing"),
+//   - a ThrowScope is constructed or destroyed (not released) while `pending`
+//     ("function exits with an unchecked exception").
+//
+// Whether a callee may throw is decided from its definition when it is visible
+// in the translation unit (inline functions, templates, same-file helpers,
+// lambdas): a visible body that constructs a ThrowScope, or calls something
+// that may throw, may throw. For callees defined in another translation unit,
+// summaries exported by a previous run over the whole project are consulted
+// (--export-summaries / --import-summaries). For everything else the JSC
+// convention applies: a parameter of type JSGlobalObject* (or a subclass), or
+// ThrowScope&, means it may throw, unless the qualified name is listed in the
+// nothrow allowlist passed with --nothrow=<file>.
+//
+// Build and run through scripts/jsc-exception-lint/run.ts.
+
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
+#include "clang/AST/GlobalDecl.h"
+#include "clang/AST/Mangle.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Analysis/CFG.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Frontend/FrontendAction.h"
+#include "clang/Lex/Lexer.h"
+#include "clang/Tooling/CommonOptionsParser.h"
+#include "clang/Tooling/Tooling.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <fstream>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+using namespace clang;
+using namespace clang::tooling;
+
+static llvm::cl::OptionCategory Category("jsc-exception-lint options");
+static llvm::cl::opt<std::string> NothrowFile("nothrow", llvm::cl::desc("file with one qualified function name per line that is known not to throw"), llvm::cl::cat(Category));
+static llvm::cl::opt<std::string> ThrowFile("maythrow", llvm::cl::desc("file with one qualified function name per line that is known to throw"), llvm::cl::cat(Category));
+static llvm::cl::opt<std::string> OnlyPathPrefix("only-under", llvm::cl::desc("only report functions defined in files whose path contains this string"), llvm::cl::init("src/jsc/bindings"), llvm::cl::cat(Category));
+static llvm::cl::opt<std::string> ExportSummaries("export-summaries", llvm::cl::desc("write callee summaries for functions defined in files matching --export-under to this file"), llvm::cl::cat(Category));
+static llvm::cl::opt<std::string> ExportUnder("export-under", llvm::cl::desc("path substring that selects functions to export"), llvm::cl::init("/src/"), llvm::cl::cat(Category));
+static llvm::cl::list<std::string> ImportSummaries("import-summaries", llvm::cl::desc("read callee summaries from this file (repeatable)"), llvm::cl::cat(Category));
+static llvm::cl::opt<bool> JsonOutput("json", llvm::cl::desc("emit one JSON object per line"), llvm::cl::cat(Category));
+static llvm::cl::opt<bool> Verbose("verbose", llvm::cl::desc("print callee classification for every call"), llvm::cl::cat(Category));
+
+namespace {
+
+// Abstract state bits. The set of reachable states at a program point is a
+// bitmask over the 8 combinations of these three bits.
+enum : unsigned {
+    kPending = 1, // a callee's ThrowScope simulated a throw; an exception() query is due
+    kThrown = 2, // this function threw (or a callee surely did); it must return without calling into JS again
+    kReleased = 4, // this function's own ThrowScope was released (RELEASE_AND_RETURN)
+    kMaybe = 8, // a callee may have thrown into our scope and returned a failure value; the bit is clear
+    kNumStates = 16,
+};
+
+using StateSet = unsigned; // bit i set <=> abstract state i is reachable
+
+static constexpr StateSet kCleanOnly = 1u << 0;
+
+static bool anyState(StateSet s, unsigned bit)
+{
+    for (unsigned st = 0; st < kNumStates; st++)
+        if ((s & (1u << st)) && (st & bit))
+            return true;
+    return false;
+}
+
+template<typename F>
+static StateSet mapStates(StateSet in, F f)
+{
+    StateSet out = 0;
+    for (unsigned st = 0; st < kNumStates; st++)
+        if (in & (1u << st))
+            out |= 1u << (f(st) & (kNumStates - 1));
+    return out;
+}
+
+// Summary of a callee, as seen by its callers.
+struct Summary {
+    enum Kind {
+        Nothrow, // cannot throw; does not touch the exception bit
+        Check, // queries the exception (clears the bit)
+        Release, // ThrowScope::release()
+        MayThrow, // declares a scope: after the call, the state is `pending`
+        Thrower, // after the call, the state is `thrown`
+        Transparent, // no own scope; exit states are those of its body
+    };
+    Kind kind = Nothrow;
+    bool verifiesAtEntry = false; // constructs a scope (or calls into one) before any check
+    StateSet exitStates = kCleanOnly; // for Transparent: states at exit when entered clean
+    std::string why;
+
+    bool mayThrow() const { return kind == MayThrow || kind == Thrower || kind == Transparent; }
+
+    static const char* kindName(Kind k)
+    {
+        switch (k) {
+        case Nothrow:
+            return "nothrow";
+        case Check:
+            return "check";
+        case Release:
+            return "release";
+        case MayThrow:
+            return "maythrow";
+        case Thrower:
+            return "thrower";
+        case Transparent:
+            return "transparent";
+        }
+        return "?";
+    }
+    static bool parseKind(const std::string& s, Kind& out)
+    {
+        for (int k = Nothrow; k <= Transparent; k++) {
+            if (s == kindName((Kind)k)) {
+                out = (Kind)k;
+                return true;
+            }
+        }
+        return false;
+    }
+};
+
+// Merge two summaries for the same name/arity coming from different
+// translation units or overloads. The result is the more conservative one.
+static Summary mergeSummaries(const Summary& a, const Summary& b)
+{
+    if (a.kind == Summary::MayThrow || b.kind == Summary::MayThrow) {
+        Summary s = a.kind == Summary::MayThrow ? a : b;
+        return s;
+    }
+    if (a.kind == b.kind && a.kind != Summary::Transparent)
+        return a;
+    auto toExit = [](const Summary& s) -> StateSet {
+        switch (s.kind) {
+        case Summary::Nothrow:
+        case Summary::Check:
+        case Summary::Release:
+            return kCleanOnly;
+        case Summary::Thrower:
+            return 1u << kThrown;
+        case Summary::Transparent:
+            return s.exitStates;
+        default:
+            return kCleanOnly;
+        }
+    };
+    Summary s;
+    s.kind = Summary::Transparent;
+    s.exitStates = toExit(a) | toExit(b);
+    s.verifiesAtEntry = a.verifiesAtEntry || b.verifiesAtEntry;
+    s.why = a.why;
+    return s;
+}
+
+struct Finding {
+    std::string file;
+    unsigned line = 0;
+    unsigned col = 0;
+    std::string function;
+    std::string callee;
+    std::string kind; // pending-call | thrown-call | unchecked-exit | scope-while-pending | lambda-check
+    std::string message;
+};
+
+// Explicit classifications from --nothrow/--maythrow files. Each line is
+// `<qualified name> [kind]` where kind is one of nothrow (default for the
+// --nothrow file), maythrow (default for the --maythrow file), thrower,
+// check, checkrelease, release. `indirect:<member>` classifies calls
+// through a function pointer member of that name (method tables).
+static std::map<std::string, Summary> gClassified;
+static std::map<std::string, Summary> gImported; // key: name/arity
+
+static void loadList(const std::string& path, Summary::Kind defaultKind)
+{
+    if (path.empty())
+        return;
+    std::ifstream in(path);
+    std::string line;
+    while (std::getline(in, line)) {
+        auto hash = line.find('#');
+        if (hash != std::string::npos)
+            line = line.substr(0, hash);
+        std::stringstream ss(line);
+        std::string name, kindStr;
+        ss >> name >> kindStr;
+        if (name.empty())
+            continue;
+        Summary s;
+        s.kind = defaultKind;
+        s.why = "allowlist";
+        if (kindStr == "nothrow")
+            s.kind = Summary::Nothrow;
+        else if (kindStr == "maythrow")
+            s.kind = Summary::MayThrow;
+        else if (kindStr == "thrower")
+            s.kind = Summary::Thrower;
+        else if (kindStr == "check")
+            s.kind = Summary::Check;
+        else if (kindStr == "release")
+            s.kind = Summary::Release;
+        else if (kindStr == "checkrelease") {
+            // Consumes the pending exception and releases the caller's scope
+            // (JSPromise::rejectWithCaughtException). Modeled as a helper
+            // whose exit state is clean+released.
+            s.kind = Summary::Transparent;
+            s.exitStates = (1u << 0) | (1u << kReleased);
+        }
+        if (s.kind == Summary::MayThrow || s.kind == Summary::Thrower)
+            s.verifiesAtEntry = true;
+        gClassified[name] = s;
+    }
+}
+
+// Summary line format (tab separated):
+//   mangledName  qualifiedName/arity  kind  exitStates  verifiesAtEntry  why
+// The mangled name identifies one overload across translation units. extern
+// "C" functions have no mangling and use their plain name.
+static void loadSummaries(const std::string& path)
+{
+    std::ifstream in(path);
+    std::string line;
+    while (std::getline(in, line)) {
+        std::vector<std::string> cols;
+        std::stringstream ss(line);
+        std::string col;
+        while (std::getline(ss, col, '\t'))
+            cols.push_back(col);
+        if (cols.size() < 5)
+            continue;
+        Summary s;
+        if (!Summary::parseKind(cols[2], s.kind))
+            continue;
+        s.exitStates = (StateSet)std::stoul(cols[3]);
+        s.verifiesAtEntry = cols[4] == "1";
+        s.why = cols.size() > 5 ? cols[5] : "";
+        auto it = gImported.find(cols[0]);
+        if (it == gImported.end())
+            gImported.emplace(cols[0], s);
+        else
+            it->second = mergeSummaries(it->second, s);
+    }
+}
+
+static std::string qualifiedName(const NamedDecl* D)
+{
+    std::string s;
+    llvm::raw_string_ostream os(s);
+    D->printQualifiedName(os);
+    return os.str();
+}
+
+static std::string summaryKey(const FunctionDecl* FD)
+{
+    return qualifiedName(FD) + "/" + std::to_string(FD->getNumParams());
+}
+
+static bool isGlobalObjectRecord(const CXXRecordDecl* RD)
+{
+    if (!RD)
+        return false;
+    if (RD->getDefinition())
+        RD = RD->getDefinition();
+    std::string name = qualifiedName(RD);
+    if (name == "JSC::JSGlobalObject")
+        return true;
+    if (!RD->hasDefinition())
+        return name.find("GlobalObject") != std::string::npos;
+    for (const CXXBaseSpecifier& base : RD->bases()) {
+        if (const CXXRecordDecl* baseRD = base.getType()->getAsCXXRecordDecl())
+            if (isGlobalObjectRecord(baseRD))
+                return true;
+    }
+    return false;
+}
+
+// True for JSC::JSGlobalObject* (or any subclass pointer/reference) and
+// JSC::ThrowScope&. These are the JSC conventions for "may throw".
+static bool isThrowCarrierType(QualType T)
+{
+    T = T.getNonReferenceType();
+    if (T->isPointerType())
+        T = T->getPointeeType();
+    const CXXRecordDecl* RD = T->getAsCXXRecordDecl();
+    if (!RD)
+        return false;
+    std::string name = qualifiedName(RD);
+    if (name == "JSC::ThrowScope")
+        return true;
+    return isGlobalObjectRecord(RD);
+}
+
+// A JSGlobalObject* parameter means "may throw" only when the function was
+// written for a global object. In an instantiation of WriteBarrier<T>::set or
+// jsCast<T*> with T = JSGlobalObject the type is incidental, so look at the
+// template pattern's parameter types and ignore the dependent ones.
+static bool hasThrowCarrierParam(const FunctionDecl* FD)
+{
+    const FunctionDecl* pattern = FD->getTemplateInstantiationPattern();
+    if (pattern && pattern->getNumParams() == FD->getNumParams()) {
+        for (unsigned i = 0; i < FD->getNumParams(); i++) {
+            QualType patternType = pattern->getParamDecl(i)->getType();
+            if (patternType->isDependentType())
+                continue;
+            if (isThrowCarrierType(FD->getParamDecl(i)->getType()))
+                return true;
+        }
+        return false;
+    }
+    for (const ParmVarDecl* P : FD->parameters())
+        if (isThrowCarrierType(P->getType()))
+            return true;
+    return false;
+}
+
+static bool hasThrowCarrierParam(const FunctionProtoType* FPT)
+{
+    if (!FPT)
+        return false;
+    for (QualType T : FPT->getParamTypes())
+        if (isThrowCarrierType(T))
+            return true;
+    return false;
+}
+
+static bool isScopeRecordName(const std::string& name)
+{
+    return name == "JSC::ThrowScope" || name == "JSC::TopExceptionScope";
+}
+
+static bool isScopeType(QualType T)
+{
+    const CXXRecordDecl* RD = T.getNonReferenceType()->getAsCXXRecordDecl();
+    return RD && isScopeRecordName(qualifiedName(RD));
+}
+
+static bool isExceptionOwnerRecord(const CXXRecordDecl* RD)
+{
+    if (!RD)
+        return false;
+    std::string n = qualifiedName(RD);
+    return n == "JSC::VM" || n == "JSC::ExceptionScope" || n == "JSC::ThrowScope" || n == "JSC::TopExceptionScope";
+}
+
+class Analyzer {
+public:
+    Analyzer(ASTContext& Ctx, std::vector<Finding>& out)
+        : m_ctx(Ctx)
+        , m_sm(Ctx.getSourceManager())
+        , m_findings(out)
+        , m_mangler(ItaniumMangleContext::create(Ctx, Ctx.getDiagnostics()))
+    {
+    }
+
+    // One name per overload, stable across translation units.
+    std::string mangledKey(const FunctionDecl* FD)
+    {
+        if (!m_mangler->shouldMangleDeclName(FD))
+            return FD->getNameAsString();
+        std::string out;
+        llvm::raw_string_ostream os(out);
+        if (const auto* ctor = dyn_cast<CXXConstructorDecl>(FD))
+            m_mangler->mangleName(GlobalDecl(ctor, Ctor_Complete), os);
+        else if (const auto* dtor = dyn_cast<CXXDestructorDecl>(FD))
+            m_mangler->mangleName(GlobalDecl(dtor, Dtor_Complete), os);
+        else
+            m_mangler->mangleName(GlobalDecl(FD), os);
+        return os.str();
+    }
+
+    // Classify a function for its callers. Memoized. Visible bodies are
+    // analyzed; invisible ones fall back to imported summaries, then to the
+    // JSC signature convention.
+    const Summary& summarize(const FunctionDecl* FD)
+    {
+        FD = FD->getCanonicalDecl();
+        auto it = m_summaries.find(FD);
+        if (it != m_summaries.end())
+            return it->second;
+        // Cycle guard: while a function is being analyzed, treat recursive
+        // calls to it as nothrow. This under-approximates recursion only.
+        Summary& slot = m_summaries[FD];
+        slot.kind = Summary::Nothrow;
+        slot.why = "in progress";
+        Summary computed = computeSummary(FD);
+        m_summaries[FD] = computed;
+        return m_summaries[FD];
+    }
+
+    // Analyze one function body and report findings.
+    void analyzeFunction(const FunctionDecl* FD)
+    {
+        if (!FD->doesThisDeclarationHaveABody() || !FD->getBody())
+            return;
+        if (!m_analyzed.insert(FD->getCanonicalDecl()).second)
+            return;
+        runBody(FD, /*report=*/true);
+        if (!ExportSummaries.empty())
+            summarize(FD);
+    }
+
+    // Summaries of functions with visible bodies, for --export-summaries.
+    void exportSummaries(llvm::raw_ostream& os, const std::string& under)
+    {
+        for (auto& [FD, s] : m_summaries) {
+            if (s.kind == Summary::Check || s.kind == Summary::Release)
+                continue;
+            if (s.why == "allowlist" || s.why == "imported")
+                continue;
+            if (s.why.rfind("no visible body", 0) == 0) {
+                // Not a summary: a leaf the analysis had to guess. Listed so
+                // the driver can report the most common guesses. The import
+                // side skips the "unknown" kind.
+                if (s.kind == Summary::MayThrow)
+                    os << mangledKey(FD) << "\t" << summaryKey(FD) << "\tunknown\t0\t0\t" << s.why << "\n";
+                continue;
+            }
+            const FunctionDecl* def = nullptr;
+            if (!FD->hasBody(def) || !def)
+                continue;
+            if (isa<CXXMethodDecl>(def) && cast<CXXMethodDecl>(def)->getParent()->isLambda())
+                continue;
+            PresumedLoc P = m_sm.getPresumedLoc(m_sm.getExpansionLoc(def->getLocation()));
+            if (!P.isValid())
+                continue;
+            std::string file = P.getFilename();
+            if (file.find(under) == std::string::npos || file.find("vendor/WebKit") != std::string::npos)
+                continue;
+            os << mangledKey(FD) << "\t" << summaryKey(FD) << "\t" << Summary::kindName(s.kind) << "\t" << s.exitStates << "\t" << (s.verifiesAtEntry ? "1" : "0") << "\t" << s.why << "\n";
+        }
+    }
+
+    // Force summaries for every function with a body in the TU (for export).
+    void summarizeForExport(const FunctionDecl* FD)
+    {
+        if (!FD->doesThisDeclarationHaveABody() || !FD->getBody())
+            return;
+        summarize(FD);
+    }
+
+private:
+    struct BodyResult {
+        StateSet exitStates = kCleanOnly;
+        bool hasOwnScope = false;
+        bool touchesException = false; // any may-throw call or scope
+        bool verifiesAtEntry = false;
+        std::string firstCause; // what made this body touch the exception state
+    };
+
+    std::string locString(SourceLocation loc)
+    {
+        PresumedLoc P = m_sm.getPresumedLoc(m_sm.getExpansionLoc(loc));
+        if (!P.isValid())
+            return "?";
+        std::string f = P.getFilename();
+        auto pos = f.rfind('/');
+        if (pos != std::string::npos)
+            f = f.substr(pos + 1);
+        return f + ":" + std::to_string(P.getLine());
+    }
+
+    Summary computeSummary(const FunctionDecl* FD)
+    {
+        Summary s;
+        std::string name = qualifiedName(FD);
+
+        // Explicit lists win.
+        {
+            auto it = gClassified.find(name);
+            if (it != gClassified.end())
+                return it->second;
+        }
+
+        // Exception-state accessors.
+        if (const auto* MD = dyn_cast<CXXMethodDecl>(FD)) {
+            if (isExceptionOwnerRecord(MD->getParent())) {
+                StringRef n = MD->getIdentifier() ? MD->getName() : StringRef();
+                if (n == "exception" || n == "clearException" || n == "assertNoException" || n == "releaseAssertNoException"
+                    || n == "assertNoExceptionExceptTermination" || n == "releaseAssertNoExceptionExceptTermination"
+                    || n == "tryClearException" || n == "clearExceptionExceptTermination" || n == "hasExceptionsAfterHandlingTraps") {
+                    s.kind = Summary::Check;
+                    s.why = "exception accessor";
+                    return s;
+                }
+                if (n == "release") {
+                    s.kind = Summary::Release;
+                    s.why = "scope release";
+                    return s;
+                }
+                if (n == "throwException") {
+                    s.kind = Summary::Thrower;
+                    s.verifiesAtEntry = true;
+                    s.why = "throwException";
+                    return s;
+                }
+            }
+        }
+
+        const FunctionDecl* def = nullptr;
+        if (FD->hasBody(def) && def && def->getBody() && !def->isDefaulted()) {
+            // Visible body. Analyze it.
+            BodyResult r = runBody(def, /*report=*/false);
+            if (r.hasOwnScope) {
+                s.kind = Summary::MayThrow;
+                s.verifiesAtEntry = true;
+                s.why = "declares a ThrowScope";
+                return s;
+            }
+            if (!r.touchesException) {
+                s.kind = Summary::Nothrow;
+                s.why = "body cannot throw";
+                return s;
+            }
+            if (!anyState(r.exitStates, kPending | kThrown | kReleased | kMaybe)) {
+                // It checks everything it calls before returning. Callers see
+                // no pending bit, exactly like the validator.
+                s.kind = Summary::Transparent;
+                s.verifiesAtEntry = r.verifiesAtEntry;
+                s.exitStates = r.exitStates;
+                s.why = "self-checking body (" + r.firstCause + ")";
+                return s;
+            }
+            // Transparent helper: no scope of its own.
+            s.kind = Summary::Transparent;
+            s.verifiesAtEntry = r.verifiesAtEntry;
+            s.exitStates = r.exitStates;
+            s.why = "calls " + r.firstCause;
+            return s;
+        }
+
+        // Throw helpers with no visible body are terminators: throwTypeError, throwVMError,
+        // throwOutOfMemoryError, Bun::ERR::*, Bun::throwError, ...
+        {
+            StringRef n = FD->getIdentifier() ? FD->getName() : StringRef();
+            bool inErrNamespace = name.rfind("Bun::ERR::", 0) == 0 || name.rfind("WebCore::ERR::", 0) == 0;
+            if ((n.starts_with("throw") && hasThrowCarrierParam(FD)) || inErrNamespace) {
+                s.kind = Summary::Thrower;
+                s.verifiesAtEntry = true;
+                s.why = "throw helper";
+                return s;
+            }
+        }
+
+        // Imported whole-project summary.
+        {
+            auto it = gImported.find(mangledKey(FD));
+            if (it != gImported.end()) {
+                s = it->second;
+                s.why = "imported";
+                return s;
+            }
+        }
+
+        // An extern "C" function with no body in any C++ translation unit is
+        // implemented in Rust. The Rust side runs under its own exception
+        // scope and reports a throw with a sentinel return value (empty
+        // JSValue, false, null), so the caller sees a conditional thrower.
+        if (FD->isExternC() && hasThrowCarrierParam(FD)) {
+            s.kind = Summary::Transparent;
+            s.verifiesAtEntry = true;
+            s.exitStates = kCleanOnly | (1u << kThrown);
+            s.why = "extern \"C\" with no C++ body (Rust); a throw is signaled by the return value";
+            return s;
+        }
+
+        // Virtual methods and unknown bodies: JSC convention.
+        if (hasThrowCarrierParam(FD)) {
+            s.kind = Summary::MayThrow;
+            s.verifiesAtEntry = true;
+            s.why = "no visible body; takes JSGlobalObject*/ThrowScope&";
+            return s;
+        }
+        s.kind = Summary::Nothrow;
+        s.why = "no visible body; no throw carrier parameter";
+        return s;
+    }
+
+    // The callee of a call expression, or null for indirect calls.
+    static const FunctionDecl* calleeOf(const CallExpr* CE)
+    {
+        if (const FunctionDecl* FD = CE->getDirectCallee())
+            return FD;
+        return nullptr;
+    }
+
+    Summary summarizeCall(const CallExpr* CE)
+    {
+        if (const FunctionDecl* FD = calleeOf(CE))
+            return summarize(FD);
+        // Indirect call: a method-table function pointer, a std::function,
+        // a lambda through a pointer. Use the member name, then the signature.
+        Summary s;
+        const Expr* calleeExpr = CE->getCallee()->IgnoreParenImpCasts();
+        if (const auto* ME = dyn_cast<MemberExpr>(calleeExpr)) {
+            auto it = gClassified.find("indirect:" + ME->getMemberDecl()->getNameAsString());
+            if (it != gClassified.end())
+                return it->second;
+        }
+        QualType T = calleeExpr->getType();
+        if (T->isPointerType() || T->isMemberPointerType())
+            T = T->getPointeeType();
+        if (const auto* FPT = T->getAs<FunctionProtoType>()) {
+            if (hasThrowCarrierParam(FPT)) {
+                s.kind = Summary::MayThrow;
+                s.verifiesAtEntry = true;
+                s.why = "indirect call; signature takes JSGlobalObject*/ThrowScope&";
+                return s;
+            }
+        }
+        s.kind = Summary::Nothrow;
+        s.why = "indirect call; no throw carrier parameter";
+        return s;
+    }
+
+    std::string describeCallee(const CallExpr* CE)
+    {
+        if (!calleeOf(CE)) {
+            if (const auto* ME = dyn_cast<MemberExpr>(CE->getCallee()->IgnoreParenImpCasts()))
+                return "<indirect call through " + ME->getMemberDecl()->getNameAsString() + ">";
+        }
+        if (const FunctionDecl* FD = calleeOf(CE)) {
+            if (const auto* MD = dyn_cast<CXXMethodDecl>(FD)) {
+                if (MD->getParent()->isLambda())
+                    return "<lambda at " + locString(MD->getParent()->getLocation()) + ">";
+            }
+            return qualifiedName(FD);
+        }
+        return "<indirect call>";
+    }
+
+    void report(const FunctionDecl* FD, SourceLocation loc, const std::string& kind, const std::string& callee, const std::string& message)
+    {
+        SourceLocation spelling = m_sm.getExpansionLoc(loc);
+        PresumedLoc P = m_sm.getPresumedLoc(spelling);
+        Finding f;
+        f.file = P.isValid() ? P.getFilename() : "<unknown>";
+        f.line = P.isValid() ? P.getLine() : 0;
+        f.col = P.isValid() ? P.getColumn() : 0;
+        f.function = qualifiedName(FD);
+        if (const auto* MD = dyn_cast<CXXMethodDecl>(FD))
+            if (MD->getParent()->isLambda())
+                f.function = "<lambda at " + locString(MD->getParent()->getLocation()) + ">";
+        f.callee = callee;
+        f.kind = kind;
+        f.message = message;
+        m_findings.push_back(std::move(f));
+    }
+
+    // Per-walk context: the last call that made the state pending/thrown, for
+    // the hint in messages.
+    struct WalkCtx {
+        std::string lastSource;
+    };
+
+    // Apply one CFG element to a state set. Returns the new state set.
+    // `report` controls whether violations are recorded.
+    StateSet step(const FunctionDecl* FD, const CFGElement& E, StateSet in, bool report, BodyResult& result, WalkCtx& ctx)
+    {
+        if (auto dtor = E.getAs<CFGAutomaticObjDtor>()) {
+            const VarDecl* VD = dtor->getVarDecl();
+            if (!VD || !isScopeType(VD->getType()))
+                return in;
+            std::string rdName = qualifiedName(VD->getType()->getAsCXXRecordDecl());
+            bool isTop = rdName == "JSC::TopExceptionScope";
+            bool reported = false;
+            StateSet out = mapStates(in, [&](unsigned st) {
+                bool pending = st & kPending;
+                bool released = st & kReleased;
+                if (pending && (isTop || !released) && report && !reported) {
+                    reported = true;
+                    SourceLocation loc = dtor->getTriggerStmt() ? dtor->getTriggerStmt()->getEndLoc() : VD->getLocation();
+                    this->report(FD, loc, "unchecked-exit", ctx.lastSource,
+                        "function exits with an exception check pending after " + ctx.lastSource + " (the " + (isTop ? "TopExceptionScope" : "ThrowScope") + " destructor asserts); add RETURN_IF_EXCEPTION or use RELEASE_AND_RETURN");
+                }
+                // After a ThrowScope destructor the caller must check
+                // (simulateThrow). TopExceptionScope does not simulate.
+                if (!isTop)
+                    return st | kPending;
+                return st & ~kPending;
+            });
+            if (!isTop)
+                ctx.lastSource = "the nested ThrowScope declared at " + locString(VD->getLocation());
+            return out;
+        }
+
+        auto stmtElem = E.getAs<CFGStmt>();
+        if (!stmtElem)
+            return in;
+        const Stmt* S = stmtElem->getStmt();
+
+        // Scope construction.
+        if (const auto* CC = dyn_cast<CXXConstructExpr>(S)) {
+            const CXXConstructorDecl* ctor = CC->getConstructor();
+            if (ctor && isScopeRecordName(qualifiedName(ctor->getParent())) && !ctor->isCopyOrMoveConstructor()) {
+                // A TopExceptionScope verifies like a ThrowScope but does not
+                // simulate a throw when destroyed, so it does not make the
+                // function "may throw" for its callers.
+                if (qualifiedName(ctor->getParent()) == "JSC::ThrowScope")
+                    result.hasOwnScope = true;
+                if (!result.touchesException) {
+                    result.verifiesAtEntry = true;
+                    result.firstCause = "ThrowScope at " + locString(CC->getBeginLoc());
+                }
+                result.touchesException = true;
+                if (anyState(in, kPending) && report)
+                    this->report(FD, CC->getBeginLoc(), "scope-while-pending", ctx.lastSource, "ThrowScope constructed while an exception check is pending after " + ctx.lastSource);
+                return mapStates(in, [](unsigned st) { return st & ~kPending; });
+            }
+            // Constructors that take a global object may run JS (rare).
+            if (ctor && hasThrowCarrierParam(ctor)) {
+                Summary s = summarize(ctor);
+                return applyCallSummary(FD, CC->getBeginLoc(), qualifiedName(ctor), s, in, report, result, ctx);
+            }
+            return in;
+        }
+
+        if (const auto* RS = dyn_cast<ReturnStmt>(S)) {
+            // The early return of RETURN_IF_EXCEPTION: the check happened and
+            // the exception is set. For a lambda or a scope-less helper this
+            // exit state tells the caller that an exception may be pending
+            // even though the bit is clear.
+            if (isInReturnIfExceptionMacro(RS))
+                return mapStates(in, [](unsigned st) { return (st & kReleased) | kThrown; });
+            return in;
+        }
+
+        const auto* CE = dyn_cast<CallExpr>(S);
+        if (!CE)
+            return in;
+        Summary s = summarizeCall(CE);
+        if (Verbose) {
+            llvm::errs() << locString(CE->getBeginLoc()) << " call " << describeCallee(CE) << " -> " << Summary::kindName(s.kind) << " exit=" << s.exitStates << " (" << s.why << ")\n";
+        }
+        return applyCallSummary(FD, CE->getBeginLoc(), describeCallee(CE), s, in, report, result, ctx);
+    }
+
+    // True when the statement is spelled inside a RETURN_IF_EXCEPTION-style
+    // macro expansion.
+    bool isInReturnIfExceptionMacro(const Stmt* S)
+    {
+        SourceLocation loc = S->getBeginLoc();
+        if (!loc.isMacroID())
+            return false;
+        while (loc.isMacroID()) {
+            StringRef name = Lexer::getImmediateMacroName(loc, m_sm, m_ctx.getLangOpts());
+            if (name.contains("RETURN_IF_EXCEPTION") || name.contains("RETURN_IF_VM_EXCEPTION") || name.contains("RETURN_STATUS_IF_EXCEPTION") || name == "TRY_CLEAR_EXCEPTION")
+                return true;
+            loc = m_sm.getImmediateMacroCallerLoc(loc);
+        }
+        return false;
+    }
+
+    StateSet applyCallSummary(const FunctionDecl* FD, SourceLocation loc, const std::string& callee, const Summary& s, StateSet in, bool report, BodyResult& result, WalkCtx& ctx)
+    {
+        switch (s.kind) {
+        case Summary::Nothrow:
+            return in;
+        case Summary::Check:
+            result.touchesException = true;
+            return mapStates(in, [](unsigned st) { return st & ~(kPending | kThrown | kMaybe); });
+        case Summary::Release:
+            return mapStates(in, [](unsigned st) { return st | kReleased; });
+        case Summary::MayThrow:
+        case Summary::Thrower:
+        case Summary::Transparent: {
+            if (!result.touchesException) {
+                result.verifiesAtEntry = s.verifiesAtEntry;
+                result.firstCause = callee + " at " + locString(loc);
+            }
+            result.touchesException = true;
+            if (report) {
+                if (anyState(in, kPending) && s.verifiesAtEntry)
+                    this->report(FD, loc, "pending-call", callee, "call to " + callee + " while an exception check is pending after " + ctx.lastSource + "; add RETURN_IF_EXCEPTION after it");
+                if (anyState(in, kThrown))
+                    this->report(FD, loc, "thrown-call", callee, "call to " + callee + " after " + ctx.lastSource + " threw; return after throwing");
+                else if (anyState(in, kMaybe))
+                    this->report(FD, loc, "maybe-thrown-call", callee, "call to " + callee + " after " + ctx.lastSource + " may have thrown and returned a failure value; check the exception or the result first");
+            }
+            // Exit states of the callee, as seen from here. A conditional
+            // thrower (exits both clean and thrown) becomes `maybe`: the
+            // caller usually tests its return value, which the analysis
+            // cannot see.
+            StateSet calleeExits;
+            switch (s.kind) {
+            case Summary::MayThrow:
+                calleeExits = 1u << kPending;
+                break;
+            case Summary::Thrower:
+                calleeExits = 1u << kThrown;
+                break;
+            default:
+                calleeExits = s.exitStates;
+                break;
+            }
+            bool hasClean = false, hasThrown = false;
+            for (unsigned ex = 0; ex < kNumStates; ex++) {
+                if (!(calleeExits & (1u << ex)))
+                    continue;
+                if (!(ex & (kPending | kThrown | kMaybe)))
+                    hasClean = true;
+                if (ex & kThrown)
+                    hasThrown = true;
+            }
+            StateSet out = 0;
+            for (unsigned st = 0; st < kNumStates; st++) {
+                if (!(in & (1u << st)))
+                    continue;
+                unsigned keep = st & kReleased;
+                for (unsigned ex = 0; ex < kNumStates; ex++) {
+                    if (!(calleeExits & (1u << ex)))
+                        continue;
+                    unsigned bits = ex & (kPending | kThrown | kMaybe | kReleased);
+                    if ((bits & kThrown) && hasClean && hasThrown)
+                        bits = (bits & ~kThrown) | kMaybe;
+                    out |= 1u << ((keep | bits) & (kNumStates - 1));
+                }
+            }
+            if (anyState(out, kPending | kThrown | kMaybe))
+                ctx.lastSource = callee + " (" + locString(loc) + ")";
+            return out;
+        }
+        }
+        return in;
+    }
+
+    BodyResult runBody(const FunctionDecl* FD, bool report)
+    {
+        BodyResult result;
+        CFG::BuildOptions opts;
+        opts.AddImplicitDtors = true;
+        opts.AddTemporaryDtors = true;
+        opts.AddInitializers = true;
+        opts.AddCXXDefaultInitExprInCtors = true;
+        opts.setAllAlwaysAdd();
+        std::unique_ptr<CFG> cfg = CFG::buildCFG(FD, FD->getBody(), &m_ctx, opts);
+        if (!cfg)
+            return result;
+
+        unsigned n = cfg->getNumBlockIDs();
+        std::vector<StateSet> inStates(n, 0), outStates(n, 0);
+        std::vector<std::string> inSource(n), outSource(n);
+        std::vector<bool> inSourceDirty(n, false); // inSource came from a predecessor with a pending/thrown state
+        inStates[cfg->getEntry().getBlockID()] = kCleanOnly;
+
+        // Worklist fixpoint. The lattice is tiny (8 bits), so this converges fast.
+        std::vector<const CFGBlock*> work;
+        std::vector<bool> queued(n, false);
+        work.push_back(&cfg->getEntry());
+        queued[cfg->getEntry().getBlockID()] = true;
+        while (!work.empty()) {
+            const CFGBlock* B = work.back();
+            work.pop_back();
+            unsigned id = B->getBlockID();
+            queued[id] = false;
+            StateSet st = inStates[id];
+            BodyResult scratch;
+            WalkCtx ctx;
+            ctx.lastSource = inSource[id];
+            for (const CFGElement& E : *B)
+                st = step(FD, E, st, /*report=*/false, scratch, ctx);
+            bool changed = st != outStates[id] || outSource[id] != ctx.lastSource;
+            outStates[id] = st;
+            outSource[id] = ctx.lastSource;
+            if (!changed && st != 0)
+                continue;
+            for (const CFGBlock::AdjacentBlock& succ : B->succs()) {
+                const CFGBlock* S = succ.getReachableBlock();
+                if (!S)
+                    continue;
+                unsigned sid = S->getBlockID();
+                StateSet merged = inStates[sid] | st;
+                bool srcChanged = false;
+                bool dirty = anyState(st, kPending | kThrown | kMaybe);
+                if (!ctx.lastSource.empty() && (inSource[sid].empty() || (dirty && !inSourceDirty[sid]))) {
+                    inSource[sid] = ctx.lastSource;
+                    inSourceDirty[sid] = dirty;
+                    srcChanged = true;
+                }
+                if (merged != inStates[sid] || srcChanged || !queued[sid]) {
+                    inStates[sid] = merged;
+                    if (!queued[sid]) {
+                        queued[sid] = true;
+                        work.push_back(S);
+                    }
+                }
+            }
+        }
+
+        // Final pass: report, and compute the body facts.
+        for (const CFGBlock* B : *cfg) {
+            unsigned id = B->getBlockID();
+            StateSet st = inStates[id];
+            if (st == 0)
+                continue; // unreachable
+            WalkCtx ctx;
+            ctx.lastSource = inSource[id];
+            for (const CFGElement& E : *B)
+                st = step(FD, E, st, report, result, ctx);
+        }
+        result.exitStates = inStates[cfg->getExit().getBlockID()];
+        if (result.exitStates == 0)
+            result.exitStates = kCleanOnly; // no normal exit (noreturn)
+        return result;
+    }
+
+    ASTContext& m_ctx;
+    SourceManager& m_sm;
+    std::vector<Finding>& m_findings;
+    std::unique_ptr<ItaniumMangleContext> m_mangler;
+    std::unordered_map<const FunctionDecl*, Summary> m_summaries;
+    std::unordered_set<const FunctionDecl*> m_analyzed;
+};
+
+class Visitor : public RecursiveASTVisitor<Visitor> {
+public:
+    Visitor(ASTContext& Ctx, Analyzer& A, std::string onlyUnder, std::string exportUnder)
+        : m_ctx(Ctx)
+        , m_analyzer(A)
+        , m_onlyUnder(std::move(onlyUnder))
+        , m_exportUnder(std::move(exportUnder))
+    {
+    }
+
+    bool shouldVisitTemplateInstantiations() const { return true; }
+    bool shouldVisitImplicitCode() const { return false; }
+
+    bool VisitFunctionDecl(FunctionDecl* FD)
+    {
+        maybeAnalyze(FD);
+        return true;
+    }
+
+    bool VisitLambdaExpr(LambdaExpr* LE)
+    {
+        if (CXXMethodDecl* op = LE->getCallOperator())
+            maybeAnalyze(op);
+        return true;
+    }
+
+private:
+    void maybeAnalyze(FunctionDecl* FD)
+    {
+        if (!FD->doesThisDeclarationHaveABody() || !FD->getBody())
+            return;
+        if (FD->isDependentContext())
+            return; // uninstantiated template pattern; instantiations are visited separately
+        SourceManager& SM = m_ctx.getSourceManager();
+        SourceLocation loc = SM.getExpansionLoc(FD->getLocation());
+        if (loc.isInvalid())
+            return;
+        PresumedLoc P = SM.getPresumedLoc(loc);
+        if (!P.isValid())
+            return;
+        std::string file = P.getFilename();
+        if (file.find(m_onlyUnder) != std::string::npos)
+            m_analyzer.analyzeFunction(FD);
+        else if (!ExportSummaries.empty() && file.find(m_exportUnder) != std::string::npos && file.find("vendor/WebKit") == std::string::npos)
+            m_analyzer.summarizeForExport(FD);
+    }
+
+    ASTContext& m_ctx;
+    Analyzer& m_analyzer;
+    std::string m_onlyUnder;
+    std::string m_exportUnder;
+};
+
+class Consumer : public ASTConsumer {
+public:
+    void HandleTranslationUnit(ASTContext& Ctx) override
+    {
+        std::vector<Finding> findings;
+        Analyzer analyzer(Ctx, findings);
+        Visitor visitor(Ctx, analyzer, OnlyPathPrefix, ExportUnder);
+        visitor.TraverseDecl(Ctx.getTranslationUnitDecl());
+
+        if (!ExportSummaries.empty()) {
+            std::error_code ec;
+            llvm::raw_fd_ostream os(ExportSummaries, ec, llvm::sys::fs::OF_Append | llvm::sys::fs::OF_Text);
+            if (!ec)
+                analyzer.exportSummaries(os, ExportUnder);
+        }
+
+        // Dedupe (template instantiations report the same line many times).
+        std::set<std::string> seen;
+        for (const Finding& f : findings) {
+            std::string key = f.file + ":" + std::to_string(f.line) + ":" + std::to_string(f.col) + ":" + f.kind + ":" + f.callee;
+            if (!seen.insert(key).second)
+                continue;
+            if (JsonOutput) {
+                auto esc = [](const std::string& s) {
+                    std::string o;
+                    for (char c : s) {
+                        if (c == '"' || c == '\\')
+                            o += '\\';
+                        if (c == '\n') {
+                            o += "\\n";
+                            continue;
+                        }
+                        o += c;
+                    }
+                    return o;
+                };
+                llvm::outs() << "{\"file\":\"" << esc(f.file) << "\",\"line\":" << f.line << ",\"col\":" << f.col
+                             << ",\"function\":\"" << esc(f.function) << "\",\"callee\":\"" << esc(f.callee)
+                             << "\",\"kind\":\"" << f.kind << "\",\"message\":\"" << esc(f.message) << "\"}\n";
+            } else {
+                llvm::outs() << f.file << ":" << f.line << ":" << f.col << ": [" << f.kind << "] in " << f.function << ": " << f.message << "\n";
+            }
+        }
+        llvm::outs().flush();
+    }
+};
+
+class Action : public ASTFrontendAction {
+public:
+    std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance& CI, StringRef) override
+    {
+        // We only need the AST. Silence diagnostics from the huge header set.
+        CI.getDiagnostics().setIgnoreAllWarnings(true);
+        return std::make_unique<Consumer>();
+    }
+};
+
+} // namespace
+
+int main(int argc, const char** argv)
+{
+    auto parser = CommonOptionsParser::create(argc, argv, Category);
+    if (!parser) {
+        llvm::errs() << llvm::toString(parser.takeError());
+        return 1;
+    }
+    loadList(NothrowFile, Summary::Nothrow);
+    loadList(ThrowFile, Summary::MayThrow);
+    for (const std::string& path : ImportSummaries)
+        loadSummaries(path);
+    ClangTool tool(parser->getCompilations(), parser->getSourcePathList());
+    // Drop flags that only matter for code generation and slow down parsing.
+    tool.appendArgumentsAdjuster(getClangStripOutputAdjuster());
+    tool.appendArgumentsAdjuster(getClangStripDependencyFileAdjuster());
+    tool.appendArgumentsAdjuster(getInsertArgumentAdjuster("-Wno-everything", ArgumentInsertPosition::END));
+    tool.appendArgumentsAdjuster(getInsertArgumentAdjuster("-fsyntax-only", ArgumentInsertPosition::END));
+    // The build writes shell-escaped quotes into the arguments array
+    // (-DFOO=\"bar\"). The PCH was built with the unescaped value, so the
+    // macro definitions have to match or clang rejects the PCH.
+    tool.appendArgumentsAdjuster([](const CommandLineArguments& args, StringRef) {
+        CommandLineArguments out;
+        for (std::string a : args) {
+            if (a.rfind("-D", 0) == 0) {
+                std::string fixed;
+                for (size_t i = 0; i < a.size(); i++) {
+                    if (a[i] == '\\' && i + 1 < a.size() && a[i + 1] == '"')
+                        continue;
+                    fixed += a[i];
+                }
+                a = fixed;
+            }
+            out.push_back(a);
+        }
+        return out;
+    });
+    return tool.run(newFrontendActionFactory<Action>().get());
+}

--- a/scripts/jsc-exception-lint/jsc-exception-lint.cpp
+++ b/scripts/jsc-exception-lint/jsc-exception-lint.cpp
@@ -66,136 +66,169 @@ using namespace clang;
 using namespace clang::tooling;
 
 static llvm::cl::OptionCategory Category("jsc-exception-lint options");
-static llvm::cl::opt<std::string> NothrowFile("nothrow", llvm::cl::desc("file with one qualified function name per line that is known not to throw"), llvm::cl::cat(Category));
-static llvm::cl::opt<std::string> ThrowFile("maythrow", llvm::cl::desc("file with one qualified function name per line that is known to throw"), llvm::cl::cat(Category));
-static llvm::cl::opt<std::string> OnlyPathPrefix("only-under", llvm::cl::desc("only report functions defined in files whose path contains this string"), llvm::cl::init("src/jsc/bindings"), llvm::cl::cat(Category));
-static llvm::cl::opt<std::string> ExportSummaries("export-summaries", llvm::cl::desc("write callee summaries for functions defined in files matching --export-under to this file"), llvm::cl::cat(Category));
-static llvm::cl::opt<std::string> ExportUnder("export-under", llvm::cl::desc("path substring that selects functions to export"), llvm::cl::init("/src/"), llvm::cl::cat(Category));
-static llvm::cl::list<std::string> ImportSummaries("import-summaries", llvm::cl::desc("read callee summaries from this file (repeatable)"), llvm::cl::cat(Category));
-static llvm::cl::opt<bool> JsonOutput("json", llvm::cl::desc("emit one JSON object per line"), llvm::cl::cat(Category));
-static llvm::cl::opt<bool> Verbose("verbose", llvm::cl::desc("print callee classification for every call"), llvm::cl::cat(Category));
+static llvm::cl::opt<std::string>
+    NothrowFile("nothrow",
+                llvm::cl::desc("file with one qualified function name per line "
+                               "that is known not to throw"),
+                llvm::cl::cat(Category));
+static llvm::cl::opt<std::string>
+    ThrowFile("maythrow",
+              llvm::cl::desc("file with one qualified function name per line "
+                             "that is known to throw"),
+              llvm::cl::cat(Category));
+static llvm::cl::opt<std::string>
+    OnlyPathPrefix("only-under",
+                   llvm::cl::desc("only report functions defined in files "
+                                  "whose path contains this string"),
+                   llvm::cl::init("src/jsc/bindings"), llvm::cl::cat(Category));
+static llvm::cl::opt<std::string> ExportSummaries(
+    "export-summaries",
+    llvm::cl::desc("write callee summaries for functions defined in files "
+                   "matching --export-under to this file"),
+    llvm::cl::cat(Category));
+static llvm::cl::list<std::string> ExportUnder(
+    "export-under",
+    llvm::cl::desc(
+        "path substring that selects functions to export (repeatable)"),
+    llvm::cl::cat(Category));
+static llvm::cl::list<std::string> ImportSummaries(
+    "import-summaries",
+    llvm::cl::desc("read callee summaries from this file (repeatable)"),
+    llvm::cl::cat(Category));
+static llvm::cl::opt<bool>
+    JsonOutput("json", llvm::cl::desc("emit one JSON object per line"),
+               llvm::cl::cat(Category));
+static llvm::cl::opt<bool>
+    Verbose("verbose",
+            llvm::cl::desc("print callee classification for every call"),
+            llvm::cl::cat(Category));
 
 namespace {
 
 // Abstract state bits. The set of reachable states at a program point is a
 // bitmask over the 8 combinations of these three bits.
 enum : unsigned {
-    kPending = 1, // a callee's ThrowScope simulated a throw; an exception() query is due
-    kThrown = 2, // this function threw (or a callee surely did); it must return without calling into JS again
-    kReleased = 4, // this function's own ThrowScope was released (RELEASE_AND_RETURN)
-    kMaybe = 8, // a callee may have thrown into our scope and returned a failure value; the bit is clear
-    kNumStates = 16,
+  kPending =
+      1, // a callee's ThrowScope simulated a throw; an exception() query is due
+  kThrown = 2, // this function threw (or a callee surely did); it must return
+               // without calling into JS again
+  kReleased =
+      4, // this function's own ThrowScope was released (RELEASE_AND_RETURN)
+  kMaybe = 8, // a callee may have thrown into our scope and returned a failure
+              // value; the bit is clear
+  kNumStates = 16,
 };
 
 using StateSet = unsigned; // bit i set <=> abstract state i is reachable
 
 static constexpr StateSet kCleanOnly = 1u << 0;
 
-static bool anyState(StateSet s, unsigned bit)
-{
-    for (unsigned st = 0; st < kNumStates; st++)
-        if ((s & (1u << st)) && (st & bit))
-            return true;
-    return false;
+static bool anyState(StateSet s, unsigned bit) {
+  for (unsigned st = 0; st < kNumStates; st++)
+    if ((s & (1u << st)) && (st & bit))
+      return true;
+  return false;
 }
 
-template<typename F>
-static StateSet mapStates(StateSet in, F f)
-{
-    StateSet out = 0;
-    for (unsigned st = 0; st < kNumStates; st++)
-        if (in & (1u << st))
-            out |= 1u << (f(st) & (kNumStates - 1));
-    return out;
+template <typename F> static StateSet mapStates(StateSet in, F f) {
+  StateSet out = 0;
+  for (unsigned st = 0; st < kNumStates; st++)
+    if (in & (1u << st))
+      out |= 1u << (f(st) & (kNumStates - 1));
+  return out;
 }
 
 // Summary of a callee, as seen by its callers.
 struct Summary {
-    enum Kind {
-        Nothrow, // cannot throw; does not touch the exception bit
-        Check, // queries the exception (clears the bit)
-        Release, // ThrowScope::release()
-        MayThrow, // declares a scope: after the call, the state is `pending`
-        Thrower, // after the call, the state is `thrown`
-        Transparent, // no own scope; exit states are those of its body
-    };
-    Kind kind = Nothrow;
-    bool verifiesAtEntry = false; // constructs a scope (or calls into one) before any check
-    StateSet exitStates = kCleanOnly; // for Transparent: states at exit when entered clean
-    std::string why;
+  enum Kind {
+    Nothrow,     // cannot throw; does not touch the exception bit
+    Check,       // queries the exception (clears the bit)
+    Release,     // ThrowScope::release()
+    MayThrow,    // declares a scope: after the call, the state is `pending`
+    Thrower,     // after the call, the state is `thrown`
+    Transparent, // no own scope; exit states are those of its body
+  };
+  Kind kind = Nothrow;
+  bool verifiesAtEntry =
+      false; // constructs a scope (or calls into one) before any check
+  bool consumesException = false; // takes the pending exception off the VM
+                                  // (rejectWithCaughtException)
+  StateSet exitStates =
+      kCleanOnly; // for Transparent: states at exit when entered clean
+  std::string why;
 
-    bool mayThrow() const { return kind == MayThrow || kind == Thrower || kind == Transparent; }
+  bool mayThrow() const {
+    return kind == MayThrow || kind == Thrower || kind == Transparent;
+  }
 
-    static const char* kindName(Kind k)
-    {
-        switch (k) {
-        case Nothrow:
-            return "nothrow";
-        case Check:
-            return "check";
-        case Release:
-            return "release";
-        case MayThrow:
-            return "maythrow";
-        case Thrower:
-            return "thrower";
-        case Transparent:
-            return "transparent";
-        }
-        return "?";
+  static const char *kindName(Kind k) {
+    switch (k) {
+    case Nothrow:
+      return "nothrow";
+    case Check:
+      return "check";
+    case Release:
+      return "release";
+    case MayThrow:
+      return "maythrow";
+    case Thrower:
+      return "thrower";
+    case Transparent:
+      return "transparent";
     }
-    static bool parseKind(const std::string& s, Kind& out)
-    {
-        for (int k = Nothrow; k <= Transparent; k++) {
-            if (s == kindName((Kind)k)) {
-                out = (Kind)k;
-                return true;
-            }
-        }
-        return false;
+    return "?";
+  }
+  static bool parseKind(const std::string &s, Kind &out) {
+    for (int k = Nothrow; k <= Transparent; k++) {
+      if (s == kindName((Kind)k)) {
+        out = (Kind)k;
+        return true;
+      }
     }
+    return false;
+  }
 };
 
 // Merge two summaries for the same name/arity coming from different
 // translation units or overloads. The result is the more conservative one.
-static Summary mergeSummaries(const Summary& a, const Summary& b)
-{
-    if (a.kind == Summary::MayThrow || b.kind == Summary::MayThrow) {
-        Summary s = a.kind == Summary::MayThrow ? a : b;
-        return s;
-    }
-    if (a.kind == b.kind && a.kind != Summary::Transparent)
-        return a;
-    auto toExit = [](const Summary& s) -> StateSet {
-        switch (s.kind) {
-        case Summary::Nothrow:
-        case Summary::Check:
-        case Summary::Release:
-            return kCleanOnly;
-        case Summary::Thrower:
-            return 1u << kThrown;
-        case Summary::Transparent:
-            return s.exitStates;
-        default:
-            return kCleanOnly;
-        }
-    };
-    Summary s;
-    s.kind = Summary::Transparent;
-    s.exitStates = toExit(a) | toExit(b);
-    s.verifiesAtEntry = a.verifiesAtEntry || b.verifiesAtEntry;
-    s.why = a.why;
+static Summary mergeSummaries(const Summary &a, const Summary &b) {
+  if (a.kind == Summary::MayThrow || b.kind == Summary::MayThrow) {
+    Summary s = a.kind == Summary::MayThrow ? a : b;
     return s;
+  }
+  if (a.kind == b.kind && a.kind != Summary::Transparent)
+    return a;
+  auto toExit = [](const Summary &s) -> StateSet {
+    switch (s.kind) {
+    case Summary::Nothrow:
+    case Summary::Check:
+    case Summary::Release:
+      return kCleanOnly;
+    case Summary::Thrower:
+      return 1u << kThrown;
+    case Summary::Transparent:
+      return s.exitStates;
+    default:
+      return kCleanOnly;
+    }
+  };
+  Summary s;
+  s.kind = Summary::Transparent;
+  s.exitStates = toExit(a) | toExit(b);
+  s.verifiesAtEntry = a.verifiesAtEntry || b.verifiesAtEntry;
+  s.why = a.why;
+  return s;
 }
 
 struct Finding {
-    std::string file;
-    unsigned line = 0;
-    unsigned col = 0;
-    std::string function;
-    std::string callee;
-    std::string kind; // pending-call | thrown-call | unchecked-exit | scope-while-pending | lambda-check
-    std::string message;
+  std::string file;
+  unsigned line = 0;
+  unsigned col = 0;
+  std::string function;
+  std::string callee;
+  std::string kind; // pending-call | thrown-call | unchecked-exit |
+                    // scope-while-pending | lambda-check
+  std::string message;
 };
 
 // Explicit classifications from --nothrow/--maythrow files. Each line is
@@ -206,893 +239,946 @@ struct Finding {
 static std::map<std::string, Summary> gClassified;
 static std::map<std::string, Summary> gImported; // key: name/arity
 
-static void loadList(const std::string& path, Summary::Kind defaultKind)
-{
-    if (path.empty())
-        return;
-    std::ifstream in(path);
-    std::string line;
-    while (std::getline(in, line)) {
-        auto hash = line.find('#');
-        if (hash != std::string::npos)
-            line = line.substr(0, hash);
-        std::stringstream ss(line);
-        std::string name, kindStr;
-        ss >> name >> kindStr;
-        if (name.empty())
-            continue;
-        Summary s;
-        s.kind = defaultKind;
-        s.why = "allowlist";
-        if (kindStr == "nothrow")
-            s.kind = Summary::Nothrow;
-        else if (kindStr == "maythrow")
-            s.kind = Summary::MayThrow;
-        else if (kindStr == "thrower")
-            s.kind = Summary::Thrower;
-        else if (kindStr == "check")
-            s.kind = Summary::Check;
-        else if (kindStr == "release")
-            s.kind = Summary::Release;
-        else if (kindStr == "checkrelease") {
-            // Consumes the pending exception and releases the caller's scope
-            // (JSPromise::rejectWithCaughtException). Modeled as a helper
-            // whose exit state is clean+released.
-            s.kind = Summary::Transparent;
-            s.exitStates = (1u << 0) | (1u << kReleased);
-        }
-        if (s.kind == Summary::MayThrow || s.kind == Summary::Thrower)
-            s.verifiesAtEntry = true;
-        gClassified[name] = s;
+static void loadList(const std::string &path, Summary::Kind defaultKind) {
+  if (path.empty())
+    return;
+  std::ifstream in(path);
+  std::string line;
+  while (std::getline(in, line)) {
+    auto hash = line.find('#');
+    if (hash != std::string::npos)
+      line = line.substr(0, hash);
+    std::stringstream ss(line);
+    std::string name, kindStr;
+    ss >> name >> kindStr;
+    if (name.empty())
+      continue;
+    Summary s;
+    s.kind = defaultKind;
+    s.why = "allowlist";
+    if (kindStr == "nothrow")
+      s.kind = Summary::Nothrow;
+    else if (kindStr == "maythrow")
+      s.kind = Summary::MayThrow;
+    else if (kindStr == "thrower")
+      s.kind = Summary::Thrower;
+    else if (kindStr == "check")
+      s.kind = Summary::Check;
+    else if (kindStr == "release")
+      s.kind = Summary::Release;
+    else if (kindStr == "checkrelease") {
+      // Consumes the pending exception and releases the caller's scope
+      // (JSPromise::rejectWithCaughtException). Modeled as a helper
+      // whose exit state is clean+released.
+      s.kind = Summary::Transparent;
+      s.consumesException = true;
+      s.exitStates = (1u << 0) | (1u << kReleased);
     }
+    if (s.kind == Summary::MayThrow || s.kind == Summary::Thrower)
+      s.verifiesAtEntry = true;
+    gClassified[name] = s;
+  }
 }
 
 // Summary line format (tab separated):
 //   mangledName  qualifiedName/arity  kind  exitStates  verifiesAtEntry  why
 // The mangled name identifies one overload across translation units. extern
 // "C" functions have no mangling and use their plain name.
-static void loadSummaries(const std::string& path)
-{
-    std::ifstream in(path);
-    std::string line;
-    while (std::getline(in, line)) {
-        std::vector<std::string> cols;
-        std::stringstream ss(line);
-        std::string col;
-        while (std::getline(ss, col, '\t'))
-            cols.push_back(col);
-        if (cols.size() < 5)
-            continue;
-        Summary s;
-        if (!Summary::parseKind(cols[2], s.kind))
-            continue;
-        s.exitStates = (StateSet)std::stoul(cols[3]);
-        s.verifiesAtEntry = cols[4] == "1";
-        s.why = cols.size() > 5 ? cols[5] : "";
-        auto it = gImported.find(cols[0]);
-        if (it == gImported.end())
-            gImported.emplace(cols[0], s);
-        else
-            it->second = mergeSummaries(it->second, s);
-    }
+static void loadSummaries(const std::string &path) {
+  std::ifstream in(path);
+  std::string line;
+  while (std::getline(in, line)) {
+    std::vector<std::string> cols;
+    std::stringstream ss(line);
+    std::string col;
+    while (std::getline(ss, col, '\t'))
+      cols.push_back(col);
+    if (cols.size() < 5)
+      continue;
+    Summary s;
+    if (!Summary::parseKind(cols[2], s.kind))
+      continue;
+    s.exitStates = (StateSet)std::stoul(cols[3]);
+    s.verifiesAtEntry = cols[4] == "1";
+    s.why = cols.size() > 5 ? cols[5] : "";
+    auto it = gImported.find(cols[0]);
+    if (it == gImported.end())
+      gImported.emplace(cols[0], s);
+    else
+      it->second = mergeSummaries(it->second, s);
+  }
 }
 
-static std::string qualifiedName(const NamedDecl* D)
-{
-    std::string s;
-    llvm::raw_string_ostream os(s);
-    D->printQualifiedName(os);
-    return os.str();
+static std::string qualifiedName(const NamedDecl *D) {
+  std::string s;
+  llvm::raw_string_ostream os(s);
+  D->printQualifiedName(os);
+  return os.str();
 }
 
-static std::string summaryKey(const FunctionDecl* FD)
-{
-    return qualifiedName(FD) + "/" + std::to_string(FD->getNumParams());
+static std::string summaryKey(const FunctionDecl *FD) {
+  return qualifiedName(FD) + "/" + std::to_string(FD->getNumParams());
 }
 
-static bool isGlobalObjectRecord(const CXXRecordDecl* RD)
-{
-    if (!RD)
-        return false;
-    if (RD->getDefinition())
-        RD = RD->getDefinition();
-    std::string name = qualifiedName(RD);
-    if (name == "JSC::JSGlobalObject")
-        return true;
-    if (!RD->hasDefinition())
-        return name.find("GlobalObject") != std::string::npos;
-    for (const CXXBaseSpecifier& base : RD->bases()) {
-        if (const CXXRecordDecl* baseRD = base.getType()->getAsCXXRecordDecl())
-            if (isGlobalObjectRecord(baseRD))
-                return true;
-    }
+static bool isGlobalObjectRecord(const CXXRecordDecl *RD) {
+  if (!RD)
     return false;
+  if (RD->getDefinition())
+    RD = RD->getDefinition();
+  std::string name = qualifiedName(RD);
+  if (name == "JSC::JSGlobalObject")
+    return true;
+  if (!RD->hasDefinition())
+    return name.find("GlobalObject") != std::string::npos;
+  for (const CXXBaseSpecifier &base : RD->bases()) {
+    if (const CXXRecordDecl *baseRD = base.getType()->getAsCXXRecordDecl())
+      if (isGlobalObjectRecord(baseRD))
+        return true;
+  }
+  return false;
 }
 
 // True for JSC::JSGlobalObject* (or any subclass pointer/reference) and
 // JSC::ThrowScope&. These are the JSC conventions for "may throw".
-static bool isThrowCarrierType(QualType T)
-{
-    T = T.getNonReferenceType();
-    if (T->isPointerType())
-        T = T->getPointeeType();
-    const CXXRecordDecl* RD = T->getAsCXXRecordDecl();
-    if (!RD)
-        return false;
-    std::string name = qualifiedName(RD);
-    if (name == "JSC::ThrowScope")
-        return true;
-    return isGlobalObjectRecord(RD);
+static bool isThrowCarrierType(QualType T) {
+  T = T.getNonReferenceType();
+  if (T->isPointerType())
+    T = T->getPointeeType();
+  const CXXRecordDecl *RD = T->getAsCXXRecordDecl();
+  if (!RD)
+    return false;
+  std::string name = qualifiedName(RD);
+  if (name == "JSC::ThrowScope")
+    return true;
+  return isGlobalObjectRecord(RD);
 }
 
 // A JSGlobalObject* parameter means "may throw" only when the function was
 // written for a global object. In an instantiation of WriteBarrier<T>::set or
 // jsCast<T*> with T = JSGlobalObject the type is incidental, so look at the
 // template pattern's parameter types and ignore the dependent ones.
-static bool hasThrowCarrierParam(const FunctionDecl* FD)
-{
-    const FunctionDecl* pattern = FD->getTemplateInstantiationPattern();
-    if (pattern && pattern->getNumParams() == FD->getNumParams()) {
-        for (unsigned i = 0; i < FD->getNumParams(); i++) {
-            QualType patternType = pattern->getParamDecl(i)->getType();
-            if (patternType->isDependentType())
-                continue;
-            if (isThrowCarrierType(FD->getParamDecl(i)->getType()))
-                return true;
-        }
-        return false;
+static bool hasThrowCarrierParam(const FunctionDecl *FD) {
+  const FunctionDecl *pattern = FD->getTemplateInstantiationPattern();
+  if (pattern && pattern->getNumParams() == FD->getNumParams()) {
+    for (unsigned i = 0; i < FD->getNumParams(); i++) {
+      QualType patternType = pattern->getParamDecl(i)->getType();
+      if (patternType->isDependentType())
+        continue;
+      if (isThrowCarrierType(FD->getParamDecl(i)->getType()))
+        return true;
     }
-    for (const ParmVarDecl* P : FD->parameters())
-        if (isThrowCarrierType(P->getType()))
-            return true;
     return false;
+  }
+  for (const ParmVarDecl *P : FD->parameters())
+    if (isThrowCarrierType(P->getType()))
+      return true;
+  return false;
 }
 
-static bool hasThrowCarrierParam(const FunctionProtoType* FPT)
-{
-    if (!FPT)
-        return false;
-    for (QualType T : FPT->getParamTypes())
-        if (isThrowCarrierType(T))
-            return true;
+static bool hasThrowCarrierParam(const FunctionProtoType *FPT) {
+  if (!FPT)
     return false;
+  for (QualType T : FPT->getParamTypes())
+    if (isThrowCarrierType(T))
+      return true;
+  return false;
 }
 
-static bool isScopeRecordName(const std::string& name)
-{
-    return name == "JSC::ThrowScope" || name == "JSC::TopExceptionScope";
+static bool isScopeRecordName(const std::string &name) {
+  return name == "JSC::ThrowScope" || name == "JSC::TopExceptionScope";
 }
 
-static bool isScopeType(QualType T)
-{
-    const CXXRecordDecl* RD = T.getNonReferenceType()->getAsCXXRecordDecl();
-    return RD && isScopeRecordName(qualifiedName(RD));
+static bool isScopeType(QualType T) {
+  const CXXRecordDecl *RD = T.getNonReferenceType()->getAsCXXRecordDecl();
+  return RD && isScopeRecordName(qualifiedName(RD));
 }
 
-static bool isExceptionOwnerRecord(const CXXRecordDecl* RD)
-{
-    if (!RD)
-        return false;
-    std::string n = qualifiedName(RD);
-    return n == "JSC::VM" || n == "JSC::ExceptionScope" || n == "JSC::ThrowScope" || n == "JSC::TopExceptionScope";
+static bool isExceptionOwnerRecord(const CXXRecordDecl *RD) {
+  if (!RD)
+    return false;
+  std::string n = qualifiedName(RD);
+  return n == "JSC::VM" || n == "JSC::ExceptionScope" ||
+         n == "JSC::ThrowScope" || n == "JSC::TopExceptionScope";
 }
 
 class Analyzer {
 public:
-    Analyzer(ASTContext& Ctx, std::vector<Finding>& out)
-        : m_ctx(Ctx)
-        , m_sm(Ctx.getSourceManager())
-        , m_findings(out)
-        , m_mangler(ItaniumMangleContext::create(Ctx, Ctx.getDiagnostics()))
-    {
-    }
+  Analyzer(ASTContext &Ctx, std::vector<Finding> &out)
+      : m_ctx(Ctx), m_sm(Ctx.getSourceManager()), m_findings(out),
+        m_mangler(ItaniumMangleContext::create(Ctx, Ctx.getDiagnostics())) {}
 
-    // One name per overload, stable across translation units.
-    std::string mangledKey(const FunctionDecl* FD)
-    {
-        if (!m_mangler->shouldMangleDeclName(FD))
-            return FD->getNameAsString();
-        std::string out;
-        llvm::raw_string_ostream os(out);
-        if (const auto* ctor = dyn_cast<CXXConstructorDecl>(FD))
-            m_mangler->mangleName(GlobalDecl(ctor, Ctor_Complete), os);
-        else if (const auto* dtor = dyn_cast<CXXDestructorDecl>(FD))
-            m_mangler->mangleName(GlobalDecl(dtor, Dtor_Complete), os);
-        else
-            m_mangler->mangleName(GlobalDecl(FD), os);
-        return os.str();
-    }
+  // One name per overload, stable across translation units.
+  std::string mangledKey(const FunctionDecl *FD) {
+    if (!m_mangler->shouldMangleDeclName(FD))
+      return FD->getNameAsString();
+    std::string out;
+    llvm::raw_string_ostream os(out);
+    if (const auto *ctor = dyn_cast<CXXConstructorDecl>(FD))
+      m_mangler->mangleName(GlobalDecl(ctor, Ctor_Complete), os);
+    else if (const auto *dtor = dyn_cast<CXXDestructorDecl>(FD))
+      m_mangler->mangleName(GlobalDecl(dtor, Dtor_Complete), os);
+    else
+      m_mangler->mangleName(GlobalDecl(FD), os);
+    return os.str();
+  }
 
-    // Classify a function for its callers. Memoized. Visible bodies are
-    // analyzed; invisible ones fall back to imported summaries, then to the
-    // JSC signature convention.
-    const Summary& summarize(const FunctionDecl* FD)
-    {
-        FD = FD->getCanonicalDecl();
-        auto it = m_summaries.find(FD);
-        if (it != m_summaries.end())
-            return it->second;
-        // Cycle guard: while a function is being analyzed, treat recursive
-        // calls to it as nothrow. This under-approximates recursion only.
-        Summary& slot = m_summaries[FD];
-        slot.kind = Summary::Nothrow;
-        slot.why = "in progress";
-        Summary computed = computeSummary(FD);
-        m_summaries[FD] = computed;
-        return m_summaries[FD];
-    }
+  // Classify a function for its callers. Memoized. Visible bodies are
+  // analyzed; invisible ones fall back to imported summaries, then to the
+  // JSC signature convention.
+  const Summary &summarize(const FunctionDecl *FD) {
+    FD = FD->getCanonicalDecl();
+    auto it = m_summaries.find(FD);
+    if (it != m_summaries.end())
+      return it->second;
+    // Cycle guard: while a function is being analyzed, treat recursive
+    // calls to it as nothrow. This under-approximates recursion only.
+    Summary &slot = m_summaries[FD];
+    slot.kind = Summary::Nothrow;
+    slot.why = "in progress";
+    Summary computed = computeSummary(FD);
+    m_summaries[FD] = computed;
+    return m_summaries[FD];
+  }
 
-    // Analyze one function body and report findings.
-    void analyzeFunction(const FunctionDecl* FD)
-    {
-        if (!FD->doesThisDeclarationHaveABody() || !FD->getBody())
-            return;
-        if (!m_analyzed.insert(FD->getCanonicalDecl()).second)
-            return;
-        runBody(FD, /*report=*/true);
-        if (!ExportSummaries.empty())
-            summarize(FD);
-    }
+  // Analyze one function body and report findings.
+  void analyzeFunction(const FunctionDecl *FD) {
+    if (!FD->doesThisDeclarationHaveABody() || !FD->getBody())
+      return;
+    if (!m_analyzed.insert(FD->getCanonicalDecl()).second)
+      return;
+    runBody(FD, /*report=*/true);
+    if (!ExportSummaries.empty())
+      summarize(FD);
+  }
 
-    // Summaries of functions with visible bodies, for --export-summaries.
-    void exportSummaries(llvm::raw_ostream& os, const std::string& under)
-    {
-        for (auto& [FD, s] : m_summaries) {
-            if (s.kind == Summary::Check || s.kind == Summary::Release)
-                continue;
-            if (s.why == "allowlist" || s.why == "imported")
-                continue;
-            if (s.why.rfind("no visible body", 0) == 0) {
-                // Not a summary: a leaf the analysis had to guess. Listed so
-                // the driver can report the most common guesses. The import
-                // side skips the "unknown" kind.
-                if (s.kind == Summary::MayThrow)
-                    os << mangledKey(FD) << "\t" << summaryKey(FD) << "\tunknown\t0\t0\t" << s.why << "\n";
-                continue;
-            }
-            const FunctionDecl* def = nullptr;
-            if (!FD->hasBody(def) || !def)
-                continue;
-            if (isa<CXXMethodDecl>(def) && cast<CXXMethodDecl>(def)->getParent()->isLambda())
-                continue;
-            PresumedLoc P = m_sm.getPresumedLoc(m_sm.getExpansionLoc(def->getLocation()));
-            if (!P.isValid())
-                continue;
-            std::string file = P.getFilename();
-            if (file.find(under) == std::string::npos || file.find("vendor/WebKit") != std::string::npos)
-                continue;
-            os << mangledKey(FD) << "\t" << summaryKey(FD) << "\t" << Summary::kindName(s.kind) << "\t" << s.exitStates << "\t" << (s.verifiesAtEntry ? "1" : "0") << "\t" << s.why << "\n";
-        }
-    }
+  // Summaries of functions with visible bodies, for --export-summaries.
+  static bool matchesAny(const std::string &file,
+                         const std::vector<std::string> &unders) {
+    for (const std::string &u : unders)
+      if (file.find(u) != std::string::npos)
+        return true;
+    return false;
+  }
 
-    // Force summaries for every function with a body in the TU (for export).
-    void summarizeForExport(const FunctionDecl* FD)
-    {
-        if (!FD->doesThisDeclarationHaveABody() || !FD->getBody())
-            return;
-        summarize(FD);
+  void exportSummaries(llvm::raw_ostream &os,
+                       const std::vector<std::string> &under) {
+    for (auto &[FD, s] : m_summaries) {
+      if (s.kind == Summary::Check || s.kind == Summary::Release)
+        continue;
+      if (s.why == "allowlist" || s.why == "imported")
+        continue;
+      if (s.why.rfind("no visible body", 0) == 0) {
+        // Not a summary: a leaf the analysis had to guess. Listed so
+        // the driver can report the most common guesses. The import
+        // side skips the "unknown" kind.
+        if (s.kind == Summary::MayThrow)
+          os << mangledKey(FD) << "\t" << summaryKey(FD) << "\tunknown\t0\t0\t"
+             << s.why << "\n";
+        continue;
+      }
+      const FunctionDecl *def = nullptr;
+      if (!FD->hasBody(def) || !def)
+        continue;
+      if (isa<CXXMethodDecl>(def) &&
+          cast<CXXMethodDecl>(def)->getParent()->isLambda())
+        continue;
+      PresumedLoc P =
+          m_sm.getPresumedLoc(m_sm.getExpansionLoc(def->getLocation()));
+      if (!P.isValid())
+        continue;
+      std::string file = P.getFilename();
+      if (!matchesAny(file, under) ||
+          file.find("vendor/WebKit") != std::string::npos)
+        continue;
+      os << mangledKey(FD) << "\t" << summaryKey(FD) << "\t"
+         << Summary::kindName(s.kind) << "\t" << s.exitStates << "\t"
+         << (s.verifiesAtEntry ? "1" : "0") << "\t" << s.why << "\n";
     }
+  }
+
+  // Force summaries for every function with a body in the TU (for export).
+  void summarizeForExport(const FunctionDecl *FD) {
+    if (!FD->doesThisDeclarationHaveABody() || !FD->getBody())
+      return;
+    summarize(FD);
+  }
 
 private:
-    struct BodyResult {
-        StateSet exitStates = kCleanOnly;
-        bool hasOwnScope = false;
-        bool touchesException = false; // any may-throw call or scope
-        bool verifiesAtEntry = false;
-        std::string firstCause; // what made this body touch the exception state
-    };
+  struct BodyResult {
+    StateSet exitStates = kCleanOnly;
+    bool hasOwnScope = false;
+    bool touchesException = false; // any may-throw call or scope
+    bool verifiesAtEntry = false;
+    std::string firstCause; // what made this body touch the exception state
+  };
 
-    std::string locString(SourceLocation loc)
+  std::string locString(SourceLocation loc) {
+    PresumedLoc P = m_sm.getPresumedLoc(m_sm.getExpansionLoc(loc));
+    if (!P.isValid())
+      return "?";
+    std::string f = P.getFilename();
+    auto pos = f.rfind('/');
+    if (pos != std::string::npos)
+      f = f.substr(pos + 1);
+    return f + ":" + std::to_string(P.getLine());
+  }
+
+  Summary computeSummary(const FunctionDecl *FD) {
+    Summary s;
+    std::string name = qualifiedName(FD);
+
+    // Explicit lists win.
     {
-        PresumedLoc P = m_sm.getPresumedLoc(m_sm.getExpansionLoc(loc));
-        if (!P.isValid())
-            return "?";
-        std::string f = P.getFilename();
-        auto pos = f.rfind('/');
-        if (pos != std::string::npos)
-            f = f.substr(pos + 1);
-        return f + ":" + std::to_string(P.getLine());
+      auto it = gClassified.find(name);
+      if (it != gClassified.end())
+        return it->second;
     }
 
-    Summary computeSummary(const FunctionDecl* FD)
-    {
-        Summary s;
-        std::string name = qualifiedName(FD);
-
-        // Explicit lists win.
-        {
-            auto it = gClassified.find(name);
-            if (it != gClassified.end())
-                return it->second;
+    // Exception-state accessors.
+    if (const auto *MD = dyn_cast<CXXMethodDecl>(FD)) {
+      if (isExceptionOwnerRecord(MD->getParent())) {
+        StringRef n = MD->getIdentifier() ? MD->getName() : StringRef();
+        if (n == "exception" || n == "clearException" ||
+            n == "assertNoException" || n == "releaseAssertNoException" ||
+            n == "assertNoExceptionExceptTermination" ||
+            n == "releaseAssertNoExceptionExceptTermination" ||
+            n == "tryClearException" ||
+            n == "clearExceptionExceptTermination" ||
+            n == "hasExceptionsAfterHandlingTraps") {
+          s.kind = Summary::Check;
+          s.why = "exception accessor";
+          return s;
         }
-
-        // Exception-state accessors.
-        if (const auto* MD = dyn_cast<CXXMethodDecl>(FD)) {
-            if (isExceptionOwnerRecord(MD->getParent())) {
-                StringRef n = MD->getIdentifier() ? MD->getName() : StringRef();
-                if (n == "exception" || n == "clearException" || n == "assertNoException" || n == "releaseAssertNoException"
-                    || n == "assertNoExceptionExceptTermination" || n == "releaseAssertNoExceptionExceptTermination"
-                    || n == "tryClearException" || n == "clearExceptionExceptTermination" || n == "hasExceptionsAfterHandlingTraps") {
-                    s.kind = Summary::Check;
-                    s.why = "exception accessor";
-                    return s;
-                }
-                if (n == "release") {
-                    s.kind = Summary::Release;
-                    s.why = "scope release";
-                    return s;
-                }
-                if (n == "throwException") {
-                    s.kind = Summary::Thrower;
-                    s.verifiesAtEntry = true;
-                    s.why = "throwException";
-                    return s;
-                }
-            }
+        if (n == "release") {
+          s.kind = Summary::Release;
+          s.why = "scope release";
+          return s;
         }
-
-        const FunctionDecl* def = nullptr;
-        if (FD->hasBody(def) && def && def->getBody() && !def->isDefaulted()) {
-            // Visible body. Analyze it.
-            BodyResult r = runBody(def, /*report=*/false);
-            if (r.hasOwnScope) {
-                s.kind = Summary::MayThrow;
-                s.verifiesAtEntry = true;
-                s.why = "declares a ThrowScope";
-                return s;
-            }
-            if (!r.touchesException) {
-                s.kind = Summary::Nothrow;
-                s.why = "body cannot throw";
-                return s;
-            }
-            if (!anyState(r.exitStates, kPending | kThrown | kReleased | kMaybe)) {
-                // It checks everything it calls before returning. Callers see
-                // no pending bit, exactly like the validator.
-                s.kind = Summary::Transparent;
-                s.verifiesAtEntry = r.verifiesAtEntry;
-                s.exitStates = r.exitStates;
-                s.why = "self-checking body (" + r.firstCause + ")";
-                return s;
-            }
-            // Transparent helper: no scope of its own.
-            s.kind = Summary::Transparent;
-            s.verifiesAtEntry = r.verifiesAtEntry;
-            s.exitStates = r.exitStates;
-            s.why = "calls " + r.firstCause;
-            return s;
+        if (n == "throwException") {
+          s.kind = Summary::Thrower;
+          s.verifiesAtEntry = true;
+          s.why = "throwException";
+          return s;
         }
+      }
+    }
 
-        // Throw helpers with no visible body are terminators: throwTypeError, throwVMError,
-        // throwOutOfMemoryError, Bun::ERR::*, Bun::throwError, ...
-        {
-            StringRef n = FD->getIdentifier() ? FD->getName() : StringRef();
-            bool inErrNamespace = name.rfind("Bun::ERR::", 0) == 0 || name.rfind("WebCore::ERR::", 0) == 0;
-            if ((n.starts_with("throw") && hasThrowCarrierParam(FD)) || inErrNamespace) {
-                s.kind = Summary::Thrower;
-                s.verifiesAtEntry = true;
-                s.why = "throw helper";
-                return s;
-            }
-        }
-
-        // Imported whole-project summary.
-        {
-            auto it = gImported.find(mangledKey(FD));
-            if (it != gImported.end()) {
-                s = it->second;
-                s.why = "imported";
-                return s;
-            }
-        }
-
-        // An extern "C" function with no body in any C++ translation unit is
-        // implemented in Rust. The Rust side runs under its own exception
-        // scope and reports a throw with a sentinel return value (empty
-        // JSValue, false, null), so the caller sees a conditional thrower.
-        if (FD->isExternC() && hasThrowCarrierParam(FD)) {
-            s.kind = Summary::Transparent;
-            s.verifiesAtEntry = true;
-            s.exitStates = kCleanOnly | (1u << kThrown);
-            s.why = "extern \"C\" with no C++ body (Rust); a throw is signaled by the return value";
-            return s;
-        }
-
-        // Virtual methods and unknown bodies: JSC convention.
-        if (hasThrowCarrierParam(FD)) {
-            s.kind = Summary::MayThrow;
-            s.verifiesAtEntry = true;
-            s.why = "no visible body; takes JSGlobalObject*/ThrowScope&";
-            return s;
-        }
-        s.kind = Summary::Nothrow;
-        s.why = "no visible body; no throw carrier parameter";
+    const FunctionDecl *def = nullptr;
+    if (FD->hasBody(def) && def && def->getBody() && !def->isDefaulted()) {
+      // Visible body. Analyze it.
+      BodyResult r = runBody(def, /*report=*/false);
+      if (r.hasOwnScope) {
+        s.kind = Summary::MayThrow;
+        s.verifiesAtEntry = true;
+        s.why = "declares a ThrowScope";
         return s;
-    }
-
-    // The callee of a call expression, or null for indirect calls.
-    static const FunctionDecl* calleeOf(const CallExpr* CE)
-    {
-        if (const FunctionDecl* FD = CE->getDirectCallee())
-            return FD;
-        return nullptr;
-    }
-
-    Summary summarizeCall(const CallExpr* CE)
-    {
-        if (const FunctionDecl* FD = calleeOf(CE))
-            return summarize(FD);
-        // Indirect call: a method-table function pointer, a std::function,
-        // a lambda through a pointer. Use the member name, then the signature.
-        Summary s;
-        const Expr* calleeExpr = CE->getCallee()->IgnoreParenImpCasts();
-        if (const auto* ME = dyn_cast<MemberExpr>(calleeExpr)) {
-            auto it = gClassified.find("indirect:" + ME->getMemberDecl()->getNameAsString());
-            if (it != gClassified.end())
-                return it->second;
-        }
-        QualType T = calleeExpr->getType();
-        if (T->isPointerType() || T->isMemberPointerType())
-            T = T->getPointeeType();
-        if (const auto* FPT = T->getAs<FunctionProtoType>()) {
-            if (hasThrowCarrierParam(FPT)) {
-                s.kind = Summary::MayThrow;
-                s.verifiesAtEntry = true;
-                s.why = "indirect call; signature takes JSGlobalObject*/ThrowScope&";
-                return s;
-            }
-        }
+      }
+      if (!r.touchesException) {
         s.kind = Summary::Nothrow;
-        s.why = "indirect call; no throw carrier parameter";
+        s.why = "body cannot throw";
         return s;
+      }
+      if (!anyState(r.exitStates, kPending | kThrown | kReleased | kMaybe)) {
+        // It checks everything it calls before returning. Callers see
+        // no pending bit, exactly like the validator.
+        s.kind = Summary::Transparent;
+        s.verifiesAtEntry = r.verifiesAtEntry;
+        s.exitStates = r.exitStates;
+        s.why = "self-checking body (" + r.firstCause + ")";
+        return s;
+      }
+      // Transparent helper: no scope of its own.
+      s.kind = Summary::Transparent;
+      s.verifiesAtEntry = r.verifiesAtEntry;
+      s.exitStates = r.exitStates;
+      s.why = "calls " + r.firstCause;
+      return s;
     }
 
-    std::string describeCallee(const CallExpr* CE)
+    // Throw helpers with no visible body are terminators: throwTypeError,
+    // throwVMError, throwOutOfMemoryError, Bun::ERR::*, Bun::throwError, ...
     {
-        if (!calleeOf(CE)) {
-            if (const auto* ME = dyn_cast<MemberExpr>(CE->getCallee()->IgnoreParenImpCasts()))
-                return "<indirect call through " + ME->getMemberDecl()->getNameAsString() + ">";
-        }
-        if (const FunctionDecl* FD = calleeOf(CE)) {
-            if (const auto* MD = dyn_cast<CXXMethodDecl>(FD)) {
-                if (MD->getParent()->isLambda())
-                    return "<lambda at " + locString(MD->getParent()->getLocation()) + ">";
-            }
-            return qualifiedName(FD);
-        }
-        return "<indirect call>";
+      StringRef n = FD->getIdentifier() ? FD->getName() : StringRef();
+      bool inErrNamespace = name.rfind("Bun::ERR::", 0) == 0 ||
+                            name.rfind("WebCore::ERR::", 0) == 0;
+      if ((n.starts_with("throw") && hasThrowCarrierParam(FD)) ||
+          inErrNamespace) {
+        s.kind = Summary::Thrower;
+        s.verifiesAtEntry = true;
+        s.why = "throw helper";
+        return s;
+      }
     }
 
-    void report(const FunctionDecl* FD, SourceLocation loc, const std::string& kind, const std::string& callee, const std::string& message)
+    // Imported whole-project summary.
     {
-        SourceLocation spelling = m_sm.getExpansionLoc(loc);
-        PresumedLoc P = m_sm.getPresumedLoc(spelling);
-        Finding f;
-        f.file = P.isValid() ? P.getFilename() : "<unknown>";
-        f.line = P.isValid() ? P.getLine() : 0;
-        f.col = P.isValid() ? P.getColumn() : 0;
-        f.function = qualifiedName(FD);
-        if (const auto* MD = dyn_cast<CXXMethodDecl>(FD))
-            if (MD->getParent()->isLambda())
-                f.function = "<lambda at " + locString(MD->getParent()->getLocation()) + ">";
-        f.callee = callee;
-        f.kind = kind;
-        f.message = message;
-        m_findings.push_back(std::move(f));
+      auto it = gImported.find(mangledKey(FD));
+      if (it != gImported.end()) {
+        s = it->second;
+        s.why = "imported";
+        return s;
+      }
     }
 
-    // Per-walk context: the last call that made the state pending/thrown, for
-    // the hint in messages.
-    struct WalkCtx {
-        std::string lastSource;
-    };
-
-    // Apply one CFG element to a state set. Returns the new state set.
-    // `report` controls whether violations are recorded.
-    StateSet step(const FunctionDecl* FD, const CFGElement& E, StateSet in, bool report, BodyResult& result, WalkCtx& ctx)
-    {
-        if (auto dtor = E.getAs<CFGAutomaticObjDtor>()) {
-            const VarDecl* VD = dtor->getVarDecl();
-            if (!VD || !isScopeType(VD->getType()))
-                return in;
-            std::string rdName = qualifiedName(VD->getType()->getAsCXXRecordDecl());
-            bool isTop = rdName == "JSC::TopExceptionScope";
-            bool reported = false;
-            StateSet out = mapStates(in, [&](unsigned st) {
-                bool pending = st & kPending;
-                bool released = st & kReleased;
-                if (pending && (isTop || !released) && report && !reported) {
-                    reported = true;
-                    SourceLocation loc = dtor->getTriggerStmt() ? dtor->getTriggerStmt()->getEndLoc() : VD->getLocation();
-                    this->report(FD, loc, "unchecked-exit", ctx.lastSource,
-                        "function exits with an exception check pending after " + ctx.lastSource + " (the " + (isTop ? "TopExceptionScope" : "ThrowScope") + " destructor asserts); add RETURN_IF_EXCEPTION or use RELEASE_AND_RETURN");
-                }
-                // After a ThrowScope destructor the caller must check
-                // (simulateThrow). TopExceptionScope does not simulate.
-                if (!isTop)
-                    return st | kPending;
-                return st & ~kPending;
-            });
-            if (!isTop)
-                ctx.lastSource = "the nested ThrowScope declared at " + locString(VD->getLocation());
-            return out;
-        }
-
-        auto stmtElem = E.getAs<CFGStmt>();
-        if (!stmtElem)
-            return in;
-        const Stmt* S = stmtElem->getStmt();
-
-        // Scope construction.
-        if (const auto* CC = dyn_cast<CXXConstructExpr>(S)) {
-            const CXXConstructorDecl* ctor = CC->getConstructor();
-            if (ctor && isScopeRecordName(qualifiedName(ctor->getParent())) && !ctor->isCopyOrMoveConstructor()) {
-                // A TopExceptionScope verifies like a ThrowScope but does not
-                // simulate a throw when destroyed, so it does not make the
-                // function "may throw" for its callers.
-                if (qualifiedName(ctor->getParent()) == "JSC::ThrowScope")
-                    result.hasOwnScope = true;
-                if (!result.touchesException) {
-                    result.verifiesAtEntry = true;
-                    result.firstCause = "ThrowScope at " + locString(CC->getBeginLoc());
-                }
-                result.touchesException = true;
-                if (anyState(in, kPending) && report)
-                    this->report(FD, CC->getBeginLoc(), "scope-while-pending", ctx.lastSource, "ThrowScope constructed while an exception check is pending after " + ctx.lastSource);
-                return mapStates(in, [](unsigned st) { return st & ~kPending; });
-            }
-            // Constructors that take a global object may run JS (rare).
-            if (ctor && hasThrowCarrierParam(ctor)) {
-                Summary s = summarize(ctor);
-                return applyCallSummary(FD, CC->getBeginLoc(), qualifiedName(ctor), s, in, report, result, ctx);
-            }
-            return in;
-        }
-
-        if (const auto* RS = dyn_cast<ReturnStmt>(S)) {
-            // The early return of RETURN_IF_EXCEPTION: the check happened and
-            // the exception is set. For a lambda or a scope-less helper this
-            // exit state tells the caller that an exception may be pending
-            // even though the bit is clear.
-            if (isInReturnIfExceptionMacro(RS))
-                return mapStates(in, [](unsigned st) { return (st & kReleased) | kThrown; });
-            return in;
-        }
-
-        const auto* CE = dyn_cast<CallExpr>(S);
-        if (!CE)
-            return in;
-        Summary s = summarizeCall(CE);
-        if (Verbose) {
-            llvm::errs() << locString(CE->getBeginLoc()) << " call " << describeCallee(CE) << " -> " << Summary::kindName(s.kind) << " exit=" << s.exitStates << " (" << s.why << ")\n";
-        }
-        return applyCallSummary(FD, CE->getBeginLoc(), describeCallee(CE), s, in, report, result, ctx);
+    // An extern "C" function with no body in any C++ translation unit is
+    // implemented in Rust. The Rust side runs under its own exception
+    // scope and reports a throw with a sentinel return value (empty
+    // JSValue, false, null), so the caller sees a conditional thrower.
+    if (FD->isExternC() && hasThrowCarrierParam(FD)) {
+      s.kind = Summary::Transparent;
+      s.verifiesAtEntry = true;
+      s.exitStates = kCleanOnly | (1u << kThrown);
+      s.why = "extern \"C\" with no C++ body (Rust); a throw is signaled by "
+              "the return value";
+      return s;
     }
 
-    // True when the statement is spelled inside a RETURN_IF_EXCEPTION-style
-    // macro expansion.
-    bool isInReturnIfExceptionMacro(const Stmt* S)
-    {
-        SourceLocation loc = S->getBeginLoc();
-        if (!loc.isMacroID())
-            return false;
-        while (loc.isMacroID()) {
-            StringRef name = Lexer::getImmediateMacroName(loc, m_sm, m_ctx.getLangOpts());
-            if (name.contains("RETURN_IF_EXCEPTION") || name.contains("RETURN_IF_VM_EXCEPTION") || name.contains("RETURN_STATUS_IF_EXCEPTION") || name == "TRY_CLEAR_EXCEPTION")
-                return true;
-            loc = m_sm.getImmediateMacroCallerLoc(loc);
-        }
-        return false;
+    // Virtual methods and unknown bodies: JSC convention.
+    if (hasThrowCarrierParam(FD)) {
+      s.kind = Summary::MayThrow;
+      s.verifiesAtEntry = true;
+      s.why = "no visible body; takes JSGlobalObject*/ThrowScope&";
+      return s;
     }
+    s.kind = Summary::Nothrow;
+    s.why = "no visible body; no throw carrier parameter";
+    return s;
+  }
 
-    StateSet applyCallSummary(const FunctionDecl* FD, SourceLocation loc, const std::string& callee, const Summary& s, StateSet in, bool report, BodyResult& result, WalkCtx& ctx)
-    {
-        switch (s.kind) {
-        case Summary::Nothrow:
-            return in;
-        case Summary::Check:
-            result.touchesException = true;
-            return mapStates(in, [](unsigned st) { return st & ~(kPending | kThrown | kMaybe); });
-        case Summary::Release:
-            return mapStates(in, [](unsigned st) { return st | kReleased; });
-        case Summary::MayThrow:
-        case Summary::Thrower:
-        case Summary::Transparent: {
-            if (!result.touchesException) {
-                result.verifiesAtEntry = s.verifiesAtEntry;
-                result.firstCause = callee + " at " + locString(loc);
-            }
-            result.touchesException = true;
-            if (report) {
-                if (anyState(in, kPending) && s.verifiesAtEntry)
-                    this->report(FD, loc, "pending-call", callee, "call to " + callee + " while an exception check is pending after " + ctx.lastSource + "; add RETURN_IF_EXCEPTION after it");
-                if (anyState(in, kThrown))
-                    this->report(FD, loc, "thrown-call", callee, "call to " + callee + " after " + ctx.lastSource + " threw; return after throwing");
-                else if (anyState(in, kMaybe))
-                    this->report(FD, loc, "maybe-thrown-call", callee, "call to " + callee + " after " + ctx.lastSource + " may have thrown and returned a failure value; check the exception or the result first");
-            }
-            // Exit states of the callee, as seen from here. A conditional
-            // thrower (exits both clean and thrown) becomes `maybe`: the
-            // caller usually tests its return value, which the analysis
-            // cannot see.
-            StateSet calleeExits;
-            switch (s.kind) {
-            case Summary::MayThrow:
-                calleeExits = 1u << kPending;
-                break;
-            case Summary::Thrower:
-                calleeExits = 1u << kThrown;
-                break;
-            default:
-                calleeExits = s.exitStates;
-                break;
-            }
-            bool hasClean = false, hasThrown = false;
-            for (unsigned ex = 0; ex < kNumStates; ex++) {
-                if (!(calleeExits & (1u << ex)))
-                    continue;
-                if (!(ex & (kPending | kThrown | kMaybe)))
-                    hasClean = true;
-                if (ex & kThrown)
-                    hasThrown = true;
-            }
-            StateSet out = 0;
-            for (unsigned st = 0; st < kNumStates; st++) {
-                if (!(in & (1u << st)))
-                    continue;
-                unsigned keep = st & kReleased;
-                for (unsigned ex = 0; ex < kNumStates; ex++) {
-                    if (!(calleeExits & (1u << ex)))
-                        continue;
-                    unsigned bits = ex & (kPending | kThrown | kMaybe | kReleased);
-                    if ((bits & kThrown) && hasClean && hasThrown)
-                        bits = (bits & ~kThrown) | kMaybe;
-                    out |= 1u << ((keep | bits) & (kNumStates - 1));
-                }
-            }
-            if (anyState(out, kPending | kThrown | kMaybe))
-                ctx.lastSource = callee + " (" + locString(loc) + ")";
-            return out;
-        }
-        }
+  // The callee of a call expression, or null for indirect calls.
+  static const FunctionDecl *calleeOf(const CallExpr *CE) {
+    if (const FunctionDecl *FD = CE->getDirectCallee())
+      return FD;
+    return nullptr;
+  }
+
+  Summary summarizeCall(const CallExpr *CE) {
+    if (const FunctionDecl *FD = calleeOf(CE))
+      return summarize(FD);
+    // Indirect call: a method-table function pointer, a std::function,
+    // a lambda through a pointer. Use the member name, then the signature.
+    Summary s;
+    const Expr *calleeExpr = CE->getCallee()->IgnoreParenImpCasts();
+    if (const auto *ME = dyn_cast<MemberExpr>(calleeExpr)) {
+      auto it = gClassified.find("indirect:" +
+                                 ME->getMemberDecl()->getNameAsString());
+      if (it != gClassified.end())
+        return it->second;
+    }
+    QualType T = calleeExpr->getType();
+    if (T->isPointerType() || T->isMemberPointerType())
+      T = T->getPointeeType();
+    if (const auto *FPT = T->getAs<FunctionProtoType>()) {
+      if (hasThrowCarrierParam(FPT)) {
+        s.kind = Summary::MayThrow;
+        s.verifiesAtEntry = true;
+        s.why = "indirect call; signature takes JSGlobalObject*/ThrowScope&";
+        return s;
+      }
+    }
+    s.kind = Summary::Nothrow;
+    s.why = "indirect call; no throw carrier parameter";
+    return s;
+  }
+
+  std::string describeCallee(const CallExpr *CE) {
+    if (!calleeOf(CE)) {
+      if (const auto *ME =
+              dyn_cast<MemberExpr>(CE->getCallee()->IgnoreParenImpCasts()))
+        return "<indirect call through " +
+               ME->getMemberDecl()->getNameAsString() + ">";
+    }
+    if (const FunctionDecl *FD = calleeOf(CE)) {
+      if (const auto *MD = dyn_cast<CXXMethodDecl>(FD)) {
+        if (MD->getParent()->isLambda())
+          return "<lambda at " + locString(MD->getParent()->getLocation()) +
+                 ">";
+      }
+      return qualifiedName(FD);
+    }
+    return "<indirect call>";
+  }
+
+  void report(const FunctionDecl *FD, SourceLocation loc,
+              const std::string &kind, const std::string &callee,
+              const std::string &message) {
+    SourceLocation spelling = m_sm.getExpansionLoc(loc);
+    PresumedLoc P = m_sm.getPresumedLoc(spelling);
+    Finding f;
+    f.file = P.isValid() ? P.getFilename() : "<unknown>";
+    f.line = P.isValid() ? P.getLine() : 0;
+    f.col = P.isValid() ? P.getColumn() : 0;
+    f.function = qualifiedName(FD);
+    if (const auto *MD = dyn_cast<CXXMethodDecl>(FD))
+      if (MD->getParent()->isLambda())
+        f.function =
+            "<lambda at " + locString(MD->getParent()->getLocation()) + ">";
+    f.callee = callee;
+    f.kind = kind;
+    f.message = message;
+    m_findings.push_back(std::move(f));
+  }
+
+  // Per-walk context: the last call that made the state pending/thrown, for
+  // the hint in messages.
+  struct WalkCtx {
+    std::string lastSource;
+  };
+
+  // Apply one CFG element to a state set. Returns the new state set.
+  // `report` controls whether violations are recorded.
+  StateSet step(const FunctionDecl *FD, const CFGElement &E, StateSet in,
+                bool report, BodyResult &result, WalkCtx &ctx) {
+    if (auto dtor = E.getAs<CFGAutomaticObjDtor>()) {
+      const VarDecl *VD = dtor->getVarDecl();
+      if (!VD || !isScopeType(VD->getType()))
         return in;
+      std::string rdName = qualifiedName(VD->getType()->getAsCXXRecordDecl());
+      bool isTop = rdName == "JSC::TopExceptionScope";
+      bool reported = false;
+      StateSet out = mapStates(in, [&](unsigned st) {
+        bool pending = st & kPending;
+        bool released = st & kReleased;
+        if (pending && (isTop || !released) && report && !reported) {
+          reported = true;
+          SourceLocation loc = dtor->getTriggerStmt()
+                                   ? dtor->getTriggerStmt()->getEndLoc()
+                                   : VD->getLocation();
+          this->report(FD, loc, "unchecked-exit", ctx.lastSource,
+                       "function exits with an exception check pending after " +
+                           ctx.lastSource + " (the " +
+                           (isTop ? "TopExceptionScope" : "ThrowScope") +
+                           " destructor asserts); add RETURN_IF_EXCEPTION or "
+                           "use RELEASE_AND_RETURN");
+        }
+        // After a ThrowScope destructor the caller must check
+        // (simulateThrow). TopExceptionScope does not simulate.
+        if (!isTop)
+          return st | kPending;
+        return st & ~kPending;
+      });
+      if (!isTop)
+        ctx.lastSource =
+            "the nested ThrowScope declared at " + locString(VD->getLocation());
+      return out;
     }
 
-    BodyResult runBody(const FunctionDecl* FD, bool report)
-    {
-        BodyResult result;
-        CFG::BuildOptions opts;
-        opts.AddImplicitDtors = true;
-        opts.AddTemporaryDtors = true;
-        opts.AddInitializers = true;
-        opts.AddCXXDefaultInitExprInCtors = true;
-        opts.setAllAlwaysAdd();
-        std::unique_ptr<CFG> cfg = CFG::buildCFG(FD, FD->getBody(), &m_ctx, opts);
-        if (!cfg)
-            return result;
+    auto stmtElem = E.getAs<CFGStmt>();
+    if (!stmtElem)
+      return in;
+    const Stmt *S = stmtElem->getStmt();
 
-        unsigned n = cfg->getNumBlockIDs();
-        std::vector<StateSet> inStates(n, 0), outStates(n, 0);
-        std::vector<std::string> inSource(n), outSource(n);
-        std::vector<bool> inSourceDirty(n, false); // inSource came from a predecessor with a pending/thrown state
-        inStates[cfg->getEntry().getBlockID()] = kCleanOnly;
-
-        // Worklist fixpoint. The lattice is tiny (8 bits), so this converges fast.
-        std::vector<const CFGBlock*> work;
-        std::vector<bool> queued(n, false);
-        work.push_back(&cfg->getEntry());
-        queued[cfg->getEntry().getBlockID()] = true;
-        while (!work.empty()) {
-            const CFGBlock* B = work.back();
-            work.pop_back();
-            unsigned id = B->getBlockID();
-            queued[id] = false;
-            StateSet st = inStates[id];
-            BodyResult scratch;
-            WalkCtx ctx;
-            ctx.lastSource = inSource[id];
-            for (const CFGElement& E : *B)
-                st = step(FD, E, st, /*report=*/false, scratch, ctx);
-            bool changed = st != outStates[id] || outSource[id] != ctx.lastSource;
-            outStates[id] = st;
-            outSource[id] = ctx.lastSource;
-            if (!changed && st != 0)
-                continue;
-            for (const CFGBlock::AdjacentBlock& succ : B->succs()) {
-                const CFGBlock* S = succ.getReachableBlock();
-                if (!S)
-                    continue;
-                unsigned sid = S->getBlockID();
-                StateSet merged = inStates[sid] | st;
-                bool srcChanged = false;
-                bool dirty = anyState(st, kPending | kThrown | kMaybe);
-                if (!ctx.lastSource.empty() && (inSource[sid].empty() || (dirty && !inSourceDirty[sid]))) {
-                    inSource[sid] = ctx.lastSource;
-                    inSourceDirty[sid] = dirty;
-                    srcChanged = true;
-                }
-                if (merged != inStates[sid] || srcChanged || !queued[sid]) {
-                    inStates[sid] = merged;
-                    if (!queued[sid]) {
-                        queued[sid] = true;
-                        work.push_back(S);
-                    }
-                }
-            }
+    // Scope construction.
+    if (const auto *CC = dyn_cast<CXXConstructExpr>(S)) {
+      const CXXConstructorDecl *ctor = CC->getConstructor();
+      if (ctor && isScopeRecordName(qualifiedName(ctor->getParent())) &&
+          !ctor->isCopyOrMoveConstructor()) {
+        // A TopExceptionScope verifies like a ThrowScope but does not
+        // simulate a throw when destroyed, so it does not make the
+        // function "may throw" for its callers.
+        if (qualifiedName(ctor->getParent()) == "JSC::ThrowScope")
+          result.hasOwnScope = true;
+        if (!result.touchesException) {
+          result.verifiesAtEntry = true;
+          result.firstCause = "ThrowScope at " + locString(CC->getBeginLoc());
         }
-
-        // Final pass: report, and compute the body facts.
-        for (const CFGBlock* B : *cfg) {
-            unsigned id = B->getBlockID();
-            StateSet st = inStates[id];
-            if (st == 0)
-                continue; // unreachable
-            WalkCtx ctx;
-            ctx.lastSource = inSource[id];
-            for (const CFGElement& E : *B)
-                st = step(FD, E, st, report, result, ctx);
-        }
-        result.exitStates = inStates[cfg->getExit().getBlockID()];
-        if (result.exitStates == 0)
-            result.exitStates = kCleanOnly; // no normal exit (noreturn)
-        return result;
+        result.touchesException = true;
+        if (anyState(in, kPending) && report)
+          this->report(FD, CC->getBeginLoc(), "scope-while-pending",
+                       ctx.lastSource,
+                       "ThrowScope constructed while an exception check is "
+                       "pending after " +
+                           ctx.lastSource);
+        return mapStates(in, [](unsigned st) { return st & ~kPending; });
+      }
+      // Constructors that take a global object may run JS (rare).
+      if (ctor && hasThrowCarrierParam(ctor)) {
+        Summary s = summarize(ctor);
+        return applyCallSummary(FD, CC->getBeginLoc(), qualifiedName(ctor), s,
+                                in, report, result, ctx);
+      }
+      return in;
     }
 
-    ASTContext& m_ctx;
-    SourceManager& m_sm;
-    std::vector<Finding>& m_findings;
-    std::unique_ptr<ItaniumMangleContext> m_mangler;
-    std::unordered_map<const FunctionDecl*, Summary> m_summaries;
-    std::unordered_set<const FunctionDecl*> m_analyzed;
+    if (const auto *RS = dyn_cast<ReturnStmt>(S)) {
+      // The early return of RETURN_IF_EXCEPTION: the check happened and
+      // the exception is set. For a lambda or a scope-less helper this
+      // exit state tells the caller that an exception may be pending
+      // even though the bit is clear.
+      if (isInReturnIfExceptionMacro(RS))
+        return mapStates(
+            in, [](unsigned st) { return (st & kReleased) | kThrown; });
+      return in;
+    }
+
+    const auto *CE = dyn_cast<CallExpr>(S);
+    if (!CE)
+      return in;
+    Summary s = summarizeCall(CE);
+    if (Verbose) {
+      llvm::errs() << locString(CE->getBeginLoc()) << " call "
+                   << describeCallee(CE) << " -> " << Summary::kindName(s.kind)
+                   << " exit=" << s.exitStates << " (" << s.why << ")\n";
+    }
+    return applyCallSummary(FD, CE->getBeginLoc(), describeCallee(CE), s, in,
+                            report, result, ctx);
+  }
+
+  // True when the statement is spelled inside a RETURN_IF_EXCEPTION-style
+  // macro expansion.
+  bool isInReturnIfExceptionMacro(const Stmt *S) {
+    SourceLocation loc = S->getBeginLoc();
+    if (!loc.isMacroID())
+      return false;
+    while (loc.isMacroID()) {
+      StringRef name =
+          Lexer::getImmediateMacroName(loc, m_sm, m_ctx.getLangOpts());
+      if (name.contains("RETURN_IF_EXCEPTION") ||
+          name.contains("RETURN_IF_VM_EXCEPTION") ||
+          name.contains("RETURN_STATUS_IF_EXCEPTION") ||
+          name == "TRY_CLEAR_EXCEPTION")
+        return true;
+      loc = m_sm.getImmediateMacroCallerLoc(loc);
+    }
+    return false;
+  }
+
+  StateSet applyCallSummary(const FunctionDecl *FD, SourceLocation loc,
+                            const std::string &callee, const Summary &s,
+                            StateSet in, bool report, BodyResult &result,
+                            WalkCtx &ctx) {
+    switch (s.kind) {
+    case Summary::Nothrow:
+      return in;
+    case Summary::Check:
+      result.touchesException = true;
+      return mapStates(
+          in, [](unsigned st) { return st & ~(kPending | kThrown | kMaybe); });
+    case Summary::Release:
+      return mapStates(in, [](unsigned st) { return st | kReleased; });
+    case Summary::MayThrow:
+    case Summary::Thrower:
+    case Summary::Transparent: {
+      if (!result.touchesException) {
+        result.verifiesAtEntry = s.verifiesAtEntry;
+        result.firstCause = callee + " at " + locString(loc);
+      }
+      result.touchesException = true;
+      if (s.consumesException) {
+        // The helper reads and clears the exception itself; a pending
+        // or thrown state is what it expects.
+        in = mapStates(in, [](unsigned st) { return st & kReleased; });
+      }
+      if (report) {
+        if (anyState(in, kPending) && s.verifiesAtEntry)
+          this->report(FD, loc, "pending-call", callee,
+                       "call to " + callee +
+                           " while an exception check is pending after " +
+                           ctx.lastSource +
+                           "; add RETURN_IF_EXCEPTION after it");
+        if (anyState(in, kThrown))
+          this->report(FD, loc, "thrown-call", callee,
+                       "call to " + callee + " after " + ctx.lastSource +
+                           " threw; return after throwing");
+        else if (anyState(in, kMaybe))
+          this->report(FD, loc, "maybe-thrown-call", callee,
+                       "call to " + callee + " after " + ctx.lastSource +
+                           " may have thrown and returned a failure value; "
+                           "check the exception or the result first");
+      }
+      // Exit states of the callee, as seen from here. A conditional
+      // thrower (exits both clean and thrown) becomes `maybe`: the
+      // caller usually tests its return value, which the analysis
+      // cannot see.
+      StateSet calleeExits;
+      switch (s.kind) {
+      case Summary::MayThrow:
+        calleeExits = 1u << kPending;
+        break;
+      case Summary::Thrower:
+        calleeExits = 1u << kThrown;
+        break;
+      default:
+        calleeExits = s.exitStates;
+        break;
+      }
+      bool hasClean = false, hasThrown = false;
+      for (unsigned ex = 0; ex < kNumStates; ex++) {
+        if (!(calleeExits & (1u << ex)))
+          continue;
+        if (!(ex & (kPending | kThrown | kMaybe)))
+          hasClean = true;
+        if (ex & kThrown)
+          hasThrown = true;
+      }
+      StateSet out = 0;
+      for (unsigned st = 0; st < kNumStates; st++) {
+        if (!(in & (1u << st)))
+          continue;
+        unsigned keep = st & kReleased;
+        for (unsigned ex = 0; ex < kNumStates; ex++) {
+          if (!(calleeExits & (1u << ex)))
+            continue;
+          unsigned bits = ex & (kPending | kThrown | kMaybe | kReleased);
+          if ((bits & kThrown) && hasClean && hasThrown)
+            bits = (bits & ~kThrown) | kMaybe;
+          out |= 1u << ((keep | bits) & (kNumStates - 1));
+        }
+      }
+      if (anyState(out, kPending | kThrown | kMaybe))
+        ctx.lastSource = callee + " (" + locString(loc) + ")";
+      return out;
+    }
+    }
+    return in;
+  }
+
+  BodyResult runBody(const FunctionDecl *FD, bool report) {
+    BodyResult result;
+    CFG::BuildOptions opts;
+    opts.AddImplicitDtors = true;
+    opts.AddTemporaryDtors = true;
+    opts.AddInitializers = true;
+    opts.AddCXXDefaultInitExprInCtors = true;
+    opts.setAllAlwaysAdd();
+    std::unique_ptr<CFG> cfg = CFG::buildCFG(FD, FD->getBody(), &m_ctx, opts);
+    if (!cfg)
+      return result;
+
+    unsigned n = cfg->getNumBlockIDs();
+    std::vector<StateSet> inStates(n, 0), outStates(n, 0);
+    std::vector<std::string> inSource(n), outSource(n);
+    std::vector<bool> inSourceDirty(
+        n,
+        false); // inSource came from a predecessor with a pending/thrown state
+    inStates[cfg->getEntry().getBlockID()] = kCleanOnly;
+
+    // Worklist fixpoint. The lattice is tiny (8 bits), so this converges fast.
+    std::vector<const CFGBlock *> work;
+    std::vector<bool> queued(n, false);
+    work.push_back(&cfg->getEntry());
+    queued[cfg->getEntry().getBlockID()] = true;
+    while (!work.empty()) {
+      const CFGBlock *B = work.back();
+      work.pop_back();
+      unsigned id = B->getBlockID();
+      queued[id] = false;
+      StateSet st = inStates[id];
+      BodyResult scratch;
+      WalkCtx ctx;
+      ctx.lastSource = inSource[id];
+      for (const CFGElement &E : *B)
+        st = step(FD, E, st, /*report=*/false, scratch, ctx);
+      bool changed = st != outStates[id] || outSource[id] != ctx.lastSource;
+      outStates[id] = st;
+      outSource[id] = ctx.lastSource;
+      if (!changed && st != 0)
+        continue;
+      for (const CFGBlock::AdjacentBlock &succ : B->succs()) {
+        const CFGBlock *S = succ.getReachableBlock();
+        if (!S)
+          continue;
+        unsigned sid = S->getBlockID();
+        StateSet merged = inStates[sid] | st;
+        bool srcChanged = false;
+        bool dirty = anyState(st, kPending | kThrown | kMaybe);
+        if (!ctx.lastSource.empty() &&
+            (inSource[sid].empty() || (dirty && !inSourceDirty[sid]))) {
+          inSource[sid] = ctx.lastSource;
+          inSourceDirty[sid] = dirty;
+          srcChanged = true;
+        }
+        if (merged != inStates[sid] || srcChanged || !queued[sid]) {
+          inStates[sid] = merged;
+          if (!queued[sid]) {
+            queued[sid] = true;
+            work.push_back(S);
+          }
+        }
+      }
+    }
+
+    // Final pass: report, and compute the body facts.
+    for (const CFGBlock *B : *cfg) {
+      unsigned id = B->getBlockID();
+      StateSet st = inStates[id];
+      if (st == 0)
+        continue; // unreachable
+      WalkCtx ctx;
+      ctx.lastSource = inSource[id];
+      for (const CFGElement &E : *B)
+        st = step(FD, E, st, report, result, ctx);
+    }
+    result.exitStates = inStates[cfg->getExit().getBlockID()];
+    if (result.exitStates == 0)
+      result.exitStates = kCleanOnly; // no normal exit (noreturn)
+    return result;
+  }
+
+  ASTContext &m_ctx;
+  SourceManager &m_sm;
+  std::vector<Finding> &m_findings;
+  std::unique_ptr<ItaniumMangleContext> m_mangler;
+  std::unordered_map<const FunctionDecl *, Summary> m_summaries;
+  std::unordered_set<const FunctionDecl *> m_analyzed;
 };
 
 class Visitor : public RecursiveASTVisitor<Visitor> {
 public:
-    Visitor(ASTContext& Ctx, Analyzer& A, std::string onlyUnder, std::string exportUnder)
-        : m_ctx(Ctx)
-        , m_analyzer(A)
-        , m_onlyUnder(std::move(onlyUnder))
-        , m_exportUnder(std::move(exportUnder))
-    {
-    }
+  Visitor(ASTContext &Ctx, Analyzer &A, std::string onlyUnder,
+          std::vector<std::string> exportUnder)
+      : m_ctx(Ctx), m_analyzer(A), m_onlyUnder(std::move(onlyUnder)),
+        m_exportUnder(std::move(exportUnder)) {}
 
-    bool shouldVisitTemplateInstantiations() const { return true; }
-    bool shouldVisitImplicitCode() const { return false; }
+  bool shouldVisitTemplateInstantiations() const { return true; }
+  bool shouldVisitImplicitCode() const { return false; }
 
-    bool VisitFunctionDecl(FunctionDecl* FD)
-    {
-        maybeAnalyze(FD);
-        return true;
-    }
+  bool VisitFunctionDecl(FunctionDecl *FD) {
+    maybeAnalyze(FD);
+    return true;
+  }
 
-    bool VisitLambdaExpr(LambdaExpr* LE)
-    {
-        if (CXXMethodDecl* op = LE->getCallOperator())
-            maybeAnalyze(op);
-        return true;
-    }
+  bool VisitLambdaExpr(LambdaExpr *LE) {
+    if (CXXMethodDecl *op = LE->getCallOperator())
+      maybeAnalyze(op);
+    return true;
+  }
 
 private:
-    void maybeAnalyze(FunctionDecl* FD)
-    {
-        if (!FD->doesThisDeclarationHaveABody() || !FD->getBody())
-            return;
-        if (FD->isDependentContext())
-            return; // uninstantiated template pattern; instantiations are visited separately
-        SourceManager& SM = m_ctx.getSourceManager();
-        SourceLocation loc = SM.getExpansionLoc(FD->getLocation());
-        if (loc.isInvalid())
-            return;
-        PresumedLoc P = SM.getPresumedLoc(loc);
-        if (!P.isValid())
-            return;
-        std::string file = P.getFilename();
-        if (file.find(m_onlyUnder) != std::string::npos)
-            m_analyzer.analyzeFunction(FD);
-        else if (!ExportSummaries.empty() && file.find(m_exportUnder) != std::string::npos && file.find("vendor/WebKit") == std::string::npos)
-            m_analyzer.summarizeForExport(FD);
-    }
+  void maybeAnalyze(FunctionDecl *FD) {
+    if (!FD->doesThisDeclarationHaveABody() || !FD->getBody())
+      return;
+    if (FD->isDependentContext())
+      return; // uninstantiated template pattern; instantiations are visited
+              // separately
+    SourceManager &SM = m_ctx.getSourceManager();
+    SourceLocation loc = SM.getExpansionLoc(FD->getLocation());
+    if (loc.isInvalid())
+      return;
+    PresumedLoc P = SM.getPresumedLoc(loc);
+    if (!P.isValid())
+      return;
+    std::string file = P.getFilename();
+    if (file.find(m_onlyUnder) != std::string::npos)
+      m_analyzer.analyzeFunction(FD);
+    else if (!ExportSummaries.empty() &&
+             Analyzer::matchesAny(file, m_exportUnder) &&
+             file.find("vendor/WebKit") == std::string::npos)
+      m_analyzer.summarizeForExport(FD);
+  }
 
-    ASTContext& m_ctx;
-    Analyzer& m_analyzer;
-    std::string m_onlyUnder;
-    std::string m_exportUnder;
+  ASTContext &m_ctx;
+  Analyzer &m_analyzer;
+  std::string m_onlyUnder;
+  std::vector<std::string> m_exportUnder;
 };
 
 class Consumer : public ASTConsumer {
 public:
-    void HandleTranslationUnit(ASTContext& Ctx) override
-    {
-        std::vector<Finding> findings;
-        Analyzer analyzer(Ctx, findings);
-        Visitor visitor(Ctx, analyzer, OnlyPathPrefix, ExportUnder);
-        visitor.TraverseDecl(Ctx.getTranslationUnitDecl());
+  void HandleTranslationUnit(ASTContext &Ctx) override {
+    std::vector<Finding> findings;
+    Analyzer analyzer(Ctx, findings);
+    std::vector<std::string> exportUnder(ExportUnder.begin(),
+                                         ExportUnder.end());
+    if (exportUnder.empty())
+      exportUnder.push_back("/src/");
+    Visitor visitor(Ctx, analyzer, OnlyPathPrefix, exportUnder);
+    visitor.TraverseDecl(Ctx.getTranslationUnitDecl());
 
-        if (!ExportSummaries.empty()) {
-            std::error_code ec;
-            llvm::raw_fd_ostream os(ExportSummaries, ec, llvm::sys::fs::OF_Append | llvm::sys::fs::OF_Text);
-            if (!ec)
-                analyzer.exportSummaries(os, ExportUnder);
-        }
-
-        // Dedupe (template instantiations report the same line many times).
-        std::set<std::string> seen;
-        for (const Finding& f : findings) {
-            std::string key = f.file + ":" + std::to_string(f.line) + ":" + std::to_string(f.col) + ":" + f.kind + ":" + f.callee;
-            if (!seen.insert(key).second)
-                continue;
-            if (JsonOutput) {
-                auto esc = [](const std::string& s) {
-                    std::string o;
-                    for (char c : s) {
-                        if (c == '"' || c == '\\')
-                            o += '\\';
-                        if (c == '\n') {
-                            o += "\\n";
-                            continue;
-                        }
-                        o += c;
-                    }
-                    return o;
-                };
-                llvm::outs() << "{\"file\":\"" << esc(f.file) << "\",\"line\":" << f.line << ",\"col\":" << f.col
-                             << ",\"function\":\"" << esc(f.function) << "\",\"callee\":\"" << esc(f.callee)
-                             << "\",\"kind\":\"" << f.kind << "\",\"message\":\"" << esc(f.message) << "\"}\n";
-            } else {
-                llvm::outs() << f.file << ":" << f.line << ":" << f.col << ": [" << f.kind << "] in " << f.function << ": " << f.message << "\n";
-            }
-        }
-        llvm::outs().flush();
+    if (!ExportSummaries.empty()) {
+      std::error_code ec;
+      llvm::raw_fd_ostream os(ExportSummaries, ec,
+                              llvm::sys::fs::OF_Append |
+                                  llvm::sys::fs::OF_Text);
+      if (!ec)
+        analyzer.exportSummaries(os, exportUnder);
     }
+
+    // Dedupe (template instantiations report the same line many times).
+    std::set<std::string> seen;
+    for (const Finding &f : findings) {
+      std::string key = f.file + ":" + std::to_string(f.line) + ":" +
+                        std::to_string(f.col) + ":" + f.kind + ":" + f.callee;
+      if (!seen.insert(key).second)
+        continue;
+      if (JsonOutput) {
+        auto esc = [](const std::string &s) {
+          std::string o;
+          for (char c : s) {
+            if (c == '"' || c == '\\')
+              o += '\\';
+            if (c == '\n') {
+              o += "\\n";
+              continue;
+            }
+            o += c;
+          }
+          return o;
+        };
+        llvm::outs() << "{\"file\":\"" << esc(f.file)
+                     << "\",\"line\":" << f.line << ",\"col\":" << f.col
+                     << ",\"function\":\"" << esc(f.function)
+                     << "\",\"callee\":\"" << esc(f.callee) << "\",\"kind\":\""
+                     << f.kind << "\",\"message\":\"" << esc(f.message)
+                     << "\"}\n";
+      } else {
+        llvm::outs() << f.file << ":" << f.line << ":" << f.col << ": ["
+                     << f.kind << "] in " << f.function << ": " << f.message
+                     << "\n";
+      }
+    }
+    llvm::outs().flush();
+  }
 };
 
 class Action : public ASTFrontendAction {
 public:
-    std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance& CI, StringRef) override
-    {
-        // We only need the AST. Silence diagnostics from the huge header set.
-        CI.getDiagnostics().setIgnoreAllWarnings(true);
-        return std::make_unique<Consumer>();
-    }
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
+                                                 StringRef) override {
+    // We only need the AST. Silence diagnostics from the huge header set.
+    CI.getDiagnostics().setIgnoreAllWarnings(true);
+    return std::make_unique<Consumer>();
+  }
 };
 
 } // namespace
 
-int main(int argc, const char** argv)
-{
-    auto parser = CommonOptionsParser::create(argc, argv, Category);
-    if (!parser) {
-        llvm::errs() << llvm::toString(parser.takeError());
-        return 1;
-    }
-    loadList(NothrowFile, Summary::Nothrow);
-    loadList(ThrowFile, Summary::MayThrow);
-    for (const std::string& path : ImportSummaries)
-        loadSummaries(path);
-    ClangTool tool(parser->getCompilations(), parser->getSourcePathList());
-    // Drop flags that only matter for code generation and slow down parsing.
-    tool.appendArgumentsAdjuster(getClangStripOutputAdjuster());
-    tool.appendArgumentsAdjuster(getClangStripDependencyFileAdjuster());
-    tool.appendArgumentsAdjuster(getInsertArgumentAdjuster("-Wno-everything", ArgumentInsertPosition::END));
-    tool.appendArgumentsAdjuster(getInsertArgumentAdjuster("-fsyntax-only", ArgumentInsertPosition::END));
-    // The build writes shell-escaped quotes into the arguments array
-    // (-DFOO=\"bar\"). The PCH was built with the unescaped value, so the
-    // macro definitions have to match or clang rejects the PCH.
-    tool.appendArgumentsAdjuster([](const CommandLineArguments& args, StringRef) {
-        CommandLineArguments out;
-        for (std::string a : args) {
-            if (a.rfind("-D", 0) == 0) {
-                std::string fixed;
-                for (size_t i = 0; i < a.size(); i++) {
-                    if (a[i] == '\\' && i + 1 < a.size() && a[i + 1] == '"')
-                        continue;
-                    fixed += a[i];
-                }
-                a = fixed;
-            }
-            out.push_back(a);
+int main(int argc, const char **argv) {
+  auto parser = CommonOptionsParser::create(argc, argv, Category);
+  if (!parser) {
+    llvm::errs() << llvm::toString(parser.takeError());
+    return 1;
+  }
+  loadList(NothrowFile, Summary::Nothrow);
+  loadList(ThrowFile, Summary::MayThrow);
+  for (const std::string &path : ImportSummaries)
+    loadSummaries(path);
+  ClangTool tool(parser->getCompilations(), parser->getSourcePathList());
+  // Drop flags that only matter for code generation and slow down parsing.
+  tool.appendArgumentsAdjuster(getClangStripOutputAdjuster());
+  tool.appendArgumentsAdjuster(getClangStripDependencyFileAdjuster());
+  tool.appendArgumentsAdjuster(getInsertArgumentAdjuster(
+      "-Wno-everything", ArgumentInsertPosition::END));
+  tool.appendArgumentsAdjuster(
+      getInsertArgumentAdjuster("-fsyntax-only", ArgumentInsertPosition::END));
+  // The build writes shell-escaped quotes into the arguments array
+  // (-DFOO=\"bar\"). The PCH was built with the unescaped value, so the
+  // macro definitions have to match or clang rejects the PCH.
+  tool.appendArgumentsAdjuster([](const CommandLineArguments &args, StringRef) {
+    CommandLineArguments out;
+    for (std::string a : args) {
+      if (a.rfind("-D", 0) == 0) {
+        std::string fixed;
+        for (size_t i = 0; i < a.size(); i++) {
+          if (a[i] == '\\' && i + 1 < a.size() && a[i + 1] == '"')
+            continue;
+          fixed += a[i];
         }
-        return out;
-    });
-    return tool.run(newFrontendActionFactory<Action>().get());
+        a = fixed;
+      }
+      out.push_back(a);
+    }
+    return out;
+  });
+  return tool.run(newFrontendActionFactory<Action>().get());
 }

--- a/scripts/jsc-exception-lint/nothrow.txt
+++ b/scripts/jsc-exception-lint/nothrow.txt
@@ -1,0 +1,112 @@
+# Functions that take a JSGlobalObject* or ThrowScope& but cannot throw, or
+# whose effect on the exception state differs from the default convention.
+#
+# Format: <qualified name> [kind]
+#   kind: nothrow (default) | maythrow | thrower | check | checkrelease | release
+#   indirect:<member> classifies calls through a function-pointer member
+#   (method tables) by the member name.
+#
+# Everything with a visible body, or a body in a file the summary pass has
+# seen, is classified from the body. Entries here cover the remainder, and
+# override the body analysis where the analysis is too coarse.
+
+# Error object construction does not throw. JSC throws with
+# throwException(globalObject, scope, createTypeError(...)).
+JSC::createError
+JSC::createEvalError
+JSC::createRangeError
+JSC::createReferenceError
+JSC::createSyntaxError
+JSC::createTypeError
+JSC::createURIError
+JSC::createOutOfMemoryError
+JSC::createNotEnoughArgumentsError
+JSC::createNotAFunctionError
+JSC::createNotAConstructorError
+JSC::createNotAnObjectError
+JSC::createStackOverflowError
+JSC::createTerminatedExecutionException
+JSC::createInvalidFunctionApplyParameterError
+JSC::createInvalidInParameterError
+JSC::createInvalidInstanceofParameterErrorNotFunction
+JSC::createInvalidInstanceofParameterErrorHasInstanceValueNotFunction
+JSC::createErrorForInvalidGlobalAssignment
+JSC::createTDZError
+JSC::createUndefinedVariableError
+JSC::createInvalidPrivateNameError
+JSC::createRedefinedPrivateNameError
+JSC::createPrivateMethodAccessError
+JSC::createReinstallPrivateMethodError
+JSC::createGetterTypeError
+JSC::ErrorInstance::create
+JSC::Exception::create
+
+# Functions installing properties on objects that are being built.
+JSC::JSObject::putDirectNativeFunction
+JSC::JSObject::putDirectNativeFunctionWithoutTransition
+JSC::JSObject::putDirectBuiltinFunction
+JSC::JSObject::putDirectBuiltinFunctionWithoutTransition
+JSC::JSObject::putDirectAccessor
+JSC::JSFunction::create
+JSC::JSFunction::createFunctionThatMasqueradesAsUndefined
+JSC::JSNativeStdFunction::create
+JSC::JSBoundFunction::create
+JSC::JSCustomGetterFunction::create
+JSC::JSCustomSetterFunction::create
+
+# Value predicates with a slow path that takes the global object for
+# masquerades-as-undefined checks only.
+JSC::JSValue::toBooleanSlowCase
+JSC::JSValue::toThisSlowCase
+
+# Promise plumbing. reject/resolve run no user code synchronously (thenable
+# lookups are caught internally and turned into rejections).
+JSC::JSPromise::rejectedPromise
+JSC::JSPromise::rejectWithCaughtException checkrelease
+JSC::JSPromise::rejectedPromiseWithCaughtException checkrelease
+JSC::JSInternalPromise::rejectWithCaughtException checkrelease
+
+# Global object method table hooks that Bun implements without a throw scope.
+indirect:promiseRejectionTracker
+indirect:reportUncaughtExceptionAtEventLoop
+indirect:queueMicrotaskToEventLoop
+indirect:shouldInterruptScript
+indirect:shouldInterruptScriptBeforeTimeout
+indirect:javaScriptRuntimeFlags
+indirect:supportsRichSourceInfo
+indirect:currentScriptExecutionOwner
+indirect:scriptExecutionStatus
+indirect:reportViolationForUnsafeEval
+indirect:defaultLanguage
+indirect:trustedScriptStructure
+
+# Virtual hooks resolved to the base declaration. Bun's overrides do not throw.
+JSC::TypedArrayController::registerWrapper
+JSC::SimpleTypedArrayController::registerWrapper
+WebCore::WebCoreTypedArrayController::registerWrapper
+
+# Microtask and promise plumbing that only enqueues work.
+JSC::JSGlobalObject::queueMicrotask
+JSC::JSGlobalObject::queueMicrotaskSlow
+JSC::VM::queueMicrotask
+JSC::JSPromise::performPromiseThen
+JSC::JSPromise::performPromiseThenWithContext
+JSC::JSPromise::performPromiseThenExported
+JSC::JSPromise::performPromiseThenWithInternalMicrotask
+JSC::JSPromise::fulfill
+JSC::JSPromise::fulfillPromise
+JSC::JSPromise::triggerPromiseReactions
+
+# toThis only boxes primitives. The method table hook is implemented by
+# JSObject and friends without a scope.
+JSC::JSCell::toThis
+JSC::JSValue::toThisSloppySlowCase
+indirect:toThis
+
+# Wraps an ArrayBuffer in its JS object. Bun's override does not throw.
+JSC::TypedArrayController::toJS
+JSC::JSPromise::resolve
+JSC::JSPromise::reject
+JSC::JSPromise::rejectAsHandled
+JSC::JSPromise::resolvePromise
+JSC::JSPromise::rejectPromise

--- a/scripts/jsc-exception-lint/nothrow.txt
+++ b/scripts/jsc-exception-lint/nothrow.txt
@@ -62,6 +62,11 @@ JSC::JSValue::toThisSlowCase
 # Promise plumbing. reject/resolve run no user code synchronously (thenable
 # lookups are caught internally and turned into rejections).
 JSC::JSPromise::rejectedPromise
+JSC::JSPromise::resolve
+JSC::JSPromise::reject
+JSC::JSPromise::rejectAsHandled
+JSC::JSPromise::resolvePromise
+JSC::JSPromise::rejectPromise
 JSC::JSPromise::rejectWithCaughtException checkrelease
 JSC::JSPromise::rejectedPromiseWithCaughtException checkrelease
 JSC::JSInternalPromise::rejectWithCaughtException checkrelease
@@ -105,8 +110,3 @@ indirect:toThis
 
 # Wraps an ArrayBuffer in its JS object. Bun's override does not throw.
 JSC::TypedArrayController::toJS
-JSC::JSPromise::resolve
-JSC::JSPromise::reject
-JSC::JSPromise::rejectAsHandled
-JSC::JSPromise::resolvePromise
-JSC::JSPromise::rejectPromise

--- a/scripts/jsc-exception-lint/run.ts
+++ b/scripts/jsc-exception-lint/run.ts
@@ -1,0 +1,305 @@
+#!/usr/bin/env bun
+// Driver for scripts/jsc-exception-lint/jsc-exception-lint.cpp.
+//
+//   bun scripts/jsc-exception-lint/run.ts [options] [file...]
+//
+// Options:
+//   --build-dir <dir>    cmake build dir with compile_commands.json (default build/debug)
+//   --jobs <n>           parallel processes (default: cpu count)
+//   --json <file>        also write the findings as JSON
+//   --webkit             recompute the JavaScriptCore callee summaries
+//   --webkit-rounds <n>  summary passes over JavaScriptCore (default 3). Each pass
+//                        resolves one more level of cross-file calls.
+//   --no-summaries       skip the whole-project summary passes (faster, more false positives)
+//   --reuse-summaries    skip the Bun summary pass and import the one from the previous run
+//   --kind <k>[,<k>]     only print these kinds (pending-call, thrown-call, unchecked-exit,
+//                        scope-while-pending, maybe-thrown-call). maybe-thrown-call is
+//                        hidden unless asked for: it marks a call made after a helper
+//                        that may have thrown and returned a failure value the caller
+//                        usually tests.
+//
+// The tool needs the LLVM 21 development package (libclang-cpp, headers). Set
+// LLVM_DIR to point at it if it is not under /usr/lib/llvm-21 or `brew
+// --prefix llvm`.
+//
+// Summaries: functions defined in another translation unit cannot be analyzed
+// from their call site. Two export passes (JavaScriptCore sources, then Bun's
+// bindings) record each function's effect on the exception state in a .tsv,
+// which the final pass imports. The JavaScriptCore summaries are cached in the
+// build dir keyed by the WebKit version and only recomputed with --webkit.
+
+import { spawn } from "bun";
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync, copyFileSync, rmSync } from "node:fs";
+import { cpus } from "node:os";
+import { basename, dirname, join, relative, resolve } from "node:path";
+
+const repo = resolve(import.meta.dirname, "../..");
+const toolDir = import.meta.dirname;
+const args = process.argv.slice(2);
+
+function flag(name: string): boolean {
+  const i = args.indexOf(name);
+  if (i === -1) return false;
+  args.splice(i, 1);
+  return true;
+}
+function opt(name: string, def?: string): string | undefined {
+  const i = args.indexOf(name);
+  if (i === -1) return def;
+  const v = args[i + 1];
+  args.splice(i, 2);
+  return v;
+}
+
+const buildDir = resolve(repo, opt("--build-dir", "build/debug")!);
+const jobs = Number(opt("--jobs", String(cpus().length)));
+const jsonOut = opt("--json");
+const recomputeWebKit = flag("--webkit");
+const webkitRounds = Number(opt("--webkit-rounds", "3"));
+const noSummaries = flag("--no-summaries");
+const reuseSummaries = flag("--reuse-summaries");
+const kinds = opt("--kind")?.split(",");
+const onlyFiles = args.filter(a => !a.startsWith("--")).map(f => resolve(f));
+
+const outDir = join(buildDir, "jsc-exception-lint");
+mkdirSync(outDir, { recursive: true });
+
+function llvmDir(): string {
+  if (process.env.LLVM_DIR) return process.env.LLVM_DIR;
+  for (const d of ["/usr/lib/llvm-21", "/opt/homebrew/opt/llvm", "/usr/local/opt/llvm"]) if (existsSync(d)) return d;
+  throw new Error("LLVM 21 not found; set LLVM_DIR");
+}
+
+async function run(cmd: string[], opts: { cwd?: string; stdout?: "pipe" | "inherit" } = {}): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = spawn({ cmd, cwd: opts.cwd ?? repo, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { code, stdout, stderr };
+}
+
+async function buildTool(): Promise<string> {
+  const src = join(toolDir, "jsc-exception-lint.cpp");
+  const bin = join(outDir, "jsc-exception-lint");
+  if (existsSync(bin) && statSync(bin).mtimeMs >= statSync(src).mtimeMs) return bin;
+  const llvm = llvmDir();
+  console.error(`building ${relative(repo, bin)} against ${llvm}`);
+  const cmd = [
+    "clang++", "-std=c++17", "-O2", "-fno-rtti", "-fno-exceptions",
+    `-I${llvm}/include`, "-D_GNU_SOURCE", "-D__STDC_CONSTANT_MACROS", "-D__STDC_FORMAT_MACROS", "-D__STDC_LIMIT_MACROS",
+    src, "-o", bin, `-L${llvm}/lib`, "-lclang-cpp", "-lLLVM", `-Wl,-rpath,${llvm}/lib`,
+  ];
+  const r = await run(cmd);
+  if (r.code !== 0) {
+    console.error(r.stderr);
+    throw new Error("tool build failed");
+  }
+  return bin;
+}
+
+type Entry = { directory: string; arguments?: string[]; command?: string; file: string };
+
+function loadCompileCommands(dir: string): Entry[] {
+  return JSON.parse(readFileSync(join(dir, "compile_commands.json"), "utf8"));
+}
+
+// The individual bindings .cpp files, plus the unified sources that are the
+// only compile entries for src/jsc/modules, src/runtime/bake and friends.
+function bunSourceFiles(entries: Entry[]): string[] {
+  return entries
+    .map(e => e.file)
+    .filter(f => f.endsWith(".cpp"))
+    .filter(f => f.includes("/src/jsc/bindings/") || (f.includes("/unified/UnifiedSource-src_") && !f.includes("-src_jsc_bindings")));
+}
+
+// Run the tool over `files` in parallel shards. Returns the concatenated stdout.
+async function shardRun(bin: string, ccDir: string, files: string[], extra: string[], label: string): Promise<string> {
+  const shards: string[][] = Array.from({ length: Math.min(jobs, files.length) }, () => []);
+  files.forEach((f, i) => shards[i % shards.length].push(f));
+  let done = 0;
+  const started = Date.now();
+  const outputs = await Promise.all(
+    shards.map(async (shard, i) => {
+      const r = await run([bin, "-p", ccDir, ...extra.map(a => a.replace("{shard}", String(i))), ...shard]);
+      done += shard.length;
+      if (r.code !== 0 && !r.stdout) console.error(`[${label}] shard ${i} exited ${r.code}: ${r.stderr.slice(-2000)}`);
+      return r.stdout;
+    }),
+  );
+  console.error(`[${label}] ${done} files in ${((Date.now() - started) / 1000).toFixed(0)}s`);
+  return outputs.join("");
+}
+
+// Merge per-shard summary files. "unknown" rows are leaves the analysis had
+// to guess (no body anywhere); the most frequent ones are printed so they can
+// be added to nothrow.txt or covered by another summary pass.
+function mergeTsv(dir: string, out: string, label: string) {
+  const lines = new Set<string>();
+  const unknown = new Map<string, number>();
+  for (const f of readdirSync(dir)) {
+    if (!f.endsWith(".tsv")) continue;
+    for (const l of readFileSync(join(dir, f), "utf8").split("\n")) {
+      if (!l) continue;
+      const cols = l.split("\t");
+      if (cols[2] === "unknown") {
+        unknown.set(cols[1], (unknown.get(cols[1]) ?? 0) + 1);
+        continue;
+      }
+      lines.add(l);
+    }
+  }
+  writeFileSync(out, [...lines].sort().join("\n") + "\n");
+  const top = [...unknown].sort((a, b) => b[1] - a[1]).slice(0, 25);
+  if (top.length) {
+    console.error(`[${label}] most frequent callees without a known body (guessed as may-throw):`);
+    for (const [k, n] of top) console.error(`  ${String(n).padStart(5)}  ${k}`);
+  }
+}
+
+function freshDir(d: string) {
+  rmSync(d, { recursive: true, force: true });
+  mkdirSync(d, { recursive: true });
+}
+
+// JavaScriptCore is consumed as a prebuilt library, so there is no compile
+// database for its sources. Build one: copy each .cpp next to nothing (so its
+// quoted includes resolve through -I), and assemble one flat header directory
+// from the prebuilt include dir (which has the derived headers) plus the
+// source headers missing from it.
+function webkitCompileDb(bindingsEntry: Entry): string {
+  const wkDir = join(outDir, "webkit");
+  const jsc = join(repo, "vendor/WebKit/Source/JavaScriptCore");
+  const baseArgs = bindingsEntry.arguments!;
+  const prebuilt = baseArgs.find(a => a.startsWith("-I") && /webkit-[0-9a-f]+/.test(a) && a.endsWith("/include"))?.slice(2);
+  if (!prebuilt) throw new Error("prebuilt WebKit include dir not found in compile command");
+
+  freshDir(wkDir);
+  const fwd = join(wkDir, "fwd/JavaScriptCore");
+  mkdirSync(fwd, { recursive: true });
+  for (const f of readdirSync(join(prebuilt, "JavaScriptCore"))) copyFileSync(join(prebuilt, "JavaScriptCore", f), join(fwd, f));
+  const walk = (d: string, cb: (p: string) => void) => {
+    for (const e of readdirSync(d, { withFileTypes: true })) {
+      const p = join(d, e.name);
+      if (e.isDirectory()) walk(p, cb);
+      else cb(p);
+    }
+  };
+  walk(jsc, p => {
+    if (p.endsWith(".h") && !existsSync(join(fwd, basename(p)))) copyFileSync(p, join(fwd, basename(p)));
+  });
+
+  const srcDir = join(wkDir, "src");
+  mkdirSync(srcDir);
+  const keep: string[] = [];
+  let skip = 0;
+  for (const a of baseArgs) {
+    if (skip) { skip--; continue; }
+    if (a === "-include-pch" || a === "-o" || a === "-c") { skip = 1; continue; }
+    if (a.startsWith("-I") && (a.includes("/src/jsc/bindings") || a.includes("/codegen"))) continue;
+    if (a.startsWith("-DREPORTED_") || a.startsWith("-DBUN_DYNAMIC")) continue;
+    keep.push(a);
+  }
+  const firstInclude = keep.findIndex(a => a.startsWith("-I"));
+  keep.splice(firstInclude, 0, `-I${join(wkDir, "fwd")}`, `-I${fwd}`);
+  keep.push("-DBUILDING_JavaScriptCore", "-DSTATICALLY_LINKED_WITH_WTF", "-DUSE_BUN_JSC_ADDITIONS=1", "-DUSE_BUN_EVENT_LOOP=1");
+
+  const entries: Entry[] = [];
+  const dirs = ["runtime", "API", "interpreter", "heap", "parser", "bytecompiler", "bytecode", "profiler", "debugger", "inspector", "tools", "domjit", "yarr", "wasm/js", "jit", "dfg", "llint"];
+  for (const d of dirs) {
+    const p = join(jsc, d);
+    if (!existsSync(p)) continue;
+    for (const f of readdirSync(p)) {
+      if (!f.endsWith(".cpp")) continue;
+      const dst = join(srcDir, `${d.replace("/", "__")}__${f}`);
+      copyFileSync(join(p, f), dst);
+      entries.push({ directory: bindingsEntry.directory, arguments: [...keep, "-c", dst], file: dst });
+    }
+  }
+  writeFileSync(join(wkDir, "compile_commands.json"), JSON.stringify(entries));
+  return wkDir;
+}
+
+async function main() {
+  const bin = await buildTool();
+  const entries = loadCompileCommands(buildDir);
+  const allBindings = bunSourceFiles(entries);
+  const bindingsEntry = entries.find(e => e.file.endsWith("/src/jsc/bindings/bindings.cpp"))!;
+  const nothrow = join(toolDir, "nothrow.txt");
+  const imports: string[] = [];
+
+  if (!noSummaries) {
+    // JavaScriptCore summaries, cached per WebKit version.
+    const wkVersion = bindingsEntry.arguments!.find(a => /webkit-[0-9a-f]+/.test(a))?.match(/webkit-([0-9a-f]+)/)?.[1] ?? "unknown";
+    const wkSummaries = join(outDir, `webkit-summaries-${wkVersion}.tsv`);
+    if (recomputeWebKit || !existsSync(wkSummaries)) {
+      const wkDir = webkitCompileDb(bindingsEntry);
+      const wkFiles = loadCompileCommands(wkDir).map(e => e.file);
+      // Each round resolves one more level of cross-file calls: a function
+      // whose callee lives in another file is classified from that callee's
+      // summary of the previous round.
+      let previous: string | undefined;
+      for (let round = 1; round <= webkitRounds; round++) {
+        const tmp = join(wkDir, `round${round}`);
+        freshDir(tmp);
+        const importArgs = previous ? [`--import-summaries=${previous}`] : [];
+        await shardRun(bin, wkDir, wkFiles, ["--only-under=NEVER", `--export-under=${join(wkDir, "src")}`, `--nothrow=${nothrow}`, ...importArgs, `--export-summaries=${tmp}/{shard}.tsv`], `webkit round ${round}`);
+        const merged = round === webkitRounds ? wkSummaries : join(wkDir, `round${round}.tsv`);
+        mergeTsv(tmp, merged, `webkit round ${round}`);
+        previous = merged;
+      }
+    }
+    imports.push(wkSummaries);
+
+    // Bun summaries (always recomputed: the bindings are what changes). The
+    // analysis pass below exports a second round, so a helper defined in
+    // another translation unit is seen with the summaries of its own callees.
+    const previous = join(outDir, "bun-summaries.tsv");
+    if (reuseSummaries && existsSync(previous)) {
+      imports.push(previous);
+    } else {
+      const bunTmp = join(outDir, "bun-summaries");
+      freshDir(bunTmp);
+      await shardRun(bin, buildDir, allBindings, ["--only-under=NEVER", `--export-under=${join(repo, "src")}/`, `--nothrow=${nothrow}`, ...imports.map(i => `--import-summaries=${i}`), `--export-summaries=${bunTmp}/{shard}.tsv`], "bun summaries");
+      const bunSummaries = join(outDir, "bun-summaries-round1.tsv");
+      mergeTsv(bunTmp, bunSummaries, "bun summaries");
+      imports.push(bunSummaries);
+    }
+  }
+
+  const files = onlyFiles.length ? onlyFiles : allBindings;
+  const exportArgs: string[] = [];
+  const bunTmp2 = join(outDir, "bun-summaries-2");
+  if (!noSummaries && !onlyFiles.length) {
+    freshDir(bunTmp2);
+    exportArgs.push(`--export-under=${join(repo, "src")}/`, `--export-summaries=${bunTmp2}/{shard}.tsv`);
+  }
+  const out = await shardRun(bin, buildDir, files, ["--json", `--only-under=${join(repo, "src")}/`, `--nothrow=${nothrow}`, ...imports.map(i => `--import-summaries=${i}`), ...exportArgs], "analysis");
+  if (exportArgs.length) mergeTsv(bunTmp2, join(outDir, "bun-summaries.tsv"), "analysis");
+  type Finding = { file: string; line: number; col: number; function: string; callee: string; kind: string; message: string };
+  const seen = new Set<string>();
+  const findings: Finding[] = [];
+  for (const line of out.split("\n")) {
+    if (!line.startsWith("{")) continue;
+    const f: Finding = JSON.parse(line);
+    const key = `${f.file}:${f.line}:${f.col}:${f.kind}:${f.callee}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (kinds ? !kinds.includes(f.kind) : f.kind === "maybe-thrown-call") continue;
+    findings.push(f);
+  }
+  findings.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line || a.col - b.col);
+  if (jsonOut) writeFileSync(jsonOut, JSON.stringify(findings, null, 2));
+
+  for (const f of findings) console.log(`${relative(repo, f.file)}:${f.line}:${f.col}: [${f.kind}] ${f.function}: ${f.message}`);
+
+  const byKind = new Map<string, number>();
+  const byCallee = new Map<string, number>();
+  for (const f of findings) {
+    byKind.set(f.kind, (byKind.get(f.kind) ?? 0) + 1);
+    if (f.kind === "pending-call" || f.kind === "thrown-call") byCallee.set(f.callee, (byCallee.get(f.callee) ?? 0) + 1);
+  }
+  console.error(`\n${findings.length} findings in ${new Set(findings.map(f => f.file)).size} files`);
+  for (const [k, n] of [...byKind].sort((a, b) => b[1] - a[1])) console.error(`  ${k}: ${n}`);
+  console.error("\ntop callees flagged while a check is pending:");
+  for (const [k, n] of [...byCallee].sort((a, b) => b[1] - a[1]).slice(0, 40)) console.error(`  ${String(n).padStart(5)}  ${k}`);
+}
+
+await main();

--- a/scripts/jsc-exception-lint/run.ts
+++ b/scripts/jsc-exception-lint/run.ts
@@ -8,6 +8,7 @@
 //   --jobs <n>           parallel processes (default: cpu count)
 //   --json <file>        also write the findings as JSON
 //   --webkit             recompute the JavaScriptCore callee summaries
+//   --webkit-only        stop after the JavaScriptCore summaries
 //   --webkit-rounds <n>  summary passes over JavaScriptCore (default 3). Each pass
 //                        resolves one more level of cross-file calls.
 //   --no-summaries       skip the whole-project summary passes (faster, more false positives)
@@ -29,7 +30,16 @@
 // build dir keyed by the WebKit version and only recomputed with --webkit.
 
 import { spawn } from "bun";
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync, copyFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+  copyFileSync,
+  rmSync,
+} from "node:fs";
 import { cpus } from "node:os";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
@@ -51,10 +61,22 @@ function opt(name: string, def?: string): string | undefined {
   return v;
 }
 
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(
+    readFileSync(import.meta.filename, "utf8")
+      .split("\n")
+      .slice(1, 26)
+      .map(l => l.replace(/^\/\/ ?/, ""))
+      .join("\n"),
+  );
+  process.exit(0);
+}
+
 const buildDir = resolve(repo, opt("--build-dir", "build/debug")!);
 const jobs = Number(opt("--jobs", String(cpus().length)));
 const jsonOut = opt("--json");
 const recomputeWebKit = flag("--webkit");
+const webkitOnly = flag("--webkit-only");
 const webkitRounds = Number(opt("--webkit-rounds", "3"));
 const noSummaries = flag("--no-summaries");
 const reuseSummaries = flag("--reuse-summaries");
@@ -70,7 +92,10 @@ function llvmDir(): string {
   throw new Error("LLVM 21 not found; set LLVM_DIR");
 }
 
-async function run(cmd: string[], opts: { cwd?: string; stdout?: "pipe" | "inherit" } = {}): Promise<{ code: number; stdout: string; stderr: string }> {
+async function run(
+  cmd: string[],
+  opts: { cwd?: string; stdout?: "pipe" | "inherit" } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
   const proc = spawn({ cmd, cwd: opts.cwd ?? repo, stdout: "pipe", stderr: "pipe" });
   const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { code, stdout, stderr };
@@ -83,9 +108,23 @@ async function buildTool(): Promise<string> {
   const llvm = llvmDir();
   console.error(`building ${relative(repo, bin)} against ${llvm}`);
   const cmd = [
-    "clang++", "-std=c++17", "-O2", "-fno-rtti", "-fno-exceptions",
-    `-I${llvm}/include`, "-D_GNU_SOURCE", "-D__STDC_CONSTANT_MACROS", "-D__STDC_FORMAT_MACROS", "-D__STDC_LIMIT_MACROS",
-    src, "-o", bin, `-L${llvm}/lib`, "-lclang-cpp", "-lLLVM", `-Wl,-rpath,${llvm}/lib`,
+    "clang++",
+    "-std=c++17",
+    "-O2",
+    "-fno-rtti",
+    "-fno-exceptions",
+    `-I${llvm}/include`,
+    "-D_GNU_SOURCE",
+    "-D__STDC_CONSTANT_MACROS",
+    "-D__STDC_FORMAT_MACROS",
+    "-D__STDC_LIMIT_MACROS",
+    src,
+    "-o",
+    bin,
+    `-L${llvm}/lib`,
+    "-lclang-cpp",
+    "-lLLVM",
+    `-Wl,-rpath,${llvm}/lib`,
   ];
   const r = await run(cmd);
   if (r.code !== 0) {
@@ -107,7 +146,18 @@ function bunSourceFiles(entries: Entry[]): string[] {
   return entries
     .map(e => e.file)
     .filter(f => f.endsWith(".cpp"))
-    .filter(f => f.includes("/src/jsc/bindings/") || (f.includes("/unified/UnifiedSource-src_") && !f.includes("-src_jsc_bindings")));
+    .filter(
+      f =>
+        f.includes("/src/jsc/bindings/") ||
+        (f.includes("/unified/UnifiedSource-src_") && !f.includes("-src_jsc_bindings")),
+    );
+}
+
+// Generated C++ (ZigGeneratedClasses.cpp, JSSink.cpp, ...). Summarized so
+// calls into it are classified from its bodies; not analyzed, the generators
+// own that code.
+function generatedSourceFiles(entries: Entry[]): string[] {
+  return entries.map(e => e.file).filter(f => f.endsWith(".cpp") && f.includes("/codegen/"));
 }
 
 // Run the tool over `files` in parallel shards. Returns the concatenated stdout.
@@ -168,13 +218,16 @@ function webkitCompileDb(bindingsEntry: Entry): string {
   const wkDir = join(outDir, "webkit");
   const jsc = join(repo, "vendor/WebKit/Source/JavaScriptCore");
   const baseArgs = bindingsEntry.arguments!;
-  const prebuilt = baseArgs.find(a => a.startsWith("-I") && /webkit-[0-9a-f]+/.test(a) && a.endsWith("/include"))?.slice(2);
+  const prebuilt = baseArgs
+    .find(a => a.startsWith("-I") && /webkit-[0-9a-f]+/.test(a) && a.endsWith("/include"))
+    ?.slice(2);
   if (!prebuilt) throw new Error("prebuilt WebKit include dir not found in compile command");
 
   freshDir(wkDir);
   const fwd = join(wkDir, "fwd/JavaScriptCore");
   mkdirSync(fwd, { recursive: true });
-  for (const f of readdirSync(join(prebuilt, "JavaScriptCore"))) copyFileSync(join(prebuilt, "JavaScriptCore", f), join(fwd, f));
+  for (const f of readdirSync(join(prebuilt, "JavaScriptCore")))
+    copyFileSync(join(prebuilt, "JavaScriptCore", f), join(fwd, f));
   const walk = (d: string, cb: (p: string) => void) => {
     for (const e of readdirSync(d, { withFileTypes: true })) {
       const p = join(d, e.name);
@@ -191,18 +244,47 @@ function webkitCompileDb(bindingsEntry: Entry): string {
   const keep: string[] = [];
   let skip = 0;
   for (const a of baseArgs) {
-    if (skip) { skip--; continue; }
-    if (a === "-include-pch" || a === "-o" || a === "-c") { skip = 1; continue; }
+    if (skip) {
+      skip--;
+      continue;
+    }
+    if (a === "-include-pch" || a === "-o" || a === "-c") {
+      skip = 1;
+      continue;
+    }
     if (a.startsWith("-I") && (a.includes("/src/jsc/bindings") || a.includes("/codegen"))) continue;
     if (a.startsWith("-DREPORTED_") || a.startsWith("-DBUN_DYNAMIC")) continue;
     keep.push(a);
   }
   const firstInclude = keep.findIndex(a => a.startsWith("-I"));
   keep.splice(firstInclude, 0, `-I${join(wkDir, "fwd")}`, `-I${fwd}`);
-  keep.push("-DBUILDING_JavaScriptCore", "-DSTATICALLY_LINKED_WITH_WTF", "-DUSE_BUN_JSC_ADDITIONS=1", "-DUSE_BUN_EVENT_LOOP=1");
+  keep.push(
+    "-DBUILDING_JavaScriptCore",
+    "-DSTATICALLY_LINKED_WITH_WTF",
+    "-DUSE_BUN_JSC_ADDITIONS=1",
+    "-DUSE_BUN_EVENT_LOOP=1",
+  );
 
   const entries: Entry[] = [];
-  const dirs = ["runtime", "API", "interpreter", "heap", "parser", "bytecompiler", "bytecode", "profiler", "debugger", "inspector", "tools", "domjit", "yarr", "wasm/js", "jit", "dfg", "llint"];
+  const dirs = [
+    "runtime",
+    "API",
+    "interpreter",
+    "heap",
+    "parser",
+    "bytecompiler",
+    "bytecode",
+    "profiler",
+    "debugger",
+    "inspector",
+    "tools",
+    "domjit",
+    "yarr",
+    "wasm/js",
+    "jit",
+    "dfg",
+    "llint",
+  ];
   for (const d of dirs) {
     const p = join(jsc, d);
     if (!existsSync(p)) continue;
@@ -227,7 +309,8 @@ async function main() {
 
   if (!noSummaries) {
     // JavaScriptCore summaries, cached per WebKit version.
-    const wkVersion = bindingsEntry.arguments!.find(a => /webkit-[0-9a-f]+/.test(a))?.match(/webkit-([0-9a-f]+)/)?.[1] ?? "unknown";
+    const wkVersion =
+      bindingsEntry.arguments!.find(a => /webkit-[0-9a-f]+/.test(a))?.match(/webkit-([0-9a-f]+)/)?.[1] ?? "unknown";
     const wkSummaries = join(outDir, `webkit-summaries-${wkVersion}.tsv`);
     if (recomputeWebKit || !existsSync(wkSummaries)) {
       const wkDir = webkitCompileDb(bindingsEntry);
@@ -240,24 +323,55 @@ async function main() {
         const tmp = join(wkDir, `round${round}`);
         freshDir(tmp);
         const importArgs = previous ? [`--import-summaries=${previous}`] : [];
-        await shardRun(bin, wkDir, wkFiles, ["--only-under=NEVER", `--export-under=${join(wkDir, "src")}`, `--nothrow=${nothrow}`, ...importArgs, `--export-summaries=${tmp}/{shard}.tsv`], `webkit round ${round}`);
+        await shardRun(
+          bin,
+          wkDir,
+          wkFiles,
+          [
+            "--only-under=NEVER",
+            `--export-under=${join(wkDir, "src")}`,
+            `--nothrow=${nothrow}`,
+            ...importArgs,
+            `--export-summaries=${tmp}/{shard}.tsv`,
+          ],
+          `webkit round ${round}`,
+        );
         const merged = round === webkitRounds ? wkSummaries : join(wkDir, `round${round}.tsv`);
         mergeTsv(tmp, merged, `webkit round ${round}`);
         previous = merged;
       }
     }
     imports.push(wkSummaries);
+    if (webkitOnly) return;
 
     // Bun summaries (always recomputed: the bindings are what changes). The
     // analysis pass below exports a second round, so a helper defined in
     // another translation unit is seen with the summaries of its own callees.
+    // A previous run's summaries seed this one, so each run refines the
+    // classification of helpers defined in another translation unit instead
+    // of starting from the signature convention again.
     const previous = join(outDir, "bun-summaries.tsv");
     if (reuseSummaries && existsSync(previous)) {
       imports.push(previous);
     } else {
       const bunTmp = join(outDir, "bun-summaries");
       freshDir(bunTmp);
-      await shardRun(bin, buildDir, allBindings, ["--only-under=NEVER", `--export-under=${join(repo, "src")}/`, `--nothrow=${nothrow}`, ...imports.map(i => `--import-summaries=${i}`), `--export-summaries=${bunTmp}/{shard}.tsv`], "bun summaries");
+      const seed = existsSync(previous) ? [`--import-summaries=${previous}`] : [];
+      const exportUnder = [`--export-under=${join(repo, "src")}/`, `--export-under=${join(buildDir, "codegen")}/`];
+      await shardRun(
+        bin,
+        buildDir,
+        [...allBindings, ...generatedSourceFiles(entries)],
+        [
+          "--only-under=NEVER",
+          ...exportUnder,
+          `--nothrow=${nothrow}`,
+          ...imports.map(i => `--import-summaries=${i}`),
+          ...seed,
+          `--export-summaries=${bunTmp}/{shard}.tsv`,
+        ],
+        "bun summaries",
+      );
       const bunSummaries = join(outDir, "bun-summaries-round1.tsv");
       mergeTsv(bunTmp, bunSummaries, "bun summaries");
       imports.push(bunSummaries);
@@ -269,11 +383,35 @@ async function main() {
   const bunTmp2 = join(outDir, "bun-summaries-2");
   if (!noSummaries && !onlyFiles.length) {
     freshDir(bunTmp2);
-    exportArgs.push(`--export-under=${join(repo, "src")}/`, `--export-summaries=${bunTmp2}/{shard}.tsv`);
+    exportArgs.push(
+      `--export-under=${join(repo, "src")}/`,
+      `--export-under=${join(buildDir, "codegen")}/`,
+      `--export-summaries=${bunTmp2}/{shard}.tsv`,
+    );
   }
-  const out = await shardRun(bin, buildDir, files, ["--json", `--only-under=${join(repo, "src")}/`, `--nothrow=${nothrow}`, ...imports.map(i => `--import-summaries=${i}`), ...exportArgs], "analysis");
+  const out = await shardRun(
+    bin,
+    buildDir,
+    files,
+    [
+      "--json",
+      `--only-under=${join(repo, "src")}/`,
+      `--nothrow=${nothrow}`,
+      ...imports.map(i => `--import-summaries=${i}`),
+      ...exportArgs,
+    ],
+    "analysis",
+  );
   if (exportArgs.length) mergeTsv(bunTmp2, join(outDir, "bun-summaries.tsv"), "analysis");
-  type Finding = { file: string; line: number; col: number; function: string; callee: string; kind: string; message: string };
+  type Finding = {
+    file: string;
+    line: number;
+    col: number;
+    function: string;
+    callee: string;
+    kind: string;
+    message: string;
+  };
   const seen = new Set<string>();
   const findings: Finding[] = [];
   for (const line of out.split("\n")) {
@@ -288,18 +426,21 @@ async function main() {
   findings.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line || a.col - b.col);
   if (jsonOut) writeFileSync(jsonOut, JSON.stringify(findings, null, 2));
 
-  for (const f of findings) console.log(`${relative(repo, f.file)}:${f.line}:${f.col}: [${f.kind}] ${f.function}: ${f.message}`);
+  for (const f of findings)
+    console.log(`${relative(repo, f.file)}:${f.line}:${f.col}: [${f.kind}] ${f.function}: ${f.message}`);
 
   const byKind = new Map<string, number>();
   const byCallee = new Map<string, number>();
   for (const f of findings) {
     byKind.set(f.kind, (byKind.get(f.kind) ?? 0) + 1);
-    if (f.kind === "pending-call" || f.kind === "thrown-call") byCallee.set(f.callee, (byCallee.get(f.callee) ?? 0) + 1);
+    if (f.kind === "pending-call" || f.kind === "thrown-call")
+      byCallee.set(f.callee, (byCallee.get(f.callee) ?? 0) + 1);
   }
   console.error(`\n${findings.length} findings in ${new Set(findings.map(f => f.file)).size} files`);
   for (const [k, n] of [...byKind].sort((a, b) => b[1] - a[1])) console.error(`  ${k}: ${n}`);
   console.error("\ntop callees flagged while a check is pending:");
-  for (const [k, n] of [...byCallee].sort((a, b) => b[1] - a[1]).slice(0, 40)) console.error(`  ${String(n).padStart(5)}  ${k}`);
+  for (const [k, n] of [...byCallee].sort((a, b) => b[1] - a[1]).slice(0, 40))
+    console.error(`  ${String(n).padStart(5)}  ${k}`);
 }
 
 await main();

--- a/scripts/jsc-exception-lint/run.ts
+++ b/scripts/jsc-exception-lint/run.ts
@@ -57,7 +57,19 @@ function opt(name: string, def?: string): string | undefined {
   const i = args.indexOf(name);
   if (i === -1) return def;
   const v = args[i + 1];
+  if (v === undefined || v.startsWith("--")) {
+    console.error(`${name} needs a value`);
+    process.exit(1);
+  }
   args.splice(i, 2);
+  return v;
+}
+function intOpt(name: string, def: number): number {
+  const v = Number(opt(name, String(def)));
+  if (!Number.isInteger(v) || v < 1) {
+    console.error(`${name} must be a positive integer`);
+    process.exit(1);
+  }
   return v;
 }
 
@@ -77,11 +89,11 @@ if (args.includes("--help") || args.includes("-h")) {
 }
 
 const buildDir = resolve(repo, opt("--build-dir", "build/debug")!);
-const jobs = Number(opt("--jobs", String(cpus().length)));
+const jobs = intOpt("--jobs", cpus().length);
 const jsonOut = opt("--json");
 const recomputeWebKit = flag("--webkit");
 const webkitOnly = flag("--webkit-only");
-const webkitRounds = Number(opt("--webkit-rounds", "3"));
+const webkitRounds = intOpt("--webkit-rounds", 3);
 const noSummaries = flag("--no-summaries");
 const reuseSummaries = flag("--reuse-summaries");
 const kinds = opt("--kind")?.split(",");
@@ -261,7 +273,7 @@ function webkitCompileDb(bindingsEntry: Entry): string {
     keep.push(a);
   }
   const firstInclude = keep.findIndex(a => a.startsWith("-I"));
-  keep.splice(firstInclude, 0, `-I${join(wkDir, "fwd")}`, `-I${fwd}`);
+  keep.splice(firstInclude === -1 ? keep.length : firstInclude, 0, `-I${join(wkDir, "fwd")}`, `-I${fwd}`);
   keep.push(
     "-DBUILDING_JavaScriptCore",
     "-DSTATICALLY_LINKED_WITH_WTF",

--- a/scripts/jsc-exception-lint/run.ts
+++ b/scripts/jsc-exception-lint/run.ts
@@ -62,10 +62,14 @@ function opt(name: string, def?: string): string | undefined {
 }
 
 if (args.includes("--help") || args.includes("-h")) {
+  // The header comment of this file is the usage text.
+  const lines = readFileSync(import.meta.filename, "utf8")
+    .split("\n")
+    .slice(1);
+  const end = lines.findIndex(l => !l.startsWith("//"));
   console.log(
-    readFileSync(import.meta.filename, "utf8")
-      .split("\n")
-      .slice(1, 26)
+    lines
+      .slice(0, end === -1 ? undefined : end)
       .map(l => l.replace(/^\/\/ ?/, ""))
       .join("\n"),
   );
@@ -94,7 +98,7 @@ function llvmDir(): string {
 
 async function run(
   cmd: string[],
-  opts: { cwd?: string; stdout?: "pipe" | "inherit" } = {},
+  opts: { cwd?: string } = {},
 ): Promise<{ code: number; stdout: string; stderr: string }> {
   const proc = spawn({ cmd, cwd: opts.cwd ?? repo, stdout: "pipe", stderr: "pipe" });
   const [stdout, stderr, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);

--- a/scripts/jsc-exception-lint/run.ts
+++ b/scripts/jsc-exception-lint/run.ts
@@ -31,17 +31,17 @@
 
 import { spawn } from "bun";
 import {
+  copyFileSync,
   existsSync,
   mkdirSync,
   readFileSync,
   readdirSync,
+  rmSync,
   statSync,
   writeFileSync,
-  copyFileSync,
-  rmSync,
 } from "node:fs";
 import { cpus } from "node:os";
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { basename, join, relative, resolve } from "node:path";
 
 const repo = resolve(import.meta.dirname, "../..");
 const toolDir = import.meta.dirname;

--- a/scripts/jsc-exception-lint/rust-externs.ts
+++ b/scripts/jsc-exception-lint/rust-externs.ts
@@ -60,7 +60,8 @@ const rsFiles: string[] = [];
 
 type Decl = { name: string; file: string; line: number; arity: number; hasGlobal: boolean; ret: string };
 const decls = new Map<string, Decl>();
-const declRe = /^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+|safe\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^;{]*?)\)\s*(?:->\s*([^;{]+?))?\s*;/gm;
+const declRe =
+  /^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+|safe\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^;{]*?)\)\s*(?:->\s*([^;{]+?))?\s*;/gm;
 const sources = new Map<string, string>();
 for (const f of rsFiles) {
   const text = readFileSync(f, "utf8");
@@ -86,12 +87,20 @@ for (const f of rsFiles) {
       const [, name, params, ret] = d;
       const arity = params.trim() ? params.split(",").filter(p => p.trim()).length : 0;
       const line = text.slice(0, m.index + d.index).split("\n").length;
-      decls.set(name, { name, file: f, line, arity, hasGlobal: /JSGlobalObject/.test(params), ret: (ret ?? "()").trim() });
+      decls.set(name, {
+        name,
+        file: f,
+        line,
+        arity,
+        hasGlobal: /JSGlobalObject/.test(params),
+        ret: (ret ?? "()").trim(),
+      });
     }
   }
 }
 
-const wrappers = /call_zero_is_throw|call_check_slow|from_js_host_call|call_false_is_throw|call_null_is_throw|top_scope!|validation_scope!|host_fn_result|return_if_exception|assert_exception_presence_matches/;
+const wrappers =
+  /call_zero_is_throw|call_check_slow|from_js_host_call|call_false_is_throw|call_null_is_throw|top_scope!|validation_scope!|host_fn_result|return_if_exception|assert_exception_presence_matches/;
 
 let reported = 0;
 for (const d of [...decls.values()].sort((a, b) => a.name.localeCompare(b.name))) {
@@ -108,10 +117,18 @@ for (const d of [...decls.values()].sort((a, b) => a.name.localeCompare(b.name))
       // Skip the declaration itself and re-exports.
       const lineStart = text.lastIndexOf("\n", m.index) + 1;
       const lineText = text.slice(lineStart, text.indexOf("\n", m.index));
-      if (/\bfn\s+\w+\s*\($/.test(text.slice(lineStart, m.index + m[0].length)) || /^\s*(pub\s+)?(unsafe\s+|safe\s+)?fn\b/.test(lineText)) continue;
+      if (
+        /\bfn\s+\w+\s*\($/.test(text.slice(lineStart, m.index + m[0].length)) ||
+        /^\s*(pub\s+)?(unsafe\s+|safe\s+)?fn\b/.test(lineText)
+      )
+        continue;
       if (/^\s*\/\//.test(lineText)) continue;
       const after = text.slice(m.index, m.index + 400);
-      if (wrappers.test(before.slice(-400)) || /return_if_exception|assert_exception_presence_matches|\.exception\(\)/.test(after)) continue;
+      if (
+        wrappers.test(before.slice(-400)) ||
+        /return_if_exception|assert_exception_presence_matches|\.exception\(\)/.test(after)
+      )
+        continue;
       const line = text.slice(0, m.index).split("\n").length;
       unwrapped.push(`${relative(repo, f)}:${line}: ${lineText.trim().slice(0, 140)}`);
     }

--- a/scripts/jsc-exception-lint/rust-externs.ts
+++ b/scripts/jsc-exception-lint/rust-externs.ts
@@ -11,7 +11,7 @@
 // summary pass classified as able to throw, and the call sites that are not
 // wrapped. It is a heuristic: it looks at the text around each call.
 
-import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 
 const repo = resolve(import.meta.dirname, "../..");

--- a/scripts/jsc-exception-lint/rust-externs.ts
+++ b/scripts/jsc-exception-lint/rust-externs.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env bun
+// Cross-check hand-declared Rust externs against the C++ callee summaries.
+//
+//   bun scripts/jsc-exception-lint/rust-externs.ts [--summaries <tsv>]
+//
+// The Rust side calls C++ through `unsafe extern "C"` blocks. A C++ function
+// that takes a JSGlobalObject* and can throw must be called through one of the
+// scope helpers (call_zero_is_throw, call_check_slow, from_js_host_call, ...)
+// or inside a top_scope!/validation_scope! so that the Rust side observes the
+// exception. This script lists extern declarations whose C++ definition the
+// summary pass classified as able to throw, and the call sites that are not
+// wrapped. It is a heuristic: it looks at the text around each call.
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const repo = resolve(import.meta.dirname, "../..");
+const args = process.argv.slice(2);
+const sIdx = args.indexOf("--summaries");
+const summaryFile = sIdx !== -1 ? args[sIdx + 1] : join(repo, "build/debug/jsc-exception-lint/bun-summaries.tsv");
+if (!existsSync(summaryFile)) {
+  console.error(`missing ${summaryFile}; run scripts/jsc-exception-lint/run.ts first`);
+  process.exit(1);
+}
+
+type Summary = { kind: string; exit: number; why: string };
+const summaries = new Map<string, Summary>();
+for (const line of readFileSync(summaryFile, "utf8").split("\n")) {
+  const [, key, kind, exit, , why] = line.split("\t");
+  if (!key) continue;
+  // Key is `qualified::name/arity`. extern "C" symbols are unqualified, but
+  // may be declared inside a namespace block; index by the last component.
+  const name = key.slice(0, key.lastIndexOf("/"));
+  const short = name.includes("::") ? name.slice(name.lastIndexOf("::") + 2) : name;
+  const prev = summaries.get(short);
+  const s = { kind, exit: Number(exit), why };
+  // Keep the more pessimistic one.
+  if (!prev || rank(s) > rank(prev)) summaries.set(short, s);
+}
+function rank(s: Summary): number {
+  if (s.kind === "maythrow") return 3;
+  if (s.kind === "thrower") return 2;
+  if (s.kind === "transparent" && s.exit & ~1) return 2;
+  return 0;
+}
+function mayThrow(s: Summary): boolean {
+  return rank(s) > 0;
+}
+
+const rsFiles: string[] = [];
+(function walk(d: string) {
+  for (const e of readdirSync(d, { withFileTypes: true })) {
+    const p = join(d, e.name);
+    if (e.isDirectory()) {
+      if (e.name === "target" || e.name === "node_modules") continue;
+      walk(p);
+    } else if (e.name.endsWith(".rs")) rsFiles.push(p);
+  }
+})(join(repo, "src"));
+
+type Decl = { name: string; file: string; line: number; arity: number; hasGlobal: boolean; ret: string };
+const decls = new Map<string, Decl>();
+const declRe = /^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+|safe\s+)?fn\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^;{]*?)\)\s*(?:->\s*([^;{]+?))?\s*;/gm;
+const sources = new Map<string, string>();
+for (const f of rsFiles) {
+  const text = readFileSync(f, "utf8");
+  sources.set(f, text);
+  // Only declarations inside extern blocks.
+  const externRe = /extern\s+"(?:C|sysv64|system)"\s*\{/g;
+  let m: RegExpExecArray | null;
+  while ((m = externRe.exec(text))) {
+    // Find the matching close brace.
+    let depth = 0;
+    let i = m.index + m[0].length - 1;
+    for (; i < text.length; i++) {
+      if (text[i] === "{") depth++;
+      else if (text[i] === "}") {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    const block = text.slice(m.index, i);
+    let d: RegExpExecArray | null;
+    declRe.lastIndex = 0;
+    while ((d = declRe.exec(block))) {
+      const [, name, params, ret] = d;
+      const arity = params.trim() ? params.split(",").filter(p => p.trim()).length : 0;
+      const line = text.slice(0, m.index + d.index).split("\n").length;
+      decls.set(name, { name, file: f, line, arity, hasGlobal: /JSGlobalObject/.test(params), ret: (ret ?? "()").trim() });
+    }
+  }
+}
+
+const wrappers = /call_zero_is_throw|call_check_slow|from_js_host_call|call_false_is_throw|call_null_is_throw|top_scope!|validation_scope!|host_fn_result|return_if_exception|assert_exception_presence_matches/;
+
+let reported = 0;
+for (const d of [...decls.values()].sort((a, b) => a.name.localeCompare(b.name))) {
+  if (!d.hasGlobal) continue;
+  const s = summaries.get(d.name);
+  if (!s) continue; // not a C++ function the summary pass saw (Rust-exported, or unused)
+  if (!mayThrow(s)) continue;
+  const callRe = new RegExp(`\\b${d.name}\\s*\\(`, "g");
+  const unwrapped: string[] = [];
+  for (const [f, text] of sources) {
+    let m: RegExpExecArray | null;
+    while ((m = callRe.exec(text))) {
+      const before = text.slice(Math.max(0, m.index - 600), m.index);
+      // Skip the declaration itself and re-exports.
+      const lineStart = text.lastIndexOf("\n", m.index) + 1;
+      const lineText = text.slice(lineStart, text.indexOf("\n", m.index));
+      if (/\bfn\s+\w+\s*\($/.test(text.slice(lineStart, m.index + m[0].length)) || /^\s*(pub\s+)?(unsafe\s+|safe\s+)?fn\b/.test(lineText)) continue;
+      if (/^\s*\/\//.test(lineText)) continue;
+      const after = text.slice(m.index, m.index + 400);
+      if (wrappers.test(before.slice(-400)) || /return_if_exception|assert_exception_presence_matches|\.exception\(\)/.test(after)) continue;
+      const line = text.slice(0, m.index).split("\n").length;
+      unwrapped.push(`${relative(repo, f)}:${line}: ${lineText.trim().slice(0, 140)}`);
+    }
+  }
+  if (!unwrapped.length) continue;
+  reported++;
+  console.log(`\n${d.name} (${relative(repo, d.file)}:${d.line}) -> ${d.ret}`);
+  console.log(`  C++: ${s.kind}${s.kind === "transparent" ? ` exit=${s.exit}` : ""} (${s.why})`);
+  for (const u of unwrapped) console.log(`  unwrapped: ${u}`);
+}
+console.error(`\n${reported} externs with unwrapped call sites`);

--- a/src/http_jsc/headers_jsc.rs
+++ b/src/http_jsc/headers_jsc.rs
@@ -123,7 +123,6 @@ pub fn to_fetch_headers(
     global: &JSGlobalObject,
 ) -> JsResult<NonNull<FetchHeaders>> {
     use bun_http_types::ETag::HeaderEntryColumns;
-    use bun_jsc::JsError;
     if this.entries.len() == 0 {
         return Ok(FetchHeaders::create_empty());
     }
@@ -142,7 +141,6 @@ pub fn to_fetch_headers(
         &EncodedSlice::from_bytes(this.buf.as_slice()),
         this.entries.len() as u32,
     )
-    .ok_or(JsError::Thrown)
 }
 
 struct H2TestingAPIs;

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4265,7 +4265,7 @@ pub mod formatter {
                 let _qs = defer_restore!(self.quote_strings, prev_quote_strings);
                 let mut empty_start: Option<u32> = None;
                 'first: {
-                    let element = value.get_direct_index(self.global_this, 0);
+                    let element = value.get_direct_index(self.global_this, 0)?;
 
                     let tag = Tag::get_advanced(element, self.global_this, tag_opts)?;
 
@@ -4305,7 +4305,7 @@ pub mod formatter {
                 let mut nonempty_count: u32 = 1;
 
                 while (i as u64) < len {
-                    let element = value.get_direct_index(self.global_this, i);
+                    let element = value.get_direct_index(self.global_this, i)?;
                     if element.is_empty() {
                         if empty_start.is_none() {
                             empty_start = Some(i);

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -133,30 +133,36 @@ impl FetchHeaders {
         self.put(name_, value, global)
     }
 
+    /// `fill` validates every name/value pair and throws on an invalid one.
     pub fn create(
         global: &JSGlobalObject,
         names: *mut StringPointer,
         values: *mut StringPointer,
         buf: &EncodedSlice,
         count_: u32,
-    ) -> Option<NonNull<FetchHeaders>> {
+    ) -> JsResult<NonNull<FetchHeaders>> {
         // SAFETY: forwarding caller-provided buffers to C++; `global` is an opaque ZST handle
         // passed by address only.
-        let p =
-            unsafe { WebCore__FetchHeaders__createValueNotJS(global, names, values, buf, count_) };
-        NonNull::new(p)
+        crate::call_null_is_throw(global, || unsafe {
+            WebCore__FetchHeaders__createValueNotJS(global, names, values, buf, count_)
+        })
     }
 
+    /// Like [`create`](Self::create) but wrapped as a JS `Headers`. The C++
+    /// side returns the wrapper even after `fill` threw, so the exception state
+    /// is checked explicitly.
     pub fn from(
         global: &JSGlobalObject,
         names: *mut StringPointer,
         values: *mut StringPointer,
         buf: &EncodedSlice,
         count_: u32,
-    ) -> JSValue {
+    ) -> JsResult<JSValue> {
         // SAFETY: forwarding caller-provided buffers to C++; `global` is an opaque ZST handle
         // passed by address only.
-        unsafe { WebCore__FetchHeaders__createValue(global, names, values, buf, count_) }
+        crate::call_check_slow(global, || unsafe {
+            WebCore__FetchHeaders__createValue(global, names, values, buf, count_)
+        })
     }
 
     pub fn is_empty(&mut self) -> bool {

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -1113,28 +1113,38 @@ impl JSGlobalObject {
         crate::from_js_host_call_generic(self, || JSC__JSGlobalObject__handleRejectedPromises(self))
     }
 
-    pub fn readable_stream_to_array_buffer(&self, value: JSValue) -> JSValue {
-        ZigGlobalObject__readableStreamToArrayBuffer(self, value)
+    // The `readableStreamTo*` consumers throw `ERR_INVALID_ARG_TYPE` when
+    // `value` is not a `ReadableStream` and propagate what the consumer throws.
+    pub fn readable_stream_to_array_buffer(&self, value: JSValue) -> JsResult<JSValue> {
+        crate::call_zero_is_throw(self, || {
+            ZigGlobalObject__readableStreamToArrayBuffer(self, value)
+        })
     }
 
-    pub fn readable_stream_to_bytes(&self, value: JSValue) -> JSValue {
-        ZigGlobalObject__readableStreamToBytes(self, value)
+    pub fn readable_stream_to_bytes(&self, value: JSValue) -> JsResult<JSValue> {
+        crate::call_zero_is_throw(self, || ZigGlobalObject__readableStreamToBytes(self, value))
     }
 
-    pub fn readable_stream_to_text(&self, value: JSValue) -> JSValue {
-        ZigGlobalObject__readableStreamToText(self, value)
+    pub fn readable_stream_to_text(&self, value: JSValue) -> JsResult<JSValue> {
+        crate::call_zero_is_throw(self, || ZigGlobalObject__readableStreamToText(self, value))
     }
 
-    pub fn readable_stream_to_json(&self, value: JSValue) -> JSValue {
-        ZigGlobalObject__readableStreamToJSON(self, value)
+    pub fn readable_stream_to_json(&self, value: JSValue) -> JsResult<JSValue> {
+        crate::call_zero_is_throw(self, || ZigGlobalObject__readableStreamToJSON(self, value))
     }
 
-    pub fn readable_stream_to_blob(&self, value: JSValue) -> JSValue {
-        ZigGlobalObject__readableStreamToBlob(self, value)
+    pub fn readable_stream_to_blob(&self, value: JSValue) -> JsResult<JSValue> {
+        crate::call_zero_is_throw(self, || ZigGlobalObject__readableStreamToBlob(self, value))
     }
 
-    pub fn readable_stream_to_form_data(&self, value: JSValue, content_type: JSValue) -> JSValue {
-        ZigGlobalObject__readableStreamToFormData(self, value, content_type)
+    pub fn readable_stream_to_form_data(
+        &self,
+        value: JSValue,
+        content_type: JSValue,
+    ) -> JsResult<JSValue> {
+        crate::call_zero_is_throw(self, || {
+            ZigGlobalObject__readableStreamToFormData(self, value, content_type)
+        })
     }
 
     /// Returns a freshly-created `napi_env` owned by this global, for use by

--- a/src/jsc/JSObject.rs
+++ b/src/jsc/JSObject.rs
@@ -152,19 +152,23 @@ impl JSObject {
         unsafe { JSC__createStructure(global.as_ptr(), owner_cell, length, names) }
     }
 
+    /// The C++ side returns the object even when `creator` threw inside
+    /// `initializer_call`, so the exception state is checked explicitly.
     pub fn create_with_initializer<Ctx: ObjectInitializer>(
         creator: &mut Ctx,
         global: &JSGlobalObject,
         length: usize,
-    ) -> JSValue {
+    ) -> JsResult<JSValue> {
         // `ctx` is the `&mut Ctx` round-tripped through `*mut c_void`;
         // `initializer_call::<Ctx>` casts it back. C++ only forwards it.
-        JSC__JSObject__create(
-            global,
-            length,
-            std::ptr::from_mut::<Ctx>(creator).cast::<c_void>(),
-            initializer_call::<Ctx>,
-        )
+        crate::call_check_slow(global, || {
+            JSC__JSObject__create(
+                global,
+                length,
+                std::ptr::from_mut::<Ctx>(creator).cast::<c_void>(),
+                initializer_call::<Ctx>,
+            )
+        })
     }
 
     #[track_caller]

--- a/src/jsc/JSUint8Array.rs
+++ b/src/jsc/JSUint8Array.rs
@@ -1,6 +1,6 @@
 use core::ffi::c_void;
 
-use crate::{JSGlobalObject, JSValue};
+use crate::{JSGlobalObject, JSValue, JsResult};
 
 bun_opaque::opaque_ffi! {
     /// Opaque FFI handle for a JSC `JSUint8Array` cell.
@@ -9,31 +9,36 @@ bun_opaque::opaque_ffi! {
 
 impl JSUint8Array {
     /// `bytes` must come from `bun.default_allocator` (the global mimalloc allocator);
-    /// ownership is transferred to the returned JS Uint8Array.
+    /// ownership is transferred to the returned JS Uint8Array (and is released by the
+    /// C++ side if the allocation throws).
     // The global allocator IS mimalloc, so `Box<[u8]>` encodes that ownership.
-    pub fn from_bytes(global: &JSGlobalObject, bytes: Box<[u8]>) -> JSValue {
+    pub fn from_bytes(global: &JSGlobalObject, bytes: Box<[u8]>) -> JsResult<JSValue> {
         let len = bytes.len();
         let ptr = bun_core::heap::into_raw(bytes).cast::<u8>();
         // SAFETY: `ptr`/`len` describe a heap allocation from the global (mimalloc)
         // allocator; the C++ side adopts and later frees it with the same allocator.
-        unsafe { JSUint8Array__fromDefaultAllocator(global, ptr, len) }
+        crate::call_zero_is_throw(global, || unsafe {
+            JSUint8Array__fromDefaultAllocator(global, ptr, len)
+        })
     }
 
-    pub fn from_bytes_copy(global: &JSGlobalObject, bytes: &[u8]) -> JSValue {
+    pub fn from_bytes_copy(global: &JSGlobalObject, bytes: &[u8]) -> JsResult<JSValue> {
         // SAFETY: C++ copies `len` bytes out of `ptr`; it does not retain the pointer.
-        unsafe {
+        crate::call_zero_is_throw(global, || unsafe {
             Bun__createUint8ArrayForCopy(
                 global,
                 bytes.as_ptr().cast::<c_void>(),
                 bytes.len(),
                 false,
             )
-        }
+        })
     }
 
-    pub fn create_empty(global: &JSGlobalObject) -> JSValue {
+    pub fn create_empty(global: &JSGlobalObject) -> JsResult<JSValue> {
         // SAFETY: null/0 is the documented "empty" input for this FFI entrypoint.
-        unsafe { Bun__createUint8ArrayForCopy(global, core::ptr::null(), 0, false) }
+        crate::call_zero_is_throw(global, || unsafe {
+            Bun__createUint8ArrayForCopy(global, core::ptr::null(), 0, false)
+        })
     }
 }
 

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -695,11 +695,11 @@ impl JSValue {
         keys: &mut [bun_core::EncodedSlice],
         values: &mut [bun_core::EncodedSlice],
         clone: bool,
-    ) -> JSValue {
+    ) -> JsResult<JSValue> {
         debug_assert_eq!(keys.len(), values.len());
         // SAFETY: `global` is live; `keys`/`values` are valid for `keys.len()`
         // elements; the C++ binding only reads (and optionally clones) them.
-        unsafe {
+        crate::call_zero_is_throw(global, || unsafe {
             JSC__JSValue__fromEntries(
                 global,
                 keys.as_mut_ptr(),
@@ -707,7 +707,7 @@ impl JSValue {
                 keys.len(),
                 clone,
             )
-        }
+        })
     }
 }
 
@@ -1350,13 +1350,18 @@ impl JSValue {
         }
         Ok(Some(prop))
     }
+    /// Own property lookup by key value (index or `toPropertyKey`). `None` when
+    /// absent; the C++ side also returns empty when a getter or `toPropertyKey`
+    /// throws, so the exception state is what tells the two apart.
     pub fn get_own_by_value(
         self,
         global: &JSGlobalObject,
         property_value: JSValue,
-    ) -> Option<JSValue> {
-        let v = JSC__JSValue__getOwnByValue(self, global, property_value);
-        if v.is_empty() { None } else { Some(v) }
+    ) -> JsResult<Option<JSValue>> {
+        let v = crate::call_check_slow(global, || {
+            JSC__JSValue__getOwnByValue(self, global, property_value)
+        })?;
+        Ok(if v.is_empty() { None } else { Some(v) })
     }
     /// `Object.hasOwnProperty(key)`. `self` **must** be an object — the C++ side
     /// `uncheckedDowncast`s. `key.toPropertyKey()` and Proxy `ownKeys` traps
@@ -1467,10 +1472,12 @@ impl JSValue {
         }
         Ok(())
     }
-    /// `JSValue.deleteProperty` — delete an own property by name.
-    pub fn delete_property(self, global: &JSGlobalObject, key: impl AsRef<[u8]>) -> bool {
+    /// `JSValue.deleteProperty` — delete an own property by name. `false` is
+    /// both "not deleted" and the C++ side's return on throw (a Proxy
+    /// `deleteProperty` trap), so the exception state is checked explicitly.
+    pub fn delete_property(self, global: &JSGlobalObject, key: impl AsRef<[u8]>) -> JsResult<bool> {
         let key = bun_core::EncodedSlice::latin1(key.as_ref());
-        JSC__JSValue__deleteProperty(self, global, &key)
+        crate::call_check_slow(global, || JSC__JSValue__deleteProperty(self, global, &key))
     }
     /// `JSValue.putMayBeIndex` — same as [`put`] but accepts
     /// both non-numeric and numeric keys. Prefer [`put`] when the key is
@@ -2295,12 +2302,7 @@ impl JSValue {
     }
     /// `JSValue.toObject` — ECMA `ToObject`; throws on null/undefined.
     pub fn to_object(self, global: &JSGlobalObject) -> JsResult<*mut JSObject> {
-        let p = JSC__JSValue__toObject(self, global);
-        if p.is_null() {
-            Err(JsError::Thrown)
-        } else {
-            Ok(p)
-        }
+        Ok(crate::call_null_is_throw(global, || JSC__JSValue__toObject(self, global))?.as_ptr())
     }
     /// `JSValue.unwrapBoxedPrimitive` — unwraps Number,
     /// Boolean, String, and BigInt objects to their primitive forms.
@@ -2526,10 +2528,11 @@ impl JSValue {
         }
         JSBuffer__isBuffer(global, self)
     }
-    /// `JSValue.getDirectIndex` — read the `i`th indexed
-    /// own-property slot directly (no prototype walk, no getters). Returns
-    /// the empty value for holes.
-    pub fn get_direct_index(self, global: &JSGlobalObject, i: u32) -> JSValue {
+    /// `JSValue.getDirectIndex` — read the `i`th indexed own-property slot
+    /// (no prototype walk). Returns the empty value for holes; an own
+    /// accessor or a Proxy trap runs (and may throw), so empty is not a
+    /// throw sentinel here.
+    pub fn get_direct_index(self, global: &JSGlobalObject, i: u32) -> JsResult<JSValue> {
         unsafe extern "C" {
             safe fn JSC__JSValue__getDirectIndex(
                 this: JSValue,
@@ -2537,7 +2540,7 @@ impl JSValue {
                 i: u32,
             ) -> JSValue;
         }
-        JSC__JSValue__getDirectIndex(self, global, i)
+        crate::call_check_slow(global, || JSC__JSValue__getDirectIndex(self, global, i))
     }
     /// Smallest own present index of a `JSArray` that is `>= start`, or
     /// `None` when every index from `start` to the end of the array is a

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2851,7 +2851,12 @@ impl VirtualMachine {
                     if let Some(stored) = self.pending_internal_promise {
                         return Ok(stored);
                     }
-                    let resolved = JSC__JSInternalPromise__resolvedPromise(global_ref, ret);
+                    // `Promise.resolve(ret)` reads `ret.constructor` / `ret.then`,
+                    // which may throw.
+                    let resolved = jsc::call_check_slow(global_ref, || {
+                        JSC__JSInternalPromise__resolvedPromise(global_ref, ret)
+                    })
+                    .map_err(|_| crate::CrateError::JSError)?;
                     self.pending_internal_promise = Some(resolved);
                     self.pending_internal_promise_is_protected = false;
                     return Ok(resolved);

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -225,6 +225,10 @@ impl ArrayBuffer {
         Ok(buffer_value)
     }
 
+    /// `Ok(JSValue::ZERO)` means the C++ side declined (length above the
+    /// ArrayBuffer limit, `mmap` failed, or Windows) and the caller falls back
+    /// to copying; the typed-array allocation can also throw, so empty alone
+    /// does not mean "declined".
     #[inline]
     pub fn to_array_buffer_from_shared_memfd(
         fd: i64,
@@ -233,8 +237,10 @@ impl ArrayBuffer {
         byte_length: usize,
         total_size: usize,
         ty: JSType,
-    ) -> JSValue {
-        ArrayBuffer__fromSharedMemfd(fd, global, byte_offset, byte_length, total_size, ty)
+    ) -> JsResult<JSValue> {
+        crate::call_check_slow(global, || {
+            ArrayBuffer__fromSharedMemfd(fd, global, byte_offset, byte_length, total_size, ty)
+        })
     }
 
     pub fn to_js_buffer_from_memfd(fd: Fd, global: &JSGlobalObject) -> JsResult<JSValue> {
@@ -362,13 +368,13 @@ impl ArrayBuffer {
         global: &JSGlobalObject,
         typed_array_type: JSType,
         bytes: &mut [u8],
-    ) -> JSValue {
+    ) -> JsResult<JSValue> {
         match typed_array_type {
             // SAFETY: FFI — `global` is a live opaque ZST handle (coerces to *const); `bytes` is
             // a mimalloc-backed buffer whose ownership transfers to JSC.
-            JSType::ArrayBuffer => unsafe {
+            JSType::ArrayBuffer => Ok(unsafe {
                 JSArrayBuffer__fromDefaultAllocator(global, bytes.as_mut_ptr(), bytes.len())
-            },
+            }),
             // `JSUint8Array::from_bytes` takes `Box<[u8]>`; reconstruct
             // ownership from the mimalloc-backed slice the caller hands us.
             JSType::Uint8Array => {

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -684,14 +684,17 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionCreateConnection, (JSGlobalObject * globalObj
     if (!debuggerGlobalObject)
         return JSValue::encode(jsUndefined());
 
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     ScriptExecutionContext* targetContext = ScriptExecutionContext::getScriptExecutionContext(static_cast<ScriptExecutionContextIdentifier>(callFrame->argument(0).toUInt32(globalObject)));
+    RETURN_IF_EXCEPTION(scope, {});
     bool shouldRef = !callFrame->argument(1).toBoolean(globalObject);
     JSFunction* onMessageFn = uncheckedDowncast<JSFunction>(callFrame->argument(2).toObject(globalObject));
+    RETURN_IF_EXCEPTION(scope, {});
 
     if (!targetContext || !onMessageFn)
         return JSValue::encode(jsUndefined());
 
-    auto& vm = JSC::getVM(globalObject);
     auto connection = BunInspectorConnection::create(
         *targetContext,
         targetContext->jsGlobalObject(), shouldRef);
@@ -805,6 +808,7 @@ static bool postNodeInspectorControlMessage(const String& message)
         if (auto* exception = scope.exception()) [[unlikely]] {
             (void)scope.tryClearException();
             Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+            RETURN_IF_EXCEPTION(scope, );
         }
     });
 
@@ -966,6 +970,7 @@ extern "C" void Bun__startJSDebuggerThread(Zig::GlobalObject* debuggerGlobalObje
 
     arguments.append(jsNumber(static_cast<unsigned int>(scriptId)));
     auto* portOrPathJS = Bun::toJS(debuggerGlobalObject, *portOrPathString);
+    RETURN_IF_EXCEPTION(scope, );
     if (!portOrPathJS) [[unlikely]] {
         return;
     }

--- a/src/jsc/bindings/BunInjectedScriptHost.cpp
+++ b/src/jsc/bindings/BunInjectedScriptHost.cpp
@@ -82,6 +82,7 @@ static JSObject* objectForEventTargetListeners(VM& vm, JSGlobalObject* exec, Eve
             Bun::putDirectNamed(vm, propertiesForListener, "passive"_s, jsBoolean(eventListener->isPassive()));
             Bun::putDirectNamed(vm, propertiesForListener, "once"_s, jsBoolean(eventListener->isOnce()));
             listenersForEvent->putDirectIndex(exec, listenersForEventIndex++, propertiesForListener);
+            RETURN_IF_EXCEPTION(scope, {});
         }
 
         if (listenersForEventIndex) {
@@ -129,12 +130,17 @@ JSValue BunInjectedScriptHost::getInternalProperties(VM& vm, JSGlobalObject* exe
         RETURN_IF_EXCEPTION(scope, {});
 
         String name = worker->name();
-        if (!name.isEmpty())
+        if (!name.isEmpty()) {
             array->putDirectIndex(exec, index++, constructInternalProperty(vm, exec, "name"_s, jsString(vm, WTF::move(name))));
+            RETURN_IF_EXCEPTION(scope, {});
+        }
 
         array->putDirectIndex(exec, index++, constructInternalProperty(vm, exec, "terminated"_s, jsBoolean(worker->wasTerminated())));
+        RETURN_IF_EXCEPTION(scope, {});
 
-        if (auto* listeners = objectForEventTargetListeners(vm, exec, worker))
+        auto* listeners = objectForEventTargetListeners(vm, exec, worker);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (listeners)
             array->putDirectIndex(exec, index++, constructInternalProperty(vm, exec, "listeners"_s, listeners));
 
         RETURN_IF_EXCEPTION(scope, {});
@@ -149,7 +155,9 @@ JSValue BunInjectedScriptHost::getInternalProperties(VM& vm, JSGlobalObject* exe
             if (auto* headers = dynamicDowncast<JSFetchHeaders>(value)) {
                 auto* array = constructEmptyArray(exec, nullptr);
                 RETURN_IF_EXCEPTION(scope, {});
-                constructDataProperties(vm, exec, array, WebCore::getInternalProperties(vm, exec, headers));
+                JSValue internalProperties = WebCore::getInternalProperties(vm, exec, headers);
+                RETURN_IF_EXCEPTION(scope, {});
+                constructDataProperties(vm, exec, array, internalProperties);
                 RETURN_IF_EXCEPTION(scope, {});
                 return array;
             }
@@ -157,7 +165,9 @@ JSValue BunInjectedScriptHost::getInternalProperties(VM& vm, JSGlobalObject* exe
             if (auto* formData = dynamicDowncast<JSDOMFormData>(value)) {
                 auto* array = constructEmptyArray(exec, nullptr);
                 RETURN_IF_EXCEPTION(scope, {});
-                constructDataProperties(vm, exec, array, WebCore::getInternalProperties(vm, exec, formData));
+                JSValue internalProperties = WebCore::getInternalProperties(vm, exec, formData);
+                RETURN_IF_EXCEPTION(scope, {});
+                constructDataProperties(vm, exec, array, internalProperties);
                 RETURN_IF_EXCEPTION(scope, {});
                 return array;
             }
@@ -166,7 +176,9 @@ JSValue BunInjectedScriptHost::getInternalProperties(VM& vm, JSGlobalObject* exe
             if (auto* params = dynamicDowncast<JSURLSearchParams>(value)) {
                 auto* array = constructEmptyArray(exec, nullptr);
                 RETURN_IF_EXCEPTION(scope, {});
-                constructDataProperties(vm, exec, array, WebCore::getInternalProperties(vm, exec, params));
+                JSValue internalProperties = WebCore::getInternalProperties(vm, exec, params);
+                RETURN_IF_EXCEPTION(scope, {});
+                constructDataProperties(vm, exec, array, internalProperties);
                 RETURN_IF_EXCEPTION(scope, {});
                 return array;
             }
@@ -174,7 +186,9 @@ JSValue BunInjectedScriptHost::getInternalProperties(VM& vm, JSGlobalObject* exe
             if (auto* cookie = dynamicDowncast<JSCookie>(value)) {
                 auto* array = constructEmptyArray(exec, nullptr);
                 RETURN_IF_EXCEPTION(scope, {});
-                constructDataProperties(vm, exec, array, WebCore::getInternalProperties(vm, exec, cookie));
+                JSValue internalProperties = WebCore::getInternalProperties(vm, exec, cookie);
+                RETURN_IF_EXCEPTION(scope, {});
+                constructDataProperties(vm, exec, array, internalProperties);
                 RETURN_IF_EXCEPTION(scope, {});
                 return array;
             }
@@ -182,7 +196,9 @@ JSValue BunInjectedScriptHost::getInternalProperties(VM& vm, JSGlobalObject* exe
             if (auto* cookieMap = dynamicDowncast<JSCookieMap>(value)) {
                 auto* array = constructEmptyArray(exec, nullptr);
                 RETURN_IF_EXCEPTION(scope, {});
-                constructDataProperties(vm, exec, array, WebCore::getInternalProperties(vm, exec, cookieMap));
+                JSValue internalProperties = WebCore::getInternalProperties(vm, exec, cookieMap);
+                RETURN_IF_EXCEPTION(scope, {});
+                constructDataProperties(vm, exec, array, internalProperties);
                 RETURN_IF_EXCEPTION(scope, {});
                 return array;
             }
@@ -194,7 +210,9 @@ JSValue BunInjectedScriptHost::getInternalProperties(VM& vm, JSGlobalObject* exe
         auto* array = constructEmptyArray(exec, nullptr);
         RETURN_IF_EXCEPTION(scope, {});
 
-        if (auto* listeners = objectForEventTargetListeners(vm, exec, eventTarget)) {
+        auto* listeners = objectForEventTargetListeners(vm, exec, eventTarget);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (listeners) {
             array->putDirectIndex(exec, index++, constructInternalProperty(vm, exec, "listeners"_s, listeners));
             RETURN_IF_EXCEPTION(scope, {});
         }

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -259,13 +259,13 @@ JSC_DEFINE_HOST_FUNCTION(functionConcatTypedArrays, (JSGlobalObject * globalObje
     size_t maxLength = std::numeric_limits<size_t>::max();
     auto arg1 = callFrame->argument(1);
     if (!arg1.isUndefined() && arg1.isNumber()) {
-        double number = arg1.toNumber(globalObject);
+        double number = arg1.asNumber();
         if (std::isnan(number) || number < 0) {
             throwRangeError(globalObject, throwScope, "Maximum length must be >= 0"_s);
             return {};
         }
         if (!std::isinf(number)) {
-            maxLength = arg1.toUInt32(globalObject);
+            maxLength = JSC::toUInt32(number);
         }
     }
 
@@ -680,8 +680,7 @@ JSC_DEFINE_HOST_FUNCTION(functionBunDeepEquals, (JSGlobalObject * globalObject, 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (callFrame->argumentCount() < 2) {
-        auto throwScope = DECLARE_THROW_SCOPE(vm);
-        throwTypeError(globalObject, throwScope, "Expected 2 values to compare"_s);
+        throwTypeError(globalObject, scope, "Expected 2 values to compare"_s);
         return {};
     }
 
@@ -815,6 +814,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshot, (JSC::JSGlobalObject * gl
         if (useArrayBuffer) {
             JSC::BunV8HeapSnapshotBuilder builder(heapProfiler);
             auto bytes = builder.jsonBytes();
+            RETURN_IF_EXCEPTION(throwScope, {});
             auto released = bytes.releaseBuffer();
             auto span = released.leakSpan();
             auto buffer = ArrayBuffer::createFromBytes(std::span<const uint8_t> { span.data(), span.size() }, createSharedTask<void(void*)>([](void* p) {
@@ -824,12 +824,15 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshot, (JSC::JSGlobalObject * gl
         }
 
         JSC::BunV8HeapSnapshotBuilder builder(heapProfiler);
-        return JSC::JSValue::encode(jsString(vm, builder.json()));
+        auto json = builder.json();
+        RETURN_IF_EXCEPTION(throwScope, {});
+        return JSC::JSValue::encode(jsString(vm, json));
     }
 
     JSC::HeapSnapshotBuilder builder(heapProfiler);
     builder.buildSnapshot();
     auto json = builder.json();
+    RETURN_IF_EXCEPTION(throwScope, {});
     // Returning an object was a bad idea but it's a breaking change
     // so we'll just keep it for now.
     JSC::JSValue jsonValue = JSONParseWithException(globalObject, json);

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -96,6 +96,7 @@ static JSC::EncodedJSValue jsFunctionAppendOnLoadPluginBody(JSC::JSGlobalObject*
 
     plugin.append(vm, filter->regExp(), func.getObject(), namespaceString);
     callback(ctx, globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(callframe->thisValue());
 }
@@ -216,6 +217,7 @@ static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginBody(JSC::JSGlobalObje
 
     plugin.append(vm, filter->regExp(), uncheckedDowncast<JSObject>(func), namespaceString);
     callback(ctx, globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
 
     return JSValue::encode(callframe->thisValue());
 }
@@ -379,9 +381,13 @@ void BunPlugin::Base::append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSObject* fu
 
 JSC::JSObject* BunPlugin::Group::find(JSC::JSGlobalObject* globalObject, String& path)
 {
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     size_t count = filters.size();
     for (size_t i = 0; i < count; i++) {
-        if (filters[i].get()->match(globalObject, path, 0)) {
+        auto matchResult = filters[i].get()->match(globalObject, path, 0);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        if (matchResult) {
             return callbacks[i].get();
         }
     }
@@ -556,7 +562,7 @@ extern "C" JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(JSMock__jsModuleMock, __attr
             RETURN_IF_EXCEPTION(scope, );
 
             if (result.isString()) {
-                auto* specifierStr = result.toString(globalObject);
+                auto* specifierStr = asString(result);
                 if (specifierStr->length() > 0) {
                     specifierString = specifierStr;
                     specifier = specifierString->value(globalObject);
@@ -731,14 +737,15 @@ EncodedJSValue BunPlugin::OnLoad::run(JSC::JSGlobalObject* globalObject, const B
 
     auto pathString = path->toWTFString(BunString::ZeroCopy);
 
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* function = group.find(globalObject, pathString);
+    RETURN_IF_EXCEPTION(scope, {});
     if (!function) {
         return JSValue::encode(JSC::jsUndefined());
     }
 
     JSC::MarkedArgumentBuffer arguments;
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
     scope.assertNoExceptionExceptTermination();
 
     JSC::JSObject* paramsObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 1);
@@ -816,7 +823,9 @@ EncodedJSValue BunPlugin::OnResolve::run(JSC::JSGlobalObject* globalObject, cons
         return {};
     }
     for (size_t i = 0; i < filters.size(); i++) {
-        if (!filters[i].get()->match(globalObject, pathString, 0)) {
+        auto matchResult = filters[i].get()->match(globalObject, pathString, 0);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!matchResult) {
             continue;
         }
         auto* function = callbacks[i].get();

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -746,7 +746,6 @@ EncodedJSValue BunPlugin::OnLoad::run(JSC::JSGlobalObject* globalObject, const B
     }
 
     JSC::MarkedArgumentBuffer arguments;
-    scope.assertNoExceptionExceptTermination();
 
     JSC::JSObject* paramsObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 1);
     const auto& builtinNames = WebCore::builtinNames(vm);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1329,8 +1329,6 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
         auto monitorScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         wrapped.emit(uncaughtExceptionMonitor, args);
         RETURN_IF_EXCEPTION(monitorScope, true);
-        if (vm.hasPendingTerminationException()) [[unlikely]]
-            return true;
     }
 
     auto uncaughtExceptionIdent = Identifier::fromString(JSC::getVM(globalObject), "uncaughtException"_s);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -797,6 +797,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionUmask, (JSGlobalObject * globalObject, 
     mode_t newUmask;
     if (value.isString()) {
         auto str = value.getString(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
         auto policy = WTF::TrailingJunkPolicy::Disallow;
         auto opt = str.is8Bit() ? WTF::parseInteger<mode_t, uint8_t>(str.span8(), 8, policy) : WTF::parseInteger<mode_t, char16_t>(str.span16(), 8, policy);
         if (!opt.has_value()) return Bun::ERR::INVALID_ARG_VALUE(throwScope, globalObject, "mask"_s, value, "must be a 32-bit unsigned integer or an octal string"_s);
@@ -804,7 +805,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionUmask, (JSGlobalObject * globalObject, 
     } else {
         Bun::V::validateUint32(throwScope, globalObject, value, "mask"_s, jsUndefined());
         RETURN_IF_EXCEPTION(throwScope, {});
-        newUmask = value.toUInt32(globalObject);
+        newUmask = JSC::toUInt32(value.asNumber());
     }
 
     return JSC::JSValue::encode(JSC::jsNumber(umask(newUmask)));
@@ -821,15 +822,18 @@ extern "C" void Process__dispatchOnBeforeExit(Zig::GlobalObject* globalObject, u
         return;
     }
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* process = globalObject->processObject();
     MarkedArgumentBuffer arguments;
     arguments.append(jsNumber(exitCode));
     Bun__VirtualMachine__exitDuringUncaughtException(bunVM(vm));
     auto fired = process->wrapped().emit(Identifier::fromString(vm, "beforeExit"_s), arguments);
+    RETURN_IF_EXCEPTION(scope, );
     if (fired) {
         if (globalObject->m_nextTickQueue) {
             auto nextTickQueue = globalObject->m_nextTickQueue.get();
             nextTickQueue->drain(vm, globalObject);
+            RETURN_IF_EXCEPTION(scope, );
         }
     }
 }
@@ -988,7 +992,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionChdir, (JSC::JSGlobalObject * globalObj
     Bun::V::validateString(scope, globalObject, value, "directory"_s);
     RETURN_IF_EXCEPTION(scope, {});
 
-    EncodedSlice str = Zig::toEncodedSlice(value.toWTFString(globalObject));
+    WTF::String directory = value.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    EncodedSlice str = Zig::toEncodedSlice(directory);
     JSC::JSValue result = JSC::JSValue::decode(Bun__Process__setCwd(globalObject, &str));
     RETURN_IF_EXCEPTION(scope, {});
 
@@ -1320,7 +1326,9 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
 
     auto uncaughtExceptionMonitor = Identifier::fromString(JSC::getVM(globalObject), "uncaughtExceptionMonitor"_s);
     if (wrapped.listenerCount(uncaughtExceptionMonitor) > 0) {
+        auto monitorScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         wrapped.emit(uncaughtExceptionMonitor, args);
+        RETURN_IF_EXCEPTION(monitorScope, true);
         if (vm.hasPendingTerminationException()) [[unlikely]]
             return true;
     }
@@ -1341,7 +1349,9 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
             Bun__Process__exit(lexicalGlobalObject, 1);
         }
     } else if (wrapped.listenerCount(uncaughtExceptionIdent) > 0) {
+        auto emitScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         wrapped.emit(uncaughtExceptionIdent, args);
+        RETURN_IF_EXCEPTION(emitScope, true);
     } else {
         return false;
     }
@@ -1483,6 +1493,7 @@ extern "C" bool Bun__emitHandledPromiseEvent(JSC::JSGlobalObject* lexicalGlobalO
         MarkedArgumentBuffer args;
         args.append(promise);
         wrapped.emit(eventType, args);
+        RETURN_IF_EXCEPTION(scope, true);
         return true;
     }
 
@@ -1772,6 +1783,7 @@ static JSValue callLazyProcessBuilder(VM& vm, JSC::JSGlobalObject* globalObject,
     if (auto* exception = scope.exception()) [[unlikely]] {
         (void)scope.tryClearException();
         Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        RETURN_IF_EXCEPTION(scope, jsUndefined());
         return jsUndefined();
     }
     return result;
@@ -2098,11 +2110,15 @@ static bool isJSValueEqualToASCIILiteral(JSC::JSGlobalObject* globalObject, JSC:
         return false;
     }
 
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* str = value.toStringOrNull(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
     if (!str) {
         return false;
     }
     auto view = str->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
     return view == literal;
 }
 
@@ -2126,7 +2142,9 @@ JSValue Process::emitWarningErrorInstance(JSC::JSGlobalObject* lexicalGlobalObje
 
     auto warningName = errorInstance.get(lexicalGlobalObject, vm.propertyNames->name);
     RETURN_IF_EXCEPTION(scope, {});
-    if (isJSValueEqualToASCIILiteral(globalObject, warningName, "DeprecationWarning"_s)) {
+    bool isDeprecationWarning = isJSValueEqualToASCIILiteral(globalObject, warningName, "DeprecationWarning"_s);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (isDeprecationWarning) {
         // Read the per-Process data properties (per-Worker), not the CLI seed:
         // a Worker's `process.throwDeprecation = true` must not affect other VMs.
         JSValue noDep = process->getIfPropertyExists(globalObject, Identifier::fromString(vm, "noDeprecation"_s));
@@ -2160,7 +2178,9 @@ __attribute__((minsize)) JSValue Process::emitWarning(JSC::JSGlobalObject* lexic
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue detail = jsUndefined();
 
-    if (isJSValueEqualToASCIILiteral(globalObject, type, "DeprecationWarning"_s)) {
+    bool isDeprecationWarning = isJSValueEqualToASCIILiteral(globalObject, type, "DeprecationWarning"_s);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (isDeprecationWarning) {
         JSValue noDep = globalObject->processObject()->getIfPropertyExists(globalObject, Identifier::fromString(vm, "noDeprecation"_s));
         RETURN_IF_EXCEPTION(scope, {});
         if (noDep && noDep.toBoolean(globalObject))
@@ -2206,6 +2226,7 @@ __attribute__((minsize)) JSValue Process::emitWarning(JSC::JSGlobalObject* lexic
 
     if (warning.isString()) {
         auto s = warning.getString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
         errorInstance = createError(globalObject, !s.isEmpty() ? s : "Warning"_s);
         errorInstance->putDirect(vm, vm.propertyNames->name, type, JSC::PropertyAttribute::DontEnum | 0);
     } else if (warning.isCell() && warning.asCell()->type() == ErrorInstanceType) {
@@ -2248,11 +2269,15 @@ bool setProcessExitCodeInner(JSC::JSGlobalObject* lexicalGlobalObject, Process* 
     auto throwScope = DECLARE_THROW_SCOPE(process->vm());
 
     if (!code.isUndefinedOrNull()) {
-        if (code.isString() && !code.getString(lexicalGlobalObject).isEmpty()) {
-            auto num = code.toNumber(lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(throwScope, {});
-            if (!std::isnan(num)) {
-                code = jsNumber(num);
+        if (code.isString()) {
+            auto codeString = code.getString(lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(throwScope, false);
+            if (!codeString.isEmpty()) {
+                auto num = code.toNumber(lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                if (!std::isnan(num)) {
+                    code = jsNumber(num);
+                }
             }
         }
         ssize_t exitCodeInt;
@@ -2555,6 +2580,7 @@ __attribute__((minsize)) static JSValue constructReportObjectComplete(VM& vm, Zi
                 vm, globalObject, globalObject, name, message,
                 line, column,
                 sourceURL, stackFrames, nullptr);
+            RETURN_IF_EXCEPTION(scope, {});
 
             WTF::String stack;
             // first line after "Error:"
@@ -2768,6 +2794,7 @@ __attribute__((minsize)) static JSValue constructProcessConfigObject(VM& vm, JSO
     if (auto* exception = scope.exception()) [[unlikely]] {
         (void)scope.tryClearException();
         Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        RETURN_IF_EXCEPTION(scope, JSC::jsUndefined());
         return JSC::jsUndefined();
     }
     putDirectNamed(vm, variables, "v8_enable_i18n_support"_s, JSC::jsNumber(1));
@@ -2906,6 +2933,7 @@ static JSValue constructNodeWorkerStdioStream(JSC::JSGlobalObject* globalObject,
     if (auto* exception = scope.exception()) {
         (void)scope.tryClearException();
         Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        RETURN_IF_EXCEPTION(scope, jsUndefined());
         return jsUndefined();
     }
     return result;
@@ -2932,6 +2960,7 @@ static JSValue constructStdioWriteStream(JSC::JSGlobalObject* globalObject, JSC:
     if (auto* exception = scope.exception()) {
         (void)scope.tryClearException();
         Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        RETURN_IF_EXCEPTION(scope, jsUndefined());
         return jsUndefined();
     }
 
@@ -2956,10 +2985,14 @@ static JSValue constructStdioWriteStream(JSC::JSGlobalObject* globalObject, JSC:
     forceSync = true;
 #endif
     if (forceSync) {
-        Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio(globalObject, JSValue::encode(resultObject->getIndex(globalObject, 1)));
+        JSValue sink = resultObject->getIndex(globalObject, 1);
+        RETURN_IF_EXCEPTION(scope, jsUndefined());
+        Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio(globalObject, JSValue::encode(sink));
     }
 
-    return resultObject->getIndex(globalObject, 0);
+    JSValue stream = resultObject->getIndex(globalObject, 0);
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    return stream;
 }
 
 static JSValue constructStdout(VM& vm, JSObject* processObject)
@@ -2995,6 +3028,7 @@ static JSValue constructStdin(VM& vm, JSObject* processObject)
     if (auto* exception = scope.exception()) {
         (void)scope.tryClearException();
         Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        RETURN_IF_EXCEPTION(scope, jsUndefined());
         return jsUndefined();
     }
     return result;
@@ -3236,6 +3270,7 @@ static JSValue constructEnv(VM& vm, JSObject* processObject)
     if (auto* exception = scope.exception()) [[unlikely]] {
         (void)scope.tryClearException();
         Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        RETURN_IF_EXCEPTION(scope, JSC::jsUndefined());
         return JSC::jsUndefined();
     }
     return env;
@@ -3278,6 +3313,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functiongetgroups, (JSGlobalObject * globalObje
     getgroups(ngroups, groupVector.begin());
     for (unsigned i = 0; i < ngroups; i++) {
         groups->putDirectIndex(globalObject, i, jsNumber(groupVector[i]));
+        RETURN_IF_EXCEPTION(throwScope, {});
     }
     return JSValue::encode(groups);
 }
@@ -3434,12 +3470,13 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionsetgroups, (JSGlobalObject * globalObje
         if (item.isNumber()) {
             Bun::V::validateUint32(scope, globalObject, item, jsString(vm, name), jsUndefined());
             RETURN_IF_EXCEPTION(scope, {});
-            groupsStack[i] = item.toUInt32(globalObject);
+            groupsStack[i] = JSC::toUInt32(item.asNumber());
             continue;
         } else if (item.isString()) {
             item = maybe_gid_by_name(scope, globalObject, item);
             RETURN_IF_EXCEPTION(scope, {});
             groupsStack[i] = item.toUInt32(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
             continue;
         }
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "number or string"_s, item);
@@ -4292,6 +4329,7 @@ static JSValue Process_stubEmptyArray(VM& vm, JSObject* processObject)
     if (auto* exception = scope.exception()) [[unlikely]] {
         (void)scope.tryClearException();
         Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(processObject->globalObject(), exception);
+        RETURN_IF_EXCEPTION(scope, {});
         return JSC::jsUndefined();
     }
     return array;
@@ -4430,6 +4468,7 @@ static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
     if (auto* exception = scope.exception()) [[unlikely]] {
         (void)scope.tryClearException();
         Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        RETURN_IF_EXCEPTION(scope, {});
         return JSC::jsUndefined();
     }
     auto* requireMap = globalObject->requireMap();
@@ -4437,6 +4476,7 @@ static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
     if (auto* exception = scope.exception()) [[unlikely]] {
         (void)scope.tryClearException();
         Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        RETURN_IF_EXCEPTION(scope, {});
         return JSC::jsUndefined();
     }
     return mainModule;
@@ -4467,6 +4507,7 @@ JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObjec
     if (auto* exception = scope.exception()) [[unlikely]] {
         (void)scope.tryClearException();
         Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        RETURN_IF_EXCEPTION(scope, {});
         return JSC::jsUndefined();
     }
     if (nextTickFunction && nextTickFunction.isObject()) {
@@ -4723,9 +4764,10 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionKill, (JSC::JSGlobalObject * globalObje
         RETURN_IF_EXCEPTION(scope, {});
     } else if (signalValue.isString()) {
         loadSignalNumberMap();
-        if (auto num = signalNameToNumberMap->get(signalValue.toWTFString(globalObject))) {
+        auto signalName = signalValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (auto num = signalNameToNumberMap->get(signalName)) {
             signal = num;
-            RETURN_IF_EXCEPTION(scope, {});
         } else {
             return Bun::ERR::UNKNOWN_SIGNAL(scope, globalObject, signalValue);
         }

--- a/src/jsc/bindings/BunProcessReportObjectWindows.cpp
+++ b/src/jsc/bindings/BunProcessReportObjectWindows.cpp
@@ -263,6 +263,7 @@ JSValue constructReportObjectWindows(VM& vm, Zig::GlobalObject* globalObject, Pr
             vm, globalObject, globalObject, name, message,
             line, column,
             sourceURL, stackFrames, nullptr);
+        RETURN_IF_EXCEPTION(scope, {});
 
         WTF::String stack;
         size_t firstLine = stackProperty.find('\n');

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -840,7 +840,9 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__upsertBunStringArray(
         } else {
             // Create new array with both values
             JSC::JSArray* array = JSC::constructEmptyArray(global, nullptr, 2);
+            RETURN_IF_EXCEPTION(scope, {});
             array->putDirectIndex(global, 0, existingValue);
+            RETURN_IF_EXCEPTION(scope, {});
             array->putDirectIndex(global, 1, newValue);
             target->putDirect(vm, id, array, 0);
         }

--- a/src/jsc/bindings/CallSite.cpp
+++ b/src/jsc/bindings/CallSite.cpp
@@ -99,17 +99,21 @@ JSValue createNativeFrameForTesting(Zig::GlobalObject* globalObject)
 
 void CallSite::formatAsString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::StringBuilder& sb)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue thisValue = jsUndefined();
     if (m_thisValue) {
         thisValue = m_thisValue.get();
     }
 
     JSString* myFunctionName = functionName().toStringOrNull(globalObject);
+    RETURN_IF_EXCEPTION(scope, );
     JSString* mySourceURL = sourceURL().toStringOrNull(globalObject);
+    RETURN_IF_EXCEPTION(scope, );
 
     String functionName;
     if (myFunctionName && myFunctionName->length() > 0) {
         functionName = myFunctionName->getString(globalObject);
+        RETURN_IF_EXCEPTION(scope, );
     } else if (m_flags & (static_cast<unsigned int>(Flags::IsFunction) | static_cast<unsigned int>(Flags::IsEval))) {
         functionName = "<anonymous>"_s;
     }
@@ -155,6 +159,7 @@ void CallSite::formatAsString(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WT
             sb.append("unknown"_s);
         } else {
             sb.append(mySourceURL->getString(globalObject));
+            RETURN_IF_EXCEPTION(scope, );
         }
 
         if (line && column) {

--- a/src/jsc/bindings/CallSitePrototype.cpp
+++ b/src/jsc/bindings/CallSitePrototype.cpp
@@ -257,6 +257,7 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncToString, (JSGlobalObject * globalObje
     ENTER_PROTO_FUNC();
     WTF::StringBuilder sb;
     callSite->formatAsString(vm, globalObject, sb);
+    RETURN_IF_EXCEPTION(scope, {});
     return JSC::JSValue::encode(jsString(vm, sb.toString()));
 }
 

--- a/src/jsc/bindings/ConsoleObject.cpp
+++ b/src/jsc/bindings/ConsoleObject.cpp
@@ -34,12 +34,14 @@ void ConsoleObject::messageWithTypeAndLevel(MessageType type, MessageLevel level
     JSC::JSGlobalObject* globalObject,
     Ref<ScriptArguments>&& arguments)
 {
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     if (globalObject->inspectable()) {
         if (auto client = globalObject->inspectorController().consoleClient()) {
             client->messageWithTypeAndLevel(type, level, globalObject, arguments.copyRef());
+            RETURN_IF_EXCEPTION(scope, );
         }
     }
-    auto& vm = JSC::getVM(globalObject);
     auto args = arguments.ptr();
     JSC::EncodedJSValue jsArgs[255];
 
@@ -50,12 +52,11 @@ void ConsoleObject::messageWithTypeAndLevel(MessageType type, MessageLevel level
     }
 
     if (type == MessageType::Table && count >= 2 && !args->argumentAt(1).isUndefined() && (!args->argumentAt(1).isCell() || args->argumentAt(1).asCell()->type() != JSC::JSType::ArrayType)) [[unlikely]] {
-        auto scope = DECLARE_THROW_SCOPE(vm);
         JSC::throwTypeError(globalObject, scope, "The \"properties\" argument must be an instance of Array."_s);
         return;
     }
 
-    Bun__ConsoleObject__messageWithTypeAndLevel(this->m_client, static_cast<uint32_t>(type), static_cast<uint32_t>(level), globalObject, jsArgs, count);
+    RELEASE_AND_RETURN(scope, Bun__ConsoleObject__messageWithTypeAndLevel(this->m_client, static_cast<uint32_t>(type), static_cast<uint32_t>(level), globalObject, jsArgs, count));
 }
 void ConsoleObject::count(JSGlobalObject* globalObject, const String& label)
 {

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -116,6 +116,7 @@ JSCStackTrace JSCStackTrace::fromExisting(JSC::VM& vm, const WTF::Vector<JSC::St
 void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, JSC::JSCell* owner, JSC::JSValue caller, WTF::Vector<JSC::StackFrame>& stackTrace, size_t stackTraceLimit)
 {
     UNUSED_PARAM(callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Delegate to Interpreter::getStackTrace which includes async stack frames
     // (from the await chain via getAsyncStackTrace). The previous hand-rolled
@@ -153,6 +154,7 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
     JSC::JSObject* callerObject = caller.getObject();
     auto* globalObject = callerObject->globalObject();
     WTF::String callerName = Zig::functionName(vm, globalObject, callerObject);
+    RETURN_IF_EXCEPTION(scope, );
 
     // Match V8: remove all frames up to and including the caller. If the caller
     // is not found anywhere in the sync portion of the stack, remove everything.
@@ -169,9 +171,13 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
             removeCount = i + 1;
             break;
         }
-        if (!callerName.isEmpty() && Zig::functionName(vm, globalObject, frame, FinalizerSafety::NotInFinalizer, nullptr) == callerName) {
-            removeCount = i + 1;
-            break;
+        if (!callerName.isEmpty()) {
+            WTF::String frameName = Zig::functionName(vm, globalObject, frame, FinalizerSafety::NotInFinalizer, nullptr);
+            RETURN_IF_EXCEPTION(scope, );
+            if (frameName == callerName) {
+                removeCount = i + 1;
+                break;
+            }
         }
     }
 
@@ -485,9 +491,9 @@ String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::
         if (object->getOwnNonIndexPropertySlot(vm, object->structure(), vm.propertyNames->name, slot)) {
             if (!slot.isAccessor()) {
                 JSValue functionNameValue = slot.getValue(lexicalGlobalObject, vm.propertyNames->name);
-                if (functionNameValue && functionNameValue.isString()) {
+                if (!topExceptionScope.exception() && functionNameValue && functionNameValue.isString()) {
                     name = functionNameValue.toWTFString(lexicalGlobalObject);
-                    if (!name.isEmpty()) {
+                    if (!topExceptionScope.exception() && !name.isEmpty()) {
                         return name;
                     }
                 }

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -483,24 +483,23 @@ String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::
     auto jstype = object->type();
     if (jstype == JSC::ProxyObjectType) return {};
 
-    // First try the "name" property.
+    // First try the "name" property. This names a frame for error output, so a
+    // custom getter that throws, or a rope that fails to resolve, is not an
+    // error to report here: clear it and fall through to the next strategy.
     {
-        WTF::String name;
         auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
         PropertySlot slot(object, PropertySlot::InternalMethodType::VMInquiry, &vm);
-        if (object->getOwnNonIndexPropertySlot(vm, object->structure(), vm.propertyNames->name, slot)) {
-            if (!slot.isAccessor()) {
-                JSValue functionNameValue = slot.getValue(lexicalGlobalObject, vm.propertyNames->name);
-                if (!topExceptionScope.exception() && functionNameValue && functionNameValue.isString()) {
-                    name = functionNameValue.toWTFString(lexicalGlobalObject);
-                    if (!topExceptionScope.exception() && !name.isEmpty()) {
-                        return name;
-                    }
-                }
+        if (object->getOwnNonIndexPropertySlot(vm, object->structure(), vm.propertyNames->name, slot) && !slot.isAccessor()) {
+            JSValue functionNameValue = slot.getValue(lexicalGlobalObject, vm.propertyNames->name);
+            if (topExceptionScope.exception()) [[unlikely]]
+                (void)topExceptionScope.tryClearException();
+            else if (functionNameValue && functionNameValue.isString()) {
+                WTF::String name = functionNameValue.toWTFString(lexicalGlobalObject);
+                if (topExceptionScope.exception()) [[unlikely]]
+                    (void)topExceptionScope.tryClearException();
+                else if (!name.isEmpty())
+                    return name;
             }
-        }
-        if (topExceptionScope.exception()) [[unlikely]] {
-            (void)topExceptionScope.tryClearException();
         }
     }
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -150,6 +150,7 @@ WTF::String formatStackTrace(
     Vector<JSC::StackFrame>& stackTrace,
     JSC::JSObject* errorInstance)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
     WTF::StringBuilder sb;
 
     if (!name.isEmpty()) {
@@ -306,6 +307,7 @@ WTF::String formatStackTrace(
         }
 
         WTF::String functionName = Zig::functionName(vm, globalObjectForFrame, frame, errorInstance ? Zig::FinalizerSafety::NotInFinalizer : Zig::FinalizerSafety::MustNotTriggerGC, &flags);
+        RETURN_IF_EXCEPTION(scope, {});
         OrdinalNumber originalLine = {};
         OrdinalNumber originalColumn = {};
         OrdinalNumber displayLine = {};
@@ -422,7 +424,7 @@ static String computeErrorInfoWithoutPrepareStackTrace(
         globalObject = defaultGlobalObject();
     }
 
-    return Bun::formatStackTrace(vm, globalObject, lexicalGlobalObject, name, message, line, column, sourceURL, stackTrace, errorInstance);
+    RELEASE_AND_RETURN(scope, Bun::formatStackTrace(vm, globalObject, lexicalGlobalObject, name, message, line, column, sourceURL, stackTrace, errorInstance));
 }
 
 static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, Vector<StackFrame>& stackFrames, OrdinalNumber& line, OrdinalNumber& column, String& sourceURL, JSObject* errorObject, JSObject* prepareStackTrace)
@@ -436,6 +438,7 @@ static JSValue computeErrorInfoWithPrepareStackTrace(JSC::VM& vm, Zig::GlobalObj
 
     // Create the call sites (one per frame)
     Zig::createCallSitesFromFrames(globalObject, lexicalGlobalObject, stackTrace, callSites);
+    RETURN_IF_EXCEPTION(scope, {});
 
     // We need to sourcemap it if it's a GlobalObject.
 
@@ -774,6 +777,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace, (JSC::JSGlobalOb
 
     WTF::Vector<JSC::StackFrame> stackTrace;
     JSCStackTrace::getFramesForCaller(vm, callFrame, errorObject, caller, stackTrace, stackTraceLimit);
+    RETURN_IF_EXCEPTION(scope, {});
 
     if (auto* instance = dynamicDowncast<JSC::ErrorInstance>(errorObject)) {
         if (instance->hasMaterializedErrorInfo()) {
@@ -825,6 +829,8 @@ void createCallSitesFromFrames(Zig::GlobalObject* globalObject, JSC::JSGlobalObj
      * strict mode function and all frames below (its caller etc.) are not allow to access
      * their receiver and function objects. For those frames, getFunction() and getThis()
      * will return undefined."." */
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     bool encounteredStrictFrame = false;
 
     // TODO: is it safe to use CallSite structure from a different JSGlobalObject? This case would happen within a node:vm
@@ -833,6 +839,7 @@ void createCallSitesFromFrames(Zig::GlobalObject* globalObject, JSC::JSGlobalObj
 
     for (size_t i = 0; i < framesCount; i++) {
         CallSite* callSite = CallSite::create(lexicalGlobalObject, callSiteStructure, stackTrace.at(i), encounteredStrictFrame);
+        RETURN_IF_EXCEPTION(scope, );
 
         if (!encounteredStrictFrame) {
             encounteredStrictFrame = callSite->isStrict();

--- a/src/jsc/bindings/HTMLEntryPoint.cpp
+++ b/src/jsc/bindings/HTMLEntryPoint.cpp
@@ -30,7 +30,7 @@ extern "C" JSPromise* Bun__loadHTMLEntryPoint(Zig::GlobalObject* globalObject)
     }
 
     if (result.isUndefined()) {
-        return JSPromise::resolvedPromise(globalObject, result);
+        RELEASE_AND_RETURN(scope, JSPromise::resolvedPromise(globalObject, result));
     }
 
     JSPromise* promise = dynamicDowncast<JSC::JSPromise>(result);

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -159,7 +159,6 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSync(JSC::JSGlobalObje
     } else {
         JSC::JSObject* thisObject = dynamicDowncast<JSC::JSObject>(thisValue);
         if (!thisObject) [[unlikely]] {
-            auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
             JSC::throwTypeError(globalObject, scope, "import.meta.resolveSync must be bound to an import.meta object"_s);
             return {};
         }

--- a/src/jsc/bindings/InspectorLifecycleAgent.cpp
+++ b/src/jsc/bindings/InspectorLifecycleAgent.cpp
@@ -160,6 +160,7 @@ Protocol::ErrorStringOr<ModuleGraph> InspectorLifecycleAgent::getModuleGraph()
         RETURN_IF_EXCEPTION(scope, fail("Failed to create iterator"_s));
         JSC::JSValue value;
         while (iter2->next(global, value)) {
+            RETURN_IF_EXCEPTION(scope, fail("Failed to iterate over cjs map"_s));
             cjs->addItem(value.toWTFString(global));
             RETURN_IF_EXCEPTION(scope, fail("Failed to add item to cjs array"_s));
         }

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -230,6 +230,7 @@ JSC_DEFINE_HOST_FUNCTION(InternalModuleRegistry::jsCreateInternalModuleById, (JS
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto id = callframe->argument(0).toUInt32(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
 
     auto registry = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject)->internalModuleRegistry();
     auto mod = registry->createInternalModuleById(lexicalGlobalObject, vm, static_cast<Field>(id));

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -329,6 +329,7 @@ static int normalizeCompareVal(int val, size_t a_length, size_t b_length)
 static WebCore::BufferEncodingType parseEncoding(JSC::ThrowScope& scope, JSC::JSGlobalObject* lexicalGlobalObject, JSString* argString, JSValue arg, bool validateUnknown)
 {
     const auto& view = argString->view(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, WebCore::BufferEncodingType::utf8);
 
     std::optional<BufferEncodingType> encoded = parseEnumerationFromView<BufferEncodingType>(view);
     if (!encoded) [[unlikely]] {
@@ -586,6 +587,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_allocUnsafeBody(JSC::JSGl
     Bun::V::validateNumber(throwScope, lexicalGlobalObject, lengthValue, "size"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength));
     RETURN_IF_EXCEPTION(throwScope, {});
     size_t length = lengthValue.toLength(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
     auto result = allocBufferUnsafe(lexicalGlobalObject, length);
     RETURN_IF_EXCEPTION(throwScope, {});
     if (Bun__Node__ZeroFillBuffers) memset(result->typedVector(), 0, length);
@@ -684,10 +686,12 @@ static JSC::EncodedJSValue constructBufferFromStringAndEncoding(JSC::JSGlobalObj
 
     if (arg1 && arg1.isString()) {
         std::optional<BufferEncodingType> encoded = parseEnumeration<BufferEncodingType>(*lexicalGlobalObject, arg1);
+        RETURN_IF_EXCEPTION(scope, {});
         if (!encoded) {
             auto* encodingString = arg1.toString(lexicalGlobalObject);
             RETURN_IF_EXCEPTION(scope, {});
             const auto& view = encodingString->view(lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, {});
             return Bun::ERR::UNKNOWN_ENCODING(scope, lexicalGlobalObject, view);
         }
 
@@ -742,6 +746,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_allocBody(JSC::JSGlobalOb
             auto str_ = value.toString(lexicalGlobalObject);
             RETURN_IF_EXCEPTION(scope, {});
             const auto& view = str_->view(lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(scope, {});
             if (view->isEmpty()) {
                 memset(startPtr, 0, length);
                 RELEASE_AND_RETURN(scope, JSC::JSValue::encode(uint8Array));
@@ -841,6 +846,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_byteLengthBody(JSC::JSGlo
 
         if (arg1.value().isString()) {
             std::optional<BufferEncodingType> encoded = parseEnumeration<BufferEncodingType>(*lexicalGlobalObject, arg1.value());
+            RETURN_IF_EXCEPTION(scope, {});
 
             // this one doesn't fail
             if (encoded) {
@@ -911,7 +917,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
     if (callFrame->argumentCount() < 1) {
-        return constructBufferEmpty(lexicalGlobalObject);
+        RELEASE_AND_RETURN(throwScope, constructBufferEmpty(lexicalGlobalObject));
     }
     auto listValue = callFrame->argument(0);
 
@@ -1092,6 +1098,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_isEncodingBody(JSC::JSGlo
     auto* encoding = encodingValue.toString(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
     std::optional<BufferEncodingType> encoded = parseEnumeration<BufferEncodingType>(*lexicalGlobalObject, encoding);
+    RETURN_IF_EXCEPTION(throwScope, {});
     return JSValue::encode(jsBoolean(!!encoded));
 }
 
@@ -2557,6 +2564,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlobalObje
         Bun::V::validateString(scope, lexicalGlobalObject, stringValue, "string"_s);
         RETURN_IF_EXCEPTION(scope, {});
         auto* str = stringValue.toString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
         offset = 0;
         length = castedThis->byteLength();
         RELEASE_AND_RETURN(scope, writeToBuffer(lexicalGlobalObject, castedThis, str, offset, length, WebCore::BufferEncodingType::utf8));
@@ -2598,6 +2606,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlobalObje
     Bun::V::validateString(scope, lexicalGlobalObject, stringValue, "string"_s);
     RETURN_IF_EXCEPTION(scope, {});
     auto* str = stringValue.toString(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
 
     if (!encodingValue.toBoolean(lexicalGlobalObject)) {
         RELEASE_AND_RETURN(scope, writeToBuffer(lexicalGlobalObject, castedThis, str, offset, length, WebCore::BufferEncodingType::utf8));
@@ -3923,6 +3932,7 @@ static JSC::EncodedJSValue createJSBufferFromJS(JSC::JSGlobalObject* lexicalGlob
         Bun::V::validateNumber(throwScope, lexicalGlobalObject, lengthValue, "size"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength));
         RETURN_IF_EXCEPTION(throwScope, {});
         size_t length = lengthValue.toLength(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
         RELEASE_AND_RETURN(throwScope, JSValue::encode(allocBuffer(lexicalGlobalObject, length)));
     } else if (distinguishingArg.isUndefinedOrNull() || distinguishingArg.isBoolean()) {
         auto arg_string = distinguishingArg.toWTFString(globalObject);

--- a/src/jsc/bindings/JSCTestingHelpers.cpp
+++ b/src/jsc/bindings/JSCTestingHelpers.cpp
@@ -26,6 +26,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsUTF16String,
     JSC::JSValue value = callframe->argument(0);
     if (value.isString()) {
         WTF::String string = value.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
         if (string.is8Bit()) {
             return JSValue::encode(jsBoolean(false));
         }
@@ -46,6 +47,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsLatin1String,
     JSC::JSValue value = callframe->argument(0);
     if (value.isString()) {
         WTF::String string = value.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
         if (string.is8Bit()) {
             return JSValue::encode(jsBoolean(true));
         }

--- a/src/jsc/bindings/JSCommonJSExtensions.cpp
+++ b/src/jsc/bindings/JSCommonJSExtensions.cpp
@@ -193,8 +193,11 @@ bool JSCommonJSExtensions::put(JSC::JSCell* cell, JSC::JSGlobalObject* globalObj
 
 bool JSCommonJSExtensions::deleteProperty(JSC::JSCell* cell, JSC::JSGlobalObject* globalObject, JSC::PropertyName propertyName, JSC::DeletePropertySlot& slot)
 {
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     if (!isAllowedToMutateExtensions(globalObject)) return true;
     bool deleted = Base::deleteProperty(cell, globalObject, propertyName, slot);
+    RETURN_IF_EXCEPTION(scope, false);
     if (deleted) {
         onAssign(defaultGlobalObject(globalObject), propertyName, JSC::jsUndefined());
     }

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -226,6 +226,7 @@ static bool evaluateCommonJSModuleOnce(JSC::VM& vm, Zig::GlobalObject* globalObj
         if (jsFunction->jsExecutable()->parameterCount() > 5) {
             // it expects ImportMetaObject
             args.append(Zig::ImportMetaObject::create(globalObject, filename));
+            RETURN_IF_EXCEPTION(scope, false);
         }
     }
 
@@ -263,6 +264,7 @@ bool JSCommonJSModule::load(JSC::VM& vm, Zig::GlobalObject* globalObject)
         // On error, remove the module from the require map/
         // so that it can be re-evaluated on the next require.
         bool wasRemoved = globalObject->requireMap()->remove(globalObject, this->filename());
+        RETURN_IF_EXCEPTION(scope, false);
         ASSERT(wasRemoved);
 
         scope.throwException(globalObject, exception);
@@ -333,15 +335,15 @@ JSC_DEFINE_HOST_FUNCTION(requireResolvePathsFunction, (JSGlobalObject * globalOb
     JSValue thisValue = callframe->thisValue();
     auto* requireResolveBound = dynamicDowncast<JSC::JSBoundFunction>(thisValue);
     if (!requireResolveBound) [[unlikely]] {
-        return JSValue::encode(constructEmptyArray(globalObject, nullptr, 0));
+        RELEASE_AND_RETURN(scope, JSValue::encode(constructEmptyArray(globalObject, nullptr, 0)));
     }
     auto* boundModule = dynamicDowncast<Bun::JSCommonJSModule>(requireResolveBound->boundThis());
     if (!boundModule) [[unlikely]] {
-        return JSValue::encode(constructEmptyArray(globalObject, nullptr, 0));
+        RELEASE_AND_RETURN(scope, JSValue::encode(constructEmptyArray(globalObject, nullptr, 0)));
     }
     JSString* filename = dynamicDowncast<JSString>(boundModule->filename());
     if (!filename) [[unlikely]] {
-        return JSValue::encode(constructEmptyArray(globalObject, nullptr, 0));
+        RELEASE_AND_RETURN(scope, JSValue::encode(constructEmptyArray(globalObject, nullptr, 0)));
     }
     RETURN_IF_EXCEPTION(scope, {});
     Bun::PathResolveModule parent = { .paths = nullptr, .filename = filename, .pathsArrayLazy = true };
@@ -770,6 +772,7 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * glo
     RETURN_IF_EXCEPTION(throwScope, {});
 
     String dirnameString = dirnameValue.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
 
     WTF::NakedPtr<JSC::Exception> exception;
     evaluateCommonJSModuleOnce(
@@ -1287,6 +1290,7 @@ ALWAYS_INLINE EncodedJSValue finishRequireWithError(Zig::GlobalObject* globalObj
     // On error, remove the module from the require map/
     // so that it can be re-evaluated on the next require.
     bool wasRemoved = globalObject->requireMap()->remove(globalObject, specifierValue);
+    RETURN_IF_EXCEPTION(throwScope, {});
     ASSERT(wasRemoved);
 
     throwScope.throwException(globalObject, exception);

--- a/src/jsc/bindings/JSDOMExceptionHandling.cpp
+++ b/src/jsc/bindings/JSDOMExceptionHandling.cpp
@@ -74,6 +74,7 @@ void reportException(JSGlobalObject* lexicalGlobalObject, JSC::Exception* except
     // }
 
     Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+    RETURN_IF_EXCEPTION(scope, );
 
     if (exceptionDetails) {
         auto errorMessage = retrieveErrorMessage(*lexicalGlobalObject, vm, exception->value(), scope);

--- a/src/jsc/bindings/JSDOMFile.cpp
+++ b/src/jsc/bindings/JSDOMFile.cpp
@@ -67,12 +67,11 @@ public:
     {
         auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
         auto& vm = JSC::getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
         JSObject* newTarget = asObject(callFrame->newTarget());
         auto* constructor = globalObject->JSDOMFileConstructor();
         Structure* structure = globalObject->JSBlobStructure();
         if (constructor != newTarget) {
-            auto scope = DECLARE_THROW_SCOPE(vm);
-
             auto* functionGlobalObject = static_cast<Zig::GlobalObject*>(
                 // ShadowRealm functions belong to a different global object.
                 getFunctionRealm(lexicalGlobalObject, newTarget));
@@ -82,6 +81,7 @@ public:
         }
 
         void* ptr = JSDOMFile__construct(lexicalGlobalObject, callFrame);
+        RETURN_IF_EXCEPTION(scope, {});
 
         if (!ptr) [[unlikely]] {
             return JSValue::encode(JSC::jsUndefined());

--- a/src/jsc/bindings/JSDOMWrapperCache.cpp
+++ b/src/jsc/bindings/JSDOMWrapperCache.cpp
@@ -42,7 +42,9 @@ void setSubclassStructure(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFra
     auto* functionGlobalObject = JSC::getFunctionRealm(lexicalGlobalObject, newTarget);
     RETURN_IF_EXCEPTION(scope, void());
     auto* newTargetGlobalObject = defaultGlobalObject(functionGlobalObject);
-    auto* subclassStructure = JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, baseStructure(vm, *newTargetGlobalObject));
+    auto* structure = baseStructure(vm, *newTargetGlobalObject);
+    RETURN_IF_EXCEPTION(scope, void());
+    auto* subclassStructure = JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, structure);
     RETURN_IF_EXCEPTION(scope, void());
     jsObject->setStructure(vm, subclassStructure);
 }

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramConstructor.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramConstructor.cpp
@@ -70,7 +70,7 @@ static JSNodePerformanceHooksHistogram* createHistogramInternal(JSGlobalObject* 
     Structure* structure = zigGlobalObject->m_JSNodePerformanceHooksHistogramClassStructure.get(zigGlobalObject);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    return JSNodePerformanceHooksHistogram::create(vm, structure, globalObject, lowest, highest, figures);
+    RELEASE_AND_RETURN(scope, JSNodePerformanceHooksHistogram::create(vm, structure, globalObject, lowest, highest, figures));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsNodePerformanceHooksHistogramConstructorCall, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/JSPropertyIterator.cpp
+++ b/src/jsc/bindings/JSPropertyIterator.cpp
@@ -117,7 +117,7 @@ static EncodedJSValue getOwnProxyObject(JSPropertyIterator* iter, JSObject* obje
     PropertySlot slot(object, PropertySlot::InternalMethodType::GetOwnProperty, nullptr);
     auto* globalObject = object->globalObject();
     if (!object->methodTable()->getOwnPropertySlot(object, globalObject, prop, slot)) {
-        return {};
+        RELEASE_AND_RETURN(scope, {});
     }
     RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -566,12 +566,14 @@ JSC::EncodedJSValue JSStringDecoderConstructor::construct(JSC::JSGlobalObject* l
     auto jsEncoding = callFrame->argument(0);
     if (!jsEncoding.isUndefinedOrNull()) {
         std::optional<BufferEncodingType> opt = parseEnumeration<BufferEncodingType>(*lexicalGlobalObject, jsEncoding);
+        RETURN_IF_EXCEPTION(throwScope, {});
         if (opt.has_value()) {
             encoding = opt.value();
         } else {
             auto* encodingString = jsEncoding.toString(lexicalGlobalObject);
             RETURN_IF_EXCEPTION(throwScope, {});
             const auto& view = encodingString->view(lexicalGlobalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             return Bun::ERR::UNKNOWN_ENCODING(throwScope, lexicalGlobalObject, view);
         }
     }

--- a/src/jsc/bindings/JSX509Certificate.cpp
+++ b/src/jsc/bindings/JSX509Certificate.cpp
@@ -363,6 +363,7 @@ static JSObject* GetX509NameObject(JSGlobalObject* globalObject, const X509* cer
                     return nullptr;
                 }
                 array->putDirectIndex(globalObject, 0, existing);
+                RETURN_IF_EXCEPTION(scope, nullptr);
                 array->putDirectIndex(globalObject, 1, jsvalue);
                 result->putDirect(vm, Identifier::fromString(vm, key), array, 0);
             } else {
@@ -761,7 +762,7 @@ __attribute__((minsize)) JSC::JSObject* JSX509Certificate::toLegacyObject(ncrypt
 
     // Helper function to convert JSValue to undefined if empty/null
     auto valueOrUndefined = [&](JSValue value) -> JSValue {
-        if (value.isEmpty() || value.isNull() || (value.isString() && value.toString(globalObject)->length() == 0))
+        if (value.isEmpty() || value.isNull() || (value.isString() && asString(value)->length() == 0))
             return jsUndefined();
         return value;
     };
@@ -971,7 +972,7 @@ JSC::JSObject* JSX509Certificate::toLegacyObject(JSGlobalObject* globalObject)
 
     // Helper function to convert JSValue to undefined if empty/null
     auto valueOrUndefined = [&](JSValue value) -> JSValue {
-        if (value.isEmpty() || value.isNull() || (value.isString() && value.toString(globalObject)->length() == 0))
+        if (value.isEmpty() || value.isNull() || (value.isString() && asString(value)->length() == 0))
             return jsUndefined();
         return value;
     };

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -252,6 +252,7 @@ OnLoadResult handleOnLoadResultNotPromise(Zig::GlobalObject* globalObject, JSC::
             }
             if (loaderJSString) {
                 WTF::String loaderString = loaderJSString->value(globalObject);
+                RETURN_IF_EXCEPTION(scope, result);
                 if (loaderString == "js"_s) {
                     loader = BunLoaderTypeJS;
                 } else if (loaderString == "object"_s) {
@@ -296,8 +297,11 @@ OnLoadResult handleOnLoadResultNotPromise(Zig::GlobalObject* globalObject, JSC::
     }
     if (contentsValue) {
         if (contentsValue.isString()) {
-            if (JSC::JSString* contentsJSString = contentsValue.toStringOrNull(globalObject)) {
+            JSC::JSString* contentsJSString = contentsValue.toStringOrNull(globalObject);
+            RETURN_IF_EXCEPTION(scope, result);
+            if (contentsJSString) {
                 result.value.sourceText.string = Zig::toEncodedSlice(contentsJSString, globalObject);
+                RETURN_IF_EXCEPTION(scope, result);
                 result.value.sourceText.value = contentsValue;
             }
         } else if (JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(contentsValue)) {
@@ -1233,13 +1237,19 @@ using namespace Bun;
 BUN_DEFINE_HOST_FUNCTION(jsFunctionEvictIsolationSourceProviderCache, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSValue arg = callFrame->argument(0);
     if (arg.isUndefined()) {
         Bun::IsolatedModuleCache::clear(vm);
         return JSC::JSValue::encode(JSC::jsUndefined());
     }
-    if (auto* str = arg.toStringOrNull(globalObject))
-        Bun::IsolatedModuleCache::evict(vm, str->value(globalObject));
+    auto* str = arg.toStringOrNull(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (str) {
+        WTF::String key = str->value(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        Bun::IsolatedModuleCache::evict(vm, key);
+    }
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 

--- a/src/jsc/bindings/NodeDirent.cpp
+++ b/src/jsc/bindings/NodeDirent.cpp
@@ -214,7 +214,7 @@ static inline int32_t getType(JSC::VM& vm, JSValue value, Zig::GlobalObject* glo
     }
 
     if (type.isAnyInt()) {
-        return type.toInt32(globalObject);
+        return JSC::toInt32(type.asNumber());
     }
 
     return std::numeric_limits<int32_t>::max();

--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -840,7 +840,6 @@ inline JSValue constructJSStatsObject(JSC::JSGlobalObject* lexicalGlobalObject, 
     JSObject* newTarget = asObject(callFrame->newTarget());
 
     if (constructor != newTarget) {
-        auto scope = DECLARE_THROW_SCOPE(vm);
         auto* functionGlobalObject = static_cast<Zig::GlobalObject*>(
             // ShadowRealm functions belong to a different global object.
             getFunctionRealm(lexicalGlobalObject, newTarget));

--- a/src/jsc/bindings/NodeFSStatFSBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatFSBinding.cpp
@@ -369,7 +369,6 @@ inline JSValue constructJSStatFSObject(JSC::JSGlobalObject* lexicalGlobalObject,
     JSObject* newTarget = asObject(callFrame->newTarget());
 
     if (constructor != newTarget) {
-        auto scope = DECLARE_THROW_SCOPE(vm);
         auto* functionGlobalObject = static_cast<Zig::GlobalObject*>(
             // ShadowRealm functions belong to a different global object.
             getFunctionRealm(lexicalGlobalObject, newTarget));

--- a/src/jsc/bindings/NodeFetch.cpp
+++ b/src/jsc/bindings/NodeFetch.cpp
@@ -22,27 +22,34 @@ using namespace WebCore;
 JSC::JSValue createNodeFetchInternalBinding(Zig::GlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* obj = constructEmptyObject(globalObject);
     obj->putDirectIndex(
         globalObject, 0,
         globalObject->JSResponseConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
     obj->putDirectIndex(
         globalObject, 1,
         globalObject->JSRequestConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
     obj->putDirectIndex(
         globalObject, 2,
         globalObject->JSBlobConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
     obj->putDirectIndex(
         globalObject, 3,
         WebCore::JSFetchHeaders::getConstructor(vm, globalObject));
+    RETURN_IF_EXCEPTION(scope, {});
 
     obj->putDirectIndex(
         globalObject, 4,
         WebCore::JSDOMFormData::getConstructor(vm, globalObject));
+    RETURN_IF_EXCEPTION(scope, {});
     obj->putDirectIndex(
         globalObject, 5,
         globalObject->JSDOMFileConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
 
     return obj;
 }

--- a/src/jsc/bindings/NodeTLS.cpp
+++ b/src/jsc/bindings/NodeTLS.cpp
@@ -27,6 +27,7 @@ using namespace JSC;
 JSC_DEFINE_HOST_FUNCTION(getBundledRootCertificates, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     struct us_cert_string_t* out;
     auto size = us_raw_root_certs(&out);
@@ -38,9 +39,10 @@ JSC_DEFINE_HOST_FUNCTION(getBundledRootCertificates, (JSC::JSGlobalObject * glob
         auto raw = out[i];
         auto str = WTF::String::fromUTF8(std::span { raw.str, raw.len });
         rootCertificates->putDirectIndex(globalObject, i, JSC::jsString(vm, str));
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
-    return JSValue::encode(JSC::objectConstructorFreeze(globalObject, rootCertificates));
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSC::objectConstructorFreeze(globalObject, rootCertificates)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(getExtraCACertificates, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -269,16 +269,19 @@ JSC::JSValue createNodeURLBinding(Zig::GlobalObject* globalObject)
         (unsigned)0,
         domainToAsciiFunction,
         false);
+    RETURN_IF_EXCEPTION(scope, {});
     binding->putByIndexInline(
         globalObject,
         (unsigned)1,
         domainToUnicodeFunction,
         false);
+    RETURN_IF_EXCEPTION(scope, {});
     binding->putByIndexInline(
         globalObject,
         (unsigned)2,
         idnaToASCIIFunction,
         false);
+    RETURN_IF_EXCEPTION(scope, {});
     return binding;
 }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -152,6 +152,7 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
     if (!args.isEmpty() && args.at(0).isString()) {
         ParserError error;
         String code = args.at(0).toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
 
         SourceCode sourceCode(
             JSC::StringSourceProvider::create(code, sourceOrigin, options.filename, sourceTaintOrigin, position, SourceProviderSourceType::Program),
@@ -188,6 +189,7 @@ JSC::JSFunction* constructAnonymousFunction(JSC::JSGlobalObject* globalObject, c
                 // Node always attaches the arrow header to compile-time SyntaxErrors
                 // (node_contextify.cc DecorateErrorStack), independent of displayErrors.
                 decorateParseErrorStack(globalObject, vm, exception, code, options.filename, error, options.lineOffset);
+                RETURN_IF_EXCEPTION(throwScope, nullptr);
                 throwException(globalObject, throwScope, exception);
                 return nullptr;
             }
@@ -990,7 +992,9 @@ JSC_DEFINE_HOST_FUNCTION(jsNodeVmWasmDisallowed, (JSC::JSGlobalObject * globalOb
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    scope.throwException(globalObject, JSC::createJSWebAssemblyCompileError(globalObject, vm, "Wasm code generation disallowed by embedder"_s));
+    JSObject* error = JSC::createJSWebAssemblyCompileError(globalObject, vm, "Wasm code generation disallowed by embedder"_s);
+    RETURN_IF_EXCEPTION(scope, {});
+    scope.throwException(globalObject, error);
     return {};
 }
 
@@ -1007,7 +1011,9 @@ JSC_DEFINE_HOST_FUNCTION(jsNodeVmWasmCompileDisallowed, (JSC::JSGlobalObject * g
 
 void NodeVMGlobalObject::finishCreation(JSC::VM& vm)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
     Base::finishCreation(vm);
+    RETURN_IF_EXCEPTION(scope, );
 
     // microtaskMode: "afterEvaluate" — give this context its own microtask
     // queue, like Node's contextify own_microtask_queue. Microtasks enqueued
@@ -1040,7 +1046,6 @@ void NodeVMGlobalObject::finishCreation(JSC::VM& vm)
         // CompileError, while introspection (Module.imports/exports/
         // customSections) and instantiating an already-compiled module stay
         // available.
-        auto scope = DECLARE_THROW_SCOPE(vm);
         JSValue webAssembly = get(this, Identifier::fromString(vm, "WebAssembly"_s));
         RETURN_IF_EXCEPTION(scope, );
         if (webAssembly.isObject()) {
@@ -1084,6 +1089,7 @@ void NodeVMGlobalObject::finishCreation(JSC::VM& vm)
     // but it should not be visible in node:vm contexts.
     JSC::DeletePropertySlot slot;
     JSC::JSObject::deleteProperty(this, this, vm.propertyNames->Loader, slot);
+    RETURN_IF_EXCEPTION(scope, );
 
     vm.ensureTerminationException();
 
@@ -1256,7 +1262,9 @@ bool NodeVMGlobalObject::getOwnPropertySlot(JSObject* cell, JSGlobalObject* glob
 
             // If there is a `get` trap, we don't need to our special handling
             if (getHandler) {
-                if (contextifiedObject->methodTable()->getOwnPropertySlot(contextifiedObject, globalObject, propertyName, slot)) {
+                bool result = contextifiedObject->methodTable()->getOwnPropertySlot(contextifiedObject, globalObject, propertyName, slot);
+                RETURN_IF_EXCEPTION(scope, false);
+                if (result) {
                     return true;
                 }
                 goto try_from_global;
@@ -1365,6 +1373,7 @@ bool NodeVMGlobalObject::defineOwnProperty(JSObject* cell, JSGlobalObject* globa
 
     PropertySlot slot(globalObject, PropertySlot::InternalMethodType::GetOwnProperty, nullptr);
     bool isDeclaredOnGlobalProxy = globalObject->JSC::JSGlobalObject::getOwnPropertySlot(globalObject, globalObject, propertyName, slot);
+    RETURN_IF_EXCEPTION(scope, false);
 
     // If the property is set on the global as neither writable nor
     // configurable, don't change it on the global or sandbox.
@@ -1623,12 +1632,13 @@ bool NodeVMGlobalObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto* sandbox = thisObject->m_sandbox.get();
-    if (!sandbox->deleteProperty(sandbox, globalObject, propertyName, slot)) {
+    bool deleted = sandbox->deleteProperty(sandbox, globalObject, propertyName, slot);
+    RETURN_IF_EXCEPTION(scope, false);
+    if (!deleted) {
         return false;
     }
 
-    RETURN_IF_EXCEPTION(scope, false);
-    return Base::deleteProperty(cell, globalObject, propertyName, slot);
+    RELEASE_AND_RETURN(scope, Base::deleteProperty(cell, globalObject, propertyName, slot));
 }
 
 static JSPromise* moduleLoaderImportModuleInner(NodeVMGlobalObject* globalObject, JSC::JSModuleLoader* moduleLoader, JSC::JSString* moduleName, RefPtr<JSC::ScriptFetchParameters> parameters, const JSC::SourceOrigin& sourceOrigin)

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -187,10 +187,12 @@ JSValue NodeVMModule::evaluate(JSGlobalObject* globalObject, uint32_t timeout, b
             switch (innerPromise->status()) {
             case JSPromise::Status::Fulfilled:
                 result = JSPromise::resolvedPromise(callerGlobalObject, innerPromise->settlementValue());
+                RETURN_IF_EXCEPTION(scope, );
                 break;
             case JSPromise::Status::Rejected:
                 innerPromise->markAsHandled();
                 result = JSPromise::rejectedPromise(callerGlobalObject, innerPromise->settlementValue());
+                RETURN_IF_EXCEPTION(scope, );
                 break;
             case JSPromise::Status::Pending:
                 break;
@@ -616,7 +618,9 @@ JSC_DEFINE_HOST_FUNCTION(jsNodeVmModuleSetExport, (JSC::JSGlobalObject * globalO
             return {};
         }
         JSValue exportValue = callFrame->argument(1);
-        thisObject->setExport(globalObject, nameValue.toWTFString(globalObject), exportValue);
+        WTF::String exportName = nameValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        thisObject->setExport(globalObject, exportName, exportValue);
         RETURN_IF_EXCEPTION(scope, {});
     } else {
         throwTypeError(globalObject, scope, "This function must be called on a SyntheticModule"_s);

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -161,9 +161,11 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
         const ScriptOptions& scriptOptions = script->options();
         String url = scriptOptions.filenameProvided ? scriptOptions.filename : "evalmachine.<anonymous>"_s;
         decorateParseErrorStack(globalObject, vm, exception, sourceString, url, parseError, scriptOptions.lineOffset);
+        RETURN_IF_EXCEPTION(scope, {});
         throwException(globalObject, scope, exception);
         return {};
     }
+    RETURN_IF_EXCEPTION(scope, {});
 
     WTF::Vector<uint8_t>& cachedData = script->cachedData();
 
@@ -200,6 +202,7 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
         }
     } else if (script->options().produceCachedData) {
         script->cacheBytecode();
+        RETURN_IF_EXCEPTION(scope, {});
         // TODO(@heimskr): is there ever a case where bytecode production fails?
         script->cachedDataProduced(true);
     }
@@ -260,6 +263,7 @@ void NodeVMScript::cacheBytecode()
 
 JSC::JSUint8Array* NodeVMScript::getBytecodeBuffer()
 {
+    auto scope = DECLARE_THROW_SCOPE(vm());
     if (!m_options.produceCachedData) {
         return nullptr;
     }
@@ -267,12 +271,14 @@ JSC::JSUint8Array* NodeVMScript::getBytecodeBuffer()
     if (!m_cachedBytecodeBuffer) {
         if (!m_cachedBytecode) {
             cacheBytecode();
+            RETURN_IF_EXCEPTION(scope, nullptr);
         }
 
         ASSERT(m_cachedBytecode);
 
         std::span<const uint8_t> bytes = m_cachedBytecode->span();
         m_cachedBytecodeBuffer.set(vm(), this, WebCore::createBuffer(globalObject(), bytes));
+        RETURN_IF_EXCEPTION(scope, nullptr);
         if (!m_cachedBytecodeBuffer) {
             return nullptr;
         }

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -293,6 +293,7 @@ JSValue NodeVMSourceTextModule::createModuleRecord(JSGlobalObject* globalObject)
         requestObject->putDirect(vm, attributesIdentifier, attributesObject);
         addModuleRequest({ request.m_specifier.string(), WTF::move(attributeMap) });
         requestsArray->putDirectIndex(globalObject, i, requestObject);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     m_moduleRequestsArray.set(vm, this, requestsArray);

--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -240,6 +240,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_validatePort, (JSC::JSGlobalObject * globalO
 
     if (port.isString()) {
         auto port_str = port.getString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
         auto trimmed = port_str.trim([](auto c) {
             // https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.trim
             // The definition of white space is the union of *WhiteSpace* and *LineTerminator*.
@@ -492,12 +493,13 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_validateEncoding, (JSC::JSGlobalObject * glo
     auto encoding = callFrame->argument(1);
 
     auto normalized = WebCore::parseEnumeration<BufferEncodingType>(*globalObject, encoding);
+    RETURN_IF_EXCEPTION(scope, {});
     if (normalized == BufferEncodingType::hex) {
         auto data = callFrame->argument(0);
 
         size_t length = 0;
         if (data.isString()) {
-            length = data.toString(globalObject)->length();
+            length = asString(data)->length();
         } else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(data)) {
             length = view->length();
         } else if (auto* buffer = dynamicDowncast<JSC::JSArrayBuffer>(data)) {

--- a/src/jsc/bindings/ProcessBindingHTTPParser.cpp
+++ b/src/jsc/bindings/ProcessBindingHTTPParser.cpp
@@ -13,10 +13,14 @@ static constexpr ASCIILiteral httpAllMethodNames[] = { HTTP_ALL_METHOD_MAP(METHO
 
 static JSValue methodNamesArray(VM& vm, JSObject* binding, std::span<const ASCIILiteral> names)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSGlobalObject* globalObject = binding->globalObject();
     JSArray* methods = constructEmptyArray(globalObject, nullptr, names.size());
-    for (unsigned i = 0; i < names.size(); ++i)
+    RETURN_IF_EXCEPTION(scope, {});
+    for (unsigned i = 0; i < names.size(); ++i) {
         methods->putDirectIndex(globalObject, i, jsString(vm, String(names[i])));
+        RETURN_IF_EXCEPTION(scope, {});
+    }
     return methods;
 }
 

--- a/src/jsc/bindings/ProcessBindingTTYWrap.cpp
+++ b/src/jsc/bindings/ProcessBindingTTYWrap.cpp
@@ -264,7 +264,7 @@ JSC_DEFINE_HOST_FUNCTION(TTYWrap_functionSetMode,
     int err = uv_tty_set_mode(ttyWrap->handle->tty(), mode.toInt32(globalObject));
 #else
     // Nodejs does not throw when ttySetMode fails. An Error event is emitted instead.
-    int err = Bun__ttySetMode(fd, mode.toInt32(globalObject), &ttyWrap->ttyState, 1);
+    int err = Bun__ttySetMode(fd, JSC::toInt32(mode.asNumber()), &ttyWrap->ttyState, 1);
 #endif
     return JSValue::encode(jsNumber(err));
 }
@@ -299,7 +299,9 @@ JSC_DEFINE_HOST_FUNCTION(TTYWrap_functionGetWindowSize,
     }
 
     array->putDirectIndex(globalObject, 0, jsNumber(width));
+    RETURN_IF_EXCEPTION(throwScope, {});
     array->putDirectIndex(globalObject, 1, jsNumber(height));
+    RETURN_IF_EXCEPTION(throwScope, {});
 
     return JSC::JSValue::encode(jsBoolean(true));
 }

--- a/src/jsc/bindings/ProcessBindingTTYWrap.cpp
+++ b/src/jsc/bindings/ProcessBindingTTYWrap.cpp
@@ -256,15 +256,16 @@ JSC_DEFINE_HOST_FUNCTION(TTYWrap_functionSetMode,
         return {};
     }
 
+    int modeInt = JSC::toInt32(mode.asNumber());
 #if OS(WINDOWS)
-    if (mode.toInt32(globalObject) == 0) {
+    if (modeInt == 0) {
         Bun__setCTRLHandler(1);
     }
 
-    int err = uv_tty_set_mode(ttyWrap->handle->tty(), mode.toInt32(globalObject));
+    int err = uv_tty_set_mode(ttyWrap->handle->tty(), modeInt);
 #else
     // Nodejs does not throw when ttySetMode fails. An Error event is emitted instead.
-    int err = Bun__ttySetMode(fd, JSC::toInt32(mode.asNumber()), &ttyWrap->ttyState, 1);
+    int err = Bun__ttySetMode(fd, modeInt, &ttyWrap->ttyState, 1);
 #endif
     return JSValue::encode(jsNumber(err));
 }

--- a/src/jsc/bindings/ProcessBindingUV.cpp
+++ b/src/jsc/bindings/ProcessBindingUV.cpp
@@ -151,7 +151,7 @@ JSC_DEFINE_HOST_FUNCTION(jsErrname, (JSGlobalObject * globalObject, JSC::CallFra
         return JSValue::encode(jsString(vm, String("Unknown system error"_s)));
     }
 
-    auto err = arg0.toInt32(globalObject);
+    auto err = arg0.asInt32AsAnyInt();
     for (auto& entry : uvErrnoEntries) {
         if (err == entry.value)
             return JSValue::encode(JSC::jsString(vm, String(entry.name)));
@@ -164,14 +164,18 @@ JSC_DEFINE_HOST_FUNCTION(jsErrname, (JSGlobalObject * globalObject, JSC::CallFra
 JSC_DEFINE_HOST_FUNCTION(jsGetErrorMap, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto map = JSC::JSMap::create(vm, globalObject->mapStructure());
 
     for (auto& entry : uvErrnoEntries) {
         auto arr = JSC::constructEmptyArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), 2);
-        // RETURN_IF_EXCEPTION
+        RETURN_IF_EXCEPTION(scope, {});
         arr->putDirectIndex(globalObject, 0, JSC::jsString(vm, String(entry.name)));
+        RETURN_IF_EXCEPTION(scope, {});
         arr->putDirectIndex(globalObject, 1, JSC::jsString(vm, String(entry.description)));
+        RETURN_IF_EXCEPTION(scope, {});
         map->set(globalObject, JSC::jsNumber(entry.value), arr);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     return JSValue::encode(map);

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -423,6 +423,7 @@ public:
 
 static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& frames, ZigStackTrace& trace, JSC::JSGlobalObject* globalObject, PopulateStackTraceFlags flags, FinalizerSafety finalizerSafety = FinalizerSafety::NotInFinalizer)
 {
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     if (flags == PopulateStackTraceFlags::OnlyPosition) {
         uint8_t frame_i = 0;
         size_t stack_frame_i = 0;
@@ -440,6 +441,7 @@ static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& 
             ZigStackFrame& frame = trace.frames_ptr[frame_i];
             frame.jsc_stack_frame_index = static_cast<int32_t>(stack_frame_i);
             populateStackFrame(vm, trace, frames[stack_frame_i], frame, frame_i == 0, &trace.referenced_source_provider, globalObject, flags, finalizerSafety);
+            RETURN_IF_EXCEPTION(scope, );
             stack_frame_i++;
             frame_i++;
         }
@@ -450,19 +452,24 @@ static void populateStackTrace(JSC::VM& vm, const WTF::Vector<JSC::StackFrame>& 
             if (frame.jsc_stack_frame_index < 0 || static_cast<size_t>(frame.jsc_stack_frame_index) >= frames.size())
                 continue;
             populateStackFrame(vm, trace, frames[frame.jsc_stack_frame_index], frame, i == 0, &trace.referenced_source_provider, globalObject, flags, finalizerSafety);
+            RETURN_IF_EXCEPTION(scope, );
         }
     }
 }
 
 static JSC::JSValue getNonObservable(JSC::VM& vm, JSC::JSGlobalObject* global, JSC::JSObject* obj, const JSC::PropertyName& propertyName)
 {
+    auto scope = DECLARE_THROW_SCOPE(vm);
     PropertySlot slot = PropertySlot(obj, PropertySlot::InternalMethodType::VMInquiry, &vm);
-    if (obj->getNonIndexPropertySlot(global, propertyName, slot)) {
+    bool hasProperty = obj->getNonIndexPropertySlot(global, propertyName, slot);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (hasProperty) {
         if (slot.isAccessor()) {
             return {};
         }
 
         JSValue value = slot.getValue(global, propertyName);
+        RETURN_IF_EXCEPTION(scope, {});
         if (!value || value.isUndefinedOrNull()) {
             return {};
         }
@@ -482,9 +489,11 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
     bool getFromSourceURL = false;
     if (stackTrace != nullptr && stackTrace->size() > 0) {
         populateStackTrace(vm, *stackTrace, except.stack, global, flags);
+        RETURN_IF_EXCEPTION(scope, );
 
     } else if (err->stackTrace() != nullptr && err->stackTrace()->size() > 0) {
         populateStackTrace(vm, *err->stackTrace(), except.stack, global, flags, FinalizerSafety::MustNotTriggerGC);
+        RETURN_IF_EXCEPTION(scope, );
 
     } else {
         getFromSourceURL = true;
@@ -500,10 +509,12 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
         except.message = Bun::toStringRef(err->sanitizedMessageString(global));
 
     } else if (JSC::JSValue message = obj->getIfPropertyExists(global, vm.propertyNames->message)) {
+        RETURN_IF_EXCEPTION(scope, );
         except.message = Bun::toStringRef(global, message);
         if (!scope.clearExceptionExceptTermination()) [[unlikely]]
             return;
     } else {
+        RETURN_IF_EXCEPTION(scope, );
 
         except.message = Bun::toStringRef(err->sanitizedMessageString(global));
     }
@@ -560,7 +571,7 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
             return;
         if (fd) {
             if (fd.isNumber()) {
-                except.fd = fd.toInt32(global);
+                except.fd = JSC::toInt32(fd.asNumber());
             }
         }
 
@@ -569,7 +580,7 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
             return;
         if (errno_) {
             if (errno_.isNumber()) {
-                except.errno_ = errno_.toInt32(global);
+                except.errno_ = JSC::toInt32(errno_.asNumber());
             }
         }
     }
@@ -653,7 +664,7 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
                     return;
                 if (column) {
                     if (column.isNumber()) {
-                        except.stack.frames_ptr[0].position.column_zero_based = OrdinalNumber::fromOneBasedInt(column.toInt32(global)).zeroBasedInt();
+                        except.stack.frames_ptr[0].position.column_zero_based = OrdinalNumber::fromOneBasedInt(JSC::toInt32(column.asNumber())).zeroBasedInt();
                     }
                 }
 
@@ -662,15 +673,16 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
                     return;
                 if (line) {
                     if (line.isNumber()) {
-                        except.stack.frames_ptr[0].position.line_zero_based = OrdinalNumber::fromOneBasedInt(line.toInt32(global)).zeroBasedInt();
+                        except.stack.frames_ptr[0].position.line_zero_based = OrdinalNumber::fromOneBasedInt(JSC::toInt32(line.asNumber())).zeroBasedInt();
 
                         JSC::JSValue lineText = getNonObservable(vm, global, obj, builtinNames(vm).lineTextPublicName());
                         if (!scope.clearExceptionExceptTermination()) [[unlikely]]
                             return;
                         if (lineText) {
                             if (lineText.isString()) {
-                                if (JSC::JSString* jsStr = lineText.toStringOrNull(global)) {
+                                if (JSC::JSString* jsStr = asString(lineText)) {
                                     auto str = jsStr->value(global);
+                                    RETURN_IF_EXCEPTION(scope, );
                                     except.stack.source_lines_ptr[0] = Bun::toStringRef(str);
                                     except.stack.source_lines_numbers[0] = except.stack.frames_ptr[0].position.line();
                                     except.stack.source_lines_len = 1;
@@ -712,6 +724,7 @@ void exceptionFromString(ZigException& except, JSC::JSValue value, JSC::JSGlobal
         if (name_value) {
             if (name_value.isString()) {
                 auto name_str = name_value.toWTFString(global);
+                RETURN_IF_EXCEPTION(scope, );
                 except.name = Bun::toStringRef(name_str);
                 if (name_str == "Error"_s) {
                     except.type = JSErrorCodeError;
@@ -740,6 +753,7 @@ void exceptionFromString(ZigException& except, JSC::JSValue value, JSC::JSGlobal
         if (message) {
             if (message.isString()) {
                 except.message = Bun::toStringRef(message.toWTFString(global));
+                RETURN_IF_EXCEPTION(scope, );
             }
         }
 
@@ -765,7 +779,7 @@ void exceptionFromString(ZigException& except, JSC::JSValue value, JSC::JSGlobal
             }
             if (line) {
                 if (line.isNumber()) {
-                    except.stack.frames_ptr[0].position.line_zero_based = OrdinalNumber::fromOneBasedInt(line.toInt32(global)).zeroBasedInt();
+                    except.stack.frames_ptr[0].position.line_zero_based = OrdinalNumber::fromOneBasedInt(JSC::toInt32(line.asNumber())).zeroBasedInt();
 
                     // TODO: don't sourcemap it twice
                     auto originalLine = obj->getIfPropertyExists(global, builtinNames(vm).originalLinePublicName());

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -786,7 +786,7 @@ void exceptionFromString(ZigException& except, JSC::JSValue value, JSC::JSGlobal
                     }
                     if (originalLine) {
                         if (originalLine.isNumber()) {
-                            except.stack.frames_ptr[0].position.line_zero_based = OrdinalNumber::fromOneBasedInt(originalLine.toInt32(global)).zeroBasedInt();
+                            except.stack.frames_ptr[0].position.line_zero_based = OrdinalNumber::fromOneBasedInt(JSC::toInt32(originalLine.asNumber())).zeroBasedInt();
                         }
                     }
                     except.stack.frames_len = 1;

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -680,14 +680,12 @@ __attribute__((minsize)) static void fromErrorInstance(ZigException& except, JSC
                             return;
                         if (lineText) {
                             if (lineText.isString()) {
-                                if (JSC::JSString* jsStr = asString(lineText)) {
-                                    auto str = jsStr->value(global);
-                                    RETURN_IF_EXCEPTION(scope, );
-                                    except.stack.source_lines_ptr[0] = Bun::toStringRef(str);
-                                    except.stack.source_lines_numbers[0] = except.stack.frames_ptr[0].position.line();
-                                    except.stack.source_lines_len = 1;
-                                    except.remapped = true;
-                                }
+                                auto str = asString(lineText)->value(global);
+                                RETURN_IF_EXCEPTION(scope, );
+                                except.stack.source_lines_ptr[0] = Bun::toStringRef(str);
+                                except.stack.source_lines_numbers[0] = except.stack.frames_ptr[0].position.line();
+                                except.stack.source_lines_len = 1;
+                                except.remapped = true;
                             }
                         }
                     }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1304,7 +1304,9 @@ JSC_DEFINE_HOST_FUNCTION(functionBTOA,
     }
 
     if (!encodedString.containsOnlyLatin1()) {
-        throwException(globalObject, throwScope, createDOMException(globalObject, InvalidCharacterError));
+        auto exception = createDOMException(globalObject, InvalidCharacterError);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        throwException(globalObject, throwScope, exception);
         return {};
     }
 
@@ -1350,7 +1352,9 @@ JSC_DEFINE_HOST_FUNCTION(functionATOB,
 
     auto result = Bun::Base64::atob(encodedString);
     if (result.hasException()) {
-        throwException(globalObject, throwScope, createDOMException(*globalObject, result.releaseException()));
+        auto exception = createDOMException(*globalObject, result.releaseException());
+        RETURN_IF_EXCEPTION(throwScope, {});
+        throwException(globalObject, throwScope, exception);
         return {};
     }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -670,10 +670,14 @@ JSValue getIndexWithoutAccessors(JSGlobalObject* globalObject, JSObject* obj, ui
         return obj->tryGetIndexQuickly(i);
     }
 
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     PropertySlot slot(obj, PropertySlot::InternalMethodType::Get);
-    if (obj->methodTable()->getOwnPropertySlotByIndex(obj, globalObject, i, slot)) {
+    bool hasSlot = obj->methodTable()->getOwnPropertySlotByIndex(obj, globalObject, i, slot);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (hasSlot) {
         if (!slot.isAccessor()) {
-            return slot.getValue(globalObject, i);
+            RELEASE_AND_RETURN(scope, slot.getValue(globalObject, i));
         }
     }
 
@@ -814,6 +818,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                 return true;
             case AsymmetricMatcherResult::NOT_MATCHER:
                 // continue comparison
+                RETURN_IF_EXCEPTION(scope, false);
                 break;
             }
         } else if (v1.isCell() && !v1.isEmpty() && v1.asCell()->type() == JSC::JSType(JSDOMWrapperType)) {
@@ -824,6 +829,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                 return true;
             case AsymmetricMatcherResult::NOT_MATCHER:
                 // continue comparison
+                RETURN_IF_EXCEPTION(scope, false);
                 break;
             }
         }
@@ -850,9 +856,13 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     const auto originalGCBufferSize = gcBuffer.size();
     for (size_t i = 0; i < length; i++) {
         auto values = stack.at(i);
-        if (JSC::JSValue::strictEqual(globalObject, values.first, v1)) {
-            return JSC::JSValue::strictEqual(globalObject, values.second, v2);
-        } else if (JSC::JSValue::strictEqual(globalObject, values.second, v2))
+        bool firstMatches = JSC::JSValue::strictEqual(globalObject, values.first, v1);
+        RETURN_IF_EXCEPTION(scope, false);
+        bool secondMatches = JSC::JSValue::strictEqual(globalObject, values.second, v2);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (firstMatches)
+            return secondMatches;
+        if (secondMatches)
             return false;
     }
 
@@ -3389,14 +3399,14 @@ JSC::EncodedJSValue JSC__JSModuleLoader__evaluate(JSC::JSGlobalObject* globalObj
     WTF::URL referrer = WTF::URL::fileURLWithFileSystemPath(WTF::String::fromUTF8(std::span { referrerUrlPtr, referrerUrlLen })).isolatedCopy();
 
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSC::SourceCode sourceCode = JSC::makeSource(
         src, JSC::SourceOrigin { origin }, JSC::SourceTaintedOrigin::Untainted, origin.fileSystemPath(),
         WTF::TextPosition(), JSC::SourceProviderSourceType::Module);
     globalObject->moduleLoader()->provideFetch(globalObject, JSC::Identifier::fromString(vm, origin.fileSystemPath()), JSC::ScriptFetchParameters::Type::JavaScript, WTF::move(sourceCode));
+    RETURN_IF_EXCEPTION(scope, {});
     auto* promise = JSC::importModule(globalObject, JSC::Identifier::fromString(vm, origin.fileSystemPath()), JSC::Identifier::fromString(vm, referrer.fileSystemPath()), nullptr, nullptr);
-
-    auto scope = DECLARE_THROW_SCOPE(vm);
 
     if (scope.exception()) [[unlikely]] {
         promise->rejectWithCaughtException(vm, scope);
@@ -4103,6 +4113,7 @@ JSC::EncodedJSValue JSC__JSGlobalObject__generateHeapSnapshot(JSC::JSGlobalObjec
     snapshotBuilder.buildSnapshot();
 
     WTF::String jsonString = snapshotBuilder.json();
+    RETURN_IF_EXCEPTION(scope, {});
     JSC::EncodedJSValue result = JSC::JSValue::encode(JSONParse(globalObject, jsonString));
     scope.releaseAssertNoException();
     return result;
@@ -4933,6 +4944,7 @@ BunString JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlo
 
     if (name && name.isString()) {
         auto str = name.toWTFString(arg1);
+        RETURN_IF_EXCEPTION(scope, BunStringEmpty);
         if (!str.isEmpty()) {
             return toStringAdopt(WTF::move(str));
         }
@@ -4974,6 +4986,7 @@ BunString JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlo
         if (toStringTagValue) {
             if (toStringTagValue.isString()) {
                 displayName = toStringTagValue.toWTFString(globalObject);
+                RETURN_IF_EXCEPTION(scope, );
             }
         }
     }
@@ -5396,12 +5409,16 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__fastGetOwn(JSC::EncodedJSValue JSVa
 {
     JSC::JSValue value = JSC::JSValue::decode(JSValue0);
     ASSERT(value.isCell());
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     PropertySlot slot = PropertySlot(value, PropertySlot::InternalMethodType::GetOwnProperty);
     const Identifier name = builtinNameMap(globalObject->vm(), arg2);
     auto* object = value.getObject();
 
-    if (object->getOwnPropertySlot(object, globalObject, name, slot)) {
-        return JSValue::encode(slot.getValue(globalObject, name));
+    bool hasOwnProperty = object->getOwnPropertySlot(object, globalObject, name, slot);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (hasOwnProperty) {
+        RELEASE_AND_RETURN(scope, JSValue::encode(slot.getValue(globalObject, name)));
     }
 
     return {};
@@ -5447,7 +5464,9 @@ static void JSC__JSValue__forEachPropertyImpl(JSC::EncodedJSValue JSValue0, JSC:
         if (structure->outOfLineSize() == 0 && structure->inlineSize() == 0) {
             fast = false;
 
-            if (JSValue proto = object->getPrototype(globalObject)) {
+            JSValue proto = object->getPrototype(globalObject);
+            RETURN_IF_EXCEPTION(scope, );
+            if (proto) {
                 if ((structure = proto.structureOrNull())) {
                     prototypeObject = proto;
                     fast = canPerformFastPropertyEnumerationForIterationBun(structure);
@@ -5622,6 +5641,7 @@ restart:
                     } else if (slot.isValue()) {
                         propertyValue = slot.getValue(globalObject, property);
                     } else if (object->getOwnPropertySlot(object, globalObject, property, slot)) {
+                        RETURN_IF_EXCEPTION(scope, );
                         propertyValue = slot.getValue(globalObject, property);
                     }
                 } else if (slot.isAccessor()) {
@@ -5770,6 +5790,7 @@ extern "C" [[ZIG_EXPORT(nothrow)]] bool JSC__isBigIntInInt64Range(JSC::EncodedJS
             } else if (slot.isValue()) {
                 propertyValue = slot.getValue(globalObject, property);
             } else if (object->getOwnPropertySlot(object, globalObject, property, slot)) {
+                RETURN_IF_EXCEPTION(scope, );
                 propertyValue = slot.getValue(globalObject, property);
             }
         } else if ((slot.attributes() & PropertyAttribute::Accessor) != 0) {
@@ -5821,7 +5842,13 @@ bool JSC__JSValue__isInstanceOf(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObjec
 
 extern "C" JSC::EncodedJSValue JSC__JSValue__createRopeString(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* globalObject)
 {
-    return JSValue::encode(JSC::jsString(globalObject, JSC::JSValue::decode(JSValue0).toString(globalObject), JSC::JSValue::decode(JSValue1).toString(globalObject)));
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSString* str0 = JSC::JSValue::decode(JSValue0).toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSString* str1 = JSC::JSValue::decode(JSValue1).toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSC::jsString(globalObject, str0, str1)));
 }
 
 extern "C" size_t JSC__VM__blockBytesAllocated(JSC::VM* vm)
@@ -6033,12 +6060,12 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__getOwnByValue(JSC::EncodedJSValue v
 
     PropertySlot slot(object, PropertySlot::InternalMethodType::GetOwnProperty);
     if (property.getUInt32(index)) {
-        if (!object->getOwnPropertySlotByIndex(object, globalObject, index, slot))
+        bool hasSlot = object->getOwnPropertySlotByIndex(object, globalObject, index, slot);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (!hasSlot)
             return {};
 
-        RETURN_IF_EXCEPTION(scope, {});
-
-        return JSC::JSValue::encode(slot.getValue(globalObject, index));
+        RELEASE_AND_RETURN(scope, JSC::JSValue::encode(slot.getValue(globalObject, index)));
     } else {
         auto propertyName = property.toPropertyKey(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
@@ -6047,7 +6074,7 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__getOwnByValue(JSC::EncodedJSValue v
 
         RETURN_IF_EXCEPTION(scope, {});
 
-        return JSC::JSValue::encode(slot.getValue(globalObject, propertyName));
+        RELEASE_AND_RETURN(scope, JSC::JSValue::encode(slot.getValue(globalObject, propertyName)));
     }
 }
 

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -684,11 +684,13 @@ void JSNodeHTTPServerSocket::onClose()
                 if (auto* ptr = exception.get()) {
                     exception.clear();
                     globalObject->reportUncaughtExceptionAtEventLoop(globalObject, ptr);
+                    RETURN_IF_EXCEPTION(scope, );
                 }
             } else if (!vm.hasPendingTerminationException()) {
                 auto* ptr = scope.exception();
                 scope.clearException();
                 globalObject->reportUncaughtExceptionAtEventLoop(globalObject, ptr);
+                RETURN_IF_EXCEPTION(scope, );
             }
         }
         thisObject->detach();
@@ -711,6 +713,7 @@ void JSNodeHTTPServerSocket::onDrain()
         if (auto* exception = scope.exception()) {
             (void)scope.tryClearException();
             globalObject->reportUncaughtExceptionAtEventLoop(globalObject, exception);
+            RETURN_IF_EXCEPTION(scope, );
             return;
         }
         bufferedSize = this->streamBuffer.bufferedSize();
@@ -764,6 +767,7 @@ void JSNodeHTTPServerSocket::onData(const char* data, int length, bool last)
         if (auto* exception = scope.exception()) {
             (void)scope.tryClearException();
             globalObject->reportUncaughtExceptionAtEventLoop(globalObject, exception);
+            RETURN_IF_EXCEPTION(scope, );
             return;
         }
         gcProtect(chunk);

--- a/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoPrimes.cpp
@@ -243,6 +243,7 @@ JSValue GeneratePrimeJob::result(JSGlobalObject* globalObject, JSC::ThrowScope& 
         }
 
         JSValue result = JSBigInt::parseInt(globalObject, vm, primeHex.span(), 16, JSBigInt::ErrorParseMode::IgnoreExceptions, JSBigInt::ParseIntSign::Unsigned);
+        RETURN_IF_EXCEPTION(scope, {});
         if (result.isEmpty()) {
             ERR::CRYPTO_OPERATION_FAILED(scope, globalObject, "could not generate prime"_s);
             return {};
@@ -472,7 +473,7 @@ JSC_DEFINE_HOST_FUNCTION(jsGeneratePrimeSync, (JSC::JSGlobalObject * lexicalGlob
     if (!prime.generate({ .bits = size, .safe = safe, .add = add, .rem = rem }, whileScriptAllowed(lexicalGlobalObject))) [[unlikely]]
         return ERR::CRYPTO_OPERATION_FAILED(scope, lexicalGlobalObject, "could not generate prime"_s);
 
-    return JSValue::encode(GeneratePrimeJob::result(lexicalGlobalObject, scope, prime, bigint));
+    RELEASE_AND_RETURN(scope, JSValue::encode(GeneratePrimeJob::result(lexicalGlobalObject, scope, prime, bigint)));
 }
 
 } // namespace Bun

--- a/src/jsc/bindings/node/crypto/CryptoUtil.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoUtil.cpp
@@ -488,6 +488,7 @@ JSValue createCryptoError(JSC::JSGlobalObject* globalObject, ThrowScope& scope, 
         for (int32_t i = 0; i < errorStack.size(); i++) {
             WTF::String error = errorStack.pop_back().value();
             arr->putDirectIndex(globalObject, i, jsString(vm, error));
+            RETURN_IF_EXCEPTION(scope, {});
         }
         errorObject->put(errorObject, globalObject, Identifier::fromString(vm, "opensslErrorStack"_s), arr, stackSlot);
         RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/node/crypto/JSDiffieHellmanGroupConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellmanGroupConstructor.cpp
@@ -54,7 +54,6 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellmanGroup, (JSC::JSGlobalObject * glo
     JSC::JSValue newTarget = callFrame->newTarget();
 
     if (zigGlobalObject->m_JSDiffieHellmanGroupClassStructure.constructor(zigGlobalObject) != newTarget) [[unlikely]] {
-        auto scope = DECLARE_THROW_SCOPE(vm);
         if (!newTarget) {
             throwError(globalObject, scope, ErrorCode::ERR_INVALID_THIS, "Class constructor DiffieHellmanGroup cannot be invoked without 'new'"_s);
             return {};

--- a/src/jsc/bindings/node/crypto/JSPrivateKeyObjectPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSPrivateKeyObjectPrototype.cpp
@@ -66,5 +66,5 @@ JSC_DEFINE_HOST_FUNCTION(jsPrivateKeyObjectPrototype_toCryptoKey, (JSGlobalObjec
     JSValue extractableValue = callFrame->argument(1);
     JSValue keyUsagesValue = callFrame->argument(2);
 
-    return JSValue::encode(handle.toCryptoKey(globalObject, scope, algorithmValue, extractableValue, keyUsagesValue));
+    RELEASE_AND_RETURN(scope, JSValue::encode(handle.toCryptoKey(globalObject, scope, algorithmValue, extractableValue, keyUsagesValue)));
 }

--- a/src/jsc/bindings/node/crypto/JSPublicKeyObjectPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSPublicKeyObjectPrototype.cpp
@@ -66,5 +66,5 @@ JSC_DEFINE_HOST_FUNCTION(jsPublicKeyObjectPrototype_toCryptoKey, (JSGlobalObject
     JSValue extractableValue = callFrame->argument(1);
     JSValue keyUsagesValue = callFrame->argument(2);
 
-    return JSValue::encode(handle.toCryptoKey(globalObject, scope, algorithmValue, extractableValue, keyUsagesValue));
+    RELEASE_AND_RETURN(scope, JSValue::encode(handle.toCryptoKey(globalObject, scope, algorithmValue, extractableValue, keyUsagesValue)));
 }

--- a/src/jsc/bindings/node/crypto/JSSecretKeyObjectPrototype.cpp
+++ b/src/jsc/bindings/node/crypto/JSSecretKeyObjectPrototype.cpp
@@ -85,5 +85,5 @@ JSC_DEFINE_HOST_FUNCTION(jsSecretKeyObjectToCryptoKey, (JSGlobalObject * globalO
     JSValue extractableValue = callFrame->argument(1);
     JSValue keyUsagesValue = callFrame->argument(2);
 
-    return JSValue::encode(handle.toCryptoKey(globalObject, scope, algorithmValue, extractableValue, keyUsagesValue));
+    RELEASE_AND_RETURN(scope, JSValue::encode(handle.toCryptoKey(globalObject, scope, algorithmValue, extractableValue, keyUsagesValue)));
 }

--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -176,9 +176,11 @@ JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject,
         }
     })();
 
+    auto crvKey = commonStrings.jwkCrvString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(
         vm,
-        Identifier::fromString(vm, commonStrings.jwkCrvString(lexicalGlobalObject)->value(lexicalGlobalObject)),
+        Identifier::fromString(vm, crvKey),
         jsString(vm, makeString(curve)));
 
     if (exportType == CryptoKeyType::Private) {
@@ -186,18 +188,22 @@ JSC::JSValue KeyObject::exportJwkEdKey(JSC::JSGlobalObject* lexicalGlobalObject,
 
         JSValue encoded = JSValue::decode(StringBytes::encode(lexicalGlobalObject, scope, privateData.span(), BufferEncodingType::base64url));
         RETURN_IF_EXCEPTION(scope, {});
+        auto dKey = commonStrings.jwkDString(lexicalGlobalObject)->value(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
         jwk->putDirect(
             vm,
-            Identifier::fromString(vm, commonStrings.jwkDString(lexicalGlobalObject)->value(lexicalGlobalObject)),
+            Identifier::fromString(vm, dKey),
             encoded);
     }
 
     ncrypto::DataPointer publicData = pkey.rawPublicKey();
     JSValue encoded = JSValue::decode(StringBytes::encode(lexicalGlobalObject, scope, publicData.span(), BufferEncodingType::base64url));
     RETURN_IF_EXCEPTION(scope, {});
+    auto xKey = commonStrings.jwkXString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(
         vm,
-        Identifier::fromString(vm, commonStrings.jwkXString(lexicalGlobalObject)->value(lexicalGlobalObject)),
+        Identifier::fromString(vm, xKey),
         encoded);
 
     jwk->putDirect(
@@ -237,9 +243,11 @@ JSC::JSValue KeyObject::exportJwkEcKey(JSC::JSGlobalObject* lexicalGlobalObject,
 
     JSObject* jwk = JSC::constructEmptyObject(lexicalGlobalObject);
 
+    auto ktyKey = commonStrings.jwkKtyString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(
         vm,
-        Identifier::fromString(vm, commonStrings.jwkKtyString(lexicalGlobalObject)->value(lexicalGlobalObject)),
+        Identifier::fromString(vm, ktyKey),
         commonStrings.jwkEcString(lexicalGlobalObject));
 
     setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkXString(lexicalGlobalObject), x.get(), degree_bytes);
@@ -268,9 +276,11 @@ JSC::JSValue KeyObject::exportJwkEcKey(JSC::JSGlobalObject* lexicalGlobalObject,
     }
     }
 
+    auto crvKey = commonStrings.jwkCrvString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(
         vm,
-        Identifier::fromString(vm, commonStrings.jwkCrvString(lexicalGlobalObject)->value(lexicalGlobalObject)),
+        Identifier::fromString(vm, crvKey),
         jsString(vm, makeString(crvName)));
 
     if (exportType == CryptoKeyType::Private) {
@@ -295,8 +305,10 @@ JSC::JSValue KeyObject::exportJwkRsaKey(JSC::JSGlobalObject* lexicalGlobalObject
 
     auto publicKey = rsa.getPublicKey();
 
+    auto ktyKey = commonStrings.jwkKtyString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(vm,
-        Identifier::fromString(vm, commonStrings.jwkKtyString(lexicalGlobalObject)->value(lexicalGlobalObject)),
+        Identifier::fromString(vm, ktyKey),
         commonStrings.jwkRsaString(lexicalGlobalObject));
 
     setEncodedValue(lexicalGlobalObject, scope, jwk, commonStrings.jwkNString(lexicalGlobalObject), publicKey.n);
@@ -334,8 +346,10 @@ JSC::JSValue KeyObject::exportJwkSecretKey(JSC::JSGlobalObject* lexicalGlobalObj
     JSValue encoded = JSValue::decode(StringBytes::encode(lexicalGlobalObject, scope, m_data->symmetricKey, BufferEncodingType::base64url));
     RETURN_IF_EXCEPTION(scope, {});
 
+    auto ktyKey = commonStrings.jwkKtyString(lexicalGlobalObject)->value(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
     jwk->putDirect(vm,
-        Identifier::fromString(vm, commonStrings.jwkKtyString(lexicalGlobalObject)->value(lexicalGlobalObject)),
+        Identifier::fromString(vm, ktyKey),
         commonStrings.jwkOctString(lexicalGlobalObject));
 
     jwk->putDirect(vm,
@@ -790,6 +804,7 @@ void KeyObject::getRsaKeyDetails(JSGlobalObject* globalObject, ThrowScope& scope
     }
 
     JSValue publicExponent = JSBigInt::parseInt(globalObject, vm, publicExponentHex.span(), 16, JSBigInt::ErrorParseMode::IgnoreExceptions, JSBigInt::ParseIntSign::Unsigned);
+    RETURN_IF_EXCEPTION(scope, );
     if (!publicExponent) {
         ERR::CRYPTO_OPERATION_FAILED(scope, globalObject, "Failed to create public exponent"_s);
         return;

--- a/src/jsc/bindings/node/http/JSConnectionsList.cpp
+++ b/src/jsc/bindings/node/http/JSConnectionsList.cpp
@@ -62,13 +62,16 @@ JSArray* JSConnectionsList::all(JSGlobalObject* globalObject)
     JSValue item;
     size_t i = 0;
     while (iter->next(globalObject, item)) {
+        RETURN_IF_EXCEPTION(scope, nullptr);
         JSHTTPParser* parser = dynamicDowncast<JSHTTPParser>(item);
         if (!parser) {
             continue;
         }
 
         result->putDirectIndex(globalObject, i++, parser);
+        RETURN_IF_EXCEPTION(scope, nullptr);
     }
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
     return result;
 }
@@ -88,6 +91,7 @@ JSArray* JSConnectionsList::idle(JSGlobalObject* globalObject)
     JSValue item;
     size_t i = 0;
     while (iter->next(globalObject, item)) {
+        RETURN_IF_EXCEPTION(scope, nullptr);
         JSHTTPParser* parser = dynamicDowncast<JSHTTPParser>(item);
         if (!parser) {
             continue;
@@ -95,8 +99,10 @@ JSArray* JSConnectionsList::idle(JSGlobalObject* globalObject)
 
         if (parser->impl()->lastMessageStart() == 0) {
             result->putDirectIndex(globalObject, i++, parser);
+            RETURN_IF_EXCEPTION(scope, nullptr);
         }
     }
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
     return result;
 }
@@ -116,13 +122,16 @@ JSArray* JSConnectionsList::active(JSGlobalObject* globalObject)
     JSValue item;
     size_t i = 0;
     while (iter->next(globalObject, item)) {
+        RETURN_IF_EXCEPTION(scope, nullptr);
         JSHTTPParser* parser = dynamicDowncast<JSHTTPParser>(item);
         if (!parser) {
             continue;
         }
 
         result->putDirectIndex(globalObject, i++, parser);
+        RETURN_IF_EXCEPTION(scope, nullptr);
     }
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
     return result;
 }
@@ -142,6 +151,7 @@ JSArray* JSConnectionsList::expired(JSGlobalObject* globalObject, uint64_t heade
     JSValue item;
     size_t i = 0;
     while (iter->next(globalObject, item)) {
+        RETURN_IF_EXCEPTION(scope, nullptr);
         JSHTTPParser* parser = dynamicDowncast<JSHTTPParser>(item);
         if (!parser) {
             continue;
@@ -149,9 +159,12 @@ JSArray* JSConnectionsList::expired(JSGlobalObject* globalObject, uint64_t heade
 
         if ((!parser->impl()->headersCompleted() && headersDeadline > 0 && parser->impl()->lastMessageStart() < headersDeadline) || (requestDeadline > 0 && parser->impl()->lastMessageStart() < requestDeadline)) {
             result->putDirectIndex(globalObject, i++, item);
+            RETURN_IF_EXCEPTION(scope, nullptr);
             active->remove(globalObject, item);
+            RETURN_IF_EXCEPTION(scope, nullptr);
         }
     }
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
     return result;
 }

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -906,12 +906,14 @@ static inline bool rebindValue(JSC::JSGlobalObject* lexicalGlobalObject, sqlite3
         CHECK_BIND(sqlite3_bind_double(stmt, i, value.asDouble()))
     } else if (value.isString()) {
         auto* str = value.toStringOrNull(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, false);
         if (!str) [[unlikely]] {
             throwException(lexicalGlobalObject, scope, createTypeError(lexicalGlobalObject, "Expected string"_s));
             return false;
         }
 
         const auto roped = str->view(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, false);
         if (roped->isNull()) [[unlikely]] {
             throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Out of memory :("_s));
             return false;
@@ -936,7 +938,9 @@ static inline bool rebindValue(JSC::JSGlobalObject* lexicalGlobalObject, sqlite3
             if ((min == JSBigInt::ComparisonResult::GreaterThan || min == JSBigInt::ComparisonResult::Equal) && (max == JSBigInt::ComparisonResult::LessThan || max == JSBigInt::ComparisonResult::Equal)) [[likely]] {
                 CHECK_BIND(sqlite3_bind_int64(stmt, i, JSBigInt::toBigInt64(value)));
             } else {
-                throwRangeError(lexicalGlobalObject, scope, makeString("BigInt value '"_s, bigInt->toString(lexicalGlobalObject, 10), "' is out of range"_s));
+                auto bigIntString = bigInt->toString(lexicalGlobalObject, 10);
+                RETURN_IF_EXCEPTION(scope, false);
+                throwRangeError(lexicalGlobalObject, scope, makeString("BigInt value '"_s, bigIntString, "' is out of range"_s));
                 sqlite3_clear_bindings(stmt);
                 return false;
             }
@@ -1018,6 +1022,7 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
             auto* name = sqlite3_bind_parameter_name(stmt, i + 1);
 
             JSValue value = getValue(name, i);
+            RETURN_IF_EXCEPTION(scope, {});
             if (!statementStillAlive())
                 return {};
             if (!value && !scope.exception()) {
@@ -1045,6 +1050,7 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
     else if (bindings.isOnlyIndexed) [[unlikely]] {
         for (size_t i = 0; i < size; i++) {
             JSValue value = target->getDirectIndex(globalObject, i);
+            RETURN_IF_EXCEPTION(scope, {});
             if (!statementStillAlive())
                 return {};
             if (!value && !scope.exception()) {
@@ -1091,6 +1097,7 @@ static JSC::JSValue rebindObject(JSC::JSGlobalObject* globalObject, SQLiteBindin
                             value = target->get(globalObject, property);
                     }
                 }
+                RETURN_IF_EXCEPTION(scope, {});
                 if (!statementStillAlive())
                     return {};
                 structure = target->structure();
@@ -1338,6 +1345,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementSerialize, (JSC::JSGlobalObject * lexical
     }
 
     int32_t dbIndex = callFrame->argument(0).toInt32(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
     VersionSqlite3* versionDB = databaseForHandle(dbIndex);
     if (!versionDB) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Invalid database handle"_s));
@@ -1382,6 +1390,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementLoadExtensionFunction, (JSC::JSGlobalObje
     }
 
     int32_t dbIndex = callFrame->argument(0).toInt32(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
     VersionSqlite3* versionDB = databaseForHandle(dbIndex);
     if (!versionDB) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Invalid database handle"_s));
@@ -1451,6 +1460,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
     }
 
     int32_t handle = callFrame->argument(0).toInt32(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
     VersionSqlite3* versionDB = databaseForHandle(handle);
     if (!versionDB) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "Invalid database handle"_s));
@@ -1482,6 +1492,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementExecuteFunction, (JSC::JSGlobalObject * l
     }
 
     Bun::UTF8View utf8 = Bun::UTF8View(jsSqlString->view(lexicalGlobalObject));
+    RETURN_IF_EXCEPTION(scope, {});
 
     const char* sqlStringHead = utf8.span().data();
     const char* end = utf8.span().data() + utf8.span().size();
@@ -1609,7 +1620,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementIsInTransactionFunction, (JSC::JSGlobalOb
         return {};
     }
 
-    int32_t handle = dbNumber.toInt32(lexicalGlobalObject);
+    int32_t handle = JSC::toInt32(dbNumber.asNumber());
 
     VersionSqlite3* versionDB = databaseForHandle(handle);
     if (!versionDB) [[unlikely]] {
@@ -1650,7 +1661,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementPrepareStatementFunction, (JSC::JSGlobalO
         return {};
     }
 
-    int32_t handle = dbNumber.toInt32(lexicalGlobalObject);
+    int32_t handle = JSC::toInt32(dbNumber.asNumber());
     VersionSqlite3* versionDB = databaseForHandle(handle);
     if (!versionDB) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createRangeError(lexicalGlobalObject, "Invalid database handle"_s));
@@ -1676,7 +1687,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementPrepareStatementFunction, (JSC::JSGlobalO
     unsigned int flags = DEFAULT_SQLITE_PREPARE_FLAGS;
     if (prepareFlagsValue.isNumber()) {
 
-        int prepareFlags = prepareFlagsValue.toInt32(lexicalGlobalObject);
+        int prepareFlags = JSC::toInt32(prepareFlagsValue.asNumber());
         if (prepareFlags < 0 || prepareFlags > MAX_SQLITE_PREPARE_FLAG) {
             throwException(lexicalGlobalObject, scope, createRangeError(lexicalGlobalObject, "Invalid prepare flags"_s));
             return {};
@@ -1768,7 +1779,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementOpenStatementFunction, (JSC::JSGlobalObje
             return {};
         }
 
-        openFlags = flags.toInt32(lexicalGlobalObject);
+        openFlags = JSC::toInt32(flags.asNumber());
     }
 
     JSValue finalizationTarget = callFrame->argument(2);
@@ -1828,7 +1839,7 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementCloseStatementFunction, (JSC::JSGlobalObj
         return {};
     }
 
-    int dbIndex = dbNumber.toInt32(lexicalGlobalObject);
+    int dbIndex = JSC::toInt32(dbNumber.asNumber());
 
     VersionSqlite3* versionDB = databaseForHandle(dbIndex);
     if (!versionDB) {
@@ -1908,8 +1919,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementFcntlFunction, (JSC::JSGlobalObject * lex
         return {};
     }
 
-    int dbIndex = dbNumber.toInt32(lexicalGlobalObject);
-    int op = opNumber.toInt32(lexicalGlobalObject);
+    int dbIndex = JSC::toInt32(dbNumber.asNumber());
+    int op = JSC::toInt32(opNumber.asNumber());
 
     VersionSqlite3* versionDB = databaseForHandle(dbIndex);
     if (!versionDB) {
@@ -2969,6 +2980,7 @@ template void JSSQLStatement::visitOutputConstraints(JSCell*, SlotVisitor&);
 JSValue createJSSQLStatementConstructor(Zig::GlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSObject* object = JSC::constructEmptyObject(globalObject);
     auto* diff = InternalFieldTuple::create(vm, globalObject->internalFieldTupleStructure(), jsUndefined(), jsUndefined());
 
@@ -2976,9 +2988,12 @@ JSValue createJSSQLStatementConstructor(Zig::GlobalObject* globalObject)
         vm,
         globalObject,
         JSSQLStatementConstructor::createStructure(vm, globalObject, globalObject->m_functionPrototype.get()));
+    RETURN_IF_EXCEPTION(scope, {});
 
     object->putDirectIndex(globalObject, 0, constructor);
+    RETURN_IF_EXCEPTION(scope, {});
     object->putDirectIndex(globalObject, 1, diff);
+    RETURN_IF_EXCEPTION(scope, {});
 
     return object;
 }

--- a/src/jsc/bindings/webcore/AbortSignal.cpp
+++ b/src/jsc/bindings/webcore/AbortSignal.cpp
@@ -344,7 +344,9 @@ void AbortSignal::throwIfAborted(JSC::JSGlobalObject& lexicalGlobalObject)
 
     Ref vm = lexicalGlobalObject.vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    throwException(&lexicalGlobalObject, scope, jsReason(lexicalGlobalObject));
+    JSValue reason = jsReason(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, );
+    throwException(&lexicalGlobalObject, scope, reason);
 }
 
 WebCoreOpaqueRoot root(AbortSignal* signal)

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -105,10 +105,16 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCookieMapDOMConstructo
 
     std::variant<Vector<Vector<String>>, HashMap<String, String>, String> init;
 
-    if (initValue.isUndefinedOrNull() || (initValue.isString() && initValue.getString(lexicalGlobalObject).isEmpty())) {
+    String initString;
+    if (initValue.isString()) {
+        initString = initValue.getString(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+    }
+
+    if (initValue.isUndefinedOrNull() || (initValue.isString() && initString.isEmpty())) {
         init = String();
     } else if (initValue.isString()) {
-        init = initValue.getString(lexicalGlobalObject);
+        init = WTF::move(initString);
     } else if (initValue.isObject()) {
         auto* object = initValue.getObject();
 
@@ -138,9 +144,13 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCookieMapDOMConstructo
                 auto second = subArray->getIndex(lexicalGlobalObject, 1);
                 RETURN_IF_EXCEPTION(throwScope, {});
 
-                auto firstStr = first.toString(lexicalGlobalObject)->value(lexicalGlobalObject);
+                auto* firstString = first.toString(lexicalGlobalObject);
                 RETURN_IF_EXCEPTION(throwScope, {});
-                auto secondStr = second.toString(lexicalGlobalObject)->value(lexicalGlobalObject);
+                auto firstStr = firstString->value(lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                auto* secondString = second.toString(lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                auto secondStr = secondString->value(lexicalGlobalObject);
                 RETURN_IF_EXCEPTION(throwScope, {});
 
                 Vector<String> pair;
@@ -164,7 +174,9 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCookieMapDOMConstructo
                 JSValue value = object->get(lexicalGlobalObject, propertyName);
                 RETURN_IF_EXCEPTION(throwScope, {});
 
-                auto valueStr = value.toString(lexicalGlobalObject)->value(lexicalGlobalObject);
+                auto* valueString = value.toString(lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(throwScope, {});
+                auto valueStr = valueString->value(lexicalGlobalObject);
                 RETURN_IF_EXCEPTION(throwScope, {});
 
                 Vector<String> pair;

--- a/src/jsc/bindings/webcore/JSDOMConvertBase.h
+++ b/src/jsc/bindings/webcore/JSDOMConvertBase.h
@@ -176,6 +176,7 @@ template<typename T, typename U> inline JSC::JSValue toJS(JSC::JSGlobalObject& l
             return JSC::jsUndefined();
         } else if constexpr (std::is_same_v<ExceptionOr<void>, FunctorReturnType>) {
             auto result = valueOrFunctor();
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (result.hasException()) [[unlikely]] {
                 propagateException(lexicalGlobalObject, throwScope, result.releaseException());
                 return {};

--- a/src/jsc/bindings/webcore/JSDOMConvertBase.h
+++ b/src/jsc/bindings/webcore/JSDOMConvertBase.h
@@ -207,6 +207,7 @@ template<typename T, typename U> inline JSC::JSValue toJS(JSC::JSGlobalObject& l
             return JSC::jsUndefined();
         } else if constexpr (std::is_same_v<ExceptionOr<void>, FunctorReturnType>) {
             auto result = valueOrFunctor();
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (result.hasException()) [[unlikely]] {
                 propagateException(lexicalGlobalObject, throwScope, result.releaseException());
                 return {};
@@ -237,6 +238,7 @@ template<typename T, typename U> inline JSC::JSValue toJSNewlyCreated(JSC::JSGlo
             return JSC::jsUndefined();
         } else if constexpr (std::is_same_v<ExceptionOr<void>, FunctorReturnType>) {
             auto result = valueOrFunctor();
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (result.hasException()) [[unlikely]] {
                 propagateException(lexicalGlobalObject, throwScope, result.releaseException());
                 return {};

--- a/src/jsc/bindings/webcore/JSDOMConvertNumbers.h
+++ b/src/jsc/bindings/webcore/JSDOMConvertNumbers.h
@@ -277,8 +277,10 @@ template<> struct Converter<IDLFloat> : DefaultConverter<IDLFloat> {
         auto scope = DECLARE_THROW_SCOPE(vm);
         double number = value.toNumber(&lexicalGlobalObject);
         RETURN_IF_EXCEPTION(scope, 0.0);
-        if (number < std::numeric_limits<float>::lowest() || number > std::numeric_limits<float>::max()) [[unlikely]]
+        if (number < std::numeric_limits<float>::lowest() || number > std::numeric_limits<float>::max()) [[unlikely]] {
             throwTypeError(&lexicalGlobalObject, scope, "The provided value is outside the range of a float"_s);
+            return 0.0;
+        }
         if (!std::isfinite(number)) [[unlikely]]
             throwNonFiniteTypeError(lexicalGlobalObject, scope);
         return static_cast<float>(number);

--- a/src/jsc/bindings/webcore/JSDOMConvertStrings.h
+++ b/src/jsc/bindings/webcore/JSDOMConvertStrings.h
@@ -143,7 +143,11 @@ template<typename T> struct Converter<IDLAtomStringAdaptor<T>> : DefaultConverte
     {
         static_assert(std::is_same<T, IDLDOMString>::value, "This adaptor is only supported for IDLDOMString at the moment.");
 
-        return value.toString(&lexicalGlobalObject)->toAtomString(&lexicalGlobalObject).data;
+        auto& vm = JSC::getVM(&lexicalGlobalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        auto* string = value.toString(&lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        RELEASE_AND_RETURN(scope, string->toAtomString(&lexicalGlobalObject).data);
     }
 };
 

--- a/src/jsc/bindings/webcore/JSDOMIterator.h
+++ b/src/jsc/bindings/webcore/JSDOMIterator.h
@@ -139,7 +139,13 @@ inline JSC::JSValue jsPair(JSC::JSGlobalObject&, JSDOMGlobalObject& globalObject
 template<typename FirstType, typename SecondType, typename T, typename U>
 inline JSC::JSValue jsPair(JSC::JSGlobalObject& lexicalGlobalObject, JSDOMGlobalObject& globalObject, const T& value1, const U& value2)
 {
-    return jsPair(lexicalGlobalObject, globalObject, toJS<FirstType>(lexicalGlobalObject, globalObject, value1), toJS<SecondType>(lexicalGlobalObject, globalObject, value2));
+    auto& vm = JSC::getVM(&lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto first = toJS<FirstType>(lexicalGlobalObject, globalObject, value1);
+    RETURN_IF_EXCEPTION(scope, {});
+    auto second = toJS<SecondType>(lexicalGlobalObject, globalObject, value2);
+    RETURN_IF_EXCEPTION(scope, {});
+    RELEASE_AND_RETURN(scope, jsPair(lexicalGlobalObject, globalObject, first, second));
 }
 
 template<typename JSIterator> JSC::JSValue iteratorCreate(typename JSIterator::Wrapper&, IterationKind);
@@ -222,6 +228,7 @@ template<typename JSIterator> JSC::JSValue iteratorForEach(JSC::JSGlobalObject& 
     while (auto value = iterator.next()) {
         JSC::MarkedArgumentBuffer arguments;
         appendForEachArguments<JSIterator>(lexicalGlobalObject, *thisObject.globalObject(), arguments, value);
+        RETURN_IF_EXCEPTION(scope, {});
         arguments.append(&thisObject);
         if (arguments.hasOverflowed()) [[unlikely]] {
             throwOutOfMemoryError(&lexicalGlobalObject, scope);

--- a/src/jsc/bindings/webcore/JSEventEmitter.cpp
+++ b/src/jsc/bindings/webcore/JSEventEmitter.cpp
@@ -114,7 +114,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSEventEmitterDOMConstru
     JSValue maxListeners = castedThis->getIfPropertyExists(lexicalGlobalObject, JSC::Identifier::fromString(vm, "defaultMaxListeners"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (maxListeners && maxListeners.isUInt32()) {
-        object->setMaxListeners(maxListeners.toUInt32(lexicalGlobalObject));
+        object->setMaxListeners(maxListeners.asUInt32());
     }
     static_assert(TypeOrExceptionOrUnderlyingType<decltype(object)>::isRef);
     auto jsValue = toJSNewlyCreated<IDLInterface<EventEmitter>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, WTF::move(object));
@@ -143,7 +143,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSEventEmitterDOMConstru
     JSValue maxListeners = castedThis->getIfPropertyExists(lexicalGlobalObject, JSC::Identifier::fromString(vm, "defaultMaxListeners"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (maxListeners && maxListeners.isUInt32()) {
-        object->setMaxListeners(maxListeners.toUInt32(lexicalGlobalObject));
+        object->setMaxListeners(maxListeners.asUInt32());
     }
     static_assert(TypeOrExceptionOrUnderlyingType<decltype(object)>::isRef);
     auto jsValue = toJSNewlyCreated<IDLInterface<EventEmitter>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, object.copyRef());
@@ -307,7 +307,7 @@ static inline JSC::EncodedJSValue jsEventEmitterPrototypeFunction_setMaxListener
         throwTypeError(lexicalGlobalObject, throwScope, "The maxListeners argument must be a number"_s);
         return JSC::JSValue::encode(JSC::jsUndefined());
     }
-    unsigned maxListeners = argument0.value().toUInt32(lexicalGlobalObject);
+    unsigned maxListeners = JSC::toUInt32(argument0.value().asNumber());
 
     impl.setMaxListeners(maxListeners);
     return JSC::JSValue::encode(JSC::jsUndefined());

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -663,6 +663,7 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
             const auto& name = it.key;
             const auto& value = it.value;
             obj->putDirectMayBeIndex(lexicalGlobalObject, Identifier::fromString(vm, lowercaseHeaderName(name)), jsString(vm, value));
+            RETURN_IF_EXCEPTION(throwScope, {});
         }
     }
 

--- a/src/jsc/bindings/webcore/JSPerformance.cpp
+++ b/src/jsc/bindings/webcore/JSPerformance.cpp
@@ -463,7 +463,9 @@ static inline JSC::EncodedJSValue jsPerformancePrototypeFunction_markBody(JSC::J
     EnsureStillAliveScope argument1 = callFrame->argument(1);
     auto markOptions = convert<IDLDictionary<PerformanceMarkOptions>>(*lexicalGlobalObject, argument1.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLInterface<PerformanceMark>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, impl.mark(*uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), WTF::move(markName), WTF::move(markOptions)))));
+    auto result = impl.mark(*uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), WTF::move(markName), WTF::move(markOptions));
+    RETURN_IF_EXCEPTION(throwScope, {});
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLInterface<PerformanceMark>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, WTF::move(result))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsPerformancePrototypeFunction_mark, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -509,7 +511,9 @@ static inline JSC::EncodedJSValue jsPerformancePrototypeFunction_measureBody(JSC
     EnsureStillAliveScope argument2 = callFrame->argument(2);
     auto endMark = argument2.value().isUndefined() ? String() : convert<IDLDOMString>(*lexicalGlobalObject, argument2.value());
     RETURN_IF_EXCEPTION(throwScope, {});
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLInterface<PerformanceMeasure>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, impl.measure(*uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), WTF::move(measureName), WTF::move(startOrMeasureOptions), WTF::move(endMark)))));
+    auto result = impl.measure(*uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject), WTF::move(measureName), WTF::move(startOrMeasureOptions), WTF::move(endMark));
+    RETURN_IF_EXCEPTION(throwScope, {});
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLInterface<PerformanceMeasure>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, WTF::move(result))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsPerformancePrototypeFunction_measure, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/JSURLPattern.cpp
+++ b/src/jsc/bindings/webcore/JSURLPattern.cpp
@@ -423,7 +423,9 @@ static inline JSC::EncodedJSValue jsURLPatternPrototypeFunction_testBody(JSC::JS
     EnsureStillAliveScope argument1 = callFrame->argument(1);
     auto baseURL = argument1.value().isUndefined() ? String() : convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLBoolean>(*lexicalGlobalObject, throwScope, impl.test(*context, convertToOptionalWTFVariant(WTF::move(input)), WTF::move(baseURL)))));
+    auto result = impl.test(*context, convertToOptionalWTFVariant(WTF::move(input)), WTF::move(baseURL));
+    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLBoolean>(*lexicalGlobalObject, throwScope, WTF::move(result))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsURLPatternPrototypeFunction_test, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -447,7 +449,9 @@ static inline JSC::EncodedJSValue jsURLPatternPrototypeFunction_execBody(JSC::JS
     EnsureStillAliveScope argument1 = callFrame->argument(1);
     auto baseURL = argument1.value().isUndefined() ? String() : convert<IDLUSVString>(*lexicalGlobalObject, argument1.value());
     RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLNullable<IDLDictionary<URLPatternResult>>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, impl.exec(*context, convertToOptionalWTFVariant(WTF::move(input)), WTF::move(baseURL)))));
+    auto result = impl.exec(*context, convertToOptionalWTFVariant(WTF::move(input)), WTF::move(baseURL));
+    RETURN_IF_EXCEPTION(throwScope, encodedJSValue());
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLNullable<IDLDictionary<URLPatternResult>>>(*lexicalGlobalObject, *castedThis->globalObject(), throwScope, WTF::move(result))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsURLPatternPrototypeFunction_exec, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -359,6 +359,7 @@ template<> __attribute__((minsize)) JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES
     // Reports a DataCloneError through ExceptionOr, but a getter or toJSON that throws during serialization
     // leaves that exception on the VM and returns normally.
     ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*lexicalGlobalObject, valueToTransfer, WTF::move(transferList), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
+    RETURN_IF_EXCEPTION(throwScope, {});
     if (serialized.hasException()) {
         WebCore::propagateException(*lexicalGlobalObject, throwScope, serialized.releaseException());
         RELEASE_AND_RETURN(throwScope, {});

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -137,6 +137,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
                 JSC::JSValue::encode(JSC::jsUndefined()));
             CLEAR_IF_EXCEPTION(warnScope);
             close();
+            RETURN_IF_EXCEPTION(warnScope, Exception { ExistingExceptionError });
             return {};
         }
     }

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -876,9 +876,13 @@ private:
 
     JSValue getProperty(JSObject* object, const Identifier& propertyName)
     {
+        VM& vm = m_lexicalGlobalObject->vm();
+        auto scope = DECLARE_THROW_SCOPE(vm);
         PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-        if (object->methodTable()->getOwnPropertySlot(object, m_lexicalGlobalObject, propertyName, slot))
-            return slot.getValue(m_lexicalGlobalObject, propertyName);
+        bool found = object->methodTable()->getOwnPropertySlot(object, m_lexicalGlobalObject, propertyName, slot);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (found)
+            RELEASE_AND_RETURN(scope, slot.getValue(m_lexicalGlobalObject, propertyName));
         return JSValue();
     }
 
@@ -1156,6 +1160,7 @@ private:
                 if (!startObjectInternal(stringObject)) // handle duplicates
                     return true;
                 String str = asString(stringObject->internalValue())->value(m_lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(scope, false);
                 dumpStringObject(str);
                 return true;
             }
@@ -1412,6 +1417,7 @@ private:
                 StructuredCloneableSerialize to_write = WTF::move(_cloneable.value());
                 write(to_write.tag);
                 to_write.write(this, m_lexicalGlobalObject);
+                RETURN_IF_EXCEPTION(scope, false);
                 if (to_write.tag == Bun__nodenet_BlockList)
                     m_serializedBlockListRefs.append(to_write.impl);
                 return true;
@@ -2199,7 +2205,9 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
         case SetDataStartVisitEntry: {
             JSSetIterator* iterator = setIteratorStack.last();
             JSValue key;
-            if (!iterator->next(m_lexicalGlobalObject, key)) {
+            bool hasNext = iterator->next(m_lexicalGlobalObject, key);
+            RETURN_IF_EXCEPTION(scope, SerializationReturnCode::ExistingExceptionError);
+            if (!hasNext) {
                 setIteratorStack.removeLast();
                 JSObject* object = inputObjectStack.last();
                 ASSERT(dynamicDowncast<JSSet>(object));
@@ -2732,6 +2740,7 @@ private:
     template<typename LengthType>
     bool readArrayBufferViewImpl(VM& vm, JSValue& arrayBufferView)
     {
+        auto scope = DECLARE_THROW_SCOPE(vm);
         ArrayBufferViewSubtag arrayBufferViewSubtag;
         if (!readArrayBufferViewSubtag(arrayBufferViewSubtag))
             return false;
@@ -2759,6 +2768,7 @@ private:
             return false;
         }
         JSValue arrayBufferValue = readTerminal();
+        RETURN_IF_EXCEPTION(scope, false);
         if (!arrayBufferValue || !arrayBufferValue.inherits<JSArrayBuffer>())
             return false;
         JSObject* arrayBufferObj = asObject(arrayBufferValue);
@@ -2787,42 +2797,55 @@ private:
         switch (arrayBufferViewSubtag) {
         case DataViewTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, DataView::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case Int8ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, Int8Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case Uint8ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, Uint8Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case Uint8ClampedArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, Uint8ClampedArray::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case Int16ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, Int16Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case Uint16ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, Uint16Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case Int32ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, Int32Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case Uint32ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, Uint32Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case Float16ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, Float16Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case Float32ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, Float32Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case Float64ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, Float64Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case BigInt64ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, BigInt64Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         case BigUint64ArrayTag:
             arrayBufferView = toJS(m_lexicalGlobalObject, m_globalObject, BigUint64Array::wrappedAs(arrayBuffer.releaseNonNull(), byteOffset, length).get());
+            RETURN_IF_EXCEPTION(scope, false);
             return true;
         default:
             return false;
@@ -4059,6 +4082,9 @@ DeserializationResult CloneDeserializer::deserialize()
         }
         case ObjectEndVisitMember: {
             putProperty(outputObjectStack.last(), propertyNameStack.last(), outValue);
+            if (scope.exception()) [[unlikely]] {
+                goto error;
+            }
             propertyNameStack.removeLast();
             goto objectStartVisitMember;
         }

--- a/src/jsc/bindings/webcore/StructuredClone.cpp
+++ b/src/jsc/bindings/webcore/StructuredClone.cpp
@@ -62,6 +62,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredClone, (JSC::JSGlobalObject * globa
     // only the WorkerPostMessage context takes the SAB-sharing path; Default would copy to a plain AB.
     ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTF::move(serializeOptions.transfer), ports,
         SerializationForStorage::No, SerializationContext::WorkerPostMessage);
+    RETURN_IF_EXCEPTION(throwScope, {});
     if (serialized.hasException()) {
         WebCore::propagateException(*globalObject, throwScope, serialized.releaseException());
         RELEASE_AND_RETURN(throwScope, {});
@@ -92,16 +93,19 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredCloneAdvanced, (JSC::JSGlobalObject
 
     SerializationContext serializationContext = SerializationContext::Default;
     if (serializationContextValue.isString()) {
-        if (serializationContextValue.getString(globalObject) == "worker"_s) {
+        String serializationContextString = serializationContextValue.getString(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (serializationContextString == "worker"_s) {
             serializationContext = SerializationContext::WorkerPostMessage;
-        } else if (serializationContextValue.getString(globalObject) == "window"_s) {
+        } else if (serializationContextString == "window"_s) {
             serializationContext = SerializationContext::WindowPostMessage;
-        } else if (serializationContextValue.getString(globalObject) == "postMessage"_s) {
+        } else if (serializationContextString == "postMessage"_s) {
             serializationContext = SerializationContext::WindowPostMessage;
-        } else if (serializationContextValue.getString(globalObject) == "default"_s) {
+        } else if (serializationContextString == "default"_s) {
             serializationContext = SerializationContext::Default;
         } else {
             throwTypeError(globalObject, throwScope, "invalid serialization context"_s);
+            return {};
         }
     }
 
@@ -125,6 +129,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStructuredCloneAdvanced, (JSC::JSGlobalObject
 
     Vector<RefPtr<MessagePort>> ports;
     ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTF::move(transferList), ports, forStorage, serializationContext, forTransfer);
+    RETURN_IF_EXCEPTION(throwScope, {});
     if (serialized.hasException()) {
         WebCore::propagateException(*globalObject, throwScope, serialized.releaseException());
         RELEASE_AND_RETURN(throwScope, {});

--- a/src/jsc/bindings/webcore/URLPattern.cpp
+++ b/src/jsc/bindings/webcore/URLPattern.cpp
@@ -212,10 +212,13 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
 // https://urlpattern.spec.whatwg.org/#url-pattern-create
 ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context, URLPatternInput&& input, String&& baseURL, URLPatternOptions&& options)
 {
+    Ref vm = context.vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     URLPatternInit init;
 
     if (std::holds_alternative<String>(input) && !std::get<String>(input).isNull()) {
         auto maybeInit = URLPatternConstructorStringParser(WTF::move(std::get<String>(input))).parse(context);
+        RETURN_IF_EXCEPTION(scope, Exception { ExceptionCode::ExistingExceptionError });
         if (maybeInit.hasException())
             return maybeInit.releaseException();
         init = maybeInit.releaseReturnValue();
@@ -260,6 +263,7 @@ ExceptionOr<Ref<URLPattern>> URLPattern::create(ScriptExecutionContext& context,
     Ref result = adoptRef(*new URLPattern);
 
     auto maybeCompileException = result->compileAllComponents(context, WTF::move(processedInit), options);
+    RETURN_IF_EXCEPTION(scope, Exception { ExceptionCode::ExistingExceptionError });
     if (maybeCompileException.hasException())
         return maybeCompileException.releaseException();
 
@@ -433,9 +437,11 @@ ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionCo
 
     Ref vm = context.vm();
     JSC::JSLockHolder lock(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     auto tryMatch = [&](const URLPatternUtilities::URLPatternComponent& component, String&& input, URLPatternComponentResult& out) -> bool {
         auto matched = component.componentMatch(globalObject, WTF::move(input));
+        RETURN_IF_EXCEPTION(scope, false);
         if (!matched)
             return false;
         out = WTF::move(*matched);
@@ -449,8 +455,10 @@ ExceptionOr<std::optional<URLPatternResult>> URLPattern::match(ScriptExecutionCo
         || !tryMatch(m_pathnameComponent, WTF::move(pathname), result.pathname)
         || !tryMatch(m_portComponent, WTF::move(port), result.port)
         || !tryMatch(m_searchComponent, WTF::move(search), result.search)
-        || !tryMatch(m_hashComponent, WTF::move(hash), result.hash))
+        || !tryMatch(m_hashComponent, WTF::move(hash), result.hash)) {
+        RETURN_IF_EXCEPTION(scope, Exception { ExceptionCode::ExistingExceptionError });
         return { std::nullopt };
+    }
 
     return { WTF::move(result) };
 }

--- a/src/jsc/bindings/webcore/URLPatternComponent.cpp
+++ b/src/jsc/bindings/webcore/URLPatternComponent.cpp
@@ -77,9 +77,13 @@ bool URLPatternComponent::matchSpecialSchemeProtocol(JSC::JSGlobalObject* global
 {
     static constexpr std::array specialSchemeList { "ftp"_s, "file"_s, "http"_s, "https"_s, "ws"_s, "wss"_s };
 
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* regExp = m_regularExpression.get();
     for (auto scheme : specialSchemeList) {
-        if (regExp->match(globalObject, scheme, 0))
+        auto result = regExp->match(globalObject, scheme, 0);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (result)
             return true;
     }
     return false;

--- a/src/jsc/bindings/webcore/URLPatternConstructorStringParser.cpp
+++ b/src/jsc/bindings/webcore/URLPatternConstructorStringParser.cpp
@@ -303,6 +303,8 @@ void URLPatternConstructorStringParser::updateState(ScriptExecutionContext& cont
 
 void URLPatternConstructorStringParser::performParse(ScriptExecutionContext& context)
 {
+    Ref vm = context.vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     while (m_tokenIndex < m_tokenList.size()) {
         m_tokenIncrement = 1;
 
@@ -346,6 +348,7 @@ void URLPatternConstructorStringParser::performParse(ScriptExecutionContext& con
         }
 
         updateState(context);
+        RETURN_IF_EXCEPTION(scope, );
         m_tokenIndex += m_tokenIncrement;
     }
     if (!m_result.hostname.isNull() && m_result.port.isNull())

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1360,8 +1360,10 @@ void WebSocket::didReceiveHandshakeResponse(uint16_t statusCode, std::span<const
     for (size_t i = 0; i < headers.size(); i++) {
         rawHeaders->putDirectIndex(globalObject, i * 2,
             JSC::jsString(vm, WTF::String(headers[i].name.span())));
+        RETURN_IF_EXCEPTION(scope, );
         rawHeaders->putDirectIndex(globalObject, i * 2 + 1,
             JSC::jsString(vm, WTF::String(headers[i].value.span())));
+        RETURN_IF_EXCEPTION(scope, );
     }
     obj->putDirect(vm, builtinNames.rawHeadersPublicName(), rawHeaders);
 

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -340,24 +340,41 @@ JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)
     JSObject* array = constructEmptyArray(globalObject, nullptr, 17);
     RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 0, workerData);
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 1, threadId);
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 2, JSFunction::create(vm, globalObject, 1, "receiveMessageOnPort"_s, jsReceiveMessageOnPort, ImplementationVisibility::Public, NoIntrinsic));
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 3, environmentData);
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 4, threadName);
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 5, JSFunction::create(vm, globalObject, 1, "isMessagePortActive"_s, jsMessagePortIsActive, ImplementationVisibility::Public, NoIntrinsic));
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 6, JSFunction::create(vm, globalObject, 1, "markAsUntransferable"_s, jsFunctionMarkAsUntransferable, ImplementationVisibility::Public, NoIntrinsic));
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 7, JSFunction::create(vm, globalObject, 1, "isMarkedAsUntransferable"_s, jsFunctionIsMarkedAsUntransferable, ImplementationVisibility::Public, NoIntrinsic));
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 8, JSFunction::create(vm, globalObject, 1, "markAsUncloneable"_s, jsFunctionMarkAsUncloneable, ImplementationVisibility::Public, NoIntrinsic));
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 9, JSFunction::create(vm, globalObject, 1, "setEntryEvaluatedHook"_s, jsFunctionSetEntryEvaluatedHook, ImplementationVisibility::Public, NoIntrinsic));
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 10, jsBoolean(isNodeWorker));
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 11, JSFunction::create(vm, globalObject, 1, "setParentPort"_s, jsFunctionSetParentPort, ImplementationVisibility::Public, NoIntrinsic));
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 12, JSFunction::create(vm, globalObject, 1, "setStdioPorts"_s, jsFunctionSetNodeWorkerStdioPorts, ImplementationVisibility::Public, NoIntrinsic));
+    RETURN_IF_EXCEPTION(scope, {});
     // The intrinsic constructors, so worker_threads keeps working when user code
     // replaces globalThis.MessagePort etc. before the module loads (#40268).
     array->putDirectIndex(globalObject, 13, JSMessagePort::getConstructor(vm, globalObject));
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 14, JSMessageChannel::getConstructor(vm, globalObject));
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 15, JSBroadcastChannel::getConstructor(vm, globalObject));
+    RETURN_IF_EXCEPTION(scope, {});
     array->putDirectIndex(globalObject, 16, JSWorker::getConstructor(vm, globalObject));
+    RETURN_IF_EXCEPTION(scope, {});
     return array;
 }
 
@@ -426,6 +443,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionPostMessage,
 
     Vector<RefPtr<MessagePort>> ports;
     ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTF::move(transferList), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
+    RETURN_IF_EXCEPTION(scope, {});
     if (serialized.hasException()) {
         WebCore::propagateException(*globalObject, scope, serialized.releaseException());
         RELEASE_AND_RETURN(scope, {});

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -333,7 +333,9 @@ static bool drainInbox(WorkerMessagingProxy::MessageInbox& inbox, Zig::GlobalObj
                 dispatch(MessageEvent::create(eventNames().messageerrorEvent, MessageEvent::Init { {}, jsNull() }, MessageEvent::IsTrusted::Yes));
             } else
                 dispatch(event->event);
-            if (globalObject.drainMicrotasks())
+            bool terminating = globalObject.drainMicrotasks();
+            RETURN_IF_EXCEPTION(scope, false);
+            if (terminating)
                 return false; // termination pending
         }
     }

--- a/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp
@@ -311,7 +311,7 @@ void nativeCodecContinue(JSGlobalObject* globalObject, JSTransformStream* stream
         CodecOutcome outcome = stepChunkHere(globalObject, stream, coder, nullptr, 0, false);
         stream->m_nativeStateInUse = false;
         RETURN_IF_EXCEPTION(scope, );
-        settlePendingChunk(globalObject, stream, outcome); }, [&](JSValue thrown) {
+        RELEASE_AND_RETURN(scope, settlePendingChunk(globalObject, stream, outcome)); }, [&](JSValue thrown) {
         if (stream->m_codecPromise)
             settleCodecChunk(globalObject, stream, thrown); });
     RETURN_IF_EXCEPTION(scope, );

--- a/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
@@ -152,7 +152,7 @@ void JSReadRequest::closeSteps(JSGlobalObject* globalObject)
             RETURN_IF_EXCEPTION(scope, void());
         }
         if (!teeState->m_canceled1 || !teeState->m_canceled2)
-            resolvePromise(globalObject, teeState->m_cancelPromise.get(), jsUndefined());
+            RELEASE_AND_RETURN(scope, resolvePromise(globalObject, teeState->m_cancelPromise.get(), jsUndefined()));
         return;
     }
     case ReadRequestKind::ByteTee: {
@@ -177,7 +177,7 @@ void JSReadRequest::closeSteps(JSGlobalObject* globalObject)
             RETURN_IF_EXCEPTION(scope, void());
         }
         if (!teeState->m_canceled1 || !teeState->m_canceled2)
-            resolvePromise(globalObject, teeState->m_cancelPromise.get(), jsUndefined());
+            RELEASE_AND_RETURN(scope, resolvePromise(globalObject, teeState->m_cancelPromise.get(), jsUndefined()));
         return;
     }
     case ReadRequestKind::ReadStreamIntoSink:
@@ -350,7 +350,7 @@ void JSReadIntoRequest::closeSteps(JSGlobalObject* globalObject, JSArrayBufferVi
             }
         }
         if (!byobCanceled || !otherCanceled)
-            resolvePromise(globalObject, teeState->m_cancelPromise.get(), jsUndefined());
+            RELEASE_AND_RETURN(scope, resolvePromise(globalObject, teeState->m_cancelPromise.get(), jsUndefined()));
         return;
     }
     }

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
@@ -155,6 +155,7 @@ static void pipeToLoopStep(JSGlobalObject* globalObject, JSStreamPipeToOperation
     auto* runtime = JSStreamsRuntime::from(globalObject);
     if (*desiredSize <= 0) {
         registerPipeReaction(globalObject, writer->readyPromise(globalObject), runtime->onPipeWriterReadyFulfilled(), nullptr, op);
+        RETURN_IF_EXCEPTION(scope, );
         return;
     }
     auto* readRequest = JSReadRequest::create(vm, runtime->readRequestStructure(defaultGlobalObject(globalObject)), ReadRequestKind::PipeTo, op);
@@ -587,6 +588,7 @@ void startPipeToOperation(JSGlobalObject* globalObject, JSStreamPipeToOperation*
         auto* boundAlgorithm = JSBoundFunction::create(vm, globalObject, runtime->boundPipeAbortAlgorithm(), jsUndefined(), ArgList(boundArguments), 1, nullptr, sourceCode);
         RETURN_IF_EXCEPTION(scope, );
         op->m_abortAlgorithmId = WebCore::AbortSignal::addAbortAlgorithmToSignal(signal, WebCore::JSAbortAlgorithm::create(vm, boundAlgorithm));
+        RETURN_IF_EXCEPTION(scope, );
     }
 
     const auto* reader = op->m_reader.get();

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -198,7 +198,9 @@ JSC_DEFINE_HOST_FUNCTION(jsTextDecoderStreamPrototype_inspectCustom, (JSGlobalOb
     if (!thisObject) [[unlikely]]
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "TextDecoderStream"_s);
     JSObject* data = constructEmptyObject(lexicalGlobalObject);
-    Bun::putDirectNamed(vm, data, "encoding"_s, Bun::toJS(lexicalGlobalObject, thisObject->m_encodingLabel));
+    auto* encoding = Bun::toJS(lexicalGlobalObject, thisObject->m_encodingLabel);
+    RETURN_IF_EXCEPTION(scope, {});
+    Bun::putDirectNamed(vm, data, "encoding"_s, encoding);
     Bun::putDirectNamed(vm, data, "fatal"_s, jsBoolean(thisObject->m_fatal));
     Bun::putDirectNamed(vm, data, "ignoreBOM"_s, jsBoolean(thisObject->m_ignoreBOM));
     Bun::putDirectNamed(vm, data, "readable"_s, thisObject->m_readable.get() ? JSValue(thisObject->m_readable.get()) : jsUndefined());
@@ -276,7 +278,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_encoding, (JSGlobalO
     const auto* stream = dynamicDowncast<JSTextDecoderStream>(JSValue::decode(thisValue));
     if (!stream) [[unlikely]]
         return throwThisTypeError(*lexicalGlobalObject, scope, "TextDecoderStream"_s, "encoding"_s);
-    return JSValue::encode(Bun::toJS(lexicalGlobalObject, stream->m_encodingLabel));
+    RELEASE_AND_RETURN(scope, JSValue::encode(Bun::toJS(lexicalGlobalObject, stream->m_encodingLabel)));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsTextDecoderStreamPrototypeGetter_fatal, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))

--- a/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/TransformStreamOperations.cpp
@@ -258,6 +258,7 @@ JSPromise* transformStreamDefaultSourceCancelAlgorithm(JSGlobalObject* globalObj
     // The readable is closed: a codec chunk (or, with a close in flight, flush) still being
     // drained into it can no longer finish.
     nativeCodecAbandon(globalObject, stream);
+    RETURN_IF_EXCEPTION(scope, nullptr);
     if (auto* finishPromise = controller->m_finishPromise.get())
         return finishPromise;
     auto* finishPromise = JSPromise::create(vm, globalObject->promiseStructure());
@@ -334,6 +335,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSinkAbortCancelFulfilled, (JSGl
     const auto* readable = stream->m_readable.get();
     if (readable->m_state == ReadableStreamState::Errored) {
         rejectPromise(globalObject, finishPromise, readable->m_storedError.get());
+        RETURN_IF_EXCEPTION(scope, {});
         return JSValue::encode(jsUndefined());
     }
     if (auto* readableController = transformReadableController(stream)) {
@@ -359,6 +361,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSinkAbortCancelRejected, (JSGlo
         RETURN_IF_EXCEPTION(scope, {});
     }
     rejectPromise(globalObject, finishPromise, rejection);
+    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
 
@@ -372,6 +375,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSinkCloseFlushFulfilled, (JSGlo
     const auto* readable = stream->m_readable.get();
     if (readable->m_state == ReadableStreamState::Errored) {
         rejectPromise(globalObject, finishPromise, readable->m_storedError.get());
+        RETURN_IF_EXCEPTION(scope, {});
         return JSValue::encode(jsUndefined());
     }
     if (auto* readableController = transformReadableController(stream)) {
@@ -397,6 +401,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSinkCloseFlushRejected, (JSGlob
         RETURN_IF_EXCEPTION(scope, {});
     }
     rejectPromise(globalObject, finishPromise, rejection);
+    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
 
@@ -412,6 +417,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSourceCancelFulfilled, (JSGloba
     const auto* writable = stream->m_writable.get();
     if (writable->m_state == WritableStreamState::Errored) {
         rejectPromise(globalObject, finishPromise, writable->m_storedError.get());
+        RETURN_IF_EXCEPTION(scope, {});
         return JSValue::encode(jsUndefined());
     }
     writableStreamDefaultControllerErrorIfNeeded(globalObject, writable->m_controller.get(), reason);
@@ -437,6 +443,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onTSSourceCancelRejected, (JSGlobal
     transformStreamUnblockWrite(globalObject, stream);
     RETURN_IF_EXCEPTION(scope, {});
     rejectPromise(globalObject, finishPromise, rejection);
+    RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());
 }
 

--- a/src/jsc/bindings/webcore/streams/WritableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/WritableStreamOperations.cpp
@@ -314,8 +314,10 @@ void writableStreamStartErroring(JSGlobalObject* globalObject, JSWritableStream*
     // The in-flight write may be a native codec chunk still being drained into the readable,
     // which nothing on this side would ever finish; give it up so the erroring can complete.
     // An in-flight close (a flush) is left to finish: a close in progress wins over the abort.
-    if (controller->m_algorithms.kind == SinkKind::Transform && stream->m_inFlightWriteRequest)
+    if (controller->m_algorithms.kind == SinkKind::Transform && stream->m_inFlightWriteRequest) {
         nativeCodecAbandon(globalObject, uncheckedDowncast<JSTransformStream>(controller->m_algorithms.algorithmContext.get()));
+        RETURN_IF_EXCEPTION(scope, );
+    }
     if (!writableStreamHasOperationMarkedInFlight(stream) && controller->m_started)
         RELEASE_AND_RETURN(scope, writableStreamFinishErroring(globalObject, stream));
 }

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -88,6 +88,7 @@ JSC_DEFINE_HOST_FUNCTION(functionStartRemoteDebugger,
     if (hostValue.isString()) {
 
         auto str = hostValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
         hostCString = toCString(str);
         if (!str.isEmpty())
             host = hostCString.span().data();
@@ -99,7 +100,7 @@ JSC_DEFINE_HOST_FUNCTION(functionStartRemoteDebugger,
 
     uint16_t port = defaultPort;
     if (portValue.isNumber()) {
-        auto port_int = portValue.toUInt32(globalObject);
+        auto port_int = JSC::toUInt32(portValue.asNumber());
         if (!(port_int > 0 && port_int < 65536)) {
             throwVMError(
                 globalObject, scope,
@@ -469,6 +470,7 @@ JSC_DEFINE_HOST_FUNCTION(functionStartSamplingProfiler,
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (directoryValue.isString()) {
         auto path = directoryValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
         if (!path.isEmpty()) {
             StringPrintStream pathOut;
             auto pathCString = toCString(String(path));
@@ -484,7 +486,7 @@ JSC_DEFINE_HOST_FUNCTION(functionStartSamplingProfiler,
         }
     }
     if (sampleValue.isNumber()) {
-        unsigned sampleInterval = sampleValue.toUInt32(globalObject);
+        unsigned sampleInterval = JSC::toUInt32(sampleValue.asNumber());
         samplingProfiler.setTimingInterval(
             Seconds::fromMicroseconds(sampleInterval));
     }
@@ -709,7 +711,7 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
     }
 
     if (sampleValue.isNumber()) {
-        unsigned sampleInterval = sampleValue.toUInt32(globalObject);
+        unsigned sampleInterval = JSC::toUInt32(sampleValue.asNumber());
         samplingProfiler.setTimingInterval(Seconds::fromMicroseconds(sampleInterval));
     } else {
         // Reset to default interval (1000 microseconds) to ensure each profile()
@@ -764,7 +766,7 @@ JSC_DEFINE_HOST_FUNCTION(functionRunProfiler, (JSGlobalObject * globalObject, Ca
     samplingProfiler.start();
     JSValue returnValue = JSC::profiledCall(globalObject, ProfilingReason::API, callbackValue, callData, JSC::jsUndefined(), args);
 
-    if (returnValue.isEmpty() || throwScope.exception()) {
+    if (throwScope.exception() || returnValue.isEmpty()) {
         return JSValue::encode(reportFailure(vm));
     }
 
@@ -823,7 +825,7 @@ JSC_DEFINE_HOST_FUNCTION(functionGenerateHeapSnapshotForDebugging,
     }
     scope.releaseAssertNoException();
 
-    return JSValue::encode(JSONParse(globalObject, WTF::move(jsonString)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSONParse(globalObject, WTF::move(jsonString))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionSerialize,
@@ -926,8 +928,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCodeCoverageForFile,
         sourceID, vm);
 
     if (basicBlocks.isEmpty()) {
-        return JSC::JSValue::encode(
-            JSC::constructEmptyArray(globalObject, nullptr, 0));
+        RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(JSC::constructEmptyArray(globalObject, nullptr, 0)));
     }
 
     size_t functionStartOffset = basicBlocks.size();

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -892,7 +892,7 @@ pub fn set_main(global_this: &JSGlobalObject, new_value: JSValue) -> bool {
     true
 }
 
-fn get_argv(global_this: &JSGlobalObject, _: &JSObject) -> JSValue {
+fn get_argv(global_this: &JSGlobalObject, _: &JSObject) -> JsResult<JSValue> {
     node::process::get_argv(global_this)
 }
 

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -654,12 +654,7 @@ impl FileSystemRouter {
             name_strings_slice[i] = EncodedSlice::from_bytes(name);
             paths_strings[i] = EncodedSlice::from_bytes(paths[i]);
         }
-        Ok(JSValue::from_entries(
-            global_this,
-            name_strings_slice,
-            paths_strings,
-            true,
-        ))
+        JSValue::from_entries(global_this, name_strings_slice, paths_strings, true)
     }
 
     #[bun_jsc::host_fn(getter)]
@@ -896,9 +891,7 @@ impl MatchedRoute {
         let count = map.get_name_count();
         let mut creator = QueryObjectCreator { query: map };
 
-        let value = JSObject::create_with_initializer(&mut creator, ctx, count);
-
-        Ok(value)
+        JSObject::create_with_initializer(&mut creator, ctx, count)
     }
 
     #[bun_jsc::host_fn(getter)]

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -37,7 +37,7 @@ fn create_buffer_with_ctx(
     slice: &mut [u8],
     ctx: *mut c_void,
     callback: jsc::JSTypedArrayBytesDeallocator,
-) -> JSValue {
+) -> JsResult<JSValue> {
     unsafe extern "C" {
         fn JSBuffer__bufferFromPointerAndLengthAndDeinit(
             global: *const JSGlobalObject,
@@ -49,7 +49,7 @@ fn create_buffer_with_ctx(
     }
     // SAFETY: `global` is live; `slice` stays valid for the Buffer's lifetime.
     // `callback` controls disposal (a no-op when the storage stays caller-owned).
-    unsafe {
+    jsc::call_zero_is_throw(global, || unsafe {
         JSBuffer__bufferFromPointerAndLengthAndDeinit(
             global,
             slice.as_mut_ptr(),
@@ -57,7 +57,7 @@ fn create_buffer_with_ctx(
             ctx,
             callback,
         )
-    }
+    })
 }
 
 // ── Put helpers from ZigGeneratedCode.cpp; each installs a host fn over its `*__slowpath` export ──
@@ -730,12 +730,12 @@ fn to_buffer(
             let slice = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
             // No finalizer means borrow: the noop deallocator keeps GC from freeing
             // caller-owned storage (oven-sh/bun#35405).
-            Ok(create_buffer_with_ctx(
+            create_buffer_with_ctx(
                 global_this,
                 slice,
                 ctx.unwrap_or(core::ptr::null_mut()),
                 callback.or(Some(noop_bytes_deallocator)),
-            ))
+            )
         }
     }
 }

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -117,16 +117,19 @@ unsafe extern "C" {
     ) -> JSValue;
 }
 
+/// `Ok(JSValue::ZERO)` is the C++ side's "could not create" without a
+/// pending exception; a TypeError for an unsupported signature comes back as
+/// `Err`.
 fn create_jsc_ffi_function(
     global: &JSGlobalObject,
     symbol_name: &EncodedSlice,
     function: &Function,
     target: *mut c_void,
     owner: JSValue,
-) -> JSValue {
+) -> JsResult<JSValue> {
     let arg_types: Vec<u8> = function.arg_types.iter().map(|t| *t as u8).collect();
     // SAFETY: `global` is a live JSC handle and `arg_types` outlives the call.
-    unsafe {
+    jsc::call_check_slow(global, || unsafe {
         Bun__CreateJSCFFIFunction(
             global,
             symbol_name,
@@ -140,7 +143,7 @@ fn create_jsc_ffi_function(
             target,
             owner,
         )
-    }
+    })
 }
 
 /// Raw extern fn pointers fed to the TCC-JIT'd C trampolines via `add_symbol`.
@@ -1271,7 +1274,8 @@ impl FFI {
 
         let arg_types: Vec<u8> = func.arg_types.iter().map(|t| *t as u8).collect();
         // SAFETY: `global_this` is a live JSC handle and `js_callback` is a live callable.
-        let cb = unsafe {
+        // Empty without an exception is the C++ side's "could not create".
+        let cb = jsc::call_check_slow(global_this, || unsafe {
             Bun__CreateJSCFFICallback(
                 global_this,
                 js_callback,
@@ -1284,13 +1288,8 @@ impl FFI {
                 func.return_type as u8,
                 func.threadsafe,
             )
-        };
+        })?;
         if cb.is_empty() {
-            // An exception left by the constructor (OOM, or a termination
-            // request landing in it) is the caller's, not a value.
-            if global_this.has_exception() {
-                return Err(JsError::Thrown);
-            }
             return Ok(
                 global_this.create_error_instance(format_args!("Failed to create FFI callback"))
             );
@@ -1533,23 +1532,24 @@ impl FFI {
                 .symbol_from_dynamic_library
                 .expect("symbol was resolved above");
             let symbol_name = EncodedSlice::utf8(function_name.as_bytes());
-            let cb = create_jsc_ffi_function(global, &symbol_name, function, target, js_object);
-            if cb.is_empty() {
-                // An exception the constructor left pending is the caller's.
-                let ret = if global.has_exception() {
-                    Err(JsError::Thrown)
-                } else {
-                    Ok(global.to_invalid_arguments(format_args!(
-                        "Failed to create FFI function for symbol \"{}\" in \"{}\"",
-                        BStr::new(function_name.as_bytes()),
-                        BStr::new(name)
-                    )))
+            let cb =
+                match create_jsc_ffi_function(global, &symbol_name, function, target, js_object) {
+                    Ok(cb) if !cb.is_empty() => cb,
+                    result => {
+                        // An exception the constructor left pending is the caller's.
+                        let ret = result.map(|_| {
+                            global.to_invalid_arguments(format_args!(
+                                "Failed to create FFI function for symbol \"{}\" in \"{}\"",
+                                BStr::new(function_name.as_bytes()),
+                                BStr::new(name)
+                            ))
+                        });
+                        dylib.close();
+                        // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).
+                        unsafe { &*lib_ptr }.do_close();
+                        return ret;
+                    }
                 };
-                dylib.close();
-                // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).
-                unsafe { &*lib_ptr }.do_close();
-                return ret;
-            }
             obj.put(global, symbol_name, cb);
         }
 
@@ -1619,21 +1619,22 @@ impl FFI {
             }
             let target = function.symbol_from_dynamic_library.expect("checked above");
             let symbol_name = EncodedSlice::utf8(function_name.as_bytes());
-            let cb = create_jsc_ffi_function(global, &symbol_name, function, target, js_object);
-            if cb.is_empty() {
-                // An exception the constructor left pending is the caller's.
-                let err = if global.has_exception() {
-                    Err(JsError::Thrown)
-                } else {
-                    Ok(global.to_invalid_arguments(format_args!(
-                        "Failed to create FFI function for symbol \"{}\"",
-                        BStr::new(function_name.as_bytes())
-                    )))
+            let cb =
+                match create_jsc_ffi_function(global, &symbol_name, function, target, js_object) {
+                    Ok(cb) if !cb.is_empty() => cb,
+                    result => {
+                        // An exception the constructor left pending is the caller's.
+                        let err = result.map(|_| {
+                            global.to_invalid_arguments(format_args!(
+                                "Failed to create FFI function for symbol \"{}\"",
+                                BStr::new(function_name.as_bytes())
+                            ))
+                        });
+                        // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).
+                        unsafe { &*lib_ptr }.do_close();
+                        return err;
+                    }
                 };
-                // SAFETY: lib_ptr is the live, JS-owned FFI allocation (from into_raw).
-                unsafe { &*lib_ptr }.do_close();
-                return err;
-            }
             obj.put(global, symbol_name, cb);
         }
 
@@ -1678,13 +1679,9 @@ impl FFI {
             &function,
             target,
             JSValue::UNDEFINED,
-        );
+        )?;
         if cb.is_empty() {
-            return Ok(if global.has_exception() {
-                global.take_error(JsError::Thrown)
-            } else {
-                global.to_invalid_arguments(format_args!("Failed to create FFI function"))
-            });
+            return Ok(global.to_invalid_arguments(format_args!("Failed to create FFI function")));
         }
         Ok(cb)
     }

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -2021,8 +2021,14 @@ fn import_windows_socket_payload(
         log!("importWindowsSocketPayload: WSASocketW failed: {}", err);
         return Ok(None);
     }
-    msg_data.delete_property(global, WIN_SOCKET_INFO_KEY)?;
-    Ok(Some(Fd::from_system(sock as *mut c_void)))
+    let fd = Fd::from_system(sock as *mut c_void);
+    if let Err(err) = msg_data.delete_property(global, WIN_SOCKET_INFO_KEY) {
+        // The imported socket is not owned by anything yet; do not leak it
+        // with the exception.
+        fd.close();
+        return Err(err);
+    }
+    Ok(Some(fd))
 }
 
 fn received_fd_to_js(fd: Fd) -> JSValue {

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -2021,7 +2021,7 @@ fn import_windows_socket_payload(
         log!("importWindowsSocketPayload: WSASocketW failed: {}", err);
         return Ok(None);
     }
-    msg_data.delete_property(global, WIN_SOCKET_INFO_KEY);
+    msg_data.delete_property(global, WIN_SOCKET_INFO_KEY)?;
     Ok(Some(Fd::from_system(sock as *mut c_void)))
 }
 

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -5,8 +5,10 @@ use core::ffi::c_char;
 use bun_core::EncodedSlice;
 use bun_core::env_var;
 use bun_core::{self, Environment, Global};
-use bun_jsc::{EncodedSliceJsc as _, JSGlobalObject, JSValue};
+use bun_jsc::{EncodedSliceJsc as _, JSGlobalObject, JSValue, JsResult};
 
+// Both materialize the array on first access through `Bun__Process__createArgv`
+// / `createExecArgv` below, which return zero with the exception pending.
 unsafe extern "C" {
     safe fn Bun__Process__getArgv(global: &JSGlobalObject) -> JSValue;
     safe fn Bun__Process__getExecArgv(global: &JSGlobalObject) -> JSValue;
@@ -52,12 +54,12 @@ pub(crate) fn worker_option_string(wtf: bun_core::WTFStringImpl) -> bun_core::St
 
 // ───────────────────────────── argv (C++ accessor wrappers) ─────────────────
 
-pub(crate) extern "C" fn get_argv(global: &JSGlobalObject) -> JSValue {
-    Bun__Process__getArgv(global)
+pub(crate) fn get_argv(global: &JSGlobalObject) -> JsResult<JSValue> {
+    bun_jsc::call_zero_is_throw(global, || Bun__Process__getArgv(global))
 }
 
-pub(crate) extern "C" fn get_exec_argv(global: &JSGlobalObject) -> JSValue {
-    Bun__Process__getExecArgv(global)
+pub(crate) fn get_exec_argv(global: &JSGlobalObject) -> JsResult<JSValue> {
+    bun_jsc::call_zero_is_throw(global, || Bun__Process__getExecArgv(global))
 }
 
 // ───────────────────────────── exit ─────────────────────────────

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -3415,7 +3415,10 @@ fn resolve(
             // Micro-optimization #1: avoid creating a new string when passing no arguments or only empty strings.
             // Micro-optimization #2: path.resolve(".") and path.resolve("./") === process.cwd()
             if paths.is_empty() || (paths.len() == 1 && (paths[0] == b"." || paths[0] == b"./")) {
-                return Ok(Process__getCachedCwd(global_object));
+                // Throws when `getcwd` fails (for example, a deleted cwd).
+                return crate::jsc::call_zero_is_throw(global_object, || {
+                    Process__getCachedCwd(global_object)
+                });
             }
         }
     }

--- a/src/runtime/node/util/parse_args.rs
+++ b/src/runtime/node/util/parse_args.rs
@@ -186,8 +186,8 @@ fn find_option_by_long_name(long_name: &String, options: &[OptionDefinition]) ->
 fn get_default_args(global: &JSGlobalObject) -> JsResult<ArgsSlice> {
     // Work out where to slice process.argv for user supplied arguments
 
-    let exec_argv = super::process::get_exec_argv(global);
-    let argv = super::process::get_argv(global);
+    let exec_argv = super::process::get_exec_argv(global)?;
+    let argv = super::process::get_argv(global)?;
     if argv.is_array() && exec_argv.is_array() {
         let mut iter = exec_argv.array_iterator(global)?;
         while let Some(item) = iter.next()? {

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2396,12 +2396,14 @@ impl NodeHTTPResponse {
         &self,
         global_object: &JSGlobalObject,
         _callframe: &CallFrame,
-    ) -> JSValue {
+    ) -> JsResult<JSValue> {
         let section = self.raw_request_headers.replace(Vec::new());
         if section.is_empty() {
-            return JSValue::UNDEFINED;
+            return Ok(JSValue::UNDEFINED);
         }
-        Bun__NodeHTTP__buildRawHeadersArray(global_object, section.as_ptr(), section.len())
+        bun_jsc::call_zero_is_throw(global_object, || {
+            Bun__NodeHTTP__buildRawHeadersArray(global_object, section.as_ptr(), section.len())
+        })
     }
 
     /// `handle.takeRequestTrailers()` — this request's captured trailer section
@@ -2410,20 +2412,22 @@ impl NodeHTTPResponse {
         &self,
         global_object: &JSGlobalObject,
         callframe: &CallFrame,
-    ) -> JSValue {
+    ) -> JsResult<JSValue> {
         let section = self.request_trailers.replace(Vec::new());
         if section.is_empty() {
-            return JSValue::UNDEFINED;
+            return Ok(JSValue::UNDEFINED);
         }
         // Lenient (insecureHTTPParser) servers accept CTL bytes in trailer values on
         // the wire; parse them with the same leniency so they surface on req.trailers.
         let use_insecure_http_parser = callframe.argument(0).to_boolean();
-        Bun__NodeHTTP__parseRequestTrailers(
-            global_object,
-            section.as_ptr(),
-            section.len(),
-            use_insecure_http_parser,
-        )
+        bun_jsc::call_zero_is_throw(global_object, || {
+            Bun__NodeHTTP__parseRequestTrailers(
+                global_object,
+                section.as_ptr(),
+                section.len(),
+                use_insecure_http_parser,
+            )
+        })
     }
 
     pub(crate) fn get_bytes_written(

--- a/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
@@ -28,7 +28,7 @@ pub(crate) fn to_have_last_returned_with(
     let mut last_error_value: JSValue = JSValue::UNDEFINED;
 
     if calls_count > 0 {
-        let last_result = returns.get_direct_index(global_this, calls_count - 1);
+        let last_result = returns.get_direct_index(global_this, calls_count - 1)?;
 
         if last_result.is_object() {
             let result_type = last_result.get(global_this, "type")?.unwrap_or(JSValue::UNDEFINED);

--- a/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
@@ -43,7 +43,7 @@ pub(crate) fn to_have_nth_returned_with(
 
     if index < calls_count {
         nth_call_exists = true;
-        let nth_result = returns.get_direct_index(global, index);
+        let nth_result = returns.get_direct_index(global, index)?;
         if nth_result.is_object() {
             let result_type = nth_result.get(global, "type")?.unwrap_or(JSValue::UNDEFINED);
             if result_type.is_string() {

--- a/src/runtime/test_runner/expect/toHaveReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveReturnedWith.rs
@@ -31,7 +31,7 @@ pub(crate) fn to_have_returned_with(
 
     // Check for a pass and collect info for error messages
     for i in 0..calls_count {
-        let result = returns.get_direct_index(global, i);
+        let result = returns.get_direct_index(global, i)?;
 
         if result.is_object() {
             let result_type = result.get(global, "type")?.unwrap_or(JSValue::UNDEFINED);

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -324,24 +324,25 @@ fn error_unless_fake_timers(global: &JSGlobalObject) -> JsResult<()> {
 /// Set or remove the "clock" property on setTimeout to indicate that fake timers are active.
 /// This is used by testing-library/react's jestFakeTimersAreEnabled() function to detect
 /// if jest.advanceTimersByTime() should be called when draining the microtask queue.
-fn set_fake_timer_marker(global: &JSGlobalObject, enabled: bool) {
+fn set_fake_timer_marker(global: &JSGlobalObject, enabled: bool) -> JsResult<()> {
     let global_this = global.to_js_value();
     // `get()` (vs `get_own_truthy`) so the LUT-registered `setTimeout` is
     // resolved even before first reification — semantically equivalent on
     // the global since `setTimeout` is always an own property.
-    let Ok(Some(set_timeout_fn)) = global_this.get(global, "setTimeout") else {
-        return;
+    let Some(set_timeout_fn) = global_this.get(global, "setTimeout")? else {
+        return Ok(());
     };
     if !set_timeout_fn.is_object() {
-        return;
+        return Ok(());
     }
     // testing-library/react checks Object.hasOwnProperty.call(setTimeout, 'clock')
     // to detect if fake timers are enabled.
     if enabled {
         set_timeout_fn.put(global, "clock", JSValue::TRUE);
     } else {
-        let _ = set_timeout_fn.delete_property(global, "clock");
+        set_timeout_fn.delete_property(global, "clock")?;
     }
+    Ok(())
 }
 
 #[bun_jsc::host_fn]
@@ -377,7 +378,7 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
 
     // Set setTimeout.clock = true to signal that fake timers are enabled.
     // This is used by testing-library/react to detect if jest.advanceTimersByTime should be called.
-    set_fake_timer_marker(global, true);
+    set_fake_timer_marker(global, true)?;
 
     Ok(frame.this())
 }
@@ -389,7 +390,7 @@ fn use_real_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
     cleared.release(global.bun_vm_ptr());
 
     // Remove the setTimeout.clock marker when switching back to real timers.
-    set_fake_timer_marker(global, false);
+    set_fake_timer_marker(global, false)?;
 
     Ok(frame.this())
 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2946,6 +2946,7 @@ impl BlobExt for Blob {
                                     // from `heap::alloc` (see `LinuxMemFdAllocator::deref`
                                     // contract).
                                     unsafe { LinuxMemFdAllocator::deref(memfd) };
+                                    let result = result?;
                                     debug!(
                                         "toArrayBuffer COW clone({}, {}) = {}",
                                         byte_offset,
@@ -6458,11 +6459,7 @@ impl Any {
                 // Ownership transfers to JSC via the default-allocator path.
                 let bytes: &mut [u8] = ib.to_owned_slice().leak();
                 *self = Any::Blob(Blob::default());
-                Ok(jsc::ArrayBuffer::from_default_allocator(
-                    global,
-                    TYPED_ARRAY_VIEW,
-                    bytes,
-                ))
+                jsc::ArrayBuffer::from_default_allocator(global, TYPED_ARRAY_VIEW, bytes)
             }
             Any::WTFStringImpl(impl_) => {
                 let str =
@@ -6472,11 +6469,11 @@ impl Any {
                 let out_bytes = str.to_utf8();
                 if out_bytes.is_owned() {
                     let owned: &mut [u8] = out_bytes.into_vec().leak();
-                    return Ok(jsc::ArrayBuffer::from_default_allocator(
+                    return jsc::ArrayBuffer::from_default_allocator(
                         global,
                         TYPED_ARRAY_VIEW,
                         owned,
-                    ));
+                    );
                 }
                 jsc::ArrayBuffer::create::<TYPED_ARRAY_VIEW>(global, out_bytes.slice())
             }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -411,7 +411,7 @@ impl PendingValue {
                     // The ReadableStream within is expected to keep this Promise alive.
                     // If you try to protect() this, it will leak memory because the other end of the ReadableStream won't call it.
                     // See https://github.com/oven-sh/bun/issues/13678
-                    return Ok(promise);
+                    return promise;
                 }
                 Action::None => {}
             }

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -816,11 +816,12 @@ pub extern "C" fn CompressionStreamCoder__transform(
     let result = match unsafe { (*this).step(slice, finish, &mut out) } {
         Ok(has_more) => {
             *more = has_more;
-            if out.is_empty() {
+            let chunk = if out.is_empty() {
                 JSUint8Array::create_empty(global)
             } else {
                 JSUint8Array::from_bytes_copy(global, &out)
-            }
+            };
+            bun_jsc::to_js_host_fn_result(global, chunk)
         }
         Err(e) => {
             *more = false;

--- a/src/runtime/webcore/TextEncoderStreamEncoder.rs
+++ b/src/runtime/webcore/TextEncoderStreamEncoder.rs
@@ -3,7 +3,7 @@ use core::ptr::NonNull;
 
 use bun_alloc::AllocError;
 use bun_core::strings;
-use bun_jsc::{JSGlobalObject, JSUint8Array, JSValue};
+use bun_jsc::{JSGlobalObject, JSUint8Array, JSValue, JsResult};
 use bun_ptr::RawSlice;
 use bun_simdutf_sys::simdutf;
 
@@ -25,13 +25,13 @@ pub struct TextEncoderStreamEncoder {
 }
 
 impl TextEncoderStreamEncoder {
-    fn encode_latin1(&self, global: &JSGlobalObject, input: &[u8]) -> JSValue {
+    fn encode_latin1(&self, global: &JSGlobalObject, input: &[u8]) -> JsResult<JSValue> {
         if input.is_empty() {
             return JSUint8Array::create_empty(global);
         }
         let mut buffer = Vec::new();
         if self.encode_latin1_into(input, &mut buffer).is_err() {
-            return global.throw_out_of_memory_value();
+            return Err(global.throw_out_of_memory());
         }
         JSUint8Array::from_bytes(global, buffer.into())
     }
@@ -92,13 +92,13 @@ impl TextEncoderStreamEncoder {
         Ok(())
     }
 
-    fn encode_utf16(&self, global: &JSGlobalObject, input: &[u16]) -> JSValue {
+    fn encode_utf16(&self, global: &JSGlobalObject, input: &[u16]) -> JsResult<JSValue> {
         if input.is_empty() {
             return JSUint8Array::create_empty(global);
         }
         let mut buf = Vec::new();
         if self.encode_utf16_into(input, &mut buf).is_err() {
-            return global.throw_out_of_memory_value();
+            return Err(global.throw_out_of_memory());
         }
         if buf.is_empty() {
             return JSUint8Array::create_empty(global);
@@ -206,7 +206,7 @@ impl TextEncoderStreamEncoder {
         Ok(())
     }
 
-    fn flush_body(&self, global: &JSGlobalObject) -> JSValue {
+    fn flush_body(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
         if self.pending_lead_surrogate.get().is_none() {
             JSUint8Array::create_empty(global)
         } else {
@@ -251,11 +251,12 @@ pub extern "C" fn TextEncoderStreamEncoder__encodeForStream(
     // only from the JS thread, so `&*this` has no mutable alias. Taken after
     // the coercion so no user JS runs while the borrow is live.
     let this = unsafe { &*this };
-    if str.is_utf16() {
+    let encoded = if str.is_utf16() {
         this.encode_utf16(global, str.utf16())
     } else {
         this.encode_latin1(global, str.latin1())
-    }
+    };
+    bun_jsc::to_js_host_fn_result(global, encoded)
 }
 
 #[unsafe(no_mangle)]
@@ -265,7 +266,7 @@ pub extern "C" fn TextEncoderStreamEncoder__flushForStream(
     global: &JSGlobalObject,
 ) -> JSValue {
     // SAFETY: as in `TextEncoderStreamEncoder__encodeForStream`.
-    unsafe { &*this }.flush_body(global)
+    bun_jsc::to_js_host_fn_result(global, unsafe { &*this }.flush_body(global))
 }
 
 /// Cap on the reusable scratch buffer so a single huge chunk doesn't pin

--- a/src/sql_jsc/shared/ObjectIterator.rs
+++ b/src/sql_jsc/shared/ObjectIterator.rs
@@ -67,19 +67,18 @@ impl<'a> ObjectIterator<'a> {
                 )));
             }
 
-            // `get_own_by_value` maps the C++ empty (zero) return to `None`,
-            // so the `Some(JSValue::ZERO)` comparison below is defensively dead
-            // (an unwrapped value is never zero).
-            let value: Option<JSValue> = self.current_row.get_own_by_value(global_object, property);
-            if value == Some(JSValue::ZERO) || value.is_some_and(|v| v.is_undefined()) {
-                if !global_object.has_exception() {
-                    break 'out Err(global_object.throw(format_args!(
-                        "Expected a value at index {} in row {}",
-                        cell_i, row_i
-                    )));
+            let value = match self.current_row.get_own_by_value(global_object, property) {
+                Ok(v) => v,
+                Err(_) => {
+                    self.any_failed = true;
+                    break 'out Ok(None);
                 }
-                self.any_failed = true;
-                break 'out Ok(None);
+            };
+            if value.is_some_and(|v| v.is_undefined()) {
+                break 'out Err(global_object.throw(format_args!(
+                    "Expected a value at index {} in row {}",
+                    cell_i, row_i
+                )));
             }
             Ok(value)
         };

--- a/test/internal/source-lints/jsresult-swallow.inventory.json
+++ b/test/internal/source-lints/jsresult-swallow.inventory.json
@@ -17,9 +17,6 @@
   "src/runtime/node/node_fs.rs": {
     "discarded result of a call that enters script": 1
   },
-  "src/runtime/test_runner/timers/FakeTimers.rs": {
-    "discarded result of a call that enters script": 1
-  },
   "src/runtime/webcore/Request.rs": {
     "JsResult collapsed on the spot": 1
   },

--- a/test/js/bun/jsc/exception-checks.test.ts
+++ b/test/js/bun/jsc/exception-checks.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Each snippet reaches a native code path that used to run a second JSC
+// operation, or return from a ThrowScope, while an exception check was still
+// pending. On a debug build BUN_JSC_validateExceptionChecks=1 aborts the
+// process at that point, so the assertion is that the snippet completes and
+// prints its marker. On a release build the validator is compiled out and the
+// test only checks the behavior.
+const snippets: Record<string, { code: string; stdout: string }> = {
+  "Bun.deepEquals with one argument": {
+    code: `try { Bun.deepEquals(1); } catch (e) { console.log(e.constructor.name + ": " + e.message); }`,
+    stdout: "TypeError: Expected 2 values to compare",
+  },
+};
+
+for (const [name, { code, stdout: expected }] of Object.entries(snippets)) {
+  test.concurrent(name, async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1", BUN_JSC_dumpSimulatedThrows: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The validator prints the two scopes involved before it aborts; keep
+    // them in the comparison so a failure names the call site.
+    const unchecked = stderr
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
+    expect({ stdout: stdout.trim(), unchecked, exitCode }).toEqual({ stdout: expected, unchecked: [], exitCode: 0 });
+  });
+}

--- a/test/js/bun/jsc/exception-checks.test.ts
+++ b/test/js/bun/jsc/exception-checks.test.ts
@@ -7,10 +7,25 @@ import { bunEnv, bunExe } from "harness";
 // process at that point, so the assertion is that the snippet completes and
 // prints its marker. On a release build the validator is compiled out and the
 // test only checks the behavior.
+// A string built at run time is a rope; reading it resolves the rope under a
+// ThrowScope, which is what makes the snippets below observable to the
+// validator.
 const snippets: Record<string, { code: string; stdout: string }> = {
   "Bun.deepEquals with one argument": {
     code: `try { Bun.deepEquals(1); } catch (e) { console.log(e.constructor.name + ": " + e.message); }`,
     stdout: "TypeError: Expected 2 values to compare",
+  },
+  "process.umask with a rope string": {
+    code: `const a = "0"; const b = "22"; const old = process.umask(a + b); process.umask(old); console.log(typeof old);`,
+    stdout: "number",
+  },
+  "process.exitCode assigned a rope string": {
+    code: `const a = "1"; const b = "0"; process.exitCode = a + b; console.log(process.exitCode); process.exitCode = 0;`,
+    stdout: "10",
+  },
+  "process.kill with an unknown rope signal name": {
+    code: `const a = "SIG"; const b = "BOGUS"; try { process.kill(process.pid, a + b); } catch (e) { console.log(e.code); }`,
+    stdout: "ERR_UNKNOWN_SIGNAL",
   },
 };
 


### PR DESCRIPTION
### Problem
- Native code must check for a pending JS exception before the next JS-observable call and before it returns from a `ThrowScope`. A missing check asserts on debug builds (`ERROR: Unchecked JS exception` from `VM::verifyExceptionCheckNeedIsSatisfied`). On release builds the code runs on a dummy result, a later unrelated check misattributes the error, or a second throw overwrites it.
- Coverage was dynamic only (`BUN_JSC_validateExceptionChecks=1` on the ASAN lane), so a path no test executes was never checked.

### Fix
- `scripts/jsc-exception-lint`: a clang LibTooling checker that models the validator's state machine over the CFG of every function in `src/**/*.cpp`. Callees are classified from visible bodies, then from summary passes over the JavaScriptCore sources and Bun's bindings, then from the `JSGlobalObject*` / `ThrowScope&` convention. `run.ts` drives it; `rust-externs.ts` cross-checks hand-declared Rust externs.
- Fixes its findings: `RETURN_IF_EXCEPTION` after the throwing call, `RELEASE_AND_RETURN` for tail calls, `asNumber()`/`asInt32()` after a type check instead of the throwing coercion, one nested `DECLARE_THROW_SCOPE` removed. Rust externs whose C++ body throws go through the scope helpers and return `JsResult`. No termination special cases, no `clearException`.
- Not touched: the files and functions #40068 and #40249 cover (napi, v8, JSMockFunction, ErrorCode, MIME, asymmetric matchers). The JSC-side sites are in oven-sh/WebKit#514; their skip-list entries stay until that bump.
- Verified: `test/js/bun/jsc/exception-checks.test.ts` (new; each snippet aborted the validator before), the affected suites under the validator (sqlite, process, ffi, headers, streams, workers, vm, buffer, crypto), and `bun run rust:check` for linux, windows and macOS.

### Background
- The validator: every `ThrowScope` destructor sets `VM::m_needExceptionCheck`. The next `ThrowScope` constructor or non-released destructor asserts if it is still set. Only `exception()` (what `RETURN_IF_EXCEPTION` expands to), `clearException()` and `assertNoException` clear it. The tool reports the states in which those asserts fire, plus a call made after the function already threw.
- A summary is a callee's exit state set: clean, check pending, thrown, or conditional thrower (the caller tests the return value; reported only with `--kind maybe-thrown-call`). Each pass resolves one more level of cross-file calls, so JSC gets three passes (cached per WebKit version).
- Rust-implemented `extern "C"` functions run under their own scope and signal a throw with a sentinel, so the C++ side sees them as conditional throwers.

<details><summary>Notes</summary>

Numbers. First pass over `src/jsc/bindings` with only the signature convention: 2194 findings. With JSC and Bun summaries, the TopExceptionScope model, template-aware carrier detection, and the Rust-extern rule: 667 findings in 103 files (480 pending-call, 164 unchecked-exit, 13 nested scope, 10 call-after-throw). 603 were in scope for this PR after excluding the files above. After the fixes: 113 in 21 files, of which 72 are in the excluded files and the rest were reviewed as false positives (generated `JSSink` and `ZigGeneratedClasses` code, `JSSetIterator::next` in `Keys` mode, `JSFunction::name`, `getCalculatedDisplayName`, `rejectWithCaughtException` right after a throw, global object construction). Those need entries in `nothrow.txt` or the summary pass over `build/*/codegen` the driver now does.

What the tool does not see: a throwing call whose result is passed straight into another call and then `RELEASE_AND_RETURN` (the JSMockFunction pattern #40068 fixes) is legal for the validator and not reported. That needs value tracking. Exceptions observed only through a return value (`if (!result) return {}` after a helper that throws into the caller's scope) are reported as `maybe-thrown-call` and hidden by default.

Running it: `bun scripts/jsc-exception-lint/run.ts` needs a configured debug build (`build/debug/compile_commands.json`) and the LLVM 21 development package (`libclang-cpp`, headers; CI's `llvm.sh 21 all` installs them). The first run parses the JSC sources three times (about 30 minutes, cached in `build/debug/jsc-exception-lint/`); later runs take about 15 minutes. A CI step on the linux debug lane after the C++ build is the natural next step; this PR does not add it.

How the fixes were made: the findings were split by file and fixed in parallel under one written rule set (`RETURN_IF_EXCEPTION` only, no termination special cases, report false positives instead of editing), then the tree was rebuilt, re-analyzed, and a second pass handled the remainder. I reverted two of the resulting hunks by hand (a scope added to `rsisDetachNativeTransform`, a no-op branch in `JSCTaskScheduler.cpp`) because they rested on a stale classification of callees that cannot throw.

Dynamic runs: `test/js/bun/util/BunObject.test.ts` and `test/js/bun/jsonl/jsonl-parse.test.ts` still abort under the validator on the JSC-side sites (oven-sh/WebKit#514). `test/js/node/test/parallel/test-repl-inspect-defaults.js` is the JSONP `doGet` case in the same PR. Tests that failed in my container (worker message flood, ffi FTL warm-up, node:util parseArgs stress, stdin fixtures, IPv6 fetch, root-permission checks) fail identically on an unmodified main build there.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 115 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/jsc/exception-checks.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/jsc/exception-checks.test.ts:
(pass) process.exitCode assigned a rope string [272.39ms]
(pass) process.kill with an unknown rope signal name [268.19ms]
(pass) process.umask with a rope string [340.13ms]
42 |     // them in the comparison so a failure names the call site.
43 |     const unchecked = stderr
44 |       .split("\n")
45 |       .map(line => line.trim())
46 |       .filter(line => line.startsWith("This scope can throw") || line.startsWith("But the exception was unchecked"));
47 |     expect({ stdout: stdout.trim(), unchecked, exitCode }).toEqual({ stdout: expected, unchecked: [], exitCode: 0 });
                                                                ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stdout": "TypeError: Expected 2 values to compare",
-   "unchecked": [],
+   "exitCode": 134,
+   "stdout": "",
+   "unchecked": [
+     "This scope can throw a JS exception: functionBunDeepEquals @ ../../src/jsc/bindin
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (a95369a05)

test/js/bun/jsc/exception-checks.test.ts:
(pass) process.umask with a rope string [4.80ms]
(pass) Bun.deepEquals with one argument [5.74ms]
(pass) process.exitCode assigned a rope string [4.57ms]
(pass) process.kill with an unknown rope signal name [4.33ms]

 4 pass
 0 fail
 4 expect() calls
Ran 4 tests across 1 file. [91.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/jsc/exception-checks.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/jsc/exception-checks.test.ts:
(pass) Bun.deepEquals with one argument [313.84ms]
(pass) process.umask with a rope string [277.49ms]
(pass) process.exitCode assigned a rope string [276.65ms]
(pass) process.kill with an unknown rope signal name [272.38ms]

 4 pass
 0 fail
 4 expect() calls
Ran 4 tests across 1 file. [2.32s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 628ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/60] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[2/60] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/60] gen cpp.rs (cppbind)
[4/60] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/60] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 242 extern-C blocks audited
[6/60] gen BunObject.lut.h
Generating /workspace/bun/build/release/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[7/60] gen JS modules (bundle-modules)
Preprocess modules (7492ms)
Bundle modules (48ms)
Postprocesss modules (96ms)
Bundle Functions (491ms)
Generate Code (32ms)

[8.17s] Bundled "src/js" for production
  2594 kb
  197 internal modules
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/jsc-exception-lint/README.md               |   83 ++
 scripts/jsc-exception-lint/jsc-exception-lint.cpp  | 1184 ++++++++++++++++++++
 scripts/jsc-exception-lint/nothrow.txt             |  112 ++
 scripts/jsc-exception-lint/run.ts                  |  450 ++++++++
 scripts/jsc-exception-lint/rust-externs.ts         |  142 +++
 src/http_jsc/headers_jsc.rs                        |    2 -
 src/jsc/ConsoleObject.rs                           |    4 +-
 src/jsc/FetchHeaders.rs                            |   18 +-
 src/jsc/JSGlobalObject.rs                          |   34 +-
 src/jsc/JSObject.rs                                |   18 +-
 src/jsc/JSUint8Array.rs                            |   23 +-
 src/jsc/JSValue.rs                                 |   43 +-
 src/jsc/VirtualMachine.rs                          |    7 +-
 src/jsc/array_buffer.rs                            |   16 +-
 src/jsc/bindings/BunDebugger.cpp                   |    7 +-
 src/jsc/bindings/BunInjectedScriptHost.cpp         |   34 +-
 src/jsc/bindings/BunObject.cpp                     |   13 +-
 src/jsc/bindings/BunPlugin.cpp                     |   20 +-
 src/jsc/bindings/BunProcess.cpp                    |   72 +-
 src/jsc/bindings/BunProcessReportObjectWindows.cpp |    1 +
 src/jsc/bindings/BunString.cpp                     |    2 +
 src/jsc/bindings/CallSite.cpp                      |    5 +
 src/jsc/bindings/CallSitePrototype.cpp             |    1 +
 src/jsc/bindings/ConsoleObject.cpp                 |    7 +-
 src/jsc/bindings/ErrorStackTrace.cpp               |   39 +-
 src/jsc/bindings/FormatStackTraceForJS.cpp         |    9 +-
 src/jsc/bindings/HTMLEntryPoint.cpp                |    2 +-
 src/jsc/bindings/ImportMetaObject.cpp              |    1 -
 src/jsc/bindings/InspectorLifecycleAgent.cpp       |    1 +
 src/jsc/bindings/InternalModuleRegistry.cpp        |    1 +
 src/jsc/bindings/JSBuffer.cpp                      |   12 +-
 src/jsc/bindings/JSCTestingHelpers.cpp       
... (truncated)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
scripts/jsc-exception-lint/README.md                   0      1      0
scripts/jsc-exception-lint/jsc-exception-lint.cpp      2      4      0
scripts/jsc-exception-lint/nothrow.txt                 0      1      0
scripts/jsc-exception-lint/run.ts                      0      1      0
scripts/jsc-exception-lint/rust-externs.ts             0      1      0
src/http_jsc/headers_jsc.rs                            0      0      0
src/jsc/ConsoleObject.rs                               0      0      0
src/jsc/FetchHeaders.rs                                0      0      0
src/jsc/JSGlobalObject.rs                              0      0      0
src/jsc/JSObject.rs                                    0      0      0
src/jsc/JSUint8Array.rs                                0      0      0
src/jsc/JSValue.rs                                     0      0      0
src/jsc/VirtualMachine.rs                              0      0      0
src/jsc/array_buffer.rs                                0      0      0
src/jsc/bindings/BunDebugger.cpp                       0      0      0
src/jsc/bindings/BunInjectedScriptHost.cpp             0      0      0
(+ 99 more files)
```

</details>

<!-- robobun:evidence:end -->