### PR TITLE
test(node:http): speed up node-http-uaf.test.ts and tighten its assertions

### DIFF
--- a/test/js/node/http/node-http-uaf-fixture-2.ts
+++ b/test/js/node/http/node-http-uaf-fixture-2.ts
@@ -1,30 +1,36 @@
-import http from "http";
-import { once } from "events";
+// Fixture for #18564: the server destroys a response while the client is still
+// uploading a large body. Ten uploads at a time, ROUNDS times. Prints one JSON
+// line with the request tally.
+import { once } from "node:events";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
 const server = http
   .createServer((req, res) => {
     res.writeHead(200, { Connection: "close" });
     res.destroy();
   })
-  .listen(0);
+  .listen(0, "127.0.0.1");
 await once(server, "listening");
-const url = `http://localhost:${server.address().port}`;
-console.log(`Server running at ${url}`);
+const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
 
 const body = new Blob([Buffer.allocUnsafe(1024 * 1024 * 10)]);
 const ROUNDS = Number(process.env.ROUNDS ?? 100);
+const tally = { requests: 0, responded: 0, failed: 0 };
 
 for (let i = 0; i < ROUNDS; i++) {
   await Promise.all(
-    [...Array(10)].map(() =>
-      fetch(url, {
-        method: "POST",
-        body,
-      })
+    [...Array(10)].map(() => {
+      tally.requests++;
+      return fetch(url, { method: "POST", body })
         .then(r => r.blob())
-        .catch(() => {}),
-    ),
+        .then(
+          () => tally.responded++,
+          () => tally.failed++,
+        );
+    }),
   );
 }
 
 server.close();
-console.log("Done");
+console.log(JSON.stringify(tally));

--- a/test/js/node/http/node-http-uaf-fixture.ts
+++ b/test/js/node/http/node-http-uaf-fixture.ts
@@ -1,65 +1,109 @@
-import express from "express";
-import bodyParser from "body-parser";
+// Fixture for #18485: a node:http response written after the client went away.
+//
+// The original crash: a POST handler read the whole body, then answered from a
+// timer. If the client aborted between those two points, the server socket
+// was freed and the late write touched it. Reading the body to its end had
+// cleared the native request-body callback, and with it the user data the
+// abort callback needed, so the response was never told about the abort.
+//
+// Part 1 reproduces that order of events exactly, once per round, with a raw
+// socket: read the body, close the client, wait until the server saw the
+// close, then write. Part 2 is the original load pattern, a plain node:http
+// version of the express app from the report: REQUESTS POSTs with CONCURRENCY
+// in flight, each aborted 1 to 6 ms after it started, each answered 1 ms after
+// its body was read.
+//
+// Prints one JSON line with the outcome of every round and the request tally.
+import { once } from "node:events";
+import http from "node:http";
+import net from "node:net";
 
-import { setTimeout as sleep } from "node:timers/promises";
-
-const CONCURRENCY = 100;
+const ROUNDS = Number(process.env.ROUNDS ?? 10);
 const REQUESTS = Number(process.env.REQUESTS ?? 10000);
+const CONCURRENCY = Number(process.env.CONCURRENCY ?? 100);
 
-const app = express();
-app.use(bodyParser.json());
+function respondLate(res: http.ServerResponse) {
+  res.statusCode = 500;
+  res.setHeader("Content-Type", "application/json; charset=utf-8");
+  res.end(JSON.stringify({ error: "late" }));
+}
 
-app.post("/error", (req, res) => {
+// Part 1: close after the body is read, write after the close.
+let round: { client: net.Socket; connection?: net.Socket; done: (outcome: string) => void };
+const closeThenWrite = http.createServer((req, res) => {
+  req.on("data", () => {});
+  req.on("end", async () => {
+    const { client, connection, done } = round;
+    const closed = once(connection!, "close");
+    client.destroy();
+    await closed;
+    try {
+      respondLate(res);
+      done("wrote after close");
+    } catch (e) {
+      done(`threw ${(e as NodeJS.ErrnoException)?.code}`);
+    }
+  });
+});
+closeThenWrite.on("connection", connection => {
+  round.connection = connection;
+});
+await once(closeThenWrite.listen(0, "127.0.0.1"), "listening");
+const closeThenWritePort = (closeThenWrite.address() as net.AddressInfo).port;
+
+const rounds: string[] = [];
+for (let i = 0; i < ROUNDS; i++) {
+  const { promise, resolve } = Promise.withResolvers<string>();
+  const client = net.connect(closeThenWritePort, "127.0.0.1");
+  client.on("error", () => {});
+  round = { client, done: resolve };
+  await once(client, "connect");
+  client.write("POST /error HTTP/1.1\r\nHost: a\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}");
+  rounds.push(await promise);
+}
+closeThenWrite.close();
+
+// Part 2: the original load pattern.
+const app = http.createServer((req, res) => {
+  req.on("data", () => {});
+  req.on("end", () => setTimeout(respondLate, 1, res));
+});
+await once(app.listen(0, "127.0.0.1"), "listening");
+const url = `http://127.0.0.1:${(app.address() as net.AddressInfo).port}/error`;
+
+const tally = { requests: 0, responded: 0, aborted: 0 };
+let free = CONCURRENCY;
+let slotFreed = Promise.withResolvers<void>();
+const inFlight = new Set<Promise<void>>();
+
+async function request() {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), Math.random() * 5 + 1);
   try {
-    // This specific pattern causes the segfault in Bun v1.2.6
-    const headers = { location: undefined };
-    headers.location.split("*/")["2"].split(")")["0"];
-  } catch (err) {
-    setTimeout(() => res.status(500).json({ error: err.message }), 1);
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+      signal: controller.signal,
+    });
+    await response.text();
+    tally.responded++;
+  } catch {
+    tally.aborted++;
   }
