### PR TITLE
Run runtime plugin onLoad for a resolved file without an extension

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -711,6 +711,12 @@ impl JSGlobalObject {
         Ok(Some(result))
     }
 
+    /// Whether a runtime plugin registered an `onLoad` callback in `namespace_`.
+    pub(crate) fn has_on_load_namespace(&self, namespace_: &BunString) -> bool {
+        crate::mark_binding();
+        Bun__onLoadPluginsHasNamespace(self, namespace_)
+    }
+
     pub(crate) fn run_on_resolve_plugins(
         &self,
         namespace_: &BunString,
@@ -1489,6 +1495,8 @@ unsafe extern "C" {
         path: &BunString,
         target: BunPluginTarget,
     ) -> JSValue;
+    safe fn Bun__onLoadPluginsHasNamespace(global: &JSGlobalObject, namespace_: &BunString)
+    -> bool;
     safe fn Bun__runOnResolvePlugins(
         global: &JSGlobalObject,
         namespace_: Option<&BunString>,

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -242,13 +242,10 @@ unsafe extern "C" fn Bun__runVirtualModule(
     let specifier_slice = unsafe { &*specifier_ptr }.to_utf8();
     let specifier = specifier_slice.slice();
 
-    // The specifier is the resolved module key. An absolute path is a file on
-    // disk, so it always goes to the `file` namespace filters, with or without
-    // an extension. It skips `could_be_plugin`, which keys off the extension,
-    // and `extract_namespace`, which would read the first colon in
-    // `/dir/a:b/x.js` or a `Z:\` drive as a namespace. Every other key keeps
-    // the pre-filter: under `bun test` this runs before the builtin lookup, and
-    // a bare name such as `ws` must stay out of the `file` namespace.
+    // A resolved absolute path is a file, so it belongs to the `file` namespace:
+    // no extension check, and no `extract_namespace`, which would read a colon
+    // inside the path as a namespace. Other keys (`ns:path`, or a bare builtin
+    // name under `bun test`) still go through the pre-filter.
     let (namespace, after_namespace): (&[u8], &[u8]) = if bun_paths::is_absolute(specifier) {
         (b"", specifier)
     } else {

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -6,7 +6,6 @@
 //! `extern "Rust"` decls.
 
 use bun_alloc::Arena as ArenaAllocator;
-use bun_bundler::transpiler::PluginRunner;
 use bun_options_types::LoaderExt as _;
 
 use crate::virtual_machine::VirtualMachine;
@@ -247,7 +246,8 @@ unsafe extern "C" fn Bun__runVirtualModule(
     specifier_ptr: *const bun_core::String,
 ) -> JSValue {
     jsc::mark_binding();
-    if global.bun_vm().plugin_runner.is_none() {
+    let vm = global.bun_vm();
+    if vm.plugin_runner.is_none() {
         return JSValue::ZERO;
     }
 
@@ -255,23 +255,16 @@ unsafe extern "C" fn Bun__runVirtualModule(
     let specifier_slice = unsafe { &*specifier_ptr }.to_utf8();
     let specifier = specifier_slice.slice();
 
-    // A registered namespace wins. Any other absolute path is a file.
+    // A registered namespace wins. Any other absolute path is a file on disk.
+    // What remains (`node:fs`, `ws`, `data:`, the `[eval]` entry) has no file
+    // for the `file` namespace to load.
     let (namespace, after_namespace): (&[u8], &[u8]) =
         if let Some(namespace) = registered_on_load_namespace(global, specifier) {
             (namespace, &specifier[namespace.len() + 1..])
-        } else if bun_paths::is_absolute(specifier) {
+        } else if bun_paths::is_absolute(specifier) && !vm.is_eval_or_stdin_entry(specifier) {
             (b"", specifier)
         } else {
-            if !PluginRunner::could_be_plugin(specifier) {
-                return JSValue::ZERO;
-            }
-            let namespace = PluginRunner::extract_namespace(specifier);
-            let after_namespace = if namespace.is_empty() {
-                specifier
-            } else {
-                &specifier[(namespace.len() + 1).min(specifier.len())..]
-            };
-            (namespace, after_namespace)
+            return JSValue::ZERO;
         };
 
     match global.run_on_load_plugins(

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -227,12 +227,11 @@ extern "C" fn Bun__getDefaultLoader(
     loader
 }
 
-/// The `ns` of an `ns:path` module key when a plugin registered an onLoad
-/// callback in `ns`. `C:\...` is a Windows drive, never a namespace. This is
-/// the same rule `moduleLoaderResolve` applies to already-resolved keys.
+/// The `ns` of an `ns:path` key when `ns` has onLoad callbacks, as in `moduleLoaderResolve`.
 fn registered_on_load_namespace<'a>(global: &JSGlobalObject, key: &'a [u8]) -> Option<&'a [u8]> {
     let colon = bun_core::strings::index_of_char_usize(key, b':')?;
-    if colon == 0 || (colon == 1 && key[0].is_ascii_alphabetic()) {
+    let is_windows_drive = colon == 1 && key[0].is_ascii_alphabetic();
+    if colon == 0 || is_windows_drive {
         return None;
     }
     let namespace = &key[..colon];
@@ -256,8 +255,7 @@ unsafe extern "C" fn Bun__runVirtualModule(
     let specifier_slice = unsafe { &*specifier_ptr }.to_utf8();
     let specifier = specifier_slice.slice();
 
-    // A key whose prefix is a registered onLoad namespace is a virtual module.
-    // Any other absolute path is a file, whatever its extension or colons.
+    // A registered namespace wins. Any other absolute path is a file.
     let (namespace, after_namespace): (&[u8], &[u8]) =
         if let Some(namespace) = registered_on_load_namespace(global, specifier) {
             (namespace, &specifier[namespace.len() + 1..])

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -242,7 +242,12 @@ unsafe extern "C" fn Bun__runVirtualModule(
     let specifier_slice = unsafe { &*specifier_ptr }.to_utf8();
     let specifier = specifier_slice.slice();
 
-    if !PluginRunner::could_be_plugin(specifier) {
+    // The specifier is the resolved module key. An absolute path is a file on
+    // disk whether or not it has an extension, so the `file` namespace filters
+    // always see it. `could_be_plugin` keys off the extension and would skip
+    // `/dir/LICENSE`. Under `bun test` this runs before the builtin lookup, so
+    // the pre-filter still screens bare names such as `ws` or `bun`.
+    if !bun_paths::is_absolute(specifier) && !PluginRunner::could_be_plugin(specifier) {
         return JSValue::ZERO;
     }
 

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -226,10 +226,15 @@ extern "C" fn Bun__getDefaultLoader(
     loader
 }
 
-/// The `ns` of an `ns:path` key when `ns` has onLoad callbacks, as in `moduleLoaderResolve`.
+/// The `ns` of an `ns:path` key when `ns` has onLoad callbacks. A Windows drive path is never one.
 fn registered_on_load_namespace<'a>(global: &JSGlobalObject, key: &'a [u8]) -> Option<&'a [u8]> {
     let colon = bun_core::strings::index_of_char_usize(key, b':')?;
-    let is_windows_drive = colon == 1 && key[0].is_ascii_alphabetic();
+    let is_windows_drive = cfg!(windows)
+        && colon == 1
+        && bun_paths::resolve_path::is_drive_letter(key[0])
+        && key
+            .get(2)
+            .is_some_and(|&c| bun_paths::resolve_path::is_sep_any(c));
     if colon == 0 || is_windows_drive {
         return None;
     }

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -227,6 +227,20 @@ extern "C" fn Bun__getDefaultLoader(
     loader
 }
 
+/// The `ns` of an `ns:path` module key when a plugin registered an onLoad
+/// callback in `ns`. `C:\...` is a Windows drive, never a namespace. This is
+/// the same rule `moduleLoaderResolve` applies to already-resolved keys.
+fn registered_on_load_namespace<'a>(global: &JSGlobalObject, key: &'a [u8]) -> Option<&'a [u8]> {
+    let colon = bun_core::strings::index_of_char_usize(key, b':')?;
+    if colon == 0 || (colon == 1 && key[0].is_ascii_alphabetic()) {
+        return None;
+    }
+    let namespace = &key[..colon];
+    global
+        .has_on_load_namespace(&bun_core::String::from_bytes(namespace))
+        .then_some(namespace)
+}
+
 /// C++ entry point: runs the plugin for a virtual-module specifier, returning its exports (or zero when no plugin runner is set).
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Bun__runVirtualModule(
@@ -242,21 +256,25 @@ unsafe extern "C" fn Bun__runVirtualModule(
     let specifier_slice = unsafe { &*specifier_ptr }.to_utf8();
     let specifier = specifier_slice.slice();
 
-    // A resolved absolute path is a file, whatever its extension or colons.
-    let (namespace, after_namespace): (&[u8], &[u8]) = if bun_paths::is_absolute(specifier) {
-        (b"", specifier)
-    } else {
-        if !PluginRunner::could_be_plugin(specifier) {
-            return JSValue::ZERO;
-        }
-        let namespace = PluginRunner::extract_namespace(specifier);
-        let after_namespace = if namespace.is_empty() {
-            specifier
+    // A key whose prefix is a registered onLoad namespace is a virtual module.
+    // Any other absolute path is a file, whatever its extension or colons.
+    let (namespace, after_namespace): (&[u8], &[u8]) =
+        if let Some(namespace) = registered_on_load_namespace(global, specifier) {
+            (namespace, &specifier[namespace.len() + 1..])
+        } else if bun_paths::is_absolute(specifier) {
+            (b"", specifier)
         } else {
-            &specifier[(namespace.len() + 1).min(specifier.len())..]
+            if !PluginRunner::could_be_plugin(specifier) {
+                return JSValue::ZERO;
+            }
+            let namespace = PluginRunner::extract_namespace(specifier);
+            let after_namespace = if namespace.is_empty() {
+                specifier
+            } else {
+                &specifier[(namespace.len() + 1).min(specifier.len())..]
+            };
+            (namespace, after_namespace)
         };
-        (namespace, after_namespace)
-    };
 
     match global.run_on_load_plugins(
         &bun_core::String::from_bytes(namespace),

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -243,19 +243,25 @@ unsafe extern "C" fn Bun__runVirtualModule(
     let specifier = specifier_slice.slice();
 
     // The specifier is the resolved module key. An absolute path is a file on
-    // disk whether or not it has an extension, so the `file` namespace filters
-    // always see it. `could_be_plugin` keys off the extension and would skip
-    // `/dir/LICENSE`. Under `bun test` this runs before the builtin lookup, so
-    // the pre-filter still screens bare names such as `ws` or `bun`.
-    if !bun_paths::is_absolute(specifier) && !PluginRunner::could_be_plugin(specifier) {
-        return JSValue::ZERO;
-    }
-
-    let namespace = PluginRunner::extract_namespace(specifier);
-    let after_namespace = if namespace.is_empty() {
-        specifier
+    // disk, so it always goes to the `file` namespace filters, with or without
+    // an extension. It skips `could_be_plugin`, which keys off the extension,
+    // and `extract_namespace`, which would read the first colon in
+    // `/dir/a:b/x.js` or a `Z:\` drive as a namespace. Every other key keeps
+    // the pre-filter: under `bun test` this runs before the builtin lookup, and
+    // a bare name such as `ws` must stay out of the `file` namespace.
+    let (namespace, after_namespace): (&[u8], &[u8]) = if bun_paths::is_absolute(specifier) {
+        (b"", specifier)
     } else {
-        &specifier[(namespace.len() + 1).min(specifier.len())..]
+        if !PluginRunner::could_be_plugin(specifier) {
+            return JSValue::ZERO;
+        }
+        let namespace = PluginRunner::extract_namespace(specifier);
+        let after_namespace = if namespace.is_empty() {
+            specifier
+        } else {
+            &specifier[(namespace.len() + 1).min(specifier.len())..]
+        };
+        (namespace, after_namespace)
     };
 
     match global.run_on_load_plugins(

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -242,10 +242,7 @@ unsafe extern "C" fn Bun__runVirtualModule(
     let specifier_slice = unsafe { &*specifier_ptr }.to_utf8();
     let specifier = specifier_slice.slice();
 
-    // A resolved absolute path is a file, so it belongs to the `file` namespace:
-    // no extension check, and no `extract_namespace`, which would read a colon
-    // inside the path as a namespace. Other keys (`ns:path`, or a bare builtin
-    // name under `bun test`) still go through the pre-filter.
+    // A resolved absolute path is a file, whatever its extension or colons.
     let (namespace, after_namespace): (&[u8], &[u8]) = if bun_paths::is_absolute(specifier) {
         (b"", specifier)
     } else {

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -256,8 +256,6 @@ unsafe extern "C" fn Bun__runVirtualModule(
     let specifier = specifier_slice.slice();
 
     // A registered namespace wins. Any other absolute path is a file on disk.
-    // What remains (`node:fs`, `ws`, `data:`, the `[eval]` entry) has no file
-    // for the `file` namespace to load.
     let (namespace, after_namespace): (&[u8], &[u8]) =
         if let Some(namespace) = registered_on_load_namespace(global, specifier) {
             (namespace, &specifier[namespace.len() + 1..])

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4347,8 +4347,7 @@ impl VirtualMachine {
         result
     }
 
-    /// Whether `specifier` is the synthetic `<cwd>/[eval]` or `<cwd>/[stdin]`
-    /// entry of `bun -e` / `bun -`, whose source is in memory, not on disk.
+    /// The in-memory `<cwd>/[eval]` or `<cwd>/[stdin]` entry of `bun -e` / `bun -`.
     pub fn is_eval_or_stdin_entry(&self, specifier: &[u8]) -> bool {
         self.module_loader.eval_source.is_some()
             && (specifier.ends_with(bun_paths::path_literal!("/[eval]").as_bytes())

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4347,6 +4347,14 @@ impl VirtualMachine {
         result
     }
 
+    /// Whether `specifier` is the synthetic `<cwd>/[eval]` or `<cwd>/[stdin]`
+    /// entry of `bun -e` / `bun -`, whose source is in memory, not on disk.
+    pub fn is_eval_or_stdin_entry(&self, specifier: &[u8]) -> bool {
+        self.module_loader.eval_source.is_some()
+            && (specifier.ends_with(bun_paths::path_literal!("/[eval]").as_bytes())
+                || specifier.ends_with(bun_paths::path_literal!("/[stdin]").as_bytes()))
+    }
+
     /// Dupe `s` into a VM-owned allocation for the `_resolve` fast-paths.
     fn dupe_resolved_path(&mut self, s: &[u8]) -> &'static [u8] {
         let boxed: Box<[u8]> = s.to_vec().into_boxed_slice();
@@ -4406,10 +4414,7 @@ impl VirtualMachine {
             ret.path = result.path.as_bytes();
             return Ok(());
         }
-        if self.module_loader.eval_source.is_some()
-            && (specifier.ends_with(bun_paths::path_literal!("/[eval]").as_bytes())
-                || specifier.ends_with(bun_paths::path_literal!("/[stdin]").as_bytes()))
-        {
+        if self.is_eval_or_stdin_entry(specifier) {
             ret.result = None;
             ret.path = self.dupe_resolved_path(specifier);
             return Ok(());

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -910,6 +910,11 @@ extern "C" JSC::EncodedJSValue Bun__runOnLoadPlugins(Zig::GlobalObject* globalOb
     return globalObject->onLoadPlugins.run(globalObject, namespaceString, path);
 }
 
+extern "C" bool Bun__onLoadPluginsHasNamespace(Zig::GlobalObject* globalObject, const BunString* namespaceString)
+{
+    return globalObject->onLoadPlugins.group(namespaceString->toWTFString(BunString::ZeroCopy)) != nullptr;
+}
+
 namespace Bun {
 
 Structure* createModuleMockStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -958,6 +958,36 @@ it.concurrent.skipIf(isWindows)("onLoad runs in the file namespace for a path th
   expect(exitCode).toBe(0);
 });
 
+// The key of a module in the namespace "/virtual" is "/virtual:foo.txt", which
+// also reads as an absolute path. The registered namespace wins.
+it.concurrent("onLoad runs in a registered namespace whose key looks like an absolute path", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        Bun.plugin({
+          name: "slash-namespace",
+          setup(build) {
+            build.onResolve({ filter: /^virt\\.mod$/ }, () => ({ path: "foo.txt", namespace: "/virtual" }));
+            build.onLoad({ filter: /.*/, namespace: "/virtual" }, args => ({
+              contents: "export default " + JSON.stringify("virtual:" + args.path) + ";",
+              loader: "js",
+            }));
+          },
+        });
+        console.log((await import("virt.mod")).default);
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim() || stderr).toBe("virtual:foo.txt");
+  expect(exitCode).toBe(0);
+});
+
 // `bun test` consults plugins before the builtin modules so that mock.module()
 // can replace a builtin. A file-namespace onLoad filter must still see a file
 // without an extension there, and must not see bare builtin names such as "ws".

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -988,6 +988,52 @@ it.concurrent("onLoad runs in a registered namespace whose key looks like an abs
   expect(exitCode).toBe(0);
 });
 
+// `bun -e` and `bun -` give their in-memory source the key "<cwd>/[eval]" or
+// "<cwd>/[stdin]". There is no file to load, so a file-namespace onLoad filter
+// must not see them. The directory name contains a dot on purpose: stock bun
+// read ".eval-entry_xyz/[eval]" as a file extension and ran the filter.
+it.concurrent("onLoad does not run for the [eval] and [stdin] entries", async () => {
+  using dir = tempDir("plugin-onload.eval-entry", {
+    "preload.js": `
+      Bun.plugin({
+        name: "catch-all",
+        setup(build) {
+          build.onLoad({ filter: /.*/ }, args => ({
+            contents: "console.log(" + JSON.stringify("replaced " + args.path) + ");",
+            loader: "js",
+          }));
+        },
+      });
+    `,
+  });
+
+  await using evalProc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.js", "-e", "console.log('eval ran')"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  await using stdinProc = Bun.spawn({
+    cmd: [bunExe(), "--preload", "./preload.js", "-"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdin: Buffer.from("console.log('stdin ran')"),
+    stderr: "pipe",
+  });
+  const [evalOut, evalErr, evalExit, stdinOut, stdinErr, stdinExit] = await Promise.all([
+    evalProc.stdout.text(),
+    evalProc.stderr.text(),
+    evalProc.exited,
+    stdinProc.stdout.text(),
+    stdinProc.stderr.text(),
+    stdinProc.exited,
+  ]);
+
+  expect(evalOut.trim() || evalErr).toBe("eval ran");
+  expect(stdinOut.trim() || stdinErr).toBe("stdin ran");
+  expect([evalExit, stdinExit]).toEqual([0, 0]);
+});
+
 // `bun test` consults plugins before the builtin modules so that mock.module()
 // can replace a builtin. A file-namespace onLoad filter must still see a file
 // without an extension there, and must not see bare builtin names such as "ws".

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="./plugins" />
 import { plugin } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import { resolve } from "path";
 
 declare global {
@@ -900,6 +900,61 @@ it.concurrent("onLoad runs for a file without an extension", async () => {
   expect(stdout.trim() || stderr).toBe(
     ["dynamic:MIT License text", "require:MIT License text", "static:MIT License text", "seen:true"].join("\n"),
   );
+  expect(exitCode).toBe(0);
+});
+
+// A colon in a directory name is legal on POSIX. The loader must not read the
+// resolved path "/dir/a:b/file" as the namespace "/dir/a" plus the path "b/file".
+it.concurrent.skipIf(isWindows)("onLoad runs in the file namespace for a path that contains a colon", async () => {
+  using dir = tempDir("plugin-onload-colon-path", {
+    "with:colon/LICENSE": "MIT License text",
+    "with:colon/note.txt": "note text",
+    "entry.js": `
+      import { readFileSync } from "node:fs";
+      import { basename } from "node:path";
+
+      const seen = [];
+      Bun.plugin({
+        name: "colon-loader",
+        setup(build) {
+          build.onLoad({ filter: /(LICENSE|\\.txt)$/ }, args => {
+            seen.push(basename(args.path));
+            return {
+              contents: "export default " + JSON.stringify("plugin:" + readFileSync(args.path, "utf8")) + ";",
+              loader: "js",
+            };
+          });
+        },
+      });
+
+      async function attempt(specifier) {
+        try {
+          return (await import(specifier)).default;
+        } catch (error) {
+          return "threw: " + error.message;
+        }
+      }
+
+      const note = await attempt("./with:colon/note.txt");
+      const license = await attempt("./with:colon/LICENSE");
+      console.log(JSON.stringify({ note, license, seen }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The fixture catches its own failures, so empty stdout means it crashed.
+  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+    note: "plugin:note text",
+    license: "plugin:MIT License text",
+    seen: ["note.txt", "LICENSE"],
+  });
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -959,24 +959,31 @@ it.concurrent.skipIf(isWindows)("onLoad runs in the file namespace for a path th
 });
 
 // The key of a module in the namespace "/virtual" is "/virtual:foo.txt", which
-// also reads as an absolute path. The registered namespace wins.
-it.concurrent("onLoad runs in a registered namespace whose key looks like an absolute path", async () => {
+// also reads as an absolute path, and the key "a:boop" of the namespace "a"
+// reads like a Windows drive. The registered namespace wins in both cases.
+it.concurrent("onLoad runs in a registered namespace whose key looks like a path", async () => {
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
         Bun.plugin({
-          name: "slash-namespace",
+          name: "path-like-namespaces",
           setup(build) {
             build.onResolve({ filter: /^virt\\.mod$/ }, () => ({ path: "foo.txt", namespace: "/virtual" }));
             build.onLoad({ filter: /.*/, namespace: "/virtual" }, args => ({
               contents: "export default " + JSON.stringify("virtual:" + args.path) + ";",
               loader: "js",
             }));
+            build.onResolve({ filter: /^one\\.mod$/ }, () => ({ path: "boop", namespace: "a" }));
+            build.onLoad({ filter: /.*/, namespace: "a" }, args => ({
+              exports: { value: "a:" + args.path },
+              loader: "object",
+            }));
           },
         });
         console.log((await import("virt.mod")).default);
+        console.log(require("one.mod").value);
       `,
     ],
     env: bunEnv,
@@ -984,7 +991,7 @@ it.concurrent("onLoad runs in a registered namespace whose key looks like an abs
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout.trim() || stderr).toBe("virtual:foo.txt");
+  expect(stdout.trim() || stderr).toBe("virtual:foo.txt\na:boop");
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -855,6 +855,107 @@ it.concurrent("onResolve can redirect a specifier to a real file in the file nam
   expect(exitCode).toBe(0);
 });
 
+it.concurrent("onLoad runs for a file without an extension", async () => {
+  using dir = tempDir("plugin-onload-no-extension", {
+    "LICENSE": "MIT License text",
+    "static.js": `
+      import license from "./LICENSE";
+      console.log("static:" + license);
+    `,
+    "entry.js": `
+      import { readFileSync } from "node:fs";
+      import { join } from "node:path";
+
+      const seen = new Set();
+      Bun.plugin({
+        name: "license-loader",
+        setup(build) {
+          // Synchronous on purpose: require() rejects an onLoad result that is a promise.
+          build.onLoad({ filter: /LICENSE$/ }, args => {
+            seen.add(args.path);
+            return {
+              contents: "export default " + JSON.stringify(readFileSync(args.path, "utf8")) + ";",
+              loader: "js",
+            };
+          });
+        },
+      });
+
+      const dynamic = await import("./LICENSE");
+      console.log("dynamic:" + dynamic.default);
+      console.log("require:" + require("./LICENSE").default);
+      await import("./static.js");
+      console.log("seen:" + [...seen].map(path => path === join(import.meta.dir, "LICENSE")).join(","));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim() || stderr).toBe(
+    ["dynamic:MIT License text", "require:MIT License text", "static:MIT License text", "seen:true"].join("\n"),
+  );
+  expect(exitCode).toBe(0);
+});
+
+// `bun test` consults plugins before the builtin modules so that mock.module()
+// can replace a builtin. A file-namespace onLoad filter must still see a file
+// without an extension there, and must not see bare builtin names such as "ws".
+it.concurrent("onLoad runs for a file without an extension under bun test", async () => {
+  using dir = tempDir("plugin-onload-no-extension-test", {
+    "LICENSE": "MIT License text",
+    "preload.js": `
+      import { readFileSync } from "node:fs";
+
+      Bun.plugin({
+        name: "license-loader",
+        setup(build) {
+          build.onLoad({ filter: /LICENSE$/ }, args => ({
+            contents: "export default " + JSON.stringify(readFileSync(args.path, "utf8")) + ";",
+            loader: "js",
+          }));
+          build.onLoad({ filter: /^ws$/ }, () => ({
+            exports: { WebSocket: "replaced by plugin" },
+            loader: "object",
+          }));
+        },
+      });
+    `,
+    "license.test.js": `
+      import { expect, test } from "bun:test";
+      import license from "./LICENSE";
+      import { WebSocket } from "ws";
+
+      test("extension-less file goes through onLoad", () => {
+        expect(license).toBe("MIT License text");
+        expect(require("./LICENSE").default).toBe("MIT License text");
+      });
+
+      test("bare builtin names stay out of the file namespace", () => {
+        expect(typeof WebSocket).toBe("function");
+        expect(typeof require("ws").WebSocket).toBe("function");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--preload", "./preload.js", "license.test.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain(" 2 pass");
+  expect(stderr).toContain(" 0 fail");
+  expect(exitCode).toBe(0);
+});
+
 it.concurrent("a no-op onResolve that returns args.path unchanged is transparent", async () => {
   using dir = tempDir("plugin-onresolve-no-op", {
     "preload.js": `


### PR DESCRIPTION
Fixes the `onLoad` half of #4609 and #37699.

### Problem
- A runtime `Bun.plugin` `onLoad` callback never runs for a resolved file without an extension. `await import("./LICENSE")` with a matching `onLoad({ filter: /LICENSE$/ })` fails with `error: Expected ";" but found "License"`. Bun parses the file as JavaScript. The same happens for `require()` and for a static import.
- The cause is `Bun__runVirtualModule` (src/jsc/ModuleLoader.rs:245). It gates the resolved module key with `could_be_plugin` (src/bundler/transpiler.rs:88), a pre-filter written for raw import specifiers. It accepts only a `.ext` or a `namespace:` colon, so `/dir/LICENSE` never reaches the filters. An extension that starts with a digit (#4609) or a query string with a dot (#37699) fails the same gate.
- The function then calls `extract_namespace` on the key. For a POSIX path with a colon in a directory name (`/dir/a:b/note.txt`) it returns `/dir/a` as the namespace, so the `file` namespace filters never see that file either.

### Fix
- Route a resolved module key by shape, in two steps. If the prefix before the first colon is a namespace with registered `onLoad` callbacks, the key is a virtual module in that namespace. Otherwise, if the key is an absolute path, it is a file and goes to the `file` namespace filters as is. Any other key (`node:fs`, `ws`, `data:`) has no file to load and gets no callback.
- This is correct because a resolved absolute path is a file on disk, with two exceptions that the code handles: a registered namespace that starts with `/` (`/virtual:foo.txt`), which only the registered set can tell apart from a file, and the in-memory `<cwd>/[eval]` and `<cwd>/[stdin]` entries of `bun -e` and `bun -`, which are skipped. `moduleLoaderResolve` (src/jsc/bindings/ZigGlobalObject.cpp:3411) already applies the registered namespace rule to resolved keys.
- Under `bun test` the hook runs before the builtin lookup (so `mock.module("fs", ...)` can replace a builtin). A bare builtin name such as `ws` has no registered namespace and is not absolute, so it gets no callback. This no longer depends on `could_be_plugin`, which #40398 widens to accept bare names.
- Verified: five new tests in `test/js/bun/plugin/plugins.test.ts` (four fail on stock bun, one guards the registered namespace rule). Also all of `test/js/bun/plugin/`, `test/js/bun/test/mock/`, `test/bundler/bundler_plugin.test.ts`, and `test/cli/run/run-eval.test.ts`.

### Background
- A runtime plugin registers `onLoad({ filter, namespace })` callbacks. `BunPlugin::OnLoad::run` (src/jsc/bindings/BunPlugin.cpp) picks the group for the namespace and calls the first callback whose RegExp matches the path. An empty namespace means `file`. The new `Bun__onLoadPluginsHasNamespace` asks whether a group exists for a namespace.
- `Bun__runVirtualModule` is the Rust entry the module loader calls for every resolved module key before it reads the file from disk. The key is an absolute path, a `namespace:path` from `onResolve`, or a builtin name.
- `could_be_plugin` and `extract_namespace` still gate the two `onResolve` sites (`src/jsc/VirtualMachine.rs:4594`, `src/bundler/linker.rs:442`), which see raw import specifiers. This PR does not change them. #36592, #37702 and #40398 do.

<details><summary>Notes</summary>

- Repro: `printf 'MIT License text' > LICENSE`, then a script that registers `onLoad({ filter: /LICENSE$/ })` and runs `await import("./LICENSE")`. Before: `onLoad` never logs and the import rejects with `Expected ";" but found "License"`. After: `onLoad` receives the absolute path and the import evaluates to the file text.
- Colon probe on stock bun: with `onLoad({ filter: /\.txt$/ })` registered, `import("./with:colon/note.txt")` loads through the built-in `text` loader and the callback never runs. The first colon in the path was read as a namespace.
- Sibling probes on this branch: the #4609 repro (`onLoad({ filter: /\.1$/ })` for `ok.yaml.1`) returns the plugin value, stock returns `undefined`. The #37699 `onLoad` case (`import("/abs/plain.ts?v=123.456")` with `onLoad({ filter: /plain\.ts/ })`) returns the plugin source, stock returns the disk source. Their `onResolve` halves still need the resolve-side changes in #36592 and #37702. After this lands, the `onLoad` tests in those two PRs pass on main, so they need a rescope to `onResolve`.
- `[eval]` and `[stdin]`: stock bun ran the `file` namespace filters for `<cwd>/[eval]` only when the cwd contained a dot (the text after the last dot looked like an extension). A plugin cannot decline a matched `onLoad`, and there is no file at that path. This PR never runs them for these entries. Test 4 pins that, in a directory whose name contains a dot.
- `Bun.build` already runs `onLoad` for the LICENSE and colon files. The runtime was the outlier.
- Test 1 covers dynamic `import()`, `require()`, and a static import in a later-loaded module, and asserts that `args.path` is the absolute path. The callback is synchronous because `require()` rejects a promise result (existing, tested behavior).
- Test 2 (POSIX only, a colon is illegal in a Windows file name) covers a directory name with a colon, for a file with and without an extension.
- Test 3 registers `onLoad` in the namespaces `/virtual` and `a`. The keys `/virtual:foo.txt` and `a:boop` read as an absolute path and as a drive path. The registered namespace wins. This passes on stock bun too and guards the rule.
- Test 5 runs `bun test --preload` with the same plugin and a second `onLoad({ filter: /^ws$/ })` in the `file` namespace. It asserts that the extension-less file goes through `onLoad` and that `ws` is still the builtin.
- Windows: a key shaped like a drive path (a letter, a colon and a separator) is never read as a namespace, the same guard `extract_namespace` uses, but with every letter accepted. `Z:\dir\file` is an absolute path and reaches the `file` namespace. Before, `extract_namespace` returned `Z` for it (a pre-existing strict range check at src/bundler/transpiler.rs:78). The guard is Windows only and needs the separator, so a single letter namespace (`a:boop`) keeps working through `require()` on every platform. `@:/id.txt` with a registered `@` namespace also reaches its group.
- A relative key from an `onResolve` result without a namespace (`{ path: "real.js" }`) no longer reaches `onLoad`. That flow is already broken on main: the dynamic import yields an empty namespace, and a debug build of main asserts in `getModuleNamespace` on a later `require()` of the same key, before and after this change.
- Earlier revisions: the first only widened the gate (`is_absolute || could_be_plugin`) and still called `extract_namespace`. The second sent every absolute path to the `file` namespace, which would have broken a registered namespace that starts with `/`. Review pointed at both, hence the registered namespace rule.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/plugin/plugins.test.ts

<!-- robobun:evidence:end -->