### PR TITLE
test(fetch.tls): abort the stalled handshakes instead of waiting for the idle sweep

### DIFF
--- a/test/js/web/fetch/fetch-reject-authorized-env-fixture.js
+++ b/test/js/web/fetch/fetch-reject-authorized-env-fixture.js
@@ -1,8 +1,8 @@
-const { SERVER } = process.env;
-
+// Fetches process.env.SERVER under the process's NODE_TLS_REJECT_UNAUTHORIZED
+// setting and prints the outcome as one JSON line: the body, or the error code.
 try {
-  const result = await fetch(SERVER).then(res => res.text());
-  if (result !== "Hello World") process.exit(2);
+  const body = await fetch(process.env.SERVER).then(res => res.text());
+  console.log(JSON.stringify({ body }));
 } catch (err) {
-  process.exit(err.code.indexOf("CERT") !== -1 ? 1 : 3);
+  console.log(JSON.stringify({ code: err.code }));
 }

--- a/test/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts
+++ b/test/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts
@@ -5,11 +5,12 @@
 // chain is trusted but whose hostname does not match, with the server
 // speaking first so SSL_read completes the handshake from the data path
 // (on_handshake fires from us_internal_ssl_on_data), racing AbortSignal
-// timeouts and keepalive pool churn. Run with BUN_CONFIG_HTTP_IDLE_TIMEOUT=1
-// so the idle-timeout failure path (HTTPClient::on_timeout) is reachable.
+// timeouts, keepalive pool churn, and handshakes that stall and are torn down
+// mid-handshake while the HTTP thread is busy with all of the above.
 //
-// Exits non-zero if any fetch produces an unexpected outcome or if the
-// process crashes.
+// Prints one JSON line: the count of every outcome class plus the list of
+// unexpected outcomes. The test asserts the exact shape, so a phase that
+// silently stops running fails it. Exits non-zero on any unexpected outcome.
 import tls from "node:tls";
 import net from "node:net";
 // Harness localhost cert (test/harness.ts `tls`): valid for localhost/127.0.0.1,
@@ -65,55 +66,74 @@ const goodServer = tls.createServer({ key: validTls.key, cert: validTls.cert }, 
   });
 });
 
-// Accepts TCP, never answers the ClientHello: exercises the idle-timeout
-// (HTTPClient::on_timeout) failure path mid-handshake.
+// Accepts TCP, never answers the ClientHello, so every fetch to it parks
+// mid-handshake until the fixture aborts it. The teardown then runs on a TLS
+// socket whose handshake never finished: the close callback fires
+// on_handshake, and the client must still deliver exactly one final result.
+// HTTPClient::on_timeout takes the same path, but the idle timer cannot fire
+// before uSockets' 4s sweep tick; bun-install-stalled-tls.test.ts covers it.
+const STALLED = 3;
+let stalledClientHellos = 0;
+const { promise: allStalled, resolve: onAllStalled } = Promise.withResolvers<void>();
 const stallServer = net.createServer(socket => {
   socket.on("error", () => {});
-  socket.on("data", () => {});
+  socket.once("data", () => {
+    if (++stalledClientHellos === STALLED) onAllStalled();
+  });
 });
 
 const mismatchPort = await listen(mismatchServer);
 const goodPort = await listen(goodServer);
 const stallPort = await listen(stallServer);
 
-const counts = new Map<string, number>();
-const bump = (k: string) => counts.set(k, (counts.get(k) ?? 0) + 1);
-
+const counts = {
+  // Plain mismatched-cert fetches: every one must reject with the altname error.
+  mismatch: { altname: 0 },
+  // Mismatched-cert fetches racing an AbortSignal: either side may win.
+  racedMismatch: { altname: 0, aborted: 0 },
+  // Valid cert through the keepalive pool: completes, or dies to the churn.
+  keepalive: { ok: 0, churn: 0 },
+  // Handshakes that never complete, torn down by the fixture's abort.
+  stalled: { aborted: 0 },
+};
 const failures: string[] = [];
 
-// Launched up front so the idle-timeout waits overlap the batch loop. The 1s
-// env override is padded for the 4s sweep tick, so on_timeout fires at ~4-8s;
-// the AbortSignal budget must be larger for that path to stay reachable.
+function errorCode(err: any): string {
+  return typeof err?.code === "string" ? err.code : String(err?.name ?? err);
+}
+
+// Launched up front so the stalled sockets sit on the HTTP thread for the
+// whole run and their teardown lands while it is busy with the batches.
+const stallControllers: AbortController[] = [];
 const stallJobs: Promise<void>[] = [];
