### PR TITLE
bun:test: reject a non-finite now in useFakeTimers

### DIFF
--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -419,7 +419,7 @@ fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
     let arg = frame.arguments_as_array::<1>()[0];
     if !arg.is_number() {
         return Err(global.throw_invalid_arguments(format_args!(
-            "advanceTimersToNextTimer() expects a number of milliseconds"
+            "advanceTimersByTime() expects a number of milliseconds"
         )));
     }
     let Some(current) = CURRENT_TIME.get_timespec_now() else {
@@ -429,9 +429,9 @@ fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
     };
     let arg_number = arg.as_number();
     let max_advance = u32::MAX;
-    if arg_number < 0.0 || arg_number > max_advance as f64 {
+    if arg_number.is_nan() || arg_number < 0.0 || arg_number > max_advance as f64 {
         return Err(global.throw_invalid_arguments(format_args!(
-            "advanceTimersToNextTimer() ms is out of range. It must be >= 0 and <= {}. Received {:.0}",
+            "advanceTimersByTime() ms is out of range. It must be >= 0 and <= {}. Received {:.0}",
             max_advance, arg_number
         )));
     }

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -369,10 +369,7 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
                     "'now' must be a number or Date"
                 )));
             }
-            // NaN is `JSGlobalObject::overridenDateNow`'s "no override"
-            // sentinel, so a NaN clock leaves `Date.now()` real while
-            // `performance.timeOrigin` reads NaN. Reject it (and an Invalid
-            // Date, whose timestamp is NaN) before it reaches the clock.
+            // NaN is `JSGlobalObject::overridenDateNow`'s "no override" sentinel.
             if !js_now.is_finite() {
                 return Err(global.throw_invalid_arguments(format_args!(
                     "'now' must be a finite number or a valid Date"

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -369,6 +369,15 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
                     "'now' must be a number or Date"
                 )));
             }
+            // NaN is `JSGlobalObject::overridenDateNow`'s "no override"
+            // sentinel, so a NaN clock leaves `Date.now()` real while
+            // `performance.timeOrigin` reads NaN. Reject it (and an Invalid
+            // Date, whose timestamp is NaN) before it reaches the clock.
+            if !js_now.is_finite() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "'now' must be a finite number or a valid Date"
+                )));
+            }
         }
     }
 

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -133,6 +133,13 @@ describe("advanceTimersByTime", () => {
     expect(order.takeOrderMessages()).toEqual([]);
     vi.useRealTimers();
   });
