### PR TITLE
test(install): pin stderr and the whole lockfile state in bun-update-lockfile-sync.test.ts

### DIFF
--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -1,10 +1,11 @@
 import { Archive, file, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { appendFile, exists } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, normalizeBunSnapshot, runBunInstall } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, normalizeBunSnapshot } from "harness";
 import { join } from "path";
 
-// Registry: no-deps 1.0.0/1.0.1/1.1.0/2.0.0, @types/no-deps 1.0.0/2.0.0, a-dep 1.0.1..1.0.10, one-range-dep@1.0.0 -> no-deps ^1.0.0, dep-with-tags 1.0.0..3.0.1 (latest=3.0.0, pre-2=2.0.1).
+// Registry: no-deps 1.0.0/1.0.1/1.1.0/2.0.0, @types/no-deps 1.0.0/2.0.0, a-dep 1.0.1..1.0.10, what-bin 1.0.0/1.5.0,
+// one-range-dep@1.0.0 -> no-deps ^1.0.0, dep-with-tags 1.0.0..3.0.1 (latest=3.0.0, pre-2=2.0.1).
 
 const verdaccio = new VerdaccioRegistry();
 
@@ -22,61 +23,92 @@ const GROUPS = ["dependencies", "devDependencies", "optionalDependencies", "peer
 // CI exports one BUN_INSTALL_CACHE_DIR per file, which overrides bunfig's cache; concurrent cases sharing a cache race on Windows.
 const envFor = (dir: string) => ({ ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") });
 
-function json(contents: Json | string) {
-  return typeof contents === "string" ? contents : JSON.stringify(contents, null, 2) + "\n";
-}
+const SAVED = "Saved lockfile";
+const PROGRESS_LINES = /^(?:Resolving dependencies|Resolved, downloaded and extracted \[\d+\])(?:\n|$)/gm;
 
-async function setup(
-  files: Record<string, Json | string>,
-  opts: { exact?: boolean; text?: boolean; install?: boolean; allowWarnings?: boolean } = {},
-): Promise<string> {
-  const { packageDir: dir } = await verdaccio.createTestDir({
-    bunfigOpts: { linker: "hoisted", saveTextLockfile: opts.text ?? true },
-    files: Object.fromEntries(Object.entries(files).map(([path, contents]) => [path, json(contents)])),
-  });
-  if (opts.exact) await appendFile(join(dir, "bunfig.toml"), "exact = true\n");
-  if (opts.install !== false) await runBunInstall(envFor(dir), dir, { allowWarnings: opts.allowWarnings });
-  return dir;
-}
+// A name declared in two groups makes every install and update print this warning (two source excerpts that quote
+// the test dir's path) before the rest of its stderr.
+const duplicateWarning = (rest = "") =>
+  new RegExp(
+    `^(?:.*\\n){2}warn: Duplicate dependency: "no-deps" specified in package\\.json\\n(?:.*\\n){4}note: "no-deps" originally specified here\\n.*${rest && `\\n${rest}`}$`,
+  );
 
-async function tryRun(dir: string, rel: string, ...args: string[]) {
+// Both streams come back normalized for inline snapshots. stderr also loses the two progress lines every resolving
+// run prints, so callers assert the rest of it exactly.
+async function tryRun(dir: string, args: string[], cwd = "") {
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...args],
-    cwd: join(dir, rel),
+    cwd: join(dir, cwd),
     env: envFor(dir),
     stdout: "pipe",
     stderr: "pipe",
     stdin: "ignore",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, exitCode };
+  return {
+    stdout: normalizeBunSnapshot(stdout),
+    stderr: normalizeBunSnapshot(stderr).replace(PROGRESS_LINES, ""),
+    exitCode,
+  };
 }
 
-async function runIn(dir: string, rel: string, ...args: string[]) {
-  const result = await tryRun(dir, rel, ...args);
-  expect(result.stderr).not.toContain("error:");
-  expect(result.exitCode).toBe(0);
-  return result;
+// A run that rewrites bun.lock says so on stderr and nothing else. `stderr` pins a different expectation: "" for a
+// run that must not write, or the warning a run is known to print.
+async function run(dir: string, args: string[], opts: { cwd?: string; stderr?: string | RegExp } = {}) {
+  const { stdout, stderr, exitCode } = await tryRun(dir, args, opts.cwd);
+  const expected = opts.stderr ?? SAVED;
+  if (typeof expected === "string") expect(stderr).toBe(expected);
+  else expect(stderr).toMatch(expected);
+  expect(exitCode).toBe(0);
+  return stdout;
 }
 
-const run = (dir: string, ...args: string[]) => runIn(dir, "", ...args);
+const install = (dir: string, opts: { frozen?: boolean; stderr?: string | RegExp } = {}) =>
+  run(dir, ["install", ...(opts.frozen ? ["--frozen-lockfile"] : [])], {
+    stderr: opts.stderr ?? (opts.frozen ? "" : SAVED),
+  });
+
+function json(contents: Json | string) {
+  return typeof contents === "string" ? contents : JSON.stringify(contents, null, 2) + "\n";
+}
+
+async function setup(
+  files: Record<string, Json | string>,
+  opts: { exact?: boolean; text?: boolean; install?: boolean; stderr?: string | RegExp } = {},
+): Promise<string> {
+  const { packageDir: dir } = await verdaccio.createTestDir({
+    bunfigOpts: { linker: "hoisted", saveTextLockfile: opts.text ?? true },
+    files: Object.fromEntries(Object.entries(files).map(([path, contents]) => [path, json(contents)])),
+  });
+  if (opts.exact) await appendFile(join(dir, "bunfig.toml"), "exact = true\n");
+  if (opts.install !== false) await install(dir, { stderr: opts.stderr });
+  return dir;
+}
 
 const pkg = (dir: string, rel = ""): Promise<Json> => file(join(dir, rel, "package.json")).json();
 const pkgText = (dir: string, rel = "") => file(join(dir, rel, "package.json")).text();
 const writePkg = (dir: string, contents: Json, rel = "") => write(join(dir, rel, "package.json"), json(contents));
-const installed = (dir: string, name: string): Promise<Json> =>
-  file(join(dir, "node_modules", name, "package.json")).json();
 const lockText = (dir: string) => file(join(dir, "bun.lock")).text();
 const lock = async (dir: string): Promise<Json> => Bun.JSONC.parse(await lockText(dir)) as Json;
 
-async function resolutions(dir: string, name: string): Promise<string[]> {
+// Every `<name>@<version>` bun.lock resolved, sorted and deduplicated.
+async function resolved(dir: string): Promise<string[]> {
   const entries = Object.values((await lock(dir)).packages) as [string, ...unknown[]][];
-  return [...new Set(entries.map(entry => entry[0]).filter(res => res.startsWith(`${name}@`)))].sort();
+  return [...new Set(entries.map(entry => entry[0]))].sort();
+}
+
+// What node_modules/<name> holds for each name, as `<name>@<version>` (the package's own name, so an alias shows its target).
+async function installed(dir: string, ...names: string[]): Promise<Record<string, string>> {
+  const entries = names.map(async name => {
+    const manifest = await file(join(dir, "node_modules", name, "package.json")).json();
+    return [name, `${manifest.name}@${manifest.version}`];
+  });
+  return Object.fromEntries(await Promise.all(entries));
 }
 
 async function reinstall(dir: string, contents: Json, rel = "") {
   await writePkg(dir, contents, rel);
-  await runBunInstall(envFor(dir), dir);
+  await install(dir);
 }
 
 function declaredLiteral(manifest: Json, name: string): string | undefined {
@@ -86,42 +118,52 @@ function declaredLiteral(manifest: Json, name: string): string | undefined {
   }
 }
 
+// bun.lock repeats each workspace's dependency groups, plus the root's overrides, catalog and catalogs, and a
+// `--frozen-lockfile` install must accept it as is. With `reinstall`, a plain install must leave it byte-identical too.
 async function expectInSync(
   dir: string,
   workspaces: string[] = [""],
-  opts: { allowWarnings?: boolean; reinstall?: boolean } = {},
+  opts: { stderr?: string | RegExp; reinstall?: boolean } = {},
 ) {
   const lockfile = await lock(dir);
+  const declared: Json = {};
+  const locked: Json = {};
   for (const key of workspaces) {
     const manifest = await pkg(dir, key);
+    declared[key] = {};
+    locked[key] = {};
     for (const group of GROUPS) {
       if (manifest[group] === undefined) continue;
-      expect({ [key || "."]: { [group]: lockfile.workspaces[key]?.[group] } }).toStrictEqual({
-        [key || "."]: { [group]: manifest[group] },
-      });
+      declared[key][group] = manifest[group];
+      locked[key][group] = lockfile.workspaces[key]?.[group];
     }
     if (key !== "") continue;
     const overrides = manifest.overrides ?? manifest.resolutions;
     if (overrides !== undefined) {
-      const expected = Object.fromEntries(
+      declared[key].overrides = Object.fromEntries(
         Object.entries(overrides).map(([name, value]) => [
           name,
           typeof value === "string" && value.startsWith("$") ? declaredLiteral(manifest, value.slice(1)) : value,
         ]),
       );
-      expect(lockfile.overrides).toStrictEqual(expected);
+      locked[key].overrides = lockfile.overrides;
     }
     const catalog = manifest.workspaces?.catalog ?? manifest.catalog;
-    if (catalog !== undefined) expect(lockfile.catalog).toStrictEqual(catalog);
+    if (catalog !== undefined) {
+      declared[key].catalog = catalog;
+      locked[key].catalog = lockfile.catalog;
+    }
     const catalogs = manifest.workspaces?.catalogs ?? manifest.catalogs;
-    if (catalogs !== undefined) expect(lockfile.catalogs).toStrictEqual(catalogs);
+    if (catalogs !== undefined) {
+      declared[key].catalogs = catalogs;
+      locked[key].catalogs = lockfile.catalogs;
+    }
   }
-  const env = envFor(dir);
-  await runBunInstall(env, dir, { frozenLockfile: true, allowWarnings: opts.allowWarnings });
+  expect(locked).toStrictEqual(declared);
+  await install(dir, { frozen: true, stderr: opts.stderr ?? "" });
   if (!opts.reinstall) return;
   const before = await lockText(dir);
-  const { err } = await runBunInstall(env, dir, { savesLockfile: false, allowWarnings: opts.allowWarnings });
-  expect(err).not.toContain("Saved lockfile");
+  await install(dir, { stderr: opts.stderr ?? "" });
   expect(await lockText(dir)).toBe(before);
 }
 
@@ -142,61 +184,140 @@ const PKG2 = "packages/pkg2";
 describe.concurrent("bun update rewrites bun.lock together with package.json", () => {
   test("bun update", async () => {
     const dir = await setup({
-      "package.json": root({ dependencies: { "no-deps": "^1.0.0", aliased: "npm:no-deps@~1.0.0" } }),
+      "package.json": root({
+        dependencies: { "no-deps": "^1.0.0", aliased: "npm:no-deps@~1.0.0", bare: "npm:no-deps" },
+      }),
     });
-    await run(dir, "update");
-    const expected = { "no-deps": "^1.1.0", aliased: "npm:no-deps@~1.0.1" };
+    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.1 -> 1.1.0 (v2.0.0 available)
+
+      1 package installed"
+    `);
+    const expected = { "no-deps": "^1.1.0", aliased: "npm:no-deps@~1.0.1", bare: "npm:no-deps" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
+    expect(await installed(dir, "no-deps", "aliased", "bare")).toStrictEqual({
+      "no-deps": "no-deps@1.1.0",
+      aliased: "no-deps@1.0.1",
+      bare: "no-deps@2.0.0",
+    });
     await expectInSync(dir, [""], { reinstall: true });
   });
 
   test("bun update --latest", async () => {
     const dir = await setup({
-      "package.json": root({ dependencies: { "no-deps": "~1.0.0", aliased: "npm:no-deps@~1.0.0" } }),
+      "package.json": root({
+        dependencies: {
+          "no-deps": "~1.0.0",
+          aliased: "npm:no-deps@~1.0.0",
+          types: "npm:@types/no-deps",
+          tagged: "npm:dep-with-tags@pre-2",
+        },
+      }),
     });
-    await run(dir, "update", "--latest");
-    const expected = { "no-deps": "~2.0.0", aliased: "npm:no-deps@~2.0.0" };
+    expect(await run(dir, ["update", "--latest"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ aliased 1.0.1 -> 2.0.0
+      ^ no-deps 1.0.1 -> 2.0.0
+      ^ tagged 2.0.1 -> 3.0.0
+
+      2 packages installed"
+    `);
+    const expected = {
+      "no-deps": "~2.0.0",
+      aliased: "npm:no-deps@~2.0.0",
+      types: "npm:@types/no-deps@^2.0.0",
+      tagged: "npm:dep-with-tags@^3.0.0",
+    };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
-    const ws = (await lock(dir)).workspaces[""];
-    expect(ws.dependencies).toStrictEqual(expected);
-    expect(JSON.stringify(ws)).not.toContain("latest");
+    expect((await lock(dir)).workspaces[""]).toStrictEqual({ name: "foo", dependencies: expected });
+    expect(await installed(dir, "no-deps", "aliased", "types", "tagged")).toStrictEqual({
+      "no-deps": "no-deps@2.0.0",
+      aliased: "no-deps@2.0.0",
+      types: "@types/no-deps@2.0.0",
+      tagged: "dep-with-tags@3.0.0",
+    });
     await expectInSync(dir);
   });
 
-  test.each([
-    ["*", "2.0.0"],
-    ["1", "1.1.0"],
-    ["1.x", "1.1.0"],
-    [">=1.0.0", "2.0.0"],
-    ["1.0.0 - 1.0.1", "1.0.1"],
-  ])("bun update leaves a %s range as written and moves bun.lock to %s", async (literal, resolved) => {
-    const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "1.0.0" } }) });
-    await reinstall(dir, root({ dependencies: { "no-deps": literal } }));
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.0"]);
+  // Each range is installed pinned first, so the update has a newer version inside the range to move to.
+  test("bun update leaves *, major, 1.x, >= and hyphen ranges as written and moves only bun.lock", async () => {
+    const pinned = {
+      "no-deps": "1.0.0",
+      "a-dep": "1.0.1",
+      "what-bin": "1.0.0",
+      "@types/no-deps": "1.0.0",
+      "dep-with-tags": "1.0.0",
+      aliased: "npm:no-deps@1.0.0",
+    };
+    const ranges = {
+      "no-deps": "*",
+      "a-dep": "1",
+      "what-bin": "1.x",
+      "@types/no-deps": ">=1.0.0",
+      "dep-with-tags": "1.0.0 - 1.0.1",
+      aliased: "npm:no-deps@*",
+    };
+    const dir = await setup({ "package.json": root({ dependencies: pinned }) });
+    await reinstall(dir, root({ dependencies: ranges }));
+    expect(await resolved(dir)).toStrictEqual([
+      "@types/no-deps@1.0.0",
+      "a-dep@1.0.1",
+      "dep-with-tags@1.0.0",
+      "no-deps@1.0.0",
+      "what-bin@1.0.0",
+    ]);
     const pkgBefore = await pkgText(dir);
-    const { stdout } = await run(dir, "update");
-    expect(stdout).toMatch(new RegExp(`no-deps 1\\.0\\.0 (→|->) ${resolved.replaceAll(".", "\\.")}`));
+    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ @types/no-deps 1.0.0 -> 2.0.0
+      ^ a-dep 1.0.1 -> 1.0.10
+      ^ aliased 1.0.0 -> 2.0.0
+      ^ dep-with-tags 1.0.0 -> 1.0.1 (v3.0.0 available)
+      ^ no-deps 1.0.0 -> 2.0.0
+      ^ what-bin 1.0.0 -> 1.5.0
+
+      5 packages installed"
+    `);
     expect(await pkgText(dir)).toBe(pkgBefore);
-    expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": literal });
-    expect(await resolutions(dir, "no-deps")).toStrictEqual([`no-deps@${resolved}`]);
-    expect(await installed(dir, "no-deps")).toMatchObject({ version: resolved });
+    expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(ranges);
+    expect(await resolved(dir)).toStrictEqual([
+      "@types/no-deps@2.0.0",
+      "a-dep@1.0.10",
+      "dep-with-tags@1.0.1",
+      "no-deps@2.0.0",
+      "what-bin@1.5.0",
+    ]);
+    expect(await installed(dir, ...Object.keys(ranges))).toStrictEqual({
+      "no-deps": "no-deps@2.0.0",
+      "a-dep": "a-dep@1.0.10",
+      "what-bin": "what-bin@1.5.0",
+      "@types/no-deps": "@types/no-deps@2.0.0",
+      "dep-with-tags": "dep-with-tags@1.0.1",
+      aliased: "no-deps@2.0.0",
+    });
     await expectInSync(dir);
   });
 
-  test("bun update on a * range that already resolves the newest version leaves both files byte-identical", async () => {
+  test("bun update on a * range that already resolves the newest version leaves both files byte-identical, --latest rewrites it", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "*" } }) });
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
-    const { stdout } = await run(dir, "update");
-    expect(stdout).not.toContain("->");
-    expect(stdout).not.toContain("→");
+    expect(await run(dir, ["update"], { stderr: "" })).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      Checked 1 install across 2 packages (no changes)"
+    `);
     expect(await pkgText(dir)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
-  });
+    expect(await run(dir, ["update", "--latest"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
 
-  test("bun update --latest rewrites a * range", async () => {
-    const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "*" } }) });
-    await run(dir, "update", "--latest");
+      Checked 1 install across 2 packages (no changes)"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
     await expectInSync(dir);
@@ -204,7 +325,11 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("bun update <name> keeps the pin style", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "~1.0.0" } }) });
-    await run(dir, "update", "no-deps");
+    expect(await run(dir, ["update", "no-deps"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      Checked 1 install across 2 packages (no changes)"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     await expectInSync(dir);
@@ -212,7 +337,11 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("bun update <name> on an exact literal", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "1.0.0" } }) });
-    await run(dir, "update", "no-deps");
+    expect(await run(dir, ["update", "no-deps"], { stderr: "" })).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      Checked 1 install across 2 packages (no changes)"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "1.0.0" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": "1.0.0" });
     await expectInSync(dir);
