### PR TITLE
install: drain deferred peer dependencies before sleeping in the wait loop

### DIFF
--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1037,28 +1037,35 @@ impl<const CHECK_PEERS: bool, const ONLY_PRE_PATCH: bool>
         // duration of the callback (no `&mut event_loop` straddles it). The original
         // `this: &mut` in `run_and_wait` is dead past the `let mgr = ...` line.
         let this = unsafe { &mut *closure.manager };
-        if CHECK_PEERS {
-            if let Err(err) = this.process_peer_dependency_list() {
+        loop {
+            if CHECK_PEERS {
+                if let Err(err) = this.process_peer_dependency_list() {
+                    closure.err = Some(err);
+                    return true;
+                }
+            }
+
+            this.drain_dependency_list();
+
+            // void RunTasksCallbacks — the trait dispatch needs a
+            // concrete `RunTasksCallbacks` impl; `extract_ctx` collapses to `()` so we
+            // do NOT pass `this` as both receiver and ctx (would alias `&mut`).
+            let log_level = this.options.log_level;
+            if let Err(err) =
+                run_tasks::<InstallWaitCallbacks>(this, &mut (), CHECK_PEERS, log_level)
+            {
                 closure.err = Some(err);
                 return true;
             }
-        }
 
-        this.drain_dependency_list();
-
-        // void RunTasksCallbacks — the trait dispatch needs a
-        // concrete `RunTasksCallbacks` impl; `extract_ctx` collapses to `()` so we
-        // do NOT pass `this` as both receiver and ctx (would alias `&mut`).
-        let log_level = this.options.log_level;
-        if let Err(err) = run_tasks::<InstallWaitCallbacks>(this, &mut (), CHECK_PEERS, log_level) {
-            closure.err = Some(err);
-            return true;
-        }
-
-        if CHECK_PEERS {
-            if this.peer_dependencies.readable_length() > 0 {
-                return false;
+            // `run_tasks` can resolve a package whose deferred peers create no
+            // new async task (e.g. its tarball is already extracted). With zero
+            // pending tasks nothing wakes this loop again, so drain the peer
+            // queue now instead of sleeping on a wakeup that never comes.
+            if CHECK_PEERS && this.peer_dependencies.readable_length() > 0 {
+                continue;
             }
+            break;
         }
 
         if ONLY_PRE_PATCH {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2052,6 +2052,102 @@ test("transitive peer deps are resolved when resolution is fully synchronous", a
   );
 });
 
+// https://github.com/oven-sh/bun/issues/40466
+// Two registry URLs sharing one install cache. The extracted-tarball cache key
+// has no port, so the warmup's strict-peer-dep tarball is reused by the second
+// registry, while the manifest cache is keyed by registry URL hash and is not.
+// The cold install then fetches strict-peer-dep's manifest as its last pending
+// task, resolves the package with no new task (tarball already extracted), and
+// defers its peer `no-deps@^2.0.0`. Without the fix nothing wakes the wait
+// loop again and `bun install` hangs in "Resolving dependencies" forever.
+test("transitive peer resolves when its tarball is cached from another registry", async () => {
+  const packagesDir = join(import.meta.dir, "registry", "packages");
+
+  function serveFixtures() {
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const pathname = new URL(req.url).pathname;
+
+        // Tarball: /<name>/-/<name>-<version>.tgz
+        if (pathname.endsWith(".tgz")) {
+          const match = pathname.match(/\/([^/]+)\/-\/(.+\.tgz)$/);
+          if (match) {
+            const tarball = file(join(packagesDir, match[1], match[2]));
+            if (await tarball.exists()) {
+              return new Response(tarball, {
+                headers: { "Content-Type": "application/octet-stream" },
+              });
+            }
+          }
+          return new Response("Not found", { status: 404 });
+        }
+
+        // Manifest: /<name>
+        const packageName = decodeURIComponent(pathname.slice(1));
+        const metaFile = file(join(packagesDir, packageName, "package.json"));
+        if (!(await metaFile.exists())) {
+          return new Response("Not found", { status: 404 });
+        }
+
+        const meta = await metaFile.json();
+        for (const [ver, info] of Object.entries(meta.versions ?? {}) as [string, any][]) {
+          if (info?.dist?.tarball) {
+            info.dist.tarball = `http://localhost:${server.port}/${packageName}/-/${packageName}-${ver}.tgz`;
+          }
+        }
+
+        return new Response(JSON.stringify(meta), {
+          headers: {
+            "Content-Type": "application/json",
+            "Cache-Control": "public, max-age=300",
+          },
+        });
+      },
+    });
+    return server;
+  }
+
+  using serverA = serveFixtures();
+  using serverB = serveFixtures();
+
+  using root = tempDir("transitive-peer-two-registries-", {
+    "warmup/package.json": JSON.stringify({
+      name: "warmup",
+      dependencies: { "strict-peer-dep": "1.0.0" },
+    }),
+    "cold/package.json": JSON.stringify({
+      name: "cold",
+      dependencies: { "no-deps": "1.0.0", "uses-strict-peer": "1.0.0" },
+    }),
+  });
+  const cacheDir = join(String(root), "cache").replaceAll("\\", "\\\\");
+  const bunfig = (port: number) =>
+    `[install]\ncache = "${cacheDir}"\nregistry = "http://localhost:${port}/"\nlinker = "isolated"\n`;
+  await write(join(String(root), "warmup", "bunfig.toml"), bunfig(serverA.port));
+  await write(join(String(root), "cold", "bunfig.toml"), bunfig(serverB.port));
+
+  // Caches strict-peer-dep's manifest (registry A's URL hash) and extracts its
+  // tarball (shared across registries).
+  await runBunInstall(bunEnv, join(String(root), "warmup"), { allowWarnings: true });
+
+  // Hangs forever without the fix.
+  await runBunInstall(bunEnv, join(String(root), "cold"), { allowWarnings: true });
+
+  const bunDir = join(String(root), "cold", "node_modules", ".bun");
+  const entries = await readdirSorted(bunDir);
+  const strictPeerEntry = entries.find(e => e.startsWith("strict-peer-dep@1.0.0"));
+  const usesStrictEntry = entries.find(e => e.startsWith("uses-strict-peer@1.0.0"));
+  expect(strictPeerEntry).toBeDefined();
+  expect(usesStrictEntry).toBeDefined();
+
+  // The deferred transitive peer must end up resolved and linked.
+  expect(existsSync(join(bunDir, strictPeerEntry!, "node_modules", "no-deps"))).toBe(true);
+  expect(withoutEntryHash(readlinkSync(join(bunDir, usesStrictEntry!, "node_modules", "strict-peer-dep")))).toBe(
+    join("..", "..", strictPeerEntry!, "node_modules", "strict-peer-dep"),
+  );
+});
+
 // https://github.com/oven-sh/bun/issues/36987
 // A tarball URL with a query string must not put a literal `?` in the .bun
 // store directory name: module resolution parses `?` as a query-string

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1937,24 +1937,15 @@ test("runs lifecycle scripts correctly", async () => {
   expect(allLifecycleScriptsDir).toEqual(["all-lifecycle-scripts"]);
 });
 
