### PR TITLE
test(install): run the two cold installs of the 16-branch git test at the same time

### DIFF
--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -297,27 +297,32 @@ test.concurrent(
   async () => {
     using dir = tempDir("git-dep-dup", {});
     const root = String(dir);
-    const project = writeProject(root, Object.fromEntries(letters.map(l => [nameOf(l), `${sharedRepoUrl}#pkg-${l}`])));
+    const dependencies = Object.fromEntries(letters.map(l => [nameOf(l), `${sharedRepoUrl}#pkg-${l}`]));
     const { resolutions, locked } = expectedGitPackages(sharedRepoUrl, sharedCommits, letters, {
       [nameOf("a")]: sharedTransitive,
     });
 
     // the race depends on threadpool scheduling; two fresh-cache attempts to
-    // make the failure reliable on the unfixed code
-    for (let attempt = 0; attempt < 2; attempt++) {
-      rmSync(join(project, "node_modules"), { recursive: true, force: true });
-      rmSync(join(project, "bun.lock"), { force: true });
-      const { stdout, stderr, exitCode } = await runInstall(project, join(root, `cache-${attempt}`), {});
-      expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
-        "Resolving dependencies
-        Resolved, downloaded and extracted [17]
-        Saved lockfile"
-      `);
-      expectInstalled(stdout, resolutions);
-      expect(await installedVersions(project, letters.map(nameOf))).toEqual(markers(letters));
-      expect(await lockedPackages(project)).toEqual(locked);
-      expect(exitCode).toBe(0);
-    }
+    // make the failure reliable on the unfixed code. Each attempt installs
+    // into a project and cache of its own so that both run at the same time:
+    // a cold install of 16 git packages spawns about 60 git processes, which
+    // is what this test costs on Windows.
+    await Promise.all(
+      [0, 1].map(async attempt => {
+        const attemptRoot = join(root, `attempt-${attempt}`);
+        const project = writeProject(attemptRoot, dependencies);
+        const { stdout, stderr, exitCode } = await runInstall(project, join(attemptRoot, "cache"), {});
+        expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+          "Resolving dependencies
+          Resolved, downloaded and extracted [17]
+          Saved lockfile"
+        `);
+        expectInstalled(stdout, resolutions);
+        expect(await installedVersions(project, letters.map(nameOf))).toEqual(markers(letters));
+        expect(await lockedPackages(project)).toEqual(locked);
+        expect(exitCode).toBe(0);
+      }),
+    );
   },
   30_000,
 );

