### PR TITLE
Fix Bun.spawnSync + GC unbalancing the event loop's keep-alive count

### DIFF
--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -99,8 +99,8 @@ pub struct SpawnSyncEventLoop {
     // stored back into `internal_loop_data` (self-referential w.r.t. `event_loop`).
     uws_loop: NonNull<uws::Loop>,
 
-    /// On POSIX, we need to temporarily override the VM's event_loop_handle
-    /// Store the original so we can restore it
+    /// `prepare` overrides the VM's event_loop_handle; the original, restored
+    /// by `cleanup`.
     original_event_loop_handle: VmEventLoopHandle,
 
     #[cfg(windows)]

--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -8,9 +8,8 @@
 //!
 //! Implementation approach:
 //! - Creates a separate uws.Loop instance with its own kqueue/epoll fd (POSIX) or libuv loop (Windows)
-//! - Wraps it in a full jsc.EventLoop instance
-//! - On POSIX: temporarily overrides vm.event_loop_handle to point to isolated loop
-//! - On Windows: stores isolated loop pointer in EventLoop.uws_loop
+//! - Wraps it in a full jsc.EventLoop instance whose `uws_loop` is the isolated loop
+//! - Temporarily overrides vm.event_loop_handle to point to the isolated loop
 //! - Minimal handler callbacks (wakeup/pre/post are no-ops)
 //!
 //! Similar to Node.js's approach in vendor/node/src/spawn_sync.cc but adapted for Bun's architecture.
@@ -45,8 +44,8 @@ pub type VmEventLoopHandle = Option<NonNull<libuv::Loop>>;
 // encapsulates the erased-pointer derefs), so the declarations are `safe fn` —
 // no caller-side `unsafe { }` needed.
 unsafe extern "Rust" {
-    /// Heap-allocate and zero-init a `jsc::EventLoop` bound to `vm`, with
-    /// `uws_loop` as its loop on Windows. Returns erased `*mut jsc::EventLoop`.
+    /// Heap-allocate and zero-init a `jsc::EventLoop` bound to `vm`, running
+    /// on `uws_loop`. Returns erased `*mut jsc::EventLoop`.
     safe fn __bun_spawn_sync_create_event_loop(vm: *mut (), uws_loop: *mut uws::Loop) -> *mut ();
     safe fn __bun_spawn_sync_destroy_event_loop(el: *mut ());
     /// Re-bind `event_loop.{global, virtual_machine}` to `vm` (prepare path).
@@ -156,8 +155,7 @@ impl SpawnSyncEventLoop {
         let loop_ =
             NonNull::new(loop_).expect("uws::Loop::create never returns null (asserts on OOM)");
 
-        // Initialize the JSC EventLoop with empty state.
-        // CRITICAL: On Windows, the impl stores our isolated loop pointer in `uws_loop`.
+        // A fresh `jsc::EventLoop` whose `uws_loop` is the isolated loop.
         let event_loop = __bun_spawn_sync_create_event_loop(vm, loop_.as_ptr());
 
         this.write(Self {

--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -53,8 +53,6 @@ unsafe extern "Rust" {
     safe fn __bun_spawn_sync_event_loop_tick_tasks_only(el: *mut ());
     safe fn __bun_spawn_sync_vm_get_event_loop_handle(vm: *mut ()) -> VmEventLoopHandle;
     safe fn __bun_spawn_sync_vm_set_event_loop_handle(vm: *mut (), h: VmEventLoopHandle);
-    /// `vm.event_loop = prev` (cleanup path).
-    safe fn __bun_spawn_sync_vm_set_event_loop(vm: *mut (), el: *mut ());
     /// Swap `vm.suppress_microtask_drain`, return previous.
     safe fn __bun_spawn_sync_vm_swap_suppress_microtask_drain(vm: *mut (), v: bool) -> bool;
 }
@@ -302,13 +300,8 @@ impl SpawnSyncEventLoop {
     }
 
     /// Restore the original event loop handle after spawnSync completes
-    pub fn cleanup(
-        &mut self,
-        vm: *mut (),              /* SAFETY: erased *mut VirtualMachine */
-        prev_event_loop: *mut (), /* SAFETY: erased *mut jsc::EventLoop */
-    ) {
+    pub fn cleanup(&mut self, vm: *mut () /* SAFETY: erased *mut VirtualMachine */) {
         __bun_spawn_sync_vm_set_event_loop_handle(vm, self.original_event_loop_handle);
-        __bun_spawn_sync_vm_set_event_loop(vm, prev_event_loop);
 
         #[cfg(windows)]
         {

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1036,6 +1036,9 @@ impl EventLoop {
     pub fn ensure_waker(&mut self) {
         jsc::mark_binding();
         if self.uws_loop.is_none() {
+            // The VM's embedded loops run on the thread's loop, the one
+            // `vm.event_loop_handle` names below.
+            debug_assert_eq!(Async::uws_to_native(uws::Loop::get()), Async::Loop::get());
             self.uws_loop = NonNull::new(uws::Loop::get());
         }
         if self.vm_ref().event_loop_handle.is_none() {

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -87,11 +87,10 @@ pub struct EventLoop {
     #[cfg(not(windows))]
     pub holds_forever_poll: bool,
     pub deferred_tasks: DeferredTaskQueue::DeferredTaskQueue,
-    #[cfg(windows)]
-    // `?*uws.Loop` FFI handle.
+    /// The uws loop this `EventLoop` runs on: the process loop for the VM's
+    /// embedded loops, a private one for a spawnSync loop. Set by
+    /// `ensure_waker` / `__bun_spawn_sync_create_event_loop`.
     pub uws_loop: Option<NonNull<uws::Loop>>,
-    #[cfg(not(windows))]
-    pub uws_loop: (),
 
     pub entered_event_loop_count: isize,
     pub concurrent_ref: AtomicI32,
@@ -132,10 +131,7 @@ impl Default for EventLoop {
             #[cfg(not(windows))]
             holds_forever_poll: false,
             deferred_tasks: DeferredTaskQueue::DeferredTaskQueue::default(),
-            #[cfg(windows)]
             uws_loop: None,
-            #[cfg(not(windows))]
-            uws_loop: (),
             entered_event_loop_count: 0,
             concurrent_ref: AtomicI32::new(0),
             imminent_gc_timer: AtomicPtr::new(core::ptr::null_mut()),
@@ -666,19 +662,21 @@ impl EventLoop {
     }
 
     /// Fold refs/unrefs queued through `ref_keep_alive`/`unref_keep_alive`
-    /// (here, or from another thread through `VmHandle`) into the platform
-    /// loop's keep-alive count. Runs at the top of every tick,
-    /// and once more from a worker's shutdown after its stop phase (which unrefs
-    /// ports/channels/sockets on a loop that no longer ticks) so the loop is not
-    /// torn down still believing something keeps it alive.
+    /// (here, or from another thread through `VmHandle`) into this loop's own
+    /// platform loop keep-alive count — not `vm.event_loop_handle`, which
+    /// `Bun.spawnSync` points at its private loop while it runs (a GC inside it
+    /// still reaches this through FinalizationRegistry / MessagePort refs).
+    /// Runs at the top of every tick, and once more from a worker's shutdown
+    /// after its stop phase (which unrefs ports/channels/sockets on a loop that
+    /// no longer ticks) so the loop is not torn down still believing something
+    /// keeps it alive.
     pub(crate) fn apply_concurrent_ref_delta(&self) {
         // Do NOT silently drop the swapped delta when the handle is
         // missing — queued refs would be lost forever.
         let delta = self.concurrent_ref.swap(0, Ordering::SeqCst);
-        let loop_ = self
-            .vm_ref()
-            .platform_loop_opt()
-            .expect("event_loop_handle");
+        // SAFETY: `uv_loop()` is this loop's live uws/uv loop (set once in
+        // `ensure_waker` / at spawnSync-loop creation); JS thread only.
+        let loop_ = unsafe { &mut *self.uv_loop() };
         #[cfg(windows)]
         {
             if delta > 0 {
@@ -703,37 +701,29 @@ impl EventLoop {
         }
     }
 
-    /// Walk `self.virtual_machine.event_loop_handle` via raw-pointer
-    /// projection without materializing a `&VirtualMachine` (the VM may be
-    /// mutably borrowed elsewhere on the JS thread when libuv completion
-    /// callbacks reach for the loop).
+    /// This loop's platform loop (the uws loop on POSIX, its libuv loop on
+    /// Windows).
     #[inline]
     pub fn uv_loop(&self) -> *mut crate::PlatformEventLoop {
-        let vm = self.virtual_machine.expect("virtual_machine").as_ptr();
-        // SAFETY: `virtual_machine` is set in `VirtualMachine::init()` to the
-        // owning per-thread singleton; non-null and live for the VM lifetime.
-        // `addr_of!` projects to the field place without forming an
-        // intermediate `&VirtualMachine` that would assert no-alias.
-        unsafe { core::ptr::addr_of!((*vm).event_loop_handle).read() }.expect("event_loop_handle")
+        #[cfg(windows)]
+        {
+            // SAFETY: `usockets_loop()` is a live uws loop; `uv_loop` is set by
+            // `us_create_loop` for its lifetime.
+            return unsafe { (*self.usockets_loop()).uv_loop };
+        }
+        #[cfg(not(windows))]
+        {
+            self.usockets_loop()
+        }
     }
 
     pub fn usockets_loop(&self) -> *mut uws::Loop {
         // Panic on null rather than returning it — callers immediately
         // materialize `&mut *`, so a null return would be instant UB instead
         // of a clean panic.
-        #[cfg(windows)]
-        {
-            return self
-                .uws_loop
-                .expect("usockets_loop: uws_loop not initialized (call ensure_waker first)")
-                .as_ptr();
-        }
-        #[cfg(not(windows))]
-        {
-            self.vm_ref().event_loop_handle.expect(
-                "usockets_loop: event_loop_handle not initialized (call ensure_waker first)",
-            )
-        }
+        self.uws_loop
+            .expect("usockets_loop: uws_loop not initialized (call ensure_waker first)")
+            .as_ptr()
     }
 
     #[inline]
@@ -1052,11 +1042,10 @@ impl EventLoop {
 
     pub fn ensure_waker(&mut self) {
         jsc::mark_binding();
+        if self.uws_loop.is_none() {
+            self.uws_loop = NonNull::new(uws::Loop::get());
+        }
         if self.vm_ref().event_loop_handle.is_none() {
-            #[cfg(windows)]
-            {
-                self.uws_loop = NonNull::new(uws::Loop::get());
-            }
             let vm = self.vm();
             // SAFETY: `vm` is the live owning VM.
             unsafe { (*vm).event_loop_handle = Some(Async::Loop::get()) };
@@ -1067,12 +1056,6 @@ impl EventLoop {
                 let gc: *mut GarbageCollectionController =
                     core::ptr::addr_of_mut!((*vm).gc_controller);
                 (*gc).init(&mut *vm);
-            }
-        }
-        #[cfg(windows)]
-        {
-            if self.uws_loop.is_none() {
-                self.uws_loop = NonNull::new(uws::Loop::get());
             }
         }
         // Note: `EventLoopHandle` lives in `bun_event_loop` (lower tier),
@@ -1142,23 +1125,9 @@ impl EventLoop {
     }
 
     pub fn wakeup(&self) {
-        #[cfg(windows)]
-        {
-            if let Some(loop_) = self.uws_loop {
-                // SAFETY: uws_loop is a valid live uws::Loop handle
-                unsafe { (*loop_.as_ptr()).wakeup() };
-            }
-            return;
-        }
-        #[cfg(not(windows))]
-        {
-            // Route through the single audited `platform_loop_opt()` accessor
-            // (set-once `Option<*mut>` deref) instead of open-coding the raw
-            // `(*event_loop_handle).wakeup()` here. Same `&mut Loop` is formed
-            // either way (autoref), so no soundness change vs the prior code.
-            if let Some(loop_) = self.vm_ref().platform_loop_opt() {
-                loop_.wakeup();
-            }
+        if let Some(loop_) = self.uws_loop {
+            // SAFETY: uws_loop is a valid live uws::Loop handle
+            unsafe { (*loop_.as_ptr()).wakeup() };
         }
     }
 
@@ -1483,9 +1452,6 @@ fn el_ref<'a>(owner: *mut ()) -> &'a mut EventLoop {
 // JS thread.
 bun_event_loop::link_impl_JsEventLoop! {
     Jsc for EventLoop => |this| {
-        // Reads the EventLoop's own `uws_loop` field; on
-        // Windows that and `VM::uws_loop()` (= `uws::Loop::get()`) are different
-        // code paths. Route through `usockets_loop()`.
         iteration_number() => (&*(*this).usockets_loop()).iteration_number(),
         // Return raw to avoid asserting uniqueness — multiple handles may name the
         // same VM.
@@ -1561,22 +1527,14 @@ fn vm_from_ptr<'a>(vm: *mut ()) -> &'a mut VirtualMachine {
     unsafe { &mut *vm.cast::<VirtualMachine>() }
 }
 
-/// Heap-allocate a fresh `EventLoop` bound to `vm`; on Windows, store
-/// `uws_loop` in `event_loop.uws_loop`.
+/// Heap-allocate a fresh `EventLoop` bound to `vm`, running on `uws_loop`.
 #[unsafe(no_mangle)]
 pub(crate) fn __bun_spawn_sync_create_event_loop(vm: *mut (), uws_loop: *mut uws::Loop) -> *mut () {
     let vm = vm_from_ptr(vm);
     let mut el = Box::new(EventLoop::default());
     el.global = NonNull::new(vm.global);
     el.virtual_machine = NonNull::new(std::ptr::from_mut(vm));
-    #[cfg(windows)]
-    {
-        el.uws_loop = NonNull::new(uws_loop);
-    }
-    #[cfg(not(windows))]
-    {
-        let _ = uws_loop;
-    }
+    el.uws_loop = NonNull::new(uws_loop);
     let el = bun_core::heap::into_raw(el);
     // SAFETY: `el` is the stable heap address the poster targets until destroy.
     unsafe { (*el).isolated_poster = Some(crate::vm_handle::IsolatedPosterInner::new(el)) };

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -662,19 +662,19 @@ impl EventLoop {
     }
 
     /// Fold refs/unrefs queued through `ref_keep_alive`/`unref_keep_alive`
-    /// (here, or from another thread through `VmHandle`) into this loop's own
-    /// platform loop keep-alive count — not `vm.event_loop_handle`, which
-    /// `Bun.spawnSync` points at its private loop while it runs (a GC inside it
-    /// still reaches this through FinalizationRegistry / MessagePort refs).
-    /// Runs at the top of every tick, and once more from a worker's shutdown
-    /// after its stop phase (which unrefs ports/channels/sockets on a loop that
-    /// no longer ticks) so the loop is not torn down still believing something
-    /// keeps it alive.
+    /// (here, or from another thread through `VmHandle`) into this loop's
+    /// keep-alive count. Runs at the top of every tick, and once more from a
+    /// worker's shutdown after its stop phase (which unrefs
+    /// ports/channels/sockets on a loop that no longer ticks) so the loop is not
+    /// torn down still believing something keeps it alive.
+    ///
+    /// Targets `self.native_loop()`, never `vm.event_loop_handle`: `Bun.spawnSync`
+    /// points the latter at its private loop, and a GC inside it still refs
+    /// this loop (FinalizationRegistry, MessagePort).
     pub(crate) fn apply_concurrent_ref_delta(&self) {
         let delta = self.concurrent_ref.swap(0, Ordering::SeqCst);
-        // SAFETY: `uv_loop()` is this loop's live uws/uv loop (set once in
-        // `ensure_waker` / at spawnSync-loop creation); JS thread only.
-        let loop_ = unsafe { &mut *self.uv_loop() };
+        // SAFETY: `native_loop()` is live for this loop's lifetime; JS thread only.
+        let loop_ = unsafe { &mut *self.native_loop() };
         #[cfg(windows)]
         {
             if delta > 0 {
@@ -699,29 +699,24 @@ impl EventLoop {
         }
     }
 
-    /// This loop's platform loop (the uws loop on POSIX, its libuv loop on
-    /// Windows).
-    #[inline]
-    pub fn uv_loop(&self) -> *mut crate::PlatformEventLoop {
-        #[cfg(windows)]
-        {
-            // SAFETY: `usockets_loop()` is a live uws loop; `uv_loop` is set by
-            // `us_create_loop` for its lifetime.
-            return unsafe { (*self.usockets_loop()).uv_loop };
-        }
-        #[cfg(not(windows))]
-        {
-            self.usockets_loop()
-        }
-    }
-
+    /// The uws loop this `EventLoop` runs on.
     pub fn usockets_loop(&self) -> *mut uws::Loop {
-        // Panic on null rather than returning it — callers immediately
-        // materialize `&mut *`, so a null return would be instant UB instead
-        // of a clean panic.
         self.uws_loop
             .expect("usockets_loop: uws_loop not initialized (call ensure_waker first)")
             .as_ptr()
+    }
+
+    /// [`usockets_loop`](Self::usockets_loop) as the platform-native loop
+    /// (`us_loop_t*` on POSIX, its `uv_loop_t*` on Windows).
+    #[inline]
+    pub fn native_loop(&self) -> *mut crate::PlatformEventLoop {
+        Async::uws_to_native(self.usockets_loop())
+    }
+
+    #[cfg(windows)]
+    #[inline]
+    pub fn uv_loop(&self) -> *mut crate::PlatformEventLoop {
+        self.native_loop()
     }
 
     #[inline]
@@ -1204,8 +1199,8 @@ impl EventLoop {
     pub unsafe fn tick_while_paused(&mut self, done: *const bool) {
         // SAFETY: see fn contract — `done` is a live FFI bool written by C++.
         while !unsafe { done.read_volatile() } {
-            // SAFETY: `uv_loop()` is this loop's live platform loop; JS thread.
-            unsafe { (*self.uv_loop()).tick() };
+            // SAFETY: `native_loop()` is live for this loop's lifetime; JS thread.
+            unsafe { (*self.native_loop()).tick() };
         }
     }
 
@@ -1576,13 +1571,6 @@ pub(crate) fn __bun_spawn_sync_vm_set_event_loop_handle(
     h: bun_event_loop::SpawnSyncEventLoop::VmEventLoopHandle,
 ) {
     vm_from_ptr(vm).event_loop_handle = h.map(NonNull::as_ptr);
-}
-
-#[unsafe(no_mangle)]
-pub(crate) fn __bun_spawn_sync_vm_set_event_loop(vm: *mut (), el: *mut ()) {
-    // `el` is its previous `event_loop` pointer (a `*mut EventLoop` into
-    // `regular_event_loop`/`macro_event_loop`).
-    vm_from_ptr(vm).event_loop = el.cast::<EventLoop>();
 }
 
 #[unsafe(no_mangle)]

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -671,8 +671,6 @@ impl EventLoop {
     /// no longer ticks) so the loop is not torn down still believing something
     /// keeps it alive.
     pub(crate) fn apply_concurrent_ref_delta(&self) {
-        // Do NOT silently drop the swapped delta when the handle is
-        // missing — queued refs would be lost forever.
         let delta = self.concurrent_ref.swap(0, Ordering::SeqCst);
         // SAFETY: `uv_loop()` is this loop's live uws/uv loop (set once in
         // `ensure_waker` / at spawnSync-loop creation); JS thread only.
@@ -1206,10 +1204,8 @@ impl EventLoop {
     pub unsafe fn tick_while_paused(&mut self, done: *const bool) {
         // SAFETY: see fn contract — `done` is a live FFI bool written by C++.
         while !unsafe { done.read_volatile() } {
-            self.vm_ref()
-                .platform_loop_opt()
-                .expect("event_loop_handle")
-                .tick();
+            // SAFETY: `uv_loop()` is this loop's live platform loop; JS thread.
+            unsafe { (*self.uv_loop()).tick() };
         }
     }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1079,11 +1079,10 @@ fn spawn_maybe_sync(
         if is_sync {
             // SAFETY: defer runs while `jsc_vm` (the thread VM) is still live.
             unsafe {
-                let main_loop = (*jsc_vm_ptr_cleanup).event_loop();
                 (*jsc_vm_ptr_cleanup)
                     .rare_data()
                     .spawn_sync_event_loop(&mut *jsc_vm_ptr_cleanup)
-                    .cleanup(jsc_vm_ptr_cleanup.cast(), main_loop.cast());
+                    .cleanup(jsc_vm_ptr_cleanup.cast());
             }
         }
     }

--- a/test/js/bun/spawn/spawnSync-keepalive-gc-fixture.js
+++ b/test/js/bun/spawn/spawnSync-keepalive-gc-fixture.js
@@ -1,0 +1,28 @@
+// A GC that ends while Bun.spawnSync() is on the stack schedules the
+// FinalizationRegistry's cleanup as deferred work, which takes a keep-alive on
+// the event loop. That keep-alive and its release must land on the main loop,
+// not the private loop spawnSync installs for the call.
+const { getEventLoopStats } = require("bun:internal-for-testing");
+
+const registry = new FinalizationRegistry(() => {});
+function makeGarbage() {
+  for (let i = 0; i < 5000; i++) registry.register({ i }, i);
+}
+
+const { BUN_JSC_collectContinuously, ...childEnv } = process.env;
+const cmd = process.platform === "win32" ? ["cmd", "/c", "exit 0"] : ["true"];
+
+const baseline = getEventLoopStats().numPolls;
+for (let iter = 0; iter < 8; iter++) {
+  makeGarbage();
+  Bun.spawnSync(cmd, { env: childEnv });
+  // Let the FinalizationRegistry callback run and the loop tick once.
+  await new Promise(resolve => setImmediate(resolve));
+  await Bun.sleep(1);
+  const { numPolls, loopActive } = getEventLoopStats();
+  if (numPolls < baseline) {
+    console.log("DRIFT " + JSON.stringify({ iter, baseline, numPolls, loopActive }));
+    process.exit(1);
+  }
+}
+console.log("OK");

--- a/test/js/bun/spawn/spawnSync-keepalive-stress-fixture.js
+++ b/test/js/bun/spawn/spawnSync-keepalive-stress-fixture.js
@@ -1,0 +1,56 @@
+// Everything that can touch the main loop's keep-alive while Bun.spawnSync has
+// its private loop installed, at once: a GC ending inside spawnSync
+// (FinalizationRegistry deferred work), a worker posting messages to this
+// thread (cross-thread wakeups + tasks), and a listening server (a poll that
+// must stay registered). After each round the main loop must still do I/O and
+// its poll count must not have moved; at the end the process must exit on its
+// own (a keep-alive leaked in the other direction would hang here).
+const { getEventLoopStats } = require("bun:internal-for-testing");
+
+const registry = new FinalizationRegistry(() => {});
+const { BUN_JSC_collectContinuously, ...childEnv } = process.env;
+const cmd = process.platform === "win32" ? ["cmd", "/c", "exit 0"] : ["true"];
+
+const worker = new Worker(
+  URL.createObjectURL(new Blob([`setInterval(() => postMessage(0), 1); postMessage(0);`])),
+);
+let received = 0;
+await new Promise(resolve => {
+  worker.onmessage = () => {
+    received++;
+    resolve();
+  };
+});
+
+const server = Bun.serve({ port: 0, fetch: () => new Response("hi") });
+const baseline = getEventLoopStats().numPolls;
+
+for (let iter = 0; iter < 8; iter++) {
+  for (let i = 0; i < 2000; i++) registry.register({ i }, i);
+  const before = received;
+  Bun.spawnSync(cmd, { env: childEnv });
+  await new Promise(resolve => setImmediate(resolve));
+
+  let timer;
+  const body = await Promise.race([
+    fetch(server.url).then(r => r.text()),
+    new Promise(resolve => (timer = setTimeout(() => resolve("TIMEOUT"), 5000))),
+  ]);
+  clearTimeout(timer);
+  if (body !== "hi") {
+    console.log("HANG " + JSON.stringify({ iter, body, ...getEventLoopStats() }));
+    process.exit(1);
+  }
+  // Worker messages posted during/after spawnSync were delivered.
+  while (received === before) await new Promise(resolve => setImmediate(resolve));
+
+  const { numPolls } = getEventLoopStats();
+  if (numPolls < baseline) {
+    console.log("DRIFT " + JSON.stringify({ iter, baseline, ...getEventLoopStats() }));
+    process.exit(1);
+  }
+}
+
+server.stop(true);
+worker.terminate();
+console.log("OK");

--- a/test/js/bun/spawn/spawnSync-keepalive-stress-fixture.js
+++ b/test/js/bun/spawn/spawnSync-keepalive-stress-fixture.js
@@ -42,7 +42,14 @@ for (let iter = 0; iter < 8; iter++) {
     process.exit(1);
   }
   // Worker messages posted during/after spawnSync were delivered.
-  while (received === before) await new Promise(resolve => setImmediate(resolve));
+  const deadline = performance.now() + 5000;
+  while (received === before) {
+    if (performance.now() > deadline) {
+      console.log("NO WORKER MESSAGE " + JSON.stringify({ iter, ...getEventLoopStats() }));
+      process.exit(1);
+    }
+    await new Promise(resolve => setImmediate(resolve));
+  }
 
   const { numPolls } = getEventLoopStats();
   if (numPolls < baseline) {

--- a/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
+++ b/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
@@ -134,6 +134,20 @@ describe.concurrent("spawnSync isolated event loop", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("spawnSync under GC pressure with a worker and a server keeps the main loop balanced and exits", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "spawnSync-keepalive-stress-fixture.js")],
+      env: { ...bunEnv, BUN_JSC_collectContinuously: "1" },
+      stderr: "inherit",
+      stdout: "pipe",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout).toBe("OK\n");
+    expect(exitCode).toBe(0);
+  });
+
   test("multiple spawnSync calls should each use isolated event loop", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
+++ b/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
 
 describe.concurrent("spawnSync isolated event loop", () => {
   test("JavaScript timers should not fire during spawnSync", async () => {
@@ -115,6 +116,21 @@ describe.concurrent("spawnSync isolated event loop", () => {
     expect(stdout).toContain("BEFORE");
     expect(stdout).toContain("AFTER");
     expect(stdout).toContain("SUCCESS");
+    expect(exitCode).toBe(0);
+  });
+
+  test("GC finishing inside spawnSync does not move the main loop's keep-alive count", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "spawnSync-keepalive-gc-fixture.js")],
+      // collectContinuously makes a collection reliably end inside spawnSync.
+      env: { ...bunEnv, BUN_JSC_collectContinuously: "1" },
+      stderr: "inherit",
+      stdout: "pipe",
+    });
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout).toBe("OK\n");
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### What

`Bun.spawnSync` points `vm.event_loop_handle` at a private uws/libuv loop for the duration of the call (`SpawnSyncEventLoop::prepare`/`cleanup`). If a GC finishes while `spawnSync` is on the stack and a `FinalizationRegistry` has dead targets, `JSFinalizationRegistry::reconcileWeakReferencesAtGCEnd` → `DeferredWorkTimer::addPendingWork` → `JSCTaskScheduler::onAddPendingWork` takes a keep-alive with `Bun__eventLoop__refKeepAlive`, which folded into `vm.event_loop_handle` — the private loop. The matching `-1` (when the cleanup task runs) is queued on the regular `EventLoop` and folded at its next tick onto the main loop.

Net per occurrence: main loop `num_polls -= 1` / `active -= 1`. Once `num_polls` reads 0 while polls are still registered, `us_loop_run_bun_tick` returns before `epoll_wait`/`kevent` and the process stops observing I/O and child exits (timers keep firing; `Bun.serve` never accepts, `await proc.exited` never resolves, …). On Windows the same sequence shows up as `active_handles` drift and a process that never exits. Regressed by #39905 (which switched this `+1` from a queued `VmHandle` ref to an immediate fold); 1.4.0 is unaffected.

### Fix

`EventLoop` now records the uws loop it runs on (`uws_loop`, previously a Windows-only field): the thread's loop for the VM's regular/macro loops (set in `ensure_waker`), the private loop for a spawnSync loop (set at creation). `apply_concurrent_ref_delta`, `wakeup`, `usockets_loop` and `native_loop`/`uv_loop` resolve through that instead of through `vm.event_loop_handle`, so a keep-alive taken on the regular loop lands on the regular loop regardless of what spawnSync has installed. This covers every `Bun__eventLoop__refKeepAlive` caller (deferred work, `MessagePort`, `BroadcastChannel`, `ScriptExecutionContext`), not just the FinalizationRegistry path, and also removes an off-thread read of `vm.event_loop_handle` (`VmHandle` → `wakeup()`) that raced spawnSync's swap.

Also: `EventLoop::uv_loop()` is now Windows-only (every caller already was) with `native_loop()` as the cross-platform accessor, matching `EventLoopHandle`; and spawnSync's `cleanup` no longer writes `vm.event_loop` back to the value it just read.

### Why this is behaviour-preserving outside spawnSync

Every writer of `vm.event_loop_handle` (`ensure_waker`, two sites in `server/mod.rs`) stores the thread's loop (`bun_io::Loop::get()`), except spawnSync's `prepare`/`cleanup`. For the regular and macro `EventLoop`s, `uws_loop` is `uws::Loop::get()`, and `uws_to_native(uws::Loop::get()) == bun_io::Loop::get()` on every platform (Windows: `uws_get_loop_with_native(uv::Loop::get())`; now `debug_assert`ed in `ensure_waker`). So old and new resolve to the same pointer everywhere except between `prepare` and `cleanup` — which is exactly the broken window.

This was checked mechanically: a temporary build computed both the old (`vm.event_loop_handle`) and new (`self.uws_loop`) pointer in each touched method and aborted if they differed outside the spawnSync window. ~14k tests across 39 directories (`js/bun/spawn`, `js/node/child_process`, `js/web/workers`, `js/bun/shell`, `cli/run`, `js/bun/http/serve`, `js/web/fetch`, `js/node/fs`, `js/node/http`, …) on a Linux release build: **0 divergences outside the window**. Inside the window the only divergent callers were, by backtrace, `reconcileWeakReferencesAtGCEnd → onAddPendingWork → ref_keep_alive` (the bug) and `→ scheduleWorkSoon → VmHandle::post → wakeup` (previously woke the private loop, now the main one), both on the JS thread.

### Tests

- `spawnSync-keepalive-gc-fixture.js`: 5000 FinalizationRegistry targets, `spawnSync`, tick, assert `numPolls` never drops below its starting value; run under `BUN_JSC_collectContinuously=1` so a collection reliably ends inside `spawnSync`.
- `spawnSync-keepalive-stress-fixture.js`: the same under a message-flooding Worker and a listening `Bun.serve`; after each round the server must still answer a `fetch`, `numPolls` must not move, and the process must exit on its own at the end.

| | Linux x64 | macOS arm64 | Windows x64 |
|---|---|---|---|
| gc fixture, canary `11fb73032` | DRIFT 3/3 | DRIFT 3/3 | hangs at exit 3/3 |
| stress fixture, canary | DRIFT 3/3 | DRIFT 3/3 | DRIFT 3/3 |
| both fixtures, this PR | OK | OK | OK |
| issue repro (serve never accepts), canary → this PR | HANG after 19 → OK | HANG after 5 → OK | — |
| `spawnsync-isolated-event-loop`, `spawnSync`, `spawn`, `child_process`, `39900`, macro-test, `worker`, `message-channel`, `broadcastchannel`, `worker_threads`, `serve` | pass | pass | pass¹ |

¹ `stdin/stdout … not affected by spawnSync` fails on the Windows box used here on 1.4.0/canary/this PR alike (it spawns `echo`); passes in CI.
