### PR TITLE
bun:test: setSystemTime reset moves performance.timeOrigin back to real

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1411,6 +1411,8 @@ extern "C" void Bun__FakeTimers__setSystemTime(JSC::JSGlobalObject* globalObject
 
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue argument0 = callframe->argument(0);
 
     // JSGlobalObject::overridenDateNow's "no override" sentinel is NaN (see
@@ -1421,6 +1423,9 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalO
         ms = dateInstance->internalNumber();
     } else {
         ms = argument0.isNumber() ? argument0.asNumber() : PNaN;
+    }
+    if (std::isinf(ms)) {
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "setSystemTime() expects a finite number or a Date"_s);
     }
     globalObject->overridenDateNow = ms;
     // Rebase the Rust-side fake-timers offset so advanceTimersByTime ticks

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -98,21 +98,26 @@ impl CurrentTime {
 /// the next `advanceTimersByTime` recomputes `Date.now` from the set time
 /// instead of the stale activation-time offset. `performance.now()` does not
 /// move, so `performance.timeOrigin` follows the rebased offset. No-op when
-/// fake timers are inactive or `ms` is NaN (the "clear override" sentinel).
+/// fake timers are inactive. A NaN `ms` is the "clear override" sentinel:
+/// `Date.now()` is real again until the next tick, so the mocked wall clock
+/// and `performance.timeOrigin` go back to real as well.
 #[unsafe(no_mangle)]
 extern "C" fn Bun__FakeTimers__setSystemTime(global: &JSGlobalObject, ms: f64) {
-    if ms.is_nan() {
-        return;
-    }
     let Some(current) = CURRENT_TIME.get_timespec_now() else {
         return;
     };
+    let vm = global.bun_vm().as_mut();
+    if ms.is_nan() {
+        bun_core::mock_time::clear_wall();
+        vm.overridden_time_origin = None;
+        return;
+    }
     let date_now_offset = ms - current.ms() as f64;
     CURRENT_TIME
         .date_now_offset
         .store(date_now_offset.to_bits(), Ordering::Relaxed);
     bun_core::mock_time::set_wall_ms(ms);
-    global.bun_vm().as_mut().overridden_time_origin = Some(date_now_offset);
+    vm.overridden_time_origin = Some(date_now_offset);
 }
 
 use crate::jsc_hooks::timer_all;

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -641,6 +641,40 @@ describe("performance.now() mocking", () => {
     expect(performance.timeOrigin).toBe(realTimeOrigin);
     setSystemTime();
   });
+
+  // setSystemTime() with no argument, NaN, or an Invalid Date resets Date.now()
+  // to the real clock. The origin goes back to real with it.
+  test.each([undefined, NaN, new Date(NaN)])(
+    "setSystemTime(%p) under fake timers resets performance.timeOrigin too",
+    reset => {
+      const realTimeOrigin = performance.timeOrigin;
+      const realBefore = Date.now();
+      vi.useFakeTimers({ now: 5000 });
+      expect(performance.timeOrigin).toBe(5000);
+
+      setSystemTime(reset);
+      expect(Date.now()).toBeGreaterThanOrEqual(realBefore);
+      expect(performance.timeOrigin).toBe(realTimeOrigin);
+      expect(performance.toJSON().timeOrigin).toBe(realTimeOrigin);
+
+      // The next tick of the fake clock overrides Date.now() again, and the origin follows it.
+      vi.advanceTimersByTime(1000);
+      expect(Date.now()).toBe(6000);
+      expect(performance.timeOrigin).toBe(5000);
+      expect(performance.timeOrigin + performance.now()).toBe(Date.now());
+    },
+  );
+
+  test.each([Infinity, -Infinity])("setSystemTime(%p) throws and leaves the clocks alone", ms => {
+    const realBefore = Date.now();
+    expect(() => setSystemTime(ms)).toThrow("setSystemTime() expects a finite number or a Date");
+    expect(Date.now()).toBeGreaterThanOrEqual(realBefore);
+
+    vi.useFakeTimers({ now: 5000 });
+    expect(() => setSystemTime(ms)).toThrow("setSystemTime() expects a finite number or a Date");
+    expect(Date.now()).toBe(5000);
+    expect(performance.timeOrigin).toBe(5000);
+  });
 });
 
 describe("useFakeTimers with options", () => {


### PR DESCRIPTION
### Problem
- Under `jest.useFakeTimers({ now: 5000 })`, `jest.setSystemTime()` (or `NaN`, or an Invalid Date) resets `Date.now()` to the real clock, as documented. `performance.timeOrigin` stays at 5000. `timeOrigin + performance.now()` is then about 1.79e12 ms behind `Date.now()`. 1.4.0 kept the real origin here.
- The cause is the reset branch of `Bun__FakeTimers__setSystemTime` (`src/runtime/test_runner/timers/FakeTimers.rs:104`). It returned on `NaN` before it could clear `vm.overridden_time_origin`, which #40104 added so that the origin follows the fake clock. The mocked wall clock (`bun_core::mock_time`) stayed fake too.
- `setSystemTime(Infinity)` and `setSystemTime(-Infinity)` set `Date.now()` to `Infinity` and, since #40104, `timeOrigin` too. `useFakeTimers({ now: Infinity })` throws since #40414.

### Fix
- The reset branch now clears `overridden_time_origin` and the mocked wall clock. `Date.now()`, `performance.timeOrigin` and the cron wall clock go back to real together. The next tick of the fake clock (`advanceTimersByTime`) overrides all of them again from the kept `date_now_offset`, as before.
- `JSMock__jsSetSystemTime` (`src/jsc/bindings/JSMockFunction.cpp`) throws `ERR_INVALID_ARG_TYPE` for an infinite time: `setSystemTime() expects a finite number or a Date`. `NaN` and an Invalid Date keep their documented reset meaning.
- Correct because `timeOrigin` is the wall-clock time at which `performance.now()` reads 0. When `Date.now()` leaves the fake clock, the fake origin has no meaning and the real one is what `useRealTimers()` gives. An infinite clock has no meaning at all: `new Date()` is invalid.
- Verified: `test/js/bun/test/fake-timers/fake-timers.test.ts` (five new cases, all fail on main). Also `test/js/bun/test/test-timers.test.ts`, `test/js/web/timers/performance.test.js`, `test/js/node/perf_hooks/perf_hooks.test.ts`, `test/regression/issue/32793.test.ts` and `test/js/bun/cron/`.

### Background
- The bun:test fake clock keeps one fake monotonic `Timespec` (`CURRENT_TIME`) and one `date_now_offset` that maps it to the fake `Date.now()`. `setSystemTime(ms)` under fake timers rebases the offset and sets `overridden_time_origin` to it.
- `JSGlobalObject::overridenDateNow` is a `double`. `jsDateNow()` returns the real time when it is `NaN`. `setSystemTime()` with no argument writes `NaN` there. That is the documented reset.
- `bun_core::mock_time` mirrors the fake clock for Rust consumers. The wall half (`set_wall_ms`) feeds `Bun.cron`, so calendar schedules and `Date.now()` move together.

<details><summary>Notes</summary>

Repro on main (debug build):

```ts
import { test, jest } from "bun:test";
test("stale timeOrigin", () => {
  jest.useFakeTimers({ now: 5000 });
  jest.setSystemTime();
  console.log(Date.now());              // real wall clock
  console.log(performance.timeOrigin);  // 5000
  jest.setSystemTime(Infinity);
  console.log(Date.now());              // Infinity
  console.log(performance.timeOrigin);  // Infinity
  jest.useRealTimers();
});
```

The reset is temporary by design: `advanceTimersByTime` calls `CurrentTime::set(.., None)`, which recomputes `Date.now()` from the kept `date_now_offset` and sets the origin again. The new test asserts that too, so the two clocks agree in both states.

`setSystemTime("2020")` and `setSystemTime(null)` also reset (a non-number non-Date is `NaN` in the C++ parse). That is pre-existing and this PR does not change it.

Related open PR: #39305 also edits `JSMock__jsSetSystemTime` (Temporal.Now). The two changes are independent and rebase onto each other mechanically.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/fake-timers/fake-timers.test.ts
bun test v1.4.1 (861e9ae04)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [23.62ms]
(pass) advanceTimersToNextTimer > one setTimeout [7.24ms]
(pass) advanceTimersToNextTimer > setInterval [6.84ms]
(pass) advanceTimersToNextTimer > sorted timeouts [10.96ms]
(pass) advanceTimersToNextTimer > alternating intervals [8.37ms]
(pass) advanceTimersByTime > setInterval [5.99ms]
(pass) advanceTimersByTime > advanceTimersByTime(NaN) throws and does not move the clock [5.11ms]
(pass) advanceTimersByTime > advanceTimersByTime(-1) throws and does not move the clock [1.71ms]
(pass) advanceTimersByTime > advanceTimersByTime(Infinity) throws and does not move the clock [0.93ms]
(pass) advanceTimersByTime > advanceTimersByTime(4294967296) throws and does not move the clock [1.29ms]
(pass) runOnlyPendingTimers > two setIntervals [7.09ms]
(pass) runAllTimers > two setIntervals [7.98ms]
(pass) getTimerCount > returns correct count of pending timers [6.77ms]
(pass) getTimerCount > thro
... (truncated)

release without fix: 11 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [10.37ms]
(pass) advanceTimersToNextTimer > one setTimeout [0.11ms]
(pass) advanceTimersToNextTimer > setInterval [0.09ms]
(pass) advanceTimersToNextTimer > sorted timeouts [0.11ms]
(pass) advanceTimersToNextTimer > alternating intervals [0.08ms]
(pass) advanceTimersByTime > setInterval [0.07ms]
134 |     vi.useRealTimers();
135 |   });
136 | 
137 |   test.each([NaN, -1, Infinity, 2 ** 32])("advanceTimersByTime(%p) throws and does not move the clock", ms => {
138 |     vi.useFakeTimers({ now: 1000 });
139 |     expect(() => vi.advanceTimersByTime(ms)).toThrow("ms is out of range. It must be >= 0 and <= 4294967295");
                                                   ^
error: expect(received).toThrow(expected)

Expected substring: "ms is out of range. It must be >= 0 and <= 4294967295"

Received function did not throw
Received value: {
  fn: [Function: fn],
  mock: [Function: module],
  spyOn: [Function: spyOn],
  restoreAllMocks: [Function: restoreAllMocks],
  resetAllMocks: [Function: resetAllMocks],
  clearAllMocks: [Function: clearAllMocks],
  useFakeTimers:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/fake-timers/fake-timers.test.ts
bun test v1.4.1 (861e9ae04)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [23.94ms]
(pass) advanceTimersToNextTimer > one setTimeout [7.18ms]
(pass) advanceTimersToNextTimer > setInterval [7.10ms]
(pass) advanceTimersToNextTimer > sorted timeouts [10.96ms]
(pass) advanceTimersToNextTimer > alternating intervals [8.31ms]
(pass) advanceTimersByTime > setInterval [5.93ms]
(pass) advanceTimersByTime > advanceTimersByTime(NaN) throws and does not move the clock [5.05ms]
(pass) advanceTimersByTime > advanceTimersByTime(-1) throws and does not move the clock [1.70ms]
(pass) advanceTimersByTime > advanceTimersByTime(Infinity) throws and does not move the clock [0.89ms]
(pass) advanceTimersByTime > advanceTimersByTime(4294967296) throws and does not move the clock [0.93ms]
(pass) runOnlyPendingTimers > two setIntervals [7.00ms]
(pass) runAllTimers > two setIntervals [7.89ms]
(pass) getTimerCount > returns correct count of pending timers [6.48ms]
(pass) getTimerCount > thro
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 674ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 116 exports (host=5, lazy=10, generic=101, rust=0); 242 extern-C blocks audited
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 09s
[4/7] link bun-profile
[6/7] strip bun
[6/7] bun-profile --revision
1.4.1-canary.1+8b32082fc
[build] done
bun test v1.4.1-canary.1 (8b32082fc)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [10.34ms]
(pass) advanceTimersToNextTimer > one setTimeout [0.14ms]
(pass) advanceTimersToNextTimer > setInterval [0.16ms]
(pass) advanceTimersToNextTimer > sorted timeouts [0.13ms]
(pass) advanceTimersToNextTimer > alternating in
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSMockFunction.cpp              |  5 ++++
 src/runtime/test_runner/timers/FakeTimers.rs     | 15 +++++++----
 test/js/bun/test/fake-timers/fake-timers.test.ts | 34 ++++++++++++++++++++++++
 3 files changed, 49 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/jsc/bindings/JSMockFunction.cpp                   2      1      0
src/runtime/test_runner/timers/FakeTimers.rs          3      5      0
test/js/bun/test/fake-timers/fake-timers.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->