### PR TITLE
test: stall the CompressionStream HTTP sink test with a raw socket, not fetch

### DIFF
--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -589,7 +589,13 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
   test("CompressionStream -> native HTTP sink applies backpressure to a stalled client", async () => {
     let pulls = 0;
     // Incompressible data so the gzipped output is ~as large as the input.
+    // Each pull stamps its sequence number into the first 4 bytes.
     const chunk = crypto.getRandomValues(new Uint8Array(64 * 1024));
+    const numbered = (n: number) => {
+      const data = Buffer.from(chunk);
+      data.writeUInt32BE(n, 0);
+      return data;
+    };
     // Backpressure parks after ~tens of pulls (a few MB of socket buffers /
     // 64KB); 200 is enough headroom to distinguish "parked" from "ran away"
     // without pushing ~32MB through gzip+HTTP under debug+ASAN.
@@ -602,7 +608,7 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
           pull(c) {
             pulls++;
             if (pulls === 1) onFirstPull();
-            c.enqueue(chunk.slice());
+            c.enqueue(numbered(pulls));
             if (pulls >= TOTAL) c.close();
           },
         });
@@ -658,7 +664,7 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
     }
     const out = zlib.gunzipSync(Buffer.concat(body));
     expect(out.byteLength).toBe(TOTAL * chunk.byteLength);
