### PR TITLE
node:crypto: skip DH_check for the RFC 3526 well-known groups

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1280,8 +1280,25 @@ bool EqualNoCase(const WTF::StringView a, const WTF::StringView b)
     return a.startsWithIgnoringASCIICase(b);
 }
 
+bool MatchesPrime(const BIGNUM* p, BIGNUM* (*getPrime)(BIGNUM*))
+{
+    BignumPointer known(getPrime(nullptr));
+    return known && BN_cmp(p, known.get()) == 0;
+}
+
+// BoringSSL exposes this group as a DH, not as a BIGNUM getter.
+bool IsFfdhe2048(const BIGNUM* p)
+{
+    DHPointer known(DH_get_rfc7919_2048());
+    if (!known) return false;
+    const BIGNUM* knownP = nullptr;
+    DH_get0_pqg(known.get(), &knownP, nullptr, nullptr);
+    return BN_cmp(p, knownP) == 0;
+}
+
 // OpenSSL's DH_check() skips its primality tests for the built-in named groups
-// (DH_get_nid() != NID_undef). BoringSSL's does not, so check() does it here.
+// (DH_get_nid() != NID_undef). BoringSSL's does not, so check() does it here for
+// the named groups BoringSSL ships: RFC 3526 modp1536..8192 and RFC 7919 ffdhe2048.
 bool IsWellKnownGroup(const DH* dh)
 {
     const BIGNUM* p = nullptr;
@@ -1291,32 +1308,22 @@ bool IsWellKnownGroup(const DH* dh)
     if (p == nullptr || q != nullptr || g == nullptr) return false;
     if (!BN_is_word(g, DH_GENERATOR_2)) return false;
 
-    BIGNUM* (*getPrime)(BIGNUM*) = nullptr;
     switch (BN_num_bits(p)) {
     case 1536:
-        getPrime = BN_get_rfc3526_prime_1536;
-        break;
+        return MatchesPrime(p, BN_get_rfc3526_prime_1536);
     case 2048:
-        getPrime = BN_get_rfc3526_prime_2048;
-        break;
+        return MatchesPrime(p, BN_get_rfc3526_prime_2048) || IsFfdhe2048(p);
     case 3072:
-        getPrime = BN_get_rfc3526_prime_3072;
-        break;
+        return MatchesPrime(p, BN_get_rfc3526_prime_3072);
     case 4096:
-        getPrime = BN_get_rfc3526_prime_4096;
-        break;
+        return MatchesPrime(p, BN_get_rfc3526_prime_4096);
     case 6144:
-        getPrime = BN_get_rfc3526_prime_6144;
-        break;
+        return MatchesPrime(p, BN_get_rfc3526_prime_6144);
     case 8192:
-        getPrime = BN_get_rfc3526_prime_8192;
-        break;
+        return MatchesPrime(p, BN_get_rfc3526_prime_8192);
     default:
         return false;
     }
-
-    BignumPointer known(getPrime(nullptr));
-    return known && BN_cmp(p, known.get()) == 0;
 }
 } // namespace
 

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1280,6 +1280,7 @@ bool EqualNoCase(const WTF::StringView a, const WTF::StringView b)
     return a.startsWithIgnoringASCIICase(b);
 }
 
+#ifdef OPENSSL_IS_BORINGSSL
 bool MatchesPrime(const BIGNUM* p, BIGNUM* (*getPrime)(BIGNUM*))
 {
     BignumPointer known(getPrime(nullptr));
@@ -1325,6 +1326,7 @@ bool IsWellKnownGroup(const DH* dh)
         return false;
     }
 }
+#endif // OPENSSL_IS_BORINGSSL
 } // namespace
 
 DHPointer::DHPointer(DH* dh)
