### PR TITLE
fix(io): emulate EPOLLONESHOT with DEL + ADD

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -224,6 +224,10 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE, "BUN_FEATURE_FLAG_DISABLE_FETCH_TLS_SESSION_CACHE", {});
     new_feature_flag!(pub BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO, "BUN_FEATURE_FLAG_DISABLE_DNS_CACHE_LIBINFO", {});
+    // Emulate EPOLLONESHOT with EPOLL_CTL_DEL + EPOLL_CTL_ADD. This supports
+    // Linux-compatible kernels that accept EPOLLONESHOT but do not implement
+    // its automatic disarm semantics.
+    new_feature_flag!(pub BUN_FEATURE_FLAG_EMULATE_EPOLL_ONESHOT, "BUN_FEATURE_FLAG_EMULATE_EPOLL_ONESHOT", {});
     // Force the event loop to use epoll_pwait(2) instead of epoll_pwait2(2).
     // Escape hatch for seccomp policies that block syscall 441 without
     // returning a checkable errno (Android app sandbox, some container

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -676,6 +676,37 @@ pub use crate::closer::Closer;
 pub use crate::waker::Waker;
 use bun_sys::{self as sys, E, Fd};
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[inline]
+pub(crate) fn emulate_epoll_oneshot() -> bool {
+    bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_EMULATE_EPOLL_ONESHOT::get()
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(crate) fn disarm_emulated_epoll_oneshot(watcher_fd: Fd, fd: Fd) -> sys::Result<()> {
+    use bun_sys::linux::{self, EPOLL};
+
+    loop {
+        // SAFETY: both descriptors came from a successful epoll registration;
+        // null is valid for EPOLL_CTL_DEL on Linux 2.6.9 and newer.
+        let rc = unsafe {
+            linux::epoll_ctl(
+                watcher_fd.native(),
+                EPOLL::CTL_DEL,
+                fd.native(),
+                core::ptr::null_mut(),
+            )
+        };
+        match sys::get_errno(rc) {
+            E::EINTR => continue,
+            E::SUCCESS | E::ENOENT | E::EBADF => return sys::Result::Ok(()),
+            errno => {
+                return sys::Result::Err(sys::Error::from_code(errno, sys::Tag::epoll_ctl));
+            }
+        }
+    }
+}
+
 // `loop` is a Rust keyword, so the static is
 // named `io_loop` but the runtime tagname is `"loop"` so `BUN_DEBUG_loop=1` works.
 #[allow(non_upper_case_globals)]
@@ -1075,7 +1106,7 @@ impl IoRequestLoop {
                 let Some(poll) = core::ptr::NonNull::new(pollable.poll()) else {
                     continue;
                 };
-                Poll::on_update_epoll(poll, pollable.tag(), *event);
+                Poll::on_update_epoll(self.pollfd(), poll, pollable.tag(), *event);
             }
         }
     }
@@ -1437,6 +1468,8 @@ static GENERATION_NUMBER_MONOTONIC: core::sync::atomic::AtomicU64 =
 
 pub struct Poll {
     pub flags: FlagsSet,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    registered_fd: Fd,
     #[cfg(all(target_os = "macos", debug_assertions))]
     pub(crate) generation_number: GenerationNumberInt,
 }
