### PR TITLE
Remove dead code from the WebSocket client, ncrypto, bun_core, and misc JSC bindings

### DIFF
--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -123,15 +123,11 @@ pub use bun_core::base64::encode;
 
 /// [`encode`] appended to `out` (reserving the room itself); returns the number of bytes appended.
 pub fn encode_append(out: &mut Vec<u8>, source: &[u8]) -> usize {
-    encode_append_impl(out, source, false)
-}
-
-fn encode_append_impl(out: &mut Vec<u8>, source: &[u8], is_urlsafe: bool) -> usize {
-    let len = simdutf::base64::encode_len(source.len(), is_urlsafe);
+    let len = simdutf::base64::encode_len(source.len(), false);
     // SAFETY: `encode_raw` writes exactly `len` bytes into the `len` spare bytes reserved here.
     unsafe {
         bun_core::vec::fill_spare(out, len, |spare| {
-            let written = simdutf::base64::encode_raw(source, spare.as_mut_ptr(), is_urlsafe);
+            let written = simdutf::base64::encode_raw(source, spare.as_mut_ptr(), false);
             debug_assert_eq!(written, len);
             (written, written)
         })
@@ -156,13 +152,6 @@ fn simdutf_encode_len_url_safe(source_len: usize) -> usize {
 /// See the documentation for simdutf's `binary_to_base64` function for more details (simdutf_impl.h).
 pub fn encode_url_safe(dest: &mut [u8], source: &[u8]) -> usize {
     simdutf::base64::encode(source, dest, true)
-}
-
-/// [`encode_url_safe`] into a freshly-allocated `Vec<u8>`.
-pub fn simdutf_encode_url_safe_alloc(source: &[u8]) -> Vec<u8> {
-    let mut destination = Vec::new();
-    encode_append_impl(&mut destination, source, true);
-    destination
 }
 
 pub fn decode_len(source: &[u8]) -> usize {

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -598,25 +598,6 @@ pub fn rsplit_once_char(self_: &[u8], delimiter: u8) -> Option<(&[u8], &[u8])> {
     Some((&self_[..i], &self_[i + 1..]))
 }
 
-/// `str::split_once` for bytes with a multi-byte delimiter. An empty
-/// delimiter never matches.
-#[inline]
-pub fn split_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
-    let i = index_of(self_, delimiter)?;
-    Some((&self_[..i], &self_[i + delimiter.len()..]))
-}
-
-/// `str::rsplit_once` for bytes with a multi-byte delimiter. An empty
-/// delimiter never matches.
-#[inline]
-pub fn rsplit_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
-    if delimiter.is_empty() {
-        return None;
-    }
-    let i = last_index_of(self_, delimiter)?;
-    Some((&self_[..i], &self_[i + delimiter.len()..]))
-}
-
 pub struct SplitIterator<'a> {
     pub(crate) buffer: &'a [u8],
     pub(crate) index: Option<usize>,

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -598,6 +598,25 @@ pub fn rsplit_once_char(self_: &[u8], delimiter: u8) -> Option<(&[u8], &[u8])> {
     Some((&self_[..i], &self_[i + 1..]))
 }
 
+/// `str::split_once` for bytes with a multi-byte delimiter. An empty
+/// delimiter never matches.
+#[inline]
+pub fn split_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
+    let i = index_of(self_, delimiter)?;
+    Some((&self_[..i], &self_[i + delimiter.len()..]))
+}
+
+/// `str::rsplit_once` for bytes with a multi-byte delimiter. An empty
+/// delimiter never matches.
+#[inline]
+pub fn rsplit_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
+    if delimiter.is_empty() {
+        return None;
+    }
+    let i = last_index_of(self_, delimiter)?;
+    Some((&self_[..i], &self_[i + delimiter.len()..]))
+}
+
 pub struct SplitIterator<'a> {
     pub(crate) buffer: &'a [u8],
     pub(crate) index: Option<usize>,

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -18,7 +18,7 @@ use bun_collections::linear_fifo::DynamicBuffer;
 use bun_core::{EncodedSlice, strings};
 use bun_http::websocket::{Opcode, WebsocketHeader};
 use bun_io::KeepAlive;
-use bun_jsc::{self as jsc, GlobalRef, JSGlobalObject, JSValue};
+use bun_jsc::{self as jsc, GlobalRef, JSGlobalObject};
 use bun_ptr::{BackRef, JsCell, RefPtr, Root, ThisPtr};
 use bun_uws::{self as uws, NewSocketHandler, us_bun_verify_error_t};
 use bun_uws_sys::us_socket_t;
@@ -1291,34 +1291,6 @@ impl<const SSL: bool> WebSocket<SSL> {
         !tcp.is_closed() && !tcp.is_shutdown()
     }
 