@@ -1437,7 +1439,9 @@ DHPointer::CheckResult DHPointer::check()
 {
     ClearErrorOnReturn clearErrorOnReturn;
     if (!dh_) return DHPointer::CheckResult::NONE;
+#ifdef OPENSSL_IS_BORINGSSL
     if (IsWellKnownGroup(dh_.get())) return DHPointer::CheckResult::NONE;
+#endif
     int codes = 0;
     if (DH_check(dh_.get(), &codes) != 1)
         return DHPointer::CheckResult::CHECK_FAILED;

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1280,12 +1280,8 @@ bool EqualNoCase(const WTF::StringView a, const WTF::StringView b)
     return a.startsWithIgnoringASCIICase(b);
 }
 
-// OpenSSL's DH_check() returns at once, with no flags set, when (p, q, g) is one
-// of its built-in named groups (DH_get_nid() != NID_undef). BoringSSL's DH_check()
-// has no such shortcut: it runs 64 Miller-Rabin rounds on p and again on
-// (p - 1) / 2, which takes seconds for the larger groups (26 s for modp18).
-// These are the named groups BoringSSL ships: the RFC 3526 MODP primes with
-// generator 2.
+// OpenSSL's DH_check() skips its primality tests for the built-in named groups
+// (DH_get_nid() != NID_undef). BoringSSL's does not, so check() does it here.
 bool IsWellKnownGroup(const DH* dh)
 {
     const BIGNUM* p = nullptr;

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1279,6 +1279,49 @@ bool EqualNoCase(const WTF::StringView a, const WTF::StringView b)
     if (a.length() != b.length()) return false;
     return a.startsWithIgnoringASCIICase(b);
 }
+
+// OpenSSL's DH_check() returns at once, with no flags set, when (p, q, g) is one
+// of its built-in named groups (DH_get_nid() != NID_undef). BoringSSL's DH_check()
+// has no such shortcut: it runs 64 Miller-Rabin rounds on p and again on
+// (p - 1) / 2, which takes seconds for the larger groups (26 s for modp18).
+// These are the named groups BoringSSL ships: the RFC 3526 MODP primes with
+// generator 2.
+bool IsWellKnownGroup(const DH* dh)
+{
+    const BIGNUM* p = nullptr;
+    const BIGNUM* q = nullptr;
+    const BIGNUM* g = nullptr;
+    DH_get0_pqg(dh, &p, &q, &g);
+    if (p == nullptr || q != nullptr || g == nullptr) return false;
+    if (!BN_is_word(g, DH_GENERATOR_2)) return false;
+
+    BIGNUM* (*getPrime)(BIGNUM*) = nullptr;
+    switch (BN_num_bits(p)) {
+    case 1536:
+        getPrime = BN_get_rfc3526_prime_1536;
+        break;
+    case 2048:
+        getPrime = BN_get_rfc3526_prime_2048;
+        break;
+    case 3072:
+        getPrime = BN_get_rfc3526_prime_3072;
+        break;
+    case 4096:
+        getPrime = BN_get_rfc3526_prime_4096;
+        break;
+    case 6144:
+        getPrime = BN_get_rfc3526_prime_6144;
+        break;
+    case 8192:
+        getPrime = BN_get_rfc3526_prime_8192;
+        break;
+    default:
+        return false;
+    }
+
+    BignumPointer known(getPrime(nullptr));
+    return known && BN_cmp(p, known.get()) == 0;
+}
 } // namespace
 
 DHPointer::DHPointer(DH* dh)
