### PR TITLE
Bump WebKit: reject non-ASCII identity escapes in unicode RegExp patterns

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "c4ddc0cf5255ec9cc209e6369292739b78e3ca80";
+export const WEBKIT_VERSION = "autobuild-preview-pr-517-f390a25a";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/webkit-upgrade-f390a25a.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-f390a25a.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+// Coverage for the WebKit f390a25a sync (oven-sh/WebKit#517): under the u and
+// v flags, an identity escape of a non-ASCII character must be a SyntaxError.
+// Yarr only validated ASCII escapes, so /\Ç/u compiled and matched with the
+// Annex B meaning. Fixes oven-sh/bun#40441.
+
+describe.concurrent("WebKit f390a25a upgrade", () => {
+  test("non-ASCII identity escapes throw under the u and v flags", () => {
+    expect(() => new RegExp("\\Ç", "u")).toThrow(SyntaxError);
+    expect(() => new RegExp("\\Ç", "v")).toThrow(SyntaxError);
+    expect(() => new RegExp("\\é", "u")).toThrow(SyntaxError);
+    expect(() => new RegExp("\\字", "u")).toThrow(SyntaxError);
+    expect(() => new RegExp("\\𝒳", "u")).toThrow(SyntaxError);
+    expect(() => new RegExp("\\𝒳", "v")).toThrow(SyntaxError);
+    expect(() => new RegExp("[\\Ç]", "u")).toThrow(SyntaxError);
+    expect(() => new RegExp("[\\Ç]", "v")).toThrow(SyntaxError);
+    expect(() => new RegExp("[\\q{\\Ç}]", "v")).toThrow(SyntaxError);
+  });
+
+  test("ASCII identity escapes keep their behavior", () => {
+    // Still invalid under u: not a SyntaxCharacter or '/'.
+    expect(() => new RegExp("\\q", "u")).toThrow(SyntaxError);
+    expect(() => new RegExp("\\\u0000", "u")).toThrow(SyntaxError);
+    // Still valid.
+    expect(new RegExp("\\$", "u").test("$")).toBe(true);
+    expect(new RegExp("\\/", "u").test("/")).toBe(true);
+    expect(new RegExp("[\\-]", "u").test("-")).toBe(true);
+    expect(new RegExp("[\\&]", "v").test("&")).toBe(true);
+  });
+
+  test("non-unicode patterns and escaped code points are unchanged", () => {
+    expect(new RegExp("\\Ç").test("Ç")).toBe(true);
+    expect(new RegExp("Ç", "u").test("Ç")).toBe(true);
+    expect(new RegExp("\\u00C7", "u").test("Ç")).toBe(true);
+  });
+});


### PR DESCRIPTION
### Problem
- `new RegExp("\\Ç", "u")` compiles, and `/\Ç/u` matches `Ç` with the Annex B meaning. ECMA-262 requires a SyntaxError: IdentityEscape under the `u` or `v` flag allows only SyntaxCharacter or `/`, plus ClassSetReservedPunctuator inside `v`-mode class sets. All of those are ASCII. V8 and SpiderMonkey throw. Fixes #40441.
- The cause is `isIdentityEscapeAnError` in Yarr (`Source/JavaScriptCore/yarr/YarrParser.h:860` in oven-sh/WebKit). The error condition is gated on `isASCII(ch)` because `strchr` only handles bytes, so any non-ASCII escape skips validation.

### Fix
- The engine fix is oven-sh/WebKit#517: treat any non-ASCII character as an invalid identity escape in unicode and unicode-sets patterns. One condition changes, non-unicode patterns are untouched.
- This PR bumps `WEBKIT_VERSION` to that PR's preview build (`autobuild-preview-pr-517-f390a25a`) and adds `test/js/bun/jsc/webkit-upgrade-f390a25a.test.ts`. After oven-sh/WebKit#517 merges, the pin should move to the merged sha.
- Verified: the new test fails on bun 1.4.1 (`\Ç`, `\é`, `\字`, astral escapes, in and out of classes, with `u` and `v`) and passes with the bump. Also ran `test/js/bun/jsc/` and the regexp jsc-stress fixtures.

### Background
- Yarr is JavaScriptCore's regex engine. Bun vendors JSC through the oven-sh/WebKit fork and downloads prebuilt libraries pinned by `WEBKIT_VERSION` in `scripts/build/deps/webkit.ts`.
- An identity escape is `\` followed by a character that stands for itself. Annex B lets non-unicode patterns escape almost anything. The `u` and `v` flags removed that laxness so escapes stay forward-compatible.
- The engine PR includes a JSTests stress test (`regexp-unicode-identity-escape-non-ascii.js`) that covers the same matrix inside the fork's own test suite.

<details><summary>Notes</summary>

- Gate note: the fix lives in the WebKit prebuilt, selected by `scripts/build/deps/webkit.ts`. A `src/`-only stash keeps the bump, so a mechanical fail-before run of the test still passes. The fail-before proof is: `USE_SYSTEM_BUN=1 bun test test/js/bun/jsc/webkit-upgrade-f390a25a.test.ts` fails 1 of 3 on 1.4.1, and the same file passes under `bun bd` with this branch.
- Verified the fix directly against a local JSCOnly debug build of the fork: 24 checks covering throw and no-throw cases pass; the same script fails on the unfixed engine.
- `test/js/bun/jsc/domjit.test.ts` shows 10 timeout failures locally in the debug ASAN build on a capped-core container (the same tests pass earlier in the same file in 1 to 4 s, the JIT-warmup repeat pass exceeds the 5 s budget). The Yarr change only runs at RegExp compile time and does not touch those paths.
- Every other call site of `isIdentityEscapeAnError` passes an ASCII literal, so only the IdentityEscape default case in `parseEscape` changes behavior. `\-` inside a class is special-cased before the check and stays valid.
</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 6 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/webkit-upgrade-f390a25a.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/bun/jsc/webkit-upgrade-f390a25a.test.ts"
bun test v1.4.1 (65362b53b)

test/js/bun/jsc/webkit-upgrade-f390a25a.test.ts:
(pass) WebKit f390a25a upgrade > non-ASCII identity escapes throw under the u and v flags [39.09ms]
(pass) WebKit f390a25a upgrade > ASCII identity escapes keep their behavior [9.36ms]
(pass) WebKit f390a25a upgrade > non-unicode patterns and escaped code points are unchanged [4.01ms]

 3 pass
 0 fail
 18 expect() calls
Ran 3 tests across 1 file. [2.29s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                    |  2 +-
 test/js/bun/jsc/webkit-upgrade-f390a25a.test.ts | 37 +++++++++++++++++++++++++
 2 files changed, 38 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 8 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
scripts/build/deps/webkit.ts                         8      8      0
test/js/bun/jsc/webkit-upgrade-f390a25a.test.ts      0      0      0
```

</details>

**root cause** · written by the author bot

In Yarr's regular expression parser, the unicode-mode check that rejects invalid identity escapes was gated behind an ASCII test, so any non-ASCII character following a backslash bypassed validation and fell through to the lenient Annex B behavior where the escaped character matches itself. The fix removes the ASCII gate so the validation applies to all code points, meaning an identity escape under the u or v flag is only accepted for the syntax characters the specification permits and anything else raises a SyntaxError at compile time. This brings behavior in line with ECMA-262 and with V8…

<!-- robobun:evidence:end -->




