### PR TITLE
Free a native microtask's context when the microtask queue discards it

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1598,14 +1598,9 @@ impl<const SSL: bool> Drop for WebSocket<SSL> {
         // deflate already dropped in clear_data; this is defensive
         self.deflate.replace(None);
         if let Some(task) = self.pending_initial_task.take() {
-            // Still queued (or abandoned with the VM's microtask queue); it
-            // must not follow its back-reference to us.
+            // Still owned by the microtask queue (run later, or dropped unrun
+            // at teardown); it must not follow its back-reference to us.
             task.ws.set(None);
-            if self.global_this.bun_vm().is_shutting_down() {
-                // The queue will never run it; release the C++ pending-activity
-                // ref it holds now.
-                task.data.set(None);
-            }
         }
         bun_core::scoped_log!(alloc, "destroy({}) = {:p}", Self::ALLOC_TYPE_NAME, self);
     }
@@ -1850,6 +1845,16 @@ impl<const SSL: bool> jsc::MicrotaskCallback for InitialDataTask<SSL> {
         if let Some(initial_data) = self.data.replace(None) {
             let _guard = RefPtr::from_this(ws);
             initial_data.deliver(ws);
+        }
+    }
+}
+
+impl<const SSL: bool> Drop for InitialDataTask<SSL> {
+    fn drop(&mut self) {
+        // Dropped unrun by the microtask queue while the client is still
+        // alive: clear its back-reference to us.
+        if let Some(ws) = self.ws.take() {
+            ws.this_ptr().pending_initial_task.set(None);
         }
     }
 }

--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -818,32 +818,31 @@ impl JSGlobalObject {
         self.throw_value(instance)
     }
 