@@ -1391,6 +1434,7 @@ DHPointer::CheckResult DHPointer::check()
 {
     ClearErrorOnReturn clearErrorOnReturn;
     if (!dh_) return DHPointer::CheckResult::NONE;
+    if (IsWellKnownGroup(dh_.get())) return DHPointer::CheckResult::NONE;
     int codes = 0;
     if (DH_check(dh_.get(), &codes) != 1)
         return DHPointer::CheckResult::CHECK_FAILED;

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1300,7 +1300,7 @@ bool IsFfdhe2048(const BIGNUM* p)
 // OpenSSL's DH_check() skips its primality tests for the built-in named groups
 // (DH_get_nid() != NID_undef). BoringSSL's does not, so check() does it here for
 // the named groups BoringSSL ships: RFC 3526 modp1536..8192 and RFC 7919 ffdhe2048.
-bool IsWellKnownGroup(const DH* dh)
+bool IsNamedGroup(const DH* dh)
 {
     const BIGNUM* p = nullptr;
     const BIGNUM* q = nullptr;
@@ -1440,7 +1440,7 @@ DHPointer::CheckResult DHPointer::check()
     ClearErrorOnReturn clearErrorOnReturn;
     if (!dh_) return DHPointer::CheckResult::NONE;
 #ifdef OPENSSL_IS_BORINGSSL
-    if (IsWellKnownGroup(dh_.get())) return DHPointer::CheckResult::NONE;
+    if (IsNamedGroup(dh_.get())) return DHPointer::CheckResult::NONE;
 #endif
     int codes = 0;
     if (DH_check(dh_.get(), &codes) != 1)

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -720,6 +720,24 @@ describe("DiffieHellman", () => {
       expect(elapsed).toBeLessThan(5_000);
     });
 
+    // RFC 7919 appendix A.1. Node has no group name for it, so it only arrives
+    // as a prime. It is 2048 bits wide, like modp14, so it also shows that the
+    // match is on the value and not on the width alone.
+    it("recognizes ffdhe2048", () => {
+      const ffdhe2048 =
+        "FFFFFFFFFFFFFFFFADF85458A2BB4A9AAFDC5620273D3CF1D8B9C583CE2D3695" +
+        "A9E13641146433FBCC939DCE249B3EF97D2FE363630C75D8F681B202AEC4617A" +
+        "D3DF1ED5D5FD65612433F51F5F066ED0856365553DED1AF3B557135E7F57C935" +
+        "984F0C70E0E68B77E2A689DAF3EFE8721DF158A136ADE73530ACCA4F483A797A" +
+        "BC0AB182B324FB61D108A94BB2C8E3FBB96ADAB760D7F4681D4F42A3DE394DF4" +
+        "AE56EDE76372BB190B07A7C8EE0A6D709E02FCE1CDF7E2ECC03404CD28342F61" +
+        "9172FE9CE98583FF8E4F1232EEF28183C3FE3B1B4C6FAD733BB5FCBC2EC22005" +
+        "C58EF1837D1683B2C6F34A26C1B2EFFA886B423861285C97FFFFFFFFFFFFFFFF";
+      const dh = crypto.createDiffieHellman(ffdhe2048, "hex", 2);
+      expect(dh.getPrime().length).toBe(crypto.getDiffieHellman("modp14").getPrime().length);
+      expect(dh.verifyError).toBe(0);
+    });
+
     it("matches the prime by value, not by length", () => {
       const p = crypto.getDiffieHellman("modp5").getPrime();
       // Flip bit 1 so p stays odd and keeps its width, but is no longer prime.

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -689,6 +689,53 @@ describe("DiffieHellman", () => {
       value: expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
     });
   });
+
+  // OpenSSL's DH_check() returns at once, with no flags set, for its built-in
+  // named groups. So Node constructs every modp group in microseconds with
+  // verifyError 0. BoringSSL's DH_check() has no such shortcut: it runs 64
+  // Miller-Rabin rounds on p and on (p - 1) / 2, about 26 s for the 8192-bit
+  // group, and its generator heuristic then reports DH_NOT_SUITABLE_GENERATOR.
+  describe("well-known groups", () => {
+    const { DH_CHECK_P_NOT_PRIME } = crypto.constants;
+
+    it.each(["modp5", "modp14", "modp15", "modp16", "modp17", "modp18"])(
+      "getDiffieHellman(%s) reports verifyError 0",
+      group => {
+        expect(crypto.getDiffieHellman(group).verifyError).toBe(0);
+      },
+    );
+
+    it("constructs the 8192-bit group without running the primality tests", () => {
+      const start = performance.now();
+      const named = crypto.getDiffieHellman("modp18");
+      const group = new crypto.DiffieHellmanGroup("modp18");
+      const fromPrime = crypto.createDiffieHellman(named.getPrime(), 2);
+      const fromBufferGenerator = crypto.createDiffieHellman(named.getPrime(), Buffer.from([2]));
+      const elapsed = performance.now() - start;
+
+      expect([named.verifyError, group.verifyError, fromPrime.verifyError, fromBufferGenerator.verifyError]).toEqual([
+        0, 0, 0, 0,
+      ]);
+      // Without the shortcut the four constructions above take about 107 s.
+      expect(elapsed).toBeLessThan(5_000);
+    });
+
+    it("matches the prime by value, not by length", () => {
+      const p = crypto.getDiffieHellman("modp5").getPrime();
+      // Flip bit 1 so p stays odd and keeps its width, but is no longer prime.
+      p[p.length - 1] ^= 0x02;
+      const dh = crypto.createDiffieHellman(p, 2);
+      expect(dh.verifyError & DH_CHECK_P_NOT_PRIME).toBe(DH_CHECK_P_NOT_PRIME);
+    });
+
+    it("only skips the check for generator 2", () => {
+      const p = crypto.getDiffieHellman("modp5").getPrime();
+      const pMinusOne = Buffer.from(p);
+      pMinusOne[pMinusOne.length - 1] -= 1;
+      // g = p - 1 is outside the valid range, which the full check reports.
+      expect(crypto.createDiffieHellman(p, pMinusOne).verifyError).not.toBe(0);
+    });
+  });
 });
 
 // An integer-valued Number is not always an int32 JSValue. An element of an array that
