### PR TITLE
Bun.serve: keep Request.url and Request.headers readable after a synchronous response

### DIFF
--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -2,10 +2,12 @@
 //! Only really exists because of `NewServer()` and `NewRequestContext()` generics.
 
 use core::ffi::{c_uint, c_void};
+use core::ptr::NonNull;
 
 use bun_uws as uws;
 
 use crate::webcore::CookieMap;
+use crate::webcore::request_head::RequestHeadSnapshot;
 
 pub use super::request_context::AdditionalOnAbortCallback;
 use super::request_context::RequestContext;
@@ -40,6 +42,9 @@ pub enum CtxTag {
     HttpsMux,
     DebugHttpMux,
     DebugHttpsMux,
+    /// The context finished while JS may still hold the `Request`: `ptr` is the
+    /// [`RequestHeadSnapshot`] its lazy `url`/`headers` getters read instead.
+    Head,
 }
 
 #[derive(Copy, Clone)]
@@ -53,6 +58,34 @@ impl AnyRequestContext {
         tag: CtxTag::None,
         ptr: core::ptr::null_mut(),
     };
+
+    /// The `Request` that stores this owns the snapshot and frees it with [`Self::take_head`].
+    pub(crate) fn head(snapshot: RequestHeadSnapshot) -> Self {
+        Self {
+            tag: CtxTag::Head,
+            ptr: snapshot.into_raw().as_ptr().cast::<()>(),
+        }
+    }
+
+    pub(crate) fn get_head(&self) -> Option<&RequestHeadSnapshot> {
+        if self.tag != CtxTag::Head {
+            return None;
+        }
+        // SAFETY: `RequestHeadSnapshot` is `repr(transparent)` over the non-null
+        // pointer `head()` stored in `ptr`.
+        Some(unsafe { &*core::ptr::from_ref(&self.ptr).cast::<RequestHeadSnapshot>() })
+    }
+
+    pub(crate) fn take_head(&mut self) -> Option<RequestHeadSnapshot> {
+        if self.tag != CtxTag::Head {
+            return None;
+        }
+        let ptr = NonNull::new(self.ptr.cast::<u8>())?;
+        *self = Self::NULL;
+        // SAFETY: `ptr` came from `into_raw` in `head()`, and the slot is cleared
+        // above so it is taken back exactly once.
+        Some(unsafe { RequestHeadSnapshot::from_raw(ptr) })
+    }
 }
 
 /// Internal: maps each `RequestContext` monomorphization to its tag so
