### PR TITLE
ci: retry a timed out artifact download and bound the darwin guest warmup installs

### DIFF
--- a/scripts/darwin-ci/guest/job.sh
+++ b/scripts/darwin-ci/guest/job.sh
@@ -10,8 +10,19 @@ set -a; source ~/job.env; set +a
 cd ~/work
 
 echo "[guest] macOS $(sw_vers -productVersion) shard=${BUILDKITE_PARALLEL_JOB:-0}/${BUILDKITE_PARALLEL_JOB_COUNT:-1}"
-bun install >/dev/null 2>&1 || true
-(cd test && bun install >/dev/null 2>&1) || true
+
+# Best-effort cache warmup before the runner's own `bun install`. macOS has no timeout(1), and a guest
+# whose network stalls here would otherwise sit silent until Buildkite's job timeout kills it.
+warm_install() {
+  bun install >/dev/null 2>&1 &
+  local pid=$!
+  ( sleep 180; kill "$pid" 2>/dev/null && echo "[guest] bun install in $PWD timed out after 180s" ) &
+  local watchdog=$!
+  wait "$pid" 2>/dev/null
+  kill "$watchdog" 2>/dev/null
+}
+warm_install
+(cd test && warm_install)
 
 shard=()
 [ -n "${BUILDKITE_PARALLEL_JOB:-}" ] && shard=(--shard="$BUILDKITE_PARALLEL_JOB" --max-shards="$BUILDKITE_PARALLEL_JOB_COUNT")

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -2750,6 +2750,9 @@ async function getExecPathFromBuildKite(target, buildId) {
   const releasePath = join(cwd, "release");
   mkdirSync(releasePath, { recursive: true });
 
+  const downloadTimeout = 120_000;
+  const maxDownloadTimeouts = 3;
+  let downloadTimeouts = 0;
   let zipPath;
   downloadLoop: for (let i = 0; i < 10; i++) {
     // build-bun also uploads libbun-*.a / libbun_runtime.a / dep libs; only the zips are wanted here.
@@ -2761,13 +2764,26 @@ async function getExecPathFromBuildKite(target, buildId) {
     const { error } = await spawnSafe({
       command: "buildkite-agent",
       args,
-      timeout: 120000,
+      timeout: downloadTimeout,
     });
     if (error === "timeout") {
-      throw new Error(
-        `buildkite-agent artifact download timed out after 120s for step '${target}'. ` +
-          `Refusing to continue with a partial download (would silently fall back to the wrong binary).`,
+      // The zip the timeout interrupted is truncated. If it stayed on disk, the
+      // readdir below would pick it (or the smaller release zip that did finish)
+      // and the tests would run against the wrong binary.
+      rmSync(releasePath, { recursive: true, force: true });
+      mkdirSync(releasePath, { recursive: true });
+      if (++downloadTimeouts >= maxDownloadTimeouts) {
+        throw new Error(
+          `buildkite-agent artifact download timed out after ${downloadTimeout / 1000}s for step '${target}' ` +
+            `(${downloadTimeouts} attempts). Refusing to continue with a partial download ` +
+            `(would silently fall back to the wrong binary).`,
+        );
+      }
+      console.warn(
+        `buildkite-agent artifact download timed out after ${downloadTimeout / 1000}s for step '${target}' ` +
+          `(attempt ${downloadTimeouts}/${maxDownloadTimeouts}), retrying...`,
       );
+      continue;
     }
 
     zipPath = readdirSync(releasePath, { recursive: true, encoding: "utf-8" })


### PR DESCRIPTION
### Problem
- A darwin test job (build 105816, agent `darwin-arm64-ciabatta-tart-15-1`) failed with `buildkite-agent artifact download timed out after 120s for step 'darwin-aarch64-build-bun'`. The guest's network stalled for about two minutes: the 24 MiB release zip took 63s (normally 1 to 2s), then the 119 MiB profile zip hit the cap. The runner fails the job on the first timeout (`scripts/runner.node.mjs`, `getExecPathFromBuildKite`).
- Two hours earlier the same slot hung for 45 minutes with no output after the guest banner (build 105772). The guest script runs two best-effort `bun install` warmups with no time limit before the runner starts, so a stalled guest network holds the job until Buildkite's timeout.

### Fix
- The runner retries the artifact download after a timeout, up to three attempts. Before each retry it wipes the release directory, so a truncated zip can never be picked as the binary. That keeps the guarantee #29039 added. After the third timeout it throws the same error as before, with the attempt count.
- The darwin guest script wraps each warmup `bun install` in a bash watchdog that kills it after 180s and prints one line. macOS has no `timeout(1)` and the guest image does not ship coreutils. The installs stay best effort: the runner repeats them with the bun under test and reports those.
- Verified: a fake `buildkite-agent` on PATH with a 2s cap. Two hung calls then a good one: two `retrying...` lines, the truncated zip gone, the tests start. Three hung calls: exit 1 with the `(3 attempts)` error and an empty release dir. The watchdog was run on macOS bash 3.2 (darwin-arm64-ciabatta) and on linux: the hung install is killed at the limit, a fast one is not, and `wait 2>/dev/null` hides bash's `Terminated` notice.
- `scripts/darwin-ci/guest/job.sh` overlaps with the rewrite of the same lines in #37771. Whichever lands second needs a small rebase.

### Background
- The darwin test agents run each job in a fresh Tart guest. The host clones `bun-ci-base`, rsyncs the checkout in, and runs `guest/job.sh` over ssh. The guest reaches the internet through the host's vmnet NAT.
- `getExecPathFromBuildKite` downloads `*.zip` from the build step with `buildkite-agent artifact download`. The profile zip is preferred. If only the smaller release zip finished, the tests would run against the wrong binary, which is why #29039 made a timeout fatal instead of silent.
- Over the last 2.5 days (2095 tart jobs, retried jobs included) these two jobs are the only network stalls in the fleet. The host checks out healthy: same 10GbE link and config as the other Studios, 0 interface errors, no memory pressure, 62 MB/s from inside its guests right now. So the fix is on the runner side, not the host.

<details><summary>Notes</summary>

Evidence for the stall being local to the guest's NAT path, not the host or the artifact store:

- The other shard of the same step (challah-tart-26-1) started in the same second and downloaded the same zips (same SHA256) in 4s. A darwin-x64 mini and linux agents downloading at the same minute were also fast.
- Host-side kernel TCP summaries during the slow download: the host's own sockets (tailscaled, buildkite-agent, git) had rtt 5 to 15 ms and 0 retransmits. The host-to-guest ssh session for the job had rtt 1 ms and 0 retransmits over 128s.
- For the 45-minute hang, the job's ssh session lasted 2734s and carried 6.6 KB in and 7.5 KB out: keepalives only. The guest answered ssh the whole time. The first command after the banner is `bun install`, which discards its output.
- Host comparison (ciabatta vs focaccia vs sourdough): identical hardware (M2 Ultra, 24 cores, 64 GB), tart 2.32.1, same `bun-ci-base` size, same checkout size (1.2 GB, .git 980 MB), WiFi off, 10Gbase-T active, 253 DHCP leases on all (the pool is full everywhere, leases recycle fine), no swap or compression.
- Failure counts per agent over the window, retried jobs included: ciabatta-1 16, ciabatta-2 8, focaccia-1 9, focaccia-2 9, sourdough-1 22, sourdough-2 11, baguette-1 10, baguette-2 17, challah-1 7, challah-2 8. All other failures ran 500s or more (test failures), none were download timeouts.
- 141 of 142 artifact downloads on the six macOS 15 tart agents today took 2 to 4s. The one in build 105816 is the only slow one.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->