### PR TITLE
install: resolve .npmrc credentials for tarballs; scope --registry inheritance to the path

### DIFF
--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -712,6 +712,15 @@ impl NetworkTask {
         Ok(())
     }
 
+    /// Moves the fully written header block into `self.header_buf` and returns the
+    /// view of it that the HTTP thread reads.
+    fn store_header_buf(&mut self, header_builder: &mut HeaderBuilder) -> &'static [u8] {
+        debug_assert_eq!(header_builder.content.len, header_builder.content.cap);
+        self.header_buf = header_builder.content.move_to_slice();
+        // SAFETY: `self.header_buf` outlives the request; it is freed when the slot returns to the pool.
+        unsafe { bun_ptr::detach_lifetime(&*self.header_buf) }
+    }
+
     pub(crate) fn get_completion_callback(&mut self) -> HTTPClientResultCallback {
         // `HTTPClientResultCallback::new`
         // performs type erasure over a `fn(*mut T, *mut AsyncHTTP, _)`.
@@ -819,59 +828,37 @@ impl NetworkTask {
             None => None,
         };
 
-        // Only attach the registry `Authorization` header when the tarball URL
-        // origin matches the configured registry scope origin. The npm manifest
-        // is registry-controlled, so a malicious registry could otherwise point
-        // the tarball at an attacker-controlled host and receive the scope
-        // credentials. The empty-`tarball_url` branch builds the URL from
-        // `scope.url.href()`, so its origin matches and authorized downloads
-        // keep working.
-        // Compare (protocol, hostname, effective port) rather than the raw
-        // `URL.origin` slice — `origin` is a borrowed prefix of the input
-        // string and is not normalized for default ports, so a tarball URL of
-        // `https://host:443/...` would not byte-match a `.npmrc` registry of
-        // `https://host/...` even though they are the same origin. Some
-        // registries emit `dist.tarball` URLs with the default port spelled
-        // out; without normalization those installs lose the `Authorization`
-        // header and fail with 401.
-        let send_auth = matches!(authorization, Authorization::AllowAuthorization) && {
-            let tarball = URL::parse(&self.url_buf);
-            let registry = scope.url.url();
-            tarball.protocol == registry.protocol
-                && tarball.hostname == registry.hostname
-                && tarball.get_port_auto() == registry.get_port_auto()
+        // The empty-`tarball_url` branch above built the URL from `scope.url`, so it
+        // is under the registry and gets the scope's credentials.
+        let credentials = match authorization {
+            Authorization::NoAuthorization => None,
+            Authorization::AllowAuthorization => pm
+                .options
+                .tarball_credentials(scope, &URL::parse(&self.url_buf)),
         };
 
         self.response_buffer = MutableString::init_empty();
 
         let mut header_builder = HeaderBuilder::default();
 
-        if send_auth {
-            count_auth(&mut header_builder, scope);
-        }
-
-        // Registry credentials win over URL userinfo, as in npm.
-        let url_authorization = match url_authorization {
-            Some(value) if header_builder.header_count == 0 => {
+        // Configured credentials win over the URL's userinfo, as in npm.
+        let header_buf: &'static [u8] = match (credentials, url_authorization) {
+            (Some(credentials), _) => {
+                count_auth(&mut header_builder, credentials);
+                header_builder.allocate()?;
+                append_auth(&mut header_builder, credentials);
+                self.store_header_buf(&mut header_builder)
+            }
+            (None, Some(value)) => {
                 header_builder.count("Authorization", &value);
-                Some(value)
+                header_builder.allocate()?;
+                header_builder.append("Authorization", &value);
+                self.store_header_buf(&mut header_builder)
             }
-            _ => None,
-        };
-
-        let header_buf: &'static [u8] = if header_builder.header_count > 0 {
-            header_builder.allocate()?;
-            match &url_authorization {
-                Some(value) => header_builder.append("Authorization", value),
-                None => append_auth(&mut header_builder, scope),
+            (None, None) => {
+                self.header_buf = Box::default();
+                b""
             }
-            debug_assert_eq!(header_builder.content.len, header_builder.content.cap);
-            self.header_buf = header_builder.content.move_to_slice();
-            // SAFETY: `self.header_buf` outlives the request; it is freed when the slot returns to the pool.
-            unsafe { bun_ptr::detach_lifetime(&*self.header_buf) }
-        } else {
-            self.header_buf = Box::default();
-            b""
         };
 
         // SAFETY: lifetime extension — `url_buf` is a heap allocation owned by

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -40,8 +40,10 @@ pub struct Options {
     pub scope: Npm::registry::Scope,
 
     pub(crate) registries: Npm::registry::Map,
-    /// Every `.npmrc` credential key, for the registries whose URL is only known
-    /// after the config files were read.
+    /// `.npmrc` `//host/path/` credential keys, matched against request URLs. Fills in
+    /// a registry configured without credentials of its own (`--registry`,
+    /// `$NPM_CONFIG_REGISTRY`) and authenticates tarballs served elsewhere than their
+    /// registry's origin.
     pub(crate) url_auth: Vec<Npm::registry::UrlAuth>,
     pub(crate) cache_directory: &'static [u8],
     pub enable: Enable,
@@ -280,6 +282,60 @@ impl Options {
             _ => &self.scope,
         }
     }
+
+    /// The credentials a tarball download may carry.
+    ///
+    /// The manifest that names the tarball URL comes from the registry, so a hostile
+    /// registry (or another tenant on a shared host) could point `dist.tarball` where
+    /// it likes; `scope`'s own credentials therefore only go to URLs at or under
+    /// `scope`'s registry URL. Any other URL gets exactly what `.npmrc` configures
+    /// for it by key, which covers registries that serve tarballs from another host
+    /// or path and lockfiles recorded against a registry that has since moved.
+    pub(crate) fn tarball_credentials<'a>(
+        &'a self,
+        scope: &'a Npm::registry::Scope,
+        tarball: &bun_url::URL,
+    ) -> Option<&'a Npm::registry::Scope> {
+        if scope.has_credentials() && url_under(tarball, &scope.url.url()) {
+            return Some(scope);
+        }
+        Npm::registry::UrlAuth::find(&self.url_auth, tarball)
+    }
+
+    /// Give every scope that ended up without credentials the ones `.npmrc`
+    /// configures for its registry URL. `--registry` and `$NPM_CONFIG_REGISTRY` are
+    /// applied after the `.npmrc` files were read, so only this pass can serve them.
+    fn fill_credentials_from_url_auth(&mut self) {
+        if self.url_auth.is_empty() {
+            return;
+        }
+        let url_auth = &self.url_auth;
+        for scope in core::iter::once(&mut self.scope).chain(self.registries.values_mut()) {
+            if scope.has_credentials() {
+                continue;
+            }
+            if let Some(credentials) = Npm::registry::UrlAuth::find(url_auth, &scope.url.url()) {
+                scope.copy_credentials_from(credentials);
+            }
+        }
+    }
+}
+
+/// `url` is at or under `base`: same scheme, host and effective port (some registries
+/// spell out `:443` in `dist.tarball`), and `base`'s path is a segment-wise prefix of
+/// `url`'s canonical path, so `/npm/team-ab/x` is not under `/npm/team-a/`.
+fn url_under(url: &bun_url::URL, base: &bun_url::URL) -> bool {
+    if base.hostname.is_empty()
+        || !url.protocol.eq_ignore_ascii_case(base.protocol)
+        || !url.hostname.eq_ignore_ascii_case(base.hostname)
+        || url.get_port_auto() != base.get_port_auto()
+        || !Npm::registry::path_is_canonical(url.pathname)
+    {
+        return false;
+    }
+    let mut segments = bun_core::strings::tokenize(url.pathname, b"/");
+    bun_core::strings::tokenize(base.pathname, b"/")
+        .all(|expected| segments.next() == Some(expected))
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -300,7 +300,11 @@ impl Options {
         scope: &'a Npm::registry::Scope,
         tarball: &bun_url::URL,
     ) -> Option<&'a Npm::registry::Scope> {
-        if !Npm::registry::path_is_canonical(tarball.pathname) {
+        // `dist.tarball` is registry-controlled, and `.npmrc` keys carry no scheme: a
+        // token written for an https registry must not go out in plaintext.
+        if !Npm::registry::path_is_canonical(tarball.pathname)
+            || (scope.url.url().is_https() && !tarball.is_https())
+        {
             return None;
         }
         let own = Npm::registry::UrlAuth::find_entry(&self.url_auth, tarball);

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -294,20 +294,25 @@ impl Options {
     /// bunfig, env or CLI credential, so `scope` wins; any other key is the tarball's
     /// own and wins as in npm.
     /// A path the server would resolve elsewhere (`..`, `%2e`, a backslash) gets
-    /// nothing.
+    /// nothing, and an `http://` tarball on another host never gets a key's credential.
     pub fn tarball_credentials<'a>(
         &'a self,
         scope: &'a Npm::registry::Scope,
         tarball: &bun_url::URL,
     ) -> Option<&'a Npm::registry::Scope> {
-        // `dist.tarball` is registry-controlled, and `.npmrc` keys carry no scheme: a
-        // token written for an https registry must not go out in plaintext.
-        if !Npm::registry::path_is_canonical(tarball.pathname)
-            || (scope.url.url().is_https() && !tarball.is_https())
-        {
+        if !Npm::registry::path_is_canonical(tarball.pathname) {
             return None;
         }
-        let own = Npm::registry::UrlAuth::find_entry(&self.url_auth, tarball);
+        // `dist.tarball` is registry-controlled and `.npmrc` keys carry no scheme, so a
+        // key's credential goes over plaintext only back to the registry's own origin,
+        // which already sees the registry's credentials that way; never to another host.
+        let plaintext_to_another_host =
+            !tarball.is_https() && !same_origin(tarball, &scope.url.url());
+        let own = if plaintext_to_another_host {
+            None
+        } else {
+            Npm::registry::UrlAuth::find_entry(&self.url_auth, tarball)
+        };
         if scope.has_credentials() && same_origin(tarball, &scope.url.url()) {
             let registry_own = Npm::registry::UrlAuth::find_entry(&self.url_auth, &scope.url.url());
             return match own {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -289,9 +289,10 @@ impl Options {
     /// port), whatever its path. That fallback serves GitLab's instance-level
     /// registry, whose tarballs live under a project path with no key of their own.
     ///
-    /// One refinement to npm's order: a key the registry URL itself resolves to is
-    /// already reflected in `scope`, behind any bunfig, env or CLI credential, so it
-    /// does not override `scope`; only a key specific to the tarball's path does.
+    /// One refinement to npm's order: when the tarball resolves to the same key the
+    /// registry URL resolved to, that key is already reflected in `scope`, behind any
+    /// bunfig, env or CLI credential, so `scope` wins; any other key is the tarball's
+    /// own and wins as in npm.
     /// A path the server would resolve elsewhere (`..`, `%2e`, a backslash) gets
     /// nothing.
     pub fn tarball_credentials<'a>(
@@ -304,8 +305,11 @@ impl Options {
         }
         let own = Npm::registry::UrlAuth::find_entry(&self.url_auth, tarball);
         if scope.has_credentials() && same_origin(tarball, &scope.url.url()) {
+            let registry_own = Npm::registry::UrlAuth::find_entry(&self.url_auth, &scope.url.url());
             return match own {
-                Some(entry) if !entry.applies_to(&scope.url.url()) => Some(entry.credentials()),
+                Some(entry) if !registry_own.is_some_and(|r| r.same_key(entry)) => {
+                    Some(entry.credentials())
+                }
                 _ => Some(scope),
             };
         }

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -283,20 +283,23 @@ impl Options {
         }
     }
 
-    /// The credentials a tarball download may carry.
-    ///
-    /// The manifest that names the tarball URL comes from the registry, so a hostile
-    /// registry (or another tenant on a shared host) could point `dist.tarball` where
-    /// it likes; `scope`'s own credentials therefore only go to URLs at or under
-    /// `scope`'s registry URL. Any other URL gets exactly what `.npmrc` configures
-    /// for it by key, which covers registries that serve tarballs from another host
-    /// or path and lockfiles recorded against a registry that has since moved.
-    pub(crate) fn tarball_credentials<'a>(
+    /// The credentials a tarball download carries. On the registry's own origin
+    /// (same scheme, host and effective port) the registry's credentials follow it,
+    /// whatever its path: that is what serves GitLab's instance-level registry, whose
+    /// tarballs live under a project path, and it keeps bunfig, env and CLI
+    /// credentials ahead of `.npmrc` the way they are for the manifest. Off that
+    /// origin, or when the registry has no credentials, the tarball gets what
+    /// `.npmrc` configures for its own URL by key. A path the server would resolve
+    /// elsewhere (`..`, `%2e`, a backslash) gets nothing.
+    pub fn tarball_credentials<'a>(
         &'a self,
         scope: &'a Npm::registry::Scope,
         tarball: &bun_url::URL,
     ) -> Option<&'a Npm::registry::Scope> {
-        if scope.has_credentials() && url_under(tarball, &scope.url.url()) {
+        if !Npm::registry::path_is_canonical(tarball.pathname) {
+            return None;
+        }
+        if scope.has_credentials() && same_origin(tarball, &scope.url.url()) {
             return Some(scope);
         }
         Npm::registry::UrlAuth::find(&self.url_auth, tarball)
@@ -321,19 +324,13 @@ impl Options {
     }
 }
 
-/// `url` is at or under `base`: same scheme, host and effective port (some registries
-/// spell out `:443` in `dist.tarball`), and `base`'s path is a segment-wise prefix of
-/// `url`'s canonical path, so `/npm/team-ab/x` is not under `/npm/team-a/`.
-fn url_under(url: &bun_url::URL, base: &bun_url::URL) -> bool {
-    if base.hostname.is_empty()
-        || !url.protocol.eq_ignore_ascii_case(base.protocol)
-        || !url.hostname.eq_ignore_ascii_case(base.hostname)
-        || url.get_port_auto() != base.get_port_auto()
-        || !Npm::registry::path_is_canonical(url.pathname)
-    {
-        return false;
-    }
-    path_under(url.pathname, base.pathname)
+/// Same scheme, host and effective port (some registries spell out `:443` in
+/// `dist.tarball`).
+fn same_origin(url: &bun_url::URL, base: &bun_url::URL) -> bool {
+    !base.hostname.is_empty()
+        && url.protocol.eq_ignore_ascii_case(base.protocol)
+        && url.hostname.eq_ignore_ascii_case(base.hostname)
+        && url.get_port_auto() == base.get_port_auto()
 }
 
 /// `url` names the registry `base` already holds credentials for, or one below it:
@@ -347,6 +344,8 @@ fn registry_under(url: &bun_url::URL, base: &bun_url::URL) -> bool {
         && path_under(url.pathname, base.pathname)
 }
 
+/// `base`'s path is a segment-wise prefix of `path`, so `/npm/team-ab/x` is not under
+/// `/npm/team-a/`.
 fn path_under(path: &[u8], base: &[u8]) -> bool {
     let mut segments = bun_core::strings::tokenize(path, b"/");
     bun_core::strings::tokenize(base, b"/").all(|expected| segments.next() == Some(expected))

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -293,16 +293,16 @@ impl Options {
     /// registry URL resolved to, that key is already reflected in `scope`, behind any
     /// bunfig, env or CLI credential, so `scope` wins; any other key is the tarball's
     /// own and wins as in npm.
-    /// A path the server would resolve elsewhere (`..`, `%2e`, a backslash) gets
-    /// nothing, and an `http://` tarball on another host never gets a key's credential.
+    /// A `.npmrc` line is only looked up for a path the server would resolve as
+    /// written (no `%2f`-split dot segment, no `%5c`); on the registry's own origin a
+    /// dot segment changes nothing about who receives the credential, so the
+    /// registry's credentials follow such a tarball as they do in npm. An `http://`
+    /// tarball on another host never gets a key's credential.
     pub fn tarball_credentials<'a>(
         &'a self,
         scope: &'a Npm::registry::Scope,
         tarball: &bun_url::URL,
     ) -> Option<&'a Npm::registry::Scope> {
-        if !Npm::registry::path_is_canonical(tarball.pathname) {
-            return None;
-        }
         // `dist.tarball` is registry-controlled and `.npmrc` keys carry no scheme, so a
         // key's credential goes over plaintext only back to the registry's own origin,
         // which already sees the registry's credentials that way; never to another host.
@@ -341,15 +341,17 @@ impl Options {
     }
 
     /// Give every scope that ended up without credentials the ones `.npmrc`
-    /// configures for its registry URL. `--registry` and `$NPM_CONFIG_REGISTRY` are
-    /// applied after the `.npmrc` files were read, so only this pass can serve them.
+    /// configures for its registry URL, by npm's key walk. A registry from
+    /// `bunfig.toml`, `--registry` or `$NPM_CONFIG_REGISTRY` is only known here, and
+    /// a credential from any of those sources outranks a `.npmrc` line; one written
+    /// into a `.npmrc` `registry=` URL does not.
     fn fill_credentials_from_url_auth(&mut self) {
         if self.url_auth.is_empty() {
             return;
         }
         let url_auth = &self.url_auth;
         for scope in core::iter::once(&mut self.scope).chain(self.registries.values_mut()) {
-            if scope.has_credentials() {
+            if scope.has_credentials() && !scope.credentials_from_url {
                 continue;
             }
             if let Some(credentials) = Npm::registry::UrlAuth::find(url_auth, &scope.url.url()) {
@@ -375,8 +377,8 @@ fn same_origin(url: &bun_url::URL, base: &bun_url::URL) -> bool {
 fn registry_under(url: &bun_url::URL, base: &bun_url::URL) -> bool {
     bun_core::without_trailing_slash(url.host) == bun_core::without_trailing_slash(base.host)
         && (url.is_https() || !base.is_https())
-        && Npm::registry::path_is_canonical(url.pathname)
-        && path_under(url.pathname, base.pathname)
+        && Npm::registry::path_is_canonical(url.path)
+        && path_under(url.path, base.path)
 }
 
 /// `base`'s path is a segment-wise prefix of `path`, so `/npm/team-ab/x` is not under
@@ -526,25 +528,6 @@ fn leak_static(s: &[u8]) -> &'static [u8] {
 }
 
 impl Options {
-    /// Give every scope that ended up without credentials the ones `.npmrc`
-    /// configures for its registry URL, by npm's key walk. A registry from
-    /// `bunfig.toml`, `--registry` or `$NPM_CONFIG_REGISTRY` is only known here, and
-    /// a credential from any of those sources outranks a `.npmrc` line.
-    fn fill_credentials_from_url_auth(&mut self) {
-        if self.url_auth.is_empty() {
-            return;
-        }
-        let url_auth = &self.url_auth;
-        for scope in core::iter::once(&mut self.scope).chain(self.registries.values_mut()) {
-            if scope.has_credentials() && !scope.credentials_from_url {
-                continue;
-            }
-            if let Some(credentials) = Npm::registry::UrlAuth::find(url_auth, &scope.url.url()) {
-                scope.copy_credentials_from(credentials);
-            }
-        }
-    }
-
     pub(crate) fn load(
         &mut self,
         log: &mut bun_ast::Log,
@@ -1246,11 +1229,4 @@ impl Enable {
     pub(crate) fn global_virtual_store(self) -> bool {
         self.contains(Enable::GLOBAL_VIRTUAL_STORE)
     }
-}
-
-/// `new` is on `base`'s host and does not downgrade https to http, so `base`'s
-/// credentials may follow it: the shape `npm_config_registry` and `--registry` share.
-fn same_host_not_downgraded(new: &bun_url::URL, base: &bun_url::URL) -> bool {
-    bun_core::without_trailing_slash(new.host) == bun_core::without_trailing_slash(base.host)
-        && (new.is_https() || !base.is_https())
 }

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -283,14 +283,17 @@ impl Options {
         }
     }
 
-    /// The credentials a tarball download carries. On the registry's own origin
-    /// (same scheme, host and effective port) the registry's credentials follow it,
-    /// whatever its path: that is what serves GitLab's instance-level registry, whose
-    /// tarballs live under a project path, and it keeps bunfig, env and CLI
-    /// credentials ahead of `.npmrc` the way they are for the manifest. Off that
-    /// origin, or when the registry has no credentials, the tarball gets what
-    /// `.npmrc` configures for its own URL by key. A path the server would resolve
-    /// elsewhere (`..`, `%2e`, a backslash) gets nothing.
+    /// The credentials a tarball download carries, in npm's order: the deepest
+    /// `.npmrc` key on the tarball URL's own walk, else the registry's credentials
+    /// when the tarball is on the registry's origin (same scheme, host and effective
+    /// port), whatever its path. That fallback serves GitLab's instance-level
+    /// registry, whose tarballs live under a project path with no key of their own.
+    ///
+    /// One refinement to npm's order: a key the registry URL itself resolves to is
+    /// already reflected in `scope`, behind any bunfig, env or CLI credential, so it
+    /// does not override `scope`; only a key specific to the tarball's path does.
+    /// A path the server would resolve elsewhere (`..`, `%2e`, a backslash) gets
+    /// nothing.
     pub fn tarball_credentials<'a>(
         &'a self,
         scope: &'a Npm::registry::Scope,
@@ -299,10 +302,14 @@ impl Options {
         if !Npm::registry::path_is_canonical(tarball.pathname) {
             return None;
         }
+        let own = Npm::registry::UrlAuth::find_entry(&self.url_auth, tarball);
         if scope.has_credentials() && same_origin(tarball, &scope.url.url()) {
-            return Some(scope);
+            return match own {
+                Some(entry) if !entry.applies_to(&scope.url.url()) => Some(entry.credentials()),
+                _ => Some(scope),
+            };
         }
-        Npm::registry::UrlAuth::find(&self.url_auth, tarball)
+        own.map(|entry| entry.credentials())
     }
 
     /// Give every scope that ended up without credentials the ones `.npmrc`

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -325,6 +325,21 @@ impl Options {
         own.map(|entry| entry.credentials())
     }
 
+    /// A `--registry` or env registry at or under the current default registry keeps
+    /// the default's credentials, unless `.npmrc` has a line specific to the new
+    /// path: then the key walk supplies that line instead, as npm would resolve it.
+    fn inherits_default_credentials(&self, new_url: &bun_url::URL) -> bool {
+        let old_url = self.scope.url.url();
+        if !registry_under(new_url, &old_url) {
+            return false;
+        }
+        match Npm::registry::UrlAuth::find_entry(&self.url_auth, new_url) {
+            Some(own) => Npm::registry::UrlAuth::find_entry(&self.url_auth, &old_url)
+                .is_some_and(|old| old.same_key(own)),
+            None => true,
+        }
+    }
+
     /// Give every scope that ended up without credentials the ones `.npmrc`
     /// configures for its registry URL. `--registry` and `$NPM_CONFIG_REGISTRY` are
     /// applied after the `.npmrc` files were read, so only this pass can serve them.
@@ -751,7 +766,7 @@ impl Options {
                         // Credentials in the URL win, as they do for `registry=` in .npmrc.
                         if !api_registry.has_credentials() {
                             let new_url = bun_url::URL::parse(&api_registry.url);
-                            if registry_under(&new_url, &self.scope.url.url()) {
+                            if self.inherits_default_credentials(&new_url) {
                                 api_registry.token = core::mem::take(&mut self.scope.token);
                                 api_registry.auth = core::mem::take(&mut self.scope.auth);
                                 api_registry.credentials_from_url = self.scope.credentials_from_url;
@@ -770,7 +785,7 @@ impl Options {
                 // Credentials in the URL win, as they do for `registry=` in .npmrc.
                 if !api_registry.has_credentials() {
                     let new_url = bun_url::URL::parse(&api_registry.url);
-                    if registry_under(&new_url, &self.scope.url.url()) {
+                    if self.inherits_default_credentials(&new_url) {
                         api_registry.token = core::mem::take(&mut self.scope.token);
                         api_registry.auth = core::mem::take(&mut self.scope.auth);
                         api_registry.credentials_from_url = self.scope.credentials_from_url;

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -333,9 +333,23 @@ fn url_under(url: &bun_url::URL, base: &bun_url::URL) -> bool {
     {
         return false;
     }
-    let mut segments = bun_core::strings::tokenize(url.pathname, b"/");
-    bun_core::strings::tokenize(base.pathname, b"/")
-        .all(|expected| segments.next() == Some(expected))
+    path_under(url.pathname, base.pathname)
+}
+
+/// `url` names the registry `base` already holds credentials for, or one below it:
+/// same host and port text, no https-to-http downgrade, and `base`'s path is a
+/// segment-wise prefix of `url`'s. A registry on a sibling path of the same host
+/// inherits nothing; its own `.npmrc` line applies through the key walk instead.
+fn registry_under(url: &bun_url::URL, base: &bun_url::URL) -> bool {
+    bun_core::without_trailing_slash(url.host) == bun_core::without_trailing_slash(base.host)
+        && (url.is_https() || !base.is_https())
+        && Npm::registry::path_is_canonical(url.pathname)
+        && path_under(url.pathname, base.pathname)
+}
+
+fn path_under(path: &[u8], base: &[u8]) -> bool {
+    let mut segments = bun_core::strings::tokenize(path, b"/");
+    bun_core::strings::tokenize(base, b"/").all(|expected| segments.next() == Some(expected))
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Default, Debug)]
@@ -718,7 +732,7 @@ impl Options {
                         // Credentials in the URL win, as they do for `registry=` in .npmrc.
                         if !api_registry.has_credentials() {
                             let new_url = bun_url::URL::parse(&api_registry.url);
-                            if same_host_not_downgraded(&new_url, &self.scope.url.url()) {
+                            if registry_under(&new_url, &self.scope.url.url()) {
                                 api_registry.token = core::mem::take(&mut self.scope.token);
                                 api_registry.auth = core::mem::take(&mut self.scope.auth);
                                 api_registry.credentials_from_url = self.scope.credentials_from_url;
@@ -737,7 +751,7 @@ impl Options {
                 // Credentials in the URL win, as they do for `registry=` in .npmrc.
                 if !api_registry.has_credentials() {
                     let new_url = bun_url::URL::parse(&api_registry.url);
-                    if same_host_not_downgraded(&new_url, &self.scope.url.url()) {
+                    if registry_under(&new_url, &self.scope.url.url()) {
                         api_registry.token = core::mem::take(&mut self.scope.token);
                         api_registry.auth = core::mem::take(&mut self.scope.auth);
                         api_registry.credentials_from_url = self.scope.credentials_from_url;

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -377,8 +377,11 @@ fn same_origin(url: &bun_url::URL, base: &bun_url::URL) -> bool {
 fn registry_under(url: &bun_url::URL, base: &bun_url::URL) -> bool {
     bun_core::without_trailing_slash(url.host) == bun_core::without_trailing_slash(base.host)
         && (url.is_https() || !base.is_https())
-        && Npm::registry::path_is_canonical(url.path)
-        && path_under(url.path, base.path)
+        && Npm::registry::path_is_canonical(Npm::registry::query_free_path(url))
+        && path_under(
+            Npm::registry::query_free_path(url),
+            Npm::registry::query_free_path(base),
+        )
 }
 
 /// `base`'s path is a segment-wise prefix of `path`, so `/npm/team-ab/x` is not under

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -686,13 +686,15 @@ pub mod registry {
         &pathname[..strings::index_of_char_usize(pathname, b'?').unwrap_or(pathname.len())]
     }
 
-    /// A path only the server can resolve: a `%5c`, or a `%2f` that splits a segment
-    /// into pieces one of which is a dot segment. Plain dot segments (and their `%2e`
-    /// spellings) are resolved by the WHATWG serialisation the key is built from, so
-    /// they are fine here; a plain `%2f` inside a name, the `@scope%2fpkg` form
-    /// manifests are requested with, is fine too.
+    /// A path the request sends as written but the key would resolve differently: a
+    /// backslash (the WHATWG serialisation reads it as `/`; the wire request keeps it),
+    /// a `%5c`, or a `%2f` that splits a segment into pieces one of which is a dot
+    /// segment. Plain dot segments (and their `%2e` spellings) are resolved the same
+    /// way on both sides, so they are fine here; a plain `%2f` inside a name, the
+    /// `@scope%2fpkg` form manifests are requested with, is fine too.
     pub(crate) fn is_opaque_path(path: &[u8]) -> bool {
-        contains_percent_encoded(path, b'5', b'c')
+        strings::contains_char(path, b'\\')
+            || contains_percent_encoded(path, b'5', b'c')
             || strings::split(path, b"/").any(|segment| {
                 contains_percent_encoded(segment, b'2', b'f') && is_unsafe_segment(segment)
             })

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -668,6 +668,63 @@ pub mod registry {
         }
     }
 
+    /// No `.`/`..` segment (plain or `%2e`-spelled), no backslash (plain or `%5c`),
+    /// and no `%2f` that splits a segment into pieces containing a dot segment. A
+    /// plain `%2f` inside a name, the `@scope%2fpkg` form manifests are requested
+    /// with, is fine.
+    pub(crate) fn path_is_canonical(path: &[u8]) -> bool {
+        if strings::contains_char(path, b'\\') || contains_percent_encoded(path, b'5', b'c') {
+            return false;
+        }
+        strings::split(path, b"/").all(|segment| !is_unsafe_segment(segment))
+    }
+
+    /// `%Xy` anywhere in `bytes`, the hex digit `y` matched case-insensitively.
+    fn contains_percent_encoded(bytes: &[u8], x: u8, y_lower: u8) -> bool {
+        let mut rest = bytes;
+        while let Some(i) = strings::index_of_char_usize(rest, b'%') {
+            rest = &rest[i + 1..];
+            if rest.len() >= 2 && rest[0] == x && rest[1].eq_ignore_ascii_case(&y_lower) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// A dot segment, or a segment that an encoded `/` (`%2f`) splits into pieces
+    /// one of which is a dot segment.
+    fn is_unsafe_segment(segment: &[u8]) -> bool {
+        if !contains_percent_encoded(segment, b'2', b'f') {
+            return is_dot_segment(segment);
+        }
+        let mut start = 0;
+        let mut i = 0;
+        while i + 2 < segment.len() {
+            if segment[i] == b'%'
+                && segment[i + 1] == b'2'
+                && segment[i + 2].eq_ignore_ascii_case(&b'f')
+            {
+                if is_dot_segment(&segment[start..i]) {
+                    return true;
+                }
+                i += 3;
+                start = i;
+            } else {
+                i += 1;
+            }
+        }
+        is_dot_segment(&segment[start..])
+    }
+
+    /// WHATWG single-dot and double-dot path segments, including the percent-encoded
+    /// spellings a server would normalize.
+    fn is_dot_segment(segment: &[u8]) -> bool {
+        const DOT_SEGMENTS: [&[u8]; 6] = [b".", b"..", b"%2e", b"%2e.", b".%2e", b"%2e%2e"];
+        DOT_SEGMENTS
+            .iter()
+            .any(|dot| segment.eq_ignore_ascii_case(dot))
+    }
+
     pub(crate) enum PackageVersionResponse {
         Cached(PackageManifest),
         Fresh(PackageManifest),

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -658,13 +658,27 @@ pub mod registry {
         /// The credentials `.npmrc` configures for `url`: the first key on npm's walk
         /// from `url` that has an entry, so `//host/a/b/` beats `//host/`.
         pub(crate) fn find<'a>(list: &'a [UrlAuth], url: &URL) -> Option<&'a Scope> {
-            if list.is_empty() {
+            UrlAuth::find_entry(list, url).map(|entry| &entry.credentials)
+        }
+
+        pub(crate) fn find_entry<'a>(list: &'a [UrlAuth], url: &URL) -> Option<&'a UrlAuth> {
+            if list.is_empty() || !path_is_canonical(url.path) {
                 return None;
             }
             bun_ini::RegistryKey::from_url(url.href)
                 .walk()
                 .find_map(|key| list.iter().find(|entry| *entry.key == *key))
-                .map(|entry| &entry.credentials)
+        }
+
+        pub(crate) fn credentials(&self) -> &Scope {
+            &self.credentials
+        }
+
+        /// Whether this key is on `url`'s own walk, so `url` itself resolves to it.
+        pub(crate) fn applies_to(&self, url: &URL) -> bool {
+            bun_ini::RegistryKey::from_url(url.href)
+                .walk()
+                .any(|key| *self.key == *key)
         }
     }
 

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -665,6 +665,17 @@ pub mod registry {
             if list.is_empty() || is_opaque_path(query_free_path(url)) {
                 return None;
             }
+            // The key comes from the WHATWG serialisation while the request goes to
+            // the authority the fast parser read; a URL the two read differently
+            // (`https://a#@b/x.tgz`) gets nothing.
+            if let Ok(whatwg) = URL::from_string(&bun_core::String::borrow_utf8(url.href)) {
+                let whatwg = whatwg.url();
+                if !whatwg.hostname.eq_ignore_ascii_case(url.hostname)
+                    || whatwg.get_port_auto() != url.get_port_auto()
+                {
+                    return None;
+                }
+            }
             bun_ini::RegistryKey::from_url(url.href)
                 .walk()
                 .find_map(|key| list.iter().find(|entry| *entry.key == *key))

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -662,7 +662,7 @@ pub mod registry {
         }
 
         pub(crate) fn find_entry<'a>(list: &'a [UrlAuth], url: &URL) -> Option<&'a UrlAuth> {
-            if list.is_empty() || !path_is_canonical(url.path) {
+            if list.is_empty() || is_opaque_path(query_free_path(url)) {
                 return None;
             }
             bun_ini::RegistryKey::from_url(url.href)
@@ -679,10 +679,27 @@ pub mod registry {
         }
     }
 
-    /// No `.`/`..` segment (plain or `%2e`-spelled), no backslash (plain or `%5c`),
-    /// and no `%2f` that splits a segment into pieces containing a dot segment. A
-    /// plain `%2f` inside a name, the `@scope%2fpkg` form manifests are requested
-    /// with, is fine.
+    /// `url.pathname` without its query: `url.path` is query-free too, but collapses a
+    /// one-byte path such as `/r/` to `/`.
+    pub(crate) fn query_free_path<'a>(url: &URL<'a>) -> &'a [u8] {
+        let pathname = url.pathname;
+        &pathname[..strings::index_of_char_usize(pathname, b'?').unwrap_or(pathname.len())]
+    }
+
+    /// A path only the server can resolve: a `%5c`, or a `%2f` that splits a segment
+    /// into pieces one of which is a dot segment. Plain dot segments (and their `%2e`
+    /// spellings) are resolved by the WHATWG serialisation the key is built from, so
+    /// they are fine here; a plain `%2f` inside a name, the `@scope%2fpkg` form
+    /// manifests are requested with, is fine too.
+    pub(crate) fn is_opaque_path(path: &[u8]) -> bool {
+        contains_percent_encoded(path, b'5', b'c')
+            || strings::split(path, b"/").any(|segment| {
+                contains_percent_encoded(segment, b'2', b'f') && is_unsafe_segment(segment)
+            })
+    }
+
+    /// `is_opaque_path`, plus no dot segment at all (plain, `%2e`-spelled, or a
+    /// backslash): for a path compared before any normalisation.
     pub(crate) fn path_is_canonical(path: &[u8]) -> bool {
         if strings::contains_char(path, b'\\') || contains_percent_encoded(path, b'5', b'c') {
             return false;

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -674,11 +674,8 @@ pub mod registry {
             &self.credentials
         }
 
-        /// Whether this key is on `url`'s own walk, so `url` itself resolves to it.
-        pub(crate) fn applies_to(&self, url: &URL) -> bool {
-            bun_ini::RegistryKey::from_url(url.href)
-                .walk()
-                .any(|key| *self.key == *key)
+        pub(crate) fn same_key(&self, other: &UrlAuth) -> bool {
+            self.key == other.key
         }
     }
 

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -859,17 +859,11 @@ fn registry_get(
 ) -> Result<MutableString, crate::Error> {
     let mut headers = http::HeaderBuilder::default();
     headers.count(b"Accept", accept);
-    // `dist.tarball` is registry-controlled; credentials only go back to the registry's own origin.
-    let same_origin = {
-        let registry = scope.url.url();
-        url.protocol == registry.protocol
-            && url.hostname == registry.hostname
-            && url.get_port_auto() == registry.get_port_auto()
-    };
-    let authorization = if same_origin {
-        scope.authorization_parts()
-    } else {
-        None
+    // `dist.tarball` is registry-controlled; the same rule as `bun install` decides
+    // which credentials, if any, follow it.
+    let authorization = match pm.options.tarball_credentials(scope, &url) {
+        Some(credentials) => credentials.authorization_parts(),
+        None => None,
     };
     if let Some((scheme, value)) = authorization {
         headers.count(b"Authorization", b"");

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1437,6 +1437,10 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     publicManifest?: boolean;
     /** Serve over https with the harness certificate (`install` passes it as `--ca`). */
     secure?: boolean;
+    /** The package the manifest describes (default `no-deps`); a scoped name is served at `@scope%2fname`. */
+    packageName?: string;
+    /** A query string appended to the advertised `dist.tarball` URL. */
+    tarballQuery?: string;
   };
 
   // Serves no-deps@1.0.0 and answers 401 to any request that does not carry
@@ -1448,6 +1452,8 @@ describe.concurrent("//host/ credential lines are matched against the request UR
       tarballPath = "/no-deps/-/no-deps-1.0.0.tgz",
       publicManifest,
       secure,
+      packageName = "no-deps",
+      tarballQuery = "",
     } = options;
     const requests: Req[] = [];
     const server = Bun.serve({
@@ -1458,7 +1464,7 @@ describe.concurrent("//host/ credential lines are matched against the request UR
         const url = new URL(req.url);
         const auth = req.headers.get("authorization");
         requests.push({ path: url.pathname, auth });
-        const isManifest = url.pathname === `${registryPath}/no-deps`;
+        const isManifest = url.pathname === `${registryPath}/${packageName.replace("/", "%2f")}`;
         if (auth !== expectedAuth && !(isManifest && publicManifest)) {
           return new Response("unauthorized", { status: 401 });
         }
@@ -1466,13 +1472,13 @@ describe.concurrent("//host/ credential lines are matched against the request UR
         if (isManifest) {
           const origin = tarballOrigin ? tarballOrigin() : `${secure ? "https" : "http"}://127.0.0.1:${server.port}`;
           return Response.json({
-            name: "no-deps",
+            name: packageName,
             "dist-tags": { latest: "1.0.0" },
             versions: {
               "1.0.0": {
-                name: "no-deps",
+                name: packageName,
                 version: "1.0.0",
-                dist: { tarball: `${origin}${tarballPath}` },
+                dist: { tarball: `${origin}${tarballPath}${tarballQuery}` },
               },
             },
           });
@@ -1875,8 +1881,7 @@ describe.concurrent("//host/ credential lines are matched against the request UR
   // npm's fallback: a tarball with no `.npmrc` line of its own gets the registry's
   // credentials when it is on the registry's origin, whatever its path. GitLab's
   // instance-level registry serves tarballs under a project path, so this is the
-  // documented setup (#30513). A path the server would resolve elsewhere (`..`,
-  // `%2e%2e`, backslash) still matches nothing.
+  // documented setup (#30513).
   test("registry credentials follow a tarball on a sibling path of the same origin", async () => {
     const registryPath = "/npm/team-a";
     const tarballPath = "/npm/team-b/no-deps/-/no-deps-1.0.0.tgz";
@@ -2060,8 +2065,11 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     expect(tarballRequests).toEqual([null]);
   });
 
+  // On the registry's own origin a dot segment cannot change who receives the
+  // credential, so the registry's token follows the tarball as it does on main and in
+  // npm; the guard below only applies to a `.npmrc` line looked up for another host.
   test.each(["/npm/team-a/../team-b/x.tgz", "/npm/team-a/%2e%2e/team-b/x.tgz", "/npm/team-a/..%2fteam-b/x.tgz"])(
-    "a dist.tarball of %s carries no credentials",
+    "a dist.tarball of %s on the registry's origin still carries the registry's credentials",
     async tarballPath => {
       const registryPath = "/npm/team-a";
       using registry = mockRegistry("Bearer team-a-token", { registryPath, tarballPath });
@@ -2074,14 +2082,184 @@ describe.concurrent("//host/ credential lines are matched against the request UR
         ].join("\n"),
       });
 
-      const { exitCode } = await install(String(dir));
+      await install(String(dir));
 
-      // Bun's URL parser may normalise the path before sending; either way no token goes.
       expect(registry.requests[0]).toEqual({ path: `${registryPath}/no-deps`, auth: "Bearer team-a-token" });
-      expect(registry.requests.slice(1).map(r => r.auth)).not.toContain("Bearer team-a-token");
+      expect(registry.requests.length).toBeGreaterThan(1);
+      expect(registry.requests.slice(1).map(r => r.auth)).toEqual(
+        registry.requests.slice(1).map(() => "Bearer team-a-token"),
+      );
+    },
+  );
+
+  // A `.npmrc` line is looked up for the tarball's own path only when the server would
+  // resolve that path as written. A `%2f` that splits a dot segment, or a `%5c`, is
+  // left for the server to decode, so the walk matches nothing; the plain and `%2e`
+  // spellings are normalised away before the walk, so they match the resolved path.
+  test.each([
+    "/npm/team-a/../team-b/x.tgz",
+    "/npm/team-a/./x.tgz",
+    "/npm/team-a/%2e%2e/team-b/x.tgz",
+    "/npm/team-a/%2E%2E/team-b/x.tgz",
+    "/npm/team-a/%2e./team-b/x.tgz",
+    "/npm/team-a/.%2e/team-b/x.tgz",
+    "/npm/team-a/..%2Fteam-b/x.tgz",
+    "/npm/team-a/%2f../team-b/x.tgz",
+    "/npm/team-a/a%2f..%2fteam-b/x.tgz",
+    "/npm/team-a/%5c..%5cteam-b/x.tgz",
+    "/npm/team-a/%5C..%5Cteam-b/x.tgz",
+  ])("a line scoped to another host's path is not applied to its tarball at %s", async tarballPath => {
+    using cdn = mockRegistry("Bearer cdn-a", { secure: true, tarballPath });
+    using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin, tarballPath });
+    using dir = tempDir("npmrc-url-auth-cdn-dot-segments", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/npm/team-a/:_authToken=cdn-a`,
+        "",
+      ].join("\n"),
+    });
+
+    await install(String(dir));
+
+    expect(registry.requests[0]).toEqual({ path: "/no-deps", auth: "Bearer registry-token" });
+    expect(cdn.requests.map(r => r.auth)).not.toContain("Bearer cdn-a");
+    expect(cdn.requests.map(r => r.auth)).not.toContain("Bearer registry-token");
+  });
+
+  // The `..` in the new URL resolves to a sibling of the default registry, so the
+  // default's token must not follow it.
+  test.each([
+    ["--registry", (origin: string) => [["--registry", `${origin}/npm/team-a/../team-b/`], {}] as const],
+    [
+      "NPM_CONFIG_REGISTRY",
+      (origin: string) => [[], { NPM_CONFIG_REGISTRY: `${origin}/npm/team-a/../team-b/` }] as const,
+    ],
+  ])(
+    "a registry from %s that dot-segments to a sibling path does not inherit the default's token",
+    async (_source, overrideFor) => {
+      using registry = mockRegistry("Bearer team-a-token", { registryPath: "/npm/team-b" });
+      using dir = tempDir("npmrc-url-auth-dot-segment-registry", {
+        "package.json": packageJson,
+        ".npmrc": [
+          `registry=${registry.origin}/npm/team-a/`,
+          `//${registry.host}/npm/team-a/:_authToken=team-a-token`,
+          "",
+        ].join("\n"),
+        "home/.gitkeep": "",
+      });
+      const [args, extraEnv] = overrideFor(registry.origin);
+
+      const { exitCode } = await install(String(dir), [...args], { ...extraEnv });
+
+      expect(registry.requests[0]).toEqual({ path: "/npm/team-b/no-deps", auth: null });
       expect(exitCode).toBe(1);
     },
   );
+
+  // A bare `$VAR` registry URL is expanded only when the scope is built, so its
+  // `.npmrc` line can only be found by the walk that runs after every source.
+  test("a scoped registry written as $VAR picks up its .npmrc line", async () => {
+    using registry = mockRegistry("Bearer corp-token", { registryPath: "/npm", packageName: "@corp/no-deps" });
+    using dir = tempDir("npmrc-url-auth-env-var-scope", {
+      "package.json": JSON.stringify({ name: "foo", version: "1.0.0", dependencies: { "@corp/no-deps": "1.0.0" } }),
+      ".npmrc": [`@corp:registry=$CORP_REG`, `//${registry.host}/npm/:_authToken=corp-token`, ""].join("\n"),
+      "home/.gitkeep": "",
+    });
+
+    const { exitCode } = await install(String(dir), [], { CORP_REG: `${registry.origin}/npm/` });
+
+    expect(registry.requests.map(r => r.auth)).toEqual(["Bearer corp-token", "Bearer corp-token"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("a bunfig registry written as $VAR picks up its .npmrc line", async () => {
+    using registry = mockRegistry("Bearer corp-token", { registryPath: "/npm" });
+    using dir = tempDir("npmrc-url-auth-env-var-bunfig", {
+      "package.json": packageJson,
+      "bunfig.toml": `[install]\nregistry = "$MY_REG"\n`,
+      ".npmrc": [`//${registry.host}/npm/:_authToken=corp-token`, ""].join("\n"),
+      "home/.gitkeep": "",
+    });
+
+    const { exitCode } = await install(String(dir), [], { MY_REG: `${registry.origin}/npm/` });
+
+    expect(registry.requests.map(r => r.auth)).toEqual(["Bearer corp-token", "Bearer corp-token"]);
+    expect(exitCode).toBe(0);
+  });
+
+  // `_auth` goes out as `Basic <value>` verbatim at request time too.
+  test("an _auth line applies to a --registry registry and its tarball", async () => {
+    const blob = "opaque-blob";
+    using registry = mockRegistry(`Basic ${blob}`);
+    using dir = tempDir("npmrc-url-auth-basic-cli", {
+      "package.json": packageJson,
+      ".npmrc": [`//${registry.host}/:_auth=${blob}`, ""].join("\n"),
+      "home/.gitkeep": "",
+    });
+
+    const { exitCode } = await install(String(dir), ["--registry", `${registry.origin}/`]);
+
+    expect(registry.requests.map(r => r.auth)).toEqual([`Basic ${blob}`, `Basic ${blob}`]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("an _auth line keyed to the tarball host applies to the tarball", async () => {
+    const blob = "opaque-blob";
+    using cdn = mockRegistry(`Basic ${blob}`, { secure: true });
+    using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
+    using dir = tempDir("npmrc-url-auth-basic-cdn", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/:_auth=${blob}`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect(cdn.requests).toEqual([{ path: "/no-deps/-/no-deps-1.0.0.tgz", auth: `Basic ${blob}` }]);
+    expect(exitCode).toBe(0);
+  });
+
+  // The query string is not part of the path the key or the guard look at.
+  test("a query on a same-origin dist.tarball does not disturb the registry's credentials", async () => {
+    using registry = mockRegistry("Bearer registry-token", { tarballQuery: "?p=/../x&q=%5c" });
+    using dir = tempDir("npmrc-url-auth-query-same-origin", {
+      "package.json": packageJson,
+      ".npmrc": [`registry=${registry.origin}/`, `//${registry.host}/:_authToken=registry-token`, ""].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect(registry.requests.map(r => r.auth)).toEqual(["Bearer registry-token", "Bearer registry-token"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("a query on a cross-host dist.tarball still resolves the deeper line", async () => {
+    using cdn = mockRegistry("Bearer cdn-token", { secure: true, tarballPath: "/npm/x.tgz", tarballQuery: "?sig=abc" });
+    using registry = mockRegistry("Bearer registry-token", {
+      tarballOrigin: () => cdn.origin,
+      tarballPath: "/npm/x.tgz",
+    });
+    using dir = tempDir("npmrc-url-auth-query-cdn", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/npm/:_authToken=cdn-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect(cdn.requests).toEqual([{ path: "/npm/x.tgz", auth: "Bearer cdn-token" }]);
+    expect(exitCode).toBe(0);
+  });
 
   // Bun's docs long showed the key with a scheme; npm never writes one, but it must keep
   // working. The scheme is dropped when the line is read.

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1913,6 +1913,34 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     });
   });
 
+  // A shallower line the registry never reached is the tarball's own line, as in npm:
+  // the registry stopped at its team key, the tarball outside that tree walks to root.
+  test("a same-origin tarball outside the registry's tree uses the host-root line", async () => {
+    const registryPath = "/npm/team-a";
+    const tarballPath = "/cdn/no-deps/-/no-deps-1.0.0.tgz";
+    using registry = mockRegistry("Bearer root-token", { registryPath, tarballPath, publicManifest: true });
+    using dir = tempDir("npmrc-url-auth-root-line", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}${registryPath}/`,
+        `//${registry.host}${registryPath}/:_authToken=team-a-token`,
+        `//${registry.host}/:_authToken=root-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect({ requests: registry.requests, exitCode, stderr }).toEqual({
+      requests: [
+        { path: `${registryPath}/no-deps`, auth: "Bearer team-a-token" },
+        { path: tarballPath, auth: "Bearer root-token" },
+      ],
+      exitCode: 0,
+      stderr: expect.not.stringContaining("401"),
+    });
+  });
+
   test.each(["/npm/team-a/../team-b/x.tgz", "/npm/team-a/%2e%2e/team-b/x.tgz", "/npm/team-a/..%2fteam-b/x.tgz"])(
     "a dist.tarball of %s carries no credentials",
     async tarballPath => {

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1730,7 +1730,8 @@ describe.concurrent("//host/ credential lines are matched against the request UR
   });
 
   test("a line for another path on the tarball host does not authenticate it, even if it is a string prefix", async () => {
-    using cdn = mockRegistry("Bearer other-token");
+    // https, so the key walk is what decides, not the plaintext guard.
+    using cdn = mockRegistry("Bearer other-token", { secure: true });
     using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
     using dir = tempDir("npmrc-url-auth-tarball-wrong-path", {
       "package.json": packageJson,

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1525,6 +1525,67 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     });
   });
 
+  // The default registry's token used to follow any `--registry`/env registry on the
+  // same host, path ignored, so a sibling path got the wrong token and its own line
+  // was never consulted. Only a registry at or under the old one inherits now.
+  test.each([
+    ["--registry", (origin: string) => [["--registry", `${origin}/npm/team-b/`], {}] as const],
+    ["NPM_CONFIG_REGISTRY", (origin: string) => [[], { NPM_CONFIG_REGISTRY: `${origin}/npm/team-b/` }] as const],
+  ])(
+    "a registry from %s on a sibling path uses that path's own line, not the default registry's token",
+    async (_source, overrideFor) => {
+      using registry = mockRegistry("Bearer team-b-token", {
+        registryPath: "/npm/team-b",
+        tarballPath: "/npm/team-b/no-deps/-/no-deps-1.0.0.tgz",
+      });
+      using dir = tempDir("npmrc-url-auth-sibling-registry", {
+        "package.json": packageJson,
+        ".npmrc": [
+          `registry=${registry.origin}/npm/team-a/`,
+          `//${registry.host}/npm/team-a/:_authToken=team-a-token`,
+          `//${registry.host}/npm/team-b/:_authToken=team-b-token`,
+          "",
+        ].join("\n"),
+        "home/.gitkeep": "",
+      });
+      const [args, extraEnv] = overrideFor(registry.origin);
+
+      const { stderr, exitCode } = await install(String(dir), [...args], { ...extraEnv });
+
+      expect({ requests: registry.requests, exitCode, stderr }).toEqual({
+        requests: [
+          { path: "/npm/team-b/no-deps", auth: "Bearer team-b-token" },
+          { path: "/npm/team-b/no-deps/-/no-deps-1.0.0.tgz", auth: "Bearer team-b-token" },
+        ],
+        exitCode: 0,
+        stderr: expect.not.stringContaining("401"),
+      });
+    },
+  );
+
+  test("--registry below the default registry keeps its token", async () => {
+    using registry = mockRegistry("Bearer team-a-token", {
+      registryPath: "/npm/team-a/sub",
+      tarballPath: "/npm/team-a/sub/no-deps/-/no-deps-1.0.0.tgz",
+    });
+    using dir = tempDir("npmrc-url-auth-child-registry", {
+      "package.json": packageJson,
+      ".npmrc": `registry=${registry.origin}/npm/team-a/\n//${registry.host}/npm/team-a/:_authToken=team-a-token\n`,
+      "home/.gitkeep": "",
+    });
+
+    const { stderr, exitCode } = await install(String(dir), ["--registry", `${registry.origin}/npm/team-a/sub/`]);
+
+    expect({ requests: registry.requests, exitCode, stderr }).toEqual({
+      requests: [
+        { path: "/npm/team-a/sub/no-deps", auth: "Bearer team-a-token" },
+        { path: "/npm/team-a/sub/no-deps/-/no-deps-1.0.0.tgz", auth: "Bearer team-a-token" },
+      ],
+      exitCode: 0,
+      stderr: expect.not.stringContaining("401"),
+    });
+  });
+
   test.each(["NPM_CONFIG_REGISTRY", "BUN_CONFIG_REGISTRY"])(
     "a registry from %s uses the token the project .npmrc has for that host",
     async variable => {

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -2130,6 +2130,28 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     expect(cdn.requests.map(r => r.auth)).not.toContain("Bearer registry-token");
   });
 
+  // The key is built from the WHATWG serialisation; the request goes to the authority
+  // Bun's fast parser reads. A URL the two read differently must match no line.
+  test("a dist.tarball whose authority the two parsers read differently gets no line", async () => {
+    using cdn = mockRegistry("Bearer registry-token", { secure: true, tarballPath: "/x.tgz" });
+    using registry = mockRegistry("Bearer registry-token", {
+      secure: true,
+      tarballPath: "/x.tgz",
+      // `https://<registry>#@<cdn>/x.tgz`: WHATWG stops the authority at `#` (host =
+      // registry); the fast parser reads `<registry>#` as userinfo (host = cdn).
+      tarballOrigin: () => `${registry.origin}#@${cdn.host}`,
+    });
+    using dir = tempDir("npmrc-url-auth-parser-split", {
+      "package.json": packageJson,
+      ".npmrc": [`registry=${registry.origin}/`, `//${registry.host}/:_authToken=registry-token`, ""].join("\n"),
+    });
+
+    await install(String(dir));
+
+    expect(registry.requests[0]).toEqual({ path: "/no-deps", auth: "Bearer registry-token" });
+    expect(cdn.requests.map(r => r.auth)).not.toContain("Bearer registry-token");
+  });
+
   // A redundant `/./` resolves within the line's path, so the line applies, as it does
   // in npm after `new URL()`.
   test("a redundant dot segment in a cross-host dist.tarball still resolves the line", async () => {

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1,7 +1,7 @@
 import { write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { rm } from "fs/promises";
-import { VerdaccioRegistry, bunExe, bunEnv as env, isIPv6, tempDir } from "harness";
+import { VerdaccioRegistry, bunExe, bunEnv as env, isIPv6, tempDir, tls } from "harness";
 import { join } from "path";
 const { iniInternals } = require("bun:internal-for-testing");
 const { loadNpmrc } = iniInternals;
@@ -1939,6 +1939,51 @@ describe.concurrent("//host/ credential lines are matched against the request UR
       exitCode: 0,
       stderr: expect.not.stringContaining("401"),
     });
+  });
+
+  // `.npmrc` keys carry no scheme. A registry-supplied `http://` tarball must not
+  // receive a token the user wrote for an https host: the manifest is registry-controlled.
+  test("an http tarball from an https registry gets no .npmrc credentials", async () => {
+    const tarballRequests: (string | null)[] = [];
+    using plain = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        tarballRequests.push(req.headers.get("authorization"));
+        return new Response(Bun.file(tgz));
+      },
+    });
+    using secure = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls,
+      fetch() {
+        return Response.json({
+          name: "no-deps",
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              name: "no-deps",
+              version: "1.0.0",
+              dist: { tarball: `http://127.0.0.1:${plain.port}/no-deps/-/no-deps-1.0.0.tgz` },
+            },
+          },
+        });
+      },
+    });
+    using dir = tempDir("npmrc-url-auth-http-tarball", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=https://127.0.0.1:${secure.port}/`,
+        `//127.0.0.1:${secure.port}/:_authToken=registry-token`,
+        `//127.0.0.1:${plain.port}/:_authToken=must-not-leak`,
+        "",
+      ].join("\n"),
+    });
+
+    await install(String(dir), ["--ca", tls.cert]);
+
+    expect(tarballRequests).toEqual([null]);
   });
 
   test.each(["/npm/team-a/../team-b/x.tgz", "/npm/team-a/%2e%2e/team-b/x.tgz", "/npm/team-a/..%2fteam-b/x.tgz"])(

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1572,6 +1572,39 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     },
   );
 
+  // A deeper line wins over inheritance, as npm resolves it from the request URL.
+  test.each([
+    ["--registry", (origin: string) => [["--registry", `${origin}/npm/team-a/sub/`], {}] as const],
+    ["NPM_CONFIG_REGISTRY", (origin: string) => [[], { NPM_CONFIG_REGISTRY: `${origin}/npm/team-a/sub/` }] as const],
+  ])("a registry from %s below the default registry uses its own deeper line", async (_source, overrideFor) => {
+    using registry = mockRegistry("Bearer sub-token", {
+      registryPath: "/npm/team-a/sub",
+      tarballPath: "/npm/team-a/sub/no-deps/-/no-deps-1.0.0.tgz",
+    });
+    using dir = tempDir("npmrc-url-auth-deeper-line", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/npm/team-a/`,
+        `//${registry.host}/npm/team-a/:_authToken=team-a-token`,
+        `//${registry.host}/npm/team-a/sub/:_authToken=sub-token`,
+        "",
+      ].join("\n"),
+      "home/.gitkeep": "",
+    });
+    const [args, extraEnv] = overrideFor(registry.origin);
+
+    const { stderr, exitCode } = await install(String(dir), [...args], { ...extraEnv });
+
+    expect({ requests: registry.requests, exitCode, stderr }).toEqual({
+      requests: [
+        { path: "/npm/team-a/sub/no-deps", auth: "Bearer sub-token" },
+        { path: "/npm/team-a/sub/no-deps/-/no-deps-1.0.0.tgz", auth: "Bearer sub-token" },
+      ],
+      exitCode: 0,
+      stderr: expect.not.stringContaining("401"),
+    });
+  });
+
   test("--registry below the default registry keeps its token", async () => {
     using registry = mockRegistry("Bearer team-a-token", {
       registryPath: "/npm/team-a/sub",

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1829,10 +1829,12 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     });
   });
 
-  // From the multi-tenant case: the manifest names the tarball URL, so a registry's
-  // own credentials only follow a tarball at or under the registry URL, and a path a
-  // server would resolve elsewhere (`..`, `%2e%2e`, backslash) matches nothing.
-  test("registry credentials are not sent to a sibling path on the same host", async () => {
+  // npm's fallback: a tarball with no `.npmrc` line of its own gets the registry's
+  // credentials when it is on the registry's origin, whatever its path. GitLab's
+  // instance-level registry serves tarballs under a project path, so this is the
+  // documented setup (#30513). A path the server would resolve elsewhere (`..`,
+  // `%2e%2e`, backslash) still matches nothing.
+  test("registry credentials follow a tarball on a sibling path of the same origin", async () => {
     const registryPath = "/npm/team-a";
     const tarballPath = "/npm/team-b/no-deps/-/no-deps-1.0.0.tgz";
     using registry = mockRegistry("Bearer team-a-token", { registryPath, tarballPath });
@@ -1845,14 +1847,40 @@ describe.concurrent("//host/ credential lines are matched against the request UR
       ].join("\n"),
     });
 
-    const { exitCode } = await install(String(dir));
+    const { stderr, exitCode } = await install(String(dir));
 
-    expect({ requests: registry.requests, exitCode }).toEqual({
+    expect({ requests: registry.requests, exitCode, stderr }).toEqual({
       requests: [
         { path: `${registryPath}/no-deps`, auth: "Bearer team-a-token" },
-        { path: tarballPath, auth: null },
+        { path: tarballPath, auth: "Bearer team-a-token" },
       ],
-      exitCode: 1,
+      exitCode: 0,
+      stderr: expect.not.stringContaining("401"),
+    });
+  });
+
+  test("GitLab's instance-level registry: the project-path tarball gets the instance token", async () => {
+    const registryPath = "/api/v4/packages/npm";
+    const tarballPath = "/api/v4/projects/123/packages/npm/no-deps/-/no-deps-1.0.0.tgz";
+    using registry = mockRegistry("Bearer instance-token", { registryPath, tarballPath });
+    using dir = tempDir("npmrc-url-auth-gitlab-instance", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}${registryPath}/`,
+        `//${registry.host}${registryPath}/:_authToken=instance-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect({ requests: registry.requests, exitCode, stderr }).toEqual({
+      requests: [
+        { path: `${registryPath}/no-deps`, auth: "Bearer instance-token" },
+        { path: tarballPath, auth: "Bearer instance-token" },
+      ],
+      exitCode: 0,
+      stderr: expect.not.stringContaining("401"),
     });
   });
 

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -2240,10 +2240,11 @@ describe.concurrent("//host/ credential lines are matched against the request UR
   });
 
   test("a query on a cross-host dist.tarball still resolves the deeper line", async () => {
-    using cdn = mockRegistry("Bearer cdn-token", { secure: true, tarballPath: "/npm/x.tgz", tarballQuery: "?sig=abc" });
+    using cdn = mockRegistry("Bearer cdn-token", { secure: true, tarballPath: "/npm/x.tgz" });
     using registry = mockRegistry("Bearer registry-token", {
       tarballOrigin: () => cdn.origin,
       tarballPath: "/npm/x.tgz",
+      tarballQuery: "?sig=abc",
     });
     using dir = tempDir("npmrc-url-auth-query-cdn", {
       "package.json": packageJson,

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -2107,6 +2107,9 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     "/npm/team-a/a%2f..%2fteam-b/x.tgz",
     "/npm/team-a/%5c..%5cteam-b/x.tgz",
     "/npm/team-a/%5C..%5Cteam-b/x.tgz",
+    // A raw backslash: the request keeps it, the key would read it as `/` and resolve
+    // `team-b\..\team-a` back into team-a's line.
+    "/npm/team-b\\..\\team-a/x.tgz",
   ])("a line scoped to another host's path is not applied to its tarball at %s", async tarballPath => {
     using cdn = mockRegistry("Bearer cdn-a", { secure: true, tarballPath });
     using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin, tarballPath });

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -2092,13 +2092,12 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     },
   );
 
-  // A `.npmrc` line is looked up for the tarball's own path only when the server would
-  // resolve that path as written. A `%2f` that splits a dot segment, or a `%5c`, is
-  // left for the server to decode, so the walk matches nothing; the plain and `%2e`
-  // spellings are normalised away before the walk, so they match the resolved path.
+  // A `.npmrc` line is looked up for the tarball's resolved path: dot segments, plain,
+  // `%2e`-spelled or after a backslash, are resolved as the WHATWG parser resolves
+  // them, so a path that leaves `team-a` matches no `team-a` line. A `%2f` that splits
+  // a dot segment, or a `%5c`, is left for the server to decode, so it matches nothing.
   test.each([
     "/npm/team-a/../team-b/x.tgz",
-    "/npm/team-a/./x.tgz",
     "/npm/team-a/%2e%2e/team-b/x.tgz",
     "/npm/team-a/%2E%2E/team-b/x.tgz",
     "/npm/team-a/%2e./team-b/x.tgz",
@@ -2126,6 +2125,29 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     expect(registry.requests[0]).toEqual({ path: "/no-deps", auth: "Bearer registry-token" });
     expect(cdn.requests.map(r => r.auth)).not.toContain("Bearer cdn-a");
     expect(cdn.requests.map(r => r.auth)).not.toContain("Bearer registry-token");
+  });
+
+  // A redundant `/./` resolves within the line's path, so the line applies, as it does
+  // in npm after `new URL()`.
+  test("a redundant dot segment in a cross-host dist.tarball still resolves the line", async () => {
+    using cdn = mockRegistry("Bearer cdn-a", { secure: true, tarballPath: "/npm/team-a/./x.tgz" });
+    using registry = mockRegistry("Bearer registry-token", {
+      tarballOrigin: () => cdn.origin,
+      tarballPath: "/npm/team-a/./x.tgz",
+    });
+    using dir = tempDir("npmrc-url-auth-cdn-single-dot", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/npm/team-a/:_authToken=cdn-a`,
+        "",
+      ].join("\n"),
+    });
+
+    await install(String(dir));
+
+    expect(cdn.requests.map(r => r.auth)).toEqual(["Bearer cdn-a"]);
   });
 
   // The `..` in the new URL resolves to a sibling of the default registry, so the

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1414,3 +1414,443 @@ describe.skipIf(!isIPv6())("registry on a bracketed IPv6 host", () => {
     expect(exitCode).not.toBe(0);
   });
 });
+
+// `//host/path/:_authToken=` lines are keyed by URL, not by a registry declared
+// in the same file. Like npm, they have to apply to whatever request ends up on
+// that host: a registry that only exists on the command line or in the
+// environment, or a tarball served from a different host than the registry.
+describe.concurrent("//host/ credential lines are matched against the request URL", () => {
+  const tgz = join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz");
+  const basic = (user: string, password: string) => `Basic ${Buffer.from(`${user}:${password}`).toString("base64")}`;
+  const packageJson = JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "no-deps": "1.0.0" } });
+
+  type Req = { path: string; auth: string | null };
+
+  type MockRegistryOptions = {
+    /** Serve dist.tarball from another server instead of this one. */
+    tarballOrigin?: () => string;
+    /** Mount the registry under this path prefix instead of `/`. */
+    registryPath?: string;
+    /** Path of the tarball on its server. */
+    tarballPath?: string;
+    /** Let the manifest through without credentials; only the tarball is protected. */
+    publicManifest?: boolean;
+  };
+
+  // Serves no-deps@1.0.0 and answers 401 to any request that does not carry
+  // exactly `expectedAuth`.
+  function mockRegistry(expectedAuth: string, options: MockRegistryOptions = {}) {
+    const { tarballOrigin, registryPath = "", tarballPath = "/no-deps/-/no-deps-1.0.0.tgz", publicManifest } = options;
+    const requests: Req[] = [];
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        const auth = req.headers.get("authorization");
+        requests.push({ path: url.pathname, auth });
+        const isManifest = url.pathname === `${registryPath}/no-deps`;
+        if (auth !== expectedAuth && !(isManifest && publicManifest)) {
+          return new Response("unauthorized", { status: 401 });
+        }
+        if (url.pathname === tarballPath) return new Response(Bun.file(tgz));
+        if (isManifest) {
+          const origin = tarballOrigin ? tarballOrigin() : `http://127.0.0.1:${server.port}`;
+          return Response.json({
+            name: "no-deps",
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "no-deps",
+                version: "1.0.0",
+                dist: { tarball: `${origin}${tarballPath}` },
+              },
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    return {
+      requests,
+      host: `127.0.0.1:${server.port}`,
+      origin: `http://127.0.0.1:${server.port}`,
+      [Symbol.dispose]() {
+        server.stop(true);
+      },
+    };
+  }
+
+  async function install(dir: string, args: string[] = [], extraEnv: Record<string, string> = {}) {
+    // bunEnv spreads process.env; the user-level .npmrc of the machine running the
+    // tests must not leak in, and the cache must be cold so the tarball is fetched.
+    const spawnEnv: Record<string, string> = {
+      ...(env as Record<string, string>),
+      HOME: join(dir, "home"),
+      USERPROFILE: join(dir, "home"),
+      BUN_INSTALL_CACHE_DIR: join(dir, ".cache"),
+      ...extraEnv,
+    };
+    delete spawnEnv.XDG_CONFIG_HOME;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd: dir,
+      env: spawnEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const manifestPath = "/no-deps";
+  const tarballPath = "/no-deps/-/no-deps-1.0.0.tgz";
+
+  test("--registry uses the token the user-level .npmrc has for that host", async () => {
+    using registry = mockRegistry("Bearer user-npmrc-token");
+    using dir = tempDir("npmrc-url-auth-cli-registry", {
+      "package.json": packageJson,
+      "home/.npmrc": `//${registry.host}/:_authToken=user-npmrc-token\n`,
+    });
+
+    const { stderr, exitCode } = await install(String(dir), ["--registry", `${registry.origin}/`]);
+
+    expect({ requests: registry.requests, exitCode, stderr }).toEqual({
+      requests: [
+        { path: manifestPath, auth: "Bearer user-npmrc-token" },
+        { path: tarballPath, auth: "Bearer user-npmrc-token" },
+      ],
+      exitCode: 0,
+      stderr: expect.not.stringContaining("401"),
+    });
+  });
+
+  test.each(["NPM_CONFIG_REGISTRY", "BUN_CONFIG_REGISTRY"])(
+    "a registry from %s uses the token the project .npmrc has for that host",
+    async variable => {
+      using registry = mockRegistry("Bearer env-registry-token");
+      using dir = tempDir("npmrc-url-auth-env-registry", {
+        "package.json": packageJson,
+        ".npmrc": `//${registry.host}/:_authToken=env-registry-token\n`,
+      });
+
+      const { exitCode } = await install(String(dir), [], { [variable]: `${registry.origin}/` });
+
+      expect({ requests: registry.requests, exitCode }).toEqual({
+        requests: [
+          { path: manifestPath, auth: "Bearer env-registry-token" },
+          { path: tarballPath, auth: "Bearer env-registry-token" },
+        ],
+        exitCode: 0,
+      });
+    },
+  );
+
+  test("username and _password lines for the --registry host are sent as basic auth", async () => {
+    using registry = mockRegistry(basic("alice", "open sesame"));
+    using dir = tempDir("npmrc-url-auth-basic", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `//${registry.host}/:username=alice`,
+        `//${registry.host}/:_password=${Buffer.from("open sesame").toString("base64")}`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir), ["--registry", `${registry.origin}/`]);
+
+    expect({ requests: registry.requests, exitCode }).toEqual({
+      requests: [
+        { path: manifestPath, auth: basic("alice", "open sesame") },
+        { path: tarballPath, auth: basic("alice", "open sesame") },
+      ],
+      exitCode: 0,
+    });
+  });
+
+  test("a line for the tarball host takes precedence over userinfo in the dist.tarball url", async () => {
+    using cdn = mockRegistry("Bearer cdn-token");
+    using registry = mockRegistry("Bearer registry-token", {
+      tarballOrigin: () => `http://carol:s3cret@${cdn.host}`,
+    });
+    using dir = tempDir("npmrc-url-auth-line-over-userinfo", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/:_authToken=cdn-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ cdn: cdn.requests, exitCode }).toEqual({
+      cdn: [{ path: tarballPath, auth: "Bearer cdn-token" }],
+      exitCode: 0,
+    });
+  });
+
+  test("a tarball on a different host than its registry gets that host's own line", async () => {
+    using cdn = mockRegistry("Bearer cdn-token");
+    using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
+    using dir = tempDir("npmrc-url-auth-tarball-host", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/:_authToken=cdn-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ registry: registry.requests, cdn: cdn.requests, exitCode }).toEqual({
+      registry: [{ path: manifestPath, auth: "Bearer registry-token" }],
+      cdn: [{ path: tarballPath, auth: "Bearer cdn-token" }],
+      exitCode: 0,
+    });
+  });
+
+  test("username and _password lines for the tarball host are sent to it as basic auth", async () => {
+    using cdn = mockRegistry(basic("cdn-user", "cdn-pass"));
+    using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
+    using dir = tempDir("npmrc-url-auth-tarball-host-basic", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/:username=cdn-user`,
+        `//${cdn.host}/:_password=${Buffer.from("cdn-pass").toString("base64")}`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ registry: registry.requests, cdn: cdn.requests, exitCode }).toEqual({
+      registry: [{ path: manifestPath, auth: "Bearer registry-token" }],
+      cdn: [{ path: tarballPath, auth: basic("cdn-user", "cdn-pass") }],
+      exitCode: 0,
+    });
+  });
+
+  test("the line with the deepest path covering the tarball url wins; other paths on the host do not apply", async () => {
+    using cdn = mockRegistry("Bearer deep-token");
+    using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
+    using dir = tempDir("npmrc-url-auth-tarball-path", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//${cdn.host}/no-deps-other/:_authToken=other-token`,
+        `//${cdn.host}/:_authToken=shallow-token`,
+        `//${cdn.host}/no-deps/:_authToken=deep-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ cdn: cdn.requests, exitCode }).toEqual({
+      cdn: [{ path: tarballPath, auth: "Bearer deep-token" }],
+      exitCode: 0,
+    });
+  });
+
+  test("a line for another path on the tarball host does not authenticate it, even if it is a string prefix", async () => {
+    using cdn = mockRegistry("Bearer other-token");
+    using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
+    using dir = tempDir("npmrc-url-auth-tarball-wrong-path", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        // "/no" is a prefix of "/no-deps/..." but not a parent directory of it.
+        `//${cdn.host}/no/:_authToken=other-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect({ cdn: cdn.requests, exitCode }).toEqual({
+      cdn: [{ path: tarballPath, auth: null }],
+      exitCode: 1,
+    });
+    expect(stderr).toContain(`error: GET ${cdn.origin}${tarballPath} - 401`);
+  });
+
+  // https://github.com/oven-sh/bun/issues/30513: GitLab resolves packages through
+  // an instance-level registry path but serves tarballs from (and keys tokens to)
+  // a project-level path. The token line covers the tarball URL and nothing else.
+  test("a line keyed to the tarball path authenticates the tarball when the registry itself has no credentials", async () => {
+    const registryPath = "/api/v4/packages/npm";
+    const tarballPath = "/api/v4/projects/123/packages/npm/no-deps/-/no-deps-1.0.0.tgz";
+    using registry = mockRegistry("Bearer project-token", { registryPath, tarballPath, publicManifest: true });
+    using dir = tempDir("npmrc-url-auth-divergent-path", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}${registryPath}/`,
+        `//${registry.host}/api/v4/projects/123/packages/npm/:_authToken=project-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ requests: registry.requests, exitCode }).toEqual({
+      requests: [
+        { path: `${registryPath}/no-deps`, auth: null },
+        { path: tarballPath, auth: "Bearer project-token" },
+      ],
+      exitCode: 0,
+    });
+  });
+
+  test("a line keyed to a parent path of the registry url applies to the registry", async () => {
+    const registryPath = "/api/v4/packages/npm";
+    const tarballPath = `${registryPath}/no-deps/-/no-deps-1.0.0.tgz`;
+    using registry = mockRegistry("Bearer host-token", { registryPath, tarballPath });
+    using dir = tempDir("npmrc-url-auth-parent-path", {
+      "package.json": packageJson,
+      ".npmrc": [`registry=${registry.origin}${registryPath}/`, `//${registry.host}/:_authToken=host-token`, ""].join(
+        "\n",
+      ),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ requests: registry.requests, exitCode }).toEqual({
+      requests: [
+        { path: `${registryPath}/no-deps`, auth: "Bearer host-token" },
+        { path: tarballPath, auth: "Bearer host-token" },
+      ],
+      exitCode: 0,
+    });
+  });
+
+  test("a lockfile recorded against a registry that has since moved still downloads from the old host", async () => {
+    using oldRegistry = mockRegistry("Bearer old-token");
+    using newRegistry = mockRegistry("Bearer new-token");
+    using dir = tempDir("npmrc-url-auth-moved-registry", {
+      "package.json": packageJson,
+      ".npmrc": [`registry=${oldRegistry.origin}/`, `//${oldRegistry.host}/:_authToken=old-token`, ""].join("\n"),
+    });
+
+    const first = await install(String(dir));
+    expect(first.exitCode).toBe(0);
+    const lockfile = await Bun.file(join(String(dir), "bun.lock")).text();
+    expect(lockfile).toContain(`${oldRegistry.origin}${tarballPath}`);
+    oldRegistry.requests.length = 0;
+
+    // The registry moves; the user keeps credentials for both hosts, as npm
+    // needs them to for the same lockfile.
+    await Bun.write(
+      join(String(dir), ".npmrc"),
+      [
+        `registry=${newRegistry.origin}/`,
+        `//${newRegistry.host}/:_authToken=new-token`,
+        `//${oldRegistry.host}/:_authToken=old-token`,
+        "",
+      ].join("\n"),
+    );
+    await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+    await rm(join(String(dir), ".cache"), { recursive: true, force: true });
+
+    const second = await install(String(dir), ["--frozen-lockfile"]);
+
+    expect({ old: oldRegistry.requests, new: newRegistry.requests, exitCode: second.exitCode }).toEqual({
+      old: [{ path: tarballPath, auth: "Bearer old-token" }],
+      new: [],
+      exitCode: 0,
+    });
+  });
+
+  // From the multi-tenant case: the manifest names the tarball URL, so a registry's
+  // own credentials only follow a tarball at or under the registry URL, and a path a
+  // server would resolve elsewhere (`..`, `%2e%2e`, backslash) matches nothing.
+  test("registry credentials are not sent to a sibling path on the same host", async () => {
+    const registryPath = "/npm/team-a";
+    const tarballPath = "/npm/team-b/no-deps/-/no-deps-1.0.0.tgz";
+    using registry = mockRegistry("Bearer team-a-token", { registryPath, tarballPath });
+    using dir = tempDir("npmrc-url-auth-sibling-path", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}${registryPath}/`,
+        `//${registry.host}${registryPath}/:_authToken=team-a-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ requests: registry.requests, exitCode }).toEqual({
+      requests: [
+        { path: `${registryPath}/no-deps`, auth: "Bearer team-a-token" },
+        { path: tarballPath, auth: null },
+      ],
+      exitCode: 1,
+    });
+  });
+
+  test.each(["/npm/team-a/../team-b/x.tgz", "/npm/team-a/%2e%2e/team-b/x.tgz", "/npm/team-a/..%2fteam-b/x.tgz"])(
+    "a dist.tarball of %s carries no credentials",
+    async tarballPath => {
+      const registryPath = "/npm/team-a";
+      using registry = mockRegistry("Bearer team-a-token", { registryPath, tarballPath });
+      using dir = tempDir("npmrc-url-auth-dot-segments", {
+        "package.json": packageJson,
+        ".npmrc": [
+          `registry=${registry.origin}${registryPath}/`,
+          `//${registry.host}/:_authToken=team-a-token`,
+          "",
+        ].join("\n"),
+      });
+
+      const { exitCode } = await install(String(dir));
+
+      // Bun's URL parser may normalise the path before sending; either way no token goes.
+      expect(registry.requests[0]).toEqual({ path: `${registryPath}/no-deps`, auth: "Bearer team-a-token" });
+      expect(registry.requests.slice(1).map(r => r.auth)).not.toContain("Bearer team-a-token");
+      expect(exitCode).toBe(1);
+    },
+  );
+
+  // Bun's docs long showed the key with a scheme; npm never writes one, but it must keep
+  // working. The scheme is dropped when the line is read.
+  test("a key written with a scheme, as Bun's docs showed it, still applies", async () => {
+    using registry = mockRegistry("Bearer docs-token");
+    using dir = tempDir("npmrc-url-auth-scheme-key", {
+      "package.json": packageJson,
+      ".npmrc": [`registry=${registry.origin}/`, `//http://${registry.host}/:_authToken=docs-token`, ""].join("\n"),
+    });
+
+    const { exitCode } = await install(String(dir));
+
+    expect({ requests: registry.requests, exitCode }).toEqual({
+      requests: [
+        { path: manifestPath, auth: "Bearer docs-token" },
+        { path: tarballPath, auth: "Bearer docs-token" },
+      ],
+      exitCode: 0,
+    });
+  });
+
+  // `_authtoken` used to match `_auth` as a substring and go out as `Basic <token>`.
+  test("a misspelt option sends nothing and warns, without printing the value", async () => {
+    using registry = mockRegistry("Bearer typo-token");
+    using dir = tempDir("npmrc-url-auth-typo", {
+      "package.json": packageJson,
+      ".npmrc": [`registry=${registry.origin}/`, `//${registry.host}/:_authtoken=typo-token`, ""].join("\n"),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect(registry.requests).toEqual([{ path: manifestPath, auth: null }]);
+    expect(stderr).toContain("_authtoken is not a known .npmrc option");
+    expect(stderr).not.toContain("typo-token");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1884,6 +1884,35 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     });
   });
 
+  // A line specific to the tarball's path beats the registry's credentials, as in
+  // npm; a line the registry itself resolves to does not (bunfig, env and CLI
+  // credentials stay ahead of `.npmrc`, as they are for the manifest).
+  test("a tarball path with its own .npmrc line uses that line, not the registry's token", async () => {
+    const registryPath = "/npm/team-a";
+    const tarballPath = "/npm/team-b/no-deps/-/no-deps-1.0.0.tgz";
+    using registry = mockRegistry("Bearer team-b-token", { registryPath, tarballPath, publicManifest: true });
+    using dir = tempDir("npmrc-url-auth-own-line", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}${registryPath}/`,
+        `//${registry.host}${registryPath}/:_authToken=team-a-token`,
+        `//${registry.host}/npm/team-b/:_authToken=team-b-token`,
+        "",
+      ].join("\n"),
+    });
+
+    const { stderr, exitCode } = await install(String(dir));
+
+    expect({ requests: registry.requests, exitCode, stderr }).toEqual({
+      requests: [
+        { path: `${registryPath}/no-deps`, auth: "Bearer team-a-token" },
+        { path: tarballPath, auth: "Bearer team-b-token" },
+      ],
+      exitCode: 0,
+      stderr: expect.not.stringContaining("401"),
+    });
+  });
+
   test.each(["/npm/team-a/../team-b/x.tgz", "/npm/team-a/%2e%2e/team-b/x.tgz", "/npm/team-a/..%2fteam-b/x.tgz"])(
     "a dist.tarball of %s carries no credentials",
     async tarballPath => {

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -1435,16 +1435,25 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     tarballPath?: string;
     /** Let the manifest through without credentials; only the tarball is protected. */
     publicManifest?: boolean;
+    /** Serve over https with the harness certificate (`install` passes it as `--ca`). */
+    secure?: boolean;
   };
 
   // Serves no-deps@1.0.0 and answers 401 to any request that does not carry
   // exactly `expectedAuth`.
   function mockRegistry(expectedAuth: string, options: MockRegistryOptions = {}) {
-    const { tarballOrigin, registryPath = "", tarballPath = "/no-deps/-/no-deps-1.0.0.tgz", publicManifest } = options;
+    const {
+      tarballOrigin,
+      registryPath = "",
+      tarballPath = "/no-deps/-/no-deps-1.0.0.tgz",
+      publicManifest,
+      secure,
+    } = options;
     const requests: Req[] = [];
     const server = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
+      ...(secure ? { tls } : {}),
       fetch(req) {
         const url = new URL(req.url);
         const auth = req.headers.get("authorization");
@@ -1455,7 +1464,7 @@ describe.concurrent("//host/ credential lines are matched against the request UR
         }
         if (url.pathname === tarballPath) return new Response(Bun.file(tgz));
         if (isManifest) {
-          const origin = tarballOrigin ? tarballOrigin() : `http://127.0.0.1:${server.port}`;
+          const origin = tarballOrigin ? tarballOrigin() : `${secure ? "https" : "http"}://127.0.0.1:${server.port}`;
           return Response.json({
             name: "no-deps",
             "dist-tags": { latest: "1.0.0" },
@@ -1474,7 +1483,7 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     return {
       requests,
       host: `127.0.0.1:${server.port}`,
-      origin: `http://127.0.0.1:${server.port}`,
+      origin: `${secure ? "https" : "http"}://127.0.0.1:${server.port}`,
       [Symbol.dispose]() {
         server.stop(true);
       },
@@ -1493,7 +1502,7 @@ describe.concurrent("//host/ credential lines are matched against the request UR
     };
     delete spawnEnv.XDG_CONFIG_HOME;
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "install", ...args],
+      cmd: [bunExe(), "install", "--ca", tls.cert, ...args],
       cwd: dir,
       env: spawnEnv,
       stdout: "pipe",
@@ -1630,9 +1639,9 @@ describe.concurrent("//host/ credential lines are matched against the request UR
   });
 
   test("a line for the tarball host takes precedence over userinfo in the dist.tarball url", async () => {
-    using cdn = mockRegistry("Bearer cdn-token");
+    using cdn = mockRegistry("Bearer cdn-token", { secure: true });
     using registry = mockRegistry("Bearer registry-token", {
-      tarballOrigin: () => `http://carol:s3cret@${cdn.host}`,
+      tarballOrigin: () => `https://carol:s3cret@${cdn.host}`,
     });
     using dir = tempDir("npmrc-url-auth-line-over-userinfo", {
       "package.json": packageJson,
@@ -1653,7 +1662,7 @@ describe.concurrent("//host/ credential lines are matched against the request UR
   });
 
   test("a tarball on a different host than its registry gets that host's own line", async () => {
-    using cdn = mockRegistry("Bearer cdn-token");
+    using cdn = mockRegistry("Bearer cdn-token", { secure: true });
     using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
     using dir = tempDir("npmrc-url-auth-tarball-host", {
       "package.json": packageJson,
@@ -1675,7 +1684,7 @@ describe.concurrent("//host/ credential lines are matched against the request UR
   });
 
   test("username and _password lines for the tarball host are sent to it as basic auth", async () => {
-    using cdn = mockRegistry(basic("cdn-user", "cdn-pass"));
+    using cdn = mockRegistry(basic("cdn-user", "cdn-pass"), { secure: true });
     using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
     using dir = tempDir("npmrc-url-auth-tarball-host-basic", {
       "package.json": packageJson,
@@ -1698,7 +1707,7 @@ describe.concurrent("//host/ credential lines are matched against the request UR
   });
 
   test("the line with the deepest path covering the tarball url wins; other paths on the host do not apply", async () => {
-    using cdn = mockRegistry("Bearer deep-token");
+    using cdn = mockRegistry("Bearer deep-token", { secure: true });
     using registry = mockRegistry("Bearer registry-token", { tarballOrigin: () => cdn.origin });
     using dir = tempDir("npmrc-url-auth-tarball-path", {
       "package.json": packageJson,
@@ -1793,7 +1802,7 @@ describe.concurrent("//host/ credential lines are matched against the request UR
   });
 
   test("a lockfile recorded against a registry that has since moved still downloads from the old host", async () => {
-    using oldRegistry = mockRegistry("Bearer old-token");
+    using oldRegistry = mockRegistry("Bearer old-token", { secure: true });
     using newRegistry = mockRegistry("Bearer new-token");
     using dir = tempDir("npmrc-url-auth-moved-registry", {
       "package.json": packageJson,
@@ -1981,7 +1990,38 @@ describe.concurrent("//host/ credential lines are matched against the request UR
       ].join("\n"),
     });
 
-    await install(String(dir), ["--ca", tls.cert]);
+    await install(String(dir));
+
+    expect(tarballRequests).toEqual([null]);
+  });
+
+  // The same holds when the registry itself is http: a plaintext registry (or anyone
+  // on its path) must not be able to steer another host's token over plaintext.
+  test("an http tarball on another host gets no .npmrc credentials even from an http registry", async () => {
+    const tarballRequests: (string | null)[] = [];
+    using other = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        tarballRequests.push(req.headers.get("authorization"));
+        return new Response(Bun.file(tgz));
+      },
+    });
+    using registry = mockRegistry("Bearer registry-token", {
+      tarballOrigin: () => `http://127.0.0.1:${other.port}`,
+      publicManifest: true,
+    });
+    using dir = tempDir("npmrc-url-auth-http-other-host", {
+      "package.json": packageJson,
+      ".npmrc": [
+        `registry=${registry.origin}/`,
+        `//${registry.host}/:_authToken=registry-token`,
+        `//127.0.0.1:${other.port}/:_authToken=must-not-leak`,
+        "",
+      ].join("\n"),
+    });
+
+    await install(String(dir));
 
     expect(tarballRequests).toEqual([null]);
   });


### PR DESCRIPTION
Part 2 of 2, split out of #33869. Stacked on #40423. Replaces #38800; takes the dot-segment guard from #40058.

| | |
|---|---|
| #40423 | `_auth` sent as written; no credential left in the request path; npm's key walk for `.npmrc` lines, applied once in the package manager |
| **#40425** | **(this) request-time lookup for tarballs; `--registry` inheritance scoped to the path** |

Fixes #30513.

### What this changes

#40423 applies `.npmrc` lines to every registry the package manager ends up with, whichever source named it. One kind of request still never saw them: a tarball served from another path or host than its registry. GitLab resolves packages through an instance-level path and serves tarballs from a project-level path, so a token keyed to the project path matched nothing (#30513). A registry that moved, with a lockfile still holding the old host's tarball URLs, had the same shape.

Each tarball URL is now matched against #40423's collapsed key list with the same walk: build the URL's own key, then try it and every shorter key down to the bare host. The key comes from the WHATWG serialisation of the URL, so dot segments are resolved and the query string is left out before the walk.

The tarball rule follows npm's `getAuth`, in this order:

1. The deepest `.npmrc` key on the tarball URL's own walk wins.
2. With no such key, the registry's credentials follow the tarball when the tarball is on the registry's origin: same scheme, host and effective port, any path. This is what serves GitLab's instance-level registry, whose tarballs live under a project path with no key of their own.
3. One refinement to step 1: if the tarball resolves to the same key the registry itself resolved to, the registry's credentials win. That key is already reflected in them, behind any bunfig, env or CLI credential.

Two guards sit in front of the `.npmrc` lookup, never in front of the same-origin rule. A tarball path the server would still have to decode (`%2f` splitting a dot segment, `%5c`) is matched against no line, since the walk cannot know what the server resolves it to; on the registry's own origin a dot segment changes nothing about who receives the credential, so the registry's credentials follow such a tarball as they do in npm and on main. An `http://` tarball on another host never gets a `.npmrc` line's credential: the keys carry no scheme, the manifest is registry-controlled, and a plaintext registry must not be able to steer another host's token over plaintext. Over plaintext, a line's credential only goes back to the registry's own origin, which already sees the registry's credentials that way.

`bun pm diff` goes through the same rule instead of its own same-origin check.

| registry | tarball | before | after |
|---|---|---|---|
| `https://host/api/v4/packages/npm/` (instance key) | `https://host/api/v4/projects/123/packages/npm/pkg.tgz` | sent | sent |
| `https://host/npm/team-a/` + `//host/npm/team-b/:_authToken=T` | `https://host/npm/team-b/pkg.tgz` | team-a's token | `Bearer T` |
| `https://host/npm/team-a/` | `https://host/npm/team-a/../team-b/pkg.tgz` | sent | sent |
| `https://host/npm/team-a/` + `//cdn/npm/team-a/:_authToken=T` | `https://cdn/npm/team-a/..%2fteam-b/pkg.tgz` | not sent | not sent |
| `https://host/npm/team-a/` | `https://other-host/pkg.tgz` + `//other-host/:_authToken=T` | not sent | `Bearer T` |

Configured credentials win over userinfo in a `dist.tarball` URL, as in npm.

A registry set by `--registry` or `$NPM_CONFIG_REGISTRY` used to inherit the default registry's token on host match alone, path ignored, so `--registry https://host/npm/team-b/` with a `.npmrc` line for `team-b` still sent `team-a`'s token. Now it inherits only at or under the old registry's path (after WHATWG normalisation, so `/npm/team-a/../team-b/` is a sibling), and only when `.npmrc` has no line specific to the new path; otherwise its own `.npmrc` line applies through #40423's walk. A registry URL written as a bare `$VAR` is only expanded when its scope is built, so its `.npmrc` line is found by that walk too; before, no credential was sent for it.

Not taken from #38800: the "add `//host/:_authToken=<token>` to .npmrc" hint on a 401. Not taken from #40058: path-scoping a registry's token to its own path (it diverges from npm and breaks GitLab's documented instance-level setup), `install.allowedHosts` and `[[install.rewrite]]`.

### Tests

Every case above runs `bun install` against local mock registries (http and https) that record the exact request path and `Authorization` header: the request-time block from #38800, the GitLab instance-level shape, a sibling-path tarball with and without its own line, every dot-segment spelling on the registry's origin and on another host with its own line, `--registry`/env registries on a sibling, child or dot-segmented path, bare `$VAR` registries, `_auth` lines at request time, tarball URLs with a query string, and http tarballs from https and http registries. Each fix was also driven by hand against the debug build and the release binary.