@@ -221,18 +350,27 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
   test("bun update <name> keeps a * literal and leaves the unnamed sibling alone", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" } }) });
     await reinstall(dir, root({ dependencies: { "no-deps": "*", "a-dep": "^1.0.1" } }));
-    await run(dir, "update", "no-deps");
+    expect(await run(dir, ["update", "no-deps"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.0 -> 2.0.0
+
+      1 package installed"
+    `);
     const expected = { "no-deps": "*", "a-dep": "^1.0.1" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@2.0.0"]);
-    expect(await resolutions(dir, "a-dep")).toStrictEqual(["a-dep@1.0.1"]);
+    expect(await resolved(dir)).toStrictEqual(["a-dep@1.0.1", "no-deps@2.0.0"]);
     await expectInSync(dir);
   });
 
   test("bun update <alias> keeps the alias", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { aliased: "npm:no-deps@~1.0.0" } }) });
-    await run(dir, "update", "aliased");
+    expect(await run(dir, ["update", "aliased"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      Checked 1 install across 2 packages (no changes)"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: "npm:no-deps@~1.0.1" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ aliased: "npm:no-deps@~1.0.1" });
     await expectInSync(dir);
@@ -240,41 +378,59 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("bun update <name>@<range>", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "~1.0.0" } }) });
-    await run(dir, "update", "no-deps@^1.0.0");
+    expect(await run(dir, ["update", "no-deps@^1.0.0"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.1 -> 1.1.0 (v2.0.0 available)
+
+      1 package installed"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "~1.1.0" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": "~1.1.0" });
     await expectInSync(dir);
   });
 
-  // `bun install` warns about a name declared in two groups, so these two allow warnings.
   const inBothGroups = (version: string) =>
     root({ dependencies: { "no-deps": version }, devDependencies: { "no-deps": version } });
 
   test("bun update <name> with the name in dependencies and devDependencies", async () => {
-    const dir = await setup({ "package.json": inBothGroups("~1.0.0") }, { allowWarnings: true });
-    await run(dir, "update", "no-deps");
+    const dir = await setup({ "package.json": inBothGroups("~1.0.0") }, { stderr: duplicateWarning(SAVED) });
+    expect(await run(dir, ["update", "no-deps"], { stderr: duplicateWarning(SAVED) })).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      Checked 1 install across 2 packages (no changes)"
+    `);
     const manifest = await pkg(dir);
     expect(manifest.dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     expect(manifest.devDependencies).toStrictEqual({ "no-deps": "~1.0.0" });
-    await expectInSync(dir, [""], { allowWarnings: true });
+    await expectInSync(dir, [""], { stderr: duplicateWarning() });
   });
 
   test("bun update with the name in dependencies and devDependencies moves one group", async () => {
-    const dir = await setup({ "package.json": inBothGroups("1.0.0") }, { allowWarnings: true });
+    const dir = await setup({ "package.json": inBothGroups("1.0.0") }, { stderr: duplicateWarning(SAVED) });
     await writePkg(dir, inBothGroups("~1.0.0"));
-    const { stdout } = await run(dir, "update");
-    expect(stdout).toMatch(/no-deps 1\.0\.0 (→|->) 1\.0\.1/);
+    expect(await run(dir, ["update"], { stderr: duplicateWarning(SAVED) })).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.0 -> 1.0.1 (v2.0.0 available)
+
+      1 package installed"
+    `);
     const manifest = await pkg(dir);
     expect([manifest.dependencies["no-deps"], manifest.devDependencies["no-deps"]].sort()).toStrictEqual([
       "~1.0.0",
       "~1.0.1",
     ]);
-    await expectInSync(dir, [""], { allowWarnings: true });
+    await expectInSync(dir, [""], { stderr: duplicateWarning() });
   });
 
   test("install.exact", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "^1.0.0" } }) }, { exact: true });
-    await run(dir, "update");
+    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      Checked 1 install across 2 packages (no changes)"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "1.1.0" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": "1.1.0" });
     await expectInSync(dir);
@@ -299,50 +455,59 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
       { "package/package.json": JSON.stringify({ name: "tgz-dep", version: "1.0.0" }) },
       { compress: "gzip" },
     );
-    await runBunInstall(envFor(dir), dir);
-    await run(dir, "update", ...args);
+    await install(dir);
+    await run(dir, ["update", ...args]);
     const expected = { ...dependencies, "no-deps": args.length ? "^2.0.0" : "^1.1.0" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
     await expectInSync(dir, ["", PKG1]);
   });
 
-  test("bun update -r", async () => {
-    const dir = await setup(MONOREPO({ dependencies: { "no-deps": "~1.0.0" } }));
-    await run(dir, "update", "-r");
-    expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
-    expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
-    await expectInSync(dir, ["", PKG1]);
-  });
-
   test("bun update -r keeps a member's 1.x literal", async () => {
     const dir = await setup(MONOREPO({ dependencies: { "no-deps": "1.0.0" } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "1.x" } }), PKG1);
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.0"]);
-    await run(dir, "update", "-r");
+    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
+    expect(await run(dir, ["update", "-r"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
+
+      1 package installed"
+    `);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "1.x" });
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual({ "no-deps": "1.x" });
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.1.0"]);
+    expect(await resolved(dir)).toStrictEqual(["no-deps@1.1.0", "pkg1@workspace:packages/pkg1"]);
     await expectInSync(dir, ["", PKG1]);
   });
 