@@ -114,7 +147,7 @@ macro_rules! dispatch {
             }};
         }
         match this.tag {
-            CtxTag::None => $default,
+            CtxTag::None | CtxTag::Head => $default,
             CtxTag::Http => arm!(HttpCtx),
             CtxTag::Https => arm!(HttpsCtx),
             CtxTag::DebugHttp => arm!(DebugHttpCtx),
@@ -138,7 +171,7 @@ macro_rules! dispatch {
             }};
         }
         match this.tag {
-            CtxTag::None => $default,
+            CtxTag::None | CtxTag::Head => $default,
             CtxTag::Http => arm!(HttpCtx),
             CtxTag::Https => arm!(HttpsCtx),
             CtxTag::DebugHttp => arm!(DebugHttpCtx),
@@ -162,6 +195,9 @@ impl AnyRequestContext {
     }
 
     pub(crate) fn memory_cost(self) -> usize {
+        if let Some(head) = self.get_head() {
+            return head.memory_cost();
+        }
         dispatch!(self, 0, |_T, ctx| ctx.memory_cost())
     }
 

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -44,7 +44,6 @@ pub enum CtxTag {
     DebugHttpsMux,
     /// The context finished; `ptr` is the [`RequestHeadSnapshot`] the lazy getters read instead.
     Head,
-    Head,
 }
 
 #[derive(Copy, Clone)]

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -42,8 +42,8 @@ pub enum CtxTag {
     HttpsMux,
     DebugHttpMux,
     DebugHttpsMux,
-    /// The context finished while JS may still hold the `Request`: `ptr` is the
-    /// [`RequestHeadSnapshot`] its lazy `url`/`headers` getters read instead.
+    /// The context finished; `ptr` is the [`RequestHeadSnapshot`] the lazy getters read instead.
+    Head,
     Head,
 }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1538,7 +1538,6 @@ where
             // `req` is live only while the dispatch is still on the stack.
             if !HTTP3 {
                 if let Some(req) = self.req.get() {
-                    // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
                     request.snapshot_request_head(bun_opaque::opaque_deref(
                         req.cast::<uws::Request>(),
                     ));

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1536,7 +1536,7 @@ where
 
         if let Some(request) = self.request_mut() {
             // `req` is live only while the dispatch is still on the stack.
-            let req = if HTTP3 { None } else { self.req.get() };
+            let req = if MUX { None } else { self.req.get() };
             request.detach_request_context(
                 req.map(|req| bun_opaque::opaque_deref(req.cast::<uws::Request>())),
             );

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1536,14 +1536,10 @@ where
 
         if let Some(request) = self.request_mut() {
             // `req` is live only while the dispatch is still on the stack.
-            if !HTTP3 {
-                if let Some(req) = self.req.get() {
-                    request.snapshot_request_head(bun_opaque::opaque_deref(
-                        req.cast::<uws::Request>(),
-                    ));
-                }
-            }
-            request.request_context = AnyRequestContext::NULL;
+            let req = if HTTP3 { None } else { self.req.get() };
+            request.detach_request_context(
+                req.map(|req| bun_opaque::opaque_deref(req.cast::<uws::Request>())),
+            );
             self.request_weakref.set(request::WeakRef::EMPTY);
         }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1535,9 +1535,7 @@ where
         drop(self.cookies.replace(None));
 
         if let Some(request) = self.request_mut() {
-            // `req` is still set only while the dispatch is on the stack (a handler
-            // that responded synchronously). JS may still hold the `Request`, so
-            // keep what its lazy `url`/`headers` getters read from the uWS request.
+            // `req` is live only while the dispatch is still on the stack.
             if !HTTP3 {
                 if let Some(req) = self.req.get() {
                     // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1535,6 +1535,17 @@ where
         drop(self.cookies.replace(None));
 
         if let Some(request) = self.request_mut() {
+            // `req` is still set only while the dispatch is on the stack (a handler
+            // that responded synchronously). JS may still hold the `Request`, so
+            // keep what its lazy `url`/`headers` getters read from the uWS request.
+            if !HTTP3 {
+                if let Some(req) = self.req.get() {
+                    // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
+                    request.snapshot_request_head(bun_opaque::opaque_deref(
+                        req.cast::<uws::Request>(),
+                    ));
+                }
+            }
             request.request_context = AnyRequestContext::NULL;
             self.request_weakref.set(request::WeakRef::EMPTY);
         }

--- a/src/runtime/webcore.rs
+++ b/src/runtime/webcore.rs
@@ -220,6 +220,9 @@ pub use response::Response;
 pub mod request;
 pub use request::Request;
 
+#[path = "webcore/request_head.rs"]
+pub(crate) mod request_head;
+
 #[path = "webcore/ReadableStream.rs"]
 pub mod readable_stream;
 pub use readable_stream::ReadableStream;

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -258,8 +258,7 @@ impl Request {
     /// already read both. (An async handler gets both built eagerly instead, in
     /// `RequestContext::to_async`.)
     pub(crate) fn snapshot_request_head(&self, req: &uws::Request) {
-        if self.head.get().is_some()
-            || (!self.url.get().is_empty() && self.headers.get().is_some())
+        if self.head.get().is_some() || (!self.url.get().is_empty() && self.headers.get().is_some())
         {
             return;
         }
@@ -428,7 +427,11 @@ impl Request {
         core::mem::size_of::<Request>()
             + self.request_context.memory_cost()
             + self.url.get().byte_slice().len()
-            + self.head.get().as_ref().map_or(0, RequestHeadSnapshot::memory_cost)
+            + self
+                .head
+                .get()
+                .as_ref()
+                .map_or(0, RequestHeadSnapshot::memory_cost)
             + self.body_value().memory_cost()
     }
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -243,7 +243,6 @@ impl Request {
     /// `None` for a `Request` built by JS.
     fn request_head(&self) -> Option<RequestHead<'_>> {
         if let Some(req) = self.request_context.get_request() {
-            // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
             return Some(RequestHead::Uws(bun_opaque::opaque_deref(req)));
         }
         self.head.get().as_ref().map(RequestHead::Snapshot)

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -5,8 +5,10 @@ use core::ptr::NonNull;
 use std::borrow::Cow;
 
 use bun_jsc::JsCell;
+use bun_uws as uws;
 use enumset::EnumSet;
 
+use super::request_head::RequestHeadSnapshot;
 use super::response::HeadersRef;
 use crate::api::AnyRequestContext;
 use crate::webcore::BlobExt as _;
@@ -84,6 +86,10 @@ pub struct Request {
     pub(crate) url: JsCell<BunString>,
 
     headers: JsCell<Option<HeadersRef>>,
+    /// Copy of the uWS request head, taken by the server when that request goes
+    /// out of scope before JS read `url` or `headers`. The lazy getters fall back
+    /// to it once `request_context` no longer has a live uWS request.
+    head: JsCell<Option<RequestHeadSnapshot>>,
     // AbortSignal is an opaque C++ handle with intrusive WebCore refcounting —
     // `Arc` of an opaque ZST is meaningless (its payload address is not the
     // C++ object). `AbortSignalRef` wraps `NonNull<AbortSignal>` and routes
@@ -236,6 +242,30 @@ impl Request {
         self.headers.set(headers);
     }
 
+    /// Where the lazy `url`/`headers` getters read the request head from, for a
+    /// `Request` that `Bun.serve` created. `None` for a `Request` built by JS.
+    fn request_head(&self) -> Option<RequestHead<'_>> {
+        if let Some(req) = self.request_context.get_request() {
+            // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
+            return Some(RequestHead::Uws(bun_opaque::opaque_deref(req)));
+        }
+        self.head.get().as_ref().map(RequestHead::Snapshot)
+    }
+
+    /// The server calls this when a handler responded synchronously and the uWS
+    /// request `request_context` points at is about to go out of scope. Copies
+    /// what the lazy `url`/`headers` getters still need from it, unless JS
+    /// already read both. (An async handler gets both built eagerly instead, in
+    /// `RequestContext::to_async`.)
+    pub(crate) fn snapshot_request_head(&self, req: &uws::Request) {
+        if self.head.get().is_some()
+            || (!self.url.get().is_empty() && self.headers.get().is_some())
+        {
+            return;
+        }
+        self.head.set(Some(RequestHeadSnapshot::capture(req)));
+    }
+
     /// Returns the headers of the request. If the headers are not already cached, it will create a new FetchHeaders object.
     /// If the headers are empty, it will look at request_context to get the headers.
     /// If the headers are empty and request_context is null, it will create an empty FetchHeaders object.
@@ -249,11 +279,8 @@ impl Request {
             return Ok(self.headers_mut().as_mut().unwrap());
         }
 
-        if let Some(req) = self.request_context.get_request() {
-            // we have a request context, so we can get the headers from it
-            self.headers.set(Some(HeadersRef::create_from_uws(
-                req.cast::<core::ffi::c_void>(),
-            )));
+        if let Some(head) = self.request_head() {
+            self.headers.set(Some(head.to_fetch_headers()));
         } else {
             // we don't have a request context, so we need to create an empty headers object
             self.headers.set(Some(HeadersRef::create_empty()));
@@ -298,11 +325,8 @@ impl Request {
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn get_fetch_headers_unless_empty(&self) -> Option<&mut HeadersRef> {
         if self.headers.get().is_none() {
-            if let Some(req) = self.request_context.get_request() {
-                // we have a request context, so we can get the headers from it
-                self.headers.set(Some(HeadersRef::create_from_uws(
-                    req.cast::<core::ffi::c_void>(),
-                )));
+            if let Some(head) = self.request_head() {
+                self.headers.set(Some(head.to_fetch_headers()));
             }
         }
 
@@ -323,10 +347,8 @@ impl Request {
         global_this: &JSGlobalObject,
     ) -> JsResult<Option<HeadersRef>> {
         if self.headers.get().is_none() {
-            if let Some(uws_req) = self.request_context.get_request() {
-                self.headers.set(Some(HeadersRef::create_from_uws(
-                    uws_req.cast::<core::ffi::c_void>(),
-                )));
+            if let Some(head) = self.request_head() {
+                self.headers.set(Some(head.to_fetch_headers()));
             }
         }
 
@@ -342,10 +364,8 @@ impl Request {
     }
 
     pub(crate) fn get_content_type(&self) -> JsResult<Option<bun_core::Utf8Bytes<'_>>> {
-        if let Some(req) = self.request_context.get_request() {
-            // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
-            let req = bun_opaque::opaque_deref(req);
-            if let Some(value) = req.header(b"content-type") {
+        if let Some(head) = self.request_head() {
+            if let Some(value) = head.header(b"content-type") {
                 return Ok(Some(bun_core::Utf8Bytes::Borrowed(value)));
             }
         }
@@ -367,11 +387,48 @@ impl Request {
     }
 }
 
+/// The request head a `Bun.serve` `Request` reads `url` and `headers` from.
+enum RequestHead<'a> {
+    /// The uWS request. Live only while the server dispatch is on the stack.
+    Uws(&'a uws::Request),
+    /// The copy the server took when that dispatch ended.
+    Snapshot(&'a RequestHeadSnapshot),
+}
+
+impl<'a> RequestHead<'a> {
+    /// The request target from the request line (path and query).
+    fn target(&self) -> &'a [u8] {
+        match *self {
+            Self::Uws(req) => req.url(),
+            Self::Snapshot(head) => head.target(),
+        }
+    }
+
+    fn header(&self, lowercase_name: &[u8]) -> Option<&'a [u8]> {
+        match *self {
+            Self::Uws(req) => req.header(lowercase_name),
+            Self::Snapshot(head) => head.header(lowercase_name),
+        }
+    }
+
+    fn to_fetch_headers(&self) -> HeadersRef {
+        match *self {
+            Self::Uws(req) => HeadersRef::create_from_uws(
+                core::ptr::from_ref::<uws::Request>(req)
+                    .cast_mut()
+                    .cast::<core::ffi::c_void>(),
+            ),
+            Self::Snapshot(head) => head.to_fetch_headers(),
+        }
+    }
+}
+
 impl Request {
     pub(crate) fn memory_cost(&self) -> usize {
         core::mem::size_of::<Request>()
             + self.request_context.memory_cost()
             + self.url.get().byte_slice().len()
+            + self.head.get().as_ref().map_or(0, RequestHeadSnapshot::memory_cost)
             + self.body_value().memory_cost()
     }
 
@@ -423,6 +480,7 @@ impl Request {
         Request {
             url: JsCell::new(url),
             headers: JsCell::new(headers),
+            head: JsCell::new(None),
             signal: JsCell::new(None),
             body: ManuallyDrop::new(body),
             js_ref: JsCell::new(JsRef::empty()),
@@ -708,6 +766,7 @@ impl Request {
     pub(crate) fn finalize_without_deinit(&mut self) {
         // headers.deref() → HeadersRef::Drop when set to None
         self.headers.set(None);
+        self.head.set(None);
 
         self.url.set(BunString::EMPTY);
 
@@ -771,12 +830,10 @@ impl Request {
             return url.byte_slice().len();
         }
 
-        if let Some(req) = self.request_context.get_request() {
-            // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
-            let req = bun_opaque::opaque_deref(req);
-            let req_url = Self::request_target_path(req.url());
+        if let Some(head) = self.request_head() {
+            let req_url = Self::request_target_path(head.target());
             if !req_url.is_empty() && req_url[0] == b'/' {
-                if let Some(host) = req
+                if let Some(host) = head
                     .header(b"host")
                     .filter(|host| Self::is_valid_host_header(host))
                 {
@@ -863,12 +920,10 @@ impl Request {
             return Ok(());
         }
 
-        if let Some(req) = self.request_context.get_request() {
-            // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
-            let req = bun_opaque::opaque_deref(req);
-            let req_url = Self::request_target_path(req.url());
+        if let Some(head) = self.request_head() {
+            let req_url = Self::request_target_path(head.target());
             if !req_url.is_empty() && req_url[0] == b'/' {
-                if let Some(host) = req
+                if let Some(host) = head
                     .header(b"host")
                     .filter(|host| Self::is_valid_host_header(host))
                 {
@@ -987,6 +1042,7 @@ impl Request {
         let mut req = Request {
             url: JsCell::new(BunString::EMPTY),
             headers: JsCell::new(None),
+            head: JsCell::new(None),
             signal: JsCell::new(None),
             body: ManuallyDrop::new(body),
             js_ref: JsCell::new(JsRef::init_weak(this_value)),
@@ -1494,6 +1550,7 @@ impl Request {
                 Request {
                     url: JsCell::new(url),
                     headers: JsCell::new(headers),
+                    head: JsCell::new(None),
                     signal: JsCell::new(None),
                     body: ManuallyDrop::new(body),
                     js_ref: JsCell::new(JsRef::empty()),
@@ -1520,6 +1577,7 @@ impl Request {
         let mut req = Box::new(Request {
             url: JsCell::new(BunString::EMPTY),
             headers: JsCell::new(None),
+            head: JsCell::new(None),
             signal: JsCell::new(None),
             // `clone_into` `ptr::write`s the whole struct without dropping the
             // sentinel; seed with a non-deref'd dangling handle. `ManuallyDrop`
@@ -1552,6 +1610,7 @@ impl Request {
         Request {
             url: JsCell::new(BunString::EMPTY),
             headers: JsCell::new(None),
+            head: JsCell::new(None),
             signal: JsCell::new(signal),
             body: ManuallyDrop::new(body),
             js_ref: JsCell::new(JsRef::empty()),

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -249,8 +249,7 @@ impl Request {
         self.head.get().as_ref().map(RequestHead::Snapshot)
     }
 
-    /// Copies what the lazy `url`/`headers` getters still need from `req` before
-    /// the server dispatch that owns it returns. A no-op once JS read both.
+    /// Keeps what the lazy `url`/`headers` getters still need from `req`. A no-op once JS read both.
     pub(crate) fn snapshot_request_head(&self, req: &uws::Request) {
         if self.head.get().is_some() || (!self.url.get().is_empty() && self.headers.get().is_some())
         {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -246,8 +246,7 @@ impl Request {
         self.request_context.get_head().map(RequestHead::Snapshot)
     }
 
-    /// Ends the link to the server context. When the uWS request is still live and JS has
-    /// not read both `url` and `headers`, a copy of its head takes the context's place.
+    /// Ends the link to the server context; `req`, when still live, is copied for the lazy getters.
     pub(crate) fn detach_request_context(&mut self, req: Option<&uws::Request>) {
         drop(self.request_context.take_head());
         self.request_context = match req {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -86,8 +86,6 @@ pub struct Request {
     pub(crate) url: JsCell<BunString>,
 
     headers: JsCell<Option<HeadersRef>>,
-    /// Source for the lazy `url`/`headers` getters once the uWS request is gone.
-    head: JsCell<Option<RequestHeadSnapshot>>,
     // AbortSignal is an opaque C++ handle with intrusive WebCore refcounting —
     // `Arc` of an opaque ZST is meaningless (its payload address is not the
     // C++ object). `AbortSignalRef` wraps `NonNull<AbortSignal>` and routes
@@ -245,16 +243,19 @@ impl Request {
         if let Some(req) = self.request_context.get_request() {
             return Some(RequestHead::Uws(bun_opaque::opaque_deref(req)));
         }
-        self.head.get().as_ref().map(RequestHead::Snapshot)
+        self.request_context.get_head().map(RequestHead::Snapshot)
     }
 
-    /// Keeps what the lazy `url`/`headers` getters still need from `req`. A no-op once JS read both.
-    pub(crate) fn snapshot_request_head(&self, req: &uws::Request) {
-        if self.head.get().is_some() || (!self.url.get().is_empty() && self.headers.get().is_some())
-        {
-            return;
-        }
-        self.head.set(Some(RequestHeadSnapshot::capture(req)));
+    /// Ends the link to the server context. When the uWS request is still live and JS has
+    /// not read both `url` and `headers`, a copy of its head takes the context's place.
+    pub(crate) fn detach_request_context(&mut self, req: Option<&uws::Request>) {
+        drop(self.request_context.take_head());
+        self.request_context = match req {
+            Some(req) if self.url.get().is_empty() || self.headers.get().is_none() => {
+                AnyRequestContext::head(RequestHeadSnapshot::capture(req))
+            }
+            _ => AnyRequestContext::NULL,
+        };
     }
 
     /// Returns the headers of the request. If the headers are not already cached, it will create a new FetchHeaders object.
@@ -419,11 +420,6 @@ impl Request {
         core::mem::size_of::<Request>()
             + self.request_context.memory_cost()
             + self.url.get().byte_slice().len()
-            + self
-                .head
-                .get()
-                .as_ref()
-                .map_or(0, RequestHeadSnapshot::memory_cost)
             + self.body_value().memory_cost()
     }
 
@@ -475,7 +471,6 @@ impl Request {
         Request {
             url: JsCell::new(url),
             headers: JsCell::new(headers),
-            head: JsCell::new(None),
             signal: JsCell::new(None),
             body: ManuallyDrop::new(body),
             js_ref: JsCell::new(JsRef::empty()),
@@ -761,7 +756,7 @@ impl Request {
     pub(crate) fn finalize_without_deinit(&mut self) {
         // headers.deref() → HeadersRef::Drop when set to None
         self.headers.set(None);
-        self.head.set(None);
+        drop(self.request_context.take_head());
 
         self.url.set(BunString::EMPTY);
 
@@ -778,6 +773,8 @@ impl Request {
         // hot-path `Box::from_raw().drop()` below cannot re-run this.
         // SAFETY: `this` is live and this is the sole release point for `body`.
         unsafe { ManuallyDrop::drop(&mut this.body) };
+        // `AnyRequestContext` is `Copy`, so the drop glue below cannot free the head copy.
+        drop(this.request_context.take_head());
         if this.weak_ptr_data.on_finalize() {
             // Hot path: no outstanding weak refs. Reclaim and drop the whole
             // allocation in one shot — `Box::from_raw`'s drop runs
@@ -1037,7 +1034,6 @@ impl Request {
         let mut req = Request {
             url: JsCell::new(BunString::EMPTY),
             headers: JsCell::new(None),
-            head: JsCell::new(None),
             signal: JsCell::new(None),
             body: ManuallyDrop::new(body),
             js_ref: JsCell::new(JsRef::init_weak(this_value)),
@@ -1545,7 +1541,6 @@ impl Request {
                 Request {
                     url: JsCell::new(url),
                     headers: JsCell::new(headers),
-                    head: JsCell::new(None),
                     signal: JsCell::new(None),
                     body: ManuallyDrop::new(body),
                     js_ref: JsCell::new(JsRef::empty()),
@@ -1572,7 +1567,6 @@ impl Request {
         let mut req = Box::new(Request {
             url: JsCell::new(BunString::EMPTY),
             headers: JsCell::new(None),
-            head: JsCell::new(None),
             signal: JsCell::new(None),
             // `clone_into` `ptr::write`s the whole struct without dropping the
             // sentinel; seed with a non-deref'd dangling handle. `ManuallyDrop`
@@ -1605,7 +1599,6 @@ impl Request {
         Request {
             url: JsCell::new(BunString::EMPTY),
             headers: JsCell::new(None),
-            head: JsCell::new(None),
             signal: JsCell::new(signal),
             body: ManuallyDrop::new(body),
             js_ref: JsCell::new(JsRef::empty()),

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -86,9 +86,7 @@ pub struct Request {
     pub(crate) url: JsCell<BunString>,
 
     headers: JsCell<Option<HeadersRef>>,
-    /// Copy of the uWS request head, taken by the server when that request goes
-    /// out of scope before JS read `url` or `headers`. The lazy getters fall back
-    /// to it once `request_context` no longer has a live uWS request.
+    /// Source for the lazy `url`/`headers` getters once the uWS request is gone.
     head: JsCell<Option<RequestHeadSnapshot>>,
     // AbortSignal is an opaque C++ handle with intrusive WebCore refcounting —
     // `Arc` of an opaque ZST is meaningless (its payload address is not the
@@ -242,8 +240,7 @@ impl Request {
         self.headers.set(headers);
     }
 
-    /// Where the lazy `url`/`headers` getters read the request head from, for a
-    /// `Request` that `Bun.serve` created. `None` for a `Request` built by JS.
+    /// `None` for a `Request` built by JS.
     fn request_head(&self) -> Option<RequestHead<'_>> {
         if let Some(req) = self.request_context.get_request() {
             // S008: `uws::Request` is an `opaque_ffi!` ZST handle — safe deref.
@@ -252,11 +249,8 @@ impl Request {
         self.head.get().as_ref().map(RequestHead::Snapshot)
     }
 
-    /// The server calls this when a handler responded synchronously and the uWS
-    /// request `request_context` points at is about to go out of scope. Copies
-    /// what the lazy `url`/`headers` getters still need from it, unless JS
-    /// already read both. (An async handler gets both built eagerly instead, in
-    /// `RequestContext::to_async`.)
+    /// Copies what the lazy `url`/`headers` getters still need from `req` before
+    /// the server dispatch that owns it returns. A no-op once JS read both.
     pub(crate) fn snapshot_request_head(&self, req: &uws::Request) {
         if self.head.get().is_some() || (!self.url.get().is_empty() && self.headers.get().is_some())
         {

--- a/src/runtime/webcore/request_head.rs
+++ b/src/runtime/webcore/request_head.rs
@@ -1,15 +1,7 @@
-//! An owned copy of an HTTP/1 request head: the request target and the header
-//! fields, in wire order.
-//!
-//! `Bun.serve` reads `Request.url` and `Request.headers` from the uWS request
-//! the first time JS asks for them. That request lives on the dispatch stack,
-//! so it is gone once the handler returns and the response is sent. When the
-//! dispatch ends before JS read them (a handler that returns a `Response`
-//! synchronously and logs `req.headers` from a `setTimeout`, for example), the
-//! server copies the head into a [`RequestHeadSnapshot`] and the getters read
-//! from that instead. Building a `FetchHeaders` is deferred to the first read,
-//! so the per-request cost for the common case (nobody reads them) is one
-//! allocation and one copy of the wire bytes.
+//! An owned copy of an HTTP/1 request head (target and header fields), taken
+//! when the uWS request a `Bun.serve` `Request` reads `url`/`headers` from is
+//! about to leave the stack. Parsing into a `FetchHeaders` waits for the first
+//! read, so a request nobody reads costs one allocation and one memcpy.
 
 use bun_core::strings;
 use bun_picohttp::Header as PicoHeader;
@@ -18,8 +10,7 @@ use bun_uws::Request as UwsRequest;
 use crate::webcore::FetchHeaders;
 use crate::webcore::response::HeadersRef;
 
-/// One allocation, filled by `uws_req_copy_head` (src/uws_sys/libuwsockets.cpp):
-/// a native-endian `u32` index, then the wire bytes the index points into.
+/// Filled by `uws_req_copy_head` (src/uws_sys/libuwsockets.cpp), native-endian:
 ///
 /// ```text
 /// u32 count                   header fields
@@ -56,8 +47,7 @@ impl RequestHeadSnapshot {
         (0..self.u32(0)).map(move |i| (self.view(3 + 4 * i), self.view(5 + 4 * i)))
     }
 
-    /// The value of the first field named `lowercase_name` (ASCII case-insensitive),
-    /// like `uws::Request::header`.
+    /// The first field named `lowercase_name`, ASCII case-insensitive.
     pub(crate) fn header(&self, lowercase_name: &[u8]) -> Option<&[u8]> {
         self.headers()
             .find(|(name, _)| {

--- a/src/runtime/webcore/request_head.rs
+++ b/src/runtime/webcore/request_head.rs
@@ -60,7 +60,9 @@ impl RequestHeadSnapshot {
     /// like `uws::Request::header`.
     pub(crate) fn header(&self, lowercase_name: &[u8]) -> Option<&[u8]> {
         self.headers()
-            .find(|(name, _)| strings::eql_case_insensitive_ascii_check_length(name, lowercase_name))
+            .find(|(name, _)| {
+                strings::eql_case_insensitive_ascii_check_length(name, lowercase_name)
+            })
             .map(|(_, value)| value)
     }
 

--- a/src/runtime/webcore/request_head.rs
+++ b/src/runtime/webcore/request_head.rs
@@ -9,8 +9,7 @@ use bun_uws::Request as UwsRequest;
 use crate::webcore::FetchHeaders;
 use crate::webcore::response::HeadersRef;
 
-/// Owns one allocation written by `uws_req_copy_head` (libuwsockets.cpp): the `u32` index below,
-/// then the wire bytes. A thin pointer, so it fits the `AnyRequestContext` slot of a `Request`.
+/// One allocation written by `uws_req_copy_head` (libuwsockets.cpp): the `u32` index below, then the wire bytes.
 #[repr(transparent)]
 pub(crate) struct RequestHeadSnapshot(NonNull<u8>);
 
@@ -40,8 +39,7 @@ impl RequestHeadSnapshot {
         core::mem::ManuallyDrop::new(self).0
     }
 
-    /// # Safety
-    /// `ptr` must come from [`Self::into_raw`] and not have been taken back already.
+    /// Safety: `ptr` comes from [`Self::into_raw`] and is taken back only once.
     pub(crate) unsafe fn from_raw(ptr: NonNull<u8>) -> Self {
         Self(ptr)
     }

--- a/src/runtime/webcore/request_head.rs
+++ b/src/runtime/webcore/request_head.rs
@@ -1,5 +1,7 @@
 //! The copy of a uWS request head that outlives the server dispatch, for `Request.url`/`.headers`.
 
+use core::ptr::NonNull;
+
 use bun_core::strings;
 use bun_picohttp::Header as PicoHeader;
 use bun_uws::Request as UwsRequest;
@@ -7,16 +9,17 @@ use bun_uws::Request as UwsRequest;
 use crate::webcore::FetchHeaders;
 use crate::webcore::response::HeadersRef;
 
-/// Written by `uws_req_copy_head` (libuwsockets.cpp): the `u32` index below, then the wire bytes.
-pub(crate) struct RequestHeadSnapshot {
-    bytes: Box<[u8]>,
-}
+/// Owns one allocation written by `uws_req_copy_head` (libuwsockets.cpp): the `u32` index below,
+/// then the wire bytes. A thin pointer, so it fits the `AnyRequestContext` slot of a `Request`.
+#[repr(transparent)]
+pub(crate) struct RequestHeadSnapshot(NonNull<u8>);
 
 const U32: usize = core::mem::size_of::<u32>();
 /// Index words. A view is an (offset into the wire bytes, length) pair of words.
-const COUNT_WORD: usize = 0;
-const TARGET_VIEW: usize = 1;
-const FIRST_FIELD_VIEW: usize = 3;
+const SIZE_WORD: usize = 0;
+const COUNT_WORD: usize = 1;
+const TARGET_VIEW: usize = 2;
+const FIRST_FIELD_VIEW: usize = 4;
 /// Name view, then value view.
 const WORDS_PER_FIELD: usize = 4;
 
@@ -26,11 +29,21 @@ impl RequestHeadSnapshot {
         let mut bytes = Box::<[u8]>::new_uninit_slice(size);
         let written = req.copy_head(&mut bytes);
         debug_assert_eq!(written, size);
-        Self {
-            // SAFETY: the head did not change between the two calls, so the
-            // second one filled all `size` bytes.
-            bytes: unsafe { bytes.assume_init() },
-        }
+        // SAFETY: the head did not change between the two calls, so the second
+        // one filled all `size` bytes.
+        let bytes: &mut [u8] = Box::leak(unsafe { bytes.assume_init() });
+        Self(NonNull::from(bytes).cast::<u8>())
+    }
+
+    /// Hands the allocation to a raw slot. [`Self::from_raw`] takes it back.
+    pub(crate) fn into_raw(self) -> NonNull<u8> {
+        core::mem::ManuallyDrop::new(self).0
+    }
+
+    /// # Safety
+    /// `ptr` must come from [`Self::into_raw`] and not have been taken back already.
+    pub(crate) unsafe fn from_raw(ptr: NonNull<u8>) -> Self {
+        Self(ptr)
     }
 
     /// The request target from the request line (path and query).
@@ -66,18 +79,43 @@ impl RequestHeadSnapshot {
     }
 
     pub(crate) fn memory_cost(&self) -> usize {
-        self.bytes.len()
+        self.size()
+    }
+
+    fn size(&self) -> usize {
+        // SAFETY: the allocation starts with its own size, written by `uws_req_copy_head`.
+        let word = unsafe {
+            self.0
+                .as_ptr()
+                .add(SIZE_WORD * U32)
+                .cast::<[u8; U32]>()
+                .read()
+        };
+        u32::from_ne_bytes(word) as usize
+    }
+
+    fn bytes(&self) -> &[u8] {
+        // SAFETY: `self.0` is the live `size()`-byte allocation `capture` leaked.
+        unsafe { core::slice::from_raw_parts(self.0.as_ptr(), self.size()) }
     }
 
     fn word(&self, i: usize) -> usize {
         let at = i * U32;
-        u32::from_ne_bytes(self.bytes[at..at + U32].try_into().unwrap()) as usize
+        u32::from_ne_bytes(self.bytes()[at..at + U32].try_into().unwrap()) as usize
     }
 
     fn view(&self, i: usize) -> &[u8] {
         let index_words = FIRST_FIELD_VIEW + WORDS_PER_FIELD * self.word(COUNT_WORD);
-        let wire = &self.bytes[U32 * index_words..];
+        let wire = &self.bytes()[U32 * index_words..];
         let (offset, len) = (self.word(i), self.word(i + 1));
         &wire[offset..offset + len]
+    }
+}
+
+impl Drop for RequestHeadSnapshot {
+    fn drop(&mut self) {
+        let size = self.size();
+        // SAFETY: reassembles the `Box<[u8]>` that `capture` leaked; this is its one owner.
+        drop(unsafe { Box::from_raw(core::ptr::slice_from_raw_parts_mut(self.0.as_ptr(), size)) });
     }
 }

--- a/src/runtime/webcore/request_head.rs
+++ b/src/runtime/webcore/request_head.rs
@@ -1,7 +1,4 @@
-//! An owned copy of an HTTP/1 request head (target and header fields), taken
-//! when the uWS request a `Bun.serve` `Request` reads `url`/`headers` from is
-//! about to leave the stack. Parsing into a `FetchHeaders` waits for the first
-//! read, so a request nobody reads costs one allocation and one memcpy.
+//! The copy of a uWS request head that outlives the server dispatch, for `Request.url`/`.headers`.
 
 use bun_core::strings;
 use bun_picohttp::Header as PicoHeader;
@@ -10,19 +7,18 @@ use bun_uws::Request as UwsRequest;
 use crate::webcore::FetchHeaders;
 use crate::webcore::response::HeadersRef;
 
-/// Filled by `uws_req_copy_head` (src/uws_sys/libuwsockets.cpp), native-endian:
-///
-/// ```text
-/// u32 count                   header fields
-/// u32 target[2]               offset, length
-/// u32 field[count][4]         name offset, name length, value offset, value length
-/// u8  block[]                 the wire bytes; offsets are relative to it
-/// ```
+/// Written by `uws_req_copy_head` (libuwsockets.cpp): the `u32` index below, then the wire bytes.
 pub(crate) struct RequestHeadSnapshot {
     bytes: Box<[u8]>,
 }
 
 const U32: usize = core::mem::size_of::<u32>();
+/// Index words. A view is an (offset into the wire bytes, length) pair of words.
+const COUNT_WORD: usize = 0;
+const TARGET_VIEW: usize = 1;
+const FIRST_FIELD_VIEW: usize = 3;
+/// Name view, then value view.
+const WORDS_PER_FIELD: usize = 4;
 
 impl RequestHeadSnapshot {
     pub(crate) fn capture(req: &UwsRequest) -> Self {
@@ -39,12 +35,15 @@ impl RequestHeadSnapshot {
 
     /// The request target from the request line (path and query).
     pub(crate) fn target(&self) -> &[u8] {
-        self.view(1)
+        self.view(TARGET_VIEW)
     }
 
     /// Header fields in wire order. Names keep their wire casing.
     pub(crate) fn headers(&self) -> impl Iterator<Item = (&[u8], &[u8])> {
-        (0..self.u32(0)).map(move |i| (self.view(3 + 4 * i), self.view(5 + 4 * i)))
+        (0..self.word(COUNT_WORD)).map(move |i| {
+            let name = FIRST_FIELD_VIEW + WORDS_PER_FIELD * i;
+            (self.view(name), self.view(name + 2))
+        })
     }
 
     /// The first field named `lowercase_name`, ASCII case-insensitive.
@@ -70,15 +69,15 @@ impl RequestHeadSnapshot {
         self.bytes.len()
     }
 
-    fn u32(&self, i: usize) -> usize {
+    fn word(&self, i: usize) -> usize {
         let at = i * U32;
         u32::from_ne_bytes(self.bytes[at..at + U32].try_into().unwrap()) as usize
     }
 
-    /// The bytes of the (offset, length) pair stored at index words `i` and `i + 1`.
     fn view(&self, i: usize) -> &[u8] {
-        let block = &self.bytes[U32 * (3 + 4 * self.u32(0))..];
-        let (offset, len) = (self.u32(i), self.u32(i + 1));
-        &block[offset..offset + len]
+        let index_words = FIRST_FIELD_VIEW + WORDS_PER_FIELD * self.word(COUNT_WORD);
+        let wire = &self.bytes[U32 * index_words..];
+        let (offset, len) = (self.word(i), self.word(i + 1));
+        &wire[offset..offset + len]
     }
 }

--- a/src/runtime/webcore/request_head.rs
+++ b/src/runtime/webcore/request_head.rs
@@ -1,0 +1,92 @@
+//! An owned copy of an HTTP/1 request head: the request target and the header
+//! fields, in wire order.
+//!
+//! `Bun.serve` reads `Request.url` and `Request.headers` from the uWS request
+//! the first time JS asks for them. That request lives on the dispatch stack,
+//! so it is gone once the handler returns and the response is sent. When the
+//! dispatch ends before JS read them (a handler that returns a `Response`
+//! synchronously and logs `req.headers` from a `setTimeout`, for example), the
+//! server copies the head into a [`RequestHeadSnapshot`] and the getters read
+//! from that instead. Building a `FetchHeaders` is deferred to the first read,
+//! so the per-request cost for the common case (nobody reads them) is one
+//! allocation and one copy of the wire bytes.
+
+use bun_core::strings;
+use bun_picohttp::Header as PicoHeader;
+use bun_uws::Request as UwsRequest;
+
+use crate::webcore::FetchHeaders;
+use crate::webcore::response::HeadersRef;
+
+/// One allocation, filled by `uws_req_copy_head` (src/uws_sys/libuwsockets.cpp):
+/// a native-endian `u32` index, then the wire bytes the index points into.
+///
+/// ```text
+/// u32 count                   header fields
+/// u32 target[2]               offset, length
+/// u32 field[count][4]         name offset, name length, value offset, value length
+/// u8  block[]                 the wire bytes; offsets are relative to it
+/// ```
+pub(crate) struct RequestHeadSnapshot {
+    bytes: Box<[u8]>,
+}
+
+const U32: usize = core::mem::size_of::<u32>();
+
+impl RequestHeadSnapshot {
+    pub(crate) fn capture(req: &UwsRequest) -> Self {
+        let size = req.copy_head(&mut []);
+        let mut bytes = Box::<[u8]>::new_uninit_slice(size);
+        let written = req.copy_head(&mut bytes);
+        debug_assert_eq!(written, size);
+        Self {
+            // SAFETY: the head did not change between the two calls, so the
+            // second one filled all `size` bytes.
+            bytes: unsafe { bytes.assume_init() },
+        }
+    }
+
+    /// The request target from the request line (path and query).
+    pub(crate) fn target(&self) -> &[u8] {
+        self.view(1)
+    }
+
+    /// Header fields in wire order. Names keep their wire casing.
+    pub(crate) fn headers(&self) -> impl Iterator<Item = (&[u8], &[u8])> {
+        (0..self.u32(0)).map(move |i| (self.view(3 + 4 * i), self.view(5 + 4 * i)))
+    }
+
+    /// The value of the first field named `lowercase_name` (ASCII case-insensitive),
+    /// like `uws::Request::header`.
+    pub(crate) fn header(&self, lowercase_name: &[u8]) -> Option<&[u8]> {
+        self.headers()
+            .find(|(name, _)| strings::eql_case_insensitive_ascii_check_length(name, lowercase_name))
+            .map(|(_, value)| value)
+    }
+
+    pub(crate) fn to_fetch_headers(&self) -> HeadersRef {
+        let list: Vec<PicoHeader> = self
+            .headers()
+            .map(|(name, value)| PicoHeader::new(name, value))
+            .collect();
+        // SAFETY: C++ allocates a new FetchHeaders with refcount 1 and copies
+        // every name and value before returning; never null.
+        unsafe { HeadersRef::adopt(FetchHeaders::create_from_pico_headers(&list)) }
+    }
+
+    pub(crate) fn memory_cost(&self) -> usize {
+        self.bytes.len()
+    }
+
+    fn u32(&self, i: usize) -> usize {
+        let at = i * U32;
+        u32::from_ne_bytes(self.bytes[at..at + U32].try_into().unwrap()) as usize
+    }
+
+    /// The bytes of the (offset, length) pair stored at index words `i` and `i + 1`.
+    fn view(&self, i: usize) -> &[u8] {
+        let block = &self.bytes[U32 * (3 + 4 * self.u32(0))..];
+        let (offset, len) = (self.u32(i), self.u32(i + 1));
+        &block[offset..offset + len]
+    }
+}

--- a/src/uws_sys/Request.rs
+++ b/src/uws_sys/Request.rs
@@ -91,9 +91,7 @@ impl Request {
         unsafe { bun_core::ffi::slice(ptr, len) }
     }
 
-    /// Copies the request target and header fields into `dest` (layout: see
-    /// `RequestHeadSnapshot`). Returns the size needed; writes nothing when
-    /// `dest` is smaller than that.
+    /// Returns the size the copy needs; writes it only when `dest` is at least that large.
     pub fn copy_head(&self, dest: &mut [core::mem::MaybeUninit<u8>]) -> usize {
         // SAFETY: the shim writes at most `dest.len()` bytes, into `dest`.
         unsafe { c::uws_req_copy_head(self, dest.as_mut_ptr().cast::<u8>(), dest.len()) }

--- a/src/uws_sys/Request.rs
+++ b/src/uws_sys/Request.rs
@@ -90,6 +90,16 @@ impl Request {
         // ffi::slice tolerates the (null, 0) shape uWS returns when no parameter is present.
         unsafe { bun_core::ffi::slice(ptr, len) }
     }
+
+    /// Copies the request target and every header field (wire order, wire
+    /// casing) into `dest`, in the layout `uws_req_copy_head` documents in
+    /// libuwsockets.cpp. Returns the size the copy needs. When that is more
+    /// than `dest.len()`, nothing is written; call again with a buffer of the
+    /// returned size.
+    pub fn copy_head(&self, dest: &mut [core::mem::MaybeUninit<u8>]) -> usize {
+        // SAFETY: the shim writes at most `dest.len()` bytes, into `dest`.
+        unsafe { c::uws_req_copy_head(self, dest.as_mut_ptr().cast::<u8>(), dest.len()) }
+    }
 }
 
 mod c {
@@ -115,5 +125,6 @@ mod c {
             dest: &mut *const u8,
         ) -> usize;
         pub(super) safe fn uws_req_has_transfer_encoding(res: &Request) -> bool;
+        pub(super) fn uws_req_copy_head(res: &Request, dest: *mut u8, capacity: usize) -> usize;
     }
 }

--- a/src/uws_sys/Request.rs
+++ b/src/uws_sys/Request.rs
@@ -91,11 +91,9 @@ impl Request {
         unsafe { bun_core::ffi::slice(ptr, len) }
     }
 
-    /// Copies the request target and every header field (wire order, wire
-    /// casing) into `dest`, in the layout `uws_req_copy_head` documents in
-    /// libuwsockets.cpp. Returns the size the copy needs. When that is more
-    /// than `dest.len()`, nothing is written; call again with a buffer of the
-    /// returned size.
+    /// Copies the request target and header fields into `dest` (layout: see
+    /// `RequestHeadSnapshot`). Returns the size needed; writes nothing when
+    /// `dest` is smaller than that.
     pub fn copy_head(&self, dest: &mut [core::mem::MaybeUninit<u8>]) -> usize {
         // SAFETY: the shim writes at most `dest.len()` bytes, into `dest`.
         unsafe { c::uws_req_copy_head(self, dest.as_mut_ptr().cast::<u8>(), dest.len()) }

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1499,7 +1499,7 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
       extend(value);
     }
     size_t blockLength = (size_t)(blockEnd - blockBegin);
-    size_t needed = sizeof(uint32_t) * (3 + 4 * (size_t)count) + blockLength;
+    size_t needed = sizeof(uint32_t) * (4 + 4 * (size_t)count) + blockLength;
     if (needed > capacity)
     {
       return needed;
@@ -1515,6 +1515,7 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
       putU32(view.data() ? (uint32_t)(view.data() - blockBegin) : 0);
       putU32((uint32_t)view.length());
     };
+    putU32((uint32_t)needed);
     putU32(count);
     putView(target);
     for (auto [key, value] : *uwsReq)

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1470,6 +1470,79 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
     return uwsReq->getHasTransferEncoding();
   }
 
+  /* Copies the request head into `dest` for `RequestHeadSnapshot`
+   * (src/runtime/webcore/request_head.rs), which reads this layout:
+   *
+   *   uint32_t count;                                 header fields
+   *   uint32_t target[2];                             offset, length
+   *   uint32_t field[count][4];                       name offset, name length,
+   *                                                   value offset, value length
+   *   char block[];                                   the wire bytes from the
+   *                                                   request target through the
+   *                                                   last header value
+   *
+   * Offsets are relative to `block`. The parser stores every name and value as
+   * a view into one receive buffer, in wire order, so one memcpy of that range
+   * is the whole copy. Returns the size the copy needs and writes nothing when
+   * that is more than `capacity`. */
+  size_t uws_req_copy_head(uws_req_t *res, char *dest, size_t capacity)
+  {
+    uWS::HttpRequest *uwsReq = (uWS::HttpRequest *)res;
+    std::string_view target = uwsReq->getFullUrl();
+    const char *blockBegin = target.data();
+    const char *blockEnd = target.data() + target.length();
+    uint32_t count = 0;
+    auto extend = [&](std::string_view view) {
+      if (view.data() == nullptr)
+      {
+        return;
+      }
+      if (view.data() < blockBegin)
+      {
+        blockBegin = view.data();
+      }
+      if (view.data() + view.length() > blockEnd)
+      {
+        blockEnd = view.data() + view.length();
+      }
+    };
+    for (auto [key, value] : *uwsReq)
+    {
+      count++;
+      extend(key);
+      extend(value);
+    }
+    size_t blockLength = (size_t)(blockEnd - blockBegin);
+    size_t needed = sizeof(uint32_t) * (3 + 4 * (size_t)count) + blockLength;
+    if (needed > capacity)
+    {
+      return needed;
+    }
+
+    /* `dest` is byte-aligned, so every uint32_t goes through memcpy. */
+    auto putU32 = [&dest](uint32_t value) {
+      memcpy(dest, &value, sizeof(value));
+      dest += sizeof(value);
+    };
+    auto putView = [&](std::string_view view) {
+      /* An absent value reads as an empty one at offset 0. */
+      putU32(view.data() ? (uint32_t)(view.data() - blockBegin) : 0);
+      putU32((uint32_t)view.length());
+    };
+    putU32(count);
+    putView(target);
+    for (auto [key, value] : *uwsReq)
+    {
+      putView(key);
+      putView(value);
+    }
+    if (blockLength > 0)
+    {
+      memcpy(dest, blockBegin, blockLength);
+    }
+    return needed;
+  }
+
   us_socket_t *uws_res_upgrade(int ssl, uws_res_r res, void *data,
                              const char *sec_web_socket_key,
                              size_t sec_web_socket_key_length,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1470,10 +1470,7 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
     return uwsReq->getHasTransferEncoding();
   }
 
-  /* Writes the layout `RequestHeadSnapshot` (src/runtime/webcore/request_head.rs)
-   * documents: a uint32_t index, then one memcpy of the wire bytes every
-   * name and value is a view into. Returns the size needed; writes nothing
-   * when that exceeds `capacity`. */
+  /* The writer for `RequestHeadSnapshot` (src/runtime/webcore/request_head.rs). */
   size_t uws_req_copy_head(uws_req_t *res, char *dest, size_t capacity)
   {
     uWS::HttpRequest *uwsReq = (uWS::HttpRequest *)res;

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1470,21 +1470,10 @@ size_t uws_req_get_header(uws_req_t *res, const char *lower_case_header,
     return uwsReq->getHasTransferEncoding();
   }
 
-  /* Copies the request head into `dest` for `RequestHeadSnapshot`
-   * (src/runtime/webcore/request_head.rs), which reads this layout:
-   *
-   *   uint32_t count;                                 header fields
-   *   uint32_t target[2];                             offset, length
-   *   uint32_t field[count][4];                       name offset, name length,
-   *                                                   value offset, value length
-   *   char block[];                                   the wire bytes from the
-   *                                                   request target through the
-   *                                                   last header value
-   *
-   * Offsets are relative to `block`. The parser stores every name and value as
-   * a view into one receive buffer, in wire order, so one memcpy of that range
-   * is the whole copy. Returns the size the copy needs and writes nothing when
-   * that is more than `capacity`. */
+  /* Writes the layout `RequestHeadSnapshot` (src/runtime/webcore/request_head.rs)
+   * documents: a uint32_t index, then one memcpy of the wire bytes every
+   * name and value is a view into. Returns the size needed; writes nothing
+   * when that exceeds `capacity`. */
   size_t uws_req_copy_head(uws_req_t *res, char *dest, size_t capacity)
   {
     uWS::HttpRequest *uwsReq = (uWS::HttpRequest *)res;

--- a/test/js/bun/http/bun-serve-headers.test.ts
+++ b/test/js/bun/http/bun-serve-headers.test.ts
@@ -160,3 +160,158 @@ describe("response Connection: close closes the socket", () => {
     }
   });
 });
+
+// `Request.url` and `Request.headers` are read from the uWS request the first
+// time JS asks for them. That request only lives while the handler dispatch is
+// on the stack. A handler that responded synchronously used to leave a Request
+// that read back as url "" and an empty Headers once the dispatch ended, so a
+// deferred log hook saw nothing (an async handler that awaited I/O was fine).
+describe("Request.url and Request.headers after the handler returned", () => {
+  const requestHeaders = { "user-agent": "UA/1", cookie: "a=1; b=2", "x-custom": "custom-value" };
+
+  // Reads the request from a timer: the dispatch that created it has returned by then.
+  function readLater(req: Request) {
+    const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
+    setTimeout(() => {
+      // The copies read url/headers through the same lazy path as the original.
+      const clone = req.clone();
+      const copy = new Request(req);
+      const copyWithInit = new Request(req, { method: "POST" });
+      resolve({
+        url: req.url,
+        headers: Object.fromEntries(req.headers),
+        ua: req.headers.get("user-agent"),
+        clone: [clone.url, clone.headers.get("user-agent")],
+        copy: [copy.url, copy.headers.get("user-agent")],
+        copyWithInit: [copyWithInit.url, copyWithInit.method, copyWithInit.headers.get("user-agent")],
+        inspectHasUa: Bun.inspect(req).includes("UA/1"),
+      });
+    }, 0);
+    return promise;
+  }
+
+  const handlers: Record<string, (req: Request) => Response | Promise<Response> | undefined> = {
+    "returns a Response": () => new Response("ok"),
+    "returns Promise.resolve(Response)": () => Promise.resolve(new Response("ok")),
+    "resumes from a microtask": async () => {
+      await 0;
+      return new Response("ok");
+    },
+    "awaits a timer": async () => {
+      await Bun.sleep(1);
+      return new Response("ok");
+    },
+    "returns undefined": () => undefined,
+    "throws": () => {
+      throw new Error("boom");
+    },
+  };
+
+  describe.each([false, true])("development: %p", development => {
+    for (const [name, handler] of Object.entries(handlers)) {
+      test(`fetch handler ${name}`, async () => {
+        let later: Promise<Record<string, unknown>> | undefined;
+        let expectedHeaders: Record<string, string> | undefined;
+        using server = Bun.serve({
+          port: 0,
+          development,
+          fetch(req) {
+            if (!later) {
+              later = readLater(req);
+              return handler(req) as Response;
+            }
+            // Control request: a synchronous read of the same headers.
+            expectedHeaders = Object.fromEntries(req.headers);
+            return new Response("control");
+          },
+          error() {
+            return new Response("handled", { status: 500 });
+          },
+        });
+
+        const url = `${server.url}path?q=1`;
+        await (await fetch(url, { headers: requestHeaders })).text();
+        await (await fetch(url, { headers: requestHeaders })).text();
+
+        expect(await later!).toEqual({
+          url,
+          headers: expectedHeaders!,
+          ua: "UA/1",
+          clone: [url, "UA/1"],
+          copy: [url, "UA/1"],
+          copyWithInit: [url, "POST", "UA/1"],
+          inspectHasUa: true,
+        });
+        expect(expectedHeaders!["x-custom"]).toBe("custom-value");
+      });
+    }
+
+    test("routes handler: url, params, headers and cookies", async () => {
+      let later: Promise<Record<string, unknown>> | undefined;
+      using server = Bun.serve({
+        port: 0,
+        development,
+        routes: {
+          "/r/:id": req => {
+            const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
+            later = promise;
+            setTimeout(() => {
+              resolve({
+                url: req.url,
+                id: req.params.id,
+                ua: req.headers.get("user-agent"),
+                cookieA: req.cookies.get("a"),
+                cookieB: req.cookies.get("b"),
+              });
+            }, 0);
+            return new Response("ok");
+          },
+        },
+        fetch: () => new Response("not found", { status: 404 }),
+      });
+
+      const url = `${server.url}r/42`;
+      await (await fetch(url, { headers: requestHeaders })).text();
+
+      expect(await later!).toEqual({ url, id: "42", ua: "UA/1", cookieA: "1", cookieB: "2" });
+    });
+  });
+
+  test("a retained Request never shows the next request on the same connection", async () => {
+    const requests: Request[] = [];
+    using server = Bun.serve({
+      port: 0,
+      development: false,
+      fetch(req) {
+        requests.push(req);
+        return new Response("ok");
+      },
+    });
+
+    const socket = net.connect(server.port, "127.0.0.1");
+    try {
+      socket.on("error", () => {});
+      await once(socket, "connect");
+      socket.write(
+        "GET /first HTTP/1.1\r\nHost: x\r\nX-Id: first\r\n\r\n" +
+          "GET /second HTTP/1.1\r\nHost: x\r\nX-Id: second\r\n\r\n",
+      );
+
+      let raw = "";
+      await new Promise<void>((resolve, reject) => {
+        socket.on("data", chunk => {
+          raw += chunk.toString("latin1");
+          if ((raw.match(/HTTP\/1\.1 200/g) ?? []).length >= 2) resolve();
+        });
+        socket.on("close", () => reject(new Error("server closed the connection")));
+      });
+    } finally {
+      socket.destroy();
+    }
+
+    expect(requests.map(req => [req.url, req.headers.get("x-id")])).toEqual([
+      ["http://x/first", "first"],
+      ["http://x/second", "second"],
+    ]);
+  });
+});


### PR DESCRIPTION
### Problem
- A `Bun.serve` handler that returns a `Response` synchronously leaves a `Request` whose `url` reads back as `""` and whose `headers` is empty once the dispatch ends. A `setTimeout` log hook, `req.clone()` or `new Request(req)` registered in the handler all see `url === ""`, 0 headers, `req.cookies.get()` null. No error. An async handler that awaited I/O was fine.
- `Request.url` and `Request.headers` are read from the uWS request on first access, and that request lives only while the dispatch is on the stack. `to_async()` copies both for async handlers (`RequestContext.rs:2285`). On the sync path the context finalizes inside the dispatch and `finalize_without_deinit` nulls `request.request_context` (`RequestContext.rs:1537`) with no copy.

### Fix
- `finalize_without_deinit` now calls `Request::detach_request_context` with the still live uWS request. When JS has not read both fields yet, the new `RequestHeadSnapshot` (`src/runtime/webcore/request_head.rs`) takes the context's place in the `request_context` tagged pointer (`CtxTag::Head`), so `Request` stays at 104 bytes. The snapshot is one allocation: a small offset index and one memcpy of the wire bytes, written by the new `uws_req_copy_head` shim.
- The lazy getters read through one `RequestHead` view that is either the live uWS request or the snapshot. `ensure_url`, `ensure_fetch_headers`, `clone_headers`, `get_content_type` and `size_of_url` all go through it, so `clone()` and `new Request(req)` are covered too. The `FetchHeaders` is still built on first read only.
- The async path is unchanged: `to_async` and `server.upgrade()` keep building url and headers eagerly (see Notes for why).
- Verified: `test/js/bun/http/bun-serve-headers.test.ts` (13 of 21 cases fail on 1.4.1, all pass with the fix). Also `websocket-server.test.ts` (upgrade cases), `bun-serve-routes`, `bun-serve-cookies`, `req-url-leak`, `serve-body-leak`, `test/js/web/request/`.

### Background
- `RequestContext` is the per-request server state. It owns the uWS response and a weak pointer to the Rust `Request`. The uWS request (`ctx.req`) is a pointer into the stack frame of the uWS dispatch, so it is only valid while that frame is live.
- `Request.request_context` is a tagged pointer back to the context. `get_request()` returns the uWS request through it, and `None` once the context detached or finalized. With this change a finalized context leaves the head copy behind in that slot; every other context call (`requestIP`, `timeout`) treats it like no context.
- `to_async()` runs when the handler did not finish the response synchronously. It materializes `url` and a `FetchHeaders` from the uWS request and detaches it. The sync path never reaches it.

<details><summary>Notes</summary>

Cost on the hot path. The snapshot runs once per synchronous request that did not read both `url` and `headers`. It is two FFI calls (size, then fill), one `malloc`, one memcpy of the head bytes and one `free` in the Request finalizer. Measured with a release build on this machine, a hello-world `fetch` handler, 16 keep-alive connections: 7.8 us/req of server CPU before, about +0.05 to +0.2 us/req after, inside the run-to-run noise (12 alternating pairs, SD 0.2 to 0.8 us). Building the `FetchHeaders` and URL eagerly instead costs about 1 us/req on the same setup, which is why the copy stays raw and the parse stays lazy.

Why the async path stays eager. A first version used the snapshot in `to_async()` and `server.upgrade()` too. Two things broke: `server.upgrade()` after an await reads the `Sec-WebSocket-*` headers straight from the materialized `FetchHeaders` (`server_body.rs:1857`), and `req-url-leak.test.ts` went from 395 MB to 686 MB under ASAN because the 15 KB URL per request moved from bmalloc (WTF::String, not instrumented) into the ASAN-quarantined Rust allocator. Both are fixable, but neither is this bug.

`server.requestIP(req)` from a timer returns `null` on the sync and the async path alike after the response completed. That matches the documented "request was closed" behavior and is not part of this change.

Pre-existing local failures, same on main in this container: `ServerWebSocket > send*` timeouts, `bun-server.test.ts` tests that connect to `localhost` (IPv6), `request-clone-leak.test.ts` timeouts under the debug build, `leaks-test.test.ts` `server.fetch(string)` (the fixture detects ASAN by the binary name `bun-asan`).
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-headers.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [440.88ms]
(pass) response Connection: close closes the socket > string body [392.07ms]
(pass) response Connection: close closes the socket > case-insensitive value [47.66ms]
(pass) response Connection: close closes the socket > token list [38.92ms]
(pass) response Connection: close closes the socket > streaming body [58.28ms]
(pass) response Connection: close closes the socket > keep-alive still the default [47.13ms]
174 |     const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
175 |     setTimeout(() => {
176 |       // The copies read url/headers through the same lazy path as the original.
177 |       const clone = req.clone();
178 |       const copy = new Request(req);
179 |       const copyWithInit = new Request(req, { method: "POST" });
                                 ^
error: Failed to construct 'Request': url is required.
      at <anonymous> (/workspace/bun/test/js
... (truncated)

release without fix: 13 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [12.37ms]
(pass) response Connection: close closes the socket > string body [7.04ms]
(pass) response Connection: close closes the socket > case-insensitive value [1.76ms]
(pass) response Connection: close closes the socket > token list [1.75ms]
(pass) response Connection: close closes the socket > streaming body [2.06ms]
(pass) response Connection: close closes the socket > keep-alive still the default [2.18ms]
174 |     const { promise, resolve } = Promise.withResolvers<Record<string, unknown>>();
175 |     setTimeout(() => {
176 |       // The copies read url/headers through the same lazy path as the original.
177 |       const clone = req.clone();
178 |       const copy = new Request(req);
179 |       const copyWithInit = new Request(req, { method: "POST" });
                                 ^
error: Failed to construct 'Request': url is required.
      at <anonymous> (/workspace/bun/test/js/bun/http/bun-serve-headers.test.ts:179:28)
(fail) Request.url and Request.headers after the handler returned > development: false > fetch handler returns a Response [2.85ms]
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-headers.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/http/bun-serve-headers.test.ts:
(pass) weird headers [378.01ms]
(pass) response Connection: close closes the socket > string body [384.38ms]
(pass) response Connection: close closes the socket > case-insensitive value [52.41ms]
(pass) response Connection: close closes the socket > token list [39.94ms]
(pass) response Connection: close closes the socket > streaming body [49.95ms]
(pass) response Connection: close closes the socket > keep-alive still the default [55.78ms]
(pass) Request.url and Request.headers after the handler returned > development: false > fetch handler returns a Response [71.71ms]
(pass) Request.url and Request.headers after the handler returned > development: false > fetch handler returns Promise.resolve(Response) [23.47ms]
(pass) Request.url and Request.headers after the handler returned > development: false > fetch handler resumes from a microtask [24.95ms]
(pass) Request.url and Request.headers after the handler returned > develop
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     91689d1f80
  features     baseline

23 deps, 129 codegen, 1172 objects in 665ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [7.00ms]
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1244] gen bindgenv2
[5/1244] gen .bind.ts → GeneratedBindings.cpp
[6/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [15.00ms]
[7/1244] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1244] fetch zlib
[zlib] up to date
[9/1244] fetch tinycc
[tinycc] up to date
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/AnyRequestContext.rs    |  39 +++++++-
 src/runtime/server/RequestContext.rs       |   6 +-
 src/runtime/webcore.rs                     |   3 +
 src/runtime/webcore/Request.rs             | 102 +++++++++++++------
 src/runtime/webcore/request_head.rs        | 119 ++++++++++++++++++++++
 src/uws_sys/Request.rs                     |   7 ++
 src/uws_sys/libuwsockets.cpp               |  60 +++++++++++
 test/js/bun/http/bun-serve-headers.test.ts | 155 +++++++++++++++++++++++++++++
 8 files changed, 460 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/server/AnyRequestContext.rs         2      2      0
src/runtime/server/RequestContext.rs           11      8      0
src/runtime/webcore.rs                          1      2      0
src/runtime/webcore/Request.rs                 17     21      0
src/runtime/webcore/request_head.rs             6     13      0
src/uws_sys/Request.rs                          6     12      0
src/uws_sys/libuwsockets.cpp                    7      9      0
test/js/bun/http/bun-serve-headers.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->