-    pub(crate) fn write_blob(this: ThisPtr<Self>, blob_value: JSValue, op: u8) {
-        // See write_binary_data() — tunnel.write() can re-enter fail().
-        let _guard = this.ref_guard();
-
-        if !this.has_tcp() || op > 0xF {
-            this.dispatch_abrupt_close(ErrorCode::Ended);
-            return;
-        }
-
-        // Cast the JSValue to a Blob.
-        // `bun_jsc::webcore::Blob` is an opaque C-ABI shim (real
-        // layout lives in `bun_runtime::webcore::Blob`, a higher-tier crate).
-        // `from_js`/`shared_view` trampoline through extern fns to avoid the
-        // dep cycle — see `bun_jsc::webcore::Blob` impl block.
-        let Some(blob) = blob_value.as_class_ref::<bun_jsc::webcore::Blob>() else {
-            this.dispatch_abrupt_close(ErrorCode::Ended);
-            return;
-        };
-        let opcode = Opcode::from_raw(op);
-        let data = blob.shared_view();
-        if data.is_empty() {
-            let _ = this.send_data(Copy::Bytes(&[]), !this.has_backpressure(), opcode);
-            return;
-        }
-
-        this.send_frame(Copy::Bytes(data), data.len(), opcode);
-    }
-
     pub(crate) fn write_string(this: ThisPtr<Self>, str: &EncodedSlice, op: u8) {
         // See write_binary_data() — tunnel.write() can re-enter fail().
         let _guard = this.ref_guard();
@@ -1724,14 +1696,6 @@ pub fn bun__websocketclient__write_binary_data(
 ) {
     WebSocketClient::write_binary_data(this, bytes, op)
 }
-// HOST_EXPORT(Bun__WebSocketClient__writeBlob, c)
-pub fn bun__websocketclient__write_blob(
-    this: ThisPtr<crate::websocket_client::WebSocketClient>,
-    blob_value: JSValue,
-    op: u8,
-) {
-    WebSocketClient::write_blob(this, blob_value, op)
-}
 // HOST_EXPORT(Bun__WebSocketClient__writeString, c)
 pub fn bun__websocketclient__write_string(
     this: ThisPtr<crate::websocket_client::WebSocketClient>,
@@ -1783,22 +1747,6 @@ pub fn bun__websocketclienttls__init(
         secure,
     )
 }
-// HOST_EXPORT(Bun__WebSocketClientTLS__initWithTunnel, c)
-pub fn bun__websocketclienttls__init_with_tunnel(
-    outgoing: &crate::websocket_client::cpp_websocket::CppWebSocket,
-    tunnel: ThisPtr<crate::websocket_client::websocket_proxy_tunnel::WebSocketProxyTunnel>,
-    global_this: &JSGlobalObject,
-    buffered_data: Option<Box<crate::websocket_client::InitialData>>,
-    deflate_params: Option<&crate::websocket_client::websocket_deflate::Params>,
-) -> *mut crate::websocket_client::WebSocketClientTLS {
-    WebSocketClientTLS::init_with_tunnel(
-        outgoing,
-        tunnel,
-        global_this,
-        buffered_data,
-        deflate_params,
-    )
-}
 // HOST_EXPORT(Bun__WebSocketClientTLS__memoryCost, c)
 pub fn bun__websocketclienttls__memory_cost(
     this: &crate::websocket_client::WebSocketClientTLS,
@@ -1812,14 +1760,6 @@ pub fn bun__websocketclienttls__write_binary_data(
     op: u8,
 ) {
     WebSocketClientTLS::write_binary_data(this, bytes, op)
-}
-// HOST_EXPORT(Bun__WebSocketClientTLS__writeBlob, c)
-pub fn bun__websocketclienttls__write_blob(
-    this: ThisPtr<crate::websocket_client::WebSocketClientTLS>,
-    blob_value: JSValue,
-    op: u8,
-) {
-    WebSocketClientTLS::write_blob(this, blob_value, op)
 }
 // HOST_EXPORT(Bun__WebSocketClientTLS__writeString, c)
 pub fn bun__websocketclienttls__write_string(

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -256,15 +256,6 @@ JSC::JSString* JSCStackFrame::functionName()
     return jsString(this->m_vm, m_functionName);
 }
 
-JSC::JSString* JSCStackFrame::typeName()
-{
-    if (!m_typeName) {
-        m_typeName = retrieveTypeName();
-    }
-
-    return jsString(this->m_vm, m_typeName);
-}
-
 JSCStackFrame::SourcePositions* JSCStackFrame::getSourcePositions()
 {
     if (SourcePositionsState::NotCalculated == m_sourcePositionsState) {
@@ -336,12 +327,6 @@ ALWAYS_INLINE String JSCStackFrame::retrieveFunctionName()
     }
 
     return emptyString();
-}
-
-ALWAYS_INLINE String JSCStackFrame::retrieveTypeName()
-{
-    JSC::JSObject* calleeObject = uncheckedDowncast<JSC::JSObject>(m_callee);
-    return calleeObject->className();
 }
 
 // General flow here is based on JSC's appendSourceToError (ErrorInstance.cpp)

--- a/src/jsc/bindings/ErrorStackTrace.h
+++ b/src/jsc/bindings/ErrorStackTrace.h
@@ -56,7 +56,6 @@ private:
     // Lazy-initialized
     WTF::String m_sourceURL;
     WTF::String m_functionName;
-    WTF::String m_typeName;
 
     // m_wasmFunctionIndexOrName has meaning only when m_isWasmFrame is set
     JSC::Wasm::IndexOrName m_wasmFunctionIndexOrName;
@@ -84,7 +83,6 @@ public:
     intptr_t sourceID() const;
     JSC::JSString* sourceURL();
     JSC::JSString* functionName();
-    JSC::JSString* typeName();
 
     bool isFunctionOrEval() const { return m_isFunctionOrEval; }
     bool isAsync() const { return m_isAsync; }
@@ -150,8 +148,6 @@ private:
      * "display name" property -> "name" property -> JSFunction\InternalFunction "name" methods.
      */
     ALWAYS_INLINE String retrieveFunctionName();
-
-    ALWAYS_INLINE String retrieveTypeName();
 
     bool calculateSourcePositions();
 };

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.cpp
@@ -57,17 +57,6 @@ JSNodePerformanceHooksHistogram* JSNodePerformanceHooksHistogram::create(VM& vm,
     return ptr;
 }
 
-JSNodePerformanceHooksHistogram* JSNodePerformanceHooksHistogram::create(VM& vm, Structure* structure, JSGlobalObject* globalObject, HistogramData&& existingHistogramData)
-{
-    JSNodePerformanceHooksHistogram* ptr = new (NotNull, allocateCell<JSNodePerformanceHooksHistogram>(vm)) JSNodePerformanceHooksHistogram(vm, structure, std::move(existingHistogramData));
-    ptr->finishCreation(vm);
-    if (ptr->m_histogramData.histogram) {
-        ptr->m_extraMemorySizeForGC = hdr_get_memory_size(ptr->m_histogramData.histogram);
-        vm.heap.reportExtraMemoryAllocated(ptr, ptr->m_extraMemorySizeForGC);
-    }
-    return ptr;
-}
-
 void JSNodePerformanceHooksHistogram::destroy(JSCell* cell)
 {
     static_cast<JSNodePerformanceHooksHistogram*>(cell)->~JSNodePerformanceHooksHistogram();

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
@@ -110,12 +110,6 @@ public:
         int64_t highest,
         int figures);
 
-    static JSNodePerformanceHooksHistogram* create(
-        JSC::VM& vm,
-        JSC::Structure* structure,
-        JSC::JSGlobalObject* globalObject,
-        HistogramData&& existingHistogramData);
-
     void finishCreation(JSC::VM& vm);
     static void destroy(JSC::JSCell*);
 

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -87,24 +87,11 @@ void CryptoErrorList::capture()
     }
 }
 
