### PR TITLE
install: fix silently dropped github dependencies after package-lock.json migration

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1586,6 +1586,26 @@ impl<'a> PackageInstaller<'a> {
             {
                 debug_assert!(resolution.can_enqueue_install_task());
 
+                // `needs_verify == false` means the download for this package
+                // already completed, so the cache must have it. Re-enqueueing
+                // would dedupe against the finished task and never call back,
+                // silently skipping the package. Fail loudly instead.
+                if !needs_verify {
+                    if log_level != Options::LogLevel::Silent {
+                        bun_core::pretty_errorln!(
+                            "<r><red>error<r>: failed to install <b>{}<r>: the downloaded package was not found in the cache",
+                            bstr::BStr::new(alias.slice(string_buf!())),
+                        );
+                    }
+                    self.summary.fail += 1;
+                    self.increment_tree_install_count(
+                        !is_pending_package_install,
+                        self.current_tree_id,
+                        log_level,
+                    );
+                    return;
+                }
+
                 let context =
                     TaskCallbackContext::DependencyInstallContext(DependencyInstallContext {
                         tree_id: self.current_tree_id,

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1586,10 +1586,8 @@ impl<'a> PackageInstaller<'a> {
             {
                 debug_assert!(resolution.can_enqueue_install_task());
 
-                // `needs_verify == false` means the download for this package
-                // already completed, so the cache must have it. Re-enqueueing
-                // would dedupe against the finished task and never call back,
-                // silently skipping the package. Fail loudly instead.
+                // The download already completed, so re-enqueueing would
+                // dedupe against the finished task and never call back.
                 if !needs_verify {
                     if log_level != Options::LogLevel::Silent {
                         bun_core::pretty_errorln!(

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1586,8 +1586,7 @@ impl<'a> PackageInstaller<'a> {
             {
                 debug_assert!(resolution.can_enqueue_install_task());
 
-                // The download already completed, so re-enqueueing would
-                // dedupe against the finished task and never call back.
+                // Re-enqueueing would dedupe against the finished download and never call back.
                 if !needs_verify {
                     if log_level != Options::LogLevel::Silent {
                         bun_core::pretty_errorln!(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2106,6 +2106,7 @@ fn enqueue_local_tarball(
                     .expect("unreachable"),
                     skip_verify: false,
                     in_trusted_dependencies: false,
+                    github_resolved: StringOrTinyString::init(b""),
                 },
                 tarball_path: StringOrTinyString::init_append_if_needed(
                     tarball_path,

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -2006,8 +2006,7 @@ pub fn generate_network_task_for_tarball<'a>(
             &mut crate::network_task::filename_store_appender(),
         )
         .expect("unreachable"),
-        // Copied out of the lockfile here on the main thread: the extract
-        // task runs on a worker and must not read lockfile buffers.
+        // Copied here: extract workers must not read lockfile buffers.
         github_resolved: if package.resolution.tag == bun_install::ResolutionTag::Github {
             strings::StringOrTinyString::init_append_if_needed(
                 this.lockfile.str(&package.resolution.github().resolved),

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -2006,6 +2006,17 @@ pub fn generate_network_task_for_tarball<'a>(
             &mut crate::network_task::filename_store_appender(),
         )
         .expect("unreachable"),
+        // Copied out of the lockfile here on the main thread: the extract
+        // task runs on a worker and must not read lockfile buffers.
+        github_resolved: if package.resolution.tag == bun_install::ResolutionTag::Github {
+            strings::StringOrTinyString::init_append_if_needed(
+                this.lockfile.str(&package.resolution.github().resolved),
+                &mut crate::network_task::filename_store_appender(),
+            )
+            .expect("unreachable")
+        } else {
+            strings::StringOrTinyString::init(b"")
+        },
     };
 
     network_task.for_tarball(extract_tarball, scope, authorization)?;

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -227,8 +227,7 @@ impl TarballStream {
         );
 
         let npm_mode = tarball.resolution.tag != ResolutionTag::Github;
-        // When the lockfile already carries a bun-tag for this package, the
-        // cache lookup is keyed by it: use it for the cache folder instead of
+        // An existing lockfile bun-tag keys the cache lookup; prefer it over
         // harvesting the archive's root directory name.
         let lockfile_github_tag = tarball.github_resolved.slice();
         let resolved_github_dirname: &'static [u8] =

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -227,8 +227,7 @@ impl TarballStream {
         );
 
         let npm_mode = tarball.resolution.tag != ResolutionTag::Github;
-        // An existing lockfile bun-tag keys the cache lookup; prefer it over
-        // harvesting the archive's root directory name.
+        // An existing lockfile bun-tag keys the cache lookup; prefer it over the root dir name.
         let lockfile_github_tag = tarball.github_resolved.slice();
         let resolved_github_dirname: &'static [u8] =
             if tarball.resolution.tag == ResolutionTag::Github && !lockfile_github_tag.is_empty() {

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -227,7 +227,21 @@ impl TarballStream {
         );
 
         let npm_mode = tarball.resolution.tag != ResolutionTag::Github;
-        let want_first_dirname = tarball.resolution.tag == ResolutionTag::Github;
+        // When the lockfile already carries a bun-tag for this package, the
+        // cache lookup is keyed by it: use it for the cache folder instead of
+        // harvesting the archive's root directory name.
+        let lockfile_github_tag = tarball.github_resolved.slice();
+        let resolved_github_dirname: &'static [u8] =
+            if tarball.resolution.tag == ResolutionTag::Github && !lockfile_github_tag.is_empty() {
+                FileSystem::instance()
+                    .dirname_store()
+                    .append(lockfile_github_tag)
+                    .expect("unreachable")
+            } else {
+                b""
+            };
+        let want_first_dirname =
+            tarball.resolution.tag == ResolutionTag::Github && resolved_github_dirname.is_empty();
         let hasher = integrity::Streaming::init(
             &if tarball.skip_verify {
                 Integrity::default()
@@ -261,7 +275,7 @@ impl TarballStream {
             dest: None,
             tmpname: ZBox::from_bytes(b""),
             hasher,
-            resolved_github_dirname: b"",
+            resolved_github_dirname,
             want_first_dirname,
             npm_mode,
             #[cfg(unix)]

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -37,13 +37,11 @@ pub struct ExtractTarball {
     pub(crate) in_trusted_dependencies: bool,
     pub(crate) integrity: Integrity, // = Integrity::default()
     pub(crate) url: StringOrTinyString,
-    /// For a Github resolution whose lockfile entry already carries a bun-tag
-    /// (`repository.resolved`), the tag's bytes, copied on the main thread
-    /// (worker threads must not read lockfile buffers). The cache lookup is
-    /// keyed by that tag, so the extracted cache folder and `.bun-tag` adopt
-    /// it instead of the archive's root directory name, which can differ
-    /// (a package-lock.json migration only knows the commit sha). Empty for a
-    /// fresh resolve: the archive's root directory name is used as today.
+    /// The lockfile's existing bun-tag (`repository.resolved`) for a Github
+    /// resolution, copied out because workers must not read lockfile buffers.
+    /// Cache lookups are keyed by it, so extraction names the cache folder and
+    /// `.bun-tag` after it. Empty on a fresh resolve (no tag yet): the
+    /// archive's root directory name is used instead.
     pub(crate) github_resolved: StringOrTinyString,
     /// BACKREF: PackageManager owns the task pool that owns this struct.
     pub(crate) package_manager: bun_ptr::BackRef<PackageManager>,

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -37,6 +37,14 @@ pub struct ExtractTarball {
     pub(crate) in_trusted_dependencies: bool,
     pub(crate) integrity: Integrity, // = Integrity::default()
     pub(crate) url: StringOrTinyString,
+    /// For a Github resolution whose lockfile entry already carries a bun-tag
+    /// (`repository.resolved`), the tag's bytes, copied on the main thread
+    /// (worker threads must not read lockfile buffers). The cache lookup is
+    /// keyed by that tag, so the extracted cache folder and `.bun-tag` adopt
+    /// it instead of the archive's root directory name, which can differ
+    /// (a package-lock.json migration only knows the commit sha). Empty for a
+    /// fresh resolve: the archive's root directory name is used as today.
+    pub(crate) github_resolved: StringOrTinyString,
     /// BACKREF: PackageManager owns the task pool that owns this struct.
     pub(crate) package_manager: bun_ptr::BackRef<PackageManager>,
 }
@@ -377,6 +385,14 @@ impl ExtractTarball {
                             ..Default::default()
                         },
                     )?;
+
+                    let lockfile_tag = self.github_resolved.slice();
+                    if !lockfile_tag.is_empty() {
+                        resolved = FileSystem::instance()
+                            .dirname_store()
+                            .append(lockfile_tag)
+                            .expect("unreachable");
+                    }
 
                     // This tag is used to know which version of the package was
                     // installed from GitHub. package.json version becomes sort of

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -37,11 +37,10 @@ pub struct ExtractTarball {
     pub(crate) in_trusted_dependencies: bool,
     pub(crate) integrity: Integrity, // = Integrity::default()
     pub(crate) url: StringOrTinyString,
-    /// The lockfile's existing bun-tag (`repository.resolved`) for a Github
-    /// resolution, copied out because workers must not read lockfile buffers.
-    /// Cache lookups are keyed by it, so extraction names the cache folder and
-    /// `.bun-tag` after it. Empty on a fresh resolve (no tag yet): the
-    /// archive's root directory name is used instead.
+    /// The lockfile's bun-tag (`repository.resolved`) for a Github resolution,
+    /// copied out because extract workers must not read lockfile buffers. When
+    /// set it names the cache folder and `.bun-tag` (cache lookups are keyed by
+    /// it); empty on a fresh resolve, which uses the archive's root dir name.
     pub(crate) github_resolved: StringOrTinyString,
     /// BACKREF: PackageManager owns the task pool that owns this struct.
     pub(crate) package_manager: bun_ptr::BackRef<PackageManager>,

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -858,6 +858,108 @@ describe("package-lock.json migration fixes", () => {
     await frozen(dir);
   });
 
+  // Minimal codeload-style tarball: a single root directory that wraps the
+  // package contents. GitHub names it `<Owner>-<repo>-<short sha>`, which a
+  // package-lock.json migration cannot know ahead of the download.
+  function githubTarball(rootDir: string, files: Record<string, string>): Uint8Array {
+    const octal = (n: number, width: number) => n.toString(8).padStart(width - 1, "0") + "\0";
+    const header = (name: string, size: number, type: "0" | "5") => {
+      const buf = Buffer.alloc(512, 0);
+      buf.write(name, 0, 100, "utf8");
+      buf.write(octal(type === "5" ? 0o755 : 0o644, 8), 100); // mode
+      buf.write(octal(0, 8), 108); // uid
+      buf.write(octal(0, 8), 116); // gid
+      buf.write(octal(size, 12), 124); // size
+      buf.write(octal(0, 12), 136); // mtime
+      buf.fill(" ", 148, 156); // checksum placeholder
+      buf.write(type, 156);
+      buf.write("ustar\0", 257);
+      buf.write("00", 263);
+      let sum = 0;
+      for (let i = 0; i < 512; i++) sum += buf[i];
+      buf.write(octal(sum, 8), 148);
+      return buf;
+    };
+    const chunks: Buffer[] = [header(`${rootDir}/`, 0, "5")];
+    for (const [path, contents] of Object.entries(files)) {
+      const body = Buffer.from(contents, "utf8");
+      chunks.push(header(`${rootDir}/${path}`, body.length, "0"), body, Buffer.alloc((512 - (body.length % 512)) % 512));
+    }
+    chunks.push(Buffer.alloc(1024));
+    return Bun.gzipSync(Buffer.concat(chunks));
+  }
+
+  // #40489: a github: dependency migrated from package-lock.json was
+  // downloaded and extracted, but never written to node_modules, and the
+  // install still exited 0. The migrated bun-tag (the commit sha) never
+  // matches the cache folder, which is named after the tarball's root
+  // directory and only known after extraction.
+  test.concurrent("github dependency from package-lock.json is installed (#40489)", async () => {
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    const rootDir = "User-repo-0123456";
+    const tgz = githubTarball(rootDir, {
+      "package.json": JSON.stringify({ name: "@scope/internal-name", version: "2.0.1" }),
+      "index.js": "module.exports = 42;\n",
+    });
+    const requests: string[] = [];
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        requests.push(new URL(req.url).pathname);
+        return new Response(tgz, { headers: { "content-type": "application/gzip" } });
+      },
+    });
+    const spec = `git+https://github.com/user/repo#${sha}`;
+    using dir = synthetic("npm-migrate-github-install", {
+      "package.json": JSON.stringify({ name: "gh-install", dependencies: { alias: spec } }),
+      "package-lock.json": npmLock("gh-install", {
+        "": { name: "gh-install", dependencies: { alias: spec } },
+        "node_modules/alias": {
+          name: "@scope/internal-name",
+          version: "2.0.1",
+          resolved: `git+ssh://git@github.com/user/repo.git#${sha}`,
+        },
+      }),
+    });
+    const install = async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        env: {
+          ...bunEnv,
+          BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+          GITHUB_API_URL: `http://localhost:${server.port}`,
+        },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    };
+
+    const first = await install();
+    expect(first.stderr).toContain("Saved lockfile");
+    expect(first.stdout).toContain("1 package installed");
+    expect(first.exitCode).toBe(0);
+    expect(requests).toEqual([`/repos/user/repo/tarball/${sha}`]);
+    const installed = JSON.parse(fs.readFileSync(join(String(dir), "node_modules/alias/package.json"), "utf8"));
+    expect(installed.name).toBe("@scope/internal-name");
+
+    // The saved lockfile keeps the migrated bun-tag (the commit sha), and the
+    // cache folder is keyed by it, not by the archive's root directory name.
+    const { lock } = await readLock(dir);
+    expect(lock.packages.alias[0]).toBe(`@scope/internal-name@github:user/repo#${sha}`);
+    expect(lock.packages.alias[2]).toBe(sha);
+
+    // Reinstall from the saved bun.lock and the warm cache: no new download.
+    fs.rmSync(join(String(dir), "node_modules"), { recursive: true, force: true });
+    const second = await install();
+    expect(second.stdout).toContain("1 package installed");
+    expect(second.exitCode).toBe(0);
+    expect(requests).toHaveLength(1);
+    expect(fs.existsSync(join(String(dir), "node_modules/alias/index.js"))).toBeTrue();
+  });
+
   test.concurrent("root bundleDependencies keeps its subtree (B2)", async () => {
     using dir = fixture("testing-rebuild-bundle--a");
     const { text, lock } = await migrate(dir);

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -883,7 +883,11 @@ describe("package-lock.json migration fixes", () => {
     const chunks: Buffer[] = [header(`${rootDir}/`, 0, "5")];
     for (const [path, contents] of Object.entries(files)) {
       const body = Buffer.from(contents, "utf8");
-      chunks.push(header(`${rootDir}/${path}`, body.length, "0"), body, Buffer.alloc((512 - (body.length % 512)) % 512));
+      chunks.push(
+        header(`${rootDir}/${path}`, body.length, "0"),
+        body,
+        Buffer.alloc((512 - (body.length % 512)) % 512),
+      );
     }
     chunks.push(Buffer.alloc(1024));
     return Bun.gzipSync(Buffer.concat(chunks));


### PR DESCRIPTION
### Problem

- A github dependency migrated from `package-lock.json` is downloaded, extracted, and then never written to `node_modules`. The install reports `15 packages installed` instead of 16 and exits 0. Repro: `libsignal` aliased to `git+https://github.com/whiskeysockets/libsignal-node#1c30d7d7` with npm's lockfile present (#40489).
- The migration stores the commit sha as the bun-tag, but extraction names the cache folder `@GH@<tarball root dir>` (for example `@GH@WhiskeySockets-libsignal-node-1c30d7d`). The post-download retry in `PackageInstaller.rs` looks up `@GH@<bun-tag>`, misses, re-enqueues the download, and the dedupe map in `generate_network_task_for_tarball` swallows it. Nothing fails.

### Fix

- When the lockfile already carries a bun-tag, both extractors (`extract_tarball.rs` and `TarballStream.rs`) now name the cache folder and write `.bun-tag` with that tag. The lookup keyed by the lockfile then finds the package. A fresh resolve still uses the archive's root directory name, which is how the actual commit is learned.
- The tag bytes are copied into `ExtractTarball` on the main thread. Extract workers must not read lockfile buffers (they can be reallocated concurrently).
- The hoisted installer now fails loudly when a completed download is missing from the cache, instead of re-enqueueing in silence. This makes any future bug of this class exit 1 (the isolated linker already did).
- Verified: `test/cli/install/migration/migrate.test.ts` (new test, fails on stock bun). Also the full migrate, isolated-install, streaming-extract, git-deps, tarball-integrity, bun-lock and bun-patch suites, plus both linkers against the real `libsignal` repro.

### Background

- A github resolution downloads `codeload` tarballs whose single root directory is `<Owner>-<repo>-<short sha>`. Bun uses that name as the "bun-tag": the cache folder key (`@GH@<tag>`), the `.bun-tag` file, and the third element of a `bun.lock` github entry.
- npm's lockfile only knows the commit sha, so the migration cannot predict the tarball's root directory name (casing and the short form belong to GitHub).
- An earlier draft rewrote the package's `resolved` after extraction instead. That broke the isolated linker: store paths derive from the resolution, so paths computed before and after the download disagreed.

<details><summary>Notes</summary>

- The bug fires for every github dependency migrated from `package-lock.json`, aliased or not. The alias mismatch in the issue report is a red herring on current main: a fresh resolve also names the package by its internal `package.json` name and installs fine.
- Silent-exit mechanism: `install_enqueued_packages_after_extraction` retries with `needs_verify == false`. The retry misses the cache, `enqueue_tarball_for_download` creates a fresh `task_queue` entry (the old one was removed), and `has_created_network_task` dedupes the network task, so the callback list is never drained. Pending tasks reach 0 and the install finishes.
- The isolated linker hit the same cache miss but reported `Failed to install 1 package` and exited 1.
- A lockfile whose bun-tag is the root-directory name (every fresh resolve) behaves as before: the tag and the archive's root directory agree. The new path only matters when they differ, for example a migrated lockfile or a renamed repository.
- Reruns are no-ops: `.bun-tag` now contains the lockfile tag, so `verify` matches and a second install prints `no changes` without a download.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/migration/migrate.test.ts

<!-- robobun:evidence:end -->