-});
+  free++;
+  slotFreed.resolve();
+  slotFreed = Promise.withResolvers<void>();
+}
 
-var server = app.listen(0, async () => {
-  const port = server.address().port;
-  console.log(`Server running on http://localhost:${port}`);
+for (let i = 0; i < REQUESTS; i++) {
+  while (free === 0) await slotFreed.promise;
+  free--;
+  tally.requests++;
+  const p = request().finally(() => inFlight.delete(p));
+  inFlight.add(p);
+}
+app.close();
+await Promise.all(inFlight);
 
-  const active = new Set();
-
-  async function makeRequest(id) {
-    const controller = new AbortController();
-
-    const secondPromise = setTimeout(() => controller.abort(), Math.random() * 5 + 1);
-
-    try {
-      await fetch(`http://localhost:${port}/error`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: "{}",
-        signal: controller.signal,
-      }).catch(() => {});
-    } catch (e) {}
-
-    try {
-      await secondPromise;
-    } catch (e) {}
-
-    active.delete(id);
-  }
-
-  console.log(`Starting ${REQUESTS} concurrent requests...`);
-  for (let i = 0; i < REQUESTS; i++) {
-    while (active.size >= CONCURRENCY) {
-      await sleep(1);
-    }
-
-    active.add(i);
-    makeRequest(i);
-    if (i > 0 && i % 1000 === 0) {
-      console.count("Completed request x 1000");
-    }
-  }
-
-  server.close();
-  while (active.size > 0) await sleep(1);
-  console.log("Done");
-});
+console.log(JSON.stringify({ rounds, tally }));

--- a/test/js/node/http/node-http-uaf-fixture.ts
+++ b/test/js/node/http/node-http-uaf-fixture.ts
@@ -71,7 +71,11 @@ const app = http.createServer((req, res) => {
 await once(app.listen(0, "127.0.0.1"), "listening");
 const url = `http://127.0.0.1:${(app.address() as net.AddressInfo).port}/error`;
 
-const tally = { requests: 0, responded: 0, aborted: 0 };
+// `aborted` counts requests the AbortController cut short. Anything else that
+// fails lands in `failed` under its error name, so a reset or a refused
+// connection cannot pass as an abort.
+const tally = { requests: 0, handled: 0, responded: 0, aborted: 0, failed: {} as Record<string, number> };
+app.on("request", () => tally.handled++);
 let free = CONCURRENCY;
 let slotFreed = Promise.withResolvers<void>();
 const inFlight = new Set<Promise<void>>();
@@ -88,8 +92,10 @@ async function request() {
     });
     await response.text();
     tally.responded++;
-  } catch {
-    tally.aborted++;
+  } catch (e) {
+    const { name, code } = e as NodeJS.ErrnoException;
+    if (name === "AbortError") tally.aborted++;
+    else tally.failed[code ?? name] = (tally.failed[code ?? name] ?? 0) + 1;
   }
   free++;
   slotFreed.resolve();
@@ -103,7 +109,10 @@ for (let i = 0; i < REQUESTS; i++) {
   const p = request().finally(() => inFlight.delete(p));
   inFlight.add(p);
 }
-app.close();
+// Let the last CONCURRENCY requests settle before the listener goes away, or
+// close() resets the ones still in the accept queue and they never reach the
+// handler.
 await Promise.all(inFlight);
+app.close();
 
 console.log(JSON.stringify({ rounds, tally }));

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -55,8 +55,13 @@ test.concurrent(
       stderr: "",
       exitCode: 0,
     });
+    // Under ASAN every request is aborted before the server answers; release
+    // answers about a third of them. Both must add up, and the load did abort.
     const { tally } = result as { tally: { responded: number; aborted: number } };
-    expect(tally.responded + tally.aborted).toBe(requests);
+    expect({ settled: tally.responded + tally.aborted, aborted: tally.aborted > 0 }).toEqual({
+      settled: requests,
+      aborted: true,
+    });
   },
   fixtureTimeout,
 );