-void CryptoErrorList::add(WTF::String error)
-{
-    errors_.push_back(error);
-}
-
 std::optional<WTF::String> CryptoErrorList::pop_back()
 {
     if (errors_.empty()) return std::nullopt;
     WTF::String error = errors_.back();
     errors_.pop_back();
-    return error;
-}
-
-std::optional<WTF::String> CryptoErrorList::pop_front()
-{
-    if (errors_.empty()) return std::nullopt;
-    WTF::String error = errors_.front();
-    errors_.pop_front();
     return error;
 }
 
@@ -278,17 +265,6 @@ size_t BignumPointer::byteLength() const
 {
     if (bn_ == nullptr) return 0;
     return BN_num_bytes(bn_.get());
-}
-
-DataPointer BignumPointer::encode() const
-{
-    return EncodePadded(bn_.get(), byteLength());
-}
-
-size_t BignumPointer::encodeInto(unsigned char* out) const
-{
-    if (!bn_) return 0;
-    return BN_bn2bin(bn_.get(), out);
 }
 
 DataPointer BignumPointer::Encode(const BIGNUM* bn)
@@ -1183,13 +1159,6 @@ std::optional<WTF::String> X509View::getFingerprint(
     return std::nullopt;
 }
 
-X509Pointer X509View::clone() const
-{
-    ClearErrorOnReturn clear_error_on_return;
-    if (!cert_) return {};
-    return X509Pointer(X509_dup(const_cast<X509*>(cert_)));
-}
-
 Result<X509Pointer, int> X509Pointer::Parse(
     Buffer<const unsigned char> buffer)
 {
@@ -1289,12 +1258,6 @@ BIOPointer BIOPointer::NewMem()
     return BIOPointer(BIO_new(BIO_s_mem()));
 }
 
-BIOPointer BIOPointer::New(const BIO_METHOD* method)
-{
-    if (method == nullptr) return {};
-    return BIOPointer(BIO_new(method));
-}
-
 BIOPointer BIOPointer::New(const void* data, size_t len)
 {
     return BIOPointer(BIO_new_mem_buf(data, len));
@@ -1305,13 +1268,6 @@ BIOPointer BIOPointer::New(const BIGNUM* bn)
     auto res = NewMem();
     if (!res || !BN_print(res.get(), bn)) return {};
     return res;
-}
-
-int BIOPointer::Write(BIOPointer* bio, WTF::StringView message)
-{
-    if (bio == nullptr || !*bio) return 0;
-    auto messageUtf8 = message.utf8();
-    return BIO_write(bio->get(), messageUtf8.data(), messageUtf8.length());
 }
 
 // ============================================================================
@@ -1875,12 +1831,6 @@ int EVPKeyPointer::id() const
 int EVPKeyPointer::base_id() const
 {
     return base_id(get());
-}
-
-int EVPKeyPointer::bits() const
-{
-    if (get() == nullptr) return 0;
-    return EVP_PKEY_bits(get());
 }
 
 size_t EVPKeyPointer::size() const
@@ -2496,11 +2446,6 @@ const Cipher Cipher::FromCtx(const CipherCtxPointer& ctx)
     return Cipher(EVP_CIPHER_CTX_cipher(ctx.get()));
 }
 
-const Cipher& Cipher::EMPTY()
-{
-    static const Cipher cipher = Cipher();
-    return cipher;
-}
 const Cipher& Cipher::AES_128_CBC()
 {
     static const Cipher cipher = Cipher::FromNid(NID_aes_128_cbc);
@@ -3056,14 +3001,6 @@ ECKeyPointer ECKeyPointer::NewByCurveName(int nid)
     return ECKeyPointer(EC_KEY_new_by_curve_name(nid));
 }
 
-ECKeyPointer ECKeyPointer::New(const EC_GROUP* group)
-{
-    auto ptr = ECKeyPointer(EC_KEY_new());
-    if (!ptr) return {};
-    if (!EC_KEY_set_group(ptr.get(), group)) return {};
-    return ptr;
-}
-
 // ============================================================================
 
 EVPKeyCtxPointer::EVPKeyCtxPointer()
@@ -3257,21 +3194,6 @@ bool EVPKeyCtxPointer::initForDecrypt()
 {
     if (!ctx_) return false;
     return EVP_PKEY_decrypt_init(ctx_.get()) == 1;
-}
-
-DataPointer EVPKeyCtxPointer::derive() const
-{
-    if (!ctx_) return {};
-    size_t len = 0;
-    if (EVP_PKEY_derive(ctx_.get(), nullptr, &len) != 1) return {};
-    auto data = DataPointer::Alloc(len);
-    if (!data) return {};
-    if (EVP_PKEY_derive(
-            ctx_.get(), static_cast<unsigned char*>(data.get()), &len)
-        != 1) {
-        return {};
-    }
-    return data;
 }
 
 EVPKeyPointer EVPKeyCtxPointer::paramgen() const
@@ -3489,21 +3411,6 @@ DataPointer Cipher::recover(const EVPKeyPointer& key,
 }
 
 // ============================================================================
-
-Ec::Ec()
-    : ec_(nullptr)
-{
-}
-
-Ec::Ec(OSSL3_CONST EC_KEY* key)
-    : ec_(key)
-{
-}
-
-const EC_GROUP* Ec::getGroup() const
-{
-    return ECKeyPointer::GetGroup(ec_);
-}
 
 int Ec::GetCurveIdFromName(const char* name)
 {
@@ -3764,15 +3671,6 @@ bool HMACCtxPointer::update(const Buffer<const void>& buf)
                static_cast<const unsigned char*>(buf.data),
                buf.len)
         == 1;
-}
-
-DataPointer HMACCtxPointer::digest()
-{
-    auto data = DataPointer::Alloc(EVP_MAX_MD_SIZE);
-    if (!data) return {};
-    Buffer<void> buf = data;
-    if (!digestInto(&buf)) return {};
-    return data.resize(buf.len);
 }
 
 bool HMACCtxPointer::digestInto(Buffer<void>* buf)

--- a/src/jsc/bindings/ncrypto.h
+++ b/src/jsc/bindings/ncrypto.h
@@ -111,9 +111,6 @@ public:
 
     void capture();
 
-    // Add an error message to the end of the stack.
-    void add(WTF::String message);
-
     inline size_t size() const { return errors_.size(); }
     inline bool empty() const { return errors_.empty(); }
 
