### PR TITLE
Task/callback carriers own their payload (ManagedTask, S3 callbacks, WriteFile, install pool tasks)

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2846,13 +2846,12 @@ pub mod parse_worker {
             .expect("BundleV2.linker.loop must be set before scheduling ParseTask")
         {
             bun_event_loop::AnyEventLoop::Js { .. } => {
-                let ct =
-                    bun_event_loop::ConcurrentTask::ConcurrentTask::from_callback(result, |p| {
-                        // SAFETY: `p` is the `result` Box leaked above; ownership
-                        // transfers to `on_complete`, which deallocates it.
-                        unsafe { on_complete(p) };
-                        Ok(())
-                    });
+                let ct = bun_event_loop::ConcurrentTask::ConcurrentTask::from_callback(move || {
+                    // SAFETY: `result` is the Box leaked above; ownership
+                    // transfers to `on_complete`, which deallocates it.
+                    unsafe { on_complete(result) };
+                    Ok(())
+                });
                 let poster = worker
                     .ctx
                     .js_poster

--- a/src/bundler/ServerComponentParseTask.rs
+++ b/src/bundler/ServerComponentParseTask.rs
@@ -117,10 +117,10 @@ fn task_callback_wrap(thread_pool_task: *mut ThreadPoolTask) {
         .expect("BundleV2.linker.loop must be set before scheduling ServerComponentParseTask")
     {
         bun_event_loop::AnyEventLoop::Js { .. } => {
-            let ct = bun_event_loop::ConcurrentTask::ConcurrentTask::from_callback(result, |p| {
-                // SAFETY: `p` is the `result` Box leaked above; ownership
+            let ct = bun_event_loop::ConcurrentTask::ConcurrentTask::from_callback(move || {
+                // SAFETY: `result` is the Box leaked above; ownership
                 // transfers to `on_complete`, which deallocates it.
-                unsafe { on_complete(p) };
+                unsafe { on_complete(result) };
                 Ok(())
             });
             let poster = worker

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4376,10 +4376,13 @@ pub mod bv2_impl {
             // mutate `graph` / allocate from `graph.heap` off-thread.
             match self.any_loop_mut() {
                 bun_event_loop::AnyEventLoop::Js { .. } => {
-                    let ct = bun_event_loop::ConcurrentTask::ConcurrentTask::from_callback(
-                        std::ptr::from_mut(load),
-                        on_load_from_js_loop_raw,
-                    );
+                    let load = std::ptr::from_mut(load);
+                    let ct =
+                        bun_event_loop::ConcurrentTask::ConcurrentTask::from_callback(move || {
+                            // SAFETY: `load` lives until it is answered on this hop.
+                            on_load_from_js_loop(unsafe { &mut *load });
+                            Ok(())
+                        });
                     let poster = self
                         .js_poster
                         .as_ref()
@@ -4410,10 +4413,13 @@ pub mod bv2_impl {
             // See `on_load_async` — must dispatch on the bundler's own loop.
             match self.any_loop_mut() {
                 bun_event_loop::AnyEventLoop::Js { .. } => {
-                    let ct = bun_event_loop::ConcurrentTask::ConcurrentTask::from_callback(
-                        std::ptr::from_mut(resolve),
-                        on_resolve_from_js_loop_raw,
-                    );
+                    let resolve = std::ptr::from_mut(resolve);
+                    let ct =
+                        bun_event_loop::ConcurrentTask::ConcurrentTask::from_callback(move || {
+                            // SAFETY: `resolve` lives until it is answered on this hop.
+                            on_resolve_from_js_loop(unsafe { &mut *resolve });
+                            Ok(())
+                        });
                     let poster = self
                         .js_poster
                         .as_ref()
@@ -4457,14 +4463,6 @@ pub mod bv2_impl {
         // SAFETY: `bv2` is a live backref set in `Load::init`.
         let bv2 = unsafe { &mut *load.bv2 };
         BundleV2::on_load(load, bv2);
-    }
-
-    fn on_load_from_js_loop_raw(
-        load: *mut jsc_api::JSBundler::Load,
-    ) -> bun_event_loop::JsResult<()> {
-        // SAFETY: `load` is a valid pointer set up by `from_callback`.
-        on_load_from_js_loop(unsafe { &mut *load });
-        Ok(())
     }
 
     impl<'a> BundleV2<'a> {
@@ -4658,14 +4656,6 @@ pub mod bv2_impl {
         // SAFETY: `bv2` is a live backref set in `Resolve::init`.
         let bv2 = unsafe { &mut *resolve.bv2 };
         BundleV2::on_resolve(resolve, bv2);
-    }
-
-    fn on_resolve_from_js_loop_raw(
-        resolve: *mut jsc_api::JSBundler::Resolve,
-    ) -> bun_event_loop::JsResult<()> {
-        // SAFETY: `resolve` is a valid pointer set up by `from_callback`.
-        on_resolve_from_js_loop(unsafe { &mut *resolve });
-        Ok(())
     }
 
     impl<'a> BundleV2<'a> {

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -200,7 +200,7 @@ impl Taskable for crate::ManagedTask::ManagedTask {
     const TAG: TaskTag = task_tag::ManagedTask;
     unsafe fn release_unrun(this: *mut Self) {
         // SAFETY: fn contract — a queued ManagedTask is the heap box `new` made.
-        unsafe { crate::ManagedTask::ManagedTask::release(this) }
+        unsafe { crate::ManagedTask::ManagedTask::release_unrun(this) }
     }
 }
 // ────────────────────────────────────────────────────────────────────────────
@@ -287,7 +287,7 @@ impl ConcurrentTask {
         Self::create(Task::init(task))
     }
 
-    /// Heap task that runs `f` once on the JS thread (see [`ManagedTask`]).
+    /// Heap task that runs `f` once on the JS thread (see [`ManagedTask::ManagedTask`]).
     pub fn from_callback<F: FnOnce() -> crate::JsResult<()> + 'static>(
         f: F,
     ) -> core::ptr::NonNull<ConcurrentTask> {
@@ -338,7 +338,7 @@ impl ConcurrentTask {
         // closure behind `task.ptr` as well.
         if inner.tag == crate::task_tag::ManagedTask {
             // SAFETY: as above; refused ⇒ ours.
-            unsafe { crate::ManagedTask::ManagedTask::release(inner.ptr.cast()) };
+            unsafe { crate::ManagedTask::ManagedTask::release_unrun(inner.ptr.cast()) };
         }
     }
 

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -199,7 +199,7 @@ impl Task {
 impl Taskable for crate::ManagedTask::ManagedTask {
     const TAG: TaskTag = task_tag::ManagedTask;
     unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract — a queued ManagedTask is the heap box `new*` made.
+        // SAFETY: fn contract — a queued ManagedTask is the heap box `new` made.
         unsafe { crate::ManagedTask::ManagedTask::release(this) }
     }
 }
@@ -287,14 +287,12 @@ impl ConcurrentTask {
         Self::create(Task::init(task))
     }
 
-    // callback returns `JsResult<()>` to match `ManagedTask::new`'s stored ABI;
-    // callers that have a `fn(*mut T)` should wrap it as `|p| { f(p); Ok(()) }` at the call site.
-    pub fn from_callback<T>(
-        ptr: *mut T,
-        callback: fn(*mut T) -> crate::JsResult<()>,
+    /// Heap task that runs `f` once on the JS thread (see [`ManagedTask`]).
+    pub fn from_callback<F: FnOnce() -> crate::JsResult<()> + 'static>(
+        f: F,
     ) -> core::ptr::NonNull<ConcurrentTask> {
         bun_core::mark_binding!();
-        Self::create(ManagedTask::ManagedTask::new(ptr, callback))
+        Self::create(ManagedTask::ManagedTask::new(f))
     }
 
     pub fn from<T: Taskable>(
@@ -336,8 +334,8 @@ impl ConcurrentTask {
     pub unsafe fn release_refused(task: core::ptr::NonNull<ConcurrentTask>) {
         // SAFETY: fn contract.
         let inner = unsafe { Self::into_task(task) };
-        // A callback task (`from_callback`, `ManagedTask::new*`) owns a heap
-        // `ManagedTask` behind `task.ptr` as well.
+        // A callback task (`from_callback`, `ManagedTask::new`) owns its
+        // closure behind `task.ptr` as well.
         if inner.tag == crate::task_tag::ManagedTask {
             // SAFETY: as above; refused ⇒ ours.
             unsafe { crate::ManagedTask::ManagedTask::release(inner.ptr.cast()) };

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -8,7 +8,7 @@ use crate::{JsResult, Task};
 #[repr(C)]
 pub struct ManagedTask {
     run: unsafe fn(*mut ManagedTask) -> JsResult<()>,
-    release: unsafe fn(*mut ManagedTask),
+    release_unrun: unsafe fn(*mut ManagedTask),
 }
 
 #[repr(C)]
@@ -25,8 +25,10 @@ impl ManagedTask {
                 // SAFETY: only reached through this header, so `p` is this
                 // `ManagedTaskOf<F>`; consumes the box.
                 run: |p| (unsafe { bun_core::heap::take(p.cast::<ManagedTaskOf<F>>()) }.f)(),
-                // SAFETY: as above.
-                release: |p| drop(unsafe { bun_core::heap::take(p.cast::<ManagedTaskOf<F>>()) }),
+                release_unrun: |p| {
+                    // SAFETY: as above.
+                    drop(unsafe { bun_core::heap::take(p.cast::<ManagedTaskOf<F>>()) })
+                },
             },
             f,
         }));
@@ -47,7 +49,7 @@ impl ManagedTask {
     /// As [`run`](Self::run).
     pub(crate) unsafe fn release_unrun(this: *mut ManagedTask) {
         // SAFETY: fn contract.
-        unsafe { ((*this).release)(this) }
+        unsafe { ((*this).release_unrun)(this) }
     }
 }
 

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -45,7 +45,7 @@ impl ManagedTask {
     ///
     /// # Safety
     /// As [`run`](Self::run).
-    pub unsafe fn release(this: *mut ManagedTask) {
+    pub(crate) unsafe fn release_unrun(this: *mut ManagedTask) {
         // SAFETY: fn contract.
         unsafe { ((*this).release)(this) }
     }

--- a/src/event_loop/ManagedTask.rs
+++ b/src/event_loop/ManagedTask.rs
@@ -1,83 +1,54 @@
-//! This is a slow, dynamically-allocated one-off task
-//! Use it when you can't add to jsc.Task directly and managing the lifetime of the Task struct is overly complex
-
-use core::ffi::c_void;
-use core::ptr::NonNull;
+//! A one-off queued closure. Use it when adding a dedicated `Task` tag is not
+//! worth it; the closure and everything it captured are dropped, not run, if
+//! the VM stops first.
 
 use crate::{JsResult, Task};
 
+/// Type-erased head of a [`ManagedTaskOf<F>`]; `Task::ptr` points here.
+#[repr(C)]
 pub struct ManagedTask {
-    // Opaque userdata pointer round-tripped through `new`/`run`; raw by design.
-    pub ctx: Option<NonNull<c_void>>,
-    pub(crate) callback: fn(*mut c_void) -> JsResult<()>,
-    pub cleanup: Option<fn(*mut c_void)>,
+    run: unsafe fn(*mut ManagedTask) -> JsResult<()>,
+    release: unsafe fn(*mut ManagedTask),
+}
+
+#[repr(C)]
+struct ManagedTaskOf<F> {
+    header: ManagedTask,
+    f: F,
 }
 
 impl ManagedTask {
-    pub(crate) fn task(this: *mut ManagedTask) -> Task {
-        // Per §Dispatch (tag+ptr), name the tag explicitly.
-        Task::new(crate::task_tag::ManagedTask, this.cast())
+    /// Queueable task that runs `f` once on the JS thread.
+    pub fn new<F: FnOnce() -> JsResult<()> + 'static>(f: F) -> Task {
+        let task = bun_core::heap::into_raw(Box::new(ManagedTaskOf {
+            header: ManagedTask {
+                // SAFETY: only reached through this header, so `p` is this
+                // `ManagedTaskOf<F>`; consumes the box.
+                run: |p| (unsafe { bun_core::heap::take(p.cast::<ManagedTaskOf<F>>()) }.f)(),
+                // SAFETY: as above.
+                release: |p| drop(unsafe { bun_core::heap::take(p.cast::<ManagedTaskOf<F>>()) }),
+            },
+            f,
+        }));
+        Task::new(crate::task_tag::ManagedTask, task.cast())
     }
 
     /// # Safety
-    /// `this` must be the live `*mut ManagedTask` embedded in a `Task` returned
-    /// by `new()`/`new_owned()`; ownership transfers — `this` is freed (via
-    /// `heap::take`) before return on both Ok and Err paths.
+    /// `this` is the `Task::ptr` of a task built by [`new`](Self::new); it is
+    /// consumed.
     pub unsafe fn run(this: *mut ManagedTask) -> JsResult<()> {
-        // SAFETY: `this` was produced by `heap::into_raw` in `new`/`new_owned`
-        // (caller contract). Reconstituting the Box here frees it at scope
-        // exit on both the Ok and Err paths.
-        let this = unsafe { bun_core::heap::take(this) };
-        let callback = this.callback;
-        let ctx = this.ctx;
-        callback(ctx.unwrap().as_ptr())
+        // SAFETY: fn contract.
+        unsafe { ((*this).run)(this) }
     }
 
-    /// Free without running: the owned context (if `new_owned`) is dropped.
+    /// Drop the closure without running it.
     ///
     /// # Safety
-    /// As [`run`](Self::run); the task is not queued anywhere.
+    /// As [`run`](Self::run).
     pub unsafe fn release(this: *mut ManagedTask) {
         // SAFETY: fn contract.
-        let this = unsafe { bun_core::heap::take(this) };
-        if let (Some(cleanup), Some(ctx)) = (this.cleanup, this.ctx) {
-            cleanup(ctx.as_ptr());
-        }
-    }
-
-    // A per-(Type, Callback) trampoline is folded away by storing
-    // the type-erased fn pointer directly — `fn(*mut T)` and `fn(*mut c_void)` share ABI.
-    pub fn new<T>(ctx: *mut T, callback: fn(*mut T) -> JsResult<()>) -> Task {
-        let managed = bun_core::heap::into_raw(Box::new(ManagedTask {
-            // SAFETY: `fn(*mut T) -> R` and `fn(*mut c_void) -> R` have identical
-            // ABI for all `T: Sized`; `run` passes back the exact pointer stored
-            // in `ctx` below, so the callee observes its original `*mut T`.
-            callback: unsafe {
-                bun_ptr::cast_fn_ptr::<fn(*mut T) -> JsResult<()>, fn(*mut c_void) -> JsResult<()>>(
-                    callback,
-                )
-            },
-            ctx: NonNull::new(ctx.cast::<c_void>()),
-            cleanup: None,
-        }));
-        ManagedTask::task(managed)
-    }
-
-    pub fn new_owned<T>(ctx: *mut T, callback: fn(*mut T) -> JsResult<()>) -> Task {
-        fn drop_ctx<T>(p: *mut c_void) {
-            // SAFETY: `p` is the `heap::into_raw(Box<T>)` stored in `ctx` by `new_owned`.
-            unsafe { bun_core::heap::destroy(p.cast::<T>()) };
-        }
-        let managed = bun_core::heap::into_raw(Box::new(ManagedTask {
-            // SAFETY: same fn-pointer ABI cast as `new`.
-            callback: unsafe {
-                bun_ptr::cast_fn_ptr::<fn(*mut T) -> JsResult<()>, fn(*mut c_void) -> JsResult<()>>(
-                    callback,
-                )
-            },
-            ctx: NonNull::new(ctx.cast::<c_void>()),
-            cleanup: Some(drop_ctx::<T>),
-        }));
-        ManagedTask::task(managed)
+        unsafe { ((*this).release)(this) }
     }
 }
+
+const _: () = assert!(core::mem::offset_of!(ManagedTaskOf<[usize; 3]>, header) == 0);

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -10,7 +10,6 @@ use bun_semver::String as SemverString;
 #[cfg(not(windows))]
 use bun_sys::OpenDirOptions;
 use bun_sys::{self as sys, Dir, EntryKind, Fd, FdExt, walker_skippable};
-use bun_threading::thread_pool::{Batch, Node as ThreadPoolNode};
 use bun_threading::work_pool::Task as WorkPoolTask;
 #[cfg(windows)]
 use bun_threading::{ThreadPool, WaitGroup};
@@ -449,29 +448,17 @@ impl<TaskType> NewTaskQueue<TaskType> {
         self.wait_group.finish();
     }
 
-    /// # Safety
-    /// `task` must point to a live, Box-allocated `TaskType` whose ownership is
-    /// being handed to the thread pool; the worker reclaims it in its callback.
-    pub(crate) unsafe fn push(&self, task: *mut TaskType)
+    pub(crate) fn push(&self, task: Box<TaskType>)
     where
-        TaskType: HasWorkPoolTask,
+        TaskType: bun_threading::OwnedTask,
     {
         self.wait_group.add_one();
-        // SAFETY: caller contract — `task` is a valid Box-allocated task; `.task()`
-        // is the intrusive node field.
-        self.thread_pool.schedule(Batch::from(unsafe {
-            std::ptr::from_mut::<WorkPoolTask>((*task).task())
-        }));
+        self.thread_pool.schedule_owned(task);
     }
 
     pub(crate) fn wait(&self) {
         self.wait_group.wait();
     }
-}
-
-#[cfg(windows)]
-pub(crate) trait HasWorkPoolTask {
-    fn task(&mut self) -> &mut WorkPoolTask;
 }
 
 // ───────────────────────────── HardLinkWindowsInstallTask ─────────────────────────────
@@ -490,11 +477,7 @@ struct HardLinkWindowsInstallTask {
 }
 
 #[cfg(windows)]
-impl HasWorkPoolTask for HardLinkWindowsInstallTask {
-    fn task(&mut self) -> &mut WorkPoolTask {
-        &mut self.task
-    }
-}
+bun_threading::owned_task!(HardLinkWindowsInstallTask, task);
 
 #[cfg(windows)]
 type HardLinkQueue = NewTaskQueue<HardLinkWindowsInstallTask>;
@@ -546,7 +529,7 @@ impl HardLinkWindowsInstallTask {
         }
     }
 
-    fn init(src: &[OSPathChar], dest: &[OSPathChar], basename: &[OSPathChar]) -> *mut Self {
+    fn init(src: &[OSPathChar], dest: &[OSPathChar], basename: &[OSPathChar]) -> Box<Self> {
         let allocation_size = src.len() + 1 + dest.len() + 1;
 
         let mut combined = vec![0u16; allocation_size].into_boxed_slice();
@@ -556,41 +539,30 @@ impl HardLinkWindowsInstallTask {
         remaining[..dest.len()].copy_from_slice(dest);
         remaining[dest.len()] = 0;
 
-        bun_core::heap::into_raw(Box::new(Self {
+        Box::new(Self {
             bytes: combined,
             src_len: src.len(),
             basename: basename.len() as u16, // @truncate
-            task: WorkPoolTask {
-                callback: Self::run_from_thread_pool,
-                node: ThreadPoolNode::default(),
-            },
+            task: WorkPoolTask::default(),
             err: None,
-        }))
+        })
     }
 
-    fn run_from_thread_pool(task: *mut WorkPoolTask) {
-        // SAFETY: task points to the `task` field of a HardLinkWindowsInstallTask.
-        let self_: *mut Self = unsafe { bun_core::from_field_ptr!(Self, task, task) };
+    fn run_owned(self: Box<Self>) {
         // SAFETY: HARDLINK_QUEUE initialized by init_queue() before scheduling.
         let queue = unsafe { (*HARDLINK_QUEUE.get()).assume_init_ref() };
+        // Declared before `this` so the task is freed before `wait()` can return.
         scopeguard::defer! { queue.complete_one(); }
+        let mut this = self;
 
-        // SAFETY: self_ is valid until we reclaim the Box below.
-        if let Some(err) = unsafe { (*self_).run() } {
-            unsafe { (*self_).err = Some(err) };
-            // SAFETY: self_ was heap-allocated in init(); reclaim ownership now.
-            let boxed = unsafe { bun_core::heap::take(self_) };
-            // First-write-wins: keep only the first error. Any later failing task
-            // simply drops its Box here (leaking it would also leak the inner
-            // `Box<[u16]>` per failed file).
+        if let Some(err) = this.run() {
+            this.err = Some(err);
+            // First-write-wins: keep only the first error.
             let mut slot = queue.errored_task.lock();
             if slot.is_none() {
-                *slot = Some(boxed);
+                *slot = Some(this);
             }
-            return;
         }
-        // SAFETY: self_ was heap-allocated in init().
-        unsafe { drop(bun_core::heap::take(self_)) };
     }
 
     fn run(&mut self) -> Option<crate::Error> {
@@ -667,14 +639,12 @@ struct UninstallTask {
     absolute_path: Box<[u8]>,
     task: WorkPoolTask,
 }
+bun_threading::owned_task!(UninstallTask, task);
 
 impl UninstallTask {
-    fn run(task: *mut WorkPoolTask) {
-        // SAFETY: task points to the `task` field of an UninstallTask.
-        let uninstall_task: *mut Self = unsafe { bun_core::from_field_ptr!(Self, task, task) };
-
-        // declared *before* the Box is reclaimed so it drops *after* the
-        // Box — Rust drops locals in reverse declaration order. The task must be freed
+    fn run_owned(self: Box<Self>) {
+        // declared *before* the Box binding so it drops *after* the Box —
+        // Rust drops locals in reverse declaration order. The task must be freed
         // before the main thread can observe pending_tasks==0.
         scopeguard::defer! {
             let pm = crate::package_manager::get();
@@ -688,8 +658,7 @@ impl UninstallTask {
             }
         }
 
-        // SAFETY: heap-allocated in uninstall_before_install; reclaim ownership here.
-        let uninstall_task = unsafe { bun_core::heap::take(uninstall_task) };
+        let uninstall_task = self;
         let mut debug_timer = Output::DebugTimer::start();
 
         let dirname =
@@ -1653,15 +1622,11 @@ impl<'a> PackageInstall<'a> {
                     head2[src_len] = 0;
                     let src = bun_core::WStr::from_buf(head2, src_len);
 
-                    // SAFETY: `init` returns a fresh Box-allocated task; ownership
-                    // transfers to the thread pool, reclaimed in `run_from_thread_pool`.
-                    unsafe {
-                        queue.push(HardLinkWindowsInstallTask::init(
-                            src.as_slice(),
-                            dest.as_slice(),
-                            entry.basename.as_slice(),
-                        ));
-                    }
+                    queue.push(HardLinkWindowsInstallTask::init(
+                        src.as_slice(),
+                        dest.as_slice(),
+                        entry.basename.as_slice(),
+                    ));
                 }
             }
 
@@ -1967,13 +1932,10 @@ impl<'a> PackageInstall<'a> {
                     bun_fs::FileSystem::instance().top_level_dir(),
                     &[&self.node_modules.path, temp_path.as_bytes()],
                 );
-                let task = bun_core::heap::into_raw(Box::new(UninstallTask {
+                let task = Box::new(UninstallTask {
                     absolute_path: absolute_path.to_vec().into_boxed_slice(),
-                    task: WorkPoolTask {
-                        callback: UninstallTask::run,
-                        node: ThreadPoolNode::default(),
-                    },
-                }));
+                    task: WorkPoolTask::default(),
+                });
                 let pm = crate::package_manager::get();
                 // SAFETY: `uninstall_before_install` runs on the install main thread.
                 // Raw-pointer field projection avoids forming `&mut PackageManager`
@@ -1984,12 +1946,7 @@ impl<'a> PackageInstall<'a> {
                     *core::ptr::addr_of_mut!((*pm).total_tasks) += 1;
                     (*pm).pending_tasks.fetch_add(1, Ordering::Relaxed);
                 }
-                // SAFETY: task is a valid heap allocation; .task is the intrusive node.
-                PackageManager::get()
-                    .thread_pool
-                    .schedule(Batch::from(unsafe {
-                        core::ptr::addr_of_mut!((*task).task)
-                    }));
+                PackageManager::get().thread_pool.schedule_owned(task);
             }
         }
     }

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -658,19 +658,18 @@ impl UninstallTask {
             }
         }
 
-        let uninstall_task = self;
+        let this = self;
         let mut debug_timer = Output::DebugTimer::start();
 
-        let dirname =
-            path::resolve_path::dirname::<path::platform::Auto>(&uninstall_task.absolute_path);
+        let dirname = path::resolve_path::dirname::<path::platform::Auto>(&this.absolute_path);
         if dirname.is_empty() {
             bun_core::debug_warn!(
                 "Unexpectedly failed to get dirname of {}",
-                bstr::BStr::new(&uninstall_task.absolute_path)
+                bstr::BStr::new(&this.absolute_path)
             );
             return;
         }
-        let basename = bun_paths::basename(&uninstall_task.absolute_path);
+        let basename = bun_paths::basename(&this.absolute_path);
 
         let dir = match open_dir_a(Fd::cwd(), dirname) {
             Ok(d) => d,
@@ -678,7 +677,7 @@ impl UninstallTask {
                 if bun_core::Environment::IS_DEBUG || bun_core::Environment::ENABLE_ASAN {
                     bun_core::debug_warn!(
                         "Failed to delete {}: {}",
-                        bstr::BStr::new(&uninstall_task.absolute_path),
+                        bstr::BStr::new(&this.absolute_path),
                         bstr::BStr::new(err.name())
                     );
                 }

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -10,7 +10,7 @@ use bun_semver::String as SemverString;
 #[cfg(not(windows))]
 use bun_sys::OpenDirOptions;
 use bun_sys::{self as sys, Dir, EntryKind, Fd, FdExt, walker_skippable};
-use bun_threading::work_pool::Task as WorkPoolTask;
+use bun_threading::WorkPoolTask;
 #[cfg(windows)]
 use bun_threading::{ThreadPool, WaitGroup};
 
@@ -643,9 +643,8 @@ bun_threading::owned_task!(UninstallTask, task);
 
 impl UninstallTask {
     fn run_owned(self: Box<Self>) {
-        // declared *before* the Box binding so it drops *after* the Box —
-        // Rust drops locals in reverse declaration order. The task must be freed
-        // before the main thread can observe pending_tasks==0.
+        // Declared before `this` so the task is freed before the main thread
+        // can observe `pending_tasks == 0`.
         scopeguard::defer! {
             let pm = crate::package_manager::get();
             // SAFETY: `pending_tasks` is `AtomicU32`; raw-pointer field projection

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1254,9 +1254,7 @@ pub mod package_manifest {
             tmpdir: Fd,
             cache_dir: Fd,
         ) {
-            use bun_threading::thread_pool::{
-                Batch as PoolBatch, Node as PoolNode, Task as PoolTask,
-            };
+            use bun_threading::thread_pool::Task as PoolTask;
 
             struct SaveTask {
                 manifest: PackageManifest,
@@ -1269,28 +1267,12 @@ pub mod package_manifest {
                 task: PoolTask,
             }
 
-            bun_threading::intrusive_work_task!(SaveTask, task);
+            bun_threading::owned_task!(SaveTask, task);
 
             impl SaveTask {
-                fn new(init: SaveTask) -> Box<SaveTask> {
-                    Box::new(init)
-                }
-
-                // Safe-fn: only ever invoked by `ThreadPool` via the `callback`
-                // fn-pointer with the `*mut PoolTask` we registered below
-                // (`heap::into_raw(SaveTask { task: .. })`). The thread-pool
-                // contract — not the Rust caller — guarantees `task` is live
-                // and points at `SaveTask.task`, so the precondition is
-                // discharged locally (matches `HardLinkWindowsInstallTask::
-                // run_from_thread_pool` in PackageInstall.rs). Safe `fn`
-                // coerces to the `unsafe fn(*mut Task)` field type.
-                fn run(task: *mut PoolTask) {
-                    use bun_threading::IntrusiveWorkTask as _;
+                fn run_owned(self: Box<Self>) {
                     let _tracer = bun_core::perf::trace("PackageManifest.Serializer.save");
-
-                    // SAFETY: thread-pool callback contract — `task` points to
-                    // `SaveTask.task`; allocated via `heap::into_raw` in `save_async`.
-                    let save_task = unsafe { bun_core::heap::take(SaveTask::from_task_ptr(task)) };
+                    let save_task = self;
 
                     if let Err(err) = Serializer::save(
                         &save_task.manifest,
@@ -1310,20 +1292,15 @@ pub mod package_manifest {
                 }
             }
 
-            let task = bun_core::heap::into_raw(SaveTask::new(SaveTask {
-                manifest: this.clone(),
-                scope: scope.clone(),
-                tmpdir,
-                cache_dir,
-                task: PoolTask {
-                    node: PoolNode::default(),
-                    callback: SaveTask::run,
-                },
-            }));
-
-            // SAFETY: task is a valid Box-allocated SaveTask
-            let batch = PoolBatch::from(unsafe { core::ptr::addr_of_mut!((*task).task) });
-            PackageManager::get().thread_pool.schedule(batch);
+            PackageManager::get()
+                .thread_pool
+                .schedule_owned(Box::new(SaveTask {
+                    manifest: this.clone(),
+                    scope: scope.clone(),
+                    tmpdir,
+                    cache_dir,
+                    task: PoolTask::default(),
+                }));
         }
 
         fn manifest_file_name<'b>(

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1254,7 +1254,7 @@ pub mod package_manifest {
             tmpdir: Fd,
             cache_dir: Fd,
         ) {
-            use bun_threading::thread_pool::Task as PoolTask;
+            use bun_threading::WorkPoolTask;
 
             struct SaveTask {
                 manifest: PackageManifest,
@@ -1264,26 +1264,23 @@ pub mod package_manifest {
                 tmpdir: Fd,
                 cache_dir: Fd,
 
-                task: PoolTask,
+                task: WorkPoolTask,
             }
 
             bun_threading::owned_task!(SaveTask, task);
 
             impl SaveTask {
+                #[allow(clippy::boxed_local)] // `owned_task!`'s required signature
                 fn run_owned(self: Box<Self>) {
                     let _tracer = bun_core::perf::trace("PackageManifest.Serializer.save");
-                    let save_task = self;
 
-                    if let Err(err) = Serializer::save(
-                        &save_task.manifest,
-                        &save_task.scope,
-                        save_task.tmpdir,
-                        save_task.cache_dir,
-                    ) {
+                    if let Err(err) =
+                        Serializer::save(&self.manifest, &self.scope, self.tmpdir, self.cache_dir)
+                    {
                         if PackageManager::verbose_install() {
                             bun_core::warn!(
                                 "Error caching manifest for {}: {}",
-                                bstr::BStr::new(save_task.manifest.name()),
+                                bstr::BStr::new(self.manifest.name()),
                                 err.name(),
                             );
                             Output::flush();
@@ -1299,7 +1296,7 @@ pub mod package_manifest {
                     scope: scope.clone(),
                     tmpdir,
                     cache_dir,
-                    task: PoolTask::default(),
+                    task: WorkPoolTask::default(),
                 }));
         }
 

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -324,7 +324,7 @@ impl Queue {
         if let crate::vm_handle::Posted::Refused(task) = ctx.handle.post(ctx.kind, task) {
             // That VM has closed: nobody is waiting on these modules any more.
             // SAFETY: refused ⇒ we own the task box.
-            unsafe { drop(bun_core::heap::take(task.as_ptr())) };
+            unsafe { ConcurrentTaskItem::release_refused(task) };
         }
     }
 

--- a/src/jsc/JSCScheduler.rs
+++ b/src/jsc/JSCScheduler.rs
@@ -63,7 +63,7 @@ unsafe extern "C" fn Bun__queueJSCDeferredWorkTaskConcurrently(
         // SAFETY: refused ⇒ we own the ConcurrentTask box; the C++ job's ticket
         // was already cancelled by the VM teardown (DeferredWorkTimer is shut
         // down before ~VM), so dropping the job pointer here loses nothing.
-        drop(unsafe { bun_core::heap::take(ct.as_ptr()) });
+        unsafe { ConcurrentTask::release_refused(ct) };
         // SAFETY: `task` is the C++ job handed over for exactly one run/destroy.
         unsafe { JSCDeferredWorkTask::destroy(task) };
     }

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -358,7 +358,7 @@ impl VmHandle {
         if let Posted::Refused(ct) = self.post(kind, ct) {
             // SAFETY: refused ⇒ we own both boxes.
             unsafe {
-                drop(bun_core::heap::take(ct.as_ptr()));
+                ConcurrentTaskItem::release_refused(ct);
                 Bun__deleteEventLoopTask(task);
             }
         }

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -141,10 +141,8 @@ struct HandledPromiseContext {
 }
 
 impl HandledPromiseContext {
-    fn callback(context: *mut Self) -> bun_event_loop::JsResult<()> {
-        // SAFETY: `context` was produced by `heap::alloc` below; we are the
-        // sole owner and reconstitute the Box to drop it at end of scope.
-        let context = unsafe { bun_core::heap::take(context) };
+    fn callback(self) -> bun_event_loop::JsResult<()> {
+        let context = self;
         let global: &JSGlobalObject = &context.global_this;
         // JSGlobalObject::bun_vm contract.
         let _ = global
@@ -161,14 +159,14 @@ impl HandledPromiseContext {
 pub fn handle_handled_promise(global: &JSGlobalObject, promise: &JSPromise) {
     crate::mark_binding!();
     let promise_js = promise.to_js();
-    let context = bun_core::heap::into_raw(Box::new(HandledPromiseContext {
+    let context = HandledPromiseContext {
         global_this: global.into(),
         promise: Strong::create(promise_js, global),
-    }));
+    };
     global
         .bun_vm()
         .event_loop_mut()
-        .enqueue_task(ManagedTask::new(context, HandledPromiseContext::callback));
+        .enqueue_task(ManagedTask::new(move || context.callback()));
 }
 
 // HOST_EXPORT(Bun__onDidAppendPlugin, c)

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -131,39 +131,22 @@ pub fn handle_rejected_promise(global: &JSGlobalObject, promise: &mut JSPromise)
     jsc_vm.auto_garbage_collect();
 }
 
-struct HandledPromiseContext {
-    // VM-lifetime backref (JSC_BORROW) — `GlobalRef` encapsulates the deref.
-    global_this: crate::GlobalRef,
-    // PORTING.md forbids bare JSValue fields on heap-allocated structs;
-    // `Strong` is the prescribed root type and its `Drop` releases the
-    // handle slot.
-    promise: Strong,
-}
-
-impl HandledPromiseContext {
-    fn callback(self) -> bun_event_loop::JsResult<()> {
-        let global: &JSGlobalObject = &self.global_this;
-        // JSGlobalObject::bun_vm contract.
-        let _ = global
-            .bun_vm()
-            .as_mut()
-            .handled_promise(global, self.promise.get());
-        Ok(())
-    }
-}
-
 // HOST_EXPORT(Bun__handleHandledPromise, c)
 pub fn handle_handled_promise(global: &JSGlobalObject, promise: &JSPromise) {
     crate::mark_binding!();
-    let promise_js = promise.to_js();
-    let context = HandledPromiseContext {
-        global_this: global.into(),
-        promise: Strong::create(promise_js, global),
-    };
+    let promise = Strong::create(promise.to_js(), global);
+    let global_ref = crate::GlobalRef::from(global);
     global
         .bun_vm()
         .event_loop_mut()
-        .enqueue_task(ManagedTask::new(move || context.callback()));
+        .enqueue_task(ManagedTask::new(move || {
+            let global: &JSGlobalObject = &global_ref;
+            let _ = global
+                .bun_vm()
+                .as_mut()
+                .handled_promise(global, promise.get());
+            Ok(())
+        }));
 }
 
 // HOST_EXPORT(Bun__onDidAppendPlugin, c)

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -142,15 +142,12 @@ struct HandledPromiseContext {
 
 impl HandledPromiseContext {
     fn callback(self) -> bun_event_loop::JsResult<()> {
-        let context = self;
-        let global: &JSGlobalObject = &context.global_this;
+        let global: &JSGlobalObject = &self.global_this;
         // JSGlobalObject::bun_vm contract.
         let _ = global
             .bun_vm()
             .as_mut()
-            .handled_promise(global, context.promise.get());
-        // drop(context) — Box freed at scope exit (replaces `default_allocator.destroy`);
-        // Strong's Drop replaces the explicit `.unprotect()`.
+            .handled_promise(global, self.promise.get());
         Ok(())
     }
 }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1530,7 +1530,13 @@ pub mod js_bundler {
                 match &mut *any_loop.as_ptr() {
                     bun_event_loop::AnyEventLoop::Js { .. } => {
                         let load = std::ptr::from_mut::<Load>(self);
-                        let ct = ConcurrentTask::from_callback(move || on_notify_defer_js(load));
+                        // `load` is the live request `on_defer` posted; the hop runs
+                        // on the loop that runs the bundle.
+                        let ct = ConcurrentTask::from_callback(move || {
+                            let load = &mut *load;
+                            BundleV2::on_notify_defer(load, bv2_mut(load.bv2));
+                            Ok(())
+                        });
                         let poster = (*ctx.as_mut_ptr())
                             .js_poster
                             .as_ref()
@@ -1552,14 +1558,6 @@ pub mod js_bundler {
                 Ok(bv2_plugin(self.bv2).append_defer_promise())
             }
         }
-    }
-
-    fn on_notify_defer_js(load: *mut Load) -> bun_event_loop::JsResult<()> {
-        // SAFETY: task contract — `load` is the live request `on_defer` posted; this runs on the loop
-        // that runs the bundle (bake: the plugins' own), so it is the bundle thread here.
-        let load = unsafe { &mut *load };
-        BundleV2::on_notify_defer(load, bv2_mut(load.bv2));
-        Ok(())
     }
 
     fn on_notify_defer_mini_wrap(load: *mut Load, ctx: *mut BundleV2<'static>) {

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1529,10 +1529,8 @@ pub mod js_bundler {
                     .expect("BundleV2.linker.loop must be set before plugins run");
                 match &mut *any_loop.as_ptr() {
                     bun_event_loop::AnyEventLoop::Js { .. } => {
-                        let ct = ConcurrentTask::from_callback(
-                            std::ptr::from_mut::<Load>(self),
-                            on_notify_defer_js,
-                        );
+                        let load = std::ptr::from_mut::<Load>(self);
+                        let ct = ConcurrentTask::from_callback(move || on_notify_defer_js(load));
                         let poster = (*ctx.as_mut_ptr())
                             .js_poster
                             .as_ref()

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1318,40 +1318,12 @@ impl RewriterPipe {
             self.background_pull_queued.set(false);
             return;
         }
-        let cell = self.cell.get();
-        if cell.is_cell() {
-            cell.protect();
-        }
-        self.ref_();
-        let pipe = core::ptr::from_ref(self).cast_mut();
+        let task = BackgroundPull::new(self);
         vm.as_mut()
             .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(move || {
-                Self::run_background_pull(pipe)
+                task.run();
+                Ok(())
             }));
-    }
-
-    fn run_background_pull(pipe: *mut RewriterPipe) -> bun_event_loop::JsResult<()> {
-        // SAFETY: the task's ref (taken in `schedule_background_pull`) keeps
-        // the allocation live until the `deref_nn` below.
-        let this = BackRef::from(unsafe { NonNull::new_unchecked(pipe) });
-        let cell = this.cell.get();
-        this.background_pull_queued.set(false);
-        if this.background_pull_armed.replace(false)
-            && !this.done.get()
-            && this.phase.get() != RewritePhase::Done
-            && !this.driving.get()
-            && !this.is_suspended()
-            && !this.output_backpressured()
-        {
-            this.drain_pending_input(PullPacing::AlreadyYielded);
-        }
-        // The cell cannot have been swept while protected, so this balances
-        // the `protect()` exactly.
-        if cell.is_cell() {
-            cell.unprotect();
-        }
-        Self::deref_nn(this.into());
-        Ok(())
     }
 
     /// `PendingValue::on_start_streaming` — the output Response's body is
@@ -1806,6 +1778,52 @@ impl RewriterPipe {
             let _ = body_value.to_error_instance(err, &self.global);
         }
         self.release_input_roots(src);
+    }
+}
+
+/// The queued background pull: a ref on the pipe plus a `protect()` on its
+/// Transform cell, both released when the task has run or is dropped unrun.
+struct BackgroundPull {
+    pipe: BackRef<RewriterPipe>,
+    cell: JSValue,
+}
+
+impl BackgroundPull {
+    fn new(pipe: &RewriterPipe) -> Self {
+        let cell = pipe.cell.get();
+        if cell.is_cell() {
+            cell.protect();
+        }
+        pipe.ref_();
+        Self {
+            pipe: BackRef::new(pipe),
+            cell,
+        }
+    }
+
+    fn run(&self) {
+        let this = self.pipe;
+        this.background_pull_queued.set(false);
+        if this.background_pull_armed.replace(false)
+            && !this.done.get()
+            && this.phase.get() != RewritePhase::Done
+            && !this.driving.get()
+            && !this.is_suspended()
+            && !this.output_backpressured()
+        {
+            this.drain_pending_input(PullPacing::AlreadyYielded);
+        }
+    }
+}
+
+impl Drop for BackgroundPull {
+    fn drop(&mut self) {
+        // The cell cannot have been swept while protected, so this balances
+        // the `protect()` exactly.
+        if self.cell.is_cell() {
+            self.cell.unprotect();
+        }
+        RewriterPipe::deref_nn(self.pipe.into());
     }
 }
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1323,11 +1323,11 @@ impl RewriterPipe {
             cell.protect();
         }
         self.ref_();
+        let pipe = core::ptr::from_ref(self).cast_mut();
         vm.as_mut()
-            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(
-                core::ptr::from_ref(self).cast_mut(),
-                Self::run_background_pull,
-            ));
+            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(move || {
+                Self::run_background_pull(pipe)
+            }));
     }
 
     fn run_background_pull(pipe: *mut RewriterPipe) -> bun_event_loop::JsResult<()> {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -310,8 +310,8 @@ pub(crate) fn run_task(
             }?;
         }
         task_tag::ManagedTask => {
-            // SAFETY: `task.ptr` was produced by `heap::alloc` in `ManagedTask::new`
-            // and enqueued under `task_tag::ManagedTask`; `run` consumes/frees it.
+            // SAFETY: `task.ptr` is the task `ManagedTask::new` built, enqueued
+            // under `task_tag::ManagedTask`; `run` consumes it.
             unsafe { ManagedTask::run(cast_ptr!(ManagedTask)) }?;
         }
         task_tag::CppTask => {

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -701,46 +701,14 @@ impl ErrorDeferred {
     }
 
     pub(crate) fn reject_later(self: Box<Self>, global_this: &JSGlobalObject) {
-        struct Context {
-            deferred: Box<ErrorDeferred>,
-            // LIFETIMES.tsv row 1403: JSC_BORROW — the global outlives the
-            // enqueued task (VM-owned), so a `BackRef` captures the invariant.
-            global_this: bun_ptr::BackRef<JSGlobalObject>,
-        }
-        impl Context {
-            // `bun_event_loop::ManagedTask::new` expects
-            // `fn(*mut T) -> bun_event_loop::JsResult<()>` (tier-0 `bun_core::JsError`).
-            fn callback(this: *mut Context) -> bun_event_loop::JsResult<()> {
-                // SAFETY: `this` is the heap-allocated pointer passed to ManagedTask::new
-                // below; ManagedTask::run calls us exactly once with that pointer.
-                let this = unsafe { bun_core::heap::take(this) };
-                let global = this.global_this.get();
-                this.deferred.reject(global)
-            }
-        }
-
-        let vm = global_this.bun_vm();
-        // Worker terminate's `stop_dns_for_vm_teardown` fires EDESTRUCTION with
-        // `is_shutting_down` already set; the task queue is about to be
-        // drained-without-run and ManagedTask has no cleanup here, so enqueuing
-        // would leak the `Context` and its `JSPromiseStrong` box. Drop now while
-        // JSC is still live so the Strong handle releases cleanly.
-        if vm.is_shutting_down() {
-            return;
-        }
-
-        let context = bun_core::heap::into_raw(Box::new(Context {
-            deferred: self,
-            global_this: bun_ptr::BackRef::new(global_this),
-        }));
-        // TODO(@heimskr): new custom Task type
-        // SAFETY: `bun_vm()` returns a non-null VM pointer (VM-owned for the lifetime of
-        // the JSGlobalObject).
-        vm.as_mut()
-            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(
-                context,
-                Context::callback,
-            ));
+        // The global outlives the queued task (VM-owned).
+        let global = bun_ptr::BackRef::new(global_this);
+        global_this
+            .bun_vm()
+            .as_mut()
+            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(move || {
+                (*self).reject(global.get())
+            }));
     }
 }
 

--- a/src/runtime/dns_jsc/cares_jsc.rs
+++ b/src/runtime/dns_jsc/cares_jsc.rs
@@ -653,13 +653,13 @@ impl ErrorDeferred {
         syscall: &'static [u8],
         hostname: Option<bstr::String>,
         promise: bun_jsc::JSPromiseStrong,
-    ) -> Box<ErrorDeferred> {
-        Box::new(ErrorDeferred {
+    ) -> ErrorDeferred {
+        ErrorDeferred {
             errno,
             syscall,
             hostname,
             promise,
-        })
+        }
     }
 
     fn reject(mut self, global_this: &JSGlobalObject) -> JsResult<()> {
@@ -700,27 +700,23 @@ impl ErrorDeferred {
         self.promise.reject(global_this, Ok(instance))
     }
 
-    pub(crate) fn reject_later(self: Box<Self>, global_this: &JSGlobalObject) {
-        // The global outlives the queued task (VM-owned).
-        let global = bun_ptr::BackRef::new(global_this);
+    pub(crate) fn reject_later(self, global_this: &JSGlobalObject) {
+        let global = bun_jsc::GlobalRef::from(global_this);
         global_this
             .bun_vm()
             .as_mut()
             .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(move || {
-                (*self).reject(global.get())
+                self.reject(&global)
             }));
     }
 }
-
-// Drop: hostname (bun_core::String) and promise (JSPromiseStrong) drop their own resources;
-// the allocation itself is handled by Box drop at the call site.
 
 pub(crate) fn error_to_deferred(
     this: c_ares::Error,
     syscall: &'static [u8],
     hostname: Option<&[u8]>,
     promise: &mut bun_jsc::JSPromiseStrong,
-) -> Box<ErrorDeferred> {
+) -> ErrorDeferred {
     let host_string: Option<bstr::String> = hostname.map(bstr::String::clone_utf8);
     let taken = core::mem::take(promise);
     ErrorDeferred::init(this, syscall, host_string, taken)

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -14,8 +14,8 @@ use core::mem;
 use crate::generated_classes::PropertyName;
 use crate::webcore::Blob;
 use crate::webcore::BlobExt as _;
+use crate::webcore::blob::ReadBytesResult;
 use crate::webcore::blob::store as blob_store;
-use crate::webcore::blob::{ReadBytesHandler, ReadBytesResult};
 use crate::webcore::node_types::PathOrFileDescriptor;
 use bun_core::ZBox;
 use bun_core::base64;
@@ -1248,18 +1248,18 @@ impl Image {
 /// Promise-of-promise flattens, so the caller sees one `await` for
 /// read+decode+ops+encode. After the first read, subsequent terminals on the
 /// same instance reuse the `.owned` bytes without re-reading.
-struct BlobReadChain<'a> {
+struct BlobReadChain {
     image: *const Image,
-    global: &'a JSGlobalObject,
+    global: jsc::GlobalRef,
     kind: Kind,
     deliver: Deliver,
     outer: jsc::JSPromiseStrong,
 }
 
-impl<'a> BlobReadChain<'a> {
+impl BlobReadChain {
     fn start(
         image: &Image,
-        global: &'a JSGlobalObject,
+        global: &JSGlobalObject,
         this_value: JSValue,
         kind: Kind,
         deliver: Deliver,
@@ -1287,23 +1287,21 @@ impl<'a> BlobReadChain<'a> {
         }
         image.pending_tasks.set(image.pending_tasks.get() + 1);
 
-        let chain = Box::new(BlobReadChain {
+        let chain = BlobReadChain {
             image: std::ptr::from_ref::<Image>(image),
-            global,
+            global: jsc::GlobalRef::from(global),
             kind,
             deliver,
             outer: jsc::JSPromiseStrong::init(global),
-        });
+        };
         let promise = chain.outer.value();
-        // `on_read_bytes` runs on the JS thread (sync for in-memory, async for
-        // file/S3).
-        blob.read_bytes_to_handler(chain, global)?;
+        blob.read_bytes_to_handler(move |result| chain.on_read_bytes(result), global)?;
         Ok(promise)
     }
 
     /// JS thread — `read_bytes_to_handler` guarantees this. `r.ok` is owned by us.
-    fn on_read_bytes_impl(self, r: ReadBytesResult) -> JsResult<()> {
-        let global = self.global;
+    fn on_read_bytes(self, r: ReadBytesResult) -> JsResult<()> {
+        let global: &JSGlobalObject = &self.global;
         // SAFETY: `image` is a BACKREF kept alive by the Strong `this_ref`
         // bump in `start()`; we are on the JS thread. R-2: shared deref —
         // mutation goes through `Cell`/`JsCell`.
@@ -1353,12 +1351,6 @@ impl<'a> BlobReadChain<'a> {
                 outer.reject(global, Ok(e.to_error_instance(global)))
             }
         }
-    }
-}
-
-impl<'a> ReadBytesHandler for BlobReadChain<'a> {
-    fn on_read_bytes(self: Box<Self>, result: ReadBytesResult) -> JsResult<()> {
-        self.on_read_bytes_impl(result)
     }
 }
 

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1295,16 +1295,9 @@ impl<'a> BlobReadChain<'a> {
             outer: jsc::JSPromiseStrong::init(global),
         });
         let promise = chain.outer.value();
-        // `read_bytes_to_handler` stores the handler pointer and calls
-        // `on_read_bytes` on the JS thread (sync for in-memory, async for
-        // file/S3). Ownership of the chain transfers there; the trait impl
-        // below reconstructs the Box and frees it.
-        let raw = bun_core::heap::into_raw(chain);
-        // SAFETY: `raw` is freshly leaked and not used again here; the read
-        // dispatch hands it to `on_read_bytes` below exactly once, also when it
-        // returns `Err` (an exception left pending while delivering synchronously,
-        // i.e. after the chain has already been reclaimed).
-        unsafe { blob.read_bytes_to_handler(raw, global) }?;
+        // `on_read_bytes` runs on the JS thread (sync for in-memory, async for
+        // file/S3).
+        blob.read_bytes_to_handler(chain, global)?;
         Ok(promise)
     }
 
@@ -1364,12 +1357,8 @@ impl<'a> BlobReadChain<'a> {
 }
 
 impl<'a> ReadBytesHandler for BlobReadChain<'a> {
-    unsafe fn on_read_bytes(this: *mut Self, result: ReadBytesResult) -> JsResult<()> {
-        // SAFETY: `this` is the Box `start()` leaked into `read_bytes_to_handler`,
-        // handed back to us exactly once (trait contract); nothing else points
-        // at it, so reclaiming it here is the chain's one and only free.
-        let boxed = unsafe { bun_core::heap::take(this) };
-        boxed.on_read_bytes_impl(result)
+    fn on_read_bytes(self: Box<Self>, result: ReadBytesResult) -> JsResult<()> {
+        self.on_read_bytes_impl(result)
     }
 }
 

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1309,7 +1309,6 @@ impl BlobReadChain {
         let mut outer = self.outer;
         let kind = self.kind;
         let deliver = self.deliver;
-        // `bun.destroy(self)` — Box drops at end of scope.
 
         image.pending_tasks.set(image.pending_tasks.get() - 1);
         if image.pending_tasks.get() == 0 {

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2929,7 +2929,7 @@ impl ThreadSafeFunction {
                     // dispatch will happen; the queued calls are released by the
                     // teardown path. Free the task and fall back to Idle.
                     // SAFETY: refused ⇒ we own the task box.
-                    unsafe { drop(bun_core::heap::take(ct.as_ptr())) };
+                    unsafe { ConcurrentTask::release_refused(ct) };
                     self.dispatch_state
                         .store(DispatchState::Idle as u8, Ordering::SeqCst);
                 }
@@ -5293,7 +5293,7 @@ impl NapiFinalizerTask {
             {
                 // SAFETY: refused ⇒ we own both boxes.
                 unsafe {
-                    drop(bun_core::heap::take(ct.as_ptr()));
+                    ConcurrentTask::release_refused(ct);
                     let task = bun_core::heap::take(this);
                     let _ = core::mem::ManuallyDrop::new(task.finalizer.env);
                 }

--- a/src/runtime/node/memory_pressure.rs
+++ b/src/runtime/node/memory_pressure.rs
@@ -348,7 +348,7 @@ mod windows {
             {
                 // VM torn down (uninstall joins us right after): drop the notification.
                 // SAFETY: refused ⇒ we own the task box.
-                unsafe { drop(bun_core::heap::take(task.as_ptr())) };
+                unsafe { ConcurrentTask::release_refused(task) };
                 break;
             }
             // SAFETY: `shutdown` is valid for the thread's lifetime.

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2421,8 +2421,8 @@ where
             resp.write_header_int(b"content-length", pair.size as u64);
         }
         this.end_without_body(this.should_close_connection());
-        // `end_without_body` released the base ref; the caller
-        // (`on_s3_size_resolved`) releases the ref taken for the S3 stat.
+        // `end_without_body` released the base ref; the S3 stat callback's
+        // guard releases the ref taken for the stat.
     }
 
     pub(crate) fn on_s3_size_resolved(&self, result: S3::simple_request::S3StatResult<'_>) {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2425,16 +2425,6 @@ where
         // (`on_s3_size_resolved`) releases the ref taken for the S3 stat.
     }
 
-    /// `S3::client::stat` callback shape: `fn(S3StatResult, *mut c_void) -> JsResult<()>`.
-    fn on_s3_size_resolved_thunk(
-        result: S3::simple_request::S3StatResult<'_>,
-        this: *mut c_void,
-    ) -> JsResult<()> {
-        let stat_ref = RequestContextRef::adopt(this.cast::<Self>());
-        stat_ref.ctx().on_s3_size_resolved(result);
-        Ok(())
-    }
-
     pub(crate) fn on_s3_size_resolved(&self, result: S3::simple_request::S3StatResult<'_>) {
         if let Some(resp) = self.resp.get() {
             let size = match result {
@@ -2558,9 +2548,8 @@ where
                 if shim::blob_is_s3(blob) {
                     // we need to read the size asynchronously
                     // in this case should always be a redirect so should not hit this path, but in case we change it in the future lets handle it
-                    // Ref for the S3 stat; adopted and released by
-                    // `on_s3_size_resolved_thunk`.
                     this.ref_();
+                    let stat_ref = RequestContextRef::adopt(this.as_ctx_ptr());
 
                     let crate::webcore::blob::store::Data::S3(s3) =
                         &blob.store.get().as_ref().unwrap().data
@@ -2582,8 +2571,10 @@ where
                     let _ = S3::client::stat(
                         credentials,
                         path,
-                        Self::on_s3_size_resolved_thunk,
-                        this.as_ctx_ptr().cast::<c_void>(),
+                        move |result| {
+                            stat_ref.ctx().on_s3_size_resolved(result);
+                            Ok(())
+                        },
                         proxy_url,
                         s3.request_payer,
                     ); // TODO: properly propagate exception upwards

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1922,8 +1922,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             // context, `&mut` scoped to this call.
             unsafe {
                 (*self.vm_mut()).enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(
-                    app,
-                    |app| {
+                    move || {
                         // S008: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
                         bun_opaque::opaque_deref_mut(app).close();
                         Ok(())
@@ -1932,11 +1931,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             }
         }
 
+        let this = std::ptr::from_mut::<Self>(self);
         // SAFETY: as above — `&mut` scoped to this call.
         unsafe {
             (*self.vm_mut()).enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(
-                std::ptr::from_mut::<Self>(self),
-                |this| {
+                move || {
                     // SAFETY: `this` is the unique owning server pointer enqueued
                     // above; the task runs once on the JS thread.
                     Self::deinit(this);

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -883,7 +883,6 @@ impl BunTest {
 
     pub(crate) fn run_next_tick(weak: &BunTestPtrWeak, global_this: &JSGlobalObject, phase: RefDataValue) {
         let vm = global_this.bun_vm().as_mut();
-        // Check liveness before allocating so the early return doesn't strand a Box.
         let Some(strong) = weak.upgrade() else {
             debug_assert!(false); // shouldn't be calling runNextTick after moving on to the next file
             return; // but just in case
@@ -1520,21 +1519,20 @@ pub struct RunTestsTask {
 }
 impl RunTestsTask {
     pub fn call(self) -> JsResult<()> {
-        let this = self;
-        let Some(strong) = this.weak.upgrade() else { return Ok(()) };
-        if let Err(e) = BunTest::run(&strong, &this.global_this) {
+        let Some(strong) = self.weak.upgrade() else { return Ok(()) };
+        if let Err(e) = BunTest::run(&strong, &self.global_this) {
             // A termination is the tick's to fold, not a test failure.
-            if this.global_this.has_pending_termination_exception() {
+            if self.global_this.has_pending_termination_exception() {
                 return Err(e);
             }
             // SAFETY: `&mut` derived via `UnsafeCell` after `run` returned; sole
             // borrow at this point.
             let bt = strong.get();
             bt.on_uncaught_exception(
-                &this.global_this,
-                Some(this.global_this.take_exception(e)),
+                &self.global_this,
+                Some(self.global_this.take_exception(e)),
                 false,
-                &this.phase,
+                &self.phase,
             );
         }
         Ok(())

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -888,18 +888,12 @@ impl BunTest {
             debug_assert!(false); // shouldn't be calling runNextTick after moving on to the next file
             return; // but just in case
         };
-        let done_callback_test = bun_core::heap::into_raw(Box::new(RunTestsTask {
+        let task = RunTestsTask {
             weak: Weak::clone(weak),
             global_this: GlobalRef::from(global_this),
             phase,
-        }));
-        fn call_erased(this: *mut RunTestsTask) -> bun_event_loop::JsResult<()> {
-            // `this` was `heap::into_raw`'d above (always non-null) and is
-            // invoked exactly once by `ManagedTask`.
-            RunTestsTask::call(NonNull::new(this).unwrap())
-        }
-        // `new_owned`: if the task never runs (VM teardown), the queue drainer frees `done_callback_test`.
-        let task = jsc::ManagedTask::ManagedTask::new_owned::<RunTestsTask>(done_callback_test, call_erased);
+        };
+        let task = jsc::ManagedTask::ManagedTask::new(move || task.call());
         // SAFETY: single field write through `UnsafeCell`; no other `&mut` live.
         strong.get().wants_wakeup = true;
         // we need to wake up the event loop so autoTick() doesn't wait for 16-100ms because we just enqueued a task
@@ -1525,16 +1519,8 @@ pub struct RunTestsTask {
     pub(crate) phase: RefDataValue,
 }
 impl RunTestsTask {
-    /// `ManagedTask` callback ABI: `fn(*mut T) -> JsResult<()>`. The pointer
-    /// was `heap::alloc`'d in `run_next_tick`; reconstitute and drop here.
-    ///
-    /// `this` must be the pointer produced by `heap::into_raw` in
-    /// `run_next_tick`; ownership is consumed (the box is dropped on return).
-    pub fn call(this: NonNull<RunTestsTask>) -> JsResult<()> {
-        // SAFETY: `this` was produced by `heap::into_raw` in `run_next_tick` and
-        // is invoked exactly once by `ManagedTask`; ownership is reclaimed here.
-        let this = unsafe { bun_core::heap::take(this.as_ptr()) };
-        // Box drops at end of scope; the Weak drops with it.
+    pub fn call(self) -> JsResult<()> {
+        let this = self;
         let Some(strong) = this.weak.upgrade() else { return Ok(()) };
         if let Err(e) = BunTest::run(&strong, &this.global_this) {
             // A termination is the tick's to fold, not a test failure.

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -296,9 +296,9 @@ struct DeferredFailure {
 }
 
 impl DeferredFailure {
-    fn run(self) -> JsResult<()> {
+    fn run(mut self) -> JsResult<()> {
         debug!("running deferred failure");
-        let mut this = self;
+        let this = &mut self;
         let err = valkey_error_to_js(&this.global_this, &*this.message, this.err);
         ValkeyClient::reject_all_pending_commands(
             &mut this.in_flight,
@@ -308,11 +308,11 @@ impl DeferredFailure {
         )
     }
 
-    fn enqueue(self: Box<Self>) {
+    fn enqueue(self) {
         debug!("enqueueing deferred failure");
-        VirtualMachine::get().event_loop_mut().enqueue_task(
-            bun_jsc::ManagedTask::ManagedTask::new(move || (*self).run()),
-        );
+        VirtualMachine::get()
+            .event_loop_mut()
+            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(move || self.run()));
     }
 }
 
@@ -506,13 +506,13 @@ impl ValkeyClient {
 
         if self.flags.finalized {
             let vm = self.vm;
-            let deferred_failure = Box::new(DeferredFailure {
+            let deferred_failure = DeferredFailure {
                 message: Box::<[u8]>::from(message),
                 err,
                 global_this: GlobalRef::from(vm.global()),
                 in_flight: core::mem::take(&mut self.in_flight),
                 queue: command::entry::Queue::new(),
-            });
+            };
             deferred_failure.enqueue();
             return Ok(());
         }
@@ -548,7 +548,7 @@ impl ValkeyClient {
             // We can't run promises inside finalizers.
             if !self.queue.is_empty() || !self.in_flight.is_empty() {
                 let vm = self.vm;
-                let deferred_failure = Box::new(DeferredFailure {
+                let deferred_failure = DeferredFailure {
                     // This memory is not owned by us.
                     message: Box::<[u8]>::from(message),
 
@@ -556,7 +556,7 @@ impl ValkeyClient {
                     global_this: GlobalRef::from(vm.global()),
                     in_flight: core::mem::take(&mut self.in_flight),
                     queue: core::mem::take(&mut self.queue),
-                });
+                };
                 deferred_failure.enqueue();
             }
 

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -310,9 +310,9 @@ impl DeferredFailure {
 
     fn enqueue(self: Box<Self>) {
         debug!("enqueueing deferred failure");
-        VirtualMachine::get()
-            .event_loop_mut()
-            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(move || (*self).run()));
+        VirtualMachine::get().event_loop_mut().enqueue_task(
+            bun_jsc::ManagedTask::ManagedTask::new(move || (*self).run()),
+        );
     }
 }
 

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -310,17 +310,9 @@ impl DeferredFailure {
 
     fn enqueue(self: Box<Self>) {
         debug!("enqueueing deferred failure");
-        // The Box is leaked into a raw pointer here and reconstituted inside the trampoline.
-        fn run_raw(ptr: *mut DeferredFailure) -> bun_event_loop::JsResult<()> {
-            // SAFETY: `ptr` was produced by `heap::alloc` below; we are the sole owner.
-            let this = unsafe { bun_core::heap::take(ptr) };
-            DeferredFailure::run(*this)
-        }
-        let managed_task =
-            bun_jsc::ManagedTask::ManagedTask::new(bun_core::heap::into_raw(self), run_raw);
         VirtualMachine::get()
             .event_loop_mut()
-            .enqueue_task(managed_task);
+            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(move || (*self).run()));
     }
 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -91,17 +91,12 @@ pub(crate) fn is_valid_blob_type(slice: &[u8]) -> bool {
     slice.iter().all(|&c| matches!(c, 0x20..=0x7E))
 }
 
-/// Result delivered to `ReadBytesHandler::on_read_bytes`.
+/// Result delivered to `read_bytes_to_handler`'s handler.
 pub enum ReadBytesResult {
     /// global-allocator-owned by the callback.
     Ok(Vec<u8>),
     Err(Box<bun_jsc::SystemError>),
 }
-
-/// `read_bytes_to_handler`'s completion: invoked exactly once, on the JS
-/// thread. It may settle promises: an exception it leaves pending is the `Err`.
-pub trait ReadBytesHandler: FnOnce(ReadBytesResult) -> JsResult<()> + 'static {}
-impl<F: FnOnce(ReadBytesResult) -> JsResult<()> + 'static> ReadBytesHandler for F {}
 
 // ──────────────────────────────────────────────────────────────────────────
 // Blob — single nominal definition lives in `bun_jsc::webcore_types`.
@@ -145,7 +140,7 @@ pub trait BlobExt {
     fn do_read_file<F: read_file::ReadFileToJs>(&self, global: &JSGlobalObject) -> JSValue;
     /// `handler` runs once — synchronously or from the async completion —
     /// whatever this returns.
-    fn read_bytes_to_handler<H: ReadBytesHandler>(
+    fn read_bytes_to_handler<H: FnOnce(ReadBytesResult) -> JsResult<()> + 'static>(
         &self,
         handler: H,
         global: &JSGlobalObject,
@@ -476,7 +471,7 @@ impl BlobExt for Blob {
         }
     }
     /// Read this Blob's bytes — file (`ReadFile`/`ReadFileUV`), S3 (`S3.download`),
-    /// or in-memory — and deliver them to `Handler::on_read_bytes(ctx, result)` on the
+    /// or in-memory — and deliver them to `handler` on the
     /// JS thread without ever materialising a JSValue. `.ok` bytes are
     /// global-allocator-OWNED by the callback. The point is to give callers
     /// the same store-agnostic dispatch as `.bytes()` while staying in native land,
@@ -496,13 +491,13 @@ impl BlobExt for Blob {
     /// exception a synchronous delivery left pending, so the handler has
     /// already been consumed in that case too.
     ///
-    fn read_bytes_to_handler<H: ReadBytesHandler>(
+    fn read_bytes_to_handler<H: FnOnce(ReadBytesResult) -> JsResult<()> + 'static>(
         &self,
         handler: H,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
         if self.needs_to_read_file() {
-            fn run<H: ReadBytesHandler>(
+            fn run<H: FnOnce(ReadBytesResult) -> JsResult<()> + 'static>(
                 ctx: *mut c_void,
                 r: read_file::ReadFileResultType,
             ) -> JsResult<()> {
@@ -519,7 +514,7 @@ impl BlobExt for Blob {
                 // exactly once (`run` or `cancel`).
                 (unsafe { bun_core::heap::take(ctx.cast::<H>()) })(result)
             }
-            fn cancel<H: ReadBytesHandler>(ctx: *mut c_void) {
+            fn cancel<H: FnOnce(ReadBytesResult) -> JsResult<()> + 'static>(ctx: *mut c_void) {
                 let err = jsc::SystemError {
                     code: BunString::static_("ECANCELED"),
                     message: BunString::static_(
@@ -560,15 +555,22 @@ impl BlobExt for Blob {
         }
         if self.is_s3() {
             struct Task<H> {
-                handler: H,
+                /// `None` once delivered.
+                handler: Option<H>,
                 blob: Blob, // dupe for store ref + offset/size
                 poll: bun_io::KeepAlive,
             }
-            impl<H: ReadBytesHandler> Task<H> {
-                fn done(mut self, r: ReadBytesResult) -> JsResult<()> {
+            impl<H> Drop for Task<H> {
+                fn drop(&mut self) {
                     self.poll.unref(bun_io::js_vm_ctx());
                     self.blob.deinit();
-                    (self.handler)(r)
+                }
+            }
+            impl<H: FnOnce(ReadBytesResult) -> JsResult<()> + 'static> Task<H> {
+                fn done(mut self, r: ReadBytesResult) -> JsResult<()> {
+                    let handler = self.handler.take().expect("delivered once");
+                    drop(self);
+                    handler(r)
                 }
                 fn cb(self, result: crate::webcore::__s3_client::S3DownloadResult) -> JsResult<()> {
                     match result {
@@ -595,7 +597,7 @@ impl BlobExt for Blob {
                 }
             }
             let mut t = Task {
-                handler,
+                handler: Some(handler),
                 blob: self.dupe(),
                 poll: bun_io::KeepAlive::default(),
             };
@@ -603,7 +605,11 @@ impl BlobExt for Blob {
             let proxy = http_proxy_href(global);
             // `t.blob` shares `self`'s store, so borrow credentials/path from
             // `self` while `t` moves into the callback.
-            let s3 = self.store.get().as_ref().unwrap().data.as_s3();
+            let s3 = self
+                .store()
+                .expect("infallible: store present")
+                .data
+                .as_s3();
             let cred = s3.get_credentials();
             let path = s3.path();
             let payer = s3.request_payer;
@@ -4350,12 +4356,12 @@ fn write_file_with_empty_source_to_destination(
                 }
             };
 
-            let promise = jsc::JSPromiseStrong::init(ctx);
+            let mut promise = jsc::JSPromiseStrong::init(ctx);
             let promise_value = promise.value();
             let proxy_owned = http_proxy_href(ctx);
             let proxy_url = proxy_owned.as_deref();
             let store = destination_store.clone();
-            let global = bun_jsc::GlobalRef::from(ctx);
+            let global = jsc::GlobalRef::from(ctx);
             s3_client::upload(
                 &aws_options.credentials,
                 s3.path(),
@@ -4368,7 +4374,6 @@ fn write_file_with_empty_source_to_destination(
                 aws_options.storage_class,
                 aws_options.request_payer,
                 move |result| {
-                    let mut promise = promise;
                     let global: &JSGlobalObject = &global;
                     match result {
                         S3UploadResult::Success => promise.resolve(global, JSValue::js_number(0.0)),
@@ -4424,7 +4429,7 @@ pub(crate) fn write_file_with_source_destination(
     if destination_type == store::DataTag::File && source_type == store::DataTag::Bytes {
         let write_file_promise = WriteFilePromise {
             promise: jsc::JSPromiseStrong::init(ctx),
-            global_this: bun_jsc::GlobalRef::from(ctx),
+            global_this: jsc::GlobalRef::from(ctx),
         };
         let promise_value = write_file_promise.promise.value();
         promise_value.ensure_still_alive();
@@ -4573,10 +4578,10 @@ pub(crate) fn write_file_with_source_destination(
                         ));
                     }
                 } else {
-                    let promise = jsc::JSPromiseStrong::init(ctx);
+                    let mut promise = jsc::JSPromiseStrong::init(ctx);
                     let promise_value = promise.value();
                     let store = source_store.clone();
-                    let global = bun_jsc::GlobalRef::from(ctx);
+                    let global = jsc::GlobalRef::from(ctx);
                     s3_client::upload(
                         &aws_options.credentials,
                         s3.path(),
@@ -4589,7 +4594,6 @@ pub(crate) fn write_file_with_source_destination(
                         aws_options.storage_class,
                         aws_options.request_payer,
                         move |result| {
-                            let mut promise = promise;
                             let global: &JSGlobalObject = &global;
                             match result {
                                 S3UploadResult::Success => promise.resolve(
@@ -5591,10 +5595,10 @@ impl S3BlobDownloadTask {
     }
 
     pub(crate) fn on_s3_download_resolved(
-        self,
+        mut self,
         result: crate::webcore::__s3_client::S3DownloadResult,
     ) -> JsResult<()> {
-        let mut this = self;
+        let this = &mut self;
         // Copy the `BackRef` out so the `&JSGlobalObject` borrow is detached
         // from `this` (it must coexist with `&mut this` calls below).
         let global_ref = this.global_this;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -98,22 +98,12 @@ pub enum ReadBytesResult {
     Err(Box<bun_jsc::SystemError>),
 }
 
-/// Handler trait for `read_bytes_to_handler` — the body only requires
-/// `on_read_bytes`.
+/// Handler trait for `read_bytes_to_handler`.
 pub trait ReadBytesHandler {
-    /// Invoked exactly once, on the JS thread, with the `ctx` given to
-    /// `read_bytes_to_handler`; ownership of `*this` comes back to the handler
-    /// here, and a heap-allocated one reclaims itself (`heap::take(this)`).
-    /// That is why the receiver is a raw pointer, as in
-    /// `read_file::ReadFileCompletion::run`: freeing the allocation behind a
-    /// `&mut self` argument is UB under the aliasing model (the argument is
-    /// protected for the whole call), even if `self` is never touched again.
-    /// It may settle promises: an exception it leaves pending is the `Err`.
-    ///
-    /// # Safety
-    /// `this` is the `ctx` passed to `read_bytes_to_handler`, still live, and
-    /// the caller does not use it afterwards.
-    unsafe fn on_read_bytes(this: *mut Self, result: ReadBytesResult) -> JsResult<()>;
+    /// Invoked exactly once, on the JS thread, with the handler given to
+    /// `read_bytes_to_handler`. It may settle promises: an exception it leaves
+    /// pending is the `Err`.
+    fn on_read_bytes(self: Box<Self>, result: ReadBytesResult) -> JsResult<()>;
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -156,24 +146,16 @@ pub trait BlobExt {
         global: &JSGlobalObject,
     ) -> JsResult<JSValue>;
     fn do_read_file<F: read_file::ReadFileToJs>(&self, global: &JSGlobalObject) -> JSValue;
-    /// # Safety
-    /// `ctx` must be a valid, exclusively-accessible `*mut H`. Ownership of
-    /// `*ctx` passes to the single `H::on_read_bytes(ctx, ..)` this makes
-    /// (synchronously or from the async completion), whatever this returns;
-    /// the caller must not use `ctx` afterwards.
-    unsafe fn read_bytes_to_handler<H: ReadBytesHandler>(
+    /// `handler.on_read_bytes` runs once — synchronously or from the async
+    /// completion — whatever this returns.
+    fn read_bytes_to_handler<H: ReadBytesHandler>(
         &self,
-        ctx: *mut H,
+        handler: Box<H>,
         global: &JSGlobalObject,
     ) -> JsResult<()>;
     fn do_image(_this: &Self, global: &JSGlobalObject, cf: &CallFrame) -> JsResult<JSValue>
     where
         Self: Sized;
-    fn do_read_file_internal<C, F: InternalReadFileFn<C>>(
-        &self,
-        ctx: *mut C,
-        global: &JSGlobalObject,
-    );
     fn get_content_type(&self) -> Option<Utf8Bytes<'_>>;
     fn _on_structured_clone_serialize<W: bun_io::Write>(&self, writer: &mut W)
     -> crate::Result<()>;
@@ -517,49 +499,65 @@ impl BlobExt for Blob {
     /// exception a synchronous delivery left pending, so the handler has
     /// already been consumed in that case too.
     ///
-    /// # Safety
-    /// `ctx` must be a valid, exclusively-accessible `*mut H`. Ownership of
-    /// `*ctx` passes to the single `H::on_read_bytes(ctx, ..)` this makes,
-    /// whatever this returns; the caller must not use `ctx` afterwards.
-    unsafe fn read_bytes_to_handler<H: ReadBytesHandler>(
+    fn read_bytes_to_handler<H: ReadBytesHandler>(
         &self,
-        ctx: *mut H,
+        handler: Box<H>,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
         if self.needs_to_read_file() {
-            struct Adapter<H>(core::marker::PhantomData<H>);
-            impl<H: ReadBytesHandler> InternalReadFileFn<H> for Adapter<H> {
-                fn call(c: *mut H, r: read_file::ReadFileResultType) -> JsResult<()> {
-                    let result = match r {
-                        read_file::ReadFileResultType::Result(b) => {
-                            // SAFETY: `buf` is `Box::<[u8]>::into_raw` from the
-                            // ReadFile finisher; reclaim ownership here.
-                            let buf = unsafe { bun_core::heap::take(b.buf) };
-                            ReadBytesResult::Ok(buf.into_vec())
-                        }
-                        read_file::ReadFileResultType::Err(e) => ReadBytesResult::Err(Box::new(e)),
-                    };
-                    // SAFETY: `c` is the `ctx` handed to `read_bytes_to_handler`,
-                    // and the read completion fires exactly once (`call` or
-                    // `cancel`), so this is its single delivery.
-                    unsafe { H::on_read_bytes(c, result) }
-                }
-                fn cancel(c: *mut H) {
-                    let err = jsc::SystemError {
-                        code: BunString::static_("ECANCELED"),
-                        message: BunString::static_(
-                            "The file read did not complete before its thread stopped",
-                        ),
-                        syscall: BunString::static_("read"),
-                        ..Default::default()
-                    };
-                    // The read's thread stopped; this runs at teardown (the unrun job's release,
-                    // or `JobList::release_all_js`), where what the handler leaves stays pending.
-                    // SAFETY: as for `call`.
-                    let _ = unsafe { H::on_read_bytes(c, ReadBytesResult::Err(Box::new(err))) };
-                }
+            fn run<H: ReadBytesHandler>(
+                ctx: *mut c_void,
+                r: read_file::ReadFileResultType,
+            ) -> JsResult<()> {
+                let result = match r {
+                    read_file::ReadFileResultType::Result(b) => {
+                        // SAFETY: `buf` is `Box::<[u8]>::into_raw` from the
+                        // ReadFile finisher; reclaim ownership here.
+                        let buf = unsafe { bun_core::heap::take(b.buf) };
+                        ReadBytesResult::Ok(buf.into_vec())
+                    }
+                    read_file::ReadFileResultType::Err(e) => ReadBytesResult::Err(Box::new(e)),
+                };
+                // SAFETY: `ctx` is the handler boxed below; the completion fires
+                // exactly once (`run` or `cancel`).
+                unsafe { bun_core::heap::take(ctx.cast::<H>()) }.on_read_bytes(result)
             }
-            self.do_read_file_internal::<H, Adapter<H>>(ctx, global);
+            fn cancel<H: ReadBytesHandler>(ctx: *mut c_void) {
+                let err = jsc::SystemError {
+                    code: BunString::static_("ECANCELED"),
+                    message: BunString::static_(
+                        "The file read did not complete before its thread stopped",
+                    ),
+                    syscall: BunString::static_("read"),
+                    ..Default::default()
+                };
+                // The read's thread stopped; this runs at teardown (the unrun job's release,
+                // or `JobList::release_all_js`), where what the handler leaves stays pending.
+                // SAFETY: as for `run`.
+                let _ = unsafe { bun_core::heap::take(ctx.cast::<H>()) }
+                    .on_read_bytes(ReadBytesResult::Err(Box::new(err)));
+            }
+            let completion = read_file::ReadFileCompletionFns {
+                ctx: bun_core::heap::into_raw(handler).cast::<c_void>(),
+                run: run::<H>,
+                cancel: cancel::<H>,
+            };
+            let store = self.store().expect("infallible: store present").clone();
+            #[cfg(windows)]
+            read_file::ReadFileUV::start_with_ctx(
+                global.bun_vm().event_loop(),
+                store,
+                self.offset.get(),
+                self.size.get(),
+                completion,
+            );
+            #[cfg(not(windows))]
+            read_file::ReadFile::schedule(
+                read_file::ReadFile::create(store, self.offset.get(), self.size.get())
+                    .unwrap_or_else(|e| bun_core::handle_oom(Err(e))),
+                completion,
+                global,
+            );
             return Ok(());
         }
         if self.is_s3() {
@@ -576,9 +574,8 @@ impl BlobExt for Blob {
                     self.blob.deinit();
                     let (ctx, on_read_bytes) = (self.ctx, self.on_read_bytes);
                     drop(self);
-                    // SAFETY: `ctx` is the pointer handed to `read_bytes_to_handler`;
-                    // the download callback (and so `done`) runs exactly once, and
-                    // the `Task` that held the pointer is gone.
+                    // SAFETY: `ctx` is the handler boxed in `read_bytes_to_handler`;
+                    // the download callback (and so `done`) runs exactly once.
                     unsafe { on_read_bytes(ctx, r) }
                 }
                 fn cb(
@@ -613,9 +610,11 @@ impl BlobExt for Blob {
                 }
             }
             let mut t = Box::new(Task {
-                ctx: ctx.cast(),
+                ctx: bun_core::heap::into_raw(handler).cast(),
                 // SAFETY: only called with the `ctx` erased on the line above.
-                on_read_bytes: |ctx, r| unsafe { H::on_read_bytes(ctx.cast::<H>(), r) },
+                on_read_bytes: |ctx, r| {
+                    unsafe { bun_core::heap::take(ctx.cast::<H>()) }.on_read_bytes(r)
+                },
                 blob: self.dupe(),
                 poll: bun_io::KeepAlive::default(),
             });
@@ -669,9 +668,7 @@ impl BlobExt for Blob {
         // In-memory or detached.
         let view = self.shared_view();
         let owned = view.to_vec();
-        // SAFETY: `ctx` is this call's handler (fn contract) and this is its
-        // only delivery.
-        unsafe { H::on_read_bytes(ctx, ReadBytesResult::Ok(owned)) }
+        handler.on_read_bytes(ReadBytesResult::Ok(owned))
     }
 
     /// `Bun.file("…").image(opts?)` ≡ `new Bun.Image(this, opts?)`. Lives here so
@@ -682,37 +679,6 @@ impl BlobExt for Blob {
         Image::from_blob_js(global, cf.this(), cf.argument(0))
     }
 
-    fn do_read_file_internal<C, F: InternalReadFileFn<C>>(
-        &self,
-        ctx: *mut C,
-        global: &JSGlobalObject,
-    ) {
-        #[cfg(windows)]
-        {
-            return read_file::ReadFileUV::start_with_ctx(
-                // SAFETY: `bun_vm()` returns the live VM for this global.
-                global.bun_vm().event_loop(),
-                self.store().expect("infallible: store present").clone(),
-                self.offset.get(),
-                self.size.get(),
-                NewInternalReadFileHandler::<C, F>::completion(ctx),
-            );
-        }
-        #[cfg(not(windows))]
-        {
-            let file_read = read_file::ReadFile::create(
-                self.store().expect("infallible: store present").clone(),
-                self.offset.get(),
-                self.size.get(),
-            )
-            .unwrap_or_else(|e| bun_core::handle_oom(Err(e)));
-            read_file::ReadFile::schedule(
-                file_read,
-                NewInternalReadFileHandler::<C, F>::completion(ctx),
-                global,
-            );
-        }
-    }
     fn get_content_type(&self) -> Option<Utf8Bytes<'_>> {
         let ct = self.content_type_slice();
         if !ct.is_empty() {
@@ -3658,40 +3624,6 @@ pub(crate) enum FormDataEntry<'a> {
         blob: &'a mut Blob,
         filename: EncodedSlice<'a>,
     },
-}
-
-/// Carries `Function(ctx, bytes)` at the type level —
-/// a trait impl so `run` can be taken as a
-/// plain `fn(*mut c_void, ReadFileResultType)` thunk, monomorphized per `(C, F)`.
-pub trait InternalReadFileFn<C> {
-    fn call(ctx: *mut C, bytes: read_file::ReadFileResultType) -> JsResult<()>;
-    /// The read will never complete (its VM stopped first): do with `ctx` what its owner needs.
-    fn cancel(ctx: *mut C);
-}
-
-pub(crate) struct NewInternalReadFileHandler<C, F>(core::marker::PhantomData<(C, F)>);
-
-impl<C, F> NewInternalReadFileHandler<C, F>
-where
-    F: InternalReadFileFn<C>,
-{
-    /// The erased `(ctx, run, cancel)` a `ReadFile`/`ReadFileUV` carries for this handler.
-    pub(crate) fn completion(ctx: *mut C) -> read_file::ReadFileCompletionFns {
-        fn run<C, F: InternalReadFileFn<C>>(
-            ctx: *mut c_void,
-            bytes: read_file::ReadFileResultType,
-        ) -> JsResult<()> {
-            F::call(ctx.cast::<C>(), bytes)
-        }
-        fn cancel<C, F: InternalReadFileFn<C>>(ctx: *mut c_void) {
-            F::cancel(ctx.cast::<C>());
-        }
-        read_file::ReadFileCompletionFns {
-            ctx: ctx.cast::<c_void>(),
-            run: run::<C, F>,
-            cancel: cancel::<C, F>,
-        }
-    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -563,28 +563,29 @@ impl BlobExt for Blob {
             return Ok(());
         }
         if self.is_s3() {
-            struct Task<H> {
-                ctx: *mut H,
+            /// `H` erased to a pointer + fn so the download closure is `'static`.
+            struct Task {
+                ctx: *mut (),
+                on_read_bytes: unsafe fn(*mut (), ReadBytesResult) -> JsResult<()>,
                 blob: Blob, // dupe for store ref + offset/size
                 poll: bun_io::KeepAlive,
             }
-            impl<H: ReadBytesHandler> Task<H> {
+            impl Task {
                 fn done(mut self: Box<Self>, r: ReadBytesResult) -> JsResult<()> {
                     self.poll.unref(bun_io::js_vm_ctx());
                     self.blob.deinit();
-                    let ctx = self.ctx;
+                    let (ctx, on_read_bytes) = (self.ctx, self.on_read_bytes);
                     drop(self);
                     // SAFETY: `ctx` is the pointer handed to `read_bytes_to_handler`;
                     // the download callback (and so `done`) runs exactly once, and
                     // the `Task` that held the pointer is gone.
-                    unsafe { H::on_read_bytes(ctx, r) }
+                    unsafe { on_read_bytes(ctx, r) }
                 }
                 fn cb(
+                    self: Box<Self>,
                     result: crate::webcore::__s3_client::S3DownloadResult,
-                    opaque_self: *mut c_void,
                 ) -> JsResult<()> {
-                    // SAFETY: `opaque_self` was heap-allocated below.
-                    let t = unsafe { bun_core::heap::take(opaque_self.cast::<Task<H>>()) };
+                    let t = self;
                     match result {
                         // `body` is owned by us (simple_request.rs); take the Vec's items as-is.
                         crate::webcore::__s3_client::S3DownloadResult::Success(response) => {
@@ -611,17 +612,19 @@ impl BlobExt for Blob {
                     }
                 }
             }
-            let mut t = Box::new(Task::<H> {
-                ctx,
+            let mut t = Box::new(Task {
+                ctx: ctx.cast(),
+                // SAFETY: only called with the `ctx` erased on the line above.
+                on_read_bytes: |ctx, r| unsafe { H::on_read_bytes(ctx.cast::<H>(), r) },
                 blob: self.dupe(),
                 poll: bun_io::KeepAlive::default(),
             });
             t.poll.ref_(bun_io::js_vm_ctx());
             let proxy = http_proxy_href(global);
-            // reshaped for borrowck — `heap::alloc(t)` moves `t`,
+            // reshaped for borrowck — the callback closure moves `t`,
             // so clone the `Rc<S3Credentials>` out (cheap ref bump)
             // and stash `path` as a raw `*const [u8]` whose backing store is
-            // kept alive by the same `t.blob` now owned by the heap task.
+            // kept alive by the same `t.blob` now owned by the closure.
             let (cred, path, payer);
             {
                 let s3 = t
@@ -637,7 +640,6 @@ impl BlobExt for Blob {
             // SAFETY: `path` borrows the store held by `t.blob` (a fresh +1 ref);
             // it stays valid until `Task::done` deinits the blob in the callback.
             let path = unsafe { &*path };
-            let t_ptr = bun_core::heap::into_raw(t).cast::<c_void>();
             if self.offset.get() > 0 || self.size.get() != MAX_SIZE {
                 let len: Option<usize> = if self.size.get() != MAX_SIZE {
                     Some(self.size.get() as usize)
@@ -649,8 +651,7 @@ impl BlobExt for Blob {
                     path,
                     self.offset.get() as usize,
                     len,
-                    Task::<H>::cb,
-                    t_ptr,
+                    move |result| t.cb(result),
                     proxy.as_deref(),
                     payer,
                 )?;
@@ -658,8 +659,7 @@ impl BlobExt for Blob {
                 crate::webcore::__s3_client::download(
                     &cred,
                     path,
-                    Task::<H>::cb,
-                    t_ptr,
+                    move |result| t.cb(result),
                     proxy.as_deref(),
                     payer,
                 )?;
@@ -1427,7 +1427,6 @@ impl BlobExt for Blob {
                 proxy_url,
                 aws_options.request_payer,
                 None,
-                core::ptr::null_mut(),
             );
         }
 
@@ -4449,38 +4448,13 @@ fn write_file_with_empty_source_to_destination(
                 }
             };
 
-            struct Wrapper {
-                promise: jsc::JSPromiseStrong,
-                store: RefPtr<Store>,
-                global: bun_ptr::BackRef<JSGlobalObject>,
-            }
-            impl Wrapper {
-                fn resolve(result: S3UploadResult, opaque_this: *mut c_void) -> JsResult<()> {
-                    // SAFETY: opaque_this was heap-allocated in the caller below.
-                    let mut this = unsafe { bun_core::heap::take(opaque_this.cast::<Wrapper>()) };
-                    let global = this.global.get();
-                    match result {
-                        S3UploadResult::Success => {
-                            this.promise.resolve(global, JSValue::js_number(0.0))?
-                        }
-                        S3UploadResult::Failure(err) => {
-                            let err_js = s3_client::error_jsc::s3_error_to_js_with_async_stack(
-                                &err,
-                                global,
-                                this.store.get_path(),
-                                this.promise.get(),
-                            );
-                            this.promise.reject(global, Ok(err_js))?;
-                        }
-                    }
-                    Ok(())
-                }
-            }
-
             let promise = jsc::JSPromiseStrong::init(ctx);
             let promise_value = promise.value();
             let proxy_owned = http_proxy_href(ctx);
             let proxy_url = proxy_owned.as_deref();
+            let store = destination_store.clone();
+            // The global outlives any in-flight request (VM-owned).
+            let global = bun_ptr::BackRef::new(ctx);
             s3_client::upload(
                 &aws_options.credentials,
                 s3.path(),
@@ -4492,13 +4466,22 @@ fn write_file_with_empty_source_to_destination(
                 proxy_url,
                 aws_options.storage_class,
                 aws_options.request_payer,
-                Wrapper::resolve,
-                bun_core::heap::into_raw(Box::new(Wrapper {
-                    promise,
-                    store: destination_store.clone(),
-                    global: bun_ptr::BackRef::new(ctx),
-                }))
-                .cast::<c_void>(),
+                move |result| {
+                    let mut promise = promise;
+                    let global = global.get();
+                    match result {
+                        S3UploadResult::Success => promise.resolve(global, JSValue::js_number(0.0)),
+                        S3UploadResult::Failure(err) => {
+                            let err = s3_client::error_jsc::s3_error_to_js_with_async_stack(
+                                &err,
+                                global,
+                                store.get_path(),
+                                promise.get(),
+                            );
+                            promise.reject(global, Ok(err))
+                        }
+                    }
+                },
             )?;
             return Ok(promise_value);
         }
@@ -4693,7 +4676,6 @@ pub(crate) fn write_file_with_source_destination(
                             proxy_url,
                             aws_options.request_payer,
                             None,
-                            core::ptr::null_mut(),
                         );
                     } else {
                         return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
@@ -4702,43 +4684,11 @@ pub(crate) fn write_file_with_source_destination(
                         ));
                     }
                 } else {
-                    struct Wrapper {
-                        store: RefPtr<Store>,
-                        promise: jsc::JSPromiseStrong,
-                        global: bun_ptr::BackRef<JSGlobalObject>,
-                    }
-                    impl Wrapper {
-                        fn resolve(
-                            result: S3UploadResult,
-                            opaque_self: *mut c_void,
-                        ) -> JsResult<()> {
-                            // SAFETY: opaque_self is the heap::alloc(Wrapper) we passed to S3::upload below.
-                            let mut this =
-                                unsafe { bun_core::heap::take(opaque_self.cast::<Wrapper>()) };
-                            let global = this.global.get();
-                            match result {
-                                S3UploadResult::Success => {
-                                    this.promise.resolve(
-                                        global,
-                                        JSValue::js_number(this.store.data.as_bytes().len() as f64),
-                                    )?;
-                                }
-                                S3UploadResult::Failure(err) => {
-                                    let err_js =
-                                        s3_client::error_jsc::s3_error_to_js_with_async_stack(
-                                            &err,
-                                            global,
-                                            this.store.get_path(),
-                                            this.promise.get(),
-                                        );
-                                    this.promise.reject(global, Ok(err_js))?;
-                                }
-                            }
-                            Ok(())
-                        }
-                    }
                     let promise = jsc::JSPromiseStrong::init(ctx);
                     let promise_value = promise.value();
+                    let store = source_store.clone();
+                    // The global outlives any in-flight request (VM-owned).
+                    let global = bun_ptr::BackRef::new(ctx);
                     s3_client::upload(
                         &aws_options.credentials,
                         s3.path(),
@@ -4750,13 +4700,25 @@ pub(crate) fn write_file_with_source_destination(
                         proxy_url,
                         aws_options.storage_class,
                         aws_options.request_payer,
-                        Wrapper::resolve,
-                        bun_core::heap::into_raw(Box::new(Wrapper {
-                            store: source_store.clone(),
-                            promise,
-                            global: bun_ptr::BackRef::new(ctx),
-                        }))
-                        .cast::<c_void>(),
+                        move |result| {
+                            let mut promise = promise;
+                            let global = global.get();
+                            match result {
+                                S3UploadResult::Success => promise.resolve(
+                                    global,
+                                    JSValue::js_number(store.data.as_bytes().len() as f64),
+                                ),
+                                S3UploadResult::Failure(err) => {
+                                    let err = s3_client::error_jsc::s3_error_to_js_with_async_stack(
+                                        &err,
+                                        global,
+                                        store.get_path(),
+                                        promise.get(),
+                                    );
+                                    promise.reject(global, Ok(err))
+                                }
+                            }
+                        },
                     )?;
                     return Ok(promise_value);
                 }
@@ -4789,7 +4751,6 @@ pub(crate) fn write_file_with_source_destination(
                         proxy_url,
                         aws_options.request_payer,
                         None,
-                        core::ptr::null_mut(),
                     );
                 } else {
                     return Ok(
@@ -5076,7 +5037,6 @@ pub(crate) fn write_file_internal(
                                 proxy_url,
                                 aws_options.request_payer,
                                 None,
-                                core::ptr::null_mut(),
                             )?));
                         }
                         destination_blob.detach();
@@ -5791,24 +5751,17 @@ impl S3BlobDownloadTask {
         // The callback may read this.blob.content_type, which is heap-owned by the
         // source JS Blob and freed on finalize(). Take an owning dupe so the task
         // outliving the source can't dangle.
-        let this = bun_core::heap::into_raw(Box::new(S3BlobDownloadTask {
+        let mut this = Box::new(S3BlobDownloadTask {
             global_this: bun_ptr::BackRef::new(global_this),
             blob: Blob::dupe(blob),
             promise: jsc::JSPromiseStrong::init(global_this),
             poll_ref: bun_io::KeepAlive::default(),
             handler,
-        }));
-        // SAFETY: just allocated; sole pointer until handed to the s3 callback
-        // below. Exclusive access scoped to the call.
-        unsafe { (*this).poll_ref.ref_(bun_io::js_vm_ctx()) };
-        // SAFETY: as above; shared access only from here on.
-        let this_ref = unsafe { &*this };
-        let promise = this_ref.promise.value();
-        let store::Data::S3(s3_store) = &this_ref
-            .blob
-            .store()
-            .expect("infallible: store present")
-            .data
+        });
+        this.poll_ref.ref_(bun_io::js_vm_ctx());
+        let promise = this.promise.value();
+        // `this.blob` shares this store.
+        let store::Data::S3(s3_store) = &blob.store().expect("infallible: store present").data
         else {
             unreachable!("S3BlobDownloadTask::init on non-S3 blob")
         };
@@ -5817,15 +5770,9 @@ impl S3BlobDownloadTask {
 
         let proxy_owned = http_proxy_href(global_this);
         let proxy = proxy_owned.as_deref();
-
-        fn s3_cb(
-            result: crate::webcore::__s3_client::S3DownloadResult<'_>,
-            ctx: *mut c_void,
-        ) -> JsResult<()> {
-            // SAFETY: `ctx` is the box leaked in `init()`; the download callback fires once.
-            let task = unsafe { bun_core::heap::take(ctx.cast::<S3BlobDownloadTask>()) };
-            S3BlobDownloadTask::on_s3_download_resolved(result, task)
-        }
+        let s3_cb = move |result: crate::webcore::__s3_client::S3DownloadResult<'_>| {
+            S3BlobDownloadTask::on_s3_download_resolved(result, this)
+        };
 
         if blob.offset.get() > 0 {
             let len: Option<usize> = if blob.size.get() != MAX_SIZE {
@@ -5840,7 +5787,6 @@ impl S3BlobDownloadTask {
                 offset,
                 len,
                 s3_cb,
-                this.cast::<c_void>(),
                 proxy,
                 s3_store.request_payer,
             )?;
@@ -5849,7 +5795,6 @@ impl S3BlobDownloadTask {
                 credentials,
                 path,
                 s3_cb,
-                this.cast::<c_void>(),
                 proxy,
                 s3_store.request_payer,
             )?;
@@ -5862,7 +5807,6 @@ impl S3BlobDownloadTask {
                 offset,
                 Some(len),
                 s3_cb,
-                this.cast::<c_void>(),
                 proxy,
                 s3_store.request_payer,
             )?;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -98,13 +98,10 @@ pub enum ReadBytesResult {
     Err(Box<bun_jsc::SystemError>),
 }
 
-/// Handler trait for `read_bytes_to_handler`.
-pub trait ReadBytesHandler {
-    /// Invoked exactly once, on the JS thread, with the handler given to
-    /// `read_bytes_to_handler`. It may settle promises: an exception it leaves
-    /// pending is the `Err`.
-    fn on_read_bytes(self: Box<Self>, result: ReadBytesResult) -> JsResult<()>;
-}
+/// `read_bytes_to_handler`'s completion: invoked exactly once, on the JS
+/// thread. It may settle promises: an exception it leaves pending is the `Err`.
+pub trait ReadBytesHandler: FnOnce(ReadBytesResult) -> JsResult<()> + 'static {}
+impl<F: FnOnce(ReadBytesResult) -> JsResult<()> + 'static> ReadBytesHandler for F {}
 
 // ──────────────────────────────────────────────────────────────────────────
 // Blob — single nominal definition lives in `bun_jsc::webcore_types`.
@@ -146,11 +143,11 @@ pub trait BlobExt {
         global: &JSGlobalObject,
     ) -> JsResult<JSValue>;
     fn do_read_file<F: read_file::ReadFileToJs>(&self, global: &JSGlobalObject) -> JSValue;
-    /// `handler.on_read_bytes` runs once — synchronously or from the async
-    /// completion — whatever this returns.
+    /// `handler` runs once — synchronously or from the async completion —
+    /// whatever this returns.
     fn read_bytes_to_handler<H: ReadBytesHandler>(
         &self,
-        handler: Box<H>,
+        handler: H,
         global: &JSGlobalObject,
     ) -> JsResult<()>;
     fn do_image(_this: &Self, global: &JSGlobalObject, cf: &CallFrame) -> JsResult<JSValue>
@@ -491,7 +488,7 @@ impl BlobExt for Blob {
     /// callers that already special-case `shared_view()` can keep doing that and
     /// only call this when it's empty.
     ///
-    /// Every store kind hands `ctx` to exactly one `H::on_read_bytes` call:
+    /// Every store kind hands the result to `handler` exactly once:
     /// in-memory stores synchronously below, file stores from the read's
     /// `run`/`cancel` completion (exactly one of which fires), S3 from the
     /// download callback (which `execute_simple_s3_request` also invokes
@@ -501,7 +498,7 @@ impl BlobExt for Blob {
     ///
     fn read_bytes_to_handler<H: ReadBytesHandler>(
         &self,
-        handler: Box<H>,
+        handler: H,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
         if self.needs_to_read_file() {
@@ -520,7 +517,7 @@ impl BlobExt for Blob {
                 };
                 // SAFETY: `ctx` is the handler boxed below; the completion fires
                 // exactly once (`run` or `cancel`).
-                unsafe { bun_core::heap::take(ctx.cast::<H>()) }.on_read_bytes(result)
+                (unsafe { bun_core::heap::take(ctx.cast::<H>()) })(result)
             }
             fn cancel<H: ReadBytesHandler>(ctx: *mut c_void) {
                 let err = jsc::SystemError {
@@ -534,11 +531,12 @@ impl BlobExt for Blob {
                 // The read's thread stopped; this runs at teardown (the unrun job's release,
                 // or `JobList::release_all_js`), where what the handler leaves stays pending.
                 // SAFETY: as for `run`.
-                let _ = unsafe { bun_core::heap::take(ctx.cast::<H>()) }
-                    .on_read_bytes(ReadBytesResult::Err(Box::new(err)));
+                let _ = (unsafe { bun_core::heap::take(ctx.cast::<H>()) })(ReadBytesResult::Err(
+                    Box::new(err),
+                ));
             }
             let completion = read_file::ReadFileCompletionFns {
-                ctx: bun_core::heap::into_raw(handler).cast::<c_void>(),
+                ctx: bun_core::heap::into_raw(Box::new(handler)).cast::<c_void>(),
                 run: run::<H>,
                 cancel: cancel::<H>,
             };
@@ -561,84 +559,56 @@ impl BlobExt for Blob {
             return Ok(());
         }
         if self.is_s3() {
-            /// `H` erased to a pointer + fn so the download closure is `'static`.
-            struct Task {
-                ctx: *mut (),
-                on_read_bytes: unsafe fn(*mut (), ReadBytesResult) -> JsResult<()>,
+            struct Task<H> {
+                handler: H,
                 blob: Blob, // dupe for store ref + offset/size
                 poll: bun_io::KeepAlive,
             }
-            impl Task {
-                fn done(mut self: Box<Self>, r: ReadBytesResult) -> JsResult<()> {
+            impl<H: ReadBytesHandler> Task<H> {
+                fn done(mut self, r: ReadBytesResult) -> JsResult<()> {
                     self.poll.unref(bun_io::js_vm_ctx());
                     self.blob.deinit();
-                    let (ctx, on_read_bytes) = (self.ctx, self.on_read_bytes);
-                    drop(self);
-                    // SAFETY: `ctx` is the handler boxed in `read_bytes_to_handler`;
-                    // the download callback (and so `done`) runs exactly once.
-                    unsafe { on_read_bytes(ctx, r) }
+                    (self.handler)(r)
                 }
-                fn cb(
-                    self: Box<Self>,
-                    result: crate::webcore::__s3_client::S3DownloadResult,
-                ) -> JsResult<()> {
-                    let t = self;
+                fn cb(self, result: crate::webcore::__s3_client::S3DownloadResult) -> JsResult<()> {
                     match result {
                         // `body` is owned by us (simple_request.rs); take the Vec's items as-is.
                         crate::webcore::__s3_client::S3DownloadResult::Success(response) => {
-                            t.done(ReadBytesResult::Ok(response.body.list))
+                            self.done(ReadBytesResult::Ok(response.body.list))
                         }
                         // S3Error has its own JS-error builder; flatten to a
                         // SystemError so the callback has one shape to handle.
                         crate::webcore::__s3_client::S3DownloadResult::NotFound(e)
                         | crate::webcore::__s3_client::S3DownloadResult::Failure(e) => {
-                            // reshaped for borrowck — `t.done` moves
-                            // `t`, so build the SystemError (cloning the path
-                            // out of `t.blob.store`) before the call.
                             let err = bun_jsc::SystemError {
                                 code: BunString::clone_utf8(e.code),
                                 message: BunString::clone_utf8(e.message),
                                 path: BunString::clone_utf8(
-                                    t.blob.store().and_then(|s| s.get_path()).unwrap_or(b""),
+                                    self.blob.store().and_then(|s| s.get_path()).unwrap_or(b""),
                                 ),
                                 syscall: BunString::static_("fetch"),
                                 ..Default::default()
                             };
-                            t.done(ReadBytesResult::Err(Box::new(err)))
+                            self.done(ReadBytesResult::Err(Box::new(err)))
                         }
                     }
                 }
             }
-            let mut t = Box::new(Task {
-                ctx: bun_core::heap::into_raw(handler).cast(),
-                // SAFETY: only called with the `ctx` erased on the line above.
-                on_read_bytes: |ctx, r| {
-                    unsafe { bun_core::heap::take(ctx.cast::<H>()) }.on_read_bytes(r)
-                },
+            let mut t = Task {
+                handler,
                 blob: self.dupe(),
                 poll: bun_io::KeepAlive::default(),
-            });
+            };
             t.poll.ref_(bun_io::js_vm_ctx());
             let proxy = http_proxy_href(global);
-            // reshaped for borrowck — the callback closure moves `t`,
-            // so clone the `Rc<S3Credentials>` out (cheap ref bump)
-            // and stash `path` as a raw `*const [u8]` whose backing store is
-            // kept alive by the same `t.blob` now owned by the closure.
-            let (cred, path, payer);
-            {
-                let s3 = t
-                    .blob
-                    .store()
-                    .expect("infallible: store present")
-                    .data
-                    .as_s3();
-                cred = std::rc::Rc::clone(s3.get_credentials());
-                path = std::ptr::from_ref::<[u8]>(s3.path());
-                payer = s3.request_payer;
-            }
-            // SAFETY: `path` borrows the store held by `t.blob` (a fresh +1 ref);
-            // it stays valid until `Task::done` deinits the blob in the callback.
-            let path = unsafe { &*path };
+            // `t.blob` shares `self`'s store, so borrow credentials/path from
+            // `self` while `t` moves into the callback.
+            let s3 = self.store.get().as_ref().unwrap().data.as_s3();
+            let cred = s3.get_credentials();
+            let path = s3.path();
+            let payer = s3.request_payer;
+            let callback =
+                move |result: crate::webcore::__s3_client::S3DownloadResult<'_>| t.cb(result);
             if self.offset.get() > 0 || self.size.get() != MAX_SIZE {
                 let len: Option<usize> = if self.size.get() != MAX_SIZE {
                     Some(self.size.get() as usize)
@@ -646,19 +616,19 @@ impl BlobExt for Blob {
                     None
                 };
                 crate::webcore::__s3_client::download_slice(
-                    &cred,
+                    cred,
                     path,
                     self.offset.get() as usize,
                     len,
-                    move |result| t.cb(result),
+                    callback,
                     proxy.as_deref(),
                     payer,
                 )?;
             } else {
                 crate::webcore::__s3_client::download(
-                    &cred,
+                    cred,
                     path,
-                    move |result| t.cb(result),
+                    callback,
                     proxy.as_deref(),
                     payer,
                 )?;
@@ -668,7 +638,7 @@ impl BlobExt for Blob {
         // In-memory or detached.
         let view = self.shared_view();
         let owned = view.to_vec();
-        handler.on_read_bytes(ReadBytesResult::Ok(owned))
+        handler(ReadBytesResult::Ok(owned))
     }
 
     /// `Bun.file("…").image(opts?)` ≡ `new Bun.Image(this, opts?)`. Lives here so
@@ -4385,8 +4355,7 @@ fn write_file_with_empty_source_to_destination(
             let proxy_owned = http_proxy_href(ctx);
             let proxy_url = proxy_owned.as_deref();
             let store = destination_store.clone();
-            // The global outlives any in-flight request (VM-owned).
-            let global = bun_ptr::BackRef::new(ctx);
+            let global = bun_jsc::GlobalRef::from(ctx);
             s3_client::upload(
                 &aws_options.credentials,
                 s3.path(),
@@ -4400,7 +4369,7 @@ fn write_file_with_empty_source_to_destination(
                 aws_options.request_payer,
                 move |result| {
                     let mut promise = promise;
-                    let global = global.get();
+                    let global: &JSGlobalObject = &global;
                     match result {
                         S3UploadResult::Success => promise.resolve(global, JSValue::js_number(0.0)),
                         S3UploadResult::Failure(err) => {
@@ -4455,7 +4424,7 @@ pub(crate) fn write_file_with_source_destination(
     if destination_type == store::DataTag::File && source_type == store::DataTag::Bytes {
         let write_file_promise = WriteFilePromise {
             promise: jsc::JSPromiseStrong::init(ctx),
-            global_this: Some(bun_jsc::GlobalRef::from(ctx)),
+            global_this: bun_jsc::GlobalRef::from(ctx),
         };
         let promise_value = write_file_promise.promise.value();
         promise_value.ensure_still_alive();
@@ -4607,8 +4576,7 @@ pub(crate) fn write_file_with_source_destination(
                     let promise = jsc::JSPromiseStrong::init(ctx);
                     let promise_value = promise.value();
                     let store = source_store.clone();
-                    // The global outlives any in-flight request (VM-owned).
-                    let global = bun_ptr::BackRef::new(ctx);
+                    let global = bun_jsc::GlobalRef::from(ctx);
                     s3_client::upload(
                         &aws_options.credentials,
                         s3.path(),
@@ -4622,7 +4590,7 @@ pub(crate) fn write_file_with_source_destination(
                         aws_options.request_payer,
                         move |result| {
                             let mut promise = promise;
-                            let global = global.get();
+                            let global: &JSGlobalObject = &global;
                             match result {
                                 S3UploadResult::Success => promise.resolve(
                                     global,
@@ -5622,11 +5590,11 @@ impl S3BlobDownloadTask {
         (self.handler)(&self.blob, self.global_this, raw_bytes)
     }
 
-    #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
     pub(crate) fn on_s3_download_resolved(
+        self,
         result: crate::webcore::__s3_client::S3DownloadResult,
-        mut this: Box<S3BlobDownloadTask>,
     ) -> JsResult<()> {
+        let mut this = self;
         // Copy the `BackRef` out so the `&JSGlobalObject` borrow is detached
         // from `this` (it must coexist with `&mut this` calls below).
         let global_ref = this.global_this;
@@ -5671,13 +5639,13 @@ impl S3BlobDownloadTask {
         // The callback may read this.blob.content_type, which is heap-owned by the
         // source JS Blob and freed on finalize(). Take an owning dupe so the task
         // outliving the source can't dangle.
-        let mut this = Box::new(S3BlobDownloadTask {
+        let mut this = S3BlobDownloadTask {
             global_this: bun_ptr::BackRef::new(global_this),
             blob: Blob::dupe(blob),
             promise: jsc::JSPromiseStrong::init(global_this),
             poll_ref: bun_io::KeepAlive::default(),
             handler,
-        });
+        };
         this.poll_ref.ref_(bun_io::js_vm_ctx());
         let promise = this.promise.value();
         // `this.blob` shares this store.
@@ -5691,7 +5659,7 @@ impl S3BlobDownloadTask {
         let proxy_owned = http_proxy_href(global_this);
         let proxy = proxy_owned.as_deref();
         let s3_cb = move |result: crate::webcore::__s3_client::S3DownloadResult<'_>| {
-            S3BlobDownloadTask::on_s3_download_resolved(result, this)
+            this.on_s3_download_resolved(result)
         };
 
         if blob.offset.get() > 0 {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4521,26 +4521,22 @@ pub(crate) fn write_file_with_source_destination(
     let source_type = source_store.data.tag();
 
     if destination_type == store::DataTag::File && source_type == store::DataTag::Bytes {
-        let write_file_promise = bun_core::heap::into_raw(Box::new(WriteFilePromise {
-            promise: jsc::JSPromiseStrong::default(),
-            global_this: ctx,
-        }));
+        let write_file_promise = WriteFilePromise {
+            promise: jsc::JSPromiseStrong::init(ctx),
+            global_this: Some(bun_jsc::GlobalRef::from(ctx)),
+        };
+        let promise_value = write_file_promise.promise.value();
+        promise_value.ensure_still_alive();
 
         // The borrowed views below are +0 on the store ref;
         // `WriteFile::create` takes its own ref.
         #[cfg(windows)]
         {
-            let promise = JSPromise::create(ctx);
-            let promise_value = promise.as_value(ctx);
-            promise_value.ensure_still_alive();
-            // SAFETY: write_file_promise was just produced by heap::alloc above; sole owner.
-            unsafe { (*write_file_promise).promise.set(ctx, promise_value) };
             match write_file_mod::WriteFileWindows::create(
                 ctx.bun_vm().event_loop(),
                 destination_blob.borrowed_view(),
                 source_blob.borrowed_view(),
                 write_file_promise,
-                WriteFilePromise::run,
                 options.mkdirp_if_not_exists.unwrap_or(true),
             ) {
                 Err(write_file_mod::WriteFileWindowsError::WriteFileWindowsDeinitialized) => {}
@@ -4556,16 +4552,8 @@ pub(crate) fn write_file_with_source_destination(
                 destination_blob.borrowed_view(),
                 source_blob.borrowed_view(),
                 write_file_promise,
-                WriteFilePromise::run,
                 options.mkdirp_if_not_exists.unwrap_or(true),
-            )
-            .expect("unreachable");
-            // Defer promise creation until we're just about to schedule the task.
-            // SAFETY: write_file_promise was just produced by heap::alloc above; sole owner.
-            unsafe { (*write_file_promise).promise = jsc::JSPromiseStrong::init(ctx) };
-            // SAFETY: same `write_file_promise` as above; still solely owned here.
-            let promise_value = unsafe { (*write_file_promise).promise.value() };
-            promise_value.ensure_still_alive();
+            );
             write_file_mod::WriteFile::schedule(file_copier, ctx);
             return Ok(promise_value);
         }

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -362,19 +362,9 @@ pub(crate) struct S3BlobStatTask {
 }
 
 impl S3BlobStatTask {
-    fn new(init: S3BlobStatTask) -> *mut S3BlobStatTask {
-        bun_core::heap::into_raw(Box::new(init))
-    }
-
-    fn on_s3_exists_resolved(
-        result: s3::S3StatResult,
-        this: *mut core::ffi::c_void,
-    ) -> JsResult<()> {
-        // SAFETY: `this` was allocated via heap::alloc in `exists`; reconstructing here replaces `defer this.deinit()`
-        let mut this = unsafe { bun_core::heap::take(this.cast::<S3BlobStatTask>()) };
-        // Copy the BackRef out so `this` is not borrowed across `&mut this.promise`.
-        let global_ref = this.global;
-        let global = global_ref.get();
+    fn on_s3_exists_resolved(self, result: s3::S3StatResult) -> JsResult<()> {
+        let mut this = self;
+        let global = this.global.get();
         match result {
             s3::S3StatResult::NotFound(_) => {
                 this.promise.resolve(global, JSValue::FALSE)?;
@@ -400,13 +390,9 @@ impl S3BlobStatTask {
         Ok(())
     }
 
-    fn on_s3_size_resolved(result: s3::S3StatResult, this: *mut core::ffi::c_void) -> JsResult<()> {
-        // SAFETY: `this` was allocated via heap::alloc in `size`; reconstructing here replaces `defer this.deinit()`
-        let mut this = unsafe { bun_core::heap::take(this.cast::<S3BlobStatTask>()) };
-        // Copy the BackRef out so `this` is not borrowed across `&mut this.promise`.
-        let global_ref = this.global;
-        let global = global_ref.get();
-
+    fn on_s3_size_resolved(self, result: s3::S3StatResult) -> JsResult<()> {
+        let mut this = self;
+        let global = this.global.get();
         match result {
             s3::S3StatResult::Success(stat_result) => {
                 this.promise
@@ -425,12 +411,9 @@ impl S3BlobStatTask {
         Ok(())
     }
 
-    fn on_s3_stat_resolved(result: s3::S3StatResult, this: *mut core::ffi::c_void) -> JsResult<()> {
-        // SAFETY: `this` was allocated via heap::alloc in `stat`; reconstructing here replaces `defer this.deinit()`
-        let mut this = unsafe { bun_core::heap::take(this.cast::<S3BlobStatTask>()) };
-        // Copy the BackRef out so `this` is not borrowed across `&mut this.promise`.
-        let global_ref = this.global;
-        let global = global_ref.get();
+    fn on_s3_stat_resolved(self, result: s3::S3StatResult) -> JsResult<()> {
+        let mut this = self;
+        let global = this.global.get();
         match result {
             s3::S3StatResult::Success(stat_result) => {
                 let s3_stat = match S3Stat::init(
@@ -460,88 +443,43 @@ impl S3BlobStatTask {
         Ok(())
     }
 
-    pub(crate) fn exists(global: &JSGlobalObject, blob: &Blob) -> JsResult<JSValue> {
-        let this = S3BlobStatTask::new(S3BlobStatTask {
+    /// HEAD the blob's object and settle a new promise with `on_resolved`.
+    fn run(
+        global: &JSGlobalObject,
+        blob: &Blob,
+        on_resolved: fn(Self, s3::S3StatResult) -> JsResult<()>,
+    ) -> JsResult<JSValue> {
+        let this = S3BlobStatTask {
             promise: bun_jsc::JSPromiseStrong::init(global),
             store: blob.store.get().as_ref().unwrap().clone(),
             global: bun_ptr::BackRef::new(global),
-        });
-        // SAFETY: `this` is a freshly leaked Box; sole pointer until handed to the s3
-        // callback below. Scoped shared access.
-        let promise = unsafe { (*this).promise.value() };
+        };
+        let promise = this.promise.value();
         let s3_store = blob.store.get().as_ref().unwrap().data.as_s3();
-        let credentials = s3_store.get_credentials();
-        let path = s3_store.path();
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
         // dotenv loader (set during init).
         let env = global.bun_vm().as_mut().transpiler.env_mut();
-
         s3::stat(
-            credentials,
-            path,
-            S3BlobStatTask::on_s3_exists_resolved,
-            this.cast::<core::ffi::c_void>(),
+            s3_store.get_credentials(),
+            s3_store.path(),
+            move |result| on_resolved(this, result),
             env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
             s3_store.request_payer,
         )?;
         Ok(promise)
+    }
+
+    pub(crate) fn exists(global: &JSGlobalObject, blob: &Blob) -> JsResult<JSValue> {
+        Self::run(global, blob, Self::on_s3_exists_resolved)
     }
 
     pub(crate) fn stat(global: &JSGlobalObject, blob: &Blob) -> JsResult<JSValue> {
-        let this = S3BlobStatTask::new(S3BlobStatTask {
-            promise: bun_jsc::JSPromiseStrong::init(global),
-            store: blob.store.get().as_ref().unwrap().clone(),
-            global: bun_ptr::BackRef::new(global),
-        });
-        // SAFETY: `this` is a freshly leaked Box; sole pointer until handed to the s3
-        // callback below. Scoped shared access.
-        let promise = unsafe { (*this).promise.value() };
-        let s3_store = blob.store.get().as_ref().unwrap().data.as_s3();
-        let credentials = s3_store.get_credentials();
-        let path = s3_store.path();
-        // `Transpiler::env_mut` is the safe accessor for the process-singleton
-        // dotenv loader (set during init).
-        let env = global.bun_vm().as_mut().transpiler.env_mut();
-
-        s3::stat(
-            credentials,
-            path,
-            S3BlobStatTask::on_s3_stat_resolved,
-            this.cast::<core::ffi::c_void>(),
-            env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
-            s3_store.request_payer,
-        )?;
-        Ok(promise)
+        Self::run(global, blob, Self::on_s3_stat_resolved)
     }
 
     pub(crate) fn size(global: &JSGlobalObject, blob: &mut Blob) -> JsResult<JSValue> {
-        let this = S3BlobStatTask::new(S3BlobStatTask {
-            promise: bun_jsc::JSPromiseStrong::init(global),
-            store: blob.store.get().as_ref().unwrap().clone(),
-            global: bun_ptr::BackRef::new(global),
-        });
-        // SAFETY: `this` is a freshly leaked Box; sole pointer until handed to the s3
-        // callback below. Scoped shared access.
-        let promise = unsafe { (*this).promise.value() };
-        let s3_store = blob.store.get().as_ref().unwrap().data.as_s3();
-        let credentials = s3_store.get_credentials();
-        let path = s3_store.path();
-        // `Transpiler::env_mut` is the safe accessor for the process-singleton
-        // dotenv loader (set during init).
-        let env = global.bun_vm().as_mut().transpiler.env_mut();
-
-        s3::stat(
-            credentials,
-            path,
-            S3BlobStatTask::on_s3_size_resolved,
-            this.cast::<core::ffi::c_void>(),
-            env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
-            s3_store.request_payer,
-        )?;
-        Ok(promise)
+        Self::run(global, blob, Self::on_s3_size_resolved)
     }
-
-    // Teardown (store deref, promise deinit, freeing the box) is handled by Box<Self> Drop.
 }
 
 // `Method.fromJS` lives in `bun_http_jsc` so `bun_http_types` stays

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -362,12 +362,11 @@ pub(crate) struct S3BlobStatTask {
 }
 
 impl S3BlobStatTask {
-    fn on_s3_exists_resolved(self, result: s3::S3StatResult) -> JsResult<()> {
-        let mut this = self;
-        let global = this.global.get();
+    fn on_s3_exists_resolved(mut self, result: s3::S3StatResult) -> JsResult<()> {
+        let global = self.global.get();
         match result {
             s3::S3StatResult::NotFound(_) => {
-                this.promise.resolve(global, JSValue::FALSE)?;
+                self.promise.resolve(global, JSValue::FALSE)?;
             }
             s3::S3StatResult::Success(_) => {
                 // calling .exists() should not prevent it to download a bigger file
@@ -375,45 +374,43 @@ impl S3BlobStatTask {
                 // if (this.blob.size == Blob.max_size) {
                 //     this.blob.size = @truncate(stat.size);
                 // }
-                this.promise.resolve(global, JSValue::TRUE)?;
+                self.promise.resolve(global, JSValue::TRUE)?;
             }
             s3::S3StatResult::Failure(err) => {
                 let value = s3_error_to_js_with_async_stack(
                     &err,
                     global,
-                    Some(this.store.data.as_s3().path()),
-                    this.promise.get(),
+                    Some(self.store.data.as_s3().path()),
+                    self.promise.get(),
                 );
-                this.promise.reject(global, Ok(value))?;
+                self.promise.reject(global, Ok(value))?;
             }
         }
         Ok(())
     }
 
-    fn on_s3_size_resolved(self, result: s3::S3StatResult) -> JsResult<()> {
-        let mut this = self;
-        let global = this.global.get();
+    fn on_s3_size_resolved(mut self, result: s3::S3StatResult) -> JsResult<()> {
+        let global = self.global.get();
         match result {
             s3::S3StatResult::Success(stat_result) => {
-                this.promise
+                self.promise
                     .resolve(global, JSValue::js_number(stat_result.size as f64))?;
             }
             s3::S3StatResult::NotFound(err) | s3::S3StatResult::Failure(err) => {
                 let value = s3_error_to_js_with_async_stack(
                     &err,
                     global,
-                    Some(this.store.data.as_s3().path()),
-                    this.promise.get(),
+                    Some(self.store.data.as_s3().path()),
+                    self.promise.get(),
                 );
-                this.promise.reject(global, Ok(value))?;
+                self.promise.reject(global, Ok(value))?;
             }
         }
         Ok(())
     }
 
-    fn on_s3_stat_resolved(self, result: s3::S3StatResult) -> JsResult<()> {
-        let mut this = self;
-        let global = this.global.get();
+    fn on_s3_stat_resolved(mut self, result: s3::S3StatResult) -> JsResult<()> {
+        let global = self.global.get();
         match result {
             s3::S3StatResult::Success(stat_result) => {
                 let s3_stat = match S3Stat::init(
@@ -425,19 +422,19 @@ impl S3BlobStatTask {
                 ) {
                     Ok(b) => (*b).to_js(global),
                     Err(_) => {
-                        return this.promise.reject(global, Err(JsError::Thrown));
+                        return self.promise.reject(global, Err(JsError::Thrown));
                     }
                 };
-                this.promise.resolve(global, s3_stat)?;
+                self.promise.resolve(global, s3_stat)?;
             }
             s3::S3StatResult::NotFound(err) | s3::S3StatResult::Failure(err) => {
                 let value = s3_error_to_js_with_async_stack(
                     &err,
                     global,
-                    Some(this.store.data.as_s3().path()),
-                    this.promise.get(),
+                    Some(self.store.data.as_s3().path()),
+                    self.promise.get(),
                 );
-                this.promise.reject(global, Ok(value))?;
+                self.promise.reject(global, Ok(value))?;
             }
         }
         Ok(())
@@ -447,7 +444,7 @@ impl S3BlobStatTask {
     fn run(
         global: &JSGlobalObject,
         blob: &Blob,
-        on_resolved: fn(Self, s3::S3StatResult) -> JsResult<()>,
+        on_resolved: impl FnOnce(Self, s3::S3StatResult<'_>) -> JsResult<()> + 'static,
     ) -> JsResult<JSValue> {
         let this = S3BlobStatTask {
             promise: bun_jsc::JSPromiseStrong::init(global),

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -355,15 +355,13 @@ fn construct_s3_file_internal(
 
 pub(crate) struct S3BlobStatTask {
     promise: bun_jsc::JSPromiseStrong,
-    // LIFETIMES.tsv: JSC_BORROW (&JSGlobalObject). `BackRef` so the heap task
-    // can outlive the constructing frame while reads stay safe.
-    global: bun_ptr::BackRef<JSGlobalObject>,
+    global: bun_jsc::GlobalRef,
     store: RefPtr<Store>,
 }
 
 impl S3BlobStatTask {
     fn on_s3_exists_resolved(mut self, result: s3::S3StatResult) -> JsResult<()> {
-        let global = self.global.get();
+        let global: &JSGlobalObject = &self.global;
         match result {
             s3::S3StatResult::NotFound(_) => {
                 self.promise.resolve(global, JSValue::FALSE)?;
@@ -390,7 +388,7 @@ impl S3BlobStatTask {
     }
 
     fn on_s3_size_resolved(mut self, result: s3::S3StatResult) -> JsResult<()> {
-        let global = self.global.get();
+        let global: &JSGlobalObject = &self.global;
         match result {
             s3::S3StatResult::Success(stat_result) => {
                 self.promise
@@ -410,7 +408,7 @@ impl S3BlobStatTask {
     }
 
     fn on_s3_stat_resolved(mut self, result: s3::S3StatResult) -> JsResult<()> {
-        let global = self.global.get();
+        let global: &JSGlobalObject = &self.global;
         match result {
             s3::S3StatResult::Success(stat_result) => {
                 let s3_stat = match S3Stat::init(
@@ -449,7 +447,7 @@ impl S3BlobStatTask {
         let this = S3BlobStatTask {
             promise: bun_jsc::JSPromiseStrong::init(global),
             store: blob.store.get().as_ref().unwrap().clone(),
-            global: bun_ptr::BackRef::new(global),
+            global: bun_jsc::GlobalRef::from(global),
         };
         let promise = this.promise.value();
         let s3_store = blob.store.get().as_ref().unwrap().data.as_s3();

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -5,7 +5,6 @@
 //! this module re-exports them and layers the `bun_runtime`-tier behaviour
 //! (S3 I/O, async file ops, structured-clone serialize) via extension traits.
 
-use core::ffi::c_void;
 use core::ptr::NonNull;
 
 use crate::node::fs as node_fs;
@@ -15,8 +14,7 @@ use crate::webcore::node_types::{PathLike, PathOrFileDescriptor};
 use crate::webcore::s3::client as s3_client;
 use crate::webcore::s3::client::S3ErrorJsc as _;
 use crate::webcore::s3::client::{
-    S3Credentials, S3CredentialsWithOptions, S3DeleteResult, S3ListObjectsOptions,
-    S3ListObjectsResult,
+    S3Credentials, S3CredentialsWithOptions, S3DeleteResult, S3ListObjectsResult,
 };
 use bun_core::strings;
 use bun_http_types::MimeType::MimeType;
@@ -276,44 +274,6 @@ impl S3Ext for S3 {
         global_this: &JSGlobalObject,
         extra_options: Option<JSValue>,
     ) -> JsResult<JSValue> {
-        struct Wrapper {
-            promise: bun_jsc::JSPromiseStrong,
-            store: RefPtr<Store>,
-            // LIFETIMES.tsv: JSC_BORROW → &JSGlobalObject. `BackRef` so the heap
-            // wrapper can outlive the constructing frame while reads stay safe.
-            global: bun_ptr::BackRef<JSGlobalObject>,
-        }
-
-        impl Wrapper {
-            #[inline]
-            fn new(init: Wrapper) -> Box<Wrapper> {
-                Box::new(init)
-            }
-
-            fn resolve(result: S3DeleteResult<'_>, opaque_self: *mut c_void) -> JsResult<()> {
-                // SAFETY: opaque_self was created via heap::alloc(Wrapper::new(..)) below.
-                let mut self_ = unsafe { bun_core::heap::take(opaque_self.cast::<Wrapper>()) };
-                // `defer self.deinit()` → Box drops at scope exit.
-                let global_object = self_.global.get();
-                match result {
-                    S3DeleteResult::Success => {
-                        self_.promise.resolve(global_object, JSValue::TRUE)?;
-                    }
-                    S3DeleteResult::NotFound(err) | S3DeleteResult::Failure(err) => {
-                        // Split borrows: `reject` takes `&mut promise`, so
-                        // compute the error (which reads `promise.get()`) first.
-                        let err_val = err.to_js_with_async_stack(
-                            global_object,
-                            self_.store.get_path(),
-                            self_.promise.get(),
-                        );
-                        self_.promise.reject(global_object, err_val)?;
-                    }
-                }
-                Ok(())
-            }
-        }
-
         let promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
@@ -326,18 +286,25 @@ impl S3Ext for S3 {
             .get_http_proxy(true, None, None);
         let proxy = proxy_url.as_ref().map(|url| url.href);
         let aws_options = self.get_credentials_with_options(extra_options, global_this)?;
-        // `defer aws_options.deinit()` → Drop handles it.
 
+        let store = store.clone();
+        // The global outlives any in-flight request (VM-owned).
+        let global = bun_ptr::BackRef::new(global_this);
         s3_client::delete(
             &aws_options.credentials,
             self.path(),
-            Wrapper::resolve,
-            bun_core::heap::into_raw(Wrapper::new(Wrapper {
-                promise,
-                store: store.clone(),
-                global: bun_ptr::BackRef::new(global_this),
-            }))
-            .cast::<c_void>(),
+            move |result| {
+                let mut promise = promise;
+                let global = global.get();
+                match result {
+                    S3DeleteResult::Success => promise.resolve(global, JSValue::TRUE),
+                    S3DeleteResult::NotFound(err) | S3DeleteResult::Failure(err) => {
+                        let err =
+                            err.to_js_with_async_stack(global, store.get_path(), promise.get());
+                        promise.reject(global, err)
+                    }
+                }
+            },
             proxy,
             aws_options.request_payer,
         )?;
@@ -358,48 +325,6 @@ impl S3Ext for S3 {
             )));
         }
 
-        struct Wrapper {
-            promise: bun_jsc::JSPromiseStrong,
-            store: RefPtr<Store>,
-            resolved_list_options: S3ListObjectsOptions,
-            // LIFETIMES.tsv: JSC_BORROW. `BackRef` for safe deref across the async callback.
-            global: bun_ptr::BackRef<JSGlobalObject>,
-        }
-
-        impl Wrapper {
-            fn resolve(result: S3ListObjectsResult<'_>, opaque_self: *mut c_void) -> JsResult<()> {
-                // SAFETY: opaque_self was created via heap::alloc below.
-                let mut self_ = unsafe { bun_core::heap::take(opaque_self.cast::<Wrapper>()) };
-                // `defer self.deinit()` → Box drops at scope exit.
-                let global_object = self_.global.get();
-
-                match result {
-                    S3ListObjectsResult::Success(list_result) => {
-                        // `defer list_result.deinit()` → Drop handles it.
-                        let list_result_js = match list_result.to_js(global_object) {
-                            Ok(v) => v,
-                            Err(e) => {
-                                return self_.promise.reject(global_object, Err(e));
-                            }
-                        };
-                        self_.promise.resolve(global_object, list_result_js)?;
-                    }
-
-                    S3ListObjectsResult::NotFound(err) | S3ListObjectsResult::Failure(err) => {
-                        // Split borrows: `reject` takes `&mut promise`, so
-                        // compute the error (which reads `promise.get()`) first.
-                        let err_val = err.to_js_with_async_stack(
-                            global_object,
-                            self_.store.get_path(),
-                            self_.promise.get(),
-                        );
-                        self_.promise.reject(global_object, err_val)?;
-                    }
-                }
-                Ok(())
-            }
-        }
-
         let promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
@@ -412,28 +337,29 @@ impl S3Ext for S3 {
             .get_http_proxy(true, None, None);
         let proxy = proxy_url.as_ref().map(|url| url.href);
         let aws_options = self.get_credentials_with_options(extra_options, global_this)?;
-        // `defer aws_options.deinit()` → Drop handles it.
-
         let options = s3_client::get_list_objects_options_from_js(global_this, list_options)?;
 
-        // Box the wrapper first so the options live on the heap, then hand a
-        // borrow to `list_objects` (which only reads them synchronously to
-        // build the search-params string). The wrapper retains ownership for
-        // `Drop` after the async callback.
-        let wrapper = bun_core::heap::into_raw(Box::new(Wrapper {
-            promise,
-            store: store.clone(),
-            resolved_list_options: options,
-            global: bun_ptr::BackRef::new(global_this),
-        }));
-
+        let store = store.clone();
+        // The global outlives any in-flight request (VM-owned).
+        let global = bun_ptr::BackRef::new(global_this);
         s3_client::list_objects(
             &aws_options.credentials,
-            // SAFETY: `wrapper` is freshly leaked and untouched until the
-            // callback; this borrow ends before any other access.
-            unsafe { &(*wrapper).resolved_list_options },
-            Wrapper::resolve,
-            wrapper.cast::<c_void>(),
+            &options,
+            move |result| {
+                let mut promise = promise;
+                let global = global.get();
+                match result {
+                    S3ListObjectsResult::Success(list_result) => match list_result.to_js(global) {
+                        Ok(v) => promise.resolve(global, v),
+                        Err(e) => promise.reject(global, Err(e)),
+                    },
+                    S3ListObjectsResult::NotFound(err) | S3ListObjectsResult::Failure(err) => {
+                        let err =
+                            err.to_js_with_async_stack(global, store.get_path(), promise.get());
+                        promise.reject(global, err)
+                    }
+                }
+            },
             proxy,
         )?;
 

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -288,14 +288,13 @@ impl S3Ext for S3 {
         let aws_options = self.get_credentials_with_options(extra_options, global_this)?;
 
         let store = store.clone();
-        // The global outlives any in-flight request (VM-owned).
-        let global = bun_ptr::BackRef::new(global_this);
+        let global = bun_jsc::GlobalRef::from(global_this);
         s3_client::delete(
             &aws_options.credentials,
             self.path(),
             move |result| {
                 let mut promise = promise;
-                let global = global.get();
+                let global: &JSGlobalObject = &global;
                 match result {
                     S3DeleteResult::Success => promise.resolve(global, JSValue::TRUE),
                     S3DeleteResult::NotFound(err) | S3DeleteResult::Failure(err) => {
@@ -340,14 +339,13 @@ impl S3Ext for S3 {
         let options = s3_client::get_list_objects_options_from_js(global_this, list_options)?;
 
         let store = store.clone();
-        // The global outlives any in-flight request (VM-owned).
-        let global = bun_ptr::BackRef::new(global_this);
+        let global = bun_jsc::GlobalRef::from(global_this);
         s3_client::list_objects(
             &aws_options.credentials,
             &options,
             move |result| {
                 let mut promise = promise;
-                let global = global.get();
+                let global: &JSGlobalObject = &global;
                 match result {
                     S3ListObjectsResult::Success(list_result) => match list_result.to_js(global) {
                         Ok(v) => promise.resolve(global, v),

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -274,7 +274,7 @@ impl S3Ext for S3 {
         global_this: &JSGlobalObject,
         extra_options: Option<JSValue>,
     ) -> JsResult<JSValue> {
-        let promise = bun_jsc::JSPromiseStrong::init(global_this);
+        let mut promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
         // dotenv loader (never null once the VM is initialised).
@@ -293,7 +293,6 @@ impl S3Ext for S3 {
             &aws_options.credentials,
             self.path(),
             move |result| {
-                let mut promise = promise;
                 let global: &JSGlobalObject = &global;
                 match result {
                     S3DeleteResult::Success => promise.resolve(global, JSValue::TRUE),
@@ -324,7 +323,7 @@ impl S3Ext for S3 {
             )));
         }
 
-        let promise = bun_jsc::JSPromiseStrong::init(global_this);
+        let mut promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
         // dotenv loader (never null once the VM is initialised).
@@ -344,13 +343,12 @@ impl S3Ext for S3 {
             &aws_options.credentials,
             &options,
             move |result| {
-                let mut promise = promise;
                 let global: &JSGlobalObject = &global;
                 match result {
-                    S3ListObjectsResult::Success(list_result) => match list_result.to_js(global) {
-                        Ok(v) => promise.resolve(global, v),
-                        Err(e) => promise.reject(global, Err(e)),
-                    },
+                    S3ListObjectsResult::Success(list_result) => {
+                        let value = list_result.to_js(global);
+                        promise.settle(global, value)
+                    }
                     S3ListObjectsResult::NotFound(err) | S3ListObjectsResult::Failure(err) => {
                         let err =
                             err.to_js_with_async_stack(global, store.get_path(), promise.get());

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -1917,16 +1917,15 @@ fn on_mkdirp_complete_concurrent(ctx: *mut (), err_: bun_sys::Maybe<()>, ticket:
         bun_sys::Result::Err(e) => Some(e),
         bun_sys::Result::Ok(()) => None,
     };
-    // callback signature to match `ManagedTask::new`'s `fn(*mut T) -> jsc::JsResult<()>`.
-    fn call_erased(this: *mut CopyFileWindows<'_>) -> bun_event_loop::JsResult<()> {
-        // SAFETY: `this` is the heap-allocated `CopyFileWindows` passed to
-        // `ManagedTask::new` below; `on_mkdirp_complete` may free it via `throw`, so we
-        // do not touch `this` afterward.
-        unsafe { (*this).on_mkdirp_complete() };
-        Ok(())
-    }
-    ticket.post(jsc::ConcurrentTask::create(
-        jsc::ManagedTask::ManagedTask::new::<CopyFileWindows>(this, call_erased),
+    let this: *mut CopyFileWindows<'static> = core::ptr::from_mut(this).cast();
+    ticket.post(jsc::event_loop::ConcurrentTaskItem::from_callback(
+        move || {
+            // SAFETY: `this` is the heap-allocated `CopyFileWindows`;
+            // `on_mkdirp_complete` may free it via `throw`, so it is not touched
+            // afterward.
+            unsafe { (*this).on_mkdirp_complete() };
+            Ok(())
+        },
     ));
 }
 

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -8,6 +8,8 @@ use crate::webcore::blob::{MAX_SIZE, MkdirpTarget, SizeType, Store, store};
 use crate::webcore::node_types::PathOrFileDescriptor;
 #[cfg(windows)]
 use bun_io as aio;
+#[cfg(windows)]
+use bun_jsc::event_loop::ConcurrentTaskItem;
 use bun_jsc::{self as jsc, JSGlobalObject, JSPromise, JSValue};
 use bun_paths::PathBuffer;
 use bun_ptr::RefPtr;
@@ -1918,15 +1920,13 @@ fn on_mkdirp_complete_concurrent(ctx: *mut (), err_: bun_sys::Maybe<()>, ticket:
         bun_sys::Result::Ok(()) => None,
     };
     let this: *mut CopyFileWindows<'static> = core::ptr::from_mut(this).cast();
-    ticket.post(jsc::event_loop::ConcurrentTaskItem::from_callback(
-        move || {
-            // SAFETY: `this` is the heap-allocated `CopyFileWindows`;
-            // `on_mkdirp_complete` may free it via `throw`, so it is not touched
-            // afterward.
-            unsafe { (*this).on_mkdirp_complete() };
-            Ok(())
-        },
-    ));
+    ticket.post(ConcurrentTaskItem::from_callback(move || {
+        // SAFETY: `this` is the heap-allocated `CopyFileWindows`;
+        // `on_mkdirp_complete` may free it via `throw`, so it is not touched
+        // afterward.
+        unsafe { (*this).on_mkdirp_complete() };
+        Ok(())
+    }));
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -9,7 +9,7 @@ use bun_io as io;
 #[cfg(not(windows))]
 use bun_io::IntrusiveIoRequest as _;
 use bun_jsc::node_path::PathOrFileDescriptor;
-use bun_jsc::{self as jsc, JSGlobalObject, JSPromise, JSValue, SystemError};
+use bun_jsc::{self as jsc, GlobalRef, JSGlobalObject, JSPromise, JSValue, SystemError};
 use bun_sys::{self as sys, Fd};
 use bun_threading::{IntrusiveWorkTask as _, WorkPool, WorkPoolTask};
 
@@ -22,10 +22,6 @@ use crate::webcore::body;
 
 bun_output::declare_scope!(WriteFile, hidden);
 
-// A tagged result-or-error union. Modeled
-// as a plain Rust enum: it only ever travels through the Rust fn-pointer
-// callbacks below (`WriteFileOnWriteFileCallback`), never across FFI, so the
-// layout is unconstrained.
 /// One `write()` attempt on the pool thread.
 #[cfg(not(windows))]
 pub(crate) enum WriteStep {
@@ -41,9 +37,6 @@ pub enum WriteFileResultType {
     Err(Box<SystemError>),
 }
 
-pub type WriteFileOnWriteFileCallback =
-    fn(ctx: *mut c_void, count: WriteFileResultType) -> jsc::JsResult<()>;
-
 /// The completion token a `WriteFile` keeps across its async I/O.
 pub type WriteFileTask = bun_jsc::Completion<WriteFile>;
 
@@ -55,7 +48,7 @@ unsafe impl Send for WriteFile {}
 impl bun_jsc::JobContext for WriteFile {
     const CANCELLABLE: bool = cfg!(not(windows));
     type OffThread = Self;
-    /// The completion is delivered through `on_complete_callback(ctx, ..)`.
+    /// The completion is delivered through `on_complete`.
     type Js = ();
     fn run(this: &mut Self, done: bun_jsc::Completion<Self>) -> Option<bun_jsc::Completion<Self>> {
         // Starts the write; finishes from the io loop via the token.
@@ -103,8 +96,7 @@ pub struct WriteFile {
     pub(crate) io_parking: super::IoParking,
     pub(crate) state: AtomicU8, // ClosingState
 
-    pub(crate) on_complete_ctx: *mut c_void,
-    pub(crate) on_complete_callback: WriteFileOnWriteFileCallback,
+    pub(crate) on_complete: WriteFilePromise,
     pub(crate) total_written: usize,
 
     #[cfg(not(windows))]
@@ -276,14 +268,13 @@ impl WriteFile {
     }
 
     #[cfg(not(windows))]
-    pub(crate) fn create_with_ctx(
+    pub(crate) fn create(
         file_blob: Blob,
         bytes_blob: Blob,
-        on_write_file_context: *mut c_void,
-        on_complete_callback: WriteFileOnWriteFileCallback,
+        on_complete: WriteFilePromise,
         mkdirp_if_not_exists: bool,
-    ) -> Result<WriteFile, Error> {
-        let write_file = WriteFile {
+    ) -> WriteFile {
+        WriteFile {
             file_blob,
             bytes_blob,
             opened_fd: Fd::INVALID,
@@ -299,34 +290,12 @@ impl WriteFile {
             #[cfg(not(windows))]
             io_parking: super::IoParking::new(),
             state: AtomicU8::new(ClosingState::Running as u8),
-            on_complete_ctx: on_write_file_context,
-            on_complete_callback,
+            on_complete,
             total_written: 0,
             could_block: false,
             close_after_io: false,
             mkdirp_if_not_exists,
-        };
-        Ok(write_file)
-    }
-
-    #[cfg(not(windows))]
-    pub(crate) fn create<C>(
-        file_blob: Blob,
-        bytes_blob: Blob,
-        context: *mut C,
-        callback: WriteFileOnWriteFileCallback,
-        mkdirp_if_not_exists: bool,
-    ) -> Result<WriteFile, Error> {
-        // The caller supplies a
-        // `*mut c_void`-typed callback directly (see `WriteFilePromise::run`),
-        // so this is just a `.cast()` on `context`.
-        WriteFile::create_with_ctx(
-            file_blob,
-            bytes_blob,
-            context.cast::<c_void>(),
-            callback,
-            mkdirp_if_not_exists,
-        )
+        }
     }
 
     // reshaped for borrowck — take (off, len) here and re-derive the slice
@@ -361,22 +330,15 @@ impl WriteFile {
     }
 
     pub(crate) fn then(mut this: WriteFile, _global: &JSGlobalObject) -> jsc::JsResult<()> {
-        let cb = this.on_complete_callback;
-        let cb_ctx = this.on_complete_ctx;
+        let on_complete = core::mem::take(&mut this.on_complete);
         let system_error = this.system_error.take();
         let total_written = this.total_written;
         drop(this);
 
-        if let Some(err) = system_error {
-            cb(cb_ctx, WriteFileResultType::Err(Box::new(err)))?;
-            return Ok(());
-        }
-
-        cb(
-            cb_ctx,
-            WriteFileResultType::Result(total_written as SizeType),
-        )?;
-        Ok(())
+        on_complete.run(match system_error {
+            Some(err) => WriteFileResultType::Err(Box::new(err)),
+            None => WriteFileResultType::Result(total_written as SizeType),
+        })
     }
 
     pub(crate) fn run(&mut self, task: WriteFileTask) {
@@ -577,8 +539,7 @@ mod windows_impl {
         pub(crate) io_request: uv::fs_t,
         pub(crate) file_blob: Blob,
         pub(crate) bytes_blob: Blob,
-        pub(crate) on_complete_callback: WriteFileOnWriteFileCallback,
-        pub(crate) on_complete_ctx: *mut c_void,
+        pub(crate) on_complete: WriteFilePromise,
         pub(crate) mkdirp_if_not_exists: bool,
         pub(crate) uv_bufs: [uv::uv_buf_t; 1],
 
@@ -609,12 +570,11 @@ mod windows_impl {
     }
 
     impl WriteFileWindows {
-        pub(crate) fn create_with_ctx(
+        pub(crate) fn create(
+            event_loop: *mut EventLoop,
             file_blob: Blob,
             bytes_blob: Blob,
-            event_loop: *mut EventLoop,
-            on_write_file_context: *mut c_void,
-            on_complete_callback: WriteFileOnWriteFileCallback,
+            on_complete: WriteFilePromise,
             mkdirp_if_not_exists: bool,
         ) -> Result<*mut WriteFileWindows, WriteFileWindowsError> {
             let mkdirp = mkdirp_if_not_exists
@@ -630,8 +590,7 @@ mod windows_impl {
             let write_file = Self::new(WriteFileWindows {
                 file_blob,
                 bytes_blob,
-                on_complete_ctx: on_write_file_context,
-                on_complete_callback,
+                on_complete,
                 mkdirp_if_not_exists: mkdirp,
                 io_request: bun_core::ffi::zeroed::<uv::fs_t>(),
                 uv_bufs: [uv::uv_buf_t {
@@ -1032,25 +991,21 @@ mod windows_impl {
         /// `this` must point to a live `WriteFileWindows` allocated via [`Self::new`].
         /// On return, `*this` has been freed and must not be accessed again.
         pub(crate) unsafe fn run_from_js_thread(this: *mut Self) -> WriteFileWindowsError {
-            // SAFETY: caller contract — `this` is live; copy out everything we
+            // SAFETY: caller contract — `this` is live; move out everything we
             // need before `deinit` frees the allocation.
-            let (cb, cb_ctx) = unsafe { ((*this).on_complete_callback, (*this).on_complete_ctx) };
-
-            // SAFETY: caller contract — `this` is live.
-            if let Some(err) = unsafe { (*this).to_system_error() } {
-                // SAFETY: caller contract — `this` is live; consumed here.
-                unsafe { Self::deinit(this) };
-                if let Err(e) = cb(cb_ctx, WriteFileResultType::Err(Box::new(err))) {
-                    return e.into();
-                }
-            } else {
-                // SAFETY: caller contract — `this` is live.
-                let wrote = unsafe { (*this).total_written };
-                // SAFETY: caller contract — `this` is live; consumed here.
-                unsafe { Self::deinit(this) };
-                if let Err(e) = cb(cb_ctx, WriteFileResultType::Result(wrote as SizeType)) {
-                    return e.into();
-                }
+            let (on_complete, result) = unsafe {
+                (
+                    core::mem::take(&mut (*this).on_complete),
+                    match (*this).to_system_error() {
+                        Some(err) => WriteFileResultType::Err(Box::new(err)),
+                        None => WriteFileResultType::Result((*this).total_written as SizeType),
+                    },
+                )
+            };
+            // SAFETY: caller contract — `this` is live; consumed here.
+            unsafe { Self::deinit(this) };
+            if let Err(e) = on_complete.run(result) {
+                return e.into();
             }
 
             WriteFileWindowsError::WriteFileWindowsDeinitialized
@@ -1190,50 +1145,26 @@ mod windows_impl {
                 drop(bun_core::heap::take(this));
             }
         }
-
-        pub(crate) fn create<C>(
-            event_loop: *mut EventLoop,
-            file_blob: Blob,
-            bytes_blob: Blob,
-            context: *mut C,
-            callback: WriteFileOnWriteFileCallback,
-            mkdirp_if_not_exists: bool,
-        ) -> Result<*mut WriteFileWindows, WriteFileWindowsError> {
-            // see `WriteFile::create` — caller supplies an erased
-            // `*mut c_void` callback directly; `context` is just `.cast()`ed.
-            WriteFileWindows::create_with_ctx(
-                file_blob,
-                bytes_blob,
-                event_loop,
-                context.cast::<c_void>(),
-                callback,
-                mkdirp_if_not_exists,
-            )
-        }
     }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
 
+/// Where a finished `WriteFile` delivers its byte count or error.
+#[derive(Default)]
 pub struct WriteFilePromise {
     pub(crate) promise: jsc::JSPromiseStrong,
-    pub global_this: *const JSGlobalObject,
+    pub global_this: Option<GlobalRef>,
 }
 
 impl WriteFilePromise {
-    pub(crate) fn run(handler: *mut c_void, count: WriteFileResultType) -> jsc::JsResult<()> {
-        let handler = handler.cast::<Self>();
-        // SAFETY: handler is the Box-allocated WriteFilePromise created in
-        // Blob.rs (`heap::into_raw(Box::new(WriteFilePromise { .. }))`); consumed here.
-        // `swap()` releases the Strong's handle slot and yields a GC-owned `*mut JSPromise`,
-        // which stays valid past `drop(heap::take(handler))`.
-        let (promise, global_this): (*mut JSPromise, &JSGlobalObject) = unsafe {
-            let h = &mut *handler;
-            let promise = std::ptr::from_mut::<JSPromise>(h.promise.swap());
-            let global_this = &*h.global_this;
-            drop(bun_core::heap::take(handler));
-            (promise, global_this)
-        };
+    pub(crate) fn run(mut self, count: WriteFileResultType) -> jsc::JsResult<()> {
+        // `swap()` releases the Strong's handle slot and yields a GC-owned
+        // `*mut JSPromise`, which stays valid past dropping `self`.
+        let promise = std::ptr::from_mut::<JSPromise>(self.promise.swap());
+        let global_this = self.global_this.take().expect("set at creation");
+        let global_this: &JSGlobalObject = &global_this;
+        drop(self);
         // SAFETY: GC-owned cell (kept alive below); scoped shared access.
         let value = unsafe { (*promise).to_js() };
         value.ensure_still_alive();

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -40,9 +40,9 @@ pub enum WriteFileResultType {
 /// The completion token a `WriteFile` keeps across its async I/O.
 pub type WriteFileTask = bun_jsc::Completion<WriteFile>;
 
-// SAFETY: the two blobs are native values holding store refs (atomic counts);
-// io-loop registration state and an opaque completion ctx that only the
-// JS-thread completion dereferences — nothing used off-thread is thread-affine.
+// SAFETY: the two blobs are native values holding store refs (atomic counts)
+// and io-loop registration state; `on_complete` (a JS promise handle) is only
+// touched on the JS thread, where every `WriteFile` completes or is released.
 unsafe impl Send for WriteFile {}
 
 impl bun_jsc::JobContext for WriteFile {

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -530,8 +530,6 @@ mod windows_impl {
     use core::ptr::null_mut;
 
     use bun_io::{self as aio, IntrusiveUvFs as _, KeepAlive};
-    // `bun_jsc::EventLoop`/`ManagedTask` are *modules* (namespace
-    // re-exports); the structs live one level deeper.
     use bun_jsc::event_loop::{ConcurrentTaskItem, EventLoop};
     use bun_sys::ReturnCodeExt as _;
     use bun_sys::windows::libuv as uv;
@@ -922,7 +920,7 @@ mod windows_impl {
                 bun_sys::Result::Err(e) => Some(e),
                 bun_sys::Result::Ok(()) => None,
             };
-            let this: *mut WriteFileWindows = this;
+            let this = core::ptr::from_mut(this);
             ticket.post(ConcurrentTaskItem::from_callback(move || {
                 // SAFETY: `this` is the live Box-allocated `WriteFileWindows`; the
                 // JS thread is the sole accessor at this point. `*this` may be
@@ -1152,42 +1150,23 @@ mod windows_impl {
 // ──────────────────────────────────────────────────────────────────────────
 
 /// Where a finished `WriteFile` delivers its byte count or error.
-pub struct WriteFilePromise {
+pub(crate) struct WriteFilePromise {
     pub(crate) promise: jsc::JSPromiseStrong,
     pub(crate) global_this: GlobalRef,
 }
 
 impl WriteFilePromise {
-    pub(crate) fn run(self, count: WriteFileResultType) -> jsc::JsResult<()> {
-        let Self {
-            mut promise,
-            global_this,
-        } = self;
-        let global_this: &JSGlobalObject = &global_this;
-        // `swap()` releases the Strong's handle slot and yields a GC-owned
-        // `*mut JSPromise`.
-        let promise = std::ptr::from_mut::<JSPromise>(promise.swap());
-        // SAFETY: GC-owned cell (kept alive below); scoped shared access.
-        let value = unsafe { (*promise).to_js() };
-        value.ensure_still_alive();
+    pub(crate) fn run(mut self, count: WriteFileResultType) -> jsc::JsResult<()> {
+        let global: &JSGlobalObject = &self.global_this;
         match count {
             WriteFileResultType::Err(err) => {
-                // SAFETY: GC-owned cell; the error build's shared borrow ends before the
-                // scoped exclusive `reject` borrow.
-                unsafe {
-                    let err_js = err.to_error_instance_with_async_stack(global_this, &*promise);
-                    (*promise).reject(global_this, Ok(err_js))?;
-                }
+                let err = err.to_error_instance_with_async_stack(global, self.promise.get());
+                self.promise.reject(global, Ok(err))
             }
-            WriteFileResultType::Result(wrote) => {
-                // SAFETY: GC-owned cell; exclusive borrow scoped to the call.
-                unsafe {
-                    (*promise)
-                        .resolve(global_this, JSValue::js_number_from_uint64(wrote as u64))?;
-                }
-            }
+            WriteFileResultType::Result(wrote) => self
+                .promise
+                .resolve(global, JSValue::js_number_from_uint64(wrote as u64)),
         }
-        Ok(())
     }
 }
 

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -96,7 +96,8 @@ pub struct WriteFile {
     pub(crate) io_parking: super::IoParking,
     pub(crate) state: AtomicU8, // ClosingState
 
-    pub(crate) on_complete: WriteFilePromise,
+    /// `None` once delivered.
+    pub(crate) on_complete: Option<WriteFilePromise>,
     pub(crate) total_written: usize,
 
     #[cfg(not(windows))]
@@ -290,7 +291,7 @@ impl WriteFile {
             #[cfg(not(windows))]
             io_parking: super::IoParking::new(),
             state: AtomicU8::new(ClosingState::Running as u8),
-            on_complete,
+            on_complete: Some(on_complete),
             total_written: 0,
             could_block: false,
             close_after_io: false,
@@ -330,7 +331,7 @@ impl WriteFile {
     }
 
     pub(crate) fn then(mut this: WriteFile, _global: &JSGlobalObject) -> jsc::JsResult<()> {
-        let on_complete = core::mem::take(&mut this.on_complete);
+        let on_complete = this.on_complete.take().expect("delivered once");
         let system_error = this.system_error.take();
         let total_written = this.total_written;
         drop(this);
@@ -531,7 +532,7 @@ mod windows_impl {
     use bun_io::{self as aio, IntrusiveUvFs as _, KeepAlive};
     // `bun_jsc::EventLoop`/`ManagedTask` are *modules* (namespace
     // re-exports); the structs live one level deeper.
-    use bun_jsc::{ConcurrentTask, event_loop::EventLoop};
+    use bun_jsc::event_loop::{ConcurrentTaskItem, EventLoop};
     use bun_sys::ReturnCodeExt as _;
     use bun_sys::windows::libuv as uv;
 
@@ -539,7 +540,7 @@ mod windows_impl {
         pub(crate) io_request: uv::fs_t,
         pub(crate) file_blob: Blob,
         pub(crate) bytes_blob: Blob,
-        pub(crate) on_complete: WriteFilePromise,
+        pub(crate) on_complete: Option<WriteFilePromise>,
         pub(crate) mkdirp_if_not_exists: bool,
         pub(crate) uv_bufs: [uv::uv_buf_t; 1],
 
@@ -590,7 +591,7 @@ mod windows_impl {
             let write_file = Self::new(WriteFileWindows {
                 file_blob,
                 bytes_blob,
-                on_complete,
+                on_complete: Some(on_complete),
                 mkdirp_if_not_exists: mkdirp,
                 io_request: bun_core::ffi::zeroed::<uv::fs_t>(),
                 uv_bufs: [uv::uv_buf_t {
@@ -766,7 +767,7 @@ mod windows_impl {
             let this: *mut WriteFileWindows = unsafe { WriteFileWindows::from_uv_fs(req) };
             debug_assert!(core::ptr::eq(
                 this,
-                // SAFETY: req == &(*this).io_request; data was set to `this` in create_with_ctx/open.
+                // SAFETY: req == &(*this).io_request; data was set to `this` in create/open.
                 unsafe { (*req).data }.cast::<WriteFileWindows>()
             ));
             // SAFETY: `this` is live (libuv invokes us with the req we registered).
@@ -922,7 +923,7 @@ mod windows_impl {
                 bun_sys::Result::Ok(()) => None,
             };
             let this: *mut WriteFileWindows = this;
-            ticket.post(ConcurrentTask::ConcurrentTask::from_callback(move || {
+            ticket.post(ConcurrentTaskItem::from_callback(move || {
                 // SAFETY: `this` is the live Box-allocated `WriteFileWindows`; the
                 // JS thread is the sole accessor at this point. `*this` may be
                 // freed inside; not accessed afterward.
@@ -995,7 +996,7 @@ mod windows_impl {
             // need before `deinit` frees the allocation.
             let (on_complete, result) = unsafe {
                 (
-                    core::mem::take(&mut (*this).on_complete),
+                    (*this).on_complete.take().expect("delivered once"),
                     match (*this).to_system_error() {
                         Some(err) => WriteFileResultType::Err(Box::new(err)),
                         None => WriteFileResultType::Result((*this).total_written as SizeType),
@@ -1151,20 +1152,21 @@ mod windows_impl {
 // ──────────────────────────────────────────────────────────────────────────
 
 /// Where a finished `WriteFile` delivers its byte count or error.
-#[derive(Default)]
 pub struct WriteFilePromise {
     pub(crate) promise: jsc::JSPromiseStrong,
-    pub global_this: Option<GlobalRef>,
+    pub(crate) global_this: GlobalRef,
 }
 
 impl WriteFilePromise {
-    pub(crate) fn run(mut self, count: WriteFileResultType) -> jsc::JsResult<()> {
-        // `swap()` releases the Strong's handle slot and yields a GC-owned
-        // `*mut JSPromise`, which stays valid past dropping `self`.
-        let promise = std::ptr::from_mut::<JSPromise>(self.promise.swap());
-        let global_this = self.global_this.take().expect("set at creation");
+    pub(crate) fn run(self, count: WriteFileResultType) -> jsc::JsResult<()> {
+        let Self {
+            mut promise,
+            global_this,
+        } = self;
         let global_this: &JSGlobalObject = &global_this;
-        drop(self);
+        // `swap()` releases the Strong's handle slot and yields a GC-owned
+        // `*mut JSPromise`.
+        let promise = std::ptr::from_mut::<JSPromise>(promise.swap());
         // SAFETY: GC-owned cell (kept alive below); scoped shared access.
         let value = unsafe { (*promise).to_js() };
         value.ensure_still_alive();

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -569,7 +569,7 @@ mod windows_impl {
     use bun_io::{self as aio, IntrusiveUvFs as _, KeepAlive};
     // `bun_jsc::EventLoop`/`ManagedTask` are *modules* (namespace
     // re-exports); the structs live one level deeper.
-    use bun_jsc::{ConcurrentTask, ManagedTask::ManagedTask, event_loop::EventLoop};
+    use bun_jsc::{ConcurrentTask, event_loop::EventLoop};
     use bun_sys::ReturnCodeExt as _;
     use bun_sys::windows::libuv as uv;
 
@@ -948,18 +948,6 @@ mod windows_impl {
             }
         }
 
-        /// `ManagedTask`-shaped trampoline for [`on_mkdirp_complete`]: takes
-        /// `*mut Self` and returns the event-loop `jsc::JsResult<()>` (always `Ok`: the inner body
-        /// reports a delivery exception itself).
-        fn on_mkdirp_complete_task(this: *mut WriteFileWindows) -> bun_event_loop::JsResult<()> {
-            // SAFETY: `this` is the live Box-allocated `WriteFileWindows` whose
-            // pointer was stashed in `on_mkdirp_complete_concurrent` below;
-            // the JS thread is the sole accessor at this point. `*this` may be
-            // freed inside; not accessed afterward.
-            unsafe { Self::on_mkdirp_complete(this) };
-            Ok(())
-        }
-
         fn on_mkdirp_complete_concurrent(
             ctx: *mut (),
             err_: bun_sys::Result<()>,
@@ -974,9 +962,14 @@ mod windows_impl {
                 bun_sys::Result::Err(e) => Some(e),
                 bun_sys::Result::Ok(()) => None,
             };
-            ticket.post(ConcurrentTask::create(
-                ManagedTask::new::<WriteFileWindows>(this, Self::on_mkdirp_complete_task),
-            ));
+            let this: *mut WriteFileWindows = this;
+            ticket.post(ConcurrentTask::ConcurrentTask::from_callback(move || {
+                // SAFETY: `this` is the live Box-allocated `WriteFileWindows`; the
+                // JS thread is the sole accessor at this point. `*this` may be
+                // freed inside; not accessed afterward.
+                unsafe { Self::on_mkdirp_complete(this) };
+                Ok(())
+            }));
         }
 
         extern "C" fn on_write_complete(req: *mut uv::fs_t) {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -46,7 +46,7 @@ use bun_core::{String as BunString, Tag as BunStringTag, Utf8Bytes};
 use bun_http::{self as http, FetchRedirect, Headers, HeadersExt as _, MimeType};
 use bun_http_jsc::method_jsc;
 use bun_http_types::Method::Method;
-use bun_jsc::{HTTPHeaderName, StringJsc as _, SysErrorJsc as _, URLJsc as _};
+use bun_jsc::{GlobalRef, HTTPHeaderName, StringJsc as _, SysErrorJsc as _, URLJsc as _};
 use bun_paths::{self, PathBuffer};
 use bun_sys::FdExt as _;
 // `FromJsEnum for FetchRedirect` lives in bun_http_jsc; importing the impl crate
@@ -1765,16 +1765,8 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 url: url_static,
                 _url_proxy_buffer: owned_buffer,
                 promise,
-                global: global_this,
+                global: GlobalRef::from(global_this),
             });
-            // Shim: erases both the payload type and the `Result` return when
-            // coercing to the `fn (S3UploadResult, *mut c_void)` callback shape.
-            fn s3_stream_wrapper_resolve(result: s3::S3UploadResult<'_>, ctx: *mut libc::c_void) {
-                // SAFETY: ctx was produced by `heap::alloc(s3_stream)` below; the
-                // 'static lifetime is a raw-pointer fiction (the pointee's real
-                // lifetime is managed by the resolve callback itself).
-                let _ = S3StreamWrapper::resolve(result, ctx.cast::<S3StreamWrapper<'static>>());
-            }
             // `dupe()` heap-allocates a fresh intrusive-refcounted copy.
             // `upload_stream` adopts the ref by value (no extra bump) and the
             // MultiPartUpload derefs on completion.
@@ -1791,8 +1783,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 headers.as_ref().and_then(|h| h.get_content_encoding()),
                 proxy_url,
                 credentials_with_options.request_payer,
-                Some(s3_stream_wrapper_resolve),
-                bun_core::heap::into_raw(s3_stream).cast::<libc::c_void>(),
+                Some(Box::new(move |result| {
+                    let _ = s3_stream.resolve(result);
+                })),
             )?;
             // url/url_proxy_buffer ownership moved into s3_stream above.
             return Ok(promise_value);
@@ -1949,21 +1942,18 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 // `impl` blocks inside fn bodies for types referenced by external fn pointers.
 // ──────────────────────────────────────────────────────────────────────────
 
-struct S3StreamWrapper<'a> {
+struct S3StreamWrapper {
     promise: jsc::JSPromiseStrong,
-    url: ZigURL<'a>,
+    /// Borrows `_url_proxy_buffer`.
+    url: ZigURL<'static>,
     _url_proxy_buffer: Box<[u8]>,
-    global: &'a JSGlobalObject,
+    global: GlobalRef,
 }
 
-impl<'a> S3StreamWrapper<'a> {
-    fn resolve(result: s3::S3UploadResult, self_: *mut Self) -> JsResult<()> {
-        // SAFETY: self_ was created via heap::alloc in fetch_impl; we reclaim
-        // ownership here exactly once on the resolve callback.
-        let mut self_ = unsafe { bun_core::heap::take(self_) };
-        let global = self_.global;
-        // `defer bun.destroy(self)` + `defer free(url_proxy_buffer)` →
-        // Box<Self> and Box<[u8]> Drop at end of scope.
+impl S3StreamWrapper {
+    fn resolve(self: Box<Self>, result: s3::S3UploadResult) -> JsResult<()> {
+        let mut self_ = self;
+        let global: &JSGlobalObject = &self_.global;
         match result {
             s3::S3UploadResult::Success => {
                 let response = Box::new(Response::init(

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1761,12 +1761,12 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 None
             };
 
-            let s3_stream = Box::new(S3StreamWrapper {
+            let s3_stream = S3StreamWrapper {
                 url: url_static,
                 _url_proxy_buffer: owned_buffer,
                 promise,
                 global: GlobalRef::from(global_this),
-            });
+            };
             // `dupe()` heap-allocates a fresh intrusive-refcounted copy.
             // `upload_stream` adopts the ref by value (no extra bump) and the
             // MultiPartUpload derefs on completion.
@@ -1783,9 +1783,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 headers.as_ref().and_then(|h| h.get_content_encoding()),
                 proxy_url,
                 credentials_with_options.request_payer,
-                Some(Box::new(move |result| {
-                    let _ = s3_stream.resolve(result);
-                })),
+                Some(Box::new(move |result| s3_stream.resolve(result))),
             )?;
             // url/url_proxy_buffer ownership moved into s3_stream above.
             return Ok(promise_value);
@@ -1938,8 +1936,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// S3 ReadableStream upload Wrapper — module level because Rust does not allow
-// `impl` blocks inside fn bodies for types referenced by external fn pointers.
+// S3 ReadableStream upload wrapper
 // ──────────────────────────────────────────────────────────────────────────
 
 struct S3StreamWrapper {
@@ -1951,9 +1948,8 @@ struct S3StreamWrapper {
 }
 
 impl S3StreamWrapper {
-    fn resolve(self: Box<Self>, result: s3::S3UploadResult) -> JsResult<()> {
-        let mut self_ = self;
-        let global: &JSGlobalObject = &self_.global;
+    fn resolve(mut self, result: s3::S3UploadResult) -> JsResult<()> {
+        let global: &JSGlobalObject = &self.global;
         match result {
             s3::S3UploadResult::Success => {
                 let response = Box::new(Response::init(
@@ -1963,7 +1959,7 @@ impl S3StreamWrapper {
                         ..Default::default()
                     },
                     Body::new(BodyValue::Empty),
-                    BunString::create_atom_if_possible(self_.url.href),
+                    BunString::create_atom_if_possible(self.url.href),
                     false,
                 ));
                 // SAFETY: `into_raw` yields a freshly allocated heap `Response`;
@@ -1971,7 +1967,7 @@ impl S3StreamWrapper {
                 let response_js =
                     Response::make_maybe_pooled(global, bun_core::heap::into_raw(response));
                 response_js.ensure_still_alive();
-                self_.promise.resolve(global, response_js)?;
+                self.promise.resolve(global, response_js)?;
             }
             s3::S3UploadResult::Failure(err) => {
                 let response = Box::new(Response::init(
@@ -1985,7 +1981,7 @@ impl S3StreamWrapper {
                         bytes: err.message.to_vec(),
                         was_string: true,
                     })),
-                    BunString::create_atom_if_possible(self_.url.href),
+                    BunString::create_atom_if_possible(self.url.href),
                     false,
                 ));
 
@@ -1994,7 +1990,7 @@ impl S3StreamWrapper {
                 let response_js =
                     Response::make_maybe_pooled(global, bun_core::heap::into_raw(response));
                 response_js.ensure_still_alive();
-                self_.promise.resolve(global, response_js)?;
+                self.promise.resolve(global, response_js)?;
             }
         }
         Ok(())

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2134,8 +2134,7 @@ impl FetchTasklet {
         let this_ref = Self::from_raw_ref(this);
         // ref until the main thread callback is called
         this_ref.ref_();
-        // `from_callback` heap-allocates a fresh `ConcurrentTaskItem`.
-        let task = ConcurrentTask::from_callback(this, FetchTasklet::resume_request_data_stream);
+        let task = ConcurrentTask::from_callback(move || Self::resume_request_data_stream(this));
         this_ref
             .http_ticket
             .as_ref()

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -34,10 +34,6 @@ use crate::webcore::sink::JSSink;
 use crate::webcore::streams::{SourceHandle, StreamError, StreamResult, Writable};
 use crate::webcore::{AbortSignal, DrainResult, FetchHeaders, InternalBlob, Response, SinkHandle};
 
-// `bun_event_loop::JsResult` (cycle-broken erased error) — used by
-// ConcurrentTask callbacks at the tier-3 layer.
-type ElJsResult<T> = bun_event_loop::JsResult<T>;
-
 use http::signals::BODY_HIGH_WATER_MARK;
 
 use boringssl::c::{X509_free, d2i_X509};
@@ -2131,11 +2127,14 @@ impl FetchTasklet {
 
     /// This is ALWAYS called from the http thread and we cannot touch the buffer here because is locked
     fn on_write_request_data_drain(this: *mut FetchTasklet) {
-        let this_ref = Self::from_raw_ref(this);
-        // ref until the main thread callback is called
-        this_ref.ref_();
-        let task = ConcurrentTask::from_callback(move || Self::resume_request_data_stream(this));
-        this_ref
+        // Held by the JS-thread callback until it has run (or is dropped unrun).
+        // SAFETY: `this` is the live heap tasklet (fn contract).
+        let guard = unsafe { bun_ptr::RefPtr::init_ref(this) };
+        let task = ConcurrentTask::from_callback(move || {
+            Self::resume_request_data_stream(guard.as_ptr());
+            Ok(())
+        });
+        Self::from_raw_ref(this)
             .http_ticket
             .as_ref()
             .expect(Self::HOLDS_TICKET)
@@ -2143,8 +2142,7 @@ impl FetchTasklet {
     }
 
     /// This is ALWAYS called from the main thread
-    // ConcurrentTask::from_callback expects `fn(*mut T) -> bun_event_loop::JsResult<()>`.
-    fn resume_request_data_stream(this: *mut FetchTasklet) -> ElJsResult<()> {
+    fn resume_request_data_stream(this: *mut FetchTasklet) {
         let this_ref = Self::from_raw_mut(this);
         bun_output::scoped_log!(FetchTasklet, "resumeRequestDataStream");
         if !this_ref.signal_aborted() {
@@ -2153,10 +2151,6 @@ impl FetchTasklet {
                 sink.on_drain(&global_this);
             }
         }
-        // deref when done because we ref inside onWriteRequestDataDrain
-        // SAFETY: `this` is the live heap tasklet; we hold a ref.
-        FetchTasklet::deref(this);
-        Ok(())
     }
 
     /// Whether the request body should skip chunked transfer encoding framing.

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -555,7 +555,7 @@ pub struct S3UploadStreamWrapper {
     pub sink: Option<NonNull<NetworkSink>>,
     pub task: *mut MultiPartUpload,
     pub(crate) end_promise: bun_jsc::JSPromiseStrong,
-    pub callback: Option<Box<dyn FnOnce(S3UploadResult<'_>)>>,
+    pub callback: Option<Box<dyn FnOnce(S3UploadResult<'_>) -> JsResult<()>>>,
     /// this is owned by the task not by the wrapper
     pub path: bun_ptr::RawSlice<u8>,
     /// Pins the source ReadableStream when the native ByteStream fast-path is
@@ -742,7 +742,11 @@ impl S3UploadStreamWrapper {
         }
 
         if let Some(callback) = self_.callback.take() {
-            callback(result);
+            if settled.is_ok() {
+                settled = callback(result);
+            } else {
+                let _ = callback(result);
+            }
         }
         settled
     }
@@ -829,7 +833,7 @@ pub(crate) fn upload_stream(
     content_encoding: Option<&[u8]>,
     proxy: Option<&[u8]>,
     request_payer: bool,
-    callback: Option<Box<dyn FnOnce(S3UploadResult<'_>)>>,
+    callback: Option<Box<dyn FnOnce(S3UploadResult<'_>) -> JsResult<()>>>,
 ) -> JsResult<JSValue> {
     let proxy_url = proxy.unwrap_or(b"");
     if readable_stream.is_disturbed(global_this) {

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -249,6 +249,7 @@ pub(crate) fn list_objects<F: FnOnce(S3ListObjectsResult<'_>) -> JsResult<()> + 
         this,
         s3_simple_request::Options {
             path: b"",
+            allow_empty_path: true,
             method: bun_http::Method::GET,
             search_params: Some(search_params.slice()),
             proxy_url,

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -742,11 +742,8 @@ impl S3UploadStreamWrapper {
         }
 
         if let Some(callback) = self_.callback.take() {
-            if settled.is_ok() {
-                settled = callback(result);
-            } else {
-                let _ = callback(result);
-            }
+            let delivered = callback(result);
+            settled = settled.and(delivered);
         }
         settled
     }

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -36,7 +36,6 @@ pub(crate) use crate::webcore::s3::list_objects::S3ListObjectsOptions;
 pub(crate) use crate::webcore::s3::list_objects::get_list_objects_options_from_js;
 pub(crate) use crate::webcore::s3::simple_request::S3DeleteResult;
 pub(crate) use crate::webcore::s3::simple_request::S3DownloadResult;
-pub(crate) use crate::webcore::s3::simple_request::S3HttpSimpleTask;
 pub(crate) use crate::webcore::s3::simple_request::S3ListObjectsResult;
 pub(crate) use crate::webcore::s3::simple_request::S3StatResult;
 pub use crate::webcore::s3::simple_request::S3UploadResult;
@@ -58,10 +57,10 @@ use bun_jsc::CallFrame;
 
 bun_core::declare_scope!(S3UploadStream, visible);
 
-pub(crate) fn stat(
+pub(crate) fn stat<F: FnOnce(S3StatResult<'_>) -> JsResult<()> + 'static>(
     this: &S3Credentials,
     path: &[u8],
-    callback: impl FnOnce(S3StatResult<'_>) -> JsResult<()> + 'static,
+    callback: F,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -75,14 +74,15 @@ pub(crate) fn stat(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Stat(Box::new(callback)),
+        s3_simple_request::Completion::stat(callback),
     )
+    .or_else(|(callback, err)| callback(S3StatResult::Failure(err)))
 }
 
-pub(crate) fn download(
+pub(crate) fn download<F: FnOnce(S3DownloadResult<'_>) -> JsResult<()> + 'static>(
     this: &S3Credentials,
     path: &[u8],
-    callback: impl FnOnce(S3DownloadResult<'_>) -> JsResult<()> + 'static,
+    callback: F,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -96,16 +96,17 @@ pub(crate) fn download(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Download(Box::new(callback)),
+        s3_simple_request::Completion::download(callback),
     )
+    .or_else(|(callback, err)| callback(S3DownloadResult::Failure(err)))
 }
 
-pub(crate) fn download_slice(
+pub(crate) fn download_slice<F: FnOnce(S3DownloadResult<'_>) -> JsResult<()> + 'static>(
     this: &S3Credentials,
     path: &[u8],
     offset: usize,
     size: Option<usize>,
-    callback: impl FnOnce(S3DownloadResult<'_>) -> JsResult<()> + 'static,
+    callback: F,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -138,14 +139,15 @@ pub(crate) fn download_slice(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Download(Box::new(callback)),
+        s3_simple_request::Completion::download(callback),
     )
+    .or_else(|(callback, err)| callback(S3DownloadResult::Failure(err)))
 }
 
-pub(crate) fn delete(
+pub(crate) fn delete<F: FnOnce(S3DeleteResult<'_>) -> JsResult<()> + 'static>(
     this: &S3Credentials,
     path: &[u8],
-    callback: impl FnOnce(S3DeleteResult<'_>) -> JsResult<()> + 'static,
+    callback: F,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -159,14 +161,15 @@ pub(crate) fn delete(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Delete(Box::new(callback)),
+        s3_simple_request::Completion::delete(callback),
     )
+    .or_else(|(callback, err)| callback(S3DeleteResult::Failure(err)))
 }
 
-pub(crate) fn list_objects(
+pub(crate) fn list_objects<F: FnOnce(S3ListObjectsResult<'_>) -> JsResult<()> + 'static>(
     this: &S3Credentials,
     list_options: &S3ListObjectsOptions,
-    callback: impl FnOnce(S3ListObjectsResult<'_>) -> JsResult<()> + 'static,
+    callback: F,
     proxy_url: Option<&[u8]>,
 ) -> JsResult<()> {
     let mut search_params: Vec<u8> = Vec::<u8>::default();
@@ -242,124 +245,21 @@ pub(crate) fn list_objects(
         let _ = search_params.append_fmt(format_args!("&start-after={}", bstr::BStr::new(encoded))); // OOM/capacity: fire-and-forget
     }
 
-    let result = match this.sign_request::<true>(
-        &bun_s3_signing::SignOptions {
+    s3_simple_request::execute_simple_s3_request(
+        this,
+        s3_simple_request::Options {
             path: b"",
             method: bun_http::Method::GET,
             search_params: Some(search_params.slice()),
-            content_hash: None,
-            content_md5: None,
-            content_disposition: None,
-            content_type: None,
-            content_encoding: None,
-            acl: None,
-            storage_class: None,
-            request_payer: false,
-        },
-        None,
-    ) {
-        Ok(r) => r,
-        Err(sign_err) => {
-            drop(search_params);
-
-            let error_code_and_message = Error::get_sign_error_code_and_message(sign_err.into());
-            return callback(S3ListObjectsResult::Failure(Error::S3Error {
-                code: error_code_and_message.code,
-                message: error_code_and_message.message,
-            }));
-        }
-    };
-
-    drop(search_params);
-
-    let headers = bun_http::Headers::from_pico_http_headers(result.headers());
-
-    let task_ptr = bun_core::heap::into_raw(Box::new(S3HttpSimpleTask {
-        // Written below via `MaybeUninit::write` before any read.
-        http: core::mem::MaybeUninit::uninit(),
-        sign_result: result,
-        callback: Some(s3_simple_request::Callback::ListObjects(Box::new(callback))),
-        headers,
-        http_ticket: None,
-        response_buffer: MutableString::default(),
-        result: bun_http::HTTPClientResult::default(),
-        concurrent_task: Default::default(),
-        proxy_url: Box::default(),
-        body: Box::default(),
-        poll_ref: bun_io::KeepAlive::init(),
-        signal_store: Default::default(),
-    }));
-    // SAFETY: just allocated, non-null
-    let task = unsafe { &mut *task_ptr };
-
-    task.poll_ref.ref_(bun_io::js_vm_ctx());
-
-    let proxy = proxy_url.unwrap_or(b"");
-    task.proxy_url = if !proxy.is_empty() {
-        Box::<[u8]>::from(proxy)
-    } else {
-        Box::<[u8]>::default()
-    };
-
-    // SAFETY: lifetime extension — `url`, `headers_buf`, and `proxy_url` borrow from
-    // heap-allocated fields of `*task` which the task outlives. AsyncHTTP::init wants
-    // `'static` borrows because the HTTP thread reads them concurrently; they remain valid
-    // until `task` is dropped in `on_response`.
-    let url = bun_url::URL::parse(unsafe { bun_ptr::detach_lifetime_ref(&*task.sign_result.url) });
-    // SAFETY: same lifetime-extension invariant as `url` above — `task.headers.buf` is
-    // heap-owned by `*task` and outlives the AsyncHTTP request.
-    let headers_buf: &'static [u8] =
-        unsafe { bun_ptr::detach_lifetime(task.headers.buf.as_slice()) };
-    let http_proxy = if !task.proxy_url.is_empty() {
-        // SAFETY: same lifetime-extension invariant as `url` above — `task.proxy_url` is
-        // heap-owned by `*task` and outlives the AsyncHTTP request.
-        Some(bun_url::URL::parse(unsafe {
-            bun_ptr::detach_lifetime_ref(&*task.proxy_url)
-        }))
-    } else {
-        None
-    };
-    // JS thread (request setup): read options from the current VM.
-    let vm = VirtualMachine::get();
-
-    task.http.write(bun_http::AsyncHTTP::init(
-        bun_http::Method::GET,
-        url,
-        task.headers.entries.clone().expect("OOM"),
-        headers_buf,
-        b"",
-        bun_http::HTTPClientResultCallback::new_with_release::<S3HttpSimpleTask>(
-            task_ptr,
-            // SAFETY: `task_ptr` is the heap-allocated task registered above; the
-            // HTTP thread invokes this with that exact pointer.
-            S3HttpSimpleTask::http_callback,
-            S3HttpSimpleTask::release_at_shutdown,
-        ),
-        bun_http::FetchRedirect::Follow,
-        bun_http::async_http::Options {
-            http_proxy,
-            verbose: Some(vm.get_verbose_fetch()),
-            reject_unauthorized: Some(vm.get_tls_reject_unauthorized()),
-            signals: Some(task.signal_store.to()),
+            proxy_url,
             ..Default::default()
         },
-    ));
-
-    // queue http request
-    bun_http::http_thread::init(&Default::default());
-    let mut batch = bun_threading::thread_pool::Batch::default();
-    // SAFETY: `http` was initialised by `task.http.write(...)` immediately above.
-    unsafe { task.http.assume_init_mut() }.schedule(&mut batch);
-    // Out on the HTTP thread until its final callback: the VM aborts it at
-    // teardown (registry) and waits for it (the ticket).
-    task.http_ticket = Some(VirtualMachine::get().ticket());
-    crate::jsc_hooks::ActiveHandle::S3Request(core::ptr::NonNull::new(task_ptr).expect("task"))
-        .register();
-    bun_http::HTTPThread::schedule(batch);
-    Ok(())
+        s3_simple_request::Completion::list_objects(callback),
+    )
+    .or_else(|(callback, err)| callback(S3ListObjectsResult::Failure(err)))
 }
 
-pub(crate) fn upload(
+pub(crate) fn upload<F: FnOnce(S3UploadResult<'_>) -> JsResult<()> + 'static>(
     this: &S3Credentials,
     path: &[u8],
     content: &[u8],
@@ -370,7 +270,7 @@ pub(crate) fn upload(
     proxy_url: Option<&[u8]>,
     storage_class: Option<StorageClass>,
     request_payer: bool,
-    callback: impl FnOnce(S3UploadResult<'_>) -> JsResult<()> + 'static,
+    callback: F,
 ) -> JsResult<()> {
     s3_simple_request::execute_simple_s3_request(
         this,
@@ -387,8 +287,9 @@ pub(crate) fn upload(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Upload(Box::new(callback)),
+        s3_simple_request::Completion::upload(callback),
     )
+    .or_else(|(callback, err)| callback(S3UploadResult::Failure(err)))
 }
 
 /// returns a writable stream that writes to the s3 path

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -61,8 +61,7 @@ bun_core::declare_scope!(S3UploadStream, visible);
 pub(crate) fn stat(
     this: &S3Credentials,
     path: &[u8],
-    callback: fn(S3StatResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: impl FnOnce(S3StatResult<'_>) -> JsResult<()> + 'static,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -76,16 +75,14 @@ pub(crate) fn stat(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Stat(callback),
-        callback_context,
+        s3_simple_request::Callback::Stat(Box::new(callback)),
     )
 }
 
 pub(crate) fn download(
     this: &S3Credentials,
     path: &[u8],
-    callback: fn(S3DownloadResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: impl FnOnce(S3DownloadResult<'_>) -> JsResult<()> + 'static,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -99,8 +96,7 @@ pub(crate) fn download(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Download(callback),
-        callback_context,
+        s3_simple_request::Callback::Download(Box::new(callback)),
     )
 }
 
@@ -109,8 +105,7 @@ pub(crate) fn download_slice(
     path: &[u8],
     offset: usize,
     size: Option<usize>,
-    callback: fn(S3DownloadResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: impl FnOnce(S3DownloadResult<'_>) -> JsResult<()> + 'static,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -143,16 +138,14 @@ pub(crate) fn download_slice(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Download(callback),
-        callback_context,
+        s3_simple_request::Callback::Download(Box::new(callback)),
     )
 }
 
 pub(crate) fn delete(
     this: &S3Credentials,
     path: &[u8],
-    callback: fn(S3DeleteResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: impl FnOnce(S3DeleteResult<'_>) -> JsResult<()> + 'static,
     proxy_url: Option<&[u8]>,
     request_payer: bool,
 ) -> JsResult<()> {
@@ -166,16 +159,14 @@ pub(crate) fn delete(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Delete(callback),
-        callback_context,
+        s3_simple_request::Callback::Delete(Box::new(callback)),
     )
 }
 
 pub(crate) fn list_objects(
     this: &S3Credentials,
     list_options: &S3ListObjectsOptions,
-    callback: fn(S3ListObjectsResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: impl FnOnce(S3ListObjectsResult<'_>) -> JsResult<()> + 'static,
     proxy_url: Option<&[u8]>,
 ) -> JsResult<()> {
     let mut search_params: Vec<u8> = Vec::<u8>::default();
@@ -272,15 +263,10 @@ pub(crate) fn list_objects(
             drop(search_params);
 
             let error_code_and_message = Error::get_sign_error_code_and_message(sign_err.into());
-            callback(
-                S3ListObjectsResult::Failure(Error::S3Error {
-                    code: error_code_and_message.code,
-                    message: error_code_and_message.message,
-                }),
-                callback_context,
-            )?;
-
-            return Ok(());
+            return callback(S3ListObjectsResult::Failure(Error::S3Error {
+                code: error_code_and_message.code,
+                message: error_code_and_message.message,
+            }));
         }
     };
 
@@ -292,8 +278,7 @@ pub(crate) fn list_objects(
         // Written below via `MaybeUninit::write` before any read.
         http: core::mem::MaybeUninit::uninit(),
         sign_result: result,
-        callback_context,
-        callback: s3_simple_request::Callback::ListObjects(callback),
+        callback: Some(s3_simple_request::Callback::ListObjects(Box::new(callback))),
         headers,
         http_ticket: None,
         response_buffer: MutableString::default(),
@@ -385,8 +370,7 @@ pub(crate) fn upload(
     proxy_url: Option<&[u8]>,
     storage_class: Option<StorageClass>,
     request_payer: bool,
-    callback: fn(S3UploadResult, *mut c_void) -> JsResult<()>,
-    callback_context: *mut c_void,
+    callback: impl FnOnce(S3UploadResult<'_>) -> JsResult<()> + 'static,
 ) -> JsResult<()> {
     s3_simple_request::execute_simple_s3_request(
         this,
@@ -403,8 +387,7 @@ pub(crate) fn upload(
             request_payer,
             ..Default::default()
         },
-        s3_simple_request::Callback::Upload(callback),
-        callback_context,
+        s3_simple_request::Callback::Upload(Box::new(callback)),
     )
 }
 
@@ -572,8 +555,7 @@ pub struct S3UploadStreamWrapper {
     pub sink: Option<NonNull<NetworkSink>>,
     pub task: *mut MultiPartUpload,
     pub(crate) end_promise: bun_jsc::JSPromiseStrong,
-    pub callback: Option<fn(S3UploadResult, *mut c_void)>,
-    pub(crate) callback_context: *mut c_void,
+    pub callback: Option<Box<dyn FnOnce(S3UploadResult<'_>)>>,
     /// this is owned by the task not by the wrapper
     pub path: bun_ptr::RawSlice<u8>,
     /// Pins the source ReadableStream when the native ByteStream fast-path is
@@ -759,8 +741,8 @@ impl S3UploadStreamWrapper {
             }
         }
 
-        if let Some(callback) = self_.callback {
-            callback(result, self_.callback_context);
+        if let Some(callback) = self_.callback.take() {
+            callback(result);
         }
         settled
     }
@@ -847,8 +829,7 @@ pub(crate) fn upload_stream(
     content_encoding: Option<&[u8]>,
     proxy: Option<&[u8]>,
     request_payer: bool,
-    callback: Option<fn(S3UploadResult, *mut c_void)>,
-    callback_context: *mut c_void,
+    callback: Option<Box<dyn FnOnce(S3UploadResult<'_>)>>,
 ) -> JsResult<JSValue> {
     let proxy_url = proxy.unwrap_or(b"");
     if readable_stream.is_disturbed(global_this) {
@@ -994,7 +975,6 @@ pub(crate) fn upload_stream(
             ref_count: Cell::new(2), // +1 for the stream pump (released by the .then shim / handle_*_stream)
             sink: None,
             callback,
-            callback_context,
             path: bun_ptr::RawSlice::new(&task.path),
             task: task_ptr,
             end_promise: bun_jsc::JSPromiseStrong::init(global_this),

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -114,7 +114,7 @@ use bun_s3_signing::storage_class::StorageClass;
 use crate::webcore::s3::multipart_options::MultiPartUploadOptions;
 use crate::webcore::s3::simple_request::{
     self as s3_simple_request, S3CommitResult, S3DownloadResult, S3PartResult, S3UploadResult,
-    execute_simple_s3_request,
+    execute_multipart_request,
 };
 use crate::webcore::s3::xml_response;
 use bun_collections::index_sort;
@@ -330,7 +330,7 @@ impl UploadPart {
             2048 - w.len()
         };
         let search_params = &params_buffer[..written];
-        execute_simple_s3_request(
+        execute_multipart_request(
             &ctx.credentials,
             s3_simple_request::S3RequestOptions {
                 path: &ctx.path,
@@ -408,7 +408,7 @@ impl MultiPartUpload {
                     options.retry -= 1;
                     self_.options.set(options);
                     self_.ref_();
-                    execute_simple_s3_request(
+                    execute_multipart_request(
                         &self_.credentials,
                         s3_simple_request::S3RequestOptions {
                             path: &self_.path,
@@ -791,7 +791,7 @@ impl MultiPartUpload {
             2048 - w.len()
         };
         let search_params = &params_buffer[..written];
-        execute_simple_s3_request(
+        execute_multipart_request(
             &self.credentials,
             s3_simple_request::S3RequestOptions {
                 path: &self.path,
@@ -819,7 +819,7 @@ impl MultiPartUpload {
             2048 - w.len()
         };
         let search_params = &params_buffer[..written];
-        execute_simple_s3_request(
+        execute_multipart_request(
             &self.credentials,
             s3_simple_request::S3RequestOptions {
                 path: &self.path,
@@ -848,7 +848,7 @@ impl MultiPartUpload {
             // will auto start later
             self.state.set(State::MultipartStarted);
             self.ref_();
-            execute_simple_s3_request(
+            execute_multipart_request(
                 &self.credentials,
                 s3_simple_request::S3RequestOptions {
                     path: &self.path,
@@ -981,7 +981,7 @@ impl MultiPartUpload {
             self.state.set(State::SinglefileStarted);
             // we can do only 1 request
             self.ref_();
-            let _ = execute_simple_s3_request(
+            let _ = execute_multipart_request(
                 &self.credentials,
                 s3_simple_request::S3RequestOptions {
                     path: &self.path,

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -330,7 +330,6 @@ impl UploadPart {
             2048 - w.len()
         };
         let search_params = &params_buffer[..written];
-        let this = std::ptr::from_ref::<Self>(self).cast_mut();
         execute_simple_s3_request(
             &ctx.credentials,
             s3_simple_request::S3RequestOptions {
@@ -342,7 +341,7 @@ impl UploadPart {
                 request_payer: ctx.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::Callback::MultipartPart(this),
+            s3_simple_request::Callback::MultipartPart(std::ptr::from_ref(self).cast_mut()),
         )
     }
 
@@ -792,7 +791,6 @@ impl MultiPartUpload {
             2048 - w.len()
         };
         let search_params = &params_buffer[..written];
-        let this = self.root_ptr();
         execute_simple_s3_request(
             &self.credentials,
             s3_simple_request::S3RequestOptions {
@@ -804,7 +802,7 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::Callback::MultipartCommit(this),
+            s3_simple_request::Callback::MultipartCommit(self.root_ptr()),
         )
     }
 
@@ -821,7 +819,6 @@ impl MultiPartUpload {
             2048 - w.len()
         };
         let search_params = &params_buffer[..written];
-        let this = self.root_ptr();
         execute_simple_s3_request(
             &self.credentials,
             s3_simple_request::S3RequestOptions {
@@ -833,7 +830,7 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::Callback::MultipartRollback(this),
+            s3_simple_request::Callback::MultipartRollback(self.root_ptr()),
         )
     }
 
@@ -851,7 +848,6 @@ impl MultiPartUpload {
             // will auto start later
             self.state.set(State::MultipartStarted);
             self.ref_();
-            let this = self.root_ptr();
             execute_simple_s3_request(
                 &self.credentials,
                 s3_simple_request::S3RequestOptions {
@@ -868,7 +864,7 @@ impl MultiPartUpload {
                     request_payer: self.request_payer,
                     ..Default::default()
                 },
-                s3_simple_request::Callback::MultipartStart(this),
+                s3_simple_request::Callback::MultipartStart(self.root_ptr()),
             )?;
         } else if self.state.get() == State::MultipartCompleted {
             part.start()?;
@@ -985,7 +981,6 @@ impl MultiPartUpload {
             self.state.set(State::SinglefileStarted);
             // we can do only 1 request
             self.ref_();
-            let this = self.root_ptr();
             let _ = execute_simple_s3_request(
                 &self.credentials,
                 s3_simple_request::S3RequestOptions {
@@ -1001,7 +996,7 @@ impl MultiPartUpload {
                     request_payer: self.request_payer,
                     ..Default::default()
                 },
-                s3_simple_request::Callback::MultipartUpload(this),
+                s3_simple_request::Callback::MultipartUpload(self.root_ptr()),
             ); // TODO: properly propagate exception upwards
         } else {
             // we need to split

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -204,11 +204,6 @@ impl MultiPartUpload {
             .expect("MultiPartUpload root set at construction")
             .as_ptr()
     }
-
-    #[inline]
-    fn as_ctx_ptr(&self) -> *mut c_void {
-        self.root_ptr().cast::<c_void>()
-    }
 }
 
 #[repr(u8)]
@@ -260,10 +255,10 @@ impl UploadPart {
         unsafe { &*self.data.get() }
     }
 
-    fn on_part_response(result: S3PartResult, this: *mut c_void) -> bun_jsc::JsResult<()> {
+    fn on_part_response(result: S3PartResult, this: *mut Self) -> bun_jsc::JsResult<()> {
         // SAFETY: callback context — `this` is the queue slot passed in `perform()`; the
         // ref this part holds on `ctx` keeps the queue alive until the tail `deref_` below.
-        let this = unsafe { &*this.cast::<Self>() };
+        let this = unsafe { &*this };
         let ctx_ptr = this.ctx.as_ptr();
         let ctx = this.ctx.get();
         let part_number = this.part_number.get();
@@ -335,6 +330,7 @@ impl UploadPart {
             2048 - w.len()
         };
         let search_params = &params_buffer[..written];
+        let this = std::ptr::from_ref::<Self>(self).cast_mut();
         execute_simple_s3_request(
             &ctx.credentials,
             s3_simple_request::S3RequestOptions {
@@ -346,8 +342,9 @@ impl UploadPart {
                 request_payer: ctx.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Part(Self::on_part_response),
-            std::ptr::from_ref::<Self>(self).cast_mut().cast::<c_void>(),
+            s3_simple_request::S3Callback::Part(Box::new(move |result| {
+                Self::on_part_response(result, this)
+            })),
         )
     }
 
@@ -392,9 +389,8 @@ impl Drop for MultiPartUpload {
 impl MultiPartUpload {
     pub(crate) fn single_send_upload_response(
         result: S3UploadResult,
-        this: *mut c_void,
+        this: *mut Self,
     ) -> bun_jsc::JsResult<()> {
-        let this = this.cast::<Self>();
         // SAFETY: callback context — `this` is live; this takes over the ref
         // `process_buffered` (or the retry path) took for this request.
         let _guard = unsafe { RefPtr::from_raw(this) };
@@ -430,8 +426,9 @@ impl MultiPartUpload {
                             request_payer: self_.request_payer,
                             ..Default::default()
                         },
-                        s3_simple_request::S3Callback::Upload(Self::single_send_upload_response),
-                        this.cast::<c_void>(),
+                        s3_simple_request::S3Callback::Upload(Box::new(move |result| {
+                            Self::single_send_upload_response(result, this)
+                        })),
                     )
                 } else {
                     scoped_log!(S3MultiPartUpload, "singleSendUploadResponse failed");
@@ -634,9 +631,8 @@ impl MultiPartUpload {
     /// Result of the Multipart request, after this we can start draining the parts
     pub(crate) fn start_multi_part_request_result(
         result: S3DownloadResult,
-        this: *mut c_void,
+        this: *mut Self,
     ) -> bun_jsc::JsResult<()> {
-        let this = this.cast::<Self>();
         // SAFETY: callback context — takes over the ref taken before the request was queued.
         let _guard = unsafe { RefPtr::from_raw(this) };
         // SAFETY: `this` is live for at least the guard's duration.
@@ -712,9 +708,8 @@ impl MultiPartUpload {
     /// We do a best effort to commit the multipart upload, if it fails we will retry, if it still fails we will fail the upload
     pub(crate) fn on_commit_multi_part_request(
         result: S3CommitResult,
-        this: *mut c_void,
+        this: *mut Self,
     ) -> bun_jsc::JsResult<()> {
-        let this = this.cast::<Self>();
         // SAFETY: callback context — `this` is live; the request owns the final-step ref,
         // released as the tail statement below.
         let self_ = unsafe { &*this };
@@ -758,9 +753,8 @@ impl MultiPartUpload {
     /// We do a best effort to rollback the multipart upload, if it fails we will retry, if it still we just deinit the upload
     pub(crate) fn on_rollback_multi_part_request(
         result: S3UploadResult,
-        this: *mut c_void,
+        this: *mut Self,
     ) -> bun_jsc::JsResult<()> {
-        let this = this.cast::<Self>();
         // SAFETY: callback context — `this` is live; the request owns the final-step ref,
         // released as the tail statement below.
         let self_ = unsafe { &*this };
@@ -802,7 +796,7 @@ impl MultiPartUpload {
             2048 - w.len()
         };
         let search_params = &params_buffer[..written];
-
+        let this = self.root_ptr();
         execute_simple_s3_request(
             &self.credentials,
             s3_simple_request::S3RequestOptions {
@@ -814,8 +808,9 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Commit(Self::on_commit_multi_part_request),
-            self.as_ctx_ptr(),
+            s3_simple_request::S3Callback::Commit(Box::new(move |result| {
+                Self::on_commit_multi_part_request(result, this)
+            })),
         )
     }
 
@@ -832,7 +827,7 @@ impl MultiPartUpload {
             2048 - w.len()
         };
         let search_params = &params_buffer[..written];
-
+        let this = self.root_ptr();
         execute_simple_s3_request(
             &self.credentials,
             s3_simple_request::S3RequestOptions {
@@ -844,8 +839,9 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Upload(Self::on_rollback_multi_part_request),
-            self.as_ctx_ptr(),
+            s3_simple_request::S3Callback::Upload(Box::new(move |result| {
+                Self::on_rollback_multi_part_request(result, this)
+            })),
         )
     }
 
@@ -863,6 +859,7 @@ impl MultiPartUpload {
             // will auto start later
             self.state.set(State::MultipartStarted);
             self.ref_();
+            let this = self.root_ptr();
             execute_simple_s3_request(
                 &self.credentials,
                 s3_simple_request::S3RequestOptions {
@@ -879,8 +876,9 @@ impl MultiPartUpload {
                     request_payer: self.request_payer,
                     ..Default::default()
                 },
-                s3_simple_request::S3Callback::Download(Self::start_multi_part_request_result),
-                self.as_ctx_ptr(),
+                s3_simple_request::S3Callback::Download(Box::new(move |result| {
+                    Self::start_multi_part_request_result(result, this)
+                })),
             )?;
         } else if self.state.get() == State::MultipartCompleted {
             part.start()?;
@@ -997,6 +995,7 @@ impl MultiPartUpload {
             self.state.set(State::SinglefileStarted);
             // we can do only 1 request
             self.ref_();
+            let this = self.root_ptr();
             let _ = execute_simple_s3_request(
                 &self.credentials,
                 s3_simple_request::S3RequestOptions {
@@ -1012,8 +1011,9 @@ impl MultiPartUpload {
                     request_payer: self.request_payer,
                     ..Default::default()
                 },
-                s3_simple_request::S3Callback::Upload(Self::single_send_upload_response),
-                self.as_ctx_ptr(),
+                s3_simple_request::S3Callback::Upload(Box::new(move |result| {
+                    Self::single_send_upload_response(result, this)
+                })),
             ); // TODO: properly propagate exception upwards
         } else {
             // we need to split

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -255,7 +255,7 @@ impl UploadPart {
         unsafe { &*self.data.get() }
     }
 
-    fn on_part_response(result: S3PartResult, this: *mut Self) -> bun_jsc::JsResult<()> {
+    pub(crate) fn on_part_response(this: *mut Self, result: S3PartResult) -> bun_jsc::JsResult<()> {
         // SAFETY: callback context — `this` is the queue slot passed in `perform()`; the
         // ref this part holds on `ctx` keeps the queue alive until the tail `deref_` below.
         let this = unsafe { &*this };
@@ -342,9 +342,7 @@ impl UploadPart {
                 request_payer: ctx.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Part(Box::new(move |result| {
-                Self::on_part_response(result, this)
-            })),
+            s3_simple_request::Callback::MultipartPart(this),
         )
     }
 
@@ -388,8 +386,8 @@ impl Drop for MultiPartUpload {
 
 impl MultiPartUpload {
     pub(crate) fn single_send_upload_response(
-        result: S3UploadResult,
         this: *mut Self,
+        result: S3UploadResult,
     ) -> bun_jsc::JsResult<()> {
         // SAFETY: callback context — `this` is live; this takes over the ref
         // `process_buffered` (or the retry path) took for this request.
@@ -426,9 +424,7 @@ impl MultiPartUpload {
                             request_payer: self_.request_payer,
                             ..Default::default()
                         },
-                        s3_simple_request::S3Callback::Upload(Box::new(move |result| {
-                            Self::single_send_upload_response(result, this)
-                        })),
+                        s3_simple_request::Callback::MultipartUpload(this),
                     )
                 } else {
                     scoped_log!(S3MultiPartUpload, "singleSendUploadResponse failed");
@@ -630,8 +626,8 @@ impl MultiPartUpload {
 
     /// Result of the Multipart request, after this we can start draining the parts
     pub(crate) fn start_multi_part_request_result(
-        result: S3DownloadResult,
         this: *mut Self,
+        result: S3DownloadResult,
     ) -> bun_jsc::JsResult<()> {
         // SAFETY: callback context — takes over the ref taken before the request was queued.
         let _guard = unsafe { RefPtr::from_raw(this) };
@@ -707,8 +703,8 @@ impl MultiPartUpload {
 
     /// We do a best effort to commit the multipart upload, if it fails we will retry, if it still fails we will fail the upload
     pub(crate) fn on_commit_multi_part_request(
-        result: S3CommitResult,
         this: *mut Self,
+        result: S3CommitResult,
     ) -> bun_jsc::JsResult<()> {
         // SAFETY: callback context — `this` is live; the request owns the final-step ref,
         // released as the tail statement below.
@@ -752,8 +748,8 @@ impl MultiPartUpload {
 
     /// We do a best effort to rollback the multipart upload, if it fails we will retry, if it still we just deinit the upload
     pub(crate) fn on_rollback_multi_part_request(
-        result: S3UploadResult,
         this: *mut Self,
+        result: S3UploadResult,
     ) -> bun_jsc::JsResult<()> {
         // SAFETY: callback context — `this` is live; the request owns the final-step ref,
         // released as the tail statement below.
@@ -808,9 +804,7 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Commit(Box::new(move |result| {
-                Self::on_commit_multi_part_request(result, this)
-            })),
+            s3_simple_request::Callback::MultipartCommit(this),
         )
     }
 
@@ -839,9 +833,7 @@ impl MultiPartUpload {
                 request_payer: self.request_payer,
                 ..Default::default()
             },
-            s3_simple_request::S3Callback::Upload(Box::new(move |result| {
-                Self::on_rollback_multi_part_request(result, this)
-            })),
+            s3_simple_request::Callback::MultipartRollback(this),
         )
     }
 
@@ -876,9 +868,7 @@ impl MultiPartUpload {
                     request_payer: self.request_payer,
                     ..Default::default()
                 },
-                s3_simple_request::S3Callback::Download(Box::new(move |result| {
-                    Self::start_multi_part_request_result(result, this)
-                })),
+                s3_simple_request::Callback::MultipartStart(this),
             )?;
         } else if self.state.get() == State::MultipartCompleted {
             part.start()?;
@@ -1011,9 +1001,7 @@ impl MultiPartUpload {
                     request_payer: self.request_payer,
                     ..Default::default()
                 },
-                s3_simple_request::S3Callback::Upload(Box::new(move |result| {
-                    Self::single_send_upload_response(result, this)
-                })),
+                s3_simple_request::Callback::MultipartUpload(this),
             ); // TODO: properly propagate exception upwards
         } else {
             // we need to split

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -644,6 +644,9 @@ pub(crate) type S3RequestOptions<'a> = S3SimpleRequestOptions<'a>;
 pub struct S3SimpleRequestOptions<'a> {
     // signing options
     pub path: &'a [u8],
+    /// Bucket-level request (ListObjectsV2): an empty `path` is the bucket
+    /// root rather than an invalid key.
+    pub(crate) allow_empty_path: bool,
     pub method: Method,
     pub(crate) search_params: Option<&'a [u8]>,
     pub(crate) content_type: Option<&'a [u8]>,
@@ -664,6 +667,7 @@ impl<'a> Default for S3SimpleRequestOptions<'a> {
     fn default() -> Self {
         Self {
             path: b"",
+            allow_empty_path: false,
             method: Method::GET,
             search_params: None,
             content_type: None,
@@ -710,7 +714,7 @@ pub(crate) fn execute_simple_s3_request<F: 'static>(
         content_md5: None,
         content_type: None,
     };
-    let result = match if options.path.is_empty() {
+    let result = match if options.allow_empty_path {
         this.sign_request::<true>(&sign_options, None)
     } else {
         this.sign_request::<false>(&sign_options, None)

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -525,9 +525,8 @@ impl Drop for S3HttpSimpleTask {
     }
 }
 
-// callers in `client.rs` / `multipart.rs` were translated with three different
-// names for the request-options struct (`Options`, `S3RequestOptions`, `S3SimpleRequestOptions`)
-// and two for the callback enum. Alias them here so the call sites compile without churn.
+// callers in `client.rs` / `multipart.rs` use three different names for the
+// request-options struct (`Options`, `S3RequestOptions`, `S3SimpleRequestOptions`).
 pub(crate) type Options<'a> = S3SimpleRequestOptions<'a>;
 pub(crate) type S3RequestOptions<'a> = S3SimpleRequestOptions<'a>;
 

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -1,4 +1,3 @@
-use core::ffi::c_void;
 use core::sync::atomic::Ordering;
 
 use bun_core::MutableString;
@@ -120,8 +119,8 @@ pub struct S3HttpSimpleTask {
     pub(crate) http_ticket: Option<bun_jsc::Ticket>,
     pub(crate) sign_result: SignResult,
     pub(crate) headers: Headers,
-    pub(crate) callback_context: *mut c_void,
-    pub callback: Callback,
+    /// `None` once delivered.
+    pub callback: Option<Callback>,
     pub(crate) response_buffer: MutableString,
     pub(crate) result: HTTPClientResult<'static>,
     pub(crate) concurrent_task: ConcurrentTask,
@@ -149,50 +148,42 @@ impl Taskable for S3HttpSimpleTask {
     }
 }
 
+/// How a finished request is delivered. The closure owns whatever it needs
+/// to settle (promise, store ref, …) and runs exactly once — or is dropped if
+/// the request is abandoned.
 pub enum Callback {
-    Stat(fn(S3StatResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    Download(fn(S3DownloadResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    Upload(fn(S3UploadResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    Delete(fn(S3DeleteResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    ListObjects(fn(S3ListObjectsResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    Commit(fn(S3CommitResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
-    Part(fn(S3PartResult<'_>, *mut c_void) -> bun_jsc::JsResult<()>),
+    Stat(Box<dyn FnOnce(S3StatResult<'_>) -> bun_jsc::JsResult<()>>),
+    Download(Box<dyn FnOnce(S3DownloadResult<'_>) -> bun_jsc::JsResult<()>>),
+    Upload(Box<dyn FnOnce(S3UploadResult<'_>) -> bun_jsc::JsResult<()>>),
+    Delete(Box<dyn FnOnce(S3DeleteResult<'_>) -> bun_jsc::JsResult<()>>),
+    ListObjects(Box<dyn FnOnce(S3ListObjectsResult<'_>) -> bun_jsc::JsResult<()>>),
+    Commit(Box<dyn FnOnce(S3CommitResult<'_>) -> bun_jsc::JsResult<()>>),
+    Part(Box<dyn FnOnce(S3PartResult<'_>) -> bun_jsc::JsResult<()>>),
 }
 
 impl Callback {
-    fn fail(&self, code: &[u8], message: &[u8], context: *mut c_void) -> bun_jsc::JsResult<()> {
+    pub(crate) fn fail(self, code: &[u8], message: &[u8]) -> bun_jsc::JsResult<()> {
         let err = S3Error { code, message };
         match self {
-            Callback::Upload(callback) => callback(S3UploadResult::Failure(err), context)?,
-            Callback::Download(callback) => callback(S3DownloadResult::Failure(err), context)?,
-            Callback::Stat(callback) => callback(S3StatResult::Failure(err), context)?,
-            Callback::Delete(callback) => callback(S3DeleteResult::Failure(err), context)?,
-            Callback::ListObjects(callback) => {
-                callback(S3ListObjectsResult::Failure(err), context)?
-            }
-            Callback::Commit(callback) => callback(S3CommitResult::Failure(err), context)?,
-            Callback::Part(callback) => callback(S3PartResult::Failure(err), context)?,
+            Callback::Upload(callback) => callback(S3UploadResult::Failure(err)),
+            Callback::Download(callback) => callback(S3DownloadResult::Failure(err)),
+            Callback::Stat(callback) => callback(S3StatResult::Failure(err)),
+            Callback::Delete(callback) => callback(S3DeleteResult::Failure(err)),
+            Callback::ListObjects(callback) => callback(S3ListObjectsResult::Failure(err)),
+            Callback::Commit(callback) => callback(S3CommitResult::Failure(err)),
+            Callback::Part(callback) => callback(S3PartResult::Failure(err)),
         }
-        Ok(())
     }
 
-    fn not_found(
-        &self,
-        code: &[u8],
-        message: &[u8],
-        context: *mut c_void,
-    ) -> bun_jsc::JsResult<()> {
+    fn not_found(self, code: &[u8], message: &[u8]) -> bun_jsc::JsResult<()> {
         let err = S3Error { code, message };
         match self {
-            Callback::Download(callback) => callback(S3DownloadResult::NotFound(err), context)?,
-            Callback::Stat(callback) => callback(S3StatResult::NotFound(err), context)?,
-            Callback::Delete(callback) => callback(S3DeleteResult::NotFound(err), context)?,
-            Callback::ListObjects(callback) => {
-                callback(S3ListObjectsResult::NotFound(err), context)?
-            }
-            _ => self.fail(code, message, context)?,
+            Callback::Download(callback) => callback(S3DownloadResult::NotFound(err)),
+            Callback::Stat(callback) => callback(S3StatResult::NotFound(err)),
+            Callback::Delete(callback) => callback(S3DeleteResult::NotFound(err)),
+            Callback::ListObjects(callback) => callback(S3ListObjectsResult::NotFound(err)),
+            _ => self.fail(code, message),
         }
-        Ok(())
     }
 }
 
@@ -212,7 +203,8 @@ impl S3HttpSimpleTask {
         bun_core::heap::into_raw(Box::new(init))
     }
 
-    fn error_with_body(&self, error_type: ErrorType) -> bun_jsc::JsResult<()> {
+    fn error_with_body(&mut self, error_type: ErrorType) -> bun_jsc::JsResult<()> {
+        let callback = self.callback.take().expect("delivered once");
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
         let mut has_error_code = false;
@@ -242,16 +234,16 @@ impl S3HttpSimpleTask {
                 code = b"NoSuchKey";
                 message = b"The specified key does not exist.";
             }
-            self.callback
-                .not_found(code, message, self.callback_context)?;
+            callback.not_found(code, message)
         } else {
-            self.callback.fail(code, message, self.callback_context)?;
+            callback.fail(code, message)
         }
-        Ok(())
     }
 
-    /// A commit can answer 200 and still carry an `<Error>` document.
-    fn fail_if_contains_error(&mut self, status: u32) -> bun_jsc::JsResult<bool> {
+    /// A commit can answer 200 and still carry an `<Error>` document; on
+    /// `Ok(Some(callback))` it did not and the callback is still to run.
+    fn fail_if_contains_error(&mut self, status: u32) -> bun_jsc::JsResult<Option<Callback>> {
+        let callback = self.callback.take().expect("delivered once");
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
         let parsed;
@@ -268,11 +260,11 @@ impl S3HttpSimpleTask {
                 message = error.message.as_deref().unwrap_or(message);
             }
             if (parsed.is_none() && status == 200) || status == 206 {
-                return Ok(false);
+                return Ok(Some(callback));
             }
         }
-        self.callback.fail(code, message, self.callback_context)?;
-        Ok(true)
+        callback.fail(code, message)?;
+        Ok(None)
     }
 
     /// this is the task callback from the last task result and is always in the main thread
@@ -297,89 +289,72 @@ impl S3HttpSimpleTask {
             return Ok(());
         }
         debug_assert!(this.result.metadata.is_some());
-        // reshaped for borrowck — borrow response once, dispatch on a copy of `callback`.
-        let response = &this.result.metadata.as_ref().unwrap().response;
-        match this.callback {
-            Callback::Stat(callback) => match response.status_code {
-                200 => {
-                    callback(
-                        S3StatResult::Success(S3StatSuccess {
-                            etag: response.headers.get(b"etag").unwrap_or(b""),
-                            last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
-                            content_type: response.headers.get(b"content-type").unwrap_or(b""),
-                            size: response
-                                .headers
-                                .get(b"content-length")
-                                .map(bun_http_types::parse_content_length)
-                                .unwrap_or(0),
-                        }),
-                        this.callback_context,
-                    )?;
-                }
-                404 => this.error_with_body(ErrorType::NotFound)?,
-                _ => this.error_with_body(ErrorType::Failure)?,
-            },
-            Callback::Delete(callback) => match response.status_code {
-                200 | 204 => callback(S3DeleteResult::Success, this.callback_context)?,
-                404 => this.error_with_body(ErrorType::NotFound)?,
-                _ => this.error_with_body(ErrorType::Failure)?,
-            },
-            Callback::ListObjects(callback) => match response.status_code {
-                200 => {
-                    let body = this.response_buffer.list.as_slice();
-                    let result = match list_objects::parse_s3_list_objects_result(body) {
-                        Some(listing) => S3ListObjectsResult::Success(Box::new(listing)),
-                        // Half a listing is worse than none: S3 emits keys
-                        // with control characters as (ill-formed) XML
-                        // unless asked to URL-encode them.
-                        None => S3ListObjectsResult::Failure(S3Error {
-                            code: b"InvalidResponse",
-                            message: b"ListObjectsV2 response is not a well-formed <ListBucketResult> document (if keys can contain control characters, pass encodingType: \"url\")",
-                        }),
-                    };
-                    callback(result, this.callback_context)?;
-                }
-                404 => this.error_with_body(ErrorType::NotFound)?,
-                _ => this.error_with_body(ErrorType::Failure)?,
-            },
-            Callback::Upload(callback) => match response.status_code {
-                200 => callback(S3UploadResult::Success, this.callback_context)?,
-                _ => this.error_with_body(ErrorType::Failure)?,
-            },
-            Callback::Download(callback) => match response.status_code {
-                200 | 204 | 206 => {
-                    let body = core::mem::take(&mut this.response_buffer);
-                    callback(
-                        S3DownloadResult::Success(S3DownloadSuccess { body }),
-                        this.callback_context,
-                    )?;
-                }
-                404 => this.error_with_body(ErrorType::NotFound)?,
-                _ => {
-                    // error
-                    this.error_with_body(ErrorType::Failure)?;
-                }
-            },
-            Callback::Commit(callback) => {
-                // commit multipart upload can fail with status 200
-                let status = response.status_code;
-                if !this.fail_if_contains_error(status)? {
-                    callback(S3CommitResult::Success, this.callback_context)?;
-                }
-            }
-            Callback::Part(callback) => {
-                let status = response.status_code;
-                if !this.fail_if_contains_error(status)? {
-                    let response = &this.result.metadata.as_ref().unwrap().response;
-                    if let Some(etag) = response.headers.get(b"etag") {
-                        callback(S3PartResult::Etag(etag), this.callback_context)?;
-                    } else {
-                        this.error_with_body(ErrorType::Failure)?;
-                    }
-                }
-            }
+        let status = this.result.metadata.as_ref().unwrap().response.status_code;
+        let error_type = match (this.callback.as_ref().expect("delivered once"), status) {
+            (Callback::Stat(_) | Callback::ListObjects(_) | Callback::Upload(_), 200)
+            | (Callback::Delete(_), 200 | 204)
+            | (Callback::Download(_), 200 | 204 | 206)
+            | (Callback::Commit(_) | Callback::Part(_), _) => None,
+            (
+                Callback::Stat(_)
+                | Callback::ListObjects(_)
+                | Callback::Delete(_)
+                | Callback::Download(_),
+                404,
+            ) => Some(ErrorType::NotFound),
+            _ => Some(ErrorType::Failure),
+        };
+        if let Some(error_type) = error_type {
+            return this.error_with_body(error_type);
         }
-        Ok(())
+        let callback = match this.callback.as_ref().unwrap() {
+            // Commit / part uploads can answer 200 and still carry an error.
+            Callback::Commit(_) | Callback::Part(_) => match this.fail_if_contains_error(status)? {
+                Some(callback) => callback,
+                None => return Ok(()),
+            },
+            _ => this.callback.take().unwrap(),
+        };
+        let response = &this.result.metadata.as_ref().unwrap().response;
+        match callback {
+            Callback::Stat(callback) => callback(S3StatResult::Success(S3StatSuccess {
+                etag: response.headers.get(b"etag").unwrap_or(b""),
+                last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
+                content_type: response.headers.get(b"content-type").unwrap_or(b""),
+                size: response
+                    .headers
+                    .get(b"content-length")
+                    .map(bun_http_types::parse_content_length)
+                    .unwrap_or(0),
+            })),
+            Callback::Delete(callback) => callback(S3DeleteResult::Success),
+            Callback::ListObjects(callback) => {
+                let body = this.response_buffer.list.as_slice();
+                callback(match list_objects::parse_s3_list_objects_result(body) {
+                    Some(listing) => S3ListObjectsResult::Success(Box::new(listing)),
+                    // Half a listing is worse than none: S3 emits keys
+                    // with control characters as (ill-formed) XML
+                    // unless asked to URL-encode them.
+                    None => S3ListObjectsResult::Failure(S3Error {
+                        code: b"InvalidResponse",
+                        message: b"ListObjectsV2 response is not a well-formed <ListBucketResult> document (if keys can contain control characters, pass encodingType: \"url\")",
+                    }),
+                })
+            }
+            Callback::Upload(callback) => callback(S3UploadResult::Success),
+            Callback::Download(callback) => {
+                let body = core::mem::take(&mut this.response_buffer);
+                callback(S3DownloadResult::Success(S3DownloadSuccess { body }))
+            }
+            Callback::Commit(callback) => callback(S3CommitResult::Success),
+            Callback::Part(callback) => match response.headers.get(b"etag") {
+                Some(etag) => callback(S3PartResult::Etag(etag)),
+                None => {
+                    this.callback = Some(Callback::Part(callback));
+                    this.error_with_body(ErrorType::Failure)
+                }
+            },
+        }
     }
 
     fn stage_http_result(
@@ -553,18 +528,15 @@ pub(crate) fn execute_simple_s3_request(
     this: &S3Credentials,
     options: S3SimpleRequestOptions<'_>,
     callback: Callback,
-    callback_context: *mut c_void,
 ) -> bun_jsc::JsResult<()> {
     // A multipart/retry continuation can reach here from teardown's queue
     // release; nothing new leaves a VM that is stopping.
     if !VirtualMachine::get().script_allowed() {
         drop(options.range);
-        callback.fail(
+        return callback.fail(
             b"ERR_S3_VM_SHUTDOWN",
             b"The JavaScript VM that owns this request is shutting down",
-            callback_context,
-        )?;
-        return Ok(());
+        );
     }
     let result = match this.sign_request::<false>(
         &SignOptions {
@@ -587,12 +559,7 @@ pub(crate) fn execute_simple_s3_request(
             // options.range drops here automatically
             drop(options.range);
             let error_code_and_message = get_sign_error_code_and_message(sign_err.into());
-            callback.fail(
-                error_code_and_message.code,
-                error_code_and_message.message,
-                callback_context,
-            )?;
-            return Ok(());
+            return callback.fail(error_code_and_message.code, error_code_and_message.message);
         }
     };
 
@@ -625,8 +592,7 @@ pub(crate) fn execute_simple_s3_request(
         // written below via `MaybeUninit::write` before any read.
         http: core::mem::MaybeUninit::uninit(),
         sign_result: result,
-        callback_context,
-        callback,
+        callback: Some(callback),
         headers,
         http_ticket: None,
         response_buffer: MutableString::default(),

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -18,6 +18,7 @@ use bun_s3_signing::storage_class::StorageClass;
 use bun_threading::thread_pool;
 use bun_url::URL;
 
+use crate::webcore::s3::multipart::{MultiPartUpload, UploadPart};
 use crate::webcore::s3::{list_objects, xml_response};
 
 // The result/options structs below carry borrowed slices that are valid only for the
@@ -149,46 +150,71 @@ impl Taskable for S3HttpSimpleTask {
 }
 
 /// How a finished request is delivered. The closure owns whatever it needs
-/// to settle (promise, store ref, …) and runs exactly once — or is dropped if
-/// the request is abandoned.
+/// to settle (promise, store ref, …) and runs exactly once. The multipart
+/// state machine's own requests carry its pointer instead (it holds a ref on
+/// itself across each one).
 pub enum Callback {
     Stat(Box<dyn FnOnce(S3StatResult<'_>) -> bun_jsc::JsResult<()>>),
     Download(Box<dyn FnOnce(S3DownloadResult<'_>) -> bun_jsc::JsResult<()>>),
     Upload(Box<dyn FnOnce(S3UploadResult<'_>) -> bun_jsc::JsResult<()>>),
     Delete(Box<dyn FnOnce(S3DeleteResult<'_>) -> bun_jsc::JsResult<()>>),
     ListObjects(Box<dyn FnOnce(S3ListObjectsResult<'_>) -> bun_jsc::JsResult<()>>),
-    Commit(Box<dyn FnOnce(S3CommitResult<'_>) -> bun_jsc::JsResult<()>>),
-    Part(Box<dyn FnOnce(S3PartResult<'_>) -> bun_jsc::JsResult<()>>),
+    /// → [`MultiPartUpload::start_multi_part_request_result`]
+    MultipartStart(*mut MultiPartUpload),
+    /// → [`MultiPartUpload::single_send_upload_response`]
+    MultipartUpload(*mut MultiPartUpload),
+    /// → [`MultiPartUpload::on_commit_multi_part_request`]
+    MultipartCommit(*mut MultiPartUpload),
+    /// → [`MultiPartUpload::on_rollback_multi_part_request`]
+    MultipartRollback(*mut MultiPartUpload),
+    /// → [`UploadPart::on_part_response`]
+    MultipartPart(*mut UploadPart),
 }
 
 impl Callback {
-    pub(crate) fn fail(self, code: &[u8], message: &[u8]) -> bun_jsc::JsResult<()> {
+    fn fail(self, code: &[u8], message: &[u8]) -> bun_jsc::JsResult<()> {
         let err = S3Error { code, message };
         match self {
-            Callback::Upload(callback) => callback(S3UploadResult::Failure(err)),
-            Callback::Download(callback) => callback(S3DownloadResult::Failure(err)),
             Callback::Stat(callback) => callback(S3StatResult::Failure(err)),
+            Callback::Download(callback) => callback(S3DownloadResult::Failure(err)),
+            Callback::Upload(callback) => callback(S3UploadResult::Failure(err)),
             Callback::Delete(callback) => callback(S3DeleteResult::Failure(err)),
             Callback::ListObjects(callback) => callback(S3ListObjectsResult::Failure(err)),
-            Callback::Commit(callback) => callback(S3CommitResult::Failure(err)),
-            Callback::Part(callback) => callback(S3PartResult::Failure(err)),
+            Callback::MultipartStart(this) => MultiPartUpload::start_multi_part_request_result(
+                this,
+                S3DownloadResult::Failure(err),
+            ),
+            Callback::MultipartUpload(this) => {
+                MultiPartUpload::single_send_upload_response(this, S3UploadResult::Failure(err))
+            }
+            Callback::MultipartCommit(this) => {
+                MultiPartUpload::on_commit_multi_part_request(this, S3CommitResult::Failure(err))
+            }
+            Callback::MultipartRollback(this) => {
+                MultiPartUpload::on_rollback_multi_part_request(this, S3UploadResult::Failure(err))
+            }
+            Callback::MultipartPart(this) => {
+                UploadPart::on_part_response(this, S3PartResult::Failure(err))
+            }
         }
     }
 
     fn not_found(self, code: &[u8], message: &[u8]) -> bun_jsc::JsResult<()> {
         let err = S3Error { code, message };
         match self {
-            Callback::Download(callback) => callback(S3DownloadResult::NotFound(err)),
             Callback::Stat(callback) => callback(S3StatResult::NotFound(err)),
+            Callback::Download(callback) => callback(S3DownloadResult::NotFound(err)),
             Callback::Delete(callback) => callback(S3DeleteResult::NotFound(err)),
             Callback::ListObjects(callback) => callback(S3ListObjectsResult::NotFound(err)),
+            Callback::MultipartStart(this) => MultiPartUpload::start_multi_part_request_result(
+                this,
+                S3DownloadResult::NotFound(err),
+            ),
             _ => self.fail(code, message),
         }
     }
 }
 
-// `error_type` is a runtime parameter — the
-// branch is on an error path, no perf concern.
 #[derive(PartialEq, Eq, Clone, Copy)]
 enum ErrorType {
     NotFound,
@@ -203,8 +229,7 @@ impl S3HttpSimpleTask {
         bun_core::heap::into_raw(Box::new(init))
     }
 
-    fn error_with_body(&mut self, error_type: ErrorType) -> bun_jsc::JsResult<()> {
-        let callback = self.callback.take().expect("delivered once");
+    fn error_with_body(&self, callback: Callback, error_type: ErrorType) -> bun_jsc::JsResult<()> {
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
         let mut has_error_code = false;
@@ -240,10 +265,13 @@ impl S3HttpSimpleTask {
         }
     }
 
-    /// A commit can answer 200 and still carry an `<Error>` document; on
-    /// `Ok(Some(callback))` it did not and the callback is still to run.
-    fn fail_if_contains_error(&mut self, status: u32) -> bun_jsc::JsResult<Option<Callback>> {
-        let callback = self.callback.take().expect("delivered once");
+    /// A commit can answer 200 and still carry an `<Error>` document; hands
+    /// the callback back if it did not.
+    fn fail_if_contains_error(
+        &self,
+        callback: Callback,
+        status: u32,
+    ) -> bun_jsc::JsResult<Option<Callback>> {
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
         let parsed;
@@ -283,76 +311,105 @@ impl S3HttpSimpleTask {
         // reclaimed here exactly once via the ConcurrentTask `AutoDeinit::ManualDeinit` contract;
         // `this` is dropped at scope exit.
         let mut this = unsafe { bun_core::heap::take(this) };
+        let callback = this.callback.take().expect("delivered once");
 
         if !this.result.is_success() {
-            this.error_with_body(ErrorType::Failure)?;
-            return Ok(());
+            return this.error_with_body(callback, ErrorType::Failure);
         }
         debug_assert!(this.result.metadata.is_some());
-        let status = this.result.metadata.as_ref().unwrap().response.status_code;
-        let error_type = match (this.callback.as_ref().expect("delivered once"), status) {
-            (Callback::Stat(_) | Callback::ListObjects(_) | Callback::Upload(_), 200)
-            | (Callback::Delete(_), 200 | 204)
-            | (Callback::Download(_), 200 | 204 | 206)
-            | (Callback::Commit(_) | Callback::Part(_), _) => None,
-            (
-                Callback::Stat(_)
-                | Callback::ListObjects(_)
-                | Callback::Delete(_)
-                | Callback::Download(_),
-                404,
-            ) => Some(ErrorType::NotFound),
-            _ => Some(ErrorType::Failure),
-        };
-        if let Some(error_type) = error_type {
-            return this.error_with_body(error_type);
-        }
-        let callback = match this.callback.as_ref().unwrap() {
-            // Commit / part uploads can answer 200 and still carry an error.
-            Callback::Commit(_) | Callback::Part(_) => match this.fail_if_contains_error(status)? {
-                Some(callback) => callback,
-                None => return Ok(()),
-            },
-            _ => this.callback.take().unwrap(),
-        };
         let response = &this.result.metadata.as_ref().unwrap().response;
+        let status = response.status_code;
         match callback {
-            Callback::Stat(callback) => callback(S3StatResult::Success(S3StatSuccess {
-                etag: response.headers.get(b"etag").unwrap_or(b""),
-                last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
-                content_type: response.headers.get(b"content-type").unwrap_or(b""),
-                size: response
-                    .headers
-                    .get(b"content-length")
-                    .map(bun_http_types::parse_content_length)
-                    .unwrap_or(0),
-            })),
-            Callback::Delete(callback) => callback(S3DeleteResult::Success),
-            Callback::ListObjects(callback) => {
-                let body = this.response_buffer.list.as_slice();
-                callback(match list_objects::parse_s3_list_objects_result(body) {
-                    Some(listing) => S3ListObjectsResult::Success(Box::new(listing)),
-                    // Half a listing is worse than none: S3 emits keys
-                    // with control characters as (ill-formed) XML
-                    // unless asked to URL-encode them.
-                    None => S3ListObjectsResult::Failure(S3Error {
-                        code: b"InvalidResponse",
-                        message: b"ListObjectsV2 response is not a well-formed <ListBucketResult> document (if keys can contain control characters, pass encodingType: \"url\")",
-                    }),
-                })
-            }
-            Callback::Upload(callback) => callback(S3UploadResult::Success),
-            Callback::Download(callback) => {
-                let body = core::mem::take(&mut this.response_buffer);
-                callback(S3DownloadResult::Success(S3DownloadSuccess { body }))
-            }
-            Callback::Commit(callback) => callback(S3CommitResult::Success),
-            Callback::Part(callback) => match response.headers.get(b"etag") {
-                Some(etag) => callback(S3PartResult::Etag(etag)),
-                None => {
-                    this.callback = Some(Callback::Part(callback));
-                    this.error_with_body(ErrorType::Failure)
+            Callback::Stat(callback) => match status {
+                200 => callback(S3StatResult::Success(S3StatSuccess {
+                    etag: response.headers.get(b"etag").unwrap_or(b""),
+                    last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
+                    content_type: response.headers.get(b"content-type").unwrap_or(b""),
+                    size: response
+                        .headers
+                        .get(b"content-length")
+                        .map(bun_http_types::parse_content_length)
+                        .unwrap_or(0),
+                })),
+                404 => this.error_with_body(Callback::Stat(callback), ErrorType::NotFound),
+                _ => this.error_with_body(Callback::Stat(callback), ErrorType::Failure),
+            },
+            Callback::Delete(callback) => match status {
+                200 | 204 => callback(S3DeleteResult::Success),
+                404 => this.error_with_body(Callback::Delete(callback), ErrorType::NotFound),
+                _ => this.error_with_body(Callback::Delete(callback), ErrorType::Failure),
+            },
+            Callback::ListObjects(callback) => match status {
+                200 => {
+                    let body = this.response_buffer.list.as_slice();
+                    callback(match list_objects::parse_s3_list_objects_result(body) {
+                        Some(listing) => S3ListObjectsResult::Success(Box::new(listing)),
+                        // Half a listing is worse than none: S3 emits keys
+                        // with control characters as (ill-formed) XML
+                        // unless asked to URL-encode them.
+                        None => S3ListObjectsResult::Failure(S3Error {
+                            code: b"InvalidResponse",
+                            message: b"ListObjectsV2 response is not a well-formed <ListBucketResult> document (if keys can contain control characters, pass encodingType: \"url\")",
+                        }),
+                    })
                 }
+                404 => this.error_with_body(Callback::ListObjects(callback), ErrorType::NotFound),
+                _ => this.error_with_body(Callback::ListObjects(callback), ErrorType::Failure),
+            },
+            Callback::Upload(_) | Callback::MultipartUpload(_) | Callback::MultipartRollback(_) => {
+                match status {
+                    200 => match callback {
+                        Callback::Upload(callback) => callback(S3UploadResult::Success),
+                        Callback::MultipartUpload(this) => {
+                            MultiPartUpload::single_send_upload_response(
+                                this,
+                                S3UploadResult::Success,
+                            )
+                        }
+                        Callback::MultipartRollback(this) => {
+                            MultiPartUpload::on_rollback_multi_part_request(
+                                this,
+                                S3UploadResult::Success,
+                            )
+                        }
+                        _ => unreachable!(),
+                    },
+                    _ => this.error_with_body(callback, ErrorType::Failure),
+                }
+            }
+            Callback::Download(_) | Callback::MultipartStart(_) => match status {
+                200 | 204 | 206 => {
+                    let body = core::mem::take(&mut this.response_buffer);
+                    let result = S3DownloadResult::Success(S3DownloadSuccess { body });
+                    match callback {
+                        Callback::Download(callback) => callback(result),
+                        Callback::MultipartStart(this) => {
+                            MultiPartUpload::start_multi_part_request_result(this, result)
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+                404 => this.error_with_body(callback, ErrorType::NotFound),
+                _ => this.error_with_body(callback, ErrorType::Failure),
+            },
+            // commit multipart upload can fail with status 200
+            Callback::MultipartCommit(upload) => match this
+                .fail_if_contains_error(callback, status)?
+            {
+                Some(_) => {
+                    MultiPartUpload::on_commit_multi_part_request(upload, S3CommitResult::Success)
+                }
+                None => Ok(()),
+            },
+            Callback::MultipartPart(part) => match this.fail_if_contains_error(callback, status)? {
+                Some(callback) => {
+                    let response = &this.result.metadata.as_ref().unwrap().response;
+                    match response.headers.get(b"etag") {
+                        Some(etag) => UploadPart::on_part_response(part, S3PartResult::Etag(etag)),
+                        None => this.error_with_body(callback, ErrorType::Failure),
+                    }
+                }
+                None => Ok(()),
             },
         }
     }
@@ -484,7 +541,6 @@ impl Drop for S3HttpSimpleTask {
 // and two for the callback enum. Alias them here so the call sites compile without churn.
 pub(crate) type Options<'a> = S3SimpleRequestOptions<'a>;
 pub(crate) type S3RequestOptions<'a> = S3SimpleRequestOptions<'a>;
-pub(crate) type S3Callback = Callback;
 
 pub struct S3SimpleRequestOptions<'a> {
     // signing options

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -172,45 +172,30 @@ pub enum Callback {
 }
 
 impl Callback {
-    fn fail(self, code: &[u8], message: &[u8]) -> bun_jsc::JsResult<()> {
-        let err = S3Error { code, message };
+    fn fail(self, err: S3Error<'_>) -> bun_jsc::JsResult<()> {
         match self {
             Callback::Stat(callback) => callback(S3StatResult::Failure(err)),
             Callback::Download(callback) => callback(S3DownloadResult::Failure(err)),
             Callback::Upload(callback) => callback(S3UploadResult::Failure(err)),
             Callback::Delete(callback) => callback(S3DeleteResult::Failure(err)),
             Callback::ListObjects(callback) => callback(S3ListObjectsResult::Failure(err)),
-            Callback::MultipartStart(this) => MultiPartUpload::start_multi_part_request_result(
-                this,
+            Callback::MultipartStart(upload) => MultiPartUpload::start_multi_part_request_result(
+                upload,
                 S3DownloadResult::Failure(err),
             ),
-            Callback::MultipartUpload(this) => {
-                MultiPartUpload::single_send_upload_response(this, S3UploadResult::Failure(err))
+            Callback::MultipartUpload(upload) => {
+                MultiPartUpload::single_send_upload_response(upload, S3UploadResult::Failure(err))
             }
-            Callback::MultipartCommit(this) => {
-                MultiPartUpload::on_commit_multi_part_request(this, S3CommitResult::Failure(err))
+            Callback::MultipartCommit(upload) => {
+                MultiPartUpload::on_commit_multi_part_request(upload, S3CommitResult::Failure(err))
             }
-            Callback::MultipartRollback(this) => {
-                MultiPartUpload::on_rollback_multi_part_request(this, S3UploadResult::Failure(err))
-            }
-            Callback::MultipartPart(this) => {
-                UploadPart::on_part_response(this, S3PartResult::Failure(err))
-            }
-        }
-    }
-
-    fn not_found(self, code: &[u8], message: &[u8]) -> bun_jsc::JsResult<()> {
-        let err = S3Error { code, message };
-        match self {
-            Callback::Stat(callback) => callback(S3StatResult::NotFound(err)),
-            Callback::Download(callback) => callback(S3DownloadResult::NotFound(err)),
-            Callback::Delete(callback) => callback(S3DeleteResult::NotFound(err)),
-            Callback::ListObjects(callback) => callback(S3ListObjectsResult::NotFound(err)),
-            Callback::MultipartStart(this) => MultiPartUpload::start_multi_part_request_result(
-                this,
-                S3DownloadResult::NotFound(err),
+            Callback::MultipartRollback(upload) => MultiPartUpload::on_rollback_multi_part_request(
+                upload,
+                S3UploadResult::Failure(err),
             ),
-            _ => self.fail(code, message),
+            Callback::MultipartPart(part) => {
+                UploadPart::on_part_response(part, S3PartResult::Failure(err))
+            }
         }
     }
 }
@@ -229,7 +214,13 @@ impl S3HttpSimpleTask {
         bun_core::heap::into_raw(Box::new(init))
     }
 
-    fn error_with_body(&self, callback: Callback, error_type: ErrorType) -> bun_jsc::JsResult<()> {
+    /// The error the transport or the response body carries, handed to
+    /// `deliver` while the parsed body is alive.
+    fn with_body_error<R>(
+        &self,
+        error_type: ErrorType,
+        deliver: impl FnOnce(S3Error<'_>) -> R,
+    ) -> R {
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
         let mut has_error_code = false;
@@ -253,25 +244,20 @@ impl S3HttpSimpleTask {
                 }
             }
         }
-
-        if error_type == ErrorType::NotFound {
-            if !has_error_code {
-                code = b"NoSuchKey";
-                message = b"The specified key does not exist.";
-            }
-            callback.not_found(code, message)
-        } else {
-            callback.fail(code, message)
+        if error_type == ErrorType::NotFound && !has_error_code {
+            code = b"NoSuchKey";
+            message = b"The specified key does not exist.";
         }
+        deliver(S3Error { code, message })
     }
 
-    /// A commit can answer 200 and still carry an `<Error>` document; hands
-    /// the callback back if it did not.
-    fn fail_if_contains_error(
+    /// A commit can answer 200 and still carry an `<Error>` document: hands
+    /// `deliver` that error, or `None`.
+    fn with_ok_body_error<R>(
         &self,
-        callback: Callback,
         status: u32,
-    ) -> bun_jsc::JsResult<Option<Callback>> {
+        deliver: impl FnOnce(Option<S3Error<'_>>) -> R,
+    ) -> R {
         let mut code: &[u8] = b"UnknownError";
         let mut message: &[u8] = b"an unexpected error has occurred";
         let parsed;
@@ -288,11 +274,10 @@ impl S3HttpSimpleTask {
                 message = error.message.as_deref().unwrap_or(message);
             }
             if (parsed.is_none() && status == 200) || status == 206 {
-                return Ok(Some(callback));
+                return deliver(None);
             }
         }
-        callback.fail(code, message)?;
-        Ok(None)
+        deliver(Some(S3Error { code, message }))
     }
 
     /// this is the task callback from the last task result and is always in the main thread
@@ -305,6 +290,7 @@ impl S3HttpSimpleTask {
     // pointer the queue hands back, non-null by the `ConcurrentTask::from` contract.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub(crate) fn on_response(this: *mut Self) -> bun_jsc::JsResult<()> {
+        use ErrorType::{Failure, NotFound};
         crate::jsc_hooks::ActiveHandle::S3Request(core::ptr::NonNull::new(this).expect("task"))
             .unregister();
         // SAFETY: `this` was produced by `S3HttpSimpleTask::new` (heap::alloc) and ownership is
@@ -314,14 +300,15 @@ impl S3HttpSimpleTask {
         let callback = this.callback.take().expect("delivered once");
 
         if !this.result.is_success() {
-            return this.error_with_body(callback, ErrorType::Failure);
+            return this.with_body_error(Failure, |err| callback.fail(err));
         }
         debug_assert!(this.result.metadata.is_some());
+        let this = &mut *this;
         let response = &this.result.metadata.as_ref().unwrap().response;
         let status = response.status_code;
         match callback {
-            Callback::Stat(callback) => match status {
-                200 => callback(S3StatResult::Success(S3StatSuccess {
+            Callback::Stat(cb) => match status {
+                200 => cb(S3StatResult::Success(S3StatSuccess {
                     etag: response.headers.get(b"etag").unwrap_or(b""),
                     last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
                     content_type: response.headers.get(b"content-type").unwrap_or(b""),
@@ -331,86 +318,88 @@ impl S3HttpSimpleTask {
                         .map(bun_http_types::parse_content_length)
                         .unwrap_or(0),
                 })),
-                404 => this.error_with_body(Callback::Stat(callback), ErrorType::NotFound),
-                _ => this.error_with_body(Callback::Stat(callback), ErrorType::Failure),
+                404 => this.with_body_error(NotFound, |e| cb(S3StatResult::NotFound(e))),
+                _ => this.with_body_error(Failure, |e| cb(S3StatResult::Failure(e))),
             },
-            Callback::Delete(callback) => match status {
-                200 | 204 => callback(S3DeleteResult::Success),
-                404 => this.error_with_body(Callback::Delete(callback), ErrorType::NotFound),
-                _ => this.error_with_body(Callback::Delete(callback), ErrorType::Failure),
+            Callback::Delete(cb) => match status {
+                200 | 204 => cb(S3DeleteResult::Success),
+                404 => this.with_body_error(NotFound, |e| cb(S3DeleteResult::NotFound(e))),
+                _ => this.with_body_error(Failure, |e| cb(S3DeleteResult::Failure(e))),
             },
-            Callback::ListObjects(callback) => match status {
+            Callback::ListObjects(cb) => match status {
+                200 => cb(match list_objects::parse_s3_list_objects_result(
+                    this.response_buffer.list.as_slice(),
+                ) {
+                    Some(listing) => S3ListObjectsResult::Success(Box::new(listing)),
+                    // Half a listing is worse than none: S3 emits keys
+                    // with control characters as (ill-formed) XML
+                    // unless asked to URL-encode them.
+                    None => S3ListObjectsResult::Failure(S3Error {
+                        code: b"InvalidResponse",
+                        message: b"ListObjectsV2 response is not a well-formed <ListBucketResult> document (if keys can contain control characters, pass encodingType: \"url\")",
+                    }),
+                }),
+                404 => this.with_body_error(NotFound, |e| cb(S3ListObjectsResult::NotFound(e))),
+                _ => this.with_body_error(Failure, |e| cb(S3ListObjectsResult::Failure(e))),
+            },
+            Callback::Upload(cb) => match status {
+                200 => cb(S3UploadResult::Success),
+                _ => this.with_body_error(Failure, |e| cb(S3UploadResult::Failure(e))),
+            },
+            Callback::MultipartUpload(upload) => match status {
+                200 => MultiPartUpload::single_send_upload_response(upload, S3UploadResult::Success),
+                _ => this.with_body_error(Failure, |e| {
+                    MultiPartUpload::single_send_upload_response(upload, S3UploadResult::Failure(e))
+                }),
+            },
+            Callback::MultipartRollback(upload) => match status {
                 200 => {
-                    let body = this.response_buffer.list.as_slice();
-                    callback(match list_objects::parse_s3_list_objects_result(body) {
-                        Some(listing) => S3ListObjectsResult::Success(Box::new(listing)),
-                        // Half a listing is worse than none: S3 emits keys
-                        // with control characters as (ill-formed) XML
-                        // unless asked to URL-encode them.
-                        None => S3ListObjectsResult::Failure(S3Error {
-                            code: b"InvalidResponse",
-                            message: b"ListObjectsV2 response is not a well-formed <ListBucketResult> document (if keys can contain control characters, pass encodingType: \"url\")",
-                        }),
-                    })
+                    MultiPartUpload::on_rollback_multi_part_request(upload, S3UploadResult::Success)
                 }
-                404 => this.error_with_body(Callback::ListObjects(callback), ErrorType::NotFound),
-                _ => this.error_with_body(Callback::ListObjects(callback), ErrorType::Failure),
+                _ => this.with_body_error(Failure, |e| {
+                    MultiPartUpload::on_rollback_multi_part_request(upload, S3UploadResult::Failure(e))
+                }),
             },
-            Callback::Upload(_) | Callback::MultipartUpload(_) | Callback::MultipartRollback(_) => {
-                match status {
-                    200 => match callback {
-                        Callback::Upload(callback) => callback(S3UploadResult::Success),
-                        Callback::MultipartUpload(this) => {
-                            MultiPartUpload::single_send_upload_response(
-                                this,
-                                S3UploadResult::Success,
-                            )
-                        }
-                        Callback::MultipartRollback(this) => {
-                            MultiPartUpload::on_rollback_multi_part_request(
-                                this,
-                                S3UploadResult::Success,
-                            )
-                        }
-                        _ => unreachable!(),
-                    },
-                    _ => this.error_with_body(callback, ErrorType::Failure),
-                }
-            }
-            Callback::Download(_) | Callback::MultipartStart(_) => match status {
-                200 | 204 | 206 => {
-                    let body = core::mem::take(&mut this.response_buffer);
-                    let result = S3DownloadResult::Success(S3DownloadSuccess { body });
-                    match callback {
-                        Callback::Download(callback) => callback(result),
-                        Callback::MultipartStart(this) => {
-                            MultiPartUpload::start_multi_part_request_result(this, result)
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-                404 => this.error_with_body(callback, ErrorType::NotFound),
-                _ => this.error_with_body(callback, ErrorType::Failure),
+            Callback::Download(cb) => match status {
+                200 | 204 | 206 => cb(S3DownloadResult::Success(S3DownloadSuccess {
+                    body: core::mem::take(&mut this.response_buffer),
+                })),
+                404 => this.with_body_error(NotFound, |e| cb(S3DownloadResult::NotFound(e))),
+                _ => this.with_body_error(Failure, |e| cb(S3DownloadResult::Failure(e))),
+            },
+            Callback::MultipartStart(upload) => match status {
+                200 | 204 | 206 => MultiPartUpload::start_multi_part_request_result(
+                    upload,
+                    S3DownloadResult::Success(S3DownloadSuccess {
+                        body: core::mem::take(&mut this.response_buffer),
+                    }),
+                ),
+                404 => this.with_body_error(NotFound, |e| {
+                    MultiPartUpload::start_multi_part_request_result(upload, S3DownloadResult::NotFound(e))
+                }),
+                _ => this.with_body_error(Failure, |e| {
+                    MultiPartUpload::start_multi_part_request_result(upload, S3DownloadResult::Failure(e))
+                }),
             },
             // commit multipart upload can fail with status 200
-            Callback::MultipartCommit(upload) => match this
-                .fail_if_contains_error(callback, status)?
-            {
-                Some(_) => {
-                    MultiPartUpload::on_commit_multi_part_request(upload, S3CommitResult::Success)
-                }
-                None => Ok(()),
-            },
-            Callback::MultipartPart(part) => match this.fail_if_contains_error(callback, status)? {
-                Some(callback) => {
-                    let response = &this.result.metadata.as_ref().unwrap().response;
-                    match response.headers.get(b"etag") {
-                        Some(etag) => UploadPart::on_part_response(part, S3PartResult::Etag(etag)),
-                        None => this.error_with_body(callback, ErrorType::Failure),
-                    }
-                }
-                None => Ok(()),
-            },
+            Callback::MultipartCommit(upload) => this.with_ok_body_error(status, |err| {
+                MultiPartUpload::on_commit_multi_part_request(
+                    upload,
+                    match err {
+                        Some(e) => S3CommitResult::Failure(e),
+                        None => S3CommitResult::Success,
+                    },
+                )
+            }),
+            Callback::MultipartPart(part) => this.with_ok_body_error(status, |err| match err {
+                Some(e) => UploadPart::on_part_response(part, S3PartResult::Failure(e)),
+                None => match response.headers.get(b"etag") {
+                    Some(etag) => UploadPart::on_part_response(part, S3PartResult::Etag(etag)),
+                    None => this.with_body_error(Failure, |e| {
+                        UploadPart::on_part_response(part, S3PartResult::Failure(e))
+                    }),
+                },
+            }),
         }
     }
 
@@ -589,10 +578,10 @@ pub(crate) fn execute_simple_s3_request(
     // release; nothing new leaves a VM that is stopping.
     if !VirtualMachine::get().script_allowed() {
         drop(options.range);
-        return callback.fail(
-            b"ERR_S3_VM_SHUTDOWN",
-            b"The JavaScript VM that owns this request is shutting down",
-        );
+        return callback.fail(S3Error {
+            code: b"ERR_S3_VM_SHUTDOWN",
+            message: b"The JavaScript VM that owns this request is shutting down",
+        });
     }
     let result = match this.sign_request::<false>(
         &SignOptions {
@@ -615,7 +604,10 @@ pub(crate) fn execute_simple_s3_request(
             // options.range drops here automatically
             drop(options.range);
             let error_code_and_message = get_sign_error_code_and_message(sign_err.into());
-            return callback.fail(error_code_and_message.code, error_code_and_message.message);
+            return callback.fail(S3Error {
+                code: error_code_and_message.code,
+                message: error_code_and_message.message,
+            });
         }
     };
 

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -121,7 +121,10 @@ pub struct S3HttpSimpleTask {
     pub(crate) sign_result: SignResult,
     pub(crate) headers: Headers,
     /// `None` once delivered.
-    pub callback: Option<Callback>,
+    callback: Option<Callback>,
+    /// Frees this allocation — an `S3HttpSimpleTaskOf<F>` whose `F` only the
+    /// constructor knew.
+    destroy: unsafe fn(*mut S3HttpSimpleTask),
     pub(crate) response_buffer: MutableString,
     pub(crate) result: HTTPClientResult<'static>,
     pub(crate) concurrent_task: ConcurrentTask,
@@ -149,16 +152,18 @@ impl Taskable for S3HttpSimpleTask {
     }
 }
 
-/// How a finished request is delivered. The closure owns whatever it needs
-/// to settle (promise, store ref, …) and runs exactly once. The multipart
-/// state machine's own requests carry its pointer instead (it holds a ref on
-/// itself across each one).
+/// How a finished request is delivered. For the closure kinds the closure is
+/// a field after the task in the same allocation ([`S3HttpSimpleTaskOf`]) and
+/// the fn here is the monomorphized "call that field"; the multipart state
+/// machine's own requests carry its pointer instead (it holds a ref on itself
+/// across each).
+#[derive(Clone, Copy)]
 pub enum Callback {
-    Stat(Box<dyn FnOnce(S3StatResult<'_>) -> bun_jsc::JsResult<()>>),
-    Download(Box<dyn FnOnce(S3DownloadResult<'_>) -> bun_jsc::JsResult<()>>),
-    Upload(Box<dyn FnOnce(S3UploadResult<'_>) -> bun_jsc::JsResult<()>>),
-    Delete(Box<dyn FnOnce(S3DeleteResult<'_>) -> bun_jsc::JsResult<()>>),
-    ListObjects(Box<dyn FnOnce(S3ListObjectsResult<'_>) -> bun_jsc::JsResult<()>>),
+    Stat(fn(*mut S3HttpSimpleTask, S3StatResult<'_>) -> bun_jsc::JsResult<()>),
+    Download(fn(*mut S3HttpSimpleTask, S3DownloadResult<'_>) -> bun_jsc::JsResult<()>),
+    Upload(fn(*mut S3HttpSimpleTask, S3UploadResult<'_>) -> bun_jsc::JsResult<()>),
+    Delete(fn(*mut S3HttpSimpleTask, S3DeleteResult<'_>) -> bun_jsc::JsResult<()>),
+    ListObjects(fn(*mut S3HttpSimpleTask, S3ListObjectsResult<'_>) -> bun_jsc::JsResult<()>),
     /// → [`MultiPartUpload::start_multi_part_request_result`]
     MultipartStart(*mut MultiPartUpload),
     /// → [`MultiPartUpload::single_send_upload_response`]
@@ -171,14 +176,75 @@ pub enum Callback {
     MultipartPart(*mut UploadPart),
 }
 
+/// A task and its completion closure in one allocation.
+#[repr(C)]
+struct S3HttpSimpleTaskOf<F> {
+    task: S3HttpSimpleTask,
+    /// `None` once delivered.
+    on_done: Option<F>,
+}
+
+impl<F> S3HttpSimpleTaskOf<F> {
+    /// The completion closure of the allocation `task` heads.
+    ///
+    /// # Safety
+    /// `task` heads a live `S3HttpSimpleTaskOf<F>` for this `F`.
+    unsafe fn on_done(task: *mut S3HttpSimpleTask) -> F {
+        // SAFETY: fn contract; `repr(C)` puts `task` first.
+        unsafe {
+            (*task.cast::<Self>())
+                .on_done
+                .take()
+                .expect("delivered once")
+        }
+    }
+
+    /// # Safety
+    /// As [`on_done`](Self::on_done); frees the allocation.
+    unsafe fn destroy(task: *mut S3HttpSimpleTask) {
+        // SAFETY: fn contract.
+        drop(unsafe { bun_core::heap::take(task.cast::<Self>()) });
+    }
+}
+
+/// What a request delivers to: the [`Callback`] and, for the closure kinds,
+/// the closure it reaches — paired here so they cannot disagree.
+pub(crate) struct Completion<F> {
+    callback: Callback,
+    on_done: F,
+}
+
+/// `Completion::$ctor(f)`: `Callback::$variant` whose fn takes `f` back out of
+/// the `S3HttpSimpleTaskOf<F>` it was stored in and calls it.
+macro_rules! closure_completion {
+    ($ctor:ident, $variant:ident, $result:ident) => {
+        pub(crate) fn $ctor(on_done: F) -> Self
+        where
+            F: FnOnce($result<'_>) -> bun_jsc::JsResult<()> + 'static,
+        {
+            Completion {
+                callback: Callback::$variant(|task, result| {
+                    // SAFETY: `task` is the live `S3HttpSimpleTaskOf<F>` this
+                    // `Completion` was allocated into (`on_response` contract).
+                    (unsafe { S3HttpSimpleTaskOf::<F>::on_done(task) })(result)
+                }),
+                on_done,
+            }
+        }
+    };
+}
+impl<F> Completion<F> {
+    closure_completion!(stat, Stat, S3StatResult);
+    closure_completion!(download, Download, S3DownloadResult);
+    closure_completion!(upload, Upload, S3UploadResult);
+    closure_completion!(delete, Delete, S3DeleteResult);
+    closure_completion!(list_objects, ListObjects, S3ListObjectsResult);
+}
+
 impl Callback {
-    fn fail(self, err: S3Error<'_>) -> bun_jsc::JsResult<()> {
+    /// Deliver a failure to a multipart callback (which needs no task).
+    pub(crate) fn fail_multipart(self, err: S3Error<'_>) -> bun_jsc::JsResult<()> {
         match self {
-            Callback::Stat(callback) => callback(S3StatResult::Failure(err)),
-            Callback::Download(callback) => callback(S3DownloadResult::Failure(err)),
-            Callback::Upload(callback) => callback(S3UploadResult::Failure(err)),
-            Callback::Delete(callback) => callback(S3DeleteResult::Failure(err)),
-            Callback::ListObjects(callback) => callback(S3ListObjectsResult::Failure(err)),
             Callback::MultipartStart(upload) => MultiPartUpload::start_multi_part_request_result(
                 upload,
                 S3DownloadResult::Failure(err),
@@ -196,6 +262,19 @@ impl Callback {
             Callback::MultipartPart(part) => {
                 UploadPart::on_part_response(part, S3PartResult::Failure(err))
             }
+            _ => unreachable!("closure callbacks fail through their task"),
+        }
+    }
+
+    /// `task`: the live task this callback belongs to, closure not yet taken.
+    fn fail(self, task: *mut S3HttpSimpleTask, err: S3Error<'_>) -> bun_jsc::JsResult<()> {
+        match self {
+            Callback::Stat(deliver) => deliver(task, S3StatResult::Failure(err)),
+            Callback::Download(deliver) => deliver(task, S3DownloadResult::Failure(err)),
+            Callback::Upload(deliver) => deliver(task, S3UploadResult::Failure(err)),
+            Callback::Delete(deliver) => deliver(task, S3DeleteResult::Failure(err)),
+            Callback::ListObjects(deliver) => deliver(task, S3ListObjectsResult::Failure(err)),
+            _ => self.fail_multipart(err),
         }
     }
 }
@@ -208,11 +287,6 @@ enum ErrorType {
 
 impl S3HttpSimpleTask {
     const HOLDS_TICKET: &str = "S3 request on the HTTP thread holds a ticket";
-
-    // bun.TrivialNew(@This()) — heap-allocate; pointer crosses thread boundary via http callback
-    pub(crate) fn new(init: Self) -> *mut Self {
-        bun_core::heap::into_raw(Box::new(init))
-    }
 
     /// The error the transport or the response body carries, handed to
     /// `deliver` while the parsed body is alive.
@@ -283,8 +357,8 @@ impl S3HttpSimpleTask {
     /// this is the task callback from the last task result and is always in the main thread
     ///
     /// # Safety
-    /// `this` must be a live heap pointer produced by `S3HttpSimpleTask::new` whose ownership
-    /// is being transferred to this call (it is reclaimed and dropped here exactly once).
+    /// `this` must be a live heap pointer produced by `execute_simple_s3_request` whose
+    /// ownership is being transferred to this call (it is freed here exactly once).
     //
     // ConcurrentTask dispatch entrypoint (see `runtime::dispatch`): `this` is the raw task
     // pointer the queue hands back, non-null by the `ConcurrentTask::from` contract.
@@ -293,61 +367,81 @@ impl S3HttpSimpleTask {
         use ErrorType::{Failure, NotFound};
         crate::jsc_hooks::ActiveHandle::S3Request(core::ptr::NonNull::new(this).expect("task"))
             .unregister();
-        // SAFETY: `this` was produced by `S3HttpSimpleTask::new` (heap::alloc) and ownership is
-        // reclaimed here exactly once via the ConcurrentTask `AutoDeinit::ManualDeinit` contract;
-        // `this` is dropped at scope exit.
-        let mut this = unsafe { bun_core::heap::take(this) };
+        let _destroy = scopeguard::guard(this, |this| {
+            // SAFETY: fn contract — sole owner; freed through its own `destroy`
+            // when this returns (after the callback, which reads the response
+            // through it).
+            unsafe { ((*this).destroy)(this) }
+        });
+        let task = this;
+        // SAFETY: as above; the deliver fns below only touch the closure slot
+        // that follows `*this`, never `*this` itself.
+        let this = unsafe { &mut *this };
         let callback = this.callback.take().expect("delivered once");
 
         if !this.result.is_success() {
-            return this.with_body_error(Failure, |err| callback.fail(err));
+            return this.with_body_error(Failure, |err| callback.fail(task, err));
         }
         debug_assert!(this.result.metadata.is_some());
-        let this = &mut *this;
         let response = &this.result.metadata.as_ref().unwrap().response;
         let status = response.status_code;
         match callback {
-            Callback::Stat(cb) => match status {
-                200 => cb(S3StatResult::Success(S3StatSuccess {
-                    etag: response.headers.get(b"etag").unwrap_or(b""),
-                    last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
-                    content_type: response.headers.get(b"content-type").unwrap_or(b""),
-                    size: response
-                        .headers
-                        .get(b"content-length")
-                        .map(bun_http_types::parse_content_length)
-                        .unwrap_or(0),
-                })),
-                404 => this.with_body_error(NotFound, |e| cb(S3StatResult::NotFound(e))),
-                _ => this.with_body_error(Failure, |e| cb(S3StatResult::Failure(e))),
-            },
-            Callback::Delete(cb) => match status {
-                200 | 204 => cb(S3DeleteResult::Success),
-                404 => this.with_body_error(NotFound, |e| cb(S3DeleteResult::NotFound(e))),
-                _ => this.with_body_error(Failure, |e| cb(S3DeleteResult::Failure(e))),
-            },
-            Callback::ListObjects(cb) => match status {
-                200 => cb(match list_objects::parse_s3_list_objects_result(
-                    this.response_buffer.list.as_slice(),
-                ) {
-                    Some(listing) => S3ListObjectsResult::Success(Box::new(listing)),
-                    // Half a listing is worse than none: S3 emits keys
-                    // with control characters as (ill-formed) XML
-                    // unless asked to URL-encode them.
-                    None => S3ListObjectsResult::Failure(S3Error {
-                        code: b"InvalidResponse",
-                        message: b"ListObjectsV2 response is not a well-formed <ListBucketResult> document (if keys can contain control characters, pass encodingType: \"url\")",
+            Callback::Stat(deliver) => match status {
+                200 => deliver(
+                    task,
+                    S3StatResult::Success(S3StatSuccess {
+                        etag: response.headers.get(b"etag").unwrap_or(b""),
+                        last_modified: response.headers.get(b"last-modified").unwrap_or(b""),
+                        content_type: response.headers.get(b"content-type").unwrap_or(b""),
+                        size: response
+                            .headers
+                            .get(b"content-length")
+                            .map(bun_http_types::parse_content_length)
+                            .unwrap_or(0),
                     }),
-                }),
-                404 => this.with_body_error(NotFound, |e| cb(S3ListObjectsResult::NotFound(e))),
-                _ => this.with_body_error(Failure, |e| cb(S3ListObjectsResult::Failure(e))),
+                ),
+                404 => this.with_body_error(NotFound, |e| deliver(task, S3StatResult::NotFound(e))),
+                _ => this.with_body_error(Failure, |e| deliver(task, S3StatResult::Failure(e))),
             },
-            Callback::Upload(cb) => match status {
-                200 => cb(S3UploadResult::Success),
-                _ => this.with_body_error(Failure, |e| cb(S3UploadResult::Failure(e))),
+            Callback::Delete(deliver) => match status {
+                200 | 204 => deliver(task, S3DeleteResult::Success),
+                404 => {
+                    this.with_body_error(NotFound, |e| deliver(task, S3DeleteResult::NotFound(e)))
+                }
+                _ => this.with_body_error(Failure, |e| deliver(task, S3DeleteResult::Failure(e))),
+            },
+            Callback::ListObjects(deliver) => match status {
+                200 => {
+                    deliver(
+                        task,
+                        match list_objects::parse_s3_list_objects_result(
+                            this.response_buffer.list.as_slice(),
+                        ) {
+                            Some(listing) => S3ListObjectsResult::Success(Box::new(listing)),
+                            // Half a listing is worse than none: S3 emits keys
+                            // with control characters as (ill-formed) XML
+                            // unless asked to URL-encode them.
+                            None => S3ListObjectsResult::Failure(S3Error {
+                                code: b"InvalidResponse",
+                                message: b"ListObjectsV2 response is not a well-formed <ListBucketResult> document (if keys can contain control characters, pass encodingType: \"url\")",
+                            }),
+                        },
+                    )
+                }
+                404 => this.with_body_error(NotFound, |e| {
+                    deliver(task, S3ListObjectsResult::NotFound(e))
+                }),
+                _ => this
+                    .with_body_error(Failure, |e| deliver(task, S3ListObjectsResult::Failure(e))),
+            },
+            Callback::Upload(deliver) => match status {
+                200 => deliver(task, S3UploadResult::Success),
+                _ => this.with_body_error(Failure, |e| deliver(task, S3UploadResult::Failure(e))),
             },
             Callback::MultipartUpload(upload) => match status {
-                200 => MultiPartUpload::single_send_upload_response(upload, S3UploadResult::Success),
+                200 => {
+                    MultiPartUpload::single_send_upload_response(upload, S3UploadResult::Success)
+                }
                 _ => this.with_body_error(Failure, |e| {
                     MultiPartUpload::single_send_upload_response(upload, S3UploadResult::Failure(e))
                 }),
@@ -357,15 +451,23 @@ impl S3HttpSimpleTask {
                     MultiPartUpload::on_rollback_multi_part_request(upload, S3UploadResult::Success)
                 }
                 _ => this.with_body_error(Failure, |e| {
-                    MultiPartUpload::on_rollback_multi_part_request(upload, S3UploadResult::Failure(e))
+                    MultiPartUpload::on_rollback_multi_part_request(
+                        upload,
+                        S3UploadResult::Failure(e),
+                    )
                 }),
             },
-            Callback::Download(cb) => match status {
-                200 | 204 | 206 => cb(S3DownloadResult::Success(S3DownloadSuccess {
-                    body: core::mem::take(&mut this.response_buffer),
-                })),
-                404 => this.with_body_error(NotFound, |e| cb(S3DownloadResult::NotFound(e))),
-                _ => this.with_body_error(Failure, |e| cb(S3DownloadResult::Failure(e))),
+            Callback::Download(deliver) => match status {
+                200 | 204 | 206 => deliver(
+                    task,
+                    S3DownloadResult::Success(S3DownloadSuccess {
+                        body: core::mem::take(&mut this.response_buffer),
+                    }),
+                ),
+                404 => {
+                    this.with_body_error(NotFound, |e| deliver(task, S3DownloadResult::NotFound(e)))
+                }
+                _ => this.with_body_error(Failure, |e| deliver(task, S3DownloadResult::Failure(e))),
             },
             Callback::MultipartStart(upload) => match status {
                 200 | 204 | 206 => MultiPartUpload::start_multi_part_request_result(
@@ -375,10 +477,16 @@ impl S3HttpSimpleTask {
                     }),
                 ),
                 404 => this.with_body_error(NotFound, |e| {
-                    MultiPartUpload::start_multi_part_request_result(upload, S3DownloadResult::NotFound(e))
+                    MultiPartUpload::start_multi_part_request_result(
+                        upload,
+                        S3DownloadResult::NotFound(e),
+                    )
                 }),
                 _ => this.with_body_error(Failure, |e| {
-                    MultiPartUpload::start_multi_part_request_result(upload, S3DownloadResult::Failure(e))
+                    MultiPartUpload::start_multi_part_request_result(
+                        upload,
+                        S3DownloadResult::Failure(e),
+                    )
                 }),
             },
             // commit multipart upload can fail with status 200
@@ -568,51 +676,59 @@ impl<'a> Default for S3SimpleRequestOptions<'a> {
     }
 }
 
-pub(crate) fn execute_simple_s3_request(
+/// Sign and send `options`; `completion` runs once with the outcome. If the
+/// request cannot be made, hands the closure back with the reason instead.
+pub(crate) fn execute_simple_s3_request<F: 'static>(
     this: &S3Credentials,
     options: S3SimpleRequestOptions<'_>,
-    callback: Callback,
-) -> bun_jsc::JsResult<()> {
+    Completion { callback, on_done }: Completion<F>,
+) -> Result<(), (F, S3Error<'static>)> {
     // A multipart/retry continuation can reach here from teardown's queue
     // release; nothing new leaves a VM that is stopping.
     if !VirtualMachine::get().script_allowed() {
-        drop(options.range);
-        return callback.fail(S3Error {
-            code: b"ERR_S3_VM_SHUTDOWN",
-            message: b"The JavaScript VM that owns this request is shutting down",
-        });
+        return Err((
+            on_done,
+            S3Error {
+                code: b"ERR_S3_VM_SHUTDOWN",
+                message: b"The JavaScript VM that owns this request is shutting down",
+            },
+        ));
     }
-    let result = match this.sign_request::<false>(
-        &SignOptions {
-            path: options.path,
-            method: options.method,
-            search_params: options.search_params,
-            content_disposition: options.content_disposition,
-            content_encoding: options.content_encoding,
-            acl: options.acl,
-            storage_class: options.storage_class,
-            request_payer: options.request_payer,
-            content_hash: None,
-            content_md5: None,
-            content_type: None,
-        },
-        None,
-    ) {
+    let sign_options = SignOptions {
+        path: options.path,
+        method: options.method,
+        search_params: options.search_params,
+        content_disposition: options.content_disposition,
+        content_encoding: options.content_encoding,
+        acl: options.acl,
+        storage_class: options.storage_class,
+        request_payer: options.request_payer,
+        content_hash: None,
+        content_md5: None,
+        content_type: None,
+    };
+    let result = match if options.path.is_empty() {
+        this.sign_request::<true>(&sign_options, None)
+    } else {
+        this.sign_request::<false>(&sign_options, None)
+    } {
         Ok(r) => r,
         Err(sign_err) => {
-            // options.range drops here automatically
-            drop(options.range);
-            let error_code_and_message = get_sign_error_code_and_message(sign_err.into());
-            return callback.fail(S3Error {
-                code: error_code_and_message.code,
-                message: error_code_and_message.message,
-            });
+            let err = get_sign_error_code_and_message(sign_err.into());
+            return Err((
+                on_done,
+                S3Error {
+                    code: err.code,
+                    message: err.message,
+                },
+            ));
         }
     };
 
+    let range = options.range;
     let headers = 'brk: {
         let mut header_buffer = [picohttp::Header::ZERO; SignResult::MAX_HEADERS + 1];
-        if let Some(range_) = &options.range {
+        if let Some(range_) = &range {
             let _headers =
                 result.mix_with_header(&mut header_buffer, picohttp::Header::new(b"range", range_));
             break 'brk Headers::from_pico_http_headers(_headers);
@@ -635,25 +751,54 @@ pub(crate) fn execute_simple_s3_request(
         bun_io::AllocatorType::Js,
     ));
     let proxy = options.proxy_url.unwrap_or(b"");
-    let task_ptr = S3HttpSimpleTask::new(S3HttpSimpleTask {
-        // written below via `MaybeUninit::write` before any read.
-        http: core::mem::MaybeUninit::uninit(),
-        sign_result: result,
-        callback: Some(callback),
-        headers,
-        http_ticket: None,
-        response_buffer: MutableString::default(),
-        result: HTTPClientResult::default(),
-        concurrent_task: ConcurrentTask::default(),
-        proxy_url: if !proxy.is_empty() {
-            Box::<[u8]>::from(proxy)
-        } else {
-            Box::default()
+    let task_ptr: *mut S3HttpSimpleTask = bun_core::heap::into_raw(Box::new(S3HttpSimpleTaskOf {
+        task: S3HttpSimpleTask {
+            // written below via `MaybeUninit::write` before any read.
+            http: core::mem::MaybeUninit::uninit(),
+            sign_result: result,
+            callback: Some(callback),
+            destroy: S3HttpSimpleTaskOf::<F>::destroy,
+            headers,
+            http_ticket: None,
+            response_buffer: MutableString::default(),
+            result: HTTPClientResult::default(),
+            concurrent_task: ConcurrentTask::default(),
+            proxy_url: if !proxy.is_empty() {
+                Box::<[u8]>::from(proxy)
+            } else {
+                Box::default()
+            },
+            body: Box::<[u8]>::from(options.body),
+            poll_ref,
+            signal_store: Default::default(),
         },
-        body: Box::<[u8]>::from(options.body),
-        poll_ref,
-        signal_store: Default::default(),
-    });
+        on_done: Some(on_done),
+    }))
+    .cast();
+    start(task_ptr, options.method);
+    Ok(())
+}
+
+/// [`execute_simple_s3_request`] for the multipart state machine's own
+/// requests: `callback` names the target, there is no closure.
+pub(crate) fn execute_multipart_request(
+    this: &S3Credentials,
+    options: S3SimpleRequestOptions<'_>,
+    callback: Callback,
+) -> bun_jsc::JsResult<()> {
+    execute_simple_s3_request(
+        this,
+        options,
+        Completion {
+            callback,
+            on_done: (),
+        },
+    )
+    .or_else(|((), err)| callback.fail_multipart(err))
+}
+
+/// Hand a freshly built task to the HTTP thread.
+fn start(task_ptr: *mut S3HttpSimpleTask, method: Method) {
     // SAFETY: `task_ptr` is a freshly heap-allocated pointer; shared reads only until
     // the scoped exclusive `http` writes below.
     let task = unsafe { &*task_ptr };
@@ -683,7 +828,7 @@ pub(crate) fn execute_simple_s3_request(
     let verbose = vm.get_verbose_fetch();
     let reject_unauthorized = vm.get_tls_reject_unauthorized();
     let async_http = AsyncHTTP::init(
-        options.method,
+        method,
         url,
         task.headers.entries.clone().expect("OOM"),
         headers_buf,
@@ -721,5 +866,4 @@ pub(crate) fn execute_simple_s3_request(
     crate::jsc_hooks::ActiveHandle::S3Request(core::ptr::NonNull::new(task_ptr).expect("task"))
         .register();
     bun_http::HTTPThread::schedule(batch);
-    Ok(())
 }

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -374,10 +374,11 @@ impl S3HttpSimpleTask {
             unsafe { ((*this).destroy)(this) }
         });
         let task = this;
-        // SAFETY: as above; the deliver fns below only touch the closure slot
-        // that follows `*this`, never `*this` itself.
-        let this = unsafe { &mut *this };
-        let callback = this.callback.take().expect("delivered once");
+        // SAFETY: (here and the two `response_buffer` takes below) sole owner;
+        // the deliver fns only touch the closure slot after `*task`.
+        let callback = unsafe { (*task).callback.take() }.expect("delivered once");
+        // SAFETY: as above.
+        let this = unsafe { &*task };
 
         if !this.result.is_success() {
             return this.with_body_error(Failure, |err| callback.fail(task, err));
@@ -461,7 +462,8 @@ impl S3HttpSimpleTask {
                 200 | 204 | 206 => deliver(
                     task,
                     S3DownloadResult::Success(S3DownloadSuccess {
-                        body: core::mem::take(&mut this.response_buffer),
+                        // SAFETY: as above.
+                        body: core::mem::take(unsafe { &mut (*task).response_buffer }),
                     }),
                 ),
                 404 => {
@@ -473,7 +475,8 @@ impl S3HttpSimpleTask {
                 200 | 204 | 206 => MultiPartUpload::start_multi_part_request_result(
                     upload,
                     S3DownloadResult::Success(S3DownloadSuccess {
-                        body: core::mem::take(&mut this.response_buffer),
+                        // SAFETY: as above.
+                        body: core::mem::take(unsafe { &mut (*task).response_buffer }),
                     }),
                 ),
                 404 => this.with_body_error(NotFound, |e| {

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -958,18 +958,17 @@ impl PipeEvent {
 #[cfg(windows)]
 impl QueuedEvent {
     fn deliver(self) -> bun_jsc::JsResult<()> {
-        let queued = self;
-        if queued.generation != GENERATION.load(Ordering::Relaxed) {
+        if self.generation != GENERATION.load(Ordering::Relaxed) {
             scoped_log!(
                 Chrome,
                 "dropping event from replaced chrome (generation {})",
-                queued.generation
+                self.generation
             );
             return Ok(());
         }
         // SAFETY: plain FFI; onData copies `bytes` before returning.
         unsafe {
-            match queued.event {
+            match self.event {
                 PipeEvent::Data(bytes) => Bun__Chrome__onPipeData(bytes.as_ptr(), bytes.len()),
                 PipeEvent::Closed => Bun__Chrome__onPipeClosed(),
                 PipeEvent::Exited { signo } => Bun__Chrome__died(signo),

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -942,25 +942,23 @@ struct QueuedEvent {
 #[cfg(windows)]
 impl PipeEvent {
     fn post(self, generation: u32) {
-        let queued = bun_core::heap::into_raw(Box::new(QueuedEvent {
+        let queued = QueuedEvent {
             generation,
             event: self,
-        }));
+        };
         // Not dispatched from the read callback: C++ runs JS that may spin a nested event loop (bun:test does), and libuv re-arms the read only after the callback returns.
         VirtualMachine::get()
             .as_mut()
-            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new_owned(
-                queued,
-                QueuedEvent::deliver,
-            ));
+            .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(move || {
+                queued.deliver()
+            }));
     }
 }
 
 #[cfg(windows)]
 impl QueuedEvent {
-    fn deliver(this: *mut QueuedEvent) -> bun_jsc::JsResult<()> {
-        // SAFETY: the box leaked by `post`; ManagedTask hands it over once.
-        let queued = unsafe { bun_core::heap::take(this) };
+    fn deliver(self) -> bun_jsc::JsResult<()> {
+        let queued = self;
         if queued.generation != GENERATION.load(Ordering::Relaxed) {
             scoped_log!(
                 Chrome,

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -934,41 +934,28 @@ enum PipeEvent {
 }
 
 #[cfg(windows)]
-struct QueuedEvent {
-    generation: u32,
-    event: PipeEvent,
-}
-
-#[cfg(windows)]
 impl PipeEvent {
     fn post(self, generation: u32) {
-        let queued = QueuedEvent {
-            generation,
-            event: self,
-        };
         // Not dispatched from the read callback: C++ runs JS that may spin a nested event loop (bun:test does), and libuv re-arms the read only after the callback returns.
         VirtualMachine::get()
             .as_mut()
             .enqueue_task(bun_jsc::ManagedTask::ManagedTask::new(move || {
-                queued.deliver()
+                self.deliver(generation)
             }));
     }
-}
 
-#[cfg(windows)]
-impl QueuedEvent {
-    fn deliver(self) -> bun_jsc::JsResult<()> {
-        if self.generation != GENERATION.load(Ordering::Relaxed) {
+    fn deliver(self, generation: u32) -> bun_jsc::JsResult<()> {
+        if generation != GENERATION.load(Ordering::Relaxed) {
             scoped_log!(
                 Chrome,
                 "dropping event from replaced chrome (generation {})",
-                self.generation
+                generation
             );
             return Ok(());
         }
         // SAFETY: plain FFI; onData copies `bytes` before returning.
         unsafe {
-            match self.event {
+            match self {
                 PipeEvent::Data(bytes) => Bun__Chrome__onPipeData(bytes.as_ptr(), bytes.len()),
                 PipeEvent::Closed => Bun__Chrome__onPipeClosed(),
                 PipeEvent::Exited { signo } => Bun__Chrome__died(signo),

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1236,7 +1236,7 @@ pub mod waiter_thread_posix {
                                     // task and drop the ref its delivery would have released.
                                     // SAFETY: refused ⇒ we own both boxes; `process` is strong-ref'd.
                                     unsafe {
-                                        drop(bun_core::heap::take(ct.as_ptr()));
+                                        ConcurrentTask::release_refused(ct);
                                         drop(bun_core::heap::take(rt));
                                         T::release_ref_from_waiter_thread(process);
                                     }

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -365,7 +365,7 @@ unsafe impl Send for Task {}
 
 impl Default for Task {
     /// Placeholder for fields where the callback is installed later
-    /// (e.g. by [`crate::work_pool::WorkPool::schedule_owned`]). The
+    /// (e.g. by [`ThreadPool::schedule_owned`]). The
     /// `unreachable` callback panics if scheduled un-initialized.
     #[inline]
     fn default() -> Self {

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -653,6 +653,19 @@ impl ThreadPool {
         self.schedule_impl(&batch, false);
     }
 
+    /// Schedule a heap-allocated task by value. The pool takes ownership of
+    /// the `Box`; [`OwnedTask::run`](crate::work_pool::OwnedTask::run)
+    /// receives it back on a worker thread.
+    pub fn schedule_owned<T: crate::work_pool::OwnedTask>(&self, mut task: Box<T>) {
+        task.task_mut().callback = T::__callback;
+        // Derive the intrusive `*mut Task` *after* into_raw so provenance
+        // covers the full allocation.
+        let raw = Box::into_raw(task);
+        // SAFETY: `raw` is a live heap allocation now owned by the pool;
+        // `IntrusiveField::field_of` projects to the embedded `Task`.
+        self.schedule(Batch::from(unsafe { T::field_of(raw) }));
+    }
+
     /// This function should only be called from threads that are part of the thread pool.
     pub fn schedule_inside_thread_pool(&self, batch: Batch) {
         self.schedule_impl(&batch, true);

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -19,7 +19,7 @@ pub struct WorkPool;
 /// `core::mem::offset_of!(Self, <task field>)`.
 pub unsafe trait IntrusiveWorkTask: bun_core::IntrusiveField<Task> {
     /// Safe accessor for the intrusive `task: Task` field
-    /// (`&mut self.task`); [`WorkPool::schedule_owned`] uses this to install
+    /// (`&mut self.task`); [`ThreadPool::schedule_owned`](crate::ThreadPool::schedule_owned) uses this to install
     /// the callback without raw byte-offset arithmetic.
     #[inline]
     fn task_mut(&mut self) -> &mut Task {
@@ -96,7 +96,7 @@ macro_rules! intrusive_work_task {
 
 /// Implements [`OwnedTask`] (and the required `Send`) for a struct that
 /// embeds an intrusive `task: Task` field and is scheduled fire-and-forget
-/// via [`WorkPool::schedule_owned`]. Expands to [`intrusive_work_task!`] +
+/// via [`ThreadPool::schedule_owned`](crate::ThreadPool::schedule_owned). Expands to [`intrusive_work_task!`] +
 /// `unsafe impl Send` + the `run` forward — the implementor supplies only an
 /// inherent `fn run_owned(self: Box<Self>)`.
 ///
@@ -150,8 +150,7 @@ impl WorkPool {
         Self::get().schedule(Batch::from(task));
     }
 
-    /// Schedule a heap-allocated task by value. The pool takes ownership of
-    /// the `Box`; [`OwnedTask::run`] receives it back on a worker thread.
+    /// [`ThreadPool::schedule_owned`] on the global pool.
     pub fn schedule_owned<T: OwnedTask>(task: Box<T>) {
         Self::get().schedule_owned(task);
     }

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -152,20 +152,8 @@ impl WorkPool {
 
     /// Schedule a heap-allocated task by value. The pool takes ownership of
     /// the `Box`; [`OwnedTask::run`] receives it back on a worker thread.
-    /// Replaces the open-coded `Box::into_raw` + `&raw mut (*p).task` +
-    /// `container_of`-in-callback pattern.
-    pub fn schedule_owned<T: OwnedTask>(mut task: Box<T>) {
-        // Install the monomorphized shim via the safe accessor — no raw
-        // byte-offset write. `node` is left as the caller initialized it
-        // (always `Node::default()`).
-        task.task_mut().callback = T::__callback;
-        // The single into_raw for every OwnedTask scheduler call. Derive the
-        // intrusive `*mut Task` *after* into_raw so provenance covers the full
-        // allocation and there is exactly one raw-pointer derivation.
-        let raw = Box::into_raw(task);
-        // SAFETY: `raw` is a live heap allocation now owned by the pool;
-        // `IntrusiveField::field_of` projects to the embedded `Task`.
-        Self::schedule(unsafe { T::field_of(raw) });
+    pub fn schedule_owned<T: OwnedTask>(task: Box<T>) {
+        Self::get().schedule_owned(task);
     }
 
     /// `Box::new` + [`schedule_owned`](Self::schedule_owned). Convenience for

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -39,8 +39,8 @@ pub unsafe trait IntrusiveWorkTask: bun_core::IntrusiveField<Task> {
 }
 
 /// An [`IntrusiveWorkTask`] that the [`WorkPool`] takes ownership of by value
-/// (`Box<Self>`). [`WorkPool::schedule_owned`] performs the `Box` →
-/// raw-pointer hand-off and [`__callback`](OwnedTask::__callback) recovers
+/// (`Box<Self>`). [`ThreadPool::schedule_owned`](crate::ThreadPool::schedule_owned) performs the
+/// `Box` → raw-pointer hand-off and [`__callback`](OwnedTask::__callback) recovers
 /// `Box<Self>` via [`IntrusiveWorkTask::from_task_ptr`], so call sites never
 /// touch `Box::into_raw`/`from_raw` directly.
 ///
@@ -59,7 +59,7 @@ pub unsafe trait OwnedTask: IntrusiveWorkTask + Send + 'static {
     #[doc(hidden)]
     unsafe fn __callback(task: *mut Task) {
         // SAFETY: `task` points to the `Task` field inside a `Box<Self>` that
-        // `WorkPool::schedule_owned` leaked. The thread pool guarantees this
+        // `ThreadPool::schedule_owned` leaked. The thread pool guarantees this
         // callback fires exactly once per scheduled task, so reclaiming the
         // `Box` here is sound.
         let this = unsafe { Box::from_raw(Self::from_task_ptr(task)) };

--- a/test/internal/source-lints/vm-thread-door.inventory.json
+++ b/test/internal/source-lints/vm-thread-door.inventory.json
@@ -246,7 +246,7 @@
     "HTTPThread::schedule": 1
   },
   "src/runtime/webcore/s3/client.rs": {
-    "HTTPThread::schedule": 2
+    "HTTPThread::schedule": 1
   },
   "src/runtime/webcore/s3/simple_request.rs": {
     "HTTPThread::schedule": 1

--- a/test/js/bun/s3/s3-list-objects.test.ts
+++ b/test/js/bun/s3/s3-list-objects.test.ts
@@ -1330,3 +1330,22 @@ it("rejects a large malformed list response (repeated unclosed Key tags) quickly
   // a single 5MB response should be handled in well under 10 seconds.
   expect(elapsed).toBeLessThan(10_000);
 }, 600_000);
+
+it("only list() may address the bucket root; an empty key is rejected before any request", async () => {
+  let requests = 0;
+  using server = createBunServer(async () => {
+    requests++;
+    return new Response("<ListBucketResult></ListBucketResult>", { status: 200 });
+  });
+  const client = new S3Client({ ...options, endpoint: server.url.href });
+  const file = client.file("");
+
+  expect(await file.exists().then(String, e => e.code)).toBe("ERR_S3_INVALID_PATH");
+  expect(await file.unlink().then(String, e => e.code)).toBe("ERR_S3_INVALID_PATH");
+  expect(await file.text().then(String, e => e.code)).toBe("ERR_S3_INVALID_PATH");
+  expect(await file.write("x").then(String, e => e.code)).toBe("ERR_S3_INVALID_PATH");
+  expect(requests).toBe(0);
+
+  await client.list();
+  expect(requests).toBe(1);
+});


### PR DESCRIPTION
### What does this PR do?

Several "run this later with that context" carriers held their payload as `(fn(*mut c_void), *mut c_void)`, so every producer wrote `heap::into_raw(Box::new(ctx))` and every consumer `unsafe { heap::take(ctx.cast()) }`, and a payload whose task never ran (VM teardown, refused cross-thread post) simply leaked. This makes those carriers own their payload, so producing one is a `move` closure and dropping one unrun frees what it captured. No behaviour change otherwise; allocation counts per path are the same as or lower than on main.

- **`ManagedTask::new(FnOnce)`** / **`ConcurrentTask::from_callback(FnOnce)`**: the closure is stored inline behind a two-fn header (one allocation), consumed by `run`, dropped by `release_unrun`/`release_refused`. Replaces `new`/`new_owned(*mut T, fn(*mut T))` and the fn-pointer ABI cast. Fixes leak-if-unrun for valkey `DeferredFailure`, `HandledPromiseContext`, and cares `reject_later` (whose `is_shutting_down` workaround goes away).
- Refused posts release their carrier through `ConcurrentTask::release_refused` everywhere.
- **`ThreadPool::schedule_owned(Box<T>)`** (WorkPool forwards to it); install's `UninstallTask`, manifest `SaveTask` and the Windows hardlink queue use `owned_task!` instead of `into_raw` + `from_field_ptr` + `heap::take` in the callback.
- **S3 requests**: the caller's completion closure is a field of the request task's allocation (`S3HttpSimpleTaskOf<F> { task, on_done }`), reached through a typed fn in `Callback` — no `Box<dyn>`, no `callback_context`. `stat`/`download`/`download_slice`/`delete`/`list_objects`/`upload` and `upload_stream` take closures, and every caller's leaked `Wrapper` + thunk becomes a `move` closure (`Store` unlink/list, `Blob` uploads and S3 reads, `S3File` stat/size/exists, fetch's S3 upload, the server's S3 content-length stat — which now owns its `RequestContextRef` guard). The multipart state machine's own requests use typed `Multipart*` variants carrying its pointer. `client::list_objects` goes through the shared request setup instead of a copy of it.
- **`WriteFile`** owns its `WriteFilePromise`; `create<C>`/`create_with_ctx` and `WriteFileOnWriteFileCallback` are gone.
- **`Blob::read_bytes_to_handler`** takes an `FnOnce`; `InternalReadFileFn`/`NewInternalReadFileHandler`/`do_read_file_internal` are gone.

**Bugs fixed** (teardown-only; nothing a running program observes): when a VM tears down with one of these queued but not yet run, main leaked the payload and the branch drops it — valkey `DeferredFailure` (message + in-flight command queue), c-ares `ErrorDeferred` (hostname + promise handle; its `is_shutting_down()` early return existed only to dodge that leak and is removed), `HandledPromiseContext`, the FetchTasklet request-body-drain ref, the HTMLRewriter background-pull ref + `protect()`, and a `WriteFile` job's promise handle. All other behaviour is identical to main.

Deliberately untouched (different shape — multi-shot, refcounted context, or FFI userdata): `MultiPartUpload.callback/on_writable`, `S3HttpDownloadStreamingTask.callback`, `HTTPClientResultCallback`, `PendingValue.task`, `ReadFileCompletionFns`, the bundler's `parse_task::Result` hop, shell WorkPool tasks.

### How did you verify your code works?

`cargo check`/clippy for linux + windows targets. Debug build + the suites that exercise each carrier: `bun test` itself (RunTestsTask), dns/cares failure paths, valkey connection failures, bundler plugins (resolve/load/defer hops), fetch streaming bodies, `Bun.serve` (deinit task) + serve-file, html-rewriter, `bun install`, the local-server S3 suites (list-objects, storage-class, requester-pays, insecure, connection-close, stream-cancel-leak, fd-validation, checksum), `Bun.write`/blob/`Bun.file`, `Bun.Image` from blobs — all pass.