@@ -1445,6 +1478,8 @@ impl Default for Poll {
     fn default() -> Self {
         Self {
             flags: FlagsSet::empty(),
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            registered_fd: Fd::INVALID,
             #[cfg(all(target_os = "macos", debug_assertions))]
             generation_number: 0,
         }
@@ -1485,6 +1520,10 @@ pub enum Flags {
     WasEverRegistered,
 
     Registered,
+
+    // Keep compatibility-only flags at the end so existing flag bit values
+    // remain stable on every platform.
+    EmulatedOneShot,
 }
 
 pub type FlagsSet = enumset::EnumSet<Flags>;
@@ -1605,6 +1644,7 @@ impl Poll {
             );
         }
         self.flags.remove(Flags::Registered);
+        self.registered_fd = Fd::INVALID;
     }
 
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
@@ -1652,6 +1692,7 @@ impl Poll {
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub(crate) fn on_update_epoll(
+        watcher_fd: Fd,
         poll: core::ptr::NonNull<Poll>,
         tag: PollableTag,
         event: linux::epoll_event,
@@ -1661,6 +1702,24 @@ impl Poll {
             return;
         }
         let poll = poll.as_ptr();
+
+        // EPOLLONESHOT normally removes the fd from the ready set before
+        // userspace can re-enter the loop. Do that explicitly on kernels where
+        // the flag is accepted but its disarm semantics are not implemented.
+        if unsafe { (*poll).flags.contains(Flags::EmulatedOneShot) } {
+            let fd = unsafe { (*poll).registered_fd };
+            if let Err(err) = disarm_emulated_epoll_oneshot(watcher_fd, fd) {
+                // SAFETY: poll is the embedded io_poll of the live owner.
+                unsafe { __bun_io_pollable_on_io_error(tag, poll, &err) };
+                return;
+            }
+            // SAFETY: the io thread owns this Poll until the callback below.
+            unsafe {
+                (*poll).flags.remove(Flags::Registered);
+                (*poll).registered_fd = Fd::INVALID;
+            }
+        }
+
         // CYCLEBREAK: owner (ReadFile/WriteFile) is T6; dispatch via link-time
         // `extern "Rust"` defined in `bun_runtime::dispatch`. The
         // container_of(io_poll) recovery happens there.
@@ -1702,7 +1761,15 @@ impl Poll {
             self.flags.insert(Flags::OneShot);
         }
 
-        let one_shot_flag: u32 = if !self.flags.contains(Flags::OneShot) {
+        if self.flags.contains(Flags::OneShot) && emulate_epoll_oneshot() {
+            self.flags.insert(Flags::EmulatedOneShot);
+        } else {
+            self.flags.remove(Flags::EmulatedOneShot);
+        }
+
+        let one_shot_flag: u32 = if !self.flags.contains(Flags::OneShot)
+            || self.flags.contains(Flags::EmulatedOneShot)
+        {
             0
         } else {
             linux::EPOLL_ONESHOT
@@ -1723,7 +1790,13 @@ impl Poll {
             u64: Pollable::init(tag, std::ptr::from_mut::<Poll>(self)).ptr(),
         };
 
-        let op: i32 = if self.flags.contains(Flags::WasEverRegistered)
+        let op: i32 = if self.flags.contains(Flags::EmulatedOneShot) {
+            if self.flags.contains(Flags::Registered) {
+                linux::EPOLL_CTL_MOD
+            } else {
+                linux::EPOLL_CTL_ADD
+            }
+        } else if self.flags.contains(Flags::WasEverRegistered)
             || self.flags.contains(Flags::NeedsRearm)
         {
             linux::EPOLL_CTL_MOD
@@ -1750,6 +1823,7 @@ impl Poll {
         // it never had done so in the first place.
         self.flags.insert(Flags::Registered);
         self.flags.insert(Flags::WasEverRegistered);
+        self.registered_fd = fd;
 
         self.flags.insert(match flag {
             Flags::PollReadable => Flags::PollReadable,

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -611,7 +611,15 @@ impl FilePoll {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             use bun_sys::linux::{self, EPOLL};
-            let one_shot_flag: u32 = if !self.flags.contains(Flags::OneShot) {
+            if self.flags.contains(Flags::OneShot) && crate::emulate_epoll_oneshot() {
+                self.flags.insert(Flags::EmulatedOneShot);
+            } else {
+                self.flags.remove(Flags::EmulatedOneShot);
+            }
+
+            let one_shot_flag: u32 = if !self.flags.contains(Flags::OneShot)
+                || self.flags.contains(Flags::EmulatedOneShot)
+            {
                 0
             } else {
                 EPOLL::ONESHOT
@@ -643,7 +651,12 @@ impl FilePoll {
                 u64: Pollable::init(self).ptr() as u64,
             };
 
-            let op: c_int = if self.is_registered() || self.flags.contains(Flags::NeedsRearm) {
+            let needs_rearm = self.flags.contains(Flags::NeedsRearm);
+            let op: c_int = if needs_rearm && self.flags.contains(Flags::EmulatedOneShot) {
+                // The ready-event path removed this fd from epoll to emulate
+                // the kernel's one-shot disarm. Re-arming therefore adds it.
+                EPOLL::CTL_ADD
+            } else if self.is_registered() || needs_rearm {
                 EPOLL::CTL_MOD
             } else {
                 EPOLL::CTL_ADD
@@ -1140,6 +1153,7 @@ impl FilePoll {
 
         self.flags.remove(Flags::NeedsRearm);
         self.flags.remove(Flags::OneShot);
+        self.flags.remove(Flags::EmulatedOneShot);
         self.flags.remove(Flags::PollReadable);
         self.flags.remove(Flags::PollWritable);
         self.flags.remove(Flags::PollProcess);
@@ -1209,6 +1223,10 @@ pub enum Flags {
     IgnoreUpdates,
 
     Socket,
+
+    // Keep compatibility-only flags at the end so existing flag bit values
+    // remain stable on every platform.
+    EmulatedOneShot,
 }
 
 pub type FlagsSet = enumset::EnumSet<Flags>;
@@ -1481,6 +1499,20 @@ unsafe extern "C" fn Bun__internal_dispatch_ready_poll(
 
     // SAFETY: tag matched FilePoll; pointer was set via Pollable::init in register_with_fd.
     let file_poll: &mut FilePoll = unsafe { &mut *tag.as_file_poll() };
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    if file_poll.flags.contains(Flags::EmulatedOneShot) {
+        // Copy the epoll fd without holding a Loop borrow across the callback,
+        // which may re-enter the event loop and re-arm this FilePoll.
+        let watcher_fd = Fd::from_native(unsafe { &*loop_ }.fd);
+        if let Err(err) = crate::disarm_emulated_epoll_oneshot(watcher_fd, file_poll.fd) {
+            bun_core::Output::panic(format_args!(
+                "failed to emulate EPOLLONESHOT for fd {}: {:?}",
+                file_poll.fd, err
+            ));
+        }
+    }
+
     if file_poll.flags.contains(Flags::IgnoreUpdates) {
         return;
     }

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -34,6 +34,9 @@ const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 //                            recv guarantees the streaming inner loop's mid-read
 //                            flush (`head_start` past the half-buffer cutoff)
 //                            fires in a single poll wake.
+//   SHELL_STRIP_EPOLL_ONESHOT=1 removes EPOLLONESHOT before epoll_ctl reaches
+//                            the kernel, emulating a kernel that accepts but
+//                            ignores the flag.
 // FilePoll registers the socketpair through the raw syscall(SYS_epoll_ctl,
 // ...) wrapper, not the libc epoll_ctl symbol, so the epoll modes interpose
 // syscall(2).
@@ -57,6 +60,7 @@ const SHIM_C = /* c */ `
 
 static ssize_t (*real_recv)(int, void *, size_t, int);
 static long (*real_syscall)(long, long, long, long, long, long, long);
+static int (*real_epoll_ctl)(int, int, int, struct epoll_event *);
 static int (*real_close)(int);
 static int fail_recv = -1;
 static int fail_epoll = -1;
@@ -65,6 +69,7 @@ static int recv_one_chunk = -1;
 static int recv_eagain_first = -1;
 static int fail_epoll_from = -1; /* 0 = off, N >= 1 = 1-based index of the first failing call */
 static int recv_bulk = -1;       /* 0 = off, N >= 1 = number of fabricated full-buffer recvs */
+static int strip_epoll_oneshot = -1;
 static unsigned char recv_count[MAX_FD];
 static unsigned char epoll_count[MAX_FD];
 static unsigned char bulk_count[MAX_FD];
@@ -83,6 +88,19 @@ static void init_modes(void) {
     const char *s = getenv("SHELL_RECV_BULK");
     recv_bulk = s ? atoi(s) : 0;
   }
+  if (strip_epoll_oneshot < 0) strip_epoll_oneshot = getenv("SHELL_STRIP_EPOLL_ONESHOT") != NULL;
+}
+
+static struct epoll_event *maybe_strip_epoll_oneshot(
+    int op,
+    struct epoll_event *event,
+    struct epoll_event *copy) {
+  if (strip_epoll_oneshot && event && (op == EPOLL_CTL_ADD || op == EPOLL_CTL_MOD)) {
+    *copy = *event;
+    copy->events &= ~EPOLLONESHOT;
+    return copy;
+  }
+  return event;
 }
 
 static int is_unix_sock(int fd) {
@@ -130,9 +148,19 @@ ssize_t recv(int fd, void *buf, size_t len, int flags) {
   return real_recv(fd, buf, len, flags);
 }
 
+int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event) {
+  if (!real_epoll_ctl) {
+    real_epoll_ctl = (int (*)(int, int, int, struct epoll_event *))dlsym(RTLD_NEXT, "epoll_ctl");
+    init_modes();
+  }
+  struct epoll_event copy;
+  return real_epoll_ctl(epfd, op, fd, maybe_strip_epoll_oneshot(op, event, &copy));
+}
+
 long syscall(long number, ...) {
   va_list ap;
   long a, b, c, d, e, f;
+  struct epoll_event event_copy;
   va_start(ap, number);
   a = va_arg(ap, long);
   b = va_arg(ap, long);
@@ -148,6 +176,7 @@ long syscall(long number, ...) {
   if (number == SYS_epoll_ctl) {
     int op = (int)b;
     int target = (int)c;
+    d = (long)maybe_strip_epoll_oneshot(op, (struct epoll_event *)d, &event_copy);
     if (op == EPOLL_CTL_ADD || op == EPOLL_CTL_MOD) {
       if (fail_epoll && is_pipe_like(target)) {
         errno = ENOMEM;
@@ -228,6 +257,64 @@ const r = await $\`sh -c 'printf AAAA; exec sleep 5' 2> /dev/null\`.quiet().noth
 console.log(JSON.stringify({ exitCode: r.exitCode }));
 `;
 
+const ONESHOT_EMULATION_CHILD = /* js */ `
+process.on("message", message => {
+  if (message !== "drain") return;
+  void (async () => {
+    const input = await Bun.stdin.bytes();
+    await Bun.write(Bun.stdout, input);
+    process.disconnect();
+  })().catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+    process.disconnect();
+  });
+});
+process.send("ready");
+`;
+
+const ONESHOT_EMULATION_FIXTURE = /* js */ `
+const size = 4 * 1024 * 1024;
+let readyDone = false;
+const { promise: ready, resolve, reject } = Promise.withResolvers();
+await using child = Bun.spawn({
+  cmd: [process.execPath, "-e", ${JSON.stringify(ONESHOT_EMULATION_CHILD)}],
+  stdin: "pipe",
+  stdout: "pipe",
+  stderr: "pipe",
+  ipc(message) {
+    if (message === "ready") {
+      readyDone = true;
+      resolve();
+    }
+  },
+});
+const exited = child.exited;
+void exited.then(code => {
+  if (!readyDone) reject(new Error(\`child exited before IPC handshake: \${code}\`));
+});
+await ready;
+
+const stdoutPromise = child.stdout.bytes();
+const stderrPromise = child.stderr.text();
+const writeResult = child.stdin.write(Buffer.alloc(size, 0x61));
+if (!(writeResult instanceof Promise)) {
+  throw new Error("expected the undrained pipe write to apply backpressure");
+}
+child.send("drain");
+await writeResult;
+await child.stdin.end();
+
+const [stdout, stderr, exitCode] = await Promise.all([stdoutPromise, stderrPromise, exited]);
+console.log(JSON.stringify({
+  bytes: stdout.byteLength,
+  first: stdout[0],
+  last: stdout[stdout.byteLength - 1],
+  stderr,
+  exitCode,
+}));
+`;
+
 const TEE_CHUNK_FIXTURE = /* js */ `
 import { $ } from "bun";
 const r = await $\`sh -c 'printf AAAA; exec sleep 5' 2> /dev/null\`.nothrow();
@@ -273,6 +360,7 @@ const MODES = [
   "SHELL_FAIL_EPOLL_AFTER",
   "SHELL_RECV_ONE_CHUNK",
   "SHELL_RECV_EAGAIN_FIRST",
+  "SHELL_STRIP_EPOLL_ONESHOT",
 ] as const;
 // Integer-valued fault knobs; cleared alongside MODES and set through `extraEnv`.
 const VALUE_MODES = ["SHELL_FAIL_EPOLL_FROM", "SHELL_RECV_BULK"] as const;
@@ -294,6 +382,26 @@ function shimEnv(
   Object.assign(env, extraEnv);
   return env;
 }
+
+test.concurrent.skipIf(!isLinux || !cc)("DEL + ADD emulates EPOLLONESHOT for Bun I/O polls", async () => {
+  const env = shimEnv(["SHELL_STRIP_EPOLL_ONESHOT"]);
+  env.BUN_FEATURE_FLAG_EMULATE_EPOLL_ONESHOT = "1";
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", ONESHOT_EMULATION_FIXTURE],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+    // A missing disarm spins on permanent readiness; bound that regression.
+    timeout: 30_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: `${JSON.stringify({ bytes: 4 * 1024 * 1024, first: 0x61, last: 0x61, stderr: "", exitCode: 0 })}\n`,
+    stderr: "",
+    exitCode: 0,
+  });
+});
 
 async function expectShellFault(
   script: string,


### PR DESCRIPTION
### What does this PR do?

Adds an opt-in compatibility path for Linux-compatible kernels that accept `EPOLLONESHOT` but do not implement its automatic disarm semantics.

When `BUN_FEATURE_FLAG_EMULATE_EPOLL_ONESHOT=1` is set, Bun:

- omits `EPOLLONESHOT` when registering logical one-shot polls
- calls `EPOLL_CTL_DEL` before dispatching a ready event
- re-arms the poll with `EPOLL_CTL_ADD`
- applies the behavior to both the main `FilePoll` event loop and the dedicated `Bun.file()` / `Bun.write()` I/O loop

The native Linux path remains unchanged unless the flag is enabled. Existing flag bit values are preserved, and the uSockets network event loop is untouched.

Adds an LD_PRELOAD regression test that strips `EPOLLONESHOT` before it reaches the kernel and exercises backpressured subprocess pipes plus `Bun.stdin` / `Bun.write`.

### How did you verify your code works?

Passed:

- `rustfmt +nightly-2026-07-20 --edition 2024 --check src/bun_core/env_var.rs src/io/lib.rs src/io/posix_event_loop.rs`
- `npx --yes prettier@3.6.2 --check test/js/bun/shell/shell-pipe-read-fault.test.ts`
- `git diff --check`

Not run locally:

- Full Rust compilation and the integration test. The available WSL environment has no Linux `cc` linker or built Bun executable; `cargo check -p bun_io --lib` stops before compiling the project changes with `linker cc not found`.