### PR TITLE
Bun.Image: do not split one colour across two palette boxes in median cut

### DIFF
--- a/src/runtime/image/quantize.rs
+++ b/src/runtime/image/quantize.rs
@@ -5,10 +5,9 @@
 //! is GPL, so we roll a small permissive one. Median-cut is the classic
 //! Heckbert '82 algorithm: treat the RGBA pixels as points in a 4-D box,
 //! repeatedly split the box with the largest channel range at that channel's
-//! median (nudged to a run boundary so one colour never straddles the cut,
-//! see `cut_point`) until you have N boxes, then each box's mean becomes a
-//! palette entry. Mapping is nearest-entry by squared RGBA distance,
-//! optionally with Floyd–Steinberg error diffusion (`dither: true`).
+//! median until you have N boxes, then each box's mean becomes a palette
+//! entry. Mapping is nearest-entry by squared RGBA distance, optionally with
+//! Floyd–Steinberg error diffusion (`dither: true`).
 
 use bun_alloc::AllocError;
 
@@ -263,18 +262,12 @@ fn clamp255(v: i32) -> i32 {
     v.clamp(0, 255)
 }
 
-/// Index in `sorted` (a box's pixel indices, sorted by channel `ch`) at
-/// which to split the box.
-///
-/// Classic median cut splits at the count midpoint. When the midpoint lands
-/// inside a run of pixels that share the key, the same colour ends up in
-/// both halves and each half's mean is a blend of it with its neighbours:
-/// 75% white / 25% black at `colors: 2` came out as white + mid-grey. So
-/// when the midpoint is not already on a run boundary, cut at whichever
-/// boundary of that run (its start or its end) is nearer, the start on a
-/// tie. A boundary at the edge of `sorted` would leave one half empty and is
-/// never picked. The caller only splits a box whose range on `ch` is > 0, so
-/// the run never covers the whole slice and the other boundary is available.
+/// Where to split `sorted` (a box's pixel indices, sorted by channel `ch`):
+/// the count midpoint, moved to the nearer boundary of the run of equal keys
+/// it lands in (the start on a tie) so one colour never sits in both halves.
+/// A boundary at the slice edge would leave a half empty and is never picked.
+/// The caller only splits a box whose range on `ch` is > 0, so the run never
+/// covers the whole slice and the other boundary exists.
 fn cut_point(rgba: &[u8], sorted: &[u32], ch: u8) -> usize {
     let key = |p: u32| rgba[p as usize * 4 + ch as usize];
     let mid = sorted.len() / 2;

--- a/src/runtime/image/quantize.rs
+++ b/src/runtime/image/quantize.rs
@@ -4,9 +4,11 @@
 //! compression", not perceptual perfection — Sharp uses libimagequant which
 //! is GPL, so we roll a small permissive one. Median-cut is the classic
 //! Heckbert '82 algorithm: treat the RGBA pixels as points in a 4-D box,
-//! repeatedly split the box with the largest channel range at that channel's
-//! median until you have N boxes, then each box's mean becomes a palette
-//! entry. Mapping is nearest-entry by squared RGBA distance, optionally with
+//! repeatedly split the box with the largest channel range along that channel
+//! until you have N boxes, then each box's mean becomes a palette entry. The
+//! cut goes between two distinct values, at the position that leaves the two
+//! halves the least squared error (see `cut_point`), not at the pixel-count
+//! median. Mapping is nearest-entry by squared RGBA distance, optionally with
 //! Floyd–Steinberg error diffusion (`dither: true`).
 
 use bun_alloc::AllocError;
@@ -104,12 +106,15 @@ pub(crate) fn quantize(
         }
 
         let ch = b.widest_channel();
-        // Partial sort by the chosen channel, then cut near the midpoint.
+        // Partial sort by the chosen channel, then cut between two of its values.
         let slice = &mut order[b.lo as usize..b.hi as usize];
         // u32 ×4 overflows past ~1.07B pixels (allowed when the user raises
         // `maxPixels`); the other order-index sites already widen first.
         slice.sort_unstable_by_key(|&p| rgba[p as usize * 4 + ch as usize]);
-        let cut = b.lo + u32::try_from(cut_point(rgba, slice, ch)).expect("int cast");
+        let Some(cut) = cut_point(rgba, slice, ch) else {
+            break;
+        };
+        let cut = b.lo + u32::try_from(cut).expect("int cast");
         boxes[pick] = shrink(rgba, &order, b.lo, cut);
         boxes.push(shrink(rgba, &order, cut, b.hi));
     }
