### PR TITLE
build: in-process task engine behind --runner=ts, compile steps as native tasks

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -23,6 +23,7 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { declareAll } from "./build/bridge.ts";
 import {
   canTraceOrderFile,
   downloadArtifacts,
@@ -45,9 +46,8 @@ import {
 } from "./build/ci.ts";
 import { formatConfig, formatConfigUnchanged, type PartialConfig } from "./build/config.ts";
 import { configure, type ConfigureInput, type ConfigureResult } from "./build/configure.ts";
-import { BuildError } from "./build/error.ts";
-import { declareAll } from "./build/bridge.ts";
 import { Engine, type EngineOptions } from "./build/engine.ts";
+import { BuildError } from "./build/error.ts";
 import { STREAM_FD } from "./build/stream.ts";
 import { interactive, nameColor, status } from "./build/tty.ts";
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -315,7 +315,10 @@ async function runExecutor(
     const task = engine.lookup(name);
     if (task === undefined) {
       throw new BuildError(`unknown target '${name}'`, {
-        hint: `Known targets: ${engine.aliasNames.filter(a => !a.includes("/")).sort().join(", ")}`,
+        hint: `Known targets: ${engine.aliasNames
+          .filter(a => !a.includes("/"))
+          .sort()
+          .join(", ")}`,
       });
     }
     return task;
@@ -345,7 +348,9 @@ function runNinjaLocal(result: ConfigureResult, args: CliArgs, quiet: boolean): 
   // index STREAM_FD dups it there for the whole ninja process tree.
   //
   // In quiet mode, capture to buffers instead — dumped only on failure.
-  const stdio: (number | "inherit" | "pipe")[] = quiet ? ["inherit", "pipe", "pipe"] : ["inherit", "inherit", "inherit"];
+  const stdio: (number | "inherit" | "pipe")[] = quiet
+    ? ["inherit", "pipe", "pipe"]
+    : ["inherit", "inherit", "inherit"];
   if (!quiet && interactive) {
     stdio[STREAM_FD] = 2;
   }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -46,6 +46,8 @@ import {
 import { formatConfig, formatConfigUnchanged, type PartialConfig } from "./build/config.ts";
 import { configure, type ConfigureInput, type ConfigureResult } from "./build/configure.ts";
 import { BuildError } from "./build/error.ts";
+import { declareAll } from "./build/bridge.ts";
+import { Engine, type EngineOptions } from "./build/engine.ts";
 import { STREAM_FD } from "./build/stream.ts";
 import { interactive, nameColor, status } from "./build/tty.ts";
 
@@ -95,7 +97,6 @@ async function main(): Promise<void> {
     ? loadConfigFile(args.configFile)
     : { profile: args.profile, overrides: args.overrides };
 
-  const ninjaArgv = (cfg: { buildDir: string }) => ["-C", cfg.buildDir, ...args.ninjaArgs, ...args.ninjaTargets];
   // GNU-style include-path vars (CPATH, C_INCLUDE_PATH, CPLUS_INCLUDE_PATH,
   // OBJC_INCLUDE_PATH) apply to every clang invocation regardless of
   // --target. The CI build containers set them for the *host* gcc toolchain
@@ -104,16 +105,6 @@ async function main(): Promise<void> {
   // found"). Scrub them for Windows cross builds — they are host-targeted by
   // definition. Native Windows builds (INCLUDE/LIB from the VS dev shell) and
   // every other target keep the environment as provisioned.
-  const ninjaEnv = (cfg: { windows: boolean; host: { os: string } }, env: Record<string, string>) => {
-    const merged: NodeJS.ProcessEnv = { ...process.env, ...env };
-    if (cfg.windows && cfg.host.os !== "windows") {
-      for (const name of ["CPATH", "C_INCLUDE_PATH", "CPLUS_INCLUDE_PATH", "OBJC_INCLUDE_PATH"]) {
-        delete merged[name];
-      }
-    }
-    return merged;
-  };
-
   if (isCI) {
     // CI: machine/env dump + collapsible groups + annotation-on-failure.
     printEnvironment();
@@ -140,10 +131,12 @@ async function main(): Promise<void> {
     let inherited = false;
 
     const runNinja = (targets: string[] = args.ninjaTargets) =>
-      spawnWithAnnotations("ninja", ["-C", result.cfg.buildDir, ...args.ninjaArgs, ...targets], {
-        label: "ninja",
-        env: ninjaEnv(result.cfg, result.env),
-      });
+      args.runner === "ts"
+        ? runExecutor(result, targets, args, { display: "plain" })
+        : spawnWithAnnotations("ninja", ["-C", result.cfg.buildDir, ...args.ninjaArgs, ...targets], {
+            label: "ninja",
+            env: buildEnv(result.cfg, result.env),
+          });
 
     // rust-and-link: build libbun_runtime.a first so cargo overlaps with the
     // sibling build-cpp job, THEN poll for build-cpp's outcome + download
@@ -236,43 +229,16 @@ async function main(): Promise<void> {
       }
       return;
     }
-    // FD 3 sideband — only when interactive. stream.ts (wrapping deps +
-    // cargo) writes live output there, bypassing ninja's per-job buffering.
-    // A human watching a terminal wants to see cmake configure spew and
-    // cargo build progress in real time. A log file (CI) doesn't —
-    // that live output is noise (hundreds of `-- Looking for header.h`
-    // lines from cmake). When FD 3 isn't set up, stream.ts falls back to
-    // stdout which ninja buffers per-job: deps stay quiet until they
-    // finish or fail, failure logs stay compact.
-    //
-    // Ninja's subprocess spawn only touches FDs 0-2; higher fds inherit
-    // through posix_spawn/CreateProcessA. Passing our stderr fd (2) at
-    // index STREAM_FD dups it there for the whole ninja process tree.
-    //
-    // In quiet mode, capture to buffers instead — dumped only on failure.
-    const stdio: (number | "inherit" | "pipe")[] = quiet
-      ? ["inherit", "pipe", "pipe"]
-      : ["inherit", "inherit", "inherit"];
-    if (!quiet && interactive) {
-      stdio[STREAM_FD] = 2;
-    }
-    const ninja = spawnSync("ninja", ninjaArgv(result.cfg), {
-      stdio,
-      env: ninjaEnv(result.cfg, result.env),
-      // cargo's compile output (now part of the ninja graph via emitRust) can
-      // be tens of MB on a cold build; the default 1 MB maxBuffer ENOBUFSes.
-      maxBuffer: 1024 * 1024 * 1024,
-    });
-    if (ninja.error) {
-      process.stderr.write(`Failed to exec ninja: ${ninja.error.message}\nIs ninja in your PATH?\n`);
-      process.exit(127);
-    }
-    if (ninja.status !== 0) {
-      if (quiet) {
-        if (ninja.stdout) process.stderr.write(ninja.stdout);
-        if (ninja.stderr) process.stderr.write(ninja.stderr);
-      }
-      process.exit(ninja.status ?? 1);
+
+    if (args.runner === "ts") {
+      // In-process executor. Same graph, no ninja binary. Console jobs and
+      // stream.ts (via fd 3) write to the terminal directly, as with ninja.
+      await runExecutor(result, args.ninjaTargets, args, {
+        display: quiet ? "quiet" : interactive ? "tty" : "plain",
+        streamFd: !quiet && interactive ? 2 : undefined,
+      });
+    } else {
+      runNinjaLocal(result, args, quiet);
     }
 
     if (args.execArgs.length === 0) {
@@ -305,6 +271,101 @@ async function main(): Promise<void> {
       return;
     }
     process.exit(child.status ?? 0);
+  }
+}
+
+/** The environment for build commands: ours plus ccache's, minus host include paths on Windows cross builds. */
+function buildEnv(cfg: { windows: boolean; host: { os: string } }, env: Record<string, string>): NodeJS.ProcessEnv {
+  const merged: NodeJS.ProcessEnv = { ...process.env, ...env };
+  if (cfg.windows && cfg.host.os !== "windows") {
+    for (const name of ["CPATH", "C_INCLUDE_PATH", "CPLUS_INCLUDE_PATH", "OBJC_INCLUDE_PATH"]) {
+      delete merged[name];
+    }
+  }
+  return merged;
+}
+
+/**
+ * Run the build in process (`--runner=ts`): declare every recorded task on the
+ * engine and run the requested targets. Exits the process on failure, like the
+ * ninja paths do.
+ */
+async function runExecutor(
+  result: ConfigureResult,
+  targets: string[],
+  args: CliArgs,
+  opts: Pick<EngineOptions, "display" | "streamFd">,
+): Promise<void> {
+  const start = Date.now();
+  const engine = new Engine({
+    buildDir: result.cfg.buildDir,
+    hostOs: result.cfg.host.os,
+    env: buildEnv(result.cfg, result.env),
+    jobs: args.jobs,
+    keepGoing: args.keepGoing,
+    verbose: args.verbose,
+    dryRun: args.dryRun,
+    explain: args.explain,
+    pools: Object.fromEntries(result.graph.poolDepths),
+    ...opts,
+  });
+  declareAll(engine, result.graph, result.cfg.host.os === "windows");
+  const names = targets.length > 0 ? targets : [...result.graph.defaultTargets];
+  const wanted = names.map(name => {
+    const task = engine.lookup(name);
+    if (task === undefined) {
+      throw new BuildError(`unknown target '${name}'`, {
+        hint: `Known targets: ${engine.aliasNames.filter(a => !a.includes("/")).sort().join(", ")}`,
+      });
+    }
+    return task;
+  });
+  const outcome = await engine.run(wanted);
+  if (isCI) {
+    const elapsed = Date.now() - start;
+    const took = elapsed > 60000 ? `${(elapsed / 60000).toFixed(2)} minutes` : `${(elapsed / 1000).toFixed(2)} seconds`;
+    console.log(`build took ${took}`);
+  }
+  if (!outcome.ok) process.exit(outcome.interrupted ? 130 : 1);
+}
+
+/** Spawn ninja for a local (non-CI) build. Exits the process on failure. */
+function runNinjaLocal(result: ConfigureResult, args: CliArgs, quiet: boolean): void {
+  // FD 3 sideband — only when interactive. stream.ts (wrapping deps +
+  // cargo) writes live output there, bypassing ninja's per-job buffering.
+  // A human watching a terminal wants to see cmake configure spew and
+  // cargo build progress in real time. A log file (CI) doesn't —
+  // that live output is noise (hundreds of `-- Looking for header.h`
+  // lines from cmake). When FD 3 isn't set up, stream.ts falls back to
+  // stdout which ninja buffers per-job: deps stay quiet until they
+  // finish or fail, failure logs stay compact.
+  //
+  // Ninja's subprocess spawn only touches FDs 0-2; higher fds inherit
+  // through posix_spawn/CreateProcessA. Passing our stderr fd (2) at
+  // index STREAM_FD dups it there for the whole ninja process tree.
+  //
+  // In quiet mode, capture to buffers instead — dumped only on failure.
+  const stdio: (number | "inherit" | "pipe")[] = quiet ? ["inherit", "pipe", "pipe"] : ["inherit", "inherit", "inherit"];
+  if (!quiet && interactive) {
+    stdio[STREAM_FD] = 2;
+  }
+  const ninja = spawnSync("ninja", ["-C", result.cfg.buildDir, ...args.ninjaArgs, ...args.ninjaTargets], {
+    stdio,
+    env: buildEnv(result.cfg, result.env),
+    // cargo's compile output (now part of the ninja graph via emitRust) can
+    // be tens of MB on a cold build; the default 1 MB maxBuffer ENOBUFSes.
+    maxBuffer: 1024 * 1024 * 1024,
+  });
+  if (ninja.error) {
+    process.stderr.write(`Failed to exec ninja: ${ninja.error.message}\nIs ninja in your PATH?\n`);
+    process.exit(127);
+  }
+  if (ninja.status !== 0) {
+    if (quiet) {
+      if (ninja.stdout) process.stderr.write(ninja.stdout);
+      if (ninja.stderr) process.stderr.write(ninja.stderr);
+    }
+    process.exit(ninja.status ?? 1);
   }
 }
 
@@ -401,6 +462,18 @@ interface CliArgs {
    * Mutually exclusive with --profile/overrides.
    */
   configFile: string | undefined;
+  /** Which program runs the graph: the in-process engine, or ninja. */
+  runner: "ninja" | "ts";
+  /** -j<N>: parallel jobs. undefined = engine default (cores + 2). */
+  jobs: number | undefined;
+  /** -k<N>: failures tolerated before stopping. undefined = 1. */
+  keepGoing: number | undefined;
+  /** -v: print commands. */
+  verbose: boolean;
+  /** -n: plan only. */
+  dryRun: boolean;
+  /** --explain: say why each task runs. */
+  explain: boolean;
 }
 
 /**
@@ -428,6 +501,12 @@ function parseArgs(argv: string[]): CliArgs {
   let quiet = false;
   let configFile: string | undefined;
   let inExec = false;
+  let runner: "ninja" | "ts" = process.env.BUN_BUILD_RUNNER === "ts" ? "ts" : "ninja";
+  let jobs: number | undefined;
+  let keepGoing: number | undefined;
+  let verbose = false;
+  let dryRun = false;
+  let explain = false;
 
   // PartialConfig fields that are BOOLEANS. Used for value coercion.
   // Not exhaustive — add as needed. Unknown --<field> is rejected so you
@@ -482,10 +561,23 @@ function parseArgs(argv: string[]): CliArgs {
       continue;
     }
 
-    // Ninja passthrough: -j<N>, -v, -k<N>, -l<N>. Short flags only —
-    // anything starting with `--` is OURS.
-    if (/^-[jklv]/.test(arg)) {
+    // Ninja-style short flags: -j<N>, -v, -k<N>, -l<N>, -n. Kept for ninja
+    // and parsed for the engine. Anything starting with `--` is OURS.
+    if (/^-[jklvn]/.test(arg)) {
       ninjaArgs.push(arg);
+      const m = arg.match(/^-([jklvn])(\d*)$/);
+      if (m) {
+        if (m[1] === "j" && m[2]) jobs = Number(m[2]);
+        else if (m[1] === "k") keepGoing = m[2] ? Number(m[2]) : 0;
+        else if (m[1] === "v") verbose = true;
+        else if (m[1] === "n") dryRun = true;
+      }
+      continue;
+    }
+
+    if (arg === "--explain") {
+      explain = true;
+      ninjaArgs.push("-d", "explain");
       continue;
     }
 
@@ -526,7 +618,12 @@ function parseArgs(argv: string[]): CliArgs {
     const rawKey = eq[1]!;
     const key = rawKey.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
     const isOurs =
-      key === "profile" || key === "target" || key === "configFile" || boolFields.has(key) || stringFields.has(key);
+      key === "profile" ||
+      key === "target" ||
+      key === "configFile" ||
+      key === "runner" ||
+      boolFields.has(key) ||
+      stringFields.has(key);
 
     let value = eq[2];
     if (value === undefined) {
@@ -552,6 +649,13 @@ function parseArgs(argv: string[]): CliArgs {
       configureOnly = true;
       continue;
     }
+    if (key === "runner") {
+      if (value !== "ninja" && value !== "ts") {
+        throw new BuildError(`--runner must be ninja or ts, got: ${value}`);
+      }
+      runner = value;
+      continue;
+    }
     if (key === "profile") {
       profile = value;
     } else if (boolFields.has(key)) {
@@ -565,7 +669,22 @@ function parseArgs(argv: string[]): CliArgs {
     }
   }
 
-  return { profile, overrides, ninjaTargets, ninjaArgs, execArgs, configureOnly, quiet, configFile };
+  return {
+    profile,
+    overrides,
+    ninjaTargets,
+    ninjaArgs,
+    execArgs,
+    configureOnly,
+    quiet,
+    configFile,
+    runner,
+    jobs,
+    keepGoing,
+    verbose,
+    dryRun,
+    explain,
+  };
 }
 
 function parseBool(v: string): boolean {
@@ -594,9 +713,12 @@ Options:
                                   buildDir, mode (full|cpp-only|link-only),
                                   unifiedSources, timeTrace, os, arch, abi,
                                   winsysroot (Windows cross-compile SDK root)
-  --target=<name>         Build a specific ninja target (repeatable)
+  --target=<name>         Build a specific target (repeatable)
+  --runner=<ninja|ts>     ninja (default) or the in-process engine.
+                          BUN_BUILD_RUNNER=ts sets the default.
   --configure-only        Emit build.ninja, don't run it
-  -j<N>, -v, -k<N>        Passed through to ninja
+  -j<N>, -v, -k<N>, -n    Jobs, verbose, keep going, dry run
+  --explain               Say why each task runs
   --help                  Show this help
 
 Any bare positional and everything after is passed to the built binary:

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -1,6 +1,11 @@
 # TypeScript Build System
 
-This directory generates `build.ninja`. The scripts **describe** the build; ninja **performs** it.
+This directory describes the build as tasks and runs them. Two runners execute the same declarations:
+
+- `--runner=ts` (or `BUN_BUILD_RUNNER=ts`): `engine.ts`, in process. Tasks are argv + inputs + outputs; the engine decides what is stale (mtimes, recorded header deps, command hash), runs stale tasks in parallel within pools, and keeps its state in `.build_log` / `.build_deps`. No ninja binary involved.
+- `--runner=ninja` (the default, for now): the same declarations serialized to `build.ninja`, run by ninja.
+
+Tasks are declared in two forms. `Ninja.task()` is the native one: a `NativeTask` with `commands: [{ argv, cwd?, env? }]`, `inputs`, `outputs`, `after`, `depfile`, `restat`, `pool`. No rule templates, no `$vars`, no shell quoting anywhere in the emitter. The compile/link/archive constructors in `compile.ts` and the dep codegen tool in `source.ts` use it. The older `rule()` + `build()` form still exists for the emitters not yet ported (deps fetch, codegen scripts, cargo, shims, strip, upload); `bridge.ts` expands those the way ninja would and hands them to the engine as shell commands. Porting an emitter means replacing its `n.rule()`/`n.build()` pair with one `n.task()` call whose argv is what the rule's shell string used to spell out. When the last one is ported, the shell path in the engine, `bridge.ts`'s expander, `stream.ts`, `shell.ts`'s `quote()`, the regen rule and `build.ninja` itself all go.
 
 ## Goals
 
@@ -9,7 +14,7 @@ This directory generates `build.ninja`. The scripts **describe** the build; ninj
 - **Configure always runs.** Every `bun run build` reconfigures before spawning ninja — no separate first-time configure step, no cached options that persist across runs. Config is `profile + overrides` evaluated fresh each time. Fast enough to not matter (~200ms — we haven't tried to make it faster yet).
 - `writeIfChanged()` — preserves mtimes on unchanged content, so the always-configure cost is near-zero for ninja: if `build.ninja` didn't change, ninja doesn't restat the graph
 - `restat = 1` on fetch/codegen/dep rules — prunes downstream rebuilds when outputs don't actually change
-- Self-rebuilding `build.ninja` — the `regen` generator rule re-runs configure when running ninja directly and a build script changed
+- Self-rebuilding `build.ninja` — the `regen` generator rule re-runs configure when running ninja directly and a build script changed. The engine never needs it: `bun run build` always configures first.
 
 **Explicit over implicit.** Every decision traceable to a line of code you can grep for. No hidden defaults, no order-dependent global state, no "it works because something else happened to set this."
 
@@ -84,13 +89,19 @@ Edge dependency types:
 ## Iterating on the build system
 
 ```sh
-bun scripts/build.ts --configure-only       # regenerate build.ninja, don't run ninja
+bun scripts/build.ts --configure-only       # regenerate build.ninja, don't run anything
 bunx tsc --noEmit -p scripts/build/tsconfig.json   # typecheck
-grep "yourtarget\|yourrule" build/debug/build.ninja  # inspect generated output
-ninja -C build/debug -t query <target>      # why does <target> rebuild?
-ninja -C build/debug -t deps <target>       # what headers does foo.o depend on?
-ninja -C build/debug <target>               # build a specific target (e.g. tinycc, bun-rust)
+bun scripts/build.ts --runner=ts -n --explain      # engine: what would run, and why (runs nothing)
+bun scripts/build.ts --runner=ts --target=bun-rust # engine: one target
+grep "yourtarget\|yourrule" build/debug/build.ninja  # inspect the ninja export
+ninja -C build/debug -t query <target>      # ninja: why does <target> rebuild?
+ninja -C build/debug -t deps <target>       # ninja: what headers does foo.o depend on?
+ninja -C build/debug <target>               # ninja: build a specific target (e.g. tinycc, bun-rust)
 ```
+
+The two runners keep separate state (`.build_log`/`.build_deps` vs `.ninja_log`/`.ninja_deps`), so switching runners in one build dir rebuilds once.
+
+Engine tests: `bun bd test test/internal/build-engine.test.ts` (synthetic tasks in a temp dir: what reruns, ordering, pools, failures, depfiles).
 
 The generated `build.ninja` is the ground truth. If an edge isn't doing what you expect, read it there first.
 
@@ -170,8 +181,10 @@ Split CI modes: `rust-only` (path deps+codegen+cargo → libbun_runtime.a), `cpp
 
 ### Phase 3 — Execute
 
-- **CI:** collapsible log groups, spawn ninja with `spawnWithAnnotations` (parses compiler errors into Buildkite annotations), upload/download artifacts.
-- **Local:** spawn ninja with FD 3 dup'd to stderr — `stream.ts`-wrapped commands write to FD 3, bypassing ninja's per-job output buffering so dep/cargo build progress streams live. If positionals given, exec the built binary with them.
+- **`--runner=ts`:** `bridge.ts` declares every recorded task on an `Engine`; `engine.run(targets)` plans and runs. Local: a status line on a TTY, one line per task otherwise, failures only in quiet mode (`bun bd test …`). CI: one line per task. Console tasks (cargo, link, smoke test) inherit the terminal; everything else is captured and printed when it finishes.
+- **`--runner=ninja`, CI:** collapsible log groups, spawn ninja with `spawnWithAnnotations` (parses compiler errors into Buildkite annotations), upload/download artifacts.
+- **`--runner=ninja`, local:** spawn ninja with FD 3 dup'd to stderr — `stream.ts`-wrapped commands write to FD 3, bypassing ninja's per-job output buffering so dep/cargo build progress streams live. The engine passes the same fd, so stream.ts keeps working until it is deleted.
+- If positionals given, exec the built binary with them.
 
 ## Module inventory
 
@@ -183,7 +196,11 @@ Split CI modes: `rust-only` (path deps+codegen+cargo → libbun_runtime.a), `cpp
 | `profiles.ts`                  | Named `PartialConfig` presets + `getProfile()`                                                                          |
 | `tools.ts`                     | Tool discovery: `findTool()`, `resolveLlvmToolchain()`, version parsing                                                 |
 | `flags.ts`                     | Flat flag tables, `computeFlags()`, `computeDepFlags()`, `computeCpuTargetFlags()`                                      |
-| `ninja.ts`                     | `Ninja` class — the build-file writer                                                                                   |
+| `ninja.ts`                     | `Ninja` class — records tasks (`task()`) and rule edges (`rule()`/`build()`), writes `build.ninja`                      |
+| `engine.ts`                    | `Engine` — in-process runner: staleness, scheduling, pools, process output (`--runner=ts`)                              |
+| `bridge.ts`                    | Declares a `Ninja`'s recorded tasks and edges on an `Engine`; expands rule edges the way ninja would                    |
+| `build-log.ts`                 | Engine state on disk: `.build_log` (command hash, start time, duration) and `.build_deps` (header deps)                 |
+| `depfile.ts`                   | Parsers: Makefile depfiles, clang-cl `/showIncludes`, ninja `$var` expansion                                            |
 | `rules.ts`                     | `registerAllRules()` — calls each module's `registerXxxRules()`                                                         |
 | `compile.ts`                   | `cc`/`cxx`/`pch`/`link`/`ar` + `registerCompileRules()`                                                                 |
 | `unified.ts`                   | WebKit-style unified-source bundling, `generateUnifiedSources()`                                                        |
@@ -222,14 +239,18 @@ Split CI modes: `rust-only` (path deps+codegen+cargo → libbun_runtime.a), `cpp
 
 ## registerXxxRules vs emitXxx
 
-**Rules** are ninja `rule` blocks — reusable command templates. **Build edges** are `build` statements — input→output instances.
+**Rules** are ninja `rule` blocks — reusable command templates. **Build edges** are `build` statements — input→output instances. Only the not-yet-ported emitters use them; a native `task()` carries its own argv and needs no rule.
 
 Ninja requires all rules defined before any build references them. Hence:
 
-1. `registerXxxRules(n, cfg)` — each module registers its rules. Called once via `registerAllRules()`.
-2. `emitXxx(n, cfg, ...)` — each module emits build edges.
+1. `registerXxxRules(n, cfg)` — each module registers its rules. Called once via `registerAllRules()`. (`compile.ts` only registers its pool now.)
+2. `emitXxx(n, cfg, ...)` — each module emits build edges or tasks.
 
 Why not auto-register in emit functions? Some rules are shared (`dep_configure` used by both `source.ts` and `webkit.ts` local mode). Explicit registration keeps "which rule lives where" clear.
+
+## Engine semantics (what replaced ninja)
+
+A task reruns when any of these hold, checked in this order: a task it depends on ran and `changed`; an output is missing; it is not in `.build_log`; its command hash (argv + cwd + env + response file) differs; a header recorded in `.build_deps` is missing or the output is newer than that record; an input or recorded header is newer than the task's last start time (read from the file system clock through `.build_lock`, so it compares with output mtimes); or `alwaysRun`. `restat: true` tasks count as `changed` only when an output mtime moved, which is what lets writeIfChanged codegen and a no-op cargo build stop a relink. Dependencies come from `after` and from inputs another task produces; `after` on an alias name waits for everything behind it. Pools are priority semaphores: the task with the longest recorded duration goes first, so the slow translation units and cargo start early.
 
 ## Gotchas
 

--- a/scripts/build/bridge.ts
+++ b/scripts/build/bridge.ts
@@ -14,6 +14,7 @@ import { resolve } from "node:path";
 import { expandNinja } from "./depfile.ts";
 import { type Command, type Engine, type Task } from "./engine.ts";
 import type { GraphEdge, NativeTask, Ninja, Rule } from "./ninja.ts";
+import { quoteWin32Argv } from "./shell.ts";
 
 /** Declare every recorded edge and task. Returns the phony aliases by name (for `--target`). */
 export function declareAll(engine: Engine, n: Ninja, hostWindows: boolean): void {
@@ -140,7 +141,7 @@ class EdgeExpander {
 
   private paths(paths: readonly string[], sep: string, escape: boolean): string {
     if (!escape) return paths.join(sep);
-    return paths.map(p => (this.windows ? win32Escape(p) : shellEscape(p))).join(sep);
+    return paths.map(p => (this.windows ? quoteWin32Argv(p) : shellEscape(p))).join(sep);
   }
 }
 
@@ -148,22 +149,4 @@ class EdgeExpander {
 export function shellEscape(s: string): string {
   if (/^[A-Za-z0-9_+=:,./@%-]+$/.test(s)) return s;
   return `'${s.replace(/'/g, `'\\''`)}'`;
-}
-
-/** Win32: quote when needed, escaping quotes and the backslashes before them (CommandLineToArgvW rules). */
-export function win32Escape(s: string): string {
-  if (/^[A-Za-z0-9_+=:,./\\@%-]+$/.test(s)) return s;
-  let out = '"';
-  let backslashes = 0;
-  for (const ch of s) {
-    if (ch === "\\") {
-      backslashes++;
-      out += ch;
-      continue;
-    }
-    if (ch === '"') out += "\\".repeat(backslashes) + '\\"';
-    else out += ch;
-    backslashes = 0;
-  }
-  return out + "\\".repeat(backslashes) + '"';
 }

--- a/scripts/build/bridge.ts
+++ b/scripts/build/bridge.ts
@@ -88,7 +88,8 @@ function declareNative(engine: Engine, t: NativeTask): Task {
     inputs: [...t.inputs, ...(t.implicitInputs ?? [])],
     after: t.after,
     command: t.commands.map(c => ({ argv: c.argv, cwd: c.cwd, env: c.env })),
-    rspfile: t.rspfile !== undefined ? { path: t.rspfile, content: t.inputs.map(p => engine.rel(p)).join("\n") } : undefined,
+    rspfile:
+      t.rspfile !== undefined ? { path: t.rspfile, content: t.inputs.map(p => engine.rel(p)).join("\n") } : undefined,
     depfile: t.depfile,
     restat: t.restat,
     alwaysRun: t.alwaysRun,
@@ -112,7 +113,11 @@ class EdgeExpander {
   }
 
   /** depfile and rspfile are paths we open ourselves: no shell escaping, like ninja's GetUnescaped*. */
-  binding(e: GraphEdge, rule: Rule, name: "command" | "description" | "depfile" | "rspfile" | "rspfile_content"): string {
+  binding(
+    e: GraphEdge,
+    rule: Rule,
+    name: "command" | "description" | "depfile" | "rspfile" | "rspfile_content",
+  ): string {
     const raw = rule[name];
     if (raw === undefined) return "";
     return this.expand(e, rule, raw, name !== "depfile" && name !== "rspfile");

--- a/scripts/build/bridge.ts
+++ b/scripts/build/bridge.ts
@@ -1,0 +1,164 @@
+/**
+ * Declares everything the emitters recorded on a `Ninja` instance as engine
+ * tasks, so `--runner=ts` can run the whole build while modules are still
+ * being ported to `Ninja.task()`.
+ *
+ * Native tasks map one to one. Rule-template edges (`Ninja.build()`) are
+ * expanded here the way ninja expands them (`$in`, `$out`, `$var`, rule-level
+ * `depfile`/`rspfile`), and run as a shell string. When the last `build()`
+ * caller is gone, this file shrinks to `declareNative()` and the shell path
+ * in engine.ts goes with it.
+ */
+
+import { resolve } from "node:path";
+import { expandNinja } from "./depfile.ts";
+import { type Command, type Engine, type Task } from "./engine.ts";
+import type { GraphEdge, NativeTask, Ninja, Rule } from "./ninja.ts";
+
+/** Declare every recorded edge and task. Returns the phony aliases by name (for `--target`). */
+export function declareAll(engine: Engine, n: Ninja, hostWindows: boolean): void {
+  const abs = (p: string) => resolve(n.buildDir, p);
+
+  for (const t of n.tasks) declareNative(engine, t);
+
+  // Phony edges with inputs are aliases. A phony with no inputs (`always`)
+  // exists to make its dependents rerun every build; those dependents get
+  // `alwaysRun` below and the phony itself is dropped.
+  const always = new Set<string>();
+  for (const e of n.edges) {
+    if (e.rule !== "phony") continue;
+    if (e.inputs.length === 0 && e.implicitInputs.length === 0) {
+      for (const out of e.outputs) always.add(out);
+    }
+  }
+
+  const expander = new EdgeExpander(n, hostWindows);
+  for (const e of n.edges) {
+    if (e.rule === "phony") {
+      if (e.inputs.length + e.implicitInputs.length === 0) continue;
+      for (const out of e.outputs) {
+        engine.alias(out, [...e.inputs, ...e.implicitInputs, ...e.orderOnlyInputs].map(abs));
+      }
+      continue;
+    }
+    const rule = n.getRule(e.rule)!;
+    // The generator rule re-runs configure when ninja is driven directly. The
+    // engine only ever runs right after configure: nothing to do.
+    if (rule.generator === true) continue;
+
+    const after = e.orderOnlyInputs.filter(p => !always.has(p)).map(abs);
+    const alwaysRun = e.orderOnlyInputs.some(p => always.has(p));
+    const command: Command = { shell: expander.command(e, rule) };
+    const rspfile = rule.rspfile !== undefined ? expander.binding(e, rule, "rspfile") : undefined;
+    const depfile: NativeTask["depfile"] =
+      rule.deps === "msvc"
+        ? { kind: "msvc" }
+        : rule.depfile !== undefined
+          ? { kind: "gcc", path: abs(expander.binding(e, rule, "depfile")) }
+          : undefined;
+    // Labels come from the rule's description ("cxx obj/foo.o", "fetch zstd");
+    // the leading word usually repeats the rule name, so drop it.
+    let label = rule.description !== undefined ? expander.binding(e, rule, "description") : e.outputs[0]!;
+    if (label.startsWith(e.rule + " ")) label = label.slice(e.rule.length + 1);
+    engine.task({
+      kind: e.rule,
+      label,
+      outputs: [...e.outputs, ...e.implicitOutputs].map(abs),
+      inputs: [...e.inputs, ...e.implicitInputs].map(abs),
+      after,
+      command,
+      rspfile:
+        rspfile !== undefined
+          ? { path: abs(rspfile), content: expander.binding(e, rule, "rspfile_content") }
+          : undefined,
+      depfile,
+      restat: rule.restat === true,
+      alwaysRun,
+      pool: e.pool === "console" || e.pool === "" ? undefined : e.pool,
+      console: e.pool === "console",
+    });
+  }
+}
+
+function declareNative(engine: Engine, t: NativeTask): Task {
+  return engine.task({
+    kind: t.kind,
+    label: t.label,
+    outputs: [...t.outputs, ...(t.implicitOutputs ?? [])],
+    inputs: [...t.inputs, ...(t.implicitInputs ?? [])],
+    after: t.after,
+    command: t.commands.map(c => ({ argv: c.argv, cwd: c.cwd, env: c.env })),
+    rspfile: t.rspfile !== undefined ? { path: t.rspfile, content: t.inputs.map(p => engine.rel(p)).join("\n") } : undefined,
+    depfile: t.depfile,
+    restat: t.restat,
+    alwaysRun: t.alwaysRun,
+    pool: t.pool,
+    console: t.console,
+  });
+}
+
+/** ninja's EdgeEnv: `$in`/`$out`/edge vars/rule bindings, with shell escaping of paths. */
+class EdgeExpander {
+  private readonly n: Ninja;
+  private readonly windows: boolean;
+
+  constructor(n: Ninja, windows: boolean) {
+    this.n = n;
+    this.windows = windows;
+  }
+
+  command(e: GraphEdge, rule: Rule): string {
+    return this.binding(e, rule, "command");
+  }
+
+  /** depfile and rspfile are paths we open ourselves: no shell escaping, like ninja's GetUnescaped*. */
+  binding(e: GraphEdge, rule: Rule, name: "command" | "description" | "depfile" | "rspfile" | "rspfile_content"): string {
+    const raw = rule[name];
+    if (raw === undefined) return "";
+    return this.expand(e, rule, raw, name !== "depfile" && name !== "rspfile");
+  }
+
+  private expand(e: GraphEdge, rule: Rule, template: string, escape: boolean): string {
+    return expandNinja(template, name => this.lookup(e, rule, name, escape));
+  }
+
+  private lookup(e: GraphEdge, rule: Rule, name: string, escape: boolean): string | undefined {
+    if (name === "in") return this.paths(e.inputs, " ", escape);
+    if (name === "in_newline") return this.paths(e.inputs, "\n", escape);
+    if (name === "out") return this.paths(e.outputs, " ", escape);
+    const local = e.vars[name];
+    if (local !== undefined) return local;
+    const ruleVal = (rule as unknown as Record<string, unknown>)[name];
+    if (typeof ruleVal === "string") return this.expand(e, rule, ruleVal, escape);
+    return undefined;
+  }
+
+  private paths(paths: readonly string[], sep: string, escape: boolean): string {
+    if (!escape) return paths.join(sep);
+    return paths.map(p => (this.windows ? win32Escape(p) : shellEscape(p))).join(sep);
+  }
+}
+
+/** POSIX: single-quote anything outside ninja's safe set. */
+export function shellEscape(s: string): string {
+  if (/^[A-Za-z0-9_+=:,./@%-]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Win32: quote when needed, escaping quotes and the backslashes before them (CommandLineToArgvW rules). */
+export function win32Escape(s: string): string {
+  if (/^[A-Za-z0-9_+=:,./\\@%-]+$/.test(s)) return s;
+  let out = '"';
+  let backslashes = 0;
+  for (const ch of s) {
+    if (ch === "\\") {
+      backslashes++;
+      out += ch;
+      continue;
+    }
+    if (ch === '"') out += "\\".repeat(backslashes) + '\\"';
+    else out += ch;
+    backslashes = 0;
+  }
+  return out + "\\".repeat(backslashes) + '"';
+}

--- a/scripts/build/build-log.ts
+++ b/scripts/build/build-log.ts
@@ -1,0 +1,234 @@
+/**
+ * On-disk state of the TypeScript build executor (`executor.ts`). Two
+ * append-only JSON-lines files in the build directory, the counterparts of
+ * ninja's `.ninja_log` and `.ninja_deps`:
+ *
+ * - `.build_log`: per output, the hash of the command that produced it, the
+ *   filesystem time the command started, and how long it took. The hash is
+ *   what makes a flag change rebuild; the start time is what makes an input
+ *   edited mid-compile rebuild; the duration feeds the scheduler's
+ *   critical-path weights.
+ * - `.build_deps`: per output, the headers the compiler reported (depfile or
+ *   /showIncludes), with the output's mtime at the time of recording. A path
+ *   table keeps the file small: a header is written once and referenced by
+ *   index afterwards.
+ *
+ * Both files are rewritten compacted when dead entries outnumber live ones.
+ * A truncated trailing line (crash mid-write) is ignored on load.
+ */
+
+import { closeSync, openSync, readFileSync, renameSync, writeFileSync, writeSync } from "node:fs";
+import { resolve } from "node:path";
+
+export interface LogEntry {
+  /** Hash of the expanded command line (plus response file content). */
+  commandHash: string;
+  /** Filesystem time (ms) when the command started. See `Executor.fsNow()`. */
+  startMtime: number;
+  /** Wall-clock duration of the command in ms. Scheduler weight. */
+  durationMs: number;
+}
+
+export const BUILD_LOG_FILE = ".build_log";
+export const DEPS_LOG_FILE = ".build_deps";
+
+const LOG_HEADER = "# bun build log v1";
+const DEPS_HEADER = "# bun build deps v1";
+
+export class BuildLog {
+  private readonly path: string;
+  private readonly entries = new Map<string, LogEntry>();
+  private lineCount = 0;
+  private fd: number | undefined;
+
+  constructor(buildDir: string) {
+    this.path = resolve(buildDir, BUILD_LOG_FILE);
+  }
+
+  load(): void {
+    let text: string;
+    try {
+      text = readFileSync(this.path, "utf8");
+    } catch {
+      return;
+    }
+    const lines = text.split("\n");
+    if (lines[0] !== LOG_HEADER) return;
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i]!;
+      if (line.length === 0) continue;
+      let rec: unknown;
+      try {
+        rec = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(rec) || rec.length !== 4) continue;
+      const [output, commandHash, startMtime, durationMs] = rec as [string, string, number, number];
+      this.entries.set(output, { commandHash, startMtime, durationMs });
+      this.lineCount++;
+    }
+  }
+
+  lookup(output: string): LogEntry | undefined {
+    return this.entries.get(output);
+  }
+
+  /** Record one finished edge. One line per output, like ninja. */
+  record(outputs: readonly string[], entry: LogEntry): void {
+    if (this.fd === undefined) this.open();
+    let text = "";
+    for (const output of outputs) {
+      this.entries.set(output, entry);
+      text += JSON.stringify([output, entry.commandHash, entry.startMtime, entry.durationMs]) + "\n";
+      this.lineCount++;
+    }
+    writeSync(this.fd!, text);
+  }
+
+  close(): void {
+    if (this.fd !== undefined) {
+      closeSync(this.fd);
+      this.fd = undefined;
+    }
+    if (this.lineCount > 2 * this.entries.size + 1000) this.compact();
+  }
+
+  private open(): void {
+    if (this.lineCount === 0) {
+      writeFileSync(this.path, LOG_HEADER + "\n");
+    }
+    this.fd = openSync(this.path, "a");
+  }
+
+  private compact(): void {
+    let text = LOG_HEADER + "\n";
+    for (const [output, e] of this.entries) {
+      text += JSON.stringify([output, e.commandHash, e.startMtime, e.durationMs]) + "\n";
+    }
+    writeFileSync(this.path + ".tmp", text);
+    renameSync(this.path + ".tmp", this.path);
+    this.lineCount = this.entries.size;
+  }
+}
+
+export interface DepsEntry {
+  /** mtime (ms) of the output when the deps were recorded. Older than the file now → stale. */
+  mtime: number;
+  deps: readonly string[];
+}
+
+export class DepsLog {
+  private readonly path: string;
+  private readonly entries = new Map<string, DepsEntry>();
+  private readonly paths: string[] = [];
+  private readonly pathIds = new Map<string, number>();
+  private recordCount = 0;
+  private fd: number | undefined;
+
+  constructor(buildDir: string) {
+    this.path = resolve(buildDir, DEPS_LOG_FILE);
+  }
+
+  load(): void {
+    let text: string;
+    try {
+      text = readFileSync(this.path, "utf8");
+    } catch {
+      return;
+    }
+    const lines = text.split("\n");
+    if (lines[0] !== DEPS_HEADER) return;
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i]!;
+      if (line.length === 0) continue;
+      let rec: unknown;
+      try {
+        rec = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(rec)) continue;
+      if (rec[0] === "p" && typeof rec[1] === "string") {
+        this.intern(rec[1], false);
+      } else if (rec[0] === "d" && typeof rec[1] === "number" && Array.isArray(rec[3])) {
+        const output = this.paths[rec[1]];
+        if (output === undefined) continue;
+        const deps: string[] = [];
+        for (const id of rec[3] as number[]) {
+          const p = this.paths[id];
+          if (p !== undefined) deps.push(p);
+        }
+        this.entries.set(output, { mtime: rec[2] as number, deps });
+        this.recordCount++;
+      }
+    }
+  }
+
+  lookup(output: string): DepsEntry | undefined {
+    return this.entries.get(output);
+  }
+
+  record(output: string, mtime: number, deps: readonly string[]): void {
+    const existing = this.entries.get(output);
+    if (
+      existing !== undefined &&
+      existing.mtime === mtime &&
+      existing.deps.length === deps.length &&
+      existing.deps.every((d, i) => d === deps[i])
+    ) {
+      return;
+    }
+    if (this.fd === undefined) this.open();
+    let text = "";
+    const ids: number[] = [];
+    const outId = this.intern(output, true, s => (text += s));
+    for (const d of deps) ids.push(this.intern(d, true, s => (text += s)));
+    text += JSON.stringify(["d", outId, mtime, ids]) + "\n";
+    writeSync(this.fd!, text);
+    this.entries.set(output, { mtime, deps: [...deps] });
+    this.recordCount++;
+  }
+
+  close(): void {
+    if (this.fd !== undefined) {
+      closeSync(this.fd);
+      this.fd = undefined;
+    }
+    if (this.recordCount > 2 * this.entries.size + 100) this.compact();
+  }
+
+  private intern(path: string, write: boolean, emit?: (line: string) => void): number {
+    let id = this.pathIds.get(path);
+    if (id === undefined) {
+      id = this.paths.length;
+      this.paths.push(path);
+      this.pathIds.set(path, id);
+      if (write && emit !== undefined) emit(JSON.stringify(["p", path]) + "\n");
+    }
+    return id;
+  }
+
+  private open(): void {
+    if (this.recordCount === 0 && this.paths.length === 0) {
+      writeFileSync(this.path, DEPS_HEADER + "\n");
+    }
+    this.fd = openSync(this.path, "a");
+  }
+
+  private compact(): void {
+    // Rebuild the path table from live entries only.
+    this.paths.length = 0;
+    this.pathIds.clear();
+    let text = DEPS_HEADER + "\n";
+    const emit = (line: string) => (text += line);
+    for (const [output, e] of this.entries) {
+      const outId = this.intern(output, true, emit);
+      const ids = e.deps.map(d => this.intern(d, true, emit));
+      text += JSON.stringify(["d", outId, e.mtime, ids]) + "\n";
+    }
+    writeFileSync(this.path + ".tmp", text);
+    renameSync(this.path + ".tmp", this.path);
+    this.recordCount = this.entries.size;
+  }
+}

--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -160,6 +160,13 @@ export function registerCodegenRules(n: Ninja, cfg: Config): void {
 
   // Codegen dir stamp — all outputs go into cfg.codegenDir, but the dir must
   // exist first. Scripts generally mkdir themselves, but some (esbuild) don't.
+  // mkdir + touch stamp. Both sides must tolerate "already exists" — posix
+  // has -p, cmd doesn't, so suppress the error (2>nul) and touch
+  // unconditionally (&).
+  n.rule("mkdir_stamp", {
+    command: hostWin ? `cmd /c "mkdir $dir 2>nul & type nul > $out"` : `mkdir -p $dir && touch $out`,
+    description: "mkdir $dir",
+  });
   n.build({
     outputs: [codegenDirStamp(cfg)],
     rule: "mkdir_stamp",
@@ -249,8 +256,7 @@ export interface CodegenOutputs {
 /**
  * Emit all codegen steps. Returns grouped outputs for downstream wiring.
  *
- * Call after registerCodegenRules() and after registerDirStamps() (we use
- * the `mkdir_stamp` rule for the codegen dir).
+ * Call after registerCodegenRules().
  */
 export function emitCodegen(n: Ninja, cfg: Config, sources: Sources): CodegenOutputs {
   n.comment("─── Codegen ───");

--- a/scripts/build/compile.ts
+++ b/scripts/build/compile.ts
@@ -1,9 +1,10 @@
 /**
  * Compilation constructors.
  *
- * These are NOT abstractions — they're shortcuts that build a `BuildNode` and
- * register it with the Ninja instance. A "library" is just an array of cxx()
- * outputs + one ar() output. An executable is cxx() outputs + one link().
+ * These are NOT abstractions — they're shortcuts that build one compiler,
+ * linker or archiver invocation and declare it as a task. A "library" is just
+ * an array of cxx() outputs + one ar() output. An executable is cxx() outputs
+ * + one link().
  */
 
 import { mkdirSync } from "node:fs";
@@ -12,187 +13,36 @@ import { basename, dirname, extname, relative, resolve, sep } from "node:path";
 import type { Config } from "./config.ts";
 import { assert } from "./error.ts";
 import { writeIfChanged } from "./fs.ts";
-import type { BuildNode, Ninja, Rule } from "./ninja.ts";
-import { quote } from "./shell.ts";
-import { elfDebugCompressPostlinkCommand, machoPostlinkCommand } from "./shims.ts";
-import { streamPath } from "./stream.ts";
+import type { NativeTask, Ninja } from "./ninja.ts";
+import { postlinkCommands } from "./shims.ts";
 
 // ---------------------------------------------------------------------------
-// Rule registration — call once per Ninja instance
+// Tool invocations
 // ---------------------------------------------------------------------------
 
 /**
- * Register all compilation-related ninja rules.
- * Call once before using cxx/cc/pch/link/ar.
+ * Depfile handling differs between clang (gcc-style .d, `-MMD -MF`) and
+ * clang-cl (`/showIncludes` on stdout).
  */
-export function registerCompileRules(n: Ninja, cfg: Config): void {
-  // Quote tool paths — ninja passes commands through cmd/sh; a space in a
-  // toolchain path (e.g. "C:\Program Files\LLVM\bin\clang-cl.exe") would
-  // split argv without quoting. quote() passes through safe paths unchanged.
-  // Quoting style follows the HOST shell (cmd vs sh) — the target decides
-  // the command *shape* (clang-cl vs clang flags) below.
-  const q = (p: string) => quote(p, cfg.host.os === "windows");
-  const cc = q(cfg.cc);
-  const cxx = q(cfg.cxx);
-  const ar = q(cfg.ar);
-  const ccacheLauncher = cfg.ccache !== undefined ? `${q(cfg.ccache)} ` : "";
+function depfileFor(cfg: Config, out: string): NativeTask["depfile"] {
+  return cfg.windows ? { kind: "msvc" } : { kind: "gcc", path: `${out}.d` };
+}
 
-  // Depfile handling differs between clang (gcc-style .d) and clang-cl (/showIncludes)
-  const depfileOpts: Pick<Rule, "depfile" | "deps"> = cfg.windows
-    ? { deps: "msvc" }
-    : { depfile: "$out.d", deps: "gcc" };
+/** `-c src -o out` in the dialect of the target compiler. */
+function compileOutputArgs(cfg: Config, n: Ninja, src: string, out: string): string[] {
+  return cfg.windows ? ["/c", n.rel(src), `/Fo${n.rel(out)}`] : ["-c", n.rel(src), "-o", n.rel(out)];
+}
 
-  // Compiles are capped at the core count, below ninja's default -j of cores+2, so cargo / dep builds start the moment they are ready: without a .ninja_log ninja weighs every edge as 1, and the cc → ar → link chain outranks cargo → link.
-  n.pool("compile", availableParallelism());
+/**
+ * Compiles are capped at the core count, below the engine's (and ninja's)
+ * default job count of cores + 2, so cargo and dep builds start the moment
+ * they are ready instead of queueing behind a thousand compiles.
+ */
+export const COMPILE_POOL = "compile";
 
-  // ─── C++ compile ───
-  // Note: $cxxflags is set per-build (allows per-file overrides).
-  n.rule("cxx", {
-    command: cfg.windows
-      ? `${ccacheLauncher}${cxx} /nologo /showIncludes $cxxflags /c $in /Fo$out`
-      : `${ccacheLauncher}${cxx} $cxxflags -MMD -MT $out -MF $out.d -c $in -o $out`,
-    description: "cxx $out",
-    ...depfileOpts,
-    pool: "compile",
-  });
-
-  // ─── C++ compile with PCH ───
-  // PCH is loaded with -include-pch (clang) or /Yu (clang-cl).
-  // $pch_file is the .pch/.gch output, $pch_header is the wrapper .hxx.
-  //
-  // Both -include-pch AND -include (force-include of the wrapper) are passed,
-  // mirroring CMake's target_precompile_headers(). The force-include re-applies
-  // `#pragma clang system_header` for the current translation unit's
-  // preprocessing pass — without it, warnings from PCH-included headers aren't
-  // suppressed (the pragma's effect is per-preprocessing-pass, not per-AST).
-  // The -Xclang prefix is required: plain -include doesn't combine with PCH
-  // on the clang driver, but -Xclang bypasses the driver's sanity check.
-  //
-  // clang-cl: same -Xclang -include-pch / -include pair as posix. clang-cl
-  // accepts -Xclang directly. The MSVC-style alternative (/Yu + /FI) does
-  // NOT work: clang-cl's /Yu scans the literal source for the through-header
-  // and ignores /FI-injected includes, so it errors with "#include ... not
-  // seen" on any TU that doesn't itself spell out the wrapper include.
-  n.rule("cxx_pch", {
-    command: cfg.windows
-      ? `${ccacheLauncher}${cxx} /nologo /showIncludes $cxxflags -Xclang -include-pch -Xclang $pch_file -Xclang -include -Xclang $pch_header /c $in /Fo$out`
-      : `${ccacheLauncher}${cxx} $cxxflags -Winvalid-pch -Xclang -include-pch -Xclang $pch_file -Xclang -include -Xclang $pch_header -MMD -MT $out -MF $out.d -c $in -o $out`,
-    description: "cxx $out",
-    ...depfileOpts,
-    pool: "compile",
-  });
-
-  // ─── C compile ───
-  n.rule("cc", {
-    command: cfg.windows
-      ? `${ccacheLauncher}${cc} /nologo /showIncludes $cflags /c $in /Fo$out`
-      : `${ccacheLauncher}${cc} $cflags -MMD -MT $out -MF $out.d -c $in -o $out`,
-    description: "cc $out",
-    ...depfileOpts,
-    pool: "compile",
-  });
-
-  // ─── NASM assemble (x64 only) ───
-  // BoringSSL's win-x64 assembly and libjpeg-turbo's x86_64 SIMD are NASM syntax; clang can't assemble it.
-  // -MD writes a Make-style depfile; nasm 2.14+ supports it.
-  if (cfg.nasm !== undefined) {
-    n.rule("nasm", {
-      command: `${q(cfg.nasm)} $nasmflags -MD $out.d -o $out $in`,
-      description: "nasm $out",
-      depfile: "$out.d",
-      deps: "gcc",
-      pool: "compile",
-    });
-  }
-
-  // ─── PCH compilation ───
-  // Compiles a header into a precompiled header.
-  //
-  // CMake's approach (replicated here): compile an EMPTY stub .cxx as the
-  // main file, force-include the wrapper .hxx via -Xclang -include, emit
-  // the PCH via -Xclang -emit-pch. The indirection lets `#pragma clang
-  // system_header` in the wrapper take effect — that pragma is ignored
-  // when the file containing it is the MAIN file, but works when the
-  // file is included. -fpch-instantiate-templates: instantiate templates
-  // during PCH compilation instead of deferring to each consuming .cpp
-  // (faster builds, CMake does this too).
-  // -MD (not -MMD): the wrapper header has `#pragma clang system_header` to
-  // suppress JSC warnings, which makes everything it transitively includes
-  // "system" for -MMD purposes. -MMD would give a near-empty depfile; -MD
-  // tracks all headers so PCH invalidates when WebKit headers change.
-  // -fno-pch-timestamp: don't embed input mtimes in the PCH. A cached PCH's
-  // embedded mtime can be stale (e.g. after deleting pch/ and reconfiguring)
-  // → every consumer fails with "mtime changed". ninja's depfile already
-  // tracks invalidation; clang's redundant mtime check just fights caching.
-  // Windows: -Xclang -include, NOT /FI. clang-cl's /FI auto-promotes to
-  // -include-pch when a .pch already exists at the /Fp path — even for the
-  // /Yc -emit-pch cc1 job — so a stale PCH (e.g. after a cxxflags change)
-  // gets validated instead of overwritten and the build fails with
-  // "<langopt> was enabled in precompiled file but is currently disabled".
-  // -Xclang goes straight to cc1, bypassing the driver's auto-detection.
-  //
-  // No ccache for the pch rule. CCACHE_BASEDIR + CCACHE_NOHASHDIR (set in
-  // configure.ts so worktrees share .o cache entries) makes the pch compile
-  // hash identically across worktrees, but clang bakes ABSOLUTE header paths
-  // into the .pch artifact. ccache would serve worktree A's .pch (with
-  // /path/to/A/src/... inside) to worktree B; B's .cpp files then see
-  // every PCH-reached header at A's path and their own #include of the same
-  // header at B's path → #pragma once doesn't match → "redefinition of
-  // 'DOMClientIsoSubspaces'" et al. The pch compile is one ~10-15s job per
-  // build; the cross-worktree correctness hazard outweighs the cache savings.
-  n.rule("pch", {
-    command: cfg.windows
-      ? `${cxx} /nologo /showIncludes $cxxflags /clang:-fpch-instantiate-templates -Xclang -fno-pch-timestamp /Yc$pch_header -Xclang -include -Xclang $pch_header /Fp$out /c $in /Fo$pch_stub_obj`
-      : `${cxx} $cxxflags -Winvalid-pch -fpch-instantiate-templates -Xclang -fno-pch-timestamp -Xclang -emit-pch -Xclang -include -Xclang $pch_header -x c++-header -MD -MT $out -MF $out.d -c $in -o $out`,
-    description: "pch $out",
-    ...depfileOpts,
-    pool: "compile",
-  });
-
-  // ─── Link executable ───
-  // Uses response file because object lists get long (>32k args breaks on windows).
-  // console pool: link is inherently serial (one exe), takes 30s+ on large
-  // binaries, and lld prints useful progress (undefined symbol errors,
-  // --verbose timing). Streaming beats sitting at [N/N] wondering if it hung.
-  // stream.ts --console: passthrough + ninja Windows buffering fix — see stream.ts.
-  //
-  // Windows: -fuse-ld=lld forces lld-link (VS dev shell puts link.exe
-  // first in PATH, clang-cl would default to it). /link separator —
-  // everything after passes verbatim to lld-link. Our ldflags are all
-  // pure linker options (/STACK, /DEF, /OPT, /errorlimit, system libs)
-  // that clang-cl's driver doesn't recognize.
-  //
-  // /clang:-B<dir of cfg.ld> pins WHICH lld-link `-fuse-ld=lld` resolves:
-  // -B program-prefix dirs are searched before the driver's own InstalledDir
-  // and PATH. Normally that's the same host-LLVM lld-link the driver would
-  // pick anyway; under cross-language LTO resolveConfig() swaps cfg.ld to
-  // rustc's gcc-ld/lld-link (newer LLVM, able to read rustc's bitcode), and
-  // this is what makes the link actually use it — clang-cl has no working
-  // --ld-path= spelling, and `-fuse-ld=<abs path>` mangles the path with the
-  // target triple.
-  //
-  // Darwin cross links append `&& macho-postlink $out ...` (the suffix is
-  // empty everywhere else): ninja runs the whole command through `sh -c`,
-  // so the fixup runs after the link succeeds and the declared output is
-  // already the final, patched, re-signed artifact. See shims.ts.
-  const wrap = `${cfg.jsRuntime} ${q(streamPath)} link --console`;
-  n.rule("link", {
-    command: cfg.windows
-      ? `${wrap} ${cxx} /nologo -fuse-ld=lld ${q(`/clang:-B${dirname(cfg.ld)}`)} @$out.rsp /Fe$out /link $ldflags`
-      : `${wrap} ${cxx} @$out.rsp $ldflags -o $out${elfDebugCompressPostlinkCommand(cfg)}${machoPostlinkCommand(cfg)}`,
-    description: "link $out",
-    rspfile: "$out.rsp",
-    rspfile_content: "$in_newline",
-    pool: "console",
-  });
-
-  // ─── Static library archive ───
-  n.rule("ar", {
-    command: cfg.windows ? `${ar} /nologo /out:$out @$out.rsp` : `${ar} rcs $out @$out.rsp`,
-    description: "ar $out",
-    rspfile: "$out.rsp",
-    rspfile_content: "$in_newline",
-  });
+/** Register the pools compile tasks use. Call once per Ninja instance. */
+export function registerCompilePools(n: Ninja): void {
+  n.pool(COMPILE_POOL, availableParallelism());
 }
 
 // ---------------------------------------------------------------------------
@@ -276,12 +126,16 @@ export function nasm(
         : "Install nasm from your distro (apt/dnf/brew install nasm) or https://nasm.us",
   });
   const out = objectPath(cfg, src);
-  n.build({
+  // -MD writes a Make-style depfile; nasm 2.14+ supports it.
+  n.task({
+    kind: "nasm",
+    label: n.rel(out),
+    commands: [{ argv: [cfg.nasm, ...opts.flags, "-MD", `${n.rel(out)}.d`, "-o", n.rel(out), resolve(cfg.cwd, src)] }],
     outputs: [out],
-    rule: "nasm",
     inputs: [resolve(cfg.cwd, src)],
-    orderOnlyInputs: [objectDirStamp(cfg), ...(opts.orderOnlyInputs ?? [])],
-    vars: { nasmflags: opts.flags.join(" ") },
+    after: opts.orderOnlyInputs,
+    depfile: { kind: "gcc", path: `${out}.d` },
+    pool: COMPILE_POOL,
   });
   return out;
 }
@@ -289,33 +143,56 @@ export function nasm(
 function compile(n: Ninja, cfg: Config, src: string, opts: CompileOpts, lang: "cxx" | "cc"): string {
   const absSrc = resolve(cfg.cwd, src);
   const out = objectPath(cfg, src);
+  const compiler = lang === "cxx" ? cfg.cxx : cfg.cc;
 
-  const rule = opts.pch !== undefined && lang === "cxx" ? "cxx_pch" : lang;
-  const flagVar = lang === "cxx" ? "cxxflags" : "cflags";
+  const argv: string[] = [];
+  if (cfg.ccache !== undefined) argv.push(cfg.ccache);
+  argv.push(compiler);
+  if (cfg.windows) argv.push("/nologo", "/showIncludes");
+  argv.push(...opts.flags);
 
   const implicitInputs: string[] = [...(opts.implicitInputs ?? [])];
-  const vars: Record<string, string> = {
-    [flagVar]: opts.flags.join(" "),
-  };
 
-  // PCH is always an implicit dep — if it changes, recompile.
-  if (opts.pch !== undefined) {
+  // PCH is loaded with -include-pch, plus a force-include of the wrapper
+  // header, mirroring CMake's target_precompile_headers(). The force-include
+  // re-applies `#pragma clang system_header` for the current translation
+  // unit's preprocessing pass — without it, warnings from PCH-included
+  // headers aren't suppressed (the pragma's effect is per-preprocessing-pass,
+  // not per-AST). The -Xclang prefix is required: plain -include doesn't
+  // combine with PCH on the clang driver, but -Xclang bypasses the driver's
+  // sanity check. clang-cl accepts the same -Xclang pair; its MSVC-style
+  // alternative (/Yu + /FI) does NOT work — /Yu scans the literal source for
+  // the through-header and ignores /FI-injected includes.
+  if (opts.pch !== undefined && lang === "cxx") {
     assert(opts.pchHeader !== undefined, "cxx with pch requires pchHeader (the wrapper .hxx)");
+    if (!cfg.windows) argv.push("-Winvalid-pch");
+    argv.push(
+      "-Xclang",
+      "-include-pch",
+      "-Xclang",
+      n.rel(opts.pch),
+      "-Xclang",
+      "-include",
+      "-Xclang",
+      n.rel(opts.pchHeader),
+    );
+    // If the PCH changes, recompile.
     implicitInputs.push(opts.pch);
-    vars.pch_file = n.rel(opts.pch);
-    vars.pch_header = n.rel(opts.pchHeader);
   }
+  if (!cfg.windows) argv.push("-MMD", "-MT", n.rel(out), "-MF", `${n.rel(out)}.d`);
+  argv.push(...compileOutputArgs(cfg, n, absSrc, out));
 
-  const node: BuildNode = {
+  n.task({
+    kind: lang,
+    label: n.rel(out),
+    commands: [{ argv }],
     outputs: [out],
-    rule,
     inputs: [absSrc],
-    orderOnlyInputs: [objectDirStamp(cfg), ...(opts.orderOnlyInputs ?? [])],
-    vars,
-  };
-  if (implicitInputs.length > 0) node.implicitInputs = implicitInputs;
-  if (opts.pool !== undefined) node.pool = opts.pool;
-  n.build(node);
+    implicitInputs,
+    after: opts.orderOnlyInputs,
+    depfile: depfileFor(cfg, out),
+    pool: opts.pool ?? COMPILE_POOL,
+  });
 
   // Record for compile_commands.json
   n.addCompileCommand({
@@ -323,7 +200,7 @@ function compile(n: Ninja, cfg: Config, src: string, opts: CompileOpts, lang: "c
     file: absSrc,
     output: n.rel(out),
     arguments: [
-      lang === "cxx" ? cfg.cxx : cfg.cc,
+      compiler,
       ...opts.flags,
       ...(opts.pch !== undefined ? ["-include-pch", n.rel(opts.pch)] : []),
       "-c",
@@ -412,26 +289,102 @@ export function pch(
   // The pragma is ignored in main files but works in includes, hence this dance.
   writeIfChanged(stubCxx, `/* generated by scripts/build/compile.ts */\n`);
 
-  const node: BuildNode = {
+  // CMake's approach (replicated here): compile an EMPTY stub .cxx as the
+  // main file, force-include the wrapper .hxx via -Xclang -include, emit
+  // the PCH via -Xclang -emit-pch. The indirection lets `#pragma clang
+  // system_header` in the wrapper take effect — that pragma is ignored
+  // when the file containing it is the MAIN file, but works when the
+  // file is included. -fpch-instantiate-templates: instantiate templates
+  // during PCH compilation instead of deferring to each consuming .cpp
+  // (faster builds, CMake does this too).
+  // -MD (not -MMD): the wrapper header has `#pragma clang system_header` to
+  // suppress JSC warnings, which makes everything it transitively includes
+  // "system" for -MMD purposes. -MMD would give a near-empty depfile; -MD
+  // tracks all headers so PCH invalidates when WebKit headers change.
+  // -fno-pch-timestamp: don't embed input mtimes in the PCH. A cached PCH's
+  // embedded mtime can be stale (e.g. after deleting pch/ and reconfiguring)
+  // → every consumer fails with "mtime changed". The depfile already
+  // tracks invalidation; clang's redundant mtime check just fights caching.
+  // Windows: -Xclang -include, NOT /FI. clang-cl's /FI auto-promotes to
+  // -include-pch when a .pch already exists at the /Fp path — even for the
+  // /Yc -emit-pch cc1 job — so a stale PCH (e.g. after a cxxflags change)
+  // gets validated instead of overwritten and the build fails with
+  // "<langopt> was enabled in precompiled file but is currently disabled".
+  // -Xclang goes straight to cc1, bypassing the driver's auto-detection.
+  //
+  // No ccache for the PCH. CCACHE_BASEDIR + CCACHE_NOHASHDIR (set in
+  // configure.ts so worktrees share .o cache entries) makes the pch compile
+  // hash identically across worktrees, but clang bakes ABSOLUTE header paths
+  // into the .pch artifact. ccache would serve worktree A's .pch (with
+  // /path/to/A/src/... inside) to worktree B; B's .cpp files then see
+  // every PCH-reached header at A's path and their own #include of the same
+  // header at B's path → #pragma once doesn't match → "redefinition of
+  // 'DOMClientIsoSubspaces'" et al. The pch compile is one ~10-15s job per
+  // build; the cross-worktree correctness hazard outweighs the cache savings.
+  const wrapper = n.rel(wrapperHeader);
+  const argv = cfg.windows
+    ? [
+        cfg.cxx,
+        "/nologo",
+        "/showIncludes",
+        ...opts.flags,
+        "/clang:-fpch-instantiate-templates",
+        "-Xclang",
+        "-fno-pch-timestamp",
+        `/Yc${wrapper}`,
+        "-Xclang",
+        "-include",
+        "-Xclang",
+        wrapper,
+        `/Fp${n.rel(out)}`,
+        "/c",
+        n.rel(stubCxx),
+        `/Fo${n.rel(stubObj)}`,
+      ]
+    : [
+        cfg.cxx,
+        ...opts.flags,
+        "-Winvalid-pch",
+        "-fpch-instantiate-templates",
+        "-Xclang",
+        "-fno-pch-timestamp",
+        "-Xclang",
+        "-emit-pch",
+        "-Xclang",
+        "-include",
+        "-Xclang",
+        wrapper,
+        "-x",
+        "c++-header",
+        "-MD",
+        "-MT",
+        n.rel(out),
+        "-MF",
+        `${n.rel(out)}.d`,
+        "-c",
+        n.rel(stubCxx),
+        "-o",
+        n.rel(out),
+      ];
+
+  n.task({
+    kind: "pch",
+    label: n.rel(out),
+    commands: [{ argv }],
     outputs: [out],
-    rule: "pch",
+    // clang-cl /Yc always writes the stub's .obj as a side effect. Declared
+    // so the engine tracks and cleans it; nothing links it.
+    implicitOutputs: cfg.windows ? [stubObj] : undefined,
     // Compile the STUB, force-include the wrapper.
     inputs: [stubCxx],
     // absHeader + wrapper editing must rebuild PCH. Dep outputs too — see
     // the docstring above for why these can't be order-only (startup-stat
     // vs mid-build header regeneration). The depfile tracks the REST.
     implicitInputs: [absHeader, wrapperHeader, ...(opts.implicitInputs ?? [])],
-    orderOnlyInputs: [pchDirStamp(cfg), ...(opts.orderOnlyInputs ?? [])],
-    vars: {
-      cxxflags: opts.flags.join(" "),
-      pch_header: n.rel(wrapperHeader),
-    },
-  };
-  if (cfg.windows) {
-    node.implicitOutputs = [stubObj];
-    node.vars!.pch_stub_obj = n.rel(stubObj);
-  }
-  n.build(node);
+    after: opts.orderOnlyInputs,
+    depfile: depfileFor(cfg, out),
+    pool: COMPILE_POOL,
+  });
 
   return { pch: out, wrapperHeader };
 }
@@ -461,23 +414,55 @@ export interface LinkOpts {
  */
 export function link(n: Ninja, cfg: Config, out: string, objects: string[], opts: LinkOpts): string {
   const absOut = resolve(cfg.buildDir, out + cfg.exeSuffix);
+  const rsp = `${absOut}.rsp`;
 
-  // Linker maps are implicit outputs (ninja tracks them but they're not in $out)
-  const implicitOutputs = (opts.linkerMapOutputs ?? []).map(map => resolve(cfg.buildDir, map));
+  // Object lists get long (>32k args breaks on windows): a response file
+  // carries the inputs. The link owns the console: it is inherently serial
+  // (one exe), takes 30s+ on large binaries, and lld prints useful progress
+  // (undefined symbol errors, --verbose timing).
+  //
+  // Windows: -fuse-ld=lld forces lld-link (VS dev shell puts link.exe
+  // first in PATH, clang-cl would default to it). /link separator —
+  // everything after passes verbatim to lld-link. Our ldflags are all
+  // pure linker options (/STACK, /DEF, /OPT, /errorlimit, system libs)
+  // that clang-cl's driver doesn't recognize.
+  //
+  // /clang:-B<dir of cfg.ld> pins WHICH lld-link `-fuse-ld=lld` resolves:
+  // -B program-prefix dirs are searched before the driver's own InstalledDir
+  // and PATH. Normally that's the same host-LLVM lld-link the driver would
+  // pick anyway; under cross-language LTO resolveConfig() swaps cfg.ld to
+  // rustc's gcc-ld/lld-link (newer LLVM, able to read rustc's bitcode), and
+  // this is what makes the link actually use it — clang-cl has no working
+  // --ld-path= spelling, and `-fuse-ld=<abs path>` mangles the path with the
+  // target triple.
+  const argv = cfg.windows
+    ? [
+        cfg.cxx,
+        "/nologo",
+        "-fuse-ld=lld",
+        `/clang:-B${dirname(cfg.ld)}`,
+        `@${n.rel(rsp)}`,
+        `/Fe${n.rel(absOut)}`,
+        "/link",
+        ...opts.flags,
+      ]
+    : [cfg.cxx, `@${n.rel(rsp)}`, ...opts.flags, "-o", n.rel(absOut)];
 
-  const node: BuildNode = {
+  n.task({
+    kind: "link",
+    label: n.rel(absOut),
+    // Darwin cross links and rust-lld ELF links need a fixup on the linked
+    // file (re-sign, compress DWARF). They run after the link succeeds, so
+    // the declared output is the final artifact. See shims.ts.
+    commands: [{ argv }, ...postlinkCommands(cfg, n.rel(absOut))],
     outputs: [absOut],
-    rule: "link",
+    // Linker maps: tracked, but not the product.
+    implicitOutputs: (opts.linkerMapOutputs ?? []).map(map => resolve(cfg.buildDir, map)),
     inputs: [...objects, ...opts.libs],
-    vars: {
-      ldflags: opts.flags.join(" "),
-    },
-  };
-  if (implicitOutputs.length > 0) node.implicitOutputs = implicitOutputs;
-  if (opts.implicitInputs !== undefined && opts.implicitInputs.length > 0) {
-    node.implicitInputs = opts.implicitInputs;
-  }
-  n.build(node);
+    implicitInputs: opts.implicitInputs,
+    rspfile: rsp,
+    console: true,
+  });
 
   return absOut;
 }
@@ -489,12 +474,22 @@ export function link(n: Ninja, cfg: Config, out: string, objects: string[], opts
  */
 export function ar(n: Ninja, cfg: Config, out: string, objects: string[], implicitInputs: string[] = []): string {
   const absOut = resolve(cfg.buildDir, out);
+  const rsp = `${absOut}.rsp`;
 
-  n.build({
+  n.task({
+    kind: "ar",
+    label: n.rel(absOut),
+    commands: [
+      {
+        argv: cfg.windows
+          ? [cfg.ar, "/nologo", `/out:${n.rel(absOut)}`, `@${n.rel(rsp)}`]
+          : [cfg.ar, "rcs", n.rel(absOut), `@${n.rel(rsp)}`],
+      },
+    ],
     outputs: [absOut],
-    rule: "ar",
     inputs: objects,
-    ...(implicitInputs.length > 0 ? { implicitInputs } : {}),
+    implicitInputs,
+    rspfile: rsp,
   });
 
   return absOut;
@@ -510,12 +505,7 @@ export function ar(n: Ninja, cfg: Config, out: string, objects: string[], implic
  * Mirrors the source tree under obj/, so `src/jsc/bindings/foo.cpp` →
  * `obj/src/jsc/bindings/foo.cpp.o`. Generated sources (codegen .cpp
  * files under buildDir) go under `obj/codegen/` to keep a single tree.
- *
- * Ninja does NOT auto-create parent directories of outputs. Directories
- * are created at configure time — each `cxx()`/`cc()` call tracks its
- * object's parent dir, and `createObjectDirs()` is called once at the end
- * of configure to mkdir the whole tree. Same approach as CMake, which
- * pre-creates `CMakeFiles/<target>.dir/` during its generate step.
+ * The runner creates the parent directory before the compiler runs.
  */
 function objectPath(cfg: Config, src: string): string {
   const absSrc = resolve(cfg.cwd, src);
@@ -541,47 +531,4 @@ function objectPath(cfg: Config, src: string): string {
   assert(!relSrc.startsWith(".."), `object path for ${absSrc} escapes the build dir (obj/${relSrc})`);
 
   return resolve(cfg.buildDir, "obj", relSrc + cfg.objSuffix);
-}
-
-/**
- * Stamp file for the obj/ directory. Object files depend on this order-only
- * so the dir exists before compilation runs.
- */
-function objectDirStamp(cfg: Config): string {
-  return resolve(cfg.buildDir, "obj", ".dir");
-}
-
-function pchDirStamp(cfg: Config): string {
-  return resolve(cfg.buildDir, "pch", ".dir");
-}
-
-/**
- * Register directory stamp rules. Call once.
- */
-export function registerDirStamps(n: Ninja, cfg: Config): void {
-  const objDir = dirname(objectDirStamp(cfg));
-  const pchDir = dirname(pchDirStamp(cfg));
-
-  // Single rule, mkdir + touch stamp. Configure pre-creates these dirs;
-  // the rule still runs once to write the stamp ninja tracks. Both sides
-  // must tolerate "already exists" — posix has -p, cmd doesn't, so
-  // suppress the error (2>nul) and touch unconditionally (&).
-  n.rule("mkdir_stamp", {
-    command: cfg.host.os === "windows" ? `cmd /c "mkdir $dir 2>nul & type nul > $out"` : `mkdir -p $dir && touch $out`,
-    description: "mkdir $dir",
-  });
-
-  n.build({
-    outputs: [objectDirStamp(cfg)],
-    rule: "mkdir_stamp",
-    inputs: [],
-    vars: { dir: n.rel(objDir) },
-  });
-
-  n.build({
-    outputs: [pchDirStamp(cfg)],
-    rule: "mkdir_stamp",
-    inputs: [],
-    vars: { dir: n.rel(pchDir) },
-  });
 }

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -198,7 +198,7 @@ export interface Config {
   cc: string;
   cxx: string;
   /**
-   * Compiler for build-time host tools (dep_host_cc codegen helpers).
+   * Compiler for build-time host tools (host_cc codegen helpers).
    * Same as `cc` except when cross-compiling for windows from a unix host,
    * where `cc` is clang-cl (emits COFF) and host tools need plain clang.
    */

--- a/scripts/build/configure.ts
+++ b/scripts/build/configure.ts
@@ -95,6 +95,8 @@ export function resolveToolchain(targetOs?: OS): Toolchain {
 export interface ConfigureResult {
   cfg: Config;
   output: BunOutput;
+  /** The assembled graph. build.ninja is its serialization; executor.ts runs it directly. */
+  graph: Ninja;
   /** Build.ninja absolute path. */
   ninjaFile: string;
   /** Env vars the caller should set before spawning ninja. */
@@ -361,5 +363,5 @@ export async function configure(input: ConfigureInput): Promise<ConfigureResult>
   const elapsed = Math.round(performance.now() - start);
   const exe = bunExeName(cfg) + (shouldStrip(cfg) ? " → bun (stripped)" : "");
 
-  return { cfg, output, ninjaFile, env: ccacheEnv(cfg), elapsed, changed, exe };
+  return { cfg, output, graph: n, ninjaFile, env: ccacheEnv(cfg), elapsed, changed, exe };
 }

--- a/scripts/build/depfile.ts
+++ b/scripts/build/depfile.ts
@@ -1,0 +1,247 @@
+/**
+ * Pure parsing helpers for the TypeScript build executor (`executor.ts`).
+ *
+ * - `expandNinja()`: the `$var` / `$$` / `$ ` expansion ninja applies to rule
+ *   strings. The rule commands in this directory are written in that syntax,
+ *   so the executor has to evaluate them the same way ninja does.
+ * - `parseDepfile()`: Makefile-style `.d` files (clang `-MMD -MF`, nasm `-MD`).
+ *   Equivalent of ninja's `deps = gcc`.
+ * - `parseShowIncludes()`: clang-cl `/showIncludes` lines on stdout.
+ *   Equivalent of ninja's `deps = msvc`.
+ */
+
+/**
+ * Expand a ninja rule string. Escapes: `$$` → `$`, `$ ` → space, `$:` → `:`,
+ * `$` + newline → line continuation. `$name` and `${name}` resolve through
+ * `lookup`; an unknown variable expands to the empty string, as in ninja.
+ */
+export function expandNinja(template: string, lookup: (name: string) => string | undefined): string {
+  let out = "";
+  let i = 0;
+  const n = template.length;
+  while (i < n) {
+    const ch = template[i]!;
+    if (ch !== "$") {
+      out += ch;
+      i++;
+      continue;
+    }
+    const next = template[i + 1];
+    if (next === undefined) {
+      throw new Error(`expandNinja: dangling '$' at end of ${JSON.stringify(template)}`);
+    }
+    if (next === "$" || next === " " || next === ":") {
+      out += next;
+      i += 2;
+      continue;
+    }
+    if (next === "\n" || next === "\r") {
+      // Line continuation: skip the newline and the indentation after it.
+      i += 2;
+      if (next === "\r" && template[i] === "\n") i++;
+      while (template[i] === " " || template[i] === "\t") i++;
+      continue;
+    }
+    if (next === "{") {
+      const close = template.indexOf("}", i + 2);
+      if (close === -1) throw new Error(`expandNinja: unterminated '\${' in ${JSON.stringify(template)}`);
+      out += lookup(template.slice(i + 2, close)) ?? "";
+      i = close + 1;
+      continue;
+    }
+    let j = i + 1;
+    while (j < n && /[A-Za-z0-9_-]/.test(template[j]!)) j++;
+    if (j === i + 1) {
+      throw new Error(`expandNinja: bad '$' escape at offset ${i} in ${JSON.stringify(template)}`);
+    }
+    out += lookup(template.slice(i + 1, j)) ?? "";
+    i = j;
+  }
+  return out;
+}
+
+export interface Depfile {
+  /** Paths before the colon. Usually exactly one: the object file. */
+  targets: string[];
+  /** Every prerequisite, in file order, deduplicated. */
+  deps: string[];
+}
+
+/**
+ * Parse a Makefile-style dependency file.
+ *
+ * The escape rules follow ninja's depfile parser (src/depfile_parser.in.cc),
+ * since clang and nasm write files for that consumer today:
+ * - `\` + newline is a line continuation.
+ * - 2N+1 backslashes + space → N backslashes and a space inside the path.
+ *   2N backslashes + space → 2N literal backslashes, then the path ends.
+ * - `\#` → `#`, `\:` (not followed by whitespace) → `:`, `$$` → `$`.
+ * - Any other backslash is literal (Windows path separators in nasm output).
+ * - A colon ends a target only when whitespace or end of input follows it,
+ *   so `C:\x` is a path, not a rule.
+ */
+export function parseDepfile(text: string): Depfile {
+  const targets: string[] = [];
+  const deps: string[] = [];
+  const seen = new Set<string>();
+  // Tokens before the colon of the current rule. `a b : c` and `a: c` both
+  // make `a` a target; nasm writes the former, clang the latter.
+  let pendingTargets: string[] = [];
+  let parsingTargets = true;
+  let token = "";
+  let i = 0;
+  const n = text.length;
+
+  const isSpace = (c: string | undefined) => c === " " || c === "\t" || c === "\n" || c === "\r";
+
+  const endToken = () => {
+    if (token.length === 0) return;
+    if (parsingTargets) pendingTargets.push(token);
+    else if (!seen.has(token)) {
+      seen.add(token);
+      deps.push(token);
+    }
+    token = "";
+  };
+  const colon = () => {
+    endToken();
+    if (pendingTargets.length === 0) throw new Error("depfile: ':' without a target");
+    for (const t of pendingTargets) if (!targets.includes(t)) targets.push(t);
+    pendingTargets = [];
+    parsingTargets = false;
+  };
+  const newline = () => {
+    endToken();
+    if (pendingTargets.length > 0) {
+      // Tokens on a line of their own with no colon: more deps (tolerated, as in make).
+      for (const t of pendingTargets) {
+        if (!seen.has(t)) {
+          seen.add(t);
+          deps.push(t);
+        }
+      }
+      pendingTargets = [];
+    }
+    parsingTargets = true;
+  };
+
+  while (i < n) {
+    const ch = text[i]!;
+    if (ch === "\n" || ch === "\r") {
+      newline();
+      i++;
+      continue;
+    }
+    if (ch === " " || ch === "\t") {
+      endToken();
+      i++;
+      continue;
+    }
+    if (ch === "\\") {
+      let k = 0;
+      while (text[i + k] === "\\") k++;
+      const next = text[i + k];
+      if (next === "\n" || next === "\r") {
+        // Line continuation: the rule goes on.
+        token += "\\".repeat(k - 1);
+        endToken();
+        i += k + 1;
+        if (next === "\r" && text[i] === "\n") i++;
+        continue;
+      }
+      if (next === " ") {
+        if (k % 2 === 1) {
+          token += "\\".repeat((k - 1) / 2) + " ";
+        } else {
+          token += "\\".repeat(k);
+          endToken();
+        }
+        i += k + 1;
+        continue;
+      }
+      if (next === "#") {
+        token += "\\".repeat(k - 1) + "#";
+        i += k + 1;
+        continue;
+      }
+      if (next === ":" && !isSpace(text[i + k + 1]) && i + k + 1 < n) {
+        token += "\\".repeat(k - 1) + ":";
+        i += k + 1;
+        continue;
+      }
+      if (k === 1 && (next === "*" || next === "[" || next === "]" || next === "|")) {
+        token += next;
+        i += 2;
+        continue;
+      }
+      token += "\\".repeat(k);
+      i += k;
+      continue;
+    }
+    if (ch === "$" && text[i + 1] === "$") {
+      token += "$";
+      i += 2;
+      continue;
+    }
+    if (ch === ":") {
+      const next = text[i + 1];
+      if (next === undefined || isSpace(next)) {
+        colon();
+        i++;
+        continue;
+      }
+    }
+    token += ch;
+    i++;
+  }
+  newline();
+  return { targets, deps };
+}
+
+/** What ninja's `msvc_deps_prefix` defaults to. clang-cl prints this in English on every locale. */
+export const SHOW_INCLUDES_PREFIX = "Note: including file:";
+
+export interface ShowIncludes {
+  /** Included headers, in first-seen order, deduplicated. */
+  deps: string[];
+  /** The compiler output with the include lines removed. This is what the user sees. */
+  filtered: string;
+}
+
+/**
+ * Split clang-cl `/showIncludes` output into header deps and the remaining
+ * diagnostics. Mirrors ninja's `CLParser`: include lines are consumed, a
+ * first line that only echoes the source filename is dropped too (cl.exe does
+ * that; clang-cl does not, but the check is cheap).
+ */
+export function parseShowIncludes(output: string, sourceFile?: string): ShowIncludes {
+  const deps: string[] = [];
+  const seen = new Set<string>();
+  const kept: string[] = [];
+  const lines = output.split(/\r?\n/);
+  // `split` on text that ends with a newline leaves a trailing empty string.
+  const trailingNewline = lines.length > 0 && lines[lines.length - 1] === "";
+  if (trailingNewline) lines.pop();
+
+  let first = true;
+  for (const line of lines) {
+    if (line.startsWith(SHOW_INCLUDES_PREFIX)) {
+      const path = line.slice(SHOW_INCLUDES_PREFIX.length).trim();
+      if (path.length > 0 && !seen.has(path)) {
+        seen.add(path);
+        deps.push(path);
+      }
+      continue;
+    }
+    if (first && sourceFile !== undefined) {
+      first = false;
+      const base = sourceFile.replace(/^.*[\\/]/, "");
+      if (line.trim() === base) continue;
+    }
+    first = false;
+    kept.push(line);
+  }
+  let filtered = kept.join("\n");
+  if (kept.length > 0 && trailingNewline) filtered += "\n";
+  return { deps, filtered };
+}

--- a/scripts/build/engine.ts
+++ b/scripts/build/engine.ts
@@ -140,7 +140,7 @@ export class Task {
   startMtime = 0;
   /** @internal */
   startTime = 0;
-  /** @internal */
+  /** @internal Scheduling priority: see Engine.computePriorities. */
   weight = 1;
 
   constructor(id: number, spec: TaskSpec) {
@@ -312,10 +312,7 @@ export class Engine {
 
     const wanted = targets === undefined ? this.tasks : this.closure(targets);
     this.planned = wanted.filter(t => !t.phony).length;
-    for (const t of wanted) {
-      const entry = this.log.lookup(t.spec.outputs[0] ?? "");
-      t.weight = entry !== undefined && entry.durationMs > 0 ? entry.durationMs : 1;
-    }
+    this.computePriorities(wanted);
 
     const onSignal = () => this.interrupt();
     const events = process as unknown as NodeJS.EventEmitter;
@@ -343,6 +340,42 @@ export class Engine {
     }
     if (this.ranCount === 0) this.print("no work to do.\n");
     return { ok: true, ran: this.ranCount, failed: 0, interrupted: false };
+  }
+
+  /**
+   * Pool priority = the longest chain of work from this task to the end of
+   * the build, in ms of last recorded duration (1 ms for a task with no
+   * history). The PCH ranks above the hundreds of dep compiles that are
+   * ready at the same time, because 150 compiles wait on it and nothing
+   * waits on them but the link. Same heuristic as ninja's critical path.
+   */
+  private computePriorities(wanted: Task[]): void {
+    const dependents = new Map<Task, Task[]>();
+    const inSet = new Set(wanted);
+    for (const t of wanted) {
+      for (const d of this.dependencies(t)) {
+        if (!inSet.has(d)) continue;
+        let list = dependents.get(d);
+        if (list === undefined) dependents.set(d, (list = []));
+        list.push(t);
+      }
+    }
+    const own = (t: Task): number => {
+      if (t.phony) return 0;
+      const entry = this.log.lookup(t.spec.outputs[0]!);
+      return entry !== undefined && entry.durationMs > 0 ? entry.durationMs : 1;
+    };
+    const memo = new Map<Task, number>();
+    const critical = (t: Task): number => {
+      const cached = memo.get(t);
+      if (cached !== undefined) return cached;
+      let rest = 0;
+      for (const d of dependents.get(t) ?? []) rest = Math.max(rest, critical(d));
+      const v = own(t) + rest;
+      memo.set(t, v);
+      return v;
+    };
+    for (const t of wanted) t.weight = critical(t);
   }
 
   /** The tasks `targets` depend on, transitively, plus themselves. */

--- a/scripts/build/engine.ts
+++ b/scripts/build/engine.ts
@@ -164,10 +164,14 @@ export class Task {
 
 /** A semaphore whose waiters are served by priority (heaviest task first), then FIFO. */
 class Pool {
+  readonly depth: number;
   private active = 0;
   private readonly queue: { priority: number; seq: number; go: () => void }[] = [];
   private seq = 0;
-  constructor(readonly depth: number) {}
+
+  constructor(depth: number) {
+    this.depth = depth;
+  }
 
   acquire(priority: number): Promise<void> {
     if (this.active < this.depth) {

--- a/scripts/build/engine.ts
+++ b/scripts/build/engine.ts
@@ -547,7 +547,13 @@ export class Engine {
   private spawnCommand(
     task: Task,
     cmd: Command,
-  ): Promise<{ code: number; signal: NodeJS.Signals | null; spawnError: Error | undefined; output: string; stdout: string }> {
+  ): Promise<{
+    code: number;
+    signal: NodeJS.Signals | null;
+    spawnError: Error | undefined;
+    output: string;
+    stdout: string;
+  }> {
     const inherit = task.spec.console === true && this.opts.display !== "quiet";
     const stdio: (number | "pipe" | "inherit" | "ignore")[] = inherit
       ? ["inherit", "inherit", "inherit"]

--- a/scripts/build/engine.ts
+++ b/scripts/build/engine.ts
@@ -1,0 +1,790 @@
+/**
+ * The build engine: incremental task execution, in process.
+ *
+ * This is what ninja did for us, reduced to what the build needs and written
+ * against our own types. Build modules declare work as tasks (an argv, the
+ * files it reads and writes, what it must run after), then `run()` executes
+ * everything that is out of date, in parallel, bounded by pools.
+ *
+ * A task is out of date when: an output is missing; a task it depends on ran
+ * and changed its outputs; an input or a header the compiler reported last
+ * time is newer than the task's last start time (or is gone); the command or
+ * key differs from the one recorded; or it asks to always run (nested builds
+ * that track their own staleness, e.g. cargo, combined with `restat`).
+ *
+ * `restat: true` means "my outputs may come out identical" (writeIfChanged
+ * codegen, cargo no-op): the engine compares output mtimes before and after
+ * and only marks the task `changed` when they moved, so dependents can skip.
+ *
+ * State lives next to the outputs (`build-log.ts`): per output, the command
+ * hash, the filesystem time the command started, its duration (scheduler
+ * weight), and the header deps parsed from the depfile (`depfile.ts`).
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { availableParallelism } from "node:os";
+import { dirname, isAbsolute, normalize, relative, resolve } from "node:path";
+import { BuildLog, DepsLog } from "./build-log.ts";
+import { parseDepfile, parseShowIncludes } from "./depfile.ts";
+import { BuildError } from "./error.ts";
+
+/** How a task does its work. Every path is absolute. */
+export type Command =
+  | { argv: string[]; cwd?: string | undefined; env?: Record<string, string> | undefined }
+  /**
+   * A shell command line, run by `sh -c` (posix) or handed to CreateProcess
+   * (windows) the way ninja did. Only the bridge for not-yet-ported emitters
+   * produces these; new code uses `argv`.
+   */
+  | { shell: string; cwd?: string | undefined; env?: Record<string, string> | undefined };
+
+export interface TaskSpec {
+  /** Group for display and for `--only`: "cxx", "link", "fetch", "codegen", … */
+  kind: string;
+  /** Shown next to the kind while running: the main output, or the dep name. */
+  label: string;
+  /** Files this task writes. At least one, unless it is an alias. */
+  outputs: string[];
+  /** Files this task reads. A newer one than the last run → rerun. */
+  inputs?: string[] | undefined;
+  /**
+   * Must finish first, but their outputs are not inputs (generated headers
+   * the depfile will track, directory stamps). A string names an alias or an
+   * output path and is resolved when the build runs, so declaration order
+   * does not matter. A string that names nothing is ignored.
+   */
+  after?: (Task | string)[] | undefined;
+  /** What to run. A list runs in order and stops at the first failure (link, then a post-link fixup). */
+  command?: Command | Command[] | undefined;
+  /** Written before the command runs, removed after it succeeds. */
+  rspfile?: { path: string; content: string } | undefined;
+  /** Where the compiler reports the headers it read. */
+  depfile?: { kind: "gcc"; path: string } | { kind: "msvc" } | undefined;
+  /** Outputs may be byte-identical after a run; only a moved mtime counts as a change. */
+  restat?: boolean | undefined;
+  /** Run every build (the command decides what is stale). Pair with `restat`. */
+  alwaysRun?: boolean | undefined;
+  /** Concurrency group. Unknown pools are unlimited (within `jobs`). */
+  pool?: string | undefined;
+  /** Owns the terminal while it runs (cargo, the linker). A pool of one. */
+  console?: boolean | undefined;
+  /** Extra material for the change key, when argv does not capture everything. */
+  key?: string | undefined;
+}
+
+export interface TaskResult {
+  /** The command ran (dry run: would have run). */
+  ran: boolean;
+  /** Outputs differ from before. Dependents rerun. */
+  changed: boolean;
+  /** The command failed, or a task it depends on did. */
+  failed: boolean;
+}
+
+export interface EngineOptions {
+  buildDir: string;
+  hostOs: string;
+  env: NodeJS.ProcessEnv;
+  /** Overall parallelism. Default: cores + 2. */
+  jobs?: number | undefined;
+  /** Failures tolerated before no new task starts. 0 = unlimited. Default 1. */
+  keepGoing?: number | undefined;
+  /** Show commands instead of labels. */
+  verbose?: boolean | undefined;
+  /** Decide what would run, run nothing. */
+  dryRun?: boolean | undefined;
+  /** Say why each task runs (stderr). */
+  explain?: boolean | undefined;
+  /** tty: one status line. plain: a line per task (CI logs). quiet: failures only. */
+  display?: "tty" | "plain" | "quiet" | undefined;
+  /** Parent fd exposed as fd 3 to every child (stream.ts live output). */
+  streamFd?: number | undefined;
+  /** Pool depths. `console` is always 1. */
+  pools?: Record<string, number> | undefined;
+}
+
+interface ResolvedOptions {
+  buildDir: string;
+  hostOs: string;
+  env: NodeJS.ProcessEnv;
+  jobs: number;
+  keepGoing: number;
+  verbose: boolean;
+  dryRun: boolean;
+  explain: boolean;
+  display: "tty" | "plain" | "quiet";
+  streamFd: number | undefined;
+}
+
+export interface RunSummary {
+  ok: boolean;
+  ran: number;
+  failed: number;
+  interrupted: boolean;
+}
+
+type State = "pending" | "running" | "done" | "failed" | "skipped";
+
+/** A declared unit of work. Await `task.result` after `Engine.run()` starts. */
+export class Task {
+  readonly id: number;
+  readonly spec: TaskSpec;
+  readonly result: Promise<TaskResult>;
+  /** @internal */
+  resolve!: (r: TaskResult) => void;
+  /** @internal */
+  state: State = "pending";
+  /** @internal */
+  startMtime = 0;
+  /** @internal */
+  startTime = 0;
+  /** @internal */
+  weight = 1;
+
+  constructor(id: number, spec: TaskSpec) {
+    this.id = id;
+    this.spec = spec;
+    this.result = new Promise<TaskResult>(res => {
+      this.resolve = res;
+    });
+  }
+
+  get phony(): boolean {
+    return this.spec.command === undefined;
+  }
+
+  /** @internal */
+  get commands(): Command[] {
+    const c = this.spec.command;
+    return c === undefined ? [] : Array.isArray(c) ? c : [c];
+  }
+}
+
+/** A semaphore whose waiters are served by priority (heaviest task first), then FIFO. */
+class Pool {
+  private active = 0;
+  private readonly queue: { priority: number; seq: number; go: () => void }[] = [];
+  private seq = 0;
+  constructor(readonly depth: number) {}
+
+  acquire(priority: number): Promise<void> {
+    if (this.active < this.depth) {
+      this.active++;
+      return Promise.resolve();
+    }
+    return new Promise(go => {
+      this.queue.push({ priority, seq: this.seq++, go });
+    });
+  }
+
+  release(): void {
+    this.active--;
+    if (this.queue.length === 0) return;
+    let best = 0;
+    for (let i = 1; i < this.queue.length; i++) {
+      const a = this.queue[i]!;
+      const b = this.queue[best]!;
+      if (a.priority > b.priority || (a.priority === b.priority && a.seq < b.seq)) best = i;
+    }
+    const [next] = this.queue.splice(best, 1);
+    this.active++;
+    next!.go();
+  }
+
+  /** Wake every waiter; they see the aborted build and skip. */
+  abort(): void {
+    for (const w of this.queue.splice(0)) {
+      this.active++;
+      w.go();
+    }
+  }
+}
+
+export class Engine {
+  readonly buildDir: string;
+  private readonly opts: ResolvedOptions;
+  private readonly tasks: Task[] = [];
+  private readonly producers = new Map<string, Task>();
+  private readonly aliases = new Map<string, Task>();
+  private readonly pools = new Map<string, Pool>();
+  private readonly jobsPool: Pool;
+  private readonly log: BuildLog;
+  private readonly deps: DepsLog;
+  private readonly lockPath: string;
+  private readonly mtimes = new Map<string, number>();
+  private readonly children = new Map<Task, ChildProcess>();
+
+  private started = false;
+  private planned = 0;
+  private startedCount = 0;
+  private finishedCount = 0;
+  private ranCount = 0;
+  private failures = 0;
+  private interrupted = false;
+  private statusLineActive = false;
+  private consoleActive = false;
+
+  constructor(opts: EngineOptions) {
+    this.buildDir = resolve(opts.buildDir);
+    this.opts = {
+      buildDir: this.buildDir,
+      hostOs: opts.hostOs,
+      env: opts.env,
+      jobs: opts.jobs ?? availableParallelism() + 2,
+      keepGoing: opts.keepGoing ?? 1,
+      verbose: opts.verbose ?? false,
+      dryRun: opts.dryRun ?? false,
+      explain: opts.explain ?? false,
+      display: opts.display ?? (process.stdout.isTTY ? "tty" : "plain"),
+      streamFd: opts.streamFd,
+    };
+    this.jobsPool = new Pool(this.opts.jobs);
+    this.pools.set("console", new Pool(1));
+    for (const [name, depth] of Object.entries(opts.pools ?? {})) this.pools.set(name, new Pool(depth));
+    this.log = new BuildLog(this.buildDir);
+    this.deps = new DepsLog(this.buildDir);
+    this.lockPath = resolve(this.buildDir, ".build_lock");
+  }
+
+  // ─── Declaration ───
+
+  /** Declare a task. Nothing runs until `run()`. */
+  task(spec: TaskSpec): Task {
+    if (this.started) throw new BuildError("engine: task() after run()");
+    if (spec.outputs.length === 0) throw new BuildError(`engine: task '${spec.kind} ${spec.label}' has no outputs`);
+    const task = new Task(this.tasks.length, {
+      ...spec,
+      outputs: spec.outputs.map(p => this.abs(p)),
+      inputs: (spec.inputs ?? []).map(p => this.abs(p)),
+    });
+    for (const out of task.spec.outputs) {
+      const prev = this.producers.get(out);
+      if (prev !== undefined) {
+        throw new BuildError(`engine: two tasks produce ${this.rel(out)}`, {
+          hint: `${prev.spec.kind} ${prev.spec.label} and ${spec.kind} ${spec.label}`,
+        });
+      }
+      this.producers.set(out, task);
+    }
+    this.tasks.push(task);
+    return task;
+  }
+
+  /** A named group of tasks (`bun`, `check`, `codegen`). Runs nothing itself. */
+  alias(name: string, after: (Task | string)[]): Task {
+    if (this.aliases.has(name)) throw new BuildError(`engine: duplicate alias '${name}'`);
+    const task = new Task(this.tasks.length, { kind: "alias", label: name, outputs: [], after });
+    this.aliases.set(name, task);
+    this.aliases.set(this.abs(name), task);
+    this.tasks.push(task);
+    return task;
+  }
+
+  /** Resolve `--target` names: an alias, or an output path. */
+  lookup(name: string): Task | undefined {
+    return this.aliases.get(name) ?? this.producers.get(this.abs(name));
+  }
+
+  /** buildDir-relative form of an absolute path, for display and response files. */
+  rel(p: string): string {
+    const r = relative(this.buildDir, p);
+    return r.startsWith("..") ? p : r;
+  }
+
+  get aliasNames(): string[] {
+    return [...this.aliases.keys()];
+  }
+
+  // ─── Execution ───
+
+  /** Run the given tasks (default: every declared task) and everything they depend on. */
+  async run(targets?: Task[]): Promise<RunSummary> {
+    if (this.started) throw new BuildError("engine: run() twice");
+    this.started = true;
+    this.log.load();
+    this.deps.load();
+
+    const wanted = targets === undefined ? this.tasks : this.closure(targets);
+    this.planned = wanted.filter(t => !t.phony).length;
+    for (const t of wanted) {
+      const entry = this.log.lookup(t.spec.outputs[0] ?? "");
+      t.weight = entry !== undefined && entry.durationMs > 0 ? entry.durationMs : 1;
+    }
+
+    const onSignal = () => this.interrupt();
+    const events = process as unknown as NodeJS.EventEmitter;
+    events.on("SIGINT", onSignal);
+    events.on("SIGTERM", onSignal);
+    try {
+      await Promise.all(wanted.map(t => this.execute(t)));
+    } finally {
+      events.off("SIGINT", onSignal);
+      events.off("SIGTERM", onSignal);
+      this.log.close();
+      this.deps.close();
+      rmSync(this.lockPath, { force: true });
+      this.endStatusLine();
+    }
+
+    if (this.interrupted) {
+      this.print("interrupted by user\n", true);
+      return { ok: false, ran: this.ranCount, failed: this.failures, interrupted: true };
+    }
+    if (this.failures > 0) {
+      const what = this.failures === 1 ? "1 task failed" : `${this.failures} tasks failed`;
+      this.print(`build stopped: ${what}.\n`, true);
+      return { ok: false, ran: this.ranCount, failed: this.failures, interrupted: false };
+    }
+    if (this.ranCount === 0) this.print("no work to do.\n");
+    return { ok: true, ran: this.ranCount, failed: 0, interrupted: false };
+  }
+
+  /** The tasks `targets` depend on, transitively, plus themselves. */
+  private closure(targets: Task[]): Task[] {
+    const seen = new Set<Task>();
+    const visit = (t: Task) => {
+      if (seen.has(t)) return;
+      seen.add(t);
+      for (const d of this.dependencies(t)) visit(d);
+    };
+    for (const t of targets) visit(t);
+    return this.tasks.filter(t => seen.has(t));
+  }
+
+  private dependencies(task: Task): Task[] {
+    const deps = new Set<Task>();
+    for (const a of task.spec.after ?? []) {
+      const t = typeof a === "string" ? this.lookup(a) : a;
+      if (t !== undefined && t !== task) deps.add(t);
+    }
+    for (const input of task.spec.inputs ?? []) {
+      const p = this.producers.get(input) ?? this.aliases.get(input);
+      if (p !== undefined && p !== task) deps.add(p);
+    }
+    return [...deps];
+  }
+
+  /** Inputs that are files: alias names listed as inputs only order the build. */
+  private fileInputs(task: Task): string[] {
+    return (task.spec.inputs ?? []).filter(p => !this.aliases.has(p));
+  }
+
+  private async execute(task: Task): Promise<TaskResult> {
+    if (task.state !== "pending") return task.result;
+    task.state = "running";
+    const result = await this.evaluate(task);
+    task.resolve(result);
+    return result;
+  }
+
+  private async evaluate(task: Task): Promise<TaskResult> {
+    const deps = this.dependencies(task);
+    const upstream = await Promise.all(deps.map(d => this.execute(d)));
+    if (upstream.some(r => r.failed) || this.interrupted || !this.canStart()) {
+      task.state = "skipped";
+      if (!task.phony) this.planned--;
+      return { ran: false, changed: false, failed: true };
+    }
+
+    if (task.phony) {
+      task.state = "done";
+      return { ran: false, changed: upstream.some(r => r.changed), failed: false };
+    }
+
+    const reason = this.whyDirty(task, deps, upstream);
+    if (reason === undefined) {
+      task.state = "done";
+      this.planned--;
+      return { ran: false, changed: false, failed: false };
+    }
+    this.explain(`${task.spec.kind} ${task.spec.label}: ${reason}`);
+
+    // The pool slot first (the scarce one), then a global job slot. Both
+    // queues serve the heaviest waiting task first.
+    const pool = task.spec.console ? this.pools.get("console")! : this.pools.get(task.spec.pool ?? "");
+    if (pool !== undefined) await pool.acquire(task.weight);
+    await this.jobsPool.acquire(task.weight);
+    try {
+      if (!this.canStart()) {
+        task.state = "skipped";
+        this.planned--;
+        return { ran: false, changed: false, failed: true };
+      }
+      return await this.runTask(task);
+    } finally {
+      this.jobsPool.release();
+      pool?.release();
+    }
+  }
+
+  private canStart(): boolean {
+    if (this.interrupted) return false;
+    return this.opts.keepGoing === 0 || this.failures < this.opts.keepGoing;
+  }
+
+  // ─── Dirtiness ───
+
+  /** undefined when up to date; otherwise the first reason to rerun. */
+  private whyDirty(task: Task, deps: Task[], upstream: TaskResult[]): string | undefined {
+    const { spec } = task;
+    if (spec.alwaysRun) return "always runs";
+    for (let i = 0; i < deps.length; i++) {
+      if (upstream[i]!.changed) return `${deps[i]!.spec.kind} ${deps[i]!.spec.label} changed`;
+    }
+    for (const out of spec.outputs) {
+      if (this.mtime(out) === 0) return `${this.rel(out)} is missing`;
+    }
+    const primary = spec.outputs[0]!;
+    const entry = this.log.lookup(primary);
+    if (entry === undefined) return "not in the build log";
+    if (entry.commandHash !== this.hash(task)) return "command changed";
+
+    let inputs: readonly string[] = this.fileInputs(task);
+    if (spec.depfile !== undefined) {
+      const recorded = this.deps.lookup(primary);
+      if (recorded === undefined) return "no header deps recorded";
+      if (this.mtime(primary) > recorded.mtime) return `${this.rel(primary)} changed since its deps were recorded`;
+      inputs = [...inputs, ...recorded.deps];
+    }
+    let oldestOutput = Infinity;
+    for (const out of spec.outputs) oldestOutput = Math.min(oldestOutput, this.mtime(out));
+    for (const input of inputs) {
+      const m = this.mtime(input);
+      if (m === 0) return `${this.rel(input)} is missing`;
+      if (m > entry.startMtime) return `${this.rel(input)} is newer than the last run`;
+      if (spec.restat !== true && m > oldestOutput) return `${this.rel(input)} is newer than ${this.rel(primary)}`;
+    }
+    return undefined;
+  }
+
+  private hash(task: Task): string {
+    const { spec } = task;
+    const h = createHash("sha1");
+    for (const cmd of task.commands) {
+      if ("argv" in cmd) h.update(JSON.stringify([cmd.argv, cmd.cwd ?? "", cmd.env ?? {}]));
+      else h.update(JSON.stringify([cmd.shell, cmd.cwd ?? "", cmd.env ?? {}]));
+    }
+    if (spec.rspfile !== undefined) h.update("\0rsp\0" + spec.rspfile.content);
+    if (spec.key !== undefined) h.update("\0key\0" + spec.key);
+    return h.digest("hex").slice(0, 16);
+  }
+
+  // ─── Running one task ───
+
+  private async runTask(task: Task): Promise<TaskResult> {
+    const { spec } = task;
+    const before = spec.outputs.map(o => this.mtime(o));
+    for (const out of spec.outputs) mkdirSync(dirname(out), { recursive: true });
+    if (spec.rspfile !== undefined && !this.opts.dryRun) {
+      mkdirSync(dirname(this.abs(spec.rspfile.path)), { recursive: true });
+      writeFileSync(this.abs(spec.rspfile.path), spec.rspfile.content);
+    }
+    task.startMtime = this.opts.dryRun ? 0 : this.fsNow();
+    task.startTime = Date.now();
+    this.ranCount++;
+    this.startedCount++;
+    this.statusStarted(task);
+
+    let failure: string | undefined;
+    let failedCommand: Command | undefined;
+    let output = "";
+    let stdout = "";
+    if (!this.opts.dryRun) {
+      for (const cmd of task.commands) {
+        const r = await this.spawnCommand(task, cmd);
+        output += r.output;
+        stdout += r.stdout;
+        if (r.spawnError !== undefined) failure = `failed to start: ${r.spawnError.message}`;
+        else if (r.signal !== null) failure = `terminated by ${r.signal}`;
+        else if (r.code !== 0) failure = `exit code ${r.code}`;
+        if (failure !== undefined || this.interrupted) {
+          failedCommand = cmd;
+          break;
+        }
+      }
+    }
+    this.finishedCount++;
+
+    let headerDeps: string[] | undefined;
+    if (failure === undefined && !this.opts.dryRun && spec.depfile !== undefined) {
+      const extracted = this.extractDeps(task, stdout);
+      if (extracted.error !== undefined) failure = extracted.error;
+      else {
+        headerDeps = extracted.deps;
+        if (extracted.filteredStdout !== undefined) output = extracted.filteredStdout + output.slice(stdout.length);
+      }
+    }
+
+    if (failure !== undefined || this.interrupted) {
+      task.state = "failed";
+      this.failures++;
+      if (!this.interrupted) this.reportFailure(task, failedCommand, output, failure ?? "interrupted");
+      return { ran: true, changed: false, failed: true };
+    }
+
+    if (spec.rspfile !== undefined) rmSync(this.abs(spec.rspfile.path), { force: true });
+    this.statusFinished(task, output);
+
+    let changed = true;
+    if (!this.opts.dryRun) {
+      for (const out of spec.outputs) this.mtimes.delete(out);
+      if (spec.restat === true) {
+        changed = spec.outputs.some((o, i) => this.mtime(o) !== before[i]);
+      }
+      this.log.record(spec.outputs, {
+        commandHash: this.hash(task),
+        startMtime: task.startMtime,
+        durationMs: Date.now() - task.startTime,
+      });
+      if (headerDeps !== undefined) this.deps.record(spec.outputs[0]!, this.mtime(spec.outputs[0]!), headerDeps);
+    }
+    task.state = "done";
+    return { ran: true, changed, failed: false };
+  }
+
+  private spawnCommand(
+    task: Task,
+    cmd: Command,
+  ): Promise<{ code: number; signal: NodeJS.Signals | null; spawnError: Error | undefined; output: string; stdout: string }> {
+    const inherit = task.spec.console === true && this.opts.display !== "quiet";
+    const stdio: (number | "pipe" | "inherit" | "ignore")[] = inherit
+      ? ["inherit", "inherit", "inherit"]
+      : ["ignore", "pipe", "pipe"];
+    if (this.opts.streamFd !== undefined) stdio[3] = this.opts.streamFd;
+    if (inherit) this.consoleBegin();
+
+    const env = cmd.env !== undefined ? { ...this.opts.env, ...cmd.env } : this.opts.env;
+    const cwd = cmd.cwd ?? this.buildDir;
+    const windows = this.opts.hostOs === "windows";
+    let child: ChildProcess;
+    if ("argv" in cmd) {
+      const [program, ...args] = cmd.argv;
+      child = spawn(program!, args, { cwd, env, stdio, windowsHide: true, detached: !windows && !inherit });
+    } else if (windows) {
+      // ninja handed the raw line to CreateProcess. node wants a program plus
+      // arguments: split off the first token, pass the rest verbatim.
+      const { program, rest } = splitProgram(cmd.shell);
+      child = spawn(program, rest.length > 0 ? [rest] : [], {
+        cwd,
+        env,
+        stdio,
+        argv0: /\s/.test(program) ? `"${program}"` : program,
+        windowsVerbatimArguments: true,
+        windowsHide: true,
+      });
+    } else {
+      // Own process group, so a terminal ^C reaches only us and we forward it.
+      // Console jobs stay in ours and get it directly. Same as ninja.
+      child = spawn("/bin/sh", ["-c", cmd.shell], { cwd, env, stdio, detached: !inherit });
+    }
+    this.children.set(task, child);
+
+    return new Promise(done => {
+      const chunks: Buffer[] = [];
+      const stdoutChunks: Buffer[] = [];
+      child.stdout?.on("data", (c: Buffer) => {
+        chunks.push(c);
+        stdoutChunks.push(c);
+      });
+      child.stderr?.on("data", (c: Buffer) => chunks.push(c));
+      let spawnError: Error | undefined;
+      child.on("error", err => {
+        spawnError = err;
+      });
+      child.on("close", (code, signal) => {
+        this.children.delete(task);
+        if (inherit) this.consoleEnd();
+        done({
+          code: code ?? 0,
+          signal,
+          spawnError,
+          output: Buffer.concat(chunks).toString(),
+          stdout: Buffer.concat(stdoutChunks).toString(),
+        });
+      });
+    });
+  }
+
+  private extractDeps(task: Task, stdout: string): { deps?: string[]; filteredStdout?: string; error?: string } {
+    const { spec } = task;
+    const cwd = task.commands[0]?.cwd ?? this.buildDir;
+    const toAbs = (p: string) => normalizePath(isAbsolute(p) ? p : resolve(cwd, p));
+    if (spec.depfile!.kind === "msvc") {
+      const { deps, filtered } = parseShowIncludes(stdout, spec.inputs?.[0]);
+      return { deps: deps.map(toAbs), filteredStdout: filtered };
+    }
+    const path = this.abs(spec.depfile!.path);
+    let text: string;
+    try {
+      text = readFileSync(path, "utf8");
+    } catch (e) {
+      return { error: `depfile ${this.rel(path)} could not be read: ${(e as Error).message}` };
+    }
+    const parsed = parseDepfile(text);
+    const primary = spec.outputs[0]!;
+    if (parsed.targets.length > 0 && !parsed.targets.some(t => toAbs(t) === primary)) {
+      return { error: `depfile ${this.rel(path)} names '${parsed.targets[0]}', expected '${this.rel(primary)}'` };
+    }
+    // Folded into .build_deps; the file itself is not needed again.
+    rmSync(path, { force: true });
+    return { deps: parsed.deps.map(toAbs) };
+  }
+
+  // ─── Interrupt ───
+
+  private interrupt(): void {
+    if (this.interrupted) return;
+    this.interrupted = true;
+    this.jobsPool.abort();
+    for (const p of this.pools.values()) p.abort();
+    for (const [task, child] of this.children) {
+      if (child.pid !== undefined) {
+        try {
+          if (this.opts.hostOs !== "windows" && task.spec.console !== true) process.kill(-child.pid, "SIGINT");
+          else child.kill("SIGINT");
+        } catch {}
+      }
+      // Drop outputs the interrupted command touched, and its depfile, so the
+      // next build does not trust a half-written file. Same as ninja's Cleanup.
+      const depfile = task.spec.depfile?.kind === "gcc" ? this.abs(task.spec.depfile.path) : undefined;
+      for (const out of task.spec.outputs) {
+        if (depfile !== undefined || this.stat(out) !== (this.mtimes.get(out) ?? 0)) rmSync(out, { force: true });
+      }
+      if (depfile !== undefined) rmSync(depfile, { force: true });
+    }
+  }
+
+  // ─── Files ───
+
+  private abs(p: string): string {
+    return normalizePath(isAbsolute(p) ? p : resolve(this.buildDir, p));
+  }
+
+  private mtime(abs: string): number {
+    let m = this.mtimes.get(abs);
+    if (m === undefined) {
+      m = this.stat(abs);
+      this.mtimes.set(abs, m);
+    }
+    return m;
+  }
+
+  private stat(abs: string): number {
+    const st = statSync(abs, { throwIfNoEntry: false });
+    return st === undefined ? 0 : st.mtimeMs;
+  }
+
+  /** The file system's clock, so recorded start times compare with output mtimes. */
+  private fsNow(): number {
+    writeFileSync(this.lockPath, "");
+    return this.stat(this.lockPath);
+  }
+
+  // ─── Output ───
+
+  private explain(msg: string): void {
+    if (this.opts.explain) process.stderr.write(`explain: ${msg}\n`);
+  }
+
+  private print(text: string, always = false): void {
+    if (this.opts.display === "quiet" && !always) return;
+    this.endStatusLine();
+    process.stdout.write(text);
+  }
+
+  private endStatusLine(): void {
+    if (this.statusLineActive) {
+      process.stdout.write("\n");
+      this.statusLineActive = false;
+    }
+  }
+
+  private describe(task: Task): string {
+    if (this.opts.verbose && !task.phony) return task.commands.map(commandText).join(" && ");
+    return `${task.spec.kind} ${task.spec.label}`;
+  }
+
+  private statusText(task: Task): string {
+    return `[${this.startedCount}/${this.planned}] ${this.describe(task)}`;
+  }
+
+  private statusStarted(task: Task): void {
+    if (this.opts.display === "quiet") return;
+    if (this.opts.display === "plain") {
+      process.stdout.write(this.statusText(task) + "\n");
+      return;
+    }
+    // A console job owns the terminal: no status line until it is done.
+    if (this.consoleActive) return;
+    process.stdout.write(`\r\x1b[K${this.statusText(task)}`);
+    this.statusLineActive = true;
+  }
+
+  private statusFinished(task: Task, output: string): void {
+    if (this.opts.display === "quiet") return;
+    if (output.length === 0) {
+      if (this.opts.display === "tty" && !this.consoleActive) {
+        process.stdout.write(`\r\x1b[K${this.statusText(task)}`);
+        this.statusLineActive = true;
+      }
+      return;
+    }
+    this.endStatusLine();
+    if (this.opts.display === "tty") process.stdout.write(this.statusText(task) + "\n");
+    process.stdout.write(output.endsWith("\n") ? output : output + "\n");
+  }
+
+  private reportFailure(task: Task, cmd: Command | undefined, output: string, why: string): void {
+    this.endStatusLine();
+    const text = cmd !== undefined ? commandText(cmd) + "\n" : "";
+    process.stdout.write(`FAILED: ${task.spec.kind} ${task.spec.label} (${why})\n${text}${output}`);
+    if (output.length > 0 && !output.endsWith("\n")) process.stdout.write("\n");
+  }
+
+  private consoleBegin(): void {
+    this.endStatusLine();
+    this.consoleActive = true;
+  }
+
+  private consoleEnd(): void {
+    this.consoleActive = false;
+  }
+}
+
+// ─── Helpers ───
+
+/** A command as a human would type it. For logs and `-v`, not for execution. */
+export function commandText(cmd: Command): string {
+  let prefix = "";
+  if (cmd.cwd !== undefined) prefix += `cd ${cmd.cwd} && `;
+  for (const [k, v] of Object.entries(cmd.env ?? {})) prefix += `${k}=${shellQuote(v)} `;
+  if ("shell" in cmd) return prefix + cmd.shell;
+  return prefix + cmd.argv.map(shellQuote).join(" ");
+}
+
+function shellQuote(s: string): string {
+  if (/^[A-Za-z0-9_+=:,./@%-]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Collapse `a/./b` and `a/../b`. Drops a trailing separator. */
+export function normalizePath(p: string): string {
+  if (p.length === 0) return p;
+  const norm = normalize(p);
+  return norm.length > 1 && (norm.endsWith("/") || norm.endsWith("\\")) ? norm.slice(0, -1) : norm;
+}
+
+/** Split a raw command line into its program token and the verbatim remainder. */
+export function splitProgram(command: string): { program: string; rest: string } {
+  const trimmed = command.trimStart();
+  if (trimmed.startsWith('"')) {
+    const close = trimmed.indexOf('"', 1);
+    if (close === -1) return { program: trimmed.slice(1), rest: "" };
+    return { program: trimmed.slice(1, close), rest: trimmed.slice(close + 1).trimStart() };
+  }
+  const space = trimmed.search(/\s/);
+  if (space === -1) return { program: trimmed, rest: "" };
+  return { program: trimmed.slice(0, space), rest: trimmed.slice(space).trimStart() };
+}

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -13,7 +13,7 @@
 
 import { join } from "node:path";
 import { bunExeName, type Config } from "./config.ts";
-import { quote, slash } from "./shell.ts";
+import { slash } from "./shell.ts";
 import { ucrtServicingLibDir } from "./winsysroot.ts";
 
 export type FlagValue = string | string[] | ((cfg: Config) => string | string[]);
@@ -100,7 +100,7 @@ export const globalFlags: Flag[] = [
     // splat laid out like a VS install (VC/Tools/MSVC + Windows Kits/10),
     // covering the MSVC CRT/STL and Windows SDK headers + import libs.
     // The lld-link equivalent (/winsysroot:) is added in linkerFlags below.
-    flag: c => ["/winsysroot", quote(c.winsysroot!, false)],
+    flag: c => ["/winsysroot", c.winsysroot!],
     when: c => c.windows && c.winsysroot !== undefined,
     desc: "Windows cross-compile: MSVC CRT + Windows SDK root (xwin splat)",
   },
@@ -737,9 +737,9 @@ export const defines: Flag[] = [
     desc: "Core bun defines (always on)",
   },
   {
-    // Shell-escaped quotes so clang receives literal quotes in the define
-    // (the preprocessor needs the string to be "26.3.0", not bare 26.3.0).
-    flag: c => `REPORTED_NODEJS_VERSION=\\"${c.nodejsVersion}\\"`,
+    // Literal quotes: the preprocessor needs the string to be "26.3.0", not
+    // bare 26.3.0. Flags are argv entries, so nothing here is shell-escaped.
+    flag: c => `REPORTED_NODEJS_VERSION="${c.nodejsVersion}"`,
     desc: "Node.js version string reported by process.version",
   },
   {
@@ -747,7 +747,7 @@ export const defines: Flag[] = [
     desc: "Node.js ABI version (process.versions.modules)",
   },
   {
-    flag: c => `REPORTED_NODEJS_V8_VERSION=\\"${c.nodejsV8Version}\\"`,
+    flag: c => `REPORTED_NODEJS_V8_VERSION="${c.nodejsV8Version}"`,
     desc: "V8 version string (process.versions.v8)",
   },
   {
@@ -774,7 +774,7 @@ export const defines: Flag[] = [
   },
   {
     // slash(): path becomes a C string literal — `\U` would be a unicode escape.
-    flag: c => `BUN_DYNAMIC_JS_LOAD_PATH=\\"${slash(join(c.buildDir, "js"))}\\"`,
+    flag: c => `BUN_DYNAMIC_JS_LOAD_PATH="${slash(join(c.buildDir, "js"))}"`,
     when: c => c.debug && !c.ci,
     desc: "Hot-reload built-in JS from build dir (dev convenience)",
   },
@@ -949,7 +949,7 @@ export const linkerFlags: Flag[] = [
     // splat's stale copies (see UCRT_SERVICING_VERSION in winsysroot.ts —
     // the VS-manifest payload xwin downloads carries an ancient arm64 UCRT
     // with broken printf formatting).
-    flag: c => quote(`/libpath:${ucrtServicingLibDir(c)!}`, false),
+    flag: c => `/libpath:${ucrtServicingLibDir(c)!}`,
     when: c => c.windows && c.host.os !== "windows",
     desc: "Windows cross-compile: serviced Universal CRT static libs (SDK NuGet) override the splat's",
   },
@@ -959,7 +959,7 @@ export const linkerFlags: Flag[] = [
     // globalFlags — repeat it in lld-link's own spelling so the MSVC CRT
     // and Windows SDK import libraries (libcmt, kernel32, ...) are found
     // without a VS dev shell's LIB env.
-    flag: c => quote(`/winsysroot:${c.winsysroot!}`, false),
+    flag: c => `/winsysroot:${c.winsysroot!}`,
     when: c => c.windows && c.winsysroot !== undefined,
     desc: "Windows cross-compile: MSVC CRT + Windows SDK library search root (xwin splat)",
   },
@@ -1426,7 +1426,7 @@ export const linkerFlags: Flag[] = [
     // We only fall onto rust-lld for cross-language LTO when rustc's LLVM is
     // newer than the system clang/lld (see config.ts `cfg.ld` selection); in
     // that case the link-time flag is dropped and llvm-objcopy compresses
-    // post-link instead (shims.ts elfDebugCompressPostlinkCommand) — an
+    // post-link instead (shims.ts postlinkCommands) — an
     // uncompressed bun-profile is ~2x larger and every `--compile` test
     // copies it, so leaving it uncompressed times CI out.
     flag: "-Wl,--compress-debug-sections=zlib",

--- a/scripts/build/ninja.ts
+++ b/scripts/build/ninja.ts
@@ -12,6 +12,7 @@ import { mkdir } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 import { BuildError, assert } from "./error.ts";
 import { writeIfChanged } from "./fs.ts";
+import { quote } from "./shell.ts";
 
 /**
  * A ninja `rule` — a reusable command template.
@@ -86,13 +87,81 @@ export interface NinjaOptions {
   buildDir: string;
   /** Minimum ninja version to require. */
   ninjaVersion?: string;
+  /** Host runs cmd.exe (affects how native tasks are quoted in build.ninja). Default: this process's platform. */
+  hostWindows?: boolean;
 }
 
 /**
- * Ninja build file writer.
+ * A `build()` statement as retained in memory for the engine bridge
+ * (`bridge.ts`). Same shape as `BuildNode`, but every path is already
+ * buildDir-relative and unescaped, and the rule is resolved. `build.ninja`
+ * is the serialized form of this list.
+ */
+export interface GraphEdge {
+  readonly id: number;
+  readonly rule: string;
+  readonly outputs: readonly string[];
+  readonly implicitOutputs: readonly string[];
+  readonly inputs: readonly string[];
+  readonly implicitInputs: readonly string[];
+  readonly orderOnlyInputs: readonly string[];
+  readonly vars: Readonly<Record<string, string>>;
+  /** Effective pool: the edge override, else the rule's pool, else "" (none). */
+  readonly pool: string;
+}
+
+/** One program invocation inside a `NativeTask`. argv paths are as the tool sees them (cwd-relative or absolute). */
+export interface NativeCommand {
+  argv: string[];
+  /** Working directory. Default: the build dir. */
+  cwd?: string | undefined;
+  /** Extra environment on top of the build's. */
+  env?: Record<string, string> | undefined;
+}
+
+/**
+ * A task declared with `Ninja.task()`: the native form, which the engine runs
+ * as-is (`engine.ts`). Paths are absolute. Unlike `BuildNode` there is no
+ * rule, no `$var` template, and no shell: the command is argv plus cwd/env.
+ * `toString()` still serializes it for `--runner=ninja`, with the shell
+ * quoting done in one place here instead of in every emitter.
+ */
+export interface NativeTask {
+  /** Display group: "cxx", "link", "fetch", … Also the exported rule name. */
+  kind: string;
+  /** Shown while running: the main output, or the dep name. */
+  label: string;
+  /** Runs in order; stops at the first failure. */
+  commands: NativeCommand[];
+  outputs: string[];
+  /** Outputs the engine tracks that are not the main product (linker maps, the PCH stub object). */
+  implicitOutputs?: string[] | undefined;
+  /** Inputs the command consumes. These are also the response file's lines when `rspfile` is set. */
+  inputs: string[];
+  /** Inputs tracked for staleness only (the PCH, a dep's .a, a symbol list). */
+  implicitInputs?: string[] | undefined;
+  /** Must exist first, mtime ignored: generated headers (the depfile tracks the ones really read), dir stamps. Paths or phony names. */
+  after?: string[] | undefined;
+  depfile?: { kind: "gcc"; path: string } | { kind: "msvc" } | undefined;
+  /** Response file: `inputs`, one per line. For linkers and archivers. */
+  rspfile?: string | undefined;
+  /** Outputs may be identical after a run; only a moved mtime is a change. */
+  restat?: boolean | undefined;
+  /** Run every build; the command tracks its own staleness (cargo, cmake). */
+  alwaysRun?: boolean | undefined;
+  pool?: string | undefined;
+  /** Owns the terminal while it runs. */
+  console?: boolean | undefined;
+}
+
+/**
+ * Build recorder and ninja file writer.
  *
- * Accumulates rules, build statements, variables, pools. Call `write()` to emit
- * `build.ninja` + `compile_commands.json`.
+ * Two ways to declare work, both retained in memory and both serializable to
+ * `build.ninja`:
+ * - `task()`: the native form (argv, cwd, env). New code uses this.
+ * - `rule()` + `build()`: ninja rule templates. The not-yet-ported emitters
+ *   use these; `bridge.ts` expands them for the engine.
  *
  * All paths given to this class should be ABSOLUTE. They are converted to
  * buildDir-relative at write time via `rel()`.
@@ -108,6 +177,14 @@ export class Ninja {
   private readonly defaults: string[] = [];
   private readonly compileCommands: CompileCommand[] = [];
 
+  // Structured copy of everything written to `lines`, for the engine.
+  // `build.ninja` stays the serialized form of the same data.
+  private readonly ruleSpecs = new Map<string, Rule>();
+  private readonly edgeList: GraphEdge[] = [];
+  private readonly nativeTasks: NativeTask[] = [];
+  /** Host shell dialect for the exported `$cmd` of native tasks. */
+  private readonly hostWindows: boolean;
+
   constructor(opts: NinjaOptions) {
     assert(isAbsolute(opts.buildDir), `Ninja buildDir must be absolute, got: ${opts.buildDir}`);
     this.buildDir = resolve(opts.buildDir);
@@ -115,6 +192,7 @@ export class Ninja {
     // (1.5), restat (1.0). We don't use dyndep (1.10's headline feature).
     // Some CI agents (darwin) ship 1.9 and we don't control their image.
     this.ninjaVersion = opts.ninjaVersion ?? "1.9";
+    this.hostWindows = opts.hostWindows ?? process.platform === "win32";
   }
 
   /**
@@ -158,6 +236,7 @@ export class Ninja {
     assert(/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name), `Invalid ninja rule name: ${name}`);
     assert(!this.ruleNames.has(name), `Duplicate rule: ${name}`);
     this.ruleNames.add(name);
+    this.ruleSpecs.set(name, { ...spec });
 
     this.lines.push(`rule ${name}`);
     this.lines.push(`  command = ${spec.command}`);
@@ -212,11 +291,29 @@ export class Ninja {
       this.outputSet.add(abs);
     }
 
-    const outs = node.outputs.map(p => ninjaEscapePath(this.rel(p)));
-    const implOuts = (node.implicitOutputs ?? []).map(p => ninjaEscapePath(this.rel(p)));
-    const ins = node.inputs.map(p => ninjaEscapePath(this.rel(p)));
-    const implIns = (node.implicitInputs ?? []).map(p => ninjaEscapePath(this.rel(p)));
-    const orderIns = (node.orderOnlyInputs ?? []).map(p => ninjaEscapePath(this.rel(p)));
+    const relOuts = node.outputs.map(p => this.rel(p));
+    const relImplOuts = (node.implicitOutputs ?? []).map(p => this.rel(p));
+    const relIns = node.inputs.map(p => this.rel(p));
+    const relImplIns = (node.implicitInputs ?? []).map(p => this.rel(p));
+    const relOrderIns = (node.orderOnlyInputs ?? []).map(p => this.rel(p));
+
+    this.edgeList.push({
+      id: this.edgeList.length,
+      rule: node.rule,
+      outputs: relOuts,
+      implicitOutputs: relImplOuts,
+      inputs: relIns,
+      implicitInputs: relImplIns,
+      orderOnlyInputs: relOrderIns,
+      vars: { ...(node.vars ?? {}) },
+      pool: node.pool ?? this.ruleSpecs.get(node.rule)?.pool ?? "",
+    });
+
+    const outs = relOuts.map(ninjaEscapePath);
+    const implOuts = relImplOuts.map(ninjaEscapePath);
+    const ins = relIns.map(ninjaEscapePath);
+    const implIns = relImplIns.map(ninjaEscapePath);
+    const orderIns = relOrderIns.map(ninjaEscapePath);
 
     let line = `build ${outs.join(" ")}`;
     if (implOuts.length > 0) {
@@ -283,6 +380,54 @@ export class Ninja {
   }
 
   /**
+   * Declare a native task. Outputs must be unique across the whole build.
+   * Serialized to build.ninja as a rule named after `kind` (see
+   * `nativeRuleName`) with the shell-quoted command in `$cmd`.
+   */
+  task(t: NativeTask): void {
+    assert(t.outputs.length > 0, `task '${t.kind} ${t.label}' must have at least one output`);
+    assert(t.commands.length > 0, `task '${t.kind} ${t.label}' must have a command`);
+    assert(/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(t.kind), `Invalid task kind: ${t.kind}`);
+    for (const out of [...t.outputs, ...(t.implicitOutputs ?? [])]) {
+      const abs = resolve(this.buildDir, out);
+      if (this.outputSet.has(abs)) {
+        throw new BuildError(`Duplicate build output: ${out}`, {
+          hint: "Another build statement already produces this file",
+        });
+      }
+      this.outputSet.add(abs);
+    }
+    this.nativeTasks.push(t);
+  }
+
+  // ─── Structured graph access (for bridge.ts) ───
+
+  /** Every `build()` statement, in emission order. Paths are buildDir-relative. */
+  get edges(): readonly GraphEdge[] {
+    return this.edgeList;
+  }
+
+  /** Every `task()` declaration, in emission order. Paths are absolute. */
+  get tasks(): readonly NativeTask[] {
+    return this.nativeTasks;
+  }
+
+  /** The rule a build statement refers to. "phony" has no spec. */
+  getRule(name: string): Rule | undefined {
+    return this.ruleSpecs.get(name);
+  }
+
+  /** Declared pools. "console" is implicit (depth 1) and not listed here. */
+  get poolDepths(): ReadonlyMap<string, number> {
+    return this.pools;
+  }
+
+  /** Default targets, buildDir-relative. */
+  get defaultTargets(): readonly string[] {
+    return this.defaults;
+  }
+
+  /**
    * Record a compile command for compile_commands.json.
    * Called by `cxx()` and `cc()` in compile.ts.
    */
@@ -312,7 +457,73 @@ export class Ninja {
     const defaultLines: string[] =
       this.defaults.length > 0 ? [`default ${this.defaults.map(ninjaEscapePath).join(" ")}`, ""] : [];
 
-    return [...header, ...poolLines, ...this.lines, ...defaultLines].join("\n");
+    return [...header, ...poolLines, ...this.lines, ...this.nativeLines(), ...defaultLines].join("\n");
+  }
+
+  /**
+   * Native tasks as ninja text. One rule per distinct (kind, depfile, restat,
+   * rspfile, pool) combination; the command itself is a per-edge `$cmd`.
+   */
+  private nativeLines(): string[] {
+    const lines: string[] = [];
+    const rules = new Map<string, string>();
+    let usesAlways = false;
+    for (const t of this.nativeTasks) {
+      const pool = t.console ? "console" : t.pool;
+      const key = JSON.stringify([t.kind, t.depfile?.kind, t.restat === true, t.rspfile !== undefined, pool]);
+      let name = rules.get(key);
+      if (name === undefined) {
+        name = nativeRuleName(t.kind, [...rules.values()], this.ruleNames);
+        rules.set(key, name);
+        lines.push(`rule ${name}`, `  command = $cmd`, `  description = $desc`);
+        if (t.depfile?.kind === "gcc") lines.push(`  depfile = $depfile`, `  deps = gcc`);
+        if (t.depfile?.kind === "msvc") lines.push(`  deps = msvc`);
+        if (t.restat === true) lines.push(`  restat = 1`);
+        if (t.rspfile !== undefined) lines.push(`  rspfile = $rspfile`, `  rspfile_content = $in_newline`);
+        if (pool !== undefined) lines.push(`  pool = ${pool}`);
+        lines.push("");
+      }
+      const esc = (p: string) => ninjaEscapePath(this.rel(p));
+      let line = `build ${t.outputs.map(esc).join(" ")}`;
+      if (t.implicitOutputs?.length) line += ` | ${t.implicitOutputs.map(esc).join(" ")}`;
+      line += `: ${name}`;
+      if (t.inputs.length > 0) line += ` ${t.inputs.map(esc).join(" ")}`;
+      if (t.implicitInputs?.length) line += ` | ${t.implicitInputs.map(esc).join(" ")}`;
+      const after = [...(t.after ?? [])];
+      if (t.alwaysRun === true) {
+        after.push("always");
+        usesAlways = true;
+      }
+      if (after.length > 0) line += ` || ${after.map(esc).join(" ")}`;
+      lines.push(wrapLongLine(line));
+      lines.push(`  cmd = ${ninjaEscapeVarValue(this.shellCommand(t.commands))}`);
+      lines.push(`  desc = ${ninjaEscapeVarValue(`${t.kind} ${t.label}`)}`);
+      if (t.depfile?.kind === "gcc") lines.push(`  depfile = ${ninjaEscapeVarValue(this.rel(t.depfile.path))}`);
+      if (t.rspfile !== undefined) lines.push(`  rspfile = ${ninjaEscapeVarValue(this.rel(t.rspfile))}`);
+      lines.push("");
+    }
+    if (usesAlways && !this.outputSet.has(resolve(this.buildDir, "always"))) {
+      lines.push("build always: phony", "");
+    }
+    return lines;
+  }
+
+  /**
+   * The shell text ninja runs for a native task. posix: `cd X && K=V prog
+   * args && …`. Windows host: ninja hands the line to CreateProcess, so a cwd,
+   * env, or chain needs `cmd /c "…"`; a bare argv goes through verbatim.
+   */
+  private shellCommand(commands: NativeCommand[]): string {
+    const win = this.hostWindows;
+    const parts = commands.map(c => {
+      let s = "";
+      if (c.cwd !== undefined) s += win ? `cd /d ${quote(c.cwd, true)} && ` : `cd ${quote(c.cwd, false)} && `;
+      for (const [k, v] of Object.entries(c.env ?? {})) s += win ? `set ${k}=${v}&& ` : `${k}=${quote(v, false)} `;
+      return s + c.argv.map(a => quote(a, win)).join(" ");
+    });
+    const joined = parts.join(" && ");
+    const needsShell = commands.length > 1 || commands.some(c => c.cwd !== undefined || c.env !== undefined);
+    return win && needsShell ? `cmd /c "${joined}"` : joined;
   }
 
   /**
@@ -349,6 +560,13 @@ export class Ninja {
 // 1. Paths in build lines: $ and space must be escaped with $
 // 2. Variable values: only $ needs escaping (newlines need $\n but we don't emit those)
 // ---------------------------------------------------------------------------
+
+/** `kind`, or `kind_2`, `kind_3`… when the same kind needs several rule variants. Never a legacy rule's name. */
+function nativeRuleName(kind: string, taken: string[], legacy: Set<string>): string {
+  let name = kind;
+  for (let i = 2; taken.includes(name) || legacy.has(name); i++) name = `${kind}_${i}`;
+  return name;
+}
 
 /** Escape a path for use in a `build` line. */
 function ninjaEscapePath(path: string): string {

--- a/scripts/build/ninja.ts
+++ b/scripts/build/ninja.ts
@@ -12,7 +12,7 @@ import { mkdir } from "node:fs/promises";
 import { isAbsolute, relative, resolve } from "node:path";
 import { BuildError, assert } from "./error.ts";
 import { writeIfChanged } from "./fs.ts";
-import { quote } from "./shell.ts";
+import { quote, quoteWin32Argv } from "./shell.ts";
 
 /**
  * A ninja `rule` — a reusable command template.
@@ -511,7 +511,9 @@ export class Ninja {
   /**
    * The shell text ninja runs for a native task. posix: `cd X && K=V prog
    * args && …`. Windows host: ninja hands the line to CreateProcess, so a cwd,
-   * env, or chain needs `cmd /c "…"`; a bare argv goes through verbatim.
+   * env, or chain needs `cmd /c "…"`; a bare argv goes through verbatim with
+   * CommandLineToArgvW quoting (cmd leaves `\"` alone, so the same quoting
+   * works inside the wrapper).
    */
   private shellCommand(commands: NativeCommand[]): string {
     const win = this.hostWindows;
@@ -519,7 +521,7 @@ export class Ninja {
       let s = "";
       if (c.cwd !== undefined) s += win ? `cd /d ${quote(c.cwd, true)} && ` : `cd ${quote(c.cwd, false)} && `;
       for (const [k, v] of Object.entries(c.env ?? {})) s += win ? `set ${k}=${v}&& ` : `${k}=${quote(v, false)} `;
-      return s + c.argv.map(a => quote(a, win)).join(" ");
+      return s + c.argv.map(a => (win ? quoteWin32Argv(a) : quote(a, false))).join(" ");
     });
     const joined = parts.join(" && ");
     const needsShell = commands.length > 1 || commands.some(c => c.cwd !== undefined || c.env !== undefined);

--- a/scripts/build/rules.ts
+++ b/scripts/build/rules.ts
@@ -20,7 +20,7 @@
  */
 
 import { registerCodegenRules } from "./codegen.ts";
-import { registerCompileRules, registerDirStamps } from "./compile.ts";
+import { registerCompilePools } from "./compile.ts";
 import type { Config } from "./config.ts";
 import type { Ninja } from "./ninja.ts";
 import { registerRustRules } from "./rust.ts";
@@ -35,12 +35,8 @@ import { registerDepRules } from "./source.ts";
  * rules in build.ninja are ignored by ninja.
  */
 export function registerAllRules(n: Ninja, cfg: Config): void {
-  // mkdir_stamp rule + obj/pch dir stamps. Must be first — codegen
-  // registers its own dir stamp using this rule.
-  registerDirStamps(n, cfg);
-
-  // cxx, cc, pch, link, ar
-  registerCompileRules(n, cfg);
+  // The `compile` pool that caps cc/cxx/pch/nasm tasks.
+  registerCompilePools(n);
 
   // dep_fetch, dep_fetch_prebuilt, dep_configure, dep_build, dep_cargo
   // WebKit prebuilt uses dep_fetch_prebuilt; local uses dep_configure/dep_build.

--- a/scripts/build/shell.ts
+++ b/scripts/build/shell.ts
@@ -63,6 +63,29 @@ export function quote(arg: string, windows: boolean): string {
 }
 
 /**
+ * Quote one argv entry for a Windows command line that CreateProcess hands
+ * to the program unchanged (no cmd.exe in between): CommandLineToArgvW rules,
+ * so `"` becomes `\"` and the backslashes before a quote are doubled. This is
+ * what ninja does for `$in`/`$out` on Windows. Safe characters pass through.
+ */
+export function quoteWin32Argv(arg: string): string {
+  if (/^[A-Za-z0-9_@%+=:,./\\\-]+$/.test(arg)) return arg;
+  let out = '"';
+  let backslashes = 0;
+  for (const ch of arg) {
+    if (ch === "\\") {
+      backslashes++;
+      out += ch;
+      continue;
+    }
+    if (ch === '"') out += "\\".repeat(backslashes) + '\\"';
+    else out += ch;
+    backslashes = 0;
+  }
+  return out + "\\".repeat(backslashes) + '"';
+}
+
+/**
  * Quote an array of arguments and join with spaces.
  *
  * Convenience for the common "I have argv[] and want a shell command string"

--- a/scripts/build/shims.ts
+++ b/scripts/build/shims.ts
@@ -15,7 +15,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { Config } from "./config.ts";
 import { DARWIN_STACK_SIZE } from "./flags.ts";
-import type { Ninja } from "./ninja.ts";
+import type { NativeCommand, Ninja } from "./ninja.ts";
 import { quote } from "./shell.ts";
 
 export interface ShimLinkOpts {
@@ -69,9 +69,34 @@ export function machoEntitlementsPlist(cfg: Config): string {
 }
 
 /**
+ * The fixups to run on a freshly linked executable, as argv commands for the
+ * link task (`compile.ts`). `out` is the executable as the linker names it
+ * (buildDir-relative). Empty when no fixup is needed.
+ */
+export function postlinkCommands(cfg: Config, out: string): NativeCommand[] {
+  const commands: NativeCommand[] = [];
+  if (needsElfDebugCompressPostlink(cfg)) {
+    const llvmObjcopy = resolve(dirname(cfg.cc), "llvm-objcopy");
+    commands.push({
+      argv: [existsSync(llvmObjcopy) ? llvmObjcopy : "llvm-objcopy", "--compress-debug-sections=zlib", out],
+    });
+  }
+  if (needsMachoPostlink(cfg)) {
+    // x64 has no LC_CODE_SIGNATURE to re-sign (see the -adhoc_codesign flag
+    // entry) — only the stack size is patched. macho-postlink errors if asked
+    // to embed entitlements into an unsigned binary, which is the safety net
+    // that keeps arm64 from ever silently shipping unsigned.
+    const argv = [machoPostlinkToolPath(cfg), out, `--stack-size=${DARWIN_STACK_SIZE}`];
+    if (cfg.arm64) argv.push(`--entitlements=${machoEntitlementsPlist(cfg)}`);
+    commands.push({ argv });
+  }
+  return commands;
+}
+
+/**
  * Command suffix to append to a rule that produces a Mach-O executable at
- * `$out` (the link rule and the strip rule). Empty string when the fixup
- * isn't needed so callers can append unconditionally.
+ * `$out` (the strip rule). Empty string when the fixup isn't needed so
+ * callers can append unconditionally. The link task uses `postlinkCommands`.
  */
 export function machoPostlinkCommand(cfg: Config): string {
   if (!needsMachoPostlink(cfg)) return "";
@@ -106,17 +131,6 @@ export function machoPostlinkImplicitInputs(cfg: Config): string[] {
  */
 export function needsElfDebugCompressPostlink(cfg: Config): boolean {
   return (cfg.linux || cfg.freebsd) && cfg.rustLld !== undefined && cfg.ld === cfg.rustLld;
-}
-
-/**
- * Command suffix for the link rule: `... -o $out && llvm-objcopy
- * --compress-debug-sections=zlib $out`. Empty when not needed so callers
- * can append unconditionally (mutually exclusive with machoPostlinkCommand).
- */
-export function elfDebugCompressPostlinkCommand(cfg: Config): string {
-  if (!needsElfDebugCompressPostlink(cfg)) return "";
-  const llvmObjcopy = resolve(dirname(cfg.cc), "llvm-objcopy");
-  return ` && ${quote(existsSync(llvmObjcopy) ? llvmObjcopy : "llvm-objcopy", false)} --compress-debug-sections=zlib $out`;
 }
 
 /**

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -665,25 +665,6 @@ export function registerDepRules(n: Ninja, cfg: Config): void {
     pool: "dep",
   });
 
-  // DirectBuild host tool: compile+link in one clang invocation with NO
-  // cfg target/arch flags — the tool runs on the build host. cc()/link()
-  // would add --target which breaks cross-compiles. cfg.hostCc (not cfg.cc):
-  // when cross-compiling for windows, cc is clang-cl and defaults to a
-  // *-windows-msvc triple — host tools must stay plain clang.
-  n.rule("dep_host_cc", {
-    command: `${q(cfg.hostCc)} $flags -o $out $in`,
-    description: "host-cc $out",
-  });
-
-  // DirectBuild codegen: runs a host tool built by this graph to produce a
-  // header. cwd is the dep source dir so the tool sees its inputs; output
-  // path is absolute. restat: no-op if the header content is unchanged.
-  n.rule("dep_codegen", {
-    command: `${stream} --cwd=$cwd $tool $args`,
-    description: "codegen $name",
-    restat: true,
-  });
-
   // DirectBuild header substitution: literal string replacement on a
   // template file (cmake's configure_file(@ONLY) without the cmake).
   // restat is what makes this cheap — if the output text is unchanged
@@ -1634,32 +1615,34 @@ function emitDirect(
     // target triple, just the tool defines and -w. Compile+link in one go
     // so host-arch objects never land in obj/ (which would dirty ccache
     // for the target build).
+    // cfg.hostCc (not cfg.cc): when cross-compiling for windows, cc is
+    // clang-cl and defaults to a *-windows-msvc triple — host tools must
+    // stay plain clang.
     const toolDefs = Object.entries(cg.toolDefines ?? {}).map(([k, v]) => defineFlag(k, v));
-    n.build({
+    n.task({
+      kind: "host_cc",
+      label: n.rel(toolOut),
+      commands: [{ argv: [cfg.hostCc, "-w", ...toolDefs, "-o", n.rel(toolOut), toolSrc] }],
       outputs: [toolOut],
-      rule: "dep_host_cc",
       inputs: [toolSrc],
-      orderOnlyInputs: orderOnly,
-      vars: { flags: ["-w", ...toolDefs].join(" ") },
+      after: orderOnly,
     });
     const toolExe = toolOut;
 
     // Run tool. "$out" in args expands to the generated header's absolute
     // path; other args resolve against srcDir. Tool runs with srcDir as
-    // cwd so relative input paths it opens internally Just Work.
+    // cwd so relative input paths it opens internally Just Work. restat:
+    // no-op if the header content is unchanged.
     generatedHeader = resolve(buildDir, cg.output);
     const argv = cg.args.map(a => (a === "$out" ? generatedHeader! : resolve(srcDir, a)));
 
-    n.build({
+    n.task({
+      kind: "dep_codegen",
+      label: name,
+      commands: [{ argv: [toolExe, ...argv], cwd: srcDir }],
       outputs: [generatedHeader],
-      rule: "dep_codegen",
       inputs: [toolExe],
-      vars: {
-        name,
-        cwd: srcDir,
-        tool: q(toolExe),
-        args: quoteArgs(argv, hostWin),
-      },
+      restat: true,
     });
   }
 
@@ -1760,11 +1743,11 @@ function emitForbidUndefined(
 }
 
 /**
- * Format a -D flag. String values become shell-escaped C string literals
- * (-DNAME=\"val\" → compiler sees "val"); numbers/true pass through bare.
+ * Format a -D flag. String values become C string literals (-DNAME="val");
+ * numbers/true pass through bare. Flags are argv entries: no shell escaping.
  */
 function defineFlag(name: string, value: string | number | true): string {
   if (value === true) return `-D${name}`;
   if (typeof value === "number") return `-D${name}=${value}`;
-  return `-D${name}=\\"${value}\\"`;
+  return `-D${name}="${value}"`;
 }

--- a/scripts/build/tools.ts
+++ b/scripts/build/tools.ts
@@ -446,7 +446,7 @@ export function resolveLlvmToolchain(
     }
   }
 
-  // Host compiler for build-time codegen tools (dep_host_cc) and host-side
+  // Host compiler for build-time codegen tools (host_cc) and host-side
   // cargo artifacts (.cargo/config.toml linker for the host triple). Normally
   // the same as cc/cxx, but when cross-compiling for windows from a unix
   // host, cc/cxx are clang-cl (which defaults to a *-windows-msvc triple,

--- a/test/internal/build-codegen-declared-outputs.test.ts
+++ b/test/internal/build-codegen-declared-outputs.test.ts
@@ -24,7 +24,6 @@ import { readdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { emitBindgen, emitBindgenV2, registerCodegenRules, type CodegenOutputs } from "../../scripts/build/codegen.ts";
-import { registerDirStamps } from "../../scripts/build/compile.ts";
 import { resolveConfig, type Config, type Toolchain } from "../../scripts/build/config.ts";
 import { Ninja } from "../../scripts/build/ninja.ts";
 import type { Sources } from "../../scripts/glob-sources.ts";
@@ -84,7 +83,6 @@ function configure(buildDir: string): Configured {
     mockToolchain(),
   );
   const n = new Ninja({ buildDir });
-  registerDirStamps(n, cfg);
   registerCodegenRules(n, cfg);
   const o: CodegenOutputs = {
     all: [],

--- a/test/internal/build-engine.test.ts
+++ b/test/internal/build-engine.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Tests for the build engine (scripts/build/engine.ts): what reruns, what
+ * does not, ordering, pools, failure handling. Commands are small bun
+ * scripts so the tests run on every host.
+ */
+import { describe, expect, test } from "bun:test";
+import { bunExe, tempDir } from "harness";
+import { existsSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { expandNinja, parseDepfile, parseShowIncludes } from "../../scripts/build/depfile.ts";
+import { Engine, type EngineOptions, type Task } from "../../scripts/build/engine.ts";
+
+/** `bun -e <code> args…`: the code sees `args` as `process.argv.slice(1)` (no script path with -e). */
+function script(code: string, ...args: string[]): string[] {
+  return [bunExe(), "-e", `const fs = require("fs"); const A = process.argv.slice(1); ${code}`, ...args];
+}
+
+const COPY = `fs.copyFileSync(A[0], A[1]);`;
+/** Copy, and append a line to a log file so tests can see when the command ran. */
+const COPY_LOGGED = `fs.copyFileSync(A[0], A[1]); fs.appendFileSync(A[2], A[1] + "\\n");`;
+/** Write `content` to `out` only if different (writeIfChanged). */
+const WRITE_IF_CHANGED = `const [out, content] = A; let cur; try { cur = fs.readFileSync(out, "utf8"); } catch {} if (cur !== content) fs.writeFileSync(out, content);`;
+/** Copy `src` to `out`, and write a make-style depfile naming `extra` as a header. */
+const COPY_WITH_DEPFILE = `const [src, out, depfile, extra] = A; fs.copyFileSync(src, out); fs.writeFileSync(depfile, out + ": " + src + " \\\\\\n  " + extra + "\\n");`;
+
+function makeEngine(buildDir: string, extra: Partial<EngineOptions> = {}): Engine {
+  return new Engine({
+    buildDir,
+    hostOs: process.platform === "win32" ? "windows" : "linux",
+    env: process.env,
+    display: "quiet",
+    ...extra,
+  });
+}
+
+/**
+ * Give a file an mtime newer than everything the previous run recorded, without
+ * dating it into the future (a future mtime would look modified on every run,
+ * for ninja too). The engine reads the clock through a file it writes, and the
+ * kernel stamps files with a coarse clock that can lag Date.now() by a tick, so
+ * spin until a freshly written file is stamped later than `t`. A few ms at most.
+ */
+function touchNewer(path: string): void {
+  const t = new Date();
+  utimesSync(path, t, t);
+  const probe = `${path}.clock`;
+  for (;;) {
+    writeFileSync(probe, "");
+    if (statSync(probe).mtimeMs > t.getTime()) break;
+  }
+  rmSync(probe);
+}
+
+describe.concurrent("engine", () => {
+  test("runs every task once, then nothing", async () => {
+    using dir = tempDir("engine", { "a.txt": "a", "b.txt": "b" });
+    const d = String(dir);
+    const declare = (e: Engine) => {
+      const a = e.task({
+        kind: "copy",
+        label: "a",
+        outputs: [join(d, "out/a.out")],
+        inputs: [join(d, "a.txt")],
+        command: { argv: script(COPY, join(d, "a.txt"), join(d, "out/a.out")) },
+      });
+      e.task({
+        kind: "copy",
+        label: "b",
+        outputs: [join(d, "out/b.out")],
+        inputs: [join(d, "out/a.out"), join(d, "b.txt")],
+        after: [a],
+        command: { argv: script(COPY, join(d, "b.txt"), join(d, "out/b.out")) },
+      });
+    };
+
+    const first = makeEngine(d);
+    declare(first);
+    expect(await first.run()).toEqual({ ok: true, ran: 2, failed: 0, interrupted: false });
+    expect(readFileSync(join(d, "out/a.out"), "utf8")).toBe("a");
+    expect(readFileSync(join(d, "out/b.out"), "utf8")).toBe("b");
+
+    const second = makeEngine(d);
+    declare(second);
+    expect(await second.run()).toEqual({ ok: true, ran: 0, failed: 0, interrupted: false });
+  });
+
+  test("a newer input reruns the task and its dependents, not the rest", async () => {
+    using dir = tempDir("engine", { "a.txt": "a", "b.txt": "b", "c.txt": "c" });
+    const d = String(dir);
+    const log = join(d, "ran.log");
+    const declare = (e: Engine) => {
+      const a = e.task({
+        kind: "copy",
+        label: "a",
+        outputs: [join(d, "a.out")],
+        inputs: [join(d, "a.txt")],
+        command: { argv: script(COPY_LOGGED, join(d, "a.txt"), join(d, "a.out"), log) },
+      });
+      e.task({
+        kind: "copy",
+        label: "b",
+        outputs: [join(d, "b.out")],
+        inputs: [join(d, "a.out")],
+        after: [a],
+        command: { argv: script(COPY_LOGGED, join(d, "a.out"), join(d, "b.out"), log) },
+      });
+      e.task({
+        kind: "copy",
+        label: "c",
+        outputs: [join(d, "c.out")],
+        inputs: [join(d, "c.txt")],
+        command: { argv: script(COPY_LOGGED, join(d, "c.txt"), join(d, "c.out"), log) },
+      });
+    };
+    const first = makeEngine(d);
+    declare(first);
+    expect((await first.run()).ran).toBe(3);
+
+    writeFileSync(log, "");
+    writeFileSync(join(d, "a.txt"), "A");
+    touchNewer(join(d, "a.txt"));
+    const second = makeEngine(d);
+    declare(second);
+    expect((await second.run()).ran).toBe(2);
+    expect(
+      readFileSync(log, "utf8")
+        .trim()
+        .split("\n")
+        .map(l => l.split(/[\\/]/).pop()),
+    ).toEqual(["a.out", "b.out"]);
+    expect(readFileSync(join(d, "b.out"), "utf8")).toBe("A");
+  });
+
+  test("a changed command or a missing output reruns", async () => {
+    using dir = tempDir("engine", { "a.txt": "a" });
+    const d = String(dir);
+    const declare = (e: Engine, content: string) =>
+      e.task({
+        kind: "write",
+        label: "a",
+        outputs: [join(d, "a.out")],
+        command: { argv: script(WRITE_IF_CHANGED, join(d, "a.out"), content) },
+      });
+
+    const first = makeEngine(d);
+    declare(first, "one");
+    expect((await first.run()).ran).toBe(1);
+
+    const sameCommand = makeEngine(d);
+    declare(sameCommand, "one");
+    expect((await sameCommand.run()).ran).toBe(0);
+
+    const newCommand = makeEngine(d);
+    declare(newCommand, "two");
+    expect((await newCommand.run()).ran).toBe(1);
+    expect(readFileSync(join(d, "a.out"), "utf8")).toBe("two");
+
+    rmSync(join(d, "a.out"));
+    const missing = makeEngine(d);
+    declare(missing, "two");
+    expect((await missing.run()).ran).toBe(1);
+  });
+
+  test("depfile headers are tracked and the depfile is consumed", async () => {
+    using dir = tempDir("engine", { "a.c": "a", "a.h": "h" });
+    const d = String(dir);
+    const out = join(d, "a.o");
+    const declare = (e: Engine) =>
+      e.task({
+        kind: "cc",
+        label: "a.o",
+        outputs: [out],
+        inputs: [join(d, "a.c")],
+        depfile: { kind: "gcc", path: `${out}.d` },
+        command: { argv: script(COPY_WITH_DEPFILE, join(d, "a.c"), out, `${out}.d`, join(d, "a.h")) },
+      });
+    const first = makeEngine(d);
+    declare(first);
+    expect((await first.run()).ran).toBe(1);
+    expect(existsSync(`${out}.d`)).toBe(false);
+
+    const noop = makeEngine(d);
+    declare(noop);
+    expect((await noop.run()).ran).toBe(0);
+
+    // The header is not an input the task declared; only the depfile knows about it.
+    touchNewer(join(d, "a.h"));
+    const headerChanged = makeEngine(d);
+    declare(headerChanged);
+    expect((await headerChanged.run()).ran).toBe(1);
+  });
+
+  test("restat: an unchanged output does not rerun dependents", async () => {
+    using dir = tempDir("engine", { "src.txt": "same" });
+    const d = String(dir);
+    const declare = (e: Engine) => {
+      const gen = e.task({
+        kind: "gen",
+        label: "gen",
+        outputs: [join(d, "gen.h")],
+        inputs: [join(d, "src.txt")],
+        restat: true,
+        command: { argv: script(WRITE_IF_CHANGED, join(d, "gen.h"), "same") },
+      });
+      e.task({
+        kind: "copy",
+        label: "use",
+        outputs: [join(d, "use.out")],
+        inputs: [join(d, "gen.h")],
+        after: [gen],
+        command: { argv: script(COPY, join(d, "gen.h"), join(d, "use.out")) },
+      });
+    };
+    const first = makeEngine(d);
+    declare(first);
+    expect((await first.run()).ran).toBe(2);
+
+    // src.txt is newer: gen reruns, writes nothing (content identical), use stays.
+    touchNewer(join(d, "src.txt"));
+    const second = makeEngine(d);
+    declare(second);
+    expect((await second.run()).ran).toBe(1);
+
+    const third = makeEngine(d);
+    declare(third);
+    expect((await third.run()).ran).toBe(0);
+  });
+
+  test("after: orders tasks that share no files", async () => {
+    using dir = tempDir("engine", {});
+    const d = String(dir);
+    const log = join(d, "order.log");
+    const e = makeEngine(d, { jobs: 4 });
+    const first = e.task({
+      kind: "w",
+      label: "1",
+      outputs: [join(d, "1")],
+      command: { argv: script(COPY_LOGGED, join(d, "order.log"), join(d, "1"), log) },
+    });
+    writeFileSync(log, "");
+    e.task({
+      kind: "w",
+      label: "2",
+      outputs: [join(d, "2")],
+      after: [first],
+      command: { argv: script(COPY_LOGGED, join(d, "order.log"), join(d, "2"), log) },
+    });
+    expect((await e.run()).ok).toBe(true);
+    expect(
+      readFileSync(log, "utf8")
+        .trim()
+        .split("\n")
+        .map(l => l.split(/[\\/]/).pop()),
+    ).toEqual(["1", "2"]);
+  });
+
+  test("a failing task skips its dependents and fails the build", async () => {
+    using dir = tempDir("engine", { "a.txt": "a" });
+    const d = String(dir);
+    const e = makeEngine(d, { keepGoing: 0 });
+    const bad = e.task({
+      kind: "fail",
+      label: "bad",
+      outputs: [join(d, "bad.out")],
+      command: { argv: script(`process.exit(3);`) },
+    });
+    e.task({
+      kind: "copy",
+      label: "after-bad",
+      outputs: [join(d, "after.out")],
+      after: [bad],
+      command: { argv: script(COPY, join(d, "a.txt"), join(d, "after.out")) },
+    });
+    const independent = e.task({
+      kind: "copy",
+      label: "independent",
+      outputs: [join(d, "ind.out")],
+      inputs: [join(d, "a.txt")],
+      command: { argv: script(COPY, join(d, "a.txt"), join(d, "ind.out")) },
+    });
+
+    const summary = await e.run();
+    expect(summary).toEqual({ ok: false, ran: 2, failed: 1, interrupted: false });
+    expect(existsSync(join(d, "after.out"))).toBe(false);
+    expect(existsSync(join(d, "ind.out"))).toBe(true);
+    expect((await independent.result).failed).toBe(false);
+    expect((await bad.result).failed).toBe(true);
+  });
+
+  test("a pool of one serializes its tasks", async () => {
+    using dir = tempDir("engine", {});
+    const d = String(dir);
+    const log = join(d, "slots.log");
+    writeFileSync(log, "");
+    // Each task logs start, works for a moment, logs end. With depth 1 the windows never interleave.
+    const SLOT = `const [log, name, out] = A; fs.appendFileSync(log, "start " + name + "\\n"); const end = Date.now() + 50; while (Date.now() < end) {} fs.appendFileSync(log, "end " + name + "\\n"); fs.writeFileSync(out, "");`;
+    const e = makeEngine(d, { jobs: 8, pools: { one: 1 } });
+    for (const name of ["a", "b", "c"]) {
+      e.task({
+        kind: "slot",
+        label: name,
+        outputs: [join(d, name)],
+        pool: "one",
+        command: { argv: script(SLOT, log, name, join(d, name)) },
+      });
+    }
+    expect((await e.run()).ok).toBe(true);
+    const lines = readFileSync(log, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(6);
+    for (let i = 0; i < lines.length; i += 2) {
+      const name = lines[i]!.split(" ")[1];
+      expect(lines[i]).toBe(`start ${name}`);
+      expect(lines[i + 1]).toBe(`end ${name}`);
+    }
+  });
+
+  test("aliases select a subset, dry runs touch nothing", async () => {
+    using dir = tempDir("engine", { "a.txt": "a" });
+    const d = String(dir);
+    const declare = (e: Engine): Task => {
+      const a = e.task({
+        kind: "copy",
+        label: "a",
+        outputs: [join(d, "a.out")],
+        inputs: [join(d, "a.txt")],
+        command: { argv: script(COPY, join(d, "a.txt"), join(d, "a.out")) },
+      });
+      e.task({
+        kind: "copy",
+        label: "other",
+        outputs: [join(d, "other.out")],
+        inputs: [join(d, "a.txt")],
+        command: { argv: script(COPY, join(d, "a.txt"), join(d, "other.out")) },
+      });
+      return e.alias("just-a", [a]);
+    };
+    const dry = makeEngine(d, { dryRun: true });
+    const dryAlias = declare(dry);
+    expect((await dry.run([dryAlias])).ran).toBe(1);
+    expect(existsSync(join(d, "a.out"))).toBe(false);
+
+    const real = makeEngine(d);
+    declare(real);
+    expect((await real.run([real.lookup("just-a")!])).ran).toBe(1);
+    expect(existsSync(join(d, "a.out"))).toBe(true);
+    expect(existsSync(join(d, "other.out"))).toBe(false);
+    expect(statSync(join(d, "a.out")).isFile()).toBe(true);
+  });
+
+  test("two tasks for one output is an error at declaration", () => {
+    using dir = tempDir("engine", {});
+    const d = String(dir);
+    const e = makeEngine(d);
+    e.task({ kind: "w", label: "1", outputs: [join(d, "x")], command: { argv: script("") } });
+    expect(() => e.task({ kind: "w", label: "2", outputs: [join(d, "x")], command: { argv: script("") } })).toThrow(
+      /two tasks produce/,
+    );
+  });
+});
+
+describe("depfile parsing", () => {
+  test("clang -MMD output", () => {
+    expect(parseDepfile("obj/x.o: ../../src/x.cpp \\\n  /usr/include/foo.h ../../src/a\\ b.h\n")).toEqual({
+      targets: ["obj/x.o"],
+      deps: ["../../src/x.cpp", "/usr/include/foo.h", "../../src/a b.h"],
+    });
+  });
+
+  test("nasm -MD output puts a space before the colon", () => {
+    expect(parseDepfile("/tmp/t.o : a.asm \\\n  b.inc \\\n  c.inc\n\n")).toEqual({
+      targets: ["/tmp/t.o"],
+      deps: ["a.asm", "b.inc", "c.inc"],
+    });
+  });
+
+  test("several rules, windows paths, escapes", () => {
+    expect(parseDepfile("a.o: a.c\nb.o: b.c a.h\n").targets).toEqual(["a.o", "b.o"]);
+    expect(parseDepfile("C:\\out\\x.obj: C:\\src\\x.c C:\\src\\x.h\n")).toEqual({
+      targets: ["C:\\out\\x.obj"],
+      deps: ["C:\\src\\x.c", "C:\\src\\x.h"],
+    });
+    expect(parseDepfile("x.o: a$$b.h \\#.h\n").deps).toEqual(["a$b.h", "#.h"]);
+    expect(parseDepfile("x.o:\n")).toEqual({ targets: ["x.o"], deps: [] });
+  });
+
+  test("/showIncludes lines become deps and leave the diagnostics", () => {
+    const out =
+      "Note: including file: C:\\a.h\nNote: including file:  C:\\b.h\nx.cpp(3): warning C4100\nNote: including file: C:\\a.h\n";
+    expect(parseShowIncludes(out)).toEqual({ deps: ["C:\\a.h", "C:\\b.h"], filtered: "x.cpp(3): warning C4100\n" });
+  });
+
+  test("ninja variable expansion", () => {
+    const vars: Record<string, string> = { in: "a b", out: "o", flags: "-O2" };
+    expect(expandNinja("cc $flags -c $in -o $out", n => vars[n])).toBe("cc -O2 -c a b -o o");
+    expect(expandNinja("$$HOME $ x$:y ${out}.d $missing", n => vars[n])).toBe("$HOME  x:y o.d ");
+  });
+});

--- a/test/internal/macos-cross-config.test.ts
+++ b/test/internal/macos-cross-config.test.ts
@@ -18,7 +18,7 @@ import { parsePackedFeaturesList } from "../../scripts/build/features-json.ts";
 import { computeFlags, DARWIN_STACK_SIZE } from "../../scripts/build/flags.ts";
 import { MACOS_SDK_VERSION, macosSdkCachePath, resolveMacosSdkPath } from "../../scripts/build/macos-sdk.ts";
 import { rustTarget } from "../../scripts/build/rust.ts";
-import { postlinkCommands, machoEntitlementsPlist, machoPostlinkCommand } from "../../scripts/build/shims.ts";
+import { machoEntitlementsPlist, machoPostlinkCommand, postlinkCommands } from "../../scripts/build/shims.ts";
 
 /** A fully-populated fake toolchain — resolveConfig never spawns any of these. */
 function mockToolchain(overrides: Partial<Toolchain> = {}): Toolchain {

--- a/test/internal/macos-cross-config.test.ts
+++ b/test/internal/macos-cross-config.test.ts
@@ -18,11 +18,7 @@ import { parsePackedFeaturesList } from "../../scripts/build/features-json.ts";
 import { computeFlags, DARWIN_STACK_SIZE } from "../../scripts/build/flags.ts";
 import { MACOS_SDK_VERSION, macosSdkCachePath, resolveMacosSdkPath } from "../../scripts/build/macos-sdk.ts";
 import { rustTarget } from "../../scripts/build/rust.ts";
-import {
-  elfDebugCompressPostlinkCommand,
-  machoEntitlementsPlist,
-  machoPostlinkCommand,
-} from "../../scripts/build/shims.ts";
+import { postlinkCommands, machoEntitlementsPlist, machoPostlinkCommand } from "../../scripts/build/shims.ts";
 
 /** A fully-populated fake toolchain — resolveConfig never spawns any of these. */
 function mockToolchain(overrides: Partial<Toolchain> = {}): Toolchain {
@@ -231,7 +227,9 @@ describe.skipIf(isMacOS)("macOS cross-compile config (non-darwin host)", () => {
     );
     expect(withRustLld.ld).toBe(rustLld);
     expect(computeFlags(withRustLld).ldflags).not.toContain("-Wl,--compress-debug-sections=zlib");
-    expect(elfDebugCompressPostlinkCommand(withRustLld)).toContain("--compress-debug-sections=zlib $out");
+    expect(postlinkCommands(withRustLld, "bun-profile").map(c => c.argv.slice(1))).toEqual([
+      ["--compress-debug-sections=zlib", "bun-profile"],
+    ]);
 
     // System lld (no swap): compress at link time, no postlink pass.
     const systemLld = resolveConfig(
@@ -240,7 +238,7 @@ describe.skipIf(isMacOS)("macOS cross-compile config (non-darwin host)", () => {
     );
     expect(systemLld.ld).toBe("/fake/llvm/bin/ld.lld");
     expect(computeFlags(systemLld).ldflags).toContain("-Wl,--compress-debug-sections=zlib");
-    expect(elfDebugCompressPostlinkCommand(systemLld)).toBe("");
+    expect(postlinkCommands(systemLld, "bun-profile")).toEqual([]);
   });
 
   test("linux configs don't pick up darwin cross machinery", () => {


### PR DESCRIPTION
### Problem
- The build system describes the build in TypeScript but hands execution to ninja. To do that, every step is a shell string in ninja syntax: `cmd /c "cd /d $cwd && set X=1&& …"`, `stream.ts --cwd --env` wrappers for live output, a `regen` rule so `ninja` run by hand reconfigures, and `quote()` on every path.
- Of what ninja does, the build needs one thing: run the stale steps, in parallel, with header deps from the compiler. That part is small. The install surface is not: ninja is a prerequisite in bootstrap.sh, bootstrap.ps1, the CI Dockerfile, nix, the darwin-ci toolchain check, a GitHub action and the docs.

### Change
- `scripts/build/engine.ts`: an in-process task runner. A task is argv + cwd + env, inputs, outputs, `after`, a depfile kind, `restat`, a pool. The engine decides what is stale (recorded start time vs input mtimes, command hash, recorded header deps, missing outputs), runs stale tasks in parallel within pools, and keeps its state in `.build_log` and `.build_deps`. Interrupts kill the process groups and drop half-written outputs. `-n` and `--explain` say what would run and why.
- `Ninja.task()` declares a native task. `compile.ts` (cc, cxx, pch, nasm, link, ar) and the dep codegen tool use it: 1219 of the 1289 tasks. The other ~70 (fetch, codegen scripts, bun install, esbuild, cargo, strip, smoke test, uploads) still go through `rule()`/`build()`; `bridge.ts` expands those the way ninja would. Porting one is replacing the pair with a `task()` call.
- `--runner=ts` (or `BUN_BUILD_RUNNER=ts`) selects the engine. The default is still ninja: native tasks are exported to `build.ninja` as one rule per kind with the quoted command in `$cmd`, so both runners build from the same declarations.
- Verified: `test/internal/build-engine.test.ts` (staleness, depfiles, restat, ordering, pools, failures, dry run), the existing `test/internal/build-*` and `macos-cross-config` tests, a full debug build through the engine, and `bun bd` through ninja from the new export.

### Background
- A depfile is the list of headers the compiler read (`clang -MMD`, `clang-cl /showIncludes`). Both runners fold it into their own database after the compile and use it as extra inputs next time.
- `restat` marks a task whose outputs can come out byte-identical (writeIfChanged codegen, a no-op cargo build). Only a moved mtime counts as a change, so dependents skip.
- The engine reads the clock through a file it writes (`.build_lock`), so recorded start times compare with output mtimes on the same clock. Ninja does the same with `.ninja_lock`.

<details><summary>Notes</summary>

Measurements on the linux-x64 container (8 cores, warm ccache, debug profile, 1289 tasks). Wall seconds, median of 3 to 6 runs. Totals include the 0.75 s configure both runners pay.

| scenario | ninja | engine (`--runner=ts`) |
| --- | --- | --- |
| no-op build, total | 0.84 | 0.84 |
| no-op, runner alone | 0.05 | about 0.08 |
| dry run (`-n`), everything clean, total | 0.81 | 0.81 |
| dry run (`-n`), all 1289 tasks stale | 0.04 (ninja alone) | about 0.1 (0.75 to 0.89 total) |
| touch 1 header: 16 TUs + link + smoke test | 9.5 (n=4) | 10.0 (n=4) |
| touch 1 .cpp: 1 TU + link + smoke test | 9.6 (n=4) | 10.4 (n=4) |
| the 1 TU compile alone, total | 0.88 | 0.87 |
| link + smoke test alone, total | 10.0 | 9.1 to 9.8 |
| full rebuild, all stale, warm ccache | 33.7 | 33.3 |
| full rebuild, cold (`CCACHE_DISABLE=1`), 3 runs | 120.9, 121.1, 124.1 | 122.0, 130.1 (an 18 s link; the others took 10) |
| cold build, total CPU in tasks | 882 to 904 s | 889 to 898 s |
| runner peak RSS | 8 to 12 MB | 110 to 155 MB (configure alone: 85 to 93 MB) |
| state on disk | 1.29 MB (`.ninja_log` + `.ninja_deps`) | 1.6 MB (`.build_log` + `.build_deps`) |

The header touch reruns the same 16 objects that `.ninja_deps` lists for that header, then link, then the smoke test. The incremental rows differ by less than the link's own spread (9 to 11 s between runs). The cold rows keep the cargo target warm: the Rust build is one identical console task in both runners and would add the same minutes to each. Not measured: Windows, macOS.

The first cold run through the engine took 149 s. The pool priority was the task's own last duration, so the PCH waited in the compile pool's FIFO behind the ~700 dep compiles declared before it, and 150 translation units then idled behind the PCH for 13 s. Priority is now the longest chain of remaining work to the end of the build (ninja's critical path), the PCH starts the moment codegen is done, and the timelines of the two runners match: 8 cores busy from second 10 to second 100, then the link alone.

Export check: `ninja -C build/debug obj/src/jsc/bindings/JSBuffer.cpp.o` rebuilt the PCH and the object from the new `$cmd` edges; `bun bd --version` links through ninja from the same export.

Flags are argv entries now. `flags.ts` dropped the shell escaping on three defines (`REPORTED_NODEJS_VERSION="26.3.0"` is the literal argv entry) and on the `/winsysroot` paths; `defineFlag()` in `source.ts` writes plain quotes. The ninja export re-quotes each entry, so the shell sees the same thing it did before.

What is gone already: the `cc`/`cxx`/`cxx_pch`/`pch`/`nasm`/`link`/`ar`/`dep_host_cc`/`dep_codegen` rule templates, the `obj/` and `pch/` dir stamps (both runners create output dirs), `elfDebugCompressPostlinkCommand`. Post-link fixups are extra commands on the link task.

Remaining to port, then delete: `dep_fetch`/`dep_fetch_prebuilt`/`dep_subst`/`dep_check_undefined` (fetch-cli.ts could be called in process), `codegen`/`esbuild`/`bun_install`, `rust_build*`/`dep_cargo*`, `shim_*`, `strip`/`dsymutil`/`rc`/`smoke_test`, `bk_upload*`, `dep_configure`/`dep_build` (WebKit `--webkit=local`, which keeps cmake and ninja as its own prerequisites). After that: `bridge.ts`'s expander and the shell path in `engine.ts`, `stream.ts`, `shell.ts`'s `quote()`, the `regen` rule with `configure.json` and `--config-file`, `build.ninja`, the `-t`-style hints in CLAUDE.md, and the ninja install lines in bootstrap.sh, bootstrap.ps1, .buildkite/Dockerfile, flake.nix, shell.nix, darwin-ci/lib/config.ts, .github/actions/rust-lint-setup, CONTRIBUTING.md and docs/project. `scripts/rust-miri.ts`, `scripts/rust-timings.ts` and the rust-lint action call `ninja -C build/debug clone-lolhtml …` after `--configure-only`; `scripts/build.ts --target=clone-lolhtml` does the same on either runner.

Not done here: CI annotations for engine failures (spawnWithAnnotations parses ninja's combined output; the engine would hand it the failed task's output directly), a Windows run (the engine has the CreateProcess path for bridged shell commands and `/showIncludes` parsing, untested on a Windows host), in-process actions (calling fetch-cli/codegen functions instead of spawning bun), and deleting anything ninja-related while both runners coexist.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/internal/macos-cross-config.test.ts, test/internal/build-engine.test.ts

<!-- robobun:evidence:end -->