### PR TITLE
Compiled executables: prefetch the startup bytecode with madvise on macOS too

### DIFF
--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2540,12 +2540,10 @@ impl StandaloneModuleGraph {
         Ok(Some(graph))
     }
 
-    /// Reads the payload pages the entry point's static import closure needs
-    /// into the page cache before JSC touches them: its modules' bytecode (or
-    /// source text when there is none), the internal-module bytecode and the
-    /// string table, one run by construction (`to_bytes`). On a cold start that
-    /// is a few large reads instead of one page fault per page while the
-    /// bytecode decodes. Errors are ignored.
+    /// Reads the startup run into the page cache before JSC decodes it: the
+    /// first `startup_module_count` modules' bytecode (or source text), the
+    /// internal-module bytecode and the string table, contiguous by
+    /// construction (`to_bytes`). Errors are ignored.
     /// `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1` skips it.
     fn prefetch_startup_pages(&self) {
         if self.startup_module_count == 0
@@ -2678,19 +2676,11 @@ fn address_span(regions: impl Iterator<Item = (*const u8, usize)>) -> Option<(us
     (lo < hi).then_some((lo, hi))
 }
 
-/// `MADV_WILLNEED` over the pages of `[lo, hi)`: the kernel reads the file
-/// bytes behind the mapping into the page cache.
-///
-/// Linux queues the readahead and returns. One call reads at most
-/// `max(bdi->io_pages, ra_pages)` (device dependent, 128 KiB by default), so
-/// it is issued in 128 KiB pieces.
-///
-/// Darwin (`vm_map_willneed`) pre-faults every page with reads of up to 1 MiB
-/// and returns once they are resident. It write-faults a writable mapping
-/// "to preclude subsequent soft-faults", which copies every page out of the
-/// page cache into private memory, so the range is read-only for the duration
-/// of the call. JSC's later writes to the bytecode copy one page at a time, as
-/// without the prefetch.
+/// `MADV_WILLNEED` over the pages of `[lo, hi)`. Linux queues readahead of at
+/// most `max(bdi->io_pages, ra_pages)` per call, hence the 128 KiB pieces.
+/// Darwin (`vm_map_willneed`) pre-faults the pages synchronously and
+/// write-faults a writable mapping, which copies every page out of the page
+/// cache, hence the read-only window around the call.
 #[cfg(not(windows))]
 fn read_ahead(lo: usize, hi: usize) {
     let start = lo & !(bun_alloc::page_size() - 1);

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2615,29 +2615,18 @@ impl StandaloneModuleGraph {
             return;
         };
 
-        // This is a best-effort hint, so call libc madvise directly and
-        // just log on failure rather than treating errors as fatal.
-        // SAFETY: start..end lies inside the mapped executable image, and
-        // MADV_DONTNEED neither reads nor writes through it.
-        let rc = unsafe {
-            libc::madvise(
-                start as *mut core::ffi::c_void,
-                end - start,
-                libc::MADV_DONTNEED,
-            )
-        };
-        if rc != 0 {
-            bun_core::scoped_log!(
-                StandaloneModuleGraph,
-                "hintSourcePagesDontNeed: madvise failed errno={}",
-                bun_sys::last_errno()
-            );
-        } else {
-            bun_core::scoped_log!(
+        // A best-effort hint: log a failure instead of treating it as fatal.
+        match bun_sys::madvise(start as *mut u8, end - start, bun_sys::MADV::DONTNEED) {
+            Ok(()) => bun_core::scoped_log!(
                 StandaloneModuleGraph,
                 "hintSourcePagesDontNeed: MADV_DONTNEED {} bytes",
                 end - start
-            );
+            ),
+            Err(err) => bun_core::scoped_log!(
+                StandaloneModuleGraph,
+                "hintSourcePagesDontNeed: madvise failed: {}",
+                err
+            ),
         }
     }
 
@@ -2686,39 +2675,18 @@ fn read_ahead(lo: usize, hi: usize) {
     let start = lo & !(bun_alloc::page_size() - 1);
     #[cfg(target_os = "macos")]
     {
-        let range = start as *mut core::ffi::c_void;
+        // The `__BUN` segment's maximum protection is read-write, and nothing
+        // else runs in this process yet, so no write lands while it is read-only.
+        let range = start as *mut u8;
         let len = hi - start;
-        // SAFETY: `[start, hi)` lies inside the `__BUN` segment, whose maximum
-        // protection is read-write; nothing else runs in this process yet, so
-        // no write lands while the range is read-only.
-        let rc = unsafe { libc::mprotect(range, len, libc::PROT_READ) };
-        if rc != 0 {
-            bun_core::scoped_log!(
-                StandaloneModuleGraph,
-                "prefetch: mprotect failed errno={}",
-                bun_sys::last_errno()
-            );
+        if let Err(err) = bun_sys::mprotect(range, len, bun_sys::PROT::READ) {
+            bun_core::scoped_log!(StandaloneModuleGraph, "prefetch: {}", err);
             return;
         }
-        // SAFETY: same range; `MADV_WILLNEED` neither reads nor writes through it.
-        let advised = unsafe { libc::madvise(range, len, libc::MADV_WILLNEED) };
-        let advise_errno = bun_sys::last_errno();
-        // SAFETY: restores the segment's own protection on the same range.
-        let restored = unsafe { libc::mprotect(range, len, libc::PROT_READ | libc::PROT_WRITE) };
-        if restored != 0 {
-            bun_core::scoped_log!(
-                StandaloneModuleGraph,
-                "prefetch: mprotect restore failed errno={}",
-                bun_sys::last_errno()
-            );
-            return;
-        }
-        if advised != 0 {
-            bun_core::scoped_log!(
-                StandaloneModuleGraph,
-                "prefetch: madvise failed errno={}",
-                advise_errno
-            );
+        let advised = bun_sys::madvise(range, len, bun_sys::MADV::WILLNEED);
+        let restored = bun_sys::mprotect(range, len, bun_sys::PROT::READ | bun_sys::PROT::WRITE);
+        if let Err(err) = restored.and(advised) {
+            bun_core::scoped_log!(StandaloneModuleGraph, "prefetch: {}", err);
             return;
         }
     }
@@ -2728,16 +2696,8 @@ fn read_ahead(lo: usize, hi: usize) {
         let mut at = start;
         while at < hi {
             let len = PIECE.min(hi - at);
-            // SAFETY: `[at, at + len)` lies inside the mapped executable image;
-            // `MADV_WILLNEED` neither reads nor writes through it.
-            let rc =
-                unsafe { libc::madvise(at as *mut core::ffi::c_void, len, libc::MADV_WILLNEED) };
-            if rc != 0 {
-                bun_core::scoped_log!(
-                    StandaloneModuleGraph,
-                    "prefetch: madvise failed errno={}",
-                    bun_sys::last_errno()
-                );
+            if let Err(err) = bun_sys::madvise(at as *mut u8, len, bun_sys::MADV::WILLNEED) {
+                bun_core::scoped_log!(StandaloneModuleGraph, "prefetch: {}", err);
                 return;
             }
             at += len;

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -403,57 +403,6 @@ mod macho {
         // SAFETY: section data is `length` bytes immediately following the u64 header.
         Some((unsafe { slice_ptr.add(data_offset) }, length as usize))
     }
-
-    unsafe extern "C" {
-        /// `<mach-o/getsect.h>`: the named segment's load command in the main executable.
-        fn getsegbyname(
-            segname: *const core::ffi::c_char,
-        ) -> *const bun_sys::macho::segment_command_64;
-        /// `<mach-o/dyld.h>`: the path dyld loaded image `image_index` from.
-        fn _dyld_get_image_name(image_index: u32) -> *const core::ffi::c_char;
-    }
-
-    /// `F_RDADVISE` on the executable for the file bytes backing `[lo, hi)`: an
-    /// asynchronous read into the page cache that returns at once.
-    /// (`MADV_WILLNEED` blocks on Darwin until the pages are in, so it is no use
-    /// for overlapping I/O with startup.)
-    pub(super) fn read_ahead(lo: usize, hi: usize) {
-        // SAFETY: NUL-terminated segment name; returns null or a pointer into the
-        // main image's load commands, which live as long as the process.
-        let segment = unsafe { getsegbyname(c"__BUN".as_ptr()) };
-        if segment.is_null() {
-            return;
-        }
-        // SAFETY: non-null per the check above.
-        let segment = unsafe { &*segment };
-        let slide = bun_sys::c::_dyld_get_image_vmaddr_slide(0) as usize;
-        let segment_start = (segment.vmaddr as usize).wrapping_add(slide);
-        let segment_end = segment_start.saturating_add(segment.filesize as usize);
-        if lo < segment_start || hi > segment_end {
-            return;
-        }
-        // SAFETY: image 0 is the main executable; dyld keeps its NUL-terminated
-        // path alive for the life of the process.
-        let exe_path = unsafe { bun_core::ZStr::from_c_ptr(_dyld_get_image_name(0)) };
-        let Ok(file) = bun_sys::File::open(exe_path, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0)
-        else {
-            return;
-        };
-        let advisory = libc::radvisory {
-            ra_offset: (lo - segment_start + segment.fileoff as usize) as libc::off_t,
-            ra_count: (hi - lo).min(i32::MAX as usize) as core::ffi::c_int,
-        };
-        // SAFETY: `advisory` is a valid `struct radvisory` for the duration of
-        // the call; the fd stays open until `file` drops below.
-        let rc = unsafe { libc::fcntl(file.fd().native(), libc::F_RDADVISE, &advisory) };
-        bun_core::scoped_log!(
-            super::StandaloneModuleGraph,
-            "prefetch: F_RDADVISE offset={} count={} rc={}",
-            advisory.ra_offset,
-            advisory.ra_count,
-            rc
-        );
-    }
 }
 
 #[cfg(windows)]
@@ -524,36 +473,6 @@ mod elf {
         }
         // SAFETY: payload_len bytes follow the 8-byte header at `target`.
         Some((unsafe { target.add(8) }, payload_len as usize))
-    }
-
-    /// `MADV_WILLNEED` over `[lo, hi)`: queues page-cache readahead for the
-    /// file bytes backing the mapping and returns once the I/O is submitted.
-    /// Issued in 128 KiB pieces because one call reads at most
-    /// `max(bdi->io_pages, ra_pages)` (device dependent, 128 KiB on some).
-    pub(super) fn read_ahead(lo: usize, hi: usize) {
-        const PIECE: usize = 128 * 1024;
-        let mut at = lo & !(bun_alloc::page_size() - 1);
-        while at < hi {
-            let len = PIECE.min(hi - at);
-            // SAFETY: `[at, at + len)` lies inside the mapped executable
-            // image; `MADV_WILLNEED` neither reads nor writes through it.
-            let rc =
-                unsafe { libc::madvise(at as *mut core::ffi::c_void, len, libc::MADV_WILLNEED) };
-            if rc != 0 {
-                bun_core::scoped_log!(
-                    super::StandaloneModuleGraph,
-                    "prefetch: madvise failed errno={}",
-                    bun_sys::last_errno()
-                );
-                return;
-            }
-            at += len;
-        }
-        bun_core::scoped_log!(
-            super::StandaloneModuleGraph,
-            "prefetch: MADV_WILLNEED {} bytes",
-            hi - lo
-        );
     }
 }
 
@@ -2621,12 +2540,12 @@ impl StandaloneModuleGraph {
         Ok(Some(graph))
     }
 
-    /// Starts reading the payload pages the entry point's static import closure
-    /// needs — its modules' bytecode (or source text when there is none), the
-    /// internal-module bytecode and the string table, one run by construction
-    /// (`to_bytes`) — so on a cold start the disk reads overlap JSC
-    /// initialization instead of arriving one page fault at a time while the
-    /// bytecode decodes. Pages already cached cost nothing; errors are ignored.
+    /// Reads the payload pages the entry point's static import closure needs
+    /// into the page cache before JSC touches them: its modules' bytecode (or
+    /// source text when there is none), the internal-module bytecode and the
+    /// string table, one run by construction (`to_bytes`). On a cold start that
+    /// is a few large reads instead of one page fault per page while the
+    /// bytecode decodes. Errors are ignored.
     /// `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1` skips it.
     fn prefetch_startup_pages(&self) {
         if self.startup_module_count == 0
@@ -2643,10 +2562,16 @@ impl StandaloneModuleGraph {
                     .flat_map(|f| [f.bytecode, f.module_info])
                     .chain(self.builtin_bytecode.iter().map(|&(_, bytes)| bytes))
                     .map(|bytes| (bytes.cast::<u8>().cast_const(), bytes.len()))
-                    .chain([(
-                        self.bytecode_string_table.as_ptr(),
-                        self.bytecode_string_table.len(),
-                    )]),
+                    .chain([
+                        (
+                            self.bytecode_string_table.as_ptr(),
+                            self.bytecode_string_table.len(),
+                        ),
+                        (
+                            self.module_info_string_table.as_ptr(),
+                            self.module_info_string_table.len(),
+                        ),
+                    ]),
             )
         } else {
             address_span(
@@ -2658,12 +2583,10 @@ impl StandaloneModuleGraph {
         let Some((lo, hi)) = span else {
             return;
         };
-        #[cfg(target_os = "macos")]
-        macho::read_ahead(lo, hi);
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
-        elf::read_ahead(lo, hi);
         #[cfg(windows)]
         let _ = (lo, hi);
+        #[cfg(not(windows))]
+        read_ahead(lo, hi);
     }
 
     /// Hint to the kernel that the embedded source text is unlikely to be
@@ -2753,6 +2676,88 @@ fn address_span(regions: impl Iterator<Item = (*const u8, usize)>) -> Option<(us
             (lo.min(ptr as usize), hi.max(ptr as usize + len))
         });
     (lo < hi).then_some((lo, hi))
+}
+
+/// `MADV_WILLNEED` over the pages of `[lo, hi)`: the kernel reads the file
+/// bytes behind the mapping into the page cache.
+///
+/// Linux queues the readahead and returns. One call reads at most
+/// `max(bdi->io_pages, ra_pages)` (device dependent, 128 KiB by default), so
+/// it is issued in 128 KiB pieces.
+///
+/// Darwin (`vm_map_willneed`) pre-faults every page with reads of up to 1 MiB
+/// and returns once they are resident. It write-faults a writable mapping
+/// "to preclude subsequent soft-faults", which copies every page out of the
+/// page cache into private memory, so the range is read-only for the duration
+/// of the call. JSC's later writes to the bytecode copy one page at a time, as
+/// without the prefetch.
+#[cfg(not(windows))]
+fn read_ahead(lo: usize, hi: usize) {
+    let start = lo & !(bun_alloc::page_size() - 1);
+    #[cfg(target_os = "macos")]
+    {
+        let range = start as *mut core::ffi::c_void;
+        let len = hi - start;
+        // SAFETY: `[start, hi)` lies inside the `__BUN` segment, whose maximum
+        // protection is read-write; nothing else runs in this process yet, so
+        // no write lands while the range is read-only.
+        let rc = unsafe { libc::mprotect(range, len, libc::PROT_READ) };
+        if rc != 0 {
+            bun_core::scoped_log!(
+                StandaloneModuleGraph,
+                "prefetch: mprotect failed errno={}",
+                bun_sys::last_errno()
+            );
+            return;
+        }
+        // SAFETY: same range; `MADV_WILLNEED` neither reads nor writes through it.
+        let advised = unsafe { libc::madvise(range, len, libc::MADV_WILLNEED) };
+        let advise_errno = bun_sys::last_errno();
+        // SAFETY: restores the segment's own protection on the same range.
+        let restored = unsafe { libc::mprotect(range, len, libc::PROT_READ | libc::PROT_WRITE) };
+        if restored != 0 {
+            bun_core::scoped_log!(
+                StandaloneModuleGraph,
+                "prefetch: mprotect restore failed errno={}",
+                bun_sys::last_errno()
+            );
+            return;
+        }
+        if advised != 0 {
+            bun_core::scoped_log!(
+                StandaloneModuleGraph,
+                "prefetch: madvise failed errno={}",
+                advise_errno
+            );
+            return;
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        const PIECE: usize = 128 * 1024;
+        let mut at = start;
+        while at < hi {
+            let len = PIECE.min(hi - at);
+            // SAFETY: `[at, at + len)` lies inside the mapped executable image;
+            // `MADV_WILLNEED` neither reads nor writes through it.
+            let rc =
+                unsafe { libc::madvise(at as *mut core::ffi::c_void, len, libc::MADV_WILLNEED) };
+            if rc != 0 {
+                bun_core::scoped_log!(
+                    StandaloneModuleGraph,
+                    "prefetch: madvise failed errno={}",
+                    bun_sys::last_errno()
+                );
+                return;
+            }
+            at += len;
+        }
+    }
+    bun_core::scoped_log!(
+        StandaloneModuleGraph,
+        "prefetch: MADV_WILLNEED {} bytes",
+        hi - lo
+    );
 }
 
 /// Writes the ahead-of-time bytecode of the internal modules, the shared

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1224,6 +1224,23 @@ pub mod O {
     #[cfg(not(target_os = "macos"))]
     pub const NOFOLLOW_ANY: i32 = 0;
 }
+
+/// `madvise(2)` advice values; see `bun_sys::madvise`.
+#[cfg(unix)]
+pub mod MADV {
+    pub const NORMAL: i32 = libc::MADV_NORMAL;
+    pub const WILLNEED: i32 = libc::MADV_WILLNEED;
+    pub const DONTNEED: i32 = libc::MADV_DONTNEED;
+}
+
+/// `mprotect(2)` / `mmap(2)` page protection bits; see `bun_sys::mprotect`.
+#[cfg(unix)]
+pub mod PROT {
+    pub const NONE: i32 = libc::PROT_NONE;
+    pub const READ: i32 = libc::PROT_READ;
+    pub const WRITE: i32 = libc::PROT_WRITE;
+    pub const EXEC: i32 = libc::PROT_EXEC;
+}
 // ──────────────────────────────────────────────────────────────────────────
 // `File` / `Dir` — high-level handles. Extracted to file.rs / dir.rs.
 // ──────────────────────────────────────────────────────────────────────────
@@ -1393,6 +1410,8 @@ impl Tag {
     #[cfg(not(windows))]
     pub(crate) const setrlimit: Tag = Tag(106);
     pub const clone3: Tag = Tag(107);
+    pub const madvise: Tag = Tag(108);
+    pub const mprotect: Tag = Tag(109);
     // `inotify_init1`/`inotify_add_watch` fold under the generic `.watch`
     // tag; `INotifyWatcher.rs` spells it `.inotify`. Alias to `.watch`
     // so the JS-facing `err.syscall == "watch"` string stays node-compatible.
@@ -1400,7 +1419,7 @@ impl Tag {
     /// The tag name — spelling is frozen (JS-facing
     /// `err.syscall` string; node-compat code matches on it).
     pub fn name(self) -> &'static str {
-        const NAMES: [&str; 108] = [
+        const NAMES: [&str; 110] = [
             "TODO",
             "dup",
             "access",
@@ -1510,6 +1529,8 @@ impl Tag {
             "getrlimit",
             "setrlimit",
             "clone3",
+            "madvise",
+            "mprotect",
         ];
         NAMES.get(self.0 as usize).copied().unwrap_or("unknown")
     }
@@ -3343,6 +3364,32 @@ mod posix_impl {
         Ok(())
     }
 
+    /// `madvise(2)` with one of `MADV::*` over the pages of `[ptr, ptr + len)`.
+    /// `ptr` must be page aligned. Callers own the mapping and pick advice that
+    /// keeps its contents intact for every live reference into it.
+    pub fn madvise(ptr: *mut u8, len: usize, advice: i32) -> Maybe<()> {
+        check!(
+            // SAFETY: `madvise` neither reads nor writes through `ptr`; the kernel
+            // validates the range and reports a bad one as ENOMEM/EINVAL.
+            unsafe { libc::madvise(ptr.cast(), len, advice) },
+            Tag::madvise
+        );
+        Ok(())
+    }
+
+    /// `mprotect(2)`: sets the `PROT::*` bits of the pages of `[ptr, ptr + len)`.
+    /// `ptr` must be page aligned. Callers own the mapping and must not hold
+    /// references that access it in a way the new protection forbids.
+    pub fn mprotect(ptr: *mut u8, len: usize, prot: i32) -> Maybe<()> {
+        check!(
+            // SAFETY: `mprotect` neither reads nor writes through `ptr`; the kernel
+            // validates the range and reports a bad one as ENOMEM/EINVAL/EACCES.
+            unsafe { libc::mprotect(ptr.cast(), len, prot) },
+            Tag::mprotect
+        );
+        Ok(())
+    }
+
     /// `bun.sys.mmapFile` — open `path` RDWR, fstat for size, mmap [offset, offset+len).
     /// Returns `(map, delta)` where `map` is the full page-aligned mapping and
     /// `delta = offset % page_size` is the byte offset into `map` at which the
@@ -4412,6 +4459,12 @@ mod windows_impl {
     }
     pub fn munmap(_ptr: *mut u8, _len: usize) -> Maybe<()> {
         Err(Error::new(E::ENOTSUP, Tag::munmap))
+    }
+    pub fn madvise(_ptr: *mut u8, _len: usize, _advice: i32) -> Maybe<()> {
+        Err(Error::new(E::ENOTSUP, Tag::madvise))
+    }
+    pub fn mprotect(_ptr: *mut u8, _len: usize, _prot: i32) -> Maybe<()> {
+        Err(Error::new(E::ENOTSUP, Tag::mprotect))
     }
     pub type FcntlInt = isize;
 }

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -128,3 +128,57 @@ test.concurrent.skipIf(isWindows || !isDebug)(
   },
   30_000,
 );
+
+// Before JSC decodes anything, the runtime reads the startup run ahead: the
+// entry point's bytecode and the bytecode string table, which holds the
+// literal below. The source text is a separate run and is not part of it.
+test.concurrent.skipIf(isWindows || !isDebug)(
+  "standalone prefetch covers the startup bytecode and not the source text",
+  async () => {
+    const literalBytes = 64 * 1024;
+    using dir = tempDir("standalone-prefetch", {
+      "entry.ts": `const s = "${Buffer.alloc(literalBytes, "a").toString()}";\nconsole.log("len=" + s.length);\n`,
+    });
+
+    const out = path.join(String(dir), "compiled");
+    const build = Bun.spawnSync({
+      cmd: [bunExe(), "build", "--compile", "--bytecode", path.join(String(dir), "entry.ts"), "--outfile", out],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    expect(build.stderr.toString()).not.toContain("error:");
+    expect(build.exitCode).toBe(0);
+
+    for (const [flag, prefetched] of [
+      [undefined, true],
+      ["1", false],
+    ] as const) {
+      await using proc = Bun.spawn({
+        cmd: [out],
+        env: {
+          ...bunEnv,
+          BUN_DEBUG_StandaloneModuleGraph: "1",
+          BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE: flag,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain(`len=${literalBytes}`);
+      const prefetch = stdout.match(/prefetch: MADV_WILLNEED (\d+) bytes/);
+      if (prefetched) {
+        expect(prefetch).not.toBeNull();
+        const bytes = Number(prefetch![1]);
+        expect(bytes).toBeGreaterThan(literalBytes);
+        expect(bytes).toBeLessThan(2 * literalBytes);
+      } else {
+        expect(stdout).not.toContain("prefetch:");
+      }
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    }
+  },
+  30_000,
+);

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -171,8 +171,11 @@ test.concurrent.skipIf(isWindows || !isDebug)(
       if (prefetched) {
         expect(prefetch).not.toBeNull();
         const bytes = Number(prefetch![1]);
+        // The string table holds the literal; the module's bytecode and
+        // module info add under a kilobyte. The source text would add
+        // another copy of the literal.
         expect(bytes).toBeGreaterThan(literalBytes);
-        expect(bytes).toBeLessThan(2 * literalBytes);
+        expect(bytes).toBeLessThan(literalBytes + 16 * 1024);
       } else {
         expect(stdout).not.toContain("prefetch:");
       }

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -131,13 +131,16 @@ test.concurrent.skipIf(isWindows || !isDebug)(
 
 // Before JSC decodes anything, the runtime reads the startup run ahead: the
 // entry point's bytecode and the bytecode string table, which holds the
-// literal below. The source text is a separate run and is not part of it.
+// literal below. The source text is a separate run and is not part of it;
+// the text import lives only there, so a run that covered the source text
+// would be at least twice the literal.
 test.concurrent.skipIf(isWindows || !isDebug)(
   "standalone prefetch covers the startup bytecode and not the source text",
   async () => {
     const literalBytes = 64 * 1024;
     using dir = tempDir("standalone-prefetch", {
-      "entry.ts": `const s = "${Buffer.alloc(literalBytes, "a").toString()}";\nconsole.log("len=" + s.length);\n`,
+      "entry.ts": `import pad from "./pad.txt" with { type: "text" };\nconst s = "${Buffer.alloc(literalBytes, "a").toString()}";\nconsole.log("len=" + s.length + " pad=" + pad.length);\n`,
+      "pad.txt": Buffer.alloc(literalBytes, "b").toString(),
     });
 
     const out = path.join(String(dir), "compiled");
@@ -166,14 +169,14 @@ test.concurrent.skipIf(isWindows || !isDebug)(
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect(stdout).toContain(`len=${literalBytes}`);
+      expect(stdout).toContain(`len=${literalBytes} pad=${literalBytes}`);
       const prefetch = stdout.match(/prefetch: MADV_WILLNEED (\d+) bytes/);
       if (prefetched) {
         expect(prefetch).not.toBeNull();
         const bytes = Number(prefetch![1]);
         // The string table holds the literal; the module's bytecode and
-        // module info add under a kilobyte. The source text would add
-        // another copy of the literal.
+        // module info add under a kilobyte. The source text (the entry's
+        // source plus the text import) would add two more copies.
         expect(bytes).toBeGreaterThan(literalBytes);
         expect(bytes).toBeLessThan(literalBytes + 16 * 1024);
       } else {


### PR DESCRIPTION
### Problem
- #40407 prefetches the startup bytecode of a `--compile --bytecode` executable on a cold start. On macOS it used `fcntl(F_RDADVISE)`, which needs a file descriptor and a file offset. For those it read the Mach-O load commands (`getsegbyname("__BUN")`), asked dyld for the slide and the image path, and opened the executable (`macho::read_ahead` in `src/standalone_graph/StandaloneModuleGraph.rs`).
- The payload's address is already known: it is the `BUN_COMPILED` symbol. The prefetch should work from that address alone.

### Fix
- One `read_ahead` for macOS and Linux: `madvise(MADV_WILLNEED)` over the startup run's pages. The dyld and libmacho externs, the open, and `F_RDADVISE` are gone. `bun_sys` gains `madvise` and `mprotect` wrappers (with `MADV::*` and `PROT::*` constants), used here and by the existing `MADV_DONTNEED` hint.
- On macOS the range is read-only during the call. XNU's `vm_map_willneed` write-faults a writable mapping, which copies every page out of the page cache. Measured on a 24 MB range: phys_footprint +24 MB without the `mprotect` pair, +48 KB with it.
- Linux keeps the 128 KiB pieces (one call reads at most `max(bdi->io_pages, ra_pages)`).
- The prefetched run now also covers the module-info string table that #40509 added right after the bytecode string table.
- Verified: `test/js/bun/compile/standalone-madvise-tla.test.ts` (new test: the prefetched run holds the 64 KiB literal in the bytecode string table but not the 64 KiB text import, which lives only in the source text, and the feature flag skips the prefetch). Also `bundler_compile_splitting.test.ts` and `bundler_compile.test.ts`.

### Background
- A compiled executable carries the module graph in its own segment (`__BUN` on Mach-O, `.bun` on ELF). The kernel maps it with the executable, so the payload is plain memory at `BUN_COMPILED`. JSC patches some bytecode in place, so the segment is read-write.
- On a cold start every page JSC touches is one disk read. `MADV_WILLNEED` asks the kernel to read a range ahead. Linux queues the readahead and returns. macOS faults the pages in synchronously, in reads of up to 1 MiB. Its only asynchronous read-ahead call is `F_RDADVISE`, on a file descriptor.

<details><summary>Notes</summary>

Measurements on the macOS CI minis, 24 MB file, private writable mapping, evicted from the page cache with `msync(MS_INVALIDATE)` before each run. `touch` reads one byte per page.

M2 mini, macOS 26 (16 KiB pages):

| | call | touch after | total |
|---|---|---|---|
| faults only, sequential | | 48 ms | 48 ms |
| faults only, strided | | 130 ms | 130 ms |
| `MADV_WILLNEED`, RW mapping | 15.5 ms | 0.07 ms | 15.6 ms, phys_footprint +24 MB |
| `mprotect(RO)`, `MADV_WILLNEED`, `mprotect(RW)` | 13.9 ms | 0.15 ms | 14 ms, phys_footprint +48 KB |
| `F_RDADVISE` (#40407) | 1.2 ms | 6.3 ms | 7.5 ms |
| warm, faults only | | 1.7 ms | |
| warm, `mprotect` + `MADV_WILLNEED` | 0.7 ms | 0.05 ms | |

Intel i7 mini, macOS 14 (4 KiB pages): faults only 51 ms sequential and 175 to 209 ms strided. `MADV_WILLNEED` 47 ms. `F_RDADVISE` 8 ms.

Also tried: `MADV_SEQUENTIAL` (no gain, hurts strided access), `MADV_WILLNEED` on a helper thread while the main thread faults the same pages (slower than the plain call). One `MADV_WILLNEED` call covers the whole range on macOS 14, 15 and 26. Pieces under 1 MiB make it slower (256 KiB pieces: 45 ms).

Linux, this container (6.17, 24 MB): cold faults 77 to 102 ms, `MADV_WILLNEED` in 128 KiB pieces 6.4 ms call plus 1.6 ms touch. Warm: the 192 calls cost 0.22 ms.

Real binary, from this PR's darwin-aarch64 CI artifact, on the same M2 mini (a CI agent was running jobs on it, so absolute numbers are noisy; runs interleaved, medians). App: 40,000 functions all called at startup, `--compile --bytecode`, 21 MB payload. Cold start is the executable evicted with `msync(MS_INVALIDATE)` before each run.

| | prefetch on | prefetch off (`BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1`) |
|---|---|---|
| cold, quiet window (7 runs) | 137 ms (min 131) | 154 ms (min 149) |
| cold, busy window (15 runs) | 213 ms | 234 ms |
| warm (12 runs) | 51 ms | 51 ms |

The main build (`F_RDADVISE`) on the same app and machine: 177 ms on, 184 ms off (busy window). A direct comparison between the two binaries is not meaningful: the CI link order differs between builds (in the profile builds `_mi_thread_init` is function 19 in the base build and function 16034 in this one), and that alone moves the cold start of the same app by tens of milliseconds.

Why `MADV_WILLNEED` blocks and copies on macOS: `osfmk/vm/vm_map.c`, `vm_map_willneed`, calls `vm_pre_fault_with_info` per page with `fault_prot = entry->protection & VM_PROT_WRITE ? VM_PROT_WRITE : VM_PROT_READ` ("Write-fault if the entry supports it to preclude subsequent soft-faults"). Nothing in the Mach VM interface reads file pages asynchronously. The async path is `advisory_read` behind `F_RDADVISE`.

`test/bundler/bundler_compile.test.ts`: `compile/HelloWorldWithProcessVersionsBun` fails on a debug build with or without this change. It compares `process.versions.bun` (`1.4.1-debug`) with `Bun.version` stripped of `-debug`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/compile/standalone-madvise-tla.test.ts

<!-- robobun:evidence:end -->