### PR TITLE
Fix --bytecode builds aborting when a function record lands on an encoder page boundary

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "1cb96a7b0edd24a18927c4c05007b0649abda4f4";
+export const WEBKIT_VERSION = "76882271d74a6e7f5ca09db301d64302b1f4cd67";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -254,6 +254,7 @@ impl<C: CompletionStruct> BundleThread<C> {
             }
 
             if has_bundled {
+                crate::bundle_v2::dispatch::__bun_jsc_destroy_bytecode_cache_vm();
                 bun_alloc::mimalloc::mi_collect(false);
                 has_bundled = false;
             }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1425,6 +1425,7 @@ pub mod bv2_impl {
             ) -> Vec<(u32, Box<[u8]>)>;
 
             safe fn __bun_jsc_encoder_string_table_new() -> core::ptr::NonNull<EncoderStringTable>;
+            pub(crate) safe fn __bun_jsc_destroy_bytecode_cache_vm();
             safe fn __bun_jsc_encoder_string_table_take(
                 table: core::ptr::NonNull<EncoderStringTable>,
             ) -> Box<[u8]>;

--- a/src/jsc/CachedBytecode.rs
+++ b/src/jsc/CachedBytecode.rs
@@ -165,6 +165,15 @@ pub(crate) fn __bun_jsc_generate_cached_bytecode(
     Some(owned)
 }
 
