### PR TITLE
WebKit: fused resolve_and_get_from_scope (oven-sh/WebKit#516)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "1cb96a7b0edd24a18927c4c05007b0649abda4f4";
+export const WEBKIT_VERSION = "autobuild-preview-pr-516-87cc6cc0";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
Stacked on #40440. Pin bump only; runs Bun's test suite against oven-sh/WebKit#516's preview build.

`resolve_scope` + `get_from_scope` become one instruction for static non-local reads. Claude Code binary (darwin-arm64) with #40440 + this: 220.4 MB → 203.1 MB; embedded bytecode 89.0 MB → 72.3 MB; startup and footprint unchanged.

Will be re-pinned to the WebKit main sha once #516 lands.