+
+  test.each([NaN, -1, Infinity, 2 ** 32])("advanceTimersByTime(%p) throws and does not move the clock", ms => {
+    vi.useFakeTimers({ now: 1000 });
+    expect(() => vi.advanceTimersByTime(ms)).toThrow("ms is out of range. It must be >= 0 and <= 4294967295");
+    expect(Date.now()).toBe(1000);
+    expect(performance.now()).toBe(0);
+  });
 });
 describe("runOnlyPendingTimers", () => {
   test("two setIntervals", () => {

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -727,4 +727,14 @@ describe("useFakeTimers with options", () => {
     expect(() => vi.useFakeTimers(123 as any)).toThrow("useFakeTimers() expects an options object");
     expect(vi.isFakeTimers()).toBe(false);
   });
+
+  // NaN is the "no override" sentinel of the Date.now() override. A NaN clock
+  // left Date.now() real while performance.timeOrigin read NaN.
+  test.each([NaN, Infinity, -Infinity, new Date(NaN)])("useFakeTimers({ now: %p }) throws", now => {
+    const realTimeOrigin = performance.timeOrigin;
+    expect(() => vi.useFakeTimers({ now })).toThrow("'now' must be a finite number or a valid Date");
+    expect(vi.isFakeTimers()).toBe(false);
+    expect(performance.timeOrigin).toBe(realTimeOrigin);
+    expect(performance.toJSON().timeOrigin).toBe(realTimeOrigin);
+  });
 });


### PR DESCRIPTION
### Problem
- `jest.useFakeTimers({ now: NaN })` (or `{ now: new Date(NaN) }`) leaves `Date.now()` on the real clock but sets `performance.timeOrigin` to `NaN`. `performance.toJSON()` then fails `ASSERTION FAILED: !std::isnan(value)` (`JSDOMConvertNumbers.h:349`, `IDLDouble`) in an assert build. A release build returns `NaN`.
- The cause is `use_fake_timers` (`src/runtime/test_runner/timers/FakeTimers.rs:362`). It accepts any number or Date as `now`. `CurrentTime::set` then computes `date_now_offset = NaN` and stores it as `overridden_time_origin = Some(NaN)` (line 77). The Date path never sees the override, because `NaN` is the "no override" sentinel of `JSGlobalObject::overridenDateNow`. The two clocks disagree.
- Since #40104 (post-1.4.0). 1.4.0 left `timeOrigin` real for the same input. `advanceTimersByTime(NaN)` has the same class of hole: its range check is `<` and `>`, both false for `NaN`, so the call passes and advances by nothing.

### Fix
- `use_fake_timers` throws a `TypeError` for a non-finite `now`: `'now' must be a finite number or a valid Date`. This covers `NaN`, `Infinity`, `-Infinity` and an Invalid Date (its timestamp is `NaN`).
- `advance_timers_by_time` rejects `NaN` as out of range. Its two error messages now name `advanceTimersByTime()` instead of `advanceTimersToNextTimer()`.
- Correct because user input must not be able to produce the internal sentinel, and a non-finite clock has no meaning: `Date.now()` cannot return it and `new Date()` is invalid. `setSystemTime(NaN)` is not changed. It is documented to reset the Date override, and `Bun__FakeTimers__setSystemTime` already returns early for `NaN`.
- Verified: `test/js/bun/test/fake-timers/fake-timers.test.ts` (eight new cases, the `NaN` ones fail on main). Also `test/js/bun/test/test-timers.test.ts`, `test/js/web/timers/performance.test.js`, `test/js/node/perf_hooks/perf_hooks.test.ts`.

### Background
- The bun:test fake clock keeps one fake monotonic `Timespec` (`CURRENT_TIME`) and one `date_now_offset` that maps it to the fake `Date.now()`. `useFakeTimers({ now })` resets the monotonic value to 0 and sets the offset to `now`.
- `performance.timeOrigin` is the wall-clock time at which `performance.now()` reads 0. Under fake timers it is `date_now_offset` (#40104).
- `JSGlobalObject::overridenDateNow` is a `double`. `jsDateNow()` returns the real time when it is `NaN`. So a `NaN` offset disables the Date override but still reaches `overridden_time_origin`.

<details><summary>Notes</summary>

Repro on main (debug build):

```ts
import { test, jest } from "bun:test";
test("nan clock", () => {
  jest.useFakeTimers({ now: NaN });
  console.log(Date.now());               // real wall clock
  console.log(performance.timeOrigin);   // NaN
  performance.toJSON();                  // ASSERTION FAILED: !std::isnan(value)
});
```

`advanceTimersByTime(NaN)` on main (debug build, `useFakeTimers({ now: 1000 })` first): no throw, `Date.now()` stays 1000, `performance.now()` stays 0, a pending 1 ms timer does not fire. `add_ms_float` floors `NaN` and the `as i64` cast saturates to 0, so the clock does not move and no `NaN` reaches `date_now_offset`. The new check makes the mistake visible. `Infinity` and negatives were already rejected by the range check.

The `advanceTimersByTime` test asserts on `ms is out of range. It must be >= 0 and <= 4294967295` and not on the function name, so the `-1`, `Infinity` and `2 ** 32` cases pass on main and the `NaN` case is the one that fails there.

The other option for `now` was to treat `NaN` as "no Date override", which is what 1.4.0 did by accident. That state is odd: timers and `performance.now()` are fake, `Date.now()` is real, and `timeOrigin + performance.now()` is neither. Nobody asks for it on purpose, so the error is the more useful response.

`Infinity` was accepted as the clock on 1.4.0 too (`Date.now() === Infinity`). The `is_finite()` check rejects it as well.

Jest with `@sinonjs/fake-timers` maps a `NaN` `now` to epoch 0 (a falsy check in `getEpoch`) and an Invalid Date to a `NaN` clock. Neither is a contract to match.

Related open PR: #38740 moves the fake clock statics to per-VM storage and touches `FakeTimers.rs`. This change is in `use_fake_timers` and `advance_timers_by_time` only and rebases onto it mechanically.

</details>
