### PR TITLE
css: keep incompatible selectors that fail the same way in one rule

### DIFF
--- a/src/css/build-prefixes.js
+++ b/src/css/build-prefixes.js
@@ -652,6 +652,9 @@ pub enum Feature {
 }
 
 impl Feature {
+    /// The number of variants. Discriminants run from \`0\` to \`COUNT - 1\`.
+    pub(crate) const COUNT: usize = ${variants.length};
+
     /// Returns whether every browser in \`browsers\` supports this feature
     /// natively, without fallback.
     pub(crate) fn is_compatible(self, browsers: &Browsers) -> bool {

--- a/src/css/compat.rs
+++ b/src/css/compat.rs
@@ -224,6 +224,9 @@ pub enum Feature {
 }
 
 impl Feature {
+    /// The number of variants. Discriminants run from `0` to `COUNT - 1`.
+    pub(crate) const COUNT: usize = 215;
+
     /// Returns whether all of the given browser targets support this feature
     /// natively, without fallback.
     pub(crate) fn is_compatible(self, browsers: &Browsers) -> bool {

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -664,7 +664,8 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
 
     /// Incompatible selectors that share a reason and a prefix. Each group becomes one rule.
     struct IncompatibleSelectors {
-        reason: selector::Incompatibility,
+        /// `None` when the downleveled selector prints compatibly, as `:dir()` does as `:lang()`.
+        reason: Option<selector::Incompatibility>,
         vendor_prefix: css::VendorPrefix,
         selectors: SmallList<Selector, 1>,
     }
@@ -697,24 +698,24 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
             let mut incompatible = SmallList::<IncompatibleSelectors, 1>::default();
             let mut i: u32 = 0;
             while i < sty.selectors.v.len() {
-                let Some(reason) =
-                    selector::incompatibility(sty.selectors.v.at(i), context.targets)
-                else {
+                if selector::incompatibility(sty.selectors.v.at(i), context.targets).is_none() {
                     i += 1;
                     continue;
-                };
+                }
                 let mut sel = sty.selectors.v.ordered_remove(i);
                 let vendor_prefix = selector::update_prefix(
                     context.arena,
                     core::slice::from_mut(&mut sel),
                     context.targets,
                 );
+                // Downleveling can rewrite the selector, so key the group on what will print.
+                let reason = selector::incompatibility(&sel, context.targets);
                 let group = match reason {
-                    selector::Incompatibility::Features(_) => incompatible
+                    Some(selector::Incompatibility::Unknown) => None,
+                    _ => incompatible
                         .slice_mut()
                         .iter_mut()
                         .find(|g| g.reason == reason && g.vendor_prefix == vendor_prefix),
-                    _ => None,
                 };
                 match group {
                     Some(group) => group.selectors.append(sel),

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -662,8 +662,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         return Ok(());
     }
 
-    /// Selectors moved out of the rule because some target does not support
-    /// them. Each group becomes one rule below.
+    /// Incompatible selectors that share a reason and a prefix. Each group becomes one rule.
     struct IncompatibleSelectors {
         reason: selector::Incompatibility,
         vendor_prefix: css::VendorPrefix,
@@ -694,11 +693,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         } else {
             // Otherwise, partition the selectors and keep the compatible ones in this rule.
             // We will generate additional rules for incompatible selectors later.
-            //
-            // Selectors that fail on the same features are dropped by the same
-            // browsers. When they also print with the same vendor prefixes, the
-            // rule they share behaves like one rule per selector in every
-            // target, so group them instead of duplicating the declarations.
+            // Same reason and prefix means the same browsers drop them, so they share one rule.
             let mut incompatible = SmallList::<IncompatibleSelectors, 1>::default();
             let mut i: u32 = 0;
             while i < sty.selectors.v.len() {
@@ -815,8 +810,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         SmallList::init_capacity(incompatible.len());
     while incompatible.len() > 0 {
         let group = incompatible.ordered_remove(0);
-        // The selectors were downleveled and their prefix computed when the
-        // group was formed, so this is what `update_prefix` would produce.
+        // The prefix was computed per selector when the group was formed.
         let clone = style::StyleRule::<R> {
             selectors: SelectorList { v: group.selectors },
             vendor_prefix: group.vendor_prefix,

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -662,9 +662,17 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         return Ok(());
     }
 
+    /// Selectors moved out of the rule because some target does not support
+    /// them. Each group becomes one rule below.
+    struct IncompatibleSelectors {
+        reason: selector::Incompatibility,
+        vendor_prefix: css::VendorPrefix,
+        selectors: SmallList<Selector, 1>,
+    }
+
     // If some of the selectors in this rule are not compatible with the targets,
     // we need to either wrap in :is() or split them into multiple rules.
-    let mut incompatible: SmallList<Selector, 1> = if sty.selectors.v.len() > 1
+    let mut incompatible: SmallList<IncompatibleSelectors, 1> = if sty.selectors.v.len() > 1
         && context.targets.should_compile_selectors()
         && !sty.is_compatible(context.targets)
     {
@@ -686,16 +694,40 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         } else {
             // Otherwise, partition the selectors and keep the compatible ones in this rule.
             // We will generate additional rules for incompatible selectors later.
-            let mut incompatible = SmallList::<Selector, 1>::default();
+            //
+            // Selectors that fail on the same features are dropped by the same
+            // browsers. When they also print with the same vendor prefixes, the
+            // rule they share behaves like one rule per selector in every
+            // target, so group them instead of duplicating the declarations.
+            let mut incompatible = SmallList::<IncompatibleSelectors, 1>::default();
             let mut i: u32 = 0;
             while i < sty.selectors.v.len() {
-                if selector::is_compatible(
-                    &sty.selectors.v.slice()[i as usize..i as usize + 1],
-                    context.targets,
-                ) {
+                let Some(reason) =
+                    selector::incompatibility(sty.selectors.v.at(i), context.targets)
+                else {
                     i += 1;
-                } else {
-                    incompatible.append(sty.selectors.v.ordered_remove(i));
+                    continue;
+                };
+                let mut sel = sty.selectors.v.ordered_remove(i);
+                let vendor_prefix = selector::update_prefix(
+                    context.arena,
+                    core::slice::from_mut(&mut sel),
+                    context.targets,
+                );
+                let group = match reason {
+                    selector::Incompatibility::Features(_) => incompatible
+                        .slice_mut()
+                        .iter_mut()
+                        .find(|g| g.reason == reason && g.vendor_prefix == vendor_prefix),
+                    _ => None,
+                };
+                match group {
+                    Some(group) => group.selectors.append(sel),
+                    None => incompatible.append(IncompatibleSelectors {
+                        reason,
+                        vendor_prefix,
+                        selectors: SmallList::with_one(sel),
+                    }),
                 }
             }
             incompatible
@@ -782,13 +814,12 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     let mut incompatible_rules: SmallList<IncompatibleRuleEntry<R>, 1> =
         SmallList::init_capacity(incompatible.len());
     while incompatible.len() > 0 {
-        let sel = incompatible.ordered_remove(0);
-        let list = SelectorList {
-            v: SmallList::with_one(sel),
-        };
-        let mut clone = style::StyleRule::<R> {
-            selectors: list,
-            vendor_prefix: sty.vendor_prefix,
+        let group = incompatible.ordered_remove(0);
+        // The selectors were downleveled and their prefix computed when the
+        // group was formed, so this is what `update_prefix` would produce.
+        let clone = style::StyleRule::<R> {
+            selectors: SelectorList { v: group.selectors },
+            vendor_prefix: group.vendor_prefix,
             declarations: dc::decl_block_static(
                 incompatible_decls.as_ref().unwrap_or(&sty.declarations),
                 context.arena,
@@ -796,7 +827,6 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
             rules: sty.rules.deep_clone(context.arena),
             loc: sty.loc,
         };
-        clone.update_prefix(context);
         let s = context.handler_context.get_supports_rules::<R>(&clone);
         let l = context.handler_context.get_additional_rules::<R>(&clone);
         incompatible_rules.append(IncompatibleRuleEntry {

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -53,16 +53,8 @@ impl<R> StyleRule<R> {
     }
 
     pub(crate) fn update_prefix(&mut self, context: &mut MinifyContext<'_, '_>) {
-        self.vendor_prefix = selector::get_prefix(&self.selectors);
-        if self.vendor_prefix.contains(VendorPrefix::NONE)
-            && context.targets.should_compile_selectors()
-        {
-            self.vendor_prefix = selector::downlevel_selectors(
-                context.arena,
-                self.selectors.v.slice_mut(),
-                context.targets,
-            );
-        }
+        self.vendor_prefix =
+            selector::update_prefix(context.arena, self.selectors.v.slice_mut(), context.targets);
     }
 
     pub(crate) fn is_compatible(&self, targets: &css::targets::Targets) -> bool {
@@ -426,7 +418,8 @@ impl<R> StyleRule<R> {
         // Mirrors the selector-compatibility branch in `minify_style_arm`
         // (rules/mod.rs): an incompatible selector list is either collapsed
         // into a single `:is()` selector (nothing cloned) or partitioned
-        // into one cloned rule per selector (fan-out = selector count).
+        // into cloned rules, at most one per selector (fan-out <= selector
+        // count).
         // Only the partition case multiplies on its own — but the `:is()`
         // wrap keeps one `&` reference per original selector, so when
         // nesting is compiled away the printed output still fans out per

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -418,8 +418,7 @@ impl<R> StyleRule<R> {
         // Mirrors the selector-compatibility branch in `minify_style_arm`
         // (rules/mod.rs): an incompatible selector list is either collapsed
         // into a single `:is()` selector (nothing cloned) or partitioned
-        // into cloned rules, at most one per selector (fan-out <= selector
-        // count).
+        // into cloned rules, at most one per selector (fan-out <= count).
         // Only the partition case multiplies on its own — but the `:is()`
         // wrap keeps one `&` reference per original selector, so when
         // nesting is compiled away the printed output still fans out per

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -274,13 +274,19 @@ pub(crate) fn get_prefix(selectors: &[Selector]) -> VendorPrefix {
     prefix
 }
 
-/// A set of [`Feature`]s, one bit per discriminant.
+/// Grouping bits past the compat features, for components whose compat bucket is
+/// wider than what the printer writes for them.
+const BIT_NESTING_LEADING: usize = Feature::COUNT;
+const BIT_NESTING_INNER: usize = Feature::COUNT + 1;
+const BIT_SCOPE: usize = Feature::COUNT + 2;
+const BIT_COUNT: usize = Feature::COUNT + 3;
+
+/// A set of [`Feature`]s (one bit per discriminant) plus the `BIT_*` grouping bits.
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
-pub(crate) struct FeatureSet([u64; Feature::COUNT.div_ceil(64)]);
+pub(crate) struct FeatureSet([u64; BIT_COUNT.div_ceil(64)]);
 
 impl FeatureSet {
-    fn insert(&mut self, feature: Feature) {
-        let bit = feature as usize;
+    fn insert(&mut self, bit: usize) {
         self.0[bit / 64] |= 1 << (bit % 64);
     }
 }
@@ -288,9 +294,23 @@ impl FeatureSet {
 /// Why a selector is incompatible with the targets. See [`incompatibility`].
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Incompatibility {
-    /// Unsupported features. Equal sets fail in the same browsers and can share one rule.
+    /// Unsupported features. Equal sets print the same way for every target, so they share a rule.
     Features(FeatureSet),
     /// A component with no support data (unknown or prefixed pseudo, `:nth-col()`): never shared.
+    Unknown,
+}
+
+/// What one selector component needs from the targets.
+enum Requirement {
+    Feature(Feature),
+    /// `&` with nesting compiled away. Checked as `:is()`, but keyed apart from it: the
+    /// printer inlines a lone parent selector, with `:is()` only for an inner `&`.
+    Nesting {
+        leading: bool,
+    },
+    /// `:scope`. Checked as Shadow DOM v1 like `:host`, but keyed apart: it shipped years earlier.
+    Scope,
+    /// No support data.
     Unknown,
 }
 
@@ -301,13 +321,20 @@ pub(crate) fn incompatibility(
 ) -> Option<Incompatibility> {
     let mut features = FeatureSet::default();
     let mut unknown = false;
-    visit_incompatible(core::slice::from_ref(selector), targets, &mut |feature| {
-        match feature {
-            Some(feature) => features.insert(feature),
-            None => unknown = true,
-        }
-        !unknown
-    });
+    visit_incompatible(
+        core::slice::from_ref(selector),
+        targets,
+        &mut |requirement| {
+            match requirement {
+                Requirement::Feature(feature) => features.insert(feature as usize),
+                Requirement::Nesting { leading: true } => features.insert(BIT_NESTING_LEADING),
+                Requirement::Nesting { leading: false } => features.insert(BIT_NESTING_INNER),
+                Requirement::Scope => features.insert(BIT_SCOPE),
+                Requirement::Unknown => unknown = true,
+            }
+            !unknown
+        },
+    );
     if unknown {
         Some(Incompatibility::Unknown)
     } else if features == FeatureSet::default() {
@@ -321,14 +348,15 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
     visit_incompatible(selectors, targets, &mut |_| false)
 }
 
-/// Feeds each unmet requirement to `sink` (`None`: no support data) until `sink` returns `false`.
+/// Feeds each unmet [`Requirement`] of `selectors` to `sink` until `sink` returns `false`.
 fn visit_incompatible(
     selectors: &[parser::Selector],
     targets: &Targets,
-    sink: &mut impl FnMut(Option<Feature>) -> bool,
+    sink: &mut impl FnMut(Requirement) -> bool,
 ) -> bool {
     use Feature as F;
     for selector in selectors {
+        let mut leading_nesting = has_leading_nesting(selector);
         'components: for component in selector.components.iter() {
             let feature = match component {
                 Component::Id(_) | Component::Class(_) | Component::LocalName(_) => continue,
@@ -346,19 +374,15 @@ fn visit_incompatible(
                     case_sensitivity,
                     operator,
                     ..
-                } => 'brk: {
-                    if *case_sensitivity != parser::attrs::ParsedCaseSensitivity::CaseSensitive {
-                        break 'brk F::CaseInsensitive;
+                } => match attribute_requirement(*case_sensitivity, *operator) {
+                    Requirement::Feature(feature) => feature,
+                    requirement => {
+                        if !sink(requirement) {
+                            return false;
+                        }
+                        continue;
                     }
-                    match operator {
-                        parser::attrs::AttrSelectorOperator::Equal
-                        | parser::attrs::AttrSelectorOperator::Includes
-                        | parser::attrs::AttrSelectorOperator::DashMatch => F::Selectors2,
-                        parser::attrs::AttrSelectorOperator::Prefix
-                        | parser::attrs::AttrSelectorOperator::Substring
-                        | parser::attrs::AttrSelectorOperator::Suffix => F::Selectors3,
-                    }
-                }
+                },
 
                 Component::AttributeOther(attr) => match &attr.operation {
                     parser::attrs::ParsedAttrSelectorOperation::Exists => F::Selectors2,
@@ -366,20 +390,15 @@ fn visit_incompatible(
                         case_sensitivity,
                         operator,
                         ..
-                    } => 'brk: {
-                        if *case_sensitivity != parser::attrs::ParsedCaseSensitivity::CaseSensitive
-                        {
-                            break 'brk F::CaseInsensitive;
+                    } => match attribute_requirement(*case_sensitivity, *operator) {
+                        Requirement::Feature(feature) => feature,
+                        requirement => {
+                            if !sink(requirement) {
+                                return false;
+                            }
+                            continue;
                         }
-                        match operator {
-                            parser::attrs::AttrSelectorOperator::Equal
-                            | parser::attrs::AttrSelectorOperator::Includes
-                            | parser::attrs::AttrSelectorOperator::DashMatch => F::Selectors2,
-                            parser::attrs::AttrSelectorOperator::Prefix
-                            | parser::attrs::AttrSelectorOperator::Substring
-                            | parser::attrs::AttrSelectorOperator::Suffix => F::Selectors3,
-                        }
-                    }
+                    },
                 },
 
                 Component::Empty | Component::Root => F::Selectors3,
@@ -398,7 +417,7 @@ fn visit_incompatible(
                         break 'brk F::Selectors2;
                     }
                     if data.ty == parser::NthType::Col || data.ty == parser::NthType::LastCol {
-                        if !sink(None) {
+                        if !sink(Requirement::Unknown) {
                             return false;
                         }
                         continue 'components;
@@ -425,9 +444,21 @@ fn visit_incompatible(
                     }
                     F::IsSelector
                 }
-                Component::Where(_) | Component::Nesting => F::IsSelector,
+                Component::Where(_) => F::IsSelector,
+                Component::Nesting => {
+                    let leading = core::mem::take(&mut leading_nesting);
+                    if !require_as(
+                        F::IsSelector,
+                        Requirement::Nesting { leading },
+                        targets,
+                        sink,
+                    ) {
+                        return false;
+                    }
+                    continue;
+                }
                 Component::Any { .. } => {
-                    if !sink(None) {
+                    if !sink(Requirement::Unknown) {
                         return false;
                     }
                     continue;
@@ -441,7 +472,13 @@ fn visit_incompatible(
                     continue;
                 }
 
-                Component::Scope | Component::Host(_) | Component::Slotted(_) => F::Shadowdomv1,
+                Component::Scope => {
+                    if !require_as(F::Shadowdomv1, Requirement::Scope, targets, sink) {
+                        return false;
+                    }
+                    continue;
+                }
+                Component::Host(_) | Component::Slotted(_) => F::Shadowdomv1,
 
                 Component::Part(_) => F::PartPseudo,
 
@@ -524,7 +561,7 @@ fn visit_incompatible(
 
                         _ => {}
                     }
-                    if !sink(None) {
+                    if !sink(Requirement::Unknown) {
                         return false;
                     }
                     continue 'components;
@@ -556,7 +593,7 @@ fn visit_incompatible(
                         PseudoElement::Custom { .. } => {}
                         _ => {}
                     }
-                    if !sink(None) {
+                    if !sink(Requirement::Unknown) {
                         return false;
                     }
                     continue 'components;
@@ -582,9 +619,52 @@ fn visit_incompatible(
 fn require(
     feature: Feature,
     targets: &Targets,
-    sink: &mut impl FnMut(Option<Feature>) -> bool,
+    sink: &mut impl FnMut(Requirement) -> bool,
 ) -> bool {
-    targets.is_compatible(feature) || sink(Some(feature))
+    require_as(feature, Requirement::Feature(feature), targets, sink)
+}
+
+/// Like [`require`], but reports `requirement` in place of the checked `feature`.
+fn require_as(
+    feature: Feature,
+    requirement: Requirement,
+    targets: &Targets,
+    sink: &mut impl FnMut(Requirement) -> bool,
+) -> bool {
+    targets.is_compatible(feature) || sink(requirement)
+}
+
+/// Whether the printer writes the selector's first `&` in the leading form (the parent
+/// selector itself when there is one parent). `&div` swaps to `div&` and takes the inner form.
+fn has_leading_nesting(selector: &parser::Selector) -> bool {
+    let mut compounds = CompoundSelectorIter {
+        sel: selector,
+        i: 0,
+    };
+    let Some(compound) = compounds.next() else {
+        return false;
+    };
+    matches!(compound.first(), Some(Component::Nesting)) && !is_type_selector(compound.get(1))
+}
+
+/// What an attribute selector with a value needs: the `i` flag needs `CaseInsensitive`, the `s`
+/// flag has no support data, and no flag (or the one HTML implies) leaves it to the operator.
+fn attribute_requirement(
+    case_sensitivity: parser::attrs::ParsedCaseSensitivity,
+    operator: parser::attrs::AttrSelectorOperator,
+) -> Requirement {
+    use parser::attrs::AttrSelectorOperator as Op;
+    use parser::attrs::ParsedCaseSensitivity as C;
+    match case_sensitivity {
+        C::AsciiCaseInsensitive => Requirement::Feature(Feature::CaseInsensitive),
+        C::ExplicitCaseSensitive => Requirement::Unknown,
+        C::CaseSensitive | C::AsciiCaseInsensitiveIfInHtmlElementInHtmlDocument => {
+            Requirement::Feature(match operator {
+                Op::Equal | Op::Includes | Op::DashMatch => Feature::Selectors2,
+                Op::Prefix | Op::Substring | Op::Suffix => Feature::Selectors3,
+            })
+        }
+    }
 }
 
 /// Determines whether a selector list contains only unused selectors.

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -274,8 +274,7 @@ pub(crate) fn get_prefix(selectors: &[Selector]) -> VendorPrefix {
     prefix
 }
 
-/// Grouping bits past the compat features, for components whose compat bucket is
-/// wider than what the printer writes for them.
+/// Grouping bits past the compat features, for components that print unlike their compat bucket.
 const BIT_NESTING_LEADING: usize = Feature::COUNT;
 const BIT_NESTING_INNER: usize = Feature::COUNT + 1;
 const BIT_SCOPE: usize = Feature::COUNT + 2;
@@ -303,8 +302,7 @@ pub(crate) enum Incompatibility {
 /// What one selector component needs from the targets.
 enum Requirement {
     Feature(Feature),
-    /// `&` with nesting compiled away. Checked as `:is()`, but keyed apart from it: the
-    /// printer inlines a lone parent selector, with `:is()` only for an inner `&`.
+    /// `&` compiled away. Checked as `:is()`; keyed apart since a lone parent inlines without it.
     Nesting {
         leading: bool,
     },
@@ -634,8 +632,7 @@ fn require_as(
     targets.is_compatible(feature) || sink(requirement)
 }
 
-/// Whether the printer writes the selector's first `&` in the leading form (the parent
-/// selector itself when there is one parent). `&div` swaps to `div&` and takes the inner form.
+/// Whether the selector's first `&` prints in the leading form (`&div` swaps to `div&`: inner).
 fn has_leading_nesting(selector: &parser::Selector) -> bool {
     let mut compounds = CompoundSelectorIter {
         sel: selector,
@@ -647,8 +644,7 @@ fn has_leading_nesting(selector: &parser::Selector) -> bool {
     matches!(compound.first(), Some(Component::Nesting)) && !is_type_selector(compound.get(1))
 }
 
-/// What an attribute selector with a value needs: the `i` flag needs `CaseInsensitive`, the `s`
-/// flag has no support data, and no flag (or the one HTML implies) leaves it to the operator.
+/// The `i` flag needs `CaseInsensitive`, `s` has no support data, otherwise the operator decides.
 fn attribute_requirement(
     case_sensitivity: parser::attrs::ParsedCaseSensitivity,
     operator: parser::attrs::AttrSelectorOperator,

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -79,8 +79,7 @@ pub(crate) fn is_equivalent(selectors: &[Selector], other: &[Selector]) -> bool 
     true
 }
 
-/// Returns the vendor prefixes a rule with these selectors is printed with.
-/// When the targets need it, this also downlevels the selectors in place.
+/// Downlevels the selectors for the targets and returns the vendor prefixes to print the rule with.
 pub(crate) fn update_prefix<'bump>(
     bump: &'bump Bump,
     selectors: &mut [Selector],
@@ -289,21 +288,13 @@ impl FeatureSet {
 /// Why a selector is incompatible with the targets. See [`incompatibility`].
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Incompatibility {
-    /// The features the selector needs that some target does not support.
+    /// Unsupported features. Equal sets fail in the same browsers and can share one rule.
     Features(FeatureSet),
-    /// The selector has a component with no support data: an unknown or
-    /// vendor-prefixed pseudo-class or pseudo-element, `:nth-col()`, ...
+    /// A component with no support data (unknown or prefixed pseudo, `:nth-col()`): never shared.
     Unknown,
 }
 
-/// Returns why the targets do not all support `selector`, or `None` when
-/// they do.
-///
-/// A browser drops a whole rule when one selector in its list is invalid, so
-/// the minifier moves the selectors some target cannot parse into rules of
-/// their own. Two selectors with equal `Features` are invalid in exactly the
-/// same target browsers, so they can share one rule. An `Unknown` selector
-/// never shares one: nothing says which browsers accept it.
+/// Returns why the targets do not all support `selector`, or `None` when they do.
 pub(crate) fn incompatibility(
     selector: &parser::Selector,
     targets: &Targets,
@@ -330,10 +321,7 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
     visit_incompatible(selectors, targets, &mut |_| false)
 }
 
-/// Reports each requirement of `selectors` that the targets do not meet to
-/// `sink`: `Some(feature)` for an unsupported compat feature, `None` for a
-/// component with no support data. `sink` returns `false` to stop the walk.
-/// Returns `false` when the walk was stopped.
+/// Feeds each unmet requirement to `sink` (`None`: no support data) until `sink` returns `false`.
 fn visit_incompatible(
     selectors: &[parser::Selector],
     targets: &Targets,
@@ -428,8 +416,7 @@ fn visit_incompatible(
 
                 // These support forgiving selector lists, so no need to check nested selectors.
                 Component::Is(sels) => {
-                    // ... except if we are going to unwrap them: the printer then
-                    // writes the inner selector in place of the `:is()`.
+                    // ... except if we unwrap them: the printer writes the inner selector instead.
                     if should_unwrap_is(sels) {
                         if !visit_incompatible(sels, targets, sink) {
                             return false;
@@ -591,8 +578,7 @@ fn visit_incompatible(
     true
 }
 
-/// Reports `feature` to `sink` when the targets do not support it. Returns
-/// `false` when `sink` stopped the walk.
+/// Reports `feature` to `sink` when the targets lack it; `false` means `sink` stopped the walk.
 fn require(
     feature: Feature,
     targets: &Targets,

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -79,6 +79,20 @@ pub(crate) fn is_equivalent(selectors: &[Selector], other: &[Selector]) -> bool 
     true
 }
 
+/// Returns the vendor prefixes a rule with these selectors is printed with.
+/// When the targets need it, this also downlevels the selectors in place.
+pub(crate) fn update_prefix<'bump>(
+    bump: &'bump Bump,
+    selectors: &mut [Selector],
+    targets: &Targets,
+) -> VendorPrefix {
+    let prefix = get_prefix(selectors);
+    if prefix.contains(VendorPrefix::NONE) && targets.should_compile_selectors() {
+        return downlevel_selectors(bump, selectors, targets);
+    }
+    prefix
+}
+
 /// Downlevels the given selectors to be compatible with the given browser targets.
 /// Returns the necessary vendor prefixes.
 pub(crate) fn downlevel_selectors<'bump>(
@@ -224,9 +238,9 @@ fn lang_list_to_selectors<'bump>(_bump: &'bump Bump, langs: &[&'static [u8]]) ->
 
 /// Returns the vendor prefix (if any) used in the given selector list.
 /// If multiple vendor prefixes are seen, this is invalid, and an empty result is returned.
-pub(crate) fn get_prefix(selectors: &SelectorList) -> VendorPrefix {
+pub(crate) fn get_prefix(selectors: &[Selector]) -> VendorPrefix {
     let mut prefix = VendorPrefix::empty();
-    for selector in selectors.v.slice() {
+    for selector in selectors {
         for component in selector.components.iter() {
             let component: &Component = component;
             let p = match component {
@@ -261,10 +275,73 @@ pub(crate) fn get_prefix(selectors: &SelectorList) -> VendorPrefix {
     prefix
 }
 
+/// A set of [`Feature`]s, one bit per discriminant.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct FeatureSet([u64; Feature::COUNT.div_ceil(64)]);
+
+impl FeatureSet {
+    fn insert(&mut self, feature: Feature) {
+        let bit = feature as usize;
+        self.0[bit / 64] |= 1 << (bit % 64);
+    }
+}
+
+/// Why a selector is incompatible with the targets. See [`incompatibility`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Incompatibility {
+    /// The features the selector needs that some target does not support.
+    Features(FeatureSet),
+    /// The selector has a component with no support data: an unknown or
+    /// vendor-prefixed pseudo-class or pseudo-element, `:nth-col()`, ...
+    Unknown,
+}
+
+/// Returns why the targets do not all support `selector`, or `None` when
+/// they do.
+///
+/// A browser drops a whole rule when one selector in its list is invalid, so
+/// the minifier moves the selectors some target cannot parse into rules of
+/// their own. Two selectors with equal `Features` are invalid in exactly the
+/// same target browsers, so they can share one rule. An `Unknown` selector
+/// never shares one: nothing says which browsers accept it.
+pub(crate) fn incompatibility(
+    selector: &parser::Selector,
+    targets: &Targets,
+) -> Option<Incompatibility> {
+    let mut features = FeatureSet::default();
+    let mut unknown = false;
+    visit_incompatible(core::slice::from_ref(selector), targets, &mut |feature| {
+        match feature {
+            Some(feature) => features.insert(feature),
+            None => unknown = true,
+        }
+        !unknown
+    });
+    if unknown {
+        Some(Incompatibility::Unknown)
+    } else if features == FeatureSet::default() {
+        None
+    } else {
+        Some(Incompatibility::Features(features))
+    }
+}
+
 pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -> bool {
+    visit_incompatible(selectors, targets, &mut |_| false)
+}
+
+/// Reports each requirement of `selectors` that the targets do not meet to
+/// `sink`: `Some(feature)` for an unsupported compat feature, `None` for a
+/// component with no support data. `sink` returns `false` to stop the walk.
+/// Returns `false` when the walk was stopped.
+fn visit_incompatible(
+    selectors: &[parser::Selector],
+    targets: &Targets,
+    sink: &mut impl FnMut(Option<Feature>) -> bool,
+) -> bool {
     use Feature as F;
     for selector in selectors {
-        for component in selector.components.iter() {
+        'components: for component in selector.components.iter() {
             let feature = match component {
                 Component::Id(_) | Component::Class(_) | Component::LocalName(_) => continue,
 
@@ -320,7 +397,9 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
                 Component::Empty | Component::Root => F::Selectors3,
                 Component::Negation(sels) => {
                     // :not() selector list is not forgiving.
-                    if !targets.is_compatible(F::Selectors3) || !is_compatible(sels, targets) {
+                    if !require(F::Selectors3, targets, sink)
+                        || !visit_incompatible(sels, targets, sink)
+                    {
                         return false;
                     }
                     continue;
@@ -331,13 +410,16 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
                         break 'brk F::Selectors2;
                     }
                     if data.ty == parser::NthType::Col || data.ty == parser::NthType::LastCol {
-                        return false;
+                        if !sink(None) {
+                            return false;
+                        }
+                        continue 'components;
                     }
                     F::Selectors3
                 }
                 Component::NthOf(n) => {
-                    if !targets.is_compatible(F::NthChildOf)
-                        || !is_compatible(&n.selectors, targets)
+                    if !require(F::NthChildOf, targets, sink)
+                        || !visit_incompatible(&n.selectors, targets, sink)
                     {
                         return false;
                     }
@@ -346,16 +428,27 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
 
                 // These support forgiving selector lists, so no need to check nested selectors.
                 Component::Is(sels) => {
-                    // ... except if we are going to unwrap them.
-                    if should_unwrap_is(sels) && is_compatible(sels, targets) {
+                    // ... except if we are going to unwrap them: the printer then
+                    // writes the inner selector in place of the `:is()`.
+                    if should_unwrap_is(sels) {
+                        if !visit_incompatible(sels, targets, sink) {
+                            return false;
+                        }
                         continue;
                     }
                     F::IsSelector
                 }
                 Component::Where(_) | Component::Nesting => F::IsSelector,
-                Component::Any { .. } => return false,
+                Component::Any { .. } => {
+                    if !sink(None) {
+                        return false;
+                    }
+                    continue;
+                }
                 Component::Has(sels) => {
-                    if !targets.is_compatible(F::HasSelector) || !is_compatible(sels, targets) {
+                    if !require(F::HasSelector, targets, sink)
+                        || !visit_incompatible(sels, targets, sink)
+                    {
                         return false;
                     }
                     continue;
@@ -438,13 +531,16 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
                         | PseudoClass::Blank
                         | PseudoClass::UserInvalid
                         | PseudoClass::UserValid
-                        | PseudoClass::Defined => return false,
+                        | PseudoClass::Defined => {}
 
                         PseudoClass::Custom { .. } => {}
 
                         _ => {}
                     }
-                    return false;
+                    if !sink(None) {
+                        return false;
+                    }
+                    continue 'components;
                 }
 
                 Component::PseudoElement(pseudo) => 'brk: {
@@ -470,10 +566,13 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
                         }
                         PseudoElement::Cue => break 'brk F::Cue,
                         PseudoElement::CueFunction { .. } => break 'brk F::CueFunction,
-                        PseudoElement::Custom { .. } => return false,
+                        PseudoElement::Custom { .. } => {}
                         _ => {}
                     }
-                    return false;
+                    if !sink(None) {
+                        return false;
+                    }
+                    continue 'components;
                 }
 
                 Component::Combinator(combinator) => match combinator {
@@ -483,13 +582,23 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
                 },
             };
 
-            if !targets.is_compatible(feature) {
+            if !require(feature, targets, sink) {
                 return false;
             }
         }
     }
 
     true
+}
+
+/// Reports `feature` to `sink` when the targets do not support it. Returns
+/// `false` when `sink` stopped the walk.
+fn require(
+    feature: Feature,
+    targets: &Targets,
+    sink: &mut impl FnMut(Option<Feature>) -> bool,
+) -> bool {
+    targets.is_compatible(feature) || sink(Some(feature))
 }
 
 /// Determines whether a selector list contains only unused selectors.

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -476,7 +476,25 @@ fn visit_incompatible(
                     }
                     continue;
                 }
-                Component::Host(_) | Component::Slotted(_) => F::Shadowdomv1,
+                // :host() and ::slotted() take one compound selector, not a forgiving list.
+                Component::Host(selector) => {
+                    if !require(F::Shadowdomv1, targets, sink)
+                        || !selector.as_ref().is_none_or(|selector| {
+                            visit_incompatible(core::slice::from_ref(selector), targets, sink)
+                        })
+                    {
+                        return false;
+                    }
+                    continue;
+                }
+                Component::Slotted(selector) => {
+                    if !require(F::Shadowdomv1, targets, sink)
+                        || !visit_incompatible(core::slice::from_ref(selector), targets, sink)
+                    {
+                        return false;
+                    }
+                    continue;
+                }
 
                 Component::Part(_) => F::PartPseudo,
 
@@ -587,7 +605,18 @@ fn visit_incompatible(
                             }
                         }
                         PseudoElement::Cue => break 'brk F::Cue,
-                        PseudoElement::CueFunction { .. } => break 'brk F::CueFunction,
+                        PseudoElement::CueFunction { selector } => {
+                            if !require(F::CueFunction, targets, sink)
+                                || !visit_incompatible(
+                                    core::slice::from_ref(selector.as_ref()),
+                                    targets,
+                                    sink,
+                                )
+                            {
+                                return false;
+                            }
+                            continue 'components;
+                        }
                         PseudoElement::Custom { .. } => {}
                         _ => {}
                     }

--- a/test/bundler/css/incompatible-selector-list-40364.test.ts
+++ b/test/bundler/css/incompatible-selector-list-40364.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect } from "bun:test";
+import { itBundled } from "../expectBundled";
+
+// https://github.com/oven-sh/bun/issues/40364
+// A browser drops a whole rule when one selector in its list is invalid, so
+// the minifier moves selectors the browser targets do not support out of the
+// rule. Selectors that fail on the same feature are dropped by the same
+// browsers, so they must keep sharing one rule instead of each getting a copy
+// of the declarations. The explicit-target cases live in
+// test/js/bun/css/css.test.ts; this checks the default bundler targets.
+describe("css", () => {
+  itBundled("css/incompatible-selector-list-40364", {
+    files: {
+      "index.css": /* css */ `
+        :where(.a), :where(.b) { color: red; padding: 4px }
+        :has(.c), :has(.d) { color: blue }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    minifyWhitespace: true,
+    minifySyntax: true,
+    onAfterBundle(api) {
+      const output = api.readFile("/out/index.css");
+      expect(output).toContain(":where(.a),:where(.b){color:red;padding:4px}");
+      expect(output.split("color:red").length - 1).toBe(1);
+      expect(output.split("color:#00f").length - 1).toBe(1);
+    },
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5974,6 +5974,46 @@ describe("css tests", () => {
       { chrome: 60 << 16 },
     );
 
+    // The group key comes from the downleveled selector: a top-level :dir()
+    // prints as :lang(), one inside ::slotted() or :nth-child(of) prints as is.
+    prefix_test(
+      "::slotted(:dir(ltr)), :dir(ltr) { color: red }",
+      `
+      ::slotted(:dir(ltr)) {
+        color: red;
+      }
+
+      :not(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
+        color: red;
+      }
+      `,
+      { chrome: 100 << 16 },
+    );
+
+    prefix_test(
+      ":nth-child(2 of :dir(ltr)), :dir(ltr) { color: red }",
+      `
+      :nth-child(2 of :dir(ltr)) {
+        color: red;
+      }
+
+      :not(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)) {
+        color: red;
+      }
+      `,
+      { chrome: 115 << 16 },
+    );
+
+    prefix_test(
+      ":dir(ltr)::before, :dir(ltr)::after { color: red }",
+      `
+      :not(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)):before, :not(:lang(ae), :lang(ar), :lang(arc), :lang(bcc), :lang(bqi), :lang(ckb), :lang(dv), :lang(fa), :lang(glk), :lang(he), :lang(ku), :lang(mzn), :lang(nqo), :lang(pnb), :lang(ps), :lang(sd), :lang(ug), :lang(ur), :lang(yi)):after {
+        color: red;
+      }
+      `,
+      { chrome: 100 << 16 },
+    );
+
     // The `s` flag has no support data. An implied HTML case-insensitive
     // attribute prints without a flag and needs nothing more.
     prefix_test(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5934,6 +5934,46 @@ describe("css tests", () => {
       { firefox: 60 << 16 },
     );
 
+    // :host() and ::slotted() take one compound selector, so their argument
+    // counts too.
+    prefix_test(
+      ":host(:hover), :host(:focus-visible) { color: red }",
+      `
+      :host(:hover) {
+        color: red;
+      }
+
+      :host(:focus-visible) {
+        color: red;
+      }
+      `,
+      { chrome: 50 << 16 },
+    );
+
+    prefix_test(
+      ":host(:hover), ::slotted(.a) { color: red }",
+      `
+      :host(:hover), ::slotted(.a) {
+        color: red;
+      }
+      `,
+      { chrome: 50 << 16 },
+    );
+
+    prefix_test(
+      ":host(:focus-visible), .x { color: red }",
+      `
+      .x {
+        color: red;
+      }
+
+      :host(:focus-visible) {
+        color: red;
+      }
+      `,
+      { chrome: 60 << 16 },
+    );
+
     // The `s` flag has no support data. An implied HTML case-insensitive
     // attribute prints without a flag and needs nothing more.
     prefix_test(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5867,6 +5867,99 @@ describe("css tests", () => {
       { safari: 14 << 16 },
     );
 
+    // `&` is checked as :is() but a lone parent selector is inlined without
+    // it, so `&` never shares a rule with a selector that really prints :is()
+    // or :where(). An inner `&` under a type-selector parent does print :is().
+    prefix_test(
+      ".parent { .c, :where(.a) { color: red } }",
+      `
+      .parent .c {
+        color: red;
+      }
+
+      .parent :where(.a) {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+
+    prefix_test(
+      ".parent { .c, .d { color: red } }",
+      `
+      .parent .c, .parent .d {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+
+    prefix_test(
+      "div { &:focus-visible, :focus-visible & { color: red } }",
+      `
+      div:focus-visible {
+        color: red;
+      }
+
+      :focus-visible :is(div) {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+
+    // :scope shares its compat bucket with :host and ::slotted() but shipped
+    // years earlier, so it does not share a rule with them.
+    prefix_test(
+      ":scope, :host { color: red }",
+      `
+      :scope {
+        color: red;
+      }
+
+      :host {
+        color: red;
+      }
+      `,
+      { firefox: 60 << 16 },
+    );
+
+    prefix_test(
+      ":scope, :scope > .a { color: red }",
+      `
+      :scope, :scope > .a {
+        color: red;
+      }
+      `,
+      { firefox: 60 << 16 },
+    );
+
+    // The `s` flag has no support data. An implied HTML case-insensitive
+    // attribute prints without a flag and needs nothing more.
+    prefix_test(
+      "[a=b s], [c=d i] { color: red }",
+      `
+      [a="b" s] {
+        color: red;
+      }
+
+      [c="d" i] {
+        color: red;
+      }
+      `,
+      { chrome: 45 << 16 },
+    );
+
+    prefix_test(
+      "[type=text], .x { color: red }",
+      `
+      [type="text"], .x {
+        color: red;
+      }
+      `,
+      { chrome: 45 << 16 },
+    );
+
     prefix_test(
       ":where(.a), :where(.b) { margin-inline-start: 24px }",
       `

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5693,6 +5693,194 @@ describe("css tests", () => {
       },
     );
 
+    // Selector lists with selectors the targets do not support. A browser
+    // drops the whole rule when one selector is invalid, so the unsupported
+    // selectors are moved out of the rule. Chrome 80 supports neither
+    // :is()/:where() (88) nor :has() (105) nor :focus-visible (86).
+    // https://github.com/oven-sh/bun/issues/40364
+    prefix_test(
+      ":where(.a), :where(.b) { color: red; padding: 4px }",
+      `
+      :where(.a), :where(.b) {
+        color: red;
+        padding: 4px;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+
+    prefix_test(
+      ":has(.a), :has(.b) { color: red }",
+      `
+      :has(.a), :has(.b) {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+
+    prefix_test(
+      ":where(.a), .c { color: red }",
+      `
+      .c {
+        color: red;
+      }
+
+      :where(.a) {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+
+    prefix_test(
+      ":where(.a), :has(.b), :where(.c), :has(.d) { color: red }",
+      `
+      :where(.a), :where(.c) {
+        color: red;
+      }
+
+      :has(.b), :has(.d) {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+
+    prefix_test(
+      ':where(.a)::before, :where(.c)::before, :where(.a)::after, :where(.c)::after { content: "" }',
+      `
+      :where(.a):before, :where(.c):before, :where(.a):after, :where(.c):after {
+        content: "";
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+
+    prefix_test(
+      ":hover, :focus-visible { color: red }",
+      `
+      :hover {
+        color: red;
+      }
+
+      :focus-visible {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+
+    prefix_test(
+      ":focus-within, :focus-visible { color: red }",
+      `
+      :focus-within {
+        color: red;
+      }
+
+      :focus-visible {
+        color: red;
+      }
+      `,
+      { safari: 9 << 16 },
+    );
+
+    prefix_test(
+      "a::unknown-a, a::unknown-b { color: red }",
+      `
+      a::unknown-a {
+        color: red;
+      }
+
+      a::unknown-b {
+        color: red;
+      }
+      `,
+      { safari: 14 << 16 },
+    );
+
+    prefix_test(
+      ":hover, :focus-visible { color: red }",
+      `
+      :is(:hover, :focus-visible) {
+        color: red;
+      }
+      `,
+      { safari: 14 << 16 },
+    );
+
+    prefix_test(
+      ":is(.a, .b), :where(.c) { color: red }",
+      `
+      :-webkit-any(.a, .b) {
+        color: red;
+      }
+
+      :is(.a, .b) {
+        color: red;
+      }
+
+      :where(.c) {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+
+    // A single simple selector inside :is() is printed unwrapped, so the rule
+    // needs what the inner selector needs, not :is() itself.
+    prefix_test(
+      ".foo :is(.bar), .bar :is(.baz) { color: red }",
+      `
+      .foo .bar, .bar .baz {
+        color: red;
+      }
+      `,
+      { chrome: 87 << 16 },
+    );
+
+    prefix_test(
+      ".foo :is(.bar:focus-visible), .bar :is(.baz:hover) { color: red }",
+      `
+      .bar .baz:hover {
+        color: red;
+      }
+
+      .foo .bar:focus-visible {
+        color: red;
+      }
+      `,
+      { chrome: 85 << 16 },
+    );
+
+    prefix_test(
+      ".a, .b:is(:focus-visible) { color: red }",
+      `
+      .a {
+        color: red;
+      }
+
+      .b:focus-visible {
+        color: red;
+      }
+      `,
+      { safari: 14 << 16 },
+    );
+
+    prefix_test(
+      ":where(.a), :where(.b) { margin-inline-start: 24px }",
+      `
+      :where(.a):not(:lang(ae, ar, arc, bcc, bqi, ckb, dv, fa, glk, he, ku, mzn, nqo, pnb, ps, sd, ug, ur, yi)), :where(.b):not(:lang(ae, ar, arc, bcc, bqi, ckb, dv, fa, glk, he, ku, mzn, nqo, pnb, ps, sd, ug, ur, yi)) {
+        margin-left: 24px;
+      }
+
+      :where(.a):lang(ae, ar, arc, bcc, bqi, ckb, dv, fa, glk, he, ku, mzn, nqo, pnb, ps, sd, ug, ur, yi), :where(.b):lang(ae, ar, arc, bcc, bqi, ckb, dv, fa, glk, he, ku, mzn, nqo, pnb, ps, sd, ug, ur, yi) {
+        margin-right: 24px;
+      }
+      `,
+      { safari: 11 << 16 },
+    );
+
     minify_test(".foo::cue {color: red}", ".foo::cue{color:red}");
     minify_test(".foo::cue-region {color: red}", ".foo::cue-region{color:red}");
     minify_test(".foo::cue(b) {color: red}", ".foo::cue(b){color:red}");

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -168,17 +168,19 @@ test.each(CONTEXT_PRESERVING_AT_RULES)("shallow nesting spanning %s still compil
   const src = nestedAcrossAtRule(atRule, ".a, .b", 1, 2);
   const out = minifyTest(src, "", OLD_TARGETS);
   expect(out.length).toBeLessThan(10_000);
-  // The inner rules resolve against the outer `.a, .b` chain (cartesian product).
-  expect(out).toContain(":is(.a,.b) .b .b");
+  // The inner rules resolve against the outer `.a, .b` chain. Both nested
+  // selectors need `:is()` for their `&`, which the targets lack, so they stay
+  // in one rule and the chain nests as `:is()` instead of fanning out.
+  expect(out).toContain(":is(:is(.a,.b) .a,:is(.a,.b) .b) .b");
 });
 
 test("shallow nesting spanning @starting-style still compiles for old targets", () => {
   const src = nestedAcrossStartingStyle('[foo="bar"], .bar', 1, 2);
   const out = prefixTest(src, "", { safari: 11 << 16, firefox: 60 << 16, chrome: 50 << 16 });
-  // The `&` chain flows through `@starting-style`, so the inner rules expand to
-  // the cartesian product of the two-selector lists.
+  // The `&` chain flows through `@starting-style`, so the inner rules resolve
+  // against the outer two-selector list.
   expect(out).toContain("@starting-style");
-  expect(out).toContain(':is([foo="bar"], .bar) .bar .bar');
+  expect(out).toContain(':is(:is([foo="bar"], .bar) [foo="bar"], :is([foo="bar"], .bar) .bar) .bar');
   expect(out.length).toBeLessThan(10_000);
 });
 


### PR DESCRIPTION
### Problem
- A selector list that uses `:where()` or `:has()` is split into one rule per selector, and the declaration block is copied into each: `:where(.a), :where(.b) { color: red; padding: 4px }` becomes `:where(.a){color:red;padding:4px}:where(.b){color:red;padding:4px}`. The reporter measured +26.6% on a real stylesheet (#40364). `:hover, :focus-visible` and `.a { .c, .d { } }` (compiled nesting) hit the same path.
- The split is the lightningcss downlevel for selectors the browser targets cannot parse. The default bundler targets resolve to chrome 80, which predates `:is()`/`:where()` (88) and `:has()` (105). `minify_style_arm` (`src/css/rules/mod.rs`) moved each unsupported selector into its own rule, even when the selectors fail for the same reason. lightningcss with the same targets produces the same split.

### Fix
- `selector::incompatibility` (`src/css/selectors/selector.rs`) classifies one selector as the set of compat features it needs that the targets lack, or `Unknown` for components with no support data (unknown pseudos, `:nth-col()`, the attribute `s` flag). `is_compatible` runs on the same walker.
- `minify_style_arm` groups the moved selectors by that set, computed on the downleveled selector (`:dir()` prints as `:lang()`), plus the vendor prefix they print with. Each group becomes one rule. Equal sets print the same way for every target browser, and the same prefix set means every prefix pass prints both alike, so one shared rule behaves like one rule per selector. `Unknown` selectors never share a rule.
- Three components print unlike their compat bucket and get their own grouping bits: a leading `&` (inlined when the parent has one selector), an inner `&` (`:is(parent)` under a type selector parent), and `:scope` (checked as Shadow DOM v1 like `:host`, shipped years earlier). Their compatibility verdict is unchanged.
- A single simple selector inside `:is()` prints unwrapped, so its compatibility follows the inner selector. `.a, .b:is(:focus-visible)` with safari 14 now splits so `.a` keeps its styling. `:host()`, `::slotted()`, and `::cue()` take one compound selector, so the walker now checks their argument too.
- Verified: `test/js/bun/css/css.test.ts` (26 new cases), `test/bundler/css/incompatible-selector-list-40364.test.ts`, `test/js/bun/css/nested-selector-list-expansion.test.ts`. Also ran `test/js/bun/css/`, `test/bundler/css/`, `bundler_html`, `bundler_regressions`, `bun-build-api`.

### Background
- A browser drops a whole style rule when one selector in its list is invalid. That is why the minifier moves unsupported selectors out of a rule: the supported ones then still apply in old browsers.
- `Targets::is_compatible(feature)` checks a feature against every target browser. `FeatureSet` is a bitset over `compat::Feature` (`Feature::COUNT` is new in the generated `compat.rs`) plus the three grouping bits.
- A rule's `vendor_prefix` is a set of prefix passes. `StyleRule::to_css` prints the rule once per pass and writes prefixed forms such as `:-webkit-any()` for `:is()`. `:where()` has no prefixed form, so `:is(.a, .b), :where(.c)` still splits.
- #40369 takes a different route for the same report: it raises the default targets. Both can land. This change removes the duplication for any target that still needs the downlevel.

<details><summary>Notes</summary>

- Repro: `Bun.build({ entrypoints: ["in.css"], minify: true })` on `:where(.a), :where(.b) { color: red; padding: 4px }`. Before: two rules. After: `:where(.a),:where(.b){color:red;padding:4px}`. `target: "node"` (no browser targets) never split.
- lightningcss 1.33.0 with `targets: { chrome: 80 << 16, edge: 80 << 16, firefox: 78 << 16, safari: 14 << 16, opera: 67 << 16 }` prints the same split as bun 1.4.1 for `:where`, `:has`, `:focus-visible`, `::-webkit-scrollbar` lists. The reporter compared against lightningcss with no targets.
- The effective default targets come from `Browsers::convert_from_string` keeping the lowest version per browser: `es2020` maps to chrome 80 and edge 80, below the explicit `chrome87`/`edge88` entries.
- Soundness of the key. Grouping S1 and S2 is safe when every target browser accepts the printed S1 exactly when it accepts the printed S2. The feature set is computed before downleveling (`:dir()` to `:lang()`, `:lang(a, b)` to `:is()`); every such rewrite that adds a prefixed form also changes the per-selector `vendor_prefix` (computed by the new `selector::update_prefix`, shared with `StyleRule::update_prefix`), which is part of the key. For `Features` selectors `get_prefix` only ever sees `empty` or `NONE` components, so the group's prefix equals each member's.
- Why `&` needs its own bits: `serialize_nesting` inlines the parent when the parent list has one selector (always for a leading `&`, only for a simple parent without a type selector for an inner `&`) and writes `:is(parents)` otherwise. All selectors of one nested list print under the same parent, so within a list the rendering differs only by `&` position. The first review round caught `.parent { .c, :where(.a) {} }` grouping `& .c` with `& :where(.a)` under the shared `IsSelector` bit.
- Argument recursion: `:host(:hover)` and `:host(:focus-visible)` shared a key when only the outer `Shadowdomv1` feature was checked. The second review round caught it. `:not()`, `:has()`, and `:nth-child(of)` already recursed.
- Downlevel timing: the key was first computed before `update_prefix` rewrote the selector, so `::slotted(:dir(ltr))` (printed as is) and `:dir(ltr)` (printed as `:not(:lang(...))`) shared a key. The third review round caught it. The key now comes from the downleveled selector; the pre-downlevel check still decides which selectors leave the rule.
- Attribute flags: the `i` flag needs `CaseInsensitive`; the `s` flag has no compat row and is now `Unknown` (it was checked as `i`); the case insensitivity HTML implies for attributes like `type` prints no flag and now needs nothing beyond the operator (it was checked as `i`, which split `[type=text], .x` for targets before chrome 49).
- Compiled nesting for old targets: `.a, .b { .c, .d { color: red } }` now prints `:is(.a,.b) .c,:is(.a,.b) .d{color:red}` (what chrome 110 targets already printed) instead of two rules. Deeper nesting nests `:is()` the same way chrome 110 targets do, so the `nested-selector-list-expansion` assertions were updated to that shape. The selector expansion cap still fires on the deep cases.
- `test/js/bun/css/css-fuzz.test.ts` (skipped in CI) and the 20k-rule perf test in `nested-vendor-prefix-duplication.test.ts` exceed their 5s/10s budgets in this debug build, with or without the change. The perf test's minify alone takes 3.6s here and runs only single-selector rules, which this change does not touch.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 18 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/css/incompatible-selector-list-40364.test.ts" test/js/bun/css/css.test.ts test/js/bun/css/nested-selector-list-expansion.test.ts
bun test v1.4.1 (861e9ae04)

test/bundler/css/incompatible-selector-list-40364.test.ts:
20 |     entryPoints: ["/index.css"],
21 |     minifyWhitespace: true,
22 |     minifySyntax: true,
23 |     onAfterBundle(api) {
24 |       const output = api.readFile("/out/index.css");
25 |       expect(output).toContain(":where(.a),:where(.b){color:red;padding:4px}");
                          ^
error: expect(received).toContain(expected)

Expected to contain: ":where(.a),:where(.b){color:red;padding:4px}"
Received: ":where(.a){color:red;padding:4px}:where(.b){color:red;padding:4px}:has(.c){color:#00f}:has(.d){color:#00f}\n"

      at onAfterBundle (/workspace/bun/test/bundler/css/incompatible-selector-list-40364.test.ts:25:22)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1591:7)
(fail) css > css/incompatible-selector-list-40364 [600.81ms]

test/js/bun/css/nested-selector-list-expans
... (truncated)

release without fix: 2 failed, 67 skipped
bun test v1.4.1-canary.1 (76e7adf85)

test/bundler/css/incompatible-selector-list-40364.test.ts:
(pass) css > css/incompatible-selector-list-40364 [12.61ms]

test/js/bun/css/nested-selector-list-expansion.test.ts:
(pass) deeply nested multi-selector rules error instead of exploding when compiled for old targets [0.20ms]
(pass) deeply nested ::part() selector lists error instead of exploding when compiled for old targets [0.11ms]
(pass) nested rules below the expansion limit still compile for old targets [0.15ms]
(pass) the fuzzer reproduction still minifies when no targets are configured [0.19ms]
(pass) deep nesting is preserved as-is for targets that support CSS nesting [0.13ms]
(pass) incompatible selector lists that collapse into :is() don't hit the limit when nesting is preserved [0.08ms]
(pass) collapsed :is() lists still hit the limit when nesting has to be compiled away [0.09ms]
(pass) bun build reports an error instead of exploding on deeply nested multi-selector css [5.21ms]
(pass) nested multi-selector rules spanning @starting-style error instead of exploding (minify) [0.14ms]
(pass) nested multi-selector rules spanning @starting-style error instead of exp
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/css/incompatible-selector-list-40364.test.ts" test/js/bun/css/css.test.ts test/js/bun/css/nested-selector-list-expansion.test.ts
bun test v1.4.1 (861e9ae04)

test/bundler/css/incompatible-selector-list-40364.test.ts:
(pass) css > css/incompatible-selector-list-40364 [569.45ms]

test/js/bun/css/nested-selector-list-expansion.test.ts:
(pass) deeply nested multi-selector rules error instead of exploding when compiled for old targets [9.79ms]
(pass) deeply nested ::part() selector lists error instead of exploding when compiled for old targets [6.52ms]
(pass) nested rules below the expansion limit still compile for old targets [9.65ms]
(pass) the fuzzer reproduction still minifies when no targets are configured [6.97ms]
(pass) deep nesting is preserved as-is for targets that support CSS nesting [7.73ms]
(pass) incompatible selector lists that collapse into :is() don't hit the limit when nesting is preserved [5.38ms]
(pass) collapsed :is() lists still hit the limit when nesting has to be compiled away [5.49ms]
(pass) bun build 
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 707ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/build-prefixes.js                          |   3 +
 src/css/compat.rs                                  |   3 +
 src/css/rules/mod.rs                               |  57 +++-
 src/css/rules/style.rs                             |  14 +-
 src/css/selectors/selector.rs                      | 288 +++++++++++++---
 .../css/incompatible-selector-list-40364.test.ts   |  30 ++
 test/js/bun/css/css.test.ts                        | 361 +++++++++++++++++++++
 .../bun/css/nested-selector-list-expansion.test.ts |  12 +-
 8 files changed, 692 insertions(+), 76 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/css/build-prefixes.js                                     1      1      0
src/css/compat.rs                                             3      1      0
src/css/rules/mod.rs                                          5      6      0
src/css/rules/style.rs                                        2      2      0
src/css/selectors/selector.rs                                16     13      0
…st/bundler/css/incompatible-selector-list-40364.test.ts      0      3      0
test/js/bun/css/css.test.ts                                   6      6      0
test/js/bun/css/nested-selector-list-expansion.test.ts        1      1      0
```

</details>

<!-- robobun:evidence:end -->