### PR TITLE
node:http: the implicit header calls an overridden writeHead with one argument

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -3678,7 +3678,9 @@ function callWriteHeadIfObservable(self, headerState, fromEnd) {
     // the way an explicit writeHead() does — the body is already in hand.
     if (fromEnd) self[kImplicitHeaderFromEnd] = true;
     try {
-      self.writeHead(self.statusCode, self.statusMessage);
+      // One argument, like _implicitHeader: _writeHead then applies the
+      // STATUS_CODES default to a falsy res.statusMessage instead of snapshotting "".
+      self.writeHead(self.statusCode);
     } finally {
       if (fromEnd) self[kImplicitHeaderFromEnd] = false;
     }

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2155,6 +2155,19 @@ describe("HTTP Server Security Tests - Advanced", () => {
         res.end();
         return;
       }
+      if (req.url === "/implicit-empty" || req.url === "/implicit-empty-wrapped") {
+        if (req.url === "/implicit-empty-wrapped") {
+          // on-headers/compression wrap writeHead. Node's _implicitHeader calls it
+          // with one argument, so a falsy statusMessage still gets the default.
+          const writeHead = res.writeHead;
+          res.writeHead = function (...args) {
+            return writeHead.apply(this, args);
+          };
+        }
+        res.statusMessage = "";
+        res.end();
+        return;
+      }
       res.setHeader("x-h", "café");
       res.writeHead(200, "OKé");
       res.end();
@@ -2175,6 +2188,9 @@ describe("HTTP Server Security Tests - Advanced", () => {
     expect(lines).toContain("x-h: café");
     // An explicit empty reason phrase is written as-is (only an omitted one defaults).
     expect((await raw("/empty")).toString("latin1").split("\r\n")[0]).toBe("HTTP/1.1 200 ");
+    // statusMessage = "" without writeHead is "omitted": the implicit header defaults it.
+    expect((await raw("/implicit-empty")).toString("latin1").split("\r\n")[0]).toBe("HTTP/1.1 200 OK");
+    expect((await raw("/implicit-empty-wrapped")).toString("latin1").split("\r\n")[0]).toBe("HTTP/1.1 200 OK");
     const wide = (await raw("/wide")).toString("latin1");
     expect(wide.split("\r\n")[0]).toBe("HTTP/1.1 200 OK");
     expect(wide).toEndWith("ERR_INVALID_CHAR");


### PR DESCRIPTION
Follow-up to #40416. This PR targets `claude/wire-encodings`, so it can merge into that branch.

### Problem
- On #40416 at d99befbd75d, `res.statusMessage = ""; res.end()` writes `HTTP/1.1 200 ` when `writeHead` is wrapped. Node writes `HTTP/1.1 200 OK`. Bun 1.4.1 also writes `OK`. `on-headers`, `compression`, and `morgan` wrap `writeHead`, so this is the common Express path.
- The cause is `callWriteHeadIfObservable` (`src/js/node/_http_server.ts:3681`). It calls `self.writeHead(self.statusCode, self.statusMessage)`. The wrapper forwards `""` to `_writeHead`, which stores it as an explicit reason phrase and snapshots it. Native no longer defaults an empty phrase since d99befbd75d, so the empty phrase reaches the wire.

### Fix
- `callWriteHeadIfObservable` calls `self.writeHead(self.statusCode)` with one argument. This matches Node's `_implicitHeader` and Bun's own `ServerResponse.prototype._implicitHeader` (line 3421). `_writeHead` then sees `reason === undefined` and applies the `STATUS_CODES` default to a falsy `statusMessage`.
- An explicit `writeHead(200, "")` is unchanged. It still writes `HTTP/1.1 200 `.
- Verified: `test/js/node/http/node-http.test.ts` (two new routes in the Latin-1 test, `/implicit-empty-wrapped` fails on the base branch). Also the 7 tests from #35017 and the upstream `test-http-{status-message,status-reason-invalid-chars,write-head,write-head-2,response-statuscode,server-response-standalone,outgoing-*}.js`.

### Background
- `_implicitHeader` is the Node path that sends headers when user code calls `end()` or `write()` without `writeHead()`. It calls `this.writeHead(this.statusCode)` with one argument.
- `callWriteHeadIfObservable` is Bun's version of that path. It runs the JS `writeHead` only when user code replaced `writeHead` or `_implicitHeader`. Otherwise the native handle renders the status line directly.
- In `_writeHead`, a string `reason` is stored as-is. A non-string `reason` means the default applies when `statusMessage` is falsy.

<details><summary>Notes</summary>

Wire output of `res.statusMessage = ""; res.end("x")` with `ServerResponse.prototype.writeHead` wrapped by a pass-through function:

| runtime | status line |
|---|---|
| node v26.3.0 | `HTTP/1.1 200 OK` |
| bun 1.4.1 | `HTTP/1.1 200 OK` |
| #40416 at d99befbd75d | `HTTP/1.1 200 ` |
| this PR | `HTTP/1.1 200 OK` |

Without the wrapper, d99befbd75d already writes `OK`: the four `handle.writeHead*` call sites pass `this.statusMessage || undefined`. The wrapped path bypasses that because the snapshot `kSnapshotStatusMessage` is `""` and `?? ` does not fall through on `""`.

Other suites run on the debug build: `test/regression/issue/19111.test.ts`, `node-http-transfer-encoding`, `early-hints-crlf-injection`, `numeric-header`, the express `express`, `res.send`, `res.redirect` suites (74 pass). The express test `should respond with 404 when wrong method is used` fails on the debug build with and without this change (a 500 ms `AbortSignal.timeout`) and passes on the release build. `node-http-nested-cork.test.ts` hits its 5 s timeout on this debug build with and without this change.

</details>