@@ -123,7 +120,6 @@ public:
     inline auto rend() const noexcept { return errors_.rend(); }
 
     std::optional<WTF::String> pop_back();
-    std::optional<WTF::String> pop_front();
 
 private:
     std::list<WTF::String> errors_;
@@ -318,7 +314,6 @@ public:
     // the result will be an empty Cipher object whose bool operator
     // will return false.
 
-    static const Cipher& EMPTY();
     static const Cipher& AES_128_CBC();
     static const Cipher& AES_192_CBC();
     static const Cipher& AES_256_CBC();
@@ -424,19 +419,7 @@ private:
 
 class Ec final {
 public:
-    Ec();
-    Ec(OSSL3_CONST EC_KEY* key);
-    NCRYPTO_DISALLOW_COPY_AND_MOVE(Ec)
-
-    const EC_GROUP* getGroup() const;
-
     static int GetCurveIdFromName(const char* name);
-
-    inline operator bool() const { return ec_ != nullptr; }
-    inline operator OSSL3_CONST EC_KEY*() const { return ec_; }
-
-private:
-    OSSL3_CONST EC_KEY* ec_ = nullptr;
 };
 
 // A managed pointer to a buffer of data. When destroyed the underlying
@@ -507,7 +490,6 @@ class BIOPointer final {
 
 public:
     static BIOPointer NewMem();
-    static BIOPointer New(const BIO_METHOD* method);
     static BIOPointer New(const void* data, size_t len);
     static BIOPointer New(const BIGNUM* bn);
     template<typename T>
@@ -545,8 +527,6 @@ public:
 
     bool resetBio() const;
 
-    static int Write(BIOPointer* bio, WTF::StringView message);
-
 private:
     mutable DeleteFnPtr<BIO, BIO_free_all> bio_;
 };
@@ -581,8 +561,6 @@ public:
 
     static DataPointer toHex(const BIGNUM* bn);
     DataPointer toHex() const;
-    DataPointer encode() const;
-    size_t encodeInto(unsigned char* out) const;
 
     using PrimeCheckCallback = WTF::Function<bool(int, int)>;
     int isPrime(int checks,
@@ -688,8 +666,6 @@ public:
     inline EVP_PKEY_CTX* get() const { return ctx_.get(); }
     void reset(EVP_PKEY_CTX* ctx = nullptr);
     EVP_PKEY_CTX* release();
-
-    DataPointer derive() const;
 
     bool initForParamgen();
     bool setDhParameters(int prime_size, uint32_t generator);
@@ -837,7 +813,6 @@ public:
 
     int id() const;
     int base_id() const;
-    int bits() const;
     size_t size() const;
 
     size_t rawPublicKeySize() const;
@@ -993,8 +968,6 @@ public:
     bool checkPublicKey(const EVPKeyPointer& pkey) const;
 
     std::optional<WTF::String> getFingerprint(const Digest& method) const;
-
-    X509Pointer clone() const;
 
     enum class CheckMatch {
         NO_MATCH,
@@ -1165,7 +1138,6 @@ public:
     const BIGNUM* getPrivateKey() const;
     const EC_POINT* getPublicKey() const;
 
-    static ECKeyPointer New(const EC_GROUP* group);
     static ECKeyPointer NewByCurveName(int nid);
 
     static const EC_POINT* GetPublicKey(const EC_KEY* key);
@@ -1243,7 +1215,6 @@ public:
 
     bool init(const Buffer<const void>& buf, const Digest& md);
     bool update(const Buffer<const void>& buf);
-    DataPointer digest();
     bool digestInto(Buffer<void>* buf);
 
     static HMACCtxPointer New();

--- a/src/jsc/bindings/node/http/NodeHTTPParser.cpp
+++ b/src/jsc/bindings/node/http/NodeHTTPParser.cpp
@@ -322,19 +322,6 @@ JSValue HTTPParser::duration() const
     return jsNumber(duration);
 }
 
-bool HTTPParser::lessThan(HTTPParser& other) const
-{
-    if (m_lastMessageStart == 0 && other.m_lastMessageStart == 0) {
-        return this < &other;
-    } else if (m_lastMessageStart == 0) {
-        return true;
-    } else if (other.m_lastMessageStart == 0) {
-        return false;
-    }
-
-    return m_lastMessageStart < other.m_lastMessageStart;
-}
-
 int HTTPParser::stopForPendingException()
 {
     llhttp_set_error_reason(&m_parserData, "HPE_USER:JS Exception");

--- a/src/jsc/bindings/node/http/NodeHTTPParser.h
+++ b/src/jsc/bindings/node/http/NodeHTTPParser.h
@@ -150,8 +150,6 @@ public:
     JSC::JSValue getCurrentBuffer(JSC::JSGlobalObject*) const;
     JSC::JSValue duration() const;
 
-    bool lessThan(HTTPParser& other) const;
-
     // llhttp callbacks
     int onMessageBegin();
     int onUrl(const char* at, size_t length);

--- a/src/jsc/bindings/webcore/JSAbortAlgorithm.cpp
+++ b/src/jsc/bindings/webcore/JSAbortAlgorithm.cpp
@@ -91,12 +91,4 @@ void JSAbortAlgorithm::visitJSFunction(JSC::SlotVisitor& visitor)
     m_data->visitJSFunction(visitor);
 }
 
-JSC::JSValue toJS(AbortAlgorithm& impl)
-{
-    if (!static_cast<JSAbortAlgorithm&>(impl).callbackData())
-        return jsNull();
-
-    return static_cast<JSAbortAlgorithm&>(impl).callbackData()->callback();
-}
-
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/JSAbortAlgorithm.h
+++ b/src/jsc/bindings/webcore/JSAbortAlgorithm.h
@@ -37,7 +37,6 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const { return ContextDestructionObserver::scriptExecutionContext(); }
 
     ~JSAbortAlgorithm() final;
-    JSCallbackData* callbackData() { return m_data; }
 
     // Functions
     CallbackResult<typename IDLUndefined::ImplementationType> handleEvent(JSValue) override;
@@ -50,8 +49,5 @@ private:
 
     JSCallbackData* m_data;
 };
