### PR TITLE
feat: add rectangular extraction to Bun.Image

### DIFF
--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -3,7 +3,7 @@ title: Image
 description: Decode, transform, and encode images with a fast native pipeline
 ---
 
-`Bun.Image` is a chainable image pipeline for decoding, resizing, rotating, and re-encoding JPEG, PNG, WebP, HEIC, and AVIF. It is built on libjpeg-turbo, spng, libwebp, and SIMD geometry kernels, with zero npm dependencies and no native addon build step.
+`Bun.Image` is a chainable image pipeline for decoding, extracting, resizing, rotating, and re-encoding JPEG, PNG, WebP, HEIC, and AVIF. It is built on libjpeg-turbo, spng, libwebp, and SIMD geometry kernels, with zero npm dependencies and no native addon build step.
 
 ```ts
 await Bun.file("photo.jpg").image().resize(400, 400, { fit: "inside" }).webp({ quality: 80 }).write("thumb.webp");
@@ -79,6 +79,35 @@ img.resize(800, 600, { filter: "mitchell" });
 | `"nearest"`               | Pixel art / hard edges                           |
 
 When the source is a JPEG and the target is at most half the source size, decode skips straight to the nearest M/8 IDCT scale. As a result, generating a thumbnail from a 24 MP photo never materializes the full-resolution buffer.
+
+## Extract
+
+Extract a rectangular region with the same option names and pre-/post-resize semantics as Sharp:
+
+```ts
+const avatar = await new Bun.Image(upload)
+  .extract({ left: crop.x, top: crop.y, width: crop.width, height: crop.height })
+  .resize(512, 512)
+  .webp({ quality: 85 })
+  .bytes();
+```
+
+`left`, `top`, `width`, and `height` are required integers. Offsets must be non-negative and dimensions must be positive. The rectangle must fit within the image at the point where it is applied; otherwise an encoding terminal or a direct `Response` body fails with `error.code === "ERR_IMAGE_BAD_EXTRACT_AREA"`. Metadata-only operations don't execute transforms.
+
+Like Sharp, Bun keeps one extract slot before resize and one after resize. This makes both coordinate spaces available in one pipeline:
+
+```ts
+const output = await new Bun.Image(input)
+  .extract({ left: 100, top: 50, width: 1000, height: 800 }) // pre-resize coordinates
+  .resize(500, 400)
+  .extract({ left: 50, top: 25, width: 400, height: 300 }) // resized coordinates
+  .png()
+  .bytes();
+```
+
+A second extract call targets the post-resize slot even if `resize()` is added later. Further calls overwrite that post-resize slot, matching Sharp. Cropping compacts the decoded RGBA allocation in place instead of allocating an intermediate image buffer.
+
+Bun keeps its existing fixed transform order: `autoOrient → rotate → flip/flop → pre-extract → resize → post-extract → modulate`. Pre-resize coordinates therefore refer to the image after orientation, rotation, and flipping.
 
 ## Rotate · flip
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8863,6 +8863,8 @@ declare module "bun" {
      *   Catch this to fall back to a portable format.
      * - `ERR_IMAGE_TOO_MANY_PIXELS` — header dimensions or resize output
      *   exceed `maxPixels`, or a path-backed input is over the 256 MiB cap.
+     * - `ERR_IMAGE_BAD_EXTRACT_AREA` — an extract rectangle extends beyond
+     *   the image dimensions at the point where it is applied.
      * - `ERR_IMAGE_DECODE_FAILED` / `ERR_IMAGE_ENCODE_FAILED` — codec error.
      * - `ERR_IMAGE_UNKNOWN_FORMAT` — input bytes didn't match any sniffer.
      * - `ERR_INVALID_STATE` — the input ArrayBuffer was transferred between
@@ -8873,6 +8875,7 @@ declare module "bun" {
     type ErrorCode =
       | "ERR_IMAGE_FORMAT_UNSUPPORTED"
       | "ERR_IMAGE_TOO_MANY_PIXELS"
+      | "ERR_IMAGE_BAD_EXTRACT_AREA"
       | "ERR_IMAGE_DECODE_FAILED"
       | "ERR_IMAGE_ENCODE_FAILED"
       | "ERR_IMAGE_UNKNOWN_FORMAT"
@@ -8925,6 +8928,18 @@ declare module "bun" {
       withoutEnlargement?: boolean;
     }
 
+    /** A rectangular region passed to {@link Image.extract}. */
+    interface Region {
+      /** Zero-based horizontal offset. Integer between 0 and 100,000,000. */
+      left: number;
+      /** Zero-based vertical offset. Integer between 0 and 100,000,000. */
+      top: number;
+      /** Region width. Integer between 1 and 100,000,000. */
+      width: number;
+      /** Region height. Integer between 1 and 100,000,000. */
+      height: number;
+    }
+
     interface ModulateOptions {
       /** Multiplier; `1` leaves brightness unchanged. */
       brightness?: number;
@@ -8948,9 +8963,10 @@ declare module "bun" {
    * decode → transform → encode pipeline runs on a worker thread when a
    * terminal (`bytes`, `buffer`, `blob`, `toBase64`, `metadata`) is awaited.
    *
-   * Chainables overwrite (calling `.resize()` twice keeps the second). Order
-   * of execution is fixed regardless of call order:
-   * `autoOrient → rotate → flip/flop → resize → modulate`.
+   * Chainables overwrite (calling `.resize()` twice keeps the second).
+   * `extract()` has Sharp-compatible pre-resize and post-resize slots. Order
+   * of execution is fixed:
+   * `autoOrient → rotate → flip/flop → pre-extract → resize → post-extract → modulate`.
    *
    * The source ICC colour profile (Display P3, Adobe RGB, Jpegli XYB, etc.)
    * is preserved through re-encode to JPEG, PNG, and WebP so non-sRGB
@@ -9005,6 +9021,18 @@ declare module "bun" {
 
     /** Set target dimensions. Omit `height` to keep the source aspect ratio. */
     resize(width: number, height?: number, options?: Image.ResizeOptions): this;
+    /**
+     * Extract a rectangular region.
+     *
+     * The first call before `resize()` uses pre-resize pipeline coordinates
+     * (after auto-orientation, rotation, and flipping). A call after `resize()`,
+     * or a second call, uses resized-image coordinates. This matches Sharp's
+     * pre-/post-resize slots and allows `extract().resize().extract()` in one
+     * pipeline. An encoding terminal rejects with
+     * `ERR_IMAGE_BAD_EXTRACT_AREA` when the rectangle extends beyond the image
+     * at the stage where it is applied.
+     */
+    extract(region: Image.Region): this;
     /** Rotate by a multiple of 90°. */
     rotate(degrees: number): this;
     /** Mirror about the x-axis (vertical). */

--- a/src/runtime/image/Image.classes.ts
+++ b/src/runtime/image/Image.classes.ts
@@ -37,6 +37,7 @@ export default [
     proto: {
       // Chainable mutators — record an op and return `this`.
       resize: { fn: "doResize", length: 2 },
+      extract: { fn: "doExtract", length: 1 },
       rotate: { fn: "doRotate", length: 1 },
       flip: { fn: "doFlip", length: 0 },
       flop: { fn: "doFlop", length: 0 },

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -2,10 +2,11 @@
 //! libjpeg-turbo / libspng / libwebp codecs and the highway resize kernel.
 //!
 //! Shape: the constructor only captures the *input* (path or bytes). Chainable
-//! mutators (`resize`, `rotate`, `flip`, `flop`, `jpeg`/`png`/`webp`) each
-//! write one slot of `Pipeline` and return `this` — there is no op list, so
-//! calling a setter twice overwrites. The actual decode → transform → encode
-//! work happens off-thread when a terminal (`bytes`/`buffer`/`blob`/
+//! mutators (`extract`, `resize`, `rotate`, `flip`, `flop`,
+//! `jpeg`/`png`/`webp`) write fixed slots in `Pipeline` and return `this` — one
+//! slot per setting, except Sharp's pre/post extract pair. There is no op list,
+//! so later setters overwrite their slot. The actual decode → transform →
+//! encode work happens off-thread when a terminal (`bytes`/`buffer`/`blob`/
 //! `toBase64`/`metadata`) is awaited, as a `bun_jsc::Job` (`PipelineTask`).
 
 use core::cell::Cell;
@@ -190,20 +191,32 @@ impl Default for Resize {
     }
 }
 
-/// One slot per operation, not an op list — calling `.resize()` twice
-/// overwrites, it doesn't resize twice. This is Sharp's semantics and means
-/// the worker snapshot is a plain struct copy with a fixed execution order
+#[derive(Clone, Copy)]
+pub struct Extract {
+    pub(crate) left: u32,
+    pub(crate) top: u32,
+    pub(crate) w: u32,
+    pub(crate) h: u32,
+}
+
+/// Fixed slots, not an op list — calling `.resize()` twice overwrites, it
+/// doesn't resize twice. Extract has Sharp's two pre/post slots. This means the
+/// worker snapshot is a plain struct copy with a fixed execution order
 /// (`run()` below), no allocation, no "too many ops" edge.
 ///
-/// Execution order matches Sharp: (autoOrient) → rotate → flip/flop → resize
-/// → modulate. Rotate precedes resize so the target box is interpreted in
-/// upright space; modulate runs last so it operates on the fewest pixels.
+/// Execution order matches Sharp: (autoOrient) → rotate → flip/flop →
+/// pre-extract → resize → post-extract → modulate. Sharp exposes two extract
+/// slots so `.extract().resize().extract()` can crop in both coordinate spaces.
+/// Rotate precedes resize so the target box is interpreted in upright space;
+/// modulate runs last so it operates on the fewest pixels.
 #[derive(Clone, Copy, Default)]
 pub struct Pipeline {
     pub(crate) rotate: u16, // 0/90/180/270
     pub(crate) flip: bool,  // vertical
     pub(crate) flop: bool,  // horizontal
+    pub(crate) extract_pre: Option<Extract>,
     pub(crate) resize: Option<Resize>,
+    pub(crate) extract_post: Option<Extract>,
     pub(crate) modulate: Option<Modulate>,
     /// Output settings from `.jpeg()/.png()/.webp()`. `None` ⇒ re-encode in
     /// source format.
@@ -251,6 +264,42 @@ macro_rules! coerce_int {
 /// real-world image (a 268 MP JPEG is ~80 MB) while keeping a single
 /// path-driven request from materialising gigabytes before any guard runs.
 const MAX_INPUT_FILE_BYTES: u64 = 256 << 20;
+
+/// Sharp applies the same upper bound to each extract field. Keeping this
+/// below `u32::MAX` also makes the worker-side checked arithmetic predictable.
+const MAX_EXTRACT_VALUE: f64 = 100_000_000.0;
+
+fn extract_integer(
+    global: &JSGlobalObject,
+    options: JSValue,
+    property: &'static str,
+    minimum: f64,
+) -> JsResult<u32> {
+    let Some(value) = options.get(global, property)? else {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "extract: {property} must be an integer between {} and {}",
+            minimum as u32, MAX_EXTRACT_VALUE as u32
+        )));
+    };
+    if !value.is_number() {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "extract: {property} must be an integer between {} and {}",
+            minimum as u32, MAX_EXTRACT_VALUE as u32
+        )));
+    }
+    let number = value.as_number();
+    if !number.is_finite()
+        || number < minimum
+        || number > MAX_EXTRACT_VALUE
+        || number.trunc() != number
+    {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "extract: {property} must be an integer between {} and {}",
+            minimum as u32, MAX_EXTRACT_VALUE as u32
+        )));
+    }
+    Ok(number as u32)
+}
 
 // ───────────────────────────── lifecycle ────────────────────────────────────
 
@@ -489,6 +538,39 @@ impl Image {
     }
 
     #[bun_jsc::host_fn(method)]
+    pub(crate) fn do_extract(
+        &self,
+        global: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let args = callframe.arguments();
+        if args.len() < 1 || !args[0].is_object() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "extract(options) expects left, top, width and height"
+            )));
+        }
+        let options = args[0];
+        let extract = Extract {
+            left: extract_integer(global, options, "left", 0.0)?,
+            top: extract_integer(global, options, "top", 0.0)?,
+            w: extract_integer(global, options, "width", 1.0)?,
+            h: extract_integer(global, options, "height", 1.0)?,
+        };
+
+        self.update_pipeline(|p| {
+            // Sharp has one slot on either side of resize. Once a pre-extract
+            // exists, subsequent calls target (and overwrite) the post slot,
+            // even when resize is added later in the chain.
+            if p.resize.is_some() || p.extract_pre.is_some() {
+                p.extract_post = Some(extract);
+            } else {
+                p.extract_pre = Some(extract);
+            }
+        });
+        Ok(callframe.this())
+    }
+
+    #[bun_jsc::host_fn(method)]
     pub(crate) fn do_rotate(
         &self,
         global: &JSGlobalObject,
@@ -667,6 +749,14 @@ fn error_message(e: codecs::Error) -> &'static ZStr {
 
 fn reject_error(global: &JSGlobalObject, e: codecs::Error) -> JSValue {
     error_with_code(global, error_code(e), error_message(e))
+}
+
+fn reject_bad_extract_area(global: &JSGlobalObject) -> JSValue {
+    error_with_code(
+        global,
+        zstr!("ERR_IMAGE_BAD_EXTRACT_AREA"),
+        zstr!("Image: bad extract area"),
+    )
 }
 
 fn error_with_code(global: &JSGlobalObject, code: &'static ZStr, msg: &'static ZStr) -> JSValue {
@@ -1232,6 +1322,7 @@ impl Image {
                 "{}",
                 bstr::BStr::new(error_message(e).as_bytes())
             ))),
+            TaskResult::BadExtractArea => Err(global.throw_value(reject_bad_extract_area(global))),
             // Preserve errno/path/syscall instead of flattening to DecodeFailed.
             TaskResult::IoErr(e) => Err(global.throw_value(e.to_js(global))),
             TaskResult::Meta { .. } => unreachable!(),
@@ -1531,7 +1622,19 @@ pub enum TaskResult {
         format: codecs::Format,
     },
     Err(codecs::Error),
+    BadExtractArea,
     IoErr(sys::Error),
+}
+
+enum PipelineError {
+    Codec(codecs::Error),
+    BadExtractArea,
+}
+
+impl From<codecs::Error> for PipelineError {
+    fn from(value: codecs::Error) -> Self {
+        Self::Codec(value)
+    }
 }
 
 impl PipelineTask {
@@ -1641,7 +1744,13 @@ impl PipelineTask {
         // can be over-shrunk and then upscaled, throwing away detail.
         // (flip/flop are pure mirrors that never change w/h, so the hint
         //  stays valid through them.)
-        let hint: codecs::DecodeHint = if let Some(r) = self.pipeline.resize {
+        // A pre-extract is expressed in full-resolution coordinates, so a
+        // decode-time JPEG downscale would change its coordinate space. A
+        // post-extract is already expressed in resized coordinates and keeps
+        // this optimisation available.
+        let hint: codecs::DecodeHint = if self.pipeline.extract_pre.is_some() {
+            codecs::DecodeHint::default()
+        } else if let Some(r) = self.pipeline.resize {
             let mut tw = r.w;
             // r.h==0 means "preserve aspect" — constrain on width only.
             let mut th = if r.h != 0 { r.h } else { r.w };
@@ -1703,7 +1812,10 @@ impl PipelineTask {
         }
 
         if let Err(e) = self.apply_pipeline(&mut decoded) {
-            self.result = TaskResult::Err(e);
+            self.result = match e {
+                PipelineError::Codec(e) => TaskResult::Err(e),
+                PipelineError::BadExtractArea => TaskResult::BadExtractArea,
+            };
             return;
         }
 
@@ -1927,19 +2039,22 @@ impl PipelineTask {
                 promise.resolve(global, obj)?;
             }
             TaskResult::Err(e) => promise.reject(global, Ok(reject_error(global, e)))?,
+            TaskResult::BadExtractArea => {
+                promise.reject(global, Ok(reject_bad_extract_area(global)))?
+            }
             TaskResult::IoErr(e) => promise.reject(global, Ok(e.to_js(global)))?,
         }
         Ok(())
     }
 
-    /// Fixed Sharp order: rotate → flip/flop → resize. Each stage replaces
-    /// `d` in place; the old buffer is freed before assigning the new one so
-    /// peak memory is at most 2× one frame. Every stage hand-swaps only the
-    /// pixel slots — rotate/resize return a fresh `Decoded` with
-    /// `icc_profile == None`, so overwriting `d.*` wholesale would drop the
-    /// source's colour profile. Geometry doesn't change colour meaning, so
-    /// the profile survives unchanged.
-    fn apply_pipeline(&self, d: &mut codecs::Decoded) -> Result<(), codecs::Error> {
+    /// Fixed Sharp order: rotate → flip/flop → pre-extract → resize →
+    /// post-extract. Extract compacts the existing allocation; stages that
+    /// need a fresh buffer free the old one before assignment, so peak memory
+    /// is at most 2× one frame. Every stage hand-swaps only the pixel slots —
+    /// rotate/resize return a fresh `Decoded` with `icc_profile == None`, so
+    /// overwriting `d.*` wholesale would drop the source's colour profile.
+    /// Geometry doesn't change colour meaning, so the profile survives.
+    fn apply_pipeline(&self, d: &mut codecs::Decoded) -> Result<(), PipelineError> {
         let p = &self.pipeline;
         if p.rotate != 0 {
             let next = codecs::rotate(&d.rgba, d.width, d.height, u32::from(p.rotate))?;
@@ -1957,6 +2072,9 @@ impl PipelineTask {
             let next = codecs::flip(&d.rgba, d.width, d.height, true)?;
             d.rgba = next;
         }
+        if let Some(extract) = p.extract_pre {
+            extract_region(d, extract)?;
+        }
         if let Some(r) = p.resize {
             let t = resolve_resize(r, d.width, d.height);
             // Guard the output canvas AND the H-then-V intermediate (always
@@ -1968,7 +2086,7 @@ impl PipelineTask {
             if (t.0 as u64) * (t.1 as u64) > self.max_pixels
                 || (t.0 as u64) * (d.height as u64) > self.max_pixels
             {
-                return Err(codecs::Error::TooManyPixels);
+                return Err(codecs::Error::TooManyPixels.into());
             }
             if t.0 != d.width || t.1 != d.height {
                 let next = codecs::resize(&d.rgba, d.width, d.height, t.0, t.1, r.filter)?;
@@ -1977,11 +2095,93 @@ impl PipelineTask {
                 d.height = t.1;
             }
         }
+        if let Some(extract) = p.extract_post {
+            extract_region(d, extract)?;
+        }
         if let Some(m) = p.modulate {
             codecs::modulate(&mut d.rgba, m.brightness, m.saturation);
         }
         Ok(())
     }
+}
+
+/// Compact a rectangular RGBA region into the front of the existing buffer.
+/// Destination rows always begin at or before their source rows, so
+/// `copy_within` safely handles overlap and avoids a second image allocation.
+fn extract_region(d: &mut codecs::Decoded, extract: Extract) -> Result<(), PipelineError> {
+    let right = u64::from(extract.left) + u64::from(extract.w);
+    let bottom = u64::from(extract.top) + u64::from(extract.h);
+    if extract.w == 0
+        || extract.h == 0
+        || right > u64::from(d.width)
+        || bottom > u64::from(d.height)
+    {
+        return Err(PipelineError::BadExtractArea);
+    }
+
+    let decoded_pixels = u64::from(d.width)
+        .checked_mul(u64::from(d.height))
+        .ok_or(PipelineError::Codec(codecs::Error::DecodeFailed))?;
+    let decoded_bytes = decoded_pixels
+        .checked_mul(4)
+        .and_then(|n| usize::try_from(n).ok())
+        .ok_or(PipelineError::Codec(codecs::Error::DecodeFailed))?;
+    if decoded_bytes != d.rgba.len() {
+        return Err(PipelineError::Codec(codecs::Error::DecodeFailed));
+    }
+
+    if extract.left == 0 && extract.top == 0 && extract.w == d.width && extract.h == d.height {
+        return Ok(());
+    }
+
+    let src_stride = usize::try_from(d.width)
+        .ok()
+        .and_then(|n| n.checked_mul(4))
+        .ok_or(PipelineError::Codec(codecs::Error::DecodeFailed))?;
+    let row_bytes = usize::try_from(extract.w)
+        .ok()
+        .and_then(|n| n.checked_mul(4))
+        .ok_or(PipelineError::Codec(codecs::Error::DecodeFailed))?;
+    let left_bytes = usize::try_from(extract.left)
+        .ok()
+        .and_then(|n| n.checked_mul(4))
+        .ok_or(PipelineError::Codec(codecs::Error::DecodeFailed))?;
+    let top = usize::try_from(extract.top)
+        .map_err(|_| PipelineError::Codec(codecs::Error::DecodeFailed))?;
+    let height = usize::try_from(extract.h)
+        .map_err(|_| PipelineError::Codec(codecs::Error::DecodeFailed))?;
+
+    for output_y in 0..height {
+        let source_y = top
+            .checked_add(output_y)
+            .ok_or(PipelineError::Codec(codecs::Error::DecodeFailed))?;
+        let source_start = source_y
+            .checked_mul(src_stride)
+            .and_then(|n| n.checked_add(left_bytes))
+            .ok_or(PipelineError::Codec(codecs::Error::DecodeFailed))?;
+        let source_end = source_start
+            .checked_add(row_bytes)
+            .ok_or(PipelineError::Codec(codecs::Error::DecodeFailed))?;
+        let destination_start = output_y
+            .checked_mul(row_bytes)
+            .ok_or(PipelineError::Codec(codecs::Error::DecodeFailed))?;
+        let destination_end = destination_start
+            .checked_add(row_bytes)
+            .ok_or(PipelineError::Codec(codecs::Error::DecodeFailed))?;
+        if source_end > d.rgba.len() || destination_end > d.rgba.len() {
+            return Err(PipelineError::Codec(codecs::Error::DecodeFailed));
+        }
+        d.rgba
+            .copy_within(source_start..source_end, destination_start);
+    }
+
+    let output_len = row_bytes
+        .checked_mul(height)
+        .ok_or(PipelineError::Codec(codecs::Error::DecodeFailed))?;
+    d.rgba.truncate(output_len);
+    d.width = extract.w;
+    d.height = extract.h;
+    Ok(())
 }
 
 /// `.placeholder()` body — runs on the worker. Input is the decoded RGBA

--- a/src/runtime/image/README.md
+++ b/src/runtime/image/README.md
@@ -27,9 +27,11 @@ The codecs themselves are vendored via `scripts/build/deps/{libjpeg-turbo,libspn
 ## Adding a chainable op
 
 1. Add a field to `Pipeline` in `Image.rs` (one slot per op — setters
-   overwrite, there is no op list) and a stage in `PipelineTask.applyPipeline`
-   at the right point in the fixed `rotate → flip/flop → resize → modulate`
-   order.
+   overwrite, there is no op list) and a stage in `PipelineTask.apply_pipeline`
+   at the right point in the fixed pipeline:
+   `rotate → flip/flop → pre-extract → resize → post-extract → modulate`.
+   `extract` is the intentional exception to the one-slot rule: Sharp has one
+   slot on each side of resize.
 2. Add a `do<Name>` method that parses args, writes the slot, returns
    `callframe.this()`.
 3. Add it to `proto:` in `Image.classes.ts`.