@@ -144,19 +149,16 @@ test.concurrent.skipIf(!slow)(
 // An 8 MiB write does not fit the socket buffer, so the response is left with
 // a registered uWS writable handler while its onwritable slot holds a
 // non-callable (#32661 set undefined, #32735 the rest). The drain must skip
-// the slot: no crash, no uncaught TypeError, and the whole body still arrives.
-// One child runs the four values in turn and prints a line per value, so a
-// crash still names the value it happened on.
+// the slot: the whole body still arrives, and the child exits clean. A drain
+// that calls the slot throws an uncaught TypeError, which ends the child with
+// the error on stderr. One child runs the four values in turn and prints a
+// line per value, so a crash still names the value it happened on.
 test.concurrent("drain skips an onwritable slot set to undefined, null, 0 or false", async () => {
   const src = /* js */ `
     import http from "node:http";
     import { once } from "node:events";
 
-    let caught;
-    process.on("uncaughtException", err => { caught = String(err); });
-
     for (const slot of [undefined, null, 0, false]) {
-      caught = undefined;
       let hadBackpressure;
       const server = http.createServer(async (req, res) => {
         res.writeHead(200, { "Content-Type": "application/octet-stream" });
@@ -172,7 +174,7 @@ test.concurrent("drain skips an onwritable slot set to undefined, null, 0 or fal
 
       const response = await fetch("http://127.0.0.1:" + server.address().port + "/", { headers: { connection: "close" } });
       const body = await response.bytes();
-      console.log(JSON.stringify({ slot: String(slot), status: response.status, bodyLength: body.length, hadBackpressure, caught }));
+      console.log(JSON.stringify({ slot: String(slot), status: response.status, bodyLength: body.length, hadBackpressure }));
       server.close();
     }
   `;

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -146,25 +146,32 @@ test.concurrent.skipIf(!slow)(
   60_000,
 );
 
-// An 8 MiB write does not fit the socket buffer, so the response is left with
-// a registered uWS writable handler while its onwritable slot holds a
-// non-callable (#32661 set undefined, #32735 the rest). The drain must skip
-// the slot: the whole body still arrives, and the child exits clean. A drain
-// that calls the slot throws an uncaught TypeError, which ends the child with
-// the error on stderr. One child runs the four values in turn and prints a
-// line per value, so a crash still names the value it happened on.
+// The handler writes 8 MiB at a time until the socket pushes back (one write
+// on Linux and macOS, two on Windows, whose loopback takes a whole 8 MiB send
+// at once). The response is then left with a registered uWS writable handler
+// while its onwritable slot holds a non-callable (#32661 set undefined, #32735
+// the rest). The drain must skip the slot: the whole body still arrives, and
+// the child exits clean. A drain that calls the slot throws an uncaught
+// TypeError, which ends the child with the error on stderr. One child runs the
+// four values in turn and prints a line per value, so a crash still names the
+// value it happened on.
 test.concurrent("drain skips an onwritable slot set to undefined, null, 0 or false", async () => {
   const src = /* js */ `
     import http from "node:http";
     import { once } from "node:events";
 
+    const chunk = Buffer.alloc(8 * 1024 * 1024, "a");
     for (const slot of [undefined, null, 0, false]) {
+      let written = 0;
       let hadBackpressure;
       const server = http.createServer(async (req, res) => {
         res.writeHead(200, { "Content-Type": "application/octet-stream" });
-        res.write(Buffer.alloc(8 * 1024 * 1024, "a"));
         const sym = Object.getOwnPropertySymbols(res).find(s => s.description === "handle");
         const handle = res[sym];
+        while (handle.bufferedAmount === 0 && written < 32 * chunk.length) {
+          res.write(chunk);
+          written += chunk.length;
+        }
         hadBackpressure = handle.bufferedAmount > 0;
         handle.onwritable = slot;
         while (handle.bufferedAmount > 0) await new Promise(r => setImmediate(r));
@@ -174,7 +181,7 @@ test.concurrent("drain skips an onwritable slot set to undefined, null, 0 or fal
 
       const response = await fetch("http://127.0.0.1:" + server.address().port + "/", { headers: { connection: "close" } });
       const body = await response.bytes();
-      console.log(JSON.stringify({ slot: String(slot), status: response.status, bodyLength: body.length, hadBackpressure }));
+      console.log(JSON.stringify({ slot: String(slot), status: response.status, hadBackpressure, written, received: body.length }));
       server.close();
     }
   `;
@@ -198,12 +205,15 @@ test.concurrent("drain skips an onwritable slot set to undefined, null, 0 or fal
     lines: ["undefined", "null", "0", "false"].map(slot => ({
       slot,
       status: 200,
-      bodyLength: 8 * 1024 * 1024,
       hadBackpressure: true,
+      written: expect.any(Number),
+      received: expect.any(Number),
     })),
     stderr: "",
     exitCode: 0,
   });
+  // Every byte the handler wrote, before and after the pushback, arrived.
+  expect(lines.map(line => line.received)).toEqual(lines.map(line => line.written));
 });
 
 test.concurrent("'connection' and 'clientError' callbacks survive GC", async () => {

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -5,20 +5,80 @@ import http from "node:http";
 import net, { type AddressInfo } from "node:net";
 import { join } from "path";
 
-// Each fixture internally loops hundreds/thousands of requests to hit the
-// abort/destroy race. The counts below were validated by running the fixtures
-// against the pre-fix release build (bun 1.2.6, commit 8ebd5d53d, before both
-// #18485 and #18564) and counting crashes out of 10 runs:
-//
-//   fixture 1 (#18485): REQUESTS=500 5/5, 1000 5/5, 2000 10/10, 10000 10/10
-//   fixture 2 (#18564): ROUNDS=20 1/5, 40-100 8/10, 200 10/10
-//
-// so a single spawn at 2000 / 200 catches the original bugs 10/10 on a release
-// build without ASAN. ASAN/debug only reduces fixture 1 (the 80 s one); fixture
-// 2 stays at 200 everywhere, equal to the previous 2x100 total.
 const slow = isASAN || isDebug;
-uafTest("node-http-uaf-fixture.ts", { REQUESTS: slow ? "2000" : "10000" });
-uafTest("node-http-uaf-fixture-2.ts", { ROUNDS: "200" });
+
+async function runFixture(fixture: string, env: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, fixture)],
+    env: { ...bunEnv, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // A fixture prints one JSON line when it completes. Keep the raw text when
+  // it did not (a crash), so the failing assertion shows what came out.
+  let result: unknown = stdout;
+  try {
+    result = JSON.parse(stdout);
+  } catch {}
+  return { result, stderr, exitCode };
+}
+
+// Ceiling for the tests that spawn a child. All of them run at once, so on a
+// loaded 16-core debug+ASAN box the children take 3 to 8 s each (the #18564
+// fixture is the longest). Release runs each in well under a second; the 20 s
+// ceiling is for the windows-aarch64 lane, which once took 5 s on one of them.
+const fixtureTimeout = slow ? 60_000 : 20_000;
+
+// The fixture replays the #18485 crash in two ways. Ten rounds make the exact
+// order of events that freed the socket under a pending response, one per
+// connection. Then the load pattern of the report: REQUESTS POSTs, 100 in
+// flight, each aborted 1 to 6 ms in. The pre-fix release (bun 1.2.6, commit
+// 8ebd5d53d) crashes on the first round every time, and the load pattern
+// crashed it around request 300 in 10/10 runs at both 500 and 1000 requests.
+// The load part costs about 5 ms per request under ASAN, so slow builds run
+// fewer of them.
+test.concurrent(
+  "a response written after the client aborted does not touch the freed socket (#18485)",
+  async () => {
+    const requests = slow ? 500 : 10000;
+    const { result, stderr, exitCode } = await runFixture("node-http-uaf-fixture.ts", {
+      ROUNDS: "10",
+      REQUESTS: String(requests),
+    });
+    expect({ result, stderr, exitCode }).toEqual({
+      result: {
+        rounds: Array.from({ length: 10 }, () => "wrote after close"),
+        tally: { requests, responded: expect.any(Number), aborted: expect.any(Number) },
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+    const { tally } = result as { tally: { responded: number; aborted: number } };
+    expect(tally.responded + tally.aborted).toBe(requests);
+  },
+  fixtureTimeout,
+);
+
+// 200 rounds of ten uploads crash bun 1.2.6 every time (8/8 here, between
+// upload 150 and 400; 10/10 in the earlier calibration, where 40 to 100 rounds
+// did in 8/10). The same count runs on every lane: the uploads are cut short,
+// so a round costs about 35 ms under ASAN whatever the body size.
+test.concurrent(
+  "destroying a response while its body is still uploading does not crash (#18564)",
+  async () => {
+    const { result, stderr, exitCode } = await runFixture("node-http-uaf-fixture-2.ts", { ROUNDS: "200" });
+    expect({ result, stderr, exitCode }).toEqual({
+      result: { requests: 2000, responded: expect.any(Number), failed: expect.any(Number) },
+      stderr: "",
+      exitCode: 0,
+    });
+    const { responded, failed } = result as { responded: number; failed: number };
+    expect(responded + failed).toBe(2000);
+  },
+  fixtureTimeout,
+);
 
 // A termination request (worker.terminate(), a node:vm timeout) that landed on
 // the native writeHead of a response used to be taken in a stretch of native
@@ -27,110 +87,94 @@ uafTest("node-http-uaf-fixture-2.ts", { ROUNDS: "200" });
 // The validator only exists in debug and ASAN builds; release has nothing to
 // observe. The fixture steers node:vm deadlines onto that call. Against the
 // unfixed build, all 20 calibration runs (five at a time on a 16-core
-// debug+ASAN box) aborted, between attempt 350 and 1060. The fixed build
-// survived 20/20 runs of the full 3000 attempts, in 17 to 19 s each.
+// debug+ASAN box) aborted, between attempt 350 and 1060. Two runs of 1500
+// attempts each keep the total and take half the wall time: each run alone
+// covers the window the calibration saw, with the same end/flushHeaders
+// alternation.
 test.concurrent.skipIf(!slow)(
   "a termination request landing on the native writeHead passes the exception-check validator",
   async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "node-http-writehead-termination-fixture.ts")],
-      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
-      stdout: "pipe",
-      stderr: "pipe",
-      stdin: "ignore",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // On a failure stdout stays empty and stderr carries the validator's report.
-    const summary = stdout.startsWith("ok ") ? JSON.parse(stdout.slice(3)) : stdout;
+    const runs = await Promise.all(
+      [1, 2].map(() =>
+        runFixture("node-http-writehead-termination-fixture.ts", {
+          BUN_JSC_validateExceptionChecks: "1",
+          ATTEMPTS: "1500",
+        }),
+      ),
+    );
     const counts = {
       early: expect.any(Number),
       inCall: expect.any(Number),
       late: expect.any(Number),
       cutAfterHead: expect.any(Number),
     };
-    expect({ summary, stderr, exitCode }).toEqual({
-      summary: {
-        attempts: expect.any(Number),
-        timeout: expect.any(Number),
-        paths: [
-          { name: "end", ...counts },
-          { name: "flushHeaders", ...counts },
-        ],
-      },
-      stderr: "",
-      exitCode: 0,
-    });
-    expect(summary.attempts).toBeGreaterThan(100);
-    // The deadlines did land inside both calls (about 45% of them do here), and
-    // on the end() path some were taken right after the native writeHead had
-    // put the head out (20 to 30% of that path's attempts here).
-    const [end, flushHeaders] = summary.paths;
-    expect({ end: end.inCall > 0, flushHeaders: flushHeaders.inCall > 0, cutAfterHead: end.cutAfterHead > 0 }).toEqual({
-      end: true,
-      flushHeaders: true,
-      cutAfterHead: true,
-    });
+    for (const { result: summary, stderr, exitCode } of runs as { result: any; stderr: string; exitCode: number }[]) {
+      // On a failure stdout stays empty and stderr carries the validator's report.
+      expect({ summary, stderr, exitCode }).toEqual({
+        summary: {
+          attempts: expect.any(Number),
+          timeout: expect.any(Number),
+          paths: [
+            { name: "end", ...counts },
+            { name: "flushHeaders", ...counts },
+          ],
+        },
+        stderr: "",
+        exitCode: 0,
+      });
+      expect(summary.attempts).toBeGreaterThan(100);
+      // The deadlines did land inside both calls (about 45% of them do here),
+      // and on the end() path some were taken right after the native writeHead
+      // had put the head out (15 to 30% of that path's attempts here).
+      const [end, flushHeaders] = summary.paths;
+      expect({
+        end: end.inCall > 0,
+        flushHeaders: flushHeaders.inCall > 0,
+        cutAfterHead: end.cutAfterHead > 0,
+      }).toEqual({
+        end: true,
+        flushHeaders: true,
+        cutAfterHead: true,
+      });
+    }
   },
   60_000,
 );
 
-function uafTest(fixture: string, extraEnv: Record<string, string>) {
-  test.concurrent(
-    `should not crash on abort (${fixture})`,
-    async () => {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(import.meta.dir, fixture)],
-        env: { ...bunEnv, ...extraEnv },
-        stdout: "pipe",
-        stderr: "pipe",
-        stdin: "ignore",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(stdout.trimEnd().split("\n").at(-1)).toBe("Done");
-      expect(exitCode).toBe(0);
-    },
-    // Measured ~21 s (fixture 1) / ~10 s (fixture 2) on a 16-core debug+ASAN
-    // box with the other concurrent tests contending; release runs the full
-    // 10k in ~1 s. Keep the 20 s release ceiling for the windows-aarch64 lane
-    // that previously ran one fixture to 5006 ms.
-    slow ? 60_000 : 20_000,
-  );
-}
-
-test.concurrent.each([
-  ["undefined", "undefined"],
-  ["null", "null"],
-  ["0", "0"],
-  ["false", "false"],
-])("should not crash when drain fires after onWritable slot is set to %s", async (_, slotExpr) => {
+// An 8 MiB write does not fit the socket buffer, so the response is left with
+// a registered uWS writable handler while its onwritable slot holds a
+// non-callable (#32661 set undefined, #32735 the rest). The drain must skip
+// the slot: no crash, no uncaught TypeError, and the whole body still arrives.
+// One child runs the four values in turn and prints a line per value, so a
+// crash still names the value it happened on.
+test.concurrent("drain skips an onwritable slot set to undefined, null, 0 or false", async () => {
   const src = /* js */ `
     import http from "node:http";
-    import net from "node:net";
     import { once } from "node:events";
 
     let caught;
     process.on("uncaughtException", err => { caught = String(err); });
 
-    const server = http.createServer(async (req, res) => {
-      res.writeHead(200, { "Content-Type": "application/octet-stream" });
-      res.write(Buffer.alloc(8 * 1024 * 1024, "a"));
-      const sym = Object.getOwnPropertySymbols(res).find(s => s.description === "handle");
-      const handle = res[sym];
-      handle.onwritable = ${slotExpr};
-      while (handle.bufferedAmount > 0) await new Promise(r => setImmediate(r));
-      res.end();
-    });
-    await once(server.listen(0), "listening");
+    for (const slot of [undefined, null, 0, false]) {
+      caught = undefined;
+      let hadBackpressure;
+      const server = http.createServer(async (req, res) => {
+        res.writeHead(200, { "Content-Type": "application/octet-stream" });
+        res.write(Buffer.alloc(8 * 1024 * 1024, "a"));
+        const sym = Object.getOwnPropertySymbols(res).find(s => s.description === "handle");
+        const handle = res[sym];
+        hadBackpressure = handle.bufferedAmount > 0;
+        handle.onwritable = slot;
+        while (handle.bufferedAmount > 0) await new Promise(r => setImmediate(r));
+        res.end();
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
 
-    const sock = net.connect(server.address().port, "127.0.0.1");
-    await once(sock, "connect");
-    sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
-    let received = 0;
-    sock.on("data", d => (received += d.length));
-    await once(sock, "close");
-    console.log(JSON.stringify({ received, caught }));
-    server.close();
+      const response = await fetch("http://127.0.0.1:" + server.address().port + "/", { headers: { connection: "close" } });
+      const body = await response.bytes();
+      console.log(JSON.stringify({ slot: String(slot), status: response.status, bodyLength: body.length, hadBackpressure, caught }));
+      server.close();
+    }
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", src],
@@ -138,15 +182,29 @@ test.concurrent.each([
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-    stdout: { received: expect.any(Number) },
+  const lines = stdout
+    .split("\n")
+    .filter(Boolean)
+    .map(line => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return line;
+      }
+    });
+  expect({ lines, stderr, exitCode }).toEqual({
+    lines: ["undefined", "null", "0", "false"].map(slot => ({
+      slot,
+      status: 200,
+      bodyLength: 8 * 1024 * 1024,
+      hadBackpressure: true,
+    })),
     stderr: "",
     exitCode: 0,
   });
-  expect(JSON.parse(stdout).received).toBeGreaterThan(8 * 1024 * 1024);
 });
 
-test("'connection' and 'clientError' callbacks survive GC", async () => {
+test.concurrent("'connection' and 'clientError' callbacks survive GC", async () => {
   // The server's native struct stores these two node:http callbacks on the JS
   // wrapper (GC-visited WriteBarrier slots), not in Strong handles. Force GC
   // between registration and dispatch to prove the wrapper roots them.
@@ -175,21 +233,19 @@ test("'connection' and 'clientError' callbacks survive GC", async () => {
   }
 });
 
-test("'request' and 'clientError' still dispatch on a connection that outlives server.close() and a GC", async () => {
-  // The fixture also runs under `node --expose-gc` and prints the same result.
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), join(import.meta.dir, "node-http-server-close-gc-fixture.mjs")],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ results: JSON.parse(stdout.trim() || "null"), stderr, exitCode }).toEqual({
-    results: Array.from({ length: 3 }, () => ({
-      statuses: ["HTTP/1.1 200 OK", "HTTP/1.1 200 OK"],
-      clientErrors: ["HPE_INVALID_HEADER_TOKEN"],
-    })),
-    stderr: "",
-    exitCode: 0,
-  });
-});
+test.concurrent(
+  "'request' and 'clientError' still dispatch on a connection that outlives server.close() and a GC",
+  async () => {
+    // The fixture also runs under `node --expose-gc` and prints the same result.
+    const { result, stderr, exitCode } = await runFixture("node-http-server-close-gc-fixture.mjs");
+    expect({ result, stderr, exitCode }).toEqual({
+      result: Array.from({ length: 3 }, () => ({
+        statuses: ["HTTP/1.1 200 OK", "HTTP/1.1 200 OK"],
+        clientErrors: ["HPE_INVALID_HEADER_TOKEN"],
+      })),
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+  fixtureTimeout,
+);

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -37,12 +37,15 @@ const fixtureTimeout = slow ? 60_000 : 20_000;
 // flight, each aborted 1 to 6 ms in. The pre-fix release (bun 1.2.6, commit
 // 8ebd5d53d) crashes on the first round every time, and the load pattern
 // crashed it around request 300 in 10/10 runs at both 500 and 1000 requests.
-// The load part costs about 5 ms per request under ASAN, so slow builds run
-// fewer of them.
+// Release ran 10000 before. Every request is a new connection, and on darwin
+// the listen(0) of the two GC tests below failed right after that burst
+// (builds 105020, 105316 and 105364), which fits an exhausted ephemeral port
+// range. 1000 is the largest calibrated count and a tenth of the churn. The
+// load part costs about 5 ms per request under ASAN, so slow builds run fewer.
 test.concurrent(
   "a response written after the client aborted does not touch the freed socket (#18485)",
   async () => {
-    const requests = slow ? 500 : 10000;
+    const requests = slow ? 500 : 1000;
     const { result, stderr, exitCode } = await runFixture("node-http-uaf-fixture.ts", {
       ROUNDS: "10",
       REQUESTS: String(requests),
@@ -50,17 +53,31 @@ test.concurrent(
     expect({ result, stderr, exitCode }).toEqual({
       result: {
         rounds: Array.from({ length: 10 }, () => "wrote after close"),
-        tally: { requests, responded: expect.any(Number), aborted: expect.any(Number) },
+        tally: {
+          requests,
+          handled: expect.any(Number),
+          responded: expect.any(Number),
+          aborted: expect.any(Number),
+          // Only AbortError counts as aborted. A reset or a refused connection
+          // would show up here by name.
+          failed: {},
+        },
       },
       stderr: "",
       exitCode: 0,
     });
     // Under ASAN every request is aborted before the server answers; release
-    // answers about a third of them. Both must add up, and the load did abort.
-    const { tally } = result as { tally: { responded: number; aborted: number } };
-    expect({ settled: tally.responded + tally.aborted, aborted: tally.aborted > 0 }).toEqual({
+    // answers about a fifth of them and about a tenth are aborted before they
+    // reach the server at all. The rest must have reached it and settled.
+    const { tally } = result as { tally: { handled: number; responded: number; aborted: number } };
+    expect({
+      settled: tally.responded + tally.aborted,
+      aborted: tally.aborted > 0,
+      handled: tally.handled > 0,
+    }).toEqual({
       settled: requests,
       aborted: true,
+      handled: true,
     });
   },
   fixtureTimeout,

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -67,17 +67,15 @@ test.concurrent(
       exitCode: 0,
     });
     // Under ASAN every request is aborted before the server answers; release
-    // answers about a fifth of them and about a tenth are aborted before they
-    // reach the server at all. The rest must have reached it and settled.
-    const { tally } = result as { tally: { handled: number; responded: number; aborted: number } };
-    expect({
-      settled: tally.responded + tally.aborted,
-      aborted: tally.aborted > 0,
-      handled: tally.handled > 0,
-    }).toEqual({
+    // answers about a fifth of them. `handled` says how many reached the
+    // server: about nine in ten on a fast machine, and none on a slow one
+    // (windows-aarch64 in CI), where every abort lands before the accept. It
+    // is reported, not asserted. The deterministic rounds above carry the
+    // coverage; the load only has to settle, and abort at least once.
+    const { tally } = result as { tally: { responded: number; aborted: number } };
+    expect({ settled: tally.responded + tally.aborted, aborted: tally.aborted > 0 }).toEqual({
       settled: requests,
       aborted: true,
-      handled: true,
     });
   },
   fixtureTimeout,

--- a/test/js/node/http/node-http-writehead-termination-fixture.ts
+++ b/test/js/node/http/node-http-writehead-termination-fixture.ts
@@ -113,7 +113,7 @@ server.listen(0, "127.0.0.1", () => {
       timeout,
       paths: paths.map(({ name, early, inCall, late, cutAfterHead }) => ({ name, early, inCall, late, cutAfterHead })),
     };
-    console.log("ok " + JSON.stringify(summary));
+    console.log(JSON.stringify(summary));
     process.exit(0);
   }
 


### PR DESCRIPTION
### Problem
- `test/js/node/http/node-http-uaf.test.ts`: 12 s on the ASAN lane (build #105417), 28.8 s on a local debug build. The express fixture for #18485 (22 s) and the writeHead termination fixture (18 s) set the pace.
- On darwin the file flakes: after its 12000-connection burst, the `listen(0)` of the two GC tests fails with `EADDRINUSE` (builds 105020, 105316, 105364). That is why it sits in `test/parallel-denylist.txt`.
- The drain test never reached a drain on Windows, and once got 1503 of 8 MiB on darwin x64 (build 105333).

### Fix
- The #18485 fixture is plain `node:http` and replays the crash on purpose: read the body, close the client, wait for the server to see the close, write. bun 1.2.6 (pre-fix) crashes on the first round, 5/5. The load pattern follows at 500 requests on debug and ASAN builds and 1000 on release, both calibrated (1.2.6 crashes at about request 300, 10/10). 1000 is a tenth of the darwin churn.
- The load counts only `AbortError` as aborted, reports other errors by name, and settles before `close()`. Before, `close()` reset the last 100 queued requests and they never reached the handler.
- The termination fixture runs as two children of 1500 attempts, same alternation; each alone covers the window where the unfixed build aborted (attempt 350 to 1060). The drain test writes until the socket pushes back and asserts `received === written`. The GC tests run concurrently with the rest, on purpose.
- Verified: `bun bd test test/js/node/http/node-http-uaf.test.ts`, 11.9 to 12.9 s (before 28.8 s, same machine and build). Release: 0.45 s (before 0.97 s). Windows x64 with the system bun: 6 pass.

### Background
- #18485: reading a body to its end cleared the uWS `userData` that `onAborted` shared. A client close then called `onAborted` with a null response (segfault at 0x8E), and a later write reached the freed socket.
- #18564: the server destroys a response while the client still uploads. That race needs the load: 200 rounds of ten uploads crash 1.2.6 8/8.
- On darwin `on_listen_failed` (`src/runtime/server/mod.rs:2016`) reports every listen failure as `EADDRINUSE`, so the real errno is unknown. Each request is a new connection and macOS has 16384 ephemeral ports, so the count is the lever this PR has.

<details><summary>Notes</summary>

Per-test times, local debug build, before: express fixture 22.3 s, termination 19.0 s, fixture 2 8.3 s, drain cases 2.4 to 3.1 s each, GC test 0.6 s, server-close fixture 2.9 s (the last two after the concurrent group). After: termination 9.3 to 10.0 s (two children), fixture 2 6.8 to 7.3 s, fixture 1 4.8 to 5.5 s, drain child 2.3 s, server-close fixture 2.5 s, GC test 0.5 s. User CPU for the file: 113 to 116 s before, 70 to 74 s after.

CI-level effect: this file is 0.2% of the ASAN lane's test time, so the wall-time win is a few seconds on one shard. The observable CI problem with this file is the darwin flake and the denylist seat. Once darwin has passed a few builds with the smaller burst, a one-line follow-up can remove `js/node/http/node-http-uaf.test.ts` from `test/parallel-denylist.txt` so the file leaves the serial phase.

Express fixture cost on the debug build: `import express; import body-parser` alone takes 6.1 s. With REQUESTS=1 the fixture takes 7.6 s, with 2000 it takes 27 s (about 10 ms per request). The plain node:http version takes about 3.7 ms per request plus 2.4 s fixed (module load and the ten deterministic rounds, 50 ms each after the first).

Calibration against bun 1.2.6 (commit 8ebd5d53d, the release before #18485 and #18564 landed, release build): the deterministic rounds crash it at ROUNDS=1, 5/5, with or without the write after the close, "Segmentation fault at address 0x8E". The load pattern crashes it 10/10 at REQUESTS=500 and 10/10 at 1000, at `fetch(300)` in almost every run, and still 3/3 at both counts after the close() reorder. The express version crashed at about `fetch(200)`.

Why the close is enough: in 1.2.6, `uws_res_on_data(res, null, null)` (called when the body has been read) set `HttpResponseData::userData` to null, and `onAborted` shared that field. On close, `HttpContext` called `onAborted((HttpResponse*)s, nullptr)` and `NodeHTTPResponse.onAbort` read `this.finished` through the null pointer. The fix in #18485 added a `userData != nullptr` guard and the `closed` flag set from the socket wrapper's `onClose`, which `cork()` checks before touching the socket.

Load tally: the first version of this PR kept the fixture's original order, `close()` then wait for the in-flight requests. Review found that `close()` resets the requests still in the accept queue (exactly CONCURRENCY of them: 100 of 500 on debug never reached the handler) and that the catch-all counted those resets as aborts, so `aborted > 0` held even with the AbortController removed. The fixture now waits first, counts only `AbortError`, reports other errors under `failed` by name (the test pins it to `{}`), and counts `request` events as `handled`. Measured: debug 500/500 handled, 0 responded, 500 aborted; release at 1000: 885 to 891 handled, 144 to 214 responded, the rest aborted before the server saw them; `failed` was `{}` in every run. `handled` is reported, not asserted: on windows-aarch64 in CI (build 105796) two of three attempts had every request aborted before the server accepted it, a statement about that machine's speed, not about bun.

Darwin history (annotations of main builds): 105020 (darwin aarch64, hard fail), 105316 and 105364 (darwin aarch64, passed on retry) all show `Failed to start server. Is port 0 in use? code: "EADDRINUSE"` in `'connection' and 'clientError' callbacks survive GC` and again in `node-http-server-close-gc-fixture.mjs`. Both tests ran in the serial tail, right after the 10000 + 2000 connection burst. 105333 (darwin x64, passed on retry): the drain case for `null` received 1503 bytes instead of more than 8 MiB. The old client was a raw socket that stopped at `close`; the new one reads the response with `fetch` and the assertion is exact, so a repeat reports the byte count.

Fixture 2: the body size does not change the cost (3.9 s for 50 rounds at 10 MiB and at 1 MiB under ASAN), because the server destroys the response on the headers and the upload is cut short. The crashes landed between upload 150 and 400 in 8/8 runs of 200 rounds. A forced `Bun.gc(true)` after every round stopped 1.2.6 from crashing (0/6 at 20 rounds, against 3/6 without), so the crash depends on a GC landing during a round. I did not find a deterministic form and left the count at 200.

Termination fixture: per attempt on the debug build, 2.6 ms inside `runInContext` (the 2 ms deadline plus entry), 1.9 ms between handler exit and the next handler entry. A pipelined client (two requests in flight) did not change the total (9.3 to 9.9 s for 1500 attempts, same as 9.4 s without), so the gap is event loop work, not the round trip. Running one path per child changed the landing distribution (`cutAfterHead` for `end` fell from 487 to 111 per 1500 attempts), so the children keep the alternation instead. A 1 ms deadline would save 1.5 s per child but changes the mechanics the calibration was made with, so it stays at 2 ms. The JIT worker threads use about 0.7 core per child during the run, so the split costs about 13 s more CPU in total.

Drain cases: the four slot values exercise one guard (`on_drain_corked` skipping a non-cell), so they share one child: that saves three ASAN process startups (about 7 CPU-seconds) and changes no wall time, since the four already ran concurrently. The fixture used a raw socket and asserted `received > 8 MiB`. The first CI run of this PR failed the new `hadBackpressure` check on both Windows lanes: a single 8 MiB `res.write` left `bufferedAmount` at 0, so the old test never reached the drain there. On Windows Server 2019 the loopback accepted one 8 MiB send whole and the second was buffered whole (`bufferedAmount` 8 MiB + 8 bytes of chunk framing); with 1 MiB chunks it accepted 4 and buffered the fifth. The handler now writes 8 MiB chunks until `bufferedAmount` is non-zero, capped at 32, and the test asserts `received === written` per slot. Verified with the system bun on windows-x64: 6 pass in 3.1 s.

GC tests: they were plain `test()` after the concurrent group, so their `listen(0)` ran right after the burst. They are `test.concurrent` now, so their `listen(0)` runs at the start of the file, and the burst is a tenth of what it was. If darwin still fails them after this, the next lever is their own file.

Release run (`USE_SYSTEM_BUN=1`): 8 pass, 1 skip (the termination test), 0.45 s.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 4 · 4 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/http/node-http-uaf.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/http/node-http-uaf.test.ts
bun test v1.4.1 (861e9ae04)

test/js/node/http/node-http-uaf.test.ts:
(pass) 'connection' and 'clientError' callbacks survive GC [535.32ms]
(pass) drain skips an onwritable slot set to undefined, null, 0 or false [2203.73ms]
(pass) 'request' and 'clientError' still dispatch on a connection that outlives server.close() and a GC [2414.82ms]
(pass) a response written after the client aborted does not touch the freed socket (#18485) [4897.61ms]
(pass) destroying a response while its body is still uploading does not crash (#18564) [6753.48ms]
(pass) a termination request landing on the native writeHead passes the exception-check validator [9324.85ms]

 6 pass
 0 fail
 14 expect() calls
Ran 6 tests across 1 file. [11.93s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/http/node-http-uaf-fixture-2.ts       |  32 +-
 test/js/node/http/node-http-uaf-fixture.ts         | 159 ++++++----
 test/js/node/http/node-http-uaf.test.ts            | 325 +++++++++++++--------
 .../node-http-writehead-termination-fixture.ts     |   2 +-
 4 files changed, 330 insertions(+), 188 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
test/js/node/http/node-http-uaf-fixture-2.ts                  1      1      0
test/js/node/http/node-http-uaf-fixture.ts                    3      3      0
test/js/node/http/node-http-uaf.test.ts                      10     16      0
…js/node/http/node-http-writehead-termination-fixture.ts      2      3      0
```

</details>

<!-- robobun:evidence:end -->