-
-JSC::JSValue toJS(AbortAlgorithm&);
-inline JSC::JSValue toJS(AbortAlgorithm* impl) { return impl ? toJS(*impl) : JSC::jsNull(); }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/JSDOMOperation.cpp
+++ b/src/jsc/bindings/webcore/JSDOMOperation.cpp
@@ -28,17 +28,6 @@ JSC::JSObject* createNotEnoughArgumentsErrorBun(JSC::JSGlobalObject* globalObjec
 
 #pragma pop_macro("createNotEnoughArgumentsError")
 
-void throwNodeRangeError(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, const String& message)
-{
-    auto* error = createRangeError(lexicalGlobalObject, message);
-    if (error) [[likely]] {
-        auto& vm = getVM(lexicalGlobalObject);
-        auto& builtinNames = Bun::builtinNames(vm);
-        error->putDirect(vm, builtinNames.codePublicName(), jsString(vm, String("ERR_OUT_OF_RANGE"_s)));
-        scope.throwException(lexicalGlobalObject, error);
-    }
-}
-
 void throwNodeRangeError(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, ASCIILiteral message)
 {
     auto* error = createRangeError(lexicalGlobalObject, message);

--- a/src/jsc/bindings/webcore/JSDOMOperation.h
+++ b/src/jsc/bindings/webcore/JSDOMOperation.h
@@ -80,6 +80,5 @@ JSC::JSObject* createNotEnoughArgumentsErrorBun(JSGlobalObject* globalObject);
 #endif
 
 void throwNodeRangeError(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, ASCIILiteral message);
-void throwNodeRangeError(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, const String& message);
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/JSPerformance.cpp
+++ b/src/jsc/bindings/webcore/JSPerformance.cpp
@@ -579,11 +579,4 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
     return wrap(lexicalGlobalObject, globalObject, impl);
 }
 
-Performance* JSPerformance::toWrapped(JSC::VM&, JSC::JSValue value)
-{
-    if (auto* wrapper = dynamicDowncast<JSPerformance>(value))
-        return &wrapper->wrapped();
-    return nullptr;
-}
-
 }

--- a/src/jsc/bindings/webcore/JSPerformance.h
+++ b/src/jsc/bindings/webcore/JSPerformance.h
@@ -40,7 +40,6 @@ public:
 
     static JSC::JSObject* createPrototype(JSC::VM&, JSDOMGlobalObject&);
     static JSC::JSObject* prototype(JSC::VM&, JSDOMGlobalObject&);
-    static Performance* toWrapped(JSC::VM&, JSC::JSValue);
 
     DECLARE_INFO;
 

--- a/src/jsc/bindings/webcrypto/CryptoKey.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKey.cpp
@@ -28,7 +28,6 @@
 
 #if ENABLE(WEB_CRYPTO)
 
-#include "WebCoreOpaqueRoot.h"
 #include <openssl/rand.h>
 namespace WebCore {
 
@@ -71,11 +70,6 @@ auto CryptoKey::usages() const -> Vector<CryptoKeyUsage>
     if (m_usages & CryptoKeyUsageDecapsulateBits)
         result.append(CryptoKeyUsage::DecapsulateBits);
     return result;
-}
-
-WebCoreOpaqueRoot root(CryptoKey* key)
-{
-    return WebCoreOpaqueRoot { key };
 }
 
 Vector<uint8_t> CryptoKey::randomData(size_t size)

--- a/src/jsc/bindings/webcrypto/CryptoKey.h
+++ b/src/jsc/bindings/webcrypto/CryptoKey.h
@@ -43,8 +43,6 @@
 
 namespace WebCore {
 
-class WebCoreOpaqueRoot;
-
 enum class CryptoKeyClass {
     AES,
     AKP,
@@ -88,8 +86,6 @@ inline auto CryptoKey::type() const -> Type
 {
     return m_type;
 }
-
-WebCoreOpaqueRoot root(CryptoKey*);
 
 } // namespace WebCore
 

--- a/src/ptr/CowSlice.rs
+++ b/src/ptr/CowSlice.rs
@@ -303,21 +303,6 @@ impl<T: 'static, const Z: bool> CowSliceZ<T, Z> {
 
         Ok(())
     }
-
-    /// Does not include debug safety checks.
-    ///
-    /// `data` is the logical slice. For `Z = true` with `is_owned = true`, the
-    /// backing allocation must physically hold `data.len() + 1` elements (the
-    /// sentinel beyond the slice), as `Drop` frees the physical length.
-    pub fn init_unchecked(data: &[T], is_owned: bool) -> Self {
-        Self {
-            // SAFETY: const semantics are enforced by is_owned flag
-            ptr: data.as_ptr().cast_mut(),
-            flags: Flags::new(data.len(), is_owned),
-            #[cfg(debug_assertions)]
-            debug: None,
-        }
-    }
 }
 
 impl<T: 'static, const Z: bool> Drop for CowSliceZ<T, Z> {

