### PR TITLE
tls: close a destroyed TLS socket with a bare FIN, no close_notify

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1849,7 +1849,7 @@ static int ssl_renegotiate(struct us_socket_t *s) {
 
 /* Returns 1 if shutdown is complete (or impossible) and the TCP socket may be
  * closed; 0 if we sent close_notify but must wait for the peer's. */
-static int ssl_handle_shutdown(struct us_socket_t *s, int force_fast_shutdown) {
+static int ssl_handle_shutdown(struct us_socket_t *s) {
     if (!s->ssl || us_internal_ssl_is_shut_down(s) || s->ssl_fatal_error || !SSL_is_init_finished(s_ssl(s)))
     return 1;
 
@@ -1859,7 +1859,6 @@ static int ssl_handle_shutdown(struct us_socket_t *s, int force_fast_shutdown) {
   if (!sent_shutdown || !received_shutdown) {
     ssl_set_loop_data(s);
     int ret = SSL_shutdown(s_ssl(s));
-    if (ret == 0 && force_fast_shutdown) ret = SSL_shutdown(s_ssl(s));
     if (ret < 0) {
       int err = SSL_get_error(s_ssl(s), ret);
       if (err == SSL_ERROR_SSL || err == SSL_ERROR_SYSCALL) {
@@ -1942,9 +1941,14 @@ struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void 
     if (ssl_gone(s)) return s;
   }
 
-  /* code == 2 (forceful — `_destroy()` / `_handle.close()`): send close_notify
-   * best-effort and raw-close now. The destroy path detaches + poll_ref.unref()
-   * right after, so deferring would orphan the us_socket_t.
+  /* code == 2 (forceful — `_destroy()` / `_handle.close()`): raw-close now,
+   * with no close_notify — a bare FIN, like node's destroy (crypto_tls.cc
+   * only sends the alert from DoShutdown, the end() path). A destroy-time
+   * alert would land in the peer's receive buffer ahead of the FIN, and a
+   * peer whose stream is paused never reads it, which holds that stream's
+   * 'end'/'close' back forever (node semantics). The destroy path also
+   * detaches + poll_ref.unref() right after, so deferring would orphan the
+   * us_socket_t.
    *
    * code == 1 (reset — terminate() / abort): no close_notify, only the RST,
    * like node's resetAndDestroy().
@@ -1957,7 +1961,7 @@ struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void 
    * under low-prio fan-out (connectionListener race). The actual raw-close
    * happens via on_end/ZERO_RETURN re-entering this function with
    * SSL_SENT_SHUTDOWN already set (ssl_handle_shutdown then returns 1). */
-  if (code == LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET || ssl_handle_shutdown(s, code != 0)) {
+  if (code != LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN || ssl_handle_shutdown(s)) {
     return us_internal_socket_close_raw(s, code, reason);
   }
   return s;
@@ -2608,7 +2612,7 @@ void us_internal_ssl_shutdown(struct us_socket_t *s) {
     /* ssl_handle_shutdown sends the close_notify (BoringSSL's do_tls_write
      * prepends any pending TLS 1.3 NewSessionTicket flight to the alert, so
      * tickets are still delivered) and owns the error handling. */
-    ssl_handle_shutdown(s, 0);
+    ssl_handle_shutdown(s);
     us_internal_socket_raw_shutdown(s);
     return;
   }

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -65,6 +65,11 @@ pub(crate) struct UpgradedDuplex {
     /// Replayed by [`Self::drain_pending`] after the staged bytes, preserving
     /// the original data-then-EOF order.
     pub pending_end: Cell<bool>,
+    /// The transport delivered EOF (its 'end' event fired). Teardown-phase
+    /// bytes (close_notify, the trailing end()) are dropped after this: node
+    /// writes nothing into a transport that already ended, and a transport
+    /// that forwards to an auto-ended net.Socket throws writeAfterFIN (EPIPE).
+    pub transport_eof: Cell<bool>,
 }
 
 bun_event_loop::impl_timer_owner!(UpgradedDuplex; from_timer_ptr => event_loop_timer);
@@ -231,6 +236,9 @@ impl UpgradedDuplex {
         // probe so write-after-end still errors like node.
         let teardown = data.is_none() || self.wrapper_ref().is_some_and(|w| w.is_shutdown());
         if teardown {
+            if self.transport_eof.get() {
+                return;
+            }
             match duplex.get(&global, "writableEnded") {
                 Ok(Some(ended)) if ended.to_boolean() => return,
                 Ok(_) => {}
@@ -397,6 +405,7 @@ impl UpgradedDuplex {
             current_timeout: Cell::new(0),
             pending_data: JsCell::new(Vec::new()),
             pending_end: Cell::new(false),
+            transport_eof: Cell::new(false),
         }
     }
 
@@ -677,6 +686,7 @@ impl UpgradedDuplex {
         self.ssl_error.set(CertError::default());
         self.pending_data.set(Vec::new());
         self.pending_end.set(false);
+        self.transport_eof.set(false);
     }
 }
 
@@ -735,6 +745,7 @@ fn on_end(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         // SAFETY: see host-fn note above.
         let this = unsafe { &*self_ptr.cast::<UpgradedDuplex>() };
 
+        this.transport_eof.set(true);
         if this.wrapper_ref().is_some() {
             (this.handlers.on_end)(this.handlers.ctx);
         } else {

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -65,10 +65,8 @@ pub(crate) struct UpgradedDuplex {
     /// Replayed by [`Self::drain_pending`] after the staged bytes, preserving
     /// the original data-then-EOF order.
     pub pending_end: Cell<bool>,
-    /// The transport delivered EOF (its 'end' event fired). Teardown-phase
-    /// bytes (close_notify, the trailing end()) are dropped after this: node
-    /// writes nothing into a transport that already ended, and a transport
-    /// that forwards to an auto-ended net.Socket throws writeAfterFIN (EPIPE).
+    /// The transport delivered EOF (its 'end' event fired). Teardown payloads
+    /// (close_notify) are dropped after this; see [`Self::call_write_or_end`].
     pub transport_eof: Cell<bool>,
 }
 
@@ -236,7 +234,13 @@ impl UpgradedDuplex {
         // probe so write-after-end still errors like node.
         let teardown = data.is_none() || self.wrapper_ref().is_some_and(|w| w.is_shutdown());
         if teardown {
-            if self.transport_eof.get() {
+            // A teardown payload (close_notify) after the transport's readable
+            // side ended has no reader behind it: node writes nothing there,
+            // and a transport that forwards into an auto-ended net.Socket
+            // throws writeAfterFIN (EPIPE). The trailing end() is not a write
+            // and still goes through the writableEnded probe below, so a
+            // half-open transport sees our FIN.
+            if data.is_some() && self.transport_eof.get() {
                 return;
             }
             match duplex.get(&global, "writableEnded") {

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3186,14 +3186,14 @@ impl<const SSL: bool> NewSocket<SSL> {
         // `on_connecting_error` synchronously inside `close()` and so does
         // its own `deref()`; double-releasing it would underflow.
         let is_semi_connect = socket.socket.get().is_some() && !socket.is_established();
-        // `_handle.close()` is the net.Socket `_destroy()` path — Node emits close_notify
-        // once and closes the fd without waiting for the peer's reply. `.fast_shutdown`
-        // makes `ssl_handle_shutdown` take the fast branch so the raw close runs
-        // synchronously (with `.normal` the SSL layer defers waiting for the peer, but we
-        // detach + unref immediately below, orphaning the `us_socket_t`). NOT `.failure`:
-        // that arms SO_LINGER{1,0} → RST and drops any data still in the kernel send
-        // buffer, which `destroy()` after `write()` must not do. The SSL layer may
-        // defer this close behind its own ciphertext write spill
+        // `_handle.close()` is the net.Socket `_destroy()` path — Node closes the fd
+        // with no close_notify (crypto_tls.cc only sends the alert from DoShutdown,
+        // the end() path), so `.fast_shutdown` raw-closes synchronously: a bare FIN
+        // (with `.normal` the SSL layer sends close_notify and defers waiting for the
+        // peer, but we detach + unref immediately below, orphaning the `us_socket_t`).
+        // NOT `.failure`: that arms SO_LINGER{1,0} → RST and drops any data still in
+        // the kernel send buffer, which `destroy()` after `write()` must not do. The
+        // SSL layer may defer this close behind its own ciphertext write spill
         // (`ssl_close_after_spill`) until the kernel takes the spill or the peer's
         // FIN arrives, with no timeout; a peer that stopped reading holds it open.
         socket.close(uws::CloseCode::FastShutdown);

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3186,16 +3186,14 @@ impl<const SSL: bool> NewSocket<SSL> {
         // `on_connecting_error` synchronously inside `close()` and so does
         // its own `deref()`; double-releasing it would underflow.
         let is_semi_connect = socket.socket.get().is_some() && !socket.is_established();
-        // `_handle.close()` is the net.Socket `_destroy()` path — Node closes the fd
-        // with no close_notify (crypto_tls.cc only sends the alert from DoShutdown,
-        // the end() path), so `.fast_shutdown` raw-closes synchronously: a bare FIN
-        // (with `.normal` the SSL layer sends close_notify and defers waiting for the
-        // peer, but we detach + unref immediately below, orphaning the `us_socket_t`).
-        // NOT `.failure`: that arms SO_LINGER{1,0} → RST and drops any data still in
-        // the kernel send buffer, which `destroy()` after `write()` must not do. The
-        // SSL layer may defer this close behind its own ciphertext write spill
-        // (`ssl_close_after_spill`) until the kernel takes the spill or the peer's
-        // FIN arrives, with no timeout; a peer that stopped reading holds it open.
+        // `_handle.close()` is the net.Socket `_destroy()` path. Node closes the fd
+        // with no close_notify (crypto_tls.cc sends the alert only from DoShutdown,
+        // the end() path), so `.fast_shutdown` raw-closes synchronously: a bare FIN.
+        // Not `.normal`: that defers for the peer's reply while we detach + unref
+        // below, orphaning the `us_socket_t`. Not `.failure`: that arms
+        // SO_LINGER{1,0} → RST and drops data still in the kernel send buffer,
+        // which `destroy()` after `write()` must not do. The SSL layer may still
+        // defer behind its ciphertext write spill (`ssl_close_after_spill`).
         socket.close(uws::CloseCode::FastShutdown);
         this.socket.set(SocketHandler::<SSL>::DETACHED);
         let _ = global;

--- a/test/regression/issue/40401.test.ts
+++ b/test/regression/issue/40401.test.ts
@@ -1,0 +1,71 @@
+// https://github.com/oven-sh/bun/issues/40401
+// Destroying a TLS socket layered over a caller-supplied socket (undici's
+// SOCKS5 + requestTls flow) must tear the connection down like node: a bare
+// FIN, with no close_notify written from the destroy path (node only sends
+// the alert from the end() path). A destroy-time alert lands in the tunnel
+// proxy's receive buffer ahead of the FIN. The proxy's socket is paused once
+// its pipe target is gone, the alert is never read, and node stream
+// semantics then withhold 'end'/'close' forever, so the proxy leaks one
+// connection per request.
+import { expect, test } from "bun:test";
+import { tls as tlsCert } from "harness";
+import { once } from "node:events";
+import net from "node:net";
+import tls from "node:tls";
+
+const listen = (server: net.Server) =>
+  new Promise<number>(resolve =>
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port)),
+  );
+
+test("destroying a TLS socket over a tunneled net.Socket sends a bare FIN", async () => {
+  // TLS echo target. It never closes its side, so every byte the tunnel sees
+  // from the client after the reply comes from the client's own teardown.
+  const target = tls.createServer({ cert: tlsCert.cert, key: tlsCert.key }, socket => {
+    socket.on("error", () => {});
+    socket.on("data", () => socket.write("ok"));
+  });
+  const targetPort = await listen(target);
+
+  // Byte-piping tunnel proxy, as a SOCKS5 proxy is after CONNECT.
+  let countTeardownBytes = false;
+  let teardownBytes = 0;
+  const clientEnded = Promise.withResolvers<void>();
+  const clientClosed = Promise.withResolvers<void>();
+  const proxy = net.createServer(client => {
+    client.on("error", () => {});
+    client.on("data", chunk => {
+      if (countTeardownBytes) teardownBytes += chunk.length;
+    });
+    client.on("end", () => clientEnded.resolve());
+    client.on("close", () => clientClosed.resolve());
+    const up = net.connect(targetPort, "127.0.0.1");
+    up.on("error", () => {});
+    client.pipe(up);
+    up.pipe(client);
+  });
+  const proxyPort = await listen(proxy);
+
+  // The client: a raw socket through the tunnel, TLS layered on top.
+  const raw = net.connect(proxyPort, "127.0.0.1");
+  await once(raw, "connect");
+  const secure = tls.connect({ socket: raw, ca: tlsCert.cert, servername: "localhost" });
+  secure.on("error", () => {});
+  await once(secure, "secureConnect");
+
+  secure.write("hello");
+  const [reply] = await once(secure, "data");
+  expect(reply.toString()).toBe("ok");
+
+  // Destroy, as undici does when a response carries 'connection: close'.
+  // Node sends nothing here, only the FIN.
+  countTeardownBytes = true;
+  secure.destroy();
+
+  await clientEnded.promise;
+  expect(teardownBytes).toBe(0);
+  await clientClosed.promise;
+
+  proxy.close();
+  target.close();
+});

--- a/test/regression/issue/40401.test.ts
+++ b/test/regression/issue/40401.test.ts
@@ -48,24 +48,27 @@ test("destroying a TLS socket over a tunneled net.Socket sends a bare FIN", asyn
 
   // The client: a raw socket through the tunnel, TLS layered on top.
   const raw = net.connect(proxyPort, "127.0.0.1");
-  await once(raw, "connect");
-  const secure = tls.connect({ socket: raw, ca: tlsCert.cert, servername: "localhost" });
-  secure.on("error", () => {});
-  await once(secure, "secureConnect");
+  try {
+    await once(raw, "connect");
+    const secure = tls.connect({ socket: raw, ca: tlsCert.cert, servername: "localhost" });
+    secure.on("error", () => {});
+    await once(secure, "secureConnect");
 
-  secure.write("hello");
-  const [reply] = await once(secure, "data");
-  expect(reply.toString()).toBe("ok");
+    secure.write("hello");
+    const [reply] = await once(secure, "data");
+    expect(reply.toString()).toBe("ok");
 
-  // Destroy, as undici does when a response carries 'connection: close'.
-  // Node sends nothing here, only the FIN.
-  countTeardownBytes = true;
-  secure.destroy();
+    // Destroy, as undici does when a response carries 'connection: close'.
+    // Node sends nothing here, only the FIN.
+    countTeardownBytes = true;
+    secure.destroy();
 
-  await clientEnded.promise;
-  expect(teardownBytes).toBe(0);
-  await clientClosed.promise;
-
-  proxy.close();
-  target.close();
+    await clientEnded.promise;
+    expect(teardownBytes).toBe(0);
+    await clientClosed.promise;
+  } finally {
+    raw.destroy();
+    proxy.close();
+    target.close();
+  }
 });

--- a/test/regression/issue/40401.test.ts
+++ b/test/regression/issue/40401.test.ts
@@ -14,9 +14,10 @@ import net from "node:net";
 import tls from "node:tls";
 
 const listen = (server: net.Server) =>
-  new Promise<number>(resolve =>
-    server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port)),
-  );
+  new Promise<number>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port));
+  });
 
 test("destroying a TLS socket over a tunneled net.Socket sends a bare FIN", async () => {
   // TLS echo target. It never closes its side, so every byte the tunnel sees
@@ -25,11 +26,11 @@ test("destroying a TLS socket over a tunneled net.Socket sends a bare FIN", asyn
     socket.on("error", () => {});
     socket.on("data", () => socket.write("ok"));
   });
-  const targetPort = await listen(target);
 
   // Byte-piping tunnel proxy, as a SOCKS5 proxy is after CONNECT.
   let countTeardownBytes = false;
   let teardownBytes = 0;
+  let targetPort = 0;
   const clientEnded = Promise.withResolvers<void>();
   const clientClosed = Promise.withResolvers<void>();
   const proxy = net.createServer(client => {
@@ -44,11 +45,14 @@ test("destroying a TLS socket over a tunneled net.Socket sends a bare FIN", asyn
     client.pipe(up);
     up.pipe(client);
   });
-  const proxyPort = await listen(proxy);
 
-  // The client: a raw socket through the tunnel, TLS layered on top.
-  const raw = net.connect(proxyPort, "127.0.0.1");
+  let raw: net.Socket | undefined;
   try {
+    targetPort = await listen(target);
+    const proxyPort = await listen(proxy);
+
+    // The client: a raw socket through the tunnel, TLS layered on top.
+    raw = net.connect(proxyPort, "127.0.0.1");
     await once(raw, "connect");
     const secure = tls.connect({ socket: raw, ca: tlsCert.cert, servername: "localhost" });
     secure.on("error", () => {});
@@ -67,7 +71,7 @@ test("destroying a TLS socket over a tunneled net.Socket sends a bare FIN", asyn
     expect(teardownBytes).toBe(0);
     await clientClosed.promise;
   } finally {
-    raw.destroy();
+    raw?.destroy();
     proxy.close();
     target.close();
   }

--- a/test/regression/issue/40401.test.ts
+++ b/test/regression/issue/40401.test.ts
@@ -34,7 +34,9 @@ test("destroying a TLS socket over a tunneled net.Socket sends a bare FIN", asyn
   const clientEnded = Promise.withResolvers<void>();
   const clientClosed = Promise.withResolvers<void>();
   const proxy = net.createServer(client => {
-    client.on("error", () => {});
+    // A client error (an RST regression in the destroy path) must fail the
+    // awaited 'end', not hang the test to its timeout.
+    client.on("error", clientEnded.reject);
     client.on("data", chunk => {
       if (countTeardownBytes) teardownBytes += chunk.length;
     });


### PR DESCRIPTION
### Problem
- Follow-up to #40306 for issue #40401. When undici layers a `TLSSocket` over a caller-supplied socket (the SOCKS5 + `requestTls` flow), the proxy keeps one connection open per HTTPS request. The issue's repro leaks 5/5 tunnels on 1.4.1, 0/5 on node and bun 1.3.14.
- Destroying a TLS socket (`socket.destroy()`, which undici calls after a `connection: close` response) writes a close_notify alert before it closes the fd (`us_internal_ssl_close`, `packages/bun-usockets/src/crypto/openssl.c:1960`). Node sends nothing there, only the FIN. The alert lands in the proxy's receive buffer ahead of the FIN. The proxy's socket is paused (its pipe target is gone), the alert is never read, and stream semantics withhold 'end' and 'close' forever.

### Fix
- A forceful close (`LIBUS_SOCKET_CLOSE_CODE_FAST_SHUTDOWN`, the `_handle.close()` destroy path) now raw-closes at once with no close_notify: a bare FIN, like node. crypto_tls.cc sends the alert only from `DoShutdown`, the `end()` path. Measured with a byte-counting relay: node writes 0 bytes at destroy, bun wrote an 88-byte alert flight.
- A TLS socket over a generic Duplex (`UpgradedDuplex`) now drops its teardown payloads (the close_notify flush) once the transport's 'end' event fired. Node writes nothing there. Bun's reply alert after EOF hit `writeAfterFIN` (EPIPE) when the Duplex forwards to an auto-ended net.Socket, which failed the https clientError test in CI. The trailing `end()` still goes through the existing `writableEnded` probe, so a half-open transport sees our FIN.
- The graceful paths do not change. `end()` still sends close_notify, and a close that answers the peer's close_notify or FIN (code 0) still replies.
- Verified: `test/regression/issue/40401.test.ts` (released bun fails it with 24 stray bytes). The issue's undici repro goes from 5/5 leaked tunnels to 0/5. Also the node tls, net, http, http2, bun socket, fetch, websocket, proxy and valkey suites (remaining failures match the released binary or main's debug build, notes).

### Background
- `tls.connect({ socket })` on an established net.Socket upgrades it natively: the raw handle and the TLS handle share one `us_socket_t`, and `_destroy()` closes that handle with `CloseCode::FastShutdown`. On a generic Duplex the engine is `UpgradedDuplex`, whose ciphertext goes out through the duplex's JS `write`.
- `us_internal_ssl_close` dispatches on the close code: 0 is graceful (close_notify, defer for the peer's reply), 1 is `resetAndDestroy()` (RST), 2 is the destroy path.
- A paused node stream that has unread bytes buffered does not emit 'end' when the FIN arrives, in node and bun alike. So any byte sent right before the FIN leaks a receiver that nothing reads. That receiver is exactly a byte-piping proxy whose other side already closed.

<details><summary>Notes</summary>

Why only the TLS row of #40401 leaked: the two plain-HTTP rows send nothing at destroy, so #39830 fixed them. The TLS row still wrote the alert.

Why node is clean in the undici repro even though node replies close_notify to a received close_notify on the graceful path: undici destroys the socket at HTTP message complete, before the TLS layer processes the server's close_notify. A variant that waits for the TLS 'end' and then destroys leaks on node exactly like bun (verified), so the regression test destroys at message complete as undici does, and asserts at the byte level: after the reply, the tunnel sees zero bytes from the client before the FIN.

The duplex commit (0a56294): with the server now destroying with a bare FIN, the client's first teardown signal is the transport EOF. The duplex engine's graceful shutdown then flushed a close_notify into the transport after its 'end', which node does not do (probed with a logging relay: node writes nothing after EOF). `UpgradedDuplex` already dropped teardown bytes when the duplex's own `writableEnded` was true; the new `transport_eof` flag extends that guard to a transport whose far side ended. This fixed the CI failure in `node-http.test.ts` ("https 'clientError' for a connection whose handshake completes after close()"), where the EPIPE from `writeAfterFIN` surfaced as an unhandled error.

The Windows named-pipe arm of the same close dispatch (`pipe p => p.close()` in `src/uws_sys/socket.rs`, `WindowsNamedPipe::close`) still takes the graceful `shutdown(false)` and writes the alert into the pipe before `writer.end()`. That arm is intentionally excluded here: it predates this PR, TLS over a named pipe is not reachable by the reported leak (TCP tunnels), and switching it to the fast shutdown moves the wrapper's close callback to a different point in the Windows teardown, which needs its own Windows verification.

`ssl_handle_shutdown` loses its `force_fast_shutdown` parameter: the only caller that passed 1 was the code-2 path, which no longer calls it.

Suites run on the debug build (linux x64): `test/js/node/tls/` (1 failure, `SNICallback runs even when the requested servername matches the bind hostname`, ECONNREFUSED from the localhost-resolves-to-::1 container quirk, fails on the released binary too), `test/js/node/net/` (13 failures, 10 match the released binary, the other two pass individually, both are plain-TCP paths this diff cannot reach), `test/js/node/http/node-http.test.ts` (1 failure, `request via http proxy, issue#4295`, same ECONNREFUSED quirk on the released binary), `test/js/node/http2/` clean (484 tests), `test/js/bun/net/socket.test.ts` (released-binary failures plus one GC churn test that passes individually at 4.1s of its 5s budget), `test/js/web/fetch/fetch.test.ts` (failure set matches the released binary modulo debug-slowness timeouts on gc-heavy tests), `test/js/web/websocket/websocket.test.js` (same 2 failures as the released binary), `test/js/node/http/node-http-connect.test.ts` (1 failure, reproduced on main's debug build without this diff), `test/js/bun/http/proxy.test.ts` and `test/js/valkey/reliability/connection-failures.test.ts` clean, `node-https-checkServerIdentity`, `tls-connect-socket-churn`, `tls-syscall-fault`, `node-tls-connect`, `renegotiation`, `node-tls-duplex-close-throw-uaf` clean.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/40401.test.ts"
bun test v1.4.1 (861e9ae04)

test/regression/issue/40401.test.ts:
68 |     // Node sends nothing here, only the FIN.
69 |     countTeardownBytes = true;
70 |     secure.destroy();
71 | 
72 |     await clientEnded.promise;
73 |     expect(teardownBytes).toBe(0);
                               ^
error: expect(received).toBe(expected)

Expected: 0
Received: 24

      at <anonymous> (/workspace/bun/test/regression/issue/40401.test.ts:73:27)
(fail) destroying a TLS socket over a tunneled net.Socket sends a bare FIN [934.64ms]

 0 pass
 1 fail
 2 expect() calls
Ran 1 test across 1 file. [3.24s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: all passed
bun test v1.4.1-canary.1 (23bbd8c3b)

test/regression/issue/40401.test.ts:
(pass) destroying a TLS socket over a tunneled net.Socket sends a bare FIN [22.82ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [108.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/40401.test.ts"
bun test v1.4.1 (861e9ae04)

test/regression/issue/40401.test.ts:
(pass) destroying a TLS socket over a tunneled net.Socket sends a bare FIN [916.75ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [3.13s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 589ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/61] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[2/61] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/61] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 242 extern-C blocks audited
[4/61] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/61] gen cpp.rs (cppbind)
[6/61] gen BunObject.lut.h
Generating /workspace/bun/build/release/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[7/61] gen JS modules (bundle-modules)
Preprocess modules (7470ms)
Bundle modules (45ms)
Postprocesss modules (241ms)
Bundle Functions (479ms)
Generate Code (38ms)

[8.28s] Bundled "src/js" for production
  2594 kb
  197 internal module
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/openssl.c | 18 ++++---
 src/runtime/socket/UpgradedDuplex.rs       | 15 ++++++
 src/runtime/socket/socket_body.rs          | 18 +++----
 test/regression/issue/40401.test.ts        | 80 ++++++++++++++++++++++++++++++
 4 files changed, 114 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
packages/bun-usockets/src/crypto/openssl.c      1      3      0
src/runtime/socket/UpgradedDuplex.rs            3      9      0
src/runtime/socket/socket_body.rs               5      8      0
test/regression/issue/40401.test.ts             3      8      0
```

</details>

**root cause** · written by the author bot

Forceful destruction of a TLS socket layered over a caller-supplied transport attempted a graceful `close_notify` shutdown, which never propagated a FIN to the underlying socket, so a SOCKS proxy kept one tunnel open per request. The shutdown helper no longer performs the forced second `SSL_shutdown()` pass, and forceful closes now tear down the raw socket directly with a bare FIN rather than waiting on `close_notify`. The upgraded duplex also records transport EOF and drops any teardown payload once EOF is reached, ensuring the connection terminates promptly.

<!-- robobun:evidence:end -->