### PR TITLE
test: pull five batch-flaky files out of the parallel batch

### DIFF
--- a/test/parallel-allowlist.json
+++ b/test/parallel-allowlist.json
@@ -9,7 +9,7 @@
     "stats": {
       "dirs": 250,
       "files": 1513,
-      "excluded": 361
+      "excluded": 366
     }
   },
   "dirs": [
@@ -302,9 +302,11 @@
     "cli/env/bun-options.test.ts",
     "cli/hot/hot.test.ts",
     "cli/hot/watch-many-dirs.test.ts",
+    "cli/inspect/bun-inspector-protocol.test.ts",
     "cli/inspect/BunFrontendDevServer.test.ts",
     "cli/inspect/inspect.test.ts",
     "cli/install/migration/complex-workspace.test.ts",
+    "cli/install/migration/migrate.test.ts",
     "cli/install/migration/pnpm-lock-v9.test.ts",
     "cli/install/migration/pnpm-migration.test.ts",
     "cli/run/as-node.test.ts",
@@ -383,6 +385,7 @@
     "js/bun/net/socket-retention.test.ts",
     "js/bun/net/socket.test.ts",
     "js/bun/plugin/plugins.test.ts",
+    "js/bun/resolve/bun-main-entry-point.test.ts",
     "js/bun/resolve/import-custom-condition.test.ts",
     "js/bun/resolve/resolve-ts.test.ts",
     "js/bun/resolve/resolve.test.ts",
@@ -483,6 +486,7 @@
     "js/node/tls/node-tls-getpeercert-leak.test.ts",
     "js/node/tls/node-tls-namedpipes.test.ts",
     "js/node/tls/node-tls-server.test.ts",
+    "js/node/tls/renegotiation.test.ts",
     "js/node/util/bun-inspect.test.ts",
     "js/node/util/mime-api.test.ts",
     "js/node/util/util.test.js",
@@ -501,6 +505,7 @@
     "js/sql/postgres-pgsslmode-env.test.ts",
     "js/sql/postgres-prepared-pipeline-reorder.test.ts",
     "js/sql/postgres-simple-query-pipeline.test.ts",
+    "js/sql/postgres-tls-ctx-leak.test.ts",
     "js/sql/sql-mariadb-json.test.ts",
     "js/sql/sql-mysql-auth-short-nonce.test.ts",
     "js/sql/sql-mysql-bigint-out-of-range.test.ts",

--- a/test/parallel-denylist.txt
+++ b/test/parallel-denylist.txt
@@ -14,7 +14,9 @@ bundler/transpiler/transpiler-stack-overflow.test.ts
 bundler/transpiler/transpiler.test.js
 cli/env/bun-options.test.ts
 cli/hot/watch-many-dirs.test.ts
+cli/inspect/bun-inspector-protocol.test.ts
 cli/install/migration/complex-workspace.test.ts
+cli/install/migration/migrate.test.ts
 cli/run/as-node.test.ts
 cli/run/env.test.ts
 cli/run/if-present.test.ts
@@ -60,6 +62,7 @@ js/bun/jsc/string-noAtomize.test.ts
 js/bun/md/md-edge-cases.test.ts
 js/bun/net/socket-retention.test.ts
 js/bun/plugin/plugins.test.ts
+js/bun/resolve/bun-main-entry-point.test.ts
 js/bun/resolve/import-custom-condition.test.ts
 js/bun/resolve/resolve-ts.test.ts
 js/bun/resolve/resolve.test.ts
@@ -138,12 +141,14 @@ js/node/tls/fetch-tls-cert.test.ts
 js/node/tls/node-tls-cert.test.ts
 js/node/tls/node-tls-context.test.ts
 js/node/tls/node-tls-namedpipes.test.ts
+js/node/tls/renegotiation.test.ts
 js/node/tty.test.ts
 js/node/util/bun-inspect.test.ts
 js/node/util/mime-api.test.ts
 js/node/util/util.test.js
 js/node/vm/sourcetextmodule-leak.test.ts
 js/sql/postgres-pgsslmode-env.test.ts
+js/sql/postgres-tls-ctx-leak.test.ts
 js/third_party/@azure/service-bus/azure-service-bus.test.ts
 js/third_party/astro/astro-post.test.js
 js/third_party/comlink/comlink.test.ts


### PR DESCRIPTION
### What does this PR do?

Five test files have been failing inside the shard's parallel batch and then passing when the runner reruns them alone (the "in the parallel batch … passed alone" flaky annotation). This takes them out of the batch so they always run on their own:

- `cli/inspect/bun-inspector-protocol.test.ts`
- `cli/install/migration/migrate.test.ts`
- `js/bun/resolve/bun-main-entry-point.test.ts`
- `js/node/tls/renegotiation.test.ts`
- `js/sql/postgres-tls-ctx-leak.test.ts`

They're added to `test/parallel-denylist.txt` (so `scripts/update-parallel-allowlist.mjs` never re-qualifies them) and to `excludeFiles` in `test/parallel-allowlist.json` (what `scripts/runner.node.mjs` reads).

### How did you verify your code works?

Confirmed each file was previously allowlisted (its dir in `dirs`, not in `excludeFiles`) and is now excluded. CI on this PR will show whether the batch annotations for these files stop.
