### PR TITLE
Throw instead of panicking or silently returning "" when a string can't be created

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -149,10 +149,9 @@ with `type_error`/`range_error`/`syntax_error` siblings, one C++ entry):
 literal → atomized; formatted → copied once), `string.to_error_instance(global)`
 (WTF-backed shares the impl, static atomizes, borrowed `EncodedSlice`
 copies), `EncodedSlice::utf8(bytes).to_error_instance(global)` for raw UTF-8
-bytes (copied). The infallible
-`EncodedSlice::…(bytes).to_js(global)` is only for callbacks that cannot
-return `JsResult`, or for bytes already validated as ASCII where a rescan
-is unwanted (`EncodedSlice::latin1(bytes).to_js(global)`).
+bytes (copied). `EncodedSlice::latin1(bytes).to_js(global)?` is for bytes already validated as
+ASCII/Latin-1 where `create_utf8_for_js`'s scan is unwanted; both throw
+`STRING_TOO_LONG` past the string length limit.
 
 JSValue → string: `value.to_bun_string(global)?` (owned `String`),
 `value.to_utf8(global)?` (owned UTF-8 `Utf8Bytes<'static>`), or

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -379,37 +379,72 @@ impl String {
         let _ = buf.write_fmt(args);
         Self::clone_utf8(buf.as_bytes())
     }
-    /// Returns `(String, ptr)` where `ptr` is `len` writable bytes — or
-    /// `(dead, null)` if WTF allocation failed (check `tag == .Dead` before
-    /// using the buffer).
-    pub fn create_uninitialized_latin1(len: usize) -> (Self, &'static mut [u8]) {
+    /// One WTF 8-bit allocation of `len` characters, written by `fill` before
+    /// the string is observable. `Err` if WTF could not allocate it (which
+    /// includes `len` over the maximum string length).
+    #[inline]
+    pub fn create_latin1_with(
+        len: usize,
+        fill: impl FnOnce(&mut [u8]),
+    ) -> Result<Self, crate::AllocError> {
+        Self::try_create_latin1_with(len, |buf| {
+            fill(buf);
+            Ok(())
+        })
+    }
+    /// UTF-16 form of [`Self::create_latin1_with`].
+    #[inline]
+    pub fn create_utf16_with(
+        len: usize,
+        fill: impl FnOnce(&mut [u16]),
+    ) -> Result<Self, crate::AllocError> {
+        Self::try_create_utf16_with(len, |buf| {
+            fill(buf);
+            Ok(())
+        })
+    }
+    /// [`Self::create_latin1_with`] with a fallible `fill`; its error drops
+    /// the allocation.
+    pub fn try_create_latin1_with<E: From<crate::AllocError>>(
+        len: usize,
+        fill: impl FnOnce(&mut [u8]) -> Result<(), E>,
+    ) -> Result<Self, E> {
+        if len == 0 {
+            fill(&mut [])?;
+            return Ok(Self::EMPTY);
+        }
         let s = BunString__fromLatin1Unitialized(len);
         if s.tag != Tag::WTFStringImpl {
-            return (s, &mut []);
+            return Err(crate::AllocError.into());
         }
         debug_assert_eq!(s.as_wtf().ref_count(), 1);
-        // SAFETY: WTF tag verified above; impl has a writable latin1 buffer of
-        // `len`. `ptr` points at `len` writable bytes owned by the new WTF
-        // impl; the `'static` lifetime is actually tied to `s` — caller must
-        // not outlive it.
+        // SAFETY: a fresh, uniquely owned 8-bit impl of exactly `len` characters.
         let buf = unsafe {
-            let ptr = (*s.value.wtf_string_impl).m_ptr.latin1.cast_mut();
-            core::slice::from_raw_parts_mut(ptr, len)
+            core::slice::from_raw_parts_mut((*s.value.wtf_string_impl).m_ptr.latin1.cast_mut(), len)
         };
-        (s, buf)
+        fill(buf)?;
+        Ok(s)
     }
-    pub fn create_uninitialized_utf16(len: usize) -> (Self, &'static mut [u16]) {
+    /// UTF-16 form of [`Self::try_create_latin1_with`].
+    pub fn try_create_utf16_with<E: From<crate::AllocError>>(
+        len: usize,
+        fill: impl FnOnce(&mut [u16]) -> Result<(), E>,
+    ) -> Result<Self, E> {
+        if len == 0 {
+            fill(&mut [])?;
+            return Ok(Self::EMPTY);
+        }
         let s = BunString__fromUTF16Unitialized(len);
         if s.tag != Tag::WTFStringImpl {
-            return (s, &mut []);
+            return Err(crate::AllocError.into());
         }
         debug_assert_eq!(s.as_wtf().ref_count(), 1);
-        // SAFETY: see `create_uninitialized_latin1`.
+        // SAFETY: a fresh, uniquely owned 16-bit impl of exactly `len` characters.
         let buf = unsafe {
-            let ptr = (*s.value.wtf_string_impl).m_ptr.utf16.cast_mut();
-            core::slice::from_raw_parts_mut(ptr, len)
+            core::slice::from_raw_parts_mut((*s.value.wtf_string_impl).m_ptr.utf16.cast_mut(), len)
         };
-        (s, buf)
+        fill(buf)?;
+        Ok(s)
     }
 
     /// Takes ownership of a globally-allocated (mimalloc-backed) Latin-1

--- a/src/js_parser_jsc/expr_jsc.rs
+++ b/src/js_parser_jsc/expr_jsc.rs
@@ -244,14 +244,13 @@ fn utf8_bytes_to_js(bytes: &[u8], global: &JSGlobalObject) -> Result<JSValue, To
         return Ok(JSValue::js_empty_string(global));
     }
     if let Some(utf16) = strings::wtf8_to_utf16_alloc(bytes) {
-        let (out, chars) = BunString::create_uninitialized_utf16(utf16.len());
-        chars.copy_from_slice(&utf16);
-        out.into_js(global).map_err(js_err)
+        BunString::create_utf16_with(utf16.len(), |buf| buf.copy_from_slice(&utf16))
     } else {
-        let (out, chars) = BunString::create_uninitialized_latin1(bytes.len());
-        chars.copy_from_slice(bytes);
-        out.into_js(global).map_err(js_err)
+        BunString::create_latin1_with(bytes.len(), |buf| buf.copy_from_slice(bytes))
     }
+    .map_err(|_| ToJSError::OutOfMemory)?
+    .into_js(global)
+    .map_err(js_err)
 }
 
 /// `E.String` → JS string conversion.
@@ -288,9 +287,10 @@ macro_rules! impl_string_to_js {
                 utf8_bytes_to_js(s.slice8(), global)
             } else {
                 let utf16 = s.slice16();
-                let (out, chars) = BunString::create_uninitialized_utf16(utf16.len());
-                chars.copy_from_slice(utf16);
-                out.into_js(global).map_err(js_err)
+                BunString::create_utf16_with(utf16.len(), |buf| buf.copy_from_slice(utf16))
+                    .map_err(|_| ToJSError::OutOfMemory)?
+                    .into_js(global)
+                    .map_err(js_err)
             }
         }
     };

--- a/src/jsc/EncodedSlice.rs
+++ b/src/jsc/EncodedSlice.rs
@@ -31,8 +31,7 @@ unsafe extern "C" {
         global: &JSGlobalObject,
         code: u8,
     ) -> JSValue;
-    safe fn EncodedSlice__toValueGC(this: &EncodedSlice, global: &JSGlobalObject) -> JSValue;
-    // EncodedSlice__toExternalValue: use the generated `cpp::` re-export (canonical signature).
+    // EncodedSlice__toValueGC / EncodedSlice__toExternalValue: use the generated `cpp::` wrappers.
     // safe: `EncodedSlice`/`JSGlobalObject` are `#[repr(C)]`/opaque-ZST handles (`&`
     // is ABI-identical to non-null `*const`); `ctx` is an opaque round-trip
     // pointer C++ stores into the external string's finalizer slot and forwards
@@ -60,9 +59,9 @@ pub trait EncodedSliceJsc: Sized {
     fn to_range_error_instance(&self, global: &JSGlobalObject) -> JSValue;
     fn to_dom_exception_instance(&self, global: &JSGlobalObject, code: DOMExceptionCode)
     -> JSValue;
-    /// Copies into a GC-managed `JSString` (or hands over an external value
-    /// if globally allocated).
-    fn to_js(&self, global: &JSGlobalObject) -> JSValue;
+    /// Copies into a GC-managed `JSString`; throws `ERR_STRING_TOO_LONG` if
+    /// the copy would exceed the engine's string length limit.
+    fn to_js(&self, global: &JSGlobalObject) -> JsResult<JSValue>;
     /// Transfers ownership of a globally-allocated buffer to JSC's
     /// external-string finalizer.
     fn to_external_value(&self, global: &JSGlobalObject) -> JsResult<JSValue>;
@@ -101,9 +100,10 @@ impl EncodedSliceJsc for EncodedSlice<'_> {
     ) -> JSValue {
         EncodedSlice__toDOMExceptionInstance(self, global, code as u8)
     }
