### PR TITLE
Keep positionals in process.argv for node -e and -p emulation

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2926,18 +2926,10 @@ impl RunCommand {
         }
 
         if !ctx.runtime_options.eval.script.is_empty() {
-            // synthetic `[eval]` path under cwd
-            let mut entry_point_buf = [0u8; MAX_PATH_BYTES + EVAL_TRIGGER.len()];
-            let mut cwd_buf = PathBuffer::uninit();
-            let cwd = bun_core::getcwd_or_exe_dir(&mut cwd_buf);
-            let cwd_bytes = cwd.as_bytes();
-            let cwd_len = cwd_bytes.len();
-            entry_point_buf[..cwd_len].copy_from_slice(cwd_bytes);
-            entry_point_buf[cwd_len..cwd_len + EVAL_TRIGGER.len()].copy_from_slice(EVAL_TRIGGER);
-            let entry: Box<[u8]> = entry_point_buf[..cwd_len + EVAL_TRIGGER.len()]
-                .to_vec()
-                .into_boxed_slice();
-            return Self::boot(ctx, entry, None);
+            // Shares the synthetic `[eval]` entry point and the
+            // positionals-into-passthrough merge, so `node -e code foo bar`
+            // keeps `foo` in `process.argv` like Node does. #40482
+            return Self::exec_eval(ctx);
         }
 
         if ctx.positionals.is_empty() {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2926,9 +2926,7 @@ impl RunCommand {
         }
 
         if !ctx.runtime_options.eval.script.is_empty() {
-            // Shares the synthetic `[eval]` entry point and the
-            // positionals-into-passthrough merge, so `node -e code foo bar`
-            // keeps `foo` in `process.argv` like Node does. #40482
+            // exec_eval's positionals merge keeps `foo` in `node -e code foo`. #40482
             return Self::exec_eval(ctx);
         }
 

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -87,6 +87,21 @@ describe("fake node cli", () => {
     expect(fakeNodeRun(temp, ["-e", "console.log('pass')"]).stdout).toBe("pass");
   });
 
+  // #40482: positionals after the eval source must all reach process.argv
+  test("node -e keeps positionals in process.argv", () => {
+    using temp = tempDir("fake-node", {});
+    expect(
+      fakeNodeRun(temp, ["-e", "console.log(JSON.stringify(process.argv.slice(1)))", "foo", "bar"]).stdout,
+    ).toBe(JSON.stringify(["foo", "bar"]));
+  });
+
+  test("node -p keeps positionals in process.argv", () => {
+    using temp = tempDir("fake-node", {});
+    expect(fakeNodeRun(temp, ["-p", "JSON.stringify(process.argv.slice(1))", "foo", "bar"]).stdout).toBe(
+      JSON.stringify(["foo", "bar"]),
+    );
+  });
+
   test("process args work", () => {
     using temp = tempDir("fake-node", {
       "index.js": "console.log(JSON.stringify(process.argv.slice(1)))",

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -90,9 +90,9 @@ describe("fake node cli", () => {
   // #40482: positionals after the eval source must all reach process.argv
   test("node -e keeps positionals in process.argv", () => {
     using temp = tempDir("fake-node", {});
-    expect(
-      fakeNodeRun(temp, ["-e", "console.log(JSON.stringify(process.argv.slice(1)))", "foo", "bar"]).stdout,
-    ).toBe(JSON.stringify(["foo", "bar"]));
+    expect(fakeNodeRun(temp, ["-e", "console.log(JSON.stringify(process.argv.slice(1)))", "foo", "bar"]).stdout).toBe(
+      JSON.stringify(["foo", "bar"]),
+    );
   });
 
   test("node -p keeps positionals in process.argv", () => {

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -87,19 +87,20 @@ describe("fake node cli", () => {
     expect(fakeNodeRun(temp, ["-e", "console.log('pass')"]).stdout).toBe("pass");
   });
 
-  // #40482: positionals after the eval source must all reach process.argv
-  test("node -e keeps positionals in process.argv", () => {
+  // #40482: like node, `-e`/`-p` take no script positional, so everything
+  // after the code is process.argv. The first of them used to be dropped.
+  const argvExpr = "JSON.stringify(process.argv.slice(1))";
+  const logArgv = `console.log(${argvExpr})`;
+  test.each([
+    { args: ["-e", logArgv, "foo", "bar"], argv: ["foo", "bar"] },
+    { args: ["-e", logArgv, "foo"], argv: ["foo"] },
+    { args: ["-e", logArgv, "foo", "--flag", "bar"], argv: ["foo", "--flag", "bar"] },
+    { args: ["-e", logArgv], argv: [] },
+    { args: ["-p", argvExpr, "foo", "bar"], argv: ["foo", "bar"] },
+    { args: ["-pe", argvExpr, "foo", "bar"], argv: ["foo", "bar"] },
+  ])("node $args keeps every positional in process.argv", ({ args, argv }) => {
     using temp = tempDir("fake-node", {});
-    expect(fakeNodeRun(temp, ["-e", "console.log(JSON.stringify(process.argv.slice(1)))", "foo", "bar"]).stdout).toBe(
-      JSON.stringify(["foo", "bar"]),
-    );
-  });
-
-  test("node -p keeps positionals in process.argv", () => {
-    using temp = tempDir("fake-node", {});
-    expect(fakeNodeRun(temp, ["-p", "JSON.stringify(process.argv.slice(1))", "foo", "bar"]).stdout).toBe(
-      JSON.stringify(["foo", "bar"]),
-    );
+    expect(JSON.parse(fakeNodeRun(temp, args).stdout)).toEqual(argv);
   });
 
   test("process args work", () => {


### PR DESCRIPTION
### Problem
- When bun runs as `node` (an argv0 symlink, or `bun --bun node`), `node -e code foo bar` drops `foo`: `process.argv.slice(1)` is `["bar"]`. Node gives `["foo", "bar"]`. `-p` and `-pe` have the same bug.
- `Arguments::parse` puts the first positional in `ctx.positionals` and the rest in `ctx.passthrough` (`stop_after_positional_at: 1`, `src/runtime/cli/Arguments.rs:772`). The eval branch of `exec_as_if_node` (`src/runtime/cli/run_command.rs:2928`) booted from `passthrough` alone, so `ctx.positionals[0]` never reached `process.argv`.

### Fix
- Route the eval branch of `exec_as_if_node` through `Self::exec_eval`. It already merges `ctx.positionals` into `ctx.passthrough` and builds the same `cwd/[eval]` entry point. The branch was a copy of it minus the merge.
- Correct because `-e`/`-p` take no script positional, so everything after the code is `process.argv`. `bun -e` already takes this path. `node -e code` with no arguments and `node --interactive -e code` are unchanged.
- Verified: `test/cli/run/as-node.test.ts` gains six cases: `-e` with one, two, and flag-like arguments, `-e` with none, `-p`, `-pe`. The five with arguments fail on the released bun. All 17 tests in the file pass with this build. Also run: `test/cli/run/run-eval.test.ts` (45 pass) and the node emulation tests in `repl.test.ts` and `env.test.ts`.

### Background
- Bun emulates Node when `argv[0]` is `node`. `exec_as_if_node` is that entry path.
- An eval run has no real file. Bun boots a synthetic entry point named `cwd/[eval]`. `process.argv` comes from `ctx.passthrough`.
- The CLI parser collects non-flag arguments into `ctx.positionals` until it has `stop_after_positional_at` of them. The rest, flags included, stays in `ctx.passthrough`. For run-like commands the limit is 1 so flags after the script name belong to the script.

<details><summary>Notes</summary>

- #38556 carried the same one-line change with a wider test matrix. Its test cases are folded into this PR and that PR is closed in favour of this one.
- With a single argument (`node -e code foo`) the argument was lost entirely: `process.argv.slice(1)` was `[]`.
- The `bun -e` form of this bug was #12209 (closed). The pre-port Zig `execAsIfNode` had the same shape, so this is not a regression.
- Related node-CLI shapes in the same area, each tracked on its own: `node -` reading the script from stdin (#38566), a bare `--` being stripped from `process.argv` (#36684), `process.execArgv` not stopping at `-` / `--` (#38577).

</details>

Fixes #40482

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/as-node.test.ts
bun test v1.4.1 (861e9ae04)

test/cli/run/as-node.test.ts:
(pass) fake node cli > the node cli actually works [502.77ms]
(pass) fake node cli > doesnt resolve bins [386.20ms]
(pass) fake node cli > doesnt resolve scripts [393.41ms]
(pass) fake node cli > can run a script named run.js [448.55ms]
(pass) fake node cli > entrypoint file extension picking > picks tsx over any other ext [393.41ms]
(pass) fake node cli > entrypoint file extension picking > picks jsx over ts [383.87ms]
(pass) fake node cli > entrypoint file extension picking > picks mts over ts [521.30ms]
(pass) fake node cli > entrypoint file extension picking > picks ts over js/cjs/etc [378.64ms]
(pass) fake node cli > node -e  [449.79ms]
 98 |     { args: ["-e", logArgv], argv: [] },
 99 |     { args: ["-p", argvExpr, "foo", "bar"], argv: ["foo", "bar"] },
100 |     { args: ["-pe", argvExpr, "foo", "bar"], argv: ["foo", "bar"] },
101 |   ])("node $args keeps every positional in process.argv", ({ args, argv }) => {
102 |     using temp = tempDir(
... (truncated)

release without fix: 5 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/cli/run/as-node.test.ts:
(pass) fake node cli > the node cli actually works [10.80ms]
(pass) fake node cli > doesnt resolve bins [7.86ms]
(pass) fake node cli > doesnt resolve scripts [7.98ms]
(pass) fake node cli > can run a script named run.js [7.02ms]
(pass) fake node cli > entrypoint file extension picking > picks tsx over any other ext [7.09ms]
(pass) fake node cli > entrypoint file extension picking > picks jsx over ts [6.52ms]
(pass) fake node cli > entrypoint file extension picking > picks mts over ts [6.97ms]
(pass) fake node cli > entrypoint file extension picking > picks ts over js/cjs/etc [6.70ms]
(pass) fake node cli > node -e  [7.79ms]
 98 |     { args: ["-e", logArgv], argv: [] },
 99 |     { args: ["-p", argvExpr, "foo", "bar"], argv: ["foo", "bar"] },
100 |     { args: ["-pe", argvExpr, "foo", "bar"], argv: ["foo", "bar"] },
101 |   ])("node $args keeps every positional in process.argv", ({ args, argv }) => {
102 |     using temp = tempDir("fake-node", {});
103 |     expect(JSON.parse(fakeNodeRun(temp, args).stdout)).toEqual(argv);
                                                             ^
error: expect
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/as-node.test.ts
bun test v1.4.1 (861e9ae04)

test/cli/run/as-node.test.ts:
(pass) fake node cli > the node cli actually works [566.96ms]
(pass) fake node cli > doesnt resolve bins [456.79ms]
(pass) fake node cli > doesnt resolve scripts [378.22ms]
(pass) fake node cli > can run a script named run.js [383.72ms]
(pass) fake node cli > entrypoint file extension picking > picks tsx over any other ext [521.40ms]
(pass) fake node cli > entrypoint file extension picking > picks jsx over ts [382.95ms]
(pass) fake node cli > entrypoint file extension picking > picks mts over ts [383.45ms]
(pass) fake node cli > entrypoint file extension picking > picks ts over js/cjs/etc [380.95ms]
(pass) fake node cli > node -e  [382.21ms]
(pass) fake node cli > node [ "-e", "console.log(JSON.stringify(process.argv.slice(1)))", "foo", "bar" ] keeps every positional in process.argv [381.61ms]
(pass) fake node cli > node [ "-e", "console.log(JSON.stringify(process.argv.slice(1)))", "foo" ] keeps every positional in process.argv [454.49ms]
(pass) fak
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 619ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 116 exports (host=5, lazy=10, generic=101, rust=0); 242 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 13s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.1-canary.1+b44225786
[build] done
bun test v1.4.1-canary.1 (b44225786)

test/cli/run/as-node.test.ts:
(pass) fake node cli > the node cli actually works [12.74ms]
(pass) fake node cli > doesnt resolve bins [8.38ms]
(pass) fake node cli > doesnt resolve scripts [7.96ms]
(pass) fake node cli > can run a script named run.js [7.17ms]
(pass) fake node cli > entrypoint file extension picking > picks tsx over any other ext [7.85ms]
(pass) fake node cli > entrypo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/run_command.rs | 14 ++------------
 test/cli/run/as-node.test.ts   | 16 ++++++++++++++++
 2 files changed, 18 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/runtime/cli/run_command.rs      3      2      0
test/cli/run/as-node.test.ts        1      1      0
```

</details>

**root cause** · written by the author bot

The node emulation path in `exec_as_if_node` handled `--eval` with an inline copy of the eval boot logic that omitted one step from the shared `exec_eval` helper: merging the parsed positional arguments into the passthrough list before booting. As a result, the first positional after the eval source was left behind in `ctx.positionals` and never reached `process.argv`, so `node -e code foo bar` reported only `bar`. The fix deletes the duplicated block and delegates to `exec_eval`, whose positionals-to-passthrough merge forwards every argument, restoring Node-compatible `process.argv` contents.

<!-- robobun:evidence:end -->