### PR TITLE
bun_ptr: RefPtr releases on Drop; remove ScopedRef/IntrusiveRc/DestructorCtx

### DIFF
--- a/src/bun_core_macros/lib.rs
+++ b/src/bun_core_macros/lib.rs
@@ -215,7 +215,7 @@ pub fn comptime_string_set_impl(input: TokenStream) -> TokenStream {
 // Replaces the former `impl_cell_ref_counted` declarative macro and
 // the ~80 hand-written `ref_count: Cell<u32>` + `unsafe impl` pairs. The
 // derive locates the intrusive refcount field and emits the trait impl, the
-// `AnyRefCounted` bridge (so `RefPtr`/`ScopedRef` accept the type), and
+// `AnyRefCounted` bridge (so `RefPtr` accepts the type), and
 // inherent `ref_()`/`deref()` forwarders so existing call sites keep working
 // without importing the trait.
 //
@@ -342,7 +342,6 @@ pub fn derive_cell_ref_counted(input: TokenStream) -> TokenStream {
             #destroy_impl
         }
         impl #impl_g ::bun_ptr::AnyRefCounted for #name #ty_g #where_g {
-            type DestructorCtx = ();
             #[inline]
             unsafe fn rc_ref(this: *mut Self) {
                 // SAFETY: caller contract — `this` is live. Raw field
@@ -351,7 +350,7 @@ pub fn derive_cell_ref_counted(input: TokenStream) -> TokenStream {
                 rc.set(rc.get() + 1);
             }
             #[inline]
-            unsafe fn rc_deref_with_context(this: *mut Self, (): ()) {
+            unsafe fn rc_deref(this: *mut Self) {
                 // SAFETY: caller contract — `this` is live.
                 unsafe { <Self as ::bun_ptr::CellRefCounted>::deref(this) }
             }
@@ -444,14 +443,13 @@ pub fn derive_thread_safe_ref_counted(input: TokenStream) -> TokenStream {
             #destroy_impl
         }
         impl #impl_g ::bun_ptr::AnyRefCounted for #name #ty_g #where_g {
-            type DestructorCtx = ();
             #[inline]
             unsafe fn rc_ref(this: *mut Self) {
                 // SAFETY: caller contract — `this` points to a live Self.
                 unsafe { ::bun_ptr::ThreadSafeRefCount::<Self>::ref_(this) }
             }
             #[inline]
-            unsafe fn rc_deref_with_context(this: *mut Self, (): ()) {
+            unsafe fn rc_deref(this: *mut Self) {
                 // SAFETY: caller contract — `this` points to a live Self.
                 unsafe { ::bun_ptr::ThreadSafeRefCount::<Self>::deref(this) }
             }
@@ -489,8 +487,8 @@ pub fn derive_thread_safe_ref_counted(input: TokenStream) -> TokenStream {
 // ──────────────────────────────────────────────────────────────────────────
 //
 // Third sibling of CellRefCounted / ThreadSafeRefCounted — replaces the ~17
-// hand-rolls that all spell out `type DestructorCtx = (); get_ref_count =
-// &raw mut (*this).ref_count; destructor = drop(heap::take(this))`.
+// hand-rolls that all spell out `get_ref_count = &raw mut (*this).ref_count;
+// destructor = drop(heap::take(this))`.
 //
 // Struct-level attribute:
 //   #[ref_count(destroy = <path>)]      — `unsafe fn(*mut Self)`; default is
@@ -581,7 +579,6 @@ pub fn derive_ref_counted(input: TokenStream) -> TokenStream {
 
     quote! {
         impl #impl_g ::bun_ptr::RefCounted for #name #ty_g #where_g {
-            type DestructorCtx = ();
             #debug_name_impl
             #[inline]
             unsafe fn get_ref_count(this: *mut Self) -> *mut ::bun_ptr::RefCount<Self> {
@@ -589,7 +586,7 @@ pub fn derive_ref_counted(input: TokenStream) -> TokenStream {
                 unsafe { &raw mut (*this).#field }
             }
             #[inline]
-            unsafe fn destructor(this: *mut Self, _ctx: ()) {
+            unsafe fn destructor(this: *mut Self) {
                 #destructor_body
             }
         }

--- a/src/bun_core_macros/lib.rs
+++ b/src/bun_core_macros/lib.rs
@@ -356,14 +356,6 @@ pub fn derive_cell_ref_counted(input: TokenStream) -> TokenStream {
                 // SAFETY: caller contract — `this` is live. Raw field projection.
                 unsafe { &*::core::ptr::addr_of!((*this).#field) }.get() == 1
             }
-            #[inline]
-            unsafe fn rc_assert_no_refs(this: *const Self) {
-                debug_assert_eq!(
-                    // SAFETY: caller contract — `this` is live. Raw field projection.
-                    unsafe { &*::core::ptr::addr_of!((*this).#field) }.get(),
-                    0,
-                );
-            }
         }
         // Inherent forwarders so callers don't need the trait in scope.
         impl #impl_g #name #ty_g #where_g {
@@ -451,14 +443,6 @@ pub fn derive_thread_safe_ref_counted(input: TokenStream) -> TokenStream {
                 unsafe {
                     (*<Self as ::bun_ptr::ThreadSafeRefCounted>::get_ref_count(this.cast_mut()))
                         .has_one_ref()
-                }
-            }
-            #[inline]
-            unsafe fn rc_assert_no_refs(this: *const Self) {
-                // SAFETY: caller contract — `this` points to a live Self.
-                unsafe {
-                    (*<Self as ::bun_ptr::ThreadSafeRefCounted>::get_ref_count(this.cast_mut()))
-                        .assert_no_refs()
                 }
             }
             #[inline]

--- a/src/bun_core_macros/lib.rs
+++ b/src/bun_core_macros/lib.rs
@@ -212,12 +212,9 @@ pub fn comptime_string_set_impl(input: TokenStream) -> TokenStream {
 // #[derive(CellRefCounted)] / #[derive(ThreadSafeRefCounted)]
 // ──────────────────────────────────────────────────────────────────────────
 //
-// Replaces the former `impl_cell_ref_counted` declarative macro and
-// the ~80 hand-written `ref_count: Cell<u32>` + `unsafe impl` pairs. The
-// derive locates the intrusive refcount field and emits the trait impl, the
-// `AnyRefCounted` bridge (so `RefPtr` accepts the type), and
-// inherent `ref_()`/`deref()` forwarders so existing call sites keep working
-// without importing the trait.
+// Locates the intrusive refcount field and emits the trait impl, the
+// `AnyRefCounted` bridge (so `RefPtr` accepts the type), and inherent
+// `ref_()`/`deref()` forwarders so call sites don't need the trait in scope.
 //
 // Field selection (first match wins):
 //   1. a field annotated `#[ref_count]`
@@ -367,11 +364,6 @@ pub fn derive_cell_ref_counted(input: TokenStream) -> TokenStream {
                     0,
                 );
             }
-            #[cfg(debug_assertions)]
-            #[inline]
-            unsafe fn rc_debug_data(_this: *mut Self) -> *mut dyn ::bun_ptr::ref_count::DebugDataOps {
-                ::bun_ptr::ref_count::noop_debug_data()
-            }
         }
         // Inherent forwarders so callers don't need the trait in scope.
         impl #impl_g #name #ty_g #where_g {
@@ -469,12 +461,12 @@ pub fn derive_thread_safe_ref_counted(input: TokenStream) -> TokenStream {
                         .assert_no_refs()
                 }
             }
-            #[cfg(debug_assertions)]
             #[inline]
-            unsafe fn rc_debug_data(this: *mut Self) -> *mut dyn ::bun_ptr::ref_count::DebugDataOps {
+            unsafe fn rc_assert_valid(this: *const Self) {
                 // SAFETY: caller contract — `this` points to a live Self.
                 unsafe {
-                    (*<Self as ::bun_ptr::ThreadSafeRefCounted>::get_ref_count(this)).debug_data_ptr()
+                    (*<Self as ::bun_ptr::ThreadSafeRefCounted>::get_ref_count(this.cast_mut()))
+                        .assert_valid()
                 }
             }
         }
@@ -486,9 +478,7 @@ pub fn derive_thread_safe_ref_counted(input: TokenStream) -> TokenStream {
 // #[derive(RefCounted)]  — intrusive single-thread `RefCount<Self>` mixin
 // ──────────────────────────────────────────────────────────────────────────
 //
-// Third sibling of CellRefCounted / ThreadSafeRefCounted — replaces the ~17
-// hand-rolls that all spell out `get_ref_count = &raw mut (*this).ref_count;
-// destructor = drop(heap::take(this))`.
+// Third sibling of CellRefCounted / ThreadSafeRefCounted.
 //
 // Struct-level attribute:
 //   #[ref_count(destroy = <path>)]      — `unsafe fn(*mut Self)`; default is

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -749,12 +749,7 @@ impl<'a> AsyncHTTP<'a> {
                     drop(core::mem::take(&mut client.prev_redirect));
                     drop(core::mem::take(&mut client.compressed_request_body));
                     drop(core::mem::take(&mut client.proxy_authorization));
-                    if let Some(tunnel) = client.proxy_tunnel.take() {
-                        // SAFETY: tunnel was created by ProxyTunnel::start
-                        // (heap::alloc) and is refcounted; detach the socket
-                        // before the clone's strong ref drops.
-                        (*tunnel.as_ptr()).detach_socket();
-                    }
+                    client.close_proxy_tunnel(false);
                     debug_assert!(client.h2.is_none());
                     client.custom_ssl_ctx = None;
                     // `state` was `Default` at `ptr::read` time and was

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -751,7 +751,7 @@ impl<'a> AsyncHTTP<'a> {
                     drop(core::mem::take(&mut client.proxy_authorization));
                     client.close_proxy_tunnel(false);
                     debug_assert!(client.h2.is_none());
-                    client.custom_ssl_ctx = None;
+                    drop(core::mem::take(&mut client.custom_ssl_ctx));
                     // `state` was `Default` at `ptr::read` time and was
                     // populated by the clone (`on_start` → `client.start`); it
                     // owns the decompressor / compressed_body buffers.

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -752,16 +752,11 @@ impl<'a> AsyncHTTP<'a> {
                     if let Some(tunnel) = client.proxy_tunnel.take() {
                         // SAFETY: tunnel was created by ProxyTunnel::start
                         // (heap::alloc) and is refcounted; detach the socket
-                        // (the first half of the old `detach_and_deref`)
-                        // before releasing the clone's strong ref below.
+                        // before the clone's strong ref drops.
                         (*tunnel.as_ptr()).detach_socket();
-                        tunnel.deref();
                     }
                     debug_assert!(client.h2.is_none());
-                    if let Some(ctx) = client.custom_ssl_ctx.take() {
-                        // Release the strong ref the clone took in set_custom_ssl_ctx.
-                        ctx.deref();
-                    }
+                    client.custom_ssl_ctx = None;
                     // `state` was `Default` at `ptr::read` time and was
                     // populated by the clone (`on_start` → `client.start`); it
                     // owns the decompressor / compressed_body buffers.

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -699,7 +699,6 @@ impl<const SSL: bool> HTTPContext<SSL> {
             ProxyTunnel::shutdown(t.as_non_null());
             crate::proxy_tunnel::raw_as_mut(t.as_ptr()).detach_socket();
         }
-        drop(h2_session);
         Self::close_socket(socket);
     }
 

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -215,24 +215,20 @@ pub struct PooledSocket<const SSL: bool> {
     pub(crate) h2_session: Option<RefPtr<h2::ClientSession>>,
 }
 
-/// Upgrade an `Option<RefPtr<h2::ClientSession>>` held by a pool / found-slot
-/// entry to `Option<&'a mut h2::ClientSession>`, for the field writes and
-/// idle-frame handling that cannot release the session. Anything that can
-/// (`adopt`, the socket events) goes through a [`h2::SessionPtr`] instead.
+/// `&mut` access to a pooled / found-slot HTTP/2 session, for the field
+/// writes and idle-frame handling that cannot release the session. Anything
+/// that can (`adopt`, the socket events) goes through a [`h2::SessionPtr`]
+/// instead.
 ///
-/// INVARIANT: while the holder stores `Some`, it owns one strong intrusive ref
-/// on the session (taken in `release_socket`, released in
-/// `add_memory_back_to_pool` or handed to the socket ext by `existing_socket` /
-/// `connect`); the session is a distinct heap allocation that outlives the
-/// holder. HTTP-thread-only, so no concurrent `&mut`. Centralises the SAFETY
-/// argument shared by `PooledSocket::h2_session_mut` and
-/// `ExistingSocket::h2_session_mut`.
+/// INVARIANT: the holder owns one ref on the session, a distinct heap
+/// allocation; HTTP-thread-only, so no concurrent `&mut`. Each call re-derives
+/// a fresh `&mut`, so callers may interleave raw `as_ptr()` reads (e.g.
+/// `register_h2`) without a spanning Unique tag.
 #[inline]
-fn h2_session_as_mut<'a>(
-    s: &Option<RefPtr<h2::ClientSession>>,
-) -> Option<&'a mut h2::ClientSession> {
+#[allow(clippy::mut_from_ref)]
+fn h2_session_mut(s: &RefPtr<h2::ClientSession>) -> &mut h2::ClientSession {
     // SAFETY: see INVARIANT above.
-    s.as_ref().map(|s| unsafe { &mut *s.as_ptr() })
+    unsafe { &mut *s.as_ptr() }
 }
 
 /// Upgrade a `*mut PooledSocket<SSL>` returned by `HiveArray::at` to `&mut`.
@@ -251,16 +247,6 @@ fn pooled_socket_mut<'a, const SSL: bool>(p: *mut PooledSocket<SSL>) -> &'a mut 
 }
 
 impl<const SSL: bool> PooledSocket<SSL> {
-    /// Mutable access to the parked HTTP/2 session.
-    ///
-    /// INVARIANT: the pool owns one strong ref on the session while parked
-    /// (taken in `release_socket`, released in `add_memory_back_to_pool` /
-    /// `existing_socket`); the pointee outlives `self`.
-    #[inline]
-    fn h2_session_mut(&mut self) -> Option<&mut h2::ClientSession> {
-        h2_session_as_mut(&self.h2_session)
-    }
-
     /// Drop the strong refs the pool holds while a socket is parked
     /// (proxy_tunnel / h2_session / ssl_config) and clear the heap-owned
     /// `target_hostname`. Called from `Drop` and `add_memory_back_to_pool`
@@ -287,20 +273,6 @@ struct ExistingSocket<const SSL: bool> {
     /// Present if the socket negotiated "h2"; ownership transferred.
     h2_session: Option<RefPtr<h2::ClientSession>>,
     verification: PeerVerification,
-}
-
-impl<const SSL: bool> ExistingSocket<SSL> {
-    /// Mutable access to the transferred HTTP/2 session.
-    ///
-    /// INVARIANT: `h2_session` carries one strong ref moved out of the pool by
-    /// `existing_socket`; the pointee is a distinct heap allocation that
-    /// outlives `self`. HTTP-thread-only. Each call re-derives a fresh `&mut`
-    /// from the raw `NonNull`, so callers may interleave calls with raw
-    /// `as_ptr()` reads (e.g. `register_h2`) without a spanning Unique tag.
-    #[inline]
-    fn h2_session_mut(&mut self) -> Option<&mut h2::ClientSession> {
-        h2_session_as_mut(&self.h2_session)
-    }
 }
 
 impl<const SSL: bool> HTTPContext<SSL> {
@@ -981,25 +953,17 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     ),
                 );
                 client.allow_retry = true;
-                if found.h2_session.is_some() {
-                    if SSL {
-                        // Note: `session.socket = sock` — direct field
-                        // write; ClientSession.socket is `HTTPSocket<true>`.
-                        // The `&mut` ends with the statement: `register_h2`
-                        // forms a fresh `&*session`, which under Stacked
-                        // Borrows would invalidate a spanning Unique.
-                        found.h2_session_mut().unwrap().socket = sock.assume_ssl();
-                        // The pool's ref (carried by `found`) becomes the
-                        // socket ext's; `adopt` goes through that handle and
-                        // may release it again if the session turns out to be
-                        // unusable, so nothing touches `session` afterwards.
-                        let session = found.h2_session.take().unwrap().into_this_ptr();
-                        Self::tag_as_h2(sock, session.as_ptr());
-                        self.register_h2(session.as_ptr());
-                        h2::ClientSession::adopt(session, client);
-                    } else {
-                        unreachable!();
-                    }
+                if let Some(session) = found.h2_session.take() {
+                    debug_assert!(SSL);
+                    h2_session_mut(&session).socket = sock.assume_ssl();
+                    // The pool's ref becomes the socket ext's; `adopt` goes
+                    // through that handle and may release it again if the
+                    // session turns out to be unusable, so nothing touches
+                    // `session` afterwards.
+                    let session = session.into_this_ptr();
+                    Self::tag_as_h2(sock, session.as_ptr());
+                    self.register_h2(session.as_ptr());
+                    h2::ClientSession::adopt(session, client);
                     return Ok(None);
                 }
                 if let Some(tunnel) = found.tunnel {
@@ -1274,7 +1238,7 @@ impl<const SSL: bool> Handler<SSL> {
                 return;
             }
 
-            if let Some(session) = pooled.h2_session_mut() {
+            if let Some(session) = pooled.h2_session.as_ref().map(h2_session_mut) {
                 session.on_idle_data(buf);
                 if !session.can_pool() {
                     HTTPContext::<SSL>::terminate_socket(socket);

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -6,13 +6,15 @@ use crate::Error;
 use crate::http_thread::InitOpts as HTTPThreadInitOpts;
 use crate::ssl_config::{self, SSLConfig};
 use crate::{
-    self as http, AlpnOffer, HTTPCertError, HTTPClient, InitError, get_cert_error_from_no, h2,
+    self as http, AlpnOffer, HTTPCertError, HTTPClient, InitError, ProxyTunnel,
+    get_cert_error_from_no, h2,
 };
 use bun_boringssl::ssl_ctx_setup;
 use bun_boringssl_sys::SSL_CTX;
 use bun_collections::{HiveArray, TaggedPtrUnion};
 use bun_core::strings;
 use bun_core::{self, FeatureFlags};
+use bun_ptr::RefPtr;
 use bun_uws as uws;
 
 bun_core::declare_scope!(HTTPContext, hidden);
@@ -64,7 +66,6 @@ pub struct HTTPContext<const SSL: bool> {
 // PORTING.md this stays intrusive rather than `Rc<T>`. Derived via
 // `#[derive(CellRefCounted)]` above; default `destroy` (`heap::take`) applies
 // (this struct is Box-allocated for custom-SSL entries; statics never hit 0).
-pub(crate) type HTTPContextRc<const SSL: bool> = bun_ptr::IntrusiveRc<HTTPContext<SSL>>;
 
 pub(crate) type PooledSocketHiveAllocator<const SSL: bool> =
     HiveArray<PooledSocket<SSL>, POOL_SIZE>;
@@ -205,7 +206,7 @@ pub struct PooledSocket<const SSL: bool> {
     /// an HTTP proxy), the tunnel is preserved here. The pool owns one
     /// strong ref while the socket is parked (the `RefPtr` *is* that ref).
     /// None for direct connections.
-    pub(crate) proxy_tunnel: Option<crate::proxy_tunnel::RefPtr>,
+    pub(crate) proxy_tunnel: Option<RefPtr<ProxyTunnel>>,
     /// Target (origin) hostname the tunnel connects to. `hostname_buf`
     /// above holds the PROXY hostname; this is the upstream we CONNECTed
     /// to. Heap-allocated only when proxy_tunnel is set; empty otherwise.
@@ -279,10 +280,7 @@ impl<const SSL: bool> PooledSocket<SSL> {
         // pool-key matching.
         self.ssl_config = None;
         self.target_hostname = Box::default();
-        if let Some(rp) = self.proxy_tunnel.take() {
-            // The pool's strong ref *is* this `RefPtr`; release it.
-            rp.deref();
-        }
+        self.proxy_tunnel = None;
         if let Some(s) = self.h2_session.take() {
             // SAFETY: pool owns one strong ref while parked.
             unsafe { h2::ClientSession::deref(s.as_ptr()) };
@@ -294,7 +292,7 @@ struct ExistingSocket<const SSL: bool> {
     socket: HTTPSocket<SSL>,
     /// Present if the socket carries an established CONNECT tunnel.
     /// Ownership (one strong ref) is transferred to the caller.
-    tunnel: Option<crate::proxy_tunnel::RefPtr>,
+    tunnel: Option<RefPtr<ProxyTunnel>>,
     /// Non-null if the socket negotiated "h2"; ownership transferred.
     h2_session: Option<NonNull<h2::ClientSession>>,
     verification: PeerVerification,
@@ -627,7 +625,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
         hostname: &[u8],
         port: u16,
         ssl_config: Option<&ssl_config::SharedPtr>,
-        tunnel: Option<crate::proxy_tunnel::RefPtr>,
+        tunnel: Option<RefPtr<ProxyTunnel>>,
         target_hostname: &[u8],
         target_port: u16,
         proxy_auth_hash: u64,
@@ -707,12 +705,8 @@ impl<const SSL: bool> HTTPContext<SSL> {
         }
         bun_core::scoped_log!(HTTPContext, "close socket");
         if let Some(t) = tunnel {
-            crate::proxy_tunnel::ProxyTunnel::shutdown(t.data);
-            // `t` is the strong ref the caller transferred; releasing it
-            // through the handle (usually the last ref) mirrors
-            // `HTTPClient::close_proxy_tunnel`.
+            crate::proxy_tunnel::ProxyTunnel::shutdown(t.as_non_null());
             crate::proxy_tunnel::raw_as_mut(t.as_ptr()).detach_socket();
-            t.deref();
         }
         if let Some(s) = h2_session {
             // SAFETY: live intrusive-refcounted ClientSession; deref releases
@@ -820,7 +814,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
                 // Release the pool's strong ref (caller has its own via tls_props)
                 socket.ssl_config = None;
                 // Transfer tunnel ownership (the parked strong ref) to the caller.
-                let tunnel: Option<crate::proxy_tunnel::RefPtr> = socket.proxy_tunnel.take();
+                let tunnel: Option<RefPtr<ProxyTunnel>> = socket.proxy_tunnel.take();
                 socket.target_hostname = Box::default();
                 let h2_session = socket.h2_session.take();
                 let verification = socket.verification;
@@ -1133,7 +1127,7 @@ impl<const SSL: bool> Drop for HTTPContext<SSL> {
             }
         }
         // Note: `bun.default_allocator.destroy(this)` is the Box drop
-        // performed by IntrusiveRc when refcount hits 0; not repeated here.
+        // performed by RefPtr when refcount hits 0; not repeated here.
     }
 }
 

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -61,12 +61,6 @@ pub struct HTTPContext<const SSL: bool> {
     pub(crate) session_cache: crate::session_cache::SessionCache,
 }
 
-// Intrusive refcount:
-// `*T` crosses FFI (group.ext) and is recovered from socket ext, so per
-// PORTING.md this stays intrusive rather than `Rc<T>`. Derived via
-// `#[derive(CellRefCounted)]` above; default `destroy` (`heap::take`) applies
-// (this struct is Box-allocated for custom-SSL entries; statics never hit 0).
-
 pub(crate) type PooledSocketHiveAllocator<const SSL: bool> =
     HiveArray<PooledSocket<SSL>, POOL_SIZE>;
 
@@ -218,10 +212,10 @@ pub struct PooledSocket<const SSL: bool> {
     pub(crate) proxy_auth_hash: u64,
     /// HTTP/2 connection state (HPACK tables, server SETTINGS) when
     /// this socket negotiated "h2". Owned by the pool while parked.
-    pub(crate) h2_session: Option<NonNull<h2::ClientSession>>,
+    pub(crate) h2_session: Option<RefPtr<h2::ClientSession>>,
 }
 
-/// Upgrade an `Option<NonNull<h2::ClientSession>>` held by a pool / found-slot
+/// Upgrade an `Option<RefPtr<h2::ClientSession>>` held by a pool / found-slot
 /// entry to `Option<&'a mut h2::ClientSession>`, for the field writes and
 /// idle-frame handling that cannot release the session. Anything that can
 /// (`adopt`, the socket events) goes through a [`h2::SessionPtr`] instead.
@@ -235,10 +229,10 @@ pub struct PooledSocket<const SSL: bool> {
 /// `ExistingSocket::h2_session_mut`.
 #[inline]
 fn h2_session_as_mut<'a>(
-    s: Option<NonNull<h2::ClientSession>>,
+    s: &Option<RefPtr<h2::ClientSession>>,
 ) -> Option<&'a mut h2::ClientSession> {
     // SAFETY: see INVARIANT above.
-    s.map(|mut s| unsafe { s.as_mut() })
+    s.as_ref().map(|s| unsafe { &mut *s.as_ptr() })
 }
 
 /// Upgrade a `*mut PooledSocket<SSL>` returned by `HiveArray::at` to `&mut`.
@@ -264,7 +258,7 @@ impl<const SSL: bool> PooledSocket<SSL> {
     /// `existing_socket`); the pointee outlives `self`.
     #[inline]
     fn h2_session_mut(&mut self) -> Option<&mut h2::ClientSession> {
-        h2_session_as_mut(self.h2_session)
+        h2_session_as_mut(&self.h2_session)
     }
 
     /// Drop the strong refs the pool holds while a socket is parked
@@ -281,10 +275,7 @@ impl<const SSL: bool> PooledSocket<SSL> {
         self.ssl_config = None;
         self.target_hostname = Box::default();
         self.proxy_tunnel = None;
-        if let Some(s) = self.h2_session.take() {
-            // SAFETY: pool owns one strong ref while parked.
-            unsafe { h2::ClientSession::deref(s.as_ptr()) };
-        }
+        self.h2_session = None;
     }
 }
 
@@ -293,8 +284,8 @@ struct ExistingSocket<const SSL: bool> {
     /// Present if the socket carries an established CONNECT tunnel.
     /// Ownership (one strong ref) is transferred to the caller.
     tunnel: Option<RefPtr<ProxyTunnel>>,
-    /// Non-null if the socket negotiated "h2"; ownership transferred.
-    h2_session: Option<NonNull<h2::ClientSession>>,
+    /// Present if the socket negotiated "h2"; ownership transferred.
+    h2_session: Option<RefPtr<h2::ClientSession>>,
     verification: PeerVerification,
 }
 
@@ -308,7 +299,7 @@ impl<const SSL: bool> ExistingSocket<SSL> {
     /// `as_ptr()` reads (e.g. `register_h2`) without a spanning Unique tag.
     #[inline]
     fn h2_session_mut(&mut self) -> Option<&mut h2::ClientSession> {
-        h2_session_as_mut(self.h2_session)
+        h2_session_as_mut(&self.h2_session)
     }
 }
 
@@ -629,7 +620,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
         target_hostname: &[u8],
         target_port: u16,
         proxy_auth_hash: u64,
-        h2_session: Option<NonNull<h2::ClientSession>>,
+        h2_session: Option<RefPtr<h2::ClientSession>>,
     ) {
         // log("releaseSocket(0x{f})", .{bun.fmt.hexIntUpper(@intFromPtr(socket.socket))});
 
@@ -705,14 +696,10 @@ impl<const SSL: bool> HTTPContext<SSL> {
         }
         bun_core::scoped_log!(HTTPContext, "close socket");
         if let Some(t) = tunnel {
-            crate::proxy_tunnel::ProxyTunnel::shutdown(t.as_non_null());
+            ProxyTunnel::shutdown(t.as_non_null());
             crate::proxy_tunnel::raw_as_mut(t.as_ptr()).detach_socket();
         }
-        if let Some(s) = h2_session {
-            // SAFETY: live intrusive-refcounted ClientSession; deref releases
-            // the strong ref the caller transferred.
-            unsafe { h2::ClientSession::deref(s.as_ptr()) };
-        }
+        drop(h2_session);
         Self::close_socket(socket);
     }
 
@@ -995,7 +982,7 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     ),
                 );
                 client.allow_retry = true;
-                if let Some(session) = found.h2_session {
+                if found.h2_session.is_some() {
                     if SSL {
                         // Note: `session.socket = sock` — direct field
                         // write; ClientSession.socket is `HTTPSocket<true>`.
@@ -1007,9 +994,10 @@ impl<const SSL: bool> HTTPContext<SSL> {
                         // socket ext's; `adopt` goes through that handle and
                         // may release it again if the session turns out to be
                         // unusable, so nothing touches `session` afterwards.
+                        let session = found.h2_session.take().unwrap().into_this_ptr();
                         Self::tag_as_h2(sock, session.as_ptr());
                         self.register_h2(session.as_ptr());
-                        h2::ClientSession::adopt(h2::ClientSession::this_ptr(session), client);
+                        h2::ClientSession::adopt(session, client);
                     } else {
                         unreachable!();
                     }
@@ -1126,8 +1114,6 @@ impl<const SSL: bool> Drop for HTTPContext<SSL> {
                 unsafe { bun_boringssl_sys::SSL_CTX_free(c) };
             }
         }
-        // Note: `bun.default_allocator.destroy(this)` is the Box drop
-        // performed by RefPtr when refcount hits 0; not repeated here.
     }
 }
 

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -769,7 +769,7 @@ impl HttpThread {
                                 // The resume may tear the session down and
                                 // release the socket's ref; hold one across
                                 // the second call.
-                                let _keep_alive = RefPtr::from_this(session);
+                                let _guard = RefPtr::from_this(session);
                                 h2::ClientSession::resume_receive_by_http_id(session, id);
                                 h2::ClientSession::drain_response_body_by_http_id(session, id);
                             }
@@ -782,7 +782,7 @@ impl HttpThread {
                             }
                             if let Some(session) = tagged.session() {
                                 // See the Tls arm.
-                                let _keep_alive = RefPtr::from_this(session);
+                                let _guard = RefPtr::from_this(session);
                                 h2::ClientSession::resume_receive_by_http_id(session, id);
                                 h2::ClientSession::drain_response_body_by_http_id(session, id);
                             }
@@ -1011,7 +1011,7 @@ impl HttpThread {
                 drop(core::mem::take(&mut client.compressed_request_body));
                 drop(core::mem::take(&mut client.proxy_authorization));
                 client.close_proxy_tunnel(false);
-                client.custom_ssl_ctx = None;
+                drop(core::mem::take(&mut client.custom_ssl_ctx));
                 drop(core::mem::take(&mut client.state));
                 if let Some(f) = release.release_at_shutdown {
                     f(release.ctx);

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1012,11 +1012,8 @@ impl HttpThread {
                 drop(core::mem::take(&mut client.proxy_authorization));
                 if let Some(tunnel) = client.proxy_tunnel.take() {
                     (*tunnel.as_ptr()).detach_socket();
-                    tunnel.deref();
                 }
-                if let Some(ctx) = client.custom_ssl_ctx.take() {
-                    ctx.deref();
-                }
+                client.custom_ssl_ctx = None;
                 drop(core::mem::take(&mut client.state));
                 if let Some(f) = release.release_at_shutdown {
                     f(release.ctx);

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use bun_collections::ArrayHashMap;
 use bun_core::{self, Output};
-
+use bun_ptr::RefPtr;
 use bun_threading::{Mutex, UnboundedQueue};
 use bun_uws as uws;
 
@@ -769,7 +769,7 @@ impl HttpThread {
                                 // The resume may tear the session down and
                                 // release the socket's ref; hold one across
                                 // the second call.
-                                let _keep_alive = session.ref_guard();
+                                let _keep_alive = RefPtr::from_this(session);
                                 h2::ClientSession::resume_receive_by_http_id(session, id);
                                 h2::ClientSession::drain_response_body_by_http_id(session, id);
                             }
@@ -782,7 +782,7 @@ impl HttpThread {
                             }
                             if let Some(session) = tagged.session() {
                                 // See the Tls arm.
-                                let _keep_alive = session.ref_guard();
+                                let _keep_alive = RefPtr::from_this(session);
                                 h2::ClientSession::resume_receive_by_http_id(session, id);
                                 h2::ClientSession::drain_response_body_by_http_id(session, id);
                             }
@@ -1010,9 +1010,7 @@ impl HttpThread {
                 drop(core::mem::take(&mut client.prev_redirect));
                 drop(core::mem::take(&mut client.compressed_request_body));
                 drop(core::mem::take(&mut client.proxy_authorization));
-                if let Some(tunnel) = client.proxy_tunnel.take() {
-                    (*tunnel.as_ptr()).detach_socket();
-                }
+                client.close_proxy_tunnel(false);
                 client.custom_ssl_ctx = None;
                 drop(core::mem::take(&mut client.state));
                 if let Some(f) = release.release_at_shutdown {

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -726,9 +726,9 @@ impl ProxyTunnel {
         Err(crate::Error::ConnectionClosed)
     }
 
-    /// Forget the outer socket. Holders call this before releasing their
-    /// handle (`RefPtr::deref`), so a tunnel that outlives them (a deferred
-    /// `on_close` deref is still pending) never retains a dangling socket.
+    /// Forget the outer socket. Holders call this before dropping their
+    /// `RefPtr`, so a tunnel that outlives them (a deferred `on_close` deref
+    /// is still pending) never retains a dangling socket.
     #[inline]
     pub(crate) fn detach_socket(&mut self) {
         self.socket = Socket::None;

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -4,6 +4,7 @@ use core::sync::atomic::Ordering;
 
 use crate::Error;
 use bun_core::scoped_log;
+use bun_ptr::RefPtr;
 use bun_uws as uws;
 
 use crate::http_cert_error::HTTPCertError;
@@ -14,8 +15,6 @@ use crate::ssl_wrapper::{Handlers as SSLWrapperHandlers, InitError, SSLWrapper, 
 use crate::{AlpnOffer, HTTPClient};
 
 bun_core::declare_scope!(http_proxy_tunnel, visible);
-
-use bun_ptr::RefPtr;
 
 /// Upgrade a `*mut ProxyTunnel` (obtained from [`RefPtr::as_ptr`]) to
 /// `&'a mut ProxyTunnel`.
@@ -171,9 +170,9 @@ impl ProxyTunnel {
     /// so it does not alias the caller's `&SSLWrapper` (see ALIASING NOTE).
     /// HTTP-thread-only.
     #[inline]
-    fn ref_scope(this: NonNull<Self>) -> bun_ptr::RefPtr<Self> {
+    fn ref_guard(this: NonNull<Self>) -> RefPtr<Self> {
         // SAFETY: see INVARIANT above.
-        unsafe { bun_ptr::RefPtr::init_ref(this.as_ptr()) }
+        unsafe { RefPtr::init_ref(this.as_ptr()) }
     }
 }
 
@@ -210,12 +209,12 @@ fn on_open(ctx: *mut HTTPClient) {
     bun_analytics::features::http_client_proxy.fetch_add(1, Ordering::Relaxed);
     this.state.response_stage = HTTPStage::ProxyHandshake;
     this.state.request_stage = HTTPStage::ProxyHandshake;
-    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.as_non_null()) else {
+    let Some(proxy_nn) = this.proxy_tunnel_ptr() else {
         return;
     };
     // Live intrusive-refcounted tunnel allocated in `start()`. Do NOT form
     // `&mut ProxyTunnel` — see ALIASING NOTE.
-    let _guard = ProxyTunnel::ref_scope(proxy_nn);
+    let _guard = ProxyTunnel::ref_guard(proxy_nn);
     if let Some(ssl_ptr) = ProxyTunnel::wrapper_ssl(proxy_nn) {
         let _hostname = this.hostname.unwrap_or(this.url.hostname);
 
@@ -261,10 +260,10 @@ fn on_data(ctx: *mut HTTPClient, decoded_data: &[u8]) {
     // ends this borrow before any reentrant call below that re-derives
     // `&mut *ctx` (close → on_close, progress_update).
     let this = client_from_ctx(ctx);
-    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.as_non_null()) else {
+    let Some(proxy_nn) = this.proxy_tunnel_ptr() else {
         return;
     };
-    let _guard = ProxyTunnel::ref_scope(proxy_nn);
+    let _guard = ProxyTunnel::ref_guard(proxy_nn);
     // While parked waiting for the JS `checkServerIdentity` verdict no request
     // has been written through the tunnel, so any decrypted application data
     // arriving here is unexpected.
@@ -350,12 +349,12 @@ fn on_handshake(
 ) {
     // NLL ends `this` before any reentrant call below.
     let this = client_from_ctx(ctx);
-    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.as_non_null()) else {
+    let Some(proxy_nn) = this.proxy_tunnel_ptr() else {
         return;
     };
     scoped_log!(http_proxy_tunnel, "ProxyTunnel onHandshake");
     // Do NOT form `&mut ProxyTunnel` (see ALIASING NOTE).
-    let _guard = ProxyTunnel::ref_scope(proxy_nn);
+    let _guard = ProxyTunnel::ref_guard(proxy_nn);
     this.state.response_stage = HTTPStage::ProxyHeaders;
     this.state.request_stage = HTTPStage::ProxyHeaders;
     this.state.request_sent_len = 0;
@@ -453,11 +452,7 @@ pub(crate) fn write_encrypted(ctx: *mut HTTPClient, encoded_data: &[u8]) {
     // is the sole live borrow, dropped immediately after copying out the
     // tunnel's `data` `NonNull`. The pointee is alive: this client holds a
     // strong ref to the tunnel for the duration of tunneling.
-    let Some(proxy_nn) = client_from_ctx(ctx)
-        .proxy_tunnel
-        .as_ref()
-        .map(|p| p.as_non_null())
-    else {
+    let Some(proxy_nn) = client_from_ctx(ctx).proxy_tunnel_ptr() else {
         return;
     };
     // Live intrusive-refcounted tunnel. Access `write_buffer` and `socket` via
@@ -502,13 +497,13 @@ fn on_close(ctx: *mut HTTPClient) {
             "tunnel exists"
         }
     );
-    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.as_non_null()) else {
+    let Some(proxy_nn) = this.proxy_tunnel_ptr() else {
         return;
     };
     let proxy_ptr = proxy_nn.as_ptr();
-    // bump refcount via the disjoint Cell projection.
-    // Not a RefPtr — the matching deref is deferred via
-    // `schedule_proxy_deref` to avoid freeing within the callback.
+    // bump refcount via the disjoint Cell projection. No guard here — the
+    // matching deref is deferred via `schedule_proxy_deref` to avoid freeing
+    // within the callback.
     {
         let rc = ProxyTunnel::ref_count_of(proxy_nn);
         rc.set(rc.get() + 1);
@@ -670,12 +665,12 @@ impl ProxyTunnel {
     }
 
     /// Outer socket became writable. `this` is the client's `proxy_tunnel`
-    /// handle (see [`Self::ref_scope`]): the flush below can complete or fail
+    /// handle (see [`Self::ref_guard`]): the flush below can complete or fail
     /// the request, which releases that handle, leaving the guard's ref as the
     /// last one. A `&mut self` receiver would then be freed while still live.
     pub(crate) fn on_writable<const IS_SSL: bool>(this: NonNull<Self>, socket: HTTPSocket<IS_SSL>) {
         scoped_log!(http_proxy_tunnel, "ProxyTunnel onWritable");
-        let _guard = Self::ref_scope(this);
+        let _guard = Self::ref_guard(this);
         // flush() must run AFTER the body but BEFORE the guard's deref; that
         // order is written out explicitly at the single exit below.
         // flush() → handle_traffic → write_encrypted reenters and touches
@@ -708,7 +703,7 @@ impl ProxyTunnel {
     /// [`Self::on_writable`]: delivering the decrypted data can release the
     /// client's handle, so the guard taken from it may hold the last ref.
     pub(crate) fn receive(this: NonNull<Self>, buf: &[u8]) {
-        let _guard = Self::ref_scope(this);
+        let _guard = Self::ref_guard(this);
         // receive_data() fires on_data/on_handshake/write_encrypted/on_close
         // synchronously; each accesses only tunnel fields disjoint from
         // `wrapper` via the accessors above (see ALIASING NOTE), so the

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -15,10 +15,7 @@ use crate::{AlpnOffer, HTTPClient};
 
 bun_core::declare_scope!(http_proxy_tunnel, visible);
 
-// Intrusive single-thread refcount (bun.ptr.RefCount). `ref_count` field at
-// matching offset; deref() hitting 0 calls ProxyTunnel::deinit (mapped to Drop
-// + dealloc via IntrusiveRc).
-pub type RefPtr = bun_ptr::IntrusiveRc<ProxyTunnel>;
+use bun_ptr::RefPtr;
 
 /// Upgrade a `*mut ProxyTunnel` (obtained from [`RefPtr::as_ptr`]) to
 /// `&'a mut ProxyTunnel`.
@@ -169,14 +166,14 @@ impl ProxyTunnel {
     /// eventual release, which is the last one whenever the guarded call
     /// released the client's ref, goes through the holder's own pointer
     /// rather than through a `&mut self` that would still be live at that
-    /// point. `ScopedRef::new` bumps via raw `CellRefCounted::ref_count_raw`
+    /// point. `RefPtr::init_ref` bumps via raw `CellRefCounted::ref_count_raw`
     /// field projection — touching only `ref_count`, never the whole tunnel —
     /// so it does not alias the caller's `&SSLWrapper` (see ALIASING NOTE).
     /// HTTP-thread-only.
     #[inline]
-    fn ref_scope(this: NonNull<Self>) -> bun_ptr::ScopedRef<Self> {
+    fn ref_scope(this: NonNull<Self>) -> bun_ptr::RefPtr<Self> {
         // SAFETY: see INVARIANT above.
-        unsafe { bun_ptr::ScopedRef::new(this.as_ptr()) }
+        unsafe { bun_ptr::RefPtr::init_ref(this.as_ptr()) }
     }
 }
 
@@ -213,7 +210,7 @@ fn on_open(ctx: *mut HTTPClient) {
     bun_analytics::features::http_client_proxy.fetch_add(1, Ordering::Relaxed);
     this.state.response_stage = HTTPStage::ProxyHandshake;
     this.state.request_stage = HTTPStage::ProxyHandshake;
-    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.data) else {
+    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.as_non_null()) else {
         return;
     };
     // Live intrusive-refcounted tunnel allocated in `start()`. Do NOT form
@@ -264,7 +261,7 @@ fn on_data(ctx: *mut HTTPClient, decoded_data: &[u8]) {
     // ends this borrow before any reentrant call below that re-derives
     // `&mut *ctx` (close → on_close, progress_update).
     let this = client_from_ctx(ctx);
-    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.data) else {
+    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.as_non_null()) else {
         return;
     };
     let _guard = ProxyTunnel::ref_scope(proxy_nn);
@@ -353,7 +350,7 @@ fn on_handshake(
 ) {
     // NLL ends `this` before any reentrant call below.
     let this = client_from_ctx(ctx);
-    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.data) else {
+    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.as_non_null()) else {
         return;
     };
     scoped_log!(http_proxy_tunnel, "ProxyTunnel onHandshake");
@@ -456,7 +453,11 @@ pub(crate) fn write_encrypted(ctx: *mut HTTPClient, encoded_data: &[u8]) {
     // is the sole live borrow, dropped immediately after copying out the
     // tunnel's `data` `NonNull`. The pointee is alive: this client holds a
     // strong ref to the tunnel for the duration of tunneling.
-    let Some(proxy_nn) = client_from_ctx(ctx).proxy_tunnel.as_ref().map(|p| p.data) else {
+    let Some(proxy_nn) = client_from_ctx(ctx)
+        .proxy_tunnel
+        .as_ref()
+        .map(|p| p.as_non_null())
+    else {
         return;
     };
     // Live intrusive-refcounted tunnel. Access `write_buffer` and `socket` via
@@ -501,12 +502,12 @@ fn on_close(ctx: *mut HTTPClient) {
             "tunnel exists"
         }
     );
-    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.data) else {
+    let Some(proxy_nn) = this.proxy_tunnel.as_ref().map(|p| p.as_non_null()) else {
         return;
     };
     let proxy_ptr = proxy_nn.as_ptr();
     // bump refcount via the disjoint Cell projection.
-    // Not a ScopedRef — the matching deref is deferred via
+    // Not a RefPtr — the matching deref is deferred via
     // `schedule_proxy_deref` to avoid freeing within the callback.
     {
         let rc = ProxyTunnel::ref_count_of(proxy_nn);
@@ -765,7 +766,7 @@ impl ProxyTunnel {
     /// `tunnel` is the pool's handle; it moves into `client.proxy_tunnel` as
     /// is, so the ref the client later releases is the one the pool held.
     pub(crate) fn adopt<const IS_SSL: bool>(
-        tunnel: RefPtr,
+        tunnel: RefPtr<ProxyTunnel>,
         client: &mut HTTPClient,
         socket: HTTPSocket<IS_SSL>,
     ) {

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -450,7 +450,7 @@ pub(crate) fn write_encrypted(ctx: *mut HTTPClient, encoded_data: &[u8]) {
     // before reentering, so there is NO live `&mut HTTPClient` anywhere up the
     // stack — re-deriving via the centralised `client_from_ctx` accessor here
     // is the sole live borrow, dropped immediately after copying out the
-    // tunnel's `data` `NonNull`. The pointee is alive: this client holds a
+    // tunnel pointer. The pointee is alive: this client holds a
     // strong ref to the tunnel for the duration of tunneling.
     let Some(proxy_nn) = client_from_ctx(ctx).proxy_tunnel_ptr() else {
         return;

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -147,7 +147,7 @@ pub struct ClientSession {
 /// `&mut self` and goes through [`ClientSession::enter`], so the releases
 /// happen through the holder's pointer after the body's `&mut` borrow has
 /// ended. Callers that need the session alive across two entry points hold a
-/// [`bun_ptr::ThisPtr::ref_guard`] of their own across both.
+/// [`RefPtr::from_this`] guard of their own across both.
 pub(crate) type SessionPtr = bun_ptr::ThisPtr<ClientSession>;
 
 /// Upgrade a `*mut Stream` from `self.streams` to `&mut Stream`.

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -236,13 +236,13 @@ impl ClientSession {
     /// own ref, both through `this`. When the body tore the session down that
     /// second release frees it, with no reference to it live anywhere.
     fn enter(this: SessionPtr, body: impl FnOnce(&mut ClientSession)) {
-        let _keep_alive = RefPtr::from_this(this);
+        let _guard = RefPtr::from_this(this);
         // SAFETY: `this` is live (see `this_ptr`; the guard above holds it for
         // the rest of this call) and HTTP-thread-only, so this is the only
         // borrow of the session for the duration of `body`.
         body(unsafe { &mut *this.as_ptr() });
         if this.socket_ref_owed.take() {
-            // SAFETY: the body gave up the socket ext's ref; `_keep_alive`
+            // SAFETY: the body gave up the socket ext's ref; `_guard`
             // still holds one, so the session is live and this release is not
             // the last. No borrow of the session is live: the body's ended.
             unsafe { ClientSession::deref(this.as_ptr()) };

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -8,6 +8,7 @@ use core::sync::atomic::Ordering;
 use crate::Error;
 use bun_collections::{ArrayHashMap, VecExt};
 use bun_core::strings;
+use bun_ptr::RefPtr;
 
 use super::stream::{State as StreamState, Stream};
 use super::{dispatch, encode};
@@ -235,7 +236,7 @@ impl ClientSession {
     /// own ref, both through `this`. When the body tore the session down that
     /// second release frees it, with no reference to it live anywhere.
     fn enter(this: SessionPtr, body: impl FnOnce(&mut ClientSession)) {
-        let _keep_alive = this.ref_guard();
+        let _keep_alive = RefPtr::from_this(this);
         // SAFETY: `this` is live (see `this_ptr`; the guard above holds it for
         // the rest of this call) and HTTP-thread-only, so this is the only
         // borrow of the session for the duration of `body`.
@@ -1040,9 +1041,9 @@ impl ClientSession {
         unsafe { NewHTTPContext::<true>::unregister_h2_raw(self.ctx, self) };
         if self.can_pool() && !self.socket.is_closed_or_has_error() {
             // Pool stores the live *ClientSession so a later fetch can resume
-            // the multiplexed connection. SAFETY: `self` is heap-owned and
-            // outlives the pool entry (release_socket takes the strong ref).
-            let self_ptr = NonNull::from(&mut *self);
+            // the multiplexed connection; the socket ext's ref moves to it.
+            // SAFETY: `self` is heap-owned and that ref is outstanding.
+            let self_ref = unsafe { RefPtr::from_raw(core::ptr::from_mut(self)) };
             // ctx back-ref is valid for the session's lifetime. Unlike
             // `unregister_h2_raw` above, this branch is *not* reachable on the
             // re-entrant `connect()` → `adopt()` path: every adopt-side entry
@@ -1063,7 +1064,7 @@ impl ClientSession {
                 b"",
                 0,
                 self.host_header_hash,
-                Some(self_ptr),
+                Some(self_ref),
             );
         } else {
             NewHTTPContext::<true>::close_socket(self.socket);

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -26,7 +26,7 @@ pub struct ClientSession {
     /// `quic.Socket` ext slot while connected (1, transferred from the registry
     /// add via `connect`), and one per entry in `pending`. `PendingConnect` holds
     /// an extra ref while DNS is in flight.
-    // Intrusive refcount — see `bun_ptr::IntrusiveRc<ClientSession>`.
+    // Intrusive refcount — see `bun_ptr::RefPtr<ClientSession>`.
     ref_count: Cell<u32>,
     /// Null while DNS is in flight; set once `us_quic_connect_addr` returns.
     // FFI handle that becomes dangling after onConnClose; raw is intentional.

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -26,7 +26,6 @@ pub struct ClientSession {
     /// `quic.Socket` ext slot while connected (1, transferred from the registry
     /// add via `connect`), and one per entry in `pending`. `PendingConnect` holds
     /// an extra ref while DNS is in flight.
-    // Intrusive refcount — see `bun_ptr::RefPtr<ClientSession>`.
     ref_count: Cell<u32>,
     /// Null while DNS is in flight; set once `us_quic_connect_addr` returns.
     // FFI handle that becomes dangling after onConnClose; raw is intentional.

--- a/src/http/h3_client/PendingConnect.rs
+++ b/src/http/h3_client/PendingConnect.rs
@@ -11,6 +11,7 @@
 use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 
+use bun_ptr::RefPtr;
 use bun_threading::Guarded;
 use bun_uws as uws;
 use bun_uws::quic;
@@ -19,22 +20,11 @@ use super::ClientSession;
 use super::client_session::session_mut;
 
 pub struct PendingConnect {
-    // INTRUSIVE: intrusive-refcounted (ref_/deref) ClientSession; one ref held
-    // from `register` until `on_dns_resolved` runs.
-    session: *mut ClientSession,
+    session: RefPtr<ClientSession>,
     // FFI: C handle owned until exactly one of resolved()/cancel() consumes it.
     pc: *mut quic::PendingConnect,
     // BACKREF: the uws event loop (lives as long as the HTTP thread).
     loop_ptr: *mut uws::Loop,
-}
-
-impl Drop for PendingConnect {
-    fn drop(&mut self) {
-        // Invariant: a constructed PendingConnect holds exactly one ref on `session`
-        // (taken in `register`); release it here.
-        // SAFETY: ref taken in `register`; session is live until this drops it.
-        unsafe { ClientSession::deref(self.session) };
-    }
 }
 
 impl PendingConnect {
@@ -57,12 +47,9 @@ impl PendingConnect {
         pc: *mut quic::PendingConnect,
         l: *mut uws::Loop,
     ) {
-        // Caller passes a live intrusive-refcounted ClientSession; PendingConnect
-        // holds one ref from construction until Drop. `session_mut` centralises
-        // the backref upgrade (same invariant as the other call sites below).
-        session_mut(session).ref_();
         let self_ = Box::new(PendingConnect {
-            session,
+            // SAFETY: caller passes a live intrusive-refcounted ClientSession.
+            session: unsafe { RefPtr::init_ref(session) },
             pc,
             loop_ptr: l,
         });
@@ -82,10 +69,10 @@ impl PendingConnect {
     /// SAFETY: `this` must be the pointer produced by `heap::alloc` in `register`
     /// and must not be used after this call (it is freed here).
     pub unsafe fn on_dns_resolved(this: *mut PendingConnect) {
-        // SAFETY: `this` was heap-allocated in `register`; reclaim it so the Box drops at
-        // end of scope — `Drop` derefs `session` and the allocation is freed.
+        // SAFETY: `this` was heap-allocated in `register`; reclaim it so the Box
+        // (and its `session` ref) drops at end of scope.
         let this = unsafe { bun_core::heap::take(this) };
-        let session = this.session;
+        let session = this.session.as_ptr();
 
         // session is kept alive by the ref `this` holds for the duration of this
         // fn — `session_mut` centralises the backref upgrade.

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -169,6 +169,7 @@ pub use bun_http_types::{ETag, MimeType};
 
 use bun_core::MutableString;
 use bun_http_types::FetchRedirect::CommonAbortReason;
+use bun_ptr::RefPtr;
 use core::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 
 #[repr(u8)]
@@ -834,8 +835,8 @@ pub struct HTTPClient<'a> {
     /// Set by HTTPThread.connect() when using custom TLS configs.
     /// Holds one owned strong ref (taken in `set_custom_ssl_ctx`, released on
     /// drop). `HttpsContext` is intrusive-refcounted (also recovered from socket
-    /// ext), so this is an `IntrusiveRc`, not an `Arc`.
-    pub(crate) custom_ssl_ctx: Option<http_context::HTTPContextRc<true>>,
+    /// ext), so this is a `RefPtr`, not an `Arc`.
+    pub(crate) custom_ssl_ctx: Option<RefPtr<HttpsContext>>,
     pub(crate) result_callback: HTTPClientResultCallback,
 
     /// Some HTTP servers (such as npm) report Last-Modified times but ignore If-Modified-Since.
@@ -853,9 +854,9 @@ pub struct HTTPClient<'a> {
     /// Set while this request is tunneling through an HTTP proxy (CONNECT).
     /// Holds one owned strong ref on the intrusive-refcounted `ProxyTunnel`
     /// (taken by `ProxyTunnel::start` / `adopt`, released on drop / pool
-    /// hand-off), so this is an `IntrusiveRc`, not an `Arc`. The pointee is
+    /// hand-off), so this is a `RefPtr`, not an `Arc`. The pointee is
     /// also recovered raw from the SSLWrapper callback `ctx`, hence intrusive.
-    pub(crate) proxy_tunnel: Option<proxy_tunnel::RefPtr>,
+    pub(crate) proxy_tunnel: Option<RefPtr<ProxyTunnel>>,
     /// Set when this request is bound to a stream on an HTTP/2 session.
     /// Owned by the session; cleared by the session when the stream completes.
     pub(crate) h2: Option<NonNull<h2::Stream>>,
@@ -932,11 +933,6 @@ impl Drop for HTTPClient<'_> {
         // The session detaches `h2` before any terminal callback, so this should
         // be None by the time the result callback's deinit path runs.
         debug_assert!(self.h2.is_none());
-        // tls_props: Option<SharedPtr> — Drop releases strong ref.
-        if let Some(ctx) = self.custom_ssl_ctx.take() {
-            // Release the strong ref taken in set_custom_ssl_ctx.
-            ctx.deref();
-        }
     }
 }
 
@@ -1623,7 +1619,7 @@ impl<'a> HTTPClient<'a> {
     /// handle while they run (`ProxyTunnel::on_writable` / `receive`).
     #[inline]
     fn proxy_tunnel_ptr(&self) -> Option<NonNull<ProxyTunnel>> {
-        self.proxy_tunnel.as_ref().map(|p| p.data)
+        self.proxy_tunnel.as_ref().map(|p| p.as_non_null())
     }
     /// Detach the proxy tunnel, if one is attached, and release this client's
     /// ref on it through the handle that holds it.
@@ -1631,10 +1627,9 @@ impl<'a> HTTPClient<'a> {
     fn close_proxy_tunnel(&mut self, shutdown: bool) {
         if let Some(t) = self.proxy_tunnel.take() {
             if shutdown {
-                proxy_tunnel::ProxyTunnel::shutdown(t.data);
+                proxy_tunnel::ProxyTunnel::shutdown(t.as_non_null());
             }
             proxy_tunnel::raw_as_mut(t.as_ptr()).detach_socket();
-            t.deref();
         }
     }
     /// Common tail of `fail` / `fail_from_h2` / `complete_connecting_process`:
@@ -2394,11 +2389,7 @@ impl<'a> HTTPClient<'a> {
         // Intrusive-refcounted: this fn takes ownership of one strong ref by
         // bumping it here. Callers do NOT pre-bump.
         // SAFETY: ctx points at a live HttpsContext.
-        let new_ref = unsafe { http_context::HTTPContextRc::<true>::init_ref(ctx.as_ptr()) };
-        if let Some(old) = self.custom_ssl_ctx.replace(new_ref) {
-            // Release the ref we previously held.
-            old.deref();
-        }
+        self.custom_ssl_ctx = Some(unsafe { RefPtr::init_ref(ctx.as_ptr()) });
     }
 
     pub(crate) fn header_str(&self, ptr: StringPointer) -> &'a [u8] {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -833,9 +833,6 @@ pub struct HTTPClient<'a> {
     pub(crate) tls_props: Option<ssl_config::SharedPtr>,
     /// The custom SSL context used for this request (None = default context).
     /// Set by HTTPThread.connect() when using custom TLS configs.
-    /// Holds one owned strong ref (taken in `set_custom_ssl_ctx`, released on
-    /// drop). `HttpsContext` is intrusive-refcounted (also recovered from socket
-    /// ext), so this is a `RefPtr`, not an `Arc`.
     pub(crate) custom_ssl_ctx: Option<RefPtr<HttpsContext>>,
     pub(crate) result_callback: HTTPClientResultCallback,
 
@@ -851,11 +848,9 @@ pub struct HTTPClient<'a> {
     pub(crate) proxy_settings: Option<Box<ProxySettings>>,
     pub(crate) proxy_headers: Option<Headers>,
     pub(crate) proxy_authorization: Option<Vec<u8>>,
-    /// Set while this request is tunneling through an HTTP proxy (CONNECT).
-    /// Holds one owned strong ref on the intrusive-refcounted `ProxyTunnel`
-    /// (taken by `ProxyTunnel::start` / `adopt`, released on drop / pool
-    /// hand-off), so this is a `RefPtr`, not an `Arc`. The pointee is
-    /// also recovered raw from the SSLWrapper callback `ctx`, hence intrusive.
+    /// Set while this request is tunneling through an HTTP proxy (CONNECT);
+    /// moved to the keep-alive pool with the socket. The pointee is also
+    /// recovered raw from the SSLWrapper callback `ctx`, hence intrusive.
     pub(crate) proxy_tunnel: Option<RefPtr<ProxyTunnel>>,
     /// Set when this request is bound to a stream on an HTTP/2 session.
     /// Owned by the session; cleared by the session when the stream completes.
@@ -923,12 +918,6 @@ impl<'a> HTTPClient<'a> {
 
 impl Drop for HTTPClient<'_> {
     fn drop(&mut self) {
-        // redirect / prev_redirect are Vec<u8> — dropped automatically.
-        // proxy_authorization: Option<Vec<u8>> — dropped automatically.
-        // proxy_headers: Option<Headers> — dropped automatically.
-        // tunnel was created by ProxyTunnel::new (heap::alloc) and refcounted;
-        // close_proxy_tunnel releases this client's strong ref (detach+deref
-        // only, no shutdown).
         self.close_proxy_tunnel(false);
         // The session detaches `h2` before any terminal callback, so this should
         // be None by the time the result callback's deinit path runs.
@@ -1618,13 +1607,13 @@ impl<'a> HTTPClient<'a> {
     /// The tunnel handle's pointer, for the entry points that may release the
     /// handle while they run (`ProxyTunnel::on_writable` / `receive`).
     #[inline]
-    fn proxy_tunnel_ptr(&self) -> Option<NonNull<ProxyTunnel>> {
+    pub(crate) fn proxy_tunnel_ptr(&self) -> Option<NonNull<ProxyTunnel>> {
         self.proxy_tunnel.as_ref().map(|p| p.as_non_null())
     }
-    /// Detach the proxy tunnel, if one is attached, and release this client's
-    /// ref on it through the handle that holds it.
+    /// Detach the proxy tunnel, if one is attached, and drop this client's ref
+    /// on it.
     #[inline]
-    fn close_proxy_tunnel(&mut self, shutdown: bool) {
+    pub(crate) fn close_proxy_tunnel(&mut self, shutdown: bool) {
         if let Some(t) = self.proxy_tunnel.take() {
             if shutdown {
                 proxy_tunnel::ProxyTunnel::shutdown(t.as_non_null());

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -186,7 +186,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         drop(self.secure.take());
         // Detach the tunnel first so its shutdown callbacks cannot re-enter this path.
         if let Some(tunnel) = self.proxy_tunnel.replace(None) {
-            tunnel.data().clear_connected_web_socket();
+            tunnel.clear_connected_web_socket();
             WebSocketProxyTunnel::shutdown(tunnel.this_ptr());
             drop(tunnel);
             // Release the I/O-layer ref taken in init_with_tunnel() — the
@@ -203,7 +203,7 @@ impl<const SSL: bool> WebSocket<SSL> {
     pub(crate) fn cancel(this: ThisPtr<Self>) {
         // clear_data() may drop the tunnel's I/O-layer ref; keep `this`
         // alive until we've finished closing the socket below.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         this.cancel_guarded();
     }
 
@@ -524,7 +524,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             return;
         }
         // Bumps the intrusive refcount and derefs on Drop.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         // Due to scheduling, it is possible for the websocket onData
         // handler to run with additional data before the microtask queue is
@@ -1247,7 +1247,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         // In tunnel mode, SSLWrapper.writeData() can synchronously fire
         // onClose → ws.fail() → cancel() → clear_data() and free `this`
         // before the catch block in enqueue_encoded_bytes/send_buffer runs.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         if !this.has_tcp() || op > 0xF {
             this.dispatch_abrupt_close(ErrorCode::Ended);
@@ -1288,7 +1288,7 @@ impl<const SSL: bool> WebSocket<SSL> {
 
     pub(crate) fn write_string(this: ThisPtr<Self>, str: &EncodedSlice, op: u8) {
         // See write_binary_data() — tunnel.write() can re-enter fail().
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         if !this.has_tcp() {
             this.dispatch_abrupt_close(ErrorCode::Ended);
@@ -1351,7 +1351,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         // enqueue_encoded_bytes → tunnel.write) can synchronously fire
         // onClose → ws.fail() → cancel() → clear_data() and free `this`
         // before send_close_with_body's own clear_data/dispatch_close run.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         if !this.has_tcp() {
             return;
@@ -1420,7 +1420,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         let ws = io_ref.this_ptr();
         // C++ holds the returned pointer as `m_connectedWebSocket`.
         ws.outgoing_websocket
-            .set(Some((BackRef::new(outgoing), io_ref.dupe_ref())));
+            .set(Some((BackRef::new(outgoing), io_ref.clone())));
         ws.io_ref.set(Some(io_ref));
         bun_core::handle_oom(ws.send_buffer.borrow_mut().ensure_total_capacity(2048));
         bun_core::handle_oom(ws.receive_buffer.borrow_mut().ensure_total_capacity(2048));
@@ -1474,8 +1474,6 @@ impl<const SSL: bool> WebSocket<SSL> {
             ws.as_ptr(),
             |_, sock| this.tcp.set(sock),
         ) {
-            // Sole owner on this failure path.
-            drop(ws);
             return core::ptr::null_mut();
         }
 
@@ -1527,7 +1525,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         // send_buffer → tunnel.write() can re-enter fail() synchronously
         // (see write_binary_data). The tunnel ref-guards itself in
         // on_writable() but not this struct.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         this.drain_send_buffer_and_finish_close();
     }
@@ -1538,7 +1536,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         // clear_data() may drop the tunnel's I/O-layer ref and the block
         // below drops the C++ ref; keep `this` alive until we've finished the
         // tcp close check.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         this.clear_data();
 
@@ -1555,15 +1553,13 @@ impl<const SSL: bool> WebSocket<SSL> {
     /// a raw close on TLS too, since no loop remains to finish a graceful one.
     pub(crate) fn drop_connection_without_callback(this: ThisPtr<Self>) {
         log!("dropConnectionWithoutCallback");
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
-        let cpp = this.outgoing_websocket.replace(None);
+        let _cpp_ref = this.outgoing_websocket.replace(None);
         this.clear_data();
         if !this.tcp.get().is_closed() {
             this.tcp.get().close(uws::CloseKind::Failure);
         }
-        // The ref held on behalf of the C++ object.
-        drop(cpp);
     }
 
     pub(crate) fn memory_cost(&self) -> usize {
@@ -1803,7 +1799,7 @@ impl<const SSL: bool> jsc::MicrotaskCallback for InitialDataTask<SSL> {
         let ws = ws.this_ptr();
         ws.pending_initial_task.set(None);
         if let Some(initial_data) = self.data.replace(None) {
-            let _guard = ws.ref_guard();
+            let _guard = RefPtr::from_this(ws);
             initial_data.deliver(ws);
         }
     }

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -152,16 +152,12 @@ impl<const SSL: bool> WebSocket<SSL> {
     /// C++ let go of `m_connectedWebSocket`: forget the back-reference and
     /// release the ref held on its behalf. May free `self`.
     fn release_cpp_ref(&self) {
-        if let Some((_, cpp_ref)) = self.outgoing_websocket.replace(None) {
-            cpp_ref.deref();
-        }
+        self.outgoing_websocket.set(None);
     }
 
     /// Release the I/O layer's ref. May free `self`.
     fn release_io_ref(&self) {
-        if let Some(r) = self.io_ref.take() {
-            r.deref();
-        }
+        self.io_ref.set(None);
     }
 
     fn should_compress(&self, data_len: usize, opcode: Opcode) -> bool {
@@ -192,7 +188,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         if let Some(tunnel) = self.proxy_tunnel.replace(None) {
             tunnel.data().clear_connected_web_socket();
             WebSocketProxyTunnel::shutdown(tunnel.this_ptr());
-            tunnel.deref();
+            drop(tunnel);
             // Release the I/O-layer ref taken in init_with_tunnel() — the
             // tunnel was this struct's socket-equivalent owner. In the
             // non-tunnel path this same ref is released by handle_close()
@@ -237,10 +233,9 @@ impl<const SSL: bool> WebSocket<SSL> {
     /// or the tunnel callback), so `self` outlives the releases below.
     pub(crate) fn fail(&self, code: ErrorCode) {
         jsc::mark_binding!();
-        if let Some((ws, cpp_ref)) = self.outgoing_websocket.replace(None) {
+        if let Some((ws, _cpp_ref)) = self.outgoing_websocket.replace(None) {
             log!("fail ({})", <&'static str>::from(code));
             ws.did_abrupt_close(code);
-            cpp_ref.deref();
         }
 
         self.cancel_guarded();
@@ -1333,24 +1328,22 @@ impl<const SSL: bool> WebSocket<SSL> {
 
     /// May free `self`.
     fn dispatch_abrupt_close(&self, code: ErrorCode) {
-        let Some((out, cpp_ref)) = self.outgoing_websocket.replace(None) else {
+        let Some((out, _cpp_ref)) = self.outgoing_websocket.replace(None) else {
             return;
         };
         self.unref_keep_alive();
         jsc::mark_binding!();
         out.did_abrupt_close(code);
-        cpp_ref.deref();
     }
 
     /// May free `self`.
     fn dispatch_close(&self, code: u16, reason: bun_core::String) {
-        let Some((out, cpp_ref)) = self.outgoing_websocket.replace(None) else {
+        let Some((out, _cpp_ref)) = self.outgoing_websocket.replace(None) else {
             return;
         };
         self.unref_keep_alive();
         jsc::mark_binding!();
         out.did_close(code, reason);
-        cpp_ref.deref();
     }
 
     pub(crate) fn close(this: ThisPtr<Self>, code: u16, reason: Option<&EncodedSlice>) {
@@ -1482,7 +1475,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             |_, sock| this.tcp.set(sock),
         ) {
             // Sole owner on this failure path.
-            ws.deref();
+            drop(ws);
             return core::ptr::null_mut();
         }
 
@@ -1569,10 +1562,8 @@ impl<const SSL: bool> WebSocket<SSL> {
         if !this.tcp.get().is_closed() {
             this.tcp.get().close(uws::CloseKind::Failure);
         }
-        if let Some((_, cpp_ref)) = cpp {
-            // The ref held on behalf of the C++ object.
-            cpp_ref.deref();
-        }
+        // The ref held on behalf of the C++ object.
+        drop(cpp);
     }
 
     pub(crate) fn memory_cost(&self) -> usize {

--- a/src/http_jsc/websocket_client/WebSocketProxy.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxy.rs
@@ -68,7 +68,6 @@ impl Drop for WebSocketProxy {
         // target_host / websocket_request_buf: Box<[u8]> drops automatically.
         if let Some(tunnel) = self.tunnel.take() {
             WebSocketProxyTunnel::shutdown(tunnel.this_ptr());
-            tunnel.deref();
         }
     }
 }

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -235,14 +235,14 @@ impl WebSocketProxyTunnel {
 
     /// SSLWrapper callback: Called before TLS handshake starts
     fn on_open(this: ThisPtr<Self>) {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         bun_core::scoped_log!(WebSocketProxyTunnel, "onOpen");
         // SNI configuration is done in `start()` before the wrapper is driven.
     }
 
     /// SSLWrapper callback: Called with decrypted data from the network
     fn on_data(this: ThisPtr<Self>, decrypted_data: &[u8]) {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         bun_core::scoped_log!(
             WebSocketProxyTunnel,
@@ -273,7 +273,7 @@ impl WebSocketProxyTunnel {
 
     /// SSLWrapper callback: Called after TLS handshake completes
     fn on_handshake(this: ThisPtr<Self>, success: bool, ssl_error: us_bun_verify_error_t) {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         bun_core::scoped_log!(WebSocketProxyTunnel, "onHandshake: success={}", success);
 
@@ -320,7 +320,7 @@ impl WebSocketProxyTunnel {
 
     /// SSLWrapper callback: Called when connection is closing
     fn on_close(this: ThisPtr<Self>) {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         bun_core::scoped_log!(WebSocketProxyTunnel, "onClose");
 
@@ -333,7 +333,7 @@ impl WebSocketProxyTunnel {
         // If we have a connected WebSocket client, notify it of the close
         if let Some(ws) = connected_websocket {
             let ws = ws.this_ptr();
-            let _ws_guard = ws.ref_guard();
+            let _ws_guard = RefPtr::from_this(ws);
             ws.fail(ErrorCode::Ended);
             return;
         }
@@ -402,7 +402,7 @@ impl WebSocketProxyTunnel {
     /// `handle_tunnel_writable()` re-enters `tunnel.write()`, either of which
     /// can reach a close path that drops a ref on the tunnel.
     pub(crate) fn on_writable(this: ThisPtr<Self>) {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         // Flush the SSL state machine; no borrow of `*this` other than
         // `wrapper` spans the synchronous `write_encrypted` re-entry.
@@ -449,7 +449,7 @@ impl WebSocketProxyTunnel {
     /// `on_data`/`on_handshake`/`on_close`/`write_encrypted`, which can reach a
     /// close path that drops a ref on the tunnel.
     pub(crate) fn receive(this: ThisPtr<Self>, data: &[u8]) {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         if let Some(w) = this.wrapper.get() {
             w.receive_data(data);
@@ -463,7 +463,7 @@ impl WebSocketProxyTunnel {
     pub(crate) fn write(this: ThisPtr<Self>, data: &[u8]) -> crate::Result<usize> {
         // The caller's ref (the client's `proxy`/`proxy_tunnel` field) can be
         // released from inside `write_data` via `on_close`; keep `w` alive.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         if let Some(w) = this.wrapper.get() {
             return w
                 .write_data(data)
@@ -477,7 +477,7 @@ impl WebSocketProxyTunnel {
     /// Takes `ThisPtr<Self>` because `shutdown()` may fire
     /// `on_close(ctx)`/`write_encrypted(ctx)`.
     pub(crate) fn shutdown(this: ThisPtr<Self>) {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         if let Some(w) = this.wrapper.get() {
             let _ = w.shutdown(true); // Fast shutdown
         }

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -333,7 +333,7 @@ impl WebSocketProxyTunnel {
         // If we have a connected WebSocket client, notify it of the close
         if let Some(ws) = connected_websocket {
             let ws = ws.this_ptr();
-            let _ws_guard = RefPtr::from_this(ws);
+            let _guard = RefPtr::from_this(ws);
             ws.fail(ErrorCode::Ended);
             return;
         }

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -817,7 +817,7 @@ where
         );
     }
 
-    /// Caller holds a `ref_guard` and owns `full` (must not borrow `self`).
+    /// Caller holds a `RefPtr` guard and owns `full` (must not borrow `self`).
     fn process_websocket_upgrade_response(this: ThisPtr<Self>, full: &[u8]) {
         let mut scratch = [picohttp::Header::ZERO; 128];
         let Ok(response) = picohttp::Response::parse(full, &mut scratch) else {

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -410,7 +410,7 @@ where
                     this.tcp.set(socket);
                     if this.state.get() == State::Failed {
                         socket.take_ext_owner::<Self>();
-                        client.deref();
+                        drop(client);
                         return None;
                     }
                     bun_analytics::features::web_socket
@@ -434,7 +434,7 @@ where
                 }
                 Err(_) => {
                     // Never installed as userdata on the Err path.
-                    client.deref();
+                    drop(client);
                 }
             }
             return None;
@@ -454,7 +454,7 @@ where
                 // I don't think this case gets reached.
                 if this.state.get() == State::Failed {
                     sock.take_ext_owner::<Self>();
-                    client.deref();
+                    drop(client);
                     return None;
                 }
                 bun_analytics::features::web_socket
@@ -475,7 +475,7 @@ where
             }
             Err(_) => {
                 // Never installed as userdata on the Err path.
-                client.deref();
+                drop(client);
                 None
             }
         }
@@ -499,16 +499,12 @@ where
     /// C++ let go of `m_upgradeClient`: forget the back-reference and release
     /// the ref held on its behalf. May free `self`.
     fn release_cpp_ref(&self) {
-        if let Some((_, cpp_ref)) = self.outgoing_websocket.replace(None) {
-            cpp_ref.deref();
-        }
+        self.outgoing_websocket.set(None);
     }
 
     /// Release the ref held for the socket's userdata pointer. May free `self`.
     fn release_socket_ref(&self) {
-        if let Some(r) = self.socket_ref.take() {
-            r.deref();
-        }
+        self.socket_ref.set(None);
     }
 
     /// Write the unsent suffix of `input_body_buf` via `write` (which returns
@@ -590,9 +586,8 @@ where
     /// handlers and may re-enter via C++ `cancel()`, and the trailing `deref`
     /// may free `this`.
     fn dispatch_abrupt_close(this: ThisPtr<Self>, code: ErrorCode) {
-        if let Some((ws, cpp_ref)) = this.outgoing_websocket.replace(None) {
+        if let Some((ws, _cpp_ref)) = this.outgoing_websocket.replace(None) {
             ws.did_abrupt_close(code);
-            cpp_ref.deref();
         }
     }
 
@@ -974,7 +969,7 @@ where
 
         // Start TLS handshake
         if WebSocketProxyTunnel::start(tunnel.this_ptr(), &ssl_options, initial_data).is_err() {
-            tunnel.deref();
+            drop(tunnel);
             Self::terminate(this, ErrorCode::ProxyTunnelFailed);
             return;
         }
@@ -990,7 +985,7 @@ where
         });
         if let Some(tunnel) = unattached {
             // Nothing else holds the tunnel.
-            tunnel.deref();
+            drop(tunnel);
             Self::terminate(this, ErrorCode::ProxyTunnelFailed);
             return;
         }
@@ -1365,7 +1360,7 @@ where
                     },
                 );
 
-                cpp_ref.deref();
+                drop(cpp_ref);
             } else if tcp.is_closed() {
                 Self::terminate(this, ErrorCode::Cancel);
             } else if !has_ws {
@@ -1413,7 +1408,7 @@ where
             // Two refs are released here (C++'s, then the TCP socket's — the
             // socket now belongs to the connected WebSocket). The second may
             // free `this`.
-            cpp_ref.deref();
+            drop(cpp_ref);
             this.release_socket_ref();
         } else if tcp.is_closed() {
             Self::terminate(this, ErrorCode::Cancel);

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -410,7 +410,6 @@ where
                     this.tcp.set(socket);
                     if this.state.get() == State::Failed {
                         socket.take_ext_owner::<Self>();
-                        drop(client);
                         return None;
                     }
                     bun_analytics::features::web_socket
@@ -432,10 +431,8 @@ where
                     this.state.set(State::Reading);
                     return Some(Self::connected(client, websocket));
                 }
-                Err(_) => {
-                    // Never installed as userdata on the Err path.
-                    drop(client);
-                }
+                // Never installed as userdata on the Err path.
+                Err(_) => {}
             }
             return None;
         }
@@ -454,7 +451,6 @@ where
                 // I don't think this case gets reached.
                 if this.state.get() == State::Failed {
                     sock.take_ext_owner::<Self>();
-                    drop(client);
                     return None;
                 }
                 bun_analytics::features::web_socket
@@ -473,11 +469,8 @@ where
                 this.state.set(State::Reading);
                 Some(Self::connected(client, websocket))
             }
-            Err(_) => {
-                // Never installed as userdata on the Err path.
-                drop(client);
-                None
-            }
+            // Never installed as userdata on the Err path.
+            Err(_) => None,
         }
     }
 
@@ -486,7 +479,7 @@ where
     fn connected(client: RefPtr<Self>, websocket: &CppWebSocket) -> *mut Self {
         let this = client.this_ptr();
         this.outgoing_websocket
-            .set(Some((BackRef::new(websocket), client.dupe_ref())));
+            .set(Some((BackRef::new(websocket), client.clone())));
         this.socket_ref.set(Some(client));
         this.as_ptr()
     }
@@ -539,7 +532,7 @@ where
         // Bumps the intrusive refcount and derefs on Drop (after `tcp.close`
         // below), which may free `this` — no `&`/`&mut Self` is live at that
         // point.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         // The C++ end of the socket is no longer holding a reference to this, so we must clear it.
         this.release_cpp_ref();
@@ -772,7 +765,7 @@ where
         }
         // Bumps the intrusive refcount and derefs on Drop at every return path
         // below. No `&`/`&mut Self` is live when the guard drops.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         debug_assert!(this.is_same_socket(socket));
 
@@ -1037,7 +1030,7 @@ where
     /// drop may free `this`; see `fail`.
     pub(crate) fn handle_decrypted_data(this: ThisPtr<Self>, data: &[u8]) {
         log!("handleDecryptedData: {} bytes", data.len());
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         // Process as if it came directly from the socket.
         let full = match this.buffer_and_parse_head(data) {
@@ -1334,7 +1327,7 @@ where
                 // never call cancel() to drop it. The TCP socket's ref (released
                 // in handle_close) is what keeps this struct alive to forward
                 // socket data to the tunnel after we switch to .done.
-                let (ws, cpp_ref) = this.outgoing_websocket.replace(None).unwrap();
+                let (ws, _cpp_ref) = this.outgoing_websocket.replace(None).unwrap();
 
                 // Switch to forwarding before entering C++. did_connect_with_tunnel
                 // dispatches `open`, and an open handler that spins the event loop
@@ -1359,8 +1352,6 @@ where
                         None
                     },
                 );
-
-                drop(cpp_ref);
             } else if tcp.is_closed() {
                 Self::terminate(this, ErrorCode::Cancel);
             } else if !has_ws {
@@ -1436,7 +1427,7 @@ where
         // `on_writable`/`write` flush the tunnel and can reach `terminate` →
         // `handle_close`, dropping the socket's ref while this frame still
         // reads `*this`.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         // Forward to proxy tunnel if active
         let tunnel = this.proxy.get().as_ref().and_then(|p| p.get_tunnel());

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -398,46 +398,40 @@ where
 
         // Unix domain socket path (ws+unix:// / wss+unix://)
         if let Some(usp) = &unix_socket_path_slice {
-            match Socket::<SSL>::connect_unix_group(
+            let socket = Socket::<SSL>::connect_unix_group(
                 group,
                 kind,
                 secure_ptr,
                 usp.slice(),
                 client.as_ptr(),
                 false,
-            ) {
-                Ok(socket) => {
-                    this.tcp.set(socket);
-                    if this.state.get() == State::Failed {
-                        socket.take_ext_owner::<Self>();
-                        return None;
-                    }
-                    bun_analytics::features::web_socket
-                        .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-
-                    if SSL {
-                        // SNI uses the URL host (defaulted to "localhost" in
-                        // C++ when absent), mirroring the TCP path below. A
-                        // user-supplied Host header does NOT affect SNI; use
-                        // `tls: { checkServerIdentity }` or put the hostname
-                        // in the URL (wss+unix://name/path) to verify against
-                        // a specific certificate name.
-                        if !host_slice.slice().is_empty() {
-                            this.hostname.set(ZBox::from_bytes(host_slice.slice()));
-                        }
-                    }
-
-                    socket.set_timeout(handshake_timeout_seconds());
-                    this.state.set(State::Reading);
-                    return Some(Self::connected(client, websocket));
-                }
-                // Never installed as userdata on the Err path.
-                Err(_) => {}
+            )
+            .ok()?;
+            this.tcp.set(socket);
+            if this.state.get() == State::Failed {
+                socket.take_ext_owner::<Self>();
+                return None;
             }
-            return None;
+            bun_analytics::features::web_socket.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+
+            if SSL {
+                // SNI uses the URL host (defaulted to "localhost" in
+                // C++ when absent), mirroring the TCP path below. A
+                // user-supplied Host header does NOT affect SNI; use
+                // `tls: { checkServerIdentity }` or put the hostname
+                // in the URL (wss+unix://name/path) to verify against
+                // a specific certificate name.
+                if !host_slice.slice().is_empty() {
+                    this.hostname.set(ZBox::from_bytes(host_slice.slice()));
+                }
+            }
+
+            socket.set_timeout(handshake_timeout_seconds());
+            this.state.set(State::Reading);
+            return Some(Self::connected(client, websocket));
         }
 
-        match Socket::<SSL>::connect_group(
+        let sock = Socket::<SSL>::connect_group(
             group,
             kind,
             secure_ptr,
@@ -445,33 +439,28 @@ where
             c_int::from(connect_port),
             client.as_ptr(),
             false,
-        ) {
-            Ok(sock) => {
-                this.tcp.set(sock);
-                // I don't think this case gets reached.
-                if this.state.get() == State::Failed {
-                    sock.take_ext_owner::<Self>();
-                    return None;
-                }
-                bun_analytics::features::web_socket
-                    .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
-
-                if SSL {
-                    // SNI for the outer TLS socket must use the host we actually
-                    // dialed. For HTTPS proxy connections, that's the proxy host,
-                    // not the wss:// target.
-                    if !display_host_.is_empty() {
-                        this.hostname.set(ZBox::from_bytes(display_host_));
-                    }
-                }
-
-                sock.set_timeout(handshake_timeout_seconds());
-                this.state.set(State::Reading);
-                Some(Self::connected(client, websocket))
-            }
-            // Never installed as userdata on the Err path.
-            Err(_) => None,
+        )
+        .ok()?;
+        this.tcp.set(sock);
+        // I don't think this case gets reached.
+        if this.state.get() == State::Failed {
+            sock.take_ext_owner::<Self>();
+            return None;
         }
+        bun_analytics::features::web_socket.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+
+        if SSL {
+            // SNI for the outer TLS socket must use the host we actually
+            // dialed. For HTTPS proxy connections, that's the proxy host,
+            // not the wss:// target.
+            if !display_host_.is_empty() {
+                this.hostname.set(ZBox::from_bytes(display_host_));
+            }
+        }
+
+        sock.set_timeout(handshake_timeout_seconds());
+        this.state.set(State::Reading);
+        Some(Self::connected(client, websocket))
     }
 
     /// The socket now holds `client` as its userdata; record that ref and take

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -1001,6 +1001,10 @@ impl<'a> Drop for SecurityScanSubprocess<'a> {
                 ThreadSafeRefCount::<Process>::deref(p);
             }
         }
+        // Dropping the writer can synchronously close it and re-enter
+        // `on_close_io` through the parent backref; move it out first so that
+        // sees `None`.
+        drop(self.json_writer.take());
     }
 }
 
@@ -1316,7 +1320,7 @@ impl<'a> SecurityScanSubprocess<'a> {
             StaticPipeWriter::create(event_loop, parent.cast(), make_json_stdio(), json_source);
         // Keep a duped ref locally so no borrow on `(*parent).json_writer` is
         // held across `start()` — `on_close_io` may `.take()` the field.
-        let writer_local = writer.dupe_ref();
+        let writer_local = writer.clone();
         // SAFETY: see `parent` note above.
         unsafe { (*parent).json_writer = Some(writer) };
 
@@ -1337,11 +1341,6 @@ impl<'a> SecurityScanSubprocess<'a> {
         // SAFETY: `writer_local` holds a live ref; `start()` mutates the writer
         // in place (raw intrusive object — no Rust aliasing across the RefPtr).
         let start_result = unsafe { (*writer_ptr).start() };
-        // SAFETY: `writer_local` keeps `*writer_ptr` live; we own the `start()` ref.
-        unsafe { RefCount::<StaticPipeWriter>::deref(writer_ptr) };
-        // SAFETY: `writer_local` keeps `*writer_ptr` live.
-        unsafe { (*writer_ptr).started = false };
-        drop(writer_local);
         if let Err(e) = start_result {
             Output::err_generic(
                 "Failed to start security scanner JSON pipe writer: {}",
@@ -1349,6 +1348,15 @@ impl<'a> SecurityScanSubprocess<'a> {
             );
             return Err(crate::Error::JSONPipeWriterFailed);
         }
+        // The writer's lifetime is owned by `json_writer`, not by its own
+        // `started` ref: release the ref `start()` took and clear the flag so
+        // its close path doesn't release it again.
+        // SAFETY: `writer_local` keeps `*writer_ptr` live.
+        unsafe {
+            RefCount::<StaticPipeWriter>::deref(writer_ptr);
+            (*writer_ptr).started = false;
+        }
+        drop(writer_local);
 
         // SAFETY: `process` is live (we hold a ref); reached via the local raw
         // ptr per the single-provenance note. `watch_or_reap` may re-enter

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -977,7 +977,7 @@ impl<'a> subprocess::StaticPipeWriterProcess for SecurityScanSubprocess<'a> {
         // SAFETY: `this` is the `parent` backref passed to `StaticPipeWriter::create`;
         // the subprocess outlives its writer (it owns the writer ref in `json_writer`).
         // `finish_spawn` holds no Rust borrow on `self.json_writer` across `start()`
-        // (it clones the `Rc` first), so this `&mut` is unique for the call.
+        // (it clones the `RefPtr` first), so this `&mut` is unique for the call.
         unsafe { (*this).on_close_io(kind) };
     }
 }
@@ -1175,16 +1175,17 @@ impl<'a> SecurityScanSubprocess<'a> {
 
         let pipe_ptr: *mut uv::Pipe =
             bun_core::heap::into_raw(Box::new(bun_core::ffi::zeroed::<uv::Pipe>()));
-        // errdefer pipe.closeAndDestroy() — guard owns the raw Box ptr; libuv's
-        // close callback frees the heap allocation, so do NOT re-box on the
-        // cleanup path (would double-free). Disarmed only after finish_spawn
-        // succeeds: it must stay armed
-        // across `ipc_reader.start()` inside finish_spawn (the pre-writer error
-        // window) so a registered-but-unowned uv handle is never leaked.
+        // errdefer pipe.closeAndDestroy() until `StaticPipeWriter` takes the
+        // pipe (inside `finish_spawn`); from then on the writer's `Drop` closes
+        // it. libuv's close callback frees the allocation, so do NOT re-box on
+        // the cleanup path.
+        let pipe_taken = core::cell::Cell::new(false);
         let mut pipe = scopeguard::guard(pipe_ptr, |p| {
-            // SAFETY: p is the live Box-allocated uv_pipe_t; close_and_destroy
-            // schedules uv_close + frees the allocation.
-            unsafe { uv::Pipe::close_and_destroy(p) };
+            if !pipe_taken.get() {
+                // SAFETY: p is the live Box-allocated uv_pipe_t; close_and_destroy
+                // schedules uv_close + frees the allocation.
+                unsafe { uv::Pipe::close_and_destroy(p) };
+            }
         });
         // `self.loop_()` already projects to the libuv `uv_loop_t*` on
         // Windows (see the `.uv_loop` projection in `loop_()`); pass through.
@@ -1237,25 +1238,19 @@ impl<'a> SecurityScanSubprocess<'a> {
             .flags
             .insert(bun_io::pipe_reader::WindowsFlags::NONBLOCKING);
 
-        // Hand the pipe to StaticPipeWriter lazily: the closure captures only the
-        // raw `*mut uv::Pipe` (Copy, no Drop) and reconstitutes the Box at the
-        // exact `StaticPipeWriter::create` call site inside `finish_spawn`. If
-        // `finish_spawn` errors before that point (`ipc_reader.start()`), the
-        // closure drops as a no-op and the still-armed cleanup guard performs
-        // `close_and_destroy`. After the writer takes the pipe, post-create
-        // errors detach it from the writer (`finish_spawn`'s guard) before the
-        // writer's refs drop, so the guard's `close_and_destroy` remains the
-        // sole cleanup.
-        self.finish_spawn(&mut spawned, ipc_output_fds[0], move || {
+        // Hand the pipe to StaticPipeWriter lazily: the closure reconstitutes
+        // the Box at the exact `StaticPipeWriter::create` call site inside
+        // `finish_spawn`. If `finish_spawn` errors before that point
+        // (`ipc_reader.start()`), the closure drops as a no-op and the
+        // still-armed cleanup guard performs `close_and_destroy`.
+        self.finish_spawn(&mut spawned, ipc_output_fds[0], || {
+            pipe_taken.set(true);
             // SAFETY: `pipe_ptr` is the same allocation produced by
             // heap::alloc above and has not been freed; ownership transfers
             // here exactly once.
             StdioResult::Buffer(unsafe { bun_core::heap::take(pipe_ptr) })
         })?;
 
-        // Success: pipe ownership now lives in StaticPipeWriter; disarm the
-        // close_and_destroy errdefer.
-        scopeguard::ScopeGuard::into_inner(pipe);
         // fd slots are already None.
         scopeguard::ScopeGuard::into_inner(fds);
         Ok(())

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -959,8 +959,6 @@ pub struct SecurityScanSubprocess<'a> {
     has_received_ipc: bool,
     exit_status: Option<Status>,
     remaining_fds: i8,
-    /// Intrusive `RefPtr`. `StaticPipeWriter<P>` is
-    /// `RefCounted`; `Rc` would double-count against the embedded refcount.
     json_writer: Option<RefPtr<StaticPipeWriter>>,
 }
 
@@ -977,7 +975,7 @@ impl<'a> subprocess::StaticPipeWriterProcess for SecurityScanSubprocess<'a> {
     const POLL_OWNER_TAG: bun_io::PollTag = bun_io::PollTag::SecurityScanStaticPipeWriter;
     unsafe fn on_close_io(this: *mut Self, kind: subprocess::StdioKind) {
         // SAFETY: `this` is the `parent` backref passed to `StaticPipeWriter::create`;
-        // the subprocess outlives its writer (it `deref`s the writer in `deinit`/Drop).
+        // the subprocess outlives its writer (it owns the writer ref in `json_writer`).
         // `finish_spawn` holds no Rust borrow on `self.json_writer` across `start()`
         // (it clones the `Rc` first), so this `&mut` is unique for the call.
         unsafe { (*this).on_close_io(kind) };
@@ -1003,13 +1001,6 @@ impl<'a> Drop for SecurityScanSubprocess<'a> {
                 ThreadSafeRefCount::<Process>::deref(p);
             }
         }
-        if let Some(w) = self.json_writer.take() {
-            // `on_close_io` normally takes the field first; guard for the case
-            // where it didn't run. `RefPtr` has no auto-`Drop`, so the ref we
-            // hold must be released with an explicit `deref()`.
-            w.deref();
-        }
-        // code, json_data drop automatically (Box<[u8]>)
     }
 }
 
@@ -1247,10 +1238,10 @@ impl<'a> SecurityScanSubprocess<'a> {
         // exact `StaticPipeWriter::create` call site inside `finish_spawn`. If
         // `finish_spawn` errors before that point (`ipc_reader.start()`), the
         // closure drops as a no-op and the still-armed cleanup guard performs
-        // `close_and_destroy`. After the writer takes
-        // the pipe, post-create errors leave the writer leaked at refcount >= 1
-        // (RefPtr has no Drop), so the Box is never auto-freed and the guard's
-        // `close_and_destroy` remains the sole cleanup.
+        // `close_and_destroy`. After the writer takes the pipe, post-create
+        // errors detach it from the writer (`finish_spawn`'s guard) before the
+        // writer's refs drop, so the guard's `close_and_destroy` remains the
+        // sole cleanup.
         self.finish_spawn(&mut spawned, ipc_output_fds[0], move || {
             // SAFETY: `pipe_ptr` is the same allocation produced by
             // heap::alloc above and has not been freed; ownership transfers
@@ -1339,7 +1330,6 @@ impl<'a> SecurityScanSubprocess<'a> {
             if let Some(w) = unsafe { (*parent).json_writer.take() } {
                 // SAFETY: `w` holds the field's ref; sole live access path.
                 unsafe { (*w.as_ptr()).source.detach() };
-                w.deref();
             }
         });
 
@@ -1351,18 +1341,14 @@ impl<'a> SecurityScanSubprocess<'a> {
         unsafe { RefCount::<StaticPipeWriter>::deref(writer_ptr) };
         // SAFETY: `writer_local` keeps `*writer_ptr` live.
         unsafe { (*writer_ptr).started = false };
-        match start_result {
-            Err(e) => {
-                writer_local.deref();
-                Output::err_generic(
-                    "Failed to start security scanner JSON pipe writer: {}",
-                    (e,),
-                );
-                return Err(crate::Error::JSONPipeWriterFailed);
-            }
-            Ok(()) => {}
+        drop(writer_local);
+        if let Err(e) = start_result {
+            Output::err_generic(
+                "Failed to start security scanner JSON pipe writer: {}",
+                (e,),
+            );
+            return Err(crate::Error::JSONPipeWriterFailed);
         }
-        writer_local.deref();
 
         // SAFETY: `process` is live (we hold a ref); reached via the local raw
         // ptr per the single-provenance note. `watch_or_reap` may re-enter
@@ -1381,7 +1367,6 @@ impl<'a> SecurityScanSubprocess<'a> {
             // SAFETY: `writer` holds the field's intrusive ref; sole access path
             // (single-threaded event loop callback).
             unsafe { (*writer.as_ptr()).source.detach() };
-            writer.deref();
             self.remaining_fds -= 1;
         }
     }

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -966,11 +966,6 @@ pub use self::js_promise::Strong as JSPromiseStrong;
 /// it via `jsc::PromiseStatus::{Pending,Fulfilled,Rejected}`).
 pub use self::js_promise::Status as PromiseStatus;
 
-/// `bun_ptr::RefPtr` — intrusive refcounted smart pointer. Re-exported here so
-/// `crate::RefPtr<SourceProvider>` (ZigStackTrace.rs) resolves without every
-/// submodule taking a direct `bun_ptr` dep.
-pub use bun_ptr::RefPtr;
-
 /// `bun.String` — refcounted WTF-backed string. Re-exported at the crate root
 /// so submodules can write `crate::String`.
 pub use bun_core::String;

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -273,10 +273,7 @@ impl Blob {
         (!p.is_null()).then(|| JSGlobalObject::opaque_ref(p))
     }
 
-    /// Accepts both `Box<Store>` (from `Store::new` / `Store::init*`) and
-    /// `RefPtr<Store>`.
-    pub fn init_with_store<S: Into<RefPtr<Store>>>(store: S, global_this: &JSGlobalObject) -> Blob {
-        let store: RefPtr<Store> = store.into();
+    pub fn init_with_store(store: RefPtr<Store>, global_this: &JSGlobalObject) -> Blob {
         let size = store.size();
         let content_type = if let store::Data::File(ref f) = store.data {
             BlobContentType::from_mime(&f.mime_type)
@@ -871,21 +868,15 @@ pub mod store {
     // ────────────────────────────────────────────────────────────────────
 
     impl Store {
-        /// `bun.TrivialNew(@This())`.
-        #[inline]
-        pub fn new(init: Store) -> Box<Store> {
-            Box::new(init)
-        }
-
         /// Takes ownership of
         /// `bytes`. Returns a +1-ref heap `Store`.
         pub fn init(bytes: Vec<u8>) -> RefPtr<Store> {
-            RefPtr::from(Store::new(Store {
+            RefPtr::new(Store {
                 data: Data::Bytes(Bytes::init(bytes)),
                 mime_type: bun_http_types::MimeType::NONE,
                 ref_count: bun_ptr::ThreadSafeRefCount::init(),
                 is_all_ascii: None,
-            }))
+            })
         }
 
         pub fn get_path(&self) -> Option<&[u8]> {
@@ -976,9 +967,7 @@ pub mod store {
             // `heap::alloc`) as the opaque pointer.
             unsafe { Store::deref(this) };
         }
-    }
 
-    impl Store {
         /// Mutable access to `data` through a shared handle. The caller must
         /// ensure no other `&mut` to the same `Store` is live (single-threaded
         /// JS event-loop discipline).

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -17,14 +17,13 @@
 
 use core::cell::Cell;
 use core::ptr::NonNull;
-// (atomic refcounting now via `bun_ptr::ThreadSafeRefCount`)
 use std::rc::Rc;
 
 use bun_core::strings::AsciiStatus;
 use bun_http_types::MimeType::MimeType;
+use bun_ptr::RefPtr;
 
 use crate::JsCell;
-
 use crate::node_path::{PathLike, PathOrFileDescriptor};
 use crate::{JSGlobalObject, JSValue, JsClass};
 
@@ -120,9 +119,7 @@ pub struct Blob {
     pub reported_estimated_size: Cell<usize>,
     pub size: Cell<SizeType>,
     pub offset: Cell<SizeType>,
-    /// Intrusively-refcounted backing store. `StoreRef::clone`/`drop` map
-    /// directly to `Store::ref_()`/`Store::deref()`.
-    pub store: JsCell<Option<StoreRef>>,
+    pub store: JsCell<Option<RefPtr<Store>>>,
     pub content_type: JsCell<BlobContentType>,
     pub content_type_was_set: Cell<bool>,
     /// Cached encoding probe of `shared_view()`.
@@ -172,7 +169,7 @@ impl Default for Blob {
 
 // Codegen externs (build/debug/codegen/ZigGeneratedClasses.cpp `JSBlob`).
 // `*mut Blob` is opaque to C++ — only Rust dereferences it. The
-// `improper_ctypes` lint recurses through `Option<StoreRef>` → `NonNull<Store>`
+// `improper_ctypes` lint recurses through `Option<RefPtr<Store>>` → `NonNull<Store>`
 // and complains `Store` lacks `#[repr(C)]`, but `Store` never crosses FFI by
 // value, so silence it for the whole anon-const.
 #[allow(improper_ctypes)]
@@ -250,18 +247,16 @@ impl Blob {
         self.content_type.get().as_slice()
     }
 
-    /// Borrowed accessor for the `JsCell`-wrapped store. R-2: the field is
-    /// interior-mutable so host-fns can take `&self`; this projects back to the
-    /// `Option<&StoreRef>` shape every caller used pre-migration.
+    /// Borrowed accessor for the `JsCell`-wrapped store.
     #[inline]
-    pub fn store(&self) -> Option<&StoreRef> {
+    pub fn store(&self) -> Option<&RefPtr<Store>> {
         self.store.get().as_ref()
     }
 
     /// Move the store ref out without releasing it —
     /// the caller adopts the existing +1. `None` if already detached.
     #[inline]
-    pub fn take_store(&self) -> Option<StoreRef> {
+    pub fn take_store(&self) -> Option<RefPtr<Store>> {
         self.store.replace(None)
     }
 
@@ -278,10 +273,10 @@ impl Blob {
         (!p.is_null()).then(|| JSGlobalObject::opaque_ref(p))
     }
 
-    /// Accepts both
-    /// `Box<Store>` (from `Store::new` / `Store::init*`) and `StoreRef`.
-    pub fn init_with_store<S: Into<StoreRef>>(store: S, global_this: &JSGlobalObject) -> Blob {
-        let store: StoreRef = store.into();
+    /// Accepts both `Box<Store>` (from `Store::new` / `Store::init*`) and
+    /// `RefPtr<Store>`.
+    pub fn init_with_store<S: Into<RefPtr<Store>>>(store: S, global_this: &JSGlobalObject) -> Blob {
+        let store: RefPtr<Store> = store.into();
         let size = store.size();
         let content_type = if let store::Data::File(ref f) = store.data {
             BlobContentType::from_mime(&f.mime_type)
@@ -343,7 +338,6 @@ impl Blob {
     /// dropping `self`.
     #[inline]
     pub fn detach(&self) {
-        // `StoreRef::drop` calls `Store::deref()`.
         self.store.set(None);
     }
 
@@ -365,7 +359,6 @@ impl Blob {
     /// borrow path was removed because it dropped user-supplied parameters
     /// like multipart boundaries on a static-mime miss).
     pub fn dupe_with_content_type(&self, _include_content_type: bool) -> Blob {
-        // `Option<StoreRef>::clone` bumps the intrusive `Store::ref_count`.
         Blob {
             reported_estimated_size: Cell::new(self.reported_estimated_size.get()),
             size: Cell::new(self.size.get()),
@@ -886,8 +879,8 @@ pub mod store {
 
         /// Takes ownership of
         /// `bytes`. Returns a +1-ref heap `Store`.
-        pub fn init(bytes: Vec<u8>) -> StoreRef {
-            StoreRef::from(Store::new(Store {
+        pub fn init(bytes: Vec<u8>) -> RefPtr<Store> {
+            RefPtr::from(Store::new(Store {
                 data: Data::Bytes(Bytes::init(bytes)),
                 mime_type: bun_http_types::MimeType::NONE,
                 ref_count: bun_ptr::ThreadSafeRefCount::init(),
@@ -985,120 +978,24 @@ pub mod store {
         }
     }
 
-    impl Drop for Store {
-        /// `Box` handles the allocation. Every `Data` variant self-frees on
-        /// field drop: `Bytes::drop` frees its buffer + `stored_name`; the
-        /// `File.pathlike` / `S3` payloads release in `PathLike::drop`.
-        fn drop(&mut self) {}
-    }
-
-    // ────────────────────────────────────────────────────────────────────
-    // StoreRef — intrusive-refcounted handle
-    // ────────────────────────────────────────────────────────────────────
-
-    /// Owning handle to a heap `Store`, refcounted via the *intrusive*
-    /// `Store::ref_count` field.
-    ///
-    /// Not `Arc<Store>`: `Store::deref()` (reachable from `Store::external` and
-    /// other FFI callbacks) frees via `heap::take` when the intrusive count
-    /// hits zero; `Arc` would own the allocation itself, and the two refcounts
-    /// would diverge. One refcount, one deallocation path.
-    #[repr(transparent)]
-    pub struct StoreRef {
-        ptr: NonNull<Store>,
-    }
-
-    impl StoreRef {
-        /// Wrap a raw `*Store`, incrementing its intrusive refcount.
-        ///
-        /// # Safety
-        /// `ptr` must be a live `Store` allocated by `Store::new`/`Box::new`.
-        #[inline]
-        pub unsafe fn retained(ptr: NonNull<Store>) -> Self {
-            let this = Self { ptr };
-            // Deref impl encapsulates the `NonNull::as_ref` (caller contract
-            // discharges its liveness precondition).
-            this.ref_();
-            this
-        }
-
-        #[inline]
-        pub fn as_ptr(&self) -> *mut Store {
-            self.ptr.as_ptr()
-        }
-
-        /// Leak the held +1 and return the raw pointer. Pair with a later
-        /// `Store::deref()` (typically via `Store::external` / an FFI
-        /// deallocator).
-        #[inline]
-        pub fn into_raw(self) -> *mut Store {
-            core::mem::ManuallyDrop::new(self).ptr.as_ptr()
-        }
-
-        /// Mutable access to `data` through the shared handle. The caller
-        /// must ensure no
-        /// other `&mut` to the same `Store` is live (single-threaded JS
-        /// event-loop discipline).
+    impl Store {
+        /// Mutable access to `data` through a shared handle. The caller must
+        /// ensure no other `&mut` to the same `Store` is live (single-threaded
+        /// JS event-loop discipline).
         #[inline]
         #[allow(clippy::mut_from_ref)]
-        pub fn data_mut(&self) -> &mut Data {
+        pub fn data_mut(this: &RefPtr<Store>) -> &mut Data {
             // SAFETY: caller guarantees no other `&mut` to this `Store` is
-            // live; see doc comment.
-            unsafe { &mut (*self.as_ptr()).data }
+            // live; `as_ptr` carries the allocation's provenance.
+            unsafe { &mut (*this.as_ptr()).data }
         }
     }
-
-    impl From<Box<Store>> for StoreRef {
-        #[inline]
-        fn from(b: Box<Store>) -> Self {
-            // `Store::new` initializes `ref_count` to 1 — adopt that +1.
-            Self {
-                ptr: bun_core::heap::into_raw_nn(b),
-            }
-        }
-    }
-
-    impl Clone for StoreRef {
-        #[inline]
-        fn clone(&self) -> Self {
-            // `Deref` (below) encapsulates the NonNull access under the
-            // `StoreRef` liveness invariant.
-            (**self).ref_();
-            Self { ptr: self.ptr }
-        }
-    }
-
-    impl Drop for StoreRef {
-        #[inline]
-        fn drop(&mut self) {
-            // SAFETY: invariant — `ptr` is live and originated from
-            // `heap::alloc` (mutable provenance); `deref()` frees on last ref.
-            unsafe { Store::deref(self.ptr) };
-        }
-    }
-
-    impl core::ops::Deref for StoreRef {
-        type Target = Store;
-        #[inline]
-        fn deref(&self) -> &Store {
-            // SAFETY: invariant — `ptr` is live while any `StoreRef` exists.
-            unsafe { self.ptr.as_ref() }
-        }
-    }
-
-    impl PartialEq for StoreRef {
-        #[inline]
-        fn eq(&self, other: &Self) -> bool {
-            self.ptr == other.ptr
-        }
-    }
-    impl Eq for StoreRef {}
 
     // SAFETY: `Store`'s refcount is atomic and its payload is either
     // immutable-after-init or guarded by callers.
-    unsafe impl Send for StoreRef {}
-    // SAFETY: `Store::ref_count` is atomic and `&StoreRef` only derefs to
-    // `&Store`.
-    unsafe impl Sync for StoreRef {}
+    unsafe impl Send for Store {}
+    // SAFETY: `Store::ref_count` is atomic; `&Store` gives no unguarded
+    // interior mutation.
+    unsafe impl Sync for Store {}
 }
-pub use store::{Store, StoreRef};
+pub use store::Store;

--- a/src/ptr/js_cell.rs
+++ b/src/ptr/js_cell.rs
@@ -86,12 +86,12 @@ impl<T> JsCell<T> {
         f(unsafe { &mut *self.0.get() })
     }
 
-    /// Overwrite the contained value.
+    /// Overwrite the contained value. Like `Cell::set`, the old value is
+    /// dropped *after* the write, with no borrow of the cell live — so a `Drop`
+    /// that re-enters (or frees the struct holding this cell) is sound.
     #[inline(always)]
     pub fn set(&self, value: T) {
-        // Route through the single audited `with_mut` site rather than
-        // open-coding a second raw `*self.0.get() = …` write here.
-        self.with_mut(|slot| *slot = value);
+        drop(self.replace(value));
     }
 
     /// Replace the contained value, returning the old one.

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -564,13 +564,10 @@ impl core::fmt::Debug for Interned {
 // ThisPtr<T> — callback-dispatch self-pointer
 //
 // uSockets / C++ FFI dispatch hands every socket-event handler a raw
-// `*mut Self` recovered from the userdata slot. The original port open-coded
-// `unsafe { (*this).field }` / `unsafe { (&*this).ref_() }` /
-// `scopeguard::guard(this, |p| unsafe { Self::deref(p) })` at ~90 call sites
-// across the websocket-client family. `ThisPtr` centralises that pattern under
-// ONE constructor SAFETY contract: wrap the raw pointer once at fn entry, then
-// read fields via `Deref` and bracket the body with `ref_guard()` (RAII
-// `RefPtr`) instead of hand-paired `ref_()`/`deref()` at every early-exit.
+// `*mut Self` recovered from the userdata slot. `ThisPtr` wraps it under ONE
+// constructor SAFETY contract: wrap the raw pointer once at fn entry, then
+// read fields via `Deref` and hold `RefPtr::from_this(this)` across any
+// re-entrant call that could drop the last ref.
 //
 // Unlike [`BackRef`] (owner-outlives-holder back-reference), a `ThisPtr` is for
 // the *callee-is-the-allocation* case: the pointee is an intrusively-refcounted
@@ -642,18 +639,6 @@ impl<T> core::ops::Deref for ThisPtr<T> {
     #[inline]
     fn deref(&self) -> &T {
         self.get()
-    }
-}
-
-impl<T: AnyRefCounted> ThisPtr<T> {
-    /// Take a ref on the pointee, held for as long as the returned `RefPtr`
-    /// lives — brackets a re-entrant call that may otherwise drop the last ref.
-    ///
-    /// Safe: the [`new`](Self::new) invariant already established that the
-    /// pointee is live, which is exactly [`RefPtr::init_ref`]'s precondition.
-    #[inline]
-    pub fn ref_guard(self) -> RefPtr<T> {
-        RefPtr::from_this(self)
     }
 }
 
@@ -775,25 +760,23 @@ impl<T> Default for DetachablePtr<T> {
 // The returned pointer carries **shared (read-only) provenance** — it is
 // derived from `&self`, so writing through it directly is UB. The `*mut`
 // spelling exists purely to match C-shaped signatures (`void *`, uSockets
-// ext slots, `RefPtr` guard ctx, vtable thunks, intrusive
+// ext slots, `RefPtr::init_ref`, vtable thunks, intrusive
 // `RefCount::deref`). Consumers must deref as `&*p` and route mutation
 // through `Cell` / `JsCell` / `UnsafeCell` interior-mutability fields.
 //
 // Blanket-implemented for all `T`: bring the trait into scope with
 // `use bun_ptr::AsCtxPtr;` and the inherent-looking `self.as_ctx_ptr()`
-// resolves on any type. Replaces 19 identical hand-rolled
-// `fn as_ctx_ptr(&self) -> *mut Self { (self as *const Self).cast_mut() }`
-// inherent methods scattered across runtime JS-class wrappers.
+// resolves on any type.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// `&self` → `*mut Self` with shared provenance, for C-callback / scopeguard
 /// ctx slots. See module-level comment above for the safety contract.
 pub trait AsCtxPtr {
     /// `self`'s address as `*mut Self` for deferred-task / scopeguard /
-    /// `ref_guard` ctx slots. The closures/trampolines deref it as shared
+    /// `RefPtr::init_ref` ctx slots. The closures/trampolines deref it as shared
     /// (`&*p`) — every method they reach is `&self` post-R-2, so no write
     /// provenance is required; the `*mut` spelling is purely to match the
-    /// existing `DerefOnDrop` / `HasAutoFlush` / `RefCount` ABI.
+    /// `HasAutoFlush` / `RefCount` ABI.
     #[inline(always)]
     fn as_ctx_ptr(&self) -> *mut Self
     where

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -41,7 +41,7 @@ pub use tagged_pointer::TaggedPtr;
 
 pub mod ref_count;
 pub use ref_count::{
-    AnyRefCounted, CellRefCounted, RefCount, RefCounted, RefPtr, ScopedRef, ThreadSafeRefCount,
+    AnyRefCounted, CellRefCounted, RefCount, RefCounted, RefPtr, ThreadSafeRefCount,
     ThreadSafeRefCounted, destroy_box_with, finalize_js_box, finalize_js_box_noop,
 };
 // Derive macros — same names as the traits (separate namespace). The derives
@@ -51,9 +51,6 @@ pub use bun_core_macros::{CellRefCounted, RefCounted, ThreadSafeRefCounted};
 
 pub mod parent_ref;
 pub use parent_ref::ParentRef;
-// Compat alias for callers that use the pointer-typedef name.
-pub type IntrusiveRc<T> = RefPtr<T>;
-
 pub use raw_ref_count::RawRefCount;
 pub use weak_ptr::WeakPtr;
 
@@ -573,7 +570,7 @@ impl core::fmt::Debug for Interned {
 // across the websocket-client family. `ThisPtr` centralises that pattern under
 // ONE constructor SAFETY contract: wrap the raw pointer once at fn entry, then
 // read fields via `Deref` and bracket the body with `ref_guard()` (RAII
-// `ScopedRef`) instead of hand-paired `ref_()`/`deref()` at every early-exit.
+// `RefPtr`) instead of hand-paired `ref_()`/`deref()` at every early-exit.
 //
 // Unlike [`BackRef`] (owner-outlives-holder back-reference), a `ThisPtr` is for
 // the *callee-is-the-allocation* case: the pointee is an intrusively-refcounted
@@ -648,23 +645,15 @@ impl<T> core::ops::Deref for ThisPtr<T> {
     }
 }
 
-impl<T: AnyRefCounted> ThisPtr<T>
-where
-    T::DestructorCtx: Default,
-{
-    /// Bump the intrusive refcount and return an RAII guard that derefs on
-    /// `Drop`. Replaces the hand-rolled
-    /// `this.ref_(); scopeguard::guard(this_ptr, |p| Self::deref(p))` /
-    /// `this.ref_(); … defer this.deref()` bracket: the guard runs the paired
-    /// `deref()` on every exit path, so manual `Self::deref(this)` at each
-    /// early return goes away.
+impl<T: AnyRefCounted> ThisPtr<T> {
+    /// Take a ref on the pointee, held for as long as the returned `RefPtr`
+    /// lives — brackets a re-entrant call that may otherwise drop the last ref.
     ///
     /// Safe: the [`new`](Self::new) invariant already established that the
-    /// pointee is live, which is exactly [`ScopedRef::new`]'s precondition.
+    /// pointee is live, which is exactly [`RefPtr::init_ref`]'s precondition.
     #[inline]
-    pub fn ref_guard(self) -> ScopedRef<T> {
-        // SAFETY: `ThisPtr::new` invariant — `self.0` points to a live `T`.
-        unsafe { ScopedRef::new(self.0.as_ptr()) }
+    pub fn ref_guard(self) -> RefPtr<T> {
+        RefPtr::from_this(self)
     }
 }
 
@@ -786,7 +775,7 @@ impl<T> Default for DetachablePtr<T> {
 // The returned pointer carries **shared (read-only) provenance** — it is
 // derived from `&self`, so writing through it directly is UB. The `*mut`
 // spelling exists purely to match C-shaped signatures (`void *`, uSockets
-// ext slots, `ScopedRef` / `DerefOnDrop` ctx, vtable thunks, intrusive
+// ext slots, `RefPtr` guard ctx, vtable thunks, intrusive
 // `RefCount::deref`). Consumers must deref as `&*p` and route mutation
 // through `Cell` / `JsCell` / `UnsafeCell` interior-mutability fields.
 //

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -584,7 +584,7 @@ impl core::fmt::Debug for Interned {
 ///
 /// See the module comment above for the full rationale. Construct once per
 /// handler entry with [`ThisPtr::new`], then use `Deref` for field reads and
-/// [`ThisPtr::ref_guard`] for the keep-alive bracket.
+/// [`RefPtr::from_this`] for the keep-alive bracket.
 #[repr(transparent)]
 pub struct ThisPtr<T>(core::ptr::NonNull<T>);
 
@@ -596,7 +596,7 @@ impl<T> ThisPtr<T> {
     /// `heap::alloc`, intrusively refcounted) that remains live for every
     /// subsequent access through this `ThisPtr` and its copies — i.e. either
     /// the caller already holds a ref, or the first thing it does is take a
-    /// [`ref_guard`](Self::ref_guard). No `&mut T` to `*p` may be live across
+    /// [`RefPtr::from_this`]. No `&mut T` to `*p` may be live across
     /// any `Deref` borrow produced from this `ThisPtr`.
     #[inline]
     pub unsafe fn new(p: *mut T) -> Self {

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -9,35 +9,7 @@ use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicU32, Ordering};
 
-use bun_core::StoredTrace;
 use bun_core::ThreadLock;
-
-// was `bun_collections::{ArrayHashMap, HashMap}` (T1 → upward).
-// Debug-only diagnostic storage; std HashMap drops insertion order for `frees`
-// which is acceptable for leak reports.
-#[cfg(debug_assertions)]
-use std::collections::HashMap;
-#[cfg(debug_assertions)]
-type ArrayHashMap<K, V> = HashMap<K, V>;
-
-// ──────────────────────────────────────────────────────────────────────────
-// Debug stack dump — calls straight into bun_core (T0 owns the std::backtrace
-// fallback). Crash-report symbolication lives in bun_crash_handler and is
-// invoked from there directly when needed.
-// ──────────────────────────────────────────────────────────────────────────
-
-#[inline]
-fn dump_stack_hook(trace: Option<&StoredTrace>, ret_addr: usize) {
-    match trace {
-        None => bun_core::dump_current_stack_trace(
-            if ret_addr == 0 { None } else { Some(ret_addr) },
-            bun_core::DumpStackTraceOptions::default(),
-        ),
-        Some(stored) => {
-            bun_core::dump_stack_trace(&stored.trace(), bun_core::DumpStackTraceOptions::default())
-        }
-    }
-}
 
 // ──────────────────────────────────────────────────────────────────────────
 // Host-type traits (field projection + destructor)
@@ -130,11 +102,12 @@ pub trait AnyRefCounted: Sized {
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn rc_assert_no_refs(this: *const Self);
-
-    #[cfg(debug_assertions)]
+    /// Debug-asserts the refcount has not already been destroyed.
+    ///
     /// # Safety
     /// `this` must point to a live `Self`.
-    unsafe fn rc_debug_data(this: *mut Self) -> *mut dyn DebugDataOps;
+    #[inline]
+    unsafe fn rc_assert_valid(_this: *const Self) {}
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -208,11 +181,9 @@ pub struct RefCount<T: RefCounted> {
     raw_count: Cell<u32>,
     thread: ThreadLock,
     #[cfg(debug_assertions)]
-    debug: DebugData<Cell<u32>>,
+    debug: DebugData,
     _phantom: PhantomData<*const T>,
 }
-
-const DEBUG_STACK_TRACE: bool = false;
 
 impl<T: RefCounted> RefCount<T> {
     pub fn init() -> Self {
@@ -239,12 +210,7 @@ impl<T: RefCounted> RefCount<T> {
     pub unsafe fn ref_(self_: *mut T) {
         // SAFETY: caller contract
         let count = unsafe { &*T::get_ref_count(self_) };
-        #[cfg(debug_assertions)]
-        {
-            count.debug.assert_valid();
-        }
-        // `bun_core::scoped_log!` requires a static scope ident, so all types
-        // share the single `ref_count` scope.
+        count.assert_valid();
         bun_core::scoped_log!(
             ref_count,
             "0x{:x}   ref {} -> {}:",
@@ -252,9 +218,6 @@ impl<T: RefCounted> RefCount<T> {
             count.raw_count.get(),
             count.raw_count.get() + 1,
         );
-        if DEBUG_STACK_TRACE {
-            dump_stack_hook(None, return_address());
-        }
         count.assert_single_threaded();
         count.raw_count.set(count.raw_count.get() + 1);
     }
@@ -264,10 +227,7 @@ impl<T: RefCounted> RefCount<T> {
     pub unsafe fn deref(self_: *mut T) {
         // SAFETY: caller contract
         let count = unsafe { &*T::get_ref_count(self_) };
-        #[cfg(debug_assertions)]
-        {
-            count.debug.assert_valid(); // Likely double deref.
-        }
+        count.assert_valid(); // Likely double deref.
         bun_core::scoped_log!(
             ref_count,
             "0x{:x} deref {} -> {}:",
@@ -275,16 +235,13 @@ impl<T: RefCounted> RefCount<T> {
             count.raw_count.get(),
             count.raw_count.get() - 1,
         );
-        if DEBUG_STACK_TRACE {
-            dump_stack_hook(None, return_address());
-        }
         count.assert_single_threaded();
         count.raw_count.set(count.raw_count.get() - 1);
         if count.raw_count.get() == 0 {
             #[cfg(debug_assertions)]
             {
-                // SAFETY: count is &*get_ref_count(self_); we need &mut for deinit
-                unsafe { (*T::get_ref_count(self_)).debug.deinit(return_address()) };
+                // SAFETY: `count` is not used again; we need &mut for deinit
+                unsafe { (*T::get_ref_count(self_)).debug.deinit() };
             }
             // SAFETY: raw_count == 0, sole owner
             unsafe { T::destructor(self_) };
@@ -311,12 +268,11 @@ impl<T: RefCounted> RefCount<T> {
         self.thread.lock_or_assert();
     }
 
-    // `getRefCount(self: *T) *@This()` is the trait method
-    // `T::get_ref_count` above; not duplicated here.
-
-    // `is_ref_count = unique_symbol` and `ref_count_options` were
-    // reflection markers for `RefPtr`; replaced by the `AnyRefCounted`
-    // trait bound.
+    #[inline]
+    pub fn assert_valid(&self) {
+        #[cfg(debug_assertions)]
+        self.debug.assert_valid();
+    }
 }
 
 impl<T: RefCounted> AnyRefCounted for T {
@@ -336,10 +292,9 @@ impl<T: RefCounted> AnyRefCounted for T {
         // SAFETY: caller contract — `this` points to a live T
         unsafe { (*T::get_ref_count(this.cast_mut())).assert_no_refs() }
     }
-    #[cfg(debug_assertions)]
-    unsafe fn rc_debug_data(this: *mut Self) -> *mut dyn DebugDataOps {
+    unsafe fn rc_assert_valid(this: *const Self) {
         // SAFETY: caller contract — `this` points to a live T
-        unsafe { &raw mut (*T::get_ref_count(this)).debug }
+        unsafe { (*T::get_ref_count(this.cast_mut())).assert_valid() }
     }
 }
 
@@ -359,7 +314,7 @@ impl<T: RefCounted> AnyRefCounted for T {
 pub struct ThreadSafeRefCount<T: ThreadSafeRefCounted> {
     raw_count: AtomicU32,
     #[cfg(debug_assertions)]
-    debug: DebugData<AtomicU32>,
+    debug: DebugData,
     _phantom: PhantomData<*const T>,
 }
 
@@ -386,8 +341,7 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
     pub unsafe fn ref_(self_: *mut T) {
         // SAFETY: caller contract
         let count = unsafe { &*T::get_ref_count(self_) };
-        #[cfg(debug_assertions)]
-        count.debug.assert_valid();
+        count.assert_valid();
         let old_count = count.raw_count.fetch_add(1, Ordering::SeqCst);
         bun_core::scoped_log!(
             ref_count,
@@ -404,8 +358,7 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
     pub unsafe fn deref(self_: *mut T) {
         // SAFETY: caller contract
         let count = unsafe { &*T::get_ref_count(self_) };
-        #[cfg(debug_assertions)]
-        count.debug.assert_valid();
+        count.assert_valid();
         let old_count = count.raw_count.fetch_sub(1, Ordering::SeqCst);
         bun_core::scoped_log!(
             ref_count,
@@ -419,7 +372,7 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
             #[cfg(debug_assertions)]
             {
                 // SAFETY: we hold the last ref; exclusive access
-                unsafe { (*T::get_ref_count(self_)).debug.deinit(return_address()) };
+                unsafe { (*T::get_ref_count(self_)).debug.deinit() };
             }
             // SAFETY: last ref dropped
             unsafe { T::destructor(self_) };
@@ -439,8 +392,7 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
     pub unsafe fn release(self_: *mut T) -> bool {
         // SAFETY: caller contract
         let count = unsafe { &*T::get_ref_count(self_) };
-        #[cfg(debug_assertions)]
-        count.debug.assert_valid();
+        count.assert_valid();
         let old_count = count.raw_count.fetch_sub(1, Ordering::SeqCst);
         bun_core::scoped_log!(
             ref_count,
@@ -454,7 +406,7 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
             #[cfg(debug_assertions)]
             {
                 // SAFETY: we hold the last ref; exclusive access
-                unsafe { (*T::get_ref_count(self_)).debug.deinit(return_address()) };
+                unsafe { (*T::get_ref_count(self_)).debug.deinit() };
             }
             true
         } else {
@@ -469,8 +421,7 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
     }
 
     pub fn has_one_ref(&self) -> bool {
-        #[cfg(debug_assertions)]
-        self.debug.assert_valid();
+        self.assert_valid();
         self.get() == 1
     }
 
@@ -479,18 +430,11 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
         assert!(self.raw_count.load(Ordering::SeqCst) == 0);
     }
 
-    /// Type-erased accessor for the embedded debug tracker. Exposed (rather
-    /// than the private `debug` field) so `#[derive(ThreadSafeRefCounted)]`
-    /// can emit [`AnyRefCounted::rc_debug_data`] from outside this crate.
-    #[cfg(debug_assertions)]
-    #[doc(hidden)]
     #[inline]
-    pub fn debug_data_ptr(&mut self) -> *mut dyn DebugDataOps {
-        &raw mut self.debug
+    pub fn assert_valid(&self) {
+        #[cfg(debug_assertions)]
+        self.debug.assert_valid();
     }
-
-    // `getRefCount` / `is_ref_count` / `ref_count_options` — see
-    // notes on RefCount above.
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -499,7 +443,7 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
 
 /// Lightweight intrusive refcount trait for types that embed a bare
 /// `ref_count: Cell<u32>` field (no [`RefCount<Self>`] wrapper, no debug
-/// tracking, no thread-lock).
+/// canary, no thread-lock).
 ///
 /// This is the migration target for the ~30 types that previously hand-rolled
 /// `ref_()`/`deref()` pairs around a `Cell<u32>`. Implementors supply only
@@ -630,37 +574,6 @@ pub fn destroy_box_with<T>(this: *mut T, before: impl FnOnce(&T)) {
     }
 }
 
-/// No-op [`DebugDataOps`] for [`CellRefCounted`] types — they carry no
-/// `DebugData` field, so [`RefPtr`]'s acquire/release tracking degrades to
-/// a stub.
-#[cfg(debug_assertions)]
-#[doc(hidden)]
-struct NoopDebugData;
-
-#[cfg(debug_assertions)]
-impl DebugDataOps for NoopDebugData {
-    fn assert_valid_dyn(&self) {}
-    fn acquire(&mut self, _return_address: usize) -> TrackedRefId {
-        TrackedRefId::new(0)
-    }
-    fn release(&mut self, _id: TrackedRefId, _return_address: usize) {}
-}
-
-#[cfg(debug_assertions)]
-#[doc(hidden)]
-pub fn noop_debug_data() -> *mut dyn DebugDataOps {
-    // Per-call leaked stub — `RefPtr` only calls `acquire`/`release` on it,
-    // both of which are no-ops, so a shared static would also be sound; but
-    // `*mut dyn` from a `static mut` is unergonomic. Debug-only.
-    // SAFETY: NonNull::dangling is fine here? No — `RefPtr` derefs it.
-    // Use a thread-local static to avoid per-ref allocation.
-    thread_local! {
-        static NOOP: core::cell::UnsafeCell<NoopDebugData> =
-            const { core::cell::UnsafeCell::new(NoopDebugData) };
-    }
-    NOOP.with(|n| n.get() as *mut dyn DebugDataOps)
-}
-
 // A blanket `impl<T: ThreadSafeRefCounted> AnyRefCounted for T` would overlap
 // with the `RefCounted` blanket above (Rust forbids overlapping blanket impls).
 // Instead, thread-safe hosts opt in via `#[derive(ThreadSafeRefCounted)]`,
@@ -678,185 +591,131 @@ pub fn noop_debug_data() -> *mut dyn DebugDataOps {
 /// consumer (C++ `m_ctx`, a uws/libuv userdata slot) use
 /// [`into_raw`](Self::into_raw) and reclaim it later with
 /// [`from_raw`](Self::from_raw).
-///
-/// In debug builds every `RefPtr` is tracked in `T`'s `DebugData`, so
-/// `T.ref_count.dump_active_refs()` lists the acquisition site of each live one.
 #[must_use = "dropping a RefPtr releases its ref"]
-pub struct RefPtr<T: AnyRefCounted> {
-    data: NonNull<T>,
-    #[cfg(debug_assertions)]
-    debug: TrackedRefId,
-}
+#[repr(transparent)]
+pub struct RefPtr<T: AnyRefCounted>(NonNull<T>);
 
 impl<T: AnyRefCounted> Drop for RefPtr<T> {
     #[inline]
     fn drop(&mut self) {
-        let ptr = self.data.as_ptr();
-        #[cfg(debug_assertions)]
-        {
-            // SAFETY: we still own a ref, so `ptr` is live.
-            unsafe { (*T::rc_debug_data(ptr)).release(self.debug, return_address()) };
-        }
-        // SAFETY: we own a ref, so `ptr` is live; this releases it.
-        unsafe { T::rc_deref(ptr) };
+        // SAFETY: we own a ref, so the pointee is live; this releases it.
+        unsafe { T::rc_deref(self.0.as_ptr()) };
+    }
+}
+
+// Like `Arc<T>`: sending or sharing a `RefPtr` sends/shares `&T` and may run
+// `T`'s destructor on another thread.
+// SAFETY: see above; hosts opt in by being `Send + Sync` themselves.
+unsafe impl<T: AnyRefCounted + Send + Sync> Send for RefPtr<T> {}
+// SAFETY: see above.
+unsafe impl<T: AnyRefCounted + Send + Sync> Sync for RefPtr<T> {}
+
+/// Adopt the initial ref of a freshly constructed `T` (its embedded count
+/// starts at 1).
+impl<T: AnyRefCounted> From<Box<T>> for RefPtr<T> {
+    #[inline]
+    fn from(value: Box<T>) -> Self {
+        let ptr = bun_core::heap::into_raw_nn(value);
+        // SAFETY: freshly boxed, so live.
+        debug_assert!(unsafe { T::rc_has_one_ref(ptr.as_ptr()) });
+        Self(ptr)
     }
 }
 
 impl<T: AnyRefCounted> RefPtr<T> {
-    /// Increment the reference count, and return a structure boxing the pointer.
+    /// Allocate `value` on the heap and own its initial ref.
+    #[inline]
+    pub fn new(value: T) -> Self {
+        Self::from(Box::new(value))
+    }
+
+    /// Take a new ref on `*raw_ptr`.
     ///
     /// # Safety
     /// `raw_ptr` must point to a live `T`.
+    #[inline]
     pub unsafe fn init_ref(raw_ptr: *mut T) -> Self {
         // SAFETY: caller contract
-        unsafe { T::rc_ref(raw_ptr) };
-        // SAFETY: caller contract
-        unsafe { Self::unchecked_and_unsafe_init(raw_ptr, return_address()) }
-    }
-
-    pub fn dupe_ref(&self) -> Self {
-        // SAFETY: data is live (we hold a ref)
-        unsafe { Self::init_ref(self.as_ptr()) }
-    }
-
-    /// Allocate a new object, returning a RefPtr to it.
-    pub fn new(init_data: T) -> Self {
-        // SAFETY: freshly boxed, ref_count == 1
-        unsafe { Self::adopt_ref(bun_core::heap::into_raw(Box::new(init_data))) }
-    }
-
-    /// Initialize a newly allocated pointer, returning a RefPtr to it.
-    /// Care must be taken when using non-default allocators.
-    ///
-    /// # Safety
-    /// `raw_ptr` must point to a live `T` with exactly one ref.
-    pub unsafe fn adopt_ref(raw_ptr: *mut T) -> Self {
-        #[cfg(debug_assertions)]
-        {
-            // SAFETY: caller contract
-            debug_assert!(unsafe { T::rc_has_one_ref(raw_ptr) });
-            // SAFETY: caller contract
-            unsafe { (*T::rc_debug_data(raw_ptr)).assert_valid_dyn() };
+        unsafe {
+            T::rc_assert_valid(raw_ptr);
+            T::rc_ref(raw_ptr);
+            Self(NonNull::new_unchecked(raw_ptr))
         }
-        // SAFETY: caller contract
-        unsafe { Self::unchecked_and_unsafe_init(raw_ptr, return_address()) }
     }
 
-    /// A [`ThisPtr`](crate::ThisPtr) to the pointee, for the FFI-shaped call
-    /// sites that take one.
-    ///
-    /// Safe: holding a `RefPtr` means we own a ref, so the pointee is live —
-    /// which is exactly `ThisPtr::new`'s precondition. The returned handle is
-    /// only valid while this `RefPtr` (or another ref) is alive.
-    #[inline]
-    pub fn this_ptr(&self) -> crate::ThisPtr<T> {
-        // SAFETY: we own an outstanding ref, so `self.data` is live and non-null.
-        unsafe { crate::ThisPtr::new(self.data.as_ptr()) }
-    }
-
-    /// Take a new ref on the pointee of a dispatch-time [`ThisPtr`](crate::ThisPtr).
-    /// Safe: the `ThisPtr` invariant is that its pointee is live.
+    /// Take a new ref on the pointee of a [`ThisPtr`](crate::ThisPtr). Safe:
+    /// the `ThisPtr` invariant is that its pointee is live. This is the guard
+    /// to hold across a re-entrant call that may otherwise drop the last ref.
     #[inline]
     pub fn from_this(this: crate::ThisPtr<T>) -> Self {
         // SAFETY: `ThisPtr::new` invariant — pointee is live.
         unsafe { Self::init_ref(this.as_ptr()) }
     }
 
-    /// Consume this `RefPtr` into a [`ThisPtr`](crate::ThisPtr), transferring
-    /// the ref to the callee — the counterpart of `into_raw` for the
-    /// `ThisPtr`-shaped dispatch entry points. Safe for the same reason
-    /// `into_raw` is: no ref is released, and the pointee stays live.
+    /// Take ownership of a ref the caller already holds on `*raw_ptr`, without
+    /// incrementing. Inverse of [`into_raw`](Self::into_raw) (`Arc::from_raw`
+    /// semantics).
+    ///
+    /// # Safety
+    /// `raw_ptr` must point to a live `T` and the caller must own one ref.
+    #[inline]
+    pub unsafe fn from_raw(raw_ptr: *mut T) -> Self {
+        // SAFETY: caller contract
+        unsafe {
+            T::rc_assert_valid(raw_ptr);
+            Self(NonNull::new_unchecked(raw_ptr))
+        }
+    }
+
+    /// Give up ownership of the ref without decrementing; whoever holds the
+    /// returned pointer now owns it. Inverse of [`from_raw`](Self::from_raw)
+    /// (`Arc::into_raw` semantics).
+    #[inline]
+    pub fn into_raw(self) -> *mut T {
+        core::mem::ManuallyDrop::new(self).0.as_ptr()
+    }
+
+    /// A [`ThisPtr`](crate::ThisPtr) to the pointee, valid while this (or
+    /// another) ref is alive.
+    #[inline]
+    pub fn this_ptr(&self) -> crate::ThisPtr<T> {
+        // SAFETY: we own a ref, so the pointee is live.
+        unsafe { crate::ThisPtr::new(self.0.as_ptr()) }
+    }
+
+    /// [`into_raw`](Self::into_raw) for the `ThisPtr`-shaped dispatch entry
+    /// points: the callee takes over this ref.
     #[inline]
     pub fn into_this_ptr(self) -> crate::ThisPtr<T> {
         // SAFETY: `into_raw` transfers our live ref; the pointee is non-null.
         unsafe { crate::ThisPtr::new(self.into_raw()) }
     }
 
-    /// Wrap a raw pointer whose ref is being transferred to this RefPtr
-    /// WITHOUT incrementing the refcount. The caller gives up their ref;
-    /// this RefPtr now owns it. Unlike `adopt_ref`, this does not assert
-    /// `has_one_ref()` — the pointer may have other outstanding refs.
-    /// Inverse of [`into_raw`](Self::into_raw) (`Arc::from_raw` semantics).
-    ///
-    /// # Safety
-    /// `raw_ptr` must point to a live `T` and the caller must own one ref.
-    #[inline]
-    pub unsafe fn from_raw(raw_ptr: *mut T) -> Self {
-        #[cfg(debug_assertions)]
-        {
-            // SAFETY: caller contract
-            unsafe { (*T::rc_debug_data(raw_ptr)).assert_valid_dyn() };
-        }
-        // SAFETY: caller contract
-        unsafe { Self::unchecked_and_unsafe_init(raw_ptr, return_address()) }
-    }
-
-    /// Extract the raw pointer, giving up ownership WITHOUT decrementing the
-    /// refcount; whoever holds the pointer now owns the ref. Inverse of
-    /// [`from_raw`](Self::from_raw) (`Arc::into_raw` semantics).
-    #[inline]
-    pub fn into_raw(self) -> *mut T {
-        let this = core::mem::ManuallyDrop::new(self);
-        let ptr = this.data.as_ptr();
-        #[cfg(debug_assertions)]
-        {
-            // SAFETY: data is live (we hold a ref)
-            unsafe { (*T::rc_debug_data(ptr)).release(this.debug, return_address()) };
-        }
-        ptr
-    }
-
-    /// Borrow the inner `*mut T` without affecting the refcount (analogous to
-    /// `Arc::as_ptr`). The pointer carries the original `heap::alloc`
-    /// provenance, so it is sound to thread it back through APIs that may
-    /// eventually `heap::take` it (e.g. allocator-vtable `free`), provided
-    /// the caller still holds a ref for the duration.
+    /// The pointee's address without affecting the refcount (`Arc::as_ptr`).
+    /// It carries the allocation's own provenance, so it may be threaded back
+    /// through APIs that eventually free it, provided a ref is held meanwhile.
     ///
     /// This is the only sanctioned way to mutate the pointee: `RefPtr` is a
-    /// shared-ownership handle, so a `&mut T` accessor would alias with any
-    /// other live `RefPtr`/`&T` to the same allocation. Callers that need
-    /// mutation must go through this raw pointer and uphold the no-alias
-    /// invariant themselves.
+    /// shared-ownership handle, so a `&mut T` accessor would alias any other
+    /// live `RefPtr`/`&T` to the same allocation.
     #[inline]
     pub fn as_ptr(&self) -> *mut T {
-        self.data.as_ptr()
+        self.0.as_ptr()
     }
 
+    /// [`as_ptr`](Self::as_ptr) as a `NonNull`.
     #[inline]
     pub fn as_non_null(&self) -> NonNull<T> {
-        self.data
-    }
-
-    /// Borrow the pointee (same as `<RefPtr<T> as Deref>::deref`).
-    #[inline]
-    pub fn data(&self) -> &T {
-        // SAFETY: holding a `RefPtr` means we own at least one ref, so the
-        // pointee is live for the borrow. Single-threaded `RefCount` hosts are
-        // !Send/!Sync so no concurrent mutation; thread-safe hosts coordinate
-        // their own interior mutability.
-        unsafe { self.data.as_ref() }
-    }
-
-    /// # Safety
-    /// `raw_ptr` must point to a live `T` and the caller must hold/own a ref.
-    pub(crate) unsafe fn unchecked_and_unsafe_init(raw_ptr: *mut T, ret_addr: usize) -> Self {
-        let _ = ret_addr;
-        Self {
-            // SAFETY: caller contract — raw_ptr is non-null and live
-            data: unsafe { NonNull::new_unchecked(raw_ptr) },
-            #[cfg(debug_assertions)]
-            // SAFETY: caller contract
-            debug: unsafe { (*T::rc_debug_data(raw_ptr)).acquire(ret_addr) },
-        }
+        self.0
     }
 }
 
 impl<T: AnyRefCounted> Clone for RefPtr<T> {
-    /// Bumps the intrusive refcount and returns a new `RefPtr` to the same
-    /// allocation. Equivalent to [`dupe_ref`](Self::dupe_ref).
+    /// Takes another ref on the same allocation.
     #[inline]
     fn clone(&self) -> Self {
-        self.dupe_ref()
+        // SAFETY: we own a ref, so the pointee is live.
+        unsafe { Self::init_ref(self.0.as_ptr()) }
     }
 }
 
@@ -864,139 +723,50 @@ impl<T: AnyRefCounted> core::ops::Deref for RefPtr<T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &T {
-        self.data()
+        // SAFETY: we own a ref, so the pointee is live for the borrow.
+        // Single-threaded hosts are !Send/!Sync so no concurrent mutation;
+        // thread-safe hosts coordinate their own interior mutability.
+        unsafe { self.0.as_ref() }
     }
 }
-
-// ──────────────────────────────────────────────────────────────────────────
-// TrackedRef / TrackedDeref
-// ──────────────────────────────────────────────────────────────────────────
-
-#[cfg(debug_assertions)]
-struct TrackedRef;
-
-/// Not an index, just a unique identifier for the debug data.
-#[derive(Copy, Clone, Eq, PartialEq, Hash)]
-pub struct TrackedRefId(u32);
-
-#[cfg(debug_assertions)]
-impl TrackedRefId {
-    #[inline]
-    const fn new(n: u32) -> Self {
-        Self(n)
-    }
-}
-
-#[cfg(debug_assertions)]
-struct TrackedDeref;
 
 // ──────────────────────────────────────────────────────────────────────────
 // DebugData
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Dyn-safe surface of `DebugData<Count>` so `RefPtr<T>` can interact with it
-/// without knowing whether `Count` is `Cell<u32>` or `AtomicU32`.
 #[cfg(debug_assertions)]
-pub trait DebugDataOps {
-    fn assert_valid_dyn(&self);
-    fn acquire(&mut self, return_address: usize) -> TrackedRefId;
-    fn release(&mut self, id: TrackedRefId, return_address: usize);
+const MAGIC_VALID: u32 = 0x2f84_e51d;
+
+/// Debug-only liveness canary embedded in `RefCount`/`ThreadSafeRefCount`:
+/// poisoned when the destructor runs, so a ref/deref through a dangling
+/// pointer asserts instead of silently corrupting the count.
+#[cfg(debug_assertions)]
+pub struct DebugData {
+    magic: u32,
 }
 
 #[cfg(debug_assertions)]
-const MAGIC_VALID: u128 = 0x2f84_e51d;
-
-/// Provides Ref tracking. This is not generic over the pointer T to reduce
-/// analysis complexity.
-// Parameterized on the `Count` storage type directly (`Cell<u32>` or
-// `AtomicU32`). The lock and `next_id` are made uniformly thread-safe
-// (debug-only — perf irrelevant).
-#[cfg(debug_assertions)]
-pub struct DebugData<Count> {
-    magic: u128,
-    lock: bun_core::Mutex<()>,
-    next_id: AtomicU32,
-    map: HashMap<TrackedRefId, TrackedRef>,
-    frees: ArrayHashMap<TrackedRefId, TrackedDeref>,
-    _count: core::marker::PhantomData<Count>,
-}
-
-#[cfg(debug_assertions)]
-impl<Count> DebugData<Count> {
-    // was `pub const EMPTY` — std HashMap::new() is non-const.
-    pub(crate) fn empty() -> Self {
-        Self {
-            magic: MAGIC_VALID,
-            lock: bun_core::Mutex::new(()),
-            next_id: AtomicU32::new(0),
-            map: HashMap::new(),
-            frees: ArrayHashMap::new(),
-            _count: core::marker::PhantomData,
-        }
+impl DebugData {
+    pub(crate) const fn empty() -> Self {
+        Self { magic: MAGIC_VALID }
     }
 
     fn assert_valid(&self) {
-        debug_assert!(self.magic == MAGIC_VALID);
+        debug_assert!(
+            self.magic == MAGIC_VALID,
+            "ref/deref on a destroyed refcount"
+        );
     }
 
-    fn alloc_id(&self) -> TrackedRefId {
-        // Debug-only path; always atomic here.
-        TrackedRefId::new(self.next_id.fetch_add(1, Ordering::SeqCst))
-    }
-
-    fn release_impl(&mut self, id: TrackedRefId, return_address: usize) {
-        // If this triggers ASAN, the RefCounted object is double-freed.
-        let _guard = self.lock.lock();
-        let _ = return_address;
-        if self.map.remove(&id).is_none() {
-            return;
-        }
-        self.frees.insert(id, TrackedDeref);
-    }
-
-    fn deinit(&mut self, ret_addr: usize) {
+    fn deinit(&mut self) {
         self.assert_valid();
         self.magic = 0;
-        let _guard = self.lock.lock();
-        self.map.clear();
-        self.map.shrink_to_fit();
-        // Clear and release the allocation.
-        self.frees.clear();
-        self.frees.shrink_to_fit();
-        let _ = ret_addr;
-    }
-}
-
-#[cfg(debug_assertions)]
-impl<Count> DebugDataOps for DebugData<Count> {
-    fn assert_valid_dyn(&self) {
-        self.assert_valid();
-    }
-
-    fn acquire(&mut self, return_address: usize) -> TrackedRefId {
-        let _guard = self.lock.lock();
-        let id = self.alloc_id();
-        let _ = return_address;
-        self.map.insert(id, TrackedRef);
-        id
-    }
-
-    fn release(&mut self, id: TrackedRefId, return_address: usize) {
-        self.release_impl(id, return_address);
     }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
 // helpers
 // ──────────────────────────────────────────────────────────────────────────
-
-#[inline(always)]
-fn return_address() -> usize {
-    bun_core::return_address()
-}
-
-// `const unique_symbol = opaque {};` — type-identity marker for
-// compile-time assertion in `RefPtr`. Replaced by `AnyRefCounted` trait bound.
 
 bun_core::declare_scope!(ref_count, hidden);
 
@@ -1106,9 +876,9 @@ mod tests {
             ref_count: RefCount::init(),
             payload: Box::new(42),
         });
-        assert_eq!(*p.data().payload, 42);
+        assert_eq!(*p.payload, 42);
 
-        let q = p.dupe_ref();
+        let q = p.clone();
         let r = p.clone();
         assert_eq!(p.as_ptr(), q.as_ptr());
         assert_eq!(p.as_ptr(), r.as_ptr());

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -1,5 +1,5 @@
-//! Intrusive reference counting (single-threaded and thread-safe) + `RefPtr<T>`
-//! debug-tracking wrapper.
+//! Intrusive reference counting (single-threaded and thread-safe) and
+//! `RefPtr<T>`, the owning handle to one such ref.
 //!
 //! Each ref-count mixin is a pair of (embedded struct + trait the host
 //! type implements). See `RefCounted` / `ThreadSafeRefCounted`.
@@ -99,9 +99,6 @@ pub trait AnyRefCounted: Sized {
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn rc_has_one_ref(this: *const Self) -> bool;
-    /// # Safety
-    /// `this` must point to a live `Self`.
-    unsafe fn rc_assert_no_refs(this: *const Self);
     /// Debug-asserts the refcount has not already been destroyed.
     ///
     /// # Safety
@@ -174,9 +171,6 @@ pub fn finalize_js_box_noop<T: AnyRefCounted>(boxed: Box<T>) {
 ///     }
 /// }
 /// ```
-///
-/// When `RefCount` is implemented, it can be used with `RefPtr<T>` to track
-/// where a reference leak may be happening.
 pub struct RefCount<T: RefCounted> {
     raw_count: Cell<u32>,
     thread: ThreadLock,
@@ -287,10 +281,6 @@ impl<T: RefCounted> AnyRefCounted for T {
     unsafe fn rc_has_one_ref(this: *const Self) -> bool {
         // SAFETY: caller contract — `this` points to a live T
         unsafe { (*T::get_ref_count(this.cast_mut())).has_one_ref() }
-    }
-    unsafe fn rc_assert_no_refs(this: *const Self) {
-        // SAFETY: caller contract — `this` points to a live T
-        unsafe { (*T::get_ref_count(this.cast_mut())).assert_no_refs() }
     }
     unsafe fn rc_assert_valid(this: *const Self) {
         // SAFETY: caller contract — `this` points to a live T
@@ -445,10 +435,8 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
 /// `ref_count: Cell<u32>` field (no [`RefCount<Self>`] wrapper, no debug
 /// canary, no thread-lock).
 ///
-/// This is the migration target for the ~30 types that previously hand-rolled
-/// `ref_()`/`deref()` pairs around a `Cell<u32>`. Implementors supply only
-/// [`ref_count`] and [`destroy`]; the trait provides `ref_()`/`deref()` with
-/// the canonical inc/dec/destroy-at-zero logic.
+/// Implementors supply only [`ref_count`] and [`destroy`]; the trait provides
+/// `ref_()`/`deref()` with the canonical inc/dec/destroy-at-zero logic.
 ///
 /// Use `#[derive(CellRefCounted)]` to derive this trait together with the
 /// [`AnyRefCounted`] bridge (so [`RefPtr`] accepts the type)
@@ -610,23 +598,15 @@ unsafe impl<T: AnyRefCounted + Send + Sync> Send for RefPtr<T> {}
 // SAFETY: see above.
 unsafe impl<T: AnyRefCounted + Send + Sync> Sync for RefPtr<T> {}
 
-/// Adopt the initial ref of a freshly constructed `T` (its embedded count
-/// starts at 1).
-impl<T: AnyRefCounted> From<Box<T>> for RefPtr<T> {
+impl<T: AnyRefCounted> RefPtr<T> {
+    /// Allocate `value` on the heap and own its initial ref (its embedded count
+    /// starts at 1).
     #[inline]
-    fn from(value: Box<T>) -> Self {
-        let ptr = bun_core::heap::into_raw_nn(value);
+    pub fn new(value: T) -> Self {
+        let ptr = bun_core::heap::into_raw_nn(Box::new(value));
         // SAFETY: freshly boxed, so live.
         debug_assert!(unsafe { T::rc_has_one_ref(ptr.as_ptr()) });
         Self(ptr)
-    }
-}
-
-impl<T: AnyRefCounted> RefPtr<T> {
-    /// Allocate `value` on the heap and own its initial ref.
-    #[inline]
-    pub fn new(value: T) -> Self {
-        Self::from(Box::new(value))
     }
 
     /// Take a new ref on `*raw_ptr`.
@@ -741,13 +721,13 @@ const MAGIC_VALID: u32 = 0x2f84_e51d;
 /// poisoned when the destructor runs, so a ref/deref through a dangling
 /// pointer asserts instead of silently corrupting the count.
 #[cfg(debug_assertions)]
-pub struct DebugData {
+struct DebugData {
     magic: u32,
 }
 
 #[cfg(debug_assertions)]
 impl DebugData {
-    pub(crate) const fn empty() -> Self {
+    const fn empty() -> Self {
         Self { magic: MAGIC_VALID }
     }
 
@@ -902,7 +882,7 @@ mod tests {
         let t = Thing::new(3);
         {
             // SAFETY: `t` is live; the guard's ref keeps it alive for the scope.
-            let _g = unsafe { RefPtr::init_ref(t) };
+            let _guard = unsafe { RefPtr::init_ref(t) };
             // SAFETY: two refs outstanding.
             assert_eq!(unsafe { (*RefCounted::get_ref_count(t)).get() }, 2);
         }

--- a/src/ptr/ref_count.rs
+++ b/src/ptr/ref_count.rs
@@ -58,8 +58,6 @@ fn type_base_name(name: &'static str) -> &'static str {
 
 /// Implemented by types that embed a [`RefCount`] field.
 pub trait RefCounted: Sized {
-    type DestructorCtx;
-
     /// Defaults to the type basename.
     fn debug_name() -> &'static str {
         type_base_name(core::any::type_name::<Self>())
@@ -82,7 +80,7 @@ pub trait RefCounted: Sized {
     ///
     /// # Safety
     /// `this` must point to a live `Self` with `raw_count == 0`.
-    unsafe fn destructor(this: *mut Self, ctx: Self::DestructorCtx);
+    unsafe fn destructor(this: *mut Self);
 }
 
 /// Implemented by types that embed a [`ThreadSafeRefCount`] field.
@@ -120,27 +118,12 @@ pub trait ThreadSafeRefCounted: Sized {
 
 /// Unifying trait so `RefPtr<T>` works with either ref-count flavor.
 pub trait AnyRefCounted: Sized {
-    type DestructorCtx;
-
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn rc_ref(this: *mut Self);
     /// # Safety
-    /// `this` must point to a live `Self`.
-    unsafe fn rc_deref_with_context(this: *mut Self, ctx: Self::DestructorCtx);
-    /// Forwards `Default::default()` as the ctx. Types with a non-unit
-    /// `DestructorCtx` must call `rc_deref_with_context` explicitly.
-    ///
-    /// # Safety
-    /// `this` must point to a live `Self`.
-    #[inline]
-    unsafe fn rc_deref(this: *mut Self)
-    where
-        Self::DestructorCtx: Default,
-    {
-        // SAFETY: caller contract — `this` points to a live Self.
-        unsafe { Self::rc_deref_with_context(this, Default::default()) }
-    }
+    /// `this` must point to a live `Self` and the caller must own one ref.
+    unsafe fn rc_deref(this: *mut Self);
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn rc_has_one_ref(this: *const Self) -> bool;
@@ -174,7 +157,6 @@ pub trait AnyRefCounted: Sized {
 pub fn finalize_js_box<T, F>(boxed: Box<T>, before: F)
 where
     T: AnyRefCounted,
-    T::DestructorCtx: Default,
     F: FnOnce(&T),
 {
     let ptr: *mut T = Box::into_raw(boxed);
@@ -188,11 +170,7 @@ where
 /// [`finalize_js_box`] with no pre-release work — just hands ownership back to
 /// the intrusive refcount and drops the JS wrapper's `+1`.
 #[inline]
-pub fn finalize_js_box_noop<T>(boxed: Box<T>)
-where
-    T: AnyRefCounted,
-    T::DestructorCtx: Default,
-{
+pub fn finalize_js_box_noop<T: AnyRefCounted>(boxed: Box<T>) {
     let ptr: *mut T = Box::into_raw(boxed);
     // SAFETY: `ptr` was just leaked from `Box`; ref_count >= 1.
     unsafe { T::rc_deref(ptr) };
@@ -214,11 +192,10 @@ where
 ///     other_field: u32,
 /// }
 /// impl RefCounted for Thing {
-///     type DestructorCtx = ();
 ///     unsafe fn get_ref_count(this: *mut Self) -> *mut RefCount<Self> {
 ///         unsafe { &raw mut (*this).ref_count }
 ///     }
-///     unsafe fn destructor(this: *mut Self, _: ()) {
+///     unsafe fn destructor(this: *mut Self) {
 ///         println!("deinit {}", unsafe { (*this).other_field });
 ///         drop(unsafe { heap::take(this) });
 ///     }
@@ -284,17 +261,7 @@ impl<T: RefCounted> RefCount<T> {
 
     /// # Safety
     /// `self_` must point to a live `T`.
-    pub unsafe fn deref(self_: *mut T)
-    where
-        T: RefCounted<DestructorCtx = ()>,
-    {
-        // SAFETY: caller contract
-        unsafe { Self::deref_with_context(self_, ()) }
-    }
-
-    /// # Safety
-    /// `self_` must point to a live `T`.
-    pub(crate) unsafe fn deref_with_context(self_: *mut T, ctx: T::DestructorCtx) {
+    pub unsafe fn deref(self_: *mut T) {
         // SAFETY: caller contract
         let count = unsafe { &*T::get_ref_count(self_) };
         #[cfg(debug_assertions)]
@@ -320,7 +287,7 @@ impl<T: RefCounted> RefCount<T> {
                 unsafe { (*T::get_ref_count(self_)).debug.deinit(return_address()) };
             }
             // SAFETY: raw_count == 0, sole owner
-            unsafe { T::destructor(self_, ctx) };
+            unsafe { T::destructor(self_) };
         }
     }
 
@@ -353,15 +320,13 @@ impl<T: RefCounted> RefCount<T> {
 }
 
 impl<T: RefCounted> AnyRefCounted for T {
-    type DestructorCtx = <T as RefCounted>::DestructorCtx;
-
     unsafe fn rc_ref(this: *mut Self) {
         // SAFETY: caller contract — `this` points to a live T
         unsafe { RefCount::<T>::ref_(this) }
     }
-    unsafe fn rc_deref_with_context(this: *mut Self, ctx: Self::DestructorCtx) {
+    unsafe fn rc_deref(this: *mut Self) {
         // SAFETY: caller contract — `this` points to a live T
-        unsafe { RefCount::<T>::deref_with_context(this, ctx) }
+        unsafe { RefCount::<T>::deref(this) }
     }
     unsafe fn rc_has_one_ref(this: *const Self) -> bool {
         // SAFETY: caller contract — `this` points to a live T
@@ -542,7 +507,7 @@ impl<T: ThreadSafeRefCounted> ThreadSafeRefCount<T> {
 /// the canonical inc/dec/destroy-at-zero logic.
 ///
 /// Use `#[derive(CellRefCounted)]` to derive this trait together with the
-/// [`AnyRefCounted`] bridge (so [`RefPtr`] / [`ScopedRef`] accept the type)
+/// [`AnyRefCounted`] bridge (so [`RefPtr`] accepts the type)
 /// and inherent `ref_()`/`deref()` forwarders (so existing call sites that
 /// invoke them as inherent methods keep compiling without importing the
 /// trait).
@@ -705,38 +670,36 @@ pub fn noop_debug_data() -> *mut dyn DebugDataOps {
 // RefPtr
 // ──────────────────────────────────────────────────────────────────────────
 
-/// A pointer to an object implementing `RefCount` or `ThreadSafeRefCount`.
-/// The benefit of this over `*mut T` is that instances of `RefPtr` are tracked.
+/// An owned strong reference to an intrusively refcounted `T` (`RefCount`,
+/// `ThreadSafeRefCount`, or `CellRefCounted`).
 ///
-/// By using this, you gain the following memory debugging tools:
+/// Holding a `RefPtr` *is* holding one ref: `Drop` releases it (destroying `T`
+/// if it was the last), `Clone` takes another. To hand the ref to a raw-pointer
+/// consumer (C++ `m_ctx`, a uws/libuv userdata slot) use
+/// [`into_raw`](Self::into_raw) and reclaim it later with
+/// [`from_raw`](Self::from_raw).
 ///
-/// - `T.ref_count.dump_active_refs()` to dump all active references.
-///
-/// If you want to enforce usage of RefPtr for memory management, you
-/// can remove the forwarded `ref` and `deref` methods from `RefCount`.
-///
-/// # ⚠️ No `Drop` impl — the owned ref must be released *manually*
-///
-/// `RefPtr` does **not** implement `Drop`: dropping a `RefPtr`
-/// value — including `Option::take()`-then-drop, or letting a struct field
-/// holding one go out of scope — **leaks** the strong ref it owns. On every
-/// path that gives up a `RefPtr` you must explicitly call one of:
-///
-/// - [`deref`](Self::deref) / [`deref_with_context`](Self::deref_with_context)
-///   — release the ref (and destroy `T` if it was the last);
-/// - [`leak`](Self::leak) / [`into_raw`](Self::into_raw) — hand the ref off to
-///   someone else (the inverse of [`from_raw`](Self::from_raw)).
-///
-/// Any new struct field of `RefPtr<T>` type must document, at the field site,
-/// which of its owners' methods discharges this obligation. (Newtypes like
-/// `CookieMapRef` wrap a single owned ref *and* implement `Drop` themselves —
-/// `RefPtr` itself does not.)
-///
-/// See [`RefCount`]'s comment for examples & best practices.
+/// In debug builds every `RefPtr` is tracked in `T`'s `DebugData`, so
+/// `T.ref_count.dump_active_refs()` lists the acquisition site of each live one.
+#[must_use = "dropping a RefPtr releases its ref"]
 pub struct RefPtr<T: AnyRefCounted> {
-    pub data: NonNull<T>,
+    data: NonNull<T>,
     #[cfg(debug_assertions)]
     debug: TrackedRefId,
+}
+
+impl<T: AnyRefCounted> Drop for RefPtr<T> {
+    #[inline]
+    fn drop(&mut self) {
+        let ptr = self.data.as_ptr();
+        #[cfg(debug_assertions)]
+        {
+            // SAFETY: we still own a ref, so `ptr` is live.
+            unsafe { (*T::rc_debug_data(ptr)).release(self.debug, return_address()) };
+        }
+        // SAFETY: we own a ref, so `ptr` is live; this releases it.
+        unsafe { T::rc_deref(ptr) };
+    }
 }
 
 impl<T: AnyRefCounted> RefPtr<T> {
@@ -749,33 +712,6 @@ impl<T: AnyRefCounted> RefPtr<T> {
         unsafe { T::rc_ref(raw_ptr) };
         // SAFETY: caller contract
         unsafe { Self::unchecked_and_unsafe_init(raw_ptr, return_address()) }
-    }
-
-    // NOTE: would be nice to use a const for deref dispatch, but keep two
-    // methods for clarity.
-
-    /// Decrement the reference count, and destroy the object if the count is 0.
-    pub fn deref(&self)
-    where
-        T::DestructorCtx: Default,
-    {
-        self.deref_with_context(Default::default());
-    }
-
-    /// Decrement the reference count, and destroy the object if the count is 0.
-    pub(crate) fn deref_with_context(&self, ctx: T::DestructorCtx) {
-        #[cfg(debug_assertions)]
-        {
-            // SAFETY: data is live (we hold a ref)
-            unsafe { (*T::rc_debug_data(self.as_ptr())).release(self.debug, return_address()) };
-        }
-        // SAFETY: data is live (we hold a ref)
-        unsafe { T::rc_deref_with_context(self.as_ptr(), ctx) };
-        // The handle is not poisoned after release: that would require
-        // mutating through `&self` (UnsafeCell), and `&self` is load-bearing
-        // here: hundreds of call sites (including Drop impls and ScopedRef)
-        // deref through a borrow they cannot move out of, so a by-value
-        // signature is not an option.
     }
 
     pub fn dupe_ref(&self) -> Self {
@@ -840,25 +776,34 @@ impl<T: AnyRefCounted> RefPtr<T> {
     /// WITHOUT incrementing the refcount. The caller gives up their ref;
     /// this RefPtr now owns it. Unlike `adopt_ref`, this does not assert
     /// `has_one_ref()` — the pointer may have other outstanding refs.
-    /// This is the inverse of `leak()` / `into_raw()`.
-    ///
-    /// Std-conventional alias for [`take_ref`] (matches `Arc::from_raw` /
-    /// `Rc::from_raw` semantics) so call sites that reach for the idiomatic
-    /// Rust name compile without churn.
+    /// Inverse of [`into_raw`](Self::into_raw) (`Arc::from_raw` semantics).
     ///
     /// # Safety
     /// `raw_ptr` must point to a live `T` and the caller must own one ref.
     #[inline]
     pub unsafe fn from_raw(raw_ptr: *mut T) -> Self {
-        // SAFETY: forwarded caller contract
-        unsafe { Self::take_ref(raw_ptr) }
+        #[cfg(debug_assertions)]
+        {
+            // SAFETY: caller contract
+            unsafe { (*T::rc_debug_data(raw_ptr)).assert_valid_dyn() };
+        }
+        // SAFETY: caller contract
+        unsafe { Self::unchecked_and_unsafe_init(raw_ptr, return_address()) }
     }
 
-    /// Std-conventional alias for [`leak`]. Extract the raw pointer, giving up
-    /// ownership WITHOUT decrementing the refcount. Inverse of [`from_raw`].
+    /// Extract the raw pointer, giving up ownership WITHOUT decrementing the
+    /// refcount; whoever holds the pointer now owns the ref. Inverse of
+    /// [`from_raw`](Self::from_raw) (`Arc::into_raw` semantics).
     #[inline]
     pub fn into_raw(self) -> *mut T {
-        self.leak()
+        let this = core::mem::ManuallyDrop::new(self);
+        let ptr = this.data.as_ptr();
+        #[cfg(debug_assertions)]
+        {
+            // SAFETY: data is live (we hold a ref)
+            unsafe { (*T::rc_debug_data(ptr)).release(this.debug, return_address()) };
+        }
+        ptr
     }
 
     /// Borrow the inner `*mut T` without affecting the refcount (analogous to
@@ -877,10 +822,12 @@ impl<T: AnyRefCounted> RefPtr<T> {
         self.data.as_ptr()
     }
 
-    /// Borrow the pointee immutably. Named accessor equivalent to
-    /// `<RefPtr<T> as Deref>::deref` — provided so call sites can be explicit
-    /// (the inherent `RefPtr::deref` *decrements the refcount*, so `r.deref()`
-    /// is not the borrow you want).
+    #[inline]
+    pub fn as_non_null(&self) -> NonNull<T> {
+        self.data
+    }
+
+    /// Borrow the pointee (same as `<RefPtr<T> as Deref>::deref`).
     #[inline]
     pub fn data(&self) -> &T {
         // SAFETY: holding a `RefPtr` means we own at least one ref, so the
@@ -888,40 +835,6 @@ impl<T: AnyRefCounted> RefPtr<T> {
         // !Send/!Sync so no concurrent mutation; thread-safe hosts coordinate
         // their own interior mutability.
         unsafe { self.data.as_ref() }
-    }
-
-    /// Wrap a raw pointer whose ref is being transferred to this RefPtr
-    /// WITHOUT incrementing the refcount. The caller gives up their ref;
-    /// this RefPtr now owns it. Unlike `adopt_ref`, this does not assert
-    /// `has_one_ref()` — the pointer may have other outstanding refs.
-    /// This is the inverse of `leak()`.
-    ///
-    /// # Safety
-    /// `raw_ptr` must point to a live `T` and the caller must own one ref.
-    pub(crate) unsafe fn take_ref(raw_ptr: *mut T) -> Self {
-        #[cfg(debug_assertions)]
-        {
-            // SAFETY: caller contract
-            unsafe { (*T::rc_debug_data(raw_ptr)).assert_valid_dyn() };
-        }
-        // SAFETY: caller contract
-        unsafe { Self::unchecked_and_unsafe_init(raw_ptr, return_address()) }
-    }
-
-    /// Extract the raw pointer, giving up ownership WITHOUT decrementing
-    /// the refcount. The caller is responsible for the ref that this
-    /// RefPtr was holding. After calling this, the RefPtr is invalid
-    /// and must not be used. This is the inverse of `take_ref()`.
-    pub fn leak(self) -> *mut T {
-        let ptr = self.data.as_ptr();
-        #[cfg(debug_assertions)]
-        {
-            // mark debug tracking as released without actually derefing
-            // SAFETY: data is live (we hold a ref)
-            unsafe { (*T::rc_debug_data(ptr)).release(self.debug, return_address()) };
-        }
-        // Taking `self` by value makes the RefPtr unusable afterwards.
-        ptr
     }
 
     /// # Safety
@@ -952,72 +865,6 @@ impl<T: AnyRefCounted> core::ops::Deref for RefPtr<T> {
     #[inline]
     fn deref(&self) -> &T {
         self.data()
-    }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// ScopedRef
-// ──────────────────────────────────────────────────────────────────────────
-
-/// RAII scope guard for an intrusive refcount: bumps on construction, derefs
-/// on `Drop`. Use to bracket a `ref_()`/`deref()` pair that protects `*T`
-/// across a re-entrant call.
-///
-/// Unlike [`RefPtr`] this is not a smart-pointer handle (no `Deref`, not
-/// stored in fields) — it exists solely so the paired deref runs on every
-/// exit path. Requires `DestructorCtx: Default` (the common unit case).
-#[must_use = "dropping immediately releases the ref"]
-pub struct ScopedRef<T: AnyRefCounted>(NonNull<T>)
-where
-    T::DestructorCtx: Default;
-
-impl<T: AnyRefCounted> ScopedRef<T>
-where
-    T::DestructorCtx: Default,
-{
-    /// Bump the intrusive refcount and return a guard that derefs on `Drop`.
-    ///
-    /// # Safety
-    /// `ptr` must point to a live `T` and remain a valid allocation until the
-    /// guard is dropped (the guard's own ref keeps it alive past that point).
-    #[inline]
-    pub unsafe fn new(ptr: *mut T) -> Self {
-        // SAFETY: caller contract — `ptr` is live.
-        unsafe { T::rc_ref(ptr) };
-        // SAFETY: caller contract — `ptr` is non-null.
-        Self(unsafe { NonNull::new_unchecked(ptr) })
-    }
-
-    /// Adopt an already-held ref: does **not** bump on construction, but still
-    /// derefs on `Drop`. Use when the matching `ref()` was taken earlier (e.g.
-    /// by an in-flight async op) and this scope is responsible for releasing
-    /// it.
-    ///
-    /// # Safety
-    /// `ptr` must point to a live `T` for which the caller owns one outstanding
-    /// ref that this guard will consume.
-    #[inline]
-    pub unsafe fn adopt(ptr: *mut T) -> Self {
-        // SAFETY: caller contract — `ptr` is non-null and live.
-        Self(unsafe { NonNull::new_unchecked(ptr) })
-    }
-
-    /// Defuse the guard without derefing, handing the ref to whatever adopts
-    /// it next. Inverse of [`adopt`](Self::adopt).
-    #[inline]
-    pub fn forget(self) {
-        let _ = core::mem::ManuallyDrop::new(self);
-    }
-}
-
-impl<T: AnyRefCounted> Drop for ScopedRef<T>
-where
-    T::DestructorCtx: Default,
-{
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: `new` took a ref, so the pointee is live until this deref.
-        unsafe { T::rc_deref(self.0.as_ptr()) };
     }
 }
 
@@ -1204,13 +1051,12 @@ mod tests {
     }
 
     impl RefCounted for Thing {
-        type DestructorCtx = ();
         unsafe fn get_ref_count(this: *mut Self) -> *mut RefCount<Self> {
             // SAFETY: caller contract — `this` is in-bounds of a `Thing`
             // allocation. Pure field projection, no read.
             unsafe { &raw mut (*this).ref_count }
         }
-        unsafe fn destructor(this: *mut Self, _: ()) {
+        unsafe fn destructor(this: *mut Self) {
             // SAFETY: caller contract — refcount hit zero, sole owner.
             drop(unsafe { bun_core::heap::take(this) });
         }
@@ -1266,27 +1112,27 @@ mod tests {
         let r = p.clone();
         assert_eq!(p.as_ptr(), q.as_ptr());
         assert_eq!(p.as_ptr(), r.as_ptr());
-        r.deref();
-        q.deref();
+        drop(r);
+        drop(q);
         assert_eq!(drops(), before);
 
-        // `leak` hands the ref off without decrementing; `from_raw` takes it back.
-        let raw = p.leak();
+        // `into_raw` hands the ref off without decrementing; `from_raw` takes it back.
+        let raw = p.into_raw();
         // SAFETY: `raw` still owns the ref `p` gave up.
         let p = unsafe { RefPtr::from_raw(raw) };
         assert_eq!(*p.payload, 42);
-        p.deref();
+        drop(p);
         assert_eq!(drops(), before + 1);
     }
 
     #[test]
-    fn scoped_ref_releases_on_drop() {
+    fn ref_ptr_init_ref_releases_on_drop() {
         let _serial = serial();
         let before = drops();
         let t = Thing::new(3);
         {
             // SAFETY: `t` is live; the guard's ref keeps it alive for the scope.
-            let _g = unsafe { ScopedRef::new(t) };
+            let _g = unsafe { RefPtr::init_ref(t) };
             // SAFETY: two refs outstanding.
             assert_eq!(unsafe { (*RefCounted::get_ref_count(t)).get() }, 2);
         }
@@ -1298,12 +1144,12 @@ mod tests {
     }
 
     #[test]
-    fn scoped_ref_adopt_consumes_caller_ref() {
+    fn ref_ptr_from_raw_consumes_caller_ref() {
         let _serial = serial();
         let before = drops();
         let t = Thing::new(3);
-        // SAFETY: `t` is live and we own the one ref the guard will consume.
-        drop(unsafe { ScopedRef::adopt(t) });
+        // SAFETY: `t` is live and we own the one ref the RefPtr will consume.
+        drop(unsafe { RefPtr::from_raw(t) });
         assert_eq!(drops(), before + 1);
     }
 

--- a/src/ptr/weak_ptr.rs
+++ b/src/ptr/weak_ptr.rs
@@ -107,15 +107,6 @@ impl<T: HasWeakPtrData> WeakPtr<T> {
         }
     }
 
-    /// Release this handle's weak ref now (idempotent; `Drop` does the same).
-    pub fn deref(&mut self) {
-        if let Some(value) = self.raw_ptr {
-            // SAFETY: `raw_ptr` was set by `init_ref` and not yet released;
-            // the allocation outlives all `WeakPtr`s by construction.
-            unsafe { self.deref_internal(value) };
-        }
-    }
-
     /// Borrow the pointee, or `None` once the owner has finalized it (which
     /// also releases this handle's weak ref).
     ///
@@ -158,7 +149,11 @@ impl<T: HasWeakPtrData> WeakPtr<T> {
 
 impl<T: HasWeakPtrData> Drop for WeakPtr<T> {
     fn drop(&mut self) {
-        self.deref();
+        if let Some(value) = self.raw_ptr {
+            // SAFETY: `raw_ptr` was set by `init_ref` and not yet released;
+            // the allocation outlives all `WeakPtr`s by construction.
+            unsafe { self.deref_internal(value) };
+        }
     }
 }
 
@@ -272,7 +267,7 @@ mod tests {
         assert_eq!(drops(), before + 1);
         // The handle is now empty: a second `get`/`deref` must be a no-op.
         assert!(weak.get().is_none());
-        weak.deref();
+        drop(weak);
     }
 
     /// `deref` before finalize leaves the allocation to the owner.
@@ -282,8 +277,8 @@ mod tests {
         let before = drops();
         let raw = new_owner(6);
         // SAFETY: `raw` is a freshly leaked Box; live and not finalized.
-        let mut weak = unsafe { WeakPtr::init_ref(raw) };
-        weak.deref();
+        let weak = unsafe { WeakPtr::init_ref(raw) };
+        drop(weak);
         assert_eq!(drops(), before);
         // SAFETY: no weak refs remain; the owner frees its own allocation.
         drop(unsafe { bun_core::heap::take(raw) });
@@ -309,7 +304,7 @@ mod tests {
             assert_eq!(weak.get().map(|o| o.payload), Some(i));
         }
 
-        weak.deref();
+        drop(weak);
         // SAFETY: no weak refs remain.
         drop(unsafe { bun_core::heap::take(raw) });
         assert_eq!(drops(), before + 1);
@@ -334,9 +329,9 @@ mod tests {
 
         // SAFETY: `raw` is live.
         assert!(!unsafe { (*Owner::weak_ptr_data(raw)).on_finalize() });
-        a.deref();
+        drop(a);
         assert_eq!(drops(), before);
-        b.deref();
+        drop(b);
         assert_eq!(drops(), before + 1);
     }
 }

--- a/src/ptr/weak_ptr.rs
+++ b/src/ptr/weak_ptr.rs
@@ -107,6 +107,7 @@ impl<T: HasWeakPtrData> WeakPtr<T> {
         }
     }
 
+    /// Release this handle's weak ref now (idempotent; `Drop` does the same).
     pub fn deref(&mut self) {
         if let Some(value) = self.raw_ptr {
             // SAFETY: `raw_ptr` was set by `init_ref` and not yet released;
@@ -152,6 +153,12 @@ impl<T: HasWeakPtrData> WeakPtr<T> {
             // is dead here, so freeing through `value` disturbs no live borrow.
             drop(unsafe { bun_core::heap::take(value.as_ptr()) });
         }
+    }
+}
+
+impl<T: HasWeakPtrData> Drop for WeakPtr<T> {
+    fn drop(&mut self) {
+        self.deref();
     }
 }
 

--- a/src/ptr/weak_ptr.rs
+++ b/src/ptr/weak_ptr.rs
@@ -73,13 +73,10 @@ pub trait HasWeakPtrData {
 /// `heap::into_raw`), which is why [`init_ref`](Self::init_ref) takes `*mut T`
 /// rather than `&mut T`. Deriving it from a `&mut T` reborrow instead makes the
 /// next write through any *other* pointer to the object a foreign write that
-/// invalidates the handle, so every later `get`/`deref` is UB. This mirrors
+/// invalidates the handle, so every later `get` or drop is UB. This mirrors
 /// [`ThisPtr::new`](crate::ThisPtr::new) and
 /// [`ParentRef::from_raw_mut`](crate::ParentRef::from_raw_mut).
 pub struct WeakPtr<T: HasWeakPtrData> {
-    // Intentionally a raw pointer, not `std::sync::Weak<T>`: this file *is*
-    // the definition of the intrusive weak pointer, with liveness tracked by
-    // the embedded `WeakPtrData` and manual ref/deref.
     raw_ptr: Option<NonNull<T>>,
 }
 
@@ -265,14 +262,14 @@ mod tests {
         // is the last ref, so `deref_internal` frees the allocation.
         assert!(weak.get().is_none());
         assert_eq!(drops(), before + 1);
-        // The handle is now empty: a second `get`/`deref` must be a no-op.
+        // The handle is now empty: a second `get` or the drop must be a no-op.
         assert!(weak.get().is_none());
         drop(weak);
     }
 
-    /// `deref` before finalize leaves the allocation to the owner.
+    /// Dropping before finalize leaves the allocation to the owner.
     #[test]
-    fn weak_ptr_deref_before_finalize_leaves_owner_in_charge() {
+    fn weak_ptr_drop_before_finalize_leaves_owner_in_charge() {
         let _serial = serial();
         let before = drops();
         let raw = new_owner(6);

--- a/src/runtime/allocators/LinuxMemFdAllocator.rs
+++ b/src/runtime/allocators/LinuxMemFdAllocator.rs
@@ -249,10 +249,9 @@ impl LinuxMemFdAllocator {
             }
         }
 
-        // `Self::new` returns refcount=1; `into_raw()` extracts the
-        // `heap::alloc` pointer and transfers the +1 to us (RefPtr has no
-        // `Drop`). On `Ok` that ref moves into `res.allocator`; on `Err`
-        // we `deref` it explicitly.
+        // `Self::new` returns refcount=1; `into_raw()` transfers that +1 to
+        // us. On `Ok` it moves into `res.allocator`; on `Err` we `deref` it
+        // explicitly.
         let memfd: *mut Self = Self::new(fd, bytes.len()).into_raw();
 
         // SAFETY: `memfd` is the `heap::alloc` pointer

--- a/src/runtime/allocators/LinuxMemFdAllocator.rs
+++ b/src/runtime/allocators/LinuxMemFdAllocator.rs
@@ -249,22 +249,13 @@ impl LinuxMemFdAllocator {
             }
         }
 
-        // `Self::new` returns refcount=1; `into_raw()` transfers that +1 to
-        // us. On `Ok` it moves into `res.allocator`; on `Err` we `deref` it
-        // explicitly.
-        let memfd: *mut Self = Self::new(fd, bytes.len()).into_raw();
-
-        // SAFETY: `memfd` is the `heap::alloc` pointer
-        // (full provenance) with one live ref — required by `Self::alloc`.
-        match unsafe { Self::alloc(memfd, bytes.len(), 0, libc::MAP_SHARED) } {
-            Ok(res) => Ok(res),
-            Err(err) => {
-                // SAFETY: we still own the +1 from `into_raw()`; release it
-                // (closes the fd and frees the Box on hitting zero).
-                unsafe { Self::deref(memfd) };
-                Err(err)
-            }
-        }
+        let memfd = Self::new(fd, bytes.len());
+        // SAFETY: `memfd` is the `heap::alloc` pointer (full provenance) with
+        // one live ref — required by `Self::alloc`.
+        let res = unsafe { Self::alloc(memfd.as_ptr(), bytes.len(), 0, libc::MAP_SHARED) }?;
+        // That ref now lives in `res.allocator`.
+        let _ = memfd.into_raw();
+        Ok(res)
     }
 }
 

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -34,8 +34,7 @@ pub(crate) struct GzipOptions {
 }
 
 // Hand-written JS class glue (not the `#[bun_jsc::JsClass]` derive): Archive
-// needs a custom `finalize` and no constructor, which the proc-macro does not
-// expose.
+// has no constructor, which the proc-macro does not expose.
 #[repr(C)]
 pub struct Archive {
     /// The underlying data for the archive - uses Blob.Store for thread-safe ref counting

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -176,7 +176,6 @@ impl Archive {
         // For Blob/Archive, ref the existing store (zero-copy)
         if let Some(blob) = blob_from_js(data_arg) {
             if let Some(store) = blob.store.get().as_ref() {
-                // RefPtr<Store>::clone == store.ref()
                 return Ok(Box::new(Archive {
                     store: store.clone(),
                     compress,

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -4,7 +4,7 @@ use std::ffi::CString;
 
 use crate::webcore::Blob;
 use crate::webcore::BlobExt as _;
-use crate::webcore::blob::{Store as BlobStore, StoreRef};
+use crate::webcore::blob::Store;
 use bun_core::{self, EncodedSlice, Output, Utf8Bytes, ZBox, strings};
 use bun_glob as glob;
 use bun_jsc::{
@@ -12,6 +12,7 @@ use bun_jsc::{
 };
 use bun_jsc::{EncodedSliceJsc as _, StringJsc as _, SysErrorJsc as _};
 use bun_libarchive as libarchive;
+use bun_ptr::RefPtr;
 use bun_sys::{self, Fd, FdDirExt as _, FdExt as _, Mode};
 
 /// libarchive `AE_IFREG` (== `S_IFREG`). The Rust `bun_libarchive::lib` port
@@ -38,15 +39,15 @@ pub(crate) struct GzipOptions {
 #[repr(C)]
 pub struct Archive {
     /// The underlying data for the archive - uses Blob.Store for thread-safe ref counting
-    store: StoreRef,
+    store: RefPtr<Store>,
     /// Compression settings for this archive
     compress: Compression,
 }
 
 impl Archive {
-    /// Borrow the backing `StoreRef`.
+    /// Borrow the backing `RefPtr<Store>`.
     #[inline]
-    pub(crate) fn store_ref(&self) -> &StoreRef {
+    pub(crate) fn store_ref(&self) -> &RefPtr<Store> {
         &self.store
     }
 }
@@ -63,12 +64,6 @@ impl Archive {
     #[inline]
     pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         self::write(global, callframe)
-    }
-
-    pub fn finalize(self: Box<Self>) {
-        jsc::mark_binding();
-        drop(self);
-        // store.deref() happens via Arc<BlobStore>::drop
     }
 
     /// Pretty-print for console.log
@@ -182,7 +177,7 @@ impl Archive {
         // For Blob/Archive, ref the existing store (zero-copy)
         if let Some(blob) = blob_from_js(data_arg) {
             if let Some(store) = blob.store.get().as_ref() {
-                // StoreRef::clone == store.ref()
+                // RefPtr<Store>::clone == store.ref()
                 return Ok(Box::new(Archive {
                     store: store.clone(),
                     compress,
@@ -267,7 +262,7 @@ fn parse_compression_options(
 }
 
 fn create_archive(data: Vec<u8>, compress: Compression) -> Box<Archive> {
-    let store = BlobStore::init(data);
+    let store = Store::init(data);
     Box::new(Archive { store, compress })
 }
 
@@ -719,7 +714,7 @@ pub enum ExtractResult {
 }
 
 pub struct ExtractContext {
-    store: StoreRef,
+    store: RefPtr<Store>,
     path: Box<[u8]>,
     glob_patterns: Option<Vec<Box<[u8]>>>,
     result: ExtractResult,
@@ -781,7 +776,7 @@ pub(crate) type ExtractTask = AsyncTask<ExtractContext>;
 
 fn start_extract_task(
     global: &JSGlobalObject,
-    store: &StoreRef,
+    store: &RefPtr<Store>,
     path: &[u8],
     glob_patterns: Option<Vec<Box<[u8]>>>,
 ) -> JsResult<JSValue> {
@@ -815,7 +810,7 @@ enum BlobResult {
 }
 
 pub struct BlobContext {
-    store: StoreRef,
+    store: RefPtr<Store>,
     compress: Compression,
     output_type: BlobOutputType,
     result: BlobResult,
@@ -881,7 +876,7 @@ pub(crate) type BlobTask = AsyncTask<BlobContext>;
 
 fn start_blob_task(
     global: &JSGlobalObject,
-    store: &StoreRef,
+    store: &RefPtr<Store>,
     compress: Compression,
     output_type: BlobOutputType,
 ) -> JsResult<JSValue> {
@@ -907,7 +902,7 @@ enum WriteResult {
 
 enum WriteData {
     Owned(Vec<u8>),
-    Store(StoreRef),
+    Store(RefPtr<Store>),
 }
 
 pub struct WriteContext {
@@ -1016,7 +1011,7 @@ enum FilesResult {
 // freeEntries deleted — Vec<FileEntry> drops each entry; FileEntry fields drop their boxes.
 
 pub struct FilesContext {
-    store: StoreRef,
+    store: RefPtr<Store>,
     glob_patterns: Option<Vec<Box<[u8]>>>,
     result: FilesResult,
 }
@@ -1165,7 +1160,7 @@ pub(crate) type FilesTask = AsyncTask<FilesContext>;
 
 fn start_files_task(
     global: &JSGlobalObject,
-    store: &StoreRef,
+    store: &RefPtr<Store>,
     glob_patterns: Option<Vec<Box<[u8]>>>,
 ) -> JsResult<JSValue> {
     let store = store.clone();

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2901,9 +2901,7 @@ mod stdio_stores {
             Ok(stat) => stat.st_mode as bun_sys::Mode,
             Err(_) => 0,
         };
-        // NOTE: with `RefPtr<Store>` (intrusive RAII) the slot is +1 and
-        // the Blob takes its own +1 via `clone()`.
-        let store = Store::new(Store {
+        RefPtr::new(Store {
             data: Data::File(FileStore {
                 pathlike: PathOrFileDescriptor::Fd(fd),
                 is_atty: Some(is_atty),
@@ -2913,8 +2911,7 @@ mod stdio_stores {
             mime_type: bun_http_types::MimeType::NONE,
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
             is_all_ascii: None,
-        });
-        RefPtr::from(store)
+        })
     }
 
     fn make_blob(

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2881,26 +2881,27 @@ pub mod JSZstd {
 // crate and can't move down without dragging `node::PathLike`/S3/aio. The
 // stores exist purely for per-VM lazy init; that is per-thread
 // in practice (`VirtualMachine::get()` is thread-local), so cache the
-// `StoreRef`s here.
+// `RefPtr<Store>`s here.
 mod stdio_stores {
     use super::*;
     use crate::node::types::PathOrFileDescriptor;
     use crate::webcore::blob::store::{Data, File as FileStore};
-    use crate::webcore::blob::{Blob, BlobExt as _, Store, StoreRef};
+    use crate::webcore::blob::{Blob, BlobExt as _, Store};
+    use bun_ptr::RefPtr;
 
     thread_local! {
-        static STDIN: core::cell::RefCell<Option<StoreRef>> = const { core::cell::RefCell::new(None) };
-        static STDOUT: core::cell::RefCell<Option<StoreRef>> = const { core::cell::RefCell::new(None) };
-        static STDERR: core::cell::RefCell<Option<StoreRef>> = const { core::cell::RefCell::new(None) };
+        static STDIN: core::cell::RefCell<Option<RefPtr<Store>>> = const { core::cell::RefCell::new(None) };
+        static STDOUT: core::cell::RefCell<Option<RefPtr<Store>>> = const { core::cell::RefCell::new(None) };
+        static STDERR: core::cell::RefCell<Option<RefPtr<Store>>> = const { core::cell::RefCell::new(None) };
     }
 
-    fn build_store(uv_fd: i32, is_atty: bool) -> StoreRef {
+    fn build_store(uv_fd: i32, is_atty: bool) -> RefPtr<Store> {
         let fd = bun_sys::Fd::from_uv(uv_fd);
         let mode: bun_sys::Mode = match bun_sys::fstat(fd) {
             Ok(stat) => stat.st_mode as bun_sys::Mode,
             Err(_) => 0,
         };
-        // NOTE: with `StoreRef` (intrusive RAII) the slot is +1 and
+        // NOTE: with `RefPtr<Store>` (intrusive RAII) the slot is +1 and
         // the Blob takes its own +1 via `clone()`.
         let store = Store::new(Store {
             data: Data::File(FileStore {
@@ -2913,12 +2914,12 @@ mod stdio_stores {
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
             is_all_ascii: None,
         });
-        StoreRef::from(store)
+        RefPtr::from(store)
     }
 
     fn make_blob(
         global_this: &JSGlobalObject,
-        slot: &'static std::thread::LocalKey<core::cell::RefCell<Option<StoreRef>>>,
+        slot: &'static std::thread::LocalKey<core::cell::RefCell<Option<RefPtr<Store>>>>,
         uv_fd: i32,
         is_atty: bool,
         feature: &'static core::sync::atomic::AtomicUsize,

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -49,7 +49,7 @@ pub struct JSTranspiler {
     // address is stable across the move into `Box<JSTranspiler>` —
     // `transpiler.arena` holds a `&'static Arena` pointing into it.
     pub arena: Box<Arena>,
-    // Intrusive refcount field for `bun_ptr::IntrusiveRc<JSTranspiler>`:
+    // Intrusive refcount field for `bun_ptr::RefPtr<JSTranspiler>`:
     // single-thread intrusive `bun.ptr.RefCount` because `*JSTranspiler`
     // crosses FFI as `m_ctx` (per PORTING.md §Pointers; not `Arc`).
     pub(crate) ref_count: bun_ptr::RefCount<JSTranspiler>,
@@ -1087,7 +1087,7 @@ impl Drop for JSTranspiler {
         // buffer_writer.?.buffer.deinit() → Option<BufferWriter>: Drop
         // config.tsconfig.deinit() → Option<Box<TSConfigJSON>>: Drop
         // arena.deinit() → Arena: Drop
-        // bun.destroy(this) → handled by Box owner / IntrusiveRc.
+        // bun.destroy(this) → handled by Box owner / RefPtr.
     }
 }
 

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -49,9 +49,6 @@ pub struct JSTranspiler {
     // address is stable across the move into `Box<JSTranspiler>` —
     // `transpiler.arena` holds a `&'static Arena` pointing into it.
     pub arena: Box<Arena>,
-    // Intrusive refcount field for `bun_ptr::RefPtr<JSTranspiler>`:
-    // single-thread intrusive `bun.ptr.RefCount` because `*JSTranspiler`
-    // crosses FFI as `m_ctx` (per PORTING.md §Pointers; not `Arc`).
     pub(crate) ref_count: bun_ptr::RefCount<JSTranspiler>,
 }
 
@@ -1087,7 +1084,6 @@ impl Drop for JSTranspiler {
         // buffer_writer.?.buffer.deinit() → Option<BufferWriter>: Drop
         // config.tsconfig.deinit() → Option<Box<TSConfigJSON>>: Drop
         // arena.deinit() → Arena: Drop
-        // bun.destroy(this) → handled by Box owner / RefPtr.
     }
 }
 

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -89,11 +89,8 @@ pub mod js {
 /// 2. Reader (released in onReaderDone/onReaderError)
 /// 3. Writer (released in onWriterClose)
 ///
-// `bun.ptr.RefCount` is intrusive single-thread → `bun_ptr::RefPtr<Terminal>`.
-// Never `Rc`/`Arc` here: `*mut Terminal` crosses FFI as the `.classes.ts` m_ctx
-// payload and is recovered by raw pointer in finalize/host fns. (LIFETIMES.tsv
-// marks CreateResult.terminal as SHARED, but the RefCount→RefPtr rule wins;
-// the TSV row is for plain `*T` fields, not intrusive mixins.)
+// Intrusive refcount, not `Rc`/`Arc`: `*mut Terminal` crosses FFI as the
+// `.classes.ts` m_ctx payload and is recovered by raw pointer in finalize/host fns.
 //
 // `no_construct, no_finalize`: this class uses `constructNeedsThis: true` (3-arg
 // constructor) and intrusive refcounting (finalize → deref, not heap::take),
@@ -301,8 +298,6 @@ impl Options {
 
 /// Result from creating a Terminal
 pub(crate) struct CreateResult {
-    // Intrusive single-thread refcount that crosses FFI as `*mut Terminal`; see
-    // ref_count comment on `Terminal` for why this is not `Arc`.
     pub terminal: bun_ptr::RefPtr<Terminal>,
     pub js_value: JSValue,
 }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -11,6 +11,7 @@
 
 use core::cell::Cell;
 use core::ffi::{c_int, c_void};
+use core::ptr::NonNull;
 #[cfg(windows)]
 use core::sync::atomic::{AtomicU32, Ordering};
 
@@ -298,7 +299,8 @@ impl Options {
 
 /// Result from creating a Terminal
 pub(crate) struct CreateResult {
-    pub terminal: bun_ptr::RefPtr<Terminal>,
+    /// The new terminal; its initial ref belongs to the JS wrapper (`js_value`).
+    pub terminal: NonNull<Terminal>,
     pub js_value: JSValue,
 }
 
@@ -539,9 +541,8 @@ impl Terminal {
         }
 
         Ok(CreateResult {
-            // SAFETY: `parent_ptr` is the heap-allocated allocation above with
-            // ref_count >= 1; RefPtr::from_raw adopts one existing ref.
-            terminal: unsafe { bun_ptr::RefPtr::from_raw(parent_ptr) },
+            // SAFETY: `heap::into_raw` is never null.
+            terminal: unsafe { NonNull::new_unchecked(parent_ptr) },
             js_value: this_value,
         })
     }
@@ -571,7 +572,7 @@ impl Terminal {
             Ok(result) => {
                 // Hand the intrusive ref to the JS wrapper as m_ctx; finalize()
                 // releases it via deref_().
-                Ok(bun_ptr::RefPtr::into_raw(result.terminal))
+                Ok(result.terminal.as_ptr())
             }
             Err(err) => Err(match err {
                 InitError::OpenPtyFailed => global_object.throw(format_args!("Failed to open PTY")),

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -89,10 +89,10 @@ pub mod js {
 /// 2. Reader (released in onReaderDone/onReaderError)
 /// 3. Writer (released in onWriterClose)
 ///
-// `bun.ptr.RefCount` is intrusive single-thread → `bun_ptr::IntrusiveRc<Terminal>`.
+// `bun.ptr.RefCount` is intrusive single-thread → `bun_ptr::RefPtr<Terminal>`.
 // Never `Rc`/`Arc` here: `*mut Terminal` crosses FFI as the `.classes.ts` m_ctx
 // payload and is recovered by raw pointer in finalize/host fns. (LIFETIMES.tsv
-// marks CreateResult.terminal as SHARED, but the RefCount→IntrusiveRc rule wins;
+// marks CreateResult.terminal as SHARED, but the RefCount→RefPtr rule wins;
 // the TSV row is for plain `*T` fields, not intrusive mixins.)
 //
 // `no_construct, no_finalize`: this class uses `constructNeedsThis: true` (3-arg
@@ -303,7 +303,7 @@ impl Options {
 pub(crate) struct CreateResult {
     // Intrusive single-thread refcount that crosses FFI as `*mut Terminal`; see
     // ref_count comment on `Terminal` for why this is not `Arc`.
-    pub terminal: bun_ptr::IntrusiveRc<Terminal>,
+    pub terminal: bun_ptr::RefPtr<Terminal>,
     pub js_value: JSValue,
 }
 
@@ -412,7 +412,7 @@ impl Terminal {
         let pty_result = create_pty(options.cols, options.rows)?;
 
         // Heap-allocate the Terminal; the intrusive ref_count
-        // field starts at 1 (JS side's ref). Wrapped as IntrusiveRc on success.
+        // field starts at 1 (JS side's ref). Wrapped as RefPtr on success.
         let terminal: *mut Terminal = bun_core::heap::into_raw(Box::new(Terminal {
             ref_count: bun_ptr::RefCount::init(),
             master_fd: Cell::new(pty_result.master),
@@ -545,8 +545,8 @@ impl Terminal {
 
         Ok(CreateResult {
             // SAFETY: `parent_ptr` is the heap-allocated allocation above with
-            // ref_count >= 1; IntrusiveRc::from_raw adopts one existing ref.
-            terminal: unsafe { bun_ptr::IntrusiveRc::from_raw(parent_ptr) },
+            // ref_count >= 1; RefPtr::from_raw adopts one existing ref.
+            terminal: unsafe { bun_ptr::RefPtr::from_raw(parent_ptr) },
             js_value: this_value,
         })
     }
@@ -576,7 +576,7 @@ impl Terminal {
             Ok(result) => {
                 // Hand the intrusive ref to the JS wrapper as m_ctx; finalize()
                 // releases it via deref_().
-                Ok(bun_ptr::IntrusiveRc::into_raw(result.terminal))
+                Ok(bun_ptr::RefPtr::into_raw(result.terminal))
             }
             Err(err) => Err(match err {
                 InitError::OpenPtyFailed => global_object.throw(format_args!("Failed to open PTY")),

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -11,7 +11,6 @@
 
 use core::cell::Cell;
 use core::ffi::{c_int, c_void};
-use core::ptr::NonNull;
 #[cfg(windows)]
 use core::sync::atomic::{AtomicU32, Ordering};
 
@@ -90,9 +89,6 @@ pub mod js {
 /// 2. Reader (released in onReaderDone/onReaderError)
 /// 3. Writer (released in onWriterClose)
 ///
-// Intrusive refcount, not `Rc`/`Arc`: `*mut Terminal` crosses FFI as the
-// `.classes.ts` m_ctx payload and is recovered by raw pointer in finalize/host fns.
-//
 // `no_construct, no_finalize`: this class uses `constructNeedsThis: true` (3-arg
 // constructor) and intrusive refcounting (finalize → deref, not heap::take),
 // neither of which the macro's default hooks support. The C-ABI shims live in
@@ -299,8 +295,9 @@ impl Options {
 
 /// Result from creating a Terminal
 pub(crate) struct CreateResult {
-    /// The new terminal; its initial ref belongs to the JS wrapper (`js_value`).
-    pub terminal: NonNull<Terminal>,
+    /// The new terminal; its initial ref belongs to the JS wrapper (`js_value`),
+    /// which holds itself strong until the terminal closes.
+    pub terminal: bun_ptr::BackRef<Terminal, bun_ptr::Mut>,
     pub js_value: JSValue,
 }
 
@@ -408,8 +405,7 @@ impl Terminal {
         // Create PTY
         let pty_result = create_pty(options.cols, options.rows)?;
 
-        // Heap-allocate the Terminal; the intrusive ref_count
-        // field starts at 1 (JS side's ref). Wrapped as RefPtr on success.
+        // The intrusive ref_count starts at 1: the JS wrapper's ref.
         let terminal: *mut Terminal = bun_core::heap::into_raw(Box::new(Terminal {
             ref_count: bun_ptr::RefCount::init(),
             master_fd: Cell::new(pty_result.master),
@@ -440,13 +436,13 @@ impl Terminal {
             #[cfg(unix)]
             tty_state: Cell::new(bun_core::tty::State::new()),
         }));
+        let parent_ptr = terminal;
         // SAFETY: just allocated, non-null, exclusively owned here. R-2: `&`
         // (not `&mut`) — every method below takes `&self`; field writes go
         // through `Cell`/`JsCell`.
         let terminal = unsafe { &*terminal };
 
         // Set reader parent
-        let parent_ptr = terminal.as_ctx_ptr();
         terminal
             .reader
             .with_mut(|r| r.set_parent(parent_ptr.cast::<c_void>()));
@@ -541,8 +537,8 @@ impl Terminal {
         }
 
         Ok(CreateResult {
-            // SAFETY: `heap::into_raw` is never null.
-            terminal: unsafe { NonNull::new_unchecked(parent_ptr) },
+            // SAFETY: `parent_ptr` is the live `heap::into_raw` pointer above.
+            terminal: unsafe { bun_ptr::BackRef::from_raw_mut(parent_ptr) },
             js_value: this_value,
         })
     }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -28,7 +28,7 @@ use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
     CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsClass, JsRef, JsResult, StrongOptional,
 };
-use bun_ptr::IntrusiveRc;
+use bun_ptr::RefPtr;
 
 bun_output::declare_scope!(H2FrameParser, visible);
 
@@ -96,7 +96,7 @@ enum BunSocket {
     #[default]
     None,
     // BACKREF — the socket strictly outlives the H2FrameParser while attached:
-    // `Tls`/`Tcp` are kept alive by the `IntrusiveRc<H2FrameParser>` stored in
+    // `Tls`/`Tcp` are kept alive by the `RefPtr<H2FrameParser>` stored in
     // the socket's `native_callback` slot (released in `detach_native_socket`),
     // and `*Writeonly` are kept alive by the manual `ref_()`/`deref()` pair in
     // `attach_to_native_socket` / `detach_native_socket`. `BackRef` makes the
@@ -1246,7 +1246,7 @@ pub(crate) struct SignalRef {
     signal: bun_ptr::BackRef<AbortSignal>,
     // LIFETIMES.tsv: SHARED — H2FrameParser carries an intrusive RefCount and is
     // recovered via `from_field_ptr!` from the auto-flusher. It uses a hand-rolled
-    // `Cell<u32>` ref count (not `bun_ptr::RefCount<Self>`), so `IntrusiveRc`'s
+    // `Cell<u32>` ref count (not `bun_ptr::RefCount<Self>`), so `RefPtr`'s
     // `RefCounted` bound is unsatisfiable. `ParentRef` captures the backref
     // invariant (parser is `ref_()`'d in `attach_signal` and outlives the
     // `SignalRef` until `Drop` calls `deref()`), so reads go through safe
@@ -7444,7 +7444,7 @@ impl H2FrameParser {
         Ok(JSValue::UNDEFINED)
     }
 
-    /// `attach_native_callback` stores an `IntrusiveRc<H2FrameParser>` (the
+    /// `attach_native_callback` stores a `RefPtr<H2FrameParser>` (the
     /// `init_ref` bumps `ref_count`); the matching `deref` happens in
     /// `NewSocket::detach_native_callback`. When the socket already has a
     /// native callback attached we fall back to write-only mode and take a
@@ -7455,9 +7455,9 @@ impl H2FrameParser {
     ) -> BunSocket {
         // SAFETY: `self` is a live heap allocation (HiveArray slot or boxed); `init_ref`
         // increments the intrusive refcount (Cell-backed) and wraps the pointer. The
-        // `*mut` spelling is signature-only — `IntrusiveRc` only ever derefs as shared
+        // `*mut` spelling is signature-only — `RefPtr` only ever derefs as shared
         // (`on_native_*` callbacks take `&self`).
-        let h2 = unsafe { IntrusiveRc::init_ref(self.as_ctx_ptr()) };
+        let h2 = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
         // BACKREF: `socket` is the live `m_ctx` borrowed from the JS wrapper rooted by the
         // caller's `socket_js`; it strictly outlives the returned `BunSocket` via the
         // attach/detach refcount protocol (see `BunSocket` docs). `NonNull::new` panics on
@@ -7471,8 +7471,6 @@ impl H2FrameParser {
                 BunSocket::Tcp(bun_ptr::BackRef::from(socket_nn.cast::<TCPSocket>()))
             }
         } else {
-            // attach_native_callback failed: balance the init_ref taken above.
-            self.deref();
             socket_ref.ref_();
             if SSL {
                 BunSocket::TlsWriteonly(bun_ptr::BackRef::from(socket_nn.cast::<TLSSocket>()))

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1244,14 +1244,8 @@ pub(crate) struct SignalRef {
     // (signal is `ref_()`'d in `attach_signal` and outlives this struct until
     // `Drop` calls `detach()`/`unref()`), so reads go through safe `Deref`.
     signal: bun_ptr::BackRef<AbortSignal>,
-    // LIFETIMES.tsv: SHARED — H2FrameParser carries an intrusive RefCount and is
-    // recovered via `from_field_ptr!` from the auto-flusher. It uses a hand-rolled
-    // `Cell<u32>` ref count (not `bun_ptr::RefCount<Self>`), so `RefPtr`'s
-    // `RefCounted` bound is unsatisfiable. `ParentRef` captures the backref
-    // invariant (parser is `ref_()`'d in `attach_signal` and outlives the
-    // `SignalRef` until `Drop` calls `deref()`), so reads go through safe
-    // `Deref`; the explicit `ref_()/deref()` balancing stays.
-    parser: bun_ptr::ParentRef<H2FrameParser>,
+    // TODO: We should not need this ref counting here, since Parser owns Stream
+    parser: RefPtr<H2FrameParser>,
     stream_id: u32,
 }
 
@@ -1264,9 +1258,7 @@ impl SignalRef {
     pub(crate) fn abort_listener(this: &mut SignalRef, reason: JSValue) {
         bun_output::scoped_log!(H2FrameParser, "abortListener");
         reason.ensure_still_alive();
-        // ParentRef backref — ref()'d in `attach_signal`, valid until detach/deinit.
-        // R-2: shared deref — `abort_stream` takes `&self`.
-        let parser = this.parser.get();
+        let parser = &*this.parser;
         let Some(stream) = parser.streams.get().get(&this.stream_id).copied() else {
             return;
         };
@@ -1287,10 +1279,6 @@ impl Drop for SignalRef {
         // taken by `from_mut` doesn't overlap the receiver borrow.
         let signal = self.signal;
         signal.detach(std::ptr::from_mut(self).cast::<c_void>());
-        // ParentRef backref — parser outlives every SignalRef (ref()'d in
-        // `attach_signal`); release that ref now via the inherent `deref()`.
-        H2FrameParser::deref(self.parser.get());
-        // bun.destroy(this) handled by Box drop
     }
 }
 
@@ -1811,14 +1799,13 @@ impl Stream {
         // we need a stable pointer to know what signal points to what stream_id + parser
         let mut signal_ref = Box::new(SignalRef {
             signal: bun_ptr::BackRef::from(refed),
-            parser: bun_ptr::ParentRef::new(parser),
+            // SAFETY: `parser` is the live m_ctx allocation.
+            parser: unsafe { RefPtr::init_ref(parser.as_ctx_ptr()) },
             stream_id: self.id,
         });
         // `signal_ref` is heap-allocated and outlives the listener registration
         // (cleared via `detach` in `Drop for SignalRef`).
         signal.listen(&raw mut *signal_ref);
-        // TODO: We should not need this ref counting here, since Parser owns Stream
-        parser.ref_();
         self.signal = Some(signal_ref);
     }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7444,11 +7444,11 @@ impl H2FrameParser {
         Ok(JSValue::UNDEFINED)
     }
 
-    /// `attach_native_callback` stores a `RefPtr<H2FrameParser>` (the
-    /// `init_ref` bumps `ref_count`); the matching `deref` happens in
-    /// `NewSocket::detach_native_callback`. When the socket already has a
-    /// native callback attached we fall back to write-only mode and take a
-    /// manual `ref()` on the socket itself, balanced by `detach_native_socket`.
+    /// `attach_native_callback` stores a `RefPtr<H2FrameParser>`, dropped in
+    /// `NewSocket::detach_native_callback` (or inside `attach_native_callback`
+    /// when rejected). When the socket already has a native callback attached
+    /// we fall back to write-only mode and take a manual `ref()` on the socket
+    /// itself, balanced by `detach_native_socket`.
     fn attach_to_native_socket<const SSL: bool>(
         &self,
         socket: *mut crate::socket::NewSocket<SSL>,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1130,6 +1130,13 @@ impl H2FrameParser {
         Keepalive(self)
     }
 
+    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
+    #[inline]
+    pub(crate) fn ref_guard(&self) -> RefPtr<Self> {
+        // SAFETY: `self` is the live heap allocation.
+        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
+    }
+
     pub(crate) fn ref_(&self) {
         // SAFETY: `self` is live; `RefCount::ref_` only reads/writes the
         // embedded `ref_count` Cell (interior-mutable), so `&self`→`*mut`
@@ -1799,8 +1806,7 @@ impl Stream {
         // we need a stable pointer to know what signal points to what stream_id + parser
         let mut signal_ref = Box::new(SignalRef {
             signal: bun_ptr::BackRef::from(refed),
-            // SAFETY: `parser` is the live m_ctx allocation.
-            parser: unsafe { RefPtr::init_ref(parser.as_ctx_ptr()) },
+            parser: parser.ref_guard(),
             stream_id: self.id,
         });
         // `signal_ref` is heap-allocated and outlives the listener registration
@@ -7440,11 +7446,7 @@ impl H2FrameParser {
         &self,
         socket: *mut crate::socket::NewSocket<SSL>,
     ) -> BunSocket {
-        // SAFETY: `self` is a live heap allocation (HiveArray slot or boxed); `init_ref`
-        // increments the intrusive refcount (Cell-backed) and wraps the pointer. The
-        // `*mut` spelling is signature-only — `RefPtr` only ever derefs as shared
-        // (`on_native_*` callbacks take `&self`).
-        let h2 = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
+        let h2 = self.ref_guard();
         // BACKREF: `socket` is the live `m_ctx` borrowed from the JS wrapper rooted by the
         // caller's `socket_js`; it strictly outlives the returned `BunSocket` via the
         // attach/detach refcount protocol (see `BunSocket` docs). `NonNull::new` panics on

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -53,24 +53,6 @@ fn signal_code_from_js(val: JSValue, global: &JSGlobalObject) -> JsResult<Signal
     bun_sys_jsc::signal_code_jsc::from_js(val, global)
 }
 
-/// `Terminal.CreateResult` with the pointer as the `BackRef<Terminal>` that
-/// `Subprocess.terminal` and `existing_terminal` use.
-struct TerminalCreateResult {
-    /// Kept alive by its JS wrapper (`js_value`), which holds itself strong
-    /// until the terminal closes.
-    pub terminal: bun_ptr::BackRef<Terminal, bun_ptr::Mut>,
-    pub js_value: JSValue,
-}
-
-impl TerminalCreateResult {
-    /// Shared borrow of the held `Terminal` (BackRef invariant: +1-ref'd
-    /// RefPtr, live while this struct is held).
-    #[inline]
-    fn term(&self) -> &Terminal {
-        self.terminal.get()
-    }
-}
-
 #[inline]
 fn subprocess_ipc_owner(ptr: *mut SubprocessT<'_>) -> Option<IPC::SendQueueOwner> {
     core::ptr::NonNull::new(ptr.cast::<SubprocessT<'static>>()).map(IPC::SendQueueOwner::Subprocess)
@@ -392,14 +374,14 @@ fn spawn_maybe_sync(
     #[cfg(windows)]
     let mut windows_verbatim_arguments: bool = false;
     let mut abort_signal: Option<*mut WebCore::AbortSignal> = None;
-    let mut terminal_info: Option<TerminalCreateResult> = None;
+    let mut terminal_info: Option<terminal_body::CreateResult> = None;
     let mut existing_terminal: Option<bun_ptr::BackRef<Terminal, bun_ptr::Mut>> = None; // Existing terminal passed by user
     let mut terminal_js_value: JSValue = JSValue::ZERO;
     let mut defer_guard = scopeguard::guard(
         (&mut abort_signal, &mut terminal_info),
         |(abort_signal, terminal_info): (
             &mut Option<*mut WebCore::AbortSignal>,
-            &mut Option<TerminalCreateResult>,
+            &mut Option<terminal_body::CreateResult>,
         )| {
             if let Some(signal) = abort_signal.take() {
                 // signal was ref()'d when stored; unref releases that ref.
@@ -415,7 +397,7 @@ fn spawn_maybe_sync(
             if let Some(info) = terminal_info.take() {
                 // `abandon_from_spawn` is the spawn-side error-path teardown
                 // (downgrade JSRef, mark finalized, close_internal).
-                info.term().abandon_from_spawn();
+                info.terminal.abandon_from_spawn();
             }
         },
     );
@@ -842,17 +824,7 @@ fn spawn_maybe_sync(
                         let term_options =
                             TerminalOptions::parse_from_js(global_this, terminal_val)?;
                         match Terminal::create_from_spawn(global_this, &term_options) {
-                            Ok(created) => {
-                                **terminal_info = Some(TerminalCreateResult {
-                                    // Non-owning: the terminal is kept alive by its JS
-                                    // wrapper (`js_value`, held strong until closed).
-                                    // SAFETY: live heap pointer from `heap::into_raw`.
-                                    terminal: unsafe {
-                                        bun_ptr::BackRef::from_raw_mut(created.terminal.as_ptr())
-                                    },
-                                    js_value: created.js_value,
-                                });
-                            }
+                            Ok(created) => **terminal_info = Some(created),
                             Err(err) => {
                                 return Err(match err {
                                     TerminalInitError::OpenPtyFailed => {
@@ -882,7 +854,7 @@ fn spawn_maybe_sync(
                             existing_terminal
                                 .map(|t| t.get_slave_fd())
                                 .unwrap_or_else(|| {
-                                    terminal_info.as_ref().unwrap().term().get_slave_fd()
+                                    terminal_info.as_ref().unwrap().terminal.get_slave_fd()
                                 });
                         stdio[0] = Stdio::Fd(slave_fd);
                         stdio[1] = Stdio::Fd(slave_fd);
@@ -1169,13 +1141,13 @@ fn spawn_maybe_sync(
         // For existing terminals, the session is already set up - child just uses the fd as stdio.
         #[cfg(unix)]
         pty_slave_fd: match terminal_info.as_ref() {
-            Some(ti) => ti.term().get_slave_fd().native(),
+            Some(ti) => ti.terminal.get_slave_fd().native(),
             None => -1,
         },
         #[cfg(windows)]
         pseudoconsole: existing_terminal
             .as_deref()
-            .or_else(|| terminal_info.as_ref().map(TerminalCreateResult::term))
+            .or_else(|| terminal_info.as_ref().map(|info| info.terminal.get()))
             .and_then(Terminal::get_pseudoconsole),
 
         #[cfg(windows)]
@@ -1500,16 +1472,16 @@ fn spawn_maybe_sync(
     if let Some(info) = terminal_info.take() {
         terminal_js_value = info.js_value;
         #[cfg(unix)]
-        info.term().mark_inline_spawned();
+        info.terminal.mark_inline_spawned();
         #[cfg(windows)]
         {
             // ConPTY has no slave fd; this just marks inline_spawned.
-            info.term().close_slave_fd();
+            info.terminal.close_slave_fd();
             // Release the ConDrv \Reference handle now that the child holds a
             // copy: conhost then exits on its own once the child disconnects
             // and the reader observes EOF without us having to tear ConPTY
             // down from on_process_exit.
-            info.term().release_pseudoconsole_reference();
+            info.terminal.release_pseudoconsole_reference();
         }
         subprocess.update_flags(|f| f.insert(Subprocess::Flags::OWNS_TERMINAL));
     }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -53,14 +53,11 @@ fn signal_code_from_js(val: JSValue, global: &JSGlobalObject) -> JsResult<Signal
     bun_sys_jsc::signal_code_jsc::from_js(val, global)
 }
 
-/// `Terminal.CreateResult` — local mirror that flattens `RefPtr<Terminal>`
-/// to a `BackRef<Terminal>` used by `Subprocess.terminal`, so the scopeguard /
-/// field-assignment paths share one pointer type with `existing_terminal`.
+/// `Terminal.CreateResult` with the pointer as the `BackRef<Terminal>` that
+/// `Subprocess.terminal` and `existing_terminal` use.
 struct TerminalCreateResult {
-    /// BACKREF — the `RefPtr<Terminal>` pointer leaked via `into_raw()`
-    /// when this struct was populated; the +1 ref is held until
-    /// `Subprocess::finalize` (or the spawn-error scopeguard's
-    /// `abandon_from_spawn`) releases it, so the pointee outlives this struct.
+    /// Kept alive by its JS wrapper (`js_value`), which holds itself strong
+    /// until the terminal closes.
     pub terminal: bun_ptr::BackRef<Terminal, bun_ptr::Mut>,
     pub js_value: JSValue,
 }
@@ -847,14 +844,11 @@ fn spawn_maybe_sync(
                         match Terminal::create_from_spawn(global_this, &term_options) {
                             Ok(created) => {
                                 **terminal_info = Some(TerminalCreateResult {
-                                    // Transfer the +1 ref to `Subprocess.terminal` (released
-                                    // in `Subprocess::finalize`); the scopeguard's
-                                    // `abandon_from_spawn` path covers the error case.
-                                    // `RefPtr::into_raw` is never null (NonNull-backed).
-                                    // SAFETY: `into_raw()` yields the live heap pointer
-                                    // (write provenance, non-null); ref released later.
+                                    // Non-owning: the terminal is kept alive by its JS
+                                    // wrapper (`js_value`, held strong until closed).
+                                    // SAFETY: live heap pointer from `heap::into_raw`.
                                     terminal: unsafe {
-                                        bun_ptr::BackRef::from_raw_mut(created.terminal.into_raw())
+                                        bun_ptr::BackRef::from_raw_mut(created.terminal.as_ptr())
                                     },
                                     js_value: created.js_value,
                                 });

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -53,11 +53,11 @@ fn signal_code_from_js(val: JSValue, global: &JSGlobalObject) -> JsResult<Signal
     bun_sys_jsc::signal_code_jsc::from_js(val, global)
 }
 
-/// `Terminal.CreateResult` — local mirror that flattens `IntrusiveRc<Terminal>`
+/// `Terminal.CreateResult` — local mirror that flattens `RefPtr<Terminal>`
 /// to a `BackRef<Terminal>` used by `Subprocess.terminal`, so the scopeguard /
 /// field-assignment paths share one pointer type with `existing_terminal`.
 struct TerminalCreateResult {
-    /// BACKREF — the `IntrusiveRc<Terminal>` pointer leaked via `into_raw()`
+    /// BACKREF — the `RefPtr<Terminal>` pointer leaked via `into_raw()`
     /// when this struct was populated; the +1 ref is held until
     /// `Subprocess::finalize` (or the spawn-error scopeguard's
     /// `abandon_from_spawn`) releases it, so the pointee outlives this struct.
@@ -67,7 +67,7 @@ struct TerminalCreateResult {
 
 impl TerminalCreateResult {
     /// Shared borrow of the held `Terminal` (BackRef invariant: +1-ref'd
-    /// IntrusiveRc, live while this struct is held).
+    /// RefPtr, live while this struct is held).
     #[inline]
     fn term(&self) -> &Terminal {
         self.terminal.get()
@@ -850,7 +850,7 @@ fn spawn_maybe_sync(
                                     // Transfer the +1 ref to `Subprocess.terminal` (released
                                     // in `Subprocess::finalize`); the scopeguard's
                                     // `abandon_from_spawn` path covers the error case.
-                                    // `IntrusiveRc::into_raw` is never null (NonNull-backed).
+                                    // `RefPtr::into_raw` is never null (NonNull-backed).
                                     // SAFETY: `into_raw()` yields the live heap pointer
                                     // (write provenance, non-null); ref released later.
                                     terminal: unsafe {

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -497,7 +497,6 @@ impl Subprocess<'_> {
                         unreachable!()
                     };
                     Writable::buffer_writer_mut(&buffer).source.detach();
-                    buffer.deref();
                 }
                 _ => {}
             }),
@@ -522,8 +521,6 @@ impl Subprocess<'_> {
                         // pipe.state was emptied via take()
                     }
                     // else: *out stays Readable::Ignore (set by replace above).
-                    // RefPtr has no Drop — release the ref this Readable held.
-                    pipe.deref();
                 }
             }
         }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -479,17 +479,11 @@ impl Subprocess<'_> {
     pub(crate) fn on_close_io(&self, kind: StdioKind) {
         match kind {
             StdioKind::Stdin => self.stdin.with_mut(|stdin| match stdin {
-                Writable::Pipe(pipe) => {
-                    let pipe = *pipe;
-                    // `source` is a `JsCell`, so the shared `&FileSink` from the
-                    // centralised `pipe_sink` accessor suffices for `with_mut`.
-                    Writable::pipe_sink(pipe).source.with_mut(|s| s.clear());
-                    *stdin = Writable::Ignore;
-                    // `Writable::Pipe` owns one intrusive ref; release it now
-                    // that the variant has been overwritten. Ordered after the
-                    // assignment so any re-entrant `on_stdin_destroyed` from
-                    // `deinit` observes `.Ignore`.
-                    Writable::pipe_release(pipe);
+                Writable::Pipe(_) => {
+                    let Writable::Pipe(pipe) = core::mem::replace(stdin, Writable::Ignore) else {
+                        unreachable!()
+                    };
+                    pipe.source.with_mut(|s| s.clear());
                 }
                 Writable::Buffer(_) => {
                     let Writable::Buffer(buffer) = core::mem::replace(stdin, Writable::Ignore)
@@ -1012,8 +1006,7 @@ impl Subprocess<'_> {
             && self.flags.get().contains(Flags::IS_STDIN_A_READABLE_STREAM)
         {
             if let Writable::Pipe(pipe) = self.stdin.get() {
-                // Writable::Pipe already stores `NonNull<FileSink>`; just copy it.
-                Some(*pipe)
+                Some(pipe.as_non_null())
             } else {
                 unreachable!()
             }

--- a/src/runtime/api/bun/subprocess/Readable.rs
+++ b/src/runtime/api/bun/subprocess/Readable.rs
@@ -9,7 +9,7 @@ use crate::node::types::FdJsc as _;
 use crate::api::bun_spawn::stdio::Stdio;
 use crate::webcore::ReadableStream;
 use bun_io::max_buf::MaxBuf;
-use bun_ptr::IntrusiveRc;
+use bun_ptr::RefPtr;
 use bun_ptr::cow_slice::CowSlice;
 
 use super::subprocess_pipe_reader::PipeReader;
@@ -22,8 +22,8 @@ pub type CowString = CowSlice<u8>;
 pub enum Readable {
     Fd(Fd),
     Memfd(Fd),
-    // LIFETIMES.tsv: SHARED → IntrusiveRc<PipeReader> (PipeReader has intrusive RefCount; detach() → deref()).
-    Pipe(IntrusiveRc<PipeReader>),
+    // LIFETIMES.tsv: SHARED → RefPtr<PipeReader> (PipeReader has intrusive RefCount; detach() → deref()).
+    Pipe(RefPtr<PipeReader>),
     Inherit,
     Ignore,
     Closed,
@@ -39,35 +39,28 @@ pub enum Readable {
 impl Readable {
     /// Mutable borrow of the `Pipe` payload's `PipeReader`.
     ///
-    /// Centralises the `IntrusiveRc → &mut T` deref so the per-match-arm
+    /// Centralises the `RefPtr → &mut T` deref so the per-match-arm
     /// `unsafe` blocks (`ref_`/`unref`/`close` and the `Subprocess` callers in
     /// `on_close_io`/`on_process_exit`/`testing_apis`) collapse to this one
-    /// site. `IntrusiveRc` (= `RefPtr`) deliberately has no `DerefMut`; the
+    /// site. `RefPtr` deliberately has no `DerefMut`; the
     /// invariant that makes `&mut` sound here is that `Readable::Pipe` holds
     /// the owning strong ref for the variant's lifetime (created by
-    /// `PipeReader::create`, released by `detach()`/`deref()` only after the
-    /// variant is moved out), the reader lives in its own heap allocation
+    /// `PipeReader::create`, dropped only after the variant is moved out),
+    /// the reader lives in its own heap allocation
     /// disjoint from `Readable`/`Subprocess`, and access is
     /// single-JS-mutator-thread.
     #[inline]
     #[allow(clippy::mut_from_ref)]
-    pub(in crate::api) fn pipe_reader_mut(pipe: &IntrusiveRc<PipeReader>) -> &mut PipeReader {
-        // SAFETY: see fn doc — owning IntrusiveRc, heap-disjoint, single-thread.
+    pub(in crate::api) fn pipe_reader_mut(pipe: &RefPtr<PipeReader>) -> &mut PipeReader {
+        // SAFETY: see fn doc — owning RefPtr, heap-disjoint, single-thread.
         unsafe { &mut *pipe.as_ptr() }
     }
 
-    /// Clear the `PipeReader`'s `process` backref and release the caller's ref.
-    /// Centralises what was the `into_raw()` +
-    /// `unsafe { PipeReader::detach(raw) }` dance so the three callers in
-    /// `finalize` / `to_js` / `to_buffered_value` stay safe — the caller's
-    /// `IntrusiveRc` encodes the "live + one ref" invariant `detach()` needs,
-    /// and `RefPtr::deref` is the safe drop. Callers pass the `IntrusiveRc`
-    /// they just moved out of `self` and drop it (a no-op — `RefPtr` has no
-    /// `Drop`) immediately after.
+    /// Clear the `PipeReader`'s `process` backref and release the ref the
+    /// `Readable::Pipe` variant held.
     #[inline]
-    fn pipe_detach(pipe: &IntrusiveRc<PipeReader>) {
-        Self::pipe_reader_mut(pipe).process = None;
-        pipe.deref();
+    fn pipe_detach(pipe: RefPtr<PipeReader>) {
+        Self::pipe_reader_mut(&pipe).process = None;
     }
 
     pub(crate) fn memory_cost(&self) -> usize {
@@ -226,7 +219,7 @@ impl Readable {
                         unsafe { PipeReader::deref(pipe.as_ptr()) };
                     }
                 }
-                Self::pipe_detach(&pipe);
+                Self::pipe_detach(pipe);
             }
             Readable::Buffer(_) => {
                 // Dropping the CowString (via the overwrite) frees the buffer;
@@ -248,7 +241,7 @@ impl Readable {
                     unreachable!()
                 };
                 let result = Self::pipe_reader_mut(&pipe).to_js(global);
-                Self::pipe_detach(&pipe);
+                Self::pipe_detach(pipe);
                 result
             }
             Readable::Buffer(_) => {
@@ -288,7 +281,7 @@ impl Readable {
                     unreachable!()
                 };
                 let result = Self::pipe_reader_mut(&pipe).to_buffer(global);
-                Self::pipe_detach(&pipe);
+                Self::pipe_detach(pipe);
                 result
             }
             Readable::Buffer(_) => {

--- a/src/runtime/api/bun/subprocess/Readable.rs
+++ b/src/runtime/api/bun/subprocess/Readable.rs
@@ -22,7 +22,6 @@ pub type CowString = CowSlice<u8>;
 pub enum Readable {
     Fd(Fd),
     Memfd(Fd),
-    // LIFETIMES.tsv: SHARED → RefPtr<PipeReader> (PipeReader has intrusive RefCount; detach() → deref()).
     Pipe(RefPtr<PipeReader>),
     Inherit,
     Ignore,
@@ -39,16 +38,10 @@ pub enum Readable {
 impl Readable {
     /// Mutable borrow of the `Pipe` payload's `PipeReader`.
     ///
-    /// Centralises the `RefPtr → &mut T` deref so the per-match-arm
-    /// `unsafe` blocks (`ref_`/`unref`/`close` and the `Subprocess` callers in
-    /// `on_close_io`/`on_process_exit`/`testing_apis`) collapse to this one
-    /// site. `RefPtr` deliberately has no `DerefMut`; the
-    /// invariant that makes `&mut` sound here is that `Readable::Pipe` holds
-    /// the owning strong ref for the variant's lifetime (created by
-    /// `PipeReader::create`, dropped only after the variant is moved out),
-    /// the reader lives in its own heap allocation
-    /// disjoint from `Readable`/`Subprocess`, and access is
-    /// single-JS-mutator-thread.
+    /// `RefPtr` deliberately has no `DerefMut`; what makes `&mut` sound here
+    /// is that `Readable::Pipe` holds the owning ref for the variant's
+    /// lifetime, the reader lives in its own heap allocation disjoint from
+    /// `Readable`/`Subprocess`, and access is single-JS-mutator-thread.
     #[inline]
     #[allow(clippy::mut_from_ref)]
     pub(in crate::api) fn pipe_reader_mut(pipe: &RefPtr<PipeReader>) -> &mut PipeReader {
@@ -61,6 +54,7 @@ impl Readable {
     #[inline]
     fn pipe_detach(pipe: RefPtr<PipeReader>) {
         Self::pipe_reader_mut(&pipe).process = None;
+        drop(pipe);
     }
 
     pub(crate) fn memory_cost(&self) -> usize {

--- a/src/runtime/api/bun/subprocess/Readable.rs
+++ b/src/runtime/api/bun/subprocess/Readable.rs
@@ -49,14 +49,6 @@ impl Readable {
         unsafe { &mut *pipe.as_ptr() }
     }
 
-    /// Clear the `PipeReader`'s `process` backref and release the ref the
-    /// `Readable::Pipe` variant held.
-    #[inline]
-    fn pipe_detach(pipe: RefPtr<PipeReader>) {
-        Self::pipe_reader_mut(&pipe).process = None;
-        drop(pipe);
-    }
-
     pub(crate) fn memory_cost(&self) -> usize {
         match self {
             Readable::Pipe(pipe) => mem::size_of::<PipeReader>() + pipe.memory_cost(),
@@ -213,7 +205,7 @@ impl Readable {
                         unsafe { PipeReader::deref(pipe.as_ptr()) };
                     }
                 }
-                Self::pipe_detach(pipe);
+                Self::pipe_reader_mut(&pipe).process = None;
             }
             Readable::Buffer(_) => {
                 // Dropping the CowString (via the overwrite) frees the buffer;
@@ -235,7 +227,7 @@ impl Readable {
                     unreachable!()
                 };
                 let result = Self::pipe_reader_mut(&pipe).to_js(global);
-                Self::pipe_detach(pipe);
+                Self::pipe_reader_mut(&pipe).process = None;
                 result
             }
             Readable::Buffer(_) => {
@@ -275,7 +267,7 @@ impl Readable {
                     unreachable!()
                 };
                 let result = Self::pipe_reader_mut(&pipe).to_buffer(global);
-                Self::pipe_detach(pipe);
+                Self::pipe_reader_mut(&pipe).process = None;
                 result
             }
             Readable::Buffer(_) => {

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -44,7 +44,6 @@ pub struct PipeReader {
     /// Typed enum mirror of `event_loop` for the io-layer FilePoll vtable
     /// (`bun_io::EventLoopHandle` wraps `*const EventLoopHandle`).
     pub(crate) event_loop_handle: bun_jsc::EventLoopHandle,
-    /// Intrusive refcount field for `bun_ptr::RefPtr<PipeReader>`.
     pub(crate) ref_count: RefCount<PipeReader>,
     pub(crate) state: State,
     pub(crate) stdio_result: StdioResult,
@@ -174,7 +173,7 @@ impl PipeReader {
             // SAFETY: `self` is live; RefPtr bumps the intrusive refcount and
             // derefs on Drop. The deref may free `*self`, but no borrow of `self`
             // outlives the guard's drop on return.
-            let _keepalive = unsafe { RefPtr::init_ref(std::ptr::from_mut::<PipeReader>(self)) };
+            let _guard = unsafe { RefPtr::init_ref(std::ptr::from_mut::<PipeReader>(self)) };
             if let bun_sys::Result::Err(err) = self.reader.start_with_current_pipe() {
                 // Route through the same teardown as a read-callback error
                 // (matches POSIX's register_poll failure path): state=Err,
@@ -203,14 +202,14 @@ impl PipeReader {
             // SAFETY: `self` is live; RefPtr bumps the intrusive refcount and
             // derefs on Drop. The deref may free `*self`, but no borrow of `self`
             // outlives the guard's drop on return.
-            let _keepalive = unsafe { RefPtr::init_ref(std::ptr::from_mut::<PipeReader>(self)) };
+            let _guard = unsafe { RefPtr::init_ref(std::ptr::from_mut::<PipeReader>(self)) };
 
             let _ = self.reader.start(self.stdio_result.unwrap(), true);
 
             #[cfg(unix)]
             {
                 if matches!(self.state, State::Err(_)) {
-                    // onReaderError already ran; `_keepalive`'s Drop on return
+                    // onReaderError already ran; `_guard`'s Drop on return
                     // will drop the last ref and deinit() closes the handle.
                     return;
                 }

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -10,8 +10,7 @@ use bun_io::max_buf::MaxBuf;
 use bun_io::pipe_reader::PosixFlags;
 use bun_jsc::event_loop::EventLoop;
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
-use bun_ptr::ScopedRef;
-use bun_ptr::{IntrusiveRc, ParentRef, RefCount};
+use bun_ptr::{ParentRef, RefCount, RefPtr};
 use bun_sys;
 
 use super::readable::Readable;
@@ -45,7 +44,7 @@ pub struct PipeReader {
     /// Typed enum mirror of `event_loop` for the io-layer FilePoll vtable
     /// (`bun_io::EventLoopHandle` wraps `*const EventLoopHandle`).
     pub(crate) event_loop_handle: bun_jsc::EventLoopHandle,
-    /// Intrusive refcount field for `bun_ptr::IntrusiveRc<PipeReader>`.
+    /// Intrusive refcount field for `bun_ptr::RefPtr<PipeReader>`.
     pub(crate) ref_count: RefCount<PipeReader>,
     pub(crate) state: State,
     pub(crate) stdio_result: StdioResult,
@@ -107,7 +106,7 @@ impl PipeReader {
         process: NonNull<Subprocess<'static>>,
         result: StdioResult,
         limit: Option<NonNull<MaxBuf>>,
-    ) -> IntrusiveRc<PipeReader> {
+    ) -> RefPtr<PipeReader> {
         let mut this = Box::new(PipeReader {
             ref_count: RefCount::init(),
             process: Some(ParentRef::from(process)),
@@ -132,7 +131,7 @@ impl PipeReader {
         // SAFETY: `raw` is a valid, freshly-boxed PipeReader.
         unsafe {
             (*raw).reader.set_parent(raw.cast::<core::ffi::c_void>());
-            IntrusiveRc::from_raw(raw)
+            RefPtr::from_raw(raw)
         }
     }
 
@@ -172,10 +171,10 @@ impl PipeReader {
             // Hold one more ref so `self` survives the on_reader_error() teardown
             // below long enough to return; matches the POSIX keepalive.
             //
-            // SAFETY: `self` is live; ScopedRef bumps the intrusive refcount and
+            // SAFETY: `self` is live; RefPtr bumps the intrusive refcount and
             // derefs on Drop. The deref may free `*self`, but no borrow of `self`
             // outlives the guard's drop on return.
-            let _keepalive = unsafe { ScopedRef::new(std::ptr::from_mut::<PipeReader>(self)) };
+            let _keepalive = unsafe { RefPtr::init_ref(std::ptr::from_mut::<PipeReader>(self)) };
             if let bun_sys::Result::Err(err) = self.reader.start_with_current_pipe() {
                 // Route through the same teardown as a read-callback error
                 // (matches POSIX's register_poll failure path): state=Err,
@@ -201,10 +200,10 @@ impl PipeReader {
             // just took above. Hold one more ref so `this` survives long enough to
             // check state after start() returns.
             //
-            // SAFETY: `self` is live; ScopedRef bumps the intrusive refcount and
+            // SAFETY: `self` is live; RefPtr bumps the intrusive refcount and
             // derefs on Drop. The deref may free `*self`, but no borrow of `self`
             // outlives the guard's drop on return.
-            let _keepalive = unsafe { ScopedRef::new(std::ptr::from_mut::<PipeReader>(self)) };
+            let _keepalive = unsafe { RefPtr::init_ref(std::ptr::from_mut::<PipeReader>(self)) };
 
             let _ = self.reader.start(self.stdio_result.unwrap(), true);
 
@@ -246,13 +245,13 @@ impl PipeReader {
 
     fn kind(&self, process: &Subprocess<'_>) -> StdioKind {
         if let Readable::Pipe(pipe) = process.stdout.get() {
-            if core::ptr::eq(pipe.data.as_ptr(), self) {
+            if core::ptr::eq(pipe.as_ptr(), self) {
                 return StdioKind::Stdout;
             }
         }
 
         if let Readable::Pipe(pipe) = process.stderr.get() {
-            if core::ptr::eq(pipe.data.as_ptr(), self) {
+            if core::ptr::eq(pipe.as_ptr(), self) {
                 return StdioKind::Stderr;
             }
         }

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -1,5 +1,4 @@
 use core::ffi::c_void;
-use core::ptr::NonNull;
 
 use bun_jsc::{JSGlobalObject, JSValue, event_loop::EventLoop};
 use bun_ptr::RefPtr;
@@ -16,9 +15,7 @@ use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
 use super::{Flags, StaticPipeWriter, StdioResult, Subprocess, js};
 
 pub enum Writable<'a> {
-    // `FileSink` is intrusive-refcounted (manual ref/deref): keep a raw
-    // NonNull and call `FileSink::deref` explicitly.
-    Pipe(NonNull<FileSink>),
+    Pipe(RefPtr<FileSink>),
     Fd(Fd),
     Buffer(RefPtr<StaticPipeWriter<'a>>),
     Memfd(Fd),
@@ -27,71 +24,33 @@ pub enum Writable<'a> {
 }
 
 impl<'a> Writable<'a> {
-    /// Shared borrow of the `Pipe` payload's `FileSink`.
+    /// Mutable borrow of the `Pipe` payload's `FileSink`.
     ///
-    /// `Writable::Pipe` holds a +1 intrusive ref on the `FileSink` for the
-    /// variant's entire lifetime — released only by an explicit
-    /// `FileSink::deref` *after* the variant has been overwritten (see
-    /// `on_close` / `Subprocess::on_close_io`). The pointee is therefore live
-    /// and pinned for any caller still holding the `Writable::Pipe` payload —
-    /// i.e. the owner-outlives-holder `BackRef` invariant holds (single JS
-    /// thread).
-    #[inline]
-    pub(super) fn pipe_sink(pipe: NonNull<FileSink>) -> bun_ptr::BackRef<FileSink> {
-        bun_ptr::BackRef::from(pipe)
-    }
-
-    /// Mutable counterpart to [`pipe_sink`](Self::pipe_sink).
-    ///
-    /// Same invariant: `Writable::Pipe` holds a +1 intrusive ref on the
-    /// `FileSink` for the variant's lifetime, and the sink lives in its own
-    /// allocation (disjoint from both the `Writable` value and the parent
-    /// `Subprocess`), so projecting `&mut` here cannot alias any other live
-    /// borrow. Single JS-mutator thread — no concurrent `&mut FileSink`.
+    /// `RefPtr` deliberately has no `DerefMut`; what makes `&mut` sound here
+    /// is that `Writable::Pipe` holds a ref for the variant's lifetime, the
+    /// sink lives in its own heap allocation disjoint from
+    /// `Writable`/`Subprocess`, and access is single-JS-mutator-thread.
     #[inline]
     #[allow(clippy::mut_from_ref)]
-    fn pipe_sink_mut(pipe: &NonNull<FileSink>) -> &mut FileSink {
-        // SAFETY: see fn doc — +1-intrusive-ref'd, heap-disjoint, single-thread.
+    fn pipe_sink_mut(pipe: &RefPtr<FileSink>) -> &mut FileSink {
+        // SAFETY: see fn doc.
         unsafe { &mut *pipe.as_ptr() }
     }
 
-    /// Release one intrusive ref on a `FileSink` held by `Writable::Pipe`
-    /// (or freshly returned from `FileSink::create*`). Centralises the
-    /// `unsafe { FileSink::deref(ptr) }` so callers stay safe — same
-    /// invariant as [`pipe_sink`](Self::pipe_sink): the `NonNull` was
-    /// produced by `FileSink::create*` (heap-boxed, dealloc provenance) and
-    /// carries a +1 intrusive ref the caller is now discharging. Single
-    /// JS-mutator thread; the sink may be freed on return.
-    #[inline]
-    pub(in crate::api) fn pipe_release(pipe: NonNull<FileSink>) {
-        // SAFETY: see fn doc — +1-intrusive-ref'd heap allocation with
-        // dealloc provenance; `deref` decrements and may free.
-        unsafe { FileSink::deref(pipe.as_ptr()) };
-    }
-
-    /// Mutable borrow of the `Buffer` payload's `StaticPipeWriter`.
-    ///
-    /// Centralises the `RefPtr → &mut T` deref so the per-match-arm `unsafe`
-    /// blocks (`ref`/`unref`/`close`/`finalize` and `Subprocess::on_close_io`/
-    /// `on_process_exit`) collapse to this one site. `RefPtr` deliberately has
-    /// no `DerefMut` (shared ownership); the invariant that makes `&mut` sound
-    /// here is that `Writable::Buffer` holds the *only* strong ref for the
-    /// variant's lifetime (created by `StaticPipeWriter::create`, dropped
-    /// only after the variant is moved out), the writer
-    /// lives in its own heap allocation disjoint from `Writable`/`Subprocess`,
-    /// and access is single-JS-mutator-thread.
+    /// Mutable borrow of the `Buffer` payload's `StaticPipeWriter`; same
+    /// invariant as [`pipe_sink_mut`](Self::pipe_sink_mut).
     #[inline]
     #[allow(clippy::mut_from_ref)]
     pub(in crate::api) fn buffer_writer_mut<'b>(
         buffer: &'b RefPtr<StaticPipeWriter<'a>>,
     ) -> &'b mut StaticPipeWriter<'a> {
-        // SAFETY: see fn doc — sole-owning RefPtr, heap-disjoint, single-thread.
+        // SAFETY: see fn doc.
         unsafe { &mut *buffer.as_ptr() }
     }
 
     pub(crate) fn memory_cost(&self) -> usize {
         match self {
-            Writable::Pipe(pipe) => Self::pipe_sink(*pipe).memory_cost(),
+            Writable::Pipe(pipe) => pipe.memory_cost(),
             Writable::Buffer(buffer) => buffer.memory_cost(),
             // TODO: memfd
             _ => 0,
@@ -111,7 +70,7 @@ impl<'a> Writable<'a> {
     pub(crate) fn r#ref(&mut self) {
         match self {
             Writable::Pipe(pipe) => {
-                Self::pipe_sink(*pipe).update_ref(true);
+                pipe.update_ref(true);
             }
             Writable::Buffer(buffer) => {
                 Self::buffer_writer_mut(buffer).update_ref(true);
@@ -123,7 +82,7 @@ impl<'a> Writable<'a> {
     pub(crate) fn unref(&mut self) {
         match self {
             Writable::Pipe(pipe) => {
-                Self::pipe_sink(*pipe).update_ref(false);
+                pipe.update_ref(false);
             }
             Writable::Buffer(buffer) => {
                 Self::buffer_writer_mut(buffer).update_ref(false);
@@ -151,9 +110,7 @@ impl<'a> Writable<'a> {
         // (== false) instead of a just-deref'd `Buffer` (== true) inside
         // `update_has_pending_activity`, which is the state it converges to
         // immediately after anyway.
-        if let Writable::Pipe(pipe) = process.stdin.replace(Writable::Ignore) {
-            Self::pipe_release(pipe);
-        }
+        process.stdin.set(Writable::Ignore);
 
         // `on_stdin_destroyed` may `deref()` and free `process` as its last
         // act, so this must be the final access.
@@ -191,16 +148,14 @@ impl<'a> Writable<'a> {
                         // FileSink's writer (the sink takes over the heap
                         // pointer).
                         let uv_pipe: *mut _ = bun_core::heap::into_raw(buffer);
-                        // `create_with_pipe` returns a freshly-boxed non-null pointer.
-                        let pipe_nn = NonNull::new(FileSink::create_with_pipe(evtloop, uv_pipe))
-                            .expect("FileSink::create_with_pipe returns non-null");
-                        let pipe_ptr = pipe_nn.as_ptr();
-                        let pipe = Self::pipe_sink_mut(&pipe_nn);
+                        let pipe_ptr = FileSink::create_with_pipe(evtloop, uv_pipe);
+                        // SAFETY: freshly created with one ref, which `Pipe` owns.
+                        let pipe_ref = unsafe { RefPtr::from_raw(pipe_ptr) };
+                        let pipe = Self::pipe_sink_mut(&pipe_ref);
 
                         match pipe.writer.with_mut(|w| w.start_with_current_pipe()) {
                             bun_sys::Result::Ok(()) => {}
                             bun_sys::Result::Err(_err) => {
-                                Self::pipe_release(pipe_nn);
                                 if let Stdio::ReadableStream(rs) = stdio {
                                     rs.cancel(global)?;
                                 }
@@ -208,7 +163,9 @@ impl<'a> Writable<'a> {
                             }
                         }
                         pipe.writer.with_mut(|w| w.set_parent(pipe_ptr));
-                        subprocess.weak_file_sink_stdin_ptr.set(Some(pipe_nn));
+                        subprocess
+                            .weak_file_sink_stdin_ptr
+                            .set(Some(pipe_ref.as_non_null()));
                         subprocess.ref_();
                         subprocess.update_flags(|f| {
                             f.set(Flags::DEREF_ON_STDIN_DESTROYED, true);
@@ -222,7 +179,6 @@ impl<'a> Writable<'a> {
                                 subprocess.update_flags(|f| {
                                     f.set(Flags::DEREF_ON_STDIN_DESTROYED, false)
                                 });
-                                Self::pipe_release(pipe_nn);
                                 subprocess.deref();
                                 let _ = global.throw_value(err_val);
                                 return Err(crate::Error::JSError);
@@ -230,7 +186,7 @@ impl<'a> Writable<'a> {
                             *promise_for_stream = assign_result;
                         }
 
-                        return Ok(Writable::Pipe(pipe_nn));
+                        return Ok(Writable::Pipe(pipe_ref));
                     }
                     return Ok(Writable::Inherit);
                 }
@@ -291,19 +247,17 @@ impl<'a> Writable<'a> {
         match stdio {
             Stdio::Dup2(_) => panic!("TODO dup2 stdio"),
             Stdio::Pipe | Stdio::ReadableStream(_) => {
-                // `create` returns a freshly-boxed non-null pointer.
-                let pipe_nn = NonNull::new(FileSink::create(evtloop, result.unwrap()))
-                    .expect("FileSink::create returns non-null");
-                let pipe = Self::pipe_sink_mut(&pipe_nn);
+                // SAFETY: freshly created with one ref, which `Pipe` owns.
+                let pipe_ref =
+                    unsafe { RefPtr::from_raw(FileSink::create(evtloop, result.unwrap())) };
+                let pipe = Self::pipe_sink_mut(&pipe_ref);
 
                 match pipe.writer.with_mut(|w| w.start(pipe.fd.get(), true)) {
                     bun_sys::Result::Ok(()) => {}
                     bun_sys::Result::Err(_err) => {
-                        Self::pipe_release(pipe_nn);
                         if let Stdio::ReadableStream(rs) = stdio {
                             rs.cancel(global)?;
                         }
-
                         return Err(crate::Error::UnexpectedCreatingStdin);
                     }
                 }
@@ -316,7 +270,9 @@ impl<'a> Writable<'a> {
                     }
                 });
 
-                subprocess.weak_file_sink_stdin_ptr.set(Some(pipe_nn));
+                subprocess
+                    .weak_file_sink_stdin_ptr
+                    .set(Some(pipe_ref.as_non_null()));
                 subprocess.ref_();
                 subprocess.update_flags(|f| {
                     f.set(Flags::HAS_STDIN_DESTRUCTOR_CALLED, false);
@@ -328,7 +284,6 @@ impl<'a> Writable<'a> {
                     if let Some(err_val) = assign_result.to_error() {
                         subprocess.weak_file_sink_stdin_ptr.set(None);
                         subprocess.update_flags(|f| f.set(Flags::DEREF_ON_STDIN_DESTROYED, false));
-                        Self::pipe_release(pipe_nn);
                         subprocess.deref();
                         let _ = global.throw_value(err_val);
                         return Err(crate::Error::JSError);
@@ -336,7 +291,7 @@ impl<'a> Writable<'a> {
                     *promise_for_stream = assign_result;
                 }
 
-                Ok(Writable::Pipe(pipe_nn))
+                Ok(Writable::Pipe(pipe_ref))
             }
 
             Stdio::Blob(_) => {
@@ -405,10 +360,7 @@ impl<'a> Writable<'a> {
                 subprocess.stdin.set(Writable::Inherit);
                 JSValue::UNDEFINED
             }
-            Writable::Pipe(pipe_nn) => {
-                // stdin already replaced with Ignore above;
-                // pipe is live (held a +1 in this enum); separate allocation
-                // from `*subprocess` so the borrows are disjoint.
+            Writable::Pipe(pipe_ref) => {
                 if subprocess.has_exited()
                     && !subprocess
                         .flags
@@ -424,29 +376,23 @@ impl<'a> Writable<'a> {
                     // in spawn_maybe_sync and this path asserted no ref change;
                     // see https://github.com/oven-sh/bun/pull/14092).
                     //
-                    // Pass the canonical `*mut FileSink` straight through — the
-                    // call re-enters via the writer backref and may free `this`,
-                    // so no `&mut FileSink` is materialized across it.
-                    // SAFETY: `pipe_nn` is the canonical heap pointer from
-                    // `FileSink::create*` with write+dealloc provenance, held
-                    // live by the `Writable::Pipe` +1.
+                    // The call re-enters via the writer backref, so no `&mut
+                    // FileSink` is materialized across it.
+                    // SAFETY: `pipe_ref` keeps the sink live.
                     unsafe {
                         FileSink::on_attached_process_exit(
-                            pipe_nn.as_ptr(),
+                            pipe_ref.as_ptr(),
                             &subprocess.process().status,
                         )
                     };
-                    // `FileSink::to_js` takes its own per-wrapper +1. Release the
-                    // enum's create-time +1 now that the wrapper holds its own
-                    // — mirrors Blob.rs:1899-1902. `stdin` was already swapped
-                    // to `Ignore` above so `on_close` won't double-release.
-                    let js = Self::pipe_sink_mut(&pipe_nn).to_js(global_this);
-                    Self::pipe_release(pipe_nn);
-                    js
+                    // The wrapper takes its own ref; `pipe_ref` drops after.
+                    Self::pipe_sink_mut(&pipe_ref).to_js(global_this)
                 } else {
-                    let pipe = Self::pipe_sink_mut(&pipe_nn);
+                    let pipe = Self::pipe_sink_mut(&pipe_ref);
                     subprocess.update_flags(|f| f.set(Flags::HAS_STDIN_DESTRUCTOR_CALLED, false));
-                    subprocess.weak_file_sink_stdin_ptr.set(Some(pipe_nn));
+                    subprocess
+                        .weak_file_sink_stdin_ptr
+                        .set(Some(pipe_ref.as_non_null()));
                     if !subprocess
                         .flags
                         .get()
@@ -463,17 +409,13 @@ impl<'a> Writable<'a> {
                     {
                         pipe.source.with_mut(|s| s.clear());
                     }
-                    // Rust `FileSink::to_js_with_destructor` takes its own
-                    // per-wrapper +1; release the enum's create-time +1 (see
-                    // the has-exited arm above and Blob.rs:1899-1902).
-                    let js = pipe.to_js_with_destructor(
+                    // The wrapper takes its own ref; `pipe_ref` drops after.
+                    pipe.to_js_with_destructor(
                         global_this,
                         Some(sink::destructor_ptr_subprocess(
                             subprocess.as_ctx_ptr().cast::<c_void>(),
                         )),
-                    );
-                    Self::pipe_release(pipe_nn);
-                    js
+                    )
                 }
             }
         }
@@ -491,14 +433,11 @@ impl<'a> Writable<'a> {
         // Source back-pointer is the `*mut Subprocess`, not the `stdin` address.
         let parent_ptr = subprocess.as_ctx_ptr().cast::<Subprocess<'static>>();
         match subprocess.stdin.replace(Writable::Ignore) {
-            Writable::Pipe(pipe_nn) => {
-                let pipe = Self::pipe_sink_mut(&pipe_nn);
+            Writable::Pipe(pipe) => {
                 if matches!(*pipe.source.get(), SourceHandle::Subprocess(p) if p.as_const_ptr() == parent_ptr.cast_const())
                 {
                     pipe.source.with_mut(|s| s.clear());
                 }
-
-                Self::pipe_release(pipe_nn);
             }
             Writable::Buffer(buffer) => {
                 Self::buffer_writer_mut(&buffer).update_ref(false);
@@ -519,7 +458,7 @@ impl<'a> Writable<'a> {
     pub fn close(&mut self) {
         match self {
             Writable::Pipe(pipe) => {
-                let _ = Self::pipe_sink(*pipe).end(None);
+                let _ = pipe.end(None);
             }
             Writable::Memfd(fd) => {
                 fd.close();

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -76,8 +76,8 @@ impl<'a> Writable<'a> {
     /// `on_process_exit`) collapse to this one site. `RefPtr` deliberately has
     /// no `DerefMut` (shared ownership); the invariant that makes `&mut` sound
     /// here is that `Writable::Buffer` holds the *only* strong ref for the
-    /// variant's lifetime (created by `StaticPipeWriter::create`, released by
-    /// `buffer.deref()` only after the variant is overwritten), the writer
+    /// variant's lifetime (created by `StaticPipeWriter::create`, dropped
+    /// only after the variant is moved out), the writer
     /// lives in its own heap allocation disjoint from `Writable`/`Subprocess`,
     /// and access is single-JS-mutator-thread.
     #[inline]

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -151,14 +151,8 @@ impl<'a> Writable<'a> {
         // (== false) instead of a just-deref'd `Buffer` (== true) inside
         // `update_has_pending_activity`, which is the state it converges to
         // immediately after anyway.
-        match process.stdin.replace(Writable::Ignore) {
-            Writable::Buffer(buffer) => {
-                buffer.deref();
-            }
-            Writable::Pipe(pipe) => {
-                Self::pipe_release(pipe);
-            }
-            _ => {}
+        if let Writable::Pipe(pipe) = process.stdin.replace(Writable::Ignore) {
+            Self::pipe_release(pipe);
         }
 
         // `on_stdin_destroyed` may `deref()` and free `process` as its last
@@ -508,8 +502,6 @@ impl<'a> Writable<'a> {
             }
             Writable::Buffer(buffer) => {
                 Self::buffer_writer_mut(&buffer).update_ref(false);
-                // RefPtr::deref drops the held ref.
-                buffer.deref();
             }
             Writable::Memfd(fd) => {
                 fd.close();

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1443,9 +1443,8 @@ impl CronJob {
 
     /// May free `this`.
     fn release_pending_ref(this: ThisPtr<Self>) {
-        if let Some(pending) = this.pending_ref.replace(None) {
+        if let Some(_pending) = this.pending_ref.replace(None) {
             this.maybe_downgrade();
-            drop(pending);
         }
     }
 
@@ -1514,7 +1513,6 @@ impl CronJob {
             if MODE == ClearMode::Teardown {
                 Self::release_pending_ref(this);
             }
-            drop(job);
         }
     }
 
@@ -1571,7 +1569,7 @@ impl CronJob {
         // scheduleNext → finishDeferredStop downgrades this_value and derefs the
         // list entry; bracket-ref so that path can't drop the last ref mid-function.
         // Timer heap holds the entry; `this` is live until the guard drops.
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         // R-2: shared borrows only — `cb.call()` re-enters JS, which may call
         // `stop()`/`ref()`/`unref()` on this same wrapper; a `noalias`
         // `&mut Self` here would be Stacked-Borrows UB. All mutation is
@@ -1743,7 +1741,6 @@ impl CronJob {
         job.self_ref.set(BackRef::from(job.this_ptr()));
 
         let Some(next_time) = job.compute_next_timespec() else {
-            drop(job);
             return Err(global.throw_invalid_arguments(format_args!(
                 "Cron expression '{}' has no future occurrences",
                 bstr::BStr::new(schedule_slice.slice())
@@ -1755,7 +1752,7 @@ impl CronJob {
         // so skip the list ref + append entirely.
         if vm.hot_reload == HotReload::Hot || vm.worker.is_some() {
             if let Some(jobs) = crate::jsc_hooks::cron_jobs_mut() {
-                jobs.push(job.dupe_ref());
+                jobs.push(job.clone());
             }
         }
 

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -75,7 +75,7 @@ use crate::jsc_hooks::timer_all_mut as timer_all;
 // in-flight dealloc UB) and touches nothing after the call that may free
 // `this`. Mutable state lives in `Cell`/`JsCell` fields so every access is a
 // short shared borrow.
-trait CronJobBase: Sized + bun_ptr::AnyRefCounted<DestructorCtx = ()> {
+trait CronJobBase: Sized + bun_ptr::AnyRefCounted {
     /// The single owning ref; released by `finish`.
     fn owner(&self) -> &Cell<Option<RefPtr<Self>>>;
     fn promise(&self) -> &JsCell<jsc::JSPromiseStrong>;
@@ -149,7 +149,7 @@ trait CronJobBase: Sized + bun_ptr::AnyRefCounted<DestructorCtx = ()> {
                 .promise()
                 .with_mut(|p| p.resolve(&global, JSValue::UNDEFINED));
         }
-        owner.deref();
+        drop(owner);
         ev.exit();
     }
 
@@ -1445,7 +1445,7 @@ impl CronJob {
     fn release_pending_ref(this: ThisPtr<Self>) {
         if let Some(pending) = this.pending_ref.replace(None) {
             this.maybe_downgrade();
-            pending.deref();
+            drop(pending);
         }
     }
 
@@ -1494,7 +1494,7 @@ impl CronJob {
             return;
         };
         if let Some(i) = jobs.iter().position(|j| j.as_ptr() == this.as_ptr()) {
-            jobs.swap_remove(i).deref();
+            drop(jobs.swap_remove(i));
         }
     }
 
@@ -1514,7 +1514,7 @@ impl CronJob {
             if MODE == ClearMode::Teardown {
                 Self::release_pending_ref(this);
             }
-            job.deref();
+            drop(job);
         }
     }
 
@@ -1743,7 +1743,7 @@ impl CronJob {
         job.self_ref.set(BackRef::from(job.this_ptr()));
 
         let Some(next_time) = job.compute_next_timespec() else {
-            job.deref();
+            drop(job);
             return Err(global.throw_invalid_arguments(format_args!(
                 "Cron expression '{}' has no future occurrences",
                 bstr::BStr::new(schedule_slice.slice())
@@ -1760,7 +1760,7 @@ impl CronJob {
         }
 
         // `job`'s ref moves to the JS wrapper (released via `finalize`).
-        let js_value = Self::to_js_nonnull(job.data, global);
+        let js_value = Self::to_js_nonnull(job.as_non_null(), global);
         let job = job.into_this_ptr();
         job.this_value.with_mut(|v| v.set_strong(js_value, global));
         js::cron_set_cached(js_value, global, schedule_arg);

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -29,9 +29,7 @@ use bun_options_types::WindowsOptions;
 use bun_options_types::schema::api;
 use bun_paths::resolve_path::{join_abs_string, join_abs_string_buf, platform};
 use bun_paths::{self as paths, PathBuffer, SEP};
-use bun_ptr::BackRef;
-use bun_ptr::RefCount;
-use bun_ptr::RefPtr;
+use bun_ptr::{BackRef, RefCount, RefPtr};
 use bun_standalone_graph::StandaloneModuleGraph::{
     CompileErrorReason, CompileResult, Flags as StandaloneFlags, target_base_public_path,
     to_executable,

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -557,7 +557,7 @@ impl JSBundleCompletionTask {
         crate::jsc_hooks::ActiveHandle::Bundle(NonNull::new(ctx).expect("completion")).unregister();
         // For the +1 taken by `complete_on_bundle_thread` enqueue.
         // SAFETY: `ctx` is the live heap allocation; `adopt` consumes the prior +1 on Drop.
-        let _drop_ref = unsafe { bun_ptr::ScopedRef::<Self>::adopt(ctx) };
+        let _drop_ref = unsafe { bun_ptr::RefPtr::<Self>::from_raw(ctx) };
         // SAFETY: `ctx` is the heap::alloc allocation registered in `task`,
         // dispatched exactly once per task on the JS thread. Exclusive: the
         // task has no JS-visible handle, the bundle thread's access ended when
@@ -601,6 +601,7 @@ impl JSBundleCompletionTask {
                 }
                 (*this).promise = jsc::JSPromiseStrong::default();
                 (*this).bundle_ticket = None;
+                (*this).html_build_task = None;
                 // Publish only now: from here the bundle thread may free `this`.
                 (*this)
                     .stage
@@ -631,7 +632,6 @@ impl JSBundleCompletionTask {
         if let Some(html_build_task) = this.html_build_task.take() {
             this.plugins = None;
             html_build_task.on_complete(this);
-            html_build_task.deref();
             return Ok(());
         }
 

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -78,8 +78,7 @@ pub struct JSBundleCompletionTask {
     pub(crate) stage: core::sync::atomic::AtomicU8,
 
     /// The route this build is for, kept alive until `on_complete` hands it
-    /// the result (leaked with the rest of the route if the build is cancelled
-    /// at VM teardown).
+    /// the result.
     pub(crate) html_build_task: Option<RefPtr<html_bundle::Route>>,
 
     pub(crate) result: BundleV2Result,

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -555,9 +555,9 @@ impl JSBundleCompletionTask {
 
     pub(crate) fn on_complete_anytask(ctx: *mut Self) -> bun_event_loop::JsResult<()> {
         crate::jsc_hooks::ActiveHandle::Bundle(NonNull::new(ctx).expect("completion")).unregister();
-        // For the +1 taken by `complete_on_bundle_thread` enqueue.
-        // SAFETY: `ctx` is the live heap allocation; `adopt` consumes the prior +1 on Drop.
-        let _drop_ref = unsafe { bun_ptr::RefPtr::<Self>::from_raw(ctx) };
+        // SAFETY: `ctx` is the live heap allocation; takes over the +1 taken by
+        // the `complete_on_bundle_thread` enqueue.
+        let _guard = unsafe { RefPtr::from_raw(ctx) };
         // SAFETY: `ctx` is the heap::alloc allocation registered in `task`,
         // dispatched exactly once per task on the JS thread. Exclusive: the
         // task has no JS-visible handle, the bundle thread's access ended when

--- a/src/runtime/api/standalone_graph_jsc.rs
+++ b/src/runtime/api/standalone_graph_jsc.rs
@@ -7,6 +7,7 @@ use core::ptr::NonNull;
 use bun_core::{self as bstring, strings};
 use bun_http::MimeType;
 use bun_jsc::JSGlobalObject;
+use bun_ptr::RefPtr;
 
 // `StandaloneModuleGraph` here is the inner *module* (so
 // `StandaloneModuleGraph::BASE_PUBLIC_PATH_WITH_DEFAULT_SUFFIX` resolves);
@@ -14,7 +15,6 @@ use bun_jsc::JSGlobalObject;
 use crate::webcore::Blob;
 use crate::webcore::blob::SizeType;
 use crate::webcore::blob::store::{Bytes, Data, Store};
-use bun_ptr::RefPtr;
 use bun_standalone_graph::{File, StandaloneModuleGraph};
 
 /// Extension trait wiring JSC-dependent methods onto `standalone_graph::File`.
@@ -42,14 +42,14 @@ impl FileJsc for File {
                     bun_alloc::basic::C_ALLOCATOR,
                 )
             };
-            let store = RefPtr::from(Store::new(Store {
+            let store = RefPtr::new(Store {
                 data: Data::Bytes(bytes),
                 mime_type: MimeType::NONE,
                 ref_count: bun_ptr::ThreadSafeRefCount::init(),
                 is_all_ascii: None,
-            }));
+            });
             // make it never free
-            store.ref_();
+            let _ = store.clone().into_raw();
 
             // Hold the raw pointer so we can keep mutating the store after
             // `init_with_store` consumes the `RefPtr<Store>`. The store outlives

--- a/src/runtime/api/standalone_graph_jsc.rs
+++ b/src/runtime/api/standalone_graph_jsc.rs
@@ -13,7 +13,8 @@ use bun_jsc::JSGlobalObject;
 // `File` is re-exported at the crate root.
 use crate::webcore::Blob;
 use crate::webcore::blob::SizeType;
-use crate::webcore::blob::store::{Bytes, Data, Store, StoreRef};
+use crate::webcore::blob::store::{Bytes, Data, Store};
+use bun_ptr::RefPtr;
 use bun_standalone_graph::{File, StandaloneModuleGraph};
 
 /// Extension trait wiring JSC-dependent methods onto `standalone_graph::File`.
@@ -43,7 +44,7 @@ impl FileJsc for File {
             };
             // Cannot use `..Default::default()` — `Store: Drop`
             // forbids partial moves out of the temporary default.
-            let store = StoreRef::from(Store::new(Store {
+            let store = RefPtr::from(Store::new(Store {
                 data: Data::Bytes(bytes),
                 mime_type: MimeType::NONE,
                 ref_count: bun_ptr::ThreadSafeRefCount::init(),
@@ -53,7 +54,7 @@ impl FileJsc for File {
             store.ref_();
 
             // Hold the raw pointer so we can keep mutating the store after
-            // `init_with_store` consumes the `StoreRef`. The store outlives
+            // `init_with_store` consumes the `RefPtr<Store>`. The store outlives
             // this fn (leaked above).
             let store_ptr = store.as_ptr();
 

--- a/src/runtime/api/standalone_graph_jsc.rs
+++ b/src/runtime/api/standalone_graph_jsc.rs
@@ -42,8 +42,6 @@ impl FileJsc for File {
                     bun_alloc::basic::C_ALLOCATOR,
                 )
             };
-            // Cannot use `..Default::default()` — `Store: Drop`
-            // forbids partial moves out of the temporary default.
             let store = RefPtr::from(Store::new(Store {
                 data: Data::Bytes(bytes),
                 mime_type: MimeType::NONE,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1728,7 +1728,7 @@ fn on_js_request(dev: &mut DevServer, req: &mut Request, resp: AnyResponse) {
                 Ok(b) => b,
                 Err(e) => bun_core::handle_oom(Err(e)),
             };
-        let response = route_bundle::StaticRouteRef::init_from_any_blob(
+        let response = StaticRoute::init_from_any_blob(
             crate::webcore::blob::Any::from_array_list(json_bytes),
             crate::server::static_route::InitFromBytesOptions {
                 server: dev.server,
@@ -2664,7 +2664,7 @@ impl DevServer {
         // this fn; the shared reborrow ends with this statement.
         let cached: Option<bun_ptr::ThisPtr<StaticRoute>> =
             unsafe { (*route_bundle).data.html().cached_response.as_ref() }
-                .map(route_bundle::StaticRouteRef::this_ptr);
+                .map(bun_ptr::RefPtr::this_ptr);
         let blob: bun_ptr::ThisPtr<StaticRoute> = match cached {
             Some(blob) => blob,
             None => 'generate: {
@@ -2677,7 +2677,7 @@ impl DevServer {
                 }
                 .expect("oom");
 
-                let response = route_bundle::StaticRouteRef::init_from_any_blob(
+                let response = StaticRoute::init_from_any_blob(
                     crate::webcore::AnyBlob::from_owned_slice(payload),
                     crate::server::static_route::InitFromBytesOptions {
                         mime_type: Some(&MimeType::HTML),
@@ -2875,8 +2875,7 @@ impl DevServer {
         // SAFETY: `route_bundle` points into `self.route_bundles`, not resized in
         // this fn; the shared reborrow ends with this statement.
         let cached: Option<bun_ptr::ThisPtr<StaticRoute>> =
-            unsafe { (*route_bundle).client_bundle.as_ref() }
-                .map(route_bundle::StaticRouteRef::this_ptr);
+            unsafe { (*route_bundle).client_bundle.as_ref() }.map(bun_ptr::RefPtr::this_ptr);
         let client_bundle: bun_ptr::ThisPtr<StaticRoute> = match cached {
             Some(client_bundle) => client_bundle,
             None => 'generate: {
@@ -2886,7 +2885,7 @@ impl DevServer {
                 let payload =
                     unsafe { Self::generate_client_bundle(&mut *self_ptr, &*route_bundle) }
                         .expect("oom");
-                let bundle = route_bundle::StaticRouteRef::init_from_any_blob(
+                let bundle = StaticRoute::init_from_any_blob(
                     crate::webcore::AnyBlob::from_owned_slice(payload),
                     crate::server::static_route::InitFromBytesOptions {
                         mime_type: Some(&MimeType::JAVASCRIPT),

--- a/src/runtime/bake/dev_server/assets.rs
+++ b/src/runtime/bake/dev_server/assets.rs
@@ -3,7 +3,6 @@
 use bun_collections::{ArrayHashMap, MapEntry, StringArrayHashMap};
 use bun_core::{fmt as bun_fmt, scoped_log};
 use bun_http::MimeType::MimeType;
-
 use bun_ptr::RefPtr;
 
 use super::memory_cost::{memory_cost_array_hash_map, memory_cost_array_list};

--- a/src/runtime/bake/dev_server/assets.rs
+++ b/src/runtime/bake/dev_server/assets.rs
@@ -4,9 +4,11 @@ use bun_collections::{ArrayHashMap, MapEntry, StringArrayHashMap};
 use bun_core::{fmt as bun_fmt, scoped_log};
 use bun_http::MimeType::MimeType;
 
+use bun_ptr::RefPtr;
+
 use super::memory_cost::{memory_cost_array_hash_map, memory_cost_array_list};
-use super::route_bundle::StaticRouteRef;
 use super::{ASSET_PREFIX, DevServer, FileKind, Magic};
+use crate::server::StaticRoute;
 use crate::server::static_route::InitFromBytesOptions;
 use crate::webcore::AnyBlob;
 
@@ -21,7 +23,7 @@ pub struct Assets {
     pub(crate) path_map: StringArrayHashMap<EntryIndex>,
     /// Content-addressable store. Multiple paths can point to the same content
     /// hash, tracked by `refs`.
-    pub(crate) files: ArrayHashMap<u64, StaticRouteRef>,
+    pub(crate) files: ArrayHashMap<u64, RefPtr<StaticRoute>>,
     /// Parallel to `files`. Never `0`.
     pub(crate) refs: Vec<u32>,
     /// When mutating `files`'s keys, the map must be reindexed to function.
@@ -100,15 +102,14 @@ impl Assets {
             // replaced in-place with the new asset.
             if self.refs[entry_index.get_usize()] == 1 {
                 self.files.keys_mut()[entry_index.get_usize()] = content_hash;
-                self.files.values_mut()[entry_index.get_usize()] =
-                    StaticRouteRef::init_from_any_blob(
-                        contents,
-                        InitFromBytesOptions {
-                            mime_type: Some(mime_type),
-                            server,
-                            ..Default::default()
-                        },
-                    );
+                self.files.values_mut()[entry_index.get_usize()] = StaticRoute::init_from_any_blob(
+                    contents,
+                    InitFromBytesOptions {
+                        mime_type: Some(mime_type),
+                        server,
+                        ..Default::default()
+                    },
+                );
                 // `ArrayHashMap<u64, _>` keys the entry on the hash itself.
                 self.needs_reindex = true;
                 debug_assert_eq!(self.files.count(), self.refs.len());
@@ -123,7 +124,7 @@ impl Assets {
         let file_index = match self.files.entry(content_hash) {
             MapEntry::Vacant(vacant) => {
                 let file_index = vacant.index();
-                vacant.insert(StaticRouteRef::init_from_any_blob(
+                vacant.insert(StaticRoute::init_from_any_blob(
                     contents,
                     InitFromBytesOptions {
                         mime_type: Some(mime_type),
@@ -152,7 +153,7 @@ impl Assets {
         debug_assert!(dec_count > 0);
         self.refs[index.get_usize()] -= dec_count;
         if self.refs[index.get_usize()] == 0 {
-            self.files.swap_remove_at(index.get_usize());
+            drop(self.files.swap_remove_at(index.get_usize()));
             self.refs.swap_remove(index.get_usize());
             // `swap_remove` moved the entry that was at the old last index into
             // `index`'s slot. Any `path_map` value that still points at the old
@@ -189,7 +190,7 @@ impl Assets {
     }
 
     /// Look up a `StaticRoute` by content hash.
-    pub(crate) fn get(&self, content_hash: u64) -> Option<&StaticRouteRef> {
+    pub(crate) fn get(&self, content_hash: u64) -> Option<&RefPtr<StaticRoute>> {
         debug_assert_eq!(self.files.count(), self.refs.len());
         self.files.get(&content_hash)
     }

--- a/src/runtime/bake/dev_server/route_bundle.rs
+++ b/src/runtime/bake/dev_server/route_bundle.rs
@@ -4,9 +4,9 @@ use super::incremental_graph;
 use super::jsc;
 use super::source_map_store;
 use crate::bake::framework_router;
-use crate::server::static_route::InitFromBytesOptions;
+use bun_ptr::RefPtr;
+
 use crate::server::{StaticRoute, html_bundle::HTMLBundleRoute};
-use crate::webcore::AnyBlob;
 
 /// `bun.GenericIndex(u30, RouteBundle)`.
 pub enum RouteBundleMarker {}
@@ -32,55 +32,16 @@ pub struct Framework {
     pub(crate) cached_css_file_array: jsc::StrongOptional,
 }
 
-/// The one ref DevServer holds on a [`StaticRoute`] it built (client bundle,
-/// rendered HTML page, asset, source map response); released on drop. The
-/// `StaticRoute::on*` handlers take their own ref per in-flight response, so
-/// the route itself may outlive this handle.
-pub(crate) struct StaticRouteRef(bun_ptr::RefPtr<StaticRoute>);
-
-impl StaticRouteRef {
-    pub(crate) fn init_from_any_blob(blob: AnyBlob, options: InitFromBytesOptions<'_>) -> Self {
-        Self(StaticRoute::init_from_any_blob(blob, options))
-    }
-
-    /// For the `StaticRoute::on*` handlers, which register the route as uws
-    /// userdata.
-    #[inline]
-    pub(crate) fn this_ptr(&self) -> bun_ptr::ThisPtr<StaticRoute> {
-        self.0.this_ptr()
-    }
-}
-
-impl core::ops::Deref for StaticRouteRef {
-    type Target = StaticRoute;
-    #[inline]
-    fn deref(&self) -> &StaticRoute {
-        &self.0
-    }
-}
-
-impl Drop for StaticRouteRef {
-    #[inline]
-    fn drop(&mut self) {
-        self.0.deref();
-    }
-}
-
 pub struct Html {
-    /// Ref taken in `get_or_put_route_bundle`; `RefPtr` has no `Drop`, so
-    /// `Drop for Html` releases it.
-    pub(crate) html_bundle: bun_ptr::RefPtr<HTMLBundleRoute>,
+    /// Ref taken in `get_or_put_route_bundle`.
+    pub(crate) html_bundle: RefPtr<HTMLBundleRoute>,
     pub(crate) bundled_file: incremental_graph::ClientFileIndex,
     pub(crate) script_injection_offset: Option<ByteOffset>,
     pub(crate) bundled_html_text: Option<Box<[u8]>>,
-    /// The rendered page, built on first request.
-    pub(crate) cached_response: Option<StaticRouteRef>,
-}
-
-impl Drop for Html {
-    fn drop(&mut self) {
-        self.html_bundle.deref();
-    }
+    /// The rendered page, built on first request. The `StaticRoute::on*`
+    /// handlers take their own ref per in-flight response, so the route may
+    /// outlive this handle.
+    pub(crate) cached_response: Option<RefPtr<StaticRoute>>,
 }
 
 pub enum Data {
@@ -147,7 +108,7 @@ pub struct RouteBundle {
     pub(crate) server_state: State,
     pub(crate) data: Data,
     /// The route's client-side script, built on first request.
-    pub(crate) client_bundle: Option<StaticRouteRef>,
+    pub(crate) client_bundle: Option<RefPtr<StaticRoute>>,
     pub(crate) client_script_generation: u32,
     pub(crate) active_viewers: u32,
 }

--- a/src/runtime/bake/dev_server/route_bundle.rs
+++ b/src/runtime/bake/dev_server/route_bundle.rs
@@ -1,11 +1,11 @@
 //! `DevServer.RouteBundle` — per-navigatable-route bundling state.
 
+use bun_ptr::RefPtr;
+
 use super::incremental_graph;
 use super::jsc;
 use super::source_map_store;
 use crate::bake::framework_router;
-use bun_ptr::RefPtr;
-
 use crate::server::{StaticRoute, html_bundle::HTMLBundleRoute};
 
 /// `bun.GenericIndex(u30, RouteBundle)`.

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -451,7 +451,7 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
             pending_slot: None,
             head: CAresLookup {
                 // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-                resolver: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
+                resolver: resolver.map(|r| unsafe { bun_ptr::RefPtr::init_ref(r) }),
                 global_this: bun_ptr::BackRef::new(global_this),
                 promise: JSPromiseStrong::init(global_this),
                 poll_ref,
@@ -585,7 +585,7 @@ impl GetHostByAddrInfoRequest {
             pending_slot: None,
             head: CAresReverse {
                 // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-                resolver: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
+                resolver: resolver.map(|r| unsafe { bun_ptr::RefPtr::init_ref(r) }),
                 global_this: bun_ptr::BackRef::new(global_this),
                 promise: JSPromiseStrong::init(global_this),
                 poll_ref,
@@ -1156,7 +1156,7 @@ impl GetAddrInfoRequest {
             pending_slot: None,
             head: DNSLookup {
                 // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-                resolver: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
+                resolver: resolver.map(|r| unsafe { bun_ptr::RefPtr::init_ref(r) }),
                 global_this: bun_ptr::BackRef::new(global_this),
                 promise: JSPromiseStrong::init(global_this),
                 poll_ref,
@@ -1431,7 +1431,7 @@ impl c_ares::AddrInfoHandler for GetAddrInfoRequest {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct CAresReverse {
-    pub resolver: Option<bun_ptr::IntrusiveRc<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
+    pub resolver: Option<bun_ptr::RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
     pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
     pub promise: JSPromiseStrong,
     pub poll_ref: KeepAlive,
@@ -1461,7 +1461,7 @@ impl CAresReverse {
         poll_ref.ref_(js_event_loop_ctx());
         bun_core::heap::into_raw(Box::new(Self {
             // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-            resolver: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
+            resolver: resolver.map(|r| unsafe { bun_ptr::RefPtr::init_ref(r) }),
             global_this: bun_ptr::BackRef::new(global_this),
             promise: JSPromiseStrong::init(global_this),
             poll_ref,
@@ -1522,7 +1522,7 @@ impl CAresReverse {
             let global_this = (*this).global_this();
             result.settle(&mut promise, global_this);
             if let Some(resolver) = (*this).resolver.as_ref() {
-                // IntrusiveRc holds a live ref; request_completed mutates pending_requests counter only.
+                // RefPtr holds a live ref; request_completed mutates pending_requests counter only.
                 (*resolver.as_ptr()).request_completed();
             }
             Self::destroy(this);
@@ -1547,11 +1547,6 @@ impl Drop for CAresReverse {
     fn drop(&mut self) {
         let _ = self.global_this();
         self.poll_ref.unref(js_event_loop_ctx());
-        // RefPtr (= IntrusiveRc) does NOT deref on Drop; release the ref taken
-        // by `init_ref` in `init()` / `GetHostByAddrInfoRequest::init()`.
-        if let Some(resolver) = self.resolver.take() {
-            resolver.deref();
-        }
         // self.name freed by Box<[u8]> Drop
     }
 }
@@ -1561,7 +1556,7 @@ impl Drop for CAresReverse {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct CAresLookup<T: CAresRecordType> {
-    pub resolver: Option<bun_ptr::IntrusiveRc<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
+    pub resolver: Option<bun_ptr::RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
     pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
     pub promise: JSPromiseStrong,
     pub poll_ref: KeepAlive,
@@ -1586,7 +1581,7 @@ impl<T: CAresRecordType> CAresLookup<T> {
         poll_ref.ref_(js_event_loop_ctx());
         Self::new(Self {
             // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-            resolver: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
+            resolver: resolver.map(|r| unsafe { bun_ptr::RefPtr::init_ref(r) }),
             global_this: bun_ptr::BackRef::new(global_this),
             promise: JSPromiseStrong::init(global_this),
             poll_ref,
@@ -1660,7 +1655,7 @@ impl<T: CAresRecordType> CAresLookup<T> {
             let global_this = (*this).global_this();
             result.settle(&mut promise, global_this);
             if let Some(resolver) = (*this).resolver.as_ref() {
-                // IntrusiveRc holds a live ref; request_completed mutates pending_requests counter only.
+                // RefPtr holds a live ref; request_completed mutates pending_requests counter only.
                 (*resolver.as_ptr()).request_completed();
             }
             Self::destroy(this);
@@ -1685,11 +1680,6 @@ impl<T: CAresRecordType> Drop for CAresLookup<T> {
     fn drop(&mut self) {
         let _ = self.global_this();
         self.poll_ref.unref(js_event_loop_ctx());
-        // RefPtr (= IntrusiveRc) does NOT deref on Drop; release the ref taken
-        // by `init_ref` in `init()` / `ResolveInfoRequest::init()`.
-        if let Some(resolver) = self.resolver.take() {
-            resolver.deref();
-        }
         // self.name freed by Box<[u8]> Drop
     }
 }
@@ -1699,7 +1689,7 @@ impl<T: CAresRecordType> Drop for CAresLookup<T> {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct DNSLookup {
-    pub resolver: Option<bun_ptr::IntrusiveRc<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
+    pub resolver: Option<bun_ptr::RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
     pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
     pub promise: JSPromiseStrong,
     pub allocated: bool,
@@ -1729,7 +1719,7 @@ impl DNSLookup {
 
         bun_core::heap::into_raw(Box::new(Self {
             // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-            resolver: Some(unsafe { bun_ptr::IntrusiveRc::init_ref(resolver) }),
+            resolver: Some(unsafe { bun_ptr::RefPtr::init_ref(resolver) }),
             global_this: bun_ptr::BackRef::new(global_this),
             poll_ref,
             promise: JSPromiseStrong::init(global_this),
@@ -1833,7 +1823,7 @@ impl DNSLookup {
             let global_this = (*this).global_this();
             result.settle(&mut promise, global_this);
             if let Some(resolver) = (*this).resolver.as_ref() {
-                // IntrusiveRc holds a live ref; request_completed mutates pending_requests counter only.
+                // RefPtr holds a live ref; request_completed mutates pending_requests counter only.
                 (*resolver.as_ptr()).request_completed();
             }
             Self::destroy(this);
@@ -1920,11 +1910,6 @@ impl Drop for DNSLookup {
         self.poll_ref.unref(Async::posix_event_loop::get_vm_ctx(
             Async::AllocatorType::Js,
         ));
-        // RefPtr (= IntrusiveRc) does NOT deref on Drop; release the ref taken
-        // by `init_ref` in `init()` / `GetAddrInfoRequest::init()`.
-        if let Some(resolver) = self.resolver.take() {
-            resolver.deref();
-        }
     }
 }
 
@@ -3621,14 +3606,13 @@ impl Drop for ResolverRefGuard {
     }
 }
 
-// `pub const ref/deref` from RefCount mixin → provided by `bun_ptr::IntrusiveRc<Self>`.
+// `pub const ref/deref` from RefCount mixin → provided by `bun_ptr::RefPtr<Self>`.
 impl bun_ptr::RefCounted for Resolver {
-    type DestructorCtx = ();
     unsafe fn get_ref_count(this: *mut Self) -> *mut bun_ptr::RefCount<Self> {
         // SAFETY: caller contract — `this` points to a live Self.
         unsafe { &raw mut (*this).ref_count }
     }
-    unsafe fn destructor(this: *mut Self, _ctx: ()) {
+    unsafe fn destructor(this: *mut Self) {
         Self::deinit(this);
     }
 }
@@ -3971,7 +3955,7 @@ impl Resolver {
 
     // ─── R-2 interior-mutability helpers ────────────────────────────────────
 
-    /// `self`'s address as `*mut Self` for c-ares / `FilePoll` / `IntrusiveRc`
+    /// `self`'s address as `*mut Self` for c-ares / `FilePoll` / `RefPtr`
     /// ctx slots and `Self::deref`. Callbacks deref it as `&*const` (shared) —
     /// see `on_dns_poll`, `on_cares_complete` — so no write provenance is
     /// required; the `*mut` spelling is purely to match the C signature. All
@@ -4119,7 +4103,7 @@ impl Resolver {
         scopeguard::defer! {
             // SAFETY: `this` is the heap allocation from `init`. This releases
             // the ref taken by `add_timer`. Every caller holds at least one
-            // other ref for the duration of this call (an `IntrusiveRc`, a
+            // other ref for the duration of this call (a `RefPtr`, a
             // `ref_scope` guard, or the global-resolver permanent pin), so this
             // `deref` cannot reach 0 while `&self` is live.
             unsafe {

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -27,6 +27,7 @@ use bun_jsc::{
     SystemError, host_fn,
 };
 use bun_paths::{MAX_PATH_BYTES, PathBuffer};
+use bun_ptr::RefPtr;
 #[cfg(windows)]
 use bun_sys::windows::libuv;
 #[cfg(not(windows))]
@@ -451,7 +452,7 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
             pending_slot: None,
             head: CAresLookup {
                 // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-                resolver: resolver.map(|r| unsafe { bun_ptr::RefPtr::init_ref(r) }),
+                resolver: resolver.map(|r| unsafe { RefPtr::init_ref(r) }),
                 global_this: bun_ptr::BackRef::new(global_this),
                 promise: JSPromiseStrong::init(global_this),
                 poll_ref,
@@ -585,7 +586,7 @@ impl GetHostByAddrInfoRequest {
             pending_slot: None,
             head: CAresReverse {
                 // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-                resolver: resolver.map(|r| unsafe { bun_ptr::RefPtr::init_ref(r) }),
+                resolver: resolver.map(|r| unsafe { RefPtr::init_ref(r) }),
                 global_this: bun_ptr::BackRef::new(global_this),
                 promise: JSPromiseStrong::init(global_this),
                 poll_ref,
@@ -1156,7 +1157,7 @@ impl GetAddrInfoRequest {
             pending_slot: None,
             head: DNSLookup {
                 // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-                resolver: resolver.map(|r| unsafe { bun_ptr::RefPtr::init_ref(r) }),
+                resolver: resolver.map(|r| unsafe { RefPtr::init_ref(r) }),
                 global_this: bun_ptr::BackRef::new(global_this),
                 promise: JSPromiseStrong::init(global_this),
                 poll_ref,
@@ -1431,7 +1432,7 @@ impl c_ares::AddrInfoHandler for GetAddrInfoRequest {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct CAresReverse {
-    pub resolver: Option<bun_ptr::RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
+    pub resolver: Option<RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
     pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
     pub promise: JSPromiseStrong,
     pub poll_ref: KeepAlive,
@@ -1461,7 +1462,7 @@ impl CAresReverse {
         poll_ref.ref_(js_event_loop_ctx());
         bun_core::heap::into_raw(Box::new(Self {
             // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-            resolver: resolver.map(|r| unsafe { bun_ptr::RefPtr::init_ref(r) }),
+            resolver: resolver.map(|r| unsafe { RefPtr::init_ref(r) }),
             global_this: bun_ptr::BackRef::new(global_this),
             promise: JSPromiseStrong::init(global_this),
             poll_ref,
@@ -1556,7 +1557,7 @@ impl Drop for CAresReverse {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct CAresLookup<T: CAresRecordType> {
-    pub resolver: Option<bun_ptr::RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
+    pub resolver: Option<RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
     pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
     pub promise: JSPromiseStrong,
     pub poll_ref: KeepAlive,
@@ -1581,7 +1582,7 @@ impl<T: CAresRecordType> CAresLookup<T> {
         poll_ref.ref_(js_event_loop_ctx());
         Self::new(Self {
             // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-            resolver: resolver.map(|r| unsafe { bun_ptr::RefPtr::init_ref(r) }),
+            resolver: resolver.map(|r| unsafe { RefPtr::init_ref(r) }),
             global_this: bun_ptr::BackRef::new(global_this),
             promise: JSPromiseStrong::init(global_this),
             poll_ref,
@@ -1689,7 +1690,7 @@ impl<T: CAresRecordType> Drop for CAresLookup<T> {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct DNSLookup {
-    pub resolver: Option<bun_ptr::RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
+    pub resolver: Option<RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
     pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
     pub promise: JSPromiseStrong,
     pub allocated: bool,
@@ -1719,7 +1720,7 @@ impl DNSLookup {
 
         bun_core::heap::into_raw(Box::new(Self {
             // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
-            resolver: Some(unsafe { bun_ptr::RefPtr::init_ref(resolver) }),
+            resolver: Some(unsafe { RefPtr::init_ref(resolver) }),
             global_this: bun_ptr::BackRef::new(global_this),
             poll_ref,
             promise: JSPromiseStrong::init(global_this),
@@ -3592,21 +3593,6 @@ pub struct Resolver {
 
 bun_event_loop::impl_timer_owner!(Resolver; from_timer_ptr => event_loop_timer);
 
-/// RAII owner for a scoped `Resolver` refcount bump.
-/// Constructed via [`Resolver::ref_scope`]; releases the ref on Drop.
-#[must_use = "dropping immediately releases the scoped ref"]
-struct ResolverRefGuard(*mut Resolver);
-
-impl Drop for ResolverRefGuard {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: `ref_scope` took a ref on a live heap-allocated Resolver, so
-        // `self.0` is still live here and `deref` has valid write provenance.
-        unsafe { Resolver::deref(self.0) };
-    }
-}
-
-// `pub const ref/deref` from RefCount mixin → provided by `bun_ptr::RefPtr<Self>`.
 impl bun_ptr::RefCounted for Resolver {
     unsafe fn get_ref_count(this: *mut Self) -> *mut bun_ptr::RefCount<Self> {
         // SAFETY: caller contract — `this` points to a live Self.
@@ -3886,23 +3872,6 @@ impl Resolver {
         unsafe { bun_ptr::RefCount::<Self>::deref(this) };
     }
 
-    /// RAII bracket: bump the intrusive refcount now, drop it on guard Drop,
-    /// so re-entrant c-ares callbacks that release their own refs cannot free
-    /// `*this` mid-call.
-    ///
-    /// Captures a raw `*mut` (not `&self`) so the guard does not borrow the
-    /// resolver — gives `deref` proper write provenance for the final
-    /// `heap::take` in `deinit`.
-    ///
-    /// # Safety
-    /// `this` must point to a live heap-allocated `Resolver` (see `init`).
-    #[inline]
-    unsafe fn ref_scope(this: *mut Self) -> ResolverRefGuard {
-        // SAFETY: caller contract — `this` is live; `ref_()` uses interior mutability.
-        unsafe { (*this).ref_() };
-        ResolverRefGuard(this)
-    }
-
     pub(crate) fn setup(vm: &VirtualMachine) -> Self {
         Self {
             ref_count: bun_ptr::RefCount::init(),
@@ -4103,8 +4072,8 @@ impl Resolver {
         scopeguard::defer! {
             // SAFETY: `this` is the heap allocation from `init`. This releases
             // the ref taken by `add_timer`. Every caller holds at least one
-            // other ref for the duration of this call (a `RefPtr`, a
-            // `ref_scope` guard, or the global-resolver permanent pin), so this
+            // other ref for the duration of this call (a `RefPtr` or the
+            // global-resolver permanent pin), so this
             // `deref` cannot reach 0 while `&self` is live.
             unsafe {
                 let uws_loop = (*this).vm().uws_loop();
@@ -4229,8 +4198,8 @@ impl Resolver {
         result: Option<OwnedReply<T>>,
     ) {
         // cache_name = format!("pending_{}_cache_cares", T::TYPE_NAME)
-        // SAFETY: `self` is the live heap allocation; ref_scope keeps count > 0 across re-entrant callbacks.
-        let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
+        // SAFETY: `self` is the live heap allocation; the guard keeps count > 0 across re-entrant callbacks.
+        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
 
         let key = {
             let cache = self.pending_cache_for::<T>(T::CACHE_FIELD);
@@ -4298,8 +4267,8 @@ impl Resolver {
     ) {
         let key = self.get_key_host(index, PendingCacheField::PendingHostCacheCares);
 
-        // SAFETY: `self` is the live heap allocation; ref_scope keeps count > 0 across re-entrant callbacks.
-        let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
+        // SAFETY: `self` is the live heap allocation; the guard keeps count > 0 across re-entrant callbacks.
+        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
 
         let Some(addr) = result else {
             // SAFETY: `key.lookup` is the heap-allocated request stored in the
@@ -4368,8 +4337,8 @@ impl Resolver {
         bun_output::scoped_log!(DNSResolver, "drainPendingHostNative");
         let key = self.get_key_host(index, PendingCacheField::PendingHostCacheNative);
 
-        // SAFETY: `self` is the live heap allocation; ref_scope keeps count > 0 across re-entrant callbacks.
-        let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
+        // SAFETY: `self` is the live heap allocation; the guard keeps count > 0 across re-entrant callbacks.
+        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
 
         let mut array: Outcome = match super::options_jsc::result_any_to_js(result, global_object)
             .transpose()
@@ -4440,8 +4409,8 @@ impl Resolver {
     ) {
         let key = self.get_key_addr(index);
 
-        // SAFETY: `self` is the live heap allocation; ref_scope keeps count > 0 across re-entrant callbacks.
-        let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
+        // SAFETY: `self` is the live heap allocation; the guard keeps count > 0 across re-entrant callbacks.
+        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
 
         let Some(addr) = result else {
             // SAFETY: `key.lookup` is the heap-allocated request stored in the
@@ -4509,8 +4478,8 @@ impl Resolver {
     ) {
         let key = self.get_key_nameinfo(index);
 
-        // SAFETY: `self` is the live heap allocation; ref_scope keeps count > 0 across re-entrant callbacks.
-        let _g = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
+        // SAFETY: `self` is the live heap allocation; the guard keeps count > 0 across re-entrant callbacks.
+        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
 
         let Some(mut name_info) = result else {
             // SAFETY: `key.lookup` is the heap-allocated request stored in the
@@ -4669,14 +4638,14 @@ impl Resolver {
         // via `from_poll` (libuv guarantees the handle outlives this callback).
         // `parent` is the heap-allocated Resolver back-ptr (set in
         // `on_dns_socket_state`); it is kept alive across `Channel::process` by the
-        // `ref_()`/`_deref` bracket below. `channel` is non-null because c-ares
+        // `_guard` below. `channel` is non-null because c-ares
         // must have been initialized for this poll callback to fire.
         unsafe {
             let parent: *mut Resolver = (*poll).parent;
             let vm = (*parent).vm.get();
             let _exit = vm.enter_event_loop_scope();
             // SAFETY: `parent` is the live heap-allocated Resolver back-ptr.
-            let _deref = Self::ref_scope(parent);
+            let _guard = RefPtr::init_ref(parent);
             // channel must be non-null here as c_ares must have been initialized if we're receiving callbacks
             let channel = (*parent).channel.get().unwrap();
             if status < 0 {
@@ -4730,8 +4699,8 @@ impl Resolver {
             return;
         };
 
-        // SAFETY: `self` is the heap allocation from `init`; ref_scope keeps count > 0 across re-entrant callbacks.
-        let _deref = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
+        // SAFETY: `self` is the heap allocation from `init`; the guard keeps count > 0 across re-entrant callbacks.
+        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
 
         // SAFETY: `channel` is the live c-ares channel owned by `self`; no `&mut`
         // to `*self` is held across this re-entrant call (all fields are

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -1432,7 +1432,7 @@ impl c_ares::AddrInfoHandler for GetAddrInfoRequest {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct CAresReverse {
-    pub resolver: Option<RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
+    pub resolver: Option<RefPtr<Resolver>>,
     pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
     pub promise: JSPromiseStrong,
     pub poll_ref: KeepAlive,
@@ -1557,7 +1557,7 @@ impl Drop for CAresReverse {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct CAresLookup<T: CAresRecordType> {
-    pub resolver: Option<RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
+    pub resolver: Option<RefPtr<Resolver>>,
     pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
     pub promise: JSPromiseStrong,
     pub poll_ref: KeepAlive,
@@ -1690,7 +1690,7 @@ impl<T: CAresRecordType> Drop for CAresLookup<T> {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct DNSLookup {
-    pub resolver: Option<RefPtr<Resolver>>, // SHARED (intrusive — Resolver embeds ref_count and crosses FFI as m_ctx)
+    pub resolver: Option<RefPtr<Resolver>>,
     pub global_this: bun_ptr::BackRef<JSGlobalObject>, // JSC_BORROW (BACKREF — JSGlobalObject outlives the request)
     pub promise: JSPromiseStrong,
     pub allocated: bool,
@@ -3845,6 +3845,13 @@ impl RecordType {
 }
 
 impl Resolver {
+    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
+    #[inline]
+    fn ref_guard(&self) -> RefPtr<Self> {
+        // SAFETY: `self` is the live heap allocation.
+        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
+    }
+
     pub(crate) fn vm(&self) -> &VirtualMachine {
         self.vm.get()
     }
@@ -4198,8 +4205,7 @@ impl Resolver {
         result: Option<OwnedReply<T>>,
     ) {
         // cache_name = format!("pending_{}_cache_cares", T::TYPE_NAME)
-        // SAFETY: `self` is the live heap allocation; the guard keeps count > 0 across re-entrant callbacks.
-        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
+        let _guard = self.ref_guard();
 
         let key = {
             let cache = self.pending_cache_for::<T>(T::CACHE_FIELD);
@@ -4267,8 +4273,7 @@ impl Resolver {
     ) {
         let key = self.get_key_host(index, PendingCacheField::PendingHostCacheCares);
 
-        // SAFETY: `self` is the live heap allocation; the guard keeps count > 0 across re-entrant callbacks.
-        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
+        let _guard = self.ref_guard();
 
         let Some(addr) = result else {
             // SAFETY: `key.lookup` is the heap-allocated request stored in the
@@ -4337,8 +4342,7 @@ impl Resolver {
         bun_output::scoped_log!(DNSResolver, "drainPendingHostNative");
         let key = self.get_key_host(index, PendingCacheField::PendingHostCacheNative);
 
-        // SAFETY: `self` is the live heap allocation; the guard keeps count > 0 across re-entrant callbacks.
-        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
+        let _guard = self.ref_guard();
 
         let mut array: Outcome = match super::options_jsc::result_any_to_js(result, global_object)
             .transpose()
@@ -4409,8 +4413,7 @@ impl Resolver {
     ) {
         let key = self.get_key_addr(index);
 
-        // SAFETY: `self` is the live heap allocation; the guard keeps count > 0 across re-entrant callbacks.
-        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
+        let _guard = self.ref_guard();
 
         let Some(addr) = result else {
             // SAFETY: `key.lookup` is the heap-allocated request stored in the
@@ -4478,8 +4481,7 @@ impl Resolver {
     ) {
         let key = self.get_key_nameinfo(index);
 
-        // SAFETY: `self` is the live heap allocation; the guard keeps count > 0 across re-entrant callbacks.
-        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
+        let _guard = self.ref_guard();
 
         let Some(mut name_info) = result else {
             // SAFETY: `key.lookup` is the heap-allocated request stored in the
@@ -4699,8 +4701,7 @@ impl Resolver {
             return;
         };
 
-        // SAFETY: `self` is the heap allocation from `init`; the guard keeps count > 0 across re-entrant callbacks.
-        let _guard = unsafe { RefPtr::init_ref(self.as_ctx_ptr()) };
+        let _guard = self.ref_guard();
 
         // SAFETY: `channel` is the live c-ares channel owned by `self`; no `&mut`
         // to `*self` is held across this re-entrant call (all fields are

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4833,7 +4833,7 @@ pub(crate) fn parse_http_date(value: &[u8]) -> Option<u64> {
 fn __bun_stdio_blob_store_new(fd: bun_sys::Fd, is_atty: bool, mode: bun_sys::Mode) -> *mut () {
     use bun_jsc::node_path::PathOrFileDescriptor;
     use bun_jsc::webcore_types::store::{Data, File, Store};
-    let store: Box<Store> = Store::new(Store {
+    bun_core::heap::into_raw(Box::new(Store {
         data: Data::File(File {
             pathlike: PathOrFileDescriptor::Fd(fd),
             is_atty: Some(is_atty),
@@ -4843,8 +4843,8 @@ fn __bun_stdio_blob_store_new(fd: bun_sys::Fd, is_atty: bool, mode: bun_sys::Mod
         mime_type: bun_http_types::MimeType::NONE,
         ref_count: bun_ptr::ThreadSafeRefCount::init_exact_refs(2),
         is_all_ascii: None,
-    });
-    bun_core::heap::into_raw(store).cast()
+    }))
+    .cast()
 }
 
 /// Releases both refs from [`__bun_stdio_blob_store_new`]'s `+2` (one owner ref + one

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4848,7 +4848,7 @@ fn __bun_stdio_blob_store_new(fd: bun_sys::Fd, is_atty: bool, mode: bun_sys::Mod
 }
 
 /// Releases both refs from [`__bun_stdio_blob_store_new`]'s `+2` (one owner ref + one
-/// dead immortality sentinel). Live retained `StoreRef`s keep their own `+1`, so safe.
+/// dead immortality sentinel). Live retained `RefPtr<Store>`s keep their own `+1`, so safe.
 #[unsafe(no_mangle)]
 fn __bun_stdio_blob_store_deinit(ptr: *mut ()) {
     use bun_jsc::webcore_types::store::Store;

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -293,7 +293,7 @@ impl StatWatcherScheduler {
         // ref'd when the work-pool task was scheduled
         // SAFETY: `this` is live; one ref (taken in `timer_callback`) is owned
         // by this callback and adopted here.
-        let _guard = unsafe { RefPtr::from_raw(this) };
+        let guard = unsafe { RefPtr::from_raw(this) };
         // BACKREF — `this` is alive (ref'd when the timer was scheduled);
         // `ParentRef` Deref gives safe `&Self` for the queue/interval reads.
         let this_ref = ParentRef::from(NonNull::new(this).expect("work_pool_callback: scheduler"));
@@ -362,7 +362,7 @@ impl StatWatcherScheduler {
         // Publish the queue writes above before declaring the work-pool hop
         // finished; `shutdown_for_exit` Acquire-loads this and then drains.
         this_ref.work_pool_in_flight.store(false, Ordering::Release);
-        drop(_guard);
+        drop(guard);
         drop(ticket);
     }
 

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -89,60 +89,6 @@ unsafe impl bun_threading::Linked for StatWatcher {
     }
 }
 
-/// RAII owner of one outstanding [`StatWatcherScheduler`] ref. Adopts the
-/// "task in flight" ref taken in [`StatWatcherScheduler::timer_callback`] and
-/// releases it on Drop.
-#[must_use = "dropping immediately releases the adopted ref"]
-struct SchedulerRefGuard(*mut StatWatcherScheduler);
-
-impl SchedulerRefGuard {
-    /// Take ownership of a ref the caller already holds (no bump).
-    ///
-    /// # Safety
-    /// `ptr` must point to a live `StatWatcherScheduler` and the caller must
-    /// own one outstanding ref, which is transferred to the returned guard.
-    #[inline]
-    unsafe fn adopt(ptr: *mut StatWatcherScheduler) -> Self {
-        Self(ptr)
-    }
-}
-
-impl Drop for SchedulerRefGuard {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: `adopt` contract — `self.0` is live and we own one ref.
-        unsafe { ThreadSafeRefCount::<StatWatcherScheduler>::deref(self.0) };
-    }
-}
-
-/// RAII owner of one outstanding [`StatWatcher`] ref. Adopts a ref taken
-/// elsewhere (e.g. by `InitialStatTask::create_and_schedule` or
-/// [`StatWatcher::restat`]) and releases it on Drop.
-/// Holds a raw pointer so no `&`/`&mut StatWatcher` is
-/// live across the potential free in `deref`.
-#[must_use = "dropping immediately releases the adopted ref"]
-struct WatcherRefGuard(*mut StatWatcher);
-
-impl WatcherRefGuard {
-    /// Take ownership of a ref the caller already holds (no bump).
-    ///
-    /// # Safety
-    /// `ptr` must point to a live `StatWatcher` and the caller must own one
-    /// outstanding ref, which is transferred to the returned guard.
-    #[inline]
-    unsafe fn adopt(ptr: *mut StatWatcher) -> Self {
-        Self(ptr)
-    }
-}
-
-impl Drop for WatcherRefGuard {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: `adopt` contract — `self.0` is live and we own one ref.
-        unsafe { ThreadSafeRefCount::<StatWatcher>::deref(self.0) };
-    }
-}
-
 impl StatWatcherScheduler {
     /// # Safety
     /// `this` must point to a live `StatWatcherScheduler`.
@@ -327,7 +273,7 @@ impl StatWatcherScheduler {
         }
 
         // One ref is held across the work-pool hop (released by the
-        // `SchedulerRefGuard` in `work_pool_callback`). Taken here — not in
+        // `RefPtr::from_raw` in `work_pool_callback`). Taken here — not in
         // `set_interval` — so the count exactly tracks "task in flight" instead
         // of accumulating one leak per `set_interval(0)` / re-arm.
         // SAFETY: `self` is live (`&mut self`).
@@ -347,7 +293,7 @@ impl StatWatcherScheduler {
         // ref'd when the work-pool task was scheduled
         // SAFETY: `this` is live; one ref (taken in `timer_callback`) is owned
         // by this callback and adopted here.
-        let _ref_guard = unsafe { SchedulerRefGuard::adopt(this) };
+        let _guard = unsafe { RefPtr::from_raw(this) };
         // BACKREF — `this` is alive (ref'd when the timer was scheduled);
         // `ParentRef` Deref gives safe `&Self` for the queue/interval reads.
         let this_ref = ParentRef::from(NonNull::new(this).expect("work_pool_callback: scheduler"));
@@ -416,7 +362,7 @@ impl StatWatcherScheduler {
         // Publish the queue writes above before declaring the work-pool hop
         // finished; `shutdown_for_exit` Acquire-loads this and then drains.
         this_ref.work_pool_in_flight.store(false, Ordering::Release);
-        drop(_ref_guard);
+        drop(_guard);
         drop(ticket);
     }
 
@@ -476,9 +422,8 @@ impl StatWatcherScheduler {
         }
 
         // Release the RareData ref (`into_raw()` in `lazy_scheduler`). The
-        // scheduler stays alive until every remaining `StatWatcher::finalize`
-        // drops its `RefPtr` during `lastChanceToFinalize`; the last of those
-        // brings the count to zero.
+        // scheduler stays alive until the last remaining `StatWatcher` (each
+        // holds a `scheduler` ref) is freed.
         // SAFETY: `this` is live and we own the RareData ref.
         Self::deref(this);
     }
@@ -770,7 +715,7 @@ impl StatWatcher {
 
     fn initial_stat_success_on_main_thread(this: *mut StatWatcher) -> bun_event_loop::JsResult<()> {
         // SAFETY: balance the ref from createAndSchedule(); raw ptr captured (not `&self`).
-        let _ref_guard = unsafe { WatcherRefGuard::adopt(this) };
+        let _guard = unsafe { RefPtr::from_raw(this) };
         // BACKREF — `this` is alive (ref'd in
         // InitialStatTask::create_and_schedule). R-2: all field access via
         // Cell/JsCell/Atomic; `ParentRef` Deref gives safe `&Self`.
@@ -796,7 +741,7 @@ impl StatWatcher {
 
     fn initial_stat_error_on_main_thread(this: *mut StatWatcher) -> bun_event_loop::JsResult<()> {
         // SAFETY: balance the ref from createAndSchedule(); raw ptr captured (not `&self`).
-        let _ref_guard = unsafe { WatcherRefGuard::adopt(this) };
+        let _guard = unsafe { RefPtr::from_raw(this) };
         // BACKREF — `this` is alive (ref'd in
         // InitialStatTask::create_and_schedule). R-2: `cb.call()` below
         // re-enters JS, which may call `do_close()` → fresh `&Self` from
@@ -883,7 +828,7 @@ impl StatWatcher {
         this: *mut StatWatcher,
     ) -> bun_event_loop::JsResult<()> {
         // SAFETY: balance the ref from restat(); raw ptr captured (not `&self`).
-        let _ref_guard = unsafe { WatcherRefGuard::adopt(this) };
+        let _guard = unsafe { RefPtr::from_raw(this) };
         // BACKREF — `this` is alive (ref'd in restat()). R-2: `cb.call()`
         // below re-enters JS, which may call `do_close()` → fresh `&Self` from
         // m_ctx; aliased `&` is sound, aliased `&mut` is not (and the

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -763,7 +763,6 @@ impl StatWatcher {
         let this = ParentRef::from(NonNull::new(this_ptr).expect("finalize: watcher"));
         this.this_value.with_mut(|r| r.finalize());
         this.closed.store(true, Ordering::Relaxed);
-        this.scheduler.deref();
         // but don't deinit until the scheduler drops its reference.
         // SAFETY: `this_ptr` was just leaked from `Box`; we own one ref.
         Self::deref(this_ptr);

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -156,7 +156,6 @@ impl BlobOrStringOrBuffer {
                     ))));
                 }
 
-                // `Blob::dupe()` clones the RefPtr<Store> (bumps refcount) and bit-copies fields.
                 return Ok(Some(Self::Blob(Box::new(blob.dupe()))));
             }
         };

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -156,7 +156,7 @@ impl BlobOrStringOrBuffer {
                     ))));
                 }
 
-                // `Blob::dupe()` clones the StoreRef (bumps refcount) and bit-copies fields.
+                // `Blob::dupe()` clones the RefPtr<Store> (bumps refcount) and bit-copies fields.
                 return Ok(Some(Self::Blob(Box::new(blob.dupe()))));
             }
         };

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -69,8 +69,6 @@ mod _impl {
     use crate::node::node_zlib_binding::{CompressionStream, CountedKeepAlive, Error};
     use crate::node::util::validators;
 
-    // Intrusive refcount; `deinit` runs when it reaches zero.
-
     // `.classes.ts`-backed: the C++ JSCell wrapper (JSNativeBrotli) is generated;
     // this struct is the `m_ctx` payload. Codegen provides toJS/fromJS/fromJSDirect.
     // R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`; per-field
@@ -341,7 +339,6 @@ mod _impl {
                 bun_zlib::NodeMode::BROTLI_ENCODE | bun_zlib::NodeMode::BROTLI_DECODE => s.close(),
                 _ => {}
             });
-            // Freeing self is handled by RefPtr / heap::take.
         }
     }
 

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -69,7 +69,7 @@ mod _impl {
     use crate::node::node_zlib_binding::{CompressionStream, CountedKeepAlive, Error};
     use crate::node::util::validators;
 
-    // Intrusive refcount: the handle type is `bun_ptr::IntrusiveRc<NativeBrotli>`; the
+    // Intrusive refcount: the handle type is `bun_ptr::RefPtr<NativeBrotli>`; the
     // `ref_count` field below is read/written by that wrapper, and `deinit` is the
     // drop body invoked when the count reaches zero.
 
@@ -343,7 +343,7 @@ mod _impl {
                 bun_zlib::NodeMode::BROTLI_ENCODE | bun_zlib::NodeMode::BROTLI_DECODE => s.close(),
                 _ => {}
             });
-            // Freeing self is handled by IntrusiveRc / heap::take.
+            // Freeing self is handled by RefPtr / heap::take.
         }
     }
 

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -69,9 +69,7 @@ mod _impl {
     use crate::node::node_zlib_binding::{CompressionStream, CountedKeepAlive, Error};
     use crate::node::util::validators;
 
-    // Intrusive refcount: the handle type is `bun_ptr::RefPtr<NativeBrotli>`; the
-    // `ref_count` field below is read/written by that wrapper, and `deinit` is the
-    // drop body invoked when the count reaches zero.
+    // Intrusive refcount; `deinit` runs when it reaches zero.
 
     // `.classes.ts`-backed: the C++ JSCell wrapper (JSNativeBrotli) is generated;
     // this struct is the `m_ctx` payload. Codegen provides toJS/fromJS/fromJSDirect.

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -32,7 +32,7 @@ mod _impl {
     // `__impl_compression_stream!` below (wraps `bun_jsc::codegen_cached_accessors!`).
 
     /// `bun.ptr.RefCount(@This(), "ref_count", deinit, .{})` — intrusive single-thread refcount.
-    /// `ref`/`deref` are provided by `bun_ptr::IntrusiveRc<NativeZlib>`; when the count hits
+    /// `ref`/`deref` are provided by `bun_ptr::RefPtr<NativeZlib>`; when the count hits
     /// zero it invokes [`NativeZlib::deinit`].
     #[bun_jsc::JsClass]
     #[derive(bun_ptr::CellRefCounted)]
@@ -264,7 +264,7 @@ mod _impl {
         /// Not `Drop` because this is an intrusive-refcounted `m_ctx` payload whose
         /// box is freed here.
         fn deinit(this: *mut Self) {
-            // SAFETY: called exactly once by IntrusiveRc when refcount hits 0; `this`
+            // SAFETY: called exactly once by RefPtr when refcount hits 0; `this`
             // is the heap::alloc pointer produced at construction. `this_value`
             // (Strong) and `poll_ref` (CountedKeepAlive) are Drop types — freed by
             // heap::take below.

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -31,9 +31,7 @@ mod _impl {
     // `mod js { write_callback_*, error_callback_*, ... }` is emitted by
     // `__impl_compression_stream!` below (wraps `bun_jsc::codegen_cached_accessors!`).
 
-    /// `bun.ptr.RefCount(@This(), "ref_count", deinit, .{})` — intrusive single-thread refcount.
-    /// `ref`/`deref` are provided by `bun_ptr::RefPtr<NativeZlib>`; when the count hits
-    /// zero it invokes [`NativeZlib::deinit`].
+    /// Intrusive refcount; [`NativeZlib::deinit`] runs when it hits zero.
     #[bun_jsc::JsClass]
     #[derive(bun_ptr::CellRefCounted)]
     #[ref_count(destroy = Self::deinit)]

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -262,7 +262,7 @@ mod _impl {
         /// Not `Drop` because this is an intrusive-refcounted `m_ctx` payload whose
         /// box is freed here.
         fn deinit(this: *mut Self) {
-            // SAFETY: called exactly once by RefPtr when refcount hits 0; `this`
+            // SAFETY: called exactly once when the refcount hits 0; `this`
             // is the heap::alloc pointer produced at construction. `this_value`
             // (Strong) and `poll_ref` (CountedKeepAlive) are Drop types — freed by
             // heap::take below.

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -295,7 +295,7 @@ mod _impl {
 
     // Called by RefCount when the count hits 0. `poll_ref` and `this_value`
     // (Strong) cleanup are handled by their own Drop impls; the Box free is
-    // handled by IntrusiveRc dropping the Box.
+    // handled by RefPtr dropping the Box.
     impl Drop for NativeZstd {
         fn drop(&mut self) {
             self.stream.with_mut(|s| match s.mode {

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -293,9 +293,8 @@ mod _impl {
         }
     }
 
-    // Called by RefCount when the count hits 0. `poll_ref` and `this_value`
-    // (Strong) cleanup are handled by their own Drop impls; the Box free is
-    // handled by RefPtr dropping the Box.
+    // Runs when the refcount hits 0 (the derive's `destroy` frees the Box).
+    // `poll_ref` and `this_value` (Strong) clean up via their own Drop impls.
     impl Drop for NativeZstd {
         fn drop(&mut self) {
             self.stream.with_mut(|s| match s.mode {

--- a/src/runtime/server/DirectoryRoute.rs
+++ b/src/runtime/server/DirectoryRoute.rs
@@ -385,7 +385,6 @@ impl Drop for ResponseGuard {
     fn drop(&mut self) {
         if let Some(route) = self.route.take() {
             route.on_response_complete(self.resp);
-            route.deref();
         }
     }
 }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -18,6 +18,7 @@ use bun_io::{BufferedReader, FileType, ReadState};
 #[cfg(unix)]
 use bun_io::{FilePollFlag, PosixFlags as ReaderFlags};
 use bun_jsc::JsCell;
+use bun_ptr::RefPtr;
 use bun_sys::{self as sys, Fd};
 use bun_uws::{AnyResponse, WriteResult};
 
@@ -116,9 +117,9 @@ pub(crate) struct StartOptions {
 /// error is delivered, exactly once.
 pub(crate) enum StreamOwner {
     /// The ref `FileRoute::on` took for this response; released on delivery.
-    FileRoute(bun_ptr::RefPtr<FileRoute>),
+    FileRoute(RefPtr<FileRoute>),
     /// Likewise for `DirectoryRoute::on`.
-    DirectoryRoute(bun_ptr::RefPtr<DirectoryRoute>),
+    DirectoryRoute(RefPtr<DirectoryRoute>),
     Ctx {
         ctx: *mut c_void,
         on_complete: fn(*mut c_void, AnyResponse),
@@ -183,7 +184,7 @@ impl FileResponseStream {
             }));
         // SAFETY: `this` is the live allocation above; the guard's ref defers
         // any free until after `this_ref` is dead at the end of this frame.
-        let _guard = unsafe { bun_ptr::RefPtr::<Self>::init_ref(this) };
+        let _guard = unsafe { RefPtr::init_ref(this) };
         // SAFETY: `this` is live for at least as long as `_guard`.
         let this_ref = unsafe { &*this };
 
@@ -194,7 +195,7 @@ impl FileResponseStream {
                 // SAFETY: uWS hands back the userdata pointer set below; the
                 // guard keeps `*p` alive across the handler.
                 unsafe {
-                    let _guard = bun_ptr::RefPtr::<Self>::init_ref(p);
+                    let _guard = RefPtr::init_ref(p);
                     (*p).on_aborted(r);
                 }
             },
@@ -332,7 +333,7 @@ impl FileResponseStream {
                         // SAFETY: uWS hands back the userdata pointer set below;
                         // the guard keeps `*p` alive across the handler.
                         unsafe {
-                            let _guard = bun_ptr::RefPtr::<Self>::init_ref(p);
+                            let _guard = RefPtr::init_ref(p);
                             (*p).on_writable(off, r)
                         }
                     },
@@ -368,7 +369,7 @@ impl FileResponseStream {
         self.ref_();
     }
 
-    fn take_read_ref(&self) -> Option<bun_ptr::RefPtr<Self>> {
+    fn take_read_ref(&self) -> Option<RefPtr<Self>> {
         if !self.state.get().contains(State::READ_REF_HELD) {
             return None;
         }
@@ -376,7 +377,7 @@ impl FileResponseStream {
             .set(self.state.get().difference(State::READ_REF_HELD));
         // SAFETY: `self` is the live intrusive allocation; `READ_REF_HELD`
         // witnesses exactly one outstanding ref taken in `hold_read_ref`.
-        Some(unsafe { bun_ptr::RefPtr::<Self>::from_raw(self.as_ptr()) })
+        Some(unsafe { RefPtr::from_raw(self.as_ptr()) })
     }
 
     fn on_writable(&self, _: u64, _: AnyResponse) -> bool {
@@ -471,7 +472,7 @@ impl FileResponseStream {
                     // SAFETY: uWS hands back the userdata pointer set below; the
                     // guard keeps `*p` alive across the handler.
                     unsafe {
-                        let _guard = bun_ptr::RefPtr::<Self>::init_ref(p);
+                        let _guard = RefPtr::init_ref(p);
                         (*p).on_writable(off, r)
                     }
                 },
@@ -595,10 +596,6 @@ impl FileResponseStream {
             self.event_loop().r#loop()
         }
     }
-
-    // bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) — intrusive single-thread RC.
-    // `ref_()`/`deref()` are provided by `#[derive(CellRefCounted)]`; the former
-    // hand-rolled `ref_guard`/`DerefOnDrop` pair is now `bun_ptr::RefPtr<Self>`.
 }
 
 // BufferedReader vtable parent.
@@ -609,15 +606,15 @@ bun_io::impl_buffered_reader_parent! {
     FileResponseStream for FileResponseStream;
     has_on_read_chunk = true;
     on_read_chunk   = |this, chunk, state| {
-        let _guard = bun_ptr::RefPtr::<Self>::init_ref(this);
+        let _guard = RefPtr::init_ref(this);
         (*this).on_read_chunk(&chunk, state)
     };
     on_reader_done  = |this| {
-        let _guard = bun_ptr::RefPtr::<Self>::init_ref(this);
+        let _guard = RefPtr::init_ref(this);
         (*this).on_reader_done()
     };
     on_reader_error = |this, err| {
-        let _guard = bun_ptr::RefPtr::<Self>::init_ref(this);
+        let _guard = RefPtr::init_ref(this);
         (*this).on_reader_error(err)
     };
     loop_           = |this| (*this).r#loop();

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -138,14 +138,8 @@ enum StreamEnd {
 impl StreamOwner {
     fn deliver(self, resp: AnyResponse, end: StreamEnd) {
         match self {
-            StreamOwner::FileRoute(route) => {
-                route.on_response_complete(resp);
-                route.deref();
-            }
-            StreamOwner::DirectoryRoute(route) => {
-                route.on_response_complete(resp);
-                route.deref();
-            }
+            StreamOwner::FileRoute(route) => route.on_response_complete(resp),
+            StreamOwner::DirectoryRoute(route) => route.on_response_complete(resp),
             StreamOwner::Ctx {
                 ctx,
                 on_complete,
@@ -189,7 +183,7 @@ impl FileResponseStream {
             }));
         // SAFETY: `this` is the live allocation above; the guard's ref defers
         // any free until after `this_ref` is dead at the end of this frame.
-        let _guard = unsafe { bun_ptr::ScopedRef::<Self>::new(this) };
+        let _guard = unsafe { bun_ptr::RefPtr::<Self>::init_ref(this) };
         // SAFETY: `this` is live for at least as long as `_guard`.
         let this_ref = unsafe { &*this };
 
@@ -200,7 +194,7 @@ impl FileResponseStream {
                 // SAFETY: uWS hands back the userdata pointer set below; the
                 // guard keeps `*p` alive across the handler.
                 unsafe {
-                    let _guard = bun_ptr::ScopedRef::<Self>::new(p);
+                    let _guard = bun_ptr::RefPtr::<Self>::init_ref(p);
                     (*p).on_aborted(r);
                 }
             },
@@ -338,7 +332,7 @@ impl FileResponseStream {
                         // SAFETY: uWS hands back the userdata pointer set below;
                         // the guard keeps `*p` alive across the handler.
                         unsafe {
-                            let _guard = bun_ptr::ScopedRef::<Self>::new(p);
+                            let _guard = bun_ptr::RefPtr::<Self>::init_ref(p);
                             (*p).on_writable(off, r)
                         }
                     },
@@ -374,7 +368,7 @@ impl FileResponseStream {
         self.ref_();
     }
 
-    fn take_read_ref(&self) -> Option<bun_ptr::ScopedRef<Self>> {
+    fn take_read_ref(&self) -> Option<bun_ptr::RefPtr<Self>> {
         if !self.state.get().contains(State::READ_REF_HELD) {
             return None;
         }
@@ -382,7 +376,7 @@ impl FileResponseStream {
             .set(self.state.get().difference(State::READ_REF_HELD));
         // SAFETY: `self` is the live intrusive allocation; `READ_REF_HELD`
         // witnesses exactly one outstanding ref taken in `hold_read_ref`.
-        Some(unsafe { bun_ptr::ScopedRef::<Self>::adopt(self.as_ptr()) })
+        Some(unsafe { bun_ptr::RefPtr::<Self>::from_raw(self.as_ptr()) })
     }
 
     fn on_writable(&self, _: u64, _: AnyResponse) -> bool {
@@ -477,7 +471,7 @@ impl FileResponseStream {
                     // SAFETY: uWS hands back the userdata pointer set below; the
                     // guard keeps `*p` alive across the handler.
                     unsafe {
-                        let _guard = bun_ptr::ScopedRef::<Self>::new(p);
+                        let _guard = bun_ptr::RefPtr::<Self>::init_ref(p);
                         (*p).on_writable(off, r)
                     }
                 },
@@ -604,7 +598,7 @@ impl FileResponseStream {
 
     // bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) — intrusive single-thread RC.
     // `ref_()`/`deref()` are provided by `#[derive(CellRefCounted)]`; the former
-    // hand-rolled `ref_guard`/`DerefOnDrop` pair is now `bun_ptr::ScopedRef<Self>`.
+    // hand-rolled `ref_guard`/`DerefOnDrop` pair is now `bun_ptr::RefPtr<Self>`.
 }
 
 // BufferedReader vtable parent.
@@ -615,15 +609,15 @@ bun_io::impl_buffered_reader_parent! {
     FileResponseStream for FileResponseStream;
     has_on_read_chunk = true;
     on_read_chunk   = |this, chunk, state| {
-        let _guard = bun_ptr::ScopedRef::<Self>::new(this);
+        let _guard = bun_ptr::RefPtr::<Self>::init_ref(this);
         (*this).on_read_chunk(&chunk, state)
     };
     on_reader_done  = |this| {
-        let _guard = bun_ptr::ScopedRef::<Self>::new(this);
+        let _guard = bun_ptr::RefPtr::<Self>::init_ref(this);
         (*this).on_reader_done()
     };
     on_reader_error = |this, err| {
-        let _guard = bun_ptr::ScopedRef::<Self>::new(this);
+        let _guard = bun_ptr::RefPtr::<Self>::init_ref(this);
         (*this).on_reader_error(err)
     };
     loop_           = |this| (*this).r#loop();

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -274,7 +274,6 @@ impl FileRoute {
         let Some(path) = store.get_path() else {
             req.set_yield(true);
             route.on_response_complete(resp);
-            route.deref();
             return;
         };
 
@@ -301,7 +300,6 @@ impl FileRoute {
         let Ok(fd) = fd_result else {
             req.set_yield(true);
             route.on_response_complete(resp);
-            route.deref();
             return;
         };
 
@@ -317,7 +315,6 @@ impl FileRoute {
                 #[cfg(not(windows))]
                 Closer::close(fd, ());
                 route.on_response_complete(resp);
-                route.deref();
             }
             Serve::Stream {
                 file_type,

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -217,7 +217,7 @@ impl Route {
     }
 
     fn on_any_request(this: ThisPtr<Self>, mut req: AnyRequest, resp: AnyResponse, is_head: bool) {
-        let _keep_alive = RefPtr::from_this(this);
+        let _guard = RefPtr::from_this(this);
         let route: &Route = &this;
 
         let Some(server) = route.server.get() else {
@@ -738,7 +738,7 @@ impl Route {
     /// uws onAborted for a response waiting in `pending_responses`.
     fn on_pending_response_aborted(this: ThisPtr<Self>, resp: AnyResponse) {
         // Technically, this could be the final ref count, but we don't want to risk it
-        let _keep_alive = RefPtr::from_this(this);
+        let _guard = RefPtr::from_this(this);
 
         // R-2: scope the `&mut Vec` to the find+remove only — dropping the
         // removed entry releases a route ref and must not overlap a live

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -150,7 +150,6 @@ pub(crate) type HTMLBundleRoute = Route;
 #[derive(bun_ptr::RefCounted)]
 #[ref_count(debug_name = "HTMLBundleRoute")]
 pub struct Route {
-    /// Released in `Drop`.
     pub(crate) bundle: RefPtr<HTMLBundle>,
     /// One HTMLBundle.Route can be specified multiple times
     ref_count: RefCount<Route>,
@@ -174,7 +173,6 @@ pub enum State {
     /// (`schedule_bundle`).
     Building,
     Err(Log),
-    /// Released in `State::deinit`.
     Html(RefPtr<StaticRoute>),
 }
 
@@ -219,7 +217,7 @@ impl Route {
     }
 
     fn on_any_request(this: ThisPtr<Self>, mut req: AnyRequest, resp: AnyResponse, is_head: bool) {
-        let _keep_alive = this.ref_guard();
+        let _keep_alive = RefPtr::from_this(this);
         let route: &Route = &this;
 
         let Some(server) = route.server.get() else {
@@ -250,8 +248,6 @@ impl Route {
             }
 
             // Simpler development workflow which rebundles on every request.
-            // R-2: swap the state out *before* releasing what it holds so no
-            // borrow into `route.state` is live across `StaticRoute`'s deref.
             if matches!(route.state.get(), State::Html(_) | State::Err(_)) {
                 route.state.set(State::Pending);
             }
@@ -742,7 +738,7 @@ impl Route {
     /// uws onAborted for a response waiting in `pending_responses`.
     fn on_pending_response_aborted(this: ThisPtr<Self>, resp: AnyResponse) {
         // Technically, this could be the final ref count, but we don't want to risk it
-        let _keep_alive = this.ref_guard();
+        let _keep_alive = RefPtr::from_this(this);
 
         // R-2: scope the `&mut Vec` to the find+remove only — dropping the
         // removed entry releases a route ref and must not overlap a live

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -178,17 +178,7 @@ pub enum State {
     Html(RefPtr<StaticRoute>),
 }
 
-// `State::deinit` is *only* invoked from `Route::drop` and the dev-mode reset
-// in `on_any_request`; ordinary `state.set(...)` overwrites in
-// `on_complete`/`on_plugins_resolved`/etc. never replace a `State::Html`, so
-// they do not need it.
 impl State {
-    fn deinit(self) {
-        if let State::Html(html) = self {
-            html.deref();
-        }
-    }
-
     fn memory_cost(&self) -> usize {
         match self {
             State::Pending => 0,
@@ -263,7 +253,7 @@ impl Route {
             // R-2: swap the state out *before* releasing what it holds so no
             // borrow into `route.state` is live across `StaticRoute`'s deref.
             if matches!(route.state.get(), State::Html(_) | State::Err(_)) {
-                route.state.replace(State::Pending).deinit();
+                route.state.set(State::Pending);
             }
         }
 
@@ -300,7 +290,7 @@ impl Route {
                     let pending = PendingResponse {
                         method,
                         resp,
-                        route: RefPtr::from_this(this),
+                        _route: RefPtr::from_this(this),
                         is_response_pending: Cell::new(true),
                     };
                     route.pending_responses.with_mut(|v| v.push(pending));
@@ -726,8 +716,6 @@ impl Drop for Route {
     fn drop(&mut self) {
         // pending responses keep a ref to the route
         debug_assert!(self.pending_responses.get().is_empty());
-        self.state.replace(State::Pending).deinit();
-        self.bundle.deref();
     }
 }
 
@@ -736,8 +724,8 @@ pub struct PendingResponse {
     method: Method,
     resp: AnyResponse,
     is_response_pending: Cell<bool>,
-    /// Released in `Drop`.
-    route: RefPtr<Route>,
+    /// Keeps the route alive while this response waits on it.
+    _route: RefPtr<Route>,
 }
 
 impl Drop for PendingResponse {
@@ -747,7 +735,6 @@ impl Drop for PendingResponse {
             self.resp.clear_on_writable();
             self.resp.end_without_body(true);
         }
-        self.route.deref();
     }
 }
 

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2577,7 +2577,6 @@ impl NodeHTTPResponse {
 // `as_ctx_ptr()`-derived provenance; converting them to `unsafe deref(*mut)`
 // is a separate sweep.
 impl bun_ptr::AnyRefCounted for NodeHTTPResponse {
-    type DestructorCtx = ();
     #[inline]
     unsafe fn rc_ref(this: *mut Self) {
         // SAFETY: caller contract — `this` is live; touches only the
@@ -2585,7 +2584,7 @@ impl bun_ptr::AnyRefCounted for NodeHTTPResponse {
         unsafe { (*this).ref_() }
     }
     #[inline]
-    unsafe fn rc_deref_with_context(this: *mut Self, (): ()) {
+    unsafe fn rc_deref(this: *mut Self) {
         // SAFETY: caller contract — `this` is live; `deref()` touches only
         // `Cell`/`JsCell` fields and on zero frees via `heap::take`.
         unsafe { (*this).deref() }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2599,11 +2599,6 @@ impl bun_ptr::AnyRefCounted for NodeHTTPResponse {
         // SAFETY: caller contract — `this` is live.
         debug_assert_eq!(unsafe { (*this).ref_count.get() }, 0);
     }
-    #[cfg(debug_assertions)]
-    #[inline]
-    unsafe fn rc_debug_data(_this: *mut Self) -> *mut dyn bun_ptr::ref_count::DebugDataOps {
-        bun_ptr::ref_count::noop_debug_data()
-    }
 }
 
 /// # Safety

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2594,11 +2594,6 @@ impl bun_ptr::AnyRefCounted for NodeHTTPResponse {
         // SAFETY: caller contract — `this` is live.
         unsafe { (*this).ref_count.get() == 1 }
     }
-    #[inline]
-    unsafe fn rc_assert_no_refs(this: *const Self) {
-        // SAFETY: caller contract — `this` is live.
-        debug_assert_eq!(unsafe { (*this).ref_count.get() }, 0);
-    }
 }
 
 /// # Safety

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -902,7 +902,7 @@ where
 
         self.request_body_buf.set(Vec::new());
         self.response_buf_owned.set(Vec::new());
-        self.response_weakref.with_mut(|w| w.deref());
+        self.response_weakref.set(response::WeakRef::EMPTY);
 
         self.request_body_take_unref();
 
@@ -1426,7 +1426,7 @@ where
 
         if let Some(request) = this.request_mut() {
             request.request_context = AnyRequestContext::NULL;
-            this.request_weakref.with_mut(|w| w.deref());
+            this.request_weakref.set(request::WeakRef::EMPTY);
         }
         // if signal is not aborted, abort the signal
         if let Some(signal) = this.signal.take() {
@@ -1524,7 +1524,7 @@ where
             }
             self.response_jsvalue.set(JSValue::ZERO);
         }
-        self.response_weakref.with_mut(|w| w.deref());
+        self.response_weakref.set(response::WeakRef::EMPTY);
 
         self.detach_request_body_producer();
         self.request_body_readable_stream_ref
@@ -1535,7 +1535,7 @@ where
 
         if let Some(request) = self.request_mut() {
             request.request_context = AnyRequestContext::NULL;
-            self.request_weakref.with_mut(|w| w.deref());
+            self.request_weakref.set(request::WeakRef::EMPTY);
         }
 
         // if signal is not aborted, abort the signal
@@ -3944,14 +3944,16 @@ where
     /// [`as_response`]), carrying the allocation's provenance — `WeakPtr` keeps
     /// it past any reborrow.
     unsafe fn set_response(&self, response: *mut Response) {
-        self.response_weakref.with_mut(|weak| {
-            if weak.get().map(std::ptr::from_mut::<Response>) == Some(response) {
-                return;
-            }
-            weak.deref();
-            // SAFETY: caller contract — `response` is live and root-provenanced.
-            *weak = unsafe { response::WeakRef::init_ref(response) };
-        });
+        if self
+            .response_weakref
+            .with_mut(|weak| weak.get().map(std::ptr::from_mut::<Response>))
+            == Some(response)
+        {
+            return;
+        }
+        // SAFETY: caller contract — `response` is live and root-provenanced.
+        self.response_weakref
+            .set(unsafe { response::WeakRef::init_ref(response) });
     }
 
     /// # Safety

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -209,13 +209,6 @@ impl StaticRouteEntry {
     }
 }
 
-impl Drop for StaticRouteEntry {
-    fn drop(&mut self) {
-        // path: Box<[u8]> drops automatically
-        self.route.deref_();
-    }
-}
-
 impl ServerConfig {
     fn normalize_static_routes_list(&mut self) -> Result<(), crate::Error> {
         fn hash(route: &StaticRouteEntry) -> u64 {

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -362,7 +362,7 @@ impl StaticRoute {
         let n = this.pending_responses.get() - 1;
         this.pending_responses.set(n);
         if n == 0 {
-            drop(this.pending_ref.take());
+            this.pending_ref.set(None);
         }
     }
 

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -117,7 +117,6 @@ impl StaticRoute {
     ) {
         let temp_route = StaticRoute::init_from_any_blob(blob, options);
         StaticRoute::on(temp_route.this_ptr(), resp);
-        temp_route.deref();
     }
 
     pub(crate) fn clone(&mut self, global_this: &JSGlobalObject) -> RefPtr<StaticRoute> {
@@ -363,10 +362,7 @@ impl StaticRoute {
         let n = this.pending_responses.get() - 1;
         this.pending_responses.set(n);
         if n == 0 {
-            let pending_ref = this.pending_ref.take();
-            if let Some(pending_ref) = pending_ref {
-                pending_ref.deref();
-            }
+            drop(this.pending_ref.take());
         }
     }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -4100,10 +4100,7 @@ pub(crate) mod http_server_agent {
                     _ => RouteType::Default,
                 },
                 file_path: match &entry.route {
-                    // SAFETY: RefPtr.data is a live NonNull while held in the
-                    // route table; `.bundle` (RefPtr) derefs to the live
-                    // HTMLBundle whose `path` outlives this borrow.
-                    AnyRoute::Html(r) => BunString::from_bytes(&r.data().bundle.path),
+                    AnyRoute::Html(r) => BunString::from_bytes(&r.bundle.path),
                     _ => BunString::EMPTY,
                 },
                 ..Default::default()

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -139,7 +139,7 @@ pub(crate) fn write_status<const SSL: bool>(resp: *mut uws_sys::NewAppResponse<S
 }
 
 // ─── AnyRoute ────────────────────────────────────────────────────────────────
-/// The route table's ref on each route; `StaticRouteEntry`'s `Drop` releases it.
+/// The route table's ref on each route.
 pub enum AnyRoute {
     /// Serve a static file — `"/robots.txt": new Response(...)`
     Static(bun_ptr::RefPtr<StaticRoute>),
@@ -163,16 +163,6 @@ impl AnyRoute {
             AnyRoute::FrameworkRouter(_) => {
                 core::mem::size_of::<crate::bake::FileSystemRouterType>()
             }
-        }
-    }
-
-    pub(crate) fn deref_(&self) {
-        match self {
-            AnyRoute::Static(r) => r.deref(),
-            AnyRoute::File(r) => r.deref(),
-            AnyRoute::Directory(r) => r.deref(),
-            AnyRoute::Html(r) => r.deref(),
-            AnyRoute::FrameworkRouter(_) => {} // not reference counted
         }
     }
 
@@ -4111,7 +4101,7 @@ pub(crate) mod http_server_agent {
                 },
                 file_path: match &entry.route {
                     // SAFETY: RefPtr.data is a live NonNull while held in the
-                    // route table; `.bundle` (IntrusiveRc) derefs to the live
+                    // route table; `.bundle` (RefPtr) derefs to the live
                     // HTMLBundle whose `path` outlives this borrow.
                     AnyRoute::Html(r) => BunString::from_bytes(&r.data().bundle.path),
                     _ => BunString::EMPTY,

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -860,7 +860,7 @@ pub struct ServePlugins {
 }
 
 // Reference count is incremented while there are other objects waiting on plugin loads.
-// Maps to bun_ptr::IntrusiveRc<ServePlugins> — *ServePlugins crosses FFI as promise context ptr.
+// Maps to bun_ptr::RefPtr<ServePlugins> — *ServePlugins crosses FFI as promise context ptr.
 
 pub(crate) enum ServePluginsState {
     Unqueued(Box<[Box<[u8]>]>),
@@ -1105,7 +1105,6 @@ impl ServePlugins {
                 route.this_ptr(),
                 Some(NonNull::from(plugin_ref)),
             ));
-            route.deref();
         }
         if let Some(mut server) = dev_server {
             // SAFETY: dev_server outlives plugin load (stored as a back-reference
@@ -1133,7 +1132,6 @@ impl ServePlugins {
 
         for route in html_bundle_routes {
             bun_core::handle_oom(route.on_plugins_rejected());
-            route.deref();
         }
         if let Some(mut server) = dev_server {
             // SAFETY: dev_server outlives plugin load

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -14,7 +14,7 @@ use crate::webcore::body::Value as BodyValue;
 use crate::webcore::fetch as Fetch;
 use crate::webcore::response::HeadersRef;
 use crate::webcore::{
-    self as WebCore, AbortSignal, AnyBlob, Blob, FetchHeaders, Request, Response,
+    self as WebCore, AbortSignal, AnyBlob, Blob, FetchHeaders, Request, Response, request,
 };
 use ::bstr::BStr;
 use bun_collections::HashMap;
@@ -860,8 +860,6 @@ pub struct ServePlugins {
 }
 
 // Reference count is incremented while there are other objects waiting on plugin loads.
-// Maps to bun_ptr::RefPtr<ServePlugins> — *ServePlugins crosses FFI as promise context ptr.
-
 pub(crate) enum ServePluginsState {
     Unqueued(Box<[Box<[u8]>]>),
     Pending {
@@ -2037,7 +2035,7 @@ where
         // SAFETY: plain-field detach through the root pointer; the shared
         // borrow above is not used past this point.
         unsafe { (*request_ptr).request_context = AnyRequestContext::NULL };
-        upgrader.request_weakref.with_mut(|w| w.deref());
+        upgrader.request_weakref.set(request::WeakRef::EMPTY);
 
         data_value.ensure_still_alive();
         let ws = ServerWebSocket::init(

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -124,56 +124,6 @@ pub type StdioResult = WindowsStdioResult;
 #[cfg(not(windows))]
 pub type StdioResult = Option<Fd>;
 
-/// RAII handle owning one intrusive ref on a heap `FileSink`. `FileSink`
-/// carries its own `#[derive(CellRefCounted)]` refcount and is allocated via
-/// `Box::into_raw` in `FileSink::create*`, so it cannot live behind an `Arc`.
-/// Drop derefs (and frees on last ref) on teardown.
-pub struct FileSinkPtr(core::ptr::NonNull<FileSink>);
-
-impl FileSinkPtr {
-    /// Adopt the +1 ref returned by `FileSink::create*`.
-    ///
-    /// # Safety
-    /// `ptr` is non-null, points to a live `FileSink` from
-    /// `FileSink::create*`, and the caller transfers its single owned ref to
-    /// this handle.
-    #[cfg(windows)]
-    #[inline]
-    unsafe fn adopt(ptr: *mut FileSink) -> Self {
-        // SAFETY: caller contract — `ptr` is non-null.
-        Self(unsafe { core::ptr::NonNull::new_unchecked(ptr) })
-    }
-}
-
-impl core::ops::Deref for FileSinkPtr {
-    type Target = FileSink;
-    #[inline]
-    fn deref(&self) -> &FileSink {
-        // SAFETY: `adopt` contract — `self.0` is a live `FileSink` from
-        // `FileSink::create*`; the held intrusive ref keeps it alive for `'_`.
-        unsafe { self.0.as_ref() }
-    }
-}
-
-impl core::ops::DerefMut for FileSinkPtr {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut FileSink {
-        // SAFETY: `adopt` contract — `self.0` is live; `&mut self` is exclusive
-        // on this owning handle (FileSinkPtr is non-`Copy`, single-threaded
-        // shell), so no other `&`/`&mut` to the `FileSink` overlaps.
-        unsafe { self.0.as_mut() }
-    }
-}
-
-impl Drop for FileSinkPtr {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: `adopt` contract — `self.0` is live with one owned intrusive
-        // ref; `FileSink::deref` (CellRefCounted derive) frees on zero.
-        unsafe { FileSink::deref(self.0.as_ptr()) };
-    }
-}
-
 bun_output::define_scoped_log!(log, SHELL_SUBPROC, visible);
 
 /// Used for captured writer
@@ -398,10 +348,7 @@ impl ShellSubprocess {
         match kind {
             StdioKind::Stdin => match &mut self.stdin {
                 Writable::Pipe(pipe) => {
-                    // DerefMut on the owning `&mut FileSinkPtr` encapsulates
-                    // the access.
                     pipe.source.with_mut(|s| s.clear());
-                    // FileSinkPtr::drop derefs.
                     self.stdin = Writable::Ignore;
                 }
                 Writable::Buffer(_) => {
@@ -892,7 +839,7 @@ impl ShellSubprocess {
                 // SAFETY: shell is single-threaded; the FileSink allocation is
                 // disjoint from `*stdin_ptr`. `stdin_ptr` outlives the sink —
                 // the Subprocess owns both and `Writable::on_close` is the only
-                // path that drops the FileSinkPtr.
+                // path that drops it.
                 pipe.source
                     .set(webcore::streams::SourceHandle::ShellWritable(
                         // SAFETY: `stdin_ptr` is the live `&raw mut` writable (write provenance).
@@ -1014,7 +961,7 @@ pub enum WritableInitError {
 }
 
 pub enum Writable {
-    Pipe(FileSinkPtr),
+    Pipe(RefPtr<FileSink>),
     Fd(Fd),
     Buffer(RefPtr<StaticPipeWriter>),
     Memfd(Fd),
@@ -1078,8 +1025,8 @@ impl Writable {
                         // subprocess.flags.has_stdin_destructor_called = false;
 
                         // SAFETY: `create_with_pipe` returns non-null with one
-                        // owned ref; `adopt` takes it over.
-                        return Ok(Writable::Pipe(unsafe { FileSinkPtr::adopt(pipe_ptr) }));
+                        // owned ref, taken over here.
+                        return Ok(Writable::Pipe(unsafe { RefPtr::from_raw(pipe_ptr) }));
                     }
                     return Ok(Writable::Inherit);
                 }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -406,14 +406,11 @@ impl ShellSubprocess {
                 }
                 Writable::Buffer(_) => {
                     self.on_static_pipe_writer_done();
-                    // RefPtr has no Drop — move it out before reassigning so the
-                    // create ref is actually released.
                     if let Writable::Buffer(buffer) =
                         core::mem::replace(&mut self.stdin, Writable::Ignore)
                     {
                         // SAFETY: single-threaded; sole borrow of the payload.
                         unsafe { buffer_mut(&buffer) }.source.detach();
-                        buffer.deref();
                     }
                 }
                 _ => {}
@@ -1215,8 +1212,7 @@ impl Writable {
                 // SAFETY: single-threaded; temporary `&mut` for the call only.
                 unsafe { buffer_mut(buffer) }.update_ref(false);
                 // Intentionally does NOT reassign `*self` — the variant tag is
-                // left as `Writable::Buffer`. RefPtr's Drop (on
-                // Subprocess teardown) handles the final deref.
+                // left as `Writable::Buffer`; its ref drops with the Subprocess.
             }
             Writable::Memfd(fd) => {
                 fd.close();

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1155,11 +1155,14 @@ impl Writable {
                 // deref via drop-on-reassign
                 *self = Writable::Ignore;
             }
-            Writable::Buffer(buffer) => {
+            Writable::Buffer(_) => {
+                let Writable::Buffer(buffer) = core::mem::replace(self, Writable::Ignore) else {
+                    unreachable!()
+                };
                 // SAFETY: single-threaded; temporary `&mut` for the call only.
-                unsafe { buffer_mut(buffer) }.update_ref(false);
-                // Intentionally does NOT reassign `*self` — the variant tag is
-                // left as `Writable::Buffer`; its ref drops with the Subprocess.
+                unsafe { buffer_mut(&buffer) }.update_ref(false);
+                // `buffer` drops here with the variant already `Ignore`, so a
+                // re-entrant `on_close_io` from the writer's drop is a no-op.
             }
             Writable::Memfd(fd) => {
                 fd.close();

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -293,7 +293,7 @@ pub struct NewSocket<const SSL: bool> {
     pub(crate) owned_ssl_ctx: Cell<Option<*mut SSL_CTX>>,
 
     pub(crate) flags: Cell<Flags>,
-    pub(crate) ref_count: bun_ptr::RefCount<Self>, // intrusive — see `bun_ptr::RefPtr<Self>`
+    pub(crate) ref_count: bun_ptr::RefCount<Self>,
     /// The callbacks this socket dispatches to: shared with its listener and
     /// sibling sockets (server), or with its own reconnects and TLS twin
     /// (client). `None` once the socket has gone idle or been detached, which
@@ -563,10 +563,8 @@ impl<const SSL: bool> NewSocket<SSL> {
     }
 
     pub(crate) fn detach_native_callback(&self) {
-        let native_callback = self.native_callback.replace(NativeCallbacks::None);
-        match native_callback {
-            NativeCallbacks::H2(h2) => h2.on_native_close(),
-            NativeCallbacks::None => {}
+        if let NativeCallbacks::H2(h2) = self.native_callback.replace(NativeCallbacks::None) {
+            h2.on_native_close();
         }
     }
 
@@ -577,7 +575,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // Keep `self` alive across the re-entrant connect path.
         // SAFETY: `self` is live for this call and outlives the sockets below.
         let this = unsafe { bun_ptr::ThisPtr::new(self.as_ctx_ptr()) };
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
 
         // `VirtualMachine::get()` yields the canonical `*mut` (write
         // provenance) — never derive `&mut` from the `&'static` borrow stored
@@ -932,7 +930,7 @@ impl<const SSL: bool> NewSocket<SSL> {
 
         // Hold the socket alive for the rest of the dispatch: `internal_flush`
         // and the drain callback can both re-enter JS and close it.
-        let _keepalive = this.ref_guard();
+        let _keepalive = RefPtr::from_this(this);
         // NOTE (Windows): the drain dispatch deliberately does not depend on
         // whether the flush hit a fatal send error. Skipping it on fatal
         // (tried in f0325bddf2) made Windows servers reset FIN-terminated
@@ -1117,7 +1115,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // Ensure the socket is still alive for any defer's we have. Declared
         // before clear_and_free/unrefOnNextTick so the ref is balanced even if
         // those calls unwind.
-        let _keepalive = this.ref_guard();
+        let _keepalive = RefPtr::from_this(this);
         this.buffered_data_for_node_net
             .with_mut(|b| b.clear_and_free());
 
@@ -1430,7 +1428,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             this.ref_count.get()
         );
         // Ensure the socket remains alive: the callbacks below re-enter JS.
-        let _keepalive = this.ref_guard();
+        let _keepalive = RefPtr::from_this(this);
 
         // update the internal socket instance to the one that was just connected
         // This socket must be replaced because the previous one is a connecting socket not a uSockets socket
@@ -1693,7 +1691,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             }
         );
         // Ensure the socket remains alive until this is finished
-        let _keepalive = this.ref_guard();
+        let _keepalive = RefPtr::from_this(this);
 
         let callback = handlers.on_end();
         if callback.is_empty() {
@@ -1744,7 +1742,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // Keep the socket alive across the callbacks below (which re-enter JS)
         // and across `reject_unauthorized_connection`, whose close may
         // otherwise drop the last reference.
-        let _keepalive = this.ref_guard();
+        let _keepalive = RefPtr::from_this(this);
         let handlers = this.get_handlers();
         log!(
             "onHandshake {} ({})",
@@ -2611,7 +2609,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         let args = callframe.arguments_undef::<2>();
         // `write_or_end_buffered` reaches `internal_flush`, which re-enters JS.
         // SAFETY: the JS wrapper holds a ref for the whole host-fn call.
-        let _keepalive = unsafe { bun_ptr::RefPtr::init_ref(this.as_ctx_ptr()) };
+        let _keepalive = unsafe { RefPtr::init_ref(this.as_ctx_ptr()) };
         let result = match this.write_or_end_buffered::<true>(global, args.ptr[0], args.ptr[1]) {
             WriteResult::Fail => JSValue::ZERO,
             WriteResult::Success { wrote, total } => {
@@ -3226,7 +3224,7 @@ impl<const SSL: bool> NewSocket<SSL> {
 
         // `write_or_end` reaches `internal_flush`, which re-enters JS.
         // SAFETY: the JS wrapper holds a ref for the whole host-fn call.
-        let _keepalive = unsafe { bun_ptr::RefPtr::init_ref(this.as_ctx_ptr()) };
+        let _keepalive = unsafe { RefPtr::init_ref(this.as_ctx_ptr()) };
         let result = match this.write_or_end::<true>(global, args.mut_(), false) {
             WriteResult::Fail => JSValue::ZERO,
             WriteResult::Success { wrote, total } => {
@@ -3673,7 +3671,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // including the `?` early-returns below.
         // SAFETY: `this` owns the outstanding ref this guard consumes; the JS
         // wrapper's own +1 keeps the allocation alive across the whole call.
-        let _this_deref = unsafe { bun_ptr::RefPtr::from_raw(this.as_ctx_ptr()) };
+        let _this_deref = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
         this.detach_native_callback();
         this.socket.set(SocketHandler::<SSL>::DETACHED);
 

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3273,7 +3273,7 @@ impl<const SSL: bool> NewSocket<SSL> {
     /// intrusive refcount + `finalize()`.
     // SAFETY: `this` was allocated via `heap::alloc` and refcount == 0.
     unsafe fn deinit_and_destroy(this: *mut Self) {
-        // Not a `ThisPtr`: the refcount is already zero, so `ref_guard()` here
+        // Not a `ThisPtr`: the refcount is already zero, so `RefPtr::from_this` here
         // would be a resurrection bug.
         // SAFETY: per fn contract — sole owner, live until the `heap::take` below.
         let this_ref: &Self = unsafe { &*this };

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -9,7 +9,7 @@ use bun_io::KeepAlive;
 use bun_jsc::EncodedSliceJsc as _;
 use bun_jsc::JsCell;
 use bun_jsc::bun_string_jsc;
-use bun_ptr::IntrusiveRc;
+use bun_ptr::RefPtr;
 // do NOT `use bun_boringssl_sys::SSL` here — it shadows the
 // `const SSL: bool` generic param in `NewSocket<SSL>` below, making rustc
 // resolve `<SSL>` as a type arg (E0747). Use the qualified path instead.
@@ -293,7 +293,7 @@ pub struct NewSocket<const SSL: bool> {
     pub(crate) owned_ssl_ctx: Cell<Option<*mut SSL_CTX>>,
 
     pub(crate) flags: Cell<Flags>,
-    pub(crate) ref_count: bun_ptr::RefCount<Self>, // intrusive — see `bun_ptr::IntrusiveRc<Self>`
+    pub(crate) ref_count: bun_ptr::RefCount<Self>, // intrusive — see `bun_ptr::RefPtr<Self>`
     /// The callbacks this socket dispatches to: shared with its listener and
     /// sibling sockets (server), or with its own reconnects and TLS twin
     /// (client). `None` once the socket has gone idle or been detached, which
@@ -327,8 +327,8 @@ pub struct NewSocket<const SSL: bool> {
     /// no second context.
     // LIFETIMES.tsv says `Option<Rc<Self>>`, but `*Self` is stored in
     // a uws ext slot (FFI) and is intrusively refcounted — PORTING.md mandates
-    // IntrusiveRc, never Rc, when *T crosses FFI.
-    pub(crate) twin: JsCell<Option<IntrusiveRc<Self>>>,
+    // RefPtr, never Rc, when *T crosses FFI.
+    pub(crate) twin: JsCell<Option<RefPtr<Self>>>,
     /// Owned copy of the handshake verify error, so `getAuthorizationError()`
     /// keeps its verdict after detach (the live error borrows the `SSL`, and
     /// EPROTO reasons are stack-copied in uSockets).
@@ -340,12 +340,11 @@ pub(super) type SocketHandler<const SSL: bool> = uws::NewSocketHandler<SSL>;
 
 // Intrusive refcount mixin.
 impl<const SSL: bool> bun_ptr::RefCounted for NewSocket<SSL> {
-    type DestructorCtx = ();
     unsafe fn get_ref_count(this: *mut Self) -> *mut bun_ptr::RefCount<Self> {
         // SAFETY: caller contract — `this` points to a live Self.
         unsafe { &raw mut (*this).ref_count }
     }
-    unsafe fn destructor(this: *mut Self, _ctx: ()) {
+    unsafe fn destructor(this: *mut Self) {
         // SAFETY: refcount reached zero; we are the unique owner of the
         // `heap::alloc` allocation and `this` is not used after.
         unsafe { Self::deinit_and_destroy(this) };
@@ -554,12 +553,11 @@ impl<const SSL: bool> NewSocket<SSL> {
             + ssl_cost
     }
 
+    /// On `false` the rejected `callback` (and the ref it holds) is dropped.
     pub(crate) fn attach_native_callback(&self, callback: NativeCallbacks) -> bool {
         if !matches!(self.native_callback.get(), NativeCallbacks::None) {
             return false;
         }
-        // IntrusiveRc holds the +1 by construction (caller
-        // passes ownership of the handle), so no explicit inc here.
         self.native_callback.set(callback);
         true
     }
@@ -567,12 +565,7 @@ impl<const SSL: bool> NewSocket<SSL> {
     pub(crate) fn detach_native_callback(&self) {
         let native_callback = self.native_callback.replace(NativeCallbacks::None);
         match native_callback {
-            NativeCallbacks::H2(h2) => {
-                // `RefPtr: Deref<Target = H2FrameParser>`; `on_native_close`
-                // takes `&self`, so no raw-pointer reach-through is needed.
-                h2.on_native_close();
-                h2.deref();
-            }
+            NativeCallbacks::H2(h2) => h2.on_native_close(),
             NativeCallbacks::None => {}
         }
     }
@@ -2119,7 +2112,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // recurse, and `onClose` derefs the +1 we took at creation.
         if let Some(raw) = this.twin.with_mut(|t| t.take()) {
             // `on_close` consumes the twin's +1 via its `CloseTeardown`, so
-            // hand over the raw pointer rather than letting `IntrusiveRc::drop`
+            // hand over the raw pointer rather than letting `RefPtr::drop`
             // release it a second time. This frame is the twin's trampoline for
             // the event, so what its handlers left pending is folded here and
             // this socket's own close proceeds regardless.
@@ -2618,7 +2611,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         let args = callframe.arguments_undef::<2>();
         // `write_or_end_buffered` reaches `internal_flush`, which re-enters JS.
         // SAFETY: the JS wrapper holds a ref for the whole host-fn call.
-        let _keepalive = unsafe { bun_ptr::ScopedRef::new(this.as_ctx_ptr()) };
+        let _keepalive = unsafe { bun_ptr::RefPtr::init_ref(this.as_ctx_ptr()) };
         let result = match this.write_or_end_buffered::<true>(global, args.ptr[0], args.ptr[1]) {
             WriteResult::Fail => JSValue::ZERO,
             WriteResult::Success { wrote, total } => {
@@ -3233,7 +3226,7 @@ impl<const SSL: bool> NewSocket<SSL> {
 
         // `write_or_end` reaches `internal_flush`, which re-enters JS.
         // SAFETY: the JS wrapper holds a ref for the whole host-fn call.
-        let _keepalive = unsafe { bun_ptr::ScopedRef::new(this.as_ctx_ptr()) };
+        let _keepalive = unsafe { bun_ptr::RefPtr::init_ref(this.as_ctx_ptr()) };
         let result = match this.write_or_end::<true>(global, args.mut_(), false) {
             WriteResult::Fail => JSValue::ZERO,
             WriteResult::Success { wrote, total } => {
@@ -3680,7 +3673,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // including the `?` early-returns below.
         // SAFETY: `this` owns the outstanding ref this guard consumes; the JS
         // wrapper's own +1 keeps the allocation alive across the whole call.
-        let _this_deref = unsafe { bun_ptr::ScopedRef::adopt(this.as_ctx_ptr()) };
+        let _this_deref = unsafe { bun_ptr::RefPtr::from_raw(this.as_ctx_ptr()) };
         this.detach_native_callback();
         this.socket.set(SocketHandler::<SSL>::DETACHED);
 
@@ -3720,7 +3713,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         raw_ref.ref_();
         // SAFETY: `raw` came from `TLSSocket::new` (heap::alloc); intrusive +1 held.
         tls.twin
-            .set(Some(unsafe { IntrusiveRc::from_raw(raw.as_ptr()) }));
+            .set(Some(unsafe { RefPtr::from_raw(raw.as_ptr()) }));
         // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
         bun_opaque::opaque_deref_mut(new_raw.as_ptr()).set_ssl_raw_tap(true);
 
@@ -4088,7 +4081,7 @@ impl_socket_js_class!(TLSSocket, js_TLSSocket);
 // ──────────────────────────────────────────────────────────────────────────
 
 pub enum NativeCallbacks {
-    H2(IntrusiveRc<H2FrameParser>),
+    H2(RefPtr<H2FrameParser>),
     None,
 }
 
@@ -4269,7 +4262,7 @@ impl bun_event_loop::Taskable for DuplexUpgradeContext {
 pub(crate) struct DuplexUpgradeContext {
     pub upgrade: UpgradedDuplex,
     // We only us a tls and not a raw socket when upgrading a Duplex, Duplex dont support socketpairs
-    pub tls: JsCell<Option<IntrusiveRc<TLSSocket>>>,
+    pub tls: JsCell<Option<RefPtr<TLSSocket>>>,
     // task used to deinit the context in the next tick, vm is used to enqueue the task
     /// JSC_BORROW: process-lifetime per-thread VM (immortal). Stored as
     /// `&'static` so [`enqueue_self_task`](Self::enqueue_self_task) routes
@@ -4393,7 +4386,7 @@ impl DuplexUpgradeContext {
             // `start_tls()` enqueues anything and before any duplex
             // callback can dispatch), so `handle_connect_error`'s
             // `needs_deref = !is_detached()` is `true` and it consumes
-            // the owner's +1 we hold. Do NOT let `IntrusiveRc::Drop`
+            // the owner's +1 we hold. Do NOT let `RefPtr::Drop`
             // fire on top of that (over-deref → UAF on the JS wrapper's
             // pointee).
             //
@@ -4571,10 +4564,7 @@ impl DuplexUpgradeContext {
         {
             // SAFETY: `this` is live; this borrow ends with the block, before the `heap::take` free below.
             let ctx = unsafe { &*this };
-            if let Some(tls) = ctx.tls.replace(None) {
-                // Release the owner's +1.
-                tls.deref();
-            }
+            ctx.tls.set(None);
             // Close raced ahead of StartTLS — drop the unconsumed config.
             ctx.ssl_config.set(None);
             if let Some(ssl_ctx) = ctx.owned_ctx.take() {
@@ -4783,7 +4773,7 @@ pub fn js_upgrade_duplex_to_tls(
     // below before any read or `&mut DuplexUpgradeContext` is formed.
     unsafe {
         ptr::addr_of_mut!((*duplex_context).tls)
-            .write(JsCell::new(Some(IntrusiveRc::from_raw(tls.as_ptr()))));
+            .write(JsCell::new(Some(RefPtr::from_raw(tls.as_ptr()))));
         ptr::addr_of_mut!((*duplex_context).vm).write(VirtualMachine::get());
         ptr::addr_of_mut!((*duplex_context).task_event).write(Cell::new(EventState::StartTLS));
         ptr::addr_of_mut!((*duplex_context).queued).write(Cell::new(false));

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -325,9 +325,6 @@ pub struct NewSocket<const SSL: bool> {
     /// expects at index 0). The encrypted half holds a ref on the raw half
     /// here so a single `onClose` can retire both — no `Handlers.clone()`,
     /// no second context.
-    // LIFETIMES.tsv says `Option<Rc<Self>>`, but `*Self` is stored in
-    // a uws ext slot (FFI) and is intrusively refcounted — PORTING.md mandates
-    // RefPtr, never Rc, when *T crosses FFI.
     pub(crate) twin: JsCell<Option<RefPtr<Self>>>,
     /// Owned copy of the handshake verify error, so `getAuthorizationError()`
     /// keeps its verdict after detach (the live error borrows the `SSL`, and
@@ -411,7 +408,7 @@ impl<const SSL: bool> Drop for ConnectErrorTeardown<SSL> {
     fn drop(&mut self) {
         let this = self.socket;
         // `deref` before `mark_inactive`, as the hand-rolled guard did. It
-        // cannot free the socket here: `handle_connect_error`'s `_keepalive`
+        // cannot free the socket here: `handle_connect_error`'s `_guard`
         // is declared before this guard, so it outlives it.
         if self.needs_deref {
             this.get().deref();
@@ -439,6 +436,13 @@ impl<const SSL: bool> Drop for ScopeExit<SSL> {
 }
 
 impl<const SSL: bool> NewSocket<SSL> {
+    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
+    #[inline]
+    fn ref_guard(&self) -> RefPtr<Self> {
+        // SAFETY: `self` is the live heap allocation.
+        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
+    }
+
     // ─── R-2 interior-mutability helpers ─────────────────────────────────────
 
     /// Read-modify-write the packed `Cell<Flags>` through `&self`.
@@ -930,7 +934,7 @@ impl<const SSL: bool> NewSocket<SSL> {
 
         // Hold the socket alive for the rest of the dispatch: `internal_flush`
         // and the drain callback can both re-enter JS and close it.
-        let _keepalive = RefPtr::from_this(this);
+        let _guard = RefPtr::from_this(this);
         // NOTE (Windows): the drain dispatch deliberately does not depend on
         // whether the flush hit a fatal send error. Skipping it on fatal
         // (tried in f0325bddf2) made Windows servers reset FIN-terminated
@@ -1115,7 +1119,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // Ensure the socket is still alive for any defer's we have. Declared
         // before clear_and_free/unrefOnNextTick so the ref is balanced even if
         // those calls unwind.
-        let _keepalive = RefPtr::from_this(this);
+        let _guard = RefPtr::from_this(this);
         this.buffered_data_for_node_net
             .with_mut(|b| b.clear_and_free());
 
@@ -1428,7 +1432,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             this.ref_count.get()
         );
         // Ensure the socket remains alive: the callbacks below re-enter JS.
-        let _keepalive = RefPtr::from_this(this);
+        let _guard = RefPtr::from_this(this);
 
         // update the internal socket instance to the one that was just connected
         // This socket must be replaced because the previous one is a connecting socket not a uSockets socket
@@ -1691,7 +1695,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             }
         );
         // Ensure the socket remains alive until this is finished
-        let _keepalive = RefPtr::from_this(this);
+        let _guard = RefPtr::from_this(this);
 
         let callback = handlers.on_end();
         if callback.is_empty() {
@@ -1742,7 +1746,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // Keep the socket alive across the callbacks below (which re-enter JS)
         // and across `reject_unauthorized_connection`, whose close may
         // otherwise drop the last reference.
-        let _keepalive = RefPtr::from_this(this);
+        let _guard = RefPtr::from_this(this);
         let handlers = this.get_handlers();
         log!(
             "onHandshake {} ({})",
@@ -2608,8 +2612,7 @@ impl<const SSL: bool> NewSocket<SSL> {
 
         let args = callframe.arguments_undef::<2>();
         // `write_or_end_buffered` reaches `internal_flush`, which re-enters JS.
-        // SAFETY: the JS wrapper holds a ref for the whole host-fn call.
-        let _keepalive = unsafe { RefPtr::init_ref(this.as_ctx_ptr()) };
+        let _guard = this.ref_guard();
         let result = match this.write_or_end_buffered::<true>(global, args.ptr[0], args.ptr[1]) {
             WriteResult::Fail => JSValue::ZERO,
             WriteResult::Success { wrote, total } => {
@@ -3223,8 +3226,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         // `write_or_end` reaches `internal_flush`, which re-enters JS.
-        // SAFETY: the JS wrapper holds a ref for the whole host-fn call.
-        let _keepalive = unsafe { RefPtr::init_ref(this.as_ctx_ptr()) };
+        let _guard = this.ref_guard();
         let result = match this.write_or_end::<true>(global, args.mut_(), false) {
             WriteResult::Fail => JSValue::ZERO,
             WriteResult::Success { wrote, total } => {
@@ -3671,7 +3673,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         // including the `?` early-returns below.
         // SAFETY: `this` owns the outstanding ref this guard consumes; the JS
         // wrapper's own +1 keeps the allocation alive across the whole call.
-        let _this_deref = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
+        let _guard = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
         this.detach_native_callback();
         this.socket.set(SocketHandler::<SSL>::DETACHED);
 

--- a/src/runtime/socket/uws_dispatch.rs
+++ b/src/runtime/socket/uws_dispatch.rs
@@ -196,8 +196,6 @@ unsafe extern "C" fn us_dispatch_ssl_raw_tap(
     let tls: bun_ptr::ThisPtr<TLSSocket> =
         s_ref.ext::<Option<bun_ptr::ThisPtr<TLSSocket>>>().unwrap();
     if let Some(raw) = tls.twin.get().as_ref() {
-        // `twin` is `RefPtr<Self>` (intrusive ref-counted heap pointer);
-        // grab the raw `*mut` without consuming the ref so the +1 stays put.
         let raw: *mut TLSSocket = raw.as_ptr();
         // A negative length from the C side means there is nothing to deliver;
         // never panic across the `extern "C"` boundary.

--- a/src/runtime/socket/uws_dispatch.rs
+++ b/src/runtime/socket/uws_dispatch.rs
@@ -196,7 +196,7 @@ unsafe extern "C" fn us_dispatch_ssl_raw_tap(
     let tls: bun_ptr::ThisPtr<TLSSocket> =
         s_ref.ext::<Option<bun_ptr::ThisPtr<TLSSocket>>>().unwrap();
     if let Some(raw) = tls.twin.get().as_ref() {
-        // `twin` is `IntrusiveRc<Self>` (intrusive ref-counted heap pointer);
+        // `twin` is `RefPtr<Self>` (intrusive ref-counted heap pointer);
         // grab the raw `*mut` without consuming the ref so the +1 stays put.
         let raw: *mut TLSSocket = raw.as_ptr();
         // A negative length from the C side means there is nothing to deliver;

--- a/src/runtime/socket/uws_handlers.rs
+++ b/src/runtime/socket/uws_handlers.rs
@@ -9,7 +9,7 @@
 //! the same trampolines at runtime per `us_socket_context_t`.
 
 use bun_jsc::JsResult;
-use bun_ptr::ThisPtr;
+use bun_ptr::{RefPtr, ThisPtr};
 use core::ffi::{c_int, c_void};
 use core::ptr::NonNull;
 
@@ -251,7 +251,7 @@ impl<const SSL: bool> RawSocketEvents<SSL> for websocket_client::WebSocket<SSL> 
         Ok(())
     }
     fn on_writable(this: ThisPtr<Self>, s: NewSocketHandler<SSL>) -> JsResult<()> {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         this.handle_writable(s);
         Ok(())
     }
@@ -261,27 +261,27 @@ impl<const SSL: bool> RawSocketEvents<SSL> for websocket_client::WebSocket<SSL> 
         code: i32,
         reason: *mut c_void,
     ) -> JsResult<()> {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         this.handle_close(s, code, reason);
         Ok(())
     }
     fn on_timeout(this: ThisPtr<Self>, s: NewSocketHandler<SSL>) -> JsResult<()> {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         this.handle_timeout(s);
         Ok(())
     }
     fn on_long_timeout(this: ThisPtr<Self>, s: NewSocketHandler<SSL>) -> JsResult<()> {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         this.handle_timeout(s);
         Ok(())
     }
     fn on_end(this: ThisPtr<Self>, s: NewSocketHandler<SSL>) -> JsResult<()> {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         this.handle_end(s);
         Ok(())
     }
     fn on_connect_error(this: ThisPtr<Self>, s: NewSocketHandler<SSL>, code: i32) -> JsResult<()> {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         this.handle_connect_error(s, code);
         Ok(())
     }
@@ -291,7 +291,7 @@ impl<const SSL: bool> RawSocketEvents<SSL> for websocket_client::WebSocket<SSL> 
         ok: i32,
         err: bun_uws::us_bun_verify_error_t,
     ) -> JsResult<()> {
-        let _guard = this.ref_guard();
+        let _guard = RefPtr::from_this(this);
         this.handle_handshake(s, ok, err);
         Ok(())
     }

--- a/src/runtime/test_runner/DoneCallback.rs
+++ b/src/runtime/test_runner/DoneCallback.rs
@@ -11,21 +11,6 @@ pub struct DoneCallback {
 }
 
 impl DoneCallback {
-    // Codegen's `host_fn_finalize` calls this via `|b| DoneCallback::finalize(b)`
-    // and requires `fn finalize(self: Box<Self>)`; clippy::boxed_local is a
-    // false positive on that contract.
-    #[allow(clippy::boxed_local)]
-    pub fn finalize(mut self: Box<Self>) {
-        let _g = group_begin!();
-
-        // `RefDataPtr` = `RefPtr<RefData>` has NO `Drop` impl (see
-        // src/ptr/ref_count.rs) — must explicitly decrement before the Box
-        // frees the allocation.
-        if let Some(r) = self.r#ref.take() {
-            r.deref();
-        }
-    }
-
     pub(crate) fn create_unbound(global: &JSGlobalObject) -> JSValue {
         let _g = group_begin!();
 

--- a/src/runtime/test_runner/DoneCallback.rs
+++ b/src/runtime/test_runner/DoneCallback.rs
@@ -1,12 +1,13 @@
 use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSValue, JsClass as _, JsResult};
 use bun_core::String as BunString;
+use bun_ptr::RefPtr;
 
-use crate::test_runner::bun_test::{group_begin, BunTest, RefDataPtr};
+use crate::test_runner::bun_test::{group_begin, BunTest, RefData};
 
 #[bun_jsc::JsClass(no_construct, no_constructor)] // codegen wires to_js / from_js
 pub struct DoneCallback {
     /// Some = not called yet. None = done already called, no-op.
-    pub(crate) r#ref: Option<RefDataPtr>,
+    pub(crate) r#ref: Option<RefPtr<RefData>>,
     pub(crate) called: bool, // = false
 }
 

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -8,6 +8,7 @@ use bun_core::{Output, Timespec};
 use bun_jsc::{self as jsc, CallFrame, GlobalRef, JSGlobalObject, JSValue, JsResult, Strong, JsClass as _};
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::js_promise::Status as PromiseStatus;
+use bun_ptr::RefPtr;
 use super::jest::{Jest, FileId, FileColumns as _};
 use crate::timer::{EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, ElTimespec};
 use crate::cli::test_command::CommandLineReporter;
@@ -485,7 +486,7 @@ impl BunTestRoot {
             // `BunTest::run_test_callback`; it is live because the promise
             // never settled (the settle path removes the entry before
             // releasing). Single-threaded.
-            drop(unsafe { RefDataPtr::from_raw(ptr.cast_mut()) });
+            drop(unsafe { RefPtr::from_raw(ptr.cast_mut()) });
         }
     }
 
@@ -720,11 +721,11 @@ impl BunTest {
         }
     }
 
-    pub fn ref_(this_strong: &BunTestPtr, phase: RefDataValue) -> RefDataPtr {
+    pub fn ref_(this_strong: &BunTestPtr, phase: RefDataValue) -> RefPtr<RefData> {
         let _g = group_begin!();
         bun_core::scoped_log!(bun_test_group, "ref: {}", phase);
 
-        bun_ptr::RefPtr::new(RefData {
+        RefPtr::new(RefData {
             buntest_weak: Rc::downgrade(this_strong),
             phase,
             ref_count: bun_ptr::RefCount::init(),
@@ -746,7 +747,7 @@ impl BunTest {
         let raw_ref: *mut RefData = this_ptr.as_promise_ptr::<RefData>();
         // SAFETY: `raw_ref` was produced by `RefPtr::into_raw` in `run_test_callback`
         // and round-tripped via `as_promise_ptr`; we adopt the +1 it carried.
-        let refdata: RefDataPtr = unsafe { bun_ptr::RefPtr::from_raw(raw_ref) };
+        let refdata = unsafe { RefPtr::from_raw(raw_ref) };
         // Remove the pending_then_refs entry first so it never holds a freed `RefData`.
         if let Some(runner) = Jest::runner() {
             let mut pending = runner.bun_test_root.pending_then_refs.borrow_mut();
@@ -1179,7 +1180,7 @@ impl BunTest {
         // counted handle. The single +1 from `ref()` is owned by
         // `dcb_data.ref`; `dcb_ref` just remembers the address so the
         // pending-promise branch can `dupe()` it and the tail can branch on
-        // "wait for done callback". Holding a second `RefDataPtr` here would
+        // "wait for done callback". Holding a second `RefPtr<RefData>` here would
         // over-count and the done-callback path would never observe
         // `has_one_ref()`.
         let mut dcb_ref: Option<NonNull<RefData>> = None;
@@ -1212,17 +1213,17 @@ impl BunTest {
                 match bun_jsc::JSPromise::opaque_mut(promise).status() {
                     PromiseStatus::Pending => {
                         // not immediately resolved; register 'then' to handle the result when it becomes available
-                        let this_ref: RefDataPtr = if let Some(dcb_ref_value) = dcb_ref {
+                        let this_ref: RefPtr<RefData> = if let Some(dcb_ref_value) = dcb_ref {
                             // SAFETY: `dcb_ref_value` aliases the live RefData
                             // owned by `dcb_data.r#ref` (set just above; GC
                             // roots `done_callback` for this frame). Bump the
                             // refcount 1→2.
-                            unsafe { bun_ptr::RefPtr::init_ref(dcb_ref_value.as_ptr()) }
+                            unsafe { RefPtr::init_ref(dcb_ref_value.as_ptr()) }
                         } else {
                             Self::ref_(this_strong, cfg_data)
                         };
                         // Track the `+1` handed to `Promise.then()` in case the promise never settles.
-                        let raw_ref: *mut RefData = bun_ptr::RefPtr::into_raw(this_ref);
+                        let raw_ref: *mut RefData = RefPtr::into_raw(this_ref);
                         this_strong
                             .bun_test_root
                             .get()
@@ -1494,8 +1495,6 @@ pub struct RefData {
     pub(crate) phase: RefDataValue,
     pub(crate) ref_count: bun_ptr::RefCount<RefData>,
 }
-// `*RefData` crosses FFI (`as_promise_ptr`), so this MUST be `bun_ptr::RefPtr`, never `Rc`.
-pub type RefDataPtr = bun_ptr::RefPtr<RefData>;
 impl RefData {
     /// `RefCounted` destructor — last ref dropped.
     ///

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -481,12 +481,11 @@ impl BunTestRoot {
         // any reaction that is still queued is dropped wholesale by
         // `Zig__GlobalObject__destructOnExit`.
         for ptr in self.pending_then_refs.borrow_mut().drain(..) {
-            // SAFETY: `ptr` was produced by `IntrusiveRc::into_raw` in
+            // SAFETY: `ptr` was produced by `RefPtr::into_raw` in
             // `BunTest::run_test_callback`; it is live because the promise
             // never settled (the settle path removes the entry before
-            // `deref()`). `RefPtr<T>` has no `Drop`, so explicitly `.deref()`
-            // to release the `+1` and destroy the box. Single-threaded.
-            unsafe { RefDataPtr::from_raw(ptr.cast_mut()) }.deref();
+            // releasing). Single-threaded.
+            drop(unsafe { RefDataPtr::from_raw(ptr.cast_mut()) });
         }
     }
 
@@ -725,7 +724,7 @@ impl BunTest {
         let _g = group_begin!();
         bun_core::scoped_log!(bun_test_group, "ref: {}", phase);
 
-        bun_ptr::IntrusiveRc::new(RefData {
+        bun_ptr::RefPtr::new(RefData {
             buntest_weak: Rc::downgrade(this_strong),
             phase,
             ref_count: bun_ptr::RefCount::init(),
@@ -745,21 +744,18 @@ impl BunTest {
         }
 
         let raw_ref: *mut RefData = this_ptr.as_promise_ptr::<RefData>();
-        // SAFETY: `raw_ref` was produced by `IntrusiveRc::into_raw` in `run_test_callback`
+        // SAFETY: `raw_ref` was produced by `RefPtr::into_raw` in `run_test_callback`
         // and round-tripped via `as_promise_ptr`; we adopt the +1 it carried.
-        let refdata: RefDataPtr = unsafe { bun_ptr::IntrusiveRc::from_raw(raw_ref) };
-        // Remove the pending_then_refs entry before `deref()` so a freed `RefData` never lingers.
+        let refdata: RefDataPtr = unsafe { bun_ptr::RefPtr::from_raw(raw_ref) };
+        // Remove the pending_then_refs entry before `refdata` drops so a freed `RefData` never lingers.
         if let Some(runner) = Jest::runner() {
             let mut pending = runner.bun_test_root.pending_then_refs.borrow_mut();
             if let Some(pos) = pending.iter().position(|p| *p == raw_ref.cast_const()) {
                 pending.swap_remove(pos);
             }
         }
-        // refdata.deref() at scope exit — RefPtr<T> currently has NO Drop impl (src/ptr/ref_count.rs),
-        // so scope-exit drop is a silent no-op. Decrement the intrusive count explicitly so
-        // (a) RefData::destructor frees the box + Weak<BunTest>, and (b) a paired done() callback
-        // observes has_one_ref()==true on its turn instead of hanging.
-        let refdata = scopeguard::guard(refdata, |r: RefDataPtr| r.deref());
+        // `refdata` drops at scope exit, so a paired done() callback observes
+        // has_one_ref()==true on its turn.
         let has_one_ref = refdata.has_one_ref();
         let Some(this_strong) = refdata.buntest_weak.upgrade() else {
             bun_core::scoped_log!(bun_test_group, "bunTestThenOrCatch -> the BunTest is no longer active");
@@ -831,11 +827,8 @@ impl BunTest {
         let Some(ref_in) = ref_in else {
             return Ok(JSValue::UNDEFINED);
         };
-        // `this.ref` was already taken above.
-        // RefPtr<T> currently has NO Drop impl, so decrement the
-        // intrusive count explicitly at scope exit. Without this the
-        // paired promise then/catch path never sees has_one_ref()==true and the RefData leaks.
-        let ref_in = scopeguard::guard(ref_in, |r: RefDataPtr| r.deref());
+        // `this.ref` was already taken above; it drops at scope exit so the
+        // paired promise then/catch path sees has_one_ref()==true.
 
         // dupe the ref and enqueue a task to call the done callback.
         // this makes it so if you do something else after calling done(), the next test doesn't start running until the next tick.
@@ -1190,9 +1183,9 @@ impl BunTest {
         // counted handle. The single +1 from `ref()` is owned by
         // `dcb_data.ref`; `dcb_ref` just remembers the address so the
         // pending-promise branch can `dupe()` it and the tail can branch on
-        // "wait for done callback". `RefPtr<T>` has no `Drop`, so holding a
-        // second `RefDataPtr` here would over-count and the done-callback path
-        // would never observe `has_one_ref()`.
+        // "wait for done callback". Holding a second `RefDataPtr` here would
+        // over-count and the done-callback path would never observe
+        // `has_one_ref()`.
         let mut dcb_ref: Option<NonNull<RefData>> = None;
         if !done_callback.is_empty() && !result.is_empty() {
             if let Some(dcb_data) = DoneCallback::from_js(done_callback) {
@@ -1228,12 +1221,12 @@ impl BunTest {
                             // owned by `dcb_data.r#ref` (set just above; GC
                             // roots `done_callback` for this frame). Bump the
                             // refcount 1→2.
-                            unsafe { bun_ptr::IntrusiveRc::init_ref(dcb_ref_value.as_ptr()) }
+                            unsafe { bun_ptr::RefPtr::init_ref(dcb_ref_value.as_ptr()) }
                         } else {
                             Self::ref_(this_strong, cfg_data)
                         };
                         // Track the `+1` handed to `Promise.then()` in case the promise never settles.
-                        let raw_ref: *mut RefData = bun_ptr::IntrusiveRc::into_raw(this_ref);
+                        let raw_ref: *mut RefData = bun_ptr::RefPtr::into_raw(this_ref);
                         this_strong
                             .bun_test_root
                             .get()
@@ -1505,8 +1498,8 @@ pub struct RefData {
     pub(crate) phase: RefDataValue,
     pub(crate) ref_count: bun_ptr::RefCount<RefData>,
 }
-// `*RefData` crosses FFI (`as_promise_ptr`), so this MUST be `bun_ptr::IntrusiveRc` (= `RefPtr`), never `Rc`.
-pub type RefDataPtr = bun_ptr::IntrusiveRc<RefData>;
+// `*RefData` crosses FFI (`as_promise_ptr`), so this MUST be `bun_ptr::RefPtr`, never `Rc`.
+pub type RefDataPtr = bun_ptr::RefPtr<RefData>;
 impl RefData {
     /// `RefCounted` destructor — last ref dropped.
     ///

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -747,15 +747,13 @@ impl BunTest {
         // SAFETY: `raw_ref` was produced by `RefPtr::into_raw` in `run_test_callback`
         // and round-tripped via `as_promise_ptr`; we adopt the +1 it carried.
         let refdata: RefDataPtr = unsafe { bun_ptr::RefPtr::from_raw(raw_ref) };
-        // Remove the pending_then_refs entry before `refdata` drops so a freed `RefData` never lingers.
+        // Remove the pending_then_refs entry first so it never holds a freed `RefData`.
         if let Some(runner) = Jest::runner() {
             let mut pending = runner.bun_test_root.pending_then_refs.borrow_mut();
             if let Some(pos) = pending.iter().position(|p| *p == raw_ref.cast_const()) {
                 pending.swap_remove(pos);
             }
         }
-        // `refdata` drops at scope exit, so a paired done() callback observes
-        // has_one_ref()==true on its turn.
         let has_one_ref = refdata.has_one_ref();
         let Some(this_strong) = refdata.buntest_weak.upgrade() else {
             bun_core::scoped_log!(bun_test_group, "bunTestThenOrCatch -> the BunTest is no longer active");
@@ -827,8 +825,6 @@ impl BunTest {
         let Some(ref_in) = ref_in else {
             return Ok(JSValue::UNDEFINED);
         };
-        // `this.ref` was already taken above; it drops at scope exit so the
-        // paired promise then/catch path sees has_one_ref()==true.
 
         // dupe the ref and enqueue a task to call the done callback.
         // this makes it so if you do something else after calling done(), the next test doesn't start running until the next tick.

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -34,8 +34,7 @@ use bun_jsc::js_error_to_write_error;
 // field mutated post-construction (`flags`, via the `.not`/`.resolves`/`.rejects`
 // chaining getters) is `Cell`-wrapped so the codegen shim can hand out a shared
 // `&*m_ctx` borrow without aliasing UB. `parent` and `custom_label` are
-// read-only after `call()` constructs the wrapper; `finalize()` owns `Box<Self>`
-// so it may still tear them down by value.
+// read-only after `call()` constructs the wrapper.
 #[bun_jsc::JsClass]
 pub struct Expect {
     pub(crate) flags: Cell<Flags>,
@@ -697,10 +696,9 @@ impl Expect {
         } else {
             None
         };
-        // The ref
-        // moves into `Expect` below and `to_js()` is infallible, so there is no
-        // error path between ref creation and the wrapper taking ownership; from
-        // then on `Expect::finalize` derefs `parent` (RefDataPtr has no Drop).
+        // The ref moves into `Expect` below and `to_js()` is infallible, so
+        // there is no error path between ref creation and the wrapper taking
+        // ownership.
 
         let expect = Expect {
             flags: Cell::new(Flags::default()),

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -678,18 +678,6 @@ impl Expect {
         Ok(buf)
     }
 
-    // Codegen's `host_fn_finalize` calls this via `|b| Expect::finalize(b)`
-    // and requires `fn finalize(self: Box<Self>)`; clippy::boxed_local is a
-    // false positive on that contract.
-    #[allow(clippy::boxed_local)]
-    pub fn finalize(mut self: Box<Self>) {
-        // RefDataPtr = RefPtr<RefData> has NO `Drop` impl (src/ptr/ref_count.rs)
-        // so the Box drop below would leak the +1 — release explicitly.
-        if let Some(parent) = self.parent.take() {
-            parent.deref();
-        }
-    }
-
     // extern shim emitted by `#[bun_jsc::JsClass]` codegen (TypeClass__construct/__call); bare `#[host_fn]` cannot target an associated fn without a receiver.
     pub fn call(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let arguments = callframe.arguments();

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -12,6 +12,7 @@ use bun_jsc::{JsClass as _, StringJsc as _};
 use bun_jsc::js_promise;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_core::strings;
+use bun_ptr::RefPtr;
 
 use super::bun_test::{self};
 use super::diff_format::DiffFormatter;
@@ -38,7 +39,7 @@ use bun_jsc::js_error_to_write_error;
 #[bun_jsc::JsClass]
 pub struct Expect {
     pub(crate) flags: Cell<Flags>,
-    pub(crate) parent: Option<bun_test::RefDataPtr>,
+    pub(crate) parent: Option<RefPtr<bun_test::RefData>>,
     pub(crate) custom_label: bun_core::String,
 }
 

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -301,7 +301,7 @@ impl Snapshots {
                 match &mut stmt.data {
                     bun_ast::StmtData::SExpr(expr) => {
                         if let bun_ast::ExprData::EBinary(e_binary) = &mut expr.value.data {
-                            // deref `StoreRef` once to a plain `&mut E::Binary`
+                            // deref `RefPtr<Store>` once to a plain `&mut E::Binary`
                             // so the borrow checker can see `.left`/`.right` as disjoint
                             // field projections (custom `DerefMut` blocks split-borrows
                             // otherwise).

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -301,7 +301,7 @@ impl Snapshots {
                 match &mut stmt.data {
                     bun_ast::StmtData::SExpr(expr) => {
                         if let bun_ast::ExprData::EBinary(e_binary) = &mut expr.value.data {
-                            // deref `RefPtr<Store>` once to a plain `&mut E::Binary`
+                            // deref `StoreRef` once to a plain `&mut E::Binary`
                             // so the borrow checker can see `.left`/`.right` as disjoint
                             // field projections (custom `DerefMut` blocks split-borrows
                             // otherwise).

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -68,14 +68,13 @@ macro_rules! impl_timer_object {
 
         // Intrusive single-thread refcount mixin.
         impl ::bun_ptr::RefCounted for $T {
-            type DestructorCtx = ();
             #[inline]
             unsafe fn get_ref_count(this: *mut Self) -> *mut ::bun_ptr::RefCount<Self> {
                 // SAFETY: caller contract — `this` points to a live `Self`.
                 unsafe { &raw mut (*this).ref_count }
             }
             #[inline]
-            unsafe fn destructor(this: *mut Self, _ctx: ()) {
+            unsafe fn destructor(this: *mut Self) {
                 // SAFETY: `raw_count == 0` ⇒ unique ownership; `deinit`
                 // consumes the `heap::alloc`'d allocation from `init_with()`.
                 unsafe { Self::deinit(this) }

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -351,7 +351,7 @@ impl RefCountedTimer {
     /// Insert into the VM timer heap to fire after `ms`, taking the keep-alive
     /// ref if not already held. Disarms first if currently active.
     fn arm(&self, owner: &JSValkeyClient, ms: u32) {
-        let _guard = owner.ref_scope();
+        let _guard = owner.ref_guard();
         if self.state() == Timer::State::ACTIVE {
             self.disarm(owner);
         }
@@ -457,7 +457,7 @@ impl JSValkeyClient {
     /// RAII scoped ref: bumps on construction, derefs on `Drop`. Keeps `*self`
     /// alive across re-entrant connect/close/fail paths.
     #[inline]
-    pub(crate) fn ref_scope(&self) -> RefPtr<Self> {
+    pub(crate) fn ref_guard(&self) -> RefPtr<Self> {
         // SAFETY: `self` is live; the guard's own ref keeps it alive past Drop.
         unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
     }
@@ -891,7 +891,7 @@ impl JSValkeyClient {
             self._subscription_ctx.get().is_subscriber
         );
         debug_assert!(self.client.get().status == valkey::Status::Connected);
-        let _guard = self.ref_scope();
+        let _guard = self.ref_guard();
 
         if !self._subscription_ctx.get().is_subscriber {
             let flags = &self.client.get().flags;
@@ -916,7 +916,7 @@ impl JSValkeyClient {
             "removeSubscription: entering, has subscriptions: {}",
             self.has_subscriptions()
         );
-        let _guard = self.ref_scope();
+        let _guard = self.ref_guard();
 
         // This is the last subscription, restore original flags
         if !self.has_subscriptions() {
@@ -957,7 +957,7 @@ impl JSValkeyClient {
         global_object: &JSGlobalObject,
         this_value: JSValue,
     ) -> JsResult<JSValue> {
-        let _guard = self.ref_scope();
+        let _guard = self.ref_guard();
 
         // If already connected, resolve immediately
         if self.client.get().status == valkey::Status::Connected {
@@ -1032,7 +1032,7 @@ impl JSValkeyClient {
     ) -> JsResult<JSValue> {
         // `disconnect()` -> `close()` can dispatch `on_close` synchronously,
         // which derefs. Hold a ref so `&self` stays live across the call.
-        let _guard = self.ref_scope();
+        let _guard = self.ref_guard();
 
         match self.client.get().status {
             valkey::Status::NeverConnected => return Ok(JSValue::UNDEFINED),
@@ -1077,7 +1077,7 @@ impl JSValkeyClient {
     pub(crate) fn on_connection_timeout(&self) -> JsResult<()> {
         debug!("onConnectionTimeout");
 
-        let _guard = self.ref_scope();
+        let _guard = self.ref_guard();
         let _timer_ref = self.timer.take_fire_ref(self);
         if self.client.get().flags.failed {
             return Ok(());
@@ -1158,7 +1158,7 @@ impl JSValkeyClient {
     pub(crate) fn on_reconnect_timer(&self) -> JsResult<()> {
         debug!("Reconnect timer fired, attempting to reconnect");
 
-        let _guard = self.ref_scope();
+        let _guard = self.ref_guard();
         let _timer_ref = self.reconnect_timer.take_fire_ref(self);
 
         // Execute reconnection logic
@@ -1188,7 +1188,7 @@ impl JSValkeyClient {
         }
 
         // Ref to keep this alive during the reconnection
-        let _guard = self.ref_scope();
+        let _guard = self.ref_guard();
 
         // Ref the poll to keep event loop alive during connection
         self.poll_ref.with_mut(|r| {
@@ -1299,7 +1299,7 @@ impl JSValkeyClient {
     ///
     /// `SubscriptionCtx` will invoke this to communicate that it has added a new listener.
     pub(crate) fn on_new_subscription_callback_insert(&self) {
-        let _guard = self.ref_scope();
+        let _guard = self.ref_guard();
 
         self.client_mut().on_writable();
         self.update_poll_ref();
@@ -1309,7 +1309,7 @@ impl JSValkeyClient {
         debug_assert!(self.is_subscriber());
         debug_assert!(self.this_value.get().is_strong());
 
-        let _guard = self.ref_scope();
+        let _guard = self.ref_guard();
 
         let _ = value;
 
@@ -1471,7 +1471,7 @@ impl JSValkeyClient {
             self.client_mut().status = valkey::Status::Disconnected;
         }
 
-        let _guard = self.ref_scope();
+        let _guard = self.ref_guard();
 
         let is_tls = self.client.get().tls != valkey::TLS::None;
         let vm = self.client.get().vm.as_mut();
@@ -1539,7 +1539,7 @@ impl JSValkeyClient {
         // (`SocketHandler::on_close`, `SocketHandler::on_connect_error`, or
         // `ValkeyClient::close()` for a half-open socket), which is the one
         // event uSockets delivers for every socket this returns.
-        let socket_ref = self.ref_scope();
+        let socket_ref = self.ref_guard();
         // SAFETY: `client_ptr` is live; `group` is the lazy-initialised per-VM
         // `SocketGroup` (stable for the VM's lifetime). `ssl_ctx` is a +1-ref
         // BoringSSL `SSL_CTX*` (or None) forwarded opaquely to usockets.
@@ -1563,7 +1563,7 @@ impl JSValkeyClient {
     ) -> Result<*mut JSPromise, crate::Error> {
         // Keep `*self` alive across re-entrant connect/close paths below;
         // the host-fn shim passes a bare `&self` with no ref of its own.
-        let _guard = self.ref_scope();
+        let _guard = self.ref_guard();
 
         self.ensure_dialing();
 
@@ -1763,7 +1763,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
             ),
         );
         let handshake_success = success == 1;
-        let _guard = this.ref_scope();
+        let _guard = this.ref_guard();
         let _update = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
         let vm = this.client.get().vm;
         if handshake_success {
@@ -1867,8 +1867,8 @@ impl<const SSL: bool> SocketHandler<SSL> {
         _reason: Option<*mut c_void>,
     ) -> JsResult<()> {
         debug!("Socket closed.");
-        let _guard = this.ref_scope();
-        // SAFETY: adopts the keep-alive ref `connect()` forgot for this
+        let _guard = this.ref_guard();
+        // SAFETY: takes over the keep-alive ref `connect()` handed to this
         // socket; this is its one close event. Released after `_defer` runs,
         // while `_guard` still holds the client.
         let _socket_ref = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
@@ -1898,7 +1898,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
     ) -> JsResult<()> {
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
-        let _guard = this.ref_scope();
+        let _guard = this.ref_guard();
         // SAFETY: as in `on_close`; a dial that fails gets this event instead.
         let _socket_ref = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
         this.client_mut().status = valkey::Status::Disconnected;
@@ -1922,7 +1922,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Self::socket(socket);
 
-        let _guard = this.ref_scope();
+        let _guard = this.ref_guard();
         let result = this.client_mut().on_data(data);
         if this.client.get().status == valkey::Status::Connected {
             this.reset_connection_timeout();
@@ -1933,7 +1933,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
 
     pub(crate) fn on_writable(this: &JSValkeyClient, socket: SocketType<SSL>) {
         this.client_mut().socket = Self::socket(socket);
-        let _guard = this.ref_scope();
+        let _guard = this.ref_guard();
         this.client_mut().on_writable();
         this.update_poll_ref();
     }

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -454,11 +454,10 @@ impl JSValkeyClient {
         // SAFETY: caller contract.
         unsafe { bun_ptr::RefCount::deref(this) };
     }
-    /// RAII scoped ref: bumps on construction, derefs on `Drop`. Keeps `*self`
-    /// alive across re-entrant connect/close/fail paths.
+    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
     #[inline]
     pub(crate) fn ref_guard(&self) -> RefPtr<Self> {
-        // SAFETY: `self` is live; the guard's own ref keeps it alive past Drop.
+        // SAFETY: `self` is the live heap allocation.
         unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
     }
     #[inline]

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -11,7 +11,7 @@ use bun_jsc::{
     self as jsc, CallFrame, GlobalRef, JSArray, JSGlobalObject, JSMap, JSPromise, JSValue, JsCell,
     JsRef, JsResult,
 };
-use bun_ptr::{AsCtxPtr, BackRef, ScopedRef};
+use bun_ptr::{AsCtxPtr, BackRef, RefPtr};
 use bun_uws as uws;
 
 use super::protocol_jsc;
@@ -401,12 +401,12 @@ impl RefCountedTimer {
 
     /// Mark fired and hand the keep-alive ref (if held) to the callback scope.
     /// Returns `None` when no ref was held, so a stray fire cannot over-release.
-    fn take_fire_ref(&self, owner: &JSValkeyClient) -> Option<ScopedRef<JSValkeyClient>> {
+    fn take_fire_ref(&self, owner: &JSValkeyClient) -> Option<RefPtr<JSValkeyClient>> {
         self.event_loop_timer
             .with_mut(|t| t.state = Timer::State::FIRED);
         self.ref_held.replace(false).then(|| {
             // SAFETY: `arm`'s `ref_()` set `ref_held`; this scope consumes it.
-            unsafe { ScopedRef::adopt(owner.as_ctx_ptr()) }
+            unsafe { RefPtr::from_raw(owner.as_ctx_ptr()) }
         })
     }
 }
@@ -421,12 +421,11 @@ bun_event_loop::impl_timer_owner!(JSValkeyClient;
 
 // `bun.ptr.RefCount(@This(), "ref_count", deinit, .{})` → intrusive refcount.
 impl bun_ptr::RefCounted for JSValkeyClient {
-    type DestructorCtx = ();
     unsafe fn get_ref_count(this: *mut Self) -> *mut bun_ptr::RefCount<Self> {
         // SAFETY: caller contract — `this` is live.
         unsafe { &raw mut (*this).ref_count }
     }
-    unsafe fn destructor(this: *mut Self, _ctx: ()) {
+    unsafe fn destructor(this: *mut Self) {
         // SAFETY: last ref dropped; sole owner.
         unsafe { JSValkeyClient::deinit(this) };
     }
@@ -458,9 +457,9 @@ impl JSValkeyClient {
     /// RAII scoped ref: bumps on construction, derefs on `Drop`. Keeps `*self`
     /// alive across re-entrant connect/close/fail paths.
     #[inline]
-    pub(crate) fn ref_scope(&self) -> ScopedRef<Self> {
+    pub(crate) fn ref_scope(&self) -> RefPtr<Self> {
         // SAFETY: `self` is live; the guard's own ref keeps it alive past Drop.
-        unsafe { ScopedRef::new(self.as_ctx_ptr()) }
+        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
     }
     #[inline]
     pub(crate) fn new(init: JSValkeyClient) -> *mut JSValkeyClient {
@@ -1446,7 +1445,7 @@ impl JSValkeyClient {
         // ownership back to the raw refcount.
         let this: &Self = bun_core::heap::release(self);
         // SAFETY: the JS wrapper owned one ref; this scope consumes it.
-        let _guard = unsafe { ScopedRef::adopt(this.as_ctx_ptr()) };
+        let _guard = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
 
         this.stop_timers();
         this.this_value.with_mut(|t| t.finalize());
@@ -1552,7 +1551,7 @@ impl JSValkeyClient {
         self.client_mut().socket = socket;
         // Disarm on success: the socket now owns the keep-alive ref.
         scopeguard::ScopeGuard::into_inner(errdefer_status);
-        socket_ref.forget();
+        let _ = socket_ref.into_raw();
         Ok(())
     }
 
@@ -1872,7 +1871,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
         // SAFETY: adopts the keep-alive ref `connect()` forgot for this
         // socket; this is its one close event. Released after `_defer` runs,
         // while `_guard` still holds the client.
-        let _socket_ref = unsafe { ScopedRef::adopt(this.as_ctx_ptr()) };
+        let _socket_ref = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
         // Before `on_close()`: it runs `onclose` and settles the connect()
@@ -1901,7 +1900,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
         this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
         let _guard = this.ref_scope();
         // SAFETY: as in `on_close`; a dial that fails gets this event instead.
-        let _socket_ref = unsafe { ScopedRef::adopt(this.as_ctx_ptr()) };
+        let _socket_ref = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
         this.client_mut().status = valkey::Status::Disconnected;
         let _defer = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
 
@@ -2041,7 +2040,7 @@ impl ValkeyDeferredClose {
     pub(crate) fn run(self: Box<Self>) {
         // SAFETY: adopts the ref `enqueue_deferred_close` took, which kept the
         // client alive until now; released when this scope ends.
-        let _enqueue_ref = unsafe { ScopedRef::adopt(self.ctx) };
+        let _enqueue_ref = unsafe { RefPtr::from_raw(self.ctx) };
         // SAFETY: live per the ref above; tasks run on the JS thread.
         let this = unsafe { &*self.ctx };
         match self.what {
@@ -2075,7 +2074,7 @@ impl bun_event_loop::Taskable for ValkeyDeferredClose {
             // give back what `close_without_socket_next_tick` took.
             DeferredClose::WithoutSocket => {
                 // SAFETY: as in `run`.
-                let _enqueue_ref = unsafe { ScopedRef::adopt(task.ctx) };
+                let _enqueue_ref = unsafe { RefPtr::from_raw(task.ctx) };
                 // SAFETY: live per the ref above.
                 unsafe { &*task.ctx }.poll_ref.with_mut(|r| r.disable());
             }

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -1824,7 +1824,7 @@ impl JSValkeyClient {
         // `upsert_receive_handler`'s exit guard re-enters `on_writable` /
         // `update_poll_ref` before `send()` is reached; hold a ref so `*this`
         // stays live across those calls.
-        let _guard = this.ref_scope();
+        let _guard = this.ref_guard();
 
         let [channel_or_many, handler_callback] = frame.arguments_as_array::<2>();
         let mut redis_channels: Vec<JSArgument> = Vec::with_capacity(1);
@@ -1937,7 +1937,7 @@ impl JSValkeyClient {
     ) -> JsResult<JSValue> {
         // Hold a ref so `*this` stays live across the handler-map updates and
         // the `send()` below.
-        let _guard = this.ref_scope();
+        let _guard = this.ref_guard();
 
         // Check if we're in subscription mode
         require_subscriber(this, b"unsubscribe")?;

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -7,7 +7,7 @@ use bun_collections::OffsetByteList;
 use bun_core::UnwrapOrOom;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{GlobalRef, JSGlobalObject, JSPromise, JSValue, JsResult};
-use bun_ptr::ScopedRef;
+use bun_ptr::RefPtr;
 use bun_uws::{self as uws, AnySocket, SocketGroup, SocketKind, SslCtx};
 use bun_valkey::valkey_protocol as protocol;
 use bun_valkey::valkey_protocol::{RESPValue, RedisError};
@@ -653,7 +653,7 @@ impl ValkeyClient {
         // socket, as `SocketHandler::on_close` does for one uSockets closes.
         // Every caller of `close()` holds a scoped ref of its own, so the
         // client outlives this scope.
-        let _socket_ref = unsafe { ScopedRef::adopt(self.parent_ptr()) };
+        let _socket_ref = unsafe { RefPtr::from_raw(self.parent_ptr()) };
         self.status = Status::Disconnected;
         let closed = self.on_close();
         thrown.and(closed)

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -649,7 +649,7 @@ impl ValkeyClient {
         if !is_semi_socket {
             return thrown;
         }
-        // SAFETY: adopts the keep-alive ref `connect()` forgot for this
+        // SAFETY: takes over the keep-alive ref `connect()` handed to this
         // socket, as `SocketHandler::on_close` does for one uSockets closes.
         // Every caller of `close()` holds a scoped ref of its own, so the
         // client outlives this scope.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2439,8 +2439,6 @@ impl BlobExt for Blob {
                 if let Ok(result) =
                     crate::allocators::linux_mem_fd_allocator::LinuxMemFdAllocator::create(bytes_)
                 {
-                    // spell out all fields — `..Default::default()` would
-                    // attempt a partial move out of `Store` which has a `Drop` impl.
                     let store = RefPtr::from(Store::new(Store {
                         data: store::Data::Bytes(result),
                         mime_type: bun_http_types::MimeType::NONE,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1404,7 +1404,7 @@ impl BlobExt for Blob {
 
             // When no JS overrides were supplied, hand the store's *base*
             // credentials to the upload (`upload_stream` consumes an
-            // `IntrusiveRc` by value, so the else-arm heap-dupes from the
+            // `RefPtr` by value, so the else-arm heap-dupes from the
             // store's `Arc` instead of from the `aws_options` clone).
             return crate::webcore::__s3_client::upload_stream(
                 if extra_options.is_some() {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -19,6 +19,7 @@ use bun_core::Output;
 use bun_core::{EncodedSlice, String as BunString, Utf8Bytes, WTFStringImplExt as _, strings};
 use bun_http_types::MimeType::MimeType;
 use bun_jsc::{EncodedSliceJsc as _, StringJsc as _, bun_string_jsc};
+use bun_ptr::RefPtr;
 use bun_sys::{self, Fd};
 
 use crate::webcore::node_types::{PathLike, PathOrBlob, PathOrFileDescriptor};
@@ -47,8 +48,8 @@ fn http_proxy_href(global: &JSGlobalObject) -> Option<Vec<u8>> {
 #[path = "blob/Store.rs"]
 pub mod store;
 use crate::node::types::{PathLikeExt as _, PathOrFdExt as _};
+pub use store::Store;
 use store::{BytesExt as _, FileExt as _, S3Ext as _, StoreExt as _};
-pub use store::{Store, StoreRef};
 
 #[path = "blob/copy_file.rs"]
 pub mod copy_file;
@@ -62,7 +63,7 @@ pub mod write_file;
 
 /// Deallocator for `ArrayBuffer`s backed by a `Blob::Store` ref. Passed as a C
 /// callback to `ArrayBuffer::to_js_with_context`; the `ctx` is a raw `Store*`
-/// produced by `StoreRef::into_raw()`.
+/// produced by `RefPtr<Store>::into_raw()`.
 ///
 /// Defined here (rather than in `bun_jsc`) because `Store` is a `bun_runtime`
 /// type and the `bun_jsc` copy is a forward-dep placeholder.
@@ -75,7 +76,7 @@ pub(crate) extern "C" fn blob_store_array_buffer_deallocator(
     ctx: *mut c_void,
 ) {
     if let Some(store) = NonNull::new(ctx.cast::<Store>()) {
-        // SAFETY: `ctx` is a `*mut Store` previously yielded by `StoreRef::into_raw`
+        // SAFETY: `ctx` is a `*mut Store` previously yielded by `RefPtr<Store>::into_raw`
         // (one outstanding strong ref). `Store::deref` consumes that ref.
         unsafe { Store::deref(store) };
     }
@@ -1023,7 +1024,7 @@ impl BlobExt for Blob {
             let content_type = self.content_type_slice();
             let offset = self.offset.get();
             let store = self.store().expect("infallible: store present");
-            match store.data_mut() {
+            match Store::data_mut(store) {
                 store::Data::S3(s3) => {
                     S3File::write_format::<F, W, ENABLE_ANSI_COLORS>(
                         s3,
@@ -1703,7 +1704,7 @@ impl BlobExt for Blob {
         let store = self.store().expect("infallible: store present").clone();
         if self.is_s3() {
             // Borrow `s3` through the
-            // cloned `store: StoreRef` (independent of `self`) so the
+            // cloned `store: RefPtr<Store>` (independent of `self`) so the
             // content-type writes below don't conflict.
             let s3 = store.data.as_s3();
             let path = s3.path();
@@ -2121,16 +2122,16 @@ impl BlobExt for Blob {
                 // `resolve_file_stat` — it materializes `&mut File` on the same
                 // memory (Stacked Borrows UB; the optimizer may legally cache the
                 // pre-call `last_modified` and return the stale `INIT_TIMESTAMP`).
-                // Re-read via `StoreRef::data_mut` (raw-ptr-backed accessor) after
+                // Re-read via `RefPtr<Store>::data_mut` (raw-ptr-backed accessor) after
                 // the mutating call.
-                let last_modified = store.data_mut().as_file().last_modified;
+                let last_modified = Store::data_mut(store).as_file().last_modified;
                 // last_modified can be already set during read.
                 if last_modified == jsc::INIT_TIMESTAMP && !self.is_s3() {
                     resolve_file_stat(store);
                 }
                 // Fresh borrow after possible mutation by `resolve_file_stat`.
                 return JSValue::js_number(JSValue::purify_nan(
-                    store.data_mut().as_file().last_modified as f64,
+                    Store::data_mut(store).as_file().last_modified as f64,
                 ));
             }
         }
@@ -2247,14 +2248,14 @@ impl BlobExt for Blob {
         };
         // dispatch on the copied `DataTag` rather than
         // `match &store.data { File(file) => … }`. The latter goes through
-        // `StoreRef::Deref → &Store → &Data` (no `UnsafeCell`), and that shared
+        // `RefPtr<Store>::Deref → &Store → &Data` (no `UnsafeCell`), and that shared
         // borrow is live across the arm body where `resolve_file_stat`
         // materializes `&mut File` on the same memory via the raw
         // `heap::alloc` pointer — Stacked Borrows UB, and under noalias the
         // optimizer may legally cache the pre-call `seekable: None` and fall
-        // through to `self.size.get() = 0`. `StoreRef::data_mut` centralises
+        // through to `self.size.get() = 0`. `RefPtr<Store>::data_mut` centralises
         // the raw-ptr deref so each read here is a fresh, safe borrow.
-        match store.data_mut().tag() {
+        match Store::data_mut(store).tag() {
             store::DataTag::Bytes => {
                 let offset = self.offset.get();
                 let store_size = store.size();
@@ -2265,11 +2266,11 @@ impl BlobExt for Blob {
                 }
             }
             store::DataTag::File => {
-                if store.data_mut().as_file().seekable.is_none() {
+                if Store::data_mut(store).as_file().seekable.is_none() {
                     resolve_file_stat(store);
                 }
                 // Fresh borrow after possible mutation by `resolve_file_stat`.
-                let file = store.data_mut().as_file();
+                let file = Store::data_mut(store).as_file();
 
                 if file.seekable.is_some() && file.max_size != MAX_SIZE {
                     let store_size = file.max_size;
@@ -2301,9 +2302,9 @@ impl BlobExt for Blob {
             return (self.offset.get(), 0);
         };
         // see `resolve_size` — dispatch on the copied tag and re-read
-        // via `StoreRef::data_mut` after `resolve_file_stat` so no
+        // via `RefPtr<Store>::data_mut` after `resolve_file_stat` so no
         // `Deref`-produced `&Data`/`&File` is live across the mutating call.
-        match store.data_mut().tag() {
+        match Store::data_mut(store).tag() {
             store::DataTag::Bytes => {
                 let offset = self.offset.get();
                 let store_size = store.size();
@@ -2315,11 +2316,11 @@ impl BlobExt for Blob {
                 (self.offset.get(), self.size.get())
             }
             store::DataTag::File => {
-                if store.data_mut().as_file().seekable.is_none() {
+                if Store::data_mut(store).as_file().seekable.is_none() {
                     resolve_file_stat(store);
                 }
                 // Fresh borrow after possible mutation by `resolve_file_stat`.
-                let file = store.data_mut().as_file();
+                let file = Store::data_mut(store).as_file();
                 if file.seekable.is_some() && file.max_size != MAX_SIZE {
                     let store_size = file.max_size;
                     let offset = store_size.min(self.offset.get());
@@ -2389,7 +2390,7 @@ impl BlobExt for Blob {
         is_all_ascii: bool,
     ) -> Blob {
         // avoid allocating a Blob.Store if the buffer is actually empty
-        let mut store: Option<StoreRef> = None;
+        let mut store: Option<RefPtr<Store>> = None;
         let len = bytes.len();
         if len > 0 {
             let s = Store::init(bytes);
@@ -2440,7 +2441,7 @@ impl BlobExt for Blob {
                 {
                     // spell out all fields — `..Default::default()` would
                     // attempt a partial move out of `Store` which has a `Drop` impl.
-                    let store = StoreRef::from(Store::new(Store {
+                    let store = RefPtr::from(Store::new(Store {
                         data: store::Data::Bytes(result),
                         mime_type: bun_http_types::MimeType::NONE,
                         ref_count: bun_ptr::ThreadSafeRefCount::init(),
@@ -2467,9 +2468,9 @@ impl BlobExt for Blob {
         Self::try_create(bytes_, global_this, was_string).expect("oom")
     }
 
-    // non-generic `init_with_store(StoreRef, ...)` / `init_empty` removed —
-    // duplicates of the generic `init_with_store<S: Into<StoreRef>>` / `init_empty` below
-    // (E0592). All `StoreRef` callers resolve to the generic via the reflexive `Into` impl.
+    // non-generic `init_with_store(RefPtr<Store>, ...)` / `init_empty` removed —
+    // duplicates of the generic `init_with_store<S: Into<RefPtr<Store>>>` / `init_empty` below
+    // (E0592). All `RefPtr<Store>` callers resolve to the generic via the reflexive `Into` impl.
 
     // Transferring doesn't change the reference count
     // It is a move
@@ -2486,7 +2487,7 @@ impl BlobExt for Blob {
 
     /// Raw-pointer counterpart of [`shared_view`]: returns a `*mut [u8]` into
     /// the Store's byte buffer with **mutable provenance** (derived through
-    /// `StoreRef::as_ptr()` → the original `heap::alloc` tag), suitable for
+    /// `RefPtr<Store>::as_ptr()` → the original `heap::alloc` tag), suitable for
     /// the `*_with_bytes` paths that hand the buffer to JSC as a writable
     /// ArrayBuffer backing, without
     /// laundering a `&[u8]` through `as *const _ as *mut _` (which would carry
@@ -2497,7 +2498,7 @@ impl BlobExt for Blob {
     /// # Aliasing
     /// The returned pointer aliases the Store's `Vec<u8>` payload. Callers must
     /// not hold a live `&`/`&mut` into the same Store across uses of this
-    /// pointer, and must keep a `StoreRef` alive for the pointer's lifetime.
+    /// pointer, and must keep a `RefPtr<Store>` alive for the pointer's lifetime.
     fn shared_view_raw(&self) -> *mut [u8] {
         let empty = || {
             core::ptr::slice_from_raw_parts_mut(core::ptr::NonNull::<u8>::dangling().as_ptr(), 0)
@@ -2508,13 +2509,13 @@ impl BlobExt for Blob {
         let Some(store_ref) = self.store() else {
             return empty();
         };
-        // `StoreRef::data_mut` derefs the original `heap::alloc` `*mut Store`
+        // `RefPtr<Store>::data_mut` derefs the original `heap::alloc` `*mut Store`
         // (mutable provenance over the whole allocation) without materializing
         // a `Deref`-produced `&Store`, so the brief `&mut` to the payload does
-        // not alias any outstanding borrow (other `StoreRef`s only hold raw
+        // not alias any outstanding borrow (other `RefPtr<Store>`s only hold raw
         // `NonNull<Store>`, never a long-lived `&Store`; JS execution is
         // single-threaded).
-        match store_ref.data_mut() {
+        match Store::data_mut(store_ref) {
             store::Data::Bytes(bytes) => {
                 let v: &mut [u8] = bytes.as_array_list_leak();
                 let len = v.len();
@@ -2525,7 +2526,7 @@ impl BlobExt for Blob {
                 let off = (self.offset.get() as usize).min(len);
                 let clamped = (len - off).min(self.size.get() as usize);
                 // `v` already carries mutable provenance (derived through
-                // `StoreRef::data_mut`); safe sub-slicing then raw-ptr coercion
+                // `RefPtr<Store>::data_mut`); safe sub-slicing then raw-ptr coercion
                 // preserves it without `from_raw_parts_mut`/`ptr::add`.
                 core::ptr::from_mut::<[u8]>(&mut v[off..off + clamped])
             }
@@ -2541,7 +2542,7 @@ impl BlobExt for Blob {
         if self.size.get() > 0 && self.offset.get() == 0 {
             if let Some(store_ref) = self.store() {
                 let store = store_ref.as_ptr();
-                // SAFETY: `store` is live (we hold a `StoreRef`); single-threaded
+                // SAFETY: `store` is live (we hold a `RefPtr<Store>`); single-threaded
                 // JS execution means no concurrent &Store borrow is outstanding.
                 unsafe {
                     if matches!((*store).data, store::Data::Bytes(_)) {
@@ -2653,7 +2654,7 @@ impl BlobExt for Blob {
                 }
             }
             Lifetime::Transfer => {
-                // Cloning the StoreRef here would bump the
+                // Cloning the RefPtr<Store> here would bump the
                 // intrusive count by +1 *and* `transfer()` would leak the original
                 // +1, leaving an unmatched ref. Move the existing ref out instead;
                 // `into_raw` then hands that single ref to JSC.
@@ -2708,7 +2709,7 @@ impl BlobExt for Blob {
         }
 
         // `shared_view_raw` yields a `*mut [u8]` with mutable provenance (via
-        // `StoreRef::as_ptr`), avoiding a const→mut cast. `to_string_with_bytes`
+        // `RefPtr<Store>::as_ptr`), avoiding a const→mut cast. `to_string_with_bytes`
         // only ever reads through it (`&*raw_bytes`); the sole write path —
         // `heap::take` in the `Temporary` arm — is statically unreachable
         // below.
@@ -2749,7 +2750,7 @@ impl BlobExt for Blob {
         }
 
         // `shared_view_raw` yields a `*mut [u8]` with mutable provenance (via
-        // `StoreRef::as_ptr`). `to_json_with_bytes` only reads through it for the
+        // `RefPtr<Store>::as_ptr`). `to_json_with_bytes` only reads through it for the
         // non-`Temporary` lifetimes below.
         let view_ptr = self.shared_view_raw();
         match lifetime {
@@ -3088,7 +3089,7 @@ impl BlobExt for Blob {
         }
 
         // `shared_view_raw` yields a `*mut [u8]` with mutable provenance (via
-        // `StoreRef::as_ptr`). The `Clone` arm only reads (`&*buf`);
+        // `RefPtr<Store>::as_ptr`). The `Clone` arm only reads (`&*buf`);
         // `Share`/`Transfer` hand the ptr to JSC as an external ArrayBuffer
         // backing via FFI and materialize `&mut *buf` to record ptr+len, which
         // is sound now that the provenance is writable. The `Temporary` arm
@@ -3137,7 +3138,7 @@ impl BlobExt for Blob {
         }
 
         // `shared_view_raw` yields a `*mut [u8]` with mutable provenance (via
-        // `StoreRef::as_ptr`). It is *only ever read* by
+        // `RefPtr<Store>::as_ptr`). It is *only ever read* by
         // `to_form_data_with_bytes` (`FormData::to_js` takes `&[u8]`). Note: the
         // Store is intrusively shared (`ref_count: AtomicU32`); `&mut self` does
         // NOT imply exclusive ownership of the underlying bytes.
@@ -3244,7 +3245,7 @@ impl BlobExt for Blob {
                                 // Move the store without bumping its refcount, but take
                                 // independent ownership of name/content_type so the
                                 // source's eventual finalize() doesn't double-free them.
-                                // *Take* the StoreRef out of `blob`
+                                // *Take* the RefPtr<Store> out of `blob`
                                 // (no clone, no into_raw leak) and field-copy the
                                 // rest, deep-owning `name`/`content_type` — net 0 on
                                 // the store refcount.
@@ -3610,9 +3611,7 @@ impl BlobExt for Blob {
                     // SAFETY: the ctor hook (`__bun_stdio_blob_store_new`)
                     // returns `Box::<Store>::into_raw` — non-null, live for the
                     // process lifetime, and laid out as `Store`.
-                    let store = unsafe {
-                        StoreRef::retained(NonNull::new_unchecked(erased.cast::<Store>()))
-                    };
+                    let store = unsafe { RefPtr::init_ref(erased.cast::<Store>()) };
                     return Blob::init_with_store(store, global_this);
                 }
                 PathOrFileDescriptor::Fd(*fd)
@@ -4006,7 +4005,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
 
                 // ScopeGuard derefs to its inner Blob.
                 if let Some(store) = (*guard).store() {
-                    if let store::Data::Bytes(bytes_store) = &mut store.data_mut() {
+                    if let store::Data::Bytes(bytes_store) = &mut Store::data_mut(store) {
                         // Transfer ownership of the local `name: Vec<u8>` into
                         // `stored_name` (a `Box<[u8]>`); freed by `Bytes::Drop`.
                         bytes_store.stored_name = name.into_boxed_slice();
@@ -4174,7 +4173,7 @@ pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &BunString) 
 
     // This is not 100% correct...
     if let Some(store) = this.store() {
-        if let store::Data::Bytes(bytes) = &mut store.data_mut() {
+        if let store::Data::Bytes(bytes) = &mut Store::data_mut(store) {
             if bytes.stored_name.is_empty() {
                 // Owned heap slice
                 // owned by `stored_name` (`Box<[u8]>`) and freed by `Bytes::Drop`.
@@ -4458,7 +4457,7 @@ fn write_file_with_empty_source_to_destination(
 
             struct Wrapper {
                 promise: jsc::JSPromiseStrong,
-                store: StoreRef,
+                store: RefPtr<Store>,
                 global: bun_ptr::BackRef<JSGlobalObject>,
             }
             impl Wrapper {
@@ -4710,7 +4709,7 @@ pub(crate) fn write_file_with_source_destination(
                     }
                 } else {
                     struct Wrapper {
-                        store: StoreRef,
+                        store: RefPtr<Store>,
                         promise: jsc::JSPromiseStrong,
                         global: bun_ptr::BackRef<JSGlobalObject>,
                     }
@@ -4844,17 +4843,17 @@ pub(crate) fn write_file_internal(
         debug_assert!(!matches!(blob_store.data, store::Data::Bytes(_)));
         // TODO only reset last_modified on success paths instead of resetting
         // last_modified at the beginning for better performance.
-        if let store::Data::File(ref mut file) = *blob_store.data_mut() {
+        if let store::Data::File(ref mut file) = *Store::data_mut(blob_store) {
             file.last_modified = jsc::INIT_TIMESTAMP;
         }
     }
 
-    let input_store: Option<StoreRef> = if let PathOrBlob::Blob(ref b) = *path_or_blob {
+    let input_store: Option<RefPtr<Store>> = if let PathOrBlob::Blob(ref b) = *path_or_blob {
         b.store.get().clone()
     } else {
         None
     };
-    // StoreRef clone+drop keeps the store alive for the duration of this call.
+    // RefPtr<Store> clone+drop keeps the store alive for the duration of this call.
     let _input_store_hold = input_store;
 
     if let Some(mkdir) = options.mkdirp_if_not_exists {
@@ -5219,7 +5218,7 @@ pub(crate) fn write_file_internal(
     let mut source_blob = scopeguard::guard(source_blob, |b| b.detach());
 
     let destination_store = destination_blob.store.get().clone();
-    // StoreRef clone+drop keeps the destination store alive across the call.
+    // RefPtr<Store> clone+drop keeps the destination store alive across the call.
     let _dest_hold = destination_store;
 
     write_file_with_source_destination(
@@ -5564,10 +5563,10 @@ pub(crate) fn jsdom_file_construct(
 
         blob = Blob::get::<false, true>(global_this, args[0])?;
         if let Some(store_) = blob.store.get() {
-            match store_.data_mut() {
+            match Store::data_mut(store_) {
                 store::Data::Bytes(bytes) => {
                     // `get::<_, true>` on a single-Blob sequence returns
-                    // `dupe()` (a shared StoreRef), so this `Bytes` may already
+                    // `dupe()` (a shared RefPtr<Store>), so this `Bytes` may already
                     // carry an owned `stored_name` from the source blob; the
                     // assignment drops (frees) the previous `Box<[u8]>`.
                     bytes.stored_name = name_value_str.to_owned_slice().into_boxed_slice();
@@ -5578,7 +5577,7 @@ pub(crate) fn jsdom_file_construct(
             }
         } else if !name_value_str.is_empty() {
             // not store but we have a name so we need a store
-            blob.store.set(Some(StoreRef::from(Store::new(Store {
+            blob.store.set(Some(RefPtr::from(Store::new(Store {
                 data: store::Data::Bytes(store::Bytes::init_empty_with_name(
                     name_value_str.to_owned_slice().into_boxed_slice(),
                 )),
@@ -5763,7 +5762,7 @@ impl S3BlobDownloadTask {
                 // Move the downloaded body into a Blob store so its lifetime is
                 // tied to the Blob/JS view and freed via the store's finalizer.
                 let store = Store::init(response.body.list);
-                let bytes: *mut [u8] = match store.data_mut() {
+                let bytes: *mut [u8] = match Store::data_mut(&store) {
                     store::Data::Bytes(b) => std::ptr::from_mut(b.as_array_list()),
                     _ => unreachable!(),
                 };
@@ -6139,11 +6138,11 @@ fn window_size(current: SizeType, available: SizeType) -> SizeType {
 }
 
 /// resolve file stat like size, last_modified
-fn resolve_file_stat(store: &StoreRef) {
-    // `StoreRef::data_mut` encapsulates the raw-pointer deref under the
-    // `StoreRef` liveness invariant; the caller holds the only ref across
+fn resolve_file_stat(store: &RefPtr<Store>) {
+    // `RefPtr<Store>::data_mut` encapsulates the raw-pointer deref under the
+    // `RefPtr<Store>` liveness invariant; the caller holds the only ref across
     // this call, so an exclusive borrow is sound.
-    let file = store.data_mut().as_file_mut();
+    let file = Store::data_mut(store).as_file_mut();
     match &file.pathlike {
         PathOrFileDescriptor::Path(path) => {
             let mut buffer = bun_paths::PathBuffer::uninit();
@@ -6384,9 +6383,7 @@ impl Any {
         if let Any::Blob(blob) = self {
             if let Some(s) = blob.store.get() {
                 if matches!(s.data, store::Data::Bytes(_)) && s.has_one_ref() {
-                    // `StoreRef` exposes interior-mutable `data_mut()` (no DerefMut).
-                    let internal = s.data_mut().as_bytes_mut().to_internal_blob();
-                    // StoreRef::drop on the replace below releases the store ref.
+                    let internal = Store::data_mut(s).as_bytes_mut().to_internal_blob();
                     *self = Any::InternalBlob(internal);
                     return;
                 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2122,7 +2122,7 @@ impl BlobExt for Blob {
                 // `resolve_file_stat` — it materializes `&mut File` on the same
                 // memory (Stacked Borrows UB; the optimizer may legally cache the
                 // pre-call `last_modified` and return the stale `INIT_TIMESTAMP`).
-                // Re-read via `RefPtr<Store>::data_mut` (raw-ptr-backed accessor) after
+                // Re-read via `Store::data_mut` (raw-ptr-backed accessor) after
                 // the mutating call.
                 let last_modified = Store::data_mut(store).as_file().last_modified;
                 // last_modified can be already set during read.
@@ -2253,7 +2253,7 @@ impl BlobExt for Blob {
         // materializes `&mut File` on the same memory via the raw
         // `heap::alloc` pointer — Stacked Borrows UB, and under noalias the
         // optimizer may legally cache the pre-call `seekable: None` and fall
-        // through to `self.size.get() = 0`. `RefPtr<Store>::data_mut` centralises
+        // through to `self.size.get() = 0`. `Store::data_mut` centralises
         // the raw-ptr deref so each read here is a fresh, safe borrow.
         match Store::data_mut(store).tag() {
             store::DataTag::Bytes => {
@@ -2302,7 +2302,7 @@ impl BlobExt for Blob {
             return (self.offset.get(), 0);
         };
         // see `resolve_size` — dispatch on the copied tag and re-read
-        // via `RefPtr<Store>::data_mut` after `resolve_file_stat` so no
+        // via `Store::data_mut` after `resolve_file_stat` so no
         // `Deref`-produced `&Data`/`&File` is live across the mutating call.
         match Store::data_mut(store).tag() {
             store::DataTag::Bytes => {
@@ -2507,7 +2507,7 @@ impl BlobExt for Blob {
         let Some(store_ref) = self.store() else {
             return empty();
         };
-        // `RefPtr<Store>::data_mut` derefs the original `heap::alloc` `*mut Store`
+        // `Store::data_mut` derefs the original `heap::alloc` `*mut Store`
         // (mutable provenance over the whole allocation) without materializing
         // a `Deref`-produced `&Store`, so the brief `&mut` to the payload does
         // not alias any outstanding borrow (other `RefPtr<Store>`s only hold raw
@@ -2524,7 +2524,7 @@ impl BlobExt for Blob {
                 let off = (self.offset.get() as usize).min(len);
                 let clamped = (len - off).min(self.size.get() as usize);
                 // `v` already carries mutable provenance (derived through
-                // `RefPtr<Store>::data_mut`); safe sub-slicing then raw-ptr coercion
+                // `Store::data_mut`); safe sub-slicing then raw-ptr coercion
                 // preserves it without `from_raw_parts_mut`/`ptr::add`.
                 core::ptr::from_mut::<[u8]>(&mut v[off..off + clamped])
             }
@@ -6137,7 +6137,7 @@ fn window_size(current: SizeType, available: SizeType) -> SizeType {
 
 /// resolve file stat like size, last_modified
 fn resolve_file_stat(store: &RefPtr<Store>) {
-    // `RefPtr<Store>::data_mut` encapsulates the raw-pointer deref under the
+    // `Store::data_mut` encapsulates the raw-pointer deref under the
     // `RefPtr<Store>` liveness invariant; the caller holds the only ref across
     // this call, so an exclusive borrow is sound.
     let file = Store::data_mut(store).as_file_mut();

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1406,7 +1406,7 @@ impl BlobExt for Blob {
             // When no JS overrides were supplied, hand the store's *base*
             // credentials to the upload (`upload_stream` consumes an
             // `RefPtr` by value, so the else-arm heap-dupes from the
-            // store's `Arc` instead of from the `aws_options` clone).
+            // store's `Rc` instead of from the `aws_options` clone).
             return crate::webcore::__s3_client::upload_stream(
                 if extra_options.is_some() {
                     aws_options.credentials.dupe()
@@ -2439,12 +2439,12 @@ impl BlobExt for Blob {
                 if let Ok(result) =
                     crate::allocators::linux_mem_fd_allocator::LinuxMemFdAllocator::create(bytes_)
                 {
-                    let store = RefPtr::from(Store::new(Store {
+                    let store = RefPtr::new(Store {
                         data: store::Data::Bytes(result),
                         mime_type: bun_http_types::MimeType::NONE,
                         ref_count: bun_ptr::ThreadSafeRefCount::init(),
                         is_all_ascii: None,
-                    }));
+                    });
                     let blob = Blob::init_with_store(store, global_this);
                     if was_string && blob.content_type_slice().is_empty() {
                         blob.content_type
@@ -2465,10 +2465,6 @@ impl BlobExt for Blob {
     fn create(bytes_: &[u8], global_this: &JSGlobalObject, was_string: bool) -> Blob {
         Self::try_create(bytes_, global_this, was_string).expect("oom")
     }
-
-    // non-generic `init_with_store(RefPtr<Store>, ...)` / `init_empty` removed —
-    // duplicates of the generic `init_with_store<S: Into<RefPtr<Store>>>` / `init_empty` below
-    // (E0592). All `RefPtr<Store>` callers resolve to the generic via the reflexive `Into` impl.
 
     // Transferring doesn't change the reference count
     // It is a move
@@ -5575,14 +5571,14 @@ pub(crate) fn jsdom_file_construct(
             }
         } else if !name_value_str.is_empty() {
             // not store but we have a name so we need a store
-            blob.store.set(Some(RefPtr::from(Store::new(Store {
+            blob.store.set(Some(RefPtr::new(Store {
                 data: store::Data::Bytes(store::Bytes::init_empty_with_name(
                     name_value_str.to_owned_slice().into_boxed_slice(),
                 )),
                 ref_count: bun_ptr::ThreadSafeRefCount::init(),
                 mime_type: bun_http_types::MimeType::NONE,
                 is_all_ascii: None,
-            }))));
+            })));
         }
     }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -43,7 +43,7 @@ pub(super) fn wtf_impl(s: &WTFStringImpl) -> &WTFStringImplStruct {
 /// Mutable view of a [`Blob`]'s backing `Store` through its
 /// `JsCell<Option<RefPtr<Store>>>` field. Centralises the per-site raw
 /// `(*blob.store.get()…as_ptr()).mime_type = …` deref under the same
-/// invariant `RefPtr<Store>::data_mut` already documents:
+/// invariant `Store::data_mut` already documents:
 /// shared-mutable interior, single-threaded JS event-loop, no concurrent
 /// `&Store` outstanding for the borrow's duration.
 #[inline]

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -41,9 +41,9 @@ pub(super) fn wtf_impl(s: &WTFStringImpl) -> &WTFStringImplStruct {
 }
 
 /// Mutable view of a [`Blob`]'s backing `Store` through its
-/// `JsCell<Option<StoreRef>>` field. Centralises the per-site raw
+/// `JsCell<Option<RefPtr<Store>>>` field. Centralises the per-site raw
 /// `(*blob.store.get()…as_ptr()).mime_type = …` deref under the same
-/// invariant `StoreRef::data_mut` already documents:
+/// invariant `RefPtr<Store>::data_mut` already documents:
 /// shared-mutable interior, single-threaded JS event-loop, no concurrent
 /// `&Store` outstanding for the borrow's duration.
 #[inline]
@@ -52,8 +52,8 @@ fn blob_store_mut(blob: &Blob) -> Option<&mut blob::Store> {
     blob.store
         .get()
         .as_ref()
-        // SAFETY: `StoreRef` invariant — pointee is a live heap `Store` while
-        // any `StoreRef` exists; single-threaded JS event-loop discipline
+        // SAFETY: `RefPtr<Store>` invariant — pointee is a live heap `Store` while
+        // any `RefPtr<Store>` exists; single-threaded JS event-loop discipline
         // guarantees no other `&`/`&mut Store` is live for this borrow.
         .map(|s| unsafe { &mut *s.as_ptr() })
 }

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -1,11 +1,11 @@
 use bun_collections::VecExt;
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
+use bun_ptr::RefPtr;
 
 use crate::webcore::blob::store::StoreExt as _;
 use crate::webcore::blob::{self, Blob, BlobExt as _, Store};
 use crate::webcore::readable_stream;
 use crate::webcore::streams;
-use bun_ptr::RefPtr;
 
 pub struct ByteBlobLoader {
     pub offset: blob::SizeType,

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -2,14 +2,15 @@ use bun_collections::VecExt;
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 
 use crate::webcore::blob::store::StoreExt as _;
-use crate::webcore::blob::{self, Blob, BlobExt as _, StoreRef};
+use crate::webcore::blob::{self, Blob, BlobExt as _, Store};
 use crate::webcore::readable_stream;
 use crate::webcore::streams;
+use bun_ptr::RefPtr;
 
 pub struct ByteBlobLoader {
     pub offset: blob::SizeType,
     // LIFETIMES.tsv: SHARED — ref() on setup, deref() in clearData
-    pub(crate) store: Option<StoreRef>,
+    pub(crate) store: Option<RefPtr<Store>>,
     pub(crate) chunk_size: blob::SizeType,
     pub(crate) remain: blob::SizeType,
     pub(crate) done: bool,
@@ -146,7 +147,7 @@ impl ByteBlobLoader {
         // Take ownership via detach_store() up front.
         let store = self.detach_store()?;
         if self.offset == 0 && self.remain == store.size() && self.content_type.is_empty() {
-            // SAFETY: `StoreRef` deref is `&Store`; `to_any_blob` needs `&mut` to move bytes out.
+            // SAFETY: `RefPtr<Store>` deref is `&Store`; `to_any_blob` needs `&mut` to move bytes out.
             // We hold the only outstanding ref (just detached) so exclusive access is sound.
             if let Some(blob) = unsafe { (*store.as_ptr()).to_any_blob() } {
                 drop(store);
@@ -170,7 +171,7 @@ impl ByteBlobLoader {
         Some(blob::Any::Blob(blob))
     }
 
-    pub(crate) fn detach_store(&mut self) -> Option<StoreRef> {
+    pub(crate) fn detach_store(&mut self) -> Option<RefPtr<Store>> {
         if let Some(store) = self.store.take() {
             self.done = true;
             return Some(store);

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -95,9 +95,6 @@ pub type IOReader = BufferedReader;
 
 pub enum Lazy {
     None,
-    /// Intrusively-refcounted `*Blob.Store`. Uses `RefPtr<Store>` (not `Arc`) so the
-    /// raw pointer carries mutable provenance from `heap::alloc` for the
-    /// direct field writes in `open_file_blob`.
     Blob(RefPtr<blob::Store>),
 }
 

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -8,7 +8,7 @@ use bun_io as aio;
 use bun_io::FileType;
 use bun_io::{BufferedReader, Chunk, ReadState};
 use bun_jsc::JsCell;
-use bun_ptr::AsCtxPtr;
+use bun_ptr::{AsCtxPtr, RefPtr};
 use bun_sys::{self as sys, Fd, FdExt};
 
 use crate::webcore::SinkHandle;
@@ -95,10 +95,10 @@ pub type IOReader = BufferedReader;
 
 pub enum Lazy {
     None,
-    /// Intrusively-refcounted `*Blob.Store`. Uses `StoreRef` (not `Arc`) so the
+    /// Intrusively-refcounted `*Blob.Store`. Uses `RefPtr<Store>` (not `Arc`) so the
     /// raw pointer carries mutable provenance from `heap::alloc` for the
     /// direct field writes in `open_file_blob`.
-    Blob(blob::StoreRef),
+    Blob(RefPtr<blob::Store>),
 }
 
 pub struct OpenedFileBlob {
@@ -312,19 +312,17 @@ impl FileReader {
         #[cfg(unix)]
         let mut file_type = FileType::File;
         // R-2: move the `Lazy` out of the cell up-front (it's reset to `None`
-        // on every path through the original `if let` body) so the `StoreRef`
+        // on every path through the original `if let` body) so the `RefPtr<Store>`
         // is owned locally and the cell borrow is released immediately.
         if let Lazy::Blob(store) = self.lazy.replace(Lazy::None) {
-            // `StoreRef::data_mut` encapsulates the raw-pointer deref under the
-            // `StoreRef` liveness invariant (single-threaded JS event loop; we
-            // hold the only mutating handle).
-            match store.data_mut() {
+            // Single-threaded JS event loop; we hold the only mutating handle.
+            match blob::Store::data_mut(&store) {
                 blob::store::Data::S3(_) | blob::store::Data::Bytes(_) => {
                     panic!("Invalid state in FileReader: expected file ")
                 }
                 blob::store::Data::File(file) => {
                     let open_result = Lazy::open_file_blob(file);
-                    // drop the StoreRef; `lazy` was already cleared above
+                    // drop the RefPtr<Store>; `lazy` was already cleared above
                     drop(store);
                     match open_result {
                         Err(err) => {

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -5,6 +5,7 @@ use core::sync::atomic::{AtomicI32, Ordering};
 use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
 use bun_io::{self, WriteResult, WriteStatus};
 use bun_jsc::JsCell;
+use bun_ptr::RefPtr;
 use bun_sys::{self as sys, Fd, FdExt as _};
 
 use crate::api::bun::process::Status as SpawnStatus;
@@ -74,46 +75,6 @@ pub struct FileSink {
 // refcount derived via #[derive(CellRefCounted)] above. `*FileSink` crosses FFI
 // (JSSink wrapper, `@fieldParentPtr`, `asPromisePtr`), so this stays intrusive
 // rather than `Rc<T>`.
-
-/// RAII owner of one intrusive ref on a `FileSink`. Drops the ref (and frees
-/// the allocation if it was the last) on scope exit, without borrowing `self`.
-struct FileSinkRef(*mut FileSink);
-
-impl FileSinkRef {
-    /// Take a fresh ref on `this` for the guard's lifetime.
-    ///
-    /// # Safety
-    /// `this` must point to a live `FileSink` with write+dealloc provenance
-    /// (see [`FileSink::deref`]).
-    #[inline]
-    unsafe fn new_ref(this: *mut FileSink) -> Self {
-        // SAFETY: caller contract — `this` is live; `ref_` only touches the
-        // `Cell<u32>` field via shared borrow.
-        unsafe { (*this).ref_() };
-        Self(this)
-    }
-
-    /// Adopt an existing ref previously taken elsewhere (e.g. balanced against
-    /// the `ref_()` in `run_pending_later`/`assign_to_stream`). Does not bump
-    /// the count.
-    ///
-    /// # Safety
-    /// `this` must point to a live `FileSink` and the caller must own one
-    /// outstanding ref that is being transferred to this guard.
-    #[inline]
-    unsafe fn adopt(this: *mut FileSink) -> Self {
-        Self(this)
-    }
-}
-
-impl Drop for FileSinkRef {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: constructor contract — `self.0` is live and carries
-        // write+dealloc provenance for `deref`'s potential `deinit`.
-        unsafe { FileSink::deref(self.0) };
-    }
-}
 
 /// Count of live native FileSink instances. Incremented at allocation,
 /// decremented in `deinit`. Exposed to tests via `bun:internal-for-testing`
@@ -327,7 +288,7 @@ impl FileSink {
             // keep-alive ref, and `stream.cancel`/`runPending` drain microtasks
             // which may drop the JS wrapper's ref. Hold a local ref so `this`
             // stays valid for the rest of this function (same pattern as `onWrite`).
-            let _guard = FileSinkRef::new_ref(this);
+            let _guard = RefPtr::init_ref(this);
 
             (*this).done.set(true);
             let mut readable_stream = (*this)
@@ -379,7 +340,7 @@ impl FileSink {
     unsafe fn run_pending(this: *mut FileSink) {
         // SAFETY: caller contract — `this` is live with write+dealloc provenance.
         unsafe {
-            let _guard = FileSinkRef::new_ref(this);
+            let _guard = RefPtr::init_ref(this);
 
             (*this).run_pending_later.has.set(false);
 
@@ -407,7 +368,7 @@ impl FileSink {
             // ref, and `writer.end()`/`writer.close()` re-enter `onClose` which
             // releases the keep-alive ref. Hold a local ref so `this` stays valid
             // for the rest of this function (same pattern as `runPending`/`onAutoFlush`).
-            let _guard = FileSinkRef::new_ref(this);
+            let _guard = RefPtr::init_ref(this);
 
             (*this).written.set((*this).written.get() + amount);
 
@@ -902,7 +863,7 @@ impl FileSink {
                 return false;
             }
 
-            let _guard = FileSinkRef::new_ref(this);
+            let _guard = RefPtr::init_ref(this);
 
             let amount_buffered = (*this).writer.get().outgoing.size();
 
@@ -1588,7 +1549,7 @@ impl bun_event_loop::Taskable for FlushPendingTask {
         unsafe {
             (*this).has.set(false);
             let sink: *mut FileSink = bun_core::from_field_ptr!(FileSink, run_pending_later, this);
-            drop(FileSinkRef::adopt(sink));
+            drop(RefPtr::from_raw(sink));
         }
     }
 }
@@ -1609,7 +1570,7 @@ impl FlushPendingTask {
             unsafe { bun_core::from_field_ptr!(FileSink, run_pending_later, flush_pending) };
         // SAFETY: balances the `ref_()` taken in `run_pending_later()` when
         // this task was enqueued; `this` is live for at least that ref.
-        let _guard = unsafe { FileSinkRef::adopt(this) };
+        let _guard = unsafe { RefPtr::from_raw(this) };
         if had {
             // SAFETY: `this` is the canonical `*mut FileSink` recovered via
             // `from_field_ptr!` from the embedded `run_pending_later` task;
@@ -1651,7 +1612,7 @@ fn on_resolve_stream(_global_this: &JSGlobalObject, callframe: &CallFrame) -> Js
     let args = callframe.arguments();
     let this: *mut FileSink = args[args.len() - 1].as_promise_ptr::<FileSink>();
     // SAFETY: `this` is kept alive by the ref taken in `assign_to_stream`; this guard balances it.
-    let _guard = unsafe { FileSinkRef::adopt(this) };
+    let _guard = unsafe { RefPtr::from_raw(this) };
     // SAFETY: `as_promise_ptr` recovers the `*mut FileSink` stashed by `assign_to_stream`.
     unsafe { (*this).handle_resolve_stream() };
     Ok(JSValue::UNDEFINED)
@@ -1663,7 +1624,7 @@ fn on_reject_stream(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsRe
     let this: *mut FileSink = args[args.len() - 1].as_promise_ptr::<FileSink>();
     let err = args[0];
     // SAFETY: `this` is kept alive by the ref taken in `assign_to_stream`; this guard balances it.
-    let _guard = unsafe { FileSinkRef::adopt(this) };
+    let _guard = unsafe { RefPtr::from_raw(this) };
     // SAFETY: `as_promise_ptr` recovers the `*mut FileSink` stashed by `assign_to_stream`.
     unsafe { (*this).handle_reject_stream(global_this, err)? };
     Ok(JSValue::UNDEFINED)
@@ -1679,7 +1640,7 @@ impl FileSink {
         global_this: &JSGlobalObject,
     ) -> Option<JSValue> {
         // SAFETY: `&mut self` carries write+dealloc provenance over the allocation.
-        let _guard = unsafe { FileSinkRef::new_ref(std::ptr::from_mut::<FileSink>(self)) };
+        let _guard = unsafe { RefPtr::init_ref(std::ptr::from_mut::<FileSink>(self)) };
 
         self.stream_bytes.set(Some(0));
         self.stream_done
@@ -1726,7 +1687,7 @@ impl FileSink {
         global_this: &JSGlobalObject,
     ) -> JSValue {
         // SAFETY: `&mut self` carries write+dealloc provenance over the allocation.
-        let _guard = unsafe { FileSinkRef::new_ref(std::ptr::from_mut::<FileSink>(self)) };
+        let _guard = unsafe { RefPtr::init_ref(std::ptr::from_mut::<FileSink>(self)) };
 
         self.readable_stream
             .set(readable_stream::Strong::init(*stream, global_this));

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -539,7 +539,6 @@ impl S3Client {
         let object_keys = args[0];
         let options = opt_js(args[1]);
 
-        // `defer blob.detach()` — handled by Drop of `Option<RefPtr<Store>>` field.
         let blob = S3File::construct_s3_file_with_s3_credentials_and_options(
             global,
             PathLike::default(),
@@ -647,7 +646,6 @@ impl S3Client {
                 .get_s3_credentials(),
         );
 
-        // `defer blob.detach()` — handled by Drop of `Option<RefPtr<Store>>` field.
         let blob = S3File::construct_s3_file_with_s3_credentials(
             global,
             PathLike::default(),

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -539,7 +539,7 @@ impl S3Client {
         let object_keys = args[0];
         let options = opt_js(args[1]);
 
-        // `defer blob.detach()` — handled by Drop of `Option<StoreRef>` field.
+        // `defer blob.detach()` — handled by Drop of `Option<RefPtr<Store>>` field.
         let blob = S3File::construct_s3_file_with_s3_credentials_and_options(
             global,
             PathLike::default(),
@@ -647,7 +647,7 @@ impl S3Client {
                 .get_s3_credentials(),
         );
 
-        // `defer blob.detach()` — handled by Drop of `Option<StoreRef>` field.
+        // `defer blob.detach()` — handled by Drop of `Option<RefPtr<Store>>` field.
         let blob = S3File::construct_s3_file_with_s3_credentials(
             global,
             PathLike::default(),

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -39,7 +39,7 @@ pub(crate) trait S3CredentialsExt {
     fn get_credentials_with_options(
         // Takes `&S3Credentials` (not by-value) — `bun_s3_signing::S3Credentials`
         // has a private `ref_count` field and no `Clone`, so callers holding a borrow
-        // (e.g. `&IntrusiveRc<S3Credentials>` deref) cannot produce an owned copy. The
+        // (e.g. `&RefPtr<S3Credentials>` deref) cannot produce an owned copy. The
         // real impl in `s3/credentials_jsc.rs` deep-copies internally.
         this: &S3Credentials,
         default_options: MultiPartUploadOptions,
@@ -248,21 +248,11 @@ where
 
 #[bun_jsc::JsClass]
 pub struct S3Client {
-    pub(crate) credentials: bun_ptr::IntrusiveRc<S3Credentials>,
+    pub(crate) credentials: bun_ptr::RefPtr<S3Credentials>,
     pub(crate) options: MultiPartUploadOptions,
     pub(crate) acl: Option<ACL>,
     pub(crate) storage_class: Option<StorageClass>,
     pub(crate) request_payer: bool,
-}
-
-impl Drop for S3Client {
-    fn drop(&mut self) {
-        // `IntrusiveRc<T>` is `bun_ptr::RefPtr<T>`, which has no `Drop` impl
-        // of its own (only `ScopedRef<T>` does), so the +1 taken by
-        // `aws_options.credentials.dupe()` in `constructor` must be released
-        // explicitly.
-        self.credentials.deref();
-    }
 }
 
 impl S3Client {

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -278,11 +278,8 @@ pub(crate) fn construct_s3_file_with_s3_credentials_and_options(
     let credentials = if aws_options.changed_credentials {
         std::mem::take(&mut aws_options.credentials)
     } else {
-        // The `Store::S3` field is `Rc<S3Credentials>` (separate rc
-        // layer), so we can't share the existing intrusive allocation —
-        // deep-clone the value instead and let `init_s3` `Rc::new` it.
-        // PERF: profile if hot once Store.rs migrates
-        // `Rc<S3Credentials>` → `RefPtr`.
+        // `Store::S3` holds an `Rc<S3Credentials>`, so the intrusive
+        // allocation can't be shared — deep-clone the value.
         default_credentials.clone()
     };
     let store = blob::Store::init_s3(path, None, credentials).expect("oom");
@@ -314,15 +311,15 @@ pub(crate) fn construct_s3_file_with_s3_credentials(
 /// Unlike the write path, a non-string or invalid `type` is ignored here.
 fn finish_s3_blob(
     global: &JSGlobalObject,
-    mut store: Box<blob::Store>,
+    store: RefPtr<Store>,
     aws_options: &s3::S3CredentialsWithOptions,
     options: Option<JSValue>,
 ) -> JsResult<Blob> {
-    // store cleanup on early return is handled by Drop
-    store.data.as_s3_mut().options = aws_options.options;
-    store.data.as_s3_mut().acl = aws_options.acl;
-    store.data.as_s3_mut().storage_class = aws_options.storage_class;
-    store.data.as_s3_mut().request_payer = aws_options.request_payer;
+    let s3 = Store::data_mut(&store).as_s3_mut();
+    s3.options = aws_options.options;
+    s3.acl = aws_options.acl;
+    s3.storage_class = aws_options.storage_class;
+    s3.request_payer = aws_options.request_payer;
 
     let blob = Blob::init_with_store(store, global);
     if let Some(opts) = options {

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -1,5 +1,5 @@
 use crate::node::{PathLike, PathOrBlob};
-use crate::webcore::blob::store::{S3Ext as _, StoreExt as _, StoreRef};
+use crate::webcore::blob::store::{S3Ext as _, Store, StoreExt as _};
 use crate::webcore::blob::{self, Blob, BlobExt};
 use crate::webcore::s3::client as s3;
 use crate::webcore::s3::client::error_jsc::s3_error_to_js_with_async_stack;
@@ -8,6 +8,7 @@ use bun_core::strings;
 use bun_http::Method;
 use bun_jsc::bun_string_jsc;
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass as _, JsError, JsResult};
+use bun_ptr::RefPtr;
 
 // Local front for `bun_core::pretty_fmt!` that accepts a runtime / const-
 // generic bool. The proc-macro only matches `true`/`false` literals, so
@@ -360,7 +361,7 @@ pub(crate) struct S3BlobStatTask {
     // LIFETIMES.tsv: JSC_BORROW (&JSGlobalObject). `BackRef` so the heap task
     // can outlive the constructing frame while reads stay safe.
     global: bun_ptr::BackRef<JSGlobalObject>,
-    store: StoreRef,
+    store: RefPtr<Store>,
 }
 
 impl S3BlobStatTask {

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -281,7 +281,7 @@ pub(crate) fn construct_s3_file_with_s3_credentials_and_options(
         // layer), so we can't share the existing intrusive allocation —
         // deep-clone the value instead and let `init_s3` `Rc::new` it.
         // PERF: profile if hot once Store.rs migrates
-        // `Rc<S3Credentials>` → `IntrusiveRc`.
+        // `Rc<S3Credentials>` → `RefPtr`.
         default_credentials.clone()
     };
     let store = blob::Store::init_s3(path, None, credentials).expect("oom");

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -44,13 +44,13 @@ pub trait StoreExt {
         pathlike: PathLike<'static>,
         mime_type: Option<MimeType>,
         credentials: S3Credentials,
-    ) -> Result<Box<Store>, crate::Error>
+    ) -> Result<RefPtr<Store>, crate::Error>
     where
         Self: Sized;
     fn init_file(
         pathlike: PathOrFileDescriptor<'static>,
         mime_type: Option<MimeType>,
-    ) -> Result<Box<Store>, crate::Error>
+    ) -> Result<RefPtr<Store>, crate::Error>
     where
         Self: Sized;
     #[cfg(unix)]
@@ -67,18 +67,16 @@ pub trait S3Ext {
         global_object: &JSGlobalObject,
     ) -> JsResult<S3CredentialsWithOptions>;
     /// `store` is the heap `Store` that owns `self` (`self == &store.data.S3`).
-    /// Neither impl mutates `self`, so a shared receiver lets callers hold the
-    /// natural `&Store` alongside `&S3` without Stacked-Borrows gymnastics.
     fn unlink(
         &self,
-        store: &Store,
+        store: &RefPtr<Store>,
         global_this: &JSGlobalObject,
         extra_options: Option<JSValue>,
     ) -> JsResult<JSValue>;
-    /// See `unlink` — `self` is read-only; `store` is the owning `Store`.
+    /// See `unlink`.
     fn list_objects(
         &self,
-        store: &Store,
+        store: &RefPtr<Store>,
         global_this: &JSGlobalObject,
         list_options: JSValue,
         extra_options: Option<JSValue>,
@@ -125,7 +123,7 @@ impl StoreExt for Store {
         pathlike: PathLike<'static>,
         mime_type: Option<MimeType>,
         credentials: S3Credentials,
-    ) -> Result<Box<Store>, crate::Error> {
+    ) -> Result<RefPtr<Store>, crate::Error> {
         let mut path = pathlike;
         // this actually protects/refs the pathlike
         path.to_thread_safe();
@@ -134,7 +132,7 @@ impl StoreExt for Store {
         // Store so we don't need to clone the owned PathLike.
         let mime_type = mime_type.or_else(|| mime_from_path_ext(path.slice()));
 
-        Ok(Store::new(Store {
+        Ok(RefPtr::new(Store {
             data: Data::S3(S3::init(path, mime_type, credentials)),
             mime_type: bun_http_types::MimeType::NONE,
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
@@ -145,7 +143,7 @@ impl StoreExt for Store {
     fn init_file(
         pathlike: PathOrFileDescriptor<'static>,
         mime_type: Option<MimeType>,
-    ) -> Result<Box<Store>, crate::Error> {
+    ) -> Result<RefPtr<Store>, crate::Error> {
         // Compute the extension-derived fallback before moving `pathlike` into
         // the Store so we don't need to clone the owned PathOrFileDescriptor.
         let mime_type = mime_type.or_else(|| match &pathlike {
@@ -153,7 +151,7 @@ impl StoreExt for Store {
             PathOrFileDescriptor::Fd(_) => None,
         });
 
-        Ok(Store::new(Store {
+        Ok(RefPtr::new(Store {
             data: Data::File(File::init(pathlike, mime_type)),
             mime_type: bun_http_types::MimeType::NONE,
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
@@ -165,12 +163,12 @@ impl StoreExt for Store {
     /// mapping; when the refcount drops to zero, `Bytes::drop` calls `munmap`.
     #[cfg(unix)]
     fn init_mmap(slice: &'static mut [u8]) -> RefPtr<Store> {
-        RefPtr::from(Store::new(Store {
+        RefPtr::new(Store {
             data: Data::Bytes(Bytes::init_mmap(slice)),
             mime_type: bun_http_types::MimeType::NONE,
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
             is_all_ascii: None,
-        }))
+        })
     }
 
     fn serialize(&self, writer: &mut impl bun_io::Write) -> Result<(), crate::Error> {
@@ -274,7 +272,7 @@ impl S3Ext for S3 {
 
     fn unlink(
         &self,
-        store: &Store,
+        store: &RefPtr<Store>,
         global_this: &JSGlobalObject,
         extra_options: Option<JSValue>,
     ) -> JsResult<JSValue> {
@@ -316,10 +314,6 @@ impl S3Ext for S3 {
             }
         }
 
-        // Wrapper.deinit body deleted — store.deref() handled by RefPtr<Store>::drop,
-        // promise.deinit() handled by JSPromiseStrong::drop, bun.destroy(wrap) handled by
-        // heap::take + drop in resolve().
-
         let promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
@@ -340,8 +334,7 @@ impl S3Ext for S3 {
             Wrapper::resolve,
             bun_core::heap::into_raw(Wrapper::new(Wrapper {
                 promise,
-                // SAFETY: `store` is a live heap `Store`.
-                store: unsafe { RefPtr::init_ref(core::ptr::from_ref(store).cast_mut()) },
+                store: store.clone(),
                 global: bun_ptr::BackRef::new(global_this),
             }))
             .cast::<c_void>(),
@@ -354,7 +347,7 @@ impl S3Ext for S3 {
 
     fn list_objects(
         &self,
-        store: &Store,
+        store: &RefPtr<Store>,
         global_this: &JSGlobalObject,
         list_options: JSValue,
         extra_options: Option<JSValue>,
@@ -407,10 +400,6 @@ impl S3Ext for S3 {
             }
         }
 
-        // Wrapper.deinit/destroy bodies deleted — store.deref() via RefPtr<Store>::drop,
-        // promise.deinit() via JSPromiseStrong::drop, resolvedlistOptions.deinit() via
-        // S3ListObjectsOptions::drop, bun.destroy(self) via heap::take + drop.
-
         let promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
@@ -433,8 +422,7 @@ impl S3Ext for S3 {
         // `Drop` after the async callback.
         let wrapper = bun_core::heap::into_raw(Box::new(Wrapper {
             promise,
-            // SAFETY: `store` is a live heap `Store`.
-            store: unsafe { RefPtr::init_ref(core::ptr::from_ref(store).cast_mut()) },
+            store: store.clone(),
             resolved_list_options: options,
             global: bun_ptr::BackRef::new(global_this),
         }));

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -1,6 +1,6 @@
 //! `Blob.Store` — backing storage variants for `webcore::Blob`.
 //!
-//! LAYERING: the data types (`Store`/`StoreRef`/`Data`/`Bytes`/`File`/`S3`)
+//! LAYERING: the data types (`Store`/`RefPtr<Store>`/`Data`/`Bytes`/`File`/`S3`)
 //! are the **single nominal definitions** in `bun_jsc::webcore_types::store`;
 //! this module re-exports them and layers the `bun_runtime`-tier behaviour
 //! (S3 I/O, async file ops, structured-clone serialize) via extension traits.
@@ -20,6 +20,7 @@ use crate::webcore::s3::client::{
 };
 use bun_core::strings;
 use bun_http_types::MimeType::MimeType;
+use bun_ptr::RefPtr;
 use bun_url::URL;
 
 #[cfg(unix)]
@@ -29,9 +30,7 @@ use super::SizeType;
 // Re-export the canonical data types from `bun_jsc`.
 // ──────────────────────────────────────────────────────────────────────────
 
-pub use bun_jsc::webcore_types::store::{
-    Bytes, Data, DataTag, File, S3, SerializeTag, Store, StoreRef,
-};
+pub use bun_jsc::webcore_types::store::{Bytes, Data, DataTag, File, S3, SerializeTag, Store};
 
 // ──────────────────────────────────────────────────────────────────────────
 // Extension traits — `bun_runtime`-tier behaviour layered on the `bun_jsc`
@@ -55,7 +54,7 @@ pub trait StoreExt {
     where
         Self: Sized;
     #[cfg(unix)]
-    fn init_mmap(slice: &'static mut [u8]) -> StoreRef
+    fn init_mmap(slice: &'static mut [u8]) -> RefPtr<Store>
     where
         Self: Sized;
     fn serialize(&self, writer: &mut impl bun_io::Write) -> Result<(), crate::Error>;
@@ -165,8 +164,8 @@ impl StoreExt for Store {
     /// Adopt an mmap'd region — no copy. The store's `Bytes` payload owns the
     /// mapping; when the refcount drops to zero, `Bytes::drop` calls `munmap`.
     #[cfg(unix)]
-    fn init_mmap(slice: &'static mut [u8]) -> StoreRef {
-        StoreRef::from(Store::new(Store {
+    fn init_mmap(slice: &'static mut [u8]) -> RefPtr<Store> {
+        RefPtr::from(Store::new(Store {
             data: Data::Bytes(Bytes::init_mmap(slice)),
             mime_type: bun_http_types::MimeType::NONE,
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
@@ -281,7 +280,7 @@ impl S3Ext for S3 {
     ) -> JsResult<JSValue> {
         struct Wrapper {
             promise: bun_jsc::JSPromiseStrong,
-            store: StoreRef,
+            store: RefPtr<Store>,
             // LIFETIMES.tsv: JSC_BORROW → &JSGlobalObject. `BackRef` so the heap
             // wrapper can outlive the constructing frame while reads stay safe.
             global: bun_ptr::BackRef<JSGlobalObject>,
@@ -317,7 +316,7 @@ impl S3Ext for S3 {
             }
         }
 
-        // Wrapper.deinit body deleted — store.deref() handled by StoreRef::drop,
+        // Wrapper.deinit body deleted — store.deref() handled by RefPtr<Store>::drop,
         // promise.deinit() handled by JSPromiseStrong::drop, bun.destroy(wrap) handled by
         // heap::take + drop in resolve().
 
@@ -343,7 +342,7 @@ impl S3Ext for S3 {
                 promise,
                 // SAFETY: `store` is a live heap `Store`; `retained` bumps the
                 // intrusive refcount.
-                store: unsafe { StoreRef::retained(NonNull::from(store)) },
+                store: unsafe { RefPtr::init_ref(core::ptr::from_ref(store).cast_mut()) },
                 global: bun_ptr::BackRef::new(global_this),
             }))
             .cast::<c_void>(),
@@ -369,7 +368,7 @@ impl S3Ext for S3 {
 
         struct Wrapper {
             promise: bun_jsc::JSPromiseStrong,
-            store: StoreRef,
+            store: RefPtr<Store>,
             resolved_list_options: S3ListObjectsOptions,
             // LIFETIMES.tsv: JSC_BORROW. `BackRef` for safe deref across the async callback.
             global: bun_ptr::BackRef<JSGlobalObject>,
@@ -409,7 +408,7 @@ impl S3Ext for S3 {
             }
         }
 
-        // Wrapper.deinit/destroy bodies deleted — store.deref() via StoreRef::drop,
+        // Wrapper.deinit/destroy bodies deleted — store.deref() via RefPtr<Store>::drop,
         // promise.deinit() via JSPromiseStrong::drop, resolvedlistOptions.deinit() via
         // S3ListObjectsOptions::drop, bun.destroy(self) via heap::take + drop.
 
@@ -437,7 +436,7 @@ impl S3Ext for S3 {
             promise,
             // SAFETY: `store` is a live heap `Store`; `retained` bumps the
             // intrusive refcount.
-            store: unsafe { StoreRef::retained(NonNull::from(store)) },
+            store: unsafe { RefPtr::init_ref(core::ptr::from_ref(store).cast_mut()) },
             resolved_list_options: options,
             global: bun_ptr::BackRef::new(global_this),
         }));
@@ -532,7 +531,7 @@ pub(crate) extern "C" fn BlobArrayBuffer_deallocator(
     blob: *mut core::ffi::c_void,
 ) {
     // SAFETY: `blob` is the non-null `*mut Store` C++ stashed as deallocator
-    // context (originating from `heap::alloc` / `StoreRef::into_raw`); it
+    // context (originating from `heap::alloc` / `RefPtr<Store>::into_raw`); it
     // owns one outstanding reference being released here.
     unsafe { Store::deref(NonNull::new_unchecked(blob.cast::<Store>())) };
 }

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -340,8 +340,7 @@ impl S3Ext for S3 {
             Wrapper::resolve,
             bun_core::heap::into_raw(Wrapper::new(Wrapper {
                 promise,
-                // SAFETY: `store` is a live heap `Store`; `retained` bumps the
-                // intrusive refcount.
+                // SAFETY: `store` is a live heap `Store`.
                 store: unsafe { RefPtr::init_ref(core::ptr::from_ref(store).cast_mut()) },
                 global: bun_ptr::BackRef::new(global_this),
             }))
@@ -434,8 +433,7 @@ impl S3Ext for S3 {
         // `Drop` after the async callback.
         let wrapper = bun_core::heap::into_raw(Box::new(Wrapper {
             promise,
-            // SAFETY: `store` is a live heap `Store`; `retained` bumps the
-            // intrusive refcount.
+            // SAFETY: `store` is a live heap `Store`.
             store: unsafe { RefPtr::init_ref(core::ptr::from_ref(store).cast_mut()) },
             resolved_list_options: options,
             global: bun_ptr::BackRef::new(global_this),

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -4,12 +4,13 @@ use crate::node::fs as node_fs;
 use crate::node::types::PathLikeExt as _;
 #[cfg(not(windows))]
 use crate::webcore::blob::{self, Retry};
-use crate::webcore::blob::{MAX_SIZE, MkdirpTarget, SizeType, StoreRef, store};
+use crate::webcore::blob::{MAX_SIZE, MkdirpTarget, SizeType, Store, store};
 use crate::webcore::node_types::PathOrFileDescriptor;
 #[cfg(windows)]
 use bun_io as aio;
 use bun_jsc::{self as jsc, JSGlobalObject, JSPromise, JSValue};
 use bun_paths::PathBuffer;
+use bun_ptr::RefPtr;
 #[cfg(windows)]
 use bun_sys::ReturnCodeExt as _;
 #[cfg(not(windows))]
@@ -33,11 +34,11 @@ pub struct CopyFile {
     #[cfg(not(windows))]
     pub(crate) destination_file_store: store::File,
     pub(crate) source_file_store: store::File,
-    // `StoreRef` is the thread-safe refcounted handle;
+    // `RefPtr<Store>` is the thread-safe refcounted handle;
     // it keeps the stores — and the path slices the `File` clones borrow — alive
     // while this task is on the work pool.
-    pub(crate) store: Option<StoreRef>,
-    pub(crate) source_store: Option<StoreRef>,
+    pub(crate) store: Option<RefPtr<Store>>,
+    pub(crate) source_store: Option<RefPtr<Store>>,
     pub offset: SizeType,
     #[cfg(not(windows))]
     pub(crate) max_length: SizeType,
@@ -92,8 +93,8 @@ impl CopyFile {
     /// Schedule the copy on the work pool; returns its promise.
     #[cfg(not(windows))]
     pub(crate) fn create(
-        store: StoreRef,
-        source_store: StoreRef,
+        store: RefPtr<Store>,
+        source_store: RefPtr<Store>,
         off: SizeType,
         max_len: SizeType,
         global_this: &JSGlobalObject,
@@ -1015,8 +1016,8 @@ fn read_write_loop_capped(
 // droppable — `PathLike::clone` dupes owned string buffers (freed by the
 // clone's own `CowSlice` drop), bumps refs for WTF-backed slices, and only
 // shares the backing for borrowed-string/Buffer variants (whose owner is kept
-// alive by the `source_store` `StoreRef`). Each clone's field `Drop` frees
-// exactly what it owns; the `StoreRef`s release just their Store refcounts on
+// alive by the `source_store` `RefPtr<Store>`). Each clone's field `Drop` frees
+// exactly what it owns; the `RefPtr<Store>`s release just their Store refcounts on
 // drop. No explicit `Drop` impl is needed.
 
 // Kept local until bun_sys exports these; values match crate::node::fs.
@@ -1055,8 +1056,8 @@ impl TryWith {
 
 #[cfg(windows)]
 pub struct CopyFileWindows<'a> {
-    pub(crate) destination_file_store: StoreRef,
-    pub(crate) source_file_store: StoreRef,
+    pub(crate) destination_file_store: RefPtr<Store>,
+    pub(crate) source_file_store: RefPtr<Store>,
 
     pub(crate) io_request: libuv::fs_t,
     pub(crate) promise: jsc::JSPromiseStrong,
@@ -1356,8 +1357,8 @@ impl<'a> CopyFileWindows<'a> {
     }
 
     pub(crate) fn init(
-        destination_file_store: StoreRef,
-        source_file_store: StoreRef,
+        destination_file_store: RefPtr<Store>,
+        source_file_store: RefPtr<Store>,
         event_loop: &'a jsc::event_loop::EventLoop,
         mkdirp_if_not_exists: bool,
         size_: SizeType,
@@ -1435,9 +1436,7 @@ impl<'a> CopyFileWindows<'a> {
         // mkdirp(), we don't spend extra time opening the file handle for
         // the source.
         self.read_write_loop.destination_fd = match Self::prepare_pathlike(
-            &mut self
-                .destination_file_store
-                .data_mut()
+            &mut Store::data_mut(&self.destination_file_store)
                 .as_file_mut()
                 .pathlike,
             &mut self.read_write_loop.must_close_destination_fd,
@@ -1456,7 +1455,9 @@ impl<'a> CopyFileWindows<'a> {
         };
 
         self.read_write_loop.source_fd = match Self::prepare_pathlike(
-            &mut self.source_file_store.data_mut().as_file_mut().pathlike,
+            &mut Store::data_mut(&self.source_file_store)
+                .as_file_mut()
+                .pathlike,
             &mut self.read_write_loop.must_close_source_fd,
             true,
         ) {

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -11,7 +11,7 @@ use crate::webcore::Lifetime;
 #[cfg(not(windows))]
 use crate::webcore::blob::ClosingState;
 use crate::webcore::blob::store::{Bytes as ByteStore, Data, File as FileStore};
-use crate::webcore::blob::{Blob, FileCloser, FileOpener, MAX_SIZE, SizeType, StoreRef};
+use crate::webcore::blob::{Blob, FileCloser, FileOpener, MAX_SIZE, SizeType, Store};
 use crate::webcore::node_types::PathOrFileDescriptor;
 #[cfg(windows)]
 use bun_collections::ByteVecExt as _;
@@ -26,6 +26,7 @@ use bun_jsc::event_loop::EventLoop;
 use bun_jsc::{
     self as jsc, AnyPromise, JSGlobalObject, JSPromiseStrong, JSValue, JsResult, SystemError,
 };
+use bun_ptr::RefPtr;
 #[cfg(windows)]
 use bun_sys::ReturnCodeExt as _;
 #[cfg(not(windows))]
@@ -269,7 +270,7 @@ pub struct ReadFile {
     pub(crate) file_store: FileStore,
     #[cfg(not(windows))]
     pub(crate) byte_store: ByteStore,
-    pub(crate) store: Option<StoreRef>,
+    pub(crate) store: Option<RefPtr<Store>>,
     pub offset: SizeType,
     #[cfg(not(windows))]
     pub(crate) max_length: SizeType,
@@ -357,11 +358,11 @@ impl ReadFile {
     // Not for Windows; Windows callers use ReadFileUV.
     #[cfg(not(windows))]
     pub(crate) fn create(
-        store: StoreRef,
+        store: RefPtr<Store>,
         off: SizeType,
         max_len: SizeType,
     ) -> Result<ReadFile, Error> {
-        // store.ref() — `StoreRef` carries the +1; held in `self.store`.
+        // store.ref() — `RefPtr<Store>` carries the +1; held in `self.store`.
         let file_store = store.data.as_file().clone();
         let read_file = ReadFile {
             file_store,
@@ -691,7 +692,7 @@ impl ReadFile {
         };
 
         if let Some(store) = &self.store {
-            if let Data::File(file) = store.data_mut() {
+            if let Data::File(file) = Store::data_mut(store) {
                 let mtime = bun_sys::PosixStat::init(&stat).mtime();
                 file.last_modified = jsc::to_js_time(mtime.sec as isize, mtime.nsec as isize);
             }
@@ -934,7 +935,7 @@ pub struct ReadFileUV<'a> {
     pub(crate) event_loop: &'a EventLoop,
     pub(crate) file_store: FileStore,
     pub(crate) byte_store: ByteStore,
-    pub(crate) store: StoreRef,
+    pub(crate) store: RefPtr<Store>,
     pub offset: SizeType,
     pub(crate) max_length: SizeType,
     pub(crate) total_size: SizeType,
@@ -1031,7 +1032,7 @@ impl<'a> ReadFileUV<'a> {
     /// Typed entry: `C` supplies run/cancel for the erased completion.
     pub(crate) fn start<C: ReadFileCompletion>(
         event_loop: *mut EventLoop,
-        store: StoreRef,
+        store: RefPtr<Store>,
         off: SizeType,
         max_len: SizeType,
         handler: *mut C,
@@ -1049,7 +1050,7 @@ impl<'a> ReadFileUV<'a> {
     /// Shares the body with `start`.
     pub(crate) fn start_with_ctx(
         event_loop: *mut EventLoop,
-        store: StoreRef,
+        store: RefPtr<Store>,
         off: SizeType,
         max_len: SizeType,
         completion: ReadFileCompletionFns,
@@ -1123,7 +1124,7 @@ impl<'a> ReadFileUV<'a> {
         // exception the JS side left pending is reported here (a termination just stands down).
         crate::dispatch::fold(completion.complete(result));
 
-        // store.deref runs via StoreRef's Drop when the Box drops.
+        // store.deref runs via RefPtr<Store>'s Drop when the Box drops.
         this_box.req.deinit();
         drop(this_box);
         // Release the event loop reference now that we're done
@@ -1210,7 +1211,7 @@ impl<'a> ReadFileUV<'a> {
         let stat = this.req.statbuf;
 
         // keep in sync with resolveSizeAndLastModified
-        if let Data::File(file) = this.store.data_mut() {
+        if let Data::File(file) = Store::data_mut(&this.store) {
             // `uv_timespec_t` fields are `c_long` (i32 on Windows); widen to the
             // platform-width `isize` `to_js_time` expects.
             file.last_modified =

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -362,7 +362,6 @@ impl ReadFile {
         off: SizeType,
         max_len: SizeType,
     ) -> Result<ReadFile, Error> {
-        // store.ref() — `RefPtr<Store>` carries the +1; held in `self.store`.
         let file_store = store.data.as_file().clone();
         let read_file = ReadFile {
             file_store,
@@ -1124,7 +1123,6 @@ impl<'a> ReadFileUV<'a> {
         // exception the JS side left pending is reported here (a termination just stands down).
         crate::dispatch::fold(completion.complete(result));
 
-        // store.deref runs via RefPtr<Store>'s Drop when the Box drops.
         this_box.req.deinit();
         drop(this_box);
         // Release the event loop reference now that we're done

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -307,8 +307,8 @@ impl WriteFile {
             mkdirp_if_not_exists,
         };
         // No explicit store ref bump: the caller passes a `+1` Blob (via
-        // `borrowed_view()`'s `StoreRef::clone`) and dropping the `WriteFile`
-        // in `then` runs `StoreRef::drop`, so the ref/deref pair is RAII.
+        // `borrowed_view()`'s `RefPtr<Store>::clone`) and dropping the `WriteFile`
+        // in `then` runs `RefPtr<Store>::drop`, so the ref/deref pair is RAII.
         Ok(write_file)
     }
 
@@ -370,7 +370,7 @@ impl WriteFile {
         let total_written = this.total_written;
         // Cleanup is RAII: dropping the `Box` runs `WriteFile`'s field-drop
         // glue, which drops `bytes_blob.store`/`file_blob.store: Option<
-        // StoreRef>` → `Store::deref()` — exactly one deref each.
+        // RefPtr<Store>>` → `Store::deref()` — exactly one deref each.
         // (An earlier explicit `detach()` here was a no-op; the
         // bun-write-leak.test.ts failure was the ASAN debug build's ~320 MB
         // baseline RSS exceeding the fixture's 256 MB absolute threshold,
@@ -658,7 +658,7 @@ mod windows_impl {
             // SAFETY: just allocated, sole owner until returned.
             // No explicit store ref bumps — the caller passes `+1` Blobs via
             // `borrowed_view()` and `deinit` releases them via
-            // `heap::take → StoreRef::drop`.
+            // `heap::take → RefPtr<Store>::drop`.
             //
             // `open`/`do_write_loop` may free `*write_file` on the `Err` path,
             // so we operate through the raw `write_file` pointer rather than
@@ -1203,7 +1203,7 @@ mod windows_impl {
                 if fd > 0 && (*this).owned_fd {
                     aio::Closer::close(Fd::from_uv(fd), (*this).io_request.loop_);
                 }
-                // The store derefs happen via `StoreRef::drop` when the Box is
+                // The store derefs happen via `RefPtr<Store>::drop` when the Box is
                 // reclaimed below (paired with the RAII note in `create_with_ctx`).
                 (*this).poll_ref.disable();
                 // (*this).io_request is a valid uv_fs_t embedded in this struct; uv_fs_req_cleanup

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -306,9 +306,6 @@ impl WriteFile {
             close_after_io: false,
             mkdirp_if_not_exists,
         };
-        // No explicit store ref bump: the caller passes a `+1` Blob (via
-        // `borrowed_view()`'s `RefPtr<Store>::clone`) and dropping the `WriteFile`
-        // in `then` runs `RefPtr<Store>::drop`, so the ref/deref pair is RAII.
         Ok(write_file)
     }
 
@@ -368,13 +365,6 @@ impl WriteFile {
         let cb_ctx = this.on_complete_ctx;
         let system_error = this.system_error.take();
         let total_written = this.total_written;
-        // Cleanup is RAII: dropping the `Box` runs `WriteFile`'s field-drop
-        // glue, which drops `bytes_blob.store`/`file_blob.store: Option<
-        // RefPtr<Store>>` → `Store::deref()` — exactly one deref each.
-        // (An earlier explicit `detach()` here was a no-op; the
-        // bun-write-leak.test.ts failure was the ASAN debug build's ~320 MB
-        // baseline RSS exceeding the fixture's 256 MB absolute threshold,
-        // not an unbalanced ref.)
         drop(this);
 
         if let Some(err) = system_error {
@@ -656,10 +646,6 @@ mod windows_impl {
                 owned_fd: false,
             });
             // SAFETY: just allocated, sole owner until returned.
-            // No explicit store ref bumps — the caller passes `+1` Blobs via
-            // `borrowed_view()` and `deinit` releases them via
-            // `heap::take → RefPtr<Store>::drop`.
-            //
             // `open`/`do_write_loop` may free `*write_file` on the `Err` path,
             // so we operate through the raw `write_file` pointer rather than
             // holding a `&mut` across those calls (Stacked Borrows: a `&mut`
@@ -1203,8 +1189,6 @@ mod windows_impl {
                 if fd > 0 && (*this).owned_fd {
                     aio::Closer::close(Fd::from_uv(fd), (*this).io_request.loop_);
                 }
-                // The store derefs happen via `RefPtr<Store>::drop` when the Box is
-                // reclaimed below (paired with the RAII note in `create_with_ctx`).
                 (*this).poll_ref.disable();
                 // (*this).io_request is a valid uv_fs_t embedded in this struct; uv_fs_req_cleanup
                 // is safe on a zeroed or previously-used req.

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1926,7 +1926,7 @@ impl FetchTasklet {
         fetch_tasklet.tracker.did_schedule(global_this);
 
         // `body` is *moved* through `FetchOptions` into `request_body` (no
-        // shallow alias, no post-queue detach), so the StoreRef already carries
+        // shallow alias, no post-queue detach), so the RefPtr<Store> already carries
         // the caller's +1 — bumping it again here leaked one ref per
         // Blob-backed body (issue: fetch-leak fixture #5 RSS growth).
         // `clear_data() → request_body.detach()` releases it.

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -410,10 +410,10 @@ pub(crate) fn upload(
 
 /// returns a writable stream that writes to the s3 path
 ///
-/// Takes ownership of one `credentials` ref (adopted directly into the
-/// `MultiPartUpload`; not bumped). Callers pass `creds.dupe()`.
+/// Takes ownership of one `credentials` ref (moved into the `MultiPartUpload`).
+/// Callers pass `creds.dupe()`.
 pub(crate) fn writable_stream(
-    credentials: bun_ptr::IntrusiveRc<S3Credentials>,
+    credentials: bun_ptr::RefPtr<S3Credentials>,
     path: &[u8],
     global_this: &JSGlobalObject,
     options: MultiPartUploadOptions,
@@ -567,7 +567,7 @@ pub(crate) fn writable_stream(
 }
 
 pub struct S3UploadStreamWrapper {
-    // intrusive ref_count — bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) → bun_ptr::IntrusiveRc<Self>
+    // intrusive ref_count — bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) → bun_ptr::RefPtr<Self>
     pub(crate) ref_count: core::cell::Cell<u32>,
 
     pub sink: Option<NonNull<NetworkSink>>,
@@ -834,11 +834,10 @@ impl Drop for S3UploadStreamWrapper {
 
 /// consumes the readable stream and upload to s3
 ///
-/// Takes ownership of one `credentials` ref (adopted directly into the
-/// `MultiPartUpload`; not bumped). Callers pass `creds.dupe()`. On every
-/// early-return path the ref is explicitly released.
+/// Takes ownership of one `credentials` ref (moved into the `MultiPartUpload`).
+/// Callers pass `creds.dupe()`.
 pub(crate) fn upload_stream(
-    credentials: bun_ptr::IntrusiveRc<S3Credentials>,
+    credentials: bun_ptr::RefPtr<S3Credentials>,
     path: &[u8],
     readable_stream: ReadableStream,
     global_this: &JSGlobalObject,
@@ -855,7 +854,6 @@ pub(crate) fn upload_stream(
 ) -> JsResult<JSValue> {
     let proxy_url = proxy.unwrap_or(b"");
     if readable_stream.is_disturbed(global_this) {
-        credentials.deref();
         return Ok(bun_jsc::JSPromise::rejected_promise(
             global_this,
             global_this.create_error_instance(format_args!("ReadableStream is already disturbed")),
@@ -865,7 +863,6 @@ pub(crate) fn upload_stream(
 
     match readable_stream.ptr {
         ReadableStreamPtr::Invalid => {
-            credentials.deref();
             return Ok(bun_jsc::JSPromise::rejected_promise(
                 global_this,
                 global_this.create_error_instance(format_args!("ReadableStream is invalid")),
@@ -896,7 +893,6 @@ pub(crate) fn upload_stream(
                 });
                 let js_err = err.to_js(global_this);
                 js_err.ensure_still_alive();
-                credentials.deref();
                 return Ok(bun_jsc::JSPromise::rejected_promise(global_this, js_err).to_js());
             }
         }
@@ -921,7 +917,6 @@ pub(crate) fn upload_stream(
                 });
                 let js_err = err.to_js(global_this);
                 js_err.ensure_still_alive();
-                credentials.deref();
                 return Ok(bun_jsc::JSPromise::rejected_promise(global_this, js_err).to_js());
             }
         }
@@ -949,8 +944,6 @@ pub(crate) fn upload_stream(
         );
     }
 
-    // `credentials` is owned-by-value and explicitly `.deref()`ed on each early
-    // return above; the ref is adopted by value — moved into the MultiPartUpload below.
     // SAFETY (JSC_BORROW): see `writable_stream` for rationale.
     let global_static = GlobalRef::from(global_this);
     let part_size = options.part_size;

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -566,7 +566,7 @@ pub(crate) fn writable_stream(
 }
 
 pub struct S3UploadStreamWrapper {
-    // intrusive ref_count — bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) → bun_ptr::RefPtr<Self>
+    /// Hand-rolled intrusive count; released through [`Self::deref_`].
     pub(crate) ref_count: core::cell::Cell<u32>,
 
     pub sink: Option<NonNull<NetworkSink>>,

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -410,8 +410,7 @@ pub(crate) fn upload(
 
 /// returns a writable stream that writes to the s3 path
 ///
-/// Takes ownership of one `credentials` ref (moved into the `MultiPartUpload`).
-/// Callers pass `creds.dupe()`.
+/// `credentials` is moved into the `MultiPartUpload`.
 pub(crate) fn writable_stream(
     credentials: bun_ptr::RefPtr<S3Credentials>,
     path: &[u8],
@@ -834,8 +833,7 @@ impl Drop for S3UploadStreamWrapper {
 
 /// consumes the readable stream and upload to s3
 ///
-/// Takes ownership of one `credentials` ref (moved into the `MultiPartUpload`).
-/// Callers pass `creds.dupe()`.
+/// `credentials` is moved into the `MultiPartUpload`.
 pub(crate) fn upload_stream(
     credentials: bun_ptr::RefPtr<S3Credentials>,
     path: &[u8],

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -102,6 +102,7 @@ use bun_io::KeepAlive;
 use bun_io::StreamBuffer;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{GlobalRef, JsCell};
+use bun_ptr::RefPtr;
 use bun_s3_signing::acl::ACL;
 use bun_s3_signing::credentials::S3Credentials;
 use bun_s3_signing::error::S3Error;
@@ -127,14 +128,14 @@ pub struct MultiPartUpload {
     pub(crate) available: Cell<IntegerBitSet<{ Self::MAX_QUEUE_SIZE }>>,
 
     pub(crate) current_part_number: Cell<u16>,
-    pub(crate) ref_count: Cell<u32>, // intrusive refcount — see bun_ptr::RefPtr
+    pub(crate) ref_count: Cell<u32>,
     pub(crate) ended: Cell<bool>,
 
     pub(crate) options: Cell<MultiPartUploadOptions>,
     pub(crate) acl: Option<ACL>,
     pub(crate) storage_class: Option<StorageClass>,
     pub(crate) request_payer: bool,
-    pub(crate) credentials: bun_ptr::RefPtr<S3Credentials>,
+    pub(crate) credentials: RefPtr<S3Credentials>,
     pub poll_ref: JsCell<KeepAlive>,
     pub(crate) vm: &'static VirtualMachine,
     // JSC_BORROW per LIFETIMES.tsv row 1886 — rust_type `&JSGlobalObject` used verbatim
@@ -394,10 +395,9 @@ impl MultiPartUpload {
         this: *mut c_void,
     ) -> bun_jsc::JsResult<()> {
         let this = this.cast::<Self>();
-        // `adopt` consumes the ref `process_buffered` (or the retry path)
-        // took for this request.
-        // SAFETY: callback context — `this` is the live allocation ref'd before dispatch.
-        let _deref_guard = unsafe { bun_ptr::RefPtr::<Self>::from_raw(this) };
+        // SAFETY: callback context — `this` is live; this takes over the ref
+        // `process_buffered` (or the retry path) took for this request.
+        let _guard = unsafe { RefPtr::from_raw(this) };
         // SAFETY: `this` is live for at least the guard's duration.
         let self_ = unsafe { &*this };
         if self_.state.get() == State::Finished {
@@ -637,10 +637,9 @@ impl MultiPartUpload {
         this: *mut c_void,
     ) -> bun_jsc::JsResult<()> {
         let this = this.cast::<Self>();
-        // `adopt` consumes the prior +1 on Drop.
-        // SAFETY: callback context — a ref was taken before the request was queued.
-        let _deref_guard = unsafe { bun_ptr::RefPtr::<Self>::from_raw(this) };
-        // SAFETY: `this` is live for at least the adopted ref's duration.
+        // SAFETY: callback context — takes over the ref taken before the request was queued.
+        let _guard = unsafe { RefPtr::from_raw(this) };
+        // SAFETY: `this` is live for at least the guard's duration.
         let self_ = unsafe { &*this };
         if self_.state.get() == State::Finished {
             return Ok(());
@@ -1076,9 +1075,8 @@ impl MultiPartUpload {
             return Ok(UploadBackpressure::Done); // no backpressure since we are done
         }
         // we may call done inside processBuffered so we ensure that we keep a ref until we are done
-        // SAFETY: `self` is the live RefPtr allocation; `RefPtr` bumps the count
-        // and derefs on every exit path.
-        let _deref_guard = unsafe { bun_ptr::RefPtr::init_ref(self.root_ptr()) };
+        // SAFETY: `self` is live; `root_ptr()` carries the allocation's provenance.
+        let _guard = unsafe { RefPtr::init_ref(self.root_ptr()) };
 
         if self.state.get() == State::WaitStreamCheck && chunk.is_empty() && is_last {
             // we do this because stream will close if the file dont exists and we dont wanna to send an empty part in this case

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -127,14 +127,14 @@ pub struct MultiPartUpload {
     pub(crate) available: Cell<IntegerBitSet<{ Self::MAX_QUEUE_SIZE }>>,
 
     pub(crate) current_part_number: Cell<u16>,
-    pub(crate) ref_count: Cell<u32>, // intrusive refcount — see bun_ptr::IntrusiveRc
+    pub(crate) ref_count: Cell<u32>, // intrusive refcount — see bun_ptr::RefPtr
     pub(crate) ended: Cell<bool>,
 
     pub(crate) options: Cell<MultiPartUploadOptions>,
     pub(crate) acl: Option<ACL>,
     pub(crate) storage_class: Option<StorageClass>,
     pub(crate) request_payer: bool,
-    pub(crate) credentials: bun_ptr::IntrusiveRc<S3Credentials>,
+    pub(crate) credentials: bun_ptr::RefPtr<S3Credentials>,
     pub poll_ref: JsCell<KeepAlive>,
     pub(crate) vm: &'static VirtualMachine,
     // JSC_BORROW per LIFETIMES.tsv row 1886 — rust_type `&JSGlobalObject` used verbatim
@@ -385,13 +385,6 @@ impl Drop for MultiPartUpload {
                 bun_io::AllocatorType::Js,
             ))
         });
-        // path, proxy, content_type, content_disposition, content_encoding — Box dropped automatically
-        // `IntrusiveRc<T>` (= `RefPtr<T>`) has no `Drop` — release the +1 the
-        // constructing `writable_stream`/`upload_stream` adopted.
-        self.credentials.deref();
-        // multipart_etags: Vec<UploadPartResult> — Drop (each etag Box<[u8]> freed)
-        // multipart_upload_list: Vec<u8> — Drop
-        // bun.destroy(this) — handled by deref_() via heap::take
     }
 }
 
@@ -404,7 +397,7 @@ impl MultiPartUpload {
         // `adopt` consumes the ref `process_buffered` (or the retry path)
         // took for this request.
         // SAFETY: callback context — `this` is the live allocation ref'd before dispatch.
-        let _deref_guard = unsafe { bun_ptr::ScopedRef::<Self>::adopt(this) };
+        let _deref_guard = unsafe { bun_ptr::RefPtr::<Self>::from_raw(this) };
         // SAFETY: `this` is live for at least the guard's duration.
         let self_ = unsafe { &*this };
         if self_.state.get() == State::Finished {
@@ -646,7 +639,7 @@ impl MultiPartUpload {
         let this = this.cast::<Self>();
         // `adopt` consumes the prior +1 on Drop.
         // SAFETY: callback context — a ref was taken before the request was queued.
-        let _deref_guard = unsafe { bun_ptr::ScopedRef::<Self>::adopt(this) };
+        let _deref_guard = unsafe { bun_ptr::RefPtr::<Self>::from_raw(this) };
         // SAFETY: `this` is live for at least the adopted ref's duration.
         let self_ = unsafe { &*this };
         if self_.state.get() == State::Finished {
@@ -1083,9 +1076,9 @@ impl MultiPartUpload {
             return Ok(UploadBackpressure::Done); // no backpressure since we are done
         }
         // we may call done inside processBuffered so we ensure that we keep a ref until we are done
-        // SAFETY: `self` is the live IntrusiveRc allocation; `ScopedRef` bumps the count
+        // SAFETY: `self` is the live RefPtr allocation; `RefPtr` bumps the count
         // and derefs on every exit path.
-        let _deref_guard = unsafe { bun_ptr::ScopedRef::new(self.root_ptr()) };
+        let _deref_guard = unsafe { bun_ptr::RefPtr::init_ref(self.root_ptr()) };
 
         if self.state.get() == State::WaitStreamCheck && chunk.is_empty() && is_last {
             // we do this because stream will close if the file dont exists and we dont wanna to send an empty part in this case

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -163,12 +163,8 @@ fn boring_engine() -> *mut bun_sha_hmac::sha::ffi::ENGINE {
 // S3Credentials
 // ──────────────────────────────────────────────────────────────────────────
 
-// `bun.ptr.RefCount(...)` mixin → RefPtr handles ref/deref; when count hits
-// zero the boxed allocation is dropped, which drops the Box<[u8]> fields, so no
-// explicit Drop body is needed here.
 #[derive(bun_ptr::RefCounted)]
 pub struct S3Credentials {
-    // Intrusive refcount; managed by bun_ptr::RefPtr<S3Credentials>.
     ref_count: RefCount<S3Credentials>,
     pub access_key_id: Box<[u8]>,
     pub secret_access_key: Box<[u8]>,

--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -6,7 +6,7 @@ use bstr::BStr;
 use bun_core::strings;
 use bun_http_types::Method::Method;
 use bun_picohttp::Header as PicoHeader;
-use bun_ptr::{IntrusiveRc, RefCount};
+use bun_ptr::{RefCount, RefPtr};
 
 use super::acl::ACL;
 use super::storage_class::StorageClass;
@@ -163,12 +163,12 @@ fn boring_engine() -> *mut bun_sha_hmac::sha::ffi::ENGINE {
 // S3Credentials
 // ──────────────────────────────────────────────────────────────────────────
 
-// `bun.ptr.RefCount(...)` mixin → IntrusiveRc handles ref/deref; when count hits
+// `bun.ptr.RefCount(...)` mixin → RefPtr handles ref/deref; when count hits
 // zero the boxed allocation is dropped, which drops the Box<[u8]> fields, so no
 // explicit Drop body is needed here.
 #[derive(bun_ptr::RefCounted)]
 pub struct S3Credentials {
-    // Intrusive refcount; managed by bun_ptr::IntrusiveRc<S3Credentials>.
+    // Intrusive refcount; managed by bun_ptr::RefPtr<S3Credentials>.
     ref_count: RefCount<S3Credentials>,
     pub access_key_id: Box<[u8]>,
     pub secret_access_key: Box<[u8]>,
@@ -185,7 +185,7 @@ pub struct S3Credentials {
 
 // `S3Credentials` owns its bytes via
 // `Box<[u8]>`, so a manual `Clone` deep-copies them and resets `ref_count` — the
-// intrusive count only applies to heap (`IntrusiveRc`) instances; a fresh value
+// intrusive count only applies to heap (`RefPtr`) instances; a fresh value
 // must start at 1.
 impl Clone for S3Credentials {
     fn clone(&self) -> Self {
@@ -259,8 +259,8 @@ impl S3Credentials {
             + self.bucket.len()
     }
 
-    pub fn dupe(&self) -> IntrusiveRc<S3Credentials> {
-        IntrusiveRc::new(S3Credentials {
+    pub fn dupe(&self) -> RefPtr<S3Credentials> {
+        RefPtr::new(S3Credentials {
             ref_count: RefCount::init(),
             access_key_id: self.access_key_id.clone(),
             secret_access_key: self.secret_access_key.clone(),

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -15,6 +15,7 @@ use bun_event_loop::EventLoopHandle;
 use bun_io::ParentDeathWatchdog;
 #[cfg(unix)]
 use bun_io::{FilePoll, KeepAlive};
+use bun_ptr::RefPtr;
 #[cfg(windows)]
 use bun_sys::ReturnCodeExt as _;
 #[cfg(windows)]
@@ -151,7 +152,7 @@ impl Drop for Process {
 /// allocation, event-loop thread only); none escapes this type. Dropping the
 /// handle from inside the exit handler re-enters the `Process` whose `on_exit`
 /// is dispatching, exactly as the raw-pointer owners do.
-pub struct ProcessHandle(bun_ptr::RefPtr<Process>);
+pub struct ProcessHandle(RefPtr<Process>);
 
 impl ProcessHandle {
     #[inline]
@@ -326,7 +327,7 @@ impl Process {
         rusage: &Rusage,
     ) {
         // SAFETY: caller contract — adopts the queued +1 ref.
-        let _guard = unsafe { bun_ptr::RefPtr::from_raw(this) };
+        let _guard = unsafe { RefPtr::from_raw(this) };
         // SAFETY: `_guard` keeps `this` live; `&mut` scoped to the poller unref.
         unsafe {
             if let Poller::WaiterThread(waiter) = &mut (*this).poller {
@@ -345,7 +346,7 @@ impl Process {
     #[cfg(unix)]
     pub unsafe fn on_wait_pid_from_event_loop_task(this: *mut Self) {
         // SAFETY: caller contract — adopts the queued +1 ref.
-        let _guard = unsafe { bun_ptr::RefPtr::from_raw(this) };
+        let _guard = unsafe { RefPtr::from_raw(this) };
         // SAFETY: `_guard` keeps `this` live.
         unsafe { (*this).wait(false) };
     }
@@ -600,7 +601,7 @@ impl Process {
         // `&mut Process` whose tag would have to outlive that.
         let this: *mut Process = unsafe { (*uv_handle).data.cast() };
         // SAFETY: adopts the +1 ref taken at `uv_spawn`.
-        let _guard = unsafe { bun_ptr::RefPtr::from_raw(this) };
+        let _guard = unsafe { RefPtr::from_raw(this) };
         bun_sys::windows::libuv::log!("Process.onClose({})", _pid);
         // SAFETY: `_guard` keeps `this` live for this block.
         unsafe {
@@ -1577,7 +1578,7 @@ impl WindowsSpawnResult {
         // SAFETY: `to_process` returns the live heap `Process` allocated by
         // `spawn_process_windows` with its initial ref; that ref moves into
         // the handle.
-        ProcessHandle(unsafe { bun_ptr::RefPtr::from_raw(self.to_process(event_loop)) })
+        ProcessHandle(unsafe { RefPtr::from_raw(self.to_process(event_loop)) })
     }
 }
 
@@ -1743,7 +1744,7 @@ pub trait SpawnResultExt: Sized {
     fn to_process_handle(self, event_loop: EventLoopHandle) -> ProcessHandle {
         // SAFETY: `to_process` returns a live heap `Process` whose initial ref
         // the caller owns; that ref moves into the handle.
-        ProcessHandle(unsafe { bun_ptr::RefPtr::from_raw(self.to_process(event_loop)) })
+        ProcessHandle(unsafe { RefPtr::from_raw(self.to_process(event_loop)) })
     }
 }
 

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -181,7 +181,7 @@ impl ProcessHandle {
     }
 
     pub fn has_exited(&self) -> bool {
-        self.0.data().has_exited()
+        self.0.has_exited()
     }
 }
 
@@ -326,8 +326,8 @@ impl Process {
         rusage: &Rusage,
     ) {
         // SAFETY: caller contract — adopts the queued +1 ref.
-        let _g = unsafe { bun_ptr::RefPtr::<Process>::from_raw(this) };
-        // SAFETY: `_g` keeps `this` live; `&mut` scoped to the poller unref.
+        let _guard = unsafe { bun_ptr::RefPtr::from_raw(this) };
+        // SAFETY: `_guard` keeps `this` live; `&mut` scoped to the poller unref.
         unsafe {
             if let Poller::WaiterThread(waiter) = &mut (*this).poller {
                 let ctx = event_loop_handle_to_ctx((*this).event_loop);
@@ -335,7 +335,7 @@ impl Process {
                 (*this).poller = Poller::Detached;
             }
         }
-        // SAFETY: `_g` keeps `this` live; `&mut` scoped to this call (which
+        // SAFETY: `_guard` keeps `this` live; `&mut` scoped to this call (which
         // can fire the JS exit handler).
         unsafe { (*this).on_wait_pid(waitpid_result, rusage) };
     }
@@ -345,8 +345,8 @@ impl Process {
     #[cfg(unix)]
     pub unsafe fn on_wait_pid_from_event_loop_task(this: *mut Self) {
         // SAFETY: caller contract — adopts the queued +1 ref.
-        let _g = unsafe { bun_ptr::RefPtr::<Process>::from_raw(this) };
-        // SAFETY: `_g` keeps `this` live.
+        let _guard = unsafe { bun_ptr::RefPtr::from_raw(this) };
+        // SAFETY: `_guard` keeps `this` live.
         unsafe { (*this).wait(false) };
     }
 
@@ -600,9 +600,9 @@ impl Process {
         // `&mut Process` whose tag would have to outlive that.
         let this: *mut Process = unsafe { (*uv_handle).data.cast() };
         // SAFETY: adopts the +1 ref taken at `uv_spawn`.
-        let _g = unsafe { bun_ptr::RefPtr::<Process>::from_raw(this) };
+        let _guard = unsafe { bun_ptr::RefPtr::from_raw(this) };
         bun_sys::windows::libuv::log!("Process.onClose({})", _pid);
-        // SAFETY: `_g` keeps `this` live for this block.
+        // SAFETY: `_guard` keeps `this` live for this block.
         unsafe {
             if matches!((*this).poller, Poller::Uv(_)) {
                 (*this).poller = Poller::Detached;

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -188,7 +188,6 @@ impl ProcessHandle {
 impl Drop for ProcessHandle {
     fn drop(&mut self) {
         self.process_mut().detach();
-        self.0.deref();
     }
 }
 
@@ -317,7 +316,7 @@ impl Process {
 
     /// # Safety
     /// `this` carries the +1 ref taken when the waiter-thread task was queued.
-    /// `ScopedRef::adopt` releases it on return — which may free `this` — so
+    /// `RefPtr::from_raw` releases it on return — which may free `this` — so
     /// this takes `*mut Self`, not `&mut self` (a `&mut` argument's
     /// Stacked-Borrows protector outliving the allocation is UB; see :215).
     #[cfg(unix)]
@@ -327,7 +326,7 @@ impl Process {
         rusage: &Rusage,
     ) {
         // SAFETY: caller contract — adopts the queued +1 ref.
-        let _g = unsafe { bun_ptr::ScopedRef::<Process>::adopt(this) };
+        let _g = unsafe { bun_ptr::RefPtr::<Process>::from_raw(this) };
         // SAFETY: `_g` keeps `this` live; `&mut` scoped to the poller unref.
         unsafe {
             if let Poller::WaiterThread(waiter) = &mut (*this).poller {
@@ -346,7 +345,7 @@ impl Process {
     #[cfg(unix)]
     pub unsafe fn on_wait_pid_from_event_loop_task(this: *mut Self) {
         // SAFETY: caller contract — adopts the queued +1 ref.
-        let _g = unsafe { bun_ptr::ScopedRef::<Process>::adopt(this) };
+        let _g = unsafe { bun_ptr::RefPtr::<Process>::from_raw(this) };
         // SAFETY: `_g` keeps `this` live.
         unsafe { (*this).wait(false) };
     }
@@ -597,11 +596,11 @@ impl Process {
         // `Poller::Uv` payload inside `*this` (see `on_exit_uv`).
         let _pid = unsafe { (*uv_handle).pid };
         // SAFETY: `*mut Process` back-pointer stashed in `data` at spawn. Stay
-        // raw — `ScopedRef::Drop` may free the allocation, so never bind a
+        // raw — `RefPtr::drop` may free the allocation, so never bind a
         // `&mut Process` whose tag would have to outlive that.
         let this: *mut Process = unsafe { (*uv_handle).data.cast() };
         // SAFETY: adopts the +1 ref taken at `uv_spawn`.
-        let _g = unsafe { bun_ptr::ScopedRef::<Process>::adopt(this) };
+        let _g = unsafe { bun_ptr::RefPtr::<Process>::from_raw(this) };
         bun_sys::windows::libuv::log!("Process.onClose({})", _pid);
         // SAFETY: `_g` keeps `this` live for this block.
         unsafe {

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -4,7 +4,7 @@ use bun_event_loop::EventLoopHandle;
 #[cfg(windows)]
 use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
 use bun_io::{BufferedWriter, WriteStatus};
-use bun_ptr::{IntrusiveRc, RawSlice, RefCount};
+use bun_ptr::{RawSlice, RefCount, RefPtr};
 use bun_sys;
 
 use crate::process::StdioKind;
@@ -111,7 +111,7 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         subprocess: *mut P,
         result: StdioResult,
         source: Source,
-    ) -> IntrusiveRc<Self> {
+    ) -> RefPtr<Self> {
         #[allow(unused_mut)]
         let mut boxed = Box::new(Self {
             ref_count: RefCount::init(),
@@ -149,8 +149,8 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         // SAFETY: `this` was just leaked above; borrow scoped to registering
         // the parent backref.
         unsafe { (*this).writer.set_parent(this) };
-        // SAFETY: ownership of the initial ref is transferred to the returned IntrusiveRc.
-        unsafe { IntrusiveRc::from_raw(this) }
+        // SAFETY: ownership of the initial ref is transferred to the returned RefPtr.
+        unsafe { RefPtr::from_raw(this) }
     }
 
     pub fn start(&mut self) -> bun_sys::Result<()> {
@@ -172,7 +172,7 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
                 // start() failed: `started` stays false so no release site
                 // fires — release start()'s `+1` here.
                 // SAFETY: `self` is the live `Self` we ref'd at the top of
-                // `start()`; the caller's `IntrusiveRc` keeps it alive and
+                // `start()`; the caller's `RefPtr` keeps it alive and
                 // `started` is false so no other site re-derefs.
                 unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
             }
@@ -186,7 +186,7 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
                     // start() failed: `started` stays false so no release
                     // site fires — release start()'s `+1` here.
                     // SAFETY: `self` is the live `Self` we ref'd at the top
-                    // of `start()`; the caller's `IntrusiveRc` keeps it alive
+                    // of `start()`; the caller's `RefPtr` keeps it alive
                     // and `started` is false so no other site re-derefs.
                     unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
                     bun_sys::Result::Err(err)
@@ -294,7 +294,7 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
 }
 
 /// The `RefCount` destructor callback.
-/// The heap free is handled by `IntrusiveRc` after `drop` returns.
+/// The heap free is handled by `RefPtr` after `drop` returns.
 impl<P: StaticPipeWriterProcess> Drop for StaticPipeWriter<P> {
     fn drop(&mut self) {
         self.writer.end();

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -11,7 +11,7 @@ use crate::shared::CachedStructure;
 use crate::shared::connection_ctor_args::{self, ConnectionCtorArgs};
 use bun_core::strings;
 use bun_core::{TimespecMockMode, timespec};
-use bun_ptr::{AsCtxPtr, BackRef, ParentRef};
+use bun_ptr::{AsCtxPtr, BackRef, ParentRef, RefPtr};
 use bun_sql::mysql::MySQLQueryResult;
 use bun_sql::mysql::protocol::any_mysql_error::Error as AnyMySQLErrorT;
 use bun_sql::mysql::protocol::error_packet::ErrorPacket;
@@ -91,30 +91,13 @@ bun_event_loop::impl_timer_owner!(JSMySQLConnection;
 
 bun_jsc::impl_js_class_via_generated!(JSMySQLConnection => crate::jsc::codegen::js_mysql_connection);
 
-/// RAII owner for one intrusive refcount on a `JSMySQLConnection`. Dropping
-/// calls [`JSMySQLConnection::deref`], which may free `*self.0` — so callers
-/// must not hold a live `&`/`&mut JSMySQLConnection` across the guard's drop
-/// point. Construct via [`JSMySQLConnection::ref_guard`] (which also bumps the
-/// count) or directly when adopting a ref taken elsewhere (e.g. the socket ref
-/// from `on_open`).
-struct DerefOnDrop(*mut JSMySQLConnection);
-impl Drop for DerefOnDrop {
-    fn drop(&mut self) {
-        // SAFETY: constructor contract — `self.0` is a live `heap::alloc`
-        // pointer with at least one outstanding ref owned by this guard.
-        unsafe { JSMySQLConnection::deref(self.0) }
-    }
-}
-
 impl JSMySQLConnection {
-    /// RAII pair for `ref_()` / `deref()`: bumps the intrusive refcount now and
-    /// releases it on drop. The guard stashes a raw pointer (not `&Self`) so no Rust
-    /// reference is held across the potential free in `deref()`; the `&self`
-    /// receiver here is only borrowed for the bump itself.
+    /// Hold a ref across a re-entrant call. No Rust reference is held across
+    /// the potential free on drop; `&self` is borrowed only for the bump.
     #[inline]
-    fn ref_guard(&self) -> DerefOnDrop {
-        self.ref_();
-        DerefOnDrop(self.as_ctx_ptr())
+    fn ref_guard(&self) -> RefPtr<Self> {
+        // SAFETY: `self` is the live m_ctx payload.
+        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
     }
 
     /// Shared borrow of the JS-thread `VirtualMachine` singleton stored in this
@@ -943,10 +926,9 @@ impl<const SSL: bool> SocketHandler<SSL> {
         _: i32,
         _: Option<*mut c_void>,
     ) {
-        // Releases the socket ref taken in on_open.
-        // RAII guard adopts that existing ref (no `ref_()` here); raw-pointer
-        // shaped so no reference outlives the potential free.
-        let _ref = DerefOnDrop(this.as_ctx_ptr());
+        // Takes over the socket ref taken in on_open.
+        // SAFETY: `this` is live and that ref is outstanding.
+        let _ref = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
         // A close before the handshake finished means the server (or an
         // intermediary like a container port proxy) accepted the TCP
         // connection but went away before completing startup — e.g. the

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -92,11 +92,10 @@ bun_event_loop::impl_timer_owner!(JSMySQLConnection;
 bun_jsc::impl_js_class_via_generated!(JSMySQLConnection => crate::jsc::codegen::js_mysql_connection);
 
 impl JSMySQLConnection {
-    /// Hold a ref across a re-entrant call. No Rust reference is held across
-    /// the potential free on drop; `&self` is borrowed only for the bump.
+    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
     #[inline]
     fn ref_guard(&self) -> RefPtr<Self> {
-        // SAFETY: `self` is the live m_ctx payload.
+        // SAFETY: `self` is the live heap allocation.
         unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
     }
 
@@ -354,7 +353,7 @@ impl JSMySQLConnection {
         bun_core::scoped_log!(MySQLConnection, "drainInternal");
         // Raw-pointer RAII guard so no reference is live across the potential
         // free.
-        let _ref = self.ref_guard();
+        let _guard = self.ref_guard();
         let _loop_guard = self.event_loop().entered();
         self.ensure_js_value_is_alive();
         if let Err(my_sql_connection::FlushQueueError::AuthenticationFailed) =
@@ -672,11 +671,11 @@ impl JSMySQLConnection {
     fn fail_with_js_value(&self, value: JSValue) {
         // Runs on every exit path. Re-enter through a raw pointer so no
         // reference is live across the potential free in `deref()`. LIFO drop
-        // order: the `defer!` body runs first, then `_ref` releases the count.
+        // order: the `defer!` body runs first, then `_guard` releases the count.
         let p = ParentRef::new(self);
-        let _ref = self.ref_guard();
+        let _guard = self.ref_guard();
         scopeguard::defer! {
-            // `_ref` has not yet dropped, so `*p` is still live; `ParentRef`
+            // `_guard` has not yet dropped, so `*p` is still live; `ParentRef`
             // yields a fresh `&Self` per access (R-2: every callee is `&self`).
             let queries = p.get_queries_array();
             p.connection_mut().clean_queue_and_close(Some(value), queries);
@@ -928,7 +927,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
     ) {
         // Takes over the socket ref taken in on_open.
         // SAFETY: `this` is live and that ref is outstanding.
-        let _ref = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
+        let _guard = unsafe { RefPtr::from_raw(this.as_ctx_ptr()) };
         // A close before the handshake finished means the server (or an
         // intermediary like a container port proxy) accepted the TCP
         // connection but went away before completing startup — e.g. the
@@ -961,13 +960,13 @@ impl<const SSL: bool> SocketHandler<SSL> {
 
     pub fn on_data(this: &JSMySQLConnection, _: NewSocketHandler<SSL>, data: &[u8]) {
         // Both guards re-enter via raw pointer so no reference is live across
-        // the potential free. Guard drop order is LIFO, so `_ref` (deref) runs
+        // the potential free. Guard drop order is LIFO, so `_guard` (deref) runs
         // last.
         let p = ParentRef::new(this);
-        let _ref = this.ref_guard();
+        let _guard = this.ref_guard();
 
         scopeguard::defer! {
-            // `_ref` has not yet dropped, so `*p` is still live; `ParentRef`
+            // `_guard` has not yet dropped, so `*p` is still live; `ParentRef`
             // yields a fresh `&JSMySQLConnection` per access (R-2: every
             // callee is `&self`).
             if p.connection.get().status == my_sql_connection::Status::Connected {

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -8,7 +8,7 @@ use crate::jsc::{
 };
 use crate::shared::query_ctor_args::QueryCtorArgs;
 use bun_jsc::JsCell;
-use bun_ptr::{AsCtxPtr, BackRef, ParentRef};
+use bun_ptr::{AsCtxPtr, BackRef, ParentRef, RefPtr};
 use bun_sql::mysql::MySQLQueryResult;
 use bun_sql::mysql::protocol::any_mysql_error::{self as AnyMySQLError};
 use bun_sql::postgres::command_tag::CommandTag;
@@ -53,15 +53,11 @@ pub struct JSMySQLQuery {
 // struct-level `#[ref_count(destroy = …)]` attribute.
 
 impl JSMySQLQuery {
-    /// RAII `ref()`/`deref()` bracket around `self`. One audited
-    /// `RefPtr::init_ref` here replaces N per-site
-    /// `unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }` — `&self` is the live
-    /// m_ctx payload by construction, so the [`RefPtr::init_ref`] precondition
-    /// (live, non-null) is always satisfied.
+    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
     #[inline]
-    pub(crate) fn ref_guard(&self) -> bun_ptr::RefPtr<Self> {
-        // SAFETY: `&self` ⇒ the allocation is live and non-null.
-        unsafe { bun_ptr::RefPtr::init_ref(self.as_ctx_ptr()) }
+    pub(crate) fn ref_guard(&self) -> RefPtr<Self> {
+        // SAFETY: `self` is the live heap allocation.
+        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
     }
 
     pub fn estimated_size(&self) -> usize {

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -54,14 +54,14 @@ pub struct JSMySQLQuery {
 
 impl JSMySQLQuery {
     /// RAII `ref()`/`deref()` bracket around `self`. One audited
-    /// `ScopedRef::new` here replaces N per-site
-    /// `unsafe { ScopedRef::new(self.as_ctx_ptr()) }` — `&self` is the live
-    /// m_ctx payload by construction, so the [`ScopedRef::new`] precondition
+    /// `RefPtr::init_ref` here replaces N per-site
+    /// `unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }` — `&self` is the live
+    /// m_ctx payload by construction, so the [`RefPtr::init_ref`] precondition
     /// (live, non-null) is always satisfied.
     #[inline]
-    pub(crate) fn ref_guard(&self) -> bun_ptr::ScopedRef<Self> {
+    pub(crate) fn ref_guard(&self) -> bun_ptr::RefPtr<Self> {
         // SAFETY: `&self` ⇒ the allocation is live and non-null.
-        unsafe { bun_ptr::ScopedRef::new(self.as_ctx_ptr()) }
+        unsafe { bun_ptr::RefPtr::init_ref(self.as_ctx_ptr()) }
     }
 
     pub fn estimated_size(&self) -> usize {

--- a/src/sql_jsc/mysql/MySQLRequestQueue.rs
+++ b/src/sql_jsc/mysql/MySQLRequestQueue.rs
@@ -294,9 +294,7 @@ impl MySQLRequestQueue {
         Some(q.peek_item(0))
     }
 
-    /// [`current`] as a [`bun_ptr::ThisPtr`] — one audited deref site here
-    /// replaces the per-caller `unsafe { &*ptr }` / `RefPtr::init_ref(ptr)` pair.
-    /// The queue holds a ref on every stored request, so the pointee is live;
+    /// [`current`] as a [`bun_ptr::ThisPtr`]. The queue holds a ref on every stored request, so the pointee is live;
     /// `JSMySQLQuery` is a separate heap allocation (never aliases the queue or
     /// its embedding connection) and is fully interior-mutable (R-2: every
     /// method is `&self`), so a shared `&JSMySQLQuery` derived via `Deref` is

--- a/src/sql_jsc/mysql/MySQLRequestQueue.rs
+++ b/src/sql_jsc/mysql/MySQLRequestQueue.rs
@@ -295,7 +295,7 @@ impl MySQLRequestQueue {
     }
 
     /// [`current`] as a [`bun_ptr::ThisPtr`] — one audited deref site here
-    /// replaces the per-caller `unsafe { &*ptr }` / `ScopedRef::new(ptr)` pair.
+    /// replaces the per-caller `unsafe { &*ptr }` / `RefPtr::init_ref(ptr)` pair.
     /// The queue holds a ref on every stored request, so the pointee is live;
     /// `JSMySQLQuery` is a separate heap allocation (never aliases the queue or
     /// its embedding connection) and is fully interior-mutable (R-2: every

--- a/src/sql_jsc/mysql/MySQLStatement.rs
+++ b/src/sql_jsc/mysql/MySQLStatement.rs
@@ -14,9 +14,9 @@ pub use bun_sql::mysql::mysql_param::Param;
 bun_core::declare_scope!(MySQLStatement, hidden);
 
 // `bun.ptr.RefCount(@This(), "ref_count", deinit, .{})` → intrusive single-thread refcount.
-// Shared ownership is expressed as `bun_ptr::IntrusiveRc<MySQLStatement>`; the
-// `ref_count` field below is the embedded counter that `IntrusiveRc` manipulates.
-// `ref()`/`deref()` are methods on `IntrusiveRc`, not on this struct.
+// Shared ownership is expressed as `bun_ptr::RefPtr<MySQLStatement>`; the
+// `ref_count` field below is the embedded counter that `RefPtr` manipulates.
+// `ref()`/`deref()` are methods on `RefPtr`, not on this struct.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct MySQLStatement {
     pub(crate) cached_structure: CachedStructure,

--- a/src/sql_jsc/mysql/MySQLStatement.rs
+++ b/src/sql_jsc/mysql/MySQLStatement.rs
@@ -13,10 +13,6 @@ pub use bun_sql::mysql::mysql_param::Param;
 
 bun_core::declare_scope!(MySQLStatement, hidden);
 
-// `bun.ptr.RefCount(@This(), "ref_count", deinit, .{})` → intrusive single-thread refcount.
-// Shared ownership is expressed as `bun_ptr::RefPtr<MySQLStatement>`; the
-// `ref_count` field below is the embedded counter that `RefPtr` manipulates.
-// `ref()`/`deref()` are methods on `RefPtr`, not on this struct.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct MySQLStatement {
     pub(crate) cached_structure: CachedStructure,

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -47,7 +47,7 @@ pub struct PostgresSQLQuery {
 
     // bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) — intrusive single-thread refcount.
     // `#[derive(CellRefCounted)]` provides `ref_()`/`deref()` and the `AnyRefCounted`
-    // bridge so `ScopedRef<PostgresSQLQuery>` brackets re-entrant callback paths.
+    // bridge so `RefPtr<PostgresSQLQuery>` brackets re-entrant callback paths.
     ref_count: Cell<u32>,
 
     pub(crate) flags: Cell<Flags>,
@@ -128,14 +128,14 @@ impl PostgresSQLQuery {
     }
 
     /// RAII `ref()`/`deref()` bracket around `self`. One audited
-    /// `ScopedRef::new` here replaces N per-site
-    /// `unsafe { ScopedRef::new(self.as_ctx_ptr()) }` — `&self` is the live
+    /// `RefPtr::init_ref` here replaces N per-site
+    /// `unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }` — `&self` is the live
     /// `heap::alloc` payload (held by the connection's request FIFO), so the
-    /// [`ScopedRef::new`] precondition (live, non-null) is always satisfied.
+    /// [`RefPtr::init_ref`] precondition (live, non-null) is always satisfied.
     #[inline]
-    pub(crate) fn ref_guard(&self) -> bun_ptr::ScopedRef<Self> {
+    pub(crate) fn ref_guard(&self) -> bun_ptr::RefPtr<Self> {
         // SAFETY: `&self` ⇒ the allocation is live and non-null.
-        unsafe { bun_ptr::ScopedRef::new(self.as_ctx_ptr()) }
+        unsafe { bun_ptr::RefPtr::init_ref(self.as_ctx_ptr()) }
     }
 
     /// Dereference the intrusive `statement` pointer as `&mut`. Mirrors
@@ -198,7 +198,7 @@ impl PostgresSQLQuery {
         queries_array: JSValue,
     ) {
         // R-2: every field touched below is `Cell`/`JsCell`-backed, so `&self`
-        // is sufficient and `noalias` is suppressed. `ScopedRef` brackets the
+        // is sufficient and `noalias` is suppressed. `RefPtr` brackets the
         // JS-re-entrant `run_callback` so a re-entrant `deref()` cannot free
         // `*self` mid-body.
         let _deref = self.ref_guard();
@@ -234,7 +234,7 @@ impl PostgresSQLQuery {
     }
 
     pub(crate) fn on_js_error(&self, err: JSValue, global_object: &JSGlobalObject) {
-        // R-2: see `on_write_fail` — `&self` + Cell/JsCell, ScopedRef brackets re-entry.
+        // R-2: see `on_write_fail` — `&self` + Cell/JsCell, RefPtr brackets re-entry.
         let _deref = self.ref_guard();
         self.status.set(Status::Fail);
         let Some(this_value) = self.this_value.get().try_get() else {
@@ -291,7 +291,7 @@ impl PostgresSQLQuery {
         connection: JSValue,
         is_last: bool,
     ) {
-        // R-2: see `on_write_fail` — `&self` + Cell/JsCell, ScopedRef brackets re-entry.
+        // R-2: see `on_write_fail` — `&self` + Cell/JsCell, RefPtr brackets re-entry.
         let _deref = self.ref_guard();
         self.status.set(if is_last {
             Status::Success

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -8,7 +8,7 @@ use crate::jsc::{
 use crate::shared::query_ctor_args::QueryCtorArgs;
 use bun_core::String as BunString;
 use bun_jsc::JsCell;
-use bun_ptr::AsCtxPtr;
+use bun_ptr::{AsCtxPtr, RefPtr};
 
 use super::PostgresSQLConnection;
 use super::PostgresSQLStatement;
@@ -127,15 +127,11 @@ impl PostgresSQLQuery {
         self.flags.set(v);
     }
 
-    /// RAII `ref()`/`deref()` bracket around `self`. One audited
-    /// `RefPtr::init_ref` here replaces N per-site
-    /// `unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }` — `&self` is the live
-    /// `heap::alloc` payload (held by the connection's request FIFO), so the
-    /// [`RefPtr::init_ref`] precondition (live, non-null) is always satisfied.
+    /// Hold a ref on `self` for the guard's lifetime (across re-entrant calls).
     #[inline]
-    pub(crate) fn ref_guard(&self) -> bun_ptr::RefPtr<Self> {
-        // SAFETY: `&self` ⇒ the allocation is live and non-null.
-        unsafe { bun_ptr::RefPtr::init_ref(self.as_ctx_ptr()) }
+    pub(crate) fn ref_guard(&self) -> RefPtr<Self> {
+        // SAFETY: `self` is the live heap allocation.
+        unsafe { RefPtr::init_ref(self.as_ctx_ptr()) }
     }
 
     /// Dereference the intrusive `statement` pointer as `&mut`. Mirrors
@@ -201,7 +197,7 @@ impl PostgresSQLQuery {
         // is sufficient and `noalias` is suppressed. `RefPtr` brackets the
         // JS-re-entrant `run_callback` so a re-entrant `deref()` cannot free
         // `*self` mid-body.
-        let _deref = self.ref_guard();
+        let _guard = self.ref_guard();
         self.status.set(Status::Fail);
         let Some(this_value) = self.this_value.get().try_get() else {
             return;
@@ -235,7 +231,7 @@ impl PostgresSQLQuery {
 
     pub(crate) fn on_js_error(&self, err: JSValue, global_object: &JSGlobalObject) {
         // R-2: see `on_write_fail` — `&self` + Cell/JsCell, RefPtr brackets re-entry.
-        let _deref = self.ref_guard();
+        let _guard = self.ref_guard();
         self.status.set(Status::Fail);
         let Some(this_value) = self.this_value.get().try_get() else {
             return;
@@ -292,7 +288,7 @@ impl PostgresSQLQuery {
         is_last: bool,
     ) {
         // R-2: see `on_write_fail` — `&self` + Cell/JsCell, RefPtr brackets re-entry.
-        let _deref = self.ref_guard();
+        let _guard = self.ref_guard();
         self.status.set(if is_last {
             Status::Success
         } else {

--- a/src/sql_jsc/postgres/PostgresSQLStatement.rs
+++ b/src/sql_jsc/postgres/PostgresSQLStatement.rs
@@ -120,7 +120,5 @@ impl Drop for PostgresSQLStatement {
         // `fields` (Vec<FieldDescription>): each element's Drop runs, then the buffer frees.
         // `parameters` (Box<[int4]>): freed by Drop.
         // `cached_structure`, `error_response`, `signature`: Drop.
-        // `bun.default_allocator.destroy(this)`: handled by `bun_ptr::RefPtr` dealloc,
-        // not here — Drop must not free `self`'s storage.
     }
 }

--- a/src/sql_jsc/postgres/PostgresSQLStatement.rs
+++ b/src/sql_jsc/postgres/PostgresSQLStatement.rs
@@ -13,9 +13,6 @@ use bun_sql::postgres::postgres_types::int4;
 
 bun_core::declare_scope!(Postgres, visible);
 
-// `bun.ptr.RefCount(@This(), "ref_count", deinit, .{})` — intrusive single-thread refcount.
-// Ported as an embedded `Cell<u32>` driven by `bun_ptr::RefPtr<PostgresSQLStatement>`;
-// `ref`/`deref` are provided by `RefPtr`, not as inherent methods.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct PostgresSQLStatement {
     pub(crate) cached_structure: PostgresCachedStructure,

--- a/src/sql_jsc/postgres/PostgresSQLStatement.rs
+++ b/src/sql_jsc/postgres/PostgresSQLStatement.rs
@@ -14,8 +14,8 @@ use bun_sql::postgres::postgres_types::int4;
 bun_core::declare_scope!(Postgres, visible);
 
 // `bun.ptr.RefCount(@This(), "ref_count", deinit, .{})` — intrusive single-thread refcount.
-// Ported as an embedded `Cell<u32>` driven by `bun_ptr::IntrusiveRc<PostgresSQLStatement>`;
-// `ref`/`deref` are provided by `IntrusiveRc`, not as inherent methods.
+// Ported as an embedded `Cell<u32>` driven by `bun_ptr::RefPtr<PostgresSQLStatement>`;
+// `ref`/`deref` are provided by `RefPtr`, not as inherent methods.
 #[derive(bun_ptr::CellRefCounted)]
 pub struct PostgresSQLStatement {
     pub(crate) cached_structure: PostgresCachedStructure,
@@ -123,7 +123,7 @@ impl Drop for PostgresSQLStatement {
         // `fields` (Vec<FieldDescription>): each element's Drop runs, then the buffer frees.
         // `parameters` (Box<[int4]>): freed by Drop.
         // `cached_structure`, `error_response`, `signature`: Drop.
-        // `bun.default_allocator.destroy(this)`: handled by `bun_ptr::IntrusiveRc` dealloc,
+        // `bun.default_allocator.destroy(this)`: handled by `bun_ptr::RefPtr` dealloc,
         // not here — Drop must not free `self`'s storage.
     }
 }

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -63,12 +63,12 @@
     "unsafe impl Send": [
       "Blob",
       "Bytes",
-      "StoreRef"
+      "Store"
     ],
     "unsafe impl Sync": [
       "Blob",
       "Bytes",
-      "StoreRef"
+      "Store"
     ]
   },
   "src/runtime/api/JSTranspiler.rs": {

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1953,7 +1953,8 @@ describe("s3 upload stream body error", () => {
             );
           }
           if (req.method === "PUT") {
-            received += (await req.arrayBuffer()).byteLength;
+            const { byteLength } = await req.arrayBuffer();
+            received += byteLength;
             return new Response(undefined, { status: 200, headers: { ETag: '"etag"' } });
           }
           if (req.method === "POST" && url.search.includes("uploadId")) {


### PR DESCRIPTION
### What does this PR do?

`RefPtr<T>` (bun_ptr's owned handle to an intrusively refcounted `T`) previously had no `Drop`, so every holder released its ref by hand — `.deref()` inside `Drop` impls, take-then-deref at every early return, and a dozen one-off guard newtypes (`StoreRef`, `ScopedRef`, `StaticRouteRef`, `FileSinkRef`, `DerefOnDrop`, …) whose only job was to add the missing `Drop`. Forgetting one leaked; doing it twice was a use-after-free. This makes `RefPtr` behave like `Arc`: dropping releases the ref, `Clone` takes one, `into_raw`/`from_raw` move a ref across raw-pointer/FFI boundaries, and it is `Send`/`Sync` when `T` is. No runtime cost change — the same decrement happens at the same points, and `RefPtr` is now a `#[repr(transparent)] NonNull<T>` in every profile (the debug-only per-ref tracking it carried was write-only and is deleted; the refcount's use-after-destroy canary stays).

On top of that:
- One owning-ref type with one API (`new`/`init_ref`/`from_this`/`from_raw`/`into_raw`/`this_ptr`/`into_this_ptr`/`as_ptr`/`as_non_null`). `ScopedRef`, the `IntrusiveRc` alias, `ThisPtr::ref_guard`, `dupe_ref`, `data()`, and the hand-rolled newtypes above (`StoreRef`, `StaticRouteRef`, `FileSinkRef`/`FileSinkPtr`, `DerefOnDrop`, `ResolverRefGuard`, `Scheduler`/`WatcherRefGuard`, `RefDataPtr`) are folded into it; `HTTPContext.h2_session`, h3 `PendingConnect.session`, subprocess `Writable::Pipe`, and h2 `SignalRef.parser` hold a `RefPtr` instead of a raw pointer + manual deref. Types that take a keep-alive ref on `&self` all spell it `self.ref_guard()`.
- The unused `DestructorCtx` associated type is removed from the refcount traits.
- `WeakPtr` releases on `Drop` (its manual `deref()` is gone).
- `JsCell::set` writes first and drops the old value after (matching `Cell::set`), so a field whose `Drop` re-enters or frees the owner is sound.
- ~60 manual `.deref()` sites, `AnyRoute::deref_`, and several `Drop`/`finalize` bodies that existed only to release a ref are deleted.
- Pre-existing, fixed while here: the install security scanner over-released its JSON pipe writer when `start()` failed (use-after-free on that error path), and on Windows its errdefer closed the uv pipe a second time after the writer already owned it.
- `s3.test.ts`: fix a racy `received += await …` accumulator that under-counted when two part uploads overlapped.

First step of replacing manual `deinit`/`deref` teardown with ownership + `Drop` across the Rust tree; converting the remaining raw `*mut T` holders of refcounted types to `RefPtr` follows separately.

### How did you verify your code works?

`cargo check --workspace` + clippy for linux-gnu/musl, windows, darwin, freebsd, android. Debug build + targeted suites covering every touched holder: blob/Bun.file/Bun.write, serve static/file/html/routes + reload, body-leak, WebSocket client (incl. proxy tunnel), fetch keep-alive/http2/proxy/SSL-ctx eviction, spawn stdin/stdout, shell, FileSink, cron, dns, `fs.watchFile`, TLS upgrade/duplex, node http2, S3 multipart, archive, security scanner, bake dev server, `bun:test` done-callback/expect — all pass.