+/// Frees the calling thread's bytecode-generation VM, if it made one.
+#[unsafe(no_mangle)]
+pub(crate) fn __bun_jsc_destroy_bytecode_cache_vm() {
+    unsafe extern "C" {
+        safe fn Bun__destroyBytecodeCacheVM();
+    }
+    Bun__destroyBytecodeCacheVM()
+}
+
 /// Serialize the shared string table into an owned buffer for the standalone graph, then free the table.
 #[unsafe(no_mangle)]
 pub(crate) fn __bun_jsc_encoder_string_table_take(table: NonNull<EncoderStringTable>) -> Box<[u8]> {

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -243,6 +243,7 @@ JSC_DEFINE_HOST_FUNCTION(InternalModuleRegistry::jsCreateInternalModuleById, (JS
 
 namespace Zig {
 JSC::VM& vmForBytecodeCache();
+void ensureBuiltinNamesForBytecodeCache(JSC::VM&);
 }
 
 // bun build --compile: bytecode for internal JS module `id` (an index below BUN_NATIVE_MODULE_START_INDEX), generated the
@@ -256,10 +257,7 @@ extern "C" bool Bun__generateInternalModuleBytecode(uint32_t id, uint32_t depth,
     const InternalJSModule& m = internalJSModules[id];
     JSC::VM& vm = Zig::vmForBytecodeCache();
     JSC::JSLockHolder locker(vm);
-    // The builtins parse with private @names; register Bun's on this throwaway VM (its own VM gets them from JSVMClientData).
-    static thread_local std::unique_ptr<BunBuiltinNames> builtinNames;
-    if (!vm.clientData && !builtinNames)
-        builtinNames = BunBuiltinNames::createStandalone(vm);
+    Zig::ensureBuiltinNamesForBytecodeCache(vm);
     String text = INTERNAL_MODULE_SOURCE(m);
     SourceCode source = makeInternalModuleSource(text, m.moduleId, m.url);
     UnlinkedFunctionExecutable* executable = createInternalModuleExecutable(vm, source, m.moduleId);

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -16,6 +16,7 @@
 #include <JavaScriptCore/SourceCodeKey.h>
 #include <mimalloc.h>
 #include <JavaScriptCore/CodeCache.h>
+#include "BunBuiltinNames.h"
 
 namespace Zig {
 
@@ -171,6 +172,8 @@ extern "C" void CachedBytecode__deref(JSC::CachedBytecode* cachedBytecode)
 
 JSC::VM& vmForBytecodeCache();
 static thread_local JSC::VM* s_vmForBytecodeCache = nullptr;
+// The builtins parse with private @names; this VM has no JSVMClientData to register Bun's, so it owns them directly.
+static thread_local std::unique_ptr<WebCore::BunBuiltinNames> s_builtinNamesForBytecodeCache;
 
 JSC::VM& vmForBytecodeCache()
 {
@@ -184,12 +187,20 @@ JSC::VM& vmForBytecodeCache()
     return *s_vmForBytecodeCache;
 }
 
+void ensureBuiltinNamesForBytecodeCache(JSC::VM& vm)
+{
+    ASSERT(&vm == s_vmForBytecodeCache);
+    if (!s_builtinNamesForBytecodeCache)
+        s_builtinNamesForBytecodeCache = WebCore::BunBuiltinNames::createStandalone(vm);
+}
+
 extern "C" void Bun__destroyBytecodeCacheVM()
 {
     JSC::VM* vm = std::exchange(s_vmForBytecodeCache, nullptr);
     if (!vm)
         return;
     JSC::JSLockHolder locker(*vm);
+    s_builtinNamesForBytecodeCache = nullptr;
     vm->derefSuppressingSaferCPPChecking();
 }
 

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -170,17 +170,27 @@ extern "C" void CachedBytecode__deref(JSC::CachedBytecode* cachedBytecode)
 }
 
 JSC::VM& vmForBytecodeCache();
+static thread_local JSC::VM* s_vmForBytecodeCache = nullptr;
+
 JSC::VM& vmForBytecodeCache()
 {
-    static thread_local JSC::VM* vmForBytecodeCache = nullptr;
-    if (!vmForBytecodeCache) {
+    if (!s_vmForBytecodeCache) {
         const auto heapSize = JSC::HeapType::Small;
         auto vmPtr = JSC::VM::tryCreate(heapSize);
         vmPtr->refSuppressingSaferCPPChecking();
-        vmForBytecodeCache = vmPtr.get();
+        s_vmForBytecodeCache = vmPtr.get();
         vmPtr->heap.acquireAccess();
     }
-    return *vmForBytecodeCache;
+    return *s_vmForBytecodeCache;
+}
+
+extern "C" void Bun__destroyBytecodeCacheVM()
+{
+    JSC::VM* vm = std::exchange(s_vmForBytecodeCache, nullptr);
+    if (!vm)
+        return;
+    JSC::JSLockHolder locker(*vm);
+    vm->derefSuppressingSaferCPPChecking();
 }
 
 extern "C" JSC::EncoderStringTable* Bun__EncoderStringTable__create()

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -7,6 +7,7 @@ import {
   bunRun,
   isASAN,
   isDebug,
+  isMacOS,
   isWindows,
   tempDir,
   tempDirWithFiles,
@@ -240,10 +241,11 @@ describe("Bun.build", () => {
         console.log(JSON.stringify({ base, after }));
       `,
     });
-    // Release, 20k functions: ~+65 MB without freeing the VM, about level with the baseline with it. Debug/ASAN parse far
-    // slower and hold freed pages in quarantine, so they get a smaller module and only guard against gross retention.
+    // Linux/Windows release, 20k functions: ~+65 MB without freeing the VM, about level with the baseline with it.
+    // Debug/ASAN parse far slower and hold freed pages in quarantine, so they get a smaller module and only guard against
+    // gross retention. macOS reports +230-280 MB here even with the VM freed (the pages leave RSS lazily), so same there.
     const slow = isASAN || isDebug;
-    const [functions, limit] = slow ? [3000, 400] : [20000, 40];
+    const [functions, limit] = slow ? [3000, 400] : [20000, isMacOS ? 400 : 40];
     await using proc = Bun.spawn({
       cmd: [bunExe(), "retained-fixture.ts", String(functions), String(limit)],
       env: bunEnv,

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -216,7 +216,7 @@ describe("Bun.build", () => {
         expect(exitCode).toBe(0);
       }),
     );
-  }, 60_000);
+  });
 
   test("bytecode: repeated builds don't retain the generated code", async () => {
     using dir = tempDir("bun-build-api-bytecode-retained", {
@@ -238,7 +238,6 @@ describe("Bun.build", () => {
         let after = rss();
         while ((Bun.gc(true), (after = rss())) - base > limit && Date.now() < deadline) await Bun.sleep(20);
         console.log(JSON.stringify({ base, after }));
-        if (after - base > limit) process.exit(1);
       `,
     });
     // Release, 20k functions: ~+65 MB without freeing the VM, about level with the baseline with it. Debug/ASAN parse far
@@ -253,10 +252,11 @@ describe("Bun.build", () => {
       stderr: "inherit",
     });
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    const { base, after } = JSON.parse(stdout.trim());
-    expect(after - base).toBeLessThanOrEqual(limit);
+    expect(stdout).toStartWith("{");
     expect(exitCode).toBe(0);
-  }, 60_000);
+    const { base, after } = JSON.parse(stdout);
+    expect(after - base).toBeLessThanOrEqual(limit);
+  });
 
   test("passing undefined doesnt segfault", () => {
     try {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -177,6 +177,47 @@ describe("Bun.build", () => {
     expect(exitCode).toBe(1);
   });
 
+  // A function's record stores its own offset as a varint, so its size depends on where it lands. Sweep the payload
+  // size across the encoder's first page boundary (64 KB) with a few tail shapes so a record lands exactly on it.
+  test("bytecode: function record on an encoder page boundary", async () => {
+    using dir = tempDir("bun-build-api-bytecode-page-boundary", {
+      "sweep-fixture.ts": /* ts */ `
+        import { writeFileSync } from "fs";
+        const variant = Number(process.argv[2]);
+        const params = variant & 1 ? Array.from({ length: 130 }, (_, i) => "a" + i).join(",") : "";
+        const consts = variant & 2 ? "var c = " + Array.from({ length: 130 }, (_, i) => i + ".5").join("+") + ";" : "";
+        async function bytecodeSize(n: number) {
+          const file = "in" + variant + ".js";
+          writeFileSync(file, 'function p(){ return "' + Buffer.alloc(n, "p").toString() + '"; }\\n'
+            + "function t(" + params + "){ " + consts + ' return "' + Buffer.alloc(200, "t").toString() + '"; }\\n'
+            + "module.exports = [p, t];\\n");
+          const build = await Bun.build({ entrypoints: ["./" + file], outdir: "./out" + variant, target: "bun", format: "cjs", bytecode: true });
+          if (!build.success) throw new AggregateError(build.logs);
+          return build.outputs.find(o => o.kind === "bytecode")!.size;
+        }
+        const pageEnd = 64 * 1024;
+        const n0 = 60000;
+        const target = n0 + (pageEnd - (await bytecodeSize(n0)));
+        for (let n = target - 24; n < target + 104; n++) await bytecodeSize(n);
+        console.log("ok");
+      `,
+    });
+    await Promise.all(
+      [0, 1, 2, 3].map(async variant => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "sweep-fixture.ts", String(variant)],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "inherit",
+        });
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        expect(stdout).toBe("ok\n");
+        expect(exitCode).toBe(0);
+      }),
+    );
+  });
+
   test("passing undefined doesnt segfault", () => {
     try {
       // @ts-ignore

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -216,7 +216,47 @@ describe("Bun.build", () => {
         expect(exitCode).toBe(0);
       }),
     );
-  });
+  }, 60_000);
+
+  test("bytecode: repeated builds don't retain the generated code", async () => {
+    using dir = tempDir("bun-build-api-bytecode-retained", {
+      "retained-fixture.ts": /* ts */ `
+        import { writeFileSync } from "fs";
+        const [functions, limit] = process.argv.slice(2).map(Number);
+        let source = "";
+        for (let i = 0; i < functions; i++)
+          source += "export function f" + i + "(a, b) { if (a > " + i + ") { return a * b + " + i + "; } for (let j = 0; j < b; j++) a += j ^ " + i + '; return { a, b, name: "f' + i + '" }; }\\n';
+        writeFileSync("in.js", source);
+        const build = (bytecode: boolean) => Bun.build({ entrypoints: ["./in.js"], outdir: "./out", target: "bun", format: "cjs", bytecode });
+        const rss = () => Math.round(process.memoryUsage.rss() / 1024 / 1024);
+        if (!(await build(false)).success) throw new Error("build failed");
+        Bun.gc(true);
+        const base = rss();
+        for (let i = 0; i < 3; i++) if (!(await build(true)).success) throw new Error("build failed");
+        // The bundle thread frees its bytecode VM once it goes idle.
+        const deadline = Date.now() + 5000;
+        let after = rss();
+        while ((Bun.gc(true), (after = rss())) - base > limit && Date.now() < deadline) await Bun.sleep(20);
+        console.log(JSON.stringify({ base, after }));
+        if (after - base > limit) process.exit(1);
+      `,
+    });
+    // Release, 20k functions: ~+65 MB without freeing the VM, about level with the baseline with it. Debug/ASAN parse far
+    // slower and hold freed pages in quarantine, so they get a smaller module and only guard against gross retention.
+    const slow = isASAN || isDebug;
+    const [functions, limit] = slow ? [3000, 400] : [20000, 40];
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "retained-fixture.ts", String(functions), String(limit)],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const { base, after } = JSON.parse(stdout.trim());
+    expect(after - base).toBeLessThanOrEqual(limit);
+    expect(exitCode).toBe(0);
+  }, 60_000);
 
   test("passing undefined doesnt segfault", () => {
     try {


### PR DESCRIPTION
### What was happening

`bun build --bytecode` (and `Bun.build({ bytecode: true })`) could abort with

```
CachedPtr<CachedFunctionCodeBlock, UnlinkedFunctionCodeBlock>::encode
encode (CachedTypes.cpp:1387)
JSC::Encoder::encodeDeferred
JSC::encodeCodeBlock
generateCachedModuleByteCodeFromSourceCode
```

The assertion is `RELEASE_ASSERT(result.offset() - regionStart == layout.recordOffsetInRegion)` in `CachedCodeBlock::create()`. A code block's record stores its own offset within its region as a varint in the packed tail, and the tail has to be packed before the record is allocated. `create()` sized the allocation from a probe tail whose offset was still `0` (1 byte), then wrote the real offset (2–5 bytes), so the real record was 1–4 bytes larger than what was used to predict where it would land. Whenever the probe exactly fit the end of the current encoder page and the real record did not, `Encoder::malloc` moved to a new page and the assert fired. Every function record near a page boundary rolls those dice, so large builds hit it intermittently; it is not size/overflow related.

### Fix

WebKit `76882271d74a` (oven-sh/WebKit main): `Encoder::mallocPlaced(alignment, sizeAt)` asks for the size at the current aligned offset and, only if that doesn't fit, once more at the (max-aligned, so known) base of a fresh page. `create()` packs its tail inside that callback, so the offset is exact — no prediction, no extra payload bytes. `predictOffset()`/`Page::canMalloc()` are gone.

Also in this PR: the bundle thread's bytecode-generation VM is destroyed when the thread goes idle. Previously every link's `UnlinkedCodeBlock` trees and source copies stayed alive in that VM until it happened to collect; on 6×typescript.js (53 MB source) repeated `Bun.build({bytecode:true})` retained ~1.0 GB RSS vs ~640 MB without bytecode.

### Test

`test/bundler/bun-build-api.test.ts` — "bytecode: function record on an encoder page boundary": sweeps a function record across the encoder's first (64 KB) page boundary with four tail shapes. Aborts on WebKit `1cb96a7b` (variants 1 and 3, every alignment shift), passes with the fix. Also verified: the original random-shape fuzz (≈1 abort per 1.3k builds before) runs 6.4k builds clean, and 400 JSC stress tests round-trip through the disk cache with no cache-specific failures.

CI will be red until the WebKit autobuild for `76882271d74a` is published.