-    expect(out.equals(Buffer.concat(Array.from({ length: TOTAL }, () => chunk)))).toBe(true);
+    expect(out.equals(Buffer.concat(Array.from({ length: TOTAL }, (_, i) => numbered(i + 1))))).toBe(true);
   });
 
   test("request body -> DecompressionStream propagates backpressure to the client", async () => {

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -585,7 +585,7 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
   // client's untouched receive buffer (a few MB on Linux). A fetch() client
   // would not do: it reads ahead up to its high-water mark in fast bursts, and
   // TCP receive autotuning grows the receive window with every read, up to
-  // tcp_rmem[2] (32 MB since Linux 6.16), enough to hold this whole body.
+  // tcp_rmem[2] (32 MB since Linux 6.16), enough to hold this whole 12.8 MB body.
   test("CompressionStream -> native HTTP sink applies backpressure to a stalled client", async () => {
     let pulls = 0;
     // Incompressible data so the gzipped output is ~as large as the input.
@@ -597,8 +597,8 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
       return data;
     };
     // Backpressure parks after ~tens of pulls (a few MB of socket buffers /
-    // 64KB); 200 is enough headroom to distinguish "parked" from "ran away"
-    // without pushing ~32MB through gzip+HTTP under debug+ASAN.
+    // 64KB); 200 pulls (12.8 MB through gzip+HTTP) is enough headroom to
+    // distinguish "parked" from "ran away" and still quick under debug+ASAN.
     const TOTAL = 200;
     const { promise: firstPull, resolve: onFirstPull } = Promise.withResolvers<void>();
     await using server = Bun.serve({

--- a/test/js/web/streams/compression.test.ts
+++ b/test/js/web/streams/compression.test.ts
@@ -579,20 +579,29 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
   // (slow client), the transform arm's writeBytes returns a pending promise and
   // the writable side parks on m_nativeSinkReadyPromise. Without that, a fast
   // source with a stalled client fills the sink buffer unboundedly.
+  //
+  // The client is a raw socket that reads nothing until the stall is observed.
+  // What the kernel can then absorb is the server's send buffer plus the
+  // client's untouched receive buffer (a few MB on Linux). A fetch() client
+  // would not do: it reads ahead up to its high-water mark in fast bursts, and
+  // TCP receive autotuning grows the receive window with every read, up to
+  // tcp_rmem[2] (32 MB since Linux 6.16), enough to hold this whole body.
   test("CompressionStream -> native HTTP sink applies backpressure to a stalled client", async () => {
     let pulls = 0;
     // Incompressible data so the gzipped output is ~as large as the input.
     const chunk = crypto.getRandomValues(new Uint8Array(64 * 1024));
-    // Backpressure parks after ~tens of pulls (a few MB of socket+sink buffer /
+    // Backpressure parks after ~tens of pulls (a few MB of socket buffers /
     // 64KB); 200 is enough headroom to distinguish "parked" from "ran away"
     // without pushing ~32MB through gzip+HTTP under debug+ASAN.
     const TOTAL = 200;
+    const { promise: firstPull, resolve: onFirstPull } = Promise.withResolvers<void>();
     await using server = Bun.serve({
       port: 0,
       fetch() {
         const body = new ReadableStream({
           pull(c) {
             pulls++;
+            if (pulls === 1) onFirstPull();
             c.enqueue(chunk.slice());
             if (pulls >= TOTAL) c.close();
           },
@@ -600,19 +609,56 @@ describe("CompressionStream chunk handling (Node v26 semantics)", () => {
         return new Response(body.pipeThrough(new CompressionStream("gzip")));
       },
     });
-    const res = await fetch(server.url);
-    const reader = res.body!.getReader();
-    await reader.read();
+    const received: Buffer[] = [];
+    const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+    using socket = await Bun.connect({
+      hostname: server.hostname,
+      port: server.port,
+      socket: {
+        open(s) {
+          s.pause();
+          s.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+        },
+        data(_s, data) {
+          received.push(data);
+        },
+        close() {
+          onClose();
+        },
+      },
+    });
+    await firstPull;
     // Let the server's pull loop run until it either parks on backpressure or
     // runs away to TOTAL.
     await waitUntilStable(() => pulls, TOTAL);
     const pullsWhileStalled = pulls;
-    while (!(await reader.read()).done) {}
+    socket.resume();
+    await closed;
     // Without backpressure the pull loop reaches TOTAL while the client is
-    // stalled; with it, pulls stay bounded by the socket + sink buffer
+    // stalled; with it, pulls stay bounded by the socket buffers
     // (~a few MB / 64KB ≈ tens of pulls).
     expect(pullsWhileStalled).toBeLessThan(TOTAL);
     expect(pulls).toBe(TOTAL);
+
+    // The stall and the resume must not lose or reorder any output: de-chunk
+    // the response and compare the gunzipped body with the source.
+    const raw = Buffer.concat(received);
+    const headEnd = raw.indexOf("\r\n\r\n");
+    const head = raw.subarray(0, headEnd).toString();
+    expect(head).toStartWith("HTTP/1.1 200");
+    expect(head.toLowerCase()).toContain("transfer-encoding: chunked");
+    const body: Buffer[] = [];
+    for (let i = headEnd + 4; ; ) {
+      const sizeEnd = raw.indexOf("\r\n", i);
+      const size = parseInt(raw.subarray(i, sizeEnd).toString(), 16);
+      if (sizeEnd < 0 || Number.isNaN(size)) throw new Error(`malformed chunk framing at offset ${i}`);
+      if (size === 0) break;
+      body.push(raw.subarray(sizeEnd + 2, sizeEnd + 2 + size));
+      i = sizeEnd + 2 + size + 2;
+    }
+    const out = zlib.gunzipSync(Buffer.concat(body));
+    expect(out.byteLength).toBe(TOTAL * chunk.byteLength);
+    expect(out.equals(Buffer.concat(Array.from({ length: TOTAL }, () => chunk)))).toBe(true);
   });
 
   test("request body -> DecompressionStream propagates backpressure to the client", async () => {


### PR DESCRIPTION
### Problem
- `compression.test.ts > CompressionStream -> native HTTP sink applies backpressure to a stalled client` is red on main on the alpine 3.23 lanes since e4c2af4cef (#39690): `Expected: < 200`, `Received: 200` at `expect(pullsWhileStalled).toBeLessThan(TOTAL)`.
- The test counts server pulls while a `fetch()` client holds one chunk unread. #39690 made fetch read ahead 256 KiB in fast bursts. Each read lets TCP receive autotuning grow the window, up to `tcp_rmem[2]`: 32 MB since Linux 6.16, which only the alpine lanes run (6.18). The kernel absorbs the whole 12.8 MB body, so the sink never pushes back.

### Fix
- The stalled client is now a `Bun.connect` socket, paused before it writes the request and resumed once the stall is observed. Nothing reads, so the window keeps its initial size and the kernel absorbs only the server's send buffer (2.7 MB here, 43 pulls on the old and the new bun).
- Correct because the test is about the server: the transform parks on the sink's pending promise. Fetch's read-ahead and the kernel's autotuning cap were hidden inputs to the old assertion. #39690's read-ahead is intended and stays.
- The test also de-chunks and gunzips the response and compares it with the source.
- Verified: `bun bd test test/js/web/streams/compression.test.ts` (65 pass). With sink backpressure disabled in `consumerFull` (local experiment) the case fails with `Received: 200`.

### Background
- `HTTPServerWritable` (`src/runtime/webcore/streams.rs`) returns a pending promise from `write()` when uWS did not take all the bytes. A native `CompressionStream` writes into that sink directly and parks on `m_nativeSinkReadyPromise` until it drains.
- TCP receive autotuning (`tcp_rcv_space_adjust`) sizes a socket's receive buffer from the application's read rate. A socket nobody reads keeps its initial 128 KiB.

<details><summary>Notes</summary>

- Red builds: 105543, 105547 (main), 105714, 105732, 105746, 105748 (unrelated PRs). 105524 (11fb73032c, just before #39690) is clean. The other lanes pass the case.
- Lane kernels from the build 105748 job logs: alpine 3.23 x64/aarch64 6.18.38, debian 13 6.12.96, ubuntu 25.04 6.14.0. `net/ipv4/tcp.c` `tcp_init`: `max_rshare = min(6UL*1024*1024, limit)` through v6.15, `min(32UL*1024*1024, limit)` from v6.16. `max_wshare` stays 4 MB.
- `ss -tmi` during the stall on this 6.17 kernel. Fetch client, debug build: client `rb1262364`, server `Send-Q 2.6 MB`, 80 pulls. Raw paused client: client `rb131072`, server `Send-Q 2.57 MB`, 43 pulls, same on the pre-#39690 release and on main.
- Fetch trace on main (`BUN_DEBUG_FetchTasklet=1 BUN_DEBUG_fetch=1`): the client takes 303 KB, 467 KB and 524 KB off the socket in three bursts, then `parkBodyStream` with `buffered=728997` and stays paused. The client-side high-water mark works as designed. The bursts are what grow the kernel window.
- Stall hold check: after `waitUntilStable` the repro held the stall for 300 ms. With the raw client `pulls` did not move (43 -> 43). With the old fetch client on the pre-#39690 build the count still moved during the hold (44 -> 82), so the old assertion had less margin than its comment suggested.
- Raw client capacity: the server's `sk_sndbuf` expands from the initial cwnd to about 2.6 MB and can reach `tcp_wmem[2]` (4 MB). Worst case is about 66 pulls against `TOTAL = 200`.
- `Bun.connect` `pause()`/`resume()` is public API and used the same way in `test/js/bun/net/socket.test.ts`. Unix sockets would give a smaller, fixed capacity, but `Bun.connect({ unix })` is skipped on Windows in the existing tests.
- Runs: 10 of the case on the main debug build, 5 on the pre-#39690 release, all pass. The old case passes on the debug build in this container (80 pulls): under ASAN the bursts are slow enough that the window grows less, which is why the break shows only on release lanes with a 6.16+ kernel.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/streams/compression.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/streams/compression.test.ts
bun test v1.4.1 (861e9ae04)

test/js/web/streams/compression.test.ts:
(pass) TransformStream.prototype getters reject native transform subclasses (0) [10.43ms]
(pass) TransformStream.prototype getters reject native transform subclasses (1) [2.47ms]
(pass) TransformStream.prototype getters reject native transform subclasses (2) [2.54ms]
(pass) TransformStream.prototype getters reject native transform subclasses (3) [2.10ms]
(pass) CompressionStream and DecompressionStream > brotli > compresses data with brotli [15.69ms]
(pass) CompressionStream and DecompressionStream > brotli > decompresses brotli data [21.65ms]
(pass) CompressionStream and DecompressionStream > brotli > round-trip compression with brotli [48.17ms]
(pass) CompressionStream and DecompressionStream > zstd > compresses data with zstd [9.19ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses zstd data [18.89ms]
(pass) CompressionStream and DecompressionStream > zstd > round-trip compression with zstd [50.42ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream [14.98ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream split across writes (next = zstd frame) [18.80ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a multi-frame zstd stream split across writes (next = skippable frame) [7.57ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses many concatenated zstd frames larger than one output chunk [14.51ms]
(pass) CompressionStream and DecompressionStream > zstd > decompresses a zstd stream with a leading skippable frame [9.64ms]
(pass) CompressionStream and DecompressionStream > zstd > rejects trailing garbage after a zstd frame [9.85ms]
(pass) CompressionStream and DecompressionStream > all formats > works with al
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/streams/compression.test.ts | 70 ++++++++++++++++++++++++++++-----
 1 file changed, 61 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
test/js/web/streams/compression.test.ts      5      6      0
```

</details>

<!-- robobun:evidence:end -->