@@ -262,26 +267,44 @@ fn clamp255(v: i32) -> i32 {
     v.clamp(0, 255)
 }
 
-/// Where to split `sorted` (a box's pixel indices, sorted by channel `ch`):
-/// the count midpoint, moved to the nearer boundary of the run of equal keys
-/// it lands in (the start on a tie) so one colour never sits in both halves.
-/// A boundary at the slice edge would leave a half empty and is never picked.
-/// The caller only splits a box whose range on `ch` is > 0, so the run never
-/// covers the whole slice and the other boundary exists.
-fn cut_point(rgba: &[u8], sorted: &[u32], ch: u8) -> usize {
-    let key = |p: u32| rgba[p as usize * 4 + ch as usize];
-    let mid = sorted.len() / 2;
-    let k = key(sorted[mid]);
-    let start = sorted.partition_point(|&p| key(p) < k);
-    if start == mid {
-        return mid;
+/// Where to split `sorted` (a box's pixel indices, sorted by channel `ch`).
+/// Only a boundary between two runs of different keys is a candidate, so one
+/// value never sits in both halves. Among those, pick the cut whose halves
+/// have the least total squared error about their means, the same error the
+/// palette entries minimise. Σv² is fixed for the box, so that is the cut
+/// with the largest Σ_c (L_c²/i + R_c²/(m-i)) for left/right channel sums
+/// L, R. `None` when every pixel has the same key.
+fn cut_point(rgba: &[u8], sorted: &[u32], ch: u8) -> Option<usize> {
+    let px = |p: u32| &rgba[p as usize * 4..][..4];
+    let m = sorted.len();
+    let mut total = [0u64; 4];
+    for &p in sorted {
+        for (t, &v) in total.iter_mut().zip(px(p)) {
+            *t += u64::from(v);
+        }
     }
-    let end = sorted.partition_point(|&p| key(p) <= k);
-    if start == 0 || (end < sorted.len() && end - mid < mid - start) {
-        end
-    } else {
-        start
+    let mut left = [0u64; 4];
+    let mut best: Option<(u128, usize)> = None;
+    for i in 1..m {
+        let prev = px(sorted[i - 1]);
+        for (l, &v) in left.iter_mut().zip(prev) {
+            *l += u64::from(v);
+        }
+        if prev[ch as usize] == px(sorted[i])[ch as usize] {
+            continue;
+        }
+        let (li, ri) = (i as u128, (m - i) as u128);
+        let mut score: u128 = 0;
+        for c in 0..4 {
+            let l = u128::from(left[c]);
+            let r = u128::from(total[c] - left[c]);
+            score += l * l / li + r * r / ri;
+        }
+        if best.is_none_or(|(s, _)| score > s) {
+            best = Some((score, i));
+        }
     }
+    best.map(|(_, i)| i)
 }
 
 /// Recompute a box's tight min/max over its pixel slice.

--- a/src/runtime/image/quantize.rs
+++ b/src/runtime/image/quantize.rs
@@ -104,7 +104,7 @@ pub(crate) fn quantize(
         }
 
         let ch = b.widest_channel();
-        // Partial sort by the chosen channel, then cut at the midpoint.
+        // Partial sort by the chosen channel, then cut near the midpoint.
         let slice = &mut order[b.lo as usize..b.hi as usize];
         // u32 ×4 overflows past ~1.07B pixels (allowed when the user raises
         // `maxPixels`); the other order-index sites already widen first.

--- a/src/runtime/image/quantize.rs
+++ b/src/runtime/image/quantize.rs
@@ -270,10 +270,11 @@ fn clamp255(v: i32) -> i32 {
 /// inside a run of pixels that share the key, the same colour ends up in
 /// both halves and each half's mean is a blend of it with its neighbours:
 /// 75% white / 25% black at `colors: 2` came out as white + mid-grey. So
-/// when the midpoint is not already on a run boundary, cut at the end of
-/// that run nearest to it instead. The caller only splits a box whose range
-/// on `ch` is > 0, so the run never covers the whole slice and the chosen
-/// end leaves both halves non-empty.
+/// when the midpoint is not already on a run boundary, cut at whichever
+/// boundary of that run (its start or its end) is nearer, the start on a
+/// tie. A boundary at the edge of `sorted` would leave one half empty and is
+/// never picked. The caller only splits a box whose range on `ch` is > 0, so
+/// the run never covers the whole slice and the other boundary is available.
 fn cut_point(rgba: &[u8], sorted: &[u32], ch: u8) -> usize {
     let key = |p: u32| rgba[p as usize * 4 + ch as usize];
     let mid = sorted.len() / 2;

--- a/src/runtime/image/quantize.rs
+++ b/src/runtime/image/quantize.rs
@@ -5,9 +5,10 @@
 //! is GPL, so we roll a small permissive one. Median-cut is the classic
 //! Heckbert '82 algorithm: treat the RGBA pixels as points in a 4-D box,
 //! repeatedly split the box with the largest channel range at that channel's
-//! median until you have N boxes, then each box's mean becomes a palette
-//! entry. Mapping is nearest-entry by squared RGBA distance, optionally with
-//! Floyd–Steinberg error diffusion (`dither: true`).
+//! median (nudged to a run boundary so one colour never straddles the cut,
+//! see `cut_point`) until you have N boxes, then each box's mean becomes a
+//! palette entry. Mapping is nearest-entry by squared RGBA distance,
+//! optionally with Floyd–Steinberg error diffusion (`dither: true`).
 
 use bun_alloc::AllocError;
 
@@ -109,9 +110,9 @@ pub(crate) fn quantize(
         // u32 ×4 overflows past ~1.07B pixels (allowed when the user raises
         // `maxPixels`); the other order-index sites already widen first.
         slice.sort_unstable_by_key(|&p| rgba[p as usize * 4 + ch as usize]);
-        let mid = b.lo + (b.hi - b.lo) / 2;
-        boxes[pick] = shrink(rgba, &order, b.lo, mid);
-        boxes.push(shrink(rgba, &order, mid, b.hi));
+        let cut = b.lo + u32::try_from(cut_point(rgba, slice, ch)).expect("int cast");
+        boxes[pick] = shrink(rgba, &order, b.lo, cut);
+        boxes.push(shrink(rgba, &order, cut, b.hi));
     }
 
     let k: u16 = u16::try_from(boxes.len()).expect("int cast");
@@ -260,6 +261,33 @@ fn map_floyd_steinberg(
 #[inline]
 fn clamp255(v: i32) -> i32 {
     v.clamp(0, 255)
+}
+
+/// Index in `sorted` (a box's pixel indices, sorted by channel `ch`) at
+/// which to split the box.
+///
+/// Classic median cut splits at the count midpoint. When the midpoint lands
+/// inside a run of pixels that share the key, the same colour ends up in
+/// both halves and each half's mean is a blend of it with its neighbours:
+/// 75% white / 25% black at `colors: 2` came out as white + mid-grey. So
+/// when the midpoint is not already on a run boundary, cut at the end of
+/// that run nearest to it instead. The caller only splits a box whose range
+/// on `ch` is > 0, so the run never covers the whole slice and the chosen
+/// end leaves both halves non-empty.
+fn cut_point(rgba: &[u8], sorted: &[u32], ch: u8) -> usize {
+    let key = |p: u32| rgba[p as usize * 4 + ch as usize];
+    let mid = sorted.len() / 2;
+    let k = key(sorted[mid]);
+    let start = sorted.partition_point(|&p| key(p) < k);
+    if start == mid {
+        return mid;
+    }
+    let end = sorted.partition_point(|&p| key(p) <= k);
+    if start == 0 || (end < sorted.len() && end - mid < mid - start) {
+        end
+    } else {
+        start
+    }
 }
 
 /// Recompute a box's tight min/max over its pixel slice.

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -140,6 +140,27 @@ function decodePngRaw(png: Uint8Array): { w: number; h: number; data: Uint8Array
   return { w, h, data: out };
 }
 
+// Palette of an indexed PNG as RGBA tuples (tRNS supplies alpha, default 255),
+// sorted so tests can compare against a set of expected colours.
+function pngPalette(png: Uint8Array): [number, number, number, number][] {
+  const dv = new DataView(png.buffer, png.byteOffset, png.byteLength);
+  let plte = new Uint8Array(0);
+  let trns = new Uint8Array(0);
+  for (let off = 8; off + 8 <= png.length; ) {
+    const len = dv.getUint32(off);
+    const type = String.fromCharCode(png[off + 4], png[off + 5], png[off + 6], png[off + 7]);
+    if (type === "PLTE") plte = png.subarray(off + 8, off + 8 + len);
+    else if (type === "tRNS") trns = png.subarray(off + 8, off + 8 + len);
+    else if (type === "IEND") break;
+    off += 12 + len;
+  }
+  const out: [number, number, number, number][] = [];
+  for (let i = 0; i < plte.length / 3; i++) {
+    out.push([plte[i * 3], plte[i * 3 + 1], plte[i * 3 + 2], i < trns.length ? trns[i] : 255]);
+  }
+  return out.sort((a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2] || a[3] - b[3]);
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe("Bun.Image", () => {
@@ -1124,6 +1145,58 @@ describe("Bun.Image", () => {
       expect(rgbaAt(back.data, 2, 1, 0)).toEqual([255, 0, 0, 255]);
       expect(rgbaAt(back.data, 2, 0, 1)).toEqual([0, 255, 0, 255]);
       expect(rgbaAt(back.data, 2, 1, 1)).toEqual([255, 255, 255, 255]);
+    });
+
+    // Median cut splits a box at its pixel-count midpoint. When one colour
+    // holds more than half the box, that midpoint falls inside its run, the
+    // colour lands in both halves and the smaller half's mean is a blend
+    // (75% white / 25% black used to give white + [128,128,128]). The cut
+    // has to move to the run boundary so a source with ≤ `colors` distinct
+    // colours comes out with exactly those colours.
+    describe("png({palette:true}) keeps every colour of an image with ≤ colors distinct colours", () => {
+      const white: [number, number, number, number] = [255, 255, 255, 255];
+      const black: [number, number, number, number] = [0, 0, 0, 255];
+
+      test.each([false, true])("white:black 3:1, colors:2, dither %p", async dither => {
+        const src = makePng(40, 40, (_x, y) => (y < 30 ? white : black));
+        const out = await new Bun.Image(src).png({ palette: true, colors: 2, dither }).bytes();
+        expect(out[25]).toBe(3); // indexed
+        expect(pngPalette(out)).toEqual([black, white]);
+        // Every pixel maps to its own colour, none to a blend.
+        const back = decodePngRaw(await new Bun.Image(out).png().bytes());
+        expect(rgbaAt(back.data, 40, 0, 0)).toEqual(white);
+        expect(rgbaAt(back.data, 40, 39, 29)).toEqual(white);
+        expect(rgbaAt(back.data, 40, 0, 30)).toEqual(black);
+        expect(rgbaAt(back.data, 40, 39, 39)).toEqual(black);
+      });
+
+      test("five colours with unequal counts, colors:5 and colors:8", async () => {
+        const red: [number, number, number, number] = [255, 0, 0, 255];
+        const green: [number, number, number, number] = [0, 255, 0, 255];
+        const blue: [number, number, number, number] = [0, 0, 255, 255];
+        // 50% white, 25% black, 12.5% red, 7.5% green, 5% blue: every split
+        // lands its midpoint inside a run.
+        const src = makePng(40, 40, (_x, y) =>
+          y < 20 ? white : y < 30 ? black : y < 35 ? red : y < 38 ? green : blue,
+        );
+        const expected = [black, blue, green, red, white];
+        const exact = await new Bun.Image(src).png({ palette: true, colors: 5 }).bytes();
+        expect(pngPalette(exact)).toEqual(expected);
+        // Spare slots must not be filled with duplicates of the same colour.
+        const spare = await new Bun.Image(src).png({ palette: true, colors: 8 }).bytes();
+        expect(pngPalette(spare)).toEqual(expected);
+      });
+
+      test("two alphas of one colour with unequal counts, colors:2", async () => {
+        // Same RGB, so the split runs on the alpha channel and the entries
+        // differ only in tRNS.
+        const src = makePng(40, 40, (_x, y) => (y < 30 ? [100, 100, 100, 255] : [100, 100, 100, 0]));
+        const out = await new Bun.Image(src).png({ palette: true, colors: 2 }).bytes();
+        expect(pngPalette(out)).toEqual([
+          [100, 100, 100, 0],
+          [100, 100, 100, 255],
+        ]);
+      });
     });
 
     test("png({palette:true, colors:16}) is much smaller than truecolour for a screenshot-ish image", async () => {

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1147,12 +1147,13 @@ describe("Bun.Image", () => {
       expect(rgbaAt(back.data, 2, 1, 1)).toEqual([255, 255, 255, 255]);
     });
 
-    // Median cut splits a box at its pixel-count midpoint. When one colour
-    // holds more than half the box, that midpoint falls inside its run, the
-    // colour lands in both halves and the smaller half's mean is a blend
-    // (75% white / 25% black used to give white + [128,128,128]). The cut
-    // has to move to the nearer end of that run instead, so a colour is
-    // never split across two palette entries.
+    // Median cut used to split a box at its pixel-count midpoint. When one
+    // colour holds more than half the box, that midpoint falls inside its
+    // run, the colour lands in both halves and the smaller half's mean is a
+    // blend (75% white / 25% black gave white + [128,128,128]). The cut now
+    // goes between two distinct values, at the position with the least
+    // squared error, so a colour is never split across two palette entries
+    // and a noisy dominant colour is cut off from the rest, not in its middle.
     describe("png({palette:true}) never splits one colour across two palette entries", () => {
       const white: [number, number, number, number] = [255, 255, 255, 255];
       const black: [number, number, number, number] = [0, 0, 0, 255];
@@ -1199,27 +1200,71 @@ describe("Bun.Image", () => {
         ]);
       });
 
-      // Three greys in 40 rows. The middle run straddles the midpoint, so
-      // the cut moves to whichever end of it is nearer.
-      const threeGreys = (dark: number, mid: number) =>
-        makePng(40, 40, (_x, y) => (y < dark ? black : y < dark + mid ? grey(128) : white));
+      // Black, a middle grey, then white, in 40 rows. The middle run straddles
+      // the midpoint, so the old cut split it.
+      const threeGreys = (dark: number, mid: number, value = 128) =>
+        makePng(40, 40, (_x, y) => (y < dark ? black : y < dark + mid ? grey(value) : white));
 
       test("three greys 30%/30%/40%, colors:3 is exact", async () => {
         const out = await new Bun.Image(threeGreys(12, 12)).png({ palette: true, colors: 3 }).bytes();
         expect(pngPalette(out)).toEqual([black, grey(128), white]);
       });
 
-      test("three greys, colors:2: the middle grey joins the side nearer the midpoint", async () => {
-        // 30%/30%/40%: the midpoint (800) is nearer the end of the middle run
-        // (960) than its start (480), so black and grey share one entry.
-        const nearerEnd = await new Bun.Image(threeGreys(12, 12)).png({ palette: true, colors: 2 }).bytes();
-        expect(pngPalette(nearerEnd)).toEqual([grey(64), white]);
-        // 40%/30%/30%: mirrored, so grey and white share one entry.
-        const nearerStart = await new Bun.Image(threeGreys(16, 12)).png({ palette: true, colors: 2 }).bytes();
-        expect(pngPalette(nearerStart)).toEqual([black, grey(192)]);
-        // 37.5%/25%/37.5%: a tie goes to the start of the run.
-        const tie = await new Bun.Image(threeGreys(15, 10)).png({ palette: true, colors: 2 }).bytes();
-        expect(pngPalette(tie)).toEqual([black, grey(204)]);
+      test("three greys, colors:2: the middle grey joins the side that costs the least error", async () => {
+        // Grey 128 is equally far from both, so the counts decide: the pair
+        // with fewer pixels merges.
+        const moreWhite = await new Bun.Image(threeGreys(12, 12)).png({ palette: true, colors: 2 }).bytes();
+        expect(pngPalette(moreWhite)).toEqual([grey(64), white]);
+        const moreBlack = await new Bun.Image(threeGreys(16, 12)).png({ palette: true, colors: 2 }).bytes();
+        expect(pngPalette(moreBlack)).toEqual([black, grey(192)]);
+        // A grey near one end merges with that end whatever the counts.
+        const nearWhite = await new Bun.Image(threeGreys(12, 12, 225)).png({ palette: true, colors: 2 }).bytes();
+        expect(pngPalette(nearWhite)).toEqual([black, grey(242)]);
+        const nearBlack = await new Bun.Image(threeGreys(16, 12, 30)).png({ palette: true, colors: 2 }).bytes();
+        expect(pngPalette(nearBlack)).toEqual([grey(13), white]);
+      });
+
+      // +-2 per channel, in a fixed pattern so the fixture is deterministic.
+      const noise = (x: number, y: number, k: number) => ((x * k + y * (k + 4)) % 5) - 2;
+
+      test("a dominant colour with noise is cut off whole, colors:2", async () => {
+        // 75% near-white (250 +- 2) over 25% black. The white is five adjacent
+        // runs, not one, so a cut at the count midpoint would land between two
+        // of them and black would again map to a grey blend.
+        const src = makePng(40, 40, (x, y) => (y < 30 ? grey(250 + noise(x, y, 7)) : black));
+        const out = await new Bun.Image(src).png({ palette: true, colors: 2 }).bytes();
+        expect(pngPalette(out)).toEqual([black, grey(250)]);
+        const back = decodePngRaw(await new Bun.Image(out).png().bytes());
+        expect(rgbaAt(back.data, 40, 0, 30)).toEqual(black);
+        expect(rgbaAt(back.data, 40, 39, 39)).toEqual(black);
+      });
+
+      test.each([3, 6])("three flat colours with JPEG-like noise, colors:%d", async colors => {
+        // 70% off-white, 20% blue, 10% red, each +-2 on every channel. Every
+        // pixel must come back within the noise of its source colour, so no
+        // two source colours share an entry and no entry is a blend.
+        const base = [
+          [240, 240, 240],
+          [30, 60, 120],
+          [200, 40, 40],
+        ];
+        const pixel = (x: number, y: number): [number, number, number, number] => {
+          const c = base[y < 45 ? 0 : y < 58 ? 1 : 2];
+          return [c[0] + noise(x, y, 7), c[1] + noise(x, y, 3), c[2] + noise(x, y, 13), 255];
+        };
+        const src = makePng(64, 64, pixel);
+        const out = await new Bun.Image(src).png({ palette: true, colors }).bytes();
+        expect(pngPalette(out)).toHaveLength(colors);
+        const back = decodePngRaw(await new Bun.Image(out).png().bytes());
+        let worst = 0;
+        for (let y = 0; y < 64; y++) {
+          for (let x = 0; x < 64; x++) {
+            const got = rgbaAt(back.data, 64, x, y);
+            const want = pixel(x, y);
+            for (let c = 0; c < 3; c++) worst = Math.max(worst, Math.abs(got[c] - want[c]));
+          }
+        }
+        expect(worst).toBeLessThanOrEqual(4);
       });
 
       test.each([4, 16])("over budget: 75%% white + a 201-step grey ramp, colors:%d", async colors => {

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1151,11 +1151,12 @@ describe("Bun.Image", () => {
     // holds more than half the box, that midpoint falls inside its run, the
     // colour lands in both halves and the smaller half's mean is a blend
     // (75% white / 25% black used to give white + [128,128,128]). The cut
-    // has to move to the run boundary so a source with ≤ `colors` distinct
-    // colours comes out with exactly those colours.
-    describe("png({palette:true}) keeps every colour of an image with ≤ colors distinct colours", () => {
+    // has to move to the nearer end of that run instead, so a colour is
+    // never split across two palette entries.
+    describe("png({palette:true}) never splits one colour across two palette entries", () => {
       const white: [number, number, number, number] = [255, 255, 255, 255];
       const black: [number, number, number, number] = [0, 0, 0, 255];
+      const grey = (v: number): [number, number, number, number] => [v, v, v, 255];
 
       test.each([false, true])("white:black 3:1, colors:2, dither %p", async dither => {
         const src = makePng(40, 40, (_x, y) => (y < 30 ? white : black));
@@ -1196,6 +1197,64 @@ describe("Bun.Image", () => {
           [100, 100, 100, 0],
           [100, 100, 100, 255],
         ]);
+      });
+
+      // Three greys in 40 rows. The middle run straddles the midpoint, so
+      // the cut moves to whichever end of it is nearer.
+      const threeGreys = (dark: number, mid: number) =>
+        makePng(40, 40, (_x, y) => (y < dark ? black : y < dark + mid ? grey(128) : white));
+
+      test("three greys 30%/30%/40%, colors:3 is exact", async () => {
+        const out = await new Bun.Image(threeGreys(12, 12)).png({ palette: true, colors: 3 }).bytes();
+        expect(pngPalette(out)).toEqual([black, grey(128), white]);
+      });
+
+      test("three greys, colors:2: the middle grey joins the side nearer the midpoint", async () => {
+        // 30%/30%/40%: the midpoint (800) is nearer the end of the middle run
+        // (960) than its start (480), so black and grey share one entry.
+        const nearerEnd = await new Bun.Image(threeGreys(12, 12)).png({ palette: true, colors: 2 }).bytes();
+        expect(pngPalette(nearerEnd)).toEqual([grey(64), white]);
+        // 40%/30%/30%: mirrored, so grey and white share one entry.
+        const nearerStart = await new Bun.Image(threeGreys(16, 12)).png({ palette: true, colors: 2 }).bytes();
+        expect(pngPalette(nearerStart)).toEqual([black, grey(192)]);
+        // 37.5%/25%/37.5%: a tie goes to the start of the run.
+        const tie = await new Bun.Image(threeGreys(15, 10)).png({ palette: true, colors: 2 }).bytes();
+        expect(pngPalette(tie)).toEqual([black, grey(204)]);
+      });
+
+      test.each([4, 16])("over budget: 75%% white + a 201-step grey ramp, colors:%d", async colors => {
+        // More colours than slots, with one dominant colour. White must get
+        // exactly one entry and every other slot must go to the ramp.
+        const src = makePng(64, 64, (x, y) => (y < 48 ? white : grey(((y - 48) * 64 + x) % 201)));
+        const out = await new Bun.Image(src).png({ palette: true, colors }).bytes();
+        const palette = pngPalette(out);
+        expect(palette).toHaveLength(colors);
+        expect(new Set(palette.map(e => e.join())).size).toBe(colors);
+        expect(palette.filter(e => e[0] === 255)).toEqual([white]);
+        // A blend of white with the ramp would land in (200, 255).
+        expect(palette.filter(e => e[0] > 200 && e[0] < 255)).toEqual([]);
+      });
+
+      test("256 distinct colours with a dominant one come out exact at the default colors", async () => {
+        // The shape of a re-encoded 256-colour GIF or PNG8: one background
+        // colour on 94% of the pixels and 255 single-pixel colours.
+        const table: [number, number, number, number][] = Array.from({ length: 256 }, (_, i) =>
+          i === 0 ? grey(128) : [i, (i * 7 + 3) & 255, (i * 13 + 5) & 255, 255],
+        );
+        const colourAt = (x: number, y: number) => table[y * 64 + x < 255 ? y * 64 + x + 1 : 0];
+        const src = makePng(64, 64, colourAt);
+        const out = await new Bun.Image(src).png({ palette: true }).bytes();
+        expect(pngPalette(out)).toEqual(
+          table.slice().sort((a, b) => a[0] - b[0] || a[1] - b[1] || a[2] - b[2] || a[3] - b[3]),
+        );
+        const back = decodePngRaw(await new Bun.Image(out).png().bytes());
+        let changed = 0;
+        for (let y = 0; y < 64; y++) {
+          for (let x = 0; x < 64; x++) {
+            if (rgbaAt(back.data, 64, x, y).join() !== colourAt(x, y).join()) changed++;
+          }
+        }
+        expect(changed).toBe(0);
       });
     });
 


### PR DESCRIPTION
### Problem
- `png({ palette: true, colors: 2 })` on a 75% white, 25% black image writes a PLTE of `[128,128,128]` and `[255,255,255]`. Every black pixel comes out mid-grey. Three flat colours with noise at `colors: 3` come back with two merged.
- The quantizer (`src/runtime/image/quantize.rs:112`) cuts each box at its pixel-count midpoint. A colour that holds more than half of the box is then on both sides, and the smaller side's mean is a blend.

### Fix
- `cut_point` only cuts between two distinct values of the sort channel, so one value never sits in both halves. It takes the cut with the least squared error about the halves' means, the error the palette entries minimise.
- Correct because a box is only split when its range on the sort channel is greater than zero, so such a cut exists. A source with at most `colors` colours now yields exactly those colours. A noisy dominant colour spans adjacent values, and the least-error cut keeps that cloud whole.
- Verified: `test/js/bun/image/image.test.ts` (12 new tests, all fail on bun 1.4.1). Also `image-kernels.test.ts`, `image-adversarial.test.ts`, clippy.

### Background
- Median cut (Heckbert 1982) repeatedly splits the RGBA box with the largest channel range along that channel. Each box's mean becomes a palette entry.
- Squared deviation from a mean sums to (sum of squares) minus (sum)²/count, so the least-error cut has the largest Σ (L²/i + R²/(m-i)) over channels, for left and right channel sums L and R.

<details><summary>Notes</summary>

Before the fix, on bun 1.4.1 (PLTE entries, sorted):

```
75% white / 25% black, colors:2        => [[128,128,128],[255,255,255]]
75% white / 25% black, colors:4        => [[0,0,0],[255,255,255],[255,255,255]]
60% white / 40% (10,10,10), colors:2   => [[59,59,59],[255,255,255]]
red 75% / green 15% / blue 10%, colors:3 => [[0,153,102],[255,0,0],[255,0,0]]
5 colours unequal, colors:5            => [[0,0,0],[0,0,1],[128,204,178],[255,128,128],[255,255,255]]
5 colours unequal, colors:256          => 28 entries, mostly duplicates
same RGB, alpha 255 (75%) / 0 (25%)    => tRNS [128, 255]
greys 0/128/255 at 30/30/40%, colors:3 => [0,102,230]
greys 0/225/255 at 30/30/40%, colors:2 => [90,249]
75% white 250+-2 / 25% black, colors:2 => [124,251]   (black maps to grey)
3 colours +-2 noise, colors:3          => blue and red merged, off by 140
75% white + 201-step ramp, colors:16   => two white entries, 15 distinct
256 colours, 94% one colour, default   => 207 unique entries, 98 pixels recoloured
```

After the fix every case above yields exactly the source colours (the noisy ones within the noise), or `colors` distinct entries with one white when the source has more colours than slots. Spare slots are no longer filled with duplicates.

`order` is a permutation of pixel indices and each `ColorBox` owns a contiguous `[lo, hi)` slice of it, sorted by the chosen channel before the split.

A first version of this PR moved the cut to the run boundary nearest the count midpoint. The self-review found that rule value-blind: with +-2 noise the dominant colour is five adjacent runs, the nearest boundary falls between two of them, and black maps to grey again (`[130,131,131]`). On `0/225/255` at 30/30/40 it merged 225 with black (`[113,255]`), worse than main. Scoring the boundaries by squared error fixes both and gives the same palettes on every count-based fixture. The tests for the count-based cases (three greys at 128) are kept, and tests for a grey near one end, the noisy dominant colour, and the JPEG-like image were added.

Cost: per split, one pass over the box for channel totals and one sweep with a score at each of at most 255 boundaries. The sort the loop already does is O(m log m), so this does not change the complexity. Squares use u128 because a channel sum can reach 255 * 2^32.

The existing palette test (2x2, four colours, `colors: 4`) relies on the same exactness property for equal counts.

Suites run with the debug build: `test/js/bun/image/image.test.ts` (107 pass, 2 platform skips), `image-kernels.test.ts` and `image-adversarial.test.ts` (98 pass), `cargo clippy -p bun_runtime` clean.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/image/image.test.ts

<!-- robobun:evidence:end -->