-    fn to_js(&self, global: &JSGlobalObject) -> JSValue {
+    fn to_js(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
         debug_assert!(!self.is_globally_allocated());
-        EncodedSlice__toValueGC(self, global)
+        // SAFETY: `self` is a live `&EncodedSlice` for the duration of the call.
+        unsafe { cpp::EncodedSlice__toValueGC(self, global) }
     }
     fn to_external_value(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
         if self.len > bun_core::String::max_length() {

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -302,10 +302,6 @@ impl JSGlobalObject {
 
     pub fn throw_todo(&self, msg: &[u8]) -> JsError {
         let err = EncodedSlice::utf8(msg).to_error_instance(self);
-        if err.is_empty() {
-            debug_assert!(self.has_exception());
-            return JsError::Thrown;
-        }
         let name_value = match BunString::static_("TODOError").to_js(self) {
             Ok(v) => v,
             Err(_) => return JsError::Thrown,
@@ -787,17 +783,18 @@ impl JSGlobalObject {
 
     pub fn throw_sys_error(&self, opts: &SysErrOptions, message: Arguments<'_>) -> JsError {
         let err = self.create_error_instance(message);
-        if err.is_empty() {
-            debug_assert!(self.has_exception());
-            return JsError::Thrown;
-        }
-        err.put(
-            self,
-            b"code",
-            EncodedSlice::latin1(<&'static str>::from(opts.code).as_bytes()).to_js(self),
-        );
+        let code =
+            match EncodedSlice::latin1(<&'static str>::from(opts.code).as_bytes()).to_js(self) {
+                Ok(code) => code,
+                Err(err) => return err,
+            };
+        err.put(self, b"code", code);
         if let Some(name) = opts.name {
-            err.put(self, b"name", EncodedSlice::latin1(name).to_js(self));
+            let name = match EncodedSlice::latin1(name).to_js(self) {
+                Ok(name) => name,
+                Err(err) => return err,
+            };
+            err.put(self, b"name", name);
         }
         if let Some(errno) = opts.errno {
             err.put(self, b"errno", JSValue::from(errno));
@@ -811,10 +808,6 @@ impl JSGlobalObject {
     /// chances are you should be using `.err(...).throw()` instead.
     pub fn throw(&self, args: Arguments<'_>) -> JsError {
         let instance = self.create_error_instance(args);
-        if instance.is_empty() {
-            debug_assert!(self.has_exception());
-            return JsError::Thrown;
-        }
         self.throw_value(instance)
     }
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -419,82 +419,31 @@ impl Entry {
                     // RuntimeTranspilerStore.rs / jsc_hooks.rs. Only if the
                     // bytes contain non-ASCII UTF-8 do we fall back to
                     // `clone_utf8` (transcode → UTF-16) and deref the scratch.
-                    let len = self.metadata.output_byte_length as usize;
-                    let (scratch, bytes) = BunString::create_uninitialized_latin1(len);
-                    // `(dead, &mut [])` on WTF allocation failure; `len > 0`
-                    // (handled above), so an empty slice means OOM.
-                    if bytes.is_empty() {
-                        return Err(crate::CrateError::Alloc(bun_alloc::AllocError));
-                    }
-                    let read_bytes = file.pread_all(bytes, self.metadata.output_byte_offset)?;
-                    if read_bytes as u64 != self.metadata.output_byte_length {
-                        return Err(crate::CrateError::MissingData);
-                    }
-
-                    if self.metadata.output_hash != 0 && hash(bytes) != self.metadata.output_hash {
-                        return Err(crate::CrateError::InvalidHash);
-                    }
-
-                    if bun_core::strings::is_all_ascii(bytes) {
+                    let scratch = BunString::try_create_latin1_with(
+                        self.metadata.output_byte_length as usize,
+                        |buf| self.metadata.read_output(file, buf),
+                    )?;
+                    if bun_core::strings::is_all_ascii(scratch.latin1()) {
                         // Fast path: ASCII ⊂ Latin-1, so `scratch` is already
                         // the correct `BunString`.
                         scratch
                     } else {
                         // Rare path: real multi-byte UTF-8. Transcode into a
                         // fresh WTF string; the Latin-1 scratch drops.
-                        BunString::clone_utf8(bytes)
+                        BunString::clone_utf8(scratch.latin1())
                     }
                 }
-                Encoding::LATIN1 => {
-                    let len = self.metadata.output_byte_length as usize;
-                    let (latin1, bytes) = BunString::create_uninitialized_latin1(len);
-                    // `create_uninitialized_latin1` returns `(dead, &mut [])` on
-                    // WTF allocation failure; `len > 0` here (handled above), so
-                    // an empty slice means OOM.
-                    if bytes.is_empty() {
-                        return Err(crate::CrateError::Alloc(bun_alloc::AllocError));
-                    }
-                    let read_bytes = file.pread_all(bytes, self.metadata.output_byte_offset)?;
-
-                    if self.metadata.output_hash != 0 {
-                        if hash(latin1.latin1()) != self.metadata.output_hash {
-                            return Err(crate::CrateError::InvalidHash);
-                        }
-                    }
-
-                    if read_bytes as u64 != self.metadata.output_byte_length {
-                        return Err(crate::CrateError::MissingData);
-                    }
-
-                    latin1
-                }
-                Encoding::UTF16 => {
-                    let char_len = (self.metadata.output_byte_length / 2) as usize;
-                    let (string, chars) = BunString::create_uninitialized_utf16(char_len);
-                    // See LATIN1 branch above — empty slice for nonzero `char_len`
-                    // signals WTF allocation failure.
-                    if chars.is_empty() {
-                        return Err(crate::CrateError::Alloc(bun_alloc::AllocError));
-                    }
-                    // `chars` is `&mut [u16; char_len]` backed by contiguous
-                    // WTFString storage; reinterpret as bytes for pread via the
-                    // safe POD cast (`u16` → `u8` always satisfies size/align).
-                    let chars_bytes: &mut [u8] = bytemuck::cast_slice_mut(chars);
-                    let read_bytes =
-                        file.pread_all(chars_bytes, self.metadata.output_byte_offset)?;
-                    if read_bytes as u64 != self.metadata.output_byte_length {
-                        return Err(crate::CrateError::MissingData);
-                    }
-
-                    if self.metadata.output_hash != 0 {
-                        let utf16_bytes: &[u8] = bytemuck::cast_slice(string.utf16());
-                        if hash(utf16_bytes) != self.metadata.output_hash {
-                            return Err(crate::CrateError::InvalidHash);
-                        }
-                    }
-
-                    string
-                }
+                Encoding::LATIN1 => BunString::try_create_latin1_with(
+                    self.metadata.output_byte_length as usize,
+                    |buf| self.metadata.read_output(file, buf),
+                )?,
+                Encoding::UTF16 => BunString::try_create_utf16_with(
+                    (self.metadata.output_byte_length / 2) as usize,
+                    |buf| {
+                        self.metadata
+                            .read_output(file, bytemuck::cast_slice_mut(buf))
+                    },
+                )?,
 
                 _ => unreachable!("Unexpected output encoding"),
             }
@@ -542,6 +491,18 @@ pub struct RuntimeTranspilerCache {
 
 pub(crate) fn hash(bytes: &[u8]) -> u64 {
     Wyhash::hash(SEED, bytes)
+}
+
+impl Metadata {
+    fn read_output(&self, file: &sys::File, buf: &mut [u8]) -> crate::CrateResult<()> {
+        if file.pread_all(buf, self.output_byte_offset)? as u64 != self.output_byte_length {
+            return Err(crate::CrateError::MissingData);
+        }
+        if self.output_hash != 0 && hash(buf) != self.output_hash {
+            return Err(crate::CrateError::InvalidHash);
+        }
+        Ok(())
+    }
 }
 
 /// Allocate `len` bytes and fill them via `pread_all` at `offset`, returning

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -145,8 +145,10 @@ extern "C" JSC::EncodedJSValue BunString__toErrorInstance(const BunString* str, 
 {
     WTF::String message = errorMessage(str);
     if (message.isNull() && !str->isEmpty()) [[unlikely]] {
-        // Allocation failed or the message exceeds the maximum string length.
-        return {};
+        // Allocation failed or the message exceeds the maximum string length:
+        // hand back that error in place of the requested one.
+        return JSValue::encode(createError(globalObject, Bun::ErrorCode::ERR_STRING_TOO_LONG,
+            makeString("Cannot create a string longer than "_s, WTF::String::MaxLength, " characters"_s)));
     }
     JSC::JSObject* result = nullptr;
     switch (kind) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3729,9 +3729,15 @@ __attribute__((__always_inline__)) VirtualMachine* JSC__JSGlobalObject__bunVM(JS
     return reinterpret_cast<VirtualMachine*>(WebCore::clientData(arg0->vm())->bunVM);
 }
 
-JSC::EncodedJSValue EncodedSlice__toValueGC(const EncodedSlice* arg0, JSC::JSGlobalObject* arg1)
+[[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue EncodedSlice__toValueGC(const EncodedSlice* arg0, JSC::JSGlobalObject* arg1)
 {
-    return JSC::JSValue::encode(JSC::jsString(arg1->vm(), Zig::toStringCopy(*arg0)));
+    auto& vm = arg1->vm();
+    auto str = Zig::toStringCopy(*arg0);
+    if (str.isNull() && arg0->len > 0) [[unlikely]] {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        return Bun::ERR::STRING_TOO_LONG(scope, arg1);
+    }
+    return JSC::JSValue::encode(JSC::jsString(vm, WTF::move(str)));
 }
 
 JSC::EncodedJSValue EncodedSlice__external(const EncodedSlice* arg0, JSC::JSGlobalObject* arg1, void* arg2, void (*ArgFn3)(void* arg0, void* arg1, size_t arg2))

--- a/src/jsc/bindings/helpers.h
+++ b/src/jsc/bindings/helpers.h
@@ -193,6 +193,10 @@ static const WTF::String toStringCopy(EncodedSlice str)
         return convertUTF8ToString(std::span { untag(str.ptr), str.len });
     }
 
+    if (str.len > Bun__stringSyntheticAllocationLimit || str.len > WTF::String::MaxLength) [[unlikely]] {
+        return {};
+    }
+
     if (isTaggedUTF16Ptr(str.ptr)) {
         std::span<char16_t> out;
         auto impl = WTF::StringImpl::tryCreateUninitialized(str.len, out);

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -70,7 +70,6 @@ pub(crate) fn get_public_path_with_asset_prefix<W: core::fmt::Write>(
     }
 }
 
-use bun_jsc::HostReturn as _;
 use core::ffi::c_void;
 use std::io::Write as _;
 
@@ -792,11 +791,11 @@ fn register_macro(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsRe
     Ok(JSValue::UNDEFINED)
 }
 
-fn get_cwd(global_this: &JSGlobalObject, _: &JSObject) -> JSValue {
+fn get_cwd(global_this: &JSGlobalObject, _: &JSObject) -> JsResult<JSValue> {
     EncodedSlice::from_bytes(bun_resolver::fs::FileSystem::get().top_level_dir).to_js(global_this)
 }
 
-fn get_origin(global_this: &JSGlobalObject, _: &JSObject) -> JSValue {
+fn get_origin(global_this: &JSGlobalObject, _: &JSObject) -> JsResult<JSValue> {
     EncodedSlice::from_bytes(VirtualMachine::get().origin.origin).to_js(global_this)
 }
 
@@ -804,16 +803,14 @@ fn enable_ansi_colors(_global_this: &JSGlobalObject, _: &JSObject) -> JSValue {
     JSValue::from(Output::enable_ansi_colors_stdout() || Output::enable_ansi_colors_stderr())
 }
 
-// callconv(jsc.conv) — `SYSV_ABI` on win-x64 (BunObject.cpp:1103). Returns
-// plain `JSValue` so the generated thunk is a bare deref+call (no
-// `ExceptionValidationScope`).
+// callconv(jsc.conv) — `SYSV_ABI` on win-x64 (BunObject.cpp:1103).
 // HOST_EXPORT(BunObject_getter_main, jsc)
-pub fn get_main(global_this: &JSGlobalObject) -> JSValue {
+pub fn get_main(global_this: &JSGlobalObject) -> JsResult<JSValue> {
     // SAFETY: bun_vm() returns the live singleton VirtualMachine for a Bun-owned global.
     let vm = global_this.bun_vm().as_mut();
     // If JS has set it to a custom value, use that one
     if let Some(overridden_main) = vm.overridden_main.get() {
-        return overridden_main;
+        return Ok(overridden_main);
     }
 
     // Attempt to use the resolved filesystem path
@@ -872,10 +869,7 @@ pub fn get_main(global_this: &JSGlobalObject) -> JSValue {
             }
         }
 
-        return vm
-            .main_resolved_path
-            .to_js(global_this)
-            .or_pending_exception();
+        return vm.main_resolved_path.to_js(global_this);
     }
 
     EncodedSlice::from_bytes(vm.main()).to_js(global_this)

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1987,7 +1987,7 @@ impl BuildArtifact {
     }
 
     #[bun_jsc::host_fn(getter)]
-    pub(crate) fn get_mime_type(this: &Self, global_object: &JSGlobalObject) -> JSValue {
+    pub(crate) fn get_mime_type(this: &Self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
         BlobExt::get_type(&this.blob, global_object)
     }
 

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -49,9 +49,9 @@ fn array_buffer_to_string(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
             // Uint16Array/Int16Array storage is u16-aligned with even byte length;
             // bytemuck checks both at runtime.
             let utf16: &[u16] = bytemuck::cast_slice(array_buffer.byte_slice());
-            Ok(EncodedSlice::utf16(utf16).to_js(global))
+            EncodedSlice::utf16(utf16).to_js(global)
         }
-        _ => Ok(EncodedSlice::latin1(array_buffer.slice()).to_js(global)),
+        _ => EncodedSlice::latin1(array_buffer.slice()).to_js(global),
     }
 }
 

--- a/src/runtime/api/bun/SecureContext.rs
+++ b/src/runtime/api/bun/SecureContext.rs
@@ -199,15 +199,15 @@ impl SecureContext {
         result.put(
             global,
             b"key",
-            EncodedSlice::latin1(key_slice).to_js(global),
+            EncodedSlice::latin1(key_slice).to_js(global)?,
         );
         result.put(
             global,
             b"cert",
-            EncodedSlice::latin1(cert_slice).to_js(global),
+            EncodedSlice::latin1(cert_slice).to_js(global)?,
         );
         if let Some(ca_slice) = ca_slice {
-            result.put(global, b"ca", EncodedSlice::latin1(ca_slice).to_js(global));
+            result.put(global, b"ca", EncodedSlice::latin1(ca_slice).to_js(global)?);
         }
         Ok(result)
     }
@@ -244,13 +244,13 @@ impl SecureContext {
             {
                 let code = boringssl::ERR_get_error();
                 if code != 0 {
-                    return Err(global.throw_value(err_to_js(global, code)));
+                    return Err(global.throw_value(err_to_js(global, code)?));
                 }
                 if err == uws::create_bun_socket_error_t::none {
                     return Err(global.throw(format_args!("Failed to create SSL context")));
                 }
             }
-            return Err(global.throw_value(create_bun_socket_error_to_js(err, global)));
+            return Err(global.throw_value(create_bun_socket_error_to_js(err, global)?));
         };
         let sc = Box::new(SecureContext {
             ctx,
@@ -346,13 +346,13 @@ impl SecureContext {
                 // preconditions; reads the thread-local error queue).
                 let code = boringssl::ERR_get_error();
                 if code != 0 {
-                    return Err(global.throw_value(err_to_js(global, code)));
+                    return Err(global.throw_value(err_to_js(global, code)?));
                 }
                 if err == uws::create_bun_socket_error_t::none {
                     return Err(global.throw(format_args!("Failed to create SSL context")));
                 }
             }
-            return Err(global.throw_value(create_bun_socket_error_to_js(err, global)));
+            return Err(global.throw_value(create_bun_socket_error_to_js(err, global)?));
         };
         Ok(Box::new(SecureContext {
             ctx,

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -15,17 +15,15 @@ use core::ffi::{c_int, c_void};
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::node::StringOrBuffer;
-use bun_core::EncodedSlice;
 use bun_core::SignalCode;
 use bun_io::Loop as AsyncLoop;
 use bun_io::pipe_reader::BufferedReaderParent;
 #[cfg(unix)]
 use bun_io::pipe_reader::PosixFlags;
 use bun_io::{BufferedReader, ReadState, StreamingWriter, WriteStatus};
-use bun_jsc::EncodedSliceJsc as _;
 use bun_jsc::{
     self as jsc, CallFrame, EventLoopHandle, JSGlobalObject, JSValue, JsCell, JsRef, JsResult,
-    MarkedArrayBuffer, SysErrorJsc,
+    MarkedArrayBuffer, StringJsc as _, SysErrorJsc,
 };
 use bun_sys::{self as sys, Fd, FdExt};
 
@@ -1859,9 +1857,13 @@ impl Terminal {
 
         let global_this = self.global();
         let signal_value: JSValue = if let Some(s) = signal {
-            // SignalCode derives Debug → "SIGTERM" etc.
-            let name = format!("{:?}", s);
-            EncodedSlice::latin1(name.as_bytes()).to_js(global_this)
+            match bun_core::String::static_(s.name()).to_js(global_this) {
+                Ok(name) => name,
+                Err(err) => {
+                    crate::dispatch::fold(Err(err));
+                    return;
+                }
+            }
         } else {
             JSValue::NULL
         };

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2033,19 +2033,18 @@ fn spawn_maybe_sync(
 
     subprocess.update_has_pending_activity();
 
-    let signal_code = SubprocessT::get_signal_code(subprocess, global_this)?;
     let exit_code = SubprocessT::get_exit_code(subprocess, global_this);
     // Propagated after `finalize`, which must run even when building the output throws.
-    let output = subprocess
-        .stdout
-        .with_mut(|s| s.to_buffered_value(global_this))
-        .and_then(|stdout| {
-            let stderr = subprocess
-                .stderr
-                .with_mut(|s| s.to_buffered_value(global_this))?;
-            let resource_usage = subprocess.create_resource_usage_object(global_this)?;
-            Ok((stdout, stderr, resource_usage))
-        });
+    let output = SubprocessT::get_signal_code(subprocess, global_this).and_then(|signal_code| {
+        let stdout = subprocess
+            .stdout
+            .with_mut(|s| s.to_buffered_value(global_this))?;
+        let stderr = subprocess
+            .stderr
+            .with_mut(|s| s.to_buffered_value(global_this))?;
+        let resource_usage = subprocess.create_resource_usage_object(global_this)?;
+        Ok((signal_code, stdout, stderr, resource_usage))
+    });
     let exited_due_to_timeout = did_timeout;
     let exited_due_to_max_buffer = subprocess.exited_due_to_maxbuf.get();
     let result_pid = JSValue::js_number_from_int32(subprocess.pid());
@@ -2053,7 +2052,7 @@ fn spawn_maybe_sync(
     // above (spawnSync path: never handed to a JS wrapper); reclaim ownership.
     // `subprocess` (`&mut *subprocess_ptr`) is not used after this line.
     SubprocessT::finalize(unsafe { Box::from_raw(subprocess_ptr) });
-    let (stdout, stderr, resource_usage) = output?;
+    let (signal_code, stdout, stderr, resource_usage) = output?;
 
     let sync_value = JSValue::create_empty_object(global_this, 0);
     sync_value.put(global_this, b"exitCode", exit_code);

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2033,7 +2033,7 @@ fn spawn_maybe_sync(
 
     subprocess.update_has_pending_activity();
 
-    let signal_code = SubprocessT::get_signal_code(subprocess, global_this);
+    let signal_code = SubprocessT::get_signal_code(subprocess, global_this)?;
     let exit_code = SubprocessT::get_exit_code(subprocess, global_this);
     // Propagated after `finalize`, which must run even when building the output throws.
     let output = subprocess

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1194,10 +1194,22 @@ impl Subprocess<'_> {
                     };
                     this_value.ensure_still_alive();
 
+                    let signal_code = match self.get_signal_code(global_this) {
+                        Ok(v) => v,
+                        Err(err) => {
+                            let err = global_this.take_exception(err);
+                            let _ = global_this.bun_vm().as_mut().uncaught_exception(
+                                global_this,
+                                err,
+                                false,
+                            );
+                            JSValue::UNDEFINED
+                        }
+                    };
                     let args = [
                         this_value,
                         self.get_exit_code(global_this),
-                        self.get_signal_code(global_this),
+                        signal_code,
                         waitpid_value,
                     ];
 
@@ -1435,21 +1447,20 @@ impl Subprocess<'_> {
     }
 
     #[bun_jsc::host_fn(getter)]
-    pub(crate) fn get_signal_code(&self, global: &JSGlobalObject) -> JSValue {
+    pub(crate) fn get_signal_code(&self, global: &JSGlobalObject) -> JsResult<JSValue> {
         if let Some(signal) = self.process().signal_code() {
             // `process.signal_code()` returns the tier-0 `bun_core::SignalCode`
             // (bare `#[repr(u8)]` discriminant); name/exit-code helpers live on
             // `bun_sys::SignalCode`.
             let sys_sig = bun_sys::SignalCode(signal as u8);
             if let Some(name) = sys_sig.name() {
-                use bun_jsc::EncodedSliceJsc as _;
-                return bun_core::EncodedSlice::latin1(name.as_bytes()).to_js(global);
+                return bun_jsc::StringJsc::to_js(&bun_core::String::static_(name), global);
             } else {
-                return JSValue::js_number(signal as u32 as f64);
+                return Ok(JSValue::js_number(signal as u32 as f64));
             }
         }
 
-        JSValue::NULL
+        Ok(JSValue::NULL)
     }
 
     pub(crate) fn handle_ipc_message(

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 
 use bun_jsc::{
     self as jsc, CallFrame, GlobalRef, JSGlobalObject, JSPromise, JSValue, JsCell, JsResult,
-    ProtectedJSValue, SystemError, bun_string_jsc,
+    ProtectedJSValue, StringJsc as _, SystemError, bun_string_jsc,
 };
 // Note: `bun_jsc::VirtualMachine` is a *module* re-export
 // (`pub use self::virtual_machine as VirtualMachine;`). The struct lives at
@@ -27,8 +27,7 @@ use crate::webcore::streams::{
     self, SourceHandle, Start, StartTag, StreamError, StreamResult, Writable, WritablePending,
 };
 use crate::webcore::{self, ByteStream, DrainResult, ReadableStream, Response, SinkHandle};
-use bun_core::{EncodedSlice, String as BunString, Utf8Bytes};
-use bun_jsc::EncodedSliceJsc as _;
+use bun_core::{String as BunString, Utf8Bytes};
 use bun_jsc::call_frame::ArgumentsSlice;
 
 // lol-html rewritable units, lifetime-erased to `'static` so a `*mut RawX`
@@ -371,7 +370,7 @@ impl HTMLRewriter {
         let selector_source = utf8_or_throw(global, selector_name)?;
         let selector = match selector_source.parse::<lol_html::Selector>() {
             Ok(s) => s,
-            Err(e) => return Err(global.throw_value(create_lolhtml_error(global, &e))),
+            Err(e) => return Err(global.throw_value(create_lolhtml_error(global, &e)?)),
         };
 
         let handler = Box::new(ElementHandler::init(global, listener)?);
@@ -1698,9 +1697,11 @@ impl RewriterPipe {
 
         if self.sync_only_noun.get().is_some() {
             // `init()` is still on the stack; make `transform()` throw.
-            return self.set_handler_error(
-                captured.unwrap_or_else(|| create_lolhtml_error(&self.global, e)),
-            );
+            return self.set_handler_error(match captured {
+                Some(err) => err,
+                None => create_lolhtml_error(&self.global, e)
+                    .unwrap_or_else(|err| self.global.take_error(err)),
+            });
         }
 
         let value_error = match captured {
@@ -2436,11 +2437,14 @@ pub struct ContentOptions {
 
 // ────────────────────────── error helpers ────────────────────────────────
 
-fn create_lolhtml_error(global: &JSGlobalObject, message: &dyn core::fmt::Display) -> JSValue {
+fn create_lolhtml_error(
+    global: &JSGlobalObject,
+    message: &dyn core::fmt::Display,
+) -> JsResult<JSValue> {
     // If there was already a pending exception, we want to use that instead.
     if let Some(err) = global.try_take_exception() {
         // it's a synchronous error
-        return err;
+        return Ok(err);
     }
     // The handler's own exception / rejection, if any, is recorded on the
     // active `RewriterPipe` (`record_handler_error`) and `on_rewriting_error`
@@ -2450,9 +2454,9 @@ fn create_lolhtml_error(global: &JSGlobalObject, message: &dyn core::fmt::Displa
     value.put(
         global,
         b"name",
-        EncodedSlice::latin1(b"HTMLRewriterError").to_js(global),
+        BunString::static_("HTMLRewriterError").to_js(global)?,
     );
-    value
+    Ok(value)
 }
 
 /// lol-html error `Display` text → owned `bun.String`.
@@ -2464,7 +2468,10 @@ fn lol_err_string(e: impl core::fmt::Display) -> BunString {
 /// an `HTMLRewriterError` carrying the `Utf8Error` `Display` text — the same
 /// text lol-html's C API `to_str!` used to stash in its last-error slot.
 fn utf8_or_throw<'a>(global: &JSGlobalObject, bytes: &'a [u8]) -> JsResult<&'a str> {
-    core::str::from_utf8(bytes).map_err(|e| global.throw_value(create_lolhtml_error(global, &e)))
+    core::str::from_utf8(bytes).map_err(|e| match create_lolhtml_error(global, &e) {
+        Ok(err) => global.throw_value(err),
+        Err(err) => err,
+    })
 }
 
 /// Decode a raw-`JSValue` setter argument to owned UTF-8. `to_utf8` runs
@@ -2728,7 +2735,7 @@ impl Comment {
             return Ok(());
         };
         if let Err(e) = comment.set_text(&text) {
-            return Err(global.throw_value(create_lolhtml_error(global, &e)));
+            return Err(global.throw_value(create_lolhtml_error(global, &e)?));
         }
         Ok(())
     }
@@ -3012,7 +3019,7 @@ impl Element {
         // `None` iff the element is void (`!can_have_content`) — the exact
         // condition lol-html's C API mapped to the "No end tag." error.
         let Some(handlers) = el.end_tag_handlers() else {
-            let err = create_lolhtml_error(global_object, &"No end tag.");
+            let err = create_lolhtml_error(global_object, &"No end tag.")?;
             return Err(global_object.throw_value(err));
         };
 
@@ -3087,7 +3094,7 @@ impl Element {
         let name = utf8_or_throw(global_object, name)?;
         let value = utf8_or_throw(global_object, value)?;
         if let Err(e) = el.set_attribute(name, value) {
-            let err = create_lolhtml_error(global_object, &e);
+            let err = create_lolhtml_error(global_object, &e)?;
             return Err(global_object.throw_value(err));
         }
         Ok(call_frame.this())
@@ -3228,7 +3235,7 @@ impl Element {
             return Ok(());
         };
         if let Err(e) = el.set_tag_name(&name) {
-            return Err(global.throw_value(create_lolhtml_error(global, &e)));
+            return Err(global.throw_value(create_lolhtml_error(global, &e)?));
         }
         Ok(())
     }

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -362,8 +362,8 @@ impl CryptoHasher {
         let Some(len) = evp.hash(boring_engine(global), input.slice(), &mut output_digest_buf)
         else {
             let err = boring_ssl::ERR_get_error();
-            let instance = create_crypto_error(global, err);
             boring_ssl::ERR_clear_error();
+            let instance = create_crypto_error(global, err)?;
             return Err(global.throw_value(instance));
         };
         encoding.encode_with_max_size(
@@ -407,8 +407,8 @@ impl CryptoHasher {
 
         let Some(len) = evp.hash(boring_engine(global), input.slice(), output_digest_slice) else {
             let err = boring_ssl::ERR_get_error();
-            let instance = create_crypto_error(global, err);
             boring_ssl::ERR_clear_error();
+            let instance = create_crypto_error(global, err)?;
             return Err(global.throw_value(instance));
         };
 
@@ -523,8 +523,8 @@ impl CryptoHasher {
                         None => {
                             let err = boring_ssl::ERR_get_error();
                             if err != 0 {
-                                let instance = create_crypto_error(global, err);
                                 boring_ssl::ERR_clear_error();
+                                let instance = create_crypto_error(global, err)?;
                                 return Err(global.throw_value(instance));
                             } else {
                                 return Err(global
@@ -610,8 +610,8 @@ impl CryptoHasher {
                 inner.with_mut(|e| e.update(buffer.slice()));
                 let err = boring_ssl::ERR_get_error();
                 if err != 0 {
-                    let instance = create_crypto_error(global, err);
                     boring_ssl::ERR_clear_error();
+                    let instance = create_crypto_error(global, err)?;
                     return Err(global.throw_value(instance));
                 }
             }
@@ -625,8 +625,8 @@ impl CryptoHasher {
                 inner.with_mut(|opt| opt.as_mut().unwrap().update(buffer.slice()));
                 let err = boring_ssl::ERR_get_error();
                 if err != 0 {
-                    let instance = create_crypto_error(global, err);
                     boring_ssl::ERR_clear_error();
+                    let instance = create_crypto_error(global, err)?;
                     return Err(global.throw_value(instance));
                 }
             }
@@ -661,8 +661,8 @@ impl CryptoHasher {
                     Ok(h) => h,
                     Err(_) => {
                         let code = boring_ssl::ERR_get_error();
-                        let err = create_crypto_error(global, code);
                         boring_ssl::ERR_clear_error();
+                        let err = create_crypto_error(global, code)?;
                         return Err(global.throw_value(err));
                     }
                 })));

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -477,7 +477,7 @@ pub(crate) trait PasswordOp: Send + 'static {
     /// the job and are `free_sensitive`d in the job's / op's `Drop`.
     fn compute(&self, password: &[u8]) -> Result<Self::Value, HashError>;
     /// Convert the success payload to a `JSValue` on the JS thread.
-    fn to_js(value: Self::Value, g: &JSGlobalObject) -> JSValue;
+    fn to_js(value: Self::Value, g: &JSGlobalObject) -> JsResult<JSValue>;
 }
 
 pub(crate) struct HashOp {
@@ -489,10 +489,9 @@ impl PasswordOp for HashOp {
     fn compute(&self, password: &[u8]) -> Result<Box<[u8]>, HashError> {
         PasswordObject::hash(password, self.algorithm)
     }
-    fn to_js(value: Box<[u8]>, g: &JSGlobalObject) -> JSValue {
+    fn to_js(value: Box<[u8]>, g: &JSGlobalObject) -> JsResult<JSValue> {
         // PHC / bcrypt output is ASCII.
         EncodedSlice::latin1(&value).to_js(g)
-        // `value` drops here.
     }
 }
 
@@ -513,14 +512,14 @@ impl PasswordOp for VerifyOp {
     fn compute(&self, password: &[u8]) -> Result<bool, HashError> {
         PasswordObject::verify(password, &self.prev_hash, self.algorithm)
     }
-    fn to_js(value: bool, _g: &JSGlobalObject) -> JSValue {
-        JSValue::js_boolean(value)
+    fn to_js(value: bool, _g: &JSGlobalObject) -> JsResult<JSValue> {
+        Ok(JSValue::js_boolean(value))
     }
 }
 
 /// Build the JS `Error` instance for a failed hash/verify, with `code` set
 /// to `PASSWORD_<SCREAMING_SNAKE_ERROR_NAME>`.
-fn password_error_instance(err: &HashError, verb: &str, g: &JSGlobalObject) -> JSValue {
+fn password_error_instance(err: &HashError, verb: &str, g: &JSGlobalObject) -> JsResult<JSValue> {
     let mut error_code: Vec<u8> = Vec::new();
     write!(
         &mut error_code,
@@ -534,8 +533,8 @@ fn password_error_instance(err: &HashError, verb: &str, g: &JSGlobalObject) -> J
         "Password {verb} failed with error \"{}\"",
         err.name()
     ));
-    instance.put(g, b"code", EncodedSlice::latin1(&error_code).to_js(g));
-    instance
+    instance.put(g, b"code", EncodedSlice::latin1(&error_code).to_js(g)?);
+    Ok(instance)
 }
 
 /// `Bun.password.hash/verify` off the JS thread: the op and the password are
@@ -570,11 +569,13 @@ impl<Op: PasswordOp> bun_jsc::JobContext for PasswordJob<Op> {
         let global = cx.global();
         match this.value.take().expect("computed") {
             Err(err) => {
-                let error_instance = password_error_instance(&err, Op::ERR_VERB, global);
-                promise.reject_with_async_stack(global, Ok(error_instance))?;
+                promise.reject_with_async_stack(
+                    global,
+                    password_error_instance(&err, Op::ERR_VERB, global),
+                )?;
             }
             Ok(v) => {
-                let js = Op::to_js(v, global);
+                let js = Op::to_js(v, global)?;
                 promise.resolve(global, js)?;
             }
         }
@@ -598,10 +599,11 @@ impl JSPasswordObject {
         if SYNC {
             return match op.compute(&password) {
                 Err(err) => {
-                    let error_instance = password_error_instance(&err, Op::ERR_VERB, global_object);
+                    let error_instance =
+                        password_error_instance(&err, Op::ERR_VERB, global_object)?;
                     Err(global_object.throw_value(error_instance))
                 }
-                Ok(v) => Ok(Op::to_js(v, global_object)),
+                Ok(v) => Op::to_js(v, global_object),
             };
         }
 

--- a/src/runtime/crypto/boringssl_jsc.rs
+++ b/src/runtime/crypto/boringssl_jsc.rs
@@ -2,7 +2,7 @@
 
 use bun_boringssl_sys as boring;
 use bun_core::EncodedSlice;
-use bun_jsc::{EncodedSliceJsc as _, JSGlobalObject, JSValue};
+use bun_jsc::{EncodedSliceJsc as _, JSGlobalObject, JSValue, JsResult, StringJsc as _};
 
 /// Node's `ERR_LIB_*` → macro-prefix map from `crypto_util.cc`
 /// (`OSSL_ERROR_CODES_MAP`). Libraries Node does not map get an empty prefix
@@ -41,18 +41,19 @@ fn lib_short_name(lib: u32) -> &'static str {
     }
 }
 
-/// SAFETY: `ptr` is a NUL-terminated static string returned by BoringSSL's
-/// error-string tables (or null).
-fn static_cstr<'a>(ptr: *const core::ffi::c_char) -> Option<&'a [u8]> {
+/// SAFETY: `ptr` is null or a NUL-terminated string returned by BoringSSL's
+/// `ERR_*_error_string` functions. Those are static table entries except
+/// `ERR_reason_error_string` for `ERR_LIB_SYS`, which returns `strerror()`.
+fn err_cstr<'a>(ptr: *const core::ffi::c_char) -> Option<&'a [u8]> {
     if ptr.is_null() {
         return None;
     }
-    // SAFETY: see above - the pointer is a 'static NUL-terminated table entry.
+    // SAFETY: see above.
     let bytes = unsafe { core::ffi::CStr::from_ptr(ptr) }.to_bytes();
     if bytes.is_empty() { None } else { Some(bytes) }
 }
 
-pub(crate) fn err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
+pub(crate) fn err_to_js(global: &JSGlobalObject, err_code: u32) -> JsResult<JSValue> {
     // The message is the raw ERR_error_string output
     // ("error:0b000074:X.509 certificate routines:OPENSSL_internal:..."),
     // exactly what Node built against BoringSSL produces - no prefix.
@@ -70,12 +71,12 @@ pub(crate) fn err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
 
     let error_message: &[u8] = bun_core::slice_to_nul(&outbuf[..]);
     if error_message.is_empty() {
-        return global
+        return Ok(global
             .err(
                 bun_jsc::ErrorCode::BORINGSSL,
                 format_args!("An unknown BoringSSL error occurred: {}", err_code),
             )
-            .to_js();
+            .to_js());
     }
 
     // A plain Error carrying Node's library/function/reason/code decomposition
@@ -83,25 +84,25 @@ pub(crate) fn err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
     // ERR_OSSL_<LIB>_<REASON> (or ERR_SSL_<REASON> for the SSL library).
     let err = EncodedSlice::utf8(error_message).to_error_instance(global);
 
-    if let Some(library) = static_cstr(boring::ERR_lib_error_string(err_code)) {
+    if let Some(library) = err_cstr(boring::ERR_lib_error_string(err_code)) {
         err.put(
             global,
             b"library",
-            EncodedSlice::latin1(library).to_js(global),
+            bun_core::String::static_(library).to_js(global)?,
         );
     }
-    if let Some(function) = static_cstr(boring::ERR_func_error_string(err_code)) {
+    if let Some(function) = err_cstr(boring::ERR_func_error_string(err_code)) {
         err.put(
             global,
             b"function",
-            EncodedSlice::latin1(function).to_js(global),
+            bun_core::String::static_(function).to_js(global)?,
         );
     }
-    if let Some(reason) = static_cstr(boring::ERR_reason_error_string(err_code)) {
+    if let Some(reason) = err_cstr(boring::ERR_reason_error_string(err_code)) {
         err.put(
             global,
             b"reason",
-            EncodedSlice::latin1(reason).to_js(global),
+            EncodedSlice::latin1(reason).to_js(global)?,
         );
 
         let lib = lib_short_name((err_code >> 24) & 0xff);
@@ -112,8 +113,8 @@ pub(crate) fn err_to_js(global: &JSGlobalObject, err_code: u32) -> JSValue {
         code.extend_from_slice(prefix.as_bytes());
         code.extend_from_slice(lib.as_bytes());
         code.extend_from_slice(reason);
-        err.put(global, b"code", EncodedSlice::latin1(&code).to_js(global));
+        err.put(global, b"code", EncodedSlice::latin1(&code).to_js(global)?);
     }
 
-    err
+    Ok(err)
 }

--- a/src/runtime/crypto/mod.rs
+++ b/src/runtime/crypto/mod.rs
@@ -1,4 +1,4 @@
-use crate::jsc::{JSGlobalObject, JSValue};
+use crate::jsc::{JSGlobalObject, JSValue, JsResult};
 
 // ─── submodules ───────────────────────────────────────────────────────────
 
@@ -21,7 +21,10 @@ pub mod pbkdf2;
 #[path = "boringssl_jsc.rs"]
 pub mod boringssl_jsc;
 
-pub(crate) fn create_crypto_error(global_this: &JSGlobalObject, err_code: u32) -> JSValue {
+pub(crate) fn create_crypto_error(
+    global_this: &JSGlobalObject,
+    err_code: u32,
+) -> JsResult<JSValue> {
     boringssl_jsc::err_to_js(global_this, err_code)
 }
 

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -738,12 +738,14 @@ extern "C" fn napi_create_string_latin1(
         return env.ok();
     }
 
-    let (string, bytes) = bun_core::String::create_uninitialized_latin1(slice.len());
-    bytes.copy_from_slice(slice);
-
+    let Ok(string) =
+        bun_core::String::create_latin1_with(slice.len(), |buf| buf.copy_from_slice(slice))
+    else {
+        return env.generic_failure();
+    };
     let js = match string.into_js(env.to_js()) {
         Ok(v) => v,
-        Err(_) => return NapiEnv::set_last_error(Some(env), NapiStatus::generic_failure),
+        Err(_) => return env.pending_exception(),
     };
     result.set(env, js);
     env.ok()
@@ -784,7 +786,7 @@ extern "C" fn napi_create_string_utf8(
     let global_object = env.to_js();
     let string = match bun_string_jsc::create_utf8_for_js(global_object, slice) {
         Ok(v) => v,
-        Err(_) => return env.generic_failure(),
+        Err(_) => return env.pending_exception(),
     };
     result.set(env, string);
     env.ok()
@@ -835,12 +837,14 @@ extern "C" fn napi_create_string_utf16(
         return env.ok();
     }
 
-    let (string, chars) = bun_core::String::create_uninitialized_utf16(slice.len());
-    chars.copy_from_slice(slice);
-
+    let Ok(string) =
+        bun_core::String::create_utf16_with(slice.len(), |buf| buf.copy_from_slice(slice))
+    else {
+        return env.generic_failure();
+    };
     let js = match string.into_js(env.to_js()) {
         Ok(v) => v,
-        Err(_) => return NapiEnv::set_last_error(Some(env), NapiStatus::generic_failure),
+        Err(_) => return env.pending_exception(),
     };
     result.set(env, js);
     env.ok()

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -465,20 +465,16 @@ pub mod random {
                 }
             }
 
-            let (str, bytes) = BunString::create_uninitialized_latin1(36);
-
             let uuid = if disable_entropy_cache {
                 UUID::init()
             } else {
                 global.bun_vm().as_mut().rare_data().next_uuid()
             };
 
-            uuid.print(
-                (&mut bytes[..36])
-                    .try_into()
-                    .expect("infallible: size matches"),
-            );
-            str.into_js(global)
+            bun_core::handle_oom(BunString::create_latin1_with(36, |buf| {
+                uuid.print(buf.try_into().unwrap())
+            }))
+            .into_js(global)
         }
 
         #[bun_jsc::host_fn]
@@ -519,13 +515,10 @@ pub mod random {
             }
             let uuid = UUID7::init(now_ms, entropy, bun_jsc::uuid::TimestampSource::Clock);
 
-            let (str, bytes) = BunString::create_uninitialized_latin1(36);
-            uuid.print(
-                (&mut bytes[..36])
-                    .try_into()
-                    .expect("infallible: size matches"),
-            );
-            str.into_js(global)
+            bun_core::handle_oom(BunString::create_latin1_with(36, |buf| {
+                uuid.print(buf.try_into().unwrap())
+            }))
+            .into_js(global)
         }
 
         fn assert_offset(

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -23,7 +23,7 @@ extern "C" fn create_argv0(global_object: &JSGlobalObject) -> JSValue {
         .get(0)
         .map(|z| z.as_bytes())
         .unwrap_or(b"bun");
-    EncodedSlice::from_bytes(argv0).to_js(global_object)
+    bun_jsc::HostReturn::or_pending_exception(EncodedSlice::from_bytes(argv0).to_js(global_object))
 }
 
 #[unsafe(export_name = "Bun__Process__getExecPath")]
@@ -32,7 +32,9 @@ extern "C" fn get_exec_path(global_object: &JSGlobalObject) -> JSValue {
         // if for any reason we are unable to get the executable path, we just return argv[0]
         return create_argv0(global_object);
     };
-    EncodedSlice::from_bytes(out.as_bytes()).to_js(global_object)
+    bun_jsc::HostReturn::or_pending_exception(
+        EncodedSlice::from_bytes(out.as_bytes()).to_js(global_object),
+    )
 }
 
 /// A worker's `argv`/`execArgv` strings live in its parent-thread
@@ -420,10 +422,14 @@ mod _impl {
             if script.is_empty() {
                 return JSValue::UNDEFINED;
             }
-            return EncodedSlice::from_bytes(script).to_js(global_object);
+            return bun_jsc::HostReturn::or_pending_exception(
+                EncodedSlice::from_bytes(script).to_js(global_object),
+            );
         }
         if let Some(source) = vm.module_loader.eval_source.as_deref() {
-            return EncodedSlice::from_bytes(source.contents()).to_js(global_object);
+            return bun_jsc::HostReturn::or_pending_exception(
+                EncodedSlice::from_bytes(source.contents()).to_js(global_object),
+            );
         }
         JSValue::UNDEFINED
     }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -3504,8 +3504,10 @@ mod ffi {
 fn throw_ssl_error_if_necessary(global: &JSGlobalObject) -> bool {
     let err_code = bun_boringssl_sys::ERR_get_error();
     if err_code != 0 {
-        let _ = global.throw_value(crate::crypto::create_crypto_error(global, err_code));
         bun_boringssl_sys::ERR_clear_error();
+        if let Ok(err) = crate::crypto::create_crypto_error(global, err_code) {
+            let _ = global.throw_value(err);
+        }
         return true;
     }
     false

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -416,7 +416,7 @@ impl Listener {
                     .set(NonNull::new(ctx.cast::<boring_sys::SSL_CTX>())),
                 None => {
                     return Err(global.throw_value(
-                        crate::socket::uws_jsc::create_bun_socket_error_to_js(create_err, global),
+                        crate::socket::uws_jsc::create_bun_socket_error_to_js(create_err, global)?,
                     ));
                 }
             }
@@ -774,12 +774,12 @@ impl Listener {
                             return Err(global.throw_value(
                                 crate::socket::uws_jsc::create_bun_socket_error_to_js(
                                     create_err, global,
-                                ),
+                                )?,
                             ));
                         }
                         let code = boring_sys::ERR_get_error();
                         return Err(global
-                            .throw_value(crate::crypto::boringssl_jsc::err_to_js(global, code)));
+                            .throw_value(crate::crypto::boringssl_jsc::err_to_js(global, code)?));
                     }
                 }
             } else {
@@ -1427,7 +1427,7 @@ impl Listener {
                         return Err(global.throw_value(
                             crate::socket::uws_jsc::create_bun_socket_error_to_js(
                                 create_err, global,
-                            ),
+                            )?,
                         ));
                     }
                 }
@@ -1535,7 +1535,7 @@ impl Listener {
             .unwrap(),
             _ => return Ok(JSValue::UNDEFINED),
         };
-        let address_js = EncodedSlice::latin1(formatted).to_js(global);
+        let address_js = EncodedSlice::latin1(formatted).to_js(global)?;
         let port_js = match socket_ref.get_local_port() {
             Some(p) => JSValue::js_number(p as f64),
             None => JSValue::UNDEFINED,
@@ -2036,7 +2036,10 @@ pub(crate) extern "C" fn us_dispatch_socket_server_name(
     // SAFETY: `hostname` is NUL-terminated per the fn contract.
     let name = unsafe { core::ffi::CStr::from_ptr(hostname) };
     // Peer-supplied SNI bytes, decoded as Latin-1 like Node's `OneByteString`.
-    let js_name = EncodedSlice::latin1(name.to_bytes()).to_js(&global);
+    let js_name = match EncodedSlice::latin1(name.to_bytes()).to_js(&global) {
+        Ok(js_name) => js_name,
+        Err(err) => return decode_sni_result(global.take_exception(err), abort_handshake).cast(),
+    };
     let result = match callback.call(&global, this_value, &[this_value, js_name, socket_handle]) {
         Ok(v) => v,
         Err(err) => global.take_exception(err),
@@ -2136,7 +2139,10 @@ extern "C" fn us_dispatch_server_name(
         .unwrap_or(JSValue::UNDEFINED);
     // SAFETY: `hostname` is NUL-terminated per the fn contract.
     let name = unsafe { core::ffi::CStr::from_ptr(hostname) };
-    let js_name = EncodedSlice::latin1(name.to_bytes()).to_js(&global);
+    let js_name = match EncodedSlice::latin1(name.to_bytes()).to_js(&global) {
+        Ok(js_name) => js_name,
+        Err(err) => return decode_sni_result(global.take_exception(err), abort_handshake),
+    };
     // The accepted socket processing this ClientHello: its JS wrapper is the
     // resume handle an asynchronous SNICallback uses (`handle.resumeSNI(...)`)
     // to complete the suspended handshake. The wrapper's lifecycle is

--- a/src/runtime/socket/SocketAddress.rs
+++ b/src/runtime/socket/SocketAddress.rs
@@ -180,22 +180,17 @@ impl SocketAddress {
         };
 
         const PREFIX: &str = "http://";
-        let url_str: BunString = if input.is_8bit() {
+        let url_str = if input.is_8bit() {
             let from_chars = input.latin1();
-            let (str, to_chars) =
-                BunString::create_uninitialized_latin1(from_chars.len() + PREFIX.len());
-            to_chars[..PREFIX.len()].copy_from_slice(PREFIX.as_bytes());
-            to_chars[PREFIX.len()..].copy_from_slice(from_chars);
-            str
+            BunString::create_latin1_with(PREFIX.len() + from_chars.len(), |buf| {
+                bun_core::concat_into(buf, &[PREFIX.as_bytes(), from_chars]);
+            })
         } else {
             let from_chars = input.utf16();
-            let (str, to_chars) =
-                BunString::create_uninitialized_utf16(from_chars.len() + PREFIX.len());
-            // bun.strings.literal(u16, "http://")
-            to_chars[..PREFIX.len()].copy_from_slice(bun_core::w!("http://"));
-            to_chars[PREFIX.len()..].copy_from_slice(from_chars);
-            str
-        };
+            BunString::create_utf16_with(PREFIX.len() + from_chars.len(), |buf| {
+                bun_core::concat_into(buf, &[bun_core::w!("http://"), from_chars]);
+            })
+        }?;
 
         let Some(url) = bun_jsc::url::Parsed::from_string(&url_str) else {
             return Ok(JSValue::UNDEFINED);

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -191,7 +191,13 @@ extern "C" fn select_alpn_callback(
             } else {
                 // SAFETY: BoringSSL hands back a NUL-terminated name.
                 let name = unsafe { core::ffi::CStr::from_ptr(servername_ptr) };
-                EncodedSlice::latin1(name.to_bytes()).to_js(&global)
+                match EncodedSlice::latin1(name.to_bytes()).to_js(&global) {
+                    Ok(name) => name,
+                    Err(err) => {
+                        crate::dispatch::fold(Err(err));
+                        return boringssl_sys::SSL_TLSEXT_ERR_ALERT_FATAL;
+                    }
+                }
             };
             let result =
                 match callback.call(&global, this_value, &[this_value, servername_js, buffer]) {
@@ -3557,11 +3563,13 @@ impl<const SSL: bool> NewSocket<SSL> {
                         return Err(global.throw_value(
                             crate::socket::uws_jsc::create_bun_socket_error_to_js(
                                 create_err, global,
-                            ),
+                            )?,
                         ));
                     }
-                    return Err(global
-                        .throw_value(boringssl_err_to_js(global, boringssl_sys::ERR_get_error())));
+                    return Err(global.throw_value(boringssl_err_to_js(
+                        global,
+                        boringssl_sys::ERR_get_error(),
+                    )?));
                 }
             };
         } else {
@@ -3646,7 +3654,7 @@ impl<const SSL: bool> NewSocket<SSL> {
                 // ref and the handlers `Rc`. Sole owner of the fresh allocation.
                 tls.get().deref();
                 if err != 0 {
-                    return Err(global.throw_value(boringssl_err_to_js(global, err)));
+                    return Err(global.throw_value(boringssl_err_to_js(global, err)?));
                 }
                 return Err(global.throw(format_args!(
                     "Failed to upgrade socket from TCP -> TLS. Is the TLS config correct?",

--- a/src/runtime/socket/uws_jsc.rs
+++ b/src/runtime/socket/uws_jsc.rs
@@ -2,7 +2,7 @@
 //! Exports here are referenced via aliases on the original structs so call
 //! sites do not change.
 
-use bun_jsc::{JSGlobalObject, JSValue};
+use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 use bun_uws::{
     AnyWebSocket, RawWebSocket, create_bun_socket_error_t, us_socket_stream_buffer_t, us_socket_t,
 };
@@ -40,8 +40,8 @@ impl StreamBufferExt for bun_uws_sys::us_socket::StreamBuffer {
 pub(crate) fn create_bun_socket_error_to_js(
     this: create_bun_socket_error_t,
     global_object: &JSGlobalObject,
-) -> JSValue {
-    match this {
+) -> JsResult<JSValue> {
+    Ok(match this {
         // us_ssl_ctx_from_options only sets *err for the CA/cipher cases;
         // bad cert/key/DH return NULL with .none and the detail is on the
         // BoringSSL error queue. Surfacing it here keeps every
@@ -49,7 +49,7 @@ pub(crate) fn create_bun_socket_error_to_js(
         create_bun_socket_error_t::none => crate::crypto::boringssl_jsc::err_to_js(
             global_object,
             bun_boringssl_sys::ERR_get_error(),
-        ),
+        )?,
         create_bun_socket_error_t::load_ca_file => global_object
             .err(
                 bun_jsc::ErrorCode::BORINGSSL,
@@ -83,7 +83,7 @@ pub(crate) fn create_bun_socket_error_to_js(
                 format_args!("Failed to set ECDH curve"),
             )
             .to_js(),
-    }
+    })
 }
 
 // LAYERING: body sunk to `bun_jsc::system_error` so `bun_sql_jsc` (which this

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -246,7 +246,7 @@ pub trait BlobExt {
     ) -> JSValue;
     fn get_slice(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue>;
     fn get_mime_type_or_content_type(&self) -> Option<MimeType>;
-    fn get_type(&self, global_this: &JSGlobalObject) -> JSValue;
+    fn get_type(&self, global_this: &JSGlobalObject) -> JsResult<JSValue>;
     fn get_name_string(&self) -> Option<&BunString>;
     fn get_name(&self, _: JSValue, global_this: &JSGlobalObject) -> JsResult<JSValue>;
     fn set_name(
@@ -2021,7 +2021,7 @@ impl BlobExt for Blob {
         self.store().map(|s| s.mime_type.clone())
     }
 
-    fn get_type(&self, global_this: &JSGlobalObject) -> JSValue {
+    fn get_type(&self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         let ct = self.content_type_slice();
         if !ct.is_empty() {
             return EncodedSlice::latin1(ct).to_js(global_this);
@@ -2029,7 +2029,7 @@ impl BlobExt for Blob {
         if let Some(store) = self.store.get() {
             return EncodedSlice::latin1(&store.mime_type.value).to_js(global_this);
         }
-        JSValue::js_empty_string(global_this)
+        Ok(JSValue::js_empty_string(global_this))
     }
 
     fn get_name_string(&self) -> Option<&BunString> {

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -21,7 +21,7 @@ use core::ptr::{self, NonNull};
 
 use bun_core::EncodedSlice;
 use bun_jsc::EncodedSliceJsc as _;
-use bun_jsc::{ErrorCode, JSGlobalObject, JSUint8Array, JSValue, Strong};
+use bun_jsc::{ErrorCode, JSGlobalObject, JSUint8Array, JSValue, JsResult, Strong};
 
 use bun_brotli::c as brotli;
 use bun_zlib as zlib;
@@ -832,8 +832,8 @@ pub extern "C" fn CompressionStreamCoder__transform(
     result
 }
 
-fn codec_error_to_js(global: &JSGlobalObject, e: &CodecError) -> JSValue {
-    match *e {
+fn codec_error_to_js(global: &JSGlobalObject, e: &CodecError) -> JsResult<JSValue> {
+    Ok(match *e {
         CodecError::TrailingJunk => global
             .err(
                 ErrorCode::ERR_TRAILING_JUNK_AFTER_STREAM_END,
@@ -845,18 +845,20 @@ fn codec_error_to_js(global: &JSGlobalObject, e: &CodecError) -> JSValue {
         CodecError::Brotli(detail) => {
             let code = format!("ERR_{detail}");
             let err = global.create_type_error_instance(format_args!("brotli decode failed"));
-            let code_js = EncodedSlice::latin1(code.as_bytes()).to_js(global);
-            err.put(global, b"code", code_js);
             let cause = global.create_error_instance(format_args!("{detail}"));
+            let code_js = EncodedSlice::latin1(code.as_bytes()).to_js(global)?;
+            err.put(global, b"code", code_js);
             cause.put(global, b"code", code_js);
             err.put(global, b"cause", cause);
             err
         }
-    }
+    })
 }
 
 fn throw_codec_error(global: &JSGlobalObject, e: CodecError) {
-    let _ = global.throw_value(codec_error_to_js(global, &e));
+    if let Ok(err) = codec_error_to_js(global, &e) {
+        let _ = global.throw_value(err);
+    }
 }
 
 /// [`CompressionStreamCoder__transform`], but the output is written to the
@@ -989,7 +991,7 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
         let global = cx.global();
         let (out, out_len, err) = match &this.error {
             None => (this.out.as_ptr(), this.out.len(), JSValue::ZERO),
-            Some(e) => (core::ptr::null(), 0, codec_error_to_js(global, e)),
+            Some(e) => (core::ptr::null(), 0, codec_error_to_js(global, e)?),
         };
         // SAFETY: FFI into `JSCompressionStreamShared.cpp`; see above.
         unsafe {

--- a/src/runtime/webcore/Crypto.rs
+++ b/src/runtime/webcore/Crypto.rs
@@ -84,17 +84,13 @@ impl Crypto {
         global: &JSGlobalObject,
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (str, bytes) = BunString::create_uninitialized_latin1(36);
-
         // SAFETY: `bun_vm()` never returns null for a Bun-owned global.
         let uuid = global.bun_vm().as_mut().rare_data().next_uuid();
 
-        uuid.print(
-            (&mut bytes[0..36])
-                .try_into()
-                .expect("infallible: size matches"),
-        );
-        str.into_js(global)
+        bun_core::handle_oom(BunString::create_latin1_with(36, |buf| {
+            uuid.print(buf.try_into().unwrap())
+        }))
+        .into_js(global)
     }
 
     // DOMJIT fast path.
@@ -221,13 +217,10 @@ fn bun_random_uuid_v7(global: &JSGlobalObject, callframe: &CallFrame) -> JsResul
     );
 
     if encoding == Encoding::Hex {
-        let (str, bytes) = BunString::create_uninitialized_latin1(36);
-        uuid.print(
-            (&mut bytes[0..36])
-                .try_into()
-                .expect("infallible: size matches"),
-        );
-        return str.into_js(global);
+        return bun_core::handle_oom(BunString::create_latin1_with(36, |buf| {
+            uuid.print(buf.try_into().unwrap())
+        }))
+        .into_js(global);
     }
 
     encoding.encode_with_max_size(global, 32, &uuid.bytes)
@@ -348,13 +341,10 @@ fn bun_random_uuid_v5(global: &JSGlobalObject, callframe: &CallFrame) -> JsResul
     let uuid = UUID5::init(&namespace, name.slice());
 
     if encoding == Encoding::Hex {
-        let (str, bytes) = BunString::create_uninitialized_latin1(36);
-        uuid.print(
-            (&mut bytes[0..36])
-                .try_into()
-                .expect("infallible: size matches"),
-        );
-        return str.into_js(global);
+        return bun_core::handle_oom(BunString::create_latin1_with(36, |buf| {
+            uuid.print(buf.try_into().unwrap())
+        }))
+        .into_js(global);
     }
 
     encoding.encode_with_max_size(global, 32, &uuid.bytes)

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -746,14 +746,14 @@ impl Request {
         fetch_redirect_to_js(self.flags.redirect, global_this)
     }
 
-    pub(crate) fn get_referrer(&self, global_object: &JSGlobalObject) -> JSValue {
+    pub(crate) fn get_referrer(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
         if let Some(headers_ref) = self.headers_mut().as_mut() {
             if let Some(referrer) = headers_ref.get(b"referrer", global_object) {
                 return referrer.to_js(global_object);
             }
         }
 
-        JSValue::js_empty_string(global_object)
+        Ok(JSValue::js_empty_string(global_object))
     }
 
     pub(crate) fn get_referrer_policy(_this: &Self, global_this: &JSGlobalObject) -> JSValue {
@@ -912,15 +912,10 @@ impl Request {
                     }
 
                     if strings::is_all_ascii(host) && strings::is_all_ascii(&req_url) {
-                        let (new_url, bytes) =
-                            BunString::create_uninitialized_latin1(url_bytelength);
-                        self.url.set(new_url);
-                        // exact space was counted above
-                        let (a, rest) = bytes.split_at_mut(protocol.len());
-                        let (b, c) = rest.split_at_mut(host.len());
-                        a.copy_from_slice(protocol);
-                        b.copy_from_slice(host);
-                        c.copy_from_slice(&req_url);
+                        self.url
+                            .set(BunString::create_latin1_with(url_bytelength, |buf| {
+                                bun_core::concat_into(buf, &[protocol, host, &req_url]);
+                            })?);
                     } else {
                         // slow path
                         let mut temp_url: Vec<u8> = Vec::with_capacity(url_bytelength);

--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -96,7 +96,7 @@ impl TextDecoder {
     }
 
     #[bun_jsc::host_fn(getter)]
-    pub(crate) fn get_encoding(&self, global_this: &JSGlobalObject) -> JSValue {
+    pub(crate) fn get_encoding(&self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         EncodedSlice::latin1(EncodingLabel::get_label(self.encoding)).to_js(global_this)
     }
 
@@ -343,7 +343,7 @@ impl TextDecoder {
         match self.encoding {
             EncodingLabel::LATIN1 => {
                 if strings::is_all_ascii(buffer_slice) {
-                    return Ok(EncodedSlice::latin1(buffer_slice).to_js(global_this));
+                    return EncodedSlice::latin1(buffer_slice).to_js(global_this);
                 }
 
                 // It's unintuitive that we encode Latin1 as UTF16 even though the engine natively supports Latin1 strings...
@@ -446,7 +446,7 @@ impl TextDecoder {
                 // All-ASCII input needed no conversion. `EncodedSlice::latin1(..).to_js`
                 // copies, so `input` may borrow the caller's buffer or `joined_owned`.
                 // Experiment: using mimalloc directly is slightly slower
-                Ok(EncodedSlice::latin1(input).to_js(global_this))
+                EncodedSlice::latin1(input).to_js(global_this)
             }
 
             enc @ (EncodingLabel::Utf16Le | EncodingLabel::Utf16Be) => {

--- a/src/runtime/webcore/encoding.rs
+++ b/src/runtime/webcore/encoding.rs
@@ -266,13 +266,10 @@ pub(crate) fn to_bun_string_from_owned_slice(input: Vec<u8>, encoding: Encoding)
                 return create_external_globally_allocated_latin1(input);
             }
 
-            let (str, chars) = BunString::create_uninitialized_latin1(input.len());
-            // `input` dropped at end of scope (was: defer allocator.free(input))
-            if str.is_dead() {
-                return str;
-            }
-            strings::copy_latin1_into_ascii(chars, &input);
-            str
+            BunString::create_latin1_with(input.len(), |buf| {
+                strings::copy_latin1_into_ascii(buf, &input)
+            })
+            .unwrap_or(BunString::DEAD)
         }
         Encoding::Latin1 => create_external_globally_allocated_latin1(input),
         Encoding::Buffer | Encoding::Utf8 => {
@@ -308,23 +305,11 @@ pub(crate) fn to_bun_string_from_owned_slice(input: Vec<u8>, encoding: Encoding)
             create_external_globally_allocated_utf16(as_u16)
         }
 
-        Encoding::Hex => {
-            // input dropped at end of scope
-            let (str, chars) = BunString::create_uninitialized_latin1(input.len() * 2);
-
-            if str.is_dead() {
-                return str;
-            }
-
-            let wrote = strings::encode_bytes_to_hex(chars, &input);
-
-            // Return an empty string in this case, just like node.
-            if wrote < chars.len() {
-                return BunString::EMPTY;
-            }
-
-            str
-        }
+        Encoding::Hex => BunString::create_latin1_with(input.len() * 2, |buf| {
+            let wrote = strings::encode_bytes_to_hex(buf, &input);
+            debug_assert_eq!(wrote, buf.len());
+        })
+        .unwrap_or(BunString::DEAD),
 
         // The output is strictly larger than the input, so the owned
         // allocation cannot be reused; drop it at end of scope.
@@ -350,21 +335,13 @@ fn to_bun_string_comptime<const ENCODING: u8>(input: &[u8]) -> BunString {
     }
 
     match encoding_from_u8(ENCODING) {
-        Encoding::Ascii => {
-            let (str, chars) = BunString::create_uninitialized_latin1(input.len());
-            if str.is_dead() {
-                return str;
-            }
-            strings::copy_latin1_into_ascii(chars, input);
-            str
-        }
+        Encoding::Ascii => BunString::create_latin1_with(input.len(), |buf| {
+            strings::copy_latin1_into_ascii(buf, input)
+        })
+        .unwrap_or(BunString::DEAD),
         Encoding::Latin1 => {
-            let (str, chars) = BunString::create_uninitialized_latin1(input.len());
-            if str.is_dead() {
-                return str;
-            }
-            chars.copy_from_slice(input);
-            str
+            BunString::create_latin1_with(input.len(), |buf| buf.copy_from_slice(input))
+                .unwrap_or(BunString::DEAD)
         }
         Encoding::Buffer | Encoding::Utf8 => {
             let converted = match strings::to_utf16_alloc(input, false, false) {
@@ -385,30 +362,18 @@ fn to_bun_string_comptime<const ENCODING: u8>(input: &[u8]) -> BunString {
                 return BunString::EMPTY;
             }
 
-            let chars_len = input.len() / 2;
-            let (str, chars) = BunString::create_uninitialized_utf16(chars_len);
-            if str.is_dead() {
-                return str;
-            }
-            // chars is a freshly-allocated [u16] buffer; reinterpret as bytes.
-            let output_bytes: &mut [u8] = bytemuck::cast_slice_mut(chars);
-            let out_len = output_bytes.len();
-            output_bytes[out_len - 1] = 0;
-
-            output_bytes.copy_from_slice(&input[..out_len]);
-            str
+            BunString::create_utf16_with(input.len() / 2, |buf| {
+                let buf: &mut [u8] = bytemuck::cast_slice_mut(buf);
+                buf.copy_from_slice(&input[..buf.len()]);
+            })
+            .unwrap_or(BunString::DEAD)
         }
 
-        Encoding::Hex => {
-            let (str, chars) = BunString::create_uninitialized_latin1(input.len() * 2);
-            if str.is_dead() {
-                return str;
-            }
-
-            let wrote = strings::encode_bytes_to_hex(chars, input);
-            debug_assert!(wrote == chars.len());
-            str
-        }
+        Encoding::Hex => BunString::create_latin1_with(input.len() * 2, |buf| {
+            let wrote = strings::encode_bytes_to_hex(buf, input);
+            debug_assert_eq!(wrote, buf.len());
+        })
+        .unwrap_or(BunString::DEAD),
 
         Encoding::Base64url => encode_base64_to_bun_string(input, true),
 
@@ -434,17 +399,15 @@ fn encode_base64_to_bun_string(input: &[u8], url_safe: bool) -> BunString {
     };
 
     if to_len < EXTERNAL_MIN_LEN {
-        let (str, chars) = BunString::create_uninitialized_latin1(to_len);
-        if str.is_dead() {
-            return str;
-        }
-        let wrote = if url_safe {
-            bun_base64::encode_url_safe(chars, input)
-        } else {
-            bun_base64::encode(chars, input)
-        };
-        debug_assert_eq!(wrote, to_len);
-        return str;
+        return BunString::create_latin1_with(to_len, |buf| {
+            let wrote = if url_safe {
+                bun_base64::encode_url_safe(buf, input)
+            } else {
+                bun_base64::encode(buf, input)
+            };
+            debug_assert_eq!(wrote, to_len);
+        })
+        .unwrap_or(BunString::DEAD);
     }
 
     let mut to: Vec<u8> = Vec::new();

--- a/src/runtime/webcore/prompt.rs
+++ b/src/runtime/webcore/prompt.rs
@@ -392,6 +392,6 @@ pub mod prompt {
         // *  Too complex for server context.
 
         // 9. Return result.
-        Ok(result.to_js(global))
+        result.to_js(global)
     }
 }

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -454,10 +454,7 @@ impl JSMySQLConnection {
         // no other live borrow in this scope.
         let vm = global_object.bun_vm().as_mut();
         let arguments = callframe.arguments();
-        let Some(args) = ConnectionCtorArgs::<SSLMode>::parse(global_object, &mut *vm, arguments)?
-        else {
-            return Ok(JSValue::ZERO);
-        };
+        let args = ConnectionCtorArgs::<SSLMode>::parse(global_object, &mut *vm, arguments)?;
         // Frees `secure` / drops `tls_config` on every early return until `into_inner` below.
         let tls_guard = connection_ctor_args::guard_tls(args.secure, args.tls_config);
 

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1071,10 +1071,7 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
     // `&mut self` helpers like `ssl_ctx_cache()` / `postgres_socket_group()`.
     let vm = global_object.bun_vm().as_mut();
     let arguments = callframe.arguments();
-    let Some(args) = ConnectionCtorArgs::<SSLMode>::parse(global_object, &mut *vm, arguments)?
-    else {
-        return Ok(JSValue::ZERO);
-    };
+    let args = ConnectionCtorArgs::<SSLMode>::parse(global_object, &mut *vm, arguments)?;
     // Covers `try arguments[7/8].toBunString()` and the null-byte rejection
     // below. Ownership passes into `ptr.*` once allocated — `into_inner`
     // recovers them just before the Box is built so the connect-fail path's

--- a/src/sql_jsc/postgres/types/date.rs
+++ b/src/sql_jsc/postgres/types/date.rs
@@ -84,7 +84,7 @@ pub(crate) fn from_js(global_object: &JSGlobalObject, value: JSValue) -> JsResul
     } else if value.is_number() {
         value.as_number()
     } else if value.is_string() {
-        let str = value.to_bun_string(global_object).expect("unreachable");
+        let str = value.to_bun_string(global_object)?;
         bun_string_jsc::parse_date(&str, global_object)?
     } else {
         return Ok(0);

--- a/src/sql_jsc/shared/ConnectionCtorArgs.rs
+++ b/src/sql_jsc/shared/ConnectionCtorArgs.rs
@@ -63,13 +63,12 @@ pub(crate) struct ConnectionCtorArgs<M> {
 }
 
 impl<M: SslModeArg> ConnectionCtorArgs<M> {
-    /// Parses `arguments[0..=6]`. Returns `Ok(None)` when a JS exception is
-    /// already pending and the caller should `return Ok(JSValue::ZERO)`.
+    /// Parses `arguments[0..=6]`.
     pub(crate) fn parse(
         global_object: &JSGlobalObject,
         vm: &mut VirtualMachine,
         arguments: &[JSValue],
-    ) -> JsResult<Option<Self>> {
+    ) -> JsResult<Self> {
         let hostname_str = arguments[0].to_bun_string(global_object)?;
         let port = arguments[1].coerce::<i32>(global_object)?;
         let username_str = arguments[2].to_bun_string(global_object)?;
@@ -89,18 +88,11 @@ impl<M: SslModeArg> ConnectionCtorArgs<M> {
             tls_config = if tls_object.is_boolean() && tls_object.to_boolean() {
                 SSLConfig::default()
             } else if tls_object.is_object() {
-                match SSLConfig::from_js(&mut *vm, global_object, tls_object) {
-                    Ok(opt) => opt.unwrap_or_default(),
-                    Err(_) => return Ok(None),
-                }
+                SSLConfig::from_js(&mut *vm, global_object, tls_object)?.unwrap_or_default()
             } else {
                 return Err(global_object
                     .throw_invalid_arguments(format_args!("tls must be a boolean or an object")));
             };
-
-            if global_object.has_exception() {
-                return Ok(None);
-            }
 
             // We always request the cert so we can verify it and manually
             // abort if the hostname doesn't match. Built here (not at STARTTLS
@@ -122,7 +114,7 @@ impl<M: SslModeArg> ConnectionCtorArgs<M> {
             }
         }
 
-        Ok(Some(Self {
+        Ok(Self {
             hostname_str,
             port,
             username_str,
@@ -131,6 +123,6 @@ impl<M: SslModeArg> ConnectionCtorArgs<M> {
             ssl_mode,
             tls_config,
             secure,
-        }))
+        })
     }
 }

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -947,3 +947,27 @@ it.each(["utf-16le", "utf-16be"])(
   },
   30_000,
 ); // 3072 decodes + repeated Bun.gc(true) take ~4s under ASAN.
+
+it("decode() throws when the result exceeds the string length limit", () => {
+  const { setSyntheticAllocationLimitForTesting } = require("bun:internal-for-testing");
+  const original = setSyntheticAllocationLimitForTesting(1024 * 1024);
+  const decode = (label, input) => {
+    try {
+      return new TextDecoder(label).decode(input).length;
+    } catch (e) {
+      return e.code;
+    }
+  };
+  try {
+    const ascii = new Uint8Array(2 * 1024 * 1024).fill(0x61);
+    expect(decode("utf-8", ascii)).toBe("ERR_STRING_TOO_LONG");
+    expect(decode("windows-1252", ascii)).toBe("ERR_STRING_TOO_LONG");
+    // 4 MiB of UTF-16LE / 2-byte UTF-8 sequences is 2 Mi code units.
+    expect(decode("utf-16le", new Uint8Array(4 * 1024 * 1024).fill(0x61))).toBe("ERR_STRING_TOO_LONG");
+    expect(decode("utf-8", Buffer.from("é".repeat(2 * 1024 * 1024)))).toBe("ERR_STRING_TOO_LONG");
+    // exactly at the limit is fine
+    expect(decode("utf-8", ascii.subarray(0, 1024 * 1024))).toBe(1024 * 1024);
+  } finally {
+    setSyntheticAllocationLimitForTesting(original);
+  }
+});

--- a/test/js/web/encoding/text-decoder.test.js
+++ b/test/js/web/encoding/text-decoder.test.js
@@ -964,7 +964,7 @@ it("decode() throws when the result exceeds the string length limit", () => {
     expect(decode("windows-1252", ascii)).toBe("ERR_STRING_TOO_LONG");
     // 4 MiB of UTF-16LE / 2-byte UTF-8 sequences is 2 Mi code units.
     expect(decode("utf-16le", new Uint8Array(4 * 1024 * 1024).fill(0x61))).toBe("ERR_STRING_TOO_LONG");
-    expect(decode("utf-8", Buffer.from("é".repeat(2 * 1024 * 1024)))).toBe("ERR_STRING_TOO_LONG");
+    expect(decode("utf-8", Buffer.alloc(4 * 1024 * 1024, "é"))).toBe("ERR_STRING_TOO_LONG");
     // exactly at the limit is fine
     expect(decode("utf-8", ascii.subarray(0, 1024 * 1024))).toBe(1024 * 1024);
   } finally {


### PR DESCRIPTION
### What does this PR do?

Three ways a failed string creation was mishandled:

**Panics.** `String::create_uninitialized_{latin1,utf16}(len)` returned `(DEAD, &mut [])` when WTF couldn't allocate (or `len` exceeded the maximum string length), and handed out the buffer as `&'static mut` (the SAFETY comment noted the lifetime was really the string's). Ten callers indexed/copied into the slice without checking — `napi_create_string_latin1/utf16`, `crypto.randomUUID`/`randomUUIDv7`/`v5`, `SocketAddress`, `Request#url`, TOML/JSON → JS — and would panic the process. Replaced by `String::create_{latin1,utf16}_with(len, |buf| …) -> Result<String, AllocError>` (+ `try_*_with` for fallible fills): the buffer lives for the call, and the error must be handled. User-sized inputs throw; the 36-byte UUID uses `handle_oom`; napi returns `napi_generic_failure`, and `napi_pending_exception` when the subsequent JS conversion throws (matching the other creators). Same single allocation and in-place writes as before.

**Silently empty.** `EncodedSlice::…(bytes).to_js(global)` was infallible; when the bytes exceeded the limit `EncodedSlice__toValueGC` produced `""`. It now throws `ERR_STRING_TOO_LONG` and `to_js` returns `JsResult` (call sites take `?`; the error-object builders that set string properties — BoringSSL, `Bun.password`, brotli, HTMLRewriter — return `JsResult` so a failed property is never left pending beside a returned value). `Zig::toStringCopy`'s Latin-1 and UTF-16 arms honour the synthetic allocation limit like the UTF-8 arm already did; observable with `setSyntheticAllocationLimitForTesting`: `TextDecoder.decode` over the limit used to return the full string (8-bit) or `""` (16-bit) and now throws.

**Pretending to throw.** `BunString__toErrorInstance` returned an empty value when the message couldn't be materialized; Rust's `throw()`/`throw_todo`/`throw_sys_error` then returned "thrown" with nothing pending (debug builds asserted — reachable from `expect().toThrow()` on a huge message under the synthetic limit). It now returns an `ERR_STRING_TOO_LONG` error in that case and the empty-check branches are gone. The SQL connection-options parser propagated errors as `Ok(None)` → `Ok(JSValue::ZERO)`; it returns `JsResult` now, and `postgres` date binding uses `?` instead of `expect`.

### How did you verify your code works?

New `text-decoder.test.js` case (fails on 1.4: returns the string / `""`; passes here: `ERR_STRING_TOO_LONG`). Debug+ASAN build driven through UUIDs, `Request#url`, TOML, `SocketAddress`, `Bun.password`, TLS/crypto error objects, brotli errors, HTMLRewriter errors, `onExit` signal codes, napi string tests; text-decoder, blob-oom, FormData, password, node crypto, web-crypto, zlib, html-rewriter, socket, tls-context, spawn-signal, terminal, sql, serve suites pass.