### PR TITLE
Apply CLI and bunfig define to HTML bundles served by Bun.serve

### DIFF
--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -466,8 +466,7 @@ impl Route {
         config.define.put(b"import.meta.env.SSR", b"false")?;
         config.define.put(b"import.meta.env.STATIC", b"false")?;
 
-        // CLI `--define` and bunfig `[define]` apply first, then
-        // `[serve.static].define` so it wins on a conflicting key.
+        // `serve_define` is applied last so it wins on a conflicting key.
         for define in [&cli.args.define, &cli.args.serve_define]
             .into_iter()
             .flatten()

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -466,7 +466,12 @@ impl Route {
         config.define.put(b"import.meta.env.SSR", b"false")?;
         config.define.put(b"import.meta.env.STATIC", b"false")?;
 
-        if let Some(define) = &cli.args.serve_define {
+        // CLI `--define` and bunfig `[define]` apply first, then
+        // `[serve.static].define` so it wins on a conflicting key.
+        for define in [&cli.args.define, &cli.args.serve_define]
+            .into_iter()
+            .flatten()
+        {
             debug_assert_eq!(define.keys.len(), define.values.len());
             // `StringMap` exposes only put/insert (no bulk re-index);
             // profile if hot.

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -969,21 +969,17 @@ impl ServerConfig {
                         _ => {}
                     }
 
-                    // `[serve.static].define` wins over the top-level define on a conflicting key.
+                    // `serve_define` entries come last: `Define::insert` is
+                    // last-write-wins, so `[serve.static].define` beats the
+                    // top-level define on a conflicting key.
                     let define = match (o.define.as_ref(), o.serve_define.as_ref()) {
                         (None, None) => None,
                         (Some(define), None) => Some(define.clone()),
                         (None, Some(serve_define)) => Some(serve_define.clone()),
                         (Some(define), Some(serve_define)) => {
                             let mut merged = define.clone();
-                            for (k, v) in serve_define.keys.iter().zip(serve_define.values.iter()) {
-                                if let Some(i) = merged.keys.iter().position(|key| **key == **k) {
-                                    merged.values[i] = v.clone();
-                                } else {
-                                    merged.keys.push(k.clone());
-                                    merged.values.push(v.clone());
-                                }
-                            }
+                            merged.keys.extend(serve_define.keys.iter().cloned());
+                            merged.values.extend(serve_define.values.iter().cloned());
                             Some(merged)
                         }
                     };

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -978,11 +978,8 @@ impl ServerConfig {
                         (None, Some(serve_define)) => Some(serve_define.clone()),
                         (Some(define), Some(serve_define)) => {
                             let mut merged = define.clone();
-                            for (k, v) in
-                                serve_define.keys.iter().zip(serve_define.values.iter())
-                            {
-                                if let Some(i) = merged.keys.iter().position(|key| **key == **k)
-                                {
+                            for (k, v) in serve_define.keys.iter().zip(serve_define.values.iter()) {
+                                if let Some(i) = merged.keys.iter().position(|key| **key == **k) {
                                     merged.values[i] = v.clone();
                                 } else {
                                     merged.keys.push(k.clone());

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -969,9 +969,7 @@ impl ServerConfig {
                         _ => {}
                     }
 
-                    // CLI `--define` and bunfig `[define]` apply to the
-                    // bundled graphs too; `[serve.static].define` wins on a
-                    // conflicting key.
+                    // `[serve.static].define` wins over the top-level define on a conflicting key.
                     let define = match (o.define.as_ref(), o.serve_define.as_ref()) {
                         (None, None) => None,
                         (Some(define), None) => Some(define.clone()),

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -969,10 +969,33 @@ impl ServerConfig {
                         _ => {}
                     }
 
-                    if let Some(define) = &o.serve_define {
+                    // CLI `--define` and bunfig `[define]` apply to the
+                    // bundled graphs too; `[serve.static].define` wins on a
+                    // conflicting key.
+                    let define = match (o.define.as_ref(), o.serve_define.as_ref()) {
+                        (None, None) => None,
+                        (Some(define), None) => Some(define.clone()),
+                        (None, Some(serve_define)) => Some(serve_define.clone()),
+                        (Some(define), Some(serve_define)) => {
+                            let mut merged = define.clone();
+                            for (k, v) in
+                                serve_define.keys.iter().zip(serve_define.values.iter())
+                            {
+                                if let Some(i) = merged.keys.iter().position(|key| **key == **k)
+                                {
+                                    merged.values[i] = v.clone();
+                                } else {
+                                    merged.keys.push(k.clone());
+                                    merged.values.push(v.clone());
+                                }
+                            }
+                            Some(merged)
+                        }
+                    };
+                    if let Some(define) = define {
                         user_options.bundler_options.client.define = define.clone();
                         user_options.bundler_options.server.define = define.clone();
-                        user_options.bundler_options.ssr.define = define.clone();
+                        user_options.bundler_options.ssr.define = define;
                     }
 
                     args.bake = Some(user_options);

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -969,9 +969,7 @@ impl ServerConfig {
                         _ => {}
                     }
 
-                    // `serve_define` entries come last: `Define::insert` is
-                    // last-write-wins, so `[serve.static].define` beats the
-                    // top-level define on a conflicting key.
+                    // Serve entries last; downstream `Define::insert` is last-write-wins.
                     let define = match (o.define.as_ref(), o.serve_define.as_ref()) {
                         (None, None) => None,
                         (Some(define), None) => Some(define.clone()),

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1580,3 +1580,59 @@ describe("production headers and import.meta.env", () => {
     expect(results).toEqual(cases.map(([, , expected]) => expected));
   });
 });
+
+// https://github.com/oven-sh/bun/issues/40479
+describe.concurrent("bunfig [define] applies to HTML bundles", () => {
+  // Serves an HTML import, fetches its script chunk, and returns the JS text.
+  async function run(development: string, bunfig: string): Promise<string> {
+    using dir = tempDir("html-define", {
+      "index.html": `<!DOCTYPE html><html><head><script type="module" src="./app.ts"></script></head><body></body></html>`,
+      "app.ts": `console.log("MARKER", BUILD_FLAG);`,
+      "bunfig.toml": bunfig,
+      "serve.ts": `
+        import app from "./index.html";
+        const server = Bun.serve({
+          port: 0,
+          development: ${development},
+          routes: { "/": app },
+          fetch: () => new Response("fallback"),
+        });
+        const html = await (await fetch(server.url)).text();
+        const src = html.match(/<script[^>]*src="([^"]+)"/)![1];
+        const js = await (await fetch(new URL(src, server.url))).text();
+        console.log(JSON.stringify({ js }));
+        await server.stop(true);
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "serve.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) throw new Error(stdout + "\n" + stderr);
+    return (JSON.parse(stdout) as { js: string }).js;
+  }
+
+  for (const development of ["true", "false"]) {
+    test(`development: ${development}: [define] replaces the identifier in the chunk`, async () => {
+      const js = await run(development, `[define]\nBUILD_FLAG = '"from-define"'`);
+      expect(js).toContain("MARKER");
+      expect(js).toContain('"from-define"');
+      expect(js).not.toContain("BUILD_FLAG");
+    });
+
+    test(`development: ${development}: [serve.static] define wins over [define]`, async () => {
+      const js = await run(
+        development,
+        `[define]\nBUILD_FLAG = '"from-define"'\n\n[serve.static.define]\nBUILD_FLAG = '"from-serve"'`,
+      );
+      expect(js).toContain("MARKER");
+      expect(js).toContain('"from-serve"');
+      expect(js).not.toContain('"from-define"');
+      expect(js).not.toContain("BUILD_FLAG");
+    });
+  }
+});

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1616,15 +1616,15 @@ describe.concurrent("bunfig [define] applies to HTML bundles", () => {
     return (JSON.parse(stdout) as { js: string }).js;
   }
 
-  for (const development of ["true", "false"]) {
-    test(`development: ${development}: [define] replaces the identifier in the chunk`, async () => {
+  describe.each(["true", "false"])("development: %s", development => {
+    test("[define] replaces the identifier in the chunk", async () => {
       const js = await run(development, `[define]\nBUILD_FLAG = '"from-define"'`);
       expect(js).toContain("MARKER");
       expect(js).toContain('"from-define"');
       expect(js).not.toContain("BUILD_FLAG");
     });
 
-    test(`development: ${development}: [serve.static] define wins over [define]`, async () => {
+    test("[serve.static] define wins over [define]", async () => {
       const js = await run(
         development,
         `[define]\nBUILD_FLAG = '"from-define"'\n\n[serve.static.define]\nBUILD_FLAG = '"from-serve"'`,
@@ -1634,5 +1634,5 @@ describe.concurrent("bunfig [define] applies to HTML bundles", () => {
       expect(js).not.toContain('"from-define"');
       expect(js).not.toContain("BUILD_FLAG");
     });
-  }
+  });
 });


### PR DESCRIPTION
### Problem

- A client bundle served by `Bun.serve` (an HTML import, or `bun index.html`) ignores the bunfig `[define]` table and the `--define`/`-d` flag. The identifier reaches the browser unreplaced and throws `ReferenceError: ENV_DEV is not defined` (#40479).
- The dev server path copies only `serve_define` into the per-graph bundler options (`src/runtime/server/ServerConfig.rs:972`). The static HTML bundle path does the same (`src/runtime/server/HTMLBundle.rs:469`). The top-level define never reaches either.

### Fix

- `ServerConfig.rs`: merge the top-level define with `[serve.static].define` before the copy into the client, server, and ssr bundler options. The serve table wins on a conflicting key.
- `HTMLBundle.rs`: put the top-level define entries into the build config first, then the `serve_define` entries. `StringMap::put` overwrites, so the serve table keeps precedence.
- This matches the docs for `[define]`: the substitution applies wherever the identifier appears. The runtime and `bun build` already behave this way.
- Verified: four new tests in `test/js/bun/http/bun-serve-html.test.ts` cover both paths and the precedence. Two fail on stock bun. The full file, `bun-serve-static.test.ts`, passes with the fix.

### Background

- `Bun.serve` bundles an imported HTML file on demand. With `development: true` the bake dev server serves it. With `development: false` the static `HTMLBundle` path runs one production build.
- Both paths build their own bundler config instead of using the runtime transpiler options, so each define source must be forwarded explicitly.
- `[serve.static].define` in bunfig is the serve-specific table. It already worked, and it keeps precedence over the top-level table.

<details><summary>Notes</summary>

- Repro: `index.html` loads `xx.ts` that reads `ENV_DEV`, bunfig has `[define] ENV_DEV = "true"`. `bun index.html`, then fetch `/_bun/client/index-*.js`: the chunk contains `console.log("ENV_DEV is", ENV_DEV)` on bun 1.4.1. With the fix it contains `console.log("ENV_DEV is", true)`.
- The same held for `development: false` through a `Bun.serve` route and for the `-d` flag, since the flag and the bunfig table land in the same `TransformOptions.define` map.
- The merge in `ServerConfig.rs` dedupes keys at the source instead of relying on last-wins insert order downstream.
- `bun-serve-html-entry.test.ts` has 5 failures in my container. They reproduce with the stock system bun without this diff (ConnectionRefused on localhost in the harness), so they are pre-existing environment noise.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.1 (861e9ae04)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_lLHtdu {
  "/": "/tmp/html-css-js_lLHtdu/index.html",
  "/dashboard": "/tmp/html-css-js_lLHtdu/dashboard.html",
}
[0.13ms] bundle index.html 1.09 KB
[0.09ms] bundle dashboard.html 1.27 KB
(pass) serve html [681.82ms]
waitForServer /tmp/bun-serve-html-txt_t0sU56 {
  "/": "/tmp/bun-serve-html-txt_t0sU56/index.html",
}
[0.18ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [669.52ms]
waitForServer /tmp/html-css-js-failing-plugin_BghFre {
  "/": "/tmp/html-css-js-failing-plugin_BghFre/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_BghFre/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_BghFre/styles.css:0
(pass) serve plugins > serve html with failing plugin [536.57ms]
waitForServer /tmp/html-css-js-empty-plugins_M9QytW {
  "/": "/tmp/html-css-js-empty-plugins_M9QytW/index.html",
}
[0.10ms] bu
... (truncated)

release without fix: all passed
bun test v1.4.1-canary.1 (88c933158)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_GqLJxP {
  "/": "/tmp/html-css-js_GqLJxP/index.html",
  "/dashboard": "/tmp/html-css-js_GqLJxP/dashboard.html",
}
[0.00ms] bundle index.html 1.09 KB
[0.00ms] bundle dashboard.html 1.27 KB
(pass) serve html [17.07ms]
waitForServer /tmp/bun-serve-html-txt_ISe28C {
  "/": "/tmp/bun-serve-html-txt_ISe28C/index.html",
}
[0.00ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [13.94ms]
waitForServer /tmp/html-css-js-failing-plugin_aYTYsd {
  "/": "/tmp/html-css-js-failing-plugin_aYTYsd/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_aYTYsd/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_aYTYsd/styles.css:0
(pass) serve plugins > serve html with failing plugin [12.95ms]
waitForServer /tmp/html-css-js-empty-plugins_hVuVmt {
  "/": "/tmp/html-css-js-empty-plugins_hVuVmt/index.html",
}
[0.00ms] bundle index.html 0.71 KB
(pass) serve plugins > empty plugin array [12.27ms]
Waiting for server
waitForServer /tmp/html-css-js-concurrent-plugins_f81aIm {
  "/": "/tmp/
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.1 (861e9ae04)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_KSFtXS {
  "/": "/tmp/html-css-js_KSFtXS/index.html",
  "/dashboard": "/tmp/html-css-js_KSFtXS/dashboard.html",
}
[0.10ms] bundle index.html 1.09 KB
[0.07ms] bundle dashboard.html 1.27 KB
(pass) serve html [775.66ms]
waitForServer /tmp/bun-serve-html-txt_VbfAbV {
  "/": "/tmp/bun-serve-html-txt_VbfAbV/index.html",
}
[0.14ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [714.26ms]
waitForServer /tmp/html-css-js-failing-plugin_0ANPBz {
  "/": "/tmp/html-css-js-failing-plugin_0ANPBz/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_0ANPBz/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_0ANPBz/styles.css:0
(pass) serve plugins > serve html with failing plugin [614.34ms]
waitForServer /tmp/html-css-js-empty-plugins_lRGipm {
  "/": "/tmp/html-css-js-empty-plugins_lRGipm/index.html",
}
[0.09ms] bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 638ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 116 exports (host=5, lazy=10, generic=101, rust=0); 242 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_pic
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/HTMLBundle.rs        |  6 +++-
 src/runtime/server/ServerConfig.rs      | 16 ++++++++--
 test/js/bun/http/bun-serve-html.test.ts | 56 +++++++++++++++++++++++++++++++++
 3 files changed, 75 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/server/HTMLBundle.rs             1      2      0
src/runtime/server/ServerConfig.rs           4      5      0
test/js/bun/http/bun-serve-html.test.ts      2      2      0
```

</details>

**root cause** · written by the author bot

When Bun.serve bundled HTML imports, the bundler options were constructed without the define entries from bunfig.toml, so identifiers declared under [define] were never substituted and surfaced at runtime as reference errors. The fix forwards the bunfig define map into the bundler configuration in both the development and production serve code paths, merging it so that [serve.static.define] entries take precedence over top-level [define] entries. As a result, defined identifiers are replaced with their configured values in the emitted chunks, which is verified by tests covering both develop…

<!-- robobun:evidence:end -->