### PR TITLE
docs: remove duplicate bun init command in quickstart

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -22,9 +22,6 @@ Build a minimal HTTP server with `Bun.serve`, run it locally, then evolve it by 
 
     `bun init` prompts you to pick a template: `Blank`, `React`, or `Library`. For this guide, pick `Blank`.
 
-    ```bash terminal icon="terminal"
-    bun init my-app
-    ```
     ```txt
     ✓ Select a project template: Blank
 


### PR DESCRIPTION
Quickstart Step 1 showed un init my-app twice in succession. Deduplicate to single command before template prompt.