### PR TITLE
node:fs: treat an undefined len as 0 in truncateSync, promises.truncate and ftruncateSync

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2665,10 +2665,11 @@ pub mod args {
             let path = PathOrFileDescriptor::from_js(ctx, arguments)?.ok_or_else(|| {
                 ctx.throw_invalid_arguments(format_args!("path must be a string or TypedArray"))
             })?;
-            let len: u64 = 'brk: {
-                let Some(len_value) = arguments.next() else {
-                    break 'brk 0;
-                };
+            // Node treats an explicit `undefined` len the same as a missing one: 0.
+            let len_value = arguments.next().unwrap_or(JSValue::UNDEFINED);
+            let len: u64 = if len_value.is_undefined() {
+                0
+            } else {
                 validators::validate_integer(ctx, len_value, "len", None, None)?.max(0) as u64
             };
             Ok(Truncate {
@@ -2742,17 +2743,23 @@ pub mod args {
             arguments: &mut ArgumentsSlice,
         ) -> JsResult<FTruncate> {
             let fd = FD::from_js_required(ctx, arguments)?;
-            let len: BlobSizeType = BlobSizeType::try_from(
-                validators::validate_integer(
-                    ctx,
-                    arguments.next().unwrap_or_else(|| JSValue::js_number(0.0)),
-                    "len",
-                    Some(i52::MIN),
-                    Some(BLOB_SIZE_MAX as i64),
-                )?
-                .max(0),
-            )
-            .expect("infallible: validated range");
+            // Node treats an explicit `undefined` len the same as a missing one: 0.
+            let len_value = arguments.next().unwrap_or(JSValue::UNDEFINED);
+            let len: BlobSizeType = if len_value.is_undefined() {
+                0
+            } else {
+                BlobSizeType::try_from(
+                    validators::validate_integer(
+                        ctx,
+                        len_value,
+                        "len",
+                        Some(i52::MIN),
+                        Some(BLOB_SIZE_MAX as i64),
+                    )?
+                    .max(0),
+                )
+                .expect("infallible: validated range")
+            };
             Ok(FTruncate { fd, len: Some(len) })
         }
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2666,7 +2666,7 @@ pub mod args {
                 ctx.throw_invalid_arguments(format_args!("path must be a string or TypedArray"))
             })?;
             // Node treats an explicit `undefined` len the same as a missing one: 0.
-            let len_value = arguments.next().unwrap_or(JSValue::UNDEFINED);
+            let len_value = arguments.next_eat().unwrap_or(JSValue::UNDEFINED);
             let len: u64 = if len_value.is_undefined() {
                 0
             } else {
@@ -2744,7 +2744,7 @@ pub mod args {
         ) -> JsResult<FTruncate> {
             let fd = FD::from_js_required(ctx, arguments)?;
             // Node treats an explicit `undefined` len the same as a missing one: 0.
-            let len_value = arguments.next().unwrap_or(JSValue::UNDEFINED);
+            let len_value = arguments.next_eat().unwrap_or(JSValue::UNDEFINED);
             let len: BlobSizeType = if len_value.is_undefined() {
                 0
             } else {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2015,6 +2015,66 @@ it("preadv", () => {
   expect(buffers[2]).toEqual(new Uint8Array([10, 11, 12]));
 });
 
+// Node defaults an explicit `undefined` len to 0 on every truncate entry point
+// (`if (len === undefined) len = 0` in truncateSync, `len = 0` default params
+// elsewhere), while `null` still fails validateInteger.
+describe.concurrent("truncate with an undefined len", () => {
+  const file = (name: string, dir: string) => {
+    const p = join(dir, name);
+    writeFileSync(p, "hello world");
+    return p;
+  };
+
+  it("truncateSync(path, undefined) truncates to 0", () => {
+    using dir = tempDir("fs-truncate-undefined", {});
+    const p = file("sync.txt", String(dir));
+    fs.truncateSync(p, undefined);
+    expect(statSync(p).size).toBe(0);
+  });
+
+  it("promises.truncate(path, undefined) truncates to 0", async () => {
+    using dir = tempDir("fs-truncate-undefined", {});
+    const p = file("promise.txt", String(dir));
+    await _promises.truncate(p, undefined);
+    expect(statSync(p).size).toBe(0);
+  });
+
+  it("truncate(path, undefined, cb) truncates to 0", async () => {
+    using dir = tempDir("fs-truncate-undefined", {});
+    const p = file("callback.txt", String(dir));
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    fs.truncate(p, undefined, err => (err ? reject(err) : resolve()));
+    await promise;
+    expect(statSync(p).size).toBe(0);
+  });
+
+  it("ftruncateSync(fd, undefined) truncates to 0", () => {
+    using dir = tempDir("fs-truncate-undefined", {});
+    const p = file("fsync.txt", String(dir));
+    const fd = openSync(p, "r+");
+    try {
+      ftruncateSync(fd, undefined);
+      expect(fstatSync(fd).size).toBe(0);
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  it("null is still rejected with ERR_INVALID_ARG_TYPE", async () => {
+    using dir = tempDir("fs-truncate-null", {});
+    const p = file("null.txt", String(dir));
+    expect(() => fs.truncateSync(p, null as any)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    await expect(() => _promises.truncate(p, null as any)).toThrowWithCodeAsync(TypeError, "ERR_INVALID_ARG_TYPE");
+    const fd = openSync(p, "r+");
+    try {
+      expect(() => ftruncateSync(fd, null as any)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(p, "utf8")).toBe("hello world");
+  });
+});
+
 describe.concurrent("writev/readv with more than IOV_MAX buffers", () => {
   // IOV_MAX is 1024 on Linux and macOS. Node's libuv loops writev in
   // IOV_MAX-sized batches and caps readv at IOV_MAX; Bun previously passed

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2075,6 +2075,226 @@ describe.concurrent("truncate with an undefined len", () => {
   });
 });
 
+// The `fs.*Sync` functions bound straight to the native binding parse their
+// arguments in Rust (`args::*::from_js` in node_fs.rs), where an absent argument
+// and an explicit `undefined` arrive differently. Node treats them the same for
+// every optional argument, so each row must produce the same outcome both ways.
+describe("explicit undefined behaves like an absent optional argument", () => {
+  type Ctx = {
+    dir: string;
+    file: () => string;
+    fresh: (prefix: string) => string;
+    withFd: <T>(flags: string, f: (fd: number) => T) => T;
+  };
+  const makeCtx = (dir: string): Ctx => {
+    let n = 0;
+    const fresh = (prefix: string) => join(dir, `${prefix}${n++}`);
+    const file = () => {
+      const p = fresh("f");
+      writeFileSync(p, "hello world");
+      return p;
+    };
+    const withFd = <T>(flags: string, f: (fd: number) => T): T => {
+      const fd = openSync(file(), flags);
+      try {
+        return f(fd);
+      } finally {
+        closeSync(fd);
+      }
+    };
+    return { dir, file, fresh, withFd };
+  };
+  // Strings (fresh paths from mkdtempSync, readlinkSync) differ between the two
+  // calls by construction, so only their type is compared.
+  const outcome = (f: () => unknown) => {
+    try {
+      const v = f();
+      return { ok: typeof v === "string" ? "string" : v };
+    } catch (e: any) {
+      return { code: e.code };
+    }
+  };
+
+  const rows: [string, (c: Ctx) => unknown, (c: Ctx) => unknown][] = [
+    ["accessSync(path[, mode])", c => fs.accessSync(c.file()), c => fs.accessSync(c.file(), undefined)],
+    [
+      "appendFileSync(path, data[, options])",
+      c => fs.appendFileSync(c.file(), "x"),
+      c => fs.appendFileSync(c.file(), "x", undefined),
+    ],
+    [
+      "copyFileSync(src, dest[, mode])",
+      c => copyFileSync(c.file(), c.fresh("c")),
+      c => copyFileSync(c.file(), c.fresh("c"), undefined),
+    ],
+    [
+      "cpSync(src, dest[, options])",
+      c => fs.cpSync(c.file(), c.fresh("cp")),
+      c => fs.cpSync(c.file(), c.fresh("cp"), undefined),
+    ],
+    ["existsSync(path)", c => existsSync(c.file()), c => existsSync(c.file(), undefined as any)],
+    [
+      "fstatSync(fd[, options]).size",
+      c => c.withFd("r", fd => fstatSync(fd).size),
+      c => c.withFd("r", fd => fstatSync(fd, undefined).size),
+    ],
+    [
+      "ftruncateSync(fd[, len])",
+      c =>
+        c.withFd("r+", fd => {
+          ftruncateSync(fd);
+          return fstatSync(fd).size;
+        }),
+      c =>
+        c.withFd("r+", fd => {
+          ftruncateSync(fd, undefined);
+          return fstatSync(fd).size;
+        }),
+    ],
+    ["lstatSync(path[, options]).size", c => lstatSync(c.file()).size, c => lstatSync(c.file(), undefined).size],
+    ["mkdirSync(path[, options])", c => mkdirSync(c.fresh("m")), c => mkdirSync(c.fresh("m"), undefined)],
+    ["mkdtempSync(prefix[, options])", c => mkdtempSync(c.fresh("t")), c => mkdtempSync(c.fresh("t"), undefined)],
+    [
+      "opendirSync(path[, options])",
+      c => fs.opendirSync(c.dir).closeSync(),
+      c => fs.opendirSync(c.dir, undefined).closeSync(),
+    ],
+    ["openSync(path[, flags])", c => closeSync(openSync(c.file())), c => closeSync(openSync(c.file(), undefined))],
+    [
+      "openSync(path, flags[, mode])",
+      c => closeSync(openSync(c.file(), "r")),
+      c => closeSync(openSync(c.file(), "r", undefined)),
+    ],
+    ["readdirSync(path[, options]).length", c => readdirSync(c.dir).length, c => readdirSync(c.dir, undefined).length],
+    [
+      "readFileSync(path[, options]).length",
+      c => readFileSync(c.file()).length,
+      c => readFileSync(c.file(), undefined).length,
+    ],
+    [
+      "readlinkSync(path[, options])",
+      c => {
+        const l = c.fresh("l");
+        symlinkSync(c.file(), l);
+        return readlinkSync(l);
+      },
+      c => {
+        const l = c.fresh("l");
+        symlinkSync(c.file(), l);
+        return readlinkSync(l, undefined);
+      },
+    ],
+    [
+      "readSync(fd, buffer[, options])",
+      c => c.withFd("r", fd => readSync(fd, Buffer.alloc(2))),
+      c => c.withFd("r", fd => readSync(fd, Buffer.alloc(2), undefined)),
+    ],
+    [
+      "readSync(fd, buffer, offset, length[, position])",
+      c => c.withFd("r", fd => readSync(fd, Buffer.alloc(2), 0, 2)),
+      c => c.withFd("r", fd => readSync(fd, Buffer.alloc(2), 0, 2, undefined)),
+    ],
+    [
+      "readvSync(fd, buffers[, position])",
+      c => c.withFd("r", fd => readvSync(fd, [Buffer.alloc(2)])),
+      c => c.withFd("r", fd => readvSync(fd, [Buffer.alloc(2)], undefined)),
+    ],
+    ["realpathSync(path[, options])", c => realpathSync(c.dir), c => realpathSync(c.dir, undefined)],
+    [
+      "realpathSync.native(path[, options])",
+      c => realpathSync.native(c.dir),
+      c => realpathSync.native(c.dir, undefined),
+    ],
+    [
+      "rmdirSync(path[, options])",
+      c => {
+        const d = c.fresh("d");
+        mkdirSync(d);
+        return rmdirSync(d);
+      },
+      c => {
+        const d = c.fresh("d");
+        mkdirSync(d);
+        return rmdirSync(d, undefined);
+      },
+    ],
+    ["rmSync(path[, options])", c => rmSync(c.file()), c => rmSync(c.file(), undefined)],
+    ["statSync(path[, options]).size", c => statSync(c.file()).size, c => statSync(c.file(), undefined).size],
+    [
+      "statfsSync(path[, options]).bsize",
+      c => typeof statfsSync(c.dir).bsize,
+      c => typeof statfsSync(c.dir, undefined).bsize,
+    ],
+    [
+      "symlinkSync(target, path[, type])",
+      c => symlinkSync(c.file(), c.fresh("s")),
+      c => symlinkSync(c.file(), c.fresh("s"), undefined),
+    ],
+    [
+      "truncateSync(path[, len])",
+      c => {
+        const p = c.file();
+        fs.truncateSync(p);
+        return statSync(p).size;
+      },
+      c => {
+        const p = c.file();
+        fs.truncateSync(p, undefined);
+        return statSync(p).size;
+      },
+    ],
+    [
+      "writeFileSync(path, data[, options])",
+      c => writeFileSync(c.file(), "x"),
+      c => writeFileSync(c.file(), "x", undefined),
+    ],
+    [
+      "writeSync(fd, buffer[, offset])",
+      c => c.withFd("r+", fd => writeSync(fd, Buffer.from("ab"))),
+      c => c.withFd("r+", fd => writeSync(fd, Buffer.from("ab"), undefined)),
+    ],
+    [
+      "writeSync(fd, buffer, offset[, length])",
+      c => c.withFd("r+", fd => writeSync(fd, Buffer.from("ab"), 0)),
+      c => c.withFd("r+", fd => writeSync(fd, Buffer.from("ab"), 0, undefined)),
+    ],
+    [
+      "writeSync(fd, buffer, offset, length[, position])",
+      c => c.withFd("r+", fd => writeSync(fd, Buffer.from("ab"), 0, 2)),
+      c => c.withFd("r+", fd => writeSync(fd, Buffer.from("ab"), 0, 2, undefined)),
+    ],
+    [
+      "writeSync(fd, string[, position])",
+      c => c.withFd("r+", fd => writeSync(fd, "ab")),
+      c => c.withFd("r+", fd => writeSync(fd, "ab", undefined)),
+    ],
+    [
+      "writevSync(fd, buffers[, position])",
+      c => c.withFd("r+", fd => writevSync(fd, [Buffer.from("ab")])),
+      c => c.withFd("r+", fd => writevSync(fd, [Buffer.from("ab")], undefined)),
+    ],
+  ];
+
+  it.each(rows)("%s", (_label, absent, explicit) => {
+    using dir = tempDir("fs-undefined-arg", {});
+    const c = makeCtx(String(dir));
+    expect(outcome(() => explicit(c))).toEqual(outcome(() => absent(c)));
+  });
+
+  // Node coerces a positional read `length` with `length |= 0`, so `undefined`
+  // reads 0 bytes. Bun validates it as an integer instead and throws
+  // ERR_OUT_OF_RANGE 'The value of "length" is out of range. It must be an
+  // integer. Received NaN'. The 3-argument form is the options overload in
+  // Node, so the comparison is against an explicit 0.
+  it.failing("readSync(fd, buffer, offset, undefined) reads 0 bytes like readSync(fd, buffer, offset, 0)", () => {
+    using dir = tempDir("fs-undefined-arg", {});
+    const c = makeCtx(String(dir));
+    expect(outcome(() => c.withFd("r", fd => readSync(fd, Buffer.alloc(2), 0, undefined)))).toEqual(
+      outcome(() => c.withFd("r", fd => readSync(fd, Buffer.alloc(2), 0, 0))),
+    );
+  });
+});
+
 describe.concurrent("writev/readv with more than IOV_MAX buffers", () => {
   // IOV_MAX is 1024 on Linux and macOS. Node's libuv loops writev in
   // IOV_MAX-sized batches and caps readv at IOV_MAX; Bun previously passed


### PR DESCRIPTION
### Problem
- `fs.truncateSync(path, undefined)`, `fs.promises.truncate(path, undefined)` and `fs.ftruncateSync(fd, undefined)` throw `ERR_INVALID_ARG_TYPE: The "len" argument must be of type number. Received undefined`. Node truncates to 0 bytes. Only the callback forms work on Bun, because their JS wrapper turns `undefined` into 0 first.
- The cause is `args::Truncate::from_js` and `args::FTruncate::from_js` (`src/runtime/node/node_fs.rs`). Both default `len` to 0 only when the argument is absent. An explicit `undefined` reaches `validate_integer`, which rejects it.

### Fix
- Both parsers read the `len` slot with `next_eat().unwrap_or(JSValue::UNDEFINED)` and treat `undefined` as 0. Every other value still goes through `validate_integer`: `null` keeps throwing `ERR_INVALID_ARG_TYPE`, `1.5` keeps throwing `ERR_OUT_OF_RANGE`.
- Matches Node. `lib/fs.js` has `if (len === undefined) len = 0` in `truncateSync` and `len = 0` default parameters in `ftruncateSync`, `fs.truncate` and `fs.ftruncate`. `lib/internal/fs/promises.js` has `truncate(path, len = 0)`.
- The rule (explicit `undefined` equals absent) holds for every optional argument of every `fs.*Sync` native. A new `it.each` table checks 33 signatures both ways. The one remaining gap is the positional `length` of `readSync`/`read`, where Node coerces with `length |= 0`. That is a different coercion class and is left out. One `it.failing` test records it.
- Verified: `test/js/node/fs/fs.test.ts` (5 new tests fail on bun 1.4.1). Also the full `fs.test.ts`, `promises.test.js` and the upstream `test-fs-truncate*.js` files.

### Background
- `truncateSync` and `ftruncateSync` are bound directly to the native binding (`fs.truncateSync.bind(fs)`), and `fs.promises.truncate` is `asyncWrap(fs.truncate)`. Their arguments reach the Rust `args::*::from_js` parsers with no JS normalization.
- `ArgumentsSlice::next_eat()` returns `None` when the caller passed fewer arguments. An explicit `undefined` is a present argument, so it returns `Some(undefined)`.

<details><summary>Notes</summary>

Repro on bun 1.4.1 and main at adc354d998:

```js
import fs from "node:fs";
fs.writeFileSync("/tmp/t.txt", "hello world");
fs.truncateSync("/tmp/t.txt", undefined);
// TypeError: The "len" argument must be of type number. Received undefined
```

Behavior matrix after the fix, identical to node v26.3.0 for every entry point both runtimes share:

| call | bun before | bun after | node v26 |
| --- | --- | --- | --- |
| `truncateSync(path, undefined)` | throws | size 0 | size 0 |
| `promises.truncate(path, undefined)` | throws | size 0 | size 0 |
| `truncate(path, undefined, cb)` | size 0 | size 0 | size 0 |
| `ftruncateSync(fd, undefined)` | throws | size 0 | size 0 |
| `ftruncate(fd, undefined, cb)` | size 0 | size 0 | size 0 |
| `FileHandle.truncate(undefined)` | size 0 | size 0 | size 0 |
| `truncateSync(path, null)` | ERR_INVALID_ARG_TYPE | ERR_INVALID_ARG_TYPE | ERR_INVALID_ARG_TYPE |
| `promises.truncate(path, null)` | ERR_INVALID_ARG_TYPE | ERR_INVALID_ARG_TYPE | ERR_INVALID_ARG_TYPE |
| `ftruncateSync(fd, null)` | ERR_INVALID_ARG_TYPE | ERR_INVALID_ARG_TYPE | ERR_INVALID_ARG_TYPE |

`fs.promises.ftruncate(fd, undefined)` is a Bun extension (Node has no `fs.promises.ftruncate`). It shares `FTruncate::from_js`, so it goes from throwing to size 0 as well.

The parity table compares `outcome(explicit undefined)` with `outcome(absent)` on the same platform, where `outcome` is `{ ok: value }` or `{ code }`. Fresh paths (`mkdtempSync`, `readlinkSync`) are compared by type only. On bun 1.4.1 the `truncateSync` and `ftruncateSync` rows fail, the other 31 pass. A row that throws the same error code both ways (for example `symlinkSync` without privileges on Windows) passes, which is the intended invariant.

The `readSync` gap, measured on the PR build against node v26.3.0 with `position` pinned to 0: `readSync(fd, buf, 0, undefined, 0)` throws `ERR_OUT_OF_RANGE "It must be an integer. Received NaN"` vs 0 in Node. `NaN` throws vs 0, `1.5` throws vs 1, `{}` throws vs 0. `Read::from_js` (`node_fs.rs`, the `// length |= 0;` block) does `to_number` plus an integer check where Node does ToInt32. The callback `fs.read` forwards `length` unnormalized, so it has the same gap. The `it.failing` test compares `readSync(fd, buf, 0, undefined)` against `readSync(fd, buf, 0, 0)`, because the 3-argument form is Node's options overload.

The `else if (len === undefined) len = 0` branch in the callback `truncate` wrapper in `src/js/node/fs.ts` is now redundant for the native call, but it mirrors Node's `lib/fs.js` and still decides where `len` lands when it is a function. It is left alone.

Open PR #40344 changes the same `Truncate::from_js` function (it adds `flags` and `mode` fields to the struct literal) and `truncate_inner`. This diff only touches the `len` computation above that literal to keep the overlap small.

Suites run with the debug build: `test/js/node/fs/fs.test.ts` (559 pass, 7 skip), `test/js/node/fs/promises.test.js` (30 pass, 5 skip), `test/js/node/test/parallel/test-fs-truncate.js`, `test-fs-truncate-sync.js`, `test-fs-truncate-fd.js`, `test-fs-truncate-clear-file-zero.js`, `test-fs-promises-file-handle-truncate.js` (all exit 0).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->