@@ -995,11 +1042,7 @@ it("verifyError should not be on the prototype of DiffieHellman and DiffieHellma
   const dhg = crypto.createDiffieHellmanGroup("modp5");
   expect("verifyError" in crypto.DiffieHellmanGroup.prototype).toBeFalse();
   expect("verifyError" in dhg).toBeTrue();
-
-  // boringssl seems to set DH_NOT_SUITABLE_GENERATOR for both
-  // DH_GENERATOR_2 and DH_GENERATOR_5 if not using
-  // DH_generate_parameters_ex
-  expect(dhg.verifyError).toBe(8);
+  expect(dhg.verifyError).toBe(0);
 });
 it("cipher.setAAD should not throw if encoding or plaintextLength is undefined #18700", () => {
   const key = crypto.randomBytes(32);


### PR DESCRIPTION
### Problem
- `crypto.getDiffieHellman("modp18")` takes about 26 s since Bun 1.4.0 (modp14: 0.5 s, modp16: 3.4 s, modp17: 11 s). Node v26.3.0 and Bun 1.3.14 take 0 ms. `new DiffieHellmanGroup(name)` and `createDiffieHellman(prime, 2)` with a well-known prime pay the same cost, and all of them report `verifyError` 8 where Node reports 0.
- #32623 made both constructors call `DHPointer::check()` eagerly, like Node. `check()` (`src/jsc/bindings/ncrypto.cpp`) calls BoringSSL's `DH_check()`, which runs 64 Miller-Rabin rounds on p and again on (p - 1) / 2. OpenSSL's `DH_check()` (`crypto/dh/dh_check.c`) returns at once with no flags when `DH_get_nid()` recognizes the group. BoringSSL has no such shortcut.

### Fix
- `DHPointer::check()` compares p against the named groups BoringSSL ships when q is absent and g is 2: the six RFC 3526 primes (`BN_get_rfc3526_prime_1536` to `_8192`) and RFC 7919 ffdhe2048 (`DH_get_rfc7919_2048()`). On a match it returns `CheckResult::NONE` without calling `DH_check()`.
- This is the same shortcut OpenSSL takes, for groups in its own named-group table. The result, `verifyError` 0, is Node's value for every one of them.
- The existing assertion `verifyError === 8` for modp5 in `node-crypto.test.js` changes to 0. That 8 was BoringSSL's `p % 24 == 11` heuristic, which every RFC 3526 prime trips.
- Verified: `test/js/node/crypto/node-crypto.test.js` (new `well-known groups` block, 8 of 10 fail on 1.4.1). Also the whole file (222 pass), the 13 vendored `test-crypto-dh*.js`, `test-tls-dhe.js`, and `test-tls-dhparam-auto-boringssl.js`.

### Background
- `DH_check()` validates DH parameters (p, g) and returns a bitmask of problems. Node exposes that bitmask as `verifyError`. Since #32623 Bun computes it in the constructor, like Node, so its cost is paid on every construction.
- RFC 3526 defines the MODP groups modp5 and modp14 to modp18 (1536 to 8192 bits). RFC 7919 defines the ffdhe groups used by TLS 1.3. All are fixed, published safe primes with generator 2. Their primality is known, which is why OpenSSL does not test it.
- `BN_is_prime_ex` with `BN_prime_checks_for_validation` is 64 rounds of Miller-Rabin. Each round is one modular exponentiation of the full modulus width, so the cost grows fast with the group size.

<details><summary>Notes</summary>

Measured on bun 1.4.1, linux x64, then with this branch (debug build):

```
                                    1.4.1            fixed / node v26.3.0
getDiffieHellman(modp5)            265 ms, vE 8      0 ms, vE 0
getDiffieHellman(modp14)           615 ms, vE 8      0 ms, vE 0
getDiffieHellman(modp15)          1985 ms, vE 8      0 ms, vE 0
getDiffieHellman(modp16)          4502 ms, vE 8      0 ms, vE 0
getDiffieHellman(modp17)         11459 ms, vE 8      0 ms, vE 0
getDiffieHellman(modp18)         26660 ms, vE 8      0 ms, vE 0
createDiffieHellman(p18, 2)      26 s, vE 8          2 ms, vE 0
new DiffieHellmanGroup("modp18") 26 s, vE 8          1 ms, vE 0
createDiffieHellman(ffdhe2048, 2) 460 ms, vE 8       4 ms, vE 0
```

Cases that must not take the shortcut, and do not:

```
                                            fixed    node
modp5 prime with bit 1 flipped, g = 2       vE 9     vE 1   (both set DH_CHECK_P_NOT_PRIME)
modp5 prime, g = p - 1                      vE 4     vE 8   (both non-zero)
```

The residual differences (9 vs 1, 4 vs 8, and g = 3 or 5 on a safe prime) are BoringSSL's generator heuristics, which OpenSSL 3 removed. #33522 addresses those by porting `DH_check_params()`. It runs the full primality tests for every group, so it does not fix the time. The two changes compose: the shortcut goes first, the ported check handles everything else. #34390 adds modulus-size bounds to the same function and does not touch the named-group path either.

OpenSSL's named-group table also holds ffdhe3072 to ffdhe8192 and the RFC 5114 groups. BoringSSL does not ship those primes, so this change does not cover them. `getDiffieHellman()` cannot produce them (neither can Node's), and a user-supplied prime from one of them keeps the behavior it had before this change: the full check, and BoringSSL's flags.

ffdhe2048 was added after a self-review of the first version: it is the one named group BoringSSL ships that the RFC 3526 getters miss. Its prime in the test comes from RFC 7919 appendix A.1 and matches the `kFFDHE2048Data` words in `vendor/boringssl/crypto/fipsmodule/dh/dh.cc.inc`. Node recognizes it (verifyError 0 in 0.2 ms), and it shares its width with modp14, so it also covers the two-candidates-per-width case.

The shortcut sits inside `#ifdef OPENSSL_IS_BORINGSSL`, like the other BoringSSL-specific blocks in this file. Under OpenSSL, `DH_check()` takes the same shortcut itself, and `DH_get_rfc7919_2048()` does not exist there.

`DHPointer::New()` always sets q to null, and no JS path sets q. A DH with q falls through to `DH_check()` unchanged. The peer public key validation (`DHPointer::checkPublicKey()` in `computeSecret`, and `DH_check_pub_key()` inside BoringSSL's `DH_compute_key()`) is a separate function and is not touched.

The `p - 1` generator test runs the full check on the 1536-bit group (about 270 ms in a debug build). The existing tests in the same file already pay that cost for their wide-generator cases.

#41470 proposed the same shortcut (RFC 3526 primes only, g = 2) as a `DHPointer::isNamedGroup()` method. This PR covers that set plus ffdhe2048, so #41470 is closed in favor of this one. Its helper name is adopted here: the anonymous-namespace helper is `IsNamedGroup`, the term OpenSSL uses for groups that `DH_get_nid()` recognizes.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.3 (f42e98025)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.49ms]
(pass) crypto.randomInt should return a number [2.26ms]
(pass) crypto.randomInt with no arguments [3.89ms]
(pass) crypto.randomInt with one argument [2.31ms]
(pass) crypto.randomInt with a callback [40.33ms]
(pass) createHash > rsa-md5 - "Hello World" [8.58ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.26ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.84ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.82ms]
(pass) createHash > rsa-sha1 - "Hello World" [8.08ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.37ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.63ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.64ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.35ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.83ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.51ms]
(pass) createH
... (truncated)

release without fix: 9 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.12ms]
(pass) crypto.randomInt should return a number [0.03ms]
(pass) crypto.randomInt with no arguments [0.06ms]
(pass) crypto.randomInt with one argument [0.02ms]
(pass) crypto.randomInt with a callback [0.56ms]
(pass) createHash > rsa-md5 - "Hello World" [0.14ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.05ms]
(pass) createHash > rsa-ripemd160 - "Hello World"
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary
(pass) createHash > rsa-sha1 - "Hello World" [0.08ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.03ms]
(pass) createHash > rsa-sha1-2 - "Hello World"
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary
(pass) createHash > rsa-sha224 - "Hello World" [0.03ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary
(pass) createHash > rsa-sha256 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary
(pass) createHash > rsa-sha3-224 - "Hello World"
(pass) createHash > rsa-sha3-224 - "Hello World" -> binary
(pass) createHash > rsa-sha3-256 - "Hello World"
(pass) cr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.3 (f42e98025)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.27ms]
(pass) crypto.randomInt should return a number [2.35ms]
(pass) crypto.randomInt with no arguments [4.32ms]
(pass) crypto.randomInt with one argument [2.31ms]
(pass) crypto.randomInt with a callback [39.14ms]
(pass) createHash > rsa-md5 - "Hello World" [8.24ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.52ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.99ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [1.41ms]
(pass) createHash > rsa-sha1 - "Hello World" [7.96ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.41ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.60ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.65ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.34ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.83ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.53ms]
(pass) createH
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 800ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] cxx obj/codegen/GeneratedSocketConfigHandlers.cpp.o
[2/20] cxx obj/codegen/JSSink.cpp.o
[3/20] cxx obj/codegen/GeneratedSocketConfigBinaryType.cpp.o
[4/20] cxx obj/codegen/GeneratedBindings.cpp.o
[5/20] cxx obj/codegen/GeneratedSocketConfig.cpp.o
[6/20] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[7/20] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[8/20] cxx obj/codegen/GeneratedSSLConfig.cpp.o
[9/20] cxx obj/codegen/GeneratedFakeTimersConfig.cpp.o
[10/20] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[11/20] gen cpp.rs (cppbind)
[11/20] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_in
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ncrypto.cpp            | 51 +++++++++++++++++++++++
 test/js/node/crypto/node-crypto.test.js | 71 ++++++++++++++++++++++++++++++---
 2 files changed, 117 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/bindings/ncrypto.cpp                 6      8     18
test/js/node/crypto/node-crypto.test.js      3      4     18
```

</details>

**root cause** · written by the author bot

The regression came from making `constructDiffieHellman()` and the DiffieHellmanGroup constructor call `DHPointer::check()` eagerly, which invokes BoringSSL's `DH_check()` and its 64-round Miller-Rabin primality tests on both p and (p-1)/2, costing up to 26 seconds for the 8192-bit RFC 3526 group because BoringSSL, unlike OpenSSL, has no well-known-group shortcut. The fix adds an `IsNamedGroup` check in `DHPointer::check()` that, when q is null and g equals 2, compares p exactly against BoringSSL's built-in RFC 3526 and RFC 7919 primes and returns `CheckResult::NONE` on a match, mirroring O…

<!-- robobun:evidence:end -->