### PR TITLE
test: validate LeakSanitizer on the REPL tests

### DIFF
--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -37,9 +37,7 @@ test/cli/install/bun-pack.test.ts
 test/cli/install/bun-pm-pkg.test.ts
 test/cli/install/bun-pm-version.test.ts
 test/cli/install/bun-pm.test.ts
-test/cli/install/bun-repl.test.ts
 test/cli/run/filter-workspace.test.ts
-test/js/bun/repl/repl.test.ts
 test/cli/install/bun-update.test.ts
 test/cli/install/bun-workspaces.test.ts
 test/cli/install/bunx.test.ts


### PR DESCRIPTION
### Problem
- `test/no-validate-leaksan.txt` lists `test/js/bun/repl/repl.test.ts` (line 42) since the REPL landed in fa3a30f075. On the ASAN lane a listed file runs without LeakSanitizer and, per `scripts/runner.node.mjs:1149-1156`, outside the parallel bucket. That is why the file ran on its own there (10.5s in build 105417) while the default lane ran it in a batch in 0.64s.
- Line 40 names `test/cli/install/bun-repl.test.ts`, a file that no longer exists.

### Fix
- Remove both entries. The REPL tests then run with `detect_leaks=1` and `BUN_DESTRUCT_VM_ON_EXIT=1` like the rest of the suite, and the file becomes a candidate for the ASAN lane's parallel bucket.
- Verified: the file passes under the runner's exact LSAN environment (`ASAN_OPTIONS=...:detect_leaks=1:abort_on_error=1`, `LSAN_OPTIONS` with `test/leaksan.supp`, `BUN_DESTRUCT_VM_ON_EXIT=1`, `BUN_JSC_validateExceptionChecks=1`) with a debug+ASAN build: 178 of 178 tests on main, 127 of 127 on #40449.

### Background
- `no-validate-leaksan.txt` is the list of test files the runner does not leak-check on ASAN builds. `shouldValidateLeakSan` in `scripts/runner.node.mjs` reads it, and `isBucketCandidate` requires it to be true before a file may join the parallel bucket.
- The env above is what the runner sets for every leak-checked file. The spawned `bun repl` children inherit it through `bunEnv`, so LeakSanitizer runs at each child's exit.
- Companion to #40449, which speeds up the file itself. This PR is kept separate so a leak report on the ASAN lane blocks only this change.
