### PR TITLE
sql(mysql): set the session time zone to UTC so TIMESTAMP stores the bound instant

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1369,7 +1369,7 @@ Bun converts MySQL types to JavaScript types:
 
 `DATETIME` and `TIMESTAMP` values have no timezone on the wire, so Bun reads them back as **UTC**. The `Date` you get has the same UTC wall-clock that was stored, regardless of the machine's timezone. Reading as UTC matches how Bun writes values (a bound `Date` stores its UTC components). The same applies to PostgreSQL's `timestamp` (without time zone); `timestamptz` carries an explicit offset and is unaffected.
 
-Bun also sets `time_zone = '+00:00'` on every MySQL connection it opens. The server converts `TIMESTAMP` columns through the session time zone, so this keeps the stored instant equal to the `Date` you bound, and it makes server-side time functions such as `NOW()` and `CURRENT_TIMESTAMP` evaluate in UTC. Running `SET time_zone = ...` yourself overrides this for that connection.
+Bun also sets `time_zone = '+00:00'` on every MySQL connection it opens. The server converts `TIMESTAMP` columns through the session time zone, so this keeps the stored instant equal to the `Date` you bound, and it makes server-side time functions such as `NOW()` and `CURRENT_TIMESTAMP` evaluate in UTC. There is no option to pick a different session time zone yet: a manual `SET time_zone = ...` reaches only the one pooled connection that runs it ([#40254](https://github.com/oven-sh/bun/issues/40254) tracks a per-connection option).
 
 #### Differences from PostgreSQL
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1369,6 +1369,8 @@ Bun converts MySQL types to JavaScript types:
 
 `DATETIME` and `TIMESTAMP` values have no timezone on the wire, so Bun reads them back as **UTC**. The `Date` you get has the same UTC wall-clock that was stored, regardless of the machine's timezone. Reading as UTC matches how Bun writes values (a bound `Date` stores its UTC components). The same applies to PostgreSQL's `timestamp` (without time zone); `timestamptz` carries an explicit offset and is unaffected.
 
+Bun also sets `time_zone = '+00:00'` on every MySQL connection it opens. The server converts `TIMESTAMP` columns through the session time zone, so this keeps the stored instant equal to the `Date` you bound, and it makes server-side time functions such as `NOW()` and `CURRENT_TIMESTAMP` evaluate in UTC. Running `SET time_zone = ...` yourself overrides this for that connection.
+
 #### Differences from PostgreSQL
 
 The API is unified, but behavior differs:

--- a/src/sql/mysql/ConnectionState.rs
+++ b/src/sql/mysql/ConnectionState.rs
@@ -5,8 +5,7 @@ pub enum ConnectionState {
     Handshaking,
     Authenticating,
     AuthenticationAwaitingPk,
-    /// Authenticated; waiting for the OK of the session-setup query
-    /// (`SET time_zone`) sent before the connection joins the pool.
+    /// Authenticated; awaiting the OK of the session-setup `SET time_zone`.
     SessionSetup,
     Connected,
     Failed,

--- a/src/sql/mysql/ConnectionState.rs
+++ b/src/sql/mysql/ConnectionState.rs
@@ -5,6 +5,9 @@ pub enum ConnectionState {
     Handshaking,
     Authenticating,
     AuthenticationAwaitingPk,
+    /// Authenticated; waiting for the OK of the session-setup query
+    /// (`SET time_zone`) sent before the connection joins the pool.
+    SessionSetup,
     Connected,
     Failed,
 }

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -298,7 +298,7 @@ impl JSMySQLConnection {
                 self.connection_timeout_ms,
                 "",
             ),
-            S::Handshaking | S::Authenticating | S::AuthenticationAwaitingPk => (
+            S::Handshaking | S::Authenticating | S::AuthenticationAwaitingPk | S::SessionSetup => (
                 AnyMySQLErrorT::ConnectionTimedOut,
                 Connection,
                 self.connection_timeout_ms,
@@ -622,7 +622,11 @@ impl JSMySQLConnection {
             // fail chain never runs: fail directly so the JS onclose callback
             // fires and the status goes terminal instead of staying
             // Connecting forever.
-            S::Connecting | S::Handshaking | S::Authenticating | S::AuthenticationAwaitingPk => {
+            S::Connecting
+            | S::Handshaking
+            | S::Authenticating
+            | S::AuthenticationAwaitingPk
+            | S::SessionSetup => {
                 this.fail(b"Connection closed", AnyMySQLErrorT::ConnectionClosed);
             }
             S::Connected | S::Disconnected | S::Failed => {

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -959,7 +959,11 @@ impl<const SSL: bool> SocketHandler<SSL> {
         // connection so the error is actionable.
         use my_sql_connection::Status as S;
         let (message, err): (&'static [u8], AnyMySQLErrorT) = match this.connection.get().status {
-            S::Connecting | S::Handshaking | S::Authenticating | S::AuthenticationAwaitingPk => (
+            S::Connecting
+            | S::Handshaking
+            | S::Authenticating
+            | S::AuthenticationAwaitingPk
+            | S::SessionSetup => (
                 b"Connection closed before the connection was established",
                 AnyMySQLErrorT::ConnectionFailed,
             ),

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -973,7 +973,9 @@ impl<const SSL: bool> SocketHandler<SSL> {
                 b"Connection closed before the connection was established",
                 AnyMySQLErrorT::ConnectionFailed,
             ),
-            _ => (b"Connection closed", AnyMySQLErrorT::ConnectionClosed),
+            S::Connected | S::Disconnected | S::Failed => {
+                (b"Connection closed", AnyMySQLErrorT::ConnectionClosed)
+            }
         };
         this.fail(message, err);
     }

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -298,11 +298,17 @@ impl JSMySQLConnection {
                 self.connection_timeout_ms,
                 "",
             ),
-            S::Handshaking | S::Authenticating | S::AuthenticationAwaitingPk | S::SessionSetup => (
+            S::Handshaking | S::Authenticating | S::AuthenticationAwaitingPk => (
                 AnyMySQLErrorT::ConnectionTimedOut,
                 Connection,
                 self.connection_timeout_ms,
                 " (during authentication)",
+            ),
+            S::SessionSetup => (
+                AnyMySQLErrorT::ConnectionTimedOut,
+                Connection,
+                self.connection_timeout_ms,
+                " (during session setup)",
             ),
             S::Disconnected | S::Failed => return,
         };

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -7,6 +7,7 @@ use bun_sql::mysql::MySQLQueryResult;
 use bun_sql::mysql::auth_method::AuthMethod;
 use bun_sql::mysql::capabilities::MariaDBCapabilities;
 use bun_sql::mysql::connection_state::ConnectionState;
+use bun_sql::mysql::mysql_request;
 use bun_sql::mysql::mysql_types::FieldType;
 use bun_sql::mysql::protocol::any_mysql_error::{self as any_mysql_error, Error as AnyMySQLError};
 use bun_sql::mysql::protocol::auth as Auth;
@@ -621,6 +622,9 @@ impl MySQLConnection {
                 ConnectionState::Authenticating | ConnectionState::AuthenticationAwaitingPk => {
                     self.handle_auth(reader, header_length)?
                 }
+                ConnectionState::SessionSetup => {
+                    self.handle_session_setup(reader, header_length)?
+                }
                 ConnectionState::Connected => self.handle_command(reader, header_length)?,
                 _ => {
                     debug!("Unexpected packet in state {}", self.status as u8);
@@ -794,12 +798,8 @@ impl MySQLConnection {
                 };
                 ok.decode_internal(reader)?;
 
-                self.set_status(ConnectionState::Connected);
-
                 self.status_flags = ok.status_flags;
-                self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
-                self.queue.mark_as_ready_for_query();
-                self.advance();
+                self.send_session_setup()?;
             }
 
             x if x == PacketType::ERROR.0 => {
@@ -948,6 +948,63 @@ impl MySQLConnection {
             }
         }
         Ok(())
+    }
+
+    /// The Date codec (`MySQLValue.rs`) encodes and decodes DATETIME/TIMESTAMP
+    /// wall clocks as UTC, but the server converts TIMESTAMP values through
+    /// `@@session.time_zone`. Align the session with the codec before the
+    /// connection becomes ready for user queries, or every `Date` written to a
+    /// TIMESTAMP column stores an instant shifted by the session's UTC offset.
+    fn send_session_setup(&mut self) -> Result<(), AnyMySQLError> {
+        self.set_status(ConnectionState::SessionSetup);
+        mysql_request::execute_query(b"SET time_zone = '+00:00'", self.writer())?;
+        self.flush_data();
+        Ok(())
+    }
+
+    fn handle_session_setup<C: ReaderContext>(
+        &mut self,
+        reader: NewReader<C>,
+        header_length: u32, // u24 on the wire
+    ) -> Result<(), AnyMySQLError> {
+        let first_byte = reader.int::<u8>()?;
+        reader.skip(-1isize);
+
+        match first_byte {
+            x if x == PacketType::OK.0 => {
+                let mut ok = OKPacket {
+                    header: 0,
+                    affected_rows: 0,
+                    last_insert_id: 0,
+                    status_flags: StatusFlags::default(),
+                    packet_size: header_length,
+                };
+                ok.decode_internal(reader)?;
+
+                self.set_status(ConnectionState::Connected);
+
+                self.status_flags = ok.status_flags;
+                self.flags.insert(ConnectionFlags::IS_READY_FOR_QUERY);
+                self.queue.mark_as_ready_for_query();
+                self.advance();
+                Ok(())
+            }
+            x if x == PacketType::ERROR.0 => {
+                let mut err = ErrorPacket::default();
+                err.decode_internal(reader)?;
+
+                self.js_connection_ref().on_error_packet(None, &err);
+                Err(AnyMySQLError::ConnectionFailed)
+            }
+            _ => {
+                bun_core::scoped_log!(
+                    MySQLConnection,
+                    "Unexpected session-setup packet: 0x{:02x}",
+                    first_byte
+                );
+                Err(AnyMySQLError::UnexpectedPacket)
+            }
+        }
     }
 
     pub(crate) fn handle_command<C: ReaderContext>(

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -950,11 +950,8 @@ impl MySQLConnection {
         Ok(())
     }
 
-    /// The Date codec (`MySQLValue.rs`) encodes and decodes DATETIME/TIMESTAMP
-    /// wall clocks as UTC, but the server converts TIMESTAMP values through
-    /// `@@session.time_zone`. Align the session with the codec before the
-    /// connection becomes ready for user queries, or every `Date` written to a
-    /// TIMESTAMP column stores an instant shifted by the session's UTC offset.
+    /// The Date codec (`MySQLValue.rs`) is UTC on both ends, but the server
+    /// converts TIMESTAMP columns through `@@session.time_zone` (#40435).
     fn send_session_setup(&mut self) -> Result<(), AnyMySQLError> {
         self.set_status(ConnectionState::SessionSetup);
         mysql_request::execute_query(b"SET time_zone = '+00:00'", self.writer())?;

--- a/test/js/sql/sql-connect-error-reporting.test.ts
+++ b/test/js/sql/sql-connect-error-reporting.test.ts
@@ -23,9 +23,19 @@
 // Uses plain TCP servers / closed ports so the tests run without Docker.
 
 import { SQL } from "bun";
-import { expect, test } from "bun:test";
+import { expect, mock, test } from "bun:test";
 import type net from "node:net";
-import { closedPort, listeningServer, pgAuthenticationOk, pgErrorResponse, pgReadyForQuery } from "./wire-frames";
+import {
+  closedPort,
+  listeningServer,
+  mysqlErrPacket,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadPackets,
+  pgAuthenticationOk,
+  pgErrorResponse,
+  pgReadyForQuery,
+} from "./wire-frames";
 
 // connectionTimeout (seconds, fractional allowed) bounds the connect-retry
 // budget; keep it short in tests that expect the failure to surface. Tests
@@ -316,6 +326,74 @@ test("mysql: onclose fires once per closed connection, not per retry attempt", a
     expect(oncloseCalls).toBe(1);
   } finally {
     await db.close({ timeout: 0 });
+    server.close();
+  }
+});
+
+// Session setup: after the auth OK the driver sends `SET time_zone = '+00:00'`
+// and holds the connection out of the pool until the OK arrives. These three
+// tests fault-inject that window: the server errors the statement, closes the
+// socket, or never answers.
+function mysqlServerUpToAuthOk(onPostAuth: (socket: net.Socket, payload: Buffer) => void) {
+  return listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        onPostAuth(socket, payload);
+      });
+    });
+    socket.on("error", () => {});
+  });
+}
+
+test("mysql: a server error during session setup surfaces the server message", async () => {
+  const { port, server } = await mysqlServerUpToAuthOk(socket => {
+    socket.write(mysqlErrPacket(1, 1298, "HY000", "Unknown or incorrect time zone: '+00:00'"));
+  });
+  try {
+    const err = await connectError(`mysql://root@127.0.0.1:${port}/db`);
+    expect(err.message).toBe("Unknown or incorrect time zone: '+00:00'");
+    expect(err.code).toBe("ERR_MYSQL_SERVER_ERROR");
+    expect(err.errno).toBe(1298);
+    expect(err.sqlState).toBe("HY000");
+  } finally {
+    server.close();
+  }
+});
+
+test("mysql: a socket close during session setup is a connect failure", async () => {
+  const onconnect = mock();
+  const { port, server } = await mysqlServerUpToAuthOk(socket => socket.destroy());
+  const db = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1, connectionTimeout: 0.25, onconnect });
+  try {
+    const err = await db.connect().catch(e => e);
+    // onconnect only fires once the session setup OK arrives, so the close is
+    // classified like any other pre-established close and retried.
+    expect(err.message).toBe("Connection closed before the connection was established");
+    expect(err.code).toBe("ERR_MYSQL_CONNECTION_FAILED");
+    expect(onconnect).not.toHaveBeenCalled();
+  } finally {
+    await db.close({ timeout: 0 });
+    server.close();
+  }
+});
+
+test("mysql: a server that never answers the session setup hits connectionTimeout", async () => {
+  const { port, server } = await mysqlServerUpToAuthOk(() => {
+    // swallow the SET time_zone query; the connection stays in session setup
+  });
+  try {
+    const err = await connectError(`mysql://root@127.0.0.1:${port}/db`, 0.25);
+    expect(err.code).toBe("ERR_MYSQL_CONNECTION_TIMEOUT");
+    expect(err.message).toContain("during session setup");
+  } finally {
     server.close();
   }
 });

--- a/test/js/sql/sql-empty-column-name.fixture.ts
+++ b/test/js/sql/sql-empty-column-name.fixture.ts
@@ -12,6 +12,7 @@
 import { SQL } from "bun";
 import {
   listeningServer,
+  mysqlAckSessionSetup,
   mysqlColumnDefinition,
   mysqlHandshakeV10,
   mysqlLenencInt,
@@ -110,6 +111,7 @@ async function mysqlServer() {
           socket.write(mysqlOkPacket(seq + 1));
           return;
         }
+        if (mysqlAckSessionSetup(socket, payload)) return;
         switch (payload[0]) {
           case COM_QUERY:
             socket.write(mysqlTextResultSet(1, columns, [values]));

--- a/test/js/sql/sql-mariadb-json.test.ts
+++ b/test/js/sql/sql-mariadb-json.test.ts
@@ -26,6 +26,7 @@ import {
   MYSQL_CLIENT_SSL,
   MYSQL_DEFAULT_CAPABILITIES,
   listeningServer,
+  mysqlAckSessionSetup,
   mysqlColumnDefinition,
   mysqlHandshakeV10,
   mysqlLenencStr,
@@ -98,6 +99,7 @@ async function mariadbMockServer(opts: {
         socket.write(mysqlOkPacket(seq + 1));
         return;
       }
+      if (mysqlAckSessionSetup(socket, payload)) return;
       const negotiated = (state.clientExtendedCaps & MARIADB_CLIENT_EXTENDED_TYPE_INFO) !== 0;
       switch (payload[0]) {
         case COM_STMT_PREPARE:

--- a/test/js/sql/sql-mysql-clean-reentry.test.ts
+++ b/test/js/sql/sql-mysql-clean-reentry.test.ts
@@ -31,7 +31,7 @@ test.skipIf(!isDebug && !isASAN)(
       "fixture.ts": /* js */ `
       import net from "node:net";
       import { SQL } from "bun";
-      import { mysqlHandshakeV10, mysqlOkPacket } from ${JSON.stringify(wireFrames)};
+      import { mysqlAckSessionSetup, mysqlHandshakeV10, mysqlOkPacket } from ${JSON.stringify(wireFrames)};
 
       let socketRef;
       const server = net.createServer(socket => {
@@ -44,9 +44,11 @@ test.skipIf(!isDebug && !isASAN)(
             const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
             if (buffered.length < 4 + len) break;
             const seq = buffered[3];
+            const payload = buffered.subarray(4, 4 + len);
             buffered = buffered.subarray(4 + len);
             if (!authed) { authed = true; socket.write(mysqlOkPacket(seq + 1)); }
-            // Never respond to queries -> they stay in the native request queue.
+            else mysqlAckSessionSetup(socket, payload);
+            // Never respond to user queries -> they stay in the native request queue.
           }
         });
         socket.on("error", () => {});

--- a/test/js/sql/sql-mysql-columns-realloc-oom.test.ts
+++ b/test/js/sql/sql-mysql-columns-realloc-oom.test.ts
@@ -18,6 +18,7 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import {
   listeningServer,
+  mysqlAckSessionSetup,
   mysqlColumnDefinition,
   mysqlHandshakeV10,
   mysqlOkPacket,
@@ -54,6 +55,7 @@ test("MySQL: OOM reallocating statement.columns does not leave a dangling slice"
           socket.write(mysqlOkPacket(seq + 1));
           return;
         }
+        if (mysqlAckSessionSetup(socket, payload)) return;
         const cmd = payload[0];
         if (cmd === COM_STMT_PREPARE) {
           socket.write(

--- a/test/js/sql/sql-mysql-datetime-tz-fixture.ts
+++ b/test/js/sql/sql-mysql-datetime-tz-fixture.ts
@@ -90,6 +90,15 @@ checkRoundTrip("text", await sql`SELECT id, dt FROM ${sql(t)} ORDER BY id`.simpl
   if (!(row.ts instanceof Date) || row.ts.getTime() !== written.getTime()) {
     failures.push(`TIMESTAMP read back: expected ${written.toISOString()}, got ${String(row.ts)}`);
   }
+
+  // A server-generated value has no cancelling encode error, so this pins the
+  // decode half on its own: NOW() is fixed per statement, so the decoded Date
+  // must equal the server's own epoch for the same instant.
+  const [gen] = await sql`
+    SELECT NOW(3) AS n, CAST(ROUND(UNIX_TIMESTAMP(NOW(3)) * 1000) AS SIGNED) AS n_ms`;
+  if (!(gen.n instanceof Date) || gen.n.getTime() !== Number(gen.n_ms)) {
+    failures.push(`NOW() decode: got ${String(gen.n)}, server epoch ${gen.n_ms}`);
+  }
 }
 
 // MySQL's permissive sql_mode stores "0000-00-00 00:00:00"; it must read back

--- a/test/js/sql/sql-mysql-datetime-tz-fixture.ts
+++ b/test/js/sql/sql-mysql-datetime-tz-fixture.ts
@@ -4,7 +4,9 @@
 // as UTC too — if it interprets them as local time, the round-trip silently
 // shifts by the machine's UTC offset. This must hold on BOTH the prepared
 // (binary) and simple (text) protocols, and MySQL zero-dates must surface as
-// Invalid Date on both.
+// Invalid Date on both. TIMESTAMP columns additionally require the session
+// time zone to be UTC (the driver sets it on connect), or the server shifts
+// the stored instant by the session offset (#40435).
 //
 // The driving test spawns this fixture under several TZ values against a real
 // MySQL server and asserts the identity holds for each.
@@ -57,6 +59,38 @@ function checkRoundTrip(protocol: string, rows: Array<{ dt: Date }>) {
 // naive wall-clock as UTC.
 checkRoundTrip("binary", await sql`SELECT id, dt FROM ${sql(t)} ORDER BY id`);
 checkRoundTrip("text", await sql`SELECT id, dt FROM ${sql(t)} ORDER BY id`.simple());
+
+// #40435: the server converts TIMESTAMP (not DATETIME) columns through
+// @@session.time_zone, while the driver's Date codec is UTC on both ends. The
+// driver must align every new session to UTC, or a Date written to a TIMESTAMP
+// column stores an instant shifted by the session offset — and the same-session
+// round trip hides it, because the decode error cancels the encode error.
+{
+  const [{ tz }] = await sql`SELECT @@session.time_zone AS tz`;
+  if (tz !== "+00:00") {
+    failures.push(`session time_zone: expected +00:00, got ${tz}`);
+  }
+
+  const tt = "ts_tz_" + randomUUIDv7("hex").replaceAll("-", "");
+  await sql`CREATE TEMPORARY TABLE ${sql(tt)} (ts TIMESTAMP(3) NULL)`;
+  const written = new Date("2026-08-25T10:00:00.000Z");
+  await sql`INSERT INTO ${sql(tt)} (ts) VALUES (${written})`;
+  // UNIX_TIMESTAMP reports the UTC instant the server actually stored,
+  // independent of the session zone, so it catches a shifted write that a
+  // read-back of `ts` through the same session would cancel out.
+  const [row] = await sql`
+    SELECT ts, CAST(ROUND(UNIX_TIMESTAMP(ts) * 1000) AS SIGNED) AS stored_ms FROM ${sql(tt)}`;
+  const storedMs = Number(row.stored_ms);
+  if (storedMs !== written.getTime()) {
+    const diffMin = (storedMs - written.getTime()) / 60000;
+    failures.push(
+      `TIMESTAMP stored instant: wrote ${written.toISOString()}, stored ${new Date(storedMs).toISOString()} diffMin=${diffMin}`,
+    );
+  }
+  if (!(row.ts instanceof Date) || row.ts.getTime() !== written.getTime()) {
+    failures.push(`TIMESTAMP read back: expected ${written.toISOString()}, got ${String(row.ts)}`);
+  }
+}
 
 // MySQL's permissive sql_mode stores "0000-00-00 00:00:00"; it must read back
 // as Invalid Date (not the Unix epoch / a wrapped date) on both protocols.

--- a/test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
+++ b/test/js/sql/sql-mysql-duplicate-auth-switch.test.ts
@@ -17,6 +17,7 @@ import { expect, test } from "bun:test";
 import { generateKeyPairSync } from "node:crypto";
 import {
   listeningServer,
+  mysqlAckSessionSetup,
   mysqlAuthMoreData,
   mysqlAuthSwitchRequest,
   mysqlHandshakeV10,
@@ -198,7 +199,7 @@ test.each([
     socket.write(mysqlHandshakeV10({ authPlugin: handshake }));
     socket.on("error", () => {});
     socket.on("data", chunk => {
-      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), seq => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
         if (phase === 0) {
           phase = 1;
           socket.write(mysqlAuthSwitchRequest(seq + 1, switchTo, Buffer.alloc(20, 0x62)));
@@ -206,6 +207,8 @@ test.each([
           phase = 2;
           responses++;
           socket.write(mysqlOkPacket(seq + 1));
+        } else {
+          mysqlAckSessionSetup(socket, payload);
         }
       });
     });

--- a/test/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts
+++ b/test/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts
@@ -8,7 +8,14 @@
 // protocol error; see StmtPrepareOKPacket::decode_internal for the invariant.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
-import { listeningServer, mysqlHandshakeV10, mysqlOkPacket, mysqlReadPackets, mysqlStmtPrepareOk } from "./wire-frames";
+import {
+  listeningServer,
+  mysqlAckSessionSetup,
+  mysqlHandshakeV10,
+  mysqlOkPacket,
+  mysqlReadPackets,
+  mysqlStmtPrepareOk,
+} from "./wire-frames";
 
 const COM_STMT_PREPARE = 0x16;
 const COM_STMT_EXECUTE = 0x17;
@@ -29,6 +36,7 @@ test("MySQL: prepare-OK with statement_id 0 is a protocol error and is never exe
           socket.write(mysqlOkPacket(seq + 1));
           return;
         }
+        if (mysqlAckSessionSetup(socket, payload)) return;
         if (payload[0] === COM_STMT_PREPARE) {
           // The hostile frame: a well-formed prepare-OK whose statement_id is 0.
           socket.write(mysqlStmtPrepareOk(1, 0, 0, 0));

--- a/test/js/sql/sql-mysql.auth.test.ts
+++ b/test/js/sql/sql-mysql.auth.test.ts
@@ -7,6 +7,7 @@ import {
   MYSQL_FAST_AUTH_SUCCESS,
   MYSQL_MOCK_AUTH_DATA_PART_1,
   MYSQL_MOCK_AUTH_DATA_PART_2,
+  mysqlAckSessionSetup,
   mysqlAuthMoreData,
   mysqlHandshakeV10,
   mysqlOkPacket,
@@ -131,6 +132,9 @@ test.each(["split", "coalesced"] as const)(
             }
             return;
           }
+          // The session-setup COM_QUERY (SET time_zone) belongs to connection
+          // establishment; ack it and keep it out of `commands`.
+          if (mysqlAckSessionSetup(socket, payload)) return;
           commands.push(payload[0]);
           if (payload[0] === COM_QUERY) {
             socket.write(mysqlTextResultSet(1, [{ name: "v", type: MYSQL_TYPE_VAR_STRING }], [["REAL-ROW"]]));
@@ -186,6 +190,8 @@ test("caching_sha2_password scramble hashes the double-SHA256 before the nonce",
           // Accept the auth so the query below completes and `await using sql` can
           // tear down over the normal COM_QUIT path; the scramble is the subject.
           socket.write(mysqlOkPacket(seq + 1));
+        } else if (mysqlAckSessionSetup(socket, payload)) {
+          // session setup acked
         } else if (payload[0] === COM_QUERY) {
           socket.write(mysqlTextResultSet(1, [{ name: "v", type: MYSQL_TYPE_VAR_STRING }], [["REAL-ROW"]]));
         } else {

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -4,6 +4,7 @@ import { bunEnv, bunExe, bunRun, describeWithContainer, isDockerEnabled, tempDir
 import path from "path";
 import {
   listeningServer,
+  mysqlAckSessionSetup,
   mysqlColumnDefinition,
   mysqlHandshakeV10,
   mysqlLenencInt,
@@ -1250,6 +1251,7 @@ test("MySQL: binary TIME with a very large days field formats without integer wr
           socket.write(mysqlOkPacket(seq + 1));
           return;
         }
+        if (mysqlAckSessionSetup(socket, payload)) return;
         if (payload[0] === COM_STMT_PREPARE) {
           socket.write(mysqlStmtPrepareOk(1, 1, 0, 0));
         } else if (payload[0] === COM_STMT_EXECUTE) {
@@ -1332,6 +1334,7 @@ test("MySQL: a row split across several maximum-size wire packets is reassembled
           socket.write(mysqlOkPacket(seq + 1));
           return;
         }
+        if (mysqlAckSessionSetup(socket, payload)) return;
         if (payload[0] !== COM_QUERY || queryIndex >= lengths.length) {
           socket.end();
           return;

--- a/test/js/sql/sql-pool-transaction-isolation.test.ts
+++ b/test/js/sql/sql-pool-transaction-isolation.test.ts
@@ -9,6 +9,7 @@ import { bunEnv, bunExe } from "harness";
 import type net from "node:net";
 import {
   listeningServer,
+  mysqlAckSessionSetup,
   mysqlHandshakeV10,
   mysqlOkPacket,
   mysqlReadPackets,
@@ -73,6 +74,7 @@ const mysqlMockServer: MockServer = received => {
           socket.write(mysqlOkPacket(seq + 1));
           return;
         }
+        if (mysqlAckSessionSetup(socket, payload)) return;
         if (payload[0] === COM_QUERY) {
           const sql = payload.subarray(1).toString("utf8");
           received.push({ conn: connId, sql });

--- a/test/js/sql/wire-frames.test.ts
+++ b/test/js/sql/wire-frames.test.ts
@@ -7,6 +7,7 @@ import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import {
   listeningServer,
+  mysqlAckSessionSetup,
   mysqlHandshakeV10,
   mysqlLenencInt,
   mysqlOkPacket,
@@ -112,10 +113,12 @@ test("mysql: mysqlHandshakeV10 + mysqlOkPacket are accepted by Bun's parser", as
     let authed = false;
     socket.write(mysqlHandshakeV10());
     socket.on("data", chunk => {
-      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), seq => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
         if (!authed) {
           authed = true;
           socket.write(mysqlOkPacket(seq + 1));
+        } else {
+          mysqlAckSessionSetup(socket, payload);
         }
       });
     });

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -356,6 +356,17 @@ export function mysqlOkPacket(seq: number, header: 0x00 | 0xfe = 0x00): Buffer {
   return mysqlRawPacket(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
 }
 
+// MySQL ERR_Packet — page_protocol_basic_err_packet.html:
+//   Int<1>(0xff) Int<2>(error_code) '#' String<5>(sql_state) String<EOF>(message)
+export function mysqlErrPacket(seq: number, code: number, sqlState: string, message: string): Buffer {
+  const codeBuf = Buffer.alloc(2);
+  codeBuf.writeUInt16LE(code);
+  return mysqlRawPacket(
+    seq,
+    Buffer.concat([Buffer.from([0xff]), codeBuf, Buffer.from("#"), Buffer.from(sqlState), Buffer.from(message)]),
+  );
+}
+
 // The driver sends `SET time_zone = '+00:00'` as a COM_QUERY on every new
 // connection right after authentication (session setup, MySQLConnection.rs)
 // and waits for its OK before it reports itself connected. A mock server must

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -356,6 +356,18 @@ export function mysqlOkPacket(seq: number, header: 0x00 | 0xfe = 0x00): Buffer {
   return mysqlRawPacket(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
 }
 
+// The driver sends `SET time_zone = '+00:00'` as a COM_QUERY on every new
+// connection right after authentication (session setup, MySQLConnection.rs)
+// and waits for its OK before it reports itself connected. A mock server must
+// acknowledge it or the client never reaches Connected. Call this first in the
+// post-auth dispatcher; it answers OK and returns true when `payload` is that
+// query.
+export function mysqlAckSessionSetup(socket: { write(data: Buffer): unknown }, payload: Buffer): boolean {
+  if (payload[0] !== 0x03 /* COM_QUERY */ || !payload.includes("SET time_zone")) return false;
+  socket.write(mysqlOkPacket(1));
+  return true;
+}
+
 // MySQL Protocol::AuthMoreData — page_protocol_connection_phase_packets_protocol_auth_more_data.html:
 //   Int<1>(0x01) String<EOF>(plugin-specific payload)
 export function mysqlAuthMoreData(seq: number, data: Buffer): Buffer {

--- a/test/js/sql/wire-frames.ts
+++ b/test/js/sql/wire-frames.ts
@@ -363,7 +363,9 @@ export function mysqlOkPacket(seq: number, header: 0x00 | 0xfe = 0x00): Buffer {
 // post-auth dispatcher; it answers OK and returns true when `payload` is that
 // query.
 export function mysqlAckSessionSetup(socket: { write(data: Buffer): unknown }, payload: Buffer): boolean {
-  if (payload[0] !== 0x03 /* COM_QUERY */ || !payload.includes("SET time_zone")) return false;
+  if (payload[0] !== 0x03 /* COM_QUERY */ || payload.subarray(1).toString("utf8") !== "SET time_zone = '+00:00'") {
+    return false;
+  }
   socket.write(mysqlOkPacket(1));
   return true;
 }

--- a/test/regression/issue/28004.test.ts
+++ b/test/regression/issue/28004.test.ts
@@ -172,7 +172,11 @@ test("MySQL-compatible server without CLIENT_DEPRECATE_EOF returns rows correctl
           state = "ready";
         } else if (state === "ready") {
           const cmd = payload[0];
-          if (cmd === 0x03) {
+          if (cmd === 0x03 && payload.includes("SET time_zone")) {
+            // Session-setup query the driver sends on every new connection
+            // before it reports itself connected; acknowledge with OK.
+            socket.write(buildOK(1));
+          } else if (cmd === 0x03) {
             // COM_QUERY → send result set with legacy EOF protocol:
             //   ResultSetHeader → ColumnDefs → EOF → Rows → EOF
             let seq = pktSeqId + 1;

--- a/test/regression/issue/28004.test.ts
+++ b/test/regression/issue/28004.test.ts
@@ -172,7 +172,7 @@ test("MySQL-compatible server without CLIENT_DEPRECATE_EOF returns rows correctl
           state = "ready";
         } else if (state === "ready") {
           const cmd = payload[0];
-          if (cmd === 0x03 && payload.includes("SET time_zone")) {
+          if (cmd === 0x03 && payload.subarray(1).toString("utf8") === "SET time_zone = '+00:00'") {
             // Session-setup query the driver sends on every new connection
             // before it reports itself connected; acknowledge with OK.
             socket.write(buildOK(1));

--- a/test/regression/issue/29268.test.ts
+++ b/test/regression/issue/29268.test.ts
@@ -200,7 +200,7 @@ function createManticoreMock(opts: { deprecateEof: boolean; info?: string }) {
           state = "ready";
         } else if (state === "ready") {
           const cmd = payload[0];
-          if (cmd === 0x03 && payload.includes("SET time_zone")) {
+          if (cmd === 0x03 && payload.subarray(1).toString("utf8") === "SET time_zone = '+00:00'") {
             // Session-setup query the driver sends on every new connection
             // before it reports itself connected; acknowledge with OK.
             socket.write(buildOK(1));

--- a/test/regression/issue/29268.test.ts
+++ b/test/regression/issue/29268.test.ts
@@ -200,7 +200,11 @@ function createManticoreMock(opts: { deprecateEof: boolean; info?: string }) {
           state = "ready";
         } else if (state === "ready") {
           const cmd = payload[0];
-          if (cmd === 0x03) {
+          if (cmd === 0x03 && payload.includes("SET time_zone")) {
+            // Session-setup query the driver sends on every new connection
+            // before it reports itself connected; acknowledge with OK.
+            socket.write(buildOK(1));
+          } else if (cmd === 0x03) {
             // COM_QUERY → send TWO result sets.
             // First carries SERVER_MORE_RESULTS_EXISTS; second does not.
             let seq = pktSeqId + 1;


### PR DESCRIPTION
### Problem
- A `Date` bound to a MySQL `TIMESTAMP` column stores the wrong instant whenever `@@session.time_zone` is not UTC. With a `+02:00` session, `2026-08-25T10:00:00Z` is stored as `08:00:00Z`. MySQL's shipped default (`time_zone = SYSTEM`) is non-UTC on any non-UTC host.
- The cause: the `Date` codec (`src/sql_jsc/mysql/MySQLValue.rs`) encodes and decodes wall clocks as UTC, but the server converts `TIMESTAMP` (not `DATETIME`) through the session time zone. The encode and decode errors cancel, so a write-then-read through Bun looks correct while the stored row is wrong for every other reader (`UNIX_TIMESTAMP`, other clients, the server itself).
- No workaround exists from Bun: `SET time_zone` through the pool reaches one physical connection, and there is no per-connection hook (#40254).

### Fix
- Send `SET time_zone = '+00:00'` on every newly established connection, after authentication and before the connection reports itself connected (new `ConnectionState::SessionSetup` between the auth OK and `Connected` in `MySQLConnection.rs`). This makes the codec's UTC assumption true, so `TIMESTAMP` stores the exact instant and reconnects are covered.
- This also fixes reads of server-generated times: `NOW()` previously came back shifted by the session offset because the decoder parses the session wall clock as UTC.
- `go-sql-driver/mysql` uses the same pattern (its `time_zone` DSN parameter issues the same statement). There is no opt-out in this PR: a different session zone needs the per-connection `timezone` option tracked in #40254. The docs say so plainly.
- Verified: `test/js/sql/sql-mysql-datetime-roundtrip.test.ts` (fixture now asserts `@@session.time_zone`, `UNIX_TIMESTAMP(ts)` against `written.getTime()`, and the `NOW()` decode; fails on stock bun). `sql-connect-error-reporting.test.ts` fault-injects the setup window: a server ERR surfaces the server message, a socket close is a retried connect failure, and a stall hits `connectionTimeout`. Also the mock-server suites and the full local MySQL test set; the mocks acknowledge the setup query via a shared `mysqlAckSessionSetup` helper in `wire-frames.ts`.

### Background
- MySQL stores `TIMESTAMP` as UTC and converts to and from `@@session.time_zone` on every read and write. `DATETIME` is stored verbatim with no conversion, which is why only `TIMESTAMP` disagreed with the UTC codec.
- The wire protocol has no time zone field; a bound `Date` travels as a bare `YYYY-MM-DD hh:mm:ss.ffff` literal that the server interprets in the session zone.
- The handshake cannot set session variables, so the driver issues one `SET` query per physical connection and holds the connection out of the pool until its OK arrives. An ERROR reply fails the connection: a server that rejects the statement would otherwise keep writing shifted timestamps silently.

<details><summary>Notes</summary>

Reproduction (MariaDB 11.8, session `+02:00`):

```
wrote                     2026-08-25T10:00:00.000Z
read back (TIMESTAMP)     2026-08-25T10:00:00.000Z   <- round trip hides it
actually stored           2026-08-25T08:00:00.000Z   <- UNIX_TIMESTAMP(ts)
read back (DATETIME)      2026-08-25T10:00:00.000Z   <- correct, no conversion
```

Why the test asserts three things: `UNIX_TIMESTAMP(ts)` is session-independent and proves the stored instant. `@@session.time_zone = '+00:00'` proves every fresh connection is aligned even when the test server's own default is already UTC (as in CI containers). The `NOW(3)` decode against the server's own `UNIX_TIMESTAMP(NOW(3))` pins the read half, which has no cancelling encode error.

Behavior changes on a non-UTC server, for the release notes:
- `NOW()` / `CURRENT_TIMESTAMP` / `CURDATE()` evaluate in UTC on Bun connections. Reading them through Bun now yields the correct instant (before, the decoded `Date` was shifted by the session offset).
- `DATETIME DEFAULT CURRENT_TIMESTAMP` columns now store UTC wall clocks instead of the server host's wall clock.
- Existing `TIMESTAMP` rows written by Bun before this change hold shifted instants. Rows written by other clients or by `DEFAULT CURRENT_TIMESTAMP` were already correct. The driver cannot tell them apart; correcting old Bun-written rows needs the session offset that was in effect at write time.

Mock updates: the driver now sends one COM_QUERY before it reports connected, so every scripted mock server that completes authentication acks it (`mysqlAckSessionSetup`, exact-match on the statement). Mocks that fail before auth completes are untouched. In `sql-mysql.auth.test.ts` the setup query is kept out of the recorded `commands` so the fast-auth framing assertion still pins exactly one user query.

Suites run locally against MariaDB 11.8 and the mocks: `sql-mysql-datetime-roundtrip`, `sql-mysql.test.ts`, `sql-mysql.auth`, `sql-mariadb-json`, `sql-mysql-duplicate-auth-switch`, `sql-mysql-auth-short-nonce`, `sql-mysql-tls-plaintext-injection`, `sql-mysql-clean-reentry`, `sql-mysql-prepare-ok-zero-statement-id`, `sql-mysql-columns-realloc-oom`, `sql-pool-transaction-isolation`, `sql-empty-column-name`, `sql-close-pending-connection`, `sql-connect-error-reporting`, `sql-onconnect-onclose-throw`, `sql-mysql.helpers`, `sql-mysql.transactions`, `wire-frames`, `regression/issue/28004`, `regression/issue/29268`. The container-gated tests that need `root@` TCP auth fail identically with and without this diff in the local environment (auth setup, pre-existing).

</details>

Fixes #40435

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 19 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-connect-error-reporting.test.ts test/js/sql/sql-mariadb-json.test.ts test/js/sql/sql-mysql-clean-reentry.test.ts test/js/sql/sql-mysql-columns-realloc-oom.test.ts test/js/sql/sql-mysql-duplicate-auth-switch.test.ts test/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts test/js/sql/sql-mysql.auth.test.ts test/js/sql/sql-mysql.test.ts test/js/sql/sql-pool-transaction-isolation.test.ts test/js/sql/wire-frames.test.ts "test/regression/issue/28004.test.ts" "test/regression/issue/29268.test.ts"
bun test v1.4.1 (861e9ae04)

test/regression/issue/29268.test.ts:
(pass) MySQL modern (DEPRECATE_EOF) multi-statement result sets [835.15ms]
(pass) MySQL legacy-EOF multi-statement result sets [281.28ms]
(pass) MySQL DEPRECATE_EOF terminator with trailing info string (Manticore szMeta) [141.93ms]

test/regression/issue/28004.test.ts:
(pass) MySQL-compatible server without CLIENT_DEPRECATE_EOF returns rows correctly [137.13ms]

test/js/sql/sql-mysql.auth.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; ch
... (truncated)

release without fix: 3 failed, 1 skipped
bun test v1.4.1-canary.1 (861e9ae04)

test/regression/issue/29268.test.ts:
(pass) MySQL modern (DEPRECATE_EOF) multi-statement result sets [13.98ms]
(pass) MySQL legacy-EOF multi-statement result sets [3.75ms]
(pass) MySQL DEPRECATE_EOF terminator with trailing info string (Manticore szMeta) [2.08ms]

test/regression/issue/28004.test.ts:
(pass) MySQL-compatible server without CLIENT_DEPRECATE_EOF returns rows correctly [2.29ms]

test/js/sql/sql-mysql.auth.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (split framing) [4.18ms]
(pass) caching_sha2_password fast-auth success: the trailing OK belongs to auth, not the first query (coalesced framing) [1.43ms]
(pass) caching_sha2_password scramble hashes the double-SHA256 before the nonce [4.65ms]
(pass) public key retrieval refusal names allowPublicKeyRetrieval and TLS as remedies [1.69ms]

test/js/sql/sql-mysql-duplicate-auth-switch.test.ts:
(pass) MySQL: a second Auth
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-connect-error-reporting.test.ts test/js/sql/sql-mariadb-json.test.ts test/js/sql/sql-mysql-clean-reentry.test.ts test/js/sql/sql-mysql-columns-realloc-oom.test.ts test/js/sql/sql-mysql-duplicate-auth-switch.test.ts test/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts test/js/sql/sql-mysql.auth.test.ts test/js/sql/sql-mysql.test.ts test/js/sql/sql-pool-transaction-isolation.test.ts test/js/sql/wire-frames.test.ts "test/regression/issue/28004.test.ts" "test/regression/issue/29268.test.ts"
bun test v1.4.1 (861e9ae04)

test/regression/issue/29268.test.ts:
(pass) MySQL modern (DEPRECATE_EOF) multi-statement result sets [564.96ms]
(pass) MySQL legacy-EOF multi-statement result sets [147.23ms]
(pass) MySQL DEPRECATE_EOF terminator with trailing info string (Manticore szMeta) [59.54ms]

test/regression/issue/28004.test.ts:
(pass) MySQL-compatible server without CLIENT_DEPRECATE_EOF returns rows correctly [89.69ms]

test/js/sql/sql-mysql.auth.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; chec
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     db6178f93b
  features     baseline

23 deps, 129 codegen, 1172 objects in 1919ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen bindgenv2
[2/1244] install /workspace/bun
bun install v1.4.1-canary.1 (861e9ae04)

Checked 26 installs across 63 packages (no changes) [28.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (861e9ae04)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] gen .bind.ts → GeneratedBindings.cpp
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (861e9ae04)

Checked 111 installs across 104 packages (no changes) [26.00ms]
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 14ms

  react-refresh.js  4.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/sql.mdx                               |  2 +
 src/sql/mysql/ConnectionState.rs                   |  2 +
 src/sql_jsc/mysql/JSMySQLConnection.rs             | 22 +++++-
 src/sql_jsc/mysql/MySQLConnection.rs               | 64 +++++++++++++++--
 test/js/sql/sql-connect-error-reporting.test.ts    | 82 +++++++++++++++++++++-
 test/js/sql/sql-empty-column-name.fixture.ts       |  2 +
 test/js/sql/sql-mariadb-json.test.ts               |  2 +
 test/js/sql/sql-mysql-clean-reentry.test.ts        |  6 +-
 test/js/sql/sql-mysql-columns-realloc-oom.test.ts  |  2 +
 test/js/sql/sql-mysql-datetime-tz-fixture.ts       | 45 +++++++++++-
 .../js/sql/sql-mysql-duplicate-auth-switch.test.ts |  5 +-
 .../sql-mysql-prepare-ok-zero-statement-id.test.ts | 10 ++-
 test/js/sql/sql-mysql.auth.test.ts                 |  6 ++
 test/js/sql/sql-mysql.test.ts                      |  3 +
 test/js/sql/sql-pool-transaction-isolation.test.ts |  2 +
 test/js/sql/wire-frames.test.ts                    |  5 +-
 test/js/sql/wire-frames.ts                         | 25 +++++++
 test/regression/issue/28004.test.ts                |  6 +-
 test/regression/issue/29268.test.ts                |  6 +-
 19 files changed, 279 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
docs/runtime/sql.mdx                                          1      2      0
src/sql/mysql/ConnectionState.rs                              2      4      0
src/sql_jsc/mysql/JSMySQLConnection.rs                        7      5      0
src/sql_jsc/mysql/MySQLConnection.rs                          8      6      0
test/js/sql/sql-connect-error-reporting.test.ts               2      3      0
test/js/sql/sql-empty-column-name.fixture.ts                  1      1      0
test/js/sql/sql-mariadb-json.test.ts                          1      1      0
test/js/sql/sql-mysql-clean-reentry.test.ts                   1      1      0
test/js/sql/sql-mysql-columns-realloc-oom.test.ts             1      1      0
test/js/sql/sql-mysql-datetime-tz-fixture.ts                  1      3      0
test/js/sql/sql-mysql-duplicate-auth-switch.test.ts           1      2      0
…t/js/sql/sql-mysql-prepare-ok-zero-statement-id.test.ts      1      2      0
test/js/sql/sql-mysql.auth.test.ts                            3      1      0
test/js/sql/sql-mysql.test.ts                                 2      1      0
test/js/sql/sql-pool-transaction-isolation.test.ts            3      1      0
test/js/sql/wire-frames.test.ts                               2      2      0
(+ 3 more files)
```

</details>

**root cause** · written by the author bot

The driver encodes a JavaScript Date as a bare UTC wall-clock datetime literal and decodes returned values as UTC, but MySQL interprets TIMESTAMP literals in the session time zone, so on any non-UTC session the stored instant was shifted by the session offset while the symmetric decode error masked the corruption on round trips. The fix makes every new MySQL connection send SET time_zone = '+00:00' immediately after authentication, in a dedicated session setup state that must complete successfully before the connection becomes available to the pool, so the session time zone always matches t…

<!-- robobun:evidence:end -->