-    /// Queue a native callback as a microtask. Callers supply the C-ABI
-    /// trampoline directly; the wrapper only erases the context pointer type.
-    pub fn queue_microtask_callback<C>(
-        &self,
-        ctx_val: *mut C,
-        function: unsafe extern "C" fn(*mut c_void),
-    ) {
-        crate::mark_binding();
-        JSC__JSGlobalObject__queueMicrotaskCallback(self, ctx_val.cast::<c_void>(), function);
-    }
-
-    /// Queue `task` to run as a microtask; the queue owns the box until then
-    /// and the returned back-reference is valid until [`MicrotaskCallback::run`]
-    /// is entered. If the VM is torn down before the microtask queue drains,
-    /// the box is leaked along with the rest of the queue.
+    /// Queue `task` to run as a microtask. The microtask queue owns the box:
+    /// it is passed to [`MicrotaskCallback::run`] when the microtask fires, or
+    /// dropped unrun if the queue discards it (VM teardown). The returned
+    /// back-reference is valid until either happens.
     pub fn queue_microtask_boxed<T: MicrotaskCallback>(
         &self,
         task: Box<T>,
     ) -> bun_ptr::BackRef<T, bun_ptr::Root> {
         unsafe extern "C" fn run<T: MicrotaskCallback>(ctx: *mut c_void) {
-            // SAFETY: `ctx` is the `Box<T>` leaked below; the microtask queue
-            // invokes each callback exactly once.
+            // SAFETY: `ctx` is the `Box<T>` leaked below; C++ hands it to
+            // exactly one of `run`/`drop`, once.
             T::run(unsafe { bun_core::heap::take(ctx.cast::<T>()) });
         }
+        unsafe extern "C" fn drop<T: MicrotaskCallback>(ctx: *mut c_void) {
+            // SAFETY: as for `run`.
+            core::mem::drop(unsafe { bun_core::heap::take(ctx.cast::<T>()) });
+        }
+        crate::mark_binding();
         let task = bun_core::heap::into_raw(task);
-        self.queue_microtask_callback(task, run::<T>);
+        JSC__JSGlobalObject__queueMicrotaskCallback(
+            self,
+            task.cast::<c_void>(),
+            run::<T>,
+            drop::<T>,
+        );
         // SAFETY: `task` is the live leaked box; see the doc comment for the
         // holder's obligation.
         unsafe { bun_ptr::BackRef::from_root(task) }
@@ -1499,11 +1498,13 @@ unsafe extern "C" {
 
     // safe: `JSGlobalObject` is an opaque `UnsafeCell`-backed ZST handle (`&` is
     // ABI-identical to non-null `*const`); `ctx` is an opaque round-trip pointer
-    // C++ only stores and forwards to `function` (never dereferenced as Rust data).
+    // C++ only stores and forwards to exactly one of `run` / `drop` (never
+    // dereferenced as Rust data).
     safe fn JSC__JSGlobalObject__queueMicrotaskCallback(
         this: &JSGlobalObject,
         ctx: *mut c_void,
-        function: unsafe extern "C" fn(*mut c_void),
+        run: unsafe extern "C" fn(*mut c_void),
+        drop: unsafe extern "C" fn(*mut c_void),
     );
 
     safe fn Bun__Process__emitWarning(

--- a/src/jsc/bindings/BunClientData.cpp
+++ b/src/jsc/bindings/BunClientData.cpp
@@ -28,6 +28,7 @@
 #include "../../runtime/bake/BakeGlobalObject.h"
 #include "napi_handle_scope.h"
 #include "NativePromiseContext.h"
+#include "NativeMicrotaskContext.h"
 #include "StrongRootBlock.h"
 
 namespace WebCore {
@@ -41,6 +42,7 @@ JSHeapData::JSHeapData(Heap& heap)
     , m_heapCellTypeForBakeGlobalObject(JSC::IsoHeapCellType::Args<Bake::GlobalObject>())
     , m_heapCellTypeForNapiHandleScopeImpl(JSC::IsoHeapCellType::Args<Bun::NapiHandleScopeImpl>())
     , m_heapCellTypeForNativePromiseContext(JSC::IsoHeapCellType::Args<Bun::NativePromiseContext>())
+    , m_heapCellTypeForNativeMicrotaskContext(JSC::IsoHeapCellType::Args<Bun::NativeMicrotaskContext>())
     , m_domConstructorSpace ISO_SUBSPACE_INIT(heap, heap.cellHeapCellType, JSDOMConstructorBase)
     , m_domNamespaceObjectSpace ISO_SUBSPACE_INIT(heap, heap.cellHeapCellType, JSDOMObject)
     , m_subspaces(makeUnique<ExtendedDOMIsoSubspaces>())

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -173,6 +173,7 @@ public:
     JSC::IsoHeapCellType m_heapCellTypeForNapiHandleScopeImpl;
     JSC::IsoHeapCellType m_heapCellTypeForBakeGlobalObject;
     JSC::IsoHeapCellType m_heapCellTypeForNativePromiseContext;
+    JSC::IsoHeapCellType m_heapCellTypeForNativeMicrotaskContext;
     // JSC::IsoHeapCellType m_heapCellTypeForGeneratedClass;
 
 private:

--- a/src/jsc/bindings/NativeMicrotaskContext.cpp
+++ b/src/jsc/bindings/NativeMicrotaskContext.cpp
@@ -1,0 +1,40 @@
+#include "NativeMicrotaskContext.h"
+
+namespace Bun {
+
+const JSC::ClassInfo NativeMicrotaskContext::s_info = {
+    "NativeMicrotaskContext"_s,
+    nullptr,
+    nullptr,
+    nullptr,
+    CREATE_METHOD_TABLE(NativeMicrotaskContext)
+};
+
+NativeMicrotaskContext* NativeMicrotaskContext::create(JSC::VM& vm, JSC::Structure* structure, void* ctx, Callback run, Callback drop)
+{
+    ASSERT(ctx && run && drop);
+    NativeMicrotaskContext* cell = new (NotNull, JSC::allocateCell<NativeMicrotaskContext>(vm))
+        NativeMicrotaskContext(vm, structure, ctx, run, drop);
+    cell->finishCreation(vm);
+    return cell;
+}
+
+void NativeMicrotaskContext::run()
+{
+    void* ctx = std::exchange(m_ctx, nullptr);
+    ASSERT(ctx);
+    m_run(ctx);
+}
+
+NativeMicrotaskContext::~NativeMicrotaskContext()
+{
+    if (void* ctx = std::exchange(m_ctx, nullptr))
+        m_drop(ctx);
+}
+
+void NativeMicrotaskContext::destroy(JSC::JSCell* cell)
+{
+    static_cast<NativeMicrotaskContext*>(cell)->~NativeMicrotaskContext();
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/NativeMicrotaskContext.h
+++ b/src/jsc/bindings/NativeMicrotaskContext.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "BunClientData.h"
+#include "root.h"
+
+namespace Bun {
+
+// The argument cell of a native microtask (JSC__JSGlobalObject__queueMicrotaskCallback).
+// It owns the native context until the trampoline runs it; if the microtask is
+// discarded instead (queue cleared at teardown, then the cell collected or the
+// VM destroyed), the destructor hands the context to its drop function.
+class NativeMicrotaskContext final : public JSC::JSCell {
+public:
+    using Base = JSC::JSCell;
+    using Callback = void (*)(void*);
+
+    static NativeMicrotaskContext* create(JSC::VM& vm, JSC::Structure* structure, void* ctx, Callback run, Callback drop);
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+    {
+        return JSC::Structure::create(vm, globalObject, JSC::jsNull(), JSC::TypeInfo(JSC::CellType, StructureFlags), info(), 0, 0);
+    }
+
+    template<typename, JSC::SubspaceAccess mode>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
+            return nullptr;
+        return WebCore::subspaceForImpl<NativeMicrotaskContext, WebCore::UseCustomHeapCellType::Yes>(vm, BUN_SUBSPACE_SLOTS(m_clientSubspaceForNativeMicrotaskContext, m_subspaceForNativeMicrotaskContext),
+            [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForNativeMicrotaskContext; });
+    }
+
+    DECLARE_INFO;
+
+    static constexpr JSC::DestructionMode needsDestruction = JSC::DestructionMode::NeedsDestruction;
+    static void destroy(JSC::JSCell* cell);
+
+    // Consume the context: the destructor is a no-op afterwards.
+    void run();
+
+private:
+    NativeMicrotaskContext(JSC::VM& vm, JSC::Structure* structure, void* ctx, Callback run, Callback drop)
+        : Base(vm, structure)
+        , m_ctx(ctx)
+        , m_run(run)
+        , m_drop(drop)
+    {
+    }
+
+    ~NativeMicrotaskContext();
+
+    void* m_ctx;
+    Callback m_run;
+    Callback m_drop;
+};
+
+} // namespace Bun

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -159,6 +159,7 @@
 #include "napi_handle_scope.h"
 #include "napi_type_tag.h"
 #include "NativePromiseContext.h"
+#include "NativeMicrotaskContext.h"
 #include "napi.h"
 #include "NodeHTTP.h"
 #include "NodeVM.h"
@@ -1326,18 +1327,10 @@ JSC_DEFINE_HOST_FUNCTION(functionQueueMicrotask,
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 
-using MicrotaskCallback = void (*)(void*);
-
 JSC_DEFINE_HOST_FUNCTION(functionNativeMicrotaskTrampoline,
     (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    // Do not use JSCell* here because the GC will try to visit it.
-    double cellPtr = callFrame->uncheckedArgument(0).asNumber();
-    double callbackPtr = callFrame->uncheckedArgument(1).asNumber();
-
-    void* cell = reinterpret_cast<void*>(std::bit_cast<uintptr_t>(cellPtr));
-    auto* callback = reinterpret_cast<MicrotaskCallback>(std::bit_cast<uintptr_t>(callbackPtr));
-    callback(cell);
+    uncheckedDowncast<Bun::NativeMicrotaskContext>(callFrame->uncheckedArgument(0))->run();
     return JSValue::encode(jsUndefined());
 }
 
@@ -2393,6 +2386,9 @@ void GlobalObject::finishCreation(VM& vm)
         { OBJECT_OFFSETOF(GlobalObject, m_NativePromiseContextStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
              init.set(Bun::NativePromiseContext::createStructure(init.vm, init.owner));
          } },
+        { OBJECT_OFFSETOF(GlobalObject, m_NativeMicrotaskContextStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
+             init.set(Bun::NativeMicrotaskContext::createStructure(init.vm, init.owner));
+         } },
         { OBJECT_OFFSETOF(GlobalObject, m_JSHTTPResponseController), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
              auto* structure = createJSSinkControllerStructure(init.vm, init.owner, WebCore::SinkID::HTTPResponseSink);
              init.set(structure);
@@ -2605,7 +2601,7 @@ void GlobalObject::finishCreation(VM& vm)
              init.set(JSC::JSFunction::create(init.vm, init.owner, wasmStreamingConsumeStreamCodeGenerator(init.vm), init.owner));
          } },
         { OBJECT_OFFSETOF(GlobalObject, m_nativeMicrotaskTrampoline), [](const LazyProperty<JSGlobalObject, JSFunction>::Initializer& init) {
-             init.set(JSFunction::create(init.vm, init.owner, 2, ""_s, functionNativeMicrotaskTrampoline, ImplementationVisibility::Private));
+             init.set(JSFunction::create(init.vm, init.owner, 1, ""_s, functionNativeMicrotaskTrampoline, ImplementationVisibility::Private));
          } },
         { OBJECT_OFFSETOF(GlobalObject, m_ipcParseHandleFunction), [](const LazyProperty<JSGlobalObject, JSFunction>::Initializer& init) {
              init.set(JSC::JSFunction::create(init.vm, init.owner, WebCore::ipcParseHandleCodeGenerator(init.vm), init.owner));
@@ -3391,20 +3387,15 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void JSC__JSGlobalObject__reload(JSC::JSGl
     globalObject->reload();
 }
 
-extern "C" void JSC__JSGlobalObject__queueMicrotaskCallback(Zig::GlobalObject* globalObject, void* ptr, MicrotaskCallback callback)
+// The queue owns `ptr` from here: `run(ptr)` when the microtask fires, else `drop(ptr)` when the
+// discarded task's context cell is destroyed.
+extern "C" void JSC__JSGlobalObject__queueMicrotaskCallback(Zig::GlobalObject* globalObject, void* ptr, Bun::NativeMicrotaskContext::Callback run, Bun::NativeMicrotaskContext::Callback drop)
 {
+    auto& vm = globalObject->vm();
     JSFunction* function = globalObject->nativeMicrotaskTrampoline();
-
-#if ASSERT_ENABLED
-    ASSERT_WITH_MESSAGE(function, "Invalid microtask function");
-    ASSERT_WITH_MESSAGE(ptr, "Invalid microtask context");
-    ASSERT_WITH_MESSAGE(callback, "Invalid microtask callback");
-#endif
-
-    // Do not use JSCell* here because the GC will try to visit it.
-    // Use BunInvokeJobWithArguments to pass the two arguments (ptr and callback) to the trampoline function
-    JSC::QueuedTask task { nullptr, JSC::InternalMicrotask::BunInvokeJobWithArguments, 0, globalObject, function, JSValue(std::bit_cast<double>(reinterpret_cast<uintptr_t>(ptr))), JSValue(std::bit_cast<double>(reinterpret_cast<uintptr_t>(callback))) };
-    globalObject->vm().queueMicrotask(WTF::move(task));
+    auto* context = Bun::NativeMicrotaskContext::create(vm, globalObject->NativeMicrotaskContextStructure(), ptr, run, drop);
+    JSC::QueuedTask task { nullptr, JSC::InternalMicrotask::BunInvokeJobWithArguments, 0, globalObject, function, context };
+    vm.queueMicrotask(WTF::move(task));
 }
 
 extern "C" const Latin1Character* Bun__standaloneModuleKey(const Latin1Character*, size_t, size_t* outLength);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -303,6 +303,7 @@ public:
     Structure* NapiHandleScopeImplStructure() const { return m_NapiHandleScopeImplStructure.getInitializedOnMainThread(this); }
     Structure* NapiTypeTagStructure() const { return m_NapiTypeTagStructure.getInitializedOnMainThread(this); }
     Structure* NativePromiseContextStructure() const { return m_NativePromiseContextStructure.getInitializedOnMainThread(this); }
+    Structure* NativeMicrotaskContextStructure() const { return m_NativeMicrotaskContextStructure.getInitializedOnMainThread(this); }
 
     Structure* JSSQLStatementStructure() const { return m_JSSQLStatementStructure.getInitializedOnMainThread(this); }
 
@@ -657,6 +658,7 @@ public:
     V(private, LazyPropertyOfGlobalObject<Structure>, m_NapiHandleScopeImplStructure)                        \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_NapiTypeTagStructure)                                \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_NativePromiseContextStructure)                       \
+    V(private, LazyPropertyOfGlobalObject<Structure>, m_NativeMicrotaskContextStructure)                     \
                                                                                                              \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSQLStatementStructure)                             \
     V(private, LazyPropertyOfGlobalObject<v8::shim::GlobalInternals>, m_V8GlobalInternals)                   \

--- a/src/jsc/bindings/v8/V8Isolate.cpp
+++ b/src/jsc/bindings/v8/V8Isolate.cpp
@@ -117,7 +117,7 @@ void Isolate::RemoveNearHeapLimitCallback(NearHeapLimitCallback callback, size_t
     });
 }
 
-extern "C" void JSC__JSGlobalObject__queueMicrotaskCallback(Zig::GlobalObject*, void*, void (*)(void*));
+extern "C" void JSC__JSGlobalObject__queueMicrotaskCallback(Zig::GlobalObject*, void*, void (*run)(void*), void (*drop)(void*));
 
 namespace {
 struct InterruptRequest {
@@ -133,11 +133,14 @@ void Isolate::RequestInterrupt(InterruptCallback callback, void* data)
     if (!vm().currentThreadIsHoldingAPILock()) [[unlikely]]
         return;
     auto* request = new InterruptRequest { this, callback, data };
-    JSC__JSGlobalObject__queueMicrotaskCallback(m_globalObject, request, [](void* ptr) {
-        auto* req = static_cast<InterruptRequest*>(ptr);
-        req->callback(req->isolate, req->data);
-        delete req;
-    });
+    JSC__JSGlobalObject__queueMicrotaskCallback(
+        m_globalObject, request,
+        [](void* ptr) {
+            auto* req = static_cast<InterruptRequest*>(ptr);
+            req->callback(req->isolate, req->data);
+            delete req;
+        },
+        [](void* ptr) { delete static_cast<InterruptRequest*>(ptr); });
 }
 
 Local<Value> Isolate::ThrowException(Local<Value> exception)

--- a/src/jsc/bindings/webcore/DOMClientIsoSubspaces.h
+++ b/src/jsc/bindings/webcore/DOMClientIsoSubspaces.h
@@ -63,6 +63,7 @@ public:
     GCClient::IsoSubspace* m_clientSubspaceForStrongRootBlock { nullptr };
     GCClient::IsoSubspace* m_clientSubspaceForNapiTypeTag { nullptr };
     GCClient::IsoSubspace* m_clientSubspaceForNativePromiseContext { nullptr };
+    GCClient::IsoSubspace* m_clientSubspaceForNativeMicrotaskContext { nullptr };
     GCClient::IsoSubspace* m_clientSubspaceForObjectTemplate { nullptr };
     GCClient::IsoSubspace* m_clientSubspaceForInternalFieldObject { nullptr };
     GCClient::IsoSubspace* m_clientSubspaceForJSMIMEType { nullptr };

--- a/src/jsc/bindings/webcore/DOMIsoSubspaces.h
+++ b/src/jsc/bindings/webcore/DOMIsoSubspaces.h
@@ -61,6 +61,7 @@ public:
     IsoSubspace* m_subspaceForStrongRootBlock { nullptr };
     IsoSubspace* m_subspaceForNapiTypeTag { nullptr };
     IsoSubspace* m_subspaceForNativePromiseContext { nullptr };
+    IsoSubspace* m_subspaceForNativeMicrotaskContext { nullptr };
     IsoSubspace* m_subspaceForObjectTemplate { nullptr };
     IsoSubspace* m_subspaceForInternalFieldObject { nullptr };
     IsoSubspace* m_subspaceForV8GlobalInternals { nullptr };

--- a/test/js/web/websocket/websocket-client-initial-data-teardown-leak.test.ts
+++ b/test/js/web/websocket/websocket-client-initial-data-teardown-leak.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
+import { join } from "node:path";
+
+// The server's first frame is written in the same cork as the 101 response, so
+// the client receives handshake-overflow bytes and queues them as a native
+// microtask. Exiting (or terminating a worker) from inside `onopen` tears the
+// VM down before that microtask runs; the queued context must be freed with the
+// discarded queue rather than leaked. LeakSanitizer only exists on ASAN builds;
+// elsewhere this asserts the scenario exits cleanly.
+
+const env = {
+  ...bunEnv,
+  BUN_DESTRUCT_VM_ON_EXIT: "1",
+  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+  LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+};
+
+async function withServerThatSendsOnOpen(fn: (url: string) => Promise<void>) {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response("not a websocket", { status: 400 });
+    },
+    websocket: {
+      open(ws) {
+        ws.send("connected");
+      },
+      message() {},
+    },
+  });
+  await fn(`ws://127.0.0.1:${server.port}`);
+}
+
+async function runAndExpectClean(script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (isASAN) expect(stderr).not.toContain("LeakSanitizer");
+  expect(stdout.trim()).toBe("open");
+  expect(exitCode).toBe(0);
+}
+
+// LSan's report symbolization alone can take tens of seconds on a debug build.
+const TIMEOUT = isASAN ? 90_000 : undefined;
+
+describe("WebSocket client initial-data microtask discarded at VM teardown", () => {
+  test.concurrent(
+    "process.exit() from onopen",
+    async () => {
+      await withServerThatSendsOnOpen(url =>
+        runAndExpectClean(`
+          const ws = new WebSocket(${JSON.stringify(url)});
+          ws.onopen = () => {
+            console.log("open");
+            ws.close();
+            process.exit(0);
+          };
+          ws.onerror = e => {
+            console.error(e?.message);
+            process.exit(1);
+          };
+        `),
+      );
+    },
+    TIMEOUT,
+  );
+
+  test.concurrent(
+    "worker.terminate() from onopen",
+    async () => {
+      await withServerThatSendsOnOpen(url =>
+        runAndExpectClean(`
+          const { Worker } = require("node:worker_threads");
+          const worker = new Worker(
+            \`
+              const { parentPort } = require("node:worker_threads");
+              const ws = new WebSocket(${JSON.stringify(url)});
+              ws.onopen = () => {
+                parentPort.postMessage("open");
+                // Stay inside onopen until the parent terminates us.
+                const until = Date.now() + 30_000;
+                while (Date.now() < until) {}
+              };
+              ws.onerror = () => process.exit(1);
+            \`,
+            { eval: true },
+          );
+          worker.on("message", async message => {
+            console.log(message);
+            await worker.terminate();
+            process.exit(0);
+          });
+        `),
+      );
+    },
+    TIMEOUT,
+  );
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a leak of a native microtask's context when the VM is torn down before the microtask runs.

**What leaks.** `JSC__JSGlobalObject__queueMicrotaskCallback` packed the context pointer and its callback into the `QueuedTask` as two doubles. When teardown clears the microtask queue without running it (`GlobalObject::forbidExecution` — process exit under `BUN_DESTRUCT_VM_ON_EXIT`, a worker exiting or being terminated), nothing owns that context any more and it is never freed.

**When it shows.** The WebSocket client delivers handshake-overflow bytes (the first frame arriving in the same read as the `101` response — e.g. a `Bun.serve` peer that `ws.send()`s in `open`) through such a microtask. A script that calls `process.exit()` — or a worker that is terminated — from inside `onopen` tears the VM down while that task is still queued, and LeakSanitizer reports:

```
Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #10 ... Box<bun_http_jsc::websocket_client::InitialDataTask<false>>::new
    #11 ... WebSocket<false>::finish_init  src/http_jsc/websocket_client.rs
    #14 ... WebCore::WebSocket::didConnect
```

This is what the x64-asan lane flagged in `test/js/web/websocket/websocket-proxy.test.ts` (the `NO_PROXY` cases, whose child does exactly `ws.onopen = () => { ws.close(); process.exit(0) }`). `v8::Isolate::RequestInterrupt` used the same entry point and leaked its request the same way.

**How it is fixed.** The trampoline's argument is now a small GC cell, `Bun::NativeMicrotaskContext { ctx, run, drop }`, so the queue owns the context like any other microtask argument. The trampoline takes `ctx` out and calls `run`; if the task is discarded instead, the cell is collected (or destroyed with the VM) and its destructor calls `drop`. `JSGlobalObject::queue_microtask_boxed` supplies a `drop` that frees the `Box`, `RequestInterrupt` one that deletes its request. On the WebSocket side, `Drop` now only detaches the task's back-reference, and `InitialDataTask` clears the client's handle to it when it is dropped unrun; `websocket_client.rs` stays free of `unsafe`.

### How did you verify your code works?

New `test/js/web/websocket/websocket-client-initial-data-teardown-leak.test.ts`: a server that sends in `open`, and a child that (a) `process.exit(0)`s from `onopen`, (b) `terminate()`s a worker that is inside `onopen`, both with `BUN_DESTRUCT_VM_ON_EXIT=1` and `detect_leaks=1`. On an ASAN debug build of `main` both cases fail with the report above; with this change both pass (the LeakSanitizer assertion is gated on `isASAN`; elsewhere the test asserts a clean exit). `strace` confirms the `101` and the first frame arrive in one `recvfrom` in this setup.

Also ran on the ASAN debug build: `websocket-client`, `websocket-client-short-read`, `websocket-close-connecting`, `websocket-close-async-dispatch`, `websocket-proxy-close-reentrancy`, `websocket-proxy-tunnel-{client,upgrade}-leak`, `websocket-permessage-deflate`, `error-event`, `websocket.test.js`, `websocket-proxy.test.ts -t NO_PROXY` under the CI LSAN env (3×), `test/bake/deinitialization.test.ts`, `test/v8/v8.test.ts`, `worker_threads.test.ts`, `worker-terminate-funnels`, `worker-shutdown-post-leak`, `worker_destruction`, `worker.test.ts`, `worker-terminate-lifetime`. The only failures (`worker.test.ts` "message flood" and one `node_fs_binding` allocation in `worker-terminate-lifetime`) reproduce identically on an unmodified debug build of `main`.