--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -490,17 +490,6 @@ impl DateHeaderTimer {
 // C-ABI export thunks
 // ════════════════════════════════════════════════════════════════════════════
 
-// HOST_EXPORT(Bun__internal_drainTimers, c)
-pub fn drain_timers_export(vm: *mut VirtualMachine) {
-    let all = timer_all();
-    if all.is_null() {
-        return;
-    }
-    // SAFETY: `all` is the live per-thread `All`; `vm` is the erased VM pointer
-    // (mod.rs::All::drain_timers takes `*mut ()`).
-    unsafe { (*all).drain_timers(vm.cast::<()>()) };
-}
-
 // `generate-host-exports.ts`
 // scrapes the `// HOST_EXPORT` markers below and emits the seven thunks into
 // `generated_host_exports.rs`, each routing through `host_fn::host_fn_result`.

--- a/test/internal/source-lints/host-export-callers.test.ts
+++ b/test/internal/source-lints/host-export-callers.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "bun:test";
 import path from "path";
 
-// Every `// HOST_EXPORT(Symbol[, abi])` marker in the Rust sources must have a
-// caller outside Rust.
+// Every `// HOST_EXPORT(Symbol[, abi])` marker in the Rust sources whose thunk
+// is `extern "C"` must have a caller on the C++ side.
 //
 // `src/codegen/generate-host-exports.ts` turns each marker into a
-// `#[unsafe(no_mangle)] extern "C"` thunk in `generated_host_exports.rs`. That
-// thunk is a linker root: rustc's `dead_code` lint and the cross-crate hawk
-// analysis both treat it as reachable, so an export whose C++ caller was
-// deleted keeps its Rust implementation alive forever without a single
-// warning. `Bun__WebSocketClient__writeBlob`, `Bun__WebSocketClientTLS__writeBlob`,
+// `#[unsafe(no_mangle)]` thunk in `generated_host_exports.rs`. That thunk is a
+// linker root: rustc's `dead_code` lint and the cross-crate hawk analysis both
+// treat it as reachable, so an export whose C++ caller was deleted keeps its
+// Rust implementation alive forever without a single warning.
+// `Bun__WebSocketClient__writeBlob`, `Bun__WebSocketClientTLS__writeBlob`,
 // `Bun__WebSocketClientTLS__initWithTunnel` and `Bun__internal_drainTimers` sat
 // in that state: thunk emitted, impl compiled, nothing on the other side of the
 // boundary naming them.
@@ -20,11 +20,15 @@ import path from "path";
 // `headers.h`); the linker is the strict judge of liveness, this lint only
 // catches the export nobody names at all.
 //
-// Exempt: symbols the bindgen generators synthesize. `bindgen_*` names are
-// built by `src/codegen/bindgen-lib-internal.ts` from `.bind.ts` inputs and
-// `js2native_*` names by `src/codegen/generate-js2native.ts`; their callers
-// live in generated C++ (`GeneratedBindings.cpp`, `GeneratedJS2Native.h`) that
-// is not part of the tracked tree.
+// Exempt:
+// - `rust`-abi markers. Their thunk is `extern "Rust"` and its consumers are
+//   `extern "Rust" {}` blocks in other Rust crates (cycle-breaking hooks), so a
+//   C++ search cannot see them.
+// - Symbols the bindgen generators synthesize. `bindgen_*` names are built by
+//   `src/codegen/bindgen-lib-internal.ts` from `.bind.ts` inputs and
+//   `js2native_*` names by `src/codegen/generate-js2native.ts`; their callers
+//   live in generated C++ (`GeneratedBindings.cpp`, `GeneratedJS2Native.h`)
+//   that is not part of the tracked tree.
 //
 // Both scans go through `git grep` so they see tracked files only (a
 // `git stash` round-trip can leave stray files in the working directory) and
@@ -34,8 +38,9 @@ const root = path.resolve(import.meta.dir, "..", "..", "..");
 
 // Same grammar as `markerRe` in src/codegen/generate-host-exports.ts: the
 // marker is the whole line. Prose such as "from the `// HOST_EXPORT(Sym, c)`
-// markers" in a doc comment does not match.
-const MARKER = /^\s*\/\/\s*HOST_EXPORT\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:,\s*(?:jsc|c|rust))?\s*\)\s*$/;
+// markers" in a doc comment does not match. Group 1 is the symbol, group 2
+// the abi (`jsc` when absent).
+const MARKER = /^\s*\/\/\s*HOST_EXPORT\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:,\s*(jsc|c|rust))?\s*\)\s*$/;
 
 const GENERATED_PREFIXES = ["bindgen_", "js2native_"];
 