-// When an auto-installed peer dependency has its OWN peer deps, those
-// transitive peers get re-queued during peer processing. If all manifest
-// loads are synchronous (cached with valid max-age) AND the transitive peer's
-// version constraint doesn't match what's already in the lockfile,
-// pendingTaskCount() stays at 0 and waitForPeers was skipped — leaving
-// the transitive peer's resolution unset (= invalid_package_id → filtered
-// from the install).
-test("transitive peer deps are resolved when resolution is fully synchronous", async () => {
+// Self-contained HTTP server that serves package manifests & tarballs
+// directly from the Verdaccio fixtures, with Cache-Control: max-age=300
+// to replicate npmjs.org behavior (fully synchronous on warm cache).
+function serveFixtures() {
   const packagesDir = join(import.meta.dir, "registry", "packages");
-
-  // Self-contained HTTP server that serves package manifests & tarballs
-  // directly from the Verdaccio fixtures, with Cache-Control: max-age=300
-  // to replicate npmjs.org behavior (fully synchronous on warm cache).
-  using server = Bun.serve({
+  const server = Bun.serve({
     port: 0,
     async fetch(req) {
-      const url = new URL(req.url);
-      const pathname = url.pathname;
+      const pathname = new URL(req.url).pathname;
 
       // Tarball: /<name>/-/<name>-<version>.tgz
       if (pathname.endsWith(".tgz")) {
@@ -1979,10 +1970,9 @@ test("transitive peer deps are resolved when resolution is fully synchronous", a
 
       // Rewrite tarball URLs to point at this server
       const meta = await metaFile.json();
-      const port = server.port;
       for (const [ver, info] of Object.entries(meta.versions ?? {}) as [string, any][]) {
         if (info?.dist?.tarball) {
-          info.dist.tarball = `http://localhost:${port}/${packageName}/-/${packageName}-${ver}.tgz`;
+          info.dist.tarball = `http://localhost:${server.port}/${packageName}/-/${packageName}-${ver}.tgz`;
         }
       }
 
@@ -1994,6 +1984,18 @@ test("transitive peer deps are resolved when resolution is fully synchronous", a
       });
     },
   });
+  return server;
+}
+
+// When an auto-installed peer dependency has its OWN peer deps, those
+// transitive peers get re-queued during peer processing. If all manifest
+// loads are synchronous (cached with valid max-age) AND the transitive peer's
+// version constraint doesn't match what's already in the lockfile,
+// pendingTaskCount() stays at 0 and waitForPeers was skipped — leaving
+// the transitive peer's resolution unset (= invalid_package_id → filtered
+// from the install).
+test("transitive peer deps are resolved when resolution is fully synchronous", async () => {
+  using server = serveFixtures();
 
   using packageDir = tempDir("transitive-peer-test-", {});
   const packageJson = join(String(packageDir), "package.json");
@@ -2061,53 +2063,6 @@ test("transitive peer deps are resolved when resolution is fully synchronous", a
 // defers its peer `no-deps@^2.0.0`. Without the fix nothing wakes the wait
 // loop again and `bun install` hangs in "Resolving dependencies" forever.
 test("transitive peer resolves when its tarball is cached from another registry", async () => {
-  const packagesDir = join(import.meta.dir, "registry", "packages");
-
-  function serveFixtures() {
-    const server = Bun.serve({
-      port: 0,
-      async fetch(req) {
-        const pathname = new URL(req.url).pathname;
-
-        // Tarball: /<name>/-/<name>-<version>.tgz
-        if (pathname.endsWith(".tgz")) {
-          const match = pathname.match(/\/([^/]+)\/-\/(.+\.tgz)$/);
-          if (match) {
-            const tarball = file(join(packagesDir, match[1], match[2]));
-            if (await tarball.exists()) {
-              return new Response(tarball, {
-                headers: { "Content-Type": "application/octet-stream" },
-              });
-            }
-          }
-          return new Response("Not found", { status: 404 });
-        }
-
-        // Manifest: /<name>
-        const packageName = decodeURIComponent(pathname.slice(1));
-        const metaFile = file(join(packagesDir, packageName, "package.json"));
-        if (!(await metaFile.exists())) {
-          return new Response("Not found", { status: 404 });
-        }
-
-        const meta = await metaFile.json();
-        for (const [ver, info] of Object.entries(meta.versions ?? {}) as [string, any][]) {
-          if (info?.dist?.tarball) {
-            info.dist.tarball = `http://localhost:${server.port}/${packageName}/-/${packageName}-${ver}.tgz`;
-          }
-        }
-
-        return new Response(JSON.stringify(meta), {
-          headers: {
-            "Content-Type": "application/json",
-            "Cache-Control": "public, max-age=300",
-          },
-        });
-      },
-    });
-    return server;
-  }
-
   using serverA = serveFixtures();
   using serverB = serveFixtures();
 


### PR DESCRIPTION
### Problem
- `bun install` hangs forever in "Resolving dependencies" when a transitive peer's manifest is cached from a different registry URL. Issue #40466.
- The wait loop's `is_done` (`src/install/PackageManager/install_with_manager.rs:1032`) returns not-done while `peer_dependencies` is non-empty, then sleeps. The wakeup only comes from a pending async task. When the last pending task (the peer's manifest fetch) resolves a package whose tarball is already extracted, no new task is created. The deferred peer sits in the queue with zero pending tasks and nothing wakes the loop.

### Fix
- Process the peer queue in a loop inside `is_done`: after `run_tasks`, if the peer queue is non-empty, run another pass instead of returning false and sleeping.
- The loop terminates. Each pass fully drains the peer queue, a peer processed with `install_peer = true` is never re-deferred, and new entries only come from newly appended packages, a finite set. A peer that needs a manifest creates a pending task, so the loop breaks and the sleep is woken normally.
- Verified: `test/cli/install/isolated-install.test.ts` ("transitive peer resolves when its tarball is cached from another registry"). It times out on stock bun and passes with the fix. Also the full isolated-install suite and the peer tests in bun-install-registry.test.ts.

### Background
- Peer dependencies resolve in a second phase. The first enqueue defers them to a `peer_dependencies` queue. The wait loop re-enqueues them with `install_peer = true`.
- Manifest cache files are keyed by registry URL hash (`<fileid>-<urlhash>.npm`), so a registry URL change forces a refetch. Extracted tarballs are keyed by `name@version@@host` with no port, so two localhost registries share them.
- Trigger chain: `uses-strict-peer -> (peer) strict-peer-dep -> (peer) no-deps@^2.0.0`. A warmup through registry A extracts `strict-peer-dep`'s tarball into the shared cache. The cold install through registry B fetches the manifest, resolves the package with no task, and defers the `no-deps` peer.

<details><summary>Notes</summary>

Debug-log trace of the hang (cold install, `BUN_DEBUG_PackageManager=1 --verbose`): the log ends with `Downloaded strict-peer-dep versions` then `- "strict-peer-dep": "1.0.0" - strict-peer-dep@1.0.0` and nothing after. No tarball request for `strict-peer-dep` follows because `determine_preinstall_state` returns `Done` (extracted by the warmup), so `ResolvedPackageResult.task` is `None`. Its dependency list (the peer `no-deps@^2.0.0`) goes through `dependency_list_queue` into `peer_dependencies`, `is_done` hits the `readable_length() > 0` early return, and `sleep_until` blocks with `pending_task_count() == 0`.

Without the warmup, `strict-peer-dep` needs an extract task, so a later task completion wakes the loop and the peer queue drains. With the same registry for both installs, the manifest cache is fresh and resolution is fully synchronous, which the existing guard in `wait_for_resolution` (`install_with_manager.rs:2050`, added with the test "transitive peer deps are resolved when resolution is fully synchronous") already handles. The gap was a deferral created by the completion of the last pending task.

Found through CI of #40463: the test runner shares one `BUN_INSTALL_CACHE_DIR` per test file, so a test that installed `strict-peer-dep` through the shared Verdaccio contaminated the cache for the per-test-registry test, which then hung for its full 90s timeout on all 8 platforms.

Suites run: `test/cli/install/isolated-install.test.ts` (83 pass), `test/cli/install/bun-install-registry.test.ts -t peer` (29 pass), `test/cli/install/bun-install.test.ts` (14 failures, all pre-existing: they need the public internet (bitbucket/gitlab/external tarball URLs) and fail identically on stock bun in this environment).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->