### PR TITLE
test(install): run the pnpm-lock-v9 migration cases concurrently

### DIFF
--- a/test/cli/install/migration/pnpm-lock-v9.test.ts
+++ b/test/cli/install/migration/pnpm-lock-v9.test.ts
@@ -126,9 +126,10 @@ snapshots:
 `;
 }
 
-describe("pnpm-lock.yaml v9", () => {
-  // Cases using toMatchSnapshot are sequential: snapshot matchers are unsupported inside a concurrent group.
-  test("v9 git and userinfo-tarball references migrate", async () => {
+// Every case works in its own directory and only reads from the shared registry.
+// The two toMatchSnapshot cases are test.serial: snapshot matchers are unsupported inside a concurrent group.
+describe.concurrent("pnpm-lock.yaml v9", () => {
+  test.serial("v9 git and userinfo-tarball references migrate", async () => {
     using dir = fixture("v9-git-references");
 
     const { stderr, exitCode } = await migrate(String(dir));
@@ -990,7 +991,7 @@ snapshots:
     expect(bunLock).toContain(`"tb": "file:tb-1.0.0.tgz"`);
   });
 
-  test("snapshot alias whose dep-path version is a file: directory or tarball", async () => {
+  test.serial("snapshot alias whose dep-path version is a file: directory or tarball", async () => {
     using dir = fixture("v9-alias-non-registry-dep-path");
 
     const { stderr, exitCode } = await migrate(String(dir));


### PR DESCRIPTION
### Problem
- `test/cli/install/migration/pnpm-lock-v9.test.ts` took 12s on the debian 13 x64-asan lane (build 105417) against 1 to 2s on the other lanes.
- 41 of its 84 cases are plain `test(...)`, so they ran one at a time. Each one spawns `bun pm migrate`, and about half of them a `bun install` after it.

### Fix
- The `describe` is `describe.concurrent`, so every case in the file runs in the concurrent group.
- The two `toMatchSnapshot` cases are `test.serial`. Snapshot matchers throw inside a concurrent group. `bun-install.test.ts` uses the same pattern for its snapshot cases.
- Correct because every case works in its own temp directory (`fixture()` or `verdaccio.createTestDir()`) and only reads from the shared registry. Nothing is shared between cases.
- Verified: `bun bd test test/cli/install/migration/pnpm-lock-v9.test.ts` passes 84 cases, also with `--rerun-each 3` (252 pass). `USE_SYSTEM_BUN=1 bun test` passes as well.

### Timing
Same machine (16 cores), debug ASAN build, `bun bd test`:

| | wall time |
|---|---|
| before (main) | 26.8s, 33.1s |
| after | 7.9s, 8.0s, 8.1s |

### Background
- `bun test` runs consecutive concurrent cases as one group, up to `--max-concurrency` (default 20) at a time. A serial case between them ends the group, so a file that mixes `test` and `test.concurrent` runs mostly serially.
- `describe.concurrent` makes every `test` and `test.each` inside it concurrent. `test.serial` opts a single case back out.
- `toMatchSnapshot` needs the one active test to write the `__snapshots__` file, so it is rejected inside a concurrent group. `toMatchInlineSnapshot` and `toEqual` work there.

<details><summary>Notes</summary>

- The diff is kept to the concurrency change on purpose. #39403 folds 171 install PRs and adds about 2100 lines to this file, and 14 other open PRs touch it. These five lines merge in either order.
- A first version of this PR also replaced the `toContain` checks on the bun.lock text with `toEqual` on the parsed lockfile and the external snapshot with inline data (+1044/-801). It ran in 8.2s to 9.7s, the same as this version, so the speed comes from the concurrency alone. That rewrite is parked on the branch `farm/9e680ea6/pnpm-lock-v9-structural-assertions` for after the fold-up lands, when it can cover the new cases too.
- Release build (`USE_SYSTEM_BUN=1 bun test`): 84 pass in 1.0s.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/migration/pnpm-lock-v9.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/cli/install/migration/pnpm-lock-v9.test.ts"
bun test v1.4.1 (861e9ae04)

test/cli/install/migration/pnpm-lock-v9.test.ts:
(pass) pnpm-lock.yaml v9 > v9 git and userinfo-tarball references migrate [260.93ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry [160.43ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a workspace importer [153.21ms]
(pass) pnpm-lock.yaml v9 > reports the missing packages entry of a transitive dependency [211.43ms]
(pass) pnpm-lock.yaml v9 > reports an importer whose package.json is missing [219.09ms]
(pass) pnpm-lock.yaml v9 > registry-qualified dep path resolves from the configured registry with a warning [265.88ms]
(pass) pnpm-lock.yaml v9 > named registries > built-in npmjs: entries record the npmjs registry [265.71ms]
(pass) pnpm-lock.yaml v9 > v9 alias in snapshot optionalDependencies gets the npm: prefix [529.77ms]
(pass) pnpm-lock.yaml v9 > named registries > namedRegistries entry pointing at another registry is used for the tarballs [324.39ms]
(pass) pnpm-lock.yaml v9 > named registries > built-in gh: entries record the GitHub Packages registry [193.16ms]
(pass) pnpm-lock.yaml v9 > named registries > two packages from one unknown registry warn once [265.31ms]
(pass) pnpm-lock.yaml v9 > named registries > namedRegistries entry pointing at the configured registry needs no warning [493.31ms]
(pass) pnpm-lock.yaml v9 > reports a package whose resolution cannot be parsed [139.73ms]
(pass) pnpm-lock.yaml v9 > warns about a lockfileVersion newer than 9 [139.21ms]
(pass) pnpm-lock.yaml v9 > named registries > namedRegistries overrides the built-in npmjs entry [339.11ms]
(pass) pnpm-lock.yaml v9 > multi-document lockfile > migrates the last document [148.53ms]
(pass) pnpm-lock.yaml v9 > multi-document lockfile > rejects a file whose main document is empty [180.01ms]
(pass) pnpm-lock.yaml v9 > named registries > al
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/install/migration/pnpm-lock-v9.test.ts | 9 +++++----
 1 file changed, 5 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
test/cli/install/migration/pnpm-lock-v9.test.ts     16     10      0
```

</details>

<!-- robobun:evidence:end -->