--- a/src/runtime/image/mod.rs
+++ b/src/runtime/image/mod.rs
@@ -59,5 +59,6 @@ pub mod thumbhash;
 #[path = "Image.rs"]
 pub mod image_body;
 pub use image_body::{
-    Deliver, Fit, Image, Input, Kind, Modulate, Pipeline, PipelineTask, Resize, Source, TaskResult,
+    Deliver, Extract, Fit, Image, Input, Kind, Modulate, Pipeline, PipelineTask, Resize, Source,
+    TaskResult,
 };

--- a/test/integration/bun-types/fixture/bun.ts
+++ b/test/integration/bun-types/fixture/bun.ts
@@ -49,6 +49,15 @@ import * as tsd from "./utilities";
   Bun.TOML.parse("asdf = asdf");
 }
 
+{
+  const image = new Bun.Image(new Uint8Array(0));
+  const region: Bun.Image.Region = { left: 0, top: 0, width: 32, height: 32 };
+  tsd.expectType<Bun.Image>(image.extract(region));
+
+  // @ts-expect-error all four region fields are required
+  image.extract({ left: 0, top: 0, width: 32 });
+}
+
 DOMException;
 
 tsd

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -432,24 +432,25 @@ describe("Bun.Image", () => {
       expect({ w: afterResize.w, h: afterResize.h }).toEqual({ w: 2, h: 2 });
     });
 