--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -306,23 +306,26 @@ test.concurrent(
     // make the failure reliable on the unfixed code. Each attempt installs
     // into a project and cache of its own so that both run at the same time:
     // a cold install of 16 git packages spawns about 60 git processes, which
-    // is what this test costs on Windows.
-    await Promise.all(
+    // is what this test costs on Windows. The checks wait for both installs,
+    // so no child process is still inside `dir` if one of them throws.
+    const attempts = await Promise.all(
       [0, 1].map(async attempt => {
         const attemptRoot = join(root, `attempt-${attempt}`);
         const project = writeProject(attemptRoot, dependencies);
-        const { stdout, stderr, exitCode } = await runInstall(project, join(attemptRoot, "cache"), {});
-        expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
-          "Resolving dependencies
-          Resolved, downloaded and extracted [17]
-          Saved lockfile"
-        `);
-        expectInstalled(stdout, resolutions);
-        expect(await installedVersions(project, letters.map(nameOf))).toEqual(markers(letters));
-        expect(await lockedPackages(project)).toEqual(locked);
-        expect(exitCode).toBe(0);
+        return { project, ...(await runInstall(project, join(attemptRoot, "cache"), {})) };
       }),
     );
+    for (const { project, stdout, stderr, exitCode } of attempts) {
+      expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+        "Resolving dependencies
+        Resolved, downloaded and extracted [17]
+        Saved lockfile"
+      `);
+      expectInstalled(stdout, resolutions);
+      expect(await installedVersions(project, letters.map(nameOf))).toEqual(markers(letters));
+      expect(await lockedPackages(project)).toEqual(locked);
+      expect(exitCode).toBe(0);
+    }
   },
   30_000,
 );


### PR DESCRIPTION
### Problem
- The file took 12.3s on the Windows 11 aarch64 lane (build 105417), 0.3s to 4.7s elsewhere. The 16-branch test is the whole wall time: two cold installs, one after the other.
- Each cold install spawns about 60 git processes: 1 bare clone, 27 `git log`, 16 `clone --no-checkout`, 16 `checkout`. Windows pays for process creation.

### Fix
- Each attempt gets its own project and cache, and both installs run at the same time. The checks run after both finish, so no child process is inside the temp directory when a check throws.
- Correct because the race is inside one `bun install` process. bun 1.3.14 (the last release without the fix) fails the test 5 of 5 runs with `failed to resolve`.
- Verified: `bun bd test test/cli/install/bun-install-git-deps.test.ts` on Windows 11 aarch64: 11.3s to 12.3s before, 8.7s to 9.5s after. CI builds 105588 and 105718: 10.3s and 10.9s on that lane, from 12.3s. The lane's wall time does not move: the file is not on its longest shard.
- Assertions are unchanged since #39737: stdout, stderr, installed markers, bun.lock rows, exit code.

### Background
- The file serves one bare repo with branches `pkg-a` to `pkg-p` over HTTP. `pkg-a` depends on 11 siblings, so their specs appear twice.
- The 16-branch test guards #35420 (fixed in #35426): on a cold cache the duplicate specs raced the shared clone task and failed with `failed to resolve`. Two attempts make that reliable.
- `BUN_INSTALL_CACHE_DIR` selects the cache. A directory per attempt keeps each install cold.

<details><summary>Notes</summary>

Timings. Old and new file run alternately on the same machine. All runs passed.

- Windows 11 aarch64 (16 vCPUs, native arm64 git through a Scoop shim), debug build (`bun bd test`): old 11.79s, 12.26s, 11.26s. New 9.52s, 8.69s, 9.26s, then five more runs, all passed. The 16-branch test inside the file: 8.8s to 9.8s before, 6.2s to 7.0s after. The first revision of this PR (checks inside the closures) measured the same: old 12.4s to 13.8s, new 9.0s to 9.4s.
- Same machine, release canary (`USE_SYSTEM_BUN=1`, what the CI lanes run): old 9.94s, 9.88s, 9.74s. New 6.72s, 6.65s, 6.64s. The 16-branch test alone (`-t "many branches"`): old 7.47s, 7.26s. New 4.72s, 4.67s.
- CI, Windows 11 aarch64 test-bun, `Ran 7 tests across 1 file`: 12.31s in build 105417 (main, before), 10.27s in build 105588 and 10.89s in build 105718 (this PR). Windows 2019 x64: 4.8s before, 5.8s and 4.3s after (noise). The shard that ran the file took 441s; the longest shard of the lane took 585s. The file is not in `test/expected-durations.json` (last regenerated Aug 14, the file landed Aug 12), so the shard packer does not yet know its cost.
- Linux x64 debug+ASAN (`bun bd test`): 3.7s to 4.5s before, 4.0s to 4.9s after, the 16-branch test 1.35s before and 1.0s to 1.35s after. Release: 0.3s to 1.3s either way. Process creation is cheap on Linux, so the file never cost much there.

Validation against unfixed code. bun 1.3.14 (the last release before #35426, downloaded from GitHub releases) ran the 16-branch test with the old shape and with this PR's shape, 5 runs each. Both shapes fail 5 of 5 runs, and every failure shows `error: @scope/pkg-X@git+http://... failed to resolve` lines in the stderr snapshot.

Why the checks wait for both installs. The first revision of this PR checked each attempt inside its `Promise.all` closure. A self-review found the problem: when attempt 0's check throws, the test body unwinds and `using dir` runs `rmSync(root, { recursive: true, force: true })` while attempt 1's `bun install` and its git children still run with their cwd inside `root`. On Windows that `rmSync` fails (a process's current directory cannot be removed). bun test then prints a bare `SuppressedError:` with no message, so neither the rmSync error nor the real expect diff is shown (reproduced with a `using` whose dispose throws on the exception path). With the checks after `Promise.all`, both installs have exited before any expect can throw. The wall time is the same: the installs still overlap.

Where a cold install spends its time, from a `git` shim on PATH that logs the start and end of each call (Linux, one attempt): the bare clone (130ms), then the 16 `git log` for the root dependencies one after another (2ms to 3ms each on Linux, 50ms to 80ms each on this Windows machine), then 16 `clone --no-checkout` in parallel (about 250ms each when all run at once), then 16 `checkout`, then 11 more `git log` one after another for pkg-a's dependencies. The `git log` calls run on bun's main thread (`Repository::find_commit`, called from `src/install/PackageManager/PackageManagerEnqueue.rs:1398`). The file spawns 173 git processes in total: 13 for the fixtures, 160 from `bun install`.

Possible follow-ups, outside this PR: `find_commit` spawns `git log` on the main thread once per dependency, including duplicates. 11 of the 27 calls per install here resolve a committish the same install already resolved. A per-install cache keyed on clone id and committish, or moving the lookup into the checkout task, would cut the Windows cost for every project with several git dependencies. Separately, `cli/install/` files are excluded from the parallel batch in `scripts/update-parallel-allowlist.mjs` (shared bin and cache state). This file sets `BUN_INSTALL_CACHE_DIR` per install and never touches the global bin dir, so it could be exempted like `cli/install/migration/`, which would take its whole run off the serial phase.

Considered and not done: merging the hoisted and isolated moved-branch tests behind one warm install (saves 12 git processes, drops the isolated warm install from this file), sharing one repo between the moved-branch tests (the branch moves would race), and keeping the fixture objects packed (fewer dumb HTTP requests per bare clone, 9 clones in the file, not the bottleneck). The tarball and `github:` tests also run two attempts one after the other, but they spawn no git processes and take about 2s on this lane with the rest of the file running, so they stay as they are.

Process count per test, from the shim: the 16-branch test 120 (2 attempts x 60), the lockfile test 14, each moved-branch test 17 plus 5 for its own repo, the `git+file://` test 4. The fixtures in `beforeAll` spawn 3.
</details>
