### PR TITLE
compile: keep chunk-[hash] names inside executables

### DIFF
--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -364,7 +364,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         let mut duplicates_map: StringArrayHashMap<DuplicateEntry> = StringArrayHashMap::default();
 
         let mut chunk_visit_map = AutoBitSet::init_empty(chunks.len())?;
-        let mut compact_chunk_index: usize = 0;
 
         // Compute the final hashes of each chunk, then use those to create the final
         // paths of each chunk. This can technically be done in parallel but it
@@ -384,38 +383,16 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             chunk.template.placeholder.hash = Some(hash.digest());
 
             let mut rel_path: Vec<u8> = Vec::new();
-            // Inside an executable nobody sees chunk file names, and every importer embeds them: number them instead of
-            // `chunk-<hash>` when the default naming is in effect.
-            if c.options.compile_mode.is_executable()
-                && !chunk.entry_point.is_entry_point()
-                && matches!(
-                    &*chunk.template.data,
-                    b"./chunk-[hash].[ext]"
-                        | b"./[name]-[hash].[ext]"
-                        | b"[name]-[hash].[ext]"
-                        | b"chunk-[hash].[ext]"
-                )
-            {
-                write!(
-                    &mut rel_path,
-                    "./_{}.{}",
-                    compact_chunk_index,
-                    bstr::BStr::new(&chunk.template.placeholder.ext)
-                )
+            // Use the byte-writer (`PathTemplate::print`) directly —
+            // routing through `Display`/`write!` goes via `from_utf8_lossy`,
+            // which would replace non-UTF-8 dir bytes with U+FFFD and corrupt
+            // the output path.
+            // Disk output sanitizes leading `..`; `--compile` keeps it so
+            // runtime bunfs references to out-of-root entrypoints resolve.
+            chunk
+                .template
+                .print(&mut rel_path, !c.options.compile_mode.is_executable())
                 .expect("write to Vec<u8>");
-                compact_chunk_index += 1;
-            } else {
-                // Use the byte-writer (`PathTemplate::print`) directly —
-                // routing through `Display`/`write!` goes via `from_utf8_lossy`,
-                // which would replace non-UTF-8 dir bytes with U+FFFD and corrupt
-                // the output path.
-                // Disk output sanitizes leading `..`; `--compile` keeps it so
-                // runtime bunfs references to out-of-root entrypoints resolve.
-                chunk
-                    .template
-                    .print(&mut rel_path, !c.options.compile_mode.is_executable())
-                    .expect("write to Vec<u8>");
-            }
             path::resolve_path::platform_to_posix_in_place::<u8>(&mut rel_path);
 
             if path_names_map.get_or_put(&rel_path)?.found_existing {

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -134,15 +134,20 @@ describe("bundler", () => {
       splitting: true,
       files: {
         "/entry.ts": /* js */ `
+          import "./shared";
           console.log("mark:entry");
           await import("./lazy");
         `,
         "/lazy.ts": /* js */ `
+          import "./shared";
           console.log("mark:lazy");
+        `,
+        "/shared.ts": /* js */ `
+          console.log("mark:shared");
         `,
       },
       run: {
-        stdout: "mark:entry\nmark:lazy",
+        stdout: "mark:shared\nmark:entry\nmark:lazy",
       },
       onAfterBundle(api) {
         const file = readFileSync(api.outfile);
@@ -151,16 +156,19 @@ describe("bundler", () => {
         const offsets = trailer - 32;
         const base = offsets - Number(file.readBigUInt64LE(offsets));
         const modules = { offset: file.readUInt32LE(offsets + 8), length: file.readUInt32LE(offsets + 12) };
-        expect(modules.length).toBe(2 * 52);
+        const count = modules.length / 52;
+        expect(count).toBe(3);
         const names: string[] = [];
-        for (let i = 0; i < 2; i++) {
+        for (let i = 0; i < count; i++) {
           const record = base + modules.offset + i * 52;
           const name = { offset: file.readUInt32LE(record), length: file.readUInt32LE(record + 4) };
           names.push(file.toString("latin1", base + name.offset, base + name.offset + name.length));
         }
-        expect(names).toHaveLength(2);
-        expect(names[0]).toBe("/$bunfs/root/out");
-        expect(names[1]).toMatch(/^\/\$bunfs\/root\/chunk-[0-9a-z]+\.js$/);
+        const chunks = names.filter(name => !name.endsWith("/root/out"));
+        expect(chunks).toHaveLength(2);
+        for (const name of chunks) {
+          expect(name).toMatch(/^(\/\$bunfs|B:\/~BUN)\/root\/chunk-[0-9a-z]+\.js$/);
+        }
       },
     });
 

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -106,7 +106,7 @@ describe("bundler", () => {
         const startupCount = u32(at);
 
         // `CompiledModuleGraphFile`: name, contents, sourcemap, bytecode, module_info, bytecode_origin_path
-        // (StringPointer each), then 4 bytes. Chunks are numbered, so identify them by their source text.
+        // (StringPointer each), then 4 bytes. Chunk names are hashed, so identify them by their source text.
         const index: Record<string, number> = {};
         const bytecodeEnd: number[] = [];
         for (let i = 0; i < count; i++) {
@@ -126,6 +126,41 @@ describe("bundler", () => {
         // The string table sits between the startup modules' bytecode and the lazy chunk's.
         expect(stringTable.offset).toBeGreaterThanOrEqual(Math.max(bytecodeEnd[0], bytecodeEnd[1]));
         expect(stringTable.offset + stringTable.length).toBeLessThanOrEqual(bytecodeEnd[2]);
+      },
+    });
+
+    itBundled("compile/splitting/ChunkNamesAreHashed", {
+      compile: true,
+      splitting: true,
+      files: {
+        "/entry.ts": /* js */ `
+          console.log("mark:entry");
+          await import("./lazy");
+        `,
+        "/lazy.ts": /* js */ `
+          console.log("mark:lazy");
+        `,
+      },
+      run: {
+        stdout: "mark:entry\nmark:lazy",
+      },
+      onAfterBundle(api) {
+        const file = readFileSync(api.outfile);
+        const trailer = file.lastIndexOf("\n---- Bun! ----\n", undefined, "latin1");
+        expect(trailer).toBeGreaterThan(0);
+        const offsets = trailer - 32;
+        const base = offsets - Number(file.readBigUInt64LE(offsets));
+        const modules = { offset: file.readUInt32LE(offsets + 8), length: file.readUInt32LE(offsets + 12) };
+        expect(modules.length).toBe(2 * 52);
+        const names: string[] = [];
+        for (let i = 0; i < 2; i++) {
+          const record = base + modules.offset + i * 52;
+          const name = { offset: file.readUInt32LE(record), length: file.readUInt32LE(record + 4) };
+          names.push(file.toString("latin1", base + name.offset, base + name.offset + name.length));
+        }
+        expect(names).toHaveLength(2);
+        expect(names[0]).toBe("/$bunfs/root/out");
+        expect(names[1]).toMatch(/^\/\$bunfs\/root\/chunk-[0-9a-z]+\.js$/);
       },
     });
 


### PR DESCRIPTION
### What does this PR do?

Reverts the numbered `./_N.js` chunk naming that #40201 introduced for chunks inside a compiled executable. Chunks use the same `chunk-<hash>.js` names as a normal build again.

### How did you verify your code works?

Built an executable with two entry points and `splitting: true`; the embedded chunk names are `chunk-<hash>.js`. Ran `test/bundler/bun-build-compile.test.ts` locally; the only failures are the local ASAN `asan-dyld-shim.dylib` load errors when the compiled binary runs, which are unrelated to this change.