-  test("bun update -r keeps a member's dist-tag literal", async () => {
+  test("bun update -r bumps a member's range and keeps its dist-tag literal", async () => {
     const dir = await setup(MONOREPO({ dependencies: { "dep-with-tags": "pre-2", "no-deps": "~1.0.0" } }));
-    await run(dir, "update", "-r");
+    expect(await run(dir, ["update", "-r"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      Checked 3 installs across 4 packages (no changes)"
+    `);
     const expected = { "dep-with-tags": "pre-2", "no-deps": "~1.0.1" };
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual(expected);
-    expect(await resolutions(dir, "dep-with-tags")).toStrictEqual(["dep-with-tags@2.0.1"]);
+    expect(await resolved(dir)).toStrictEqual(["dep-with-tags@2.0.1", "no-deps@1.0.1", "pkg1@workspace:packages/pkg1"]);
     await expectInSync(dir, ["", PKG1]);
   });
 
   test("bun update -r --latest replaces a member's dist-tag literal with the latest version", async () => {
     const dir = await setup(MONOREPO({ dependencies: { "dep-with-tags": "pre-2", "no-deps": "~1.0.0" } }));
-    await run(dir, "update", "-r", "--latest");
+    expect(await run(dir, ["update", "-r", "--latest"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ dep-with-tags 2.0.1 -> 3.0.0
+      ^ no-deps 1.0.1 -> 2.0.0
+
+      2 packages installed"
+    `);
     const expected = { "dep-with-tags": "^3.0.0", "no-deps": "~2.0.0" };
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual(expected);
-    expect(await resolutions(dir, "dep-with-tags")).toStrictEqual(["dep-with-tags@3.0.0"]);
+    expect(await resolved(dir)).toStrictEqual(["dep-with-tags@3.0.0", "no-deps@2.0.0", "pkg1@workspace:packages/pkg1"]);
     await expectInSync(dir, ["", PKG1]);
   });
 
@@ -350,7 +515,11 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     const dir = await setup(
       MONOREPO({ dependencies: { "no-deps": "~1.0.0", "a-dep": "^1.0.1" } }, { dependencies: { "no-deps": "~1.0.0" } }),
     );
-    await run(dir, "update", "no-deps", "--filter", "pkg1");
+    expect(await run(dir, ["update", "no-deps", "--filter", "pkg1"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      Checked 3 installs across 4 packages (no changes)"
+    `);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1", "a-dep": "^1.0.1" });
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
     await expectInSync(dir, ["", PKG1], { reinstall: true });
@@ -363,11 +532,22 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
         { pkg1: { dependencies: { "a-dep": "1.0.1" } }, pkg2: { dependencies: { "no-deps": "~1.0.0" } } },
       ),
     );
-    await run(dir, "update", "no-deps", "-r", "--latest");
+    expect(await run(dir, ["update", "no-deps", "-r", "--latest"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.1 -> 2.0.0
+
+      1 package installed"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "~2.0.0" });
     expect((await pkg(dir, PKG2)).dependencies).toStrictEqual({ "no-deps": "~2.0.0" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "a-dep": "1.0.1" });
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@2.0.0"]);
+    expect(await resolved(dir)).toStrictEqual([
+      "a-dep@1.0.1",
+      "no-deps@2.0.0",
+      "pkg1@workspace:packages/pkg1",
+      "pkg2@workspace:packages/pkg2",
+    ]);
     await expectInSync(dir, ["", PKG1, PKG2]);
   });
 
@@ -377,11 +557,17 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     );
     await writePkg(dir, wsRoot({ dependencies: { "no-deps": "^1.0.0" } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.0"]);
-    await run(dir, "update", "no-deps@1.0.1", "-r");
+    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
+    expect(await run(dir, ["update", "no-deps@1.0.1", "-r"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.0 -> 1.0.1 (v2.0.0 available)
+
+      1 package installed"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^1.0.1" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.1"]);
+    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.1", "pkg1@workspace:packages/pkg1"]);
     await expectInSync(dir, ["", PKG1]);
   });
 
@@ -389,15 +575,24 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     const dir = await setup(MONOREPO({ dependencies: { "no-deps": "1.0.0" } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir, PKG1), lockText(dir)]);
-    const { stderr } = await run(dir, "update", "no-deps", "-r", "--dry-run");
-    expect(stderr).not.toContain("Saved lockfile");
+    expect(await run(dir, ["update", "no-deps", "-r", "--dry-run"], { stderr: "" })).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.0 -> 1.0.1 (v2.0.0 available)
+
+      1 package would be updated"
+    `);
     expect(await pkgText(dir, PKG1)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
   });
 
   test("bun update from a workspace member", async () => {
     const dir = await setup(MONOREPO({ dependencies: { "no-deps": "~1.0.0" } }));
-    await runIn(dir, PKG1, "update");
+    expect(await run(dir, ["update"], { cwd: PKG1 })).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      Checked 2 installs across 3 packages (no changes)"
+    `);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     await expectInSync(dir, ["", PKG1]);
@@ -411,19 +606,31 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     );
     await writePkg(dir, wsRoot({ dependencies: { "no-deps": "^1.0.0" } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.0"]);
+    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
 
-    await run(dir, "update", "no-deps");
+    expect(await run(dir, ["update", "no-deps"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
+
+      2 packages installed"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^1.1.0" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.0", "no-deps@1.1.0"]);
+    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.0", "no-deps@1.1.0", "pkg1@workspace:packages/pkg1"]);
     await expectInSync(dir, ["", PKG1]);
 
-    await run(dir, "update", "no-deps", "-r");
+    expect(await run(dir, ["update", "no-deps", "-r"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.1.0 -> 1.0.1 (v2.0.0 available)
+
+      1 package installed"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^1.1.0" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.1", "no-deps@1.1.0"]);
+    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.1", "no-deps@1.1.0", "pkg1@workspace:packages/pkg1"]);
     await expectInSync(dir, ["", PKG1]);
   });
 
@@ -436,13 +643,28 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     );
     await writePkg(dir, member("pkg1", { dependencies: { "no-deps": "^1.0.0" } }), PKG1);
     await reinstall(dir, member("pkg2", { dependencies: { "no-deps": "~1.0.0" } }), PKG2);
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.0"]);
+    expect(await resolved(dir)).toStrictEqual([
+      "no-deps@1.0.0",
+      "pkg1@workspace:packages/pkg1",
+      "pkg2@workspace:packages/pkg2",
+    ]);
 
-    await runIn(dir, PKG1, "update", "no-deps");
+    expect(await run(dir, ["update", "no-deps"], { cwd: PKG1 })).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
+
+      2 packages installed"
+    `);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "^1.1.0" });
     expect((await pkg(dir, PKG2)).dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
     expect((await lock(dir)).workspaces[PKG2].dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.0", "no-deps@1.1.0"]);
+    expect(await resolved(dir)).toStrictEqual([
+      "no-deps@1.0.0",
+      "no-deps@1.1.0",
+      "pkg1@workspace:packages/pkg1",
+      "pkg2@workspace:packages/pkg2",
+    ]);
     await expectInSync(dir, ["", PKG1, PKG2]);
   });
 
@@ -456,16 +678,30 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     await writePkg(dir, wsRoot({ dependencies: { "no-deps": "^1.0.0" } }));
     await writePkg(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
     await reinstall(dir, member("pkg2", { dependencies: { "no-deps": "~1.0.0" } }), PKG2);
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.0"]);
+    expect(await resolved(dir)).toStrictEqual([
+      "no-deps@1.0.0",
+      "pkg1@workspace:packages/pkg1",
+      "pkg2@workspace:packages/pkg2",
+    ]);
 
-    await run(dir, "update", "no-deps", "--filter", "pkg1");
+    expect(await run(dir, ["update", "no-deps", "--filter", "pkg1"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.0 -> 1.0.1 (v2.0.0 available)
+
+      1 package installed"
+    `);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^1.0.0" });
     expect((await pkg(dir, PKG2)).dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
     const { workspaces } = await lock(dir);
     expect(workspaces[""].dependencies).toStrictEqual({ "no-deps": "^1.0.0" });
     expect(workspaces[PKG2].dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.1"]);
+    expect(await resolved(dir)).toStrictEqual([
+      "no-deps@1.0.1",
+      "pkg1@workspace:packages/pkg1",
+      "pkg2@workspace:packages/pkg2",
+    ]);
     await expectInSync(dir, ["", PKG1, PKG2]);
   });
 
@@ -473,12 +709,13 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     const dir = await setup(WORKSPACES({}, { pkg1: { dependencies: { "no-deps": "1.0.0" } } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir, PKG1), lockText(dir)]);
-    const { stderr, exitCode } = await tryRun(dir, "", "update", "no-deps");
-    expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+    const { stdout, stderr, exitCode } = await tryRun(dir, ["update", "no-deps"]);
+    expect(stderr).toMatchInlineSnapshot(`
       "error: "no-deps" is not a dependency of this workspace
           bun update -r no-deps
           bun update --filter pkg1 no-deps"
     `);
+    expect(stdout).toMatchInlineSnapshot(`"bun update <version> (<revision>)"`);
     expect(await pkgText(dir, PKG1)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
     expect(exitCode).toBe(1);
@@ -486,117 +723,125 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
 });
 
 describe.concurrent("npm: aliases", () => {
-  const ROWS: { pinned?: string; before: string; args: string[]; after: string; installs: [string, string] }[] = [
+  const ROWS: { before: string; args: string[]; after: string; installs: string; stderr?: string }[] = [
     {
       before: "npm:no-deps@~1.0.0",
       args: ["aliased", "--latest"],
       after: "npm:no-deps@~2.0.0",
-      installs: ["no-deps", "2.0.0"],
+      installs: "no-deps@2.0.0",
     },
-    { before: "npm:no-deps", args: [], after: "npm:no-deps", installs: ["no-deps", "2.0.0"] },
-    { before: "npm:no-deps", args: ["aliased"], after: "npm:no-deps", installs: ["no-deps", "2.0.0"] },
-    {
-      pinned: "npm:no-deps@1.0.0",
-      before: "npm:no-deps@*",
-      args: [],
-      after: "npm:no-deps@*",
-      installs: ["no-deps", "2.0.0"],
-    },
-    {
-      before: "npm:@types/no-deps",
-      args: ["--latest"],
-      after: "npm:@types/no-deps@^2.0.0",
-      installs: ["@types/no-deps", "2.0.0"],
-    },
-    {
-      before: "npm:dep-with-tags@pre-2",
-      args: ["--latest"],
-      after: "npm:dep-with-tags@^3.0.0",
-      installs: ["dep-with-tags", "3.0.0"],
-    },
-    {
-      before: "npm:no-deps@~1.0.0",
-      args: ["aliased@2.0.0"],
-      after: "npm:no-deps@~2.0.0",
-      installs: ["no-deps", "2.0.0"],
-    },
-    { before: "npm:no-deps@^1.0.0", args: ["aliased"], after: "npm:no-deps@^1.1.0", installs: ["no-deps", "1.1.0"] },
+    // A bare alias already resolves to the newest version, so this update finds nothing to write.
+    { before: "npm:no-deps", args: ["aliased"], after: "npm:no-deps", installs: "no-deps@2.0.0", stderr: "" },
+    { before: "npm:no-deps@~1.0.0", args: ["aliased@2.0.0"], after: "npm:no-deps@~2.0.0", installs: "no-deps@2.0.0" },
+    { before: "npm:no-deps@^1.0.0", args: ["aliased"], after: "npm:no-deps@^1.1.0", installs: "no-deps@1.1.0" },
   ];
 
   test.each(ROWS)(
     '"aliased": "$before" + bun update $args -> "$after"',
-    async ({ pinned, before, args, after, installs }) => {
-      const dir = await setup({ "package.json": root({ dependencies: { aliased: pinned ?? before } }) });
-      if (pinned !== undefined) {
-        await reinstall(dir, root({ dependencies: { aliased: before } }));
-        expect(await installed(dir, "aliased")).toMatchObject({ version: "1.0.0" });
-      }
-      await run(dir, "update", ...args);
-      expect((await pkg(dir)).dependencies.aliased).toBe(after);
-      const [name, version] = installs;
-      expect(await installed(dir, "aliased")).toMatchObject({ name, version });
+    async ({ before, args, after, installs, stderr }) => {
+      const dir = await setup({ "package.json": root({ dependencies: { aliased: before } }) });
+      await run(dir, ["update", ...args], { stderr });
+      expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: after });
+      expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ aliased: after });
+      expect(await installed(dir, "aliased")).toStrictEqual({ aliased: installs });
       await expectInSync(dir);
     },
   );
 
   test("bun update <alias>@npm:<other> retargets the alias", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { aliased: "npm:no-deps@~1.0.0" } }) });
-    await run(dir, "update", "aliased@npm:a-dep");
+    expect(await run(dir, ["update", "aliased@npm:a-dep"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ aliased 1.0.1 -> 1.0.10
+
+      1 package installed"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: "npm:a-dep@~1.0.10" });
-    expect(await installed(dir, "aliased")).toMatchObject({ name: "a-dep", version: "1.0.10" });
+    expect(await installed(dir, "aliased")).toStrictEqual({ aliased: "a-dep@1.0.10" });
     await expectInSync(dir);
   });
 
   test("bun update <new>@npm:<scoped>@<range> refuses to add; bun add keeps the target", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "a-dep": "1.0.1" } }) });
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
-    const { stderr, exitCode } = await tryRun(dir, "", "update", "new-alias@npm:@types/no-deps@^1.0.0");
-    expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+    const { stdout, stderr, exitCode } = await tryRun(dir, ["update", "new-alias@npm:@types/no-deps@^1.0.0"]);
+    expect(stderr).toMatchInlineSnapshot(`
       "error: "new-alias" is not in bun.lock
           bun add new-alias"
     `);
+    expect(stdout).toMatchInlineSnapshot(`"bun update <version> (<revision>)"`);
     expect(exitCode).toBe(1);
     expect(await pkgText(dir)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
 
-    await run(dir, "add", "new-alias@npm:@types/no-deps@^1.0.0");
+    expect(await run(dir, ["add", "new-alias@npm:@types/no-deps@^1.0.0"])).toMatchInlineSnapshot(`
+      "bun add <version> (<revision>)
+
+      installed new-alias@npm:@types/no-deps@1.0.0
+
+      1 package installed"
+    `);
     const expected = { "a-dep": "1.0.1", "new-alias": "npm:@types/no-deps@^1.0.0" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
-    expect(await installed(dir, "new-alias")).toMatchObject({ name: "@types/no-deps", version: "1.0.0" });
+    expect(await installed(dir, "new-alias")).toStrictEqual({ "new-alias": "@types/no-deps@1.0.0" });
     await expectInSync(dir);
   });
 
   test("bun update <alias>@npm:<scoped>@<range> retargets a scoped alias in the declared pin style", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { aliased: "npm:no-deps@~1.0.0" } }) });
-    await run(dir, "update", "aliased@npm:@types/no-deps@^1.0.0");
+    expect(await run(dir, ["update", "aliased@npm:@types/no-deps@^1.0.0"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ aliased 1.0.1 -> 1.0.0 (v2.0.0 available)
+
+      1 package installed"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: "npm:@types/no-deps@~1.0.0" });
-    expect(await installed(dir, "aliased")).toMatchObject({ name: "@types/no-deps", version: "1.0.0" });
+    expect(await installed(dir, "aliased")).toStrictEqual({ aliased: "@types/no-deps@1.0.0" });
     await expectInSync(dir);
   });
 });
 
 describe.concurrent("bun add", () => {
-  test.each([
-    { args: ["no-deps"], expected: { "no-deps": "^2.0.0" } },
-    { args: ["no-deps", "--exact"], expected: { "no-deps": "2.0.0" } },
-    { args: ["no-deps@~1.0.0"], expected: { "no-deps": "~1.0.0" } },
-    { args: ["no-deps@latest"], expected: { "no-deps": "^2.0.0" } },
-    { args: ["x@npm:no-deps@~1.0.0"], expected: { x: "npm:no-deps@~1.0.0" } },
-    { args: ["x@npm:no-deps@latest"], expected: { x: "npm:no-deps@^2.0.0" } },
-    { args: ["x@npm:no-deps"], expected: { x: "npm:no-deps@^2.0.0" } },
-    { args: ["x@npm:no-deps", "--exact"], expected: { x: "npm:no-deps@2.0.0" } },
-  ])("bun add $args", async ({ args, expected }) => {
+  // One `bun add` per pin style of the name itself; the aliases ride along to cover the `<alias>@npm:` spellings.
+  const ADDS: { args: string[]; expected: Record<string, string>; installs: Record<string, string> }[] = [
+    {
+      args: ["no-deps", "a@npm:no-deps@~1.0.0", "c@npm:no-deps"],
+      expected: { "no-deps": "^2.0.0", a: "npm:no-deps@~1.0.0", c: "npm:no-deps@^2.0.0" },
+      installs: { "no-deps": "no-deps@2.0.0", a: "no-deps@1.0.1", c: "no-deps@2.0.0" },
+    },
+    {
+      args: ["no-deps", "x@npm:no-deps", "--exact"],
+      expected: { "no-deps": "2.0.0", x: "npm:no-deps@2.0.0" },
+      installs: { "no-deps": "no-deps@2.0.0", x: "no-deps@2.0.0" },
+    },
+    {
+      args: ["no-deps@~1.0.0", "b@npm:no-deps@latest"],
+      expected: { "no-deps": "~1.0.0", b: "npm:no-deps@^2.0.0" },
+      installs: { "no-deps": "no-deps@1.0.1", b: "no-deps@2.0.0" },
+    },
+    { args: ["no-deps@latest"], expected: { "no-deps": "^2.0.0" }, installs: { "no-deps": "no-deps@2.0.0" } },
+  ];
+
+  test.each(ADDS)("bun add $args", async ({ args, expected, installs }) => {
     const dir = await setup({ "package.json": root({}) }, { install: false });
-    await run(dir, "add", ...args);
+    await run(dir, ["add", ...args]);
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
+    expect(await installed(dir, ...Object.keys(expected))).toStrictEqual(installs);
     await expectInSync(dir);
   });
 
   test("bun add <workspace>@workspace:*", async () => {
     const dir = await setup(MONOREPO());
-    await run(dir, "add", "pkg1@workspace:*");
+    expect(await run(dir, ["add", "pkg1@workspace:*"])).toMatchInlineSnapshot(`
+      "bun add <version> (<revision>)
+
+      installed pkg1@workspace:packages/pkg1
+       done"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ pkg1: "workspace:*" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ pkg1: "workspace:*" });
     await expectInSync(dir, ["", PKG1]);
@@ -604,7 +849,13 @@ describe.concurrent("bun add", () => {
 
   test("bun add --filter", async () => {
     const dir = await setup(MONOREPO());
-    await run(dir, "add", "x@npm:no-deps@latest", "--filter", "pkg1");
+    expect(await run(dir, ["add", "x@npm:no-deps@latest", "--filter", "pkg1"])).toMatchInlineSnapshot(`
+      "bun add <version> (<revision>)
+
+      installed x@npm:no-deps@2.0.0
+
+      1 package installed"
+    `);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ x: "npm:no-deps@^2.0.0" });
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual({ x: "npm:no-deps@^2.0.0" });
     await expectInSync(dir, ["", PKG1]);
@@ -612,7 +863,11 @@ describe.concurrent("bun add", () => {
 
   test("bun add --lockfile-only", async () => {
     const dir = await setup({ "package.json": root({}) }, { install: false });
-    await run(dir, "add", "no-deps", "--lockfile-only");
+    expect(await run(dir, ["add", "no-deps", "--lockfile-only"])).toMatchInlineSnapshot(`
+      "bun add <version> (<revision>)
+
+      Saved bun.lock (2 packages)"
+    `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
     expect(await exists(join(dir, "node_modules"))).toBe(false);
     await expectInSync(dir);
@@ -620,7 +875,13 @@ describe.concurrent("bun add", () => {
 
   test("bun add --trust", async () => {
     const dir = await setup({ "package.json": root({}) }, { install: false });
-    await run(dir, "add", "uses-what-bin@1.0.0", "--trust");
+    expect(await run(dir, ["add", "uses-what-bin@1.0.0", "--trust"])).toMatchInlineSnapshot(`
+      "bun add <version> (<revision>)
+
+      installed uses-what-bin@1.0.0
+
+      2 packages installed"
+    `);
     expect(await pkg(dir)).toStrictEqual({
       name: "foo",
       dependencies: { "uses-what-bin": "1.0.0" },
@@ -632,11 +893,17 @@ describe.concurrent("bun add", () => {
 
   test("bun add --trust of a package already listed in devDependencies", async () => {
     const dir = await setup({ "package.json": root({ devDependencies: { "uses-what-bin": "1.0.0" } }) });
-    await run(dir, "add", "uses-what-bin@1.0.0", "--trust");
-    const manifest = await pkg(dir);
-    expect(manifest.dependencies).toBeUndefined();
-    expect(manifest.devDependencies).toStrictEqual({ "uses-what-bin": "1.0.0" });
-    expect(manifest.trustedDependencies).toStrictEqual(["uses-what-bin"]);
+    expect(await run(dir, ["add", "uses-what-bin@1.0.0", "--trust"])).toMatchInlineSnapshot(`
+      "bun add <version> (<revision>)
+
+      installed uses-what-bin@1.0.0
+       done"
+    `);
+    expect(await pkg(dir)).toStrictEqual({
+      name: "foo",
+      devDependencies: { "uses-what-bin": "1.0.0" },
+      trustedDependencies: ["uses-what-bin"],
+    });
     expect(await exists(join(dir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBe(true);
     await expectInSync(dir);
   });
@@ -654,87 +921,86 @@ describe.concurrent("catalogs", () => {
     expect((await lock(dir)).catalog).toStrictEqual(expected);
   }
 
-  test("bun update", async () => {
-    const dir = await setup(CATALOG_REPO());
-    await run(dir, "update");
-    await expectCatalog(dir, { "no-deps": "^1.1.0", aliased: "npm:no-deps" });
-    expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "catalog:", aliased: "catalog:" });
+  // A range, a bare alias, a dist-tag, a 1.x range, an aliased range and an aliased dist-tag.
+  const FULL_CATALOG = {
+    "no-deps": "^1.0.0",
+    aliased: "npm:no-deps",
+    "dep-with-tags": "pre-2",
+    "a-dep": "1.x",
+    tilde: "npm:no-deps@~1.0.0",
+    tagged: "npm:dep-with-tags@pre-2",
+  };
+  const FULL_CATALOG_MEMBER_DEPS = Object.fromEntries(Object.keys(FULL_CATALOG).map(name => [name, "catalog:"]));
+
+  test("bun update bumps ranges in place and keeps bare aliases, dist-tags and 1.x entries", async () => {
+    const dir = await setup(CATALOG_REPO(FULL_CATALOG));
+    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      Done! Checked 7 packages (no changes)"
+    `);
+    await expectCatalog(dir, { ...FULL_CATALOG, "no-deps": "^1.1.0", tilde: "npm:no-deps@~1.0.1" });
+    expect(await installed(dir, ...Object.keys(FULL_CATALOG))).toStrictEqual({
+      "no-deps": "no-deps@1.1.0",
+      aliased: "no-deps@2.0.0",
+      "dep-with-tags": "dep-with-tags@2.0.1",
+      "a-dep": "a-dep@1.0.10",
+      tilde: "no-deps@1.0.1",
+      tagged: "dep-with-tags@2.0.1",
+    });
+    expect((await pkg(dir, PKG1)).dependencies).toStrictEqual(FULL_CATALOG_MEMBER_DEPS);
     await expectInSync(dir, ["", PKG1]);
   });
 
-  test.each([[""], [PKG1]])("bun update --latest from '%s'", async cwd => {
-    const dir = await setup(CATALOG_REPO());
-    await runIn(dir, cwd, "update", "--latest");
-    await expectCatalog(dir, { "no-deps": "^2.0.0", aliased: "npm:no-deps@^2.0.0" });
-    expect(await lockText(dir)).not.toContain('"latest"');
-    await expectInSync(dir, ["", PKG1]);
-  });
-
-  test("bun update keeps a dist-tag catalog entry", async () => {
-    const dir = await setup(CATALOG_REPO({ "dep-with-tags": "pre-2" }));
-    await run(dir, "update");
-    await expectCatalog(dir, { "dep-with-tags": "pre-2" });
-    expect(await installed(dir, "dep-with-tags")).toMatchObject({ version: "2.0.1" });
-    await expectInSync(dir, ["", PKG1]);
-  });
-
-  test("bun update --latest replaces a dist-tag catalog entry with the latest version", async () => {
-    const dir = await setup(CATALOG_REPO({ "dep-with-tags": "pre-2" }));
-    await run(dir, "update", "--latest");
-    await expectCatalog(dir, { "dep-with-tags": "^3.0.0" });
-    expect(await installed(dir, "dep-with-tags")).toMatchObject({ version: "3.0.0" });
-    await expectInSync(dir, ["", PKG1]);
-  });
-
-  test("bun update keeps a 1.x catalog entry", async () => {
-    const dir = await setup(CATALOG_REPO({ "no-deps": "1.x" }));
-    await run(dir, "update");
-    await expectCatalog(dir, { "no-deps": "1.x" });
-    expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    await expectInSync(dir, ["", PKG1]);
-  });
+  test.each([[""], [PKG1]])(
+    "bun update --latest from '%s' rewrites every entry and keeps the alias prefixes",
+    async cwd => {
+      const dir = await setup(CATALOG_REPO(FULL_CATALOG));
+      await run(dir, ["update", "--latest"], { cwd });
+      await expectCatalog(dir, {
+        "no-deps": "^2.0.0",
+        aliased: "npm:no-deps@^2.0.0",
+        "dep-with-tags": "^3.0.0",
+        "a-dep": "^1.0.10",
+        tilde: "npm:no-deps@~2.0.0",
+        tagged: "npm:dep-with-tags@^3.0.0",
+      });
+      expect(await installed(dir, ...Object.keys(FULL_CATALOG))).toStrictEqual({
+        "no-deps": "no-deps@2.0.0",
+        aliased: "no-deps@2.0.0",
+        "dep-with-tags": "dep-with-tags@3.0.0",
+        "a-dep": "a-dep@1.0.10",
+        tilde: "no-deps@2.0.0",
+        tagged: "dep-with-tags@3.0.0",
+      });
+      expect((await pkg(dir, PKG1)).dependencies).toStrictEqual(FULL_CATALOG_MEMBER_DEPS);
+      await expectInSync(dir, ["", PKG1]);
+    },
+  );
 
   test("bun update keeps a * catalog entry and moves only bun.lock", async () => {
     const dir = await setup(CATALOG_REPO({ "no-deps": "1.0.0" }));
     await reinstall(dir, wsRoot({ workspaces: { packages: ["packages/*"], catalog: { "no-deps": "*" } } }));
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.0"]);
-    await run(dir, "update");
+    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
+    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      1 package installed"
+    `);
     await expectCatalog(dir, { "no-deps": "*" });
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@2.0.0"]);
+    expect(await resolved(dir)).toStrictEqual(["no-deps@2.0.0", "pkg1@workspace:packages/pkg1"]);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "catalog:" });
     await expectInSync(dir, ["", PKG1]);
   });
 
-  const ALIASED_CATALOG = { aliased: "npm:no-deps@~1.0.0", tagged: "npm:dep-with-tags@pre-2" };
-
-  test("bun update bumps an aliased catalog range in place and keeps an aliased dist-tag", async () => {
-    const dir = await setup(CATALOG_REPO(ALIASED_CATALOG));
-    await run(dir, "update");
-    await expectCatalog(dir, { aliased: "npm:no-deps@~1.0.1", tagged: "npm:dep-with-tags@pre-2" });
-    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "1.0.1" });
-    expect(await installed(dir, "tagged")).toMatchObject({ name: "dep-with-tags", version: "2.0.1" });
-    expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ aliased: "catalog:", tagged: "catalog:" });
-    await expectInSync(dir, ["", PKG1]);
-  });
-
-  test("bun update --latest rewrites aliased catalog entries and keeps the alias prefix", async () => {
-    const dir = await setup(CATALOG_REPO(ALIASED_CATALOG));
-    await run(dir, "update", "--latest");
-    await expectCatalog(dir, { aliased: "npm:no-deps@~2.0.0", tagged: "npm:dep-with-tags@^3.0.0" });
-    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "2.0.0" });
-    expect(await installed(dir, "tagged")).toMatchObject({ name: "dep-with-tags", version: "3.0.0" });
-    expect(await lockText(dir)).not.toContain('"latest"');
-    await expectInSync(dir, ["", PKG1]);
-  });
-
   test.each([
-    [[], { "no-deps": "^1.1.0", aliased: "npm:no-deps@~1.0.1" }, "1.1.0"],
-    [["--latest"], { "no-deps": "^2.0.0", aliased: "npm:no-deps@~2.0.0" }, "2.0.0"],
+    [[], { "no-deps": "^1.1.0", aliased: "npm:no-deps@~1.0.1" }, "no-deps@1.1.0"],
+    [["--latest"], { "no-deps": "^2.0.0", aliased: "npm:no-deps@~2.0.0" }, "no-deps@2.0.0"],
   ])("bun update %j rewrites the singular catalog referenced as catalog:default", async (args, expected, version) => {
     const dir = await setup(CATALOG_REPO({ "no-deps": "^1.0.0", aliased: "npm:no-deps@~1.0.0" }, "catalog:default"));
-    await run(dir, "update", ...args);
+    await run(dir, ["update", ...args]);
     await expectCatalog(dir, expected);
-    expect(await installed(dir, "no-deps")).toMatchObject({ version });
+    expect(await installed(dir, "no-deps")).toStrictEqual({ "no-deps": version });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({
       "no-deps": "catalog:default",
       aliased: "catalog:default",
@@ -742,66 +1008,83 @@ describe.concurrent("catalogs", () => {
     await expectInSync(dir, ["", PKG1]);
   });
 
-  test("bun update --latest with install.exact pins a catalog entry", async () => {
+  test.each([
+    [[], { "no-deps": "1.1.0", aliased: "npm:no-deps@1.0.1" }, "no-deps@1.1.0"],
+    [["--latest"], { "no-deps": "2.0.0", aliased: "npm:no-deps@2.0.0" }, "no-deps@2.0.0"],
+  ])("bun update %j with install.exact pins the catalog entries", async (args, expected, version) => {
     const dir = await setup(CATALOG_REPO({ "no-deps": "^1.0.0", aliased: "npm:no-deps@~1.0.0" }), { exact: true });
-    await run(dir, "update", "--latest");
-    await expectCatalog(dir, { "no-deps": "2.0.0", aliased: "npm:no-deps@2.0.0" });
-    expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
-    await expectInSync(dir, ["", PKG1]);
-  });
-
-  test("bun update with install.exact pins a catalog range in place", async () => {
-    const dir = await setup(CATALOG_REPO({ "no-deps": "^1.0.0" }), { exact: true });
-    await run(dir, "update");
-    await expectCatalog(dir, { "no-deps": "1.1.0" });
-    expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.1.0" });
+    await run(dir, ["update", ...args]);
+    await expectCatalog(dir, expected);
+    expect(await installed(dir, "no-deps")).toStrictEqual({ "no-deps": version });
     await expectInSync(dir, ["", PKG1]);
   });
 
   test("bun update --latest keeps the = prefix of a catalog entry", async () => {
     const dir = await setup(CATALOG_REPO({ "no-deps": "=1.0.0" }));
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
-    await run(dir, "update");
+    expect(await run(dir, ["update"], { stderr: "" })).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      Checked 2 installs across 3 packages (no changes)"
+    `);
     expect(await pkgText(dir)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
-    await run(dir, "update", "--latest");
+    expect(await run(dir, ["update", "--latest"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      1 package installed"
+    `);
     await expectCatalog(dir, { "no-deps": "=2.0.0" });
-    expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
+    expect(await installed(dir, "no-deps")).toStrictEqual({ "no-deps": "no-deps@2.0.0" });
     await expectInSync(dir, ["", PKG1]);
   });
 
   test("bun add --catalog --filter", async () => {
     const dir = await setup(CATALOG_REPO());
-    await run(dir, "add", "a-dep", "--catalog", "--filter", "pkg1");
-    expect((await pkg(dir)).workspaces.catalog["a-dep"]).toBe("^1.0.10");
-    expect((await lock(dir)).catalog["a-dep"]).toBe("^1.0.10");
-    expect((await pkg(dir, PKG1)).dependencies["a-dep"]).toBe("catalog:");
+    expect(await run(dir, ["add", "a-dep", "--catalog", "--filter", "pkg1"])).toMatchInlineSnapshot(`
+      "bun add <version> (<revision>)
+
+      installed a-dep@1.0.10
+
+      1 package installed"
+    `);
+    await expectCatalog(dir, { "no-deps": "^1.0.0", aliased: "npm:no-deps", "a-dep": "^1.0.10" });
+    expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({
+      "no-deps": "catalog:",
+      aliased: "catalog:",
+      "a-dep": "catalog:",
+    });
     await expectInSync(dir, ["", PKG1]);
   });
 });
 
 describe.concurrent("$ref overrides", () => {
-  test("$name follows the rewritten dependency; a literal override stays as written", async () => {
-    const overrides = { "no-deps": "$no-deps", "one-range-dep": "1.0.0" };
-    const dir = await setup({
-      "package.json": root({ dependencies: { "no-deps": "1.0.0", "one-range-dep": "1.0.0" }, overrides }),
-    });
-    await writePkg(dir, root({ dependencies: { "no-deps": "^1.0.0", "one-range-dep": "1.0.0" }, overrides }));
-    await run(dir, "update");
-    const manifest = await pkg(dir);
-    expect(manifest.dependencies).toStrictEqual({ "no-deps": "^1.1.0", "one-range-dep": "1.0.0" });
-    expect(manifest.overrides).toStrictEqual(overrides);
-    expect((await lock(dir)).overrides).toStrictEqual({ "no-deps": "^1.1.0", "one-range-dep": "1.0.0" });
-    await expectInSync(dir);
-  });
+  test("$name and $alias follow the rewritten row; a literal override stays as written", async () => {
+    const overrides = { "no-deps": "$no-deps", "one-range-dep": "1.0.0", a1: "$a1" };
+    const dependencies = { "no-deps": "1.0.0", "one-range-dep": "1.0.0", a1: "npm:no-deps@^1.0.0" };
+    const dir = await setup({ "package.json": root({ dependencies, overrides }) });
+    await writePkg(dir, root({ dependencies: { ...dependencies, "no-deps": "^1.0.0" }, overrides }));
+    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
 
-  test("$alias follows the rewritten alias", async () => {
-    const dir = await setup({
-      "package.json": root({ dependencies: { a1: "npm:no-deps@^1.0.0" }, overrides: { a1: "$a1" } }),
+      ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
+
+      + a1@1.1.0
+
+      1 package installed"
+    `);
+    const manifest = await pkg(dir);
+    expect(manifest.dependencies).toStrictEqual({
+      "no-deps": "^1.1.0",
+      "one-range-dep": "1.0.0",
+      a1: "npm:no-deps@^1.1.0",
     });
-    await run(dir, "update");
-    expect((await pkg(dir)).dependencies).toStrictEqual({ a1: "npm:no-deps@^1.1.0" });
-    expect((await lock(dir)).overrides).toStrictEqual({ a1: "npm:no-deps@^1.1.0" });
+    expect(manifest.overrides).toStrictEqual(overrides);
+    expect((await lock(dir)).overrides).toStrictEqual({
+      "no-deps": "^1.1.0",
+      "one-range-dep": "1.0.0",
+      a1: "npm:no-deps@^1.1.0",
+    });
     await expectInSync(dir);
   });
 });
@@ -816,12 +1099,11 @@ describe.concurrent("bumping a direct dependency re-points its dependents", () =
     ["binary", false],
   ])("bun install after editing package.json (%s lockfile)", async (_, text) => {
     const dir = await setup({ "package.json": deps("1.0.0") }, { text });
-    expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.0.0" });
+    expect(await installed(dir, "no-deps")).toStrictEqual({ "no-deps": "no-deps@1.0.0" });
     expect(await nested(dir)).toBe(false);
 
-    await writePkg(dir, deps("1.0.1"));
-    await runBunInstall(envFor(dir), dir);
-    expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.0.1" });
+    await reinstall(dir, deps("1.0.1"));
+    expect(await installed(dir, "no-deps")).toStrictEqual({ "no-deps": "no-deps@1.0.1" });
     expect(await nested(dir)).toBe(false);
     if (text) {
       const { packages } = await lock(dir);
@@ -829,19 +1111,18 @@ describe.concurrent("bumping a direct dependency re-points its dependents", () =
       expect(packages["no-deps"][0]).toBe("no-deps@1.0.1");
     }
 
-    await writePkg(dir, deps("2.0.0"));
-    await runBunInstall(envFor(dir), dir);
-    expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
-    expect(await installed(dir, "one-range-dep/node_modules/no-deps")).toMatchObject({ version: "1.0.1" });
+    await reinstall(dir, deps("2.0.0"));
+    expect(await installed(dir, "no-deps", "one-range-dep/node_modules/no-deps")).toStrictEqual({
+      "no-deps": "no-deps@2.0.0",
+      "one-range-dep/node_modules/no-deps": "no-deps@1.0.1",
+    });
     if (!text) return;
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.1", "no-deps@2.0.0"]);
+    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.1", "no-deps@2.0.0", "one-range-dep@1.0.0"]);
 
-    await writePkg(dir, deps());
-    await runBunInstall(envFor(dir), dir);
-    expect(await resolutions(dir, "no-deps")).toStrictEqual(["no-deps@1.0.1"]);
+    await reinstall(dir, deps());
+    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.1", "one-range-dep@1.0.0"]);
 
-    await writePkg(dir, deps("1.0.0"));
-    await runBunInstall(envFor(dir), dir);
+    await reinstall(dir, deps("1.0.0"));
     const { packages } = await lock(dir);
     expect(packages["no-deps"][0]).toBe("no-deps@1.0.0");
     expect(packages["one-range-dep/no-deps"][0]).toBe("no-deps@1.0.1");
@@ -862,7 +1143,13 @@ describe.concurrent("bumping a direct dependency re-points its dependents", () =
   test("bun update", async () => {
     const dir = await setup({ "package.json": deps("1.0.0") });
     await writePkg(dir, deps("^1.0.0"));
-    await run(dir, "update");
+    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
+      "bun update <version> (<revision>)
+
+      ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
+
+      1 package installed"
+    `);
     const { packages } = await lock(dir);
     expect(packages["no-deps"][0]).toBe("no-deps@1.1.0");
     expect(packages["one-range-dep/no-deps"]).toBeUndefined();

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -35,10 +35,10 @@ const duplicateWarning = (rest = "") =>
 
 // Both streams come back normalized for inline snapshots. stderr also loses the two progress lines every resolving
 // run prints, so callers assert the rest of it exactly.
-async function tryRun(dir: string, args: string[], cwd = "") {
+async function tryRun(dir: string, rel: string, ...args: string[]) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...args],
-    cwd: join(dir, cwd),
+    cwd: join(dir, rel),
     env: envFor(dir),
     stdout: "pipe",
     stderr: "pipe",
@@ -52,21 +52,26 @@ async function tryRun(dir: string, args: string[], cwd = "") {
   };
 }
 
-// A run that rewrites bun.lock says so on stderr and nothing else. `stderr` pins a different expectation: "" for a
-// run that must not write, or the warning a run is known to print.
-async function run(dir: string, args: string[], opts: { cwd?: string; stderr?: string | RegExp } = {}) {
-  const { stdout, stderr, exitCode } = await tryRun(dir, args, opts.cwd);
-  const expected = opts.stderr ?? SAVED;
+// A run that succeeds prints nothing to stderr but `Saved lockfile`, and that only when it rewrote bun.lock. A case
+// whose point is that nothing may be written checks that `stderr` is empty.
+async function runIn(dir: string, rel: string, ...args: string[]) {
+  const { stdout, stderr, exitCode } = await tryRun(dir, rel, ...args);
+  expect(stderr).toMatch(/^(?:Saved lockfile)?$/);
+  expect(exitCode).toBe(0);
+  return { stdout, stderr };
+}
+
+const run = (dir: string, ...args: string[]) => runIn(dir, "", ...args);
+
+// An install rewrites bun.lock unless `--frozen-lockfile` forbids it, and says so. `stderr` pins a different
+// expectation: "" for a second install that must leave bun.lock alone, or the warning a run is known to print.
+async function install(dir: string, opts: { frozen?: boolean; stderr?: string | RegExp } = {}) {
+  const { stderr, exitCode } = await tryRun(dir, "", "install", ...(opts.frozen ? ["--frozen-lockfile"] : []));
+  const expected = opts.stderr ?? (opts.frozen ? "" : SAVED);
   if (typeof expected === "string") expect(stderr).toBe(expected);
   else expect(stderr).toMatch(expected);
   expect(exitCode).toBe(0);
-  return stdout;
 }
-
-const install = (dir: string, opts: { frozen?: boolean; stderr?: string | RegExp } = {}) =>
-  run(dir, ["install", ...(opts.frozen ? ["--frozen-lockfile"] : [])], {
-    stderr: opts.stderr ?? (opts.frozen ? "" : SAVED),
-  });
 
 function json(contents: Json | string) {
   return typeof contents === "string" ? contents : JSON.stringify(contents, null, 2) + "\n";
@@ -91,19 +96,14 @@ const writePkg = (dir: string, contents: Json, rel = "") => write(join(dir, rel,
 const lockText = (dir: string) => file(join(dir, "bun.lock")).text();
 const lock = async (dir: string): Promise<Json> => Bun.JSONC.parse(await lockText(dir)) as Json;
 
-// Every `<name>@<version>` bun.lock resolved, sorted and deduplicated.
-async function resolved(dir: string): Promise<string[]> {
-  const entries = Object.values((await lock(dir)).packages) as [string, ...unknown[]][];
-  return [...new Set(entries.map(entry => entry[0]))].sort();
-}
+const installed = (dir: string, name: string): Promise<Json> =>
+  file(join(dir, "node_modules", name, "package.json")).json();
 
-// What node_modules/<name> holds for each name, as `<name>@<version>` (the package's own name, so an alias shows its target).
-async function installed(dir: string, ...names: string[]): Promise<Record<string, string>> {
-  const entries = names.map(async name => {
-    const manifest = await file(join(dir, "node_modules", name, "package.json")).json();
-    return [name, `${manifest.name}@${manifest.version}`];
-  });
-  return Object.fromEntries(await Promise.all(entries));
+// Every `<name>@<version>` bun.lock resolved (of one name, or of all), sorted and deduplicated.
+async function resolutions(dir: string, name?: string): Promise<string[]> {
+  const entries = Object.values((await lock(dir)).packages) as [string, ...unknown[]][];
+  const all = entries.map(entry => entry[0]).filter(res => name === undefined || res.startsWith(`${name}@`));
+  return [...new Set(all)].sort();
 }
 
 async function reinstall(dir: string, contents: Json, rel = "") {
@@ -188,7 +188,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
         dependencies: { "no-deps": "^1.0.0", aliased: "npm:no-deps@~1.0.0", bare: "npm:no-deps" },
       }),
     });
-    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.1 -> 1.1.0 (v2.0.0 available)
@@ -198,11 +198,9 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     const expected = { "no-deps": "^1.1.0", aliased: "npm:no-deps@~1.0.1", bare: "npm:no-deps" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
-    expect(await installed(dir, "no-deps", "aliased", "bare")).toStrictEqual({
-      "no-deps": "no-deps@1.1.0",
-      aliased: "no-deps@1.0.1",
-      bare: "no-deps@2.0.0",
-    });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.1.0" });
+    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "1.0.1" });
+    expect(await installed(dir, "bare")).toMatchObject({ name: "no-deps", version: "2.0.0" });
     await expectInSync(dir, [""], { reinstall: true });
   });
 
@@ -217,7 +215,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
         },
       }),
     });
-    expect(await run(dir, ["update", "--latest"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update", "--latest")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ aliased 1.0.1 -> 2.0.0
@@ -234,12 +232,10 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""]).toStrictEqual({ name: "foo", dependencies: expected });
-    expect(await installed(dir, "no-deps", "aliased", "types", "tagged")).toStrictEqual({
-      "no-deps": "no-deps@2.0.0",
-      aliased: "no-deps@2.0.0",
-      types: "@types/no-deps@2.0.0",
-      tagged: "dep-with-tags@3.0.0",
-    });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
+    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "2.0.0" });
+    expect(await installed(dir, "types")).toMatchObject({ name: "@types/no-deps", version: "2.0.0" });
+    expect(await installed(dir, "tagged")).toMatchObject({ name: "dep-with-tags", version: "3.0.0" });
     await expectInSync(dir);
   });
 
@@ -263,7 +259,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     };
     const dir = await setup({ "package.json": root({ dependencies: pinned }) });
     await reinstall(dir, root({ dependencies: ranges }));
-    expect(await resolved(dir)).toStrictEqual([
+    expect(await resolutions(dir)).toStrictEqual([
       "@types/no-deps@1.0.0",
       "a-dep@1.0.1",
       "dep-with-tags@1.0.0",
@@ -271,7 +267,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
       "what-bin@1.0.0",
     ]);
     const pkgBefore = await pkgText(dir);
-    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ @types/no-deps 1.0.0 -> 2.0.0
@@ -285,39 +281,35 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     `);
     expect(await pkgText(dir)).toBe(pkgBefore);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(ranges);
-    expect(await resolved(dir)).toStrictEqual([
+    expect(await resolutions(dir)).toStrictEqual([
       "@types/no-deps@2.0.0",
       "a-dep@1.0.10",
       "dep-with-tags@1.0.1",
       "no-deps@2.0.0",
       "what-bin@1.5.0",
     ]);
-    expect(await installed(dir, ...Object.keys(ranges))).toStrictEqual({
-      "no-deps": "no-deps@2.0.0",
-      "a-dep": "a-dep@1.0.10",
-      "what-bin": "what-bin@1.5.0",
-      "@types/no-deps": "@types/no-deps@2.0.0",
-      "dep-with-tags": "dep-with-tags@1.0.1",
-      aliased: "no-deps@2.0.0",
-    });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
+    expect(await installed(dir, "a-dep")).toMatchObject({ version: "1.0.10" });
+    expect(await installed(dir, "what-bin")).toMatchObject({ version: "1.5.0" });
+    expect(await installed(dir, "@types/no-deps")).toMatchObject({ version: "2.0.0" });
+    expect(await installed(dir, "dep-with-tags")).toMatchObject({ version: "1.0.1" });
+    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "2.0.0" });
     await expectInSync(dir);
   });
 
   test("bun update on a * range that already resolves the newest version leaves both files byte-identical, --latest rewrites it", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "*" } }) });
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
-    expect(await run(dir, ["update"], { stderr: "" })).toMatchInlineSnapshot(`
+    const { stdout, stderr } = await run(dir, "update");
+    expect(stderr).toBe("");
+    expect(stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       Checked 1 install across 2 packages (no changes)"
     `);
     expect(await pkgText(dir)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
-    expect(await run(dir, ["update", "--latest"])).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      Checked 1 install across 2 packages (no changes)"
-    `);
+    expect((await run(dir, "update", "--latest")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
     await expectInSync(dir);
@@ -325,11 +317,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("bun update <name> keeps the pin style", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "~1.0.0" } }) });
-    expect(await run(dir, ["update", "no-deps"])).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      Checked 1 install across 2 packages (no changes)"
-    `);
+    expect((await run(dir, "update", "no-deps")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     await expectInSync(dir);
@@ -337,7 +325,9 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("bun update <name> on an exact literal", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "1.0.0" } }) });
-    expect(await run(dir, ["update", "no-deps"], { stderr: "" })).toMatchInlineSnapshot(`
+    const { stdout, stderr } = await run(dir, "update", "no-deps");
+    expect(stderr).toBe("");
+    expect(stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       Checked 1 install across 2 packages (no changes)"
@@ -350,7 +340,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
   test("bun update <name> keeps a * literal and leaves the unnamed sibling alone", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" } }) });
     await reinstall(dir, root({ dependencies: { "no-deps": "*", "a-dep": "^1.0.1" } }));
-    expect(await run(dir, ["update", "no-deps"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update", "no-deps")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.0 -> 2.0.0
@@ -360,17 +350,13 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     const expected = { "no-deps": "*", "a-dep": "^1.0.1" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
-    expect(await resolved(dir)).toStrictEqual(["a-dep@1.0.1", "no-deps@2.0.0"]);
+    expect(await resolutions(dir)).toStrictEqual(["a-dep@1.0.1", "no-deps@2.0.0"]);
     await expectInSync(dir);
   });
 
   test("bun update <alias> keeps the alias", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { aliased: "npm:no-deps@~1.0.0" } }) });
-    expect(await run(dir, ["update", "aliased"])).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      Checked 1 install across 2 packages (no changes)"
-    `);
+    expect((await run(dir, "update", "aliased")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: "npm:no-deps@~1.0.1" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ aliased: "npm:no-deps@~1.0.1" });
     await expectInSync(dir);
@@ -378,7 +364,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("bun update <name>@<range>", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "~1.0.0" } }) });
-    expect(await run(dir, ["update", "no-deps@^1.0.0"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update", "no-deps@^1.0.0")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.1 -> 1.1.0 (v2.0.0 available)
@@ -395,11 +381,9 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("bun update <name> with the name in dependencies and devDependencies", async () => {
     const dir = await setup({ "package.json": inBothGroups("~1.0.0") }, { stderr: duplicateWarning(SAVED) });
-    expect(await run(dir, ["update", "no-deps"], { stderr: duplicateWarning(SAVED) })).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      Checked 1 install across 2 packages (no changes)"
-    `);
+    const { stderr, exitCode } = await tryRun(dir, "", "update", "no-deps");
+    expect(stderr).toMatch(duplicateWarning(SAVED));
+    expect(exitCode).toBe(0);
     const manifest = await pkg(dir);
     expect(manifest.dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     expect(manifest.devDependencies).toStrictEqual({ "no-deps": "~1.0.0" });
@@ -409,7 +393,10 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
   test("bun update with the name in dependencies and devDependencies moves one group", async () => {
     const dir = await setup({ "package.json": inBothGroups("1.0.0") }, { stderr: duplicateWarning(SAVED) });
     await writePkg(dir, inBothGroups("~1.0.0"));
-    expect(await run(dir, ["update"], { stderr: duplicateWarning(SAVED) })).toMatchInlineSnapshot(`
+    const { stdout, stderr, exitCode } = await tryRun(dir, "", "update");
+    expect(stderr).toMatch(duplicateWarning(SAVED));
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.0 -> 1.0.1 (v2.0.0 available)
@@ -426,11 +413,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("install.exact", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "^1.0.0" } }) }, { exact: true });
-    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      Checked 1 install across 2 packages (no changes)"
-    `);
+    expect((await run(dir, "update")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "1.1.0" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": "1.1.0" });
     await expectInSync(dir);
@@ -456,7 +439,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
       { compress: "gzip" },
     );
     await install(dir);
-    await run(dir, ["update", ...args]);
+    expect((await run(dir, "update", ...args)).stderr).toBe(SAVED);
     const expected = { ...dependencies, "no-deps": args.length ? "^2.0.0" : "^1.1.0" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
@@ -466,8 +449,8 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
   test("bun update -r keeps a member's 1.x literal", async () => {
     const dir = await setup(MONOREPO({ dependencies: { "no-deps": "1.0.0" } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "1.x" } }), PKG1);
-    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
-    expect(await run(dir, ["update", "-r"])).toMatchInlineSnapshot(`
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
+    expect((await run(dir, "update", "-r")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
@@ -476,27 +459,27 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     `);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "1.x" });
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual({ "no-deps": "1.x" });
-    expect(await resolved(dir)).toStrictEqual(["no-deps@1.1.0", "pkg1@workspace:packages/pkg1"]);
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.1.0", "pkg1@workspace:packages/pkg1"]);
     await expectInSync(dir, ["", PKG1]);
   });
 
   test("bun update -r bumps a member's range and keeps its dist-tag literal", async () => {
     const dir = await setup(MONOREPO({ dependencies: { "dep-with-tags": "pre-2", "no-deps": "~1.0.0" } }));
-    expect(await run(dir, ["update", "-r"])).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      Checked 3 installs across 4 packages (no changes)"
-    `);
+    expect((await run(dir, "update", "-r")).stderr).toBe(SAVED);
     const expected = { "dep-with-tags": "pre-2", "no-deps": "~1.0.1" };
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual(expected);
-    expect(await resolved(dir)).toStrictEqual(["dep-with-tags@2.0.1", "no-deps@1.0.1", "pkg1@workspace:packages/pkg1"]);
+    expect(await resolutions(dir)).toStrictEqual([
+      "dep-with-tags@2.0.1",
+      "no-deps@1.0.1",
+      "pkg1@workspace:packages/pkg1",
+    ]);
     await expectInSync(dir, ["", PKG1]);
   });
 
   test("bun update -r --latest replaces a member's dist-tag literal with the latest version", async () => {
     const dir = await setup(MONOREPO({ dependencies: { "dep-with-tags": "pre-2", "no-deps": "~1.0.0" } }));
-    expect(await run(dir, ["update", "-r", "--latest"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update", "-r", "--latest")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ dep-with-tags 2.0.1 -> 3.0.0
@@ -507,7 +490,11 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     const expected = { "dep-with-tags": "^3.0.0", "no-deps": "~2.0.0" };
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual(expected);
-    expect(await resolved(dir)).toStrictEqual(["dep-with-tags@3.0.0", "no-deps@2.0.0", "pkg1@workspace:packages/pkg1"]);
+    expect(await resolutions(dir)).toStrictEqual([
+      "dep-with-tags@3.0.0",
+      "no-deps@2.0.0",
+      "pkg1@workspace:packages/pkg1",
+    ]);
     await expectInSync(dir, ["", PKG1]);
   });
 
@@ -515,11 +502,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     const dir = await setup(
       MONOREPO({ dependencies: { "no-deps": "~1.0.0", "a-dep": "^1.0.1" } }, { dependencies: { "no-deps": "~1.0.0" } }),
     );
-    expect(await run(dir, ["update", "no-deps", "--filter", "pkg1"])).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      Checked 3 installs across 4 packages (no changes)"
-    `);
+    expect((await run(dir, "update", "no-deps", "--filter", "pkg1")).stderr).toBe(SAVED);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1", "a-dep": "^1.0.1" });
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
     await expectInSync(dir, ["", PKG1], { reinstall: true });
@@ -532,7 +515,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
         { pkg1: { dependencies: { "a-dep": "1.0.1" } }, pkg2: { dependencies: { "no-deps": "~1.0.0" } } },
       ),
     );
-    expect(await run(dir, ["update", "no-deps", "-r", "--latest"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update", "no-deps", "-r", "--latest")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.1 -> 2.0.0
@@ -542,7 +525,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "~2.0.0" });
     expect((await pkg(dir, PKG2)).dependencies).toStrictEqual({ "no-deps": "~2.0.0" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "a-dep": "1.0.1" });
-    expect(await resolved(dir)).toStrictEqual([
+    expect(await resolutions(dir)).toStrictEqual([
       "a-dep@1.0.1",
       "no-deps@2.0.0",
       "pkg1@workspace:packages/pkg1",
@@ -557,8 +540,8 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     );
     await writePkg(dir, wsRoot({ dependencies: { "no-deps": "^1.0.0" } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
-    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
-    expect(await run(dir, ["update", "no-deps@1.0.1", "-r"])).toMatchInlineSnapshot(`
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
+    expect((await run(dir, "update", "no-deps@1.0.1", "-r")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.0 -> 1.0.1 (v2.0.0 available)
@@ -567,7 +550,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^1.0.1" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
-    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.1", "pkg1@workspace:packages/pkg1"]);
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.1", "pkg1@workspace:packages/pkg1"]);
     await expectInSync(dir, ["", PKG1]);
   });
 
@@ -575,7 +558,9 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     const dir = await setup(MONOREPO({ dependencies: { "no-deps": "1.0.0" } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir, PKG1), lockText(dir)]);
-    expect(await run(dir, ["update", "no-deps", "-r", "--dry-run"], { stderr: "" })).toMatchInlineSnapshot(`
+    const { stdout, stderr } = await run(dir, "update", "no-deps", "-r", "--dry-run");
+    expect(stderr).toBe("");
+    expect(stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.0 -> 1.0.1 (v2.0.0 available)
@@ -588,11 +573,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("bun update from a workspace member", async () => {
     const dir = await setup(MONOREPO({ dependencies: { "no-deps": "~1.0.0" } }));
-    expect(await run(dir, ["update"], { cwd: PKG1 })).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      Checked 2 installs across 3 packages (no changes)"
-    `);
+    expect((await runIn(dir, PKG1, "update")).stderr).toBe(SAVED);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     await expectInSync(dir, ["", PKG1]);
@@ -606,9 +587,9 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     );
     await writePkg(dir, wsRoot({ dependencies: { "no-deps": "^1.0.0" } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
-    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
 
-    expect(await run(dir, ["update", "no-deps"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update", "no-deps")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
@@ -618,19 +599,13 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^1.1.0" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
-    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.0", "no-deps@1.1.0", "pkg1@workspace:packages/pkg1"]);
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.0", "no-deps@1.1.0", "pkg1@workspace:packages/pkg1"]);
     await expectInSync(dir, ["", PKG1]);
 
-    expect(await run(dir, ["update", "no-deps", "-r"])).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ no-deps 1.1.0 -> 1.0.1 (v2.0.0 available)
-
-      1 package installed"
-    `);
+    expect((await run(dir, "update", "no-deps", "-r")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^1.1.0" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
-    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.1", "no-deps@1.1.0", "pkg1@workspace:packages/pkg1"]);
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.1", "no-deps@1.1.0", "pkg1@workspace:packages/pkg1"]);
     await expectInSync(dir, ["", PKG1]);
   });
 
@@ -643,13 +618,13 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     );
     await writePkg(dir, member("pkg1", { dependencies: { "no-deps": "^1.0.0" } }), PKG1);
     await reinstall(dir, member("pkg2", { dependencies: { "no-deps": "~1.0.0" } }), PKG2);
-    expect(await resolved(dir)).toStrictEqual([
+    expect(await resolutions(dir)).toStrictEqual([
       "no-deps@1.0.0",
       "pkg1@workspace:packages/pkg1",
       "pkg2@workspace:packages/pkg2",
     ]);
 
-    expect(await run(dir, ["update", "no-deps"], { cwd: PKG1 })).toMatchInlineSnapshot(`
+    expect((await runIn(dir, PKG1, "update", "no-deps")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
@@ -659,7 +634,7 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "^1.1.0" });
     expect((await pkg(dir, PKG2)).dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
     expect((await lock(dir)).workspaces[PKG2].dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
-    expect(await resolved(dir)).toStrictEqual([
+    expect(await resolutions(dir)).toStrictEqual([
       "no-deps@1.0.0",
       "no-deps@1.1.0",
       "pkg1@workspace:packages/pkg1",
@@ -678,13 +653,13 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     await writePkg(dir, wsRoot({ dependencies: { "no-deps": "^1.0.0" } }));
     await writePkg(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
     await reinstall(dir, member("pkg2", { dependencies: { "no-deps": "~1.0.0" } }), PKG2);
-    expect(await resolved(dir)).toStrictEqual([
+    expect(await resolutions(dir)).toStrictEqual([
       "no-deps@1.0.0",
       "pkg1@workspace:packages/pkg1",
       "pkg2@workspace:packages/pkg2",
     ]);
 
-    expect(await run(dir, ["update", "no-deps", "--filter", "pkg1"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update", "no-deps", "--filter", "pkg1")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.0 -> 1.0.1 (v2.0.0 available)
@@ -697,7 +672,7 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     const { workspaces } = await lock(dir);
     expect(workspaces[""].dependencies).toStrictEqual({ "no-deps": "^1.0.0" });
     expect(workspaces[PKG2].dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
-    expect(await resolved(dir)).toStrictEqual([
+    expect(await resolutions(dir)).toStrictEqual([
       "no-deps@1.0.1",
       "pkg1@workspace:packages/pkg1",
       "pkg2@workspace:packages/pkg2",
@@ -709,7 +684,7 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     const dir = await setup(WORKSPACES({}, { pkg1: { dependencies: { "no-deps": "1.0.0" } } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir, PKG1), lockText(dir)]);
-    const { stdout, stderr, exitCode } = await tryRun(dir, ["update", "no-deps"]);
+    const { stdout, stderr, exitCode } = await tryRun(dir, "", "update", "no-deps");
     expect(stderr).toMatchInlineSnapshot(`
       "error: "no-deps" is not a dependency of this workspace
           bun update -r no-deps
@@ -723,34 +698,26 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
 });
 
 describe.concurrent("npm: aliases", () => {
-  const ROWS: { before: string; args: string[]; after: string; installs: string; stderr?: string }[] = [
-    {
-      before: "npm:no-deps@~1.0.0",
-      args: ["aliased", "--latest"],
-      after: "npm:no-deps@~2.0.0",
-      installs: "no-deps@2.0.0",
-    },
-    // A bare alias already resolves to the newest version, so this update finds nothing to write.
-    { before: "npm:no-deps", args: ["aliased"], after: "npm:no-deps", installs: "no-deps@2.0.0", stderr: "" },
-    { before: "npm:no-deps@~1.0.0", args: ["aliased@2.0.0"], after: "npm:no-deps@~2.0.0", installs: "no-deps@2.0.0" },
-    { before: "npm:no-deps@^1.0.0", args: ["aliased"], after: "npm:no-deps@^1.1.0", installs: "no-deps@1.1.0" },
+  const ROWS: { before: string; args: string[]; after: string; installs: string }[] = [
+    { before: "npm:no-deps@~1.0.0", args: ["aliased", "--latest"], after: "npm:no-deps@~2.0.0", installs: "2.0.0" },
+    { before: "npm:no-deps", args: ["aliased"], after: "npm:no-deps", installs: "2.0.0" },
+    { before: "npm:no-deps@~1.0.0", args: ["aliased@2.0.0"], after: "npm:no-deps@~2.0.0", installs: "2.0.0" },
+    { before: "npm:no-deps@^1.0.0", args: ["aliased"], after: "npm:no-deps@^1.1.0", installs: "1.1.0" },
   ];
 
-  test.each(ROWS)(
-    '"aliased": "$before" + bun update $args -> "$after"',
-    async ({ before, args, after, installs, stderr }) => {
-      const dir = await setup({ "package.json": root({ dependencies: { aliased: before } }) });
-      await run(dir, ["update", ...args], { stderr });
-      expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: after });
-      expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ aliased: after });
-      expect(await installed(dir, "aliased")).toStrictEqual({ aliased: installs });
-      await expectInSync(dir);
-    },
-  );
+  test.each(ROWS)('"aliased": "$before" + bun update $args -> "$after"', async ({ before, args, after, installs }) => {
+    const dir = await setup({ "package.json": root({ dependencies: { aliased: before } }) });
+    const { stderr } = await run(dir, "update", ...args);
+    expect(stderr).toBe(before === after ? "" : SAVED);
+    expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: after });
+    expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ aliased: after });
+    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: installs });
+    await expectInSync(dir);
+  });
 
   test("bun update <alias>@npm:<other> retargets the alias", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { aliased: "npm:no-deps@~1.0.0" } }) });
-    expect(await run(dir, ["update", "aliased@npm:a-dep"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update", "aliased@npm:a-dep")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ aliased 1.0.1 -> 1.0.10
@@ -758,14 +725,14 @@ describe.concurrent("npm: aliases", () => {
       1 package installed"
     `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: "npm:a-dep@~1.0.10" });
-    expect(await installed(dir, "aliased")).toStrictEqual({ aliased: "a-dep@1.0.10" });
+    expect(await installed(dir, "aliased")).toMatchObject({ name: "a-dep", version: "1.0.10" });
     await expectInSync(dir);
   });
 
   test("bun update <new>@npm:<scoped>@<range> refuses to add; bun add keeps the target", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "a-dep": "1.0.1" } }) });
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
-    const { stdout, stderr, exitCode } = await tryRun(dir, ["update", "new-alias@npm:@types/no-deps@^1.0.0"]);
+    const { stdout, stderr, exitCode } = await tryRun(dir, "", "update", "new-alias@npm:@types/no-deps@^1.0.0");
     expect(stderr).toMatchInlineSnapshot(`
       "error: "new-alias" is not in bun.lock
           bun add new-alias"
@@ -775,7 +742,7 @@ describe.concurrent("npm: aliases", () => {
     expect(await pkgText(dir)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
 
-    expect(await run(dir, ["add", "new-alias@npm:@types/no-deps@^1.0.0"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "add", "new-alias@npm:@types/no-deps@^1.0.0")).stdout).toMatchInlineSnapshot(`
       "bun add <version> (<revision>)
 
       installed new-alias@npm:@types/no-deps@1.0.0
@@ -785,13 +752,13 @@ describe.concurrent("npm: aliases", () => {
     const expected = { "a-dep": "1.0.1", "new-alias": "npm:@types/no-deps@^1.0.0" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
-    expect(await installed(dir, "new-alias")).toStrictEqual({ "new-alias": "@types/no-deps@1.0.0" });
+    expect(await installed(dir, "new-alias")).toMatchObject({ name: "@types/no-deps", version: "1.0.0" });
     await expectInSync(dir);
   });
 
   test("bun update <alias>@npm:<scoped>@<range> retargets a scoped alias in the declared pin style", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { aliased: "npm:no-deps@~1.0.0" } }) });
-    expect(await run(dir, ["update", "aliased@npm:@types/no-deps@^1.0.0"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update", "aliased@npm:@types/no-deps@^1.0.0")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ aliased 1.0.1 -> 1.0.0 (v2.0.0 available)
@@ -799,44 +766,47 @@ describe.concurrent("npm: aliases", () => {
       1 package installed"
     `);
     expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: "npm:@types/no-deps@~1.0.0" });
-    expect(await installed(dir, "aliased")).toStrictEqual({ aliased: "@types/no-deps@1.0.0" });
+    expect(await installed(dir, "aliased")).toMatchObject({ name: "@types/no-deps", version: "1.0.0" });
     await expectInSync(dir);
   });
 });
 
 describe.concurrent("bun add", () => {
   // One `bun add` per pin style of the name itself; the aliases ride along to cover the `<alias>@npm:` spellings.
+  // Every entry installs no-deps; `installs` is the version each name gets.
   const ADDS: { args: string[]; expected: Record<string, string>; installs: Record<string, string> }[] = [
     {
       args: ["no-deps", "a@npm:no-deps@~1.0.0", "c@npm:no-deps"],
       expected: { "no-deps": "^2.0.0", a: "npm:no-deps@~1.0.0", c: "npm:no-deps@^2.0.0" },
-      installs: { "no-deps": "no-deps@2.0.0", a: "no-deps@1.0.1", c: "no-deps@2.0.0" },
+      installs: { "no-deps": "2.0.0", a: "1.0.1", c: "2.0.0" },
     },
     {
       args: ["no-deps", "x@npm:no-deps", "--exact"],
       expected: { "no-deps": "2.0.0", x: "npm:no-deps@2.0.0" },
-      installs: { "no-deps": "no-deps@2.0.0", x: "no-deps@2.0.0" },
+      installs: { "no-deps": "2.0.0", x: "2.0.0" },
     },
     {
       args: ["no-deps@~1.0.0", "b@npm:no-deps@latest"],
       expected: { "no-deps": "~1.0.0", b: "npm:no-deps@^2.0.0" },
-      installs: { "no-deps": "no-deps@1.0.1", b: "no-deps@2.0.0" },
+      installs: { "no-deps": "1.0.1", b: "2.0.0" },
     },
-    { args: ["no-deps@latest"], expected: { "no-deps": "^2.0.0" }, installs: { "no-deps": "no-deps@2.0.0" } },
+    { args: ["no-deps@latest"], expected: { "no-deps": "^2.0.0" }, installs: { "no-deps": "2.0.0" } },
   ];
 
   test.each(ADDS)("bun add $args", async ({ args, expected, installs }) => {
     const dir = await setup({ "package.json": root({}) }, { install: false });
-    await run(dir, ["add", ...args]);
+    expect((await run(dir, "add", ...args)).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
-    expect(await installed(dir, ...Object.keys(expected))).toStrictEqual(installs);
+    for (const [name, version] of Object.entries(installs)) {
+      expect(await installed(dir, name)).toMatchObject({ name: "no-deps", version });
+    }
     await expectInSync(dir);
   });
 
   test("bun add <workspace>@workspace:*", async () => {
     const dir = await setup(MONOREPO());
-    expect(await run(dir, ["add", "pkg1@workspace:*"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "add", "pkg1@workspace:*")).stdout).toMatchInlineSnapshot(`
       "bun add <version> (<revision>)
 
       installed pkg1@workspace:packages/pkg1
@@ -849,7 +819,7 @@ describe.concurrent("bun add", () => {
 
   test("bun add --filter", async () => {
     const dir = await setup(MONOREPO());
-    expect(await run(dir, ["add", "x@npm:no-deps@latest", "--filter", "pkg1"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "add", "x@npm:no-deps@latest", "--filter", "pkg1")).stdout).toMatchInlineSnapshot(`
       "bun add <version> (<revision>)
 
       installed x@npm:no-deps@2.0.0
@@ -863,7 +833,7 @@ describe.concurrent("bun add", () => {
 
   test("bun add --lockfile-only", async () => {
     const dir = await setup({ "package.json": root({}) }, { install: false });
-    expect(await run(dir, ["add", "no-deps", "--lockfile-only"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "add", "no-deps", "--lockfile-only")).stdout).toMatchInlineSnapshot(`
       "bun add <version> (<revision>)
 
       Saved bun.lock (2 packages)"
@@ -875,7 +845,7 @@ describe.concurrent("bun add", () => {
 
   test("bun add --trust", async () => {
     const dir = await setup({ "package.json": root({}) }, { install: false });
-    expect(await run(dir, ["add", "uses-what-bin@1.0.0", "--trust"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "add", "uses-what-bin@1.0.0", "--trust")).stdout).toMatchInlineSnapshot(`
       "bun add <version> (<revision>)
 
       installed uses-what-bin@1.0.0
@@ -893,7 +863,7 @@ describe.concurrent("bun add", () => {
 
   test("bun add --trust of a package already listed in devDependencies", async () => {
     const dir = await setup({ "package.json": root({ devDependencies: { "uses-what-bin": "1.0.0" } }) });
-    expect(await run(dir, ["add", "uses-what-bin@1.0.0", "--trust"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "add", "uses-what-bin@1.0.0", "--trust")).stdout).toMatchInlineSnapshot(`
       "bun add <version> (<revision>)
 
       installed uses-what-bin@1.0.0
@@ -934,20 +904,14 @@ describe.concurrent("catalogs", () => {
 
   test("bun update bumps ranges in place and keeps bare aliases, dist-tags and 1.x entries", async () => {
     const dir = await setup(CATALOG_REPO(FULL_CATALOG));
-    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      Done! Checked 7 packages (no changes)"
-    `);
+    expect((await run(dir, "update")).stderr).toBe(SAVED);
     await expectCatalog(dir, { ...FULL_CATALOG, "no-deps": "^1.1.0", tilde: "npm:no-deps@~1.0.1" });
-    expect(await installed(dir, ...Object.keys(FULL_CATALOG))).toStrictEqual({
-      "no-deps": "no-deps@1.1.0",
-      aliased: "no-deps@2.0.0",
-      "dep-with-tags": "dep-with-tags@2.0.1",
-      "a-dep": "a-dep@1.0.10",
-      tilde: "no-deps@1.0.1",
-      tagged: "dep-with-tags@2.0.1",
-    });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.1.0" });
+    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "2.0.0" });
+    expect(await installed(dir, "dep-with-tags")).toMatchObject({ version: "2.0.1" });
+    expect(await installed(dir, "a-dep")).toMatchObject({ version: "1.0.10" });
+    expect(await installed(dir, "tilde")).toMatchObject({ name: "no-deps", version: "1.0.1" });
+    expect(await installed(dir, "tagged")).toMatchObject({ name: "dep-with-tags", version: "2.0.1" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual(FULL_CATALOG_MEMBER_DEPS);
     await expectInSync(dir, ["", PKG1]);
   });
@@ -956,7 +920,7 @@ describe.concurrent("catalogs", () => {
     "bun update --latest from '%s' rewrites every entry and keeps the alias prefixes",
     async cwd => {
       const dir = await setup(CATALOG_REPO(FULL_CATALOG));
-      await run(dir, ["update", "--latest"], { cwd });
+      expect((await runIn(dir, cwd, "update", "--latest")).stderr).toBe(SAVED);
       await expectCatalog(dir, {
         "no-deps": "^2.0.0",
         aliased: "npm:no-deps@^2.0.0",
@@ -965,14 +929,12 @@ describe.concurrent("catalogs", () => {
         tilde: "npm:no-deps@~2.0.0",
         tagged: "npm:dep-with-tags@^3.0.0",
       });
-      expect(await installed(dir, ...Object.keys(FULL_CATALOG))).toStrictEqual({
-        "no-deps": "no-deps@2.0.0",
-        aliased: "no-deps@2.0.0",
-        "dep-with-tags": "dep-with-tags@3.0.0",
-        "a-dep": "a-dep@1.0.10",
-        tilde: "no-deps@2.0.0",
-        tagged: "dep-with-tags@3.0.0",
-      });
+      expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
+      expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "2.0.0" });
+      expect(await installed(dir, "dep-with-tags")).toMatchObject({ version: "3.0.0" });
+      expect(await installed(dir, "a-dep")).toMatchObject({ version: "1.0.10" });
+      expect(await installed(dir, "tilde")).toMatchObject({ name: "no-deps", version: "2.0.0" });
+      expect(await installed(dir, "tagged")).toMatchObject({ name: "dep-with-tags", version: "3.0.0" });
       expect((await pkg(dir, PKG1)).dependencies).toStrictEqual(FULL_CATALOG_MEMBER_DEPS);
       await expectInSync(dir, ["", PKG1]);
     },
@@ -981,26 +943,22 @@ describe.concurrent("catalogs", () => {
   test("bun update keeps a * catalog entry and moves only bun.lock", async () => {
     const dir = await setup(CATALOG_REPO({ "no-deps": "1.0.0" }));
     await reinstall(dir, wsRoot({ workspaces: { packages: ["packages/*"], catalog: { "no-deps": "*" } } }));
-    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
-    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      1 package installed"
-    `);
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
+    expect((await run(dir, "update")).stderr).toBe(SAVED);
     await expectCatalog(dir, { "no-deps": "*" });
-    expect(await resolved(dir)).toStrictEqual(["no-deps@2.0.0", "pkg1@workspace:packages/pkg1"]);
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@2.0.0", "pkg1@workspace:packages/pkg1"]);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "catalog:" });
     await expectInSync(dir, ["", PKG1]);
   });
 
   test.each([
-    [[], { "no-deps": "^1.1.0", aliased: "npm:no-deps@~1.0.1" }, "no-deps@1.1.0"],
-    [["--latest"], { "no-deps": "^2.0.0", aliased: "npm:no-deps@~2.0.0" }, "no-deps@2.0.0"],
+    [[], { "no-deps": "^1.1.0", aliased: "npm:no-deps@~1.0.1" }, "1.1.0"],
+    [["--latest"], { "no-deps": "^2.0.0", aliased: "npm:no-deps@~2.0.0" }, "2.0.0"],
   ])("bun update %j rewrites the singular catalog referenced as catalog:default", async (args, expected, version) => {
     const dir = await setup(CATALOG_REPO({ "no-deps": "^1.0.0", aliased: "npm:no-deps@~1.0.0" }, "catalog:default"));
-    await run(dir, ["update", ...args]);
+    expect((await run(dir, "update", ...args)).stderr).toBe(SAVED);
     await expectCatalog(dir, expected);
-    expect(await installed(dir, "no-deps")).toStrictEqual({ "no-deps": version });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({
       "no-deps": "catalog:default",
       aliased: "catalog:default",
@@ -1009,39 +967,37 @@ describe.concurrent("catalogs", () => {
   });
 
   test.each([
-    [[], { "no-deps": "1.1.0", aliased: "npm:no-deps@1.0.1" }, "no-deps@1.1.0"],
-    [["--latest"], { "no-deps": "2.0.0", aliased: "npm:no-deps@2.0.0" }, "no-deps@2.0.0"],
+    [[], { "no-deps": "1.1.0", aliased: "npm:no-deps@1.0.1" }, "1.1.0"],
+    [["--latest"], { "no-deps": "2.0.0", aliased: "npm:no-deps@2.0.0" }, "2.0.0"],
   ])("bun update %j with install.exact pins the catalog entries", async (args, expected, version) => {
     const dir = await setup(CATALOG_REPO({ "no-deps": "^1.0.0", aliased: "npm:no-deps@~1.0.0" }), { exact: true });
-    await run(dir, ["update", ...args]);
+    expect((await run(dir, "update", ...args)).stderr).toBe(SAVED);
     await expectCatalog(dir, expected);
-    expect(await installed(dir, "no-deps")).toStrictEqual({ "no-deps": version });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version });
     await expectInSync(dir, ["", PKG1]);
   });
 
   test("bun update --latest keeps the = prefix of a catalog entry", async () => {
     const dir = await setup(CATALOG_REPO({ "no-deps": "=1.0.0" }));
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
-    expect(await run(dir, ["update"], { stderr: "" })).toMatchInlineSnapshot(`
+    const { stdout, stderr } = await run(dir, "update");
+    expect(stderr).toBe("");
+    expect(stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       Checked 2 installs across 3 packages (no changes)"
     `);
     expect(await pkgText(dir)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
-    expect(await run(dir, ["update", "--latest"])).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      1 package installed"
-    `);
+    expect((await run(dir, "update", "--latest")).stderr).toBe(SAVED);
     await expectCatalog(dir, { "no-deps": "=2.0.0" });
-    expect(await installed(dir, "no-deps")).toStrictEqual({ "no-deps": "no-deps@2.0.0" });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
     await expectInSync(dir, ["", PKG1]);
   });
 
   test("bun add --catalog --filter", async () => {
     const dir = await setup(CATALOG_REPO());
-    expect(await run(dir, ["add", "a-dep", "--catalog", "--filter", "pkg1"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "add", "a-dep", "--catalog", "--filter", "pkg1")).stdout).toMatchInlineSnapshot(`
       "bun add <version> (<revision>)
 
       installed a-dep@1.0.10
@@ -1064,7 +1020,7 @@ describe.concurrent("$ref overrides", () => {
     const dependencies = { "no-deps": "1.0.0", "one-range-dep": "1.0.0", a1: "npm:no-deps@^1.0.0" };
     const dir = await setup({ "package.json": root({ dependencies, overrides }) });
     await writePkg(dir, root({ dependencies: { ...dependencies, "no-deps": "^1.0.0" }, overrides }));
-    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
@@ -1099,11 +1055,11 @@ describe.concurrent("bumping a direct dependency re-points its dependents", () =
     ["binary", false],
   ])("bun install after editing package.json (%s lockfile)", async (_, text) => {
     const dir = await setup({ "package.json": deps("1.0.0") }, { text });
-    expect(await installed(dir, "no-deps")).toStrictEqual({ "no-deps": "no-deps@1.0.0" });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.0.0" });
     expect(await nested(dir)).toBe(false);
 
     await reinstall(dir, deps("1.0.1"));
-    expect(await installed(dir, "no-deps")).toStrictEqual({ "no-deps": "no-deps@1.0.1" });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.0.1" });
     expect(await nested(dir)).toBe(false);
     if (text) {
       const { packages } = await lock(dir);
@@ -1112,15 +1068,13 @@ describe.concurrent("bumping a direct dependency re-points its dependents", () =
     }
 
     await reinstall(dir, deps("2.0.0"));
-    expect(await installed(dir, "no-deps", "one-range-dep/node_modules/no-deps")).toStrictEqual({
-      "no-deps": "no-deps@2.0.0",
-      "one-range-dep/node_modules/no-deps": "no-deps@1.0.1",
-    });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
+    expect(await installed(dir, "one-range-dep/node_modules/no-deps")).toMatchObject({ version: "1.0.1" });
     if (!text) return;
-    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.1", "no-deps@2.0.0", "one-range-dep@1.0.0"]);
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.1", "no-deps@2.0.0", "one-range-dep@1.0.0"]);
 
     await reinstall(dir, deps());
-    expect(await resolved(dir)).toStrictEqual(["no-deps@1.0.1", "one-range-dep@1.0.0"]);
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.1", "one-range-dep@1.0.0"]);
 
     await reinstall(dir, deps("1.0.0"));
     const { packages } = await lock(dir);
@@ -1143,7 +1097,7 @@ describe.concurrent("bumping a direct dependency re-points its dependents", () =
   test("bun update", async () => {
     const dir = await setup({ "package.json": deps("1.0.0") });
     await writePkg(dir, deps("^1.0.0"));
-    expect(await run(dir, ["update"])).toMatchInlineSnapshot(`
+    expect((await run(dir, "update")).stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -53,12 +53,16 @@ async function tryRun(dir: string, rel: string, ...args: string[]) {
 }
 
 // A run that succeeds prints nothing to stderr but `Saved lockfile`, and that only when it rewrote bun.lock. A case
-// whose point is that nothing may be written checks that `stderr` is empty.
+// whose point is that nothing may be written checks that `stderr` is empty. The whole result is checked at once, so
+// a failure shows stdout and stderr next to the exit code.
 async function runIn(dir: string, rel: string, ...args: string[]) {
-  const { stdout, stderr, exitCode } = await tryRun(dir, rel, ...args);
-  expect(stderr).toMatch(/^(?:Saved lockfile)?$/);
-  expect(exitCode).toBe(0);
-  return { stdout, stderr };
+  const result = await tryRun(dir, rel, ...args);
+  expect(result).toEqual({
+    stdout: expect.any(String),
+    stderr: expect.stringMatching(/^(?:Saved lockfile)?$/),
+    exitCode: 0,
+  });
+  return result;
 }
 
 const run = (dir: string, ...args: string[]) => runIn(dir, "", ...args);
@@ -66,11 +70,13 @@ const run = (dir: string, ...args: string[]) => runIn(dir, "", ...args);
 // An install rewrites bun.lock unless `--frozen-lockfile` forbids it, and says so. `stderr` pins a different
 // expectation: "" for a second install that must leave bun.lock alone, or the warning a run is known to print.
 async function install(dir: string, opts: { frozen?: boolean; stderr?: string | RegExp } = {}) {
-  const { stderr, exitCode } = await tryRun(dir, "", "install", ...(opts.frozen ? ["--frozen-lockfile"] : []));
-  const expected = opts.stderr ?? (opts.frozen ? "" : SAVED);
-  if (typeof expected === "string") expect(stderr).toBe(expected);
-  else expect(stderr).toMatch(expected);
-  expect(exitCode).toBe(0);
+  const result = await tryRun(dir, "", "install", ...(opts.frozen ? ["--frozen-lockfile"] : []));
+  const stderr = opts.stderr ?? (opts.frozen ? "" : SAVED);
+  expect(result).toEqual({
+    stdout: expect.any(String),
+    stderr: typeof stderr === "string" ? stderr : expect.stringMatching(stderr),
+    exitCode: 0,
+  });
 }
 
 function json(contents: Json | string) {
@@ -312,7 +318,6 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     await writePkg(dir, inBothGroups("~1.0.0"));
     const { stdout, stderr, exitCode } = await tryRun(dir, "", "update");
     expect(stderr).toMatch(duplicateWarning(SAVED));
-    expect(exitCode).toBe(0);
     expect(stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
@@ -320,6 +325,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
       1 package installed"
     `);
+    expect(exitCode).toBe(0);
     const manifest = await pkg(dir);
     expect([manifest.dependencies["no-deps"], manifest.devDependencies["no-deps"]].sort()).toStrictEqual([
       "~1.0.0",

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -186,120 +186,48 @@ const PKG2 = "packages/pkg2";
 describe.concurrent("bun update rewrites bun.lock together with package.json", () => {
   test("bun update", async () => {
     const dir = await setup({
-      "package.json": root({
-        dependencies: { "no-deps": "^1.0.0", aliased: "npm:no-deps@~1.0.0", bare: "npm:no-deps" },
-      }),
+      "package.json": root({ dependencies: { "no-deps": "^1.0.0", aliased: "npm:no-deps@~1.0.0" } }),
     });
-    expect((await run(dir, "update")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ no-deps 1.0.1 -> 1.1.0 (v2.0.0 available)
-
-      1 package installed"
-    `);
-    const expected = { "no-deps": "^1.1.0", aliased: "npm:no-deps@~1.0.1", bare: "npm:no-deps" };
+    expect((await run(dir, "update")).stderr).toBe(SAVED);
+    const expected = { "no-deps": "^1.1.0", aliased: "npm:no-deps@~1.0.1" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
-    expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.1.0" });
-    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "1.0.1" });
-    expect(await installed(dir, "bare")).toMatchObject({ name: "no-deps", version: "2.0.0" });
     await expectInSync(dir, [""], { reinstall: true });
   });
 
   test("bun update --latest", async () => {
     const dir = await setup({
-      "package.json": root({
-        dependencies: {
-          "no-deps": "~1.0.0",
-          aliased: "npm:no-deps@~1.0.0",
-          types: "npm:@types/no-deps",
-          tagged: "npm:dep-with-tags@pre-2",
-        },
-      }),
+      "package.json": root({ dependencies: { "no-deps": "~1.0.0", aliased: "npm:no-deps@~1.0.0" } }),
     });
-    expect((await run(dir, "update", "--latest")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ aliased 1.0.1 -> 2.0.0
-      ^ no-deps 1.0.1 -> 2.0.0
-      ^ tagged 2.0.1 -> 3.0.0
-
-      2 packages installed"
-    `);
-    const expected = {
-      "no-deps": "~2.0.0",
-      aliased: "npm:no-deps@~2.0.0",
-      types: "npm:@types/no-deps@^2.0.0",
-      tagged: "npm:dep-with-tags@^3.0.0",
-    };
+    expect((await run(dir, "update", "--latest")).stderr).toBe(SAVED);
+    const expected = { "no-deps": "~2.0.0", aliased: "npm:no-deps@~2.0.0" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""]).toStrictEqual({ name: "foo", dependencies: expected });
-    expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
-    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "2.0.0" });
-    expect(await installed(dir, "types")).toMatchObject({ name: "@types/no-deps", version: "2.0.0" });
-    expect(await installed(dir, "tagged")).toMatchObject({ name: "dep-with-tags", version: "3.0.0" });
     await expectInSync(dir);
   });
 
-  // Each range is installed pinned first, so the update has a newer version inside the range to move to.
-  test("bun update leaves *, major, 1.x, >= and hyphen ranges as written and moves only bun.lock", async () => {
-    const pinned = {
-      "no-deps": "1.0.0",
-      "a-dep": "1.0.1",
-      "what-bin": "1.0.0",
-      "@types/no-deps": "1.0.0",
-      "dep-with-tags": "1.0.0",
-      aliased: "npm:no-deps@1.0.0",
-    };
-    const ranges = {
-      "no-deps": "*",
-      "a-dep": "1",
-      "what-bin": "1.x",
-      "@types/no-deps": ">=1.0.0",
-      "dep-with-tags": "1.0.0 - 1.0.1",
-      aliased: "npm:no-deps@*",
-    };
-    const dir = await setup({ "package.json": root({ dependencies: pinned }) });
-    await reinstall(dir, root({ dependencies: ranges }));
-    expect(await resolutions(dir)).toStrictEqual([
-      "@types/no-deps@1.0.0",
-      "a-dep@1.0.1",
-      "dep-with-tags@1.0.0",
-      "no-deps@1.0.0",
-      "what-bin@1.0.0",
-    ]);
+  test.each([
+    ["*", "2.0.0"],
+    ["1", "1.1.0"],
+    ["1.x", "1.1.0"],
+    [">=1.0.0", "2.0.0"],
+    ["1.0.0 - 1.0.1", "1.0.1"],
+  ])("bun update leaves a %s range as written and moves bun.lock to %s", async (literal, resolved) => {
+    const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "1.0.0" } }) });
+    await reinstall(dir, root({ dependencies: { "no-deps": literal } }));
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.0"]);
     const pkgBefore = await pkgText(dir);
-    expect((await run(dir, "update")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ @types/no-deps 1.0.0 -> 2.0.0
-      ^ a-dep 1.0.1 -> 1.0.10
-      ^ aliased 1.0.0 -> 2.0.0
-      ^ dep-with-tags 1.0.0 -> 1.0.1 (v3.0.0 available)
-      ^ no-deps 1.0.0 -> 2.0.0
-      ^ what-bin 1.0.0 -> 1.5.0
-
-      5 packages installed"
-    `);
+    const { stdout, stderr } = await run(dir, "update");
+    expect(stderr).toBe(SAVED);
+    expect(stdout).toContain(`\n^ no-deps 1.0.0 -> ${resolved}`);
     expect(await pkgText(dir)).toBe(pkgBefore);
-    expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(ranges);
-    expect(await resolutions(dir)).toStrictEqual([
-      "@types/no-deps@2.0.0",
-      "a-dep@1.0.10",
-      "dep-with-tags@1.0.1",
-      "no-deps@2.0.0",
-      "what-bin@1.5.0",
-    ]);
-    expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
-    expect(await installed(dir, "a-dep")).toMatchObject({ version: "1.0.10" });
-    expect(await installed(dir, "what-bin")).toMatchObject({ version: "1.5.0" });
-    expect(await installed(dir, "@types/no-deps")).toMatchObject({ version: "2.0.0" });
-    expect(await installed(dir, "dep-with-tags")).toMatchObject({ version: "1.0.1" });
-    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "2.0.0" });
+    expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": literal });
+    expect(await resolutions(dir)).toStrictEqual([`no-deps@${resolved}`]);
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: resolved });
     await expectInSync(dir);
   });
 
-  test("bun update on a * range that already resolves the newest version leaves both files byte-identical, --latest rewrites it", async () => {
+  test("bun update on a * range that already resolves the newest version leaves both files byte-identical", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "*" } }) });
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
     const { stdout, stderr } = await run(dir, "update");
@@ -311,6 +239,10 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     `);
     expect(await pkgText(dir)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
+  });
+
+  test("bun update --latest rewrites a * range", async () => {
+    const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "*" } }) });
     expect((await run(dir, "update", "--latest")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
@@ -327,13 +259,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("bun update <name> on an exact literal", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "1.0.0" } }) });
-    const { stdout, stderr } = await run(dir, "update", "no-deps");
-    expect(stderr).toBe("");
-    expect(stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      Checked 1 install across 2 packages (no changes)"
-    `);
+    expect((await run(dir, "update", "no-deps")).stderr).toBe("");
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "1.0.0" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": "1.0.0" });
     await expectInSync(dir);
@@ -342,13 +268,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
   test("bun update <name> keeps a * literal and leaves the unnamed sibling alone", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" } }) });
     await reinstall(dir, root({ dependencies: { "no-deps": "*", "a-dep": "^1.0.1" } }));
-    expect((await run(dir, "update", "no-deps")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ no-deps 1.0.0 -> 2.0.0
-
-      1 package installed"
-    `);
+    expect((await run(dir, "update", "no-deps")).stderr).toBe(SAVED);
     const expected = { "no-deps": "*", "a-dep": "^1.0.1" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
@@ -366,18 +286,13 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("bun update <name>@<range>", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { "no-deps": "~1.0.0" } }) });
-    expect((await run(dir, "update", "no-deps@^1.0.0")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ no-deps 1.0.1 -> 1.1.0 (v2.0.0 available)
-
-      1 package installed"
-    `);
+    expect((await run(dir, "update", "no-deps@^1.0.0")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "~1.1.0" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ "no-deps": "~1.1.0" });
     await expectInSync(dir);
   });
 
+  // `bun install` warns about a name declared in two groups, so these two allow warnings.
   const inBothGroups = (version: string) =>
     root({ dependencies: { "no-deps": version }, devDependencies: { "no-deps": version } });
 
@@ -448,11 +363,21 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     await expectInSync(dir, ["", PKG1]);
   });
 
+  test("bun update -r", async () => {
+    const dir = await setup(MONOREPO({ dependencies: { "no-deps": "~1.0.0" } }));
+    expect((await run(dir, "update", "-r")).stderr).toBe(SAVED);
+    expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
+    expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
+    await expectInSync(dir, ["", PKG1]);
+  });
+
   test("bun update -r keeps a member's 1.x literal", async () => {
     const dir = await setup(MONOREPO({ dependencies: { "no-deps": "1.0.0" } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "1.x" } }), PKG1);
     expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
-    expect((await run(dir, "update", "-r")).stdout).toMatchInlineSnapshot(`
+    const { stdout, stderr } = await run(dir, "update", "-r");
+    expect(stderr).toBe(SAVED);
+    expect(stdout).toMatchInlineSnapshot(`
       "bun update <version> (<revision>)
 
       ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
@@ -465,7 +390,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     await expectInSync(dir, ["", PKG1]);
   });
 
-  test("bun update -r bumps a member's range and keeps its dist-tag literal", async () => {
+  test("bun update -r keeps a member's dist-tag literal", async () => {
     const dir = await setup(MONOREPO({ dependencies: { "dep-with-tags": "pre-2", "no-deps": "~1.0.0" } }));
     expect((await run(dir, "update", "-r")).stderr).toBe(SAVED);
     const expected = { "dep-with-tags": "pre-2", "no-deps": "~1.0.1" };
@@ -481,14 +406,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
 
   test("bun update -r --latest replaces a member's dist-tag literal with the latest version", async () => {
     const dir = await setup(MONOREPO({ dependencies: { "dep-with-tags": "pre-2", "no-deps": "~1.0.0" } }));
-    expect((await run(dir, "update", "-r", "--latest")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ dep-with-tags 2.0.1 -> 3.0.0
-      ^ no-deps 1.0.1 -> 2.0.0
-
-      2 packages installed"
-    `);
+    expect((await run(dir, "update", "-r", "--latest")).stderr).toBe(SAVED);
     const expected = { "dep-with-tags": "^3.0.0", "no-deps": "~2.0.0" };
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual(expected);
@@ -517,13 +435,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
         { pkg1: { dependencies: { "a-dep": "1.0.1" } }, pkg2: { dependencies: { "no-deps": "~1.0.0" } } },
       ),
     );
-    expect((await run(dir, "update", "no-deps", "-r", "--latest")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ no-deps 1.0.1 -> 2.0.0
-
-      1 package installed"
-    `);
+    expect((await run(dir, "update", "no-deps", "-r", "--latest")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "~2.0.0" });
     expect((await pkg(dir, PKG2)).dependencies).toStrictEqual({ "no-deps": "~2.0.0" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "a-dep": "1.0.1" });
@@ -543,13 +455,7 @@ describe.concurrent("bun update rewrites bun.lock together with package.json", (
     await writePkg(dir, wsRoot({ dependencies: { "no-deps": "^1.0.0" } }));
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
     expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
-    expect((await run(dir, "update", "no-deps@1.0.1", "-r")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ no-deps 1.0.0 -> 1.0.1 (v2.0.0 available)
-
-      1 package installed"
-    `);
+    expect((await run(dir, "update", "no-deps@1.0.1", "-r")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^1.0.1" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.1", "pkg1@workspace:packages/pkg1"]);
@@ -591,13 +497,7 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
     await reinstall(dir, member("pkg1", { dependencies: { "no-deps": "~1.0.0" } }), PKG1);
     expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.0", "pkg1@workspace:packages/pkg1"]);
 
-    expect((await run(dir, "update", "no-deps")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
-
-      2 packages installed"
-    `);
+    expect((await run(dir, "update", "no-deps")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^1.1.0" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
@@ -626,13 +526,7 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
       "pkg2@workspace:packages/pkg2",
     ]);
 
-    expect((await runIn(dir, PKG1, "update", "no-deps")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
-
-      2 packages installed"
-    `);
+    expect((await runIn(dir, PKG1, "update", "no-deps")).stderr).toBe(SAVED);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "^1.1.0" });
     expect((await pkg(dir, PKG2)).dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
     expect((await lock(dir)).workspaces[PKG2].dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
@@ -661,13 +555,7 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
       "pkg2@workspace:packages/pkg2",
     ]);
 
-    expect((await run(dir, "update", "no-deps", "--filter", "pkg1")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ no-deps 1.0.0 -> 1.0.1 (v2.0.0 available)
-
-      1 package installed"
-    `);
+    expect((await run(dir, "update", "no-deps", "--filter", "pkg1")).stderr).toBe(SAVED);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "~1.0.1" });
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^1.0.0" });
     expect((await pkg(dir, PKG2)).dependencies).toStrictEqual({ "no-deps": "~1.0.0" });
@@ -700,32 +588,64 @@ describe.concurrent("named update is scoped to the invoking workspace", () => {
 });
 
 describe.concurrent("npm: aliases", () => {
-  const ROWS: { before: string; args: string[]; after: string; installs: string }[] = [
-    { before: "npm:no-deps@~1.0.0", args: ["aliased", "--latest"], after: "npm:no-deps@~2.0.0", installs: "2.0.0" },
-    { before: "npm:no-deps", args: ["aliased"], after: "npm:no-deps", installs: "2.0.0" },
-    { before: "npm:no-deps@~1.0.0", args: ["aliased@2.0.0"], after: "npm:no-deps@~2.0.0", installs: "2.0.0" },
-    { before: "npm:no-deps@^1.0.0", args: ["aliased"], after: "npm:no-deps@^1.1.0", installs: "1.1.0" },
+  const ROWS: { pinned?: string; before: string; args: string[]; after: string; installs: [string, string] }[] = [
+    {
+      before: "npm:no-deps@~1.0.0",
+      args: ["aliased", "--latest"],
+      after: "npm:no-deps@~2.0.0",
+      installs: ["no-deps", "2.0.0"],
+    },
+    { before: "npm:no-deps", args: [], after: "npm:no-deps", installs: ["no-deps", "2.0.0"] },
+    { before: "npm:no-deps", args: ["aliased"], after: "npm:no-deps", installs: ["no-deps", "2.0.0"] },
+    {
+      pinned: "npm:no-deps@1.0.0",
+      before: "npm:no-deps@*",
+      args: [],
+      after: "npm:no-deps@*",
+      installs: ["no-deps", "2.0.0"],
+    },
+    {
+      before: "npm:@types/no-deps",
+      args: ["--latest"],
+      after: "npm:@types/no-deps@^2.0.0",
+      installs: ["@types/no-deps", "2.0.0"],
+    },
+    {
+      before: "npm:dep-with-tags@pre-2",
+      args: ["--latest"],
+      after: "npm:dep-with-tags@^3.0.0",
+      installs: ["dep-with-tags", "3.0.0"],
+    },
+    {
+      before: "npm:no-deps@~1.0.0",
+      args: ["aliased@2.0.0"],
+      after: "npm:no-deps@~2.0.0",
+      installs: ["no-deps", "2.0.0"],
+    },
+    { before: "npm:no-deps@^1.0.0", args: ["aliased"], after: "npm:no-deps@^1.1.0", installs: ["no-deps", "1.1.0"] },
   ];
 
-  test.each(ROWS)('"aliased": "$before" + bun update $args -> "$after"', async ({ before, args, after, installs }) => {
-    const dir = await setup({ "package.json": root({ dependencies: { aliased: before } }) });
-    const { stderr } = await run(dir, "update", ...args);
-    expect(stderr).toBe(before === after ? "" : SAVED);
-    expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: after });
-    expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ aliased: after });
-    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: installs });
-    await expectInSync(dir);
-  });
+  test.each(ROWS)(
+    '"aliased": "$before" + bun update $args -> "$after"',
+    async ({ pinned, before, args, after, installs }) => {
+      const dir = await setup({ "package.json": root({ dependencies: { aliased: pinned ?? before } }) });
+      if (pinned !== undefined) {
+        await reinstall(dir, root({ dependencies: { aliased: before } }));
+        expect(await installed(dir, "aliased")).toMatchObject({ version: "1.0.0" });
+      }
+      const { stderr } = await run(dir, "update", ...args);
+      expect(stderr).toBe(before === after && pinned === undefined ? "" : SAVED);
+      expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: after });
+      expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ aliased: after });
+      const [name, version] = installs;
+      expect(await installed(dir, "aliased")).toMatchObject({ name, version });
+      await expectInSync(dir);
+    },
+  );
 
   test("bun update <alias>@npm:<other> retargets the alias", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { aliased: "npm:no-deps@~1.0.0" } }) });
-    expect((await run(dir, "update", "aliased@npm:a-dep")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ aliased 1.0.1 -> 1.0.10
-
-      1 package installed"
-    `);
+    expect((await run(dir, "update", "aliased@npm:a-dep")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: "npm:a-dep@~1.0.10" });
     expect(await installed(dir, "aliased")).toMatchObject({ name: "a-dep", version: "1.0.10" });
     await expectInSync(dir);
@@ -744,13 +664,7 @@ describe.concurrent("npm: aliases", () => {
     expect(await pkgText(dir)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
 
-    expect((await run(dir, "add", "new-alias@npm:@types/no-deps@^1.0.0")).stdout).toMatchInlineSnapshot(`
-      "bun add <version> (<revision>)
-
-      installed new-alias@npm:@types/no-deps@1.0.0
-
-      1 package installed"
-    `);
+    expect((await run(dir, "add", "new-alias@npm:@types/no-deps@^1.0.0")).stderr).toBe(SAVED);
     const expected = { "a-dep": "1.0.1", "new-alias": "npm:@types/no-deps@^1.0.0" };
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
@@ -760,13 +674,7 @@ describe.concurrent("npm: aliases", () => {
 
   test("bun update <alias>@npm:<scoped>@<range> retargets a scoped alias in the declared pin style", async () => {
     const dir = await setup({ "package.json": root({ dependencies: { aliased: "npm:no-deps@~1.0.0" } }) });
-    expect((await run(dir, "update", "aliased@npm:@types/no-deps@^1.0.0")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ aliased 1.0.1 -> 1.0.0 (v2.0.0 available)
-
-      1 package installed"
-    `);
+    expect((await run(dir, "update", "aliased@npm:@types/no-deps@^1.0.0")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ aliased: "npm:@types/no-deps@~1.0.0" });
     expect(await installed(dir, "aliased")).toMatchObject({ name: "@types/no-deps", version: "1.0.0" });
     await expectInSync(dir);
@@ -774,46 +682,29 @@ describe.concurrent("npm: aliases", () => {
 });
 
 describe.concurrent("bun add", () => {
-  // One `bun add` per pin style of the name itself; the aliases ride along to cover the `<alias>@npm:` spellings.
-  // Every entry installs no-deps; `installs` is the version each name gets.
-  const ADDS: { args: string[]; expected: Record<string, string>; installs: Record<string, string> }[] = [
-    {
-      args: ["no-deps", "a@npm:no-deps@~1.0.0", "c@npm:no-deps"],
-      expected: { "no-deps": "^2.0.0", a: "npm:no-deps@~1.0.0", c: "npm:no-deps@^2.0.0" },
-      installs: { "no-deps": "2.0.0", a: "1.0.1", c: "2.0.0" },
-    },
-    {
-      args: ["no-deps", "x@npm:no-deps", "--exact"],
-      expected: { "no-deps": "2.0.0", x: "npm:no-deps@2.0.0" },
-      installs: { "no-deps": "2.0.0", x: "2.0.0" },
-    },
-    {
-      args: ["no-deps@~1.0.0", "b@npm:no-deps@latest"],
-      expected: { "no-deps": "~1.0.0", b: "npm:no-deps@^2.0.0" },
-      installs: { "no-deps": "1.0.1", b: "2.0.0" },
-    },
-    { args: ["no-deps@latest"], expected: { "no-deps": "^2.0.0" }, installs: { "no-deps": "2.0.0" } },
-  ];
-
-  test.each(ADDS)("bun add $args", async ({ args, expected, installs }) => {
+  test.each([
+    { args: ["no-deps"], expected: { "no-deps": "^2.0.0" } },
+    { args: ["no-deps", "--exact"], expected: { "no-deps": "2.0.0" } },
+    { args: ["no-deps@~1.0.0"], expected: { "no-deps": "~1.0.0" } },
+    { args: ["no-deps@latest"], expected: { "no-deps": "^2.0.0" } },
+    { args: ["x@npm:no-deps@~1.0.0"], expected: { x: "npm:no-deps@~1.0.0" } },
+    { args: ["x@npm:no-deps@latest"], expected: { x: "npm:no-deps@^2.0.0" } },
+    { args: ["x@npm:no-deps"], expected: { x: "npm:no-deps@^2.0.0" } },
+    { args: ["x@npm:no-deps", "--exact"], expected: { x: "npm:no-deps@2.0.0" } },
+  ])("bun add $args", async ({ args, expected }) => {
     const dir = await setup({ "package.json": root({}) }, { install: false });
     expect((await run(dir, "add", ...args)).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual(expected);
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual(expected);
-    for (const [name, version] of Object.entries(installs)) {
-      expect(await installed(dir, name)).toMatchObject({ name: "no-deps", version });
-    }
+    const [name, literal] = Object.entries(expected)[0];
+    const version = literal.endsWith("~1.0.0") ? "1.0.1" : "2.0.0";
+    expect(await installed(dir, name)).toMatchObject({ name: "no-deps", version });
     await expectInSync(dir);
   });
 
   test("bun add <workspace>@workspace:*", async () => {
     const dir = await setup(MONOREPO());
-    expect((await run(dir, "add", "pkg1@workspace:*")).stdout).toMatchInlineSnapshot(`
-      "bun add <version> (<revision>)
-
-      installed pkg1@workspace:packages/pkg1
-       done"
-    `);
+    expect((await run(dir, "add", "pkg1@workspace:*")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ pkg1: "workspace:*" });
     expect((await lock(dir)).workspaces[""].dependencies).toStrictEqual({ pkg1: "workspace:*" });
     await expectInSync(dir, ["", PKG1]);
@@ -821,13 +712,7 @@ describe.concurrent("bun add", () => {
 
   test("bun add --filter", async () => {
     const dir = await setup(MONOREPO());
-    expect((await run(dir, "add", "x@npm:no-deps@latest", "--filter", "pkg1")).stdout).toMatchInlineSnapshot(`
-      "bun add <version> (<revision>)
-
-      installed x@npm:no-deps@2.0.0
-
-      1 package installed"
-    `);
+    expect((await run(dir, "add", "x@npm:no-deps@latest", "--filter", "pkg1")).stderr).toBe(SAVED);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ x: "npm:no-deps@^2.0.0" });
     expect((await lock(dir)).workspaces[PKG1].dependencies).toStrictEqual({ x: "npm:no-deps@^2.0.0" });
     await expectInSync(dir, ["", PKG1]);
@@ -835,11 +720,7 @@ describe.concurrent("bun add", () => {
 
   test("bun add --lockfile-only", async () => {
     const dir = await setup({ "package.json": root({}) }, { install: false });
-    expect((await run(dir, "add", "no-deps", "--lockfile-only")).stdout).toMatchInlineSnapshot(`
-      "bun add <version> (<revision>)
-
-      Saved bun.lock (2 packages)"
-    `);
+    expect((await run(dir, "add", "no-deps", "--lockfile-only")).stderr).toBe(SAVED);
     expect((await pkg(dir)).dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
     expect(await exists(join(dir, "node_modules"))).toBe(false);
     await expectInSync(dir);
@@ -847,13 +728,7 @@ describe.concurrent("bun add", () => {
 
   test("bun add --trust", async () => {
     const dir = await setup({ "package.json": root({}) }, { install: false });
-    expect((await run(dir, "add", "uses-what-bin@1.0.0", "--trust")).stdout).toMatchInlineSnapshot(`
-      "bun add <version> (<revision>)
-
-      installed uses-what-bin@1.0.0
-
-      2 packages installed"
-    `);
+    expect((await run(dir, "add", "uses-what-bin@1.0.0", "--trust")).stderr).toBe(SAVED);
     expect(await pkg(dir)).toStrictEqual({
       name: "foo",
       dependencies: { "uses-what-bin": "1.0.0" },
@@ -865,12 +740,7 @@ describe.concurrent("bun add", () => {
 
   test("bun add --trust of a package already listed in devDependencies", async () => {
     const dir = await setup({ "package.json": root({ devDependencies: { "uses-what-bin": "1.0.0" } }) });
-    expect((await run(dir, "add", "uses-what-bin@1.0.0", "--trust")).stdout).toMatchInlineSnapshot(`
-      "bun add <version> (<revision>)
-
-      installed uses-what-bin@1.0.0
-       done"
-    `);
+    expect((await run(dir, "add", "uses-what-bin@1.0.0", "--trust")).stderr).toBe(SAVED);
     expect(await pkg(dir)).toStrictEqual({
       name: "foo",
       devDependencies: { "uses-what-bin": "1.0.0" },
@@ -893,54 +763,46 @@ describe.concurrent("catalogs", () => {
     expect((await lock(dir)).catalog).toStrictEqual(expected);
   }
 
-  // A range, a bare alias, a dist-tag, a 1.x range, an aliased range and an aliased dist-tag.
-  const FULL_CATALOG = {
-    "no-deps": "^1.0.0",
-    aliased: "npm:no-deps",
-    "dep-with-tags": "pre-2",
-    "a-dep": "1.x",
-    tilde: "npm:no-deps@~1.0.0",
-    tagged: "npm:dep-with-tags@pre-2",
-  };
-  const FULL_CATALOG_MEMBER_DEPS = Object.fromEntries(Object.keys(FULL_CATALOG).map(name => [name, "catalog:"]));
-
-  test("bun update bumps ranges in place and keeps bare aliases, dist-tags and 1.x entries", async () => {
-    const dir = await setup(CATALOG_REPO(FULL_CATALOG));
+  test("bun update", async () => {
+    const dir = await setup(CATALOG_REPO());
     expect((await run(dir, "update")).stderr).toBe(SAVED);
-    await expectCatalog(dir, { ...FULL_CATALOG, "no-deps": "^1.1.0", tilde: "npm:no-deps@~1.0.1" });
-    expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.1.0" });
-    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "2.0.0" });
-    expect(await installed(dir, "dep-with-tags")).toMatchObject({ version: "2.0.1" });
-    expect(await installed(dir, "a-dep")).toMatchObject({ version: "1.0.10" });
-    expect(await installed(dir, "tilde")).toMatchObject({ name: "no-deps", version: "1.0.1" });
-    expect(await installed(dir, "tagged")).toMatchObject({ name: "dep-with-tags", version: "2.0.1" });
-    expect((await pkg(dir, PKG1)).dependencies).toStrictEqual(FULL_CATALOG_MEMBER_DEPS);
+    await expectCatalog(dir, { "no-deps": "^1.1.0", aliased: "npm:no-deps" });
+    expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "catalog:", aliased: "catalog:" });
     await expectInSync(dir, ["", PKG1]);
   });
 
-  test.each([[""], [PKG1]])(
-    "bun update --latest from '%s' rewrites every entry and keeps the alias prefixes",
-    async cwd => {
-      const dir = await setup(CATALOG_REPO(FULL_CATALOG));
-      expect((await runIn(dir, cwd, "update", "--latest")).stderr).toBe(SAVED);
-      await expectCatalog(dir, {
-        "no-deps": "^2.0.0",
-        aliased: "npm:no-deps@^2.0.0",
-        "dep-with-tags": "^3.0.0",
-        "a-dep": "^1.0.10",
-        tilde: "npm:no-deps@~2.0.0",
-        tagged: "npm:dep-with-tags@^3.0.0",
-      });
-      expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
-      expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "2.0.0" });
-      expect(await installed(dir, "dep-with-tags")).toMatchObject({ version: "3.0.0" });
-      expect(await installed(dir, "a-dep")).toMatchObject({ version: "1.0.10" });
-      expect(await installed(dir, "tilde")).toMatchObject({ name: "no-deps", version: "2.0.0" });
-      expect(await installed(dir, "tagged")).toMatchObject({ name: "dep-with-tags", version: "3.0.0" });
-      expect((await pkg(dir, PKG1)).dependencies).toStrictEqual(FULL_CATALOG_MEMBER_DEPS);
-      await expectInSync(dir, ["", PKG1]);
-    },
-  );
+  test.each([[""], [PKG1]])("bun update --latest from '%s'", async cwd => {
+    const dir = await setup(CATALOG_REPO());
+    expect((await runIn(dir, cwd, "update", "--latest")).stderr).toBe(SAVED);
+    await expectCatalog(dir, { "no-deps": "^2.0.0", aliased: "npm:no-deps@^2.0.0" });
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@2.0.0", "pkg1@workspace:packages/pkg1"]);
+    await expectInSync(dir, ["", PKG1]);
+  });
+
+  test("bun update keeps a dist-tag catalog entry", async () => {
+    const dir = await setup(CATALOG_REPO({ "dep-with-tags": "pre-2" }));
+    expect((await run(dir, "update")).stderr).toBe("");
+    await expectCatalog(dir, { "dep-with-tags": "pre-2" });
+    expect(await installed(dir, "dep-with-tags")).toMatchObject({ version: "2.0.1" });
+    await expectInSync(dir, ["", PKG1]);
+  });
+
+  test("bun update --latest replaces a dist-tag catalog entry with the latest version", async () => {
+    const dir = await setup(CATALOG_REPO({ "dep-with-tags": "pre-2" }));
+    expect((await run(dir, "update", "--latest")).stderr).toBe(SAVED);
+    await expectCatalog(dir, { "dep-with-tags": "^3.0.0" });
+    expect(await installed(dir, "dep-with-tags")).toMatchObject({ version: "3.0.0" });
+    await expectInSync(dir, ["", PKG1]);
+  });
+
+  test("bun update keeps a 1.x catalog entry", async () => {
+    const dir = await setup(CATALOG_REPO({ "no-deps": "1.x" }));
+    expect((await run(dir, "update")).stderr).toBe("");
+    await expectCatalog(dir, { "no-deps": "1.x" });
+    expect(await resolutions(dir)).toStrictEqual(["no-deps@1.1.0", "pkg1@workspace:packages/pkg1"]);
+    expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+    await expectInSync(dir, ["", PKG1]);
+  });
 
   test("bun update keeps a * catalog entry and moves only bun.lock", async () => {
     const dir = await setup(CATALOG_REPO({ "no-deps": "1.0.0" }));
@@ -950,6 +812,32 @@ describe.concurrent("catalogs", () => {
     await expectCatalog(dir, { "no-deps": "*" });
     expect(await resolutions(dir)).toStrictEqual(["no-deps@2.0.0", "pkg1@workspace:packages/pkg1"]);
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+    await expectInSync(dir, ["", PKG1]);
+  });
+
+  const ALIASED_CATALOG = { aliased: "npm:no-deps@~1.0.0", tagged: "npm:dep-with-tags@pre-2" };
+
+  test("bun update bumps an aliased catalog range in place and keeps an aliased dist-tag", async () => {
+    const dir = await setup(CATALOG_REPO(ALIASED_CATALOG));
+    expect((await run(dir, "update")).stderr).toBe(SAVED);
+    await expectCatalog(dir, { aliased: "npm:no-deps@~1.0.1", tagged: "npm:dep-with-tags@pre-2" });
+    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "1.0.1" });
+    expect(await installed(dir, "tagged")).toMatchObject({ name: "dep-with-tags", version: "2.0.1" });
+    expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({ aliased: "catalog:", tagged: "catalog:" });
+    await expectInSync(dir, ["", PKG1]);
+  });
+
+  test("bun update --latest rewrites aliased catalog entries and keeps the alias prefix", async () => {
+    const dir = await setup(CATALOG_REPO(ALIASED_CATALOG));
+    expect((await run(dir, "update", "--latest")).stderr).toBe(SAVED);
+    await expectCatalog(dir, { aliased: "npm:no-deps@~2.0.0", tagged: "npm:dep-with-tags@^3.0.0" });
+    expect(await installed(dir, "aliased")).toMatchObject({ name: "no-deps", version: "2.0.0" });
+    expect(await installed(dir, "tagged")).toMatchObject({ name: "dep-with-tags", version: "3.0.0" });
+    expect(await resolutions(dir)).toStrictEqual([
+      "dep-with-tags@3.0.0",
+      "no-deps@2.0.0",
+      "pkg1@workspace:packages/pkg1",
+    ]);
     await expectInSync(dir, ["", PKG1]);
   });
 
@@ -968,27 +856,26 @@ describe.concurrent("catalogs", () => {
     await expectInSync(dir, ["", PKG1]);
   });
 
-  test.each([
-    [[], { "no-deps": "1.1.0", aliased: "npm:no-deps@1.0.1" }, "1.1.0"],
-    [["--latest"], { "no-deps": "2.0.0", aliased: "npm:no-deps@2.0.0" }, "2.0.0"],
-  ])("bun update %j with install.exact pins the catalog entries", async (args, expected, version) => {
+  test("bun update --latest with install.exact pins a catalog entry", async () => {
     const dir = await setup(CATALOG_REPO({ "no-deps": "^1.0.0", aliased: "npm:no-deps@~1.0.0" }), { exact: true });
-    expect((await run(dir, "update", ...args)).stderr).toBe(SAVED);
-    await expectCatalog(dir, expected);
-    expect(await installed(dir, "no-deps")).toMatchObject({ version });
+    expect((await run(dir, "update", "--latest")).stderr).toBe(SAVED);
+    await expectCatalog(dir, { "no-deps": "2.0.0", aliased: "npm:no-deps@2.0.0" });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
+    await expectInSync(dir, ["", PKG1]);
+  });
+
+  test("bun update with install.exact pins a catalog range in place", async () => {
+    const dir = await setup(CATALOG_REPO({ "no-deps": "^1.0.0" }), { exact: true });
+    expect((await run(dir, "update")).stderr).toBe(SAVED);
+    await expectCatalog(dir, { "no-deps": "1.1.0" });
+    expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.1.0" });
     await expectInSync(dir, ["", PKG1]);
   });
 
   test("bun update --latest keeps the = prefix of a catalog entry", async () => {
     const dir = await setup(CATALOG_REPO({ "no-deps": "=1.0.0" }));
     const [pkgBefore, lockBefore] = await Promise.all([pkgText(dir), lockText(dir)]);
-    const { stdout, stderr } = await run(dir, "update");
-    expect(stderr).toBe("");
-    expect(stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      Checked 2 installs across 3 packages (no changes)"
-    `);
+    expect((await run(dir, "update")).stderr).toBe("");
     expect(await pkgText(dir)).toBe(pkgBefore);
     expect(await lockText(dir)).toBe(lockBefore);
     expect((await run(dir, "update", "--latest")).stderr).toBe(SAVED);
@@ -999,13 +886,7 @@ describe.concurrent("catalogs", () => {
 
   test("bun add --catalog --filter", async () => {
     const dir = await setup(CATALOG_REPO());
-    expect((await run(dir, "add", "a-dep", "--catalog", "--filter", "pkg1")).stdout).toMatchInlineSnapshot(`
-      "bun add <version> (<revision>)
-
-      installed a-dep@1.0.10
-
-      1 package installed"
-    `);
+    expect((await run(dir, "add", "a-dep", "--catalog", "--filter", "pkg1")).stderr).toBe(SAVED);
     await expectCatalog(dir, { "no-deps": "^1.0.0", aliased: "npm:no-deps", "a-dep": "^1.0.10" });
     expect((await pkg(dir, PKG1)).dependencies).toStrictEqual({
       "no-deps": "catalog:",
@@ -1017,32 +898,27 @@ describe.concurrent("catalogs", () => {
 });
 
 describe.concurrent("$ref overrides", () => {
-  test("$name and $alias follow the rewritten row; a literal override stays as written", async () => {
-    const overrides = { "no-deps": "$no-deps", "one-range-dep": "1.0.0", a1: "$a1" };
-    const dependencies = { "no-deps": "1.0.0", "one-range-dep": "1.0.0", a1: "npm:no-deps@^1.0.0" };
-    const dir = await setup({ "package.json": root({ dependencies, overrides }) });
-    await writePkg(dir, root({ dependencies: { ...dependencies, "no-deps": "^1.0.0" }, overrides }));
-    expect((await run(dir, "update")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
-
-      + a1@1.1.0
-
-      1 package installed"
-    `);
+  test("$name follows the rewritten dependency; a literal override stays as written", async () => {
+    const overrides = { "no-deps": "$no-deps", "one-range-dep": "1.0.0" };
+    const dir = await setup({
+      "package.json": root({ dependencies: { "no-deps": "1.0.0", "one-range-dep": "1.0.0" }, overrides }),
+    });
+    await writePkg(dir, root({ dependencies: { "no-deps": "^1.0.0", "one-range-dep": "1.0.0" }, overrides }));
+    expect((await run(dir, "update")).stderr).toBe(SAVED);
     const manifest = await pkg(dir);
-    expect(manifest.dependencies).toStrictEqual({
-      "no-deps": "^1.1.0",
-      "one-range-dep": "1.0.0",
-      a1: "npm:no-deps@^1.1.0",
-    });
+    expect(manifest.dependencies).toStrictEqual({ "no-deps": "^1.1.0", "one-range-dep": "1.0.0" });
     expect(manifest.overrides).toStrictEqual(overrides);
-    expect((await lock(dir)).overrides).toStrictEqual({
-      "no-deps": "^1.1.0",
-      "one-range-dep": "1.0.0",
-      a1: "npm:no-deps@^1.1.0",
+    expect((await lock(dir)).overrides).toStrictEqual({ "no-deps": "^1.1.0", "one-range-dep": "1.0.0" });
+    await expectInSync(dir);
+  });
+
+  test("$alias follows the rewritten alias", async () => {
+    const dir = await setup({
+      "package.json": root({ dependencies: { a1: "npm:no-deps@^1.0.0" }, overrides: { a1: "$a1" } }),
     });
+    expect((await run(dir, "update")).stderr).toBe(SAVED);
+    expect((await pkg(dir)).dependencies).toStrictEqual({ a1: "npm:no-deps@^1.1.0" });
+    expect((await lock(dir)).overrides).toStrictEqual({ a1: "npm:no-deps@^1.1.0" });
     await expectInSync(dir);
   });
 });
@@ -1060,7 +936,8 @@ describe.concurrent("bumping a direct dependency re-points its dependents", () =
     expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.0.0" });
     expect(await nested(dir)).toBe(false);
 
-    await reinstall(dir, deps("1.0.1"));
+    await writePkg(dir, deps("1.0.1"));
+    await install(dir);
     expect(await installed(dir, "no-deps")).toMatchObject({ version: "1.0.1" });
     expect(await nested(dir)).toBe(false);
     if (text) {
@@ -1069,16 +946,19 @@ describe.concurrent("bumping a direct dependency re-points its dependents", () =
       expect(packages["no-deps"][0]).toBe("no-deps@1.0.1");
     }
 
-    await reinstall(dir, deps("2.0.0"));
+    await writePkg(dir, deps("2.0.0"));
+    await install(dir);
     expect(await installed(dir, "no-deps")).toMatchObject({ version: "2.0.0" });
     expect(await installed(dir, "one-range-dep/node_modules/no-deps")).toMatchObject({ version: "1.0.1" });
     if (!text) return;
     expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.1", "no-deps@2.0.0", "one-range-dep@1.0.0"]);
 
-    await reinstall(dir, deps());
+    await writePkg(dir, deps());
+    await install(dir);
     expect(await resolutions(dir)).toStrictEqual(["no-deps@1.0.1", "one-range-dep@1.0.0"]);
 
-    await reinstall(dir, deps("1.0.0"));
+    await writePkg(dir, deps("1.0.0"));
+    await install(dir);
     const { packages } = await lock(dir);
     expect(packages["no-deps"][0]).toBe("no-deps@1.0.0");
     expect(packages["one-range-dep/no-deps"][0]).toBe("no-deps@1.0.1");
@@ -1099,13 +979,7 @@ describe.concurrent("bumping a direct dependency re-points its dependents", () =
   test("bun update", async () => {
     const dir = await setup({ "package.json": deps("1.0.0") });
     await writePkg(dir, deps("^1.0.0"));
-    expect((await run(dir, "update")).stdout).toMatchInlineSnapshot(`
-      "bun update <version> (<revision>)
-
-      ^ no-deps 1.0.0 -> 1.1.0 (v2.0.0 available)
-
-      1 package installed"
-    `);
+    expect((await run(dir, "update")).stderr).toBe(SAVED);
     const { packages } = await lock(dir);
     expect(packages["no-deps"][0]).toBe("no-deps@1.1.0");
     expect(packages["one-range-dep/no-deps"]).toBeUndefined();

--- a/test/cli/install/bun-update-lockfile-sync.test.ts
+++ b/test/cli/install/bun-update-lockfile-sync.test.ts
@@ -120,6 +120,7 @@ function declaredLiteral(manifest: Json, name: string): string | undefined {
 
 // bun.lock repeats each workspace's dependency groups, plus the root's overrides, catalog and catalogs, and a
 // `--frozen-lockfile` install must accept it as is. With `reinstall`, a plain install must leave it byte-identical too.
+// A field is compared when either file has it, so a stale copy in bun.lock of a field package.json dropped fails too.
 async function expectInSync(
   dir: string,
   workspaces: string[] = [""],
@@ -133,15 +134,16 @@ async function expectInSync(
     declared[key] = {};
     locked[key] = {};
     for (const group of GROUPS) {
-      if (manifest[group] === undefined) continue;
+      const lockedGroup = lockfile.workspaces[key]?.[group];
+      if (manifest[group] === undefined && lockedGroup === undefined) continue;
       declared[key][group] = manifest[group];
-      locked[key][group] = lockfile.workspaces[key]?.[group];
+      locked[key][group] = lockedGroup;
     }
     if (key !== "") continue;
     const overrides = manifest.overrides ?? manifest.resolutions;
-    if (overrides !== undefined) {
+    if (overrides !== undefined || lockfile.overrides !== undefined) {
       declared[key].overrides = Object.fromEntries(
-        Object.entries(overrides).map(([name, value]) => [
+        Object.entries(overrides ?? {}).map(([name, value]) => [
           name,
           typeof value === "string" && value.startsWith("$") ? declaredLiteral(manifest, value.slice(1)) : value,
         ]),
@@ -149,12 +151,12 @@ async function expectInSync(
       locked[key].overrides = lockfile.overrides;
     }
     const catalog = manifest.workspaces?.catalog ?? manifest.catalog;
-    if (catalog !== undefined) {
+    if (catalog !== undefined || lockfile.catalog !== undefined) {
       declared[key].catalog = catalog;
       locked[key].catalog = lockfile.catalog;
     }
     const catalogs = manifest.workspaces?.catalogs ?? manifest.catalogs;
-    if (catalogs !== undefined) {
+    if (catalogs !== undefined || lockfile.catalogs !== undefined) {
       declared[key].catalogs = catalogs;
       locked[key].catalogs = lockfile.catalogs;
     }


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-update-lockfile-sync.test.ts` checked each bun child only for `error:` in stderr. A warning, a spurious `Saved lockfile`, or a panic on a run that should write nothing passed.
- `expectInSync` compared a dependency group, the overrides or a catalog only when package.json declared it, so a stale copy left in bun.lock passed.
- The file was flagged as slow (10s on x64-asan, build 105417). That lever is not in this file (notes).

### Fix
- `run`/`runIn` require stderr (minus the two progress lines) to be empty or exactly `Saved lockfile` and return both streams. Every call pins which: `Saved lockfile` where the command rewrites bun.lock, `""` for no-op updates, `--dry-run` and `--frozen-lockfile`. Two cases pin the duplicate-dependency warning.
- `expectInSync` compares a field when either file has it. `resolutions(dir)` lists every resolved `name@version`. The `bun add` rows check what was installed. 8 inline snapshots pin the version moves, the two no-op summaries and the two error cases. No summary that misreports today (#38918, #38763) is pinned.
- The 77 cases and the helper signatures are unchanged, so the cases #38847 and #38866 add here keep working.
- Verified: `bun bd test test/cli/install/bun-update-lockfile-sync.test.ts`, 77 pass, also with the release build.

### Background
- `bun.lock` repeats each workspace's dependency groups under `workspaces`, plus the root's `overrides` and catalogs. `expectInSync` compares those to the package.json files, then runs `bun install --frozen-lockfile`, which fails if bun would change the lockfile.
- A `bun update` that only rewrote a literal reports `(no changes)` on stdout today (#38908). Its stderr still says `Saved lockfile`, which is what this file pins.

<details><summary>Notes</summary>

**Why this PR no longer reduces the child process count.** The first revision merged cases that run the same command on the same kind of tree into multi-package cases (77 cases to 57, 242 bun children to 183, measured by wrapping `Bun.spawn`). Locally that was 13.6s and 13.8s to 11.5s and 11.6s. In CI it is about 2.5s of a 436s ASAN shard, nothing on the other lanes (the file takes 1.1s to 2.9s there), and no gate reads it: the only per-file budget, `--skip-slower-than=10000` in `.buildkite/ci.mjs:833`, applies to the untiered darwin lanes. Three open bugfix branches (#38847, #38866, #38918) add cases to this file. A 77-to-57 restructure is not worth that for 2.5s, so the cases are back as they were.

**Where the ASAN time of this file goes, for separate changes.**
- Startup of every debug child: `bun-debug --version` takes 92ms, 69ms of it sys time, and 26ms with `MIMALLOC_ARENA_EAGER_COMMIT=0`. With that variable in the environment this file takes 8.7s instead of 11.5s locally and its sys time drops from 19.6s to 5.4s. The build-time equivalent is `MI_DEFAULT_ARENA_EAGER_COMMIT` (`vendor/mimalloc/src/options.c:46`) in the ASAN block of `scripts/build/deps/mimalloc.ts`. It needs its own check of the ASAN tracking.
- The registry: `VerdaccioRegistry.start` forks verdaccio with `execPath: isCI ? bunExe() : ...` (`test/harness.ts:1934`), so in CI verdaccio itself runs on the ASAN build. About 31 files pay that boot.
- `scripts/update-parallel-allowlist.mjs:174` excludes all of `cli/install/` from the parallel batch, so every install file runs serially in its shard, including the hermetic ones like this file (per-dir cache, `verdaccio.createTestDir`).
- `bun test` runs consecutive concurrent cases 5 at a time under ASAN (`src/options_types/context.rs:506`). Every case here is already `describe.concurrent`.
- `VerdaccioRegistry.stop` calls `process.kill(0)`, which sends no signal, so each run leaves its verdaccio process behind. 37 were alive on the machine after a day of runs, and the thread exhaustion that followed made `bun install` panic with `Failed to start HTTP Client thread`.

**Assertion changes in detail.**
- `run`/`runIn` (signatures unchanged) assert `/^(?:Saved lockfile)?$/` on the normalized stderr and return `{ stdout, stderr }`. Call sites pin `SAVED` on 50 runs and `""` on the runs that must write nothing: `update` on a `*` range that already resolves the newest version, `update no-deps` on an exact literal, the two bare-alias rows, `update` on a `dist-tag`, `1.x` and `=1.0.0` catalog entry, and `--dry-run`. Before: `not.toContain("error:")`.
- `install(dir, { frozen, stderr })` replaces `runBunInstall`: `Saved lockfile` exactly for every setup install and re-install, `""` for every `--frozen-lockfile` install and for the second install of the `reinstall: true` cases (before: `not.toContain("Saved lockfile")`). The two cases with a name in `dependencies` and `devDependencies` pin bun's duplicate-dependency warning with `duplicateWarning(...)`.
- `expectInSync` builds one object per workspace and compares all groups, overrides and catalogs in one `toStrictEqual`, including fields only bun.lock has.
- `resolutions(dir)` without a name lists every resolved `name@version` (workspace members included), replacing the per-name lists in 16 places. `bun update --latest` checks the whole `workspaces[""]` lockfile entry instead of `not.toContain("latest")`; the catalog `--latest` cases check the resolutions instead of `lockText.not.toContain('"latest"')`. The alias rows and `bun add --catalog --filter` compare whole objects.
- The 5 range rows pin the `^ no-deps 1.0.0 -> <version>` line exactly instead of a regex that accepted either arrow. The `*` no-op, the duplicate-dependency move, the `-r` move, the `--dry-run` summary and the two error cases are inline snapshots.

**Compatibility with the open branches.** #38847 and #38866 call `run(dir, "update", ...)`, `runIn(dir, PKG2, ...)`, `installed(dir, name)` with `toMatchObject`, `setup(..., { install: false })` and `expectInSync(dir, [...])`. All keep their shapes and semantics. A case of theirs whose update writes nothing passes `run` (stderr `""` is accepted) and can pin it later.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/install/bun-update-lockfile-sync.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/install/bun-update-lockfile-sync.test.ts
bun test v1.4.1 (861e9ae04)

test/cli/install/bun-update-lockfile-sync.test.ts:
(pass) bun update rewrites bun.lock together with package.json > bun update --latest [676.76ms]
(pass) bun update rewrites bun.lock together with package.json > bun update leaves a 1.x range as written and moves bun.lock to 1.1.0 [801.85ms]
(pass) bun update rewrites bun.lock together with package.json > bun update leaves a * range as written and moves bun.lock to 2.0.0 [851.34ms]
(pass) bun update rewrites bun.lock together with package.json > bun update leaves a 1 range as written and moves bun.lock to 1.1.0 [867.56ms]
(pass) bun update rewrites bun.lock together with package.json > bun update [927.69ms]
(pass) bun update rewrites bun.lock together with package.json > bun update on a * range that already resolves the newest version leaves both files byte-identical [379.02ms]
(pass) bun update rewrites bun.lock together with package.json > bun update <name> keeps the pin style [514.93ms]
(pass) bun update rewrites bun.lock together with package.json > bun update --latest rewrites a * range [569.40ms]
(pass) bun update rewrites bun.lock together with package.json > bun update leaves a >=1.0.0 range as written and moves bun.lock to 2.0.0 [849.56ms]
(pass) bun update rewrites bun.lock together with package.json > bun update leaves a 1.0.0 - 1.0.1 range as written and moves bun.lock to 1.0.1 [802.61ms]
(pass) bun update rewrites bun.lock together with package.json > bun update <name> on an exact literal [660.70ms]
(pass) bun update rewrites bun.lock together with package.json > bun update <alias> keeps the alias [505.96ms]
(pass) bun update rewrites bun.lock together with package.json > bun update <name>@<range> [653.88ms]
(pass) bun update rewrites bun.lock together with package.json > bun update <name> keeps a * literal and leaves the unnamed sibling
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/install/bun-update-lockfile-sync.test.ts | 417 ++++++++++++++--------
 1 file changed, 270 insertions(+), 147 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
test/cli/install/bun-update-lockfile-sync.test.ts      9      4      0
```

</details>

<!-- robobun:evidence:end -->