@@ -54,7 +59,22 @@ const CALLER_PATHSPECS = [
 
 function gitGrep(args: string[]): string[] {
   const r = Bun.spawnSync({
-    cmd: ["git", "-C", root, "grep", ...args],
+    // The `-c` overrides pin the output format: a user's `grep.lineNumber`,
+    // `grep.column`, or `color.grep` setting would otherwise prefix every
+    // match and defeat the parsing below.
+    cmd: [
+      "git",
+      "-C",
+      root,
+      "-c",
+      "grep.lineNumber=false",
+      "-c",
+      "grep.column=false",
+      "-c",
+      "color.grep=never",
+      "grep",
+      ...args,
+    ],
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -65,6 +85,7 @@ function gitGrep(args: string[]): string[] {
 
 // symbol -> "file:line" of its marker
 const exports = new Map<string, string>();
+const rustAbi = new Set<string>();
 const duplicates: string[] = [];
 const markerLines = gitGrep(["-n", "-E", "^[[:space:]]*//[[:space:]]*HOST_EXPORT\\(", "--", ":(glob)src/**/*.rs"]);
 for (const hit of markerLines) {
@@ -76,9 +97,12 @@ for (const hit of markerLines) {
   if (!m) continue;
   if (exports.has(m[1])) duplicates.push(`${where}: HOST_EXPORT(${m[1]}) also at ${exports.get(m[1])}`);
   else exports.set(m[1], where);
+  if (m[2] === "rust") rustAbi.add(m[1]);
 }
 
-const checked = [...exports.keys()].filter(symbol => !GENERATED_PREFIXES.some(prefix => symbol.startsWith(prefix)));
+const checked = [...exports.keys()].filter(
+  symbol => !rustAbi.has(symbol) && !GENERATED_PREFIXES.some(prefix => symbol.startsWith(prefix)),
+);
 
 // One `git grep` for every symbol at once: `-w` gives whole-word matches (so
 // `X__setTimeout` inside `X__setTimeoutInternal` does not count), `-o -h`

--- a/test/internal/source-lints/host-export-callers.test.ts
+++ b/test/internal/source-lints/host-export-callers.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "bun:test";
+import path from "path";
+
+// Every `// HOST_EXPORT(Symbol[, abi])` marker in the Rust sources must have a
+// caller outside Rust.
+//
+// `src/codegen/generate-host-exports.ts` turns each marker into a
+// `#[unsafe(no_mangle)] extern "C"` thunk in `generated_host_exports.rs`. That
+// thunk is a linker root: rustc's `dead_code` lint and the cross-crate hawk
+// analysis both treat it as reachable, so an export whose C++ caller was
+// deleted keeps its Rust implementation alive forever without a single
+// warning. `Bun__WebSocketClient__writeBlob`, `Bun__WebSocketClientTLS__writeBlob`,
+// `Bun__WebSocketClientTLS__initWithTunnel` and `Bun__internal_drainTimers` sat
+// in that state: thunk emitted, impl compiled, nothing on the other side of the
+// boundary naming them.
+//
+// The check is textual: the exported symbol must appear as a whole word in a
+// tracked C, C++, Objective-C++, or header file under `src/`. A
+// declaration-only mention counts (the C++ side routinely declares these in
+// `headers.h`); the linker is the strict judge of liveness, this lint only
+// catches the export nobody names at all.
+//
+// Exempt: symbols the bindgen generators synthesize. `bindgen_*` names are
+// built by `src/codegen/bindgen-lib-internal.ts` from `.bind.ts` inputs and
+// `js2native_*` names by `src/codegen/generate-js2native.ts`; their callers
+// live in generated C++ (`GeneratedBindings.cpp`, `GeneratedJS2Native.h`) that
+// is not part of the tracked tree.
+//
+// Both scans go through `git grep` so they see tracked files only (a
+// `git stash` round-trip can leave stray files in the working directory) and
+// finish in milliseconds under a debug build.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+
+// Same grammar as `markerRe` in src/codegen/generate-host-exports.ts: the
+// marker is the whole line. Prose such as "from the `// HOST_EXPORT(Sym, c)`
+// markers" in a doc comment does not match.
+const MARKER = /^\s*\/\/\s*HOST_EXPORT\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:,\s*(?:jsc|c|rust))?\s*\)\s*$/;
+
+const GENERATED_PREFIXES = ["bindgen_", "js2native_"];
+
+// The C++ side of the boundary. Vendored C libraries (the sqlite amalgamation,
+// llhttp) never call back into Rust and are 10 MB of text, so they are excluded.
+const CALLER_PATHSPECS = [
+  ":(glob)src/**/*.cpp",
+  ":(glob)src/**/*.cc",
+  ":(glob)src/**/*.c",
+  ":(glob)src/**/*.h",
+  ":(glob)src/**/*.hpp",
+  ":(glob)src/**/*.mm",
+  ":(exclude)src/jsc/bindings/sqlite/",
+  ":(exclude)src/jsc/bindings/node/http/llhttp/",
+];
+
+function gitGrep(args: string[]): string[] {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "grep", ...args],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  // Exit code 1 is "no match", anything above is a real failure.
+  if (r.exitCode > 1) throw new Error(`git grep failed (${r.exitCode}): ${r.stderr.toString()}`);
+  return r.stdout.toString().split("\n").filter(Boolean);
+}
+
+// symbol -> "file:line" of its marker
+const exports = new Map<string, string>();
+const duplicates: string[] = [];
+const markerLines = gitGrep(["-n", "-E", "^[[:space:]]*//[[:space:]]*HOST_EXPORT\\(", "--", ":(glob)src/**/*.rs"]);
+for (const hit of markerLines) {
+  // `<file>:<line>:<content>`; the content may itself contain `:`.
+  const first = hit.indexOf(":");
+  const second = hit.indexOf(":", first + 1);
+  const where = hit.slice(0, second);
+  const m = MARKER.exec(hit.slice(second + 1));
+  if (!m) continue;
+  if (exports.has(m[1])) duplicates.push(`${where}: HOST_EXPORT(${m[1]}) also at ${exports.get(m[1])}`);
+  else exports.set(m[1], where);
+}
+
+const checked = [...exports.keys()].filter(symbol => !GENERATED_PREFIXES.some(prefix => symbol.startsWith(prefix)));
+
+// One `git grep` for every symbol at once: `-w` gives whole-word matches (so
+// `X__setTimeout` inside `X__setTimeoutInternal` does not count), `-o -h`
+// prints each matched symbol on its own line and nothing else.
+const named = new Set(
+  checked.length === 0
+    ? []
+    : gitGrep(["-h", "-o", "-w", "-F", ...checked.flatMap(s => ["-e", s]), "--", ...CALLER_PATHSPECS]),
+);
+
+const orphans = checked
+  .filter(symbol => !named.has(symbol))
+  .map(symbol => `${exports.get(symbol)}: HOST_EXPORT(${symbol})`)
+  .sort();
+
+test("the marker grammar still recognizes the tree's host exports", () => {
+  // If this goes empty, the marker syntax changed and MARKER above needs
+  // updating in step with generate-host-exports.ts.
+  expect(exports.size).toBeGreaterThan(50);
+  expect(duplicates).toEqual([]);
+});
+
+test("the caller scan still sees the C++ side of the boundary", () => {
+  // Guards against the pathspecs above over-excluding and turning the orphan
+  // check into a vacuous pass.
+  expect(named.size).toBeGreaterThan(50);
+});
+
+test("every HOST_EXPORT symbol is named by a C or C++ source", () => {
+  if (orphans.length > 0) {
+    throw new Error(
+      `${orphans.length} HOST_EXPORT symbol(s) have no caller outside Rust:\n  ${orphans.join("\n  ")}\n` +
+        `Delete the export and its Rust implementation, or add the C++/JS caller that was meant to use it.`,
+    );
+  }
+});


### PR DESCRIPTION
### Problem
- Four Rust host exports have no C++ caller: `Bun__WebSocketClient__writeBlob`, `Bun__WebSocketClientTLS__writeBlob`, `Bun__WebSocketClientTLS__initWithTunnel`, and `Bun__internal_drainTimers`. `WebSocket.cpp` converts a Blob to bytes itself and calls `writeBinaryData`, and the tunnel path only creates the non-TLS client. The `HOST_EXPORT` marker roots each of them, so neither rustc nor hawk can see that they are dead.
- A handful of C++ methods are declared and defined but never called: `HTTPParser::lessThan`, one `JSNodePerformanceHooksHistogram::create` overload, `JSAbortAlgorithm::callbackData` and `toJS(AbortAlgorithm&)`, `JSPerformance::toWrapped`, `JSCStackFrame::typeName`, `root(CryptoKey*)`, the `String` overload of `throwNodeRangeError`, and 16 ncrypto helpers.
- Two `pub` Rust items have no caller in any crate: `bun_base64::simdutf_encode_url_safe_alloc` and `CowSliceZ::init_unchecked`.

### Fix
- Delete the items above. `WebSocketClient::write_blob` goes with its exports. `encode_append_impl` folds into `encode_append`, its only remaining caller. The ncrypto `Ec` class keeps its one live member, `GetCurveIdFromName`.
- Every deletion is confirmed two ways: `rg` over `src/`, `build/debug/codegen/`, `src/codegen/`, `packages/`, and `vendor/WebKit` finds no reference, and a `bun-debug` relink with `--gc-sections --print-gc-sections` discards each symbol. `host_fn_this_value` and `root(MessagePort*)` looked the same way and stay: codegen emits the first, and #39841 is editing `MessagePort.cpp`, so the second waits for that fix to land.
- New source lint `test/internal/source-lints/host-export-callers.test.ts`: every `c`/`jsc` `HOST_EXPORT` marker must be named by a C or C++ source. It fails on main with exactly the four exports above and passes here.
- Verified: `bun bd` builds, `bun run rust:check-all` passes on all 12 targets, `clang-format` and `cargo fmt` are clean. Ran `test/js/web/websocket/` (blob, client, bidir proxy), `test/js/node/crypto/` (crypto, ecdh, hmac, sign, x509), `node-http`, `node-http-parser`, `perf_hooks`, and `abort`.

### Background
- `// HOST_EXPORT(Name, c)` marks a Rust fn that `src/codegen/generate-host-exports.ts` wraps in an `extern "C"` thunk for C++. The thunk exists whether or not C++ calls it, so an orphaned export compiles without a warning.
- ncrypto (`src/jsc/bindings/ncrypto.{cpp,h}`) is Bun's copy of Node's OpenSSL helper layer. Node still uses the removed helpers; Bun's callers never did.
- The linker check: a debug link with `-Wl,--gc-sections -Wl,--print-gc-sections` lists every function section nothing references. A function that is discarded and also absent from the linked binary has no caller on that platform. Platform-gated code then needs a source check, which is why the darwin-only `Bun__noOrphans_*` and the Windows-only `windowsEnv` builtin stay.

<details><summary>Notes</summary>

Removed, by file:

- `src/http_jsc/websocket_client.rs`: `bun__websocketclient__write_blob`, `bun__websocketclienttls__write_blob`, `bun__websocketclienttls__init_with_tunnel`, `WebSocketClient::write_blob`, and the now unused `JSValue` import.
- `src/runtime/timer/Timer.rs`: `drain_timers_export` (`Bun__internal_drainTimers`).
- `src/base64/lib.rs`: `simdutf_encode_url_safe_alloc`; `encode_append_impl` folded into `encode_append`.
- `src/ptr/CowSlice.rs`: `CowSliceZ::init_unchecked`.
- `src/jsc/bindings/node/http/NodeHTTPParser.{cpp,h}`: `HTTPParser::lessThan`.
- `src/jsc/bindings/JSNodePerformanceHooksHistogram.{cpp,h}`: `create(VM&, Structure*, JSGlobalObject*, HistogramData&&)`.
- `src/jsc/bindings/webcore/JSAbortAlgorithm.{cpp,h}`: `callbackData()`, `toJS(AbortAlgorithm&)`, `toJS(AbortAlgorithm*)`.
- `src/jsc/bindings/webcore/JSPerformance.{cpp,h}`: `JSPerformance::toWrapped`.
- `src/jsc/bindings/ErrorStackTrace.{cpp,h}`: `JSCStackFrame::typeName`, `retrieveTypeName`, `m_typeName`.
- `src/jsc/bindings/webcrypto/CryptoKey.{cpp,h}`: `root(CryptoKey*)` and the `WebCoreOpaqueRoot` forward declaration and include it needed.
- `src/jsc/bindings/webcore/JSDOMOperation.{cpp,h}`: `throwNodeRangeError(JSGlobalObject*, ThrowScope&, const String&)`; every caller passes an `ASCIILiteral`.
- `src/jsc/bindings/ncrypto.{cpp,h}`: `CryptoErrorList::add`, `CryptoErrorList::pop_front`, `BignumPointer::encode`, `BignumPointer::encodeInto`, `X509View::clone`, `BIOPointer::New(const BIO_METHOD*)`, `BIOPointer::Write`, `EVPKeyPointer::bits`, `Cipher::EMPTY`, `ECKeyPointer::New(const EC_GROUP*)`, `EVPKeyCtxPointer::derive`, `HMACCtxPointer::digest`, `Ec::Ec()`, `Ec::Ec(const EC_KEY*)`, `Ec::getGroup`, and the `Ec` conversion operators and field.

Scan summary for this run. Areas: Rust in `src/runtime`, `src/http_jsc`, `src/bun_core`, `src/base64`, `src/ptr`, and the JSC bindings outside the files that open dead-code PRs (#39929, #40232, #40367, #40294, #40172, #40122) already touch; the TS builtins in `src/js`.

- hawk over `x86_64-unknown-linux-gnu`, `x86_64-pc-windows-msvc`, `aarch64-apple-darwin` (release profile, per `hawk.toml`): 847 `dead_public` findings. 668 are fields of FFI mirror structs (`libuv.rs`, `windows_sys/externs.rs`, `boringssl.rs`). Most of the rest are in files the open PRs own, are debug-only (`has_resolve_breakpoint`, `StoredTrace::capture`, `ArrayHashMap::unlock_pointers`), are codegen targets (`host_fn_this_value`), or are FFI enum mirrors (`tty::Mode::Io`, `ImplementationVisibility`).
- oxlint with `no-unused-vars`, `no-unused-private-class-members`, `no-unreachable` over `src/js`: 0 findings. No `src/js` file is unimported. No `.rs` file is outside a `mod` tree except the three `[[bench]]` targets.
- `--gc-sections` relink of `bun-debug`: 1005 non-generated discarded symbols, 283 of them in files no open PR touches. After removing sqlite3.c, llhttp, vendored shims, platform-gated code, and generated `ZigGeneratedClasses` helpers, the list above is what remains.

Possibly dead, left alone:

- `bun_core::strings::split_once` / `rsplit_once`: no caller today, but `clippy.toml` names them as the replacement for the denied `str::split_once` / `bstr::split_once_str` forms. Kept as API surface.

- `src/jsc/bindings/webcore/streams/JSCrossRealmTransformState.{cpp,h}` (135 lines): the `CrossRealm` source and sink kinds in `StreamsForward.h` are never constructed. It reads as scaffolding for stream transfer in the native streams work, so it stays.
- `ECDSASigPointer`, `ECGroupPointer`, `ECPointPointer`, `HMACCtxPointer`: default constructor, move constructor, and `release()` are unreferenced, but they are the smart-pointer idiom the rest of ncrypto follows.
- `src/threading/Futex.rs` `wasm_impl` and `unsupported_impl`: no shipped target compiles them.
- `bun_core::Global::StoredTrace::{EMPTY, capture}`, `has_resolve_breakpoint`, `ArrayHashMap::unlock_pointers`, `TaskTag::name`: release-dead, used under `debug_assertions`.

</details>