-    test("validates all fields synchronously", () => {
-      const valid = { left: 0, top: 0, width: 1, height: 1 };
-      const cases: Array<[unknown, RegExp]> = [
-        [{}, /left/],
-        [{ ...valid, left: undefined }, /left/],
-        [{ ...valid, top: "0" }, /top/],
-        [{ ...valid, left: -1 }, /left/],
-        [{ ...valid, top: 0.5 }, /top/],
-        [{ ...valid, width: 0 }, /width/],
-        [{ ...valid, height: 0 }, /height/],
-        [{ ...valid, width: Number.NaN }, /width/],
-        [{ ...valid, height: Number.POSITIVE_INFINITY }, /height/],
-        [{ ...valid, left: 100_000_001 }, /left/],
-      ];
-      for (const [options, message] of cases) {
+    const validRegion = { left: 0, top: 0, width: 1, height: 1 };
+    describe.each([
+      ["missing left", {}, /left/],
+      ["undefined left", { ...validRegion, left: undefined }, /left/],
+      ["non-number top", { ...validRegion, top: "0" }, /top/],
+      ["negative left", { ...validRegion, left: -1 }, /left/],
+      ["fractional top", { ...validRegion, top: 0.5 }, /top/],
+      ["zero width", { ...validRegion, width: 0 }, /width/],
+      ["zero height", { ...validRegion, height: 0 }, /height/],
+      ["NaN width", { ...validRegion, width: Number.NaN }, /width/],
+      ["infinite height", { ...validRegion, height: Number.POSITIVE_INFINITY }, /height/],
+      ["left above the maximum", { ...validRegion, left: 100_000_001 }, /left/],
+    ] as const)("validates extract options synchronously: %s", (_, options, message) => {
+      test("throws for the invalid region", () => {
         expect(() => (new Bun.Image(coordinatesPng) as any).extract(options)).toThrow(message);
-      }
+      });
+    });
 
+    test("propagates extract option getter errors synchronously", () => {
       const sentinel = new Error("getter failed");
       expect(() =>
         new Bun.Image(coordinatesPng).extract({

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -85,6 +85,11 @@ const gradientPng = makePng(16, 16, (x, y) => {
   return [v, v, v, 255];
 });
 
+function coordinatePattern(x: number, y: number): [number, number, number, number] {
+  return [x * 29, y * 31, x * 7 + y * 11, 255];
+}
+const coordinatesPng = makePng(8, 8, coordinatePattern);
+
 function rgbaAt(buf: Uint8Array, w: number, x: number, y: number): [number, number, number, number] {
   const i = (y * w + x) * 4;
   return [buf[i], buf[i + 1], buf[i + 2], buf[i + 3]];
@@ -364,6 +369,121 @@ describe("Bun.Image", () => {
       const b = decodePngRaw(await new Bun.Image(wide).resize(4).png().bytes());
       expect({ w: a.w, h: a.h }).toEqual({ w: 4, h: 2 });
       expect({ w: a.w, h: a.h }).toEqual({ w: b.w, h: b.h });
+    });
+  });
+
+  describe("extract", () => {
+    test("is chainable and extracts the exact pixels", async () => {
+      const image = new Bun.Image(coordinatesPng);
+      expect(image.extract({ left: 4, top: 3, width: 4, height: 5 })).toBe(image);
+
+      const { w, h, data } = decodePngRaw(await image.png().bytes());
+      expect({ w, h }).toEqual({ w: 4, h: 5 });
+      expect({ width: image.width, height: image.height }).toEqual({ width: 4, height: 5 });
+      for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+          expect(rgbaAt(data, w, x, y)).toEqual(coordinatePattern(x + 4, y + 3));
+        }
+      }
+    });
+
+    test("supports Sharp-compatible extracts before and after resize", async () => {
+      const pre = { left: 1, top: 1, width: 6, height: 6 };
+      const post = { left: 2, top: 2, width: 4, height: 4 };
+
+      const combined = decodePngRaw(
+        await new Bun.Image(coordinatesPng)
+          .extract(pre)
+          .resize(8, 8, { filter: "nearest" })
+          .extract(post)
+          .png()
+          .bytes(),
+      );
+
+      const preOutput = await new Bun.Image(coordinatesPng).extract(pre).png().bytes();
+      const staged = decodePngRaw(
+        await new Bun.Image(preOutput).resize(8, 8, { filter: "nearest" }).extract(post).png().bytes(),
+      );
+
+      expect({ w: combined.w, h: combined.h }).toEqual({ w: 4, h: 4 });
+      expect([...combined.data]).toEqual([...staged.data]);
+    });
+
+    test("overwrites the post-resize slot like Sharp", async () => {
+      const withoutResize = decodePngRaw(
+        await new Bun.Image(coordinatesPng)
+          .extract({ left: 1, top: 1, width: 6, height: 6 })
+          .extract({ left: 99, top: 99, width: 1, height: 1 })
+          .extract({ left: 2, top: 1, width: 3, height: 2 })
+          .png()
+          .bytes(),
+      );
+      expect({ w: withoutResize.w, h: withoutResize.h }).toEqual({ w: 3, h: 2 });
+      expect(rgbaAt(withoutResize.data, 3, 0, 0)).toEqual(coordinatePattern(3, 2));
+
+      const afterResize = decodePngRaw(
+        await new Bun.Image(coordinatesPng)
+          .resize(4, 4, { filter: "nearest" })
+          .extract({ left: 99, top: 99, width: 1, height: 1 })
+          .extract({ left: 1, top: 1, width: 2, height: 2 })
+          .png()
+          .bytes(),
+      );
+      expect({ w: afterResize.w, h: afterResize.h }).toEqual({ w: 2, h: 2 });
+    });
+
+    test("validates all fields synchronously", () => {
+      const valid = { left: 0, top: 0, width: 1, height: 1 };
+      const cases: Array<[unknown, RegExp]> = [
+        [{}, /left/],
+        [{ ...valid, left: undefined }, /left/],
+        [{ ...valid, top: "0" }, /top/],
+        [{ ...valid, left: -1 }, /left/],
+        [{ ...valid, top: 0.5 }, /top/],
+        [{ ...valid, width: 0 }, /width/],
+        [{ ...valid, height: 0 }, /height/],
+        [{ ...valid, width: Number.NaN }, /width/],
+        [{ ...valid, height: Number.POSITIVE_INFINITY }, /height/],
+        [{ ...valid, left: 100_000_001 }, /left/],
+      ];
+      for (const [options, message] of cases) {
+        expect(() => (new Bun.Image(coordinatesPng) as any).extract(options)).toThrow(message);
+      }
+
+      const sentinel = new Error("getter failed");
+      expect(() =>
+        new Bun.Image(coordinatesPng).extract({
+          get left() {
+            throw sentinel;
+          },
+          top: 0,
+          width: 1,
+          height: 1,
+        }),
+      ).toThrow(sentinel);
+    });
+
+    test("rejects out-of-bounds pre- and post-resize regions with a stable code", async () => {
+      for (const terminal of [
+        new Bun.Image(coordinatesPng).extract({ left: 7, top: 0, width: 2, height: 1 }).png().bytes(),
+        new Bun.Image(coordinatesPng).resize(4, 4).extract({ left: 3, top: 0, width: 2, height: 1 }).png().bytes(),
+      ]) {
+        const error = await terminal.then(
+          () => null,
+          (reason: any) => reason,
+        );
+        expect(error?.code).toBe("ERR_IMAGE_BAD_EXTRACT_AREA");
+        expect(error?.message).toContain("bad extract area");
+      }
+    });
+
+    test("pre-extract keeps full-resolution JPEG coordinates", async () => {
+      const source = makePng(64, 64, (x, y) => [x * 4, y * 4, (x + y) * 2, 255]);
+      const jpeg = await new Bun.Image(source).jpeg({ quality: 100 }).bytes();
+      const output = decodePngRaw(
+        await new Bun.Image(jpeg).extract({ left: 48, top: 48, width: 16, height: 16 }).resize(4, 4).png().bytes(),
+      );
+      expect({ w: output.w, h: output.h }).toEqual({ w: 4, h: 4 });
     });
   });
 


### PR DESCRIPTION
### What does this PR do?

Adds rectangular extraction/cropping support to `Bun.Image` for server-side image processing workflows.

- Adds `image.extract({ left, top, width, height })`.
- Supports extraction before and after resizing.
- Supports chaining with existing image operations.
- Uses in-place RGBA compaction to avoid an intermediate image allocation.
- Adds stable `ERR_IMAGE_BAD_EXTRACT_AREA` errors.
- Adds TypeScript types, documentation, and regression tests.
- Keeps Bun's existing fixed transform order documented.

This extends the extraction approach from #40379 with pre-/post-resize support, stronger validation, in-place cropping, stable errors, and broader tests.

Closes #40421

### How did you verify your code works?

- `cargo check -p bun_runtime`
- `cargo fmt --all -- --check`
- Targeted Bun TypeScript type checking
- Prettier validation
- `git diff --check`

The complete `bun bd` runtime test suite could not be executed locally because LLVM 21.1.8 / `clang-cl` is not installed in the environment.