-for (let i = 0; i < 3; i++) {
+for (let i = 0; i < STALLED; i++) {
+  const controller = new AbortController();
+  stallControllers.push(controller);
   stallJobs.push(
     fetch(`https://localhost:${stallPort}/`, {
       tls: { ca: validTls.cert },
-      signal: AbortSignal.timeout(10_000),
+      signal: controller.signal,
     }).then(
       res => {
         failures.push(`stalled handshake fetch resolved with status ${res.status}`);
       },
       err => {
-        const code = typeof err?.code === "string" ? err.code : err?.name;
-        if (code === "Timeout" || code === "TimeoutError" || code === "ETIMEDOUT" || code === "ECONNRESET") {
-          bump("stalled");
+        if (errorCode(err) === "AbortError") {
+          counts.stalled.aborted++;
         } else {
-          failures.push(`stalled handshake fetch rejected with ${code ?? err}`);
+          failures.push(`stalled handshake fetch rejected with ${errorCode(err)}`);
         }
       },
     ),
   );
 }
 
-// Churn until the stalled handshakes settle (on_timeout at ~4-8s, or the 10s
-// AbortSignal) so their teardown lands while the HTTP thread is busy.
-let stallsSettled = false;
-Promise.all(stallJobs).then(() => {
-  stallsSettled = true;
-});
-
-for (let batch = 0; batch < 8 || !stallsSettled; batch++) {
+const BATCHES = 16;
+// Spread the stalled-handshake teardowns over the run: one every `abortEvery`
+// batches (4, 8 and 12), each right after that batch's connects and handshakes
+// were queued on the HTTP thread, so the teardown lands while it is busy.
+const abortEvery = Math.floor(BATCHES / (STALLED + 1));
+for (let batch = 0; batch < BATCHES; batch++) {
   const jobs: Promise<void>[] = [];
 
   // Plain mismatched-cert fetches: must reject with the altname error.
@@ -124,10 +144,10 @@ for (let batch = 0; batch < 8 || !stallsSettled; batch++) {
           failures.push(`mismatched cert fetch resolved with status ${res.status}`);
         },
         err => {
-          if (err?.code !== "ERR_TLS_CERT_ALTNAME_INVALID") {
-            failures.push(`mismatched cert fetch rejected with ${err?.code ?? err}`);
+          if (errorCode(err) === "ERR_TLS_CERT_ALTNAME_INVALID") {
+            counts.mismatch.altname++;
           } else {
-            bump("altname");
+            failures.push(`mismatched cert fetch rejected with ${errorCode(err)}`);
           }
         },
       ),
@@ -146,11 +166,13 @@ for (let batch = 0; batch < 8 || !stallsSettled; batch++) {
           failures.push(`aborted mismatched cert fetch resolved with status ${res.status}`);
         },
         err => {
-          const code = typeof err?.code === "string" ? err.code : err?.name;
-          if (code === "ERR_TLS_CERT_ALTNAME_INVALID" || code === "TimeoutError" || err?.name === "TimeoutError") {
-            bump(code === "ERR_TLS_CERT_ALTNAME_INVALID" ? "altname" : "aborted");
+          const code = errorCode(err);
+          if (code === "ERR_TLS_CERT_ALTNAME_INVALID") {
+            counts.racedMismatch.altname++;
+          } else if (code === "TimeoutError") {
+            counts.racedMismatch.aborted++;
           } else {
-            failures.push(`aborted mismatched cert fetch rejected with ${code ?? err}`);
+            failures.push(`aborted mismatched cert fetch rejected with ${code}`);
           }
         },
       ),
@@ -166,48 +188,39 @@ for (let batch = 0; batch < 8 || !stallsSettled; batch++) {
       })
         .then(res => res.text())
         .then(
-          () => bump("good"),
+          () => counts.keepalive.ok++,
           err => {
-            const code = typeof err?.code === "string" ? err.code : err?.name;
+            const code = errorCode(err);
             // redirect-target 302s loop back to the same handler; hangups and
             // truncation surface as ECONNRESET-flavored errors.
-            if (
-              code === "TimeoutError" ||
-              code === "ECONNRESET" ||
-              code === "ConnectionClosed" ||
-              err?.name === "TimeoutError"
-            ) {
-              bump("churn");
+            if (code === "TimeoutError" || code === "ECONNRESET" || code === "ConnectionClosed") {
+              counts.keepalive.churn++;
             } else {
-              failures.push(`good cert fetch rejected with ${code ?? err}`);
+              failures.push(`good cert fetch rejected with ${code}`);
             }
           },
         ),
     );
   }
 
+  if (batch > 0 && batch % abortEvery === 0) {
+    // The server has seen each ClientHello, so every abort hits a socket that
+    // is connected and parked mid-handshake, never one still connecting.
+    await allStalled;
+    stallControllers.shift()?.abort();
+  }
+
   await Promise.all(jobs);
 }
 
-// Stalled handshakes run concurrently with the batches above (launched before
-// the loop, which churns until they settle); BUN_CONFIG_HTTP_IDLE_TIMEOUT=1
-// fails each through on_timeout mid-handshake, the AbortSignal keeps the
-// fixture bounded either way.
 await Promise.all(stallJobs);
 
 mismatchServer.close();
 goodServer.close();
 stallServer.close();
 
-if (failures.length > 0) {
-  console.log("unexpected outcomes:", failures.slice(0, 10));
-  process.exit(1);
-}
-if ((counts.get("altname") ?? 0) === 0) {
-  console.log("expected at least one ERR_TLS_CERT_ALTNAME_INVALID rejection");
-  process.exit(1);
-}
-console.log("OK", JSON.stringify(Object.fromEntries(counts)));
+// The first few failures are enough to diagnose; hundreds would drown the diff.
+console.log(JSON.stringify({ ...counts, failures: failures.slice(0, 10) }));
 // Keepalive server-side sockets survive server.close() and would keep the
 // process alive; everything is settled at this point.
-process.exit(0);
+process.exit(failures.length > 0 ? 1 : 0);

--- a/test/js/web/fetch/fetch.tls.extra-cert.fixture.js
+++ b/test/js/web/fetch/fetch.tls.extra-cert.fixture.js
@@ -1,11 +1,13 @@
+// Fetches process.env.SERVER with strict certificate verification, so only
+// the CA store (plus NODE_EXTRA_CA_CERTS) decides the outcome. Prints one JSON
+// line: the body, or the error code.
 try {
-  const response = await fetch(process.env.SERVER, {
+  const body = await fetch(process.env.SERVER, {
     tls: {
       rejectUnauthorized: true,
     },
   }).then(res => res.text());
-  process.exit(response === "OK" ? 0 : 1);
+  console.log(JSON.stringify({ body }));
 } catch (err) {
-  console.error(err);
-  process.exit(1);
+  console.log(JSON.stringify({ code: err.code }));
 }

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
+import { bunEnv, bunExe, bunRun, isASAN, tmpdirSync } from "harness";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import tls from "node:tls";
@@ -24,6 +24,14 @@ const CERT_LOCALHOST_ONLY = {
 // Budget for a test whose fixture subprocess performs dozens of TLS
 // handshakes: a debug+ASAN child can exceed the 5s default.
 const fixtureTimeout = isASAN ? 20_000 : 10_000;
+
+// Runs a bun child that prints one JSON line and returns that line parsed as
+// `outcome`. When the child dies first there is no line, so `outcome` is its
+// stderr and the failing assertion shows the error instead of a bare mismatch.
+async function runJsonFixture(args: string[], env?: Record<string, string | undefined>) {
+  const { stdout, stderr, exitCode } = await bunRun(args, env);
+  return { outcome: stdout ? JSON.parse(stdout) : stderr, stderr, exitCode };
+}
 
 // Note: Do not use bun.sh as the example domain
 // Cloudflare sometimes blocks automated requests to it.
@@ -327,18 +335,9 @@ describe.concurrent("fetch-tls", () => {
   describe("client-side TLS session resumption", () => {
     const fixture = join(import.meta.dir, "fetch.tls.session-resumption-fixture.ts");
     async function run(version: string, env: Record<string, string> = {}) {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), fixture, version],
-        env: { ...bunEnv, ...env },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      // The fixture prints one JSON line. When it dies first there is none,
-      // so the assertion shows stderr (the error or the crash) instead.
-      expect(stdout.trim() || stderr).toStartWith("{");
-      expect(exitCode).toBe(0);
-      return JSON.parse(stdout.trim()) as {
+      const r = await runJsonFixture([fixture, version], env);
+      expect(r).toEqual({ outcome: expect.any(Object), stderr: "", exitCode: 0 });
+      return r.outcome as {
         default: boolean[];
         mismatch: boolean[];
         checkServerIdentity: boolean[];
@@ -404,28 +403,23 @@ describe.concurrent("fetch-tls", () => {
   it(
     "rejects a trusted cert with a mismatched hostname cleanly under abort/timeout/keepalive churn",
     async () => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(import.meta.dir, "fetch.tls.cert-mismatch-churn.fixture.ts")],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      // The fixture prints one JSON line. When it dies first there is none,
-      // so the assertion shows stderr (the error or the crash) instead.
-      const summary = stdout ? JSON.parse(stdout) : stderr;
+      const r = await runJsonFixture([join(import.meta.dir, "fetch.tls.cert-mismatch-churn.fixture.ts")]);
       // 16 batches of 4 fetches per class, plus 3 stalled handshakes.
-      expect(summary).toEqual({
-        mismatch: { altname: 64 },
-        racedMismatch: { altname: expect.any(Number), aborted: expect.any(Number) },
-        keepalive: { ok: expect.any(Number), churn: expect.any(Number) },
-        stalled: { aborted: 3 },
-        failures: [],
+      expect(r).toEqual({
+        outcome: {
+          mismatch: { altname: 64 },
+          racedMismatch: { altname: expect.any(Number), aborted: expect.any(Number) },
+          keepalive: { ok: expect.any(Number), churn: expect.any(Number) },
+          stalled: { aborted: 3 },
+          failures: [],
+        },
+        stderr: "",
+        exitCode: 0,
       });
       // Which side wins a race is timing-dependent; the total is not.
-      expect(summary.racedMismatch.altname + summary.racedMismatch.aborted).toBe(64);
-      expect(summary.keepalive.ok + summary.keepalive.churn).toBe(64);
-      expect(exitCode).toBe(0);
+      const { racedMismatch, keepalive } = r.outcome;
+      expect(racedMismatch.altname + racedMismatch.aborted).toBe(64);
+      expect(keepalive.ok + keepalive.churn).toBe(64);
     },
     fixtureTimeout,
   );
@@ -863,22 +857,16 @@ describe.concurrent("fetch-tls", () => {
   it("fetch should respect rejectUnauthorized env", async () => {
     await createServer(CERT_EXPIRED, async port => {
       const results = await Promise.all(
-        ["0", "1"].map(async rejectUnauthorized => {
-          await using proc = Bun.spawn({
-            cmd: [bunExe(), join(import.meta.dir, "fetch-reject-authorized-env-fixture.js")],
-            env: { ...bunEnv, SERVER: `https://localhost:${port}`, NODE_TLS_REJECT_UNAUTHORIZED: rejectUnauthorized },
-            stdout: "pipe",
-            stderr: "pipe",
-          });
-          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-          // The fixture prints one JSON line; when it dies first there is
-          // none, so `outcome` is stderr instead.
-          return { outcome: stdout ? JSON.parse(stdout) : stderr, exitCode };
-        }),
+        ["0", "1"].map(rejectUnauthorized =>
+          runJsonFixture([join(import.meta.dir, "fetch-reject-authorized-env-fixture.js")], {
+            SERVER: `https://localhost:${port}`,
+            NODE_TLS_REJECT_UNAUTHORIZED: rejectUnauthorized,
+          }),
+        ),
       );
       expect(results).toEqual([
-        { outcome: { body: "Hello World" }, exitCode: 0 },
-        { outcome: { code: "CERT_HAS_EXPIRED" }, exitCode: 0 },
+        { outcome: { body: "Hello World" }, stderr: "", exitCode: 0 },
+        { outcome: { code: "CERT_HAS_EXPIRED" }, stderr: "", exitCode: 0 },
       ]);
     });
   });
@@ -929,22 +917,16 @@ describe.concurrent("fetch-tls", () => {
         worker.on("exit", code => { if (code !== 0) process.exit(code); });
       `
           : steps + `console.log(JSON.stringify(await run()));`;
-      const { NODE_TLS_REJECT_UNAUTHORIZED: _, ...env } = bunEnv as Record<string, string | undefined>;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", script],
-        env: { ...env, SERVER: `https://127.0.0.1:${server.port}` },
-        stdout: "pipe",
-        stderr: "pipe",
+      // The child starts without the variable: `undefined` unsets it.
+      const r = await runJsonFixture(["-e", script], {
+        SERVER: `https://127.0.0.1:${server.port}`,
+        NODE_TLS_REJECT_UNAUTHORIZED: undefined,
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stdout ? JSON.parse(stdout) : stderr).toEqual([
-        "Hello World",
-        "undefined",
-        "CERT_HAS_EXPIRED",
-        "Hello World",
-        "CERT_HAS_EXPIRED",
-      ]);
-      expect(exitCode).toBe(0);
+      expect(r).toEqual({
+        outcome: ["Hello World", "undefined", "CERT_HAS_EXPIRED", "Hello World", "CERT_HAS_EXPIRED"],
+        stderr: "",
+        exitCode: 0,
+      });
     });
   }
 
@@ -985,24 +967,16 @@ describe.concurrent("fetch-tls", () => {
     }
   });
 
-  // Spawns fetch.tls.extra-cert.fixture.js against `url` with the given
-  // NODE_EXTRA_CA_CERTS. The fixture prints one JSON line, the body or the
-  // error code; when it dies first there is none, so `outcome` is stderr.
-  async function fetchWithExtraCaCerts(url: string, extraCaCerts: string) {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "fetch.tls.extra-cert.fixture.js")],
-      env: { ...bunEnv, SERVER: url, NODE_EXTRA_CA_CERTS: extraCaCerts },
-      stdout: "pipe",
-      stderr: "pipe",
+  // Fetches `url` with strict verification in a child whose NODE_EXTRA_CA_CERTS
+  // is `extraCaCerts`; the outcome is the body or the error code.
+  function fetchWithExtraCaCerts(url: string, extraCaCerts: string) {
+    return runJsonFixture([join(import.meta.dir, "fetch.tls.extra-cert.fixture.js")], {
+      SERVER: url,
+      NODE_EXTRA_CA_CERTS: extraCaCerts,
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return {
-      outcome: stdout ? JSON.parse(stdout) : stderr,
-      // bun warns on stderr when it cannot load the file and ignores it.
-      ignored: stderr.includes("ignoring extra certs from"),
-      exitCode,
-    };
   }
+  // bun warns once on stderr when it cannot load the file and ignores it.
+  const ignoredExtraCerts = expect.stringContaining("ignoring extra certs from");
 
   it("fetch should use NODE_EXTRA_CA_CERTS", async () => {
     using server = Bun.serve({
@@ -1016,7 +990,7 @@ describe.concurrent("fetch-tls", () => {
     await Bun.write(cert_path, validTls.cert);
 
     const result = await fetchWithExtraCaCerts(server.url, cert_path);
-    expect(result).toEqual({ outcome: { body: "OK" }, ignored: false, exitCode: 0 });
+    expect(result).toEqual({ outcome: { body: "OK" }, stderr: "", exitCode: 0 });
   });
 
   it("fetch should use NODE_EXTRA_CA_CERTS even if the used CA is not first in bundle", async () => {
@@ -1033,7 +1007,7 @@ describe.concurrent("fetch-tls", () => {
     await Bun.write(bundlePath, bundleContent);
 
     const result = await fetchWithExtraCaCerts(server.url, bundlePath);
-    expect(result).toEqual({ outcome: { body: "OK" }, ignored: false, exitCode: 0 });
+    expect(result).toEqual({ outcome: { body: "OK" }, stderr: "", exitCode: 0 });
   });
 
   it("fetch should ignore invalid NODE_EXTRA_CA_CERTS", async () => {
@@ -1051,9 +1025,9 @@ describe.concurrent("fetch-tls", () => {
     // An empty value means "unset" and is skipped without a warning; the
     // other two name files that cannot be opened.
     expect(results).toEqual([
-      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, ignored: true, exitCode: 0 },
-      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, ignored: false, exitCode: 0 },
-      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, ignored: true, exitCode: 0 },
+      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, stderr: ignoredExtraCerts, exitCode: 0 },
+      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, stderr: "", exitCode: 0 },
+      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, stderr: ignoredExtraCerts, exitCode: 0 },
     ]);
   });
 
@@ -1080,8 +1054,8 @@ describe.concurrent("fetch-tls", () => {
       ),
     );
     expect(results).toEqual([
-      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, ignored: true, exitCode: 0 },
-      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, ignored: true, exitCode: 0 },
+      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, stderr: ignoredExtraCerts, exitCode: 0 },
+      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, stderr: ignoredExtraCerts, exitCode: 0 },
     ]);
   });
 });

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -21,6 +21,10 @@ const CERT_LOCALHOST_ONLY = {
   key: readFileSync(join(import.meta.dir, "../../../regression/issue/27890-localhost-only.key"), "utf8"),
 };
 
+// Budget for a test whose fixture subprocess performs dozens of TLS
+// handshakes: a debug+ASAN child can exceed the 5s default.
+const fixtureTimeout = isASAN ? 20_000 : 10_000;
+
 // Note: Do not use bun.sh as the example domain
 // Cloudflare sometimes blocks automated requests to it.
 // so it will cause flaky tests.
@@ -330,8 +334,9 @@ describe.concurrent("fetch-tls", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).not.toMatch(/AddressSanitizer|ERROR: (Leak|Thread)Sanitizer/);
-      expect(stdout.trim()).toStartWith("{");
+      // The fixture prints one JSON line. When it dies first there is none,
+      // so the assertion shows stderr (the error or the crash) instead.
+      expect(stdout.trim() || stderr).toStartWith("{");
       expect(exitCode).toBe(0);
       return JSON.parse(stdout.trim()) as {
         default: boolean[];
@@ -345,7 +350,6 @@ describe.concurrent("fetch-tls", () => {
     // Each run starts six TLS servers and performs ~12 handshakes in a
     // debug+ASAN subprocess, which can exceed the default timeout when all
     // four run under `describe.concurrent`.
-    const timeout = isASAN ? 20_000 : 10_000;
     for (const version of ["TLSv1.2", "TLSv1.3"]) {
       it(
         `caches only verified sessions keyed on (host, port) (${version})`,
@@ -375,7 +379,7 @@ describe.concurrent("fetch-tls", () => {
           // fewer than two entries is acceptable.
           expect(r.mismatch).not.toContain(true);
         },
-        timeout,
+        fixtureTimeout,
       );
 
       it(
@@ -384,37 +388,47 @@ describe.concurrent("fetch-tls", () => {
           const r = await run(version, { BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE: "1" });
           expect(r.default).toEqual([false, false]);
         },
-        timeout,
+        fixtureTimeout,
       );
     }
   });
 
   // Covers a family of HTTP-thread crashes (sentry BUN-2WC6 and siblings) where
   // a certificate identity failure during a handshake completed from the
-  // SSL_read path, racing aborts, idle timeouts, and keepalive churn, caused a
-  // finished HTTPClient to deliver its final result twice: the second delivery
-  // read the freed AsyncHTTP clone and called through a null callback pointer.
-  // The fixture drives that exact traffic shape and exits non-zero on any
-  // unexpected outcome; every failure must surface as a catchable error.
-  it("rejects a trusted cert with a mismatched hostname cleanly under abort/timeout/keepalive churn", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "fetch.tls.cert-mismatch-churn.fixture.ts")],
-      env: { ...bunEnv, BUN_CONFIG_HTTP_IDLE_TIMEOUT: "1" },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Check stderr for sanitizer reports first (and unconditionally): a
-    // recovered ASAN report can leave exit code 0, and on an abort this
-    // surfaces the actual report instead of a bare exit-code mismatch.
-    // Don't assert emptiness: debug builds emit benign startup noise.
-    expect(stderr).not.toMatch(/AddressSanitizer|ERROR: (Leak|Thread)Sanitizer/);
-    // Fixture reports unexpected outcomes on stdout.
-    expect(stdout).toStartWith("OK ");
-    expect(exitCode).toBe(0);
-    // The fixture's stalled handshakes wait for the padded 1s idle timer,
-    // which the 4s sweep fires at ~4-8s, so this outlives the 5s default.
-  }, 30_000);
+  // SSL_read path, racing aborts, mid-handshake teardowns, and keepalive
+  // churn, caused a finished HTTPClient to deliver its final result twice: the
+  // second delivery read the freed AsyncHTTP clone and called through a null
+  // callback pointer. The fixture drives that exact traffic shape and reports
+  // the count of every outcome class; every failure must surface as a
+  // catchable error.
+  it(
+    "rejects a trusted cert with a mismatched hostname cleanly under abort/timeout/keepalive churn",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(import.meta.dir, "fetch.tls.cert-mismatch-churn.fixture.ts")],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // The fixture prints one JSON line. When it dies first there is none,
+      // so the assertion shows stderr (the error or the crash) instead.
+      const summary = stdout ? JSON.parse(stdout) : stderr;
+      // 16 batches of 4 fetches per class, plus 3 stalled handshakes.
+      expect(summary).toEqual({
+        mismatch: { altname: 64 },
+        racedMismatch: { altname: expect.any(Number), aborted: expect.any(Number) },
+        keepalive: { ok: expect.any(Number), churn: expect.any(Number) },
+        stalled: { aborted: 3 },
+        failures: [],
+      });
+      // Which side wins a race is timing-dependent; the total is not.
+      expect(summary.racedMismatch.altname + summary.racedMismatch.aborted).toBe(64);
+      expect(summary.keepalive.ok + summary.keepalive.churn).toBe(64);
+      expect(exitCode).toBe(0);
+    },
+    fixtureTimeout,
+  );
 
   // When checkServerIdentity is provided, the HTTP thread sends an intermediate
   // progress update carrying the server certificate before response headers
@@ -848,28 +862,24 @@ describe.concurrent("fetch-tls", () => {
 
   it("fetch should respect rejectUnauthorized env", async () => {
     await createServer(CERT_EXPIRED, async port => {
-      const url = `https://localhost:${port}`;
-
-      const promises = [];
-      for (let i = 0; i < 2; i++) {
-        const proc = Bun.spawn({
-          env: {
-            ...bunEnv,
-            SERVER: url,
-            NODE_TLS_REJECT_UNAUTHORIZED: i.toString(),
-          },
-          stderr: "inherit",
-          stdout: "inherit",
-          stdin: "inherit",
-          cmd: [bunExe(), join(import.meta.dir, "fetch-reject-authorized-env-fixture.js")],
-        });
-
-        promises.push(proc.exited);
-      }
-
-      const [exitCode1, exitCode2] = await Promise.all(promises);
-      expect(exitCode1).toBe(0);
-      expect(exitCode2).toBe(1);
+      const results = await Promise.all(
+        ["0", "1"].map(async rejectUnauthorized => {
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), join(import.meta.dir, "fetch-reject-authorized-env-fixture.js")],
+            env: { ...bunEnv, SERVER: `https://localhost:${port}`, NODE_TLS_REJECT_UNAUTHORIZED: rejectUnauthorized },
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          // The fixture prints one JSON line; when it dies first there is
+          // none, so `outcome` is stderr instead.
+          return { outcome: stdout ? JSON.parse(stdout) : stderr, exitCode };
+        }),
+      );
+      expect(results).toEqual([
+        { outcome: { body: "Hello World" }, exitCode: 0 },
+        { outcome: { code: "CERT_HAS_EXPIRED" }, exitCode: 0 },
+      ]);
     });
   });
 
@@ -975,6 +985,25 @@ describe.concurrent("fetch-tls", () => {
     }
   });
 
+  // Spawns fetch.tls.extra-cert.fixture.js against `url` with the given
+  // NODE_EXTRA_CA_CERTS. The fixture prints one JSON line, the body or the
+  // error code; when it dies first there is none, so `outcome` is stderr.
+  async function fetchWithExtraCaCerts(url: string, extraCaCerts: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "fetch.tls.extra-cert.fixture.js")],
+      env: { ...bunEnv, SERVER: url, NODE_EXTRA_CA_CERTS: extraCaCerts },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return {
+      outcome: stdout ? JSON.parse(stdout) : stderr,
+      // bun warns on stderr when it cannot load the file and ignores it.
+      ignored: stderr.includes("ignoring extra certs from"),
+      exitCode,
+    };
+  }
+
   it("fetch should use NODE_EXTRA_CA_CERTS", async () => {
     using server = Bun.serve({
       port: 0,
@@ -986,19 +1015,8 @@ describe.concurrent("fetch-tls", () => {
     const cert_path = join(tmpdirSync(), "cert.pem");
     await Bun.write(cert_path, validTls.cert);
 
-    const proc = Bun.spawn({
-      env: {
-        ...bunEnv,
-        SERVER: server.url,
-        NODE_EXTRA_CA_CERTS: cert_path,
-      },
-      stderr: "inherit",
-      stdout: "inherit",
-      stdin: "inherit",
-      cmd: [bunExe(), join(import.meta.dir, "fetch.tls.extra-cert.fixture.js")],
-    });
-
-    expect(await proc.exited).toBe(0);
+    const result = await fetchWithExtraCaCerts(server.url, cert_path);
+    expect(result).toEqual({ outcome: { body: "OK" }, ignored: false, exitCode: 0 });
   });
 
   it("fetch should use NODE_EXTRA_CA_CERTS even if the used CA is not first in bundle", async () => {
@@ -1014,19 +1032,8 @@ describe.concurrent("fetch-tls", () => {
     const bundleContent = `${expiredTls.cert}\n${validTls.cert}`;
     await Bun.write(bundlePath, bundleContent);
 
-    const proc = Bun.spawn({
-      env: {
-        ...bunEnv,
-        SERVER: server.url,
-        NODE_EXTRA_CA_CERTS: bundlePath,
-      },
-      stderr: "inherit",
-      stdout: "inherit",
-      stdin: "inherit",
-      cmd: [bunExe(), join(import.meta.dir, "fetch.tls.extra-cert.fixture.js")],
-    });
-
-    expect(await proc.exited).toBe(0);
+    const result = await fetchWithExtraCaCerts(server.url, bundlePath);
+    expect(result).toEqual({ outcome: { body: "OK" }, ignored: false, exitCode: 0 });
   });
 
   it("fetch should ignore invalid NODE_EXTRA_CA_CERTS", async () => {
@@ -1038,22 +1045,16 @@ describe.concurrent("fetch-tls", () => {
       },
     });
 
-    for (const invalid of ["not-exist.pem", "", " "]) {
-      const proc = Bun.spawn({
-        env: {
-          ...bunEnv,
-          SERVER: server.url,
-          NODE_EXTRA_CA_CERTS: invalid,
-        },
-        stderr: "pipe",
-        stdout: "inherit",
-        stdin: "inherit",
-        cmd: [bunExe(), join(import.meta.dir, "fetch.tls.extra-cert.fixture.js")],
-      });
-
-      expect(await proc.exited).toBe(1);
-      expect(await proc.stderr.text()).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
-    }
+    const results = await Promise.all(
+      ["not-exist.pem", "", " "].map(invalid => fetchWithExtraCaCerts(server.url, invalid)),
+    );
+    // An empty value means "unset" and is skipped without a warning; the
+    // other two name files that cannot be opened.
+    expect(results).toEqual([
+      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, ignored: true, exitCode: 0 },
+      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, ignored: false, exitCode: 0 },
+      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, ignored: true, exitCode: 0 },
+    ]);
   });
 
   it("fetch should ignore NODE_EXTRA_CA_CERTS if it's contains invalid cert", async () => {
@@ -1071,23 +1072,16 @@ describe.concurrent("fetch-tls", () => {
     const mixedInvalidAndValidCertsBundlePath = join(tmpdirSync(), "mixed-invalid-and-valid-certs-bundle.pem");
     await Bun.write(mixedInvalidAndValidCertsBundlePath, `${validTls.cert}\n${invalidTls.cert}`);
 
-    for (const invalid of [mixedValidAndInvalidCertsBundlePath, mixedInvalidAndValidCertsBundlePath]) {
-      const proc = Bun.spawn({
-        env: {
-          ...bunEnv,
-          SERVER: server.url,
-          NODE_EXTRA_CA_CERTS: invalid,
-        },
-        stderr: "pipe",
-        stdout: "inherit",
-        stdin: "inherit",
-        cmd: [bunExe(), join(import.meta.dir, "fetch.tls.extra-cert.fixture.js")],
-      });
-
-      expect(await proc.exited).toBe(1);
-      const stderr = await proc.stderr.text();
-      expect(stderr).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
-      expect(stderr).toContain("ignoring extra certs");
-    }
+    // One bad certificate anywhere in the bundle discards the whole bundle,
+    // including the valid certificate next to it.
+    const results = await Promise.all(
+      [mixedValidAndInvalidCertsBundlePath, mixedInvalidAndValidCertsBundlePath].map(bundle =>
+        fetchWithExtraCaCerts(server.url, bundle),
+      ),
+    );
+    expect(results).toEqual([
+      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, ignored: true, exitCode: 0 },
+      { outcome: { code: "DEPTH_ZERO_SELF_SIGNED_CERT" }, ignored: true, exitCode: 0 },
+    ]);
   });
 });


### PR DESCRIPTION
### Problem
- `test/js/web/fetch/fetch.tls.test.ts` takes about 9.6s on every CI platform (Buildkite build 105417), release and ASAN alike: a timer, not work. Before #39955: 2.8s.
- The churn fixture lets the HTTP client's idle timer fail three stalled TLS handshakes. `BUN_CONFIG_HTTP_IDLE_TIMEOUT=1` is padded to 5s (`src/http/lib.rs:304`) and fires on the 4s sweep: 4 to 8s idle.

### Fix
- The fixture aborts the stalled handshakes itself, one every four batches. The abort takes the same terminate-then-fail path (`close_and_fail`) as `on_timeout`, so the mid-handshake teardown still runs while the HTTP thread is busy. `bun-install-stalled-tls.test.ts` covers the idle timer itself.
- The fixture prints a JSON summary of every outcome class. The test asserts it exactly (64 plain mismatches, 64 raced, 64 keepalive, 3 stalled, no failures), so a silently skipped phase fails. The two small fixtures also print JSON.
- One file-local `runJsonFixture` replaces five spawn blocks. Callers assert the whole `{ outcome, stderr, exitCode }` record, so stderr is checked again: empty, or the one `ignoring extra certs from` warning.
- Verified: CI build 105710 runs the file in 2.0 to 2.6s on every lane (linux, linux ASAN, macOS, windows), down from 9.6 to 10s. Locally, back to back: release 9.71s to 1.9s, debug+ASAN 13.7s to 10.1s. 6 full debug+ASAN runs pass.

### Background
- uSockets sweeps socket timers on a fixed 4s tick (`LIBUS_TIMEOUT_GRANULARITY`, compile-time). #39955 pads each timer by one tick so it never fires early: 4 to 8s is the shortest `on_timeout` latency.
- The fixture guards #32015: a failed `HTTPClient` must deliver its final result once. Closing a TLS socket mid-handshake fires `on_handshake`, which must not re-enter the failed client.

<details><summary>Notes</summary>

CI, build 105710 at f5cf1d46, `fetch.tls.test.ts` 32 pass on every lane: debian 13 x64 2.02s, debian 13 x64-asan 2.62s, darwin aarch64 2.49s, windows 2019 x64 2.00s, windows 11 aarch64 2.05s, alpine 3.23 x64 2.02s. Build 105417 (main) had 9.57 to 9.98s on the same lanes.

Local timings, all on the same container (12 CPU quota, shared host, so the debug numbers move with host load; the before/after pairs were measured back to back):

| | before | after |
|---|---|---|
| release file (system bun as proxy) | 9.71s | 1.9 to 2.2s |
| release churn test | 8062ms | 276 to 497ms |
| release churn fixture standalone | 8.05s | 0.27 to 0.38s |
| debug+ASAN file (`bun bd test`) | 13.7s | 10.1s |
| debug+ASAN churn test inside the file | 9.4s | 3.9 to 4.2s |
| debug+ASAN churn fixture standalone | 9.3s | 4.0s |

The debug file is CPU-bound here: about 17 debug children plus in-process TLS servers on a capped container. During a slow host phase the same file took 20s on main and 12 to 17s on this branch. CI's ASAN lane ran the whole file in 3.1s before #39955 (`test/expected-durations.json`), so the fixed wait was the only thing holding it at 10s there.

Why not shorten the sweep wait: `LIBUS_TIMEOUT_GRANULARITY` is a `#define` in `packages/bun-usockets/src/libusockets.h`. Exposing it as a tunable is a `src/` change that this PR deliberately does not make. The old fixture also ran as many batches as fit in the wait (about 600 in release, 70 under ASAN). The new fixture runs a fixed 16 (twice the count from #32015), which keeps the expected counts exact.

Why 16 batches: 8 was the original count in #32015. 16 costs 0.3s in release and about 3s of CPU in debug+ASAN. The stalled aborts land at batches 4, 8 and 12, after the server has seen every ClientHello, so each abort hits a connected socket parked mid-handshake.

Assertion changes:
- churn test: `toStartWith("OK ")` became a `toEqual` on the whole summary plus the two race totals. A fixture cut to 8 batches fails with `altname: 32` vs `64` (checked by hand). The fixture exits non-zero on any unexpected outcome, as before.
- `fetch should respect rejectUnauthorized env`: exit codes `0`/`1` became `{ body: "Hello World" }` / `{ code: "CERT_HAS_EXPIRED" }` with empty stderr and exit code 0.
- four `NODE_EXTRA_CA_CERTS` tests: bare exit codes became the fixture's outcome (`{ body: "OK" }` or `{ code: "DEPTH_ZERO_SELF_SIGNED_CERT" }`) plus stderr: the `ignoring extra certs from` warning for an unreadable path or a bundle with a bad certificate, empty for an empty value or a good bundle. The sequential children now run concurrently.
- `delete process.env.NODE_TLS_REJECT_UNAUTHORIZED` (both modes) and the session-resumption runner now assert empty stderr too.
- Two `AddressSanitizer|LeakSanitizer` regex assertions are gone. ASAN aborts the child (`halt_on_error` defaults to 1) so no summary is printed, an LSAN report gives a non-zero exit, and both leave stderr non-empty, which the record assertion catches. When a fixture dies, `outcome` is its stderr, so the failure shows the error instead of a bare mismatch.

Other levers from the brief that I left alone: `fetch timeout works on tls` runs in 200 to 300ms (its 700ms server sleep does not extend the test), and the 500ms/1000ms busy loops in the `checkServerIdentity` tests are deliberate main-thread-busy coverage from #11579. They are now the longest tests in the file (about 1.7s in release).

Self-review: the one surviving concern was the duplicated spawn block, now the `runJsonFixture` helper.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 4 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/fetch/fetch.tls.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/fetch/fetch.tls.test.ts
bun test v1.4.1 (adc354d99)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [454.11ms]
(pass) fetch-tls > fetch with valid tls should not throw [954.88ms]
(pass) fetch-tls > drops a caller-supplied Host header on a cross-origin redirect and never verifies TLS against it [2455.58ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1151.25ms]
(pass) fetch-tls > sends the URL host as the ClientHello SNI, not the Host request header [2410.16ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [1796.14ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [134.57ms]
(pass) fetch-tls > does not let a caller-supplied Host header become the certificate-verification target [2491.44ms]
(pass) fetch-tls > client-side TLS session resumption > caches only verified sessions keyed on (host, port) (TLSv1.2) [2832.09ms]
(pass) fetch-tls > client-side TLS session resumption > is disabled by BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE (TLSv1.2) [2802.53ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers [132.78ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers (with AbortSignal) [111.48ms]
(pass) fetch-tls > client-side TLS session resumption > is disabled by BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE (TLSv1.3) [2922.63ms]
(pass) fetch-tls > client-side TLS session resumption > caches only verified sessions keyed on (host, port) (TLSv1.3) [2947.76ms]
(pass) fetch-tls > fetch with self-sign tls should throw [111.36ms]
(pass) fetch-tls > fetch with invalid tls should throw [103.45ms]
(pass) fetch-tls > fetch with checkServerIdentity fai
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../fetch/fetch-reject-authorized-env-fixture.js   |  10 +-
 .../fetch/fetch.tls.cert-mismatch-churn.fixture.ts | 129 ++++++-----
 test/js/web/fetch/fetch.tls.extra-cert.fixture.js  |  10 +-
 test/js/web/fetch/fetch.tls.test.ts                | 240 +++++++++------------
 4 files changed, 186 insertions(+), 203 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
test/js/web/fetch/fetch-reject-authorized-env-fixture.js      1      2      0
…t/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts      7      5      0
test/js/web/fetch/fetch.tls.extra-cert.fixture.js             1      1      0
test/js/web/fetch/fetch.tls.test.ts                          10     15      0
```

</details>

<!-- robobun:evidence:end -->